### PR TITLE
[#169654473] Add Program Container Default Height

### DIFF
--- a/src/dataflow/components/dataflow-program.sass
+++ b/src/dataflow/components/dataflow-program.sass
@@ -20,6 +20,7 @@ $dataflow-topbar-height: 40px
   display: flex
   flex-direction: column
   width: 100%
+  min-height: 300px
   height: 100%
 
   .toolbar-editor-container


### PR DESCRIPTION
For smaller screens on classroom Chromebooks add a default height. Testing this tomorrow in the office to verify this works on smaller screens!