### PR TITLE
Fix draw tool crash

### DIFF
--- a/src/components/canvas-tools/drawing-tool/drawing-tool.tsx
+++ b/src/components/canvas-tools/drawing-tool/drawing-tool.tsx
@@ -18,7 +18,9 @@ interface IState {
 export default class DrawingToolComponent extends BaseComponent<IProps, IState> {
 
   public componentDidMount() {
-    (this.props.model.content as DrawingContentModelType).reset();
+    if (!this.props.readOnly) {
+      (this.props.model.content as DrawingContentModelType).reset();
+    }
   }
 
   public render() {


### PR DESCRIPTION
The crash occurred in `DrawingToolComponent.componentDidMount()` when attempting to reset the current tool for the document displayed in the My Work panel. I believe what's happening is that there are two React components attempting to write to the same model in their `componentDidMount()` functions -- the one in the user's workspace and the one in the My Work tab. The first write succeeds, but triggers the firebase handler which triggers a document reload, which causes the second write to fail because the model in question has been replaced. The quick-fix here is to only try to reset the current tool in writable components, of which there should only ever be one. Ultimately, we should consider whether the currently selected tool should be in the model at all or whether it should be in model metadata, for instance.