### PR TITLE
[#169612763] Edit Document Titles via Document Titles in Titlebar

### DIFF
--- a/src/clue/clue.sass
+++ b/src/clue/clue.sass
@@ -65,6 +65,8 @@
       background-color: $peacock-light-1
     &.supportPublication
       background-color: $sky-light-1
+    #titlebar-title
+      cursor: pointer
     .actions
       .action.icon, .action.icon-button
         background-color: inherit

--- a/src/components/document/document.tsx
+++ b/src/components/document/document.tsx
@@ -124,6 +124,14 @@ const ViewModeButton = ({ onClick, icon, title }: { onClick: () => void, icon: s
   );
 };
 
+const TitleInfo = ({ docTitle, onClick, title }: { docTitle: string, onClick?: () => void, title?: string }) => {
+  return (
+    <span onClick={onClick} className={`${title} title-info`} id={title}>
+      {docTitle}
+    </span>
+  );
+};
+
 @inject("stores")
 @observer
 export class DocumentComponent extends BaseComponent<IProps, IState> {
@@ -253,11 +261,13 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
         {
           document.type === LearningLogDocument || document.type === LearningLogPublication
           ? <div className="title" data-test="learning-log-title">
-              <span className="title-info">Learning Log: {document.title}</span>
+              <TitleInfo docTitle={`Learning Log: ${document.title}`} onClick={this.handleDocumentRename}
+                         title="titlebar-title" />
               { !hideButtons && <EditButton onClick={this.handleDocumentRename} /> }
             </div>
           : <div className="title" data-test="personal-doc-title">
-              <span>{document.title}</span>
+              <TitleInfo docTitle={`${document.title}`} onClick={this.handleDocumentRename}
+                         title="titlebar-title" />
               { !hideButtons && <EditButton onClick={this.handleDocumentRename} /> }
             </div>
         }

--- a/src/components/document/document.tsx
+++ b/src/components/document/document.tsx
@@ -124,9 +124,9 @@ const ViewModeButton = ({ onClick, icon, title }: { onClick: () => void, icon: s
   );
 };
 
-const TitleInfo = ({ docTitle, onClick, title }: { docTitle: string, onClick?: () => void, title?: string }) => {
+const TitleInfo = ({ docTitle, onClick }: { docTitle: string, onClick?: () => void }) => {
   return (
-    <span onClick={onClick} className={`${title} title-info`} id={title}>
+    <span onClick={onClick} className="title-info" id="titlebar-title">
       {docTitle}
     </span>
   );
@@ -261,13 +261,11 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
         {
           document.type === LearningLogDocument || document.type === LearningLogPublication
           ? <div className="title" data-test="learning-log-title">
-              <TitleInfo docTitle={`Learning Log: ${document.title}`} onClick={this.handleDocumentRename}
-                         title="titlebar-title" />
+              <TitleInfo docTitle={`Learning Log: ${document.title}`} onClick={this.handleDocumentRename} />
               { !hideButtons && <EditButton onClick={this.handleDocumentRename} /> }
             </div>
           : <div className="title" data-test="personal-doc-title">
-              <TitleInfo docTitle={`${document.title}`} onClick={this.handleDocumentRename}
-                         title="titlebar-title" />
+              <TitleInfo docTitle={`${document.title}`} onClick={this.handleDocumentRename} />
               { !hideButtons && <EditButton onClick={this.handleDocumentRename} /> }
             </div>
         }


### PR DESCRIPTION
Clicking on a Personal or Learning Log document title in the titlebar will now open up the Rename Workspace dialog for users.