### PR TITLE
Fix sticky note dialog close icon weirdness

### DIFF
--- a/src/components/document/document.sass
+++ b/src/components/document/document.sass
@@ -304,6 +304,7 @@
         height: 24px
         cursor: pointer
         border: 0
+        z-index: 3
 
     .sticky-note-popup-items
       overflow: auto


### PR DESCRIPTION
Increase z-index of the sticky note dialog close icon so it's above the drag/drop zones of the underlying document (z-index: 2)