### PR TITLE
Add import of blueprint that was removed as part of geometry toolbar refactor

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -18,6 +18,7 @@ import { setLivelynessChecking } from "mobx-state-tree";
 // set to true to enable MST liveliness checking
 const kEnableLivelinessChecking = false;
 
+import "./components/utilities/blueprint";
 import "./index.sass";
 
 function getCurriculumJson() {


### PR DESCRIPTION
The effect was that Blueprint CSS was not imported, which meant that menus and dialogs in the table weren't formatted properly.