### PR TITLE
Fix teacher dashboard cypress tests

### DIFF
--- a/cypress/fixtures/teacher-dash-data.json
+++ b/cypress/fixtures/teacher-dash-data.json
@@ -5,7 +5,7 @@
         {
             "classIndex": 0,
             "className": "CLUE",
-            "problemTotal": 13,
+            "problemTotal": 14,
             "problems": [
                 {
                     "problem": 1.1,


### PR DESCRIPTION
The addition of Investigation 0 (the tutorial) changed the number of problems in the problem popup which broke the teacher dashboard cypress tests. @eireland 