### PR TITLE
Miscellaneous project tweaks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,5 @@
 {
   "standard.enable": false,
-  "jshint.options": {
-    "esversion": 6,
-    "node": true
-  },
   "typescript.tsdk": "./node_modules/typescript/lib",
   "search.exclude": {
     "**/coverage": true,
@@ -11,9 +7,5 @@
   },
   "files.watcherExclude": {
     "**/dist/**": true
-  },
-  "files.exclude": {
-    "**/dist": true,
-    "**/node_modules": true
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Version 0.8.0 - released October 23, 2019
+
+- User documents associated with problems rather than sections
+- Users can create personal document workspaces
+- Users can rename/delete personal documents and learning logs
+- Teacher dashboard
+- Teacher switch classes & problems
+- Teacher workspace
+- Rich-content supports
+- Support Dataflow application
+
+### Asset Sizes
+
+| File | Size | % Change from Previous Release |
+|---|---|---|
+| index.css | 421,764 bytes | -15% |
+| index.js | 4,124,348 bytes | 2% |
+
 ## Version 0.7.1 - released May 29, 2019
 
 - Fixes listeners on loading empty document causing data loss

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "collaborative-learning",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "scripts": {
     "start": "webpack-dev-server --inline --hot --content-base dist/",
     "build": "npm-run-all lint:build clean build:webpack",
+    "build:debug": "npm-run-all lint clean build:webpack",
     "build:webpack": "cross-env NODE_OPTIONS=--max_old_space_size=4096 webpack --mode production",
     "clean": "rimraf dist",
     "lint": "tslint -c tslint.json 'src/**/*.{ts,tsx}'",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collaborative-learning",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Collaborative Learning environment",
   "main": "index.js",
   "jest": {


### PR DESCRIPTION
- Release 0.8.0 (cherry-picked from `staging` branch)
- npm audit fix (eliminate `https-proxy-agent` vulnerability)
- `build:debug` script (like `build` but lint allows `console.log` & `debugger`)
- `.vscode/settings.json` simplification
  - arguably shouldn't be in the repository at all
  - since it is in the repository, it should only specify project-specific settings, not user preferences