### PR TITLE
Dataflow: No text tile; no control panel for students

### DIFF
--- a/cypress/integration/dataflow/full/control_panel_spec.js
+++ b/cypress/integration/dataflow/full/control_panel_spec.js
@@ -10,11 +10,11 @@ before(()=>{
     cy.visit(baseUrl+queryParams);
     cy.wait(4000)
     
-    header.switchWorkspace('Control Panels');
-    cy.wait(3000);
+    // header.switchWorkspace('Control Panels');
+    // cy.wait(3000);
 })
 
-context('control panel ui',()=>{
+context.skip('control panel ui',()=>{
     describe('control panel shows registered hubs', ()=>{
         it('verify Registered Hub List is visible',()=>{
             controlPanel.getHubListTitle().should('contain', 'Registered IoT Hubs');

--- a/cypress/integration/dataflow/full/header_test_spec.js
+++ b/cypress/integration/dataflow/full/header_test_spec.js
@@ -9,7 +9,7 @@ before(function(){
     cy.visit(baseUrl+queryParams);
     cy.wait(4000)
 });
-context('Workspace view',()=>{
+context.skip('Workspace view',()=>{
     //Other UI elements are in Common tests
     describe('workspace ui',()=>{
         it('verify Dataflow workspace switch',()=>{

--- a/cypress/integration/dataflow/full/workspace_test_spec.js
+++ b/cypress/integration/dataflow/full/workspace_test_spec.js
@@ -18,7 +18,7 @@ before(function(){
 
 context('Workspace view',()=>{
     describe('switch views',()=>{
-        it('verify Click on Control Panel button shows the control panel',()=>{
+        it.skip('verify Click on Control Panel button shows the control panel',()=>{
             header.switchWorkspace('Control Panels');
             controlPanel.getHubListTitle().should('contain', 'Registered IoT Hubs');
             canvas.getSingleCanvas().should('not.exist')

--- a/cypress/integration/dataflow/smoke/single_student_canvas_test.js
+++ b/cypress/integration/dataflow/smoke/single_student_canvas_test.js
@@ -27,7 +27,7 @@ before(function(){
 
 context('single student functional test',()=>{
     describe('test header elements', function(){
-        it('verifies views button changes when clicked and shows the correct corresponding workspace view', function(){
+        it.skip('verifies views button changes when clicked and shows the correct corresponding workspace view', function(){
             dfheader.switchWorkspace('Control Panels');
             controlPanel.getHubListTitle().should('contain', 'Registered IoT Hubs');
             dfheader.switchWorkspace('Workspace');

--- a/cypress/support/elements/dataflow/dfHeader.js
+++ b/cypress/support/elements/dataflow/dfHeader.js
@@ -3,8 +3,10 @@ class dfHeader{
         return cy.get('.dataflow-app-content .app-header .bp3-button')
     }
     switchWorkspace(workspace){
-        cy.wait(1000)
-        this.getDataflowWorkspaceSwitch().contains(workspace).click();
+        if (workspace !== 'Workspace') {
+            cy.wait(1000)
+            this.getDataflowWorkspaceSwitch().contains(workspace).click();
+        }
     }
 }
 export default dfHeader;

--- a/src/dataflow/app-config.json
+++ b/src/dataflow/app-config.json
@@ -15,11 +15,6 @@
         "content": {
           "type": "Dataflow"
         }
-      },
-      {
-        "content": {
-          "type": "Text"
-        }
       }
     ]
   },

--- a/src/dataflow/components/dataflow-app-header.tsx
+++ b/src/dataflow/components/dataflow-app-header.tsx
@@ -84,6 +84,7 @@ export class DataflowAppHeaderComponent extends BaseComponent<IProps, {}> {
   private renderPanelButtons() {
     const { panels } = this.props;
     if (!panels || (panels.length < 2)) return;
+    if (!this.stores.user.isTeacher) return;
 
     interface IPanelButtonProps {
       panelId: string;


### PR DESCRIPTION
- No default text tile for Dataflow [#170144963]
- Only render Control Panel/Workspace buttons for teachers [#170140529]

Note that the elimination of the Control Panel/Workspace buttons for students required changing/disabling a number of cypress tests.