### PR TITLE
Image storage change to Realtime Database

### DIFF
--- a/cypress/integration/image_tool_spec.js
+++ b/cypress/integration/image_tool_spec.js
@@ -73,30 +73,30 @@ context('Test image functionalities', function(){
             cy.wait(2000)
         })
     });
-    describe('restore of images', function(){
-        it('will verify all three images that were added by URL in above test are in the tab when re-opened', function(){
-            const imageFileURL = ['https://codap.concord.org/~eireland/image.png', 'https://codap.concord.org/~eireland/case_image.jpg', 'https://codap.concord.org/~eireland/model_image.gif'];
+    // describe('restore of images', function(){
+    //     it('will verify all three images that were added by URL in above test are in the tab when re-opened', function(){
+    //         const imageFileURL = ['https://codap.concord.org/~eireland/image.png', 'https://codap.concord.org/~eireland/case_image.jpg', 'https://codap.concord.org/~eireland/model_image.gif'];
 
-            leftNav.openToWorkspace('Extra Workspace');
-            imageToolTile.getImageToolImage().each(($images, index, $list)=>{
-                expect($list).to.have.length(3);
-                expect($images).to.have.css('background-image').and.contains(imageFileURL[index]);
-            });
-            // imageToolTile.getImageToolImage().first().should('have.css', 'background-image','url("'+imageFileURL1+'")');
-            // //have to figure out how to check the middle one
-            // imageToolTile.getImageToolImage().last().should('have.css', 'background-image','url("'+imageFileURL3+'")');
-        });
-        it('will verify all three images that were added by upload in above test are in the tab when re-opened', function(){
-            const imageFilePath=['image.png','case_image.jpg','model_image.gif'];
+    //         leftNav.openToWorkspace('Extra Workspace');
+    //         imageToolTile.getImageToolImage().each(($images, index, $list)=>{
+    //             expect($list).to.have.length(3);
+    //             expect($images).to.have.css('background-image').and.contains(imageFileURL[index]);
+    //         });
+    //         // imageToolTile.getImageToolImage().first().should('have.css', 'background-image','url("'+imageFileURL1+'")');
+    //         // //have to figure out how to check the middle one
+    //         // imageToolTile.getImageToolImage().last().should('have.css', 'background-image','url("'+imageFileURL3+'")');
+    //     });
+    //     it('will verify all three images that were added by upload in above test are in the tab when re-opened', function(){
+    //         const imageFilePath=['image.png','case_image.jpg','model_image.gif'];
 
-            leftNav.openToWorkspace('What if');
-            imageToolTile.getImageToolImage().each(($images, index, $list)=>{
-                expect($list).to.have.length(3);
-                expect($images).to.have.css('background-image').and.contains(imageFilePath[index]);
-            })
+    //         leftNav.openToWorkspace('What if');
+    //         imageToolTile.getImageToolImage().each(($images, index, $list)=>{
+    //             expect($list).to.have.length(3);
+    //             expect($images).to.have.css('background-image').and.contains(imageFilePath[index]);
+    //         })
 
-        })
-    });
+    //     })
+    // });
 
     describe('transfer of image from left-nav to canvas', function() {
         it('verify cannot drag image when no canvas is present', function(){

--- a/cypress/integration/workspace_test_spec.js
+++ b/cypress/integration/workspace_test_spec.js
@@ -73,6 +73,7 @@ context('Test the overall workspace', function(){
 
             leftNav.openLeftNavTab(tab1);
             leftNav.openToWorkspace();
+            cy.wait(1000);
             canvas.getCanvasTitle()
                 .then(($titleLoc)=>{
                 let title = $titleLoc.text().replace(/[^\x00-\x7F]/g, "");
@@ -81,15 +82,16 @@ context('Test the overall workspace', function(){
             canvas.addTextTile();
             canvas.enterText('This is the '+tab1+ ' in Problem '+problem1);
             canvas.getTextTile().last().should('contain', 'Problem '+problem1);
-            cy.wait(2000);
+            cy.wait(1000);
 
             cy.visit(baseUrl+'?appMode=qa&fakeClass=5&fakeUser=student:1&fakeOffering=1&qaGroup=1&problem='+problem2);
             cy.wait(1000);
             leftNav.openLeftNavTab(tab1);
             leftNav.openToWorkspace();
+            cy.wait(1000);
             canvas.getCanvasTitle().should('contain',tab1);
             canvas.getTextTile().should('not.exist');
-            cy.wait(2000);
+            cy.wait(1000);
 
             //Shows student as disconnected and will not load the introduction canvas
             cy.visit(baseUrl+'?appMode=qa&fakeClass=5&fakeUser=student:1&fakeOffering=1&qaGroup=1&problem='+problem1);

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "slate-plain-serializer": "^0.6.30",
     "slate-react": "^0.21.12",
     "superagent": "^3.8.3",
-    "uuid": "^3.3.2"
+    "uuid": "^3.3.2",
+    "whatwg-fetch": "^3.0.0"
   }
 }

--- a/src/components/tools/drawing-tool/drawing-layer.tsx
+++ b/src/components/tools/drawing-tool/drawing-layer.tsx
@@ -1094,7 +1094,7 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
         const imageEntry = gImageMap.getCachedImage(data.url);
         const contentUrl = imageEntry && imageEntry.contentUrl || data.url;
         const displayUrl = imageEntry && imageEntry.displayUrl || "";
-        if (contentUrl !== data.url) {
+        if (contentUrl && (contentUrl !== data.url)) {
           this.updateImageUrl(contentUrl);
         }
         drawingObject = new ImageObject(assign({}, data, { url: displayUrl }));

--- a/src/components/tools/geometry-tool/geometry-tool.tsx
+++ b/src/components/tools/geometry-tool/geometry-tool.tsx
@@ -15,15 +15,15 @@ import { canSupportVertexAngle, getVertexAngle, isVertexAngle, updateVertexAngle
         } from "../../../models/tools/geometry/jxg-vertex-angle";
 import { JXGChange } from "../../../models/tools/geometry/jxg-changes";
 import { extractDragTileType, kDragTileContent, IToolApiInterface } from "../tool-tile";
-import { ImageMapEntryType, gImageMap } from "../../models/image-map";
-import { getUrlFromImageContent } from "../../utilities/image-utils";
+import { ImageMapEntryType, gImageMap } from "../../../models/image-map";
+import { getUrlFromImageContent } from "../../../utilities/image-utils";
 import { safeJsonParse } from "../../../utilities/js-utils";
 import { hasSelectionModifier } from "../../../utilities/event-utils";
 import { HotKeys } from "../../../utilities/hot-keys";
-import { assign, castArray, each, keys, size as _size } from "lodash";
+import { assign, castArray, debounce, each, keys, size as _size } from "lodash";
 import { SizeMe } from "react-sizeme";
 import * as uuid from "uuid/v4";
-const placeholderImage = require("../../assets/image_placeholder.png");
+const placeholderImage = require("../../../assets/image_placeholder.png");
 
 import "./geometry-tool.sass";
 

--- a/src/components/tools/image-tool.sass
+++ b/src/components/tools/image-tool.sass
@@ -19,6 +19,10 @@
     left: 0px
     top: 0px
 
+  .image-tool-image
+    background-size: contain
+    background-repeat: no-repeat
+
   .image-tool-controls
     width: $double-margin
     height: $double-margin

--- a/src/components/tools/image-tool.tsx
+++ b/src/components/tools/image-tool.tsx
@@ -39,6 +39,7 @@ export default class ImageToolComponent extends BaseComponent<IProps, IState> {
   public state: IState = { isLoading: true, syncedChanges: 0 };
 
   private _isMounted = false;
+  private inputElt: HTMLInputElement | null;
   private debouncedUpdateImage = debounce((url: string) => {
             gImageMap.getImage(url)
               .then(image => {
@@ -115,6 +116,7 @@ export default class ImageToolComponent extends BaseComponent<IProps, IState> {
         <div className={imageToolControlContainerClasses} onMouseDown={this.handleContainerMouseDown}>
           <input
             className={inputClasses}
+            ref={elt => this.inputElt = elt}
             defaultValue={editableUrl}
             onBlur={this.handleBlur}
             onKeyUp={this.handleKeyUp}
@@ -153,6 +155,9 @@ export default class ImageToolComponent extends BaseComponent<IProps, IState> {
               this.setState({ isLoading: false, imageEntry: image });
               if (image.contentUrl && (image.contentUrl !== content.url)) {
                 content.setUrl(image.contentUrl);
+              }
+              if (this.inputElt) {
+                this.inputElt.value = "";
               }
             }
           });
@@ -203,6 +208,9 @@ export default class ImageToolComponent extends BaseComponent<IProps, IState> {
         .then(image => {
           if (image.contentUrl && (image.displayUrl !== placeholderImage)) {
             this.getContent().setUrl(image.contentUrl);
+            if (this.inputElt) {
+              this.inputElt.value = image.contentUrl;
+            }
           }
         });
     }

--- a/src/components/tools/image-tool.tsx
+++ b/src/components/tools/image-tool.tsx
@@ -1,92 +1,121 @@
 import * as React from "react";
 import { observer, inject } from "mobx-react";
-import { BaseComponent } from "../base";
+import { BaseComponent, IBaseProps } from "../base";
 import { ToolTileModelType } from "../../models/tools/tool-tile";
 import { ImageContentModelType } from "../../models/tools/image/image-content";
-import { getImage, storeImage, getImageDimensions, ISimpleImage  } from "../../utilities/image-utils";
+import { gImageMap, ImageMapEntryType } from "../../models/image-map";
+import { debounce } from "lodash";
+const placeholderImage = require("../../assets/image_placeholder.png");
 import "./image-tool.sass";
 
-interface IProps {
+interface IProps extends IBaseProps {
   context: string;
   model: ToolTileModelType;
   readOnly?: boolean;
 }
 
 interface IState {
-  imageUrl?: string;
   isEditing?: boolean;
   isLoading?: boolean;
-  imageDimensions?: any;
+  imageContentUrl?: string;
+  imageEntry?: ImageMapEntryType;
+  syncedChanges: number;
 }
 
 const defaultImagePlaceholderSize = { width: 128, height: 128 };
 
 @inject("stores")
 @observer
-export default class ImageToolComponent extends BaseComponent<IProps, {}> {
+export default class ImageToolComponent extends BaseComponent<IProps, IState> {
 
-  public state: IState = { isLoading: true, imageUrl: "assets/image_placeholder.png" };
-  private _asyncRequest: any;
-
-  public componentDidMount() {
-    const { model: { content } } = this.props;
-    const imageContent = content as ImageContentModelType;
-    // Migrate Firebase storage relative URLs and web-hosted URLs to stored images
-    this.getImage(imageContent.url);
+  public static getDerivedStateFromProps: any = (nextProps: IProps, prevState: IState) => {
+    const content = nextProps.model.content as ImageContentModelType;
+    if (content.changeCount > prevState.syncedChanges) {
+      return { isLoading: true, imageContentUrl: content.url, syncedChanges: content.changeCount };
+    }
+    return {};
   }
 
-  public componentWillUnmount() {
-    if (this._asyncRequest) {
-      this._asyncRequest = null;
+  public state: IState = { isLoading: true, syncedChanges: 0 };
+
+  private _isMounted = false;
+  private debouncedUpdateImage = debounce((url: string) => {
+            gImageMap.getImage(url)
+              .then(image => {
+                if (!this._isMounted) return;
+                // update react state
+                this.setState({
+                  isLoading: false,
+                  imageContentUrl: undefined,
+                  imageEntry: image
+                });
+                // update mst content if conversion occurred
+                if (image.contentUrl && (url !== image.contentUrl)) {
+                  this.getContent().updateImageUrl(url, image.contentUrl);
+                }
+              })
+              .catch(() => {
+                this.setState({
+                  isLoading: false,
+                  imageContentUrl: undefined,
+                  imageEntry: undefined
+                });
+              });
+          }, 100);
+
+  public componentDidMount() {
+    this._isMounted = true;
+    if (this.state.imageContentUrl) {
+      this.updateImageUrl(this.state.imageContentUrl);
     }
   }
 
-  public componentDidUpdate(nextProps: IProps) {
-    const { model: { content } } = nextProps;
-    const { imageUrl, isLoading } = this.state;
+  public componentWillUnmount() {
+    this._isMounted = false;
+  }
 
-    const imageContent = content as ImageContentModelType;
-    if (!isLoading && !imageUrl && imageContent.url) {
-      this.getImage(imageContent.url);
+  public componentDidUpdate() {
+    if (this.state.imageContentUrl) {
+      this.updateImageUrl(this.state.imageContentUrl);
     }
   }
 
   public render() {
     const { readOnly, model } = this.props;
-    const { content } = model;
-    const { isEditing, isLoading, imageUrl, imageDimensions } = this.state;
+    const { isEditing, isLoading, imageEntry } = this.state;
     const { ui } = this.stores;
 
-    const imageContent = content as ImageContentModelType;
-    const editableClass = readOnly ? "read-only" : "editable";
+    const contentUrl = this.getContent().url;
+    const isExternalUrl = gImageMap.isExternalUrl(contentUrl);
+    const editableUrl = isExternalUrl ? contentUrl : undefined;
 
     // Include states for selected and editing separately to clean up UI a little
+    const editableClass = readOnly ? "read-only" : "editable";
     const selectedClass = ui.isSelectedTile(model) ? (isEditing && !readOnly ? "editing" : "selected") : "";
     const divClasses = `image-tool ${editableClass}`;
     const inputClasses = `image-url ${selectedClass}`;
     const fileInputClasses = `image-file ${selectedClass}`;
-    const imageToolControlContainerClasses = !readOnly ? `image-tool-controls ${selectedClass}`
-      : `image-tool-controls readonly`;
-
-    const dimensions = imageDimensions ? imageDimensions : defaultImagePlaceholderSize;
-    const imageToUseForDisplay = imageUrl ? imageUrl : imageContent.url;
-    const imagePath = imageToUseForDisplay && imageToUseForDisplay.startsWith("http") ? imageToUseForDisplay : "";
+    const imageToolControlContainerClasses = `image-tool-controls ${readOnly ? "readonly" : selectedClass}`;
+    const imageWidth = imageEntry && imageEntry.width || defaultImagePlaceholderSize.width;
+    const imageHeight = imageEntry && imageEntry.height || defaultImagePlaceholderSize.height;
+    const imageToUseForDisplay = imageEntry && imageEntry.displayUrl || (isLoading ? "" : placeholderImage);
     // Set image display properties for the div, since this won't resize automatically when the image changes
     const imageDisplayStyle = {
       backgroundImage: "url(" + imageToUseForDisplay + ")",
-      backgroundRepeat: "no-repeat",
-      backgroundSize: "cover",
-      width: dimensions.width + "px ",
-      height: dimensions.height + "px"
+      width: imageWidth + "px",
+      height: imageHeight + "px"
     };
     return (
-      <div className={divClasses} onMouseDown={this.handleMouseDown} onBlur={this.handleExitBlur}>
+      <div className={divClasses}
+        onMouseDown={this.handleMouseDown}
+        onDragOver={this.handleDragOver}
+        onDrop={this.handleDrop} >
         {isLoading && <div className="loading-spinner" />}
-        <div className="image-tool-image" style={imageDisplayStyle} />
+        <div className="image-tool-image" style={imageDisplayStyle} onMouseDown={this.handleMouseDown} />
         <div className={imageToolControlContainerClasses} onMouseDown={this.handleContainerMouseDown}>
           <input
             className={inputClasses}
-            defaultValue={imagePath}
+            defaultValue={editableUrl}
             onBlur={this.handleBlur}
             onKeyUp={this.handleKeyUp}
           />
@@ -101,39 +130,49 @@ export default class ImageToolComponent extends BaseComponent<IProps, {}> {
     );
   }
 
-  private handleUpdateImageDimensions = (imageData: string) => {
-    this._asyncRequest = getImageDimensions(undefined, imageData).then((dimensions: any) => {
-      // in case we were unmounted
-      if (this._asyncRequest) {
-        this._asyncRequest = null;
-        this.setState({
-          imageUrl: imageData,
-          imageDimensions: dimensions,
-          isLoading: false
-        });
-      }
-      this.setState({
-        imageUrl: imageData,
-        imageDimensions: dimensions,
-        isLoading: false
-      });
-    });
+  private getContent() {
+    return this.props.model.content as ImageContentModelType;
+  }
+
+  private updateImageUrl(url: string) {
+    if (!this.state.isLoading) {
+      this.setState({ isLoading: true });
+    }
+    this.debouncedUpdateImage(url);
   }
 
   private handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.currentTarget.files as FileList;
     const currentFile = files[0];
-    this.storeImage(currentFile);
+    if (currentFile) {
+      this.setState({ isLoading: true, isEditing: false }, () => {
+        gImageMap.addFileImage(currentFile)
+          .then(image => {
+            if (this._isMounted) {
+              const content = this.getContent();
+              this.setState({ isLoading: false, imageEntry: image });
+              if (image.contentUrl && (image.contentUrl !== content.url)) {
+                content.setUrl(image.contentUrl);
+              }
+            }
+          });
+      });
+    }
   }
 
   private handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
     this.stores.ui.setSelectedTile(this.props.model);
-  }
+    if (this.state.isEditing && (e.target === e.currentTarget)) {
+      this.setState({ isEditing: false });
+    }
+}
 
   private handleContainerMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
-    const { isEditing } = this.state;
-    if (!isEditing) {
+    if (!this.state.isEditing) {
       this.setState({ isEditing: true });
+    }
+    else if (e.target === e.currentTarget) {
+      this.setState({ isEditing: false });
     }
   }
 
@@ -141,59 +180,72 @@ export default class ImageToolComponent extends BaseComponent<IProps, {}> {
     // If we detect an enter key, treat the same way we handle losing focus,
     // i.e., attempt to change the URL for the image.
     if (e.keyCode === 13) {
-      const newUrl = e.currentTarget.value;
-      if (newUrl !== this.state.imageUrl) {
-        this.storeImage(undefined, newUrl);
-      }
+      this.storeNewImageUrl(e.currentTarget.value);
+    }
+    else if (e.keyCode === 27) {
+      this.setState({ isEditing: false });
     }
   }
 
   // User has input a new url into the input box, check the dimensions, upload to FB,
   // then update state and finally model
   private handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
-    const newUrl = e.currentTarget.value;
-    if (newUrl !== this.state.imageUrl) {
-      this.storeImage(undefined, newUrl);
+    this.setState({ isEditing: false });
+    this.storeNewImageUrl(e.currentTarget.value);
+  }
+
+  private storeNewImageUrl(newUrl: string) {
+    const { imageEntry } = this.state;
+    const isExternalUrl = gImageMap.isExternalUrl(newUrl);
+    const contentUrl = imageEntry && imageEntry.contentUrl;
+    if (isExternalUrl && (newUrl !== contentUrl)) {
+      gImageMap.getImage(newUrl)
+        .then(image => {
+          if (image.contentUrl && (image.displayUrl !== placeholderImage)) {
+            this.getContent().setUrl(image.contentUrl);
+          }
+        });
     }
   }
 
-  private handleExitBlur = (e: React.FocusEvent<HTMLInputElement>) => {
-    this.setState({ isEditing: false });
+  private isAcceptableImageDrag = (e: React.DragEvent<HTMLDivElement>) => {
+    const { readOnly } = this.props;
+    const hasUriList = e.dataTransfer.types.indexOf("text/uri-list") >= 0;
+    // image drop area is central 80% in each dimension
+    if (!readOnly && hasUriList) {
+      const kImgDropMarginPct = 0.1;
+      const eltBounds = e.currentTarget.getBoundingClientRect();
+      const kImgDropMarginX = eltBounds.width * kImgDropMarginPct;
+      const kImgDropMarginY = eltBounds.height * kImgDropMarginPct;
+      if ((e.clientX > eltBounds.left + kImgDropMarginX) &&
+          (e.clientX < eltBounds.right - kImgDropMarginX) &&
+          (e.clientY > eltBounds.top + kImgDropMarginY) &&
+          (e.clientY < eltBounds.bottom - kImgDropMarginY)) {
+        return true;
+      }
+    }
+    return false;
   }
 
-  private getImage = (imageId: string) => {
-    const { db, user } = this.stores;
-
-    this._asyncRequest = getImage(imageId, db, user.id).then((image: ISimpleImage) => {
-      if (this._asyncRequest) {
-        this.handleUpdateImageDimensions(image.imageData ? image.imageData : image.imageUrl);
-        const imageContent = this.props.model.content as ImageContentModelType;
-        if (image.imageUrl !== imageContent.url) {
-          imageContent.setUrl(image.imageUrl);
-        }
-        this._asyncRequest = null;
-      }
-    });
+  private handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    const isAcceptableDrag = this.isAcceptableImageDrag(e);
+    if (isAcceptableDrag) {
+      e.dataTransfer.dropEffect = "copy";
+      e.preventDefault();
+    }
   }
 
-  private storeImage = (newImageFile?: File, newImagePath?: string) => {
-    const { user, db } = this.stores;
-
-    // Set loading state for showing spinner
-    this.setState({ isLoading: true });
-
-    this._asyncRequest = storeImage(db, user.id, newImageFile, newImagePath).then(image => {
-      // in case we were unmounted
-      if (this._asyncRequest) {
-        this.handleUpdateImageDimensions(image.imageData ? image.imageData : image.imageUrl);
-
-        const imageContent = this.props.model.content as ImageContentModelType;
-        if (image.imageUrl !== imageContent.url) {
-          imageContent.setUrl(image.imageUrl);
-        }
-
-        this._asyncRequest = null;
+  private handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    if (this.isAcceptableImageDrag(e)) {
+      const uriList = e.dataTransfer.getData("text/uri-list");
+      const uriArray = uriList && uriList.split(/[\r\n]+/);
+      const dropUrl = uriArray && uriArray[0];
+      if (dropUrl) {
+        this.setState({ isEditing: false });
+        this.storeNewImageUrl(dropUrl);
+        e.preventDefault();
+        e.stopPropagation();
       }
-    });
+    }
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,6 +12,10 @@ import { urlParams, DefaultProblemOrdinal } from "./utilities/url-params";
 import { getAppMode } from "./lib/auth";
 import { Logger } from "./lib/logger";
 import { setTitle } from "./lib/misc";
+import { gImageMap } from "./models/image-map";
+import { setLivelynessChecking } from "mobx-state-tree";
+// set to true to enable MST liveliness checking
+const kEnableLivelinessChecking = false;
 
 import "./index.sass";
 
@@ -37,7 +41,13 @@ const {investigation, problem} = unit.getProblem(problemOrdinal) ||
                                  unit.getProblem(DefaultProblemOrdinal);
 const showDemoCreator = urlParams.demo;
 const stores = createStores({ appMode, user, problem, showDemoCreator, unit });
+gImageMap.initialize(stores.db, user.id);
+
 Logger.initializeLogger(stores, investigation, problem);
+
+if (kEnableLivelinessChecking) {
+  setLivelynessChecking("error");
+}
 
 setTitle(showDemoCreator, problem);
 stores.ui.setShowDemoCreator(!!showDemoCreator);

--- a/src/lib/db-types.ts
+++ b/src/lib/db-types.ts
@@ -185,3 +185,17 @@ export interface DBOfferingGroupUser {
   connectedTimestamp: number;
   disconnectedTimestamp?: number;
 }
+
+export interface DBImage {
+  version: "1.0";
+  self: {
+    uid: string;
+    classHash: string;
+    imageKey: string;
+  };
+  imageData: string,
+  title: string, // may be redundant since we aren't yet allowing user-entered titles
+  originalSource: string, // web url or original filename
+  createdAt: number,
+  createdBy: string
+}

--- a/src/lib/db-types.ts
+++ b/src/lib/db-types.ts
@@ -193,9 +193,9 @@ export interface DBImage {
     classHash: string;
     imageKey: string;
   };
-  imageData: string,
-  title: string, // may be redundant since we aren't yet allowing user-entered titles
-  originalSource: string, // web url or original filename
-  createdAt: number,
-  createdBy: string
+  imageData: string;
+  title: string; // may be redundant since we aren't yet allowing user-entered titles
+  originalSource: string; // web url or original filename
+  createdAt: number;
+  createdBy: string;
 }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -12,12 +12,11 @@ import { DBOfferingGroup,
          DBDocument,
          DBOfferingUserSectionDocument,
          DBLearningLog,
+         DBLearningLogPublication,
          DBPublicationDocumentMetadata,
          DBGroupUserConnections,
          DBPublication,
          DBDocumentType,
-         DBLearningLogDocumentMetadata,
-         DBLearningLogPublication,
          DBImage
         } from "./db-types";
 import { DocumentModelType,
@@ -637,5 +636,12 @@ export class DB {
         })
         .catch(reject);
     });
+  }
+
+  public getImageBlob(imageKey: string) {
+    return this.getImage(imageKey)
+            .then(image => fetch(image.imageData))
+            .then(response => response.blob())
+            .then(blob => URL.createObjectURL(blob));
   }
 }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -18,6 +18,7 @@ import { DBOfferingGroup,
          DBDocumentType,
          DBLearningLogDocumentMetadata,
          DBLearningLogPublication,
+         DBImage
         } from "./db-types";
 import { DocumentModelType,
          DocumentModel,
@@ -27,6 +28,7 @@ import { DocumentModelType,
          PublicationDocument,
          LearningLogPublication
         } from "../models/document/document";
+import { ImageModelType } from "../models/image";
 import { DocumentContentSnapshotType } from "../models/document/document-content";
 import { Firebase } from "./firebase";
 import { DBListeners } from "./db-listeners";
@@ -592,5 +594,48 @@ export class DB {
     }
 
     return JSON.parse(document.content);
+  }
+
+  public addImage(imageModel: ImageModelType) {
+    const { user } = this.stores;
+    return new Promise<{ image: DBImage }>((resolve, reject) => {
+      const imageRef = this.firebase.ref(this.firebase.getImagesPath(user)).push();
+      const imageKey = imageRef.key!;
+      const version = "1.0";
+      const self = {
+        uid: user.id,
+        classHash: user.classHash,
+        imageKey
+      };
+
+      const createdAt = firebase.database.ServerValue.TIMESTAMP as number;
+      const image: DBImage = {
+        version,
+        self,
+        imageData: imageModel.imageData,
+        title: imageModel.title || "unknown",
+        originalSource: imageModel.originalSource || "unknown",
+        createdAt,
+        createdBy: user.id
+      };
+
+      return imageRef.set(image)
+        .then(() => {
+          resolve({ image });
+        })
+        .catch(reject);
+    });
+  }
+
+  public getImage(imageKey: string) {
+    const { user } = this.stores;
+    return new Promise<DBImage>((resolve, reject) => {
+      const imageRef = this.firebase.ref(this.firebase.getImagesPath(user) + "/" + imageKey);
+      return imageRef.once("value")
+        .then((snapshot) => {
+          resolve(snapshot.val());
+        })
+        .catch(reject);
+    });
   }
 }

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -106,10 +106,6 @@ export class Firebase {
     return `${this.getClassPath(user)}/images`;
   }
 
-  public getImagesPath(user: UserModelType) {
-    return `${this.getClassPath(user)}/images`;
-  }
-
   public getOfferingPath(user: UserModelType) {
     return `${this.getClassPath(user)}/offerings/${user.offeringId}`;
   }

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -102,6 +102,10 @@ export class Firebase {
     return `${this.getUserPath(user, userId)}/learningLogs${suffix}`;
   }
 
+  public getImagesPath(user: UserModelType) {
+    return `${this.getClassPath(user)}/images`;
+  }
+
   public getOfferingPath(user: UserModelType) {
     return `${this.getClassPath(user)}/offerings/${user.offeringId}`;
   }
@@ -174,7 +178,7 @@ export class Firebase {
   }
 
   //
-  // Firestore
+  // Firebase Storage
   //
 
   public getPublicUrlFromStore(storePath: string, storeUrl?: string): Promise<any> {

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -181,7 +181,7 @@ export class Firebase {
   // Firebase Storage
   //
 
-  public getPublicUrlFromStore(storePath: string, storeUrl?: string): Promise<any> {
+  public getPublicUrlFromStore(storePath?: string, storeUrl?: string): Promise<any> {
     const ref = storeUrl ? this.firebaseStorage().refFromURL(storeUrl) : this.firebaseStorage().ref(storePath);
     // Get the download URL - returns a url with an authentication token for the current session
     return ref.getDownloadURL().then((url) => {

--- a/src/models/image-map.test.ts
+++ b/src/models/image-map.test.ts
@@ -1,0 +1,279 @@
+import { externalUrlImagesHandler, localAssetsImagesHandler,
+        firebaseRealTimeDBImagesHandler, firebaseStorageImagesHandler,
+        IImageHandler, ImageMapModel, ImageMapModelType } from "./image-map";
+import * as ImageUtils from "../utilities/image-utils";
+const urlParser = require("url");
+const placeholderImage = require("../assets/image_placeholder.png");
+
+let sImageMap: ImageMapModelType;
+
+beforeAll(() => {
+  jest.spyOn(ImageUtils, "getImageDimensions")
+      .mockImplementation(() =>
+        Promise.resolve({ src: placeholderImage, width: 200, height: 150 }));
+  sImageMap = ImageMapModel.create();
+});
+
+describe("ImageMap", () => {
+  const kLocalImage = "assets/logo_tw.png";
+  const kHttpImage = "http://icon.cat/img/icon_loop.png";
+  const kHttpsImage = "https://icon.cat/img/icon_loop.png";
+  const kFBStorageUrl = "https://firebasestorage.googleapis.com/path/to/image";
+  const kFBStorageRef = "/dev/w8podRScLDbiu5zK3bE6323PY6G3/portals/localhost/coin-background.png";
+  const kCCImgOriginal = "ccimg://path/to/image";
+  const kCCImgFBRTDB = "ccimg://fbrtdb.concord.org/path/to/image";
+  const kCCImgS3 = "ccimg://s3.concord.org/path/to/image";
+  const kBlobUrl = "blob://some-blob-path";
+  const kDataUri = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAIAAABMXPacAAABG2lUWH";
+  const kInputs = [ kLocalImage, kHttpImage, kHttpsImage, kFBStorageUrl, kFBStorageRef,
+                    kCCImgOriginal, kCCImgFBRTDB, kCCImgS3, kBlobUrl, kDataUri ];
+  const kHandlers = [ localAssetsImagesHandler, externalUrlImagesHandler, externalUrlImagesHandler,
+                      firebaseStorageImagesHandler, firebaseStorageImagesHandler,
+                      firebaseRealTimeDBImagesHandler, firebaseRealTimeDBImagesHandler,
+                      undefined, undefined, undefined];
+  function expectToMatch(handler: IImageHandler, matches: string[]) {
+    expect(kInputs.every((input, index) => {
+      const didMatch = handler.match(input);
+      const shouldMatch = matches.indexOf(input) >= 0;
+      if (didMatch !== shouldMatch) {
+        // tslint:disable-next-line:no-console
+        console.log(`handler: ${handler.name}, input: ${input}, match: ${didMatch}, should: ${shouldMatch}`);
+      }
+      expect(didMatch).toBe(shouldMatch);
+      return didMatch === shouldMatch;
+    })).toBe(true);
+  }
+
+  it("test localAssetsImagesHandler", () => {
+    expectToMatch(localAssetsImagesHandler, [kLocalImage]);
+    return localAssetsImagesHandler.store(kLocalImage)
+            .then(imageResult => {
+              expect(imageResult.contentUrl).toBe(kLocalImage);
+              expect(imageResult.displayUrl).toBe(kLocalImage);
+            });
+  });
+
+  it("test externalUrlImagesHandler", () => {
+    expectToMatch(externalUrlImagesHandler, [kHttpImage, kHttpsImage, kFBStorageUrl]);
+
+    let p1: any;
+    let p2: any;
+
+    {
+      const mockDB: any = { getImageBlob: jest.fn(() => Promise.resolve(kBlobUrl)) };
+      const storeSpy = jest.spyOn(ImageUtils, "storeImage")
+                            .mockImplementation(() =>
+                              Promise.resolve({ imageUrl: kCCImgFBRTDB, imageData: kBlobUrl}));
+      p1 = externalUrlImagesHandler.store(kHttpsImage, mockDB, "user")
+        .then(imageResult => {
+          expect(storeSpy).toHaveBeenCalled();
+          expect(imageResult.contentUrl &&
+                  firebaseRealTimeDBImagesHandler.match(imageResult.contentUrl)).toBe(true);
+          expect(imageResult.displayUrl).toMatch(/^blob:/);
+        });
+    }
+    {
+      const mockDB: any = { getImageBlob: jest.fn(() => Promise.resolve(kBlobUrl)) };
+      const storeSpy = jest.spyOn(ImageUtils, "storeImage")
+                            .mockImplementation(() => Promise.reject(new Error("Loading error")));
+      p2 = externalUrlImagesHandler.store(kHttpsImage, mockDB, "user")
+        .then(imageResult => {
+          expect(storeSpy).toHaveBeenCalled();
+          expect(imageResult.contentUrl).toBeUndefined();
+          expect(imageResult.displayUrl).toBeUndefined();
+        });
+    }
+    return Promise.all([p1, p2]);
+  });
+
+  it("test firebaseStorageImagesHandler on firebase storage URL", () => {
+    expectToMatch(firebaseStorageImagesHandler, [kFBStorageUrl, kFBStorageRef]);
+
+    const mockDB: any = {
+            firebase: { getPublicUrlFromStore: (path?: string, url?: string) => Promise.resolve(kFBStorageUrl) },
+            getImageBlob: jest.fn(() => Promise.resolve(kBlobUrl))
+          };
+    const storeSpy = jest.spyOn(ImageUtils, "storeImage")
+                          .mockImplementation(() => Promise.resolve({ imageUrl: kCCImgFBRTDB, imageData: kBlobUrl}));
+    return firebaseStorageImagesHandler.store(kFBStorageUrl, mockDB, "user")
+      .then(imageResult => {
+        expect(storeSpy).toHaveBeenCalled();
+        expect(imageResult.contentUrl &&
+                firebaseRealTimeDBImagesHandler.match(imageResult.contentUrl)).toBe(true);
+        expect(imageResult.displayUrl).toMatch(/^blob:/);
+      });
+  });
+
+  it("test firebaseStorageImagesHandler on firebase storage reference", () => {
+    const mockDB: any = {
+            firebase: { getPublicUrlFromStore: (path?: string, url?: string) => Promise.resolve(kFBStorageUrl) },
+            getImageBlob: jest.fn(() => Promise.resolve(kBlobUrl))
+          };
+    const storeSpy = jest.spyOn(ImageUtils, "storeImage")
+                          .mockImplementation(() => Promise.resolve({ imageUrl: kCCImgFBRTDB, imageData: kBlobUrl}));
+    return firebaseStorageImagesHandler.store(kFBStorageRef, mockDB, "user")
+      .then(imageResult => {
+        expect(storeSpy).toHaveBeenCalled();
+        expect(imageResult.contentUrl &&
+                firebaseRealTimeDBImagesHandler.match(imageResult.contentUrl)).toBe(true);
+        expect(imageResult.displayUrl).toMatch(/^blob:/);
+      });
+  });
+
+  it("test firebaseStorageImagesHandler error handling", () => {
+    const mockDB: any = {
+            firebase: { getPublicUrlFromStore: (path?: string, url?: string) => Promise.resolve(undefined) },
+            getImageBlob: jest.fn(() => Promise.resolve(kBlobUrl))
+          };
+    const storeSpy = jest.spyOn(ImageUtils, "storeImage")
+                          .mockImplementation(() => Promise.resolve({ imageUrl: kCCImgFBRTDB, imageData: kBlobUrl}));
+    return firebaseStorageImagesHandler.store(kCCImgFBRTDB, mockDB, "user")
+      .then(imageResult => {
+        // expect(storeSpy).not.toHaveBeenCalled();
+        expect(imageResult.contentUrl).toBe(placeholderImage);
+        expect(imageResult.displayUrl).toBe(placeholderImage);
+      });
+  });
+
+  it("test firebaseStorageImagesHandler error handling", () => {
+    const mockDB: any = {
+            firebase: { getPublicUrlFromStore: (path?: string, url?: string) =>
+                                                  Promise.reject(new Error("Conversion error")) },
+            getImageBlob: jest.fn(() => Promise.resolve(kBlobUrl))
+          };
+    const storeSpy = jest.spyOn(ImageUtils, "storeImage")
+                          .mockImplementation(() => Promise.reject(new Error("Conversion error")));
+    return firebaseStorageImagesHandler.store(kCCImgFBRTDB, mockDB, "user")
+      .then(imageResult => {
+        // expect(storeSpy).not.toHaveBeenCalled();
+        expect(imageResult.contentUrl).toBe(placeholderImage);
+        expect(imageResult.displayUrl).toBe(placeholderImage);
+      });
+  });
+
+  it("test firebaseStorageImagesHandler error handling", () => {
+    const mockDB: any = {
+            firebase: { getPublicUrlFromStore: (path?: string, url?: string) => Promise.resolve(kFBStorageUrl) },
+            getImageBlob: jest.fn(() => Promise.resolve(kBlobUrl))
+          };
+    const storeSpy = jest.spyOn(ImageUtils, "storeImage")
+                          .mockImplementation(() => Promise.reject(new Error("Conversion error")));
+    return firebaseStorageImagesHandler.store(kCCImgFBRTDB, mockDB, "user")
+      .then(imageResult => {
+        expect(storeSpy).toHaveBeenCalled();
+        expect(imageResult.contentUrl).toBe(placeholderImage);
+        expect(imageResult.displayUrl).toBe(placeholderImage);
+      });
+  });
+
+  it("test firebaseRealTimeDBImagesHandler", () => {
+    const parsedPath = urlParser.parse(kCCImgFBRTDB).path;
+    const path = parsedPath.startsWith("/") ? parsedPath.slice(1) : parsedPath;
+    expectToMatch(firebaseRealTimeDBImagesHandler, [kCCImgOriginal, kCCImgFBRTDB]);
+    let p1: any;
+    let p2: any;
+    let p3: any;
+    {
+      const mockDB: any = { getImageBlob: jest.fn(() => Promise.resolve(kBlobUrl)) };
+      p1 = firebaseRealTimeDBImagesHandler.store(kCCImgOriginal, mockDB, "user")
+        .then(imageResult => {
+          expect(mockDB.getImageBlob).toHaveBeenCalledWith(path);
+          expect(imageResult.contentUrl).toBe(kCCImgFBRTDB);
+          expect(imageResult.displayUrl).toMatch(/^blob:/);
+        });
+    }
+    {
+      const mockDB: any = { getImageBlob: jest.fn(() => Promise.resolve(kBlobUrl)) };
+      p2 = firebaseRealTimeDBImagesHandler.store(kCCImgFBRTDB, mockDB, "user")
+        .then(imageResult => {
+          expect(mockDB.getImageBlob).toHaveBeenCalledWith(path);
+          expect(imageResult.contentUrl).toBe(kCCImgFBRTDB);
+          expect(imageResult.displayUrl).toMatch(/^blob:/);
+        });
+    }
+    {
+      const mockDB: any = { getImageBlob: jest.fn(() => Promise.resolve(kBlobUrl)) };
+      p3 = firebaseRealTimeDBImagesHandler.store("", mockDB, "user")
+        .then(imageResult => {
+          expect(imageResult.contentUrl).toBeUndefined();
+          expect(imageResult.displayUrl).toBeUndefined();
+        });
+    }
+    return Promise.all([p1, p2, p3]);
+  });
+
+  it("can be initialized", () => {
+    const mockDB: any = { getImageBlob: jest.fn(() => Promise.resolve(kBlobUrl)) };
+    sImageMap.initialize(mockDB, "user");
+
+    expect(sImageMap.handlers[0].name).toBe("firebaseRealTimeDB");
+    expect(sImageMap.handlers[1].name).toBe("firebaseStorage");
+    expect(sImageMap.handlers[2].name).toBe("localAssets");
+  });
+
+  it("dispatches URLs to appropriate handlers", () => {
+    expect(kInputs.every((url, index) => {
+      const expected = kHandlers[index];
+      const handler = sImageMap.getHandler(url);
+      expect(handler && handler.name).toBe(expected && expected.name);
+      return (handler && handler.name) === (expected && expected.name);
+    }));
+  });
+
+  it("can handle falsy urls", () => {
+    return sImageMap.getImage("")
+            .then(image => {
+              expect(image.displayUrl).toBe(placeholderImage);
+              expect(image.width).toBe(200);
+              expect(image.height).toBe(150);
+            });
+  });
+
+  it("can retrieve placeholder image from cache", () => {
+    expect(sImageMap.hasImage(placeholderImage));
+    return sImageMap.getImage(placeholderImage)
+            .then(image => {
+              expect(image.displayUrl).toBe(placeholderImage);
+              expect(image.width).toBe(200);
+              expect(image.height).toBe(150);
+            });
+  });
+
+  it("can add an image", () => {
+    const dimSpy = jest.spyOn(ImageUtils, "getImageDimensions")
+                        .mockImplementation(() =>
+                          Promise.resolve({ src: placeholderImage, width: 200, height: 150 }));
+    const count = sImageMap.imageCount;
+    return sImageMap.getImage(kLocalImage)
+            .then(image => {
+              expect(sImageMap.imageCount).toBe(count + 1);
+              expect(sImageMap.hasImage(kLocalImage));
+              expect(dimSpy).toHaveBeenCalled();
+              expect(image.contentUrl).toBe(kLocalImage);
+              expect(image.displayUrl).toBe(kLocalImage);
+              expect(image.width).toBe(200);
+              expect(image.height).toBe(150);
+            });
+  });
+
+  it("returns the placeholder for unmatched images", () => {
+    return sImageMap.getImage("foo")
+            .then(image => {
+              expect(image.displayUrl).toBe(placeholderImage);
+            });
+  });
+
+  it("can add a file image", () => {
+    const storeSpy = jest.spyOn(ImageUtils, "storeImage")
+                          .mockImplementation(() =>
+                            Promise.resolve({ imageUrl: kCCImgFBRTDB, imageData: kBlobUrl}));
+    const file: any = { name: "foo" };
+    return sImageMap.addFileImage(file)
+            .then(image => {
+              expect(storeSpy).toHaveBeenCalled();
+              expect(image.contentUrl &&
+                      firebaseRealTimeDBImagesHandler.match(image.contentUrl)).toBe(true);
+              expect(image.displayUrl).toMatch(/^blob:/);
+            });
+  });
+});

--- a/src/models/image-map.test.ts
+++ b/src/models/image-map.test.ts
@@ -93,7 +93,7 @@ describe("ImageMap", () => {
             firebase: { getPublicUrlFromStore: (path?: string, url?: string) => Promise.resolve(kFBStorageUrl) },
             getImageBlob: jest.fn(() => Promise.resolve(kBlobUrl))
           };
-    const storeSpy = jest.spyOn(ImageUtils, "storeImage")
+    const storeSpy = jest.spyOn(ImageUtils, "storeCorsImage")
                           .mockImplementation(() => Promise.resolve({ imageUrl: kCCImgFBRTDB, imageData: kBlobUrl}));
     return firebaseStorageImagesHandler.store(kFBStorageUrl, mockDB, "user")
       .then(imageResult => {
@@ -161,8 +161,8 @@ describe("ImageMap", () => {
     return firebaseStorageImagesHandler.store(kCCImgFBRTDB, mockDB, "user")
       .then(imageResult => {
         expect(storeSpy).toHaveBeenCalled();
-        expect(imageResult.contentUrl).toBe(placeholderImage);
-        expect(imageResult.displayUrl).toBe(placeholderImage);
+        expect(imageResult.contentUrl).toBe(kCCImgFBRTDB);
+        expect(imageResult.displayUrl).toBe(kBlobUrl);
       });
   });
 
@@ -264,7 +264,7 @@ describe("ImageMap", () => {
   });
 
   it("can add a file image", () => {
-    const storeSpy = jest.spyOn(ImageUtils, "storeImage")
+    const storeSpy = jest.spyOn(ImageUtils, "storeFileImage")
                           .mockImplementation(() =>
                             Promise.resolve({ imageUrl: kCCImgFBRTDB, imageData: kBlobUrl}));
     const file: any = { name: "foo" };

--- a/src/models/image-map.ts
+++ b/src/models/image-map.ts
@@ -26,21 +26,12 @@ export interface IImageHandler {
   store: (url: string, db?: DB, userId?: string) => Promise<ImageMapEntrySnapshot>;
 }
 
-interface IImageContext {
-  suspendCount: number;
-  url: string;
-  promise: Promise<ImageMapEntryType>;
-  resolve?: any;
-  reject?: any;
-}
-
 export const ImageMapModel = types
   .model("ImageMap", {
     images: types.map(ImageMapEntry)
   })
   .volatile(self => ({
-    handlers: [] as IImageHandler[],
-    contexts: {} as { [id: string]: IImageContext }
+    handlers: [] as IImageHandler[]
   }))
   .views(self => ({
     hasImage(url: string) {
@@ -278,9 +269,6 @@ export const firebaseStorageImagesHandler: IImageHandler = {
                 // TODO: remove old images
                 const { normalized } = parseFauxFirebaseRTDBUrl(simpleImage.imageUrl);
                 resolve({ contentUrl: normalized, displayUrl: simpleImage.imageData });
-              })
-              .catch(() => {
-                resolve({ contentUrl: placeholderImage, displayUrl: placeholderImage });
               });
           }
           else {

--- a/src/models/image-map.ts
+++ b/src/models/image-map.ts
@@ -1,0 +1,345 @@
+import { types, Instance, SnapshotIn, clone } from "mobx-state-tree";
+import { getImageDimensions, storeCorsImage, storeFileImage, storeImage } from "../utilities/image-utils";
+import { DB } from "../lib/db";
+const placeholderImage = require("../assets/image_placeholder.png");
+const loadingSpinner = require("../assets/Spinner-1s-200px.svg");
+
+export const kExternalUrlHandlerName = "externalUrl";
+export const kLocalAssetsHandlerName = "localAssets";
+export const kFirebaseStorageHandlerName = "firebaseStorage";
+export const kFirebaseRealTimeDBHandlerName = "firebaseRealTimeDB";
+
+export const ImageMapEntry = types
+  .model("ImageEntry", {
+    contentUrl: types.maybe(types.string),
+    displayUrl: types.maybe(types.string),
+    width: types.maybe(types.number),
+    height: types.maybe(types.number)
+  });
+export type ImageMapEntryType = Instance<typeof ImageMapEntry>;
+export type ImageMapEntrySnapshot = SnapshotIn<typeof ImageMapEntry>;
+
+export interface IImageHandler {
+  name: string;
+  priority: number;
+  match: (url: string) => boolean;
+  store: (url: string, db?: DB, userId?: string) => Promise<ImageMapEntrySnapshot>;
+}
+
+interface IImageContext {
+  suspendCount: number;
+  url: string;
+  promise: Promise<ImageMapEntryType>;
+  resolve?: any;
+  reject?: any;
+}
+
+export const ImageMapModel = types
+  .model("ImageMap", {
+    images: types.map(ImageMapEntry)
+  })
+  .volatile(self => ({
+    handlers: [] as IImageHandler[],
+    contexts: {} as { [id: string]: IImageContext }
+  }))
+  .views(self => ({
+    hasImage(url: string) {
+      return self.images.has(url);
+    },
+    get imageCount() {
+      return self.images.size;
+    },
+    getHandler(url: string) {
+      const index = self.handlers.findIndex(handler => handler.match(url));
+      return index >= 0 ? self.handlers[index] : undefined;
+    },
+    isExternalUrl(url: string) {
+      const index = self.handlers.findIndex(handler => handler.match(url));
+      return (index >= 0) &&
+              (self.handlers[index].name === kExternalUrlHandlerName);
+    },
+    isPlaceholder(url: string) {
+      return url === placeholderImage;
+    },
+    getCachedImage(url?: string) {
+      return url ? self.images.get(url) : undefined;
+    }
+  }))
+  .actions(self => ({
+    syncContentUrl(url: string, entry: ImageMapEntryType) {
+      if (entry.contentUrl && (url !== entry.contentUrl)) {
+        // if the url was changed, store it under the new url as well
+        self.images.set(entry.contentUrl, clone(entry));
+      }
+    },
+
+    setDimensions(url: string, width: number, height: number) {
+      const entry = self.images.get(url);
+      if (entry) {
+        entry.width = width;
+        entry.height = height;
+      }
+    },
+
+    registerHandler(handler: IImageHandler) {
+      self.handlers.push(handler);
+      self.handlers.sort((a, b) => {
+        return (b.priority || 0) - (a.priority || 0);
+      });
+    }
+  }))
+  .actions(self => ({
+    addImage(url: string, snapshot: ImageMapEntrySnapshot): Promise<ImageMapEntryType> {
+      return new Promise((resolve, reject) => {
+        let entry: ImageMapEntryType | undefined;
+
+        // update existing entry
+        if (self.images.has(url)) {
+          entry = self.images.get(url);
+          if (entry && snapshot.contentUrl) {
+            entry.contentUrl = snapshot.contentUrl;
+          }
+          if (entry && snapshot.displayUrl) {
+            entry.displayUrl = snapshot.displayUrl;
+          }
+        }
+        // create new entry
+        else {
+          entry = ImageMapEntry.create(snapshot);
+          self.images.set(url, entry);
+        }
+        self.syncContentUrl(url, entry!);
+
+        getImageDimensions(entry && entry.displayUrl || url)
+          .then(dimensions => {
+            const _entry = self.images.get(url);
+            if (_entry) {
+              self.setDimensions(url, dimensions.width, dimensions.height);
+              self.syncContentUrl(url, _entry);
+              resolve(self.images.get(url));
+            }
+          });
+      });
+    }
+  }))
+  .actions(self => ({
+    addPromise(url: string, promise: Promise<ImageMapEntrySnapshot>): Promise<ImageMapEntryType> {
+      return new Promise((resolve, reject) => {
+        promise.then(snapshot => {
+          resolve(self.addImage(url, snapshot));
+        });
+      });
+    }
+  }))
+  .actions(self => {
+    let _db: DB;
+    let _userId: string;
+
+    return {
+      afterCreate() {
+        // placeholder and spinner don't have contentUrl
+        self.addImage(placeholderImage, { displayUrl: placeholderImage });
+        self.addImage(loadingSpinner, { displayUrl: loadingSpinner });
+
+        self.registerHandler(firebaseRealTimeDBImagesHandler);
+        self.registerHandler(firebaseStorageImagesHandler);
+        self.registerHandler(localAssetsImagesHandler);
+        self.registerHandler(externalUrlImagesHandler);
+      },
+
+      initialize(db: DB, userId: string) {
+        _db = db;
+        _userId = userId;
+      },
+
+      addFileImage(file: File): Promise<ImageMapEntryType> {
+        return new Promise((resolve, reject) => {
+          storeFileImage(_db, _userId, file)
+            .then(simpleImage => {
+              const { normalized } = parseFauxFirebaseRTDBUrl(simpleImage.imageUrl);
+              const entry: ImageMapEntrySnapshot = {
+                      contentUrl: normalized,
+                      displayUrl: simpleImage.imageData
+                    };
+              resolve(self.addImage(entry.contentUrl!, entry));
+            });
+        });
+      },
+
+      getImage(url: string): Promise<ImageMapEntryType> {
+        return new Promise((resolve, reject) => {
+          if (!url) {
+            resolve(clone(self.images.get(placeholderImage)!));
+          }
+
+          if (self.images.has(url)) {
+            return resolve(self.images.get(url));
+          }
+
+          const handler = self.getHandler(url);
+          if (handler) {
+            const promise = handler.store(url, _db, _userId);
+            resolve(self.addPromise(url, promise));
+          }
+          else {
+            resolve(clone(self.images.get(placeholderImage)!));
+          }
+        });
+      }
+
+    };
+  });
+export type ImageMapModelType = Instance<typeof ImageMapModel>;
+
+/*
+ * externalUrlImagesHandler
+ */
+export const externalUrlImagesHandler: IImageHandler = {
+  name: kExternalUrlHandlerName,
+  priority: 1,
+
+  match(url: string) {
+    return url ? /^https?:\/\//.test(url) : false;
+  },
+
+  store(url: string, db: DB, userId: string) {
+    // upload images from external urls to our own firebase if possible
+    // this may fail depending on CORS settings on target image.
+    return new Promise((resolve, reject) => {
+      storeImage(db, userId, url)
+        .then(simpleImage => {
+          if (simpleImage.imageUrl === placeholderImage) {
+            // conversion errors are resolved to placeholder image
+            // this generally occurs due to a CORS error, in which
+            // case we just use the original url.
+            resolve({ contentUrl: url, displayUrl: url });
+          }
+          else {
+            const { normalized } = parseFauxFirebaseRTDBUrl(simpleImage.imageUrl);
+            resolve({ contentUrl: normalized, displayUrl: simpleImage.imageData });
+          }
+        })
+        .catch(() => {
+          // If the silent upload has failed, do we retain the full url or
+          // encourage the user to download a copy and re-upload?
+          // For now, return the original image url.
+          resolve({});
+        });
+    });
+  }
+};
+
+/*
+ * localAssetsImagesHandler
+ */
+export const localAssetsImagesHandler: IImageHandler = {
+  name: kLocalAssetsHandlerName,
+  priority: 2,
+
+  match(url: string) {
+    return url ? url.startsWith("assets/") : false;
+  },
+
+  store(url: string) {
+    return Promise.resolve({ contentUrl: url, displayUrl: url });
+  }
+};
+
+/*
+ * firebaseStorageImagesHandler
+ */
+const kFirebaseStorageUrlPrefix = "https://firebasestorage.googleapis.com";
+
+export const firebaseStorageImagesHandler: IImageHandler = {
+  name: kFirebaseStorageHandlerName,
+  priority: 3,
+
+  match(url: string) {
+    return url.startsWith(kFirebaseStorageUrlPrefix) ||
+                          // original firebase storage path reference
+                          /^\/.+\/portals\/.+$/.test(url);
+  },
+
+  store(url: string, db: DB, userId: string) {
+    return new Promise((resolve, reject) => {
+      // All images from firebase storage must be migrated to realtime database
+      const isStorageUrl = url.startsWith(kFirebaseStorageUrlPrefix);
+      const storageUrl = url.startsWith(kFirebaseStorageUrlPrefix) ? url : undefined;
+      const storagePath = !isStorageUrl ? url : undefined;
+      // Pass in the imagePath as the second argument to get the ref to firebase storage by url
+      // This is needed if an image of the same name has been uploaded in two different components,
+      // since each public URL becomes invalid and a new url generated on upload
+      db.firebase.getPublicUrlFromStore(storagePath, storageUrl)
+        .then(newUrl => {
+          if (newUrl) {
+            storeCorsImage(db, userId, newUrl)
+              .then(simpleImage => {
+                // Image has been retrieved from Storage, now we can safely remove the old image
+                // TODO: remove old images
+                const { normalized } = parseFauxFirebaseRTDBUrl(simpleImage.imageUrl);
+                resolve({ contentUrl: normalized, displayUrl: simpleImage.imageData });
+              })
+              .catch(() => {
+                resolve({ contentUrl: placeholderImage, displayUrl: placeholderImage });
+              });
+          }
+          else {
+            resolve({ contentUrl: placeholderImage, displayUrl: placeholderImage });
+          }
+        })
+        .catch(() => {
+          resolve({ contentUrl: placeholderImage, displayUrl: placeholderImage });
+        });
+    });
+  }
+};
+
+/*
+ * firebaseRealTimeDBImagesHandler
+ */
+const kCCImageScheme = "ccimg";
+const kFirebaseRTDBFauxHost = "fbrtdb.concord.org";
+const kFirebaseRTDBEscFauxHost = kFirebaseRTDBFauxHost.replace(/\./g, "\\.");
+const kFirebaseRTDBFauxUrlPrefix = `${kCCImageScheme}://${kFirebaseRTDBFauxHost}`;
+const kFirebaseRTDBFauxUrlRegex = new RegExp(`^${kCCImageScheme}:\/\/(${kFirebaseRTDBEscFauxHost}\/)?(.*)`);
+
+function createFirebaseRTDBFauxUrl(path: string) {
+  return `${kFirebaseRTDBFauxUrlPrefix}/${path}`;
+}
+function extractPathFromFirebaseRTDBFauxUrl(url: string) {
+  const match = kFirebaseRTDBFauxUrlRegex.exec(url);
+  return match && match[2] || undefined;
+}
+function parseFauxFirebaseRTDBUrl(url: string) {
+  const path = extractPathFromFirebaseRTDBFauxUrl(url) || undefined;
+  const normalized = path && createFirebaseRTDBFauxUrl(path);
+  return { path, normalized };
+}
+
+export const firebaseRealTimeDBImagesHandler: IImageHandler = {
+  name: kFirebaseRealTimeDBHandlerName,
+  priority: 4,
+
+  match(url: string) {
+    return url.startsWith(kFirebaseRTDBFauxUrlPrefix) ||
+          (url.startsWith(`${kCCImageScheme}://`) && (url.indexOf("concord.org") < 0));
+  },
+
+  store(url: string, db: DB) {
+    return new Promise((resolve, reject) => {
+      const { path, normalized } = parseFauxFirebaseRTDBUrl(url);
+
+      if (path && normalized) {
+        db.getImageBlob(path)
+          .then(blobUrl => {
+            resolve({ contentUrl: normalized, displayUrl: blobUrl });
+          });
+      }
+      else {
+        resolve({});
+      }
+    });
+  }
+};
+
+export const gImageMap = ImageMapModel.create();

--- a/src/models/image.ts
+++ b/src/models/image.ts
@@ -1,0 +1,30 @@
+import { types, Instance } from "mobx-state-tree";
+
+export function defaultImage() {
+  return ImageModel.create({
+    key: "",
+    imageData: "",
+    title: "Placeholder",
+    originalSource: "",
+    createdAt: 0,
+    createdBy: ""
+  });
+}
+
+export const ImageModel = types
+  .model("Image", {
+    key: types.string,
+    imageData: types.string,
+    title: types.maybe(types.string),
+    originalSource: types.maybe(types.string),
+    createdAt: types.number,
+    createdBy: types.string
+  })
+  .actions((self) => ({
+    setKey(key: string) {
+      self.key = key;
+    }
+
+  }));
+
+export type ImageModelType = Instance<typeof ImageModel>;

--- a/src/models/stores/stores.ts
+++ b/src/models/stores/stores.ts
@@ -45,7 +45,7 @@ export interface ICreateStores {
 }
 
 export function createStores(params?: ICreateStores): IStores {
-  const user = params && params.user || UserModel.create({id: "0"});
+  const user = params && params.user || UserModel.create({ id: "0" });
   return {
     appMode: params && params.appMode ? params.appMode : "dev",
     // for ease of testing, we create a null problem if none is provided
@@ -64,7 +64,7 @@ export function createStores(params?: ICreateStores): IStores {
       },
     }),
     groups: params && params.groups || GroupsModel.create({}),
-    class: params && params.class || ClassModel.create({name: "Null Class", classHash: ""}),
+    class: params && params.class || ClassModel.create({ name: "Null Class", classHash: "" }),
     db: params && params.db || new DB(),
     documents: params && params.documents || DocumentsModel.create({}),
     unit: params && params.unit || UnitModel.create({title: "Null Unit"}),

--- a/src/models/tools/geometry/jxg-changes.ts
+++ b/src/models/tools/geometry/jxg-changes.ts
@@ -8,6 +8,7 @@ export type JXGParentType = string | number | JXGCoordPair;
 
 export interface JXGProperties {
   position?: JXGCoordPair;
+  url?: string;
   [key: string]: any;
 }
 

--- a/src/models/tools/geometry/jxg-image.ts
+++ b/src/models/tools/geometry/jxg-image.ts
@@ -8,14 +8,14 @@ export const isImage = (v: any) => v instanceof JXG.Image;
 
 export const imageChangeAgent: JXGChangeAgent = {
   create: (board: JXG.Board, change: JXGChange) => {
-    const parents = change.parents || [];
+    const parents = (change.parents || []).slice();
     const url = parents && parents[0] as string || "";
     const imageEntry = url && gImageMap.getCachedImage(url);
     const displayUrl = imageEntry && imageEntry.displayUrl || "";
     parents[0] = displayUrl;
     const props = assign({ id: uuid(), fixed: true }, change.properties);
     return parents && parents.length >= 3
-            ? board.create("image", change.parents, props)
+            ? board.create("image", parents, props)
             : undefined;
   },
 

--- a/src/models/tools/geometry/jxg-image.ts
+++ b/src/models/tools/geometry/jxg-image.ts
@@ -1,5 +1,6 @@
 import { JXGChange, JXGChangeAgent } from "./jxg-changes";
 import { objectChangeAgent } from "./jxg-object";
+import { gImageMap } from "../../image-map";
 import { assign } from "lodash";
 import * as uuid from "uuid/v4";
 
@@ -7,14 +8,17 @@ export const isImage = (v: any) => v instanceof JXG.Image;
 
 export const imageChangeAgent: JXGChangeAgent = {
   create: (board: JXG.Board, change: JXGChange) => {
-    const parents = change.parents;
+    const parents = change.parents || [];
+    const url = parents && parents[0] as string || "";
+    const imageEntry = url && gImageMap.getCachedImage(url);
+    const displayUrl = imageEntry && imageEntry.displayUrl || "";
+    parents[0] = displayUrl;
     const props = assign({ id: uuid(), fixed: true }, change.properties);
     return parents && parents.length >= 3
             ? board.create("image", change.parents, props)
             : undefined;
   },
 
-  // update can be handled generically
   update: (board, change) => {
     if (!change.targetID || !change.properties) { return; }
     const ids = Array.isArray(change.targetID) ? change.targetID : [change.targetID];
@@ -25,14 +29,17 @@ export const imageChangeAgent: JXGChangeAgent = {
       const objProps = index < props.length ? props[index] : props[0];
       if (image && objProps) {
         const { url, size } = objProps;
-        if (url != null) {
-          image.url = url;
+        const imageEntry = gImageMap.getCachedImage(url);
+        const displayUrl = imageEntry && imageEntry.displayUrl || "";
+        if (displayUrl) {
+          image.url = displayUrl;
         }
         if (size != null) {
           image.setSize(size[0], size[1]);
         }
       }
     });
+    // other properties can be handled generically
     objectChangeAgent.update(board, change);
   },
 

--- a/src/models/tools/image/image-content.ts
+++ b/src/models/tools/image/image-content.ts
@@ -6,14 +6,16 @@ export const kImageToolID = "Image";
 export function defaultImageContent() {
   return ImageContentModel.create({
                             type: "Image",
-                            url: placeholderImage
+                            url: placeholderImage,
+                            imageId: ""
                           });
 }
 
 export const ImageContentModel = types
   .model("ImageTool", {
     type: types.optional(types.literal(kImageToolID), kImageToolID),
-    url: types.string
+    url: types.string,
+    imageId: types.maybe(types.string)
   })
   .views(self => ({
     get isUserResizable() {
@@ -27,9 +29,14 @@ export const ImageContentModel = types
       self.url = url;
     }
 
+    function setId(id: string) {
+      self.imageId = id;
+    }
+
     return {
       actions: {
-        setUrl
+        setUrl,
+        setId
       }
     };
   });

--- a/src/models/tools/image/image-content.ts
+++ b/src/models/tools/image/image-content.ts
@@ -1,40 +1,81 @@
-import { types, Instance } from "mobx-state-tree";
-const placeholderImage = "assets/image_placeholder.png";
+import { types, Instance, SnapshotOut } from "mobx-state-tree";
+import { safeJsonParse } from "../../../utilities/js-utils";
+const placeholderImage = require("../../../assets/image_placeholder.png");
 
 export const kImageToolID = "Image";
 
+export type ImageOperation = "update";
+
+export interface ImageToolChange {
+  operation: ImageOperation;
+  url: string;
+}
+
 export function defaultImageContent() {
+  const change = JSON.stringify({
+                  operation: "update",
+                  url: placeholderImage
+                });
   return ImageContentModel.create({
                             type: "Image",
-                            url: placeholderImage
+                            changes: [change]
                           });
+}
+
+function createChange(url: string) {
+  return JSON.stringify({ operation: "update", url });
 }
 
 export const ImageContentModel = types
   .model("ImageTool", {
     type: types.optional(types.literal(kImageToolID), kImageToolID),
-    url: types.string
+    changes: types.array(types.string)
   })
-  .volatile(self => ({
-    displayUrl: ""
-  }))
+  .preProcessSnapshot(snapshot => {
+    const { url, changes, ...others } = snapshot as any;
+    return url && !changes
+            ? { changes: [createChange(url)], ...others }
+            : snapshot;
+  })
   .views(self => ({
     get isUserResizable() {
       return true;
+    },
+    get changeCount() {
+      return self.changes.length;
+    },
+    get url() {
+      if (!self.changes.length) return;
+      const lastChangeJson = self.changes[self.changes.length - 1];
+      const lastChange = safeJsonParse(lastChangeJson);
+      return lastChange && lastChange.url;
     }
   }))
-  .extend(self => {
-
-    // actions
-    function setUrl(url: string) {
-      self.url = url;
+  .actions(self => ({
+    setUrl(url: string) {
+      self.changes.push(createChange(url));
+    },
+    updateImageUrl(oldUrl: string, newUrl: string) {
+      if (!oldUrl || !newUrl || (oldUrl === newUrl)) return;
+      // identify change entries to be modified
+      const updates: Array<{ index: number, change: string }> = [];
+      self.changes.forEach((changeJson, index) => {
+        const change: ImageToolChange = safeJsonParse(changeJson);
+        switch (change && change.operation) {
+          case "update":
+            if (change.url && (change.url === oldUrl)) {
+              change.url = newUrl;
+              updates.push({ index, change: JSON.stringify(change) });
+            }
+            break;
+        }
+      });
+      // make the corresponding changes
+      updates.forEach(update => {
+        self.changes[update.index] = update.change;
+      });
     }
-
-    return {
-      actions: {
-        setUrl
-      }
-    };
-  });
+  }));
 
 export type ImageContentModelType = Instance<typeof ImageContentModel>;
+export type ImageContentSnapshotOutType = SnapshotOut<typeof ImageContentModel>;

--- a/src/models/tools/image/image-content.ts
+++ b/src/models/tools/image/image-content.ts
@@ -6,17 +6,18 @@ export const kImageToolID = "Image";
 export function defaultImageContent() {
   return ImageContentModel.create({
                             type: "Image",
-                            url: placeholderImage,
-                            imageId: ""
+                            url: placeholderImage
                           });
 }
 
 export const ImageContentModel = types
   .model("ImageTool", {
     type: types.optional(types.literal(kImageToolID), kImageToolID),
-    url: types.string,
-    imageId: types.maybe(types.string)
+    url: types.string
   })
+  .volatile(self => ({
+    displayUrl: ""
+  }))
   .views(self => ({
     get isUserResizable() {
       return true;
@@ -29,14 +30,9 @@ export const ImageContentModel = types
       self.url = url;
     }
 
-    function setId(id: string) {
-      self.imageId = id;
-    }
-
     return {
       actions: {
-        setUrl,
-        setId
+        setUrl
       }
     };
   });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = (env, argv) => {
   return {
     context: __dirname, // to automatically find tsconfig.json
     devtool: 'source-map',
-    entry: './src/index.tsx',
+    entry: ['whatwg-fetch', './src/index.tsx'],
     mode: 'development',
     output: {
       filename: 'assets/index.[hash].js'


### PR DESCRIPTION
These changes will change our image storage mechanism from using Firebase Storage to storing the images as base64 strings in the realtime database.

**Important safety note** Testing this code on this branch in demo mode will add images that can only be retrieved if the users are using the same branch. The URL scheme will not be recognized if you add an image while testing on http://collaborative-learning.concord.org/branch/image-storage/?demo then view the same user's documents on Master, for example. 

Additional refactor notes: Goals of the refactor beyond what @dstrawberrygirl had done:
- Fix lingering content synchronization issues (e.g. images not appearing in My Work thumbnails).
- Consolidate as much of the functionality as possible in common/utility code to simplify adding support to downstream clients (i.e. geometry and drawing tools).
- Add full image support to geometry and drawing tools.
- Use blob urls instead of data uris for image display.

Technical details: Images are now stored under the classID, similar to document storage. These images are referenced from the ImageContent tool via ID. Some issues remain regarding updates to other copies of the same components in the sidebar (adding an image doesn't immediately update the sidebar. Displayed images are all data strings currently once they have been loaded from the specified source. I had hoped to use a volatile field for displayUrl but was unable to complete this work in time. I had also hoped to use URL.createObjectURL instead of retaining the base64 strings but again was unable to complete that part. 