### PR TITLE
Remove gratuitous timeouts now that firebase rebound has been removed

### DIFF
--- a/src/components/tools/geometry-tool/geometry-content.tsx
+++ b/src/components/tools/geometry-tool/geometry-content.tsx
@@ -491,7 +491,6 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
         if (imageUrl) {
           this.updateImageUrl(imageUrl);
         }
-        this.hackAxisHandlers(board);
         this.setState({ board });
       }
       this.syncedChanges = content.changes.length;
@@ -506,15 +505,6 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
     return images.length > 0
             ? images[images.length - 1] as JXG.Image
             : undefined;
-  }
-
-  // XXX: Hack - rescaling the board should return the new axes, but they are quickly destroyed and recreated
-  // So, any time new axes could be created, we reattach the axis handlers
-  private hackAxisHandlers(board: JXG.Board) {
-    setTimeout(() => {
-      const axes = board.objectsList.filter(el => isAxis(el)) as JXG.Line[];
-      axes.forEach(this.handleCreateAxis);
-    });
   }
 
   private updateImageUrl(url: string) {
@@ -622,8 +612,10 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
     const { board } = this.state;
     const content = this.getContent();
     if (board) {
-      content.rescaleBoard(board, xMax, yMax, xMin, yMin);
-      this.hackAxisHandlers(board);
+      const axes = content.rescaleBoard(board, xMax, yMax, xMin, yMin);
+      if (axes) {
+        axes.forEach(this.handleCreateAxis);
+      }
     }
     this.setState({ axisSettingsOpen: false });
   }
@@ -690,8 +682,6 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
             LogEventMethod.UNDO);
         });
       }
-
-      this.hackAxisHandlers(board);
     }
 
     return true;
@@ -716,8 +706,6 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
             LogEventMethod.REDO);
         });
       }
-
-      this.hackAxisHandlers(board);
     }
 
     return true;

--- a/src/components/tools/geometry-tool/geometry-content.tsx
+++ b/src/components/tools/geometry-tool/geometry-content.tsx
@@ -927,11 +927,10 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
           this.handleCreatePoint(pt);
         });
       });
-      setTimeout(() => {
-        const _tableContent = this.getTableContent(dragTileId);
-        const tableActionLinks = this.getTableActionLinks(geomActionLinks);
-        _tableContent && _tableContent.addGeometryLink(this.props.model.id, tableActionLinks);
-      });
+
+      const _tableContent = this.getTableContent(dragTileId);
+      const tableActionLinks = this.getTableActionLinks(geomActionLinks);
+      _tableContent && _tableContent.addGeometryLink(this.props.model.id, tableActionLinks);
     }
   }
 

--- a/src/components/tools/table-tool/table-tool.tsx
+++ b/src/components/tools/table-tool/table-tool.tsx
@@ -290,55 +290,36 @@ export default class TableToolComponent extends BaseComponent<IProps, IState> {
     return this.getGeometryActionLinks(links, true);
   }
 
-  // XXX: After changing the content, it is destroyed by MST. We use a timeout between consecutive content updates
-  // in the hopes that the content will be re-created when execution resumes. However, in some cases the content
-  // is still undefined - this function lets us aggregate the resulting errors for monitoring.
-  // Ultimately, the content update problem must be resolved to prevent this from happening.
-  private assertValidContent = () => {
-    const content = this.getContent();
-    if (!content) {
-      const _Rollbar = (window as any).Rollbar;
-      _Rollbar.error("TableTool.assertValidContent: Invalid content after timeout");
-    }
-    return !!content;
-  }
-
   private handleSetAttributeName = (attributeId: string, name: string) => {
     const tableActionLinks = this.getTableActionLinks();
     this.getContent().setAttributeName(attributeId, name);
-    setTimeout(() => {
-      if (!this.assertValidContent()) return;
-      const geomActionLinks = this.getGeometryActionLinksWithLabels(tableActionLinks);
-      this.getContent().metadata.linkedGeometries.forEach(id => {
-        const geometryContent = this.getGeometryContent(id);
-        if (geometryContent) {
-          geometryContent.updateAxisLabels(undefined, this.props.model.id, geomActionLinks);
-        }
-      });
+    const geomActionLinks = this.getGeometryActionLinksWithLabels(tableActionLinks);
+    this.getContent().metadata.linkedGeometries.forEach(id => {
+      const geometryContent = this.getGeometryContent(id);
+      if (geometryContent) {
+        geometryContent.updateAxisLabels(undefined, this.props.model.id, geomActionLinks);
+      }
     });
   }
 
   private handleSetExpression = (attributeId: string, expression: string, rawExpression: string) => {
     this.getContent().setExpression(attributeId, expression, rawExpression);
-    setTimeout(() => {
-      if (!this.assertValidContent()) return;
-      const dataSet = this.state.dataSet;
-      const tableActionLinks = this.getTableActionLinks();
-      const geomActionLinks = this.getGeometryActionLinks(tableActionLinks);
-      const ids: string[] = [];
-      const props: JXGProperties[] = [];
-      dataSet.cases.forEach(aCase => {
-        const caseId = aCase.__id__;
-        ids.push(caseId);
-        const position = this.getPositionOfPoint(caseId) as JXGCoordPair;
-        props.push({ position });
-      });
-      this.getContent().metadata.linkedGeometries.forEach(id => {
-        const geometryContent = this.getGeometryContent(id);
-        if (geometryContent) {
-          geometryContent.updateObjects(undefined, ids, props, geomActionLinks);
-        }
-      });
+    const dataSet = this.state.dataSet;
+    const tableActionLinks = this.getTableActionLinks();
+    const geomActionLinks = this.getGeometryActionLinks(tableActionLinks);
+    const ids: string[] = [];
+    const props: JXGProperties[] = [];
+    dataSet.cases.forEach(aCase => {
+      const caseId = aCase.__id__;
+      ids.push(caseId);
+      const position = this.getPositionOfPoint(caseId) as JXGCoordPair;
+      props.push({ position });
+    });
+    this.getContent().metadata.linkedGeometries.forEach(id => {
+      const geometryContent = this.getGeometryContent(id);
+      if (geometryContent) {
+        geometryContent.updateObjects(undefined, ids, props, geomActionLinks);
+      }
     });
   }
 
@@ -360,17 +341,14 @@ export default class TableToolComponent extends BaseComponent<IProps, IState> {
     const firstSelectedRowId = selectedRowIds && selectedRowIds.length && selectedRowIds[0] || undefined;
     const tableActionLinks = this.getTableActionLinks();
     this.getContent().addCanonicalCases(cases as ICaseCreation[], firstSelectedRowId, tableActionLinks);
-    setTimeout(() => {
-      if (!this.assertValidContent()) return;
-      const parents = cases.map(aCase => this.getPositionOfPoint(aCase.__id__));
-      const props = cases.map(aCase => ({ id: aCase.__id__ }));
-      const geomActionLinks = this.getGeometryActionLinksWithLabels(tableActionLinks);
-      this.getContent().metadata.linkedGeometries.forEach(id => {
-        const geometryContent = this.getGeometryContent(id);
-        if (geometryContent) {
-          geometryContent.addPoints(undefined, parents, props, geomActionLinks);
-        }
-      });
+    const parents = cases.map(aCase => this.getPositionOfPoint(aCase.__id__));
+    const props = cases.map(aCase => ({ id: aCase.__id__ }));
+    const geomActionLinks = this.getGeometryActionLinksWithLabels(tableActionLinks);
+    this.getContent().metadata.linkedGeometries.forEach(id => {
+      const geometryContent = this.getGeometryContent(id);
+      if (geometryContent) {
+        geometryContent.addPoints(undefined, parents, props, geomActionLinks);
+      }
     });
   }
 
@@ -378,32 +356,26 @@ export default class TableToolComponent extends BaseComponent<IProps, IState> {
     const caseId = caseValues.__id__;
     const tableActionLinks = this.getTableActionLinks();
     this.getContent().setCanonicalCaseValues([caseValues], tableActionLinks);
-    setTimeout(() => {
-      if (!this.assertValidContent()) return;
-      const geomActionLinks = this.getGeometryActionLinks(tableActionLinks);
-      this.getContent().metadata.linkedGeometries.forEach(id => {
-        const newPosition = this.getPositionOfPoint(caseId);
-        const position = newPosition as JXGCoordPair;
-        const geometryContent = this.getGeometryContent(id);
-        if (geometryContent) {
-          geometryContent.updateObjects(undefined, caseId, { position }, geomActionLinks);
-        }
-      });
+    const geomActionLinks = this.getGeometryActionLinks(tableActionLinks);
+    this.getContent().metadata.linkedGeometries.forEach(id => {
+      const newPosition = this.getPositionOfPoint(caseId);
+      const position = newPosition as JXGCoordPair;
+      const geometryContent = this.getGeometryContent(id);
+      if (geometryContent) {
+        geometryContent.updateObjects(undefined, caseId, { position }, geomActionLinks);
+      }
     });
   }
 
   private handleRemoveCases = (ids: string[]) => {
     const tableActionLinks = this.getTableActionLinks();
     this.getContent().removeCases(ids, tableActionLinks);
-    setTimeout(() => {
-      if (!this.assertValidContent()) return;
-      const geomActionLinks = this.getGeometryActionLinksWithLabels(tableActionLinks);
-      this.getContent().metadata.linkedGeometries.forEach(id => {
-        const geometryContent = this.getGeometryContent(id);
-        if (geometryContent) {
-          geometryContent.removeObjects(undefined, ids, geomActionLinks);
-        }
-      });
+    const geomActionLinks = this.getGeometryActionLinksWithLabels(tableActionLinks);
+    this.getContent().metadata.linkedGeometries.forEach(id => {
+      const geometryContent = this.getGeometryContent(id);
+      if (geometryContent) {
+        geometryContent.removeObjects(undefined, ids, geomActionLinks);
+      }
     });
   }
 }

--- a/src/models/tools/geometry/geometry-content.ts
+++ b/src/models/tools/geometry/geometry-content.ts
@@ -406,7 +406,8 @@ export const GeometryContentModel = types
         targetID: board.id,
         properties: { boardScale: {xMin, yMin, unitX, unitY, canvasWidth: width, canvasHeight: height} }
       };
-      _applyChange(undefined, change);
+      const axes = _applyChange(undefined, change);
+      return axes ? axes as any as JXG.Line[] : undefined;
     }
 
     function updateScale(board: JXG.Board, scale: number) {

--- a/src/models/tools/geometry/jxg-board.ts
+++ b/src/models/tools/geometry/jxg-board.ts
@@ -194,7 +194,7 @@ export const boardChangeAgent: JXGChangeAgent = {
           });
           const axes = addAxes(board, unitX, unitY);
           board.update();
-          return [...axes];
+          return axes;
         }
       }
     }

--- a/src/models/tools/geometry/jxg-board.ts
+++ b/src/models/tools/geometry/jxg-board.ts
@@ -192,10 +192,11 @@ export const boardChangeAgent: JXGChangeAgent = {
               board.removeObject(el);
             }
           });
-          addAxes(board, unitX, unitY);
+          const axes = addAxes(board, unitX, unitY);
+          board.update();
+          return [...axes];
         }
       }
-      board.update();
     }
   },
 

--- a/src/models/tools/geometry/jxg-changes.ts
+++ b/src/models/tools/geometry/jxg-changes.ts
@@ -49,7 +49,7 @@ export type JXGChangeResult = JXGElement | JXGElement[] | undefined;
 // for create/board the board parameter is the ID of the DOM element
 // for all other changes it should be the board
 export type JXGCreateHandler = (board: JXG.Board|string, change: JXGChange) => JXGChangeResult;
-export type JXGUpdateHandler = (board: JXG.Board, change: JXGChange) => void;
+export type JXGUpdateHandler = (board: JXG.Board, change: JXGChange) => JXGChangeResult;
 export type JXGDeleteHandler = (board: JXG.Board, change: JXGChange) => void;
 
 export interface JXGChangeAgent {

--- a/src/models/tools/geometry/jxg-comment.ts
+++ b/src/models/tools/geometry/jxg-comment.ts
@@ -124,6 +124,7 @@ export const commentChangeAgent: JXGChangeAgent = {
       // other properties can be handled generically
       objectChangeAgent.update(board, change);
     }
+    return undefined;
   },
 
   // delete can be handled generically

--- a/src/models/tools/geometry/jxg-image.ts
+++ b/src/models/tools/geometry/jxg-image.ts
@@ -41,6 +41,7 @@ export const imageChangeAgent: JXGChangeAgent = {
     });
     // other properties can be handled generically
     objectChangeAgent.update(board, change);
+    return undefined;
   },
 
   // delete can be handled generically

--- a/src/models/tools/geometry/jxg-object.ts
+++ b/src/models/tools/geometry/jxg-object.ts
@@ -53,6 +53,7 @@ export const objectChangeAgent: JXGChangeAgent = {
       }
     });
     board.update();
+    return undefined;
   },
 
   delete: (board, change) => {


### PR DESCRIPTION
Note: I'm creating this PR for @ekosmin , who did the underlying work before he left for vacation.

This PR is based on PR #300 , which should be reviewed/merged first and then this PR rebased on top of master once the other has been merged to master. It eliminates several hacks/kludges introduced to deal with the consequences of the firebase rebound, which can now be eliminated thanks to the elimination of the rebound itself.
- Geometry: remove timeout for axis rescaling
- Geometry: remove timeout from `handleTableTileDrop()`
- Table: remove obsolete timeouts in data tables
