### PR TITLE
Set height of editor tile content

### DIFF
--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -76,6 +76,7 @@ interface IProps extends SizeMeProps {
   onZoomChange: (dx: number, dy: number, scale: number) => void;
   programIsRunning?: string;
   onCheckProgramRunState: (endTime: number) => void;
+  tileHeight?: number;
 }
 
 interface IState {
@@ -142,12 +143,12 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
             isDataStorageDisabled={this.state.disableDataStorage}
             disabled={this.props.readOnly || !this.isReady()}
           /> }
-          <div className="editor-graph-container">
+          <div className="editor-graph-container" style={this.getEditorStyle()}>
             <div
               className={editorClass}
               ref={(elt) => this.editorDomElement = elt}
             >
-              <div className="flow-tool" ref={elt => this.toolDiv = elt} style={this.getEditorStyle()}/>
+              <div className="flow-tool" ref={elt => this.toolDiv = elt}/>
                 <DataflowProgramZoom
                   onZoomInClick={this.zoomIn}
                   onZoomOutClick={this.zoomOut}
@@ -209,9 +210,16 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
   private getEditorStyle = () => {
     const style: React.CSSProperties = {};
     const documentElt = document.querySelector(".document-content");
-    const titlebarElt = document.querySelector(".document .titlebar");
-    const editorHeight = documentElt && titlebarElt ? documentElt.clientHeight - titlebarElt.clientHeight : 500;
-    style.height = `${editorHeight}px`;
+    const kBottomResizeHandleHeight = 10;
+    const kTextTileHeight = 60;
+    const kProgramTopbarHeight = 44;
+    const topbarHeight = this.isComplete() ? 0 : kProgramTopbarHeight;
+    const editorHeight = documentElt
+                         ? documentElt.clientHeight - topbarHeight - kTextTileHeight - kBottomResizeHandleHeight
+                         : 500;
+    if (!this.props.tileHeight) {
+      style.height = `${editorHeight}px`;
+    }
     return style;
   }
 

--- a/src/dataflow/components/tools/dataflow-tool.tsx
+++ b/src/dataflow/components/tools/dataflow-tool.tsx
@@ -15,6 +15,7 @@ import { IOtherDocumentProperties } from "../../../lib/db-types";
 interface IProps {
   model: ToolTileModelType;
   readOnly?: boolean;
+  height?: number;
 }
 
 interface IState {
@@ -29,7 +30,7 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IState>
   public state: IState = {};
 
   public render() {
-    const { model, readOnly } = this.props;
+    const { model, readOnly, height } = this.props;
     const editableClass = readOnly ? "read-only" : "editable";
     const classes = `dataflow-tool disable-tile-content-drag ${editableClass}`;
     const { program, programRunId, programIsRunning, programStartTime, programEndTime, programRunTime, programZoom }
@@ -59,6 +60,7 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IState>
                 programZoom={programZoom}
                 onZoomChange={this.handleProgramZoomChange}
                 size={size}
+                tileHeight={height}
               />
             );
           }}


### PR DESCRIPTION
Fixes to Dataflow editor tile to ensure that appropriate tile content heights are used.  Ensure the following:
- initial tile and content height consumes available vertical space
- user tile height changes are respected (for example, user grabs tile bottom bar and resizes tile)
- height is maintained when tile content state changes (program only, graph only, program and graph side-by-side)

Note: these are NOT meant to be long term solutions to handling the tile content height.  This is a simple fix to allow the Dataflow team to continue testing and use of Dataflow 3.0 without encountering glaring UI issues.
