### PR TITLE
Fixed non-unique offeringId per problem in dev mode [#160796641]

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -12,8 +12,9 @@ interface IProps extends IBaseProps {}
 export class HeaderComponent extends BaseComponent<IProps, {}> {
 
   public render() {
-    const {user, problem, groups} = this.stores;
+    const {appMode, db, user, problem, groups} = this.stores;
     const myGroup = groups.groupForUser(user.id);
+    const userTitle = appMode !== "authed" ? `Firebase UID: ${db.firebaseUserId}` : undefined;
 
     return (
       <div className="header">
@@ -25,7 +26,7 @@ export class HeaderComponent extends BaseComponent<IProps, {}> {
         </div>
         {myGroup ? this.renderGroup(myGroup) : null}
         <div className="user">
-          <div className="name">{user.name}</div>
+          <div className="name" title={userTitle}>{user.name}</div>
         </div>
       </div>
     );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,7 +7,7 @@ import { createStores } from "./models/stores";
 import { UserModel } from "./models/user";
 import { createFromJson } from "./models/curriculum/unit";
 import * as curriculumJson from "./curriculum/stretching-and-shrinking/stretching-and-shrinking.json";
-import { urlParams } from "./utilities/url-params";
+import { urlParams, DefaultProblemOrdinal } from "./utilities/url-params";
 import { getAppMode } from "./lib/auth";
 
 import "./index.sass";
@@ -18,10 +18,9 @@ const appMode = getAppMode(urlParams.appMode, urlParams.token, host);
 const user = UserModel.create();
 
 const unit = createFromJson(curriculumJson);
-const defaultProblemOrdinal = "2.1";
-const problemOrdinal = urlParams.problem || defaultProblemOrdinal;
+const problemOrdinal = urlParams.problem || DefaultProblemOrdinal;
 const {investigation, problem} = unit.getProblem(problemOrdinal) ||
-                                 unit.getProblem(defaultProblemOrdinal);
+                                 unit.getProblem(DefaultProblemOrdinal);
 const showDemoCreator = urlParams.demo;
 const stores = createStores({ appMode, user, problem, showDemoCreator, unit });
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -93,6 +93,10 @@ export class DB {
     return this.firebaseUser !== null;
   }
 
+  public get firebaseUserId() {
+    return this.firebaseUser ? this.firebaseUser.uid : "no-user-id";
+  }
+
   public connect(options: IDBConnectOptions) {
     return new Promise<void>((resolve, reject) => {
       if (this.isConnected) {
@@ -459,7 +463,7 @@ export class DB {
     const parts = [`${appMode}`];
 
     if ((appMode === "dev") || (appMode === "test")) {
-      parts.push(this.firebaseUser ? `${this.firebaseUser.uid}` : "no-user-id");
+      parts.push(this.firebaseUserId);
     }
     parts.push("portals");
     parts.push(this.escapeKey(this.stores.user.portal));

--- a/src/utilities/url-params.ts
+++ b/src/utilities/url-params.ts
@@ -2,6 +2,8 @@ import { parse } from "query-string";
 import { AppMode } from "../models/stores";
 import { DBClearLevel } from "../lib/db";
 
+export const DefaultProblemOrdinal = "2.1";
+
 export interface QueryParams {
   // appMode is "authed", "test" or "dev" with the default of dev
   appMode?: AppMode;
@@ -55,7 +57,7 @@ const params = parse(location.search);
 // allows use of ?demo for url
 params.demo = typeof params.demo !== "undefined";
 
-export const defaultUrlParams: QueryParams = {
+export const DefaultUrlParams: QueryParams = {
   appMode: "dev",
   problem: undefined,
   token: undefined,


### PR DESCRIPTION
Previously dev mode would use a constant offeringId of "1" which caused the section documents to be persistent across problems.

This change generates a unique offeringId based on the problem in the urlParams.

This change also adds a debug helper: in non-authed mode when you hover over the username you will now see the firebase uid.