### PR TITLE
Typesafe scss imports

### DIFF
--- a/src/components/tools/link-indicator.scss.d.ts
+++ b/src/components/tools/link-indicator.scss.d.ts
@@ -1,0 +1,10 @@
+// cf. https://mattferderer.com/use-sass-variables-in-typescript-and-javascript
+
+export interface ILinkIndicatorStyleExports {
+  linkIndicatorRightOffset: string;
+  linkIndicatorWidth: string;
+}
+
+export const styles: ILinkIndicatorStyleExports;
+
+export default styles;

--- a/src/components/tools/link-indicator.tsx
+++ b/src/components/tools/link-indicator.tsx
@@ -3,10 +3,8 @@ import SvgLinkedTileIcon from "../../assets/icons/linked-tile-icon";
 import { getTableLinkColors } from "../../models/tools/table-links";
 import { IconButtonSvg } from "../utilities/icon-button-svg";
 
-// It should be possible to use a standard import and get TypeScript types
-// (cf. https://mattferderer.com/use-sass-variables-in-typescript-and-javascript).
-// See comment in `typings.d.ts` for details.
-const styles = require("./link-indicator.scss");
+// cf. https://mattferderer.com/use-sass-variables-in-typescript-and-javascript
+import styles from "./link-indicator.scss";
 
 interface IProps {
   id: string;

--- a/src/models/tools/table-links.scss.d.ts
+++ b/src/models/tools/table-links.scss.d.ts
@@ -1,0 +1,20 @@
+// cf. https://mattferderer.com/use-sass-variables-in-typescript-and-javascript
+
+export interface ITableLinksStyleExports {
+  linkColor0Light: string;
+  linkColor0Dark: string;
+  linkColor1Light: string;
+  linkColor1Dark: string;
+  linkColor2Light: string;
+  linkColor2Dark: string;
+  linkColor3Light: string;
+  linkColor3Dark: string;
+  linkColor4Light: string;
+  linkColor4Dark: string;
+  linkColor5Light: string;
+  linkColor5Dark: string;
+}
+
+export const styles: ITableLinksStyleExports;
+
+export default styles;

--- a/src/models/tools/table-links.ts
+++ b/src/models/tools/table-links.ts
@@ -1,9 +1,7 @@
 import { IObservableArray, observable } from "mobx";
 
-// It should be possible to use a standard import and get TypeScript types
-// (cf. https://mattferderer.com/use-sass-variables-in-typescript-and-javascript).
-// See comment in `typings.d.ts` for details.
-const styles = require("./table-links.scss");
+// cf. https://mattferderer.com/use-sass-variables-in-typescript-and-javascript
+import styles from "./table-links.scss";
 
 const sTableDocumentMap: Map<string, string> = new Map();
 type LinkedTableIds = IObservableArray<string>;

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1,14 +1,3 @@
 // declare modules that don't have TypeScript bindings here
 
 declare module "slate-md-serializer";
-
-// Allow untyped imports from SASS files. Typed imports should be possible
-// (cf. https://mattferderer.com/use-sass-variables-in-typescript-and-javascript),
-// but I couldn't get this to work, likely because of our tsconfig settings.
-// Current recommendations are to use `module: es6/esnext`, `moduleResolution: node`,
-// and `esModuleInterop: true`, but that would require code changes to all of our
-// "import * as foo" imports. To get the types to work, the following line should be
-// removed and individualized types declared.
-// Note also that we use the ".scss" format rather than the ".sass" format because
-// the `:export` syntax seems not to be supported in ".sass" files.
-declare module "*.scss";


### PR DESCRIPTION
Now that we've updated our TSConfig settings, we can implement type-safe sharing of values between SCSS and TS as described in [Use Sass Variables In TypeScript & JavaScript](https://mattferderer.com/use-sass-variables-in-typescript-and-javascript).