### PR TITLE
Fix selection/deselection in four-up view [#162287919]

### DIFF
--- a/src/components/canvas-tools/geometry-tool.tsx
+++ b/src/components/canvas-tools/geometry-tool.tsx
@@ -4,7 +4,7 @@ import { BaseComponent } from "../base";
 import { ToolTileModelType } from "../../models/tools/tool-tile";
 import { GeometryContentModelType, kGeometryDefaultPixelsPerUnit, setElementColor
         } from "../../models/tools/geometry/geometry-content";
-import { getEventCoords, copyCoords } from "./geometry-tool/geometry-utils";
+import { copyCoords, getEventCoords, getAllObjectsUnderMouse } from "./geometry-tool/geometry-utils";
 import { RotatePolygonIcon } from "./geometry-tool/rotate-polygon-icon";
 import { isPoint, isFreePoint, isVisiblePoint } from "../../models/tools/geometry/jxg-point";
 import { isPolygon } from "../../models/tools/geometry/jxg-polygon";
@@ -636,8 +636,7 @@ class GeometryToolComponentImpl extends BaseComponent<IProps, IState> {
         return;
       }
 
-      const index = evt[JXG.touchProperty] ? 0 : undefined;
-      const coords = getEventCoords(board, evt, scale, index);
+      const coords = getEventCoords(board, evt, scale);
       const x = coords.usrCoords[1];
       const y = coords.usrCoords[2];
       if ((x != null) && isFinite(x) && (y != null) || isFinite(y)) {
@@ -650,8 +649,7 @@ class GeometryToolComponentImpl extends BaseComponent<IProps, IState> {
       if (!this.lastBoardDown) { return; }
 
       // cf. https://jsxgraph.uni-bayreuth.de/wiki/index.php/Browser_event_and_coordinates
-      const index = evt[JXG.touchProperty] ? 0 : undefined;
-      const coords = getEventCoords(board, evt, scale, index);
+      const coords = getEventCoords(board, evt, scale);
       const [ , x, y] = this.lastBoardDown.coords.usrCoords;
       if ((x == null) || !isFinite(x) || (y == null) || !isFinite(y)) {
         return;
@@ -659,7 +657,7 @@ class GeometryToolComponentImpl extends BaseComponent<IProps, IState> {
 
       // clicks on background (or images) of board clear the selection
       const geometryContent = this.props.model.content as GeometryContentModelType;
-      const elements = board.getAllObjectsUnderMouse(evt)
+      const elements = getAllObjectsUnderMouse(board, evt, scale)
                             .filter(obj => obj && (obj.elType !== "image"));
       if (!elements.length && !hasSelectionModifier(evt) && geometryContent.hasSelection()) {
         geometryContent.deselectAll(board);
@@ -806,8 +804,7 @@ class GeometryToolComponentImpl extends BaseComponent<IProps, IState> {
       const { scale } = this.props;
       const { board } = this.state;
       if (!board) return false;
-      const index = evt[JXG.touchProperty] ? 0 : undefined;
-      const coords = getEventCoords(board, evt, scale, index);
+      const coords = getEventCoords(board, evt, scale);
       let inVertex = false;
       each(polygon.ancestors, point => {
         const pt = point as JXG.Point;

--- a/src/components/canvas-tools/geometry-tool/geometry-utils.ts
+++ b/src/components/canvas-tools/geometry-tool/geometry-utils.ts
@@ -1,15 +1,27 @@
+export function copyCoords(coords: JXG.Coords) {
+  return new JXG.Coords(JXG.COORDS_BY_USER, coords.usrCoords.slice(1), coords.board);
+}
+
 // cf. https://jsxgraph.uni-bayreuth.de/wiki/index.php/Browser_event_and_coordinates
 export function getEventCoords(board: JXG.Board, evt: any, scale?: number, index?: number) {
+  const _index = index != null
+                  ? index
+                  : (evt[JXG.touchProperty] ? 0 : undefined);
   const cPos = board.getCoordsTopLeftCorner();
-  const absPos = JXG.getPosition(evt, index);
+  const absPos = JXG.getPosition(evt, _index);
   const dx = (absPos[0] - cPos[0]) / (scale || 1);
   const dy = (absPos[1] - cPos[1]) / (scale || 1);
 
   return new JXG.Coords(JXG.COORDS_BY_SCREEN, [dx, dy], board);
 }
 
-export function copyCoords(coords: JXG.Coords) {
-  return new JXG.Coords(JXG.COORDS_BY_USER, coords.usrCoords.slice(1), coords.board);
+// Replacement for Board.getAllObjectsUnderMouse() which doesn't handle scaled coordinates
+export function getAllObjectsUnderMouse(board: JXG.Board, evt: any, scale?: number) {
+  const coords = getEventCoords(board, evt, scale);
+  return board.objectsList.filter(obj => {
+    return obj.visPropCalc.visible && obj.hasPoint &&
+            obj.hasPoint(coords.scrCoords[1], coords.scrCoords[2]);
+  });
 }
 
 export function rotateCoords(coords: JXG.Coords, center: JXG.Coords, angle: number) {

--- a/src/models/tools/geometry/jsxgraph.d.ts
+++ b/src/models/tools/geometry/jsxgraph.d.ts
@@ -40,7 +40,8 @@ declare namespace JXG {
     removeObject: (object: GeometryElement) => JXG.Board;
     on: (event: string, handler: (evt: any) => void) => void;
     getCoordsTopLeftCorner: () => number[];
-    getAllObjectsUnderMouse: (evt: any) => GeometryElement[];
+    // use geometry-utils.getAllObjectsUnderMouse() instead
+    // getAllObjectsUnderMouse: (evt: any) => GeometryElement[];
 
     resizeContainer: (canvasWidth: number, canvasHeight: number,
                       dontSet?: boolean, dontSetBoundingBox?: boolean) => JXG.Board;
@@ -74,6 +75,7 @@ declare namespace JXG {
     parents: GeometryElement[];
     childElements: { [id: string]: GeometryElement };
     visProp: { [prop: string]: any };
+    visPropCalc: { [prop: string]: any };
     fixed: boolean;
 
     removeChild: (child: GeometryElement) => JXG.Board;


### PR DESCRIPTION
Fix selection/deselection in four-up view [#162287919]
- as usual, need to scale coordinates

The bug is actually in a JSXGraph function (Board.getAllObjectsUnderMouse()) which doesn't take scaling into account. The fix is to replace it with our own version that does.