### PR TITLE
Add stop propogation to star click

### DIFF
--- a/src/components/thumbnail/thumbnail-document-item.tsx
+++ b/src/components/thumbnail/thumbnail-document-item.tsx
@@ -28,6 +28,7 @@ export const ThumbnailDocumentItem = observer((props: IProps) => {
   };
   const handleDocumentStarClick = (e: React.MouseEvent<HTMLDivElement>) => {
     onDocumentStarClick && onDocumentStarClick(document);
+    e.stopPropagation();
   };
   const handleDocumentDeleteClick = (e: React.MouseEvent<HTMLDivElement>) => {
     onDocumentDeleteClick && onDocumentDeleteClick(document);


### PR DESCRIPTION
Clicks on stars were also propagating to the thumbnail causing the document to be opened.  Use `stopPropagation` to prevent star clicks from also propagating to the thumbnail.