### PR TITLE
Update generator and timer to store period value with units as part of calculation

### DIFF
--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -17,8 +17,8 @@ import { RelayReteNodeFactory } from "./nodes/factories/relay-rete-node-factory"
 import { GeneratorReteNodeFactory } from "./nodes/factories/generator-rete-node-factory";
 import { TimerReteNodeFactory } from "./nodes/factories/timer-rete-node-factory";
 import { DataStorageReteNodeFactory } from "./nodes/factories/data-storage-rete-node-factory";
-import { NodeChannelInfo, NodeSensorTypes, NodeGeneratorTypes, NodeGeneratorPeriodUnits, ProgramRunTimes,
-         NodeTimerInfo, NodeTimerIntervalUnits, DEFAULT_PROGRAM_TIME, IntervalTimes } from "../utilities/node";
+import { NodeChannelInfo, NodeSensorTypes, NodeGeneratorTypes, ProgramRunTimes,
+         NodeTimerInfo, DEFAULT_PROGRAM_TIME, IntervalTimes } from "../utilities/node";
 import { uploadProgram, fetchProgramData, deleteProgram } from "../utilities/aws";
 import { DropdownListControl, ListOption } from "./nodes/controls/dropdown-list-control";
 import { PlotButtonControl } from "./nodes/controls/plot-button-control";
@@ -867,15 +867,12 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
   private updateGeneratorNode = (n: Node) => {
     const generatorType = n.data.generatorType;
     const period = Number(n.data.period);
-    const units = n.data.units;
     const amplitude = Number(n.data.amplitude);
     const nodeGeneratorType = NodeGeneratorTypes.find(gt => gt.name === generatorType);
     if (nodeGeneratorType && period && amplitude) {
-      const periodUnits = NodeGeneratorPeriodUnits.find((u: any) => u.unit === units);
-      const periodUnitsInSeconds = periodUnits ? periodUnits.lengthInSeconds : 1;
       const time = Date.now();
       // note: period is given in s, but we're passing in ms for time, need to adjust
-      const val = nodeGeneratorType.method(time, period * 1000 * periodUnitsInSeconds, amplitude);
+      const val = nodeGeneratorType.method(time, period * 1000, amplitude);
       const nodeValue = n.controls.get("nodeValue") as NumControl;
       if (nodeValue) {
         nodeValue.setValue(val);
@@ -887,14 +884,9 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
     const timeOn = Number(n.data.timeOn);
     const timeOff = Number(n.data.timeOff);
     if (timeOn && timeOff) {
-      const timeOnUnits = n.data.timeOnUnits;
-      const timeOffUnits = n.data.timeOffUnits;
-      const timeOnIntervalUnits = NodeTimerIntervalUnits.find((u: any) => u.unit === timeOnUnits);
-      const timeOffIntervalUnits = NodeTimerIntervalUnits.find((u: any) => u.unit === timeOffUnits);
-      const timeOnIntervalUnitsInMs = (timeOnIntervalUnits ? timeOnIntervalUnits.lengthInSeconds : 1) * 1000;
-      const timeOffIntervalUnitsInMs = (timeOffIntervalUnits ? timeOffIntervalUnits.lengthInSeconds : 1) * 1000;
       const time = Date.now();
-      const val = NodeTimerInfo.method(time, timeOn * timeOnIntervalUnitsInMs, timeOff * timeOffIntervalUnitsInMs);
+      // note: time on/off is given in s, but we're passing in ms for time, need to adjust
+      const val = NodeTimerInfo.method(time, timeOn * 1000, timeOff * 1000);
       const nodeValue = n.controls.get("nodeValue") as NumControl;
       if (nodeValue) {
         nodeValue.setValue(val);

--- a/src/dataflow/components/nodes/factories/generator-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/generator-rete-node-factory.tsx
@@ -6,7 +6,7 @@ import { NumControl } from "../controls/num-control";
 import { ValueControl } from "../controls/value-control";
 import { PlotButtonControl } from "../controls/plot-button-control";
 import { DropdownListControl } from "../controls/dropdown-list-control";
-import { NodeGeneratorTypes, NodeGeneratorPeriodUnits } from "../../../utilities/node";
+import { NodeGeneratorTypes, NodePeriodUnits } from "../../../utilities/node";
 
 export class GeneratorReteNodeFactory extends DataflowReteNodeFactory {
   constructor(numSocket: Socket) {
@@ -17,7 +17,7 @@ export class GeneratorReteNodeFactory extends DataflowReteNodeFactory {
     super.defaultBuilder(node);
     if (this.editor) {
       const out = new Rete.Output("num", "Number", this.numSocket);
-      const units = NodeGeneratorPeriodUnits.map(u => u.unit);
+      const units = NodePeriodUnits.map(u => u.unit);
       const dropdownOptions = NodeGeneratorTypes
         .map((nodeOp) => {
           return { name: nodeOp.name, icon: nodeOp.icon };

--- a/src/dataflow/components/nodes/factories/timer-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/timer-rete-node-factory.tsx
@@ -5,7 +5,7 @@ import { DataflowReteNodeFactory } from "./dataflow-rete-node-factory";
 import { NumControl } from "../controls/num-control";
 import { ValueControl } from "../controls/value-control";
 import { PlotButtonControl } from "../controls/plot-button-control";
-import { NodeTimerIntervalUnits } from "../../../utilities/node";
+import { NodePeriodUnits } from "../../../utilities/node";
 
 export class TimerReteNodeFactory extends DataflowReteNodeFactory {
   constructor(numSocket: Socket) {
@@ -16,7 +16,7 @@ export class TimerReteNodeFactory extends DataflowReteNodeFactory {
     super.defaultBuilder(node);
     if (this.editor) {
       const out = new Rete.Output("num", "Number", this.numSocket);
-      const units = NodeTimerIntervalUnits.map(u => u.unit);
+      const units = NodePeriodUnits.map(u => u.unit);
       return node
         .addControl(new NumControl(this.editor, "timeOn", node, false, "time on", 5, 1, units))
         .addControl(new NumControl(this.editor, "timeOff", node, false, "time off", 5, 1, units))

--- a/src/dataflow/utilities/node.ts
+++ b/src/dataflow/utilities/node.ts
@@ -234,7 +234,7 @@ export const NodeGeneratorTypes = [
   */
 ];
 
-export const NodeGeneratorPeriodUnits = [
+export const NodePeriodUnits = [
   {
     unit: "sec",
     lengthInSeconds: 1
@@ -251,24 +251,8 @@ export const NodeGeneratorPeriodUnits = [
 
 export const NodeTimerInfo =
 {
-  name: "Timer",
   method: (t: number, tOn: number, tOff: number) => t % (tOn + tOff) < tOn ? 1 : 0,
 };
-
-export const NodeTimerIntervalUnits = [
-  {
-    unit: "sec",
-    lengthInSeconds: 1
-  },
-  {
-    unit: "min",
-    lengthInSeconds: 60
-  },
-  {
-    unit: "hour",
-    lengthInSeconds: 3600
-  },
-];
 
 export interface NodeChannelInfo {
   hubId: string;


### PR DESCRIPTION
This PR updates the timer and the generator nodes so that they store their period values in seconds rather than in the units specified on the node.  This will prevent the cloud execution from having to change to accommodate the new period units since the period stored in the node data will always be in seconds (e.g., 1 sec is stored as 1, 1 minute is stored as 60, 1 hours is stored as 3600, etc.).