### PR TITLE
Added current document should be shown in the accordion [#170250414]

### DIFF
--- a/src/components/thumbnail/documents-section.tsx
+++ b/src/components/thumbnail/documents-section.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
+import { useState, useEffect, useRef } from "react";
 import { observer } from "mobx-react";
+import { onSnapshot } from "mobx-state-tree";
 import { CollapsibleSectionHeader } from "./collapsible-section-header";
 import { ThumbnailDocumentItem } from "./thumbnail-document-item";
 import { DocumentModelType, isUnpublishedType, isPublishedType, isProblemType, SupportPublication
@@ -44,6 +46,11 @@ function getDocumentCaption(section: NavTabSectionModelType, stores: IStores, do
   return `${namePrefix}${title}`;
 }
 
+interface IAutoExpandDocKeys {
+  primary?: string;
+  comparison?: string;
+}
+
 export const DocumentsSection = observer(({ tab, section, stores, scale,
                                   isExpanded, onToggleExpansion,
                                   onDocumentClick, onDocumentDragStart,
@@ -53,6 +60,9 @@ export const DocumentsSection = observer(({ tab, section, stores, scale,
     const { documents, user } = stores;
     let sectionDocs: DocumentModelType[] = [];
     const publishedDocs: { [source: string]: DocumentModelType } = {};
+    const [autoExpandToDocKey, setAutoExpandToDocKey] = useState<string|undefined>();
+    const [autoExpandDocKeys, setAutoExpandDocKeys] = useState<IAutoExpandDocKeys>({});
+    const listRef = useRef<HTMLDivElement>(null);
 
     (section.documentTypes || []).forEach(type => {
       if (isUnpublishedType(type)) {
@@ -101,6 +111,37 @@ export const DocumentsSection = observer(({ tab, section, stores, scale,
       });
     }
 
+    // listen for changes to the primary and comparison docs
+    useEffect(() => {
+      const disposer = onSnapshot(stores.ui.problemWorkspace, (workspace) => {
+        setAutoExpandDocKeys({
+          primary: workspace.primaryDocumentKey,
+          comparison: workspace.comparisonDocumentKey
+        });
+      });
+      return () => disposer();
+    }, []);
+
+    useEffect(() => {
+      // try to find the primary document and fall back to the comparison document
+      const docKey = sectionDocs.find(doc => autoExpandDocKeys.primary === doc.key)?.key
+                  || sectionDocs.find(doc => autoExpandDocKeys.comparison === doc.key)?.key;
+      if (!isExpanded && docKey && (docKey !== autoExpandToDocKey)) {
+        // autoexpand when not expanded and the section contains a doc key we haven't expanded to yet
+        setAutoExpandToDocKey(docKey);
+        onToggleExpansion(section);
+      } else if (isExpanded && docKey) {
+        // auto scroll to documents when we are expanded and we have a primary or comparison doc in the section
+        const thumbnail = listRef.current?.querySelector(`.list-item[data-thumbnail-key="${docKey}"]`);
+        if (thumbnail && thumbnail.parentElement) {
+          const parentRect = thumbnail.parentElement.getBoundingClientRect();
+          const thumbnailRect = thumbnail.getBoundingClientRect();
+          const top = thumbnailRect.top - parentRect.top;
+          listRef.current?.scrollTo({ behavior: "smooth", top });
+        }
+      }
+    }, [sectionDocs, isExpanded, autoExpandToDocKey, autoExpandDocKeys]);
+
     function handleSectionHeaderClick() {
       onToggleExpansion && onToggleExpansion(section);
     }
@@ -114,7 +155,7 @@ export const DocumentsSection = observer(({ tab, section, stores, scale,
           sectionTitle={sectionTitle} dataTestName={section.dataTestHeader}
           isExpanded={isExpanded} onClick={handleSectionHeaderClick}/>
         <div className="list-container">
-          <div className={"list " + (isExpanded ? "shown" : "hidden")}>
+          <div className={"list " + (isExpanded ? "shown" : "hidden")} ref={listRef}>
             {sectionDocs.map(document => {
 
               function handleDocumentClick() {
@@ -153,6 +194,7 @@ export const DocumentsSection = observer(({ tab, section, stores, scale,
                   document={document}
                   scale={scale}
                   captionText={getDocumentCaption(section, stores, document)}
+                  stores={stores}
                   onDocumentClick={handleDocumentClick} onDocumentDragStart={handleDocumentDragStart}
                   onIsStarred={onIsStarred}
                   onDocumentStarClick={_handleDocumentStarClick}

--- a/src/components/thumbnail/thumbnail-document-item.tsx
+++ b/src/components/thumbnail/thumbnail-document-item.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { CanvasComponent } from "../document/canvas";
 import { DocumentModelType } from "../../models/document/document";
 import { observer } from "mobx-react";
+import { IStores } from "../../models/stores/stores";
 
 interface IProps {
   dataTestName: string;
@@ -9,6 +10,7 @@ interface IProps {
   document: DocumentModelType;
   scale: number;
   captionText: string;
+  stores: IStores;
   onIsStarred: () => boolean;
   onDocumentClick: (document: DocumentModelType) => void;
   onDocumentDragStart?: (e: React.DragEvent<HTMLDivElement>, document: DocumentModelType) => void;
@@ -19,7 +21,8 @@ interface IProps {
 export const ThumbnailDocumentItem = observer((props: IProps) => {
   const { dataTestName, canvasContext, document, scale, captionText, onIsStarred,
           onDocumentClick, onDocumentDragStart, onDocumentStarClick,
-        onDocumentDeleteClick } = props;
+        onDocumentDeleteClick,
+        stores: { ui: { problemWorkspace: { primaryDocumentKey, comparisonDocumentKey }}} } = props;
   const handleDocumentClick = (e: React.MouseEvent<HTMLDivElement>) => {
     onDocumentClick && onDocumentClick(document);
   };
@@ -32,10 +35,14 @@ export const ThumbnailDocumentItem = observer((props: IProps) => {
   const handleDocumentDeleteClick = (e: React.MouseEvent<HTMLDivElement>) => {
     onDocumentDeleteClick && onDocumentDeleteClick(document);
   };
+  const isPrimaryDoc = document.key === primaryDocumentKey;
+  const isComparisonDoc = document.key === comparisonDocumentKey;
+  const className = `list-item${isPrimaryDoc ? " primary-doc" : ""}${isComparisonDoc ? " comparison-doc" : ""}`;
   return (
     <div
-      className="list-item"
+      className={className}
       data-test={dataTestName}
+      data-thumbnail-key={document.key}
       key={document.key} >
 
       <div

--- a/src/components/thumbnail/thumbnail-document-item.tsx
+++ b/src/components/thumbnail/thumbnail-document-item.tsx
@@ -4,13 +4,18 @@ import { DocumentModelType } from "../../models/document/document";
 import { observer } from "mobx-react";
 import { IStores } from "../../models/stores/stores";
 
+export enum ThumbnailDocumentItemRole {
+  PrimaryDoc = "primary-doc",
+  ComparisonDoc = "comparison-doc"
+}
+
 interface IProps {
   dataTestName: string;
   canvasContext: string;
   document: DocumentModelType;
   scale: number;
   captionText: string;
-  stores: IStores;
+  role?: ThumbnailDocumentItemRole;
   onIsStarred: () => boolean;
   onDocumentClick: (document: DocumentModelType) => void;
   onDocumentDragStart?: (e: React.DragEvent<HTMLDivElement>, document: DocumentModelType) => void;
@@ -21,8 +26,7 @@ interface IProps {
 export const ThumbnailDocumentItem = observer((props: IProps) => {
   const { dataTestName, canvasContext, document, scale, captionText, onIsStarred,
           onDocumentClick, onDocumentDragStart, onDocumentStarClick,
-        onDocumentDeleteClick,
-        stores: { ui: { problemWorkspace: { primaryDocumentKey, comparisonDocumentKey }}} } = props;
+        onDocumentDeleteClick, role } = props;
   const handleDocumentClick = (e: React.MouseEvent<HTMLDivElement>) => {
     onDocumentClick && onDocumentClick(document);
   };
@@ -35,9 +39,7 @@ export const ThumbnailDocumentItem = observer((props: IProps) => {
   const handleDocumentDeleteClick = (e: React.MouseEvent<HTMLDivElement>) => {
     onDocumentDeleteClick && onDocumentDeleteClick(document);
   };
-  const isPrimaryDoc = document.key === primaryDocumentKey;
-  const isComparisonDoc = document.key === comparisonDocumentKey;
-  const className = `list-item${isPrimaryDoc ? " primary-doc" : ""}${isComparisonDoc ? " comparison-doc" : ""}`;
+  const className = `list-item${role ? ` ${role}` : ""}`;
   return (
     <div
       className={className}

--- a/src/dataflow/dataflow.sass
+++ b/src/dataflow/dataflow.sass
@@ -167,6 +167,10 @@ $list-item-scale: 0.1
               background-color: $gray-light-hover
             &:active
               background-color: $gray-light-click
+            &.primary-doc
+              background-color: $gray-light-click
+            &.comparison-doc
+              background-color: $gray-light-click
 
             .scaled-list-item-container
               padding: 1px


### PR DESCRIPTION
Listens for primary and comparison document changes and auto expands the accordion menu for the section that the document exists in and then scrolls to the item in the list.

NOTE: this uses React hooks as the `DocumentSection` component is a functional component.