### PR TITLE
Log additional info with each log message

### DIFF
--- a/src/components/document/document-workspace.tsx
+++ b/src/components/document/document-workspace.tsx
@@ -271,7 +271,7 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps> {
   }
 
   private handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    this.stores.ui.restoreDefaultNavExpansion();
+    // placeholder
   }
 
   private handleNewDocument = (document: DocumentModelType) => {

--- a/src/components/navigation/document-tab-panel.tsx
+++ b/src/components/navigation/document-tab-panel.tsx
@@ -112,7 +112,6 @@ export class DocumentTabPanel extends BaseComponent<IProps, IState> {
 
     if (newDocument) {
       problemWorkspace.setAvailableDocument(newDocument);
-      ui.restoreDefaultNavExpansion();
     }
   }
 

--- a/src/lib/db-listeners/db-supports-listener.ts
+++ b/src/lib/db-listeners/db-supports-listener.ts
@@ -5,7 +5,6 @@ import { SupportTarget, TeacherSupportModel, TeacherSupportModelType, ClassAudie
 import { DBSupport } from "../db-types";
 import { SectionType } from "../../models/curriculum/section";
 import { ESupportType, SupportModel } from "../../models/curriculum/support";
-import { getProblemPath } from "../../models/stores/stores";
 import { BaseListener } from "./base-listener";
 import { isAlive } from "mobx-state-tree";
 
@@ -24,7 +23,7 @@ export class DBSupportsListener extends BaseListener {
 
   // TODO: Create different listeners for support audiences
   public start() {
-    const { user } = this.db.stores;
+    const { user, problemPath } = this.db.stores;
     this.supportsRef = this.db.firebase.ref(
       this.db.firebase.getSupportsPath(user)
     );
@@ -33,7 +32,7 @@ export class DBSupportsListener extends BaseListener {
     this.supportsRef.on("child_added", this.onChildAdded = this.handleSupportsUpdate("child_added"));
 
     this.db.firestore.getMulticlassSupportsRef()
-        .where("problem", "==", getProblemPath(this.db.stores))
+        .where("problem", "==", problemPath)
         .where("classes", "array-contains", user.classHash)
         .onSnapshot(snapshot => this.handleMulticlassSupports(snapshot));
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -3,7 +3,7 @@ import "firebase/auth";
 import "firebase/database";
 import "firebase/firestore";
 import "firebase/storage";
-import { getProblemPath, IStores } from "../models/stores/stores";
+import { IStores } from "../models/stores/stores";
 import { observable } from "mobx";
 import { DBOfferingGroup, DBOfferingGroupUser, DBOfferingGroupMap, DBOfferingUser, DBDocumentMetadata, DBDocument,
         DBGroupUserConnections, DBPublication, DBPublicationDocumentMetadata, DBDocumentType, DBImage, DBTileComment,
@@ -473,7 +473,7 @@ export class DB {
   }
 
   public publishDocumentAsSupport(documentModel: DocumentModelType, caption: string) {
-    const { user } = this.stores;
+    const { user, problemPath } = this.stores;
     const content = documentModel.content.publish();
     const fs = this.firestore;
     return fs.batch(batch => {
@@ -485,8 +485,8 @@ export class DB {
         type: "supportPublication",
         createdAt: fs.timestamp(),
         properties: { teacherSupport: "true", caption, ...documentModel.copyProperties() },
-        problem: getProblemPath(this.stores),
-        classes: user.classHashesForProblemPath(getProblemPath(this.stores)),
+        problem: problemPath,
+        classes: user.classHashesForProblemPath(problemPath),
         originDoc: documentModel.key,
         content,
         // LTI fields

--- a/src/models/stores/stores.ts
+++ b/src/models/stores/stores.ts
@@ -17,7 +17,7 @@ import { getSetting } from "./settings";
 
 export type AppMode = "authed" | "dev" | "test" | "demo" | "qa";
 
-export interface IStores {
+interface IBaseStores {
   appMode: AppMode;
   appVersion: string;
   appConfig: AppConfigModelType;
@@ -37,24 +37,27 @@ export interface IStores {
   selection: SelectionStoreModelType;
 }
 
+export interface IStores extends IBaseStores {
+  problemPath: string;
+}
+
 interface ICreateStores extends Partial<IStores> {
   demoName?: string;
 }
 
 export function createStores(params?: ICreateStores): IStores {
-  const user = params && params.user || UserModel.create({ id: "0" });
-  const appConfig = params && params.appConfig || AppConfigModel.create();
-  const demoName = params && params.demoName || appConfig.appName;
-  return {
-    appMode: params && params.appMode ? params.appMode : "dev",
-    appVersion: params && params.appVersion || "unknown",
+  const user = params?.user || UserModel.create({ id: "0" });
+  const appConfig = params?.appConfig || AppConfigModel.create();
+  const demoName = params?.demoName || appConfig.appName;
+  const stores: IBaseStores = {
+    appMode: params?.appMode || "dev",
+    appVersion: params?.appVersion || "unknown",
     appConfig,
     // for testing, we create a null problem or investigation if none is provided
-    investigation: params && params.investigation || InvestigationModel.create({
-      ordinal: 0, title: "Null Investigation"}),
-    problem: params && params.problem || ProblemModel.create({ ordinal: 0, title: "Null Problem" }),
+    investigation: params?.investigation || InvestigationModel.create({ ordinal: 0, title: "Null Investigation" }),
+    problem: params?.problem || ProblemModel.create({ ordinal: 0, title: "Null Problem" }),
     user,
-    ui: params && params.ui || UIModel.create({
+    ui: params?.ui || UIModel.create({
       problemWorkspace: {
         type: ProblemWorkspace,
         mode: "1-up"
@@ -64,16 +67,20 @@ export function createStores(params?: ICreateStores): IStores {
         mode: "1-up"
       },
     }),
-    groups: params && params.groups || GroupsModel.create({}),
-    class: params && params.class || ClassModel.create({ name: "Null Class", classHash: "" }),
-    db: params && params.db || new DB(),
-    documents: params && params.documents || DocumentsModel.create({}),
-    unit: params && params.unit || UnitModel.create({title: "Null Unit"}),
-    demo: params && params.demo || DemoModel.create({name: demoName, class: {id: "0", name: "Null Class"}}),
-    showDemoCreator: params && params.showDemoCreator || false,
-    supports: params && params.supports || SupportsModel.create({}),
+    groups: params?.groups || GroupsModel.create({}),
+    class: params?.class || ClassModel.create({ name: "Null Class", classHash: "" }),
+    db: params?.db || new DB(),
+    documents: params?.documents || DocumentsModel.create({}),
+    unit: params?.unit || UnitModel.create({code: "NULL", title: "Null Unit"}),
+    demo: params?.demo || DemoModel.create({name: demoName, class: {id: "0", name: "Null Class"}}),
+    showDemoCreator: params?.showDemoCreator || false,
+    supports: params?.supports || SupportsModel.create({}),
     clipboard: ClipboardModel.create(),
     selection: SelectionStoreModel.create()
+  };
+  return {
+    ...stores,
+    problemPath: `${stores.unit.code}/${stores.investigation.ordinal}/${stores.problem.ordinal}`
   };
 }
 
@@ -84,11 +91,6 @@ export function setAppMode(stores: IStores, appMode: AppMode) {
 export function getProblemOrdinal(stores: IStores) {
   const { investigation, problem } = stores;
   return `${investigation.ordinal}.${problem.ordinal}`;
-}
-
-export function getProblemPath(stores: IStores) {
-  const { unit, investigation, problem } = stores;
-  return `${unit.code}/${investigation.ordinal}/${problem.ordinal}`;
 }
 
 export function isFeatureSupported(stores: IStores, feature: string, sectionId?: string) {

--- a/src/models/stores/ui.test.ts
+++ b/src/models/stores/ui.test.ts
@@ -1,5 +1,4 @@
 import { UIModel, UIModelType, UIDialogModelType } from "./ui";
-import { SectionModel } from "../curriculum/section";
 import { ProblemWorkspace, LearningLogWorkspace } from "./workspace";
 import { ToolTileModel } from "../tools/tool-tile";
 
@@ -20,10 +19,7 @@ describe("ui model", () => {
   });
 
   it("has default values", () => {
-    expect(ui.allDefaulted).toBe(true);
-    expect(ui.leftNavExpanded).toBe(false);
     expect(ui.error).toBe(null);
-    expect(ui.activeSectionIndex).toBe(0);
     expect(ui.showDemoCreator).toBe(false);
     expect(ui.dialog).toBe(undefined);
   });
@@ -41,63 +37,8 @@ describe("ui model", () => {
         mode: "1-up"
       },
     });
-    expect(ui.allDefaulted).toBe(true);
-    expect(ui.leftNavExpanded).toBe(false);
     expect(ui.error).toBe("test");
     expect(ui.showDemoCreator).toBe(true);
-  });
-
-  it("allows the left nav to be toggled", () => {
-    ui.toggleLeftNav();
-    expect(ui.allDefaulted).toBe(false);
-    expect(ui.leftNavExpanded).toBe(true);
-    ui.toggleLeftNav();
-    expect(ui.allDefaulted).toBe(true);
-    expect(ui.leftNavExpanded).toBe(false);
-  });
-
-  it("allows the left nav to be explicitly set", () => {
-    ui.toggleLeftNav(false);
-    expect(ui.allDefaulted).toBe(true);
-    expect(ui.leftNavExpanded).toBe(false);
-    ui.toggleLeftNav(true);
-    expect(ui.allDefaulted).toBe(false);
-    expect(ui.leftNavExpanded).toBe(true);
-  });
-
-  // it("allows the right nav to be toggled", () => {
-  //   ui.toggleRightNav();
-  //   expect(ui.allDefaulted).toBe(false);
-  //   expect(ui.rightNavExpanded).toBe(true);
-  //   ui.toggleRightNav();
-  //   expect(ui.allDefaulted).toBe(true);
-  //   expect(ui.rightNavExpanded).toBe(false);
-  // });
-
-  // it("allows the right nav to be explicitly set", () => {
-  //   ui.toggleRightNav(false);
-  //   expect(ui.allDefaulted).toBe(true);
-  //   expect(ui.rightNavExpanded).toBe(false);
-  //   ui.toggleRightNav(true);
-  //   expect(ui.allDefaulted).toBe(false);
-  //   expect(ui.rightNavExpanded).toBe(true);
-  // });
-
-  // it("only allows some components to be expanded at a time", () => {
-  //   ui.toggleLeftNav();
-  //   expect(ui.leftNavExpanded).toBe(true);
-  //   expect(ui.rightNavExpanded).toBe(false);
-
-  //   ui.toggleRightNav();
-  //   expect(ui.leftNavExpanded).toBe(false);
-  //   expect(ui.rightNavExpanded).toBe(true);
-  // });
-
-  it("allows all components to be defaulted", () => {
-    ui.toggleLeftNav();
-    expect(ui.allDefaulted).toBe(false);
-    ui.restoreDefaultNavExpansion();
-    expect(ui.allDefaulted).toBe(true);
   });
 
   it("allows error to be set", () => {
@@ -106,16 +47,6 @@ describe("ui model", () => {
     expect(ui.error).toBe(error);
     ui.setError(null);
     expect(ui.error).toBe(null);
-  });
-
-  it("allows activeSection to be set", () => {
-    SectionModel.create({
-      type: "introduction"
-    });
-    ui.setActiveSectionIndex(1);
-    expect(ui.activeSectionIndex).toBe(1);
-    ui.setActiveSectionIndex(0);
-    expect(ui.activeSectionIndex).toBe(0);
   });
 
   it("allows demo creator to be shown", () => {

--- a/src/models/stores/ui.ts
+++ b/src/models/stores/ui.ts
@@ -27,10 +27,8 @@ export const UIDialogModel = types
 
 export const UIModel = types
   .model("UI", {
-    leftNavExpanded: false,
     navTabContentShown: false,
     error: types.maybeNull(types.string),
-    activeSectionIndex: 0,
     activeNavTab: ENavTab.kMyWork,
     activeGroupId: "",
     selectedTileIds: types.array(types.string),
@@ -45,28 +43,11 @@ export const UIModel = types
     defaultLeftNavExpanded: false,
   }))
   .views((self) => ({
-    get allDefaulted() {
-      return (self.leftNavExpanded === self.defaultLeftNavExpanded);
-    },
     isSelectedTile(tile: ToolTileModelType) {
       return self.selectedTileIds.indexOf(tile.id) !== -1;
     }
   }))
   .actions((self) => {
-    function restoreDefaultNavExpansion() {
-      self.leftNavExpanded = self.defaultLeftNavExpanded;
-    }
-
-    const toggleWithOverride = (toggle: ToggleElement, override?: boolean) => {
-      const expanded = typeof override !== "undefined" ? override : !self[toggle];
-
-      switch (toggle) {
-        case "leftNavExpanded":
-          self.leftNavExpanded = expanded;
-          break;
-      }
-    };
-
     const alert = (text: string, title?: string) => {
       self.dialog = UIDialogModel.create({type: "alert", text, title});
       dialogResolver = undefined;
@@ -121,26 +102,16 @@ export const UIModel = types
     };
 
     return {
-      restoreDefaultNavExpansion,
       alert,
       prompt,
       confirm,
       resolveDialog,
 
-      afterCreate() {
-        self.defaultLeftNavExpanded = self.leftNavExpanded;
-      },
-      toggleLeftNav(override?: boolean) {
-        toggleWithOverride("leftNavExpanded", override);
-      },
       toggleNavTabContent(show: boolean) {
         self.navTabContentShown = show;
       },
       setError(error: string|null) {
         self.error = error ? error.toString() : error;
-      },
-      setActiveSectionIndex(activeSectionIndex: number) {
-        self.activeSectionIndex = activeSectionIndex;
       },
       setActiveNavTab(tab: string) {
         self.activeNavTab = tab;
@@ -166,7 +137,6 @@ export const UIModel = types
       rightNavDocumentSelected(appConfig: AppConfigModelType, document: DocumentModelType) {
         if (!document.isPublished || appConfig.showPublishedDocsInPrimaryWorkspace) {
           self.problemWorkspace.setAvailableDocument(document);
-          restoreDefaultNavExpansion();
         }
         else if (document.isPublished) {
           if (self.problemWorkspace.primaryDocumentKey) {


### PR DESCRIPTION
[[#174789421]](https://www.pivotaltracker.com/story/show/174789421)

Log additional environment variables with every log message:
- problemPath (e.g. "SAS/1/1")
- navTabsOpen (whether the left-side navigation tabs are showing)
- selectedNavTab (the ID of the currently selected left-side navigation tab)
- workspaceMode ("1-up" or "4-up")
- teacherPanel (for teachers, "dashboard" or "workspace")
- selectedGroupId (for teachers, ID of group being viewed, if any)

Required changing the way the problemPath is determined since calling getProblemPath() from the logging function caused unit tests to fail.

Also eliminate unused/legacy UI fields.
