### PR TITLE
Sketch background image

### DIFF
--- a/src/components/canvas-tools/drawing-tool/drawing-tool.tsx
+++ b/src/components/canvas-tools/drawing-tool/drawing-tool.tsx
@@ -11,6 +11,7 @@ interface IProps {
   model: ToolTileModelType;
   readOnly: boolean;
   scale?: number;
+  onSetCanAcceptDrop: (tileId?: string) => void;
 }
 
 interface IState {
@@ -33,7 +34,7 @@ export default class DrawingToolComponent extends BaseComponent<IProps, IState> 
         <ToolbarView model={model} readOnly={!!readOnly}/>
         <div style={{left: TOOLBAR_WIDTH}}
             onMouseDown={this.handleMouseDown}>
-          <DrawingLayerView model={model} readOnly={!!readOnly} scale={scale} />
+          <DrawingLayerView {...this.props} />
         </div>
       </div>
     );

--- a/src/models/tools/drawing/drawing-objects.ts
+++ b/src/models/tools/drawing/drawing-objects.ts
@@ -57,5 +57,15 @@ export interface EllipseDrawingObjectData {
   fill: string;
 }
 
+export interface ImageDrawingObjectData {
+  type: "image";
+  id?: string;
+  url: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
 export type DrawingObjectDataType = LineDrawingObjectData | VectorDrawingObjectData
-  | RectangleDrawingObjectData | EllipseDrawingObjectData;
+  | RectangleDrawingObjectData | EllipseDrawingObjectData | ImageDrawingObjectData;


### PR DESCRIPTION
Drag/drop from image tool (same as geometry)
Background image appears behind all other objects
Subsequent drops replace earlier images (only one image at a time)

Note: this is an initial implementation using the current (firebase storage) image storage implementation. It will need to be reworked a bit (along with the geometry tool) to support the upcoming image storage rearchitecture.