### PR TITLE
Store dataset hidden state to allow user to show/hide sequences while…

### DIFF
--- a/src/dataflow/components/dataflow-program-graph.tsx
+++ b/src/dataflow/components/dataflow-program-graph.tsx
@@ -4,6 +4,7 @@ import { ChartOptions, ChartData, ChartDataSets, Chart } from "chart.js";
 import { SplitViewButtons } from "./split-view-buttons";
 import { ChartPlotColors } from "./../utilities/node";
 import { exportCSV } from "../utilities/export";
+import { isEqual } from "lodash";
 import "./dataflow-program-graph.sass";
 
 export interface DataPoint {
@@ -67,6 +68,15 @@ export class DataflowProgramGraph extends React.Component<IProps, IState> {
   public handleExport = () => {
     const {dataSet} = this.props;
     exportCSV(dataSet.sequences);
+  }
+
+  public shouldComponentUpdate(nextProps: IProps, nextState: IState) {
+    if (!isEqual(nextState.dataSetHidden, this.state.dataSetHidden)) {
+      // prevent render since allowing render after setting hidden state throws error:
+      // Uncaught TypeError: Cannot read property 'clearRect' of null
+      return false;
+    }
+    return true;
   }
 
   public render() {
@@ -249,22 +259,20 @@ export class DataflowProgramGraph extends React.Component<IProps, IState> {
           fontSize: 12,
           fontFamily: "'Ubuntu', 'Arial', sans-serif"
         },
+        // onClick: (e, legendItem) => {
         onClick: function(e, legendItem) {
-          // log the legend item
-          console.log(legendItem);
           // keep track of the index of the dataset that is hidden
           const index = legendItem.datasetIndex + indexOffset;
-          // call the defaul legend click handler
+          // call the default legend click handler
           if (defaultLegendClickHandler) {
+            // defaultLegendClickHandler(e, legendItem);
             defaultLegendClickHandler.call(this, e, legendItem);
           }
-          // we are calling our function to store state incorrectly
-          // this works, but throws the following error in the console:
-          // Uncaught TypeError: Cannot read property 'clearRect' of null
+          // set state, this will not force a rerender
           if (legendItem.hidden !== undefined) {
             setDataSetHidden(index, !legendItem.hidden);
           }
-        },
+        }
       },
       maintainAspectRatio: false,
       responsive: true,

--- a/src/dataflow/components/dataflow-program-graph.tsx
+++ b/src/dataflow/components/dataflow-program-graph.tsx
@@ -225,7 +225,6 @@ export class DataflowProgramGraph extends React.Component<IProps, IState> {
 
   private chartOptions(indexOffset: number) {
     const {dataSet} = this.props;
-    const defaultLegendClickHandler = Chart.defaults.global.legend?.onClick;
     const setDataSetHidden = (i: number, hidden: boolean) => {
       this.setDataSetHiddenState(i, hidden);
     };
@@ -259,16 +258,18 @@ export class DataflowProgramGraph extends React.Component<IProps, IState> {
           fontSize: 12,
           fontFamily: "'Ubuntu', 'Arial', sans-serif"
         },
-        // onClick: (e, legendItem) => {
+        // TODO: this approach detects the legend click and then keeps
+        // track of which dataset sequence is shown/hidden in the component state.
+        // to prevents error, we must also stop thge subsequent render in shouldComponentUpdate.
+        // in the future, we should investigate an alternative approach that doesn't require
+        // keeping track of chart.js state in our component state.
+        // tslint:disable-next-line
         onClick: function(e, legendItem) {
-          // keep track of the index of the dataset that is hidden
           const index = legendItem.datasetIndex + indexOffset;
-          // call the default legend click handler
+          const defaultLegendClickHandler = Chart.defaults.global.legend && Chart.defaults.global.legend.onClick;
           if (defaultLegendClickHandler) {
-            // defaultLegendClickHandler(e, legendItem);
             defaultLegendClickHandler.call(this, e, legendItem);
           }
-          // set state, this will not force a rerender
           if (legendItem.hidden !== undefined) {
             setDataSetHidden(index, !legendItem.hidden);
           }

--- a/src/dataflow/components/dataflow-program-graph.tsx
+++ b/src/dataflow/components/dataflow-program-graph.tsx
@@ -263,8 +263,7 @@ export class DataflowProgramGraph extends React.Component<IProps, IState> {
         // to prevents error, we must also stop thge subsequent render in shouldComponentUpdate.
         // in the future, we should investigate an alternative approach that doesn't require
         // keeping track of chart.js state in our component state.
-        // tslint:disable-next-line
-        onClick: function(e, legendItem) {
+        onClick(e, legendItem) {
           const index = legendItem.datasetIndex + indexOffset;
           const defaultLegendClickHandler = Chart.defaults.global.legend && Chart.defaults.global.legend.onClick;
           if (defaultLegendClickHandler) {


### PR DESCRIPTION
Stores the hidden state of Chart.js graph traces so we can display the dataset graph correctly when running a program.  Note, that these changes work, but throw an error in the console when used.  The error is in Chart.js:
`Uncaught TypeError: Cannot read property clearRect of null`