### PR TITLE
Specify latest lts version of node.js rather than latest stable version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: node_js
-node_js: node
+node_js: lts/*
 cache:
   bundler: true
   pip: true


### PR DESCRIPTION
This PR is a follow-up to #126. The solution to the mystery is that on October 23, 2018 node.js 11.0 was released as the latest stable version of node.js. Following some recommendation from somewhere, our `.travis.yml` included the following:
```
language: node_js
node_js: node
```
which is interpreted as a request for the latest stable version of node.js. Thus, immediately upon release of node.js 11.0 as the latest stable release, Travis started executing our builds in node.js 11.0. Unfortunately, several of the libraries we use that require native binaries do not yet provide pre-built native binaries for node.js 11.0, which means that they must resort to building those binaries from source, a process which frequently fails.

With this PR, we change our `.travis.yml` to the following:
```
language: node_js
node_js: lts/*
```
which is interpreted as a request for the `lts` or `long-term stable` version of node.js, which is currently node.js 8.12 but which will shortly become node.js 10.12. Moving forward we make the assumption that pre-built binaries will generally be available for the `lts` build of node.js.

At this point we could presumably go back to the original `jsxgraph` and `firebase` modules rather than continuing to use our `@concord-consortium` forks, but since building/installing canvas and grpc had been problematic even before this incident, I'm inclined to leave our forks in place until there's a more compelling reason to switch back.