### PR TITLE
Add timer node

### DIFF
--- a/cypress/integration/dataflow/full/canvas_test_spec.js
+++ b/cypress/integration/dataflow/full/canvas_test_spec.js
@@ -30,7 +30,7 @@ before(()=>{
 })
 
 context('canvas test',()=>{
-    var buttons = ['Sensor','Number','Generator','Math','Logic','Transform','Relay', 'Data Storage'];
+    var buttons = ['Sensor','Number','Generator', 'Timer', 'Math','Logic','Transform','Relay', 'Data Storage'];
     const numButtons = buttons.length;
 
     describe('canvas ui',()=>{

--- a/src/dataflow/components/dataflow-program-toolbar.sass
+++ b/src/dataflow/components/dataflow-program-toolbar.sass
@@ -8,6 +8,7 @@ $toolbar-background: $gray-light
 $button-sensor: $sensor-blue
 $button-number: $number-blue
 $button-generator: $generator-blue
+$button-timer: $timer-blue
 $button-math: $math-green
 $button-logic: $logic-green
 $button-transform: $transform-green
@@ -42,6 +43,8 @@ $button-label-text: $gray-text
       background-color: $button-click
     &:disabled
       opacity: 0.6
+    &.qa
+      height: 15px
 
     .label
       text-align: center
@@ -69,6 +72,8 @@ $button-label-text: $gray-text
         background-color: $button-number
       &.generator
         background-color: $button-generator
+      &.timer
+        background-color: $button-timer
       &.math
         background-color: $button-math
       &.logic

--- a/src/dataflow/components/dataflow-program-toolbar.tsx
+++ b/src/dataflow/components/dataflow-program-toolbar.tsx
@@ -25,8 +25,8 @@ export class DataflowProgramToolbar extends React.Component<IProps, {}> {
             this.renderAddNodeButton(nt.name, i)
           ))
         }
-        { isTesting && <button onClick={this.props.onClearClick}>Clear</button> }
-        { isTesting && <button onClick={this.props.onResetClick}>Reset</button> }
+        { isTesting && <button className={"qa"} onClick={this.props.onClearClick}>Clear</button> }
+        { isTesting && <button className={"qa"} onClick={this.props.onResetClick}>Reset</button> }
       </div>
     );
   }
@@ -39,6 +39,7 @@ export class DataflowProgramToolbar extends React.Component<IProps, {}> {
       case "Number":
       case "Sensor":
       case "Generator":
+      case "Timer":
         nodeIcons.push(<div className="icon-node right mid" key={"icon-node-r-m" + i}/>);
         break;
       case "Math":

--- a/src/dataflow/components/nodes/controls/dropdown-list-control.sass
+++ b/src/dataflow/components/nodes/controls/dropdown-list-control.sass
@@ -1,4 +1,3 @@
-
 @import ../../../vars
 
 .node-select-container

--- a/src/dataflow/components/nodes/controls/num-control.sass
+++ b/src/dataflow/components/nodes/controls/num-control.sass
@@ -1,13 +1,50 @@
+@import ../../../vars
+
 .number-container
   display: flex
   flex-direction: row
+  justify-content: center
+  align-items: center
   color: white
-  line-height: 24px
   margin-top: 3px
   margin-bottom: 3px
   text-align-last: right
+
+  .number-input
+    border-radius: 3px
+    &.units
+      border-top-right-radius: 0
+      border-bottom-right-radius: 0
 
   .number-label
     color: white
     margin-right: 5px
 
+  .type-options-back
+    text-align-last: auto
+    height: 24px
+    color: $gray-text
+
+  .type-options
+    height: 24px
+
+  .type-options span
+    top: 9px
+    width: 0
+    height: 0
+    border-left: 4px solid transparent
+    border-right: 4px solid transparent
+    border-top-width: 6px
+    border-top-style: solid
+
+    svg
+      display: none
+
+  .type-options select
+    width: 49px
+    height: 24px
+    border-radius: 0 12px 12px 0
+    padding: 0 2px 2px 6px
+    margin: 0
+    box-sizing: border-box
+    box-shadow: none

--- a/src/dataflow/components/nodes/controls/num-control.tsx
+++ b/src/dataflow/components/nodes/controls/num-control.tsx
@@ -62,7 +62,7 @@ export class NumControl extends Rete.Control {
             onChange={handleChange(compProps.onChange)}
             onBlur={handleBlur(compProps.onBlur)}
           />
-          { compProps.units && compProps.units.length
+          { compProps.units?.length
             ? <div className="type-options-back">
                 <HTMLSelect className="type-options"
                   onChange={handleSelectChange}

--- a/src/dataflow/components/nodes/controls/num-control.tsx
+++ b/src/dataflow/components/nodes/controls/num-control.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { useRef } from "react";
 import Rete, { NodeEditor, Node } from "rete";
 import { useStopEventPropagation } from "./custom-hooks";
+import { HTMLSelect } from "@blueprintjs/core";
 import "./num-control.sass";
 
 // cf. https://codesandbox.io/s/retejs-react-render-t899c
@@ -16,7 +17,8 @@ export class NumControl extends Rete.Control {
               readonly = false,
               label = "",
               initVal = 0,
-              minVal: number | null = null) {
+              minVal: number | null = null,
+              units: string[] | null = null) {
     super(key);
     this.emitter = emitter;
     this.key = key;
@@ -31,13 +33,19 @@ export class NumControl extends Rete.Control {
         e.currentTarget.blur();
       }
     };
-
+    const handleSelectChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+      this.props.currentUnits = event.target.value;
+      this.putData("units", this.props.currentUnits);
+      (this as any).update();
+    };
     this.component = (compProps: { readonly: any,
                                    value: any;
                                    inputValue: any;
                                    onChange: any;
                                    onBlur: any;
-                                   label: string}) => {
+                                   label: string;
+                                   currentUnits: string;
+                                   units: string[] | null}) => {
       const inputRef = useRef<HTMLInputElement>(null);
       useStopEventPropagation(inputRef, "pointerdown");
       return (
@@ -46,13 +54,28 @@ export class NumControl extends Rete.Control {
             ? <label className="number-label">{compProps.label}</label>
             : null
           }
-          <input className="number-input"
+          <input className={`number-input ${compProps.units && compProps.units.length ? "units" : ""}`}
             ref={inputRef}
             type={"text"}
             value={compProps.inputValue}
             onKeyPress={handleKeyPress}
             onChange={handleChange(compProps.onChange)}
-            onBlur={handleBlur(compProps.onBlur)} />
+            onBlur={handleBlur(compProps.onBlur)}
+          />
+          { compProps.units && compProps.units.length
+            ? <div className="type-options-back">
+                <HTMLSelect className="type-options"
+                  onChange={handleSelectChange}
+                  value={compProps.currentUnits}
+                >
+                  { compProps.units.map((unit, index) => (
+                      <option key={index} value={unit}>{unit}</option>
+                    ))
+                  }
+                </HTMLSelect>
+              </div>
+            : null
+          }
         </div>
       );
     };
@@ -60,6 +83,10 @@ export class NumControl extends Rete.Control {
     this.min = minVal;
     const initial = node.data[key] || initVal;
     node.data[key] = initial;
+
+    const unitsKey = "units";
+    const initialUnits = node.data[unitsKey] || (units?.length ? units[0] : "");
+    node.data[unitsKey] = initialUnits;
 
     this.props = {
       readonly,
@@ -76,7 +103,9 @@ export class NumControl extends Rete.Control {
           this.restoreValue();
         }
       },
-      label
+      label,
+      currentUnits: initialUnits,
+      units
     };
   }
 

--- a/src/dataflow/components/nodes/controls/text-control.sass
+++ b/src/dataflow/components/nodes/controls/text-control.sass
@@ -6,6 +6,9 @@
   margin-top: 3px
   margin-bottom: 3px
 
+  .text-input
+    border-radius: 3px
+
   .text-label
     color: white
     margin-right: 5px

--- a/src/dataflow/components/nodes/dataflow-node.sass
+++ b/src/dataflow/components/nodes/dataflow-node.sass
@@ -31,6 +31,10 @@ $node-inner-width: 140px
         color: $sensor-blue-node
       .active
         background-color: $sensor-blue-control
+      .type-options select
+        background-color: $sensor-blue-outline
+      .type-options span
+        border-top-color: $sensor-blue
     &.number
       background-color: $number-blue
       border-color: $number-blue-outline
@@ -45,6 +49,10 @@ $node-inner-width: 140px
         color: $number-blue-node
       .active
         background-color: $number-blue-control
+      .type-options select
+        background-color: $number-blue-outline
+      .type-options span
+        border-top-color: $number-blue
     &.generator
       background-color: $generator-blue
       border-color: $generator-blue-outline
@@ -59,6 +67,28 @@ $node-inner-width: 140px
         color: $generator-blue-node
       .active
         background-color: $generator-blue-control
+      .type-options select
+        background-color: $generator-blue-outline
+      .type-options span
+        border-top-color: $generator-blue
+    &.timer
+      background-color: $timer-blue
+      border-color: $timer-blue-outline
+      .main-color
+        color: $timer-blue
+        border: 2px solid $timer-blue
+        &:hover
+          background-color: $timer-blue-outline
+      .control-color
+        color: $timer-blue-control
+      .control-color-hoverable:hover
+        color: $timer-blue-node
+      .active
+        background-color: $timer-blue-control
+      .type-options select
+        background-color: $timer-blue-outline
+      .type-options span
+        border-top-color: $timer-blue
     &.math
       background-color: $math-green
       border-color: $math-green-outline
@@ -73,6 +103,10 @@ $node-inner-width: 140px
         color: $math-green-node
       .active
         background-color: $math-green-control
+      .type-options select
+        background-color: $math-green-outline
+      .type-options span
+        border-top-color: $math-green
     &.logic
       background-color: $logic-green
       border-color: $logic-green-outline
@@ -87,6 +121,10 @@ $node-inner-width: 140px
         color: $logic-green-node
       .active
         background-color: $logic-green-control
+      .type-options select
+        background-color: $logic-green-outline
+      .type-options span
+        border-top-color: $logic-green
     &.transform
       background-color: $transform-green
       border-color: $transform-green-outline
@@ -101,6 +139,10 @@ $node-inner-width: 140px
         color: $transform-green-node
       .active
         background-color: $transform-green-control
+      .type-options select
+        background-color: $transform-green-outline
+      .type-options span
+        border-top-color: $transform-green
     &.relay
       background-color: $relay-orange
       border-color: $relay-orange-outline
@@ -115,6 +157,10 @@ $node-inner-width: 140px
         color: $relay-orange-node
       .active
         background-color: $relay-orange-control
+      .type-options select
+        background-color: $relay-orange-outline
+      .type-options span
+        border-top-color: $relay-orange
     &.data-storage
       background-color: $data-storage-orange
       border-color: $data-storage-orange-outline
@@ -129,6 +175,10 @@ $node-inner-width: 140px
         color: $data-storage-orange-node
       .active
         background-color: $data-storage-orange-control
+      .type-options select
+        background-color: $data-storage-orange-outline
+      .type-options span
+        border-top-color: $data-storage-orange
 
     .top-bar
       display: flex
@@ -166,7 +216,6 @@ $node-inner-width: 140px
       font-family: 'Ubuntu', sans-serif
       font-weight: 400
       font-size: 14px
-      border-radius: 30px
       background-color: white
       padding: 2px 6px
       border: 0px solid #999
@@ -181,7 +230,6 @@ $node-inner-width: 140px
       height: 24px
       box-sizing: border-box
       flex: 1
-      border-radius: 3px
 
     .hr
       border: 1px solid

--- a/src/dataflow/components/nodes/dataflow-node.tsx
+++ b/src/dataflow/components/nodes/dataflow-node.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Node, Socket, Control } from "rete-react-render-plugin";
 import { DataflowNodePlot } from "./dataflow-node-plot";
+import { NodeType, NodeTypes } from "../../utilities/node";
 import "./dataflow-node.sass";
 
 export class DataflowNode extends Node {
@@ -19,12 +20,14 @@ export class DataflowNode extends Node {
 
     const plotButton = controls.find((c: any) => c.key === "plot");
     const showPlot = plotButton ? plotButton.props.showgraph : false;
+    const nodeType = NodeTypes.find( (n: NodeType) => n.name === node.name);
+    const displayName = nodeType ? nodeType.displayName : node.name;
 
     return (
       <div className={`node ${node.name.toLowerCase().replace(/ /g, "-")}`}>
         <div className="top-bar">
           <div className="node-title">
-            {node.name}
+            {displayName}
           </div>
           {deleteControl &&
             <Control

--- a/src/dataflow/utilities/node.ts
+++ b/src/dataflow/utilities/node.ts
@@ -1,27 +1,44 @@
-export const NodeTypes = [
+export interface NodeType {
+  name: string;
+  displayName: string;
+}
+
+export const NodeTypes: NodeType[] = [
   {
     name: "Sensor",
+    displayName: "Sensor",
   },
   {
     name: "Number",
+    displayName: "Number",
   },
   {
     name: "Generator",
+    displayName: "Generator",
+  },
+  {
+    name: "Timer",
+    displayName: "Timer (on/off)"
   },
   {
     name: "Math",
+    displayName: "Math",
   },
   {
     name: "Logic",
+    displayName: "Logic",
   },
   {
     name: "Transform",
+    displayName: "Transform",
   },
   {
     name: "Relay",
+    displayName: "Relay",
   },
   {
     name: "Data Storage",
+    displayName: "Data Storage",
   },
 ];
 
@@ -215,6 +232,42 @@ export const NodeGeneratorTypes = [
     icon: "icon-noise-generator"
   },
   */
+];
+
+export const NodeGeneratorPeriodUnits = [
+  {
+    unit: "sec",
+    lengthInSeconds: 1
+  },
+  {
+    unit: "min",
+    lengthInSeconds: 60
+  },
+  {
+    unit: "hour",
+    lengthInSeconds: 3600
+  },
+];
+
+export const NodeTimerInfo =
+{
+  name: "Timer",
+  method: (t: number, p: number, a: number) => t % p < p / 2 ? 1 * a : 0,
+};
+
+export const NodeTimerPeriodUnits = [
+  {
+    unit: "sec",
+    lengthInSeconds: 1
+  },
+  {
+    unit: "min",
+    lengthInSeconds: 60
+  },
+  {
+    unit: "hour",
+    lengthInSeconds: 3600
+  },
 ];
 
 export interface NodeChannelInfo {

--- a/src/dataflow/vars.sass
+++ b/src/dataflow/vars.sass
@@ -25,6 +25,10 @@ $generator-blue-node: #63bdf1
 $generator-blue-control: #97d3f5
 $generator-blue-outline: #cbe9fa
 $generator-blue-readout: #e5f4fc
+$timer-blue: #5bc6ea
+$timer-blue-node: #84d5f0
+$timer-blue-control: #ade2f4
+$timer-blue-outline: #d6f1fa
 
 $math-green: #218e35
 $math-green-node: #59ab68


### PR DESCRIPTION
This PR adds a new timer node to the dataflow editor.  The timer node outputs the values 1 and 0 over a user defined period.  The user can also specify the units of the period (sec, min, hours).  The timer, unlike other nodes, does not display a numeric value in its value output control, but instead displays `on` and `off` since it is intended to be fed into a relay.  