### PR TITLE
Map legacy unit codes for teacher support problem matching

### DIFF
--- a/src/clue/app-config.json
+++ b/src/clue/app-config.json
@@ -15,6 +15,10 @@
     "s s": "curriculum/stretching-and-shrinking/stretching-and-shrinking.json",
     "twmm": "curriculum/thinking-with-math-models/thinking-with-math-models.json"
   },
+  "unitCodeMap": {
+    "s s": "sas",
+    "s+s": "sas"
+  },
   "defaultProblemOrdinal": "1.1",
   "defaultUnit": "sas",
   "defaultDocumentType": "problem",

--- a/src/lib/portal-api.test.ts
+++ b/src/lib/portal-api.test.ts
@@ -1,6 +1,7 @@
 import { getPortalOfferings, IPortalOffering, PortalOfferingParser } from "./portal-api";
 import nock from "nock";
 import { TeacherMineClasses, TeacherOfferings } from "../test-fixtures/sample-portal-offerings";
+import { AppConfigModel } from "../models/stores/app-config-model";
 
 const userType = "teacher";
 const userID = 22;
@@ -38,6 +39,7 @@ describe("Portal Offerings", () => {
   describe("PortalOfferingParser", () => {
     const { getProblemOrdinal, getUnitCode } = PortalOfferingParser;
 
+    const appConfig = AppConfigModel.create();
     const samplePortalOffering = {
       id: 1190,
       teacher: "Dave Love",
@@ -56,8 +58,14 @@ describe("Portal Offerings", () => {
 
     describe("getUnitCode", () => {
       it("should return a unit code for problem", () => {
-        const unitCode = getUnitCode(samplePortalOffering.activity_url);
+        const unitCode = getUnitCode(samplePortalOffering.activity_url, appConfig);
         expect(unitCode).toEqual("foo");
+      });
+
+      it("should return a mapped unit code for legacy units", () => {
+        const barAppConfig = AppConfigModel.create({ unitCodeMap: { foo: "bar" }});
+        const unitCode = getUnitCode(samplePortalOffering.activity_url, barAppConfig);
+        expect(unitCode).toEqual("bar");
       });
     });
   });
@@ -82,8 +90,9 @@ describe("Portal Offerings", () => {
     });
 
     describe("getUnitCode", () => {
+      const appConfig = AppConfigModel.create();
       it(`should default to 'undefined'`, () => {
-        const unitCode = getUnitCode(samplePortalOffering.activity_url);
+        const unitCode = getUnitCode(samplePortalOffering.activity_url, appConfig);
         expect(unitCode).toBeUndefined();
       });
     });

--- a/src/lib/portal-api.ts
+++ b/src/lib/portal-api.ts
@@ -109,7 +109,7 @@ export const getProblemIdForAuthenticatedUser =
         } else {
           const activityUrl = ((res.body || {}).activity_url) || "";
           resolve({
-            unitCode: getUnitCode(activityUrl) || appConfig.defaultUnit,
+            unitCode: getUnitCode(activityUrl, appConfig) || appConfig.defaultUnit,
             problemOrdinal: getProblemOrdinal(activityUrl) || appConfig.defaultProblemOrdinal
           });
         }
@@ -161,11 +161,15 @@ function getProblemOrdinal(url: string) {
 
 // For units... e.g. "https://collaborative-learning.concord.org/branch/master/index.html?unit=s%2Bs
 // for the "Stretching and Shrinking" unit.
-function getUnitCode(url: string) {
+function getUnitCode(url: string, appConfig: AppConfigModelType) {
   const queryParams = parseUrl(url);
-  return queryParams.query.unit
-          ? queryParams.query.unit as string
-          : undefined;
+  const unitCode = queryParams.query.unit
+                    ? queryParams.query.unit as string
+                    : undefined;
+  const mappedUnitCode = unitCode
+                          ? appConfig.unitCodeMap.get(unitCode)
+                          : undefined;
+  return mappedUnitCode || unitCode;
 }
 
 export function getPortalClassOfferings(portalOfferings: IPortalOffering[],
@@ -189,7 +193,7 @@ export function getPortalClassOfferings(portalOfferings: IPortalOffering[],
         activityTitle: offering.activity,
         activityUrl: safeDecodeURI(offering.activity_url),
         problemOrdinal: getProblemOrdinal(offering.activity_url) || appConfig.defaultProblemOrdinal,
-        unitCode: getUnitCode(offering.activity_url) || appConfig.defaultUnit,
+        unitCode: getUnitCode(offering.activity_url, appConfig) || appConfig.defaultUnit,
         offeringId: `${offering.id}`,
         location: newLocationUrl
       }));

--- a/src/models/stores/app-config-model.ts
+++ b/src/models/stores/app-config-model.ts
@@ -47,6 +47,7 @@ export const AppConfigModel = types
     pageTitle: "",
     demoProblemTitle: "",
     units: types.map(types.string),
+    unitCodeMap: types.map(types.string),
     defaultProblemOrdinal: "",
     defaultUnit: "",
     autoAssignStudentsToIndividualGroups: false,


### PR DESCRIPTION
At various times, the "Stretching & Shrinking" unit has been abbreviated with "s+s", "s s", and now "sas". Since problem-matching is based on the unit code, we need to map to the current code ("sas") for matching purposes.