### PR TITLE
Add/improve geometry tool unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
       "^.+\\.tsx?$": "ts-jest"
     },
     "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
+    "coveragePathIgnorePatterns": [
+      "/node_modules/",
+      "src/utilities/test-utils.ts"
+    ],
     "moduleNameMapper": {
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
       "\\.(css|less|sass)$": "<rootDir>/__mocks__/styleMock.js"

--- a/src/components/canvas-tools/geometry-tool.tsx
+++ b/src/components/canvas-tools/geometry-tool.tsx
@@ -5,6 +5,7 @@ import { ToolTileModelType } from "../../models/tools/tool-tile";
 import { GeometryContentModelType } from "../../models/tools/geometry/geometry-content";
 import { isBoard } from "../../models/tools/geometry/jxg-board";
 import { isPoint, isFreePoint } from "../../models/tools/geometry/jxg-point";
+import { JXGCoordPair } from "../../models/tools/geometry/jxg-changes";
 import { assign, cloneDeep, isEqual } from "lodash";
 import { SizeMe } from "react-sizeme";
 
@@ -272,9 +273,9 @@ class GeometryToolComponentImpl extends BaseComponent<IProps, IState> {
         const { content } = this.props.model;
         const { board } = this.state;
         if ((content.type === "Geometry") && board) {
-          const coords = dragEntry.final.usrCoords.slice(1);
+          const coords = dragEntry.final.usrCoords.slice(1) as JXGCoordPair;
           const props = { position: coords };
-          this.applyChange(() => content.updatePoints(board, id, props));
+          this.applyChange(() => content.updateObjects(board, id, props));
         }
       }
     };

--- a/src/models/document-content.ts
+++ b/src/models/document-content.ts
@@ -1,5 +1,6 @@
 import { types, Instance } from "mobx-state-tree";
 import { DataSet } from "./data/data-set";
+import { defaultGeometryContent, kGeometryDefaultHeight } from "./tools/geometry/geometry-content";
 import { ToolTileModel, ToolTileModelType } from "./tools/tool-tile";
 
 export const DocumentContentModel = types
@@ -17,28 +18,11 @@ export const DocumentContentModel = types
   })
   .actions((self) => ({
     addGeometryTile() {
-      const axisMin = -0.5;
-      const xAxisMax = 20;
-      const yAxisMax = 5;
-      const createBoardChange = {
-        operation: "create",
-        target: "board",
-        properties: {
-          axis: true,
-          boundingBox: [axisMin, yAxisMax, xAxisMax, axisMin],
-          grid: {}, // defaults to 1-unit gridlines
-          minimizeReflow: "none"
-        }
-      };
-      const changeJson = JSON.stringify(createBoardChange);
       self.tiles.push(ToolTileModel.create({
         layout: {
-          height: 200
+          height: kGeometryDefaultHeight
         },
-        content: {
-          type: "Geometry",
-          changes: [changeJson]
-        }
+        content: defaultGeometryContent()
       }));
     },
     addTextTile(initialText?: string) {

--- a/src/models/tools/geometry/geometry-content.test.ts
+++ b/src/models/tools/geometry/geometry-content.test.ts
@@ -1,0 +1,129 @@
+import { GeometryContentModel, GeometryContentModelType,
+          kGeometryToolID, defaultGeometryContent } from "./geometry-content";
+import { JXGChange } from "./jxg-changes";
+import { isBoard } from "./jxg-board";
+import { isPoint, isFreePoint } from "./jxg-point";
+import { isPolygon } from "./jxg-polygon";
+import { isUuid } from "../../../utilities/test-utils";
+import { clone } from "lodash";
+
+describe("GeometryContent", () => {
+
+  it("can create with default properties", () => {
+    const content = GeometryContentModel.create();
+    expect(content.type).toBe(kGeometryToolID);
+    expect(content.changes).toEqual([]);
+
+    expect(content.nextViewId).toBe(1);
+    expect(content.nextViewId).toBe(2);
+  });
+
+  function createDefaultBoard(content: GeometryContentModelType, readOnly: boolean = false): JXG.Board {
+    const divId = "1234";
+    const divStyle = "width:200px;height:200px";
+    document.body.innerHTML = `<div id="${divId}" style="${divStyle}"></div>`;
+
+    const elts = content.initializeBoard(divId, readOnly);
+    return elts[0] as JXG.Board;
+  }
+
+  it("can create/destroy a JSXGraph board", () => {
+    const content = defaultGeometryContent();
+    expect(content.nextViewId).toBe(1);
+
+    let board = createDefaultBoard(content);
+    expect(isBoard(board)).toBe(true);
+    expect(isUuid(board.id)).toBe(true);
+
+    content.resizeBoard(board, 200, 200);
+
+    content.destroyBoard(board);
+
+    content.addChange({ operation: "create", target: "point", parents: [1, 1] });
+    board = createDefaultBoard(content, true);
+    expect(isBoard(board)).toBe(true);
+    const boardId = board.id;
+
+    const boundingBox = clone(board.boundingBox);
+    const change: JXGChange = {
+            operation: "update",
+            target: "board",
+            targetID: boardId,
+            properties: { boundingBox }
+          };
+    content.applyChange(board, change);
+
+    const badChange: JXGChange = { operation: "update", target: "board", targetID: "foo" };
+    content.applyChange(board, badChange);
+    badChange.properties = {};
+    content.applyChange(board, badChange);
+    badChange.targetID = [boardId, boardId];
+    badChange.properties = [{}];
+    content.applyChange(board, badChange);
+
+    content.syncChange(null as any as JXG.Board, null as any as JXGChange);
+
+    const polygon = content.connectFreePoints(board);
+    expect(polygon).toBeUndefined();
+
+    // can delete board with change
+    content.applyChange(board, { operation: "delete", target: "board", targetID: boardId });
+  });
+
+  it("can add/remove/update points", () => {
+    const content = defaultGeometryContent();
+    const board = createDefaultBoard(content);
+    expect(isPoint(board)).toBe(false);
+    const p1Id = "point-1";
+    let p1: JXG.Point = board.objects[p1Id];
+    expect(p1).toBeUndefined();
+    p1 = content.addPoint(board, [1, 1], { id: p1Id }) as JXG.Point;
+    expect(isPoint(p1)).toBe(true);
+    expect(isFreePoint(p1)).toBe(true);
+    // won't create generic objects
+    const obj = content.applyChange(board, { operation: "create", target: "object" });
+    expect(obj).toBeUndefined();
+    // ignores changes to unknown objects
+    content.applyChange(board, { operation: "create", target: "foo" } as any as JXGChange);
+    // auto-generates ids if asked to create a point without an id
+    const p2Change: JXGChange = { operation: "create", parents: [0, 0], target: "point" };
+    const p2: JXG.Point = content.applyChange(board, p2Change) as JXG.Point;
+    expect(p2.id).toBeDefined();
+    expect(p1.coords.usrCoords).toEqual([1, 1, 1]);
+    expect(p1.getAttribute("fixed")).toBe(false);
+    content.updateObjects(board, p1Id, { position: [2, 2] });
+    expect(p1.coords.usrCoords).toEqual([1, 2, 2]);
+    content.updateObjects(board, p1Id, { fixed: true });
+    expect(p1.getAttribute("fixed")).toBe(true);
+    content.updateObjects(board, [p1Id, p1Id], { fixed: false });
+    expect(p1.getAttribute("fixed")).toBe(false);
+    content.updateObjects(board, [p1Id, p1Id], [{ fixed: true }, { fixed: true }]);
+    expect(p1.getAttribute("fixed")).toBe(true);
+    content.updateObjects(board, "foo", { });
+    content.applyChange(board, { operation: "update", target: "point" });
+    content.removeObjects(board, p1Id);
+    expect(board.objects[p1Id]).toBeUndefined();
+    const p3: JXG.Point = content.addPoint(board, [2, 2]) as JXG.Point;
+    expect(isUuid(p3.id)).toBe(true);
+    // requests to remove points with invalid IDs are ignored
+    content.removeObjects(board, ["foo"]);
+    content.applyChange(board, { operation: "delete", target: "point" });
+  });
+
+  it("can add/remove/update polygons", () => {
+    const content = defaultGeometryContent();
+    content.addChange({ operation: "create", target: "point", parents: [1, 1], properties: { id: "p1" } });
+    content.addChange({ operation: "create", target: "point", parents: [3, 3], properties: { id: "p2" } });
+    content.addChange({ operation: "create", target: "point", parents: [5, 1], properties: { id: "p3" } });
+    const board = createDefaultBoard(content);
+    let polygon: JXG.Polygon | undefined = content.connectFreePoints(board) as JXG.Polygon;
+    expect(isPolygon(polygon)).toBe(true);
+    const polygonId = polygon.id;
+    expect(isUuid(polygonId)).toBe(true);
+    content.removeObjects(board, polygonId);
+    expect(board.objects[polygonId]).toBeUndefined();
+    // can't create polygon without vertices
+    polygon = content.applyChange(board, { operation: "create", target: "polygon" }) as JXG.Polygon;
+    expect(polygon).toBeUndefined();
+  });
+});

--- a/src/models/tools/geometry/jsxgraph.d.ts
+++ b/src/models/tools/geometry/jsxgraph.d.ts
@@ -9,7 +9,10 @@ declare namespace JXG {
 
   const touchProperty: string;
 
+  const boards: { [id: string]: Board };
+
   class Board {
+    id: string;
     axis: boolean;
     boundingBox: number[];
     canvasWidth: number;
@@ -27,10 +30,12 @@ declare namespace JXG {
     objectsList: any[];
 
     create: (elementType: string, parents?: any, attributes?: any) => any;
+    removeObject: (object: GeometryElement) => void;
     on: (event: string, handler: (evt: any) => void) => void;
     getCoordsTopLeftCorner: () => number[];
     resizeContainer: (canvasWidth: number, canvasHeight: number,
                       dontSet?: boolean, dontSetBoundingBox?: boolean) => void;
+    setBoundingBox: (boundingBox: number[]) => void;
     update: (drag?: JXG.GeometryElement) => void;
   }
 
@@ -56,7 +61,9 @@ declare namespace JXG {
     visProp: { [prop: string]: any };
     fixed: boolean;
 
+    getAttribute: (key: string) => any;
     setAttribute: (attrs: any) => void;
+    setPosition: (method: number, coords: number[]) => JXG.Point;
   }
 
   const JSXGraph: {
@@ -66,7 +73,6 @@ declare namespace JXG {
 
   class Point extends CoordsElement {
     on: (event: string, handler: (evt: any) => void) => void;
-    setPosition: (method: number, coords: number[]) => JXG.Point;
   }
 
   class Polygon extends GeometryElement {

--- a/src/models/tools/geometry/jxg-board.ts
+++ b/src/models/tools/geometry/jxg-board.ts
@@ -1,6 +1,6 @@
 import { JXGChange, JXGChangeAgent } from "./jxg-changes";
 import "./jxg";
-import { assign } from "lodash";
+import { assign, each } from "lodash";
 
 export const isBoard = (v: any) => v instanceof JXG.Board;
 
@@ -10,18 +10,34 @@ export const boardChangeAgent: JXGChangeAgent = {
     const defaults = {
             keepaspectratio: true,
             showCopyright: false,
-            showNavigation: false
+            showNavigation: false,
+            minimizeReflow: "none"
           };
     const props = assign(defaults, change.properties);
     return JXG.JSXGraph.initBoard(domElementID, props);
   },
 
   update: (board: JXG.Board, change: JXGChange) => {
-    return board;
+    if (!change.targetID || !change.properties) { return; }
+    const ids = Array.isArray(change.targetID) ? change.targetID : [change.targetID];
+    const props = Array.isArray(change.properties) ? change.properties : [change.properties];
+    ids.forEach((id, index) => {
+      const brd = JXG.boards[id];
+      const brdProps = index < props.length ? props[index] : props[0];
+      if (brd && brdProps) {
+        each(brdProps, (value, prop) => {
+          switch (prop) {
+            case "boundingBox":
+              brd.setBoundingBox(value);
+              break;
+          }
+        });
+        brd.update();
+      }
+    });
   },
 
   delete: (board: JXG.Board, change: JXGChange) => {
     JXG.JSXGraph.freeBoard(board);
-    return undefined;
   }
 };

--- a/src/models/tools/geometry/jxg-changes.ts
+++ b/src/models/tools/geometry/jxg-changes.ts
@@ -1,10 +1,13 @@
 
 export type JXGOperation = "create" | "update" | "delete";
-export type JXGObjectType = "board" | "point" | "polygon";
+export type JXGObjectType = "board" | "object" | "point" | "polygon";
 
 export type JXGParentType = string | number;
 
+export type JXGCoordPair = [number, number];
+
 export interface JXGProperties {
+  position?: JXGCoordPair;
   [key: string]: any;
 }
 

--- a/src/models/tools/geometry/jxg-dispatcher.ts
+++ b/src/models/tools/geometry/jxg-dispatcher.ts
@@ -1,5 +1,6 @@
 import { JXGChange, JXGChangeAgent, JXGChangeResult, JXGCreateHandler } from "./jxg-changes";
 import { boardChangeAgent, isBoard } from "./jxg-board";
+import { objectChangeAgent } from "./jxg-object";
 import { pointChangeAgent } from "./jxg-point";
 import { polygonChangeAgent } from "./jxg-polygon";
 
@@ -9,6 +10,7 @@ interface JXGChangeAgents {
 
 const agents: JXGChangeAgents = {
   board: boardChangeAgent,
+  object: objectChangeAgent,
   point: pointChangeAgent,
   polygon: polygonChangeAgent
 };

--- a/src/models/tools/geometry/jxg-object.ts
+++ b/src/models/tools/geometry/jxg-object.ts
@@ -1,0 +1,41 @@
+import { JXGChangeAgent } from "./jxg-changes";
+import { size } from "lodash";
+
+export const objectChangeAgent: JXGChangeAgent = {
+  create: (board, change) => {
+    // can't create generic objects
+    return undefined;
+  },
+
+  update: (board, change) => {
+    if (!change.targetID || !change.properties) { return; }
+    const ids = Array.isArray(change.targetID) ? change.targetID : [change.targetID];
+    const props = Array.isArray(change.properties) ? change.properties : [change.properties];
+    ids.forEach((id, index) => {
+      const obj = board.objects[id] as JXG.GeometryElement;
+      const objProps = index < props.length ? props[index] : props[0];
+      if (obj && objProps) {
+        const { position, ...others } = objProps;
+        if (position != null) {
+          obj.setPosition(JXG.COORDS_BY_USER, position);
+        }
+        if (size(others)) {
+          obj.setAttribute(others);
+        }
+      }
+    });
+    board.update();
+  },
+
+  delete: (board, change) => {
+    if (!change.targetID) { return; }
+    const ids = Array.isArray(change.targetID) ? change.targetID : [change.targetID];
+    ids.forEach((id) => {
+      const obj = board.objects[id] as JXG.GeometryElement;
+      if (obj) {
+        board.removeObject(obj);
+      }
+    });
+    board.update();
+  }
+};

--- a/src/models/tools/geometry/jxg-point.ts
+++ b/src/models/tools/geometry/jxg-point.ts
@@ -1,4 +1,5 @@
 import { JXGChangeAgent } from "./jxg-changes";
+import { objectChangeAgent } from "./jxg-object";
 import { assign, size } from "lodash";
 import * as uuid from "uuid/v4";
 
@@ -19,23 +20,9 @@ export const pointChangeAgent: JXGChangeAgent = {
     return (board as JXG.Board).create("point", change.parents, props);
   },
 
-  update: (board, change) => {
-    if (!change.targetID || !change.properties) { return; }
-    const ids = Array.isArray(change.targetID) ? change.targetID : [change.targetID];
-    const props = Array.isArray(change.properties) ? change.properties : [change.properties];
-    ids.forEach((id, index) => {
-      const pt = board.objects[id] as JXG.Point;
-      if (pt) {
-        const p = props[index];
-        if (p.position != null) {
-          pt.setPosition(JXG.COORDS_BY_USER, p.position);
-        }
-      }
-    });
-    board.update();
-  },
+  // update can be handled generically
+  update: objectChangeAgent.update,
 
-  delete: (board, change) => {
-    // delete stuff
-  }
+  // delete can be handled generically
+  delete: objectChangeAgent.delete
 };

--- a/src/models/tools/geometry/jxg-polygon.ts
+++ b/src/models/tools/geometry/jxg-polygon.ts
@@ -1,19 +1,20 @@
 import { JXGChange, JXGChangeAgent } from "./jxg-changes";
-import "./jxg";
+import { objectChangeAgent } from "./jxg-object";
+import { assign } from "lodash";
+import * as uuid from "uuid/v4";
 
 export const isPolygon = (v: any) => v instanceof JXG.Polygon;
 
 export const polygonChangeAgent: JXGChangeAgent = {
   create: (board: JXG.Board, change: JXGChange) => {
     const parents = (change.parents || []).map(id => board.objects[id]);
-    return board.create("polygon", parents);
+    const props = assign({ id: uuid() }, change.properties);
+    return parents.length ? board.create("polygon", parents) : undefined;
   },
 
-  update: (board: JXG.Board, change: JXGChange) => {
-    return;
-  },
+  // update can be handled generically
+  update: objectChangeAgent.update,
 
-  delete: (board: JXG.Board, change: JXGChange) => {
-    return;
-  }
+  // delete can be handled generically
+  delete: objectChangeAgent.delete
 };

--- a/src/utilities/test-utils.ts
+++ b/src/utilities/test-utils.ts
@@ -1,6 +1,10 @@
 import { each, isObject, isUndefined, unset } from "lodash";
 import * as ReactDOMServer from "react-dom/server";
 
+export const isUuid = (id: string) => {
+  return /[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}/.test(id);
+};
+
 // Recursively removes properties whose values are undefined.
 // The specified object is modified in place and returned.
 // cf. https://stackoverflow.com/a/37250225


### PR DESCRIPTION
Add/improve geometry tool unit tests [#160687622]
```
 PASS  src/models/tools/geometry/geometry-content.test.ts
  GeometryContent
    ✓ can create with default properties (13ms)
    ✓ can create/destroy a JSXGraph board (135ms)
    ✓ can add/remove/update points (41ms)
    ✓ can add/remove/update polygons (43ms)

---------------------|----------|----------|----------|----------|-------------------|
File                 |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
---------------------|----------|----------|----------|----------|-------------------|
All files            |      100 |      100 |      100 |      100 |                   |
 geometry-content.ts |      100 |      100 |      100 |      100 |                   |
 jxg-board.ts        |      100 |      100 |      100 |      100 |                   |
 jxg-dispatcher.ts   |      100 |      100 |      100 |      100 |                   |
 jxg-object.ts       |      100 |      100 |      100 |      100 |                   |
 jxg-point.ts        |      100 |      100 |      100 |      100 |                   |
 jxg-polygon.ts      |      100 |      100 |      100 |      100 |                   |
 jxg.ts              |      100 |      100 |      100 |      100 |                   |
---------------------|----------|----------|----------|----------|-------------------|
Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        2.216s
```
