### PR TITLE
Make movable line labels/equations draggable

### DIFF
--- a/src/components/tools/geometry-tool/geometry-content.tsx
+++ b/src/components/tools/geometry-tool/geometry-content.tsx
@@ -9,12 +9,12 @@ import { GeometryContentModelType, GeometryMetadataModelType, setElementColor
 import { copyCoords, getEventCoords, getAllObjectsUnderMouse, getClickableObjectUnderMouse,
           isDragTargetOrAncestor } from "../../../models/tools/geometry/geometry-utils";
 import { RotatePolygonIcon } from "./rotate-polygon-icon";
-import { kGeometryDefaultPixelsPerUnit, isAxis, isAxisLabel, isBoard } from "../../../models/tools/geometry/jxg-board";
+import { kGeometryDefaultPixelsPerUnit, isAxis, isAxisLabel } from "../../../models/tools/geometry/jxg-board";
 import { JXGChange, ILinkProperties, JXGCoordPair } from "../../../models/tools/geometry/jxg-changes";
-import { isComment } from "../../../models/tools/geometry/jxg-comment";
 import { isPoint, isFreePoint, isVisiblePoint, kSnapUnit } from "../../../models/tools/geometry/jxg-point";
 import { getPointsForVertexAngle, getPolygonEdges, isPolygon, isVisibleEdge
         } from "../../../models/tools/geometry/jxg-polygon";
+import { isComment } from "../../../models/tools/geometry/jxg-types";
 import { getVertexAngle, isVertexAngle, updateVertexAngle, updateVertexAnglesFromObjects
         } from "../../../models/tools/geometry/jxg-vertex-angle";
 import { injectIsValidTableLinkFunction } from "../../../models/tools/geometry/jxg-table-link";

--- a/src/components/tools/geometry-tool/geometry-content.tsx
+++ b/src/components/tools/geometry-tool/geometry-content.tsx
@@ -1529,13 +1529,6 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
 
           content.selectElement(text.id);
         }
-      } else if (isMovableLineEquation(text)) {
-        if (board) {
-          const parentLine = values(text.ancestors)[0] as JXG.Line;
-          if (parentLine && !readOnly) {
-            this.setState({selectedLine: parentLine});
-          }
-        }
       }
     };
 
@@ -1551,6 +1544,19 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
     };
 
     const handlePointerUp = (evt: any) => {
+      const { readOnly } = this.props;
+      const { board } = this.state;
+      if (isMovableLineEquation(text) && board) {
+        // Extended clicks/drags don't open the movable line dialog
+        const clickTimeThreshold = 500;
+        if (evt.timeStamp - this.lastBoardDown.evt.timeStamp < clickTimeThreshold) {
+          const parentLine = values(text.ancestors)[0] as JXG.Line;
+          if (parentLine && !readOnly) {
+            this.setState({selectedLine: parentLine});
+          }
+        }
+      }
+
       const id = text.id;
       const dragEntry = this.dragPts[id];
       if (!dragEntry) { return; }

--- a/src/models/tools/geometry/geometry-content.ts
+++ b/src/models/tools/geometry/geometry-content.ts
@@ -524,17 +524,6 @@ export const GeometryContentModel = types
       return elems ? elems as JXG.GeometryElement[] : undefined;
     }
 
-    function updateComment(board: JXG.Board, commentId: string, properties: JXGProperties) {
-      const change: JXGChange = {
-        operation: "update",
-        target: "comment",
-        targetID: commentId,
-        properties
-      };
-      const comment = _applyChange(undefined, change);
-      return comment ? comment as JXG.Text : undefined;
-    }
-
     function removeObjects(board: JXG.Board | undefined, ids: string | string[], links?: ILinkProperties) {
       const change: JXGChange = {
         operation: "delete",
@@ -960,7 +949,6 @@ export const GeometryContentModel = types
         applyChange: _applyChange,
         syncChange,
         addComment,
-        updateComment,
 
         suspendSync() {
           ++suspendCount;

--- a/src/models/tools/geometry/geometry-content.ts
+++ b/src/models/tools/geometry/geometry-content.ts
@@ -5,11 +5,11 @@ import { forEachNormalizedChange, ILinkProperties, JXGChange, JXGProperties, JXG
   JXGUnsafeCoordPair } from "./jxg-changes";
 import { guessUserDesiredBoundingBox, isBoard, kAxisBuffer, kGeometryDefaultAxisMin, kGeometryDefaultHeight,
           kGeometryDefaultWidth, kGeometryDefaultPixelsPerUnit, syncAxisLabels } from "./jxg-board";
-import { isComment } from "./jxg-comment";
 import { isMovableLine } from "./jxg-movable-line";
 import { isFreePoint, isPoint, kPointDefaults, kSnapUnit } from "./jxg-point";
 import { isPolygon, isVisibleEdge, prepareToDeleteObjects } from "./jxg-polygon";
 import { isLinkedPoint } from "./jxg-table-link";
+import { isComment } from "./jxg-types";
 import { isVertexAngle } from "./jxg-vertex-angle";
 import { IDataSet } from "../../data/data-set";
 import { assign, castArray, each, keys, omit, size as _size } from "lodash";

--- a/src/models/tools/geometry/jsxgraph.d.ts
+++ b/src/models/tools/geometry/jsxgraph.d.ts
@@ -108,7 +108,7 @@ declare namespace JXG {
     name: string;
     ancestors: { [id: string]: GeometryElement };
     descendants: { [id: string]: GeometryElement };
-    parents: Array<string | GeometryElement>;
+    parents: string[];
     childElements: { [id: string]: GeometryElement };
     isDraggable: boolean;
     lastDragTime: Date;
@@ -125,6 +125,7 @@ declare namespace JXG {
     getAttribute: (key: string) => any;
     setAttribute: (attrs: any) => void;
     setPosition: (method: number, coords: number[]) => JXG.Point;
+    getLabelAnchor: () => JXG.Coords;
     on: (event: string, handler: EventHandler) => void;
     _set: (key: string, value: string) => void;
   }

--- a/src/models/tools/geometry/jsxgraph.d.ts
+++ b/src/models/tools/geometry/jsxgraph.d.ts
@@ -106,6 +106,8 @@ declare namespace JXG {
     elType: string;
     type: number;
     name: string;
+    hasLabel: boolean;
+    label?: JXG.Text;
     ancestors: { [id: string]: GeometryElement };
     descendants: { [id: string]: GeometryElement };
     parents: string[];
@@ -148,7 +150,6 @@ declare namespace JXG {
     parentPolygon?: JXG.Polygon;
     getRise: () => number;
     getSlope: () => number;
-    label?: JXG.Text;
   }
 
   class Text extends CoordsElement {

--- a/src/models/tools/geometry/jxg-comment.ts
+++ b/src/models/tools/geometry/jxg-comment.ts
@@ -7,10 +7,6 @@ import { isPolygon, isVisibleEdge } from "./jxg-polygon";
 import { values } from "lodash";
 import { uniqueId } from "../../../utilities/js-utils";
 
-export const isCommentType = (v: any) => v && v.getAttribute("clientType") === "comment";
-
-export const isComment = (v: any) => isCommentType(v) && (v instanceof JXG.Text) && (v.elType === "text");
-
 const sharedProps = {
   strokeWidth: 1,
   clientType: "comment",

--- a/src/models/tools/geometry/jxg-comment.ts
+++ b/src/models/tools/geometry/jxg-comment.ts
@@ -1,7 +1,7 @@
-import { JXGChangeAgent, JXGProperties, JXGCoordPair } from "./jxg-changes";
+import { JXGChangeAgent } from "./jxg-changes";
 import { isBoard } from "./jxg-board";
 import { isMovableLine } from "./jxg-movable-line";
-import { objectChangeAgent, isPositionGraphable } from "./jxg-object";
+import { objectChangeAgent } from "./jxg-object";
 import { isPoint } from "./jxg-point";
 import { isPolygon, isVisibleEdge } from "./jxg-polygon";
 import { values } from "lodash";
@@ -102,31 +102,8 @@ export const commentChangeAgent: JXGChangeAgent = {
     }
   },
 
-  update: (board, change) => {
-    if (!change.targetID || !change.properties) { return; }
-    const id = change.targetID as string;
-    const obj = board.objects[id] as JXG.Text;
-    if (obj) {
-      const props = change.properties as JXGProperties;
-      const { text, position } = props;
-      if (text != null) {
-        obj.setText(text);
-        board.update();
-      }
-      if (position && isPositionGraphable(position)) {
-        // Element coordinates are not updated until a redraw occurs. So if redraws are suspended, and a comment or its
-        // anchor has moved, the transform will be calculated from a stale position. We unsuspend updates to force a
-        // refresh on coordinate positions.
-        const wasSuspended = board.isSuspendedUpdate;
-        if (wasSuspended) board.unsuspendUpdate();
-        obj.setPosition(JXG.COORDS_BY_USER, position as JXGCoordPair);
-        board.update();
-        if (wasSuspended) board.suspendUpdate();
-      }
-      // other properties can be handled generically
-      objectChangeAgent.update(board, change);
-    }
-  },
+  // update can be handled generically
+  update: objectChangeAgent.update,
 
   // delete can be handled generically
   delete: objectChangeAgent.delete

--- a/src/models/tools/geometry/jxg-movable-line.ts
+++ b/src/models/tools/geometry/jxg-movable-line.ts
@@ -28,7 +28,7 @@ export const handleControlPointClick = (point: JXG.Point, content: GeometryConte
   }
 };
 
-export const isMovableLineEquation = (v: any) => {
+export const isMovableLineLabel = (v: any) => {
   return v instanceof JXG.Text && v.getAttribute("clientType") === kMovableLineType;
 };
 
@@ -104,6 +104,17 @@ const pointSpecificProps = {
   showInfobox: false,
   name: "",
 };
+
+// given a movable line or its label or one of its control points, return the line itself
+export function findMovableLineRelative(obj: JXG.GeometryElement): JXG.Line | undefined {
+  if (isMovableLine(obj)) return obj as JXG.Line;
+  if (isMovableLineControlPoint(obj)) {
+    return find(obj.childElements, child => isMovableLine(child)) as JXG.Line | undefined;
+  }
+  if (isMovableLineLabel(obj)) {
+    return find(obj.ancestors, ancestor => isMovableLine(ancestor)) as JXG.Line | undefined;
+  }
+}
 
 export const movableLineChangeAgent: JXGChangeAgent = {
   create: (board, change) => {

--- a/src/models/tools/geometry/jxg-movable-line.ts
+++ b/src/models/tools/geometry/jxg-movable-line.ts
@@ -154,7 +154,8 @@ export const movableLineChangeAgent: JXGChangeAgent = {
             anchorY: "bottom",
             fontSize: 15,
             offset: [25, 0],
-            clientType: kMovableLineType
+            clientType: kMovableLineType,
+            fixed: false
           },
           ...line,
           ...overrides

--- a/src/models/tools/geometry/jxg-object.ts
+++ b/src/models/tools/geometry/jxg-object.ts
@@ -1,6 +1,6 @@
 import { sortByCreation, kReverse } from "./jxg-board";
 import { JXGChangeAgent, JXGProperties, JXGCoordPair, JXGUnsafeCoordPair } from "./jxg-changes";
-import { isComment } from "./jxg-comment";
+import { isComment } from "./jxg-types";
 import { castArrayCopy } from "../../../utilities/js-utils";
 import { castArray, find, size } from "lodash";
 

--- a/src/models/tools/geometry/jxg-point.ts
+++ b/src/models/tools/geometry/jxg-point.ts
@@ -1,7 +1,7 @@
 import { JXGChangeAgent, JXGCoordPair, JXGUnsafeCoordPair } from "./jxg-changes";
-import { isCommentType } from "./jxg-comment";
 import { objectChangeAgent, isPositionGraphable, getGraphablePosition } from "./jxg-object";
 import { prepareToDeleteObjects } from "./jxg-polygon";
+import { isCommentType } from "./jxg-types";
 import { castArray, values } from "lodash";
 import * as uuid from "uuid/v4";
 

--- a/src/models/tools/geometry/jxg-types.ts
+++ b/src/models/tools/geometry/jxg-types.ts
@@ -1,0 +1,2 @@
+export const isCommentType = (v: any) => v && v.getAttribute("clientType") === "comment";
+export const isComment = (v: any) => isCommentType(v) && (v instanceof JXG.Text) && (v.elType === "text");


### PR DESCRIPTION
Deal with potentially overlapping movable line labels by allowing the user to drag them to new locations. Attempting to re-layout movable line labels automatically is left as a potential (expensive) future improvement.