### PR TITLE
Release 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Version 1.1.1 - released February 18, 2020
+
+- Log user role
+- Fix tile drags to existing row
+- Fix table selection bug
+- Fix geometry drag bug
+
+### Asset Sizes
+
+| File | Size | % Change from Previous Release |
+|---|---|---|
+| index.css | 518,038 bytes | 0.0% |
+| index.js | 4,136,755 bytes | 0.0% |
+
 ## Version 1.1.0 - released February 10, 2020
 
 - User-editable table title row

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "collaborative-learning",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collaborative-learning",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Collaborative Learning environment",
   "main": "index.js",
   "config": {


### PR DESCRIPTION
## Version 1.1.1 - released February 18, 2020

- Log user role
- Fix tile drags to existing row
- Fix table selection bug
- Fix geometry drag bug

### Asset Sizes

| File | Size | % Change from Previous Release |
|---|---|---|
| index.css | 518,038 bytes | 0.0% |
| index.js | 4,136,755 bytes | 0.0% |
