### PR TITLE
Fix new point creation on scaled canvases (e.g. 4-up view)

### DIFF
--- a/src/components/canvas-tools/geometry-tool.tsx
+++ b/src/components/canvas-tools/geometry-tool.tsx
@@ -16,6 +16,7 @@ interface SizeMeProps {
 
 interface IProps extends SizeMeProps {
   context: string;
+  scale?: number;
   model: ToolTileModelType;
   readOnly?: boolean;
 }
@@ -28,11 +29,11 @@ interface IState extends SizeMeProps {
 }
 
 // cf. https://jsxgraph.uni-bayreuth.de/wiki/index.php/Browser_event_and_coordinates
-function getEventCoords(board: JXG.Board, evt: any, index?: number) {
+function getEventCoords(board: JXG.Board, evt: any, scale?: number, index?: number) {
   const cPos = board.getCoordsTopLeftCorner();
   const absPos = JXG.getPosition(evt, index);
-  const dx = absPos[0] - cPos[0];
-  const dy = absPos[1] - cPos[1];
+  const dx = (absPos[0] - cPos[0]) / (scale || 1);
+  const dy = (absPos[1] - cPos[1]) / (scale || 1);
 
   return new JXG.Coords(JXG.COORDS_BY_SCREEN, [dx, dy], board);
 }
@@ -135,7 +136,7 @@ class GeometryToolComponent extends BaseComponent<IProps, IState> {
 
   private pointerDownHandler = (evt: any) => {
     const { board } = this.state;
-    const { model } = this.props;
+    const { model, scale } = this.props;
     const { ui } = this.stores;
     if (!board) { return; }
 
@@ -146,7 +147,7 @@ class GeometryToolComponent extends BaseComponent<IProps, IState> {
     }
 
     const index = evt[JXG.touchProperty] ? 0 : undefined;
-    const coords = getEventCoords(board, evt, index);
+    const coords = getEventCoords(board, evt, scale, index);
     const x = coords.usrCoords[1];
     const y = coords.usrCoords[2];
     if ((x != null) && isFinite(x) && (y != null) || isFinite(y)) {
@@ -158,10 +159,11 @@ class GeometryToolComponent extends BaseComponent<IProps, IState> {
   // cf. https://jsxgraph.uni-bayreuth.de/wiki/index.php/Browser_event_and_coordinates
   private pointerUpHandler = (evt: any) => {
     const { board } = this.state;
+    const { scale } = this.props;
     if (!board || !this.lastPtrDownEvent || !this.lastPtrDownCoords) { return; }
 
     const index = evt[JXG.touchProperty] ? 0 : undefined;
-    const coords = getEventCoords(board, evt, index);
+    const coords = getEventCoords(board, evt, scale, index);
     let [ , x, y] = this.lastPtrDownCoords.usrCoords;
     if ((x == null) || !isFinite(x) || (y == null) || !isFinite(y)) {
       return;

--- a/src/components/canvas.tsx
+++ b/src/components/canvas.tsx
@@ -9,6 +9,7 @@ import "./canvas.sass";
 
 interface IProps extends IBaseProps {
   context: string;
+  scale?: number;
   readOnly?: boolean;
   document?: DocumentModelType;
   content?: DocumentContentModelType;

--- a/src/components/four-up.tsx
+++ b/src/components/four-up.tsx
@@ -81,29 +81,33 @@ export class FourUpComponent extends BaseComponent<IProps, {}> {
           })
       : [];
 
+    const groupDoc = (index: number) => {
+      return groupUsers[index] && groupUsers[index].doc;
+    };
+
     return (
       <div className="four-up" ref={(el) => this.container = el}>
         <div className="canvas-container north-west" style={nwStyle}>
           <div className="canvas-scaler" style={scaleStyle(nwCell)}>
-            <CanvasComponent context="four-up-nw" document={workspace.document} />
+            <CanvasComponent context="four-up-nw" scale={nwCell.scale} document={workspace.document} />
           </div>
           <div className="member">{user.initials}</div>
         </div>
         <div className="canvas-container north-east" style={neStyle}>
           <div className="canvas-scaler" style={scaleStyle(neCell)}>
-            <CanvasComponent context="four-up-ne" document={groupUsers[0] && groupUsers[0].doc} />
+            <CanvasComponent context="four-up-ne" scale={neCell.scale} document={groupDoc(0)} />
           </div>
           {groupUsers[0] && <div className="member">{groupUsers[0].initials}</div>}
         </div>
         <div className="canvas-container south-east" style={seStyle}>
           <div className="canvas-scaler" style={scaleStyle(seCell)}>
-            <CanvasComponent context="four-up-se" document={groupUsers[1] && groupUsers[1].doc} />
+            <CanvasComponent context="four-up-se" scale={seCell.scale} document={groupDoc(1)} />
           </div>
           {groupUsers[1] && <div className="member">{groupUsers[1].initials}</div>}
         </div>
         <div className="canvas-container south-west" style={swStyle}>
           <div className="canvas-scaler" style={scaleStyle(swCell)}>
-            <CanvasComponent context="four-up-sw" document={groupUsers[2] && groupUsers[2].doc} />
+            <CanvasComponent context="four-up-sw" scale={swCell.scale} document={groupDoc(2)} />
           </div>
           {groupUsers[2] && <div className="member">{groupUsers[2].initials}</div>}
         </div>


### PR DESCRIPTION
Fix new point creation on scaled canvases (e.g. 4-up view)
- must account for scale factor in mouse coordinate conversions
- scale factor is passed down as prop through canvas
