### PR TITLE
Configure dataflow branch

### DIFF
--- a/src/curriculum/dataflow/dataflow.json
+++ b/src/curriculum/dataflow/dataflow.json
@@ -4,6 +4,17 @@
   "subtitle": "Computational Thinking in Biology",
   "pageTitle": "%unitTitle%",
   "demoProblemTitle": "%investigationTitle%",
+  "rightNavTabs": [
+    {
+      "tab": "my-work",
+      "label": "My Work",
+      "hideGhostUser": true
+    },
+    {
+      "tab": "class-work",
+      "label": "Shared Work"
+    }
+  ],
   "toolbar": [
     {
       "name": "select",

--- a/src/dataflow/components/tools/dataflow-tool.tsx
+++ b/src/dataflow/components/tools/dataflow-tool.tsx
@@ -24,9 +24,9 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IState>
   public state: IState = {};
 
   public render() {
-    const { model, readOnly } = this.props;
+    const { readOnly } = this.props;
     const editableClass = readOnly ? "read-only" : "editable";
-    const classes = `dataflow-tool ${editableClass}`;
+    const classes = `dataflow-tool disable-tile-content-drag ${editableClass}`;
     const program = this.getContent().program;
     return (
       <div className={classes}>


### PR DESCRIPTION
- Configure right-nav tabs for Dataflow
  - "Class Work" => "Shared Work"
  - no "Class Logs" tab
- Prevent Dataflow tile content drags
