### PR TITLE
Set `programRunState` to `Running` in `runProgram()`

### DIFF
--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -375,6 +375,8 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
     const programData: any = this.generateProgramData();
     uploadProgram(programData);
     this.sequenceNames = this.getNodeSequenceNames();
+    this.setState({programRunState: ProgramRunStates.Running,
+                   programDisplayState: ProgramDisplayStates.Graph});
   }
   private stopProgram = () => {
     deleteProgram(this.props.programEndTime);
@@ -648,7 +650,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
 
   private updateRunState = () => {
     if (this.isRunning()) {
-      if (Date.now() >= this.props.programEndTime) {
+      if (this.props.programEndTime && (Date.now() >= this.props.programEndTime)) {
         this.setState({programRunState: ProgramRunStates.Complete});
       }
     }


### PR DESCRIPTION
Previously, the `programRunState` could only be set to `Running` in `initProgramEditor()` which is called from `componentDidMount()`. This relied on the fact that switching from a ProblemDocument to a PersonalDocument required a complete reload of the component. Now that we're (correctly) using a PersonalDocument for the editable document, the `DataflowProgram` component is no longer unmounted/remounted, and so we must handle the state change internally.