### PR TITLE
[#168917124] Support Properties for Document Labels in AppConfig

### DIFF
--- a/src/components/document/document-workspace.tsx
+++ b/src/components/document/document-workspace.tsx
@@ -252,9 +252,10 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps, {}> {
     const defaultDocTitle = document.isLearningLog
                             ? appConfig.defaultLearningLogTitle
                             : appConfig.defaultDocumentTitle;
-    const docTypeString = appConfig.getDocumentLabel(docType, 1);
+    const docTypeString = document.getLabel(appConfig, 1);
+    const docTypeStringL = document.getLabel(appConfig, 1, true);
     const nextTitle = this.stores.documents.getNextOtherDocumentTitle(user, docType, defaultDocTitle);
-    this.stores.ui.prompt(`Name your new ${docTypeString}:`, `${nextTitle}`, `Create ${docTypeString}`)
+    this.stores.ui.prompt(`Name your new ${docTypeStringL}:`, `${nextTitle}`, `Create ${docTypeString}`)
       .then((title: string) => {
         this.handleNewDocumentOpen(docType, title)
         .catch(this.stores.ui.setError);
@@ -273,8 +274,9 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps, {}> {
 
   private handleCopyDocument = (document: DocumentModelType) => {
     const { appConfig } = this.stores;
-    const docTypeString = appConfig.getDocumentLabel(document.type, 1);
-    this.stores.ui.prompt(`Give your ${docTypeString} copy a new name:`,
+    const docTypeString = document.getLabel(appConfig, 1);
+    const docTypeStringL = document.getLabel(appConfig, 1, true);
+    this.stores.ui.prompt(`Give your ${docTypeStringL} copy a new name:`,
                           `Copy of ${document.title || this.stores.problem.title}`, `Copy ${docTypeString}`)
       .then((title: string) => {
         this.handleCopyDocumentOpen(document, title)
@@ -292,8 +294,9 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps, {}> {
 
   private handleDeleteDocument = (document: DocumentModelType) => {
     const { appConfig } = this.stores;
-    const docTypeString = appConfig.getDocumentLabel(document.type, 1);
-    this.stores.ui.confirm(`Delete this ${docTypeString}? ${document.title}`, `Delete ${docTypeString}`)
+    const docTypeString = document.getLabel(appConfig, 1);
+    const docTypeStringL = document.getLabel(appConfig, 1, true);
+    this.stores.ui.confirm(`Delete this ${docTypeStringL}? ${document.title}`, `Delete ${docTypeString}`)
       .then((confirmDelete: boolean) => {
         const docType = document.type;
         if (confirmDelete && ((docType === PersonalDocument) || (docType === LearningLogDocument))) {
@@ -335,13 +338,14 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps, {}> {
 
   private handlePublishDocument = (document: DocumentModelType) => {
     const { appConfig, db, ui } = this.stores;
-    const docTypeString = appConfig.getDocumentLabel(document.type, 1);
+    const docTypeString = document.getLabel(appConfig, 1);
+    const docTypeStringL = document.getLabel(appConfig, 1, true);
     // TODO: Disable publish button while publishing
     const dbPublishDocumentFunc = document.type === ProblemDocument
                                     ? db.publishProblemDocument
                                     : db.publishOtherDocument;
     dbPublishDocumentFunc.call(db, document)
-      .then(() => ui.alert(`Your ${docTypeString.toLowerCase()} was published.`, `${docTypeString} Published`));
+      .then(() => ui.alert(`Your ${docTypeStringL} was published.`, `${docTypeString} Published`));
   }
 
   private getPrimaryDocument(documentKey?: string) {

--- a/src/components/document/document.tsx
+++ b/src/components/document/document.tsx
@@ -456,8 +456,9 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
   private handleDocumentRename = () => {
     const { document } = this.props;
     const { appConfig } = this.stores;
-    const docTypeString = appConfig.getDocumentLabel(document.type, 1);
-    this.stores.ui.prompt(`Rename your ${docTypeString}:`, document.title, `Rename ${docTypeString}`)
+    const docTypeString = document.getLabel(appConfig, 1);
+    const docTypeStringL = document.getLabel(appConfig, 1, true);
+    this.stores.ui.prompt(`Rename your ${docTypeStringL}:`, document.title, `Rename ${docTypeString}`)
       .then((title: string) => {
         if (title !== document.title) {
           document.setTitle(title);

--- a/src/models/document/document.ts
+++ b/src/models/document/document.ts
@@ -3,6 +3,7 @@ import { DocumentContentModel, DocumentContentModelType } from "./document-conte
 import { TileCommentsModel, TileCommentsModelType } from "../tools/tile-comments";
 import { UserStarModel, UserStarModelType } from "../tools/user-star";
 import { IDocumentProperties } from "../../lib/db-types";
+import { AppConfigModelType } from "../stores/app-config-model";
 import { forEach } from "lodash";
 
 export const DocumentDragKey = "org.concord.clue.document.key";
@@ -103,6 +104,16 @@ export const DocumentModel = types
     },
     getUserStarAtIndex(index: number) {
       return self.stars[index];
+    }
+  }))
+  .views(self => ({
+    getLabel(appConfig: AppConfigModelType, count: number, lowerCase?: boolean) {
+      const props = appConfig.documentLabelProperties || [];
+      let docStr = self.type as string;
+      props.forEach(prop => {
+        docStr += self.getProperty(prop) ? `:${prop}` : `:!${prop}`;
+      });
+      return appConfig.getDocumentLabel(docStr, count, lowerCase);
     }
   }))
   .actions((self) => ({

--- a/src/models/stores/app-config-model.ts
+++ b/src/models/stores/app-config-model.ts
@@ -42,6 +42,7 @@ export const AppConfigModel = types
     defaultLearningLogTitle: "UntitledLog",
     initialLearningLogTitle: "",
     defaultLearningLogDocument: false,
+    documentLabelProperties: types.array(types.string),
     documentLabels: types.map(DocumentLabelModel),
     showClassSwitcher: false,
     rightNavTabs: types.array(RightNavTabModel),


### PR DESCRIPTION
Properties is now supported for document labels through AppConfig in `documentLabelProperties`.

As an example this is necessary to support Dataflow's `Program` and `Data` which are both Personal Documents and needs to be merged to further work on labeling Dataflow documents.