### PR TITLE
[#168230323] Display publish button on the right side for other documents

### DIFF
--- a/src/components/document/document.tsx
+++ b/src/components/document/document.tsx
@@ -168,6 +168,11 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
     const {document} = this.props;
     return (
       <div className="other-doc titlebar">
+        {
+          document.type === "learningLogPublication"
+          ? <div className="title" data-test="learning-log-title">Learning Log: {document.title}</div>
+          : <div className="title" data-test="personal-doc-title">{document.title}</div>
+        }
         <div className="actions">
           {!hideButtons &&
             <div className="actions">
@@ -175,11 +180,6 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
             </div>
           }
         </div>
-        {
-          document.type === "learningLogPublication"
-          ? <div className="title" data-test="learning-log-title">Learning Log: {document.title}</div>
-          : <div className="title" data-test="personal-doc-title">{document.title}</div>
-        }
       </div>
     );
   }


### PR DESCRIPTION
When I refactored and consolidated `renderLearningLogTitleBar()` and `renderPersonalDocumentTitleBar()` to `renderOtherDocumentTitleBar()` in #386 I brought back the publishing button on the left hand side instead of the right hand side. This should fix it so it's back on the right hand side. At the moment in the UI the publishing button for `Learning Log` is being blocked by the right nav but it is working. This is fixed in #393 when Learning Log is moved to the main canvas and right nav.