### PR TITLE
Clear list of selected nodes after node deletion

### DIFF
--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -178,7 +178,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
     this.programEditor.clear();
   }
   private deleteSelectedNodes = () => {
-    const selectedNodes = this.programEditor.selected.list;
+    const selectedNodes = this.programEditor.selected.list.slice();
     this.programEditor.selected.clear();
     selectedNodes.forEach((n: Node) => {
       this.programEditor.removeNode(n);

--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -178,7 +178,9 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
     this.programEditor.clear();
   }
   private deleteSelectedNodes = () => {
-    this.programEditor.selected.list.forEach((n: Node) => {
+    const selectedNodes = this.programEditor.selected.list;
+    this.programEditor.selected.clear();
+    selectedNodes.forEach((n: Node) => {
       this.programEditor.removeNode(n);
     });
   }


### PR DESCRIPTION
Small fix for bug found while testing.  Clear list of selected nodes after deleting selected nodes or subsequent deletion attempts might reference invalid node(s).