### PR TITLE
Ensure new documents have unique tile ids

### DIFF
--- a/src/dataflow/components/tools/dataflow-tool.tsx
+++ b/src/dataflow/components/tools/dataflow-tool.tsx
@@ -82,11 +82,12 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IState>
             programContent.setProgramStartEndTime(startTime, endTime);
           }
         });
+
         // create and load the new document
         const params: ICreateOtherDocumentParams = {
                 title: title || id,
                 properties: { dfRunId: id },
-                content: documentContent
+                content: JSON.parse(documentContent.publish())
               };
         const newPersonalDocument = await db.createPersonalDocument(params);
         if (newPersonalDocument) {


### PR DESCRIPTION
Call `publish` on document content before creating new program run document to ensure unique tile ids.  Should take care of some of the program state issues that we've been seeing.