### PR TITLE
Support both string and numeric sensor values

### DIFF
--- a/src/dataflow/lib/iot.ts
+++ b/src/dataflow/lib/iot.ts
@@ -204,7 +204,7 @@ export class IoT {
     if (hub) {
       for (const key in message) {
         if (message.hasOwnProperty(key) && key !== "time") {
-          hub.setHubChannelValue(key, message[key]);
+          hub.setHubChannelValue(key, String(message[key]));
           hub.setHubChannelTime(key, time);
         }
       }


### PR DESCRIPTION
Previous version of sensaurus esp32 hub program and the existing sensaurus hub simulator publish MQTT topic messages which contain current sensor values as a string (such as "1.1" or "5.6"). The newer version of the sensaurus esp32 hub program now sends sensor messages that contains sensor values as a number (such as 1.1 or 5.6). Our internal hub store expects a string. For safety and compatibility (and so that the newest sensaurus does not cause errors when we process a message from it), convert all sensor values to strings before storing.