### PR TITLE
Store teacher supports as cross-class supports in firestore

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "collaborative-learning-ec215"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -48,13 +48,31 @@ To deploy a production release:
 1. Push production to GitHub
 1. Use https://github.com/concord-consortium/collaborative-learning/releases to create a new release tag
 
-### Debugging
+## Deploying database rules:
+
+### Requirements:
+
+ * You should install the firebase CLI via: `npm install -g firebase-tools`
+ * You shouuld be logged in to firebase: `firebase login`
+
+You deploy firebase functions and rules directly from the working directory using
+the `firebase deploy` command. You can see `firebase deploy help` for more info.
+
+See which project you have access to and which you are currently using via: `firebase projects:list`
+
+### To deploy database rules:
+```
+$ npm run deploy:firestore:rules    # deploys firestore rules
+$ npm run deploy:firebase:rules     # deploys firebase (real-time-database) rules
+```
+
+## Debugging
 
 To enable per component debugging set the "debug" localstorage key with one or more of the following:
 
 - `canvas` this will show the document key over the canvas, useful for looking up documents in Firebase
 
-### Testing
+## Testing
 
 Run `npm test` to run all Jest tests.
 
@@ -66,19 +84,19 @@ Along with `dev`, `test`, `authed` and `demo` modes the app has a `qa` mode.  QA
 2. qaClear - either "all", "class" or "offering".  When this parameter is present the QA database is cleared at the level requested based on the user parameters.
    This is useful to clear data between automated QA runs.  When complete the app will display `<span className="qa-clear">QA Cleared: OK</span>`.
 
-###To run Cypress integration tests:
+### To run Cypress integration tests:
 - `npm run test:local`
 - `npm run test:dev`
 - `npm run test:branch` (requires change in environments.json to add the branch name)
 - `npm run test:master`
 - `npm run test:production`
 
-## Additional notes about configuration
+### Additional notes about configuration
 
 You can also temporarily overwrite any configuration option using env variables with `CYPRESS_` prefix. E.g.:
 - `CYPRESS_baseUrl=https://collaborative-learning.concord.org/branch/fix-data-attributes npm run test:dev`
 
-## Writing tests, workflow and patterns
+### Writing tests, workflow and patterns
 
 1. Tests should not depend on other tests.
 2. Take a look at `cypress/support/commands.js`. This file implements LARA-specific helpers that will make test

--- a/database.rules.json
+++ b/database.rules.json
@@ -1,0 +1,76 @@
+{
+  "rules": {
+    "test": {
+      ".read": "auth !== null",
+      ".write": "auth !== null"
+    },
+    "dev": {
+      ".read": "auth !== null",
+      ".write": "auth !== null"
+    },
+    "demo": {
+      ".read": "auth !== null",
+      ".write": "auth !== null"
+    },
+    "qa": {
+      ".read": "auth !== null",
+      ".write": "auth !== null"
+    },
+    "authed": {
+      "portals": {
+        "learn_concord_org": {
+          "classes": {
+            "$class_hash": {
+              ".read": "auth != null && auth.class_hash == $class_hash",
+              ".write": "auth != null && auth.class_hash == $class_hash",
+              "users": {
+                "$user_id": {
+                  "latestGroupId": {
+                    ".read": "auth !== null",
+                    ".write": "auth !== null"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "learn_staging_concord_org": {
+          "classes": {
+            "$class_hash": {
+              ".read": "auth != null && auth.class_hash == $class_hash",
+              ".write": "auth != null && auth.class_hash == $class_hash",
+              "users": {
+                "$user_id": {
+                  "latestGroupId": {
+                    ".read": "auth !== null",
+                    ".write": "auth !== null"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "authed-copy": {
+      "portals": {
+        "learn_concord_org": {
+          "classes": {
+            "$class_hash": {
+              ".read": "auth != null && auth.class_hash == $class_hash",
+              ".write": "auth != null && auth.class_hash == $class_hash"
+            }
+          }
+        },
+        "learn_staging_concord_org": {
+          "classes": {
+            "$class_hash": {
+              ".read": "auth != null && auth.class_hash == $class_hash",
+              ".write": "auth != null && auth.class_hash == $class_hash"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,20 @@
+{
+  "database": {
+    "rules": "database.rules.json"
+  },
+  "firestore": {
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
+  },
+  "emulators": {
+    "firestore": {
+      "port": 8088
+    },
+    "database": {
+      "port": 9000
+    },
+    "ui": {
+      "enabled": true
+    }
+  }
+}

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,19 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "docs",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        {
+          "fieldPath": "classes",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "problem",
+          "order": "ASCENDING"
+        }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -37,6 +37,11 @@ service cloud.firestore {
       return hasUserId() && hasRole("teacher");
     }
 
+    function requestMatchUserId() {
+      return isAuthed() &&
+        string(request.auth.token.platform_user_id) == request.resource.data.uid;
+    }
+
     function docMatchUserId() {
       return isAuthed() &&
         string(request.auth.token.platform_user_id) == resource.data.uid;
@@ -54,9 +59,9 @@ service cloud.firestore {
 
         match /mcsupports/{docId} {
           // any portal-authenticated teacher can create supports
-          allow create: if isAuthedTeacher();
+          allow create: if isAuthedTeacher() && requestMatchUserId();
           // teachers can only update/delete their own supports
-          allow update, delete: if docMatchUserId();
+          allow update, delete: if requestMatchUserId() && docMatchUserId();
           // teachers and students in appropriate classes can read supports
           allow read: if docMatchUserId() || classInClasses();
         }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,91 @@
+// NOTE: to deploy only these rules run
+// `npm run deploy:firestore:rules`
+
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    function isAuthed() {
+      return request.auth != null;
+    }
+
+    // function hasClass() {
+    //   return isAuthed() && request.auth.token.class_hash != null;
+    // }
+
+    // function hasClassHash(classHash) {
+    //   return request.auth.token.class_hash == classHash;
+    // }
+
+    function hasRole(role) {
+      return isAuthed() && request.auth.token.user_type == role;
+    }
+
+    function hasUserId() {
+      return isAuthed() && request.auth.token.platform_user_id != null;
+    }
+
+    // function matchUserId(userId) {
+    //   return hasUserId() && string(request.auth.token.platform_user_id) == userId;
+    // }
+
+    function matchFirebaseUserId(userId) {
+      return isAuthed() && request.auth.uid == userId;
+    }
+
+    function isAuthedTeacher() {
+      return hasUserId() && hasRole("teacher");
+    }
+
+    function docMatchUserId() {
+      return isAuthed() &&
+        string(request.auth.token.platform_user_id) == resource.data.uid;
+    }
+
+    function classInClasses() {
+      return isAuthed() && request.auth.token.class_hash in resource.data.classes;
+    }
+
+    //
+    // portal-authenticated secure access rules
+    //
+    match /authed/{portal} {
+      allow read, write: if isAuthedTeacher();
+
+        match /mcsupports/{docId} {
+          // any portal-authenticated teacher can create supports
+          allow create: if isAuthedTeacher();
+          // teachers can only update/delete their own supports
+          allow update, delete: if docMatchUserId();
+          // teachers and students in appropriate classes can read supports
+          allow read: if docMatchUserId() || classInClasses();
+        }
+    }
+
+    //
+    // non-portal-authenticated/dev/demo/qa/test rules
+    //
+    match /demo/{demoName}/{restOfPath=**} {
+      allow read, write: if isAuthed();
+    }
+
+    match /dev/{userId}/{restOfPath=**} {
+      allow read: if isAuthed();
+      // users can only write to their own folders
+      allow write: if matchFirebaseUserId(userId);
+    }
+
+    match /qa/{userId}/{restOfPath=**} {
+      allow read: if isAuthed();
+      // users can only write to their own folders
+      allow write: if matchFirebaseUserId(userId);
+    }
+
+    match /test/{userId}/{restOfPath=**} {
+      allow read: if isAuthed();
+      // users can only write to their own folders
+      allow write: if matchFirebaseUserId(userId);
+    }
+
+  }
+}

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "build:debug": "npm-run-all lint clean build:webpack",
     "build:webpack": "cross-env NODE_OPTIONS=--max_old_space_size=4096 webpack --mode production",
     "clean": "rimraf dist",
+    "deploy:database:rules": "firebase deploy --only database",
+    "deploy:firestore:rules": "firebase deploy --only firestore:rules",
     "lint": "eslint \"./src/**/*.{js,json,jsx,ts,tsx}\"",
     "lint:build": "eslint -c \".eslintrc.build.js\" \"./src/**/*.{js,json,jsx,ts,tsx}\"",
     "lint:fix": "eslint --fix \"./src/**/*.{js,json,jsx,ts,tsx}\"",

--- a/src/components/class-menu-container.tsx
+++ b/src/components/class-menu-container.tsx
@@ -4,6 +4,7 @@ import { inject, observer } from "mobx-react";
 import { BaseComponent, IBaseProps } from "./base";
 import { LogEventName, Logger, LogEventMethod } from "../lib/logger";
 import { DropDown, IDropdownItem } from "@concord-consortium/react-components";
+import { getProblemOrdinal } from "../models/stores/stores";
 
 interface IProps extends IBaseProps {}
 
@@ -23,7 +24,7 @@ export class ClassMenuContainer extends BaseComponent <IProps> {
   }
 
   private getCurrentProblemOrdinal() {
-    const { appConfig, user: { offeringId, portalClassOfferings } } = this.stores;
+    const { appConfig, appMode, user: { offeringId, portalClassOfferings } } = this.stores;
     if (offeringId) {
       const currentOffering = portalClassOfferings.find( offering => {
         return (offering.offeringId === offeringId);
@@ -32,8 +33,10 @@ export class ClassMenuContainer extends BaseComponent <IProps> {
         return currentOffering.problemOrdinal;
       }
     }
-    console.warn(`Warning -- current offering not found. (Maybe in demo mode?)`);
-    return appConfig.defaultProblemOrdinal;
+    if (appMode === "authed") {
+      console.warn(`Warning -- current offering not found. (Maybe in demo mode?)`);
+    }
+    return getProblemOrdinal(this.stores) || appConfig.defaultProblemOrdinal;
   }
 
   private getPortalClasses() {

--- a/src/components/document/document-workspace.tsx
+++ b/src/components/document/document-workspace.tsx
@@ -6,11 +6,9 @@ import { RightNavComponent } from "../../components/navigation/right-nav";
 import { DocumentComponent } from "../../components/document/document";
 import { GroupVirtualDocumentComponent } from "../../components/document/group-virtual-document";
 import { BaseComponent, IBaseProps } from "../../components/base";
-import { kAllSectionType } from "../../models/curriculum/section";
 import { DocumentDragKey, DocumentModel, DocumentModelType, LearningLogDocument, OtherDocumentType,
          PersonalDocument, ProblemDocument } from "../../models/document/document";
 import { DocumentContentModel } from "../../models/document/document-content";
-import { AudienceModelType, ClassAudienceModel, SectionTarget } from "../../models/stores/supports";
 import { parseGhostSectionDocumentKey } from "../../models/stores/workspace";
 import { ImageDragDrop } from "../utilities/image-drag-drop";
 
@@ -373,7 +371,7 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps> {
     return match && match[1] ? match[1] : title;
   }
 
-  private getSupportDocumentBaseCaption(document: DocumentModelType, sectionTarget: SectionTarget) {
+  private getSupportDocumentBaseCaption(document: DocumentModelType) {
     return document.type === ProblemDocument
             ? this.getProblemBaseTitle(this.stores.problem.title)
             : document.title;
@@ -381,12 +379,11 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps> {
 
   private handlePublishSupport = async (document: DocumentModelType) => {
     const { db, ui } = this.stores;
-    const audience: AudienceModelType = ClassAudienceModel.create();
-    const sectionTarget: SectionTarget = kAllSectionType;
-    const caption = this.getSupportDocumentBaseCaption(document, sectionTarget) || "Untitled";
+    const caption = this.getSupportDocumentBaseCaption(document) || "Untitled";
     // TODO: Disable publish button while publishing
-    db.publishDocumentAsSupport(document, audience, sectionTarget, caption)
-      .then(() => ui.alert("Your support was published.", "Support Published"));
+    db.publishDocumentAsSupport(document, caption)
+      .then(() => ui.alert("Your support was published.", "Support Published"))
+      .catch((reason) => ui.alert(`Your support failed to publish: ${reason}`, "Error"));
   }
 
   private handlePublishDocument = (document: DocumentModelType) => {

--- a/src/components/document/document.tsx
+++ b/src/components/document/document.tsx
@@ -1,4 +1,5 @@
 import { inject, observer } from "mobx-react";
+import { autorun, IReactionDisposer } from "mobx";
 import React from "react";
 import FileSaver from "file-saver";
 
@@ -180,6 +181,7 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
   private toolApiInterface: IToolApiInterface;
   private stickyNoteIcon: HTMLDivElement | null;
   private documentContainer: HTMLDivElement | null;
+  private deleteHandler: { documentKey?: string, disposer?: IReactionDisposer } = {};
 
   constructor(props: IProps) {
     super(props);
@@ -203,6 +205,18 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
     };
   }
 
+  public componentDidMount() {
+    this.configureDeleteHandler();
+  }
+
+  public componentDidUpdate() {
+    this.configureDeleteHandler();
+  }
+
+  public componentWillUnmount() {
+    this.deleteHandler.disposer?.();
+  }
+
   public render() {
     const { document: { type } } = this.props;
     return (
@@ -216,6 +230,23 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
         </div>
       </DocumentContext.Provider>
     );
+  }
+
+  private configureDeleteHandler() {
+    const { deleteHandler, props: { document, side }, stores } = this;
+    if (document.key !== deleteHandler.documentKey) {
+      // dispose any previous delete handler
+      deleteHandler.disposer?.();
+      // install delete handler for current document
+      deleteHandler.disposer = autorun(reaction => {
+        const isDeleted = document.getProperty("isDeleted");
+        // close comparison when comparison document is deleted
+        if (isDeleted && (side === "comparison")) {
+          const { ui: { problemWorkspace } } = stores;
+          problemWorkspace.toggleComparisonVisible({ override: false, muteLog: true });
+        }
+      });
+    }
   }
 
   private renderTitleBar(type: string) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,7 @@
 import "ts-polyfill";
 
 import { Provider } from "mobx-react";
+// https://github.com/mobxjs/mobx-react#observer-batching
 import "mobx-react/batchingForReactDom";
 import React from "react";
 import ReactDOM from "react-dom";
@@ -15,7 +16,7 @@ import { Logger } from "./lib/logger";
 import { setPageTitle } from "./lib/misc";
 import { gImageMap } from "./models/image-map";
 import PackageJson from "../package.json";
-import { setLivelynessChecking } from "mobx-state-tree";
+import { setLivelinessChecking } from "mobx-state-tree";
 // set to true to enable MST liveliness checking
 const kEnableLivelinessChecking = false;
 
@@ -45,7 +46,7 @@ const initializeApp = async () => {
   Logger.initializeLogger(stores, stores.investigation, stores.problem);
 
   if (kEnableLivelinessChecking) {
-    setLivelynessChecking("error");
+    setLivelinessChecking("error");
   }
 
   setPageTitle(stores);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,7 @@
 import "ts-polyfill";
 
 import { Provider } from "mobx-react";
+import "mobx-react/batchingForReactDom";
 import React from "react";
 import ReactDOM from "react-dom";
 import { appConfigSpec, createStores } from "./app-config";

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -146,6 +146,7 @@ export interface PortalUserJWT extends BasePortalJWT {
   last_name: string;
 }
 
+// firebase JWT claims are available to firestore security rules under request.auth.token
 export interface PortalFirebaseJWTBaseClaims {
   user_id: string;          // e.g. `https://learn.concord.org/users/${platform_user_id}`
   class_hash: string;
@@ -158,7 +159,6 @@ export interface PortalFirebaseJWTStudentClaims extends PortalFirebaseJWTBaseCla
   offering_id: number;
 }
 
-// these properties are available to firestore security rules under request.auth.token
 export interface PortalFirebaseJWTTeacherClaims {
   user_type: "teacher";
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -146,16 +146,21 @@ export interface PortalUserJWT extends BasePortalJWT {
   last_name: string;
 }
 
-export interface PortalFirebaseJWTStudentClaims {
-  user_type: "learner";
-  user_id: string;
+export interface PortalFirebaseJWTBaseClaims {
+  user_id: string;          // e.g. `https://learn.concord.org/users/${platform_user_id}`
   class_hash: string;
+  platform_id: string;      // e.g. "https://learn.concord.org"
+  platform_user_id: number;
+}
+
+export interface PortalFirebaseJWTStudentClaims extends PortalFirebaseJWTBaseClaims {
+  user_type: "learner";
   offering_id: number;
 }
+
+// these properties are available to firestore security rules under request.auth.token
 export interface PortalFirebaseJWTTeacherClaims {
   user_type: "teacher";
-  user_id: string;
-  class_hash: string;
 }
 
 export type PortalFirebaseJWTClaims = PortalFirebaseJWTStudentClaims | PortalFirebaseJWTTeacherClaims;

--- a/src/lib/db-listeners/db-supports-listener.ts
+++ b/src/lib/db-listeners/db-supports-listener.ts
@@ -149,7 +149,7 @@ export class DBSupportsListener extends BaseListener {
     });
     if (teacherSupports.length === 0) return;
 
-    const {supports} = this.db.stores;
+    const { supports } = this.db.stores;
     supports.addAuthoredSupports(teacherSupports, AudienceEnum.class);
 
     const { unit, investigation, problem, documents, user } = this.db.stores;

--- a/src/lib/db-listeners/db-supports-listener.ts
+++ b/src/lib/db-listeners/db-supports-listener.ts
@@ -5,6 +5,7 @@ import { SupportTarget, TeacherSupportModel, TeacherSupportModelType, ClassAudie
 import { DBSupport } from "../db-types";
 import { SectionType } from "../../models/curriculum/section";
 import { ESupportType, SupportModel } from "../../models/curriculum/support";
+import { getProblemPath } from "../../models/stores/stores";
 import { BaseListener } from "./base-listener";
 import { isAlive } from "mobx-state-tree";
 
@@ -23,12 +24,18 @@ export class DBSupportsListener extends BaseListener {
 
   // TODO: Create different listeners for support audiences
   public start() {
+    const { user } = this.db.stores;
     this.supportsRef = this.db.firebase.ref(
-      this.db.firebase.getSupportsPath(this.db.stores.user)
+      this.db.firebase.getSupportsPath(user)
     );
     this.debugLogHandlers("#start", "adding", ["child_changed", "child_added"], this.supportsRef);
     this.supportsRef.on("child_changed", this.onChildChanged = this.handleSupportsUpdate("child_changed"));
     this.supportsRef.on("child_added", this.onChildAdded = this.handleSupportsUpdate("child_added"));
+
+    this.db.firestore.getMulticlassSupportsRef()
+        .where("problem", "==", getProblemPath(this.db.stores))
+        .where("classes", "array-contains", user.classHash)
+        .onSnapshot(snapshot => this.handleMulticlassSupports(snapshot));
 
     this.lastSupportViewTimestampRef = this.db.firebase.getLastSupportViewTimestampRef();
     this.debugLogHandler("#start", "adding", "on value", this.lastSupportViewTimestampRef);
@@ -90,7 +97,7 @@ export class DBSupportsListener extends BaseListener {
         });
       }
 
-      supports.setAuthoredSupports(teacherSupports, audienceType);
+      supports.addAuthoredSupports(teacherSupports, audienceType);
 
       const { unit, investigation, problem, documents, user } = this.db.stores;
       addSupportDocumentsToStore({
@@ -103,7 +110,7 @@ export class DBSupportsListener extends BaseListener {
               // teachers sync their support document properties to Firebase to track isDeleted
               const {audience, sectionTarget, key} = teacherSupport;
               const path = this.db.firebase.getSupportsPath(user, audience, sectionTarget, key);
-              this.db.listeners.syncDocumentProperties(document, path);
+              this.db.listeners.syncDocumentProperties(document, "firebase", path);
             }
           }
         }
@@ -131,6 +138,54 @@ export class DBSupportsListener extends BaseListener {
       originDoc: dbSupport.type === ESupportType.publication ? dbSupport.originDoc : undefined,
       caption: dbSupport.properties && dbSupport.properties.caption,
       deleted: dbSupport.deleted || !!(dbSupport.properties && dbSupport.properties.isDeleted)
+    });
+  }
+
+  private handleMulticlassSupports(querySnapshot: firebase.firestore.QuerySnapshot<firebase.firestore.DocumentData>) {
+    const teacherSupports: TeacherSupportModelType[] = [];
+    querySnapshot.forEach(doc => {
+      const supportModel = this.createMulticlassSupport(doc.data().uid, doc.id, doc.data());
+      supportModel && teacherSupports.push(supportModel);
+    });
+    if (teacherSupports.length === 0) return;
+
+    const {supports} = this.db.stores;
+    supports.addAuthoredSupports(teacherSupports, AudienceEnum.class);
+
+    const { unit, investigation, problem, documents, user } = this.db.stores;
+    addSupportDocumentsToStore({
+      unit, investigation, problem, documents, supports: teacherSupports, db: this.db, fromDB: true,
+      onDocumentCreated: (support, document) => {
+        // since there are multiple async calls before we get here check if the support is still in the tree
+        if (isAlive(support)) {
+          const teacherSupport = support as TeacherSupportModelType;
+          if (teacherSupport.uid === user.id) {
+            // teachers sync their support document properties to Firebase to track isDeleted
+            this.db.listeners.syncDocumentProperties(document, "firestore");
+          }
+        }
+      }
+    });
+  }
+
+  private createMulticlassSupport(uid: string, docId: string, dbSupport: any) {
+    if (!uid || !docId || !dbSupport) return;
+    const content = dbSupport.content;
+    const supportModel = SupportModel.create({ type: ESupportType.multiclass, content });
+    if (!supportModel) return;
+    // a just-created support will sometimes return undefined for createdAt,
+    // in which case we'll use the current date as a substitute
+    const authoredDate = dbSupport.createdAt?.toDate() || new Date();
+    return TeacherSupportModel.create({
+      uid,
+      key: docId,
+      support: supportModel,
+      type: SupportTarget.problem,
+      audience: ClassAudienceModel.create(),
+      authoredTime: authoredDate.getTime(),
+      originDoc: dbSupport.originDoc,
+      caption: dbSupport.properties?.caption,
+      deleted: dbSupport.deleted || !!dbSupport.properties?.isDeleted
     });
   }
 

--- a/src/lib/db-types.ts
+++ b/src/lib/db-types.ts
@@ -1,6 +1,8 @@
 import { ESupportMode, ESupportType } from "../models/curriculum/support";
 import { AudienceEnum, SectionTarget } from "../models/stores/supports";
 
+export type DatabaseType = "firebase" | "firestore";
+
 // NOTE: see docs/firebase-schema.md to see a visual hierarchy of these interfaces
 
 export interface DBPortalUser {
@@ -286,12 +288,17 @@ export interface DBDocumentSupport extends DBBaseSupport {
   type: ESupportType.document;
 }
 
+export interface DBMulticlassSupport extends DBBaseSupport {
+  type: ESupportType.multiclass;
+  originDoc: string;
+}
+
 export interface DBPublishedSupport extends DBBaseSupport {
   type: ESupportType.publication;
   originDoc: string;
 }
 
-export type DBSupport = DBTextSupport | DBDocumentSupport | DBPublishedSupport;
+export type DBSupport = DBTextSupport | DBDocumentSupport | DBMulticlassSupport | DBPublishedSupport;
 
 export interface DBTileComment {
   content: string;

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -473,7 +473,7 @@ export class DB {
   }
 
   public publishDocumentAsSupport(documentModel: DocumentModelType, caption: string) {
-    const {user} = this.stores;
+    const { user } = this.stores;
     const content = documentModel.content.publish();
     const fs = this.firestore;
     return fs.batch(batch => {
@@ -486,7 +486,7 @@ export class DB {
         createdAt: fs.timestamp(),
         properties: { teacherSupport: true, caption, ...documentModel.copyProperties() },
         problem: getProblemPath(this.stores),
-        classes: [user.classHash],
+        classes: user.classHashesForProblemPath(getProblemPath(this.stores)),
         originDoc: documentModel.key,
         content
       });

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -493,7 +493,7 @@ export class DB {
         platform_id: user.portal,
         context_id: user.classHash,
         resource_link_id: user.offeringId,
-        resource_url: user.offeringUrl || ""
+        resource_url: user.activityUrl || ""
       });
     });
   }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -488,7 +488,12 @@ export class DB {
         problem: getProblemPath(this.stores),
         classes: user.classHashesForProblemPath(getProblemPath(this.stores)),
         originDoc: documentModel.key,
-        content
+        content,
+        // LTI fields
+        platform_id: user.portal,
+        context_id: user.classHash,
+        resource_link_id: user.offeringId,
+        resource_url: user.offeringUrl || ""
       });
     });
   }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -484,7 +484,7 @@ export class DB {
         uid: user.id,
         type: "supportPublication",
         createdAt: fs.timestamp(),
-        properties: { teacherSupport: true, caption, ...documentModel.copyProperties() },
+        properties: { teacherSupport: "true", caption, ...documentModel.copyProperties() },
         problem: getProblemPath(this.stores),
         classes: user.classHashesForProblemPath(getProblemPath(this.stores)),
         originDoc: documentModel.key,

--- a/src/lib/fire-utils.ts
+++ b/src/lib/fire-utils.ts
@@ -1,0 +1,3 @@
+export function escapeKey(s: string): string {
+  return s.replace(/[.$[\]#/]/g, "_");
+}

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -3,6 +3,7 @@ import { OtherDocumentType, PersonalDocument } from "../models/document/document
 import { AudienceModelType, SectionTarget } from "../models/stores/supports";
 import { UserModelType } from "../models/stores/user";
 import { DB } from "./db";
+import { escapeKey } from "./fire-utils";
 import { urlParams } from "../utilities/url-params";
 import { Logger, LogEventName } from "../lib/logger";
 
@@ -13,13 +14,17 @@ import { Logger, LogEventName } from "../lib/logger";
 const FIREBASE_ROOT_OVERRIDE = undefined;
 
 export class Firebase {
-  public user: firebase.User | null = null;
+  private user: firebase.User | null = null;
   private db: DB;
   private groupOnDisconnect: firebase.database.OnDisconnect | null = null;
   private connectedRef: firebase.database.Reference | null = null;
 
   constructor(db: DB) {
     this.db = db;
+  }
+
+  public setFirebaseUser(user: firebase.User) {
+    this.user = user;
   }
 
   public get userId() {
@@ -65,20 +70,16 @@ export class Firebase {
         parts.push(this.userId);
       }
       else if (appMode === "demo") {
-        const slug = demoName && demoName.length > 0 ? this.escapeKey(demoName) : "";
+        const slug = demoName && demoName.length > 0 ? escapeKey(demoName) : "";
         if (slug.length > 0) {
           parts.push(slug);
         }
       }
     }
     parts.push("portals");
-    parts.push(this.escapeKey(user.portal));
+    parts.push(escapeKey(user.portal));
 
     return `/${parts.join("/")}/`;
-  }
-
-  public escapeKey(s: string): string {
-    return s.replace(/[.$[\]#/]/g, "_");
   }
 
   //

--- a/src/lib/firestore.ts
+++ b/src/lib/firestore.ts
@@ -67,10 +67,6 @@ export class Firestore {
     return this.documentRef(this.getMulticlassSupportDocumentPath(docId));
   }
 
-  public documentsGroup() {
-    return firebase.firestore().collectionGroup("docs");
-  }
-
   public collectionRef(path: string) {
     return firebase.firestore().collection(path);
   }

--- a/src/lib/firestore.ts
+++ b/src/lib/firestore.ts
@@ -1,0 +1,102 @@
+import firebase from "firebase/app";
+import "firebase/firestore";
+import { DB } from "./db";
+import { escapeKey } from "./fire-utils";
+
+export class Firestore {
+  private user: firebase.User | null = null;
+  private db: DB;
+
+  constructor(db: DB) {
+    this.db = db;
+  }
+
+  public setFirebaseUser(user: firebase.User) {
+    this.user = user;
+  }
+
+  public get userId() {
+    return this.user ? this.user.uid : "no-user-id";
+  }
+
+  public get isConnected() {
+    return this.user !== null;
+  }
+
+  //
+  // Firestore
+  //
+
+  public getRootFolder() {
+    const { appMode, demo: { name: demoName }, user } = this.db.stores;
+    let rootDocId: string;
+
+    // `authed/${escapedPortalDomain}`
+    if (appMode === "authed") {
+      rootDocId = escapeKey(user.portal);
+    }
+    // `demo/${escapedDemoName}`
+    else if ((appMode === "demo") && (demoName?.length > 0)) {
+      rootDocId = escapeKey(demoName);
+    }
+    // `${appMode}/${userId}`
+    else {  // (appMode === "dev") || (appMode === "test") || (appMode === "qa")
+      rootDocId = this.userId;
+    }
+
+    return `/${appMode}/${rootDocId}/`;
+  }
+
+  public getFullPath(path = "") {
+    return `${this.getRootFolder()}${path}`;
+  }
+
+  public getMulticlassSupportsPath() {
+    return this.getFullPath("mcsupports");
+  }
+
+  public getMulticlassSupportsRef() {
+    return this.collectionRef(this.getMulticlassSupportsPath());
+  }
+
+  public getMulticlassSupportDocumentPath(docId: string) {
+    return `${this.getMulticlassSupportsPath()}/${docId}`;
+  }
+
+  public getMulticlassSupportDocumentRef(docId: string) {
+    return this.documentRef(this.getMulticlassSupportDocumentPath(docId));
+  }
+
+  public documentsGroup() {
+    return firebase.firestore().collectionGroup("docs");
+  }
+
+  public collectionRef(path: string) {
+    return firebase.firestore().collection(path);
+  }
+
+  public documentRef(collectionOrFullDocumentPath: string, documentPath?: string) {
+    return documentPath
+            ? firebase.firestore().collection(collectionOrFullDocumentPath).doc(escapeKey(documentPath))
+            : firebase.firestore().doc(collectionOrFullDocumentPath);
+  }
+
+  public newDocumentRef(collectionPath: string) {
+    return firebase.firestore().collection(collectionPath).doc();
+  }
+
+  public getDocument(collectionOrFullDocumentPath: string, documentPath?: string) {
+    const docRef = this.documentRef(collectionOrFullDocumentPath, documentPath);
+    return docRef.get();
+  }
+
+  public batch(fn: (b: firebase.firestore.WriteBatch) => void) {
+    const batch = firebase.firestore().batch();
+    fn(batch);
+    return batch.commit();
+  }
+
+  public timestamp() {
+    return firebase.firestore.FieldValue.serverTimestamp() as unknown as number;
+  }
+}

--- a/src/lib/portal-api.test.ts
+++ b/src/lib/portal-api.test.ts
@@ -1,6 +1,6 @@
-import { getPortalOfferings, PortalOfferingParser } from "./portal-api";
+import { getPortalOfferings, IPortalOffering, PortalOfferingParser } from "./portal-api";
 import nock from "nock";
-import { TeacherOfferings } from "../test-fixtures/sample-portal-offerings";
+import { TeacherMineClasses, TeacherOfferings } from "../test-fixtures/sample-portal-offerings";
 
 const userType = "teacher";
 const userID = 22;
@@ -12,12 +12,15 @@ describe("Portal Offerings", () => {
     nock(/superfake/)
       .get(/\/api\/v1\/offerings\/\?user_id=22/)
       .reply(200, TeacherOfferings);
+    nock(/superfake/)
+      .get(/\/api\/v1\/classes\/mine/)
+      .reply(200, TeacherMineClasses);
   });
 
   afterEach(() => nock.cleanAll());
 
   describe("getPortalOfferings", () => {
-    let fetchedOfferings;
+    let fetchedOfferings: IPortalOffering[];
 
     beforeEach(async () => {
       fetchedOfferings = await getPortalOfferings(userType, userID, domain, fakeJWT);
@@ -25,6 +28,10 @@ describe("Portal Offerings", () => {
 
     it("Result should have 3 Offerings", () => {
       expect(fetchedOfferings.length).toEqual(3);
+    });
+
+    it("offerings should have class hashes", () => {
+      expect(fetchedOfferings.every(o => o.clazz_hash));
     });
   });
 

--- a/src/lib/portal-api.ts
+++ b/src/lib/portal-api.ts
@@ -1,5 +1,6 @@
 import { getErrorMessage } from "../utilities/super-agent-helpers";
 import superagent from "superagent";
+import { safeDecodeURI } from "../utilities/js-utils";
 import { QueryParams } from "../utilities/url-params";
 import { AppConfigModelType } from "../models/stores/app-config-model";
 import { IPortalClassOffering, PortalClassOffering } from "../models/stores/user";
@@ -182,8 +183,11 @@ export function getPortalClassOfferings(portalOfferings: IPortalOffering[],
           `&token=${urlParams.token}`;
       }
       result.push(PortalClassOffering.create({
+        classId: `${offering.clazz_id}`,
         classHash: offering.clazz_hash || "",
         className: offering.clazz,
+        activityTitle: offering.activity,
+        activityUrl: safeDecodeURI(offering.activity_url),
         problemOrdinal: getProblemOrdinal(offering.activity_url) || appConfig.defaultProblemOrdinal,
         unitCode: getUnitCode(offering.activity_url) || appConfig.defaultUnit,
         offeringId: `${offering.id}`,

--- a/src/models/curriculum/support.ts
+++ b/src/models/curriculum/support.ts
@@ -7,7 +7,9 @@ export enum ESupportType {
   // supports with embedded document content (e.g. curricular supports with document content)
   // content is stringified document content
   document = "document",
-  // published teacher supports: content is path to published support document
+  // published teacher supports: content is stringified document content
+  multiclass = "multiclass",
+  // legacy published teacher supports: content is path to published support document in firebase
   publication = "publication"
 }
 

--- a/src/models/document/document.ts
+++ b/src/models/document/document.ts
@@ -165,7 +165,7 @@ export const DocumentModel = types
       if (value == null) {
         self.properties.delete(key);
       }
-      else {
+      else if (self.getProperty(key) !== value) {
         self.properties.set(key, value);
       }
     },

--- a/src/models/stores/stores.ts
+++ b/src/models/stores/stores.ts
@@ -82,6 +82,11 @@ export function setAppMode(stores: IStores, appMode: AppMode) {
   stores.appMode = appMode;
 }
 
+export function getProblemPath(stores: IStores) {
+  const { unit, investigation, problem } = stores;
+  return `${unit.code}/${investigation.ordinal}/${problem.ordinal}`;
+}
+
 export function isFeatureSupported(stores: IStores, feature: string, sectionId?: string) {
   const { unit, investigation, problem } = stores;
   const section = sectionId && problem.getSectionById(sectionId);

--- a/src/models/stores/stores.ts
+++ b/src/models/stores/stores.ts
@@ -82,6 +82,11 @@ export function setAppMode(stores: IStores, appMode: AppMode) {
   stores.appMode = appMode;
 }
 
+export function getProblemOrdinal(stores: IStores) {
+  const { investigation, problem } = stores;
+  return `${investigation.ordinal}.${problem.ordinal}`;
+}
+
 export function getProblemPath(stores: IStores) {
   const { unit, investigation, problem } = stores;
   return `${unit.code}/${investigation.ordinal}/${problem.ordinal}`;

--- a/src/models/stores/supports.test.ts
+++ b/src/models/stores/supports.test.ts
@@ -276,7 +276,7 @@ describe("supports model", () => {
       groupSupports: [],
       userSupports: []
     });
-    supports.setAuthoredSupports([lateSupport, earlySupport], AudienceEnum.class);
+    supports.addAuthoredSupports([lateSupport, earlySupport], AudienceEnum.class);
     expect(getSnapshot(supports)).toEqual({
       curricularSupports: [],
       classSupports: [earlySupport, lateSupport],

--- a/src/models/stores/supports.ts
+++ b/src/models/stores/supports.ts
@@ -261,7 +261,7 @@ export const SupportsModel = types
         }
         const supportMap: Record<string, ISupportWithIndex> = {};
         currSupports.forEach((s, i) => {
-          supportMap[s.key] = { support: s, index: i};
+          supportMap[s.key] = { support: s, index: i };
         });
         supports
           .sort((supportA, supportB) => supportA.authoredTime - supportB.authoredTime)
@@ -310,7 +310,7 @@ function getTeacherSupportCaption(support: TeacherSupportModelType,
   const sectionPart = sectionId ? " " + getSectionInitials(sectionId) : "";
   const prefix = `${investigationPart}.${problemPart}${sectionPart}`;
   const caption = support.caption || "Untitled";
-  return caption.startsWith(prefix)
+  return caption.includes(prefix)
           ? caption
           : `${prefix} ${caption}`;
 }

--- a/src/models/stores/supports.ts
+++ b/src/models/stores/supports.ts
@@ -125,6 +125,7 @@ export interface ICreateFromUnitParams {
   documents?: DocumentsModelType;
   db?: DB;
   supports?: CurricularSupportModelType[] | TeacherSupportModelType[];
+  fromDB?: boolean;
   onDocumentCreated?: (support: UnionSupportModelType, document: DocumentModelType) => void;
 }
 
@@ -248,16 +249,33 @@ export const SupportsModel = types
         }
       },
 
-      setAuthoredSupports(supports: TeacherSupportModelType[], audienceType: AudienceEnum) {
+      addAuthoredSupports(supports: TeacherSupportModelType[], audienceType: AudienceEnum) {
         const currSupports = audienceType === AudienceEnum.class
           ? self.classSupports
           : audienceType === AudienceEnum.group
             ? self.groupSupports
             : self.userSupports;
-        currSupports.clear();
+        interface ISupportWithIndex {
+          support: TeacherSupportModelType;
+          index: number;
+        }
+        const supportMap: Record<string, ISupportWithIndex> = {};
+        currSupports.forEach((s, i) => {
+          supportMap[s.key] = { support: s, index: i};
+        });
         supports
           .sort((supportA, supportB) => supportA.authoredTime - supportB.authoredTime)
-          .forEach(support => currSupports.push(support));
+          .forEach(inSupport => {
+            const found = supportMap[inSupport.key];
+            if (found) {
+              // replace updated supports
+              currSupports[found.index] = inSupport;
+            }
+            else {
+              // add new supports
+              currSupports.push(inSupport);
+            }
+          });
       },
 
       hideSupports() {
@@ -290,7 +308,11 @@ function getTeacherSupportCaption(support: TeacherSupportModelType,
   const problemPart = problem ? `${problem.ordinal}` : "*";
   const { sectionId } = support;
   const sectionPart = sectionId ? " " + getSectionInitials(sectionId) : "";
-  return `${investigationPart}.${problemPart}${sectionPart} ${support.caption || "Untitled"}`;
+  const prefix = `${investigationPart}.${problemPart}${sectionPart}`;
+  const caption = support.caption || "Untitled";
+  return caption.startsWith(prefix)
+          ? caption
+          : `${prefix} ${caption}`;
 }
 
 function getCurricularSupportCaption(support: CurricularSupportModelType, index: number,
@@ -346,7 +368,7 @@ export function addSupportDocumentsToStore(params: ICreateFromUnitParams) {
       properties = { teacherSupport: "true", caption: supportCaption };
       // if we have a db add the properties from support document which can be
       // updated by the teacher to soft delete the document
-      if (db) {
+      if (db && !params.fromDB) {
         properties = {...properties, ...await getSupportDocumentProperties(support, db)};
       }
     }
@@ -379,18 +401,26 @@ export function addSupportDocumentsToStore(params: ICreateFromUnitParams) {
 }
 
 export async function getSupportDocumentProperties(support: TeacherSupportModelType, db: DB) {
-  const {audience, sectionTarget, key} = support;
-  const path = `${db.firebase.getSupportsPath(db.stores.user, audience, sectionTarget, key)}/properties`;
-  const ref = db.firebase.ref(path);
-  const snapshot = await ref.once("value");
+  const {audience, sectionTarget, key, support: { type }} = support;
 
-  return snapshot && snapshot.val() as IDocumentProperties;
+  if (type === ESupportType.multiclass) {
+    const snapshot = await db.firestore.getDocument(db.firestore.getMulticlassSupportDocumentPath(key));
+    return snapshot.exists && (snapshot as any).properties;
+  }
+  else {
+    const path = `${db.firebase.getSupportsPath(db.stores.user, audience, sectionTarget, key)}/properties`;
+    const ref = db.firebase.ref(path);
+    const snapshot = await ref.once("value");
+
+    return snapshot?.val() as IDocumentProperties;
+  }
 }
 
 export async function getDocumentContentForSupport(support: SupportModelType, db?: DB) {
   let content: DocumentContentSnapshotType | IAuthoredDocumentContent | undefined;
   switch (support.type) {
     case ESupportType.document:
+    case ESupportType.multiclass:
       content = safeJsonParse(support.content);
       break;
     case ESupportType.publication:

--- a/src/models/stores/user.ts
+++ b/src/models/stores/user.ts
@@ -1,15 +1,17 @@
 import { types } from "mobx-state-tree";
 import { AuthenticatedUser, PortalFirebaseStudentJWT } from "../../lib/auth";
 import initials from "initials";
-import { parse } from "query-string";
 
 export const UserTypeEnum = types.enumeration("type", ["student", "teacher"]);
 export type UserType = typeof UserTypeEnum.Type;
 
 export const PortalClassOffering = types
   .model("PortalClassOffering", {
+    classId: "",
     classHash: "",
     className: "",
+    activityTitle: "",
+    activityUrl: "",
     problemOrdinal: "",
     unitCode: "",
     offeringId: "",
@@ -93,10 +95,9 @@ export const UserModel = types
     get initials() {
       return initials(self.name);
     },
-    get offeringUrl() {
+    get activityUrl() {
       const offering = self.portalClassOfferings.find(o => o.offeringId === self.offeringId);
-      const parsed = offering?.location ? parse(offering?.location) : undefined;
-      return parsed?.offering || undefined;
+      return offering?.activityUrl || undefined;
     }
   }))
   .views((self) => ({

--- a/src/models/stores/user.ts
+++ b/src/models/stores/user.ts
@@ -5,13 +5,20 @@ const initials = require("initials");
 export const UserTypeEnum = types.enumeration("type", ["student", "teacher"]);
 export type UserType = typeof UserTypeEnum.Type;
 
-export const PortalClassOffering = types.model("PortalClassOffering", {
-  className: "",
-  problemOrdinal: "",
-  unitCode: "",
-  offeringId: "",
-  location: ""
-});
+export const PortalClassOffering = types
+  .model("PortalClassOffering", {
+    classHash: "",
+    className: "",
+    problemOrdinal: "",
+    unitCode: "",
+    offeringId: "",
+    location: ""
+  })
+  .views(self => ({
+    get problemPath() {
+      return `${self.unitCode}/${self.problemOrdinal.replace(".", "/")}`;
+    }
+  }));
 
 export type IPortalClassOffering = typeof PortalClassOffering.Type;
 
@@ -80,6 +87,19 @@ export const UserModel = types
     },
     get initials() {
       return initials(self.name);
+    }
+  }))
+  .views((self) => ({
+    classHashesForProblemPath(problemPath: string) {
+      const classSet = new Set<string>([self.classHash]);
+      if (self.isTeacher && self.portalClassOfferings) {
+        self.portalClassOfferings.forEach(o => {
+          if (o.classHash && (o.problemPath === problemPath)) {
+            classSet.add(o.classHash);
+          }
+        });
+      }
+      return [...classSet];
     }
   }));
 

--- a/src/models/stores/user.ts
+++ b/src/models/stores/user.ts
@@ -1,6 +1,7 @@
 import { types } from "mobx-state-tree";
 import { AuthenticatedUser, PortalFirebaseStudentJWT } from "../../lib/auth";
-const initials = require("initials");
+import initials from "initials";
+import { parse } from "query-string";
 
 export const UserTypeEnum = types.enumeration("type", ["student", "teacher"]);
 export type UserType = typeof UserTypeEnum.Type;
@@ -91,6 +92,11 @@ export const UserModel = types
     },
     get initials() {
       return initials(self.name);
+    },
+    get offeringUrl() {
+      const offering = self.portalClassOfferings.find(o => o.offeringId === self.offeringId);
+      const parsed = offering?.location ? parse(offering?.location) : undefined;
+      return parsed?.offering || undefined;
     }
   }))
   .views((self) => ({

--- a/src/test-fixtures/sample-portal-offerings.ts
+++ b/src/test-fixtures/sample-portal-offerings.ts
@@ -1,3 +1,23 @@
+export const TeacherMineClasses = {
+  classes: [
+    {
+      uri: "https://learn.staging.concord.org/api/v1/classes/242",
+      name: "ClueClass1",
+      class_hash: "ClueClass1Hash"
+    },
+    {
+      uri: "https://learn.staging.concord.org/api/v1/classes/243",
+      name: "ClueClass2",
+      class_hash: "ClueClass2Hash"
+    },
+    {
+      uri: "https://learn.staging.concord.org/api/v1/classes/246",
+      name: "DavesTETester",
+      class_hash: "DavesTETesterHash"
+    }
+  ]
+};
+
 export const TeacherOfferings = [
   {
     id: 1190,

--- a/src/utilities/js-utils.ts
+++ b/src/utilities/js-utils.ts
@@ -12,6 +12,22 @@ export function castArrayCopy(itemOrArray: any) {
 }
 
 /*
+ * safeDecodeURI()
+ *
+ * returns the original string on error rather than throwing an exception
+ */
+export function safeDecodeURI(uriOrComponent: string) {
+  let decoded: string | undefined;
+  try {
+    decoded = decodeURIComponent(uriOrComponent);
+  }
+  catch (e) {
+    // swallow errors
+  }
+  return decoded || uriOrComponent;
+}
+
+/*
  * safeJsonParse()
  *
  * returns undefined on error rather than throwing an exception


### PR DESCRIPTION
Published teacher supports are now stored in firestore. For portal-authenticated users, only teachers can write supports and only teachers and students in a specified list of classes can read them. This allows teacher-published supports to be visible in multiple classes (all of a teacher's CLUE classes by default). This requires a brand-new firestore database instance which currently only has teacher-published (multi-class) supports.

This PR also introduces the [firebase-tools](https://www.npmjs.com/package/firebase-tools) to this project so that rules can be edited locally and deployed from the command-line rather than being edited via the google console GUI.

For demo use, supports are shared across three-class batches, e.g. [democlass1, democlass2, democlass3], etc.

For review purposes, @mklewandowski is the primary reviewer. We've already gone over the bulk of the changes together. @scytacki the part of most relevance to you is [commit fa62e05](https://github.com/concord-consortium/collaborative-learning/pull/776/commits/fa62e052882fdfccb2311b712df92a1059a3c550) which uses the `/api/v1/classes/mine` portal API to map class hashes. @dougmartin You presumably won't see this until after you're back from vacation (and hopefully after this has already been merged). As the person who designed the CLUE real-time database schema, I'm interested in your take on my mirroring of this approach (i.e. top-level `authed`, `demo`, `dev`, `qa` collections) into the corresponding firestore schema. At some point, we should have a team-wide discussion about the pros/cons of this approach vs. the seemingly more conventional approach of separate staging/production databases.

@scytacki I added a couple of additional LTI-related fields to the support just to be on the safe side. I figure they can't hurt and might help down the road. Feel free to take a look if you're so inclined.