### PR TITLE
Fix initial text toolbar location [#175631464]

### DIFF
--- a/src/components/tools/text-tool.tsx
+++ b/src/components/tools/text-tool.tsx
@@ -106,6 +106,7 @@ export default class TextToolComponent extends BaseComponent<IToolTileProps, ISt
   private prevText: any;
   private textToolDiv: HTMLElement | null;
   private editor = React.createRef<Editor>();
+  private tileContentRect: Omit<DOMRectReadOnly, "toJSON">;
   private toolbarToolApi: IToolApi | undefined;
 
   private slateMap: ISlateMapEntry[] = [
@@ -219,6 +220,8 @@ export default class TextToolComponent extends BaseComponent<IToolTileProps, ISt
         this.toolbarToolApi?.handleDocumentScroll?.(x, y);
       },
       handleTileResize: (entry: ResizeObserverEntry) => {
+        const { x, y, width, height, top, left, bottom, right } = entry.contentRect;
+        this.tileContentRect = { x, y, width, height, top, left, bottom, right };
         this.toolbarToolApi?.handleTileResize?.(entry);
       }
     });
@@ -296,6 +299,11 @@ export default class TextToolComponent extends BaseComponent<IToolTileProps, ISt
 
   private handleRegisterToolApi = (toolApi: IToolApi) => {
     this.toolbarToolApi = toolApi;
+
+    // call resize handler immediately with current size
+    const { toolTile } = this.props;
+    toolTile && this.tileContentRect &&
+      this.toolbarToolApi?.handleTileResize?.({ target: toolTile, contentRect: this.tileContentRect });
   }
 
   private handleUnregisterToolApi = () => {


### PR DESCRIPTION
[[#175631464]](https://www.pivotaltracker.com/story/show/175631464)

The bug is essentially an order-of-initialization problem. During the initialization sequence the resize handler is called before the text toolbar has installed its handler, so it doesn't know the size of the tile when it comes time to determine the initial toolbar location. The fix here is to have the TextTool cache the size locally so that when the toolbar installs its handler the handler can be provided with the cached dimensions.