### PR TITLE
Fix sensor select message

### DIFF
--- a/src/dataflow/utilities/node.ts
+++ b/src/dataflow/utilities/node.ts
@@ -328,4 +328,4 @@ export const IntervalTimes: IntervalTime[] = [
 ];
 
 export const kRelaySelectMessage = "Select a relay";
-export const kSensorSelectMessage = "Select a relay";
+export const kSensorSelectMessage = "Select a sensor";


### PR DESCRIPTION
We found this incorrect string today while testing that caused sensor blocks to prompt users with the wrong message.