### PR TITLE
Fixes property propagation for personal publications

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -609,10 +609,10 @@ export class DB {
 
   // handles published personal documents and published learning logs
   public createDocumentModelFromOtherPublication(publication: DBOtherPublication, type: OtherPublicationType) {
-    const {title, uid, originDoc, self: {documentKey}} = publication;
+    const {title, properties, uid, originDoc, self: {documentKey}} = publication;
     const group = this.stores.groups.groupForUser(uid);
     const groupId = group && group.id;
-    return this.openDocument({type, userId: uid, documentKey, groupId, title, originDoc})
+    return this.openDocument({type, userId: uid, documentKey, groupId, title, properties, originDoc})
       .then((document) => {
         return document;
       });


### PR DESCRIPTION
- fixes the bug seen in the demo meeting today (published datasets were being incorrectly categorized as published programs in the right nav tabs)
- properties were successfully being written to firebase, but weren't being restored from firebase correctly
- will need to be merged to the Dataflow branch to affect document organization there