### PR TITLE
Add max-height and scrollbars to dropdown menus on nodes

### DIFF
--- a/src/dataflow/components/nodes/controls/dropdown-list-control.sass
+++ b/src/dataflow/components/nodes/controls/dropdown-list-control.sass
@@ -105,12 +105,14 @@
     &.logicOperator
       width: 160px
 
-  &.sensor-select
+  &.sensor-select, &.relay-select
     margin-bottom: 3px
     margin-top: 3px
     .option-list
-      width: 212px
+      width: 240px
       text-align: left
+      max-height: 250px
+      overflow-y: auto
 
 .node-select
   &.sensor-type, &.sensor-select


### PR DESCRIPTION
Limit dropdown menus on nodes from being shown offscreen (this happens when the list is very long or when using Dataflow on a small screen such as on a Chromebook) by adding a max-height and scrollbars.  