### PR TITLE
New Document Bugs

### DIFF
--- a/src/components/left-nav-panel.tsx
+++ b/src/components/left-nav-panel.tsx
@@ -72,7 +72,6 @@ export class LeftNavPanelComponent extends BaseComponent<IProps, {}> {
       }
       else {
         db.createSectionWorkspace(section.id)
-          .then(workspaces.addSectionWorkspace)
           .then(done)
           .catch(ui.setError);
       }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -763,7 +763,7 @@ export class DB {
       // otherwise set the groups
       this.stores.groups.updateFromDB(user.id, groups, this.stores.class);
 
-      Object.keys(this.groupUserSectionDocumentsListeners).forEach((sectionId) => {
+      workspaces.sections.map(workspace => workspace.sectionId).forEach((sectionId) => {
         const workspace = workspaces.getSectionWorkspace(sectionId);
         if (workspace) {
           this.updateGroupUserSectionDocumentListeners(workspace);


### PR DESCRIPTION
Demoing to Leslie this morning, I realized that newly-created documents didn't display group mates' work in the 4-up view. It turned out to be a similar problem to one I had seen before - this is what was happening:
- A workspace is opened for the first time and added to MST
- A listener is bound to the Firebase ref, which updates the workspace
- The workspace is stored in Firebase
- On child added in Firebase, we make a *new* workspace, and the ref listener gets rebound to update the new workspace, even though it isn't stored in MST
My first thought was to stop listening to workspace additions in Firebase, since we never need to see new ones, but I didn't want to break multi-tab use if I could avoid it. Instead, I keep track of workspaces we're in the process of creating, and ignore those when they come in from Firebase. Now, the process of creating a workspace either way should be identical.

It was pretty tricky to debug this, because the execution depends entirely on when the `child_added` event fires. I'd keep an eye out for other non-deterministic behavior as we go.