### PR TITLE
Show recent teacher supports at top [#171003815]

### DIFF
--- a/src/clue/components/teacher/teacher-supports.tsx
+++ b/src/clue/components/teacher/teacher-supports.tsx
@@ -25,9 +25,7 @@ export class TeacherSupports extends BaseComponent<IProps, IState> {
         { this.renderHeader() }
         <TeacherSupport time={new Date().getTime()} audience={audience}/>
           {
-            // Reverse the supports so the newest ones are first + displayed at the top
-            supports.slice()
-              .reverse()
+            supports
               .map((support, i) => {
                 return <TeacherSupport
                   support={support}


### PR DESCRIPTION
We had been reversing supports explicitly so that the most recent would be at the top. After recently changing it so that all documents are reversed to put the most recent at the top, the supports were being double-reversed into the wrong order.