### PR TITLE
Add full sized workgroup view for four-up work groups

### DIFF
--- a/src/components/document/document-workspace.tsx
+++ b/src/components/document/document-workspace.tsx
@@ -114,8 +114,8 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps, {}> {
     const {appConfig, documents, ui, groups} = this.stores;
 
     const { problemWorkspace } = ui;
-    const { comparisonDocumentKey } = problemWorkspace;
-
+    const { comparisonDocumentKey, hidePrimaryForCompare, comparisonVisible} = problemWorkspace;
+    const showPrimary = !hidePrimaryForCompare;
     const primaryDocument = this.getPrimaryDocument(problemWorkspace.primaryDocumentKey);
     const comparisonDocument = comparisonDocumentKey
                                && documents.getDocument(comparisonDocumentKey);
@@ -134,6 +134,7 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps, {}> {
           key={comparisonDocumentKey}
           document={groupVirtualDocument}
           workspace={problemWorkspace}
+          side={hidePrimaryForCompare ? "primary" : "comparison"}
         />
       : comparisonDocument
         ?
@@ -151,7 +152,7 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps, {}> {
           />
         : this.renderComparisonPlaceholder();
 
-    const Primary = (
+    const Primary =
       <DocumentComponent
         document={primaryDocument}
         workspace={problemWorkspace}
@@ -163,10 +164,10 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps, {}> {
         toolbar={toolbar}
         side="primary"
         isGhostUser={isGhostUser}
-      />
-    );
+      />;
 
-    if (problemWorkspace.comparisonVisible) {
+    // Show Pimary and comparison docs:
+    if (comparisonVisible && showPrimary) {
       return (
         <div onClick={this.handleClick}>
           { this.renderDocument("left-workspace", "primary", Primary) }
@@ -174,6 +175,11 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps, {}> {
         </div>
       );
     }
+    // Just display the "Compare" document.
+    else if (hidePrimaryForCompare) {
+      return this.renderDocument("single-workspace", "primary", CompareDocument);
+    }
+    // Just display the primary document:
     else {
       return this.renderDocument("single-workspace", "primary", Primary);
     }

--- a/src/components/document/group-virtual-document.tsx
+++ b/src/components/document/group-virtual-document.tsx
@@ -14,6 +14,7 @@ export type WorkspaceSide = "primary" | "comparison";
 interface IProps extends IBaseProps {
   workspace: WorkspaceModelType;
   document: IGroupVirtualDocument;
+  side: WorkspaceSide;
 }
 
 interface IState {
@@ -106,12 +107,46 @@ export class GroupVirtualDocumentComponent extends BaseComponent<IProps, IState>
         toolApiInterface={this.toolApiInterface} />
     );
   }
+  private isPrimary() {
+    return this.props.side === "primary";
+  }
+
+  private handleToggleTwoUp = () => {
+    const { workspace } = this.props;
+    const currMode = workspace.hidePrimaryForCompare || false;
+    this.props.workspace.toggleComparisonVisible({override: true, hidePrimary: !currMode });
+  }
+
+  private renderTwoUpButton() {
+    const { workspace } = this.props;
+    const currMode = workspace.hidePrimaryForCompare ? "up1" : "up2";
+    const nextMode = workspace.hidePrimaryForCompare ? "up2" : "up1";
+
+    return (
+      <div className="mode action">
+        <svg id="currMode" className={`mode icon icon-${currMode}`} data-test="two-up-curr-mode"
+             onClick={this.handleToggleTwoUp}>
+          <use xlinkHref={`#icon-${currMode}`} />
+        </svg>
+        <svg id="nextMode" key="nextMode" className={`mode icon icon-${nextMode}`} data-test="two-up-next-mode"
+             onClick={this.handleToggleTwoUp}
+        >
+          <use xlinkHref={`#icon-${nextMode}`} />
+        </svg>
+      </div>
+    );
+  }
 
   private renderStatusBar(type: string) {
+    const isPrimary = this.isPrimary();
     return (
       <div className={`statusbar ${type}`}>
-        <div className="supports">{ null } </div>
-        <div className="actions"> { null } </div>
+        <div className="supports">
+          {null}
+        </div>
+        <div className="actions">
+          {isPrimary ? this.renderTwoUpButton() : null}
+        </div>
       </div>
     );
   }

--- a/src/components/teacher/teacher-group-six-pack.sass
+++ b/src/components/teacher/teacher-group-six-pack.sass
@@ -65,21 +65,28 @@
 
 
 .group-header
+
   display: flex
   flex-direction: row
   justify-content: space-between
-  .icon-expand-group-view
-    background-color: transparent
-    cursor: pointer
-    border: 0
-    padding: 6px
-    &:hover
-        background-color: hsla(1, 0%, 0%, 0.1)
-
-    .expand-group-view
-      background-image: url("../../assets/icons/clue-dashboard/expand-group-view.svg")
-      background-repeat: no-repeat
-      box-sizing: content-box
-      width: 39px
-      height: 30px
-
+  .actions
+    .icon
+      background-color: transparent
+      cursor: pointer
+      border: 0
+      padding: 6px
+      .button-icon
+        background-repeat: no-repeat
+        box-sizing: content-box
+        width: 39px
+        height: 30px
+      &:hover
+          background-color: hsla(1, 0%, 0%, 0.1)
+      .support
+        background-image: url("../../assets/icons/support/support.svg")
+        &:hover
+          background-image: url("../../assets/icons/support/support-hover.svg")
+        &:active
+          background-image: url("../../assets/icons/support/support-active.svg")
+      .expand-group-view
+        background-image: url("../../assets/icons/clue-dashboard/expand-group-view.svg")

--- a/src/components/teacher/teacher-group-six-pack.tsx
+++ b/src/components/teacher/teacher-group-six-pack.tsx
@@ -59,19 +59,33 @@ export class TeacherGroupSixPack extends BaseComponent<IProps, {}> {
     const TeacherGroupHeader = (props: IGroupHeaderProps) => {
       const { ui }  = this.stores;
 
-      const clickHandler = () => {
+      const showGroupClickHandler = () => {
         ui.problemWorkspace.setComparisonDocument(new GroupVirtualDocument(group));
         ui.problemWorkspace.toggleComparisonVisible({override: true});
         ui.setTeacherPanelKey(EPanelId.workspace);
       };
+
+      const showGroupSupportClickHandler = () => {
+        ui.problemWorkspace.setComparisonDocument(new GroupVirtualDocument(group));
+        ui.problemWorkspace.toggleComparisonVisible({override: true});
+        ui.setTeacherPanelKey(EPanelId.workspace);
+      };
+
       return(
         <div className="group-header">
           <div className="group-label">Group {String(group.id)}</div>
-          <IconButton
-            icon="expand-group-view"
-            key="expand-group-view"
-            className="action icon-expand-group-view"
-            onClickButton={clickHandler} />
+          <div className="actions">
+            <IconButton
+              className="icon"
+              icon="support"
+              key="support"
+              onClickButton={showGroupSupportClickHandler} />
+            <IconButton
+              className="icon"
+              icon="expand-group-view"
+              key="expand-group-view"
+              onClickButton={showGroupClickHandler} />
+          </div>
         </div>
       );
     };

--- a/src/components/teacher/teacher-group-six-pack.tsx
+++ b/src/components/teacher/teacher-group-six-pack.tsx
@@ -61,7 +61,7 @@ export class TeacherGroupSixPack extends BaseComponent<IProps, {}> {
 
       const showGroupClickHandler = () => {
         ui.problemWorkspace.setComparisonDocument(new GroupVirtualDocument(group));
-        ui.problemWorkspace.toggleComparisonVisible({override: true});
+        ui.problemWorkspace.toggleComparisonVisible({override: true, hidePrimary: true});
         ui.setTeacherPanelKey(EPanelId.workspace);
       };
 

--- a/src/models/stores/workspace.ts
+++ b/src/models/stores/workspace.ts
@@ -69,7 +69,7 @@ export const WorkspaceModel = types
         const visible = typeof override !== "undefined" ? override : !self.comparisonVisible;
         self.comparisonVisible = visible;
         if (!visible) {
-          self.comparisonDocumentKey = undefined;
+           self.comparisonDocumentKey = undefined;
         }
 
         if (!muteLog) {

--- a/src/models/stores/workspace.ts
+++ b/src/models/stores/workspace.ts
@@ -72,7 +72,7 @@ export const WorkspaceModel = types
         self.comparisonVisible = visible;
         self.hidePrimaryForCompare = hidePrimary;
         if (!visible) {
-           self.comparisonDocumentKey = undefined;
+          self.comparisonDocumentKey = undefined;
         }
 
         if (!muteLog) {

--- a/src/models/stores/workspace.ts
+++ b/src/models/stores/workspace.ts
@@ -26,6 +26,7 @@ export const WorkspaceModel = types
     primaryDocumentKey: types.maybe(types.string),
     comparisonDocumentKey: types.maybe(types.string),
     comparisonVisible: false,
+    hidePrimaryForCompare: false
   })
   .actions((self) => {
     const setPrimaryDocument = (document?: DocumentModelType) => {
@@ -65,9 +66,11 @@ export const WorkspaceModel = types
         }
       },
 
-      toggleComparisonVisible({override, muteLog = false}: {override?: boolean; muteLog?: boolean} = {}) {
+      toggleComparisonVisible({override, muteLog = false, hidePrimary = false}:
+          {override?: boolean; muteLog?: boolean, hidePrimary?: boolean} = {}) {
         const visible = typeof override !== "undefined" ? override : !self.comparisonVisible;
         self.comparisonVisible = visible;
+        self.hidePrimaryForCompare = hidePrimary;
         if (!visible) {
            self.comparisonDocumentKey = undefined;
         }


### PR DESCRIPTION
This PR adds a full-width document view for the four-up group comparison we have been working on.

It adds a split-panel button to the four-up comparison document for switching.

Its specified in this mockup:

<img width="962" alt="Screen Shot 2019-10-16 at 5 31 02 PM" src="https://user-images.githubusercontent.com/22908/66960593-c11a3380-f03a-11e9-8b40-8ff428413a32.png">
