### PR TITLE
Add dataflow program toolbar

### DIFF
--- a/src/dataflow/components/dataflow-program-toolbar.sass
+++ b/src/dataflow/components/dataflow-program-toolbar.sass
@@ -1,0 +1,13 @@
+@import ../../components/vars
+
+$toolbar-width: 90px
+
+.program-toolbar
+  display: flex
+  flex-direction: column
+  position: absolute
+  width: $toolbar-width
+  height: 100%
+  border: solid 2px white
+  border-radius: 0 $half-border-radius 0 0
+  background-color: $color3-4

--- a/src/dataflow/components/dataflow-program-toolbar.tsx
+++ b/src/dataflow/components/dataflow-program-toolbar.tsx
@@ -1,0 +1,52 @@
+import * as React from "react";
+import { BaseComponent, IBaseProps } from "./dataflow-base";
+import { observer, inject } from "mobx-react";
+import { NodeTypes } from "../utilities/node";
+
+import "./dataflow-program-toolbar.sass";
+
+interface IProps extends IBaseProps {
+  onNodeCreateClick: (type: string) => void;
+  onDeleteClick: () => void;
+  onResetClick: () => void;
+  onClearClick: () => void;
+}
+interface IState {}
+
+@inject("stores")
+@observer
+export class DataflowProgramToolbar extends BaseComponent<IProps, IState> {
+  constructor(props: IProps) {
+    super(props);
+    this.state = {
+      showSettings: false,
+    };
+  }
+
+  public render() {
+    return (
+      <div className="program-toolbar" data-test="program-toolbar">
+        { NodeTypes.map((nt: any, i: any) => (
+            this.renderAddNodeButton(nt.name, i)
+          ))
+        }
+        <button onClick={this.props.onDeleteClick}>Delete</button>
+        <button onClick={this.props.onResetClick}>Reset</button>
+        <button onClick={this.props.onClearClick}>Clear</button>
+      </div>
+    );
+  }
+
+  public renderAddNodeButton(nodeType: string, i: number) {
+    const handleAddNodeButtonClick = () => { this.props.onNodeCreateClick(nodeType); };
+    return (
+      <button
+        key={i}
+        onClick={handleAddNodeButtonClick}
+      >
+        {nodeType}
+      </button>
+    );
+  }
+
+}

--- a/src/dataflow/components/dataflow-program-toolbar.tsx
+++ b/src/dataflow/components/dataflow-program-toolbar.tsx
@@ -11,16 +11,10 @@ interface IProps extends IBaseProps {
   onResetClick: () => void;
   onClearClick: () => void;
 }
-interface IState {}
 
-@inject("stores")
-@observer
-export class DataflowProgramToolbar extends BaseComponent<IProps, IState> {
+export class DataflowProgramToolbar extends BaseComponent<IProps, {}> {
   constructor(props: IProps) {
     super(props);
-    this.state = {
-      showSettings: false,
-    };
   }
 
   public render() {

--- a/src/dataflow/components/dataflow-program-toolbar.tsx
+++ b/src/dataflow/components/dataflow-program-toolbar.tsx
@@ -1,18 +1,16 @@
 import * as React from "react";
-import { BaseComponent, IBaseProps } from "./dataflow-base";
-import { observer, inject } from "mobx-react";
 import { NodeTypes } from "../utilities/node";
 
 import "./dataflow-program-toolbar.sass";
 
-interface IProps extends IBaseProps {
+interface IProps {
   onNodeCreateClick: (type: string) => void;
   onDeleteClick: () => void;
   onResetClick: () => void;
   onClearClick: () => void;
 }
 
-export class DataflowProgramToolbar extends BaseComponent<IProps, {}> {
+export class DataflowProgramToolbar extends React.Component<IProps, {}> {
   constructor(props: IProps) {
     super(props);
   }

--- a/src/dataflow/components/dataflow-program.sass
+++ b/src/dataflow/components/dataflow-program.sass
@@ -12,18 +12,14 @@
     &.sensor, &.number, &.generator
       background-color: #0592AF
       border-color: #C0E4EB
-      &.selected
-        border-color: $color2-4
     &.logic, &.math, &.transform
       background-color: #2DA343
       border-color: #CDE8D2
-      &.selected
-        border-color: $color2-4
     &.relay, &.data-storage
       background-color: #E16D2F
       border-color: #E09E7D
-      &.selected
-        border-color: $color2-4
+    &.selected
+      border-color: $color2-4
 
   select, input
     width: 100%

--- a/src/dataflow/components/dataflow-program.sass
+++ b/src/dataflow/components/dataflow-program.sass
@@ -1,3 +1,5 @@
+@import ../../components/vars
+
 .flow-tool
   width: 500px
   height: 500px
@@ -10,12 +12,18 @@
     &.sensor, &.number, &.generator
       background-color: #0592AF
       border-color: #C0E4EB
+      &.selected
+        border-color: $color2-4
     &.logic, &.math, &.transform
       background-color: #2DA343
       border-color: #CDE8D2
+      &.selected
+        border-color: $color2-4
     &.relay, &.data-storage
       background-color: #E16D2F
       border-color: #E09E7D
+      &.selected
+        border-color: $color2-4
 
   select, input
     width: 100%
@@ -39,3 +47,7 @@
 // Connections are offset without this for some reason
 .flow-tool > div > div
     position: absolute
+
+.editor-container
+  display: flex
+  flex-direction: row

--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -42,14 +42,6 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
   private programEditor: NodeEditor;
   private programEngine: any;
 
-  private components = [new NumberReteNodeFactory(numSocket),
-                        new MathReteNodeFactory(numSocket),
-                        new TransformReteNodeFactory(numSocket),
-                        new LogicReteNodeFactory(numSocket),
-                        new SensorReteNodeFactory(numSocket),
-                        new RelayReteNodeFactory(numSocket),
-                        new GeneratorReteNodeFactory(numSocket)];
-
   public render() {
     return (
       <div className="editor-container">
@@ -82,6 +74,14 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
 
   private initProgramEditor = () => {
     (async () => {
+      const components = [new NumberReteNodeFactory(numSocket),
+        new MathReteNodeFactory(numSocket),
+        new TransformReteNodeFactory(numSocket),
+        new LogicReteNodeFactory(numSocket),
+        new SensorReteNodeFactory(numSocket),
+        new RelayReteNodeFactory(numSocket),
+        new GeneratorReteNodeFactory(numSocket)];
+
       if (!this.toolDiv) return;
 
       this.programEditor = new Rete.NodeEditor(RETE_APP_IDENTIFIER, this.toolDiv);
@@ -90,7 +90,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
 
       this.programEngine = new Rete.Engine(RETE_APP_IDENTIFIER);
 
-      this.components.map(c => {
+      components.map(c => {
         this.programEditor.register(c);
         this.programEngine.register(c);
       });

--- a/src/dataflow/utilities/node.ts
+++ b/src/dataflow/utilities/node.ts
@@ -1,3 +1,27 @@
+export const NodeTypes = [
+  {
+    name: "Number",
+  },
+  {
+    name: "Sensor",
+  },
+  {
+    name: "Generator",
+  },
+  {
+    name: "Math",
+  },
+  {
+    name: "Logic",
+  },
+  {
+    name: "Transform",
+  },
+  {
+    name: "Relay",
+  },
+];
+
 export const NodeOperationTypes = [
   {
     name: "add",


### PR DESCRIPTION
Add initial, unstyled Dataflow program toolbar.  Includes additional changes and updates to facilitate toolbar functionality:
- remove default program when creating program tile
- add styling to node selection
- add function to reset nodes (removes array of recent values and timing info)
- add function to clear nodes (remove all nodes)
- add function to delete a single node 
- remove the Rete context menu (right click to add nodes)