### PR TITLE
Rename `GroupViewComponent` to `AppContentComponent`

### DIFF
--- a/cypress/integration/group_chooser_spec.js
+++ b/cypress/integration/group_chooser_spec.js
@@ -82,7 +82,7 @@ describe('Test student join a group', function(){
     it('will verify cancel of leave group dialog',function(){
         //have student leave first group and join second group
         setup(student5);
-        cy.get('.app > .group-view > .header > .group > .name').contains('Group '+group1).click();
+        cy.get('.app .header > .group > .name').contains('Group '+group1).click();
         cy.get('#cancelButton').should('contain','No').click();
         header.getGroupName().should('contain','Group '+group1);
         header.getUserName().should('contain','Student '+student5);
@@ -92,7 +92,7 @@ describe('Test student join a group', function(){
     it('will verify a student can switch groups',function(){
         //have student leave first group and join second group
         setup(student5);
-        cy.get('.app > .group-view > .header > .group > .name').contains('Group '+group1).click();
+        cy.get('.app .header > .group > .name').contains('Group '+group1).click();
         cy.get("#okButton").should('contain','Yes').click();
         cy.get('.groups > .group-list > .group').contains('Group '+group2).click();
         header.getGroupName().should('contain','Group '+group2);

--- a/src/components/app-content.sass
+++ b/src/components/app-content.sass
@@ -1,6 +1,6 @@
-@import ../vars
+@import ./vars
 
-.group-view
+.app-content
 
   .blocker
     position: absolute

--- a/src/components/app-content.tsx
+++ b/src/components/app-content.tsx
@@ -1,16 +1,16 @@
 import { inject, observer } from "mobx-react";
 import * as React from "react";
-import { HeaderComponent } from "../header";
-import { LeftNavComponent } from "../navigation/left-nav";
-import { RightNavComponent } from "../navigation/right-nav";
-import { BottomNavComponent } from "../navigation/bottom-nav";
-import { DocumentComponent } from "../document/document";
-import { BaseComponent, IBaseProps } from "../base";
-import { DialogComponent } from "../utilities/dialog";
-import { DocumentDragKey, DocumentModelType, DocumentModel, SectionDocument } from "../../models/document/document";
-import { parseGhostSectionDocumentKey } from "../../models/stores/workspace";
+import { HeaderComponent } from "./header";
+import { LeftNavComponent } from "./navigation/left-nav";
+import { RightNavComponent } from "./navigation/right-nav";
+import { BottomNavComponent } from "./navigation/bottom-nav";
+import { DocumentComponent } from "./document/document";
+import { BaseComponent, IBaseProps } from "./base";
+import { DialogComponent } from "./utilities/dialog";
+import { DocumentDragKey, DocumentModelType, DocumentModel, SectionDocument } from "../models/document/document";
+import { parseGhostSectionDocumentKey } from "../models/stores/workspace";
 
-import "./group-view.sass";
+import "./app-content.sass";
 
 type WorkspaceSide = "primary" | "comparison";
 
@@ -24,12 +24,12 @@ const ghostSectionDocuments: GhostDocumentMap = {};
 
 @inject("stores")
 @observer
-export class GroupViewComponent extends BaseComponent<IProps, {}> {
+export class AppContentComponent extends BaseComponent<IProps, {}> {
 
   public render() {
     const isGhostUser = this.stores.groups.ghostUserId === this.stores.user.id;
     return (
-      <div className="group-view">
+      <div className="app-content">
         <HeaderComponent isGhostUser={isGhostUser} />
         {this.renderDocuments(isGhostUser)}
         <LeftNavComponent isGhostUser={isGhostUser} />

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -1,7 +1,7 @@
 import { inject, observer } from "mobx-react";
 import * as React from "react";
 import { authenticate } from "../lib/auth";
-import { GroupViewComponent } from "./group/group-view";
+import { AppContentComponent } from "./app-content";
 import { BaseComponent, IBaseProps } from "./base";
 import { urlParams } from "../utilities/url-params";
 import { DemoCreatorComponment } from "./demo/demo-creator";
@@ -142,7 +142,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
       }
     }
 
-    return this.renderApp(<GroupViewComponent />);
+    return this.renderApp(<AppContentComponent />);
   }
 
   private renderApp(children: JSX.Element | JSX.Element[]) {


### PR DESCRIPTION
Minor code refactor of general interest to CLUE that simplifies the kind of application genericization required to support DataFlow.
- move files from `src/components/group` to `src/components`
- rename CSS class from `.group-view` to `.app-content`
- update cypress tests