### PR TITLE
Fix text tool delete & tile selection issues

### DIFF
--- a/src/components/canvas-tools/geometry-tool.tsx
+++ b/src/components/canvas-tools/geometry-tool.tsx
@@ -89,7 +89,11 @@ export default class GeometryToolComponent extends BaseComponent<IProps, IState>
     const { ui } = this.stores;
     if (!board) { return; }
 
-    ui.setSelectedTile(model);
+    // first click selects the tile; subsequent clicks create points
+    if (!ui.isSelectedTile(model)) {
+      ui.setSelectedTile(model);
+      return;
+    }
 
     const index = evt[JXG.touchProperty] ? 0 : undefined;
     const coords = getEventCoords(board, evt, index);

--- a/src/components/canvas-tools/text-tool.tsx
+++ b/src/components/canvas-tools/text-tool.tsx
@@ -51,7 +51,13 @@ export default class TextToolComponent extends BaseComponent<IProps, IState> {
 
     if (isFocused != null) {
       // polarity is reversed from what one might expect
-      ui.setSelectedTile(isFocused ? undefined : model);
+      if (!isFocused) {
+        // only select - if we deselect, it breaks delete because Slate
+        // somehow detects the selection change before the click on the
+        // delete button is processed by the workspace. For now, we just
+        // disable focus change on deselection.
+        ui.setSelectedTile(model);
+      }
     }
 
     if (content.type === "Text") {

--- a/src/components/document-content.tsx
+++ b/src/components/document-content.tsx
@@ -1,6 +1,6 @@
-import { observer } from "mobx-react";
+import { inject, observer } from "mobx-react";
 import * as React from "react";
-import { IBaseProps } from "./base";
+import { BaseComponent, IBaseProps } from "./base";
 import { DocumentContentModelType } from "../models/document-content";
 import { ToolTileComponent } from "./canvas-tools/tool-tile";
 
@@ -12,8 +12,9 @@ interface IProps extends IBaseProps {
   readOnly?: boolean;
 }
 
+@inject("stores")
 @observer
-export class DocumentContentComponent extends React.Component<IProps, {}> {
+export class DocumentContentComponent extends BaseComponent<IProps, {}> {
 
   public render() {
     const { content, ...others } = this.props;
@@ -25,6 +26,7 @@ export class DocumentContentComponent extends React.Component<IProps, {}> {
                     : null;
     return (
       <div className="document-content"
+        onClick={this.handleClick}
         onDragOver={this.handleDragOver}
         onDrop={this.handleDrop}
       >
@@ -32,6 +34,15 @@ export class DocumentContentComponent extends React.Component<IProps, {}> {
         {this.props.children}
       </div>
     );
+  }
+
+  private handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    const { ui } = this.stores;
+    // deselect tiles on click on document background
+    // click must be on DocumentContent itself, not bubble up from child
+    if (e.target === e.currentTarget) {
+      ui.setSelectedTile();
+    }
   }
 
   private handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {


### PR DESCRIPTION
- Fix delete of text tool [[#160702405]]
  - text tool no longer deselects tile on loss of focus
  - text tool still selects on tile on focus
- Clicking on document background deselects currently selected tool
  - works for both text and geometry (and future) tools
- First click on geometry tile selects it; subsequent clicks on selected tile create points

