### PR TITLE
Drag toolbar buttons to create tools; and create in visible canvas

### DIFF
--- a/src/components/document/document-content.tsx
+++ b/src/components/document/document-content.tsx
@@ -66,6 +66,13 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
     this.mutationObserver.disconnect();
   }
 
+  public componentDidUpdate() {
+    // recalculate after render
+    requestAnimationFrame(() => {
+      this.updateVisibleRows();
+    });
+  }
+
   public render() {
     return (
       <div className="document-content"
@@ -184,7 +191,6 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
             this.domElement.scrollTop += newRowInContent.top - kScrollTopMargin - visibleContent.top;
           }
         }
-        this.updateVisibleRows();
       }
     }
   }

--- a/src/components/document/document-content.tsx
+++ b/src/components/document/document-content.tsx
@@ -23,7 +23,7 @@ interface IDragResizeRow {
   deltaHeight: number;
 }
 
-interface IDropRowInfo {
+export interface IDropRowInfo {
   rowInsertIndex: number;
   rowDropIndex?: number;
   rowDropLocation?: string;
@@ -279,31 +279,8 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
     const { content } = this.props;
     if (!content) return;
     const dragTileId = e.dataTransfer.getData(kDragTileId);
-    const srcRowId = content.findRowContainingTile(dragTileId);
-    if (!srcRowId) return;
-    const srcRowIndex = content.rowOrder.findIndex(rowId => rowId === srcRowId);
     const dropRowInfo  = this.getDropRowInfo(e);
-    const { rowInsertIndex, rowDropIndex, rowDropLocation } = dropRowInfo;
-    if ((rowDropIndex != null) && (rowDropLocation === "left")) {
-      content.moveTileToRow(dragTileId, rowDropIndex, 0);
-      return;
-    }
-    if ((rowDropIndex != null) && (rowDropLocation === "right")) {
-      content.moveTileToRow(dragTileId, rowDropIndex);
-      return;
-    }
-
-    if ((srcRowIndex >= 0)) {
-      // if only one tile in source row, move the entire row
-      if (content.numTilesInRow(srcRowId) === 1) {
-        if (rowInsertIndex !== srcRowIndex) {
-          content.moveRowToIndex(srcRowIndex, rowInsertIndex);
-        }
-      }
-      else {
-        content.moveTileToNewRow(dragTileId, rowInsertIndex);
-      }
-    }
+    content.moveTile(dragTileId, dropRowInfo);
   }
 
   private handleCopyTileDrop = (e: React.DragEvent<HTMLDivElement>) => {

--- a/src/components/document/document-content.tsx
+++ b/src/components/document/document-content.tsx
@@ -27,10 +27,6 @@ interface IDropRowInfo {
   rowInsertIndex: number;
   rowDropIndex?: number;
   rowDropLocation?: string;
-  dropOffsetLeft?: number;
-  dropOffsetTop?: number;
-  dropOffsetRight?: number;
-  dropOffsetBottom?: number;
   updateTimestamp?: number;
 }
 
@@ -242,21 +238,22 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
           // below the last row - highlight bottom of last row
           ((i === rowElements.length - 1) && (e.clientY > rowBounds.bottom))) {
         dropInfo.rowDropIndex = i;
-        dropInfo.dropOffsetLeft = Math.abs(e.clientX - rowBounds.left);
-        dropInfo.dropOffsetTop = Math.abs(e.clientY - rowBounds.top);
-        dropInfo.dropOffsetRight = Math.abs(rowBounds.right - e.clientX);
-        dropInfo.dropOffsetBottom = Math.abs(rowBounds.bottom - e.clientY);
+
+        const dropOffsetLeft = Math.abs(e.clientX - rowBounds.left);
+        const dropOffsetTop = Math.abs(e.clientY - rowBounds.top);
+        const dropOffsetRight = Math.abs(rowBounds.right - e.clientX);
+        const dropOffsetBottom = Math.abs(rowBounds.bottom - e.clientY);
 
         const kSideDropThreshold = rowBounds.width * 0.25;
-        if ((dropInfo.dropOffsetLeft < kSideDropThreshold) &&
-            (dropInfo.dropOffsetLeft < dropInfo.dropOffsetRight!)) {
+        if ((dropOffsetLeft < kSideDropThreshold) &&
+            (dropOffsetLeft < dropOffsetRight)) {
           dropInfo.rowDropLocation = "left";
         }
-        else if ((dropInfo.dropOffsetRight < kSideDropThreshold) &&
-                (dropInfo.dropOffsetRight <= dropInfo.dropOffsetLeft!)) {
+        else if ((dropOffsetRight < kSideDropThreshold) &&
+                (dropOffsetRight <= dropOffsetLeft)) {
           dropInfo.rowDropLocation = "right";
         }
-        else if (dropInfo.dropOffsetTop < dropInfo.dropOffsetBottom) {
+        else if (dropOffsetTop < dropOffsetBottom) {
           dropInfo.rowDropLocation = "top";
         }
         else {

--- a/src/components/document/document-content.tsx
+++ b/src/components/document/document-content.tsx
@@ -132,18 +132,21 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
   private renderRows() {
     const { content, ...others } = this.props;
     if (!content) { return null; }
-    const { rowMap, rowOrder, tileMap } = content;
+    const { rowMap, rowOrder, tileMap, highlightPendingDropLocation } = content;
     const { dropRowInfo } = this.state;
     let tabIndex = 1;
     this.rowRefs = [];
     return rowOrder.map((rowId, index) => {
       const row = rowMap.get(rowId);
       const rowHeight = this.getRowHeight(rowId);
-      const dropHighlight = dropRowInfo && (dropRowInfo.rowDropIndex != null) &&
+      let dropHighlight = dropRowInfo && (dropRowInfo.rowDropIndex != null) &&
                             (dropRowInfo.rowDropIndex === index) &&
                             dropRowInfo.rowDropLocation
                               ? dropRowInfo.rowDropLocation
                               : undefined;
+      if (!dropHighlight && index === highlightPendingDropLocation) {
+        dropHighlight = "bottom";
+      }
       const _tabIndex = tabIndex;
       tabIndex += row ? row.tiles.length : 0;
       return row

--- a/src/components/toolbar.tsx
+++ b/src/components/toolbar.tsx
@@ -44,7 +44,9 @@ export class ToolbarComponent extends BaseComponent<IProps, {}> {
         <div className="tool text" title="Text"
             onClick={handleClickTool("text")}
             onDragStart={handleDragTool("text")}
-            draggable={true}>
+            draggable={true}
+            onMouseEnter={this.showDropRowHighlight}
+            onMouseLeave={this.removeDropRowHighlight}>
           <svg className={`icon icon-text-tool`}>
             <use xlinkHref={`#icon-text-tool`} />
           </svg>
@@ -52,13 +54,17 @@ export class ToolbarComponent extends BaseComponent<IProps, {}> {
         <div className="tool table" title="Table"
             onClick={handleClickTool("table")}
             onDragStart={handleDragTool("table")}
-            draggable={true}>
+            draggable={true}
+            onMouseEnter={this.showDropRowHighlight}
+            onMouseLeave={this.removeDropRowHighlight}>
           <Icon icon="th" iconSize={20} color="white" />
         </div>
         <div className="tool geometry" title="Geometry"
             onClick={handleClickTool("geometry")}
             onDragStart={handleDragTool("geometry")}
-            draggable={true}>
+            draggable={true}
+            onMouseEnter={this.showDropRowHighlight}
+            onMouseLeave={this.removeDropRowHighlight}>
           <svg className={`icon icon-geometry-tool`}>
             <use xlinkHref={`#icon-geometry-tool`} />
           </svg>
@@ -66,7 +72,9 @@ export class ToolbarComponent extends BaseComponent<IProps, {}> {
         <div className="tool image" title="Image"
             onClick={handleClickTool("image")}
             onDragStart={handleDragTool("image")}
-            draggable={true}>
+            draggable={true}
+            onMouseEnter={this.showDropRowHighlight}
+            onMouseLeave={this.removeDropRowHighlight}>
         <svg className={`icon icon-image-tool`}>
             <use xlinkHref={`#icon-image-tool`} />
           </svg>
@@ -74,7 +82,9 @@ export class ToolbarComponent extends BaseComponent<IProps, {}> {
         <div className="tool drawing" title="Drawing"
             onClick={handleClickTool("drawing")}
             onDragStart={handleDragTool("drawing")}
-            draggable={true}>
+            draggable={true}
+            onMouseEnter={this.showDropRowHighlight}
+            onMouseLeave={this.removeDropRowHighlight}>
           <svg className={`icon icon-drawing-tool`}>
             <use xlinkHref={`#icon-drawing-tool`} />
           </svg>
@@ -86,6 +96,16 @@ export class ToolbarComponent extends BaseComponent<IProps, {}> {
         </div>
       </div>
     );
+  }
+
+  private showDropRowHighlight = () => {
+    const { document } = this.props;
+    document.content.highlightLastVisibleRow(true);
+  }
+
+  private removeDropRowHighlight = () => {
+    const { document } = this.props;
+    document.content.highlightLastVisibleRow(false);
   }
 
   private handleAddToolTile(tool: DocumentTool) {

--- a/src/components/toolbar.tsx
+++ b/src/components/toolbar.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 
 import { BaseComponent, IBaseProps } from "./base";
 import { DocumentModelType, DocumentTool } from "../models/document/document";
-import { IToolApiMap } from "./tools/tool-tile";
+import { IToolApiMap, kDragTileCreate  } from "./tools/tool-tile";
 import { Icon } from "@blueprintjs/core";
 
 import "./toolbar.sass";
@@ -29,6 +29,11 @@ export class ToolbarComponent extends BaseComponent<IProps, {}> {
         }
       };
     };
+    const handleDragTool = (tool: DocumentTool) => {
+      return (e: React.DragEvent<HTMLDivElement>) => {
+        this.handleDragNewToolTile(tool, e);
+      };
+    };
     return (
       <div className="toolbar">
         <div className="tool select" title="Select" onClick={handleClickTool("select")}>
@@ -36,25 +41,40 @@ export class ToolbarComponent extends BaseComponent<IProps, {}> {
             <use xlinkHref={`#icon-select-tool`} />
           </svg>
         </div>
-        <div className="tool text" title="Text" onClick={handleClickTool("text")}>
+        <div className="tool text" title="Text"
+            onClick={handleClickTool("text")}
+            onDragStart={handleDragTool("text")}
+            draggable={true}>
           <svg className={`icon icon-text-tool`}>
             <use xlinkHref={`#icon-text-tool`} />
           </svg>
         </div>
-        <div className="tool table" title="Table" onClick={handleClickTool("table")}>
+        <div className="tool table" title="Table"
+            onClick={handleClickTool("table")}
+            onDragStart={handleDragTool("table")}
+            draggable={true}>
           <Icon icon="th" iconSize={20} color="white" />
         </div>
-        <div className="tool geometry" title="Geometry" onClick={handleClickTool("geometry")}>
+        <div className="tool geometry" title="Geometry"
+            onClick={handleClickTool("geometry")}
+            onDragStart={handleDragTool("geometry")}
+            draggable={true}>
           <svg className={`icon icon-geometry-tool`}>
             <use xlinkHref={`#icon-geometry-tool`} />
           </svg>
         </div>
-        <div className="tool image" title="Image" onClick={handleClickTool("image")}>
+        <div className="tool image" title="Image"
+            onClick={handleClickTool("image")}
+            onDragStart={handleDragTool("image")}
+            draggable={true}>
         <svg className={`icon icon-image-tool`}>
             <use xlinkHref={`#icon-image-tool`} />
           </svg>
         </div>
-        <div className="tool drawing" title="Drawing" onClick={handleClickTool("drawing")}>
+        <div className="tool drawing" title="Drawing"
+            onClick={handleClickTool("drawing")}
+            onDragStart={handleDragTool("drawing")}
+            draggable={true}>
           <svg className={`icon icon-drawing-tool`}>
             <use xlinkHref={`#icon-drawing-tool`} />
           </svg>
@@ -90,5 +110,9 @@ export class ToolbarComponent extends BaseComponent<IProps, {}> {
         document.deleteTile(selectedTileId);
       }
     }
+  }
+
+  private handleDragNewToolTile(tool: DocumentTool, e: React.DragEvent<HTMLDivElement>) {
+    e.dataTransfer.setData(kDragTileCreate, tool);
   }
 }

--- a/src/components/tools/tool-tile.tsx
+++ b/src/components/tools/tool-tile.tsx
@@ -35,6 +35,7 @@ export const kDragRowHeight = "org.concord.clue.row.height";
 export const kDragTileSource = "org.concord.clue.tile.src";
 export const kDragTileId = "org.concord.clue.tile.id";
 export const kDragTileContent = "org.concord.clue.tile.content";
+export const kDragTileCreate = "org.concord.clue.tile.create";
 // allows source compatibility to be checked in dragOver
 export const dragTileSrcDocId = (id: string) => `org.concord.clue.src.${id}`;
 export const dragTileType = (type: string) => `org.concord.clue.tile.type.${type}`;

--- a/src/models/document/document-content.test.ts
+++ b/src/models/document/document-content.test.ts
@@ -1,0 +1,146 @@
+import { DocumentContentModel, DocumentContentModelType } from "./document-content";
+
+describe("document-content model", () => {
+  let documentContent: DocumentContentModelType;
+
+  beforeEach(() => {
+    documentContent = DocumentContentModel.create({});
+  });
+
+  it("allows the tool tiles to be added", () => {
+    expect(documentContent.tileMap.size).toBe(0);
+    documentContent.addTile("text");
+    expect(documentContent.tileMap.size).toBe(1);
+    // adding geometry tool adds sidecar text tool
+    documentContent.addTile("geometry", true);
+    expect(documentContent.tileMap.size).toBe(3);
+  });
+
+  it("allows the tool tiles to be added as new rows at specified locations", () => {
+    documentContent.addTile("text");
+    const textTile2 = documentContent.addTile("text");
+
+    let textTile2RowId = documentContent.findRowContainingTile(textTile2!.tileId);
+    let textTile2RowIndex1 = documentContent.rowOrder.findIndex(id => id === textTile2RowId);
+
+    expect(textTile2RowIndex1).toBe(1);
+
+    // insert image between text tiles
+    const imageTile1 = documentContent.addTile("image", false, {
+      rowInsertIndex: 1,
+      rowDropIndex: 1,
+      rowDropLocation: "bottom"
+    });
+
+    const imageTile1rowId = documentContent.findRowContainingTile(imageTile1!.tileId);
+    const imageTile1rowIndex1 = documentContent.rowOrder.findIndex(id => id === imageTile1rowId);
+
+    expect(imageTile1rowIndex1).toBe(1);
+
+    // text tile should have shifted down
+    textTile2RowId = documentContent.findRowContainingTile(textTile2!.tileId);
+    textTile2RowIndex1 = documentContent.rowOrder.findIndex(id => id === textTile2RowId);
+
+    expect(textTile2RowIndex1).toBe(2);
+
+    // insert image at bottom
+    const imageTile2 = documentContent.addTile("image", false, {
+      rowInsertIndex: 3,
+      rowDropIndex: 3,
+      rowDropLocation: "bottom"
+    });
+
+    const rowId2 = documentContent.findRowContainingTile(imageTile2!.tileId);
+    const rowIndex2 = documentContent.rowOrder.findIndex(id => id === rowId2);
+
+    expect(rowIndex2).toBe(3);
+  });
+
+  it("allows the tool tiles to be added at side of existing rows", () => {
+    documentContent.addTile("text");
+    const textTile2 = documentContent.addTile("text");
+
+    let textTile2RowId = documentContent.findRowContainingTile(textTile2!.tileId);
+    let textTile2RowIndex1 = documentContent.rowOrder.findIndex(id => id === textTile2RowId);
+
+    expect(textTile2RowIndex1).toBe(1);
+
+    const imageTile1 = documentContent.addTile("image", false, {
+      rowInsertIndex: 1,
+      rowDropIndex: 1,
+      rowDropLocation: "left"
+    });
+
+    const imageTile1rowId = documentContent.findRowContainingTile(imageTile1!.tileId);
+    const imageTile1rowIndex1 = documentContent.rowOrder.findIndex(id => id === imageTile1rowId);
+
+    expect(imageTile1rowIndex1).toBe(1);
+
+    // text tile should still be on 1 as well
+    textTile2RowId = documentContent.findRowContainingTile(textTile2!.tileId);
+    textTile2RowIndex1 = documentContent.rowOrder.findIndex(id => id === textTile2RowId);
+
+    expect(textTile2RowIndex1).toBe(1);
+  });
+
+  it("allows the geometry tiles to be added with sidecar text as new row", () => {
+    documentContent.addTile("text");
+    const textTile2 = documentContent.addTile("text");
+
+    const graphTileInfo = documentContent.addTile("geometry", true, {
+      rowInsertIndex: 1,
+      rowDropIndex: 1,
+      rowDropLocation: "bottom"
+    });
+
+    const geometryRowId = documentContent.findRowContainingTile(graphTileInfo!.tileId);
+    const geometryRowIndex = documentContent.rowOrder.findIndex(id => id === geometryRowId);
+
+    expect(geometryRowIndex).toBe(1);
+
+    // sidecar text tile should be on same row
+    expect(graphTileInfo!.additionalTileIds).toBeDefined();
+
+    const sidecarRowId = documentContent.findRowContainingTile(graphTileInfo!.tileId);
+    const sidecarRowIndex = documentContent.rowOrder.findIndex(id => id === sidecarRowId);
+
+    expect(sidecarRowIndex).toBe(1);
+
+    // text tile should be on 2
+    const textTile2RowId = documentContent.findRowContainingTile(textTile2!.tileId);
+    const textTile2RowIndex1 = documentContent.rowOrder.findIndex(id => id === textTile2RowId);
+
+    expect(textTile2RowIndex1).toBe(2);
+  });
+
+  it("allows the geometry tiles to be added with sidecar text at side of existing rows", () => {
+    documentContent.addTile("text");
+    const textTile2 = documentContent.addTile("text");
+
+    const graphTileInfo = documentContent.addTile("geometry", true, {
+      rowInsertIndex: 1,
+      rowDropIndex: 1,
+      rowDropLocation: "left"
+    });
+
+    const geometryRowId = documentContent.findRowContainingTile(graphTileInfo!.tileId);
+    const geometryRowIndex = documentContent.rowOrder.findIndex(id => id === geometryRowId);
+
+    expect(geometryRowIndex).toBe(1);
+
+    // sidecar text tile should be on same row
+    expect(graphTileInfo!.additionalTileIds).toBeDefined();
+
+    const sidecarRowId = documentContent.findRowContainingTile(graphTileInfo!.tileId);
+    const sidecarRowIndex = documentContent.rowOrder.findIndex(id => id === sidecarRowId);
+
+    expect(sidecarRowIndex).toBe(1);
+
+    // original text tile should be on 1 as well
+    const textTile2RowId = documentContent.findRowContainingTile(textTile2!.tileId);
+    const textTile2RowIndex1 = documentContent.rowOrder.findIndex(id => id === textTile2RowId);
+
+    expect(textTile2RowIndex1).toBe(1);
+  });
+
+});

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -310,19 +310,31 @@ export const DocumentContentModel = types
     }
   }))
   .actions((self) => ({
-    addTile(tool: DocumentTool, addSidecarNotes?: boolean) {
+    addTile(tool: DocumentTool, addSidecarNotes?: boolean, insertRowInfo?: IDropRowInfo) {
+      let tileInfo;
       switch (tool) {
         case "text":
-          return self.addTextTile();
+          tileInfo = self.addTextTile();
+          break;
         case "table":
-          return self.addTableTile();
+          tileInfo = self.addTableTile();
+          break;
         case "geometry":
-          return self.addGeometryTile(addSidecarNotes);
+          tileInfo = self.addGeometryTile(addSidecarNotes);
+          break;
         case "image":
-          return self.addImageTile();
+          tileInfo = self.addImageTile();
+          break;
         case "drawing":
-          return self.addDrawingTile();
+          tileInfo = self.addDrawingTile();
+          break;
       }
+
+      if (tileInfo && insertRowInfo) {
+        self.moveTile(tileInfo.tileId, insertRowInfo);
+      }
+
+      return tileInfo;
     }
   }));
 

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -42,6 +42,9 @@ export const DocumentContentModel = types
             ? migrateSnapshot(snapshot)
             : snapshot;
   })
+  .volatile(self => ({
+    visibleRows: [] as string[]
+  }))
   .views(self => {
     // used for drag/drop self-drop detection, for instance
     const contentId = uuid();
@@ -126,6 +129,9 @@ export const DocumentContentModel = types
     deleteRow(rowId: string) {
       self.rowOrder.remove(rowId);
       self.rowMap.delete(rowId);
+    },
+    setVisibleRows(rows: string[]) {
+      self.visibleRows = rows;
     }
   }))
   .actions(self => ({

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -13,6 +13,7 @@ import * as uuid from "uuid/v4";
 import { Logger, LogEventName } from "../../lib/logger";
 import { DocumentsModelType } from "../stores/documents";
 import { getParentWithTypeName } from "../../utilities/mst-utils";
+import { IDropRowInfo } from "../../components/document/document-content";
 
 export interface NewRowOptions {
   rowHeight?: number;
@@ -275,6 +276,34 @@ export const DocumentContentModel = types
       else {
         if (!srcRow.isUserResizable) {
           srcRow.height = undefined;
+        }
+      }
+    }
+  }))
+  .actions((self) => ({
+    moveTile(tileId: string, rowInfo: IDropRowInfo) {
+      const srcRowId = self.findRowContainingTile(tileId);
+      if (!srcRowId) return;
+      const srcRowIndex = self.rowOrder.findIndex(rowId => rowId === srcRowId);
+      const { rowInsertIndex, rowDropIndex, rowDropLocation } = rowInfo;
+      if ((rowDropIndex != null) && (rowDropLocation === "left")) {
+        self.moveTileToRow(tileId, rowDropIndex, 0);
+        return;
+      }
+      if ((rowDropIndex != null) && (rowDropLocation === "right")) {
+        self.moveTileToRow(tileId, rowDropIndex);
+        return;
+      }
+
+      if ((srcRowIndex >= 0)) {
+        // if only one tile in source row, move the entire row
+        if (self.numTilesInRow(srcRowId) === 1) {
+          if (rowInsertIndex !== srcRowIndex) {
+            self.moveRowToIndex(srcRowIndex, rowInsertIndex);
+          }
+        }
+        else {
+          self.moveTileToNewRow(tileId, rowInsertIndex);
         }
       }
     }

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -79,6 +79,13 @@ export const DocumentContentModel = types
         const row = self.rowMap.get(rowId);
         return row ? row.tiles.length : 0;
       },
+      getLastVisibleRow() {
+        // returns last visible row or last row
+        const lastVisibleRowId = self.visibleRows.length
+          ? self.visibleRows[self.visibleRows.length - 1]
+          : self.rowOrder[self.rowOrder.length - 1];
+        return  self.rowOrder.indexOf(lastVisibleRowId);
+      },
       publish() {
         const snapshot = cloneDeep(getSnapshot(self));
         const idMap: { [id: string]: string } = {};
@@ -138,6 +145,10 @@ export const DocumentContentModel = types
     addTileInNewRow(content: ToolContentUnionType, options?: NewRowOptions): INewRowTile {
       const tile = ToolTileModel.create({ content });
       const o = options || {};
+      if (o.rowIndex === undefined) {
+        // by default, insert new tiles after last visible on screen
+        o.rowIndex = self.getLastVisibleRow() + 1;
+      }
       const row = TileRowModel.create();
       row.insertTileInRow(tile);
       if (o.rowHeight) {

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -14,6 +14,7 @@ import { Logger, LogEventName } from "../../lib/logger";
 import { DocumentsModelType } from "../stores/documents";
 import { getParentWithTypeName } from "../../utilities/mst-utils";
 import { IDropRowInfo } from "../../components/document/document-content";
+import { DocumentTool } from "./document";
 
 export interface NewRowOptions {
   rowHeight?: number;
@@ -305,6 +306,22 @@ export const DocumentContentModel = types
         else {
           self.moveTileToNewRow(tileId, rowInsertIndex);
         }
+      }
+    }
+  }))
+  .actions((self) => ({
+    addTile(tool: DocumentTool, addSidecarNotes?: boolean) {
+      switch (tool) {
+        case "text":
+          return self.addTextTile();
+        case "table":
+          return self.addTableTile();
+        case "geometry":
+          return self.addGeometryTile(addSidecarNotes);
+        case "image":
+          return self.addImageTile();
+        case "drawing":
+          return self.addDrawingTile();
       }
     }
   }));

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -43,7 +43,8 @@ export const DocumentContentModel = types
             : snapshot;
   })
   .volatile(self => ({
-    visibleRows: [] as string[]
+    visibleRows: [] as string[],
+    highlightPendingDropLocation: -1
   }))
   .views(self => {
     // used for drag/drop self-drop detection, for instance
@@ -162,6 +163,13 @@ export const DocumentContentModel = types
 
       return { rowId: row.id, tileId: tile.id };
     },
+    highlightLastVisibleRow(show: boolean) {
+      if (!show) {
+        self.highlightPendingDropLocation = -1;
+      } else {
+        self.highlightPendingDropLocation = self.getLastVisibleRow();
+      }
+    }
   }))
   .actions((self) => ({
     addGeometryTile(addSidecarNotes?: boolean) {

--- a/src/models/document/document.ts
+++ b/src/models/document/document.ts
@@ -57,18 +57,7 @@ export const DocumentModel = types
     },
 
     addTile(tool: DocumentTool, addSidecarNotes?: boolean) {
-      switch (tool) {
-        case "text":
-          return self.content.addTextTile();
-        case "table":
-          return self.content.addTableTile();
-        case "geometry":
-          return self.content.addGeometryTile(addSidecarNotes);
-        case "image":
-          return self.content.addImageTile();
-        case "drawing":
-          return self.content.addDrawingTile();
-      }
+      return self.content.addTile(tool, addSidecarNotes);
     },
 
     deleteTile(tileId: string) {


### PR DESCRIPTION
This adds the ability to drag in toolbar buttons in order to insert tools at specified locations. The ability to click to add tools to the bottom is retained.

The bulk of this work is simply refactoring existing code in order to support the ability for the `document-content` to easily create a new tile of a type, and then move that tile to a new location.

A little bit of verbose code was added to the moving of the newly-created tiles, to support the moving sidecar text tiles alongside the geometry tiles.

The only real new code is 4fa4082, which makes the tool buttons draggable, and adds a data field that tells `document-content.tsx` which new tile to create.