### PR TITLE
add thing groups to hub store

### DIFF
--- a/src/dataflow/lib/iot.ts
+++ b/src/dataflow/lib/iot.ts
@@ -102,6 +102,24 @@ export class IoT {
             this.client.subscribe(this.createTopic(OWNER_ID, hubId, TopicType.hubChannelInfo));
             this.client.subscribe(this.createTopic(OWNER_ID, hubId, TopicType.hubSensorValues));
             this.requestHubChannelInfo(hubId);
+            this.requestThingGroups(hubId);
+          }
+        });
+      }
+    });
+  }
+
+  private requestThingGroups = (hubId: string) => {
+    const params: any = {
+      thingName: hubId
+    };
+    const  { hubStore } = this.stores;
+    const hub = hubStore.getHubById(hubId);
+    this.iotCore.listThingGroupsForThing(params).promise().then(data => {
+      if (data && data.thingGroups && hub) {
+        data.thingGroups.forEach(group => {
+          if (group.groupName && !hub.hubGroups.includes(group.groupName)) {
+            hub.addHubGroup(group.groupName);
           }
         });
       }

--- a/src/dataflow/models/stores/hub-store.ts
+++ b/src/dataflow/models/stores/hub-store.ts
@@ -20,6 +20,7 @@ export const HubModel = types
     hubType: types.maybe(types.string),
     hubChannels: types.array(HubChannelModel),
     hubUpdateTime: types.number,
+    hubGroups: types.array(types.string),
   })
   .views(self => ({
     getHubChannel(id: string) {
@@ -65,6 +66,9 @@ export const HubModel = types
           ch.lastUpdateTime = newTime;
         }
       });
+    },
+    addHubGroup(group: string) {
+      self.hubGroups.push(group);
     },
   }));
 export type HubModelType = typeof HubModel.Type;


### PR DESCRIPTION
Request the array of thing groups for each thing that is registered on the AWS IoT server.  Store this information in  the HubStore.  Eventually this will be useful to organize and sort things (hubs) - particularly when filtering and displaying hubs to users.