### PR TITLE
Table changes written to content

### DIFF
--- a/src/components/tools/table-tool/editable-table-title.tsx
+++ b/src/components/tools/table-tool/editable-table-title.tsx
@@ -52,7 +52,7 @@ export const EditableTableTitle: React.FC<IProps> = observer(({
   return (
     <div className={classes} style={style} onClick={handleClick}>
       {isEditing
-        ? <HeaderCellInput style={style} value={editingTitle}
+        ? <HeaderCellInput style={style} value={editingTitle || ""}
             onKeyDown={handleKeyDown} onChange={setEditingTitle} onClose={handleClose} />
         : title}
     </div>

--- a/src/components/tools/table-tool/header-cell-input.tsx
+++ b/src/components/tools/table-tool/header-cell-input.tsx
@@ -7,7 +7,7 @@ function autoFocusAndSelect(input: HTMLInputElement | null) {
 
 interface IProps {
   style?: React.CSSProperties;
-  value?: string;
+  value: string;
   onKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => void;
   onChange: (value: string) => void;
   onClose: (accept: boolean) => void;

--- a/src/components/tools/table-tool/table-tool.tsx
+++ b/src/components/tools/table-tool/table-tool.tsx
@@ -6,6 +6,7 @@ import { TableToolbar } from "./table-toolbar";
 import { useModelDataSet } from "./use-model-data-set";
 import { useDataSet } from "./use-data-set";
 import { useGridContext } from "./use-grid-context";
+import { useRowLabelColumn } from "./use-row-label-column";
 import { useSetExpressionDialog } from "./use-set-expression-dialog";
 import { useTableTitle } from "./use-table-title";
 import { useToolbarToolApi } from "../hooks/use-toolbar-tool-api";
@@ -20,7 +21,7 @@ const TableToolComponent: React.FC<IToolTileProps> = ({
   const { dataSet, columnChanges, triggerColumnChange, rowChanges } = useModelDataSet(model);
 
   const [showRowLabels, setShowRowLabels] = useState(false);
-  const { gridContext, inputRowId, ...gridProps } = useGridContext(showRowLabels);
+  const { ref: gridRef, gridContext, inputRowId, selectedCell, ...gridProps } = useGridContext(showRowLabels);
   const { getTitle, getTitleWidthFromColumns, onBeginTitleEdit, onEndTitleEdit } = useTableTitle({
     gridContext, model, dataSet: dataSet.current, readOnly, onRequestUniqueTitle: () => onRequestUniqueTitle(model.id)
   });
@@ -33,13 +34,17 @@ const TableToolComponent: React.FC<IToolTileProps> = ({
     return () => onUnregisterToolApi();
   }, [onRegisterToolApi, onUnregisterToolApi, toolApi]);
 
+  const rowLabelProps = useRowLabelColumn({
+    inputRowId: inputRowId.current, selectedCell, showRowLabels, setShowRowLabels
+  });
+
   const handleRequestRowHeight = (options: { height?: number, delta?: number }) => {
     onRequestRowHeight(model.id, options.height, options.delta);
   };
   const { getTitleWidth, ...dataGridProps } = useDataSet({
-    gridRef: gridProps.ref, gridContext, model, dataSet: dataSet.current, columnChanges, triggerColumnChange,
-    rowChanges, readOnly: !!readOnly, getTitleWidthFromColumns,
-    inputRowId, showRowLabels, setShowRowLabels, onRequestRowHeight: handleRequestRowHeight });
+    gridRef, gridContext, model, dataSet: dataSet.current, columnChanges, triggerColumnChange,
+    rowChanges, readOnly: !!readOnly, getTitleWidthFromColumns, selectedCell,
+    inputRowId, ...rowLabelProps, onRequestRowHeight: handleRequestRowHeight });
 
   const toolbarProps = useToolbarToolApi({ id: model.id, enabled: !readOnly, onRegisterToolApi, onUnregisterToolApi });
   const [showSetExpressionDialog] = useSetExpressionDialog({ dataSet: dataSet.current });
@@ -52,7 +57,7 @@ const TableToolComponent: React.FC<IToolTileProps> = ({
         <EditableTableTitle className="table-title" readOnly={readOnly}
           getTitle={getTitle} getTitleWidth={getTitleWidth}
           onBeginEdit={onBeginTitleEdit} onEndEdit={onEndTitleEdit} />
-        <ReactDataGrid className="rdg-light" {...gridProps} {...dataGridProps} />
+        <ReactDataGrid className="rdg-light" ref={gridRef} {...gridProps} {...dataGridProps} />
       </div>
     </div>
   );

--- a/src/components/tools/table-tool/table-tool.tsx
+++ b/src/components/tools/table-tool/table-tool.tsx
@@ -20,7 +20,7 @@ const TableToolComponent: React.FC<IToolTileProps> = ({
   const { dataSet, columnChanges, triggerColumnChange, rowChanges } = useModelDataSet(model);
 
   const [showRowLabels, setShowRowLabels] = useState(false);
-  const { gridContext, ...gridProps } = useGridContext(showRowLabels);
+  const { gridContext, inputRowId, ...gridProps } = useGridContext(showRowLabels);
   const { getTitle, getTitleWidthFromColumns, onBeginTitleEdit, onEndTitleEdit } = useTableTitle({
     gridContext, model, dataSet: dataSet.current, readOnly, onRequestUniqueTitle: () => onRequestUniqueTitle(model.id)
   });
@@ -39,7 +39,7 @@ const TableToolComponent: React.FC<IToolTileProps> = ({
   const { getTitleWidth, ...dataGridProps } = useDataSet({
     gridRef: gridProps.ref, gridContext, model, dataSet: dataSet.current, columnChanges, triggerColumnChange,
     rowChanges, readOnly: !!readOnly, getTitleWidthFromColumns,
-    showRowLabels, setShowRowLabels, onRequestRowHeight: handleRequestRowHeight });
+    inputRowId, showRowLabels, setShowRowLabels, onRequestRowHeight: handleRequestRowHeight });
 
   const toolbarProps = useToolbarToolApi({ id: model.id, enabled: !readOnly, onRegisterToolApi, onUnregisterToolApi });
   const [showSetExpressionDialog] = useSetExpressionDialog({ dataSet: dataSet.current });

--- a/src/components/tools/table-tool/table-tool.tsx
+++ b/src/components/tools/table-tool/table-tool.tsx
@@ -20,7 +20,7 @@ const TableToolComponent: React.FC<IToolTileProps> = ({
   const { dataSet, columnChanges, triggerColumnChange, rowChanges } = useModelDataSet(model);
 
   const [showRowLabels, setShowRowLabels] = useState(false);
-  const { selectedCell, gridContext, ...gridProps } = useGridContext(showRowLabels);
+  const { gridContext, ...gridProps } = useGridContext(showRowLabels);
   const { getTitle, getTitleWidthFromColumns, onBeginTitleEdit, onEndTitleEdit } = useTableTitle({
     gridContext, model, dataSet: dataSet.current, readOnly, onRequestUniqueTitle: () => onRequestUniqueTitle(model.id)
   });
@@ -37,7 +37,7 @@ const TableToolComponent: React.FC<IToolTileProps> = ({
     onRequestRowHeight(model.id, options.height, options.delta);
   };
   const { getTitleWidth, ...dataGridProps } = useDataSet({
-    gridContext, selectedCell, model, dataSet: dataSet.current, columnChanges, triggerColumnChange,
+    gridRef: gridProps.ref, gridContext, model, dataSet: dataSet.current, columnChanges, triggerColumnChange,
     rowChanges, readOnly: !!readOnly, getTitleWidthFromColumns,
     showRowLabels, setShowRowLabels, onRequestRowHeight: handleRequestRowHeight });
 

--- a/src/components/tools/table-tool/use-columns-from-data-set.ts
+++ b/src/components/tools/table-tool/use-columns-from-data-set.ts
@@ -7,7 +7,6 @@ import {
 } from "./grid-types";
 import { useControlsColumn } from "./use-controls-column";
 import { useEditableColumnNames } from "./use-editable-column-names";
-import { useRowLabelColumn } from "./use-row-label-column";
 
 function estimateColumnWidthFromName(name: string) {
   // values taken from design spec
@@ -18,20 +17,18 @@ interface IUseColumnsFromDataSet {
   gridContext: IGridContext;
   dataSet: IDataSet;
   readOnly?: boolean;
-  inputRowId: string;
   columnChanges: number;
-  showRowLabels: boolean;
-  setShowRowLabels: (show: boolean) => void;
+  RowLabelHeader: React.FC<any>;
+  RowLabelFormatter: React.FC<any>;
   setColumnName: (column: TColumn, columnName: string) => void;
   onAddColumn: () => void;
   onRemoveRow: (rowId: string) => void;
 }
 export const useColumnsFromDataSet = ({
-  gridContext, dataSet, readOnly, inputRowId, columnChanges, showRowLabels,
-  setShowRowLabels, setColumnName, onAddColumn, onRemoveRow
+  gridContext, dataSet, readOnly, columnChanges, RowLabelHeader, RowLabelFormatter,
+  setColumnName, onAddColumn, onRemoveRow
 }: IUseColumnsFromDataSet) => {
   const { attributes } = dataSet;
-  const { RowLabelHeader, RowLabelFormatter } = useRowLabelColumn(inputRowId, showRowLabels, setShowRowLabels);
   const { ControlsHeaderRenderer, ControlsRowFormatter } = useControlsColumn({ readOnly, onAddColumn, onRemoveRow });
   const columnWidths = useRef<Record<string, number>>({});
 

--- a/src/components/tools/table-tool/use-data-set.ts
+++ b/src/components/tools/table-tool/use-data-set.ts
@@ -29,15 +29,15 @@ interface IUseDataSet {
   readOnly: boolean;
   getTitleWidthFromColumns: (columns: TColumn[]) => number;
   showRowLabels: boolean;
+  inputRowId: React.MutableRefObject<string>;
   setShowRowLabels: (show: boolean) => void;
   onRequestRowHeight: (options: { height?: number, deltaHeight?: number }) => void;
 }
 export const useDataSet = ({
   gridRef, gridContext, model, dataSet, columnChanges, triggerColumnChange, rowChanges,
-  readOnly, showRowLabels, setShowRowLabels, getTitleWidthFromColumns, onRequestRowHeight
+  readOnly, inputRowId, showRowLabels, setShowRowLabels, getTitleWidthFromColumns, onRequestRowHeight
 }: IUseDataSet) => {
   const selectedCell = useRef<TPosition>({ rowIdx: -1, idx: -1 });
-  const inputRowId = useRef(uniqueId());
   const setColumnName = (column: TColumn, columnName: string) => {
     const content = model.content as TableContentModelType;
     !readOnly && content.setAttributeName(column.key, columnName);

--- a/src/components/tools/table-tool/use-data-set.ts
+++ b/src/components/tools/table-tool/use-data-set.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from "react";
+import { useCallback } from "react";
 import { DataGridHandle } from "react-data-grid";
 import { ICase, IDataSet } from "../../../models/data/data-set";
 import { TableContentModelType } from "../../../models/tools/table/table-content";
@@ -27,17 +27,17 @@ interface IUseDataSet {
   triggerColumnChange: () => void;
   rowChanges: number;
   readOnly: boolean;
-  getTitleWidthFromColumns: (columns: TColumn[]) => number;
-  showRowLabels: boolean;
   inputRowId: React.MutableRefObject<string>;
-  setShowRowLabels: (show: boolean) => void;
+  selectedCell: React.MutableRefObject<TPosition>;
+  RowLabelHeader: React.FC<any>;
+  RowLabelFormatter: React.FC<any>;
+  getTitleWidthFromColumns: (columns: TColumn[]) => number;
   onRequestRowHeight: (options: { height?: number, deltaHeight?: number }) => void;
 }
 export const useDataSet = ({
-  gridRef, gridContext, model, dataSet, columnChanges, triggerColumnChange, rowChanges,
-  readOnly, inputRowId, showRowLabels, setShowRowLabels, getTitleWidthFromColumns, onRequestRowHeight
+  gridRef, gridContext, model, dataSet, columnChanges, triggerColumnChange, rowChanges, readOnly,
+  inputRowId, selectedCell, RowLabelHeader, RowLabelFormatter, getTitleWidthFromColumns, onRequestRowHeight
 }: IUseDataSet) => {
-  const selectedCell = useRef<TPosition>({ rowIdx: -1, idx: -1 });
   const setColumnName = (column: TColumn, columnName: string) => {
     const content = model.content as TableContentModelType;
     !readOnly && content.setAttributeName(column.key, columnName);
@@ -51,8 +51,8 @@ export const useDataSet = ({
     !readOnly && content.removeCases([rowId]);
   };
   const { columns, onColumnResize } = useColumnsFromDataSet({
-                                        gridContext, dataSet, readOnly, inputRowId: inputRowId.current, columnChanges,
-                                        showRowLabels, setShowRowLabels, setColumnName, onAddColumn, onRemoveRow });
+    gridContext, dataSet, readOnly, columnChanges, RowLabelHeader, RowLabelFormatter,
+    setColumnName, onAddColumn, onRemoveRow });
   const onSelectedCellChange = (position: TPosition) => {
     const forward = (selectedCell.current.rowIdx < position.rowIdx) ||
                     ((selectedCell.current.rowIdx === position.rowIdx) &&

--- a/src/components/tools/table-tool/use-grid-context.ts
+++ b/src/components/tools/table-tool/use-grid-context.ts
@@ -1,11 +1,9 @@
 import { useCallback, useMemo, useRef, useState } from "react";
-import { DataGridHandle } from "react-data-grid";
-import { IGridContext, TPosition } from "./grid-types";
+import { CellNavigationMode, DataGridHandle } from "react-data-grid";
+import { IGridContext } from "./grid-types";
 
 export const useGridContext = (showRowLabels: boolean) => {
   const gridRef = useRef<DataGridHandle>(null);
-  // this tracks ReactDataGrid's internal notion of the selected cell
-  const selectedCell = useRef<TPosition>();
   // these are passed into ReactDataGrid as the ultimate source of truth
   const [selectedRows, setSelectedRows] = useState(() => new Set<React.Key>());
   const selectOneRow = useCallback((row: string) => setSelectedRows(new Set([row])), []);
@@ -21,13 +19,11 @@ export const useGridContext = (showRowLabels: boolean) => {
             clearCellSelection();
           }
         }), [clearCellSelection, clearRowSelection, selectOneRow, showRowLabels]);
-  const onSelectedCellChange = useCallback((position: TPosition) => {
-    selectedCell.current = position;
-  }, []);
   const onSelectedRowsChange = useCallback((_rows: Set<React.Key>) => {
     setSelectedRows(_rows);
   }, []);
+  const cellNavigationMode: CellNavigationMode = "CHANGE_ROW";
   return {
-    ref: gridRef, selectedCell, selectedRows, gridContext, onSelectedCellChange, onSelectedRowsChange
+    ref: gridRef, cellNavigationMode, selectedRows, gridContext, onSelectedRowsChange
   };
 };

--- a/src/components/tools/table-tool/use-grid-context.ts
+++ b/src/components/tools/table-tool/use-grid-context.ts
@@ -1,11 +1,12 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import { CellNavigationMode, DataGridHandle } from "react-data-grid";
 import { uniqueId } from "../../../utilities/js-utils";
-import { IGridContext } from "./grid-types";
+import { IGridContext, TPosition } from "./grid-types";
 
 export const useGridContext = (showRowLabels: boolean) => {
   const gridRef = useRef<DataGridHandle>(null);
   const inputRowId = useRef(uniqueId());
+  const selectedCell = useRef<TPosition>({ rowIdx: -1, idx: -1 });
   // these are passed into ReactDataGrid as the ultimate source of truth
   const [selectedRows, setSelectedRows] = useState(() => new Set<React.Key>());
   const selectOneRow = useCallback((row: string) => setSelectedRows(new Set([row])), []);
@@ -27,6 +28,6 @@ export const useGridContext = (showRowLabels: boolean) => {
   }, []);
   const cellNavigationMode: CellNavigationMode = "CHANGE_ROW";
   return {
-    ref: gridRef, cellNavigationMode, inputRowId, selectedRows, gridContext, onSelectedRowsChange
+    ref: gridRef, cellNavigationMode, inputRowId, selectedCell, selectedRows, gridContext, onSelectedRowsChange
   };
 };

--- a/src/components/tools/table-tool/use-grid-context.ts
+++ b/src/components/tools/table-tool/use-grid-context.ts
@@ -1,9 +1,11 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import { CellNavigationMode, DataGridHandle } from "react-data-grid";
+import { uniqueId } from "../../../utilities/js-utils";
 import { IGridContext } from "./grid-types";
 
 export const useGridContext = (showRowLabels: boolean) => {
   const gridRef = useRef<DataGridHandle>(null);
+  const inputRowId = useRef(uniqueId());
   // these are passed into ReactDataGrid as the ultimate source of truth
   const [selectedRows, setSelectedRows] = useState(() => new Set<React.Key>());
   const selectOneRow = useCallback((row: string) => setSelectedRows(new Set([row])), []);
@@ -20,10 +22,11 @@ export const useGridContext = (showRowLabels: boolean) => {
           }
         }), [clearCellSelection, clearRowSelection, selectOneRow, showRowLabels]);
   const onSelectedRowsChange = useCallback((_rows: Set<React.Key>) => {
+    _rows.delete(inputRowId.current);
     setSelectedRows(_rows);
   }, []);
   const cellNavigationMode: CellNavigationMode = "CHANGE_ROW";
   return {
-    ref: gridRef, cellNavigationMode, selectedRows, gridContext, onSelectedRowsChange
+    ref: gridRef, cellNavigationMode, inputRowId, selectedRows, gridContext, onSelectedRowsChange
   };
 };

--- a/src/components/tools/table-tool/use-model-data-set.ts
+++ b/src/components/tools/table-tool/use-model-data-set.ts
@@ -1,0 +1,32 @@
+import { autorun } from "mobx";
+import { useEffect, useRef, useState } from "react";
+import { DataSet } from "../../../models/data/data-set";
+import { TableContentModelType } from "../../../models/tools/table/table-content";
+import { ToolTileModelType } from "../../../models/tools/tool-tile";
+
+/*
+  Table state is stored in content as a sequence of changes/actions.
+  This code is responsible for tracking changes in content and maintaining a
+  synchronized DataSet model for use by ReactDataGrid and other clients.
+ */
+export const useModelDataSet = (model: ToolTileModelType) => {
+  const dataSet = useRef(DataSet.create());
+  const syncedChanges = useRef(0);
+  const [columnChanges, setColumnChanges] = useState(0);
+  const triggerColumnChange = () => setColumnChanges(state => ++state);
+  const [rowChanges, setRowChanges] = useState(0);
+  const triggerRowChange = () => setRowChanges(state => ++state);
+  useEffect(() => {
+    const content = model.content as TableContentModelType;
+    const disposer = autorun(() => {
+      if (syncedChanges.current < content.changes.length) {
+        const [hasColumnChanges, hasRowChanges] = content.applyChanges(dataSet.current, syncedChanges.current);
+        hasColumnChanges && triggerColumnChange();
+        hasRowChanges && triggerRowChange();
+        syncedChanges.current = content.changes.length;
+      }
+    });
+    return () => disposer();
+  }, [model.content]);  // eslint-disable-line react-hooks/exhaustive-deps
+  return { dataSet, columnChanges, triggerColumnChange, rowChanges };
+};

--- a/src/components/tools/table-tool/use-row-label-column.tsx
+++ b/src/components/tools/table-tool/use-row-label-column.tsx
@@ -38,17 +38,19 @@ export const useRowLabelColumn = ({
     const handleClick = (e: React.MouseEvent) => {
       const hasModifier = e.ctrlKey || e.metaKey || e.shiftKey;
       const selected = hasModifier ? !isRowSelected : true;
-      if ((e.button === 0) && (selected !== isRowSelected)) {
-        if (hasModifier) {
-          onRowSelectionChange(selected, e.shiftKey);
-        }
-        else if (__id__ === inputRowId) {
-          // clear selection so navigation direction is always forward after click
-          selectedCell.current = { rowIdx: -1, idx: -1 };
-          __context__.onClearRowSelection();
-        }
-        else {
-          __context__.onSelectOneRow(__id__);
+      if (e.button === 0) {
+        // clear selection so navigation direction is always forward after click
+        selectedCell.current = { rowIdx: -1, idx: -1 };
+        if (selected !== isRowSelected) {
+          if (hasModifier) {
+            onRowSelectionChange(selected, e.shiftKey);
+          }
+          else if (__id__ === inputRowId) {
+            __context__.onClearRowSelection();
+          }
+          else {
+            __context__.onSelectOneRow(__id__);
+          }
         }
       }
     };

--- a/src/components/tools/table-tool/use-row-label-column.tsx
+++ b/src/components/tools/table-tool/use-row-label-column.tsx
@@ -3,10 +3,17 @@ import { Tooltip } from "react-tippy";
 import RowLabelsHiddenSvg from "../../../clue/assets/icons/table/row-labels-hidden-icon.svg";
 import RowLabelsShownSvg from "../../../clue/assets/icons/table/row-labels-shown-icon.svg";
 import { useTooltipOptions } from "../../../hooks/use-tooltip-options";
-import { TFormatterProps } from "./grid-types";
+import { TFormatterProps, TPosition } from "./grid-types";
 
-export const useRowLabelColumn = (
-  inputRowId: string, showRowLabels: boolean, setShowRowLabels: (show: boolean) => void) => {
+interface IProps {
+  inputRowId: string;
+  selectedCell: React.MutableRefObject<TPosition>;
+  showRowLabels: boolean;
+  setShowRowLabels: (show: boolean) => void;
+}
+export const useRowLabelColumn = ({
+  inputRowId, selectedCell, showRowLabels, setShowRowLabels
+}: IProps) => {
 
   const title = showRowLabels ? "Hide labels" : "Show labels";
   const tooltipOptions = useTooltipOptions({ title, distance: -36 });
@@ -36,6 +43,8 @@ export const useRowLabelColumn = (
           onRowSelectionChange(selected, e.shiftKey);
         }
         else if (__id__ === inputRowId) {
+          // clear selection so navigation direction is always forward after click
+          selectedCell.current = { rowIdx: -1, idx: -1 };
           __context__.onClearRowSelection();
         }
         else {
@@ -45,11 +54,11 @@ export const useRowLabelColumn = (
     };
 
     return (
-      <div className="index-cell-contents" onClick={handleClick}>
+      <div className="index-cell-contents" onClick={handleClick} onDoubleClick={handleClick}>
         {showRowLabels ? __index__ : undefined}
       </div>
     );
-  }, [inputRowId, showRowLabels]);
+  }, [inputRowId, selectedCell, showRowLabels]);
 
   return { RowLabelHeader, RowLabelFormatter };
 };

--- a/src/components/tools/table-tool/use-rows-from-data-set.ts
+++ b/src/components/tools/table-tool/use-rows-from-data-set.ts
@@ -9,16 +9,30 @@ interface IUseRowsFromDataSet {
   rowChanges: number;
   context: IGridContext;
 }
+
+const canonicalize = (dataSet: IDataSet, row: TRow) => {
+  // ReactDataGrid currently doesn't like editing undefined values,
+  // so we convert them to empty strings when building rows.
+  if (row) {
+    dataSet.attributes.forEach(attr => {
+      if (row[attr.id] == null) {
+        row[attr.id] = "";
+      }
+    });
+  }
+  return row;
+};
+
 export const useRowsFromDataSet = ({ dataSet, readOnly, inputRowId, rowChanges, context }: IUseRowsFromDataSet) => {
   return useMemo(() => {
     const rowKeyGetter = (row: TRow) => row.__id__;
     const rowClass = (row: TRow) => row.__id__ === inputRowId ? "input-row" : undefined;
     const rows = dataSet.getCanonicalCasesAtIndices()
-                        .map((row, i) => ({
+                        .map((_case, i) => canonicalize(dataSet, {
                           __index__: i + 1,
                           __context__: context,
-                          ...row })) as TRow[];
-    !readOnly && rows.push({ __id__: inputRowId, __context__: context });
+                          ..._case } as TRow));
+    !readOnly && rows.push(canonicalize(dataSet, { __id__: inputRowId, __context__: context }));
     rowChanges; // eslint-disable-line no-unused-expressions
     return { rows, rowKeyGetter, rowClass };
   }, [context, dataSet, inputRowId, readOnly, rowChanges]);

--- a/src/components/tools/table-tool/use-table-title.ts
+++ b/src/components/tools/table-tool/use-table-title.ts
@@ -1,14 +1,17 @@
 import { useCallback, useEffect } from "react";
 import { IDataSet } from "../../../models/data/data-set";
+import { TableContentModelType } from "../../../models/tools/table/table-content";
+import { ToolTileModelType } from "../../../models/tools/tool-tile";
 import { IGridContext, kControlsColumnWidth, TColumn } from "./grid-types";
 
 interface IProps {
   gridContext: IGridContext;
+  model: ToolTileModelType;
   dataSet: IDataSet;
   readOnly?: boolean;
   onRequestUniqueTitle?: () => string | undefined;
 }
-export const useTableTitle = ({ gridContext, dataSet, readOnly, onRequestUniqueTitle }: IProps) => {
+export const useTableTitle = ({ gridContext, model, dataSet, readOnly, onRequestUniqueTitle }: IProps) => {
 
   const getTitle = useCallback(() => dataSet.name, [dataSet.name]);
 
@@ -17,7 +20,8 @@ export const useTableTitle = ({ gridContext, dataSet, readOnly, onRequestUniqueT
     return !readOnly;
   };
   const onEndTitleEdit = (title?: string) => {
-    !readOnly && (title != null) && dataSet.setName(title);
+    const content = model.content as TableContentModelType;
+    !readOnly && (title != null) && content.setTableName(title);
   };
 
   const kDefaultWidth = 80;


### PR DESCRIPTION
Previously, table changes just affected the local `DataSet` instance but weren't writing changes to the content, which meant they weren't being written to firebase. Now, table changes are written to the content as before, i.e. the new table is "live".

In addition:
- fixed cell navigation so non-editable/non-visible cells are skipped in navigation
- prevent the input row from being selected