### PR TITLE
Clear drag state in `endDragSelectedPoints()` [#170243722]

### DIFF
--- a/src/components/tools/geometry-tool/geometry-content.tsx
+++ b/src/components/tools/geometry-tool/geometry-content.tsx
@@ -1218,6 +1218,7 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
     });
 
     this.dragSelectedPoints(evt, dragTarget, usrDiff);
+    this.dragPts = {};
 
     // only create a change object if there's actually a change
     if (usrDiff[1] || usrDiff[2]) {


### PR DESCRIPTION
The bug was that we were not clearing the drag state properly at the end of a drag, so a subsequent click on a polygon would be interpreted as a request to continue dragging the previously dragged points. The simple fix is to properly clear the drag state at the end of a drag.