### PR TITLE
Support portal launch via Preview button [#170588779]

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -327,8 +327,16 @@ export const authenticate = (appMode: AppMode, appConfig: AppConfigModelType, ur
     const bearerToken = urlParams.token;
     let basePortalUrl: string;
 
+    let {fakeClass, fakeUser} = urlParams;
+
+    // handle preview launch from portal
+    if (urlParams.domain && urlParams.domain_uid && !bearerToken) {
+      appMode = "demo";
+      fakeClass = `preview-${urlParams.domain_uid}`;
+      fakeUser = `student:${urlParams.domain_uid}`;
+    }
+
     if ((appMode === "demo") || (appMode === "qa")) {
-      const {fakeClass, fakeUser} = urlParams;
       if (!fakeClass || !fakeUser) {
         return reject("Missing fakeClass or fakeUser parameter for demo!");
       }

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -54,8 +54,7 @@ export class Firebase {
 
   public getRootFolder() {
     // in the form of /(dev|test|demo|authed)/[<firebaseUserId> if dev or test]/portals/<escapedPortalDomain>
-    const { appMode, user } = this.db.stores;
-    const { demoName } = urlParams;
+    const { appMode, demo: { name: demoName }, user } = this.db.stores;
 
     const parts = [];
     if (urlParams.testMigration === "true" && FIREBASE_ROOT_OVERRIDE) {

--- a/src/utilities/url-params.ts
+++ b/src/utilities/url-params.ts
@@ -22,6 +22,8 @@ export interface QueryParams {
   token?: string;
   // The domain of the portal opening the app
   domain?: string;
+  // the user ID of the user launching from the portal domain
+  domain_uid?: string;
 
   // If this exists then the demo ui is shown
   demo?: boolean;


### PR DESCRIPTION
When we detect a launch via the `Preview` button in the portal, we put the user in demo mode as the only student in their own personal class. FYI @scytacki .