### PR TITLE
Create new document when user runs a program

### DIFF
--- a/src/components/thumbnail/my-work.tsx
+++ b/src/components/thumbnail/my-work.tsx
@@ -92,7 +92,7 @@ export class MyWorkComponent extends BaseComponent<IProps, IState> {
               <ThumbnailDocumentItem
                 key={document.key} dataTestName="my-work-list-items"
                 canvasContext="my-work" document={document} scale={this.props.scale}
-                captionText={`Untitled-${index + 1}`}
+                captionText={document.title || `Untitled-${index + 1}`}
                 onDocumentClick={this.handleDocumentClick} onDocumentDragStart={this.handleDocumentDragStart} />
             );
           })}

--- a/src/dataflow/components/dataflow-program-cover.sass
+++ b/src/dataflow/components/dataflow-program-cover.sass
@@ -4,7 +4,7 @@
   position: absolute
   width: calc(50% - 45px)
   height: 100%
-  background-color: rgba(0, 0, 0, 0)
+  background-color: rgba(255, 255, 255, .5)
   display: flex
   align-items: center
   justify-content: center

--- a/src/dataflow/components/dataflow-program-cover.tsx
+++ b/src/dataflow/components/dataflow-program-cover.tsx
@@ -5,10 +5,11 @@ import "./dataflow-program-cover.sass";
 interface CoverProps {
   onStopProgramClick: () => void;
   runningProgram: boolean;
+  sideBySide: boolean;
 }
 
 export const DataflowProgramCover = (props: CoverProps) => {
-  const coverClass = props.runningProgram ? "cover" : "cover full";
+  const coverClass = props.sideBySide ? "cover" : "cover full";
   return (
     <div className={coverClass}>
       { props.runningProgram &&

--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -284,9 +284,8 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
 
       this.intervalHandle = setInterval(this.heartBeat, HEARTBEAT_INTERVAL);
 
-      const programRunState: ProgramRunStates = this.getRunState();
-      if (programRunState !== ProgramRunStates.Ready) {
-        this.setState({programRunState, showGraph: true});
+      if (this.getRunState() !== ProgramRunStates.Ready) {
+        this.setState({programRunState: this.getRunState(), showGraph: true});
         this.updateGraphDataSet();
         this.sequenceNames = this.getNodeSequenceNames();
       }
@@ -488,7 +487,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
 
   private updateNodeSensorValue = (n: Node) => {
     const sensorSelect = n.controls.get("sensorSelect") as SensorSelectControl;
-    if (sensorSelect && (!this.isComplete())) {
+    if (sensorSelect && !this.isComplete()) {
       const chInfo = this.channels.find(ci => ci.channelId === n.data.sensor);
       if (chInfo && chInfo.value) {
         sensorSelect.setSensorValue(chInfo.value);

--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -43,11 +43,13 @@ type NodeValue = number | NodeValueMap;
 interface NodeSequenceNameMap {
   [key: number]: string;
 }
+type ProgramRunStates = "ready" | "active" | "complete";
 
 interface IProps extends SizeMeProps {
   readOnly?: boolean;
   program?: string;
   onProgramChange: (program: any) => void;
+  onStartProgram: (title: string, id: string, startTime: number, endTime: number) => void;
   onSetProgramRunId: (id: string) => void;
   programRunId: string;
   onSetProgramStartTime: (time: number) => void;
@@ -63,7 +65,7 @@ interface IProps extends SizeMeProps {
 
 interface IState {
   disableDataStorage: boolean;
-  isProgramRunning: boolean;
+  programRunState: ProgramRunStates;
   graphDataSet: DataSet;
   showGraph: boolean;
   editorContainerWidth: number;
@@ -91,7 +93,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
     super(props);
     this.state = {
       disableDataStorage: false,
-      isProgramRunning: false,
+      programRunState: "ready",
       graphDataSet: { sequences: [] },
       showGraph: false,
       editorContainerWidth: 0
@@ -106,15 +108,15 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
             onProgramTimeSelectClick={this.setProgramRunTime}
             programRunTimes={ProgramRunTimes}
             programDefaultRunTime={this.props.programRunTime || DEFAULT_PROGRAM_TIME}
-            isRunEnabled={!this.state.isProgramRunning}
-            readOnly={this.props.readOnly || false}
+            isRunEnabled={this.state.programRunState === "ready"}
+            readOnly={this.props.readOnly || this.state.programRunState !== "ready"}
         />
         <div className="toolbar-editor-container">
           <DataflowProgramToolbar
             onNodeCreateClick={this.addNode}
             onDeleteClick={this.deleteSelectedNodes}
             isDataStorageDisabled={this.state.disableDataStorage}
-            disabled={this.props.readOnly || this.state.isProgramRunning}
+            disabled={this.props.readOnly || this.state.programRunState !== "ready"}
           />
           <div className="editor-graph-container">
             <div
@@ -125,15 +127,15 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
                 <DataflowProgramZoom
                   onZoomInClick={this.zoomIn}
                   onZoomOutClick={this.zoomOut}
-                  disabled={this.props.readOnly || this.state.isProgramRunning}
+                  disabled={this.props.readOnly || this.state.programRunState !== "ready"}
                 />
-                { (this.state.isProgramRunning || this.props.readOnly) &&
+                { (this.state.programRunState !== "ready" || this.props.readOnly) &&
                   <DataflowProgramCover
                     onStopProgramClick={this.stopProgram}
-                    runningProgram={this.state.isProgramRunning && !this.props.readOnly}
+                    runningProgram={this.state.programRunState === "active" && !this.props.readOnly}
+                    sideBySide={this.state.programRunState !== "ready"}
                   />
                 }
-              }
             </div>
             {this.state.showGraph && <DataflowProgramGraph dataSet={this.state.graphDataSet}/>}
           </div>
@@ -277,36 +279,43 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
 
       this.intervalHandle = setInterval(this.heartBeat, HEARTBEAT_INTERVAL);
 
-      const isProgramRunning = this.isProgramRunning();
-      if (isProgramRunning) {
-        this.setState({isProgramRunning: true, showGraph: true});
+      const programRunState: ProgramRunStates = this.programRunState();
+      if (programRunState !== "ready") {
+        this.setState({programRunState, showGraph: true});
+        this.updateGraphDataSet();
         this.sequenceNames = this.getNodeSequenceNames();
       }
+
     })();
   }
 
-  private isProgramRunning = () => {
-    return (Boolean(this.props.programRunId) && this.props.programEndTime > Date.now());
+  private programRunState = () => {
+    if (this.props.programRunId) {
+      return (this.props.programEndTime > Date.now() ? "active" : "complete");
+    } else {
+      return "ready";
+    }
   }
 
   private runProgram = () => {
     const programData: any = this.generateProgramData();
     uploadProgram(programData);
-    this.setState({isProgramRunning: true, showGraph: true});
     this.sequenceNames = this.getNodeSequenceNames();
   }
   private stopProgram = () => {
     deleteProgram(this.props.programEndTime);
     const programEndTime = Date.now();
     this.props.onSetProgramEndTime(programEndTime);
-    this.setState({isProgramRunning: false, showGraph: false});
+    this.setState({programRunState: "complete"});
   }
   private setProgramRunTime = (time: number) => {
     this.props.onProgramRunTimeChange(time);
   }
   private generateProgramData = () => {
-    const programName = "dataflow-program-" + Date.now();
+    const dateTimeSuffix = Date.now();
+    const programName = "dataflow-program-" + dateTimeSuffix;
     let interval: number =  1;
+    let datasetName = "";
     const programStartTime = Date.now();
     const programEndTime = programStartTime + (1000 * this.props.programRunTime);
 
@@ -334,6 +343,8 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
         }
       } else if (n.name === "Data Storage") {
         interval = n.data.interval as number;
+        datasetName = n.data.datasetName as string;
+        datasetName += "-" + dateTimeSuffix;
       }
     });
     const rawProgram = this.programEditor.toJSON();
@@ -364,8 +375,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
       }
     };
 
-    this.props.onSetProgramRunId(programName);
-    this.props.onSetProgramStartEndTime(programStartTime, programEndTime);
+    this.props.onStartProgram(datasetName, programName, programStartTime, programEndTime);
 
     return programData;
   }
@@ -433,7 +443,9 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
         this.updateNodeRecentValues(n);
       }
     });
-    this.updateGraphDataSet();
+    if (this.state.programRunState === "active" && this.props.programRunId) {
+      this.updateGraphDataSet();
+    }
     if (processNeeded) {
         // if we've updated values on 1 or more nodes (such as a generator),
         // we need to abort any current processing and reprocess all
@@ -461,7 +473,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
 
   private updateNodeSensorValue = (n: Node) => {
     const sensorSelect = n.controls.get("sensorSelect") as SensorSelectControl;
-    if (sensorSelect) {
+    if (sensorSelect && (this.state.programRunState !== "complete")) {
       const chInfo = this.channels.find(ci => ci.channelId === n.data.sensor);
       if (chInfo && chInfo.value) {
         sensorSelect.setSensorValue(chInfo.value);
@@ -514,28 +526,26 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
   }
 
   private updateGraphDataSet = () => {
-    if (this.state.isProgramRunning && this.props.programRunId) {
-      fetchProgramData(this.props.programRunId).then((result: any) => {
-        // make a new dataset
-        const graphDataSet: DataSet = { sequences: [] };
-        if (result.data) {
-          result.data.forEach((timeData: any) => {
-            timeData.values.forEach((value: any, i: number) => {
-              if (graphDataSet.sequences.length < (i + 1)) {
-                const name = this.sequenceNames[timeData.blockIds[i]];
-                const graphSequence: DataSequence = { name: name || timeData.blockIds[i], units: "my-units", data: []};
-                graphDataSet.sequences.push(graphSequence);
-              }
-              const pt: DataPoint = { x: 0, y: 0 };
-              pt.x = timeData.time;
-              pt.y = value;
-              graphDataSet.sequences[i].data.push(pt);
-            });
+    fetchProgramData(this.props.programRunId).then((result: any) => {
+      // make a new dataset
+      const graphDataSet: DataSet = { sequences: [] };
+      if (result.data) {
+        result.data.forEach((timeData: any) => {
+          timeData.values.forEach((value: any, i: number) => {
+            if (graphDataSet.sequences.length < (i + 1)) {
+              const name = this.sequenceNames[timeData.blockIds[i]];
+              const graphSequence: DataSequence = { name: name || timeData.blockIds[i], units: "my-units", data: []};
+              graphDataSet.sequences.push(graphSequence);
+            }
+            const pt: DataPoint = { x: 0, y: 0 };
+            pt.x = timeData.time;
+            pt.y = value;
+            graphDataSet.sequences[i].data.push(pt);
           });
-          this.setState ({ graphDataSet });
-        }
-      });
-    }
+        });
+        this.setState ({ graphDataSet });
+      }
+    });
   }
 
   private updateGeneratorNode = (n: Node) => {
@@ -557,9 +567,9 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
   }
 
   private updateRunState = () => {
-    if (this.state.isProgramRunning) {
+    if (this.state.programRunState === "active") {
       if (Date.now() >= this.props.programEndTime) {
-        this.setState({isProgramRunning: false, showGraph: false});
+        this.setState({programRunState: "complete"});
       }
     }
   }

--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -312,11 +312,10 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
     this.props.onProgramRunTimeChange(time);
   }
   private generateProgramData = () => {
-    const dateTimeSuffix = Date.now();
-    const programName = "dataflow-program-" + dateTimeSuffix;
     let interval: number =  1;
     let datasetName = "";
     const programStartTime = Date.now();
+    const programName = "dataflow-program-" + programStartTime;
     const programEndTime = programStartTime + (1000 * this.props.programRunTime);
 
     const hubs: string[] = [];
@@ -344,7 +343,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
       } else if (n.name === "Data Storage") {
         interval = n.data.interval as number;
         datasetName = n.data.datasetName as string;
-        datasetName += "-" + dateTimeSuffix;
+        datasetName += "-" + programStartTime;
       }
     });
     const rawProgram = this.programEditor.toJSON();

--- a/src/dataflow/components/nodes/controls/sensor-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/sensor-select-control.tsx
@@ -89,7 +89,11 @@ export class SensorSelectControl extends Rete.Control {
           value={id}
           onChange={handleChange(onSensorChange)}
         >
-          <option value="none" className="sensor-option">none</option>
+          <option value="none" className="sensor-option" disabled={true} hidden={true}>Choose sensor</option>
+          {
+            (id !== "none" && !channels.find((ch: any) => ch.channelId === id)) &&
+            <option value={id} className="sensor-option" disabled={true} hidden={true}>{"Searching for " + id}</option>
+          }
           {channels ? channels.filter((ch: NodeChannelInfo) => (
             ch.type === type
           ))
@@ -171,14 +175,6 @@ export class SensorSelectControl extends Rete.Control {
 
   public setChannels = (channels: NodeChannelInfo[]) => {
     this.props.channels = channels;
-    if (this.node.data.sensor && this.node.data.sensor !== "none") {
-      if (!channels.find(ch => ch.channelId === this.node.data.sensor)) {
-        this.props.value = 0;
-        this.putData("nodeValue", 0);
-        this.props.sensor = "none";
-        this.putData("sensor", "none");
-      }
-    }
     // problem, if called with event nodecreate, update doesn't exist
     // (this as any).update();
   }

--- a/src/dataflow/components/tools/dataflow-tool.tsx
+++ b/src/dataflow/components/tools/dataflow-tool.tsx
@@ -74,8 +74,8 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IState>
         const programRunDocument = DocumentModel.create(primaryDocumentSnapshot);
         // find the program tile (should only be 1) and apply the program run info
         programRunDocument.content.tileMap.forEach(tile => {
-          const programContent = tile.content as DataflowContentModelType;
-          if (programContent.program) {
+          if (tile.content.type === "Dataflow") {
+            const programContent = tile.content as DataflowContentModelType;
             programContent.setProgramRunId(id);
             programContent.setProgramStartEndTime(startTime, endTime);
           }

--- a/src/dataflow/components/tools/dataflow-tool.tsx
+++ b/src/dataflow/components/tools/dataflow-tool.tsx
@@ -1,11 +1,13 @@
 import * as React from "react";
 import { observer, inject } from "mobx-react";
+import { getSnapshot } from "mobx-state-tree";
 import { BaseComponent } from "../../../components/base";
 import { ToolTileModelType } from "../../../models/tools/tool-tile";
 import { DataflowContentModelType } from "../../models/tools/dataflow/dataflow-content";
 import { DataflowProgram } from "../dataflow-program";
+import { cloneDeep } from "lodash";
 import { SizeMe, SizeMeProps } from "react-sizeme";
-
+import { DocumentModel } from "../../../models/document/document";
 import "./dataflow-tool.sass";
 
 interface IProps {
@@ -38,6 +40,7 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IState>
                 readOnly={readOnly}
                 program={program}
                 onProgramChange={this.handleProgramChange}
+                onStartProgram={this.handleStartProgram}
                 onSetProgramRunId={this.handleSetProgramRunId}
                 programRunId={programRunId}
                 onSetProgramStartTime={this.handleSetProgramStartTime}
@@ -56,6 +59,35 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IState>
         </SizeMe>
       </div>
     );
+  }
+
+  private handleStartProgram = async (title: string, id: string, startTime: number, endTime: number) => {
+    const {documents, db, ui} = this.stores;
+    const {problemWorkspace} = ui;
+    // get the currently loaded document, we're going to spawn a new document based on it
+    if (problemWorkspace.primaryDocumentKey) {
+      const primaryDocument = documents.getDocument(problemWorkspace.primaryDocumentKey);
+      if (primaryDocument) {
+        // get snapshot of DocumentModel
+        const primaryDocumentSnapshot = cloneDeep(getSnapshot(primaryDocument));
+        // make a new DocumentModel from the snapshot
+        const programRunDocument = DocumentModel.create(primaryDocumentSnapshot);
+        // find the program tile (should only be 1) and apply the program run info
+        programRunDocument.content.tileMap.forEach(tile => {
+          const programContent = tile.content as DataflowContentModelType;
+          if (programContent.program) {
+            programContent.setProgramRunId(id);
+            programContent.setProgramStartEndTime(startTime, endTime);
+          }
+        });
+        // create and load the new document
+        const newPersonalDocument = await db.createPersonalDocument(title || id, programRunDocument);
+        if (newPersonalDocument) {
+          problemWorkspace.setAvailableDocument(newPersonalDocument);
+          ui.contractAll();
+        }
+      }
+    }
   }
 
   private handleProgramChange = (program: any) => {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -336,12 +336,13 @@ export class DB {
     });
   }
 
-  public createPersonalDocument(title?: string) {
+  public createPersonalDocument(title?: string, documentModel?: DocumentModelType) {
     const {documents, user} = this.stores;
     const docTitle = title || documents.getNextPersonalDocumentTitle();
+    const content = documentModel && documentModel.content.publish();
 
     return new Promise<DocumentModelType>((resolve, reject) => {
-      return this.createDocument({ type: PersonalDocument })
+      return this.createDocument({ type: PersonalDocument, content })
         .then(({document, metadata}) => {
           const {documentKey} = document.self;
           const personalDoc: DBPersonalDocument = {


### PR DESCRIPTION
This pull request spawns a new document when a user starts a program. The new document is a copy of the currently open document with additional properties set in the Dataflow program tile to specify a program run id, start time, and end time.  This allows us to have a document with an editable program tile and a document with a read-only program tiles that can display saved data (the "dataset" which we will evenutally need to filter out and put into its own document category).  