### PR TITLE
Fix File menu label

### DIFF
--- a/src/clue/components/custom-select.sass
+++ b/src/clue/components/custom-select.sass
@@ -49,7 +49,7 @@
       max-width: 345px
       white-space: pre-wrap
       max-height: 32px
-      margin: 0 10px 0 10px
+      margin-left: 2px
       overflow: hidden
 
     .arrow


### PR DESCRIPTION
Before:
<img width="96" alt="Screen Shot 2020-09-22 at 3 09 02 PM" src="https://user-images.githubusercontent.com/235234/93942740-df29f280-fce5-11ea-868b-98760275aa5e.png">

After:
<img width="104" alt="FIleMenuFixed" src="https://user-images.githubusercontent.com/235234/93942776-f10b9580-fce5-11ea-8e1c-79b70c0e284b.png">
