### PR TITLE
Update member colors to match spec

### DIFF
--- a/src/clue/components/clue-app-header.sass
+++ b/src/clue/components/clue-app-header.sass
@@ -120,11 +120,11 @@ $member-size: 18px
               border-right: 1px solid white
               border-top: 1px solid white
             &.disconnected
-              background-color: #777
+              background-color: $charcoal-light-4
             &.teacher
               background-color: #EA6D2F !important
             &.empty
-              background-color: $workspace-teal-light-2
+              background-color: $workspace-teal-light-5
 
             .initials
               margin-top: -3px

--- a/src/components/group/group-chooser.sass
+++ b/src/components/group/group-chooser.sass
@@ -45,13 +45,13 @@
             padding: $half-padding
 
             .user
-              background-color: #2da343
+              background-color: $id-green
               padding: $half-padding
               float: left
               margin: $quarter-margin
 
               &.disconnected
-                background-color: #777
+                background-color: $charcoal-light-4
 
             &::after
               content: ''


### PR DESCRIPTION
Minor color changes so that the member blobs in the top header match the UI spec:

![image](https://user-images.githubusercontent.com/5126913/91476107-60aa7400-e851-11ea-8a1b-b8ccfc4620ef.png)
