### PR TITLE
[#168771354] Placeholder Text in Text Regions from Units

### DIFF
--- a/src/assets/curriculum/moving-straight-ahead/moving-straight-ahead.json
+++ b/src/assets/curriculum/moving-straight-ahead/moving-straight-ahead.json
@@ -3,6 +3,7 @@
   "abbrevTitle": "MSA",
   "title": "Moving Straight Ahead",
   "subtitle": "Linear Expressions, Equations, and Relationships",
+  "placeholderText": "Enter notes here",
   "defaultStamps": [
     {
       "url": "assets/tools/drawing-tool/stamps/coin.png",

--- a/src/assets/curriculum/stretching-and-shrinking/stretching-and-shrinking.json
+++ b/src/assets/curriculum/stretching-and-shrinking/stretching-and-shrinking.json
@@ -3,6 +3,7 @@
   "abbrevTitle": "S & S",
   "title": "Stretching and Shrinking",
   "subtitle": "Understanding Similarity",
+  "placeholderText": "Enter notes here",
   "lookingAhead": {
     "tiles": [
       {

--- a/src/assets/curriculum/unit-template.json
+++ b/src/assets/curriculum/unit-template.json
@@ -1,6 +1,7 @@
 {
   "title": "Moving Straight Ahead",
   "subtitle": "Linear Expressions, Equations, and Relationships",
+  "placeholderText": "Enter notes here",
   "lookingAhead": {
     "tiles": []
   },

--- a/src/components/tools/text-tool.tsx
+++ b/src/components/tools/text-tool.tsx
@@ -89,6 +89,7 @@ export default class TextToolComponent extends BaseComponent<IProps, IState> {
 
   public render() {
     const { model, readOnly } = this.props;
+    const { unit: { placeholderText } } = this.stores;
     const editableClass = readOnly ? "read-only" : "editable";
     const classes = `text-tool ${editableClass}`;
     if (!this.state.value) { return null; }
@@ -96,6 +97,7 @@ export default class TextToolComponent extends BaseComponent<IProps, IState> {
       <Editor
         key={model.id}
         className={classes}
+        placeholder={placeholderText}
         readOnly={readOnly}
         value={this.state.value}
         onChange={this.onChange}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -28,7 +28,7 @@ const initializeApp = async () => {
 
   const user = UserModel.create();
 
-  const unitId = urlParams.unit;
+  const unitId = urlParams.unit || appConfigSpec.defaultUnit;
   const problemOrdinal = urlParams.problem || appConfigSpec.defaultProblemOrdinal;
   const showDemoCreator = urlParams.demo;
 

--- a/src/models/curriculum/unit.ts
+++ b/src/models/curriculum/unit.ts
@@ -15,6 +15,7 @@ export const UnitModel = types
     abbrevTitle: "",
     title: types.string,
     subtitle: "",
+    placeholderText: "",
     lookingAhead: types.maybe(DocumentContentModel),
     investigations: types.array(InvestigationModel),
     supports: types.array(SupportModel),


### PR DESCRIPTION
Placeholder text can now be customised per unit and/or omitted by leaving an empty string.