### PR TITLE
Disable tile drags for Dataflow [#170411493]

### DIFF
--- a/src/components/tools/tool-tile.tsx
+++ b/src/components/tools/tool-tile.tsx
@@ -134,12 +134,12 @@ export class ToolTileComponent extends BaseComponent<IProps, {}> {
 
   public render() {
     const { model, widthPct } = this.props;
-    const { ui } = this.stores;
+    const { appConfig, ui } = this.stores;
     const selectedClass = ui.isSelectedTile(model) ? " selected" : "";
     const ToolComponent = kToolComponentMap[model.content.type];
     const isPlaceholderTile = ToolComponent === PlaceholderToolComponent;
     const placeholderClass = isPlaceholderTile ? " placeholder" : "";
-    const dragTileButton = !isPlaceholderTile &&
+    const dragTileButton = !isPlaceholderTile && !appConfig.disableTileDrags &&
                             <div ref={elt => this.dragElement = elt}><DragTileButton /></div>;
     const style: React.CSSProperties = {};
     if (widthPct) {
@@ -220,11 +220,20 @@ export class ToolTileComponent extends BaseComponent<IProps, {}> {
   }
 
   private handleToolDragStart = (e: React.DragEvent<HTMLDivElement>) => {
+    // tile dragging can be disabled globally via appConfig
+    if (this.stores.appConfig.disableTileDrags) {
+      e.preventDefault();
+      return;
+    }
+
+    // tile dragging can be disabled for individual tiles
     const target: HTMLElement | null = e.target as HTMLElement;
     if (!target || target.querySelector(".disable-tile-drag")) {
       e.preventDefault();
       return;
     }
+    // tile dragging can be disabled for individual tile contents,
+    // which only allows those tiles to be dragged by their drag handle
     if (target && target.querySelector(".disable-tile-content-drag")) {
       const eltTarget = document.elementFromPoint(e.clientX, e.clientY);
       if (!eltTarget || !eltTarget.closest(".tool-tile-drag-handle")) {

--- a/src/dataflow/app-config.json
+++ b/src/dataflow/app-config.json
@@ -41,6 +41,7 @@
     }
   },
   "copyPreferOriginTitle": true,
+  "disableTileDrags": true,
   "rightNav": {
     "defaultExpanded": true,
     "preventExpandCollapse": true,

--- a/src/dataflow/components/tools/dataflow-tool.tsx
+++ b/src/dataflow/components/tools/dataflow-tool.tsx
@@ -34,7 +34,7 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IState>
   public render() {
     const { model, readOnly, height } = this.props;
     const editableClass = readOnly ? "read-only" : "editable";
-    const classes = `dataflow-tool disable-tile-content-drag ${editableClass}`;
+    const classes = `dataflow-tool disable-tile-drag disable-tile-content-drag ${editableClass}`;
     const { program, programRunId, programIsRunning, programStartTime, programEndTime, programRunTime, programZoom }
       = this.getContent();
     return (

--- a/src/models/stores/app-config-model.ts
+++ b/src/models/stores/app-config-model.ts
@@ -54,6 +54,7 @@ export const AppConfigModel = types
     documentLabelProperties: types.array(types.string),
     documentLabels: types.map(DocumentLabelModel),
     copyPreferOriginTitle: false,
+    disableTileDrags: false,
     showClassSwitcher: false,
     rightNav: types.optional(RightNavAppConfigModel, () => RightNavAppConfigModel.create()),
     toolbar: types.array(ToolButtonModel)


### PR DESCRIPTION
Note that there a common-code commit which should be cherry-picked to `master` and a Dataflow-specific commit which need not be.