### PR TITLE
174542553 reference document

### DIFF
--- a/cypress/integration/clue/branch/student_tests/canvas_test_spec.js
+++ b/cypress/integration/clue/branch/student_tests/canvas_test_spec.js
@@ -133,7 +133,7 @@ context('Test Canvas', function(){
                     clueCanvas.getSectionHeader(headers[i]).find('.title').should('contain', headerTitles[i]);
                 }
             });
-            it('verifies section headers are not deletable',function(){
+            it.skip('verifies section headers are not deletable',function(){
                 clueCanvas.getRowSectionHeader().each(function($header, index, $header_list){
                     cy.wrap($header).click({force:true});
                     clueCanvas.getDeleteTool().click();

--- a/src/components/document/document-or-browser.tsx
+++ b/src/components/document/document-or-browser.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useAppConfigStore } from "../../hooks/use-stores";
 import { ELeftTab, LeftTabSpec } from "../../models/view/left-tabs";
-import { DocumentTabContent } from "../navigation/document-tab-content";
+import { DocumentTabPanel } from "../navigation/document-tab-panel";
 import { EditableDocumentContent, IProps as IEditableDocumentContentProps } from "./editable-document-content";
 
 interface IDocumentOrBrowserProps extends IEditableDocumentContentProps {
@@ -11,7 +11,7 @@ interface IDocumentOrBrowserProps extends IEditableDocumentContentProps {
 export const DocumentOrBrowser: React.FC<IDocumentOrBrowserProps> = props => {
   const { showBrowser, tabSpec, ...others } = props;
   return showBrowser && tabSpec
-          ? <DocumentTabContent tabSpec={tabSpec} />
+          ? <DocumentTabPanel tabSpec={tabSpec} />
           : <EditableDocumentContent {...others} />;
 };
 

--- a/src/components/navigation/document-tab-content.sass
+++ b/src/components/navigation/document-tab-content.sass
@@ -3,4 +3,8 @@
 .document-tab-content
   .editable-document-content
     top: $left-tab-height * 2
-    height: calc(100% - (#{$left-tab-height} * 2))
+    height: calc(100vh - (#{$header-height} + #{$workspace-content-margin} * 2 + #{$left-tab-height} * 2 + #{$tab-section-border-width} * 2))
+    position: static
+    .canvas-area
+      position: static
+      height: 100%

--- a/src/components/navigation/document-tab-content.sass
+++ b/src/components/navigation/document-tab-content.sass
@@ -1,54 +1,6 @@
 @import ../vars
 
-.document-tabs
-  border-color: $charcoal
-  border-width: 0 2px 2px 0
-  border-style: solid
-  &.my-work
-    border-color: $workspace-teal
-  &.class-work
-    border-color: $classwork-purple
-  &.supports
-    border-color: $support-blue
-  .tab-list
-    background-color: white
-    margin: 0
-    padding: 0
-    height: $left-tab-height
-    display: flex
-    &.my-work
-      background-color: $workspace-teal-light-7
-    &.class-work
-      background-color: $classwork-purple-light-7
-    &.supports
-      background-color: $support-blue-light-7
-    .doc-tab
-      flex-grow: 1
-      height: $left-tab-height
-      display: flex
-      justify-content: center
-      align-items: center
-      cursor: pointer
-      &.learning-logs
-        background-color: $learninglog-green-light-7
-      &:hover
-        background-color: $charcoal-light-9
-        &.my-work
-          background-color: $workspace-teal-light-5
-        &.class-work
-          background-color: $classwork-purple-light-5
-        &.supports
-          background-color: $support-blue-light-5
-        &.learning-logs
-          background-color: $learninglog-green-light-5
-      &:active, &.selected
-        background-color: $charcoal-light-8
-        font-weight: bold
-        &.my-work
-          background-color: $workspace-teal-light-3
-        &.class-work
-          background-color: $classwork-purple-light-3
-        &.supports
-          background-color: $support-blue-light-3
-        &.learning-logs
-          background-color: $learninglog-green-light-4
+.document-tab-content
+  .editable-document-content
+    top: $left-tab-height * 2
+    height: calc(100% - (#{$left-tab-height} * 2))

--- a/src/components/navigation/document-tab-content.tsx
+++ b/src/components/navigation/document-tab-content.tsx
@@ -1,121 +1,33 @@
-import { inject, observer } from "mobx-react";
-import React from "react";
-import { BaseComponent, IBaseProps } from "../base";
-import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
-import { ELeftTabSectionType, LeftTabSpec, LeftTabSectionModelType } from "../../models/view/left-tabs";
-import { IStores } from "../../models/stores/stores";
-import { TabPanelDocumentsSection } from "../thumbnail/tab-panel-documents-section";
-import { DocumentDragKey, DocumentModelType, SupportPublication } from "../../models/document/document";
-import { LogEventName, Logger } from "../../lib/logger";
+import React, { useState } from "react";
+import { DocumentModelType } from "../../models/document/document";
+import { LeftTabSpec } from "../../models/view/left-tabs";
+import { DocumentTabPanel } from "./document-tab-panel";
 
 import "./document-tab-content.sass";
 
-interface IProps extends IBaseProps {
+interface IProps {
   tabSpec: LeftTabSpec;
 }
 
-const kNavItemScale = 0.11;
+export const DocumentTabContent: React.FC<IProps> = ({ tabSpec }) => {
+  const [referenceDocument, setReferenceDocument] = useState<DocumentModelType | undefined>(undefined);
 
-@inject("stores")
-@observer
-export class DocumentTabContent extends BaseComponent<IProps> {
+  const handleTabClick = () => {
+    setReferenceDocument(undefined);
+  };
 
-  public render() {
-    const { tabSpec } = this.props;
-    const { user } = this.stores;
-    const leftTabSpecs = this.stores.appConfig.leftTabs.tabSpecs;
-    const leftTabSpec = leftTabSpecs.find(spec => spec.tab === tabSpec.tab);
-    return (
-      <Tabs className={`document-tabs ${leftTabSpec?.tab}`} selectedTabClassName="selected" forceRenderTabPanel={true}>
-        <TabList className={`tab-list ${leftTabSpec?.tab}`}>
-          {leftTabSpec?.sections.map((section) => {
-            const sectionTitle = this.getSectionTitle(section, this.stores);
-            return (
-              <Tab
-                className={`doc-tab ${leftTabSpec?.tab} ${section.type}`}
-                key={`section-${section.type}`}
-                data-test={section.dataTestHeader}
-              >
-                {sectionTitle}
-              </Tab>
-            );
-          })}
-        </TabList>
-        {leftTabSpec?.sections.map((section) => {
-          const _handleDocumentStarClick = section.showStarsForUser(user)
-                ? this.handleDocumentStarClick
-                : undefined;
-          const _handleDocumentDeleteClick = section.showDeleteForUser(user)
-                ? this.handleDocumentDeleteClick
-                : undefined;
-          return (
-            <TabPanel key={`section-${section.type}`}>
-              <TabPanelDocumentsSection
-                key={section.type}
-                tab={leftTabSpec!.tab}
-                section={section}
-                stores={this.stores}
-                scale={kNavItemScale}
-                onNewDocumentClick={this.handleNewDocumentClick}
-                onDocumentClick={this.handleDocumentClick}
-                onDocumentDragStart={this.handleDocumentDragStart}
-                onDocumentStarClick={_handleDocumentStarClick}
-                onDocumentDeleteClick={_handleDocumentDeleteClick}
-              />
-            </TabPanel>
-          );
-        })}
-      </Tabs>
-    );
-  }
+  const handleDocumentClick = (document: DocumentModelType) => {
+    setReferenceDocument(document);
+  };
 
-  private getSectionTitle = (section: LeftTabSectionModelType, stores: IStores) => {
-    if (section.title === "%abbrevInvestigation%") {
-      const { unit, investigation } = stores;
-      const { abbrevTitle } = unit;
-      const prefix = abbrevTitle ? `${abbrevTitle}: ` : "";
-      return `${prefix}Investigation ${investigation.ordinal}`;
-    }
-    return section.title;
-  }
-
-  private handleNewDocumentClick = async (section: LeftTabSectionModelType) => {
-    const { appConfig: { defaultDocumentContent }, db, ui } = this.stores;
-    const { problemWorkspace } = ui;
-    const newDocument = section.type === ELeftTabSectionType.kPersonalDocuments
-                          ? await db.createPersonalDocument({ content: defaultDocumentContent })
-                          : await db.createLearningLogDocument();
-    if (newDocument) {
-      problemWorkspace.setAvailableDocument(newDocument);
-      ui.restoreDefaultNavExpansion();
-    }
-  }
-
-  private handleDocumentClick = (document: DocumentModelType) => {
-    const { appConfig, ui } = this.stores;
-    ui.rightNavDocumentSelected(appConfig, document);
-  }
-
-  private handleDocumentDragStart = (e: React.DragEvent<HTMLDivElement>, document: DocumentModelType) => {
-    e.dataTransfer.setData(DocumentDragKey, document.key);
-  }
-
-  private handleDocumentStarClick = (document: DocumentModelType) => {
-    const { user } = this.stores;
-    document?.toggleUserStar(user.id);
-  }
-
-  private handleDocumentDeleteClick = (document: DocumentModelType) => {
-    const {ui} = this.stores;
-    ui.confirm("Do you want to delete this?", "Confirm Delete")
-      .then(ok => {
-        if (ok) {
-          document.setProperty("isDeleted", "true");
-          if (document.type === SupportPublication) {
-            Logger.logDocumentEvent(LogEventName.DELETE_SUPPORT, document);
-          }
-        }
-      });
-  }
-
-}
+  return (
+    <div className="document-tab-content">
+      <DocumentTabPanel
+        tabSpec={tabSpec}
+        onTabClick={handleTabClick}
+        onDocumentClick={handleDocumentClick}
+        document={referenceDocument}
+      />
+    </div>
+  );
+};

--- a/src/components/navigation/document-tab-content.tsx
+++ b/src/components/navigation/document-tab-content.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { DocumentModelType } from "../../models/document/document";
 import { LeftTabSpec } from "../../models/view/left-tabs";
 import { DocumentTabPanel } from "./document-tab-panel";
+import { EditableDocumentContent } from "../document/editable-document-content";
 
 import "./document-tab-content.sass";
 
@@ -20,13 +21,21 @@ export const DocumentTabContent: React.FC<IProps> = ({ tabSpec }) => {
     setReferenceDocument(document);
   };
 
+  const documentView = referenceDocument &&
+          <EditableDocumentContent
+            mode={"1-up"}
+            isPrimary={false}
+            document={referenceDocument}
+            readOnly={true}
+          />;
+
   return (
     <div className="document-tab-content">
       <DocumentTabPanel
         tabSpec={tabSpec}
         onTabClick={handleTabClick}
         onDocumentClick={handleDocumentClick}
-        document={referenceDocument}
+        documentView={documentView}
       />
     </div>
   );

--- a/src/components/navigation/document-tab-panel.sass
+++ b/src/components/navigation/document-tab-panel.sass
@@ -1,0 +1,56 @@
+@import ../vars
+
+.document-tabs
+  border-color: $charcoal
+  border-width: 0 $tab-section-border-width $tab-section-border-width 0
+  border-style: solid
+  &.my-work
+    border-color: $workspace-teal
+  &.class-work
+    border-color: $classwork-purple
+  &.supports
+    border-color: $support-blue
+  .tab-panel
+    height: 100%
+  .tab-list
+    background-color: white
+    margin: 0
+    padding: 0
+    height: $left-tab-height
+    display: flex
+    &.my-work
+      background-color: $workspace-teal-light-7
+    &.class-work
+      background-color: $classwork-purple-light-7
+    &.supports
+      background-color: $support-blue-light-7
+    .doc-tab
+      flex-grow: 1
+      height: $left-tab-height
+      display: flex
+      justify-content: center
+      align-items: center
+      cursor: pointer
+      &.learning-logs
+        background-color: $learninglog-green-light-7
+      &:hover
+        background-color: $charcoal-light-9
+        &.my-work
+          background-color: $workspace-teal-light-5
+        &.class-work
+          background-color: $classwork-purple-light-5
+        &.supports
+          background-color: $support-blue-light-5
+        &.learning-logs
+          background-color: $learninglog-green-light-5
+      &:active, &.selected
+        background-color: $charcoal-light-8
+        font-weight: bold
+        &.my-work
+          background-color: $workspace-teal-light-3
+        &.class-work
+          background-color: $classwork-purple-light-3
+        &.supports
+          background-color: $support-blue-light-3
+        &.learning-logs
+          background-color: $learninglog-green-light-4

--- a/src/components/navigation/document-tab-panel.tsx
+++ b/src/components/navigation/document-tab-panel.tsx
@@ -7,7 +7,6 @@ import { IStores } from "../../models/stores/stores";
 import { TabPanelDocumentsSection } from "../thumbnail/tab-panel-documents-section";
 import { DocumentDragKey, DocumentModelType, SupportPublication } from "../../models/document/document";
 import { LogEventName, Logger } from "../../lib/logger";
-import { EditableDocumentContent } from "../document/editable-document-content";
 
 import "./document-tab-panel.sass";
 
@@ -15,7 +14,7 @@ interface IProps extends IBaseProps {
   tabSpec: LeftTabSpec;
   onDocumentClick?: (document: DocumentModelType) => void;
   onTabClick?: () => void;
-  document?: DocumentModelType;
+  documentView?: React.ReactNode;
 }
 
 interface IState {
@@ -36,7 +35,7 @@ export class DocumentTabPanel extends BaseComponent<IProps, IState> {
   }
 
   public render() {
-    const { document, tabSpec, onTabClick, onDocumentClick } = this.props;
+    const { documentView, tabSpec, onTabClick, onDocumentClick } = this.props;
     const { tabIndex } = this.state;
     const { user } = this.stores;
     const leftTabSpecs = this.stores.appConfig.leftTabs.tabSpecs;
@@ -72,13 +71,8 @@ export class DocumentTabPanel extends BaseComponent<IProps, IState> {
                 : undefined;
           return (
             <TabPanel key={`section-${section.type}`}>
-              { document && (index === tabIndex)
-                ? <EditableDocumentContent
-                    mode={"1-up"}
-                    isPrimary={false}
-                    document={document}
-                    readOnly={true}
-                  />
+              { documentView && (index === tabIndex)
+                ? documentView
                 : <TabPanelDocumentsSection
                     key={section.type}
                     tab={leftTabSpec!.tab}
@@ -111,9 +105,11 @@ export class DocumentTabPanel extends BaseComponent<IProps, IState> {
   private handleNewDocumentClick = async (section: LeftTabSectionModelType) => {
     const { appConfig: { defaultDocumentContent }, db, ui } = this.stores;
     const { problemWorkspace } = ui;
-    const newDocument = section.type === ELeftTabSectionType.kPersonalDocuments
-                          ? await db.createPersonalDocument({ content: defaultDocumentContent })
-                          : await db.createLearningLogDocument();
+
+    const newDocument = section.type === ELeftTabSectionType.kLearningLogs
+      ? await db.createLearningLogDocument()
+      : await db.createPersonalDocument({ content: defaultDocumentContent });
+
     if (newDocument) {
       problemWorkspace.setAvailableDocument(newDocument);
       ui.restoreDefaultNavExpansion();

--- a/src/components/navigation/document-tab-panel.tsx
+++ b/src/components/navigation/document-tab-panel.tsx
@@ -18,19 +18,37 @@ interface IProps extends IBaseProps {
   document?: DocumentModelType;
 }
 
+interface IState {
+  tabIndex: number;
+}
+
 const kNavItemScale = 0.11;
 
 @inject("stores")
 @observer
-export class DocumentTabPanel extends BaseComponent<IProps> {
+export class DocumentTabPanel extends BaseComponent<IProps, IState> {
+
+  constructor(props: IProps) {
+    super(props);
+    this.state = {
+      tabIndex: 0
+    };
+  }
 
   public render() {
     const { document, tabSpec, onTabClick, onDocumentClick } = this.props;
+    const { tabIndex } = this.state;
     const { user } = this.stores;
     const leftTabSpecs = this.stores.appConfig.leftTabs.tabSpecs;
     const leftTabSpec = leftTabSpecs.find(spec => spec.tab === tabSpec.tab);
     return (
-      <Tabs className={`document-tabs ${leftTabSpec?.tab}`} selectedTabClassName="selected" forceRenderTabPanel={true}>
+      <Tabs
+        className={`document-tabs ${leftTabSpec?.tab}`}
+        forceRenderTabPanel={true}
+        onSelect={this.handleTabSelect}
+        selectedIndex={tabIndex}
+        selectedTabClassName="selected"
+      >
         <TabList className={`tab-list ${leftTabSpec?.tab}`} onClick={onTabClick}>
           {leftTabSpec?.sections.map((section) => {
             const sectionTitle = this.getSectionTitle(section, this.stores);
@@ -45,7 +63,7 @@ export class DocumentTabPanel extends BaseComponent<IProps> {
             );
           })}
         </TabList>
-        {leftTabSpec?.sections.map((section) => {
+        {leftTabSpec?.sections.map((section, index) => {
           const _handleDocumentStarClick = section.showStarsForUser(user)
                 ? this.handleDocumentStarClick
                 : undefined;
@@ -54,8 +72,7 @@ export class DocumentTabPanel extends BaseComponent<IProps> {
                 : undefined;
           return (
             <TabPanel key={`section-${section.type}`}>
-              {
-              document
+              { document && (index === tabIndex)
                 ? <EditableDocumentContent
                     mode={"1-up"}
                     isPrimary={false}
@@ -73,8 +90,7 @@ export class DocumentTabPanel extends BaseComponent<IProps> {
                     onDocumentDragStart={this.handleDocumentDragStart}
                     onDocumentStarClick={_handleDocumentStarClick}
                     onDocumentDeleteClick={_handleDocumentDeleteClick}
-                  />
-              }
+                  /> }
             </TabPanel>
           );
         })}
@@ -129,6 +145,10 @@ export class DocumentTabPanel extends BaseComponent<IProps> {
           }
         }
       });
+  }
+
+  private handleTabSelect = (tabIndex: number) => {
+    this.setState({ tabIndex });
   }
 
 }

--- a/src/components/navigation/document-tab-panel.tsx
+++ b/src/components/navigation/document-tab-panel.tsx
@@ -1,0 +1,134 @@
+import { inject, observer } from "mobx-react";
+import React from "react";
+import { BaseComponent, IBaseProps } from "../base";
+import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
+import { ELeftTabSectionType, LeftTabSpec, LeftTabSectionModelType } from "../../models/view/left-tabs";
+import { IStores } from "../../models/stores/stores";
+import { TabPanelDocumentsSection } from "../thumbnail/tab-panel-documents-section";
+import { DocumentDragKey, DocumentModelType, SupportPublication } from "../../models/document/document";
+import { LogEventName, Logger } from "../../lib/logger";
+import { EditableDocumentContent } from "../document/editable-document-content";
+
+import "./document-tab-panel.sass";
+
+interface IProps extends IBaseProps {
+  tabSpec: LeftTabSpec;
+  onDocumentClick?: (document: DocumentModelType) => void;
+  onTabClick?: () => void;
+  document?: DocumentModelType;
+}
+
+const kNavItemScale = 0.11;
+
+@inject("stores")
+@observer
+export class DocumentTabPanel extends BaseComponent<IProps> {
+
+  public render() {
+    const { document, tabSpec, onTabClick, onDocumentClick } = this.props;
+    const { user } = this.stores;
+    const leftTabSpecs = this.stores.appConfig.leftTabs.tabSpecs;
+    const leftTabSpec = leftTabSpecs.find(spec => spec.tab === tabSpec.tab);
+    return (
+      <Tabs className={`document-tabs ${leftTabSpec?.tab}`} selectedTabClassName="selected" forceRenderTabPanel={true}>
+        <TabList className={`tab-list ${leftTabSpec?.tab}`} onClick={onTabClick}>
+          {leftTabSpec?.sections.map((section) => {
+            const sectionTitle = this.getSectionTitle(section, this.stores);
+            return (
+              <Tab
+                className={`doc-tab ${leftTabSpec?.tab} ${section.type}`}
+                key={`section-${section.type}`}
+                data-test={section.dataTestHeader}
+              >
+                {sectionTitle}
+              </Tab>
+            );
+          })}
+        </TabList>
+        {leftTabSpec?.sections.map((section) => {
+          const _handleDocumentStarClick = section.showStarsForUser(user)
+                ? this.handleDocumentStarClick
+                : undefined;
+          const _handleDocumentDeleteClick = section.showDeleteForUser(user)
+                ? this.handleDocumentDeleteClick
+                : undefined;
+          return (
+            <TabPanel key={`section-${section.type}`}>
+              {
+              document
+                ? <EditableDocumentContent
+                    mode={"1-up"}
+                    isPrimary={false}
+                    document={document}
+                    readOnly={true}
+                  />
+                : <TabPanelDocumentsSection
+                    key={section.type}
+                    tab={leftTabSpec!.tab}
+                    section={section}
+                    stores={this.stores}
+                    scale={kNavItemScale}
+                    onNewDocumentClick={this.handleNewDocumentClick}
+                    onDocumentClick={onDocumentClick || this.handleDocumentClick}
+                    onDocumentDragStart={this.handleDocumentDragStart}
+                    onDocumentStarClick={_handleDocumentStarClick}
+                    onDocumentDeleteClick={_handleDocumentDeleteClick}
+                  />
+              }
+            </TabPanel>
+          );
+        })}
+      </Tabs>
+    );
+  }
+
+  private getSectionTitle = (section: LeftTabSectionModelType, stores: IStores) => {
+    if (section.title === "%abbrevInvestigation%") {
+      const { unit, investigation } = stores;
+      const { abbrevTitle } = unit;
+      const prefix = abbrevTitle ? `${abbrevTitle}: ` : "";
+      return `${prefix}Investigation ${investigation.ordinal}`;
+    }
+    return section.title;
+  }
+
+  private handleNewDocumentClick = async (section: LeftTabSectionModelType) => {
+    const { appConfig: { defaultDocumentContent }, db, ui } = this.stores;
+    const { problemWorkspace } = ui;
+    const newDocument = section.type === ELeftTabSectionType.kPersonalDocuments
+                          ? await db.createPersonalDocument({ content: defaultDocumentContent })
+                          : await db.createLearningLogDocument();
+    if (newDocument) {
+      problemWorkspace.setAvailableDocument(newDocument);
+      ui.restoreDefaultNavExpansion();
+    }
+  }
+
+  private handleDocumentClick = (document: DocumentModelType) => {
+    const { appConfig, ui } = this.stores;
+    ui.rightNavDocumentSelected(appConfig, document);
+  }
+
+  private handleDocumentDragStart = (e: React.DragEvent<HTMLDivElement>, document: DocumentModelType) => {
+    e.dataTransfer.setData(DocumentDragKey, document.key);
+  }
+
+  private handleDocumentStarClick = (document: DocumentModelType) => {
+    const { user } = this.stores;
+    document?.toggleUserStar(user.id);
+  }
+
+  private handleDocumentDeleteClick = (document: DocumentModelType) => {
+    const {ui} = this.stores;
+    ui.confirm("Do you want to delete this?", "Confirm Delete")
+      .then(ok => {
+        if (ok) {
+          document.setProperty("isDeleted", "true");
+          if (document.type === SupportPublication) {
+            Logger.logDocumentEvent(LogEventName.DELETE_SUPPORT, document);
+          }
+        }
+      });
+  }
+
+}

--- a/src/components/navigation/left-tab-panel.tsx
+++ b/src/components/navigation/left-tab-panel.tsx
@@ -38,7 +38,7 @@ export class LeftTabPanel extends BaseComponent<IProps, IState> {
     const selectedTabIndex = tabs?.findIndex(t => t.tab === ui.activeLeftNavTab);
     return (
       <div className={`left-tab-panel ${ui.leftTabContentShown ? "shown" : ""}`}>
-        <Tabs selectedIndex={selectedTabIndex} onSelect={this.handleSelect}>
+        <Tabs selectedIndex={selectedTabIndex} onSelect={this.handleSelect} forceRenderTabPanel={true}>
           <div className="top-row">
             <TabList className="top-tab-list">
               { tabs?.map((tabSpec, index) => {
@@ -63,7 +63,6 @@ export class LeftTabPanel extends BaseComponent<IProps, IState> {
   }
 
   private renderTabContent = (tabSpec: LeftTabSpec) => {
-    // TODO: handle additional content types
     switch (tabSpec.tab) {
       case ELeftTab.kProblems:
         return this.renderProblems();
@@ -80,9 +79,7 @@ export class LeftTabPanel extends BaseComponent<IProps, IState> {
 
   private renderDocuments = (tabSpec: LeftTabSpec) => {
     return (
-      <DocumentTabContent
-        tabSpec={tabSpec}
-      />
+      <DocumentTabContent tabSpec={tabSpec}/>
     );
   }
 

--- a/src/components/navigation/problem-panel.sass
+++ b/src/components/navigation/problem-panel.sass
@@ -3,7 +3,7 @@
 .problem-panel
   height: 100%
   .section
-    height: calc(100vh - (#{$header-height} + #{$workspace-content-margin} * 2 + #{$left-tab-height} * 2))
+    height: calc(100vh - (#{$header-height} + #{$workspace-content-margin} * 2 + #{$left-tab-height} * 2 + #{$tab-section-border-width} * 2))
     .section-header
       height: $problem-header-height
       display: flex

--- a/src/components/navigation/problem-tab-content.sass
+++ b/src/components/navigation/problem-tab-content.sass
@@ -2,7 +2,7 @@
 
 .problem-tabs
   border-color: $problem-orange-light-3
-  border-width: 0 2px 2px 0
+  border-width: 0 $tab-section-border-width $tab-section-border-width 0
   border-style: solid
   .tab-list
     background-color: $problem-orange-light-7

--- a/src/components/thumbnail/tab-panel-documents-section.sass
+++ b/src/components/thumbnail/tab-panel-documents-section.sass
@@ -7,7 +7,7 @@ $list-item-scale: 0.11
 .tab-panel-documents-section
   height: 100%
   .list
-    height: calc(100vh - (#{$header-height} + #{$workspace-content-margin} * 2 + #{$left-tab-height} * 2))
+    height: calc(100vh - (#{$header-height} + #{$workspace-content-margin} * 2 + #{$left-tab-height} * 2 + #{$tab-section-border-width} * 2))
     display: flex
     flex-wrap: wrap
     align-content: flex-start

--- a/src/components/vars.sass
+++ b/src/components/vars.sass
@@ -316,6 +316,7 @@ $id-green: #91e7a2
 
 $header-height: 55px
 $left-tabs-width: 90px
+$tab-section-border-width: 2px
 $workspace-content-margin: 4px
 $problem-header-height: 38px
 


### PR DESCRIPTION
This PR displays a reference document in the left tab panel when a thumbnail is clicked.  Each primary tab section (my work, class work, supports) can display it's own reference document.  This work is not entirely complete (see note below), but I think it's worth putting the current progress in a PR so we can discuss the changes.

Changes include:
- rename existing `DocumentTabContent` component `DocumentTabPanel`
- additional props can be sent to `DocumentTabPanel` to specify callbacks for clicking on a thumbnail or a tab and an option document can be passed the component to be shown in place of the thumbnail content
- new `DocumentTabContent` manages the reference doc for a tab section

This does NOT complete the work on the reference doc.  There are still architectural considerations as well as additional work that is still underway which includes:
- add reference doc title bar
- determine if it's better to store a document key rather than a full document in `DocumentTabContent`