### PR TITLE
Add plug numbers to distinguish sensors of same type

### DIFF
--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -143,6 +143,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
                                             channelId: ch.id,
                                             type: ch.type,
                                             units: ch.units,
+                                            plug: ch.plug,
                                             value: Number(ch.value)};
               this.channels.push(nci);
             }

--- a/src/dataflow/components/hub-list.tsx
+++ b/src/dataflow/components/hub-list.tsx
@@ -48,16 +48,19 @@ export class HubListComponent extends BaseComponent<IProps, IState> {
           "no channels available" }
         </div>
         { hub.hubChannels.map( (ch) => {
-            return this.renderHubChannel(ch);
+            let count = 0;
+            hub.hubChannels.forEach( c => { if (c.type === ch.type) count++; } );
+            return this.renderHubChannel(ch, count > 1);
           }) }
       </div>
     );
   }
 
-  private renderHubChannel(ch: HubChannelType) {
+  private renderHubChannel(ch: HubChannelType, showPlug: boolean) {
+    const plug = ch.plug > 0 && showPlug ? ` (plug ${ch.plug})` : "";
     return (
       <div className="channel" key={ch.id}>
-        <div className="label">{ `${ch.type}: ${ch.value} ${ch.units}` }</div>
+        <div className="label">{ `${ch.type}${plug}: ${ch.value} ${ch.units}` }</div>
       </div>
     );
   }

--- a/src/dataflow/components/nodes/controls/relay-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/relay-select-control.tsx
@@ -21,21 +21,37 @@ export class RelaySelectControl extends Rete.Control {
     const handlePointerMove = (e: any) => e.stopPropagation();
 
     this.component = (compProps: { value: any; onChange: any; channels: NodeChannelInfo[] }) => (
-      <select
-        value={compProps.value}
-        onChange={handleChange(compProps.onChange)}
+      <div>
+        { renderRelayList(compProps.value, compProps.channels, compProps.onChange) }
+      </div>
+    );
+
+    const renderRelayList = (id: string, channels: NodeChannelInfo[], onRelayChange: any) => {
+      return (
+        <select
+        value={id}
+        onChange={handleChange(onRelayChange)}
         onPointerMove={handlePointerMove}>
         <option value="none">none</option>
-        {compProps.channels ? compProps.channels.filter((ch: NodeChannelInfo) => (
+        {channels ? channels.filter((ch: NodeChannelInfo) => (
           ch.type === "relay"
         ))
-        .map((ch: NodeChannelInfo, i: any) => (
-          <option key={i} value={ch.channelId}>
-            {ch.hubName + ":" + ch.type}
-          </option>
+        .map((ch: NodeChannelInfo, i: number) => (
+          renderRelayOption(i, ch, channels)
         )) : null}
       </select>
-    );
+      );
+    };
+
+    const renderRelayOption = (i: number, ch: NodeChannelInfo, channels: NodeChannelInfo[]) => {
+      let count = 0;
+      channels.forEach( c => { if (c.type === "relay" && ch.hubId === c.hubId) count++; } );
+      return (
+        <option key={i} value={ch.channelId}>
+          {`${ch.hubName}:${ch.type}${ch.plug > 0 && count > 1 ? `(plug ${ch.plug})` : ""}`}
+        </option>
+      );
+    };
 
     const initial = node.data[key] || "none";
     node.data[key] = initial;

--- a/src/dataflow/components/nodes/controls/sensor-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/sensor-select-control.tsx
@@ -41,7 +41,7 @@ export class SensorSelectControl extends Rete.Control {
 
     const renderSensorTypeList = (type: string, showList: boolean, onItemClick: any, onListClick: any) => {
       let icon = "";
-      const sensorType = NodeSensorTypes.find((s: any) => s.name === type);
+      const sensorType = NodeSensorTypes.find((s: any) => s.type === type);
       if (sensorType && sensorType.icon) {
         icon = `#${sensorType.icon}`;
       }
@@ -62,7 +62,7 @@ export class SensorSelectControl extends Rete.Control {
               <div
               className={val.name === type ? "item sensor selected" : "item sensor selectable"}
                 key={i}
-                onClick={onListClick(val.name)}
+                onClick={onListClick(val.type)}
               >
                 <svg className="icon">
                   <use xlinkHref={`#${val.icon}`}/>
@@ -88,11 +88,19 @@ export class SensorSelectControl extends Rete.Control {
             ch.type === type
           ))
           .map((ch: NodeChannelInfo, i: any) => (
-            <option key={i} value={ch.channelId} className="sensor">
-              {ch.hubName + ":" + ch.type}
-            </option>
+            renderSensorOption(i, ch, channels)
           )) : null}
         </select>
+      );
+    };
+
+    const renderSensorOption = (i: number, ch: NodeChannelInfo, channels: NodeChannelInfo[]) => {
+      let count = 0;
+      channels.forEach( c => { if (c.type === ch.type && ch.hubId === c.hubId) count++; } );
+      return (
+        <option key={i} value={ch.channelId} className="sensor">
+          {`${ch.hubName}:${ch.type}${ch.plug > 0 && count > 1 ? `(plug ${ch.plug})` : ""}`}
+        </option>
       );
     };
 

--- a/src/dataflow/lib/iot.ts
+++ b/src/dataflow/lib/iot.ts
@@ -139,6 +139,7 @@ export class IoT {
           // add channels to hub (may be sensor or relay)
           const model = channel.model || "N/A";
           const units = channel.units || "";
+          const plug = device.plug || 0;
           const id = this.constructHubChannelId(channel.id, deviceKeys[index], channel.type);
           rids = rids.filter(rid => rid !== id);
           if (!hub.getHubChannel(id)) {
@@ -149,7 +150,8 @@ export class IoT {
               model,
               units,
               value: "",
-              lastUpdateTime: Date.now()}));
+              lastUpdateTime: Date.now(),
+              plug}));
           }
         });
       });

--- a/src/dataflow/models/stores/hub-store.ts
+++ b/src/dataflow/models/stores/hub-store.ts
@@ -8,6 +8,7 @@ export const HubChannelModel = types.model({
   units: types.string,
   value: types.string,
   lastUpdateTime: types.number,
+  plug: types.number,
 });
 export type HubChannelType = typeof HubChannelModel.Type;
 

--- a/src/dataflow/utilities/node.ts
+++ b/src/dataflow/utilities/node.ts
@@ -199,5 +199,6 @@ export interface NodeChannelInfo {
   channelId: string;
   type: string;
   units: string;
+  plug: number;
   value: number;
 }


### PR DESCRIPTION
Read and store sensor plug number.  If we have a hub with 2 sensors of the same type (e.g., 2 temperature sensors), display the plug number to help distinguish the sensors.  This is used in the control panel and the sensor/relay nodes.