### PR TITLE
[#168955293] Prevent Deleting Last Personal and Learning Log Documents

### DIFF
--- a/src/clue/clue.sass
+++ b/src/clue/clue.sass
@@ -76,6 +76,13 @@
               background-image: url("../assets/icons/share/share-hover.svg")
             &:active
               background-image: url("../assets/icons/share/share-active.svg")
+        .button-icon.delete-disabled
+          background-image: url("../assets/icons/delete/delete-disabled.svg")
+          cursor: default
+          &:active
+            transform-origin: center
+            transform: none
+            cursor: default
   .statusbar
     &.personal, &.personalPublication, &.problem, &.publication
       background-color: $sage-light-1

--- a/src/clue/clue.sass
+++ b/src/clue/clue.sass
@@ -57,11 +57,19 @@
           &:active
             background-image: url("../assets/icons/copy/copy-active.svg")
         .button-icon.delete
-          background-image: url("../assets/icons/delete/delete.svg")
-          &:hover
-              background-image: url("../assets/icons/delete/delete-hover.svg")
-          &:active
-              background-image: url("../assets/icons/delete/delete-active.svg")
+          &.enabled
+            background-image: url("../assets/icons/delete/delete.svg")
+            &:hover
+                background-image: url("../assets/icons/delete/delete-hover.svg")
+            &:active
+                background-image: url("../assets/icons/delete/delete-active.svg")
+          &.disabled
+            background-image: url("../assets/icons/delete/delete-disabled.svg")
+            cursor: default
+            &:active
+              transform-origin: center
+              transform: none
+              cursor: default
         .button-icon.share
           &.visibility.public
             background-image: url("../assets/icons/share/share.svg")
@@ -76,13 +84,8 @@
               background-image: url("../assets/icons/share/share-hover.svg")
             &:active
               background-image: url("../assets/icons/share/share-active.svg")
-        .button-icon.delete-disabled
-          background-image: url("../assets/icons/delete/delete-disabled.svg")
-          cursor: default
-          &:active
-            transform-origin: center
-            transform: none
-            cursor: default
+      .icon-button.delete-disabled
+        cursor: default
   .statusbar
     &.personal, &.personalPublication, &.problem, &.publication
       background-color: $sage-light-1

--- a/src/components/document/document-workspace.tsx
+++ b/src/components/document/document-workspace.tsx
@@ -313,27 +313,22 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps, {}> {
 
   private handleDeleteDocument = (document: DocumentModelType) => {
     const { appConfig, documents, user } = this.stores;
-    let countNotDeleted = 0;
-    const getOtherDocument = documents.byTypeForUser((PersonalDocument || LearningLogDocument), user.id);
-    getOtherDocument.forEach(doc => {
-      const isDeletedStatus = doc.getProperty("isDeleted");
-      if (isDeletedStatus !== "true") {
-        ++countNotDeleted;
-      }
-    });
+    const otherDocuments = documents.byTypeForUser(document.type, user.id);
+    const countNotDeleted = otherDocuments.reduce((prev, doc) => doc.getProperty("isDeleted") ? prev : prev + 1, 0);
     const docTypeString = document.getLabel(appConfig, 1);
     const docTypeStringL = document.getLabel(appConfig, 1, true);
-    this.stores.ui.confirm(`Delete this ${docTypeStringL}? ${document.title}`, `Delete ${docTypeString}`)
+    if (countNotDeleted <= 1) {
+      this.stores.ui.alert(`Cannot delete the last ${docTypeStringL}.`, `Error: Delete ${docTypeString}`);
+    }
+    else {
+      this.stores.ui.confirm(`Delete this ${docTypeStringL}? ${document.title}`, `Delete ${docTypeString}`)
       .then((confirmDelete: boolean) => {
-        const docType = (document.type === PersonalDocument) || (document.type === LearningLogDocument);
-        if (confirmDelete && docType && (countNotDeleted > 1)) {
+        if (confirmDelete) {
           document.setProperty("isDeleted", "true");
           this.handleDeleteOpenPrimaryDocument();
         }
-        if (countNotDeleted <= 1) {
-          this.stores.ui.alert(`Cannot delete the last ${docTypeStringL}.`, `Error: Delete ${docTypeString}`);
-        }
       });
+    }
   }
 
   private handleDeleteOpenPrimaryDocument = async () => {

--- a/src/components/document/document.tsx
+++ b/src/components/document/document.tsx
@@ -96,6 +96,12 @@ const DeleteButton = ({ onClick }: { onClick: () => void }) => {
   );
 };
 
+const DeleteDisabledButton = () => {
+  return (
+    <IconButton icon="delete-disabled" key="delete-disabled" className="action icon-delete-disabled" />
+  );
+};
+
 const ShareButton = ({ onClick, isShared }: { onClick: () => void, isShared: boolean }) => {
   const visibility = isShared ? "public" : "private";
   return (
@@ -228,14 +234,24 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
 
   private renderOtherDocumentTitleBar(type: string, hideButtons?: boolean) {
     const {document} = this.props;
-    const { user: { isTeacher } } = this.stores;
+    const { user: { isTeacher }, documents, user } = this.stores;
+    let countNotDeleted = 0;
+    const getOtherDocument = documents.byTypeForUser((PersonalDocument || LearningLogDocument), user.id);
+    getOtherDocument.forEach(doc => {
+      const isDeletedStatus = doc.getProperty("isDeleted");
+      if (isDeletedStatus !== "true") {
+        ++countNotDeleted;
+      }
+    });
     return (
       <div className={`titlebar ${type}`}>
         {!hideButtons &&
           <div className="actions">
             <NewButton onClick={this.handleNewDocumentClick} />
             <CopyButton onClick={this.handleCopyDocumentClick} />
-            <DeleteButton onClick={this.handleDeleteDocumentClick} />
+            {countNotDeleted > 1
+              ? <DeleteButton onClick={this.handleDeleteDocumentClick} /> : <DeleteDisabledButton />
+            }
           </div>
         }
         {

--- a/src/components/document/document.tsx
+++ b/src/components/document/document.tsx
@@ -89,17 +89,13 @@ const CopyButton = ({ onClick }: { onClick: () => void }) => {
   );
 };
 
-const DeleteButton = ({ onClick }: { onClick: () => void }) => {
-  return (
-    <IconButton icon="delete" key="delete" className="action icon-delete"
-                onClickButton={onClick} />
-  );
-};
-
-const DeleteDisabledButton = () => {
-  return (
-    <IconButton icon="delete-disabled" key="delete-disabled" className="action icon-delete-disabled" />
-  );
+const DeleteButton = ({ onClick, enabled }: { onClick: () => void, enabled: boolean }) => {
+    const enabledClass = enabled ? "enabled" : "disabled";
+    return (
+      <IconButton icon="delete" key={`delete-${enabledClass}`} className={`action icon-delete delete-${enabledClass}`}
+                  enabled={enabled} innerClassName={enabledClass}
+                  onClickButton={enabled ? onClick : undefined} />
+    );
 };
 
 const ShareButton = ({ onClick, isShared }: { onClick: () => void, isShared: boolean }) => {
@@ -235,23 +231,15 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
   private renderOtherDocumentTitleBar(type: string, hideButtons?: boolean) {
     const {document} = this.props;
     const { user: { isTeacher }, documents, user } = this.stores;
-    let countNotDeleted = 0;
-    const getOtherDocument = documents.byTypeForUser((PersonalDocument || LearningLogDocument), user.id);
-    getOtherDocument.forEach(doc => {
-      const isDeletedStatus = doc.getProperty("isDeleted");
-      if (isDeletedStatus !== "true") {
-        ++countNotDeleted;
-      }
-    });
+    const otherDocuments = documents.byTypeForUser(document.type, user.id);
+    const countNotDeleted = otherDocuments.reduce((prev, doc) => doc.getProperty("isDeleted") ? prev : prev + 1, 0);
     return (
       <div className={`titlebar ${type}`}>
         {!hideButtons &&
           <div className="actions">
             <NewButton onClick={this.handleNewDocumentClick} />
             <CopyButton onClick={this.handleCopyDocumentClick} />
-            {countNotDeleted > 1
-              ? <DeleteButton onClick={this.handleDeleteDocumentClick} /> : <DeleteDisabledButton />
-            }
+            <DeleteButton enabled={countNotDeleted > 1} onClick={this.handleDeleteDocumentClick} />
           </div>
         }
         {

--- a/src/components/utilities/icon-button.tsx
+++ b/src/components/utilities/icon-button.tsx
@@ -5,7 +5,7 @@ interface IconButtonProps {
   key: string;
   className: string;
   innerClassName?: string;
-  onClickButton: () => void;
+  onClickButton?: () => void;
   url?: string;
 }
 

--- a/src/components/utilities/icon-button.tsx
+++ b/src/components/utilities/icon-button.tsx
@@ -6,6 +6,7 @@ interface IconButtonProps {
   className: string;
   innerClassName?: string;
   onClickButton?: () => void;
+  enabled?: boolean;
   url?: string;
 }
 


### PR DESCRIPTION
This prevents users from deleting their last Personal and Learning Log documents via both an icon change and additionally as back-up a pop-up error alert message.