### PR TITLE
Make polygon creation more robust to model generation

### DIFF
--- a/src/models/tools/geometry/jxg-polygon.ts
+++ b/src/models/tools/geometry/jxg-polygon.ts
@@ -7,9 +7,11 @@ export const isPolygon = (v: any) => v instanceof JXG.Polygon;
 
 export const polygonChangeAgent: JXGChangeAgent = {
   create: (board: JXG.Board, change: JXGChange) => {
-    const parents = (change.parents || []).map(id => board.objects[id]);
+    const parents = (change.parents || [])
+                      .map(id => board.objects[id])
+                      .filter(pt => pt != null);
     const props = assign({ id: uuid() }, change.properties);
-    return parents.length ? board.create("polygon", parents) : undefined;
+    return parents.length ? board.create("polygon", parents, props) : undefined;
   },
 
   // update can be handled generically


### PR DESCRIPTION
- Dave ended up in a situation in which content created on a branch with an older version of the geometry code wouldn't open when he rebased to the current version of the code. This makes the creation of polygons more robust to such changes.