### PR TITLE
Allow NaN in Dataflow programs

### DIFF
--- a/cypress/integration/dataflow/full/logic_block_spec.js
+++ b/cypress/integration/dataflow/full/logic_block_spec.js
@@ -38,7 +38,7 @@ context('Logic block test',()=>{
         })
         it('verify correct equation when only one node is connected',()=>{
             dfblock.getNumberInput(0).type('{backspace}'+input1+'{enter}');
-            dfblock.getLogicValueTextField().should('contain', input1+' > __ ⇒ 0')//0 > ___ ⇒ 0
+            dfblock.getLogicValueTextField().should('contain', input1+' > __ ⇒ __')
         })
         it('verify greater than',()=>{
             dfblock.connectBlocks('number',1,testBlock,1)

--- a/cypress/integration/dataflow/full/math_block_spec.js
+++ b/cypress/integration/dataflow/full/math_block_spec.js
@@ -98,10 +98,10 @@ context('Math block test',()=>{
             dfblock.getNumberInput(0).type('{backspace}'+input3+'{enter}')
         })
         it('verify block shows correct equation',()=>{ //3 / ___ = 0
-            dfblock.getMathValueTextField().should('contain',input3+' / __ = 0')
+            dfblock.getMathValueTextField().should('contain',input3+' / __ = __')
         })
         it('verify block outputs correct value',()=>{
-            dfblock.getTransformValueTextField().should('contain','|0| = 0')
+            dfblock.getTransformValueTextField().should('contain','|__| = __')
         })
     })
 })

--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -835,6 +835,8 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
       const chInfo = this.channels.find(ci => ci.channelId === n.data.sensor);
       if (chInfo && chInfo.value) {
         sensorSelect.setSensorValue(chInfo.value);
+      } else {
+        sensorSelect.setSensorValue(NaN);
       }
     }
   }

--- a/src/dataflow/components/nodes/controls/sensor-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/sensor-select-control.tsx
@@ -189,7 +189,7 @@ export class SensorSelectControl extends Rete.Control {
     const initialSensor = node.data.sensor || "none";
     node.data.type = initialType;
     node.data.sensor = initialSensor;
-    node.data.nodeValue = 0;
+    node.data.nodeValue = NaN;
 
     this.props = {
       readonly,
@@ -251,7 +251,7 @@ export class SensorSelectControl extends Rete.Control {
 
   public setSensor = (val: any) => {
     const nch: NodeChannelInfo = this.props.channels.find((ch: any) => ch.channelId === val);
-    this.setSensorValue(nch ? nch.value : 0);
+    this.setSensorValue(nch ? nch.value : NaN);
 
     if (nch && nch.type && this.getData("type") !== nch.type) {
       this.props.type = nch.type;

--- a/src/dataflow/components/nodes/controls/sensor-value-control.tsx
+++ b/src/dataflow/components/nodes/controls/sensor-value-control.tsx
@@ -3,6 +3,7 @@ import Rete, { NodeEditor, Node } from "rete";
 import { NodeSensorTypes } from "../../../utilities/node";
 import "./sensor-value-control.sass";
 import "./value-control.sass";
+import { kEmptyValueString } from "../factories/dataflow-rete-node-factory";
 
 export class SensorValueControl extends Rete.Control {
   private component: any;
@@ -27,7 +28,7 @@ export class SensorValueControl extends Rete.Control {
     this.component = (compProps: { value: number; units: string; }) => (
       <div className="sensor-value">
         <div className="value-container">
-          {compProps.value}
+          {isNaN(compProps.value) ? kEmptyValueString : compProps.value}
         </div>
         <div className={`units-container ${compProps.units.length > 4 ? "small" : ""}`}>
           {compProps.units}

--- a/src/dataflow/components/nodes/controls/sensor-value-control.tsx
+++ b/src/dataflow/components/nodes/controls/sensor-value-control.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
 import Rete, { NodeEditor, Node } from "rete";
 import { NodeSensorTypes } from "../../../utilities/node";
+import { kEmptyValueString } from "../factories/dataflow-rete-node-factory";
 import "./sensor-value-control.sass";
 import "./value-control.sass";
-import { kEmptyValueString } from "../factories/dataflow-rete-node-factory";
 
 export class SensorValueControl extends Rete.Control {
   private component: any;

--- a/src/dataflow/components/nodes/factories/dataflow-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/dataflow-rete-node-factory.tsx
@@ -3,6 +3,8 @@ import { Node, Socket } from "rete";
 import { DataflowNode } from "../dataflow-node";
 import { DeleteControl } from "../controls/delete-control";
 
+export const kEmptyValueString = "__";
+
 export abstract class DataflowReteNodeFactory extends Rete.Component {
   protected numSocket: Socket;
   constructor(name: string, numSocket: Socket) {

--- a/src/dataflow/components/nodes/factories/logic-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/logic-rete-node-factory.tsx
@@ -1,7 +1,7 @@
 import Rete from "rete";
 import { Node, Socket } from "rete";
 import { NodeData } from "rete/types/core/data";
-import { DataflowReteNodeFactory } from "./dataflow-rete-node-factory";
+import { DataflowReteNodeFactory, kEmptyValueString } from "./dataflow-rete-node-factory";
 import { ValueControl } from "../controls/value-control";
 import { DropdownListControl } from "../controls/dropdown-list-control";
 import { NodeOperationTypes } from "../../../utilities/node";
@@ -44,15 +44,18 @@ export class LogicReteNodeFactory extends DataflowReteNodeFactory {
 
     const nodeOperationTypes = NodeOperationTypes.find(op => op.name === logicOperator);
     if (nodeOperationTypes) {
-      result = nodeOperationTypes.method(n1, n2);
-
-      if (isNaN(result)) {
-        result = 0;
+      // unlike the other operators, most logic methods will still
+      //  return 0 or 1 with NaN inputs, so we must be explicit.
+      if (isNaN(n1) || isNaN(n2)) {
+        result = NaN;
+      } else {
+        result = nodeOperationTypes.method(n1, n2);
       }
 
-      const n1Str = n1 === undefined ? "__" : "" + n1;
-      const n2Str = n2 === undefined ? "__" : "" + n2;
-      resultSentence = nodeOperationTypes.numberSentence(n1Str, n2Str) + result;
+      const n1Str = isNaN(n1) ? kEmptyValueString : "" + n1;
+      const n2Str = isNaN(n2) ? kEmptyValueString : "" + n2;
+      const resultStr = isNaN(result) ? kEmptyValueString : result;
+      resultSentence = nodeOperationTypes.numberSentence(n1Str, n2Str) + resultStr;
     }
 
     if (this.editor) {

--- a/src/dataflow/components/nodes/factories/math-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/math-rete-node-factory.tsx
@@ -44,7 +44,13 @@ export class MathReteNodeFactory extends DataflowReteNodeFactory {
 
     const nodeOperationTypes = NodeOperationTypes.find(op => op.name === mathOperator);
     if (nodeOperationTypes) {
-      result = nodeOperationTypes.method(n1, n2);
+      if (isNaN(n1) || isNaN(n2)) {
+        result = NaN;
+      } else {
+        // NaNs are for propogating lack of values. Actual math erros like
+        // divide-by-zero should output 0.
+        result = nodeOperationTypes.method(n1, n2) || 0;
+      }
 
       const n1Str = isNaN(n1) ? kEmptyValueString : "" + n1;
       const n2Str = isNaN(n2) ? kEmptyValueString : "" + n2;

--- a/src/dataflow/components/nodes/factories/math-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/math-rete-node-factory.tsx
@@ -1,7 +1,7 @@
 import Rete from "rete";
 import { Node, Socket } from "rete";
 import { NodeData } from "rete/types/core/data";
-import { DataflowReteNodeFactory } from "./dataflow-rete-node-factory";
+import { DataflowReteNodeFactory, kEmptyValueString } from "./dataflow-rete-node-factory";
 import { ValueControl } from "../controls/value-control";
 import { DropdownListControl } from "../controls/dropdown-list-control";
 import { NodeOperationTypes, roundNodeValue } from "../../../utilities/node";
@@ -46,13 +46,10 @@ export class MathReteNodeFactory extends DataflowReteNodeFactory {
     if (nodeOperationTypes) {
       result = nodeOperationTypes.method(n1, n2);
 
-      if (isNaN(result)) {
-        result = 0;
-      }
-
-      const n1Str = n1 === undefined ? "__" : "" + n1;
-      const n2Str = n2 === undefined ? "__" : "" + n2;
-      resultSentence = nodeOperationTypes.numberSentence(n1Str, n2Str) + roundNodeValue(result);
+      const n1Str = isNaN(n1) ? kEmptyValueString : "" + n1;
+      const n2Str = isNaN(n2) ? kEmptyValueString : "" + n2;
+      const resultStr = isNaN(result) ? kEmptyValueString : roundNodeValue(result);
+      resultSentence = nodeOperationTypes.numberSentence(n1Str, n2Str) + resultStr;
     }
 
     if (this.editor) {

--- a/src/dataflow/components/nodes/factories/relay-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/relay-rete-node-factory.tsx
@@ -1,7 +1,7 @@
 import Rete from "rete";
 import { Node, Socket } from "rete";
 import { NodeData } from "rete/types/core/data";
-import { DataflowReteNodeFactory } from "./dataflow-rete-node-factory";
+import { DataflowReteNodeFactory, kEmptyValueString } from "./dataflow-rete-node-factory";
 import { NumControl } from "../controls/num-control";
 import { ValueControl } from "../controls/value-control";
 import { RelaySelectControl } from "../controls/relay-select-control";
@@ -27,14 +27,18 @@ export class RelayReteNodeFactory extends DataflowReteNodeFactory {
 
   public worker(node: NodeData, inputs: any, outputs: any) {
     const n1 = inputs.num1.length ? inputs.num1[0] : node.data.num1;
-    const result = n1 !== 0;
+    const result = +(n1 !== 0);   // convert all non-zero to 1
 
     if (this.editor) {
       const _node = this.editor.nodes.find((n: { id: any; }) => n.id === node.id);
       if (_node) {
         const nodeValue = _node.controls.get("nodeValue") as ValueControl;
-        nodeValue && nodeValue.setValue(+result);
-        nodeValue && nodeValue.setSentence(+result === 0 ? "off" : "on");
+        nodeValue && nodeValue.setValue(result);
+        if (isNaN(n1)) {
+          nodeValue && nodeValue.setSentence(kEmptyValueString);
+        } else {
+          nodeValue && nodeValue.setSentence(result === 0 ? "off" : "on");
+        }
         this.editor.view.updateConnections( {node: _node} );
       }
     }

--- a/src/dataflow/components/nodes/factories/transform-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/transform-rete-node-factory.tsx
@@ -1,7 +1,7 @@
 import Rete from "rete";
 import { Node, Socket } from "rete";
 import { NodeData } from "rete/types/core/data";
-import { DataflowReteNodeFactory } from "./dataflow-rete-node-factory";
+import { DataflowReteNodeFactory, kEmptyValueString } from "./dataflow-rete-node-factory";
 import { NumControl } from "../controls/num-control";
 import { ValueControl } from "../controls/value-control";
 import { DropdownListControl } from "../controls/dropdown-list-control";
@@ -43,14 +43,15 @@ export class TransformReteNodeFactory extends DataflowReteNodeFactory {
 
     const nodeOperationTypes = NodeOperationTypes.find(op => op.name === transformOperator);
     if (nodeOperationTypes) {
-      result = nodeOperationTypes.method(n1, 0);
-
-      if (isNaN(result)) {
-        result = 0;
+      if (isNaN(n1)) {
+        result = NaN;
+      } else {
+        result = nodeOperationTypes.method(n1, 0);
       }
 
-      const n1Str = n1 === undefined ? "__" : "" + n1;
-      resultSentence = nodeOperationTypes.numberSentence(n1Str, "") + result;
+      const n1Str = isNaN(n1)  ? kEmptyValueString : "" + n1;
+      const resultStr = isNaN(result) ? kEmptyValueString : result;
+      resultSentence = nodeOperationTypes.numberSentence(n1Str, "") + resultStr;
    }
 
     if (this.editor) {


### PR DESCRIPTION
This sets sensor values to NaN (displayed as "__") when they are first initialized, when a sensor can't be found, and when data drops (once the 60-second timeout passes), and passes NaNs through the program, such that any node with a NaN input will have a NaN output.

https://www.pivotaltracker.com/story/show/169755170
https://www.pivotaltracker.com/story/show/168223544 (comes along for the ride)