### PR TITLE
Show all curricular supports [#169381641]

### DIFF
--- a/src/models/stores/supports.ts
+++ b/src/models/stores/supports.ts
@@ -291,7 +291,7 @@ export function addSupportDocumentsToStore(params: ICreateFromUnitParams) {
                         : supportCaption;
     const originDoc = supportType === SupportType.teacher
                         ? (support as TeacherSupportModelType).originDoc
-                        : undefined;
+                        : supportKey; // unique origin for curricular supports
     const properties: IDocumentProperties = supportType === SupportType.curricular
                                               ? { curricularSupport: "true", caption: supportCaption }
                                               : { teacherSupport: "true", caption: supportCaption };


### PR DESCRIPTION
Fix bug in which curricular supports for a single problem were considered multiple publications from the same source document and so only the last one would get displayed.