### PR TITLE
Archive code to export student groups [#172209086]

### DIFF
--- a/src/clue/components/teacher/teacher-class-info-button.sass
+++ b/src/clue/components/teacher/teacher-class-info-button.sass
@@ -1,0 +1,13 @@
+@import ../../../components/vars
+
+.class-info-button-container
+  .class-info-button
+    height: 40px
+    width: 100px
+    border-radius: 5px
+    box-shadow: none
+    border: none
+    background-color: $sage-light-1
+    color: $sage-text
+    &:hover
+      background-color: $sage-dark-2

--- a/src/clue/components/teacher/teacher-class-info-button.tsx
+++ b/src/clue/components/teacher/teacher-class-info-button.tsx
@@ -38,13 +38,9 @@ export class ClassInfoButton extends BaseComponent <IProps, {}> {
       header.push("CLASS HASH");
       header.push("TEACHER ID");
       header.push("OFFERING");
-      header.push("CURRENT GROUP");
-      header.push("STUDENT 1 ID", "STUDENT 1 INITIALS", "STUDENT 2 ID", "STUDENT 2 INITIALS",
-                  "STUDENT 3 ID", "STUDENT 3 INITIALS", "STUDENT 4 ID", "STUDENT 4 INITIALS",
-                  "STUDENT 5 ID", "STUDENT 5 INITIALS", "STUDENT 6 ID", "STUDENT 6 INITIALS");
+      header.push("GROUP ID");
+      header.push("STUDENT ID", "STUDENT INITIALS");
       csv.push(header.join(","));
-
-      let first = true;
 
       // get the groups for each offering
       const offerings = offeringsSnapshot.val();
@@ -52,19 +48,18 @@ export class ClassInfoButton extends BaseComponent <IProps, {}> {
         if (offering) {
           each(offering.groups, (group, groupId) => {
             if (group) {
-              const row: string[] = [];
-              first ? row.push(user.className, user.classHash, user.id) : row.push("", "", "");
-              first = false;
-              row.push(offeringId);
-              row.push(groupId);
               each(group.users, (gUser, uId) => {
                 if (gUser) {
+                  const row: string[] = [];
+                  row.push(user.className, user.classHash, user.id);
+                  row.push(offeringId);
+                  row.push(groupId);
                   const classUser = this.stores.class.getUserById(uId);
                   row.push(uId);
                   classUser ? row.push(classUser.initials) : row.push("");
+                  csv.push(row.join(","));
                 }
               });
-              csv.push(row.join(","));
             }
           });
         }
@@ -86,20 +81,20 @@ export class ClassInfoButton extends BaseComponent <IProps, {}> {
       });
       // add the current groups to the CSV
       each(latestGroupsArray, (group) => {
-        const row: string[] = [];
-        row.push("", "", "");
-        row.push("CURRENT GROUPS");
-        row.push(group);
         each(users, (portalUser, userId) => {
           if (portalUser) {
             const classUser = this.stores.class.getUserById(userId);
             if (classUser?.type === "student" && portalUser.latestGroupId === group) {
+              const row: string[] = [];
+              row.push(user.className, user.classHash, user.id);
+              row.push("CURRENT GROUP");
+              row.push(group);
               row.push(classUser.id);
               row.push(classUser.initials);
+              csv.push(row.join(","));
             }
           }
         });
-        csv.push(row.join(","));
       });
 
       this.exportCSV(csv.join("\n"), `teacherId-${user.id}-classHash-${user.classHash}-studentGroups.csv`);

--- a/src/clue/components/teacher/teacher-class-info-button.tsx
+++ b/src/clue/components/teacher/teacher-class-info-button.tsx
@@ -102,7 +102,7 @@ export class ClassInfoButton extends BaseComponent <IProps, {}> {
         });
       }
 
-      this.exportCSV(csv.join("\n"), `TeacherID-${user.id}-ClassID-${user.classHash}-student-groups.csv`);
+      this.exportCSV(csv.join("\n"), `TeacherID-${user.id}-ClassHash-${user.classHash}-student-groups.csv`);
     }
   }
 

--- a/src/clue/components/teacher/teacher-class-info-button.tsx
+++ b/src/clue/components/teacher/teacher-class-info-button.tsx
@@ -1,0 +1,77 @@
+import { inject } from "mobx-react";
+import { BaseComponent, IBaseProps } from "../../../components/base";
+import React from "react";
+import { each } from "lodash";
+
+import "./teacher-class-info-button.sass";
+
+interface IProps extends IBaseProps {}
+
+@inject("stores")
+export class ClassInfoButton extends BaseComponent <IProps, {}> {
+  public render() {
+    return (
+      <div className="class-info-button-container">
+        <button className="class-info-button export" onClick={this.handleExportClick}>Export Class Groups (csv)</button>
+      </div>
+    );
+  }
+
+  private handleExportClick = async () => {
+    const {db, user} = this.stores; // access the database
+    const groupsArray: string[] = []; // store the group ids
+    const usersPath = db.firebase.getUsersPath(db.stores.user);
+    const usersRef = db.firebase.ref(usersPath);
+    // get a snapshot of the users in this class
+    const usersSnapshot = await usersRef.once("value");
+    if (usersSnapshot) {
+      const users = usersSnapshot.val();
+      each(users, (portalUser, userId) => {
+        // a user is a DBPortalUser in db-types.ts, can be undefined, each has the latestGroupId
+        if (portalUser) {
+          // classUser contains the user name information
+          const classUser = this.stores.class.getUserById(userId);
+          if (classUser?.type === "student") {
+            if (groupsArray.indexOf(portalUser.latestGroupId) === -1) groupsArray.push(portalUser.latestGroupId);
+          }
+        }
+      });
+
+      const csv: any[] = [];
+      const header: string[] = [];
+      header.push("GROUP");
+      header.push("STUDENT", "STUDENT", "STUDENT", "STUDENT");
+      csv.push(header.join(","));
+      each(groupsArray, (group) => {
+        const row: string[] = [];
+        row.push(group);
+        each(users, (portalUser, userId) => {
+          if (portalUser) {
+            const classUser = this.stores.class.getUserById(userId);
+            if (classUser?.type === "student" && portalUser.latestGroupId === group) {
+              row.push(classUser.fullName);
+            }
+          }
+        });
+        csv.push(row.join(","));
+      });
+      this.exportCSV(csv.join("\n"), `${user.className}-student-groups.csv`);
+    }
+  }
+
+  private exportCSV = (csv: string, fileName: string) => {
+    const csvBlob = new Blob([csv], {type: "text/csv;charset=utf-8;"});
+    if (navigator.msSaveBlob) {
+      navigator.msSaveBlob(csvBlob, fileName);
+    }
+    else {
+      const link = document.createElement("a");
+      link.href = window.URL.createObjectURL(csvBlob);
+      link.setAttribute("download", fileName);
+      document.body.appendChild(link);
+
+      link.click();
+      document.body.removeChild(link);
+    }
+  }
+}

--- a/src/clue/components/teacher/teacher-class-info-button.tsx
+++ b/src/clue/components/teacher/teacher-class-info-button.tsx
@@ -33,15 +33,19 @@ export class ClassInfoButton extends BaseComponent <IProps, {}> {
 
     if (usersSnapshot && offeringsSnapshot) {
       const csv: any[] = [];
-      csv.push([`CLASS NAME: ${user.className}`]);
-      csv.push(`CLASS HASH: ${user.classHash}`);
-      csv.push(`TEACHER ID: ${user.id}`);
+      const classHeader: string[] = [];
+      classHeader.push("className", "classHash", "teacherId");
+      csv.push(classHeader.join(","));
+
+      const classInfo: string[] = [];
+      classInfo.push(user.className, user.classHash, user.id);
+      csv.push(classInfo.join(","));
 
       csv.push([]);
-      csv.push(["CURRENT GROUPS"]);
+      csv.push(["currentGroups"]);
       const header: string[] = [];
-      header.push("CURRENT GROUP");
-      header.push("STUDENT ID", "STUDENT ID", "STUDENT ID", "STUDENT ID", "STUDENT ID", "STUDENT ID");
+      header.push("groupId");
+      header.push("studentId", "studentId", "studentId", "studentId", "studentId", "studentId");
       csv.push(header.join(","));
 
       // get the current set of groups
@@ -80,10 +84,11 @@ export class ClassInfoButton extends BaseComponent <IProps, {}> {
           if (offering) {
 
             csv.push([]);
-            csv.push([`OFFERING: ${offeringId}`]);
+            csv.push(["offeringId"]);
+            csv.push([offeringId]);
             const offHeader: string[] = [];
-            offHeader.push("OFFERING GROUP");
-            offHeader.push("STUDENT ID", "STUDENT ID", "STUDENT ID", "STUDENT ID", "STUDENT ID", "STUDENT ID");
+            offHeader.push("groupId");
+            offHeader.push("studentId", "studentId", "studentId", "studentId", "studentId", "studentId");
             csv.push(header.join(","));
 
             each(offering.groups, (group, groupId) => {
@@ -102,7 +107,7 @@ export class ClassInfoButton extends BaseComponent <IProps, {}> {
         });
       }
 
-      this.exportCSV(csv.join("\n"), `TeacherID-${user.id}-ClassHash-${user.classHash}-student-groups.csv`);
+      this.exportCSV(csv.join("\n"), `teacherId-${user.id}-classHash-${user.classHash}-studentGroups.csv`);
     }
   }
 

--- a/src/clue/components/teacher/teacher-class-info-button.tsx
+++ b/src/clue/components/teacher/teacher-class-info-button.tsx
@@ -81,9 +81,9 @@ export class ClassInfoButton extends BaseComponent <IProps, {}> {
 
             csv.push([]);
             csv.push([`OFFERING: ${offeringId}`]);
-            const header: string[] = [];
-            header.push("OFFERING GROUP");
-            header.push("STUDENT ID", "STUDENT ID", "STUDENT ID", "STUDENT ID", "STUDENT ID", "STUDENT ID");
+            const offHeader: string[] = [];
+            offHeader.push("OFFERING GROUP");
+            offHeader.push("STUDENT ID", "STUDENT ID", "STUDENT ID", "STUDENT ID", "STUDENT ID", "STUDENT ID");
             csv.push(header.join(","));
 
             each(offering.groups, (group, groupId) => {

--- a/src/clue/components/teacher/teacher-class-info-button.tsx
+++ b/src/clue/components/teacher/teacher-class-info-button.tsx
@@ -5,14 +5,28 @@ import { each } from "lodash";
 
 import "./teacher-class-info-button.sass";
 
+/**
+ * This component was developed to generate a CSV-formatted report for teachers of
+ * the student groupings for each problem (offering) in a class. This was required
+ * at the time because early versions of CLUE did not log group information and so
+ * there was no easy way to determine student groupings from the existing logs.
+ * A student's groupId was added to the existing logs for CLUE 0.8.0 in PR #451
+ * (https://github.com/concord-consortium/collaborative-learning/pull/451),
+ * obviating the need for this particular report component and its button.
+ * This component is left in the code base as an exemplar in case future need for
+ * CSV export of CLUE data arises.
+ */
+
 interface IProps extends IBaseProps {}
 
 @inject("stores")
-export class ClassInfoButton extends BaseComponent <IProps, {}> {
+export class ClassInfoButton extends BaseComponent <IProps> {
   public render() {
     return (
       <div className="class-info-button-container">
-        <button className="class-info-button export" onClick={this.handleExportClick}>Export Class Groups (csv)</button>
+        <button className="class-info-button export" onClick={this.handleExportClick}>
+          Export Class Groups (csv)
+        </button>
       </div>
     );
   }
@@ -56,7 +70,7 @@ export class ClassInfoButton extends BaseComponent <IProps, {}> {
                   row.push(groupId);
                   const classUser = this.stores.class.getUserById(uId);
                   row.push(uId);
-                  classUser ? row.push(classUser.initials) : row.push("");
+                  row.push(classUser?.initials || "");
                   csv.push(row.join(","));
                 }
               });

--- a/src/clue/components/teacher/teacher-class-info-button.tsx
+++ b/src/clue/components/teacher/teacher-class-info-button.tsx
@@ -39,7 +39,9 @@ export class ClassInfoButton extends BaseComponent <IProps, {}> {
       header.push("TEACHER ID");
       header.push("OFFERING");
       header.push("CURRENT GROUP");
-      header.push("STUDENT ID 1", "STUDENT ID 2", "STUDENT ID 3", "STUDENT ID 4", "STUDENT ID 5", "STUDENT ID 6");
+      header.push("STUDENT 1 ID", "STUDENT 1 INITIALS", "STUDENT 2 ID", "STUDENT 2 INITIALS",
+                  "STUDENT 3 ID", "STUDENT 3 INITIALS", "STUDENT 4 ID", "STUDENT 4 INITIALS",
+                  "STUDENT 5 ID", "STUDENT 5 INITIALS", "STUDENT 6 ID", "STUDENT 6 INITIALS");
       csv.push(header.join(","));
 
       let first = true;
@@ -57,7 +59,9 @@ export class ClassInfoButton extends BaseComponent <IProps, {}> {
               row.push(groupId);
               each(group.users, (gUser, uId) => {
                 if (gUser) {
+                  const classUser = this.stores.class.getUserById(uId);
                   row.push(uId);
+                  classUser ? row.push(classUser.initials) : row.push("");
                 }
               });
               csv.push(row.join(","));
@@ -91,6 +95,7 @@ export class ClassInfoButton extends BaseComponent <IProps, {}> {
             const classUser = this.stores.class.getUserById(userId);
             if (classUser?.type === "student" && portalUser.latestGroupId === group) {
               row.push(classUser.id);
+              row.push(classUser.initials);
             }
           }
         });

--- a/src/clue/components/teacher/teacher-class-info-button.tsx
+++ b/src/clue/components/teacher/teacher-class-info-button.tsx
@@ -102,7 +102,7 @@ export class ClassInfoButton extends BaseComponent <IProps, {}> {
         });
       }
 
-      this.exportCSV(csv.join("\n"), `${user.className}-student-groups.csv`);
+      this.exportCSV(csv.join("\n"), `TeacherID-${user.id}-ClassID-${user.classHash}-student-groups.csv`);
     }
   }
 

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -94,6 +94,10 @@ export class Firebase {
     return this.getFullPath(this.getClassPath(user));
   }
 
+  public getUsersPath(user: UserModelType) {
+    return `${this.getClassPath(user)}/users`;
+  }
+
   public getUserPath(user: UserModelType, userId?: string) {
     return `${this.getClassPath(user)}/users/${userId || user.id}`;
   }

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -159,12 +159,12 @@ export class Firebase {
     return `${this.getClassPath(user)}/images`;
   }
 
-  public getOfferingPath(user: UserModelType) {
-    return `${this.getClassPath(user)}/offerings/${user.offeringId}`;
-  }
-
   public getOfferingsPath(user: UserModelType) {
     return `${this.getClassPath(user)}/offerings`;
+  }
+
+  public getOfferingPath(user: UserModelType) {
+    return `${this.getClassPath(user)}/offerings/${user.offeringId}`;
   }
 
   public getOfferingUsersPath(user: UserModelType) {

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -163,6 +163,10 @@ export class Firebase {
     return `${this.getClassPath(user)}/offerings/${user.offeringId}`;
   }
 
+  public getOfferingsPath(user: UserModelType) {
+    return `${this.getClassPath(user)}/offerings`;
+  }
+
   public getOfferingUsersPath(user: UserModelType) {
     return `${this.getOfferingPath(user)}/users`;
   }


### PR DESCRIPTION
This component was developed to generate a CSV-formatted report for teachers of the student groupings for each problem (offering) in a class. This was required at the time because early versions of CLUE did not log group information and so there was no easy way to determine student groupings from the existing logs. A student's `groupId` was added to the existing logs for CLUE 0.8.0 in [PR #451](https://github.com/concord-consortium/collaborative-learning/pull/451), obviating the need for this particular report component and its button. This component is left in the code base as an exemplar in case future need for CSV export of CLUE data arises. [[#172209086]](https://www.pivotaltracker.com/story/show/172209086)
