### PR TITLE
Fix text tool issues after drag/drop

### DIFF
--- a/src/components/canvas-tools/text-tool.tsx
+++ b/src/components/canvas-tools/text-tool.tsx
@@ -19,34 +19,33 @@ interface IProps {
 @observer
 export default class TextToolComponent extends React.Component<IProps, IState> {
 
+  public componentWillMount() {
+    const { model: { content } } = this.props;
+    if (content.type === "Text") {
+      this.setState({ value: content.convertSlate() });
+    }
+  }
+
   public onChange = (change: Change) => {
     const { readOnly, model: { content } } = this.props;
     if (content.type === "Text") {
-      if (readOnly) {
-        this.setState({
-          value: change.value
-        });
-      }
-      else {
+      if (!readOnly) {
         content.setSlate(change.value);
       }
+      this.setState({ value: change.value });
     }
   }
 
   public render() {
     const { model, readOnly } = this.props;
-    const { content } = model;
-    const editableClass = this.props.readOnly ? "read-only" : "editable";
+    const editableClass = readOnly ? "read-only" : "editable";
     const classes = `text-tool ${editableClass}`;
-    const value = (readOnly && this.state)
-      ? this.state.value
-      : (content as TextContentModelType).convertSlate();
     return (
       <Editor
         key={model.id}
         className={classes}
         readOnly={readOnly}
-        value={value}
+        value={this.state.value}
         onChange={this.onChange}
       />
     );

--- a/src/components/document-content.tsx
+++ b/src/components/document-content.tsx
@@ -35,8 +35,10 @@ export class DocumentContentComponent extends React.Component<IProps, {}> {
   }
 
   private handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
-    // indicate we'll accept the drop
-    e.preventDefault();
+    if (!this.props.readOnly) {
+      // indicate we'll accept the drop
+      e.preventDefault();
+    }
   }
 
   private handleDrop = (e: React.DragEvent<HTMLDivElement>) => {

--- a/src/models/tools/text/text-content.test.ts
+++ b/src/models/tools/text/text-content.test.ts
@@ -76,8 +76,5 @@ describe("TextContentModel", () => {
     model.setSlate(fooValue);
     expect(model.format).toBe("slate");
     expect(Plain.serialize(model.convertSlate())).toBe(foo);
-    model.setSlateReadOnly(fooValue);
-    expect(model.format).toBe("slate");
-    expect(Plain.serialize(model.convertSlate())).toBe(foo);
   });
 });

--- a/src/models/tools/text/text-content.ts
+++ b/src/models/tools/text/text-content.ts
@@ -52,13 +52,9 @@ export const TextContentModel = types
     }
   }))
   .extend(self => {
-    // local cache of Slate's immutable.js object
-    let slateValue: Value | undefined;
 
     // views
     function getSlate() {
-      if (slateValue) { return slateValue; }
-
       const text = Array.isArray(self.text) ? "" : self.text;
       let parsed = emptyJson;
       if (text) {
@@ -70,19 +66,17 @@ export const TextContentModel = types
           parsed = errorJson;
         }
       }
-      return slateValue = Value.fromJSON(parsed);
+      return Value.fromJSON(parsed);
     }
 
     function convertSlate() {
-      if (slateValue) { return slateValue; }
-
       switch (self.format) {
         case "slate":
           return getSlate();
         case "markdown":
           // handle markdown import here; for now we treat as text
         default:
-          return slateValue = Plain.deserialize(self.joinText);
+          return Plain.deserialize(self.joinText);
       }
     }
 
@@ -90,25 +84,16 @@ export const TextContentModel = types
     function setText(text: string) {
       self.format = undefined;
       self.text = text;
-      slateValue = undefined;
     }
 
     function setMarkdown(text: string) {
       self.format = "markdown";
       self.text = text;
-      slateValue = undefined;
     }
 
     function setSlate(value: Value) {
       self.format = "slate";
-      // Workaround for missing argument in Slate types
-      const myToJSON = value.toJSON as any;
-      self.text = JSON.stringify(myToJSON.call(value, {preserveSelection: true}));
-      slateValue = value;
-    }
-
-    function setSlateReadOnly(value: Value) {
-      slateValue = value;
+      self.text = JSON.stringify(value.toJSON());
     }
 
     return {
@@ -119,8 +104,7 @@ export const TextContentModel = types
       actions: {
         setText,
         setMarkdown,
-        setSlate,
-        setSlateReadOnly
+        setSlate
       }
     };
   });


### PR DESCRIPTION
- remove Slate model from MST model
- don't serialize Slate selection to MST
- always keep Slate model in React component state
- only synchronize changes from Slate to MST in editable views

Separately, disable dropping tools into read-only documents