### PR TITLE
Section headers infrastructure

### DIFF
--- a/src/assets/curriculum/moving-straight-ahead/moving-straight-ahead.json
+++ b/src/assets/curriculum/moving-straight-ahead/moving-straight-ahead.json
@@ -4,6 +4,33 @@
   "title": "Moving Straight Ahead",
   "subtitle": "Linear Expressions, Equations, and Relationships",
   "placeholderText": "Enter notes here",
+  "sections": {
+    "introduction": {
+      "initials": "In",
+      "title": "Introduction",
+      "placeholder": "Work area for\nIntroduction section"
+    },
+    "initialChallenge": {
+      "initials": "IC",
+      "title": "Initial Challenge",
+      "placeholder": "Work area for\nInitial Challenge section"
+    },
+    "whatIf": {
+      "initials": "W?",
+      "title": "What If...?",
+      "placeholder": "Work area for\nWhat If...? section"
+    },
+    "nowWhatDoYouKnow": {
+      "initials": "N?",
+      "title": "Now What Do You Know?",
+      "placeholder": "Work area for\nNow What Do You Know? section"
+    },
+    "didYouKnow": {
+      "initials": "D?",
+      "title": "Did You Know?",
+      "placeholder": "Work area for\nDid You Know? section"
+    }
+  },
   "defaultStamps": [
     {
       "url": "assets/tools/drawing-tool/stamps/coin.png",

--- a/src/assets/curriculum/moving-straight-ahead/moving-straight-ahead.json
+++ b/src/assets/curriculum/moving-straight-ahead/moving-straight-ahead.json
@@ -6,7 +6,7 @@
   "placeholderText": "Enter notes here",
   "sections": {
     "introduction": {
-      "initials": "In",
+      "initials": "IN",
       "title": "Introduction",
       "placeholder": "Work area for\nIntroduction section"
     },
@@ -16,17 +16,17 @@
       "placeholder": "Work area for\nInitial Challenge section"
     },
     "whatIf": {
-      "initials": "W?",
+      "initials": "WI",
       "title": "What If...?",
       "placeholder": "Work area for\nWhat If...? section"
     },
     "nowWhatDoYouKnow": {
-      "initials": "N?",
+      "initials": "NW",
       "title": "Now What Do You Know?",
       "placeholder": "Work area for\nNow What Do You Know? section"
     },
     "didYouKnow": {
-      "initials": "D?",
+      "initials": "DY",
       "title": "Did You Know?",
       "placeholder": "Work area for\nDid You Know? section"
     }

--- a/src/assets/curriculum/stretching-and-shrinking/stretching-and-shrinking.json
+++ b/src/assets/curriculum/stretching-and-shrinking/stretching-and-shrinking.json
@@ -4,6 +4,33 @@
   "title": "Stretching and Shrinking",
   "subtitle": "Understanding Similarity",
   "placeholderText": "Enter notes here",
+  "sections": {
+    "introduction": {
+      "initials": "In",
+      "title": "Introduction",
+      "placeholder": "Work area for\nIntroduction section"
+    },
+    "initialChallenge": {
+      "initials": "IC",
+      "title": "Initial Challenge",
+      "placeholder": "Work area for\nInitial Challenge section"
+    },
+    "whatIf": {
+      "initials": "W?",
+      "title": "What If...?",
+      "placeholder": "Work area for\nWhat If...? section"
+    },
+    "nowWhatDoYouKnow": {
+      "initials": "N?",
+      "title": "Now What Do You Know?",
+      "placeholder": "Work area for\nNow What Do You Know? section"
+    },
+    "didYouKnow": {
+      "initials": "D?",
+      "title": "Did You Know?",
+      "placeholder": "Work area for\nDid You Know? section"
+    }
+  },
   "lookingAhead": {
     "tiles": [
       {

--- a/src/assets/curriculum/stretching-and-shrinking/stretching-and-shrinking.json
+++ b/src/assets/curriculum/stretching-and-shrinking/stretching-and-shrinking.json
@@ -6,7 +6,7 @@
   "placeholderText": "Enter notes here",
   "sections": {
     "introduction": {
-      "initials": "In",
+      "initials": "IN",
       "title": "Introduction",
       "placeholder": "Work area for\nIntroduction section"
     },
@@ -16,17 +16,17 @@
       "placeholder": "Work area for\nInitial Challenge section"
     },
     "whatIf": {
-      "initials": "W?",
+      "initials": "WI",
       "title": "What If...?",
       "placeholder": "Work area for\nWhat If...? section"
     },
     "nowWhatDoYouKnow": {
-      "initials": "N?",
+      "initials": "NW",
       "title": "Now What Do You Know?",
       "placeholder": "Work area for\nNow What Do You Know? section"
     },
     "didYouKnow": {
-      "initials": "D?",
+      "initials": "DY",
       "title": "Did You Know?",
       "placeholder": "Work area for\nDid You Know? section"
     }

--- a/src/clue/app-config.json
+++ b/src/clue/app-config.json
@@ -12,6 +12,7 @@
   "defaultLearningLogTitle": "UntitledLog",
   "initialLearningLogTitle": "My First Learning Log",
   "defaultLearningLogDocument": true,
+  "autoSectionProblemDocuments": true,
   "documentLabels": {
     "personal": {
       "labels": {

--- a/src/clue/components/sixpack-right-controls.tsx
+++ b/src/clue/components/sixpack-right-controls.tsx
@@ -42,7 +42,7 @@ export class SixPackRightControls extends BaseComponent<IProps, {}> {
       };
     };
 
-    const progressItems = sections.map(s => makeProgressItem(s.abbrev));
+    const progressItems = sections.map(s => makeProgressItem(s.initials));
     return(
       <div className="sixpack-right-controls">
         <div className="top-controls">

--- a/src/components/demo/demo-creator.test.tsx
+++ b/src/components/demo/demo-creator.test.tsx
@@ -1,10 +1,11 @@
 import * as Adapter from "enzyme-adapter-react-16";
 import * as React from "react";
 
-import { configure, mount, shallow } from "enzyme";
+import { configure, mount } from "enzyme";
 import { DemoCreatorComponment } from "./demo-creator";
 import { createStores, IStores } from "../../models/stores/stores";
 import { DemoModel } from "../../models/stores/demo";
+import { UnitModel } from "../../models/curriculum/unit";
 
 const demoUnitJson = {
   code: "test",
@@ -40,8 +41,6 @@ const demoUnitJson = {
   ]
 };
 
-import { createFromJson } from "../../models/curriculum/unit";
-
 configure({ adapter: new Adapter() });
 
 describe("DemoCreator Component", () => {
@@ -55,7 +54,7 @@ describe("DemoCreator Component", () => {
           name: "Test Class"
         }
       }),
-      unit: createFromJson(demoUnitJson)
+      unit: UnitModel.create(demoUnitJson)
     });
   });
 

--- a/src/components/document/document-workspace.tsx
+++ b/src/components/document/document-workspace.tsx
@@ -5,10 +5,10 @@ import { LeftNavComponent } from "../../components/navigation/left-nav";
 import { RightNavComponent } from "../../components/navigation/right-nav";
 import { DocumentComponent } from "../../components/document/document";
 import { BaseComponent, IBaseProps } from "../../components/base";
-import { SectionType, getSectionAbbrev } from "../../models/curriculum/section";
+import { kAllSectionType } from "../../models/curriculum/section";
 import { DocumentDragKey, DocumentModel, DocumentModelType, LearningLogDocument, OtherDocumentType,
          PersonalDocument, ProblemDocument } from "../../models/document/document";
-import { AudienceModelType, ClassAudienceModel, TeacherSupportSectionTarget } from "../../models/stores/supports";
+import { AudienceModelType, ClassAudienceModel, SectionTarget } from "../../models/stores/supports";
 import { parseGhostSectionDocumentKey } from "../../models/stores/workspace";
 import { ImageDragDrop } from "../utilities/image-drag-drop";
 
@@ -320,7 +320,7 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps, {}> {
     return match && match[1] ? match[1] : title;
   }
 
-  private getSupportDocumentBaseCaption(document: DocumentModelType, sectionTarget: TeacherSupportSectionTarget) {
+  private getSupportDocumentBaseCaption(document: DocumentModelType, sectionTarget: SectionTarget) {
     return document.type === ProblemDocument
             ? this.getProblemBaseTitle(this.stores.problem.title)
             : document.title;
@@ -329,7 +329,7 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps, {}> {
   private handlePublishSupport = async (document: DocumentModelType) => {
     const { db, ui } = this.stores;
     const audience: AudienceModelType = ClassAudienceModel.create();
-    const sectionTarget: TeacherSupportSectionTarget = SectionType.all;
+    const sectionTarget: SectionTarget = kAllSectionType;
     const caption = this.getSupportDocumentBaseCaption(document, sectionTarget) || "Untitled";
     // TODO: Disable publish button while publishing
     db.publishDocumentAsSupport(document, audience, sectionTarget, caption)

--- a/src/components/navigation/left-nav.tsx
+++ b/src/components/navigation/left-nav.tsx
@@ -43,7 +43,7 @@ export class LeftNavComponent extends BaseComponent<IProps, IState> {
             return (
               <TabComponent
                 id={this.getTabId(sectionIndex)}
-                key={section.abbrev}
+                key={section.title}
                 active={leftNavExpanded && (activeSectionIndex === sectionIndex)}
                 onClick={this.handleTabClick(sectionIndex)}
               >

--- a/src/components/teacher/teacher-support.tsx
+++ b/src/components/teacher/teacher-support.tsx
@@ -4,9 +4,8 @@ import { BaseComponent, IBaseProps } from "../base";
 
 import { niceDate } from "../../utilities/time";
 import { ENTER } from "@blueprintjs/core/lib/esm/common/keys";
-import { TeacherSupportModelType, TeacherSupportSectionTarget, AudienceModelType,
-  audienceInfo } from "../../models/stores/supports";
-import { SectionType, getSectionTitle } from "../../models/curriculum/section";
+import { TeacherSupportModelType, AudienceModelType, audienceInfo } from "../../models/stores/supports";
+import { getSectionTitle, kAllSectionType } from "../../models/curriculum/section";
 import { createTextSupport } from "../../models/curriculum/support";
 
 import "./teacher-support.sass";
@@ -42,7 +41,7 @@ export class TeacherSupport extends BaseComponent<IProps, IState> {
     const audienceType = audience.type;
     const messageTarget = audienceInfo[audienceType].display;
     const problemSectionTypes = problem.sections.map(section => section.type);
-    const sectionTypes = [SectionType.all, ...problemSectionTypes];
+    const sectionTypes = [kAllSectionType, ...problemSectionTypes];
     const sectionOptions = sectionTypes.map(sectionType => {
       return <option key={sectionType} value={sectionType}>{getSectionTitle(sectionType)}</option>;
     });
@@ -95,7 +94,7 @@ export class TeacherSupport extends BaseComponent<IProps, IState> {
     const content = this.inputElem && this.inputElem.value;
     const sectionTarget = this.sectionElem && this.sectionElem.value;
     if (this.inputElem && content && sectionTarget) {
-      db.createSupport(createTextSupport(content), sectionTarget as TeacherSupportSectionTarget, audience);
+      db.createSupport(createTextSupport(content), sectionTarget, audience);
       this.inputElem.value = "";
     }
   }

--- a/src/lib/db-types.ts
+++ b/src/lib/db-types.ts
@@ -1,5 +1,5 @@
 import { ESupportType } from "../models/curriculum/support";
-import { AudienceEnum, TeacherSupportSectionTarget } from "../models/stores/supports";
+import { AudienceEnum, SectionTarget } from "../models/stores/supports";
 
 // NOTE: see docs/firebase-schema.md to see a visual hierarchy of these interfaces
 
@@ -263,7 +263,7 @@ export interface DBBaseSupport {
     offeringId: string;
     audienceType: AudienceEnum;
     audienceId?: string;
-    sectionTarget: TeacherSupportSectionTarget;
+    sectionTarget: SectionTarget;
     key: string;
   };
   version: string;

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -20,7 +20,7 @@ import { DocumentContentSnapshotType, DocumentContentModelType, cloneContentWith
 import { Firebase } from "./firebase";
 import { DBListeners } from "./db-listeners";
 import { Logger, LogEventName } from "./logger";
-import { TeacherSupportModelType, TeacherSupportSectionTarget, AudienceModelType } from "../models/stores/supports";
+import { TeacherSupportModelType, SectionTarget, AudienceModelType } from "../models/stores/supports";
 import { safeJsonParse } from "../utilities/js-utils";
 import { find } from "lodash";
 
@@ -452,7 +452,7 @@ export class DB {
 
   public publishDocumentAsSupport(documentModel: DocumentModelType,
                                   audience: AudienceModelType,
-                                  sectionTarget: TeacherSupportSectionTarget,
+                                  sectionTarget: SectionTarget,
                                   caption: string) {
     const {user} = this.stores;
     const content = documentModel.content.publish();
@@ -810,7 +810,7 @@ export class DB {
   }
 
   public createSupport(supportModel: SupportModelType,
-                       sectionTarget: TeacherSupportSectionTarget, audience: AudienceModelType) {
+                       sectionTarget: SectionTarget, audience: AudienceModelType) {
     const { user } = this.stores;
     const classSupportsRef = this.firebase.ref(
       this.firebase.getSupportsPath(user, audience, sectionTarget)
@@ -840,7 +840,7 @@ export class DB {
   public deleteSupport(support: TeacherSupportModelType) {
     const { user } = this.stores;
     const { audience, key } = support;
-    const dbSupportType: TeacherSupportSectionTarget = support.sectionTarget;
+    const dbSupportType: SectionTarget = support.sectionTarget;
     const updateRef = this.firebase.ref(this.firebase.getSupportsPath(user, audience, dbSupportType, key));
     updateRef.update({
       deleted: true

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,6 +1,6 @@
 import * as firebase from "firebase/app";
 import { OtherDocumentType, PersonalDocument } from "../models/document/document";
-import { TeacherSupportSectionTarget, AudienceModelType } from "../models/stores/supports";
+import { AudienceModelType, SectionTarget } from "../models/stores/supports";
 import { UserModelType } from "../models/stores/user";
 import { DB } from "./db";
 import { urlParams } from "../utilities/url-params";
@@ -199,7 +199,7 @@ export class Firebase {
   public getSupportsPath(
     user: UserModelType,
     audience?: AudienceModelType,
-    sectionTarget?: TeacherSupportSectionTarget,
+    sectionTarget?: SectionTarget,
     key?: string
   ) {
     const audienceSuffix = audience

--- a/src/models/curriculum/problem.test.ts
+++ b/src/models/curriculum/problem.test.ts
@@ -1,6 +1,6 @@
 import { getSnapshot } from "mobx-state-tree";
 import { ProblemModel } from "./problem";
-import { SectionType, SectionModelType } from "./section";
+import { SectionModelType } from "./section";
 import { omitUndefined } from "../../utilities/test-utils";
 
 describe("problem model", () => {
@@ -27,10 +27,10 @@ describe("problem model", () => {
       subtitle: "sub",
       sections: [
         {
-          type: SectionType.introduction
+          type: "introduction"
         },
         {
-          type: SectionType.initialChallenge
+          type: "initialChallenge"
         }
       ]
     });
@@ -41,11 +41,11 @@ describe("problem model", () => {
       subtitle: "sub",
       sections: [
         {
-          type: SectionType.introduction,
+          type: "introduction",
           supports: []
         },
         {
-          type: SectionType.initialChallenge,
+          type: "initialChallenge",
           supports: []
         }
       ],
@@ -61,24 +61,24 @@ describe("problem model", () => {
       subtitle: "sub",
       sections: [
         {
-          type: SectionType.introduction
+          type: "introduction"
         },
         {
-          type: SectionType.initialChallenge
+          type: "initialChallenge"
         }
       ]
     });
     const firstSection = problem.getSectionByIndex(0) as SectionModelType;
-    expect(firstSection.type).toBe(SectionType.introduction);
+    expect(firstSection.type).toBe("introduction");
     const lastSection = problem.getSectionByIndex(1) as SectionModelType;
-    expect(lastSection.type).toBe(SectionType.initialChallenge);
+    expect(lastSection.type).toBe("initialChallenge");
 
     // < 0 returns first section
     const underflowSection = problem.getSectionByIndex(-1) as SectionModelType;
-    expect(underflowSection.type).toBe(SectionType.introduction);
+    expect(underflowSection.type).toBe("introduction");
     // > length return last section
     const overflowSection = problem.getSectionByIndex(10) as SectionModelType;
-    expect(overflowSection.type).toBe(SectionType.initialChallenge);
+    expect(overflowSection.type).toBe("initialChallenge");
   });
 
   it("can get sections by id", () => {
@@ -88,17 +88,17 @@ describe("problem model", () => {
       subtitle: "sub",
       sections: [
         {
-          type: SectionType.introduction
+          type: "introduction"
         },
         {
-          type: SectionType.initialChallenge
+          type: "initialChallenge"
         }
       ]
     });
-    const firstSection = problem.getSectionById(SectionType.introduction) as SectionModelType;
-    expect(firstSection.type).toBe(SectionType.introduction);
-    const lastSection = problem.getSectionById(SectionType.initialChallenge) as SectionModelType;
-    expect(lastSection.type).toBe(SectionType.initialChallenge);
+    const firstSection = problem.getSectionById("introduction") as SectionModelType;
+    expect(firstSection.type).toBe("introduction");
+    const lastSection = problem.getSectionById("initialChallenge") as SectionModelType;
+    expect(lastSection.type).toBe("initialChallenge");
 
   });
 });

--- a/src/models/curriculum/section.test.ts
+++ b/src/models/curriculum/section.test.ts
@@ -1,15 +1,35 @@
-import { getSectionInfo, SectionModel, SectionType } from "./section";
-import { each } from "lodash";
+import { getSectionInitials, getSectionPlaceholder, getSectionTitle,
+        kAllSectionType, SectionModel, setSectionInfoMap } from "./section";
 
-describe("workspace model", () => {
+describe("SectionModel", () => {
 
-  it("supports built-in section types", () => {
-    each(SectionType, type => {
-      const section = SectionModel.create({ type });
-      const info = getSectionInfo(type);
-      expect(section.title).toBe(info.title);
-      expect(section.abbrev).toBe(info.abbrev);
-    });
+  it("supports all/unknown section types by default", () => {
+    expect(getSectionInitials("foo")).toBe("?");
+    expect(getSectionTitle("foo")).toBe("Unknown");
+    expect(getSectionPlaceholder("foo")).toBe("");
+    expect(getSectionInitials(kAllSectionType)).toBe("*");
+    expect(getSectionTitle(kAllSectionType)).toBe("All");
+
+    const section = SectionModel.create({ type: "foo" });
+    expect(section.initials).toBe("?");
+    expect(section.title).toBe("Unknown");
+  });
+
+  it("supports setSectionInfoMap() to configure sections", () => {
+    setSectionInfoMap({ foo: { initials: "FS", title: "Foo Section", placeholder: "Foo Placeholder" } });
+
+    const fooSection = SectionModel.create({ type: "foo" });
+    expect(fooSection.initials).toBe("FS");
+    expect(fooSection.title).toBe("Foo Section");
+    expect(fooSection.placeholder).toBe("Foo Placeholder");
+
+    const barSection = SectionModel.create({ type: "bar" });
+    expect(barSection.initials).toBe("?");
+    expect(barSection.title).toBe("Unknown");
+    expect(barSection.placeholder).toBe("");
+
+    expect(getSectionInitials(kAllSectionType)).toBe("*");
+    expect(getSectionTitle(kAllSectionType)).toBe("All");
   });
 
 });

--- a/src/models/curriculum/section.ts
+++ b/src/models/curriculum/section.ts
@@ -1,56 +1,64 @@
 import { types } from "mobx-state-tree";
-import { values } from "lodash";
 import { DocumentContentModel } from "../document/document-content";
 import { SupportModel } from "./support";
+import { cloneDeep } from "lodash";
 
-export enum SectionType {
-  introduction = "introduction",
-  initialChallenge = "initialChallenge",
-  whatIf = "whatIf",
-  nowWhatDoYouKnow = "nowWhatDoYouKnow",
-  didYouKnow = "didYouKnow",
-  all = "all"
+export type SectionType = string;
+
+export interface ISectionInfo {
+  initials: string;
+  title: string;
+  placeholder?: string;
 }
 
-// TODO: figure out way to add SectionType as the index type to this const
-const sectionInfo = {
-  [SectionType.introduction]: { title: "Introduction", abbrev: "In" },
-  [SectionType.initialChallenge]: { title: "Initial Challenge", abbrev: "IC" },
-  [SectionType.whatIf]: { title: "What if...?", abbrev: "W?" },
-  [SectionType.nowWhatDoYouKnow]: { title: "Now What Do You Know?", abbrev: "N?" },
-  [SectionType.didYouKnow]: { title: "Did You Know?", abbrev: "D?" },
-  [SectionType.all]: { title: "All", abbrev: "*" }
-};
-
-export function getSectionInfo(sectionType: SectionType) {
-  return sectionInfo[sectionType];
+export interface ISectionInfoMap {
+  [sectionId: string]: ISectionInfo;
 }
 
-export function getSectionTitle(sectionType?: SectionType) {
-  return sectionInfo[sectionType || SectionType.all].title;
+export const kAllSectionType = "all";
+const kAllSectionInfo = { initials: "*", title: "All" };
+export const kUnknownSectionType = "unknown";
+const kUnknownSectionInfo = { initials: "?", title: "Unknown" };
+
+let gSectionInfoMap: ISectionInfoMap = { [kAllSectionType]: kAllSectionInfo };
+
+export function setSectionInfoMap(sectionInfoMap?: ISectionInfoMap) {
+  gSectionInfoMap = cloneDeep(sectionInfoMap) || {};
+  gSectionInfoMap[kAllSectionType] = kAllSectionInfo;
 }
 
-export function getSectionAbbrev(sectionType?: SectionType) {
-  return sectionInfo[sectionType || SectionType.all].abbrev;
+function getSectionInfo(type: SectionType) {
+  return gSectionInfoMap && gSectionInfoMap[type] || kUnknownSectionInfo;
+}
+
+export function getSectionInitials(type: SectionType) {
+  return getSectionInfo(type).initials;
+}
+
+export function getSectionTitle(type: SectionType) {
+  return getSectionInfo(type).title;
+}
+
+export function getSectionPlaceholder(type: SectionType) {
+  return getSectionInfo(type).placeholder || "";
 }
 
 export const SectionModel = types
   .model("Section", {
-    type: types.enumeration<SectionType>("SectionType", values(SectionType) as SectionType[]),
+    type: types.string, // sectionId corresponding to entry in unit
     content: types.maybe(DocumentContentModel),
     supports: types.array(SupportModel),
   })
   .views(self => {
     return {
-      get id() {
-        // until we come up with a more permanent ID
-        return self.type;
+      get initials() {
+        return getSectionInitials(self.type);
       },
       get title() {
-        return sectionInfo[self.type].title;
+        return getSectionTitle(self.type);
       },
-      get abbrev() {
-        return sectionInfo[self.type].abbrev;
+      get placeholder() {
+        return getSectionPlaceholder(self.type);
       }
     };
   });

--- a/src/models/curriculum/unit.ts
+++ b/src/models/curriculum/unit.ts
@@ -1,9 +1,8 @@
-import { SnapshotIn, types } from "mobx-state-tree";
+import { types } from "mobx-state-tree";
 import { DocumentContentModel } from "../document/document-content";
 import { InvestigationModel } from "./investigation";
-import { SectionModelType, SectionType } from "./section";
+import { ISectionInfoMap, setSectionInfoMap } from "./section";
 import { SupportModel } from "./support";
-import { each, isObject } from "lodash";
 import { StampModel } from "../tools/drawing/drawing-content";
 import { IStores } from "../stores/stores";
 import { AppConfigModelType } from "../stores/app-config-model";
@@ -15,11 +14,17 @@ export const UnitModel = types
     title: types.string,
     subtitle: "",
     placeholderText: "",
+    sections: types.maybe(types.frozen<ISectionInfoMap>()),
     lookingAhead: types.maybe(DocumentContentModel),
     investigations: types.array(InvestigationModel),
     supports: types.array(SupportModel),
     defaultStamps: types.array(StampModel),
   })
+  .actions(self => ({
+    afterCreate() {
+      setSectionInfoMap(self.sections);
+    }
+  }))
   .views(self => ({
     get fullTitle() {
       return `${self.title}${self.subtitle ? ": " + self.subtitle : ""}`;
@@ -49,37 +54,6 @@ export const UnitModel = types
 
 export type UnitModelType = typeof UnitModel.Type;
 
-/*
-  createFromJson
-
-  The JSON representation contains strings for things like SectionTypes.
-  CurriculumModel.create() expects proper TypeScript enumerated values instead.
-  This function recursively replaces SectionType strings with the corresponding
-  SectionType enumerated values and returns the resulting CurriculumModel.
- */
-export function createFromJson(json: any) {
-  const snapshot = replaceSectionTypes(json);
-  return UnitModel.create(snapshot);
-}
-
-/*
-  replaceSectionTypes
-
-  Recursively replaces SectionType strings in 'type' fields with corresponding
-  SectionType enumerated values.
- */
-function replaceSectionTypes(obj: {}): SnapshotIn<typeof UnitModel> {
-  each(obj, (v, k) => {
-    if ((k === "type") && (SectionType[v] != null)) {
-      (obj as SectionModelType).type = SectionType[v] as SectionType;
-    }
-    else if (isObject(v)) {
-      replaceSectionTypes(v);
-    }
-  });
-  return obj as SnapshotIn<typeof UnitModel>;
-}
-
 function getUnitJson(unitId: string | undefined, appConfig: AppConfigModelType ) {
   const unitUrlParam = unitId && appConfig.units.get(unitId);
   if (!unitUrlParam){
@@ -103,7 +77,7 @@ function getUnitJson(unitId: string | undefined, appConfig: AppConfigModelType )
 
 export const setUnitAndProblem = async (stores: IStores, unitId: string | undefined, problemOrdinal?: string) => {
   const unitJson = await getUnitJson(unitId, stores.appConfig);
-  const unit = createFromJson(unitJson);
+  const unit = UnitModel.create(unitJson);
   const {investigation, problem} = unit.getProblem(problemOrdinal || stores.appConfig.defaultProblemOrdinal);
 
   if (unit) {

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -201,6 +201,9 @@ export const DocumentContentModel = types
     }
   }))
   .actions(self => ({
+    addSectionHeaderRow(isSectionHeader: boolean, sectionId: string) {
+      self.insertRow(TileRowModel.create({ isSectionHeader, sectionId }));
+    },
     addTileInNewRow(content: ToolContentUnionType, options?: NewRowOptions): INewRowTile {
       const tile = createToolTileModelFromContent(content);
       const o = options || {};
@@ -472,7 +475,6 @@ function migrateSnapshot(snapshot: any): any {
   }
 
   interface OriginalToolTileModel {
-    id: string;
     layout?: OriginalTileLayoutModel;
     content: any;
   }
@@ -482,7 +484,13 @@ function migrateSnapshot(snapshot: any): any {
   tiles.forEach(tile => {
     const newTile = cloneDeep(tile);
     const tileHeight = newTile.layout && newTile.layout.height;
-    docContent.addTileInNewRow(newTile.content, { rowHeight: tileHeight });
+    const { isSectionHeader, sectionId } = newTile.content;
+    if (isSectionHeader && sectionId) {
+      docContent.addSectionHeaderRow(isSectionHeader, sectionId);
+    }
+    else {
+      docContent.addTileInNewRow(newTile.content, { rowHeight: tileHeight });
+    }
   });
   return getSnapshot(docContent);
 }

--- a/src/models/document/tile-row.ts
+++ b/src/models/document/tile-row.ts
@@ -24,6 +24,8 @@ export const TileRowModel = types
   .model("TileRow", {
     id: types.optional(types.identifier, () => uuid()),
     height: types.maybe(types.number),
+    isSectionHeader: false,
+    sectionId: types.maybe(types.string),
     tiles: types.array(TileLayoutModel)
   })
   .views(self => ({
@@ -56,6 +58,10 @@ export const TileRowModel = types
     // undefined height == default to content height
     setRowHeight(height?: number) {
       self.height = height;
+    },
+    setSectionHeader(sectionId: string) {
+      self.isSectionHeader = true;
+      self.sectionId = sectionId;
     },
     insertTileInRow(tile: ToolTileModelType, tileIndex?: number) {
       const dstTileIndex = (tileIndex != null) && (tileIndex >= 0) && (tileIndex < self.tiles.length)

--- a/src/models/stores/app-config-model.ts
+++ b/src/models/stores/app-config-model.ts
@@ -42,6 +42,7 @@ export const AppConfigModel = types
     defaultLearningLogTitle: "UntitledLog",
     initialLearningLogTitle: "",
     defaultLearningLogDocument: false,
+    autoSectionProblemDocuments: false,
     documentLabelProperties: types.array(types.string),
     documentLabels: types.map(DocumentLabelModel),
     showClassSwitcher: false,

--- a/src/models/stores/supports.test.ts
+++ b/src/models/stores/supports.test.ts
@@ -5,7 +5,6 @@ import { UnitModel } from "../curriculum/unit";
 import { createTextSupport, ESupportType } from "../curriculum/support";
 import { InvestigationModel } from "../curriculum/investigation";
 import { ProblemModel } from "../curriculum/problem";
-import { SectionType } from "../curriculum/section";
 import { omitUndefined } from "../../utilities/test-utils";
 import { cloneDeep } from "lodash";
 
@@ -94,14 +93,14 @@ describe("supports model", () => {
       title: "Problem 1",
       sections: [
         {
-          type: SectionType.introduction,
+          type: "introduction",
           supports: [
             {type: ESupportType.text, content: "Investigation 1, Problem 1, section: introduction, support #1"},
             {type: ESupportType.text, content: "Investigation 1, Problem 1, section: introduction, support #2"}
           ]
         },
         {
-          type: SectionType.initialChallenge,
+          type: "initialChallenge",
           supports: [
             {type: ESupportType.text, content: "Investigation 1, Problem 1, section: initial challenge, support #1"},
             {type: ESupportType.text, content: "Investigation 1, Problem 1, section: initial challenge, support #2"}
@@ -123,14 +122,14 @@ describe("supports model", () => {
           title: "Problem 2",
           sections: [
             {
-              type: SectionType.introduction,
+              type: "introduction",
               supports: [
                 {type: ESupportType.text, content: "Investigation 1, Problem 2, section: introduction, support #1"},
                 {type: ESupportType.text, content: "Investigation 1, Problem 2, section: introduction, support #2"}
               ]
             },
             {
-              type: SectionType.initialChallenge,
+              type: "initialChallenge",
               supports: [
                 {type: ESupportType.text,
                   content: "Investigation 1, Problem 2, section: initial challenge, support #1"},
@@ -159,14 +158,14 @@ describe("supports model", () => {
           title: "Problem 1",
           sections: [
             {
-              type: SectionType.introduction,
+              type: "introduction",
               supports: [
                 {type: ESupportType.text, content: "Investigation 2, Problem 1, section: introduction, support #1"},
                 {type: ESupportType.text, content: "Investigation 2, Problem 1, section: introduction, support #2"}
               ]
             },
             {
-              type: SectionType.initialChallenge,
+              type: "initialChallenge",
               supports: [
                 {type: ESupportType.text,
                   content: "Investigation 2, Problem 1, section: initial challenge, support #1"},
@@ -185,14 +184,14 @@ describe("supports model", () => {
           title: "Problem 2",
           sections: [
             {
-              type: SectionType.introduction,
+              type: "introduction",
               supports: [
                 {type: ESupportType.text, content: "Investigation 2, Problem 2, section: introduction, support #1"},
                 {type: ESupportType.text, content: "Investigation 2, Problem 2, section: introduction, support #2"}
               ]
             },
             {
-              type: SectionType.initialChallenge,
+              type: "initialChallenge",
               supports: [
                 {type: ESupportType.text,
                   content: "Investigation 2, Problem 2, section: initial challenge, support #1"},
@@ -226,7 +225,7 @@ describe("supports model", () => {
       problem: ProblemModel.create(cloneDeep(problem1))});
 
     expect(supports.getSupportsForUserProblem(
-                      { sectionId: SectionType.introduction, groupId: "groupId", userId: "userId" }))
+                      { sectionId: "introduction", groupId: "groupId", userId: "userId" }))
       .toEqual([
         {
           sectionId: "introduction",
@@ -287,12 +286,12 @@ describe("supports model", () => {
     const classSupportAll = {key: "1", support: createTextSupport(""), type: SupportTarget.problem,
       audience: ClassAudienceModel.create(), authoredTime: 42};
     const classSupportIntro = {key: "2", support: createTextSupport(""),
-      type: SupportTarget.section, sectionId: SectionType.introduction,
+      type: SupportTarget.section, sectionId: "introduction",
       audience: ClassAudienceModel.create(), authoredTime: 43};
     const groupSupport = {key: "3", support: createTextSupport(""), type: SupportTarget.problem,
       audience: GroupAudienceModel.create({identifier: "group1"}), authoredTime: 44};
     const userSupport = {key: "4", support: createTextSupport(""),
-      type: SupportTarget.section, sectionId: SectionType.didYouKnow,
+      type: SupportTarget.section, sectionId: "didYouKnow",
       audience: UserAudienceModel.create({identifier: "user1"}), authoredTime: 45};
 
     const supports = SupportsModel.create({
@@ -309,30 +308,30 @@ describe("supports model", () => {
     });
 
     const generalClassSupports = supports.getSupportsForUserProblem(
-                                  { sectionId: SectionType.didYouKnow, groupId: "group0", userId: "user0" });
+                                  { sectionId: "didYouKnow", groupId: "group0", userId: "user0" });
     expect(generalClassSupports.length).toEqual(1);
     expect((generalClassSupports[0] as TeacherSupportModelType).key).toEqual(classSupportAll.key);
 
     const setionClassSupports = supports.getSupportsForUserProblem(
-                                  { sectionId: SectionType.introduction, groupId: "group0", userId: "user0" });
+                                  { sectionId: "introduction", groupId: "group0", userId: "user0" });
     expect(setionClassSupports.length).toEqual(2);
     expect((setionClassSupports[0] as TeacherSupportModelType).key).toEqual(classSupportAll.key);
     expect((setionClassSupports[1] as TeacherSupportModelType).key).toEqual(classSupportIntro.key);
 
     const groupSupports = supports.getSupportsForUserProblem(
-                            { sectionId: SectionType.didYouKnow, groupId: "group1", userId: "user0" });
+                            { sectionId: "didYouKnow", groupId: "group1", userId: "user0" });
     expect(groupSupports.length).toEqual(2);
     expect((groupSupports[0] as TeacherSupportModelType).key).toEqual(classSupportAll.key);
     expect((groupSupports[1] as TeacherSupportModelType).key).toEqual(groupSupport.key);
 
     const userSupports = supports.getSupportsForUserProblem(
-                            { sectionId: SectionType.didYouKnow, groupId: "group0", userId: "user1" });
+                            { sectionId: "didYouKnow", groupId: "group0", userId: "user1" });
     expect(userSupports.length).toEqual(2);
     expect((userSupports[0] as TeacherSupportModelType).key).toEqual(classSupportAll.key);
     expect((userSupports[1] as TeacherSupportModelType).key).toEqual(userSupport.key);
 
     const multiSupports = supports.getSupportsForUserProblem(
-                            { sectionId: SectionType.didYouKnow, groupId: "group1", userId: "user1" });
+                            { sectionId: "didYouKnow", groupId: "group1", userId: "user1" });
     expect(multiSupports.length).toEqual(3);
     expect((multiSupports[0] as TeacherSupportModelType).key).toEqual(classSupportAll.key);
     expect((multiSupports[1] as TeacherSupportModelType).key).toEqual(groupSupport.key);

--- a/src/models/stores/supports.ts
+++ b/src/models/stores/supports.ts
@@ -2,7 +2,7 @@ import { types, Instance, getSnapshot } from "mobx-state-tree";
 import { cloneDeep } from "lodash";
 import { InvestigationModelType } from "../curriculum/investigation";
 import { ProblemModelType } from "../curriculum/problem";
-import { getSectionAbbrev, getSectionTitle, SectionType } from "../curriculum/section";
+import { getSectionInitials, getSectionTitle, kAllSectionType, SectionType } from "../curriculum/section";
 import { ESupportType, SupportModel, SupportModelType } from "../curriculum/support";
 import { UnitModelType } from "../curriculum/unit";
 import { DB } from "../../lib/db";
@@ -30,6 +30,8 @@ export enum SupportType {
   curricular = "curricular"
 }
 
+export type SectionTarget = SectionType;
+
 export enum SupportTarget {
   unit = "unit",
   investigation = "investigation",
@@ -37,10 +39,8 @@ export enum SupportTarget {
   section = "section",
 }
 
-export type TeacherSupportSectionTarget = SectionType;
-
 export interface ISupportTarget {
-  sectionId?: SectionType;
+  sectionId?: SectionTarget;
   groupId?: string;
   userId?: string;
 }
@@ -71,7 +71,7 @@ export const TeacherSupportModel = types
     support: SupportModel,
     type: types.enumeration<SupportTarget>("SupportTarget", Object.values(SupportTarget)),
     visible: false,
-    sectionId: types.maybe(types.enumeration<SectionType>("SectionType", Object.values(SectionType))),
+    sectionId: types.maybe(types.string),
     audience: AudienceModel,
     authoredTime: types.number,
     originDoc: types.maybe(types.string),
@@ -79,10 +79,10 @@ export const TeacherSupportModel = types
     deleted: false
   })
   .views(self => ({
-    get sectionTarget(): TeacherSupportSectionTarget {
+    get sectionTarget() {
       return (self.type === SupportTarget.section) && self.sectionId
               ? self.sectionId
-              : SectionType.all;
+              : kAllSectionType;
     }
   }))
   .views(self => ({
@@ -187,7 +187,7 @@ export const SupportsModel = types
         investigation && investigation.supports.forEach(createItem(SupportTarget.investigation));
         problem && problem.supports.forEach(createItem(SupportTarget.problem));
         problem && problem.sections.forEach((section) => {
-          section.supports.forEach(createItem(SupportTarget.section, section.id));
+          section.supports.forEach(createItem(SupportTarget.section, section.type));
         });
 
         self.curricularSupports.replace(supports);
@@ -238,7 +238,7 @@ function getTeacherSupportCaption(support: TeacherSupportModelType,
   const investigationPart = investigation ? `${investigation.ordinal}` : "*";
   const problemPart = problem ? `${problem.ordinal}` : "*";
   const { sectionId } = support;
-  const sectionPart = sectionId ? " " + getSectionAbbrev(sectionId as SectionType) : "";
+  const sectionPart = sectionId ? " " + getSectionInitials(sectionId) : "";
   return `${investigationPart}.${problemPart}${sectionPart} ${support.caption || "Untitled"}`;
 }
 

--- a/src/models/stores/ui.test.ts
+++ b/src/models/stores/ui.test.ts
@@ -1,5 +1,5 @@
 import { UIModel, UIModelType, UIDialogModelType } from "./ui";
-import { SectionModel, SectionType } from "../curriculum/section";
+import { SectionModel } from "../curriculum/section";
 import { ProblemWorkspace, LearningLogWorkspace } from "./workspace";
 import { ToolTileModel } from "../tools/tool-tile";
 import { ERightNavTab } from "../view/right-nav";
@@ -115,7 +115,7 @@ describe("ui model", () => {
 
   it("allows activeSection to be set", () => {
     SectionModel.create({
-      type: SectionType.introduction
+      type: "introduction"
     });
     ui.setActiveSectionIndex(1);
     expect(ui.activeSectionIndex).toBe(1);

--- a/src/models/stores/workspace.ts
+++ b/src/models/stores/workspace.ts
@@ -81,7 +81,7 @@ export const WorkspaceModel = types
       },
 
       setPrimaryGhostSection(section: SectionModelType) {
-        self.primaryDocumentKey = createGhostSectionDocumentKey(section.id);
+        self.primaryDocumentKey = createGhostSectionDocumentKey(section.type);
       },
     };
   });

--- a/src/models/tools/placeholder/placeholder-content.ts
+++ b/src/models/tools/placeholder/placeholder-content.ts
@@ -5,7 +5,7 @@ export const kPlaceholderToolID = "Placeholder";
 export const PlaceholderContentModel = types
   .model("PlaceholderContent", {
     type: types.optional(types.literal(kPlaceholderToolID), kPlaceholderToolID),
-    prompt: types.string
+    prompt: ""
   });
 
 export type PlaceholderContentModelType = Instance<typeof PlaceholderContentModel>;

--- a/src/models/tools/placeholder/placeholder-content.ts
+++ b/src/models/tools/placeholder/placeholder-content.ts
@@ -1,0 +1,12 @@
+import { types, Instance, SnapshotOut } from "mobx-state-tree";
+
+export const kPlaceholderToolID = "Placeholder";
+
+export const PlaceholderContentModel = types
+  .model("PlaceholderContent", {
+    type: types.optional(types.literal(kPlaceholderToolID), kPlaceholderToolID),
+    prompt: types.string
+  });
+
+export type PlaceholderContentModelType = Instance<typeof PlaceholderContentModel>;
+export type PlaceholderContentSnapshotOutType = SnapshotOut<typeof PlaceholderContentModel>;

--- a/src/models/tools/tool-tile.test.ts
+++ b/src/models/tools/tool-tile.test.ts
@@ -14,7 +14,6 @@ describe("ToolTileModel", () => {
       if (toolID === kUnknownToolID) {
         content.originalType = "foo";
       }
-      content.url = "foo";
       let toolTile = ToolTileModel.create({
                       content: ToolContentModel.create(content)
                     });

--- a/src/models/tools/tool-tile.ts
+++ b/src/models/tools/tool-tile.ts
@@ -1,4 +1,5 @@
 import { types, Instance, SnapshotOut } from "mobx-state-tree";
+import { kPlaceholderToolID } from "./placeholder/placeholder-content";
 import { findMetadata, ToolContentUnion, ToolContentUnionType } from "./tool-types";
 import * as uuid from "uuid/v4";
 
@@ -29,6 +30,9 @@ export const ToolTileModel = types
     },
     get isUserResizable() {
       return !!(self.content as any).isUserResizable;
+    },
+    get isPlaceholder() {
+      return self.content.type === kPlaceholderToolID;
     }
   }))
   .actions(self => ({

--- a/src/models/tools/tool-types.ts
+++ b/src/models/tools/tool-types.ts
@@ -2,6 +2,8 @@ import { IAnyType, Instance, SnapshotOut, types } from "mobx-state-tree";
 import { kGeometryToolID, GeometryContentModel, GeometryContentModelType,
           GeometryMetadataModel, GeometryMetadataModelType } from "./geometry/geometry-content";
 import { kImageToolID, ImageContentModel, ImageContentModelType } from "./image/image-content";
+import { kPlaceholderToolID, PlaceholderContentModel, PlaceholderContentModelType
+      } from "./placeholder/placeholder-content";
 import { kTableToolID, TableContentModel, TableContentModelType,
           TableMetadataModel, TableMetadataModelType } from "./table/table-content";
 import { kTextToolID, TextContentModel, TextContentModelType } from "./text/text-content";
@@ -12,6 +14,7 @@ import { DrawingContentModelType, DrawingContentModel, kDrawingToolID,
 export const ToolTypeEnum = types.enumeration(
                               "ToolTypes",
                               [
+                                kPlaceholderToolID,
                                 kGeometryToolID,
                                 kImageToolID,
                                 kTableToolID,
@@ -21,6 +24,7 @@ export const ToolTypeEnum = types.enumeration(
                               ]);
 export const ToolContentUnion = types.union(
                                   { dispatcher: toolFactory },
+                                  PlaceholderContentModel,
                                   GeometryContentModel,
                                   ImageContentModel,
                                   TableContentModel,
@@ -28,7 +32,8 @@ export const ToolContentUnion = types.union(
                                   DrawingContentModel,
                                   UnknownContentModel);
 
-export type ToolContentUnionType = GeometryContentModelType |
+export type ToolContentUnionType = PlaceholderContentModelType |
+                                    GeometryContentModelType |
                                     ImageContentModelType |
                                     TableContentModelType |
                                     TextContentModelType |
@@ -62,6 +67,7 @@ interface IPrivate {
 
 export const _private: IPrivate = {
   toolMap: {
+    [kPlaceholderToolID]: PlaceholderContentModel,
     [kGeometryToolID]: GeometryContentModel,
     [kImageToolID]: ImageContentModel,
     [kTableToolID]: TableContentModel,


### PR DESCRIPTION
Implements necessary infrastructure to support section headers, including code to automatically add section headers to newly created problem documents and to query the document for the number of tiles in a particular section.

@mklewandowski will be submitting a subsequent PR to attach the UI he's been working on to this infrastructure.