### PR TITLE
Append startTime to program title to create unique runId

### DIFF
--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -81,7 +81,6 @@ interface IProps extends SizeMeProps {
   onProgramChange: (program: any) => void;
   onShowOriginalProgram: () => void;
   onStartProgram: (params: IStartProgramParams) => void;
-  onSetProgramRunId: (id: string) => void;
   programRunId: string;
   onSetProgramStartTime: (time: number) => void;
   programStartTime: number;
@@ -763,12 +762,14 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
       }
     }
 
+    const programRunId = this.generateProgramRunId(programTitle, programStartTime);
     const programData = {
       program: {
         endTime: programEndTime,
         hubs,
         program: editedProgram,
-        programId: programTitle,
+        programId: programRunId,  // TODO: remove after lambda function changed to use "programRunId"
+        programRunId,
         runInterval: interval * 1000,
         sensors,
         relays
@@ -777,7 +778,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
 
     this.props.onStartProgram({
                 title: datasetName,
-                runId: programTitle,
+                runId: programRunId,
                 startTime: programStartTime,
                 endTime: programEndTime,
                 hasData: hasValidData,
@@ -785,6 +786,10 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
               });
 
     return programData;
+  }
+
+  private generateProgramRunId(programTitle: string, programStartTime: number) {
+    return `${programTitle}-${programStartTime}`;
   }
 
   private addNode = async (nodeType: string) => {

--- a/src/dataflow/components/tools/dataflow-tool.tsx
+++ b/src/dataflow/components/tools/dataflow-tool.tsx
@@ -49,7 +49,6 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IState>
                 onProgramChange={this.handleProgramChange}
                 onShowOriginalProgram={this.handleShowOriginalProgram}
                 onStartProgram={this.handleStartProgram}
-                onSetProgramRunId={this.handleSetProgramRunId}
                 programRunId={programRunId}
                 programIsRunning={programIsRunning}
                 onCheckProgramRunState={this.handleCheckProgramRunState}
@@ -134,10 +133,6 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IState>
     const originDocumentId = document && document.properties.get("dfProgramId");
     const originDocument = originDocumentId && documents.getDocument(originDocumentId);
     originDocument && this.switchToDocument(originDocument);
-  }
-
-  private handleSetProgramRunId = (id: string) => {
-    this.getContent().setProgramRunId(id);
   }
 
   private handleSetProgramStartTime = (time: number) => {

--- a/src/dataflow/utilities/aws.ts
+++ b/src/dataflow/utilities/aws.ts
@@ -52,7 +52,8 @@ export const getSignedUrl = (
     return requestUrl;
 };
 
-export function uploadProgram(programData: NodeEditor): string {
+// TODO: define interface type for programData
+export function uploadProgram(programData: any): string {
   if (!programData) {
     return "failed";
   }


### PR DESCRIPTION
Pair-programmed with @mklewandowski .

Recent changes to remove the timestamp from the filename resulted in non-unique programRunIds because we were using the filename+timestamp as the runId. This adds the timestamp back when determining the programRunId.