### PR TITLE
Miscellaneous bug-fixes

### DIFF
--- a/src/components/tools/geometry-tool/geometry-content.tsx
+++ b/src/components/tools/geometry-tool/geometry-content.tsx
@@ -1422,12 +1422,13 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
       if (!board) return;
       const id = point.id;
       const coords = copyCoords(point.coords);
-      const linkedTableId = point.getAttribute("linkedTableId");
+      const tableId = point.getAttribute("linkedTableId");
+      const columnId = point.getAttribute("linkedColId");
       const isPointDraggable = !this.props.readOnly && !point.getAttribute("fixed");
       if (isFreePoint(point) && this.isDoubleClick(this.lastPointDown, { evt, coords })) {
         if (board) {
           this.applyChange(() => {
-            const polygon = geometryContent.createPolygonFromFreePoints(board, linkedTableId) as JXG.Polygon;
+            const polygon = geometryContent.createPolygonFromFreePoints(board, tableId, columnId) as JXG.Polygon;
             if (polygon) {
               this.handleCreatePolygon(polygon);
               this.props.onContentChange();

--- a/src/components/tools/table-tool/editable-table-title.tsx
+++ b/src/components/tools/table-tool/editable-table-title.tsx
@@ -7,6 +7,7 @@ import { LinkGeometryButton } from "./link-geometry-button";
 interface IProps {
   className?: string;
   readOnly?: boolean;
+  linkIndex: number;
   isLinkEnabled?: boolean;
   titleCellWidth: number;
   getTitle: () => string | undefined;
@@ -15,7 +16,7 @@ interface IProps {
   onLinkGeometryClick?: () => void;
 }
 export const EditableTableTitle: React.FC<IProps> = observer(({
-  className, readOnly, isLinkEnabled, titleCellWidth, getTitle, onBeginEdit, onEndEdit, onLinkGeometryClick
+  className, readOnly, linkIndex, isLinkEnabled, titleCellWidth, getTitle, onBeginEdit, onEndEdit, onLinkGeometryClick
 }) => {
   // getTitle() and observer() allow this component to re-render
   // when the title changes without re-rendering the entire TableTool
@@ -56,7 +57,8 @@ export const EditableTableTitle: React.FC<IProps> = observer(({
         ? <HeaderCellInput style={style} value={editingTitle || ""}
             onKeyDown={handleKeyDown} onChange={setEditingTitle} onClose={handleClose} />
         : title}
-      {!isEditing && <LinkGeometryButton isEnabled={!readOnly && isLinkEnabled} onClick={onLinkGeometryClick} />}
+      {!isEditing && <LinkGeometryButton isEnabled={!readOnly && isLinkEnabled} linkIndex={linkIndex}
+                                          onClick={onLinkGeometryClick} />}
     </div>
   );
 });

--- a/src/components/tools/table-tool/link-geometry-button.tsx
+++ b/src/components/tools/table-tool/link-geometry-button.tsx
@@ -3,11 +3,12 @@ import React from "react";
 import LinkGraphIcon from "../../../clue/assets/icons/table/link-graph-icon.svg";
 
 interface IProps {
+  linkIndex: number;
   isEnabled?: boolean;
   onClick?: () => void;
 }
-export const LinkGeometryButton: React.FC<IProps> = ({ isEnabled, onClick }) => {
-  const classes = classNames("link-geometry-button", { disabled: !isEnabled });
+export const LinkGeometryButton: React.FC<IProps> = ({ isEnabled, linkIndex, onClick }) => {
+  const classes = classNames("link-geometry-button", `link-color-${linkIndex}`, { disabled: !isEnabled });
   const handleClick = (e: React.MouseEvent) => {
     isEnabled && onClick?.();
     e.stopPropagation();

--- a/src/components/tools/table-tool/table-tool.scss
+++ b/src/components/tools/table-tool/table-tool.scss
@@ -71,11 +71,11 @@ $controls-hover-background: #c0dfe7;
         }
 
         &:hover:not(.disabled) {
-          background-color: $workspace-teal-light-6;
+          background-color: $workspace-teal-light-4;
         }
 
         &:active:not(.disabled) {
-          background-color: $workspace-teal-light-4;
+          background-color: $workspace-teal-light-2;
         }
       }
     }

--- a/src/components/tools/table-tool/table-tool.tsx
+++ b/src/components/tools/table-tool/table-tool.tsx
@@ -89,7 +89,7 @@ const TableToolComponent: React.FC<IToolTileProps> = observer(({
     rowChanges, readOnly: !!readOnly, changeHandlers, measureText: measureHeaderText,
     selectedCell, inputRowId, ...rowLabelProps, onShowExpressionsDialog: handleShowExpressionsDialog });
 
-  const { isLinkEnabled, showLinkGeometryDialog } = useGeometryLinking({
+  const { isLinkEnabled, linkIndex, showLinkGeometryDialog } = useGeometryLinking({
     documentId, model, hasLinkableRows, onRequestTilesOfType, onLinkGeometryTile
   });
 
@@ -109,7 +109,7 @@ const TableToolComponent: React.FC<IToolTileProps> = observer(({
                     onSetExpression={showExpressionsDialog} scale={scale}/>
       <div className="table-grid-container" ref={containerRef} onClick={handleBackgroundClick}>
         <EditableTableTitle className="table-title" readOnly={readOnly}
-          isLinkEnabled={isLinkEnabled} onLinkGeometryClick={showLinkGeometryDialog}
+          isLinkEnabled={isLinkEnabled} linkIndex={linkIndex} onLinkGeometryClick={showLinkGeometryDialog}
           getTitle={getTitle} titleCellWidth={titleCellWidth}
           onBeginEdit={onBeginTitleEdit} onEndEdit={onEndTitleEdit} />
         <ReactDataGrid ref={gridRef} selectedRows={getSelectedRows()}

--- a/src/components/tools/table-tool/use-geometry-linking.ts
+++ b/src/components/tools/table-tool/use-geometry-linking.ts
@@ -1,7 +1,9 @@
 import { useEffect } from "react";
 import { useCurrent } from "../../../hooks/use-current";
 import { kGeometryToolID } from "../../../models/tools/geometry/geometry-content";
-import { addTableToDocumentMap, removeTableFromDocumentMap } from "../../../models/tools/table-links";
+import {
+  addTableToDocumentMap, getLinkedTableIndex, removeTableFromDocumentMap
+} from "../../../models/tools/table-links";
 import { TableContentModelType } from "../../../models/tools/table/table-content";
 import { ITileLinkMetadata } from "../../../models/tools/table/table-model-types";
 import { ToolTileModelType } from "../../../models/tools/tool-tile";
@@ -18,6 +20,7 @@ export const useGeometryLinking = ({
   documentId, model, hasLinkableRows, onRequestTilesOfType, onLinkGeometryTile
 }: IProps) => {
   const modelId = model.id;
+  const linkIndex = getLinkedTableIndex(modelId);
   const geometryTiles = useLinkableGeometryTiles({ model, onRequestTilesOfType });
   const isLinkEnabled = hasLinkableRows && (geometryTiles.length > 0);
 
@@ -28,7 +31,7 @@ export const useGeometryLinking = ({
     return () => removeTableFromDocumentMap(modelId);
   }, [documentId, modelId]);
 
-  return { isLinkEnabled, showLinkGeometryDialog };
+  return { isLinkEnabled, linkIndex, showLinkGeometryDialog };
 };
 
 interface IUseLinkableGeometryTilesProps {

--- a/src/components/tools/tool-tile.tsx
+++ b/src/components/tools/tool-tile.tsx
@@ -252,14 +252,11 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
     const { model, toolApiInterface } = this.props;
     const toolApi = toolApiInterface?.getToolApi(model.id);
     const clientTableLinks = toolApi?.getLinkedTables?.();
-    const tableLinkIndex = toolApi?.getLinkIndex?.();
     return clientTableLinks
             ? clientTableLinks.map((id, index) => {
                 return <LinkIndicatorComponent key={id} id={id} index={index} />;
               })
-            : (tableLinkIndex != null) && (tableLinkIndex >= 0)
-                ? <LinkIndicatorComponent id={model.id} />
-                : null;
+            : null; // tables don't use the original link indicator any more
   }
 
   private renderTileComments() {

--- a/src/components/tools/tool-tile.tsx
+++ b/src/components/tools/tool-tile.tsx
@@ -57,7 +57,7 @@ export const kDragTileId = "org.concord.clue.tile.id";
 export const kDragTileContent = "org.concord.clue.tile.content";
 export const kDragTileCreate = "org.concord.clue.tile.create";
 // allows source compatibility to be checked in dragOver
-export const dragTileSrcDocId = (id: string) => `org.concord.clue.src.${id}`;
+export const dragTileSrcDocId = (id: string) => `org.concord.clue.src.${id.toLowerCase()}`;
 export const dragTileType = (type: string) => `org.concord.clue.tile.type.${type}`;
 
 export function extractDragTileSrcDocId(dataTransfer: DataTransfer) {

--- a/src/models/tools/geometry/geometry-content.test.ts
+++ b/src/models/tools/geometry/geometry-content.test.ts
@@ -4,11 +4,18 @@ import { JXGChange } from "./jxg-changes";
 import { isPointInPolygon, getPointsForVertexAngle } from "./jxg-polygon";
 import { canSupportVertexAngle, getVertexAngle, updateVertexAnglesFromObjects } from "./jxg-vertex-angle";
 import { isBoard, isFreePoint, isPoint, isPolygon } from "./jxg-types";
-import { isUuid } from "../../../utilities/test-utils";
 import { clone } from "lodash";
 import { destroy } from "mobx-state-tree";
 
 import placeholderImage from "../../../assets/image_placeholder.png";
+
+// mock uniqueId so we can recognize auto-generated IDs
+const { uniqueId, castArrayCopy, safeJsonParse } = jest.requireActual("../../../utilities/js-utils");
+jest.mock("../../../utilities/js-utils", () => ({
+  uniqueId: () => `testid-${uniqueId()}`,
+  castArrayCopy: (itemOrArray: any) => castArrayCopy(itemOrArray),
+  safeJsonParse: (json: string) => safeJsonParse(json)
+}));
 
 describe("GeometryContent", () => {
 
@@ -141,7 +148,7 @@ describe("GeometryContent", () => {
     content.removeObjects(board, p1Id);
     expect(board.objects[p1Id]).toBeUndefined();
     const p3: JXG.Point = content.addPoint(board, [2, 2]) as JXG.Point;
-    expect(isUuid(p3.id)).toBe(true);
+    expect(p3.id.startsWith("testid-")).toBe(true);
     // requests to remove points with invalid IDs are ignored
     content.removeObjects(board, ["foo"]);
     content.applyChange(board, { operation: "delete", target: "point" });
@@ -158,7 +165,7 @@ describe("GeometryContent", () => {
     let polygon: JXG.Polygon | undefined = content.createPolygonFromFreePoints(board) as JXG.Polygon;
     expect(isPolygon(polygon)).toBe(true);
     const polygonId = polygon.id;
-    expect(isUuid(polygonId)).toBe(true);
+    expect(polygonId.startsWith("testid-")).toBe(true);
 
     const ptInPolyCoords = new JXG.Coords(JXG.COORDS_BY_USER, [3, 2], board);
     const [, ptInScrX, ptInScrY] = ptInPolyCoords.scrCoords;

--- a/src/models/tools/geometry/geometry-content.ts
+++ b/src/models/tools/geometry/geometry-content.ts
@@ -24,7 +24,6 @@ import {
 } from "./jxg-types";
 import { IDataSet } from "../../data/data-set";
 import { assign, castArray, each, keys, omit, size as _size } from "lodash";
-import { v4 as uuid } from "uuid";
 import { safeJsonParse, uniqueId } from "../../../utilities/js-utils";
 import { getTileContentById } from "../../../utilities/mst-utils";
 import { Logger, LogEventName } from "../../../lib/logger";
@@ -588,7 +587,7 @@ export const GeometryContentModel = types
         operation: "create",
         target: "image",
         parents: [url, coords, size],
-        properties: assign({ id: uuid() }, properties)
+        properties: assign({ id: uniqueId() }, properties)
       };
       const image = _applyChange(board, change);
       return image ? image as JXG.Image : undefined;
@@ -601,7 +600,7 @@ export const GeometryContentModel = types
         operation: "create",
         target: "point",
         parents,
-        properties: assign({ id: uuid() }, properties)
+        properties: assign({ id: uniqueId() }, properties)
       };
       const point = _applyChange(board, change);
       return point ? point as JXG.Point : undefined;
@@ -616,7 +615,7 @@ export const GeometryContentModel = types
         operation: "create",
         target: links ? "linkedPoint" : "point",
         parents,
-        properties: parents.map((p, i) => ({ id: uuid(), ...(props && props[i] || props[0]) })),
+        properties: parents.map((p, i) => ({ id: uniqueId(), ...(props && props[i] || props[0]) })),
         links
       };
       const points = _applyChange(board, change);
@@ -628,7 +627,7 @@ export const GeometryContentModel = types
         operation: "create",
         target: "movableLine",
         parents,
-        properties: {id: uuid(), ...properties}
+        properties: {id: uniqueId(), ...properties}
       };
       const elems = _applyChange(board, change);
       return elems ? elems as JXG.GeometryElement[] : undefined;
@@ -638,7 +637,7 @@ export const GeometryContentModel = types
       const change: JXGChange = {
         operation: "create",
         target: "comment",
-        properties: {id: uuid(), anchor: anchorId }
+        properties: {id: uniqueId(), anchor: anchorId }
       };
       const elems = _applyChange(board, change);
       return elems ? elems as JXG.GeometryElement[] : undefined;
@@ -678,17 +677,19 @@ export const GeometryContentModel = types
     }
 
     function createPolygonFromFreePoints(
-              board: JXG.Board, linkedTableId?: string, properties?: JXGProperties): JXG.Polygon | undefined {
+              board: JXG.Board, linkedTableId?: string, linkedColumnId?: string, properties?: JXGProperties
+            ): JXG.Polygon | undefined {
       const freePtIds = board.objectsList
                           .filter(elt => isFreePoint(elt) &&
-                                          (linkedTableId === elt?.getAttribute("linkedTableId")))
+                                          (linkedTableId === elt?.getAttribute("linkedTableId")) &&
+                                          (linkedColumnId === elt?.getAttribute("linkedColId")))
                           .map(pt => pt.id);
       if (freePtIds && freePtIds.length > 1) {
         const change: JXGChange = {
                 operation: "create",
                 target: "polygon",
                 parents: freePtIds,
-                properties: assign({ id: uuid() }, properties)
+                properties: assign({ id: uniqueId() }, properties)
               };
         const polygon = _applyChange(board, change);
         return polygon ? polygon as any as JXG.Polygon : undefined;
@@ -702,7 +703,7 @@ export const GeometryContentModel = types
               operation: "create",
               target: "vertexAngle",
               parents,
-              properties: assign({ id: uuid(), radius: 1 }, properties)
+              properties: assign({ id: uniqueId(), radius: 1 }, properties)
             };
       const angle = _applyChange(board, change);
       return angle ? angle as any as JXG.Angle : undefined;
@@ -950,7 +951,7 @@ export const GeometryContentModel = types
       // map old ids to new ones
       const newIds: { [oldId: string]: string } = {};
       selectedIds.forEach(id => {
-        newIds[id] = uuid();
+        newIds[id] = uniqueId();
       });
 
       // create change objects for each object to be copied
@@ -1417,7 +1418,7 @@ function preprocessImportFormat(snapshot: any) {
   addBoard(boardSpecs);
 
   function addComment(props: Record<string, unknown>) {
-    const id = uuid();
+    const id = uniqueId();
     changes.push({ operation: "create", target: "comment", properties: {id, ...props }});
     return id;
   }

--- a/src/models/tools/table-links.scss
+++ b/src/models/tools/table-links.scss
@@ -13,6 +13,48 @@ $link-color-4-dark: $terra-dark-5;
 $link-color-5-light: $rust-light-1;
 $link-color-5-dark: $rust-dark-5;
 
+.link-color-0 {
+  background-color: $link-color-0-light !important;
+  &:active:not(.disabled) {
+    background-color: $link-color-0-dark !important;
+  }
+}
+
+.link-color-1 {
+  background-color: $link-color-1-light !important;
+  &:active:not(.disabled) {
+    background-color: $link-color-1-dark !important;
+  }
+}
+
+.link-color-2 {
+  background-color: $link-color-2-light !important;
+  &:active:not(.disabled) {
+    background-color: $link-color-2-dark !important;
+  }
+}
+
+.link-color-3 {
+  background-color: $link-color-3-light !important;
+  &:active:not(.disabled) {
+    background-color: $link-color-3-dark !important;
+  }
+}
+
+.link-color-4 {
+  background-color: $link-color-4-light !important;
+  &:active:not(.disabled) {
+    background-color: $link-color-4-dark !important;
+  }
+}
+
+.link-color-5 {
+  background-color: $link-color-5-light !important;
+  &:active:not(.disabled) {
+    background-color: $link-color-5-dark !important;
+  }
+}
+
 :export {
   linkColor0Light: $link-color-0-light;
   linkColor0Dark: $link-color-0-dark;


### PR DESCRIPTION
- Fix drag bug which prevented row-resizing and linking tables to geometry tiles via drag/drop
- Fix polygon creation so that linked points can only be connected within a column
- Replace old-style link indicator icon with background-coloration of the new link button in tables.
  - We don't have a complete design yet, so this is engineer-design that's just intended to get us through next week's classroom use.