### PR TITLE
170250390 filter names overlap part 2

### DIFF
--- a/src/dataflow/app-config.json
+++ b/src/dataflow/app-config.json
@@ -68,14 +68,6 @@
             "properties": ["dfHasData", "!isDeleted"]
           },
           {
-            "title": "Data Stories",
-            "type": "personal-documents",
-            "dataTestHeader": "my-work-section",
-            "dataTestItem": "my-work-list-items",
-            "documentTypes": ["personal"],
-            "properties": ["dfIsDataStory", "!isDeleted"]
-          },
-          {
             "title": "Relay Programs",
             "type": "personal-documents",
             "dataTestHeader": "my-work-section",
@@ -106,15 +98,6 @@
             "dataTestItem": "class-work-list-items",
             "documentTypes": ["personalPublication"],
             "properties": ["dfHasData"]
-          },
-          {
-            "className": "section personal published",
-            "title": "Data Stories",
-            "type": "published-personal-documents",
-            "dataTestHeader": "class-work-section",
-            "dataTestItem": "class-work-list-items",
-            "documentTypes": ["personalPublication"],
-            "properties": ["dfIsDataStory"]
           },
           {
             "className": "section personal published",

--- a/src/dataflow/dataflow.sass
+++ b/src/dataflow/dataflow.sass
@@ -216,7 +216,6 @@ $list-item-scale: 0.1
 
         .my-work
           background-color: #ffffff
-          margin-top: -1px
           .header
             display: none
           .section-header,
@@ -228,7 +227,7 @@ $list-item-scale: 0.1
             border-top: 1px solid white
             border-left: 2px solid white
           .section-header
-            padding: 4px
+            padding: 5px
 
         .class-work
           background-color: #ffffff
@@ -322,7 +321,7 @@ $list-item-scale: 0.1
 .section-header
   height: 27px
   &.collapsed
-    min-height: 27px
+    min-height: 26px
 
 .list-container
   display: flex

--- a/src/dataflow/dataflow.sass
+++ b/src/dataflow/dataflow.sass
@@ -333,3 +333,15 @@ $list-item-scale: 0.1
   &.shown
     overflow-x: hidden
     overflow-y: scroll
+    // What follows is a hacky way of making sure the last document in the
+    // list has a little extra padding so the whole of the tile can be seen
+    // when there are a enough documents to cause the accordion to scroll. The
+    // less hacky ways to solve this problem would have some impact to the div
+    // structure and would, in turn, impact Clue. This way may not be perfect,
+    // but it is isolated to dataflow, only.
+    .list-item
+      &:first-child
+          padding-top: 5px
+      &:last-child
+        .footer
+          padding-bottom: 15px


### PR DESCRIPTION
Adjusting some CSS to complete the problem with overlapping accordion titles. In particular, the PR includes changes to address:

* Sass changes to remove extra pixel of white space between closed accordions;

* Removal of the dataflow "Data Stories" accordions in both My Work and Shared tabs; and

* Sass changes to provide a bit more room on the last document in a scrolling accordion.

All changes are in dataflow files, only.