### PR TITLE
Update UI of nodes to match spec

### DIFF
--- a/cypress/integration/dataflow/full/logic_block_spec.js
+++ b/cypress/integration/dataflow/full/logic_block_spec.js
@@ -16,7 +16,7 @@ before(()=>{
 
     cy.visit(baseUrl+queryParams);
     cy.wait(3000)
-    
+
     header.switchWorkspace('Workspace');
     cy.wait(1000);
     dfcanvas.openBlock('Number')
@@ -40,9 +40,9 @@ context('Logic block test',()=>{
         })
         it('verify correct equation when only one node is connected',()=>{
             dfblock.getNumberInput(0).type('{backspace}'+input1+'{enter}');
-            dfblock.getLogicValueTextField().should('contain', input1+' > ___ ⇒ 0')//0 > ___ ⇒ 0
+            dfblock.getLogicValueTextField().should('contain', input1+' > __ ⇒ 0')//0 > ___ ⇒ 0
         })
-        it('verify greater than',()=>{ 
+        it('verify greater than',()=>{
             dfblock.connectBlocks('number',1,testBlock,1)
             // dfblock.getLogicValueTextField().should('contain', input1+' > 0 ⇒ '+((input1>0)?1:0))//0 > 0 ⇒ 0
             dfblock.getNumberInput(1).type('{backspace}'+input2+'{enter}');

--- a/cypress/integration/dataflow/full/math_block_spec.js
+++ b/cypress/integration/dataflow/full/math_block_spec.js
@@ -16,7 +16,7 @@ before(()=>{
 
     cy.visit(baseUrl+queryParams);
     cy.wait(3000)
-    
+
     header.switchWorkspace('Workspace');
     cy.wait(1000);
     dfcanvas.openBlock('Number')
@@ -41,7 +41,7 @@ context('Math block test',()=>{
         before(()=>{
             dfblock.getNumberInput(0).type('{backspace}'+input1+'{enter}');
             dfblock.getNumberInput(1).type('{backspace}'+input2+'{enter}');
-            dfcanvas.scrollToTopOfTile();            
+            dfcanvas.scrollToTopOfTile();
             dfcanvas.openBlock('Transform')
             dfblock.connectBlocks(testBlock,0,'transform',0)
         })
@@ -79,7 +79,7 @@ context('Math block test',()=>{
         it('verify output is correct',()=>{
             dfblock.getTransformValueTextField().should('contain','|'+(input3/input2)+'| = '+Math.abs(input3/input2))
         })
-    })    
+    })
 
     describe('Divide by 0',()=>{//divide by 0 outputs infinity, and 0/0 outputs NaN
             var inf='Infinity', input_0=0;
@@ -94,13 +94,13 @@ context('Math block test',()=>{
             dfblock.getTransformValueTextField().should('contain','|'+(input_0)+'| = '+input_0)
         })
     })
-    describe('test when only one node is connected',()=>{ 
+    describe('test when only one node is connected',()=>{
         before(()=>{
             dfblock.deleteBlock('number',1) //lose one of the inputs
             dfblock.getNumberInput(0).type('{backspace}'+input3+'{enter}')
         })
         it('verify block shows correct equation',()=>{ //3 / ___ = 0
-            dfblock.getMathValueTextField().should('contain',input3+' / ___ = 0')
+            dfblock.getMathValueTextField().should('contain',input3+' / __ = 0')
         })
         it('verify block outputs correct value',()=>{
             dfblock.getTransformValueTextField().should('contain','|0| = 0')

--- a/src/dataflow/components/dataflow-program.sass
+++ b/src/dataflow/components/dataflow-program.sass
@@ -7,7 +7,6 @@ $dataflow-topbar-height: 40px
   font-weight: 400
 
   svg
-    position: absolute
     z-index: -1
 
 // Connections are offset without this for some reason

--- a/src/dataflow/components/nodes/controls/dropdown-list-control.sass
+++ b/src/dataflow/components/nodes/controls/dropdown-list-control.sass
@@ -1,36 +1,36 @@
 
 @import ../../../vars
 
-
 .node-select-container
   display: flex
   line-height: 24px
+  margin-top: 3px
+  margin-bottom: 3px
 
   .node-select-label
     color: white
     margin-right: 5px
 
 .node-select
-  color: black
-  // color: #2DA343
   width: 140px
   height: 24px
-  box-sizing: border-box
   &.sensor-type, &.generatorType
-    // color: #0592AF
-    margin-bottom: 6px
+    margin-bottom: 3px
+    margin-top: 3px
+    font-size: 14px
+    .label
+      margin-left: 2px
 
   .item
     display: flex
     align-items: center
-    height: 24px
+    height: 26px
+    box-sizing: border-box
     background-color: white
     padding: 0 0 0 4px
     &.top
       padding: 0 6px 0 6px
-      margin-bottom: 5px
-      border-radius: 30px
-      border: 1px solid #999
+      border-radius: 3px
       &.missing
         background-color: pink
     &.selected
@@ -85,8 +85,8 @@
     .icon
       position: static
       z-index: 0
-      width: 14px
-      height: 14px
+      width: 16px
+      height: 16px
       margin: 0 4px 0 0
       &.top
         margin: 0 2px 0 0
@@ -100,13 +100,15 @@
     position: relative
     z-index: 2
     left: 0
-    top: -6px
-    border: 1px solid #1E90FF
+    top: 0
+    border: 1px solid $gray-text
     background-color: white
     &.logicOperator
       width: 160px
 
   &.sensor-select
+    margin-bottom: 3px
+    margin-top: 3px
     .option-list
       width: 212px
       text-align: left
@@ -146,3 +148,5 @@
   .label
     &.unselected
       font-style: italic
+      font-size: 11px
+      margin-left: 0px

--- a/src/dataflow/components/nodes/controls/num-control.sass
+++ b/src/dataflow/components/nodes/controls/num-control.sass
@@ -3,6 +3,9 @@
   flex-direction: row
   color: white
   line-height: 24px
+  margin-top: 3px
+  margin-bottom: 3px
+  text-align-last: right
 
   .number-label
     color: white

--- a/src/dataflow/components/nodes/controls/plot-button-control.sass
+++ b/src/dataflow/components/nodes/controls/plot-button-control.sass
@@ -1,20 +1,22 @@
 .node-graph-container
   display: flex
-  flex-direction: column
+  justify-content: center
+  align-items: center
+  flex-direction: row
   color: white
 
   .graph-button
-    position: relative
-    width: 34px
-    height: 24px
-    background-color: white
-    border-radius: 3px
-    border: 2px solid #FFF9
+    display: flex
+    justify-content: center
+    align-items: center
+    flex-direction: row
+    padding: 3px
     box-sizing: border-box
+    border-radius: 1px
+    border: 2px solid white
+    background-color: white
 
     svg
-      width: 24px
-      height: 24px
-      left: 3px
-      top: -1px
+      width: 14px
+      height: 14px
       z-index: 1

--- a/src/dataflow/components/nodes/controls/plot-button-control.tsx
+++ b/src/dataflow/components/nodes/controls/plot-button-control.tsx
@@ -46,6 +46,7 @@ export class PlotButtonControl extends Rete.Control {
     const show = !this.props.showgraph;
     this.props.showgraph = show;
     this.putData(this.key, show);
+    (this as any).update();
     this.node.update();
   }
 

--- a/src/dataflow/components/nodes/controls/sensor-value-control.sass
+++ b/src/dataflow/components/nodes/controls/sensor-value-control.sass
@@ -1,13 +1,19 @@
+@import ../../../vars
+
 .sensor-value
   display: flex
 
   .value-container
     width: 63px
-    border-radius: 3px 0 0 3px
+    font-size: 18px
 
   .units-container
-    width: 37px
+    width: 44px
     height: 24px
     line-height: 24px
-    background-color: #c6d6f6
-    border-radius: 0 12px 12px 0
+    font-size: 18px
+    background-color: $sensor-blue-outline
+    border-radius: 0 8px 8px 0
+    border-left: 1px solid white
+    &.small
+      font-size: 12px

--- a/src/dataflow/components/nodes/controls/sensor-value-control.sass
+++ b/src/dataflow/components/nodes/controls/sensor-value-control.sass
@@ -13,7 +13,7 @@
     line-height: 24px
     font-size: 18px
     background-color: $sensor-blue-outline
-    border-radius: 0 8px 8px 0
+    border-radius: 0 13px 13px 0
     border-left: 1px solid white
     &.small
       font-size: 12px

--- a/src/dataflow/components/nodes/controls/sensor-value-control.tsx
+++ b/src/dataflow/components/nodes/controls/sensor-value-control.tsx
@@ -29,7 +29,7 @@ export class SensorValueControl extends Rete.Control {
         <div className="value-container">
           {compProps.value}
         </div>
-        <div className="units-container">
+        <div className={`units-container ${compProps.units.length > 4 ? "small" : ""}`}>
           {compProps.units}
         </div>
       </div>

--- a/src/dataflow/components/nodes/controls/text-control.sass
+++ b/src/dataflow/components/nodes/controls/text-control.sass
@@ -3,6 +3,8 @@
   flex-direction: row
   color: white
   line-height: 24px
+  margin-top: 3px
+  margin-bottom: 3px
 
   .text-label
     color: white

--- a/src/dataflow/components/nodes/controls/value-control.sass
+++ b/src/dataflow/components/nodes/controls/value-control.sass
@@ -1,12 +1,13 @@
 .value-container
-  color: black
-  background-color: white
-  font-size: 11px
+  font-size: 18px
   text-align: right
   border-radius: 3px
-  padding: 1px 10px 1px 1px
-  width: 100px
+  padding: 1px 5px 1px 1px
+  width: 106px
   height: 24px
-  line-height: 24px
   vertical-align: middle
   box-sizing: border-box
+  &.math, &.logic, &.transform
+    font-size: 16px
+    &.small
+      font-size: 12px

--- a/src/dataflow/components/nodes/controls/value-control.tsx
+++ b/src/dataflow/components/nodes/controls/value-control.tsx
@@ -14,8 +14,11 @@ export class ValueControl extends Rete.Control {
     this.emitter = emitter;
     this.key = key;
 
-    this.component = (compProps: { value: number; sentence: string }) => (
-      <div className="value-container">
+    this.component = (compProps: { value: number; sentence: string, class: string }) => (
+      <div className={`value-container
+                       ${compProps.class.toLowerCase().replace(/ /g, "-")}
+                       ${compProps.sentence.length > 12 ? "small" : ""}
+                       `}>
         {compProps.sentence ? compProps.sentence : roundNodeValue(compProps.value)}
       </div>
     );
@@ -25,7 +28,8 @@ export class ValueControl extends Rete.Control {
 
     this.props = {
       value: initial,
-      sentence: ""
+      sentence: "",
+      class: node.name,
     };
   }
 

--- a/src/dataflow/components/nodes/dataflow-node.sass
+++ b/src/dataflow/components/nodes/dataflow-node.sass
@@ -227,7 +227,7 @@ $node-inner-width: 140px
           height: 30px
           box-sizing: border-box
           border: solid 2px white
-           &.sensor, &.number
+          &.sensor, &.number
             background-color: $sensor-blue-readout
           &.generator
             background-color: $generator-blue-readout

--- a/src/dataflow/components/nodes/dataflow-node.sass
+++ b/src/dataflow/components/nodes/dataflow-node.sass
@@ -11,86 +11,113 @@ $node-inner-width: 140px
     align-items: center
     width: $node-width
     min-width: $node-width
-    padding-bottom: 8px
+    padding-bottom: 16px
     border-radius: 5px
     font-size: 11px
+    box-sizing: border-box
+    color: $gray-text
 
     &.sensor
       background-color: $sensor-blue
       border-color: $sensor-blue-outline
       .main-color
         color: $sensor-blue
+        border: 2px solid $sensor-blue
       .control-color
         color: $sensor-blue-control
       .control-color-hoverable:hover
         color: $sensor-blue-node
+      .active
+        background-color: $sensor-blue-control
     &.number
       background-color: $number-blue
       border-color: $number-blue-outline
       .main-color
         color: $number-blue
+        border: 2px solid $number-blue
       .control-color
         color: $number-blue-control
       .control-color-hoverable:hover
         color: $number-blue-node
+      .active
+        background-color: $number-blue-control
     &.generator
       background-color: $generator-blue
       border-color: $generator-blue-outline
       .main-color
         color: $generator-blue
+        border: 2px solid $generator-blue
       .control-color
         color: $generator-blue-control
       .control-color-hoverable:hover
         color: $generator-blue-node
+      .active
+        background-color: $generator-blue-control
     &.math
       background-color: $math-green
       border-color: $math-green-outline
       .main-color
         color: $math-green
+        border: 2px solid $math-green
       .control-color
         color: $math-green-control
       .control-color-hoverable:hover
         color: $math-green-node
+      .active
+        background-color: $math-green-control
     &.logic
       background-color: $logic-green
       border-color: $logic-green-outline
       .main-color
         color: $logic-green
+        border: 2px solid $logic-green
       .control-color
         color: $logic-green-control
       .control-color-hoverable:hover
         color: $logic-green-node
+      .active
+        background-color: $logic-green-control
     &.transform
       background-color: $transform-green
       border-color: $transform-green-outline
       .main-color
         color: $transform-green
+        border: 2px solid $transform-green
       .control-color
         color: $transform-green-control
       .control-color-hoverable:hover
         color: $transform-green-node
+      .active
+        background-color: $transform-green-control
     &.relay
       background-color: $relay-orange
       border-color: $relay-orange-outline
       .main-color
         color: $relay-orange
+        border: 2px solid $relay-orange
       .control-color
         color: $relay-orange-control
       .control-color-hoverable:hover
         color: $relay-orange-node
+      .active
+        background-color: $relay-orange-control
     &.data-storage
       background-color: $data-storage-orange
       border-color: $data-storage-orange-outline
       .main-color
         color: $data-storage-orange
+        border: 2px solid $data-storage-orange
       .control-color
         color: $data-storage-orange-control
       .control-color-hoverable:hover
         color: $data-storage-orange-node
+      .active
+        background-color: $data-storage-orange-control
 
     .top-bar
       display: flex
       width: $node-inner-width
+      height: 21px
       padding: 4px 0 2px 0
 
       .node-title
@@ -101,10 +128,10 @@ $node-inner-width: 140px
 
       .close-node-button
         position: absolute
-        right: 5px
-        top: 3px
-        width: 12px
-        height: 12px
+        right: 4px
+        top: 1px
+        width: 8px
+        height: 8px
         svg
           width: 8px
           height: 8px
@@ -116,17 +143,17 @@ $node-inner-width: 140px
       height: 20px
 
     .control
-      padding: 3px
+      padding: 0px
       max-width: $node-inner-width
 
     select, input
       font-family: 'Ubuntu', sans-serif
       font-weight: 400
-      font-size: 11px
+      font-size: 14px
       border-radius: 30px
       background-color: white
       padding: 2px 6px
-      border: 1px solid #999
+      border: 0px solid #999
       &.sensor
         color: #0592AF
 
@@ -171,6 +198,36 @@ $node-inner-width: 140px
         display: flex
         justify-content: space-evenly
         min-width: 151px
+
+        .output-container
+          margin: 0 3px 0 10px
+          padding: 3px
+          display: flex
+          justify-content: center
+          align-items: center
+          background-color: white
+          border-radius: 3px 12px 12px 3px
+          width: 140px
+          height: 30px
+          box-sizing: border-box
+          border: solid 2px white
+          &.sensor
+            background-color: $sensor-blue-readout
+          &.number
+            background-color: $sensor-blue-readout
+          &.generator
+            background-color: $generator-blue-readout
+          &.math
+            background-color: $math-green-readout
+          &.logic
+            background-color: $logic-green-readout
+          &.transform
+            background-color: $transform-green-readout
+          &.relay
+            background-color: $relay-orange-readout
+            margin-left: 0px
+          &.data-storage
+            display: none
 
     .decorated-inputs
       width: $node-width

--- a/src/dataflow/components/nodes/dataflow-node.sass
+++ b/src/dataflow/components/nodes/dataflow-node.sass
@@ -23,6 +23,8 @@ $node-inner-width: 140px
       .main-color
         color: $sensor-blue
         border: 2px solid $sensor-blue
+        &:hover
+          background-color: $sensor-blue-outline
       .control-color
         color: $sensor-blue-control
       .control-color-hoverable:hover
@@ -35,6 +37,8 @@ $node-inner-width: 140px
       .main-color
         color: $number-blue
         border: 2px solid $number-blue
+        &:hover
+          background-color: $number-blue-outline
       .control-color
         color: $number-blue-control
       .control-color-hoverable:hover
@@ -47,6 +51,8 @@ $node-inner-width: 140px
       .main-color
         color: $generator-blue
         border: 2px solid $generator-blue
+        &:hover
+          background-color: $generator-blue-outline
       .control-color
         color: $generator-blue-control
       .control-color-hoverable:hover
@@ -59,6 +65,8 @@ $node-inner-width: 140px
       .main-color
         color: $math-green
         border: 2px solid $math-green
+        &:hover
+          background-color: $math-green-outline
       .control-color
         color: $math-green-control
       .control-color-hoverable:hover
@@ -71,6 +79,8 @@ $node-inner-width: 140px
       .main-color
         color: $logic-green
         border: 2px solid $logic-green
+        &:hover
+          background-color: $logic-green-outline
       .control-color
         color: $logic-green-control
       .control-color-hoverable:hover
@@ -83,6 +93,8 @@ $node-inner-width: 140px
       .main-color
         color: $transform-green
         border: 2px solid $transform-green
+        &:hover
+          background-color: $transform-green-outline
       .control-color
         color: $transform-green-control
       .control-color-hoverable:hover
@@ -95,6 +107,8 @@ $node-inner-width: 140px
       .main-color
         color: $relay-orange
         border: 2px solid $relay-orange
+        &:hover
+          background-color: $relay-orange-outline
       .control-color
         color: $relay-orange-control
       .control-color-hoverable:hover
@@ -107,6 +121,8 @@ $node-inner-width: 140px
       .main-color
         color: $data-storage-orange
         border: 2px solid $data-storage-orange
+        &:hover
+          background-color: $data-storage-orange-outline
       .control-color
         color: $data-storage-orange-control
       .control-color-hoverable:hover
@@ -206,7 +222,7 @@ $node-inner-width: 140px
           justify-content: center
           align-items: center
           background-color: white
-          border-radius: 3px 12px 12px 3px
+          border-radius: 3px 15px 15px 3px
           width: 140px
           height: 30px
           box-sizing: border-box

--- a/src/dataflow/components/nodes/dataflow-node.sass
+++ b/src/dataflow/components/nodes/dataflow-node.sass
@@ -227,9 +227,7 @@ $node-inner-width: 140px
           height: 30px
           box-sizing: border-box
           border: solid 2px white
-          &.sensor
-            background-color: $sensor-blue-readout
-          &.number
+           &.sensor, &.number
             background-color: $sensor-blue-readout
           &.generator
             background-color: $generator-blue-readout

--- a/src/dataflow/components/nodes/dataflow-node.tsx
+++ b/src/dataflow/components/nodes/dataflow-node.tsx
@@ -60,14 +60,16 @@ export class DataflowNode extends Node {
             ))}
           </div>
           <div className="output-controls">
-            {outputControls.map((control: any) => (
-              <Control
-                className="control"
-                key={control.key}
-                control={control}
-                innerRef={bindControl}
-              />
-            ))}
+            <div className={`output-container ${node.name.toLowerCase().replace(/ /g, "-")}`}>
+              {outputControls.map((control: any) => (
+                <Control
+                  className="control"
+                  key={control.key}
+                  control={control}
+                  innerRef={bindControl}
+                />
+              ))}
+            </div>
           </div>
           <div className="outputs">
             {outputs.map((output: any) => (

--- a/src/dataflow/components/nodes/factories/data-storage-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/data-storage-rete-node-factory.tsx
@@ -21,11 +21,11 @@ export class DataStorageReteNodeFactory extends DataflowReteNodeFactory {
     super.defaultBuilder(node);
     if (this.editor) {
       this.inputCount = 1;
-      node.addControl(new TextControl(this.editor, "datasetName", node, "name", "my-dataset"));
+      node.addControl(new TextControl(this.editor, "datasetName", node, "Name", "my-dataset"));
       const intervalTimeOptions = IntervalTimes.map(option => ({
         name: option.text, val: option.val
       }));
-      node.addControl(new DropdownListControl(this.editor, "interval", node, intervalTimeOptions, true, "interval"));
+      node.addControl(new DropdownListControl(this.editor, "interval", node, intervalTimeOptions, true, "Interval"));
       if (node.data.inputKeys) {
         const keys: any = node.data.inputKeys;
         keys.forEach((key: string) => {

--- a/src/dataflow/components/nodes/factories/generator-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/generator-rete-node-factory.tsx
@@ -27,8 +27,8 @@ export class GeneratorReteNodeFactory extends DataflowReteNodeFactory {
         .addControl(new DropdownListControl(this.editor, "generatorType", node, dropdownOptions, true))
         .addControl(new NumControl(this.editor, "amplitude", node, false, "Amplitude", 1, .01))
         .addControl(new NumControl(this.editor, "period", node, false, "Period", 10, 1))
-        .addControl(new ValueControl(this.editor, "nodeValue", node))
         .addControl(new PlotButtonControl(this.editor, "plot", node))
+        .addControl(new ValueControl(this.editor, "nodeValue", node))
         .addOutput(out) as any;
     }
   }

--- a/src/dataflow/components/nodes/factories/logic-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/logic-rete-node-factory.tsx
@@ -29,8 +29,8 @@ export class LogicReteNodeFactory extends DataflowReteNodeFactory {
         .addInput(inp1)
         .addInput(inp2)
         .addControl(new DropdownListControl(this.editor, "logicOperator", node, dropdownOptions, true))
-        .addControl(new ValueControl(this.editor, "nodeValue", node))
         .addControl(new PlotButtonControl(this.editor, "plot", node))
+        .addControl(new ValueControl(this.editor, "nodeValue", node))
         .addOutput(out) as any;
     }
   }
@@ -50,8 +50,8 @@ export class LogicReteNodeFactory extends DataflowReteNodeFactory {
         result = 0;
       }
 
-      const n1Str = n1 === undefined ? "___" : "" + n1;
-      const n2Str = n2 === undefined ? "___" : "" + n2;
+      const n1Str = n1 === undefined ? "__" : "" + n1;
+      const n2Str = n2 === undefined ? "__" : "" + n2;
       resultSentence = nodeOperationTypes.numberSentence(n1Str, n2Str) + result;
     }
 

--- a/src/dataflow/components/nodes/factories/math-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/math-rete-node-factory.tsx
@@ -29,8 +29,8 @@ export class MathReteNodeFactory extends DataflowReteNodeFactory {
         .addInput(inp1)
         .addInput(inp2)
         .addControl(new DropdownListControl(this.editor, "mathOperator", node, dropdownOptions, true))
-        .addControl(new ValueControl(this.editor, "nodeValue", node))
         .addControl(new PlotButtonControl(this.editor, "plot", node))
+        .addControl(new ValueControl(this.editor, "nodeValue", node))
         .addOutput(out) as any;
     }
   }
@@ -50,8 +50,8 @@ export class MathReteNodeFactory extends DataflowReteNodeFactory {
         result = 0;
       }
 
-      const n1Str = n1 === undefined ? "___" : "" + n1;
-      const n2Str = n2 === undefined ? "___" : "" + n2;
+      const n1Str = n1 === undefined ? "__" : "" + n1;
+      const n2Str = n2 === undefined ? "__" : "" + n2;
       resultSentence = nodeOperationTypes.numberSentence(n1Str, n2Str) + roundNodeValue(result);
     }
 

--- a/src/dataflow/components/nodes/factories/number-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/number-rete-node-factory.tsx
@@ -16,7 +16,7 @@ export class NumberReteNodeFactory extends DataflowReteNodeFactory {
       const out1 = new Rete.Output("num", "Number", this.numSocket);
       const ctrl = new NumControl(this.editor, "nodeValue", node);
       const plot = new PlotButtonControl(this.editor, "plot", node);
-      return node.addControl(ctrl).addControl(plot).addOutput(out1) as any;
+      return node.addControl(plot).addControl(ctrl).addOutput(out1) as any;
     }
   }
 

--- a/src/dataflow/components/nodes/factories/relay-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/relay-rete-node-factory.tsx
@@ -19,8 +19,8 @@ export class RelayReteNodeFactory extends DataflowReteNodeFactory {
 
       return node
         .addControl(new RelaySelectControl(this.editor, "relayList", node, true))
-        .addControl(new ValueControl(this.editor, "nodeValue", node))
         .addControl(new PlotButtonControl(this.editor, "plot", node))
+        .addControl(new ValueControl(this.editor, "nodeValue", node))
         .addInput(inp1) as any;
     }
   }

--- a/src/dataflow/components/nodes/factories/sensor-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/sensor-rete-node-factory.tsx
@@ -17,8 +17,8 @@ export class SensorReteNodeFactory extends DataflowReteNodeFactory {
       const out1 = new Rete.Output("num", "Number", this.numSocket);
       return node
         .addControl(new SensorSelectControl(this.editor, "sensorSelect", node, true))
-        .addControl(new SensorValueControl(this.editor, "nodeValue", node, true))
         .addControl(new PlotButtonControl(this.editor, "plot", node))
+        .addControl(new SensorValueControl(this.editor, "nodeValue", node, true))
         .addOutput(out1) as any;
     }
   }

--- a/src/dataflow/components/nodes/factories/transform-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/transform-rete-node-factory.tsx
@@ -29,8 +29,8 @@ export class TransformReteNodeFactory extends DataflowReteNodeFactory {
       return node
         .addInput(inp1)
         .addControl(new DropdownListControl(this.editor, "transformOperator", node, dropdownOptions, true))
-        .addControl(new ValueControl(this.editor, "nodeValue", node))
         .addControl(new PlotButtonControl(this.editor, "plot", node))
+        .addControl(new ValueControl(this.editor, "nodeValue", node))
         .addOutput(out) as any;
       }
   }
@@ -49,7 +49,7 @@ export class TransformReteNodeFactory extends DataflowReteNodeFactory {
         result = 0;
       }
 
-      const n1Str = n1 === undefined ? "___" : "" + n1;
+      const n1Str = n1 === undefined ? "__" : "" + n1;
       resultSentence = nodeOperationTypes.numberSentence(n1Str, "") + result;
    }
 

--- a/src/dataflow/vars.sass
+++ b/src/dataflow/vars.sass
@@ -15,6 +15,7 @@ $sensor-blue: #1c5bdc
 $sensor-blue-node: #5584e5
 $sensor-blue-control: #8daded
 $sensor-blue-outline: #c6d6f6
+$sensor-blue-readout: #e2eafa
 $number-blue: #0084de
 $number-blue-node: #40a3e7
 $number-blue-control: #7fc1ee
@@ -23,24 +24,29 @@ $generator-blue: #2fa7ec
 $generator-blue-node: #63bdf1
 $generator-blue-control: #97d3f5
 $generator-blue-outline: #cbe9fa
+$generator-blue-readout: #e5f4fc
 
 $math-green: #218e35
 $math-green-node: #59ab68
 $math-green-control: #90c69a
 $math-green-outline: #c7e3cc
+$math-green-readout: #e3f1e5
 $logic-green: #40ae0d
 $logic-green-node: #70c34a
 $logic-green-control: #9fd686
 $logic-green-outline: #cfebc2
+$logic-green-readout: #e7f5e0
 $transform-green: #8abf00
 $transform-green-node: #a8cf40
 $transform-green-control: #c4df7f
 $transform-green-outline: #e2efbf
+$transform-green-readout: #f0f7df
 
 $relay-orange: #ed6a08
 $relay-orange-node: #f29046
 $relay-orange-control: #f6b483
 $relay-orange-outline: #fadac1
+$relay-orange-readout: #fcece0
 $data-storage-orange: #f99809
 $data-storage-orange-node: #fbb247
 $data-storage-orange-control: #fccb84

--- a/src/index.html
+++ b/src/index.html
@@ -381,13 +381,10 @@
         <title>noise generator</title>
         <polygon id="random" points="4.37 13.89 0.18 6.83 1.92 6.83 4.03 10.38 6.85 2.37 10.02 8.18 11.64 6.83 13.99 6.83 9.58 10.49 7.15 6.03 4.37 13.89"/>
       </symbol>
-      <symbol id="icon-preview-plot" viewBox="0 0 24 12">
+      <symbol id="icon-preview-plot" viewBox="0 0 14 14">
         <title>preview plot</title>
-        <g>
-          <polygon id="axes" points="1.5 10.5 1.5 0 0 0 0 12 24 12 24 10.5 1.5 10.5"/>
-          <path d="M24,4.63c-3,1.55-5.57.38-8.52-1C11.93,2,7.94.2,3,3.87V5.79C7.67,1.72,
-          11.17,3.32,14.86,5a15.18,15.18,0,0,0,6.23,1.86A7.6,7.6,0,0,0,24,6.28Z"/>
-        </g>
+        <polygon id="axes" points="1.5 12.5 1.5 0 0 0 0 14 14 14 14 12.5 1.5 12.5"/>
+        <path id="plot" d="M14,10.25c-3.49,0-4.81-1.92-6-3.62C7,5.09,6,3.75,3.5,3.75V2.25c3.33,0,4.62,1.88,5.76,3.53s2,3,4.74,3Z"/>
       </symbol>
       <symbol id="icon-delete-node" viewBox="0 0 8 8">
         <title>delete node</title>


### PR DESCRIPTION
This PR is primarily made up of CSS changes to update the Dataflow editor nodes to match the current UI spec.  The primary request was updating the portion of each node that displays its current value.  However, the node styling had drifted from the spec in several ways (or certain UI spec requests were never implemented) so a general styling pass was done here.  

The following changes are included:
-restructure order of components in node value output, move values closer to connection pins, move plot button to left
-add coloring to node value output
-update node fonts sizes and colors to match spec
-update node borders, padding, and margins to match spec
-improve handling of text overflow in nodes
-unify text case in text fields of each node
-update icon sizes to match spec
-update plot icon to latest icon
-update plot icon state color (fix bug preventing proper CSS class from being added to div)
