### PR TITLE
Show all curricular supports (again) [#169604919]

### DIFF
--- a/src/models/stores/supports.ts
+++ b/src/models/stores/supports.ts
@@ -294,7 +294,7 @@ export function addSupportDocumentsToStore(params: ICreateFromUnitParams) {
                         : supportCaption;
     const originDoc = support.supportType === SupportType.teacher
                         ? (support as TeacherSupportModelType).originDoc
-                        : undefined;
+                        : supportKey; // unique origin for curricular supports
     let properties: IDocumentProperties;
     if (support.supportType === SupportType.curricular) {
       properties = { curricularSupport: "true", caption: supportCaption };


### PR DESCRIPTION
>Batten down the hatches!
>I did!
>Well, batten them down again! We'll teach those hatches!

This bug was fixed in [PR #533](https://github.com/concord-consortium/collaborative-learning/pull/533) and then inadvertently unfixed in [PR  #527](https://github.com/concord-consortium/collaborative-learning/pull/527) (which was merged after #533).