### PR TITLE
Show clear/reset buttons in Dataflow toolbar in Dev/QA modes

### DIFF
--- a/src/dataflow/components/dataflow-program-toolbar.tsx
+++ b/src/dataflow/components/dataflow-program-toolbar.tsx
@@ -1,26 +1,35 @@
 import * as React from "react";
+import { BaseComponent, IBaseProps } from "./dataflow-base";
 import { NodeTypes } from "../utilities/node";
+import { inject, observer } from "mobx-react";
 
 import "./dataflow-program-toolbar.sass";
 
 interface IProps {
   onNodeCreateClick: (type: string) => void;
+  onClearClick: () => void;
+  onResetClick: () => void;
   isDataStorageDisabled: boolean;
   disabled: boolean;
 }
 
-export class DataflowProgramToolbar extends React.Component<IProps, {}> {
+@inject("stores")
+@observer
+export class DataflowProgramToolbar extends BaseComponent<IProps, {}> {
   constructor(props: IProps) {
     super(props);
   }
 
   public render() {
+    const {appMode} = this.stores;
     return (
       <div className="program-toolbar" data-test="program-toolbar">
         { NodeTypes.map((nt: any, i: any) => (
             this.renderAddNodeButton(nt.name, i)
           ))
         }
+        { appMode === "qa" && <button onClick={this.props.onClearClick}>Clear</button> }
+        { appMode === "qa" && <button onClick={this.props.onResetClick}>Reset</button> }
       </div>
     );
   }

--- a/src/dataflow/components/dataflow-program-toolbar.tsx
+++ b/src/dataflow/components/dataflow-program-toolbar.tsx
@@ -1,7 +1,5 @@
 import * as React from "react";
-import { BaseComponent, IBaseProps } from "./dataflow-base";
 import { NodeTypes } from "../utilities/node";
-import { inject, observer } from "mobx-react";
 
 import "./dataflow-program-toolbar.sass";
 
@@ -9,27 +7,26 @@ interface IProps {
   onNodeCreateClick: (type: string) => void;
   onClearClick: () => void;
   onResetClick: () => void;
+  isTesting: boolean;
   isDataStorageDisabled: boolean;
   disabled: boolean;
 }
 
-@inject("stores")
-@observer
-export class DataflowProgramToolbar extends BaseComponent<IProps, {}> {
+export class DataflowProgramToolbar extends React.Component<IProps, {}> {
   constructor(props: IProps) {
     super(props);
   }
 
   public render() {
-    const {appMode} = this.stores;
+    const { isTesting } = this.props;
     return (
       <div className="program-toolbar" data-test="program-toolbar">
         { NodeTypes.map((nt: any, i: any) => (
             this.renderAddNodeButton(nt.name, i)
           ))
         }
-        { appMode === "qa" && <button onClick={this.props.onClearClick}>Clear</button> }
-        { appMode === "qa" && <button onClick={this.props.onResetClick}>Reset</button> }
+        { isTesting && <button onClick={this.props.onClearClick}>Clear</button> }
+        { isTesting && <button onClick={this.props.onResetClick}>Reset</button> }
       </div>
     );
   }

--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -128,6 +128,8 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
         <div className="toolbar-editor-container">
           { !this.isGraphOnly() && <DataflowProgramToolbar
             onNodeCreateClick={this.addNode}
+            onResetClick={this.resetNodes}
+            onClearClick={this.clearProgram}
             isDataStorageDisabled={this.state.disableDataStorage}
             disabled={this.props.readOnly || !this.isReady()}
           /> }

--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -113,6 +113,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
 
   public render() {
     const editorClass = `editor ${(this.isSideBySide() ? "half" : "full")} ${(this.isGraphOnly() && "hidden")}`;
+    const isTesting = ["qa", "test"].indexOf(this.stores.appMode) >= 0;
     return (
       <div className="dataflow-program-container">
         <DataflowProgramTopbar
@@ -130,6 +131,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
             onNodeCreateClick={this.addNode}
             onResetClick={this.resetNodes}
             onClearClick={this.clearProgram}
+            isTesting={isTesting}
             isDataStorageDisabled={this.state.disableDataStorage}
             disabled={this.props.readOnly || !this.isReady()}
           /> }


### PR DESCRIPTION
These buttons are useful for developers and essential for QA. This just extends @mklewandowski 's earlier work and rebases it to latest Dataflow code.