### PR TITLE
Support page reload after token expiration [#170242178]

### DIFF
--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -96,6 +96,10 @@ const PARTIAL_RAW_OFFERING_INFO = {
   activity_url: "https://foo.bar/?problem=3.2"
 };
 
+beforeEach(() => {
+  window.sessionStorage.clear();
+});
+
 describe("dev mode", () => {
   it("should be in dev mode on a local machine", () => {
     const mode = getAppMode(undefined, undefined, "localhost");

--- a/src/utilities/url-params.ts
+++ b/src/utilities/url-params.ts
@@ -81,3 +81,10 @@ export const DefaultUrlParams: QueryParams = {
 };
                                                     // allows use of ?demo for url
 export const urlParams: QueryParams = { ...params, ...{ demo: typeof params.demo !== "undefined" } };
+
+// adapted from Geniventure/geniblocks
+export function removeUrlParameter(param: string) {
+  const regExp = new RegExp(param + "(.+?)(&|$)", "g");
+  const newUrl = window.location.href.replace(regExp, "");
+  window.history.replaceState("", "", newUrl);
+}


### PR DESCRIPTION
Store rawPortalJWT and rawFirebaseJWT to sessionStorage; use JWTs from sessionStorage if they are available [#170242178]

Refactor/simplify `authenticate()` function using async/await