### PR TITLE
Update IoT QoS and send interval

### DIFF
--- a/src/dataflow/lib/iot.ts
+++ b/src/dataflow/lib/iot.ts
@@ -9,8 +9,7 @@ const COGNITO_POOL = "us-east-1:153d6337-3421-4c34-a21f-d1d2143a5091";
 const AWS_IOT_ENDPOINT_HOST = "a2zxjwmcl3eyqd-ats.iot.us-east-1.amazonaws.com";
 // WTD This is for testing purposes only. Remove when we add users and hub owners.
 const OWNER_ID = "123";
-// WTD This is for testing purposes only. Sensor send interval should be set by user.
-const SEND_INTERVAL = 2;
+const SEND_INTERVAL = 1;
 
 export enum TopicType {
   hubChannelInfo = "hubChannelInfo",
@@ -132,12 +131,12 @@ export class IoT {
 
   private startSendingSensorValues(hubId: string) {
     const topicMessage = JSON.stringify({ command: "set_send_interval", send_interval: SEND_INTERVAL});
-    this.client.publish(this.createTopic(OWNER_ID, hubId, TopicType.hubCommand), topicMessage);
+    this.client.publish(this.createTopic(OWNER_ID, hubId, TopicType.hubCommand), topicMessage, { qos: 1 });
 
   }
   private requestHubChannelInfo(hubId: string) {
     const topicMessage = JSON.stringify({ command: "req_devices"});
-    this.client.publish(this.createTopic(OWNER_ID, hubId, TopicType.hubCommand), topicMessage);
+    this.client.publish(this.createTopic(OWNER_ID, hubId, TopicType.hubCommand), topicMessage, { qos: 1 });
   }
 
   private processHubChannelInfoMessage(hubId: string, message: any) {


### PR DESCRIPTION
- When publishing MQTT topics messages, include quality of service parameter = 1 (at least once) allowing for consistent message delivery.  More reading on topic here:
https://www.hivemq.com/blog/mqtt-essentials-part-6-mqtt-quality-of-service-levels/
- Change `SEND_INTERVAL` to 1 second, this allows sensor messages to be sent from the hub every second which is the desired interval for use in classrooms (we were using 2 seconds to cut back on message traffic during initial testing, but we're at the phase of the project where we need to be using and testing the interval which is required for actual classroom use).