### PR TITLE
Adds remote endpoint to log messages

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -11,6 +11,7 @@ const applicationName = "CLUE";
 
 interface LogMessage {
   application: string;
+  run_remote_endpoint?: string;
   username: string;
   classHash: string;
   session: string;
@@ -140,7 +141,7 @@ export class Logger {
     }
     if (parameters) delete parameters.section;
 
-    return {
+    const logMessage: LogMessage = {
       application: applicationName,
       username:  user.id,
       classHash: user.classHash,
@@ -154,6 +155,12 @@ export class Logger {
       method: "do",           // eventually we will want to support undo, redo
       parameters
     };
+
+    if (user.loggingRemoteEndpoint) {
+      logMessage.run_remote_endpoint = user.loggingRemoteEndpoint;
+    }
+
+    return logMessage;
   }
 
   private getDocumentForTile(tileId: string): {type: string, key?: string, section?: string, uid?: string } {

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -1,5 +1,5 @@
 import { types } from "mobx-state-tree";
-import { AuthenticatedUser } from "../lib/auth";
+import { AuthenticatedUser, PortalFirebaseStudentJWT } from "../lib/auth";
 const initials = require("initials");
 
 export const UserTypeEnum = types.enumeration("type", ["student", "teacher"]);
@@ -16,6 +16,7 @@ export const UserModel = types
     offeringId: "",
     latestGroupId: types.maybe(types.string),
     portal: "",
+    loggingRemoteEndpoint: types.maybe(types.string)
   })
   .actions((self) => ({
     setName(name: string) {
@@ -43,6 +44,9 @@ export const UserModel = types
       self.className = user.className;
       self.classHash = user.classHash;
       self.offeringId = user.offeringId;
+      if (user.firebaseJWT && (user.firebaseJWT as PortalFirebaseStudentJWT).returnUrl) {
+        self.loggingRemoteEndpoint = (user.firebaseJWT as PortalFirebaseStudentJWT).returnUrl;
+      }
     },
   }))
   .views((self) => ({


### PR DESCRIPTION
Small addition to the logs to add the property `run_remote_endpoint`, which is used by our standard log-filtering systems.

This first adds it to the user model, from the Firebase JWT Token, and then adds it to each log message if it exists.

[#161299394]