### PR TITLE
167243673 save reload program

### DIFF
--- a/src/curriculum/dataflow/dataflow.json
+++ b/src/curriculum/dataflow/dataflow.json
@@ -67,6 +67,12 @@
                   {
                     "content": {
                       "type": "Dataflow",
+                      "programRunTime": 600,
+                      "programZoom": {
+                        "dx": 0,
+                        "dy": 0,
+                        "scale": 1
+                      },
                       "program": [
                         {
                           "id": "temp-id",

--- a/src/dataflow/components/dataflow-program-topbar.tsx
+++ b/src/dataflow/components/dataflow-program-topbar.tsx
@@ -22,7 +22,7 @@ export const DataflowProgramTopbar = (props: TopbarProps) => {
       <div>Duration:</div>
       <select
         onChange={handleSelectChange}
-        disabled={props.isRunEnabled || props.readOnly}
+        disabled={!props.isRunEnabled || props.readOnly}
         defaultValue={props.programDefaultRunTime.toString()}
       >
         { props.programRunTimes.map((rt: ProgramRunTime) => (
@@ -34,13 +34,13 @@ export const DataflowProgramTopbar = (props: TopbarProps) => {
       </select>
       <button
         onClick={props.onRunProgramClick}
-        disabled={props.isRunEnabled || props.readOnly}
+        disabled={!props.isRunEnabled || props.readOnly}
       >
         Run
       </button>
       <button
         onClick={props.onStopProgramClick}
-        disabled={!props.isRunEnabled || props.readOnly}
+        disabled={props.isRunEnabled || props.readOnly}
       >
         Stop
       </button>

--- a/src/dataflow/components/dataflow-program-topbar.tsx
+++ b/src/dataflow/components/dataflow-program-topbar.tsx
@@ -10,6 +10,7 @@ interface TopbarProps {
   programDefaultRunTime: number;
   onProgramTimeSelectClick: (type: number) => void;
   isRunEnabled: boolean;
+  readOnly: boolean;
 }
 
 export const DataflowProgramTopbar = (props: TopbarProps) => {
@@ -21,7 +22,7 @@ export const DataflowProgramTopbar = (props: TopbarProps) => {
       <div>Duration:</div>
       <select
         onChange={handleSelectChange}
-        disabled={props.isRunEnabled}
+        disabled={props.isRunEnabled || props.readOnly}
         defaultValue={props.programDefaultRunTime.toString()}
       >
         { props.programRunTimes.map((rt: ProgramRunTime) => (
@@ -33,13 +34,13 @@ export const DataflowProgramTopbar = (props: TopbarProps) => {
       </select>
       <button
         onClick={props.onRunProgramClick}
-        disabled={props.isRunEnabled}
+        disabled={props.isRunEnabled || props.readOnly}
       >
         Run
       </button>
       <button
         onClick={props.onStopProgramClick}
-        disabled={!props.isRunEnabled}
+        disabled={!props.isRunEnabled || props.readOnly}
       >
         Stop
       </button>

--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -160,6 +160,11 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
           this.setState({disableDataStorage: true});
         }
       }
+      const { area } = this.programEditor.view;
+      const { programZoom } = this.props;
+      if (programZoom) {
+        area.zoom(programZoom.scale, programZoom.dx, programZoom.dy, "wheel");
+      }
 
       (this.programEditor as any).on(
         "process nodecreated noderemoved connectioncreated connectionremoved",
@@ -196,6 +201,11 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
         return source !== "dblclick";
       });
 
+      this.programEditor.on("translated", node => {
+        const { transform } = this.programEditor.view.area;
+        this.props.onZoomChange(transform.x, transform.y, transform.k);
+      });
+
       // Can this be in a control with stores injected?
       autorun(() => {
         const { hubStore } = this.stores;
@@ -227,11 +237,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
           });
         });
       });
-      const { area } = this.programEditor.view;
-      const { programZoom } = this.props;
-      if (programZoom) {
-        area.zoom(programZoom.scale, programZoom.dx, programZoom.dy, "wheel");
-      }
+
       this.programEditor.view.resize();
       this.programEditor.trigger("process");
 

--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -162,6 +162,10 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
         }
       );
 
+      this.programEditor.on("nodedraged", node => {
+        this.props.onProgramChange(this.programEditor.toJSON());
+      });
+
       this.programEditor.on("nodecreate", node => {
         // trigger after each of the first six events
         // add the current set of sensors or relays to node controls

--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -85,6 +85,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
             programRunTimes={ProgramRunTimes}
             programDefaultRunTime={this.props.programRunTime || DEFAULT_PROGRAM_TIME}
             isRunEnabled={this.state.isProgramRunning}
+            readOnly={this.props.readOnly || false}
           />
 
           <div className="horizontal-container">

--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -36,6 +36,7 @@ interface NodeValueMap {
 type NodeValue = number | NodeValueMap;
 
 interface IProps extends SizeMeProps {
+  onProgramChange: (program: any) => void;
   program?: string;
 }
 
@@ -157,6 +158,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
         async () => {
           await this.programEngine.abort();
           await this.programEngine.process(this.programEditor.toJSON());
+          this.props.onProgramChange(this.programEditor.toJSON());
         }
       );
 

--- a/src/dataflow/components/tools/dataflow-tool.tsx
+++ b/src/dataflow/components/tools/dataflow-tool.tsx
@@ -29,14 +29,21 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IState>
     const editableClass = readOnly ? "read-only" : "editable";
     const classes = `dataflow-tool disable-tile-content-drag ${editableClass}`;
     const program = this.getContent().program;
+    const programRunTime = this.getContent().programRunTime;
+    const programZoom = this.getContent().programZoom;
     return (
       <div className={classes}>
         <SizeMe monitorHeight={true}>
           {({ size }: SizeMeProps) => {
             return (
               <DataflowProgram
-                onProgramChange={this.handleProgramChange}
+                readOnly={readOnly}
                 program={program}
+                onProgramChange={this.handleProgramChange}
+                programRunTime={programRunTime}
+                onProgramRunTimeChange={this.handleProgramRunTimeChange}
+                programZoom={programZoom}
+                onZoomChange={this.handleProgramZoomChange}
                 size={size}
               />
             );
@@ -49,6 +56,16 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IState>
   private handleProgramChange = (program: any) => {
     const content = this.getContent();
     content.setProgram(program);
+  }
+
+  private handleProgramRunTimeChange = (program: any) => {
+    const content = this.getContent();
+    content.setProgramRunTime(program);
+  }
+
+  private handleProgramZoomChange = (dx: number, dy: number, scale: number) => {
+    const content = this.getContent();
+    content.setProgramZoom(dx, dy, scale);
   }
 
   private getContent() {

--- a/src/dataflow/components/tools/dataflow-tool.tsx
+++ b/src/dataflow/components/tools/dataflow-tool.tsx
@@ -28,9 +28,7 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IState>
     const { readOnly } = this.props;
     const editableClass = readOnly ? "read-only" : "editable";
     const classes = `dataflow-tool disable-tile-content-drag ${editableClass}`;
-    const program = this.getContent().program;
-    const programRunTime = this.getContent().programRunTime;
-    const programZoom = this.getContent().programZoom;
+    const { program, programRunTime, programZoom } = this.getContent();
     return (
       <div className={classes}>
         <SizeMe monitorHeight={true}>
@@ -54,18 +52,15 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IState>
   }
 
   private handleProgramChange = (program: any) => {
-    const content = this.getContent();
-    content.setProgram(program);
+    this.getContent().setProgram(program);
   }
 
   private handleProgramRunTimeChange = (program: any) => {
-    const content = this.getContent();
-    content.setProgramRunTime(program);
+    this.getContent().setProgramRunTime(program);
   }
 
   private handleProgramZoomChange = (dx: number, dy: number, scale: number) => {
-    const content = this.getContent();
-    content.setProgramZoom(dx, dy, scale);
+    this.getContent().setProgramZoom(dx, dy, scale);
   }
 
   private getContent() {

--- a/src/dataflow/components/tools/dataflow-tool.tsx
+++ b/src/dataflow/components/tools/dataflow-tool.tsx
@@ -35,6 +35,7 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IState>
           {({ size }: SizeMeProps) => {
             return (
               <DataflowProgram
+                onProgramChange={this.handleProgramChange}
                 program={program}
                 size={size}
               />
@@ -43,6 +44,11 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IState>
         </SizeMe>
       </div>
     );
+  }
+
+  private handleProgramChange = (program: any) => {
+    const content = this.getContent();
+    content.setProgram(program);
   }
 
   private getContent() {

--- a/src/dataflow/models/tools/dataflow/dataflow-content.ts
+++ b/src/dataflow/models/tools/dataflow/dataflow-content.ts
@@ -16,13 +16,14 @@ const ProgramZoom = types.model({
   scale: types.number,
 });
 export type ProgramZoomType = typeof ProgramZoom.Type;
+const DEFAULT_PROGRAM_ZOOM = { dx: 0, dy: 0, scale: 1 };
 
 export const DataflowContentModel = types
   .model("DataflowTool", {
     type: types.optional(types.literal(kDataflowToolID), kDataflowToolID),
     program: "",
     programRunTime: DEFAULT_PROGRAM_TIME,
-    programZoom: types.optional(ProgramZoom, { dx: 0, dy: 0, scale: 1 }),
+    programZoom: types.optional(ProgramZoom, DEFAULT_PROGRAM_ZOOM),
   })
   .preProcessSnapshot(snapshot => processImport(snapshot))
   .views(self => ({

--- a/src/dataflow/models/tools/dataflow/dataflow-content.ts
+++ b/src/dataflow/models/tools/dataflow/dataflow-content.ts
@@ -19,6 +19,11 @@ export const DataflowContentModel = types
     isUserResizable() {
       return true;
     }
+  }))
+  .actions(self => ({
+    setProgram(program: any) {
+      self.program = JSON.stringify(program);
+    }
   }));
 
 export type DataflowContentModelType = Instance<typeof DataflowContentModel>;

--- a/src/dataflow/models/tools/dataflow/dataflow-content.ts
+++ b/src/dataflow/models/tools/dataflow/dataflow-content.ts
@@ -1,5 +1,6 @@
 import { types, Instance } from "mobx-state-tree";
 import { each } from "lodash";
+import { DEFAULT_PROGRAM_TIME } from "../../../../dataflow/utilities/node";
 
 export const kDataflowToolID = "Dataflow";
 
@@ -9,10 +10,19 @@ export function defaultDataflowContent(): DataflowContentModelType {
 
 export const kDataflowDefaultHeight = 480;
 
+const ProgramZoom = types.model({
+  dx: types.number,
+  dy: types.number,
+  scale: types.number,
+});
+export type ProgramZoomType = typeof ProgramZoom.Type;
+
 export const DataflowContentModel = types
   .model("DataflowTool", {
     type: types.optional(types.literal(kDataflowToolID), kDataflowToolID),
-    program: ""
+    program: "",
+    programRunTime: DEFAULT_PROGRAM_TIME,
+    programZoom: types.optional(ProgramZoom, { dx: 0, dy: 0, scale: 1 }),
   })
   .preProcessSnapshot(snapshot => processImport(snapshot))
   .views(self => ({
@@ -23,6 +33,14 @@ export const DataflowContentModel = types
   .actions(self => ({
     setProgram(program: any) {
       self.program = JSON.stringify(program);
+    },
+    setProgramRunTime(runTime: number) {
+      self.programRunTime = runTime;
+    },
+    setProgramZoom(dx: number, dy: number, scale: number) {
+      self.programZoom.dx = dx;
+      self.programZoom.dy = dy;
+      self.programZoom.scale = scale;
     }
   }));
 


### PR DESCRIPTION
Add ability to save and restore a program tile contents including the Rete program (nodes, connections, positions, etc.), the program run time, and the editor zoom and position.  Also expand the use of read-only state on a program tile to hide and disable appropriate elements.