### PR TITLE
Fix another overlapping polygons drag bug

### DIFF
--- a/src/models/tools/geometry/jsxgraph.d.ts
+++ b/src/models/tools/geometry/jsxgraph.d.ts
@@ -74,6 +74,8 @@ declare namespace JXG {
     ancestors: { [id: string]: GeometryElement };
     parents: GeometryElement[];
     childElements: { [id: string]: GeometryElement };
+    isDraggable: boolean;
+    lastDragTime: Date;
     visProp: { [prop: string]: any };
     visPropCalc: { [prop: string]: any };
     fixed: boolean;


### PR DESCRIPTION
Fix bug reported by @sfentress  in which clicking on overlapping polygons could result in selecting one polygon but dragging another.

The fix is to synchronize our notion of draggable/selectable polygon with JSXGraph's.

Note: @sfentress found this while testing one of the previous bug-fixes. I don't believe it's implicated in the recent classroom issue, so it may make sense to hold off on this one until the others are released to production.