### PR TITLE
Remove code that sets selected relay to none if relay isn't immediately found

### DIFF
--- a/src/dataflow/components/nodes/controls/relay-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/relay-select-control.tsx
@@ -116,14 +116,6 @@ export class RelaySelectControl extends Rete.Control {
 
   public setChannels = (channels: NodeChannelInfo[]) => {
     this.props.channels = channels;
-
-    if (this.node.data[this.key] && this.node.data[this.key] !== "none") {
-      if (!channels.find(ch => ch.channelId === this.node.data[this.key])) {
-        this.props.value = "none";
-        this.putData(this.key, "none");
-      }
-    }
-
     // problem, if called with event nodecreate, update doesn't exist
     // (this as any).update();
   }


### PR DESCRIPTION
This PR updates the relay block to behave in the same fashion as the sensor block.  If a specific relay is selected on a block, then we leave that relay selected even if we cannot immediately find it.  Relay was still using the old model that was changed for the sensor block over the summer.  This was actually causing a bug when the user refreshed the browser and the initially loaded program contained a relay.  The program would load before we finished communicating with the AWS IoT server, we couldn't find the selected relay for the block, and we set the relay block to "none."  This change will fix this bug and sync sensor and relay selection behavior.