### PR TITLE
Support arbitrary axis scales in curriculum authoring [#163750284]

### DIFF
--- a/src/models/tools/geometry/jxg-changes.ts
+++ b/src/models/tools/geometry/jxg-changes.ts
@@ -12,6 +12,8 @@ export interface JXGProperties {
   id?: string;
   position?: JXGCoordPair;
   url?: string;
+  unitX?: number;
+  unitY?: number;
   [key: string]: any;
 }
 

--- a/src/utilities/graph-utils.test.ts
+++ b/src/utilities/graph-utils.test.ts
@@ -1,0 +1,21 @@
+import { goodTickValue } from "./graph-utils";
+
+describe("goodTickValue", () => {
+
+  it("goodTickValue() works as expected", () => {
+    expect(goodTickValue(0)).toEqual([1, 4]);
+    expect(goodTickValue(1)[0]).toBeCloseTo(0.2);
+    expect(goodTickValue(5)).toEqual([1, 4]);
+    expect(goodTickValue(8)).toEqual([1, 4]);
+    expect(goodTickValue(10)).toEqual([1, 4]);
+    expect(goodTickValue(12)).toEqual([2, 1]);
+    expect(goodTickValue(15)).toEqual([2, 1]);
+    expect(goodTickValue(20)).toEqual([2, 1]);
+    expect(goodTickValue(25)).toEqual([2, 1]);
+    expect(goodTickValue(30)).toEqual([5, 4]);
+    expect(goodTickValue(200)).toEqual([20, 1]);
+    expect(goodTickValue(250)).toEqual([20, 1]);
+    expect(goodTickValue(251)).toEqual([50, 4]);
+    expect(goodTickValue(300)).toEqual([50, 4]);
+  });
+});

--- a/src/utilities/graph-utils.ts
+++ b/src/utilities/graph-utils.ts
@@ -1,0 +1,31 @@
+  /*
+    Computes a good major tick value from a trial value. It will be the next
+    lowest value of the form 1, 2, 5, 10, ...
+    Patterned after CODAP's graph code
+    @param {Number} range - the axis range
+   */
+  export function goodTickValue(range: number) {
+    const trial = Math.abs(range / 5);
+
+    // A zero trial means that the values we're going to plot either don't
+    // exist or are all zero. Return 1 as an arbitrary choice.
+    if (trial === 0) return [1, 4];
+
+    // We move to base 10 so we can get rid of the power of ten.
+    const logTrial = Math.log(trial) / Math.LN10;
+    const floorTrial = Math.floor(logTrial);
+    const powerTrial = Math.pow(10, floorTrial);
+
+    // Whatever is left is in the range 1 to 10. Choose desired number
+    let tBase = Math.pow(10, logTrial - floorTrial);
+
+    if (tBase < 2) tBase = 1;
+    else if (tBase < 5) tBase = 2;
+    else tBase = 5;
+
+    // number of minor ticks depends on the base used for the major ticks
+    const minorTicks = tBase === 2 ? 1 : 4;
+
+    // return [majorTickDistance, minorTicks]
+    return [Math.max(powerTrial * tBase, Number.MIN_VALUE), minorTicks];
+  }


### PR DESCRIPTION
- uses CODAP tick/label heuristic

This adds support for a new `axisRange` field in the import schema for geometry tiles:
```json
"board": {
  "axisMin": [-3, -3],
  "axisRange": [60, 40]
}
```
The `axisRange` property specifies a desired total axis range given a prototypical tile of size 480x320. (These round numbers approximate the default size of a tile on a laptop screen.) Since the ratio of the sizes is 3x2, any `axisRange` values in a 3x2 ratio correspond to a 1:1 aspect ratio, i.e. the same scale factor on each axis and a perfectly square grid. Tiles larger or smaller than 480x320 will show more or less range as appropriate. Note that the `axisRange` is the total axis range, so the expected maximum value will be affected by the `axisMin` value as well as the size of the tile. As a shortcut, if only a single value is specified, e.g. `[60]`, the code assumes that the specified value is the desired range of the Y axis, and will use a square grid and determine the range of the X axis automatically.

While not directly related to this PR, a note on the `axisMin` value is in order as well. In JSXGraph axis labels are placed to the left of the Y axis (in negative X coordinate space) and below the X axis (in negative Y coordinate space). If the visible part of the coordinate system does not show sufficient room to display the axis labels fully, JSXGraph chooses not to display them at all. Therefore, to make the axis labels visible, it is important to choose `axisMin` values that leave enough room for the labels. Also, since the `axisMin` values are in coordinate system units, the appropriate values to leave room for the labels will depend on the `axisRange` values.