### PR TITLE
Fix bugs which prevented dragged points from saving/restoring properly

### DIFF
--- a/src/components/canvas-tools/geometry-tool.tsx
+++ b/src/components/canvas-tools/geometry-tool.tsx
@@ -2,10 +2,10 @@ import * as React from "react";
 import { inject, observer } from "mobx-react";
 import { BaseComponent } from "../base";
 import { ToolTileModelType } from "../../models/tools/tool-tile";
-import { GeometryContentModelType, kGeometryDefaultPixelsPerUnit, setElementColor
-        } from "../../models/tools/geometry/geometry-content";
+import { GeometryContentModelType, setElementColor } from "../../models/tools/geometry/geometry-content";
 import { copyCoords, getEventCoords, getAllObjectsUnderMouse } from "./geometry-tool/geometry-utils";
 import { RotatePolygonIcon } from "./geometry-tool/rotate-polygon-icon";
+import { kGeometryDefaultPixelsPerUnit } from "../../models/tools/geometry/jxg-board";
 import { isPoint, isFreePoint, isVisiblePoint } from "../../models/tools/geometry/jxg-point";
 import { isPolygon } from "../../models/tools/geometry/jxg-polygon";
 import { JXGCoordPair, JXGProperties } from "../../models/tools/geometry/jxg-changes";
@@ -600,7 +600,7 @@ class GeometryToolComponentImpl extends BaseComponent<IProps, IState> {
     this.dragSelectedPoints(evt, usrDiff);
 
     // only create a change object if there's actually a change
-    if ((usrDiff[0] !== 0) || (usrDiff[1] !== 0)) {
+    if (usrDiff[1] || usrDiff[2]) {
       const ids: string[] = [];
       const props: Array<{ position: number[] }> = [];
       each(this.dragPts, (entry, id) => {

--- a/src/models/tools/geometry/geometry-content.ts
+++ b/src/models/tools/geometry/geometry-content.ts
@@ -1,7 +1,7 @@
 import { types, Instance } from "mobx-state-tree";
 import { applyChange, applyChanges } from "./jxg-dispatcher";
 import { JXGChange, JXGProperties, JXGCoordPair } from "./jxg-changes";
-import { isBoard } from "./jxg-board";
+import { isBoard, kGeometryDefaultPixelsPerUnit, kGeometryDefaultAxisMin } from "./jxg-board";
 import { isFreePoint, kPointDefaults } from "./jxg-point";
 import { assign, each, keys, size as _size } from "lodash";
 import * as uuid from "uuid/v4";
@@ -9,9 +9,6 @@ import * as uuid from "uuid/v4";
 export const kGeometryToolID = "Geometry";
 
 export const kGeometryDefaultHeight = 320;
-// matches curriculum images
-export const kGeometryDefaultPixelsPerUnit = 18.3;
-export const kGeometryDefaultAxisMin = -1;
 
 export type onCreateCallback = (elt: JXG.GeometryElement) => void;
 


### PR DESCRIPTION
Fix bugs which prevented dragged points from saving/restoring properly [#162356359]
1. Incorrect coordinate reference resulted in Y-only drags not being saved
2. Make sure axis extents are set properly on board creation
    - If axis extents are off, JSXGraph's default snap-to-grid behavior restricts points to be visible, which prevents them from restoring correctly in some circumstances because they are incorrectly determined to be out-of-bounds.