### PR TITLE
[#168011215] Copy Documents via Title Bar Icon 

### DIFF
--- a/src/assets/icons/copy/copy-active.svg
+++ b/src/assets/icons/copy/copy-active.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 26" preserveAspectRatio="xMidYMid meet"><path fill="#547935" d="M22,23h2a3,3,0,0,1-3,3H3a3,3,0,0,1-3-3V8A3,3,0,0,1,3,5H4v5H2V23a1,1,0,0,0,1,1H21A1,1,0,0,0,22,23ZM30,3V18a3,3,0,0,1-3,3H9a3,3,0,0,1-3-3V3A3,3,0,0,1,9,0H27A3,3,0,0,1,30,3ZM28,5H8V18a1,1,0,0,0,1,1H27a1,1,0,0,0,1-1ZM25,8H11v8H25V8m1-1V17H10V7Z"/></svg>

--- a/src/assets/icons/copy/copy-disabled.svg
+++ b/src/assets/icons/copy/copy-disabled.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 26" preserveAspectRatio="xMidYMid meet"><path fill="#b3ca9d" d="M22,23h2a3,3,0,0,1-3,3H3a3,3,0,0,1-3-3V8A3,3,0,0,1,3,5H4v5H2V23a1,1,0,0,0,1,1H21A1,1,0,0,0,22,23ZM30,3V18a3,3,0,0,1-3,3H9a3,3,0,0,1-3-3V3A3,3,0,0,1,9,0H27A3,3,0,0,1,30,3ZM28,5H8V18a1,1,0,0,0,1,1H27a1,1,0,0,0,1-1ZM25,8H11v8H25V8m1-1V17H10V7Z"/></svg>

--- a/src/assets/icons/copy/copy-hover.svg
+++ b/src/assets/icons/copy/copy-hover.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 26" preserveAspectRatio="xMidYMid meet"><path fill="#6a8e4a" d="M22,23h2a3,3,0,0,1-3,3H3a3,3,0,0,1-3-3V8A3,3,0,0,1,3,5H4v5H2V23a1,1,0,0,0,1,1H21A1,1,0,0,0,22,23ZM30,3V18a3,3,0,0,1-3,3H9a3,3,0,0,1-3-3V3A3,3,0,0,1,9,0H27A3,3,0,0,1,30,3ZM28,5H8V18a1,1,0,0,0,1,1H27a1,1,0,0,0,1-1ZM25,8H11v8H25V8m1-1V17H10V7Z"/></svg>

--- a/src/assets/icons/copy/copy.svg
+++ b/src/assets/icons/copy/copy.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 26" preserveAspectRatio="xMidYMid meet"><path fill="#85a667" d="M22,23h2a3,3,0,0,1-3,3H3a3,3,0,0,1-3-3V8A3,3,0,0,1,3,5H4v5H2V23a1,1,0,0,0,1,1H21A1,1,0,0,0,22,23ZM30,3V18a3,3,0,0,1-3,3H9a3,3,0,0,1-3-3V3A3,3,0,0,1,9,0H27A3,3,0,0,1,30,3ZM28,5H8V18a1,1,0,0,0,1,1H27a1,1,0,0,0,1-1ZM25,8H11v8H25V8m1-1V17H10V7Z"/></svg>

--- a/src/clue/clue.sass
+++ b/src/clue/clue.sass
@@ -1,2 +1,16 @@
 // application-specific styling goes here
-  
+
+.document
+    .titlebar
+        .actions
+            .icon-copy
+                margin-left: 5px
+
+                .copy
+                    background-image: url("../assets/icons/copy/copy.svg")
+
+                    &:hover
+                        background-image: url("../assets/icons/copy/copy-hover.svg")
+
+                    &:active
+                        background-image: url("../assets/icons/copy/copy-active.svg")

--- a/src/components/document/document-workspace.tsx
+++ b/src/components/document/document-workspace.tsx
@@ -76,6 +76,7 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps, {}> {
               document={primaryDocument}
               workspace={problemWorkspace}
               onNewDocument={this.handleNewDocument}
+              onCopyDocument={this.handleCopyDocument}
               toolbar={toolbar}
               side="primary"
               isGhostUser={isGhostUser}
@@ -101,6 +102,7 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps, {}> {
                 document={primaryDocument}
                 workspace={problemWorkspace}
                 onNewDocument={this.handleNewDocument}
+                onCopyDocument={this.handleCopyDocument}
                 toolbar={toolbar}
                 side="primary"
                 isGhostUser={isGhostUser}
@@ -185,6 +187,23 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps, {}> {
     const newDocument = await db.createOtherDocument(type, {title, content});
     if (newDocument) {
       problemWorkspace.setAvailableDocument(newDocument);
+    }
+  }
+
+  private handleCopyDocument = (document: DocumentModelType) => {
+    this.stores.ui.prompt(`Give your workspace copy a new name:`,
+                          `Copy of ${document.title || this.stores.problem.title}`, `Copy Workspace`)
+      .then((title: string) => {
+        this.handleCopyDocumentOpen(document, title)
+        .catch(this.stores.ui.setError);
+      });
+  }
+
+  private handleCopyDocumentOpen = async (document: DocumentModelType, title: string) => {
+    const { db, ui: { problemWorkspace } } = this.stores;
+    const copyDocument = await db.copyOtherDocument(document, title);
+    if (copyDocument) {
+      problemWorkspace.setAvailableDocument(copyDocument);
     }
   }
 

--- a/src/components/document/document.sass
+++ b/src/components/document/document.sass
@@ -133,19 +133,16 @@
           outline: none
           outline-offset: 0
 
-      .icon-new
-        border-top-left-radius: $border-radius
+      .icon-new,.icon-copy
         background-color: $color1-3
         padding: $padding
         padding-top: 2px
-        margin-left: 0
         position: relative
         width: 40px
         height: 36px
         cursor: pointer
 
-        .new
-          background-image: url("../../assets/icons/new/new.svg")
+        .new,.copy
           background-repeat: no-repeat
           position: absolute
           left: 15%
@@ -156,13 +153,22 @@
           padding-top: 2px
           cursor: pointer
 
+          &:active
+            transform-origin: center
+            transform: scale(.85)
+
+      .icon-new
+        border-top-left-radius: $border-radius
+        margin-left: 0
+
+        .new
+          background-image: url("../../assets/icons/new/new.svg")
+
           &:hover
             background-image: url("../../assets/icons/new/new-hover.svg")
 
           &:active
             background-image: url("../../assets/icons/new/new-active.svg")
-            transform-origin: center
-            transform: scale(.85)
 
   .canvas-area
     position: absolute

--- a/src/components/document/document.tsx
+++ b/src/components/document/document.tsx
@@ -26,6 +26,7 @@ interface IProps extends IBaseProps {
   workspace: WorkspaceModelType;
   document: DocumentModelType;
   onNewDocument?: (document: DocumentModelType) => void;
+  onCopyDocument?: (document: DocumentModelType) => void;
   toolbar?: ToolbarConfig;
   side: WorkspaceSide;
   readOnly?: boolean;
@@ -69,6 +70,13 @@ const NewButton = ({ onClick }: { onClick: () => void }) => {
 const EditButton = ({ onClick }: { onClick: () => void }) => {
   return (
     <IconButton icon="edit" key="edit" className="action icon-edit"
+                onClickButton={onClick} />
+  );
+};
+
+const CopyButton = ({ onClick }: { onClick: () => void }) => {
+  return (
+    <IconButton icon="copy" key="copy" className="action icon-copy"
                 onClickButton={onClick} />
   );
 };
@@ -167,6 +175,7 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
         {!hideButtons &&
           <div className="actions">
             <NewButton onClick={this.handleNewDocumentClick} />
+            <CopyButton onClick={this.handleCopyDocumentClick} />
           </div>
         }
         <div className="title" data-test="document-title">
@@ -212,6 +221,7 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
         {!hideButtons &&
           <div className="actions">
             <NewButton onClick={this.handleNewDocumentClick} />
+            <CopyButton onClick={this.handleCopyDocumentClick} />
           </div>
         }
         {
@@ -458,6 +468,11 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
   private handleNewDocumentClick = () => {
     const { document, onNewDocument } = this.props;
     onNewDocument && onNewDocument(document);
+  }
+
+  private handleCopyDocumentClick = () => {
+    const { document, onCopyDocument } = this.props;
+    onCopyDocument && onCopyDocument(document);
   }
 
   private handleDocumentRename = () => {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -11,9 +11,10 @@ import { DBOfferingGroup, DBOfferingGroupUser, DBOfferingGroupMap, DBOfferingUse
   DBOtherDocument, DBOtherDocumentMap, IOtherDocumentProperties, DBOtherPublication } from "./db-types";
 import { DocumentModelType, DocumentModel, DocumentType, PersonalDocument, ProblemDocument, LearningLogDocument,
         PersonalPublication, PublicationDocument, LearningLogPublication, OtherPublicationType, OtherDocumentType
-      } from "../models/document/document";
+       } from "../models/document/document";
 import { ImageModelType } from "../models/image";
-import { DocumentContentSnapshotType, DocumentContentModelType } from "../models/document/document-content";
+import { DocumentContentSnapshotType, DocumentContentModelType, cloneContentWithUniqueIds
+       } from "../models/document/document-content";
 import { Firebase } from "./firebase";
 import { DBListeners } from "./db-listeners";
 import { Logger, LogEventName } from "./logger";
@@ -517,6 +518,15 @@ export class DB {
         .then(resolve)
         .catch(reject);
     });
+  }
+
+  public copyOtherDocument(document: DocumentModelType, newTitle?: string) {
+    const title = `${newTitle || document.title || this.stores.problem.title || "Untitled"}`;
+    const content = cloneContentWithUniqueIds(document.content);
+    if (document.type === ProblemDocument) {
+      return this.createPersonalDocument({ title, content });
+    }
+    return this.createOtherDocument(document.type as OtherDocumentType, { title, content });
   }
 
   public openOtherDocument(documentType: OtherDocumentType, documentKey: string) {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -520,13 +520,10 @@ export class DB {
     });
   }
 
-  public copyOtherDocument(document: DocumentModelType, newTitle?: string) {
-    const title = `${newTitle || document.title || this.stores.problem.title || "Untitled"}`;
+  public copyOtherDocument(document: DocumentModelType, title: string) {
     const content = cloneContentWithUniqueIds(document.content);
-    if (document.type === ProblemDocument) {
-      return this.createPersonalDocument({ title, content });
-    }
-    return this.createOtherDocument(document.type as OtherDocumentType, { title, content });
+    const copyType = document.type === ProblemDocument ? PersonalDocument : document.type as OtherDocumentType;
+    return this.createOtherDocument(copyType, { title, content });
   }
 
   public openOtherDocument(documentType: OtherDocumentType, documentKey: string) {


### PR DESCRIPTION
In the workspace title bars for Problem Documents, Personal Documents, and Learning Log Documents, users can now click on an icon to copy an existing document alongside its contents into a new document. Problem Documents and Personal Documents, when copied, become a Personal Document; Learning Log Documents, when copied, become a Learning Log Document.