### PR TITLE
Add lint:unused script

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "lint": "tslint -c tslint.json 'src/**/*.{ts,tsx}'",
     "lint:build": "tslint -c tslint-build.json 'src/**/*.{ts,tsx}'",
     "lint:fix": "tslint -c tslint-build.json --fix 'src/**/*.{ts,tsx}'",
+    "lint:unused": "tsc --noUnusedLocals --project .",
     "test": "jest",
     "test:all": "npm-run-all build test start",
     "test:coverage": "jest --coverage",

--- a/src/models/data/attribute.ts
+++ b/src/models/data/attribute.ts
@@ -1,4 +1,4 @@
-import { types, Instance, SnapshotIn, SnapshotOut } from "mobx-state-tree";
+import { types, Instance, SnapshotOut } from "mobx-state-tree";
 import * as uuid from "uuid/v4";
 
 const ValueType = types.union(types.number, types.string, types.undefined);

--- a/src/models/data/data-set.test.ts
+++ b/src/models/data/data-set.test.ts
@@ -1,7 +1,7 @@
 // import { applyAction, clone, destroy, getEnv, getSnapshot, onAction } from 'mobx-state-tree';
 import { applyAction, clone, destroy, getSnapshot, onAction } from "mobx-state-tree";
 import { addAttributeToDataSet, addCanonicalCasesToDataSet, addCasesToDataSet,
-          CaseID, ICaseID, ICase, ICaseCreation, DataSet, IDataSet } from "./data-set";
+          CaseID, ICaseID, ICase, DataSet, IDataSet } from "./data-set";
 import * as uuid from "uuid/v4";
 
 // tslint:disable:one-variable-per-declaration
@@ -168,8 +168,8 @@ test("DataSet basic functionality", () => {
   expect(cases[0]).toEqual({ __id__: caseB2ID, str: "B", num: 20 });
   expect(cases[1]).toEqual({ __id__: caseC3ID, str: "C", num: 30 });
 
-  const bIndex = dataset.caseIndexFromID(caseB2ID);
-  const cases2 = dataset.getCasesAtIndices(bIndex, 2);
+  // const bIndex = dataset.caseIndexFromID(caseB2ID);
+  // const cases2 = dataset.getCasesAtIndices(bIndex, 2);
   expect(cases.length).toBe(2);
   expect(cases[0]).toEqual({ __id__: caseB2ID, str: "B", num: 20 });
   expect(cases[1]).toEqual({ __id__: caseC3ID, str: "C", num: 30 });

--- a/src/models/data/data-set.ts
+++ b/src/models/data/data-set.ts
@@ -1,4 +1,4 @@
-import { addMiddleware, applyAction, getEnv, Instance,
+import { applyAction, getEnv, Instance,
           onAction, types, getSnapshot, SnapshotOut } from "mobx-state-tree";
 import { ISerializedActionCall } from "mobx-state-tree";
 import { Attribute, IAttribute, IAttributeCreation, IValueType } from "./attribute";

--- a/src/models/four-up-grid.test.ts
+++ b/src/models/four-up-grid.test.ts
@@ -2,9 +2,9 @@ import { CellPositions, DEFAULT_SPLITTER_SIZE, FourUpGridModel, FourUpGridCellMo
 
 describe("four-up grid model", () => {
 
-  it("throws an exception is the cells aren't empty", () => {
+  it("throws an exception if the cells aren't empty", () => {
     const invalidCells = () => {
-      const grid = FourUpGridModel.create({
+      FourUpGridModel.create({
         cells: [
           FourUpGridCellModel.create({})
         ]

--- a/src/models/groups.test.ts
+++ b/src/models/groups.test.ts
@@ -1,4 +1,4 @@
-import { GroupsModel, GroupsModelType, GroupModel, GroupUserModel } from "./groups";
+import { GroupsModel, GroupModel, GroupUserModel } from "./groups";
 import { ClassModel, ClassStudentModel } from "./class";
 import { DBOfferingGroupMap } from "../lib/db-types";
 

--- a/src/models/groups.ts
+++ b/src/models/groups.ts
@@ -1,5 +1,5 @@
 import { types } from "mobx-state-tree";
-import { DBOfferingGroup, DBOfferingGroupMap } from "../lib/db-types";
+import { DBOfferingGroupMap } from "../lib/db-types";
 import { ClassModelType } from "./class";
 
 export const GroupUserModel = types

--- a/src/models/supports.test.ts
+++ b/src/models/supports.test.ts
@@ -1,5 +1,5 @@
 import { getSnapshot } from "mobx-state-tree";
-import { SupportsModel, SupportsModelType, SupportItemType } from "./supports";
+import { SupportsModel, SupportItemType } from "./supports";
 import { UnitModel } from "./curriculum/unit";
 import { SupportModel } from "./curriculum/support";
 import { InvestigationModel } from "./curriculum/investigation";

--- a/src/models/ui.test.ts
+++ b/src/models/ui.test.ts
@@ -124,7 +124,7 @@ describe("ui model", () => {
   });
 
   it("allows activeSection to be set", () => {
-    const section = SectionModel.create({
+    SectionModel.create({
       type: SectionType.introduction
     });
     ui.setActiveSectionIndex(1);


### PR DESCRIPTION
Add `lint:unused` script
- eliminate unused variables from a number of model files

I made this a separate script so unused variables don't necessarily break the build, but the script can be run when desired to identify unused variables for subsequent removal.

Note: I didn't remove unused variables from `db.ts` or a number of React components because I didn't want to risk introducing merge conflicts in files that might be part of current in-progress PRs.