### PR TITLE
Improve display of large string in value control

### DIFF
--- a/src/dataflow/components/nodes/controls/value-control.sass
+++ b/src/dataflow/components/nodes/controls/value-control.sass
@@ -4,10 +4,13 @@
   border-radius: 3px
   padding: 1px 5px 1px 1px
   width: 106px
-  height: 24px
   vertical-align: middle
   box-sizing: border-box
   &.math, &.logic, &.transform
     font-size: 16px
+    &.medium
+      font-size: 14px
     &.small
       font-size: 12px
+    &.smallest
+      font-size: 10px

--- a/src/dataflow/components/nodes/controls/value-control.tsx
+++ b/src/dataflow/components/nodes/controls/value-control.tsx
@@ -14,17 +14,24 @@ export class ValueControl extends Rete.Control {
     this.emitter = emitter;
     this.key = key;
 
-    this.component = (compProps: { value: number; sentence: string, class: string }) => (
-      <div className={`value-container
-                       ${compProps.class.toLowerCase().replace(/ /g, "-")}
-                       ${compProps.sentence.length > 12 ? "small" : ""}
-                       `}
-           title={"Node Value"}>
-        {compProps.sentence
-          ? compProps.sentence
-          : isFinite(compProps.value) ? roundNodeValue(compProps.value) : ""}
-      </div>
-    );
+    this.component = (compProps: { value: number; sentence: string, class: string }) => {
+      let sizeClass = "";
+      if (compProps.sentence.length > 15) {
+        sizeClass = "smallest";
+      } else if (compProps.sentence.length > 13) {
+        sizeClass = "small";
+      } else if (compProps.sentence.length > 11) {
+        sizeClass = "medium";
+      }
+      return (
+        <div className={`value-container ${compProps.class.toLowerCase().replace(/ /g, "-")} ${sizeClass}`}
+             title={"Node Value"}>
+          {compProps.sentence
+            ? compProps.sentence
+            : isFinite(compProps.value) ? roundNodeValue(compProps.value) : ""}
+        </div>
+      );
+    };
 
     const initial = node.data[key] || 0;
     node.data[key] = initial;


### PR DESCRIPTION
Small improvements to how long node values are displayed in node value control (especially relevant in math, logic, and transform nodes where we tend to display longer strings than in other nodes):
- remove `height` from CSS so content is centered vertically
- add additional sizing tiers to better handle long strings