### PR TITLE
Added scrolling overflow to canvas

### DIFF
--- a/src/components/canvas.sass
+++ b/src/components/canvas.sass
@@ -6,6 +6,7 @@
   height: 100%
   width: 100%
   background-color: #fff
+  overflow: auto
 
   .document
     text-align: left

--- a/src/components/workspace.sass
+++ b/src/components/workspace.sass
@@ -87,7 +87,6 @@
     left: $workspace-toolbar-width
     right: 0
     border-top: 4px solid $workspace-border-color
-    overflow: scroll
 
   .learning-log-canvas-area
     .canvas

--- a/src/components/workspace.sass
+++ b/src/components/workspace.sass
@@ -87,6 +87,7 @@
     left: $workspace-toolbar-width
     right: 0
     border-top: 4px solid $workspace-border-color
+    overflow: scroll
 
   .learning-log-canvas-area
     .canvas


### PR DESCRIPTION
This is a trivial addition to the css for the canvas style. Played around with it for about a 1/2 hour and could find no visual anomalies or odd behavior -- that is, in the 1-up view.

However, in 4-up, all 4 documents and the splitter(s) are inside the scrolling area. And there is still some strange visual behavior with overflow.

Resolving this is a bit more work as it may go to the heart how the canvases and sub-canvases interact.

I suggest this quickie fix for 1-up be merged, for the moment, and the 4-up scrolling be addressed in a more lengthy user-story.