### PR TITLE
Use "period" in generator blocks

### DIFF
--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -249,15 +249,15 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
 
   private updateGeneratorNode = (n: Node) => {
     const generatorType = n.data.generatorType;
-    const frequency = Number(n.data.frequency);
+    const period = Number(n.data.period);
     const amplitude = Number(n.data.amplitude);
     let ticks: any = n.data.ticks || 0;
     const nodeGeneratorType = NodeGeneratorTypes.find(gt => gt.name === generatorType);
-    if (nodeGeneratorType && frequency && amplitude) {
+    if (nodeGeneratorType && period && amplitude) {
       ticks = ticks + 1;
       n.data.ticks = ticks;
       const prevVal: any = n.data.nodeValue || 0;
-      const val = nodeGeneratorType.method(ticks, frequency, amplitude, prevVal);
+      const val = nodeGeneratorType.method(ticks, period, amplitude, prevVal);
       const nodeValue = n.controls.get("nodeValue") as NumControl;
       if (nodeValue) {
         nodeValue.setValue(val);

--- a/src/dataflow/components/nodes/factories/generator-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/generator-rete-node-factory.tsx
@@ -23,7 +23,7 @@ export class GeneratorReteNodeFactory extends Rete.Component {
     return node
       .addControl(new DropdownListControl(this.editor, "generatorType", node, dropdownOptions, true))
       .addControl(new NumControl(this.editor, "amplitude", node, false, "amplitude", 1, .01))
-      .addControl(new NumControl(this.editor, "frequency", node, false, "frequency", 10, 1))
+      .addControl(new NumControl(this.editor, "period", node, false, "period", 10, 1))
       .addControl(new NumControl(this.editor, "nodeValue", node, true))
       .addControl(new PlotControl(this.editor, "plot", node))
       .addOutput(out) as any;


### PR DESCRIPTION
Update to use correct terminology on generator node.  User set the "period", not the "frequency."