### PR TITLE
Fix copy polygon behavior after selection changes introduced by annotation feature

### DIFF
--- a/src/models/tools/geometry/geometry-content.ts
+++ b/src/models/tools/geometry/geometry-content.ts
@@ -591,14 +591,17 @@ export const GeometryContentModel = types
     // that should also be considered selected, i.e. all of whose
     // ancestors are selected.
     function getSelectedIdsAndChildren(board: JXG.Board) {
-      const selectedIds = self.selectedIds;
+      // list of selected ids in order of creation
+      const selectedIds = board.objectsList
+                               .map(obj => obj.id)
+                               .filter(id => self.isSelected(id));
       const children: { [id: string]: JXG.GeometryElement } = {};
       // identify children (e.g. polygons) that may be selected as well
       selectedIds.forEach(id => {
         const obj = board.objects[id];
         if (obj) {
           each(obj.childElements, child => {
-            if (child && isCopyableChild(child)) {
+            if (child && !self.isSelected(child.id) && isCopyableChild(child)) {
               children[child.id] = child;
             }
           });


### PR DESCRIPTION
Fix copy polygon behavior after selection changes introduced by annotation feature [#163922781]

Prior to the annotation feature polygons were not explicitly selected at the model layer; they were simply assumed to be selected if all of their vertices were selected. Code that assumed that polygons would not be among the selected objects must be updated to account for that possibility. In this case, the copy code ends up copying the same polygon twice -- once because it's now selected and once because all of its vertices are selected.

Note that polygons that were copied in this way retain this "corruption", so it may still be possible to find polygons that can't be rotated (or duplicated) if they were copied/pasted by the affected version of the code.