### PR TITLE
Improve cell selection and add column/remove row icon visibility issues [#175959558][#175959577]

### DIFF
--- a/src/components/tools/table-tool/cell-text-editor.tsx
+++ b/src/components/tools/table-tool/cell-text-editor.tsx
@@ -1,0 +1,34 @@
+import React, { useEffect } from "react";
+import { EditorProps } from "react-data-grid";
+import { TColumn } from "./table-types";
+
+function autoFocusAndSelect(input: HTMLInputElement | null) {
+  input?.focus();
+  input?.select();
+}
+
+// patterned after TextEditor from "react-data-grid"
+export default function CellTextEditor<TRow, TSummaryRow = unknown>({
+  row, column, onRowChange, onClose
+}: EditorProps<TRow, TSummaryRow>) {
+  const _column: TColumn = column as unknown as TColumn;
+
+  useEffect(() => {
+    _column.appData?.onBeginBodyCellEdit?.();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+    onClose(true);
+    _column.appData?.onEndBodyCellEdit?.(e.target.value);
+  };
+
+  return (
+    <input
+      className="rdg-text-editor"
+      ref={autoFocusAndSelect}
+      value={row[column.key as keyof TRow] as unknown as string}
+      onChange={event => onRowChange({ ...row, [column.key]: event.target.value })}
+      onBlur={handleBlur}
+    />
+  );
+}

--- a/src/components/tools/table-tool/table-tool.scss
+++ b/src/components/tools/table-tool/table-tool.scss
@@ -114,7 +114,7 @@ $controls-hover-background: #c0dfe7;
         .add-column-button {
           width: $controls-column-width;
           height: $row-height;
-          display: flex;
+          display: none;  // overridden when tile is selected
           justify-content: center;
           align-items: center;
           svg {
@@ -172,7 +172,7 @@ $controls-hover-background: #c0dfe7;
         .remove-row-button {
           width: $controls-column-width;
           height: $row-height;
-          display: flex;
+          display: none;  // overridden when tile is selected
           justify-content: center;
           align-items: center;
           svg {
@@ -214,6 +214,15 @@ $controls-hover-background: #c0dfe7;
       &.has-expression {
         background-color: $charcoal-light-5;
       }
+    }
+  }
+}
+
+.tool-tile.selected {
+  .table-tool {
+    .add-column-button, .remove-row-button {
+      // show buttons only when tile is selected
+      display: flex !important;
     }
   }
 }

--- a/src/components/tools/table-tool/table-types.ts
+++ b/src/components/tools/table-tool/table-types.ts
@@ -6,6 +6,7 @@ export const kControlsColumnWidth = 36;
 
 export interface IGridContext {
   showRowLabels: boolean;
+  isSelectedCellInRow: (rowIdx: number) => boolean;
   onSelectOneRow: (row: string) => void;
   onClearRowSelection: () => void;
   onClearCellSelection: () => void;

--- a/src/components/tools/table-tool/table-types.ts
+++ b/src/components/tools/table-tool/table-types.ts
@@ -30,6 +30,8 @@ export interface TColumnAppData {
   onBeginHeaderCellEdit?: () => boolean | undefined;
   onHeaderCellEditKeyDown?: (e: React.KeyboardEvent<HTMLDivElement>) => void;
   onEndHeaderCellEdit?: (value?: string) => void;
+  onBeginBodyCellEdit?: () => boolean | undefined;
+  onEndBodyCellEdit?: (value?: string) => void;
 }
 export interface TColumn extends Column<TRow> {
   appData?: TColumnAppData;

--- a/src/components/tools/table-tool/use-column-extensions.ts
+++ b/src/components/tools/table-tool/use-column-extensions.ts
@@ -10,7 +10,7 @@ interface IProps {
   setColumnEditingName: (column?: TColumn) => void;
   setColumnName: (column: TColumn, name: string) => void;
 }
-export const useEditableColumnHeaders = ({
+export const useColumnExtensions = ({
   gridContext, metadata, readOnly, columns, columnEditingName, setColumnEditingName, setColumnName
 }: IProps) => {
 
@@ -41,7 +41,10 @@ export const useEditableColumnHeaders = ({
       onEndHeaderCellEdit: (value?: string) => {
         !readOnly && (value != null) && setColumnName(column, value);
         setColumnEditingName();
-      }
+      },
+      onBeginBodyCellEdit: (() => {
+        gridContext.onClearRowSelection();
+      }) as any
     };
   });
 };

--- a/src/components/tools/table-tool/use-columns-from-data-set.ts
+++ b/src/components/tools/table-tool/use-columns-from-data-set.ts
@@ -1,14 +1,14 @@
 import classNames from "classnames";
 import { useCallback, useMemo, useRef, useState } from "react";
-import { TextEditor } from "react-data-grid";
 import { IDataSet } from "../../../models/data/data-set";
 import { TableMetadataModelType } from "../../../models/tools/table/table-content";
+import CellTextEditor from "./cell-text-editor";
 import { ColumnHeaderCell } from "./column-header-cell";
 import {
   IGridContext, kControlsColumnKey, kControlsColumnWidth, kIndexColumnKey, kIndexColumnWidth, TColumn, TFormatterProps
 } from "./table-types";
+import { useColumnExtensions } from "./use-column-extensions";
 import { useControlsColumn } from "./use-controls-column";
-import { useEditableColumnHeaders } from "./use-editable-column-headers";
 import { useNumberFormat } from "./use-number-format";
 
 function estimateColumnWidthFromName(name: string) {
@@ -62,7 +62,7 @@ export const useColumnsFromDataSet = ({
       resizable: !readOnly,
       headerRenderer: ColumnHeaderCell,
       formatter: CellFormatter,
-      editor: !readOnly && !metadata.hasExpression(attr.id) ? TextEditor : undefined,
+      editor: !readOnly && !metadata.hasExpression(attr.id) ? CellTextEditor : undefined,
       editorOptions: {
         editOnClick: !readOnly
       }
@@ -100,7 +100,7 @@ export const useColumnsFromDataSet = ({
   }, [ControlsHeaderRenderer, ControlsRowFormatter, RowLabelHeader, RowLabelFormatter,
       attributes, columnChanges, columnEditingName, metadata, readOnly]);
 
-  useEditableColumnHeaders({
+  useColumnExtensions({
     gridContext, metadata, readOnly, columns, columnEditingName,
     setColumnEditingName: handleSetColumnEditingName, setColumnName });
 

--- a/src/components/tools/table-tool/use-controls-column.tsx
+++ b/src/components/tools/table-tool/use-controls-column.tsx
@@ -23,8 +23,9 @@ export const useControlsColumn = ({ readOnly, onAddColumn, onRemoveRow }: IUseCo
   }, [addColumnTooltipOptions, onAddColumn, readOnly]);
 
   const removeRowTooltipOptions = useTooltipOptions({ title: "Remove row", distance: kTooltipDistance });
-  const ControlsRowFormatter: React.FC<TFormatterProps> = useCallback(({ row, isRowSelected }) => {
-    return !readOnly && isRowSelected
+  const ControlsRowFormatter: React.FC<TFormatterProps> = useCallback(({ rowIdx, row, isRowSelected }) => {
+    const showRemoveButton = !readOnly && (isRowSelected || row.__context__.isSelectedCellInRow(rowIdx));
+    return showRemoveButton
             ? <Tooltip {...removeRowTooltipOptions}>
                 <RemoveRowButton rowId={row.__id__} onRemoveRow={onRemoveRow} />
               </Tooltip>

--- a/src/components/tools/table-tool/use-grid-context.ts
+++ b/src/components/tools/table-tool/use-grid-context.ts
@@ -9,11 +9,13 @@ export const useGridContext = (showRowLabels: boolean) => {
   const selectedCell = useRef<TPosition>({ rowIdx: -1, idx: -1 });
   // these are passed into ReactDataGrid as the ultimate source of truth
   const [selectedRows, setSelectedRows] = useState(() => new Set<React.Key>());
+  const isSelectedCellInRow = useCallback((rowIdx: number) => selectedCell.current.rowIdx === rowIdx, []);
   const selectOneRow = useCallback((row: string) => setSelectedRows(new Set([row])), []);
   const clearRowSelection = useCallback(() => setSelectedRows(new Set([])), []);
   const clearCellSelection = useCallback(() => gridRef.current?.selectCell({ idx: -1, rowIdx: -1 }), []);
   const gridContext: IGridContext = useMemo(() => ({
           showRowLabels,
+          isSelectedCellInRow,
           onSelectOneRow: selectOneRow,
           onClearRowSelection: clearRowSelection,
           onClearCellSelection: clearCellSelection,
@@ -21,7 +23,7 @@ export const useGridContext = (showRowLabels: boolean) => {
             clearRowSelection();
             clearCellSelection();
           }
-        }), [clearCellSelection, clearRowSelection, selectOneRow, showRowLabels]);
+        }), [clearCellSelection, clearRowSelection, isSelectedCellInRow, selectOneRow, showRowLabels]);
   const onSelectedRowsChange = useCallback((_rows: Set<React.Key>) => {
     _rows.delete(inputRowId.current);
     setSelectedRows(_rows);


### PR DESCRIPTION
- Clear row selection when editing a cell
- Show delete row icon when cell is selected in row as well as when row is selected [[#175959558]](https://www.pivotaltracker.com/story/show/175959558)
- Hide add colum/remove row buttons when tile isn't selected [[#175959577]](https://www.pivotaltracker.com/story/show/175959577)

Testable at https://collaborative-learning.concord.org/branch/table-selection/?demo.