### PR TITLE
Handle page-reload without short-term token [#170242178]

### DIFF
--- a/src/utilities/url-params.ts
+++ b/src/utilities/url-params.ts
@@ -85,3 +85,10 @@ export const DefaultUrlParams: QueryParams = {
 };
                                                     // allows use of ?demo for url
 export const urlParams: QueryParams = { ...params, ...{ demo: typeof params.demo !== "undefined" } };
+
+// adapted from Geniventure/geniblocks
+export function removeUrlParameter(param: string) {
+  const regExp = new RegExp(param + "(.+?)(&|$)", "g");
+  const newUrl = window.location.href.replace(regExp, "");
+  window.history.replaceState("", "", newUrl);
+}


### PR DESCRIPTION
Note: Not ready for review yet. It appears that there's more work to be done.

Store rawPortalJWT to sessionStorage; use rawPortalJWT from sessionStorage if one is available [#170242178]

Note: This should _not_ go into the next (3.0.3) build so we have more time to test it for the subsequent (3.0.4) build.