### PR TITLE
Fix geometry resizing and scaling issues

### DIFF
--- a/src/components/learning-log.tsx
+++ b/src/components/learning-log.tsx
@@ -10,6 +10,9 @@ import { DocumentComponent, WorkspaceSide } from "./document";
 import { DocumentModelType, DocumentDragKey, LearningLogDocument } from "../models/document";
 import { LearningLogWorkspace } from "../models/workspace";
 
+// cf. learning-log.sass: $list-item-scale
+const kLearningLogItemScale = 0.08;
+
 interface IProps extends IBaseProps {}
 
 @inject("stores")
@@ -122,7 +125,8 @@ export class LearningLogComponent extends BaseComponent<IProps, {}> {
                 draggable={true}
               >
                 <div className="scaled-list-item">
-                  <CanvasComponent document={learningLog} readOnly={true} context="learning-log" />
+                  <CanvasComponent context="learning-log" document={learningLog}
+                                    readOnly={true} scale={kLearningLogItemScale} />
                 </div>
               </div>
               <div className="info">

--- a/src/components/my-work.tsx
+++ b/src/components/my-work.tsx
@@ -6,6 +6,9 @@ import { BaseComponent, IBaseProps } from "./base";
 import { CanvasComponent } from "./canvas";
 import { DocumentDragKey, SectionDocument, DocumentModelType } from "../models/document";
 
+// cf. right-nav.sass: $list-item-scale
+const kMyWorkItemScale = 0.11;
+
 interface IProps extends IBaseProps {}
 
 @inject("stores")
@@ -37,7 +40,8 @@ export class MyWorkComponent extends BaseComponent<IProps, {}> {
                   draggable={true}
                 >
                   <div className="scaled-list-item">
-                    <CanvasComponent context="my-work" document={document} readOnly={true} />
+                    <CanvasComponent context="my-work" document={document}
+                                    readOnly={true} scale={kMyWorkItemScale}/>
                   </div>
                 </div>
                 <div className="info">

--- a/src/models/tools/geometry/geometry-content.test.ts
+++ b/src/models/tools/geometry/geometry-content.test.ts
@@ -43,7 +43,7 @@ describe("GeometryContent", () => {
     expect(isBoard(board)).toBe(true);
     const boardId = board.id;
 
-    const boundingBox = clone(board.boundingBox);
+    const boundingBox = clone(board.attr.boundingbox);
     const change: JXGChange = {
             operation: "update",
             target: "board",

--- a/src/models/tools/geometry/geometry-content.ts
+++ b/src/models/tools/geometry/geometry-content.ts
@@ -9,20 +9,22 @@ import { isBoard } from "./jxg-board";
 export const kGeometryToolID = "Geometry";
 
 export const kGeometryDefaultHeight = 200;
+// matches curriculum images
+export const kGeometryDefaultPixelsPerUnit = 35.5;
+export const kGeometryDefaultAxisMin = -1;
 
 export type onCreateCallback = (elt: JXG.GeometryElement) => void;
 
 export function defaultGeometryContent(overrides?: JXGProperties) {
-  const axisMin = -0.5;
-  const xAxisMax = 20;
-  const yAxisMax = 5;
+  const xAxisMax = 30;
+  const yAxisMax = kGeometryDefaultHeight / kGeometryDefaultPixelsPerUnit - kGeometryDefaultAxisMin;
   const change: JXGChange = {
     operation: "create",
     target: "board",
     properties: assign({
                   id: uuid(),
                   axis: true,
-                  boundingBox: [axisMin, yAxisMax, xAxisMax, axisMin],
+                  boundingBox: [kGeometryDefaultAxisMin, yAxisMax, xAxisMax, kGeometryDefaultAxisMin],
                   grid: {}  // defaults to 1-unit gridlines
                 }, overrides)
   };
@@ -62,8 +64,15 @@ export const GeometryContentModel = types
       JXG.JSXGraph.freeBoard(board);
     }
 
-    function resizeBoard(board: JXG.Board, width: number, height: number) {
-      board.resizeContainer(width, height);
+    function resizeBoard(board: JXG.Board, width: number, height: number, scale?: number) {
+      const scaledWidth = width / (scale || 1);
+      const scaledHeight = height / (scale || 1);
+      const unitXY = kGeometryDefaultPixelsPerUnit;
+      const [xMin, , , yMin] = board.attr.boundingbox;
+      const newXMax = scaledWidth / unitXY - xMin;
+      const newYMax = scaledHeight / unitXY - yMin;
+      board.resizeContainer(scaledWidth, scaledHeight, false, true);
+      board.setBoundingBox([xMin, newYMax, newXMax, yMin], true);
       board.update();
     }
 

--- a/src/models/tools/geometry/jsxgraph.d.ts
+++ b/src/models/tools/geometry/jsxgraph.d.ts
@@ -13,14 +13,19 @@ declare namespace JXG {
 
   class Board {
     id: string;
+    attr: {
+      // [x1,y1,x2,y2] upper left corner, lower right corner
+      boundingbox: [number, number, number, number]
+    };
     axis: boolean;
-    boundingBox: number[];
     canvasWidth: number;
     canvasHeight: number;
     keepaspectratio: boolean;
     showCopyright: boolean;
     showNavigation: boolean;
     showZoom: boolean;
+    unitX: number;
+    unitY: number;
     zoomFactor: number;
     zoomX: number;
     zoomY: number;
@@ -35,7 +40,7 @@ declare namespace JXG {
     getCoordsTopLeftCorner: () => number[];
     resizeContainer: (canvasWidth: number, canvasHeight: number,
                       dontSet?: boolean, dontSetBoundingBox?: boolean) => void;
-    setBoundingBox: (boundingBox: number[]) => void;
+    setBoundingBox: (boundingBox: [number, number, number, number], keepaspectratio?: boolean) => void;
     update: (drag?: JXG.GeometryElement) => void;
   }
 

--- a/src/models/tools/geometry/jxg-board.ts
+++ b/src/models/tools/geometry/jxg-board.ts
@@ -5,16 +5,39 @@ import { assign, each } from "lodash";
 export const isBoard = (v: any) => v instanceof JXG.Board;
 
 export const boardChangeAgent: JXGChangeAgent = {
-  create: (board: JXG.Board|string, change: JXGChange) => {
-    const domElementID = board as string;
+  create: (boardDomId: JXG.Board|string, change: JXGChange) => {
+    const domElementID = boardDomId as string;
     const defaults = {
             keepaspectratio: true,
             showCopyright: false,
             showNavigation: false,
             minimizeReflow: "none"
           };
-    const props = assign(defaults, change.properties);
-    return JXG.JSXGraph.initBoard(domElementID, props);
+    // cf. https://www.intmath.com/cg3/jsxgraph-axes-ticks-grids.php
+    const overrides = { axis: false, grid: true };
+    const props = assign(defaults, change.properties, overrides);
+    const board = JXG.JSXGraph.initBoard(domElementID, props);
+    const xAxis = board.create("axis", [ [0, 0], [1, 0] ]);
+    xAxis.removeAllTicks();
+    board.create("ticks", [xAxis, 5], {
+                  strokeColor: "#bbb",
+                  majorHeight: -1,
+                  drawLabels: true,
+                  label: { offset: [-8, -10] },
+                  minorTicks: 4,
+                  drawZero: true
+                });
+    const yAxis = board.create("axis", [ [0, 0], [0, 1] ]);
+    yAxis.removeAllTicks();
+    board.create("ticks", [yAxis, 5], {
+                  strokeColor: "#bbb",
+                  majorHeight: -1,
+                  drawLabels: true,
+                  label: { offset: [-10, -1] },
+                  minorTicks: 4,
+                  drawZero: false
+                });
+    return board;
   },
 
   update: (board: JXG.Board, change: JXGChange) => {


### PR DESCRIPTION
Fix geometry resizing [#160688141]
- fix geometry scaling in My Work and Learning Log thumbnails
- maintain consistent grid size and tick spacing
- default grid spacing matches curriculum images