### PR TITLE
Table UI IV: Implement Add Column and Remove Row buttons [#175773902]

### DIFF
--- a/src/assets/icons/add/add.nosvgo.svg
+++ b/src/assets/icons/add/add.nosvgo.svg
@@ -1,0 +1,8 @@
+<!-- apply "fill" to svg or svg.background to set background color -->
+<!-- apply "stroke" to svg or svg.foreground to set foreground color -->
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="2">
+    <circle class="background" cx="12" cy="12" r="12" stroke="none"/>
+    <circle class="foreground" cx="12" cy="12" r="9" fill="none"/>
+    <line class="foreground" x1="7" y1="12" x2="17" y2="12"/>
+    <line class="foredground" x1="12" y1="7" x2="12" y2="17"/>
+</svg>

--- a/src/assets/icons/remove/remove.nosvgo.svg
+++ b/src/assets/icons/remove/remove.nosvgo.svg
@@ -1,0 +1,7 @@
+<!-- apply "fill" to svg or svg.background to set background color -->
+<!-- apply "stroke" to svg or svg.foreground to set foreground color -->
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="2">
+    <circle class="background" cx="12" cy="12" r="12" stroke="none"/>
+    <circle class="foreground" cx="12" cy="12" r="9" fill="none"/>
+    <line class="foreground" x1="7" y1="12" x2="17" y2="12"/>
+</svg>

--- a/src/components/tools/table-tool/grid-types.ts
+++ b/src/components/tools/table-tool/grid-types.ts
@@ -1,6 +1,8 @@
 import { Column, FormatterProps, HeaderRendererProps } from "react-data-grid";
 
 export const kRowHeight = 34;
+export const kIndexColumnWidth = 34;
+export const kControlsColumnWidth = 36;
 
 export interface IGridContext {
   showRowLabels: boolean;
@@ -11,6 +13,7 @@ export interface IGridContext {
 }
 
 export const kIndexColumnKey = "__index__";
+export const kControlsColumnKey = "__controls__";
 export interface TRow extends Record<string, any> {
   __id__: string;
   __index__?: number;

--- a/src/components/tools/table-tool/table-tool.scss
+++ b/src/components/tools/table-tool/table-tool.scss
@@ -150,17 +150,17 @@ $controls-hover-background: #c0dfe7;
           align-items: center;
           svg {
             fill: white;
-            stroke: $workspace-teal-light-4;
+            stroke: $highlight-blue;
           }
           &:hover {
             svg {
-              fill: $controls-hover-background;
-              stroke: $workspace-teal-dark-1;
+              fill: $highlight-blue-25;
+              stroke: $highlight-blue;
             }
           }
           &:active {
             svg {
-              fill: $workspace-teal-dark-1;
+              fill: $highlight-blue;
               stroke: white;
             }
           }

--- a/src/components/tools/table-tool/table-tool.scss
+++ b/src/components/tools/table-tool/table-tool.scss
@@ -4,12 +4,14 @@
 $table-padding: 10px;
 $row-height: 34px;
 $index-column-width: 34px;
+$controls-column-width: 36px;
 $platform-scrollbar-width: 16px;
 $header-color: $workspace-teal-light-5;
 $header-input-color: #eef9fb;
 $border-style: 1px solid $charcoal-light-1;
 $border-input-style: 1px solid #dadada;
 $border-radius: 3px;
+$controls-hover-background: #c0dfe7;
 
 .table-tool {
   position: relative;
@@ -78,6 +80,34 @@ $border-radius: 3px;
           background-color: inherit;
         }
       }
+      .controls-column-header {
+        background-color: white;
+        border: none;
+        padding: 0;
+        .add-column-button {
+          width: $controls-column-width;
+          height: $row-height;
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          svg {
+            fill: white;
+            stroke: $workspace-teal-light-4;
+          }
+          &:hover {
+            svg {
+              fill: $controls-hover-background;
+              stroke: $workspace-teal-dark-1;
+            }
+          }
+          &:active {
+            svg {
+              fill: $workspace-teal-dark-1;
+              stroke: white;
+            }
+          }
+        }
+      }
     }
     .rdg-row {
       &.rdg-row-selected {
@@ -100,9 +130,41 @@ $border-radius: 3px;
           border-right: $border-input-style;
           border-bottom: $border-input-style;
         }
+        .controls-column {
+          border: none;
+        }
       }
       .index-column {
         border-left: $border-style;
+      }
+      .controls-column {
+        background-color: white;
+        border: none;
+        box-shadow: none;
+        padding: 0;
+        .remove-row-button {
+          width: $controls-column-width;
+          height: $row-height;
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          svg {
+            fill: white;
+            stroke: $workspace-teal-light-4;
+          }
+          &:hover {
+            svg {
+              fill: $controls-hover-background;
+              stroke: $workspace-teal-dark-1;
+            }
+          }
+          &:active {
+            svg {
+              fill: $workspace-teal-dark-1;
+              stroke: white;
+            }
+          }
+        }
       }
     }
     .index-column {

--- a/src/components/tools/table-tool/use-controls-column.tsx
+++ b/src/components/tools/table-tool/use-controls-column.tsx
@@ -1,0 +1,52 @@
+import React, { useCallback } from "react";
+import AddColumnSvg from "../../../assets/icons/add/add.nosvgo.svg";
+import RemoveRowSvg from "../../../assets/icons/remove/remove.nosvgo.svg";
+import { TFormatterProps } from "./grid-types";
+
+interface IUseControlsColumn {
+  readOnly?: boolean;
+  onAddColumn?: () => void;
+  onRemoveRow?: (rowId: string) => void;
+}
+export const useControlsColumn = ({ readOnly, onAddColumn, onRemoveRow }: IUseControlsColumn) => {
+
+  const ControlsHeaderRenderer: React.FC = useCallback(() => {
+    return !readOnly
+            ? <AddColumnButton onAddColumn={onAddColumn} />
+            : null;
+  }, [onAddColumn, readOnly]);
+
+  const ControlsRowFormatter: React.FC<TFormatterProps> = useCallback(({ row, isRowSelected }) => {
+    return !readOnly && isRowSelected
+            ? <RemoveRowButton rowId={row.__id__} onRemoveRow={onRemoveRow} />
+            : null;
+  }, [onRemoveRow, readOnly]);
+  ControlsRowFormatter.displayName = "ControlsRowFormatter";
+
+  return { ControlsHeaderRenderer, ControlsRowFormatter };
+};
+
+interface IAddColumnButtonProps {
+  onAddColumn?: () => void;
+}
+const AddColumnButton: React.FC<IAddColumnButtonProps> = ({ onAddColumn }) => {
+  return (
+    <div className="add-column-button" onClick={() => onAddColumn?.()}>
+      <AddColumnSvg className="add-column-icon"/>
+    </div>
+  );
+};
+AddColumnButton.displayName = "AddColumnButton";
+
+interface IRemoveRowButtonProps {
+  rowId: string;
+  onRemoveRow?: (rowId: string) => void;
+}
+const RemoveRowButton: React.FC<IRemoveRowButtonProps> = ({ rowId, onRemoveRow }) => {
+  return (
+    <div className="remove-row-button" onClick={() => onRemoveRow?.(rowId)}>
+      <RemoveRowSvg className="remove-row-icon"/>
+    </div>
+  );
+};
+RemoveRowButton.displayName = "RemoveRowButton";

--- a/src/utilities/js-utils.ts
+++ b/src/utilities/js-utils.ts
@@ -52,3 +52,40 @@ export function uniqueId(idLength = 16): string {
   // cf. https://zelark.github.io/nano-id-cc/
   return nanoid(idLength);
 }
+
+/*
+ * uniqueName()
+ *
+ * returns a unique name from a given base name, adding a numeric suffix if necessary
+ */
+export function uniqueName(base: string, isValid: (name: string) => boolean) {
+  if (isValid(base)) return base;
+  let name: string;
+  for (let i = 2; !isValid(name = `${base}${i}`); ++i) {
+    // nothing to do
+  }
+  return name;
+}
+
+/*
+ * uniqueSubscriptedName()
+ *
+ * returns a unique name from a given base name, adding subscripts if necessary
+ */
+export function uniqueSubscriptedName(base: string, isValid: (name: string) => boolean) {
+  if (isValid(base)) return base;
+  const numToSubscripts = (num: number) => {
+    const subscripts = "\u2080\u2081\u2082\u2083\u2084\u2085\u2086\u2087\u2088\u2089";
+    const str = `${Math.trunc(num)}`;
+    let result = "";
+    for (let i = 0; i < str.length; ++i) {
+      result += subscripts[str.charCodeAt(i) - "0".charCodeAt(0)];
+    }
+    return result;
+  };
+  let name: string;
+  for (let i = 2; !isValid(name = `${base}${numToSubscripts(i)}`); ++i) {
+    // nothing to do
+  }
+  return name;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -69,8 +69,16 @@ module.exports = (env, argv) => {
           loader: 'ts-loader',
           exclude: /node_modules/
         },
+        { // disable svgo optimization for files ending in .nosvgo.svg
+          test: /\.nosvgo\.svg$/i,
+          loader: "@svgr/webpack",
+          options: {
+            svgo: false
+          }
+        },
         {
           test: /\.svg$/i,
+          exclude: /\.nosvgo\.svg$/i,
           oneOf: [
             {
               issuer: /\.[tj]sx?$/i,


### PR DESCRIPTION
[[#175773902]](https://www.pivotaltracker.com/story/show/175773902)

I was originally just going to implement Remove Row in this PR, but it turns out that supporting Add Column as well didn't add much to the degree of difficulty.

Note that for implementation reasons, the Add Column and Remove Row buttons are implemented as an additional column in the table. This makes rendering them straightforward using normal React mechanisms, guarantees proper alignment with the row, assures that they scroll properly when the table is scrolled vertically, etc. The downside to this approach, however, is that if the table is wider than the tile the buttons can be scrolled out of view horizontally. In the interest of moving on I propose we stick with this for now. If there is a desire to implement sticky buttons that can't be scrolled out of view, we should make another story since the implementation will be non-trivial.

On another note, when new columns are created they are given the first available name in the sequence "y", "y2", "y3", etc. I experimented with using subscripts as suggested by the spec but in the absence of rich-text editing we're limited to Unicode subscripts which by default render too small and are difficult to edit/enter for the user, so I decided to skip it.