### PR TITLE
Add signout before auth to fix class switching issue

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -117,7 +117,12 @@ export class DB {
 
       if (options.appMode === "authed") {
         return firebase.auth()
-          .signInWithCustomToken(options.rawFirebaseJWT)
+          .signOut()
+          .then(() => {
+            return firebase.auth()
+              .signInWithCustomToken(options.rawFirebaseJWT)
+              .catch(reject);
+          })
           .catch(reject);
       }
       else {


### PR DESCRIPTION
Without signout the existing Firebase user seems to be cached by Firestore when signing in with another JWT which causes access errors when switching classes as the classHash in the new JWT is not the correct one.