### PR TITLE
Dispose MobX reaction on unmount

### DIFF
--- a/src/components/tools/hooks/use-mobx-on-change.ts
+++ b/src/components/tools/hooks/use-mobx-on-change.ts
@@ -4,13 +4,14 @@ import { useEffect, useRef } from "react";
 export function useMobXOnChange<T>(getValue: () => T, onChange: (value: T) => void) {
   const valueRef = useRef(getValue());
   useEffect(() => {
-    reaction(
-      getValue,
-      value => {
-        if (value !== valueRef.current) {
-          valueRef.current = value;
-          onChange(value);
-        }
-      });
+    const dispose = reaction(
+                      getValue,
+                      value => {
+                        if (value !== valueRef.current) {
+                          valueRef.current = value;
+                          onChange(value);
+                        }
+                      });
+    return () => dispose();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 }


### PR DESCRIPTION
Realized this was missing in a recent PR and wanted to clear the decks before upcoming PRs.