### PR TITLE
Disable failing cypress test

### DIFF
--- a/cypress/integration/dataflow/full/sensor_block_spec.js
+++ b/cypress/integration/dataflow/full/sensor_block_spec.js
@@ -45,7 +45,7 @@ context('Sensor block tests',()=>{
             dfblock.getOutputNode(testBlock).should('be.visible');
             dfblock.getInputNodesNum(testBlock).should('not.exist');
         })
-        it('verify changing sensor type changes the hub list selection',()=>{
+        it.skip('verify changing sensor type changes the hub list selection',()=>{
             var sensorTypes=['Humidity','Temperature','Particulates'];
 
             cy.wrap(sensorTypes).each((sensor, index, sensorList)=>{


### PR DESCRIPTION
- seems to fail if there's only one sensor of a specific type available