### PR TITLE
Re-implement SingleStringDialog in terms of new useCustomModal()

### DIFF
--- a/src/assets/icons/text-input.svg
+++ b/src/assets/icons/text-input.svg
@@ -1,0 +1,9 @@
+<!-- https://www.iconfinder.com/icons/4295558/text_field_formfield_input_textarea_textbox_textfield_icon -->
+<svg enable-background="new 0 0 48 48" id="Layer_3" version="1.1" viewBox="0 0 48 48"
+      xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <g>
+    <polygon points="8,9 10,9 10,12 10,16 10,39 8,39 8,42 16,42 16,39 14,39 14,16 14,12 14,9 16,9 16,6 8,6"/>
+    <polygon points="4,16 7.021,16 7.021,12 0,12 0,36 7.042,36 7.042,32 4,32"/>
+    <polygon points="16.979,12 16.979,16 44,16 44,32 16.958,32 16.958,36 48,36 48,12"/>
+  </g>
+</svg>

--- a/src/components/tools/table-tool/use-set-expression-dialog.tsx
+++ b/src/components/tools/table-tool/use-set-expression-dialog.tsx
@@ -58,8 +58,7 @@ export const useSetExpressionDialog = ({ dataSet }: IProps) => {
       { label: "Clear", onClick: () => { /* no-op */} },
       { label: "Cancel", onClick: "cancel" },
       { label: "OK", onClick: () => { /* no-op */} }
-    ],
-    dependencies: [currYAttr]
-  });
+    ]
+  }, [currYAttr]);
   return [showModal, hideModal];
 };

--- a/src/components/utilities/single-string-dialog.scss
+++ b/src/components/utilities/single-string-dialog.scss
@@ -1,0 +1,27 @@
+@import "../../components/vars.sass";
+
+.custom-modal.single-string {
+  width: 400px;
+  height: 183px;
+
+  .modal-icon svg {
+    width: 36px * 0.65;
+    height: 34px * 0.65;
+    fill: $charcoal;
+  }
+
+  .input-row {
+    height: 30px;
+    display: flex;
+    align-items: center;
+
+    label {
+      display: inline-block;
+      flex: 0 0 auto;
+    }
+    input {
+      height: 100%;
+      flex: 1 1 auto;
+    }
+  }
+}

--- a/src/components/utilities/single-string-dialog.tsx
+++ b/src/components/utilities/single-string-dialog.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { Button, Dialog } from "@blueprintjs/core";
+import React, { useEffect } from "react";
+import { useSingleStringDialog } from "./use-single-string-dialog";
 
 interface IProps {
   parentId?: string;
@@ -12,73 +12,27 @@ interface IProps {
   maxLength?: number;
 }
 
-interface IState {
-  content: string;
-}
+// Component wrapper for useSingleStringDialog() for use by class components.
+const SingleStringDialog: React.FC<IProps> = ({
+  parentId, title, prompt, placeholder, content, maxLength, onAccept, onClose
+}) => {
 
-export default
-class SingleStringDialog extends React.Component<IProps, IState> {
+  const [showDialog, hideDialog] = useSingleStringDialog({
+    title: title || "",
+    prompt,
+    placeholder,
+    value: content,
+    maxLength,
+    context: parentId,
+    onAccept,
+    onClose
+  });
 
-  public state = {
-            content: this.props.content || ""
-          };
+  useEffect(() => {
+    showDialog();
+    return () => hideDialog();
+  }, [hideDialog, showDialog]);
 
-  public render() {
-    const { title, prompt, placeholder, maxLength } = this.props;
-    return (
-      <Dialog
-        icon="text-highlight"
-        isOpen={true}
-        onClose={this.props.onClose}
-        title={title}
-        canOutsideClickClose={false}
-      >
-        <div className="nc-attribute-name-prompt">{prompt}:</div>
-        <input
-          className="nc-attribute-name-input pt-input"
-          type="text"
-          maxLength={maxLength ? maxLength : 100}
-          placeholder={placeholder}
-          value={this.state.content}
-          onChange={this.handleChange}
-          onKeyDown={this.handleKeyDown}
-          dir="auto"
-          ref={input => input && input.focus()}
-        />
-        <div className="nc-dialog-buttons">
-          <Button
-            className="nc-dialog-button pt-intent-primary"
-            text="OK"
-            onClick={this.handleAccept}
-          />
-          <Button className="nc-dialog-button" text="Cancel"  onClick={this.handleCancel}/>
-        </div>
-      </Dialog>
-    );
-  }
-
-  private handleChange = (evt: React.FormEvent<HTMLInputElement>) => {
-    this.setState({ content: (evt.target as HTMLInputElement).value });
-  }
-
-  private handleAccept = () => {
-    const { onAccept, parentId } = this.props;
-    const { content } = this.state;
-    onAccept && onAccept(content, parentId);
-  }
-
-  private handleCancel = () => {
-    const { onClose } = this.props;
-    onClose && onClose();
-  }
-
-  private handleKeyDown = (evt: React.KeyboardEvent<HTMLInputElement>) => {
-    evt.stopPropagation();
-    if (evt.keyCode === 13) {
-      this.handleAccept();
-    } else if (evt.keyCode === 27) {
-      this.handleCancel();
-    }
-  }
-
-}
+  return null;
+};
+export default SingleStringDialog;

--- a/src/components/utilities/use-single-string-dialog.tsx
+++ b/src/components/utilities/use-single-string-dialog.tsx
@@ -1,0 +1,52 @@
+import React, { useRef } from "react";
+import TextInputSvg from "../../assets/icons/text-input.svg";
+import { useCustomModal } from "../../hooks/use-custom-modal";
+
+import "./single-string-dialog.scss";
+
+interface IProps {
+  className?: string;
+  title: string;
+  prompt?: string;
+  label?: string;
+  placeholder?: string;
+  value?: string;
+  maxLength?: number;
+  context?: any;
+  onAccept: (value: string, context?: any) => void;
+  onClose?: () => void;
+}
+export const useSingleStringDialog = ({
+  className, title, prompt, label, placeholder, value, maxLength, context, onAccept, onClose
+}: IProps) => {
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const valueRef = useRef(value);
+
+  const Content: React.FC = () => {
+    return (
+      <>
+        {prompt && <div className="prompt">{prompt}</div>}
+        <div className="input-row">
+          {label && <label htmlFor="string-input">{label}</label>}
+          <input type="text" ref={inputRef} id="string-input" placeholder={placeholder} maxLength={maxLength}
+                  defaultValue={value} onBlur={e => valueRef.current = inputRef.current?.value}/>
+        </div>
+      </>
+    );
+  };
+
+  return useCustomModal({
+    className: `single-string ${className}`,
+    title,
+    Icon: TextInputSvg,
+    Content,
+    focusElement: "#string-input",
+    buttons: [
+      { label: "Cancel", onClick: "cancel" },
+      { label: "OK", isDefault: true,
+        onClick: () => onAccept(inputRef.current?.value || valueRef.current || "", context)}
+    ],
+    onClose
+  });
+};

--- a/src/hooks/custom-modal.scss
+++ b/src/hooks/custom-modal.scss
@@ -42,6 +42,9 @@ $modal-footer-height: 45px;
       width: $modal-header-icon-width;
       height: $modal-header-height;
       border-top-left-radius: $modal-header-border-radius;
+      display: flex;
+      justify-content: center;
+      align-items: center;
     }
 
     .modal-close {


### PR DESCRIPTION
As a further test of the new custom dialog infrastructure, we replace the existing `<SingleStringDialog>` component with an API-compatible version based on the new `useCustomModal` hook. One wrinkle is that the only existing client of the `<SingleStringDialog>` (the comment feature in the geometry tool) is a class component, which therefore can't use the `useSingleStringDialog` hook. Not to be deterred, however, with this PR we also implement a replacement `<SingleStringDialog>` as a functional component which wraps the `useSingleStringDialog` hook.