### PR TITLE
Synchronize selection between table and geometry tiles [#176582684]

### DIFF
--- a/src/components/tools/table-tool/table-tool.tsx
+++ b/src/components/tools/table-tool/table-tool.tsx
@@ -1,3 +1,4 @@
+import { observer } from "mobx-react";
 import React, { useCallback, useRef, useState } from "react";
 import ReactDataGrid from "react-data-grid";
 import { TableContentModelType } from "../../../models/tools/table/table-content";
@@ -21,7 +22,8 @@ import { useToolbarToolApi } from "../hooks/use-toolbar-tool-api";
 import "react-data-grid/dist/react-data-grid.css";
 import "./table-tool.scss";
 
-const TableToolComponent: React.FC<IToolTileProps> = ({
+// observes row selection from shared selection store
+const TableToolComponent: React.FC<IToolTileProps> = observer(({
   documentId, documentContent, toolTile, model, readOnly, height,
   onRequestRowHeight, onRequestTilesOfType, onRequestUniqueTitle, onRegisterToolApi, onUnregisterToolApi
 }) => {
@@ -54,8 +56,8 @@ const TableToolComponent: React.FC<IToolTileProps> = ({
 
   const [showRowLabels, setShowRowLabels] = useState(false);
   const {
-    ref: gridRef, gridContext, inputRowId, selectedCell, ...gridProps
-  } = useGridContext(showRowLabels, triggerColumnChange);
+    ref: gridRef, gridContext, inputRowId, selectedCell, getSelectedRows, ...gridProps
+  } = useGridContext({ modelId: model.id, showRowLabels, triggerColumnChange });
   const measureHeaderText = useMeasureText("bold 14px Lato, sans-serif");
   // const measureBodyText = useMeasureText("14px Lato, sans-serif");
   const { getTitle, onBeginTitleEdit, onEndTitleEdit } = useTableTitle({
@@ -110,11 +112,12 @@ const TableToolComponent: React.FC<IToolTileProps> = ({
           isLinkEnabled={isLinkEnabled} onLinkGeometryClick={showLinkGeometryDialog}
           getTitle={getTitle} titleCellWidth={titleCellWidth}
           onBeginEdit={onBeginTitleEdit} onEndEdit={onEndTitleEdit} />
-        <ReactDataGrid ref={gridRef} {...gridProps} {...gridModelProps} {...dataGridProps} />
+        <ReactDataGrid ref={gridRef} selectedRows={getSelectedRows()}
+          {...gridProps} {...gridModelProps} {...dataGridProps} />
       </div>
     </div>
   );
-};
+});
 export default TableToolComponent;
 (TableToolComponent as any).tileHandlesSelection = true;
 

--- a/src/components/tools/table-tool/table-types.ts
+++ b/src/components/tools/table-tool/table-types.ts
@@ -10,6 +10,7 @@ export interface IGridContext {
   isColumnSelected: (columnId: string) => boolean;
   onSelectColumn: (columnId: string) => void;
   isSelectedCellInRow: (rowIdx: number) => boolean;
+  onSelectRowById: (rowId: string, select: boolean) => void;
   onSelectOneRow: (row: string) => void;
   onClearSelection: (options?: { row?: boolean, column?: boolean, cell?: boolean }) => void;
 }

--- a/src/components/tools/table-tool/use-grid-context.ts
+++ b/src/components/tools/table-tool/use-grid-context.ts
@@ -55,8 +55,9 @@ export const useGridContext = ({ modelId, showRowLabels, triggerColumnChange }: 
   }, [modelId, sharedSelection]);
 
   const selectOneRow = useCallback((rowId: string) => {
+    clearColumnSelection();
     sharedSelection.setSelected(modelId, [rowId]);
-  }, [modelId, sharedSelection]);
+  }, [clearColumnSelection, modelId, sharedSelection]);
 
   // Creating a new gridContext can result in focus change thus disrupting cell edits;
   // therefore, it's important that all inputs to the gridContext be wrapped in useCallback()

--- a/src/hooks/use-stores.ts
+++ b/src/hooks/use-stores.ts
@@ -3,6 +3,7 @@ import { useContext } from "react";
 import { ProblemModelType } from "../models/curriculum/problem";
 import { AppConfigModelType } from "../models/stores/app-config-model";
 import { GroupsModelType } from "../models/stores/groups";
+import { SelectionStoreModelType } from "../models/stores/selection";
 import { getSettingFromStores, IStores } from "../models/stores/stores";
 import { UserModelType } from "../models/stores/user";
 import { UIModelType } from "../models/stores/ui";
@@ -30,6 +31,10 @@ export function useProblemStore(): ProblemModelType {
 
 export function useSettingFromStores(key: string, group?: string) {
   return getSettingFromStores(useStores(), key, group);
+}
+
+export function useSharedSelectionStore(): SelectionStoreModelType {
+  return useStores().selection;
 }
 
 export function useUIStore(): UIModelType {

--- a/src/models/tools/geometry/jxg-board.ts
+++ b/src/models/tools/geometry/jxg-board.ts
@@ -1,6 +1,6 @@
 import "./jxg";
 import { JXGChange, JXGChangeAgent, JXGProperties } from "./jxg-changes";
-import { isAxis, isBoard, isLinkedPoint } from "./jxg-types";
+import { isAxis, isBoard, isLinkedPoint, isPoint } from "./jxg-types";
 import { goodTickValue } from "../../../utilities/graph-utils";
 import { assign, each, find } from "lodash";
 import { ITableLinkProperties } from "../table/table-content";
@@ -24,6 +24,11 @@ export function getObjectById(board: JXG.Board, id: string) {
     obj = board.objects[caseId];
   }
   return obj;
+}
+
+export function getPointsByCaseId(board: JXG.Board, caseId: string) {
+  if (!caseId || caseId.includes(":")) return [getObjectById(board, caseId)];
+  return board.objectsList.filter(obj => isPoint(obj) && (obj.id.split(":")[0] === caseId));
 }
 
 export function syncLinkedPoints(board: JXG.Board, links: ITableLinkProperties) {


### PR DESCRIPTION
Previously, row selection was stored in local React state. Initially, I tried synchronizing the shared selection state in the selection store with the local React state, which turned out to be trickier than expected. Ultimately, I realized that I could just use the selection store state directly and eliminate the local React state and any corresponding synchronization issues.