### PR TITLE
Update relay program name and relay program document organization

### DIFF
--- a/src/dataflow/app-config.json
+++ b/src/dataflow/app-config.json
@@ -34,7 +34,7 @@
           "dataTestHeader": "my-work-section",
           "dataTestItem": "my-work-list-items",
           "documentTypes": ["personal"],
-          "properties": ["!dfRunId"]
+          "properties": ["!dfHasData"]
         },
         {
           "title": "Data",
@@ -42,7 +42,7 @@
           "dataTestHeader": "my-work-section",
           "dataTestItem": "my-work-list-items",
           "documentTypes": ["personal"],
-          "properties": ["dfRunId"]
+          "properties": ["dfHasData"]
         }
       ]
     },
@@ -57,7 +57,7 @@
           "dataTestHeader": "class-work-section",
           "dataTestItem": "class-work-list-items",
           "documentTypes": ["personalPublication"],
-          "properties": ["!dfRunId"]
+          "properties": ["!dfHasData"]
         },
         {
           "className": "section personal published",
@@ -66,7 +66,7 @@
           "dataTestHeader": "class-work-section",
           "dataTestItem": "class-work-list-items",
           "documentTypes": ["personalPublication"],
-          "properties": ["dfRunId"]
+          "properties": ["dfHasData"]
         }
       ]
     }

--- a/src/dataflow/components/tools/dataflow-tool.tsx
+++ b/src/dataflow/components/tools/dataflow-tool.tsx
@@ -10,6 +10,7 @@ import { DataflowProgram } from "../dataflow-program";
 import { cloneDeep } from "lodash";
 import { SizeMe, SizeMeProps } from "react-sizeme";
 import "./dataflow-tool.sass";
+import { IOtherDocumentProperties } from "../../../lib/db-types";
 
 interface IProps {
   model: ToolTileModelType;
@@ -63,7 +64,7 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IState>
     );
   }
 
-  private handleStartProgram = async (title: string, id: string, startTime: number, endTime: number) => {
+  private handleStartProgram = async (datasetName: string, id: string, startTime: number, endTime: number) => {
     const {documents, db, ui} = this.stores;
     const {problemWorkspace} = ui;
     // get the currently loaded document, we're going to spawn a new document based on it
@@ -82,11 +83,15 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IState>
             programContent.setProgramStartEndTime(startTime, endTime);
           }
         });
-
+        const properties: IOtherDocumentProperties = { dfRunId: id };
+        if (datasetName.length > 0) {
+          const dataProp = "dfHasData";
+          properties[dataProp] = "true";
+        }
         // create and load the new document
         const params: ICreateOtherDocumentParams = {
-                title: title || id,
-                properties: { dfRunId: id },
+                title: datasetName || `${primaryDocument.title}-${Date.now()}` ,
+                properties,
                 content: JSON.parse(documentContent.publish())
               };
         const newPersonalDocument = await db.createPersonalDocument(params);

--- a/src/dataflow/components/tools/dataflow-tool.tsx
+++ b/src/dataflow/components/tools/dataflow-tool.tsx
@@ -85,8 +85,7 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IState>
         });
         const properties: IOtherDocumentProperties = { dfRunId: id };
         if (datasetName.length > 0) {
-          const dataProp = "dfHasData";
-          properties[dataProp] = "true";
+          properties.dfHasData = "true";
         }
         // create and load the new document
         const params: ICreateOtherDocumentParams = {


### PR DESCRIPTION
Minor changes to facilitate running and complete program documents that do not have a data storage block:
- update the document title 
- show all running and completed programs that do not have a data storage block in the program list using a new `dfHasData` property that can be used to distinguish between programs (editable programs, running programs with no data storage, completed programs with no data storage) and data (all programs that have an associated dataset).