### PR TITLE
Implement <ErrorAlert> to replace blueprint.js <Alert>

### DIFF
--- a/src/assets/icons/error.svg
+++ b/src/assets/icons/error.svg
@@ -1,0 +1,10 @@
+<!-- https://www.iconfinder.com/icons/381599/error_icon -->
+<svg style="overflow:visible;enable-background:new 0 0 32 32" viewBox="0 0 32 32"
+      xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <g id="Error_1_">
+    <g id="Error">
+      <circle cx="16" cy="16" id="BG" r="16" style="fill:#D72828;"/>
+      <path d="M14.5,25h3v-3h-3V25z M14.5,6v13h3V6H14.5z" id="Exclamatory_x5F_Sign" style="fill:#E6E6E6;"/>
+    </g>
+  </g>
+</svg>

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -2,7 +2,6 @@ import { inject, observer } from "mobx-react";
 import React from "react";
 import Modal from "react-modal";
 import { ModalProvider } from "react-modal-hook";
-import { Alert } from "@blueprintjs/core";
 import { authenticate } from "../lib/auth";
 import { AppContentContainerComponent } from "./app-content";
 import { BaseComponent, IBaseProps } from "./base";
@@ -13,6 +12,8 @@ import { GroupChooserComponent } from "./group/group-chooser";
 import { IStores, setAppMode, setUnitAndProblem } from "../models/stores/stores";
 import { isDifferentUnitAndProblem } from "../models/curriculum/unit";
 import { updateProblem } from "../lib/misc";
+import ErrorAlert from "./utilities/error-alert";
+
 import "./app.sass";
 
 interface IProps extends IBaseProps {}
@@ -199,16 +200,12 @@ export class AppComponent extends BaseComponent<IProps, IState> {
   private renderError(error: string) {
     return (
       <div className="error">
-        <Alert
-          icon="error"
-          canEscapeKeyCancel={false}
-          canOutsideClickCancel={false}
-          className="error"
-          confirmButtonText="Proceed"
-          isOpen={true}
-          onConfirm={this.handlePortalLoginRedirect} >
-          <p>{error.toString()}</p>
-        </Alert>
+        <ErrorAlert
+          content={error}
+          canCancel={false}
+          buttonLabel="Proceed"
+          onClick={this.handlePortalLoginRedirect}
+        />
       </div>
     );
   }

--- a/src/components/tools/geometry-tool/geometry-content.tsx
+++ b/src/components/tools/geometry-tool/geometry-content.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { inject, observer } from "mobx-react";
 import { SizeMeProps } from "react-sizeme";
 import { BaseComponent } from "../../base";
-import { Alert, Intent } from "@blueprintjs/core";
 import { DocumentContentModelType } from "../../../models/document/document-content";
 import { getLinkedTableIndex, getTableLinkColors } from "../../../models/tools/table-links";
 import { getTableContent } from "../../../models/tools/table/table-content";
@@ -39,6 +38,7 @@ import AxisSettingsDialog from "./axis-settings-dialog";
 import LabelSegmentDialog from "./label-segment-dialog";
 import MovableLineDialog from "./movable-line-dialog";
 import placeholderImage from "../../../assets/image_placeholder.png";
+import ErrorAlert from "../../utilities/error-alert";
 import SingleStringDialog from "../../utilities/single-string-dialog";
 import { autorun } from "mobx";
 
@@ -506,19 +506,10 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
     if (!showInvalidTableDataAlert) return;
 
     return (
-      <Alert
-          confirmButtonText="OK"
-          icon="error"
-          intent={Intent.DANGER}
-          isOpen={true}
-          onClose={this.handleCloseInvalidTableDataAlert}
-          canEscapeKeyCancel={true}
-          key={"invalid-table-alert"}
-      >
-        <p>
-          Linked data must be numeric. Please edit the table values so that all cells contain numbers.
-        </p>
-      </Alert>
+      <ErrorAlert
+        content="Linked data must be numeric. Please edit the table values so that all cells contain numbers."
+        onClose={this.handleCloseInvalidTableDataAlert}
+      />
     );
   }
 

--- a/src/components/tools/table-tool/use-set-expression-dialog.tsx
+++ b/src/components/tools/table-tool/use-set-expression-dialog.tsx
@@ -56,8 +56,8 @@ export const useSetExpressionDialog = ({ dataSet }: IProps) => {
     focusElement: "#expression-input",
     buttons: [
       { label: "Clear", onClick: () => { /* no-op */} },
-      { label: "Cancel", onClick: "cancel" },
-      { label: "OK", onClick: () => { /* no-op */} }
+      { label: "Cancel", onClick: "close" },
+      { label: "OK", isDefault: true, onClick: () => { /* no-op */} }
     ]
   }, [currYAttr]);
   return [showModal, hideModal];

--- a/src/components/utilities/error-alert.scss
+++ b/src/components/utilities/error-alert.scss
@@ -1,0 +1,12 @@
+@import "../../components/vars.sass";
+
+.custom-modal.error-alert {
+  width: 400px;
+  height: 160px;
+  outline: none;
+
+  .modal-icon svg {
+    width: 36px * 0.7;
+    height: 34px * 0.7;
+  }
+}

--- a/src/components/utilities/error-alert.tsx
+++ b/src/components/utilities/error-alert.tsx
@@ -1,0 +1,16 @@
+import React, { useEffect } from "react";
+import { IErrorAlertProps, useErrorAlert } from "./use-error-alert";
+
+// Component wrapper for useErrorAlert() for use by class components.
+const ErrorAlert: React.FC<IErrorAlertProps> = (props) => {
+
+  const [showAlert, hideAlert] = useErrorAlert(props);
+
+  useEffect(() => {
+    showAlert();
+    return () => hideAlert();
+  }, [hideAlert, showAlert]);
+
+  return null;
+};
+export default ErrorAlert;

--- a/src/components/utilities/use-error-alert.tsx
+++ b/src/components/utilities/use-error-alert.tsx
@@ -1,0 +1,41 @@
+import React, { useCallback } from "react";
+import ErrorSvg from "../../assets/icons/error.svg";
+import { useCustomModal } from "../../hooks/use-custom-modal";
+
+import "./error-alert.scss";
+
+export interface IErrorAlertProps {
+  className?: string;
+  title?: string;
+  content: string | React.FC<any>;
+  canCancel?: boolean;
+  buttonLabel?: string;
+  onClick?: () => void;
+  onClose?: () => void;
+}
+
+export const useErrorAlert = ({
+  className, title, content, canCancel, buttonLabel, onClick, onClose
+}: IErrorAlertProps) => {
+
+  const TextContent: React.FC = useCallback(() => {
+    return <p>{content}</p>;
+  }, [content]);
+  const Content = typeof content === "string"
+                    ? TextContent
+                    : content;
+
+  const [showAlert, hideAlert] = useCustomModal({
+    className: `error-alert ${className || ""}`,
+    title: title || "",
+    Icon: ErrorSvg,
+    Content,
+    canCancel,
+    buttons: [
+      { label: buttonLabel || "OK", isDefault: true, onClick: onClick || "close" }
+    ],
+    onClose
+  });
+
+  return [showAlert, hideAlert];
+};

--- a/src/components/utilities/use-single-string-dialog.tsx
+++ b/src/components/utilities/use-single-string-dialog.tsx
@@ -37,13 +37,13 @@ export const useSingleStringDialog = ({
   };
 
   return useCustomModal({
-    className: `single-string ${className}`,
+    className: `single-string ${className || ""}`,
     title,
     Icon: TextInputSvg,
     Content,
     focusElement: "#string-input",
     buttons: [
-      { label: "Cancel", onClick: "cancel" },
+      { label: "Cancel", onClick: "close" },
       { label: "OK", isDefault: true,
         onClick: () => onAccept(inputRef.current?.value || valueRef.current || "", context)}
     ],

--- a/src/hooks/custom-modal.scss
+++ b/src/hooks/custom-modal.scss
@@ -103,6 +103,10 @@ $modal-footer-height: 45px;
       border-radius: $modal-control-border-radius;
       outline: none;
 
+      &.default {
+        background-color: $charcoal-light-6;
+      }
+
       &:hover, &:focus {
         background-color: $workspace-teal-light-4;
       }


### PR DESCRIPTION
The two uses of `<Alert>` being replaced are in `<AppComponent>` where it is used to show things like authentication failures:

<img width="406" alt="AppError" src="https://user-images.githubusercontent.com/235234/99858749-13cdf500-2b43-11eb-8f36-1a3c5e84f008.png">

and when attempting to link a table tile to a geometry tile with invalid data:

<img width="405" alt="TableError" src="https://user-images.githubusercontent.com/235234/99858908-6f987e00-2b43-11eb-9531-98240ccef6f4.png">

Note that the latter is cancelable via close box or escape key while the former is not.

Other improvements to the dialog infrastructure include:
- support `canCancel` option
- support `isDefault` button option with altered button appearance and handling of return/enter key
- use "close" instead of "cancel" in the button API since it's reasonable to apply it to the OK button as well as the Cancel button in some cases.