### PR TITLE
CLUE 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Version 1.7.0 - released February 26, 2021
+
+### Features/Improvements
+- Additional Moving Straight Ahead Teacher Content
+- Uses @concord-consortium/slate-editor library
+- Update `browserslist` configuration
+
+### Asset Sizes
+
+| File | Size | % Change from Previous Release |
+|---|---|---|
+| index.css | 389,494 bytes | 0.0% |
+| index.js | 4,574,452 bytes | 10.3% |
+
 ## Version 1.6.0 - released February 7, 2021
 
 ### Features/Improvements

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "collaborative-learning",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -233,12 +233,6 @@
             "escalade": "^3.1.1",
             "node-releases": "^1.1.70"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001183",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001183.tgz",
-          "integrity": "sha512-7JkwTEE1hlRKETbCFd8HDZeLiQIUcl8rC6JgNjvHCNaxOeNmQ9V4LvQXRUsKIV2CC73qKxljwVhToaA3kLRqTw==",
-          "dev": true
         },
         "electron-to-chromium": {
           "version": "1.3.650",
@@ -7102,12 +7096,6 @@
             "node-releases": "^1.1.70"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001181",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001181.tgz",
-          "integrity": "sha512-m5ul/ARCX50JB8BSNM+oiPmQrR5UmngaQ3QThTTp5HcIIQGP/nPBs82BYLE+tigzm3VW+F4BJIhUyaVtEweelQ==",
-          "dev": true
-        },
         "core-js-compat": {
           "version": "3.8.3",
           "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.8.3.tgz",
@@ -10269,9 +10257,9 @@
       "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
     },
     "caniuse-lite": {
-      "version": "1.0.30001116",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001116.tgz",
-      "integrity": "sha512-f2lcYnmAI5Mst9+g0nkMIznFGsArRmZ0qU+dnq8l91hymdc2J3SFbiPhOJEeDqC1vtE8nc1qNQyklzB8veJefQ==",
+      "version": "1.0.30001192",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001192.tgz",
+      "integrity": "sha512-63OrUnwJj5T1rUmoyqYTdRWBqFFxZFlyZnRRjDR8NSUQFB6A+j/uBORU/SyJ5WzDLg4SPiZH40hQCBNdZ/jmAw==",
       "dev": true
     },
     "capture-exit": {
@@ -11183,12 +11171,6 @@
             "escalade": "^3.1.1",
             "node-releases": "^1.1.70"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001183",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001183.tgz",
-          "integrity": "sha512-7JkwTEE1hlRKETbCFd8HDZeLiQIUcl8rC6JgNjvHCNaxOeNmQ9V4LvQXRUsKIV2CC73qKxljwVhToaA3kLRqTw==",
-          "dev": true
         },
         "electron-to-chromium": {
           "version": "1.3.650",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collaborative-learning",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Collaborative Learning environment",
   "main": "index.js",
   "config": {
@@ -10,6 +10,7 @@
     "masterBranchRegEx": "/collaborative-learning\\.concord\\.org\\/branch\\/master(\\/|$)/i",
     "rollbarAccessToken": "fb9dd070b7344cc7a5e529d8fa25e765"
   },
+  "browserslist": "> 0.2%, last 5 versions, Firefox ESR, not dead",
   "jest": {
     "transform": {
       "^.+\\.tsx?$": "ts-jest"


### PR DESCRIPTION
## Version 1.7.0 - released February 26, 2021

### Features/Improvements
- Additional Moving Straight Ahead Teacher Content
- Uses @concord-consortium/slate-editor library
- Update `browserslist` configuration

### Asset Sizes

| File | Size | % Change from Previous Release |
|---|---|---|
| index.css | 389,494 bytes | 0.0% |
| index.js | 4,574,452 bytes | 10.3% |