### PR TITLE
Set up Travis CI and S3 deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+sudo: false
+language: node_js
+node_js: node
+cache:
+  bundler: true
+  pip: true
+  yarn: true
+install:
+- travis_retry gem install s3_website -v 3.4.0
+- travis_retry pip install awscli --upgrade --user
+- travis_retry yarn install --frozen-lockfile
+script:
+- yarn build
+- yarn test
+after_script:
+- ./s3_deploy.sh

--- a/s3_deploy.sh
+++ b/s3_deploy.sh
@@ -27,10 +27,11 @@ fi
 # tagged builds deploy to /version/TAG_NAME
 if [ "$TRAVIS_BRANCH" = "$CURRENT_TAG" ]; then
   mkdir -p _site/version
-  DEPLOY_DIR="version/$TRAVIS_BRANCH"
-  DEPLOY_DEST= "_site/$DEPLOY_DIR"
+  S3_DEPLOY_DIR="version/$TRAVIS_BRANCH"
+  DEPLOY_DEST= "_site/$S3_DEPLOY_DIR"
   INVAL_PATH="/version/$TRAVIS_BRANCH/index.html"
-  export DEPLOY_DIR
+  # used by s3_website.yml
+  export S3_DEPLOY_DIR
 
 # production branch builds deploy to root of site
 elif [ "$TRAVIS_BRANCH" = "$PRODUCTION_BRANCH" ]; then
@@ -40,10 +41,11 @@ elif [ "$TRAVIS_BRANCH" = "$PRODUCTION_BRANCH" ]; then
 # branch builds deploy to /branch/BRANCH_NAME
 else
   mkdir -p _site/branch
-  DEPLOY_DIR="branch/$DEPLOY_DIR_NAME"
-  DEPLOY_DEST="_site/$DEPLOY_DIR"
+  S3_DEPLOY_DIR="branch/$DEPLOY_DIR_NAME"
+  DEPLOY_DEST="_site/$S3_DEPLOY_DIR"
   INVAL_PATH="/branch/$DEPLOY_DIR_NAME/index.html"
-  export DEPLOY_DIR
+  # used by s3_website.yml
+  export S3_DEPLOY_DIR
 fi
 
 # copy files to destination

--- a/s3_deploy.sh
+++ b/s3_deploy.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+SRC_DIR='dist'
+DISTRIBUTION_ID='E1YPVV3YLYS4J7'
+# name of branch to deploy to root of site
+PRODUCTION_BRANCH='production'
+
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+	echo "skipping deploy to S3: this is a pull request"
+	exit 0
+fi
+
+# extract current TAG if present
+# the 2> is to prevent error messages when no match is found
+CURRENT_TAG=`git describe --tags --exact-match $TRAVIS_COMMIT 2> /dev/null`
+
+# strip PT ID from branch name for branch builds
+DEPLOY_DIR_NAME=$TRAVIS_BRANCH
+PT_PREFIX_REGEX="^([0-9]{8,}-)(.+)$"
+PT_SUFFIX_REGEX="^(.+)(-[0-9]{8,})$"
+if [[ $DEPLOY_DIR_NAME =~ $PT_PREFIX_REGEX ]]; then
+  DEPLOY_DIR_NAME=${BASH_REMATCH[2]}
+fi
+if [[ $DEPLOY_DIR_NAME =~ $PT_SUFFIX_REGEX ]]; then
+  DEPLOY_DIR_NAME=${BASH_REMATCH[1]}
+fi
+
+# tagged builds deploy to /version/TAG_NAME
+if [ "$TRAVIS_BRANCH" = "$CURRENT_TAG" ]; then
+  mkdir -p _site/version
+  DEPLOY_DIR="version/$TRAVIS_BRANCH"
+  DEPLOY_DEST= "_site/$DEPLOY_DIR"
+  INVAL_PATH="/version/$TRAVIS_BRANCH/index.html"
+  export DEPLOY_DIR
+
+# production branch builds deploy to root of site
+elif [ "$TRAVIS_BRANCH" = "$PRODUCTION_BRANCH" ]; then
+  DEPLOY_DEST="_site"
+  INVAL_PATH="/index.html"
+
+# branch builds deploy to /branch/BRANCH_NAME
+else
+  mkdir -p _site/branch
+  DEPLOY_DIR="branch/$DEPLOY_DIR_NAME"
+  DEPLOY_DEST="_site/$DEPLOY_DIR"
+  INVAL_PATH="/branch/$DEPLOY_DIR_NAME/index.html"
+  export DEPLOY_DIR
+fi
+
+# copy files to destination
+mv $SRC_DIR $DEPLOY_DEST
+
+# deploy the site contents
+s3_website push --site _site
+
+# explicit CloudFront invalidation to workaround s3_website gem invalidation bug
+# with origin path (https://github.com/laurilehmijoki/s3_website/issues/207).
+aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths $INVAL_PATH

--- a/s3_website.yml
+++ b/s3_website.yml
@@ -1,0 +1,30 @@
+s3_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
+s3_secret: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
+s3_bucket: models-resources
+s3_key_prefix: collaborative-learning
+s3_endpoint: us-east-1
+gzip: true
+
+cloudfront_distribution_id: E1YPVV3YLYS4J7
+cloudfront_invalidate_root: true
+cloudfront_wildcard_invalidation: true
+
+<% if ENV['TRAVIS_BRANCH'] == 'production' %>
+# in this case we are going to deploy this branch to the top level of the domain
+# so we need to ignore the version and branch folders
+ignore_on_server: ^collaborative-learning/(version/|branch/)
+<% else %>
+# in this case we are going to deploy this code to a subfolder of either the branch
+# or version folder. So ignore everything except this folder.
+ignore_on_server: ^(?!collaborative-learning/<%= Regexp.escape(ENV['DEPLOY_DIR']) %>/)
+<% end %>
+max_age:
+  "collaborative-learning/*": 600 # 10 minutes
+  "collaborative-learning/version/*": 31536000 # 1 year
+  "collaborative-learning/branch/*": 0
+
+cloudfront_distribution_config:
+  aliases:
+    quantity: 1
+    items:
+      - collaborative-learning.concord.org

--- a/s3_website.yml
+++ b/s3_website.yml
@@ -16,7 +16,8 @@ ignore_on_server: ^collaborative-learning/(version/|branch/)
 <% else %>
 # in this case we are going to deploy this code to a subfolder of either the branch
 # or version folder. So ignore everything except this folder.
-ignore_on_server: ^(?!collaborative-learning/<%= Regexp.escape(ENV['DEPLOY_DIR']) %>/)
+# S3_DEPLOY_DIR is set by s3_deploy.sh
+ignore_on_server: ^(?!collaborative-learning/<%= Regexp.escape(ENV['S3_DEPLOY_DIR']) %>/)
 <% end %>
 max_age:
   "collaborative-learning/*": 600 # 10 minutes


### PR DESCRIPTION
Set up Travis CI and S3 deployment [#160077604]

Improvements
- strips PT story ID from deployed branch names for ease of use
- supports tagged builds on production branch (deployment document discussion)

Testable at https://collaborative-learning.concord.org/branch/travis-ci/ (note the absence of the PT story ID in the deployed branch name).