### PR TITLE
SPIKE: Enable default JSXGraph zoom controls

### DIFF
--- a/src/models/tools/geometry/jxg-board.ts
+++ b/src/models/tools/geometry/jxg-board.ts
@@ -149,7 +149,7 @@ function createBoard(domElementId: string, properties?: JXGProperties) {
   const defaults = {
           keepaspectratio: true,
           showCopyright: false,
-          showNavigation: false,
+          // showNavigation: false,
           minimizeReflow: "none"
         };
   const changeProps = properties && properties as JXGProperties;


### PR DESCRIPTION
Simply enables the default axis zoom/translate controls built in to JSXGraph. There are examples in the blog post [JSXGraph axes, ticks and grids](https://www.intmath.com/cg3/jsxgraph-axes-ticks-grids.php) of how the axes can be constrained to more reasonable behavior with additional coding effort.