### PR TITLE
Use new UI spec colors on sticky note button

### DIFF
--- a/src/components/document/document.sass
+++ b/src/components/document/document.sass
@@ -71,6 +71,7 @@
 
       .icon-sticky-note
         background-image: url("../../assets/icons/clue-dashboard/sticky-note.svg")
+        background-color: $workspace-teal-light-4
         width: 24px
         height: 24px
         cursor: pointer
@@ -83,7 +84,7 @@
           outline-offset: 0
 
         &:hover
-          background-color: #c5d9b9
+          background-color: $workspace-teal-light-3
 
     .actions
       flex-grow: 0


### PR DESCRIPTION
I know that this button will probably change once Michael gets to it in the updated UI spec, but since that probably won't happen in this iteration, I at least want to remove the gray/pea green that appear in the upper-right corner when this button is displayed in the document title bar.