### PR TITLE
Table title defaults to "Table 1", "Table 2", ...

### DIFF
--- a/src/components/document/document-content.tsx
+++ b/src/components/document/document-content.tsx
@@ -9,6 +9,7 @@ import { DocumentContentModelType, IDropRowInfo } from "../../models/document/do
 import { DocumentTool } from "../../models/document/document";
 import { IDragTiles } from "../../models/tools/tool-tile";
 import { dragTileSrcDocId, IToolApiInterface, kDragTileCreate, kDragTiles } from "../tools/tool-tile";
+import { uniqueTitle } from "../../utilities/js-utils";
 
 import "./document-content.sass";
 
@@ -176,6 +177,7 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
                                   documentContent={this.domElement}
                                   rowIndex={index} height={rowHeight} tileMap={tileMap}
                                   dropHighlight={dropHighlight}
+                                  onRequestUniqueTitle={this.handleRequestUniqueTitle}
                                   ref={(elt) => this.rowRefs.push(elt)} {...others} />
               : null;
     });
@@ -191,6 +193,16 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
     const yScroll = this.domElement?.scrollTop || 0;
     this.props.toolApiInterface?.forEach(api => api.handleDocumentScroll?.(xScroll, yScroll));
   }, 50)
+
+  private handleRequestUniqueTitle = (tileId: string) => {
+    const { content, toolApiInterface } = this.props;
+    const tile = content?.getTile(tileId);
+    const tileType = tile?.content.type;
+    if (!content || !tileType || !toolApiInterface) return;
+    const tilesOfType = content.getTilesOfType(tileType);
+    const titles = tilesOfType.map(id => toolApiInterface.getToolApi(id)?.getTitle?.());
+    return uniqueTitle(tileType, proposed => !titles.find(title => title === proposed));
+  }
 
   private handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
     const { ui } = this.stores;

--- a/src/components/document/tile-row.tsx
+++ b/src/components/document/tile-row.tsx
@@ -57,6 +57,7 @@ interface IProps {
   readOnly?: boolean;
   dropHighlight?: string;
   toolApiInterface?: IToolApiInterface;
+  onRequestUniqueTitle: (tileId: string) => string | undefined;
 }
 
 interface IState {

--- a/src/components/tools/table-tool/editable-table-title.tsx
+++ b/src/components/tools/table-tool/editable-table-title.tsx
@@ -1,4 +1,5 @@
 import classNames from "classnames";
+import { observer } from "mobx-react";
 import React, { useState } from "react";
 import { HeaderCellInput } from "./header-cell-input";
 
@@ -7,19 +8,23 @@ import "./editable-header-cell.scss";
 interface IProps {
   className?: string;
   readOnly?: boolean;
-  titleWidth?: number;
-  title: string;
-  setTitle: (title: string) => void;
+  getTitle: () => string | undefined;
+  getTitleWidth: () => number | undefined;
   onBeginEdit?: () => void;
   onEndEdit?: (title?: string) => void;
 }
-export const EditableTableTitle: React.FC<IProps> = ({
-  className, readOnly, titleWidth, title, setTitle, onBeginEdit, onEndEdit
+export const EditableTableTitle: React.FC<IProps> = observer(({
+  className, readOnly, getTitle, getTitleWidth, onBeginEdit, onEndEdit
 }) => {
+  // getTitle() and observer() allow this component to re-render
+  // when the title changes without re-rendering the entire TableTool
+  const title = getTitle();
   const [isEditing, setIsEditing] = useState(false);
+  const [editingTitle, setEditingTitle] = useState(title);
   const handleClick = () => {
     if (!readOnly && !isEditing) {
       onBeginEdit?.();
+      setEditingTitle(title);
       setIsEditing(true);
     }
   };
@@ -35,21 +40,21 @@ export const EditableTableTitle: React.FC<IProps> = ({
         break;
     }
   };
-  const handleChange = (value: string) => {
-    setTitle(value);
-  };
   const handleClose = (accept: boolean) => {
-    onEndEdit?.(accept && title ? title : undefined);
+    const trimTitle = editingTitle?.trim();
+    onEndEdit?.(accept && trimTitle ? trimTitle : undefined);
     setIsEditing(false);
   };
-  const classes = classNames("editable-header-cell", className, { "table-title-editing": isEditing });
-  const style = { width: titleWidth };
+  const isDefaultTitle = title && /Table\s+(\d+)\s*$/.test(title);
+  const classes = classNames("editable-header-cell", className,
+                            { "table-title-editing": isEditing, "table-title-default": isDefaultTitle });
+  const style = { width: getTitleWidth() };
   return (
     <div className={classes} style={style} onClick={handleClick}>
       {isEditing
-        ? <HeaderCellInput style={style} value={title}
-            onKeyDown={handleKeyDown} onChange={handleChange} onClose={handleClose} />
+        ? <HeaderCellInput style={style} value={editingTitle}
+            onKeyDown={handleKeyDown} onChange={setEditingTitle} onClose={handleClose} />
         : title}
     </div>
   );
-};
+});

--- a/src/components/tools/table-tool/header-cell-input.tsx
+++ b/src/components/tools/table-tool/header-cell-input.tsx
@@ -7,7 +7,7 @@ function autoFocusAndSelect(input: HTMLInputElement | null) {
 
 interface IProps {
   style?: React.CSSProperties;
-  value: string;
+  value?: string;
   onKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => void;
   onChange: (value: string) => void;
   onClose: (accept: boolean) => void;

--- a/src/components/tools/table-tool/table-tool.scss
+++ b/src/components/tools/table-tool/table-tool.scss
@@ -35,6 +35,10 @@ $controls-hover-background: #c0dfe7;
       border-radius: $border-radius $border-radius 0 0;
       font-weight: bold;
       padding: 8px;
+
+      &.table-title-default {
+        font-style: italic;
+      }
     }
   }
 

--- a/src/components/tools/table-tool/use-grid-context.ts
+++ b/src/components/tools/table-tool/use-grid-context.ts
@@ -1,0 +1,33 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import { DataGridHandle } from "react-data-grid";
+import { IGridContext, TPosition } from "./grid-types";
+
+export const useGridContext = (showRowLabels: boolean) => {
+  const gridRef = useRef<DataGridHandle>(null);
+  // this tracks ReactDataGrid's internal notion of the selected cell
+  const selectedCell = useRef<TPosition>();
+  // these are passed into ReactDataGrid as the ultimate source of truth
+  const [selectedRows, setSelectedRows] = useState(() => new Set<React.Key>());
+  const selectOneRow = useCallback((row: string) => setSelectedRows(new Set([row])), []);
+  const clearRowSelection = useCallback(() => setSelectedRows(new Set([])), []);
+  const clearCellSelection = useCallback(() => gridRef.current?.selectCell({ idx: -1, rowIdx: -1 }), []);
+  const gridContext: IGridContext = useMemo(() => ({
+          showRowLabels,
+          onSelectOneRow: selectOneRow,
+          onClearRowSelection: clearRowSelection,
+          onClearCellSelection: clearCellSelection,
+          onClearSelection: () => {
+            clearRowSelection();
+            clearCellSelection();
+          }
+        }), [clearCellSelection, clearRowSelection, selectOneRow, showRowLabels]);
+  const onSelectedCellChange = useCallback((position: TPosition) => {
+    selectedCell.current = position;
+  }, []);
+  const onSelectedRowsChange = useCallback((_rows: Set<React.Key>) => {
+    setSelectedRows(_rows);
+  }, []);
+  return {
+    ref: gridRef, selectedCell, selectedRows, gridContext, onSelectedCellChange, onSelectedRowsChange
+  };
+};

--- a/src/components/tools/table-tool/use-table-title.ts
+++ b/src/components/tools/table-tool/use-table-title.ts
@@ -1,0 +1,47 @@
+import { useCallback, useEffect } from "react";
+import { IDataSet } from "../../../models/data/data-set";
+import { IGridContext, kControlsColumnWidth, TColumn } from "./grid-types";
+
+interface IProps {
+  gridContext: IGridContext;
+  dataSet: IDataSet;
+  readOnly?: boolean;
+  onRequestUniqueTitle?: () => string | undefined;
+}
+export const useTableTitle = ({ gridContext, dataSet, readOnly, onRequestUniqueTitle }: IProps) => {
+
+  const getTitle = useCallback(() => dataSet.name, [dataSet.name]);
+
+  const onBeginTitleEdit = () => {
+    gridContext.onClearSelection();
+    return !readOnly;
+  };
+  const onEndTitleEdit = (title?: string) => {
+    !readOnly && (title != null) && dataSet.setName(title);
+  };
+
+  const kDefaultWidth = 80;
+  const columnWidth = (column: TColumn) => {
+    return Math.max(+(column.width || kDefaultWidth), column.maxWidth || kDefaultWidth);
+  };
+  const getTitleWidthFromColumns = (columns: TColumn[]) => {
+    return columns.reduce(
+                    (sum, col, i) => sum + (i ? columnWidth(col) : 0),
+                    1 - kControlsColumnWidth);
+  };
+
+  // request a default title if we don't already have one
+  useEffect(() => {
+    if (!dataSet.name) {
+      // wait for all tiles to have registered their callbacks
+      setTimeout(() => {
+        const _title = onRequestUniqueTitle?.();
+        if (_title) {
+          dataSet.setName(_title);
+        }
+      }, 100);
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return { getTitle, getTitleWidthFromColumns, onBeginTitleEdit, onEndTitleEdit };
+};

--- a/src/components/tools/tool-tile.tsx
+++ b/src/components/tools/tool-tile.tsx
@@ -28,6 +28,7 @@ import "../../utilities/dom-utils";
 import "./tool-tile.sass";
 
 export interface IToolApi {
+  getTitle?: () => string | undefined;
   hasSelection?: () => boolean;
   deleteSelection?: () => void;
   getSelectionInfo?: () => string;
@@ -85,6 +86,7 @@ interface IToolTileBaseProps {
   model: ToolTileModelType;
   readOnly?: boolean;
   onSetCanAcceptDrop: (tileId?: string) => void;
+  onRequestUniqueTitle: (tileId: string) => string | undefined;
   onRequestRowHeight: (tileId: string, height?: number, deltaHeight?: number) => void;
 }
 

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -232,6 +232,19 @@ export const DocumentContentModel = types
       });
       return tiles;
     },
+    getTilesOfType(type: string) {
+      const tiles: string[] = [];
+      self.rowOrder.forEach(rowId => {
+        const row = self.getRow(rowId);
+        each(row?.tiles, tileEntry => {
+          const tile = self.getTile(tileEntry.tileId);
+          if (tile?.content.type === type) {
+            tiles.push(tileEntry.tileId);
+          }
+        });
+      });
+      return tiles;
+    },
     publish() {
       return JSON.stringify(self.snapshotWithUniqueIds());
     }

--- a/src/utilities/js-utils.ts
+++ b/src/utilities/js-utils.ts
@@ -54,6 +54,19 @@ export function uniqueId(idLength = 16): string {
 }
 
 /*
+ * uniqueTitle()
+ *
+ * returns a unique title from a given base name, adding a unique numeric suffix
+ */
+export function uniqueTitle(base: string, isValid: (name: string) => boolean) {
+  let name: string;
+  for (let i = 1; !isValid(name = `${base} ${i}`); ++i) {
+    // nothing to do
+  }
+  return name;
+}
+
+/*
  * uniqueName()
  *
  * returns a unique name from a given base name, adding a numeric suffix if necessary


### PR DESCRIPTION
- table title defaults to "Table 1", "Table 2", etc.
- default table titles are italicized
- built infrastructure for table to request a default height and for the document to determine it
- eliminated default fixture data
- divided responsibility between `useGridContext`, `useTableTitle`, `useDataSet`