### PR TITLE
Implements hidden copy/download tile content as json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "collaborative-learning",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1953,6 +1953,12 @@
       "requires": {
         "@types/enzyme": "*"
       }
+    },
+    "@types/file-saver": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/file-saver/-/file-saver-2.0.0.tgz",
+      "integrity": "sha512-dxdRrUov2HVTbSRFX+7xwUPlbGYVEZK6PrSqClg2QPos3PNe0bCajkDDkDeeC1znjSH03KOEqVbXpnJuWa2wgQ==",
+      "dev": true
     },
     "@types/form-data": {
       "version": "2.2.1",
@@ -6807,6 +6813,11 @@
         "loader-utils": "^1.0.2",
         "schema-utils": "^1.0.0"
       }
+    },
+    "file-saver": {
+      "version": "2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.0-rc.4.tgz",
+      "integrity": "sha512-6Runcc5CffLF9Rpf/MLc3db9eOi2f7b+DvBXpSpJ/hEy+olM+Bw0kx/bOnnp1X4QgOkFZe8ojrM4iZ0JCWmVMQ=="
     },
     "filename-regex": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@firebase/app-types": "^0.3.2",
     "@types/enzyme": "^3.1.14",
     "@types/enzyme-adapter-react-16": "^1.0.3",
+    "@types/file-saver": "^2.0.0",
     "@types/jest": "^23.3.2",
     "@types/jsonwebtoken": "^7.2.8",
     "@types/lodash": "^4.14.116",
@@ -116,6 +117,7 @@
   "dependencies": {
     "@concord-consortium/firebase": "^5.5.6-cc.1",
     "@concord-consortium/jsxgraph": "^0.99.8-cc.1",
+    "file-saver": "^2.0.0-rc.4",
     "immutable": "^3.8.2",
     "initials": "^3.0.0",
     "jsonwebtoken": "^8.3.0",

--- a/src/components/canvas-tools/tool-tile.tsx
+++ b/src/components/canvas-tools/tool-tile.tsx
@@ -81,7 +81,7 @@ export class ToolTileComponent extends BaseComponent<IProps, {}> {
     const { appMode } = this.stores;
     if (appMode !== "authed") {
       this.hotKeys.register({
-        "cmd-option-c": this.handleCopyJson
+        "cmd-shift-c": this.handleCopyJson
       });
     }
   }

--- a/src/components/canvas-tools/tool-tile.tsx
+++ b/src/components/canvas-tools/tool-tile.tsx
@@ -11,6 +11,8 @@ import GeometryToolComponent from "./geometry-tool";
 import TextToolComponent from "./text-tool";
 import ImageToolComponent from "./image-tool";
 import DrawingToolComponent from "./drawing-tool/drawing-tool";
+import { HotKeys } from "../../utilities/hot-keys";
+import * as FileSaver from "file-saver";
 import { cloneDeep } from "lodash";
 import "./tool-tile.sass";
 
@@ -73,6 +75,17 @@ const kToolComponentMap: any = {
 @observer
 export class ToolTileComponent extends BaseComponent<IProps, {}> {
 
+  private hotKeys: HotKeys = new HotKeys();
+
+  public componentDidMount() {
+    const { appMode } = this.stores;
+    if (appMode !== "authed") {
+      this.hotKeys.register({
+        "cmd-option-c": this.handleCopyJson
+      });
+    }
+  }
+
   public render() {
     const { model, widthPct } = this.props;
     const { ui } = this.stores;
@@ -86,6 +99,7 @@ export class ToolTileComponent extends BaseComponent<IProps, {}> {
       <div className={`tool-tile${selectedClass}`}
           data-tool-id={model.id}
           style={style}
+          onKeyDown={this.handleKeyDown}
           onDragStart={this.handleToolDragStart}
           draggable={true}
       >
@@ -103,6 +117,19 @@ export class ToolTileComponent extends BaseComponent<IProps, {}> {
     return ToolComponent != null
             ? <ToolComponent key={this.props.model.id} {...this.props} />
             : null;
+  }
+
+  private handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    this.hotKeys.dispatch(e);
+  }
+
+  private handleCopyJson = () => {
+    const { content } = this.props.model;
+    const json = JSON.stringify(content);
+    const { clipboard } = this.stores;
+    clipboard.clear();
+    clipboard.addJsonTileContent(this.props.model.id, content, this.stores);
+    return true;
   }
 
   private handleToolDragStart = (e: React.DragEvent<HTMLDivElement>) => {

--- a/src/components/document.sass
+++ b/src/components/document.sass
@@ -40,6 +40,10 @@
       padding: 1px 0
       display: flex
 
+      .icon-download
+        transform: rotate(180deg)
+        transform-origin: 50% 50%
+
       .mode
         border-top-right-radius: $border-radius
 

--- a/src/models/clipboard.ts
+++ b/src/models/clipboard.ts
@@ -1,6 +1,10 @@
 import { types, Instance } from "mobx-state-tree";
 import { IStores } from "./stores";
+import { ToolContentUnionType } from "./tools/tool-types";
 import * as uuid from "uuid/v4";
+
+export const kTypeText = "text";
+export const kJsonTileContent = "org.concord.clue.clipboard.tileJson";
 
 export const ClipboardEntryModel = types
   .model("Clipboard", {
@@ -48,6 +52,20 @@ export const ClipboardModel = types
         // ignore errors
       }
       return content;
+    },
+    hasTextContent() {
+      return self.content.has(kTypeText);
+    },
+    getTextContent() {
+      const entry = self.content.get(kTypeText);
+      return entry && entry.content || "";
+    },
+    hasJsonTileContent() {
+      return self.content.has(kJsonTileContent);
+    },
+    getJsonTileContent() {
+      const entry = self.content.get(kJsonTileContent);
+      return entry && entry.content || "";
     }
   }))
   .actions(self => ({
@@ -66,6 +84,18 @@ export const ClipboardModel = types
         content: JSON.stringify(content)
       });
       self.content.set(clipType, entry);
+    },
+    addJsonTileContent(tileId: string, content: ToolContentUnionType, stores: IStores) {
+      const document = stores.documents.findDocumentOfTile(tileId);
+      const entry = ClipboardEntryModel.create({
+        userId: document ? document.uid : "",
+        srcDocumentId: document ? document.key : "",
+        srcDocumentType: document ? document.type : "",
+        srcTileId: tileId,
+        type: kJsonTileContent,
+        content: JSON.stringify(content)
+      });
+      self.content.set(kJsonTileContent, entry);
     }
   }));
 export type ClipboardModelType = Instance<typeof ClipboardModel>;


### PR DESCRIPTION
- cmd-shift-c or ctrl-shift-c in supported component (e.g. geometry) copies json content to internal clipboard
- when internal clipboard contains json tile content, download icon appears in title bar (next to publish icon)
- clicking download icon downloads json tile content as local file named `tile-content.json`
- disabled in `authed` mode

This is primarily for @lbondaryk , who needs to embed authored geometry into the curriculum.