### PR TITLE
Sensor node updates

### DIFF
--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -154,13 +154,12 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
         hubStore.hubs.forEach(hub => {
           hub.hubChannels.forEach(ch => {
             const chValue = Number.parseFloat(ch.value);
-            const nci = this.channels.find(ci => ci.hubId === hub.hubId && ci.channelId === ch.id);
+            const nci = this.channels.find(ci => ci.channelId === ch.id);
             if (nci && Number.isFinite(chValue)) {
               nci.value = chValue;
             }
             if (Number.isFinite(chValue) && ch.type !== "relay") {
-              const hubSensorId = hub.hubId + "/" + ch.id;
-              const nodes = this.programEditor.nodes.filter((n: Node) => n.data.sensor === hubSensorId);
+              const nodes = this.programEditor.nodes.filter((n: Node) => n.data.sensor === ch.id);
               if (nodes) {
                 nodes.forEach((n: Node) => {
                   const sensorSelect = n.controls.get("sensorSelect") as SensorSelectControl;

--- a/src/dataflow/components/nodes/controls/relay-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/relay-select-control.tsx
@@ -55,7 +55,7 @@ export class RelaySelectControl extends Rete.Control {
     this.props.channels = channels;
 
     if (this.node.data[this.key] && this.node.data[this.key] !== "none") {
-      if (!channels.find(ch => `${ch.hubId}/${ch.channelId}` === this.node.data[this.key])) {
+      if (!channels.find(ch => ch.channelId === this.node.data[this.key])) {
         this.props.value = "none";
         this.putData(this.key, "none");
       }

--- a/src/dataflow/components/nodes/controls/sensor-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/sensor-select-control.tsx
@@ -35,7 +35,7 @@ export class SensorSelectControl extends Rete.Control {
           onChange={handleChange(compProps.onTypeChange)}
           onPointerMove={handlePointerMove}>
           {NodeSensorTypes.map((val: any, i: any) => (
-            <option key={i} value={val.name}>
+            <option key={i} value={val.type}>
               {val.name}
             </option>
           ))}
@@ -49,7 +49,7 @@ export class SensorSelectControl extends Rete.Control {
             ch.type === compProps.type
           ))
           .map((ch: NodeChannelInfo, i: any) => (
-            <option key={i} value={ch.hubId + "/" + ch.channelId}>
+            <option key={i} value={ch.channelId}>
               {ch.hubName + ":" + ch.type}
             </option>
           )) : null}
@@ -68,14 +68,14 @@ export class SensorSelectControl extends Rete.Control {
 
     const displayedUnits = (id: string, channels: NodeChannelInfo[], type: string) => {
       let units = "";
-      const sensor = channels.find((ch: any) => ch.hubId + "/" + ch.channelId === id);
+      const sensor = channels.find((ch: any) => ch.channelId === id);
       if (sensor && sensor.units) {
         units = sensor.units;
         units = units.replace(/_/g, "");
         units = units.replace(/degrees/g, "°");
         units = units.replace(/percent/g, "%");
       } else {
-        const sensorType = NodeSensorTypes.find((s: any) => s.name === type);
+        const sensorType = NodeSensorTypes.find((s: any) => s.type === type);
         if (sensorType && sensorType.units) {
           units = sensorType.units;
         }
@@ -109,7 +109,7 @@ export class SensorSelectControl extends Rete.Control {
   public setChannels = (channels: NodeChannelInfo[]) => {
     this.props.channels = channels;
     if (this.node.data.sensor && this.node.data.sensor !== "none") {
-      if (!channels.find(ch => `${ch.hubId}/${ch.channelId}` === this.node.data.sensor)) {
+      if (!channels.find(ch => ch.channelId === this.node.data.sensor)) {
         this.props.value = 0;
         this.putData("nodeValue", 0);
         this.props.sensor = "none";
@@ -129,7 +129,8 @@ export class SensorSelectControl extends Rete.Control {
   }
 
   public setSensor = (val: any) => {
-    this.setSensorValue(0);
+    const nch: NodeChannelInfo = this.props.channels.find((ch: any) => ch.channelId === val);
+    this.setSensorValue(nch ? nch.value : 0);
 
     this.props.sensor = val;
     this.putData("sensor", val);

--- a/src/dataflow/utilities/node.ts
+++ b/src/dataflow/utilities/node.ts
@@ -89,30 +89,37 @@ export const NodeOperationTypes = [
 export const NodeSensorTypes = [
   {
     name: "temperature",
+    type: "temperature",
     units: "°C",
   },
   {
     name: "humidity",
+    type: "humidity",
     units: "%",
   },
   {
     name: "CO₂",
+    type: "CO2",
     units: "PPM",
   },
   {
     name: "O₂",
+    type: "O2",
     units: "%",
   },
   {
     name: "light",
+    type: "light",
     units: "lux",
   },
   {
     name: "soil moisture",
+    type: "soil-moisture",
     units: "",
   },
   {
     name: "particulates",
+    type: "particulates",
     units: "PM2.5",
   },
 ];


### PR DESCRIPTION
Small changes in service of ensuring sensor nodes contain and restore proper values:
- uniquely identify each sensor node's relationship to a physical sensor by the component id alone (do not include hub id).  With this change the following will be permitted:
  program contains sensor block connected to SensorA which is plugged into Hub1
  user unplugs SensorA from Hub1 and plugs into Hub2
  sensor block will still show values from SensorA (despite changing hubs)
- ensure we match sensor block to physical sensor based on a standardized type string which may not match the human readable sensor name.
- set initial value when setting sensor from dropdown