### PR TITLE
1.5.0 bug fixes

### DIFF
--- a/src/components/problem-menu-container.tsx
+++ b/src/components/problem-menu-container.tsx
@@ -56,9 +56,10 @@ export class ProblemMenuContainer extends BaseComponent <IProps> {
             offering.unitCode === unitCode
           );
         });
+        const fullTitle = invProb.subtitle ? `${invProb.title}: ${invProb.subtitle}` : invProb.title;
         const link: IDropdownItem = {
           selected: problem.title === invProb.title,
-          text: portalOffering ? invProb.title : `${invProb.title} (N/A)`,
+          text: portalOffering ? fullTitle : `${fullTitle} (N/A)`,
           link: portalOffering ? portalOffering.location : undefined,
           disabled: false
         };

--- a/src/components/tools/drawing-tool/drawing-tool.sass
+++ b/src/components/tools/drawing-tool/drawing-tool.sass
@@ -1,3 +1,5 @@
+@import ../../vars
+
 .drawing-tool
   display: flex
   border: 1px solid #BBB
@@ -7,6 +9,7 @@
   position: absolute
   height: 44px
   background-color: #eee
+  z-index: $toolbar-z-index
   &.disabled
     display: none
   .drawing-tool-buttons

--- a/src/components/tools/geometry-tool/geometry-tool.tsx
+++ b/src/components/tools/geometry-tool/geometry-tool.tsx
@@ -63,8 +63,8 @@ const GeometryToolComponent: React.FC<IGeometryProps> = ({
           onMouseUpCapture={handlePointerUp}
           onKeyDown={e => hotKeys.current.dispatch(e)} >
 
-      {<GeometryToolbar documentContent={documentContent} toolTile={toolTile}
-        board={board} content={content} handlers={actionHandlers} {...toolbarProps} />}
+      <GeometryToolbar documentContent={documentContent} toolTile={toolTile}
+        board={board} content={content} handlers={actionHandlers} {...toolbarProps} />
       <GeometryContentWrapper model={model} readOnly={readOnly} {...others}
         onSetBoard={setBoard} onSetActionHandlers={handleSetHandlers} onContentChange={forceUpdate}/>
     </div>

--- a/src/components/tools/geometry-tool/geometry-toolbar.sass
+++ b/src/components/tools/geometry-tool/geometry-toolbar.sass
@@ -6,6 +6,7 @@
   border: $toolbar-border
   border-radius: 0 0 $toolbar-border-radius $toolbar-border-radius
   background-color: $workspace-teal-light-9
+  z-index: $toolbar-z-index
 
   &.disabled
     display: none

--- a/src/components/tools/image/image-toolbar.scss
+++ b/src/components/tools/image/image-toolbar.scss
@@ -4,6 +4,7 @@
   position: absolute;
   border: $toolbar-border;
   border-radius: 0 0 $toolbar-border-radius $toolbar-border-radius;
+  z-index: $toolbar-z-index;
 
   &.disabled {
     display: none;

--- a/src/components/tools/text-toolbar.sass
+++ b/src/components/tools/text-toolbar.sass
@@ -9,6 +9,7 @@
   margin: 4px 2px 2px 2px
   width: 232px
   height: 29px
+  z-index: $toolbar-z-index
 
   &.disabled
     display: none

--- a/src/components/tools/tool-tile.tsx
+++ b/src/components/tools/tool-tile.tsx
@@ -359,7 +359,8 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
       sourceDocId: docId,
       items: []
     };
-    const { ui: { selectedTileIds } } = this.stores;
+    const { ui } = this.stores;
+    const dragSrcContentId = getContentIdFromNode(model);
 
     const getTileInfo = (tileId: string) => {
       // get tile from loaded document or from curriculum
@@ -384,15 +385,11 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
       }
     };
 
-    // support dragging a tile without selecting it first
-    const dragSrcContentId = getContentIdFromNode(model);
-    const dragTileIds = selectedTileIds.slice();
-    if (dragTileIds.indexOf(model.id) < 0) {
-      dragTileIds.push(model.id);
-    }
+    // dragging a tile selects it first
+    ui.setSelectedTile(model, { append: hasSelectionModifier(e) });
 
     // create a sorted array of selected tiles
-    dragTileIds.forEach(selectedTileId => {
+    ui.selectedTileIds.forEach(selectedTileId => {
       const tileInfo = getTileInfo(selectedTileId);
       if (tileInfo) {
         const {tile, rowIndex, rowHeight, tileIndex, tileContent} = tileInfo;
@@ -420,8 +417,8 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
 
     // and to support existing geometry and drawing layer drop logic set the single tile drag fields
     // if only 1 tile is selected
-    if (dragTileIds.length === 1) {
-      const tileInfo = getTileInfo(dragTileIds[0]);
+    if (ui.selectedTileIds.length === 1) {
+      const tileInfo = getTileInfo(ui.selectedTileIds[0]);
       if (tileInfo) {
         const {tile, tileContent} = tileInfo;
         e.dataTransfer.setData(kDragTileId, tile.id);

--- a/src/components/vars.sass
+++ b/src/components/vars.sass
@@ -348,6 +348,9 @@ $toolbar-border-radius: 5px
 $toolbar-button-width: 36px
 $toolbar-button-height: 34px
 
+// above .bottom-resize-handle
+$toolbar-z-index: 3
+
 //
 // tabs
 //

--- a/src/models/stores/ui.ts
+++ b/src/models/stores/ui.ts
@@ -5,7 +5,6 @@ import { WorkspaceModel } from "./workspace";
 import { DocumentModelType } from "../document/document";
 import { ToolTileModelType } from "../tools/tool-tile";
 import { ENavTab } from "../view/nav-tabs";
-import { isSelectionModifierKeyDown } from "../../utilities/event-utils";
 
 export type ToggleElement = "leftNavExpanded";
 
@@ -168,8 +167,7 @@ export type UIModelType = typeof UIModel.Type;
 export type UIDialogModelType = typeof UIDialogModel.Type;
 
 export function selectTile(ui: UIModelType, model: ToolTileModelType, isExtending?: boolean) {
-  const append = isExtending ?? isSelectionModifierKeyDown();
-  ui.setSelectedTile(model, { append });
+  ui.setSelectedTile(model, { append: !!isExtending });
 }
 
 // Sometimes we get multiple selection events for a single click.


### PR DESCRIPTION
- Row resize takes precedence over toolbars [[#175563814]](https://www.pivotaltracker.com/story/show/175563814)
- Geometry toolbar gets left behind after a drag [[#175550604]](https://www.pivotaltracker.com/story/show/175550604)
- Text tile deselects when typing modifier key combinations [[#175549435]](https://www.pivotaltracker.com/story/show/175549435)
- Dragging a tile should focus the tile and only drag that tile [[#175550381]](https://www.pivotaltracker.com/story/show/175550381)
- Show problem subtitle in teacher problem menu [[#175564025]](https://www.pivotaltracker.com/story/show/175564025)

@mklewandowski Each bug-fix is in a separate commit for review purposes.