### PR TITLE
Ensure relays maintains last valid state

### DIFF
--- a/src/dataflow/components/nodes/controls/value-control.tsx
+++ b/src/dataflow/components/nodes/controls/value-control.tsx
@@ -19,7 +19,9 @@ export class ValueControl extends Rete.Control {
                        ${compProps.class.toLowerCase().replace(/ /g, "-")}
                        ${compProps.sentence.length > 12 ? "small" : ""}
                        `}>
-        {compProps.sentence ? compProps.sentence : roundNodeValue(compProps.value)}
+        {compProps.sentence
+          ? compProps.sentence
+          : isFinite(compProps.value) ? roundNodeValue(compProps.value) : ""}
       </div>
     );
 

--- a/src/dataflow/components/nodes/factories/relay-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/relay-rete-node-factory.tsx
@@ -28,8 +28,8 @@ export class RelayReteNodeFactory extends DataflowReteNodeFactory {
   public worker(node: NodeData, inputs: any, outputs: any) {
     const n1 = inputs.num1.length ? inputs.num1[0] : node.data.num1;
     const recentValues: any = node.data.recentValues;
-    const mostRecentValue = recentValues && recentValues[recentValues.length - 1];
-    const lastValue = (mostRecentValue && mostRecentValue.nodeValue) ? mostRecentValue.nodeValue.val : 1;
+    const mostRecentValue = recentValues?.[recentValues.length - 1];
+    const lastValue = (mostRecentValue?.nodeValue) ? mostRecentValue.nodeValue.val : 1;
     // if there is not a valid input, use last value
     // otherwise convert all non-zero to 1
     const result = isNaN(n1) ? lastValue : +(n1 !== 0);
@@ -38,7 +38,7 @@ export class RelayReteNodeFactory extends DataflowReteNodeFactory {
       if (_node) {
         const nodeValue = _node.controls.get("nodeValue") as ValueControl;
         nodeValue && nodeValue.setValue(result);
-        nodeValue && nodeValue.setSentence(result === 0 ? "off" : "on");
+        nodeValue?.setSentence(result === 0 ? "off" : "on");
         this.editor.view.updateConnections( {node: _node} );
       }
     }

--- a/src/dataflow/components/nodes/factories/relay-rete-node-factory.tsx
+++ b/src/dataflow/components/nodes/factories/relay-rete-node-factory.tsx
@@ -27,18 +27,18 @@ export class RelayReteNodeFactory extends DataflowReteNodeFactory {
 
   public worker(node: NodeData, inputs: any, outputs: any) {
     const n1 = inputs.num1.length ? inputs.num1[0] : node.data.num1;
-    const result = +(n1 !== 0);   // convert all non-zero to 1
-
+    const recentValues: any = node.data.recentValues;
+    const mostRecentValue = recentValues && recentValues[recentValues.length - 1];
+    const lastValue = (mostRecentValue && mostRecentValue.nodeValue) ? mostRecentValue.nodeValue.val : 1;
+    // if there is not a valid input, use last value
+    // otherwise convert all non-zero to 1
+    const result = isNaN(n1) ? lastValue : +(n1 !== 0);
     if (this.editor) {
       const _node = this.editor.nodes.find((n: { id: any; }) => n.id === node.id);
       if (_node) {
         const nodeValue = _node.controls.get("nodeValue") as ValueControl;
         nodeValue && nodeValue.setValue(result);
-        if (isNaN(n1)) {
-          nodeValue && nodeValue.setSentence(kEmptyValueString);
-        } else {
-          nodeValue && nodeValue.setSentence(result === 0 ? "off" : "on");
-        }
+        nodeValue && nodeValue.setSentence(result === 0 ? "off" : "on");
         this.editor.view.updateConnections( {node: _node} );
       }
     }


### PR DESCRIPTION
This PR updates the rules regarding the current value of a relay node as follows:
- relays must hold on/off state (1/0)
- if a relay input is invalid, relay reverts to previous known value
- if new relay is created, it starts with value on/1 (this follows the previously defined rule that every relay value other than 0 is converted to on/true - so if the only known value is NaN, then we set the relay to on/1)