### PR TITLE
Update to @concord-consortium/slate-editor 0.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3610,27 +3610,39 @@
       }
     },
     "@concord-consortium/slate-editor": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/slate-editor/-/slate-editor-0.7.1.tgz",
-      "integrity": "sha512-bursZjhuExOPGfiM2VYdIJbu5EoMiGcbri4AlDISalK5FH48fMnnAtDKlQR1yUYxd/bcZyrQRg0Mcyy8JTJ1ng==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/slate-editor/-/slate-editor-0.7.2.tgz",
+      "integrity": "sha512-GTf32RHYFn5zLTLF9h49ovEnaFrUsgV8YVjAiuwqNFSeumrOvt65oO1m20j0mV7KbM0spX6NXqrhY57uAaWGkQ==",
       "requires": {
         "@concord-consortium/slate-react": "^0.22.10-cc.3",
         "classnames": "^2.2.6",
         "eventemitter3": "^4.0.7",
         "immutable": "^3.8.2",
         "is-hotkey": "^0.2.0",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.21",
         "react-select": "^4.1.0",
         "slate": "^0.47.9",
         "slate-html-serializer": "^0.8.13",
         "slate-plain-serializer": "^0.7.13",
-        "style-to-object": "^0.3.0"
+        "style-to-object": "^0.3.0",
+        "tslib": "^2.1.0",
+        "valid-url": "^1.0.9"
       },
       "dependencies": {
         "is-hotkey": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/is-hotkey/-/is-hotkey-0.2.0.tgz",
           "integrity": "sha512-UknnZK4RakDmTgz4PI1wIph5yxSs/mvChWs9ifnlXsKuXgWmOkY/hAE0H/k2MIqH0RlRye0i1oC07MCRSD28Mw=="
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
         }
       }
     },
@@ -23442,9 +23454,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.13.tgz",
-          "integrity": "sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==",
+          "version": "7.13.8",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.8.tgz",
+          "integrity": "sha512-CwQljpw6qSayc0fRG1soxHAKs1CnQMOChm4mlQP6My0kf9upVGizj/KhlTTgyUnETmHpcUXjaluNAkteRFuafg==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -27685,6 +27697,11 @@
           "dev": true
         }
       }
+    },
+    "valid-url": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "@blueprintjs/core": "^3.38.2",
     "@concord-consortium/jsxgraph": "^0.99.8-cc.1",
     "@concord-consortium/react-components": "^0.1.14",
-    "@concord-consortium/slate-editor": "^0.7.1",
+    "@concord-consortium/slate-editor": "^0.7.2",
     "classnames": "^2.2.6",
     "color-string": "^1.5.4",
     "copy-text-to-clipboard": "^2.2.0",

--- a/src/models/tools/text/text-content.test.ts
+++ b/src/models/tools/text/text-content.test.ts
@@ -1,6 +1,19 @@
-import { TextContentModel, kTextToolID, emptyJson } from "./text-content";
+import { TextContentModel, kTextToolID } from "./text-content";
 import { Value, ValueJSON } from "slate";
 import Plain from "slate-plain-serializer";
+
+const emptyJson: ValueJSON = {
+        document: {
+          nodes: [{
+            object: "block",
+            type: "paragraph",
+            nodes: [{
+              object: "text",
+              text: ""
+            }]
+          }]
+        }
+      };
 
 describe("TextContentModel", () => {
 


### PR DESCRIPTION
Fixes import/export of `className` property