### PR TITLE
Fix sensor/relay message when device is missing

### DIFF
--- a/src/dataflow/components/nodes/controls/relay-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/relay-select-control.tsx
@@ -57,7 +57,8 @@ export class RelaySelectControl extends Rete.Control {
       const getChannelString = (ch?: NodeChannelInfo | "none") => {
         if (!ch && (!id || id === "none")) return kRelaySelectMessage;
         if (ch === "none") return "None Available";
-        if (!ch || ch.missing) return `${kRelayMissingMessage} ${id}`;
+        if (!ch) return `${kRelayMissingMessage} ${id}`;
+        if (ch.missing) return `${kRelayMissingMessage} ${ch.channelId}`;
         let count = 0;
         channelsForType.forEach( c => { if (c.type === ch.type && ch.hubId === c.hubId) count++; } );
         return `${ch.hubName}:${ch.type}${ch.plug > 0 && count > 1 ? `(plug ${ch.plug})` : ""}`;
@@ -94,7 +95,7 @@ export class RelaySelectControl extends Rete.Control {
                 onMouseDown={onListOptionClick(ch ? ch.channelId : null)}
               >
                 <div className="label">
-                  {(ch.missing ? `${kRelayMissingMessage} ` : "") + getChannelString(ch)}
+                  {getChannelString(ch)}
                 </div>
               </div>
             ))}

--- a/src/dataflow/components/nodes/controls/sensor-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/sensor-select-control.tsx
@@ -135,7 +135,8 @@ export class SensorSelectControl extends Rete.Control {
       const getChannelString = (ch?: NodeChannelInfo | "none") => {
         if (!ch && (!id || id === "none")) return kSensorSelectMessage;
         if (ch === "none") return "None Available";
-        if (!ch || ch.missing) return `${kSensorMissingMessage} ${id}`;
+        if (!ch) return `${kSensorMissingMessage} ${id}`;
+        if (ch.missing) return `${kSensorMissingMessage} ${ch.channelId}`;
         let count = 0;
         channelsForType.forEach( c => { if (c.type === ch.type && ch.hubId === c.hubId) count++; } );
         return `${ch.hubName}:${ch.type}${ch.plug > 0 && count > 1 ? `(plug ${ch.plug})` : ""}`;
@@ -175,7 +176,7 @@ export class SensorSelectControl extends Rete.Control {
                 onMouseDown={onListOptionClick(ch ? ch.channelId : null)}
               >
                 <div className="label">
-                  {(ch.missing ? `${kSensorMissingMessage} ` : "") + getChannelString(ch)}
+                  {getChannelString(ch)}
                 </div>
               </div>
             ))}


### PR DESCRIPTION
The message in the node dropdown list that reported the status of a missing sensor/relay was incorrect.  This PR fixes it for sensor and relay nodes.