### PR TITLE
Support document properties in metadata for personal/learning log documents

### DIFF
--- a/src/components/document/document-context.tsx
+++ b/src/components/document/document-context.tsx
@@ -1,0 +1,26 @@
+import * as React from "react";
+import { ISetProperties } from "../../models/document/document";
+
+export interface IDocumentContext {
+  getProperty: (key: string) => string | undefined;
+  setProperties: (properties: ISetProperties) => void;
+}
+
+export const DocumentContext = React.createContext<IDocumentContext | undefined>(undefined);
+
+/*
+ * Example of use
+ *
+import { DocumentContext } from "../../../components/document/document-context";
+
+export class GeometryContentComponent extends BaseComponent<{}, {}> {
+
+  public static contextType = DocumentContext;
+
+  public context!: React.ContextType<typeof DocumentContext>;
+
+  public componentDidUpdate() {
+    this.context && this.context.setProperties({ foo: "bar", baz: "roo" });
+  }
+}
+*/

--- a/src/lib/db-listeners/index.ts
+++ b/src/lib/db-listeners/index.ts
@@ -191,6 +191,7 @@ export class DBListeners {
     listener.modelDisposer = (onSnapshot(document, (newDocument) => {
       updateRef.update({
         title: newDocument.title,
+        properties: newDocument.properties
         // TODO: for future ordering story add original to model and update here
       });
     }));

--- a/src/lib/db-types.ts
+++ b/src/lib/db-types.ts
@@ -90,6 +90,10 @@ export interface DBDocument {
   type: DBDocumentType;
 }
 
+export interface IOtherDocumentProperties {
+  [key: string]: string;
+}
+
 // personal documents and learning logs
 export interface DBOtherDocument {
   version: "1.0";
@@ -99,6 +103,7 @@ export interface DBOtherDocument {
     documentKey: string;
   };
   title: string;
+  properties?: IOtherDocumentProperties;
 }
 
 // published section documents [deprecated] and problem documents
@@ -122,6 +127,7 @@ export interface DBOtherPublication {
     documentKey: string;
   };
   title: string;
+  properties: IOtherDocumentProperties;
   uid: string;
   originDoc: string;
 }

--- a/src/models/document/document.test.ts
+++ b/src/models/document/document.test.ts
@@ -26,6 +26,7 @@ describe("document model", () => {
       createdAt: 1,
       groupId: undefined,
       title: undefined,
+      properties: {},
       visibility: "public",
       groupUserConnections: {},
       comments: {},
@@ -37,6 +38,12 @@ describe("document model", () => {
       },
       changeCount: 0
     });
+  });
+
+  it("can set title", () => {
+    expect(document.title).toBeUndefined();
+    document.setTitle("FooTitle");
+    expect(document.title).toBe("FooTitle");
   });
 
   it("can set content", () => {
@@ -79,5 +86,14 @@ describe("document model", () => {
     expect(document.visibility).toBe("public");
     document.toggleVisibility("private");
     expect(document.visibility).toBe("private");
+  });
+
+  it("can set/get document properties", () => {
+    expect(document.getProperty("foo")).toBeUndefined();
+    document.setProperty("foo", "bar");
+    expect(document.getProperty("foo")).toBe("bar");
+    document.setProperties({ foo: undefined, bar: "baz" });
+    expect(document.getProperty("foo")).toBeUndefined();
+    expect(document.getProperty("bar")).toBe("baz");
   });
 });


### PR DESCRIPTION
This is required for Dataflow to be able to filter documents based on program state, e.g. running, completed, etc. A React context implementation is provided so that clients (e.g. the DataflowProgramComponent) can access the properties.