### PR TITLE
Update dialog styling

### DIFF
--- a/src/components/utilities/dialog.sass
+++ b/src/components/utilities/dialog.sass
@@ -23,16 +23,18 @@
 
   .dialog-container
     z-index: 102
-    border: $border-width solid $border-color
+    border: 2px solid $workspace-teal
     border-radius: $border-radius
     box-shadow: $half-border-width rgba(0,0,0,0.20)
     background-color: #fff
     min-width: 400px
 
     .dialog-title
-      background-color: $color1
-      border-radius: $border-radius $border-radius 0 0
-      padding: $half-padding $padding
+      background-color: $charcoal-light-6
+      border-radius: 2px 2px 0 0
+      height: 34px
+      padding: $padding
+      text-align: center
 
     .dialog-contents
       padding: $double-padding


### PR DESCRIPTION
This PR make some simple changes based on the in-progress designs to move the dialog styling in the direction of the new UI work (I didn't touch button states since those categories are empty in the spec) in preparation for the upcoming release.  As with the sticky-note PR, the pop-up dialogs are not yet completed in the UI spec.  However, there is some preliminary work that we can follow to at least remove the pea green colors from the previous spec:
https://app.zeplin.io/project/5d62a554d64a9e02dcad80de/screen/5f3bbf9fe5e47135081b4439
