### PR TITLE
Implement improved heuristic for placing new tiles

### DIFF
--- a/src/components/document/document-content.tsx
+++ b/src/components/document/document-content.tsx
@@ -145,8 +145,13 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
                             dropRowInfo.rowDropLocation
                               ? dropRowInfo.rowDropLocation
                               : undefined;
-      if (!dropHighlight && index === highlightPendingDropLocation) {
-        dropHighlight = "bottom";
+      if (!dropHighlight) {
+        if (index === highlightPendingDropLocation) {
+          dropHighlight = "top";
+        }
+        else if ((index === rowOrder.length - 1) && (index + 1 === highlightPendingDropLocation)) {
+          dropHighlight = "bottom";
+        }
       }
       return row
               ? <TileRowComponent key={row.id} docId={content.contentId} model={row}

--- a/src/components/document/document-workspace.tsx
+++ b/src/components/document/document-workspace.tsx
@@ -241,14 +241,14 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps, {}> {
   private handleImageDrop = (e: React.DragEvent<HTMLDivElement>, rowId?: string) => {
     const {ui} = this.stores;
     this.imageDragDrop.drop(e)
-      .then((imageUrl) => {
+      .then((url) => {
         const primaryDocument = this.getPrimaryDocument(ui.problemWorkspace.primaryDocumentKey);
         if (primaryDocument) {
           // insert the tile after the row it was dropped on otherwise add to end of document
           const rowIndex = rowId ? primaryDocument.content.getRowIndex(rowId) : undefined;
           const rowInsertIndex = (rowIndex !== undefined ? rowIndex + 1 : primaryDocument.content.rowOrder.length);
           primaryDocument.content.addTile("image", {
-            imageUrl,
+            url,
             insertRowInfo: {
               rowInsertIndex
             }

--- a/src/components/toolbar.tsx
+++ b/src/components/toolbar.tsx
@@ -3,8 +3,9 @@ import * as React from "react";
 
 import { BaseComponent, IBaseProps } from "./base";
 import { DocumentModelType, DocumentTool } from "../models/document/document";
-import { IToolApiMap, kDragTileCreate  } from "./tools/tool-tile";
+import { IDocumentContentAddTileOptions } from "../models/document/document-content";
 import { ToolButtonConfig, ToolbarConfig } from "../models/tools/tool-types";
+import { IToolApiMap, kDragTileCreate  } from "./tools/tool-tile";
 
 import "./toolbar.sass";
 
@@ -88,18 +89,22 @@ export class ToolbarComponent extends BaseComponent<IProps, {}> {
 
   private showDropRowHighlight = () => {
     const { document } = this.props;
-    document.content.highlightLastVisibleRow(true);
+    document.content.showPendingInsertHighlight(true);
   }
 
   private removeDropRowHighlight = () => {
     const { document } = this.props;
-    document.content.highlightLastVisibleRow(false);
+    document.content.showPendingInsertHighlight(false);
   }
 
   private handleAddToolTile(tool: DocumentTool) {
     const { document } = this.props;
     const { ui } = this.stores;
-    const rowTile = document.addTile(tool, {addSidecarNotes: tool === "geometry"});
+    const newTileOptions: IDocumentContentAddTileOptions = {
+            addSidecarNotes: tool === "geometry",
+            insertRowInfo: { rowInsertIndex: document.content.defaultInsertRow }
+          };
+    const rowTile = document.addTile(tool, newTileOptions);
     if (rowTile && rowTile.tileId) {
       ui.setSelectedTileId(rowTile.tileId);
     }

--- a/src/lib/logger.test.ts
+++ b/src/lib/logger.test.ts
@@ -108,7 +108,7 @@ describe("logger", () => {
         return res.status(201);
       });
 
-      await document.content.addTextTile("test");
+      await document.content.addTextTile({ text: "test" });
     });
 
     it.skip("can log copying tiles between documents", async (done) => {

--- a/src/models/document/document-content.test.ts
+++ b/src/models/document/document-content.test.ts
@@ -8,6 +8,12 @@ describe("DocumentContentModel", () => {
     documentContent = DocumentContentModel.create({});
   });
 
+  it("behaves like empty content when empty", () => {
+    expect(documentContent.rowCount).toBe(0);
+    expect(documentContent.indexOfLastVisibleRow).toBe(-1);
+    expect(documentContent.defaultInsertRow).toBe(0);
+  });
+
   it("allows the tool tiles to be added", () => {
     expect(documentContent.tileMap.size).toBe(0);
     documentContent.addTile("text");
@@ -17,6 +23,7 @@ describe("DocumentContentModel", () => {
       addSidecarNotes: true
     });
     expect(documentContent.tileMap.size).toBe(3);
+    expect(documentContent.defaultInsertRow).toBe(2);
   });
 
   it("allows the tool tiles to be added as new rows at specified locations", () => {
@@ -209,6 +216,7 @@ describe("DocumentContentModel -- sectioned documents --", () => {
     expect(content.getRowByIndex(0)!.isSectionHeader).toBe(true);
     expect(content.isPlaceholderRow(content.getRowByIndex(1)!)).toBe(true);
     expect(isPlaceholderSection("A")).toBe(true);
+    expect(content.defaultInsertRow).toBe(1);
 
     content.addSectionHeaderRow("B");
     // [Header:A, Placeholder, Header:B]
@@ -218,16 +226,18 @@ describe("DocumentContentModel -- sectioned documents --", () => {
     expect(content.getRowByIndex(2)!.isSectionHeader).toBe(true);
     expect(content.isPlaceholderRow(content.getRowByIndex(3)!)).toBe(true);
     expect(isPlaceholderSection("B")).toBe(true);
+    expect(content.defaultInsertRow).toBe(1);
   });
 
   it("will remove placeholder tiles when adding a new tile in the last section", () => {
     // [Header:A, Placeholder, Header:B, Placeholder]
-    content.addTextTile("foo");
+    content.addTextTile({ text: "foo", rowIndex: content.rowCount });
     // [Header:A, Placeholder, Header:B, Text]
     expect(content.rowCount).toBe(4);
     expect(isPlaceholderSection("A")).toBe(true);
     expect(isContentSection("B")).toBe(true);
-  });
+    expect(content.defaultInsertRow).toBe(4);
+});
 
   it("will remove placeholder tiles when adding a new tile in an interior section", () => {
     // [Header:A, Placeholder, Header:B, Text]
@@ -236,6 +246,7 @@ describe("DocumentContentModel -- sectioned documents --", () => {
     expect(content.rowCount).toBe(4);
     expect(isContentSection("A")).toBe(true);
     expect(isContentSection("B")).toBe(true);
+    expect(content.defaultInsertRow).toBe(4);
   });
 
   it("will restore placeholder tiles when deleting the last row in an interior section", () => {
@@ -246,7 +257,8 @@ describe("DocumentContentModel -- sectioned documents --", () => {
     expect(content.rowCount).toBe(4);
     expect(isPlaceholderSection("A")).toBe(true);
     expect(isContentSection("B")).toBe(true);
-  });
+    expect(content.defaultInsertRow).toBe(4);
+});
 
   it("will restore placeholder tiles when deleting the last row in the last section", () => {
     // [Header:A, Placeholder, Header:B, Text]
@@ -256,17 +268,19 @@ describe("DocumentContentModel -- sectioned documents --", () => {
     expect(content.rowCount).toBe(4);
     expect(isPlaceholderSection("A")).toBe(true);
     expect(isPlaceholderSection("B")).toBe(true);
+    expect(content.defaultInsertRow).toBe(1);
   });
 
   it("will add/remove placeholder rows when moving entire rows (3 => 1)", () => {
     // [Header:A, Placeholder, Header:B, Placeholder]
-    content.addTextTile("foo");
+    content.addTextTile({ text: "foo", rowIndex: content.rowCount });
     // [Header:A, Placeholder, Header:B, Text]
     content.moveRowToIndex(3, 1);
     // [Header:A, Text, Header:B, Placeholder]
     expect(content.rowCount).toBe(4);
     expect(isContentSection("A")).toBe(true);
     expect(isPlaceholderSection("B")).toBe(true);
+    expect(content.defaultInsertRow).toBe(2);
   });
 
   it("will add/remove placeholder rows when moving entire rows (1 => 3)", () => {
@@ -276,6 +290,7 @@ describe("DocumentContentModel -- sectioned documents --", () => {
     expect(content.rowCount).toBe(4);
     expect(isPlaceholderSection("A")).toBe(true);
     expect(isContentSection("B")).toBe(true);
+    expect(content.defaultInsertRow).toBe(4);
   });
 
   it("will add/remove placeholder rows when moving a tile back to a new row", () => {
@@ -286,6 +301,7 @@ describe("DocumentContentModel -- sectioned documents --", () => {
     expect(content.rowCount).toBe(4);
     expect(isContentSection("A")).toBe(true);
     expect(isPlaceholderSection("B")).toBe(true);
+    expect(content.defaultInsertRow).toBe(2);
   });
 
   it("will add/remove placeholder rows when moving a tile forward to a new row", () => {
@@ -296,6 +312,7 @@ describe("DocumentContentModel -- sectioned documents --", () => {
     expect(content.rowCount).toBe(4);
     expect(isPlaceholderSection("A")).toBe(true);
     expect(isContentSection("B")).toBe(true);
+    expect(content.defaultInsertRow).toBe(4);
   });
 
   it("will add/remove placeholder rows when moving a tile back to an existing row", () => {
@@ -306,6 +323,7 @@ describe("DocumentContentModel -- sectioned documents --", () => {
     expect(content.rowCount).toBe(4);
     expect(isContentSection("A")).toBe(true);
     expect(isPlaceholderSection("B")).toBe(true);
+    expect(content.defaultInsertRow).toBe(2);
   });
 
   it("will add/remove placeholder rows when moving a tile forward to an existing row", () => {
@@ -400,7 +418,7 @@ describe("DocumentContentModel", () => {
 
   it("can cloneWithUniqueIds()", () => {
     const content = DocumentContentModel.create({});
-    content.addTextTile("foo");
+    content.addTextTile({ text: "foo" });
     const srcTileId = content.getRowByIndex(0)!.getTileIdAtIndex(0);
 
     const copy = cloneContentWithUniqueIds(content);

--- a/src/models/document/document.ts
+++ b/src/models/document/document.ts
@@ -47,7 +47,7 @@ export type PublicationType = typeof ProblemPublication | OtherPublicationType |
 
 export interface IDocumentAddTileOptions {
   addSidecarNotes?: boolean;
-  imageUrl?: string;
+  url?: string;
 }
 
 export const DocumentToolEnum = types.enumeration("tool",


### PR DESCRIPTION
Implements the default tile placement heuristic suggested by @sfentress .

1. New tiles are placed immediately after the last visible non-placeholder/non-section-header row.
2. If there are no non-placeholder/non-section-header rows, then new tiles are placed after the first section header row.

The heuristic was straightforward to implement. The difficulties that arose were related to the fact that there are internal clients (e.g. unit tests) that were relying on the previous behavior so a fair amount of code needed to change to explicitly specify a row rather than relying on the defaulting mechanism.

Testable at https://collaborative-learning.concord.org/branch/default-tile-placement/?demo

Note: this PR is currently based on #490 . That should be merged first and then this can be rebased on top of it.