### PR TITLE
167638035 num input fixes

### DIFF
--- a/src/dataflow/components/nodes/controls/num-control.tsx
+++ b/src/dataflow/components/nodes/controls/num-control.tsx
@@ -26,6 +26,12 @@ export class NumControl extends Rete.Control {
     const handleBlur = (onBlur: any) => {
       return (e: any) => { onBlur(e.target.value); };
     };
+    const handleKeyPress = (e: any) => {
+      if (e.key === "Enter") {
+        e.currentTarget.blur();
+      }
+    };
+
     this.component = (compProps: { readonly: any,
                                    value: any;
                                    inputValue: any;
@@ -44,6 +50,7 @@ export class NumControl extends Rete.Control {
             ref={inputRef}
             type={"text"}
             value={compProps.inputValue}
+            onKeyPress={handleKeyPress}
             onChange={handleChange(compProps.onChange)}
             onBlur={handleBlur(compProps.onBlur)} />
         </div>


### PR DESCRIPTION
Minor changes to allow editing of numeric input fields on Rete nodes to be more user-friendly.  Rete examples used `onChange` event to validate input values which made it difficult to use delete or backspace keys, input negative values, etc.  Change to using `onBlur` for validation so user can enter text as they please and then validate input for invalid text when typing is complete and user exits input control.  Also need to maintain the current node value while the user is editing (since a heartbeat program update could request the value).  To do this we keep a node `value` and a node `inputValue`.