### PR TITLE
Improve tabbing behavior

### DIFF
--- a/src/components/document/document-content.tsx
+++ b/src/components/document/document-content.tsx
@@ -134,7 +134,6 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
     if (!content) { return null; }
     const { rowMap, rowOrder, tileMap, highlightPendingDropLocation } = content;
     const { dropRowInfo } = this.state;
-    let tabIndex = 1;
     this.rowRefs = [];
     return rowOrder.map((rowId, index) => {
       const row = rowMap.get(rowId);
@@ -147,11 +146,9 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
       if (!dropHighlight && index === highlightPendingDropLocation) {
         dropHighlight = "bottom";
       }
-      const _tabIndex = tabIndex;
-      tabIndex += row ? row.tiles.length : 0;
       return row
               ? <TileRowComponent key={row.id} docId={content.contentId} model={row}
-                                  tabIndex={_tabIndex} height={rowHeight} tileMap={tileMap}
+                                  height={rowHeight} tileMap={tileMap}
                                   dropHighlight={dropHighlight}
                                   ref={(elt) => this.rowRefs.push(elt)} {...others} />
               : null;

--- a/src/components/document/tile-row.tsx
+++ b/src/components/document/tile-row.tsx
@@ -49,7 +49,6 @@ interface IProps {
   docId: string;
   scale?: number;
   model: TileRowModelType;
-  tabIndex?: number;
   height?: number;
   tileMap: any;
   readOnly?: boolean;
@@ -82,16 +81,15 @@ export class TileRowComponent extends BaseComponent<IProps, IState> {
   }
 
   private renderTiles(rowHeight?: number) {
-    const { model, tileMap, tabIndex, ...others } = this.props;
+    const { model, tileMap, ...others } = this.props;
     const { tiles } = model;
     if (!tiles) { return null; }
 
     return tiles.map((tileRef, index) => {
       const tileModel: ToolTileModelType = tileMap.get(tileRef.tileId);
       const tileWidthPct = model.renderWidth(tileRef.tileId);
-      const _tabIndex = tabIndex ? tabIndex + index : tabIndex;
       return tileModel
-              ? <ToolTileComponent key={tileModel.id} model={tileModel} tabIndex={_tabIndex}
+              ? <ToolTileComponent key={tileModel.id} model={tileModel}
                                     widthPct={tileWidthPct} height={rowHeight}
                                     onSetCanAcceptDrop={this.handleSetCanAcceptDrop}
                                     {...others} />

--- a/src/components/tools/geometry-tool/geometry-content.tsx
+++ b/src/components/tools/geometry-tool/geometry-content.tsx
@@ -336,7 +336,6 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
       <div id={this.elementId} key="jsxgraph"
           className={classes}
           ref={elt => this.domElement = elt}
-          tabIndex={this.props.tabIndex}
           onDragOver={this.handleDragOver}
           onDragLeave={this.handleDragLeave}
           onDrop={this.handleDrop} />,
@@ -1082,21 +1081,7 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
   private handleCreateBoard = (board: JXG.Board) => {
 
     const handlePointerDown = (evt: any) => {
-      const { model, scale } = this.props;
-      const { ui } = this.stores;
-
-      // clicked tile gets keyboard focus
-      if (this.domElement) {
-        // requires non-empty tabIndex
-        this.domElement.focus();
-      }
-      // first click selects the tile; subsequent clicks create points
-      if (!ui.isSelectedTile(model)) {
-        ui.setSelectedTile(model);
-        return;
-      }
-
-      const coords = getEventCoords(board, evt, scale);
+      const coords = getEventCoords(board, evt, this.props.scale);
       const x = coords.usrCoords[1];
       const y = coords.usrCoords[2];
       if ((x != null) && isFinite(x) && (y != null) || isFinite(y)) {

--- a/src/components/tools/geometry-tool/geometry-shared.tsx
+++ b/src/components/tools/geometry-tool/geometry-shared.tsx
@@ -24,7 +24,6 @@ export interface IActionHandlers {
 export interface IGeometryProps extends SizeMeProps {
   context: string;
   scale?: number;
-  tabIndex?: number;
   model: ToolTileModelType;
   readOnly?: boolean;
   toolApiInterface?: IToolApiInterface;

--- a/src/components/tools/table-tool/table-tool.tsx
+++ b/src/components/tools/table-tool/table-tool.tsx
@@ -26,7 +26,6 @@ interface IClipboardCases {
 interface IProps {
   model: ToolTileModelType;
   readOnly?: boolean;
-  tabIndex?: number;  // required for focus()
 }
 
 // all properties are optional
@@ -105,7 +104,7 @@ export default class TableToolComponent extends BaseComponent<IProps, IState> {
           };
     return (
       <div className="table-tool" ref={this.domRef}
-          tabIndex={this.props.tabIndex} onKeyDown={this.handleKeyDown} >
+          tabIndex={0} onKeyDown={this.handleKeyDown} >
         <DataTableComponent
           dataSet={this.state.dataSet}
           expressions={metadata.expressions}

--- a/src/components/tools/tool-tile.tsx
+++ b/src/components/tools/tool-tile.tsx
@@ -60,7 +60,6 @@ interface IProps {
   context: string;
   docId: string;
   scale?: number;
-  tabIndex?: number;
   widthPct?: number;
   height?: number;
   model: ToolTileModelType;
@@ -114,6 +113,7 @@ export class ToolTileComponent extends BaseComponent<IProps, {}> {
           ref={elt => this.domElement = elt}
           data-tool-id={model.id}
           style={style}
+          tabIndex={-1}
           onKeyDown={this.handleKeyDown}
           onDragStart={this.handleToolDragStart}
           draggable={true}


### PR DESCRIPTION
@ekosmin I think this is ready for re-review with an eye toward including it in the next build (0.5.2/0.6.0).

This is mostly elimination of tech debt based on a better understanding of how this is supposed to work. It's not a priority for the 0.5.1 release and would probably be better to wait until we get some more testing on it.

- Set `tabIndex` property to 0 or -1 as appropriate, rather than trying to assign unique `tabIndex` values
- Move responsibility for checking/setting tile selection from `GeometryContentComponent` to `GeometryToolComponent`

cf. https://developer.mozilla.org/en-US/docs/Learn/Accessibility/HTML#Building_keyboard_accessibility_back_in