### PR TITLE
Limit logging of tile events to user-initiated actions [#169490691]

### DIFF
--- a/src/components/document/document-content.tsx
+++ b/src/components/document/document-content.tsx
@@ -3,12 +3,12 @@ import * as React from "react";
 import { findDOMNode } from "react-dom";
 import { throttle } from "lodash";
 import { BaseComponent, IBaseProps } from "../base";
-import { DocumentContentModelType } from "../../models/document/document-content";
-import { DocumentTool } from "../../models/document/document";
 import { TileRowComponent, kDragResizeRowId, extractDragResizeRowId, extractDragResizeY,
         extractDragResizeModelHeight, extractDragResizeDomHeight } from "../document/tile-row";
-import { kDragTileSource, kDragTileId, kDragTileContent,
-        dragTileSrcDocId, kDragRowHeight, kDragTileCreate, IToolApiInterface, IDragTiles, kDragTiles } from "../tools/tool-tile";
+import { DocumentContentModelType, IDropRowInfo } from "../../models/document/document-content";
+import { DocumentTool } from "../../models/document/document";
+import { IDragTiles } from "../../models/tools/tool-tile";
+import { dragTileSrcDocId, IToolApiInterface, kDragTileCreate, kDragTiles } from "../tools/tool-tile";
 
 import "./document-content.sass";
 
@@ -27,13 +27,6 @@ interface IDragResizeRow {
   modelHeight?: number;
   domHeight?: number;
   deltaHeight: number;
-}
-
-export interface IDropRowInfo {
-  rowInsertIndex: number;
-  rowDropIndex?: number;
-  rowDropLocation?: string;
-  updateTimestamp?: number;
 }
 
 interface IState {
@@ -360,14 +353,14 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
     const { content } = this.props;
     if (!content) return;
     const dropRowInfo  = this.getDropRowInfo(e);
-    content.moveTiles(dragTiles.items, dropRowInfo);
+    content.userMoveTiles(dragTiles.items, dropRowInfo);
   }
 
   private handleCopyTilesDrop = (e: React.DragEvent<HTMLDivElement>, dragTiles: IDragTiles) => {
     const { content } = this.props;
     if (!content) return;
     const { rowInsertIndex } = this.getDropRowInfo(e);
-    content.copyTilesIntoNewRows(dragTiles.items, rowInsertIndex);
+    content.userCopyTiles(dragTiles.items, rowInsertIndex);
   }
 
   private handleInsertNewTile = (e: React.DragEvent<HTMLDivElement>) => {
@@ -382,7 +375,7 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
     const isInsertingInExistingRow = insertRowInfo && insertRowInfo.rowDropLocation &&
                                       (["left", "right"].indexOf(insertRowInfo.rowDropLocation) >= 0);
     const addSidecarNotes = (createTileType === "geometry") && !isInsertingInExistingRow;
-    const rowTile = content.addTile(createTileType, {addSidecarNotes, insertRowInfo});
+    const rowTile = content.userAddTile(createTileType, {addSidecarNotes, insertRowInfo});
 
     if (rowTile && rowTile.tileId) {
       ui.setSelectedTileId(rowTile.tileId);

--- a/src/components/document/document-workspace.tsx
+++ b/src/components/document/document-workspace.tsx
@@ -269,7 +269,7 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps, {}> {
           // insert the tile after the row it was dropped on otherwise add to end of document
           const rowIndex = rowId ? primaryDocument.content.getRowIndex(rowId) : undefined;
           const rowInsertIndex = (rowIndex !== undefined ? rowIndex + 1 : primaryDocument.content.rowOrder.length);
-          primaryDocument.content.addTile("image", {
+          primaryDocument.content.userAddTile("image", {
             url,
             insertRowInfo: {
               rowInsertIndex

--- a/src/components/tools/tool-tile.tsx
+++ b/src/components/tools/tool-tile.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
 import { observer, inject } from "mobx-react";
 import { getSnapshot } from "mobx-state-tree";
+import { cloneDeep } from "lodash";
 import { getDisabledFeaturesOfTile } from "../../models/stores/stores";
-import { ToolTileModelType } from "../../models/tools/tool-tile";
+import { ToolTileModelType, IDragTiles } from "../../models/tools/tool-tile";
 import { kGeometryToolID } from "../../models/tools/geometry/geometry-content";
 import { kTableToolID } from "../../models/tools/table/table-content";
 import { kTextToolID } from "../../models/tools/text/text-content";
@@ -17,12 +18,11 @@ import ImageToolComponent from "./image-tool";
 import DrawingToolComponent from "./drawing-tool/drawing-tool";
 import PlaceholderToolComponent from "./placeholder-tool/placeholder-tool";
 import { HotKeys } from "../../utilities/hot-keys";
-import { cloneDeep } from "lodash";
 import { TileCommentsComponent } from "./tile-comments";
 import { LinkIndicatorComponent } from "./link-indicator";
+import { hasSelectionModifier } from "../../utilities/event-utils";
 import { IconButton } from "../utilities/icon-button";
 import "../../utilities/dom-utils";
-import { hasSelectionModifier } from "../../utilities/event-utils";
 
 import "./tool-tile.sass";
 
@@ -68,21 +68,6 @@ export function extractDragTileType(dataTransfer: DataTransfer) {
       if (result) return result[1];
     }
   }
-}
-
-export interface IDragTileItem {
-  rowIndex: number;
-  rowHeight?: number;
-  tileIndex: number;
-  tileId: string;
-  tileContent: string;
-  tileType: string;
-  // height?
-}
-
-export interface IDragTiles {
-  sourceDocId: string;
-  items: IDragTileItem[];
 }
 
 interface IProps {

--- a/src/lib/logger.test.ts
+++ b/src/lib/logger.test.ts
@@ -1,14 +1,13 @@
 import mock from "xhr-mock";
-import { IStores, createStores } from "../models/stores/stores";
 import { Logger, LogEventName } from "./logger";
-import { createToolTileModelFromContent, ToolTileModelType } from "../models/tools/tool-tile";
-import { defaultTextContent } from "../models/tools/text/text-content";
 import { ProblemDocument, DocumentModel, DocumentModelType } from "../models/document/document";
-import { createSingleTileContent } from "../utilities/test-utils";
 import { DocumentContentModel } from "../models/document/document-content";
-import { getSnapshot } from "mobx-state-tree";
 import { InvestigationModel } from "../models/curriculum/investigation";
+import { IStores, createStores } from "../models/stores/stores";
 import { WorkspaceModel, ProblemWorkspace, WorkspaceModelType } from "../models/stores/workspace";
+import { defaultTextContent } from "../models/tools/text/text-content";
+import { createToolTileModelFromContent, IDragTileItem, ToolTileModelType } from "../models/tools/tool-tile";
+import { createSingleTileContent } from "../utilities/test-utils";
 
 const investigation = InvestigationModel.create({
   ordinal: 1,
@@ -55,7 +54,7 @@ describe("logger", () => {
         return res.status(201);
       });
 
-      await Logger.log(LogEventName.CREATE_TILE, {foo: "bar"});
+      Logger.log(LogEventName.CREATE_TILE, { foo: "bar" });
     });
 
     it("can log tile creation", async (done) => {
@@ -77,10 +76,10 @@ describe("logger", () => {
         return res.status(201);
       });
 
-      await Logger.logTileEvent(LogEventName.CREATE_TILE, tile);
+      Logger.logTileEvent(LogEventName.CREATE_TILE, tile);
     });
 
-    it.skip("can log tile creation in a document", async (done) => {
+    it("can log tile creation in a document", async (done) => {
       const document = DocumentModel.create({
         type: ProblemDocument,
         uid: "1",
@@ -99,19 +98,19 @@ describe("logger", () => {
         expect(request.parameters.objectType).toBe("Text");
         expect(request.parameters.serializedObject).toEqual({
           type: "Text",
-          text: "test"
+          text: ""
         });
         expect(request.parameters.documentKey).toBe("source-document");
-        expect(request.parameters.documentType).toBe("section");
+        expect(request.parameters.documentType).toBe("problem");
 
         done();
         return res.status(201);
       });
 
-      await document.content.addTextTile({ text: "test" });
+      document.content.userAddTile("text");
     });
 
-    it.skip("can log copying tiles between documents", async (done) => {
+    it("can log copying tiles between documents", async (done) => {
       const sourceDocument = DocumentModel.create({
         type: ProblemDocument,
         uid: "source-user",
@@ -148,28 +147,28 @@ describe("logger", () => {
           text: "test"
         });
         expect(request.parameters.documentKey).toBe("destination-document");
-        expect(request.parameters.documentType).toBe("section");
+        expect(request.parameters.documentType).toBe("problem");
         expect(request.parameters.objectId).not.toBe(tileToCopy.id);
         expect(request.parameters.sourceDocumentKey).toBe("source-document");
-        expect(request.parameters.sourceDocumentType).toBe("section");
-        expect(request.parameters.souceObjectId).toBe(tileToCopy.id);
+        expect(request.parameters.sourceDocumentType).toBe("problem");
+        expect(request.parameters.sourceObjectId).toBe(tileToCopy.id);
         expect(request.parameters.sourceUsername).toBe("source-user");
-        expect(request.parameters.sourceSection).toBe("source-section");
-
-        expect(request.section).toBe("destination-section");
 
         done();
         return res.status(201);
       });
 
-      // annoying way to get a tile...
-      const firstRow = sourceDocument.content.getRowByIndex(0);
-      const tileIdToCopy = firstRow!.tiles[0].tileId;
-      tileToCopy = sourceDocument.content.getTile(tileIdToCopy) as ToolTileModelType;
+      tileToCopy = sourceDocument.content.firstTile!;
 
-      const serialized = JSON.stringify(getSnapshot(tileToCopy));
+      const copyTileInfo: IDragTileItem = {
+        rowIndex: 0,
+        tileIndex: 0,
+        tileId: tileToCopy.id,
+        tileContent: JSON.stringify(tileToCopy),
+        tileType: tileToCopy.content.type
+      };
 
-      await destinationDocument.content.copyTileIntoNewRow(serialized, tileToCopy.id, 0);
+      destinationDocument.content.userCopyTiles([copyTileInfo], 0);
     });
 
   });
@@ -203,34 +202,34 @@ describe("logger", () => {
       });
     });
 
-    it.skip("can log opening the primary document", async (done) => {
+    it("can log opening the primary document", async (done) => {
       mock.post(/.*/, (req, res) => {
         const request = JSON.parse(req.body());
 
         expect(request.event).toBe("VIEW_SHOW_DOCUMENT");
         expect(request.parameters.documentKey).toBe("test1");
-        expect(request.parameters.documentType).toBe("section");
+        expect(request.parameters.documentType).toBe("problem");
 
         done();
         return res.status(201);
       });
 
-      await workspace.setPrimaryDocument(doc1);
+      workspace.setPrimaryDocument(doc1);
     });
 
-    it.skip("can log opening the comparison document", async (done) => {
+    it("can log opening the comparison document", async (done) => {
       mock.post(/.*/, (req, res) => {
         const request = JSON.parse(req.body());
 
         expect(request.event).toBe("VIEW_SHOW_COMPARISON_DOCUMENT");
         expect(request.parameters.documentKey).toBe("test2");
-        expect(request.parameters.documentType).toBe("section");
+        expect(request.parameters.documentType).toBe("problem");
 
         done();
         return res.status(201);
       });
 
-      await workspace.setComparisonDocument(doc2);
+      workspace.setComparisonDocument(doc2);
     });
 
     it("can log toggling the comparison panel", async (done) => {
@@ -243,7 +242,7 @@ describe("logger", () => {
         return res.status(201);
       });
 
-      await workspace.toggleComparisonVisible();
+      workspace.toggleComparisonVisible();
     });
 
     it("can log toggling of mode", async (done) => {
@@ -256,7 +255,7 @@ describe("logger", () => {
         return res.status(201);
       });
 
-      await workspace.toggleMode();
+      workspace.toggleMode();
     });
   });
 });

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -23,7 +23,6 @@ interface LogMessage {
   appMode: string;
   investigation?: string;
   problem?: string;
-  section?: string;
   group?: string;
   time: number;
   event: string;
@@ -44,6 +43,7 @@ export enum LogEventMethod {
 export enum LogEventName {
   CREATE_TILE,
   COPY_TILE,
+  MOVE_TILE,
   DELETE_TILE,
 
   VIEW_SHOW_DOCUMENT,
@@ -85,7 +85,6 @@ type ToolChangeEventType = JXGChange | DrawingToolChange | ITableChange;
 interface IDocumentInfo {
   type: string;
   key?: string;
-  section?: string;
   uid?: string;
   title?: string;
   properties?: { [prop: string]: string };
@@ -126,8 +125,7 @@ export class Logger {
         objectType: tile.content.type,
         serializedObject: getSnapshot(tile).content,
         documentKey: document.key,
-        documentType: document.type,
-        section: document.section
+        documentType: document.type
       };
 
       if (event === LogEventName.COPY_TILE && metaData && metaData.originalTileId) {
@@ -135,12 +133,11 @@ export class Logger {
         parameters = {
           ...parameters,
           sourceUsername: sourceDocument.uid,
-          souceObjectId: metaData.originalTileId,
+          sourceObjectId: metaData.originalTileId,
           sourceDocumentKey: sourceDocument.key,
           sourceDocumentType: sourceDocument.type,
           sourceDocumentTitle: sourceDocument.title || "",
-          sourceDocumentProperties: sourceDocument.properties || {},
-          sourceSection: sourceDocument.section || document.section   // if it's instructions, use dest doc's section
+          sourceDocumentProperties: sourceDocument.properties || {}
         };
       }
     }

--- a/src/models/document/document-content.test.ts
+++ b/src/models/document/document-content.test.ts
@@ -1,9 +1,8 @@
 import { DocumentContentModel, DocumentContentModelType, cloneContentWithUniqueIds, DocumentContentSnapshotType } from "./document-content";
-import { defaultTextContent, TextContentModelType } from "../tools/text/text-content";
-import { IDragTiles, IDragTileItem } from "../../components/tools/tool-tile";
+import { IDropRowInfo } from "../../models/document/document-content";
+import { IDragTileItem } from "../../models/tools/tool-tile";
+import { defaultTextContent } from "../tools/text/text-content";
 import { getSnapshot } from "mobx-state-tree";
-import { IDropRowInfo } from "../../components/document/document-content";
-import { TileRowModelType } from "./tile-row";
 import { cloneDeep } from "lodash";
 
 describe("DocumentContentModel", () => {

--- a/src/models/document/document.ts
+++ b/src/models/document/document.ts
@@ -145,11 +145,11 @@ export const DocumentModel = types
     },
 
     addTile(tool: DocumentTool, options?: IDocumentAddTileOptions) {
-      return self.content.addTile(tool, options);
+      return self.content.userAddTile(tool, options);
     },
 
     deleteTile(tileId: string) {
-      self.content.deleteTile(tileId);
+      self.content.userDeleteTile(tileId);
     },
 
     setTileComments(tileId: string, comments: TileCommentsModelType) {

--- a/src/models/tools/tool-tile.ts
+++ b/src/models/tools/tool-tile.ts
@@ -6,6 +6,20 @@ import * as uuid from "uuid/v4";
 // generally negotiated with app, e.g. single column width for table
 export const kDefaultMinWidth = 60;
 
+export interface IDragTileItem {
+  rowIndex: number;
+  rowHeight?: number;
+  tileIndex: number;
+  tileId: string;
+  tileContent: string;
+  tileType: string;
+}
+
+export interface IDragTiles {
+  sourceDocId: string;
+  items: IDragTileItem[];
+}
+
 export function createToolTileModelFromContent(content: ToolContentUnionType) {
   return ToolTileModel.create({ content });
 }


### PR DESCRIPTION
Note: this PR is based on #530, which should be merged first and then this should be rebased to master before merging.

- add new `userAddTile`, `userDeleteTile`, `userMoveTiles`, `userCopyTiles` methods to `DocumentContentModel`
- move all logging into the new `user...` methods
- user-initiated actions call the `user...` methods so they are logged
- added logging of `MOVE_TILE` events

In addition
- moved some definitions (components should import definitions from models, not the other way around)
- cleaned up imports (eliminated unused imports, reordered imports, etc.)
- fixed some disabled Logger unit tests
- removed document `section` from log events since documents aren't associated with a particular section any more
- fixed a typo in log events (souceObjectId => sourceObjectId)