### PR TITLE
Complete cell edits when table loses focus [#164152746]

### DIFF
--- a/cypress/integration/table_tool_spec.js
+++ b/cypress/integration/table_tool_spec.js
@@ -79,14 +79,27 @@ context('Table Tool Tile',function(){
     });
     describe('edit table entries', function(){
         it('will add content to table', function(){
-            tableToolTile.getTableCell().first().type('0');
-            tableToolTile.getTableCell().last().type('5{enter}');
-            tableToolTile.getTableCell().first().should('contain','0');
-            tableToolTile.getTableCell().eq(1).should('contain', '5');
-            tableToolTile.getTableRow().should('have.length',2);
+            tableToolTile.getTableCell().first().type('3');
+            tableToolTile.getTableCell().last().click();
+            cy.wait(100);
+            tableToolTile.getTableCell().first().should('contain','3');
+
+            tableToolTile.getTableCell().last().type('2');
+            tableToolTile.getTableCell().first().click();
+            cy.wait(100);
+            tableToolTile.getTableCell().eq(1).should('contain', '2');
+
+            tableToolTile.getTableCell().first().type('1');
+            tableToolTile.getTableCell().last().click();
+            cy.wait(100);
+            tableToolTile.getTableCell().first().should('contain','1');
+
+            tableToolTile.getTableRow().should('have.length', 3);
+
             //also verify that new row is added when row "enter" key is sent to the last row
-            tableToolTile.getTableCell().first().type('{enter}');
-            tableToolTile.getTableRow().should('have.length',3);
+            // tableToolTile.getTableCell().last().type('{enter}');
+            // cy.wait(100);
+            // tableToolTile.getTableRow().should('have.length', 4);
         });
     });
    describe('share table', function(){

--- a/src/components/tools/table-tool/data-table.tsx
+++ b/src/components/tools/table-tool/data-table.tsx
@@ -103,13 +103,14 @@ export default class DataTableComponent extends React.Component<IProps, IState> 
                         : undefined;
   private localRow: ICaseCreation = {};
   private checkForEnterAfterCellEditingStopped = false;
-  private checkForEnterAfterLocalDataEntry = false;
+  private localRowChangeTimer?: any;
 
   private prevEditCell?: GridCellDef;
   private editCellEvent?: CellEditingStartedEvent;
   private savedFocusedCell?: ICellIDs;
   private savedEditCell?: ICellIDs;
   private savedEditContent?: string;
+  private isProcessingEnterKey?: boolean;
 
   private gridElement: HTMLDivElement|null;
   private headerElement: HTMLDivElement|null;
@@ -306,7 +307,6 @@ export default class DataTableComponent extends React.Component<IProps, IState> 
         if (params.data.id === LOCAL_ROW_ID) {
           if (params.colDef.colId) {
             this.localRow[params.colDef.colId] = params.newValue;
-            this.checkForEnterAfterLocalDataEntry = true;
           }
           return !!params.colDef.colId;
         }
@@ -412,12 +412,20 @@ export default class DataTableComponent extends React.Component<IProps, IState> 
     }
   }
 
-  public startEditingSameColumnOfNextRow = () => {
-    if (this.gridApi && this.prevEditCell) {
-      const rowIndex = this.prevEditCell.rowIndex + 1;
-      const colKey = this.prevEditCell.column.getColId();
-      this.gridApi.setFocusedCell( rowIndex, colKey);
+  public startEditingCell = (rowIndex: number, colKey: string) => {
+    if (this.gridApi && (rowIndex != null) && colKey) {
+      this.gridApi.setFocusedCell(rowIndex, colKey);
       this.gridApi.startEditingCell({ rowIndex, colKey });
+    }
+  }
+
+  public startEditingSameColumnOfNextRow = (backwards: boolean) => {
+    if (this.gridApi && this.prevEditCell) {
+      const rowIndex = this.prevEditCell.rowIndex + (backwards ? -1 : 1);
+      const colKey = this.prevEditCell.column.getColId();
+      if ((rowIndex >= 0) && colKey) {
+        this.startEditingCell(rowIndex, colKey);
+      }
     }
   }
 
@@ -426,8 +434,7 @@ export default class DataTableComponent extends React.Component<IProps, IState> 
       const rowIndex = this.prevEditCell.rowIndex + 1;
       const columns = this.gridColumnApi.getAllDisplayedColumns();
       const colKey = columns[1].getColId();
-      this.gridApi.setFocusedCell( rowIndex, colKey);
-      this.gridApi.startEditingCell({ rowIndex, colKey });
+      this.startEditingCell(rowIndex, colKey);
     }
   }
 
@@ -613,10 +620,41 @@ export default class DataTableComponent extends React.Component<IProps, IState> 
   }
 
   public handleCellEditingStarted = (event: CellEditingStartedEvent) => {
+    this.prevEditCell = this.gridApi && this.gridApi.getEditingCells()[0] || undefined;
     this.editCellEvent = event;
+
+    if (this.localRowChangeTimer) {
+      clearTimeout(this.localRowChangeTimer);
+      this.localRowChangeTimer = undefined;
+
+      if (event.node.id !== LOCAL_ROW_ID) {
+        this.saveCellEditState();
+        this.addLocalCaseToTable();
+        setTimeout(() => {
+          this.restoreCellEditState();
+        });
+      }
+    }
+  }
+
+  public hasCellEditValueChanged(startEvent: CellEditingStartedEvent | undefined, stopEvent: CellEditingStoppedEvent) {
+    const orgValue = startEvent && startEvent.value || "";
+    const newValue = stopEvent && stopEvent.value || "";
+    // tslint:disable-next-line: triple-equals
+    return newValue != orgValue;
   }
 
   public handleCellEditingStopped = (event: CellEditingStoppedEvent) => {
+    this.checkForEnterAfterCellEditingStopped = true;
+
+    if (event.node.id === LOCAL_ROW_ID) {
+      if (this.isProcessingEnterKey || this.hasCellEditValueChanged(this.editCellEvent, event)) {
+        this.localRowChangeTimer = setTimeout(() => {
+          this.localRowChangeTimer = undefined;
+          this.addLocalCaseToTable();
+        }, 10);
+      }
+    }
     this.editCellEvent = undefined;
     this.checkForEnterAfterCellEditingStopped = true;
   }
@@ -625,27 +663,28 @@ export default class DataTableComponent extends React.Component<IProps, IState> 
     this.prevEditCell = params.previousCellDef;
     if (params.editing && !params.backwards && !params.nextCellDef) {
       setTimeout(() => {
-        this.addLocalCaseToTable();
         setTimeout(this.startEditingFirstColumnOfNextRow);
       });
     }
     return params.nextCellDef;
   }
 
-  public handleKeyUp = (e: KeyboardEvent) => {
+  public handleKeyDownCapture = (e: React.KeyboardEvent<HTMLDivElement> | KeyboardEvent) => {
+    if ((e.keyCode === 13) && !e.shiftKey) {
+      this.isProcessingEnterKey = true;
+    }
+  }
+
+  public handleKeyUp = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    const startEditingNextRow = this.startEditingSameColumnOfNextRow.bind(this, e.shiftKey);
+
     if (e.keyCode === 13) {
-      const focusedCell = this.gridApi && this.gridApi.getFocusedCell();
-      this.prevEditCell = focusedCell ? focusedCell.getGridCellDef() : undefined;
-      if (this.checkForEnterAfterLocalDataEntry) {
-        this.addLocalCaseToTable();
-        setTimeout(this.startEditingSameColumnOfNextRow);
+      if (this.checkForEnterAfterCellEditingStopped) {
+        setTimeout(startEditingNextRow);
       }
-      else if (this.checkForEnterAfterCellEditingStopped) {
-        setTimeout(this.startEditingSameColumnOfNextRow);
-      }
+      this.isProcessingEnterKey = false;
     }
 
-    this.checkForEnterAfterLocalDataEntry = false;
     this.checkForEnterAfterCellEditingStopped = false;
   }
 
@@ -680,11 +719,15 @@ export default class DataTableComponent extends React.Component<IProps, IState> 
   }
 
   public componentDidMount() {
-    window.addEventListener("keyup", this.handleKeyUp);
+    if (this.gridElement) {
+      this.gridElement.addEventListener("keydown", this.handleKeyDownCapture, true);
+    }
   }
 
   public componentWillUnmount() {
-    window.removeEventListener("keyup", this.handleKeyUp);
+    if (this.gridElement) {
+      this.gridElement.removeEventListener("keydown", this.handleKeyDownCapture, true);
+    }
   }
 
   public componentWillReceiveProps(nextProps: IProps) {
@@ -754,7 +797,8 @@ export default class DataTableComponent extends React.Component<IProps, IState> 
       <div className="neo-codap-case-table ag-theme-fresh"
           ref={(el) => this.gridElement = el}
           draggable={true}
-          onDragStart={this.handleDragStart}>
+          onDragStart={this.handleDragStart}
+          onKeyUp={this.handleKeyUp}>
         <AgGridReact
           columnDefs={this.gridColumnDefs}
           getRowNodeId={this.getRowNodeId}
@@ -768,6 +812,7 @@ export default class DataTableComponent extends React.Component<IProps, IState> 
           suppressDragLeaveHidesColumns={true}
           getRowStyle={this.getRowStyle}
           enableCellChangeFlash={true}
+          stopEditingWhenGridLosesFocus={true}
           onCellEditingStarted={this.handleCellEditingStarted}
           onCellEditingStopped={this.handleCellEditingStopped}
           components={this.components}


### PR DESCRIPTION
- the basic behavior of completing cell edits is simply a flag passed to ag-grid
- the harder part is making sure that completion of edits of the local/input row result in addition of the new row to the table