### PR TITLE
View published work by student

### DIFF
--- a/src/components/class-work.tsx
+++ b/src/components/class-work.tsx
@@ -18,13 +18,14 @@ export class ClassWorkComponent extends BaseComponent<IProps, {}> {
     const sections = problem.sections;
     const publications: DocumentModelType[] = [];
     sections.forEach((section) => {
-      publications.push(...documents.getLatestPublicationsForSection(section.id));
+      publications.push(...documents.getLatestPublicationsForSection(section.id, this.stores.class));
     });
 
     return (
       <div className="class-work">
         <div className="list">
           {publications.map((publication) => {
+            const user = this.stores.class.getStudentById(publication.uid);
             return (
               <div
                 className="list-item"
@@ -42,7 +43,7 @@ export class ClassWorkComponent extends BaseComponent<IProps, {}> {
                 </div>
                 <div className="info">
                   <div>{problem.getSectionById(publication.sectionId!)!.title}</div>
-                  <div>{`Group: ${publication.groupId}`}</div>
+                  <div>{user && user.fullName}</div>
                 </div>
               </div>
             );

--- a/src/models/documents.test.ts
+++ b/src/models/documents.test.ts
@@ -1,17 +1,12 @@
-import { WorkspaceModel, WorkspaceModelType, SectionWorkspace } from "./workspace";
 import { DocumentModel, DocumentModelType, SectionDocument } from "./document";
 import { DocumentsModelType, DocumentsModel } from "./documents";
+import { ClassModelType, ClassModel, ClassStudentModel } from "./class";
 
 describe("documents model", () => {
-  let workspace: WorkspaceModelType;
   let documents: DocumentsModelType;
   let document: DocumentModelType;
 
   beforeEach(() => {
-    workspace = WorkspaceModel.create({
-      type: SectionWorkspace,
-      mode: "1-up",
-    });
     document = DocumentModel.create({
       type: SectionDocument,
       title: "test",
@@ -46,33 +41,124 @@ describe("documents model", () => {
     expect(documents.getSectionDocument("1", "2")).toBe(document);
   });
 
-  const getPublishedDocument = (createdAt: number, sectionId: string, groupId: string) => {
-    return DocumentModel.create({
-      uid: "1",
-      type: "publication",
-      key: `llDoc-${groupId}-${sectionId}-${createdAt}`,
-      createdAt,
-      content: {},
-      groupId,
-      sectionId,
+  describe("getLatestPublications", () => {
+    let student1;
+    let student2;
+    let student3;
+
+    let clazz: ClassModelType;
+
+    beforeEach(() => {
+      student1 = ClassStudentModel.create({
+        id: "1",
+        firstName: "aaa",
+        lastName: "aaa",
+        fullName: "aaa aaa",
+        initials: "AA"
+      });
+      student2 = ClassStudentModel.create({
+        id: "2",
+        firstName: "zzz",
+        lastName: "aaa",
+        fullName: "zzz aaa",
+        initials: "ZA"
+      });
+      student3 = ClassStudentModel.create({
+        id: "3",
+        firstName: "zzz",
+        lastName: "zzz",
+        fullName: "zzz zzz",
+        initials: "ZZ"
+      });
+
+      clazz = ClassModel.create({
+        name: "test",
+        classHash: "testHash",
+        students: [student1, student2, student3]
+      });
     });
-  };
 
-  it("gets a correctly sorted list of publications for a given section", () => {
-    const pub1 = getPublishedDocument(0, "introduction", "1");
-    const newerPub1 = getPublishedDocument(10, "introduction", "1");
-    const badPub1 = getPublishedDocument(5, "initialChallenge", "1");
-    const pub2 = getPublishedDocument(7, "introduction", "2");
+    const getPublishedDocument = (createdAt: number, sectionId: string, uid: string) => {
+      return DocumentModel.create({
+        uid,
+        type: "publication",
+        key: `llDoc-${uid}-${sectionId}-${createdAt}`,
+        createdAt,
+        content: {},
+        groupId: "1",
+        sectionId,
+      });
+    };
 
-    documents.add(pub2);
-    documents.add(pub1);
-    documents.add(newerPub1);
-    documents.add(badPub1);
-    expect(documents.all.length).toBe(4);
+    it("finds documents from the correct section", () => {
+      const pub1 = getPublishedDocument(0, "introduction", "1");
+      const badPub1 = getPublishedDocument(10, "initialChallenge", "1");
 
-    const latestPubs = documents.getLatestPublicationsForSection("introduction");
-    expect(latestPubs.length).toBe(2);
-    expect(latestPubs[0]).toBe(newerPub1);
-    expect(latestPubs[1]).toBe(pub2);
+      documents.add(pub1);
+      documents.add(badPub1);
+      expect(documents.all.length).toBe(2);
+
+      const latestPubs = documents.getLatestPublicationsForSection("introduction", clazz);
+      expect(latestPubs.length).toBe(1);
+      expect(latestPubs[0]).toBe(pub1);
+    });
+
+    it("finds the newest document for a user", () => {
+      const pub1 = getPublishedDocument(0, "introduction", "1");
+      const newerPub1 = getPublishedDocument(10, "introduction", "1");
+
+      documents.add(pub1);
+      documents.add(newerPub1);
+      expect(documents.all.length).toBe(2);
+
+      const latestPubs = documents.getLatestPublicationsForSection("introduction", clazz);
+      expect(latestPubs.length).toBe(1);
+      expect(latestPubs[0]).toBe(newerPub1);
+    });
+
+    it("sorts publications by last name", () => {
+      const pub1 = getPublishedDocument(0, "introduction", "1");
+      const pub3 = getPublishedDocument(10, "introduction", "3");
+
+      documents.add(pub3);
+      documents.add(pub1);
+      expect(documents.all.length).toBe(2);
+
+      const latestPubs = documents.getLatestPublicationsForSection("introduction", clazz);
+      expect(latestPubs.length).toBe(2);
+      expect(latestPubs[0]).toBe(pub1);
+      expect(latestPubs[1]).toBe(pub3);
+    });
+
+    it("sorts publications by first name, in case of matching last names", () => {
+      const pub1 = getPublishedDocument(0, "introduction", "1");
+      const pub2 = getPublishedDocument(10, "introduction", "2");
+
+      documents.add(pub2);
+      documents.add(pub1);
+      expect(documents.all.length).toBe(2);
+
+      const latestPubs = documents.getLatestPublicationsForSection("introduction", clazz);
+      expect(latestPubs.length).toBe(2);
+      expect(latestPubs[0]).toBe(pub1);
+      expect(latestPubs[1]).toBe(pub2);
+    });
+
+    it("sorts publications with missing users last", () => {
+      const pub1 = getPublishedDocument(0, "introduction", "1");
+      const pub2 = getPublishedDocument(10, "introduction", "2");
+      const pubNull = getPublishedDocument(4, "introduction", "foo");
+
+      documents.add(pubNull);
+      documents.add(pub1);
+      documents.add(pub2);
+      expect(documents.all.length).toBe(3);
+
+      const latestPubs = documents.getLatestPublicationsForSection("introduction", clazz);
+      expect(latestPubs.length).toBe(3);
+      expect(latestPubs[0]).toBe(pub1);
+      expect(latestPubs[1]).toBe(pub2);
+      expect(latestPubs[2]).toBe(pubNull);
+    });
   });
 });

--- a/src/models/workspaces.ts
+++ b/src/models/workspaces.ts
@@ -121,28 +121,6 @@ export const WorkspacesModel = types
     return {
       findByDocumentId,
 
-      // Returns the most recently published docs for the given section, sorted by group ID number
-      getLatestPublicationsForSection(sectionId: string) {
-        const latestPublications: PublishedWorkspaceModelType[] = [];
-        self.publications
-          .filter((publication) => publication.sectionId === sectionId)
-          .forEach((publication) => {
-            if (publication.sectionId !== sectionId) {
-              return;
-            }
-            const groupId = publication.groupId;
-            const latestIndex = latestPublications.findIndex((pub) => pub.groupId === groupId);
-            if (latestIndex === -1) {
-              latestPublications.push(publication);
-            } else if (publication.createdAt > latestPublications[latestIndex].createdAt) {
-              latestPublications[latestIndex] = publication;
-            }
-          });
-
-        return latestPublications
-          .sort((pub1, pub2) => parseInt(pub1.groupId, 10) - parseInt(pub2.groupId, 10));
-      },
-
       getSectionWorkspace(sectionId: string) {
         return self.sections.find((workspace) => workspace.sectionId === sectionId);
       },


### PR DESCRIPTION
Now we show the most recent work published by each *student*, rather than each *group*. This didn't require any changes to the way publications are stored, just the way they're retrieved.