### PR TITLE
Update Student Identifier Colors and Font Color [#175581201]

### DIFF
--- a/src/components/four-up.sass
+++ b/src/components/four-up.sass
@@ -40,9 +40,9 @@
     .member
       position: absolute
       font-size: 10px
-      color: white
+      color: $charcoal-dark-3
       padding: $half-padding
-      opacity: .5
+      opacity: .75
 
     .member-centered
       font-size: 14px

--- a/src/components/vars.sass
+++ b/src/components/vars.sass
@@ -294,6 +294,7 @@ $classwork-purple-light-6: #f0d5ff
 $classwork-purple-light-7: #f4e0ff
 $classwork-purple-light-8: #f9efff
 $classwork-purple-light-9: #fcf7ff
+$charcoal-dark-3: #080808
 $charcoal-dark-2: #3f3f3f
 $charcoal-dark-1: #545454
 $charcoal: #707070


### PR DESCRIPTION
[[#175581201]](https://www.pivotaltracker.com/story/show/175581201)

Colors that label students make it nearly impossible to see the text, and associate it with editable and noneditable panes in 4up views. Update the teacher dashboard and student 4-up view with the new student ID colors and change font color.