### PR TITLE
Delete node recent values on load

### DIFF
--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -276,6 +276,11 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
 
       const program = this.props.program && safeJsonParse(this.props.program);
       if (program) {
+        forEach(program.nodes, (n: any) => {
+          if (n.data.recentValues) {
+            n.data.recentValues = [];
+          }
+        });
         this.closeCompletedRunProgramNodePlots(program);
         const result = await this.programEditor.fromJSON(program);
         if (this.hasDataStorage()) {


### PR DESCRIPTION
Small fix to delete recent values from node data when loading a program.  Otherwise we show the stale recent values in the node mini-plot implying that they are part of the past 15 second worth of node values (even though these are actually old values from the previous time that the program was opened).

I chose to clear recent values on load rather than on save so that:
- loading existing programs created before the fix will not show stale recent values
- recent values retained in saved program data could be useful for debugging or research   