### PR TITLE
Update editor state when switching documents

### DIFF
--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -57,6 +57,7 @@ enum ProgramDisplayStates {
 }
 
 interface IProps extends SizeMeProps {
+  modelId: string;
   readOnly?: boolean;
   program?: string;
   onProgramChange: (program: any) => void;
@@ -178,7 +179,8 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
         this.programEditor.view.resize();
       }
 
-      if (this.props.programRunId !== prevProps.programRunId) {
+      if ((this.props.modelId !== prevProps.modelId) ||
+          (this.props.programRunId !== prevProps.programRunId)) {
         this.updateRunAndGraphStates();
       }
     }

--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -312,13 +312,12 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
 
   private updateRunAndGraphStates() {
     const programRunState: ProgramRunStates = this.getRunState();
-    if (programRunState !== ProgramRunStates.Ready) {
-      const hasDataStorage = this.getNodeCount("Data Storage") > 0;
-      const programDisplayState = hasDataStorage ? ProgramDisplayStates.Graph : ProgramDisplayStates.Program;
-      this.setState({ programRunState, programDisplayState });
-      this.updateGraphDataSet();
-      this.sequenceNames = this.getNodeSequenceNames();
-    }
+    const hasDataStorage = this.getNodeCount("Data Storage") > 0;
+    const programDisplayState = (programRunState !== ProgramRunStates.Ready) && hasDataStorage
+                                  ? ProgramDisplayStates.Graph : ProgramDisplayStates.Program;
+    this.setState({ programRunState, programDisplayState });
+    this.updateGraphDataSet();
+    this.sequenceNames = this.getNodeSequenceNames();
   }
 
   private getRunState = () => {

--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -615,28 +615,32 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
   }
 
   private updateGraphDataSet = () => {
-    fetchProgramData(this.props.programRunId).then((result: any) => {
-      // make a new dataset
-      const graphDataSet: DataSet = { sequences: [],
-                                      startTime: this.props.programStartTime,
-                                      endTime: this.props.programEndTime };
-      if (result.data) {
-        result.data.forEach((timeData: any) => {
-          timeData.values.forEach((value: any, i: number) => {
-            if (graphDataSet.sequences.length < (i + 1)) {
-              const name = this.sequenceNames[timeData.blockIds[i]];
-              const graphSequence: DataSequence = { name: name || timeData.blockIds[i], units: "my-units", data: [] };
-              graphDataSet.sequences.push(graphSequence);
-            }
-            const pt: DataPoint = { x: 0, y: 0 };
-            pt.x = timeData.time;
-            pt.y = value;
-            graphDataSet.sequences[i].data.push(pt);
+    if (this.props.programRunId) {
+      fetchProgramData(this.props.programRunId).then((result: any) => {
+        // make a new dataset
+        const graphDataSet: DataSet = {
+          sequences: [],
+          startTime: this.props.programStartTime,
+          endTime: this.props.programEndTime
+        };
+        if (result.data) {
+          result.data.forEach((timeData: any) => {
+            timeData.values.forEach((value: any, i: number) => {
+              if (graphDataSet.sequences.length < (i + 1)) {
+                const name = this.sequenceNames[timeData.blockIds[i]];
+                const graphSequence: DataSequence = { name: name || timeData.blockIds[i], units: "my-units", data: [] };
+                graphDataSet.sequences.push(graphSequence);
+              }
+              const pt: DataPoint = { x: 0, y: 0 };
+              pt.x = timeData.time;
+              pt.y = value;
+              graphDataSet.sequences[i].data.push(pt);
+            });
           });
-        });
-        this.setState ({ graphDataSet });
-      }
-    });
+          this.setState({ graphDataSet });
+        }
+      });
+    }
   }
 
   private updateGeneratorNode = (n: Node) => {

--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -177,6 +177,10 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
       } else if (this.props.size !== prevProps.size) {
         this.programEditor.view.resize();
       }
+
+      if (this.props.programRunId !== prevProps.programRunId) {
+        this.updateRunAndGraphStates();
+      }
     }
 
     if (!this.programEditor && this.toolDiv) {
@@ -295,20 +299,24 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
       this.programEditor.view.resize();
       this.programEditor.trigger("process");
 
-      const programRunState: ProgramRunStates = this.getRunState();
-      if (programRunState !== ProgramRunStates.Ready) {
-        const hasDataStorage = this.getNodeCount("Data Storage") > 0;
-        const programDisplayState = hasDataStorage ? ProgramDisplayStates.Graph : ProgramDisplayStates.Program;
-        this.setState({ programRunState, programDisplayState });
-        this.updateGraphDataSet();
-        this.sequenceNames = this.getNodeSequenceNames();
-      }
+      this.updateRunAndGraphStates();
 
       if (!this.props.readOnly && !this.isComplete()) {
         this.intervalHandle = setInterval(this.heartBeat, HEARTBEAT_INTERVAL);
       }
 
     })();
+  }
+
+  private updateRunAndGraphStates() {
+    const programRunState: ProgramRunStates = this.getRunState();
+    if (programRunState !== ProgramRunStates.Ready) {
+      const hasDataStorage = this.getNodeCount("Data Storage") > 0;
+      const programDisplayState = hasDataStorage ? ProgramDisplayStates.Graph : ProgramDisplayStates.Program;
+      this.setState({ programRunState, programDisplayState });
+      this.updateGraphDataSet();
+      this.sequenceNames = this.getNodeSequenceNames();
+    }
   }
 
   private getRunState = () => {

--- a/src/dataflow/components/tools/dataflow-tool.tsx
+++ b/src/dataflow/components/tools/dataflow-tool.tsx
@@ -28,7 +28,7 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IState>
   public state: IState = {};
 
   public render() {
-    const { readOnly } = this.props;
+    const { model, readOnly } = this.props;
     const editableClass = readOnly ? "read-only" : "editable";
     const classes = `dataflow-tool disable-tile-content-drag ${editableClass}`;
     const { program, programRunId, programStartTime, programEndTime, programRunTime, programZoom } = this.getContent();
@@ -38,6 +38,7 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IState>
           {({ size }: SizeMeProps) => {
             return (
               <DataflowProgram
+                modelId={model.id}
                 readOnly={readOnly}
                 program={program}
                 onProgramChange={this.handleProgramChange}


### PR DESCRIPTION
>Previously, the programRunState could only be set to Running in initProgramEditor() which is called from componentDidMount(). This relied on the fact that switching from a ProblemDocument to a PersonalDocument required a complete reload of the component. Now that we're (correctly) using a PersonalDocument for the editable document, the DataflowProgram component is no longer unmounted/remounted, and so we must handle the state change internally.

This PR handles switching documents for the same reason.