### PR TITLE
Update channel timeout mechanism

### DIFF
--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -344,6 +344,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
               const nci: NodeChannelInfo = {hubId: hub.hubId,
                                             hubName: hub.hubName,
                                             channelId: ch.id,
+                                            missing: ch.missing,
                                             type: ch.type,
                                             units: ch.units,
                                             plug: ch.plug,

--- a/src/dataflow/components/nodes/controls/dropdown-list-control.sass
+++ b/src/dataflow/components/nodes/controls/dropdown-list-control.sass
@@ -35,8 +35,12 @@
     &.selected
       &.sensor-type-option
         background-color: $sensor-blue-control
+        &.missing
+          background-color: pink
       &.relay-type-option
         background-color: $relay-orange-control
+        &.missing
+          background-color: pink
       &.generatorType
         background-color: $generator-blue-control
       &.mathOperator
@@ -48,11 +52,17 @@
       &.interval
         background-color: $data-storage-orange-control
     &.selectable
+      &.missing
+        background-color: pink
       &:hover
         &.sensor-type-option
           background-color: $sensor-blue-outline
+          &.missing
+            background-color: #ffb8c6
         &.relay-type-option
           background-color: $relay-orange-outline
+          &.missing
+            background-color: #ffb8c6
         &.generatorType
           background-color: $generator-blue-outline
         &.mathOperator

--- a/src/dataflow/components/nodes/controls/relay-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/relay-select-control.tsx
@@ -94,7 +94,7 @@ export class RelaySelectControl extends Rete.Control {
                 onMouseDown={onListOptionClick(ch ? ch.channelId : null)}
               >
                 <div className="label">
-                  { ch.missing ? `${kRelayMissingMessage} ${getChannelString(ch)}` : getChannelString(ch) }
+                  {(ch.missing ? `${kRelayMissingMessage} ` : "") + getChannelString(ch)}
                 </div>
               </div>
             ))}

--- a/src/dataflow/components/nodes/controls/relay-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/relay-select-control.tsx
@@ -87,14 +87,14 @@ export class RelaySelectControl extends Rete.Control {
               <div
                 className={
                   (!!id && !!ch && ch.channelId === id) || (!selectedChannel && i === 0)
-                    ? "item relay-type-option selected"
-                    : "item relay-type-option selectable"
+                    ? ("item relay-type-option selected " + (ch.missing ? "missing" : ""))
+                    : ("item relay-type-option selectable " + (ch.missing ? "missing" : ""))
                 }
                 key={i}
                 onMouseDown={onListOptionClick(ch ? ch.channelId : null)}
               >
                 <div className="label">
-                  { getChannelString(ch) }
+                  { ch.missing ? `${kRelayMissingMessage} ${getChannelString(ch)}` : getChannelString(ch) }
                 </div>
               </div>
             ))}

--- a/src/dataflow/components/nodes/controls/sensor-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/sensor-select-control.tsx
@@ -175,7 +175,7 @@ export class SensorSelectControl extends Rete.Control {
                 onMouseDown={onListOptionClick(ch ? ch.channelId : null)}
               >
                 <div className="label">
-                  { ch.missing ? `${kSensorMissingMessage} ${getChannelString(ch)}` : getChannelString(ch) }
+                  {(ch.missing ? `${kSensorMissingMessage} ` : "") + getChannelString(ch)}
                 </div>
               </div>
             ))}

--- a/src/dataflow/components/nodes/controls/sensor-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/sensor-select-control.tsx
@@ -168,14 +168,14 @@ export class SensorSelectControl extends Rete.Control {
               <div
                 className={
                   (!!id && !!ch && ch.channelId === id) || (!selectedChannel && i === 0)
-                    ? "item sensor-type-option selected"
-                    : "item sensor-type-option selectable"
+                    ? ("item sensor-type-option selected " + (ch.missing ? "missing" : ""))
+                    : ("item sensor-type-option selectable " + (ch.missing ? "missing" : ""))
                 }
                 key={i}
                 onMouseDown={onListOptionClick(ch ? ch.channelId : null)}
               >
                 <div className="label">
-                  { getChannelString(ch) }
+                  { ch.missing ? `${kSensorMissingMessage} ${getChannelString(ch)}` : getChannelString(ch) }
                 </div>
               </div>
             ))}

--- a/src/dataflow/lib/iot.ts
+++ b/src/dataflow/lib/iot.ts
@@ -172,8 +172,9 @@ export class IoT {
   private processHubChannelInfoMessage(hubId: string, message: any) {
     const  { hubStore } = this.stores;
     const hub = hubStore.getHubById(hubId);
+    const currentTime = Date.now();
     if (hub) {
-      hub.setHubUpdateTime(Date.now());
+      hub.setHubUpdateTime(currentTime);
       const devices = Object.values(message);
       const deviceKeys = Object.keys(message);
       let rids: string[] = [];
@@ -198,12 +199,12 @@ export class IoT {
               model,
               units,
               value: "",
-              lastUpdateTime: Date.now(),
+              lastUpdateTime: currentTime,
               missing: false,
               plug}));
           } else {
             hub.setHubChannelMissingState(id, false);
-            hub.setHubChannelTime(id, Date.now());
+            hub.setHubChannelTime(id, currentTime);
           }
         });
       });

--- a/src/dataflow/lib/iot.ts
+++ b/src/dataflow/lib/iot.ts
@@ -84,18 +84,19 @@ export class IoT {
 
   private updateHubs = () => {
     const  { hubStore } = this.stores;
+    const currentTime = Date.now();
     // check for hubs that have not responded recently
     hubStore.hubs.forEach(hub => {
-      if ((Date.now() - hub.hubUpdateTime) > HUB_RESPONSE_TIMEOUT && hub.hubChannels.length) {
+      if ((currentTime - hub.hubUpdateTime) > HUB_RESPONSE_TIMEOUT && hub.hubChannels.length) {
         hub.setAllHubChannelsMissingState(true);
         this.requestHubChannelInfo(hub.hubId);
-      } else if ((Date.now() - hub.hubUpdateTime) > CHANNEL_REMOVE_TIMEOUT && hub.hubChannels.length) {
+      } else if ((currentTime - hub.hubUpdateTime) > CHANNEL_REMOVE_TIMEOUT && hub.hubChannels.length) {
         hub.removeAllHubChannels();
         this.requestHubChannelInfo(hub.hubId);
       }
       const rids: string[] = [];
       hub.hubChannels.forEach(ch => {
-        if ((Date.now() - ch.lastUpdateTime) > CHANNEL_REMOVE_TIMEOUT && ch.missing) {
+        if ((currentTime - ch.lastUpdateTime) > CHANNEL_REMOVE_TIMEOUT && ch.missing) {
           rids.push(ch.id);
         }
       });

--- a/src/dataflow/models/stores/hub-store.ts
+++ b/src/dataflow/models/stores/hub-store.ts
@@ -8,6 +8,7 @@ export const HubChannelModel = types.model({
   units: types.string,
   value: types.string,
   lastUpdateTime: types.number,
+  missing: types.boolean,
   plug: types.number,
 });
 export type HubChannelType = typeof HubChannelModel.Type;
@@ -51,6 +52,17 @@ export const HubModel = types
     removeAllHubChannels() {
       self.hubChannels.clear();
     },
+    setHubChannelMissingState(id: string, missing: boolean) {
+      const ch = self.getHubChannel(id);
+      if (ch) {
+        ch.missing = missing;
+      }
+    },
+    setAllHubChannelsMissingState(missing: boolean) {
+      self.hubChannels.forEach(ch => {
+        ch.missing = missing;
+      });
+    },
     setHubChannelValue(id: string, value: string) {
       const ch = self.getHubChannel(id);
       if (ch) {
@@ -61,11 +73,10 @@ export const HubModel = types
       self.hubUpdateTime = newTime;
     },
     setHubChannelTime(id: string, newTime: number) {
-      self.hubChannels.forEach(ch => {
-        if (ch.id === id) {
-          ch.lastUpdateTime = newTime;
-        }
-      });
+      const ch = self.getHubChannel(id);
+      if (ch) {
+        ch.lastUpdateTime = newTime;
+      }
     },
     addHubGroup(group: string) {
       self.hubGroups.push(group);

--- a/src/dataflow/utilities/node.ts
+++ b/src/dataflow/utilities/node.ts
@@ -258,6 +258,7 @@ export interface NodeChannelInfo {
   hubId: string;
   hubName: string;
   channelId: string;
+  missing: boolean;
   type: string;
   units: string;
   plug: number;


### PR DESCRIPTION
Add two tiers of device timeout: after 30 seconds, mark the device as missing and update the UI accordingly.  After 5 minutes, remove the device entirely for the hub store and from the UI.

@kswenson Current changes are functional, but I want to review and test more carefully before submitting the final PR.  In the meantime, feel free to take a look.