### PR TITLE
Fix load/reload of empty document prevents subsequent document saves

### DIFF
--- a/src/lib/db-listeners/index.ts
+++ b/src/lib/db-listeners/index.ts
@@ -202,12 +202,10 @@ export class DBListeners {
         const updatedDoc: DBDocument = snapshot.val();
         const updatedContent = this.db.parseDocumentContent(updatedDoc, initialLoad);
         initialLoad = false;
-        if (updatedContent) {
-          const documentModel = documents.getDocument(documentKey);
-          if (documentModel) {
-            documentModel.setContent(DocumentContentModel.create(updatedContent));
-            this.monitorDocumentModel(documentModel);
-          }
+        const documentModel = documents.getDocument(documentKey);
+        if (documentModel) {
+          documentModel.setContent(DocumentContentModel.create(updatedContent || {}));
+          this.monitorDocumentModel(documentModel);
         }
       }
     });
@@ -223,11 +221,11 @@ export class DBListeners {
     }
 
     const updateRef = this.db.firebase.ref(this.db.firebase.getUserDocumentPath(user, key));
-    docListener.modelDisposer = (onSnapshot(content, (newContent) => {
-      updateRef.update({
-        content: JSON.stringify(newContent)
-      });
-    }));
+    docListener.modelDisposer = onSnapshot(content, (newContent) => {
+                                  updateRef.update({
+                                    content: JSON.stringify(newContent)
+                                  });
+                                });
   }
 
   private stopModelListeners() {


### PR DESCRIPTION
Fix listeners when loading empty document -- caused data loss in classroom