### PR TITLE
First pass data storage block

### DIFF
--- a/src/dataflow/components/dataflow-program-toolbar.tsx
+++ b/src/dataflow/components/dataflow-program-toolbar.tsx
@@ -34,7 +34,7 @@ export class DataflowProgramToolbar extends React.Component<IProps, {}> {
     const handleAddNodeButtonClick = () => { this.props.onNodeCreateClick(nodeType); };
     return (
       <button
-        disabled={nodeType === "Data Storage" ? this.props.isDataStorageDisabled : false}
+        disabled={nodeType === "Data Storage" && this.props.isDataStorageDisabled}
         key={i}
         onClick={handleAddNodeButtonClick}
       >

--- a/src/dataflow/components/dataflow-program-toolbar.tsx
+++ b/src/dataflow/components/dataflow-program-toolbar.tsx
@@ -8,6 +8,7 @@ interface IProps {
   onDeleteClick: () => void;
   onResetClick: () => void;
   onClearClick: () => void;
+  isDataStorageDisabled: boolean;
 }
 
 export class DataflowProgramToolbar extends React.Component<IProps, {}> {
@@ -33,6 +34,7 @@ export class DataflowProgramToolbar extends React.Component<IProps, {}> {
     const handleAddNodeButtonClick = () => { this.props.onNodeCreateClick(nodeType); };
     return (
       <button
+        disabled={nodeType === "Data Storage" ? this.props.isDataStorageDisabled : false}
         key={i}
         onClick={handleAddNodeButtonClick}
       >

--- a/src/dataflow/components/nodes/controls/dropdown-list-control.tsx
+++ b/src/dataflow/components/nodes/controls/dropdown-list-control.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
-import Rete from "rete";
+import Rete, { NodeEditor, Node } from "rete";
 import "./dropdown-list-control.sass";
 
 export class DropdownListControl extends Rete.Control {
-  private emitter: any;
+  private emitter: NodeEditor;
   private component: any;
   private props: any;
-  constructor(emitter: any, key: string, node: any, optionArray: any, readonly = false) {
+  constructor(emitter: NodeEditor, key: string, node: Node, optionArray: any, readonly = false) {
     super(key);
     this.emitter = emitter;
     this.key = key;

--- a/src/dataflow/components/nodes/controls/num-control.tsx
+++ b/src/dataflow/components/nodes/controls/num-control.tsx
@@ -1,17 +1,17 @@
 import * as React from "react";
 import { useRef, useEffect } from "react";
-import Rete from "rete";
+import Rete, { NodeEditor, Node } from "rete";
 import "./num-control.sass";
 
 // cf. https://codesandbox.io/s/retejs-react-render-t899c
 export class NumControl extends Rete.Control {
-  private emitter: any;
+  private emitter: NodeEditor;
   private component: any;
   private props: any;
-  private min: any;
-  constructor(emitter: any,
+  private min: number | null;
+  constructor(emitter: NodeEditor,
               key: string,
-              node: any,
+              node: Node,
               readonly = false,
               label = "",
               initVal = 0,
@@ -23,7 +23,7 @@ export class NumControl extends Rete.Control {
       return (e: any) => { onChange(+e.target.value); };
     };
     const handlePointerDown = (e: PointerEvent) => e.stopPropagation();
-    this.component = (compProps: { readonly: any, value: any; onChange: any; label: any}) => {
+    this.component = (compProps: { readonly: any, value: any; onChange: any; label: string}) => {
       const inputRef = useRef<HTMLInputElement>(null);
       useEffect(() => {
         inputRef.current && inputRef.current.addEventListener("pointerdown", handlePointerDown);

--- a/src/dataflow/components/nodes/controls/plot-control.tsx
+++ b/src/dataflow/components/nodes/controls/plot-control.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import Rete from "rete";
+import Rete, { NodeEditor, Node } from "rete";
 import { Line } from "react-chartjs-2";
 import { ChartOptions, ChartData, ChartDataSets } from "chart.js";
 import { MAX_NODE_VALUES } from "../../dataflow-program";
@@ -7,13 +7,13 @@ import { NodePlotColors } from "../../../utilities/node";
 import "./plot-control.sass";
 
 export class PlotControl extends Rete.Control {
-  private emitter: any;
+  private emitter: NodeEditor;
   private component: any;
   private props: any;
-  private node: any;
+  private node: Node;
   private stepY = 5;
 
-  constructor(emitter: any, key: string, node: any) {
+  constructor(emitter: NodeEditor, key: string, node: Node) {
     super(key);
     this.emitter = emitter;
     this.key = key;
@@ -48,17 +48,15 @@ export class PlotControl extends Rete.Control {
       // determine how many datasets will be in graph
       const recentValuesKey = "recentValues";
       const recentValues: any = node.data[recentValuesKey];
-      const graphKeys: string[] = [];
+      let graphKeys: string[] = [];
       if (recentValues && recentValues.length) {
-        Object.keys(recentValues[recentValues.length - 1]).forEach((objKey: any) => {
-          graphKeys.push(objKey);
-        });
+        graphKeys = Object.keys(recentValues[recentValues.length - 1]);
       }
 
       let dsMax = 0;
       let dsMin = 0;
       if (graphKeys && graphKeys.length) {
-        graphKeys.forEach((graphKey: any, index: number) => {
+        graphKeys.forEach((graphKey, index: number) => {
           // set up a new dataset to be graphed
           const plotColor = NodePlotColors[index % NodePlotColors.length];
           const dataset: ChartDataSets = {
@@ -75,7 +73,7 @@ export class PlotControl extends Rete.Control {
           const chdata: any[] = [];
           recentValues.forEach((recVal: any) => {
             recVal[graphKey] ? chdata.push(recVal[graphKey].val) : chdata.push(Number.NaN);
-            if (chdata && chdata.length && !isNaN(chdata[chdata.length - 1])) {
+            if (chdata && chdata.length && isFinite(chdata[chdata.length - 1])) {
               dsMax = Math.max(dsMax, chdata[chdata.length - 1]);
               dsMin = Math.min(dsMin, chdata[chdata.length - 1]);
             }

--- a/src/dataflow/components/nodes/controls/plot-control.tsx
+++ b/src/dataflow/components/nodes/controls/plot-control.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
 import Rete from "rete";
 import { Line } from "react-chartjs-2";
-import { ChartOptions } from "chart.js";
-import { cloneDeep } from "lodash";
+import { ChartOptions, ChartData, ChartDataSets } from "chart.js";
 import { MAX_NODE_VALUES } from "../../dataflow-program";
+import { NodePlotColors } from "../../../utilities/node";
 import "./plot-control.sass";
 
 export class PlotControl extends Rete.Control {
@@ -43,29 +43,55 @@ export class PlotControl extends Rete.Control {
     );
 
     const lineData = () => {
-      const data = {
-        labels: Array.apply(null, {length: MAX_NODE_VALUES}).map(Number.call, Number),
-        datasets: [{
-          backgroundColor: "rgb(5, 146, 175)",
-          borderColor: "rgb(5, 146, 175)",
-          borderWidth: 2,
-          pointRadius: 2,
-          data: [0],
-          fill: false,
-        }]
-      };
-      const valKey = "recentValues";
-      const values: any = node.data[valKey];
-      if (values) {
-        const chdata: any[] = cloneDeep(values) as any[];
-        data.datasets[0].data = chdata;
-        const max = Math.max.apply(Math, chdata);
-        const min = Math.min.apply(Math, chdata);
-        const maxY = Math.ceil(max + 1);
-        const minY = Math.floor(min >= 1 || min < 0 ? min - 1 : min);
-        this.stepY = (maxY - minY) / 2;
+      const chartDataSets: ChartDataSets[] = [];
+
+      // determine how many datasets will be in graph
+      const recentValuesKey = "recentValues";
+      const recentValues: any = node.data[recentValuesKey];
+      const graphKeys: string[] = [];
+      if (recentValues && recentValues.length) {
+        Object.keys(recentValues[recentValues.length - 1]).forEach((objKey: any) => {
+          graphKeys.push(objKey);
+        });
       }
-      return data;
+
+      let dsMax = 0;
+      let dsMin = 0;
+      if (graphKeys && graphKeys.length) {
+        graphKeys.forEach((graphKey: any, index: number) => {
+          // set up a new dataset to be graphed
+          const plotColor = NodePlotColors[index % NodePlotColors.length];
+          const dataset: ChartDataSets = {
+            backgroundColor: plotColor,
+            borderColor: plotColor,
+            borderWidth: 2,
+            pointRadius: 2,
+            data: [0],
+            fill: false,
+          };
+          chartDataSets.push(dataset);
+
+          // get all values for this key
+          const chdata: any[] = [];
+          recentValues.forEach((recVal: any) => {
+            recVal[graphKey] ? chdata.push(recVal[graphKey].val) : chdata.push(Number.NaN);
+            if (chdata && chdata.length && !isNaN(chdata[chdata.length - 1])) {
+              dsMax = Math.max(dsMax, chdata[chdata.length - 1]);
+              dsMin = Math.min(dsMin, chdata[chdata.length - 1]);
+            }
+          });
+          // put values in dataset
+          chartDataSets[index].data = chdata;
+        });
+        this.stepY = (dsMax - dsMin) / 2;
+      }
+
+      const chartData: ChartData = {
+        labels: Array.apply(null, {length: MAX_NODE_VALUES}).map(Number.call, Number),
+        datasets: chartDataSets
+      };
+
+      return chartData;
     };
 
     const lineOptions = () => {

--- a/src/dataflow/components/nodes/controls/relay-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/relay-select-control.tsx
@@ -1,15 +1,15 @@
 import * as React from "react";
-import Rete from "rete";
+import Rete, { NodeEditor, Node } from "rete";
 import "./sensor-select-control.sass";
 import { NodeChannelInfo } from "../../../utilities/node";
 
 export class RelaySelectControl extends Rete.Control {
-  private emitter: any;
+  private emitter: NodeEditor;
   private component: any;
   private props: any;
-  private node: any;
+  private node: Node;
 
-  constructor(emitter: any, key: string, node: any, readonly = false) {
+  constructor(emitter: NodeEditor, key: string, node: Node, readonly = false) {
     super(key);
     this.emitter = emitter;
     this.key = key;

--- a/src/dataflow/components/nodes/controls/sensor-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/sensor-select-control.tsx
@@ -1,16 +1,16 @@
 import * as React from "react";
-import Rete from "rete";
+import Rete, { NodeEditor, Node } from "rete";
 import { NodeSensorTypes, NodeChannelInfo } from "../../../utilities/node";
 import "./sensor-select-control.sass";
 import "./value-control.sass";
 
 export class SensorSelectControl extends Rete.Control {
-  private emitter: any;
+  private emitter: NodeEditor;
   private component: any;
   private props: any;
-  private node: any;
+  private node: Node;
 
-  constructor(emitter: any, key: string, node: any, readonly = false) {
+  constructor(emitter: NodeEditor, key: string, node: Node, readonly = false) {
     super(key);
     this.emitter = emitter;
     this.key = key;

--- a/src/dataflow/components/nodes/controls/text-control.sass
+++ b/src/dataflow/components/nodes/controls/text-control.sass
@@ -1,0 +1,12 @@
+.text-container
+  display: flex
+  flex-direction: row
+  color: white
+
+  .text-label
+    color: white
+    margin-right: 5px
+
+  .text-input
+    width: 130px!important
+

--- a/src/dataflow/components/nodes/controls/text-control.tsx
+++ b/src/dataflow/components/nodes/controls/text-control.tsx
@@ -1,14 +1,14 @@
 import * as React from "react";
-import Rete from "rete";
+import Rete, { NodeEditor, Node } from "rete";
 import "./text-control.sass";
 
 export class TextControl extends Rete.Control {
-  private emitter: any;
+  private emitter: NodeEditor;
   private component: any;
   private props: any;
-  constructor(emitter: any,
+  constructor(emitter: NodeEditor,
               key: string,
-              node: any,
+              node: Node,
               label = "",
               initVal = "") {
     super(key);

--- a/src/dataflow/components/nodes/controls/text-control.tsx
+++ b/src/dataflow/components/nodes/controls/text-control.tsx
@@ -1,0 +1,58 @@
+import * as React from "react";
+import Rete from "rete";
+import "./text-control.sass";
+
+export class TextControl extends Rete.Control {
+  private emitter: any;
+  private component: any;
+  private props: any;
+  constructor(emitter: any,
+              key: string,
+              node: any,
+              label = "",
+              initVal = "") {
+    super(key);
+    this.emitter = emitter;
+    this.key = key;
+    const handleChange = (onChange: any) => {
+      return (e: any) => { onChange(e.target.value); };
+    };
+    const handlePointerMove = (e: any) => e.stopPropagation();
+    this.component = (compProps: { value: any; onChange: any; label: any}) => (
+      <div className="text-container">
+        { label
+          ? <label className="text-label">{compProps.label}</label>
+          : null
+        }
+        <input className="text-input"
+          type={"text"}
+          value={compProps.value}
+          onChange={handleChange(compProps.onChange)}
+          onPointerMove={handlePointerMove}
+        />
+      </div>
+    );
+
+    const initial = node.data[key] || initVal;
+    node.data[key] = initial;
+
+    this.props = {
+      value: initial,
+      onChange: (v: any) => {
+        this.setValue(v);
+        this.emitter.trigger("process");
+      },
+      label
+    };
+  }
+
+  public setValue = (val: string) => {
+    this.props.value = val;
+    this.putData(this.key, val);
+    (this as any).update();
+  }
+
+  public getValue = () => {
+    return this.props.value;
+  }
+}

--- a/src/dataflow/components/nodes/controls/value-control.tsx
+++ b/src/dataflow/components/nodes/controls/value-control.tsx
@@ -1,15 +1,15 @@
 import * as React from "react";
-import Rete from "rete";
+import Rete, { NodeEditor, Node } from "rete";
 import { roundNodeValue } from "../../../utilities/node";
 import "./value-control.sass";
 
 export class ValueControl extends Rete.Control {
-  private emitter: any;
+  private emitter: NodeEditor;
   private component: any;
   private props: any;
-  constructor(emitter: any,
+  constructor(emitter: NodeEditor,
               key: string,
-              node: any) {
+              node: Node) {
     super(key);
     this.emitter = emitter;
     this.key = key;

--- a/src/dataflow/components/nodes/factories/data-storage-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/data-storage-rete-node-factory.tsx
@@ -1,0 +1,111 @@
+import Rete from "rete";
+import { Node, Socket } from "rete";
+import { NodeData } from "rete/types/core/data";
+import { DataflowReteNodeFactory } from "./dataflow-rete-node-factory";
+import { NumControl } from "../controls/num-control";
+import { TextControl } from "../controls/text-control";
+import { PlotControl } from "../controls/plot-control";
+import * as uuid from "uuid/v4";
+
+export class DataStorageReteNodeFactory extends DataflowReteNodeFactory {
+  constructor(numSocket: Socket) {
+    super("Data Storage", numSocket);
+  }
+
+  public builder(node: Node) {
+    const inputUuid = uuid();
+    const inp = new Rete.Input("i-" + inputUuid, "sequence", this.numSocket);
+    inp.addControl(new TextControl(this.editor, "it-" + inputUuid, node, "", "my-sequence"));
+
+    return node
+      .addControl(new TextControl(this.editor, "dataset", node, "name", "my-dataset"))
+      .addControl(new NumControl(this.editor, "interval", node, false, "interval", 1, 1))
+      .addControl(new PlotControl(this.editor, "plot", node))
+      .addInput(inp) as any;
+  }
+
+  public worker(node: NodeData, inputs: any, outputs: any) {
+    const inputValues: any = {};
+    const inputKeys: any = Object.keys(inputs);
+    if (inputKeys) {
+      inputKeys.forEach((key: any) => {
+        if (inputs[key].length) {
+          const inputValue = { name: "sequence", val: inputs[key][0] };
+          inputValues[key] = inputValue;
+        }
+      });
+    }
+
+    if (this.editor) {
+      const _node = this.editor.nodes.find((n: { id: any; }) => n.id === node.id);
+      if (_node) {
+        this.updateInputs(_node);
+        _node.data.nodeValue = inputValues;
+        this.editor.view.updateConnections( {node: _node} );
+      }
+    }
+  }
+
+  private updateInputs(node: Node) {
+    this.addInputs(node);
+    this.removeInputs(node);
+  }
+
+  private addInputs(node: Node) {
+    const iterator = node.inputs.values();
+    let result = iterator.next();
+    let lastInput = result.value;
+    while (!result.done) {
+      lastInput = result.value;
+      result = iterator.next();
+    }
+    if (lastInput && lastInput.connections.length > 0) {
+      // final input has a connection, add an additional input
+        this.addInput(node);
+    }
+  }
+
+  private addInput(node: Node) {
+    const inputUuid = uuid();
+    const input = new Rete.Input("i-" + inputUuid, "sequence", this.numSocket);
+    input.addControl(new TextControl(this.editor,
+                                     "it-" + inputUuid,
+                                     node,
+                                     "",
+                                     "my-sequence"));
+    node.addInput(input);
+    node.update();
+  }
+
+  private removeInputs(node: Node) {
+    const invalidInputs = [];
+    const iterator = node.inputs.values();
+    let result = iterator.next();
+    let invalidInput = "";
+    while (!result.done) {
+      if (invalidInput) {
+        invalidInputs.push(invalidInput);
+        invalidInput = "";
+      }
+      if (result.value && result.value.connections.length === 0) {
+        // we found an input with no connections
+        // if it isn't the last input, then remove it
+        invalidInput = result.value.key;
+      }
+      result = iterator.next();
+    }
+    invalidInputs.forEach((input) => {
+      this.removeInput(node, input);
+    });
+  }
+
+  private removeInput(node: Node, inputKey: string) {
+    const input = node.inputs.get(inputKey);
+    if (input && this.editor) {
+      input.connections.slice().map(this.editor.removeConnection.bind(this.editor));
+      node.removeInput(input);
+    }
+    node.update();
+  }
+
+}

--- a/src/dataflow/components/nodes/factories/generator-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/generator-rete-node-factory.tsx
@@ -14,19 +14,22 @@ export class GeneratorReteNodeFactory extends DataflowReteNodeFactory {
   }
 
   public builder(node: Node) {
-    const out = new Rete.Output("num", "Number", this.numSocket);
-    const dropdownOptions = NodeGeneratorTypes
-      .map((nodeOp) => {
-        return { name: nodeOp.name, icon: nodeOp.icon };
-      });
+    if (this.editor) {
+      const out = new Rete.Output("num", "Number", this.numSocket);
+      const dropdownOptions = NodeGeneratorTypes
+        .map((nodeOp) => {
+          return { name: nodeOp.name, icon: nodeOp.icon };
+        });
 
-    return node
-      .addControl(new DropdownListControl(this.editor, "generatorType", node, dropdownOptions, true))
-      .addControl(new NumControl(this.editor, "amplitude", node, false, "amplitude", 1, .01))
-      .addControl(new NumControl(this.editor, "period", node, false, "period", 10, 1))
-      .addControl(new ValueControl(this.editor, "nodeValue", node))
-      .addControl(new PlotControl(this.editor, "plot", node))
-      .addOutput(out) as any;
+      return node
+
+        .addControl(new DropdownListControl(this.editor, "generatorType", node, dropdownOptions, true))
+        .addControl(new NumControl(this.editor, "amplitude", node, false, "amplitude", 1, .01))
+        .addControl(new NumControl(this.editor, "period", node, false, "period", 10, 1))
+        .addControl(new ValueControl(this.editor, "nodeValue", node))
+        .addControl(new PlotControl(this.editor, "plot", node))
+        .addOutput(out) as any;
+    }
   }
 
   public worker(node: NodeData, inputs: any, outputs: any) {

--- a/src/dataflow/components/nodes/factories/logic-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/logic-rete-node-factory.tsx
@@ -14,26 +14,28 @@ export class LogicReteNodeFactory extends DataflowReteNodeFactory {
   }
 
   public builder(node: Node) {
-    const inp1 = new Rete.Input("num1", "Number", this.numSocket);
-    const inp2 = new Rete.Input("num2", "Number2", this.numSocket);
-    const out = new Rete.Output("num", "Number", this.numSocket);
+    if (this.editor) {
+      const inp1 = new Rete.Input("num1", "Number", this.numSocket);
+      const inp2 = new Rete.Input("num2", "Number2", this.numSocket);
+      const out = new Rete.Output("num", "Number", this.numSocket);
 
-    inp1.addControl(new NumControl(this.editor, "num1", node));
-    inp2.addControl(new NumControl(this.editor, "num2", node));
+      inp1.addControl(new NumControl(this.editor, "num1", node));
+      inp2.addControl(new NumControl(this.editor, "num2", node));
 
-    const dropdownOptions = NodeOperationTypes
-      .filter((nodeOp) => {
-        return nodeOp.type === "logic";
-      }).map((nodeOp) => {
-        return { name: nodeOp.name, icon: nodeOp.icon };
-      });
-    return node
-      .addInput(inp1)
-      .addInput(inp2)
-      .addControl(new DropdownListControl(this.editor, "logicOperator", node, dropdownOptions, true))
-      .addControl(new ValueControl(this.editor, "nodeValue", node))
-      .addControl(new PlotControl(this.editor, "plot", node))
-      .addOutput(out) as any;
+      const dropdownOptions = NodeOperationTypes
+        .filter((nodeOp) => {
+          return nodeOp.type === "logic";
+        }).map((nodeOp) => {
+          return { name: nodeOp.name, icon: nodeOp.icon };
+        });
+      return node
+        .addInput(inp1)
+        .addInput(inp2)
+        .addControl(new DropdownListControl(this.editor, "logicOperator", node, dropdownOptions, true))
+        .addControl(new ValueControl(this.editor, "nodeValue", node))
+        .addControl(new PlotControl(this.editor, "plot", node))
+        .addOutput(out) as any;
+    }
   }
 
   public worker(node: NodeData, inputs: any, outputs: any) {

--- a/src/dataflow/components/nodes/factories/math-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/math-rete-node-factory.tsx
@@ -14,26 +14,28 @@ export class MathReteNodeFactory extends DataflowReteNodeFactory {
   }
 
   public builder(node: Node) {
-    const inp1 = new Rete.Input("num1", "Number", this.numSocket);
-    const inp2 = new Rete.Input("num2", "Number2", this.numSocket);
-    const out = new Rete.Output("num", "Number", this.numSocket);
+    if (this.editor) {
+      const inp1 = new Rete.Input("num1", "Number", this.numSocket);
+      const inp2 = new Rete.Input("num2", "Number2", this.numSocket);
+      const out = new Rete.Output("num", "Number", this.numSocket);
 
-    inp1.addControl(new NumControl(this.editor, "num1", node));
-    inp2.addControl(new NumControl(this.editor, "num2", node));
+      inp1.addControl(new NumControl(this.editor, "num1", node));
+      inp2.addControl(new NumControl(this.editor, "num2", node));
 
-    const dropdownOptions = NodeOperationTypes
-      .filter((nodeOp) => {
-        return nodeOp.type === "math";
-      }).map((nodeOp) => {
-        return { name: nodeOp.name, icon: nodeOp.icon };
-      });
-    return node
-      .addInput(inp1)
-      .addInput(inp2)
-      .addControl(new DropdownListControl(this.editor, "mathOperator", node, dropdownOptions, true))
-      .addControl(new ValueControl(this.editor, "nodeValue", node))
-      .addControl(new PlotControl(this.editor, "plot", node))
-      .addOutput(out) as any;
+      const dropdownOptions = NodeOperationTypes
+        .filter((nodeOp) => {
+          return nodeOp.type === "math";
+        }).map((nodeOp) => {
+          return { name: nodeOp.name, icon: nodeOp.icon };
+        });
+      return node
+        .addInput(inp1)
+        .addInput(inp2)
+        .addControl(new DropdownListControl(this.editor, "mathOperator", node, dropdownOptions, true))
+        .addControl(new ValueControl(this.editor, "nodeValue", node))
+        .addControl(new PlotControl(this.editor, "plot", node))
+        .addOutput(out) as any;
+    }
   }
 
   public worker(node: NodeData, inputs: any, outputs: any) {

--- a/src/dataflow/components/nodes/factories/number-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/number-rete-node-factory.tsx
@@ -11,10 +11,12 @@ export class NumberReteNodeFactory extends DataflowReteNodeFactory {
   }
 
   public builder(node: Node) {
-    const out1 = new Rete.Output("num", "Number", this.numSocket);
-    const ctrl = new NumControl(this.editor, "nodeValue", node);
-    const plot = new PlotControl(this.editor, "plot", node);
-    return node.addControl(ctrl).addControl(plot).addOutput(out1) as any;
+    if (this.editor) {
+      const out1 = new Rete.Output("num", "Number", this.numSocket);
+      const ctrl = new NumControl(this.editor, "nodeValue", node);
+      const plot = new PlotControl(this.editor, "plot", node);
+      return node.addControl(ctrl).addControl(plot).addOutput(out1) as any;
+    }
   }
 
   public worker(node: NodeData, inputs: any, outputs: any) {

--- a/src/dataflow/components/nodes/factories/relay-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/relay-rete-node-factory.tsx
@@ -13,13 +13,15 @@ export class RelayReteNodeFactory extends DataflowReteNodeFactory {
   }
 
   public builder(node: Node) {
-    const inp1 = new Rete.Input("num1", "Number", this.numSocket);
-    inp1.addControl(new NumControl(this.editor, "num1", node));
-    return node
-      .addControl(new RelaySelectControl(this.editor, "relayList", node, true))
-      .addControl(new ValueControl(this.editor, "nodeValue", node))
-      .addControl(new PlotControl(this.editor, "plot", node))
-      .addInput(inp1) as any;
+    if (this.editor) {
+      const inp1 = new Rete.Input("num1", "Number", this.numSocket);
+      inp1.addControl(new NumControl(this.editor, "num1", node));
+      return node
+        .addControl(new RelaySelectControl(this.editor, "relayList", node, true))
+        .addControl(new ValueControl(this.editor, "nodeValue", node))
+        .addControl(new PlotControl(this.editor, "plot", node))
+        .addInput(inp1) as any;
+    }
   }
 
   public worker(node: NodeData, inputs: any, outputs: any) {

--- a/src/dataflow/components/nodes/factories/sensor-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/sensor-rete-node-factory.tsx
@@ -11,11 +11,13 @@ export class SensorReteNodeFactory extends DataflowReteNodeFactory {
   }
 
   public builder(node: Node) {
-    const out1 = new Rete.Output("num", "Number", this.numSocket);
-    return node
-      .addControl(new SensorSelectControl(this.editor, "sensorSelect", node, true))
-      .addControl(new PlotControl(this.editor, "plot", node))
-      .addOutput(out1) as any;
+    if (this.editor) {
+      const out1 = new Rete.Output("num", "Number", this.numSocket);
+      return node
+        .addControl(new SensorSelectControl(this.editor, "sensorSelect", node, true))
+        .addControl(new PlotControl(this.editor, "plot", node))
+        .addOutput(out1) as any;
+    }
   }
 
   public worker(node: NodeData, inputs: any, outputs: any) {

--- a/src/dataflow/components/nodes/factories/transform-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/transform-rete-node-factory.tsx
@@ -14,24 +14,26 @@ export class TransformReteNodeFactory extends DataflowReteNodeFactory {
   }
 
   public builder(node: Node) {
-    const inp1 = new Rete.Input("num1", "Number", this.numSocket);
-    const out = new Rete.Output("num", "Number", this.numSocket);
+    if (this.editor) {
+      const inp1 = new Rete.Input("num1", "Number", this.numSocket);
+      const out = new Rete.Output("num", "Number", this.numSocket);
 
-    inp1.addControl(new NumControl(this.editor, "num1", node));
+      inp1.addControl(new NumControl(this.editor, "num1", node));
 
-    const dropdownOptions = NodeOperationTypes
-      .filter((nodeOp) => {
-        return nodeOp.type === "transform";
-      }).map((nodeOp) => {
-        return { name: nodeOp.name, icon: nodeOp.icon };
-      });
+      const dropdownOptions = NodeOperationTypes
+        .filter((nodeOp) => {
+          return nodeOp.type === "transform";
+        }).map((nodeOp) => {
+          return { name: nodeOp.name, icon: nodeOp.icon };
+        });
 
-    return node
-      .addInput(inp1)
-      .addControl(new DropdownListControl(this.editor, "transformOperator", node, dropdownOptions, true))
-      .addControl(new ValueControl(this.editor, "nodeValue", node))
-      .addControl(new PlotControl(this.editor, "plot", node))
-      .addOutput(out) as any;
+      return node
+        .addInput(inp1)
+        .addControl(new DropdownListControl(this.editor, "transformOperator", node, dropdownOptions, true))
+        .addControl(new ValueControl(this.editor, "nodeValue", node))
+        .addControl(new PlotControl(this.editor, "plot", node))
+        .addOutput(out) as any;
+      }
   }
 
   public worker(node: NodeData, inputs: any, outputs: any) {

--- a/src/dataflow/utilities/node.ts
+++ b/src/dataflow/utilities/node.ts
@@ -234,13 +234,9 @@ export const roundNodeValue = (n: number) => {
   return Math.round(n * 1000) / 1000;
 };
 
-export const NodePlotColors = ["#0592AF", "#FFB399", "#FF33FF", "#FFFF99", "#00B3E6",
-                               "#E6B333", "#3366E6", "#999966", "#99FF99", "#B34D4D",
-                               "#80B300", "#809900", "#E6B3B3", "#6680B3", "#66991A",
-                               "#FF99E6", "#CCFF1A", "#FF1A66", "#E6331A", "#33FFCC",
-                               "#66994D", "#B366CC", "#4D8000", "#B33300", "#CC80CC",
-                               "#66664D", "#991AFF", "#E666FF", "#4DB3FF", "#1AB399",
-                               "#E666B3", "#33991A", "#CC9999", "#B3B31A", "#00E680",
-                               "#4D8066", "#809980", "#E6FF80", "#1AFF33", "#999933",
-                               "#FF3380", "#CCCC00", "#66E64D", "#4D80CC", "#9900B3",
-                               "#E64D66", "#4DB380", "#FF4D4D", "#99E6E6", "#6666FF"];
+export const NodePlotColors = ["#0592AF", "#ebb93e", "#eb813e", "#df4a4a", "#e4448c",
+                               "#d355c1", "#b05ecb", "#ffd56d", "#ffa56d", "#f57676",
+                               "#fa73b0", "#eb80dc", "#cd88e4", "#d49600", "#d45200",
+                               "#c60e0e", "#cc0860", "#b81da1", "#8d27ad", "#8b989f",
+                               "#5dd581", "#3cc8f5", "#aeb9bf", "#92e3aa", "#7ad9f8",
+                               "#5d6e77", "#31bc5a", "#0caadd"];

--- a/src/dataflow/utilities/node.ts
+++ b/src/dataflow/utilities/node.ts
@@ -20,6 +20,9 @@ export const NodeTypes = [
   {
     name: "Relay",
   },
+  {
+    name: "Data Storage",
+  },
 ];
 
 export const NodeOperationTypes = [
@@ -230,3 +233,14 @@ export interface NodeChannelInfo {
 export const roundNodeValue = (n: number) => {
   return Math.round(n * 1000) / 1000;
 };
+
+export const NodePlotColors = ["#0592AF", "#FFB399", "#FF33FF", "#FFFF99", "#00B3E6",
+                               "#E6B333", "#3366E6", "#999966", "#99FF99", "#B34D4D",
+                               "#80B300", "#809900", "#E6B3B3", "#6680B3", "#66991A",
+                               "#FF99E6", "#CCFF1A", "#FF1A66", "#E6331A", "#33FFCC",
+                               "#66994D", "#B366CC", "#4D8000", "#B33300", "#CC80CC",
+                               "#66664D", "#991AFF", "#E666FF", "#4DB3FF", "#1AB399",
+                               "#E666B3", "#33991A", "#CC9999", "#B3B31A", "#00E680",
+                               "#4D8066", "#809980", "#E6FF80", "#1AFF33", "#999933",
+                               "#FF3380", "#CCCC00", "#66E64D", "#4D80CC", "#9900B3",
+                               "#E64D66", "#4DB380", "#FF4D4D", "#99E6E6", "#6666FF"];


### PR DESCRIPTION
Adds a new data storage node with variable inputs (node adds a new input when user connects a node and removes input when input node is disconnected).  Data storage node contains a plot (like other nodes) that can display one or more graph traces for each current input (previous inputs that are no longer present but are contained in the 15 second node history are not shown).  
User can only have a single data storage block.  Toolbar button is disabled if data storage block is present.  
To facilitate these changes, the `plot-control` can now have multiple graph traces.  `recentValue` in node data is now stored as an object to allow storage of multiple node values needed for data storage node.  A new `text-control` Rete control is used in data storage node so user can enter sequence name for a data storage node input.