### PR TITLE
Round numeric values computed by node functions

### DIFF
--- a/src/dataflow/components/nodes/controls/value-control.tsx
+++ b/src/dataflow/components/nodes/controls/value-control.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import Rete from "rete";
+import { roundNodeValue } from "../../../utilities/node";
 import "./value-control.sass";
 
 export class ValueControl extends Rete.Control {
@@ -15,7 +16,7 @@ export class ValueControl extends Rete.Control {
 
     this.component = (compProps: { value: number; sentence: string }) => (
       <div className="value-container">
-        {compProps.sentence ? compProps.sentence : compProps.value}
+        {compProps.sentence ? compProps.sentence : roundNodeValue(compProps.value)}
       </div>
     );
 

--- a/src/dataflow/components/nodes/factories/math-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/math-rete-node-factory.tsx
@@ -4,7 +4,7 @@ import { NodeData } from "rete/types/core/data";
 import { NumControl } from "../controls/num-control";
 import { ValueControl } from "../controls/value-control";
 import { DropdownListControl } from "../controls/dropdown-list-control";
-import { NodeOperationTypes } from "../../../utilities/node";
+import { NodeOperationTypes, roundNodeValue } from "../../../utilities/node";
 import { PlotControl } from "../controls/plot-control";
 
 export class MathReteNodeFactory extends Rete.Component {
@@ -47,7 +47,7 @@ export class MathReteNodeFactory extends Rete.Component {
     const nodeOperationTypes = NodeOperationTypes.find(op => op.name === mathOperator);
     if (nodeOperationTypes) {
       result = nodeOperationTypes.method(n1, n2);
-      resultSentence = nodeOperationTypes.numberSentence(n1, n2) + result;
+      resultSentence = nodeOperationTypes.numberSentence(n1, n2) + roundNodeValue(result);
     }
 
     if (this.editor) {

--- a/src/dataflow/utilities/node.ts
+++ b/src/dataflow/utilities/node.ts
@@ -202,3 +202,7 @@ export interface NodeChannelInfo {
   plug: number;
   value: number;
 }
+
+export const roundNodeValue = (n: number) => {
+  return Math.round(n * 1000) / 1000;
+};


### PR DESCRIPTION
This adds rounding to displayed node values which prevents nodes from displaying values like (.3333333333....).  This is essentially the same rounding mechanism and equation used in Dataflow 2.0:
- no more than 3 decimal digits are shown for nodes other than the number node (where the user can enter a value such as 1.11111 and the entered value is displayed)
- internally stored node values are not changed - we only adjust the value that is displayed in the node (so raw values are still passed for further calculations downstream).
