### PR TITLE
Disable dragging to read-only geometry tool instances (e.g. four-up)

### DIFF
--- a/src/components/canvas-tools/geometry-tool.tsx
+++ b/src/components/canvas-tools/geometry-tool.tsx
@@ -158,9 +158,10 @@ class GeometryToolComponentImpl extends BaseComponent<IProps, IState> {
   }
 
   private isAcceptableImageDrag = (e: React.DragEvent<HTMLDivElement>) => {
+    const { readOnly } = this.props;
     const toolType = extractDragTileType(e.dataTransfer);
     const kImgDragMargin = 25;
-    if (toolType === "image") {
+    if (!readOnly && (toolType === "image")) {
       const eltBounds = e.currentTarget.getBoundingClientRect();
       if ((e.clientX > eltBounds.left + kImgDragMargin) &&
           (e.clientX < eltBounds.right - kImgDragMargin) &&


### PR DESCRIPTION
Disable dragging to read-only geometry tool instances [#161272097]
