### PR TITLE
Remove all devices when user presses refresh button

### DIFF
--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -857,7 +857,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
     .then(ok => {
       if (ok) {
         const { iot } = this.stores;
-        iot.requestAllHubsChannelInfo();
+        iot.refreshAllHubsChannelInfo();
       }
     });
   }

--- a/src/dataflow/lib/iot.ts
+++ b/src/dataflow/lib/iot.ts
@@ -81,9 +81,11 @@ export class IoT {
     }
   }
 
-  public requestAllHubsChannelInfo() {
+  public refreshAllHubsChannelInfo() {
     const  { hubStore } = this.stores;
     hubStore.hubs.forEach(hub => {
+      hub.removeAllHubChannels();
+      hub.setHubUpdateTime(Date.now());
       this.requestHubChannelInfo(hub.hubId);
     });
   }


### PR DESCRIPTION
Clear hub channels when user presses the refresh button - this guarantees that we update the full list of channels and remove and missing channels from hub stores.