### PR TITLE
Support tool tile selection and deletion

### DIFF
--- a/src/components/canvas-tools/geometry-tool.tsx
+++ b/src/components/canvas-tools/geometry-tool.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-import { observer } from "mobx-react";
+import { inject, observer } from "mobx-react";
+import { BaseComponent } from "../base";
 import { ToolTileModelType } from "../../models/tools/tool-tile";
 
 import "./text-tool.sass";
@@ -24,8 +25,9 @@ function getEventCoords(board: JXG.Board, evt: any, index?: number) {
   return new JXG.Coords(JXG.COORDS_BY_SCREEN, [dx, dy], board);
 }
 ​
+@inject("stores")
 @observer
-export default class GeometryToolComponent extends React.Component<IProps, IState> {
+export default class GeometryToolComponent extends BaseComponent<IProps, IState> {
 
   private elementId: string;
   private lastPtrDownEvent: any;
@@ -83,7 +85,11 @@ export default class GeometryToolComponent extends React.Component<IProps, IStat
 
   private pointerDownHandler = (evt: any) => {
     const { board } = this.state;
+    const { model } = this.props;
+    const { ui } = this.stores;
     if (!board) { return; }
+
+    ui.setSelectedTile(model);
 
     const index = evt[JXG.touchProperty] ? 0 : undefined;
     const coords = getEventCoords(board, evt, index);

--- a/src/components/canvas-tools/text-tool.tsx
+++ b/src/components/canvas-tools/text-tool.tsx
@@ -40,10 +40,20 @@ export default class TextToolComponent extends BaseComponent<IProps, IState> {
     const { readOnly, model } = this.props;
     const { content } = model;
     const { ui } = this.stores;
-    const op = change.operations.get(0);
-    if (op.type === "set_selection") {
-      ui.setSelectedTile(model);
+
+    // determine last focus state from list of operations
+    let isFocused: boolean | undefined;
+    change.operations.forEach(op => {
+      if (op && op.type === "set_selection") {
+        isFocused = op.selection.get("isFocused");
+      }
+    });
+
+    if (isFocused != null) {
+      // polarity is reversed from what one might expect
+      ui.setSelectedTile(isFocused ? undefined : model);
     }
+
     if (content.type === "Text") {
       if (!readOnly) {
         content.setSlate(change.value);

--- a/src/components/canvas-tools/text-tool.tsx
+++ b/src/components/canvas-tools/text-tool.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
-import { observer } from "mobx-react";
+import { observer, inject } from "mobx-react";
 import { Change, Value } from "slate";
 import { Editor } from "slate-react";
+import { BaseComponent } from "../base";
 import { ToolTileModelType } from "../../models/tools/tool-tile";
 import { TextContentModelType } from "../../models/tools/text/text-content";
 
@@ -17,8 +18,9 @@ interface IState {
   value?: Value;
 }
 ​
+@inject("stores")
 @observer
-export default class TextToolComponent extends React.Component<IProps, IState> {
+export default class TextToolComponent extends BaseComponent<IProps, IState> {
 
   public static getDerivedStateFromProps = (props: IProps, state: IState) => {
     const { model: { content } } = props;
@@ -35,7 +37,13 @@ export default class TextToolComponent extends React.Component<IProps, IState> {
   public state: IState = {};
 
   public onChange = (change: Change) => {
-    const { readOnly, model: { content } } = this.props;
+    const { readOnly, model } = this.props;
+    const { content } = model;
+    const { ui } = this.stores;
+    const op = change.operations.get(0);
+    if (op.type === "set_selection") {
+      ui.setSelectedTile(model);
+    }
     if (content.type === "Text") {
       if (!readOnly) {
         content.setSlate(change.value);

--- a/src/components/canvas-tools/tool-tile.sass
+++ b/src/components/canvas-tools/tool-tile.sass
@@ -1,0 +1,7 @@
+.tool-tile
+  width: 100%
+  min-height: 18px
+  border: 2px solid white
+
+  &.selected
+    border: 2px solid pink

--- a/src/components/canvas-tools/tool-tile.tsx
+++ b/src/components/canvas-tools/tool-tile.tsx
@@ -1,13 +1,15 @@
 import * as React from "react";
-import { observer } from "mobx-react";
+import { observer, inject } from "mobx-react";
 import { getSnapshot } from "mobx-state-tree";
 import { ToolTileModelType } from "../../models/tools/tool-tile";
 import { kGeometryToolID } from "../../models/tools/geometry/geometry-content";
 import { kTableToolID } from "../../models/tools/table/table-content";
 import { kTextToolID } from "../../models/tools/text/text-content";
+import { BaseComponent } from "../base";
 import GeometryToolComponent from "./geometry-tool";
 import TextToolComponent from "./text-tool";
 import { cloneDeep } from "lodash";
+import "./tool-tile.sass";
 
 interface IProps {
   context: string;
@@ -15,12 +17,16 @@ interface IProps {
   readOnly?: boolean;
 }
 
+@inject("stores")
 @observer
-export class ToolTileComponent extends React.Component<IProps, {}> {
+export class ToolTileComponent extends BaseComponent<IProps, {}> {
 
   public render() {
+    const { model } = this.props;
+    const { ui } = this.stores;
+    const selectedClass = ui.isSelectedTile(model) ? " selected" : "";
     return (
-      <div className="tool-tile-component"
+      <div className={`tool-tile${selectedClass}`}
         onDragStart={this.handleToolDragStart}
         draggable={true}
       >

--- a/src/components/document-content.sass
+++ b/src/components/document-content.sass
@@ -3,3 +3,4 @@
   height: 100%
   width: 100%
   background-color: #fff
+  padding: 0 5px 0 1px

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -6,12 +6,12 @@ import { WorkspaceTool,
          SectionWorkspaceModelType,
          LearningLogWorkspaceModelType
        } from "../models/workspaces";
+import { SupportItemModelType } from "../models/supports";
 import { CanvasComponent } from "./canvas";
 import { FourUpComponent } from "./four-up";
 import { BaseComponent, IBaseProps } from "./base";
 
 import "./workspace.sass";
-import { SupportItemModelType } from "../models/supports";
 
 export type WorkspaceSide = "primary" | "comparison";
 
@@ -83,8 +83,17 @@ export class WorkspaceComponent extends BaseComponent<IProps, {}> {
       return `tool ${tool}${tool === workspace.tool ? " active" : ""}`;
     };
     const handleSelectTool = (tool: WorkspaceTool) => {
+      const { ui } = this.stores;
       return (e: React.MouseEvent<HTMLDivElement>) => {
-        workspace.selectTool(tool);
+        switch (tool) {
+          case "delete":
+            if (ui.selectedTileId) {
+              workspace.deleteTile(ui.selectedTileId);
+            }
+            break;
+          default:
+            workspace.selectTool(tool);
+        }
       };
     };
     return (
@@ -92,6 +101,7 @@ export class WorkspaceComponent extends BaseComponent<IProps, {}> {
         <div className={className("select")} title="Select" onClick={handleSelectTool("select")}>↖</div>
         <div className={className("text")} title="Text" onClick={handleSelectTool("text")}>T</div>
         <div className={className("geometry")} title="Geometry" onClick={handleSelectTool("geometry")}/>
+        <div className={className("delete")} title="Delete" onClick={handleSelectTool("delete")}>{"\u274c"}</div>
       </div>
     );
   }

--- a/src/models/document-content.ts
+++ b/src/models/document-content.ts
@@ -40,13 +40,19 @@ export const DocumentContentModel = types
         }
       }));
     },
-    addTextTile() {
+    addTextTile(initialText?: string) {
       self.tiles.push(ToolTileModel.create({
         content: {
           type: "Text",
-          text: ""
+          text: initialText
         }
       }));
+    },
+    deleteTile(tileId: string) {
+      const index = self.tiles.findIndex(tile => tile.id === tileId);
+      if (index >= 0) {
+        self.tiles.splice(index, 1);
+      }
     },
     addTileSnapshot(snapshot: ToolTileModelType) {
       self.tiles.push(ToolTileModel.create(snapshot));

--- a/src/models/tools/tool-tile.ts
+++ b/src/models/tools/tool-tile.ts
@@ -9,7 +9,7 @@ export const kDefaultMinWidth = 60;
 export const ToolTileModel = types
   .model("ToolTile", {
     // if not provided, will be generated
-    id: types.optional(types.string, () => uuid()),
+    id: types.optional(types.identifier, () => uuid()),
     // optional information about placement of tile
     layout: types.maybe(TileLayoutModel),
     // e.g. "GeometryContentModel", "RichTextContentModel", "TableContentModel", "TextContentModel"

--- a/src/models/ui.ts
+++ b/src/models/ui.ts
@@ -1,5 +1,6 @@
 import { types } from "mobx-state-tree";
 import { SectionWorkspaceModelType, LearningLogWorkspaceModelType } from "./workspaces";
+import { ToolTileModelType } from "./tools/tool-tile";
 
 export type ToggleElement = "rightNavExpanded" | "leftNavExpanded" | "bottomNavExpanded";
 
@@ -11,6 +12,7 @@ export const UIModel = types
     error: types.maybeNull(types.string),
     activeSectionIndex: 0,
     activeRightNavTab: "My Work",
+    selectedTileId: types.maybe(types.string),
     primaryWorkspaceDocumentKey: types.maybe(types.string),
     comparisonWorkspaceDocumentKey: types.maybe(types.string),
     comparisonWorkspaceVisible: false,
@@ -24,6 +26,9 @@ export const UIModel = types
     get allContracted() {
       return !self.rightNavExpanded && !self.leftNavExpanded && !self.bottomNavExpanded;
     },
+    isSelectedTile(tile: ToolTileModelType) {
+      return (tile.id === self.selectedTileId);
+    }
   }))
   .actions((self) => {
     const contractAll = () => {
@@ -92,6 +97,9 @@ export const UIModel = types
       },
       setActiveRightNavTab(tab: string) {
         self.activeRightNavTab = tab;
+      },
+      setSelectedTile(tile?: ToolTileModelType) {
+        self.selectedTileId = tile ? tile.id : undefined;
       },
       setAvailableWorkspace(workspace?: LearningLogWorkspaceModelType | SectionWorkspaceModelType) {
         if (self.comparisonWorkspaceVisible) {

--- a/src/models/workspaces.ts
+++ b/src/models/workspaces.ts
@@ -4,7 +4,7 @@ import { DocumentModel, DocumentModelType } from "./document";
 export const WorkspaceModeEnum = types.enumeration("mode", ["1-up", "4-up"]);
 export type WorkspaceMode = typeof WorkspaceModeEnum.Type;
 
-export const WorkspaceToolEnum = types.enumeration("tool", ["geometry", "select", "text"]);
+export const WorkspaceToolEnum = types.enumeration("tool", ["delete", "geometry", "select", "text"]);
 export type WorkspaceTool = typeof WorkspaceToolEnum.Type;
 
 const selectTool = (tool: WorkspaceTool, document: DocumentModelType) => {
@@ -41,6 +41,10 @@ export const SectionWorkspaceModel = types
         self.tool = selectTool(tool, self.document);
       },
 
+      deleteTile(tileId: string) {
+        self.document.content.deleteTile(tileId);
+      },
+
       toggleVisibility(overide?: "public" | "private") {
         self.visibility = typeof overide === "undefined"
           ? (self.visibility === "public" ? "private" : "public")
@@ -69,6 +73,10 @@ export const LearningLogWorkspaceModel = types
     return {
       selectTool(tool: WorkspaceTool) {
         self.tool = selectTool(tool, self.document);
+      },
+
+      deleteTile(tileId: string) {
+        self.document.content.deleteTile(tileId);
       },
 
       setTitle(title: string) {


### PR DESCRIPTION
The work in this PR has been spear-headed by @DALove1025 with input from @ekosmin and me, much of it achieved during pair- and trio-programming episodes. After sixteen commits and multiple merges from master in the original PR branch I was having a hard time reviewing the changes so I cherry-picked the changes into a new branch that makes it easier to understand. In doing so I also tweaked a few things.

Support tool selection [#160300212]
- the current "styling" is a pink border around the selected tile; true styling awaits

Add delete tool which deletes the currently selected tile [#160407213]

Parse Slate operations for more fine-grained control of tool selection
- allows clicking outside any tile to deselect a text tile
