### PR TITLE
Support multiple tiles per row

### DIFF
--- a/src/components/canvas-tools/geometry-tool.sass
+++ b/src/components/canvas-tools/geometry-tool.sass
@@ -1,3 +1,4 @@
 .geometry-tool
   width: 100%
   height: 100%
+  min-height: 52px

--- a/src/components/canvas-tools/image-tool.sass
+++ b/src/components/canvas-tools/image-tool.sass
@@ -1,10 +1,10 @@
 @import ../vars
 
 .image-tool
-  margin: 3px
+  width: 100%
+  height: 100%
   text-align: left
-  padding-left: 3px
-  padding-top: 3px
+  overflow: auto
 
   &.editable
     border: 1px solid #cccccc

--- a/src/components/canvas-tools/text-tool.sass
+++ b/src/components/canvas-tools/text-tool.sass
@@ -1,7 +1,7 @@
 @import ../vars
 
 .text-tool
-  width: 100%
+  width: calc(100% - 2px)
   min-height: 18px
   text-align: left
   padding: 3px 0

--- a/src/components/canvas-tools/tool-tile.sass
+++ b/src/components/canvas-tools/tool-tile.sass
@@ -4,8 +4,9 @@
   // create z-index stacking context ("what happens in tool tiles, stays in tool tiles")
   position: relative
   z-index: 0
-  width: 100%
+  overflow: hidden
   height: 100%
+  flex: 1 1 auto
   border: $half-border-width solid white
 
   &.selected

--- a/src/components/canvas-tools/tool-tile.tsx
+++ b/src/components/canvas-tools/tool-tile.tsx
@@ -23,7 +23,8 @@ interface IProps {
   context: string;
   docId: string;
   scale?: number;
-  rowHeight?: number;
+  widthPct?: number;
+  height?: number;
   model: ToolTileModelType;
   readOnly?: boolean;
 }
@@ -39,14 +40,19 @@ const kToolComponentMap: any = {
 export class ToolTileComponent extends BaseComponent<IProps, {}> {
 
   public render() {
-    const { model } = this.props;
+    const { model, widthPct } = this.props;
     const { ui } = this.stores;
     const selectedClass = ui.isSelectedTile(model) ? " selected" : "";
     const ToolComponent = kToolComponentMap[model.content.type];
+    const style: React.CSSProperties = {};
+    if (widthPct) {
+      style.width = `${Math.round(100 * widthPct / 100)}%`;
+    }
     return (
       <div className={`tool-tile${selectedClass}`}
-        onDragStart={this.handleToolDragStart}
-        draggable={true}
+          style={style}
+          onDragStart={this.handleToolDragStart}
+          draggable={true}
       >
         {this.renderTile(ToolComponent)}
       </div>
@@ -61,14 +67,14 @@ export class ToolTileComponent extends BaseComponent<IProps, {}> {
 
   private handleToolDragStart = (e: React.DragEvent<HTMLDivElement>) => {
     // set the drag data
-    const { model, docId, rowHeight, scale } = this.props;
+    const { model, docId, height, scale } = this.props;
     const snapshot = cloneDeep(getSnapshot(model));
     const id = snapshot.id;
     delete snapshot.id;
     const dragData = JSON.stringify(snapshot);
     e.dataTransfer.setData(kDragTileSource, docId);
-    if (rowHeight) {
-      e.dataTransfer.setData(kDragRowHeight, String(rowHeight));
+    if (height) {
+      e.dataTransfer.setData(kDragRowHeight, String(height));
     }
     e.dataTransfer.setData(kDragTileId, id);
     e.dataTransfer.setData(kDragTileContent, dragData);

--- a/src/components/canvas.sass
+++ b/src/components/canvas.sass
@@ -6,7 +6,6 @@
   height: 100%
   width: 100%
   background-color: #fff
-  overflow: auto
 
   .document
     text-align: left

--- a/src/components/document-content.sass
+++ b/src/components/document-content.sass
@@ -5,4 +5,5 @@
   height: 100%
   width: 100%
   background-color: #fff
-  padding: 0 $half-padding
+  padding: 0 $half-padding $padding $half-padding
+  overflow: auto

--- a/src/components/document/tile-row.sass
+++ b/src/components/document/tile-row.sass
@@ -1,6 +1,9 @@
 .tile-row
   position: relative
   min-height: 18px
+  display: flex
+  flex-direction: row
+  align-content: flex-start
 
   .bottom-resize-handle
     position: absolute

--- a/src/components/document/tile-row.tsx
+++ b/src/components/document/tile-row.tsx
@@ -4,14 +4,13 @@ import { TileRowModelType } from "../../models/document/tile-row";
 import { BaseComponent } from "../base";
 import { ToolTileComponent, dragTileSrcDocId } from "../canvas-tools/tool-tile";
 import { ToolTileModelType } from "../../models/tools/tool-tile";
-import { every } from "lodash";
 import "./tile-row.sass";
 
 export const kDragResizeRowId = "org.concord.clue.row-resize.id";
 // allows source compatibility to be checked in dragOver
 export const dragResizeRowId = (id: string) => `org.concord.clue.row-resize.id.${id}`;
-export const dragResizeRowPageY =
-              (pageY: number) => `org.concord.clue.row-resize.page-y.${pageY}`;
+export const dragResizeRowY =
+              (y: number) => `org.concord.clue.row-resize.event-y.${y}`;
 export const dragResizeRowModelHeight =
               (modelHeight: number) => `org.concord.clue.row-resize.model-height.${modelHeight}`;
 export const dragResizeRowDomHeight =
@@ -24,9 +23,9 @@ export function extractDragResizeRowId(dataTransfer: DataTransfer) {
   }
 }
 
-export function extractDragResizePageY(dataTransfer: DataTransfer) {
+export function extractDragResizeY(dataTransfer: DataTransfer) {
   for (const type of dataTransfer.types) {
-    const result = /org\.concord\.clue\.row-resize\.page-y\.(.*)$/.exec(type);
+    const result = /org\.concord\.clue\.row-resize\.event-y\.(.*)$/.exec(type);
     if (result) return +result[1];
   }
 }
@@ -80,15 +79,17 @@ export class TileRowComponent extends BaseComponent<IProps, {}> {
 
     return tiles.map(tileRef => {
       const tileModel: ToolTileModelType = tileMap.get(tileRef.tileId);
+      const tileWidthPct = model.renderWidth(tileRef.tileId);
       return tileModel
-              ? <ToolTileComponent key={tileModel.id} model={tileModel} rowHeight={rowHeight} {...others} />
+              ? <ToolTileComponent key={tileModel.id} model={tileModel}
+                                    widthPct={tileWidthPct} height={rowHeight} {...others} />
               : null;
     });
   }
 
   private renderBottomResizeHandle() {
     const { model, tileMap } = this.props;
-    if (this.props.readOnly || !model.isUserResizable(tileMap)) return null;
+    if (this.props.readOnly || !model.isUserResizable) return null;
     return <div className="bottom-resize-handle" draggable={true} onDragStart={this.handleStartResizeRow}/>;
   }
 
@@ -98,7 +99,7 @@ export class TileRowComponent extends BaseComponent<IProps, {}> {
     e.dataTransfer.setData(dragTileSrcDocId(docId), docId);
     e.dataTransfer.setData(kDragResizeRowId, id);
     e.dataTransfer.setData(dragResizeRowId(id), id);
-    e.dataTransfer.setData(dragResizeRowPageY(e.pageY), String(e.pageY));
+    e.dataTransfer.setData(dragResizeRowY(e.clientY), String(e.clientY));
     if (model.height) {
       e.dataTransfer.setData(dragResizeRowModelHeight(model.height), String(model.height));
     }

--- a/src/models/document-content.ts
+++ b/src/models/document-content.ts
@@ -4,7 +4,7 @@ import { defaultGeometryContent, kGeometryDefaultHeight } from "./tools/geometry
 import { defaultImageContent } from "./tools/image/image-content";
 import { defaultTextContent } from "./tools/text/text-content";
 import { ToolContentUnionType } from "./tools/tool-types";
-import { ToolTileModel, ToolTileModelType } from "./tools/tool-tile";
+import { ToolTileModel } from "./tools/tool-tile";
 import { TileRowModel, TileRowModelType, TileRowSnapshotType } from "./document/tile-row";
 import { cloneDeep } from "lodash";
 import * as uuid from "uuid/v4";
@@ -48,45 +48,61 @@ export const DocumentContentModel = types
       get contentId() {
         return contentId;
       },
-      findRowContainingTile(tileId: string) {
-        return self.rowOrder.find(rowId => rowContainsTile(rowId, tileId));
+      getTile(tileId: string) {
+        return self.tileMap.get(tileId);
+      },
+      getRow(rowId: string) {
+        return self.rowMap.get(rowId);
       },
       getRowByIndex(index: number) {
         return self.rowMap.get(self.rowOrder[index]);
       },
-      getTile(tileId: string) {
-        return self.tileMap.get(tileId);
+      findRowContainingTile(tileId: string) {
+        return self.rowOrder.find(rowId => rowContainsTile(rowId, tileId));
+      },
+      numTilesInRow(rowId: string) {
+        const row = self.rowMap.get(rowId);
+        return row ? row.tiles.length : 0;
       }
     };
   })
   .actions(self => ({
-    addTileInNewRow(content: ToolContentUnionType, options?: NewRowOptions) {
-      const tile = ToolTileModel.create({ content });
-      const o = options || {};
-      const rowSpec: TileRowSnapshotType = { tiles: [{ tileId: tile.id }] };
-      if (o.rowHeight) {
-        rowSpec.height = o.rowHeight;
-      }
-      const row = TileRowModel.create(rowSpec);
-      self.tileMap.put(tile);
+    afterCreate() {
+      self.rowMap.forEach(row => {
+        row.updateLayout(self.tileMap);
+      });
+    },
+    insertRow(row: TileRowModelType, index?: number) {
       self.rowMap.put(row);
-      if ((o.rowIndex != null) && (o.rowIndex < self.rowOrder.length)) {
-        self.rowOrder.splice(o.rowIndex, 0, row.id);
+      if ((index != null) && (index < self.rowOrder.length)) {
+        self.rowOrder.splice(index, 0, row.id);
       }
       else {
         self.rowOrder.push(row.id);
       }
+    },
+    deleteRow(rowId: string) {
+      self.rowOrder.remove(rowId);
+      self.rowMap.delete(rowId);
+    }
+  }))
+  .actions(self => ({
+    addTileInNewRow(content: ToolContentUnionType, options?: NewRowOptions) {
+      const tile = ToolTileModel.create({ content });
+      const o = options || {};
+      const row = TileRowModel.create();
+      row.insertTileInRow(tile);
+      if (o.rowHeight) {
+        row.setRowHeight(o.rowHeight);
+      }
+      self.tileMap.put(tile);
+      self.insertRow(row, o.rowIndex);
 
       const action = o.action || LogEventName.CREATE_TILE;
       Logger.logTileEvent(action, tile, o.loggingMeta);
 
       return tile.id;
     },
-    moveRowToIndex(rowIndex: number, newRowIndex: number) {
-      const rowId = self.rowOrder[rowIndex];
-      self.rowOrder.splice(rowIndex, 1);
-      self.rowOrder.splice(newRowIndex <= rowIndex ? newRowIndex : newRowIndex - 1, 0, rowId);
-    }
   }))
   .actions((self) => ({
     addGeometryTile() {
@@ -127,21 +143,78 @@ export const DocumentContentModel = types
       const rowsToDelete: TileRowModelType[] = [];
       self.rowMap.forEach(row => {
         // remove from row
-        if (row.tiles.findIndex(tile => tile.tileId === tileId) >= 0) {
-          row.tiles.replace(row.tiles.filter(tile => tile.tileId !== tileId));
+        if (row.hasTile(tileId)) {
+          row.removeTileFromRow(tileId);
         }
-        // remove empty rows
+        // track empty rows
         if (row.tiles.length === 0) {
           rowsToDelete.push(row);
         }
       });
       // remove empty rows
       rowsToDelete.forEach(row => {
-        self.rowOrder.remove(row.id);
-        self.rowMap.delete(row.id);
+        self.deleteRow(row.id);
       });
       // delete tile
       self.tileMap.delete(tileId);
+    },
+    moveRowToIndex(rowIndex: number, newRowIndex: number) {
+      const rowId = self.rowOrder[rowIndex];
+      self.rowOrder.splice(rowIndex, 1);
+      self.rowOrder.splice(newRowIndex <= rowIndex ? newRowIndex : newRowIndex - 1, 0, rowId);
+    },
+    moveTileToRow(tileId: string, rowIndex: number, tileIndex?: number) {
+      const srcRowId = self.findRowContainingTile(tileId);
+      const srcRow = srcRowId && self.rowMap.get(srcRowId);
+      const dstRowId = self.rowOrder[rowIndex];
+      const dstRow = dstRowId && self.rowMap.get(dstRowId);
+      const tile = self.getTile(tileId);
+      if (srcRow && dstRow && tile) {
+        if (srcRow === dstRow) {
+          // move a tile within a row
+          const srcIndex = srcRow.indexOfTile(tileId);
+          const dstIndex = tileIndex != null ? tileIndex : dstRow.tiles.length;
+          dstRow.moveTileInRow(tileId, srcIndex, dstIndex);
+        }
+        else {
+          // move a tile from one row to another
+          dstRow.insertTileInRow(tile, tileIndex);
+          if (srcRow.height && tile.isUserResizable &&
+              (!dstRow.height || (srcRow.height > dstRow.height))) {
+            dstRow.height = srcRow.height;
+          }
+          srcRow.removeTileFromRow(tileId);
+          if (!srcRow.tiles.length) {
+            self.deleteRow(srcRow.id);
+          }
+        }
+      }
+    },
+    moveTileToNewRow(tileId: string, rowIndex: number) {
+      const srcRowId = self.findRowContainingTile(tileId);
+      const srcRow = srcRowId && self.rowMap.get(srcRowId);
+      const tile = self.getTile(tileId);
+      if (!srcRowId || !srcRow || !tile) return;
+
+      // create tile, insert tile, insert row
+      const rowSpec: TileRowSnapshotType = {};
+      if (tile.isUserResizable) {
+        rowSpec.height = srcRow.height;
+      }
+      const dstRow = TileRowModel.create(rowSpec);
+      dstRow.insertTileInRow(tile);
+      self.insertRow(dstRow, rowIndex);
+
+      // remove tile from source row
+      srcRow.removeTileFromRow(tileId);
+      if (!srcRow.tiles.length) {
+        self.deleteRow(srcRowId);
+      }
+      else {
+        if (!srcRow.isUserResizable) {
+          srcRow.height = undefined;
+        }
+      }
     }
   }));
 

--- a/src/models/document/tile-row.ts
+++ b/src/models/document/tile-row.ts
@@ -6,7 +6,19 @@ export const TileLayoutModel = types
   .model("TileLayout", {
     tileId: types.string,
     widthPct: types.maybe(types.number)
-  });
+  })
+  .volatile(self => ({
+    isUserResizable: false
+  }))
+  .actions(self => ({
+    setWidthpct(widthPct?: number) {
+      self.widthPct = widthPct;
+    },
+    setUserResizable(isUserResizable: boolean) {
+      self.isUserResizable = isUserResizable;
+    }
+  }));
+export type TileLayoutModelType = Instance<typeof TileLayoutModel>;
 
 export const TileRowModel = types
   .model("TileRow", {
@@ -15,17 +27,61 @@ export const TileRowModel = types
     tiles: types.array(TileLayoutModel)
   })
   .views(self => ({
-    isUserResizable(tileMap: any) {
-      return self.tiles.every(tileLayout => {
-        const tile: ToolTileModelType = tileMap.get(tileLayout.tileId);
-        return tile && tile.isUserResizable;
-      });
+    get isUserResizable() {
+      return self.tiles.some(tileRef => tileRef.isUserResizable);
+    },
+    get tileIds() {
+      return self.tiles.map(tile => tile.tileId).join(", ");
+    },
+    hasTile(tileId: string) {
+      return self.tiles.findIndex(tileRef => tileRef.tileId === tileId) >= 0;
+    },
+    indexOfTile(tileId: string) {
+      return self.tiles.findIndex(tileRef => tileRef.tileId === tileId);
+    },
+    renderWidth(tileId: string) {
+      // for now, tiles divide row evenly
+      return 100 / (self.tiles.length || 1);
     }
   }))
   .actions(self => ({
+    updateLayout(tileMap: any) {
+      self.tiles.forEach(tileRef => {
+        const tile: ToolTileModelType = tileMap.get(tileRef.tileId);
+        if (tile) {
+          tileRef.setUserResizable(tile.isUserResizable);
+        }
+      });
+    },
     // undefined height == default to content height
     setRowHeight(height?: number) {
       self.height = height;
+    },
+    insertTileInRow(tile: ToolTileModelType, tileIndex?: number) {
+      const dstTileIndex = (tileIndex != null) && (tileIndex >= 0) && (tileIndex < self.tiles.length)
+                            ? tileIndex
+                            : self.tiles.length;
+      const tileRef = TileLayoutModel.create({ tileId: tile.id });
+      tileRef.setUserResizable(tile.isUserResizable);
+      self.tiles.splice(dstTileIndex, 0, tileRef);
+    },
+    moveTileInRow(tileId: string, fromTileIndex: number, toTileIndex: number) {
+      const dstTileIndex = fromTileIndex < toTileIndex ? toTileIndex - 1 : toTileIndex;
+      const tileIds = self.tiles.map(tileRef => tileRef.tileId);
+      tileIds.splice(fromTileIndex, 1);
+      tileIds.splice(dstTileIndex, 0, tileId);
+      const tileIndexMap: { [id: string]: number } = {};
+      tileIds.forEach((id, index) => { tileIndexMap[id] = index; });
+      const compareFunc = (tileRef1: TileLayoutModelType, tileRef2: TileLayoutModelType) =>
+                            tileIndexMap[tileRef1.tileId] - tileIndexMap[tileRef2.tileId];
+      const sortedTiles = self.tiles.slice().sort(compareFunc);
+      self.tiles.replace(sortedTiles);
+    },
+    removeTileFromRow(tileId: string) {
+      self.tiles.replace(self.tiles.filter(tile => tile.tileId !== tileId));
+      if (!self.isUserResizable) {
+        self.height = undefined;
+      }
     }
   }));
 

--- a/src/models/tools/image/image-content.ts
+++ b/src/models/tools/image/image-content.ts
@@ -15,6 +15,11 @@ export const ImageContentModel = types
     type: types.optional(types.literal(kImageToolID), kImageToolID),
     url: types.maybe(types.string),
   })
+  .views(self => ({
+    get isUserResizable() {
+      return true;
+    }
+  }))
   .extend(self => {
 
     // actions


### PR DESCRIPTION
Support multiple tiles per row [#160634560]
- drop tile at left or right edge of row (w/in 20px) to add tile to row
- sized components (e.g. geometry tool) carry their size with them
- deleting/removing a tile from a row resizes if there are no more sized components
- tiles in row stretch to fill vertical height of row
- drag handlers revert to using `clientY` rather than `pageY` since `pageY` reflects page scroll not element scroll

Note: tiles copied from other documents always go into new row for now. Workaround is to copy them from their new row to the desired row as a second step.