### PR TITLE
Generate new row and tile IDs on publish

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -346,7 +346,7 @@ export class DB {
 
   public publishDocument(documentModel: DocumentModelType) {
     const {user, groups} = this.stores;
-    const content = JSON.stringify(documentModel.content);
+    const content = documentModel.content.publish();
     return new Promise<{document: DBDocument, metadata: DBPublicationDocumentMetadata}>((resolve, reject) => {
       this.createDocument(PublicationDocument, content).then(({document, metadata}) => {
         const publicationRef = this.firebase.ref(this.firebase.getPublicationsPath(user)).push();
@@ -381,7 +381,7 @@ export class DB {
 
   public publishLearningLog(documentModel: DocumentModelType) {
     const {user} = this.stores;
-    const content = JSON.stringify(documentModel.content);
+    const content = documentModel.content.publish();
     return new Promise<{document: DBDocument, metadata: DBPublicationDocumentMetadata}>((resolve, reject) => {
       this.createDocument(LearningLogPublication, content).then(({document, metadata}) => {
         const publicationRef = this.firebase.ref(this.firebase.getClassPublicationsPath(user)).push();

--- a/src/models/document/tile-row.ts
+++ b/src/models/document/tile-row.ts
@@ -1,4 +1,4 @@
-import { types, Instance, SnapshotIn } from "mobx-state-tree";
+import { types, Instance, SnapshotIn, SnapshotOut } from "mobx-state-tree";
 import * as uuid from "uuid/v4";
 import { ToolTileModelType } from "../tools/tool-tile";
 
@@ -87,3 +87,4 @@ export const TileRowModel = types
 
 export type TileRowModelType = Instance<typeof TileRowModel>;
 export type TileRowSnapshotType = SnapshotIn<typeof TileRowModel>;
+export type TileRowSnapshotOutType = SnapshotOut<typeof TileRowModel>;

--- a/src/models/tools/tool-tile.ts
+++ b/src/models/tools/tool-tile.ts
@@ -1,4 +1,4 @@
-import { types, Instance } from "mobx-state-tree";
+import { types, Instance, SnapshotOut } from "mobx-state-tree";
 import { ToolContentUnion, findMetadata } from "./tool-types";
 import * as uuid from "uuid/v4";
 
@@ -37,3 +37,4 @@ export const ToolTileModel = types
   }));
 
 export type ToolTileModelType = Instance<typeof ToolTileModel>;
+export type ToolTileSnapshotOutType = SnapshotOut<typeof ToolTileModel>;


### PR DESCRIPTION
Published documents should not share row/tile IDs with their source documents.