### PR TITLE
Add DataSet and Attribute models from Workspaces/NeoCODAP

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@types/react": "^16.4.11",
     "@types/react-dom": "^16.0.7",
     "@types/superagent": "^3.8.4",
+    "@types/uuid": "^3.4.4",
     "autoprefixer": "^9.1.3",
     "babel-core": "^6.26.3",
     "babel-jest": "^23.4.2",
@@ -91,6 +92,7 @@
     "query-string": "^6.1.0",
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
-    "superagent": "^3.8.3"
+    "superagent": "^3.8.3",
+    "uuid": "^3.3.2"
   }
 }

--- a/src/models/data/attribute.test.ts
+++ b/src/models/data/attribute.test.ts
@@ -1,0 +1,76 @@
+import { Attribute, IAttributeCreation } from "./attribute";
+import { clone } from "lodash";
+
+test("Attribute functionality", () => {
+  const attribute = Attribute.create({ name: "foo" } as any);
+  expect(attribute.id).toBeDefined();
+  expect(attribute.name).toBe("foo");
+  expect(attribute.length).toBe(0);
+
+  const copy = clone(attribute);
+  expect(copy.id).toBe(attribute.id);
+  expect(copy.name).toBe(attribute.name);
+
+  attribute.setName("bar");
+  expect(attribute.name).toBe("bar");
+
+  attribute.setUnits("m");
+  expect(attribute.units).toBe("m");
+
+  attribute.addValue(1);
+  expect(attribute.length).toBe(1);
+  expect(attribute.value(0)).toBe(1);
+
+  attribute.addValues([2, 3]);
+  expect(attribute.length).toBe(3);
+  expect(attribute.value(1)).toBe(2);
+  expect(attribute.value(2)).toBe(3);
+
+  attribute.addValue(0, 0);
+  expect(attribute.length).toBe(4);
+  expect(attribute.value(0)).toBe(0);
+  expect(attribute.value(3)).toBe(3);
+
+  attribute.addValues([-2, -1], 0);
+  expect(attribute.length).toBe(6);
+  expect(attribute.value(0)).toBe(-2);
+  expect(attribute.value(5)).toBe(3);
+
+  attribute.setValue(2, 3);
+  expect(attribute.value(2)).toBe(3);
+  attribute.setValue(10, 10);
+
+  attribute.setValues([0, 1], [1, 2]);
+  expect(attribute.value(0)).toBe(1);
+  expect(attribute.value(1)).toBe(2);
+  attribute.setValues([10, 11], [10, 11]);
+
+  attribute.setValues([0, 1], [0]);
+  expect(attribute.value(0)).toBe(0);
+  expect(attribute.value(1)).toBe(2);
+
+  attribute.removeValues(2);
+  expect(attribute.length).toBe(5);
+  expect(attribute.value(2)).toBe(1);
+
+  attribute.removeValues(0, 2);
+  expect(attribute.length).toBe(3);
+  expect(attribute.value(0)).toBe(1);
+  attribute.removeValues(0, 0);
+  expect(attribute.length).toBe(3);
+  expect(attribute.value(0)).toBe(1);
+
+  const bar = Attribute.create({ name: "bar", values: [0, 1, 2] } as any);
+  expect(bar.name).toBe("bar");
+  expect(bar.length).toBe(3);
+
+  const bazSnap: IAttributeCreation = bar.derive("baz");
+  expect(bazSnap.id).toBe(bar.id);
+  expect(bazSnap.name).toBe("baz");
+  expect(bazSnap.values && bazSnap.values.length).toBe(0);
+
+  const barSnap: IAttributeCreation = bar.derive();
+  expect(barSnap.id).toBe(bar.id);
+  expect(barSnap.name).toBe(bar.name);
+  expect(barSnap.values && barSnap.values.length).toBe(0);
+});

--- a/src/models/data/attribute.ts
+++ b/src/models/data/attribute.ts
@@ -1,0 +1,85 @@
+import { types, Instance, SnapshotIn, SnapshotOut } from "mobx-state-tree";
+import * as uuid from "uuid/v4";
+
+const ValueType = types.union(types.number, types.string, types.undefined);
+export type IValueType = number | string | undefined;
+
+export const Attribute = types.model("Attribute", {
+  id: types.identifier,
+  clientKey: "",
+  sourceID: types.maybe(types.string),
+  name: types.string,
+  hidden: false,
+  units: "",
+  formula: "",
+  values: types.array(ValueType)
+}).preProcessSnapshot((snapshot) => {
+  const { id, ...others } = snapshot;
+  return { id: id || uuid(), ...others };
+}).views(self => ({
+  get length() {
+    return self.values.length;
+  },
+  value(index: number) {
+    return self.values[index];
+  },
+  derive(name?: string) {
+    return { id: self.id, name: name || self.name, units: self.units, values: [] };
+  }
+})).actions(self => ({
+  setName(newName: string) {
+    self.name = newName;
+  },
+  setUnits(units: string) {
+    self.units = units;
+  },
+  addValue(value: IValueType, beforeIndex?: number) {
+    if ((beforeIndex != null) && (beforeIndex < self.values.length)) {
+      self.values.splice(beforeIndex, 0, value);
+    }
+    else {
+      self.values.push(value);
+    }
+  },
+  addValues(values: IValueType[], beforeIndex?: number) {
+    if ((beforeIndex != null) && (beforeIndex < self.values.length)) {
+      self.values.splice.apply(self.values, [beforeIndex, 0, ...values]);
+    }
+    else {
+      self.values.push.apply(self.values, values);
+    }
+  },
+  setValue(index: number, value: IValueType) {
+    if ((index >= 0) && (index < self.values.length)) {
+      self.values[index] = value;
+    }
+  },
+  setValues(indices: number[], values: IValueType[]) {
+    const length = indices.length <= values.length ? indices.length : values.length;
+    for (let i = 0; i < length; ++i) {
+      const index = indices[i];
+      if ((index >= 0) && (index < self.values.length)) {
+        self.values[index] = values[i];
+      }
+    }
+  },
+  removeValues(index: number, count: number = 1) {
+    if ((index != null) && (index < self.values.length) && (count > 0)) {
+      self.values.splice(index, count);
+    }
+  }
+}));
+export type IAttribute = Instance<typeof Attribute>;
+
+// Need to redefine to make id optional
+export interface IAttributeCreation {
+  id?: string;
+  clientKey?: string;
+  sourceID?: string;
+  name: string;
+  hidden?: boolean;
+  units?: string;
+  formula?: string;
+  values?: IValueType[];
+}
+export type IAttributeSnapshot = SnapshotOut<typeof Attribute>;

--- a/src/models/data/data-set.test.ts
+++ b/src/models/data/data-set.test.ts
@@ -1,0 +1,595 @@
+// import { applyAction, clone, destroy, getEnv, getSnapshot, onAction } from 'mobx-state-tree';
+import { applyAction, clone, destroy, getSnapshot, onAction } from "mobx-state-tree";
+import { addAttributeToDataSet, addCanonicalCasesToDataSet, addCasesToDataSet,
+          CaseID, ICaseID, ICase, ICaseCreation, DataSet, IDataSet } from "./data-set";
+import * as uuid from "uuid/v4";
+
+// tslint:disable:one-variable-per-declaration
+
+test("CaseID functionality", () => {
+  const caseID = CaseID.create({ __id__: "0" });
+  expect(caseID.__id__).toBeDefined();
+
+  const copy = clone(caseID);
+  expect(copy.__id__).toBe(caseID.__id__);
+
+  const caseID2 = CaseID.create({} as any);
+  expect(caseID2.__id__).toBeDefined();
+});
+
+test("DataSet basic functionality", () => {
+  const dataset = DataSet.create({ name: "data" } as any);
+  expect(dataset.id).toBeDefined();
+
+  expect(dataset.isInTransaction).toBe(false);
+  dataset.beginTransaction();
+  expect(dataset.isInTransaction).toBe(true);
+  dataset.endTransaction();
+  expect(dataset.isInTransaction).toBe(false);
+
+  // add numeric attribute
+  addAttributeToDataSet(dataset, { name: "num" });
+  const numAttr = dataset.attrFromName("num");
+  const numAttrID = dataset.attributes[0].id;
+  expect(dataset.attributes.length).toBe(1);
+  expect(numAttr && numAttr.id).toBe(numAttrID);
+  expect(dataset.attributes[0].length).toBe(0);
+
+  // add string attribute before numeric attribute
+  addAttributeToDataSet(dataset, { name: "str" }, numAttrID);
+  let strAttr = dataset.attrFromName("str");
+  const strAttrID = dataset.attributes[0].id;
+  expect(dataset.attributes.length).toBe(2);
+  expect(strAttr && strAttr.id).toBe(strAttrID);
+  expect(dataset.attributes[0].length).toBe(0);
+  expect(dataset.attributes[0].name).toBe("str");
+  expect(dataset.attributes[1].name).toBe("num");
+
+  // rename attribute
+  dataset.setAttributeName(strAttrID, "str2");
+  expect(dataset.attributes[0].name).toBe("str2");
+  dataset.setAttributeName(strAttrID, "str");
+  expect(dataset.attributes[0].name).toBe("str");
+  dataset.setAttributeName("foo", "bar");
+
+  // add/remove attribute
+  addAttributeToDataSet(dataset, { id: uuid(), name: "redShirt" }, numAttrID);
+  const redShirtID = dataset.attributes[1].id;
+  expect(dataset.attributes.length).toBe(3);
+  const redShirt = dataset.attrFromID(redShirtID);
+  expect(redShirt.name).toBe("redShirt");
+  dataset.removeAttribute(redShirtID);
+  expect(dataset.attributes.length).toBe(2);
+  expect(dataset.attrFromID(redShirtID)).toBeUndefined();
+  expect(dataset.attrFromName("redShirt")).toBeUndefined();
+  // removing a non-existent attribute is a no-op
+  dataset.removeAttribute("");
+  expect(dataset.attributes.length).toBe(2);
+
+  // move first attribute to the end
+  dataset.moveAttribute(strAttrID as string);
+  expect(dataset.attributes[0].name).toBe("num");
+  expect(dataset.attributes[1].name).toBe("str");
+  // move second attribute before the first
+  dataset.moveAttribute(strAttrID, numAttrID);
+  expect(dataset.attributes[0].name).toBe("str");
+  expect(dataset.attributes[1].name).toBe("num");
+  strAttr = dataset.attrFromName("str");
+  expect(strAttr && strAttr.id).toBe(strAttrID);
+  // moving a non-existent attribute is a no-op
+  dataset.moveAttribute("");
+  expect(dataset.attributes[0].name).toBe("str");
+  expect(dataset.attributes[1].name).toBe("num");
+
+  // validate attribute indices
+  dataset.attributes.forEach((attr, index) => {
+    expect(dataset.attrIndexFromID(attr.id)).toBe(index);
+  });
+
+  expect(dataset.getCase("")).toBeUndefined();
+  dataset.setCaseValues([{ __id__: "" }]);
+
+  // should ignore if id not specified
+  dataset.addCasesWithIDs([{ str: "d", num: 4 } as any]);
+  expect(dataset.cases.length).toBe(0);
+
+  // add new case
+  addCasesToDataSet(dataset, [{ str: "d", num: 4 }]);
+  const caseD4ID = dataset.cases[0].__id__;
+  expect(dataset.getCaseAtIndex(-1)).toBeUndefined();
+  expect(dataset.getCaseAtIndex(0)).toEqual({ __id__: caseD4ID, str: "d", num: 4 });
+  expect(dataset.getCase(caseD4ID)).toEqual({ __id__: caseD4ID, str: "d", num: 4 });
+  expect(dataset.cases.length).toBe(1);
+  expect(caseD4ID).toBeDefined();
+  expect(dataset.attributes[0].value(0)).toBe("d");
+  expect(dataset.attributes[1].value(0)).toBe(4);
+
+  // add new case before first case
+  addCasesToDataSet(dataset, [{ str: "c", num: 3 }], caseD4ID);
+  const caseC3ID = dataset.cases[0].__id__;
+  expect(dataset.cases.length).toBe(2);
+  expect(caseC3ID).toBeDefined();
+  expect(caseC3ID).not.toBe(caseD4ID);
+  expect(dataset.nextCaseID("")).toBeUndefined();
+  expect(dataset.nextCaseID(caseC3ID)).toBe(caseD4ID);
+  expect(dataset.cases[1].__id__).toBe(caseD4ID);
+  expect(dataset.attributes[0].value(0)).toBe("c");
+  expect(dataset.attributes[1].value(0)).toBe(3);
+
+  // add multiple new cases
+  addCasesToDataSet(dataset, [{ str: "a", num: 1 }, { str: "b", num: 2 }], caseC3ID);
+  const caseA1ID = dataset.cases[0].__id__,
+        caseB2ID = dataset.cases[1].__id__;
+  expect(dataset.cases.length).toBe(4);
+  expect(dataset.attributes[0].value(0)).toBe("a");
+  expect(dataset.attributes[1].value(0)).toBe(1);
+  expect(dataset.attributes[0].value(1)).toBe("b");
+  expect(dataset.attributes[1].value(1)).toBe(2);
+  expect(dataset.getValue(caseA1ID, "foo")).toBeUndefined();
+  expect(dataset.getValue("foo", "bar")).toBeUndefined();
+  expect(dataset.getCase(caseA1ID)).toEqual({ __id__: caseA1ID, str: "a", num: 1 });
+  expect(dataset.getCase(caseB2ID)).toEqual({ __id__: caseB2ID, str: "b", num: 2 });
+  expect(dataset.getCanonicalCase(caseA1ID))
+    .toEqual({ __id__: caseA1ID, [strAttrID]: "a", [numAttrID]: 1 });
+  expect(dataset.getCanonicalCase(caseB2ID))
+    .toEqual({ __id__: caseB2ID, [strAttrID]: "b", [numAttrID]: 2 });
+  expect(dataset.getCanonicalCases([caseA1ID, caseB2ID]))
+    .toEqual([{ __id__: caseA1ID, [strAttrID]: "a", [numAttrID]: 1 },
+              { __id__: caseB2ID, [strAttrID]: "b", [numAttrID]: 2 }]);
+  expect(dataset.getCasesAtIndices().length).toBe(4);
+  expect(dataset.getCasesAtIndices(2).length).toBe(2);
+  // add null/undefined values
+  addCasesToDataSet(dataset, [{ str: undefined }]);
+  const nullCaseID = dataset.cases[dataset.cases.length - 1].__id__;
+  expect(dataset.getCase(nullCaseID))
+    .toEqual({ __id__: nullCaseID, str: undefined, num: undefined });
+  expect(dataset.getCanonicalCases([""])).toEqual([]);
+  // validate that caseIDMap is correct
+  dataset.cases.forEach((aCase: ICaseID) => {
+    const caseIndex = dataset.caseIndexFromID(aCase.__id__);
+    expect((caseIndex >= 0) ? dataset.cases[caseIndex].__id__ : "").toBe(aCase.__id__);
+  });
+
+  // setCaseValues
+  dataset.setCaseValues([{ __id__: caseA1ID, str: "A", num: 10 }]);
+  expect(dataset.getCase(caseA1ID)).toEqual({ __id__: caseA1ID, str: "A", num: 10 });
+  dataset.setCaseValues([{ __id__: caseB2ID, str: "B", num: 20 },
+                          { __id__: caseC3ID, str: "C", num: 30 }]);
+  expect(dataset.getCase(caseB2ID)).toEqual({ __id__: caseB2ID, str: "B", num: 20 });
+  expect(dataset.getValue(caseC3ID, strAttrID)).toBe("C");
+  expect(dataset.getValue(caseC3ID, numAttrID)).toBe(30);
+  dataset.setCaseValues([{ __id__: caseA1ID, foo: "bar" }]);
+  expect(dataset.getCase(caseA1ID)).toEqual({ __id__: caseA1ID, str: "A", num: 10 });
+  dataset.setCaseValues([{ __id__: caseA1ID, num: undefined }]);
+  expect(dataset.getCase(caseA1ID)).toEqual({ __id__: caseA1ID, str: "A", num: undefined });
+
+  const cases = dataset.getCases([caseB2ID, caseC3ID, ""]);
+  expect(cases.length).toBe(2);
+  expect(cases[0]).toEqual({ __id__: caseB2ID, str: "B", num: 20 });
+  expect(cases[1]).toEqual({ __id__: caseC3ID, str: "C", num: 30 });
+
+  const bIndex = dataset.caseIndexFromID(caseB2ID);
+  const cases2 = dataset.getCasesAtIndices(bIndex, 2);
+  expect(cases.length).toBe(2);
+  expect(cases[0]).toEqual({ __id__: caseB2ID, str: "B", num: 20 });
+  expect(cases[1]).toEqual({ __id__: caseC3ID, str: "C", num: 30 });
+
+  const copy = clone(dataset);
+  expect(copy.id).toBe(dataset.id);
+  expect(copy.name).toBe(dataset.name);
+  copy.setName("copy");
+  expect(copy.name).toBe("copy");
+  expect(copy.attributes.length).toBe(dataset.attributes.length);
+  expect(copy.cases.length).toBe(dataset.cases.length);
+
+  dataset.removeCases([nullCaseID]);
+  expect(dataset.cases.length).toBe(4);
+  dataset.removeCases([caseA1ID, caseB2ID]);
+  expect(dataset.cases.length).toBe(2);
+  // validate that caseIDMap is correct
+  dataset.cases.forEach((aCase: ICaseID) => {
+    const caseIndex = dataset.caseIndexFromID(aCase.__id__);
+    expect((caseIndex >= 0) ? dataset.cases[caseIndex].__id__ : "").toBe(aCase.__id__);
+  });
+  dataset.removeCases([""]);
+  expect(dataset.cases.length).toBe(2);
+  destroy(dataset);
+});
+
+test("Canonical case functionality", () => {
+  const dataset = DataSet.create({
+                    name: "data",
+                    attributes: [
+                      { name: "str" } as any,
+                      { name: "num" } as any
+                    ]
+                  } as any),
+        strAttrID = dataset.attributes[0].id,
+        numAttrID = dataset.attributes[1].id;
+
+  // validate attribute indices
+  dataset.attributes.forEach((attr, index) => {
+    expect(dataset.attrIndexFromID(attr.id)).toBe(index);
+  });
+  expect(dataset.attrIndexFromID("foo")).toBeUndefined();
+
+  // add new case
+  addCanonicalCasesToDataSet(dataset, [{ [strAttrID]: "d", [numAttrID]: 4 }]);
+  const caseD4ID = dataset.cases[0].__id__;
+  expect(dataset.getCaseAtIndex(-1)).toBeUndefined();
+  expect(dataset.getCanonicalCaseAtIndex(0)).toEqual({ __id__: caseD4ID, [strAttrID]: "d", [numAttrID]: 4 });
+  expect(dataset.getCaseAtIndex(0)).toEqual({ __id__: caseD4ID, str: "d", num: 4 });
+  expect(dataset.getCase(caseD4ID)).toEqual({ __id__: caseD4ID, str: "d", num: 4 });
+  expect(dataset.cases.length).toBe(1);
+  expect(caseD4ID).toBeDefined();
+  expect(dataset.attributes[0].value(0)).toBe("d");
+  expect(dataset.attributes[1].value(0)).toBe(4);
+
+  // add new case before first case
+  addCanonicalCasesToDataSet(dataset, [{ [strAttrID]: "c", [numAttrID]: 3 }], caseD4ID);
+  const caseC3ID = dataset.cases[0].__id__;
+  expect(dataset.cases.length).toBe(2);
+  expect(caseC3ID).toBeDefined();
+  expect(caseC3ID).not.toBe(caseD4ID);
+  expect(dataset.nextCaseID("")).toBeUndefined();
+  expect(dataset.nextCaseID(caseC3ID)).toBe(caseD4ID);
+  expect(dataset.cases[1].__id__).toBe(caseD4ID);
+  expect(dataset.attributes[0].value(0)).toBe("c");
+  expect(dataset.attributes[1].value(0)).toBe(3);
+
+  // add multiple new cases
+  addCanonicalCasesToDataSet(dataset, [ { [strAttrID]: "a", [numAttrID]: 1 },
+                                        { [strAttrID]: "b", [numAttrID]: 2 }], caseC3ID);
+  const caseA1ID = dataset.cases[0].__id__,
+        caseB2ID = dataset.cases[1].__id__;
+  expect(dataset.cases.length).toBe(4);
+  expect(dataset.attributes[0].value(0)).toBe("a");
+  expect(dataset.attributes[1].value(0)).toBe(1);
+  expect(dataset.attributes[0].value(1)).toBe("b");
+  expect(dataset.attributes[1].value(1)).toBe(2);
+  expect(dataset.getCase(caseA1ID)).toEqual({ __id__: caseA1ID, str: "a", num: 1 });
+  expect(dataset.getCase(caseB2ID)).toEqual({ __id__: caseB2ID, str: "b", num: 2 });
+  expect(dataset.getCanonicalCase(caseA1ID))
+    .toEqual({ __id__: caseA1ID, [strAttrID]: "a", [numAttrID]: 1 });
+  expect(dataset.getCanonicalCase(caseB2ID))
+    .toEqual({ __id__: caseB2ID, [strAttrID]: "b", [numAttrID]: 2 });
+  expect(dataset.getCanonicalCases([caseA1ID, caseB2ID]))
+    .toEqual([{ __id__: caseA1ID, [strAttrID]: "a", [numAttrID]: 1 },
+              { __id__: caseB2ID, [strAttrID]: "b", [numAttrID]: 2 }]);
+  expect(dataset.getCanonicalCasesAtIndices(0, 2))
+    .toEqual([{ __id__: caseA1ID, [strAttrID]: "a", [numAttrID]: 1 },
+              { __id__: caseB2ID, [strAttrID]: "b", [numAttrID]: 2 }]);
+  expect(dataset.getCanonicalCaseAtIndex(-1)).toBeUndefined();
+  expect(dataset.getCanonicalCasesAtIndices().length).toBe(4);
+  expect(dataset.getCanonicalCasesAtIndices(2).length).toBe(2);
+  // add null/undefined values
+  addCanonicalCasesToDataSet(dataset, [{ [strAttrID]: undefined }]);
+  // add invalid cases
+  const nullCaseID = dataset.cases[dataset.cases.length - 1].__id__;
+  expect(dataset.getCase(nullCaseID))
+    .toEqual({ __id__: nullCaseID, str: undefined, num: undefined });
+  expect(dataset.getCanonicalCases([""])).toEqual([]);
+  // validate that caseIDMap is correct
+  dataset.cases.forEach((aCase: ICaseID) => {
+    const caseIndex = dataset.caseIndexFromID(aCase.__id__);
+    expect((caseIndex >= 0) ? dataset.cases[caseIndex].__id__ : "").toBe(aCase.__id__);
+  });
+  addCanonicalCasesToDataSet(dataset, [{ __id__: "12345", [strAttrID]: "e", [numAttrID]: 5 }]);
+  dataset.removeCases(["12345"]);
+
+  // setCanonicalCaseValues
+  dataset.setCanonicalCaseValues([{ __id__: caseA1ID, [strAttrID]: "A", [numAttrID]: 10 }]);
+  expect(dataset.getCase(caseA1ID)).toEqual({ __id__: caseA1ID, str: "A", num: 10 });
+  dataset.setCanonicalCaseValues([{ __id__: caseB2ID, [strAttrID]: "B", [numAttrID]: 20 },
+                                  { __id__: caseC3ID, [strAttrID]: "C", [numAttrID]: 30 }]);
+  expect(dataset.getCase(caseB2ID)).toEqual({ __id__: caseB2ID, str: "B", num: 20 });
+  expect(dataset.getValue(caseC3ID, strAttrID)).toBe("C");
+  expect(dataset.getValue(caseC3ID, numAttrID)).toBe(30);
+  dataset.setCanonicalCaseValues([{ __id__: caseA1ID, foo: "bar" }]);
+  expect(dataset.getCase(caseA1ID)).toEqual({ __id__: caseA1ID, str: "A", num: 10 });
+  dataset.setCanonicalCaseValues([{ __id__: caseA1ID, [numAttrID]: undefined }]);
+  expect(dataset.getCase(caseA1ID)).toEqual({ __id__: caseA1ID, str: "A", num: undefined });
+
+  const cases = dataset.getCases([caseB2ID, caseC3ID, ""]);
+  expect(cases.length).toBe(2);
+  expect(cases[0]).toEqual({ __id__: caseB2ID, str: "B", num: 20 });
+  expect(cases[1]).toEqual({ __id__: caseC3ID, str: "C", num: 30 });
+
+  dataset.removeCases([nullCaseID]);
+  expect(dataset.cases.length).toBe(4);
+  dataset.removeCases([caseA1ID, caseB2ID]);
+  expect(dataset.cases.length).toBe(2);
+  // validate that caseIDMap is correct
+  dataset.cases.forEach((aCase: ICaseID) => {
+    const caseIndex = dataset.caseIndexFromID(aCase.__id__);
+    expect((caseIndex >= 0) ? dataset.cases[caseIndex].__id__ : "").toBe(aCase.__id__);
+  });
+  dataset.removeCases([""]);
+  expect(dataset.cases.length).toBe(2);
+  destroy(dataset);
+});
+
+test("Derived DataSet functionality", () => {
+  const dataset = DataSet.create({ name: "data" } as any);
+
+  // add attributes and cases
+  addAttributeToDataSet(dataset, { name: "str" });
+  addAttributeToDataSet(dataset, { name: "num" });
+  const strAttrID = dataset.attributes[0].id;
+  addCasesToDataSet(dataset, [{ str: "a", num: 1 },
+                              { str: "b", num: 2 },
+                              { str: "c", num: 3 }]);
+
+  const derived = dataset.derive("derived");
+  expect(derived.name).toBe("derived");
+  expect(derived.attributes.length).toBe(2);
+  expect(derived.cases.length).toBe(3);
+  const derivedCase0ID = derived.cases[0].__id__,
+        derivedCase1ID = derived.cases[1].__id__,
+        derivedCases = derived.getCases([derivedCase0ID, derivedCase1ID]);
+  expect(derivedCases[0]).toEqual({ __id__: derivedCase0ID, str: "a", num: 1 });
+  expect(derivedCases[1]).toEqual({ __id__: derivedCase1ID, str: "b", num: 2 });
+
+  const derived2 = dataset.derive("derived2", { attributeIDs: [strAttrID, ""] });
+  expect(derived2.name).toBe("derived2");
+  expect(derived2.attributes.length).toBe(1);
+  expect(derived.cases.length).toBe(3);
+  const derived2Case0ID = derived2.cases[0].__id__,
+        derived2Case1ID = derived2.cases[1].__id__,
+        derived2Cases = derived2.getCases([derived2Case0ID, derived2Case1ID]);
+  expect(derived2Cases[0]).toEqual({ __id__: derived2Case0ID, str: "a" });
+  expect(derived2Cases[1]).toEqual({ __id__: derived2Case1ID, str: "b" });
+
+  const filter = (aCase: ICase) => {
+          const num = aCase && aCase.num;
+          return (num != null) && (num >= 3) ? aCase : undefined;
+        },
+        derived3 = dataset.derive("derived3", { filter });
+  expect(derived3.name).toBe("derived3");
+  expect(derived3.attributes.length).toBe(2);
+  expect(derived3.cases.length).toBe(1);
+  const derived3Case0ID = derived3.cases[0].__id__,
+        derived3Cases = derived3.getCases([derived3Case0ID]);
+  expect(derived3Cases[0]).toEqual({ __id__: derived3Case0ID, str: "c", num: 3 });
+
+  const derived4 = dataset.derive();
+  expect(derived4.name).toBe("data");
+});
+
+function createDataSet(name: string) {
+  const ds = DataSet.create({ name } as any);
+  // add attributes and cases
+  addAttributeToDataSet(ds, { name: "str" });
+  addAttributeToDataSet(ds, { name: "num" });
+  addCasesToDataSet(ds, [ { str: "a", num: 1 },
+                          { str: "b", num: 2 },
+                          { str: "c", num: 3 },
+                          { str: "d", num: 4 },
+                          { str: "e", num: 5 }]);
+  return ds;
+}
+
+function createOdds(source: IDataSet) {
+  const numAttr = source.attrFromName("num"),
+        numAttrID = numAttr && numAttr.id || "";
+  return source.derive("odds", {
+                        attributeIDs: [numAttrID],
+                        filter: (aCase: ICase) => {
+                          const num: number = Number(aCase && aCase.num) || 0;
+                          return num % 2 ? aCase : undefined;
+                        },
+                        synchronize: true
+                      });
+}
+
+function createEvens(source: IDataSet) {
+  return source.derive("evens", {
+                        filter: (aCase: ICase) => {
+                          const num: number = Number(aCase && aCase.num) || 0;
+                          return num % 2 === 0 ? aCase : undefined;
+                        },
+                        synchronize: true
+                      });
+}
+
+test("Derived DataSet synchronization (subset attributes)", () => {
+  const source = createDataSet("source"),
+        odds = createOdds(source);
+
+  expect(odds.attributes.length).toBe(1);
+
+  const bCaseID = source.cases[1].__id__,
+        cCaseID = source.cases[2].__id__,
+        dCaseID = source.cases[3].__id__,
+        eCaseID = source.cases[4].__id__;
+  let fooAttrID: string,
+      abCaseID: string,
+      cdCaseID: string,
+      gCaseID: string;
+  addAttributeToDataSet(source, { name: "foo" });
+  fooAttrID = source.attributes[2].id;
+
+  return odds.onSynchronized()
+    .then(() => {
+      expect(odds.isSynchronizing).toBe(false);
+      expect(odds.attributes.length).toBe(1);
+
+      source.removeAttribute(fooAttrID);
+      return odds.onSynchronized();
+    })
+    .then(() => {
+      expect(odds.attributes.length).toBe(1);
+
+      addCasesToDataSet(source, [{ str: "f", num: 6 }, { str: "g", num: 7 }]);
+      gCaseID = source.cases[6].__id__;
+      return odds.onSynchronized();
+    })
+    .then(() => {
+      expect(odds.cases.length).toBe(4);
+      expect(odds.getCase(gCaseID)).toEqual({ __id__: gCaseID, num: 7 });
+
+      addCasesToDataSet(source, [{ str: "ab", num: -3 }, { str: "cd", num: -1 }], [bCaseID, dCaseID]);
+      abCaseID = source.cases[1].__id__;
+      expect(source.getCase(abCaseID)).toEqual({ __id__: abCaseID, str: "ab", num: -3 });
+      cdCaseID = source.cases[4].__id__;
+      expect(source.getCase(cdCaseID)).toEqual({ __id__: cdCaseID, str: "cd", num: -1 });
+      return odds.onSynchronized();
+    })
+    .then(() => {
+      expect(odds.cases.length).toBe(6);
+      expect(odds.getCase(abCaseID)).toEqual({ __id__: abCaseID, num: -3 });
+      expect(odds.nextCaseID(abCaseID)).toBe(cCaseID);
+      expect(odds.getCase(cdCaseID)).toEqual({ __id__: cdCaseID, num: -1 });
+      expect(odds.nextCaseID(cdCaseID)).toBe(eCaseID);
+      // setCaseValues: changing odd value to even should result in removing case
+      source.setCaseValues([{ __id__: cCaseID, num: 2 }]);
+      return odds.onSynchronized();
+    })
+    .then(() => {
+      expect(odds.cases.length).toBe(5);
+      source.setCaseValues([{ __id__: cCaseID, num: 3 }]);
+      return odds.onSynchronized();
+    })
+    .then(() => {
+      expect(odds.cases.length).toBe(6);
+      expect(odds.nextCaseID(cCaseID)).toBe(cdCaseID);
+      source.setCaseValues([{ __id__: bCaseID, num: 3 }, { __id__: dCaseID, num: 5 }]);
+      return odds.onSynchronized();
+    })
+    .then(() => {
+      expect(odds.cases.length).toBe(8);
+      expect(odds.nextCaseID(bCaseID)).toBe(cCaseID);
+      expect(odds.nextCaseID(dCaseID)).toBe(eCaseID);
+      return odds.onSynchronized();
+    })
+    .then(() => {
+      // test destruction
+      destroy(odds);
+    });
+});
+
+test("Derived DataSet synchronization (all attributes)", () => {
+  const source = createDataSet("source"),
+        evens = createEvens(source),
+        bCaseID = evens.cases[1].__id__;
+
+  expect(evens.attributes.length).toBe(2);
+
+  let fooAttrID: string, a1CaseID: string, a2CaseID;
+  addAttributeToDataSet(source, { name: "foo" });
+  fooAttrID = source.attributes[2].id;
+
+  return evens.onSynchronized()
+    .then(() => {
+      expect(evens.isSynchronizing).toBe(false);
+      expect(evens.attributes.length).toBe(3);
+
+      source.removeAttribute(fooAttrID);
+      return evens.onSynchronized();
+    })
+    .then(() => {
+      expect(evens.attributes.length).toBe(2);
+
+      addCasesToDataSet(source, [{ str: "a1", num: -4 }, { str: "a2", num: -2 }], bCaseID);
+      return evens.onSynchronized();
+    })
+    .then(() => {
+      expect(evens.cases.length).toBe(4);
+      a1CaseID = evens.cases[1].__id__;
+      a2CaseID = evens.cases[2].__id__;
+      expect(evens.getCase(a1CaseID)).toEqual({ __id__: a1CaseID, str: "a1", num: -4 });
+      expect(evens.nextCaseID(a1CaseID)).toBe(a2CaseID);
+      expect(evens.getCase(a2CaseID)).toEqual({ __id__: a2CaseID, str: "a2", num: -2 });
+      expect(evens.nextCaseID(a2CaseID)).toBe(bCaseID);
+      return evens.onSynchronized();
+    })
+    .then(() => {
+      // test invalid setCaseValues handling
+      source.setCaseValues([{} as ICase]);
+      // test invalid setCanonicalCaseValues handling
+      source.setCanonicalCaseValues([{} as ICase]);
+      // test multiple setCaseValues
+      source.setCaseValues([{ __id__: a1CaseID, num: -3 }]);
+      source.setCaseValues([{ __id__: a1CaseID, num: -2 }]);
+      return evens.onSynchronized();
+    })
+    .then(() => {
+      // test destruction
+      destroy(evens);
+    });
+});
+
+test("Derived DataSet synchronization (no filter)", () => {
+  const source = createDataSet("source"),
+        derived = source.derive("derived", { synchronize: true });
+
+  addCasesToDataSet(source, [{ str: "g", num: 7 }]);
+  expect(source.cases.length).toBe(6);
+  let fCaseID: string;
+  const gCaseID = source.cases[5].__id__;
+  derived.onSynchronized()
+    .then(() => {
+      expect(derived.cases.length).toBe(6);
+      expect(derived.getCase(gCaseID)).toEqual({ __id__: gCaseID, str: "g", num: 7 });
+      addCasesToDataSet(source, [{ str: "f", num: 7 }], gCaseID);
+      fCaseID = source.cases[5].__id__;
+      return derived.onSynchronized();
+    })
+    .then(() => {
+      expect(derived.cases.length).toBe(7);
+      expect(derived.getCaseAtIndex(5)).toEqual({ __id__: fCaseID, str: "f", num: 7 });
+      source.setCaseValues([{ __id__: fCaseID, num: 6 }]);
+      return derived.onSynchronized();
+    })
+    .then(() => {
+      expect(derived.getCase(fCaseID)).toEqual({ __id__: fCaseID, str: "f", num: 6 });
+      destroy(derived);
+    });
+});
+
+test("DataSet client synchronization", (done) => {
+  const src = DataSet.create({ name: "source" } as any),
+        dst = clone(src),
+        dst2 = clone(dst);
+  let srcActionCount = 0,
+      dstActionCount = 0;
+  // should initially be equivalant
+  expect(getSnapshot(src)).toEqual(getSnapshot(dst));
+  expect(getSnapshot(dst)).toEqual(getSnapshot(dst2));
+  // keep dst in sync with src
+  onAction(src, (action) => {
+    ++srcActionCount;
+    // console.log(`onSrcAction [pre]: count: ${srcActionCount}, action: ${JSON.stringify(action)}`);
+    // have to use setTimeout otherwise subsequent actions don't trigger
+    // perhaps the code that suppresses actions within actions
+    setTimeout(() => {
+      --srcActionCount;
+      // console.log(`onSrcAction [run]: count: ${srcActionCount}, action: ${JSON.stringify(action)}`);
+      applyAction(dst, action);
+      if ((srcActionCount <= 0) && (dstActionCount <= 0)) {
+        expect(getSnapshot(dst)).toEqual(getSnapshot(src));
+        done();
+      }
+    });
+  });
+  // keep dst2 in sync with dst
+  onAction(dst, (action) => {
+    ++dstActionCount;
+    // console.log(`onDstAction [pre]: count: ${dstActionCount}, action: ${JSON.stringify(action)}`);
+    setTimeout(() => {
+      --dstActionCount;
+      // console.log(`onDstAction [run]: count: ${dstActionCount}, action: ${JSON.stringify(action)}`);
+      applyAction(dst2, action);
+      if ((srcActionCount <= 0) && (dstActionCount <= 0)) {
+        expect(getSnapshot(dst2)).toEqual(getSnapshot(dst));
+        done();
+      }
+    });
+  });
+
+  addAttributeToDataSet(src, { name: "str" });
+  addAttributeToDataSet(src, { name: "num" });
+  addCasesToDataSet(src, [{ str: "a", num: 1 }]);
+  addCasesToDataSet(src, [{ str: "b", num: 2 }, { str: "c", num: 3 }]);
+  src.removeAttribute(src.attributes[0].id);
+});

--- a/src/models/data/data-set.ts
+++ b/src/models/data/data-set.ts
@@ -1,0 +1,616 @@
+import { addMiddleware, applyAction, getEnv, Instance,
+          onAction, types, getSnapshot, SnapshotOut } from "mobx-state-tree";
+import { ISerializedActionCall } from "mobx-state-tree";
+import { Attribute, IAttribute, IAttributeCreation, IValueType } from "./attribute";
+// see https://medium.com/@martin_hotell/tree-shake-lodash-with-webpack-jest-and-typescript-2734fa13b5cd
+// for more efficient ways of importing lodash functions
+import { cloneDeep, findIndex, padStart } from "lodash";
+import * as uuid from "uuid/v4";
+
+// tslint:disable:one-variable-per-declaration
+
+let localIDCounter = 0;
+
+// TODO: handle case ordering without requiring sortable IDs.
+// For now, we combine an incrementing counter with a UUID.
+export const localId = () => {
+  const uuidRight = uuid().substr(8),
+        count = ++localIDCounter,
+        uuidLeft = padStart(String(count), 8, "0");
+  return uuidLeft + uuidRight;
+};
+
+export const CaseID = types.model("CaseID", {
+  __id__: types.identifier
+  // __index__: types.number
+}).preProcessSnapshot((snapshot) => {
+  const { __id__, ...others } = snapshot;
+  return { __id__: __id__ || localId(), ...others };
+});
+export type ICaseID = typeof CaseID.Type;
+
+export interface ICase {
+  __id__: string;
+  [key: string]: IValueType;
+}
+export interface ICaseCreation {
+  __id__?: string;
+  [key: string]: IValueType | null;
+}
+
+export type ICaseFilter = (aCase: ICase) => ICase | undefined;
+
+export interface IDerivationSpec {
+  attributeIDs?: string[];
+  filter?: ICaseFilter;
+  synchronize?: boolean;
+}
+
+interface IEnvContext {
+  srcDataSet: IDataSet;
+  derivationSpec: IDerivationSpec;
+}
+
+export const DataSet = types.model("DataSet", {
+  id: types.identifier,
+  sourceID: types.maybe(types.string),
+  name: types.string,
+  attributes: types.array(Attribute),
+  cases: types.array(CaseID),
+}).preProcessSnapshot((snapshot) => {
+  const { id, ...others } = snapshot;
+  return { id: id || localId(), ...others };
+}).volatile(self => ({
+  transactionCount: 0
+})).extend(self => {
+  const attrIDMap: { [index: string]: IAttribute } = {},
+        // map from attribute names to attribute IDs
+        attrNameMap: { [index: string]: string } = {},
+        // map from case IDs to indices
+        caseIDMap: { [index: string]: number } = {},
+        disposers: { [index: string]: () => void } = {};
+  let inFlightActions = 0;
+
+  function derive(name?: string) {
+    return { id: localId(), sourceID: self.id, name: name || self.name, attributes: [], cases: [] };
+  }
+
+  function attrIndexFromID(id: string) {
+    const index = findIndex(self.attributes, (attr) => attr.id === id );
+    return index >= 0 ? index : undefined;
+  }
+
+  function mapBeforeID(srcDataSet?: IDataSet, beforeID?: string) {
+    let id: string | undefined = beforeID;
+    while (id && (caseIDMap[id] == null)) {
+      id = srcDataSet && srcDataSet.nextCaseID(id);
+    }
+    return id && caseIDMap[id] ? id : undefined;
+  }
+
+  function mapBeforeIDArg(beforeID?: string | string[]) {
+    const context: IEnvContext = getEnv(self),
+          { srcDataSet } = context;
+    if (Array.isArray(beforeID)) {
+      return beforeID.map((id) => mapBeforeID(srcDataSet, id));
+    }
+    else {
+      return mapBeforeID(srcDataSet, beforeID);
+    }
+  }
+
+  function getCase(caseID: string): ICase | undefined {
+    const index = caseIDMap[caseID];
+    if (index == null) { return undefined; }
+
+    const aCase: ICase = { __id__: caseID };
+    self.attributes.forEach((attr) => {
+      aCase[attr.name] = attr.value(index);
+    });
+    return aCase;
+  }
+
+  function getCaseAtIndex(index: number) {
+    const aCase = self.cases[index],
+          id = aCase && aCase.__id__;
+    return id ? getCase(id) : undefined;
+  }
+
+  // canonical cases are keyed by attribute ID rather than attribute name
+  function getCanonicalCase(caseID: string): ICase | undefined {
+    const index = caseIDMap[caseID];
+    if (index == null) { return undefined; }
+
+    const aCase: ICase = { __id__: caseID };
+    self.attributes.forEach((attr) => {
+      aCase[attr.id] = attr.value(index);
+    });
+    return aCase;
+  }
+
+  function getCanonicalCaseAtIndex(index: number) {
+    const aCase = self.cases[index],
+          id = aCase && aCase.__id__;
+    return id ? getCanonicalCase(id) : undefined;
+  }
+
+  function beforeIndexForInsert(index: number, beforeID?: string | string[]) {
+    if (!beforeID) { return self.cases.length; }
+    return Array.isArray(beforeID)
+            ? caseIDMap[beforeID[index]]
+            : caseIDMap[beforeID];
+  }
+
+  function insertCaseIDAtIndex(id: string, beforeIndex: number) {
+    // const newCase = { __id__: id, __index__: beforeIndex };
+    const newCase = { __id__: id };
+    if ((beforeIndex != null) && (beforeIndex < self.cases.length)) {
+      self.cases.splice(beforeIndex, 0, newCase );
+      // increment indices of all subsequent cases
+      for (let i = beforeIndex + 1; i < self.cases.length; ++i) {
+        const aCase = self.cases[i];
+        ++caseIDMap[aCase.__id__];
+        // aCase.__index__ = i;
+      }
+    }
+    else {
+      self.cases.push(newCase);
+      beforeIndex = self.cases.length - 1;
+    }
+    caseIDMap[self.cases[beforeIndex].__id__] = beforeIndex;
+  }
+
+  function setCaseValues(caseValues: ICase) {
+    const index = caseIDMap[caseValues.__id__];
+    if (index == null) { return; }
+
+    for (const key in caseValues) {
+      if (key !== "__id__") {
+        const attributeID = attrNameMap[key],
+              attribute = attrIDMap[attributeID];
+        if (attribute) {
+          const value = caseValues[key];
+          attribute.setValue(index, value != null ? value : undefined);
+        }
+      }
+    }
+  }
+
+  function setCanonicalCaseValues(caseValues: ICase) {
+    const index = caseIDMap[caseValues.__id__];
+    if (index == null) { return; }
+
+    for (const key in caseValues) {
+      if (key !== "__id__") {
+        const attributeID = key,
+              attribute = attrIDMap[attributeID];
+        if (attribute) {
+          const value = caseValues[key];
+          attribute.setValue(index, value != null ? value : undefined);
+        }
+      }
+    }
+  }
+
+  function delayApplyActions(actions: ISerializedActionCall[]) {
+    ++inFlightActions;
+    setTimeout(() => {
+      if (--inFlightActions <= 0) {
+        applyAction(self, actions);
+      }
+    });
+  }
+
+  return {
+    views: {
+      attrFromID(id: string) {
+        return attrIDMap[id];
+      },
+      attrFromName(name: string) {
+        const id = attrNameMap[name];
+        return id ? attrIDMap[id] : undefined;
+      },
+      attrIndexFromID(id: string) {
+        return attrIndexFromID(id);
+      },
+      caseIndexFromID(id: string) {
+        return caseIDMap[id];
+      },
+      nextCaseID(id: string) {
+        const index = caseIDMap[id],
+              nextCase = (index != null) && (index < self.cases.length - 1)
+                          ? self.cases[index + 1] : undefined;
+        return nextCase ? nextCase.__id__ : undefined;
+      },
+      getValue(caseID: string, attributeID: string) {
+        const attr = attrIDMap[attributeID],
+              index = caseIDMap[caseID];
+        return attr && (index != null) ? attr.value(index) : undefined;
+      },
+      getCase(caseID: string): ICase | undefined {
+        return getCase(caseID);
+      },
+      getCases(caseIDs: string[]): ICase[] {
+        const cases: ICase[] = [];
+        caseIDs.forEach((caseID) => {
+          const aCase = getCase(caseID);
+          if (aCase) {
+            cases.push(aCase);
+          }
+        });
+        return cases;
+      },
+      getCaseAtIndex(index: number) {
+        return getCaseAtIndex(index);
+      },
+      getCasesAtIndices(start: number = 0, count?: number) {
+        const endIndex = count != null
+                          ? Math.min(start + count, self.cases.length)
+                          : self.cases.length,
+              cases = [];
+        for (let i = start; i < endIndex; ++i) {
+          cases.push(getCaseAtIndex(i));
+        }
+        return cases;
+      },
+      getCanonicalCase(caseID: string): ICase | undefined {
+        return getCanonicalCase(caseID);
+      },
+      getCanonicalCases(caseIDs: string[]): ICase[] {
+        const cases: ICase[] = [];
+        caseIDs.forEach((caseID) => {
+          const aCase = getCanonicalCase(caseID);
+          if (aCase) {
+            cases.push(aCase);
+          }
+        });
+        return cases;
+      },
+      getCanonicalCaseAtIndex(index: number) {
+        return getCanonicalCaseAtIndex(index);
+      },
+      getCanonicalCasesAtIndices(start: number = 0, count?: number) {
+        const endIndex = count != null
+                          ? Math.min(start + count, self.cases.length)
+                          : self.cases.length,
+              cases = [];
+        for (let i = start; i < endIndex; ++i) {
+          cases.push(getCanonicalCaseAtIndex(i));
+        }
+        return cases;
+      },
+      get isInTransaction() {
+        return self.transactionCount > 0;
+      },
+      get isSynchronizing() {
+        return inFlightActions > 0;
+      },
+      onSynchronized() {
+        if (inFlightActions <= 0) {
+          return Promise.resolve(self);
+        }
+        return new Promise((resolve, reject) => {
+          function waitForSync() {
+            if (inFlightActions <= 0) {
+              resolve(self);
+            }
+            else {
+              setTimeout(waitForSync);
+            }
+          }
+          waitForSync();
+        });
+      },
+      derive(name?: string, derivationSpec?: IDerivationSpec) {
+        const context = { srcDataSet: self, derivationSpec };
+        const derived = DataSet.create(derive(name), context);
+        const attrIDs = derivationSpec && derivationSpec.attributeIDs ||
+                          self.attributes.map(attr => attr.id),
+              filter = derivationSpec && derivationSpec.filter;
+        attrIDs.forEach((attrID) => {
+          const attribute = attrIDMap[attrID];
+          if (attribute) {
+            addAttributeToDataSet(derived, attribute.derive());
+          }
+        });
+        self.cases.forEach((aCaseID) => {
+          const inCase = getCase(aCaseID.__id__),
+                outCase = filter && inCase ? filter(inCase) : inCase;
+          if (outCase) {
+            addCasesToDataSet(derived, [outCase]);
+          }
+        });
+        return derived;
+      }
+    },
+    actions: {
+      afterCreate() {
+        const context: IEnvContext = getEnv(self),
+              { srcDataSet, derivationSpec = {} } = context,
+              { attributeIDs, filter, synchronize } = derivationSpec;
+
+        // build attrIDMap
+        self.attributes.forEach(attr => {
+          attrIDMap[attr.id] = attr;
+        });
+
+        // build caseIDMap
+        self.cases.forEach((aCase, index) => {
+          caseIDMap[aCase.__id__] = index;
+        });
+
+        // set up onAction handler to perform synchronization with source
+        if (srcDataSet && synchronize) {
+          disposers.srcDataSetOnAction = onAction(srcDataSet, (action) => {
+            const actions = [];
+            let newAction;
+            switch (action.name) {
+              case "addAttributeWithID":
+                // ignore new attributes if we have a subset of attributes
+                if (!attributeIDs) {
+                  actions.push(action);
+                }
+                break;
+              case "addCasesWithIDs": {
+                const addCasesArgs = action.args && action.args.slice(),
+                      srcCasesToAdd = addCasesArgs && addCasesArgs[0],
+                      // only add new cases if they pass the filter
+                      dstCasesToAdd = srcCasesToAdd && filter
+                                        ? srcCasesToAdd.filter(filter)
+                                        : srcCasesToAdd,
+                      srcBeforeID = addCasesArgs && addCasesArgs[1],
+                      // map beforeIDs from src to dst
+                      dstBeforeID = srcBeforeID && mapBeforeIDArg(srcBeforeID),
+                      // adjust arguments for the updated action
+                      dstCasesArgs = [dstCasesToAdd, dstBeforeID];
+                // only add the new cases if they pass our filter
+                if (addCasesArgs && dstCasesToAdd && dstCasesToAdd.length) {
+                  newAction = { name: action.name, path: "", args: dstCasesArgs };
+                  actions.push(newAction);
+                }
+                break;
+              }
+              case "setCaseValues":
+              case "setCanonicalCaseValues": {
+                const setValuesArgs = action.args && action.args.slice(),
+                      actionCases = setValuesArgs && setValuesArgs[0],
+                      casesToAdd: ICase[] = [],
+                      beforeIDs: Array<string | undefined> = [],
+                      casesToRemove: string[] = [];
+                let isValidAction = !!(actionCases && actionCases.length);
+                actionCases.forEach((aCase: ICase) => {
+                  const caseID = aCase.__id__;
+                  const srcCase = srcDataSet && caseID && srcDataSet.getCase(caseID);
+                  if (caseID && srcCase) {
+                    const filteredCase = filter ? filter(srcCase) : srcCase,
+                          doesInclude = caseIDMap[caseID] != null;
+                    // identify cases that now pass the filter after change
+                    if (filteredCase && !doesInclude) {
+                      casesToAdd.push(filteredCase);
+                      // determine beforeIDs so that cases end up in correct locations
+                      const srcBeforeID = srcDataSet && srcDataSet.nextCaseID(caseID),
+                            dstBeforeID = mapBeforeID(srcDataSet, srcBeforeID);
+                      beforeIDs.push(dstBeforeID);
+                    }
+                    // identify cases that no longer pass the filter after change
+                    if (!filteredCase && doesInclude) {
+                      casesToRemove.push(caseID);
+                    }
+                  }
+                  else {
+                    isValidAction = false;
+                  }
+                });
+                // modify existing cases
+                if (isValidAction) {
+                  actions.push(action);
+                }
+                // add cases that now pass the filter
+                if (casesToAdd && casesToAdd.length) {
+                  actions.push({ name: "addCasesWithIDs", path: "", args: [casesToAdd, beforeIDs] });
+                }
+                // remove cases that no longer pass the filter
+                if (casesToRemove && casesToRemove.length) {
+                  actions.push({ name: "removeCases", path: "", args: [casesToRemove] });
+                }
+                break;
+              }
+              // other actions can be applied as is
+              default:
+                actions.push(action);
+                break;
+            }
+            if (actions && actions.length) {
+              delayApplyActions(actions);
+            }
+          // attachAfter: if true, listener is called after action has been applied
+          }, true); // tslint:disable-line
+        }
+      },
+      beforeDestroy() {
+        Object.keys(disposers).forEach((key: string) => disposers[key]());
+      },
+      beginTransaction() {
+        ++self.transactionCount;
+      },
+      endTransaction() {
+        --self.transactionCount;
+      },
+      setName(name: string) {
+        self.name = name;
+      },
+      addAttributeWithID(snapshot: IAttributeCreation, beforeID?: string) {
+        const beforeIndex = beforeID ? attrIndexFromID(beforeID) : undefined;
+        let newIndex = beforeIndex;
+        if (beforeIndex != null) {
+          self.attributes.splice(beforeIndex, 0, snapshot as IAttribute);
+        }
+        else {
+          newIndex = self.attributes.push(snapshot as IAttribute) - 1;
+        }
+        const attribute = self.attributes[newIndex as number];
+        attrIDMap[attribute.id] = attribute;
+        attrNameMap[attribute.name] = attribute.id;
+        for (let i = attribute.values.length; i < self.cases.length; ++i) {
+          attribute.values.push(undefined);
+        }
+      },
+
+      setAttributeName(attributeID: string, name: string) {
+        const attribute = attributeID && attrIDMap[attributeID];
+        if (attribute) {
+          attribute.setName(name);
+        }
+      },
+
+      removeAttribute(attributeID: string) {
+        const attrIndex = attrIndexFromID(attributeID),
+              attribute = attributeID && attrIDMap[attributeID],
+              attrName = attribute && attribute.name;
+        if (attrIndex != null) {
+          self.attributes.splice(attrIndex, 1);
+          delete attrIDMap[attributeID];
+          delete attrNameMap[attrName];
+        }
+      },
+
+      moveAttribute(attributeID: string, beforeID?: string) {
+        const srcAttrIndex = attrIndexFromID(attributeID);
+        if (srcAttrIndex != null) {
+          const snapshot = getSnapshot(self.attributes[srcAttrIndex]);
+          self.attributes.splice(srcAttrIndex, 1);
+          let dstAttrIndex = beforeID ? attrIndexFromID(beforeID) : undefined;
+          if (dstAttrIndex != null) {
+            self.attributes.splice(dstAttrIndex, 0, snapshot as IAttribute);
+          }
+          else {
+            self.attributes.push(snapshot as IAttribute);
+            dstAttrIndex = self.attributes.length - 1;
+          }
+          attrIDMap[attributeID] = self.attributes[dstAttrIndex];
+        }
+      },
+
+      addCasesWithIDs(cases: ICase[], beforeID?: string | string[]) {
+        cases.forEach((aCase, index) => {
+          if (!aCase || !aCase.__id__) { return; }
+          const beforeIndex = beforeIndexForInsert(index, beforeID);
+          self.attributes.forEach((attr: IAttribute) => {
+            const value = aCase[attr.name];
+            attr.addValue(value != null ? value : undefined, beforeIndex);
+          });
+          insertCaseIDAtIndex(aCase.__id__, beforeIndex);
+        });
+      },
+
+      addCanonicalCasesWithIDs(cases: ICase[], beforeID?: string | string[]) {
+        cases.forEach((aCase, index) => {
+          const beforeIndex = beforeIndexForInsert(index, beforeID);
+          self.attributes.forEach((attr: IAttribute) => {
+            const value = aCase[attr.id];
+            attr.addValue(value != null ? value : undefined, beforeIndex);
+          });
+          insertCaseIDAtIndex(aCase.__id__, beforeIndex);
+        });
+      },
+
+      setCaseValues(cases: ICase[]) {
+        cases.forEach((caseValues) => {
+          setCaseValues(caseValues);
+        });
+      },
+
+      setCanonicalCaseValues(cases: ICase[]) {
+        cases.forEach((caseValues) => {
+          setCanonicalCaseValues(caseValues);
+        });
+      },
+
+      removeCases(caseIDs: string[]) {
+        caseIDs.forEach((caseID) => {
+          const index = caseIDMap[caseID];
+          if (index != null) {
+            self.cases.splice(index, 1);
+            self.attributes.forEach((attr) => {
+              attr.removeValues(index);
+            });
+            delete caseIDMap[caseID];
+            for (let i = index; i < self.cases.length; ++i) {
+              const id = self.cases[i].__id__;
+              caseIDMap[id] = i;
+            }
+          }
+        });
+      },
+
+/*
+      addActionListener(key: string, listener: (action: ISerializedActionCall) => void) {
+        if (typeof listener === "function") {
+          disposers[key] = onAction(self, (action) => listener(action), true);
+        }
+        else {
+          // tslint:disable-next-line no-console
+          console.log(`DataSet.addActionListener called for '${key}' with non-function argument!`);
+        }
+      },
+
+      removeActionListener(key: string) {
+        const disposer = disposers[key];
+        if (disposer) {
+          delete disposers[key];
+          disposer();
+        }
+      },
+      addMiddleware(key: string, handler: (call: {}, next: {}) => void) {
+        disposers[key] = addMiddleware(self, handler);
+      },
+
+      removeMiddleware(key: string) {
+        const disposer = disposers[key];
+        if (disposer) {
+          delete disposers[key];
+          disposer();
+        }
+      }
+*/
+    }
+  };
+});
+export type IDataSet = Instance<typeof DataSet>;
+// Need to redefine to make id optional
+export interface IDataSetCreation {
+  id?: string;
+  sourceID?: string;
+  name: string;
+  attributes?: IAttribute[];
+  cases: ICaseID[];
+}
+export type IDataSetSnapshot = SnapshotOut<typeof DataSet>;
+
+export function addAttributeToDataSet(dataset: IDataSet, snapshot: IAttributeCreation, beforeID?: string) {
+  if (!snapshot.id) {
+    snapshot.id = localId();
+  }
+  dataset.addAttributeWithID(snapshot, beforeID);
+}
+
+export function addCasesToDataSet(dataset: IDataSet, cases: ICaseCreation[], beforeID?: string | string[]) {
+  const newCases = cloneDeep(cases) as ICase[];
+  newCases.forEach((aCase) => {
+    if (!aCase.__id__) {
+      aCase.__id__ = localId();
+    }
+  });
+  dataset.addCasesWithIDs(newCases, beforeID);
+}
+
+// canonical cases are keyed by attribute ID rather than attribute name
+export function addCanonicalCasesToDataSet(dataset: IDataSet, cases: ICaseCreation[], beforeID?: string | string[]) {
+  const newCases = cloneDeep(cases) as ICase[];
+  newCases.forEach((aCase) => {
+    if (!aCase.__id__) {
+      aCase.__id__ = localId();
+    }
+  });
+  dataset.addCanonicalCasesWithIDs(newCases, beforeID);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -266,6 +266,12 @@
     "@types/cookiejar" "*"
     "@types/node" "*"
 
+"@types/uuid@^3.4.4":
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.4.tgz#7af69360fa65ef0decb41fd150bf4ca5c0cefdf5"
+  dependencies:
+    "@types/node" "*"
+
 "@webassemblyjs/ast@1.5.13":
   version "1.5.13"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.5.13.tgz#81155a570bd5803a30ec31436bc2c9c0ede38f25"
@@ -1919,6 +1925,12 @@ encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
 
+encoding@^0.1.11:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  dependencies:
+    iconv-lite "~0.4.13"
+
 end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
@@ -2873,7 +2885,7 @@ iconv-lite@0.4.23:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@^0.4.22, iconv-lite@^0.4.4:
+iconv-lite@^0.4.22, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   dependencies:
@@ -3213,7 +3225,7 @@ is-regex@^1.0.4:
   dependencies:
     has "^1.0.1"
 
-is-stream@^1.1.0:
+is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
@@ -4384,6 +4396,13 @@ nock@^9.6.1:
     propagate "^1.0.0"
     qs "^6.5.1"
     semver "^5.5.0"
+
+node-fetch@^1.0.1:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
 
 node-forge@0.7.5:
   version "0.7.5"
@@ -6504,7 +6523,7 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
 
-uuid@^3.0.1, uuid@^3.1.0:
+uuid@^3.0.1, uuid@^3.1.0, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 
@@ -6698,7 +6717,7 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   dependencies:
     iconv-lite "0.4.23"
 
-whatwg-fetch@^2.0.3:
+whatwg-fetch@>=0.10.0, whatwg-fetch@^2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
 


### PR DESCRIPTION
- update to MobX-State-Tree 3 and TypeScript 3
- port/extend unit tests as well

I anticipate storing the data shared between components/tiles (e.g. between the table and the geometry/graph) in a DataSet.