### PR TITLE
Re-fix rollbar updateText() bug

### DIFF
--- a/src/components/tools/geometry-tool/geometry-tool.tsx
+++ b/src/components/tools/geometry-tool/geometry-tool.tsx
@@ -252,7 +252,7 @@ class GeometryToolComponentImpl extends BaseComponent<IProps, IState> {
       // delay so any asynchronous JSXGraph actions have time to complete
       setTimeout(() => {
         JXG.JSXGraph.freeBoard(board);
-      }, 100);
+      });
     }
 
     this._isMounted = false;


### PR DESCRIPTION
Waiting too long to call freeBoard() in componentWillUnmount() confuses JSXGraph.

The previous fix added a setTimeout() call to allow any JSXGraph asynchronous operations to complete. An arbitrary timeout of 100ms was chosen. This had adverse side effects that were visible when switching between views (for instance), and so the timeout was reduced to the minimum value, which still is sufficient to eliminate the original bug without introducing the new issues.