### PR TITLE
Clear new supports badge when appropriate

### DIFF
--- a/src/components/thumbnail/right-nav-tab-contents.tsx
+++ b/src/components/thumbnail/right-nav-tab-contents.tsx
@@ -15,6 +15,7 @@ interface IProps extends IBaseProps {
   tabId: ERightNavTab;
   className: string;
   scale: number;
+  onToggleExpansion?: (section: NavTabSectionModelType) => void;
 }
 interface IState {
   showSection: Map<string, boolean>;
@@ -106,6 +107,7 @@ export class RightNavTabContents extends BaseComponent<IProps, IState> {
     const isExpanded = this.state.showSection.get(sectionId);
     this.state.showSection.set(sectionId, !isExpanded);
     this.setState(state => ({ showSection: this.state.showSection }));
+    this.props.onToggleExpansion?.(section);
   }
 
   private handleNewDocumentClick = async (section: NavTabSectionModelType) => {


### PR DESCRIPTION
Clear new supports badge when user interacts with supports tab by
- clicking on supports tab to open or close it
- clicking to expand/collapse a supports section within the supports tab

Previously, only switching from another tab to the supports tab would clear the badge