### PR TITLE
Add cloneWithUniqueIds() function

### DIFF
--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -90,7 +90,7 @@ export const DocumentContentModel = types
           : self.rowOrder[self.rowOrder.length - 1];
         return  self.rowOrder.indexOf(lastVisibleRowId);
       },
-      publish() {
+      snapshotWithUniqueIds() {
         const snapshot = cloneDeep(getSnapshot(self));
         const idMap: { [id: string]: string } = {};
 
@@ -132,10 +132,15 @@ export const DocumentContentModel = types
 
         snapshot.rowOrder = snapshot.rowOrder.map(rowId => idMap[rowId]);
 
-        return JSON.stringify(snapshot);
+        return snapshot;
       }
     };
   })
+  .views(self => ({
+    publish() {
+      return JSON.stringify(self.snapshotWithUniqueIds());
+    }
+  }))
   .actions(self => ({
     afterCreate() {
       self.rowMap.forEach(row => {
@@ -436,3 +441,7 @@ function migrateSnapshot(snapshot: any): any {
 
 export type DocumentContentModelType = Instance<typeof DocumentContentModel>;
 export type DocumentContentSnapshotType = SnapshotIn<typeof DocumentContentModel>;
+
+export function cloneContentWithUniqueIds(content?: DocumentContentModelType) {
+  return content && DocumentContentModel.create(content.snapshotWithUniqueIds());
+}

--- a/src/models/stores/app-config-model.ts
+++ b/src/models/stores/app-config-model.ts
@@ -1,5 +1,6 @@
 import { types, Instance, SnapshotIn } from "mobx-state-tree";
-import { DocumentContentModel, DocumentContentModelType } from "../document/document-content";
+import { DocumentContentModel, DocumentContentModelType, cloneContentWithUniqueIds
+      } from "../document/document-content";
 import { ToolButtonModel } from "../tools/tool-types";
 import { RightNavTabModel } from "../view/right-nav";
 
@@ -20,10 +21,8 @@ export const AppConfigModel = types
     toolbar: types.array(ToolButtonModel)
   })
   .views(self => ({
-    get defaultDocumentContent(): DocumentContentModelType {
-      const template = self.defaultDocumentTemplate && self.defaultDocumentTemplate.publish();
-      const content = template && JSON.parse(template);
-      return DocumentContentModel.create(content);
+    get defaultDocumentContent(): DocumentContentModelType | undefined {
+      return cloneContentWithUniqueIds(self.defaultDocumentTemplate);
     }
   }));
 export type AppConfigModelType = Instance<typeof AppConfigModel>;


### PR DESCRIPTION
Some clients were callign `DocumentContent.publish()` for this purpose, but `publish()` JSON.stringifies its return value, which meant that clients were then having to parse the result. Now clients can call the more-appropriately-named `cloneWithUniqueIds()` function and avoid the cost of gratuitously JSON.stringify()/JSON.parse()-ing the result.