### PR TITLE
Use scale prop to scale mouse interaction

### DIFF
--- a/src/components/canvas-tools/drawing-tool/drawing-layer.tsx
+++ b/src/components/canvas-tools/drawing-tool/drawing-layer.tsx
@@ -547,6 +547,7 @@ interface DrawingToolMap {
 interface DrawingLayerViewProps {
   model: ToolTileModelType;
   readOnly: boolean;
+  scale?: number;
 }
 
 interface DrawingLayerViewState {
@@ -832,10 +833,11 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
 
   public getWorkspacePoint = (e: MouseEvent|React.MouseEvent<any>): Point|null => {
     if (this.svgRef) {
+      const scale = this.props.scale || 1;
       const rect = ((this.svgRef as unknown) as Element).getBoundingClientRect();
       return {
-        x: e.clientX - rect.left,
-        y: e.clientY - rect.top
+        x: (e.clientX - rect.left) / scale,
+        y: (e.clientY - rect.top) / scale
       };
     }
     return null;

--- a/src/components/canvas-tools/drawing-tool/drawing-tool.tsx
+++ b/src/components/canvas-tools/drawing-tool/drawing-tool.tsx
@@ -10,6 +10,7 @@ import "./drawing-tool.sass";
 interface IProps {
   model: ToolTileModelType;
   readOnly: boolean;
+  scale?: number;
 }
 
 interface IState {
@@ -24,7 +25,7 @@ export default class DrawingToolComponent extends BaseComponent<IProps, IState> 
   }
 
   public render() {
-    const { model, readOnly } = this.props;
+    const { model, readOnly, scale } = this.props;
     const editableClass = readOnly ? " read-only" : "";
     const className = `drawing-tool${editableClass}`;
     return (
@@ -32,8 +33,7 @@ export default class DrawingToolComponent extends BaseComponent<IProps, IState> 
         <ToolbarView model={model} readOnly={!!readOnly}/>
         <div style={{left: TOOLBAR_WIDTH}}
             onMouseDown={this.handleMouseDown}>
-          <DrawingLayerView model={model} readOnly={!!readOnly}
-          />
+          <DrawingLayerView model={model} readOnly={!!readOnly} scale={scale} />
         </div>
       </div>
     );

--- a/src/models/tools/drawing/drawing-content.ts
+++ b/src/models/tools/drawing/drawing-content.ts
@@ -185,7 +185,7 @@ export const DrawingContentModel = types
         deleteSelectedObjects,
 
         // sets the model to how we want it to appear when a user first opens a document
-        reset: () => {
+        reset() {
           self.selectedButton = "select";
         }
       }


### PR DESCRIPTION
Also, unrelated, unbind `reset` method in `drawing-content`. (Eventually we should put selected button in the metadata object instead.)