### PR TITLE
Fix relay selection

### DIFF
--- a/src/dataflow/components/nodes/controls/relay-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/relay-select-control.tsx
@@ -30,7 +30,7 @@ export class RelaySelectControl extends Rete.Control {
           ch.type === "relay"
         ))
         .map((ch: NodeChannelInfo, i: any) => (
-          <option key={i} value={ch.hubId + "/" + ch.channelId}>
+          <option key={i} value={ch.channelId}>
             {ch.hubName + ":" + ch.type}
           </option>
         )) : null}


### PR DESCRIPTION
Minor fix to ensure relay nodes stores relay value based on component id alone and do not use hub id. 