### PR TITLE
Update node to show finding state as soon as device is marked missing

### DIFF
--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -610,14 +610,14 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
     this.programEditor.nodes.forEach((n: Node) => {
       if (n.name === "Sensor" && n.data.sensor) {
         const chInfo = this.channels.find(ci => ci.channelId === n.data.sensor);
-        if (!chInfo && n.data.sensor !== "none") {
+        if ((!chInfo && n.data.sensor !== "none") || (chInfo && chInfo.missing)) {
           if (typeof n.data.sensor === "string" && typeof n.data.type === "string") {
             missingDevices.push({ id: n.data.sensor, type: n.data.type});
           }
         }
       } else if (n.name === "Relay" && n.data.relayList) {
         const chInfo = this.channels.find(ci => ci.channelId === n.data.relayList);
-        if (!chInfo && n.data.relayList !== "none") {
+        if ((!chInfo && n.data.relayList !== "none") || (chInfo && chInfo.missing)) {
           if (typeof n.data.relayList === "string") {
             missingDevices.push({ id: n.data.relayList, type: "relay"});
           }

--- a/src/dataflow/components/nodes/controls/relay-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/relay-select-control.tsx
@@ -57,7 +57,7 @@ export class RelaySelectControl extends Rete.Control {
       const getChannelString = (ch?: NodeChannelInfo | "none") => {
         if (!ch && (!id || id === "none")) return kRelaySelectMessage;
         if (ch === "none") return "None Available";
-        if (!ch) return `${kRelayMissingMessage} ${id}`;
+        if (!ch || ch.missing) return `${kRelayMissingMessage} ${id}`;
         let count = 0;
         channelsForType.forEach( c => { if (c.type === ch.type && ch.hubId === c.hubId) count++; } );
         return `${ch.hubName}:${ch.type}${ch.plug > 0 && count > 1 ? `(plug ${ch.plug})` : ""}`;

--- a/src/dataflow/components/nodes/controls/sensor-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/sensor-select-control.tsx
@@ -135,7 +135,7 @@ export class SensorSelectControl extends Rete.Control {
       const getChannelString = (ch?: NodeChannelInfo | "none") => {
         if (!ch && (!id || id === "none")) return kSensorSelectMessage;
         if (ch === "none") return "None Available";
-        if (!ch) return `${kSensorMissingMessage} ${id}`;
+        if (!ch || ch.missing) return `${kSensorMissingMessage} ${id}`;
         let count = 0;
         channelsForType.forEach( c => { if (c.type === ch.type && ch.hubId === c.hubId) count++; } );
         return `${ch.hubName}:${ch.type}${ch.plug > 0 && count > 1 ? `(plug ${ch.plug})` : ""}`;

--- a/src/dataflow/models/stores/hub-store.ts
+++ b/src/dataflow/models/stores/hub-store.ts
@@ -56,11 +56,13 @@ export const HubModel = types
       const ch = self.getHubChannel(id);
       if (ch) {
         ch.missing = missing;
+        missing && (ch.value = "NaN");
       }
     },
     setAllHubChannelsMissingState(missing: boolean) {
       self.hubChannels.forEach(ch => {
         ch.missing = missing;
+        missing && (ch.value = "NaN");
       });
     },
     setHubChannelValue(id: string, value: string) {


### PR DESCRIPTION
This PR makes small changes to unify how we handle relays and sensors that are in the missing/finding state.  Specifically:
- highlight missing selected device on sensor and relay nodes and show "finding" message
- set sensor value to NaN as soon as we detect that it is missing
- warn user if the selected device on a sensor or relay node is missing