### PR TITLE
Buttons, icons, toolbars should match UI specs [#163635414]

### DIFF
--- a/src/components/document/document.sass
+++ b/src/components/document/document.sass
@@ -41,9 +41,10 @@
       padding: 1px 0
       display: flex
 
-      .icon-download
+      .action.icon.icon-download
         transform: rotate(180deg)
         transform-origin: 50% 50%
+        padding-bottom: 2px
 
       .mode
         border-top-right-radius: $border-radius
@@ -74,11 +75,13 @@
           color: $color1-4
 
       .icon
+        box-sizing: content-box
         background-color: $color1-3
         color: $color1-7
-        height: 30px
-        width: 30px
+        width: 36px
+        height: 34px
         padding: $half-padding
+        padding-top: 2px
         margin-left: $half-margin
         cursor: pointer
 
@@ -120,11 +123,12 @@
 
         svg
           display: inline-block
+          box-sizing: content-box
           padding: $half-padding
-          margin: $quarter-margin $quarter-margin 0 0
+          margin: 1px $quarter-margin 0 0
           color: $color1-5
-          width: 25px
-          height: 25px
+          width: 24px
+          height: 24px
           cursor: pointer
 
           &.show
@@ -169,11 +173,12 @@
           display: block
 
       .icon
+        box-sizing: content-box
         background-color: $color1-3
         color: $color1-7
-        height: 30px
-        width: 30px
-        padding: $half-padding
+        width: 36px
+        height: 34px
+        padding: 0 $half-padding
         margin-left: $half-margin
         border-bottom-right-radius: $border-radius
         cursor: pointer

--- a/src/components/document/document.sass
+++ b/src/components/document/document.sass
@@ -9,6 +9,7 @@
   color: #000
   background-color: #F8FCFE
   margin: $margin
+  margin-left: $margin - $border-width
   border: $border-width solid $border-color
   border-radius: $border-radius
 

--- a/src/components/document/document.tsx
+++ b/src/components/document/document.tsx
@@ -75,7 +75,7 @@ export class DocumentComponent extends BaseComponent<IProps, {}> {
     const activeSection = problem.getSectionById(document.sectionId!);
     const show4up = !workspace.comparisonVisible;
     const downloadButton = (appMode !== "authed") && clipboard.hasJsonTileContent()
-                            ? <svg key="download" className={`icon icon-download`}
+                            ? <svg key="download" className={`action icon icon-download`}
                                     onClick={this.handleDownloadTileJson}>
                                 <use xlinkHref={`#icon-publish`} />
                               </svg>
@@ -89,7 +89,7 @@ export class DocumentComponent extends BaseComponent<IProps, {}> {
           <div className="actions" data-test="document-titlebar-actions">
             {[
               downloadButton,
-              <svg key="publish" className={`icon icon-publish`} data-test="publish-icon"
+              <svg key="publish" className={`action icon icon-publish`} data-test="publish-icon"
                    onClick={this.handlePublishWorkspace}>
                 <use xlinkHref={`#icon-publish`} />
               </svg>,

--- a/src/components/header.sass
+++ b/src/components/header.sass
@@ -76,6 +76,9 @@ $member-size: 18px
           &.empty
             background-color: $color1-4
 
+          .initials
+            margin-top: -3px
+
   .user
     flex-grow: 0
     display: flex

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -76,7 +76,7 @@ export class HeaderComponent extends BaseComponent<IProps, {}> {
         className={`${className} ${direction}`}
         title={title}
       >
-        {user.initials}
+        <div className="initials">{user.initials}</div>
       </div>
     );
   }

--- a/src/components/toolbar.sass
+++ b/src/components/toolbar.sass
@@ -12,7 +12,7 @@
 
   .tool
     width: $workspace-toolbar-width
-    height: $workspace-toolbar-width
+    height: $workspace-toolbar-width - 2px
     background-color: $color3
     display: flex
     justify-content: center
@@ -22,9 +22,12 @@
     font-weight: bold
     margin-bottom: -$border-width
     border: $border-width solid $border-color
+    border-right-width: 0
     cursor: pointer
 
     .icon
+      width: 36px
+      height: 34px
       color: $color3-1
       pointer-events: none
 

--- a/src/components/tools/drawing-tool/drawing-tool.sass
+++ b/src/components/tools/drawing-tool/drawing-tool.sass
@@ -1,7 +1,7 @@
 .drawing-tool
   display: flex
   border: 1px solid #BBB
-  height: 99%
+  height: 100%
 
 .drawing-tool-toolbar
   background-color: #eee

--- a/src/components/tools/geometry-tool/geometry-tool.sass
+++ b/src/components/tools/geometry-tool/geometry-tool.sass
@@ -32,6 +32,7 @@ $toolbar-width: 44px
         border-radius: 0 $half-border-radius 0 0
 
         .graph-tile
+          box-sizing: content-box
           width: 50%
           border: solid 2px white
           border-width: 0 2px 2px 0
@@ -51,6 +52,7 @@ $toolbar-width: 44px
           fill: white
 
       .button
+        box-sizing: content-box
         width: 36px
         height: 34px
         margin: 2px
@@ -96,7 +98,7 @@ $toolbar-width: 44px
   .geometry-wrapper
     position: absolute
     height: 100%
-    left: $toolbar-width - 1
+    left: $toolbar-width
     right: 0
 
     &.read-only

--- a/src/components/tools/tool-tile.sass
+++ b/src/components/tools/tool-tile.sass
@@ -12,8 +12,9 @@
   .tool-tile-drag-handle
     position: absolute
     right: 0px
-    width: $double-margin
-    height: $double-margin
+    box-sizing: content-box
+    width: 21px
+    height: 21px
     border-radius: $border-radius
     border-top-left-radius: 0
     border-bottom-right-radius: 0
@@ -31,8 +32,9 @@
       opacity: 1
 
     .icon
-      width: 20px
-      height: 20px
+      width: 23px
+      height: 23px
+      margin-top: -1px
       left: 0px
 
   &.selected

--- a/src/components/vars.sass
+++ b/src/components/vars.sass
@@ -164,7 +164,7 @@ $right-nav-expanded-width: 248px
 
 $workspace-titlebar-height: 40px
 $workspace-statusbar-height: 40px
-$workspace-toolbar-width: 40px
+$workspace-toolbar-width: 44px
 
 //
 // tabs


### PR DESCRIPTION
Buttons, icons, toolbars should match UI specs [#163635414]
- Adjust appearance of document toolbar to match UI specs
- Adjust title bar and status bar
- Adjust geometry widgets
- Adjust drawing tool height

The introduction of blueprint.js follows the general CSS best-practice of defaulting to `box-sizing: border-box` rather than the browser default of `box-sizing: content-box`. This has the effect of making buttons, icons, etc. smaller because any borders, padding, margins are included in the size.

[* { Box-sizing: Border-box } FTW](https://www.paulirish.com/2012/box-sizing-border-box-ftw/)
[Inheriting box-sizing Probably Slightly Better Best-Practice](https://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/)
[International box-sizing Awareness Day](https://css-tricks.com/international-box-sizing-awareness-day/)