### PR TITLE
Fix `mergeRow()` bugs [#169909893]

### DIFF
--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -251,11 +251,6 @@ export const DocumentContentModel = types
     }
   }))
   .actions(self => ({
-    afterCreate() {
-      self.rowMap.forEach(row => {
-        row.updateLayout(self.tileMap);
-      });
-    },
     insertRow(row: TileRowModelType, index?: number) {
       self.rowMap.put(row);
       if ((index != null) && (index < self.rowOrder.length)) {
@@ -318,6 +313,15 @@ export const DocumentContentModel = types
     }
   }))
   .actions(self => ({
+    afterCreate() {
+      self.rowMap.forEach(row => {
+        row.updateLayout(self.tileMap);
+      });
+      // fix any "collapsed" sections
+      for (let i = 1; i < self.rowCount; ++i) {
+        self.addPlaceholderRowIfAppropriate(i);
+      }
+    },
     addTileInNewRow(content: ToolContentUnionType, options?: INewTileOptions): INewRowTile {
       const tile = createToolTileModelFromContent(content);
       const o = options || {};

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -667,11 +667,16 @@ export const DocumentContentModel = types
           if (row?.tiles.length === rowTiles.length) {
             if ((rowDropLocation === "left") || (rowDropLocation === "right")) {
               // entire row is being merged with an existing row
-              self.mergeRow(row, rowInfo);
+              const dstRow = rowInfo.rowDropIndex ? self.getRowByIndex(rowInfo.rowDropIndex) : undefined;
+              if ((rowIndex !== rowInfo.rowDropIndex) && (dstRow && !dstRow.isSectionHeader)) {
+                self.mergeRow(row, rowInfo);
+              }
             }
             else {
               // entire row is being moved to a new row
-              self.moveRowToIndex(rowIndex, rowInsertIndex);
+              if ((rowInsertIndex < rowIndex) || (rowInsertIndex > rowIndex + 1)) {
+                self.moveRowToIndex(rowIndex, rowInsertIndex);
+              }
             }
           }
           else {


### PR DESCRIPTION
When all of the tiles of an existing row are being copied to another row that already has one or more tiles, the code merges the tiles from the source row with those of the destination row and then deletes the source row. In the bug scenario, the code attempts to merge a row with itself, after which it deletes the source (which is also the destination) resulting in the bug. The fix is simply to disallow merging a row with itself (or with a section header row, which has a similar effect).