### PR TITLE
Show full name when hovering over initials in four-up view

### DIFF
--- a/src/components/four-up.tsx
+++ b/src/components/four-up.tsx
@@ -187,9 +187,10 @@ export class FourUpComponent extends BaseComponent<IProps, IState> {
       const groupUser = this.userByContext[context];
       const isToggled = context === toggledContext;
       if (groupUser) {
+        const { name: fullName, initials } = groupUser.user;
         const className = `member${isToggled ? " member-centered" : ""}`;
-        const name = isToggled ? groupUser.user.name : groupUser.user.initials;
-        return <div className={className}>{name}</div>;
+        const name = isToggled ? fullName : initials;
+        return <div className={className} title={fullName}>{name}</div>;
       }
     };
 


### PR DESCRIPTION
Show full name when hovering over initials in four-up view in:
- student four-up view
- teacher student workspaces view