### PR TITLE
Preventing key presses in geometry dialogs from propagating to the board

### DIFF
--- a/src/components/tools/geometry-tool/axis-settings-dialog.tsx
+++ b/src/components/tools/geometry-tool/axis-settings-dialog.tsx
@@ -130,6 +130,7 @@ export default class AxisSettingsDialog extends React.Component<IProps, IState> 
   }
 
   private handleKeyDown = (evt: React.KeyboardEvent<HTMLInputElement>) => {
+    evt.stopPropagation();
     if (evt.keyCode === 13) {
       this.handleAccept();
     } else if (evt.keyCode === 27) {

--- a/src/components/tools/geometry-tool/comment-dialog.tsx
+++ b/src/components/tools/geometry-tool/comment-dialog.tsx
@@ -71,6 +71,7 @@ class CommentDialog extends React.Component<IProps, IState> {
   }
 
   private handleKeyDown = (evt: React.KeyboardEvent<HTMLInputElement>) => {
+    evt.stopPropagation();
     if (evt.keyCode === 13) {
       this.handleAccept();
     } else if (evt.keyCode === 27) {

--- a/src/components/tools/geometry-tool/movable-line-dialog.tsx
+++ b/src/components/tools/geometry-tool/movable-line-dialog.tsx
@@ -137,6 +137,7 @@ class MovableLineDialog extends React.Component<IProps, IState> {
   }
 
   private handleKeyDown = (evt: React.KeyboardEvent<HTMLInputElement>) => {
+    evt.stopPropagation();
     if (evt.keyCode === 13) {
       this.handleAccept();
     } else if (evt.keyCode === 27) {


### PR DESCRIPTION
Last bug found by @eireland - key presses on dialogs were reaching the board, so backspace deleted highlighted elements, you could undo actions etc. Now I'm stopping key propagation in all geometry dialogs.

Of course, this is another PR that shows the need to eventually refactor all the dialog code...