### PR TITLE
4-up Text View

### DIFF
--- a/src/components/canvas.tsx
+++ b/src/components/canvas.tsx
@@ -29,7 +29,6 @@ export class CanvasComponent extends React.Component<IProps, {}> {
     const {content, document, ...others} = this.props;
     const documentContent = document ? document.content : content;
     const hasContent =  documentContent && !documentContent.isEmpty;
-    const defaultContent = `${this.props.readOnly ? "NON " : ""}Editable Canvas`;
 
     if (hasContent) {
       return (
@@ -39,7 +38,7 @@ export class CanvasComponent extends React.Component<IProps, {}> {
       );
     }
     else {
-      return defaultContent;
+      return null;
     }
   }
 }

--- a/src/components/four-up.sass
+++ b/src/components/four-up.sass
@@ -29,3 +29,11 @@
       position: absolute
       top: 0
       left: 0
+
+    .member
+      position: absolute
+      font-size: 10px
+      padding: 3px
+      border: 1px solid #777
+      bottom: 0
+      right: 0

--- a/src/components/four-up.tsx
+++ b/src/components/four-up.tsx
@@ -1,4 +1,4 @@
-import { observer } from "mobx-react";
+import { observer, inject } from "mobx-react";
 import * as React from "react";
 
 import { CellPositions, FourUpGridCellModelType, FourUpGridModel,
@@ -8,11 +8,19 @@ import { CanvasComponent } from "./canvas";
 import { BaseComponent, IBaseProps } from "./base";
 
 import "./four-up.sass";
+import { values } from "mobx";
+import { DocumentModelType } from "../models/document";
 
 interface IProps extends IBaseProps {
   workspace: WorkspaceModelType;
 }
 
+interface FourUpUser {
+  doc: DocumentModelType|undefined;
+  initials: string;
+}
+
+@inject("stores")
 @observer
 export class FourUpComponent extends BaseComponent<IProps, {}> {
   private grid: FourUpGridModelType;
@@ -57,27 +65,47 @@ export class FourUpComponent extends BaseComponent<IProps, {}> {
       return {width, height, transform, transformOrigin: "0 0"};
     };
 
+    const { groups, user } = this.stores;
+    const { workspace } = this.props;
+
+    const group = groups.groupForUser(user.id);
+    const groupUsers: FourUpUser[] = group
+      ? group.users
+          .filter((groupUser) => groupUser.id !== user.id)
+          .map((groupUser) => {
+            const groupUserDoc = workspace.groupDocuments.get(groupUser.id);
+            return {
+              doc: groupUserDoc,
+              initials: groupUser.initials
+            };
+          })
+      : [];
+
     return (
       <div className="four-up" ref={(el) => this.container = el}>
         <div className="canvas-container north-west" style={nwStyle}>
           <div className="canvas-scaler" style={scaleStyle(nwCell)}>
-            <CanvasComponent context="four-up-nw" document={this.props.workspace.userDocument} />
+            <CanvasComponent context="four-up-nw" document={workspace.userDocument} />
           </div>
+          <div className="member">{user.initials}</div>
         </div>
         <div className="canvas-container north-east" style={neStyle}>
           <div className="canvas-scaler" style={scaleStyle(neCell)}>
-            <CanvasComponent context="four-up-ne" readOnly={true} />
+            <CanvasComponent context="four-up-ne" document={groupUsers[0] && groupUsers[0].doc} />
           </div>
+          {groupUsers[0] && <div className="member">{groupUsers[0].initials}</div>}
         </div>
         <div className="canvas-container south-east" style={seStyle}>
           <div className="canvas-scaler" style={scaleStyle(seCell)}>
-            <CanvasComponent context="four-up-se" readOnly={true} />
+            <CanvasComponent context="four-up-se" document={groupUsers[1] && groupUsers[1].doc} />
           </div>
+          {groupUsers[1] && <div className="member">{groupUsers[1].initials}</div>}
         </div>
         <div className="canvas-container south-west" style={swStyle}>
           <div className="canvas-scaler" style={scaleStyle(swCell)}>
-            <CanvasComponent context="four-up-sw" readOnly={true} />
+            <CanvasComponent context="four-up-sw" document={groupUsers[2] && groupUsers[2].doc} />
           </div>
+          {groupUsers[2] && <div className="member">{groupUsers[2].initials}</div>}
         </div>
         <div
           className="horizontal splitter"

--- a/src/components/workspace.sass
+++ b/src/components/workspace.sass
@@ -41,6 +41,12 @@
         padding: 3px
         color: #fff
 
+      .share-button
+        margin-right: 5px
+        width: 52px
+        display: inline-block
+        text-align: center
+
   .toolbar
     position: absolute
     top: $workspace-titlebar-height

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -38,6 +38,9 @@ export class WorkspaceComponent extends BaseComponent<IProps, {}> {
       <div className="titlebar">
         <div className="title">{activeSection ? activeSection.title : ""}</div>
         <div className="actions">
+          <span className="share-button" onClick={this.handleToggleVisibility}>
+            {workspace.visibility === "private" ? "Share" : "Unshare"}
+          </span>
           <span onClick={this.handleToggleWorkspaceMode}>{workspace.mode === "1-up" ? "4-up" : "1-up"}</span>
         </div>
       </div>
@@ -118,6 +121,10 @@ export class WorkspaceComponent extends BaseComponent<IProps, {}> {
 
   private handleToggleWorkspaceMode = () => {
     this.props.workspace.toggleMode();
+  }
+
+  private handleToggleVisibility = () => {
+    this.props.workspace.toggleVisibility();
   }
 
   private handleToggleSupport = (support: SupportItemModelType) => {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -757,7 +757,8 @@ export class DB {
 
   private monitorWorkspaceVisibility = (workspace: WorkspaceModelType) => {
     if (this.workspaceModelDisposers[workspace.sectionId]) {
-      this.workspaceModelDisposers[workspace.sectionId]();
+      // Workspaces ignores any duplicate workspaces created for a sectionId, so don't listen to them
+      return;
     }
     const { user } = this.stores;
     const updateRef = this.ref(this.getSectionDocumentPath(user, workspace.sectionId));

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -259,7 +259,7 @@ export class DB {
                       uid: user.id,
                       sectionId
                     },
-                    visibility: "public",
+                    visibility: "private",
                     documentKey: document.self.documentKey,
                   };
                   return sectionDocumentRef.set(sectionDocument).then(() => sectionDocument!);

--- a/src/models/workspaces.test.ts
+++ b/src/models/workspaces.test.ts
@@ -17,11 +17,10 @@ describe("workspaces model", () => {
         createdAt: 1,
         content: {}
       }),
-      groupDocuments: [],
+      groupDocuments: {}
     });
-    workspaces = WorkspacesModel.create({
-      workspaces: [workspace]
-    });
+    workspaces = WorkspacesModel.create({});
+    workspaces.addWorkspace(workspace);
   });
 
   it("has default values", () => {
@@ -87,7 +86,7 @@ describe("workspaces model", () => {
         createdAt: 1,
         content: {}
       }),
-      groupDocuments: [],
+      groupDocuments: {},
     });
     workspaces.addWorkspace(newWorkspace);
     expect(workspaces.getWorkspaceBySectionId("2")).toBe(newWorkspace);
@@ -105,7 +104,7 @@ describe("workspaces model", () => {
         createdAt: 1,
         content: {}
       }),
-      groupDocuments: [],
+      groupDocuments: {},
     });
     workspaces.addWorkspace(newWorkspace);
     expect(workspaces.getWorkspaceBySectionId("1")).toBe(workspace);

--- a/src/models/workspaces.ts
+++ b/src/models/workspaces.ts
@@ -1,5 +1,8 @@
 import { types } from "mobx-state-tree";
-import { DocumentModel } from "./document";
+import { DocumentModel, DocumentModelType } from "./document";
+import { set } from "mobx";
+import { TextContentModelType } from "./tools/text/text-content";
+import { DocumentContentModelType } from "./document-content";
 
 export const WorkspaceModeEnum = types.enumeration("mode", ["1-up", "4-up"]);
 export type WorkspaceMode = typeof WorkspaceModeEnum.Type;
@@ -13,7 +16,7 @@ export const WorkspaceModel = types
     tool: WorkspaceToolEnum,
     sectionId: types.string,
     userDocument: DocumentModel,
-    groupDocuments: types.array(DocumentModel),
+    groupDocuments: types.map(DocumentModel),
     visibility: types.enumeration("VisibilityType", ["public", "private"]),
   })
   .actions((self) => {
@@ -40,7 +43,11 @@ export const WorkspaceModel = types
         self.visibility = typeof overide === "undefined"
           ? (self.visibility === "public" ? "private" : "public")
           : overide;
-      }
+      },
+
+      setGroupDocument(uid: string, document: DocumentModelType) {
+        self.groupDocuments.set(uid, document);
+      },
     };
   });
 

--- a/src/models/workspaces.ts
+++ b/src/models/workspaces.ts
@@ -48,6 +48,10 @@ export const WorkspaceModel = types
       setGroupDocument(uid: string, document: DocumentModelType) {
         self.groupDocuments.set(uid, document);
       },
+
+      clearGroupDocument(uid: string) {
+        self.groupDocuments.delete(uid);
+      }
     };
   });
 


### PR DESCRIPTION
This PR includes the synced 4-up view and the hide/show button. For each workspace, listeners watch group mate section documents and the content of those documents for changes, which are persisted to the workspace model. The listeners are updated whenever a workspace is created or loaded, or whenever the group makeup changes.

Tests are still needed, but I'm hoping to get this merged for tomorrow's demo.