### PR TITLE
Geometry clipboard operations

### DIFF
--- a/src/models/clipboard.ts
+++ b/src/models/clipboard.ts
@@ -1,0 +1,71 @@
+import { types, Instance } from "mobx-state-tree";
+import { IStores } from "./stores";
+import * as uuid from "uuid/v4";
+
+export const ClipboardEntryModel = types
+  .model("Clipboard", {
+    id: types.optional(types.string, () => uuid()),
+    userId: "",
+    srcDocumentId: "",
+    srcDocumentType: "",
+    srcTileId: "",
+    timestamp: types.optional(types.number, () => new Date().getTime()),
+    type: types.string,
+    content: types.string
+  });
+export type ClipboardEntryModelType = Instance<typeof ClipboardEntryModel>;
+
+const tileClipboardType = (type: string) => `org.concord.clue.clipboard.${type}`;
+
+export const ClipboardModel = types
+  .model("Clipboard", {
+    content: types.map(ClipboardEntryModel)
+  })
+  .views(self => ({
+    get isEmpty() {
+      return !self.content.size;
+    },
+    hasType(type: string) {
+      return self.content.has(type);
+    },
+    isSourceTile(type: string, tileId: string) {
+      const entry = self.content.get(tileClipboardType(type));
+      return entry && entry.srcTileId
+              ? tileId === entry.srcTileId
+              : false;
+    },
+    getTileContentId(type: string) {
+      const entry = self.content.get(tileClipboardType(type));
+      return entry && entry.id;
+    },
+    getTileContent(type: string) {
+      const entry = self.content.get(tileClipboardType(type));
+      let content: any;
+      try {
+        content = entry && JSON.parse(entry.content);
+      }
+      catch (e) {
+        // ignore errors
+      }
+      return content;
+    }
+  }))
+  .actions(self => ({
+    clear() {
+      self.content.clear();
+    },
+    addTileContent(tileId: string, tileType: string, content: any, stores: IStores) {
+      const clipType = tileClipboardType(tileType);
+      const document = stores.documents.findDocumentOfTile(tileId);
+      const entry = ClipboardEntryModel.create({
+        userId: document ? document.uid : "",
+        srcDocumentId: document ? document.key : "",
+        srcDocumentType: document ? document.type : "",
+        srcTileId: tileId,
+        type: clipType,
+        content: JSON.stringify(content)
+      });
+      self.content.set(clipType, entry);
+    }
+  }));
+export type ClipboardModelType = Instance<typeof ClipboardModel>;

--- a/src/models/stores.ts
+++ b/src/models/stores.ts
@@ -8,7 +8,8 @@ import { UnitModelType, UnitModel } from "./curriculum/unit";
 import { DemoModelType, DemoModel } from "./demo";
 import { SupportsModel, SupportsModelType } from "./supports";
 import { DocumentsModelType, DocumentsModel } from "./documents";
-import { WorkspaceModel, WorkspaceType, LearningLogWorkspace, SectionWorkspace } from "./workspace";
+import { LearningLogWorkspace, SectionWorkspace } from "./workspace";
+import { ClipboardModel, ClipboardModelType } from "./clipboard";
 
 export type AppMode = "authed" | "dev" | "test" | "demo" | "qa";
 
@@ -25,6 +26,7 @@ export interface IStores {
   demo: DemoModelType;
   showDemoCreator: boolean;
   supports: SupportsModelType;
+  clipboard: ClipboardModelType;
 }
 
 export interface ICreateStores {
@@ -69,5 +71,6 @@ export function createStores(params?: ICreateStores): IStores {
     demo: params && params.demo || DemoModel.create({class: {id: "0", name: "Null Class"}}),
     showDemoCreator: params && params.showDemoCreator || false,
     supports: params && params.supports || SupportsModel.create({}),
+    clipboard: ClipboardModel.create()
   };
 }

--- a/src/models/tools/geometry/jsxgraph.d.ts
+++ b/src/models/tools/geometry/jsxgraph.d.ts
@@ -67,6 +67,7 @@ declare namespace JXG {
     id: string;
     elType: string;
     type: number;
+    name: string;
     ancestors: { [id: string]: GeometryElement };
     parents: GeometryElement[];
     childElements: { [id: string]: GeometryElement };

--- a/src/utilities/hot-keys.ts
+++ b/src/utilities/hot-keys.ts
@@ -1,0 +1,104 @@
+import { each } from "lodash";
+
+// cf. https://github.com/jaywcjlove/hotkeys
+
+// unprintables and punctuation
+const _keyMap: { [key: number]: string } = {
+  8: "backspace",
+  9: "tab",
+  12: "clear",
+  13: "return",
+  27: "escape",
+  32: "space",
+  33: "pageup",
+  34: "pagedown",
+  35: "end",
+  36: "home",
+  37: "left",
+  38: "up",
+  39: "right",
+  40: "down",
+  45: "insert",
+  46: "delete",
+  186: ";",
+  187: "=",
+  188: ",",
+  189: "-",
+  190: ".",
+  191: "/",
+  192: "`",
+  219: "[",
+  220: "\\",
+  221: "]",
+  222: "'"
+};
+
+function keyCodeToString(keyCode: number) {
+  // non-printables and punctuation
+  if (_keyMap[keyCode]) return _keyMap[keyCode];
+  // letters
+  if ((keyCode >= 65) && (keyCode <= 90)) {
+    return String.fromCharCode(keyCode);
+  }
+  // digits
+  if ((keyCode >= 48) && (keyCode <= 57)) {
+    return String.fromCharCode(keyCode);
+  }
+  // function keys
+  if ((keyCode >= 112) && (keyCode <= 123)) {
+    return `f${keyCode - 112 + 1}`;
+  }
+}
+
+export interface IHotKeyMap {
+  [keys: string]: (e: React.KeyboardEvent, keys: string) => boolean | undefined;
+}
+
+export class HotKeys {
+
+  private hotKeyMap: IHotKeyMap = {};
+
+  /*
+   * [ctrl|meta|cmd]-[alt|option]-[shift]-[char]
+   */
+  public register(hotKeys: IHotKeyMap) {
+    const isMac = navigator.platform.indexOf("Mac") === 0;
+    const cmdKey = isMac ? "meta" : "ctrl";
+    each(hotKeys, (handler, keys) => {
+      const _keys = keys.toLowerCase()
+                        .replace("cmd", cmdKey)
+                        .replace("option", "alt");
+      this.hotKeyMap[_keys] = handler;
+    });
+  }
+
+  public dispatch(e: React.KeyboardEvent) {
+    let keys = "";
+    if (e.ctrlKey) {
+      keys += (keys ? "-" : "") + "ctrl";
+    }
+    if (e.metaKey) {
+      keys += (keys ? "-" : "") + "meta";
+    }
+    if (e.altKey) {
+      keys += (keys ? "-" : "") + "alt";
+    }
+    if (e.shiftKey) {
+      keys += (keys ? "-" : "") + "shift";
+    }
+    const str = keyCodeToString(e.keyCode);
+    if (str) {
+      keys += (keys ? "-" : "") + str.toLowerCase();
+    }
+
+    const handler = this.hotKeyMap[keys];
+    if (handler) {
+      const result = handler(e, keys);
+      if (result) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+      return true;
+    }
+  }
+}

--- a/src/utilities/js-utils.ts
+++ b/src/utilities/js-utils.ts
@@ -1,0 +1,16 @@
+
+/*
+ * safeJsonParse()
+ *
+ * returns undefined on error rather than throwing an exception
+ */
+export function safeJsonParse(json?: string) {
+  let parsed;
+  try {
+    parsed = json && JSON.parse(json);
+  }
+  catch (e) {
+    // swallow errors
+  }
+  return parsed;
+}


### PR DESCRIPTION
Geometry clipboard operations [#160604580]
- support cut/copy of selected objects
- can paste objects into same or another geometry tile
- multiple pastes are offset slightly and get new labels
- uses new HotKeys modules to manage/dispatch keyboard shortcuts
- uses new Clipboard object in stores rather than global clipboard

We use a local Clipboard object in stores rather than the system clipboard because we aren't copying anything that would be understood outside the CLUE application and because the system clipboard has security protections that make it less convenient to deal with. I considered making it a global module like the `Logging` module, but decided that because some UI elements might one day depend on the state of the clipboard (e.g. enabling/disabling the paste button or menu item) -- which is not true for the Logging module -- it made more sense to include it in stores.

The code to handle the keyboard shortcuts started to get convoluted which led me to look into modules like [react-hot-keys](https://www.npmjs.com/package/react-hot-keys) which purport to simplify things. But that implementation didn't seem quite right, and when I tried it it didn't even work, so I ended up rolling our own HotKeys module which takes some ideas from react-hot-keys but uses a more React-friendly implementation. This module supports client code like this:
```typescript
    this.hotKeys.register({
      "backspace": this.handleDelete,
      "delete": this.handleDelete,
      "cmd-c": this.handleCopy,
      "cmd-x": this.handleCut,
      "cmd-v": this.handlePaste
    });
```
where `cmd-c` is interpreted to mean `⌘-c` on the Mac and `ctrl-c` on Windows.

Provenance information is attached to the clipboard on copy, but is not currently used. Presumably at some point it would be good to enable logging for clipboard operations.

Finally, the paste operation has some non-obvious subtleties that don't apply to drag/drop. Since the same content can (and often is) pasted multiple times into the same tile, we need to be careful to generate unique object ids on each paste. It's not sufficient to generate unique object ids on copy and then paste the same content multiple times. Likewise, for labels in the multiple paste scenario, the current implementation keeps the original labels when pasting to a new tile for the first time, but additional pastes to the same new tile and the first paste into the source tile generate new labels so as to avoid obvious label conflicts. Similarly, multiple pastes into the same destination tile are slightly staggered by position so that they don't all land on top of one another.