### PR TITLE
Update node styling

### DIFF
--- a/src/dataflow/components/dataflow-program.sass
+++ b/src/dataflow/components/dataflow-program.sass
@@ -5,35 +5,6 @@
   height: 500px
   background: white
 
-  .node .control input, .node .input-control input
-    width: 140px
-
-  .node
-    &.sensor, &.number, &.generator
-      background-color: #0592AF
-      border-color: #C0E4EB
-    &.logic, &.math, &.transform
-      background-color: #2DA343
-      border-color: #CDE8D2
-    &.relay, &.data-storage
-      background-color: #E16D2F
-      border-color: #E09E7D
-    &.selected
-      border-color: $color2-4
-
-  select, input
-    width: 100%
-    border-radius: 30px
-    background-color: white
-    padding: 2px 6px
-    border: 1px solid #999
-    width: 170px
-    font-weight: bold
-    font-size: 13px
-    font-family: 'Lato', sans-serif
-    &.sensor
-      color: #0592AF
-
   svg
     width: 1px
     height: 1px

--- a/src/dataflow/components/nodes/controls/dropdown-list-control.sass
+++ b/src/dataflow/components/nodes/controls/dropdown-list-control.sass
@@ -51,7 +51,7 @@
     position: absolute
     z-index: 1
     left: 18px
-    top: 106px
+    top: 52px
     width: 182px
     border: 1px solid #1E90FF
     background-color: white

--- a/src/dataflow/components/nodes/dataflow-node.sass
+++ b/src/dataflow/components/nodes/dataflow-node.sass
@@ -1,0 +1,42 @@
+@import ../../../components/vars
+
+.node
+  min-width: 220px
+  &.sensor, &.number, &.generator
+    background-color: #0592AF
+    border-color: #C0E4EB
+  &.logic, &.math, &.transform
+    background-color: #2DA343
+    border-color: #CDE8D2
+  &.relay, &.data-storage
+    background-color: #E16D2F
+    border-color: #E09E7D
+  &.selected
+    border-color: $color2-4
+
+  .node-title
+    font-size: 13px
+    color: white
+    padding: 4px
+
+  .node-output
+    background-color: red
+    padding: 0
+    margin: 0
+    height: 0px
+
+  .control
+    padding: 2px 18px
+
+  select, input
+    width: 100%
+    border-radius: 30px
+    background-color: white
+    padding: 2px 6px
+    border: 1px solid #999
+    width: 170px
+    font-weight: bold
+    font-size: 13px
+    font-family: 'Lato', sans-serif
+    &.sensor
+      color: #0592AF

--- a/src/dataflow/components/nodes/dataflow-node.tsx
+++ b/src/dataflow/components/nodes/dataflow-node.tsx
@@ -1,0 +1,56 @@
+import * as React from "react";
+import { Node, Socket, Control } from "rete-react-render-plugin";
+import "./dataflow-node.sass";
+
+export class DataflowNode extends Node {
+  public render() {
+    const { node, bindSocket, bindControl } = this.props;
+    const { outputs, controls, inputs, selected } = this.state;
+
+    return (
+      <div className={`node ${selected} ${node.name.toLowerCase().replace(/ /g, "-")}`}>
+        <div className="node-title">
+          {node.name}
+        </div>
+        {outputs.map((output: any) => (
+          <div className="node-output output" key={output.key}>
+            <Socket
+              type="output"
+              socket={output.socket}
+              io={output}
+              innerRef={bindSocket}
+            />
+          </div>
+        ))}
+        {controls.map((control: any) => (
+          <Control
+            className="control"
+            key={control.key}
+            control={control}
+            innerRef={bindControl}
+          />
+        ))}
+        {inputs.map((input: any) => (
+          <div className="input" key={input.key}>
+            <Socket
+              type="input"
+              socket={input.socket}
+              io={input}
+              innerRef={bindSocket}
+            />
+            {(!input.showControl() && input.name !== "sequence") && (
+              <div className="input-title">{input.name}</div>
+            )}
+            {(input.showControl() || input.name === "sequence") && (
+              <Control
+                className="input-control"
+                control={input.control}
+                innerRef={bindControl}
+              />
+            )}
+          </div>
+        ))}
+      </div>
+    );
+  }
+}

--- a/src/dataflow/components/nodes/factories/dataflow-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/dataflow-rete-node-factory.tsx
@@ -1,0 +1,13 @@
+import Rete from "rete";
+import { Socket } from "rete";
+import { DataflowNode } from "../dataflow-node";
+
+export abstract class DataflowReteNodeFactory extends Rete.Component {
+  protected numSocket: Socket;
+  constructor(name: string, numSocket: Socket) {
+    super(name);
+    this.numSocket = numSocket;
+    const data: any = this.data;
+    data.component = DataflowNode;
+  }
+}

--- a/src/dataflow/components/nodes/factories/generator-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/generator-rete-node-factory.tsx
@@ -1,20 +1,16 @@
 import Rete from "rete";
 import { Node, Socket } from "rete";
 import { NodeData } from "rete/types/core/data";
+import { DataflowReteNodeFactory } from "./dataflow-rete-node-factory";
 import { NumControl } from "../controls/num-control";
 import { ValueControl } from "../controls/value-control";
 import { PlotControl } from "../controls/plot-control";
 import { DropdownListControl } from "../controls/dropdown-list-control";
 import { NodeGeneratorTypes } from "../../../utilities/node";
-import { DataflowNode } from "../dataflow-node";
 
-export class GeneratorReteNodeFactory extends Rete.Component {
-  private numSocket: Socket;
+export class GeneratorReteNodeFactory extends DataflowReteNodeFactory {
   constructor(numSocket: Socket) {
-    super("Generator");
-    this.numSocket = numSocket;
-    const data: any = this.data;
-    data.component = DataflowNode;
+    super("Generator", numSocket);
   }
 
   public builder(node: Node) {

--- a/src/dataflow/components/nodes/factories/generator-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/generator-rete-node-factory.tsx
@@ -6,12 +6,15 @@ import { ValueControl } from "../controls/value-control";
 import { PlotControl } from "../controls/plot-control";
 import { DropdownListControl } from "../controls/dropdown-list-control";
 import { NodeGeneratorTypes } from "../../../utilities/node";
+import { DataflowNode } from "../dataflow-node";
 
 export class GeneratorReteNodeFactory extends Rete.Component {
   private numSocket: Socket;
   constructor(numSocket: Socket) {
     super("Generator");
     this.numSocket = numSocket;
+    const data: any = this.data;
+    data.component = DataflowNode;
   }
 
   public builder(node: Node) {

--- a/src/dataflow/components/nodes/factories/logic-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/logic-rete-node-factory.tsx
@@ -1,20 +1,16 @@
 import Rete from "rete";
 import { Node, Socket } from "rete";
 import { NodeData } from "rete/types/core/data";
+import { DataflowReteNodeFactory } from "./dataflow-rete-node-factory";
 import { NumControl } from "../controls/num-control";
 import { ValueControl } from "../controls/value-control";
 import { DropdownListControl } from "../controls/dropdown-list-control";
 import { NodeOperationTypes } from "../../../utilities/node";
 import { PlotControl } from "../controls/plot-control";
-import { DataflowNode } from "../dataflow-node";
 
-export class LogicReteNodeFactory extends Rete.Component {
-  private numSocket: Socket;
+export class LogicReteNodeFactory extends DataflowReteNodeFactory {
   constructor(numSocket: Socket) {
-    super("Logic");
-    this.numSocket = numSocket;
-    const data: any = this.data;
-    data.component = DataflowNode;
+    super("Logic", numSocket);
   }
 
   public builder(node: Node) {

--- a/src/dataflow/components/nodes/factories/logic-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/logic-rete-node-factory.tsx
@@ -6,12 +6,15 @@ import { ValueControl } from "../controls/value-control";
 import { DropdownListControl } from "../controls/dropdown-list-control";
 import { NodeOperationTypes } from "../../../utilities/node";
 import { PlotControl } from "../controls/plot-control";
+import { DataflowNode } from "../dataflow-node";
 
 export class LogicReteNodeFactory extends Rete.Component {
   private numSocket: Socket;
   constructor(numSocket: Socket) {
     super("Logic");
     this.numSocket = numSocket;
+    const data: any = this.data;
+    data.component = DataflowNode;
   }
 
   public builder(node: Node) {

--- a/src/dataflow/components/nodes/factories/math-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/math-rete-node-factory.tsx
@@ -1,20 +1,16 @@
 import Rete from "rete";
 import { Node, Socket } from "rete";
 import { NodeData } from "rete/types/core/data";
+import { DataflowReteNodeFactory } from "./dataflow-rete-node-factory";
 import { NumControl } from "../controls/num-control";
 import { ValueControl } from "../controls/value-control";
 import { DropdownListControl } from "../controls/dropdown-list-control";
 import { NodeOperationTypes, roundNodeValue } from "../../../utilities/node";
 import { PlotControl } from "../controls/plot-control";
-import { DataflowNode } from "../dataflow-node";
 
-export class MathReteNodeFactory extends Rete.Component {
-  private numSocket: Socket;
+export class MathReteNodeFactory extends DataflowReteNodeFactory {
   constructor(numSocket: Socket) {
-    super("Math");
-    this.numSocket = numSocket;
-    const data: any = this.data;
-    data.component = DataflowNode;
+    super("Math", numSocket);
   }
 
   public builder(node: Node) {

--- a/src/dataflow/components/nodes/factories/math-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/math-rete-node-factory.tsx
@@ -6,12 +6,15 @@ import { ValueControl } from "../controls/value-control";
 import { DropdownListControl } from "../controls/dropdown-list-control";
 import { NodeOperationTypes, roundNodeValue } from "../../../utilities/node";
 import { PlotControl } from "../controls/plot-control";
+import { DataflowNode } from "../dataflow-node";
 
 export class MathReteNodeFactory extends Rete.Component {
   private numSocket: Socket;
   constructor(numSocket: Socket) {
     super("Math");
     this.numSocket = numSocket;
+    const data: any = this.data;
+    data.component = DataflowNode;
   }
 
   public builder(node: Node) {

--- a/src/dataflow/components/nodes/factories/number-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/number-rete-node-factory.tsx
@@ -1,17 +1,13 @@
 import Rete from "rete";
 import { Node, Socket } from "rete";
 import { NodeData } from "rete/types/core/data";
+import { DataflowReteNodeFactory } from "./dataflow-rete-node-factory";
 import { NumControl } from "../controls/num-control";
 import { PlotControl } from "../controls/plot-control";
-import { DataflowNode } from "../dataflow-node";
 
-export class NumberReteNodeFactory extends Rete.Component {
-  private numSocket: Socket;
+export class NumberReteNodeFactory extends DataflowReteNodeFactory {
   constructor(numSocket: Socket) {
-    super("Number");
-    this.numSocket = numSocket;
-    const data: any = this.data;
-    data.component = DataflowNode;
+    super("Number", numSocket);
   }
 
   public builder(node: Node) {

--- a/src/dataflow/components/nodes/factories/number-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/number-rete-node-factory.tsx
@@ -3,12 +3,15 @@ import { Node, Socket } from "rete";
 import { NodeData } from "rete/types/core/data";
 import { NumControl } from "../controls/num-control";
 import { PlotControl } from "../controls/plot-control";
+import { DataflowNode } from "../dataflow-node";
 
 export class NumberReteNodeFactory extends Rete.Component {
   private numSocket: Socket;
   constructor(numSocket: Socket) {
     super("Number");
     this.numSocket = numSocket;
+    const data: any = this.data;
+    data.component = DataflowNode;
   }
 
   public builder(node: Node) {

--- a/src/dataflow/components/nodes/factories/relay-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/relay-rete-node-factory.tsx
@@ -1,19 +1,15 @@
 import Rete from "rete";
 import { Node, Socket } from "rete";
 import { NodeData } from "rete/types/core/data";
+import { DataflowReteNodeFactory } from "./dataflow-rete-node-factory";
 import { NumControl } from "../controls/num-control";
 import { ValueControl } from "../controls/value-control";
 import { RelaySelectControl } from "../controls/relay-select-control";
 import { PlotControl } from "../controls/plot-control";
-import { DataflowNode } from "../dataflow-node";
 
-export class RelayReteNodeFactory extends Rete.Component {
-  private numSocket: Socket;
+export class RelayReteNodeFactory extends DataflowReteNodeFactory {
   constructor(numSocket: Socket) {
-    super("Relay");
-    this.numSocket = numSocket;
-    const data: any = this.data;
-    data.component = DataflowNode;
+    super("Relay", numSocket);
   }
 
   public builder(node: Node) {

--- a/src/dataflow/components/nodes/factories/relay-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/relay-rete-node-factory.tsx
@@ -5,12 +5,15 @@ import { NumControl } from "../controls/num-control";
 import { ValueControl } from "../controls/value-control";
 import { RelaySelectControl } from "../controls/relay-select-control";
 import { PlotControl } from "../controls/plot-control";
+import { DataflowNode } from "../dataflow-node";
 
 export class RelayReteNodeFactory extends Rete.Component {
   private numSocket: Socket;
   constructor(numSocket: Socket) {
     super("Relay");
     this.numSocket = numSocket;
+    const data: any = this.data;
+    data.component = DataflowNode;
   }
 
   public builder(node: Node) {

--- a/src/dataflow/components/nodes/factories/sensor-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/sensor-rete-node-factory.tsx
@@ -3,12 +3,15 @@ import { Node, Socket } from "rete";
 import { NodeData } from "rete/types/core/data";
 import { SensorSelectControl } from "../controls/sensor-select-control";
 import { PlotControl } from "../controls/plot-control";
+import { DataflowNode } from "../dataflow-node";
 
 export class SensorReteNodeFactory extends Rete.Component {
   private numSocket: Socket;
   constructor(numSocket: Socket) {
     super("Sensor");
     this.numSocket = numSocket;
+    const data: any = this.data;
+    data.component = DataflowNode;
   }
 
   public builder(node: Node) {

--- a/src/dataflow/components/nodes/factories/sensor-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/sensor-rete-node-factory.tsx
@@ -1,17 +1,13 @@
 import Rete from "rete";
 import { Node, Socket } from "rete";
 import { NodeData } from "rete/types/core/data";
+import { DataflowReteNodeFactory } from "./dataflow-rete-node-factory";
 import { SensorSelectControl } from "../controls/sensor-select-control";
 import { PlotControl } from "../controls/plot-control";
-import { DataflowNode } from "../dataflow-node";
 
-export class SensorReteNodeFactory extends Rete.Component {
-  private numSocket: Socket;
+export class SensorReteNodeFactory extends DataflowReteNodeFactory {
   constructor(numSocket: Socket) {
-    super("Sensor");
-    this.numSocket = numSocket;
-    const data: any = this.data;
-    data.component = DataflowNode;
+    super("Sensor", numSocket);
   }
 
   public builder(node: Node) {

--- a/src/dataflow/components/nodes/factories/transform-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/transform-rete-node-factory.tsx
@@ -1,17 +1,20 @@
 import Rete from "rete";
-import { Node, Socket, NodeEditor } from "rete";
+import { Node, Socket } from "rete";
 import { NodeData } from "rete/types/core/data";
 import { NumControl } from "../controls/num-control";
 import { ValueControl } from "../controls/value-control";
 import { DropdownListControl } from "../controls/dropdown-list-control";
 import { NodeOperationTypes } from "../../../utilities/node";
 import { PlotControl } from "../controls/plot-control";
+import { DataflowNode } from "../dataflow-node";
 
 export class TransformReteNodeFactory extends Rete.Component {
   private numSocket: Socket;
   constructor(numSocket: Socket) {
     super("Transform");
     this.numSocket = numSocket;
+    const data: any = this.data;
+    data.component = DataflowNode;
   }
 
   public builder(node: Node) {

--- a/src/dataflow/components/nodes/factories/transform-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/transform-rete-node-factory.tsx
@@ -1,20 +1,16 @@
 import Rete from "rete";
 import { Node, Socket } from "rete";
 import { NodeData } from "rete/types/core/data";
+import { DataflowReteNodeFactory } from "./dataflow-rete-node-factory";
 import { NumControl } from "../controls/num-control";
 import { ValueControl } from "../controls/value-control";
 import { DropdownListControl } from "../controls/dropdown-list-control";
 import { NodeOperationTypes } from "../../../utilities/node";
 import { PlotControl } from "../controls/plot-control";
-import { DataflowNode } from "../dataflow-node";
 
-export class TransformReteNodeFactory extends Rete.Component {
-  private numSocket: Socket;
+export class TransformReteNodeFactory extends DataflowReteNodeFactory {
   constructor(numSocket: Socket) {
-    super("Transform");
-    this.numSocket = numSocket;
-    const data: any = this.data;
-    data.component = DataflowNode;
+    super("Transform", numSocket);
   }
 
   public builder(node: Node) {


### PR DESCRIPTION
Custom Rete node styling changes in service of adding the upcoming data storage node (which needs greater control over the layout of node controls).  I wanted to break these changes into their own PR to keep the size of the upcoming data storage PR to a minimum and to isolate a majority of the UI-specific changes so they're easier to review.  The big change here is adding `dataflow-node.tsx` which which exports `DataflowNode` which allows us to control the layout and display of the inputs, outputs, and controls of each node (instead of using the Rete defaults).  The constructor of each node factory sets `data.component = DataflowNode` to specify that we should use the layout and display specified in `DataflowNode`.  This code is lifted from the Rete example of how to make a custom node found here (my changes are fairly minimal at present):
https://codesandbox.io/s/retejs-react-render-1dsdn