### PR TITLE
[#169381657] Fixed Share Button in Two-Up View.

### DIFF
--- a/src/clue/clue.sass
+++ b/src/clue/clue.sass
@@ -91,13 +91,13 @@
               transform: none
               cursor: default
         .button-icon.share
+          margin-left: -5px
           &.visibility.public
             background-image: url("../assets/icons/share/share.svg")
             &:hover
               background-image: url("../assets/icons/share/not-share-hover.svg")
             &:active
               background-image: url("../assets/icons/share/not-share-active.svg")
-        .button-icon.share
           &.visibility.private
             background-image: url("../assets/icons/share/not-share.svg")
             &:hover

--- a/src/components/document/document.sass
+++ b/src/components/document/document.sass
@@ -75,6 +75,7 @@
 
       .mode
         border-top-right-radius: $border-radius
+        margin-left: -10px
 
       .mode #nextMode
         display: none


### PR DESCRIPTION
This corrects the margins so that the Share button does not bump up directly next to the side of the toolbar in two-up view, additionally correcting the margins to match the rest of the styling of the toolbar in the single problem document view.