### PR TITLE
169755093 logging updates

### DIFF
--- a/src/components/document/document.tsx
+++ b/src/components/document/document.tsx
@@ -15,9 +15,9 @@ import { TileCommentModel, TileCommentsModel } from "../../models/tools/tile-com
 import { ToolbarConfig } from "../../models/tools/tool-types";
 import { IconButton } from "../utilities/icon-button";
 import SingleStringDialog from "../utilities/single-string-dialog";
+import { Logger, LogEventName, LogPublishEvent } from "../../lib/logger";
 
 import "./document.sass";
-import { Logger, LogEventName } from "../../lib/logger";
 
 export enum DocumentViewMode {
   Live,
@@ -431,8 +431,11 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
   private handleToggleVisibility = () => {
     const doc = this.props.document;
     doc.toggleVisibility();
-    const op = doc.visibility && (doc.visibility === "public" ? "shared" : "unshared");
-    Logger.logDocumentEvent(LogEventName.SHOW_WORK, doc, op);
+    const publishEvent = doc.visibility &&
+      (doc.visibility === "public"
+        ? LogPublishEvent.SHARE
+        : LogPublishEvent.UNSHARE);
+    Logger.logDocumentEvent(LogEventName.SHOW_WORK, doc, publishEvent);
   }
 
   private handleToggleTwoUp = () => {

--- a/src/components/document/document.tsx
+++ b/src/components/document/document.tsx
@@ -15,7 +15,7 @@ import { TileCommentModel, TileCommentsModel } from "../../models/tools/tile-com
 import { ToolbarConfig } from "../../models/tools/tool-types";
 import { IconButton } from "../utilities/icon-button";
 import SingleStringDialog from "../utilities/single-string-dialog";
-import { Logger, LogEventName, LogPublishEvent } from "../../lib/logger";
+import { Logger, LogEventName } from "../../lib/logger";
 
 import "./document.sass";
 
@@ -431,11 +431,7 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
   private handleToggleVisibility = () => {
     const doc = this.props.document;
     doc.toggleVisibility();
-    const publishEvent = doc.visibility &&
-      (doc.visibility === "public"
-        ? LogPublishEvent.SHARE
-        : LogPublishEvent.UNSHARE);
-    Logger.logDocumentEvent(LogEventName.SHOW_WORK, doc, publishEvent);
+    Logger.logDocumentEvent(LogEventName.SHOW_WORK, doc);
   }
 
   private handleToggleTwoUp = () => {

--- a/src/components/document/document.tsx
+++ b/src/components/document/document.tsx
@@ -17,6 +17,7 @@ import { IconButton } from "../utilities/icon-button";
 import SingleStringDialog from "../utilities/single-string-dialog";
 
 import "./document.sass";
+import { Logger, LogEventName } from "../../lib/logger";
 
 export enum DocumentViewMode {
   Live,
@@ -428,7 +429,10 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
   }
 
   private handleToggleVisibility = () => {
-    this.props.document.toggleVisibility();
+    const doc = this.props.document;
+    doc.toggleVisibility();
+    const op = doc.visibility && (doc.visibility === "public" ? "shared" : "unshared");
+    Logger.logDocumentEvent(LogEventName.SHOW_WORK, doc, op);
   }
 
   private handleToggleTwoUp = () => {

--- a/src/components/navigation/left-nav.tsx
+++ b/src/components/navigation/left-nav.tsx
@@ -7,6 +7,7 @@ import { LeftNavPanelComponent } from "./left-nav-panel";
 import { BaseComponent, IBaseProps } from "../base";
 
 import "./left-nav.sass";
+import { Logger, LogEventName } from "../../lib/logger";
 
 interface IProps extends IBaseProps {
   isGhostUser: boolean;
@@ -76,14 +77,20 @@ export class LeftNavComponent extends BaseComponent<IProps, IState> {
   }
 
   private handleTabClick = (sectionIndex: number) => {
-    const { ui } = this.stores;
+    const { problem: {sections}, ui } = this.stores;
+    const logParameters = {
+      tab_name: sections[sectionIndex].title,
+      tab_type: sections[sectionIndex].type
+    };
+    const logEvent = () => { Logger.log(LogEventName.SHOW_LEFT_TAB, logParameters); };
     return (e: React.MouseEvent<HTMLDivElement>) => {
       if (ui.activeSectionIndex !== sectionIndex) {
         ui.setActiveSectionIndex(sectionIndex);
-        this.stores.ui.toggleLeftNav(true);
-      }
-      else {
-        this.stores.ui.toggleLeftNav();
+        ui.toggleLeftNav(true);
+        logEvent();
+      } else {
+        ui.toggleLeftNav();
+        ui.leftNavExpanded && logEvent();
       }
       this.updateTabLoadAllowedState(sectionIndex);
     };

--- a/src/components/navigation/left-nav.tsx
+++ b/src/components/navigation/left-nav.tsx
@@ -5,9 +5,9 @@ import { TabComponent } from "../tab";
 import { TabSetComponent } from "../tab-set";
 import { LeftNavPanelComponent } from "./left-nav-panel";
 import { BaseComponent, IBaseProps } from "../base";
+import { Logger, LogEventName } from "../../lib/logger";
 
 import "./left-nav.sass";
-import { Logger, LogEventName } from "../../lib/logger";
 
 interface IProps extends IBaseProps {
   isGhostUser: boolean;

--- a/src/components/navigation/right-nav.tsx
+++ b/src/components/navigation/right-nav.tsx
@@ -1,14 +1,15 @@
 import { inject, observer } from "mobx-react";
 import * as React from "react";
+import { map } from "lodash";
 
 import { TabComponent } from "../tab";
 import { TabSetComponent } from "../tab-set";
 import { BaseComponent, IBaseProps } from "../base";
 import { RightNavTabContents } from "../thumbnail/right-nav-tab-contents";
 import { ERightNavTab, NavTabSectionModelType, RightNavTabMap, RightNavTabSpec } from "../../models/view/right-nav";
-import { map } from "lodash";
-import "./right-nav.sass";
 import { Logger, LogEventName } from "../../lib/logger";
+
+import "./right-nav.sass";
 
 // cf. right-nav.sass: $list-item-scale
 const kRightNavItemScale = 0.11;

--- a/src/components/navigation/right-nav.tsx
+++ b/src/components/navigation/right-nav.tsx
@@ -8,6 +8,7 @@ import { RightNavTabContents } from "../thumbnail/right-nav-tab-contents";
 import { ERightNavTab, NavTabSectionModelType, RightNavTabMap, RightNavTabSpec } from "../../models/view/right-nav";
 import { map } from "lodash";
 import "./right-nav.sass";
+import { Logger, LogEventName } from "../../lib/logger";
 
 // cf. right-nav.sass: $list-item-scale
 const kRightNavItemScale = 0.11;
@@ -172,19 +173,28 @@ export class RightNavComponent extends BaseComponent<IProps, IState> {
   private handleTabClick = (tab: ERightNavTab) => {
     const { ui } = this.stores;
     const navDoneExpanding = ui.rightNavExpanded;
+    const logParameters = {
+      tab_name: tab.toString()
+    };
+    const logEvent = () => { Logger.log(LogEventName.SHOW_RIGHT_TAB, logParameters); };
     return (e: React.MouseEvent<HTMLDivElement>) => {
       if (!navDoneExpanding) {
         this.setState({navExpanding: true});
       }
+
       if (tab === ERightNavTab.kSupports) {
         this.updateStudentLastViewSupportTimestamp();
       }
+
       if (ui.activeRightNavTab !== tab) {
         ui.setActiveRightNavTab(tab);
-        this.stores.ui.toggleRightNav(true);
+        ui.toggleRightNav(true);
+        logEvent();
       } else {
-        this.stores.ui.toggleRightNav();
+        ui.toggleRightNav();
+        ui.rightNavExpanded && logEvent();
       }
+
       if (navDoneExpanding) {
         this.updateComponentLoadAllowedState();
       }

--- a/src/components/thumbnail/right-nav-tab-contents.tsx
+++ b/src/components/thumbnail/right-nav-tab-contents.tsx
@@ -108,8 +108,13 @@ export class RightNavTabContents extends BaseComponent<IProps, IState> {
     this.state.showSection.set(sectionId, !isExpanded);
     this.setState(state => ({ showSection: this.state.showSection }));
     this.props.onToggleExpansion?.(section);
-    !isExpanded && Logger.log(LogEventName.SHOW_FILTER,
-      { filter_name: section.title, filter_type: section.type });
+    Logger.log(LogEventName.SHOW_FILTER,
+      {
+        filter_state: (isExpanded ? "close" : "open"),
+        filter_name: section.title,
+        filter_type: section.type
+      }
+    );
   }
 
   private handleNewDocumentClick = async (section: NavTabSectionModelType) => {

--- a/src/components/thumbnail/right-nav-tab-contents.tsx
+++ b/src/components/thumbnail/right-nav-tab-contents.tsx
@@ -108,6 +108,8 @@ export class RightNavTabContents extends BaseComponent<IProps, IState> {
     this.state.showSection.set(sectionId, !isExpanded);
     this.setState(state => ({ showSection: this.state.showSection }));
     this.props.onToggleExpansion?.(section);
+    !isExpanded && Logger.log(LogEventName.SHOW_FILTER,
+      { filter_name: section.title, filter_type: section.type });
   }
 
   private handleNewDocumentClick = async (section: NavTabSectionModelType) => {

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -58,6 +58,8 @@ export enum LogEventName {
   CREATE_PERSONAL_DOCUMENT,
   CREATE_LEARNING_LOG,
 
+  SHOW_WORK,
+
   GRAPH_TOOL_CHANGE,
   DRAWING_TOOL_CHANGE,
   TABLE_TOOL_CHANGE,
@@ -68,7 +70,7 @@ export enum LogEventName {
   PUBLISH_DOCUMENT,
   PUBLISH_SUPPORT,
 
-  // the followng are for potential debugging purposes and are all marked "internal"
+  // the following are for potential debugging purposes and are all marked "internal"
   INTERNAL_AUTHENTICATED,
   INTERNAL_FIREBASE_DISCONNECTED,
 
@@ -145,13 +147,14 @@ export class Logger {
     Logger.log(event, parameters);
   }
 
-  public static logDocumentEvent(event: LogEventName, document: DocumentModelType) {
+  public static logDocumentEvent(event: LogEventName, document: DocumentModelType, operation?: string) {
     const parameters = {
       documentUid: document.uid,
       documentKey: document.key,
       documentType: document.type,
       documentTitle: document.title || "",
-      documentProperties: document.properties && document.properties.toJSON() || {}
+      documentProperties: document.properties && document.properties.toJSON() || {},
+      operation: operation ? operation : ""
     };
     Logger.log(event, parameters);
   }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -59,6 +59,9 @@ export enum LogEventName {
   CREATE_LEARNING_LOG,
 
   SHOW_WORK,
+  SHOW_LEFT_TAB,
+  SHOW_RIGHT_TAB,
+  SHOW_FILTER,
 
   GRAPH_TOOL_CHANGE,
   DRAWING_TOOL_CHANGE,
@@ -90,6 +93,11 @@ interface IDocumentInfo {
   uid?: string;
   title?: string;
   properties?: { [prop: string]: string };
+}
+
+export enum LogPublishEvent {
+  SHARE = "share",
+  UNSHARE = "unshare"
 }
 
 export class Logger {
@@ -147,14 +155,14 @@ export class Logger {
     Logger.log(event, parameters);
   }
 
-  public static logDocumentEvent(event: LogEventName, document: DocumentModelType, operation?: string) {
+  public static logDocumentEvent(event: LogEventName, document: DocumentModelType, publishEvent?: LogPublishEvent) {
     const parameters = {
       documentUid: document.uid,
       documentKey: document.key,
       documentType: document.type,
       documentTitle: document.title || "",
       documentProperties: document.properties && document.properties.toJSON() || {},
-      operation: operation ? operation : ""
+      publishedVisibility: (publishEvent ? publishEvent : "")
     };
     Logger.log(event, parameters);
   }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -95,11 +95,6 @@ interface IDocumentInfo {
   properties?: { [prop: string]: string };
 }
 
-export enum LogPublishEvent {
-  SHARE = "share",
-  UNSHARE = "unshare"
-}
-
 export class Logger {
   public static initializeLogger(stores: IStores, investigation?: InvestigationModelType, problem?: ProblemModelType) {
     if (DEBUG_LOGGER) {
@@ -155,14 +150,14 @@ export class Logger {
     Logger.log(event, parameters);
   }
 
-  public static logDocumentEvent(event: LogEventName, document: DocumentModelType, publishEvent?: LogPublishEvent) {
+  public static logDocumentEvent(event: LogEventName, document: DocumentModelType) {
     const parameters = {
       documentUid: document.uid,
       documentKey: document.key,
       documentType: document.type,
       documentTitle: document.title || "",
       documentProperties: document.properties && document.properties.toJSON() || {},
-      publishedVisibility: (publishEvent ? publishEvent : "")
+      documentVisibility: document.visibility
     };
     Logger.log(event, parameters);
   }


### PR DESCRIPTION
This PR addresses PT Story:

[169755093] logging updates

There are several items mentioned in the story and some of the work had be addressed with previous changes. Here is a list of the status of the numbered issues listed in the PT story.

1) serializedObject contents... **Not addressed; not in the CLUE codebase**

2) We need to log the group share/unshare event. I’d suggest calling the event something like SHOW_WORK, with an added parameter, like “visible” being set to True/False. We’d need to know the documentKey as well.

**When the learner clicks share or un-share, a `SHOW_WORK` event is logged. In additional to all the document parameters, an additional property, `"publishedVisibility"` with have either `"share"` or `"unshare"`.**

3) We need to log clicks to open the left-hand or right-hand tabs, and which one.

**When the learner causes any of the left-tabs to be exposed, a `SHOW_LEFT_TAB` event is logged. The parameters of the log event will contain the title and section type. For example, if the learner clicks the "Initial Challenge" tab, the parameters will contain `"tab_name":"Initial Challenge","tab_type":"initialChallenge"`.**

**When the learner causes any of the right-tabs to be exposed, a `SHOW_RIGHT_TAB` event is logged. The parameters of the log event will contain a single property to identify which of the right tabs is exposed. For example, if the learner clicks the "Class Work" tab, the parameters will contain `"tab_name":"class-work"`. Note that unlike the `SHOW_LEFT_TAB` event, this event does not have a name/type pair, just the name.**

4) We need to log expanding/contracting the filter lists (My documents, Problem Documents, Starred).

**When the learner expands or closes the filter list within a right-hand tab, a `SHOW_FILTER` event is logged. The parameters  will contain 3 properties. For example:
`"filter_state":"open","filter_name":"Problem Workspaces","filter_type":"problem-documents"`.

5) We need to log where in the destination document users copy elements - a documentSection parameter should be added, if possible. **Not yet implemented. Should be a new PT story.**

6) In parameters, “souceObjectId” should be spelled “sourceObjectId”. **Completed in earlier branch.**