### PR TITLE
Configure application-specific parts of index.html from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
   "version": "1.0.3",
   "description": "Collaborative Learning environment",
   "main": "index.js",
+  "config": {
+    "pageTitle": "CLUE",
+    "pageDescription": "Collaborative Learning User Environment",
+    "branchTagRegEx": "/collaborative-learning\\.concord\\.org\\/(branch|tag)(\\/|$)/i",
+    "masterBranchRegEx": "/collaborative-learning\\.concord\\.org\\/branch\\/master(\\/|$)/i"
+  },
   "jest": {
     "transform": {
       "^.+\\.tsx?$": "ts-jest"

--- a/src/index.html
+++ b/src/index.html
@@ -2,8 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8">
-    <title>CLUE</title>
-    <meta name="description" content="Collaborative Learning User Environment">
+    <title><%= pageTitle %></title>
+    <meta name="description" content="<%= pageDescription %>">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="shortcut icon" href="favicon.ico">
     <link href="https://fonts.googleapis.com/css?family=Lato:400,900&display=swap" rel="stylesheet">
@@ -11,8 +11,8 @@
     <script>
       var hostPath = window.location.hostname + window.location.pathname,
           isLocalhost = /(localhost|127\.0\.0\.1)/i.test(window.location.hostname),
-          isBranchOrTag = /collaborative-learning\.concord\.org\/(branch|tag)(\/|$)/i.test(hostPath),
-          isMasterBranch = /collaborative-learning\.concord\.org\/branch\/master(\/|$)/i.test(hostPath),
+          isBranchOrTag = <%= branchTagRegEx %>.test(hostPath),
+          isMasterBranch = <%= masterBranchRegEx %>.test(hostPath),
           isAuthed = !/appMode=(dev|demo|qa|test)/.test(window.location.search),
           isDemo = /appMode=demo/.test(window.location.search),
           isProduction = !isLocalhost && !isBranchOrTag && isAuthed;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,7 @@ const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
+const packageJson = require('./package.json');
 
 module.exports = (env, argv) => {
   const devMode = argv.mode !== 'production';
@@ -88,7 +89,8 @@ module.exports = (env, argv) => {
       }),
       new HtmlWebpackPlugin({
         filename: 'index.html',
-        template: 'src/index.html'
+        template: 'src/index.html',
+        templateParameters: packageJson.config
       }),
       new CopyWebpackPlugin([
         {from: 'src/public'}


### PR DESCRIPTION
Configure application-specific parts of `index.html` from `package.json` `config` property

When merged to Dataflow, will allow Dataflow to configure its `index.html` from its local `package.json` configuration.