### PR TITLE
Fix disappearing geometry bug [#163994734]

### DIFF
--- a/src/models/tools/geometry/geometry-content.test.ts
+++ b/src/models/tools/geometry/geometry-content.test.ts
@@ -46,8 +46,6 @@ describe("GeometryContent", () => {
     expect(content.type).toBe(kGeometryToolID);
     expect(content.changes).toEqual([]);
 
-    expect(content.nextViewId).toBe(1);
-    expect(content.nextViewId).toBe(2);
     destroy(content);
   });
 
@@ -55,7 +53,6 @@ describe("GeometryContent", () => {
     const { content, board } = createContentAndBoard(_content => {
       _content.addChange({ operation: "create", target: "point", parents: [1, 1] });
     });
-    expect(content.nextViewId).toBe(1);
     expect(isBoard(board)).toBe(true);
 
     content.resizeBoard(board, 200, 200);

--- a/src/models/tools/geometry/geometry-content.ts
+++ b/src/models/tools/geometry/geometry-content.ts
@@ -285,7 +285,6 @@ export const GeometryContentModel = types
   }))
   .extend(self => {
 
-    let viewCount = 0;
     let suspendCount = 0;
     let batchChanges: string[] = [];
 
@@ -848,9 +847,6 @@ export const GeometryContentModel = types
 
     return {
       views: {
-        get nextViewId() {
-          return ++viewCount;
-        },
         get isUserResizable() {
           return true;
         },

--- a/src/models/tools/geometry/jsxgraph.d.ts
+++ b/src/models/tools/geometry/jsxgraph.d.ts
@@ -66,6 +66,7 @@ declare namespace JXG {
     setBoundingBox: (boundingBox: [number, number, number, number], keepaspectratio?: boolean) => JXG.Board;
     showInfobox: (value: boolean) => JXG.Board;
     update: (drag?: JXG.GeometryElement) => JXG.Board;
+    fullUpdate: () => JXG.Board;
     suspendUpdate: () => JXG.Board;
     unsuspendUpdate: () => JXG.Board;
   }


### PR DESCRIPTION
Due to content lifetime issues, the code could occasionally generate duplicate IDs for JSXGraph DOM elements, which justifiably confused JSXGraph.

In this scenario, moving the tile causes a new JSXGraph instance to be generated and the original JSXGraph instance to be destroyed. In the process of removing the DOM elements of the board being destroyed, the duplicate IDs could result in the corresponding elements being removed from the new board rather than the old one.