### PR TITLE
integrate rete node drag fixes into all control types

### DIFF
--- a/src/dataflow/components/nodes/controls/custom-hooks.ts
+++ b/src/dataflow/components/nodes/controls/custom-hooks.ts
@@ -1,0 +1,13 @@
+import { RefObject, useEffect } from "react";
+
+const stopEventPropagation = (e: PointerEvent) => e.stopPropagation();
+
+export function useStopEventPropagation<T extends HTMLElement, K extends keyof HTMLElementEventMap>(
+                  domRef: RefObject<T>, event: K): void {
+  useEffect(() => {
+    domRef.current && domRef.current.addEventListener(event, stopEventPropagation);
+    return () => {
+      domRef.current && domRef.current.removeEventListener(event, stopEventPropagation);
+    };
+  }, []);
+}

--- a/src/dataflow/components/nodes/controls/dropdown-list-control.tsx
+++ b/src/dataflow/components/nodes/controls/dropdown-list-control.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useRef, useEffect } from "react";
 import Rete, { NodeEditor, Node } from "rete";
 import "./dropdown-list-control.sass";
 
@@ -14,7 +15,7 @@ export class DropdownListControl extends Rete.Control {
     const handleChange = (onChange: any) => {
       return (e: any) => { onChange(e.target.value); };
     };
-    const handlePointerMove = (e: any) => e.stopPropagation();
+    const handlePointerDown = (e: PointerEvent) => e.stopPropagation();
 
     this.component = (compProps: {
                                     value: string;
@@ -40,6 +41,13 @@ export class DropdownListControl extends Rete.Control {
                                 onListClick: any,
                                 options: any,
                                 listClass: string) => {
+      const divRef = useRef<HTMLDivElement>(null);
+      useEffect(() => {
+        divRef.current && divRef.current.addEventListener("pointerdown", handlePointerDown);
+        return () => {
+          divRef.current && divRef.current.removeEventListener("pointerdown", handlePointerDown);
+        };
+      }, []);
       let icon = "";
       const option = options.find((op: any) => op.name === val);
       if (option && option.icon) {
@@ -47,8 +55,8 @@ export class DropdownListControl extends Rete.Control {
       }
 
       return (
-        <div className={`node-select ${listClass}`}>
-          <div className="item top" onClick={handleChange(onItemClick)}>
+        <div className={`node-select ${listClass}`} ref={divRef}>
+          <div className="item top" onMouseDown={handleChange(onItemClick)}>
             <svg className="icon top">
               <use xlinkHref={icon}/>
             </svg>
@@ -63,7 +71,7 @@ export class DropdownListControl extends Rete.Control {
               <div
                 className={ops.name === val ? `item ${listClass} selected` : `item ${listClass} selectable`}
                 key={i}
-                onClick={onListClick(ops.name)}
+                onMouseDown={onListClick(ops.name)}
               >
                 <svg className="icon">
                   <use xlinkHref={`#${ops.icon}`}/>

--- a/src/dataflow/components/nodes/controls/dropdown-list-control.tsx
+++ b/src/dataflow/components/nodes/controls/dropdown-list-control.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
-import { useRef, useEffect } from "react";
+import { useRef } from "react";
 import Rete, { NodeEditor, Node } from "rete";
+import { useStopEventPropagation } from "./custom-hooks";
 import "./dropdown-list-control.sass";
 
 export class DropdownListControl extends Rete.Control {
@@ -15,8 +16,6 @@ export class DropdownListControl extends Rete.Control {
     const handleChange = (onChange: any) => {
       return (e: any) => { onChange(e.target.value); };
     };
-    const handlePointerDown = (e: PointerEvent) => e.stopPropagation();
-
     this.component = (compProps: {
                                     value: string;
                                     onItemClick: () => void;
@@ -42,12 +41,7 @@ export class DropdownListControl extends Rete.Control {
                                 options: any,
                                 listClass: string) => {
       const divRef = useRef<HTMLDivElement>(null);
-      useEffect(() => {
-        divRef.current && divRef.current.addEventListener("pointerdown", handlePointerDown);
-        return () => {
-          divRef.current && divRef.current.removeEventListener("pointerdown", handlePointerDown);
-        };
-      }, []);
+      useStopEventPropagation(divRef, "pointerdown");
       let icon = "";
       const option = options.find((op: any) => op.name === val);
       if (option && option.icon) {

--- a/src/dataflow/components/nodes/controls/num-control.tsx
+++ b/src/dataflow/components/nodes/controls/num-control.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
-import { useRef, useEffect } from "react";
+import { useRef } from "react";
 import Rete, { NodeEditor, Node } from "rete";
+import { useStopEventPropagation } from "./custom-hooks";
 import "./num-control.sass";
 
 // cf. https://codesandbox.io/s/retejs-react-render-t899c
@@ -22,15 +23,9 @@ export class NumControl extends Rete.Control {
     const handleChange = (onChange: any) => {
       return (e: any) => { onChange(+e.target.value); };
     };
-    const handlePointerDown = (e: PointerEvent) => e.stopPropagation();
     this.component = (compProps: { readonly: any, value: any; onChange: any; label: string}) => {
       const inputRef = useRef<HTMLInputElement>(null);
-      useEffect(() => {
-        inputRef.current && inputRef.current.addEventListener("pointerdown", handlePointerDown);
-        return () => {
-          inputRef.current && inputRef.current.removeEventListener("pointerdown", handlePointerDown);
-        };
-      }, []);
+      useStopEventPropagation(inputRef, "pointerdown");
       return (
         <div className="number-container">
           { label

--- a/src/dataflow/components/nodes/controls/relay-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/relay-select-control.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useRef, useEffect } from "react";
 import Rete, { NodeEditor, Node } from "rete";
 import "./sensor-select-control.sass";
 import { NodeChannelInfo } from "../../../utilities/node";
@@ -18,7 +19,7 @@ export class RelaySelectControl extends Rete.Control {
     const handleChange = (onChange: any) => {
       return (e: any) => { onChange(e.target.value); };
     };
-    const handlePointerMove = (e: any) => e.stopPropagation();
+    const handlePointerDown = (e: PointerEvent) => e.stopPropagation();
 
     this.component = (compProps: { value: any; onChange: any; channels: NodeChannelInfo[] }) => (
       <div>
@@ -27,11 +28,19 @@ export class RelaySelectControl extends Rete.Control {
     );
 
     const renderRelayList = (id: string, channels: NodeChannelInfo[], onRelayChange: any) => {
+      const selectRef = useRef<HTMLSelectElement>(null);
+      useEffect(() => {
+        selectRef.current && selectRef.current.addEventListener("pointerdown", handlePointerDown);
+        return () => {
+          selectRef.current && selectRef.current.removeEventListener("pointerdown", handlePointerDown);
+        };
+      }, []);
       return (
         <select
-        value={id}
-        onChange={handleChange(onRelayChange)}
-        onPointerMove={handlePointerMove}>
+          ref={selectRef}
+          value={id}
+          onChange={handleChange(onRelayChange)}
+        >
         <option value="none">none</option>
         {channels ? channels.filter((ch: NodeChannelInfo) => (
           ch.type === "relay"

--- a/src/dataflow/components/nodes/controls/relay-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/relay-select-control.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
-import { useRef, useEffect } from "react";
+import { useRef } from "react";
 import Rete, { NodeEditor, Node } from "rete";
-import "./sensor-select-control.sass";
 import { NodeChannelInfo } from "../../../utilities/node";
+import { useStopEventPropagation } from "./custom-hooks";
+import "./sensor-select-control.sass";
 
 export class RelaySelectControl extends Rete.Control {
   private emitter: NodeEditor;
@@ -19,7 +20,6 @@ export class RelaySelectControl extends Rete.Control {
     const handleChange = (onChange: any) => {
       return (e: any) => { onChange(e.target.value); };
     };
-    const handlePointerDown = (e: PointerEvent) => e.stopPropagation();
 
     this.component = (compProps: { value: any; onChange: any; channels: NodeChannelInfo[] }) => (
       <div>
@@ -29,12 +29,7 @@ export class RelaySelectControl extends Rete.Control {
 
     const renderRelayList = (id: string, channels: NodeChannelInfo[], onRelayChange: any) => {
       const selectRef = useRef<HTMLSelectElement>(null);
-      useEffect(() => {
-        selectRef.current && selectRef.current.addEventListener("pointerdown", handlePointerDown);
-        return () => {
-          selectRef.current && selectRef.current.removeEventListener("pointerdown", handlePointerDown);
-        };
-      }, []);
+      useStopEventPropagation(selectRef, "pointerdown");
       return (
         <select
           ref={selectRef}

--- a/src/dataflow/components/nodes/controls/sensor-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/sensor-select-control.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
-import { useRef, useEffect } from "react";
+import { useRef } from "react";
 import Rete, { NodeEditor, Node } from "rete";
 import { NodeSensorTypes, NodeChannelInfo } from "../../../utilities/node";
+import { useStopEventPropagation } from "./custom-hooks";
 import "./sensor-select-control.sass";
 import "./value-control.sass";
 
@@ -20,7 +21,6 @@ export class SensorSelectControl extends Rete.Control {
     const handleChange = (onChange: any) => {
       return (e: any) => { onChange(e.target.value); };
     };
-    const handlePointerDown = (e: PointerEvent) => e.stopPropagation();
 
     this.component = (compProps: {
                                    type: string;
@@ -42,12 +42,7 @@ export class SensorSelectControl extends Rete.Control {
 
     const renderSensorTypeList = (type: string, showList: boolean, onItemClick: any, onListClick: any) => {
       const divRef = useRef<HTMLDivElement>(null);
-      useEffect(() => {
-        divRef.current && divRef.current.addEventListener("pointerdown", handlePointerDown);
-        return () => {
-          divRef.current && divRef.current.removeEventListener("pointerdown", handlePointerDown);
-        };
-      }, []);
+      useStopEventPropagation(divRef, "pointerdown");
       let icon = "";
       const sensorType = NodeSensorTypes.find((s: any) => s.type === type);
       if (sensorType && sensorType.icon) {
@@ -86,12 +81,7 @@ export class SensorSelectControl extends Rete.Control {
 
     const renderSensorList = (id: string, channels: NodeChannelInfo[], type: string, onSensorChange: any) => {
       const selectRef = useRef<HTMLSelectElement>(null);
-      useEffect(() => {
-        selectRef.current && selectRef.current.addEventListener("pointerdown", handlePointerDown);
-        return () => {
-          selectRef.current && selectRef.current.removeEventListener("pointerdown", handlePointerDown);
-        };
-      }, []);
+      useStopEventPropagation(selectRef, "pointerdown");
       return (
         <select
           ref={selectRef}

--- a/src/dataflow/components/nodes/controls/sensor-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/sensor-select-control.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useRef, useEffect } from "react";
 import Rete, { NodeEditor, Node } from "rete";
 import { NodeSensorTypes, NodeChannelInfo } from "../../../utilities/node";
 import "./sensor-select-control.sass";
@@ -19,7 +20,7 @@ export class SensorSelectControl extends Rete.Control {
     const handleChange = (onChange: any) => {
       return (e: any) => { onChange(e.target.value); };
     };
-    const handlePointerMove = (e: any) => e.stopPropagation();
+    const handlePointerDown = (e: PointerEvent) => e.stopPropagation();
 
     this.component = (compProps: {
                                    type: string;
@@ -40,14 +41,21 @@ export class SensorSelectControl extends Rete.Control {
     );
 
     const renderSensorTypeList = (type: string, showList: boolean, onItemClick: any, onListClick: any) => {
+      const divRef = useRef<HTMLDivElement>(null);
+      useEffect(() => {
+        divRef.current && divRef.current.addEventListener("pointerdown", handlePointerDown);
+        return () => {
+          divRef.current && divRef.current.removeEventListener("pointerdown", handlePointerDown);
+        };
+      }, []);
       let icon = "";
       const sensorType = NodeSensorTypes.find((s: any) => s.type === type);
       if (sensorType && sensorType.icon) {
         icon = `#${sensorType.icon}`;
       }
       return (
-        <div className="node-select sensor-type">
-          <div className="item top" onClick={handleChange(onItemClick)}>
+        <div className="node-select sensor-type" ref={divRef}>
+          <div className="item top" onMouseDown={handleChange(onItemClick)}>
             <svg className="icon top">
               <use xlinkHref={icon}/>
             </svg>
@@ -62,7 +70,7 @@ export class SensorSelectControl extends Rete.Control {
               <div
               className={val.name === type ? "item sensor-type-option selected" : "item sensor-type-option selectable"}
                 key={i}
-                onClick={onListClick(val.type)}
+                onMouseDown={onListClick(val.type)}
               >
                 <svg className="icon">
                   <use xlinkHref={`#${val.icon}`}/>
@@ -77,12 +85,20 @@ export class SensorSelectControl extends Rete.Control {
     };
 
     const renderSensorList = (id: string, channels: NodeChannelInfo[], type: string, onSensorChange: any) => {
+      const selectRef = useRef<HTMLSelectElement>(null);
+      useEffect(() => {
+        selectRef.current && selectRef.current.addEventListener("pointerdown", handlePointerDown);
+        return () => {
+          selectRef.current && selectRef.current.removeEventListener("pointerdown", handlePointerDown);
+        };
+      }, []);
       return (
         <select
+          ref={selectRef}
           className="sensor-select"
           value={id}
           onChange={handleChange(onSensorChange)}
-          onPointerMove={handlePointerMove}>
+        >
           <option value="none" className="sensor-option">none</option>
           {channels ? channels.filter((ch: NodeChannelInfo) => (
             ch.type === type

--- a/src/dataflow/components/nodes/controls/text-control.tsx
+++ b/src/dataflow/components/nodes/controls/text-control.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
-import { useRef, useEffect } from "react";
+import { useRef } from "react";
 import Rete, { NodeEditor, Node } from "rete";
+import { useStopEventPropagation } from "./custom-hooks";
 import "./text-control.sass";
 
 export class TextControl extends Rete.Control {
@@ -18,15 +19,9 @@ export class TextControl extends Rete.Control {
     const handleChange = (onChange: any) => {
       return (e: any) => { onChange(e.target.value); };
     };
-    const handlePointerDown = (e: PointerEvent) => e.stopPropagation();
     this.component = (compProps: { value: any; onChange: any; label: any}) => {
       const inputRef = useRef<HTMLInputElement>(null);
-      useEffect(() => {
-        inputRef.current && inputRef.current.addEventListener("pointerdown", handlePointerDown);
-        return () => {
-          inputRef.current && inputRef.current.removeEventListener("pointerdown", handlePointerDown);
-        };
-      }, []);
+      useStopEventPropagation(inputRef, "pointerdown");
       return (
         <div className="text-container">
           { label

--- a/src/dataflow/components/nodes/controls/text-control.tsx
+++ b/src/dataflow/components/nodes/controls/text-control.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useRef, useEffect } from "react";
 import Rete, { NodeEditor, Node } from "rete";
 import "./text-control.sass";
 
@@ -17,21 +18,31 @@ export class TextControl extends Rete.Control {
     const handleChange = (onChange: any) => {
       return (e: any) => { onChange(e.target.value); };
     };
-    const handlePointerMove = (e: any) => e.stopPropagation();
-    this.component = (compProps: { value: any; onChange: any; label: any}) => (
-      <div className="text-container">
-        { label
-          ? <label className="text-label">{compProps.label}</label>
-          : null
-        }
-        <input className="text-input"
-          type={"text"}
-          value={compProps.value}
-          onChange={handleChange(compProps.onChange)}
-          onPointerMove={handlePointerMove}
-        />
-      </div>
-    );
+    const handlePointerDown = (e: PointerEvent) => e.stopPropagation();
+    this.component = (compProps: { value: any; onChange: any; label: any}) => {
+      const inputRef = useRef<HTMLInputElement>(null);
+      useEffect(() => {
+        inputRef.current && inputRef.current.addEventListener("pointerdown", handlePointerDown);
+        return () => {
+          inputRef.current && inputRef.current.removeEventListener("pointerdown", handlePointerDown);
+        };
+      }, []);
+      return (
+        <div className="text-container">
+          { label
+            ? <label className="text-label">{compProps.label}</label>
+            : null
+          }
+          <input
+            className="text-input"
+            ref={inputRef}
+            type={"text"}
+            value={compProps.value}
+            onChange={handleChange(compProps.onChange)}
+          />
+        </div>
+      );
+    };
 
     const initial = node.data[key] || initVal;
     node.data[key] = initial;


### PR DESCRIPTION
Take changes to handle Rete node drag state that were originally implemented in the `NumControl` and extend them to the `DropdownListControl`, `RelaySelectControl`, `SensorSelectControl`, and `TextControl` to prevent errant node drags when user is working with node controls.  Minor change to make hand-rolled dropdowns respond to `mouseDown` instead of `click` so they more closely mimic the standard `select` controls.