### PR TITLE
168198961 dataset graph updates

### DIFF
--- a/src/dataflow/components/dataflow-program-cover.sass
+++ b/src/dataflow/components/dataflow-program-cover.sass
@@ -2,14 +2,13 @@
 
 .cover
   position: absolute
-  width: calc(50% - 45px)
+  width: calc(50% - 42px)
   height: 100%
   background-color: rgba(255, 255, 255, .5)
   display: flex
   align-items: center
   justify-content: center
   top: 40px
-  left: 87px
   &.full
     width: 100%
 

--- a/src/dataflow/components/dataflow-program-cover.sass
+++ b/src/dataflow/components/dataflow-program-cover.sass
@@ -9,6 +9,7 @@
   align-items: center
   justify-content: center
   top: 40px
+  left: 87px
   &.full
     width: 100%
 

--- a/src/dataflow/components/dataflow-program-cover.tsx
+++ b/src/dataflow/components/dataflow-program-cover.tsx
@@ -7,7 +7,7 @@ interface CoverProps {
 }
 
 export const DataflowProgramCover = (props: CoverProps) => {
-  const coverClass = props.sideBySide ? "cover" : "cover full";
+  const coverClass = `cover ${(!props.sideBySide && "full")}`;
   return (
     <div className={coverClass}/>
   );

--- a/src/dataflow/components/dataflow-program-graph.sass
+++ b/src/dataflow/components/dataflow-program-graph.sass
@@ -1,10 +1,10 @@
-@import ../../components/vars
+@import ./vars
 
 .program-graph
   height: 100%
   width: 50%
   padding: 5px 5px 25px 5px
-  border: 2px solid $color7
+  border: 2px solid $data-storage-orange
   &.full
     width: 100%
 
@@ -26,15 +26,29 @@
     width: 100%
 
   .graph-button
+    font-family: 'Ubuntu', sans-serif
     position: absolute
-    bottom: 4px
+    bottom: 6px
     width: 60px
+    background-color: $data-storage-orange
+    color: white
+    font-size: 12px
+    font-style: normal
+    height: 24px
+    border: 0
+    outline: 0
+    border-radius: 3px
     &.program
-      right: 4px
+      right: 5px
     &.type
-      right: 69px
+      right: 70px
     &.layout
-      right: 134px
+      width: 70px
+      right: 135px
     &.data
-      right: 199px
+      right: 210px
       width: 90px
+    &:hover
+      background-color: $data-storage-orange-node
+    &:active
+      background-color: $data-storage-orange-control

--- a/src/dataflow/components/dataflow-program-graph.sass
+++ b/src/dataflow/components/dataflow-program-graph.sass
@@ -5,6 +5,8 @@
   width: 50%
   padding: 5px 5px 25px 5px
   border: 2px solid $color7
+  &.full
+    width: 100%
 
   .stacked-graph-container
     display: flex
@@ -27,7 +29,12 @@
     position: absolute
     bottom: 4px
     width: 60px
-    &.layout
-      right: 69px
-    &.type
+    &.program
       right: 4px
+    &.type
+      right: 69px
+    &.layout
+      right: 134px
+    &.data
+      right: 199px
+      width: 90px

--- a/src/dataflow/components/dataflow-program-graph.tsx
+++ b/src/dataflow/components/dataflow-program-graph.tsx
@@ -65,16 +65,16 @@ export class DataflowProgramGraph extends React.Component<IProps, IState> {
           : this.renderOverlappedGraphs()
         }
         <button className="graph-button program" onClick={this.handleShowProgramClick}>
-          { this.props.programVisible ? "graph" : "program" }
+          { this.props.programVisible ? "Graph" : "Program" }
         </button>
         <button className="graph-button type" onClick={this.handleTypeClick}>
-          { this.state.scatter ? "line" : "scatter" }
+          { this.state.scatter ? "Line" : "Scatter" }
         </button>
         <button className="graph-button layout" onClick={this.handleLayoutClick}>
-          { this.state.stacked ? "overlap" : "stack" }
+          { this.state.stacked ? "Combined" : "Stacked" }
         </button>
         <button className="graph-button data" onClick={this.handleDataModeClick}>
-          { this.state.allData ? "current data" : "all data" }
+          { this.state.allData ? "Current Data" : "All Data" }
         </button>
       </div>
     );

--- a/src/dataflow/components/dataflow-program-graph.tsx
+++ b/src/dataflow/components/dataflow-program-graph.tsx
@@ -27,7 +27,7 @@ interface IProps {
 interface IState {
   stacked: boolean;
   scatter: boolean;
-  allData: boolean;
+  fullRun: boolean;
 }
 
 export class DataflowProgramGraph extends React.Component<IProps, IState> {
@@ -36,7 +36,7 @@ export class DataflowProgramGraph extends React.Component<IProps, IState> {
     this.state = {
       stacked: true,
       scatter: true,
-      allData: true,
+      fullRun: true,
     };
   }
 
@@ -49,8 +49,8 @@ export class DataflowProgramGraph extends React.Component<IProps, IState> {
     this.setState({scatter});
   }
   public handleDataModeClick = () => {
-    const allData = !this.state.allData;
-    this.setState({allData});
+    const fullRun = !this.state.fullRun;
+    this.setState({fullRun});
   }
   public handleShowProgramClick = () => {
     this.props.onToggleShowProgram();
@@ -74,7 +74,7 @@ export class DataflowProgramGraph extends React.Component<IProps, IState> {
           { this.state.stacked ? "Combined" : "Stacked" }
         </button>
         <button className="graph-button data" onClick={this.handleDataModeClick}>
-          { this.state.allData ? "Current Data" : "All Data" }
+          { this.state.fullRun ? "All Data" : "Full Run" }
         </button>
       </div>
     );
@@ -181,9 +181,13 @@ export class DataflowProgramGraph extends React.Component<IProps, IState> {
     const {dataSet} = this.props;
     let dataMin = 0;
     let dataMax = 0;
-    if (this.state.allData) {
+    if (this.state.fullRun) {
       dataMin = this.props.dataSet ? this.props.dataSet.startTime : 0;
       dataMax = this.props.dataSet ? this.props.dataSet.endTime : 0;
+      // final point might be greater than end time
+      if (dataSet.sequences.length) {
+        dataMax = Math.max(dataMax, dataSet.sequences[0].data[dataSet.sequences[0].data.length - 1].x);
+      }
     } else {
       if (dataSet.sequences.length) {
         dataMin = dataSet.sequences[0].data[0].x;

--- a/src/dataflow/components/dataflow-program.sass
+++ b/src/dataflow/components/dataflow-program.sass
@@ -37,3 +37,5 @@
   .full
     height: 100%
     width: 100%
+  .hidden
+    display: none

--- a/src/dataflow/utilities/node.ts
+++ b/src/dataflow/utilities/node.ts
@@ -229,8 +229,8 @@ export const roundNodeValue = (n: number) => {
   return Math.round(n * 1000) / 1000;
 };
 
-export const ChartPlotColors = ["#0592AF", "#ebb93e", "#eb813e", "#df4a4a", "#e4448c",
-                               "#d355c1", "#b05ecb", "#ffd56d", "#ffa56d", "#f57676",
+export const ChartPlotColors = ["#d51eff", "#17ddd7", "#d3d114", "#3974ff", "#ff3d3d",
+                               "#49d381", "#b05ecb", "#ffd56d", "#ffa56d", "#f57676",
                                "#fa73b0", "#eb80dc", "#cd88e4", "#d49600", "#d45200",
                                "#c60e0e", "#cc0860", "#b81da1", "#8d27ad", "#8b989f",
                                "#5dd581", "#3cc8f5", "#aeb9bf", "#92e3aa", "#7ad9f8",


### PR DESCRIPTION
This PR adds changes to how graphed data is displayed in the Dataflow program tile:
- allow user to toggle between a show-all and show-recent mode of the graph.  Show-all sets the min and max of the graph based on the program start and end time.  Show-recent sets the min and max based on the actual data points that we have currently acquired.
- show graph as type `time` with `linear` distribution so points are shown on the graph at their actual acquisition time based spacing in relation to one another
- allow user to toggle between mode where graph consumes the entire tile and a side-by-side mode where program and graph are shown together.  This feature is only available on documents containing a program run.
- revise state used to determine if we show program, graph, or both.  Add handling of case where there is no data storage block.
- improve handling of cases where program tile is in read-only mode
- add styling from UI mock-ups