### PR TITLE
Set proper read-only state of program editor tile

### DIFF
--- a/src/dataflow/components/dataflow-program-cover.sass
+++ b/src/dataflow/components/dataflow-program-cover.sass
@@ -4,11 +4,13 @@
   position: absolute
   width: calc(50% - 45px)
   height: 100%
-  background-color: rgba(0, 0, 0, 0.25)
+  background-color: rgba(0, 0, 0, 0)
   display: flex
   align-items: center
   justify-content: center
   top: 40px
+  &.full
+    width: 100%
 
   .stop
     width: 150px

--- a/src/dataflow/components/dataflow-program-cover.tsx
+++ b/src/dataflow/components/dataflow-program-cover.tsx
@@ -4,14 +4,18 @@ import "./dataflow-program-cover.sass";
 
 interface CoverProps {
   onStopProgramClick: () => void;
+  runningProgram: boolean;
 }
 
 export const DataflowProgramCover = (props: CoverProps) => {
+  const coverClass = props.runningProgram ? "cover" : "cover full";
   return (
-    <div className="cover">
-      <button className="stop" onClick={props.onStopProgramClick}>
-        Stop
-      </button>
+    <div className={coverClass}>
+      { props.runningProgram &&
+        <button className="stop" onClick={props.onStopProgramClick}>
+          Stop
+        </button>
+      }
     </div>
   );
 };

--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -101,32 +101,26 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
             readOnly={this.props.readOnly || false}
         />
         <div className="toolbar-editor-container">
-          { !this.props.readOnly ?
-            <DataflowProgramToolbar
-              onNodeCreateClick={this.addNode}
-              onDeleteClick={this.deleteSelectedNodes}
-              isDataStorageDisabled={this.state.disableDataStorage}
-              disabled={this.state.isProgramRunning}
-            />
-            : null
-          }
+          <DataflowProgramToolbar
+            onNodeCreateClick={this.addNode}
+            onDeleteClick={this.deleteSelectedNodes}
+            isDataStorageDisabled={this.state.disableDataStorage}
+            disabled={this.props.readOnly || this.state.isProgramRunning}
+          />
           <div className="editor-graph-container">
             <div
               className={this.state.showGraph ? "editor half" : "editor full"}
               ref={(elt) => this.editorDomElement = elt}
             >
               <div className="flow-tool" ref={elt => this.toolDiv = elt} />
-              { this.state.isProgramRunning ?
+              { (this.state.isProgramRunning || this.props.readOnly) &&
                 <DataflowProgramCover
                   onStopProgramClick={this.stopProgram}
+                  runningProgram={this.state.isProgramRunning && !this.props.readOnly}
                 />
-                : null
               }
             </div>
-            { this.state.showGraph
-              ? <DataflowProgramGraph dataSet={this.state.graphDataSet}/>
-              : null
-            }
+            {this.state.showGraph && <DataflowProgramGraph dataSet={this.state.graphDataSet}/>}
           </div>
         </div>
       </div>

--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -120,12 +120,14 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
                 <DataflowProgramZoom
                   onZoomInClick={this.zoomIn}
                   onZoomOutClick={this.zoomOut}
-                  disabled={this.props.readOnly}
+                  disabled={this.props.readOnly || this.state.isProgramRunning}
                 />
-                <DataflowProgramCover
-                  onStopProgramClick={this.stopProgram}
-                  runningProgram={this.state.isProgramRunning && !this.props.readOnly}
-                />
+                { (this.state.isProgramRunning || this.props.readOnly) &&
+                  <DataflowProgramCover
+                    onStopProgramClick={this.stopProgram}
+                    runningProgram={this.state.isProgramRunning && !this.props.readOnly}
+                  />
+                }
               }
             </div>
             {this.state.showGraph && <DataflowProgramGraph dataSet={this.state.graphDataSet}/>}


### PR DESCRIPTION
Changes to program editor read-only tile state:
- topbar and toolbar are always shown
- if program is read-only or program is running topbar and toolbar are disabled
- if program is running or tile is read-only, transparent cover is placed over editor to prevent mouse interaction
- if program is running and tile is not read-only, stop button is shown

We will eventually need to handle 1 additional case.  We will need to disable the editor for both the case where a document contains a reference to a running program AND when it contains a reference to a previously run program.  We will need to bring in the personal document changes first and actually spawn new document when user runs program before making those changes.