### PR TITLE
Generalize `isPlaceholderRow()` to work when there are multiple placeholder tiles

### DIFF
--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -125,10 +125,14 @@ export const DocumentContentModel = types
         return row ? row.tiles.length : 0;
       },
       isPlaceholderRow(row: TileRowModelType) {
-        if (row.tileCount !== 1) return false;
-        const tileId = row.getTileIdAtIndex(0);
-        const tile = tileId && self.tileMap.get(tileId);
-        return tile ? tile.isPlaceholder : false;
+        // Note that more than one placeholder tile in a row shouldn't happen
+        // in theory, but it has been known to happen as a result of bugs.
+        return (row.tileCount > 0) &&
+                row.tiles.every((entry, index) => {
+                  const tileId = row.getTileIdAtIndex(index);
+                  const tile = tileId && self.tileMap.get(tileId);
+                  return tile ? tile.isPlaceholder : false;
+                });
       },
       getRowsInSection(sectionId: string): TileRowModelType[] {
         let sectionRowIndex: number | undefined;


### PR DESCRIPTION
This shouldn't happen in theory, but it can result from bugs and it's easy to handle.