### PR TITLE
Fix updateText() rollbar error

### DIFF
--- a/src/components/tools/geometry-tool/geometry-tool.tsx
+++ b/src/components/tools/geometry-tool/geometry-tool.tsx
@@ -250,8 +250,12 @@ class GeometryToolComponentImpl extends BaseComponent<IProps, IState> {
     if (this.disposeSelectionObserver) {
       this.disposeSelectionObserver();
     }
-    if (this.state.board) {
-      JXG.JSXGraph.freeBoard(this.state.board);
+    const board = this.state.board;
+    if (board) {
+      // delay so any asynchronous JSXGraph actions have time to complete
+      setTimeout(() => {
+        JXG.JSXGraph.freeBoard(board);
+      }, 100);
     }
 
     this._isMounted = false;

--- a/src/models/tools/geometry/geometry-content.test.ts
+++ b/src/models/tools/geometry/geometry-content.test.ts
@@ -57,7 +57,6 @@ describe("GeometryContent", () => {
     });
     expect(content.nextViewId).toBe(1);
     expect(isBoard(board)).toBe(true);
-    expect(isUuid(board.id)).toBe(true);
 
     content.resizeBoard(board, 200, 200);
     content.updateScale(board, 0.5);

--- a/src/models/tools/geometry/geometry-content.ts
+++ b/src/models/tools/geometry/geometry-content.ts
@@ -21,7 +21,6 @@ export function defaultGeometryContent(overrides?: JXGProperties) {
     operation: "create",
     target: "board",
     properties: assign({
-                  id: uuid(),
                   axis: true,
                   boundingBox: [kGeometryDefaultAxisMin, yAxisMax, xAxisMax, kGeometryDefaultAxisMin],
                   grid: {}  // defaults to 1-unit gridlines

--- a/src/models/tools/geometry/jxg-board.ts
+++ b/src/models/tools/geometry/jxg-board.ts
@@ -1,7 +1,6 @@
 import { JXGChange, JXGChangeAgent } from "./jxg-changes";
 import "./jxg";
-import { assign, each, cloneDeep } from "lodash";
-import * as uuid from "uuid/v4";
+import { assign, each } from "lodash";
 
 // matches curriculum images
 export const kGeometryDefaultPixelsPerUnit = 18.3;
@@ -11,23 +10,22 @@ export const isBoard = (v: any) => v instanceof JXG.Board;
 function combineProperties(domElementID: string, defaults: any, changeProps: any, overrides: any) {
   const elt = document.getElementById(domElementID);
   const eltBounds = elt && elt.getBoundingClientRect();
-  const props = cloneDeep(changeProps);
+  const { id, ...otherProps } = changeProps;
   if (eltBounds) {
     // adjust boundingBox to actual size of dom element
     const { boundingBox, unitX, unitY } = changeProps;
     const [xMin, , , yMin] = boundingBox || [kGeometryDefaultAxisMin, , , kGeometryDefaultAxisMin];
     const xMax = xMin + eltBounds.width / (unitX || kGeometryDefaultPixelsPerUnit);
     const yMax = yMin + eltBounds.height / (unitY || kGeometryDefaultPixelsPerUnit);
-    props.boundingBox = [xMin, yMax, xMax, yMin];
+    otherProps.boundingBox = [xMin, yMax, xMax, yMin];
   }
-  return assign(defaults, props, overrides);
+  return assign(defaults, otherProps, overrides);
 }
 
 export const boardChangeAgent: JXGChangeAgent = {
   create: (boardDomId: JXG.Board|string, change: JXGChange) => {
     const domElementID = boardDomId as string;
     const defaults = {
-            id: uuid(),
             keepaspectratio: true,
             showCopyright: false,
             showNavigation: false,


### PR DESCRIPTION
- delay before calling `freeBoard()` in `componentWillUnmount()`
- let JSXGraph generate unique board IDs

The error occurred because we call JSXGraph's `freeBoard()` function to dispose of the board in the `componentWillUnmount()` method of the `GeometryToolComponent`. The problem is that JSXGraph invokes some asynchronous functions via `setTimeout(..., 0)` which were completing after our call to `freeBoard()`. The solution here is to use `setTimeout(freeBoard(), 100)` to delay until after the asynchronous JSXGraph operations have completed.

The second issue, which was confirmed while debug the first, is that we were specifying UUIDs for each board in our content. However, since multiple React components can use a single content object, this resulted in the creation of duplicate board IDs, which is likely to confuse JSXGraph, as it maintains a map of active boards indexed by ID. The fix here is simply to let JSXGraph assign its own unique board IDs, as we don't have a need to reference boards by ID the way we do for objects like points and polygons.