### PR TITLE
Fix drag of overlapped polygons [#162456045]

### DIFF
--- a/src/components/canvas-tools/geometry-tool.tsx
+++ b/src/components/canvas-tools/geometry-tool.tsx
@@ -790,7 +790,7 @@ class GeometryToolComponentImpl extends BaseComponent<IProps, IState> {
         this.endDragSelectedPoints(evt, usrDiff);
       }
 
-      this.dragPts = {};
+      delete this.dragPts[id];
     };
 
     point.on("down", handlePointerDown);
@@ -893,8 +893,8 @@ class GeometryToolComponentImpl extends BaseComponent<IProps, IState> {
           this.endDragSelectedPoints(evt, usrDiff);
         }
       }
-
-      this.dragPts = {};
+      // remove this polygon's vertices from the dragPts map
+      polygon.vertices.forEach(vertex => delete this.dragPts[vertex.id]);
       this.isVertexDrag = false;
     };
 


### PR DESCRIPTION
The code assumed that only the dragged polygon would receive pointerDown/pointerUp messages. In fact, JSXGraph dispatches pointerDown/pointerUp messages to all objects at the given location. If the "wrong" polygon received the events first, it would clear the intermediate drag cache so that the changed location of the dragged polygon would not be saved. The short-term fix is to have each polygon only clear the portion of the drag cache that it is responsible for. In the long-term it might be better to not have other polygons responding at all. Dragging of overlapped polygons is most likely to occur after copy/paste operations which intentionally overlap polygons.