### PR TITLE
Allow all right nav content to display when scrolling

### DIFF
--- a/src/components/navigation/right-nav.sass
+++ b/src/components/navigation/right-nav.sass
@@ -43,6 +43,7 @@ $list-item-scale: 0.11
   .expanded-area
     position: absolute
     top: $header-height + $nav-expanded-peek
+    bottom: 0
     right: $nav-expanded-peek - ($right-nav-expanded-width - $right-nav-contracted-width)
     width: $right-nav-expanded-width - $right-nav-contracted-width
     background: $color5
@@ -51,7 +52,6 @@ $list-item-scale: 0.11
     border-bottom: $border-width solid $border-color
     border-radius: $border-radius 0 0 $border-radius
     margin-left: $right-nav-contracted-width
-    height: 100%
     box-shadow: -$half-border-width $half-border-width 0 0 rgba(0,0,0,0.20)
     transition: right $animation-speed
 


### PR DESCRIPTION
Adjust CSS so right nav has proper height which allows all content to be displayed onscreen when scrollbars are present.  A more concise, less intrusive way to handle right nav scrolling.
[#163036885]