### PR TITLE
Fix geometry tool drag image bug

### DIFF
--- a/src/components/canvas-tools/geometry-tool.tsx
+++ b/src/components/canvas-tools/geometry-tool.tsx
@@ -3,7 +3,7 @@ import { inject, observer } from "mobx-react";
 import { BaseComponent } from "../base";
 import { ToolTileModelType } from "../../models/tools/tool-tile";
 import { GeometryContentModelType } from "../../models/tools/geometry/geometry-content";
-import * as sizeMe from "react-sizeme";
+import { SizeMe } from "react-sizeme";
 
 import "./geometry-tool.sass";
 
@@ -43,7 +43,7 @@ function getEventCoords(board: JXG.Board, evt: any, scale?: number, index?: numb
 ​
 @inject("stores")
 @observer
-class GeometryToolComponent extends BaseComponent<IProps, IState> {
+class GeometryToolComponentImpl extends BaseComponent<IProps, IState> {
 
   public static getDerivedStateFromProps: any = (nextProps: IProps, prevState: IState) => {
     const { context, model: { id, content } } = nextProps;
@@ -205,4 +205,21 @@ class GeometryToolComponent extends BaseComponent<IProps, IState> {
   }
 }
 
-export default sizeMe()(GeometryToolComponent);
+export default class GeometryToolComponent extends React.Component<IProps, {}> {
+
+  public static getDragImageNode(dragTargetNode: HTMLElement) {
+    // dragTargetNode is the tool-tile div
+    // firstChild is SizeMe div
+    const child = dragTargetNode.firstChild;
+    // firstChild's firstChild is the actual SVG, which works as a drag image
+    return child && child.firstChild;
+  }
+
+  public render() {
+    return (
+      <SizeMe>
+        {() => <GeometryToolComponentImpl {...this.props} />}
+      </SizeMe>
+    );
+  }
+}

--- a/src/utilities/browser.ts
+++ b/src/utilities/browser.ts
@@ -1,0 +1,18 @@
+export function isChrome() {
+  // cf. https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent#Browser_Name
+  return (navigator.userAgent.indexOf("Chrome") >= 0) &&
+        (navigator.userAgent.indexOf("Chromium") < 0);
+}
+
+export function isFirefox() {
+  // cf. https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent#Browser_Name
+  return (navigator.userAgent.indexOf("Firefox") >= 0) &&
+        (navigator.userAgent.indexOf("Seamonkey") < 0);
+}
+
+export function isSafari() {
+  // cf. https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent#Browser_Name
+  return (navigator.userAgent.indexOf("Safari") >= 0) &&
+        (navigator.userAgent.indexOf("Chrome") < 0) &&
+        (navigator.userAgent.indexOf("Chromium") < 0);
+}

--- a/tslint.json
+++ b/tslint.json
@@ -7,6 +7,7 @@
     "jsx-curly-spacing": false,
     "jsx-no-multiline-js": false,
     "jsx-wrap-multiline": false,
+    "max-classes-per-file": false,
     "no-console": false,
     "no-debugger": false,
     "no-empty-interface": false,


### PR DESCRIPTION
After originally settling for an unsatisfactory workaround, it occurred to me that the problem might be related to the additional dom layer provided by the SizeMe component. It turns out that by using an appropriate child node for the drag image, reasonable drag image behavior can be achieved for the geometry tool.