### PR TITLE
Handle text overflow in app header sections

### DIFF
--- a/src/clue/components/clue-app-header.sass
+++ b/src/clue/components/clue-app-header.sass
@@ -26,17 +26,26 @@ $member-size: 18px
     align-items: center
     justify-content: flex-start
     .unit
+      max-width: 286px
+      flex-shrink: 0
       .title
         font-size: 13px
         font-weight: bold
+        white-space: nowrap
+        overflow: hidden
+        text-overflow: ellipsis
       .investigation
         font-size: 13px
         font-weight: normal
+        white-space: nowrap
+        overflow: hidden
+        text-overflow: ellipsis
     .separator
       width: 1.5px
       height: 40px
       background-color: $charcoal-light-1
       margin: 0 $margin
+      flex-shrink: 0
     .problem-dropdown
       height: 40px
   .middle
@@ -66,12 +75,16 @@ $member-size: 18px
 
     .group
       height: 40px
+      min-width: 109px
+      max-width: 124px
+      box-sizing: border-box
       flex-grow: 0
       padding: 0
       margin: 0 $margin
       text-align: center
       display: flex
       flex-direction: row
+      justify-content: flex-end
       align-items: center
       border-radius: 5px
       border: solid 1.5px $charcoal-light-1
@@ -93,6 +106,9 @@ $member-size: 18px
         font-weight: normal
         font-size: 13px
         margin: 0 2px 0 10px
+        white-space: nowrap
+        overflow: hidden
+        text-overflow: ellipsis
 
       .members
         display: flex
@@ -160,6 +176,9 @@ $member-size: 18px
       align-items: center
       border-radius: 5px
       border: solid 1.5px $charcoal-light-1
+      min-width: 144px
+      max-width: 191px
+      box-sizing: border-box
 
       .user-contents
         display: flex
@@ -167,10 +186,22 @@ $member-size: 18px
         align-items: flex-start
         font-weight: normal
         font-size: 13px
+        min-width: 108px
+        max-width: 155px
         .name
+          width: 100%
           padding: 0 10px 0 10px
+          text-align: left
+          white-space: nowrap
+          overflow: hidden
+          text-overflow: ellipsis
         .class
+          width: 100%
           padding: 0 10px 0 10px
+          text-align: left
+          white-space: nowrap
+          overflow: hidden
+          text-overflow: ellipsis
       .student-profile-icon
         background-color: white
         width: 36px

--- a/src/clue/components/problem-select.sass
+++ b/src/clue/components/problem-select.sass
@@ -112,6 +112,6 @@
 
   /* cf. https://css-tricks.com/line-clampin/ */
   .line-clamp
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
+    display: -webkit-box
+    -webkit-line-clamp: 2
+    -webkit-box-orient: vertical

--- a/src/clue/components/problem-select.sass
+++ b/src/clue/components/problem-select.sass
@@ -7,7 +7,8 @@
     display: flex
     flex-direction: row
     align-items: center
-    width: 300px
+    min-width: 300px
+    max-width: 400px
     height: 40px
     box-sizing: border-box
     border-radius: 5px
@@ -32,21 +33,22 @@
       background-image: url("../../assets/icons/arrow/arrow-open.svg")
 
     .item
-      display: flex
-      flex-direction: column
-      justify-content: center
       flex-grow: 1
-      max-width: 245px
+      max-width: 345px
       white-space: pre-wrap
-      height: 40px
+      max-height: 32px
       margin: 0 10px 0 10px
+      overflow: hidden
 
     .arrow
+      flex-shrink: 0
       height: 24px
       width: 24px
-      margin: 0 5px 0 5px
+      margin: 0 5px 0 0
       transition-property: transform
       transition-duration: .25s
+      background-repeat: no-repeat
+      background-position: center
       background-image: url("../../assets/icons/arrow/arrow.svg")
 
       &.show-list
@@ -59,7 +61,6 @@
   .list
     position: absolute
     margin-top: 1px
-    width: 300px
     border-radius: 0 0 5px 5px
     box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.5)
     opacity: 0
@@ -79,12 +80,12 @@
       align-items: center
       box-sizing: border-box
       height: 40px
-      margin: 0 2px 0 2px
       background-color: white
       font-size: 13px
 
       .item
-        width: 260px
+        width: fit-content
+        margin-right: 10px
 
       &:hover
         background-color: $workspace-teal-light-3
@@ -101,8 +102,16 @@
         width: 24px
         margin: 0 2px 0 2px
         background-image: url("../../assets/icons/check/check.svg")
+        background-repeat: no-repeat
+        background-position: center
         &.selected
           background-image: url("../../assets/icons/check/check-selected.svg")
 
     .list-item:last-child
       border-radius: 0 0 5px 5px
+
+  /* cf. https://css-tricks.com/line-clampin/ */
+  .line-clamp
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;

--- a/src/clue/components/problem-select.tsx
+++ b/src/clue/components/problem-select.tsx
@@ -49,7 +49,7 @@ export class ProblemSelect extends React.PureComponent<IProps, IState> {
     const disabled = isDisabled ? "disabled" : "";
     return (
       <div className={`header ${showListClass} ${disabled}`} onClick={this.handleHeaderClick}>
-        <div className="item">{selectedItem && selectedItem}</div>
+        <div className="item line-clamp">{selectedItem && selectedItem}</div>
         <div className={`arrow ${showListClass} ${disabled}`} />
       </div>
     );


### PR DESCRIPTION
Update app header so the handling of long text strings matches the UI spec.  Components expand to a max-width and then display long text with ellipsis.  

![image](https://user-images.githubusercontent.com/5126913/91530895-b79b6200-e8c0-11ea-80ec-42091f0dc6d2.png)
