### PR TITLE
Added desktop and data uri image drag/drop [#163658625]

### DIFF
--- a/src/components/document/document-content.tsx
+++ b/src/components/document/document-content.tsx
@@ -359,8 +359,8 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
 
     const isInsertingInExistingRow = insertRowInfo && insertRowInfo.rowDropLocation &&
                                       (["left", "right"].indexOf(insertRowInfo.rowDropLocation) >= 0);
-    const createSideCar = (createTileType === "geometry") && !isInsertingInExistingRow;
-    const rowTile = content.addTile(createTileType, createSideCar, insertRowInfo);
+    const addSidecarNotes = (createTileType === "geometry") && !isInsertingInExistingRow;
+    const rowTile = content.addTile(createTileType, {addSidecarNotes, insertRowInfo});
 
     if (rowTile && rowTile.tileId) {
       ui.setSelectedTileId(rowTile.tileId);

--- a/src/components/document/document-workspace.sass
+++ b/src/components/document/document-workspace.sass
@@ -1,11 +1,13 @@
 @import ../../components/vars
 
 .document-workspace
-  position: absolute
-  top: 0
-  left: 0
-  right: 0
-  bottom: 0
+
+  .drag-handler
+    position: absolute
+    top: 0
+    left: 0
+    right: 0
+    bottom: 0
 
   .single-workspace
     position: absolute

--- a/src/components/document/document-workspace.sass
+++ b/src/components/document/document-workspace.sass
@@ -4,7 +4,7 @@
 
   .drag-handler
     position: absolute
-    top: 0
+    top: $header-height
     left: 0
     right: 0
     bottom: 0

--- a/src/components/document/document-workspace.sass
+++ b/src/components/document/document-workspace.sass
@@ -1,6 +1,11 @@
 @import ../../components/vars
 
 .document-workspace
+  position: absolute
+  top: 0
+  left: 0
+  right: 0
+  bottom: 0
 
   .single-workspace
     position: absolute

--- a/src/components/document/document-workspace.tsx
+++ b/src/components/document/document-workspace.tsx
@@ -158,9 +158,7 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps, {}> {
 
   private isAcceptableImageDrag = (e: React.DragEvent<HTMLDivElement>) => {
     // make sure we have a primary document to drop onto
-    const {ui: {problemWorkspace}} = this.stores;
-    const primaryDocument = this.getPrimaryDocument(problemWorkspace.primaryDocumentKey);
-    return !!primaryDocument;
+    return !!this.getPrimaryDocument(this.stores.ui.problemWorkspace.primaryDocumentKey);
   }
 
   private handleDragOverWorkspace = (e: React.DragEvent<HTMLDivElement>) => {
@@ -210,10 +208,10 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps, {}> {
         if (primaryDocument) {
           const rowIndex = rowId ? primaryDocument.content.getRowIndex(rowId) : undefined;
           primaryDocument.content.addTile("image", {
-            imageTileUrl: dropUrl,
+            imageUrl: dropUrl,
             insertRowInfo: {
-              // insert the tile after the row it was dropped on
-              rowInsertIndex: (rowIndex ? rowIndex + 1 : 0)
+              // insert the tile after the row it was dropped on otherwise add to end of document
+              rowInsertIndex: (rowIndex ? rowIndex + 1 : primaryDocument.content.rowOrder.length)
             }
           });
         }

--- a/src/components/document/document-workspace.tsx
+++ b/src/components/document/document-workspace.tsx
@@ -217,16 +217,16 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps, {}> {
   private handleImageDrop = (e: React.DragEvent<HTMLDivElement>, rowId?: string) => {
     const {ui} = this.stores;
     this.imageDragDrop.drop(e)
-      .then((dropUrl) => {
-        const {problemWorkspace} = ui;
-        const primaryDocument = this.getPrimaryDocument(problemWorkspace.primaryDocumentKey);
+      .then((imageUrl) => {
+        const primaryDocument = this.getPrimaryDocument(ui.problemWorkspace.primaryDocumentKey);
         if (primaryDocument) {
+          // insert the tile after the row it was dropped on otherwise add to end of document
           const rowIndex = rowId ? primaryDocument.content.getRowIndex(rowId) : undefined;
+          const rowInsertIndex = (rowIndex !== undefined ? rowIndex + 1 : primaryDocument.content.rowOrder.length);
           primaryDocument.content.addTile("image", {
-            imageUrl: dropUrl,
+            imageUrl,
             insertRowInfo: {
-              // insert the tile after the row it was dropped on otherwise add to end of document
-              rowInsertIndex: (rowIndex ? rowIndex + 1 : primaryDocument.content.rowOrder.length)
+              rowInsertIndex
             }
           });
         }

--- a/src/components/document/document-workspace.tsx
+++ b/src/components/document/document-workspace.tsx
@@ -43,15 +43,30 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps, {}> {
   public render() {
     const { appConfig } = this.stores;
     const isGhostUser = this.props.isGhostUser;
+    // NOTE: the drag handlers are in three different divs because we cannot overlay
+    // the renderDocuments() div otherwise the Cypress tests will fail because none
+    // of the html elements in the documents will be visible to it.  The first div acts
+    // as a handler for the background and the left and right nav then delegate dragging
+    // and dropping to the same functions
     return (
-      <div
-        className="document-workspace"
-        onDragOver={this.handleDragOverWorkspace}
-        onDrop={this.handleImageDrop}
-      >
+      <div className="document-workspace">
+        <div
+          className="drag-handler"
+          onDragOver={this.handleDragOverWorkspace}
+          onDrop={this.handleImageDrop}
+        />
         {this.renderDocuments(isGhostUser)}
-        <LeftNavComponent isGhostUser={isGhostUser} />
-        <RightNavComponent tabs={appConfig.rightNavTabs} isGhostUser={isGhostUser} />
+        <LeftNavComponent
+          isGhostUser={isGhostUser}
+          onDragOver={this.handleDragOverWorkspace}
+          onDrop={this.handleImageDrop}
+        />
+        <RightNavComponent
+          tabs={appConfig.rightNavTabs}
+          isGhostUser={isGhostUser}
+          onDragOver={this.handleDragOverWorkspace}
+          onDrop={this.handleImageDrop}
+        />
       </div>
     );
   }

--- a/src/components/document/document-workspace.tsx
+++ b/src/components/document/document-workspace.tsx
@@ -190,20 +190,31 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps, {}> {
         }
       }
       else {
-        this.handleImageDrop(e);
+        // try to get the row it was dropped on
+        let rowNode = e.target as HTMLElement | null;
+        while (rowNode && (rowNode.className !== "tile-row")) {
+          rowNode = rowNode.parentNode as HTMLElement | null;
+        }
+        const rowId = (rowNode && rowNode.dataset && rowNode.dataset.rowId) || undefined;
+        this.handleImageDrop(e, rowId);
       }
     };
   }
 
-  private handleImageDrop = (e: React.DragEvent<HTMLDivElement>) => {
+  private handleImageDrop = (e: React.DragEvent<HTMLDivElement>, rowId?: string) => {
     const {ui} = this.stores;
     this.imageDragDrop.drop(e)
       .then((dropUrl) => {
         const {problemWorkspace} = ui;
         const primaryDocument = this.getPrimaryDocument(problemWorkspace.primaryDocumentKey);
         if (primaryDocument) {
-          primaryDocument.addTile("image", {
-            imageTileUrl: dropUrl
+          const rowIndex = rowId ? primaryDocument.content.getRowIndex(rowId) : undefined;
+          primaryDocument.content.addTile("image", {
+            imageTileUrl: dropUrl,
+            insertRowInfo: {
+              // insert the tile after the row it was dropped on
+              rowInsertIndex: (rowIndex ? rowIndex + 1 : 0)
+            }
           });
         }
       })

--- a/src/components/document/document-workspace.tsx
+++ b/src/components/document/document-workspace.tsx
@@ -9,6 +9,7 @@ import { DocumentDragKey, DocumentModel, DocumentModelType, LearningLogDocument,
          PersonalDocument, ProblemDocument, PublicationDocument, PersonalPublication, LearningLogPublication,
          SupportPublication } from "../../models/document/document";
 import { parseGhostSectionDocumentKey } from "../../models/stores/workspace";
+import { ImageDragDrop } from "../utilities/image-drag-drop";
 
 import "./document-workspace.sass";
 
@@ -27,6 +28,13 @@ const ghostProblemDocuments: GhostDocumentMap = {};
 @inject("stores")
 @observer
 export class DocumentWorkspaceComponent extends BaseComponent<IProps, {}> {
+  private imageDragDrop: ImageDragDrop;
+
+  public componentWillMount() {
+    this.imageDragDrop = new ImageDragDrop({
+      isAcceptableImageDrag: this.isAcceptableImageDrag
+    });
+  }
 
   public componentDidMount() {
     this.guaranteePrimaryDocument();
@@ -36,7 +44,11 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps, {}> {
     const { appConfig } = this.stores;
     const isGhostUser = this.props.isGhostUser;
     return (
-      <div className="document-workspace">
+      <div
+        className="document-workspace"
+        onDragOver={this.handleDragOverWorkspace}
+        onDrop={this.handleImageDrop}
+      >
         {this.renderDocuments(isGhostUser)}
         <LeftNavComponent isGhostUser={isGhostUser} />
         <RightNavComponent tabs={appConfig.rightNavTabs} isGhostUser={isGhostUser} />
@@ -122,8 +134,8 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps, {}> {
       <div
         className={className}
         style={style}
-        onDragOver={this.handleDragOver}
-        onDrop={this.handleDrop(side)}
+        onDragOver={this.handleDragOverSide}
+        onDrop={this.handleDropSide(side)}
         onClick={this.handleClick}
       >
         {child}
@@ -135,8 +147,8 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps, {}> {
     return (
       <div
         className="comparison-placeholder"
-        onDragOver={(this.handleDragOver)}
-        onDrop={this.handleDrop("comparison")}
+        onDragOver={(this.handleDragOverSide)}
+        onDrop={this.handleDropSide("comparison")}
         onClick={this.handleClick}
       >
         Click or drag an item in the right tabs to show it here
@@ -144,27 +156,60 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps, {}> {
     );
   }
 
-  private handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
-    if (e.dataTransfer.types.find((type) => type === DocumentDragKey)) {
+  private isAcceptableImageDrag = (e: React.DragEvent<HTMLDivElement>) => {
+    // make sure we have a primary document to drop onto
+    const {ui: {problemWorkspace}} = this.stores;
+    const primaryDocument = this.getPrimaryDocument(problemWorkspace.primaryDocumentKey);
+    return !!primaryDocument;
+  }
+
+  private handleDragOverWorkspace = (e: React.DragEvent<HTMLDivElement>) => {
+    this.imageDragDrop.dragOver(e);
+  }
+
+  private handleDragOverSide = (e: React.DragEvent<HTMLDivElement>) => {
+    if (this.imageDragDrop.dragOver(e) || e.dataTransfer.types.find((type) => type === DocumentDragKey)) {
       e.preventDefault();
     }
   }
 
-  private handleDrop = (side: WorkspaceSide) => {
+  private handleDropSide = (side: WorkspaceSide) => {
     return (e: React.DragEvent<HTMLDivElement>) => {
       const {ui, documents} = this.stores;
-      const {problemWorkspace} = ui;
       const documentKey = e.dataTransfer && e.dataTransfer.getData(DocumentDragKey);
-      const document = documentKey ? documents.getDocument(documentKey) : null;
-      if (document) {
-        if (side === "primary") {
-          problemWorkspace.setPrimaryDocument(document);
-        }
-        else {
-          problemWorkspace.setComparisonDocument(document);
+      if (documentKey) {
+        const {problemWorkspace} = ui;
+        const document = documents.getDocument(documentKey);
+        if (document) {
+          if (side === "primary") {
+            problemWorkspace.setPrimaryDocument(document);
+          }
+          else {
+            problemWorkspace.setComparisonDocument(document);
+          }
         }
       }
+      else {
+        this.handleImageDrop(e);
+      }
     };
+  }
+
+  private handleImageDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    const {ui} = this.stores;
+    this.imageDragDrop.drop(e)
+      .then((dropUrl) => {
+        const {problemWorkspace} = ui;
+        const primaryDocument = this.getPrimaryDocument(problemWorkspace.primaryDocumentKey);
+        if (primaryDocument) {
+          primaryDocument.addTile("image", {
+            imageTileUrl: dropUrl
+          });
+        }
+      })
+      .catch((err) => {
+        ui.alert(err.toString());
+      });
   }
 
   private handleClick = (e: React.MouseEvent<HTMLDivElement>) => {

--- a/src/components/navigation/left-nav.tsx
+++ b/src/components/navigation/left-nav.tsx
@@ -10,6 +10,8 @@ import "./left-nav.sass";
 
 interface IProps extends IBaseProps {
   isGhostUser: boolean;
+  onDragOver: (e: React.DragEvent<HTMLDivElement>) => void;
+  onDrop: (e: React.DragEvent<HTMLDivElement>) => void;
 }
 
 interface IState {
@@ -28,13 +30,14 @@ export class LeftNavComponent extends BaseComponent<IProps, IState> {
   }
 
   public render() {
+    const { onDragOver, onDrop } = this.props;
     const { problem, ui } = this.stores;
     const { activeSectionIndex, leftNavExpanded } = ui;
     const { sections } = problem;
     const outerClassName = `left-nav${leftNavExpanded ? " expanded" : ""}`;
     const expandedAreaClassName = `expanded-area${leftNavExpanded ? " expanded" : ""}`;
     return (
-      <div className={outerClassName}>
+      <div className={outerClassName} onDragOver={onDragOver} onDrop={onDrop}>
         <TabSetComponent>
           {sections.map((section, sectionIndex) => {
             return (

--- a/src/components/navigation/right-nav.tsx
+++ b/src/components/navigation/right-nav.tsx
@@ -31,6 +31,8 @@ export const SupportsComponent = () => {
 interface IProps extends IBaseProps {
   tabs?: RightNavTabSpec[];
   isGhostUser: boolean;
+  onDragOver: (e: React.DragEvent<HTMLDivElement>) => void;
+  onDrop: (e: React.DragEvent<HTMLDivElement>) => void;
 }
 
 interface IState {
@@ -74,12 +76,13 @@ export class RightNavComponent extends BaseComponent<IProps, IState> {
   }
 
   public render() {
+    const {onDragOver, onDrop} = this.props;
     const {activeRightNavTab, rightNavExpanded} = this.stores.ui;
     const tabSpecs = this.props.tabs && this.props.tabs
                       .filter(tabSpec => !(this.props.isGhostUser && tabSpec.hideGhostUser));
     if (!tabSpecs || !tabSpecs.length) return null;
     return (
-      <div className="right-nav">
+      <div className="right-nav" onDragOver={onDragOver} onDrop={onDrop}>
         <TabSetComponent className={rightNavExpanded ? "expanded" : undefined}>
           {tabSpecs.map(spec => {
             return (

--- a/src/components/toolbar.tsx
+++ b/src/components/toolbar.tsx
@@ -99,7 +99,7 @@ export class ToolbarComponent extends BaseComponent<IProps, {}> {
   private handleAddToolTile(tool: DocumentTool) {
     const { document } = this.props;
     const { ui } = this.stores;
-    const rowTile = document.addTile(tool, tool === "geometry");
+    const rowTile = document.addTile(tool, {addSidecarNotes: tool === "geometry"});
     if (rowTile && rowTile.tileId) {
       ui.setSelectedTileId(rowTile.tileId);
     }

--- a/src/components/tools/image-tool.tsx
+++ b/src/components/tools/image-tool.tsx
@@ -104,8 +104,8 @@ export default class ImageToolComponent extends BaseComponent<IProps, IState> {
     const { ui } = this.stores;
 
     const contentUrl = this.getContent().url;
-    const isExternalUrl = gImageMap.isExternalUrl(contentUrl);
-    const editableUrl = isExternalUrl ? contentUrl : undefined;
+    const isEditableUrl = gImageMap.isExternalUrl(contentUrl) && !gImageMap.isDataImageUrl(contentUrl);
+    const editableUrl = isEditableUrl ? contentUrl : undefined;
 
     // Include states for selected and editing separately to clean up UI a little
     const editableClass = readOnly ? "read-only" : "editable";

--- a/src/components/utilities/image-drag-drop.ts
+++ b/src/components/utilities/image-drag-drop.ts
@@ -12,6 +12,11 @@ export class ImageDragDrop {
   }
 
   public dragOver(e: React.DragEvent<HTMLDivElement>) {
+    // the cypress tests generate drag events without the dataTransfer element of the event
+    if (this.hasMissingDataTransfer(e)) {
+      return false;
+    }
+
     const isAcceptableDrag = this.checkForAcceptableImageDrag(e);
     if (isAcceptableDrag) {
       e.dataTransfer.dropEffect = "copy";
@@ -23,6 +28,11 @@ export class ImageDragDrop {
 
   public drop(e: React.DragEvent<HTMLDivElement>) {
     return new Promise<string>((resolve, reject) => {
+      // the cypress tests generate drag events without the dataTransfer element of the event
+      if (this.hasMissingDataTransfer(e)) {
+        return;
+      }
+
       if (this.checkForAcceptableImageDrag(e)) {
         e.preventDefault();
         e.stopPropagation();
@@ -82,5 +92,9 @@ export class ImageDragDrop {
 
   private hasFileList(e: React.DragEvent<HTMLDivElement>) {
     return e.dataTransfer.types.indexOf("Files") >= 0;
+  }
+
+  private hasMissingDataTransfer(e: React.DragEvent<HTMLDivElement>) {
+    return !e.dataTransfer;
   }
 }

--- a/src/components/utilities/image-drag-drop.ts
+++ b/src/components/utilities/image-drag-drop.ts
@@ -1,0 +1,86 @@
+import { DocumentDragKey } from "../../models/document/document";
+
+export interface ExternalImageDragDropOptions {
+  isAcceptableImageDrag?: (e: React.DragEvent<HTMLDivElement>) => boolean;
+}
+
+export class ImageDragDrop {
+  private options: ExternalImageDragDropOptions;
+
+  constructor(options: ExternalImageDragDropOptions) {
+    this.options = options;
+  }
+
+  public dragOver(e: React.DragEvent<HTMLDivElement>) {
+    const isAcceptableDrag = this.checkForAcceptableImageDrag(e);
+    if (isAcceptableDrag) {
+      e.dataTransfer.dropEffect = "copy";
+      e.preventDefault();
+      return true;
+    }
+    return false;
+  }
+
+  public drop(e: React.DragEvent<HTMLDivElement>) {
+    return new Promise<string>((resolve, reject) => {
+      if (this.checkForAcceptableImageDrag(e)) {
+        e.preventDefault();
+        e.stopPropagation();
+        if (this.hasUriList(e)) {
+          const uriList = e.dataTransfer.getData("text/uri-list");
+          const uriArray = uriList && uriList.split(/[\r\n]+/);
+          const dropUrl = uriArray && uriArray[0];
+          if (dropUrl) {
+            resolve(dropUrl);
+          } else {
+            reject("No url found for dropped image");
+          }
+        } else if (this.hasFileList(e)) {
+          const file = e.dataTransfer.files[0];
+          if (file) {
+            if (/^image\//.test(file.type)) {
+              const reader = new FileReader();
+              reader.onload = (readerEvent) => {
+                const dropUrl = readerEvent.target && readerEvent.target.result;
+                if (dropUrl) {
+                  resolve(dropUrl.toString());
+                } else {
+                  reject("No url found for dropped image file");
+                }
+              };
+              reader.onerror = () => {
+                reject("Unable to read dropped image file");
+                reader.abort();
+              };
+              reader.readAsDataURL(file);
+            }
+            else {
+              reject("Only image files are allowed to be dropped");
+            }
+          } else {
+            reject("No file found for dropped image");
+          }
+        }
+      }
+      else {
+        const isInternalDrag = !!e.dataTransfer.types.find((type) => /org\.concord\.clue\./.test(DocumentDragKey));
+        if (!isInternalDrag) {
+          reject("Only images are allowed to be dropped");
+        }
+      }
+    });
+  }
+
+  private checkForAcceptableImageDrag(e: React.DragEvent<HTMLDivElement>) {
+    const acceptableByClient = !this.options.isAcceptableImageDrag || this.options.isAcceptableImageDrag(e);
+    return (this.hasUriList(e) || this.hasFileList(e)) && acceptableByClient;
+  }
+
+  private hasUriList(e: React.DragEvent<HTMLDivElement>) {
+    return e.dataTransfer.types.indexOf("text/uri-list") >= 0;
+  }
+
+  private hasFileList(e: React.DragEvent<HTMLDivElement>) {
+    return e.dataTransfer.types.indexOf("Files") >= 0;
+  }
+}

--- a/src/models/document/document-content.test.ts
+++ b/src/models/document/document-content.test.ts
@@ -12,7 +12,9 @@ describe("document-content model", () => {
     documentContent.addTile("text");
     expect(documentContent.tileMap.size).toBe(1);
     // adding geometry tool adds sidecar text tool
-    documentContent.addTile("geometry", true);
+    documentContent.addTile("geometry", {
+      addSidecarNotes: true
+    });
     expect(documentContent.tileMap.size).toBe(3);
   });
 
@@ -26,10 +28,13 @@ describe("document-content model", () => {
     expect(textTile2RowIndex1).toBe(1);
 
     // insert image between text tiles
-    const imageTile1 = documentContent.addTile("image", false, {
-      rowInsertIndex: 1,
-      rowDropIndex: 1,
-      rowDropLocation: "bottom"
+    const imageTile1 = documentContent.addTile("image", {
+      addSidecarNotes: false,
+      insertRowInfo: {
+        rowInsertIndex: 1,
+        rowDropIndex: 1,
+        rowDropLocation: "bottom"
+      }
     });
 
     const imageTile1rowId = documentContent.findRowContainingTile(imageTile1!.tileId);
@@ -44,10 +49,13 @@ describe("document-content model", () => {
     expect(textTile2RowIndex1).toBe(2);
 
     // insert image at bottom
-    const imageTile2 = documentContent.addTile("image", false, {
-      rowInsertIndex: 3,
-      rowDropIndex: 3,
-      rowDropLocation: "bottom"
+    const imageTile2 = documentContent.addTile("image", {
+      addSidecarNotes: false,
+      insertRowInfo: {
+        rowInsertIndex: 3,
+        rowDropIndex: 3,
+        rowDropLocation: "bottom"
+      }
     });
 
     const rowId2 = documentContent.findRowContainingTile(imageTile2!.tileId);
@@ -65,10 +73,13 @@ describe("document-content model", () => {
 
     expect(textTile2RowIndex1).toBe(1);
 
-    const imageTile1 = documentContent.addTile("image", false, {
-      rowInsertIndex: 1,
-      rowDropIndex: 1,
-      rowDropLocation: "left"
+    const imageTile1 = documentContent.addTile("image", {
+      addSidecarNotes: false,
+      insertRowInfo: {
+        rowInsertIndex: 1,
+        rowDropIndex: 1,
+        rowDropLocation: "left"
+      }
     });
 
     const imageTile1rowId = documentContent.findRowContainingTile(imageTile1!.tileId);
@@ -87,10 +98,13 @@ describe("document-content model", () => {
     documentContent.addTile("text");
     const textTile2 = documentContent.addTile("text");
 
-    const graphTileInfo = documentContent.addTile("geometry", true, {
-      rowInsertIndex: 1,
-      rowDropIndex: 1,
-      rowDropLocation: "bottom"
+    const graphTileInfo = documentContent.addTile("geometry", {
+      addSidecarNotes: true,
+      insertRowInfo: {
+        rowInsertIndex: 1,
+        rowDropIndex: 1,
+        rowDropLocation: "bottom"
+      }
     });
 
     const geometryRowId = documentContent.findRowContainingTile(graphTileInfo!.tileId);
@@ -117,10 +131,13 @@ describe("document-content model", () => {
     documentContent.addTile("text");
     const textTile2 = documentContent.addTile("text");
 
-    const graphTileInfo = documentContent.addTile("geometry", true, {
-      rowInsertIndex: 1,
-      rowDropIndex: 1,
-      rowDropLocation: "left"
+    const graphTileInfo = documentContent.addTile("geometry", {
+      addSidecarNotes: true,
+      insertRowInfo: {
+        rowInsertIndex: 1,
+        rowDropIndex: 1,
+        rowDropLocation: "left"
+      }
     });
 
     const geometryRowId = documentContent.findRowContainingTile(graphTileInfo!.tileId);

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -80,6 +80,9 @@ export const DocumentContentModel = types
       getRowByIndex(index: number) {
         return self.rowMap.get(self.rowOrder[index]);
       },
+      getRowIndex(rowId: string) {
+        return self.rowOrder.findIndex(_rowId => _rowId === rowId);
+      },
       findRowContainingTile(tileId: string) {
         return self.rowOrder.find(rowId => rowContainsTile(rowId, tileId));
       },
@@ -340,7 +343,7 @@ export const DocumentContentModel = types
     moveTile(tileId: string, rowInfo: IDropRowInfo) {
       const srcRowId = self.findRowContainingTile(tileId);
       if (!srcRowId) return;
-      const srcRowIndex = self.rowOrder.findIndex(rowId => rowId === srcRowId);
+      const srcRowIndex = self.getRowIndex(srcRowId);
       const { rowInsertIndex, rowDropIndex, rowDropLocation } = rowInfo;
       if ((rowDropIndex != null) && (rowDropLocation === "left")) {
         self.moveTileToRow(tileId, rowDropIndex, 0);

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -381,7 +381,7 @@ export const DocumentContentModel = types
           tileInfo = self.addGeometryTile(addSidecarNotes);
           break;
         case "image":
-          tileInfo = self.addImageTile(options && options.imageTileUrl);
+          tileInfo = self.addImageTile(options && options.imageUrl);
           break;
         case "drawing":
           tileInfo = self.addDrawingTile();

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -15,7 +15,7 @@ import { Logger, LogEventName } from "../../lib/logger";
 import { DocumentsModelType } from "../stores/documents";
 import { getParentWithTypeName } from "../../utilities/mst-utils";
 import { IDropRowInfo } from "../../components/document/document-content";
-import { DocumentTool } from "./document";
+import { DocumentTool, IDocumentAddTileOptions } from "./document";
 
 export interface NewRowOptions {
   rowHeight?: number;
@@ -28,6 +28,10 @@ export interface INewRowTile {
   rowId: string;
   tileId: string;
   additionalTileIds?: string[];
+}
+
+export interface IDocumentContentAddTileOptions extends IDocumentAddTileOptions {
+  insertRowInfo?: IDropRowInfo;
 }
 
 export const DocumentContentModel = types
@@ -214,8 +218,8 @@ export const DocumentContentModel = types
     addTextTile(initialText?: string) {
       return self.addTileInNewRow(defaultTextContent(initialText));
     },
-    addImageTile() {
-      return self.addTileInNewRow(defaultImageContent());
+    addImageTile(url?: string) {
+      return self.addTileInNewRow(defaultImageContent(url));
     },
     addDrawingTile() {
       let defaultStamps: StampModelType[];
@@ -360,7 +364,8 @@ export const DocumentContentModel = types
     }
   }))
   .actions((self) => ({
-    addTile(tool: DocumentTool, addSidecarNotes?: boolean, insertRowInfo?: IDropRowInfo) {
+    addTile(tool: DocumentTool, options?: IDocumentContentAddTileOptions) {
+      const {addSidecarNotes, insertRowInfo} = options || {};
       let tileInfo;
       switch (tool) {
         case "text":
@@ -373,7 +378,7 @@ export const DocumentContentModel = types
           tileInfo = self.addGeometryTile(addSidecarNotes);
           break;
         case "image":
-          tileInfo = self.addImageTile();
+          tileInfo = self.addImageTile(options && options.imageTileUrl);
           break;
         case "drawing":
           tileInfo = self.addDrawingTile();

--- a/src/models/document/document.test.ts
+++ b/src/models/document/document.test.ts
@@ -62,7 +62,7 @@ describe("document model", () => {
     document.addTile("text");
     expect(document.content.tileMap.size).toBe(1);
     // adding geometry tool adds sidecar text tool
-    document.addTile("geometry", true);
+    document.addTile("geometry", {addSidecarNotes: true});
     expect(document.content.tileMap.size).toBe(3);
   });
 

--- a/src/models/document/document.ts
+++ b/src/models/document/document.ts
@@ -44,7 +44,7 @@ export type OtherPublicationType = typeof PersonalPublication | typeof LearningL
 
 export interface IDocumentAddTileOptions {
   addSidecarNotes?: boolean;
-  imageTileUrl?: string;
+  imageUrl?: string;
 }
 
 export const DocumentToolEnum = types.enumeration("tool",

--- a/src/models/document/document.ts
+++ b/src/models/document/document.ts
@@ -42,6 +42,11 @@ export type DocumentType = typeof DocumentTypeEnum.Type;
 export type OtherDocumentType = typeof PersonalDocument | typeof LearningLogDocument;
 export type OtherPublicationType = typeof PersonalPublication | typeof LearningLogPublication;
 
+export interface IDocumentAddTileOptions {
+  addSidecarNotes?: boolean;
+  imageTileUrl?: string;
+}
+
 export const DocumentToolEnum = types.enumeration("tool",
                                   ["delete", "drawing", "geometry", "image", "select", "table", "text"]);
 export type DocumentTool = typeof DocumentToolEnum.Type;
@@ -122,8 +127,8 @@ export const DocumentModel = types
                           : visibility;
     },
 
-    addTile(tool: DocumentTool, addSidecarNotes?: boolean) {
-      return self.content.addTile(tool, addSidecarNotes);
+    addTile(tool: DocumentTool, options?: IDocumentAddTileOptions) {
+      return self.content.addTile(tool, options);
     },
 
     deleteTile(tileId: string) {

--- a/src/models/image-map.test.ts
+++ b/src/models/image-map.test.ts
@@ -26,11 +26,11 @@ describe("ImageMap", () => {
   const kBlobUrl = "blob://some-blob-path";
   const kDataUri = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAIAAABMXPacAAABG2lUWH";
   const kInputs = [ kLocalImage, kHttpImage, kHttpsImage, kFBStorageUrl, kFBStorageRef,
-                    kCCImgOriginal, kCCImgFBRTDB, kCCImgS3, kBlobUrl, kDataUri ];
+                    kCCImgOriginal, kCCImgFBRTDB, kDataUri, kCCImgS3, kBlobUrl];
   const kHandlers = [ localAssetsImagesHandler, externalUrlImagesHandler, externalUrlImagesHandler,
                       firebaseStorageImagesHandler, firebaseStorageImagesHandler,
                       firebaseRealTimeDBImagesHandler, firebaseRealTimeDBImagesHandler,
-                      undefined, undefined, undefined];
+                      externalUrlImagesHandler, undefined, undefined ];
   function expectToMatch(handler: IImageHandler, matches: string[]) {
     expect(kInputs.every((input, index) => {
       const didMatch = handler.match(input);
@@ -54,7 +54,7 @@ describe("ImageMap", () => {
   });
 
   it("test externalUrlImagesHandler", () => {
-    expectToMatch(externalUrlImagesHandler, [kHttpImage, kHttpsImage, kFBStorageUrl]);
+    expectToMatch(externalUrlImagesHandler, [kHttpImage, kHttpsImage, kFBStorageUrl, kDataUri]);
 
     let p1: any;
     let p2: any;

--- a/src/models/image-map.ts
+++ b/src/models/image-map.ts
@@ -190,7 +190,7 @@ export const externalUrlImagesHandler: IImageHandler = {
   priority: 1,
 
   match(url: string) {
-    return url ? /^https?:\/\//.test(url) : false;
+    return url ? /^(https?:\/\/|data:image\/)/.test(url) : false;
   },
 
   store(url: string, db: DB, userId: string) {

--- a/src/models/image-map.ts
+++ b/src/models/image-map.ts
@@ -49,6 +49,9 @@ export const ImageMapModel = types
       return (index >= 0) &&
               (self.handlers[index].name === kExternalUrlHandlerName);
     },
+    isDataImageUrl(url: string) {
+      return /data:image\//.test(url);
+    },
     isPlaceholder(url: string) {
       return url === placeholderImage;
     },

--- a/src/models/tools/image/image-content.ts
+++ b/src/models/tools/image/image-content.ts
@@ -11,10 +11,10 @@ export interface ImageToolChange {
   url: string;
 }
 
-export function defaultImageContent() {
+export function defaultImageContent(url?: string) {
   const change = JSON.stringify({
                   operation: "update",
-                  url: placeholderImage
+                  url: url || placeholderImage
                 });
   return ImageContentModel.create({
                             type: "Image",


### PR DESCRIPTION
Extracted image drag/drop handling from image-tool component to utility library so it could also be used in the document workspace component.

In addition to extracting the existing code new code was added to handle drop/drops of image files and image data uris.

To enable drops anywhere in the workspace styling was added to the workspace component so that it overlays the entire page.