### PR TITLE
Restore orphaned tiles

### DIFF
--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -251,11 +251,6 @@ export const DocumentContentModel = types
     }
   }))
   .actions(self => ({
-    afterCreate() {
-      self.rowMap.forEach(row => {
-        row.updateLayout(self.tileMap);
-      });
-    },
     insertRow(row: TileRowModelType, index?: number) {
       self.rowMap.put(row);
       if ((index != null) && (index < self.rowOrder.length)) {
@@ -318,6 +313,15 @@ export const DocumentContentModel = types
     }
   }))
   .actions(self => ({
+    afterCreate() {
+      self.rowMap.forEach(row => {
+        row.updateLayout(self.tileMap);
+      });
+      // fix any "collapsed" sections
+      for (let i = 1; i < self.rowCount; ++i) {
+        self.addPlaceholderRowIfAppropriate(i);
+      }
+    },
     addTileInNewRow(content: ToolContentUnionType, options?: INewTileOptions): INewRowTile {
       const tile = createToolTileModelFromContent(content);
       const o = options || {};

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -667,11 +667,16 @@ export const DocumentContentModel = types
           if (row?.tiles.length === rowTiles.length) {
             if ((rowDropLocation === "left") || (rowDropLocation === "right")) {
               // entire row is being merged with an existing row
-              self.mergeRow(row, rowInfo);
+              const dstRow = rowInfo.rowDropIndex ? self.getRowByIndex(rowInfo.rowDropIndex) : undefined;
+              if ((rowIndex !== rowInfo.rowDropIndex) && (dstRow && !dstRow.isSectionHeader)) {
+                self.mergeRow(row, rowInfo);
+              }
             }
             else {
               // entire row is being moved to a new row
-              self.moveRowToIndex(rowIndex, rowInsertIndex);
+              if ((rowInsertIndex < rowIndex) || (rowInsertIndex > rowIndex + 1)) {
+                self.moveRowToIndex(rowIndex, rowInsertIndex);
+              }
             }
           }
           else {


### PR DESCRIPTION
This PR identifies "orphaned" tiles, i.e. tiles that have had their row removed as a result of the `mergeRow()` bugs fixed in #595 . We decided not to include it with #595 on the assumption that students that encountered the problem would likely have moved on to create the tiles they need and would find it more confusing than helpful to have these old tiles reappear. The effect on published documents is potentially even more confusing. That said, there might be something worth returning to here, so I'm putting it in its own PR which will be closed for now but which will be preserved for posterity.