### PR TITLE
Support graph/geometry title [#174765909]

### DIFF
--- a/src/components/document/editable-document-content.tsx
+++ b/src/components/document/editable-document-content.tsx
@@ -19,11 +19,11 @@ interface IToolbarProps {
   toolbar?: ToolbarConfig;
   toolApiMap: IToolApiMap;
 }
-const DocumentToolbar: React.FC<IToolbarProps> = ({ document, toolbar, toolApiMap }) => {
+const DocumentToolbar: React.FC<IToolbarProps> = ({ toolbar, ...others }) => {
   const appConfig = useContext(AppConfigContext);
   const toolbarConfig = toolbar?.map(tool => ({ icon: appConfig.appIcons?.[tool.iconId], ...tool }));
   return toolbarConfig
-          ? <ToolbarComponent key="toolbar" document={document} config={toolbarConfig} toolApiMap={toolApiMap} />
+          ? <ToolbarComponent key="toolbar" config={toolbarConfig} {...others} />
           : null;
 };
 
@@ -32,9 +32,9 @@ interface IOneUpCanvasProps {
   readOnly: boolean;
   toolApiInterface: IToolApiInterface;
 }
-const OneUpCanvas: React.FC<IOneUpCanvasProps> = ({ document, readOnly, toolApiInterface}) => {
+const OneUpCanvas: React.FC<IOneUpCanvasProps> = props => {
   return (
-    <CanvasComponent context="1-up" document={document} readOnly={readOnly} toolApiInterface={toolApiInterface} />
+    <CanvasComponent context="1-up" {...props} />
   );
 };
 
@@ -42,11 +42,11 @@ interface IEditableFourUpCanvasProps {
   userId: string;
   toolApiInterface: IToolApiInterface;
 }
-const EditableFourUpCanvas: React.FC<IEditableFourUpCanvasProps> = ({ userId, toolApiInterface}) => {
+const EditableFourUpCanvas: React.FC<IEditableFourUpCanvasProps> = props => {
   const groups = useGroupsStore();
-  const group = groups.groupForUser(userId);
+  const group = groups.groupForUser(props.userId);
   return (
-    <FourUpComponent userId={userId} groupId={group?.id} toolApiInterface={toolApiInterface} />
+    <FourUpComponent groupId={group?.id} {...props} />
   );
 };
 

--- a/src/components/tools/geometry-tool/editable-geometry-title.tsx
+++ b/src/components/tools/geometry-tool/editable-geometry-title.tsx
@@ -20,8 +20,14 @@ export const EditableGeometryTitle: React.FC<IProps> = observer(({
   // getTitle() and observer() allow this component to re-render
   // when the title changes without re-rendering the entire Geometry
   const title = getTitle() || "Graph";
-  const width = Math.ceil(measureText(title)) + 30;
-  const left = contentSize.width ? (contentSize.width - width) / 2 - 11 : 400;
+  const kTitlePadding = 30;
+  const kCenteringCorrection = 11;  // so it's centered w.r.t. the document title
+  // There can be one render before we know our container size, which will then be
+  // immediately replaced by a subsequent render with a known container size.
+  // Place it roughly in the middle of the screen until we have a proper position.
+  const kContainerlessPosition = 450;
+  const width = Math.ceil(measureText(title)) + kTitlePadding;
+  const left = contentSize.width ? (contentSize.width - width) / 2 - kCenteringCorrection : kContainerlessPosition;
   const [isEditing, setIsEditing] = useState(false);
   const [editingTitle, setEditingTitle] = useState(title);
   const handleClick = () => {

--- a/src/components/tools/geometry-tool/editable-geometry-title.tsx
+++ b/src/components/tools/geometry-tool/editable-geometry-title.tsx
@@ -1,0 +1,66 @@
+import classNames from "classnames";
+import { observer } from "mobx-react";
+import React, { useState } from "react";
+import { SizeMeProps } from "react-sizeme";
+import { GeometryLabelInput } from "./geometry-label-input";
+
+import "./geometry-title.scss";
+
+interface IProps extends SizeMeProps {
+  className?: string;
+  readOnly?: boolean;
+  getTitle: () => string | undefined;
+  measureText: (text: string) => number;
+  onBeginEdit?: () => void;
+  onEndEdit?: (title?: string) => void;
+}
+export const EditableGeometryTitle: React.FC<IProps> = observer(({
+  className, readOnly, size: contentSize, getTitle, measureText, onBeginEdit, onEndEdit
+}) => {
+  // getTitle() and observer() allow this component to re-render
+  // when the title changes without re-rendering the entire Geometry
+  const title = getTitle() || "Graph";
+  const width = Math.ceil(measureText(title)) + 30;
+  const left = contentSize.width ? (contentSize.width - width) / 2 - 11 : 400;
+  const [isEditing, setIsEditing] = useState(false);
+  const [editingTitle, setEditingTitle] = useState(title);
+  const handleClick = () => {
+    if (!readOnly && !isEditing) {
+      onBeginEdit?.();
+      setEditingTitle(title);
+      setIsEditing(true);
+    }
+  };
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    const { key } = e;
+    switch (key) {
+      case "Escape":
+        handleClose(false);
+        break;
+      case "Enter":
+      case "Tab":
+        handleClose(true);
+        break;
+    }
+  };
+  const handleClose = (accept: boolean) => {
+    const trimTitle = editingTitle?.trim();
+    onEndEdit?.(accept && trimTitle ? trimTitle : undefined);
+    setIsEditing(false);
+  };
+  const isDefaultTitle = title && /Graph\s+(\d+)\s*$/.test(title);
+  const classes = classNames("geometry-title", className,
+                            { "geometry-title-editing": isEditing, "geometry-title-default": isDefaultTitle });
+  const containerStyle: React.CSSProperties = { left, width };
+  const kMinInputWidth = 200; // so there's room to expand very short titles
+  const inputWidth = width >= kMinInputWidth ? "100%" : kMinInputWidth;
+  const inputStyle: React.CSSProperties = { width: inputWidth };
+  return (
+    <div className={classes} style={containerStyle} onClick={handleClick}>
+      {isEditing
+        ? <GeometryLabelInput value={editingTitle} style={inputStyle}
+            onKeyDown={handleKeyDown} onChange={setEditingTitle} onBlur={() => handleClose(true)} />
+        : <div className="geometry-title-text">{title}</div>}
+    </div>
+  );
+});

--- a/src/components/tools/geometry-tool/geometry-content-wrapper.tsx
+++ b/src/components/tools/geometry-tool/geometry-content-wrapper.tsx
@@ -1,19 +1,21 @@
 import classNames from "classnames";
 import React from "react";
 import { SizeMe, SizeMeProps } from "react-sizeme";
+import { useMeasureText } from "../hooks/use-measure-text";
 import { GeometryContentComponent, IGeometryContentProps } from "./geometry-content";
 
 interface IProps extends IGeometryContentProps{
   readOnly?: boolean;
 }
 export const GeometryContentWrapper: React.FC<IProps> = (props) => {
+  const measureLabelText = useMeasureText("italic 14px Lato, sans-serif");
   return (
     <div className={classNames("geometry-wrapper", { "read-only": props.readOnly })}>
       <SizeMe monitorHeight={true}>
         {({ size }: SizeMeProps) => {
           return (
             <div className="geometry-size-me">
-              <GeometryContentComponent size={size} {...props} />
+              <GeometryContentComponent size={size} {...props} measureText={measureLabelText} />
             </div>
           );
         }}

--- a/src/components/tools/geometry-tool/geometry-label-input.tsx
+++ b/src/components/tools/geometry-tool/geometry-label-input.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+function autoFocusAndSelect(input: HTMLInputElement | null) {
+  input?.focus();
+  input?.select();
+}
+
+interface IProps {
+  style?: React.CSSProperties;
+  value: string;
+  onKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => void;
+  onChange: (value: string) => void;
+  onBlur: (value: string) => void;
+}
+export const GeometryLabelInput: React.FC<IProps> = ({ style, value, onKeyDown, onChange, onBlur }) => {
+  return (
+    <div className="clue-editor-container" style={style}>
+      <input
+        className="clue-editor-input focusable"
+        style={style}
+        ref={autoFocusAndSelect}
+        value={value}
+        onKeyDown={onKeyDown}
+        onChange={event => onChange(event.target.value)}
+        onBlur={event => onBlur(event.target.value)}
+      />
+    </div>
+  );
+};

--- a/src/components/tools/geometry-tool/geometry-title.scss
+++ b/src/components/tools/geometry-tool/geometry-title.scss
@@ -1,0 +1,24 @@
+@import "../../vars.sass";
+
+.geometry-title {
+  position: absolute;
+  top: 6px;
+  height: 26px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: $charcoal-dark-2;
+  background-color: white;
+  border: 1.5px solid $charcoal-light-1;
+  border-radius: 5px;
+  text-align: center;
+  z-index: 10;  // has to be higher than JSXGraph entities that should be below it
+
+  input {
+    text-align: center;
+  }
+
+  .geometry-title-text {
+    font-style: italic;
+  }
+}

--- a/src/components/tools/geometry-tool/use-tile-selection-pointer-events.ts
+++ b/src/components/tools/geometry-tool/use-tile-selection-pointer-events.ts
@@ -8,6 +8,12 @@ export const useTileSelectionPointerEvents = (
   const didLastMouseDownSelectTile = useRef(false);
 
   const handlePointerDown = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+
+    // if the clicked element is focusable, let it handle the event
+    const target = e.target as HTMLElement;
+    const classList = target.classList;
+    if (classList?.contains("focusable")) return;
+
     // clicked tile gets keyboard focus
     if (focusableElement.current) {
       // requires non-empty tabIndex

--- a/src/models/document/document.ts
+++ b/src/models/document/document.ts
@@ -12,6 +12,7 @@ import { IDocumentProperties } from "../../lib/db-types";
 import { getLocalTimeStamp } from "../../utilities/time";
 
 export interface IDocumentAddTileOptions {
+  title?: string;
   addSidecarNotes?: boolean;
   url?: string;
 }
@@ -113,8 +114,10 @@ export const DocumentModel = types
       if (!docDisplayIdPropertyName) return undefined;
       if (docDisplayIdPropertyName === "key") return self.key;
       return self.getProperty(docDisplayIdPropertyName);
+    },
+    getUniqueTitle(tileType: string, titleBase: string, getTileTitle: (tileId: string) => string | undefined) {
+      return self.content.getUniqueTitle(tileType, titleBase, getTileTitle);
     }
-
   }))
   .views(self => ({
     isMatchingSpec(type: DocumentType, properties: string[]) {

--- a/src/models/tools/geometry/jxg-changes.ts
+++ b/src/models/tools/geometry/jxg-changes.ts
@@ -1,8 +1,8 @@
 import { castArray } from "lodash";
 
 export type JXGOperation = "create" | "update" | "delete";
-export type JXGObjectType = "board" |"comment" |  "image" | "linkedPoint" | "movableLine" | "object" |
-                              "point" | "polygon" | "tableLink" | "vertexAngle";
+export type JXGObjectType = "board" | "comment" | "image" | "linkedPoint" | "metadata" | "movableLine" |
+                              "object" | "point" | "polygon" | "tableLink" | "vertexAngle";
 
 export type JXGCoordPair = [number, number];
 export type JXGUnsafeCoordPair = [number?, number?];
@@ -20,6 +20,7 @@ export interface JXGProperties {
   id?: string;
   labelOption?: ESegmentLabelOption;
   position?: JXGUnsafeCoordPair;
+  title?: string; // metadata property
   url?: string;
   xMin?: number;
   yMin?: number;

--- a/src/models/tools/geometry/jxg-dispatcher.ts
+++ b/src/models/tools/geometry/jxg-dispatcher.ts
@@ -62,9 +62,7 @@ export function applyChange(board: JXG.Board|string, change: JXGChange,
   const target = change.target.toLowerCase();
 
   // give clients a chance to intercede before the change is applied
-  if (context && context.onWillApplyChange) {
-    context.onWillApplyChange(board, change);
-  }
+  context?.onWillApplyChange?.(board, change);
 
   // special case for update/object, where we dispatch by object type
   if ((change.operation === "update") && (target === "object")) {
@@ -79,7 +77,7 @@ export function applyChange(board: JXG.Board|string, change: JXGChange,
   const result = dispatchChange(board, change, context);
 
   // give clients a chance to intercede after the change has been applied
-  if (context && context.onDidApplyChange) {
+  if (context?.onDidApplyChange) {
     if (isBoard(result)) _board = result as JXG.Board;
     else if (Array.isArray(result) && isBoard(result?.[0])) _board = result[0] as JXG.Board;
     context.onDidApplyChange(_board, change);

--- a/src/models/tools/geometry/jxg-table-link.ts
+++ b/src/models/tools/geometry/jxg-table-link.ts
@@ -1,9 +1,16 @@
 import { syncLinkedPoints } from "./jxg-board";
-import { JXGChangeAgent, JXGCoordPair, ILinkProperties } from "./jxg-changes";
+import { ILinkProperties, JXGChange, JXGChangeAgent, JXGCoordPair } from "./jxg-changes";
 import { createPoint, pointChangeAgent } from "./jxg-point";
 import { isPoint } from "./jxg-types";
 import { ITableLinkProperties } from "../table/table-content";
 import { splitLinkedPointId } from "../table/table-model-types";
+
+export function getTableIdFromLinkChange(change: JXGChange) {
+  return change.target.toLowerCase() === "tablelink"
+          // during development id was initially stored in parents
+          ? (change.targetID || change.parents?.[0]) as string
+          : undefined;
+}
 
 export interface ITableLinkColors {
   fill: string;
@@ -89,8 +96,7 @@ export const tableLinkChangeAgent: JXGChangeAgent = {
 
   delete: (board, change) => {
     if (board) {
-      // during development id was initially stored in parents
-      const tableId = change.targetID || (change.parents && change.parents[0]);
+      const tableId = getTableIdFromLinkChange(change);
       const pts = board.objectsList.filter(elt => {
                     return isPoint(elt) && tableId && (elt.getAttribute("linkedTableId") === tableId);
                   });

--- a/src/models/tools/table/table-content.ts
+++ b/src/models/tools/table/table-content.ts
@@ -18,9 +18,10 @@ export const kLabelAttrName = "__label__";
 
 export const kTableDefaultHeight = 160;
 
-export function defaultTableContent() {
+export function defaultTableContent(props?: { title?: string }) {
   return TableContentModel.create({
                             type: "Table",
+                            name: props?.title,
                             columns: [
                               { name: "x" },
                               { name: "y" }
@@ -732,6 +733,7 @@ export function mapTileIdsInTableSnapshot(snapshot: SnapshotOut<TableContentMode
 registerToolContentInfo({
   id: kTableToolID,
   tool: "table",
+  titleBase: "Table",
   modelClass: TableContentModel,
   metadataClass: TableMetadataModel,
   defaultHeight: kTableDefaultHeight,

--- a/src/models/tools/tool-content-info.ts
+++ b/src/models/tools/tool-content-info.ts
@@ -7,6 +7,7 @@ export type ToolTileModelContentSnapshotPostProcessor =
 export interface IToolContentInfo {
   id: string;
   tool: string;
+  titleBase?: string;
   modelClass: any;
   metadataClass?: any;
   addSidecarNotes?: boolean;


### PR DESCRIPTION
[[#174765909]](https://www.pivotaltracker.com/story/show/174765909)

<img width="733" alt="GraphTitle" src="https://user-images.githubusercontent.com/235234/106961683-ce0cdb80-66f2-11eb-9c2b-e874f0ff62a5.png">

Graphs (aka geometry tiles) now have user-editable titles that are rendered above the geometry content. Like tables, titles are initially auto-generated with numeric suffixes, i.e. "Graph 1", "Graph 2", etc.

New with this PR is that newly created geometry and table tiles are assigned their auto-generated title on creation. Previously, newly created tiles had no assigned title and were given a title at run time. Thus, if you created two tables, e.g. "Table 1" and "Table 2", and then deleted "Table 1", and then reloaded the page the table previously known as "Table 2" would appear as "Table 1" because it would receive a different auto-generated title on launch. Now that titles are assigned on creation, tiles should maintain their titles independent of what other tiles exist when the document is opened.