### PR TITLE
Fix several bugs with polygons created from linked table points

### DIFF
--- a/src/components/tools/geometry-tool/geometry-content.tsx
+++ b/src/components/tools/geometry-tool/geometry-content.tsx
@@ -328,11 +328,13 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
     const { board, disableRotate } = this.state;
     const selectedPolygon = board && !disableRotate && !this.props.readOnly
                               ? this.getContent().getOneSelectedPolygon(board) : undefined;
+    const rotatablePolygon = selectedPolygon && selectedPolygon.vertices.every(pt => !pt.getAttribute("fixed"))
+                              ? selectedPolygon : undefined;
     return (
       <RotatePolygonIcon
         key="rotate-polygon-icon"
         board={board}
-        polygon={selectedPolygon}
+        polygon={rotatablePolygon}
         scale={this.props.scale}
         onRotate={this.handleRotatePolygon} />
     );

--- a/src/models/tools/geometry/jsxgraph.d.ts
+++ b/src/models/tools/geometry/jsxgraph.d.ts
@@ -19,6 +19,7 @@ declare namespace JXG {
     point3: GeometryElement;
     pointsquare: GeometryElement;
     radiuspoint: GeometryElement;
+    dot?: GeometryElement;
 
     Value: () => number;
   }

--- a/src/models/tools/geometry/jxg-board.ts
+++ b/src/models/tools/geometry/jxg-board.ts
@@ -34,6 +34,17 @@ export function getTickValues(pixPerUnit: number) {
   return [majorTickDistance, minorTicks, minorTickDistance];
 }
 
+export const kReverse = true;
+export function sortByCreation(board: JXG.Board, ids: string[], reverse: boolean = false) {
+  const indices: { [id: string]: number } = {};
+  board.objectsList.forEach((obj, index) => {
+    indices[obj.id] = index;
+  });
+  ids.sort(reverse
+            ? (a, b) => indices[b] - indices[a]
+            : (a, b) => indices[a] - indices[b]);
+}
+
 function combineProperties(domElementID: string, defaults: any, changeProps: any, overrides: any) {
   const elt = document.getElementById(domElementID);
   const eltBounds = elt && elt.getBoundingClientRect();

--- a/src/models/tools/geometry/jxg-object.ts
+++ b/src/models/tools/geometry/jxg-object.ts
@@ -1,4 +1,6 @@
+import { sortByCreation, kReverse } from "./jxg-board";
 import { JXGChangeAgent } from "./jxg-changes";
+import { castArrayCopy } from "../../../utilities/js-utils";
 import { castArray, size } from "lodash";
 
 // Inexplicably, we occasionally encounter JSXGraph objects with null
@@ -37,7 +39,9 @@ export const objectChangeAgent: JXGChangeAgent = {
 
   delete: (board, change) => {
     if (!change.targetID) { return; }
-    const ids = Array.isArray(change.targetID) ? change.targetID : [change.targetID];
+    const ids = castArrayCopy(change.targetID);
+    sortByCreation(board, ids, kReverse);
+    // remove objects in reverse order of creation
     ids.forEach((id) => {
       const obj = board.objects[id] as JXG.GeometryElement;
       if (obj) {

--- a/src/models/tools/geometry/jxg-point.ts
+++ b/src/models/tools/geometry/jxg-point.ts
@@ -1,7 +1,7 @@
 import { JXGChangeAgent, JXGCoordPair } from "./jxg-changes";
 import { isCommentType } from "./jxg-comment";
 import { objectChangeAgent } from "./jxg-object";
-import { removePointsToBeDeletedFromPolygons } from "./jxg-polygon";
+import { prepareToDeleteObjects } from "./jxg-polygon";
 import { castArray, values } from "lodash";
 import * as uuid from "uuid/v4";
 
@@ -80,7 +80,7 @@ export const pointChangeAgent: JXGChangeAgent = {
   update: objectChangeAgent.update,
 
   delete: (board, change) => {
-    removePointsToBeDeletedFromPolygons(board, castArray(change.targetID));
+    prepareToDeleteObjects(board, castArray(change.targetID));
     objectChangeAgent.delete(board, change);
   }
 };

--- a/src/utilities/js-utils.ts
+++ b/src/utilities/js-utils.ts
@@ -2,6 +2,17 @@
 const nanoid = require("nanoid");
 
 /*
+ * castArrayCopy()
+ *
+ * returns an array for simple items, and a copy of the array for arrays
+ */
+export function castArrayCopy(itemOrArray: any) {
+  return Array.isArray(itemOrArray)
+          ? itemOrArray.slice()
+          : [itemOrArray];
+}
+
+/*
  * safeJsonParse()
  *
  * returns undefined on error rather than throwing an exception


### PR DESCRIPTION
Fix several bugs with polygons created from linked table points
- user should not be able to rotate them (rotate button should not appear)
- deleting them can orphan angle labels [#163930085]
- after deleting a linked polygon with an angle label, cannot make another polygon with those points
