### PR TITLE
Group + User Supports by Section

### DIFF
--- a/cypress/integration/teacher_test_spec.js
+++ b/cypress/integration/teacher_test_spec.js
@@ -13,7 +13,7 @@ let qaClass = 10,
     studentArr20=[25,26,27,28],
     qaGroup20 = 20;
 
-
+let student = 15;
 let teacher = 10;
 
 let header = new Header,
@@ -162,8 +162,28 @@ context('Teacher workspace',function(){ //does not have My Work tab and has Teac
         });
     })
 
+    describe('Teacher can create supports', function(){
+      const supportText = "sample support";
+      it('will load the teacher page', function(){
+        cy.visit(baseUrl+'?appMode=qa&fakeClass='+qaClass+'&fakeUser=teacher:'+teacher+'&problem='+problem);
+        cy.wait(3000);
+      });
+      it('will create a support', function(){
+        cy.get('[data-test=support-input-class]').type(supportText);
+        cy.get('[data-test=support-submit-class]').click();
+        
+        cy.get('[data-test=teacher-support]').should('be.visible');
+      });
+      it('will load the student document', function(){
+        cy.visit(baseUrl+'?appMode=qa&fakeClass='+qaClass+'&fakeUser=student:'+student+'&problem='+problem+'&qaGroup='+qaGroup10);
+        cy.wait(3000);
 
+        leftNav.openToWorkspace('Introduction');
+        cy.wait(2000);
 
-
+        cy.get('[data-test=support-icon]').click();
+        cy.contains(supportText);
+      });
+    })
 });
 

--- a/src/components/document/document.tsx
+++ b/src/components/document/document.tsx
@@ -12,6 +12,7 @@ import { IToolApi, IToolApiInterface, IToolApiMap } from "../tools/tool-tile";
 import { WorkspaceModelType } from "../../models/stores/workspace";
 
 import "./document.sass";
+import { SectionType } from "../../models/curriculum/section";
 
 export type WorkspaceSide = "primary" | "comparison";
 
@@ -309,9 +310,10 @@ export class DocumentComponent extends BaseComponent<IProps, {}> {
   }
 
   private getSupportsWithIndices() {
-    return this.stores.supports.getAllForSection(this.props.document.sectionId!).map((support, index) => {
-      return {index, item: support};
-    });
+    return this.stores.supports.getAllForSection(this.props.document.sectionId! as SectionType)
+      .map((support, index) => {
+        return {index, item: support};
+      });
   }
 
   private isPrimary() {

--- a/src/components/document/document.tsx
+++ b/src/components/document/document.tsx
@@ -316,7 +316,8 @@ export class DocumentComponent extends BaseComponent<IProps, {}> {
     const groupId = group && group.id;
     return this.stores.supports.getSupportsForUserProblem(
       this.props.document.sectionId! as SectionType,
-      groupId
+      groupId,
+      userId
     )
     .map((support, index) => {
       return {index, item: support};

--- a/src/components/document/document.tsx
+++ b/src/components/document/document.tsx
@@ -10,9 +10,9 @@ import { DocumentModelType, SectionDocument } from "../../models/document/docume
 import { ToolbarComponent } from "../toolbar";
 import { IToolApi, IToolApiInterface, IToolApiMap } from "../tools/tool-tile";
 import { WorkspaceModelType } from "../../models/stores/workspace";
+import { SectionType } from "../../models/curriculum/section";
 
 import "./document.sass";
-import { SectionType } from "../../models/curriculum/section";
 
 export type WorkspaceSide = "primary" | "comparison";
 

--- a/src/components/document/document.tsx
+++ b/src/components/document/document.tsx
@@ -310,10 +310,17 @@ export class DocumentComponent extends BaseComponent<IProps, {}> {
   }
 
   private getSupportsWithIndices() {
-    return this.stores.supports.getAllForSection(this.props.document.sectionId! as SectionType)
-      .map((support, index) => {
-        return {index, item: support};
-      });
+    const { groups, user } = this.stores;
+    const userId = user.id;
+    const group = groups.groupForUser(userId);
+    const groupId = group && group.id;
+    return this.stores.supports.getSupportsForUserProblem(
+      this.props.document.sectionId! as SectionType,
+      groupId
+    )
+    .map((support, index) => {
+      return {index, item: support};
+    });
   }
 
   private isPrimary() {

--- a/src/components/document/document.tsx
+++ b/src/components/document/document.tsx
@@ -235,6 +235,7 @@ export class DocumentComponent extends BaseComponent<IProps, {}> {
               key={index}
               onClick={this.handleToggleSupport(item)}
               className={`icon ${this.getSupportName(index)} ${visibility}`}
+              data-test="support-icon"
             >
               <use xlinkHref={`#${this.getSupportName(index)}`} />
             </svg>

--- a/src/components/teacher/teacher-dashboard.sass
+++ b/src/components/teacher/teacher-dashboard.sass
@@ -11,6 +11,30 @@ $tab-height: 20px
     bottom: $double-margin
     color: #000
 
+    .dash-header
+      font-family: inherit
+      font-size: inherit
+      color: black
+      font-weight: bold
+
+      > div
+        margin-bottom: $teacher-margin
+
+      .header-contents
+        display: flex
+
+        div
+          text-align: center
+          margin-left: $teacher-margin
+
+        .date
+          margin-left: $date-margin
+          width: $date-width
+        
+        .section
+          width: $section-width
+
+
     .tabs
       display: flex
       flex-direction: row

--- a/src/components/teacher/teacher-dashboard.sass
+++ b/src/components/teacher/teacher-dashboard.sass
@@ -11,30 +11,6 @@ $tab-height: 20px
     bottom: $double-margin
     color: #000
 
-    .dash-header
-      font-family: inherit
-      font-size: inherit
-      color: black
-      font-weight: bold
-
-      > div
-        margin-bottom: $teacher-margin
-
-      .header-contents
-        display: flex
-
-        div
-          text-align: center
-          margin-left: $teacher-margin
-
-        .date
-          margin-left: $date-margin
-          width: $date-width
-        
-        .section
-          width: $section-width
-
-
     .tabs
       display: flex
       flex-direction: row

--- a/src/components/teacher/teacher-dashboard.tsx
+++ b/src/components/teacher/teacher-dashboard.tsx
@@ -9,6 +9,7 @@ import "./teacher-dashboard.sass";
 import { BottomNavComponent } from "../navigation/bottom-nav";
 import { RightNavComponent } from "../navigation/right-nav";
 import { TeacherSupports } from "./teacher-supports";
+import { ClassAudienceModel } from "../../models/stores/supports";
 
 interface IProps extends IBaseProps {}
 interface IState {
@@ -45,7 +46,9 @@ export class TeacherDashboardComponent extends BaseComponent<IProps, IState> {
         <HeaderComponent isGhostUser={true} />
         <div className="tabbed-area">
           <div className="tab-contents" aria-labelledby={this.getTabId(activeTab)}>
-            <TeacherSupports supports={supports.teacherSupports.filter(support => !support.deleted)}/>
+            <TeacherSupports
+              audience={ClassAudienceModel.create()}
+              supports={supports.classSupports.filter(support => !support.deleted)}/>
             {this.renderTabContents()}
           </div>
         </div>

--- a/src/components/teacher/teacher-dashboard.tsx
+++ b/src/components/teacher/teacher-dashboard.tsx
@@ -1,7 +1,5 @@
 import { inject, observer } from "mobx-react";
 import * as React from "react";
-import { TabComponent } from "../tab";
-import { TabSetComponent } from "../tab-set";
 import { BaseComponent, IBaseProps } from "../base";
 import { HeaderComponent } from "../header";
 import { TeacherGroupTabComponent } from "./teacher-group-tab";
@@ -10,7 +8,7 @@ import { TeacherStudentTabComponent } from "./teacher-student-tab";
 import "./teacher-dashboard.sass";
 import { BottomNavComponent } from "../navigation/bottom-nav";
 import { RightNavComponent } from "../navigation/right-nav";
-import { TeacherSupport } from "./teacher-support";
+import { TeacherSupports } from "./teacher-supports";
 
 interface IProps extends IBaseProps {}
 interface IState {
@@ -47,35 +45,12 @@ export class TeacherDashboardComponent extends BaseComponent<IProps, IState> {
         <HeaderComponent isGhostUser={true} />
         <div className="tabbed-area">
           <div className="tab-contents" aria-labelledby={this.getTabId(activeTab)}>
-            { this.renderHeader() }
-            <TeacherSupport time={new Date().getTime()}/>
-            {
-              // Reverse the supports so the newest ones are first + displayed at the top
-              supports.teacherSupports.slice()
-                .filter(support => !support.deleted)
-                .reverse()
-                .map((support, i) => {
-                  return <TeacherSupport support={support} time={support.authoredTime} key={support.key}/>;
-                })
-            }
+            <TeacherSupports supports={supports.teacherSupports.filter(support => !support.deleted)}/>
             {this.renderTabContents()}
           </div>
         </div>
         <BottomNavComponent />
         <RightNavComponent isGhostUser={true} />
-      </div>
-    );
-  }
-
-  private renderHeader() {
-    return (
-      <div className="dash-header">
-        <div className="title">Class Supports:</div>
-        <div className="header-contents">
-          <div className="date">Date</div>
-          <div className="section">Section</div>
-          <div className="content">Message</div>
-        </div>
       </div>
     );
   }

--- a/src/components/teacher/teacher-dashboard.tsx
+++ b/src/components/teacher/teacher-dashboard.tsx
@@ -47,6 +47,7 @@ export class TeacherDashboardComponent extends BaseComponent<IProps, IState> {
         <HeaderComponent isGhostUser={true} />
         <div className="tabbed-area">
           <div className="tab-contents" aria-labelledby={this.getTabId(activeTab)}>
+            { this.renderHeader() }
             <TeacherSupport time={new Date().getTime()}/>
             {
               // Reverse the supports so the newest ones are first + displayed at the top
@@ -62,6 +63,19 @@ export class TeacherDashboardComponent extends BaseComponent<IProps, IState> {
         </div>
         <BottomNavComponent />
         <RightNavComponent isGhostUser={true} />
+      </div>
+    );
+  }
+
+  private renderHeader() {
+    return (
+      <div className="dash-header">
+        <div className="title">Class Supports:</div>
+        <div className="header-contents">
+          <div className="date">Date</div>
+          <div className="section">Section</div>
+          <div className="content">Message</div>
+        </div>
       </div>
     );
   }

--- a/src/components/teacher/teacher-group-tab.sass
+++ b/src/components/teacher/teacher-group-tab.sass
@@ -62,5 +62,5 @@
         padding: $half-padding $padding
         border-radius: 0 $border-radius 0 0
 
-    .content
-      padding: $padding
+  .teacher-supports
+    padding: 5px

--- a/src/components/teacher/teacher-group-tab.tsx
+++ b/src/components/teacher/teacher-group-tab.tsx
@@ -5,6 +5,7 @@ import { GroupModelType } from "../../models/stores/groups";
 
 import "./teacher-group-tab.sass";
 import { TeacherSupports } from "./teacher-supports";
+import { AudienceEnum, GroupAudienceModel } from "../../models/stores/supports";
 
 interface IProps extends IBaseProps {}
 
@@ -71,7 +72,12 @@ export class TeacherGroupTabComponent extends BaseComponent<IProps, IState> {
           </div>
         </div>
         <div className="content">
-          <TeacherSupports supports={supports.teacherSupports.filter(support => !support.deleted)} />
+          <TeacherSupports
+            audience={GroupAudienceModel.create({identifier: group.id})}
+            supports={supports.groupSupports.filter(support => {
+              return !support.deleted && support.audience.identifier === group.id;
+            })}
+          />
         </div>
       </div>
     );

--- a/src/components/teacher/teacher-group-tab.tsx
+++ b/src/components/teacher/teacher-group-tab.tsx
@@ -2,11 +2,11 @@ import { inject, observer } from "mobx-react";
 import * as React from "react";
 import { BaseComponent, IBaseProps } from "../base";
 import { GroupModelType } from "../../models/stores/groups";
-
-import "./teacher-group-tab.sass";
 import { TeacherSupports } from "./teacher-supports";
 import { GroupAudienceModel } from "../../models/stores/supports";
 import { TeacherStudentTabComponent } from "./teacher-student-tab";
+
+import "./teacher-group-tab.sass";
 
 interface IProps extends IBaseProps {}
 

--- a/src/components/teacher/teacher-group-tab.tsx
+++ b/src/components/teacher/teacher-group-tab.tsx
@@ -4,6 +4,7 @@ import { BaseComponent, IBaseProps } from "../base";
 import { GroupModelType } from "../../models/stores/groups";
 
 import "./teacher-group-tab.sass";
+import { TeacherSupports } from "./teacher-supports";
 
 interface IProps extends IBaseProps {}
 
@@ -58,6 +59,7 @@ export class TeacherGroupTabComponent extends BaseComponent<IProps, IState> {
   private renderGroup(group: GroupModelType) {
     // TODO: add this to content when view learning logs story (#160072708) is worked on
     // <TeacherStudentTabComponent group={group} />
+    const { supports } = this.stores;
     return (
       <div className="selected-group">
         <div className="title">
@@ -68,7 +70,9 @@ export class TeacherGroupTabComponent extends BaseComponent<IProps, IState> {
             <span onClick={this.handleGhostGroup(group)}>Join Group</span>
           </div>
         </div>
-        <div className="content" />
+        <div className="content">
+          <TeacherSupports supports={supports.teacherSupports.filter(support => !support.deleted)} />
+        </div>
       </div>
     );
   }

--- a/src/components/teacher/teacher-group-tab.tsx
+++ b/src/components/teacher/teacher-group-tab.tsx
@@ -5,12 +5,13 @@ import { GroupModelType } from "../../models/stores/groups";
 
 import "./teacher-group-tab.sass";
 import { TeacherSupports } from "./teacher-supports";
-import { AudienceEnum, GroupAudienceModel } from "../../models/stores/supports";
+import { GroupAudienceModel } from "../../models/stores/supports";
+import { TeacherStudentTabComponent } from "./teacher-student-tab";
 
 interface IProps extends IBaseProps {}
 
 interface IState {
-  selectedGroup?: GroupModelType;
+  selectedGroupId?: string;
 }
 
 @inject("stores")
@@ -19,7 +20,9 @@ export class TeacherGroupTabComponent extends BaseComponent<IProps, IState> {
   public state: IState = {};
 
   public render() {
-    const { selectedGroup } = this.state;
+    const { groups } = this.stores;
+    const { selectedGroupId } = this.state;
+    const selectedGroup = groups.getGroupById(selectedGroupId);
     return (
       <div className="teacher-group-tab">
         {this.renderGroups()}
@@ -58,9 +61,8 @@ export class TeacherGroupTabComponent extends BaseComponent<IProps, IState> {
   }
 
   private renderGroup(group: GroupModelType) {
-    // TODO: add this to content when view learning logs story (#160072708) is worked on
-    // <TeacherStudentTabComponent group={group} />
     const { supports } = this.stores;
+    const { selectedGroupId } = this.state;
     return (
       <div className="selected-group">
         <div className="title">
@@ -79,13 +81,14 @@ export class TeacherGroupTabComponent extends BaseComponent<IProps, IState> {
             })}
           />
         </div>
+        <TeacherStudentTabComponent groupId={selectedGroupId} />
       </div>
     );
   }
 
   private handleChooseGroup = (group: GroupModelType) => {
     return (e: React.MouseEvent<HTMLElement>) => {
-      this.setState({selectedGroup: group});
+      this.setState({selectedGroupId: group.id});
     };
   }
 

--- a/src/components/teacher/teacher-student-tab.sass
+++ b/src/components/teacher/teacher-student-tab.sass
@@ -9,6 +9,7 @@
       padding: $half-padding
       float: left
       margin: $quarter-margin
+      cursor: pointer
 
       &.disconnected
         background-color: #777

--- a/src/components/teacher/teacher-student-tab.tsx
+++ b/src/components/teacher/teacher-student-tab.tsx
@@ -2,10 +2,10 @@ import { inject, observer } from "mobx-react";
 import * as React from "react";
 import { BaseComponent, IBaseProps } from "../base";
 import { GroupModelType, GroupUserModelType } from "../../models/stores/groups";
-
-import "./teacher-student-tab.sass";
 import { TeacherSupports } from "./teacher-supports";
 import { UserAudienceModel } from "../../models/stores/supports";
+
+import "./teacher-student-tab.sass";
 
 interface IProps extends IBaseProps {
   groupId?: string;
@@ -27,7 +27,7 @@ export class TeacherStudentTabComponent extends BaseComponent<IProps, IState> {
   }
 
   public render() {
-    const { groups,  } = this.stores;
+    const { groups } = this.stores;
     const { selectedUserId } = this.state;
     const { groupId } = this.props;
     const group = groups.getGroupById(groupId);

--- a/src/components/teacher/teacher-student-tab.tsx
+++ b/src/components/teacher/teacher-student-tab.tsx
@@ -4,13 +4,15 @@ import { BaseComponent, IBaseProps } from "../base";
 import { GroupModelType, GroupUserModelType } from "../../models/stores/groups";
 
 import "./teacher-student-tab.sass";
+import { TeacherSupports } from "./teacher-supports";
+import { UserAudienceModel } from "../../models/stores/supports";
 
 interface IProps extends IBaseProps {
-  group?: GroupModelType;
+  groupId?: string;
 }
 
 interface IState {
-  selectedUser?: GroupUserModelType;
+  selectedUserId?: string;
 }
 
 @inject("stores")
@@ -19,20 +21,22 @@ export class TeacherStudentTabComponent extends BaseComponent<IProps, IState> {
   public state: IState = {};
 
   public componentWillReceiveProps(nextProps: IProps) {
-    if (nextProps.group !== this.props.group) {
-      this.setState({selectedUser: undefined});
+    if (nextProps.groupId !== this.props.groupId) {
+      this.setState({selectedUserId: undefined});
     }
   }
 
   public render() {
-    const { group } = this.props;
-    const { selectedUser } = this.state;
+    const { groups,  } = this.stores;
+    const { selectedUserId } = this.state;
+    const { groupId } = this.props;
+    const group = groups.getGroupById(groupId);
     // TODO: if no group prop then get list of all users in class
     const users = group ? group.users : [];
     return (
       <div className="teacher-student-tab">
         {this.renderUsers(users)}
-        {selectedUser ? this.renderUser(selectedUser) : null}
+        {selectedUserId ? this.renderUser(selectedUserId) : null}
       </div>
     );
   }
@@ -57,14 +61,18 @@ export class TeacherStudentTabComponent extends BaseComponent<IProps, IState> {
       <div className="user-list">
         {userElements.length > 0
           ? userElements
-          : (this.props.group
+          : (this.props.groupId
               ? "No students found."
               : "TDB: Student List (same as group student list but shows all students)")}
       </div>
     );
   }
 
-  private renderUser(user: GroupUserModelType) {
+  private renderUser(userId: string) {
+    const { supports, groups } = this.stores;
+    const { selectedUserId } = this.state;
+    const { groupId } = this.props;
+    const user = groups.getGroupById(groupId)!.getUserById(selectedUserId)!;
     return (
       <div className="selected-group">
         <div className="title">
@@ -73,8 +81,12 @@ export class TeacherStudentTabComponent extends BaseComponent<IProps, IState> {
           </div>
         </div>
         <div className="content">
-          TDB: Show student section documents and learning log thumbnails
-          with each thumbnail linked to show it in a canvas under the list.
+          <TeacherSupports
+            audience={UserAudienceModel.create({identifier: user.id})}
+            supports={supports.userSupports.filter(support => {
+              return !support.deleted && support.audience.identifier === user.id;
+            })}
+          />
         </div>
       </div>
     );
@@ -82,7 +94,7 @@ export class TeacherStudentTabComponent extends BaseComponent<IProps, IState> {
 
   private handleChooseUser = (user: GroupUserModelType) => {
     return (e: React.MouseEvent<HTMLElement>) => {
-      this.setState({selectedUser: user});
+      this.setState({selectedUserId: user.id});
     };
   }
 }

--- a/src/components/teacher/teacher-support.sass
+++ b/src/components/teacher/teacher-support.sass
@@ -21,14 +21,22 @@
   input
     height: 30px
 
-  .content
+  .content, .section-target, .section-dropdown
     font-family: inherit
     font-size: inherit
-    flex-grow: 1
     margin-left: 10px
     color: black
     display: flex
     align-items: center
+
+  .content
+    flex-grow: 1
+  
+  .section-target
+    text-align: center
+
+  .section-target, .section-dropdown
+    min-width: $section-width
   
   .send-button
     display: flex
@@ -49,4 +57,5 @@
 
   .date
     color: black
-    margin-left: 24px
+    margin-left: $date-margin
+    min-width: $date-width

--- a/src/components/teacher/teacher-support.tsx
+++ b/src/components/teacher/teacher-support.tsx
@@ -5,15 +5,9 @@ import { BaseComponent, IBaseProps } from "../base";
 import "./teacher-support.sass";
 import { niceDate } from "../../utilities/time";
 import { ENTER } from "@blueprintjs/core/lib/esm/common/keys";
-import {
-  TeacherSupportModelType,
-  TeacherSupportSectionTarget,
-  AudienceEnum,
-  AudienceModelType,
-  audienceInfo
-} from "../../models/stores/supports";
-import { values } from "lodash";
-import { SectionType, AllSectionType, sectionInfo, allSectionInfo } from "../../models/curriculum/section";
+import { TeacherSupportModelType, TeacherSupportSectionTarget, AudienceModelType,
+  audienceInfo } from "../../models/stores/supports";
+import { sectionInfo, allSectionInfo } from "../../models/curriculum/section";
 
 interface IProps extends IBaseProps {
   support?: TeacherSupportModelType;
@@ -42,8 +36,8 @@ export class TeacherSupport extends BaseComponent<IProps, IState> {
 
   private renderNewSupport() {
     const { problem } = this.stores;
-    const { time, audience} = this.props;
-    const audienceType = audience.type as AudienceEnum;
+    const { time, audience } = this.props;
+    const audienceType = audience.type;
     const messageTarget = audienceInfo[audienceType].display;
     const sectionOptions = (problem.sections).map(section => {
       const sectionType = section.type;

--- a/src/components/teacher/teacher-support.tsx
+++ b/src/components/teacher/teacher-support.tsx
@@ -5,12 +5,19 @@ import { BaseComponent, IBaseProps } from "../base";
 import "./teacher-support.sass";
 import { niceDate } from "../../utilities/time";
 import { ENTER } from "@blueprintjs/core/lib/esm/common/keys";
-import { TeacherSupportModelType, TeacherSupportSectionTarget } from "../../models/stores/supports";
+import {
+  TeacherSupportModelType,
+  TeacherSupportSectionTarget,
+  AudienceEnum,
+  AudienceModelType,
+  audienceInfo
+} from "../../models/stores/supports";
 import { values } from "lodash";
 import { SectionType, AllSectionType, sectionInfo, allSectionInfo } from "../../models/curriculum/section";
 
 interface IProps extends IBaseProps {
   support?: TeacherSupportModelType;
+  audience: AudienceModelType;
   time: number;
 }
 
@@ -35,7 +42,9 @@ export class TeacherSupport extends BaseComponent<IProps, IState> {
 
   private renderNewSupport() {
     const { problem } = this.stores;
-    const { time } = this.props;
+    const { time, audience} = this.props;
+    const audienceType = audience.type as AudienceEnum;
+    const messageTarget = audienceInfo[audienceType].display;
     const sectionOptions = (problem.sections).map(section => {
       const sectionType = section.type;
       return <option key={sectionType} value={sectionType}>{sectionInfo[sectionType].title}</option>;
@@ -50,7 +59,7 @@ export class TeacherSupport extends BaseComponent<IProps, IState> {
           {sectionOptions}
         </select>
         <input className="content" onKeyUp={this.handleEnter} ref={(elem) => this.inputElem = elem}/>
-        <div className="send-button" onClick={this.handleSubmit}>Message Class</div>
+        <div className="send-button" onClick={this.handleSubmit}>{`Message ${messageTarget}`}</div>
       </div>
     );
   }
@@ -77,10 +86,11 @@ export class TeacherSupport extends BaseComponent<IProps, IState> {
 
   private handleSubmit = () => {
     const { db } = this.stores;
+    const { audience } = this.props;
     const content = this.inputElem && this.inputElem.value;
     const sectionTarget = this.sectionElem && this.sectionElem.value;
     if (this.inputElem && content && sectionTarget) {
-      db.createSupport(content, sectionTarget as TeacherSupportSectionTarget);
+      db.createSupport(content, sectionTarget as TeacherSupportSectionTarget, audience);
       this.inputElem.value = "";
     }
   }

--- a/src/components/teacher/teacher-support.tsx
+++ b/src/components/teacher/teacher-support.tsx
@@ -58,8 +58,19 @@ export class TeacherSupport extends BaseComponent<IProps, IState> {
         <select className="section-dropdown" ref={(elem) => this.sectionElem = elem}>
           {sectionOptions}
         </select>
-        <input className="content" onKeyUp={this.handleEnter} ref={(elem) => this.inputElem = elem}/>
-        <div className="send-button" onClick={this.handleSubmit}>{`Message ${messageTarget}`}</div>
+        <input
+          className="content"
+          onKeyUp={this.handleEnter}
+          ref={(elem) => this.inputElem = elem}
+          data-test={`support-input-${audienceType}`}
+        />
+        <div
+          className="send-button"
+          onClick={this.handleSubmit}
+          data-test={`support-submit-${audienceType}`}
+        >
+          {`Message ${messageTarget}`}
+        </div>
       </div>
     );
   }
@@ -69,7 +80,7 @@ export class TeacherSupport extends BaseComponent<IProps, IState> {
     const { text, sectionTargetDisplay } = support;
 
     return (
-      <div className="teacher-support">
+      <div className="teacher-support" data-test="teacher-support">
         <svg className={`icon icon-delete-tool`} onClick={this.handleDelete(support)}>
           <use xlinkHref={`#icon-delete-tool`} />
         </svg>

--- a/src/components/teacher/teacher-supports.sass
+++ b/src/components/teacher/teacher-supports.sass
@@ -1,0 +1,25 @@
+@import ../vars
+  
+.teacher-supports
+  .dash-header
+    font-family: inherit
+    font-size: inherit
+    color: black
+    font-weight: bold
+
+    > div
+      margin-bottom: $teacher-margin
+
+    .header-contents
+      display: flex
+
+      div
+        text-align: center
+        margin-left: $teacher-margin
+
+      .date
+        margin-left: $date-margin
+        width: $date-width
+      
+      .section
+        width: $section-width

--- a/src/components/teacher/teacher-supports.tsx
+++ b/src/components/teacher/teacher-supports.tsx
@@ -1,10 +1,10 @@
 import { inject, observer } from "mobx-react";
 import * as React from "react";
 import { BaseComponent, IBaseProps } from "../base";
+import { TeacherSupportModelType, AudienceModelType, audienceInfo } from "../../models/stores/supports";
+import { TeacherSupport } from "./teacher-support";
 
 import "./teacher-supports.sass";
-import { TeacherSupportModelType, AudienceModelType, AudienceEnum, audienceInfo } from "../../models/stores/supports";
-import { TeacherSupport } from "./teacher-support";
 
 interface IProps extends IBaseProps {
   supports: TeacherSupportModelType[];
@@ -42,7 +42,7 @@ export class TeacherSupports extends BaseComponent<IProps, IState> {
 
   private renderHeader() {
     const { audience } = this.props;
-    const audienceType = audience.type as AudienceEnum;
+    const audienceType = audience.type;
     const audienceDisplay = audienceInfo[audienceType].display;
     return (
       <div className="dash-header">

--- a/src/components/teacher/teacher-supports.tsx
+++ b/src/components/teacher/teacher-supports.tsx
@@ -3,11 +3,12 @@ import * as React from "react";
 import { BaseComponent, IBaseProps } from "../base";
 
 import "./teacher-supports.sass";
-import { TeacherSupportModelType } from "../../models/stores/supports";
+import { TeacherSupportModelType, AudienceModelType, AudienceEnum, audienceInfo } from "../../models/stores/supports";
 import { TeacherSupport } from "./teacher-support";
 
 interface IProps extends IBaseProps {
   supports: TeacherSupportModelType[];
+  audience: AudienceModelType;
 }
 
 interface IState {}
@@ -17,18 +18,22 @@ interface IState {}
 export class TeacherSupports extends BaseComponent<IProps, IState> {
 
   public render() {
-    const { supports } = this.props;
+    const { supports, audience } = this.props;
 
     return (
       <div className="teacher-supports">
         { this.renderHeader() }
-        <TeacherSupport time={new Date().getTime()}/>
+        <TeacherSupport time={new Date().getTime()} audience={audience}/>
           {
             // Reverse the supports so the newest ones are first + displayed at the top
             supports.slice()
               .reverse()
               .map((support, i) => {
-                return <TeacherSupport support={support} time={support.authoredTime} key={support.key}/>;
+                return <TeacherSupport
+                  support={support}
+                  time={support.authoredTime}
+                  audience={audience}
+                  key={support.key}/>;
               })
           }
       </div>
@@ -36,9 +41,12 @@ export class TeacherSupports extends BaseComponent<IProps, IState> {
   }
 
   private renderHeader() {
+    const { audience } = this.props;
+    const audienceType = audience.type as AudienceEnum;
+    const audienceDisplay = audienceInfo[audienceType].display;
     return (
       <div className="dash-header">
-        <div className="header-title">Class Supports:</div>
+        <div className="header-title">{`${audienceDisplay} Supports:`}</div>
         <div className="header-contents">
           <div className="date">Date</div>
           <div className="section">Section</div>

--- a/src/components/teacher/teacher-supports.tsx
+++ b/src/components/teacher/teacher-supports.tsx
@@ -1,0 +1,51 @@
+import { inject, observer } from "mobx-react";
+import * as React from "react";
+import { BaseComponent, IBaseProps } from "../base";
+
+import "./teacher-supports.sass";
+import { TeacherSupportModelType } from "../../models/stores/supports";
+import { TeacherSupport } from "./teacher-support";
+
+interface IProps extends IBaseProps {
+  supports: TeacherSupportModelType[];
+}
+
+interface IState {}
+
+@inject("stores")
+@observer
+export class TeacherSupports extends BaseComponent<IProps, IState> {
+
+  public render() {
+    const { supports } = this.props;
+
+    return (
+      <div className="teacher-supports">
+        { this.renderHeader() }
+        <TeacherSupport time={new Date().getTime()}/>
+          {
+            // Reverse the supports so the newest ones are first + displayed at the top
+            supports.slice()
+              .reverse()
+              .map((support, i) => {
+                return <TeacherSupport support={support} time={support.authoredTime} key={support.key}/>;
+              })
+          }
+      </div>
+    );
+  }
+
+  private renderHeader() {
+    return (
+      <div className="dash-header">
+        <div className="header-title">Class Supports:</div>
+        <div className="header-contents">
+          <div className="date">Date</div>
+          <div className="section">Section</div>
+          <div className="content">Message</div>
+        </div>
+      </div>
+    );
+  }
+
+}

--- a/src/components/vars.sass
+++ b/src/components/vars.sass
@@ -177,3 +177,10 @@ $tab-min-height: 50px
   letter-spacing: 0
   padding: 0 5px
 
+//
+// teacher dashboard
+//
+$date-width: 76px
+$date-margin: 24px
+$section-width: 185px
+$teacher-margin: 10px

--- a/src/lib/db-listeners/db-supports-listener.ts
+++ b/src/lib/db-listeners/db-supports-listener.ts
@@ -4,6 +4,7 @@ import { SupportItemType,
          TeacherSupportModel,
          TeacherSupportModelType } from "../../models/stores/supports";
 import { DBSupport } from "../db-types";
+import { SectionType } from "../../models/curriculum/section";
 
 export class DBSupportsListener {
   private db: DB;
@@ -34,16 +35,20 @@ export class DBSupportsListener {
     if (dbSupports) {
       const teacherSupports: TeacherSupportModelType[] = [];
 
-      Object.keys(dbSupports.all).forEach((key) => {
-        const dbSupport: DBSupport = dbSupports.all[key];
-        teacherSupports.push(TeacherSupportModel.create({
-          key: dbSupport.self.key,
-          text: dbSupport.content,
-          type: SupportItemType.problem,
-          audience: SupportAudienceType.class,
-          authoredTime: dbSupport.timestamp,
-          deleted: dbSupport.deleted
-        }));
+      Object.keys(dbSupports).forEach(sectionTarget => {
+        const newSupports = dbSupports[sectionTarget];
+        Object.keys(newSupports).forEach((key) => {
+          const dbSupport: DBSupport = newSupports[key];
+          teacherSupports.push(TeacherSupportModel.create({
+            key: dbSupport.self.key,
+            text: dbSupport.content,
+            type: sectionTarget === "all" ? SupportItemType.problem : SupportItemType.section,
+            sectionId: sectionTarget === "all" ? undefined : sectionTarget as SectionType,
+            audience: SupportAudienceType.class,
+            authoredTime: dbSupport.timestamp,
+            deleted: dbSupport.deleted
+          }));
+        });
       });
 
       supports.setAuthoredSupports(teacherSupports);

--- a/src/lib/db-listeners/db-supports-listener.ts
+++ b/src/lib/db-listeners/db-supports-listener.ts
@@ -1,13 +1,6 @@
 import { DB } from "../db";
-import { SupportItemType,
-         TeacherSupportModel,
-         TeacherSupportModelType,
-         ClassAudienceModel,
-         AudienceEnum,
-         TeacherSupportSectionTarget,
-         AudienceModelType,
-         GroupAudienceModel,
-         UserAudienceModel} from "../../models/stores/supports";
+import { SupportItemType, TeacherSupportModel, TeacherSupportModelType, ClassAudienceModel, AudienceEnum,
+  AudienceModelType, GroupAudienceModel, UserAudienceModel} from "../../models/stores/supports";
 import { DBSupport } from "../db-types";
 import { SectionType } from "../../models/curriculum/section";
 
@@ -53,6 +46,7 @@ export class DBSupportsListener {
           });
         });
       } else {
+        // Logic is the same as above, but group + user supports are first keyed by ID
         Object.keys(dbSupports).forEach(audienceId => {
           Object.keys(dbSupports[audienceId]).forEach(sectionTarget => {
             const newSupports = dbSupports[audienceId][sectionTarget];

--- a/src/lib/db-types.ts
+++ b/src/lib/db-types.ts
@@ -1,5 +1,5 @@
 import { SectionType } from "../models/curriculum/section";
-import { SupportAudienceType, TeacherSupportSectionTarget } from "../models/stores/supports";
+import { AudienceEnum, TeacherSupportSectionTarget } from "../models/stores/supports";
 
 // NOTE: see docs/firebase-schema.md to see a visual hierarchy of these interfaces
 
@@ -207,7 +207,8 @@ export interface DBSupport {
   self: {
     classHash: string;
     offeringId: string;
-    audience: SupportAudienceType;
+    audienceType: AudienceEnum;
+    audienceId: string;
     sectionTarget: TeacherSupportSectionTarget;
     key: string;
   };

--- a/src/lib/db-types.ts
+++ b/src/lib/db-types.ts
@@ -1,5 +1,5 @@
 import { SectionType } from "../models/curriculum/section";
-import { SupportAudienceType } from "../models/stores/supports";
+import { SupportAudienceType, TeacherSupportSectionTarget } from "../models/stores/supports";
 
 // NOTE: see docs/firebase-schema.md to see a visual hierarchy of these interfaces
 
@@ -203,17 +203,12 @@ export interface DBImage {
   createdBy: string;
 }
 
-export enum DBSectionType {
-  all = "all"
-}
-export type DBSupportSectionTarget = SectionType | DBSectionType;
-
 export interface DBSupport {
   self: {
     classHash: string;
     offeringId: string;
     audience: SupportAudienceType;
-    sectionTarget: DBSupportSectionTarget;
+    sectionTarget: TeacherSupportSectionTarget;
     key: string;
   };
   timestamp: number;

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -33,10 +33,12 @@ import { DocumentContentSnapshotType } from "../models/document/document-content
 import { Firebase } from "./firebase";
 import { DBListeners } from "./db-listeners";
 import { Logger, LogEventName } from "./logger";
-import { SupportAudienceType,
+import { AudienceEnum,
          TeacherSupportModelType,
          SupportItemType,
-         TeacherSupportSectionTarget
+         TeacherSupportSectionTarget,
+         ClassAudienceModel,
+         AudienceModelType
        } from "../models/stores/supports";
 
 export type IDBConnectOptions = IDBAuthConnectOptions | IDBNonAuthConnectOptions;
@@ -651,17 +653,18 @@ export class DB {
             .then(blob => URL.createObjectURL(blob));
   }
 
-  public createSupport(content: string, sectionTarget: TeacherSupportSectionTarget) {
+  public createSupport(content: string, sectionTarget: TeacherSupportSectionTarget, audience: AudienceModelType) {
     const { user } = this.stores;
     const classSupportsRef = this.firebase.ref(
-      this.firebase.getSupportsPath(user, SupportAudienceType.class, sectionTarget)
+      this.firebase.getSupportsPath(user, audience, sectionTarget)
     );
     const supportRef = classSupportsRef.push();
     const support: DBSupport = {
       self: {
         classHash: user.classHash,
         offeringId: user.offeringId,
-        audience: SupportAudienceType.class,
+        audienceType: audience.type as AudienceEnum, // XXX: this cast should not be necessary
+        audienceId: audience.identifier || "",
         sectionTarget,
         key: supportRef.key!
       },

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -4,42 +4,17 @@ import "firebase/database";
 import "firebase/storage";
 import { AppMode, IStores } from "../models/stores/stores";
 import { observable } from "mobx";
-import { DBOfferingGroup,
-         DBOfferingGroupUser,
-         DBOfferingGroupMap,
-         DBOfferingUser,
-         DBDocumentMetadata,
-         DBDocument,
-         DBOfferingUserSectionDocument,
-         DBLearningLog,
-         DBLearningLogPublication,
-         DBPublicationDocumentMetadata,
-         DBGroupUserConnections,
-         DBPublication,
-         DBDocumentType,
-         DBImage,
-         DBSupport,
-        } from "./db-types";
-import { DocumentModelType,
-         DocumentModel,
-         DocumentType,
-         SectionDocument,
-         LearningLogDocument,
-         PublicationDocument,
-         LearningLogPublication
-        } from "../models/document/document";
+import { DBOfferingGroup, DBOfferingGroupUser, DBOfferingGroupMap, DBOfferingUser, DBDocumentMetadata, DBDocument,
+  DBOfferingUserSectionDocument, DBLearningLog, DBLearningLogPublication, DBPublicationDocumentMetadata,
+  DBGroupUserConnections, DBPublication, DBDocumentType, DBImage, DBSupport } from "./db-types";
+import { DocumentModelType, DocumentModel, DocumentType, SectionDocument, LearningLogDocument, PublicationDocument,
+  LearningLogPublication } from "../models/document/document";
 import { ImageModelType } from "../models/image";
 import { DocumentContentSnapshotType } from "../models/document/document-content";
 import { Firebase } from "./firebase";
 import { DBListeners } from "./db-listeners";
 import { Logger, LogEventName } from "./logger";
-import { AudienceEnum,
-         TeacherSupportModelType,
-         SupportItemType,
-         TeacherSupportSectionTarget,
-         ClassAudienceModel,
-         AudienceModelType
-       } from "../models/stores/supports";
+import { TeacherSupportModelType, TeacherSupportSectionTarget, AudienceModelType } from "../models/stores/supports";
 
 export type IDBConnectOptions = IDBAuthConnectOptions | IDBNonAuthConnectOptions;
 export interface IDBAuthConnectOptions {
@@ -663,7 +638,7 @@ export class DB {
       self: {
         classHash: user.classHash,
         offeringId: user.offeringId,
-        audienceType: audience.type as AudienceEnum, // XXX: this cast should not be necessary
+        audienceType: audience.type,
         audienceId: audience.identifier || "",
         sectionTarget,
         key: supportRef.key!

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -2,7 +2,7 @@ import * as firebase from "firebase/app";
 import { UserModelType } from "../models/stores/user";
 import { DB } from "./db";
 import { urlParams } from "../utilities/url-params";
-import { SupportAudienceType, TeacherSupportSectionTarget } from "../models/stores/supports";
+import { TeacherSupportSectionTarget, AudienceModelType, AudienceEnum } from "../models/stores/supports";
 
 // Set this during database testing in combination with the urlParam testMigration=true to
 // override the top-level Firebase key regardless of mode. For example, setting this to "authed-copy"
@@ -142,11 +142,15 @@ export class Firebase {
 
   public getSupportsPath(
     user: UserModelType,
-    audience?: SupportAudienceType,
+    audience?: AudienceModelType,
     sectionTarget?: TeacherSupportSectionTarget,
     key?: string
   ) {
-    const audienceSuffix = audience ? `/${audience}` : "";
+    const audienceSuffix = audience
+      ? audience.identifier
+        ? `/${audience.type}/${audience.identifier}`
+        : `/${audience.type}`
+      : "";
     const sectionTargetSuffix = sectionTarget ? `/${sectionTarget}` : "";
     const keySuffix = key ? `/${key}` : "";
     return `${this.getOfferingPath(user)}/supports${audienceSuffix}${sectionTargetSuffix}${keySuffix}`;

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -2,8 +2,7 @@ import * as firebase from "firebase/app";
 import { UserModelType } from "../models/stores/user";
 import { DB } from "./db";
 import { urlParams } from "../utilities/url-params";
-import { DBSupportSectionTarget } from "./db-types";
-import { SupportAudienceType } from "../models/stores/supports";
+import { SupportAudienceType, TeacherSupportSectionTarget } from "../models/stores/supports";
 
 // Set this during database testing in combination with the urlParam testMigration=true to
 // override the top-level Firebase key regardless of mode. For example, setting this to "authed-copy"
@@ -144,7 +143,7 @@ export class Firebase {
   public getSupportsPath(
     user: UserModelType,
     audience?: SupportAudienceType,
-    sectionTarget?: DBSupportSectionTarget,
+    sectionTarget?: TeacherSupportSectionTarget,
     key?: string
   ) {
     const audienceSuffix = audience ? `/${audience}` : "";

--- a/src/models/curriculum/section.ts
+++ b/src/models/curriculum/section.ts
@@ -22,6 +22,11 @@ export const sectionInfo = {
   [SectionType.extraWorkspace]: { title: "Extra Workspace", abbrev: "Ex" }
 };
 
+export type AllSectionType = "all";
+export const allSectionInfo = {
+  title: "All"
+};
+
 export const SectionModel = types
   .model("Section", {
     type: types.enumeration<SectionType>("SectionType", values(SectionType) as SectionType[]),

--- a/src/models/stores/groups.ts
+++ b/src/models/stores/groups.ts
@@ -23,6 +23,13 @@ export const GroupModel = types
   .model("Group", {
     id: types.identifier,
     users: types.array(GroupUserModel)
+  })
+  .views((self) => {
+    return {
+      getUserById(id?: string) {
+        return self.users.find(user => user.id === id);
+      }
+    };
   });
 
 export const GroupsModel = types
@@ -73,6 +80,10 @@ export const GroupsModel = types
         return self.allGroups.find((group) => {
           return !!group.users.find((user) => user.id === uid);
         });
+      },
+
+      getGroupById(id?: string) {
+        return self.allGroups.find(group => group.id === id);
       }
     };
   });

--- a/src/models/stores/supports.test.ts
+++ b/src/models/stores/supports.test.ts
@@ -1,5 +1,5 @@
 import { getSnapshot } from "mobx-state-tree";
-import { SupportsModel, SupportItemType, SupportAudienceType, TeacherSupportModel } from "./supports";
+import { SupportsModel, SupportItemType, AudienceEnum, TeacherSupportModel, ClassAudienceModel } from "./supports";
 import { UnitModel } from "../curriculum/unit";
 import { SupportModel } from "../curriculum/support";
 import { InvestigationModel } from "../curriculum/investigation";
@@ -14,7 +14,9 @@ describe("supports model", () => {
     const supports = SupportsModel.create({});
     expect(getSnapshot(supports)).toEqual({
       curricularSupports: [],
-      teacherSupports: []
+      classSupports: [],
+      userSupports: [],
+      groupSupports: []
     });
   });
 
@@ -26,9 +28,9 @@ describe("supports model", () => {
         {text: "support #3", type: SupportItemType.problem, visible: true},
         {text: "support #4", type: SupportItemType.section},
       ],
-      teacherSupports: [
+      classSupports: [
         {key: "1", text: "support #5", type: SupportItemType.problem,
-          audience: SupportAudienceType.class, authoredTime: 42}
+          audience: ClassAudienceModel.create(), authoredTime: 42}
       ]
     });
     expect(omitUndefined(getSnapshot(supports))).toEqual({
@@ -54,17 +56,21 @@ describe("supports model", () => {
           visible: false,
         },
       ],
-      teacherSupports: [
+      classSupports: [
         {
           key: "1",
           text: "support #5",
           type: "problem",
-          audience: "class",
+          audience: {
+            type: "class"
+          },
           authoredTime: 42,
           visible: false,
           deleted: false
         }
-      ]
+      ],
+      groupSupports: [],
+      userSupports: []
     });
 
     expect(supports.curricularSupports.filter((support) => support.visible).length).toEqual(2);
@@ -205,7 +211,7 @@ describe("supports model", () => {
     }), InvestigationModel.create(cloneDeep(investigation1)),
         ProblemModel.create(cloneDeep(problem1)));
 
-    expect(supports.getAllForSection(SectionType.introduction)).toEqual([
+    expect(supports.getSupportsForUserProblem(SectionType.introduction, "groupId")).toEqual([
       {
         sectionId: "introduction",
         text: "Investigation 1, Problem 1, section: introduction, support #1",
@@ -227,25 +233,29 @@ describe("supports model", () => {
       key: "1",
       text: "foo",
       type: SupportItemType.problem,
-      audience: SupportAudienceType.class,
+      audience: ClassAudienceModel.create(),
       authoredTime: 100
     });
     const lateSupport = TeacherSupportModel.create({
       key: "2",
       text: "bar",
       type: SupportItemType.problem,
-      audience: SupportAudienceType.class,
+      audience: ClassAudienceModel.create(),
       authoredTime: 200
     });
 
     expect(getSnapshot(supports)).toEqual({
       curricularSupports: [],
-      teacherSupports: []
+      classSupports: [],
+      groupSupports: [],
+      userSupports: []
     });
-    supports.setAuthoredSupports([lateSupport, earlySupport]);
+    supports.setAuthoredSupports([lateSupport, earlySupport], AudienceEnum.class);
     expect(getSnapshot(supports)).toEqual({
       curricularSupports: [],
-      teacherSupports: [earlySupport, lateSupport]
+      classSupports: [earlySupport, lateSupport],
+      groupSupports: [],
+      userSupports: []
     });
   });
 });

--- a/src/models/stores/supports.test.ts
+++ b/src/models/stores/supports.test.ts
@@ -1,5 +1,12 @@
 import { getSnapshot } from "mobx-state-tree";
-import { SupportsModel, SupportItemType, AudienceEnum, TeacherSupportModel, ClassAudienceModel } from "./supports";
+import { SupportsModel,
+         SupportItemType,
+         AudienceEnum,
+         TeacherSupportModel,
+         ClassAudienceModel,
+         GroupAudienceModel,
+         UserAudienceModel,
+         TeacherSupportModelType} from "./supports";
 import { UnitModel } from "../curriculum/unit";
 import { SupportModel } from "../curriculum/support";
 import { InvestigationModel } from "../curriculum/investigation";
@@ -257,5 +264,54 @@ describe("supports model", () => {
       groupSupports: [],
       userSupports: []
     });
+  });
+
+  it("Gets supports by audience and section type", () => {
+    const classSupportAll = {key: "1", text: "", type: SupportItemType.problem,
+      audience: ClassAudienceModel.create(), authoredTime: 42};
+    const classSupportIntro = {key: "2", text: "", type: SupportItemType.section, sectionId: SectionType.introduction,
+      audience: ClassAudienceModel.create(), authoredTime: 43};
+    const groupSupport = {key: "3", text: "", type: SupportItemType.problem,
+      audience: GroupAudienceModel.create({identifier: "group1"}), authoredTime: 44};
+    const userSupport = {key: "4", text: "", type: SupportItemType.section, sectionId: SectionType.didYouKnow,
+      audience: UserAudienceModel.create({identifier: "user1"}), authoredTime: 45};
+
+    const supports = SupportsModel.create({
+      classSupports: [
+        classSupportAll,
+        classSupportIntro
+      ],
+      groupSupports: [
+        groupSupport
+      ],
+      userSupports: [
+        userSupport
+      ]
+    });
+
+    const generalClassSupports = supports.getSupportsForUserProblem(SectionType.didYouKnow, "group0", "user0");
+    expect(generalClassSupports.length).toEqual(1);
+    expect((generalClassSupports[0] as TeacherSupportModelType).key).toEqual(classSupportAll.key);
+
+    const setionClassSupports = supports.getSupportsForUserProblem(SectionType.introduction, "group0", "user0");
+    expect(setionClassSupports.length).toEqual(2);
+    expect((setionClassSupports[0] as TeacherSupportModelType).key).toEqual(classSupportAll.key);
+    expect((setionClassSupports[1] as TeacherSupportModelType).key).toEqual(classSupportIntro.key);
+
+    const groupSupports = supports.getSupportsForUserProblem(SectionType.didYouKnow, "group1", "user0");
+    expect(groupSupports.length).toEqual(2);
+    expect((groupSupports[0] as TeacherSupportModelType).key).toEqual(classSupportAll.key);
+    expect((groupSupports[1] as TeacherSupportModelType).key).toEqual(groupSupport.key);
+
+    const userSupports = supports.getSupportsForUserProblem(SectionType.didYouKnow, "group0", "user1");
+    expect(userSupports.length).toEqual(2);
+    expect((userSupports[0] as TeacherSupportModelType).key).toEqual(classSupportAll.key);
+    expect((userSupports[1] as TeacherSupportModelType).key).toEqual(userSupport.key);
+
+    const multiSupports = supports.getSupportsForUserProblem(SectionType.didYouKnow, "group1", "user1");
+    expect(multiSupports.length).toEqual(3);
+    expect((multiSupports[0] as TeacherSupportModelType).key).toEqual(classSupportAll.key);
+    expect((multiSupports[1] as TeacherSupportModelType).key).toEqual(groupSupport.key);
+    expect((multiSupports[2] as TeacherSupportModelType).key).toEqual(userSupport.key);
   });
 });

--- a/src/models/stores/supports.test.ts
+++ b/src/models/stores/supports.test.ts
@@ -211,7 +211,7 @@ describe("supports model", () => {
     }), InvestigationModel.create(cloneDeep(investigation1)),
         ProblemModel.create(cloneDeep(problem1)));
 
-    expect(supports.getSupportsForUserProblem(SectionType.introduction, "groupId")).toEqual([
+    expect(supports.getSupportsForUserProblem(SectionType.introduction, "groupId", "userId")).toEqual([
       {
         sectionId: "introduction",
         text: "Investigation 1, Problem 1, section: introduction, support #1",

--- a/src/models/stores/supports.test.ts
+++ b/src/models/stores/supports.test.ts
@@ -1,12 +1,6 @@
 import { getSnapshot } from "mobx-state-tree";
-import { SupportsModel,
-         SupportItemType,
-         AudienceEnum,
-         TeacherSupportModel,
-         ClassAudienceModel,
-         GroupAudienceModel,
-         UserAudienceModel,
-         TeacherSupportModelType} from "./supports";
+import { SupportsModel, SupportItemType, AudienceEnum, TeacherSupportModel, ClassAudienceModel, GroupAudienceModel,
+  UserAudienceModel, TeacherSupportModelType } from "./supports";
 import { UnitModel } from "../curriculum/unit";
 import { SupportModel } from "../curriculum/support";
 import { InvestigationModel } from "../curriculum/investigation";

--- a/src/models/stores/supports.ts
+++ b/src/models/stores/supports.ts
@@ -30,17 +30,17 @@ export type TeacherSupportSectionTarget = SectionType | AllSectionType;
 
 export const ClassAudienceModel = types
   .model("ClassAudienceModel", {
-    type: AudienceEnum.class,
+    type: types.optional(types.literal(AudienceEnum.class), AudienceEnum.class),
     identifier: types.undefined
   });
 export const GroupAudienceModel = types
   .model("ClassAudienceModel", {
-    type: AudienceEnum.group,
+    type: types.optional(types.literal(AudienceEnum.group), AudienceEnum.group),
     identifier: types.string
   });
 export const UserAudienceModel = types
   .model("ClassAudienceModel", {
-    type: AudienceEnum.user,
+    type: types.optional(types.literal(AudienceEnum.user), AudienceEnum.user),
     identifier: types.string
   });
 

--- a/src/models/stores/supports.ts
+++ b/src/models/stores/supports.ts
@@ -79,12 +79,13 @@ export const TeacherSupportModel = types
           : allSectionInfo.title;
       },
 
-      showForUserProblem(section: SectionType, groupId?: string) {
+      showForUserProblem(section: SectionType, groupId?: string, userId?: string) {
         const isUndeleted = !self.deleted;
         const isForSection = self.type === SupportItemType.problem
           || self.type === SupportItemType.section && self.sectionId === section;
         const isForUser = self.audience.type === AudienceEnum.class
-          || self.audience.type === AudienceEnum.group && self.audience.identifier === groupId;
+          || self.audience.type === AudienceEnum.group && self.audience.identifier === groupId
+          || self.audience.type === AudienceEnum.user && self.audience.identifier === userId;
 
         return isUndeleted && isForSection && isForUser;
       }
@@ -130,12 +131,14 @@ export const SupportsModel = types
         .concat(self.userSupports);
     },
 
-    getSupportsForUserProblem(sectionId: SectionType, groupId?: string): SupportItemModelType[] {
+    getSupportsForUserProblem(sectionId: SectionType, groupId?: string, userId?: string): SupportItemModelType[] {
       const curricularSupports = self.curricularSupports.filter((support) => {
         return (support.type === SupportItemType.section) && (support.sectionId === sectionId);
       });
 
-      const teacherSupports = self.teacherSupports.filter(support => support.showForUserProblem(sectionId, groupId));
+      const teacherSupports = self.teacherSupports.filter(support => {
+        return support.showForUserProblem(sectionId, groupId, userId);
+      });
 
       return curricularSupports.concat(teacherSupports);
     }


### PR DESCRIPTION
In addition to class supports, teachers can now author supports for a specific group or user through the dashboard. On top of that, supports can target a specific problem section in addition to targeting an entire problem.

The overall implementation looks something like this:
- When a support is created, note its target section + audience. Audience consists of an enum value (class, group or user) and an identifier (undefined, groupId or userId respectively). 
- Store the support in Firebase, using the target section and audience to create the correct path
- Listen to the supports path. When a change is received, the audience type (class/group/user) will be at the root, and all supports of that type for the offering will be beneath it
- Loop through the supports in the change and construct MST support models. Wipe out the old list of supports for that audience type and replace it