### PR TITLE
Authorization tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "tslint -c tslint.json 'src/**/*.{ts,tsx}'",
     "lint:fix": "tslint -c tslint.json --fix 'src/**/*.{ts,tsx}'",
     "test": "mocha -r ts-node/register src/**/*.test.ts",
+    "test:debug": "mocha --inspect-brk -r ts-node/register src/**/*.test.ts",
     "test:watch": "mocha --watch-extensions ts,json --watch -r ts-node/register src/**/*.test.ts"
   },
   "repository": {
@@ -28,6 +29,7 @@
     "@types/jsonwebtoken": "^7.2.8",
     "@types/lodash": "^4.14.116",
     "@types/mocha": "^5.2.5",
+    "@types/nock": "^9.3.0",
     "@types/query-string": "^6.1.0",
     "@types/react": "^16.4.11",
     "@types/react-dom": "^16.0.7",
@@ -39,6 +41,7 @@
     "html-webpack-plugin": "^3.2.0",
     "mini-css-extract-plugin": "^0.4.2",
     "mocha": "^5.2.0",
+    "nock": "^9.6.1",
     "node-sass": "^4.9.3",
     "npm-run-all": "^4.1.3",
     "postcss-loader": "^3.0.0",

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import { authenticate } from "../lib/auth";
 import { AppContainerComponent } from "./app-container";
 import { BaseComponent, IBaseProps } from "./base";
+import { urlParams } from "../utilities/url-params";
 
 import "./app.sass";
 
@@ -13,7 +14,7 @@ interface IProps extends IBaseProps {}
 export class AppComponent extends BaseComponent<IProps, {}> {
 
   public componentWillMount() {
-    authenticate(this.stores.devMode).then((authenticatedUser) => {
+    authenticate(this.stores.devMode, urlParams.token, urlParams.domain).then((authenticatedUser) => {
       if (authenticatedUser) {
         const user = this.stores.user;
         user.setName(authenticatedUser.fullName);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,18 +8,12 @@ import { UserModel } from "./models/user";
 import { createFromJson } from "./models/curriculum";
 import * as curriculumJson from "./curriculum/stretching-and-shrinking.json";
 import { urlParams } from "./utilities/url-params";
+import { getDevMode } from "./lib/auth";
 
 import "./index.sass";
 
 const host = window.location.host.split(":")[0];
-// An explicitly set devMode takes priority
-// Otherwise, assume that local users are devs, unless a token is specified,
-// in which authentication is likely being tested
-const devMode = urlParams.devMode != null
-                  ? (urlParams.devMode === "true") || (urlParams.devMode === "1")
-                  : urlParams.token == null && (
-                      (host === "localhost") || (host === "127.0.0.1")
-                    );
+const devMode = getDevMode(urlParams.devMode, urlParams.token, host);
 
 const user = UserModel.create();
 

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -1,11 +1,11 @@
 import { assert } from "chai";
-import { getPortalJWTWithBearerToken, getClassInfo, authenticate, _private } from "./auth";
+import { authenticate, _private, PortalJWT, RawUser, RawClassInfo } from "./auth";
 import * as nock from "nock";
 
 // tslint:disable-next-line:max-line-length
-const RAW_PORTAL_JWT = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhbGciOiJIUzI1NiIsImlhdCI6MTUzNTY4NDEyNCwiZXhwIjoxNTM1Njg3NzI0LCJ1aWQiOjQ4MiwiZG9tYWluIjoiaHR0cHM6Ly9sZWFybi5zdGFnaW5nLmNvbmNvcmQub3JnLyIsInVzZXJfdHlwZSI6ImxlYXJuZXIiLCJ1c2VyX2lkIjoiaHR0cHM6Ly9sZWFybi5zdGFnaW5nLmNvbmNvcmQub3JnL3VzZXJzLzQ4MiIsImxlYXJuZXJfaWQiOjExNTgsImNsYXNzX2luZm9fdXJsIjoiaHR0cHM6Ly9sZWFybi5zdGFnaW5nLmNvbmNvcmQub3JnL2FwaS92MS9jbGFzc2VzLzEyOCIsIm9mZmVyaW5nX2lkIjo5OTJ9.NTEtF2GR23SzdhE9CCoc_VMcWyb1orb11RhKjdq-st8";
+const RAW_PORTAL_JWT: string = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhbGciOiJIUzI1NiIsImlhdCI6MTUzNTY4NDEyNCwiZXhwIjoxNTM1Njg3NzI0LCJ1aWQiOjQ4MiwiZG9tYWluIjoiaHR0cHM6Ly9sZWFybi5zdGFnaW5nLmNvbmNvcmQub3JnLyIsInVzZXJfdHlwZSI6ImxlYXJuZXIiLCJ1c2VyX2lkIjoiaHR0cHM6Ly9sZWFybi5zdGFnaW5nLmNvbmNvcmQub3JnL3VzZXJzLzQ4MiIsImxlYXJuZXJfaWQiOjExNTgsImNsYXNzX2luZm9fdXJsIjoiaHR0cHM6Ly9sZWFybi5zdGFnaW5nLmNvbmNvcmQub3JnL2FwaS92MS9jbGFzc2VzLzEyOCIsIm9mZmVyaW5nX2lkIjo5OTJ9.NTEtF2GR23SzdhE9CCoc_VMcWyb1orb11RhKjdq-st8";
 
-const PORTAL_JWT = {
+const PORTAL_JWT: PortalJWT = {
   alg: "HS256",
   iat: 1535684124,
   exp: 1535687724,
@@ -18,31 +18,32 @@ const PORTAL_JWT = {
   offering_id: 992
 };
 
-const GOOD_NONCE = "goodNonce";
-const BAD_NONCE = "badNonce";
+const GOOD_NONCE: string = "goodNonce";
+const BAD_NONCE: string = "badNonce";
 
-const PORTAL_DOMAIN = "http://portal/";
+const PORTAL_DOMAIN: string = "http://portal/";
 
-const CLASS_INFO_URL = "https://learn.staging.concord.org/api/v1/classes/128";
+const CLASS_INFO_URL: string = "https://learn.staging.concord.org/api/v1/classes/128";
 
-const RAW_CORRECT_STUDENT = {
+const RAW_CORRECT_STUDENT: RawUser = {
   id: PORTAL_JWT.user_id,
   first_name: "good first",
   last_name: "good last",
 };
 
-const RAW_INCORRECT_STUDENT = {
+const RAW_INCORRECT_STUDENT: RawUser = {
   id: "bad id",
   first_name: "bad first",
   last_name: "bad last",
 };
 
-const RAW_CLASS_INFO = {
+const RAW_CLASS_INFO: RawClassInfo = {
   uri: "https://foo.bar",
   name: "test name",
   state: "test state",
   class_hash: "test hash",
-  students: [RAW_CORRECT_STUDENT, RAW_INCORRECT_STUDENT ]
+  students: [RAW_CORRECT_STUDENT, RAW_INCORRECT_STUDENT ],
+  teachers: [],
 };
 
 describe("authentication", () => {

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -1,5 +1,5 @@
 import { assert } from "chai";
-import { authenticate, _private, PortalJWT, RawUser, RawClassInfo } from "./auth";
+import { authenticate, _private, PortalJWT, RawUser, RawClassInfo, getDevMode } from "./auth";
 import * as nock from "nock";
 
 // tslint:disable-next-line:max-line-length
@@ -45,6 +45,31 @@ const RAW_CLASS_INFO: RawClassInfo = {
   students: [RAW_CORRECT_STUDENT, RAW_INCORRECT_STUDENT ],
   teachers: [],
 };
+
+describe("dev mode", () => {
+  it("should be in dev mode on a local machine", () => {
+    const mode = getDevMode(undefined, undefined, "localhost");
+    assert.equal(mode, true);
+  });
+
+  it("should not be in dev mode if authentication is being tested", () => {
+    const mode = getDevMode(undefined, "testToken", "localhost");
+    assert.equal(mode, false);
+  });
+
+  it("should not be in dev mode by default in production", () => {
+    const mode = getDevMode(undefined, undefined, "learning.concord.org");
+    assert.equal(mode, false);
+  });
+
+  it("should use the dev mode parameter if it's specified", () => {
+    const trueMode = getDevMode("true", undefined, "learning.concord.org");
+    assert.equal(trueMode, true);
+
+    const falseMode = getDevMode("false", undefined, "localhost");
+    assert.equal(falseMode, false);
+  });
+});
 
 describe("authentication", () => {
 

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -1,0 +1,122 @@
+import { assert } from "chai";
+import { getPortalJWTWithBearerToken, getClassInfo, authenticate, _private } from "./auth";
+import * as nock from "nock";
+
+// tslint:disable-next-line:max-line-length
+const RAW_PORTAL_JWT = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhbGciOiJIUzI1NiIsImlhdCI6MTUzNTY4NDEyNCwiZXhwIjoxNTM1Njg3NzI0LCJ1aWQiOjQ4MiwiZG9tYWluIjoiaHR0cHM6Ly9sZWFybi5zdGFnaW5nLmNvbmNvcmQub3JnLyIsInVzZXJfdHlwZSI6ImxlYXJuZXIiLCJ1c2VyX2lkIjoiaHR0cHM6Ly9sZWFybi5zdGFnaW5nLmNvbmNvcmQub3JnL3VzZXJzLzQ4MiIsImxlYXJuZXJfaWQiOjExNTgsImNsYXNzX2luZm9fdXJsIjoiaHR0cHM6Ly9sZWFybi5zdGFnaW5nLmNvbmNvcmQub3JnL2FwaS92MS9jbGFzc2VzLzEyOCIsIm9mZmVyaW5nX2lkIjo5OTJ9.NTEtF2GR23SzdhE9CCoc_VMcWyb1orb11RhKjdq-st8";
+
+const PORTAL_JWT = {
+  alg: "HS256",
+  iat: 1535684124,
+  exp: 1535687724,
+  uid: 482,
+  domain: "https://learn.staging.concord.org/",
+  user_type: "learner",
+  user_id: "https://learn.staging.concord.org/users/482",
+  learner_id: 1158,
+  class_info_url: "https://learn.staging.concord.org/api/v1/classes/128",
+  offering_id: 992
+};
+
+const GOOD_NONCE = "goodNonce";
+const BAD_NONCE = "badNonce";
+
+const PORTAL_DOMAIN = "http://portal/";
+
+const CLASS_INFO_URL = "https://learn.staging.concord.org/api/v1/classes/128";
+
+const RAW_CORRECT_STUDENT = {
+  id: PORTAL_JWT.user_id,
+  first_name: "good first",
+  last_name: "good last",
+};
+
+const RAW_INCORRECT_STUDENT = {
+  id: "bad id",
+  first_name: "bad first",
+  last_name: "bad last",
+};
+
+const RAW_CLASS_INFO = {
+  uri: "https://foo.bar",
+  name: "test name",
+  state: "test state",
+  class_hash: "test hash",
+  students: [RAW_CORRECT_STUDENT, RAW_INCORRECT_STUDENT ]
+};
+
+describe("authentication", () => {
+
+  beforeEach(() => {
+    nock((PORTAL_DOMAIN + _private.PORTAL_JWT_URL_SUFFIX), {
+      reqheaders: {
+        Authorization: `Bearer ${GOOD_NONCE}`
+      }
+    })
+    .get("")
+    .reply(200, {
+      token: RAW_PORTAL_JWT,
+    });
+
+    nock((PORTAL_DOMAIN + _private.PORTAL_JWT_URL_SUFFIX), {
+      reqheaders: {
+        Authorization: `Bearer ${BAD_NONCE}`
+      }
+    })
+    .get("")
+    .reply(400);
+
+    nock(CLASS_INFO_URL, {
+      reqheaders: {
+        Authorization: `Bearer/JWT ${RAW_PORTAL_JWT}`
+      }
+    })
+    .get("")
+    .reply(200, RAW_CLASS_INFO);
+  });
+
+  it("Authenticates as a developer", (done) => {
+    authenticate(true).then((authenticatedUser) => {
+      assert.deepEqual(authenticatedUser, _private.DEV_USER);
+      done();
+    });
+  });
+
+  it("Authenticates externally", (done) => {
+    authenticate(false, GOOD_NONCE, PORTAL_DOMAIN).then((authenticatedUser) => {
+      assert.deepEqual(authenticatedUser, {
+        type: "student",
+        id: PORTAL_JWT.user_id,
+        firstName: RAW_CORRECT_STUDENT.first_name,
+        lastName: RAW_CORRECT_STUDENT.last_name,
+        fullName: `${RAW_CORRECT_STUDENT.first_name} ${RAW_CORRECT_STUDENT.last_name}`,
+        className: RAW_CLASS_INFO.name
+      });
+      done();
+    });
+  });
+
+  it("Fails to authenticate with a bad nonce", (done) => {
+    authenticate(false, BAD_NONCE, PORTAL_DOMAIN)
+      .then(() => {
+        assert(false);
+      })
+      .catch(() => done());
+  });
+
+  it("Fails to authenticate with no token", (done) => {
+    authenticate(false, undefined, PORTAL_DOMAIN)
+      .then(() => {
+        assert(false);
+      })
+      .catch(() => done());
+  });
+
+  it("Fails to authenticate with no domain", (done) => {
+    authenticate(false, BAD_NONCE, undefined)
+      .then(() => {
+        assert(false);
+      })
+      .catch(() => done());
+  });
+});

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -64,6 +64,15 @@ export interface PortalJWT extends BasePortalJWT {
   offering_id: number;
 }
 
+// An explicitly set devMode takes priority
+// Otherwise, assume that local users are devs, unless a token is specified,
+// in which authentication is likely being tested
+export const getDevMode = (devModeParam?: string, token?: string, host?: string) => {
+  return devModeParam != null
+           ? devModeParam === "true" || devModeParam === "1"
+           : token == null && (host === "localhost" || host === "127.0.0.1");
+};
+
 export const getErrorMessage = (err: any, res: superagent.Response) => {
   return (res.body ? res.body.message : null) || err;
 };

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -68,9 +68,11 @@ export const getErrorMessage = (err: any, res: superagent.Response) => {
   return (res.body ? res.body.message : null) || err;
 };
 
+const PORTAL_JWT_URL_SUFFIX = "api/v1/jwt/portal";
+
 export const getPortalJWTWithBearerToken = (domain: string, type: string, token: string) => {
   return new Promise<[string, PortalJWT]>((resolve, reject) => {
-    const url = `${domain}api/v1/jwt/portal`;
+    const url = `${domain}${PORTAL_JWT_URL_SUFFIX}`;
     superagent
       .get(url)
       .set("Authorization", `${type} ${token}`)
@@ -130,14 +132,11 @@ export const getClassInfo = (classInfoUrl: string, rawPortalJWT: string) => {
   });
 };
 
-export const authenticate = (devMode: boolean) => {
+export const authenticate = (devMode: boolean, token?: string, domain?: string) => {
   return new Promise<StudentUser | null>((resolve, reject) => {
     if (devMode) {
       resolve(DEV_USER);
     }
-
-    const queryParams: AuthQueryParams = queryString.parse(window.location.search);
-    const {token, domain} = queryParams;
 
     if (!token) {
       return reject("No token provided for authentication (must launch from Portal)");
@@ -165,6 +164,14 @@ export const authenticate = (devMode: boolean) => {
 
             resolve(user);
           });
+      })
+      .catch((e) => {
+        reject(e);
       });
   });
+};
+
+export const _private = {
+  DEV_USER,
+  PORTAL_JWT_URL_SUFFIX
 };

--- a/src/models/user.test.ts
+++ b/src/models/user.test.ts
@@ -26,4 +26,17 @@ describe("user model", () => {
     user.setName("Different User");
     expect(user.name).to.equal("Different User");
   });
+
+  it("can authenticate", () => {
+    const user = UserModel.create();
+    user.setAuthentication(true);
+    expect(user.authenticated).to.equal(true);
+  });
+
+  it("can set a class name", () => {
+    const user = UserModel.create();
+    const className = "test class";
+    user.setClassName(className);
+    expect(user.className).to.equal(className);
+  });
 });

--- a/src/utilities/url-params.ts
+++ b/src/utilities/url-params.ts
@@ -7,6 +7,8 @@ interface QueryParams {
   problem?: string;
   // nonce (short-lived token) from portal for authentication
   token?: string;
+  // The domain of the portal opening the app
+  domain?: string;
 }
 
 export const urlParams: QueryParams = parse(location.search);

--- a/tslint.json
+++ b/tslint.json
@@ -8,6 +8,8 @@
     "one-line": false,
     "ordered-imports": false,
     "trailing-comma": false,
-    "interface-name" : [false]
+    "interface-name" : [false],
+    "variable-name": [true, "ban-keywords", "check-format", "allow-pascal-case", "allow-leading-underscore"],
+    "no-debugger": false
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,6 +24,12 @@
   version "5.2.5"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.2.5.tgz#8a4accfc403c124a0bafe8a9fc61a05ec1032073"
 
+"@types/nock@^9.3.0":
+  version "9.3.0"
+  resolved "https://registry.yarnpkg.com/@types/nock/-/nock-9.3.0.tgz#9d34358fdcc08afd07144e0784ac9e951d412dd4"
+  dependencies:
+    "@types/node" "*"
+
 "@types/node@*":
   version "10.9.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.9.1.tgz#06f002136fbcf51e730995149050bb3c45ee54e6"
@@ -1176,7 +1182,7 @@ deep-eql@^3.0.0:
   dependencies:
     type-detect "^4.0.0"
 
-deep-equal@^1.0.1:
+deep-equal@^1.0.0, deep-equal@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
 
@@ -2550,7 +2556,7 @@ json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
 
-json-stringify-safe@~5.0.1:
+json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
@@ -3131,6 +3137,20 @@ no-case@^2.2.0:
   resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.2.tgz#60b813396be39b3f1288a4c1ed5d1e7d28b464ac"
   dependencies:
     lower-case "^1.1.1"
+
+nock@^9.6.1:
+  version "9.6.1"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-9.6.1.tgz#d96e099be9bc1d0189a77f4490bbbb265c381b49"
+  dependencies:
+    chai "^4.1.2"
+    debug "^3.1.0"
+    deep-equal "^1.0.0"
+    json-stringify-safe "^5.0.1"
+    lodash "^4.17.5"
+    mkdirp "^0.5.0"
+    propagate "^1.0.0"
+    qs "^6.5.1"
+    semver "^5.5.0"
 
 node-fetch@^1.0.1:
   version "1.7.3"
@@ -3733,6 +3753,10 @@ prop-types@^15.6.0:
   dependencies:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
+
+propagate@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/propagate/-/propagate-1.0.0.tgz#00c2daeedda20e87e3782b344adba1cddd6ad709"
 
 proxy-addr@~2.0.3:
   version "2.0.4"


### PR DESCRIPTION
I added a handful of tests that use `Nock` to test authentication. Not 100% coverage of the `auth` file, but the main method is covered quite well.

I wanted to add tests for the logic in `index` that calculates `devMode` as well, but I couldn't manage to test anything in that file. Does it not get loaded by Mocha?

Also, I suspect I'll have some conflicts with Kirk's PR, but I'll resolve those once it's merged in.