### PR TITLE
Eliminate vestigial notion of ghost user

### DIFF
--- a/src/clue/components/clue-app-content.tsx
+++ b/src/clue/components/clue-app-content.tsx
@@ -22,12 +22,11 @@ export class ClueAppContentComponent extends BaseComponent<IProps> {
   public render() {
     const { user, ui } = this.stores;
     const isTeacher = user && user.isTeacher;
-    const isGhostUser = this.stores.groups.ghostUserId === this.stores.user.id;
 
     const panels: IPanelGroupSpec = [{
                     panelId: EPanelId.workspace,
                     label: "Workspace",
-                    content: <DocumentWorkspaceComponent isGhostUser={isGhostUser} />
+                    content: <DocumentWorkspaceComponent />
                   }];
     if (user && user.isTeacher) {
       panels.unshift({
@@ -45,7 +44,7 @@ export class ClueAppContentComponent extends BaseComponent<IProps> {
 
     return (
       <div className="clue-app-content">
-        <ClueAppHeaderComponent isGhostUser={isGhostUser} panels={panels}
+        <ClueAppHeaderComponent panels={panels}
                             current={teacherPanelKey} onPanelChange={this.handlePanelChange}
                             showGroup={true} />
         {currentPanelContent}

--- a/src/clue/components/clue-app-header.tsx
+++ b/src/clue/components/clue-app-header.tsx
@@ -15,7 +15,6 @@ import "../../components/utilities/blueprint.sass";
 import "./clue-app-header.sass";
 
 interface IProps extends IBaseProps {
-  isGhostUser: boolean;
   panels: IPanelGroupSpec;
   current: string;
   onPanelChange: (panelId: EPanelId) => void;
@@ -199,17 +198,11 @@ export class ClueAppHeaderComponent extends BaseComponent<IProps> {
   }
 
   private handleResetGroup = () => {
-    const {isGhostUser} = this.props;
-    const {ui, db, groups} = this.stores;
+    const {ui, db} = this.stores;
     ui.confirm("Do you want to leave this group?", "Leave Group")
       .then((ok) => {
         if (ok) {
-          if (isGhostUser) {
-            groups.ghostGroup();
-          }
-          else {
-            db.leaveGroup();
-          }
+          db.leaveGroup();
         }
       });
   }

--- a/src/components/document/document-workspace.tsx
+++ b/src/components/document/document-workspace.tsx
@@ -17,7 +17,6 @@ import "./document-workspace.sass";
 type WorkspaceSide = "primary" | "comparison";
 
 interface IProps extends IBaseProps {
-  isGhostUser: boolean;
 }
 
 // keep ghost documents out of MST
@@ -46,7 +45,6 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps> {
   public render() {
     const { appConfig : { leftTabs: { tabSpecs } }, user } = this.stores;
     const studentTabs = tabSpecs.filter((t) => !t.teacherOnly);
-    const isGhostUser = this.props.isGhostUser;
     const isTeacher = user.isTeacher;
     const tabsToDisplay = isTeacher ? tabSpecs : studentTabs;
     // NOTE: the drag handlers are in three different divs because we cannot overlay
@@ -61,17 +59,15 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps> {
           onDragOver={this.handleDragOverWorkspace}
           onDrop={this.handleImageDrop}
         />
-        {this.renderDocuments(isGhostUser)}
+        {this.renderDocuments()}
         <LeftTabPanel
           tabs={tabsToDisplay}
-          isGhostUser={isGhostUser}
           isTeacher={isTeacher}
           onDragOver={this.handleDragOverWorkspace}
           onDrop={this.handleImageDrop}
         />
         <LeftTabButtons
           tabs={tabsToDisplay}
-          isGhostUser={isGhostUser}
           isTeacher={isTeacher}
           onDragOver={this.handleDragOverWorkspace}
           onDrop={this.handleImageDrop}
@@ -111,7 +107,7 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps> {
     defaultLearningLogDocument && await db.guaranteeLearningLog(initialLearningLogTitle || defaultLearningLogTitle);
   }
 
-  private renderDocuments(isGhostUser: boolean) {
+  private renderDocuments() {
     const {appConfig, documents, ui, groups} = this.stores;
 
     const { problemWorkspace } = ui;
@@ -150,7 +146,6 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps> {
             toolbar={toolbar}
             side="comparison"
             readOnly={true}
-            isGhostUser={isGhostUser}
           />
         : this.renderComparisonPlaceholder();
 
@@ -165,7 +160,6 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps> {
         onPublishDocument={this.handlePublishDocument}
         toolbar={toolbar}
         side="primary"
-        isGhostUser={isGhostUser}
       />;
 
     // Show Pimary and comparison docs:

--- a/src/components/document/document.tsx
+++ b/src/components/document/document.tsx
@@ -36,7 +36,6 @@ interface IProps extends IBaseProps {
   toolbar?: ToolbarConfig;
   side: WorkspaceSide;
   readOnly?: boolean;
-  isGhostUser?: boolean;
 }
 
 interface IState {
@@ -175,7 +174,7 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
   }
 
   public render() {
-    const { workspace, document, toolbar, side, readOnly, isGhostUser } = this.props;
+    const { workspace, document, toolbar, side, readOnly } = this.props;
     return (
       <div key="document" className="document" ref={(el) => this.documentContainer = el}>
         {this.renderTitleBar(document.type)}
@@ -184,8 +183,7 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
           isPrimary={side === "primary"}
           document={document}
           toolbar={toolbar}
-          readOnly={readOnly}
-          isGhostUser={isGhostUser} />
+          readOnly={readOnly} />
         {this.renderStickyNotesPopup()}
       </div>
     );
@@ -209,8 +207,8 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
   }
 
   private renderTitleBar(type: string) {
-    const { document, side, isGhostUser } = this.props;
-    const hideButtons = isGhostUser || (side === "comparison") || document.isPublished;
+    const { document, side } = this.props;
+    const hideButtons = (side === "comparison") || document.isPublished;
     if (document.isProblem) {
       return this.renderProblemTitleBar(type, hideButtons);
     }

--- a/src/components/document/editable-document-content.tsx
+++ b/src/components/document/editable-document-content.tsx
@@ -37,18 +37,15 @@ const OneUpCanvas: React.FC<IOneUpCanvasProps> = ({ document, readOnly, toolApiI
   );
 };
 
-interface IFourUpCanvasProps {
+interface IEditableFourUpCanvasProps {
   userId: string;
-  isGhostUser: boolean;
   toolApiInterface: IToolApiInterface;
 }
-const FourUpCanvas: React.FC<IFourUpCanvasProps> = ({ userId, isGhostUser, toolApiInterface}) => {
+const EditableFourUpCanvas: React.FC<IEditableFourUpCanvasProps> = ({ userId, toolApiInterface}) => {
   const groups = useGroupsStore();
-  const group = isGhostUser ? undefined : groups.groupForUser(userId);
-  const groupId = isGhostUser ? groups.ghostGroupId : group?.id;
+  const group = groups.groupForUser(userId);
   return (
-    <FourUpComponent userId={userId} groupId={groupId} isGhostUser={isGhostUser}
-                      toolApiInterface={toolApiInterface} />
+    <FourUpComponent userId={userId} groupId={group?.id} toolApiInterface={toolApiInterface} />
   );
 };
 
@@ -57,16 +54,15 @@ interface IDocumentCanvasProps {
   isPrimary: boolean;
   document: DocumentModelType;
   readOnly: boolean;
-  isGhostUser: boolean;
   toolApiInterface: IToolApiInterface;
 }
 const DocumentCanvas: React.FC<IDocumentCanvasProps> = props => {
-  const { mode, isPrimary, document, readOnly, isGhostUser, toolApiInterface } = props;
-  const isFourUp = (document.type === ProblemDocument) && (isGhostUser || (isPrimary && (mode === "4-up")));
+  const { mode, isPrimary, document, readOnly, toolApiInterface } = props;
+  const isFourUp = (document.type === ProblemDocument) && (isPrimary && (mode === "4-up"));
   return (
     <div className="canvas-area">
       {isFourUp
-        ? <FourUpCanvas userId={document.uid} isGhostUser={isGhostUser} toolApiInterface={toolApiInterface} />
+        ? <EditableFourUpCanvas userId={document.uid} toolApiInterface={toolApiInterface} />
         : <OneUpCanvas document={document} readOnly={readOnly} toolApiInterface={toolApiInterface} />}
     </div>
   );
@@ -79,15 +75,14 @@ interface IProps {
   document: DocumentModelType;
   toolbar?: ToolbarConfig;
   readOnly?: boolean;
-  isGhostUser?: boolean;
 }
 export const EditableDocumentContent: React.FC<IProps> = props => {
-  const { mode, isPrimary, document, toolbar, readOnly, isGhostUser } = props;
+  const { mode, isPrimary, document, toolbar, readOnly } = props;
 
   const documentContext = useDocumentContext(document);
   const [toolApiMap, toolApiInterface] = useToolApiInterface();
 
-  const isReadOnly = !isPrimary || isGhostUser || readOnly || document.isPublished;
+  const isReadOnly = !isPrimary || readOnly || document.isPublished;
   const isShowingToolbar = !!toolbar && !isReadOnly;
   return (
     <DocumentContext.Provider value={documentContext}>
@@ -95,7 +90,7 @@ export const EditableDocumentContent: React.FC<IProps> = props => {
         {isShowingToolbar && <DocumentToolbar document={document} toolbar={toolbar} toolApiMap={toolApiMap} />}
         {isShowingToolbar && <div className="canvas-separator"/>}
         <DocumentCanvas mode={mode} isPrimary={isPrimary} document={document} readOnly={isReadOnly}
-                        isGhostUser={!!isGhostUser} toolApiInterface={toolApiInterface} />
+                        toolApiInterface={toolApiInterface} />
       </div>
     </DocumentContext.Provider>
   );

--- a/src/components/navigation/left-nav-panel.tsx
+++ b/src/components/navigation/left-nav-panel.tsx
@@ -9,7 +9,6 @@ import "./left-nav-panel.sass";
 
 interface IProps extends IBaseProps {
   section?: SectionModelType | null;
-  isGhostUser: boolean;
 }
 
 @inject("stores")

--- a/src/components/navigation/left-nav.tsx
+++ b/src/components/navigation/left-nav.tsx
@@ -10,7 +10,6 @@ import { Logger, LogEventName } from "../../lib/logger";
 import "./left-nav.sass";
 
 interface IProps extends IBaseProps {
-  isGhostUser: boolean;
   onDragOver: (e: React.DragEvent<HTMLDivElement>) => void;
   onDrop: (e: React.DragEvent<HTMLDivElement>) => void;
 }
@@ -65,7 +64,7 @@ export class LeftNavComponent extends BaseComponent<IProps, IState> {
                   id={this.getContainerId(index)}
                   className={"container " + (activeSectionIndex === index ? "enabled" : "disabled")}
                   key={index}>
-                  <LeftNavPanelComponent section={section} isGhostUser={this.props.isGhostUser} key={index} />
+                  <LeftNavPanelComponent section={section} key={index} />
                 </div>
               : null
             );

--- a/src/components/navigation/left-tab-buttons.tsx
+++ b/src/components/navigation/left-tab-buttons.tsx
@@ -8,7 +8,6 @@ import "./left-tab-buttons.sass";
 
 interface IProps extends IBaseProps {
   tabs?: LeftTabSpec[];
-  isGhostUser: boolean;
   isTeacher: boolean;
   onDragOver: (e: React.DragEvent<HTMLDivElement>) => void;
   onDrop: (e: React.DragEvent<HTMLDivElement>) => void;

--- a/src/components/navigation/left-tab-panel.tsx
+++ b/src/components/navigation/left-tab-panel.tsx
@@ -12,7 +12,6 @@ import "./left-tab-panel.sass";
 
 interface IProps extends IBaseProps {
   tabs?: LeftTabSpec[];
-  isGhostUser: boolean;
   isTeacher: boolean;
   onDragOver: (e: React.DragEvent<HTMLDivElement>) => void;
   onDrop: (e: React.DragEvent<HTMLDivElement>) => void;
@@ -91,10 +90,7 @@ export class LeftTabPanel extends BaseComponent<IProps, IState> {
     const { problem } = this.stores;
     const { sections } = problem;
     return (
-      <ProblemTabContent
-        isGhostUser={this.props.isGhostUser}
-        sections={sections}
-      />
+      <ProblemTabContent sections={sections} />
     );
   }
 

--- a/src/components/navigation/problem-tab-content.tsx
+++ b/src/components/navigation/problem-tab-content.tsx
@@ -6,12 +6,11 @@ import { LeftNavPanelComponent } from "./left-nav-panel";
 import "./problem-tab-content.sass";
 
 interface IProps {
-  isGhostUser: boolean;
   sections: SectionModelType[];
 }
 
 export const ProblemTabContent: React.FC<IProps> = (props) => {
-  const { isGhostUser, sections } = props;
+  const { sections } = props;
   return (
     <Tabs className="problem-tabs" selectedTabClassName="selected">
       <TabList className="tab-list">
@@ -26,11 +25,7 @@ export const ProblemTabContent: React.FC<IProps> = (props) => {
       {sections.map((section) => {
         return (
           <TabPanel key={`section-${section.type}`}>
-            <LeftNavPanelComponent
-              section={section}
-              isGhostUser={isGhostUser}
-              key={`section-${section.type}`}
-            />
+            <LeftNavPanelComponent section={section} key={`section-${section.type}`} />
           </TabPanel>
         );
       })}

--- a/src/models/stores/groups.ts
+++ b/src/models/stores/groups.ts
@@ -35,9 +35,7 @@ export const GroupModel = types
 
 export const GroupsModel = types
   .model("Groups", {
-    allGroups: types.array(GroupModel),
-    ghostUserId: types.maybe(types.string),
-    ghostGroupId: types.maybe(types.string),
+    allGroups: types.array(GroupModel)
   })
   .actions((self) => {
     return {
@@ -65,19 +63,12 @@ export const GroupsModel = types
           return GroupModel.create({id: groupId, users});
         });
         self.allGroups.replace(allGroups);
-      },
-      ghostGroup(uid?: string, groupId?: string) {
-        self.ghostUserId = uid;
-        self.ghostGroupId = groupId;
       }
     };
   })
   .views((self) => {
     return {
       groupForUser(uid: string) {
-        if (uid === self.ghostUserId) {
-          return self.allGroups.find((group) => group.id === self.ghostGroupId);
-        }
         return self.allGroups.find((group) => {
           return !!group.users.find((user) => user.id === uid);
         });


### PR DESCRIPTION
Prior to the development of the teacher dashboard, teachers could visit individual groups as a "ghost" user. With the development of the teacher dashboard, this notion became vestigial but was never removed.