### PR TITLE
Save program run state

### DIFF
--- a/src/dataflow/components/dataflow-program-cover.sass
+++ b/src/dataflow/components/dataflow-program-cover.sass
@@ -1,0 +1,15 @@
+@import ../../components/vars
+
+.cover
+  position: absolute
+  width: 100%
+  height: 100%
+  background-color: rgba(0, 0, 0, 0.25)
+  display: flex
+  align-items: center
+  justify-content: center
+  top: 0px
+
+  .stop
+    width: 150px
+    height: 50px

--- a/src/dataflow/components/dataflow-program-cover.tsx
+++ b/src/dataflow/components/dataflow-program-cover.tsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+
+import "./dataflow-program-cover.sass";
+
+interface CoverProps {
+  onStopProgramClick: () => void;
+}
+
+export const DataflowProgramCover = (props: CoverProps) => {
+  return (
+    <div className="cover">
+      <button className="stop" onClick={props.onStopProgramClick}>
+        Stop
+      </button>
+    </div>
+  );
+};

--- a/src/dataflow/components/dataflow-program-toolbar.tsx
+++ b/src/dataflow/components/dataflow-program-toolbar.tsx
@@ -7,6 +7,7 @@ interface IProps {
   onNodeCreateClick: (type: string) => void;
   onDeleteClick: () => void;
   isDataStorageDisabled: boolean;
+  disabled: boolean;
 }
 
 export class DataflowProgramToolbar extends React.Component<IProps, {}> {
@@ -30,7 +31,7 @@ export class DataflowProgramToolbar extends React.Component<IProps, {}> {
     const handleAddNodeButtonClick = () => { this.props.onNodeCreateClick(nodeType); };
     return (
       <button
-        disabled={nodeType === "Data Storage" && this.props.isDataStorageDisabled}
+        disabled={nodeType === "Data Storage" && this.props.isDataStorageDisabled || this.props.disabled}
         key={i}
         onClick={handleAddNodeButtonClick}
       >

--- a/src/dataflow/components/dataflow-program-topbar.tsx
+++ b/src/dataflow/components/dataflow-program-topbar.tsx
@@ -5,7 +5,6 @@ import "./dataflow-program-topbar.sass";
 
 interface TopbarProps {
   onRunProgramClick: () => void;
-  onStopProgramClick: () => void;
   programRunTimes: ProgramRunTime[];
   programDefaultRunTime: number;
   onProgramTimeSelectClick: (type: number) => void;
@@ -37,12 +36,6 @@ export const DataflowProgramTopbar = (props: TopbarProps) => {
         disabled={!props.isRunEnabled || props.readOnly}
       >
         Run
-      </button>
-      <button
-        onClick={props.onStopProgramClick}
-        disabled={props.isRunEnabled || props.readOnly}
-      >
-        Stop
       </button>
     </div>
   );

--- a/src/dataflow/components/tools/dataflow-tool.tsx
+++ b/src/dataflow/components/tools/dataflow-tool.tsx
@@ -28,7 +28,7 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IState>
     const { readOnly } = this.props;
     const editableClass = readOnly ? "read-only" : "editable";
     const classes = `dataflow-tool disable-tile-content-drag ${editableClass}`;
-    const { program, programRunTime, programZoom } = this.getContent();
+    const { program, programRunId, programStartTime, programEndTime, programRunTime, programZoom } = this.getContent();
     return (
       <div className={classes}>
         <SizeMe monitorHeight={true}>
@@ -38,6 +38,13 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IState>
                 readOnly={readOnly}
                 program={program}
                 onProgramChange={this.handleProgramChange}
+                onSetProgramRunId={this.handleSetProgramRunId}
+                programId={programRunId}
+                onSetProgramStartTime={this.handleSetProgramStartTime}
+                programStartTime={programStartTime}
+                onSetProgramEndTime={this.handleSetProgramEndTime}
+                programEndTime={programEndTime}
+                onSetProgramStartEndTime={this.handleSetProgramStartEndTime}
                 programRunTime={programRunTime}
                 onProgramRunTimeChange={this.handleProgramRunTimeChange}
                 programZoom={programZoom}
@@ -53,6 +60,22 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IState>
 
   private handleProgramChange = (program: any) => {
     this.getContent().setProgram(program);
+  }
+
+  private handleSetProgramRunId = (id: string) => {
+    this.getContent().setProgramRunId(id);
+  }
+
+  private handleSetProgramStartTime = (time: number) => {
+    this.getContent().setProgramStartTime(time);
+  }
+
+  private handleSetProgramEndTime = (time: number) => {
+    this.getContent().setProgramEndTime(time);
+  }
+
+  private handleSetProgramStartEndTime = (startTime: number, endTime: number) => {
+    this.getContent().setProgramStartEndTime(startTime, endTime);
   }
 
   private handleProgramRunTimeChange = (program: any) => {

--- a/src/dataflow/models/tools/dataflow/dataflow-content.ts
+++ b/src/dataflow/models/tools/dataflow/dataflow-content.ts
@@ -22,6 +22,9 @@ export const DataflowContentModel = types
   .model("DataflowTool", {
     type: types.optional(types.literal(kDataflowToolID), kDataflowToolID),
     program: "",
+    programRunId: "",
+    programStartTime: 0,
+    programEndTime: 0,
     programRunTime: DEFAULT_PROGRAM_TIME,
     programZoom: types.optional(ProgramZoom, DEFAULT_PROGRAM_ZOOM),
   })
@@ -37,6 +40,19 @@ export const DataflowContentModel = types
     },
     setProgramRunTime(runTime: number) {
       self.programRunTime = runTime;
+    },
+    setProgramRunId(id: string) {
+      self.programRunId = id;
+    },
+    setProgramStartEndTime(startTime: number, endTime: number) {
+      self.programStartTime = startTime;
+      self.programEndTime = endTime;
+    },
+    setProgramStartTime(startTime: number) {
+      self.programStartTime = startTime;
+    },
+    setProgramEndTime(endTime: number) {
+      self.programEndTime = endTime;
     },
     setProgramZoom(dx: number, dy: number, scale: number) {
       self.programZoom.dx = dx;


### PR DESCRIPTION
Modify the `DataflowContentModel` so that a program tile stores the following information about the currently running program: programId, programStartTime, programEndTime.  This is needed to set the program tile state (is a program running?) and to determine if we should show dataset data (does this program have a live or archived dataset?).  At present these values are being set on the tile within the document when the run button is pressed.  In the future, we will need to set these values in a newly created program document (that work is not completed yet).  However, to facilitate displaying dataset data, we will set these values for the current tile on the open document.

I also added some minor changes to set the UI state when running the program.  Left toolbar buttons are disabled and a program cover prevents interaction with nodes and shows a stop button (removed from the topbar).