### PR TITLE
Use type guards to simplify code and reduce type assertions; add stricter linting option

### DIFF
--- a/.eslintrc.types.js
+++ b/.eslintrc.types.js
@@ -1,0 +1,29 @@
+/* eslint-env node */
+// build/production configuration extends default/development configuration
+module.exports = {
+    parserOptions: {
+      tsconfigRootDir: __dirname,
+      project: ['./tsconfig.json']
+    },
+    extends: [
+      "./.eslintrc.js",
+      "plugin:@typescript-eslint/recommended-requiring-type-checking"
+    ],
+    rules: {
+      "@typescript-eslint/no-floating-promises": "off",         //  67 as of 2021-02-08
+      "@typescript-eslint/no-misused-promises": "off",          //  11 as of 2021-02-08
+      "@typescript-eslint/no-unsafe-assignment": "off",         // 450 as of 2021-02-08
+      "@typescript-eslint/no-unsafe-call": "off",               //  72 as of 2021-02-08
+      "@typescript-eslint/no-unsafe-member-access": "off",      // 388 as of 2021-02-08
+      "@typescript-eslint/no-unsafe-return": "off",             //  80 as of 2021-02-08
+      "@typescript-eslint/restrict-template-expressions": "off" //  31 as of 2021-02-08
+    },
+    overrides: [
+      { // some rules can be relaxed in tests
+        files: ["**/*.test.*"],
+        rules: {
+          "@typescript-eslint/require-await": "off"
+        }
+      }
+    ]
+};

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "lint": "eslint \"./src/**/*.{js,json,jsx,ts,tsx}\" \"./cypress/**/*.{js,json,jsx,ts,tsx}\"",
     "lint:build": "eslint -c \".eslintrc.build.js\" \"./src/**/*.{js,json,jsx,ts,tsx}\"",
     "lint:fix": "eslint --fix \"./src/**/*.{js,json,jsx,ts,tsx}\" \"./cypress/**/*.{js,json,jsx,ts,tsx}\"",
+    "lint:types": "eslint -c \".eslintrc.types.js\" \"./src/**/*.{js,jsx,ts,tsx}\"",
     "lint:unused": "tsc --noUnusedLocals --project .",
     "migrate": "node ./migrations/migrate",
     "migrate:debug": "node --inspect-brk ./migrations/migrate",

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -49,7 +49,7 @@ function resolveAppMode(
   const { appMode, db, ui} = stores;
   if (appMode === "authed")  {
     if (rawFirebaseJWT) {
-      db.connect({appMode, stores, rawFirebaseJWT}).catch(ui.setError);
+      db.connect({appMode, stores, rawFirebaseJWT}).catch(error => ui.setError(error));
     }
     else {
       ui.setError("No firebase token available to connect to db!");
@@ -75,7 +75,7 @@ function resolveAppMode(
           }
         }
       })
-      .catch(ui.setError);
+      .catch(error => ui.setError(error));
   }
 }
 
@@ -210,7 +210,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
     );
   }
 
-  private handlePortalLoginRedirect() {
+  private handlePortalLoginRedirect = () => {
     window.location.href = urlParams.domain || "https://learn.concord.org";
   }
 }

--- a/src/components/four-up.test.tsx
+++ b/src/components/four-up.test.tsx
@@ -49,7 +49,7 @@ describe("Four Up Component", () => {
     });
 
     const stores = createStores({ groups, documents });
-    const comp = mount(<FourUpComponent userId={document.uid} groupId={document.groupId!} stores={stores}/>);
+    const comp = mount(<FourUpComponent userId={document.uid} groupId={document.groupId} stores={stores}/>);
     expect(comp.find(CanvasComponent)).toHaveLength(4);
     expect(comp.find(".member")).toHaveLength(1);
   });

--- a/src/components/navigation/problem-tab-content.tsx
+++ b/src/components/navigation/problem-tab-content.tsx
@@ -18,7 +18,8 @@ interface IProps {
 
 export const ProblemTabContent: React.FC<IProps> = observer(({ context, sections, showSolutionsSwitch}: IProps) => {
   const { isTeacher } = useUserStore();
-  const { showTeacherContent, toggleShowTeacherContent } = useUIStore();
+  const ui = useUIStore();
+  const { showTeacherContent } = ui;
 
   const handleTabClick = (title: string, type: string) => {
     Logger.log(LogEventName.SHOW_TAB_SECTION, {
@@ -28,7 +29,7 @@ export const ProblemTabContent: React.FC<IProps> = observer(({ context, sections
   };
 
   const handleToggleSolutions = () => {
-    toggleShowTeacherContent(!showTeacherContent);
+    ui.toggleShowTeacherContent(!showTeacherContent);
     Logger.log(showTeacherContent ? LogEventName.HIDE_SOLUTIONS : LogEventName.SHOW_SOLUTIONS);
   };
 

--- a/src/components/tools/drawing-tool/drawing-layer.tsx
+++ b/src/components/tools/drawing-tool/drawing-layer.tsx
@@ -850,7 +850,7 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
       if (moved) {
         if (objectsToInteract.length > 0) {
           const moves: DrawingToolMove = objectsToInteract.map((object) => ({
-            id: object!.model.id || "",
+            id: object.model.id || "",
             destination: {x: object.model.x, y: object.model.y}
           }));
           this.sendChange({action: "move", data: moves});

--- a/src/components/tools/geometry-tool/geometry-toolbar.tsx
+++ b/src/components/tools/geometry-tool/geometry-toolbar.tsx
@@ -38,7 +38,7 @@ export const GeometryToolbar: React.FC<IProps> = observer(({
                   });
   const selectedObjects = board && content.selectedObjects(board);
   const selectedPoints = selectedObjects?.filter(isPoint);
-  const selectedPoint = selectedPoints?.length === 1 ? selectedPoints[0] as JXG.Point : undefined;
+  const selectedPoint = selectedPoints?.length === 1 ? selectedPoints[0] : undefined;
   const disableVertexAngle = !(selectedPoint && canSupportVertexAngle(selectedPoint));
   const hasVertexAngle = !!selectedPoint && !!getVertexAngle(selectedPoint);
   const disableDelete = board && !content.getDeletableSelectedIds(board).length;

--- a/src/components/tools/geometry-tool/movable-line-dialog.tsx
+++ b/src/components/tools/geometry-tool/movable-line-dialog.tsx
@@ -18,8 +18,8 @@ interface IState {
 export default
 class MovableLineDialog extends React.Component<IProps, IState> {
   public state = {
-            slope: "" + round(this.props.line.getSlope(), 1) || "",
-            intercept: "" + round(this.props.line.getRise(), 1) || "",
+            slope: `${round(this.props.line.getSlope(), 1)}`,
+            intercept: `${round(this.props.line.getRise(), 1)}`,
           };
 
   public render() {

--- a/src/components/tools/geometry-tool/rotate-polygon-icon.tsx
+++ b/src/components/tools/geometry-tool/rotate-polygon-icon.tsx
@@ -29,7 +29,7 @@ export class RotatePolygonIcon extends React.Component<IProps, IState> {
   public state: IState = {};
 
   private polygonCenter: JXG.Coords;
-  private initialIconAnchor: JXG.Coords;
+  private initialIconAnchor?: JXG.Coords;
   private initialVertexCoords: { [id: string]: JXG.Coords } = {};
   private initialDragAngle: number;
   private lastDragUpdate: number;
@@ -109,7 +109,7 @@ export class RotatePolygonIcon extends React.Component<IProps, IState> {
     this.polygonCenter = new JXG.Coords(JXG.COORDS_BY_USER, centerCoords, board);
     this.initialIconAnchor = this.state.iconAnchor
                               ? copyCoords(this.state.iconAnchor)
-                              : this.getDefaultIconCoords() as JXG.Coords;
+                              : this.getDefaultIconCoords();
     polygon.vertices.forEach(vertex => {
       this.initialVertexCoords[vertex.id] = copyCoords(vertex.coords);
     });
@@ -132,7 +132,7 @@ export class RotatePolygonIcon extends React.Component<IProps, IState> {
 
     const dragAngle = this.computeAngle(this.polygonCenter, e);
     const deltaAngle = dragAngle - this.initialDragAngle;
-    const iconAnchor = rotateCoords(this.initialIconAnchor, this.polygonCenter, deltaAngle);
+    const iconAnchor = this.initialIconAnchor && rotateCoords(this.initialIconAnchor, this.polygonCenter, deltaAngle);
     this.setState({ iconAnchor });
 
     this.rotateVertices(polygon, deltaAngle, false);

--- a/src/components/tools/image-tool.tsx
+++ b/src/components/tools/image-tool.tsx
@@ -46,7 +46,7 @@ export default class ImageToolComponent extends BaseComponent<IProps, IState> {
   private resizeObserver: ResizeObserver;
   private imageElt: HTMLDivElement | null;
   private disposers: IReactionDisposer[];
-  private debouncedUpdateImage = debounce(async (url: string) => {
+  private debouncedUpdateImage = debounce((url: string) => {
     const { documentContext } = this.state;
     const imageContext: IImageContext | undefined = documentContext
                                                       ? { type: documentContext?.type, key: documentContext?.key }
@@ -137,14 +137,14 @@ export default class ImageToolComponent extends BaseComponent<IProps, IState> {
     const showEmptyImagePrompt = !this.getContent().hasValidImage;
 
     // Include states for selected and editing separately to clean up UI a little
-    const imageToUseForDisplay = imageEntry?.displayUrl || (isLoading ? "" : placeholderImage);
+    const imageToUseForDisplay = imageEntry?.displayUrl || (isLoading ? "" : placeholderImage as string);
     // Set image display properties for the div, since this won't resize automatically when the image changes
     const imageDisplayStyle: React.CSSProperties = {
       backgroundImage: "url(" + imageToUseForDisplay + ")"
     };
     if (!imageEntry) {
-      imageDisplayStyle.width = defaultImagePlaceholderSize.width + "px";
-      imageDisplayStyle.height = defaultImagePlaceholderSize.height + "px";
+      imageDisplayStyle.width = `${defaultImagePlaceholderSize.width}px`;
+      imageDisplayStyle.height = `${defaultImagePlaceholderSize.height}px`;
     }
     return (
       <>

--- a/src/components/tools/table-tool/column-header-cell.tsx
+++ b/src/components/tools/table-tool/column-header-cell.tsx
@@ -34,7 +34,7 @@ interface IRemoveColumnButtonProps {
 }
 const RemoveColumnButton: React.FC<IRemoveColumnButtonProps> = ({ colId, colName, onRemoveColumn }) => {
   const AlertContent = () => {
-    return <p>Remove column <b>{colName as string}</b> and its contents from the table?</p>;
+    return <p>Remove column <b>{colName}</b> and its contents from the table?</p>;
   };
   const [showAlert] = useCautionAlert({
     title: "Remove Column",

--- a/src/components/tools/table-tool/use-grid-context.ts
+++ b/src/components/tools/table-tool/use-grid-context.ts
@@ -27,7 +27,7 @@ export const useGridContext = ({ modelId, showRowLabels, triggerColumnChange }: 
   const sharedSelection = useSharedSelectionStore();
   const getSelectedRows = useCallback(() => {
     // this is suitable for passing into ReactDataGrid
-    return new Set<React.Key>(Array.from(sharedSelection.getSelected(modelId)) as string[]);
+    return new Set<React.Key>(Array.from(sharedSelection.getSelected(modelId)));
   }, [modelId, sharedSelection]);
 
   const clearRowSelection = useCallback(() => sharedSelection.clear(modelId), [modelId, sharedSelection]);

--- a/src/lib/db-listeners/db-supports-listener.ts
+++ b/src/lib/db-listeners/db-supports-listener.ts
@@ -3,7 +3,6 @@ import { SupportTarget, TeacherSupportModel, TeacherSupportModelType, ClassAudie
         AudienceModelType, GroupAudienceModel, UserAudienceModel, addSupportDocumentsToStore
       } from "../../models/stores/supports";
 import { DBSupport } from "../db-types";
-import { SectionType } from "../../models/curriculum/section";
 import { ESupportType, SupportModel } from "../../models/curriculum/support";
 import { BaseListener } from "./base-listener";
 import { isAlive } from "mobx-state-tree";
@@ -123,7 +122,7 @@ export class DBSupportsListener extends BaseListener {
                              audience: AudienceModelType) {
     if (!dbSupport || !dbSupport.content) return;
     const { type, ...others } = dbSupport;
-    const supportContentType: ESupportType = (type as ESupportType) || ESupportType.text;
+    const supportContentType: ESupportType = type || ESupportType.text;
     const supportModel = SupportModel.create({ type: supportContentType, ...others });
     if (!supportModel) return;
     return TeacherSupportModel.create({
@@ -131,7 +130,7 @@ export class DBSupportsListener extends BaseListener {
       key: dbSupport.self.key,
       support: supportModel,
       type: !sectionTarget || sectionTarget === "all" ? SupportTarget.problem : SupportTarget.section,
-      sectionId: !sectionTarget || sectionTarget === "all" ? undefined : sectionTarget as SectionType,
+      sectionId: !sectionTarget || sectionTarget === "all" ? undefined : sectionTarget,
       audience,
       authoredTime: dbSupport.timestamp,
       originDoc: dbSupport.type === ESupportType.publication ? dbSupport.originDoc : undefined,

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -73,8 +73,8 @@ describe("db", () => {
       return;
     }
 
-    expect(docContent.tileMap!.size).toBe(1);
-    docContent.tileMap!.forEach((tile: ToolTileModelType) => {
+    expect(docContent.tileMap.size).toBe(1);
+    docContent.tileMap.forEach((tile: ToolTileModelType) => {
       const tileContent = tile.content as TextContentModelType;
       expect(tileContent.type).toBe("Text");
       expect(tileContent.format).toBeUndefined();

--- a/src/models/data/data-set.test.ts
+++ b/src/models/data/data-set.test.ts
@@ -65,7 +65,7 @@ test("DataSet basic functionality", () => {
   expect(dataset.attributes.length).toBe(2);
 
   // move first attribute to the end
-  dataset.moveAttribute(strAttrID as string);
+  dataset.moveAttribute(strAttrID);
   expect(dataset.attributes[0].name).toBe("num");
   expect(dataset.attributes[1].name).toBe("str");
   // move second attribute before the first

--- a/src/models/stores/supports.ts
+++ b/src/models/stores/supports.ts
@@ -322,7 +322,7 @@ function getCurricularSupportCaption(support: CurricularSupportModelType, index:
   const investigationPart = investigation ? `${investigation.ordinal}` : "*";
   const problemPart = problem ? `${problem.ordinal}` : "*";
   const { sectionId } = support;
-  const sectionPart = sectionId ? " " + getSectionTitle(sectionId as SectionType) : "";
+  const sectionPart = sectionId ? " " + getSectionTitle(sectionId) : "";
   return `${investigationPart}.${problemPart}${sectionPart} Support ${index}`;
 }
 
@@ -356,10 +356,10 @@ export function addSupportDocumentsToStore(params: ICreateFromUnitParams) {
     }
     const supportCaption = getSupportCaption(support, index, investigation, problem);
     const supportKey = support.supportType === SupportType.teacher
-                        ? (support as TeacherSupportModelType).key || supportCaption
+                        ? support.key || supportCaption
                         : supportCaption;
     const originDoc = support.supportType === SupportType.teacher
-                        ? (support as TeacherSupportModelType).originDoc
+                        ? support.originDoc
                         : supportKey; // unique origin for curricular supports
     let properties: IDocumentProperties;
     if (support.supportType === SupportType.curricular) {

--- a/src/models/tools/geometry/geometry-content.ts
+++ b/src/models/tools/geometry/geometry-content.ts
@@ -15,12 +15,12 @@ import { getAxisAnnotations, getBaseAxisLabels, getObjectById, guessUserDesiredB
 import { ESegmentLabelOption, forEachNormalizedChange, ILinkProperties, JXGChange, JXGCoordPair,
           JXGProperties, JXGParentType, JXGUnsafeCoordPair, JXGStringPair } from "./jxg-changes";
 import { applyChange, applyChanges, IDispatcherChangeContext } from "./jxg-dispatcher";
-import { isMovableLine } from "./jxg-movable-line";
 import {  kPointDefaults, kSnapUnit } from "./jxg-point";
 import { prepareToDeleteObjects } from "./jxg-polygon";
 import { getTableIdFromLinkChange } from "./jxg-table-link";
 import {
-  isBoard, isComment, isFreePoint, isLinkedPoint, isPoint, isPolygon, isVertexAngle, isVisibleEdge
+  isAxisArray, isBoard, isComment, isFreePoint, isImage, isLinkedPoint, isMovableLine, isPoint,
+  isPointArray, isPolygon, isVertexAngle, isVisibleEdge
 } from "./jxg-types";
 import { IDataSet } from "../../data/data-set";
 import { assign, castArray, each, keys, omit, size as _size } from "lodash";
@@ -463,11 +463,11 @@ export const GeometryContentModel = types
           const changeElems = castArray(changeResult);
           changeElems.forEach(changeElem => {
             if (isBoard(changeElem)) {
-              board = changeElem as JXG.Board;
+              board = changeElem;
               board.suspendUpdate();
             }
             else if (onCreate) {
-              onCreate(changeElem as JXG.GeometryElement);
+              onCreate(changeElem);
             }
           });
         });
@@ -525,7 +525,7 @@ export const GeometryContentModel = types
                       } }
       };
       const axes = _applyChange(undefined, change);
-      return axes ? axes as any as JXG.Line[] : undefined;
+      return isAxisArray(axes) ? axes : undefined;
     }
 
     function updateScale(board: JXG.Board, scale: number) {
@@ -590,7 +590,7 @@ export const GeometryContentModel = types
         properties: assign({ id: uniqueId() }, properties)
       };
       const image = _applyChange(board, change);
-      return image ? image as JXG.Image : undefined;
+      return isImage(image) ? image : undefined;
     }
 
     function addPoint(board: JXG.Board | undefined,
@@ -603,7 +603,7 @@ export const GeometryContentModel = types
         properties: assign({ id: uniqueId() }, properties)
       };
       const point = _applyChange(board, change);
-      return point ? point as JXG.Point : undefined;
+      return isPoint(point) ? point : undefined;
     }
 
     function addPoints(board: JXG.Board | undefined,
@@ -619,7 +619,7 @@ export const GeometryContentModel = types
         links
       };
       const points = _applyChange(board, change);
-      return points ? points as JXG.Point[] : [];
+      return isPointArray(points) ? points : [];
     }
 
     function addMovableLine(board: JXG.Board, parents: any, properties?: JXGProperties) {
@@ -681,8 +681,8 @@ export const GeometryContentModel = types
             ): JXG.Polygon | undefined {
       const freePtIds = board.objectsList
                           .filter(elt => isFreePoint(elt) &&
-                                          (linkedTableId === elt?.getAttribute("linkedTableId")) &&
-                                          (linkedColumnId === elt?.getAttribute("linkedColId")))
+                                          (linkedTableId === elt.getAttribute("linkedTableId")) &&
+                                          (linkedColumnId === elt.getAttribute("linkedColId")))
                           .map(pt => pt.id);
       if (freePtIds && freePtIds.length > 1) {
         const change: JXGChange = {
@@ -692,7 +692,7 @@ export const GeometryContentModel = types
                 properties: assign({ id: uniqueId() }, properties)
               };
         const polygon = _applyChange(board, change);
-        return polygon ? polygon as any as JXG.Polygon : undefined;
+        return isPolygon(polygon) ? polygon : undefined;
       }
     }
 
@@ -706,7 +706,7 @@ export const GeometryContentModel = types
               properties: assign({ id: uniqueId(), radius: 1 }, properties)
             };
       const angle = _applyChange(board, change);
-      return angle ? angle as any as JXG.Angle : undefined;
+      return isVertexAngle(angle) ? angle : undefined;
     }
 
     function addTableLink(
@@ -839,8 +839,8 @@ export const GeometryContentModel = types
     }
 
     function getOneSelectedComment(board: JXG.Board) {
-      const comments = self.selectedObjects(board).filter(el => isComment(el));
-      return comments.length === 1 ? comments[0] as JXG.Text : undefined;
+      const comments = self.selectedObjects(board).filter(isComment);
+      return comments.length === 1 ? comments[0] : undefined;
     }
 
     function getOneSelectedPoint(board: JXG.Board) {
@@ -852,7 +852,7 @@ export const GeometryContentModel = types
       // all vertices of polygon must be selected to show rotate handle
       const polygonSelection: { [id: string]: { any: boolean, all: boolean } } = {};
       const polygons = board.objectsList
-                            .filter(el => el.elType === "polygon")
+                            .filter(isPolygon)
                             .filter(polygon => {
                               const selected = { any: false, all: true };
                               each(polygon.ancestors, vertex => {
@@ -868,7 +868,7 @@ export const GeometryContentModel = types
                             });
       const selectedPolygonId = (polygons.length === 1) && polygons[0].id;
       const selectedPolygon = selectedPolygonId && polygonSelection[selectedPolygonId].all
-                                ? polygons[0] as JXG.Polygon : undefined;
+                                ? polygons[0] : undefined;
       // must not have any selected points other than the polygon vertices
       if (selectedPolygon) {
         type IEntry = [string, boolean];
@@ -903,7 +903,7 @@ export const GeometryContentModel = types
 
     function getOneSelectedSegment(board: JXG.Board) {
       const selectedObjects = self.selectedObjects(board);
-      const selectedSegments = selectedObjects.filter(isVisibleEdge) as JXG.Line[];
+      const selectedSegments = selectedObjects.filter(isVisibleEdge);
       if (selectedSegments.length === 1) {
         return selectedSegments[0];
       }
@@ -925,7 +925,7 @@ export const GeometryContentModel = types
         return selectedLines[0];
       }
 
-      const selectedSegments = selectedObjects.filter(isVisibleEdge) as JXG.Line[];
+      const selectedSegments = selectedObjects.filter(isVisibleEdge);
       if (selectedSegments.length === 1) {
         // Labeling polygon edges is not supported due to unpredictable IDs. However, if the polygon has only two sides,
         // then labeling an edge is equivalent to labeling the whole polygon.
@@ -972,7 +972,7 @@ export const GeometryContentModel = types
           switch (obj.elType) {
             case "angle":
               if (isVertexAngle(obj)) {
-                const va = obj as JXG.Angle;
+                const va = obj;
                 // parents must be in correct order
                 const parents = [va.point2, va.point1, va.point3];
                 assign(change, {
@@ -983,7 +983,7 @@ export const GeometryContentModel = types
               break;
             case "line":
               if (isMovableLine(obj)) {
-                const movableLine = obj as JXG.Line;
+                const movableLine = obj;
                 const [ , x1, y1] = movableLine.point1.coords.usrCoords;
                 const [ , x2, y2] = movableLine.point2.coords.usrCoords;
                 assign(change, {
@@ -1200,7 +1200,7 @@ export const GeometryContentModel = types
                                             : castArray(change.props as any);
       const xAttrId = dataSet.attributes.length > 0 ? dataSet.attributes[0].id : undefined;
       caseIds.forEach((caseId, caseIndex) => {
-        const tableProps = (propsArray[caseIndex] || propsArray[0]) as IRowProperties;
+        const tableProps = propsArray[caseIndex] || propsArray[0];
         // if x value changes, all points in row are affected
         if (xAttrId && tableProps[xAttrId] != null) {
           for (let attrIndex = 1; attrIndex < dataSet.attributes.length; ++attrIndex) {

--- a/src/models/tools/geometry/jxg-board.ts
+++ b/src/models/tools/geometry/jxg-board.ts
@@ -153,7 +153,7 @@ function scaleBoundingBoxToElement(domElementID: string, changeProps: any) {
   const eltBounds = elt?.getBoundingClientRect();
   const eltWidth = eltBounds?.width || kGeometryDefaultWidth;
   const eltHeight = eltBounds?.height || kGeometryDefaultHeight;
-  const { boundingBox } = changeProps;
+  const { boundingBox }: { boundingBox: JXG.BoundingBox } = changeProps;
   const [unitX, unitY] = getAxisUnitsFromProps(changeProps, getCanvasScale(elt));
   // eslint-disable-next-line no-sparse-arrays
   const [xMin, , , yMin] = boundingBox || [kGeometryDefaultAxisMin, , , kGeometryDefaultAxisMin];
@@ -197,7 +197,7 @@ function createBoard(domElementId: string, properties?: JXGProperties) {
           showNavigation: false,
           minimizeReflow: "none"
         };
-  const changeProps = properties && properties as JXGProperties;
+  const changeProps = properties;
   const [unitX, unitY] = getAxisUnitsFromProps(changeProps);
   // cf. https://www.intmath.com/cg3/jsxgraph-axes-ticks-grids.php
   const overrides = { axis: false, keepaspectratio: unitX === unitY };
@@ -265,8 +265,8 @@ export const boardChangeAgent: JXGChangeAgent = {
   create: (boardDomId: JXG.Board|string, change: JXGChange) => {
     const props = change.properties;
     const board = isBoard(boardDomId)
-                    ? boardDomId as JXG.Board
-                    : createBoard(boardDomId as string, props);
+                    ? boardDomId
+                    : createBoard(boardDomId, props);
     // If we created the board from a DOM element ID, then we need to add the axes.
     // If we are undoing an action, then the board already exists but its axes have
     // been removed, so we have to add the axes in that case as well.
@@ -295,7 +295,7 @@ export const boardChangeAgent: JXGChangeAgent = {
         const xName = xPropName ?? xClientName;
         const yName = yPropName ?? yClientName;
         const [xClientAnnotation, yClientAnnotation] = getClientAxisAnnotations(board);
-        const [xPropAnnotation, yPropAnnotation] = getAxisAnnotationsFromProps(props as JXGProperties);
+        const [xPropAnnotation, yPropAnnotation] = getAxisAnnotationsFromProps(props);
         const xAnnotation = xPropAnnotation ?? xClientAnnotation;
         const yAnnotation = yPropAnnotation ?? yClientAnnotation;
         const width = board.canvasWidth;

--- a/src/models/tools/geometry/jxg-changes.ts
+++ b/src/models/tools/geometry/jxg-changes.ts
@@ -56,8 +56,8 @@ export interface IChangeContext {
   isFeatureDisabled?: (feature: string) => boolean;
 }
 
-export type JXGElement = JXG.Board | JXG.Line | JXG.Point | JXG.Text;
-export type JXGChangeResult = JXGElement | JXGElement[] | undefined;
+export type JXGChangeElement = JXG.Board | JXG.GeometryElement;
+export type JXGChangeResult = JXGChangeElement | JXGChangeElement[] | undefined;
 
 // for create/board the board parameter is the ID of the DOM element
 // for all other changes it should be the board

--- a/src/models/tools/geometry/jxg-comment.ts
+++ b/src/models/tools/geometry/jxg-comment.ts
@@ -1,8 +1,7 @@
 import { getObjectById } from "./jxg-board";
 import { JXGChangeAgent } from "./jxg-changes";
-import { isMovableLine } from "./jxg-movable-line";
 import { objectChangeAgent } from "./jxg-object";
-import { isBoard, isPoint, isPolygon, isVisibleEdge } from "./jxg-types";
+import { isBoard, isMovableLine, isPoint, isPolygon, isVisibleEdge } from "./jxg-types";
 import { values } from "lodash";
 import { uniqueId } from "../../../utilities/js-utils";
 
@@ -32,7 +31,7 @@ const lineProps = {
 
 function getCentroid(anchor: JXG.GeometryElement) {
   if (isPoint(anchor)) {
-    const coords = (anchor as JXG.Point).coords.usrCoords;
+    const coords = anchor.coords.usrCoords;
     return [coords[1], coords[2]];
   } else if (isPolygon(anchor) || isMovableLine(anchor) || isVisibleEdge(anchor)) {
     const points = values(anchor.ancestors) as JXG.Point[];
@@ -67,7 +66,7 @@ export const commentChangeAgent: JXGChangeAgent = {
       ...changeProps,
     };
     if (isBoard(board)) {
-      const _board = board as JXG.Board;
+      const _board = board;
       const centroidCoordinateGetter = (index: number) => () => {
         const anchor = getObjectById(_board, commentProps.anchor);
         const centroid = anchor && getCentroid(anchor);

--- a/src/models/tools/geometry/jxg-dispatcher.ts
+++ b/src/models/tools/geometry/jxg-dispatcher.ts
@@ -43,7 +43,7 @@ export function applyChanges(board: JXG.Board|string, changes: JXGChange[],
   let _board: JXG.Board | undefined;
   const results = changes.map(change => {
                     const result = applyChange(_board || board, change, context);
-                    const resultBoard = castArray(result).find(isBoard) as JXG.Board;
+                    const resultBoard = castArray(result).find(isBoard);
                     if ((typeof board === "string") && resultBoard) {
                       _board = resultBoard;
                       _board.suspendUpdate();
@@ -78,8 +78,8 @@ export function applyChange(board: JXG.Board|string, change: JXGChange,
 
   // give clients a chance to intercede after the change has been applied
   if (context?.onDidApplyChange) {
-    if (isBoard(result)) _board = result as JXG.Board;
-    else if (Array.isArray(result) && isBoard(result?.[0])) _board = result[0] as JXG.Board;
+    if (isBoard(result)) _board = result;
+    else if (Array.isArray(result) && isBoard(result?.[0])) _board = result[0];
     context.onDidApplyChange(_board, change);
   }
 

--- a/src/models/tools/geometry/jxg-image.ts
+++ b/src/models/tools/geometry/jxg-image.ts
@@ -1,10 +1,9 @@
 import { getObjectById } from "./jxg-board";
 import { JXGChangeAgent } from "./jxg-changes";
 import { objectChangeAgent } from "./jxg-object";
+import { isImage } from "./jxg-types";
 import { gImageMap } from "../../image-map";
 import { uniqueId } from "../../../utilities/js-utils";
-
-export const isImage = (v: any) => v instanceof JXG.Image;
 
 export const imageChangeAgent: JXGChangeAgent = {
   create: (board, change) => {
@@ -26,7 +25,7 @@ export const imageChangeAgent: JXGChangeAgent = {
     const props = Array.isArray(change.properties) ? change.properties : [change.properties];
     ids.forEach((id, index) => {
       const obj = getObjectById(board, id);
-      const image = isImage(obj) ? obj as JXG.Image : undefined;
+      const image = isImage(obj) ? obj : undefined;
       const objProps = index < props.length ? props[index] : props[0];
       if (image && objProps) {
         const { url, size } = objProps;

--- a/src/models/tools/geometry/jxg-object.ts
+++ b/src/models/tools/geometry/jxg-object.ts
@@ -1,11 +1,9 @@
 import { sortByCreation, kReverse, getObjectById, syncLinkedPoints } from "./jxg-board";
 import { JXGChangeAgent, JXGProperties, JXGCoordPair, JXGUnsafeCoordPair } from "./jxg-changes";
-import { isLinkedPoint } from "./jxg-types";
+import { isLinkedPoint, isText } from "./jxg-types";
 import { ITableLinkProperties } from "../table/table-content";
 import { castArrayCopy } from "../../../utilities/js-utils";
 import { castArray, size } from "lodash";
-
-export const isText = (v: any) => v instanceof JXG.Text;
 
 // Inexplicably, we occasionally encounter JSXGraph objects with null
 // transformations which cause JSXGraph to crash. Until we figure out
@@ -45,7 +43,7 @@ export const objectChangeAgent: JXGChangeAgent = {
     ids.forEach((id, index) => {
       const obj = getObjectById(board, id);
       if (isLinkedPoint(obj)) hasLinkedPoints = true;
-      const textObj = isText(obj) ? obj as JXG.Text : undefined;
+      const textObj = isText(obj) ? obj : undefined;
       const objProps = index < props.length ? props[index] : props[0];
       if (obj && objProps) {
         const { position, text, ...others } = objProps;

--- a/src/models/tools/geometry/jxg-table-link.ts
+++ b/src/models/tools/geometry/jxg-table-link.ts
@@ -28,7 +28,7 @@ function createLinkedPoint(board: JXG.Board, parents: JXGCoordPair, props: any, 
   const tableId = links?.tileIds?.[0];
   const [linkedRowId, linkedColId] = splitLinkedPointId(props?.id);
   const linkColors = sGetTableLinkColors(tableId);
-  if (!linkColors) return;
+  if (!board || !linkColors) return;
   const linkedProps = {
           clientType: "linkedPoint",
           fixed: true,
@@ -43,7 +43,7 @@ function createLinkedPoint(board: JXG.Board, parents: JXGCoordPair, props: any, 
           linkedColId
         };
   const _props = { ...props, ...linkedProps };
-  return createPoint(board as JXG.Board, parents, _props);
+  return createPoint(board, parents, _props);
 }
 
 export const linkedPointChangeAgent: JXGChangeAgent = {
@@ -70,7 +70,7 @@ export const linkedPointChangeAgent: JXGChangeAgent = {
   delete: (board, change) => {
     pointChangeAgent.delete(board, change);
 
-    syncLinkedPoints(board as JXG.Board, change.links as ITableLinkProperties);
+    syncLinkedPoints(board, change.links as ITableLinkProperties);
   }
 };
 

--- a/src/models/tools/geometry/jxg-types.ts
+++ b/src/models/tools/geometry/jxg-types.ts
@@ -1,28 +1,59 @@
 import { values } from "lodash";
 
-export const isBoard = (v: any) => v instanceof JXG.Board;
-export const isAxis = (v: any) => (v instanceof JXG.Line) && (v.elType === "axis");
-export const isAxisLabel = (v: any) => v instanceof JXG.Text && !!values(v.ancestors).find(el => isAxis(el));
+export const isBoard = (v: any): v is JXG.Board => v instanceof JXG.Board;
+export const isAxis = (v: any): v is JXG.Line => (v instanceof JXG.Line) && (v.elType === "axis");
+export const isAxisArray = (v: any): v is JXG.Line[] => Array.isArray(v) && v.every(isAxis);
+export const isAxisLabel = (v: any): v is JXG.Text => {
+  return v instanceof JXG.Text && values(v.ancestors).some(isAxis);
+};
 
-export const isPoint = (v: any) => v instanceof JXG.Point;
-export const isVisiblePoint = (v: any) => isPoint(v) && v.visProp.visible;
+export const isGeometryElement = (v: any): v is JXG.GeometryElement => v instanceof JXG.GeometryElement;
 
-export const isLinkedPoint = (v: any) => isPoint(v) && (v.getAttribute("clientType") === "linkedPoint");
+export const isPoint = (v: any): v is JXG.Point => v instanceof JXG.Point;
+export const isPointArray = (v: any): v is JXG.Point[] => Array.isArray(v) && v.every(isPoint);
+export const isVisiblePoint = (v: any): v is JXG.Point => isPoint(v) && v.visProp.visible;
+
+export const isLinkedPoint = (v: any): v is JXG.Point => {
+  return isPoint(v) && (v.getAttribute("clientType") === "linkedPoint");
+};
 
 export const isCommentType = (v: any) => v && v.getAttribute("clientType") === "comment";
-export const isComment = (v: any) => isCommentType(v) && (v instanceof JXG.Text) && (v.elType === "text");
+export const isComment = (v: any): v is JXG.Text => {
+  return v instanceof JXG.Text && isCommentType(v) && (v.elType === "text");
+};
 
-export const isFreePoint = (v: any) => {
+export const isFreePoint = (v: any): v is JXG.Point => {
   if (isVisiblePoint(v)) {
-    const point = v as JXG.Point;
+    const point = v;
     return values(point.childElements).filter(el => !isCommentType(el)).length <= 1 &&
            values(point.descendants).filter(el => !isCommentType(el)).length <= 1;
   }
+  return false;
 };
 
-export const isPolygon = (v: any) => v instanceof JXG.Polygon;
-export const isVisibleEdge = (v: any) => v instanceof JXG.Line && (v.elType === "segment") && v.visProp.visible;
+export const isImage = (v: any): v is JXG.Image => v instanceof JXG.Image;
 
-export const isVertexAngle = (v: any) =>
-                (v instanceof JXG.Curve) && (v.elType === "angle") &&
-                (v.getAttribute("clientType") === "vertexAngle");
+export const isLine = (v: any): v is JXG.Line => v instanceof JXG.Line;
+
+export const isPolygon = (v: any): v is JXG.Polygon => v instanceof JXG.Polygon;
+export const isVisibleEdge = (v: any): v is JXG.Line => {
+  return v instanceof JXG.Line && (v.elType === "segment") && v.visProp.visible;
+};
+
+export const isText = (v: any): v is JXG.Text => v instanceof JXG.Text;
+
+export const isVertexAngle = (v: any): v is JXG.Angle => {
+  return (v instanceof JXG.Curve) && (v.elType === "angle") && (v.getAttribute("clientType") === "vertexAngle");
+};
+
+export const kMovableLineType = "movableLine";
+export const isMovableLine = (v: any): v is JXG.Line => {
+  return v && (v.elType === "line") && (v.getAttribute("clientType") === kMovableLineType);
+};
+export const isVisibleMovableLine = (v: any): v is JXG.Line => isMovableLine(v) && v.visProp.visible;
+export const isMovableLineControlPoint = (v: any): v is JXG.Point => {
+  return isPoint(v) && v.getAttribute("clientType") === kMovableLineType;
+};
+export const isMovableLineLabel = (v: any): v is JXG.Text => {
+  return v instanceof JXG.Text && v.getAttribute("clientType") === kMovableLineType;
+};

--- a/src/utilities/dom-utils.ts
+++ b/src/utilities/dom-utils.ts
@@ -1,7 +1,7 @@
 // cf. https://developer.mozilla.org/en-US/docs/Web/API/Element/matches#Polyfill
 if (!Element.prototype.matches) {
   Element.prototype.matches = (Element.prototype as any).msMatchesSelector ||
-                              Element.prototype.webkitMatchesSelector;
+                              (Element.prototype as any).webkitMatchesSelector;
 }
 
 // cf. https://developer.mozilla.org/en-US/docs/Web/API/Element/closest#Polyfill

--- a/src/utilities/image-utils.ts
+++ b/src/utilities/image-utils.ts
@@ -89,7 +89,7 @@ export function storeImage(db: DB, userId: string, url: string,
   return new Promise((resolve, reject) => {
     if (!url) reject(img);
 
-    resizeImage(url!, ImageConstants.maxWidth, ImageConstants.maxHeight, cors)
+    resizeImage(url, ImageConstants.maxWidth, ImageConstants.maxHeight, cors)
       .then(imageData => {
         const _name = name || url;
         const image: ImageModelType = ImageModel.create({


### PR DESCRIPTION
Wrapping up some work that began before the 1.6.0 release.

In the geometry tile we already have a number of type-checking functions for testing whether generic JSXGraph objects are of particular types. Prior to this PR these generally just returned simple booleans. With this PR we turn these type-checking functions into proper [type guards](https://2ality.com/2020/06/type-guards-assertion-functions-typescript.html#user-defined-type-guards) which serve to narrow the types as seen by TypeScript. This allows us to eliminate a number of type assertions (e.g. `foo as JXG.Point`) because the narrowing from the type guards allows the TypeScript compiler to figure out the resulting type without being told explicitly.

The result is generally cleaner/simpler code with fewer instances where we need to explicitly tell the compiler the types of things (potentially incorrectly). This led me to wonder whether there might be additional type assertions that could be removed as redundant. It turns out that there's an additional set of recommended TypeScript lint rules ([@typescript-eslint/recommended-requiring-type-checking](https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/linting/TYPED_LINTING.md)) that must be enabled separately. It essentially requires a full build, so it's not something that you necessarily want to do all the time, but I added a new lint script, `lint:types`, which tests the additional rules that require type-checking. There were ~1000 additional type errors/warnings, most of which came from a handful of rules I disabled while adding comments indicating their prevalence, but several kinds of errors/warnings were fixed, including:
- unnecessary (redundant) type assertions
- cases in which functions were being passed but the correct `this` could not be guaranteed
- uses of `async` without `await`
- uses of `+` with inconsistent arguments

In theory, none of this should change the behavior of the code, but merely tighten up the TypeScript types so that it is more likely that we're actually dealing with the types we say we are rather than having to tell the compiler at every turn what types to expect.