### PR TITLE
Update node when plot button is pressed

### DIFF
--- a/src/dataflow/components/nodes/controls/plot-button-control.tsx
+++ b/src/dataflow/components/nodes/controls/plot-button-control.tsx
@@ -45,7 +45,7 @@ export class PlotButtonControl extends Rete.Control {
   public setGraph = (show: boolean) => {
     this.props.showgraph = show;
     this.putData(this.key, show);
-    (this as any).update();
+    this.node.update();
     this.emitter.trigger("process");
   }
 

--- a/src/dataflow/components/nodes/controls/plot-button-control.tsx
+++ b/src/dataflow/components/nodes/controls/plot-button-control.tsx
@@ -45,6 +45,8 @@ export class PlotButtonControl extends Rete.Control {
   public setGraph = (show: boolean) => {
     this.props.showgraph = show;
     this.putData(this.key, show);
+    // this update is needed to ensure that we redraw the plot
+    // in the proper state after the button is pressed
     this.node.update();
     this.emitter.trigger("process");
   }


### PR DESCRIPTION
This PR adds back in a node update call that was recently removed.  We need to update the node to force a node re-render when the plot button is pressed.  Otherwise the plot is not shown/hidden until the next heartbeat hits and all nodes are updated.  This isn't a terrible bug, but without it, there is a noticeable delay when clicking the plot button (up to one second).

 `(this as any).update();` is, as far as I can tell, not needed.