### PR TITLE
Fix running a program while comparison view is open

### DIFF
--- a/src/dataflow/components/tools/dataflow-tool.tsx
+++ b/src/dataflow/components/tools/dataflow-tool.tsx
@@ -105,7 +105,8 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IState>
               };
         const newPersonalDocument = await db.createPersonalDocument(params);
         if (newPersonalDocument) {
-          problemWorkspace.setAvailableDocument(newPersonalDocument);
+          problemWorkspace.toggleComparisonVisible({ override: false });
+          problemWorkspace.setPrimaryDocument(newPersonalDocument);
           ui.contractAll();
         }
       }


### PR DESCRIPTION
Running a program while comparison view is open now closes the comparison view and shows only the running "dataset" document

Fixes [[#169764811]](https://www.pivotaltracker.com/story/show/169764811)