### PR TITLE
Uncontested logging improvements [#171218617]

### DIFF
--- a/src/lib/logger.test.ts
+++ b/src/lib/logger.test.ts
@@ -1,6 +1,7 @@
 import mock from "xhr-mock";
 import { Logger, LogEventName } from "./logger";
 import { ProblemDocument, DocumentModel, DocumentModelType } from "../models/document/document";
+import { AppConfigModel } from "../models/stores/app-config-model";
 import { DocumentContentModel } from "../models/document/document-content";
 import { InvestigationModel } from "../models/curriculum/investigation";
 import { IStores, createStores } from "../models/stores/stores";
@@ -24,6 +25,7 @@ describe("logger", () => {
     mock.setup();
     stores = createStores({
       appMode: "test",
+      appConfig: AppConfigModel.create({ appName: "TestLogger"}),
       user: UserModel.create({id: "0", portal: "test"})
     });
 
@@ -42,7 +44,7 @@ describe("logger", () => {
 
         const request = JSON.parse(req.body());
 
-        expect(request.application).toBe("CLUE");
+        expect(request.application).toBe("TestLogger");
         expect(request.username).toBe("0@test");
         expect(request.investigation).toBe("Investigation 1");
         expect(request.problem).toBe("Problem 1.1");

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -5,14 +5,12 @@ import { IStores } from "../models/stores/stores";
 import { InvestigationModelType } from "../models/curriculum/investigation";
 import { ProblemModelType } from "../models/curriculum/problem";
 import { DocumentModelType } from "../models/document/document";
-import { GroupVirtualDocument } from "../models/document/group-virtual-document";
 import { JXGChange } from "../models/tools/geometry/jxg-changes";
 import { DrawingToolChange } from "../models/tools/drawing/drawing-content";
 import { ITableChange } from "../models/tools/table/table-content";
 import { DEBUG_LOGGER } from "../lib/debug";
 
 const logManagerUrl = "//cc-log-manager.herokuapp.com/api/logs";
-const applicationName = "CLUE";
 
 interface LogMessage {
   application: string;
@@ -162,7 +160,7 @@ export class Logger {
       documentKey: document.key,
       documentType: document.type,
       documentTitle: document.title || "",
-      documentProperties: document.properties && document.properties.toJSON() || {},
+      documentProperties: document.properties?.toJSON() || {},
       documentVisibility: document.visibility
     };
     Logger.log(event, parameters);
@@ -210,10 +208,10 @@ export class Logger {
     parameters?: {section?: string},
     method: LogEventMethod = LogEventMethod.DO
   ): LogMessage {
-    const {user} = this.stores;
+    const {appConfig, user} = this.stores;
 
     const logMessage: LogMessage = {
-      application: applicationName,
+      application: appConfig.appName,
       username:  `${user.id}@${user.portal}`,
       role: user.type || "unknown",
       classHash: user.classHash,

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -18,6 +18,7 @@ interface LogMessage {
   application: string;
   run_remote_endpoint?: string;
   username: string;
+  role: string;
   classHash: string;
   session: string;
   appMode: string;
@@ -209,11 +210,12 @@ export class Logger {
     parameters?: {section?: string},
     method: LogEventMethod = LogEventMethod.DO
   ): LogMessage {
-    const {user, ui, documents} = this.stores;
+    const {user} = this.stores;
 
     const logMessage: LogMessage = {
       application: applicationName,
       username:  `${user.id}@${user.portal}`,
+      role: user.type || "unknown",
       classHash: user.classHash,
       session: this.session,
       appMode: this.stores.appMode,


### PR DESCRIPTION
- log user role with each log message
- pull application name from configuration so CLUE logs as application `CLUE` and Dataflow logs as application `Dataflow`
