### PR TITLE
Add problem content in left tabs

### DIFF
--- a/src/components/navigation/left-nav-panel.sass
+++ b/src/components/navigation/left-nav-panel.sass
@@ -1,34 +1,30 @@
 @import ../vars
 
 .left-nav-panel
-  position: absolute
-  top: 0
-  right: 0
-  bottom: 0
-  left: 0
-
+  height: 100%
   .section
+    height: calc(100vh - (#{$header-height} + #{$workspace-content-margin} * 2 + #{$left-tab-height} * 2))
     .section-header
+      height: $problem-header-height
       display: flex
-      flex-direction: row
+      flex-direction: column
       flex-wrap: nowrap
-      justify-content: flex-start
-
-      h1
-        flex-grow: 1
-        font-size: 18px
-        margin: $double-margin
+      color: $charcoal-dark-2
+      background-color: white
+      padding: 0 20px
+      .title
+        height: 37px
+        line-height: 37px
+        font-size: 14px
         text-align: center
+      .separator
+        height: 1px
+        width: 100%
+        background-color: $problem-orange-light-3
 
     .canvas
-      position: absolute
-      top: 62px
-      right: $double-margin
-      bottom: $double-margin
-      left: $double-margin
-      width: initial
-      height: initial
       overflow: auto
+      height: calc(100% - #{$problem-header-height})
 
       .document-content
         background-color: #fff

--- a/src/components/navigation/left-nav-panel.tsx
+++ b/src/components/navigation/left-nav-panel.tsx
@@ -31,7 +31,8 @@ export class LeftNavPanelComponent extends BaseComponent<IProps> {
     return (
       <div className="section">
         <div className="section-header">
-          <h1>{section.title}</h1>
+          <div className="title">{section.title}</div>
+          <div className="separator"/>
         </div>
         {content ? this.renderContent(content) : null}
       </div>

--- a/src/components/navigation/left-tab-buttons.tsx
+++ b/src/components/navigation/left-tab-buttons.tsx
@@ -34,8 +34,7 @@ export class LeftTabButtons extends BaseComponent<IProps, IState> {
     const { ui } = this.stores;
     return (
       <div className={`left-tab-buttons ${ui.leftTabContentShown ? "hidden" : ""}`}>
-        { tabs &&
-          tabs.map((tabSpec, i) => {
+        { tabs?.map((tabSpec, i) => {
             const tabClass = `left-tab tab-${tabSpec.tab}`;
             return (
               <div key={tabSpec.tab} className={tabClass} onClick={this.handleTabButtonClick(tabSpec.tab)}>

--- a/src/components/navigation/left-tab-panel.sass
+++ b/src/components/navigation/left-tab-panel.sass
@@ -2,13 +2,15 @@
 
 .left-tab-panel
   width: 50%
-  height: 100%
+  height: calc(100vh - (#{$header-height} + #{$workspace-content-margin} * 2))
   position: fixed
   left: calc(0px - 100vw * .5)
-  top: 55px
+  top: $header-height
   transition-duration: 1s
   transition-property: left
   margin-top: 4px
+  background-color: white
+  border-radius: 0 6px 0 0
   &.shown
     left: 0px
 
@@ -20,7 +22,7 @@
   .close-button
     flex-shrink: 0
     width: 36px
-    height: 34px
+    height: $left-tab-height
     background-color: $charcoal-light-6
     border-radius: 0 6px 0 0
     border-style: solid
@@ -44,7 +46,7 @@
     margin: 0
     .top-tab
       flex-grow: 1
-      height: 34px
+      height: $left-tab-height
       font-size: 13px
       color: $charcoal-dark-2
       border-style: solid

--- a/src/components/navigation/left-tab-panel.tsx
+++ b/src/components/navigation/left-tab-panel.tsx
@@ -41,8 +41,7 @@ export class LeftTabPanel extends BaseComponent<IProps, IState> {
         <Tabs selectedIndex={selectedTabIndex} onSelect={this.handleSelect}>
           <div className="top-row">
             <TabList className="top-tab-list">
-              { tabs &&
-                tabs.map((tabSpec, index) => {
+              { tabs?.map((tabSpec, index) => {
                   const tabClass = `top-tab tab-${tabSpec.tab} ${selectedTabIndex === index ? "selected" : ""}`;
                   return <Tab key={tabSpec.tab} className={tabClass}>{tabSpec.label}</Tab>;
                 })
@@ -50,8 +49,7 @@ export class LeftTabPanel extends BaseComponent<IProps, IState> {
             </TabList>
             <button className="close-button" onClick={this.handleClose}/>
           </div>
-          { tabs &&
-            tabs.map((tabSpec) => {
+          { tabs?.map((tabSpec) => {
               return (
                 <TabPanel key={tabSpec.tab}>
                   {this.renderTabContent(tabSpec)}

--- a/src/components/navigation/left-tab-panel.tsx
+++ b/src/components/navigation/left-tab-panel.tsx
@@ -2,8 +2,9 @@ import { inject, observer } from "mobx-react";
 import React from "react";
 import { BaseComponent, IBaseProps } from "../base";
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
-import { LeftTabSpec } from "../../models/view/left-tabs";
+import { LeftTabSpec, ELeftTab } from "../../models/view/left-tabs";
 import { Logger, LogEventName } from "../../lib/logger";
+import { ProblemTabContent } from "./problem-tab-content";
 
 import "react-tabs/style/react-tabs.css";
 import "./left-tab-panel.sass";
@@ -41,25 +42,46 @@ export class LeftTabPanel extends BaseComponent<IProps, IState> {
           <div className="top-row">
             <TabList className="top-tab-list">
               { tabs &&
-                tabs.map((tabSpec, i) => {
-                  const tabClass = `top-tab tab-${tabSpec.tab} ${selectedTabIndex === i ? "selected" : ""}`;
+                tabs.map((tabSpec, index) => {
+                  const tabClass = `top-tab tab-${tabSpec.tab} ${selectedTabIndex === index ? "selected" : ""}`;
                   return <Tab key={tabSpec.tab} className={tabClass}>{tabSpec.label}</Tab>;
                 })
               }
             </TabList>
             <button className="close-button" onClick={this.handleClose}/>
           </div>
-          { tabs && tabs.map((tab, i) => this.renderTabContent(tab, i)) }
+          { tabs &&
+            tabs.map((tabSpec) => {
+              return (
+                <TabPanel key={tabSpec.tab}>
+                  {this.renderTabContent(tabSpec)}
+                </TabPanel>
+              );
+            })
+          }
         </Tabs>
       </div>
     );
   }
 
-  private renderTabContent = (tabSpec: LeftTabSpec, i: number)  => {
+  private renderTabContent = (tabSpec: LeftTabSpec) => {
+    // TODO: handle additional content types
+    switch (tabSpec.tab) {
+      case ELeftTab.kProblems:
+        return this.renderProblems();
+      default:
+        return null;
+    }
+  }
+
+  private renderProblems = () => {
+    const { problem } = this.stores;
+    const { sections } = problem;
     return (
-      <TabPanel key={tabSpec.tab}>
-        {tabSpec.label} content
-      </TabPanel>
+      <ProblemTabContent
+        isGhostUser={this.props.isGhostUser}
+        sections={sections}
+      />
     );
   }
 

--- a/src/components/navigation/problem-tab-content.sass
+++ b/src/components/navigation/problem-tab-content.sass
@@ -1,0 +1,24 @@
+@import ../vars
+
+.problem-tabs
+  border-color: $problem-orange-light-3
+  border-width: 0 2px 2px 0
+  border-style: solid
+  .tab-list
+    background-color: $problem-orange-light-7
+    margin: 0
+    padding: 0
+    height: $left-tab-height
+    display: flex
+    .prob-tab
+      width: 50px
+      height: $left-tab-height
+      display: flex
+      justify-content: center
+      align-items: center
+      cursor: pointer
+      &:hover
+        background-color: $problem-orange-light-5
+      &:active, &.selected
+        background-color: $problem-orange-light-3
+        font-weight: bold

--- a/src/components/navigation/problem-tab-content.tsx
+++ b/src/components/navigation/problem-tab-content.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
-import { getSectionInitials } from "../../models/curriculum/section";
+import { getSectionInitials, SectionModelType } from "../../models/curriculum/section";
 import { LeftNavPanelComponent } from "./left-nav-panel";
-import { SectionModelType } from "../../models/curriculum/section";
 
 import "./problem-tab-content.sass";
 

--- a/src/components/navigation/problem-tab-content.tsx
+++ b/src/components/navigation/problem-tab-content.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
+import { getSectionInitials } from "../../models/curriculum/section";
+import { LeftNavPanelComponent } from "./left-nav-panel";
+import { SectionModelType } from "../../models/curriculum/section";
+
+import "./problem-tab-content.sass";
+
+interface IProps {
+  isGhostUser: boolean;
+  sections: SectionModelType[];
+}
+
+export const ProblemTabContent: React.FC<IProps> = (props) => {
+  const { isGhostUser, sections } = props;
+  return (
+    <Tabs className="problem-tabs" selectedTabClassName="selected">
+      <TabList className="tab-list">
+        {sections.map((section) => {
+          return (
+            <Tab className="prob-tab" key={`section-${section.type}`}>
+              {getSectionInitials(section.type)}
+            </Tab>
+          );
+        })}
+      </TabList>
+      {sections.map((section) => {
+        return (
+          <TabPanel key={`section-${section.type}`}>
+            <LeftNavPanelComponent
+              section={section}
+              isGhostUser={isGhostUser}
+              key={`section-${section.type}`}
+            />
+          </TabPanel>
+        );
+      })}
+    </Tabs>
+  );
+};

--- a/src/components/vars.sass
+++ b/src/components/vars.sass
@@ -313,6 +313,8 @@ $id-green: #91e7a2
 //
 
 $header-height: 55px
+$workspace-content-margin: 4px
+$problem-header-height: 38px
 
 $nav-expanded-peek: 14px
 $half-nav-expanded-peek: $nav-expanded-peek / 2
@@ -336,6 +338,7 @@ $workspace-toolbar-width: 44px
 //
 
 $tab-min-height: 50px
+$left-tab-height: 34px
 
 =tab($direction)
   display: flex


### PR DESCRIPTION
This PR adds problem content to the slide out left tabs.  Problem sections are controlled by a second set of tabs beneath the main Problems/My Work/Class Work/etc. tabs.  Problem content scrolls vertically if the content is too long.  The bulk of the work is done in the new `ProblemTabContent` React component.  The `LeftNavPanelComponent` is reused (which displays the problem content) - although we might want to rename it to be better in sync with our new UI design.

![problem-content](https://user-images.githubusercontent.com/5126913/91528332-60938e00-e8bc-11ea-89b8-6f413ab0105a.gif)
