### PR TITLE
Fix bleed-through of geometry labels onto other layers

### DIFF
--- a/src/components/canvas-tools/tool-tile.sass
+++ b/src/components/canvas-tools/tool-tile.sass
@@ -1,4 +1,7 @@
 .tool-tile
+  // create z-index stacking context ("what happens in tool tiles, stays in tool tiles")
+  position: relative
+  z-index: 0
   width: 100%
   min-height: 18px
   border: 2px solid white


### PR DESCRIPTION
Fix bleed-through of geometry labels onto other layers (e.g. learning log) [#160686040]

- create stacking context in tool-tile such that tool-specific z-indexes are contained
- "what happens in tool tiles, stays in tools tiles"