### PR TITLE
Fix new document dialog text [#169653637]

### DIFF
--- a/cypress/disabled/graph_table_integraton_test_spec.js
+++ b/cypress/disabled/graph_table_integraton_test_spec.js
@@ -204,7 +204,7 @@ context('Tests for graph and table integration', function(){
         before(()=>{
             let title = 'table to graph'
             canvas.canvas();
-            canvas.createNewProblemDocument(title);
+            canvas.createNewExtraDocument(title);
             canvas.getPersonalDocTitle().should('contain', title)
             addTableAndGraph();
         })

--- a/cypress/integration/clue/full/student_tests/canvas_test_spec.js
+++ b/cypress/integration/clue/full/student_tests/canvas_test_spec.js
@@ -49,7 +49,7 @@ context('Test Canvas', function(){
                 clueCanvas.openOneUpViewFromFourUp();
             })
             it('verify personal workspace header UI',()=>{ //other header elements are tested in common
-               canvas.createNewProblemDocument(studentWorkspace);
+               canvas.createNewExtraDocument(studentWorkspace);
                canvas.getNewDocumentIcon().should('be.visible');
                canvas.getCopyIcon().should('be.visible');
                canvas.getDeleteIcon().should('be.visible');

--- a/cypress/integration/clue/full/student_tests/graph_tool_spec.js
+++ b/cypress/integration/clue/full/student_tests/graph_tool_spec.js
@@ -28,7 +28,7 @@ context('Test graph tool functionalities', function(){
             graphToolTile.getGraphPointCoordinates().should('contain', '(0, 0)');
         });
         it('will add points to a graph', function(){
-            canvas.createNewProblemDocument(doc2)
+            canvas.createNewExtraDocument(doc2)
             cy.wait(2000)
             clueCanvas.addTile('geometry');
             graphToolTile.getGraphTile().last().click();

--- a/cypress/integration/clue/full/student_tests/image_tool_spec.js
+++ b/cypress/integration/clue/full/student_tests/image_tool_spec.js
@@ -50,7 +50,7 @@ context('Test image functionalities', function(){
     })
     describe('upload image from user computer',()=>{   
         before(()=>{ //create a new doc so that save and restore can e tested
-            canvas.createNewProblemDocument(userCanvas) 
+            canvas.createNewExtraDocument(userCanvas) 
             cy.wait(2000)
         })
         it('will upload png file from user computer', function(){

--- a/cypress/integration/clue/full/student_tests/text_tool_spec.js
+++ b/cypress/integration/clue/full/student_tests/text_tool_spec.js
@@ -33,7 +33,7 @@ context('Text tool tile functionalities', function(){
         textToolTile.getTextTile().last().should('contain', 'Hello World');
     });
     it('verifies restore of text field content',()=>{
-        canvas.createNewProblemDocument('text tool test');
+        canvas.createNewExtraDocument('text tool test');
         textToolTile.getTextTile().should('not.exist');
         //re-open investigation
         rightNav.openRightNavTab('my-work');

--- a/cypress/integration/clue/smoke/single_student_canvas_test.js
+++ b/cypress/integration/clue/smoke/single_student_canvas_test.js
@@ -107,7 +107,7 @@ context('single student functional test',()=>{
         let canvas2='Document 2';
         before(function(){ //Open a different document to see if original document is restored
             canvas.copyDocument(canvas1);
-            canvas.createNewProblemDocument(canvas2)
+            canvas.createNewExtraDocument(canvas2)
             textToolTile.getTextTile().should('not.exist')
         })
         describe('verify that canvas is saved from various locations', function(){

--- a/cypress/support/elements/common/Canvas.js
+++ b/cypress/support/elements/common/Canvas.js
@@ -52,15 +52,6 @@ class Canvas{
         return cy.get('[data-test=delete-icon]')
     }
 
-    createNewProblemDocument(title){
-        this.getNewDocumentIcon().click()
-            .then(()=>{
-                dialog.getDialogTitle().should('exist').contains('Create Problem Workspace');
-                dialog.getDialogTextInput().click().type('{selectall}{backspace}'+title);
-                dialog.getDialogOKButton().click();
-            })
-        cy.wait(3000)    
-    }
     createNewExtraDocument(title){
         this.getNewDocumentIcon().click()
             .then(()=>{

--- a/src/components/document/document-workspace.tsx
+++ b/src/components/document/document-workspace.tsx
@@ -292,8 +292,8 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps, {}> {
     const defaultDocTitle = document.isLearningLog
                             ? appConfig.defaultLearningLogTitle
                             : appConfig.defaultDocumentTitle;
-    const docTypeString = document.getLabel(appConfig, 1);
-    const docTypeStringL = document.getLabel(appConfig, 1, true);
+    const docTypeString = appConfig.getDocumentLabel(docType, 1);
+    const docTypeStringL = appConfig.getDocumentLabel(docType, 1, true);
     const nextTitle = this.stores.documents.getNextOtherDocumentTitle(user, docType, defaultDocTitle);
     this.stores.ui.prompt(`Name your new ${docTypeStringL}:`, `${nextTitle}`, `Create ${docTypeString}`)
       .then((title: string) => {


### PR DESCRIPTION
From the PT story:
>User-created documents are always "Extra" workspaces. Currently, if you click the new document icon on the title bar of a problem document the dialog says "Create Problem Workspace".