### PR TITLE
Update Rete editor size based on container resize to show editor content

### DIFF
--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -22,6 +22,7 @@ import { NumControl } from "./nodes/controls/num-control";
 import { safeJsonParse } from "../../utilities/js-utils";
 import { DataflowProgramToolbar } from "./dataflow-program-toolbar";
 import { DataflowProgramTopbar } from "./dataflow-program-topbar";
+import { SizeMeProps } from "react-sizeme";
 import "./dataflow-program.sass";
 
 interface NodeNameValuePair {
@@ -33,7 +34,7 @@ interface NodeValueMap {
 }
 type NodeValue = number | NodeValueMap;
 
-interface IProps extends IBaseProps {
+interface IProps extends SizeMeProps {
   program?: string;
 }
 
@@ -108,7 +109,12 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
     clearInterval(this.intervalHandle);
   }
 
-  public componentDidUpdate() {
+  public componentDidUpdate(prevProps: IProps) {
+    if (this.props.size !== prevProps.size) {
+      if (this.programEditor && this.programEditor.view) {
+        this.programEditor.view.resize();
+      }
+    }
     if (!this.programEditor && this.toolDiv) {
       this.initProgramEditor();
     }

--- a/src/dataflow/components/tools/dataflow-tool.tsx
+++ b/src/dataflow/components/tools/dataflow-tool.tsx
@@ -4,6 +4,7 @@ import { BaseComponent } from "../../../components/base";
 import { ToolTileModelType } from "../../../models/tools/tool-tile";
 import { DataflowContentModelType } from "../../models/tools/dataflow/dataflow-content";
 import { DataflowProgram } from "../dataflow-program";
+import { SizeMe, SizeMeProps } from "react-sizeme";
 
 import "./dataflow-tool.sass";
 
@@ -30,7 +31,16 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IState>
     const program = this.getContent().program;
     return (
       <div className={classes}>
-        <DataflowProgram program={program}/>
+        <SizeMe monitorHeight={true}>
+          {({ size }: SizeMeProps) => {
+            return (
+              <DataflowProgram
+                program={program}
+                size={size}
+              />
+            );
+          }}
+        </SizeMe>
       </div>
     );
   }


### PR DESCRIPTION
Use `react-sizeme` so we can monitor changes to the `DataflowProgram` component's height and width.  When changes are detected, signal to the Rete editor that its view needs to resize as well.  This eliminates cases where the program tile is resized, but the editor does not resize.  This caused cases where nodes were not properly displayed as the were moved (since they were outside of the editor view space.  Recommendation to call `editor.view.resize()` comes from this Rete issue:
https://github.com/retejs/rete/issues/108