### PR TITLE
Use a unique class/offering for Cypress tests

### DIFF
--- a/cypress/integration/workspace.test.ts
+++ b/cypress/integration/workspace.test.ts
@@ -1,6 +1,6 @@
 context("Test the overall workspace", () => {
   before(() => {
-      cy.visit("/?appMode=qa&fakeClass=5&fakeUser=student:1&fakeOffering=1&qaGroup=1&problem=1.1");
+      cy.visit("/?appMode=qa&fakeClass=2783&fakeUser=student:1&fakeOffering=43&qaGroup=1&problem=1.1");
   });
 
   describe("Desktop functionalities", () => {
@@ -24,7 +24,6 @@ context("Test the overall workspace", () => {
 
       it("will verify that left nav area is closes when other tabs are opened", () => {
           // should this be tab closes when no longer in that area? my work and left nav
-          cy.visit("/?appMode=qa&fakeClass=5&fakeUser=student:1&fakeOffering=1&qaGroup=1&problem=1.1");
           cy.get(".left-nav > .tabs > .tab:first").click(); // left nav expand area should be visible
           cy.get(".left-nav.expanded").should("be.visible");
           cy.get(".right-nav>.tabs.expanded").should("not.be.visible");


### PR DESCRIPTION
This should remove the collisions we saw with manual groups today...not a good long-term solution but I think it will help.