### PR TITLE
Provide mechanism for clients to disable tile drags

### DIFF
--- a/src/components/tools/tool-tile.tsx
+++ b/src/components/tools/tool-tile.tsx
@@ -16,6 +16,7 @@ import DrawingToolComponent from "./drawing-tool/drawing-tool";
 import { HotKeys } from "../../utilities/hot-keys";
 import { cloneDeep } from "lodash";
 import { TileCommentsComponent } from "./tile-comments";
+import "../../utilities/dom-utils";
 
 import "./tool-tile.sass";
 
@@ -182,6 +183,18 @@ export class ToolTileComponent extends BaseComponent<IProps, {}> {
   }
 
   private handleToolDragStart = (e: React.DragEvent<HTMLDivElement>) => {
+    const target: HTMLElement | null = e.target as HTMLElement;
+    if (!target || target.querySelector(".disable-tile-drag")) {
+      e.preventDefault();
+      return;
+    }
+    if (target && target.querySelector(".disable-tile-content-drag")) {
+      const eltTarget = document.elementFromPoint(e.clientX, e.clientY);
+      if (!eltTarget || !eltTarget.closest(".tool-tile-drag-handle")) {
+        e.preventDefault();
+        return;
+      }
+    }
     // set the drag data
     const { model, docId, height, scale } = this.props;
     const snapshot = cloneDeep(getSnapshot(model));

--- a/src/utilities/dom-utils.ts
+++ b/src/utilities/dom-utils.ts
@@ -1,0 +1,17 @@
+// cf. https://developer.mozilla.org/en-US/docs/Web/API/Element/matches#Polyfill
+if (!Element.prototype.matches) {
+  Element.prototype.matches = (Element.prototype as any).msMatchesSelector ||
+                              Element.prototype.webkitMatchesSelector;
+}
+
+// cf. https://developer.mozilla.org/en-US/docs/Web/API/Element/closest#Polyfill
+if (!Element.prototype.closest) {
+  Element.prototype.closest = function(selector: string) {
+    let el: any = this;
+    do {
+      if (el.matches(selector)) return el;
+      el = el.parentElement || el.parentNode;
+    } while (el !== null && el.nodeType === 1);
+    return null;
+  };
+}


### PR DESCRIPTION
- adding `.disable-tile-drag` class disables all tile drags
- adding `.disable-tile-content-drag` class disables dragging tile from content, but allows dragging tile from drag handle in upper right corner

Will be used in `dataflow` branch to disable tile content drags.