### PR TITLE
Scripts for archiving CLUE class contents

### DIFF
--- a/scripts/archive.py
+++ b/scripts/archive.py
@@ -1,0 +1,47 @@
+#!/usr/local/bin/python
+
+# A script to archive the classes in the "authed/portals/learn_concord_org" branch
+# of the firebase database to the "archived/portals/learn_concord_org-{DATE}" branch.
+# Note that firebase limits the size of a single write using the REST API to 256 MB
+# (cf. https://firebase.google.com/docs/database/usage/limits).
+
+import firebase_admin
+from firebase_admin import credentials
+from firebase_admin import db
+from datetime import date
+
+# cf. https://rakibul.net/fb-realtime-db-python
+# Fetch the service account key JSON file contents
+cred = credentials.Certificate('./scripts/serviceAccountKey.json')
+# Initialize the app with a service account, granting admin privileges
+firebase_admin.initialize_app(cred, {
+    'databaseURL': 'https://collaborative-learning-ec215.firebaseio.com'
+})
+
+def twoChar(d):
+    return f' {d}' if d < 10 else f'{d}'
+
+def strDate():
+    d = date.today()
+    return f'{d.year}-{twoChar(d.month)}-{twoChar(d.day)}'
+
+srcRoot = 'authed'
+dstRoot = 'archived'
+srcPortalId = 'learn_concord_org'
+dstPortalId = f'learn_concord_org-{strDate()}'
+srcClassesRef = db.reference(f'{srcRoot}/portals/{srcPortalId}/classes')
+dstClassesRef = db.reference(f'{dstRoot}/portals/{dstPortalId}/classes')
+# extract list of class keys (class hashes)
+shallowClasses = srcClassesRef.get(False, True)
+# loop through class hashes
+for i, classHash in enumerate(sorted(shallowClasses)):
+    print(f'{twoChar(i + 1)}: {classHash}')
+    srcClassRef = srcClassesRef.child(classHash)
+    dstClassRef = dstClassesRef.child(classHash)
+    print('..srcPath:', srcClassRef.path)
+    print('..dstPath:', dstClassRef.path)
+    # retrieve source class content
+    classContent = srcClassRef.get()
+    print('..writing:', dstClassRef.path)
+    # write archived class content
+    dstClassRef.set(classContent)

--- a/scripts/dedupe.py
+++ b/scripts/dedupe.py
@@ -1,0 +1,60 @@
+#!/usr/local/bin/python
+
+# A script to compare the contents of the classes in the "authed/portals/learn_concord_org"
+# branch of the firebase database to the contents of the classes in the
+# "archived/portals/learn_concord_org-{DATE}" branch and to optionally delete classes
+# whose contents match from the source. This is designed to be used after the corresponding
+# archive script has archived copies of the class contents. Classes to be preserved can be
+# specified in the "retainedClasses" set below.
+
+import hashlib
+import json
+import firebase_admin
+from firebase_admin import credentials
+from firebase_admin import db
+from datetime import date
+
+# cf. https://rakibul.net/fb-realtime-db-python
+# Fetch the service account key JSON file contents
+cred = credentials.Certificate('./scripts/serviceAccountKey.json')
+# Initialize the app with a service account, granting admin privileges
+firebase_admin.initialize_app(cred, {
+  'databaseURL': 'https://collaborative-learning-ec215.firebaseio.com'
+})
+
+def twoChar(d):
+  return f' {d}' if d < 10 else f'{d}'
+
+def strDate():
+  d = date.today()
+  return f'{d.year}-{twoChar(d.month)}-{twoChar(d.day)}'
+
+srcRoot = 'authed'
+dstRoot = 'archived'
+srcPortalId = 'learn_concord_org'
+dstPortalId = f'learn_concord_org-{strDate()}'
+srcClassesRef = db.reference(f'{srcRoot}/portals/{srcPortalId}/classes')
+dstClassesRef = db.reference(f'{dstRoot}/portals/{dstPortalId}/classes')
+retainedClasses = { "8a55c706e857b21a061316e9b25cdde142348de4ed933e8b" }
+# extract list of class keys (class hashes)
+srcClassList = srcClassesRef.get(False, True)
+# loop through class hashes
+for i, classHash in enumerate(sorted(srcClassList)):
+  print(f'{twoChar(i + 1)}: {classHash}')
+  srcClassRef = srcClassesRef.child(classHash)
+  dstClassRef = dstClassesRef.child(classHash)
+  print('..srcPath:', srcClassRef.path)
+  print('..dstPath:', dstClassRef.path)
+  # compare MD5 hashes of class contents
+  srcClassContentHash = hashlib.md5(json.dumps(srcClassRef.get()).encode('utf-8'))
+  dstClassContentHash = hashlib.md5(json.dumps(dstClassRef.get()).encode('utf-8'))
+  if classHash in retainedClasses:
+    # retain classes listed in retainedClasses
+    print(f'..retaining class {classHash}')
+  elif srcClassContentHash.hexdigest() == dstClassContentHash.hexdigest():
+    # delete classes from source that have been successfully archived
+    print(f'..deleting! class {classHash}')
+    srcClassRef.delete()
+  else:
+    # don't delete classes if MD5 hash doesn't match
+    print(f'..no-match! class {classHash}')


### PR DESCRIPTION
Python scripts for archiving CLUE class contents in firebase. There are two scripts:
- `archive.py` copies the contents of each class in `authed/portals/learn_concord_org/classes` to a corresponding location in `archived/portals/learn_concord_org-{DATE}/classes`
- `dedupe.py` compares (via MD5 hash) the original class contents with the archived class contents and deletes the original as long as they match, with the option to retain specific classes if desired.

These scripts were used to archive the current contents of `authed/portals/learn_concord_org/classes` in preparation for a production release of new CLUE features.

It turns out that the JavaScript SDK for firebase has a maximum single-write size of 16MB, which is insufficient to write the contents of an entire class. In fact, there is at least one user in one class with ~20MB. So using the JavaScript SDK for this task (as we did for the migration back in the day) would have required breaking down the class into a bunch of smaller pieces and then writing them individually. The Python SDK, in contrast, uses the firebase REST API, which has a maximum single-write size of 256MB, which is large enough to write the entire content of every currently existing class.