### PR TITLE
Fix draw tool crash switching to four-up view with non-default tool selected

### DIFF
--- a/src/models/tools/drawing/drawing-content.test.ts
+++ b/src/models/tools/drawing/drawing-content.test.ts
@@ -2,15 +2,22 @@ import { DrawingContentModel, kDrawingToolID, DrawingToolMetadataModel } from ".
 
 describe("DrawingContentModel", () => {
 
-  it("accepts default arguments on creation", () => {
+  function createDrawingContent() {
     const model = DrawingContentModel.create();
+    const metadata = DrawingToolMetadataModel.create({ id: "drawing-1" });
+    model.doPostCreate(metadata);
+    return model;
+  }
+
+  it("accepts default arguments on creation", () => {
+    const model = createDrawingContent();
     expect(model.type).toBe(kDrawingToolID);
     expect(model.changes).toEqual([]);
     expect(model.selectedButton).toBe("select");
   });
 
   it("can reset the tool button", () => {
-    const model = DrawingContentModel.create();
+    const model = createDrawingContent();
     model.setSelectedButton("vector");
     expect(model.selectedButton).toBe("vector");
     model.reset();
@@ -18,9 +25,7 @@ describe("DrawingContentModel", () => {
   });
 
   it("can delete a set of selected drawing objects", () => {
-    const model = DrawingContentModel.create();
-    const metadata = DrawingToolMetadataModel.create({ id: "drawing-1" });
-    model.doPostCreate(metadata);
+    const model = createDrawingContent();
 
     model.setSelection(["a", "b"]);
     model.deleteSelectedObjects();
@@ -32,9 +37,7 @@ describe("DrawingContentModel", () => {
   });
 
   it("can update the properties of a set of selected drawing objects", () => {
-    const model = DrawingContentModel.create();
-    const metadata = DrawingToolMetadataModel.create({ id: "drawing-1" });
-    model.doPostCreate(metadata);
+    const model = createDrawingContent();
 
     model.setSelection(["a", "b"]);
     model.setStroke("#000000");

--- a/src/models/tools/drawing/drawing-content.ts
+++ b/src/models/tools/drawing/drawing-content.ts
@@ -80,9 +80,13 @@ export interface DrawingToolChange {
 export const DrawingToolMetadataModel = types
   .model("DrawingToolMetadata", {
     id: types.string,
+    selectedButton: "select",
     selection: types.array(types.string)
   })
   .actions(self => ({
+    setSelectedButton(button: ToolbarModalButton) {
+      self.selectedButton = button;
+    },
     setSelection(selection: string[]) {
       self.selection.replace(selection);
     }
@@ -100,7 +104,6 @@ export const DrawingContentModel = types
   .model("DrawingTool", {
     type: types.optional(types.literal(kDrawingToolID), kDrawingToolID),
     changes: types.array(types.string),
-    selectedButton: "select",
     stroke: DefaultToolbarSettings.stroke,
     fill: DefaultToolbarSettings.fill,
     strokeDashArray: DefaultToolbarSettings.strokeDashArray,
@@ -147,6 +150,9 @@ export const DrawingContentModel = types
         get isUserResizable() {
           return true;
         },
+        get selectedButton() {
+          return self.metadata.selectedButton;
+        },
         get hasSelectedObjects() {
           return self.metadata.selection.length > 0;
         }
@@ -174,7 +180,7 @@ export const DrawingContentModel = types
         },
 
         setSelectedButton(button: ToolbarModalButton) {
-          self.selectedButton = button;
+          self.metadata.setSelectedButton(button);
         },
 
         setSelection(ids: string[]) {
@@ -186,7 +192,7 @@ export const DrawingContentModel = types
 
         // sets the model to how we want it to appear when a user first opens a document
         reset() {
-          self.selectedButton = "select";
+          self.metadata.setSelectedButton("select");
         }
       }
     };


### PR DESCRIPTION
This is another variant of the bug fixed in #145. The fix here is to follow the suggestion made in that PR by moving the `selectedButton` out of the content model and into the metadata model.