### PR TITLE
Add hub channel timeout status to control panel

### DIFF
--- a/src/dataflow/components/hub-list.sass
+++ b/src/dataflow/components/hub-list.sass
@@ -45,6 +45,8 @@
         margin: $half-padding
         border: 1px solid $gray-mid
         overflow: hidden
+        &.missing
+          background-color: pink
 
         .label
           margin-bottom: $quarter-padding

--- a/src/dataflow/components/hub-list.tsx
+++ b/src/dataflow/components/hub-list.tsx
@@ -58,9 +58,11 @@ export class HubListComponent extends BaseComponent<IProps, IState> {
 
   private renderHubChannel(ch: HubChannelType, showPlug: boolean) {
     const plug = ch.plug > 0 && showPlug ? ` (plug ${ch.plug})` : "";
+    const channelClass = "channel " + (ch.missing ? "missing" : "");
+    const channelText = `${ch.type}${plug}: ` + (ch.missing ? "Finding device" : `${ch.value} ${ch.units}`);
     return (
-      <div className="channel" key={ch.id}>
-        <div className="label">{ `${ch.type}${plug}: ${ch.value} ${ch.units}` }</div>
+      <div className={channelClass} key={ch.id}>
+        <div className="label">{channelText}</div>
       </div>
     );
   }


### PR DESCRIPTION
This PR adds small changes to the control panel to communicate to the user when sensors or relays are in the `missing` state.