### PR TITLE
168005513 offline sensor reporting

### DIFF
--- a/cypress/integration/dataflow/full/canvas_test_spec.js
+++ b/cypress/integration/dataflow/full/canvas_test_spec.js
@@ -58,7 +58,7 @@ context('canvas test',()=>{
             for(var i=0;i<=buttons.length-1;i++) {
                 dfcanvas.openBlock(buttons[i]);
                 dfblock.getBlock(buttons[i].toLowerCase().replace(' ','-')).should('exist');
-            }    
+            }
         })
     })
     describe('verify run program toolbar functionality', ()=>{
@@ -82,7 +82,7 @@ context('canvas test',()=>{
     })
     describe('deletion',()=>{
         describe('delete a block',()=>{
-            before(()=>{ 
+            before(()=>{
                 dfcanvas.createNewProgram('Delete Block Program'); //start with clean canvas
                 dfcanvas.openBlock('Number');
                 dfcanvas.openBlock('Relay')
@@ -132,7 +132,7 @@ context('canvas test',()=>{
             dfblock.getStorageSequenceTextField().type('{selectall}{backspace}'+seqName);
             cy.wait(3000) //wait to finish typing into element before reloading page
         })
-        it('verify program is restored when reopened',()=>{ 
+        it('verify program is restored when reopened',()=>{
             //get values before close
             const input1 = Cypress.$(dfblock.numberInputEl(0)).val()
             const input2 = Cypress.$(dfblock.numberInputEl(1)).val()

--- a/cypress/integration/dataflow/full/sensor_block_spec.js
+++ b/cypress/integration/dataflow/full/sensor_block_spec.js
@@ -25,7 +25,7 @@ before(()=>{
 
     cy.visit(baseUrl+queryParams);
     cy.wait(3000)
-    
+
     header.switchWorkspace('Workspace');
     cy.wait(1000);
     dfcanvas.openBlock('Sensor')
@@ -58,24 +58,25 @@ context('Sensor block tests',()=>{
                     }
                     else {
                         expect($option).to.contain(sensor.toLowerCase());
-                    } 
-                }) 
-            })       
+                    }
+                })
+            })
         })
         it('verify if there are more than one of the same type of sensor on one hub, plug info is shown',()=>{
             var sensorTypes=['Humidity','Temeprature'];
             var hub ='cc-west-office-hub'; //use cc-west-hub since it has two temp and two humidity
-
+            var plugIndex = 1;
             dfblock.selectSensorType(sensorTypes[0]);
             cy.wait(10000);
             dfblock.openHubSensorComboListDropdown();
             dfblock.getHubSensorComboOptionList().each(($option, index, $optionList)=>{
                 console.log($option.text()+' length: '+ $optionList.length)
                 if ($option.text().includes(hub)){ //cc-west-office-hub:humidity(plug 1),cc-west-office-hub:humidity(plug 1)
-                    console.log("hub name: "+hub+':'+(sensorTypes[0].toLowerCase())+'(plug '+(index+1)+')');
-                            expect($option).to.contain(hub+':'+sensorTypes[0].toLowerCase()+'(plug '+(index+1)+')');
+                    console.log("hub name: "+hub+':'+(sensorTypes[0].toLowerCase())+'(plug '+(plugIndex)+')');
+                    expect($option).to.contain(hub+':'+sensorTypes[0].toLowerCase()+'(plug '+(plugIndex)+')');
+                    plugIndex++;
                 }
-            }) 
+            })
         })
         it('verify sensor type matches units shown in text field',()=>{
             var sensorTypes=[
@@ -91,7 +92,7 @@ context('Sensor block tests',()=>{
             cy.wrap(sensorTypes).each((sensor, index, sensorList)=>{
                 dfblock.selectSensorType(sensor.type)
                 dfblock.getSensorValueTextField().should('contain',sensor.unit)
-            })       
+            })
         })
         it('verify sensor blocks outputs correctly',()=>{
             var sensor = "Humidity";

--- a/cypress/integration/dataflow/smoke/single_student_canvas_test.js
+++ b/cypress/integration/dataflow/smoke/single_student_canvas_test.js
@@ -97,13 +97,13 @@ context('single student functional test',()=>{
 
             })
             it('verify student name appears under thumbnail',()=>{
- 
+
             } )
             it('verify restore of published canvas', ()=>{
 
             })
         })
-    });    
+    });
 })
 after(function(){
     cy.clearQAData('all');

--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -476,16 +476,14 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
         const chInfo = this.channels.find(ci => ci.channelId === n.data.sensor);
         if (!chInfo && n.data.sensor !== "none") {
           if (typeof n.data.sensor === "string" && typeof n.data.type === "string") {
-            const missingDevice: MissingDevice = { id: n.data.sensor, type: n.data.type};
-            missingDevices.push(missingDevice);
+            missingDevices.push({ id: n.data.sensor, type: n.data.type});
           }
         }
       } else if (n.name === "Relay" && n.data.relayList) {
         const chInfo = this.channels.find(ci => ci.channelId === n.data.relayList);
         if (!chInfo && n.data.relayList !== "none") {
           if (typeof n.data.relayList === "string") {
-            const missingDevice: MissingDevice = { id: n.data.relayList, type: "relay"};
-            missingDevices.push(missingDevice);
+            missingDevices.push({ id: n.data.relayList, type: "relay"});
           }
         }
       }
@@ -497,7 +495,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
     if (!this.hasValidOutputNodes()) {
       return;
     }
-    const missingDevices: MissingDevice[] = this.hasValidInputNodes();
+    const missingDevices = this.hasValidInputNodes();
     if (missingDevices.length) {
       let message = "";
       missingDevices.forEach((md) => {
@@ -510,15 +508,15 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
       this.stores.ui.confirm(message, "Devices cannot be found")
       .then(ok => {
         if (ok) {
-          this.requestProgramName();
+          this.requestNameAndRunProgram();
         }
       });
     } else {
-      this.requestProgramName();
+      this.requestNameAndRunProgram();
     }
   }
 
-  private requestProgramName = () => {
+  private requestNameAndRunProgram = () => {
     const dialogPrompt = this.hasDataStorage()
                           ? "Save dataset as"
                           : "Save program as";

--- a/src/dataflow/components/nodes/controls/dropdown-list-control.sass
+++ b/src/dataflow/components/nodes/controls/dropdown-list-control.sass
@@ -31,6 +31,8 @@
       margin-bottom: 5px
       border-radius: 30px
       border: 1px solid #999
+      &.missing
+        background-color: pink
     &.selected
       &.sensor-type-option
         background-color: $sensor-blue-control

--- a/src/dataflow/components/nodes/controls/relay-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/relay-select-control.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { useRef } from "react";
 import Rete, { NodeEditor, Node } from "rete";
-import { NodeChannelInfo, kRelaySelectMessage } from "../../../utilities/node";
+import { NodeChannelInfo, kRelaySelectMessage, kRelayMissingMessage } from "../../../utilities/node";
 import { useStopEventPropagation } from "./custom-hooks";
 import "./sensor-select-control.sass";
 
@@ -52,7 +52,7 @@ export class RelaySelectControl extends Rete.Control {
       const getChannelString = (ch?: NodeChannelInfo | "none") => {
         if (!ch && (!id || id === "none")) return kRelaySelectMessage;
         if (ch === "none") return "None Available";
-        if (!ch) return "Finding " + id;
+        if (!ch) return `${kRelayMissingMessage} ${id}`;
         let count = 0;
         channelsForType.forEach( c => { if (c.type === ch.type && ch.hubId === c.hubId) count++; } );
         return `${ch.hubName}:${ch.type}${ch.plug > 0 && count > 1 ? `(plug ${ch.plug})` : ""}`;
@@ -65,7 +65,7 @@ export class RelaySelectControl extends Rete.Control {
       const titleClass = channelString.includes(kRelaySelectMessage)
                          ? "label unselected"
                          : "label";
-      const topItemClass = channelString.includes("Finding")
+      const topItemClass = channelString.includes(kRelayMissingMessage)
                          ? "item top missing"
                          : "item top";
       return (

--- a/src/dataflow/components/nodes/controls/relay-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/relay-select-control.tsx
@@ -52,20 +52,26 @@ export class RelaySelectControl extends Rete.Control {
       const getChannelString = (ch?: NodeChannelInfo | "none") => {
         if (!ch && (!id || id === "none")) return kRelaySelectMessage;
         if (ch === "none") return "None Available";
-        if (!ch) return "Searching for " + id;
+        if (!ch) return "Finding " + id;
         let count = 0;
         channelsForType.forEach( c => { if (c.type === ch.type && ch.hubId === c.hubId) count++; } );
         return `${ch.hubName}:${ch.type}${ch.plug > 0 && count > 1 ? `(plug ${ch.plug})` : ""}`;
       };
-      const titleClass = getChannelString(selectedChannel).includes(kRelaySelectMessage) ? "label unselected" : "label";
       const options: any = [...channelsForType];
       if (!options.length) {
         options.push("none");
       }
+      const channelString = getChannelString(selectedChannel);
+      const titleClass = channelString.includes(kRelaySelectMessage)
+                         ? "label unselected"
+                         : "label";
+      const topItemClass = channelString.includes("Finding")
+                         ? "item top missing"
+                         : "item top";
       return (
         <div className="node-select relay-select" ref={divRef}>
-          <div className="item top" onMouseDown={handleChange(onDropdownClick)}>
-            <div className={titleClass}>{getChannelString(selectedChannel)}</div>
+          <div className={topItemClass} onMouseDown={handleChange(onDropdownClick)}>
+            <div className={titleClass}>{channelString}</div>
             <svg className="icon dropdown-caret">
               <use xlinkHref="#icon-dropdown-caret"/>
             </svg>

--- a/src/dataflow/components/nodes/controls/sensor-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/sensor-select-control.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
 import { useRef } from "react";
 import Rete, { NodeEditor, Node } from "rete";
-import { NodeSensorTypes, NodeChannelInfo, kSensorSelectMessage } from "../../../utilities/node";
+import { NodeSensorTypes, NodeChannelInfo,
+         kSensorSelectMessage, kSensorMissingMessage } from "../../../utilities/node";
 import { useStopEventPropagation } from "./custom-hooks";
 import "./sensor-select-control.sass";
 import "./value-control.sass";
@@ -124,7 +125,7 @@ export class SensorSelectControl extends Rete.Control {
       const getChannelString = (ch?: NodeChannelInfo | "none") => {
         if (!ch && (!id || id === "none")) return kSensorSelectMessage;
         if (ch === "none") return "None Available";
-        if (!ch) return "Finding " + id;
+        if (!ch) return `${kSensorMissingMessage} ${id}`;
         let count = 0;
         channelsForType.forEach( c => { if (c.type === ch.type && ch.hubId === c.hubId) count++; } );
         return `${ch.hubName}:${ch.type}${ch.plug > 0 && count > 1 ? `(plug ${ch.plug})` : ""}`;
@@ -138,7 +139,7 @@ export class SensorSelectControl extends Rete.Control {
       const titleClass = channelString.includes(kSensorSelectMessage)
                          ? "label unselected"
                          : "label";
-      const topItemClass = channelString.includes("Finding")
+      const topItemClass = channelString.includes(kSensorMissingMessage)
                          ? "item top missing"
                          : "item top";
       return (

--- a/src/dataflow/components/nodes/controls/sensor-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/sensor-select-control.tsx
@@ -134,13 +134,17 @@ export class SensorSelectControl extends Rete.Control {
       if (!options.length) {
         options.push("none");
       }
-      const titleClass = getChannelString(selectedChannel).includes(kSensorSelectMessage)
+      const channelString = getChannelString(selectedChannel);
+      const titleClass = channelString.includes(kSensorSelectMessage)
                          ? "label unselected"
                          : "label";
+      const topItemClass = channelString.includes("Finding")
+                         ? "item top missing"
+                         : "item top";
       return (
         <div className="node-select sensor-select" ref={divRef}>
-          <div className="item top" onMouseDown={handleChange(onDropdownClick)}>
-            <div className={titleClass}>{getChannelString(selectedChannel)}</div>
+          <div className={topItemClass} onMouseDown={handleChange(onDropdownClick)}>
+            <div className={titleClass}>{channelString}</div>
             <div className="dropdown-caret-holder">
               <svg className="icon dropdown-caret">
                 <use xlinkHref="#icon-dropdown-caret"/>

--- a/src/dataflow/lib/iot.ts
+++ b/src/dataflow/lib/iot.ts
@@ -11,7 +11,7 @@ const AWS_IOT_ENDPOINT_HOST = "a2zxjwmcl3eyqd-ats.iot.us-east-1.amazonaws.com";
 const OWNER_ID = "123";
 const SEND_INTERVAL = 1;
 const MAX_HUBS = 200;
-const HUB_RESPONSE_TIME = 60 * 1000;
+const HUB_RESPONSE_TIMEOUT = 60 * 1000;
 
 type RelayValue = 0 | 1;
 
@@ -85,7 +85,7 @@ export class IoT {
     const  { hubStore } = this.stores;
     // check for hubs that have not responded recently
     hubStore.hubs.forEach(hub => {
-      if ((Date.now() - hub.hubUpdateTime) > HUB_RESPONSE_TIME && hub.hubChannels.length) {
+      if ((Date.now() - hub.hubUpdateTime) > HUB_RESPONSE_TIMEOUT && hub.hubChannels.length) {
         hub.removeAllHubChannels();
         this.requestHubChannelInfo(hub.hubId);
       }

--- a/src/dataflow/lib/iot.ts
+++ b/src/dataflow/lib/iot.ts
@@ -11,6 +11,7 @@ const AWS_IOT_ENDPOINT_HOST = "a2zxjwmcl3eyqd-ats.iot.us-east-1.amazonaws.com";
 const OWNER_ID = "123";
 const SEND_INTERVAL = 1;
 const MAX_HUBS = 200;
+const HUB_RESPONSE_TIME = 60 * 1000;
 
 type RelayValue = 0 | 1;
 
@@ -82,6 +83,14 @@ export class IoT {
 
   private updateHubs = () => {
     const  { hubStore } = this.stores;
+    // check for hubs that have not responded recently
+    hubStore.hubs.forEach(hub => {
+      if ((Date.now() - hub.hubUpdateTime) > HUB_RESPONSE_TIME && hub.hubChannels.length) {
+        hub.removeAllHubChannels();
+        this.requestHubChannelInfo(hub.hubId);
+      }
+    });
+
     const requestParams: AWS.Iot.ListThingsRequest = { maxResults: MAX_HUBS };
     this.iotCore.listThings(requestParams).promise().then(data => {
       if (data && data.things) {
@@ -153,6 +162,7 @@ export class IoT {
     const  { hubStore } = this.stores;
     const hub = hubStore.getHubById(hubId);
     if (hub) {
+      hub.setHubUpdateTime(Date.now());
       const devices = Object.values(message);
       const deviceKeys = Object.keys(message);
       let rids: string[] = [];
@@ -203,12 +213,35 @@ export class IoT {
     const  { hubStore } = this.stores;
     const hub = hubStore.getHubById(hubId);
     const time = message.time ? parseFloat(message.time) * 1000 : Date.now();
+    let hubStoreSensors = 0;
     if (hub) {
+      hub.setHubUpdateTime(Date.now());
+      let messageChannels = 0;
+      let unmatchedChannel = false;
       for (const key in message) {
         if (message.hasOwnProperty(key) && key !== "time") {
-          hub.setHubChannelValue(key, String(message[key]));
-          hub.setHubChannelTime(key, time);
+          messageChannels++;
+          if (hub.getHubChannel(key)) {
+            hub.setHubChannelValue(key, String(message[key]));
+            hub.setHubChannelTime(key, time);
+          } else {
+            unmatchedChannel = true;
+          }
         }
+      }
+
+      // WTD simulator doesn't currently return relay value in sensors message
+      // until fixed, need to handle both the hub and hub sim cases
+      hub.hubChannels.forEach(ch => {
+        if (ch.type !== "relay") {
+          hubStoreSensors++;
+        }
+      });
+
+      // WTD change to below once we fix the simulator so that it returns relay value with sensors message
+      // if (messageChannels !== hub.hubChannels.length || unmatchedChannel) {
+      if ((messageChannels !== hub.hubChannels.length && messageChannels !== hubStoreSensors) || unmatchedChannel) {
+        this.requestHubChannelInfo(hub.hubId);
       }
     }
   }

--- a/src/dataflow/utilities/node.ts
+++ b/src/dataflow/utilities/node.ts
@@ -331,3 +331,5 @@ export const IntervalTimes: IntervalTime[] = [
 
 export const kRelaySelectMessage = "Select a relay";
 export const kSensorSelectMessage = "Select a sensor";
+export const kRelayMissingMessage = "Finding";
+export const kSensorMissingMessage = "Finding";


### PR DESCRIPTION
Improve handling of offline hubs, sensors, and relays so that we keep better track of offline hardware and properly inform user when hardware is offline.  Changes include the following:
- Vet program for missing sensors and relays before running.  If a sensor or relay cannot be found, notify the user of the missing device and give user the option to cancel or go ahead with program run.
- Unify and improve state of relay and sensor editor nodes when a currently selected device is unavailable.  Unify message on nodes and use selected device text box colored background to indicate to user that a device is unavailable.
- Keep track of the timestamp of the last known hub communication (communication occurs when we receive a devices or a sensors MQTT message).  If a hub does not communicate for 60 seconds, assume that the hub is offline and remove its connected devices from the hub store and re-request the devices message from the hub.
- If there is a mismatch between the current hub store devices and the list of devices in the sensors message, re-request the devices message from the hub (contains additional logic to handle simulator which currently does not send relay status in sensors message).
- fix Cypress tests that assumed wrong plug number.
