### PR TITLE
Fix updateChannelInfo function call

### DIFF
--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -188,9 +188,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
                       this.updateNodeChannelInfo(n);
                       this.updateNodeSensorValue(n);
                     },
-            Relay: (n: Node) => {
-                      this.updateNodeChannelInfo(n);
-                    },
+            Relay: this.updateNodeChannelInfo
           };
 
     let processNeeded = false;
@@ -215,7 +213,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
     }
   }
 
-  private updateNodeChannelInfo(n: Node) {
+  private updateNodeChannelInfo = (n: Node) => {
     const sensorSelect = n.controls.get("sensorSelect") as SensorSelectControl;
     const relayList = n.controls.get("relayList") as RelaySelectControl;
     if (sensorSelect) {
@@ -228,7 +226,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
     }
   }
 
-  private updateNodeSensorValue(n: Node) {
+  private updateNodeSensorValue = (n: Node) => {
     const sensorSelect = n.controls.get("sensorSelect") as SensorSelectControl;
     if (sensorSelect) {
       const chInfo = this.channels.find(ci => ci.channelId === n.data.sensor);

--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -188,7 +188,9 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
                       this.updateNodeChannelInfo(n);
                       this.updateNodeSensorValue(n);
                     },
-            Relay: this.updateNodeChannelInfo
+            Relay: (n: Node) => {
+                      this.updateNodeChannelInfo(n);
+                    },
           };
 
     let processNeeded = false;


### PR DESCRIPTION
Fix call to updateChannelInfo for relay nodes to prevent exceptions (I thought this was in the original PR but perhaps was squashed by a merge or rebase along the way).