### PR TITLE
Fetch program data

### DIFF
--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -17,7 +17,7 @@ import { RelayReteNodeFactory } from "./nodes/factories/relay-rete-node-factory"
 import { GeneratorReteNodeFactory } from "./nodes/factories/generator-rete-node-factory";
 import { DataStorageReteNodeFactory } from "./nodes/factories/data-storage-rete-node-factory";
 import { NodeChannelInfo, NodeGeneratorTypes, ProgramRunTimes, DEFAULT_PROGRAM_TIME } from "../utilities/node";
-import { uploadProgram } from "../utilities/aws";
+import { uploadProgram, fetchProgramData } from "../utilities/aws";
 import { PlotControl } from "./nodes/controls/plot-control";
 import { NumControl } from "./nodes/controls/num-control";
 import { safeJsonParse } from "../../utilities/js-utils";
@@ -341,15 +341,19 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
     });
   }
   private resetNodes = () => {
-    this.programEditor.nodes.forEach((n: Node) => {
-      if (n.data.recentValues) {
-        let values: any = n.data.recentValues;
-        values = [];
-        n.data.recentValues = values;
-        if (n.data.ticks) {
-          n.data.ticks = 0;
+    // TODO: Remove test data fetch - this is a PLACEHOLDER!
+    // Test for graphs - remove the two time parameters to fetch all rows, or adjust as required
+    fetchProgramData("dataflow-program-1565888617009", 1565888633071, 1565888713124).then((result) => {
+      this.programEditor.nodes.forEach((n: Node) => {
+        if (n.data.recentValues) {
+          let values: any = n.data.recentValues;
+          values = [];
+          n.data.recentValues = values;
+          if (n.data.ticks) {
+            n.data.ticks = 0;
+          }
         }
-      }
+      });
     });
   }
 

--- a/src/dataflow/utilities/aws.ts
+++ b/src/dataflow/utilities/aws.ts
@@ -75,9 +75,11 @@ export function uploadProgram(programData: NodeEditor): string {
   return "completed";
 }
 
-export const fetchProgramData = (programId: string, time?: number) => {
-
-  const queryParams = { programId, time };
+export const fetchProgramData = (programId: string, time?: number, endTime?: number) => {
+  // Omitting the time parameter returns all program data from the start
+  // Omitting the endTime returns all data from the start time and now
+  // time and endTime togethercan be passed to specify a range between the start time and endTime
+  const queryParams = { programId, time, endTime };
   const lambda = new AWS.Lambda({ region: "us-east-1", apiVersion: "2015-03-31" });
   const params = {
     FunctionName: "arn:aws:lambda:us-east-1:816253370536:function:fetchProgramData",


### PR DESCRIPTION
Added in parameters for start and end times so you can restrict how much data to pull out at once. That part of the PR is very small and ready to roll.

@mklewandowski Part 2 of the PR is a sample of how to get data out - I have it set to fetch data when you click the Reset button because I didn't want to add any extra temporary UI. I included that change as a sample of how you can call the function for testing. The programId I included has about 330 rows of data currently, so you have a reasonable amount of data to play with.