### PR TITLE
Restore previous multi-select functionality in geometry tool [#169794619]

### DIFF
--- a/cypress/integration/clue/full/teacher_tests/teacher_dashboard_spec.js
+++ b/cypress/integration/clue/full/teacher_tests/teacher_dashboard_spec.js
@@ -212,7 +212,6 @@ context("Teacher Space", () => {
                 cy.get('@clueData').then((clueData) => {
                     let tempGroupIndex = 0
                     let tempGroup = clueData.classes[0].problems[0].groups[tempGroupIndex]
-                    debugger
                     dashboard.verifyWorkForGroupReadOnly(tempGroup)
                     cy.wait(1000)
                 })
@@ -313,6 +312,7 @@ context("Teacher Space", () => {
 
                 cy.get('@clueData').then((clueData) => {
                     groups = clueData.classes[classIndex].problems[problemIndex].groups
+                    dashboard.clearAllStarsFromPublishedWork()
                     dashboard.starPublishedWork(groups)
                 })
             })

--- a/cypress/support/elements/clue/TeacherDashboard.js
+++ b/cypress/support/elements/clue/TeacherDashboard.js
@@ -135,6 +135,13 @@ class TeacherDashboard {
         // subtract 4 because there are 4 published docs that are not in view
         this.getStarPublishIcon().should('have.length', totalPublished-4).click({force:true,multiple:true})
     }
+    clearAllStarsFromPublishedWork() {
+        return cy.get('.icon-star').each(star => {
+            if (star.hasClass('starred')) {
+                star.click({ force: true, multiple: true });
+            }
+        });
+    }
     clearAllStarred() {
         this.getRightNavTabListShown().within(() => {
             cy.get('svg.starred').click({ multiple: true })

--- a/src/components/tools/geometry-tool/geometry-tool.tsx
+++ b/src/components/tools/geometry-tool/geometry-tool.tsx
@@ -132,8 +132,8 @@ export default class GeometryToolComponent extends BaseComponent<IGeometryProps,
       // requires non-empty tabIndex
       this.domElement.current.focus();
     }
-    // first click selects (or deselects) the tile
-    if (!ui.isSelectedTile(model) || hasSelectionModifier(e)) {
+    // first click selects the tile
+    if (!ui.isSelectedTile(model)) {
       ui.setSelectedTile(model, {append: hasSelectionModifier(e)});
       this.didLastMouseDownSelectTile = true;
       // prevent the click from taking effect, e.g. creating a point


### PR DESCRIPTION
An earlier commit as part of the multi-tile selection PR caused the click to be intercepted for tile selection. With this commit we reintroduce the prior behavior, which fixes the behavior within the geometry tool at the expense of the ability to cmd/shift-click to deselect the geometry tile.

Revert "Fix geometry tool deselection"

This reverts commit cb36316531f878481e7e1e5b82f5e8aa7b134b1a.