### PR TITLE
Update to TypeScript 3.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17299,9 +17299,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "tslint": "^5.18.0",
     "tslint-loader": "^3.6.0",
     "tslint-react": "^4.0.0",
-    "typescript": "~3.4.5",
+    "typescript": "^3.5.3",
     "url-loader": "^2.0.1",
     "wait-on": "^3.3.0",
     "webpack": "^4.35.3",

--- a/src/components/tools/geometry-tool/geometry-content.tsx
+++ b/src/components/tools/geometry-tool/geometry-content.tsx
@@ -4,6 +4,7 @@ import { SizeMeProps } from "react-sizeme";
 import { BaseComponent } from "../../base";
 import { Alert, Intent } from "@blueprintjs/core";
 import { DocumentContentModelType } from "../../../models/document/document-content";
+import { getTableContent } from "../../../models/tools/table/table-content";
 import { IGeometryProps, IActionHandlers } from "./geometry-shared";
 import { GeometryContentModelType, GeometryMetadataModelType, setElementColor, getImageUrl
         } from "../../../models/tools/geometry/geometry-content";
@@ -439,7 +440,8 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
     const { board, disableRotate } = this.state;
     const selectedPolygon = board && !disableRotate && !this.props.readOnly
                               ? this.getContent().getOneSelectedPolygon(board) : undefined;
-    const rotatablePolygon = selectedPolygon && selectedPolygon.vertices.every(pt => !pt.getAttribute("fixed"))
+    const rotatablePolygon = selectedPolygon &&
+                              selectedPolygon.vertices.every((pt: JXG.Point) => !pt.getAttribute("fixed"))
                               ? selectedPolygon : undefined;
     return (
       <RotatePolygonIcon
@@ -481,7 +483,7 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
   }
 
   private getTableContent(tableId: string) {
-    return this.getContent().getTableContent(tableId);
+    return getTableContent(this.getContent(), tableId);
   }
 
   private initializeContent() {
@@ -507,7 +509,7 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
     const board = _board || this.state.board;
     if (!board) return;
     const images = this.getContent()
-                      .findObjects(board, obj => obj.elType === "image");
+                      .findObjects(board, (obj: JXG.GeometryElement) => obj.elType === "image");
     return images.length > 0
             ? images[images.length - 1] as JXG.Image
             : undefined;
@@ -580,7 +582,7 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
       if (commentAnchor) {
         this.applyChange(() => {
             const elems = content.addComment(board, commentAnchor.id);
-            const comment = elems && elems.find(elem => isComment(elem)) as JXG.Text;
+            const comment = elems && elems.find((elem: JXG.GeometryElement) => isComment(elem)) as JXG.Text;
             if (comment) {
               this.handleCreateText(comment);
               this.setState({selectedComment: comment});
@@ -888,8 +890,8 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
               const width = image.width! / kGeometryDefaultPixelsPerUnit;
               const height = image.height! / kGeometryDefaultPixelsPerUnit;
               const imageIds = geometryContent
-                                .findObjects(board, obj => obj.elType === "image")
-                                .map(obj => obj.id);
+                                .findObjects(board, (obj: JXG.GeometryElement) => obj.elType === "image")
+                                .map((obj: JXG.GeometryElement) => obj.id);
               const contentUrl = image.contentUrl || url;
               this.applyChanges(() => {
                 if (imageIds.length) {
@@ -929,7 +931,7 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
       const geomActionLinks = tableContent.getClientLinks(uniqueId(), dataSet, true);
       this.applyChange(() => {
         const pts = this.getContent().addTableLink(board, dragTileId, dataSet, geomActionLinks);
-        pts.forEach(pt => {
+        pts.forEach((pt: JXG.Point) => {
           this.handleCreatePoint(pt);
         });
       });
@@ -1027,7 +1029,7 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
     const { board } = this.state;
     const content = this.getContent();
     if (board && !hasSelectionModifier(evt)) {
-      content.metadata.selection.forEach((isSelected, id) => {
+      content.metadata.selection.forEach((isSelected: boolean, id: string) => {
         const obj = board.objects[id];
         const pt = isPoint(obj) ? obj as JXG.Point : undefined;
         if (pt && isSelected && !pt.getAttribute("fixed")) {
@@ -1190,15 +1192,15 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
 
     // synchronize initial selection
     const content = this.getContent();
-    content.findObjects(board, elt => isPoint(elt))
-      .forEach(pt => {
+    content.findObjects(board, (elt: JXG.GeometryElement) => isPoint(elt))
+      .forEach((pt: JXG.Point) => {
         if (content.isSelected(pt.id)) {
           setElementColor(board, pt.id, true);
         }
       });
 
     // synchronize selection changes
-    this.disposers.push(content.metadata.selection.observe(change => {
+    this.disposers.push(content.metadata.selection.observe((change: any) => {
       if (this.state.board) {
         setElementColor(this.state.board, change.name, (change as any).newValue.value);
       }

--- a/src/components/tools/table-tool/data-table.tsx
+++ b/src/components/tools/table-tool/data-table.tsx
@@ -268,7 +268,7 @@ export default class DataTableComponent extends React.Component<IProps, IState> 
     const expression = expressions && expressions.get(attribute.id);
     const editable = !readOnly && !expression;
 
-    function defaultAttrValueFormatter(params: ValueFormatterParams) {
+    const defaultAttrValueFormatter = (params: ValueFormatterParams) => {
       const colName = params.colDef.field || params.colDef.headerName || "";
       const colPlaces: { [key: string]: number } = {
               day: 0,
@@ -282,7 +282,7 @@ export default class DataTableComponent extends React.Component<IProps, IState> 
       return (places != null) && (typeof params.value === "number")
                 ? params.value.toFixed(places)
                 : params.value;
-    }
+    };
 
     return ({
       headerClass: "cdp-column-header cdp-attr-column-header",

--- a/src/components/tools/table-tool/table-tool.tsx
+++ b/src/components/tools/table-tool/table-tool.tsx
@@ -5,12 +5,12 @@ import { BaseComponent } from "../../base";
 import DataTableComponent, { LOCAL_ROW_ID } from "./data-table";
 import { LinkedTableCellEditor } from "./linked-table-cell-editor";
 import { IMenuItemFlags } from "./table-header-menu";
-import { ColumnApi, GridApi, GridReadyEvent } from "ag-grid-community";
+import { ColumnApi, GridApi, GridReadyEvent, ValueGetterParams, ValueFormatterParams } from "ag-grid-community";
 import { DataSet, IDataSet, ICase, ICaseCreation } from "../../../models/data/data-set";
 import { ToolTileModelType } from "../../../models/tools/tool-tile";
 import { canonicalizeValue, getRowLabel, isLinkableValue, ILinkProperties, ITableLinkProperties,
-          TableContentModelType, TableMetadataModelType } from "../../../models/tools/table/table-content";
-import { ValueGetterParams, ValueFormatterParams } from "ag-grid-community";
+          TableContentModelType } from "../../../models/tools/table/table-content";
+import { getGeometryContent } from "../../../models/tools/geometry/geometry-content";
 import { JXGCoordPair, JXGProperties, JXGUnsafeCoordPair } from "../../../models/tools/geometry/jxg-changes";
 import { HotKeys } from "../../../utilities/hot-keys";
 import { uniqueId } from "../../../utilities/js-utils";
@@ -260,7 +260,7 @@ export default class TableToolComponent extends BaseComponent<IProps, IState> {
   }
 
   private getGeometryContent(geometryId: string) {
-    return this.getContent().getGeometryContent(geometryId);
+    return getGeometryContent(this.getContent(), geometryId);
   }
 
   private getPositionOfPoint(caseId: string): JXGUnsafeCoordPair {

--- a/src/components/tools/text-tool.tsx
+++ b/src/components/tools/text-tool.tsx
@@ -8,12 +8,12 @@ import { TextContentModelType } from "../../models/tools/text/text-content";
 import * as Immutable from "immutable";
 import { autorun, IReactionDisposer } from "mobx";
 
+import "./text-tool.sass";
+
 interface SlateChange {
   operations: Immutable.List<Operation>;
   value: Value;
 }
-
-import "./text-tool.sass";
 
 interface IProps {
   model: ToolTileModelType;
@@ -33,7 +33,7 @@ export default class TextToolComponent extends BaseComponent<IProps, IState> {
 
   public onChange = (change: SlateChange) => {
     const { readOnly, model } = this.props;
-    const { content } = model;
+    const content = this.getContent();
     const { ui } = this.stores;
 
     // determine last focus state from list of operations
@@ -101,5 +101,9 @@ export default class TextToolComponent extends BaseComponent<IProps, IState> {
         onChange={this.onChange}
       />
     );
+  }
+
+  private getContent() {
+    return this.props.model.content as TextContentModelType;
   }
 }

--- a/src/models/document/document-content.test.ts
+++ b/src/models/document/document-content.test.ts
@@ -21,7 +21,7 @@ describe("document-content model", () => {
     const textTile2 = documentContent.addTile("text");
 
     let textTile2RowId = documentContent.findRowContainingTile(textTile2!.tileId);
-    let textTile2RowIndex1 = documentContent.rowOrder.findIndex(id => id === textTile2RowId);
+    let textTile2RowIndex1 = documentContent.rowOrder.findIndex((id: string) => id === textTile2RowId);
 
     expect(textTile2RowIndex1).toBe(1);
 
@@ -33,13 +33,13 @@ describe("document-content model", () => {
     });
 
     const imageTile1rowId = documentContent.findRowContainingTile(imageTile1!.tileId);
-    const imageTile1rowIndex1 = documentContent.rowOrder.findIndex(id => id === imageTile1rowId);
+    const imageTile1rowIndex1 = documentContent.rowOrder.findIndex((id: string) => id === imageTile1rowId);
 
     expect(imageTile1rowIndex1).toBe(1);
 
     // text tile should have shifted down
     textTile2RowId = documentContent.findRowContainingTile(textTile2!.tileId);
-    textTile2RowIndex1 = documentContent.rowOrder.findIndex(id => id === textTile2RowId);
+    textTile2RowIndex1 = documentContent.rowOrder.findIndex((id: string) => id === textTile2RowId);
 
     expect(textTile2RowIndex1).toBe(2);
 
@@ -51,7 +51,7 @@ describe("document-content model", () => {
     });
 
     const rowId2 = documentContent.findRowContainingTile(imageTile2!.tileId);
-    const rowIndex2 = documentContent.rowOrder.findIndex(id => id === rowId2);
+    const rowIndex2 = documentContent.rowOrder.findIndex((id: string) => id === rowId2);
 
     expect(rowIndex2).toBe(3);
   });
@@ -61,7 +61,7 @@ describe("document-content model", () => {
     const textTile2 = documentContent.addTile("text");
 
     let textTile2RowId = documentContent.findRowContainingTile(textTile2!.tileId);
-    let textTile2RowIndex1 = documentContent.rowOrder.findIndex(id => id === textTile2RowId);
+    let textTile2RowIndex1 = documentContent.rowOrder.findIndex((id: string) => id === textTile2RowId);
 
     expect(textTile2RowIndex1).toBe(1);
 
@@ -72,13 +72,13 @@ describe("document-content model", () => {
     });
 
     const imageTile1rowId = documentContent.findRowContainingTile(imageTile1!.tileId);
-    const imageTile1rowIndex1 = documentContent.rowOrder.findIndex(id => id === imageTile1rowId);
+    const imageTile1rowIndex1 = documentContent.rowOrder.findIndex((id: string) => id === imageTile1rowId);
 
     expect(imageTile1rowIndex1).toBe(1);
 
     // text tile should still be on 1 as well
     textTile2RowId = documentContent.findRowContainingTile(textTile2!.tileId);
-    textTile2RowIndex1 = documentContent.rowOrder.findIndex(id => id === textTile2RowId);
+    textTile2RowIndex1 = documentContent.rowOrder.findIndex((id: string) => id === textTile2RowId);
 
     expect(textTile2RowIndex1).toBe(1);
   });
@@ -94,7 +94,7 @@ describe("document-content model", () => {
     });
 
     const geometryRowId = documentContent.findRowContainingTile(graphTileInfo!.tileId);
-    const geometryRowIndex = documentContent.rowOrder.findIndex(id => id === geometryRowId);
+    const geometryRowIndex = documentContent.rowOrder.findIndex((id: string) => id === geometryRowId);
 
     expect(geometryRowIndex).toBe(1);
 
@@ -102,13 +102,13 @@ describe("document-content model", () => {
     expect(graphTileInfo!.additionalTileIds).toBeDefined();
 
     const sidecarRowId = documentContent.findRowContainingTile(graphTileInfo!.tileId);
-    const sidecarRowIndex = documentContent.rowOrder.findIndex(id => id === sidecarRowId);
+    const sidecarRowIndex = documentContent.rowOrder.findIndex((id: string) => id === sidecarRowId);
 
     expect(sidecarRowIndex).toBe(1);
 
     // text tile should be on 2
     const textTile2RowId = documentContent.findRowContainingTile(textTile2!.tileId);
-    const textTile2RowIndex1 = documentContent.rowOrder.findIndex(id => id === textTile2RowId);
+    const textTile2RowIndex1 = documentContent.rowOrder.findIndex((id: string) => id === textTile2RowId);
 
     expect(textTile2RowIndex1).toBe(2);
   });
@@ -124,7 +124,7 @@ describe("document-content model", () => {
     });
 
     const geometryRowId = documentContent.findRowContainingTile(graphTileInfo!.tileId);
-    const geometryRowIndex = documentContent.rowOrder.findIndex(id => id === geometryRowId);
+    const geometryRowIndex = documentContent.rowOrder.findIndex((id: string) => id === geometryRowId);
 
     expect(geometryRowIndex).toBe(1);
 
@@ -132,13 +132,13 @@ describe("document-content model", () => {
     expect(graphTileInfo!.additionalTileIds).toBeDefined();
 
     const sidecarRowId = documentContent.findRowContainingTile(graphTileInfo!.tileId);
-    const sidecarRowIndex = documentContent.rowOrder.findIndex(id => id === sidecarRowId);
+    const sidecarRowIndex = documentContent.rowOrder.findIndex((id: string) => id === sidecarRowId);
 
     expect(sidecarRowIndex).toBe(1);
 
     // original text tile should be on 1 as well
     const textTile2RowId = documentContent.findRowContainingTile(textTile2!.tileId);
-    const textTile2RowIndex1 = documentContent.rowOrder.findIndex(id => id === textTile2RowId);
+    const textTile2RowIndex1 = documentContent.rowOrder.findIndex((id: string) => id === textTile2RowId);
 
     expect(textTile2RowIndex1).toBe(1);
   });

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -64,9 +64,9 @@ export const DocumentContentModel = types
         return contentId;
       },
       getTile(tileId: string) {
-        return self.tileMap.get(tileId);
+        return tileId ? self.tileMap.get(tileId) : undefined;
       },
-      getTileContent(tileId: string) {
+      getTileContent(tileId: string): ToolContentUnionType | undefined {
         const tile = self.tileMap.get(tileId);
         return tile && tile.content;
       },

--- a/src/models/tools/geometry/geometry-content.test.ts
+++ b/src/models/tools/geometry/geometry-content.test.ts
@@ -194,7 +194,7 @@ describe("GeometryContent", () => {
     content.selectObjects(poly!.id);
     expect(content.isSelected(poly!.id)).toBe(true);
     expect(content.hasSelection()).toBe(true);
-    let found = content.findObjects(board, obj => {
+    let found = content.findObjects(board, (obj: JXG.GeometryElement) => {
                   return obj.id === p1!.id;
                 });
     expect(found.length).toBe(1);
@@ -205,7 +205,7 @@ describe("GeometryContent", () => {
     content.selectObjects(p1!.id);
     content.deleteSelection(board);
     expect(content.hasSelection()).toBe(false);
-    found = content.findObjects(board, obj => {
+    found = content.findObjects(board, (obj: JXG.GeometryElement) => {
               return obj.id === p1!.id;
             });
     expect(found.length).toBe(0);
@@ -270,7 +270,7 @@ describe("GeometryContent", () => {
     content.applyChange(board, change2);
     expect(content.changes.length).toBe(3);
     const change = content.popChangeset();
-    expect(change && change.map(changeStr => JSON.parse(changeStr))).toEqual([change2]);
+    expect(change && change.map((changeStr: any) => JSON.parse(changeStr))).toEqual([change2]);
     expect(content.changes.length).toBe(2);
     expect(JSON.parse(content.changes[1])).toEqual(change1);
   });
@@ -289,7 +289,7 @@ describe("GeometryContent", () => {
     content.applyChange(board, change4);
     expect(content.changes.length).toBe(5);
     const change = content.popChangeset();
-    expect(change && change.map(changeStr => JSON.parse(changeStr))).toEqual([change2, change3, change4]);
+    expect(change && change.map((changeStr: any) => JSON.parse(changeStr))).toEqual([change2, change3, change4]);
     expect(content.changes.length).toBe(2);
     expect(JSON.parse(content.changes[1])).toEqual(change1);
   });

--- a/src/models/tools/geometry/jxg-movable-line.ts
+++ b/src/models/tools/geometry/jxg-movable-line.ts
@@ -143,7 +143,7 @@ export const movableLineChangeAgent: JXGChangeAgent = {
           ...pt2,
         }
       );
-      const overrides = {
+      const overrides: any = {
         name() {
           return this.getSlope && this.getRise && this.getSlope() !== Infinity
             ? this.getRise() >= 0

--- a/src/models/tools/geometry/jxg-vertex-angle.ts
+++ b/src/models/tools/geometry/jxg-vertex-angle.ts
@@ -74,8 +74,8 @@ export const vertexAngleChangeAgent: JXGChangeAgent = {
                       .map(id => board.objects[id as string])
                       .filter(pt => pt != null);
     // cf. http://jsxgraph.uni-bayreuth.de/wiki/index.php/Positioning_of_labels
-    const overrides = { name() { return `${this.Value ? JXG.toFixed(this.Value() * 180 / Math.PI, 0) : ""}°`; },
-                        clientType: "vertexAngle" };
+    const overrides: any = { name() { return `${this.Value ? JXG.toFixed(this.Value() * 180 / Math.PI, 0) : ""}°`; },
+                              clientType: "vertexAngle" };
     const props = assign({ id: uuid(), radius: 1 }, change.properties, overrides);
     return parents.length === 3 ? board.create("angle", parents, props) : undefined;
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "outDir": "./dist/",
     "sourceMap": true,
     "noImplicitAny": true,
+    "noImplicitThis": true,
     "module": "commonjs",
     "target": "es5",
     "allowJs": true,


### PR DESCRIPTION
Update to TypeScript 3.5 [#167279884]{294}
- add explicit types where appropriate
- make `getTableContent()` a global function (rather than a view on `GeometryContentModel`)
- make `getGeometryContent()` a global function (rather than a view on `TableContentModel`)
- enable `noImplicitThis` in `tsconfig.json`