### PR TITLE
Fix bug with initial toolbar location [##175587882]

### DIFF
--- a/src/components/tools/hooks/use-force-update.ts
+++ b/src/components/tools/hooks/use-force-update.ts
@@ -1,6 +1,6 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 
 export const useForceUpdate = () => {
   const [ , setChangeCount] = useState(0);
-  return () => setChangeCount(count => count + 1);
+  return useCallback(() => setChangeCount(count => count + 1), []);
 };

--- a/src/components/tools/tool-tile.tsx
+++ b/src/components/tools/tool-tile.tsx
@@ -218,7 +218,7 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
           onMouseLeave={isDraggable ? e => this.setState({ hoverTile: false }) : undefined}
           onKeyDown={this.handleKeyDown}
           onDragStart={this.handleToolDragStart}
-          onDragEnd={this.handleToolDragEnd}
+          onDragEnd={this.triggerResizeHandler}
           draggable={true}
       >
         {this.renderLinkIndicators()}
@@ -272,16 +272,16 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
   }
 
   private getToolResizeHandler = () => {
-  const { model, toolApiInterface } = this.props;
-  return toolApiInterface?.getToolApi(`${model.id}[layout]`)?.handleTileResize ||
+    const { model, toolApiInterface } = this.props;
+    return toolApiInterface?.getToolApi(`${model.id}[layout]`)?.handleTileResize ||
             toolApiInterface?.getToolApi(model.id)?.handleTileResize;
   }
 
   private handleRegisterToolApi = (toolApi: IToolApi, facet?: string) => {
     const id = facet ? `${this.modelId}[${facet}]` : this.modelId;
     this.props.toolApiInterface?.register(id, toolApi);
-    // trigger initial render of link indicators
-    toolApi.isLinked?.() && this.forceUpdate();
+    // trigger initial render
+    this.forceUpdate();
   }
 
   private handleUnregisterToolApi = (facet?: string) => {
@@ -441,7 +441,7 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
     e.dataTransfer.setDragImage(dragImage, offsetX, offsetY);
   }
 
-  private handleToolDragEnd = (e: React.DragEvent<HTMLDivElement>) => {
+  private triggerResizeHandler = () => {
     const handler = this.getToolResizeHandler();
     if (this.domElement && handler) {
       const bounds = this.domElement.getBoundingClientRect();

--- a/src/components/utilities/tile-utils.ts
+++ b/src/components/utilities/tile-utils.ts
@@ -23,9 +23,9 @@ export function getToolbarLocation({
 
   if (documentContent && toolTile) {
     const docBounds = documentContent.getBoundingClientRect();
-    const textBounds = toolTile.getBoundingClientRect();
-    const topOffset = textBounds.top - docBounds.top;
-    const leftOffset = textBounds.left - docBounds.left;
+    const tileBounds = toolTile.getBoundingClientRect();
+    const topOffset = tileBounds.top - docBounds.top;
+    const leftOffset = tileBounds.left - docBounds.left;
     if ((topOffset != null) && (leftOffset != null)) {
       tileTopOffset = topOffset;
       tileLeftOffset = leftOffset;


### PR DESCRIPTION
When clicking (not dragging) the corresponding icon in the document toolbar to create a geometry or draw tool, the initial toolbar location is often near the top of the document rather than at the bottom of the tile.