### PR TITLE
167536596 nodes in view

### DIFF
--- a/src/dataflow/app-config.json
+++ b/src/dataflow/app-config.json
@@ -11,9 +11,6 @@
   "defaultDocumentTemplate": {
     "tiles": [
       {
-        "layout": {
-          "height": 500
-        },
         "content": {
           "type": "Dataflow"
         }

--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -530,16 +530,28 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
   private addNode = async (nodeType: string) => {
     const nodeFactory = this.programEditor.components.get(nodeType) as any;
     const n1 = await nodeFactory!.createNode();
-
-    const numNodes = this.programEditor.nodes.length;
-    const { k } = this.programEditor.view.area.transform;
-    n1.position = [40 * (1 / k) + Math.floor((numNodes % 20) / 5) * 245 +
-                  Math.floor(numNodes / 20) * 15, 5 + numNodes % 5 * 90];
+    n1.position = this.getNewNodePosition();
     this.programEditor.addNode(n1);
     if (nodeType === "Data Storage") {
       this.setState({disableDataStorage: true});
     }
   }
+  private getNewNodePosition = () => {
+    const numNodes = this.programEditor.nodes.length;
+    const kNodesPerColumn = 5;
+    const kNodesPerRow = 4;
+    const kColumnWidth = 200;
+    const kRowHeight = 90;
+    const kLeftMargin = 40;
+    const kTopMargin = 5;
+    const kColumnOffset = 15;
+    const { k } = this.programEditor.view.area.transform;
+    const nodePos = [kLeftMargin * (1 / k) + Math.floor((numNodes % (kNodesPerColumn * kNodesPerRow)) / kNodesPerColumn)
+                     * kColumnWidth + Math.floor(numNodes / (kNodesPerColumn * kNodesPerRow)) * kColumnOffset,
+                     kTopMargin + numNodes % kNodesPerColumn * kRowHeight];
+    return nodePos;
+  }
+
   private clearProgram = () => {
     this.programEditor.clear();
     this.setState({disableDataStorage: false});

--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -199,11 +199,10 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
 
   private getEditorStyle = () => {
     const style: React.CSSProperties = {};
-    const documentElts = document.getElementsByClassName("document-content");
-    const documentElt = documentElts && (documentElts[0]);
-    const titlebarElts = document.getElementsByClassName("other-doc titlebar");
-    const titlebarElt = titlebarElts && (titlebarElts[0]);
-    style.height = `${documentElt.clientHeight - titlebarElt.clientHeight}px`;
+    const documentElt = document.querySelector(".document-content");
+    const titlebarElt = document.querySelector(".document .titlebar");
+    const editorHeight = documentElt && titlebarElt ? documentElt.clientHeight - titlebarElt.clientHeight : 500;
+    style.height = `${editorHeight}px`;
     return style;
   }
 

--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -115,10 +115,6 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
   public render() {
     const editorClass = `editor ${(this.isSideBySide() ? "half" : "full")} ${(this.isGraphOnly() && "hidden")}`;
     const isTesting = ["qa", "test"].indexOf(this.stores.appMode) >= 0;
-    const style: React.CSSProperties = {};
-    const documentElts = document.getElementsByClassName("document-content");
-    const documentElt: HTMLInputElement = documentElts && (documentElts[0] as HTMLInputElement);
-    style.height = `${documentElt.clientHeight - 50}px`;
     return (
       <div className="dataflow-program-container">
         {this.isRunning() && <div className="running-indicator" />}
@@ -146,7 +142,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
               className={editorClass}
               ref={(elt) => this.editorDomElement = elt}
             >
-              <div className="flow-tool" ref={elt => this.toolDiv = elt} style={style}/>
+              <div className="flow-tool" ref={elt => this.toolDiv = elt} style={this.getEditorStyle()}/>
                 <DataflowProgramZoom
                   onZoomInClick={this.zoomIn}
                   onZoomOutClick={this.zoomOut}
@@ -199,6 +195,15 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
     if (!this.programEditor && this.toolDiv) {
       this.initProgramEditor();
     }
+  }
+
+  private getEditorStyle = () => {
+    const style: React.CSSProperties = {};
+    const documentElts = document.getElementsByClassName("document-content");
+    const documentElt: HTMLInputElement = documentElts && (documentElts[0] as HTMLInputElement);
+    const topbarHeight = 50;
+    style.height = `${documentElt.clientHeight - topbarHeight}px`;
+    return style;
   }
 
   private initProgramEditor = () => {

--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -386,22 +386,27 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
   private keepNodesInView = () => {
     const margin = 5;
     const { k } = this.programEditor.view.area.transform;
-    let rightMostEdge = 0;
-    let bottomMostEdge = 0;
-    this.programEditor.nodes.forEach((n: Node) => {
-      const nodeView = this.programEditor.view.nodes.get(n);
-      if (nodeView) {
-        rightMostEdge = Math.max (rightMostEdge, (nodeView.node.position[0] + nodeView.el.clientWidth) * k);
-        bottomMostEdge = Math.max (bottomMostEdge, (nodeView.node.position[1] + nodeView.el.clientHeight) * k);
-      }
-    });
-    const newZoom = Math.min(k * this.programEditor.view.container.clientWidth / ( rightMostEdge + margin),
-                             k * this.programEditor.view.container.clientHeight / ( bottomMostEdge + margin));
-    if (newZoom < k && rightMostEdge > 0 && newZoom > 0) {
+    const rect = this.getBoundingRectOfNodes();
+    const newZoom = Math.min(k * this.programEditor.view.container.clientWidth / ( rect.right + margin),
+                             k * this.programEditor.view.container.clientHeight / ( rect.bottom + margin));
+    if (newZoom < k && rect.right > 0 && newZoom > 0) {
       const currentTransform = this.programEditor.view.area.transform;
       this.programEditor.view.area.transform = {k: newZoom, x: currentTransform.x, y: currentTransform.y};
       this.programEditor.view.area.update();
     }
+  }
+
+  private getBoundingRectOfNodes = () => {
+    const { k } = this.programEditor.view.area.transform;
+    const rect: ClientRect = {bottom: 0, top: 0, left: 0, right: 0, height: 0, width: 0};
+    this.programEditor.nodes.forEach((n: Node) => {
+      const nodeView = this.programEditor.view.nodes.get(n);
+      if (nodeView) {
+        rect.right = Math.max (rect.right, (nodeView.node.position[0] + nodeView.el.clientWidth) * k);
+        rect.bottom = Math.max (rect.bottom, (nodeView.node.position[1] + nodeView.el.clientHeight) * k);
+      }
+    });
+    return rect;
   }
 
   private hasValidOutputNodes = () => {

--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -200,9 +200,10 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
   private getEditorStyle = () => {
     const style: React.CSSProperties = {};
     const documentElts = document.getElementsByClassName("document-content");
-    const documentElt: HTMLInputElement = documentElts && (documentElts[0] as HTMLInputElement);
-    const topbarHeight = 50;
-    style.height = `${documentElt.clientHeight - topbarHeight}px`;
+    const documentElt = documentElts && (documentElts[0]);
+    const titlebarElts = document.getElementsByClassName("other-doc titlebar");
+    const titlebarElt = titlebarElts && (titlebarElts[0]);
+    style.height = `${documentElt.clientHeight - titlebarElt.clientHeight}px`;
     return style;
   }
 


### PR DESCRIPTION
Changes to keep nodes in bounds when editor div changes by zooming program nodes.  As per story requirements:
- ensure program tile takes full vertical space when created
- ensure created nodes are not covered by zoom controls
- zoom nodes to keep them within the visible region when user resizes tile or toggles between graph/side-by-side view (note, this zoom is not saved but only used to aid in displaying the program).