### PR TITLE
[#168354940] Default One Learning Log

### DIFF
--- a/src/clue/app-config.json
+++ b/src/clue/app-config.json
@@ -10,6 +10,8 @@
   "defaultDocumentType": "problem",
   "defaultDocumentTitle": "Untitled",
   "defaultLearningLogTitle": "UntitledLog",
+  "defaultInitialLearningLogTitle": "My First Learning Log",
+  "defaultLearningLogDocument": true,
   "documentLabels": {
     "personal": {
       "labels": {
@@ -104,7 +106,6 @@
           "dataTestHeader": "learning-log-section",
           "dataTestItem": "learning-log-list-items",
           "documentTypes": ["learningLog"],
-          "addDocument": true,
           "properties": ["!isDeleted"]
         }
       ]

--- a/src/clue/app-config.json
+++ b/src/clue/app-config.json
@@ -10,7 +10,7 @@
   "defaultDocumentType": "problem",
   "defaultDocumentTitle": "Untitled",
   "defaultLearningLogTitle": "UntitledLog",
-  "defaultInitialLearningLogTitle": "My First Learning Log",
+  "initialLearningLogTitle": "My First Learning Log",
   "defaultLearningLogDocument": true,
   "documentLabels": {
     "personal": {

--- a/src/components/document/document-workspace.tsx
+++ b/src/components/document/document-workspace.tsx
@@ -46,7 +46,7 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps, {}> {
 
   private async guaranteeInitialDocuments() {
     const { appConfig: { defaultDocumentType, defaultDocumentContent,
-                         defaultLearningLogDocument, defaultInitialLearningLogTitle },
+                         defaultLearningLogDocument, defaultLearningLogTitle, initialLearningLogTitle },
             db, ui: { problemWorkspace } } = this.stores;
     if (!problemWorkspace.primaryDocumentKey) {
       const defaultDocument = await db.guaranteeOpenDefaultDocument(defaultDocumentType, defaultDocumentContent);
@@ -55,7 +55,7 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps, {}> {
       }
     }
     // Guarantee the user starts with one learning log
-    defaultLearningLogDocument && await db.guaranteeLearningLog(defaultInitialLearningLogTitle);
+    defaultLearningLogDocument && await db.guaranteeLearningLog(initialLearningLogTitle || defaultLearningLogTitle);
   }
 
   private renderDocuments(isGhostUser: boolean) {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -249,6 +249,22 @@ export class DB {
       : this.createPersonalDocument({ content: defaultContent });
   }
 
+  public async guaranteeLearningLog(initialTitle?: string, defaultContent?: DocumentContentModelType) {
+    const {user, documents} = this.stores;
+
+    const learningLogDocument = documents.getLearningLogDocument(user.id);
+    if (learningLogDocument) return learningLogDocument;
+
+    const learningLogDocumentsRef = this.firebase.ref(this.firebase.getLearningLogPath(user));
+    const learningLogDocumentsSnapshot = await learningLogDocumentsRef.once("value");
+    const learningLogDocuments: DBOtherDocumentMap = learningLogDocumentsSnapshot &&
+                                                  learningLogDocumentsSnapshot.val();
+    const firstLearningLogDocument = find(learningLogDocuments, () => true);
+    return firstLearningLogDocument
+      ? this.openOtherDocument(LearningLogDocument, firstLearningLogDocument.self.documentKey)
+      : this.createOtherDocument(LearningLogDocument, { title: initialTitle, content: defaultContent });
+  }
+
   public createProblemDocument(content?: DocumentContentModelType) {
     return new Promise<DocumentModelType>((resolve, reject) => {
       const {user, documents} = this.stores;

--- a/src/models/stores/app-config-model.ts
+++ b/src/models/stores/app-config-model.ts
@@ -40,7 +40,7 @@ export const AppConfigModel = types
     // clients should use the defaultDocumentContent() method below
     defaultDocumentTemplate: types.maybe(DocumentContentModel),
     defaultLearningLogTitle: "UntitledLog",
-    defaultInitialLearningLogTitle: "",
+    initialLearningLogTitle: "",
     defaultLearningLogDocument: false,
     documentLabels: types.map(DocumentLabelModel),
     showClassSwitcher: false,

--- a/src/models/stores/app-config-model.ts
+++ b/src/models/stores/app-config-model.ts
@@ -40,6 +40,8 @@ export const AppConfigModel = types
     // clients should use the defaultDocumentContent() method below
     defaultDocumentTemplate: types.maybe(DocumentContentModel),
     defaultLearningLogTitle: "UntitledLog",
+    defaultInitialLearningLogTitle: "",
+    defaultLearningLogDocument: false,
     documentLabels: types.map(DocumentLabelModel),
     showClassSwitcher: false,
     rightNavTabs: types.array(RightNavTabModel),

--- a/src/models/stores/documents.ts
+++ b/src/models/stores/documents.ts
@@ -48,6 +48,12 @@ export const DocumentsModel = types
       });
     },
 
+    getLearningLogDocument(userId: string) {
+      return self.all.find((document) => {
+        return (document.type === LearningLogDocument) && (document.uid === userId);
+      });
+    },
+
     getProblemDocument(userId: string) {
       return self.all.find((document) => {
         return (document.type === ProblemDocument) && (document.uid === userId);


### PR DESCRIPTION
Users will now have a Learning Log created upon first use of the app with the title `My First Learning Log`. New Learning Logs increment with the default `Untitled` starting from `1` if users do not change their document titles. Create Learning Logs from the right nav has been removed but can be enabled again in the future via `app-config` (`"addDocument": true,`).