### PR TITLE
Update initial node positions

### DIFF
--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -194,7 +194,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
     const n1 = await nodeFactory!.createNode();
 
     const numNodes = this.programEditor.nodes.length;
-    n1.position = [100 + Math.floor(numNodes / 10) * 200 + numNodes % 10 * 15, 5 + numNodes % 10 * 15];
+    n1.position = [95 + Math.floor((numNodes % 20) / 5) * 245 + Math.floor(numNodes / 20) * 15, 5 + numNodes % 5 * 90];
     this.programEditor.addNode(n1);
     if (nodeType === "Data Storage") {
       this.setState({disableDataStorage: true});


### PR DESCRIPTION
Minor change to adjust initial node positions so there is less node overlap to facilitate automated testing.  I'm using the number node size for layout (some nodes are obviously bigger, but the goal is to shrink nodes down to sizes closer to the number node size as we restyle the nodes). @eireland can you check if this works for you?