### PR TITLE
Geometry tool supports selecting points

### DIFF
--- a/src/components/canvas-tools/geometry-tool.tsx
+++ b/src/components/canvas-tools/geometry-tool.tsx
@@ -323,7 +323,6 @@ class GeometryToolComponentImpl extends BaseComponent<IProps, IState> {
       if (this.domElement) {
         // requires non-empty tabIndex
         this.domElement.focus();
-        evt.preventDefault();
       }
       // first click selects the tile; subsequent clicks create points
       if (!ui.isSelectedTile(model)) {

--- a/src/components/canvas-tools/geometry-tool.tsx
+++ b/src/components/canvas-tools/geometry-tool.tsx
@@ -282,7 +282,7 @@ class GeometryToolComponentImpl extends BaseComponent<IProps, IState> {
   }
 
   private applyChanges(changes: () => void) {
-    const { model: { content }, readOnly } = this.props;
+    const { model: { content } } = this.props;
     const geometryContent = content as GeometryContentModelType;
     const { board } = this.state;
     if (!geometryContent || !board) return;

--- a/src/components/canvas-tools/geometry-tool.tsx
+++ b/src/components/canvas-tools/geometry-tool.tsx
@@ -212,10 +212,10 @@ class GeometryToolComponentImpl extends BaseComponent<IProps, IState> {
             if (imageIds.length) {
               // change URL if there's already an image present
               const imageId = imageIds[imageIds.length - 1];
-              geometryContent.updateObjectsOfType(board, "image", imageId, {
-                                                    url: urlOrProxy,
-                                                    size: [width, height]
-                                                  });
+              geometryContent.updateObjects(board, imageId, {
+                                              url: urlOrProxy,
+                                              size: [width, height]
+                                            });
             }
             else {
               geometryContent.addImage(board, urlOrProxy, [0, 0], [width, height]);

--- a/src/components/canvas-tools/geometry-tool.tsx
+++ b/src/components/canvas-tools/geometry-tool.tsx
@@ -127,7 +127,7 @@ class GeometryToolComponentImpl extends BaseComponent<IProps, IState> {
   public componentDidMount() {
     this.initializeContent();
 
-    if (this.props.toolApiInterface) {
+    if (!this.props.readOnly && this.props.toolApiInterface) {
       this.props.toolApiInterface.register(this.props.model.id, {
         hasSelection: () => {
           const geometryContent = this.props.model.content as GeometryContentModelType;
@@ -205,13 +205,13 @@ class GeometryToolComponentImpl extends BaseComponent<IProps, IState> {
   }
 
   private handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    const { board } = this.state;
     const kBackspaceKeyCode = 8;
     const kDeleteKeyCode = 46;
-    if (board && ((e.keyCode === kBackspaceKeyCode) || (e.keyCode === kDeleteKeyCode))) {
+    if (!this.props.readOnly && this.state.board &&
+        ((e.keyCode === kBackspaceKeyCode) || (e.keyCode === kDeleteKeyCode))) {
       const geometryContent = this.props.model.content as GeometryContentModelType;
       if (geometryContent.hasSelection()) {
-        geometryContent.deleteSelection(board);
+        geometryContent.deleteSelection(this.state.board);
       }
     }
   }
@@ -398,8 +398,8 @@ class GeometryToolComponentImpl extends BaseComponent<IProps, IState> {
             this.handleCreatePoint(point);
 
             // select newly created points without referring to content
-            metadata.select(point.id);
-            setElementColor(board, point.id, true);
+            // metadata.select(point.id);
+            // setElementColor(board, point.id, true);
           }
         });
       }
@@ -432,7 +432,7 @@ class GeometryToolComponentImpl extends BaseComponent<IProps, IState> {
         this.dragPts[id] = { initial: coords };
         this.lastPointDown = { evt, coords };
 
-        // click on selected element - deselect unless appropriate modifier key is down
+        // click on selected element - deselect if appropriate modifier key is down
         if (geometryContent.isSelected(id)) {
           if (evt.ctrlKey || evt.metaKey) {
             geometryContent.deselectElement(board, id);

--- a/src/components/canvas-tools/tool-tile.tsx
+++ b/src/components/canvas-tools/tool-tile.tsx
@@ -12,6 +12,20 @@ import ImageToolComponent from "./image-tool";
 import { cloneDeep } from "lodash";
 import "./tool-tile.sass";
 
+export interface IToolApi {
+  hasSelection: () => boolean;
+  deleteSelection: () => void;
+}
+
+export interface IToolApiInterface {
+  register: (id: string, toolApi: IToolApi) => void;
+  unregister: (id: string) => void;
+}
+
+export interface IToolApiMap {
+  [id: string]: IToolApi;
+}
+
 export const kDragRowHeight = "org.concord.clue.row.height";
 export const kDragTileSource = "org.concord.clue.tile.src";
 export const kDragTileId = "org.concord.clue.tile.id";

--- a/src/components/canvas-tools/tool-tile.tsx
+++ b/src/components/canvas-tools/tool-tile.tsx
@@ -38,6 +38,7 @@ interface IProps {
   context: string;
   docId: string;
   scale?: number;
+  tabIndex?: number;
   widthPct?: number;
   height?: number;
   model: ToolTileModelType;

--- a/src/components/canvas.tsx
+++ b/src/components/canvas.tsx
@@ -4,6 +4,7 @@ import { IBaseProps } from "./base";
 import { DocumentModelType } from "../models/document";
 import { DocumentContentComponent } from "./document-content";
 import { DocumentContentModelType } from "../models/document-content";
+import { IToolApiInterface } from "./canvas-tools/tool-tile";
 
 import "./canvas.sass";
 
@@ -16,6 +17,7 @@ interface IProps extends IBaseProps {
   document?: DocumentModelType;
   content?: DocumentContentModelType;
   editabilityLocation?: EditabilityLocation;
+  toolApiInterface?: IToolApiInterface;
 }
 
 @observer

--- a/src/components/document-content.tsx
+++ b/src/components/document-content.tsx
@@ -228,8 +228,7 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
     if (!srcRowId) return;
     const srcRowIndex = content.rowOrder.findIndex(rowId => rowId === srcRowId);
     const dropRowInfo  = this.getDropRowInfo(e);
-    const { rowInsertIndex, rowDropIndex, dropOffsetLeft,
-            dropOffsetTop, dropOffsetRight, dropOffsetBottom } = dropRowInfo;
+    const { rowInsertIndex, rowDropIndex, dropOffsetLeft, dropOffsetRight } = dropRowInfo;
     if ((rowDropIndex != null) &&
         (dropOffsetLeft != null) &&
         (dropOffsetLeft < kSideDropThreshold) &&

--- a/src/components/document-content.tsx
+++ b/src/components/document-content.tsx
@@ -77,12 +77,16 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
     const { content, ...others } = this.props;
     if (!content) { return null; }
     const { rowMap, rowOrder, tileMap } = content;
+    let tabIndex = 1;
     return rowOrder.map(rowId => {
       const row = rowMap.get(rowId);
       const rowHeight = this.getRowHeight(rowId);
+      const _tabIndex = tabIndex;
+      tabIndex += row ? row.tiles.length : 0;
       return row
               ? <TileRowComponent key={row.id} docId={content.contentId} model={row}
-                                  height={rowHeight} tileMap={tileMap} {...others} />
+                                  tabIndex={_tabIndex} height={rowHeight} tileMap={tileMap}
+                                  {...others} />
               : null;
     });
   }

--- a/src/components/document.tsx
+++ b/src/components/document.tsx
@@ -6,15 +6,12 @@ import { CanvasComponent } from "./canvas";
 import { FourUpComponent } from "./four-up";
 import { BaseComponent, IBaseProps } from "./base";
 import { DocumentModelType,
-         SectionDocument,
-         LearningLogDocument,
-         PublicationDocument,
-         DocumentTool
-       } from "../models/document";
+          SectionDocument, LearningLogDocument, PublicationDocument } from "../models/document";
+import { ToolbarComponent } from "./toolbar";
+import { IToolApi, IToolApiInterface, IToolApiMap } from "./canvas-tools/tool-tile";
 import { WorkspaceModelType } from "../models/workspace";
 
 import "./document.sass";
-import { ToolbarComponent } from "./toolbar";
 
 export type WorkspaceSide = "primary" | "comparison";
 
@@ -29,6 +26,22 @@ interface IProps extends IBaseProps {
 @inject("stores")
 @observer
 export class DocumentComponent extends BaseComponent<IProps, {}> {
+
+  private toolApiMap: IToolApiMap = {};
+  private toolApiInterface: IToolApiInterface;
+
+  constructor(props: IProps) {
+    super(props);
+
+    this.toolApiInterface = {
+      register: (id: string, toolApi: IToolApi) => {
+        this.toolApiMap[id] = toolApi;
+      },
+      unregister: (id: string) => {
+        delete this.toolApiMap[id];
+      }
+    };
+  }
 
   public render() {
     const {document, isGhostUser, readOnly} = this.props;
@@ -62,7 +75,6 @@ export class DocumentComponent extends BaseComponent<IProps, {}> {
     const {workspace, document} = this.props;
     const activeSection = problem.getSectionById(document.sectionId!);
     const show4up = !workspace.comparisonVisible;
-    const share = document.visibility === "private" ? "share" : "unshare";
     return (
       <div className="titlebar">
         <div className="title">{activeSection ? `Section: ${activeSection.title}` : "Section"}</div>
@@ -123,7 +135,8 @@ export class DocumentComponent extends BaseComponent<IProps, {}> {
   }
 
   private renderToolbar() {
-    return <ToolbarComponent key="toolbar" document={this.props.document} />;
+    return <ToolbarComponent key="toolbar" document={this.props.document}
+                              toolApiMap={this.toolApiMap} />;
   }
 
   private renderCanvas() {
@@ -160,7 +173,8 @@ export class DocumentComponent extends BaseComponent<IProps, {}> {
   private render1UpCanvas(forceReadOnly?: boolean) {
     const readOnly = forceReadOnly ? true : this.props.readOnly;
     return (
-      <CanvasComponent context="1-up" document={this.props.document} readOnly={readOnly} />
+      <CanvasComponent context="1-up" document={this.props.document} readOnly={readOnly}
+                        toolApiInterface={this.toolApiInterface} />
     );
   }
 
@@ -168,7 +182,8 @@ export class DocumentComponent extends BaseComponent<IProps, {}> {
     const {isGhostUser, document} = this.props;
     const {sectionWorkspace} = this.stores.ui;
     return (
-      <FourUpComponent document={document} workspace={sectionWorkspace} isGhostUser={isGhostUser} />
+      <FourUpComponent document={document} workspace={sectionWorkspace} isGhostUser={isGhostUser}
+                        toolApiInterface={this.toolApiInterface} />
     );
   }
 

--- a/src/components/document/tile-row.tsx
+++ b/src/components/document/tile-row.tsx
@@ -91,7 +91,7 @@ export class TileRowComponent extends BaseComponent<IProps, {}> {
   }
 
   private renderBottomResizeHandle() {
-    const { model, tileMap } = this.props;
+    const { model } = this.props;
     if (this.props.readOnly || !model.isUserResizable) return null;
     return <div className="bottom-resize-handle" draggable={true} onDragStart={this.handleStartResizeRow}/>;
   }

--- a/src/components/document/tile-row.tsx
+++ b/src/components/document/tile-row.tsx
@@ -49,6 +49,7 @@ interface IProps {
   docId: string;
   scale?: number;
   model: TileRowModelType;
+  tabIndex?: number;
   height?: number;
   tileMap: any;
   readOnly?: boolean;
@@ -74,15 +75,16 @@ export class TileRowComponent extends BaseComponent<IProps, {}> {
   }
 
   private renderTiles(rowHeight?: number) {
-    const { model, tileMap, ...others } = this.props;
+    const { model, tileMap, tabIndex, ...others } = this.props;
     const { tiles } = model;
     if (!tiles) { return null; }
 
-    return tiles.map(tileRef => {
+    return tiles.map((tileRef, index) => {
       const tileModel: ToolTileModelType = tileMap.get(tileRef.tileId);
       const tileWidthPct = model.renderWidth(tileRef.tileId);
+      const _tabIndex = tabIndex ? tabIndex + index : tabIndex;
       return tileModel
-              ? <ToolTileComponent key={tileModel.id} model={tileModel}
+              ? <ToolTileComponent key={tileModel.id} model={tileModel} tabIndex={_tabIndex}
                                     widthPct={tileWidthPct} height={rowHeight} {...others} />
               : null;
     });

--- a/src/components/four-up.tsx
+++ b/src/components/four-up.tsx
@@ -5,15 +5,17 @@ import { CellPositions, FourUpGridCellModelType, FourUpGridModel,
          FourUpGridModelType } from "../models/four-up-grid";
 import { CanvasComponent } from "./canvas";
 import { BaseComponent, IBaseProps } from "./base";
-
-import "./four-up.sass";
 import { DocumentModelType } from "../models/document";
 import { WorkspaceModelType } from "../models/workspace";
+import { IToolApiInterface } from "./canvas-tools/tool-tile";
+
+import "./four-up.sass";
 
 interface IProps extends IBaseProps {
   document?: DocumentModelType;
   workspace: WorkspaceModelType;
   isGhostUser?: boolean;
+  toolApiInterface?: IToolApiInterface;
 }
 
 interface FourUpUser {

--- a/src/models/tools/geometry/geometry-content.test.ts
+++ b/src/models/tools/geometry/geometry-content.test.ts
@@ -74,7 +74,7 @@ describe("GeometryContent", () => {
     const board = createDefaultBoard(content);
     expect(isPoint(board)).toBe(false);
     const p1Id = "point-1";
-    let p1: JXG.Point = board.objects[p1Id];
+    let p1: JXG.Point = board.objects[p1Id] as JXG.Point;
     expect(p1).toBeUndefined();
     p1 = content.addPoint(board, [1, 1], { id: p1Id }) as JXG.Point;
     expect(isPoint(p1)).toBe(true);

--- a/src/models/tools/geometry/geometry-content.test.ts
+++ b/src/models/tools/geometry/geometry-content.test.ts
@@ -1,11 +1,13 @@
 import { GeometryContentModel, GeometryContentModelType,
-          kGeometryToolID, defaultGeometryContent } from "./geometry-content";
+          kGeometryToolID, defaultGeometryContent, GeometryMetadataModel } from "./geometry-content";
 import { JXGChange } from "./jxg-changes";
 import { isBoard } from "./jxg-board";
 import { isPoint, isFreePoint } from "./jxg-point";
 import { isPolygon } from "./jxg-polygon";
 import { isUuid } from "../../../utilities/test-utils";
 import { clone } from "lodash";
+
+const placeholderImage = require("../../../assets/image_placeholder.png");
 
 describe("GeometryContent", () => {
 
@@ -23,7 +25,11 @@ describe("GeometryContent", () => {
     const divStyle = "width:200px;height:200px";
     document.body.innerHTML = `<div id="${divId}" style="${divStyle}"></div>`;
 
-    return content.initializeBoard(divId) as JXG.Board;
+    function onCreate(elt: JXG.GeometryElement) {
+      // handle a point
+    }
+
+    return content.initializeBoard(divId, onCreate) as JXG.Board;
   }
 
   it("can create/destroy a JSXGraph board", () => {
@@ -35,6 +41,8 @@ describe("GeometryContent", () => {
     expect(isUuid(board.id)).toBe(true);
 
     content.resizeBoard(board, 200, 200);
+    content.updateScale(board, 0.5);
+    expect(board.cssTransMat).toEqual([[1, 0, 0], [0, 2, 0], [0, 0, 2]]);
 
     content.destroyBoard(board);
 
@@ -124,5 +132,77 @@ describe("GeometryContent", () => {
     // can't create polygon without vertices
     polygon = content.applyChange(board, { operation: "create", target: "polygon" }) as JXG.Polygon;
     expect(polygon).toBeUndefined();
+  });
+
+  it("can add an image", () => {
+    const content = defaultGeometryContent();
+    const board = createDefaultBoard(content);
+    const image = content.addImage(board, placeholderImage, [0, 0], [5, 5]);
+    expect(image!.elType).toBe("image");
+    content.updateObjects(board, image!.id, { url: placeholderImage });
+    expect(image!.url).toBe(placeholderImage);
+    content.updateObjects(board, image!.id, { size: [10, 10] });
+    content.updateObjects(board, image!.id, { url: placeholderImage, size: [10, 10] });
+    expect(image!.url).toBe(placeholderImage);
+
+    const change: JXGChange = {
+      operation: "create",
+      target: "image",
+      parents: [placeholderImage],
+      properties: { id: "image-fail" }
+    };
+    const failedImage = content.applyChange(board, change);
+    expect(failedImage).toBeUndefined();
+  });
+
+  it("can select points, etc.", () => {
+    const content = defaultGeometryContent();
+    const metadata = GeometryMetadataModel.create({ id: "geometry-1" });
+    content.doPostCreate(metadata);
+    const board = createDefaultBoard(content);
+    const p1 = content.addPoint(board, [0, 0]);
+    const p2 = content.addPoint(board, [1, 1]);
+    const p3 = content.addPoint(board, [1, 0]);
+    const poly = content.createPolygonFromFreePoints(board);
+    content.selectObjects(board, p1!.id);
+    expect(content.isSelected(p1!.id)).toBe(true);
+    expect(content.isSelected(p2!.id)).toBe(false);
+    content.selectObjects(board, poly!.id);
+    expect(content.isSelected(poly!.id)).toBe(true);
+    expect(content.hasSelection()).toBe(true);
+    let found = content.findObjects(board, obj => {
+                  return obj.id === p1!.id;
+                });
+    expect(found.length).toBe(1);
+    content.deselectObjects(board, p1!.id);
+    expect(content.isSelected(p1!.id)).toBe(false);
+    content.deselectAll(board);
+    expect(content.hasSelection()).toBe(false);
+    content.selectObjects(board, p1!.id);
+    content.deleteSelection(board);
+    expect(content.hasSelection()).toBe(false);
+    found = content.findObjects(board, obj => {
+              return obj.id === p1!.id;
+            });
+    expect(found.length).toBe(0);
+    content.deleteSelection(board);
+    expect(found.length).toBe(0);
+  });
+
+  it("can suspend/resume syncChanges", () => {
+    const content = defaultGeometryContent();
+    const board = createDefaultBoard(content);
+    expect(content.isSyncSuspended).toBe(false);
+    content.suspendSync();
+    expect(content.isSyncSuspended).toBe(true);
+    content.suspendSync();
+    expect(content.isSyncSuspended).toBe(true);
+    content.addPoint(board, [1, 1], { id: "p1" });
+    content.resumeSync();
+    expect(content.isSyncSuspended).toBe(true);
+    content.resumeSync();
+    expect(content.isSyncSuspended).toBe(false);
+    expect(content.batchChangeCount).toBe(0);
+    expect(content.isUserResizable).toBe(true);
   });
 });

--- a/src/models/tools/geometry/geometry-content.ts
+++ b/src/models/tools/geometry/geometry-content.ts
@@ -292,6 +292,9 @@ export const GeometryContentModel = types
         get isUserResizable() {
           return true;
         },
+        get isSyncSuspended() {
+          return suspendCount > 0;
+        },
         get batchChangeCount() {
           return batchChanges.length;
         }

--- a/src/models/tools/geometry/geometry-content.ts
+++ b/src/models/tools/geometry/geometry-content.ts
@@ -1,11 +1,10 @@
 import { types, Instance } from "mobx-state-tree";
 import { applyChange, applyChanges } from "./jxg-dispatcher";
 import { JXGChange, JXGProperties, JXGCoordPair } from "./jxg-changes";
-import { isFreePoint, kPointDefaults, isPoint } from "./jxg-point";
-import { assign, each, size as _size } from "lodash";
+import { isFreePoint, kPointDefaults } from "./jxg-point";
+import { assign, size as _size } from "lodash";
 import * as uuid from "uuid/v4";
 import { isBoard } from "./jxg-board";
-import { isPolygon } from "./jxg-polygon";
 
 export const kGeometryToolID = "Geometry";
 
@@ -65,7 +64,7 @@ export const GeometryMetadataModel = types
   }));
 export type GeometryMetadataModelType = Instance<typeof GeometryMetadataModel>;
 
-function setElementColor(board: JXG.Board, id: string, selected: boolean) {
+export function setElementColor(board: JXG.Board, id: string, selected: boolean) {
   const element = board.objects[id];
   if (element) {
     element.setAttribute({

--- a/src/models/tools/geometry/geometry-content.ts
+++ b/src/models/tools/geometry/geometry-content.ts
@@ -1,10 +1,11 @@
 import { types, Instance } from "mobx-state-tree";
 import { applyChange, applyChanges } from "./jxg-dispatcher";
-import { JXGChange, JXGProperties, JXGCoordPair, JXGObjectType } from "./jxg-changes";
-import { isFreePoint } from "./jxg-point";
-import { assign } from "lodash";
+import { JXGChange, JXGProperties, JXGCoordPair } from "./jxg-changes";
+import { isFreePoint, kPointDefaults, isPoint } from "./jxg-point";
+import { assign, each, size as _size } from "lodash";
 import * as uuid from "uuid/v4";
 import { isBoard } from "./jxg-board";
+import { isPolygon } from "./jxg-polygon";
 
 export const kGeometryToolID = "Geometry";
 
@@ -32,11 +33,100 @@ export function defaultGeometryContent(overrides?: JXGProperties) {
   return GeometryContentModel.create({ changes: [changeJson] });
 }
 
+// track selection in metadata object so it is not saved to firebase but
+// also is preserved across document/content reloads
+export const GeometryMetadataModel = types
+  .model("GeometryMetadata", {
+    id: types.string,
+    selection: types.map(types.boolean)
+  })
+  .views(self => ({
+    isSelected(id: string) {
+      return !!self.selection.get(id);
+    },
+    hasSelection() {
+      let hasSelection = false;
+      // TODO: short-circuit after first true
+      self.selection.forEach(value => {
+        if (value) {
+          hasSelection = true;
+        }
+      });
+      return hasSelection;
+    }
+  }))
+  .actions(self => ({
+    select(id: string) {
+      self.selection.set(id, true);
+    },
+    deselect(id: string) {
+      self.selection.set(id, false);
+    }
+  }));
+export type GeometryMetadataModelType = Instance<typeof GeometryMetadataModel>;
+
+function setElementColor(board: JXG.Board, id: string, selected: boolean) {
+  const element = board.objects[id];
+  if (element) {
+    element.setAttribute({
+              fillColor: selected ? kPointDefaults.selectedFillColor : kPointDefaults.fillColor,
+              strokeColor: selected ? kPointDefaults.selectedStrokeColor : kPointDefaults.strokeColor
+            });
+  }
+}
+
 export const GeometryContentModel = types
   .model("GeometryContent", {
     type: types.optional(types.literal(kGeometryToolID), kGeometryToolID),
     changes: types.array(types.string)
   })
+  .volatile(self => ({
+    metadata: undefined as any as GeometryMetadataModelType
+  }))
+  .views(self => ({
+    isSelected(id: string) {
+      return self.metadata.isSelected(id);
+    },
+    hasSelection() {
+      return self.metadata.hasSelection();
+    }
+  }))
+  .actions(self => ({
+    selectElement(board: JXG.Board, id: string) {
+      if (!self.isSelected(id)) {
+        self.metadata.select(id);
+        setElementColor(board, id, true);
+      }
+    },
+    deselectElement(board: JXG.Board, id: string) {
+      if (self.isSelected(id)) {
+        self.metadata.deselect(id);
+        setElementColor(board, id, false);
+      }
+    }
+  }))
+  .actions(self => ({
+    doPostCreate(metadata: GeometryMetadataModelType) {
+      self.metadata = metadata;
+    },
+    selectObjects(board: JXG.Board, ids: string | string[]) {
+      const _ids = Array.isArray(ids) ? ids : [ids];
+      _ids.forEach(id => {
+        self.selectElement(board, id);
+      });
+    },
+    deselectObjects(board: JXG.Board, ids: string | string[]) {
+      const _ids = Array.isArray(ids) ? ids : [ids];
+      _ids.forEach(id => {
+        self.deselectElement(board, id);
+      });
+    },
+    deselectAll(board: JXG.Board) {
+      self.metadata.selection.forEach((value, id) => {
+        self.deselectElement(board, id);
+      });
+    }
+  }))
   .extend(self => {
 
     let viewCount = 0;
@@ -163,6 +253,20 @@ export const GeometryContentModel = types
       return board.objectsList.filter(test);
     }
 
+    function deleteSelection(board: JXG.Board) {
+      const ids: string[] = [];
+      self.metadata.selection.forEach((value, id) => {
+        if (value) {
+          ids.push(id);
+        }
+      });
+      if (ids.length) {
+        self.deselectAll(board);
+        board.showInfobox(false);
+        removeObjects(board, ids);
+      }
+    }
+
     function _applyChange(board: JXG.Board, change: JXGChange) {
       const result = syncChange(board, change);
       const jsonChange = JSON.stringify(change);
@@ -205,6 +309,7 @@ export const GeometryContentModel = types
         updateObjects,
         createPolygonFromFreePoints,
         findObjects,
+        deleteSelection,
         applyChange: _applyChange,
         syncChange,
 

--- a/src/models/tools/geometry/geometry-content.ts
+++ b/src/models/tools/geometry/geometry-content.ts
@@ -143,17 +143,6 @@ export const GeometryContentModel = types
       return _applyChange(board, change);
     }
 
-    function updateObjectsOfType(board: JXG.Board, type: JXGObjectType,
-                                 ids: string | string[], properties: JXGProperties | JXGProperties[]) {
-      const change: JXGChange = {
-              operation: "update",
-              target: type,
-              targetID: ids,
-              properties
-            };
-      return _applyChange(board, change);
-    }
-
     function createPolygonFromFreePoints(board: JXG.Board, properties?: JXGProperties): JXG.Polygon | undefined {
       const freePtIds = board.objectsList
                           .filter(elt => isFreePoint(elt))
@@ -214,7 +203,6 @@ export const GeometryContentModel = types
         addPoint,
         removeObjects,
         updateObjects,
-        updateObjectsOfType,
         createPolygonFromFreePoints,
         findObjects,
         applyChange: _applyChange,

--- a/src/models/tools/geometry/jsxgraph.d.ts
+++ b/src/models/tools/geometry/jsxgraph.d.ts
@@ -31,18 +31,20 @@ declare namespace JXG {
     zoomX: number;
     zoomY: number;
 
-    objects: { [id: string]: any };
-
-    objectsList: any[];
+    objects: { [id: string]: GeometryElement };
+    objectsList: GeometryElement[];
 
     create: (elementType: string, parents?: any, attributes?: any) => any;
-    removeObject: (object: GeometryElement) => void;
+    removeObject: (object: GeometryElement) => JXG.Board;
     on: (event: string, handler: (evt: any) => void) => void;
     getCoordsTopLeftCorner: () => number[];
+    getAllObjectsUnderMouse: (evt: any) => GeometryElement[];
+
     resizeContainer: (canvasWidth: number, canvasHeight: number,
-                      dontSet?: boolean, dontSetBoundingBox?: boolean) => void;
-    setBoundingBox: (boundingBox: [number, number, number, number], keepaspectratio?: boolean) => void;
-    update: (drag?: JXG.GeometryElement) => void;
+                      dontSet?: boolean, dontSetBoundingBox?: boolean) => JXG.Board;
+    setBoundingBox: (boundingBox: [number, number, number, number], keepaspectratio?: boolean) => JXG.Board;
+    showInfobox: (value: boolean) => JXG.Board;
+    update: (drag?: JXG.GeometryElement) => JXG.Board;
   }
 
   class Coords {
@@ -66,9 +68,13 @@ declare namespace JXG {
     elType: string;
     type: number;
     ancestors: { [id: string]: GeometryElement };
+    parents: GeometryElement[];
+    childElements: { [id: string]: GeometryElement };
     visProp: { [prop: string]: any };
     fixed: boolean;
 
+    removeChild: (child: GeometryElement) => JXG.Board;
+    hasPoint: (x: number, y: number) => boolean;
     getAttribute: (key: string) => any;
     setAttribute: (attrs: any) => void;
     setPosition: (method: number, coords: number[]) => JXG.Point;

--- a/src/models/tools/geometry/jxg-dispatcher.ts
+++ b/src/models/tools/geometry/jxg-dispatcher.ts
@@ -1,5 +1,4 @@
-import { JXGChange, JXGChangeAgent, JXGChangeResult,
-        JXGCreateHandler, JXGUpdateHandler } from "./jxg-changes";
+import { JXGChange, JXGChangeAgent, JXGChangeResult, JXGCreateHandler, JXGObjectType } from "./jxg-changes";
 import { boardChangeAgent, isBoard } from "./jxg-board";
 import { imageChangeAgent } from "./jxg-image";
 import { objectChangeAgent } from "./jxg-object";
@@ -43,7 +42,7 @@ function applyUpdateObjects(board: JXG.Board, change: JXGChange) {
   const ids = Array.isArray(change.targetID) ? change.targetID : [change.targetID];
   ids.forEach((id, index) => {
     const obj = id && board.objects[id];
-    const target = obj && obj.elType;
+    const target = obj ? obj.elType as JXGObjectType : "object";
     const props = Array.isArray(change.properties)
                     ? change.properties[index]
                     : change.properties;

--- a/src/models/tools/geometry/jxg-dispatcher.ts
+++ b/src/models/tools/geometry/jxg-dispatcher.ts
@@ -1,4 +1,5 @@
-import { JXGChange, JXGChangeAgent, JXGChangeResult, JXGCreateHandler } from "./jxg-changes";
+import { JXGChange, JXGChangeAgent, JXGChangeResult,
+        JXGCreateHandler, JXGUpdateHandler } from "./jxg-changes";
 import { boardChangeAgent, isBoard } from "./jxg-board";
 import { imageChangeAgent } from "./jxg-image";
 import { objectChangeAgent } from "./jxg-object";
@@ -29,6 +30,34 @@ export function applyChanges(board: JXG.Board|string, changes: JXGChange[]): JXG
 }
 
 export function applyChange(board: JXG.Board|string, change: JXGChange): JXGChangeResult {
+  const target = change.target.toLowerCase();
+  if ((change.operation === "update") && (target === "object")) {
+    // special case for update/object, where we dispatch by object type
+    applyUpdateObjects(board as JXG.Board, change);
+    return;
+  }
+  return dispatchChange(board, change);
+}
+
+function applyUpdateObjects(board: JXG.Board, change: JXGChange) {
+  const ids = Array.isArray(change.targetID) ? change.targetID : [change.targetID];
+  ids.forEach((id, index) => {
+    const obj = id && board.objects[id];
+    const target = obj && obj.elType;
+    const props = Array.isArray(change.properties)
+                    ? change.properties[index]
+                    : change.properties;
+    return dispatchChange(board, {
+                            operation: "update",
+                            target,
+                            targetID: id,
+                            parents: change.parents,
+                            properties: props
+                          });
+  });
+}
+
+function dispatchChange(board: JXG.Board|string, change: JXGChange): JXGChangeResult {
   const target = change.target.toLowerCase();
   const agent = agents[target];
   const handler = agent && agent[change.operation];

--- a/src/models/tools/geometry/jxg-point.ts
+++ b/src/models/tools/geometry/jxg-point.ts
@@ -11,15 +11,27 @@ export const isFreePoint = (v: any) => isVisiblePoint(v) &&
                                         (size(v.childElements) <= 1) &&
                                         (size(v.descendants) <= 1);
 
+export const kPointDefaults = {
+              fillColor: "#CCCCCC",
+              strokeColor: "#888888",
+              selectedFillColor: "#FF0000",
+              selectedStrokeColor: "#FF0000"
+            };
+
+const defaultProps = {
+        fillColor: kPointDefaults.fillColor,
+        strokeColor: kPointDefaults.strokeColor
+      };
+
 export const pointChangeAgent: JXGChangeAgent = {
   create: (board, change) => {
     const changeProps: any = change.properties || {};
-    const props = changeProps.id
-                    ? changeProps
+    const props = assign(
                     // If id is not provided we generate one, but this will prevent
                     // model-level synchronization. This should only occur for very
                     // old geometry tiles created before the introduction of the uuid.
-                    : assign({ id: uuid() }, changeProps);
+                    changeProps.id ? {} : { id: uuid() },
+                    defaultProps, changeProps);
     return (board as JXG.Board).create("point", change.parents, props);
   },
 

--- a/src/models/tools/tool-tile.ts
+++ b/src/models/tools/tool-tile.ts
@@ -1,5 +1,5 @@
 import { types, Instance } from "mobx-state-tree";
-import { ToolContentUnion } from "./tool-types";
+import { ToolContentUnion, findMetadata } from "./tool-types";
 import * as uuid from "uuid/v4";
 
 // generally negotiated with app, e.g. single column width for table
@@ -24,6 +24,15 @@ export const ToolTileModel = types
     },
     get isUserResizable() {
       return !!(self.content as any).isUserResizable;
+    }
+  }))
+  .actions(self => ({
+    afterCreate() {
+      const metadata = findMetadata(self.content.type, self.id);
+      const content = self.content as any;
+      if (metadata && content.doPostCreate) {
+        content.doPostCreate(metadata);
+      }
     }
   }));
 

--- a/src/models/tools/tool-types.ts
+++ b/src/models/tools/tool-types.ts
@@ -1,5 +1,6 @@
 import { IAnyType, types } from "mobx-state-tree";
-import { kGeometryToolID, GeometryContentModel, GeometryContentModelType } from "./geometry/geometry-content";
+import { kGeometryToolID, GeometryContentModel, GeometryContentModelType,
+          GeometryMetadataModel, GeometryMetadataModelType } from "./geometry/geometry-content";
 import { kImageToolID, ImageContentModel, ImageContentModelType } from "./image/image-content";
 import { kTableToolID, TableContentModel, TableContentModelType } from "./table/table-content";
 import { kTextToolID, TextContentModel, TextContentModelType } from "./text/text-content";
@@ -28,12 +29,16 @@ export type ToolContentUnionType = GeometryContentModelType |
                                     TextContentModelType |
                                     UnknownContentModelType;
 
+export type ToolMetadataUnionType = GeometryMetadataModelType;
+
 interface IToolMap {
   [id: string]: IAnyType;
 }
 
 interface IPrivate {
   toolMap: IToolMap;
+  metadataMap: IToolMap;
+  metadata: { [id: string]: ToolMetadataUnionType };
 }
 
 export const _private: IPrivate = {
@@ -43,7 +48,13 @@ export const _private: IPrivate = {
     [kTableToolID]: TableContentModel,
     [kTextToolID]: TextContentModel,
     [kUnknownToolID]: UnknownContentModel
-  }
+  },
+
+  metadataMap: {
+    [kGeometryToolID]: GeometryMetadataModel,
+  },
+
+  metadata: {}
 };
 
 export function isToolType(type: string) {
@@ -53,4 +64,14 @@ export function isToolType(type: string) {
 export function toolFactory(snapshot: any) {
   const toolType: string | undefined = snapshot && snapshot.type;
   return toolType && _private.toolMap[toolType] || UnknownContentModel;
+}
+
+export function findMetadata(type: string, id: string) {
+  const MetadataType = _private.metadataMap[type];
+  if (!MetadataType) return;
+
+  if (!_private.metadata[id]) {
+    _private.metadata[id] = MetadataType.create({ id });
+  }
+  return _private.metadata[id];
 }


### PR DESCRIPTION
Implement selection of points [#160969495]
- points are gray by default, red when selected
- clicking on a single point selects it
- ctrl/shift/cmd-click to select/deselect multiple points
- click on background deselects all points
- backspace/delete keys delete selected points [#161272021]
- first click on the interior of a polygon selects all its vertices
- click on interior of polygon with all vertices selected creates a new point
- click on red-X in toolbar to delete selected points [#161272021]

Implementing this required several pieces of new architecture.
- pass `tabIndex` to rows/tiles
  - `tabIndex` is required for keyboard focus
- tile-specific metadata objects are created and passed to tiles that require them (currently only the geometry tool) for storage of tile-related data that is not serialized to firebase (e.g. geometry element selection)
- mechanism for tiles to specify tile-specific API callbacks for use by document/toolbar-level entities
  - required to implement red-X delete of geometry content
