### PR TITLE
Draw tool floating toolbar [#174718210]

### DIFF
--- a/cypress/integration/clue/branch/student_tests/canvas_test_spec.js
+++ b/cypress/integration/clue/branch/student_tests/canvas_test_spec.js
@@ -20,9 +20,9 @@ let tableToolTile = new TableToolTile;
 
 let studentWorkspace = 'My Student Test Workspace';
 let copyTitle = 'Personal Workspace Copy';
-let newDocTitleToPublish = 'New User Doc To Publish';
+// let newDocTitleToPublish = 'New User Doc To Publish';
 let publishTitle = 'publish 2up';
-let renameTitle = "Renamed Title title";
+// let renameTitle = "Renamed Title title";
 let renameTitlePencil = "Renamed Title pencil";
 
 

--- a/src/components/document/tile-row.sass
+++ b/src/components/document/tile-row.sass
@@ -51,3 +51,5 @@
 
     &.enable
       cursor: row-resize
+    &.disable
+      pointer-events: none

--- a/src/components/tools/drawing-tool/drawing-layer.tsx
+++ b/src/components/tools/drawing-tool/drawing-layer.tsx
@@ -613,7 +613,7 @@ interface DrawingToolMap {
 
 interface DrawingLayerViewProps {
   model: ToolTileModelType;
-  readOnly: boolean;
+  readOnly?: boolean;
   scale?: number;
   onSetCanAcceptDrop: (tileId?: string) => void;
 }

--- a/src/components/tools/drawing-tool/drawing-settings-view.tsx
+++ b/src/components/tools/drawing-tool/drawing-settings-view.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { Color, DrawingContentModelType } from "../../../models/tools/drawing/drawing-content";
+
+interface IProps {
+  drawingContent: DrawingContentModelType;
+  colors: Color[];
+  onStrokeChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+  onFillChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+  onStrokeDashArrayChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+  onStrokeWidthChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+}
+
+export const DrawingSettingsView: React.FC<IProps> = ({
+              drawingContent, colors,
+              onStrokeChange, onFillChange, onStrokeDashArrayChange, onStrokeWidthChange
+            }: IProps) => {
+  const {stroke, fill, strokeDashArray, strokeWidth} = drawingContent;
+  const pluralize = (text: string, count: number) => count === 1 ? text : `${text}s`;
+  return (
+    <div className="settings">
+      <div className="title"><span className="icon icon-menu" /> Settings</div>
+      <form>
+        <div className="form-group">
+          <label htmlFor="stroke">Color</label>
+          <select value={stroke} name="stroke" onChange={onStrokeChange}>
+            {colors.map((color, index) => <option value={color.hex} key={index}>{color.name}</option>)}
+          </select>
+        </div>
+        <div className="form-group">
+          <label htmlFor="fill">Fill</label>
+          <select value={fill} name="fill" onChange={onFillChange}>
+            <option value="none" key="none">None</option>
+            {colors.map((color, index) => <option value={color.hex} key={index}>{color.name}</option>)}
+          </select>
+        </div>
+        <div className="form-group">
+          <label htmlFor="strokeDashArray">Stroke</label>
+          <select value={strokeDashArray} name="strokeDashArray"
+              onChange={onStrokeDashArrayChange}>
+            <option value="">Solid</option>
+            <option value="dotted">Dotted</option>
+            <option value="dashed">Dashed</option>
+          </select>
+        </div>
+        <div className="form-group">
+          <label htmlFor="strokeWidth">Thickness</label>
+          <select value={strokeWidth} name="strokeWidth" onChange={onStrokeWidthChange}>
+            {[1, 2, 3, 4, 5].map((_strokeWidth) => {
+              return (
+                <option value={_strokeWidth} key={_strokeWidth}>
+                  {_strokeWidth} {pluralize("pixel", _strokeWidth)}
+                </option>
+              );
+            })}
+          </select>
+        </div>
+      </form>
+    </div>
+  );
+};

--- a/src/components/tools/drawing-tool/drawing-stamp-selection.tsx
+++ b/src/components/tools/drawing-tool/drawing-stamp-selection.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { DrawingContentModelType } from "../../../models/tools/drawing/drawing-content";
+
+interface IProps {
+  drawingContent: DrawingContentModelType;
+  onSelectStamp: (index: number) => void;
+}
+
+export const DrawingStampSelection: React.FC<IProps> = ({ drawingContent, onSelectStamp }) => {
+  const {stamps, currentStamp} = drawingContent;
+
+  const handleClick = (index: number) => {
+    onSelectStamp(index);
+  };
+  return (
+    <div className="settings stamps">
+      <div className="title"><span className="icon icon-menu" /> Stamps</div>
+      <div>
+        {
+          stamps.map((stamp, i) => {
+            const className = (currentStamp && stamp.url === currentStamp.url) ? "selected" : "";
+            return <img key={stamp.url} src={stamp.url} className={className} onClick={() => handleClick(i)} />;
+          })
+        }
+      </div>
+    </div>
+  );
+};

--- a/src/components/tools/drawing-tool/drawing-tool.sass
+++ b/src/components/tools/drawing-tool/drawing-tool.sass
@@ -4,8 +4,11 @@
   height: 100%
 
 .drawing-tool-toolbar
+  position: absolute
+  height: 44px
   background-color: #eee
   .drawing-tool-buttons
+    display: flex
     padding: 5px
     font-size: 24px
     text-align: center
@@ -17,11 +20,14 @@
         left: 22px
         font-size: 9px
         padding: 5px
+        background-color: rgba(224, 224, 224, 0.1)
       .flyout-toggle:hover
-        background-color: #fff
+        z-index: 1
+        background-color: #ccc
         color: #000
     .drawing-tool-button
       user-select: none
+      width: 32px
       padding: 2px
       margin-bottom: 5px
       cursor: pointer
@@ -42,11 +48,9 @@
       color: #000
   .settings
     position: absolute
-    top: 0
+    top: -220px
     width: 100px
-    left: 0
-    /* set in code */
-    bottom: 4px
+    left: 3px
     background-color: #bbb
     cursor: pointer
     font-size: 14px
@@ -73,6 +77,8 @@
 
     &.stamps
       width: 60px
+      left: 229px
+      top: -246px
       img
         display: block
         width: 40px

--- a/src/components/tools/drawing-tool/drawing-tool.tsx
+++ b/src/components/tools/drawing-tool/drawing-tool.tsx
@@ -1,40 +1,35 @@
-import React from "react";
-import { BaseComponent } from "../../base";
-import { ToolTileModelType } from "../../../models/tools/tool-tile";
+import classNames from "classnames";
+import React, { useEffect } from "react";
+import { IToolTileProps } from "../tool-tile";
 import { ToolbarView } from "./drawing-toolbar";
 import { DrawingLayerView } from "./drawing-layer";
-import { TOOLBAR_WIDTH, DrawingContentModelType } from "../../../models/tools/drawing/drawing-content";
+import { useToolbarToolApi } from "../hooks/use-toolbar-tool-api";
+import { DrawingContentModelType } from "../../../models/tools/drawing/drawing-content";
 
 import "./drawing-tool.sass";
 
-interface IProps {
-  model: ToolTileModelType;
-  readOnly: boolean;
-  scale?: number;
-  onSetCanAcceptDrop: (tileId?: string) => void;
-}
+type IProps = IToolTileProps;
 
-export default class DrawingToolComponent extends BaseComponent<IProps> {
+const DrawingToolComponent: React.FC<IProps> = (props) => {
+  const { documentContent, toolTile, model, readOnly, onRegisterToolApi, onUnregisterToolApi } = props;
 
-  public static tileHandlesSelection = true;
-
-  public componentDidMount() {
-    if (!this.props.readOnly) {
-      (this.props.model.content as DrawingContentModelType).reset();
+  useEffect(() => {
+    if (!readOnly) {
+      (model.content as DrawingContentModelType).reset();
     }
-  }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  public render() {
-    const { model, readOnly } = this.props;
-    const editableClass = readOnly ? " read-only" : "";
-    const className = `drawing-tool${editableClass}`;
-    return (
-      <div className={className}>
-        <ToolbarView model={model} readOnly={!!readOnly}/>
-        <div style={{left: TOOLBAR_WIDTH}} >
-          <DrawingLayerView {...this.props} />
-        </div>
-      </div>
-    );
-  }
-}
+  const toolbarProps = useToolbarToolApi({ id: model.id, readOnly, onRegisterToolApi, onUnregisterToolApi });
+
+  return (
+    <div className={classNames("drawing-tool", { "read-only": readOnly })}>
+      <ToolbarView model={model}
+                  documentContent={documentContent}
+                  toolTile={toolTile}
+                  {...toolbarProps} />
+      <DrawingLayerView {...props} />
+    </div>
+  );
+};
+(DrawingToolComponent as any).tileHandlesSelection = true;
+export default DrawingToolComponent;

--- a/src/components/tools/drawing-tool/drawing-toolbar-buttons.tsx
+++ b/src/components/tools/drawing-tool/drawing-toolbar-buttons.tsx
@@ -1,0 +1,98 @@
+import classNames from "classnames";
+import React, { useCallback, useRef } from "react";
+import {
+  computeStrokeDashArray, DrawingContentModelType, ToolbarModalButton
+} from "../../../models/tools/drawing/drawing-content";
+
+export const buttonClasses =
+        (content: DrawingContentModelType, modalButtonOrMap?: ToolbarModalButton | Record<string, any>) => {
+  const selected = typeof modalButtonOrMap === "string"
+                    ? { selected: modalButtonOrMap && (modalButtonOrMap === content.selectedButton) }
+                    : undefined;
+  const others = typeof modalButtonOrMap !== "string" ? modalButtonOrMap : undefined;
+  return classNames("drawing-tool-button", selected, others);
+};
+
+interface IBaseIconButtonProps {
+  content: DrawingContentModelType;
+  modalButton?: ToolbarModalButton | Record<string, any>;
+  title: string;
+  onSetSelectedButton?: (modalButton: ToolbarModalButton) => void;
+}
+
+/*
+ * ClassIconButton
+ */
+interface IClassIconButtonProps extends IBaseIconButtonProps {
+  iconClass: string;
+  disabled?: boolean;
+  style?: React.CSSProperties;
+  onClick?: () => void;
+  onSetSelectedButton?: (modalButton: ToolbarModalButton) => void;
+}
+export const ClassIconButton: React.FC<IClassIconButtonProps> = ({
+        content, modalButton, title, iconClass, style, onClick, onSetSelectedButton }) => {
+  const buttonRef = useRef<HTMLElement | null>(null);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const handleClick = useCallback(onClick ||
+                      (() => (typeof modalButton === "string") && onSetSelectedButton?.(modalButton)),
+                      []);
+  return (
+    <div className={buttonClasses(content, modalButton)} title={title}
+          ref={elt => buttonRef.current = elt} onClick={handleClick}>
+      <span className={`drawing-tool-icon drawing-tool-icon-${iconClass}`} style={style} />
+    </div>
+  );
+};
+
+/*
+ * SvgIconButton
+ */
+interface ISvgIconButtonProps extends IBaseIconButtonProps {
+  modalButton: ToolbarModalButton;
+}
+export const SvgIconButton: React.FC<ISvgIconButtonProps> = ({ content, modalButton, title, onSetSelectedButton }) => {
+  const handleClick = () => onSetSelectedButton?.(modalButton);
+  return (
+    <div className={buttonClasses(content, modalButton)} style={{height: 30}} title={title} onClick={handleClick}>
+      <DrawingSvgIcon content={content} button={modalButton} />
+    </div>
+  );
+};
+
+/*
+ * DrawingSvgIcon
+ */
+interface IDrawingSvgIconProps {
+  content: DrawingContentModelType;
+  button: ToolbarModalButton;
+}
+export const DrawingSvgIcon: React.FC<IDrawingSvgIconProps> = ({ content, button }) => {
+  const {stroke, fill, strokeDashArray, strokeWidth} = content;
+  let iconElement: JSX.Element|null = null;
+  const iconSize = 30;
+  const iconMargin = 5;
+  const elementSize = iconSize - (2 * iconMargin);
+  const elementHalfSize = elementSize / 2;
+
+  switch (button) {
+    case "rectangle":
+      iconElement = <rect width={elementSize} height={elementSize} />;
+      break;
+    case "ellipse":
+      iconElement = <ellipse cx={elementHalfSize} cy={elementHalfSize} rx={elementHalfSize} ry={elementHalfSize} />;
+      break;
+    case "vector":
+      iconElement = <line x1={0} y1={elementSize} x2={elementSize} y2={0} />;
+      break;
+  }
+
+  return (
+    <svg width={iconSize} height={iconSize}>
+      <g transform={`translate(${iconMargin},${iconMargin})`} fill={fill} stroke={stroke} strokeWidth={strokeWidth}
+          strokeDasharray={computeStrokeDashArray(strokeDashArray, strokeWidth)}>
+        {iconElement}
+      </g>
+    </svg>
+  );
+};

--- a/src/components/tools/drawing-tool/drawing-toolbar.tsx
+++ b/src/components/tools/drawing-tool/drawing-toolbar.tsx
@@ -1,8 +1,16 @@
-import React from "react";
-import { DrawingContentModelType, Color, ToolbarModalButton, TOOLBAR_WIDTH,
-  colors, computeStrokeDashArray } from "../../../models/tools/drawing/drawing-content";
+import React, { useState } from "react";
+import ReactDOM from "react-dom";
+import { DrawingSettingsView } from "./drawing-settings-view";
+import { DrawingStampSelection } from "./drawing-stamp-selection";
+import { buttonClasses, ClassIconButton, SvgIconButton } from "./drawing-toolbar-buttons";
+import { useFloatingToolbarLocation } from "../hooks/use-floating-toolbar-location";
+import { useForceUpdate } from "../hooks/use-force-update";
+import { useMobXOnChange } from "../hooks/use-mobx-on-change";
+import { IRegisterToolApiProps } from "../tool-tile";
+import {
+  Color, colors, DrawingContentModelType, ToolbarModalButton
+} from "../../../models/tools/drawing/drawing-content";
 import { ToolTileModelType } from "../../../models/tools/tool-tile";
-import { observer } from "mobx-react";
 
 export interface TextButtonData {
   color: string;
@@ -18,260 +26,135 @@ export interface LineButtonData {
   lineColor: Color;
 }
 
-export interface ToolbarViewProps {
+interface IProps extends IRegisterToolApiProps {
+  documentContent?: HTMLElement | null;
+  toolTile?: HTMLElement | null;
   model: ToolTileModelType;
-  readOnly: boolean;
+  onIsEnabled: () => boolean;
 }
+export const ToolbarView: React.FC<IProps> = (
+              { documentContent, model, onIsEnabled, ...others }: IProps) => {
+  const drawingContent = model.content as DrawingContentModelType;
+  const {stroke, stamps, currentStamp} = drawingContent;
+  const [showSettings, setShowSettings] = useState(false);
+  const [showStampSelection, setShowStampSelection] = useState(false);
+  const isEnabled = onIsEnabled();
+  const forceUpdate = useForceUpdate();
+  const toolbarLocation = useFloatingToolbarLocation({
+                            documentContent,
+                            toolbarHeight: 29,
+                            toolbarTopOffset: 4,
+                            minToolContent: 22,
+                            enabled: isEnabled,
+                            ...others
+                          });
 
-export interface ToolbarViewState {
-  showSettings: boolean;
-  showStampSelection: boolean;
-}
+  const modalButtonClasses = (type: ToolbarModalButton) => {
+    return buttonClasses(drawingContent, type);
+  };
 
-@observer
-export class ToolbarView extends React.Component<ToolbarViewProps, ToolbarViewState> {
-  constructor(props: ToolbarViewProps){
-    super(props);
-    this.state = {
-      showSettings: false,
-      showStampSelection: false
-    };
-  }
+  const handleSetSelectedButton = (modalButton: ToolbarModalButton) => {
+    drawingContent.setSelectedButton(modalButton);
+    forceUpdate();
+  };
 
-  public render() {
-    const drawingContent = this.props.model.content as DrawingContentModelType;
-    const {stroke, stamps, currentStamp} = drawingContent;
-    const deleteButtonClass = "drawing-tool-button" + (drawingContent.hasSelectedObjects ? "" : " disabled");
-    return (
-      <div className="drawing-tool-toolbar" style={{width: TOOLBAR_WIDTH}}>
-        <div className="drawing-tool-buttons">
-          <div className="drawing-tool-button" title="Settings" onClick={
-            this.handleSettingsButton}>
-            <span className="drawing-tool-icon drawing-tool-icon-menu" />
-          </div>
-          <div className={this.modalButtonClass("select")} title="Select"
-              onClick={this.handleSelectionToolButton}>
-            <span className="drawing-tool-icon drawing-tool-icon-mouse-pointer" />
-          </div>
-          <div className={this.modalButtonClass("line")} title="Freehand Tool"
-              onClick={this.handleLineDrawingToolButton}>
-            <span className="drawing-tool-icon drawing-tool-icon-pencil" style={{color: stroke}} />
-          </div>
-          <div className={this.modalButtonClass("vector")} style={{height: 30}} title="Line Tool"
-              onClick={this.handleVectorToolButton}>
-            {this.renderSVGIcon("vector")}
-          </div>
-          <div className={this.modalButtonClass("rectangle")} style={{height: 30}} title="Rectangle Tool"
-              onClick={this.handleRectangleToolButton}>
-            {this.renderSVGIcon("rectangle")}
-          </div>
-          <div className={this.modalButtonClass("ellipse")} style={{height: 30}} title="Ellipse Tool"
-              onClick={this.handleEllipseToolButton}>
-            {this.renderSVGIcon("ellipse")}
-          </div>
-          {
-            currentStamp &&
-            <div
-                className={"flyout-top-button " + this.modalButtonClass("stamp")}
-                style={{height: 30}} title="Coin Stamp"
-              onClick={this.handleStampToolButton}>
-              <img src={currentStamp.url} />
-              {
-                stamps.length > 1 &&
-                <div className="flyout-toggle" onClick={this.handleStampListButton}>
-                  ▶
-                </div>
-              }
-            </div>
-          }
-          <div className={deleteButtonClass} title="Delete" onClick={this.handleDeleteButton}>
-            <span className="drawing-tool-icon drawing-tool-icon-bin" />
-          </div>
-        </div>
-        {this.state.showSettings ? this.renderSettings() : null}
-        {this.state.showStampSelection ? this.renderStampSelection() : null}
-      </div>
-    );
-  }
+  const handleSettingsButton = () => {
+    setShowSettings(state => !state);
+    setShowStampSelection(false);
+  };
 
-  private handleSettingsButton = () => {
-    if (this.props.readOnly) return;
-    this.setState(state => ({
-      showSettings: !state.showSettings,
-      showStampSelection: false
-    }));
-  }
-  private handleLineDrawingToolButton = () => {
-    if (this.props.readOnly) return;
-    const drawingContent = this.props.model.content as DrawingContentModelType;
-    drawingContent.setSelectedButton("line");
-  }
-  private handleVectorToolButton = () => {
-    if (this.props.readOnly) return;
-    const drawingContent = this.props.model.content as DrawingContentModelType;
-    drawingContent.setSelectedButton("vector");
-  }
-  private handleSelectionToolButton = () => {
-    if (this.props.readOnly) return;
-    const drawingContent = this.props.model.content as DrawingContentModelType;
-    drawingContent.setSelectedButton("select");
-  }
-  private handleRectangleToolButton = () => {
-    if (this.props.readOnly) return;
-    const drawingContent = this.props.model.content as DrawingContentModelType;
-    drawingContent.setSelectedButton("rectangle");
-  }
-  private handleEllipseToolButton = () => {
-    if (this.props.readOnly) return;
-    const drawingContent = this.props.model.content as DrawingContentModelType;
-    drawingContent.setSelectedButton("ellipse");
-  }
-  private handleStampToolButton = () => {
-    if (this.props.readOnly) return;
-    const drawingContent = this.props.model.content as DrawingContentModelType;
-    drawingContent.setSelectedButton("stamp");
-  }
-  private handleStampListButton = () => {
-    if (this.props.readOnly) return;
-    this.setState(state => ({
-      showSettings: false,
-      showStampSelection: !state.showStampSelection
-    }));
-  }
-  private handleSelectStamp = (stampIndex: number) => () => {
-    if (this.props.readOnly) return;
-    const drawingContent = this.props.model.content as DrawingContentModelType;
-    drawingContent.setSelectedStamp(stampIndex);
-    drawingContent.setSelectedButton("stamp");
-    this.setState({
-      showSettings: false,
-      showStampSelection: false
-    });
-  }
-  private handleDeleteButton = () => {
-    if (this.props.readOnly) return;
-    const drawingContent = this.props.model.content as DrawingContentModelType;
-    drawingContent.deleteSelectedObjects();
-  }
-
-  private handleStrokeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    if (this.props.readOnly) return;
-    (this.props.model.content as DrawingContentModelType).setStroke(e.target.value);
-  }
-  private handleFillChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    if (this.props.readOnly) return;
-    (this.props.model.content as DrawingContentModelType).setFill(e.target.value);
-  }
-  private handleStrokeDashArrayChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    if (this.props.readOnly) return;
-    (this.props.model.content as DrawingContentModelType).setStrokeDashArray(e.target.value);
-  }
-  private handleStrokeWidthChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    if (this.props.readOnly) return;
-    (this.props.model.content as DrawingContentModelType).setStrokeWidth(+e.target.value);
-  }
-
-  private modalButtonClass(type: ToolbarModalButton) {
-    const drawingContent = this.props.model.content as DrawingContentModelType;
-    const selected = type === drawingContent.selectedButton;
-    return `drawing-tool-button ${selected ? "selected" : ""}`;
-  }
-
-  private renderSettings() {
-    const drawingContent = this.props.model.content as DrawingContentModelType;
-    const {stroke, fill, strokeDashArray, strokeWidth} = drawingContent;
-    const pluralize = (text: string, count: number) => count === 1 ? text : `${text}s`;
-    return (
-      <div className="settings" style={{left: TOOLBAR_WIDTH}}>
-        <div className="title"><span className="icon icon-menu" /> Settings</div>
-        <form>
-          <div className="form-group">
-            <label htmlFor="stroke">Color</label>
-            <select value={stroke} name="stroke" onChange={this.handleStrokeChange}>
-              {colors.map((color, index) => <option value={color.hex} key={index}>{color.name}</option>)}
-            </select>
-          </div>
-          <div className="form-group">
-            <label htmlFor="fill">Fill</label>
-            <select value={fill} name="fill" onChange={this.handleFillChange}>
-              <option value="none" key="none">None</option>
-              {colors.map((color, index) => <option value={color.hex} key={index}>{color.name}</option>)}
-            </select>
-          </div>
-          <div className="form-group">
-            <label htmlFor="strokeDashArray">Stroke</label>
-            <select value={strokeDashArray} name="strokeDashArray"
-                onChange={this.handleStrokeDashArrayChange}>
-              <option value="">Solid</option>
-              <option value="dotted">Dotted</option>
-              <option value="dashed">Dashed</option>
-            </select>
-          </div>
-          <div className="form-group">
-            <label htmlFor="strokeWidth">Thickness</label>
-            <select value={strokeWidth} name="strokeWidth" onChange={this.handleStrokeWidthChange}>
-              {[1, 2, 3, 4, 5].map((_strokeWidth) => {
-                return (
-                  <option value={_strokeWidth} key={_strokeWidth}>
-                    {_strokeWidth} {pluralize("pixel", _strokeWidth)}
-                  </option>
-                );
-              })}
-            </select>
-          </div>
-        </form>
-      </div>
-    );
-  }
-
-  private renderStampSelection() {
-    const drawingContent = this.props.model.content as DrawingContentModelType;
-    const {stamps, currentStamp} = drawingContent;
-
-    return (
-      <div className="settings stamps" style={{left: TOOLBAR_WIDTH}}>
-        <div className="title"><span className="icon icon-menu" /> Stamps</div>
-        <div>
-          {
-            stamps.map((stamp, i) => {
-              const className = (currentStamp && stamp.url === currentStamp.url) ? "selected" : "";
-              return <img key={stamp.url} src={stamp.url} className={className}
-                onClick={this.handleSelectStamp(i)} />;
-            })
-          }
-        </div>
-      </div>
-    );
-  }
-
-  private renderSVGIcon(button: ToolbarModalButton) {
-    const drawingContent = this.props.model.content as DrawingContentModelType;
-    const {stroke, fill, strokeDashArray, strokeWidth} = drawingContent;
-    let iconElement: JSX.Element|null = null;
-    const iconSize = 30;
-    const iconMargin = 5;
-    const elementSize = iconSize - (2 * iconMargin);
-    const elementHalfSize = elementSize / 2;
-
-    switch (button) {
-      case "rectangle":
-        iconElement = <rect width={elementSize} height={elementSize} />;
-        break;
-      case "ellipse":
-        iconElement = <ellipse cx={elementHalfSize} cy={elementHalfSize} rx={elementHalfSize} ry={elementHalfSize}  />;
-        break;
-      case "vector":
-        iconElement = <line x1={0} y1={elementSize} x2={elementSize} y2={0}  />;
-        break;
+  const handleStampListButton = () => {
+    if (isEnabled) {
+      setShowSettings(false);
+      setShowStampSelection(state => !state);
     }
+  };
 
-    return (
-      <svg width={iconSize} height={iconSize}>
-        <g transform={`translate(${iconMargin},${iconMargin})`} fill={fill} stroke={stroke} strokeWidth={strokeWidth}
-            strokeDasharray={computeStrokeDashArray(strokeDashArray, strokeWidth)}>
-          {iconElement}
-        </g>
-      </svg>
-    );
-  }
-}
+  const handleSelectStamp = (stampIndex: number) => {
+    if (isEnabled) {
+      drawingContent.setSelectedStamp(stampIndex);
+      drawingContent.setSelectedButton("stamp");
+      setShowSettings(false);
+      setShowStampSelection(false);
+    }
+  };
+
+  // update toolbar when object selection changes
+  useMobXOnChange(
+    () => drawingContent.hasSelectedObjects,
+    () => forceUpdate()
+  );
+
+  const handleDeleteButton = () => {
+    drawingContent.deleteSelectedObjects();
+  };
+
+  const handleStrokeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    isEnabled && drawingContent.setStroke(e.target.value);
+    forceUpdate();
+  };
+  const handleFillChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    isEnabled && drawingContent.setFill(e.target.value);
+    forceUpdate();
+  };
+  const handleStrokeDashArrayChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    isEnabled && drawingContent.setStrokeDashArray(e.target.value);
+    forceUpdate();
+  };
+  const handleStrokeWidthChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    isEnabled && drawingContent.setStrokeWidth(+e.target.value);
+    forceUpdate();
+  };
+
+  return isEnabled && documentContent
+    ? ReactDOM.createPortal(
+        <div className="drawing-tool-toolbar" style={toolbarLocation}>
+          <div className="drawing-tool-buttons">
+            <ClassIconButton content={drawingContent} title="Settings"
+                              iconClass="menu" onClick={handleSettingsButton} />
+            <ClassIconButton content={drawingContent} modalButton="select" title="Select"
+                              iconClass="mouse-pointer" onSetSelectedButton={handleSetSelectedButton} />
+            <ClassIconButton content={drawingContent} modalButton="line" title="Freehand Tool"
+                              iconClass="pencil" style={{color: stroke}}
+                              onSetSelectedButton={handleSetSelectedButton} />
+            <SvgIconButton content={drawingContent} modalButton="vector" title="Line Tool"
+                              onSetSelectedButton={handleSetSelectedButton} />
+            <SvgIconButton content={drawingContent} modalButton="rectangle" title="Rectangle Tool"
+                              onSetSelectedButton={handleSetSelectedButton} />
+            <SvgIconButton content={drawingContent} modalButton="ellipse" title="Ellipse Tool"
+                              onSetSelectedButton={handleSetSelectedButton} />
+            {
+              currentStamp &&
+              <div
+                  className={"flyout-top-button " + modalButtonClasses("stamp")}
+                  style={{height: 30}} title="Coin Stamp"
+                onClick={() => handleSetSelectedButton("stamp")}>
+                {
+                  stamps.length > 1 &&
+                  <div className="flyout-toggle" onClick={handleStampListButton}>
+                    ▶
+                  </div>
+                }
+                <img src={currentStamp.url} />
+              </div>
+            }
+            <ClassIconButton content={drawingContent} modalButton={{ disabled: !drawingContent.hasSelectedObjects }}
+                  title="Delete" iconClass="bin" onClick={handleDeleteButton} />
+          </div>
+          {showSettings
+            ? <DrawingSettingsView
+                drawingContent={drawingContent}
+                colors={colors}
+                onStrokeChange={handleStrokeChange}
+                onFillChange={handleFillChange}
+                onStrokeDashArrayChange={handleStrokeDashArrayChange}
+                onStrokeWidthChange={handleStrokeWidthChange} />
+            : null}
+          {showStampSelection
+            ? <DrawingStampSelection
+                drawingContent={drawingContent}
+                onSelectStamp={handleSelectStamp} />
+            : null}
+        </div>, documentContent)
+  : null;
+};

--- a/src/components/tools/hooks/use-force-update.ts
+++ b/src/components/tools/hooks/use-force-update.ts
@@ -1,0 +1,6 @@
+import { useState } from "react";
+
+export const useForceUpdate = () => {
+  const [ , setChangeCount] = useState(0);
+  return () => setChangeCount(count => count + 1);
+};

--- a/src/components/tools/hooks/use-mobx-on-change.ts
+++ b/src/components/tools/hooks/use-mobx-on-change.ts
@@ -1,0 +1,16 @@
+import { reaction } from "mobx";
+import { useEffect, useRef } from "react";
+
+export function useMobXOnChange<T>(getValue: () => T, onChange: (value: T) => void) {
+  const valueRef = useRef(getValue());
+  useEffect(() => {
+    reaction(
+      getValue,
+      value => {
+        if (value !== valueRef.current) {
+          valueRef.current = value;
+          onChange(value);
+        }
+      });
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+}

--- a/src/components/tools/hooks/use-toolbar-tool-api.ts
+++ b/src/components/tools/hooks/use-toolbar-tool-api.ts
@@ -1,0 +1,50 @@
+import { useEffect, useMemo, useRef } from "react";
+import { useUIStore } from "../../../hooks/use-stores";
+import { IToolApi } from "../tool-tile";
+
+interface IUseToolbarToolApi {
+  id: string;
+  readOnly?: boolean;
+  onRegisterToolApi: (toolApi: IToolApi) => void;
+  onUnregisterToolApi: () => void;
+}
+
+/*
+ * Implements the tool's side of the floating toolbar API.
+ */
+export const useToolbarToolApi = (
+  { id, readOnly, onRegisterToolApi, onUnregisterToolApi }: IUseToolbarToolApi) => {
+  const toolbarToolApi = useRef<IToolApi | undefined>();
+
+  useEffect(() => {
+    onRegisterToolApi({
+      handleDocumentScroll: (x: number, y: number) => {
+        toolbarToolApi.current?.handleDocumentScroll?.(x, y);
+      },
+      handleTileResize: (entry: ResizeObserverEntry) => {
+        toolbarToolApi.current?.handleTileResize?.(entry);
+      }
+    });
+    return () => onUnregisterToolApi();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const ui = useUIStore();
+  const handleIsEnabled = useRef(() => {
+    // Implemented as callback so that the MST accesses occur from the toolbar's
+    // render function rather than the parent tool's, so that only the former
+    // will re-render and not the latter.
+    return !readOnly &&
+            (ui?.selectedTileIds.length === 1) &&
+            (ui?.selectedTileIds.includes(id));
+  });
+
+  return useMemo(() => ({
+    onRegisterToolApi: (toolApi: IToolApi) => {
+      toolbarToolApi.current = toolApi;
+    },
+    onUnregisterToolApi: () => {
+      toolbarToolApi.current = undefined;
+    },
+    onIsEnabled: handleIsEnabled.current
+  }), []);
+};

--- a/src/components/tools/text-toolbar.tsx
+++ b/src/components/tools/text-toolbar.tsx
@@ -39,17 +39,18 @@ const handleMouseDown = (event: React.MouseEvent) => {
 
 export const TextToolbarComponent: React.FC<IProps> = (props: IProps) => {
   const { documentContent, enabled, editor, selectedButtons, onButtonClick, ...others } = props;
-  const { isValid, left, top } = useFloatingToolbarLocation({
-                                  documentContent,
-                                  toolbarHeight: 29,
-                                  minToolContent: 22,
-                                  enabled,
-                                  ...others
-                                });
-  return documentContent && enabled && isValid
+  const toolbarLocation = useFloatingToolbarLocation({
+                            documentContent,
+                            toolbarHeight: 29,
+                            minToolContent: 22,
+                            toolbarLeftOffset: -2,
+                            enabled,
+                            ...others
+                          });
+  return documentContent && enabled && toolbarLocation
     ? ReactDOM.createPortal(
         <div className={`text-toolbar ${enabled ? "enabled" : ""}`}
-              style={{ left, top }} onMouseDown={handleMouseDown}>
+              style={toolbarLocation} onMouseDown={handleMouseDown}>
           {buttonDefs.map(button => {
             const { iconName, toolTip } = button;
             const isSelected = !!selectedButtons.find(b => b === iconName);

--- a/src/components/tools/tool-tile.tsx
+++ b/src/components/tools/tool-tile.tsx
@@ -94,6 +94,7 @@ export interface IRegisterToolApiProps {
 }
 
 export interface IToolTileProps extends IToolTileBaseProps, IRegisterToolApiProps {
+  toolTile: HTMLElement | null;
 }
 
 interface IProps extends IToolTileBaseProps {
@@ -230,7 +231,7 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
     const { toolApiInterface, ...otherProps } = this.props;
     return ToolComponent != null
             ? <ToolComponent
-                key={tileId} {...otherProps}
+                key={tileId} toolTile={this.domElement} {...otherProps}
                 onRegisterToolApi={this.handleRegisterToolApi}
                 onUnregisterToolApi={this.handleUnregisterToolApi} />
             : null;
@@ -295,7 +296,7 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
     }
 
     const ToolComponent = kToolComponentMap[model.content.type];
-    if (ToolComponent && ToolComponent.tileHandlesSelection) {
+    if (ToolComponent?.tileHandlesSelection) {
       ui.setSelectedTile(model, {append: hasSelectionModifier(e)});
     }
   }

--- a/src/components/utilities/tile-utils.ts
+++ b/src/components/utilities/tile-utils.ts
@@ -1,15 +1,20 @@
-interface IGetToolbarLocationArgs {
+export interface IGetToolbarLocationBaseArgs {
   documentContent?: HTMLElement | null;
   toolTile?: HTMLElement | null;
   toolbarHeight: number;
   minToolContent?: number;
+  toolbarLeftOffset?: number;
+  toolbarTopOffset?: number;
+}
+
+interface IGetToolbarLocationArgs extends IGetToolbarLocationBaseArgs {
   toolLeft?: number;
   toolBottom?: number;
 }
 
 export function getToolbarLocation({
-                  documentContent, toolTile, toolbarHeight, minToolContent, toolLeft, toolBottom
-                }: IGetToolbarLocationArgs) {
+    documentContent, toolTile, toolbarHeight, minToolContent, toolLeft, toolBottom, toolbarLeftOffset, toolbarTopOffset
+  }: IGetToolbarLocationArgs) {
   const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
   let minToolbarTop = minToolContent || 30;
   let maxToolbarTop = viewportHeight - toolbarHeight;
@@ -30,10 +35,12 @@ export function getToolbarLocation({
   }
 
   const toolbarLeft = toolLeft != null
-                      ? tileLeftOffset + toolLeft - 4
+                      ? tileLeftOffset + toolLeft + (toolbarLeftOffset || 0)
                       : undefined;
   const toolbarTop = toolBottom != null
-                    ? Math.max(Math.min(tileTopOffset + toolBottom - 2, maxToolbarTop), minToolbarTop)
+                    ? Math.max(
+                        Math.min(tileTopOffset + toolBottom + (toolbarTopOffset || 0), maxToolbarTop),
+                        minToolbarTop)
                     : undefined;
   return { left: toolbarLeft, top: toolbarTop };
 }


### PR DESCRIPTION
[[#174718210]](https://www.pivotaltracker.com/story/show/174718210)

As with the text toolbar, this doesn't update the draw toolbar to the latest specs, it just turns the existing toolbar horizontal and makes it float. To do so, the existing code was extensively refactored into functional components using hooks. Taking the implementation from the text tool one step further, the tool's responsibilities are now encapsulated in the `useToolbarToolApi()` hook function.