### PR TITLE
Fixed error reading uid from undefined "self" field on group user

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -186,7 +186,11 @@ export interface PortalFirebaseTeacherJWT extends BasePortalFirebaseJWT {
 export type PortalFirebaseJWT = PortalFirebaseStudentJWT | PortalFirebaseTeacherJWT;
 
 export const getErrorMessage = (err: any, res: superagent.Response) => {
-  return (res.body ? res.body.message : null) || err;
+  // The response should always be non-null, per the typedef and documentation:
+  // cf. https://visionmedia.github.io/superagent/#error-handling
+  // However, Rollbar has reported errors due to undefined responses
+  // Using err.status or err.response, per the above link, may be preferable here
+  return (res && res.body ? res.body.message : null) || err;
 };
 
 export const getPortalJWTWithBearerToken = (basePortalUrl: string, type: string, rawToken: string) => {


### PR DESCRIPTION
This is the fix we discussed for this rollbar error:

https://rollbar.com/concordconsortium/CLUE/items/63/

`self` was `undefined` for some reason, but we now use the ID we read from Firebase so we no longer depend on `self`.

There was one issue with the fix that took me some thinking to resolve. When we read `rawUsers` from the Firebase snapshot, it's normally a map e.g. `{1001: user, 1002: user}` etc. However, since Firebase doesn't have explicit array support, it can get interpreted as an array by accident for small user IDs! So if a group only has a single user with ID 1, `rawUsers` will instead be an array: `[empty, user]`. Previously, we were using `Object.keys` to get the IDs from that list, which interestingly enough works correctly i.e. it returns `[1]`. Special considerations needed to be added for our new mapping function, which I documented in a comment.