### PR TITLE
Fixing Scaling + Undo

### DIFF
--- a/src/models/tools/geometry/geometry-content.ts
+++ b/src/models/tools/geometry/geometry-content.ts
@@ -341,10 +341,9 @@ export const GeometryContentModel = types
             if (isBoard(changeElem)) {
               board = changeElem as JXG.Board;
               board.suspendUpdate();
-            } else {
-              if (onCreate) {
-                onCreate(changeElem as JXG.GeometryElement);
-              }
+            }
+            else if (onCreate) {
+              onCreate(changeElem as JXG.GeometryElement);
             }
           });
         });

--- a/src/models/tools/geometry/geometry-content.ts
+++ b/src/models/tools/geometry/geometry-content.ts
@@ -335,19 +335,18 @@ export const GeometryContentModel = types
       let board: JXG.Board | undefined;
       applyChanges(domElementID, changes, onChangeApplied)
         .filter(result => result != null)
-        .forEach(elt => {
-          if (isBoard(elt)) {
-            board = elt as JXG.Board;
-            board.suspendUpdate();
-          }
-          else if (Array.isArray(elt)) {
-            if (onCreate) {
-              elt.forEach(el => onCreate(el as JXG.GeometryElement));
+        .forEach(changeResult => {
+          const changeElems = castArray(changeResult);
+          changeElems.forEach(changeElem => {
+            if (isBoard(changeElem)) {
+              board = changeElem as JXG.Board;
+              board.suspendUpdate();
+            } else {
+              if (onCreate) {
+                onCreate(changeElem as JXG.GeometryElement);
+              }
             }
-          }
-          else if (elt && onCreate) {
-            onCreate(elt as JXG.GeometryElement);
-          }
+          });
         });
       if (board) {
         board.unsuspendUpdate();

--- a/src/models/tools/geometry/jxg-board.ts
+++ b/src/models/tools/geometry/jxg-board.ts
@@ -136,6 +136,7 @@ function addAxes(board: JXG.Board, unitX: number, unitY: number) {
     minorTicks: yMinorTicks,
     drawZero: false
   });
+  return [xAxis, yAxis];
 }
 
 export const boardChangeAgent: JXGChangeAgent = {
@@ -146,8 +147,8 @@ export const boardChangeAgent: JXGChangeAgent = {
     // If we created the board from a DOM element ID, then we need to add the axes.
     // If we are undoing an action, then the board already exists but its axes have
     // been removed, so we have to add the axes in that case as well.
-    addAxes(board, board.unitX, board.unitY);
-    return board;
+    const axes = addAxes(board, board.unitX, board.unitY);
+    return [board, ...axes];
 },
 
   update: (board: JXG.Board, change: JXGChange) => {

--- a/src/models/tools/geometry/jxg-board.ts
+++ b/src/models/tools/geometry/jxg-board.ts
@@ -103,14 +103,14 @@ function createBoard(domElementId: string, properties?: JXGProperties) {
 }
 
 function addAxes(board: JXG.Board, unitX: number, unitY: number, boundingBox?: JXG.BoundingBox) {
-  if (boundingBox && boundingBox.every((val: number) => isFinite(val))) {
-    board.setBoundingBox(boundingBox);
-  }
   const [xMajorTickDistance, xMinorTicks, xMinorTickDistance] = getTickValues(unitX);
   const [yMajorTickDistance, yMinorTicks, yMinorTickDistance] = getTickValues(unitY);
   board.removeGrids();
   board.options.grid = { ...board.options.grid, gridX: xMinorTickDistance, gridY: yMinorTickDistance };
   board.addGrid();
+  if (boundingBox && boundingBox.every((val: number) => isFinite(val))) {
+    board.setBoundingBox(boundingBox);
+  }
   const xAxis = board.create("axis", [ [0, 0], [1, 0] ], {
     name: "x",
     withLabel: true,
@@ -185,11 +185,10 @@ export const boardChangeAgent: JXGChangeAgent = {
               board.removeObject(el);
             }
           });
-          const axes = addAxes(board, unitX, unitY);
-          board.update();
-          return axes;
+          addAxes(board, unitX, unitY);
         }
       }
+      board.update();
     }
   },
 

--- a/src/models/tools/geometry/jxg-dispatcher.ts
+++ b/src/models/tools/geometry/jxg-dispatcher.ts
@@ -35,8 +35,9 @@ export function applyChanges(board: JXG.Board|string, changes: JXGChange[],
   let _board: JXG.Board | undefined;
   const results = changes.map(change => {
                     const result = applyChange(_board || board, change, onChangeApplied);
-                    if ((typeof board === "string") && isBoard(result)) {
-                      _board = result as JXG.Board;
+                    const resultBoard = castArray(result).find(isBoard) as JXG.Board;
+                    if ((typeof board === "string") && resultBoard) {
+                      _board = resultBoard;
                       _board.suspendUpdate();
                     }
                     return result;


### PR DESCRIPTION
This fixes two separate bugs:

First, listeners were not added to axes after they were redrawn during an undo. This was fixed by returning the axes along with the board during the call to `create`. This was complicated slightly by the fact that some code expected a board to be returned by board creation, so that code needed to be updated to accommodate an array containing a board.

The next issue was that undo axis rescaling was broken. Basically, the issue was that the bounding box was not being updated when the board was "created" during an undo.

There is some tech debt touched by this fix, but it is not made worse by it, so I opted to leave it alone. I'll point out where that happened, let me know if you think it's worth addressing