### PR TITLE
Save dragged polygon location

### DIFF
--- a/src/models/tools/geometry/jsxgraph.d.ts
+++ b/src/models/tools/geometry/jsxgraph.d.ts
@@ -63,6 +63,7 @@ declare namespace JXG {
   class GeometryElement {
     id: string;
     type: number;
+    ancestors: { [id: string]: GeometryElement };
     visProp: { [prop: string]: any };
     fixed: boolean;
 


### PR DESCRIPTION
A previous PR (#92) enabled dragging of polygons, but didn't save the updated location(s) to the model. This PR corrects that oversight.