### PR TITLE
Refactor stores

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   "homepage": "https://github.com/concord-consortium/collaborative-learning#readme",
   "devDependencies": {
     "@types/chai": "^4.1.4",
-    "@types/lodash": "^4.14.116",
     "@types/jsonwebtoken": "^7.2.8",
+    "@types/lodash": "^4.14.116",
     "@types/mocha": "^5.2.5",
     "@types/query-string": "^6.1.0",
     "@types/react": "^16.4.11",
@@ -49,6 +49,7 @@
     "ts-node": "^7.0.1",
     "tslint": "^5.11.0",
     "tslint-loader": "^3.6.0",
+    "tslint-no-unused-expression-chai": "^0.1.3",
     "tslint-react": "^3.6.0",
     "typescript": "^3.0.1",
     "webpack": "^4.17.1",
@@ -57,8 +58,8 @@
   },
   "dependencies": {
     "chai": "^4.1.2",
-    "lodash": "^4.17.10",
     "jsonwebtoken": "^8.3.0",
+    "lodash": "^4.17.10",
     "mobx": "^5.0.4",
     "mobx-react": "^5.2.5",
     "mobx-state-tree": "^3.2.3",

--- a/src/components/app-container.tsx
+++ b/src/components/app-container.tsx
@@ -5,13 +5,15 @@ import { LearningLogComponent } from "./learning-log";
 import { LeftNavComponent } from "./left-nav";
 import { MyWorkComponent } from "./my-work";
 import { WorkspaceComponent } from "./workspace";
-import { BaseComponent } from "./base";
+import { BaseComponent, IBaseProps } from "./base";
 
 import "./app-container.sass";
 
+interface IProps extends IBaseProps {}
+
 @inject("stores")
 @observer
-export class AppContainerComponent extends BaseComponent<{}, {}> {
+export class AppContainerComponent extends BaseComponent<IProps, {}> {
 
   public render() {
     return (

--- a/src/components/app-container.tsx
+++ b/src/components/app-container.tsx
@@ -1,25 +1,17 @@
 import { inject, observer } from "mobx-react";
 import * as React from "react";
-import { IStores } from "../models/stores";
 import { HeaderComponent } from "./header";
 import { LearningLogComponent } from "./learning-log";
 import { LeftNavComponent } from "./left-nav";
 import { MyWorkComponent } from "./my-work";
 import { WorkspaceComponent } from "./workspace";
+import { BaseComponent } from "./base";
 
 import "./app-container.sass";
 
-interface IProps {
-  stores?: IStores;
-}
-
 @inject("stores")
 @observer
-export class AppContainerComponent extends React.Component<IProps, {}> {
-
-  get stores() {
-    return this.props.stores as IStores;
-  }
+export class AppContainerComponent extends BaseComponent<{}, {}> {
 
   public render() {
     return (

--- a/src/components/app-container.tsx
+++ b/src/components/app-container.tsx
@@ -1,7 +1,6 @@
 import { inject, observer } from "mobx-react";
 import * as React from "react";
-import { IAllStores } from "../index";
-import { UIModelType } from "../models/ui";
+import { IStores } from "../models/stores";
 import { HeaderComponent } from "./header";
 import { LearningLogComponent } from "./learning-log";
 import { LeftNavComponent } from "./left-nav";
@@ -10,21 +9,16 @@ import { WorkspaceComponent } from "./workspace";
 
 import "./app-container.sass";
 
-interface IInjectedProps {
-  ui: UIModelType;
+interface IProps {
+  stores?: IStores;
 }
 
-@inject((allStores: IAllStores) => {
-  const injected: IInjectedProps = {
-    ui: allStores.ui,
-  };
-  return injected;
-})
+@inject("stores")
 @observer
-export class AppContainerComponent extends React.Component<{}, {}> {
+export class AppContainerComponent extends React.Component<IProps, {}> {
 
-  get injected() {
-    return this.props as IInjectedProps;
+  get stores() {
+    return this.props.stores as IStores;
   }
 
   public render() {
@@ -32,7 +26,7 @@ export class AppContainerComponent extends React.Component<{}, {}> {
       <div className="app-container">
         <HeaderComponent />
         <WorkspaceComponent />
-        {this.injected.ui.allContracted ? null : this.renderBlocker()}
+        {this.stores.ui.allContracted ? null : this.renderBlocker()}
         <LeftNavComponent />
         <MyWorkComponent />
         <LearningLogComponent />
@@ -41,7 +35,7 @@ export class AppContainerComponent extends React.Component<{}, {}> {
   }
 
   private handleRemoveBlocker = () => {
-    this.injected.ui.contractAll();
+    this.stores.ui.contractAll();
   }
 
   private renderBlocker() {

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -1,22 +1,14 @@
 import { inject, observer } from "mobx-react";
 import * as React from "react";
-import { IStores } from "../models/stores";
 import { authenticate } from "../lib/auth";
 import { AppContainerComponent } from "./app-container";
+import { BaseComponent } from "./base";
 
 import "./app.sass";
 
-interface IProps {
-  stores?: IStores;
-}
-
 @inject("stores")
 @observer
-export class AppComponent extends React.Component<IProps, {}> {
-
-  get stores() {
-    return this.props.stores as IStores;
-  }
+export class AppComponent extends BaseComponent<{}, {}> {
 
   public componentWillMount() {
     authenticate(this.stores.devMode).then((authenticatedUser) => {

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -1,35 +1,27 @@
 import { inject, observer } from "mobx-react";
 import * as React from "react";
-import { IAllStores } from "../index";
+import { IStores } from "../models/stores";
 import { authenticate } from "../lib/auth";
-import { UserModelType } from "../models/user";
 import { AppContainerComponent } from "./app-container";
 
 import "./app.sass";
 
-interface IInjectedProps {
-  user: UserModelType;
-  devMode: boolean;
+interface IProps {
+  stores?: IStores;
 }
 
-@inject((allStores: IAllStores) => {
-  const injected: IInjectedProps = {
-    devMode: allStores.devMode,
-    user: allStores.user,
-  };
-  return injected;
-})
+@inject("stores")
 @observer
-export class AppComponent extends React.Component<{}, {}> {
+export class AppComponent extends React.Component<IProps, {}> {
 
-  get injected() {
-    return this.props as IInjectedProps;
+  get stores() {
+    return this.props.stores as IStores;
   }
 
   public componentWillMount() {
-    authenticate(this.injected.devMode).then((authenticatedUser) => {
+    authenticate(this.stores.devMode).then((authenticatedUser) => {
       if (authenticatedUser) {
-        const user = this.injected.user;
+        const user = this.stores.user;
         user.setName(authenticatedUser.fullName);
         user.setClassName(authenticatedUser.className);
         user.setAuthentication(true);

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -2,13 +2,15 @@ import { inject, observer } from "mobx-react";
 import * as React from "react";
 import { authenticate } from "../lib/auth";
 import { AppContainerComponent } from "./app-container";
-import { BaseComponent } from "./base";
+import { BaseComponent, IBaseProps } from "./base";
 
 import "./app.sass";
 
+interface IProps extends IBaseProps {}
+
 @inject("stores")
 @observer
-export class AppComponent extends BaseComponent<{}, {}> {
+export class AppComponent extends BaseComponent<IProps, {}> {
 
   public componentWillMount() {
     authenticate(this.stores.devMode).then((authenticatedUser) => {

--- a/src/components/base.ts
+++ b/src/components/base.ts
@@ -1,0 +1,15 @@
+import * as React from "react";
+import { IStores } from "../models/stores";
+
+export interface IBaseProps {
+  stores?: IStores;
+}
+
+export class BaseComponent<P, S> extends React.Component<P, S> {
+
+  // this assumes that stores are injected by the classes that extend BaseComponent
+  get stores() {
+    return (this.props as IBaseProps).stores as IStores;
+  }
+
+}

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,32 +1,23 @@
 import { inject, observer } from "mobx-react";
 import * as React from "react";
-import { IAllStores } from "../index";
-import { ProblemModelType } from "../models/problem";
-import { UserModelType } from "../models/user";
+import { IStores } from "../models/stores";
 
 import "./header.sass";
 
-interface IInjectedProps {
-  user: UserModelType;
-  problem: ProblemModelType;
+interface IProps {
+  stores?: IStores;
 }
 
-@inject((allStores: IAllStores) => {
-  const injected: IInjectedProps = {
-    problem: allStores.problem,
-    user: allStores.user,
-  };
-  return injected;
-})
+@inject("stores")
 @observer
-export class HeaderComponent extends React.Component<{}, {}> {
+export class HeaderComponent extends React.Component<IProps, {}> {
 
-  get injected() {
-    return this.props as IInjectedProps;
+  get stores() {
+    return this.props.stores as IStores;
   }
 
   public render() {
-    const {user, problem} = this.injected;
+    const {user, problem} = this.stores;
     const subtitle = problem.subtitle ? `: ${problem.subtitle}` : "";
     const problemTitle = `${problem.title}${subtitle}`;
 

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,12 +1,14 @@
 import { inject, observer } from "mobx-react";
 import * as React from "react";
-import { BaseComponent } from "./base";
+import { BaseComponent, IBaseProps } from "./base";
 
 import "./header.sass";
 
+interface IProps extends IBaseProps {}
+
 @inject("stores")
 @observer
-export class HeaderComponent extends BaseComponent<{}, {}> {
+export class HeaderComponent extends BaseComponent<IProps, {}> {
 
   public render() {
     const {user, problem} = this.stores;

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,20 +1,12 @@
 import { inject, observer } from "mobx-react";
 import * as React from "react";
-import { IStores } from "../models/stores";
+import { BaseComponent } from "./base";
 
 import "./header.sass";
 
-interface IProps {
-  stores?: IStores;
-}
-
 @inject("stores")
 @observer
-export class HeaderComponent extends React.Component<IProps, {}> {
-
-  get stores() {
-    return this.props.stores as IStores;
-  }
+export class HeaderComponent extends BaseComponent<{}, {}> {
 
   public render() {
     const {user, problem} = this.stores;

--- a/src/components/learning-log.tsx
+++ b/src/components/learning-log.tsx
@@ -4,11 +4,13 @@ import * as React from "react";
 import "./learning-log.sass";
 import { TabComponent } from "./tab";
 import { TabSetComponent } from "./tab-set";
-import { BaseComponent } from "./base";
+import { BaseComponent, IBaseProps } from "./base";
+
+interface IProps extends IBaseProps {}
 
 @inject("stores")
 @observer
-export class LearningLogComponent extends BaseComponent<{}, {}> {
+export class LearningLogComponent extends BaseComponent<IProps, {}> {
 
   public render() {
     const className = `learning-log${this.stores.ui.learningLogExpanded ? " expanded" : ""}`;

--- a/src/components/learning-log.tsx
+++ b/src/components/learning-log.tsx
@@ -1,31 +1,25 @@
 import { inject, observer } from "mobx-react";
 import * as React from "react";
 
-import { IAllStores } from "..";
-import { UIModelType } from "../models/ui";
+import { IStores } from "../models/stores";
 import "./learning-log.sass";
 import { TabComponent } from "./tab";
 import { TabSetComponent } from "./tab-set";
 
-interface IInjectedProps {
-  ui: UIModelType;
+interface IProps {
+  stores?: IStores;
 }
 
-@inject((allStores: IAllStores) => {
-  const injected: IInjectedProps = {
-    ui: allStores.ui,
-  };
-  return injected;
-})
+@inject("stores")
 @observer
-export class LearningLogComponent extends React.Component<{}, {}> {
+export class LearningLogComponent extends React.Component<IProps, {}> {
 
-  get injected() {
-    return this.props as IInjectedProps;
+  get stores() {
+    return this.props.stores as IStores;
   }
 
   public render() {
-    const className = `learning-log${this.injected.ui.learningLogExpanded ? " expanded" : ""}`;
+    const className = `learning-log${this.stores.ui.learningLogExpanded ? " expanded" : ""}`;
     return (
       <div className={className} onClick={this.handleClick}>
         <TabSetComponent>
@@ -41,6 +35,6 @@ export class LearningLogComponent extends React.Component<{}, {}> {
   }
 
   private handleClick = () => {
-    this.injected.ui.toggleLearningLog();
+    this.stores.ui.toggleLearningLog();
   }
 }

--- a/src/components/learning-log.tsx
+++ b/src/components/learning-log.tsx
@@ -1,22 +1,14 @@
 import { inject, observer } from "mobx-react";
 import * as React from "react";
 
-import { IStores } from "../models/stores";
 import "./learning-log.sass";
 import { TabComponent } from "./tab";
 import { TabSetComponent } from "./tab-set";
-
-interface IProps {
-  stores?: IStores;
-}
+import { BaseComponent } from "./base";
 
 @inject("stores")
 @observer
-export class LearningLogComponent extends React.Component<IProps, {}> {
-
-  get stores() {
-    return this.props.stores as IStores;
-  }
+export class LearningLogComponent extends BaseComponent<{}, {}> {
 
   public render() {
     const className = `learning-log${this.stores.ui.learningLogExpanded ? " expanded" : ""}`;

--- a/src/components/left-nav.tsx
+++ b/src/components/left-nav.tsx
@@ -1,35 +1,27 @@
 import { inject, observer } from "mobx-react";
 import * as React from "react";
 
-import { IAllStores } from "..";
-import { ProblemModelType } from "../models/problem";
-import { UIModelType } from "../models/ui";
+import { IStores } from "../models/stores";
 import "./left-nav.sass";
 import { TabComponent } from "./tab";
 import { TabSetComponent } from "./tab-set";
 
-interface IInjectedProps {
-  ui: UIModelType;
-  problem: ProblemModelType;
+interface IProps {
+  stores?: IStores;
 }
 
-@inject((allStores: IAllStores) => {
-  const injected: IInjectedProps = {
-    problem: allStores.problem,
-    ui: allStores.ui,
-  };
-  return injected;
-})
+@inject("stores")
 @observer
-export class LeftNavComponent extends React.Component<{}, {}> {
+export class LeftNavComponent extends React.Component<IProps, {}> {
 
-  get injected() {
-    return this.props as IInjectedProps;
+  get stores() {
+    return this.props.stores as IStores;
   }
 
   public render() {
-    const className = `left-nav${this.injected.ui.leftNavExpanded ? " expanded" : ""}`;
-    const { sections } = this.injected.problem;
+    const { problem, ui } = this.stores;
+    const className = `left-nav${ui.leftNavExpanded ? " expanded" : ""}`;
+    const { sections } = problem;
     return (
       <div className={className} onClick={this.handleClick}>
         <TabSetComponent>
@@ -49,6 +41,6 @@ export class LeftNavComponent extends React.Component<{}, {}> {
   }
 
   private handleClick = () => {
-    this.injected.ui.toggleLeftNav();
+    this.stores.ui.toggleLeftNav();
   }
 }

--- a/src/components/left-nav.tsx
+++ b/src/components/left-nav.tsx
@@ -4,11 +4,13 @@ import * as React from "react";
 import "./left-nav.sass";
 import { TabComponent } from "./tab";
 import { TabSetComponent } from "./tab-set";
-import { BaseComponent } from "./base";
+import { BaseComponent, IBaseProps } from "./base";
+
+interface IProps extends IBaseProps {}
 
 @inject("stores")
 @observer
-export class LeftNavComponent extends BaseComponent<{}, {}> {
+export class LeftNavComponent extends BaseComponent<IProps, {}> {
 
   public render() {
     const { problem, ui } = this.stores;

--- a/src/components/left-nav.tsx
+++ b/src/components/left-nav.tsx
@@ -1,22 +1,14 @@
 import { inject, observer } from "mobx-react";
 import * as React from "react";
 
-import { IStores } from "../models/stores";
 import "./left-nav.sass";
 import { TabComponent } from "./tab";
 import { TabSetComponent } from "./tab-set";
-
-interface IProps {
-  stores?: IStores;
-}
+import { BaseComponent } from "./base";
 
 @inject("stores")
 @observer
-export class LeftNavComponent extends React.Component<IProps, {}> {
-
-  get stores() {
-    return this.props.stores as IStores;
-  }
+export class LeftNavComponent extends BaseComponent<{}, {}> {
 
   public render() {
     const { problem, ui } = this.stores;

--- a/src/components/my-work.tsx
+++ b/src/components/my-work.tsx
@@ -1,22 +1,14 @@
 import { inject, observer } from "mobx-react";
 import * as React from "react";
 
-import { IStores } from "../models/stores";
 import "./my-work.sass";
 import { TabComponent } from "./tab";
 import { TabSetComponent } from "./tab-set";
-
-interface IProps {
-  stores?: IStores;
-}
+import { BaseComponent } from "./base";
 
 @inject("stores")
 @observer
-export class MyWorkComponent extends React.Component<IProps, {}> {
-
-  get stores() {
-    return this.props.stores as IStores;
-  }
+export class MyWorkComponent extends BaseComponent<{}, {}> {
 
   public render() {
     const { myWorkExpanded } = this.stores.ui;

--- a/src/components/my-work.tsx
+++ b/src/components/my-work.tsx
@@ -1,30 +1,25 @@
 import { inject, observer } from "mobx-react";
 import * as React from "react";
 
-import { IAllStores } from "..";
-import { UIModelType } from "../models/ui";
+import { IStores } from "../models/stores";
 import "./my-work.sass";
 import { TabComponent } from "./tab";
 import { TabSetComponent } from "./tab-set";
 
-interface IInjectedProps {
-  ui: UIModelType;
+interface IProps {
+  stores?: IStores;
 }
 
-@inject((allStores: IAllStores) => {
-  const injected: IInjectedProps = {
-    ui: allStores.ui,
-  };
-  return injected;
-})@observer
-export class MyWorkComponent extends React.Component<{}, {}> {
+@inject("stores")
+@observer
+export class MyWorkComponent extends React.Component<IProps, {}> {
 
-  get injected() {
-    return this.props as IInjectedProps;
+  get stores() {
+    return this.props.stores as IStores;
   }
 
   public render() {
-    const { myWorkExpanded } = this.injected.ui;
+    const { myWorkExpanded } = this.stores.ui;
     const className = `my-work${myWorkExpanded ? " expanded" : ""}`;
     return (
       <div className={className}>
@@ -39,6 +34,6 @@ export class MyWorkComponent extends React.Component<{}, {}> {
   }
 
   private handleClick = () => {
-    this.injected.ui.toggleMyWork();
+    this.stores.ui.toggleMyWork();
   }
 }

--- a/src/components/my-work.tsx
+++ b/src/components/my-work.tsx
@@ -4,11 +4,13 @@ import * as React from "react";
 import "./my-work.sass";
 import { TabComponent } from "./tab";
 import { TabSetComponent } from "./tab-set";
-import { BaseComponent } from "./base";
+import { BaseComponent, IBaseProps } from "./base";
+
+interface IProps extends IBaseProps {}
 
 @inject("stores")
 @observer
-export class MyWorkComponent extends BaseComponent<{}, {}> {
+export class MyWorkComponent extends BaseComponent<IProps, {}> {
 
   public render() {
     const { myWorkExpanded } = this.stores.ui;

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1,11 +1,11 @@
 import { inject, observer } from "mobx-react";
 import * as React from "react";
 
-import { IStores } from "../models/stores";
 import { UIModelType } from "../models/ui";
 import { WorkspaceModel, WorkspaceTool } from "../models/workspace";
 import { CanvasComponent } from "./canvas";
 import { FourUpComponent } from "./four-up";
+import { BaseComponent } from "./base";
 
 import "./workspace.sass";
 
@@ -16,17 +16,9 @@ const workspace = WorkspaceModel.create({
   tool: "select",
 });
 
-interface IProps {
-  stores?: IStores;
-}
-
 @inject("stores")
 @observer
-export class WorkspaceComponent extends React.Component<IProps, {}> {
-
-  get stores() {
-    return this.props.stores as IStores;
-  }
+export class WorkspaceComponent extends BaseComponent<{}, {}> {
 
   public render() {
     return (

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1,11 +1,10 @@
 import { inject, observer } from "mobx-react";
 import * as React from "react";
 
-import { UIModelType } from "../models/ui";
 import { WorkspaceModel, WorkspaceTool } from "../models/workspace";
 import { CanvasComponent } from "./canvas";
 import { FourUpComponent } from "./four-up";
-import { BaseComponent } from "./base";
+import { BaseComponent, IBaseProps } from "./base";
 
 import "./workspace.sass";
 
@@ -16,9 +15,11 @@ const workspace = WorkspaceModel.create({
   tool: "select",
 });
 
+interface IProps extends IBaseProps {}
+
 @inject("stores")
 @observer
-export class WorkspaceComponent extends BaseComponent<{}, {}> {
+export class WorkspaceComponent extends BaseComponent<IProps, {}> {
 
   public render() {
     return (

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1,7 +1,7 @@
 import { inject, observer } from "mobx-react";
 import * as React from "react";
 
-import { IAllStores } from "../index";
+import { IStores } from "../models/stores";
 import { UIModelType } from "../models/ui";
 import { WorkspaceModel, WorkspaceTool } from "../models/workspace";
 import { CanvasComponent } from "./canvas";
@@ -16,21 +16,16 @@ const workspace = WorkspaceModel.create({
   tool: "select",
 });
 
-interface IInjectedProps {
-  ui: UIModelType;
+interface IProps {
+  stores?: IStores;
 }
 
-@inject((allStores: IAllStores) => {
-  const injected: IInjectedProps = {
-    ui: allStores.ui,
-  };
-  return injected;
-})
+@inject("stores")
 @observer
-export class WorkspaceComponent extends React.Component<{}, {}> {
+export class WorkspaceComponent extends React.Component<IProps, {}> {
 
-  get injected() {
-    return this.props as IInjectedProps;
+  get stores() {
+    return this.props.stores as IStores;
   }
 
   public render() {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -7,8 +7,8 @@ const DEV_USER: StudentUser = {
   id: "123",
   firstName: "Sofia",
   lastName: "Q.",
-  fullName: "Sophia Q.",
-  className: "Mr. Singh's Class",
+  fullName: "Sofia Q.",
+  className: "Geometry (3rd)",
 };
 
 export interface RawUser {

--- a/src/models/curriculum.ts
+++ b/src/models/curriculum.ts
@@ -7,7 +7,7 @@ import { each, isObject } from "lodash";
 export const CurriculumModel = types
   .model("Curriculum", {
     title: types.string,
-    subtitle: types.optional(types.string, ""),
+    subtitle: "",
     lookingAhead: types.maybe(DocumentContentModel),
     investigations: types.array(InvestigationModel)
   })

--- a/src/models/problem.ts
+++ b/src/models/problem.ts
@@ -5,7 +5,7 @@ export const ProblemModel = types
   .model("Problem", {
     ordinal: types.integer,
     title: types.string,
-    subtitle: types.optional(types.string, ""),
+    subtitle: "",
     sections: types.array(SectionModel)
   });
 

--- a/src/models/stores.test.ts
+++ b/src/models/stores.test.ts
@@ -7,10 +7,10 @@ describe("stores object", () => {
 
   it("supports creating dummy stores for testing", () => {
     const stores = createStores();
-    expect(stores).to.exist;          // tslint:disable-line
-    expect(stores.user).to.exist;     // tslint:disable-line
-    expect(stores.problem).to.exist;  // tslint:disable-line
-    expect(stores.ui).to.exist;       // tslint:disable-line
+    expect(stores).to.exist;
+    expect(stores.user).to.exist;
+    expect(stores.problem).to.exist;
+    expect(stores.ui).to.exist;
   });
 
   it("supports passing in stores for testing", () => {

--- a/src/models/stores.test.ts
+++ b/src/models/stores.test.ts
@@ -1,0 +1,28 @@
+import { expect } from "chai";
+import { createStores } from "./stores";
+import { ProblemModel } from "./problem";
+import { UserModel } from "./user";
+
+describe("stores object", () => {
+
+  it("supports creating dummy stores for testing", () => {
+    const stores = createStores();
+    expect(stores).to.exist;          // tslint:disable-line
+    expect(stores.user).to.exist;     // tslint:disable-line
+    expect(stores.problem).to.exist;  // tslint:disable-line
+    expect(stores.ui).to.exist;       // tslint:disable-line
+  });
+
+  it("supports passing in stores for testing", () => {
+    const devMode = true;
+    const name = "Colonel Mustard";
+    const user = UserModel.create({ name });
+    const title = "Test Problem";
+    const problem = ProblemModel.create({ ordinal: 1, title });
+    const stores = createStores({ devMode, user, problem });
+    expect(stores.devMode).to.equal(true);
+    expect(stores.user.name).to.equal(name);
+    expect(stores.problem.title).to.equal(title);
+  });
+
+});

--- a/src/models/stores.ts
+++ b/src/models/stores.ts
@@ -1,0 +1,27 @@
+import { ProblemModel, ProblemModelType } from "./problem";
+import { UIModel, UIModelType } from "./ui";
+import { UserModel, UserModelType } from "./user";
+
+export interface IStores {
+  devMode: boolean;
+  problem: ProblemModelType;
+  user: UserModelType;
+  ui: UIModelType;
+}
+
+export interface ICreateStores {
+  devMode: boolean;
+  problem?: ProblemModelType;
+  user?: UserModelType;
+  ui?: UIModelType;
+}
+
+export function createStores(params?: ICreateStores): IStores {
+  return {
+    devMode: params && (params.devMode != null) ? params.devMode : false,
+    // for ease of testing, we create a null problem if none is provided
+    problem: params && params.problem || ProblemModel.create({ ordinal: 0, title: "Null Problem" }),
+    user: params && params.user || UserModel.create(),
+    ui: params && params.ui || UIModel.create()
+  };
+}

--- a/src/models/stores.ts
+++ b/src/models/stores.ts
@@ -10,7 +10,7 @@ export interface IStores {
 }
 
 export interface ICreateStores {
-  devMode: boolean;
+  devMode?: boolean;
   problem?: ProblemModelType;
   user?: UserModelType;
   ui?: UIModelType;

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -3,8 +3,8 @@ import { types } from "mobx-state-tree";
 export const UserModel = types
   .model("User", {
     authenticated: false,
-    name: types.optional(types.string, "Anonymous User"),
-    className: types.maybeNull(types.string),
+    name: "Anonymous User",
+    className: "",
   })
   .actions((self) => ({
     setName(name: string) {

--- a/src/utilities/url-params.ts
+++ b/src/utilities/url-params.ts
@@ -1,8 +1,12 @@
 import { parse } from "query-string";
 
 interface QueryParams {
+  // devMode === "true" or "1" for auto-authentication as developer
   devMode?: string;
+  // ordinal string, e.g. "2.1", "3.2", etc.
   problem?: string;
+  // nonce (short-lived token) from portal for authentication
+  token?: string;
 }
 
 export const urlParams: QueryParams = parse(location.search);

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["tslint:recommended", "tslint-react"],
+  "extends": ["tslint:recommended", "tslint-react", "tslint-no-unused-expression-chai"],
   "rules": {
     "arrow-parens": false,
     "jsx-no-multiline-js": false,

--- a/tslint.json
+++ b/tslint.json
@@ -3,6 +3,7 @@
   "rules": {
     "arrow-parens": false,
     "jsx-no-multiline-js": false,
+    "no-empty-interface": false,
     "object-literal-sort-keys": false,
     "one-line": false,
     "ordered-imports": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,9 +6,6 @@
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.1.4.tgz#5ca073b330d90b4066d6ce18f60d57f2084ce8ca"
 
-"@types/lodash@^4.14.116":
-  version "4.14.116"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.116.tgz#5ccf215653e3e8c786a58390751033a9adca0eb9"
 "@types/cookiejar@*":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@types/cookiejar/-/cookiejar-2.1.0.tgz#4b7daf2c51696cfc70b942c11690528229d1a1ce"
@@ -18,6 +15,10 @@
   resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-7.2.8.tgz#8d199dab4ddb5bba3234f8311b804d2027af2b3a"
   dependencies:
     "@types/node" "*"
+
+"@types/lodash@^4.14.116":
+  version "4.14.116"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.116.tgz#5ccf215653e3e8c786a58390751033a9adca0eb9"
 
 "@types/mocha@^5.2.5":
   version "5.2.5"
@@ -4760,6 +4761,12 @@ tslint-loader@^3.6.0:
     rimraf "^2.4.4"
     semver "^5.3.0"
 
+tslint-no-unused-expression-chai@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/tslint-no-unused-expression-chai/-/tslint-no-unused-expression-chai-0.1.3.tgz#280e7e747744d6f4a59f06df422e29e4794ead09"
+  dependencies:
+    tsutils "^2.3.0"
+
 tslint-react@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/tslint-react/-/tslint-react-3.6.0.tgz#7f462c95c4a0afaae82507f06517ff02942196a1"
@@ -4783,7 +4790,7 @@ tslint@^5.11.0:
     tslib "^1.8.0"
     tsutils "^2.27.2"
 
-tsutils@^2.13.1, tsutils@^2.27.2:
+tsutils@^2.13.1, tsutils@^2.27.2, tsutils@^2.3.0:
   version "2.29.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.29.0.tgz#32b488501467acbedd4b85498673a0812aca0b99"
   dependencies:


### PR DESCRIPTION
Refactor stores [#160188594]
- moves `stores` into separate module
- @inject stores into all components that need them

@ekosmin The API has changed a bit since we reviewed it together, so you may want to take another glance. Also, I added the unit test we talked about.
@dougmartin I ended up not going with the special derived/base class approach. It seemed like we could get enough of our boilerplate reduction and testing benefits without it.

@dougmartin @ekosmin I made some changes based on code review in case you want to take another look. I'm going to do a quick test of `tslint-no-unused-expression-chai` to see if it drops in as easily as it's supposed to. If it does I'll update the PR. -- Well that was easy. It dropped right in. 