### PR TITLE
Sectioned documents

### DIFF
--- a/src/components/document/document-content.tsx
+++ b/src/components/document/document-content.tsx
@@ -150,7 +150,7 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
       }
       return row
               ? <TileRowComponent key={row.id} docId={content.contentId} model={row}
-                                  height={rowHeight} tileMap={tileMap}
+                                  rowIndex={index} height={rowHeight} tileMap={tileMap}
                                   dropHighlight={dropHighlight}
                                   ref={(elt) => this.rowRefs.push(elt)} {...others} />
               : null;
@@ -345,7 +345,7 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
     if (e.dataTransfer.getData(kDragRowHeight)) {
       dragRowHeight = +e.dataTransfer.getData(kDragRowHeight);
     }
-    content.copyTileIntoRow(dragTileContent, dragTileId, rowInsertIndex, dragRowHeight);
+    content.copyTileIntoNewRow(dragTileContent, dragTileId, rowInsertIndex, dragRowHeight);
   }
 
   private handleInsertNewTile = (e: React.DragEvent<HTMLDivElement>) => {

--- a/src/components/document/document-workspace.tsx
+++ b/src/components/document/document-workspace.tsx
@@ -80,8 +80,7 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps, {}> {
       const tiles: any = [];
       problem.sections.forEach(section => {
         tiles.push({ content: { isSectionHeader: true, sectionId: section.type }});
-        const placeholder = getSectionPlaceholder(section.type);
-        tiles.push({ content: { type: "Placeholder", prompt: placeholder }});
+        tiles.push({ content: { type: "Placeholder", sectionId: section.type }});
       });
       return DocumentContentModel.create({ tiles } as any);
     }

--- a/src/components/document/tile-row.tsx
+++ b/src/components/document/tile-row.tsx
@@ -107,13 +107,17 @@ export class TileRowComponent extends BaseComponent<IProps, IState> {
   private renderDragDropHandles() {
     const { model: { isUserResizable }, dropHighlight } = this.props;
     const highlight = this.state.tileAcceptDrop ? undefined : dropHighlight;
+    const { isSectionHeader } = this.props.model;
+    if (isSectionHeader && highlight === "top") {
+      // WTD determine if 0th section, if so, disable drag highlight
+    }
     return [
       <div key="top-drop-feedback"
           className={`drop-feedback ${highlight === "top" ? "show top" : ""}`} />,
       <div key="left-drop-feedback"
-          className={`drop-feedback ${highlight === "left" ? "show left" : ""}`} />,
+          className={`drop-feedback ${highlight === "left" && !isSectionHeader ? "show left" : ""}`} />,
       <div key="right-drop-feedback"
-          className={`drop-feedback ${highlight === "right" ? "show right" : ""}`} />,
+          className={`drop-feedback ${highlight === "right" && !isSectionHeader ? "show right" : ""}`} />,
       <div key="bottom-drop-feedback"
           className={`drop-feedback ${highlight === "bottom" ? "show bottom" : ""}`} />,
       <div key="bottom-resize-handle"

--- a/src/components/document/tile-row.tsx
+++ b/src/components/document/tile-row.tsx
@@ -50,6 +50,7 @@ interface IProps {
   docId: string;
   scale?: number;
   model: TileRowModelType;
+  rowIndex: number;
   height?: number;
   tileMap: any;
   readOnly?: boolean;
@@ -105,21 +106,22 @@ export class TileRowComponent extends BaseComponent<IProps, IState> {
   }
 
   private renderDragDropHandles() {
-    const { model: { isUserResizable }, dropHighlight } = this.props;
+    const { model: { isUserResizable }, rowIndex, dropHighlight } = this.props;
     const highlight = this.state.tileAcceptDrop ? undefined : dropHighlight;
     const { isSectionHeader } = this.props.model;
-    if (isSectionHeader && highlight === "top") {
-      // WTD determine if 0th section, if so, disable drag highlight
-    }
+    const showTopHighlight = (highlight === "top") && (!isSectionHeader || (rowIndex > 0));
+    const showLeftHighlight = (highlight === "left") && !isSectionHeader;
+    const showRightHighlight = (highlight === "right") && !isSectionHeader;
+    const showBottomHighlight = (highlight === "bottom");
     return [
       <div key="top-drop-feedback"
-          className={`drop-feedback ${highlight === "top" ? "show top" : ""}`} />,
+          className={`drop-feedback ${showTopHighlight ? "show top" : ""}`} />,
       <div key="left-drop-feedback"
-          className={`drop-feedback ${highlight === "left" && !isSectionHeader ? "show left" : ""}`} />,
+          className={`drop-feedback ${showLeftHighlight ? "show left" : ""}`} />,
       <div key="right-drop-feedback"
-          className={`drop-feedback ${highlight === "right" && !isSectionHeader ? "show right" : ""}`} />,
+          className={`drop-feedback ${showRightHighlight ? "show right" : ""}`} />,
       <div key="bottom-drop-feedback"
-          className={`drop-feedback ${highlight === "bottom" ? "show bottom" : ""}`} />,
+          className={`drop-feedback ${showBottomHighlight ? "show bottom" : ""}`} />,
       <div key="bottom-resize-handle"
         className={`bottom-resize-handle ${isUserResizable ? "enable" : "disable"}`}
         draggable={isUserResizable}

--- a/src/components/tools/placeholder-tool/placeholder-tool.tsx
+++ b/src/components/tools/placeholder-tool/placeholder-tool.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
 import { BaseComponent } from "../../base";
-import { ToolTileModelType } from "../../../models/tools/tool-tile";
+import { getSectionPlaceholder } from "../../../models/curriculum/section";
 import { PlaceholderContentModelType } from "../../../models/tools/placeholder/placeholder-content";
+import { ToolTileModelType } from "../../../models/tools/tool-tile";
 
 import "./placeholder-tool.sass";
 
@@ -18,9 +19,11 @@ export default class PlaceholderToolComponent extends BaseComponent<IProps, {}> 
     );
   }
 
-  private renderPlaceholderText = () => {
-    const placeholderContent = this.props.model.content as PlaceholderContentModelType;
-    const placeholderLines = placeholderContent.prompt.split("\n");
+  private renderPlaceholderText() {
+    const content = this.props.model.content as PlaceholderContentModelType;
+    const { sectionId } = content;
+    const placeholder = getSectionPlaceholder(sectionId);
+    const placeholderLines = placeholder.split("\n");
     return (
       <div>
         {placeholderLines.map((line, index) => {

--- a/src/components/tools/tool-tile.tsx
+++ b/src/components/tools/tool-tile.tsx
@@ -135,11 +135,14 @@ export class ToolTileComponent extends BaseComponent<IProps, {}> {
           onDragStart={this.handleToolDragStart}
           draggable={true}
       >
-        <div className="tool-tile-drag-handle tool select">
-          <svg className={`icon icon-select-tool`}>
-            <use xlinkHref={`#icon-select-tool`} />
-          </svg>
-        </div>
+        { ToolComponent !== PlaceholderToolComponent
+          ? <div className="tool-tile-drag-handle tool select">
+            <svg className={`icon icon-select-tool`}>
+              <use xlinkHref={`#icon-select-tool`} />
+            </svg>
+          </div>
+          : null
+        }
         {this.renderTile(ToolComponent)}
         {this.renderTileComments()}
       </div>
@@ -207,6 +210,11 @@ export class ToolTileComponent extends BaseComponent<IProps, {}> {
     }
     // set the drag data
     const { model, docId, height, scale } = this.props;
+    const ToolComponent = kToolComponentMap[model.content.type];
+    if (ToolComponent === PlaceholderToolComponent) {
+      e.preventDefault();
+      return;
+    }
     const snapshot = cloneDeep(getSnapshot(model));
     const id = snapshot.id;
     delete snapshot.id;
@@ -222,7 +230,6 @@ export class ToolTileComponent extends BaseComponent<IProps, {}> {
     e.dataTransfer.setData(dragTileType(model.content.type), model.content.type);
 
     // set the drag image
-    const ToolComponent = kToolComponentMap[model.content.type];
     const dragElt = e.target as HTMLElement;
     // tool components can provide alternate dom node for drag image
     const dragImage = ToolComponent && ToolComponent.getDragImageNode

--- a/src/lib/logger.test.ts
+++ b/src/lib/logger.test.ts
@@ -169,7 +169,7 @@ describe("logger", () => {
 
       const serialized = JSON.stringify(getSnapshot(tileToCopy));
 
-      await destinationDocument.content.copyTileIntoRow(serialized, tileToCopy.id, 0);
+      await destinationDocument.content.copyTileIntoNewRow(serialized, tileToCopy.id, 0);
     });
 
   });

--- a/src/models/curriculum/section.test.ts
+++ b/src/models/curriculum/section.test.ts
@@ -1,14 +1,15 @@
 import { getSectionInitials, getSectionPlaceholder, getSectionTitle,
-        kAllSectionType, SectionModel, setSectionInfoMap } from "./section";
+        kAllSectionType, SectionModel, setSectionInfoMap, kDefaultPlaceholder } from "./section";
 
 describe("SectionModel", () => {
 
   it("supports all/unknown section types by default", () => {
     expect(getSectionInitials("foo")).toBe("?");
     expect(getSectionTitle("foo")).toBe("Unknown");
-    expect(getSectionPlaceholder("foo")).toBe("");
+    expect(getSectionPlaceholder("foo")).toBe(kDefaultPlaceholder);
     expect(getSectionInitials(kAllSectionType)).toBe("*");
     expect(getSectionTitle(kAllSectionType)).toBe("All");
+    expect(getSectionPlaceholder(kAllSectionType)).toBe(kDefaultPlaceholder);
 
     const section = SectionModel.create({ type: "foo" });
     expect(section.initials).toBe("?");
@@ -26,7 +27,7 @@ describe("SectionModel", () => {
     const barSection = SectionModel.create({ type: "bar" });
     expect(barSection.initials).toBe("?");
     expect(barSection.title).toBe("Unknown");
-    expect(barSection.placeholder).toBe("");
+    expect(barSection.placeholder).toBe(kDefaultPlaceholder);
 
     expect(getSectionInitials(kAllSectionType)).toBe("*");
     expect(getSectionTitle(kAllSectionType)).toBe("All");

--- a/src/models/curriculum/section.ts
+++ b/src/models/curriculum/section.ts
@@ -18,7 +18,8 @@ export interface ISectionInfoMap {
 export const kAllSectionType = "all";
 const kAllSectionInfo = { initials: "*", title: "All" };
 export const kUnknownSectionType = "unknown";
-const kUnknownSectionInfo = { initials: "?", title: "Unknown" };
+export const kDefaultPlaceholder = "Create or drag tiles here";
+const kUnknownSectionInfo = { initials: "?", title: "Unknown", placeholder: kDefaultPlaceholder };
 
 let gSectionInfoMap: ISectionInfoMap = { [kAllSectionType]: kAllSectionInfo };
 
@@ -40,7 +41,7 @@ export function getSectionTitle(type: SectionType) {
 }
 
 export function getSectionPlaceholder(type: SectionType) {
-  return getSectionInfo(type).placeholder || "";
+  return getSectionInfo(type).placeholder || kDefaultPlaceholder;
 }
 
 export const SectionModel = types

--- a/src/models/document/document-content.test.ts
+++ b/src/models/document/document-content.test.ts
@@ -1,4 +1,4 @@
-import { DocumentContentModel, DocumentContentModelType } from "./document-content";
+import { DocumentContentModel, DocumentContentModelType, cloneContentWithUniqueIds } from "./document-content";
 import { defaultTextContent } from "../tools/text/text-content";
 
 describe("DocumentContentModel", () => {
@@ -394,4 +394,35 @@ describe("DocumentContentModel -- sectioned documents --", () => {
     expect(isContentSection("B")).toBe(true);
   });
 
+});
+
+describe("DocumentContentModel", () => {
+
+  it("can cloneWithUniqueIds()", () => {
+    const content = DocumentContentModel.create({});
+    content.addTextTile("foo");
+    const srcTileId = content.getRowByIndex(0)!.getTileIdAtIndex(0);
+
+    const copy = cloneContentWithUniqueIds(content);
+    const copyTileId = copy!.getRowByIndex(0)!.getTileIdAtIndex(0);
+    expect(copy!.rowCount).toBe(1);
+    expect(copyTileId).not.toBe(srcTileId);
+  });
+
+  it("can import authored content", () => {
+    const srcContent: any = {
+            tiles: [
+              { content: { isSectionHeader: true, sectionId: "Foo" } },
+              { content: { type: "Text", text: "foo" } }
+            ]
+          };
+    const content = DocumentContentModel.create(srcContent);
+    expect(content.rowCount).toBe(2);
+    const row = content.getRowByIndex(1);
+    expect(row!.tileCount).toBe(1);
+    const tileId = row!.getTileIdAtIndex(0);
+    const tile = content.tileMap.get(tileId);
+    const tileContent = tile!.content;
+    expect(tileContent.type).toBe("Text");
+  });
 });

--- a/src/models/document/document-content.test.ts
+++ b/src/models/document/document-content.test.ts
@@ -1,6 +1,7 @@
 import { DocumentContentModel, DocumentContentModelType } from "./document-content";
+import { defaultTextContent } from "../tools/text/text-content";
 
-describe("document-content model", () => {
+describe("DocumentContentModel", () => {
   let documentContent: DocumentContentModelType;
 
   beforeEach(() => {
@@ -158,6 +159,239 @@ describe("document-content model", () => {
     const textTile2RowIndex1 = documentContent.rowOrder.findIndex((id: string) => id === textTile2RowId);
 
     expect(textTile2RowIndex1).toBe(1);
+  });
+
+});
+
+describe("DocumentContentModel -- sectioned documents --", () => {
+
+  const content = DocumentContentModel.create({});
+
+  function isPlaceholderSection(sectionId: string) {
+    const rows = content.getRowsInSection(sectionId);
+    if (rows.length !== 1) return false;
+    if (!content.isPlaceholderRow(rows[0])) return false;
+    if (rows[0].tileCount !== 1) return false;
+    if (content.getTilesInSection(sectionId).length !== 0) return false;
+    return true;
+  }
+
+  function isContentSection(sectionId: string, tileCount: number = 1) {
+    const rows = content.getRowsInSection(sectionId);
+    if (rows.length !== 1) return false;
+    if (content.isPlaceholderRow(rows[0])) return false;
+    if (rows[0].tileCount !== tileCount) return false;
+    if (content.getTilesInSection(sectionId).length !== tileCount) return false;
+    return true;
+  }
+
+  // function logRows(label: string, c: DocumentContentModelType) {
+  //   console.log("***", label, "[begin] ***");
+  //   c.rowOrder.forEach((rowId, rowIndex) => {
+  //     const row = c.rowMap.get(rowId);
+  //     console.log(`Row ${rowIndex + 1}:`, "id:", row!.id, "isSectionHeader:",
+  //                 row!.isSectionHeader, "# tiles:", row!.tiles.length);
+  //     row && row.tiles.forEach((layout, tileIndex) => {
+  //       const tile = c.tileMap.get(layout.tileId);
+  //       console.log(`..Tile ${tileIndex + 1}:`, "type:", tile!.content.type);
+  //     });
+  //   });
+  //   console.log("***", label, "[end] ***");
+  // }
+
+  it("can create sectioned documents", () => {
+    // []
+    content.addSectionHeaderRow("A");
+    // [Header:A]
+    content.addPlaceholderTile("A");
+    // [Header:A, Placeholder]
+    expect(content.rowCount).toBe(2);
+    expect(content.getRowByIndex(0)!.isSectionHeader).toBe(true);
+    expect(content.isPlaceholderRow(content.getRowByIndex(1)!)).toBe(true);
+    expect(isPlaceholderSection("A")).toBe(true);
+
+    content.addSectionHeaderRow("B");
+    // [Header:A, Placeholder, Header:B]
+    content.addPlaceholderTile("B");
+    // [Header:A, Placeholder, Header:B, Placeholder]
+    expect(content.rowCount).toBe(4);
+    expect(content.getRowByIndex(2)!.isSectionHeader).toBe(true);
+    expect(content.isPlaceholderRow(content.getRowByIndex(3)!)).toBe(true);
+    expect(isPlaceholderSection("B")).toBe(true);
+  });
+
+  it("will remove placeholder tiles when adding a new tile in the last section", () => {
+    // [Header:A, Placeholder, Header:B, Placeholder]
+    content.addTextTile("foo");
+    // [Header:A, Placeholder, Header:B, Text]
+    expect(content.rowCount).toBe(4);
+    expect(isPlaceholderSection("A")).toBe(true);
+    expect(isContentSection("B")).toBe(true);
+  });
+
+  it("will remove placeholder tiles when adding a new tile in an interior section", () => {
+    // [Header:A, Placeholder, Header:B, Text]
+    content.addTileInNewRow(defaultTextContent("foo"), { rowIndex: 1 });
+    // [Header:A, Text, Header:B, Text]
+    expect(content.rowCount).toBe(4);
+    expect(isContentSection("A")).toBe(true);
+    expect(isContentSection("B")).toBe(true);
+  });
+
+  it("will restore placeholder tiles when deleting the last row in an interior section", () => {
+    // [Header:A, Text, Header:B, Text]
+    const rowId = content.rowOrder[1];
+    content.deleteRowAddingPlaceholderRowIfAppropriate(rowId);
+    // [Header:A, Placeholder, Header:B, Text]
+    expect(content.rowCount).toBe(4);
+    expect(isPlaceholderSection("A")).toBe(true);
+    expect(isContentSection("B")).toBe(true);
+  });
+
+  it("will restore placeholder tiles when deleting the last row in the last section", () => {
+    // [Header:A, Placeholder, Header:B, Text]
+    const rowId = content.rowOrder[3];
+    content.deleteRowAddingPlaceholderRowIfAppropriate(rowId);
+    // [Header:A, Placeholder, Header:B, Placeholder]
+    expect(content.rowCount).toBe(4);
+    expect(isPlaceholderSection("A")).toBe(true);
+    expect(isPlaceholderSection("B")).toBe(true);
+  });
+
+  it("will add/remove placeholder rows when moving entire rows (3 => 1)", () => {
+    // [Header:A, Placeholder, Header:B, Placeholder]
+    content.addTextTile("foo");
+    // [Header:A, Placeholder, Header:B, Text]
+    content.moveRowToIndex(3, 1);
+    // [Header:A, Text, Header:B, Placeholder]
+    expect(content.rowCount).toBe(4);
+    expect(isContentSection("A")).toBe(true);
+    expect(isPlaceholderSection("B")).toBe(true);
+  });
+
+  it("will add/remove placeholder rows when moving entire rows (1 => 3)", () => {
+    // [Header:A, Text, Header:B, Placeholder]
+    content.moveRowToIndex(1, 3);
+    // [Header:A, Placeholder, Header:B, Text]
+    expect(content.rowCount).toBe(4);
+    expect(isPlaceholderSection("A")).toBe(true);
+    expect(isContentSection("B")).toBe(true);
+  });
+
+  it("will add/remove placeholder rows when moving a tile back to a new row", () => {
+    // [Header:A, Placeholder, Header:B, Text]
+    const tileId = content.getRowByIndex(3)!.tiles[0].tileId;
+    content.moveTileToNewRow(tileId, 2);
+    // [Header:A, Text, Header:B, Placeholder]
+    expect(content.rowCount).toBe(4);
+    expect(isContentSection("A")).toBe(true);
+    expect(isPlaceholderSection("B")).toBe(true);
+  });
+
+  it("will add/remove placeholder rows when moving a tile forward to a new row", () => {
+    // [Header:A, Text, Header:B, Placeholder]
+    const tileId = content.getRowByIndex(1)!.tiles[0].tileId;
+    content.moveTileToNewRow(tileId, 4);
+    // [Header:A, Placeholder, Header:B, Text]
+    expect(content.rowCount).toBe(4);
+    expect(isPlaceholderSection("A")).toBe(true);
+    expect(isContentSection("B")).toBe(true);
+  });
+
+  it("will add/remove placeholder rows when moving a tile back to an existing row", () => {
+    // [Header:A, Placeholder, Header:B, Text]
+    const tileId = content.getRowByIndex(3)!.tiles[0].tileId;
+    content.moveTileToRow(tileId, 1);
+    // [Header:A, Text, Header:B, Placeholder]
+    expect(content.rowCount).toBe(4);
+    expect(isContentSection("A")).toBe(true);
+    expect(isPlaceholderSection("B")).toBe(true);
+  });
+
+  it("will add/remove placeholder rows when moving a tile forward to an existing row", () => {
+    // [Header:A, Text, Header:B, Placeholder]
+    const tileId = content.getRowByIndex(1)!.tiles[0].tileId;
+    content.moveTileToRow(tileId, 3, 0);
+    // [Header:A, Placeholder, Header:B, Text]
+    expect(content.rowCount).toBe(4);
+    expect(isPlaceholderSection("A")).toBe(true);
+    expect(isContentSection("B")).toBe(true);
+  });
+
+  it("deleteTile() will add/remove placeholder rows", () => {
+    // [Header:A, Placeholder, Header:B, Text]
+    const tileId = content.getRowByIndex(3)!.tiles[0].tileId;
+    content.deleteTile(tileId);
+    // [Header:A, Placeholder, Header:B, Placeholder]
+    expect(content.rowCount).toBe(4);
+    expect(isPlaceholderSection("A")).toBe(true);
+    expect(isPlaceholderSection("B")).toBe(true);
+  });
+
+  it("addTile() will add/remove placeholder rows", () => {
+    // [Header:A, Placeholder, Header:B, Placeholder]
+    content.addTile("text");
+    // [Header:A, Placeholder, Header:B, Text]
+    expect(content.rowCount).toBe(4);
+    expect(isPlaceholderSection("A")).toBe(true);
+    expect(isContentSection("B")).toBe(true);
+  });
+
+  it("moveTile() will add/remove placeholder rows", () => {
+    // [Header:A, Placeholder, Header:B, Text]
+    const tileId = content.getRowByIndex(3)!.tiles[0].tileId;
+    content.moveTile(tileId, { rowDropIndex: 1, rowDropLocation: "right", rowInsertIndex: 1 });
+    // [Header:A, Text, Header:B, Placeholder]
+    expect(content.rowCount).toBe(4);
+    expect(isContentSection("A")).toBe(true);
+    expect(isPlaceholderSection("B")).toBe(true);
+
+    content.moveTile(tileId, { rowDropIndex: 3, rowDropLocation: "left", rowInsertIndex: 3 });
+    // [Header:A, Placeholder, Header:B, Text]
+    expect(content.rowCount).toBe(4);
+    expect(isPlaceholderSection("A")).toBe(true);
+    expect(isContentSection("B")).toBe(true);
+
+    content.moveTile(tileId, { rowInsertIndex: 1 });
+    // [Header:A, Text, Header:B, Placeholder]
+    expect(content.rowCount).toBe(4);
+    expect(isContentSection("A")).toBe(true);
+    expect(isPlaceholderSection("B")).toBe(true);
+
+    content.moveTile(tileId, { rowInsertIndex: 3 });
+    // [Header:A, Placeholder, Header:B, Text]
+    expect(content.rowCount).toBe(4);
+    expect(isPlaceholderSection("A")).toBe(true);
+    expect(isContentSection("B")).toBe(true);
+
+    content.addTile("geometry", { addSidecarNotes: true, insertRowInfo: { rowInsertIndex: 2 } });
+    // [Header:A, [Geometry, Text], Header:B, Text]
+    expect(content.rowCount).toBe(4);
+    expect(isContentSection("A", 2)).toBe(true);
+    expect(isContentSection("B")).toBe(true);
+
+    const geometryId = content.getRowByIndex(1)!.tiles[0].tileId;
+    content.moveTile(geometryId, { rowDropIndex: 3, rowDropLocation: "left", rowInsertIndex: 3 });
+    // [Header:A, Text, Header:B, [Geometry, Text]]
+    expect(content.rowCount).toBe(4);
+    expect(isContentSection("A")).toBe(true);
+    expect(isContentSection("B", 2)).toBe(true);
+
+    content.moveTile(geometryId, { rowDropIndex: 1, rowDropLocation: "left", rowInsertIndex: 1 });
+    // [Header:A, [Geometry, Text], Header:B, Text]
+    expect(content.rowCount).toBe(4);
+    expect(isContentSection("A", 2)).toBe(true);
+    expect(isContentSection("B")).toBe(true);
+  });
+
+  it("deleteTile() will remove individual tiles from rows", () => {
+    // [Header:A, [Geometry, Text], Header:B, Text]
+    const tileId = content.getRowByIndex(1)!.tiles[1].tileId;
+    content.deleteTile(tileId);
+    // [Header:A, Geometry, Header:B, Text]
+    expect(content.rowCount).toBe(4);
+    expect(isContentSection("A")).toBe(true);
+    expect(isContentSection("B")).toBe(true);
   });
 
 });

--- a/src/models/document/tile-row.ts
+++ b/src/models/document/tile-row.ts
@@ -32,11 +32,18 @@ export const TileRowModel = types
     get isEmpty() {
       return (self.tiles.length === 0) && !self.isSectionHeader;
     },
+    get tileCount() {
+      return self.tiles.length;
+    },
     get isUserResizable() {
       return !self.isSectionHeader && self.tiles.some(tileRef => tileRef.isUserResizable);
     },
     get tileIds() {
       return self.tiles.map(tile => tile.tileId).join(", ");
+    },
+    getTileIdAtIndex(index: number) {
+      const layout = self.tiles[index];
+      return layout && layout.tileId;
     },
     hasTile(tileId: string) {
       return self.tiles.findIndex(tileRef => tileRef.tileId === tileId) >= 0;

--- a/src/models/tools/placeholder/placeholder-content.ts
+++ b/src/models/tools/placeholder/placeholder-content.ts
@@ -2,21 +2,21 @@ import { types, Instance, SnapshotOut } from "mobx-state-tree";
 
 export const kPlaceholderToolID = "Placeholder";
 
-export function defaultPlaceholderContent() {
+export function defaultPlaceholderContent(sectionId: string = "") {
   return PlaceholderContentModel.create({
     type: kPlaceholderToolID,
-    prompt: "Create or drag tiles here"
+    sectionId
   });
 }
 
 export const PlaceholderContentModel = types
   .model("PlaceholderContent", {
     type: types.optional(types.literal(kPlaceholderToolID), kPlaceholderToolID),
-    prompt: ""
+    sectionId: ""
   })
   .actions(self => ({
-    setPrompt(prompt: string) {
-      self.prompt = prompt;
+    setSectionId(sectionId: string = "") {
+      self.sectionId = sectionId;
     }
   }));
 


### PR DESCRIPTION
Newly created CLUE problem documents have sections corresponding to the available sections in the corresponding curriculum content. Empty sections contain a placeholder tile that goes away when content tiles are added to that section.

Notes:
- @mklewandowski did all the UI work. I just refined the model architecture and fixed the bugs.
- this does not include the new heuristics for where new tiles are generated.