### PR TITLE
Save user work

### DIFF
--- a/src/components/canvas-tools/text-tool.tsx
+++ b/src/components/canvas-tools/text-tool.tsx
@@ -1,11 +1,15 @@
 import * as React from "react";
 import { observer } from "mobx-react";
-import { Change } from "slate";
+import { Change, Value } from "slate";
 import { Editor } from "slate-react";
 import { ToolTileModelType } from "../../models/tools/tool-tile";
 import { TextContentModelType } from "../../models/tools/text/text-content";
 
 import "./text-tool.sass";
+
+interface IState {
+  value: Value;
+}
 ​
 interface IProps {
   model: ToolTileModelType;
@@ -13,13 +17,15 @@ interface IProps {
 }
 
 @observer
-export default class TextToolComponent extends React.Component<IProps, {}> {
+export default class TextToolComponent extends React.Component<IProps, IState> {
 
   public onChange = (change: Change) => {
     const { readOnly, model: { content } } = this.props;
     if (content.type === "Text") {
       if (readOnly) {
-        content.setSlateReadOnly(change.value);
+        this.setState({
+          value: change.value
+        });
       }
       else {
         content.setSlate(change.value);
@@ -28,15 +34,13 @@ export default class TextToolComponent extends React.Component<IProps, {}> {
   }
 
   public render() {
-    const { model } = this.props;
+    const { model, readOnly } = this.props;
     const { content } = model;
     const editableClass = this.props.readOnly ? "read-only" : "editable";
     const classes = `text-tool ${editableClass}`;
-    // Slate's readOnly mode interacts poorly with MST/React.
-    // We prevent readOnly from making model changes in onChange().
-    // Unfortunately, copy from readOnly doesn't work for unknown reasons.
-    const readOnly = false;
-    const value = (content as TextContentModelType).convertSlate();
+    const value = (readOnly && this.state)
+      ? this.state.value
+      : (content as TextContentModelType).convertSlate();
     return (
       <Editor
         key={model.id}

--- a/src/components/canvas-tools/text-tool.tsx
+++ b/src/components/canvas-tools/text-tool.tsx
@@ -37,8 +37,6 @@ export default class TextToolComponent extends React.Component<IProps, {}> {
     // Unfortunately, copy from readOnly doesn't work for unknown reasons.
     const readOnly = false;
     const value = (content as TextContentModelType).convertSlate();
-    // triggers re-render on changes, even if resulting stringified JSON is the same
-    const changes = content.type === "Text" ? content.changes : 0;
     return (
       <Editor
         key={model.id}
@@ -46,7 +44,6 @@ export default class TextToolComponent extends React.Component<IProps, {}> {
         readOnly={readOnly}
         value={value}
         onChange={this.onChange}
-        data-changes={changes}
       />
     );
   }

--- a/src/lib/db-types.ts
+++ b/src/lib/db-types.ts
@@ -38,7 +38,7 @@ export interface DBDocument {
     uid: string;
     documentKey: string;
   };
-  // TDB: serialized document model contents
+  content?: string;
 }
 
 export interface DBClass {

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -1,6 +1,8 @@
 import { DB } from "./db";
 import { IStores, createStores } from "../models/stores";
 import { UserModel } from "../models/user";
+import { DBDocument } from "./db-types";
+import { TextContentModelType } from "../models/tools/text/text-content";
 
 describe("db", () => {
   let stores: IStores;
@@ -54,6 +56,24 @@ describe("db", () => {
           });
         })
       .then(() => db.disconnect());
+  });
+
+  it("can parse document text content", () => {
+    const db = new DB();
+    // tslint:disable-next-line:max-line-length
+    const storedJsonString = "{\"tiles\":[{\"id\":\"9d1cfc99-121a-4817-bc08-2144d00ba6d0\",\"content\":{\"type\":\"Text\",\"text\":\"{\\\"object\\\":\\\"value\\\",\\\"document\\\":{\\\"object\\\":\\\"document\\\",\\\"data\\\":{},\\\"nodes\\\":[{\\\"object\\\":\\\"block\\\",\\\"type\\\":\\\"line\\\",\\\"data\\\":{},\\\"nodes\\\":[{\\\"object\\\":\\\"text\\\",\\\"leaves\\\":[{\\\"object\\\":\\\"leaf\\\",\\\"text\\\":\\\"laaa\\\",\\\"marks\\\":[]}]}]}]}}\"}},{\"id\":\"72c8d88f-edea-4ac4-a7e7-0d70ecf960c0\",\"content\":{\"type\":\"Text\",\"text\":\"{\\\"object\\\":\\\"value\\\",\\\"document\\\":{\\\"object\\\":\\\"document\\\",\\\"data\\\":{},\\\"nodes\\\":[{\\\"object\\\":\\\"block\\\",\\\"type\\\":\\\"line\\\",\\\"data\\\":{},\\\"nodes\\\":[{\\\"object\\\":\\\"text\\\",\\\"leaves\\\":[{\\\"object\\\":\\\"leaf\\\",\\\"text\\\":\\\"Testing\\\",\\\"marks\\\":[]}]}]}]}}\",\"format\":\"slate\"}}]}";
+    const docContent = db._private.parseDocumentContent({content: storedJsonString} as DBDocument);
+
+    if (docContent == null) {
+      fail();
+      return;
+    }
+
+    expect(docContent.tiles.length).toBe(2);
+    const tileContent = docContent.tiles[1].content as TextContentModelType;
+    expect(tileContent.type).toBe("Text");
+    expect(tileContent.format).toBe("slate");
+    expect(tileContent.getSlate().texts.get(0).getText()).toBe("Testing");
   });
 
 });

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -47,6 +47,9 @@ export interface DisposerMap {
 export class DB {
   @observable public isListening = false;
   @observable public groups: GroupUsersMap = {};
+  public _private = {
+    parseDocumentContent: this.parseDocumentContent
+  };
   private appMode: AppMode;
   private firebaseUser: firebase.User | null = null;
   private stores: IStores;
@@ -668,7 +671,8 @@ export class DB {
         return workspace;
       });
   }
-  private parseDocumentContent = (document: DBDocument): DocumentContentModelType|null => {
+
+  private parseDocumentContent(document: DBDocument): DocumentContentModelType|null {
     if (!document.content) {
       return null;
     }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -656,22 +656,7 @@ export class DB {
   }
 
   private parseDocumentContent(document: DBDocument): DocumentContentModelType|null {
-    if (!document.content) {
-      return null;
-    }
-
-    const storedContent: DocumentContentModelType = JSON.parse(document.content);
-    return DocumentContentModel.create({
-      shared: storedContent.shared,
-      tiles: storedContent.tiles.map((tile) => {
-        const tileTool = toolFactory(tile.content);
-        return ToolTileModel.create({
-          id: tile.id,
-          layout: tile.layout,
-          content: tileTool.create(tile.content)
-        });
-      })
-    });
+    return document.content ? DocumentContentModel.create(JSON.parse(document.content)) : null;
   }
 
   private monitorSectionDocumentRef = (sectionId: string, document: DocumentModelType) => {

--- a/src/models/document.ts
+++ b/src/models/document.ts
@@ -1,5 +1,5 @@
 import { types, Instance } from "mobx-state-tree";
-import { DocumentContentModel } from "./document-content";
+import { DocumentContentModel, DocumentContentModelType } from "./document-content";
 
 export const DocumentModel = types
   .model("Document", {
@@ -7,6 +7,11 @@ export const DocumentModel = types
     key: types.string,
     createdAt: types.number,
     content: DocumentContentModel
-  });
+  })
+  .actions((self) => ({
+    setContent(content: DocumentContentModelType) {
+      self.content = content;
+    }
+  }));
 
 export type DocumentModelType = Instance<typeof DocumentModel>;

--- a/src/models/tools/text/text-content.test.ts
+++ b/src/models/tools/text/text-content.test.ts
@@ -73,13 +73,10 @@ describe("TextContentModel", () => {
     expect(Plain.serialize(model.convertSlate())).toBe(foo);
 
     const fooValue = Value.fromJSON(fooJson);
-    const preChanges = model.changes;
     model.setSlate(fooValue);
-    expect(model.changes).toBe(preChanges + 1);
     expect(model.format).toBe("slate");
     expect(Plain.serialize(model.convertSlate())).toBe(foo);
     model.setSlateReadOnly(fooValue);
-    expect(model.changes).toBe(preChanges + 1);
     expect(model.format).toBe("slate");
     expect(Plain.serialize(model.convertSlate())).toBe(foo);
   });

--- a/src/models/tools/text/text-content.ts
+++ b/src/models/tools/text/text-content.ts
@@ -41,8 +41,7 @@ export const TextContentModel = types
     type: types.optional(types.literal(kTextToolID), kTextToolID),
     text: types.optional(StringOrArray, ""),
     // e.g. "markdown", "slate", "quill", empty => plain text
-    format: types.maybe(types.string),
-    changes: 0
+    format: types.maybe(types.string)
   })
   .views(self => ({
     get joinText() {
@@ -102,8 +101,9 @@ export const TextContentModel = types
 
     function setSlate(value: Value) {
       self.format = "slate";
-      self.text = JSON.stringify(value.toJSON());
-      ++self.changes;
+      // Workaround for missing argument in Slate types
+      const myToJSON = value.toJSON as any;
+      self.text = JSON.stringify(myToJSON.call(value, {preserveSelection: true}));
       slateValue = value;
     }
 


### PR DESCRIPTION
User work is saved based on the "whole doc" storage, for now. Parses Slate correctly now, too!

I realized there was a bug when I demo'd this morning - documents were only saved if they were just opened, so returning to an opened tab broke saving. Now, I'm monitoring all user documents at the same time. The alternative would be to listen for changes to the UI to figure out what to listen to, but I'd be surprised if the performance cost of a few extra listeners was noticeable.