### PR TITLE
Fix cover top position

### DIFF
--- a/src/dataflow/components/dataflow-program-cover.sass
+++ b/src/dataflow/components/dataflow-program-cover.sass
@@ -10,8 +10,6 @@
     align-items: center
     justify-content: center
     top: 0px
-    &.running
-      top: $dataflow-topbar-height
     &.half
       width: 50%
     &.some


### PR DESCRIPTION
Fix top position of program cover.  Note, that I'm still leaving the `running` class on the cover div (even though it no longer modifies the div) since I have a hunch that it could end up being useful if there are future changes to how we display the program editor (which based on how many times we've changed this so far, I assume there will be more changes moving forward).