### PR TITLE
Support dragging image tool to geometry to overlay image

### DIFF
--- a/src/components/canvas-tools/geometry-tool.tsx
+++ b/src/components/canvas-tools/geometry-tool.tsx
@@ -188,7 +188,7 @@ class GeometryToolComponentImpl extends BaseComponent<IProps, IState> {
         const geometryContent = content as GeometryContentModelType;
         const droppedContent = parsedContent.content;
         const urlOrProxy = droppedContent && droppedContent.url;
-        getImageDimensions(dimensions => {
+        getImageDimensions((dimensions: any) => {
           const width = dimensions.width / kGeometryDefaultPixelsPerUnit;
           const height = dimensions.height / kGeometryDefaultPixelsPerUnit;
           geometryContent.addImage(board, urlOrProxy, [0, 0], [width, height]);

--- a/src/components/canvas-tools/geometry-tool.tsx
+++ b/src/components/canvas-tools/geometry-tool.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { inject, observer } from "mobx-react";
 import { BaseComponent } from "../base";
 import { ToolTileModelType } from "../../models/tools/tool-tile";
-import { GeometryContentModelType } from "../../models/tools/geometry/geometry-content";
+import { GeometryContentModelType, kGeometryDefaultPixelsPerUnit } from "../../models/tools/geometry/geometry-content";
 import { isPoint, isFreePoint, isVisiblePoint } from "../../models/tools/geometry/jxg-point";
 import { isPolygon } from "../../models/tools/geometry/jxg-polygon";
 import { JXGCoordPair, JXGProperties } from "../../models/tools/geometry/jxg-changes";
@@ -10,6 +10,8 @@ import { assign, cloneDeep, each, isEqual, some } from "lodash";
 import { SizeMe } from "react-sizeme";
 
 import "./geometry-tool.sass";
+import { extractDragTileType, kDragTileContent } from "./tool-tile";
+import { getImageDimensions } from "../../utilities/image-utils";
 
 interface SizeMeProps {
   size?: {
@@ -125,7 +127,8 @@ class GeometryToolComponentImpl extends BaseComponent<IProps, IState> {
     const editableClass = this.props.readOnly ? "read-only" : "editable";
     const classes = `geometry-tool ${editableClass}`;
     return (
-      <div id={this.state.elementId} className={classes} />
+      <div id={this.state.elementId} className={classes}
+          onDragOver={this.handleDragOver} onDrop={this.handleDrop} />
     );
   }
 
@@ -144,6 +147,55 @@ class GeometryToolComponentImpl extends BaseComponent<IProps, IState> {
       const newState = assign({ syncedChanges: content.changes.length },
                                 board ? { board } : null);
       this.setState(newState);
+    }
+  }
+
+  private isAcceptableImageDrag = (e: React.DragEvent<HTMLDivElement>) => {
+    const toolType = extractDragTileType(e.dataTransfer);
+    const kImgDragMargin = 25;
+    if (toolType === "image") {
+      const eltBounds = e.currentTarget.getBoundingClientRect();
+      if ((e.clientX > eltBounds.left + kImgDragMargin) &&
+          (e.clientX < eltBounds.right - kImgDragMargin) &&
+          (e.clientY > eltBounds.top + kImgDragMargin) &&
+          (e.clientY < eltBounds.bottom - kImgDragMargin)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    if (this.isAcceptableImageDrag(e)) {
+      e.dataTransfer.dropEffect = "copy";
+      e.preventDefault();
+    }
+  }
+
+  private handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    if (this.isAcceptableImageDrag(e)) {
+      const dragContent = e.dataTransfer.getData(kDragTileContent);
+      let parsedContent;
+      try {
+        parsedContent = JSON.parse(dragContent);
+      }
+      catch (e) {
+        // ignore errors
+      }
+      const { board } = this.state;
+      if (parsedContent && board) {
+        const { model: { content } } = this.props;
+        const geometryContent = content as GeometryContentModelType;
+        const droppedContent = parsedContent.content;
+        const urlOrProxy = droppedContent && droppedContent.url;
+        getImageDimensions(dimensions => {
+          const width = dimensions.width / kGeometryDefaultPixelsPerUnit;
+          const height = dimensions.height / kGeometryDefaultPixelsPerUnit;
+          geometryContent.addImage(board, urlOrProxy, [0, 0], [width, height]);
+        }, undefined, urlOrProxy);
+        e.preventDefault();
+        e.stopPropagation();
+      }
     }
   }
 

--- a/src/components/canvas-tools/tool-tile.tsx
+++ b/src/components/canvas-tools/tool-tile.tsx
@@ -18,6 +18,21 @@ export const kDragTileId = "org.concord.clue.tile.id";
 export const kDragTileContent = "org.concord.clue.tile.content";
 // allows source compatibility to be checked in dragOver
 export const dragTileSrcDocId = (id: string) => `org.concord.clue.src.${id}`;
+export const dragTileType = (type: string) => `org.concord.clue.tile.type.${type}`;
+
+export function extractDragTileSrcDocId(dataTransfer: DataTransfer) {
+  for (const type of dataTransfer.types) {
+    const result = /org\.concord\.clue\.src\.(.*)$/.exec(type);
+    if (result) return result[1];
+  }
+}
+
+export function extractDragTileType(dataTransfer: DataTransfer) {
+  for (const type of dataTransfer.types) {
+    const result = /org\.concord\.clue\.tile\.type\.(.*)$/.exec(type);
+    if (result) return result[1];
+  }
+}
 
 interface IProps {
   context: string;
@@ -79,6 +94,7 @@ export class ToolTileComponent extends BaseComponent<IProps, {}> {
     e.dataTransfer.setData(kDragTileId, id);
     e.dataTransfer.setData(kDragTileContent, dragData);
     e.dataTransfer.setData(dragTileSrcDocId(docId), docId);
+    e.dataTransfer.setData(dragTileType(model.content.type), model.content.type);
 
     // set the drag image
     const ToolComponent = kToolComponentMap[model.content.type];


### PR DESCRIPTION
Support dragging image tool to geometry to overlay image [#160604676]
- image drop zone is central area more than 25 pixels from edge (to avoid conflict with tile drop zones)
- only works for simple URLs (e.g. curriculum images) - no image upload support yet

Note: I cribbed the `getImageDimensions()` routine from @dstrawberrygirl 's image upload PR, but haven't tried to integrate the image upload itself.