### PR TITLE
Set min height of editor container

### DIFF
--- a/src/dataflow/components/dataflow-program.sass
+++ b/src/dataflow/components/dataflow-program.sass
@@ -1,6 +1,7 @@
 @import ../vars
 
 $dataflow-topbar-height: 40px
+$dataflow-toolbar-height: 364px
 .flow-tool
   background: white
   font-family: 'Ubuntu', sans-serif
@@ -32,6 +33,7 @@ $dataflow-topbar-height: 40px
     display: flex
     flex: 1
     overflow: hidden
+    min-height: $dataflow-toolbar-height
 
     .editor
       flex: 0 0 auto


### PR DESCRIPTION
Small fix to improve display of program editor content.  When the program editor tile height was shorter than the program toolbar height, we displayed the tile with scrollbars (this would occasionally happen in the 2-up display).  This resulted in the scrolled content being cut off due to an incorrect container height.  Enforce a min-height in the editor container so that in cases where the content is scrolled, we do not cut off editor content.
 