### PR TITLE
Fix initial placeholders bug introduced with the change to default insert row

### DIFF
--- a/src/models/document/document-content.test.ts
+++ b/src/models/document/document-content.test.ts
@@ -443,4 +443,25 @@ describe("DocumentContentModel", () => {
     const tileContent = tile!.content;
     expect(tileContent.type).toBe("Text");
   });
+
+  it("can import authored content with sections and placeholders", () => {
+    const srcContent: any = {
+            tiles: [
+              { content: { isSectionHeader: true, sectionId: "foo" } },
+              { content: { type: "Placeholder", sectionId: "foo" } },
+              { content: { isSectionHeader: true, sectionId: "bar" } },
+              { content: { type: "Placeholder", sectionId: "bar" } }
+            ]
+          };
+    const content = DocumentContentModel.create(srcContent);
+    expect(content.rowCount).toBe(4);
+    expect(content.getRowByIndex(0)!.isSectionHeader).toBe(true);
+    expect(content.isPlaceholderRow(content.getRowByIndex(1)!)).toBe(true);
+    expect(content.getRowByIndex(2)!.isSectionHeader).toBe(true);
+    expect(content.isPlaceholderRow(content.getRowByIndex(3)!)).toBe(true);
+    expect(content.getSectionTypeForPlaceholderRow(content.getRowByIndex(1)!))
+      .toBe(content.getRowByIndex(0)!.sectionId);
+    expect(content.getSectionTypeForPlaceholderRow(content.getRowByIndex(3)!))
+      .toBe(content.getRowByIndex(2)!.sectionId);
+  });
 });

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -186,6 +186,11 @@ export const DocumentContentModel = types
     };
   })
   .views(self => ({
+    getSectionTypeForPlaceholderRow(row: TileRowModelType) {
+      if (!self.isPlaceholderRow(row)) return;
+      const tile = self.getTile(row.tiles[0].tileId);
+      return tile && tile.placeholderSectionId;
+    },
     get defaultInsertRow() {
       // next tile comes after the last visible row with content
       for (let i = self.indexOfLastVisibleRow; i >= 0; --i) {
@@ -605,7 +610,8 @@ function migrateSnapshot(snapshot: any): any {
       docContent.addSectionHeaderRow(sectionId);
     }
     else {
-      docContent.addTileInNewRow(newTile.content, { rowHeight: tileHeight });
+      const options = { rowIndex: docContent.rowCount, rowHeight: tileHeight };
+      docContent.addTileInNewRow(newTile.content, options);
     }
   });
   return getSnapshot(docContent);

--- a/src/models/tools/tool-tile.ts
+++ b/src/models/tools/tool-tile.ts
@@ -32,6 +32,9 @@ export const ToolTileModel = types
     },
     get isPlaceholder() {
       return self.content.type === kPlaceholderToolID;
+    },
+    get placeholderSectionId() {
+      return (self.content.type === kPlaceholderToolID) ? self.content.sectionId : undefined;
     }
   }))
   .actions(self => ({


### PR DESCRIPTION
Remember in #491 when I said:

>The difficulties that arose were related to the fact that there are internal clients (e.g. unit tests) that were relying on the previous behavior so a fair amount of code needed to change to explicitly specify a row rather than relying on the defaulting mechanism.

One of those internal clients that needed to change (but was not changed) is the one that handles importing curriculum content. The result was that only one placeholder row would appear (in the first section) in a document of multiple sections. I've added a unit test to test this case (and fixed the bug).