### PR TITLE
Update margins and user icon size to match spec

### DIFF
--- a/src/clue/components/clue-app-header.sass
+++ b/src/clue/components/clue-app-header.sass
@@ -21,7 +21,7 @@ $member-size: 18px
 
   .left
     flex: 2
-    padding: 0 $header-padding
+    padding: 0 $padding
     display: flex
     align-items: center
     justify-content: flex-start
@@ -36,7 +36,7 @@ $member-size: 18px
       width: 1.5px
       height: 40px
       background-color: $charcoal-light-1
-      margin: 0 $header-margin 0 5px
+      margin: 0 $margin 0 $margin
     .problem-dropdown
       height: 40px
   .middle
@@ -56,20 +56,19 @@ $member-size: 18px
 
   .right
     flex: 2
-    padding: 0 $header-padding
+    padding: 0 $padding
     text-align: center
     display: flex
     align-items: center
     justify-content: flex-end
     .version
-      padding-right: $padding
       font-size: 0.9em
 
     .group
       height: 40px
       flex-grow: 0
       padding: 0
-      margin: 0 10px 0 0
+      margin: 0 $margin 0 $margin
       text-align: center
       display: flex
       flex-direction: row
@@ -175,8 +174,8 @@ $member-size: 18px
         align-items: center
         text-align: center
         .student-profile-icon-inner
-          width: 30px
-          height: 30px
+          width: 24px
+          height: 24px
           mask-image: url("../../assets/icons/clue-dashboard/teacher-student.svg")
           background-color: $problem-orange
 

--- a/src/clue/components/clue-app-header.sass
+++ b/src/clue/components/clue-app-header.sass
@@ -36,7 +36,7 @@ $member-size: 18px
       width: 1.5px
       height: 40px
       background-color: $charcoal-light-1
-      margin: 0 $margin 0 $margin
+      margin: 0 $margin
     .problem-dropdown
       height: 40px
   .middle
@@ -68,7 +68,7 @@ $member-size: 18px
       height: 40px
       flex-grow: 0
       padding: 0
-      margin: 0 $margin 0 $margin
+      margin: 0 $margin
       text-align: center
       display: flex
       flex-direction: row

--- a/src/components/vars.sass
+++ b/src/components/vars.sass
@@ -313,8 +313,6 @@ $id-green: #91e7a2
 //
 
 $header-height: 55px
-$header-margin: 9px
-$header-padding: 9px
 
 $nav-expanded-peek: 14px
 $half-nav-expanded-peek: $nav-expanded-peek / 2


### PR DESCRIPTION
This PR makes small adjustments to the margins and account icon in the student header based on changes to the spec seen here:
https://app.zeplin.io/project/5d62a554d64a9e02dcad80de/screen/5f3adcf9b77c3129d28841ce

- icon size is 24x24
- component margin and padding sizing is 10 pixels (not 9)