### PR TITLE
Fix geometry bugs

### DIFF
--- a/src/components/canvas-tools/geometry-tool.tsx
+++ b/src/components/canvas-tools/geometry-tool.tsx
@@ -297,7 +297,9 @@ class GeometryToolComponentImpl extends BaseComponent<IProps, IState> {
         const props = { snapToGrid: true, snapSizeX: kSnapUnit, snapSizeY: kSnapUnit };
         this.applyChange(() => {
           const point = content.addPoint(board, [x, y], props) as JXG.Point;
-          this.handleCreatePoint(point);
+          if (point) {
+            this.handleCreatePoint(point);
+          }
         });
       }
     };
@@ -317,7 +319,9 @@ class GeometryToolComponentImpl extends BaseComponent<IProps, IState> {
         if (board && (content.type === "Geometry")) {
           this.applyChange(() => {
             const polygon = content.createPolygonFromFreePoints(board) as JXG.Polygon;
-            this.handleCreatePolygon(polygon);
+            if (polygon) {
+              this.handleCreatePolygon(polygon);
+            }
           });
           this.lastPointDown = undefined;
         }

--- a/src/components/canvas-tools/geometry-tool.tsx
+++ b/src/components/canvas-tools/geometry-tool.tsx
@@ -52,6 +52,24 @@ function getEventCoords(board: JXG.Board, evt: any, scale?: number, index?: numb
 
   return new JXG.Coords(JXG.COORDS_BY_SCREEN, [dx, dy], board);
 }
+
+function syncBoardChanges(board: JXG.Board, content: GeometryContentModelType,
+                          syncedChanges?: number, readOnly?: boolean) {
+  for (let i = syncedChanges || 0; i < content.changes.length; ++i) {
+    try {
+      const change = JSON.parse(content.changes[i]);
+      const result = content.syncChange(board, change);
+      if (readOnly && (result instanceof JXG.GeometryElement)) {
+        const obj = result as JXG.GeometryElement;
+        obj.setAttribute({ fixed: true });
+      }
+    }
+    catch (e) {
+      // ignore exceptions
+    }
+  }
+  return content.changes.length;
+}
 ​
 @inject("stores")
 @observer
@@ -86,20 +104,8 @@ class GeometryToolComponentImpl extends BaseComponent<IProps, IState> {
 
     if (content !== prevState.content) {
       if (geometryContent.changes.length !== prevState.syncedChanges) {
-        for (let i = prevState.syncedChanges || 0; i < geometryContent.changes.length; ++i) {
-          try {
-            const change = JSON.parse(geometryContent.changes[i]);
-            const result = geometryContent.syncChange(prevState.board, change);
-            if (readOnly && (result instanceof JXG.GeometryElement)) {
-              const obj = result as JXG.GeometryElement;
-              obj.setAttribute({ fixed: true });
-            }
-          }
-          catch (e) {
-            // ignore exceptions
-          }
-        }
-        nextState.syncedChanges = geometryContent.changes.length;
+        nextState.syncedChanges = syncBoardChanges(prevState.board, geometryContent,
+                                                  prevState.syncedChanges, readOnly);
       }
       nextState.content = geometryContent;
     }
@@ -199,7 +205,16 @@ class GeometryToolComponentImpl extends BaseComponent<IProps, IState> {
         getImageDimensions(undefined, urlOrProxy).then((dimensions: any) => {
           const width = dimensions.width / kGeometryDefaultPixelsPerUnit;
           const height = dimensions.height / kGeometryDefaultPixelsPerUnit;
-          geometryContent.addImage(board, urlOrProxy, [0, 0], [width, height]);
+          const imageIds = geometryContent
+                            .findObjects(board, obj => obj.elType === "image")
+                            .map(obj => obj.id);
+          this.applyChanges(() => {
+            if (imageIds.length) {
+              // remove any previous images
+              geometryContent.removeObjects(board, imageIds);
+            }
+            geometryContent.addImage(board, urlOrProxy, [0, 0], [width, height]);
+          });
         });
         e.preventDefault();
         e.stopPropagation();
@@ -221,6 +236,22 @@ class GeometryToolComponentImpl extends BaseComponent<IProps, IState> {
 
   private applyChange(change: () => void) {
     this.setState({ syncedChanges: (this.state.syncedChanges || 0) + 1 }, change);
+  }
+
+  private applyChanges(changes: () => void) {
+    const { model: { content }, readOnly } = this.props;
+    const geometryContent = content as GeometryContentModelType;
+    const { board } = this.state;
+    if (!geometryContent || !board) return;
+
+    // update the geometry without updating the model
+    geometryContent.suspendSync();
+    changes();
+
+    // update the model as a batch
+    const changeCount = geometryContent.batchChangeCount;
+    this.setState({ syncedChanges: (this.state.syncedChanges || 0) + changeCount },
+                  () => geometryContent.resumeSync());
   }
 
   private isSqrDistanceWithinThreshold(threshold: number, c1?: JXG.Coords, c2?: JXG.Coords) {

--- a/src/components/canvas-tools/geometry-tool.tsx
+++ b/src/components/canvas-tools/geometry-tool.tsx
@@ -210,10 +210,16 @@ class GeometryToolComponentImpl extends BaseComponent<IProps, IState> {
                             .map(obj => obj.id);
           this.applyChanges(() => {
             if (imageIds.length) {
-              // remove any previous images
-              geometryContent.removeObjects(board, imageIds);
+              // change URL if there's already an image present
+              const imageId = imageIds[imageIds.length - 1];
+              geometryContent.updateObjectsOfType(board, "image", imageId, {
+                                                    url: urlOrProxy,
+                                                    size: [width, height]
+                                                  });
             }
-            geometryContent.addImage(board, urlOrProxy, [0, 0], [width, height]);
+            else {
+              geometryContent.addImage(board, urlOrProxy, [0, 0], [width, height]);
+            }
           });
         });
         e.preventDefault();

--- a/src/models/tools/geometry/geometry-content.ts
+++ b/src/models/tools/geometry/geometry-content.ts
@@ -1,6 +1,6 @@
 import { types, Instance } from "mobx-state-tree";
 import { applyChange, applyChanges } from "./jxg-dispatcher";
-import { JXGChange, JXGProperties, JXGCoordPair } from "./jxg-changes";
+import { JXGChange, JXGProperties, JXGCoordPair, JXGObjectType } from "./jxg-changes";
 import { isFreePoint } from "./jxg-point";
 import { assign } from "lodash";
 import * as uuid from "uuid/v4";
@@ -143,6 +143,17 @@ export const GeometryContentModel = types
       return _applyChange(board, change);
     }
 
+    function updateObjectsOfType(board: JXG.Board, type: JXGObjectType,
+                                 ids: string | string[], properties: JXGProperties | JXGProperties[]) {
+      const change: JXGChange = {
+              operation: "update",
+              target: type,
+              targetID: ids,
+              properties
+            };
+      return _applyChange(board, change);
+    }
+
     function createPolygonFromFreePoints(board: JXG.Board, properties?: JXGProperties): JXG.Polygon | undefined {
       const freePtIds = board.objectsList
                           .filter(elt => isFreePoint(elt))
@@ -203,6 +214,7 @@ export const GeometryContentModel = types
         addPoint,
         removeObjects,
         updateObjects,
+        updateObjectsOfType,
         createPolygonFromFreePoints,
         findObjects,
         applyChange: _applyChange,

--- a/src/models/tools/geometry/jsxgraph.d.ts
+++ b/src/models/tools/geometry/jsxgraph.d.ts
@@ -63,6 +63,7 @@ declare namespace JXG {
 
   class GeometryElement {
     id: string;
+    elType: string;
     type: number;
     ancestors: { [id: string]: GeometryElement };
     visProp: { [prop: string]: any };

--- a/src/models/tools/geometry/jsxgraph.d.ts
+++ b/src/models/tools/geometry/jsxgraph.d.ts
@@ -83,6 +83,8 @@ declare namespace JXG {
   class Image extends CoordsElement {
     size: [number, number];
     url: string;
+
+    setSize: (width: number, height: number) => void;
   }
 
   class Point extends CoordsElement {

--- a/src/models/tools/geometry/jxg-image.ts
+++ b/src/models/tools/geometry/jxg-image.ts
@@ -8,7 +8,7 @@ export const isImage = (v: any) => v instanceof JXG.Image;
 export const imageChangeAgent: JXGChangeAgent = {
   create: (board: JXG.Board, change: JXGChange) => {
     const parents = change.parents;
-    const props = assign({ id: uuid() }, change.properties);
+    const props = assign({ id: uuid(), fixed: true }, change.properties);
     return parents && parents.length >= 3
             ? board.create("image", change.parents, props)
             : undefined;

--- a/src/models/tools/geometry/jxg-image.ts
+++ b/src/models/tools/geometry/jxg-image.ts
@@ -15,7 +15,26 @@ export const imageChangeAgent: JXGChangeAgent = {
   },
 
   // update can be handled generically
-  update: objectChangeAgent.update,
+  update: (board, change) => {
+    if (!change.targetID || !change.properties) { return; }
+    const ids = Array.isArray(change.targetID) ? change.targetID : [change.targetID];
+    const props = Array.isArray(change.properties) ? change.properties : [change.properties];
+    ids.forEach((id, index) => {
+      const obj = board.objects[id] as JXG.GeometryElement;
+      const image = isImage(obj) ? obj as JXG.Image : undefined;
+      const objProps = index < props.length ? props[index] : props[0];
+      if (image && objProps) {
+        const { url, size } = objProps;
+        if (url != null) {
+          image.url = url;
+        }
+        if (size != null) {
+          image.setSize(size[0], size[1]);
+        }
+      }
+    });
+    objectChangeAgent.update(board, change);
+  },
 
   // delete can be handled generically
   delete: objectChangeAgent.delete


### PR DESCRIPTION
- Add null test before handleCreatePolygon() [#161349320]
- Prevent geometry background images from being dragged [#161343613]
- Remove previous image when dropping image on geometry [#161343613]

The first two were trivial. The last one required adding the ability to batch multiple changes.