### PR TITLE
Fix hitbox on node close button

### DIFF
--- a/src/dataflow/components/nodes/dataflow-node.sass
+++ b/src/dataflow/components/nodes/dataflow-node.sass
@@ -144,10 +144,10 @@ $node-inner-width: 140px
 
       .close-node-button
         position: absolute
-        right: 4px
+        right: 0px
         top: 1px
-        width: 8px
-        height: 8px
+        width: 18px
+        height: 18px
         svg
           width: 8px
           height: 8px


### PR DESCRIPTION
Small change to make the node x close button hit box larger so it is easier for the user to close/delete a node.