### PR TITLE
Floating text toolbar

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,7 +37,7 @@ module.exports = {
       "@typescript-eslint/no-non-null-assertion": "off",  // 27 as of 2020-09-13
       "@typescript-eslint/no-require-imports": "error",
       "@typescript-eslint/no-shadow": ["error", { builtinGlobals: false, hoist: "all", allow: [] }],
-      "@typescript-eslint/no-unused-vars": ["error", { args: "none", ignoreRestSiblings: true }],
+      "@typescript-eslint/no-unused-vars": ["warn", { args: "none", ignoreRestSiblings: true }],
       "@typescript-eslint/prefer-optional-chain": "off",  // 300 as of 2020-09-13
       curly: ["error", "multi-line", "consistent"],
       "dot-notation": "error",

--- a/src/components/document/canvas.tsx
+++ b/src/components/document/canvas.tsx
@@ -57,9 +57,7 @@ export class CanvasComponent extends React.Component<IProps> {
 
     if (documentContent) {
       return (
-        <DocumentContentComponent content={documentContent} {...others}>
-          {/* {this.props.children} */}
-        </DocumentContentComponent>
+        <DocumentContentComponent content={documentContent} {...others} />
       );
     }
     else {

--- a/src/components/document/canvas.tsx
+++ b/src/components/document/canvas.tsx
@@ -58,7 +58,7 @@ export class CanvasComponent extends React.Component<IProps> {
     if (documentContent) {
       return (
         <DocumentContentComponent content={documentContent} {...others}>
-          {this.props.children}
+          {/* {this.props.children} */}
         </DocumentContentComponent>
       );
     }

--- a/src/components/document/document-content.tsx
+++ b/src/components/document/document-content.tsx
@@ -94,6 +94,7 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
     const {viaTeacherDashboard} = this.props;
     return (
       <div className={`document-content${viaTeacherDashboard ? " document-content-smooth-scroll" : ""}`}
+        onScroll={this.handleScroll}
         onClick={this.handleClick}
         onDragOver={this.handleDragOver}
         onDragLeave={this.handleDragLeave}
@@ -101,7 +102,7 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
         ref={(elt) => this.domElement = elt}
       >
         {this.renderRows()}
-        {this.props.children}
+        {/* {this.props.children} */}
         {this.renderSpacer()}
       </div>
     );
@@ -173,6 +174,7 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
       }
       return row
               ? <TileRowComponent key={row.id} docId={content.contentId} model={row}
+                                  documentContent={this.domElement}
                                   rowIndex={index} height={rowHeight} tileMap={tileMap}
                                   dropHighlight={dropHighlight}
                                   ref={(elt) => this.rowRefs.push(elt)} {...others} />
@@ -184,6 +186,12 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
     return !this.props.readOnly &&
             <div className="spacer" onClick={this.handleClick} />;
   }
+
+  private handleScroll = throttle((e: React.UIEvent<HTMLDivElement>) => {
+    const xScroll = this.domElement?.scrollLeft || 0;
+    const yScroll = this.domElement?.scrollTop || 0;
+    this.props.toolApiInterface?.forEach(api => api.handleDocumentScroll?.(xScroll, yScroll));
+  }, 50)
 
   private handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
     const { ui } = this.stores;

--- a/src/components/document/document-content.tsx
+++ b/src/components/document/document-content.tsx
@@ -102,7 +102,6 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
         ref={(elt) => this.domElement = elt}
       >
         {this.renderRows()}
-        {/* {this.props.children} */}
         {this.renderSpacer()}
       </div>
     );

--- a/src/components/document/tile-row.tsx
+++ b/src/components/document/tile-row.tsx
@@ -48,6 +48,7 @@ export function extractDragResizeDomHeight(dataTransfer: DataTransfer) {
 interface IProps {
   context: string;
   docId: string;
+  documentContent: HTMLElement | null;
   scale?: number;
   model: TileRowModelType;
   rowIndex: number;

--- a/src/components/toolbar.tsx
+++ b/src/components/toolbar.tsx
@@ -182,8 +182,8 @@ export class ToolbarComponent extends BaseComponent<IProps, IState> {
     ui.selectedTileIds.forEach(tileId => {
       const toolApi = this.props.toolApiMap[tileId];
       // if there is selected content inside the selected tile, delete it first
-      if (toolApi && toolApi.hasSelection()) {
-        toolApi.deleteSelection();
+      if (toolApi?.hasSelection?.()) {
+        toolApi.deleteSelection?.();
       }
       else {
         document.deleteTile(tileId);

--- a/src/components/tools/hooks/use-floating-toolbar-location.ts
+++ b/src/components/tools/hooks/use-floating-toolbar-location.ts
@@ -1,0 +1,54 @@
+import { useEffect, useRef, useState } from "react";
+import { getToolbarLocation } from "../../utilities/tile-utils";
+import { IRegisterToolApiProps } from "../tool-tile";
+
+interface IFloatingToolbarArgs extends IRegisterToolApiProps {
+  documentContent?: HTMLElement | null;
+  toolTile?: HTMLElement | null;
+  toolbarHeight: number;
+  minToolContent?: number;
+  enabled: boolean;
+}
+
+/*
+ * Custom hook which determines the correct location for the floating
+ * toolbar relative to its associated tile.
+ */
+export const useFloatingToolbarLocation = ({
+        onRegisterToolApi, onUnregisterToolApi,
+        documentContent, toolTile,
+        toolbarHeight, minToolContent, enabled
+      }: IFloatingToolbarArgs) => {
+
+  const [ , setScrollCount] = useState(0);
+  const [tileOffset, setTileOffset] = useState<{ left: number, bottom: number }>({ left: 0, bottom: 0 });
+  const enabledRef = useRef(enabled);
+  enabledRef.current = enabled;
+
+  useEffect(() => {
+    onRegisterToolApi({
+      handleDocumentScroll: () => {
+        if (enabledRef.current) {
+          // force redraw
+          setScrollCount(count => count + 1);
+        }
+      },
+      handleTileResize: (entry: ResizeObserverEntry) => {
+        const { contentRect } = entry;
+        setTileOffset({ left: contentRect.left, bottom: contentRect.bottom });
+      }
+    });
+    return () => onUnregisterToolApi();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const { left, top } = getToolbarLocation({
+                          documentContent,
+                          toolTile,
+                          toolbarHeight,
+                          minToolContent,
+                          toolLeft: tileOffset.left,
+                          toolBottom: tileOffset.bottom
+                        });
+  const isValid = (left != null) && (top != null) && (top >= 0);
+  return { isValid, left, top };
+};

--- a/src/components/tools/table-tool/table-tool.tsx
+++ b/src/components/tools/table-tool/table-tool.tsx
@@ -68,10 +68,6 @@ export default class TableToolComponent extends BaseComponent<IToolTileProps, IS
 
     const metadata = this.getContent().metadata;
     this.props.onRegisterToolApi({
-      hasSelection: () => false,
-      deleteSelection: () => { /* nop */ },
-      getSelectionInfo: () => "",
-      setSelectionHighlight: () => { /* nop */ },
       isLinked: () => {
         return metadata.isLinked;
       },

--- a/src/components/tools/text-style-bar.sass
+++ b/src/components/tools/text-style-bar.sass
@@ -2,51 +2,36 @@
 
 .text-style-bar
   background-color: $color3-4
-  padding-top: 35px
   position: absolute
-  display: inline-block
+  display: flex
+  justify-content: space-around
+  align-items: center
   margin: 4px 2px 2px 2px
   float: left
-  top: -5px
+  top: 86px
   left: 0
-  width: 40px
-  min-height: 350px
-  height: 100%
+  width: 232px
+  height: 29px
 
-.bar-header-icon
-  position: absolute
-  top: -5px
-  left: 0
-  .header-icon
-    fill: white
-    width: 22px
-    height: 32px
-    background-color: $color3-6
-    border-bottom-right-radius: 5px
-    border: white solid 2px
-
-.button-with-tool-tip
-  position: relative
-  display: inline-block
-  background-color: $color3-4
-  color: black
-  font-size: 16px
-  margin: auto
-  padding-top: 3px
-  width: 30px
-  height: 28px
-  .on
-    color: #009CDC
-  .off
-    color: #909090
-  &:hover
-    background-color: $color3-5
-    .tool-tip-text
-      visibility: visible
-      opacity: 1
-      transition: opacity 0.5s
-      transition-delay: 0.8s
-      background-color: #f0f0f0
+  .button-with-tool-tip
+    background-color: $color3-4
+    color: black
+    font-size: 16px
+    padding-top: 3px
+    width: 30px
+    height: 28px
+    .on
+      color: #009CDC
+    .off
+      color: #909090
+    &:hover
+      background-color: $color3-5
+      .tool-tip-text
+        visibility: visible
+        opacity: 1
+        transition: opacity 0.5s
+        transition-delay: 0.8s
+        background-color: #f0f0f0
 
 .tool-tip-text
   position: absolute

--- a/src/components/tools/text-style-bar.tsx
+++ b/src/components/tools/text-style-bar.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import ReactDOM from "react-dom";
 import { inject, observer } from "mobx-react";
 import { BaseComponent } from "../base";
 import { isMac } from "../../utilities/browser";
@@ -11,27 +12,15 @@ interface IButtonDef {
 }
 
 interface IProps {
+  portalDomElement?: HTMLElement | null;
+  top?: number;
+  left?: number;
   selectedButtonNames: string[];
   clickHandler: (buttonName: string, editor: any, event: React.MouseEvent) => void;
   editor: any;
   visible: boolean;  // If true, render the tool bar.
   enabled: boolean;  // If true, let user events be processed.
 }
-
-// This component renders HTML for a vertical tool-bar used to style text in
-// a text-tool-editor. What follows is a pseudo-markup-outline for the various
-// HTML-tags & CSS-class names.
-//
-// <div text-style-bar>
-//   <div bar-header-icon>
-//     <svg header-icon />
-//   </div>
-//   <div button-with-tool-tip >  // This div is repeated for each button.
-//     <i button-icon fa fa-fw (on | off) [fa-bold, fa-italic, ..., fa-undo] />
-//     <span tool-tip-text />
-//   </div>
-//   ...
-// </div>
 
 @inject("stores")
 @observer
@@ -52,35 +41,25 @@ export class TextStyleBarComponent extends BaseComponent<IProps> {
     { iconName: "subscript",   toolTip: `Subscript (${this.prefix},)`},
     { iconName: "superscript", toolTip: `Superscript (${this.prefix}Shift-,)`},
     { iconName: "list-ol",     toolTip: `Numbered List`},
-    { iconName: "list-ul",     toolTip: `Bulleted List`},
-    { iconName: "undo",        toolTip: `Undo (${this.prefix}z)` }
+    { iconName: "list-ul",     toolTip: `Bulleted List`}
   ];
 
   public render() {
+    const { portalDomElement, top, left, enabled, visible } = this.props;
     const onMouseDownHandler = (event: React.MouseEvent) => {
       event.preventDefault();
     };
-    if (this.props.visible) {
-      const enabledClass = this.props.enabled ? "enabled" : "";
+    if (portalDomElement && top && (left != null) && visible) {
+      const enabledClass = enabled ? "enabled" : "";
+      const style = { top, left };
       return (
-        <div className={`text-style-bar ${enabledClass}`}
-             onMouseDown={onMouseDownHandler}>
-          {this.renderHeaderIcon()}
-          {this.buttonDefs.map(bDef => this.renderButton(bDef))}
-        </div>
+        ReactDOM.createPortal(
+          <div className={`text-style-bar ${enabledClass}`} style={style} onMouseDown={onMouseDownHandler}>
+            {this.buttonDefs.map(button => this.renderButton(button))}
+          </div>, portalDomElement)
       );
     }
     return (null);
-  }
-
-  private renderHeaderIcon() {
-    return (
-      <div className={"bar-header-icon"}>
-        <svg className="header-icon" viewBox="10 10 150 150">
-          <use xlinkHref="#icon-text-tool"/>
-        </svg>
-      </div>
-    );
   }
 
   private renderButton(buttonDef: IButtonDef) {

--- a/src/components/tools/text-tool.sass
+++ b/src/components/tools/text-tool.sass
@@ -4,20 +4,13 @@
   width: 100%
   height: 100%
 
-.text-tool
-  width: calc(100% - 50px)
-  min-height: auto
-  text-align: left
-  padding: 3px 0
-  margin: 3px 0
-  overflow: 
-
   &.editable
     border: 1px solid #cccccc
-    min-height: 311px
-    left: 44px
-    top: 0
-    position: relative
-    width: calc(100% - 46px)
-    padding 0
-    margin 0
+
+  .text-tool
+    width: 100%
+    min-height: 52px
+    text-align: left
+    padding: 3px
+    margin: 3px
+    overflow:

--- a/src/components/tools/text-tool.tsx
+++ b/src/components/tools/text-tool.tsx
@@ -11,7 +11,7 @@ import { debouncedSelectTile } from "../../models/stores/ui";
 import { TextContentModelType } from "../../models/tools/text/text-content";
 import { hasSelectionModifier } from "../../utilities/event-utils";
 import { getToolbarLocation } from "../utilities/tile-utils";
-import { TextStyleBarComponent } from "./text-style-bar";
+import { TextStyleBarComponent } from "./text-toolbar";
 import { IToolTileProps } from "./tool-tile";
 import { renderSlateMark, renderSlateBlock } from "./slate-renderers";
 

--- a/src/components/tools/text-tool.tsx
+++ b/src/components/tools/text-tool.tsx
@@ -8,10 +8,11 @@ import { isHotkey } from "is-hotkey";
 
 import { BaseComponent } from "../base";
 import { debouncedSelectTile } from "../../models/stores/ui";
-import { ToolTileModelType } from "../../models/tools/tool-tile";
 import { TextContentModelType } from "../../models/tools/text/text-content";
 import { hasSelectionModifier } from "../../utilities/event-utils";
+import { getToolbarLocation } from "../utilities/tile-utils";
 import { TextStyleBarComponent } from "./text-style-bar";
+import { IToolTileProps } from "./tool-tile";
 import { renderSlateMark, renderSlateBlock } from "./slate-renderers";
 
 import "./text-tool.sass";
@@ -93,23 +94,20 @@ interface ISlateMapEntry {
   hotKey?: string;            // If missing, not a keyboard function.
 }
 
-interface IProps {
-  model: ToolTileModelType;
-  readOnly?: boolean;
-}
-
 interface IState {
   value?: Value;
   selectedButtons?: string[];
+  toolLeft?: number;
+  toolBottom?: number;
 }
 
 @inject("stores")
 @observer
-export default class TextToolComponent extends BaseComponent<IProps, IState> {
+export default class TextToolComponent extends BaseComponent<IToolTileProps, IState> {
   public state: IState = {};
   private disposers: IReactionDisposer[];
   private prevText: any;
-  private wrapper = React.createRef<HTMLDivElement>();
+  private textToolDiv: HTMLElement | null;
   private editor = React.createRef<Editor>();
 
   private slateMap: ISlateMapEntry[] = [
@@ -202,6 +200,18 @@ export default class TextToolComponent extends BaseComponent<IProps, IState> {
         }
       }));
     }
+
+    this.props.onRegisterToolApi({
+      handleDocumentScroll: (x: number, y: number) => {
+        if (this.isEditableAndSelected()) {
+          this.forceUpdate();
+        }
+      },
+      handleTileResize: entry => {
+        const { left, bottom } = entry.contentRect;
+        this.setState({ toolLeft: left, toolBottom: bottom });
+      }
+    });
   }
 
   public componentWillUnmount() {
@@ -209,18 +219,28 @@ export default class TextToolComponent extends BaseComponent<IProps, IState> {
   }
 
   public render() {
-    const { model, readOnly } = this.props;
-    const { ui, unit: { placeholderText } } = this.stores;
+    const { documentContent, model, readOnly } = this.props;
+    const { value: editorValue, selectedButtons, toolLeft, toolBottom } = this.state;
+    const isFocused = editorValue?.selection.isFocused;
+    const { unit: { placeholderText } } = this.stores;
     const editableClass = readOnly ? "read-only" : "editable";
     // Ideally this would just be 'text-tool-editor', but 'text-tool' has been
     // used here for a while now and cypress tests depend on it. Should transition
     // to using 'text-tool-editor' for these purposes moving forward.
     const classes = `text-tool text-tool-editor ${editableClass}`;
 
-    const renderStyleBar = !readOnly;
-    const enableStyleBar = !readOnly && ui.isSelectedTile(model);
+    if (!editorValue) return null;
 
-    if (!this.state.value) { return null; }
+    const enableStyleBar = this.isEditableAndSelected();
+    const [toolbarLeft, toolbarTop] = getToolbarLocation({
+                                        documentContent,
+                                        toolTile: this.textToolDiv,
+                                        toolbarHeight: 29,
+                                        minToolContent: 22,
+                                        toolLeft,
+                                        toolBottom
+                                      });
+    const isStyleBarVisible = enableStyleBar && ((toolbarTop || 0) >= 0);
 
     const handleToolBarButtonClick = (
         buttonIconName: string,
@@ -246,15 +266,18 @@ export default class TextToolComponent extends BaseComponent<IProps, IState> {
       // Ideally, this would just be 'text-tool' for consistency with other tools,
       // but 'text-tool` is used for the internal editor (cf. 'classes' above),
       // which is used for cypress tests and other purposes.
-      <div className="text-tool-wrapper"
-        ref={this.wrapper}
+      <div className={`text-tool-wrapper ${readOnly ? "" : "editable"}`}
+        ref={elt => this.textToolDiv = elt}
         onMouseDown={this.handleMouseDownInWrapper}>
         <TextStyleBarComponent
-          selectedButtonNames={this.state.selectedButtons ? this.state.selectedButtons : []}
+          portalDomElement={isFocused ? documentContent : undefined}
+          top={toolbarTop}
+          left={toolbarLeft}
+          selectedButtonNames={selectedButtons || []}
           clickHandler={handleToolBarButtonClick}
           editor={this.editor}
           enabled={enableStyleBar}
-          visible={renderStyleBar}
+          visible={isStyleBarVisible}
         />
         <Editor
           key={model.id}
@@ -262,7 +285,7 @@ export default class TextToolComponent extends BaseComponent<IProps, IState> {
           ref={this.editor}
           placeholder={placeholderText}
           readOnly={readOnly}
-          value={this.state.value}
+          value={editorValue}
           onChange={this.handleChange}
           renderMark={this.renderMark}
           renderBlock={this.renderBlock}
@@ -272,28 +295,19 @@ export default class TextToolComponent extends BaseComponent<IProps, IState> {
     );
   }
 
+  private isEditableAndSelected() {
+    const { model, readOnly } = this.props;
+    const { ui } = this.stores;
+    return !readOnly && ui.isSelectedTile(model);
+  }
+
   private handleChange = (change: SlateChange) => {
     const { readOnly, model } = this.props;
     const content = this.getContent();
     const { ui } = this.stores;
 
-    // determine last focus state from list of operations
-    let isFocused: boolean | undefined;
-    change.operations.forEach(op => {
-      if (op && op.type === "set_selection") {
-        isFocused = op.properties.isFocused;
-      }
-    });
-
-    if (isFocused != null) {
-      // polarity is reversed from what one might expect
-      if (!isFocused) {
-        // only select - if we deselect, it breaks delete because Slate
-        // somehow detects the selection change before the click on the
-        // delete button is processed by the workspace. For now, we just
-        // disable focus change on deselection.
-        debouncedSelectTile(ui, model);
-      }
+    if (change.value.selection.isFocused) {
+      debouncedSelectTile(ui, model);
     }
 
     if (content.type === "Text" && !readOnly) {
@@ -356,7 +370,7 @@ export default class TextToolComponent extends BaseComponent<IProps, IState> {
     const { ui } = this.stores;
     const { model, readOnly } = this.props;
     const isExtendingSelection = hasSelectionModifier(e);
-    const isWrapperClick = e.target === this.wrapper.current;
+    const isWrapperClick = e.target === this.textToolDiv;
     if (readOnly || isWrapperClick || isExtendingSelection) {
       isWrapperClick && this.editor.current?.focus();
       ui.setSelectedTile(model, { append: isExtendingSelection });

--- a/src/components/tools/text-toolbar-button.tsx
+++ b/src/components/tools/text-toolbar-button.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import classNames from "classnames";
+
+interface IProps {
+  iconName: string;
+  tooltip: string;
+  enabled: boolean;
+  isSelected: boolean;
+  onClick: (e: React.MouseEvent) => void;
+}
+
+const iconClasses = (iconName: string, enabled: boolean, isSelected: boolean) => {
+  return classNames("button-icon", "fa", "fa-fw", `fa-${iconName}`, isSelected ? "on" : "off", { enabled });
+};
+
+export const TextToolbarButton: React.FC<IProps> = ({
+              iconName, tooltip, enabled, isSelected, onClick
+            }: IProps) => {
+  return (
+    <div className={classNames("button-with-tool-tip", { enabled })} key={iconName}>
+      <i className={iconClasses(iconName, enabled, isSelected)} onClick={onClick} />
+      <span className={classNames("tool-tip-text", { enabled })}>
+        {tooltip}
+      </span>
+    </div>
+  );
+};

--- a/src/components/tools/text-toolbar.sass
+++ b/src/components/tools/text-toolbar.sass
@@ -1,6 +1,6 @@
 @import ../vars
 
-.text-style-bar
+.text-toolbar
   background-color: $color3-4
   position: absolute
   display: flex
@@ -11,6 +11,7 @@
   height: 29px
 
   .button-with-tool-tip
+    position: relative
     background-color: $color3-4
     color: black
     font-size: 16px
@@ -44,5 +45,5 @@
   border: solid 1px #dfdfdf
   box-shadow: 4px 4px 2px lightgray
   font-size: 8pt
-  top: 10px
-  left: 25px
+  top: 28px
+  left: 0px

--- a/src/components/tools/text-toolbar.sass
+++ b/src/components/tools/text-toolbar.sass
@@ -7,9 +7,6 @@
   justify-content: space-around
   align-items: center
   margin: 4px 2px 2px 2px
-  float: left
-  top: 86px
-  left: 0
   width: 232px
   height: 29px
 

--- a/src/components/tools/text-toolbar.tsx
+++ b/src/components/tools/text-toolbar.tsx
@@ -4,7 +4,7 @@ import { inject, observer } from "mobx-react";
 import { BaseComponent } from "../base";
 import { isMac } from "../../utilities/browser";
 
-import "./text-style-bar.sass";
+import "./text-toolbar.sass";
 
 interface IButtonDef {
   iconName: string;  // Font-Awesome icon name for this button.

--- a/src/components/tools/tile-comments.tsx
+++ b/src/components/tools/tile-comments.tsx
@@ -64,18 +64,14 @@ export class TileCommentsComponent extends BaseComponent<IProps> {
 
   private handleHover = (selectionInfo?: string) => () => {
     const { toolApiInterface, model } = this.props;
-    const toolApi = toolApiInterface && toolApiInterface.getToolApi(model.tileId);
-    if (toolApi && selectionInfo) {
-      toolApi.setSelectionHighlight(selectionInfo, true);
-    }
+    const toolApi = toolApiInterface?.getToolApi(model.tileId);
+    selectionInfo && toolApi?.setSelectionHighlight?.(selectionInfo, true);
   }
 
   private handleLeave = (selectionInfo?: string) => () => {
     const { toolApiInterface, model } = this.props;
-    const toolApi = toolApiInterface && toolApiInterface.getToolApi(model.tileId);
-    if (toolApi && selectionInfo) {
-      toolApi.setSelectionHighlight(selectionInfo, false);
-    }
+    const toolApi = toolApiInterface?.getToolApi(model.tileId);
+    selectionInfo && toolApi?.setSelectionHighlight?.(selectionInfo, false);
   }
 
   private handleDelete = (comment: TileCommentModelType) => () => {

--- a/src/components/tools/tool-tile.tsx
+++ b/src/components/tools/tool-tile.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import classNames from "classnames";
+import ResizeObserver from "resize-observer-polyfill";
 import { observer, inject } from "mobx-react";
 import { getDisabledFeaturesOfTile } from "../../models/stores/stores";
 import { cloneTileSnapshotWithoutId, IDragTiles, ToolTileModelType } from "../../models/tools/tool-tile";
@@ -27,24 +28,25 @@ import "../../utilities/dom-utils";
 import "./tool-tile.sass";
 
 export interface IToolApi {
-  hasSelection: () => boolean;
-  deleteSelection: () => void;
-  getSelectionInfo: () => string;
-  setSelectionHighlight: (selectionInfo: string, isHighlighted: boolean) => void;
+  hasSelection?: () => boolean;
+  deleteSelection?: () => void;
+  getSelectionInfo?: () => string;
+  setSelectionHighlight?: (selectionInfo: string, isHighlighted: boolean) => void;
   isLinked?: () => boolean;
   getLinkIndex?: (index?: number) => number;
   getLinkedTables?: () => string[] | undefined;
+  handleDocumentScroll?: (x: number, y: number) => void;
+  handleTileResize?: (entry: ResizeObserverEntry) => void;
 }
 
 export interface IToolApiInterface {
   register: (id: string, toolApi: IToolApi) => void;
   unregister: (id: string) => void;
   getToolApi: (id: string) => IToolApi;
+  forEach: (callback: (api: IToolApi) => void) => void;
 }
 
-export interface IToolApiMap {
-  [id: string]: IToolApi;
-}
+export type IToolApiMap = Record<string, IToolApi>;
 
 export const kDragTiles = "org.concord.clue.drag-tiles";
 
@@ -76,6 +78,7 @@ export function extractDragTileType(dataTransfer: DataTransfer) {
 interface IToolTileBaseProps {
   context: string;
   docId: string;
+  documentContent: HTMLElement | null;
   scale?: number;
   widthPct?: number;
   height?: number;
@@ -128,6 +131,7 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
 
   private modelId: string;
   private domElement: HTMLDivElement | null;
+  private resizeObserver: ResizeObserver;
   private hotKeys: HotKeys = new HotKeys();
   private dragElement: HTMLDivElement | null;
 
@@ -152,14 +156,29 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
   }
 
   public componentDidMount() {
-    if (this.domElement) {
-      this.domElement.addEventListener("mousedown", this.handleMouseDown, true);
+    this.domElement?.addEventListener("touchstart", this.handlePointerDown, true);
+    this.domElement?.addEventListener("mousedown", this.handlePointerDown, true);
+  }
+
+  public componentDidUpdate() {
+    const { model, toolApiInterface } = this.props;
+    if (this.domElement && !this.resizeObserver) {
+      this.resizeObserver = new ResizeObserver(entries => {
+        for (const entry of entries) {
+          if (entry.target === this.domElement) {
+            toolApiInterface?.getToolApi(model.id)?.handleTileResize?.(entry);
+          }
+        }
+      });
+      this.resizeObserver.observe(this.domElement);
     }
   }
+
   public componentWillUnmount() {
-    if (this.domElement) {
-      this.domElement.removeEventListener("mousedown", this.handleMouseDown, true);
-    }
+    this.resizeObserver?.disconnect();
+
+    this.domElement?.removeEventListener("mousedown", this.handlePointerDown, true);
+    this.domElement?.removeEventListener("touchstart", this.handlePointerDown, true);
   }
 
   public render() {
@@ -259,7 +278,7 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
     this.hotKeys.dispatch(e);
   }
 
-  private handleMouseDown = (e: MouseEvent) => {
+  private handlePointerDown = (e: MouseEvent | TouchEvent) => {
     const { model } = this.props;
     const { ui } = this.stores;
 

--- a/src/components/tools/tool-tile.tsx
+++ b/src/components/tools/tool-tile.tsx
@@ -88,9 +88,12 @@ interface IToolTileBaseProps {
   onRequestRowHeight: (tileId: string, height?: number, deltaHeight?: number) => void;
 }
 
-export interface IToolTileProps extends IToolTileBaseProps {
+export interface IRegisterToolApiProps {
   onRegisterToolApi: (toolApi: IToolApi) => void;
   onUnregisterToolApi: () => void;
+}
+
+export interface IToolTileProps extends IToolTileBaseProps, IRegisterToolApiProps {
 }
 
 interface IProps extends IToolTileBaseProps {

--- a/src/components/utilities/tile-utils.ts
+++ b/src/components/utilities/tile-utils.ts
@@ -11,7 +11,7 @@ export function getToolbarLocation({
                   documentContent, toolTile, toolbarHeight, minToolContent, toolLeft, toolBottom
                 }: IGetToolbarLocationArgs) {
   const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
-  let minToolbarTop = minToolContent || 22;
+  let minToolbarTop = minToolContent || 30;
   let maxToolbarTop = viewportHeight - toolbarHeight;
   let tileLeftOffset = 0;
   let tileTopOffset = 0;

--- a/src/components/utilities/tile-utils.ts
+++ b/src/components/utilities/tile-utils.ts
@@ -35,5 +35,5 @@ export function getToolbarLocation({
   const toolbarTop = toolBottom != null
                     ? Math.max(Math.min(tileTopOffset + toolBottom - 2, maxToolbarTop), minToolbarTop)
                     : undefined;
-  return [toolbarLeft, toolbarTop];
+  return { left: toolbarLeft, top: toolbarTop };
 }

--- a/src/components/utilities/tile-utils.ts
+++ b/src/components/utilities/tile-utils.ts
@@ -1,0 +1,39 @@
+interface IGetToolbarLocationArgs {
+  documentContent?: HTMLElement | null;
+  toolTile?: HTMLElement | null;
+  toolbarHeight: number;
+  minToolContent?: number;
+  toolLeft?: number;
+  toolBottom?: number;
+}
+
+export function getToolbarLocation({
+                  documentContent, toolTile, toolbarHeight, minToolContent, toolLeft, toolBottom
+                }: IGetToolbarLocationArgs) {
+  const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
+  let minToolbarTop = minToolContent || 22;
+  let maxToolbarTop = viewportHeight - toolbarHeight;
+  let tileLeftOffset = 0;
+  let tileTopOffset = 0;
+
+  if (documentContent && toolTile) {
+    const docBounds = documentContent.getBoundingClientRect();
+    const textBounds = toolTile.getBoundingClientRect();
+    const topOffset = textBounds.top - docBounds.top;
+    const leftOffset = textBounds.left - docBounds.left;
+    if ((topOffset != null) && (leftOffset != null)) {
+      tileTopOffset = topOffset;
+      tileLeftOffset = leftOffset;
+    }
+    minToolbarTop += topOffset;
+    maxToolbarTop -= docBounds.top;
+  }
+
+  const toolbarLeft = toolLeft != null
+                      ? tileLeftOffset + toolLeft - 4
+                      : undefined;
+  const toolbarTop = toolBottom != null
+                    ? Math.max(Math.min(tileTopOffset + toolBottom - 2, maxToolbarTop), minToolbarTop)
+                    : undefined;
+  return [toolbarLeft, toolbarTop];
+}

--- a/src/hooks/use-tool-api-interface.ts
+++ b/src/hooks/use-tool-api-interface.ts
@@ -1,3 +1,4 @@
+import { each } from "lodash";
 import { useRef } from "react";
 import { IToolApi, IToolApiInterface, IToolApiMap } from "../components/tools/tool-tile";
 
@@ -12,6 +13,9 @@ export function useToolApiInterface(): [IToolApiMap, IToolApiInterface] {
     },
     getToolApi: (id: string) => {
       return toolApiMap.current[id];
+    },
+    forEach: (callback: (api: IToolApi) => void) => {
+      each(toolApiMap.current, api => callback(api));
     }
   });
   return [toolApiMap.current, toolApiInterface.current];

--- a/src/utilities/event-utils.ts
+++ b/src/utilities/event-utils.ts
@@ -10,14 +10,14 @@ export function isSelectionModifierKeyDown() {
   return selectionModiferKeyDown;
 }
 
-export function hasSelectionModifier(e: MouseEvent | KeyboardEvent | React.MouseEvent) {
+export function hasSelectionModifier(e: MouseEvent | TouchEvent | KeyboardEvent | React.MouseEvent) {
   return e.ctrlKey || e.metaKey || e.shiftKey;
 }
 
-export function hasContiguousModifier(e: MouseEvent | KeyboardEvent | React.MouseEvent) {
+export function hasContiguousModifier(e: MouseEvent | TouchEvent | KeyboardEvent | React.MouseEvent) {
   return e.shiftKey;
 }
 
-export function hasDiscontiguousModifier(e: MouseEvent | KeyboardEvent | React.MouseEvent) {
+export function hasDiscontiguousModifier(e: MouseEvent | TouchEvent | KeyboardEvent | React.MouseEvent) {
   return e.ctrlKey || e.metaKey;
 }


### PR DESCRIPTION
[[#174930211]](https://www.pivotaltracker.com/story/show/174930211)

Implements a floating toolbar below the tile for the text tile. Toolbar is only visible/enabled when the text tile has focus. Toolbar scrolls with the document to stay pinned to bottom of tile. Toolbar is pinned to edge of window if bottom of tile extends off screen and is hidden if the entire tile is offscreen. Design changes are not included in this PR.

The core of the implementation is encapsulated in a custom hook which computes the location of the toolbar and updates the location as the document is scrolled or the tile is resized.