### PR TITLE
163028478 load left nav improvements

### DIFF
--- a/cypress/integration/canvas_test_spec.js
+++ b/cypress/integration/canvas_test_spec.js
@@ -20,7 +20,7 @@ context('Test Canvas', function(){
        describe('test header elements', function(){
            it('verifies header title appears correctly', function(){
                 leftNav.openLeftNavTab('Introduction');
-                leftNav.openToWorkspace();
+                leftNav.openToWorkspace('Introduction');
                 canvas.getCanvasTitle().should('contain','Introduction');
            });
 
@@ -37,7 +37,7 @@ context('Test Canvas', function(){
                canvas.getSouthEastCanvas().should('be.visible');
                canvas.getSouthEastCanvas().should('be.visible');
                // canvas.getSingleCanvas().should('not.be.visible');
-               
+
                //can get back to 1 up view from 4 up
                canvas.openOneUpViewFromFourUp();
                canvas.getSingleCanvas().should('be.visible');
@@ -140,7 +140,7 @@ context('Test Canvas', function(){
                 // let canvas2='Introduction';
                 // //open the my work tab, click a different canvas, verify canvas is shown, open the my work tab, click the introduction canvas, verify intro canvas is showing
                 // leftNav.openLeftNavTab('Initial Challenge');
-                // leftNav.openToWorkspace();
+                // leftNav.openToWorkspace('Initial Challenge');
                 // canvas.getCanvasTitle().should('contain',canvas1);
                 // rightNav.openMyWorkTab();
                 // rightNav.openMyWorkAreaCanvasItem(canvas1);
@@ -159,7 +159,7 @@ context('Test Canvas', function(){
                 // });
                 //open the my work tab, click a different canvas, verify canvas is shown, open the my work tab, click the introduction canvas, verify intro canvas is showing
                 cy.get('#leftNavTab1').click();
-                cy.get('.left-nav-panel > .section > .canvas > .document-content > .buttons > button').click();
+                cy.get('#leftNavContainer1 > .left-nav-panel > .section > .canvas > .document-content > .buttons > button').click();
                 cy.get('.single-workspace > .document > .titlebar > .title').should('contain','Initial');
                 cy.get('#rightNavTabMy\\ Work').click({force:true});
                 cy.get('.list > .list-item[title*="Initial"]').click();
@@ -177,10 +177,10 @@ context('Test Canvas', function(){
         describe('verify that if user opens same canvas from on left-nav tab, saved canvas opens', function() {
             it('will restore from left nav', ()=>{
                 leftNav.openLeftNavTab('What if');
-                leftNav.openToWorkspace();
+                leftNav.openToWorkspace('What if');
                 canvas.getCanvasTitle().should('contain', 'What if');
                 leftNav.openLeftNavTab('Introduction');
-                leftNav.openToWorkspace();
+                leftNav.openToWorkspace('Introduction');
                 canvas.getCanvasTitle().should('contain','Introduction');
                 //verify text element with Hello World in showing
                 canvas.getTextTile().first().should('contain', 'Hello World');
@@ -194,13 +194,13 @@ context('Test Canvas', function(){
             it('verify canvas stays in 4up view when changing canvases', ()=>{
                 //Open a canvas
                 leftNav.openLeftNavTab('Initial Challenge');
-                leftNav.openToWorkspace();
+                leftNav.openToWorkspace('Initial Challenge');
                 canvas.getCanvasTitle().should('contain','Initial');
                 //switch to 4-up view
                 canvas.openFourUpView();
                 //open another canvas
                 leftNav.openLeftNavTab('What if');
-                leftNav.openToWorkspace();
+                leftNav.openToWorkspace('What if');
                 canvas.getCanvasTitle().should('contain','What if');
                 canvas.getFourUpView().should('be.visible');
                 //Re-open Initial Challenge canvas from My Work

--- a/cypress/integration/left_nav_test_spec.js
+++ b/cypress/integration/left_nav_test_spec.js
@@ -15,7 +15,7 @@ describe('Test Left tabs',function(){
          for (i = 0; i < $tab.length - 1; i++) {
              let title = $tab.text;
              cy.get('#leftNavTab' + i).click({force:true});
-                 leftNav.getOpenToWorkspaceButton().should('contain', titleArr[i]).click({force: true});
+                 leftNav.getOpenToWorkspaceButton(i).should('contain', titleArr[i]).click({force: true});
                      canvas.getCanvasTitle().should('contain', titleArr[i]);
          }
      })

--- a/cypress/integration/workspace_test_spec.js
+++ b/cypress/integration/workspace_test_spec.js
@@ -72,7 +72,7 @@ context('Test the overall workspace', function(){
             cy.wait(1000);
 
             leftNav.openLeftNavTab(tab1);
-            leftNav.openToWorkspace();
+            leftNav.openToWorkspace(tab1);
             cy.wait(1000);
             canvas.getCanvasTitle()
                 .then(($titleLoc)=>{
@@ -87,7 +87,7 @@ context('Test the overall workspace', function(){
             cy.visit(baseUrl+'?appMode=qa&fakeClass=5&fakeUser=student:1&qaGroup=1&problem='+problem2);
             cy.wait(1000);
             leftNav.openLeftNavTab(tab1);
-            leftNav.openToWorkspace();
+            leftNav.openToWorkspace(tab1);
             cy.wait(1000);
             canvas.getCanvasTitle().should('contain',tab1);
             canvas.getTextTile().should('not.exist');
@@ -97,7 +97,7 @@ context('Test the overall workspace', function(){
             cy.visit(baseUrl+'?appMode=qa&fakeClass=5&fakeUser=student:1&qaGroup=1&problem='+problem1);
             cy.wait(1000);
             leftNav.openLeftNavTab(tab1);
-            leftNav.openToWorkspace();
+            leftNav.openToWorkspace(tab1);
             cy.wait(1000);
             canvas.getCanvasTitle().should('contain',tab1);
             canvas.getTextTile().last().should('contain', 'Problem '+problem1);

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -48,7 +48,7 @@ Cypress.Commands.add("setupGroup", (students, group) => {
         cy.wait(2000);
         cy.visit(baseUrl+'?appMode=qa&qaGroup='+group+'&fakeClass='+qaClass+'&fakeUser=student:'+students[i]+'&problem='+problem);
         leftNav.openLeftNavTab('Now What')
-            leftNav.openToWorkspace();
+            leftNav.openToWorkspace('Now What');
         canvas.addTextTile();
         canvas.enterText('This is to test the 4-up view of S'+students[i]);
         canvas.getTextTile().last().should('contain', '4-up').and('contain','S'+students[i]);

--- a/cypress/support/elements/LeftNav.js
+++ b/cypress/support/elements/LeftNav.js
@@ -52,24 +52,8 @@ class LeftNav{
     }
 
     openToWorkspace(title) {
-        let index = -1;
-        switch(title){
-            case 'Introduction':
-                index = 0;
-                break;
-            case 'Initial Challenge':
-                index = 1;
-                break;
-            case 'What if':
-                index = 2;
-                break;
-            case 'Now What':
-                index = 3;
-                break;
-            case 'Extra Workspace':
-                index = 4;
-                break;
-        }
+        const workspaces = ['Introduction', 'Initial Challenge', 'What if', 'Now What', 'Extra Workspace'];
+        const index = workspaces.indexOf(title);
         this.openLeftNavTab(title);
         this.getOpenToWorkspaceButton(index).click({force:true});
     }

--- a/cypress/support/elements/LeftNav.js
+++ b/cypress/support/elements/LeftNav.js
@@ -47,13 +47,31 @@ class LeftNav{
         }
     }
 
-    getOpenToWorkspaceButton(){
-        return cy.get('[data-test=open-document-button]');
+    getOpenToWorkspaceButton(index){
+        return cy.get('#leftNavContainer' + index).find('[data-test=open-document-button]');
     }
 
     openToWorkspace(title) {
+        let index = -1;
+        switch(title){
+            case 'Introduction':
+                index = 0;
+                break;
+            case 'Initial Challenge':
+                index = 1;
+                break;
+            case 'What if':
+                index = 2;
+                break;
+            case 'Now What':
+                index = 3;
+                break;
+            case 'Extra Workspace':
+                index = 4;
+                break;
+        }
         this.openLeftNavTab(title);
-        this.getOpenToWorkspaceButton().click({force:true});
+        this.getOpenToWorkspaceButton(index).click({force:true});
     }
 }
 export default LeftNav;

--- a/cypress/support/elements/Workspace.js
+++ b/cypress/support/elements/Workspace.js
@@ -18,7 +18,7 @@ class Workspace{
                 var i=0;
                 for (i=0;i<$tabList.length;i++){
                     cy.get('#leftNavTab'+i).click({force:true});
-                    this.leftnav.openToWorkspace();
+                    this.leftnav.getOpenToWorkspaceButton(i).click({force:true});
                     this.canvas.publishCanvas();
                 }
                 // cy.get('#leftNavTab'+i).click({force:true}); //Close the last tab--leaving clean up to individual tests for now

--- a/src/components/navigation/left-nav.sass
+++ b/src/components/navigation/left-nav.sass
@@ -55,3 +55,6 @@
 
     &.expanded
       background: $color4-selected
+
+    .disabled
+      display: none

--- a/src/components/navigation/left-nav.tsx
+++ b/src/components/navigation/left-nav.tsx
@@ -11,9 +11,20 @@ interface IProps extends IBaseProps {
   isGhostUser: boolean;
 }
 
+interface IState {
+  tabLoadAllowed: { [tab: number]: boolean };
+}
+
 @inject("stores")
 @observer
-export class LeftNavComponent extends BaseComponent<IProps, {}> {
+export class LeftNavComponent extends BaseComponent<IProps, IState> {
+
+  constructor(props: IProps) {
+    super(props);
+    this.state = {
+      tabLoadAllowed: {}
+    };
+  }
 
   public render() {
     const { problem, ui } = this.stores;
@@ -43,7 +54,16 @@ export class LeftNavComponent extends BaseComponent<IProps, {}> {
           aria-labelledby={this.getTabId(activeSectionIndex)}
           aria-hidden={ui.leftNavExpanded}
         >
-          <LeftNavPanelComponent section={activeSection} isGhostUser={this.props.isGhostUser} />
+          {sections.map((section, index) => {
+            return (
+              this.state.tabLoadAllowed[index]
+              ? <div className={"container " + (activeSectionIndex === index ? "enabled" : "disabled")} key={index}>
+                  <LeftNavPanelComponent section={section} isGhostUser={this.props.isGhostUser} key={index} />
+                </div>
+              : null
+            );
+          })}
+
         </div>
       </div>
     );
@@ -59,7 +79,14 @@ export class LeftNavComponent extends BaseComponent<IProps, {}> {
       else {
         this.stores.ui.toggleLeftNav();
       }
+      this.updateTabLoadAllowedState(sectionIndex);
     };
+  }
+
+  private updateTabLoadAllowedState = (sectionIndex: number) => {
+    const tabLoadAllowed = this.state.tabLoadAllowed;
+    tabLoadAllowed[sectionIndex] = true;
+    this.setState({ tabLoadAllowed });
   }
 
   private getTabId(sectionIndex: number) {

--- a/src/components/navigation/left-nav.tsx
+++ b/src/components/navigation/left-nav.tsx
@@ -57,7 +57,10 @@ export class LeftNavComponent extends BaseComponent<IProps, IState> {
           {sections.map((section, index) => {
             return (
               this.state.tabLoadAllowed[index]
-              ? <div className={"container " + (activeSectionIndex === index ? "enabled" : "disabled")} key={index}>
+              ? <div
+                  id={this.getContainerId(index)}
+                  className={"container " + (activeSectionIndex === index ? "enabled" : "disabled")}
+                  key={index}>
                   <LeftNavPanelComponent section={section} isGhostUser={this.props.isGhostUser} key={index} />
                 </div>
               : null
@@ -91,5 +94,9 @@ export class LeftNavComponent extends BaseComponent<IProps, IState> {
 
   private getTabId(sectionIndex: number) {
     return `leftNavTab${sectionIndex}`;
+  }
+
+  private getContainerId(sectionIndex: number) {
+    return `leftNavContainer${sectionIndex}`;
   }
 }


### PR DESCRIPTION
Once a tab is clicked on the left nav panel, the tab contents will now stay loaded.  This is to prevent lag caused by reloading content every time a tab is clicked.  

As a result, the Cypress tests needed to be updated to accommodate this new structure.  Previously, we loaded a single tab at a time, so there was always a single "open" button to load the workspace.  If, for example, you wanted to load the Initial Challenge workspace, you simply clicked on the Initial Challenge tab and then clicked on the Open button.  Now, however, multiple tabs, each with their own Open button, might be loaded at the same time.  Hence we need to be more explicit when loading a workspace to ensure that we target the correct open button.  @kevinsantos-cc @eireland I'm open to suggestions when it comes to the Cypress code.  I tried to follow the existing model, but we could tweak if you think there is a better way to handle this. 