### PR TITLE
166111125 simple slope fix

### DIFF
--- a/src/models/tools/geometry/jxg-movable-line.test.ts
+++ b/src/models/tools/geometry/jxg-movable-line.test.ts
@@ -3,13 +3,17 @@ import { getBoundingBoxIntersections } from "./jxg-movable-line";
 describe("Movable line utils", () => {
 
   it("calculates boundary intersections on edges", () => {
-    const mockBoard = {attr: {boundingbox: [-1, 5, 5, -1]}} as any as JXG.Board;
+    const mockBoard = {
+      getBoundingBox: () => [-1, 5, 5, -1]
+    } as JXG.Board;
     const intersections = getBoundingBoxIntersections(0, 3, mockBoard);
     expect(intersections).toEqual([[-1, 3], [5, 3]]);
   });
 
   it("calculates boundary intersections on corners", () => {
-    const mockBoard = {attr: {boundingbox: [-5, 5, 5, -5]}} as any as JXG.Board;
+    const mockBoard = {
+      getBoundingBox: () => [-5, 5, 5, -5]
+    } as JXG.Board;
     const intersections = getBoundingBoxIntersections(1, 0, mockBoard);
     expect(intersections).toEqual([[-5, -5], [5, 5]]);
   });

--- a/src/models/tools/geometry/jxg-movable-line.ts
+++ b/src/models/tools/geometry/jxg-movable-line.ts
@@ -1,6 +1,6 @@
 import { JXGChangeAgent } from "./jxg-changes";
 import { objectChangeAgent } from "./jxg-object";
-import { kSnapUnit, syncClientColors } from "./jxg-point";
+import { syncClientColors } from "./jxg-point";
 import { castArray, each, find, uniqWith } from "lodash";
 import { uniqueId } from "../../../utilities/js-utils";
 import { GeometryContentModelType } from "./geometry-content";
@@ -98,10 +98,10 @@ const lineSpecificProps = {
 };
 
 const pointSpecificProps = {
-  snapToGrid: true,
-  snapSizeX: kSnapUnit,
-  snapSizeY: kSnapUnit,
+  snapToGrid: false,
   highlightStrokeColor: darkBlue,
+  clientUndeletable: true,
+  showInfobox: false,
   name: "",
 };
 
@@ -121,7 +121,6 @@ export const movableLineChangeAgent: JXGChangeAgent = {
           id: `${lineId}-point1`,
           ...pointProps,
           ...pt1,
-          clientUndeletable: true
         }
       );
       const slopePoint = (board as JXG.Board).create(
@@ -131,7 +130,6 @@ export const movableLineChangeAgent: JXGChangeAgent = {
           id: `${lineId}-point2`,
           ...pointProps,
           ...pt2,
-          clientUndeletable: true
         }
       );
       const overrides = {

--- a/src/models/tools/geometry/jxg-movable-line.ts
+++ b/src/models/tools/geometry/jxg-movable-line.ts
@@ -34,7 +34,7 @@ export const isMovableLineEquation = (v: any) => {
 
 // Returns the two points where the given line intersects the given board, sorted from left to right
 export const getBoundingBoxIntersections = (slope: number, intercept: number, board: JXG.Board) => {
-  const boundingBox = board.attr.boundingbox;
+  const boundingBox = board.getBoundingBox();
   const leftX = boundingBox[0];
   const topY = boundingBox[1];
   const rightX = boundingBox[2];


### PR DESCRIPTION
Graph control points are no longer snapped to the grid, and bounding boxes are calculated correctly during control point calculation.