### PR TITLE
Remove problem title in left tab

### DIFF
--- a/src/components/navigation/problem-panel.sass
+++ b/src/components/navigation/problem-panel.sass
@@ -4,27 +4,10 @@
   height: 100%
   .section
     height: calc(100vh - (#{$header-height} + #{$workspace-content-margin} * 2 + #{$nav-tab-height} * 2 + #{$tab-section-border-width} * 2))
-    .section-header
-      height: $problem-header-height
-      display: flex
-      flex-direction: column
-      flex-wrap: nowrap
-      color: $charcoal-dark-2
-      background-color: white
-      padding: 0 20px
-      .title
-        height: 37px
-        line-height: 37px
-        font-size: 14px
-        text-align: center
-      .separator
-        height: 1px
-        width: 100%
-        background-color: $problem-orange-light-3
 
     .canvas
       overflow: auto
-      height: calc(100% - #{$problem-header-height})
+      height: 100%
 
       .document-content
         background-color: #fff

--- a/src/components/navigation/problem-panel.tsx
+++ b/src/components/navigation/problem-panel.tsx
@@ -29,10 +29,6 @@ export class ProblemPanelComponent extends BaseComponent<IProps> {
     const {content} = section;
     return (
       <div className="section">
-        <div className="section-header">
-          <div className="title">{section.title}</div>
-          <div className="separator"/>
-        </div>
         {content ? this.renderContent(content) : null}
       </div>
     );


### PR DESCRIPTION
This PR removes the problem titles in each problem section in the left tab panel (this was previously in the UI spec, but has since been removed).