### PR TITLE
Fix publication of documents with linked tables/geometries

### DIFF
--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -1,8 +1,10 @@
-import { types, Instance, SnapshotIn, getSnapshot } from "mobx-state-tree";
+import { types, getSnapshot, Instance, SnapshotIn, SnapshotOut } from "mobx-state-tree";
 import { defaultDrawingContent, kDrawingDefaultHeight, StampModelType } from "../tools/drawing/drawing-content";
-import { defaultGeometryContent, kGeometryDefaultHeight } from "../tools/geometry/geometry-content";
+import { defaultGeometryContent, kGeometryDefaultHeight, GeometryContentModelType, mapTileIdsInGeometrySnapshot
+        } from "../tools/geometry/geometry-content";
 import { defaultImageContent } from "../tools/image/image-content";
-import { defaultTableContent, kTableDefaultHeight } from "../tools/table/table-content";
+import { defaultTableContent, kTableDefaultHeight, TableContentModelType, mapTileIdsInTableSnapshot
+        } from "../tools/table/table-content";
 import { defaultTextContent } from "../tools/text/text-content";
 import { ToolContentUnionType } from "../tools/tool-types";
 import { createToolTileModelFromContent, ToolTileModel, ToolTileSnapshotOutType } from "../tools/tool-tile";
@@ -100,6 +102,20 @@ export const DocumentContentModel = types
           });
           return _tileMap;
         })(snapshot.tileMap);
+
+        each(snapshot.tileMap, (tile, id) => {
+          const tileContent = tile.content;
+          switch (tileContent.type) {
+            case "Geometry":
+              const geometryContentSnapshot: SnapshotOut<GeometryContentModelType> = tileContent;
+              mapTileIdsInGeometrySnapshot(geometryContentSnapshot, idMap);
+              break;
+            case "Table":
+              const tableContentSnapshot: SnapshotOut<TableContentModelType> = tileContent;
+              mapTileIdsInTableSnapshot(tableContentSnapshot, idMap);
+              break;
+          }
+        });
 
         snapshot.rowMap = (rowMap => {
           const _rowMap: { [id: string]: TileRowSnapshotOutType } = {};

--- a/src/models/tools/geometry/geometry-content.ts
+++ b/src/models/tools/geometry/geometry-content.ts
@@ -1,4 +1,4 @@
-import { types, Instance } from "mobx-state-tree";
+import { types, Instance, SnapshotOut } from "mobx-state-tree";
 import { ITableChange, ITableLinkProperties, kLabelAttrName, TableContentModelType } from "../table/table-content";
 import { applyChange, applyChanges } from "./jxg-dispatcher";
 import { forEachNormalizedChange, ILinkProperties, JXGChange, JXGProperties, JXGCoordPair, JXGParentType
@@ -1131,4 +1131,19 @@ function preprocessImportFormat(snapshot: any) {
   return {
     changes: changes.map(change => JSON.stringify(change))
   };
+}
+
+export function mapTileIdsInGeometrySnapshot(snapshot: SnapshotOut<GeometryContentModelType>,
+                                             idMap: { [id: string]: string }) {
+  snapshot.changes = snapshot.changes.map(changeJson => {
+    const change: JXGChange = safeJsonParse(changeJson);
+    if ((change.operation === "create") && (change.target === "tableLink")) {
+      change.targetID = idMap[change.targetID as string];
+    }
+    if (change.links) {
+      change.links.tileIds = change.links.tileIds.map(id => idMap[id]);
+    }
+    return JSON.stringify(change);
+  });
+  return snapshot;
 }

--- a/src/models/tools/geometry/jxg-dispatcher.ts
+++ b/src/models/tools/geometry/jxg-dispatcher.ts
@@ -11,7 +11,8 @@ import { vertexAngleChangeAgent } from "./jxg-vertex-angle";
 import { castArrayCopy } from "../../../utilities/js-utils";
 import { castArray } from "lodash";
 
-type OnChangeApplied = (board: JXG.Board | undefined, change: JXGChange) => void;
+type OnWillApplyChange = (board: JXG.Board | string, change: JXGChange) => void;
+type OnDidApplyChange = (board: JXG.Board | undefined, change: JXGChange) => void;
 
 interface JXGChangeAgents {
   [key: string]: JXGChangeAgent;
@@ -31,10 +32,12 @@ const agents: JXGChangeAgents = {
 };
 
 export function applyChanges(board: JXG.Board|string, changes: JXGChange[],
-                             onChangeApplied?: OnChangeApplied): JXGChangeResult[] {
+                             onWillApplyChange?: OnWillApplyChange,
+                             onDidApplyChange?: OnDidApplyChange): JXGChangeResult[] {
   let _board: JXG.Board | undefined;
   const results = changes.map(change => {
-                    const result = applyChange(_board || board, change, onChangeApplied);
+                    const result = applyChange(_board || board, change,
+                                               onWillApplyChange, onDidApplyChange);
                     const resultBoard = castArray(result).find(isBoard) as JXG.Board;
                     if ((typeof board === "string") && resultBoard) {
                       _board = resultBoard;
@@ -49,9 +52,16 @@ export function applyChanges(board: JXG.Board|string, changes: JXGChange[],
 }
 
 export function applyChange(board: JXG.Board|string, change: JXGChange,
-                            onChangeApplied?: OnChangeApplied): JXGChangeResult {
+                            onWillApplyChange?: OnWillApplyChange,
+                            onDidApplyChange?: OnDidApplyChange): JXGChangeResult {
   let _board = board as JXG.Board;
   const target = change.target.toLowerCase();
+
+  // give clients a chance to intercede before the change is applied
+  if (onWillApplyChange) {
+    onWillApplyChange(board, change);
+  }
+
   // special case for update/object, where we dispatch by object type
   if ((change.operation === "update") && (target === "object")) {
     applyUpdateObjects(_board, change);
@@ -63,10 +73,13 @@ export function applyChange(board: JXG.Board|string, change: JXGChange,
     return;
   }
   const result = dispatchChange(board, change);
-  if (onChangeApplied) {
+
+  // give clients a chance to intercede after the change has been applied
+  if (onDidApplyChange) {
     if (isBoard(result)) _board = result as JXG.Board;
-    onChangeApplied(_board, change);
+    onDidApplyChange(_board, change);
   }
+
   return result;
 }
 

--- a/src/models/tools/geometry/jxg-table-link.ts
+++ b/src/models/tools/geometry/jxg-table-link.ts
@@ -7,8 +7,17 @@ export const isLinkedPoint = (v: any) => isPoint(v) && (v.getAttribute("clientTy
 // Eventually should use a different color for each table
 const linkedPointColor = "#0099FF";
 
+export type IsValidTableLinkFunctionType = (boardId: string, tableId?: string) => boolean;
+
+let isValidTableLinkFunction: IsValidTableLinkFunctionType;
+
+export function injectIsValidTableLinkFunction(isValidTableLink: IsValidTableLinkFunctionType) {
+  isValidTableLinkFunction = isValidTableLink;
+}
+
 function createLinkedPoint(board: JXG.Board, parents: JXGCoordPair, props: any, links?: ILinkProperties) {
   const tableId = links && links.tileIds && links.tileIds[0];
+  if (!isValidTableLinkFunction(board.container, tableId)) return;
   const linkedProps = {
           clientType: "linkedPoint",
           fixed: true,

--- a/src/models/tools/table/table-content.ts
+++ b/src/models/tools/table/table-content.ts
@@ -316,7 +316,8 @@ export const TableContentModel = types
           break;
         case "geometryLink":
           const geometryId = change.ids && change.ids as string;
-          geometryId && self.metadata.addLinkedGeometry(geometryId);
+          const geometryContent = geometryId && self.getGeometryContent(geometryId);
+          geometryContent && self.metadata.addLinkedGeometry(geometryId!);
           break;
       }
     },

--- a/src/models/tools/table/table-content.ts
+++ b/src/models/tools/table/table-content.ts
@@ -1,4 +1,4 @@
-import { types, Instance } from "mobx-state-tree";
+import { types, Instance, SnapshotOut } from "mobx-state-tree";
 import { IDataSet, ICaseCreation, ICase, DataSet } from "../../data/data-set";
 import { safeJsonParse, uniqueId } from "../../../utilities/js-utils";
 import { castArray, each } from "lodash";
@@ -455,4 +455,19 @@ export function convertImportToChanges(snapshot: any) {
     changes.push({ action: "create", target: "rows", props: { rows } });
   }
   return changes.map(change => JSON.stringify(change));
+}
+
+export function mapTileIdsInTableSnapshot(snapshot: SnapshotOut<TableContentModelType>,
+                                          idMap: { [id: string]: string }) {
+  snapshot.changes = snapshot.changes.map(changeJson => {
+    const change: ITableChange = safeJsonParse(changeJson);
+    if ((change.action === "create") && (change.target === "geometryLink")) {
+      change.ids = idMap[change.ids as string];
+    }
+    if (change.links) {
+      change.links.tileIds = change.links.tileIds.map(id => idMap[id]);
+    }
+    return JSON.stringify(change);
+  });
+  return snapshot;
 }


### PR DESCRIPTION
There were several related issues at work here:
- During publication tile IDs are mapped to new IDs. Since linked actions contain tile IDs, linked actions need to be updated during publication.
- When processing linked actions, table must validate that the corresponding geometry tile is present.
- When processing linked actions, the geometry tile must validate that the corresponding table tile is present.

With these changes, publication of a document should retain any table-geometry links, but copying a linked table or graph to a new document (that doesn't contain the other end of the link) should result in an unlinked table or graph.