### PR TITLE
Default document type and content can be configured in app-config.json

### DIFF
--- a/src/app-config.json
+++ b/src/app-config.json
@@ -5,6 +5,7 @@
     "s+s": "assets/curriculum/stretching-and-shrinking/stretching-and-shrinking.json"
   },
   "defaultUnit": "s+s",
+  "defaultDocumentType": "problem",
   "rightNavTabs": [
     {
       "tab": "my-work",

--- a/src/components/document/document-workspace.tsx
+++ b/src/components/document/document-workspace.tsx
@@ -43,11 +43,12 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps, {}> {
   }
 
   private async guaranteePrimaryDocument() {
-    const { appConfig: { defaultDocumentType }, db, ui: { problemWorkspace } } = this.stores;
+    const { appConfig: { defaultDocumentType, defaultDocumentContent },
+            db, ui: { problemWorkspace } } = this.stores;
     if (!problemWorkspace.primaryDocumentKey) {
-      const problemDocument = await db.guaranteeOpenDefaultDocument(defaultDocumentType);
-      if (problemDocument) {
-        problemWorkspace.setPrimaryDocument(problemDocument);
+      const defaultDocument = await db.guaranteeOpenDefaultDocument(defaultDocumentType, defaultDocumentContent);
+      if (defaultDocument) {
+        problemWorkspace.setPrimaryDocument(defaultDocument);
       }
     }
   }

--- a/src/components/document/document-workspace.tsx
+++ b/src/components/document/document-workspace.tsx
@@ -43,9 +43,9 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps, {}> {
   }
 
   private async guaranteePrimaryDocument() {
-    const { db, ui: { problemWorkspace } } = this.stores;
+    const { appConfig: { defaultDocumentType }, db, ui: { problemWorkspace } } = this.stores;
     if (!problemWorkspace.primaryDocumentKey) {
-      const problemDocument = await db.guaranteeOpenProblemDocument();
+      const problemDocument = await db.guaranteeOpenDefaultDocument(defaultDocumentType);
       if (problemDocument) {
         problemWorkspace.setPrimaryDocument(problemDocument);
       }

--- a/src/components/thumbnail/my-work.tsx
+++ b/src/components/thumbnail/my-work.tsx
@@ -50,10 +50,10 @@ export class MyWorkComponent extends BaseComponent<IProps, IState> {
   }
 
   private handleNewDocumentClick = async (sectionType: string, documentTypes: string[]) => {
-    const { db, ui } = this.stores;
+    const { appConfig: { defaultDocumentContent }, db, ui } = this.stores;
     const { problemWorkspace } = ui;
     const newDocument = sectionType === ENavTabSectionType.kPersonalDocuments
-                          ? await db.createPersonalDocument()
+                          ? await db.createPersonalDocument("", defaultDocumentContent)
                           : await db.createLearningLogDocument();
     if (newDocument) {
       problemWorkspace.setAvailableDocument(newDocument);

--- a/src/lib/db-types.ts
+++ b/src/lib/db-types.ts
@@ -225,6 +225,10 @@ export interface DBOfferingGroupUser {
   disconnectedTimestamp?: number;
 }
 
+export interface DBOtherDocumentMap {
+  [key: string]: DBOtherDocument;
+}
+
 export interface DBImage {
   version: "1.0";
   self: {

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -126,7 +126,7 @@ export class Firebase {
     return `${this.getUserPath(user)}/${dir}${key}`;
   }
 
-// Unpublished learning log
+  // Unpublished learning log
   public getLearningLogPath(user: UserModelType, documentKey?: string, userId?: string) {
     const suffix = documentKey ? `/${documentKey}` : "";
     return `${this.getUserPath(user, userId)}/learningLogs${suffix}`;

--- a/src/models/stores/app-config.ts
+++ b/src/models/stores/app-config.ts
@@ -8,6 +8,7 @@ export const AppConfigModel = types
     demoProblemTitle: "",
     units: types.map(types.string),
     defaultUnit: "",
+    defaultDocumentType: types.optional(types.enumeration(["problem", "personal"]), "personal"),
     rightNavTabs: types.array(RightNavTabModel),
     toolbar: types.array(ToolButtonModel)
   });

--- a/src/models/stores/app-config.ts
+++ b/src/models/stores/app-config.ts
@@ -1,4 +1,5 @@
 import { types, Instance, SnapshotIn } from "mobx-state-tree";
+import { DocumentContentModel } from "../document/document-content";
 import { ToolButtonModel } from "../tools/tool-types";
 import { RightNavTabModel } from "../view/right-nav";
 
@@ -9,6 +10,7 @@ export const AppConfigModel = types
     units: types.map(types.string),
     defaultUnit: "",
     defaultDocumentType: types.optional(types.enumeration(["problem", "personal"]), "personal"),
+    defaultDocumentContent: types.maybe(DocumentContentModel),
     rightNavTabs: types.array(RightNavTabModel),
     toolbar: types.array(ToolButtonModel)
   });

--- a/src/models/stores/documents.ts
+++ b/src/models/stores/documents.ts
@@ -40,6 +40,12 @@ export const DocumentsModel = types
       return `Untitled-${++maxUntitled}`;
     },
 
+    getPersonalDocument(userId: string) {
+      return self.all.find((document) => {
+        return (document.type === PersonalDocument) && (document.uid === userId);
+      });
+    },
+
     getProblemDocument(userId: string) {
       return self.all.find((document) => {
         return (document.type === ProblemDocument) && (document.uid === userId);


### PR DESCRIPTION
CLUE by default opens a problem-specific document on launch. In Dataflow, all user documents are non-problem-specific "Personal" documents, and so for Dataflow the application needs to open a Personal document by default. This PR allows this to be specified per application in the application configuration.

With the second commit we also allow the default document content to be specified so that, for instance, Dataflow can specify that a program tile and a text tile should be created by default.