### PR TITLE
Connect free points to form polygon (no selection)

### DIFF
--- a/src/components/canvas-tools/geometry-tool.tsx
+++ b/src/components/canvas-tools/geometry-tool.tsx
@@ -242,7 +242,6 @@ class GeometryToolComponentImpl extends BaseComponent<IProps, IState> {
 
     const handlePointerUp = (evt: any) => {
       const id = point.id;
-      const _uuid_ = (point as any)._uuid_;
       const dragEntry = this.dragPts[id];
       if (!dragEntry) { return; }
 
@@ -254,7 +253,7 @@ class GeometryToolComponentImpl extends BaseComponent<IProps, IState> {
         if ((content.type === "Geometry") && board) {
           const coords = dragEntry.final.usrCoords.slice(1);
           const props = { position: coords };
-          this.applyChange(() => content.updatePoints(board, _uuid_, props));
+          this.applyChange(() => content.updatePoints(board, id, props));
         }
       }
     };

--- a/src/models/tools/geometry/geometry-content.ts
+++ b/src/models/tools/geometry/geometry-content.ts
@@ -48,7 +48,7 @@ export const GeometryContentModel = types
         operation: "create",
         target: "point",
         parents,
-        properties: assign({ _uuid_: uuid() }, properties)
+        properties: assign({ id: uuid() }, properties)
       };
       return _applyChange(board, change);
     }

--- a/src/models/tools/geometry/geometry-content.ts
+++ b/src/models/tools/geometry/geometry-content.ts
@@ -1,6 +1,7 @@
 import { types, Instance } from "mobx-state-tree";
 import { applyChange, applyChanges } from "./jxg-dispatcher";
 import { JXGChange, JXGElement, JXGProperties } from "./jxg-changes";
+import { isFreePoint } from "./jxg-point";
 import { assign } from "lodash";
 import * as uuid from "uuid/v4";
 
@@ -63,6 +64,20 @@ export const GeometryContentModel = types
       return _applyChange(board, change);
     }
 
+    function connectFreePoints(board: JXG.Board) {
+      const freePtIds = board.objectsList
+                          .filter(elt => isFreePoint(elt))
+                          .map(pt => pt.id);
+      if (freePtIds && freePtIds.length > 1) {
+        const change: JXGChange = {
+                operation: "create",
+                target: "polygon",
+                parents: freePtIds
+              };
+        return _applyChange(board, change);
+      }
+    }
+
     function _applyChange(board: JXG.Board, change: JXGChange) {
       const result = syncChange(board, change);
       self.changes.push(JSON.stringify(change));
@@ -88,6 +103,7 @@ export const GeometryContentModel = types
         addChange,
         addPoint,
         updatePoints,
+        connectFreePoints,
         applyChange: _applyChange,
         syncChange
       }

--- a/src/models/tools/geometry/jsxgraph.d.ts
+++ b/src/models/tools/geometry/jsxgraph.d.ts
@@ -24,6 +24,8 @@ declare namespace JXG {
 
     objects: { [id: string]: any };
 
+    objectsList: any[];
+
     create: (elementType: string, parents?: any, attributes?: any) => any;
     on: (event: string, handler: (evt: any) => void) => void;
     getCoordsTopLeftCorner: () => number[];
@@ -45,13 +47,16 @@ declare namespace JXG {
   }
 
   class CoordsElement extends GeometryElement {
-
+    coords: JXG.Coords;
   }
 
   class GeometryElement {
+    id: string;
     type: number;
     visProp: { [prop: string]: any };
     fixed: boolean;
+
+    setAttribute: (attrs: any) => void;
   }
 
   const JSXGraph: {
@@ -59,8 +64,9 @@ declare namespace JXG {
     freeBoard: (board: JXG.Board | string) => void;
   };
 
-  class Point extends GeometryElement {
-
+  class Point extends CoordsElement {
+    on: (event: string, handler: (evt: any) => void) => void;
+    setPosition: (method: number, coords: number[]) => JXG.Point;
   }
 
   const _ceil10: (value: number, exp: number) => number;

--- a/src/models/tools/geometry/jsxgraph.d.ts
+++ b/src/models/tools/geometry/jsxgraph.d.ts
@@ -69,6 +69,9 @@ declare namespace JXG {
     setPosition: (method: number, coords: number[]) => JXG.Point;
   }
 
+  class Polygon extends GeometryElement {
+  }
+
   const _ceil10: (value: number, exp: number) => number;
   const _floor10: (value: number, exp: number) => number;
   const _round10: (value: number, exp: number) => number;

--- a/src/models/tools/geometry/jxg-board.ts
+++ b/src/models/tools/geometry/jxg-board.ts
@@ -1,8 +1,12 @@
 import { JXGChange, JXGChangeAgent } from "./jxg-changes";
 import "./jxg";
-import { assign } from "lodash";
+import { assign, find } from "lodash";
 
 export const isBoard = (v: any) => v instanceof JXG.Board;
+
+export const getElementByUuid = (board: JXG.Board, uuid: string): JXG.GeometryElement | undefined => {
+  return find(board.objectsList, elt => elt._uuid_ === uuid);
+};
 
 export const boardChangeAgent: JXGChangeAgent = {
   create: (board: JXG.Board|string, change: JXGChange) => {

--- a/src/models/tools/geometry/jxg-board.ts
+++ b/src/models/tools/geometry/jxg-board.ts
@@ -1,12 +1,8 @@
 import { JXGChange, JXGChangeAgent } from "./jxg-changes";
 import "./jxg";
-import { assign, find } from "lodash";
+import { assign } from "lodash";
 
 export const isBoard = (v: any) => v instanceof JXG.Board;
-
-export const getElementByUuid = (board: JXG.Board, uuid: string): JXG.GeometryElement | undefined => {
-  return find(board.objectsList, elt => elt._uuid_ === uuid);
-};
 
 export const boardChangeAgent: JXGChangeAgent = {
   create: (board: JXG.Board|string, change: JXGChange) => {

--- a/src/models/tools/geometry/jxg-changes.ts
+++ b/src/models/tools/geometry/jxg-changes.ts
@@ -1,13 +1,8 @@
 
 export type JXGOperation = "create" | "update" | "delete";
-export type JXGObjectType = "board" | "point";
+export type JXGObjectType = "board" | "point" | "polygon";
 
-export interface JXGObjectRef {
-  type: JXGObjectType;
-  id: string;
-}
-
-export type JXGParentType = JXGObjectRef | number;
+export type JXGParentType = string | number;
 
 export interface JXGProperties {
   [key: string]: any;

--- a/src/models/tools/geometry/jxg-changes.ts
+++ b/src/models/tools/geometry/jxg-changes.ts
@@ -18,14 +18,17 @@ export interface JXGChange {
   target: JXGObjectType;
   targetID?: string | string[];
   parents?: JXGParentType[];
-  properties?: JXGProperties;
+  properties?: JXGProperties | JXGProperties[];
 }
+
+export type JXGElement = JXG.Board | JXG.Point;
+export type JXGChangeResult = JXGElement | undefined;
 
 // for create/board the board parameter is the ID of the DOM element
 // for all other changes it should be the board
-export type JXGCreateHandler = (board: JXG.Board|string, change: JXGChange) => any;
-export type JXGUpdateHandler = (board: JXG.Board|string, change: JXGChange) => any;
-export type JXGDeleteHandler = (board: JXG.Board|string, change: JXGChange) => any;
+export type JXGCreateHandler = (board: JXG.Board|string, change: JXGChange) => JXGChangeResult;
+export type JXGUpdateHandler = (board: JXG.Board, change: JXGChange) => void;
+export type JXGDeleteHandler = (board: JXG.Board, change: JXGChange) => void;
 
 export interface JXGChangeAgent {
   create: JXGCreateHandler;

--- a/src/models/tools/geometry/jxg-dispatcher.ts
+++ b/src/models/tools/geometry/jxg-dispatcher.ts
@@ -1,4 +1,4 @@
-import { JXGChange, JXGChangeAgent } from "./jxg-changes";
+import { JXGChange, JXGChangeAgent, JXGChangeResult, JXGCreateHandler } from "./jxg-changes";
 import { boardChangeAgent, isBoard } from "./jxg-board";
 import { pointChangeAgent } from "./jxg-point";
 
@@ -11,22 +11,22 @@ const agents: JXGChangeAgents = {
   point: pointChangeAgent
 };
 
-export function applyChanges(board: JXG.Board|string, changes: JXGChange[]) {
+export function applyChanges(board: JXG.Board|string, changes: JXGChange[]): JXGChangeResult[] {
   let _board: JXG.Board | undefined;
-  changes.forEach(change => {
-    const result = applyChange(_board || board, change);
-    if ((typeof board === "string") && isBoard(result)) {
-      _board = result as JXG.Board;
-    }
-  });
-  return _board;
+  return changes.map(change => {
+          const result = applyChange(_board || board, change);
+          if ((typeof board === "string") && isBoard(result)) {
+            _board = result as JXG.Board;
+          }
+          return result;
+        });
 }
 
-export function applyChange(board: JXG.Board|string, change: JXGChange): JXG.Board | undefined {
+export function applyChange(board: JXG.Board|string, change: JXGChange): JXGChangeResult {
   const target = change.target.toLowerCase();
   const agent = agents[target];
   const handler = agent && agent[change.operation];
   return handler
-          ? handler(board, change)
-          : (isBoard(board) ? board : undefined);
+          ? (handler as JXGCreateHandler)(board, change)
+          : undefined;
 }

--- a/src/models/tools/geometry/jxg-dispatcher.ts
+++ b/src/models/tools/geometry/jxg-dispatcher.ts
@@ -1,6 +1,7 @@
 import { JXGChange, JXGChangeAgent, JXGChangeResult, JXGCreateHandler } from "./jxg-changes";
 import { boardChangeAgent, isBoard } from "./jxg-board";
 import { pointChangeAgent } from "./jxg-point";
+import { polygonChangeAgent } from "./jxg-polygon";
 
 interface JXGChangeAgents {
   [key: string]: JXGChangeAgent;
@@ -8,7 +9,8 @@ interface JXGChangeAgents {
 
 const agents: JXGChangeAgents = {
   board: boardChangeAgent,
-  point: pointChangeAgent
+  point: pointChangeAgent,
+  polygon: polygonChangeAgent
 };
 
 export function applyChanges(board: JXG.Board|string, changes: JXGChange[]): JXGChangeResult[] {

--- a/src/models/tools/geometry/jxg-point.ts
+++ b/src/models/tools/geometry/jxg-point.ts
@@ -1,16 +1,39 @@
+import { getElementByUuid } from "./jxg-board";
 import { JXGChangeAgent } from "./jxg-changes";
+import * as uuid from "uuid/v4";
+
+export const isPoint = (v: any) => v instanceof JXG.Point;
 
 export const pointChangeAgent: JXGChangeAgent = {
   create: (board, change) => {
-    const point = (board as JXG.Board).create("point", change.parents, change.properties);
-    return board;
+    const { _uuid_, ...otherProps } = (change.properties || {}) as any;
+    const pt = (board as JXG.Board).create("point", change.parents, otherProps);
+    if (pt) {
+      // If uuid is not provided we generate one, but this will prevent
+      // model-level synchronization. This should only occur for very
+      // old geometry tiles created before the introduction of the uuid.
+      pt._uuid_ = _uuid_ || uuid();
+    }
+    return pt;
   },
 
   update: (board, change) => {
-    return board;
+    if (!change.targetID || !change.properties) { return; }
+    const ids = Array.isArray(change.targetID) ? change.targetID : [change.targetID];
+    const props = Array.isArray(change.properties) ? change.properties : [change.properties];
+    ids.forEach((id, index) => {
+      const pt = getElementByUuid(board, id) as JXG.Point;
+      if (pt) {
+        const p = props[index];
+        if (p.position != null) {
+          pt.setPosition(JXG.COORDS_BY_USER, p.position);
+        }
+      }
+    });
+    board.update();
   },
 
   delete: (board, change) => {
-    return board;
+    // delete stuff
   }
 };

--- a/src/models/tools/geometry/jxg-point.ts
+++ b/src/models/tools/geometry/jxg-point.ts
@@ -1,20 +1,19 @@
-import { getElementByUuid } from "./jxg-board";
 import { JXGChangeAgent } from "./jxg-changes";
+import { assign } from "lodash";
 import * as uuid from "uuid/v4";
 
 export const isPoint = (v: any) => v instanceof JXG.Point;
 
 export const pointChangeAgent: JXGChangeAgent = {
   create: (board, change) => {
-    const { _uuid_, ...otherProps } = (change.properties || {}) as any;
-    const pt = (board as JXG.Board).create("point", change.parents, otherProps);
-    if (pt) {
-      // If uuid is not provided we generate one, but this will prevent
-      // model-level synchronization. This should only occur for very
-      // old geometry tiles created before the introduction of the uuid.
-      pt._uuid_ = _uuid_ || uuid();
-    }
-    return pt;
+    const changeProps: any = change.properties || {};
+    const props = changeProps.id
+                    ? changeProps
+                    // If id is not provided we generate one, but this will prevent
+                    // model-level synchronization. This should only occur for very
+                    // old geometry tiles created before the introduction of the uuid.
+                    : assign({ id: uuid() }, changeProps);
+    return (board as JXG.Board).create("point", change.parents, props);
   },
 
   update: (board, change) => {
@@ -22,7 +21,7 @@ export const pointChangeAgent: JXGChangeAgent = {
     const ids = Array.isArray(change.targetID) ? change.targetID : [change.targetID];
     const props = Array.isArray(change.properties) ? change.properties : [change.properties];
     ids.forEach((id, index) => {
-      const pt = getElementByUuid(board, id) as JXG.Point;
+      const pt = board.objects[id] as JXG.Point;
       if (pt) {
         const p = props[index];
         if (p.position != null) {

--- a/src/models/tools/geometry/jxg-point.ts
+++ b/src/models/tools/geometry/jxg-point.ts
@@ -1,8 +1,11 @@
 import { JXGChangeAgent } from "./jxg-changes";
-import { assign } from "lodash";
+import { assign, size } from "lodash";
 import * as uuid from "uuid/v4";
 
 export const isPoint = (v: any) => v instanceof JXG.Point;
+
+export const isFreePoint = (v: any) => isPoint(v) && v.hasLabel &&
+                                        (size(v.childElements) <= 1) && (size(v.descendants) <= 1);
 
 export const pointChangeAgent: JXGChangeAgent = {
   create: (board, change) => {

--- a/src/models/tools/geometry/jxg-polygon.ts
+++ b/src/models/tools/geometry/jxg-polygon.ts
@@ -1,0 +1,19 @@
+import { JXGChange, JXGChangeAgent } from "./jxg-changes";
+import "./jxg";
+
+export const isPolygon = (v: any) => v instanceof JXG.Polygon;
+
+export const polygonChangeAgent: JXGChangeAgent = {
+  create: (board: JXG.Board, change: JXGChange) => {
+    const parents = (change.parents || []).map(id => board.objects[id]);
+    return board.create("polygon", parents);
+  },
+
+  update: (board: JXG.Board, change: JXGChange) => {
+    return;
+  },
+
+  delete: (board: JXG.Board, change: JXGChange) => {
+    return;
+  }
+};


### PR DESCRIPTION
Implement double-click on free point to connect free points into polygon [#160575042]

It occurred to me that I could bypass the issue of needing a selection model by having a double-click on a free point automatically connect all free points, i.e. all points not otherwise connected to anything. Polygons for the win!

Note: this PR is built on the previous PR #69, which should be reviewed/merged first, after which this PR can be rebased to master.