### PR TITLE
168205168 menu cleanup

### DIFF
--- a/src/dataflow/components/nodes/controls/custom-hooks.ts
+++ b/src/dataflow/components/nodes/controls/custom-hooks.ts
@@ -11,3 +11,29 @@ export function useStopEventPropagation<T extends HTMLElement, K extends keyof H
     };
   }, []);
 }
+
+export function useCloseDropdownOnOutsideEvent<T extends HTMLElement>(
+                  domRef: RefObject<T>, isOpen: () => boolean, close: () => void) {
+  function eventHandler(e: MouseEvent | PointerEvent) {
+    // close on click outside the specified DOM node
+    if (domRef.current && e.target && !domRef.current.contains(e.target as Node) && isOpen()) {
+      close();
+    }
+  }
+  function keyEventHandler(e: KeyboardEvent) {
+    // close on escape key
+    if ((e.keyCode === 27) && isOpen()) {
+      close();
+    }
+  }
+  useEffect(() => {
+    window.addEventListener("mousedown", eventHandler, true);
+    window.addEventListener("pointerdown", eventHandler, true);
+    window.addEventListener("keydown", keyEventHandler, true);
+    return () => {
+      window.removeEventListener("mousedown", eventHandler);
+      window.removeEventListener("pointerdown", eventHandler);
+      window.removeEventListener("keydown", keyEventHandler);
+    };
+  }, []);
+}

--- a/src/dataflow/components/nodes/controls/dropdown-list-control.tsx
+++ b/src/dataflow/components/nodes/controls/dropdown-list-control.tsx
@@ -18,6 +18,7 @@ export class DropdownListControl extends Rete.Control {
   private emitter: NodeEditor;
   private component: any;
   private props: any;
+  private listRef: any;
   constructor(emitter: NodeEditor, key: string, node: Node, optionArray: ListOption[], readonly = false, label = "") {
     super(key);
     this.emitter = emitter;
@@ -79,7 +80,7 @@ export class DropdownListControl extends Rete.Control {
             </svg>
           </div>
           {showList ?
-          <div className={`option-list ${listClass}`}>
+          <div className={`option-list ${listClass}`} ref={listRef => this.listRef = listRef}>
             {options.map((ops: any, i: any) => {
               let className = `item ${listClass}`;
               const disabled = isDisabled && isDisabled(ops);
@@ -135,9 +136,11 @@ export class DropdownListControl extends Rete.Control {
     };
   }
 
-  public handlePointerDown = () => {
-    this.props.showList = false;
-    (this as any).update();
+  public handlePointerDown = (e: PointerEvent) => {
+    if (this.listRef && !this.listRef.contains(e.target) && this.props.showList) {
+      this.props.showList = false;
+      (this as any).update();
+    }
   }
 
   public setValue = (val: any) => {

--- a/src/dataflow/components/nodes/controls/dropdown-list-control.tsx
+++ b/src/dataflow/components/nodes/controls/dropdown-list-control.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { useRef } from "react";
 import Rete, { NodeEditor, Node } from "rete";
-import { useStopEventPropagation } from "./custom-hooks";
+import { useStopEventPropagation, useCloseDropdownOnOutsideEvent } from "./custom-hooks";
 import "./dropdown-list-control.sass";
 
 export interface ListOption {
@@ -18,13 +18,10 @@ export class DropdownListControl extends Rete.Control {
   private emitter: NodeEditor;
   private component: any;
   private props: any;
-  private listRef: any;
   constructor(emitter: NodeEditor, key: string, node: Node, optionArray: ListOption[], readonly = false, label = "") {
     super(key);
     this.emitter = emitter;
     this.key = key;
-
-    window.addEventListener("pointerdown", this.handlePointerDown, true);
 
     const handleChange = (onChange: any) => {
       return (e: any) => { onChange(e.target.value); };
@@ -62,6 +59,11 @@ export class DropdownListControl extends Rete.Control {
                                 isDisabled?: DisabledChecker) => {
       const divRef = useRef<HTMLDivElement>(null);
       useStopEventPropagation(divRef, "pointerdown");
+      const listRef = useRef<HTMLDivElement>(null);
+      useCloseDropdownOnOutsideEvent(listRef, () => this.props.showList, () => {
+                                      this.props.showList = false;
+                                      (this as any).update();
+                                    });
       const option = options.find((opt) => optionValue(opt) === val);
       const name = option ? option.name : val;
       const icon = option && option.icon ? `#${option.icon}` : null;
@@ -80,7 +82,7 @@ export class DropdownListControl extends Rete.Control {
             </svg>
           </div>
           {showList ?
-          <div className={`option-list ${listClass}`} ref={listRef => this.listRef = listRef}>
+          <div className={`option-list ${listClass}`} ref={listRef}>
             {options.map((ops: any, i: any) => {
               let className = `item ${listClass}`;
               const disabled = isDisabled && isDisabled(ops);
@@ -134,13 +136,6 @@ export class DropdownListControl extends Rete.Control {
       label,
       isDisabled: null
     };
-  }
-
-  public handlePointerDown = (e: PointerEvent) => {
-    if (this.listRef && !this.listRef.contains(e.target) && this.props.showList) {
-      this.props.showList = false;
-      (this as any).update();
-    }
   }
 
   public setValue = (val: any) => {

--- a/src/dataflow/components/nodes/controls/dropdown-list-control.tsx
+++ b/src/dataflow/components/nodes/controls/dropdown-list-control.tsx
@@ -23,6 +23,8 @@ export class DropdownListControl extends Rete.Control {
     this.emitter = emitter;
     this.key = key;
 
+    window.addEventListener("pointerdown", this.handlePointerDown, true);
+
     const handleChange = (onChange: any) => {
       return (e: any) => { onChange(e.target.value); };
     };
@@ -131,6 +133,11 @@ export class DropdownListControl extends Rete.Control {
       label,
       isDisabled: null
     };
+  }
+
+  public handlePointerDown = () => {
+    this.props.showList = false;
+    (this as any).update();
   }
 
   public setValue = (val: any) => {

--- a/src/dataflow/components/nodes/controls/relay-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/relay-select-control.tsx
@@ -17,6 +17,8 @@ export class RelaySelectControl extends Rete.Control {
     this.key = key;
     this.node = node;
 
+    window.addEventListener("pointerdown", this.handlePointerDown, true);
+
     const handleChange = (onChange: any) => {
       return (e: any) => { onChange(e.target.value); };
     };
@@ -118,6 +120,11 @@ export class RelaySelectControl extends Rete.Control {
       },
       channels: []
     };
+  }
+
+  public handlePointerDown = () => {
+    this.props.showList = false;
+    (this as any).update();
   }
 
   public setChannels = (channels: NodeChannelInfo[]) => {

--- a/src/dataflow/components/nodes/controls/relay-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/relay-select-control.tsx
@@ -10,7 +10,7 @@ export class RelaySelectControl extends Rete.Control {
   private component: any;
   private props: any;
   private node: Node;
-
+  private listRef: any;
   constructor(emitter: NodeEditor, key: string, node: Node, readonly = false) {
     super(key);
     this.emitter = emitter;
@@ -79,7 +79,7 @@ export class RelaySelectControl extends Rete.Control {
             </svg>
           </div>
           {showList ?
-          <div className="option-list">
+          <div className="option-list" ref={listRef => this.listRef = listRef}>
             {options.map((ch: NodeChannelInfo, i: any) => (
               <div
                 className={
@@ -122,9 +122,11 @@ export class RelaySelectControl extends Rete.Control {
     };
   }
 
-  public handlePointerDown = () => {
-    this.props.showList = false;
-    (this as any).update();
+  public handlePointerDown = (e: PointerEvent) => {
+    if (this.listRef && !this.listRef.contains(e.target) && this.props.showList) {
+      this.props.showList = false;
+      (this as any).update();
+    }
   }
 
   public setChannels = (channels: NodeChannelInfo[]) => {

--- a/src/dataflow/components/nodes/controls/relay-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/relay-select-control.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { useRef } from "react";
 import Rete, { NodeEditor, Node } from "rete";
 import { NodeChannelInfo, kRelaySelectMessage, kRelayMissingMessage } from "../../../utilities/node";
-import { useStopEventPropagation } from "./custom-hooks";
+import { useStopEventPropagation, useCloseDropdownOnOutsideEvent } from "./custom-hooks";
 import "./sensor-select-control.sass";
 
 export class RelaySelectControl extends Rete.Control {
@@ -10,14 +10,12 @@ export class RelaySelectControl extends Rete.Control {
   private component: any;
   private props: any;
   private node: Node;
-  private listRef: any;
+
   constructor(emitter: NodeEditor, key: string, node: Node, readonly = false) {
     super(key);
     this.emitter = emitter;
     this.key = key;
     this.node = node;
-
-    window.addEventListener("pointerdown", this.handlePointerDown, true);
 
     const handleChange = (onChange: any) => {
       return (e: any) => { onChange(e.target.value); };
@@ -47,6 +45,11 @@ export class RelaySelectControl extends Rete.Control {
         onListOptionClick: any) => {
       const divRef = useRef<HTMLDivElement>(null);
       useStopEventPropagation(divRef, "pointerdown");
+      const listRef = useRef<HTMLDivElement>(null);
+      useCloseDropdownOnOutsideEvent(listRef, () => this.props.showList, () => {
+                                      this.props.showList = false;
+                                      (this as any).update();
+                                    });
 
       const channelsForType = channels.filter((ch: NodeChannelInfo) => (ch.type === "relay"));
       const selectedChannel = channelsForType.find((ch: any) => ch.channelId === id);
@@ -79,7 +82,7 @@ export class RelaySelectControl extends Rete.Control {
             </svg>
           </div>
           {showList ?
-          <div className="option-list" ref={listRef => this.listRef = listRef}>
+          <div className="option-list" ref={listRef}>
             {options.map((ch: NodeChannelInfo, i: any) => (
               <div
                 className={
@@ -120,13 +123,6 @@ export class RelaySelectControl extends Rete.Control {
       },
       channels: []
     };
-  }
-
-  public handlePointerDown = (e: PointerEvent) => {
-    if (this.listRef && !this.listRef.contains(e.target) && this.props.showList) {
-      this.props.showList = false;
-      (this as any).update();
-    }
   }
 
   public setChannels = (channels: NodeChannelInfo[]) => {

--- a/src/dataflow/components/nodes/controls/sensor-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/sensor-select-control.tsx
@@ -3,7 +3,7 @@ import { useRef } from "react";
 import Rete, { NodeEditor, Node } from "rete";
 import { NodeSensorTypes, NodeChannelInfo,
          kSensorSelectMessage, kSensorMissingMessage } from "../../../utilities/node";
-import { useStopEventPropagation } from "./custom-hooks";
+import { useStopEventPropagation, useCloseDropdownOnOutsideEvent } from "./custom-hooks";
 import "./sensor-select-control.sass";
 import "./value-control.sass";
 
@@ -12,16 +12,12 @@ export class SensorSelectControl extends Rete.Control {
   private component: any;
   private props: any;
   private node: Node;
-  private typeListRef: any;
-  private sensorListRef: any;
 
   constructor(emitter: NodeEditor, key: string, node: Node, readonly = false) {
     super(key);
     this.emitter = emitter;
     this.key = key;
     this.node = node;
-
-    window.addEventListener("pointerdown", this.handlePointerDown, true);
 
     const handleChange = (onChange: any) => {
       return (e: any) => { onChange(e.target.value); };
@@ -63,6 +59,11 @@ export class SensorSelectControl extends Rete.Control {
     const renderSensorTypeList = (type: string, showList: boolean, onDropdownClick: any, onListOptionClick: any) => {
       const divRef = useRef<HTMLDivElement>(null);
       useStopEventPropagation(divRef, "pointerdown");
+      const listRef = useRef<HTMLDivElement>(null);
+      useCloseDropdownOnOutsideEvent(listRef, () => this.props.showTypeList, () => {
+                                      this.props.showTypeList = false;
+                                      (this as any).update();
+                                    });
       let icon = "";
       let name = "";
       const sensorType = NodeSensorTypes.find((s: any) => s.type === type);
@@ -88,7 +89,7 @@ export class SensorSelectControl extends Rete.Control {
             </svg>
           </div>
           {showList ?
-          <div className="option-list" ref={typeListRef => this.typeListRef = typeListRef}>
+          <div className="option-list" ref={listRef}>
             {NodeSensorTypes.map((val: any, i: any) => (
               <div
                 className={
@@ -120,6 +121,11 @@ export class SensorSelectControl extends Rete.Control {
         onListOptionClick: any) => {
       const divRef = useRef<HTMLDivElement>(null);
       useStopEventPropagation(divRef, "pointerdown");
+      const listRef = useRef<HTMLDivElement>(null);
+      useCloseDropdownOnOutsideEvent(listRef, () => this.props.showSensorList, () => {
+                                      this.props.showSensorList = false;
+                                      (this as any).update();
+                                    });
 
       const channelsForType = channels.filter((ch: NodeChannelInfo) => {
         return (ch.type === type) || (type === "none" && ch.type !== "relay");
@@ -157,7 +163,7 @@ export class SensorSelectControl extends Rete.Control {
             </div>
           </div>
           {showList ?
-          <div className="option-list" ref={sensorListRef => this.sensorListRef = sensorListRef}>
+          <div className="option-list" ref={listRef}>
             {options.map((ch: NodeChannelInfo, i: any) => (
               <div
                 className={
@@ -223,17 +229,6 @@ export class SensorSelectControl extends Rete.Control {
       showTypeList: false,
       channels: []
     };
-  }
-
-  public handlePointerDown = (e: PointerEvent) => {
-    if (this.sensorListRef && !this.sensorListRef.contains(e.target) && this.props.showSensorList) {
-      this.props.showSensorList = false;
-      (this as any).update();
-    }
-    if (this.typeListRef && !this.typeListRef.contains(e.target) && this.props.showTypeList) {
-      this.props.showTypeList = false;
-      (this as any).update();
-    }
   }
 
   public setChannels = (channels: NodeChannelInfo[]) => {

--- a/src/dataflow/components/nodes/controls/sensor-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/sensor-select-control.tsx
@@ -12,6 +12,8 @@ export class SensorSelectControl extends Rete.Control {
   private component: any;
   private props: any;
   private node: Node;
+  private typeListRef: any;
+  private sensorListRef: any;
 
   constructor(emitter: NodeEditor, key: string, node: Node, readonly = false) {
     super(key);
@@ -86,7 +88,7 @@ export class SensorSelectControl extends Rete.Control {
             </svg>
           </div>
           {showList ?
-          <div className="option-list">
+          <div className="option-list" ref={typeListRef => this.typeListRef = typeListRef}>
             {NodeSensorTypes.map((val: any, i: any) => (
               <div
                 className={
@@ -155,7 +157,7 @@ export class SensorSelectControl extends Rete.Control {
             </div>
           </div>
           {showList ?
-          <div className="option-list">
+          <div className="option-list" ref={sensorListRef => this.sensorListRef = sensorListRef}>
             {options.map((ch: NodeChannelInfo, i: any) => (
               <div
                 className={
@@ -223,10 +225,15 @@ export class SensorSelectControl extends Rete.Control {
     };
   }
 
-  public handlePointerDown = () => {
-    this.props.showSensorList = false;
-    this.props.showTypeList = false;
-    (this as any).update();
+  public handlePointerDown = (e: PointerEvent) => {
+    if (this.sensorListRef && !this.sensorListRef.contains(e.target) && this.props.showSensorList) {
+      this.props.showSensorList = false;
+      (this as any).update();
+    }
+    if (this.typeListRef && !this.typeListRef.contains(e.target) && this.props.showTypeList) {
+      this.props.showTypeList = false;
+      (this as any).update();
+    }
   }
 
   public setChannels = (channels: NodeChannelInfo[]) => {

--- a/src/dataflow/components/nodes/controls/sensor-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/sensor-select-control.tsx
@@ -19,6 +19,8 @@ export class SensorSelectControl extends Rete.Control {
     this.key = key;
     this.node = node;
 
+    window.addEventListener("pointerdown", this.handlePointerDown, true);
+
     const handleChange = (onChange: any) => {
       return (e: any) => { onChange(e.target.value); };
     };
@@ -219,6 +221,12 @@ export class SensorSelectControl extends Rete.Control {
       showTypeList: false,
       channels: []
     };
+  }
+
+  public handlePointerDown = () => {
+    this.props.showSensorList = false;
+    this.props.showTypeList = false;
+    (this as any).update();
   }
 
   public setChannels = (channels: NodeChannelInfo[]) => {


### PR DESCRIPTION
This PR adds changes to close node dropdown menus when clicks are detected outside of the dropdown list (previously the dropdown stayed open).  Essentially we listen for pointer down events and if we find one that isn't on the dropdown list (save a ref to the list and check if the event target is contained within the list ref), then we close to list (if it is open).