### PR TITLE
Common geometry improvements

### DIFF
--- a/src/components/tools/geometry-tool/geometry-tool.tsx
+++ b/src/components/tools/geometry-tool/geometry-tool.tsx
@@ -80,6 +80,10 @@ function syncBoardChanges(board: JXG.Board, content: GeometryContentModelType,
       if (result instanceof JXG.GeometryElement) {
         newElements.push(result);
       }
+      else if (Array.isArray(result)) {
+        const elts = result as JXG.GeometryElement[];
+        newElements.push(...elts);
+      }
       if (change.operation === "update") {
         const ids = castArray(change.targetID);
         const targets = ids.map(id => board.objects[id]);

--- a/src/models/tools/geometry/geometry-content.ts
+++ b/src/models/tools/geometry/geometry-content.ts
@@ -59,9 +59,11 @@ export type GeometryMetadataModelType = Instance<typeof GeometryMetadataModel>;
 export function setElementColor(board: JXG.Board, id: string, selected: boolean) {
   const element = board.objects[id];
   if (element) {
+    const fillColor = element.getAttribute("clientFillColor") || kPointDefaults.fillColor;
+    const strokeColor = element.getAttribute("clientStrokeColor") || kPointDefaults.strokeColor;
     element.setAttribute({
-              fillColor: selected ? kPointDefaults.selectedFillColor : kPointDefaults.fillColor,
-              strokeColor: selected ? kPointDefaults.selectedStrokeColor : kPointDefaults.strokeColor
+              fillColor: selected ? kPointDefaults.selectedFillColor : fillColor,
+              strokeColor: selected ? kPointDefaults.selectedStrokeColor : strokeColor
             });
   }
 }
@@ -144,6 +146,11 @@ export const GeometryContentModel = types
           if (isBoard(elt)) {
             board = elt as JXG.Board;
             board.suspendUpdate();
+          }
+          else if (Array.isArray(elt)) {
+            if (onCreate) {
+              elt.forEach(el => onCreate(el as JXG.GeometryElement));
+            }
           }
           else if (elt && onCreate) {
             onCreate(elt as JXG.GeometryElement);

--- a/src/models/tools/geometry/jxg-changes.ts
+++ b/src/models/tools/geometry/jxg-changes.ts
@@ -21,7 +21,7 @@ export interface JXGChange {
 }
 
 export type JXGElement = JXG.Board | JXG.Point;
-export type JXGChangeResult = JXGElement | undefined;
+export type JXGChangeResult = JXGElement | JXGElement[] | undefined;
 
 // for create/board the board parameter is the ID of the DOM element
 // for all other changes it should be the board


### PR DESCRIPTION
In his movable line PR (#224) @ekosmin encountered the need for some geometry improvements that I had already made as part of my linked table-geometry work. This PR extracts those pieces for common use.

- setElementColor() supports clientFillColor and clientStrokeColor
- applyChange() can return multiple new elements
- applyChange() dispatches delete/object by object type