### PR TITLE
Fit image in tile

### DIFF
--- a/src/components/document/tile-row.tsx
+++ b/src/components/document/tile-row.tsx
@@ -93,6 +93,7 @@ export class TileRowComponent extends BaseComponent<IProps, IState> {
               ? <ToolTileComponent key={tileModel.id} model={tileModel}
                                     widthPct={tileWidthPct} height={rowHeight}
                                     onSetCanAcceptDrop={this.handleSetCanAcceptDrop}
+                                    onRequestRowHeight={this.handleRequestRowHeight}
                                     {...others} />
               : null;
     });
@@ -119,6 +120,10 @@ export class TileRowComponent extends BaseComponent<IProps, IState> {
 
   private handleSetCanAcceptDrop = (tileId?: string) => {
     this.setState({ tileAcceptDrop: tileId });
+  }
+
+  private handleRequestRowHeight = (height: number) => {
+    this.props.model.setRowHeight(height);
   }
 
   private handleStartResizeRow = (e: React.DragEvent<HTMLDivElement>) => {

--- a/src/components/document/tile-row.tsx
+++ b/src/components/document/tile-row.tsx
@@ -122,7 +122,7 @@ export class TileRowComponent extends BaseComponent<IProps, IState> {
     this.setState({ tileAcceptDrop: tileId });
   }
 
-  private handleRequestRowHeight = (height: number) => {
+  private handleRequestRowHeight = (tileId: string, height: number) => {
     this.props.model.setRowHeight(height);
   }
 

--- a/src/components/tools/image-tool.sass
+++ b/src/components/tools/image-tool.sass
@@ -20,6 +20,8 @@
     top: 0px
 
   .image-tool-image
+    width: 100%
+    height: 100%
     background-size: contain
     background-repeat: no-repeat
 

--- a/src/components/tools/image-tool.tsx
+++ b/src/components/tools/image-tool.tsx
@@ -16,7 +16,7 @@ interface IProps extends IBaseProps {
   context: string;
   model: ToolTileModelType;
   readOnly?: boolean;
-  onRequestRowHeight: (height: number) => void;
+  onRequestRowHeight: (tileId: string, height: number) => void;
 }
 
 interface IState {
@@ -101,7 +101,7 @@ export default class ImageToolComponent extends BaseComponent<IProps, IState> {
     // if we have a new image, or the image height has changed, reqest an explicit height
     if (this.state.imageEntry && this.state.imageEntry.height
         && (!prevState.imageEntry || prevState.imageEntry.height !== this.state.imageEntry.height)) {
-      this.props.onRequestRowHeight(this.state.imageEntry.height);
+      this.props.onRequestRowHeight(this.props.model.id, this.state.imageEntry.height);
     }
   }
 

--- a/src/components/tools/image-tool.tsx
+++ b/src/components/tools/image-tool.tsx
@@ -16,6 +16,7 @@ interface IProps extends IBaseProps {
   context: string;
   model: ToolTileModelType;
   readOnly?: boolean;
+  onRequestRowHeight: (height: number) => void;
 }
 
 interface IState {
@@ -93,9 +94,14 @@ export default class ImageToolComponent extends BaseComponent<IProps, IState> {
     this.disposers.forEach(disposer => disposer());
   }
 
-  public componentDidUpdate() {
+  public componentDidUpdate(prevProps: IProps, prevState: IState) {
     if (this.state.imageContentUrl) {
       this.updateImageUrl(this.state.imageContentUrl);
+    }
+    // if we have a new image, or the image height has changed, reqest an explicit height
+    if (this.state.imageEntry && this.state.imageEntry.height
+        && (!prevState.imageEntry || prevState.imageEntry.height !== this.state.imageEntry.height)) {
+      this.props.onRequestRowHeight(this.state.imageEntry.height);
     }
   }
 

--- a/src/components/tools/image-tool.tsx
+++ b/src/components/tools/image-tool.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { observer, inject } from "mobx-react";
+import CSS from "csstype";
 import { BaseComponent, IBaseProps } from "../base";
 import { ToolTileModelType } from "../../models/tools/tool-tile";
 import { ImageContentModelType } from "../../models/tools/image/image-content";
@@ -118,11 +119,13 @@ export default class ImageToolComponent extends BaseComponent<IProps, IState> {
     const imageHeight = imageEntry && imageEntry.height || defaultImagePlaceholderSize.height;
     const imageToUseForDisplay = imageEntry && imageEntry.displayUrl || (isLoading ? "" : placeholderImage);
     // Set image display properties for the div, since this won't resize automatically when the image changes
-    const imageDisplayStyle = {
-      backgroundImage: "url(" + imageToUseForDisplay + ")",
-      width: imageWidth + "px",
-      height: imageHeight + "px"
+    const imageDisplayStyle: CSS.Properties = {
+      backgroundImage: "url(" + imageToUseForDisplay + ")"
     };
+    if (!imageEntry) {
+      imageDisplayStyle.width = defaultImagePlaceholderSize.width + "px";
+      imageDisplayStyle.height = defaultImagePlaceholderSize.height + "px";
+    }
     return (
       <div className={divClasses}
         onMouseDown={this.handleMouseDown}

--- a/src/components/tools/tool-tile.tsx
+++ b/src/components/tools/tool-tile.tsx
@@ -72,7 +72,7 @@ interface IProps {
   readOnly?: boolean;
   toolApiInterface?: IToolApiInterface;
   onSetCanAcceptDrop: (tileId?: string) => void;
-  onRequestRowHeight: (height: number) => void;
+  onRequestRowHeight: (tileId: string, height: number) => void;
 }
 
 const kToolComponentMap: any = {

--- a/src/components/tools/tool-tile.tsx
+++ b/src/components/tools/tool-tile.tsx
@@ -72,6 +72,7 @@ interface IProps {
   readOnly?: boolean;
   toolApiInterface?: IToolApiInterface;
   onSetCanAcceptDrop: (tileId?: string) => void;
+  onRequestRowHeight: (height: number) => void;
 }
 
 const kToolComponentMap: any = {


### PR DESCRIPTION
Uses `contain` to ensure image is letterboxed and fully-visible, no matter how small the container, and adds ability for a tile to `requestRowHeight`, which sets the row to the desired height.