### PR TITLE
Prevent tile drops on section header rows [#171362427]

### DIFF
--- a/src/components/document/tile-row.tsx
+++ b/src/components/document/tile-row.tsx
@@ -73,7 +73,10 @@ export class TileRowComponent extends BaseComponent<IProps, IState> {
   public render() {
     const { model } = this.props;
     const { isSectionHeader, sectionId } = model;
-    const height = this.props.height || model.height;
+    // ignore height setting for section header rows
+    const height = !isSectionHeader
+                      ? this.props.height || model.height
+                      : undefined;
     const style = height ? { height } : undefined;
     return (
       <div className={`tile-row`} data-row-id={model.id}

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -746,7 +746,8 @@ export const DocumentContentModel = types
       self.moveTiles(tiles, rowInfo);
     },
     userCopyTiles(tiles: IDragTileItem[], rowInfo: IDropRowInfo) {
-      const results = rowInfo.rowDropIndex != null
+      const dropRow = (rowInfo.rowDropIndex != null) && self.getRowByIndex(rowInfo.rowDropIndex);
+      const results = dropRow && dropRow.acceptsTileDrops
                         ? self.copyTilesIntoExistingRow(tiles, rowInfo)
                         : self.copyTilesIntoNewRows(tiles, rowInfo.rowInsertIndex);
       results.forEach((result, i) => {

--- a/src/models/document/tile-row.ts
+++ b/src/models/document/tile-row.ts
@@ -38,6 +38,9 @@ export const TileRowModel = types
     get isUserResizable() {
       return !self.isSectionHeader && self.tiles.some(tileRef => tileRef.isUserResizable);
     },
+    get acceptsTileDrops() {
+      return !self.isSectionHeader;
+    },
     get tileIds() {
       return self.tiles.map(tile => tile.tileId).join(", ");
     },


### PR DESCRIPTION
Ignore explicit height for section header rows (prevent glitchy box from showing)
