### PR TITLE
Add stacked two-up view for Dataflow

### DIFF
--- a/src/assets/dataflow/icons/one-up/one-up-active.svg
+++ b/src/assets/dataflow/icons/one-up/one-up-active.svg
@@ -1,0 +1,3 @@
+<svg id="document" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 26"><title>document</title><rect id="back" width="30" height="26" rx="1" style="fill:rgb(205,205,205);"/>
+<rect id="body" x="5" y="5" width="20" height="16" style="stroke:rgb(150,150,150);stroke-width:2;fill:#fff"/>
+</svg>

--- a/src/assets/dataflow/icons/one-up/one-up-disabled.svg
+++ b/src/assets/dataflow/icons/one-up/one-up-disabled.svg
@@ -1,0 +1,3 @@
+<svg id="document" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 26"><title>document</title><rect id="back" width="30" height="26" rx="1" style="fill:rgb(255,255,255);"/>
+<rect id="body" x="5" y="5" width="20" height="16" style="stroke:rgb(238,238,238);stroke-width:2;fill:#fff"/>
+</svg>

--- a/src/assets/dataflow/icons/one-up/one-up-hover.svg
+++ b/src/assets/dataflow/icons/one-up/one-up-hover.svg
@@ -1,0 +1,3 @@
+<svg id="document" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 26"><title>document</title><rect id="back" width="30" height="26" rx="1" style="fill:rgb(221,221,221);"/>
+<rect id="body" x="5" y="5" width="20" height="16" style="stroke:rgb(168,168,168);stroke-width:2;fill:#fff"/>
+</svg>

--- a/src/assets/dataflow/icons/one-up/one-up-selected.svg
+++ b/src/assets/dataflow/icons/one-up/one-up-selected.svg
@@ -1,0 +1,3 @@
+<svg id="document" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 26"><title>document</title><rect id="back" width="30" height="26" rx="1" style="fill:rgb(205,205,205);"/>
+<rect id="body" x="5" y="5" width="20" height="16" style="stroke:rgb(150,150,150);stroke-width:2;fill:#fff"/>
+</svg>

--- a/src/assets/dataflow/icons/one-up/one-up.svg
+++ b/src/assets/dataflow/icons/one-up/one-up.svg
@@ -1,0 +1,3 @@
+<svg id="document" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 26"><title>document</title><rect id="back" width="30" height="26" rx="1" style="fill:rgb(255,255,255);"/>
+<rect id="body" x="5" y="5" width="20" height="16" style="stroke:rgb(150,150,150);stroke-width:2;fill:#eeeeee"/>
+</svg>

--- a/src/assets/dataflow/icons/two-up-stacked/two-up-stacked-active.svg
+++ b/src/assets/dataflow/icons/two-up-stacked/two-up-stacked-active.svg
@@ -1,0 +1,4 @@
+<svg id="document" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 26"><title>document</title><rect id="back" width="30" height="26" rx="1" style="fill:rgb(205,205,205);"/>
+<rect id="body" x="5" y="5" width="20" height="16" style="stroke:rgb(150,150,150);stroke-width:2;fill:#fff"/>
+<line id="line" x1="5" y1="13" x2="26" y2="13" style="stroke:rgb(150,150,150);stroke-width:2"/>
+</svg>

--- a/src/assets/dataflow/icons/two-up-stacked/two-up-stacked-disabled.svg
+++ b/src/assets/dataflow/icons/two-up-stacked/two-up-stacked-disabled.svg
@@ -1,0 +1,4 @@
+<svg id="document" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 26"><title>document</title><rect id="back" width="30" height="26" rx="1" style="fill:rgb(255,255,255);"/>
+<rect id="body" x="5" y="5" width="20" height="16" style="stroke:rgb(238,238,238);stroke-width:2;fill:#fff"/>
+<line id="line" x1="5" y1="13" x2="26" y2="13" style="stroke:rgb(238,238,238);stroke-width:2"/>
+</svg>

--- a/src/assets/dataflow/icons/two-up-stacked/two-up-stacked-hover.svg
+++ b/src/assets/dataflow/icons/two-up-stacked/two-up-stacked-hover.svg
@@ -1,0 +1,4 @@
+<svg id="document" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 26"><title>document</title><rect id="back" width="30" height="26" rx="1" style="fill:rgb(221,221,221);"/>
+<rect id="body" x="5" y="5" width="20" height="16" style="stroke:rgb(168,168,168);stroke-width:2;fill:#fff"/>
+<line id="line" x1="5" y1="13" x2="26" y2="13" style="stroke:rgb(168,168,168);stroke-width:2"/>
+</svg>

--- a/src/assets/dataflow/icons/two-up-stacked/two-up-stacked-selected.svg
+++ b/src/assets/dataflow/icons/two-up-stacked/two-up-stacked-selected.svg
@@ -1,0 +1,4 @@
+<svg id="document" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 26"><title>document</title><rect id="back" width="30" height="26" rx="1" style="fill:rgb(205,205,205);"/>
+<rect id="body" x="5" y="5" width="20" height="16" style="stroke:rgb(150,150,150);stroke-width:2;fill:#fff"/>
+<line id="line" x1="5" y1="13" x2="26" y2="13" style="stroke:rgb(150,150,150);stroke-width:2"/>
+</svg>

--- a/src/assets/dataflow/icons/two-up-stacked/two-up-stacked.svg
+++ b/src/assets/dataflow/icons/two-up-stacked/two-up-stacked.svg
@@ -1,0 +1,4 @@
+<svg id="document" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 26"><title>document</title><rect id="back" width="30" height="26" rx="1" style="fill:rgb(255,255,255);"/>
+<rect id="body" x="5" y="5" width="20" height="16" style="stroke:rgb(150,150,150);stroke-width:2;fill:#eeeeee"/>
+<line id="line" x1="5" y1="13" x2="26" y2="13" style="stroke:rgb(150,150,150);stroke-width:2"/>
+</svg>

--- a/src/components/document/document-workspace.tsx
+++ b/src/components/document/document-workspace.tsx
@@ -204,6 +204,10 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps, {}> {
   }
 
   private renderComparisonPlaceholder() {
+    const { appConfig } = this.stores;
+    const placeholderContent = Array.isArray(appConfig.comparisonPlaceholderContent)
+                                ? appConfig.comparisonPlaceholderContent.map(str => <div key={str}>{str}</div>)
+                                : appConfig.comparisonPlaceholderContent;
     return (
       <div
         className="comparison-placeholder"
@@ -211,7 +215,7 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps, {}> {
         onDrop={this.handleDropSide("comparison")}
         onClick={this.handleClick}
       >
-        Click or drag an item in the right tabs to show it here
+        {placeholderContent}
       </div>
     );
   }

--- a/src/components/document/document.tsx
+++ b/src/components/document/document.tsx
@@ -101,6 +101,24 @@ const CopyButton = ({ onClick }: { onClick: () => void }) => {
   );
 };
 
+const OneUpButton = ({ onClick, selected }: { onClick: () => void, selected: boolean }) => {
+  const selectedClass = selected ? "selected" : "";
+  return (
+    <IconButton icon="one-up" key="one-up" className={"action icon-one-up"}
+                innerClassName={selectedClass}
+                onClickButton={onClick} title="One-Up View" />
+  );
+};
+
+const TwoUpStackedButton = ({ onClick, selected }: { onClick: () => void, selected: boolean }) => {
+  const selectedClass = selected ? "selected" : "";
+  return (
+    <IconButton icon="two-up-stacked" key="two-up-stacked" className={"action icon-two-up-stacked"}
+                innerClassName={selectedClass}
+                onClickButton={onClick} title="Two-Up View" />
+  );
+};
+
 const DeleteButton = ({ onClick, enabled }: { onClick: () => void, enabled: boolean }) => {
     const enabledClass = enabled ? "enabled" : "disabled";
     return (
@@ -347,10 +365,12 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
   }
 
   private renderOtherDocumentTitleBar(type: string, hideButtons?: boolean) {
-    const {document} = this.props;
+    const { document, workspace } = this.props;
     const { appConfig, user: { isTeacher }, documents, user } = this.stores;
     const otherDocuments = documents.byTypeForUser(document.type, user.id);
     const countNotDeleted = otherDocuments.reduce((prev, doc) => doc.getProperty("isDeleted") ? prev : prev + 1, 0);
+    const { supportStackedTwoUpView } = appConfig;
+    const isPrimary = this.isPrimary();
     return (
       <div className={`titlebar ${type}`}>
         {!hideButtons &&
@@ -377,6 +397,10 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
             <div className="actions">
               {this.showPublishButton(document) &&
                 <PublishButton onClick={this.handlePublishDocument} />}
+                {supportStackedTwoUpView && isPrimary &&
+                  <OneUpButton onClick={this.handleHideTwoUp} selected={!workspace.comparisonVisible} />}
+                {supportStackedTwoUpView && isPrimary &&
+                  <TwoUpStackedButton onClick={this.handleShowTwoUp} selected={workspace.comparisonVisible} />}
             </div>
           }
         </div>
@@ -434,6 +458,7 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
   }
 
   private renderStatusBar(type: string) {
+    const { appConfig: { supportStackedTwoUpView }} = this.stores;
     const isPrimary = this.isPrimary();
     // Tile comments are disabled for now; uncomment the logic for showComment to re-enable them
     // const showComment = !isPrimary && (document.type === ProblemPublication);
@@ -444,7 +469,7 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
           {null}
         </div>
         <div className="actions">
-          {isPrimary ? this.renderTwoUpButton() : null}
+          {!supportStackedTwoUpView && isPrimary && this.renderTwoUpButton()}
           {showComment ? this.renderCommentButton() : null}
         </div>
         {this.renderCommentDialog()}
@@ -538,6 +563,12 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
 
   private handleToggleTwoUp = () => {
     this.props.workspace.toggleComparisonVisible();
+  }
+  private handleShowTwoUp = () => {
+    this.props.workspace.toggleComparisonVisible({override: true});
+  }
+  private handleHideTwoUp = () => {
+    this.props.workspace.toggleComparisonVisible({override: false});
   }
 
   private handleDownloadTileJson = () => {

--- a/src/dataflow/app-config.json
+++ b/src/dataflow/app-config.json
@@ -47,6 +47,11 @@
   }],
   "copyPreferOriginTitle": true,
   "disableTileDrags": true,
+  "supportStackedTwoUpView": true,
+  "comparisonPlaceholderContent": [
+    "Comparison View:",
+    "Select another data file to view it here."
+  ],
   "rightNav": {
     "defaultExpanded": true,
     "preventExpandCollapse": true,

--- a/src/dataflow/components/dataflow-program.sass
+++ b/src/dataflow/components/dataflow-program.sass
@@ -36,7 +36,7 @@ $dataflow-topbar-height: 40px
     .editor
       flex: 0 0 auto
       &.half
-        width: calc(50% - #{$dataflow-toolbar-width / 2})
+        width: 50%
       &.some
         width: calc(20% - #{$dataflow-toolbar-width / 5})
 

--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -240,11 +240,10 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
     const style: React.CSSProperties = {};
     const documentElt = document.querySelector(".document-content");
     const kBottomResizeHandleHeight = 10;
-    const kTextTileHeight = 60;
     const kProgramTopbarHeight = 44;
     const topbarHeight = this.isComplete() ? 0 : kProgramTopbarHeight;
     const editorHeight = documentElt
-                         ? documentElt.clientHeight - topbarHeight - kTextTileHeight - kBottomResizeHandleHeight
+                         ? documentElt.clientHeight - topbarHeight - kBottomResizeHandleHeight
                          : 500;
     if (!this.props.tileHeight) {
       style.height = `${editorHeight}px`;

--- a/src/dataflow/dataflow.sass
+++ b/src/dataflow/dataflow.sass
@@ -10,12 +10,37 @@ $section-header-height: 27px
   background-color: $gray-mid !important
 
 .document-workspace
+  .left-workspace
+    position: absolute
+    top: $dataflow-app-header
+    left: -4px
+    right: 140px
+    bottom: calc(50% - #{$dataflow-app-header / 2})
+
+  .right-workspace
+    position: absolute
+    top: calc(50% + #{$dataflow-app-header / 2})
+    left: -4px
+    right: 140px
+    bottom: 0px
+
+    .comparison-placeholder
+      color: #242424
+      background-color: #f5f5f5
+      border-color: #ffffff
+      border-radius: 0px
+      border-top-left-radius: 3px
+      border-top-right-radius: 3px
+      display: flex
+      flex-direction: column
+
   .single-workspace
     left: -4px
     right: 140px
     top: 56px
     bottom: -4px
 
+  .left-workspace, .right-workspace, .single-workspace
     .document
       border-radius: 0px
       border-top-left-radius: 3px
@@ -47,6 +72,26 @@ $section-header-height: 27px
                 background-image: url("../assets/dataflow/icons/publish/publish-hover.svg")
               &:active
                 background-image: url("../assets/dataflow/icons/publish/publish-active.svg")
+          .icon-two-up-stacked
+            margin-left: 0
+            .two-up-stacked
+              background-image: url("../assets/dataflow/icons/two-up-stacked/two-up-stacked.svg")
+              &:hover
+                background-image: url("../assets/dataflow/icons/two-up-stacked/two-up-stacked-hover.svg")
+              &:active
+                background-image: url("../assets/dataflow/icons/two-up-stacked/two-up-stacked-active.svg")
+              &.selected
+                background-image: url("../assets/dataflow/icons/two-up-stacked/two-up-stacked-selected.svg")
+          .icon-one-up
+            margin-left: 0
+            .one-up
+              background-image: url("../assets/dataflow/icons/one-up/one-up.svg")
+              &:hover
+                background-image: url("../assets/dataflow/icons/one-up/one-up-hover.svg")
+              &:active
+                background-image: url("../assets/dataflow/icons/one-up/one-up-active.svg")
+              &.selected
+                background-image: url("../assets/dataflow/icons/one-up/one-up-selected.svg")
           .icon-copy
             margin-left: 0
             .copy

--- a/src/dataflow/vars.sass
+++ b/src/dataflow/vars.sass
@@ -72,3 +72,4 @@ $data-green: #49d381
 //
 $dataflow-topbar-height: 40px
 $dataflow-toolbar-width: 84px
+$dataflow-app-header: 56px

--- a/src/models/stores/app-config-model.ts
+++ b/src/models/stores/app-config-model.ts
@@ -64,6 +64,8 @@ export const AppConfigModel = types
     copyPreferOriginTitle: false,
     disableTileDrags: false,
     showClassSwitcher: false,
+    supportStackedTwoUpView: false,
+    comparisonPlaceholderContent: types.optional(types.union(types.string, types.array(types.string)), ""),
     rightNav: types.optional(RightNavAppConfigModel, () => RightNavAppConfigModel.create()),
     toolbar: types.array(ToolButtonModel)
   })


### PR DESCRIPTION
Adds a top-down two-up view for use in Dataflow.  

Some of the changes in `document-workspace.tsx` (text changes for DF) and `document.tsx` (adds a couple new buttons for DF) might need to be incorporated into the app config file.  For now, we can at least begin discussion.  Most of the other changes are DF specific styling and icons.

@kswenson Note, this has been condensed into a single commit, but if we need to slice it up, it will be pretty easy to do so on another branch (or whatever works best).  I wanted you to look first though.