### PR TITLE
170250390 filter names overlap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2312,7 +2312,7 @@
       "dependencies": {
         "whatwg-fetch": {
           "version": "2.0.4",
-          "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
           "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
         }
       }

--- a/src/dataflow/dataflow.sass
+++ b/src/dataflow/dataflow.sass
@@ -314,20 +314,21 @@ $list-item-scale: 0.1
       background-color: $gray-light
 
 .section-tab-container
+  display: flex
+  flex-direction: column
   overflow-y: hidden
+  min-height: 27px
 
 .section-header
   height: 27px
-  flex-shrink: 0
-  flex-grow: 0
+  &.collapsed
+    min-height: 27px
 
 .list-container
   display: flex
   flex-direction: column
   justify-content: flex-start
   height: 100%
-  flex-shrink: 0
-  flex-grow: 0
 
 .list
   &.shown


### PR DESCRIPTION
Fixes the PT story for Dataflow:

[170250390] Wherein the filter names don't maintain their height when their respective lists are collapsed.

This was fixed with minimal, surgical changes to the flex-box styling within dataflow's CSS and should have no impact on Clue. (At least, until we what it to have impact on Clue.)