### PR TITLE
Support drag-resize of geometry tile rows

### DIFF
--- a/src/components/document/tile-row.sass
+++ b/src/components/document/tile-row.sass
@@ -1,2 +1,12 @@
 .tile-row
+  position: relative
   min-height: 18px
+
+  .bottom-resize-handle
+    position: absolute
+    left: 2px
+    right: -4px
+    bottom: -6px
+    height: 10px
+    z-index: 1
+    cursor: row-resize

--- a/src/models/document/tile-row.ts
+++ b/src/models/document/tile-row.ts
@@ -1,5 +1,6 @@
 import { types, Instance, SnapshotIn } from "mobx-state-tree";
 import * as uuid from "uuid/v4";
+import { ToolTileModelType } from "../tools/tool-tile";
 
 export const TileLayoutModel = types
   .model("TileLayout", {
@@ -12,7 +13,21 @@ export const TileRowModel = types
     id: types.optional(types.identifier, () => uuid()),
     height: types.maybe(types.number),
     tiles: types.array(TileLayoutModel)
-  });
+  })
+  .views(self => ({
+    isUserResizable(tileMap: any) {
+      return self.tiles.every(tileLayout => {
+        const tile: ToolTileModelType = tileMap.get(tileLayout.tileId);
+        return tile && tile.isUserResizable;
+      });
+    }
+  }))
+  .actions(self => ({
+    // undefined height == default to content height
+    setRowHeight(height?: number) {
+      self.height = height;
+    }
+  }));
 
 export type TileRowModelType = Instance<typeof TileRowModel>;
 export type TileRowSnapshotType = SnapshotIn<typeof TileRowModel>;

--- a/src/models/tools/geometry/geometry-content.ts
+++ b/src/models/tools/geometry/geometry-content.ts
@@ -10,7 +10,7 @@ export const kGeometryToolID = "Geometry";
 
 export const kGeometryDefaultHeight = 200;
 // matches curriculum images
-export const kGeometryDefaultPixelsPerUnit = 35.5;
+export const kGeometryDefaultPixelsPerUnit = 26;
 export const kGeometryDefaultAxisMin = -1;
 
 export type onCreateCallback = (elt: JXG.GeometryElement) => void;
@@ -69,8 +69,8 @@ export const GeometryContentModel = types
       const scaledHeight = height / (scale || 1);
       const unitXY = kGeometryDefaultPixelsPerUnit;
       const [xMin, , , yMin] = board.attr.boundingbox;
-      const newXMax = scaledWidth / unitXY - xMin;
-      const newYMax = scaledHeight / unitXY - yMin;
+      const newXMax = scaledWidth / unitXY + xMin;
+      const newYMax = scaledHeight / unitXY + yMin;
       board.resizeContainer(scaledWidth, scaledHeight, false, true);
       board.setBoundingBox([xMin, newYMax, newXMax, yMin], true);
       board.update();
@@ -142,6 +142,9 @@ export const GeometryContentModel = types
       views: {
         get nextViewId() {
           return ++viewCount;
+        },
+        get isUserResizable() {
+          return true;
         }
       },
       actions: {

--- a/src/models/tools/tool-tile.ts
+++ b/src/models/tools/tool-tile.ts
@@ -21,6 +21,9 @@ export const ToolTileModel = types
     // e.g. width of all columns for table
     get maxWidth(): number | undefined {
       return;
+    },
+    get isUserResizable() {
+      return !!(self.content as any).isUserResizable;
     }
   }));
 


### PR DESCRIPTION
- infrastructure supports drag-resize of any tile row
- tiles opt-in to user-resizability -- only geometry tool supports it for now
- row can only be resized when all tiles within it support resize
- fix computational error in geometry scaling calculations

Note: image tool is the obvious next candidate to support resize, but will require some additional work. The `<img>` tag doesn't by default provide the kind of resize behavior I think we want. Switching to `background-image` provides better resize behavior but would require a different default size implementation. @dstrawberrygirl I'm tagging you for review since you're in the middle of image tool work.