### PR TITLE
Save and restore plot state when loading a program

### DIFF
--- a/src/dataflow/components/nodes/controls/plot-control.tsx
+++ b/src/dataflow/components/nodes/controls/plot-control.tsx
@@ -132,8 +132,11 @@ export class PlotControl extends Rete.Control {
       return options;
     };
 
+    const initial = node.data[key] || false;
+    node.data[key] = initial;
+
     this.props = {
-      showgraph: false,
+      showgraph: initial,
       onGraphButtonClick: () => {
         this.setGraph();
         // needed to force connections to update
@@ -144,6 +147,7 @@ export class PlotControl extends Rete.Control {
 
   public setGraph = () => {
     this.props.showgraph = !this.props.showgraph;
+    this.putData(this.key, this.props.showgraph);
     (this as any).update();
   }
 


### PR DESCRIPTION
Save and restore the state of the plot control (shown or hidden) on each node when the program is loaded.  It became apparent while working on document spawning that we were not restoring the plot state.  This resulted in cases where a user had plots showing, ran a program (which spawned and loaded a new document), and then the plots were hidden AND the editor was locked so a user could not show the plots.