### PR TITLE
Small tweak to flex settings for dashboard right-controls (fixed width)

### DIFF
--- a/cypress/fixtures/teacher-dash-data.json
+++ b/cypress/fixtures/teacher-dash-data.json
@@ -5,7 +5,7 @@
         {
             "classIndex": 0,
             "className": "CLUE",
-            "problemTotal": 13,
+            "problemTotal": 14,
             "problems": [
                 {
                     "problem": 1.1,

--- a/cypress/integration/clue/full/teacher_tests/teacher_dashboard_spec.js
+++ b/cypress/integration/clue/full/teacher_tests/teacher_dashboard_spec.js
@@ -50,7 +50,7 @@ context("Teacher Space", () => {
                     // Check problem list  UI and visibility
                     dashboard.getProblemList().should('not.exist')
                     dashboard.getProblemDropdown().should('be.visible').click({ force: true })
-                    // dashboard.getProblemList().should('exist').and('have.length', tempClass.problemTotal)
+                    dashboard.getProblemList().should('exist').and('have.length', tempClass.problemTotal)
                     dashboard.getProblemDropdown().click({ force: true })
                     dashboard.getProblemList().should('not.exist')
                     // Check class list UI and visibility
@@ -73,7 +73,7 @@ context("Teacher Space", () => {
                     let group = groups[tempGroupIndex]
 
                     // Check for group title
-                    // dashboard.getSixPackView().should('exist').and('be.visible')
+                    dashboard.getSixPackView().should('exist').and('be.visible')
                     dashboard.getGroupName().eq(group.groupIndex).should('contain', group.groupName)
                     // Check for group length (4Up Count)
                     dashboard.getSixPackView().then(() => {

--- a/cypress/integration/clue/full/teacher_tests/teacher_dashboard_spec.js
+++ b/cypress/integration/clue/full/teacher_tests/teacher_dashboard_spec.js
@@ -50,7 +50,7 @@ context("Teacher Space", () => {
                     // Check problem list  UI and visibility
                     dashboard.getProblemList().should('not.exist')
                     dashboard.getProblemDropdown().should('be.visible').click({ force: true })
-                    dashboard.getProblemList().should('exist').and('have.length', tempClass.problemTotal)
+                    // dashboard.getProblemList().should('exist').and('have.length', tempClass.problemTotal)
                     dashboard.getProblemDropdown().click({ force: true })
                     dashboard.getProblemList().should('not.exist')
                     // Check class list UI and visibility
@@ -73,7 +73,7 @@ context("Teacher Space", () => {
                     let group = groups[tempGroupIndex]
 
                     // Check for group title
-                    dashboard.getSixPackView().should('exist').and('be.visible')
+                    // dashboard.getSixPackView().should('exist').and('be.visible')
                     dashboard.getGroupName().eq(group.groupIndex).should('contain', group.groupName)
                     // Check for group length (4Up Count)
                     dashboard.getSixPackView().then(() => {

--- a/src/clue/components/teacher/sixpack-right-controls.sass
+++ b/src/clue/components/teacher/sixpack-right-controls.sass
@@ -9,7 +9,7 @@
   margin-left: 0px
   padding-right: 5px
   border: #c9dab7
-  flex: 1    // Sets 10:1 width-ratio between .teacher-group-six-pack and .sixpack-right-controls
+  width: 110px
   .top-controls
     background-color: $sage
     padding: 5px

--- a/src/clue/components/teacher/teacher-group-six-pack.sass
+++ b/src/clue/components/teacher/teacher-group-six-pack.sass
@@ -8,7 +8,7 @@
   grid-gap: 6px
   justify-items: center
   color: black
-  flex: 10    // Sets 10:1 width-ratio between .teacher-group-six-pack and .sixpack-right-controls
+  flex: auto
   overflow: auto
 
   .teacher-group-canvas-container


### PR DESCRIPTION
This PR is for a very simple tweak to the flex properties controlling the width of the teacher-dashboard's right controls. Without this fix, the width of those controls is a percentage of the browser window's width -- this change keeps the width fixed so the rendering of the controls and buttons don't get all messed up with wide browser settings.

No PT story is associated with this quickie change.