### PR TITLE
Fixed learning log title wrapping [#160797339]

### DIFF
--- a/src/components/learning-log.sass
+++ b/src/components/learning-log.sass
@@ -85,12 +85,14 @@ $button-width: 60px;
         float: left
         margin: 0 $half-margin
         overflow: hidden
+        width: ($list-item-width * $list-item-scale) + $double-margin
 
         .scaled-list-item-container
           position: relative
           border: 1px solid #aaa
           width: $list-item-width * $list-item-scale
           height: $list-item-height * $list-item-scale
+          margin: 0 $margin
 
           .scaled-list-item
             position: absolute
@@ -107,6 +109,11 @@ $button-width: 60px;
           margin-top: $half-margin
           text-align: center
           font-size: 0.8em
+
+          .title
+            white-space: nowrap
+            overflow: hidden
+            text-overflow: ellipsis
 
           .created
             font-style: italic

--- a/src/components/learning-log.tsx
+++ b/src/components/learning-log.tsx
@@ -116,7 +116,12 @@ export class LearningLogComponent extends BaseComponent<IProps, {}> {
                 </div>
               </div>
               <div className="info">
-                <span onClick={this.handleRenameLearningLog(learningLog)}>{learningLog.title}</span>
+                <div
+                  className="title"
+                  title={learningLog.title}
+                  onClick={this.handleRenameLearningLog(learningLog)}>
+                    {learningLog.title}
+                </div>
                 <div className="created" title={niceDateTime(learningLog.createdAt)}>
                   {timeAgo(learningLog.createdAt)}
                 </div>

--- a/src/components/workspace.sass
+++ b/src/components/workspace.sass
@@ -29,8 +29,11 @@
     .title
       flex-grow: 1
       text-align: center
-      margin: $margin 0
+      padding: $margin
       font-weight: bold
+      white-space: nowrap
+      overflow: hidden
+      text-overflow: ellipsis
 
     .actions
       flex-grow: 0


### PR DESCRIPTION
Fixed title wrapping looks like this now (with right nav tabs hidden to show the titlebar fully):

![image](https://user-images.githubusercontent.com/112938/46286108-e92c1700-c54b-11e8-9aae-adfaff8e83cf.png)
