### PR TITLE
Release 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
-## Version 1.5.0 - released November 6, 2020
+## Version 1.5.1 - released November 8, 2020
+
+### Bugs Fixed
+- Fix text toolbar initial location bug
+
+### Asset Sizes
+
+| File | Size | % Change from Previous Release |
+|---|---|---|
+| index.css | 517,550 bytes | 0.0% |
+| index.js | 4,950,629 bytes | 0.0% |
+
+## Version 1.5.0 - released November 7, 2020
 
 ### Features/Improvements
 - Combined Problem and Extra Workspaces under single Workspaces tab

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "collaborative-learning",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collaborative-learning",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Collaborative Learning environment",
   "main": "index.js",
   "config": {

--- a/src/components/tools/text-tool.tsx
+++ b/src/components/tools/text-tool.tsx
@@ -106,6 +106,7 @@ export default class TextToolComponent extends BaseComponent<IToolTileProps, ISt
   private prevText: any;
   private textToolDiv: HTMLElement | null;
   private editor = React.createRef<Editor>();
+  private tileContentRect: Omit<DOMRectReadOnly, "toJSON">;
   private toolbarToolApi: IToolApi | undefined;
 
   private slateMap: ISlateMapEntry[] = [
@@ -219,6 +220,8 @@ export default class TextToolComponent extends BaseComponent<IToolTileProps, ISt
         this.toolbarToolApi?.handleDocumentScroll?.(x, y);
       },
       handleTileResize: (entry: ResizeObserverEntry) => {
+        const { x, y, width, height, top, left, bottom, right } = entry.contentRect;
+        this.tileContentRect = { x, y, width, height, top, left, bottom, right };
         this.toolbarToolApi?.handleTileResize?.(entry);
       }
     });
@@ -296,6 +299,11 @@ export default class TextToolComponent extends BaseComponent<IToolTileProps, ISt
 
   private handleRegisterToolApi = (toolApi: IToolApi) => {
     this.toolbarToolApi = toolApi;
+
+    // call resize handler immediately with current size
+    const { toolTile } = this.props;
+    toolTile && this.tileContentRect &&
+      this.toolbarToolApi?.handleTileResize?.({ target: toolTile, contentRect: this.tileContentRect });
   }
 
   private handleUnregisterToolApi = () => {


### PR DESCRIPTION
## Version 1.5.1 - released November 8, 2020

### Bugs Fixed
- Fix text toolbar initial location bug

### Asset Sizes

| File | Size | % Change from Previous Release |
|---|---|---|
| index.css | 517,550 bytes | 0.0% |
| index.js | 4,950,629 bytes | 0.0% |