### PR TITLE
Fix row resize issue resulting from lower-case key limitation in DataTransfer

### DIFF
--- a/src/components/document/document-content.tsx
+++ b/src/components/document/document-content.tsx
@@ -148,7 +148,8 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
     const { rowMap } = content;
     const row = rowMap.get(rowId);
     const { dragResizeRow } = this.state;
-    if (rowId !== dragResizeRow?.id) {
+    // must match lower-case for ids stored in DataTransfer key
+    if (rowId.toLowerCase() !== dragResizeRow?.id) {
       return row?.height;
     }
     const rowHeight = dragResizeRow && (dragResizeRow.domHeight || dragResizeRow.modelHeight);
@@ -300,7 +301,7 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
     }
     else if (withinDocument && this.hasDragType(e.dataTransfer, kDragResizeRowId)) {
       const dragResizeRow = this.getDragResizeRowInfo(e);
-      if (dragResizeRow && dragResizeRow.id && dragResizeRow.newHeight != null) {
+      if (dragResizeRow?.id && dragResizeRow.newHeight != null) {
         this.setState({ dragResizeRow });
       }
       // indicate we'll accept the drop
@@ -382,9 +383,9 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
   private handleRowResizeDrop = (e: React.DragEvent<HTMLDivElement>) => {
     const { content } = this.props;
     const dragResizeRow = this.getDragResizeRowInfo(e);
-    if (content && dragResizeRow && dragResizeRow.id && dragResizeRow.newHeight != null) {
+    if (content && dragResizeRow?.id && dragResizeRow.newHeight != null) {
       const row = content.rowMap.get(dragResizeRow.id);
-      row && row.setRowHeight(dragResizeRow.newHeight);
+      row?.setRowHeight(dragResizeRow.newHeight);
       this.setState({ dragResizeRow: undefined });
     }
   }

--- a/src/components/document/tile-row.tsx
+++ b/src/components/document/tile-row.tsx
@@ -22,6 +22,11 @@ export const dragResizeRowDomHeight =
               (domHeight: number) => `org.concord.clue.row-resize.dom-height.${domHeight}`;
 
 export function extractDragResizeRowId(dataTransfer: DataTransfer) {
+  // get the actual rowId from contents if possible (e.g. on drop)
+  const dragRowId = dataTransfer.getData(kDragResizeRowId);
+  if (dragRowId) return dragRowId;
+
+  // if not, extract the toLowerCase() version from the key (e.g. on over)
   for (const type of dataTransfer.types) {
     const result = /org\.concord\.clue\.row-resize\.id\.(.*)$/.exec(type);
     if (result) return result[1];


### PR DESCRIPTION
Fix bug which prevented some rows from being resizable. Must use case-insensitive comparison when comparing ids that have been `toLowerCase()`d to fit within the key of the `DataTransfer` object.