### PR TITLE
Refactor `AppHeaderComponent` to `ClueAppHeaderComponent`

### DIFF
--- a/src/clue/components/clue-app-content.tsx
+++ b/src/clue/components/clue-app-content.tsx
@@ -1,6 +1,7 @@
 import { inject, observer } from "mobx-react";
 import * as React from "react";
-import { AppHeaderComponent, EPanelId, IPanelGroupSpec } from "../../components/app-header";
+import { ClueAppHeaderComponent } from "./clue-app-header";
+import { EPanelId, IPanelGroupSpec } from "../../components/app-header";
 import { BaseComponent, IBaseProps } from "../../components/base";
 import { DocumentWorkspaceComponent } from "../../components/document/document-workspace";
 import { DialogComponent } from "../../components/utilities/dialog";
@@ -48,7 +49,7 @@ export class ClueAppContentComponent extends BaseComponent<IProps, {}> {
 
     return (
       <div className="clue-app-content">
-        <AppHeaderComponent isGhostUser={isGhostUser} panels={panels}
+        <ClueAppHeaderComponent isGhostUser={isGhostUser} panels={panels}
                             current={teacherPanelKey} onPanelChange={this.handlePanelChange}
                             showGroup={true} />
         {currentPanelContent}

--- a/src/clue/components/clue-app-header.sass
+++ b/src/clue/components/clue-app-header.sass
@@ -1,4 +1,4 @@
-@import ./vars
+@import ../../components/vars
 
 $member-size: 18px
 
@@ -126,7 +126,7 @@ $member-size: 18px
       .profile-icon-inner
         width: 30px
         height: 30px
-        mask-image: url("../assets/icons/clue-dashboard/teacher-student.svg")
+        mask-image: url("../../assets/icons/clue-dashboard/teacher-student.svg")
         background-color: $sage-light-2
 
     .user

--- a/src/clue/components/clue-app-header.tsx
+++ b/src/clue/components/clue-app-header.tsx
@@ -1,27 +1,15 @@
-import { Button, ButtonGroup } from "@blueprintjs/core";
 import { inject, observer } from "mobx-react";
 import * as React from "react";
-import { BaseComponent, IBaseProps } from "./base";
-import { ClassMenuContainer } from "./class-menu-container";
-import { ProblemMenuContainer } from "./problem-menu-container";
+import { EPanelId, IPanelGroupSpec } from "../../components/app-header";
+import { BaseComponent, IBaseProps } from "../../components/base";
+import { ClassMenuContainer } from "../../components/class-menu-container";
+import { ProblemMenuContainer } from "../../components/problem-menu-container";
 import { ToggleGroup, Themes } from "@concord-consortium/react-components";
-import { GroupModelType, GroupUserModelType } from "../models/stores/groups";
+import { GroupModelType, GroupUserModelType } from "../../models/stores/groups";
 
-import "./utilities/blueprint.sass";
-import "./app-header.sass";
+import "../../components/utilities/blueprint.sass";
+import "./clue-app-header.sass";
 const Colors = Themes.Default;
-
-export enum EPanelId {
-  dashboard = "dashboard",
-  workspace = "workspace"
-}
-
-export interface IPanelSpec {
-  panelId: EPanelId;
-  label: string;
-  content: JSX.Element;
-}
-export type IPanelGroupSpec = IPanelSpec[];
 
 interface IProps extends IBaseProps {
   isGhostUser: boolean;
@@ -33,7 +21,7 @@ interface IProps extends IBaseProps {
 
 @inject("stores")
 @observer
-export class AppHeaderComponent extends BaseComponent<IProps, {}> {
+export class ClueAppHeaderComponent extends BaseComponent<IProps, {}> {
 
   public render() {
     const { showGroup } = this.props;

--- a/src/components/app-header.ts
+++ b/src/components/app-header.ts
@@ -1,0 +1,12 @@
+export enum EPanelId {
+  controlPanel = "control-panels",
+  dashboard = "dashboard",
+  workspace = "workspace"
+}
+
+export interface IPanelSpec {
+  panelId: EPanelId;
+  label: string;
+  content: JSX.Element;
+}
+export type IPanelGroupSpec = IPanelSpec[];


### PR DESCRIPTION
This is the `master` side of the refactor done in the `dataflow` branch in #602.