### PR TITLE
Fix program cover sizing

### DIFF
--- a/src/dataflow/components/dataflow-program-cover.sass
+++ b/src/dataflow/components/dataflow-program-cover.sass
@@ -13,9 +13,9 @@
     &.running
       top: $dataflow-topbar-height
     &.half
-      width: calc(50% - #{$dataflow-toolbar-width / 2})
+      width: 50%
     &.some
-      width: calc(20% - #{$dataflow-toolbar-width / 5})
+      width: 20%
 
     .stop
       width: 150px


### PR DESCRIPTION
The right edge of the program cover (used when program is disabled to prevent interaction) did not cover the program content.  This allowed the user to edit a read-only program.  This PR fixes the program editor cover size (no longer takes toolbar which is now hidden into account).