### PR TITLE
Store channel value in NodeChannelInfo so initial sensor node value is correct

### DIFF
--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -152,10 +152,10 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
           hub.hubChannels.forEach(ch => {
             const chValue = Number.parseFloat(ch.value);
             const nci = this.channels.find(ci => ci.hubId === hub.hubId && ci.channelId === ch.id);
-            if (nci && !Number.isNaN(chValue)) {
+            if (nci && Number.isFinite(chValue)) {
               nci.value = chValue;
             }
-            if (!Number.isNaN(chValue) && ch.type !== "relay") {
+            if (Number.isFinite(chValue) && ch.type !== "relay") {
               const hubSensorId = hub.hubId + "/" + ch.id;
               const nodes = this.programEditor.nodes.filter((n: Node) => n.data.sensor === hubSensorId);
               if (nodes) {

--- a/src/dataflow/components/nodes/controls/sensor-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/sensor-select-control.tsx
@@ -120,7 +120,7 @@ export class SensorSelectControl extends Rete.Control {
 
   public setSensor = (val: any) => {
     const ch: NodeChannelInfo = this.props.channels.find((ci: any) => `${ci.hubId}/${ci.channelId}` === val);
-    ch ? this.setSensorValue(ch.value) : this.setSensorValue(0);
+    this.setSensorValue(ch ? ch.value : 0);
 
     this.props.sensor = val;
     this.putData("sensor", val);

--- a/src/dataflow/components/nodes/controls/sensor-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/sensor-select-control.tsx
@@ -119,7 +119,8 @@ export class SensorSelectControl extends Rete.Control {
   }
 
   public setSensor = (val: any) => {
-    this.setSensorValue(0);
+    const ch: NodeChannelInfo = this.props.channels.find((ci: any) => `${ci.hubId}/${ci.channelId}` === val);
+    ch ? this.setSensorValue(ch.value) : this.setSensorValue(0);
 
     this.props.sensor = val;
     this.putData("sensor", val);

--- a/src/dataflow/utilities/node.ts
+++ b/src/dataflow/utilities/node.ts
@@ -123,4 +123,5 @@ export interface NodeChannelInfo {
   channelId: string;
   type: string;
   units: string;
+  value: number;
 }


### PR DESCRIPTION
Store sensor channel values in the `NodeChannelInfo` which is passed to each sensor node.  If a user changes a sensor node such that it has a new active sensor (via the sensor select dropdown), we can immediately set a sensor value from the `NodeChannelInfo` stored in the node rather than having to wait for a new sensor value to be received and the `hubStore` to be updated which in turn triggers a node value update (in the case where a sensor value is stable this could be a noticeable period of time).