### PR TITLE
Miscellaneous table-related bug-fixes

### DIFF
--- a/src/components/document/document-content.tsx
+++ b/src/components/document/document-content.tsx
@@ -58,6 +58,9 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
         this.mutationObserver = new MutationObserver(this.handleRowElementsChanged);
         this.mutationObserver.observe(this.domElement, { childList: true });
       }
+      // We pass the domElement to our children, but it's undefined during the first render,
+      // so we force an update to make sure we draw at least once after we have our domElement.
+      this.forceUpdate();
     }
   }
 

--- a/src/components/tools/drawing-tool/drawing-tool.tsx
+++ b/src/components/tools/drawing-tool/drawing-tool.tsx
@@ -11,7 +11,7 @@ import "./drawing-tool.sass";
 type IProps = IToolTileProps;
 
 const DrawingToolComponent: React.FC<IProps> = (props) => {
-  const { documentContent, toolTile, model, readOnly, onRegisterToolApi, onUnregisterToolApi } = props;
+  const { documentContent, toolTile, model, readOnly, scale, onRegisterToolApi, onUnregisterToolApi } = props;
 
   useEffect(() => {
     if (!readOnly) {
@@ -26,6 +26,7 @@ const DrawingToolComponent: React.FC<IProps> = (props) => {
       <ToolbarView model={model}
                   documentContent={documentContent}
                   toolTile={toolTile}
+                  scale={scale}
                   {...toolbarProps} />
       <DrawingLayerView {...props} />
     </div>

--- a/src/components/tools/drawing-tool/drawing-toolbar.tsx
+++ b/src/components/tools/drawing-tool/drawing-toolbar.tsx
@@ -7,7 +7,7 @@ import {
 import { StampsPalette } from "./stamps-palette";
 import { StrokeColorPalette } from "./stroke-color-palette";
 import { FillColorPalette } from "./fill-color-palette";
-import { useFloatingToolbarLocation } from "../hooks/use-floating-toolbar-location";
+import { IFloatingToolbarProps, useFloatingToolbarLocation } from "../hooks/use-floating-toolbar-location";
 import { useForceUpdate } from "../hooks/use-force-update";
 import { useMobXOnChange } from "../hooks/use-mobx-on-change";
 import { IRegisterToolApiProps } from "../tool-tile";
@@ -24,11 +24,8 @@ interface IPaletteState {
 type PaletteKey = keyof IPaletteState;
 const kClosedPalettesState = { showStamps: false, showStroke: false, showFill: false };
 
-interface IProps extends IRegisterToolApiProps {
-  documentContent?: HTMLElement | null;
-  toolTile?: HTMLElement | null;
+interface IProps extends IFloatingToolbarProps, IRegisterToolApiProps {
   model: ToolTileModelType;
-  onIsEnabled: () => boolean;
 }
 export const ToolbarView: React.FC<IProps> = (
               { documentContent, model, onIsEnabled, ...others }: IProps) => {

--- a/src/components/tools/geometry-tool/geometry-content-wrapper.tsx
+++ b/src/components/tools/geometry-tool/geometry-content-wrapper.tsx
@@ -6,16 +6,14 @@ import { GeometryContentComponent, IGeometryContentProps } from "./geometry-cont
 interface IProps extends IGeometryContentProps{
   readOnly?: boolean;
 }
-export const GeometryContentWrapper: React.FC<IProps> = ({
-  readOnly, ...others
-}) => {
+export const GeometryContentWrapper: React.FC<IProps> = (props) => {
   return (
-    <div className={classNames("geometry-wrapper", { "read-only": readOnly })}>
+    <div className={classNames("geometry-wrapper", { "read-only": props.readOnly })}>
       <SizeMe monitorHeight={true}>
         {({ size }: SizeMeProps) => {
           return (
             <div className="geometry-size-me">
-              <GeometryContentComponent size={size} {...others} />
+              <GeometryContentComponent size={size} {...props} />
             </div>
           );
         }}

--- a/src/components/tools/geometry-tool/geometry-tool.tsx
+++ b/src/components/tools/geometry-tool/geometry-tool.tsx
@@ -15,7 +15,7 @@ import "./geometry-tool.sass";
 const GeometryToolComponent: React.FC<IGeometryProps> = ({
   model, readOnly, ...others
 }) => {
-  const { documentContent, toolTile, onRegisterToolApi, onUnregisterToolApi } = others;
+  const { documentContent, toolTile, scale, onRegisterToolApi, onUnregisterToolApi } = others;
   const modelRef = useCurrent(model);
   const domElement = useRef<HTMLDivElement>(null);
   const content = model.content as GeometryContentModelType;
@@ -63,7 +63,7 @@ const GeometryToolComponent: React.FC<IGeometryProps> = ({
           onMouseUpCapture={handlePointerUp}
           onKeyDown={e => hotKeys.current.dispatch(e)} >
 
-      <GeometryToolbar documentContent={documentContent} toolTile={toolTile}
+      <GeometryToolbar documentContent={documentContent} toolTile={toolTile} scale={scale}
         board={board} content={content} handlers={actionHandlers} {...toolbarProps} />
       <GeometryContentWrapper model={model} readOnly={readOnly} {...others}
         onSetBoard={setBoard} onSetActionHandlers={handleSetHandlers} onContentChange={forceUpdate}/>

--- a/src/components/tools/hooks/use-floating-toolbar-location.ts
+++ b/src/components/tools/hooks/use-floating-toolbar-location.ts
@@ -7,6 +7,7 @@ import { useForceUpdate } from "./use-force-update";
 export interface IFloatingToolbarProps extends IRegisterToolApiProps {
   documentContent?: HTMLElement | null;
   toolTile?: HTMLElement | null;
+  scale?: number;
   onIsEnabled: () => boolean;
 }
 

--- a/src/components/tools/image-tool.tsx
+++ b/src/components/tools/image-tool.tsx
@@ -131,7 +131,7 @@ export default class ImageToolComponent extends BaseComponent<IProps, IState> {
   }
 
   public render() {
-    const { documentContent, toolTile, readOnly } = this.props;
+    const { documentContent, toolTile, readOnly, scale } = this.props;
     const { isLoading, imageEntry } = this.state;
     const showEmptyImagePrompt = !this.getContent().hasValidImage;
 
@@ -157,6 +157,7 @@ export default class ImageToolComponent extends BaseComponent<IProps, IState> {
             onUnregisterToolApi={() => this.toolbarToolApi = undefined}
             documentContent={documentContent}
             toolTile={toolTile}
+            scale={scale}
             onIsEnabled={this.handleIsEnabled}
             onUploadImageFile={this.handleUploadImageFile}
           />

--- a/src/components/tools/table-tool/column-header-cell.tsx
+++ b/src/components/tools/table-tool/column-header-cell.tsx
@@ -11,14 +11,14 @@ interface IProps extends THeaderRendererProps {
 }
 export const ColumnHeaderCell: React.FC<IProps> = (props: IProps) => {
   const column = props.column as unknown as TColumn;
-  const { isEditing, isRemovable, showExpressions, expression, onRemoveColumn } = column.appData || {};
+  const { readOnly, isEditing, isRemovable, showExpressions, expression, onRemoveColumn } = column.appData || {};
   const hasExpression = showExpressions && !!expression;
   const classes = classNames("column-header-cell", { "show-expression": showExpressions });
   return (
     <div className={classes}>
       <div className="flex-container">
         <EditableHeaderCell {...props} />
-        {showExpressions && <ExpressionCell column={column} />}
+        {showExpressions && <ExpressionCell readOnly={readOnly} column={column} />}
       </div>
       {!isEditing && isRemovable &&
         <RemoveColumnButton colId={column.key} colName={column.name as string} onRemoveColumn={onRemoveColumn}/>}
@@ -51,13 +51,14 @@ const RemoveColumnButton: React.FC<IRemoveColumnButtonProps> = ({ colId, colName
 RemoveColumnButton.displayName = "RemoveColumnButton";
 
 interface IExpressionCellProps {
+  readOnly?: boolean;
   column: TColumn;
 }
-export const ExpressionCell: React.FC<IExpressionCellProps> = ({ column }) => {
+export const ExpressionCell: React.FC<IExpressionCellProps> = ({ readOnly, column }) => {
   const { expression, onShowExpressionsDialog } = column?.appData || {};
   const expressionStr = expression ? `= ${expression}` : "";
   const classes = classNames("expression-cell", { "has-expression": !!expression });
-  const handleClick = () => expression && onShowExpressionsDialog?.(column.key);
+  const handleClick = () => !readOnly && expression && onShowExpressionsDialog?.(column.key);
   return (
     <div className={classes} onClick={handleClick}>
       {expressionStr}

--- a/src/components/tools/table-tool/editable-table-title.tsx
+++ b/src/components/tools/table-tool/editable-table-title.tsx
@@ -56,7 +56,7 @@ export const EditableTableTitle: React.FC<IProps> = observer(({
         ? <HeaderCellInput style={style} value={editingTitle || ""}
             onKeyDown={handleKeyDown} onChange={setEditingTitle} onClose={handleClose} />
         : title}
-      {!isEditing && <LinkGeometryButton isEnabled={isLinkEnabled} onClick={onLinkGeometryClick} />}
+      {!isEditing && <LinkGeometryButton isEnabled={!readOnly && isLinkEnabled} onClick={onLinkGeometryClick} />}
     </div>
   );
 });

--- a/src/components/tools/table-tool/table-tool.tsx
+++ b/src/components/tools/table-tool/table-tool.tsx
@@ -24,7 +24,7 @@ import "./table-tool.scss";
 
 // observes row selection from shared selection store
 const TableToolComponent: React.FC<IToolTileProps> = observer(({
-  documentId, documentContent, toolTile, model, readOnly, height,
+  documentId, documentContent, toolTile, model, readOnly, height, scale,
   onRequestRowHeight, onRequestTilesOfType, onRequestUniqueTitle, onRegisterToolApi, onUnregisterToolApi
 }) => {
   const modelRef = useCurrent(model);
@@ -106,7 +106,7 @@ const TableToolComponent: React.FC<IToolTileProps> = observer(({
   return (
     <div className="table-tool">
       <TableToolbar documentContent={documentContent} toolTile={toolTile} {...toolbarProps}
-                    onSetExpression={showExpressionsDialog} />
+                    onSetExpression={showExpressionsDialog} scale={scale}/>
       <div className="table-grid-container" ref={containerRef} onClick={handleBackgroundClick}>
         <EditableTableTitle className="table-title" readOnly={readOnly}
           isLinkEnabled={isLinkEnabled} onLinkGeometryClick={showLinkGeometryDialog}

--- a/src/components/tools/table-tool/table-types.ts
+++ b/src/components/tools/table-tool/table-types.ts
@@ -24,6 +24,7 @@ export interface TRow extends Record<string, any> {
 }
 
 export interface TColumnAppData {
+  readOnly?: boolean;
   gridContext: IGridContext;
   editableName: boolean;
   isEditing: boolean;

--- a/src/components/tools/table-tool/use-column-extensions.ts
+++ b/src/components/tools/table-tool/use-column-extensions.ts
@@ -23,10 +23,11 @@ export const useColumnExtensions = ({
 
   columns.forEach((column, i) => {
     column.appData = {
+      readOnly,
       gridContext,
-      editableName: isDataColumn(column),
+      editableName: !readOnly && isDataColumn(column),
       isEditing: column.key === columnEditingName,
-      isRemovable: isDataColumn(column) && (column.key !== firstDataColumn?.key),
+      isRemovable: !readOnly && isDataColumn(column) && (column.key !== firstDataColumn?.key),
       showExpressions: metadata.hasExpressions,
       expression: getEditableExpression(
                     metadata.rawExpressions.get(column.key),

--- a/src/components/tools/text-tool.tsx
+++ b/src/components/tools/text-tool.tsx
@@ -232,9 +232,8 @@ export default class TextToolComponent extends BaseComponent<IToolTileProps, ISt
   }
 
   public render() {
-    const { documentContent, toolTile, model, readOnly } = this.props;
+    const { documentContent, toolTile, model, readOnly, scale } = this.props;
     const { value: editorValue, selectedButtons } = this.state;
-    const isFocused = !!editorValue?.selection.isFocused;
     const { unit: { placeholderText } } = this.stores;
     const editableClass = readOnly ? "read-only" : "editable";
     // Ideally this would just be 'text-tool-editor', but 'text-tool' has been
@@ -274,10 +273,11 @@ export default class TextToolComponent extends BaseComponent<IToolTileProps, ISt
         <TextToolbarComponent
           documentContent={documentContent}
           toolTile={toolTile}
+          scale={scale}
           selectedButtons={selectedButtons || []}
           onButtonClick={handleToolBarButtonClick}
           editor={this.editor}
-          enabled={isFocused}
+          onIsEnabled={this.handleIsEnabled}
           onRegisterToolApi={this.handleRegisterToolApi}
           onUnregisterToolApi={this.handleUnregisterToolApi}
         />
@@ -308,6 +308,11 @@ export default class TextToolComponent extends BaseComponent<IToolTileProps, ISt
 
   private handleUnregisterToolApi = () => {
     this.toolbarToolApi = undefined;
+  }
+
+  private handleIsEnabled = () => {
+    // text toolbar is based on editor focus rather than tile selection
+    return !!this.state.value?.selection.isFocused;
   }
 
   private handleChange = (change: SlateChange) => {

--- a/src/components/tools/text-toolbar.tsx
+++ b/src/components/tools/text-toolbar.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import { useFloatingToolbarLocation } from "./hooks/use-floating-toolbar-location";
+import { IFloatingToolbarProps, useFloatingToolbarLocation } from "./hooks/use-floating-toolbar-location";
 import { TextToolbarButton } from "./text-toolbar-button";
 import { IRegisterToolApiProps } from "./tool-tile";
 import { isMac } from "../../utilities/browser";
@@ -12,13 +12,10 @@ interface IButtonDef {
   toolTip: string;   // Text for the button's tool-tip.
 }
 
-interface IProps extends IRegisterToolApiProps {
-  documentContent?: HTMLElement | null;
-  toolTile?: HTMLElement | null;
+interface IProps extends IFloatingToolbarProps, IRegisterToolApiProps {
   selectedButtons: string[];
   onButtonClick: (buttonName: string, editor: any, event: React.MouseEvent) => void;
   editor: any;
-  enabled: boolean;
 }
 
 const kShortcutPrefix = isMac() ? "Cmd-" : "Ctrl-";
@@ -38,7 +35,8 @@ const handleMouseDown = (event: React.MouseEvent) => {
 };
 
 export const TextToolbarComponent: React.FC<IProps> = (props: IProps) => {
-  const { documentContent, enabled, editor, selectedButtons, onButtonClick, ...others } = props;
+  const { documentContent, editor, selectedButtons, onIsEnabled, onButtonClick, ...others } = props;
+  const enabled = onIsEnabled();
   const toolbarLocation = useFloatingToolbarLocation({
                             documentContent,
                             toolbarHeight: 29,

--- a/src/components/utilities/tile-utils.ts
+++ b/src/components/utilities/tile-utils.ts
@@ -1,6 +1,7 @@
 export interface IGetToolbarLocationBaseArgs {
   documentContent?: HTMLElement | null;
   toolTile?: HTMLElement | null;
+  scale?: number;
   toolbarHeight: number;
   minToolContent?: number;
   toolbarLeftOffset?: number;
@@ -13,8 +14,9 @@ interface IGetToolbarLocationArgs extends IGetToolbarLocationBaseArgs {
 }
 
 export function getToolbarLocation({
-    documentContent, toolTile, toolbarHeight, minToolContent, toolLeft, toolBottom, toolbarLeftOffset, toolbarTopOffset
-  }: IGetToolbarLocationArgs) {
+  documentContent, toolTile, scale,
+  toolbarHeight, minToolContent, toolLeft, toolBottom, toolbarLeftOffset, toolbarTopOffset
+}: IGetToolbarLocationArgs) {
   const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
   let minToolbarTop = minToolContent || 30;
   let maxToolbarTop = viewportHeight - toolbarHeight;
@@ -22,13 +24,14 @@ export function getToolbarLocation({
   let tileTopOffset = 0;
 
   if (documentContent && toolTile) {
+    const _scale = scale || 1;
     const docBounds = documentContent.getBoundingClientRect();
     const tileBounds = toolTile.getBoundingClientRect();
     const topOffset = tileBounds.top - docBounds.top;
     const leftOffset = tileBounds.left - docBounds.left;
     if ((topOffset != null) && (leftOffset != null)) {
-      tileTopOffset = topOffset;
-      tileLeftOffset = leftOffset;
+      tileTopOffset = topOffset / _scale;
+      tileLeftOffset = leftOffset / _scale;
     }
     minToolbarTop += topOffset;
     maxToolbarTop -= docBounds.top;

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -11,13 +11,12 @@ import { createToolTileModelFromContent, ToolTileModel, ToolTileModelType, ToolT
         } from "../tools/tool-tile";
 import { TileRowModel, TileRowModelType, TileRowSnapshotType, TileRowSnapshotOutType } from "../document/tile-row";
 import { cloneDeep, each } from "lodash";
-import { v4 as uuid } from "uuid";
 import { Logger, LogEventName } from "../../lib/logger";
 import { IDragTileItem } from "../../models/tools/tool-tile";
 import { DocumentsModelType } from "../stores/documents";
 import { getParentWithTypeName } from "../../utilities/mst-utils";
 import { DocumentTool, IDocumentAddTileOptions } from "./document";
-import { safeJsonParse } from "../../utilities/js-utils";
+import { safeJsonParse, uniqueId } from "../../utilities/js-utils";
 
 export interface INewTileOptions {
   rowHeight?: number;
@@ -75,7 +74,7 @@ export const DocumentContentModel = types
   }))
   .views(self => {
     // used for drag/drop self-drop detection, for instance
-    const contentId = uuid();
+    const contentId = uniqueId();
 
     function rowContainsTile(rowId: string, tileId: string) {
       const row = self.rowMap.get(rowId);
@@ -168,7 +167,7 @@ export const DocumentContentModel = types
         snapshot.tileMap = (tileMap => {
           const _tileMap: { [id: string]: ToolTileSnapshotOutType } = {};
           each(tileMap, (tile, id) => {
-            idMap[id] = tile.id = uuid();
+            idMap[id] = tile.id = uniqueId();
             _tileMap[tile.id] = tile;
           });
           return _tileMap;
@@ -182,7 +181,7 @@ export const DocumentContentModel = types
         snapshot.rowMap = (rowMap => {
           const _rowMap: { [id: string]: TileRowSnapshotOutType } = {};
           each(rowMap, (row, id) => {
-            idMap[id] = row.id = uuid();
+            idMap[id] = row.id = uniqueId();
             row.tiles = row.tiles.map(tileLayout => {
               tileLayout.tileId = idMap[tileLayout.tileId];
               return tileLayout;

--- a/src/models/tools/geometry/geometry-content.ts
+++ b/src/models/tools/geometry/geometry-content.ts
@@ -1162,9 +1162,9 @@ export const GeometryContentModel = types
       const pointIds: string[] = [];
       const positions: JXGUnsafeCoordPair[] = [];
       const caseIds = castArray(change.ids);
-      const propsArray = castArray(change.action === "create"
-                                    ? (change.props as ICreateRowsProperties)?.rows
-                                    : change.props);
+      const propsArray: IRowProperties[] = change.action === "create"
+                                            ? (change.props as ICreateRowsProperties)?.rows
+                                            : castArray(change.props as any);
       const xAttrId = dataSet.attributes.length > 0 ? dataSet.attributes[0].id : undefined;
       caseIds.forEach((caseId, caseIndex) => {
         const tableProps = (propsArray[caseIndex] || propsArray[0]) as IRowProperties;
@@ -1212,7 +1212,7 @@ export const GeometryContentModel = types
         case "update": {
           const ids = castArray(change.ids);
           const attrIdsWithExpr: string[] = [];
-          const changeProps = castArray(change.props) as IColumnProperties[];
+          const changeProps: IColumnProperties[] = castArray(change.props as any);
           ids.forEach((attrId, index) => {
             const props = changeProps[index] || changeProps[0];
             // update column name => update axis labels

--- a/src/models/tools/table/table-content.ts
+++ b/src/models/tools/table/table-content.ts
@@ -33,6 +33,24 @@ export function getTableContent(target: IAnyStateTreeNode, tileId: string): Tabl
   return content && content as TableContentModelType;
 }
 
+export function getAxisLabelsFromDataSet(dataSet: IDataSet): [string | undefined, string | undefined] {
+  // label for x axis
+  const xAttr = dataSet.attributes.length > 0 ? dataSet.attributes[0] : undefined;
+  const xLabel = xAttr?.name;
+
+  // label for y axis
+  let yLabel = undefined;
+  for (let yIndex = 1; yIndex < dataSet.attributes.length; ++yIndex) {
+    // concatenate column names for y axis label
+    const yAttr = dataSet.attributes[yIndex];
+    if (yAttr.name && (yAttr.name !== kLabelAttrName)) {
+      if (!yLabel) yLabel = yAttr.name;
+      else yLabel += `, ${yAttr.name}`;
+    }
+  }
+  return [xLabel, yLabel];
+}
+
 export interface ITransferCase {
   id: string;
   label?: string;
@@ -236,21 +254,10 @@ export const TableContentModel = types
     getClientLinks(linkId: string, dataSet: IDataSet): ITableLinkProperties {
       const labels: IRowLabel[] = [];
 
-      // add label for x axis
-      const xAttr = dataSet.attributes.length > 0 ? dataSet.attributes[0] : undefined;
-      xAttr && labels.push({ id: "xAxis", label: xAttr.name });
-
-      // add label for y axis
-      let yLabel = "";
-      for (let yIndex = 1; yIndex < dataSet.attributes.length; ++yIndex) {
-        // concatenate column names for y axis label
-        const yAttr = dataSet.attributes[yIndex];
-        if (yAttr.name) {
-          if (!yLabel) yLabel = yAttr.name;
-          else yLabel += `, ${yAttr.name}`;
-        }
-      }
-      yLabel && labels.push({ id: "yAxis", label: yLabel });
+      // add axis labels
+      const [xAxisLabel, yAxisLabel] = getAxisLabelsFromDataSet(dataSet);
+      xAxisLabel && labels.push({ id: "xAxis", label: xAxisLabel });
+      yAxisLabel && labels.push({ id: "yAxis", label: yAxisLabel });
 
       // add label for each case, indexed by case ID
       labels.push(...dataSet.cases.map((aCase, i) => ({ id: aCase.__id__, label: getRowLabel(i) })));


### PR DESCRIPTION
@mklewandowski The individual bug-fixes are each in their own commit, so you may want to review this commit-by-commit rather than reviewing all changes at once.

- Fix Clear button in expressions dialog [[#176602087]](https://www.pivotaltracker.com/story/show/176602087)
  - The clear button needed to update the to-be-returned expressions as well as the currently edited expression.
- Fix axis labels for table-linked geometry tiles [[#176615381]](https://www.pivotaltracker.com/story/show/176615381)
  - There were multiple paths for determining the axis labels which produced slightly different results. There is now a single `getAxisLabelsFromDataSet()` function in `TableContent` which is called from all other paths.
- Fix floating toolbar bugs with four-up view [[#176615793]](https://www.pivotaltracker.com/story/show/176615793) [[#176615891]](https://www.pivotaltracker.com/story/show/176615891)
  - This was reported as a bug in the table toolbar specifically, but all floating toolbars were affected. We weren't taking scale factor into account when determining the correct placement of the floating toolbars.
- Table respects readOnly flag (e.g. in left-hand navigation panel) [[#176617546]](https://www.pivotaltracker.com/story/show/176617546)
  - This was missing functionality that had never been implemented during the table rearchitecture.
- Geometry tool respects readOnly flag (e.g. in left-side navigation panel) [[#176617546]](https://www.pivotaltracker.com/story/show/176617546)
  - This had been working before the bug was introduced in a refactor which prevented the `readOnly` flag from being passed down. The fix was simply to make sure the flag gets passed to where it needs to go.
- Fix mapping of tile ids when copying documents with linked table/geometry tiles [[#176616940]](https://www.pivotaltracker.com/story/show/176616940)
  - Axis label synchronization relies on tracking linked tile IDs. When copying documents we must remap tile IDs, but we weren't handling the mapping correctly when handling some linking-related changes.
- Linking a table to a geometry tile requires synchronization in only the newly linked geometry tile [[#176616085]](https://www.pivotaltracker.com/story/show/176616085)
  - Most table changes should be synchronized to all linked clients, e.g. adding/removing rows/columns, changing column expressions, etc. We were extending this approach of updating all linked clients to the synchronization of a newly linked geometry tile, but in that case only the newly linked tile is affected. The result was that we were adding redundant points to previously linked geometry tiles, which were then left over when the link was broken.
