### PR TITLE
Support multiple unit files with url parameter to select desired unit [#162777044]

### DIFF
--- a/src/curriculum/moving-straight-ahead/moving-straight-ahead.json
+++ b/src/curriculum/moving-straight-ahead/moving-straight-ahead.json
@@ -1,0 +1,610 @@
+{
+  "title": "Moving Straight Ahead",
+  "subtitle": "Linear Expressions, Equations, and Relationships",
+  "lookingAhead": {
+    "tiles": []
+  },
+  "investigations": [
+    {
+      "description": "Investigation 1",
+      "ordinal": 1,
+      "title": "Investigation 1",
+      "introduction": {
+        "tiles": []
+      },
+      "problems": [
+        {
+          "description": "Problem 1.1",
+          "ordinal": 1,
+          "title": "Problem 1.1",
+          "subtitle": "",
+          "sections": [
+            {
+              "type": "introduction",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "initialChallenge",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "whatIf",
+              "content": {
+                "tiles": [],
+                "supports": []
+              }
+            },
+            {
+              "type": "nowWhatDoYouKnow",
+              "content": {
+                "tiles": [],
+                "supports": []
+              }
+            },
+            {
+              "type": "extraWorkspace",
+              "content": {
+                "tiles": [],
+                "supports": []
+              }
+            }
+          ],
+          "supports": []
+        },
+        {
+          "description": "Problem 1.2",
+          "ordinal": 2,
+          "title": "Problem 1.2",
+          "subtitle": "",
+          "sections": [
+            {
+              "type": "introduction",
+              "content": {
+                "tiles": [],
+                "supports": []
+              }
+            },
+            {
+              "type": "initialChallenge",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "whatIf",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "nowWhatDoYouKnow",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "extraWorkspace",
+              "content": {
+                "tiles": [
+                  {
+                    "content": {
+                      "type": "Text",
+                      "text": ""
+                    }
+                  }
+                ],
+                "supports": []
+              }
+            }
+          ],
+          "supports": []
+        },
+        {
+          "description": "Problem 1.3",
+          "ordinal": 3,
+          "title": "Problem 1.3",
+          "subtitle": "",
+          "sections": [
+            {
+              "type": "introduction",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "initialChallenge",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "whatIf",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "nowWhatDoYouKnow",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "extraWorkspace",
+              "content": {
+                "tiles": [],
+                "supports": []
+              }
+            }
+          ]
+        },
+        {
+          "description": "Reflection 1.4",
+          "ordinal": 4,
+          "title": "Reflection 1.4",
+          "subtitle": "",
+          "sections": [
+            {
+              "type": "nowWhatDoYouKnow",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            }
+          ]
+        }
+      ],
+      "supports": []
+    },
+    {
+      "description": "Investigation 2",
+      "ordinal": 2,
+      "title": "Investigation 2",
+      "introduction": {
+      },
+      "problems": [
+        {
+          "description": "Problem 2.1",
+          "ordinal": 1,
+          "title": "Problem 2.1",
+          "subtitle": "",
+          "sections": [
+            {
+              "type": "introduction",
+              "content": {
+                  "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "initialChallenge",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "whatIf",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "nowWhatDoYouKnow",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "extraWorkspace",
+              "content": {
+                "tiles": [],
+                "supports": []
+              }
+            }
+          ],
+          "supports": []
+        },
+        {
+          "description": "Problem 2.2",
+          "ordinal": 2,
+          "title": "Problem 2.2",
+          "subtitle": "",
+          "sections": [
+            {
+              "type": "introduction",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "initialChallenge",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "whatIf",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "nowWhatDoYouKnow",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "extraWorkspace",
+              "content": {
+                "tiles": [],
+                "supports": []
+              }
+            }
+          ],
+          "supports": []
+        },
+        {
+          "description": "Problem 2.3",
+          "ordinal": 3,
+          "title": "Problem 2.3",
+          "subtitle": "",
+          "sections": [
+            {
+              "type": "introduction",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "initialChallenge",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "whatIf",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "nowWhatDoYouKnow",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "extraWorkspace",
+              "content": {
+                "tiles": [],
+                "supports": []
+              }
+            }
+          ],
+          "supports": []
+        },
+        {
+          "description": "Reflection 2.4",
+          "ordinal": 4,
+          "title": "Reflection 2.4",
+          "subtitle": "",
+          "sections": [
+            {
+              "type": "nowWhatDoYouKnow",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            }
+          ]
+        }
+      ],
+      "supports": []
+    },
+    {
+      "description": "Investigation 3",
+      "ordinal": 3,
+      "title": "Investigation 3",
+      "problems": [
+        {
+          "description": "Problem 3.1",
+          "ordinal": 1,
+          "title": "Problem 3.1",
+          "subtitle": "",
+          "sections": [
+             {
+              "type": "introduction",
+              "content": {
+                 "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "initialChallenge",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "whatIf",
+              "content": {
+                "tiles": [],
+                "supports": []
+              }
+            },
+            {
+              "type": "nowWhatDoYouKnow",
+              "content": {
+                "tiles": [],
+                "supports": []
+              }
+            },
+            {
+              "type": "extraWorkspace",
+              "content": {
+                "tiles": [],
+                "supports": []
+              }
+            }
+          ],
+          "supports": []
+        },
+        {
+          "description": "Problem 3.2",
+          "ordinal": 2,
+          "title": "Problem 3.2",
+          "subtitle": "",
+          "sections": [
+            {
+              "type": "introduction",
+              "content": {
+                "tiles": [],
+                "supports": []
+              }
+            },
+            {
+              "type": "initialChallenge",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "whatIf",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "nowWhatDoYouKnow",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "extraWorkspace",
+              "content": {
+                "tiles": [],
+                "supports": []
+              }
+            }
+          ],
+          "supports": []
+        },
+        {
+          "description": "Problem 3.3",
+          "ordinal": 3,
+          "title": "Problem 3.3",
+          "subtitle": "",
+          "sections": [
+            {
+              "type": "introduction",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "initialChallenge",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "whatIf",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "nowWhatDoYouKnow",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "extraWorkspace",
+              "content": {
+                "tiles": [],
+                "supports": []
+              }
+            }
+          ]
+        },
+        {
+          "description": "Reflection 3.4",
+          "ordinal": 4,
+          "title": "Reflection 3.4",
+          "subtitle": "",
+          "sections": [
+            {
+              "type": "nowWhatDoYouKnow",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            }
+          ]
+        }
+      ],
+      "supports": []
+    },
+     {
+      "description": "Investigation 4",
+      "ordinal": 4,
+      "title": "Investigation 4",
+      "problems": [
+        {
+          "description": "Problem 4.1",
+          "ordinal": 1,
+          "title": "Problem 4.1",
+          "subtitle": "",
+          "sections": [
+            {
+              "type": "introduction",
+              "content": {
+                "tiles": []
+              }
+            }, {
+              "type": "initialChallenge",
+              "content": {
+                "tiles": []
+              },
+              "supports" : []
+            }, {
+              "type": "whatIf",
+              "content": {
+                "tiles": []
+              }
+            }, {
+              "type": "extraWorkspace",
+              "content": {
+                "tiles": [],
+                "supports": []
+              }
+            }
+          ]
+        }, {
+          "description": "Problem 4.2",
+          "ordinal": 2,
+          "title": "Problem 4.2",
+          "subtitle": "",
+          "sections": [
+            {
+              "type": "introduction",
+              "content": {
+                "tiles": []
+              }
+            }, {
+              "type": "initialChallenge",
+              "content": {
+                "tiles": []
+              },
+              "supports" : []
+            }, {
+              "type": "whatIf",
+              "content": {
+                "tiles": []
+              }
+            }, {
+              "type": "nowWhatDoYouKnow",
+              "content": {
+                "tiles": []
+              }
+            }, {
+              "type": "extraWorkspace",
+              "content": {
+                "tiles": [],
+                "supports": []
+              }
+            }
+          ],
+          "supports": []
+        }, {
+          "description": "Problem 4.3",
+          "ordinal": 3,
+          "title": "Problem 4.3",
+          "subtitle": "",
+          "sections": [
+            {
+              "type": "introduction",
+              "content": {
+                "tiles": []
+              }
+            }, {
+              "type": "initialChallenge",
+              "content": {
+                "tiles": []
+              },
+              "supports" : []
+            }, {
+              "type": "whatIf",
+              "content": {
+                "tiles": []
+              }
+            }, {
+              "type": "nowWhatDoYouKnow",
+              "content": {
+                "tiles": []
+              }
+            }, {
+              "type": "extraWorkspace",
+              "content": {
+                "tiles": [],
+                "supports": []
+              }
+            }
+          ]
+        }, {
+          "description": "Reflection 4.4",
+          "ordinal": 4,
+          "title": "Reflection 4.4",
+          "subtitle": "",
+          "sections": [
+            {
+              "type": "nowWhatDoYouKnow",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            }
+          ]
+        }
+      ],
+      "supports": [
+      ]
+    }
+  ],
+  "supports": []
+}

--- a/src/curriculum/unit-template.json
+++ b/src/curriculum/unit-template.json
@@ -1,0 +1,610 @@
+{
+  "title": "Moving Straight Ahead",
+  "subtitle": "Linear Expressions, Equations, and Relationships",
+  "lookingAhead": {
+    "tiles": []
+  },
+  "investigations": [
+    {
+      "description": "Investigation 1",
+      "ordinal": 1,
+      "title": "Investigation 1",
+      "introduction": {
+        "tiles": []
+      },
+      "problems": [
+        {
+          "description": "Problem 1.1",
+          "ordinal": 1,
+          "title": "Problem 1.1",
+          "subtitle": "",
+          "sections": [
+            {
+              "type": "introduction",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "initialChallenge",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "whatIf",
+              "content": {
+                "tiles": [],
+                "supports": []
+              }
+            },
+            {
+              "type": "nowWhatDoYouKnow",
+              "content": {
+                "tiles": [],
+                "supports": []
+              }
+            },
+            {
+              "type": "extraWorkspace",
+              "content": {
+                "tiles": [],
+                "supports": []
+              }
+            }
+          ],
+          "supports": []
+        },
+        {
+          "description": "Problem 1.2",
+          "ordinal": 2,
+          "title": "Problem 1.2",
+          "subtitle": "",
+          "sections": [
+            {
+              "type": "introduction",
+              "content": {
+                "tiles": [],
+                "supports": []
+              }
+            },
+            {
+              "type": "initialChallenge",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "whatIf",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "nowWhatDoYouKnow",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "extraWorkspace",
+              "content": {
+                "tiles": [
+                  {
+                    "content": {
+                      "type": "Text",
+                      "text": ""
+                    }
+                  }
+                ],
+                "supports": []
+              }
+            }
+          ],
+          "supports": []
+        },
+        {
+          "description": "Problem 1.3",
+          "ordinal": 3,
+          "title": "Problem 1.3",
+          "subtitle": "",
+          "sections": [
+            {
+              "type": "introduction",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "initialChallenge",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "whatIf",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "nowWhatDoYouKnow",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "extraWorkspace",
+              "content": {
+                "tiles": [],
+                "supports": []
+              }
+            }
+          ]
+        },
+        {
+          "description": "Reflection 1.4",
+          "ordinal": 4,
+          "title": "Reflection 1.4",
+          "subtitle": "",
+          "sections": [
+            {
+              "type": "nowWhatDoYouKnow",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            }
+          ]
+        }
+      ],
+      "supports": []
+    },
+    {
+      "description": "Investigation 2",
+      "ordinal": 2,
+      "title": "Investigation 2",
+      "introduction": {
+      },
+      "problems": [
+        {
+          "description": "Problem 2.1",
+          "ordinal": 1,
+          "title": "Problem 2.1",
+          "subtitle": "",
+          "sections": [
+            {
+              "type": "introduction",
+              "content": {
+                  "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "initialChallenge",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "whatIf",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "nowWhatDoYouKnow",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "extraWorkspace",
+              "content": {
+                "tiles": [],
+                "supports": []
+              }
+            }
+          ],
+          "supports": []
+        },
+        {
+          "description": "Problem 2.2",
+          "ordinal": 2,
+          "title": "Problem 2.2",
+          "subtitle": "",
+          "sections": [
+            {
+              "type": "introduction",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "initialChallenge",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "whatIf",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "nowWhatDoYouKnow",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "extraWorkspace",
+              "content": {
+                "tiles": [],
+                "supports": []
+              }
+            }
+          ],
+          "supports": []
+        },
+        {
+          "description": "Problem 2.3",
+          "ordinal": 3,
+          "title": "Problem 2.3",
+          "subtitle": "",
+          "sections": [
+            {
+              "type": "introduction",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "initialChallenge",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "whatIf",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "nowWhatDoYouKnow",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "extraWorkspace",
+              "content": {
+                "tiles": [],
+                "supports": []
+              }
+            }
+          ],
+          "supports": []
+        },
+        {
+          "description": "Reflection 2.4",
+          "ordinal": 4,
+          "title": "Reflection 2.4",
+          "subtitle": "",
+          "sections": [
+            {
+              "type": "nowWhatDoYouKnow",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            }
+          ]
+        }
+      ],
+      "supports": []
+    },
+    {
+      "description": "Investigation 3",
+      "ordinal": 3,
+      "title": "Investigation 3",
+      "problems": [
+        {
+          "description": "Problem 3.1",
+          "ordinal": 1,
+          "title": "Problem 3.1",
+          "subtitle": "",
+          "sections": [
+             {
+              "type": "introduction",
+              "content": {
+                 "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "initialChallenge",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "whatIf",
+              "content": {
+                "tiles": [],
+                "supports": []
+              }
+            },
+            {
+              "type": "nowWhatDoYouKnow",
+              "content": {
+                "tiles": [],
+                "supports": []
+              }
+            },
+            {
+              "type": "extraWorkspace",
+              "content": {
+                "tiles": [],
+                "supports": []
+              }
+            }
+          ],
+          "supports": []
+        },
+        {
+          "description": "Problem 3.2",
+          "ordinal": 2,
+          "title": "Problem 3.2",
+          "subtitle": "",
+          "sections": [
+            {
+              "type": "introduction",
+              "content": {
+                "tiles": [],
+                "supports": []
+              }
+            },
+            {
+              "type": "initialChallenge",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "whatIf",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "nowWhatDoYouKnow",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "extraWorkspace",
+              "content": {
+                "tiles": [],
+                "supports": []
+              }
+            }
+          ],
+          "supports": []
+        },
+        {
+          "description": "Problem 3.3",
+          "ordinal": 3,
+          "title": "Problem 3.3",
+          "subtitle": "",
+          "sections": [
+            {
+              "type": "introduction",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "initialChallenge",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "whatIf",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "nowWhatDoYouKnow",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            },
+            {
+              "type": "extraWorkspace",
+              "content": {
+                "tiles": [],
+                "supports": []
+              }
+            }
+          ]
+        },
+        {
+          "description": "Reflection 3.4",
+          "ordinal": 4,
+          "title": "Reflection 3.4",
+          "subtitle": "",
+          "sections": [
+            {
+              "type": "nowWhatDoYouKnow",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            }
+          ]
+        }
+      ],
+      "supports": []
+    },
+     {
+      "description": "Investigation 4",
+      "ordinal": 4,
+      "title": "Investigation 4",
+      "problems": [
+        {
+          "description": "Problem 4.1",
+          "ordinal": 1,
+          "title": "Problem 4.1",
+          "subtitle": "",
+          "sections": [
+            {
+              "type": "introduction",
+              "content": {
+                "tiles": []
+              }
+            }, {
+              "type": "initialChallenge",
+              "content": {
+                "tiles": []
+              },
+              "supports" : []
+            }, {
+              "type": "whatIf",
+              "content": {
+                "tiles": []
+              }
+            }, {
+              "type": "extraWorkspace",
+              "content": {
+                "tiles": [],
+                "supports": []
+              }
+            }
+          ]
+        }, {
+          "description": "Problem 4.2",
+          "ordinal": 2,
+          "title": "Problem 4.2",
+          "subtitle": "",
+          "sections": [
+            {
+              "type": "introduction",
+              "content": {
+                "tiles": []
+              }
+            }, {
+              "type": "initialChallenge",
+              "content": {
+                "tiles": []
+              },
+              "supports" : []
+            }, {
+              "type": "whatIf",
+              "content": {
+                "tiles": []
+              }
+            }, {
+              "type": "nowWhatDoYouKnow",
+              "content": {
+                "tiles": []
+              }
+            }, {
+              "type": "extraWorkspace",
+              "content": {
+                "tiles": [],
+                "supports": []
+              }
+            }
+          ],
+          "supports": []
+        }, {
+          "description": "Problem 4.3",
+          "ordinal": 3,
+          "title": "Problem 4.3",
+          "subtitle": "",
+          "sections": [
+            {
+              "type": "introduction",
+              "content": {
+                "tiles": []
+              }
+            }, {
+              "type": "initialChallenge",
+              "content": {
+                "tiles": []
+              },
+              "supports" : []
+            }, {
+              "type": "whatIf",
+              "content": {
+                "tiles": []
+              }
+            }, {
+              "type": "nowWhatDoYouKnow",
+              "content": {
+                "tiles": []
+              }
+            }, {
+              "type": "extraWorkspace",
+              "content": {
+                "tiles": [],
+                "supports": []
+              }
+            }
+          ]
+        }, {
+          "description": "Reflection 4.4",
+          "ordinal": 4,
+          "title": "Reflection 4.4",
+          "subtitle": "",
+          "sections": [
+            {
+              "type": "nowWhatDoYouKnow",
+              "content": {
+                "tiles": []
+              },
+              "supports": []
+            }
+          ]
+        }
+      ],
+      "supports": [
+      ]
+    }
+  ],
+  "supports": []
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,7 +6,8 @@ import { AppComponent } from "./components/app";
 import { createStores } from "./models/stores/stores";
 import { UserModel } from "./models/stores/user";
 import { createFromJson } from "./models/curriculum/unit";
-import * as curriculumJson from "./curriculum/stretching-and-shrinking/stretching-and-shrinking.json";
+import * as movingStraightAheadUnit from "./curriculum/moving-straight-ahead/moving-straight-ahead.json";
+import * as stretchingAndShrinkingUnit from "./curriculum/stretching-and-shrinking/stretching-and-shrinking.json";
 import { urlParams, DefaultProblemOrdinal } from "./utilities/url-params";
 import { getAppMode } from "./lib/auth";
 import { Logger } from "./lib/logger";
@@ -14,12 +15,23 @@ import { setTitle } from "./lib/misc";
 
 import "./index.sass";
 
+function getCurriculumJson() {
+  const unitParam = (urlParams.unit || "").toLowerCase();
+  switch (unitParam) {
+    case "msa":
+      return movingStraightAheadUnit;
+    case "s&s":
+    default:
+      return stretchingAndShrinkingUnit;
+  }
+}
+
 const host = window.location.host.split(":")[0];
 const appMode = getAppMode(urlParams.appMode, urlParams.token, host);
 
 const user = UserModel.create();
 
-const unit = createFromJson(curriculumJson);
+const unit = createFromJson(getCurriculumJson());
 const problemOrdinal = urlParams.problem || DefaultProblemOrdinal;
 const {investigation, problem} = unit.getProblem(problemOrdinal) ||
                                  unit.getProblem(DefaultProblemOrdinal);

--- a/src/utilities/url-params.ts
+++ b/src/utilities/url-params.ts
@@ -8,6 +8,8 @@ export const DefaultProblemOrdinal = "2.1";
 export interface QueryParams {
   // appMode is "authed", "test" or "dev" with the default of dev
   appMode?: AppMode;
+  // string, e.g. "s&s" for Stretching and Shrinking or "msa" for Moving Straight Ahead
+  unit?: string;
   // ordinal string, e.g. "2.1", "3.2", etc.
   problem?: string;
   // Used during migration testing to put the app into a "post-migration" mode.
@@ -62,6 +64,7 @@ const params = parse(location.search);
 
 export const DefaultUrlParams: QueryParams = {
   appMode: "dev",
+  unit: undefined,
   problem: undefined,
   token: undefined,
   domain: undefined,


### PR DESCRIPTION
Support multiple unit files with url parameter to select desired unit [#162777044]
- add template for `moving-straight-ahead.json`

Add URL parameter `unit=msa` to specify Moving Straight Ahead, `unit=s&s` or no unit parameter at all for Stretching and Shrinking.