### PR TITLE
Fix teacher class/problem menus

### DIFF
--- a/cypress/integration/clue/branch/teacher_tests/teacher_dashboard_spec.js
+++ b/cypress/integration/clue/branch/teacher_tests/teacher_dashboard_spec.js
@@ -41,7 +41,8 @@ const baseUrl = `${Cypress.config("baseUrl")}`;
                     dashboard.getProblemList().should('not.have.class','show');
                     // Check class list UI and visibility
                     dashboard.getClassList().should('not.have.class','show');
-                    dashboard.getClassDropdown().should('contain',clueData.teacherName).and('contain',tempClass.className);
+                    dashboard.getClassDropdown().should('contain',clueData.teacherName);
+                    // dashboard.getClassDropdown().should('contain',tempClass.className);
                     dashboard.getClassDropdown().should('be.visible').click({ force: true });
                     // Check Dashboard and Workspace toggle default
                     dashboard.getViewToggle('Dashboard').should('be.visible').and('have.class', 'selected');

--- a/src/clue/components/clue-app-header.sass
+++ b/src/clue/components/clue-app-header.sass
@@ -177,13 +177,13 @@ $member-size: 18px
       align-items: center
       border-radius: 5px
       border: solid 1.5px $charcoal-light-1
-      min-width: 144px
-      max-width: 191px
       box-sizing: border-box
       &.teacher
         border-width: 0
       .class > .custom-select > .header
-        min-width: 150px
+        min-width: 250px
+        border-radius: 5px 0 0 5px
+        border-right: 0
 
       .user-contents
         display: flex

--- a/src/clue/components/custom-select.sass
+++ b/src/clue/components/custom-select.sass
@@ -40,6 +40,10 @@
       margin: 0 10px 0 10px
       flex-grow: 1
 
+      .title
+        white-space: nowrap
+        text-overflow: ellipsis
+
     .item
       flex-grow: 1
       max-width: 345px

--- a/src/clue/components/custom-select.tsx
+++ b/src/clue/components/custom-select.tsx
@@ -69,18 +69,19 @@ export class CustomSelect extends React.PureComponent<IProps, IState> {
   private renderHeader = () => {
     const { items, isDisabled, title, titlePrefix, titleIcon } = this.props;
     const selectedItem = items.find(i => i.text === this.state.selected);
+    const titleText = title || selectedItem?.text;
     const showListClass = this.state.showList ? "show-list" : "";
     const disabled = isDisabled || items.length === 0 ? "disabled" : "";
     return (
       <div className={`header ${showListClass} ${disabled}`}
         data-test={this.getDataTest("header")} onClick={this.handleHeaderClick}>
         {titleIcon && <div className="title-icon">{titleIcon}</div>}
-        { title
+        { titlePrefix
           ? <div className="title-container">
-              {titlePrefix && <div className="title-prefix">{titlePrefix}</div>}
-              <div className="title">{title}</div>
+              <div className="title-prefix">{titlePrefix}</div>
+              <div className="title">{titleText}</div>
             </div>
-          : <div className="item line-clamp">{selectedItem && selectedItem.text}</div>
+          : <div className="item line-clamp">{titleText}</div>
         }
         <div className={`arrow ${showListClass} ${disabled}`} />
       </div>

--- a/src/clue/components/custom-select.tsx
+++ b/src/clue/components/custom-select.tsx
@@ -34,7 +34,8 @@ export class CustomSelect extends React.PureComponent<IProps, IState> {
   constructor(props: IProps) {
     super(props);
     this.state = {
-      selected: props.items.length > 0 ? props.items[0].text : "",
+      selected: props.items.find(item => item.selected)?.text ||
+                (props.items.length > 0 ? props.items[0].text : ""),
       showList: false
     };
   }

--- a/src/components/class-menu-container.tsx
+++ b/src/components/class-menu-container.tsx
@@ -17,7 +17,6 @@ export class ClassMenuContainer extends BaseComponent <IProps> {
     const { user } = this.stores;
     return(
       <CustomSelect
-        title="Class Menu"
         titlePrefix={user.name}
         items={links}
       />
@@ -58,8 +57,8 @@ export class ClassMenuContainer extends BaseComponent <IProps> {
     // current problem. If we find a match, we add that one to the link array.
     // If not, we use the first one in the list of offerings for that class.
     classNames.forEach( (className) => {
-      const classLinks = user.portalClassOfferings.filter(o => o.className === className);
-      const matchingLink = classLinks.find( l => l.problemOrdinal === currentProblemOrdinal);
+      const classProblems = user.portalClassOfferings.filter(o => o.className === className);
+      const matchingProblem = classProblems.find( l => l.problemOrdinal === currentProblemOrdinal);
       const handleClick = (name: string, url: string) => {
         const log = {
           event: LogEventName.DASHBOARD_SWITCH_CLASS,
@@ -69,17 +68,17 @@ export class ClassMenuContainer extends BaseComponent <IProps> {
         window.location.replace(url);
       };
 
-      if (matchingLink) {
+      if (matchingProblem) {
         links.push({
           text: className,
-          link: matchingLink.location,
+          link: matchingProblem.location,
           selected: className === user.className,
-          onClick: () => handleClick(className, matchingLink.location)
+          onClick: () => handleClick(className, matchingProblem.location)
         });
-      } else if (classLinks) {
+      } else if (classProblems) {
         links.push({
           text: className,
-          link: classLinks[0].location
+          link: classProblems[0].location
         });
       } else {
         console.warn(`Warning -- no problems assigned in this class ${className}`);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,8 +1,6 @@
 import "ts-polyfill";
 
 import { Provider } from "mobx-react";
-// https://github.com/mobxjs/mobx-react#observer-batching
-import "mobx-react/batchingForReactDom";
 import React from "react";
 import ReactDOM from "react-dom";
 import { appConfigSpec, appIcons, createStores } from "./app-config";


### PR DESCRIPTION
- show correct item as selected
- show current class in class menu header
- clip long class names with ellipsis
- expand size of class menu to allow longer class names

Testable at https://collaborative-learning.concord.org/branch/teacher-menus/?demo, but note that the teacher menus don't really work when not launched from portal, so to test you really have to launch from portal and then manually change the URL.