### PR TITLE
When loading completed dataset, show error message if load returns no…

### DIFF
--- a/src/dataflow/components/dataflow-program-graph.sass
+++ b/src/dataflow/components/dataflow-program-graph.sass
@@ -27,6 +27,14 @@
     background-size: 20%
     background-position-x: 50%
 
+  .graph-error
+    display: flex
+    flex-direction: column
+    align-items: center
+    justify-content: center
+    height: 100%
+    width: 100%
+
   .stacked-graph-container
     display: flex
     flex-direction: column

--- a/src/dataflow/components/dataflow-program-graph.tsx
+++ b/src/dataflow/components/dataflow-program-graph.tsx
@@ -128,12 +128,12 @@ export class DataflowProgramGraph extends React.Component<IProps, IState> {
                             ? "most"
                             : "half");
     const wideClass = programDisplayState === ProgramDisplayStates.Graph ? "wide" : "";
-    const hasValidTime = dataSet.startTime !== 0 || dataSet.endTime !== 0;
+    const hasValidTime = dataSet.startTime > 0 || dataSet.endTime > 0;
     return (
       <div className={`program-graph ${graphClass}`} data-test="program-graph">
         {dataSet.sequences.length === 0 && (!hasValidTime
                                             ? <div className="graph-loading"/>
-                                            : <div className="graph-error">Error loading dataset</div>)}
+                                            : <div className="graph-error">Dataset contains no data</div>)}
         { this.state.stacked
           ? this.renderStackedGraphs()
           : this.renderOverlappedGraphs()

--- a/src/dataflow/components/dataflow-program-graph.tsx
+++ b/src/dataflow/components/dataflow-program-graph.tsx
@@ -128,9 +128,12 @@ export class DataflowProgramGraph extends React.Component<IProps, IState> {
                             ? "most"
                             : "half");
     const wideClass = programDisplayState === ProgramDisplayStates.Graph ? "wide" : "";
+    const hasValidTime = dataSet.startTime !== 0 || dataSet.endTime !== 0;
     return (
       <div className={`program-graph ${graphClass}`} data-test="program-graph">
-        {dataSet.sequences.length === 0 && <div className="graph-loading" />}
+        {dataSet.sequences.length === 0 && (!hasValidTime
+                                            ? <div className="graph-loading"/>
+                                            : <div className="graph-error">Error loading dataset</div>)}
         { this.state.stacked
           ? this.renderStackedGraphs()
           : this.renderOverlappedGraphs()

--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -1047,6 +1047,8 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
             });
           });
           this.setState({ graphDataSet });
+        } else {
+          this.getRunState() === ProgramRunStates.Complete && this.setState({ graphDataSet });
         }
       });
     }

--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -1048,7 +1048,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
           });
           this.setState({ graphDataSet });
         } else {
-          this.getRunState() === ProgramRunStates.Complete && this.setState({ graphDataSet });
+          (this.getRunState() === ProgramRunStates.Complete) && this.setState({ graphDataSet });
         }
       });
     }


### PR DESCRIPTION
This PR adds a data load error in the case where:
- we are loading data from a completed program (so load will be attempted once)
- dataset is passed as props with valid start/end timestamps but no sequence data (timestamps indicate that we returned from the load and passed something to the component to be rendered.  If sequence is empty, something went wrong while attempting to load dataset.  This allows us to differentiate between the case where a dataset is empty because it is still being loaded and the case where a dataset is empty because the load completed but returned nothing)

The above approach might need refinement, but for now it's a solution that provides additional feedback to the user about the dataset load status while making minimal changes before a classroom test.  Another option might be to include an error (or a loadComplete or hasData) parameter with the dataset that gets passed as props.  This could be used to differentiate between when data is loading and when data was loaded and returned no data (timestamps are less than ideal to be used to determine this, but do do the trick).