### PR TITLE
Add additional null tests in firebase document handling

### DIFF
--- a/src/lib/db-listeners/db-problem-documents-listener.ts
+++ b/src/lib/db-listeners/db-problem-documents-listener.ts
@@ -68,8 +68,10 @@ export class DBProblemDocumentsListener extends BaseListener {
   }
 
   private handleOfferingUser = (user: DBOfferingUser) => {
+    if (!user?.self?.uid) return;
     const { documents, user: currentUser, groups } = this.db.stores;
     forEach(user.documents, document => {
+      if (!document?.documentKey || !document?.self?.uid) return;
       const existingDoc = documents.getDocument(document.documentKey);
       if (existingDoc) {
         this.db.updateDocumentFromProblemDocument(existingDoc, document);

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -241,7 +241,7 @@ export class DB {
       const problemDocuments: DBOfferingUserProblemDocumentMap = problemDocumentsSnapshot &&
                                                                   problemDocumentsSnapshot.val();
       const lastProblemDocument = findLast(problemDocuments, () => true);
-      return lastProblemDocument
+      return lastProblemDocument?.documentKey
               ? this.openProblemDocument(lastProblemDocument.documentKey)
               : this.createProblemDocument(defaultContent);
     }
@@ -255,7 +255,7 @@ export class DB {
     const personalDocuments: DBOtherDocumentMap = personalDocumentsSnapshot &&
                                                   personalDocumentsSnapshot.val();
     const lastPersonalDocument = findLast(personalDocuments, (pd) => !pd.properties || !pd.properties.isDeleted);
-    return lastPersonalDocument
+    return lastPersonalDocument?.self?.documentKey
       ? this.openOtherDocument(PersonalDocument, lastPersonalDocument.self.documentKey)
       : this.createPersonalDocument({ content: defaultContent });
   }
@@ -271,7 +271,7 @@ export class DB {
     const learningLogDocuments: DBOtherDocumentMap = learningLogDocumentsSnapshot &&
                                                   learningLogDocumentsSnapshot.val();
     const lastLearningLogDocument = findLast(learningLogDocuments, () => true);
-    return lastLearningLogDocument
+    return lastLearningLogDocument?.self?.documentKey
       ? this.openOtherDocument(LearningLogDocument, lastLearningLogDocument.self.documentKey)
       : this.createOtherDocument(LearningLogDocument, { title: initialTitle, content: defaultContent });
   }


### PR DESCRIPTION
We recently encountered a situation in which users in `CLUE` `democlass1` were unable to open MSA problem 1.3 due to some offering-specific corruption. Specifically, user `1` was missing some required metadata (the `self` field) as was this user's problem document for this problem. When the code attempted to load this corrupted document it halted the application. The fix here is to simply ignore users and documents that lack required metadata.