### PR TITLE
Update node UI, ensure proper units are sent to graph component

### DIFF
--- a/src/dataflow/components/nodes/controls/dropdown-list-control.sass
+++ b/src/dataflow/components/nodes/controls/dropdown-list-control.sass
@@ -140,3 +140,7 @@
       color: $relay-orange
       &.dropdown-caret
         fill: $relay-orange
+
+  .label
+    &.unselected
+      font-style: italic

--- a/src/dataflow/components/nodes/controls/relay-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/relay-select-control.tsx
@@ -57,7 +57,7 @@ export class RelaySelectControl extends Rete.Control {
         channelsForType.forEach( c => { if (c.type === ch.type && ch.hubId === c.hubId) count++; } );
         return `${ch.hubName}:${ch.type}${ch.plug > 0 && count > 1 ? `(plug ${ch.plug})` : ""}`;
       };
-
+      const titleClass = getChannelString(selectedChannel).includes("Select") ? "label unselected" : "label";
       const options: any = [...channelsForType];
       if (!options.length) {
         options.push("none");
@@ -65,7 +65,7 @@ export class RelaySelectControl extends Rete.Control {
       return (
         <div className="node-select relay-select" ref={divRef}>
           <div className="item top" onMouseDown={handleChange(onDropdownClick)}>
-            <div className="label">{getChannelString(selectedChannel)}</div>
+            <div className={titleClass}>{getChannelString(selectedChannel)}</div>
             <svg className="icon dropdown-caret">
               <use xlinkHref="#icon-dropdown-caret"/>
             </svg>

--- a/src/dataflow/components/nodes/controls/relay-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/relay-select-control.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { useRef } from "react";
 import Rete, { NodeEditor, Node } from "rete";
-import { NodeChannelInfo } from "../../../utilities/node";
+import { NodeChannelInfo, kRelaySelectMessage } from "../../../utilities/node";
 import { useStopEventPropagation } from "./custom-hooks";
 import "./sensor-select-control.sass";
 
@@ -50,14 +50,14 @@ export class RelaySelectControl extends Rete.Control {
       const selectedChannel = channelsForType.find((ch: any) => ch.channelId === id);
 
       const getChannelString = (ch?: NodeChannelInfo | "none") => {
-        if (!ch && (!id || id === "none")) return "Select a relay";
+        if (!ch && (!id || id === "none")) return kRelaySelectMessage;
         if (ch === "none") return "None Available";
         if (!ch) return "Searching for " + id;
         let count = 0;
         channelsForType.forEach( c => { if (c.type === ch.type && ch.hubId === c.hubId) count++; } );
         return `${ch.hubName}:${ch.type}${ch.plug > 0 && count > 1 ? `(plug ${ch.plug})` : ""}`;
       };
-      const titleClass = getChannelString(selectedChannel).includes("Select") ? "label unselected" : "label";
+      const titleClass = getChannelString(selectedChannel).includes(kRelaySelectMessage) ? "label unselected" : "label";
       const options: any = [...channelsForType];
       if (!options.length) {
         options.push("none");

--- a/src/dataflow/components/nodes/controls/sensor-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/sensor-select-control.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { useRef } from "react";
 import Rete, { NodeEditor, Node } from "rete";
-import { NodeSensorTypes, NodeChannelInfo } from "../../../utilities/node";
+import { NodeSensorTypes, NodeChannelInfo, kSensorSelectMessage } from "../../../utilities/node";
 import { useStopEventPropagation } from "./custom-hooks";
 import "./sensor-select-control.sass";
 import "./value-control.sass";
@@ -122,7 +122,7 @@ export class SensorSelectControl extends Rete.Control {
       const selectedChannel = channelsForType.find((ch: any) => ch.channelId === id);
 
       const getChannelString = (ch?: NodeChannelInfo | "none") => {
-        if (!ch && (!id || id === "none")) return "Select a sensor";
+        if (!ch && (!id || id === "none")) return kSensorSelectMessage;
         if (ch === "none") return "None Available";
         if (!ch) return "Finding " + id;
         let count = 0;
@@ -134,7 +134,7 @@ export class SensorSelectControl extends Rete.Control {
       if (!options.length) {
         options.push("none");
       }
-      const titleClass = getChannelString(selectedChannel).includes("Select") ? "label unselected" : "label";
+      const titleClass = getChannelString(selectedChannel).includes(kSensorSelectMessage) ? "label unselected" : "label";
       return (
         <div className="node-select sensor-select" ref={divRef}>
           <div className="item top" onMouseDown={handleChange(onDropdownClick)}>

--- a/src/dataflow/components/nodes/controls/sensor-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/sensor-select-control.tsx
@@ -59,21 +59,23 @@ export class SensorSelectControl extends Rete.Control {
       const divRef = useRef<HTMLDivElement>(null);
       useStopEventPropagation(divRef, "pointerdown");
       let icon = "";
+      let name = "";
       const sensorType = NodeSensorTypes.find((s: any) => s.type === type);
       if (sensorType && sensorType.icon) {
         icon = `#${sensorType.icon}`;
+        name = sensorType.name;
       }
 
       return (
         <div className="node-select sensor-type" ref={divRef}>
           <div className="item top" onMouseDown={handleChange(onDropdownClick)}>
             { type === "none"
-              ? <div className="label">Select a sensor type</div>
+              ? <div className="label unselected">Select a sensor type</div>
               : <div className="top-item-holder">
                   <svg className="icon top">
                     <use xlinkHref={icon}/>
                   </svg>
-                  <div className="label">{type}</div>
+                  <div className="label">{name}</div>
                 </div>
             }
             <svg className="icon dropdown-caret">
@@ -132,10 +134,11 @@ export class SensorSelectControl extends Rete.Control {
       if (!options.length) {
         options.push("none");
       }
+      const titleClass = getChannelString(selectedChannel).includes("Select") ? "label unselected" : "label";
       return (
         <div className="node-select sensor-select" ref={divRef}>
           <div className="item top" onMouseDown={handleChange(onDropdownClick)}>
-            <div className="label">{getChannelString(selectedChannel)}</div>
+            <div className={titleClass}>{getChannelString(selectedChannel)}</div>
             <div className="dropdown-caret-holder">
               <svg className="icon dropdown-caret">
                 <use xlinkHref="#icon-dropdown-caret"/>

--- a/src/dataflow/components/nodes/controls/sensor-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/sensor-select-control.tsx
@@ -134,7 +134,9 @@ export class SensorSelectControl extends Rete.Control {
       if (!options.length) {
         options.push("none");
       }
-      const titleClass = getChannelString(selectedChannel).includes(kSensorSelectMessage) ? "label unselected" : "label";
+      const titleClass = getChannelString(selectedChannel).includes(kSensorSelectMessage)
+                         ? "label unselected"
+                         : "label";
       return (
         <div className="node-select sensor-select" ref={divRef}>
           <div className="item top" onMouseDown={handleChange(onDropdownClick)}>

--- a/src/dataflow/utilities/node.ts
+++ b/src/dataflow/utilities/node.ts
@@ -326,3 +326,6 @@ export const IntervalTimes: IntervalTime[] = [
     maxProgramRunTime: 2592000
   }
 ];
+
+export const kRelaySelectMessage = "Select a relay";
+export const kSensorSelectMessage = "Select a relay";

--- a/src/dataflow/utilities/node.ts
+++ b/src/dataflow/utilities/node.ts
@@ -27,119 +27,119 @@ export const NodeTypes = [
 
 export const NodeOperationTypes = [
   {
-    name: "add",
+    name: "Add",
     type: "math",
     method: (n1: number, n2: number) => n1 + n2,
     numberSentence: (n1: string, n2: string) => `${n1} + ${n2} = `,
     icon: "icon-add"
   },
   {
-    name: "subtract",
+    name: "Subtract",
     type: "math",
     method: (n1: number, n2: number) => n1 - n2,
     numberSentence: (n1: string, n2: string) => `${n1} - ${n2} = `,
     icon: "icon-subtract"
   },
   {
-    name: "multiply",
+    name: "Multiply",
     type: "math",
     method: (n1: number, n2: number) => n1 * n2,
     numberSentence: (n1: string, n2: string) => `${n1} * ${n2} = `,
     icon: "icon-multiply"
   },
   {
-    name: "divide",
+    name: "Divide",
     type: "math",
     method: (n1: number, n2: number) => n1 / n2,
     numberSentence: (n1: string, n2: string) => `${n1} / ${n2} = `,
     icon: "icon-divide"
   },
   {
-    name: "absolute value",
+    name: "Absolute Value",
     type: "transform",
     method: (n1: number, n2: number) => Math.abs(n1),
     numberSentence: (n1: string, n2: string) => `|${n1}| = `,
     icon: "icon-absolute-value"
   },
   {
-    name: "negation",
+    name: "Negation",
     type: "transform",
     method: (n1: number, n2: number) => 0 - n1,
     numberSentence: (n1: string, n2: string) => `-(${n1}) = `,
     icon: "icon-negation"
   },
   {
-    name: "not",
+    name: "Not",
     type: "transform",
     method: (n1: number, n2: number) => n1 ? 0 : 1,
     numberSentence: (n1: string, n2: string) => `!${n1} ⇒ `,
     icon: "icon-not"
   },
   {
-    name: "greater than",
+    name: "Greater Than",
     type: "logic",
     method: (n1: number, n2: number) => +(n1 > n2),
     numberSentence: (n1: string, n2: string) => `${n1} > ${n2} ⇒ `,
     icon: "icon-greater-than"
   },
   {
-    name: "less than",
+    name: "Less Than",
     type: "logic",
     method: (n1: number, n2: number) => +(n1 < n2),
     numberSentence: (n1: string, n2: string) => `${n1} < ${n2} ⇒ `,
     icon: "icon-less-than"
   },
   {
-    name: "greater than or equal to",
+    name: "Greater Than Or Equal To",
     type: "logic",
     method: (n1: number, n2: number) => +(n1 >= n2),
     numberSentence: (n1: string, n2: string) => `${n1} >= ${n2} ⇒ `,
     icon: "icon-greater-than-or-equal-to"
   },
   {
-    name: "less than or equal to",
+    name: "Less Than Or Equal To",
     type: "logic",
     method: (n1: number, n2: number) => +(n1 <= n2),
     numberSentence: (n1: string, n2: string) => `${n1} <= ${n2} ⇒ `,
     icon: "icon-less-than-or-equal-to"
   },
   {
-    name: "equal",
+    name: "Equal",
     type: "logic",
     method: (n1: number, n2: number) => +(n1 === n2),
     numberSentence: (n1: string, n2: string) => `${n1} == ${n2} ⇒ `,
     icon: "icon-equal"
   },
   {
-    name: "not equal",
+    name: "Not Equal",
     type: "logic",
     method: (n1: number, n2: number) => +(n1 !== n2),
     numberSentence: (n1: string, n2: string) => `${n1} != ${n2} ⇒ `,
     icon: "icon-not-equal"
   },
   {
-    name: "and",
+    name: "And",
     type: "logic",
     method: (n1: number, n2: number) => n1 && n2 ? 1 : 0,
     numberSentence: (n1: string, n2: string) => `${n1} && ${n2} ⇒ `,
     icon: "icon-and"
   },
   {
-    name: "or",
+    name: "Or",
     type: "logic",
     method: (n1: number, n2: number) => n1 || n2 ? 1 : 0,
     numberSentence: (n1: string, n2: string) => `${n1} || ${n2} ⇒ `,
     icon: "icon-or"
   },
   {
-    name: "nand",
+    name: "Nand",
     type: "logic",
     method: (n1: number, n2: number) => +(!(n1 && n2 ? 1 : 0)),
     numberSentence: (n1: string, n2: string) => `${n1} nand ${n2} ⇒ `,
     icon: "icon-nand"
   },
   {
-    name: "xor",
+    name: "Xor",
     type: "logic",
     method: (n1: number, n2: number) => +((n1 ? 1 : 0) !== (n2 ? 1 : 0)),
     numberSentence: (n1: string, n2: string) => `${n1} xor ${n2} ⇒ `,
@@ -149,13 +149,13 @@ export const NodeOperationTypes = [
 
 export const NodeSensorTypes = [
   {
-    name: "temperature",
+    name: "Temperature",
     type: "temperature",
     units: "°C",
     icon: "icon-temperature"
   },
   {
-    name: "humidity",
+    name: "Humidity",
     type: "humidity",
     units: "%",
     icon: "icon-humidity"
@@ -173,19 +173,19 @@ export const NodeSensorTypes = [
     icon: "icon-o2"
   },
   {
-    name: "light",
+    name: "Light",
     type: "light",
     units: "lux",
     icon: "icon-light"
   },
   {
-    name: "soil moisture",
+    name: "Soil Moisture",
     type: "soil-moisture",
     units: "",
     icon: "icon-soil-moisture"
   },
   {
-    name: "particulates",
+    name: "Particulates",
     type: "particulates",
     units: "PM2.5",
     icon: "icon-particulates"
@@ -194,22 +194,22 @@ export const NodeSensorTypes = [
 
 export const NodeGeneratorTypes = [
   {
-    name: "sine",
+    name: "Sine",
     method: (t: number, p: number, a: number, v: number) => Math.round(Math.sin(t * Math.PI / (p / 2)) * a * 100) / 100,
     icon: "icon-sine-generator"
   },
   {
-    name: "square",
+    name: "Square",
     method: (t: number, p: number, a: number, v: number) => t % p < p / 2 ? 1 * a : 0,
     icon: "icon-square-generator"
   },
   {
-    name: "triangle",
+    name: "Triangle",
     method: (t: number, p: number, a: number, v: number) => (2 * a / p) * Math.abs(t % p - p / 2),
     icon: "icon-triangle-generator"
   },
   {
-    name: "noise",
+    name: "Noise",
     method: (t: number, p: number, a: number, v: number) => Math.random() * a,
     icon: "icon-noise-generator"
   },


### PR DESCRIPTION
Small, miscellaneous Dataflow updates that I had stashed locally for a variety of reasons (waiting to bring in to avoid merge conflict, changes were partially complete, etc.).  Changes include the following:
- pass proper units to graph when unit is available (at present only if connection is directly to a sensor), units are not presently shown in graph but are shown in the exported CSV
- ensure proper text formatting is used on sensor and relay dropdown
- ensure proper capitalization is used in math, logic, transform, generator, and sensor node dropdowns
- use node name, not node type when displaying node to user (for example, a soil moisture sensor should present itself as "Soil Moisture" not "soil-moisture")