### PR TITLE
Simplify group document listening to fix student 4-up view

### DIFF
--- a/src/components/document/document-workspace.tsx
+++ b/src/components/document/document-workspace.tsx
@@ -220,10 +220,6 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps, {}> {
             createdAt: 1,
             content: {},
           });
-
-          // The creation of normal documents would start listeners for group documents in the same section
-          // Since the creation of ghost documents is faked, listeners must be started manually here
-          this.stores.db.listeners.updateGroupUserProblemDocumentListeners(ghostProblemDocuments[ghostSectionId]);
         }
         return ghostProblemDocuments[ghostSectionId];
       }

--- a/src/lib/db-listeners/base-listener.ts
+++ b/src/lib/db-listeners/base-listener.ts
@@ -1,0 +1,40 @@
+import {DEBUG_LISTENERS} from "../../lib/debug";
+
+export class BaseListener {
+  protected listener: string;
+
+  constructor(listener: string) {
+    this.listener = listener;
+  }
+
+  protected debugLogHandler(
+    methodName: string,
+    action: "adding" | "removing",
+    handler: string,
+    ref: firebase.database.Reference) {
+    this.debugLog(methodName, action, handler, "handler for", this.refName(ref));
+  }
+
+  protected debugLogHandlers(
+    methodName: string,
+    action: "adding" | "removing",
+    handlers: string[],
+    ref: firebase.database.Reference) {
+    this.debugLog(methodName, action, handlers.join(" and "), "handlers for", this.refName(ref));
+  }
+
+  protected debugLogSnapshot(methodName: string, snapshot: firebase.database.DataSnapshot) {
+    this.debugLog(methodName, snapshot.val(), "for", this.refName(snapshot.ref));
+  }
+
+  protected debugLog(methodName: string, ...args: any[]) {
+    if (DEBUG_LISTENERS) {
+      // tslint:disable-next-line:no-console
+      console.log(`${this.listener}${methodName}`, ...args);
+    }
+  }
+
+  private refName(ref: firebase.database.Reference) {
+    return ref.toString().replace(/^https:\/\/collaborative-learning-ec215.firebaseio.com/, "");
+  }
+}

--- a/src/lib/db-listeners/db-comments-listener.ts
+++ b/src/lib/db-listeners/db-comments-listener.ts
@@ -1,12 +1,16 @@
 import { DB } from "../db";
 import { TileCommentModel, TileCommentsModelType, TileCommentsModel } from "../../models/tools/tile-comments";
 import { forEach } from "lodash";
+import { BaseListener } from "./base-listener";
 
-export class DBCommentsListener {
+export class DBCommentsListener extends BaseListener {
   private db: DB;
   private commentsRef: firebase.database.Reference | null = null;
+  private onChildAdded: (snapshot: firebase.database.DataSnapshot) => void;
+  private onChildChanged: (snapshot: firebase.database.DataSnapshot) => void;
 
   constructor(db: DB) {
+    super("DBCommentsListener");
     this.db = db;
   }
 
@@ -14,20 +18,23 @@ export class DBCommentsListener {
     this.commentsRef = this.db.firebase.ref(
       this.db.firebase.getUserDocumentCommentsPath(this.db.stores.user)
     );
-    this.commentsRef.on("child_changed", this.handleUpdateComments);
-    this.commentsRef.on("child_added", this.handleUpdateComments);
+    this.debugLogHandlers("#start", "adding", ["child_changed", "child_added"], this.commentsRef);
+    this.commentsRef.on("child_changed", this.onChildChanged = this.handleUpdateComments("child_changed"));
+    this.commentsRef.on("child_added", this.onChildAdded = this.handleUpdateComments("child_added"));
   }
 
   public stop() {
     if (this.commentsRef) {
-      this.commentsRef.off("child_changed", this.handleUpdateComments);
-      this.commentsRef.off("child_added", this.handleUpdateComments);
+      this.debugLogHandlers("#stop", "removing", ["child_changed", "child_added"], this.commentsRef);
+      this.commentsRef.off("child_changed", this.onChildChanged);
+      this.commentsRef.off("child_added", this.onChildAdded);
     }
   }
 
-  private handleUpdateComments = (snapshot: firebase.database.DataSnapshot) => {
+  private handleUpdateComments = (eventType: string) => (snapshot: firebase.database.DataSnapshot) => {
     const { documents } = this.db.stores;
     const dbDocComments = snapshot.val();
+    this.debugLogSnapshot(`#handleUpdateComments (${eventType})`, snapshot);
     if (dbDocComments) {
       const docModel = snapshot.ref.key && documents.getDocument(snapshot.ref.key);
       if (docModel) {

--- a/src/lib/db-listeners/db-groups-listener.ts
+++ b/src/lib/db-listeners/db-groups-listener.ts
@@ -1,14 +1,16 @@
-import { DB } from "../db";
+import { DB, Monitor } from "../db";
 import { DBOfferingGroupMap } from "../db-types";
 import * as firebase from "firebase/app";
 import { ProblemDocument } from "../../models/document/document";
 import { map } from "lodash";
+import { BaseListener } from "./base-listener";
 
-export class DBGroupsListener {
+export class DBGroupsListener extends BaseListener {
   private db: DB;
   private groupsRef: firebase.database.Reference | null = null;
 
   constructor(db: DB) {
+    super("DBGroupsListener");
     this.db = db;
   }
 
@@ -18,9 +20,11 @@ export class DBGroupsListener {
       const groupsRef = this.groupsRef = this.db.firebase.ref(this.db.firebase.getGroupsPath(user));
 
       // use once() so we are ensured that groups are set before we resolve
+      this.debugLogHandler("#start", "adding", "once", groupsRef);
       groupsRef.once("value")
         .then((snapshot) => {
           const dbGroups: DBOfferingGroupMap = snapshot.val() || {};
+          this.debugLogSnapshot("#start", snapshot);
           // Groups may be invalid at this point, but the listener will resolve it once connection times are set
           groups.updateFromDB(user.id, dbGroups, this.db.stores.class);
 
@@ -36,6 +40,7 @@ export class DBGroupsListener {
           }
         })
         .then(() => {
+          this.debugLogHandler("#start", "adding", "on value", groupsRef);
           groupsRef.on("value", this.handleGroupsRef);
         })
         .then(resolve)
@@ -45,6 +50,7 @@ export class DBGroupsListener {
 
   public stop() {
     if (this.groupsRef) {
+      this.debugLogHandler("#stop", "removing", "on value", this.groupsRef);
       this.groupsRef.off("value", this.handleGroupsRef);
       this.groupsRef = null;
     }
@@ -55,6 +61,8 @@ export class DBGroupsListener {
     const groups: DBOfferingGroupMap = snapshot.val() || {};
     const myGroupIds: string[] = [];
     const overSubscribedUserUpdates: any = {};
+
+    this.debugLogSnapshot("#handleGroupsRef", snapshot);
 
     // ensure that the current user is not in more than 1 group and groups are not oversubscribed
     Object.keys(groups).forEach((groupId) => {
@@ -107,7 +115,20 @@ export class DBGroupsListener {
 
       documents.byType(ProblemDocument).forEach((document) => {
         document.setGroupId(userGroupIds[document.uid]);
-        this.db.listeners.updateGroupUserProblemDocumentListeners(document);
+
+        // students only monitor documents in their group to save bandwidth
+        if (user.isStudent) {
+          if (document.groupId === user.latestGroupId) {
+            if (document.uid !== user.id) {
+              // ensure the group document is monitored
+              this.db.listeners.monitorDocument(document, Monitor.Remote);
+            }
+          }
+          else {
+            // ensure we don't monitor documents outside the group
+            this.db.listeners.unmonitorDocument(document, Monitor.Remote);
+          }
+        }
       });
     }
   }

--- a/src/lib/db-listeners/db-problem-documents-listener.ts
+++ b/src/lib/db-listeners/db-problem-documents-listener.ts
@@ -1,48 +1,39 @@
-import { DB } from "../db";
-import { DBOfferingUserProblemDocument,
-         DBOfferingUser,
-         DBOfferingUserProblemDocumentMap,
-         DBOfferingUserMap } from "../db-types";
+import { DB, Monitor } from "../db";
+import { DBOfferingUser, DBOfferingUserMap } from "../db-types";
 import { forEach } from "lodash";
+import { BaseListener } from "./base-listener";
 
-export class DBProblemDocumentsListener {
+export class DBProblemDocumentsListener extends BaseListener {
   private db: DB;
-  private problemDocsRef: firebase.database.Reference | null  = null;
   private offeringUsersRef: firebase.database.Reference | null  = null;
+  private onLoadOfferingUserChildAdded: (snapshot: firebase.database.DataSnapshot) => void;
+  private onLoadOfferingUserChildChanged: (snapshot: firebase.database.DataSnapshot) => void;
 
   constructor(db: DB) {
+    super("DBProblemDocumentsListener");
     this.db = db;
   }
 
   public start() {
     const { user } = this.db.stores;
 
-    // teacher user - load documents for all users
-    if (user.isTeacher) {
-      return new Promise<void>((resolve, reject) => {
-        const offeringUsersRef = this.offeringUsersRef = this.db.firebase.ref(
-          this.db.firebase.getOfferingUsersPath(user));
-        // use once() so we are ensured that documents are set before we resolve
-        offeringUsersRef.once("value", (snapshot) => {
-          this.handleLoadOfferingUsersProblemDocuments(snapshot);
-          // We have to listen to both events because of a race condition of the documents
-          // not being set when the child is added
-          offeringUsersRef.on("child_added", this.handleLoadOfferingUserAddedOrChanged);
-          offeringUsersRef.on("child_changed", this.handleLoadOfferingUserAddedOrChanged);
-        })
-        .then(() => resolve())
-        .catch(reject);
-      });
-    }
-
-    // student user - load documents for user and group
+    // both teachers and students listen to all problem documents
+    // but only teachers listen to all content.  students only listen
+    // to content of users in their group to reduce network traffic
     return new Promise<void>((resolve, reject) => {
-      const problemDocsRef = this.problemDocsRef = this.db.firebase.ref(
-        this.db.firebase.getProblemDocumentsPath(user));
+      const offeringUsersRef = this.offeringUsersRef = this.db.firebase.ref(
+        this.db.firebase.getOfferingUsersPath(user));
       // use once() so we are ensured that documents are set before we resolve
-      problemDocsRef.once("value", (snapshot) => {
-        this.handleLoadCurrentUserProblemDocuments(snapshot);
-        problemDocsRef.on("child_added", this.handleCurrentUserProblemDocumentAdded);
+      this.debugLogHandler("#start", "adding", "once", offeringUsersRef);
+      offeringUsersRef.once("value", (snapshot) => {
+        this.handleLoadOfferingUsersProblemDocuments(snapshot);
+        // We have to listen to both events because of a race condition of the documents
+        // not being set when the child is added
+        this.debugLogHandlers("#start", "adding", ["child_added", "child_changed"], offeringUsersRef);
+        offeringUsersRef.on("child_added",
+          this.onLoadOfferingUserChildAdded = this.handleLoadOfferingUserAddedOrChanged("child_added"));
+        offeringUsersRef.on("child_changed",
+          this.onLoadOfferingUserChildChanged = this.handleLoadOfferingUserAddedOrChanged("child_changed"));
       })
       .then(() => resolve())
       .catch(reject);
@@ -50,17 +41,16 @@ export class DBProblemDocumentsListener {
   }
 
   public stop() {
-    if (this.problemDocsRef) {
-      this.problemDocsRef.off("child_added", this.handleCurrentUserProblemDocumentAdded);
-    }
     if (this.offeringUsersRef) {
-      this.offeringUsersRef.off("child_added", this.handleLoadOfferingUserAddedOrChanged);
-      this.offeringUsersRef.off("child_changed", this.handleLoadOfferingUserAddedOrChanged);
+      this.debugLogHandlers("#stop", "removing", ["child_added", "child_changed"], this.offeringUsersRef);
+      this.offeringUsersRef.off("child_added", this.onLoadOfferingUserChildAdded);
+      this.offeringUsersRef.off("child_changed", this.onLoadOfferingUserChildChanged);
     }
   }
 
   private handleLoadOfferingUsersProblemDocuments = (snapshot: firebase.database.DataSnapshot) => {
     const users: DBOfferingUserMap = snapshot.val();
+    this.debugLogSnapshot("#handleLoadOfferingUsersProblemDocuments", snapshot);
     forEach(users, (user: DBOfferingUser) => {
       if (user) {
         this.handleOfferingUser(user);
@@ -68,52 +58,35 @@ export class DBProblemDocumentsListener {
     });
   }
 
-  private handleLoadOfferingUserAddedOrChanged = (snapshot: firebase.database.DataSnapshot) => {
+  private handleLoadOfferingUserAddedOrChanged = (eventType: string) => (snapshot: firebase.database.DataSnapshot) => {
     const user: DBOfferingUser = snapshot.val();
+    this.debugLogSnapshot(`#handleLoadOfferingUserAddedOrChanged (${eventType})`, snapshot);
     if (user) {
       this.handleOfferingUser(user);
     }
   }
 
   private handleOfferingUser = (user: DBOfferingUser) => {
-    const { documents, user: currentUser } = this.db.stores;
+    const { documents, user: currentUser, groups } = this.db.stores;
     forEach(user.documents, document => {
-      if (document && !documents.getDocument(document.documentKey)) {
-        // current user's own document should be monitored for changes;
-        // all other users' documents can be monitored readOnly
-        const readOnly = user.self.uid !== currentUser.id;
-        this.db.createDocumentFromProblemDocument(document.self.uid, document, readOnly)
+      const existingDoc = documents.getDocument(document.documentKey);
+      if (existingDoc) {
+        this.db.updateDocumentFromProblemDocument(existingDoc, document);
+      } else {
+        const isOwnDocument = user.self.uid === currentUser.id;
+        const userInGroup = groups.userInGroup(document.self.uid, currentUser.latestGroupId);
+        const monitorRemote = currentUser.isTeacher || (!isOwnDocument && userInGroup);
+        const monitorLocal = isOwnDocument;
+        const monitor = monitorRemote ? Monitor.Remote : (monitorLocal ? Monitor.Local : Monitor.None);
+        this.db.createDocumentFromProblemDocument(document.self.uid, document, monitor)
+          .then((doc) => {
+            if (isOwnDocument) {
+              this.db.listeners.monitorDocumentVisibility(doc);
+            }
+            return doc;
+          })
           .then(documents.add);
       }
     });
-  }
-
-  private handleLoadCurrentUserProblemDocuments = (snapshot: firebase.database.DataSnapshot) => {
-    const problemDocuments: DBOfferingUserProblemDocumentMap = snapshot.val();
-    if (problemDocuments) {
-      forEach(problemDocuments, (document) => {
-        this.handleCurrentUserProblemDocument(document);
-      });
-    }
-  }
-
-  private handleCurrentUserProblemDocumentAdded = (snapshot: firebase.database.DataSnapshot) => {
-    const problemDocument: DBOfferingUserProblemDocument|null = snapshot.val();
-    this.handleCurrentUserProblemDocument(problemDocument);
-  }
-
-  private handleCurrentUserProblemDocument(problemDocument: DBOfferingUserProblemDocument|null) {
-    const {user, documents} = this.db.stores;
-    // If a workspace has already been created, or is currently been created, then its listeners are already set
-    if (problemDocument
-          && !documents.getDocument(problemDocument.documentKey)) {
-      this.db.createDocumentFromProblemDocument(user.id, problemDocument)
-        .then((document) => {
-          this.db.listeners.updateGroupUserProblemDocumentListeners(document);
-          this.db.listeners.monitorDocumentVisibility(document);
-          return document;
-        })
-        .then(documents.add);
-    }
   }
 }

--- a/src/lib/db-listeners/db-publications-listener.ts
+++ b/src/lib/db-listeners/db-publications-listener.ts
@@ -2,12 +2,14 @@ import { DB } from "../db";
 import { DBPublication } from "../db-types";
 import { forEach } from "lodash";
 import { onPatch } from "mobx-state-tree";
+import { BaseListener } from "./base-listener";
 
-export class DBPublicationsListener {
+export class DBPublicationsListener extends BaseListener {
   private db: DB;
   private publicationsRef: firebase.database.Reference | null = null;
 
   constructor(db: DB) {
+    super("DBPublicationsListener");
     this.db = db;
   }
 
@@ -17,8 +19,10 @@ export class DBPublicationsListener {
         this.db.firebase.getPublicationsPath(this.db.stores.user)
       );
       // use once() so we are ensured that publications are set before we resolve
+      this.debugLogHandler("#start", "adding", "once", publicationsRef);
       publicationsRef.once("value", (snapshot) => {
         this.handleLoadPublications(snapshot);
+        this.debugLogHandler("#start", "adding", "child_added", publicationsRef);
         publicationsRef.on("child_added", this.handlePublicationChildAdded);
       })
       .then(snapshot => {
@@ -30,12 +34,14 @@ export class DBPublicationsListener {
 
   public stop() {
     if (this.publicationsRef) {
+      this.debugLogHandler("#stop", "removing", "child_added", this.publicationsRef);
       this.publicationsRef.off("child_added", this.handlePublicationChildAdded);
     }
   }
 
   private handleLoadPublications = (snapshot: firebase.database.DataSnapshot) => {
     const publications = snapshot.val();
+    this.debugLogSnapshot("#handleLoadPublications", snapshot);
     if (publications) {
       forEach(publications, (publication) => {
         this.handlePublication(publication);
@@ -45,6 +51,7 @@ export class DBPublicationsListener {
 
   private handlePublicationChildAdded = (snapshot: firebase.database.DataSnapshot) => {
     const publication: DBPublication|null = snapshot.val();
+    this.debugLogSnapshot("#handlePublicationChildAdded", snapshot);
     this.handlePublication(publication);
   }
 

--- a/src/lib/db-listeners/db-stars-listener.ts
+++ b/src/lib/db-listeners/db-stars-listener.ts
@@ -1,12 +1,16 @@
 import { DB } from "../db";
 import { UserStarModel } from "../../models/tools/user-star";
 import { forEach } from "lodash";
+import { BaseListener } from "./base-listener";
 
-export class DBStarsListener {
+export class DBStarsListener extends BaseListener {
   private db: DB;
   private starsRef: firebase.database.Reference | null = null;
+  private onChildAdded: (snapshot: firebase.database.DataSnapshot) => void;
+  private onChildChanged: (snapshot: firebase.database.DataSnapshot) => void;
 
   constructor(db: DB) {
+    super("DBStarsListener");
     this.db = db;
   }
 
@@ -14,20 +18,23 @@ export class DBStarsListener {
     this.starsRef = this.db.firebase.ref(
       this.db.firebase.getUserDocumentStarsPath(this.db.stores.user)
     );
-    this.starsRef.on("child_changed", this.handleUpdateStars);
-    this.starsRef.on("child_added", this.handleUpdateStars);
+    this.debugLogHandlers("#start", "adding", ["child_changed", "child_added"], this.starsRef);
+    this.starsRef.on("child_changed", this.onChildChanged = this.handleUpdateStars("child_changed"));
+    this.starsRef.on("child_added", this.onChildAdded = this.handleUpdateStars("child_added"));
   }
 
   public stop() {
     if (this.starsRef) {
-      this.starsRef.off("child_changed", this.handleUpdateStars);
-      this.starsRef.off("child_added", this.handleUpdateStars);
+      this.debugLogHandlers("#stop", "removing", ["child_changed", "child_added"], this.starsRef);
+      this.starsRef.off("child_changed", this.onChildChanged);
+      this.starsRef.off("child_added", this.onChildAdded);
     }
   }
 
-  private handleUpdateStars = (snapshot: firebase.database.DataSnapshot) => {
+  private handleUpdateStars = (eventType: string) => (snapshot: firebase.database.DataSnapshot) => {
     const { documents } = this.db.stores;
     const dbDocStars = snapshot.val();
+    this.debugLogSnapshot(`#handleUpdateStars (${eventType})`, snapshot);
     if (dbDocStars) {
       const docModel = snapshot.ref.key && documents.getDocument(snapshot.ref.key);
       if (docModel) {

--- a/src/lib/db-listeners/db-supports-listener.ts
+++ b/src/lib/db-listeners/db-supports-listener.ts
@@ -4,12 +4,16 @@ import { SupportTarget, TeacherSupportModel, TeacherSupportModelType, ClassAudie
 import { DBSupport } from "../db-types";
 import { SectionType } from "../../models/curriculum/section";
 import { ESupportType, SupportModel } from "../../models/curriculum/support";
+import { BaseListener } from "./base-listener";
 
-export class DBSupportsListener {
+export class DBSupportsListener extends BaseListener {
   private db: DB;
   private supportsRef: firebase.database.Reference | null = null;
+  private onChildAdded: (snapshot: firebase.database.DataSnapshot) => void;
+  private onChildChanged: (snapshot: firebase.database.DataSnapshot) => void;
 
   constructor(db: DB) {
+    super("DBSupportsListener");
     this.db = db;
   }
 
@@ -18,20 +22,23 @@ export class DBSupportsListener {
     this.supportsRef = this.db.firebase.ref(
       this.db.firebase.getSupportsPath(this.db.stores.user)
     );
-    this.supportsRef.on("child_changed", this.handleSupportsUpdate);
-    this.supportsRef.on("child_added", this.handleSupportsUpdate);
+    this.debugLogHandlers("#start", "adding", ["child_changed", "child_added"], this.supportsRef);
+    this.supportsRef.on("child_changed", this.onChildChanged = this.handleSupportsUpdate("child_changed"));
+    this.supportsRef.on("child_added", this.onChildAdded = this.handleSupportsUpdate("child_added"));
   }
 
   public stop() {
     if (this.supportsRef) {
-      this.supportsRef.off("child_changed", this.handleSupportsUpdate);
-      this.supportsRef.off("child_added", this.handleSupportsUpdate);
+      this.debugLogHandlers("#stop", "removing", ["child_changed", "child_added"], this.supportsRef);
+      this.supportsRef.off("child_changed", this.onChildChanged);
+      this.supportsRef.off("child_added", this.onChildAdded);
     }
   }
 
-  private handleSupportsUpdate = (snapshot: firebase.database.DataSnapshot) => {
+  private handleSupportsUpdate = (eventType: string) => (snapshot: firebase.database.DataSnapshot) => {
     const {supports} = this.db.stores;
     const dbSupports = snapshot.val();
+    this.debugLogSnapshot("#handleSupportsUpdate", snapshot);
     // The top-level key will be the audience for with an updated support
     const audienceType: AudienceEnum = snapshot.ref.key as AudienceEnum;
     if (dbSupports) {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -23,6 +23,12 @@ import { TeacherSupportModelType, TeacherSupportSectionTarget, AudienceModelType
 import { safeJsonParse } from "../utilities/js-utils";
 import { find } from "lodash";
 
+export enum Monitor {
+  None = "None",
+  Local = "Local",
+  Remote = "Remote",
+}
+
 export type IDBConnectOptions = IDBAuthConnectOptions | IDBNonAuthConnectOptions;
 export interface IDBAuthConnectOptions {
   appMode: "authed";
@@ -308,13 +314,9 @@ export class DB {
           return found;
         })
         .then((problemDocument) => {
-          return this.createDocumentFromProblemDocument(user.id, problemDocument);
+          return this.createDocumentFromProblemDocument(user.id, problemDocument, Monitor.Local);
         })
-        .then((problemDocument) => {
-          this.listeners.updateGroupUserProblemDocumentListeners(problemDocument);
-          this.listeners.monitorDocumentVisibility(problemDocument);
-          resolve(problemDocument);
-        })
+        .then(resolve)
         .catch(reject);
     });
   }
@@ -579,7 +581,7 @@ export class DB {
 
   public createDocumentFromProblemDocument(userId: string,
                                            problemDocument: DBOfferingUserProblemDocument,
-                                           readOnly: boolean = false) {
+                                           monitor: Monitor) {
     const {documentKey} = problemDocument;
     const group = this.stores.groups.groupForUser(userId);
     return this.openDocument({
@@ -590,9 +592,16 @@ export class DB {
         visibility: problemDocument.visibility
       })
       .then((document) => {
-        this.listeners.monitorDocument(document, readOnly);
+        if (monitor !== Monitor.None) {
+          this.listeners.monitorDocument(document, monitor);
+        }
         return document;
       });
+  }
+
+  public updateDocumentFromProblemDocument(document: DocumentModelType,
+                                           problemDocument: DBOfferingUserProblemDocument) {
+    document.setVisibility(problemDocument.visibility);
   }
 
   // handles personal documents and learning logs
@@ -602,7 +611,7 @@ export class DB {
     const groupId = group && group.id;
     return this.openDocument({type, userId: uid, documentKey, groupId, title, properties})
       .then((documentModel) => {
-        this.listeners.monitorDocument(documentModel);
+        this.listeners.monitorDocument(documentModel, Monitor.Local);
         return documentModel;
       });
   }

--- a/src/lib/debug.ts
+++ b/src/lib/debug.ts
@@ -6,5 +6,6 @@ if (debug.length > 0) {
 
 const debugContains = (key: string) => debug.indexOf(key) !== -1;
 
+export const DEBUG_LISTENERS = debugContains("listeners");
 export const DEBUG_CANVAS = debugContains("canvas");
 export const DEBUG_LOGGER = debugContains("logger");

--- a/src/models/document/document.ts
+++ b/src/models/document/document.ts
@@ -122,6 +122,10 @@ export const DocumentModel = types
                           : visibility;
     },
 
+    setVisibility(visibility: "public" | "private") {
+      self.visibility = visibility;
+    },
+
     addTile(tool: DocumentTool, addSidecarNotes?: boolean) {
       return self.content.addTile(tool, addSidecarNotes);
     },

--- a/src/models/stores/groups.ts
+++ b/src/models/stores/groups.ts
@@ -86,6 +86,14 @@ export const GroupsModel = types
         return self.allGroups.find(group => group.id === id);
       }
     };
+  })
+  .views((self) => {
+    return {
+      userInGroup(uid: string, groupId?: string) {
+        const groupUser = self.groupForUser(uid);
+        return !!(groupId && groupUser && (groupUser.id === groupId));
+      }
+    };
   });
 
 export type GroupUserModelType = typeof GroupUserModel.Type;


### PR DESCRIPTION
With this change all problem document metadata is monitored but only the document content of those within a student's groups are monitored.