### PR TITLE
Table: Support JSON export; improve import [#176874316]

### DIFF
--- a/src/components/tools/table-tool/table-tool.tsx
+++ b/src/components/tools/table-tool/table-tool.tsx
@@ -11,6 +11,7 @@ import { useDataSet } from "./use-data-set";
 import { useExpressionsDialog } from "./use-expressions-dialog";
 import { useGeometryLinking } from "./use-geometry-linking";
 import { useGridContext } from "./use-grid-context";
+import { useJsonExport } from "./use-json-export";
 import { useModelDataSet } from "./use-model-data-set";
 import { useRowLabelColumn } from "./use-row-label-column";
 import { useTableTitle } from "./use-table-title";
@@ -76,7 +77,9 @@ const TableToolComponent: React.FC<IToolTileProps> = observer(({
     onSetTableTitle, onRequestUniqueTitle: handleRequestUniqueTitle
   });
 
-  useToolApi({ metadata, getTitle, getContentHeight, onRegisterToolApi, onUnregisterToolApi });
+  const exportContentAsTileJson = useJsonExport(() => getContent().metadata, dataSet);
+  useToolApi({ metadata, getTitle, getContentHeight, exportContentAsTileJson,
+                onRegisterToolApi, onUnregisterToolApi });
 
   const rowLabelProps = useRowLabelColumn({
     inputRowId: inputRowId.current, selectedCell, showRowLabels, setShowRowLabels

--- a/src/components/tools/table-tool/use-content-change-handlers.ts
+++ b/src/components/tools/table-tool/use-content-change-handlers.ts
@@ -2,9 +2,8 @@ import { useCallback } from "react";
 import { useCurrent } from "../../../hooks/use-current";
 import { ICase, ICaseCreation, IDataSet } from "../../../models/data/data-set";
 import { getGeometryContent } from "../../../models/tools/geometry/geometry-content";
-import {
-  getTableContentHeight, ILinkProperties, ITableChange, TableContentModelType
-} from "../../../models/tools/table/table-content";
+import { ILinkProperties, ITableChange } from "../../../models/tools/table/table-change";
+import { getTableContentHeight, TableContentModelType } from "../../../models/tools/table/table-content";
 import { isLinkableValue, ITileLinkMetadata } from "../../../models/tools/table/table-model-types";
 import { ToolTileModelType } from "../../../models/tools/tool-tile";
 import { safeJsonParse, uniqueId, uniqueName } from "../../../utilities/js-utils";

--- a/src/components/tools/table-tool/use-json-export.ts
+++ b/src/components/tools/table-tool/use-json-export.ts
@@ -1,0 +1,39 @@
+import { IDataSet } from "../../../models/data/data-set";
+import { TableMetadataModelType } from "../../../models/tools/table/table-content";
+
+export const useJsonExport = (
+  getMetadata: () => TableMetadataModelType, dataSetRef: React.MutableRefObject<IDataSet>
+) => {
+  return () => {
+    const metadata = getMetadata();
+    const dataSet = dataSetRef.current;
+    const columns = dataSet.attributes.map((attr, attrIndex, attrs) => {
+      const id = attr.id;
+      const expression = metadata.expressions.get(id);
+      const rawExpression = metadata.rawExpressions.get(id);
+      const hasExpression = !!expression || !!rawExpression;
+      const values: (string | number)[] = [];
+      if (!hasExpression) {
+        for (let i = 0; i < dataSet.cases.length; ++i) {
+          const value = dataSet.getValueAtIndex(i, attr.id);
+          values.push(value != null ? value : "");
+        }
+      }
+      return `    ${JSON.stringify({
+        name: attr.name,
+        expression,
+        rawExpression,
+        values: values.length ? values : undefined
+      })}${attrIndex < attrs.length - 1 ? "," : ""}`;
+    });
+    return [
+      `{`,
+      `  "type": "Table",`,
+      `  "name": "${dataSet.name}",`,
+      `  "columns": [`,
+      ...columns,
+      `  ]`,
+      `}`
+    ].join("\n");
+  };
+};

--- a/src/components/tools/table-tool/use-tool-api.ts
+++ b/src/components/tools/table-tool/use-tool-api.ts
@@ -8,16 +8,18 @@ interface IProps {
   metadata: TableMetadataModelType;
   getTitle: () => string | undefined;
   getContentHeight: () => number | undefined;
+  exportContentAsTileJson: () => string;
   onRegisterToolApi: (toolApi: IToolApi, facet?: string | undefined) => void;
   onUnregisterToolApi: (facet?: string | undefined) => void;
 }
 export const useToolApi = ({
-  metadata, getTitle, getContentHeight, onRegisterToolApi, onUnregisterToolApi
+  metadata, getTitle, getContentHeight, exportContentAsTileJson, onRegisterToolApi, onUnregisterToolApi
 }: IProps) => {
   const metadataRef = useCurrent(metadata);
   const toolApi: IToolApi = useMemo(() => ({
     getTitle,
     getContentHeight,
+    exportContentAsTileJson,
     isLinked: () => {
       return metadataRef.current.isLinked;
     },
@@ -26,7 +28,7 @@ export const useToolApi = ({
               ? getLinkedTableIndex(metadataRef.current.id)
               : -1;
     }
-  }), [getContentHeight, getTitle, metadataRef]);
+  }), [exportContentAsTileJson, getContentHeight, getTitle, metadataRef]);
 
   useEffect(() => {
     onRegisterToolApi(toolApi);

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -8,7 +8,7 @@ import { ProblemModelType } from "../models/curriculum/problem";
 import { DocumentModelType } from "../models/document/document";
 import { JXGChange } from "../models/tools/geometry/jxg-changes";
 import { DrawingToolChange } from "../models/tools/drawing/drawing-content";
-import { ITableChange } from "../models/tools/table/table-content";
+import { ITableChange } from "../models/tools/table/table-change";
 import { ENavTab } from "../models/view/nav-tabs";
 import { DEBUG_LOGGER } from "../lib/debug";
 

--- a/src/models/data/data-set.ts
+++ b/src/models/data/data-set.ts
@@ -209,6 +209,9 @@ export const DataSet = types.model("DataSet", {
       caseIndexFromID(id: string) {
         return caseIDMap[id];
       },
+      caseIDFromIndex(index: number) {
+        return getCaseAtIndex(index)?.__id__;
+      },
       nextCaseID(id: string) {
         const index = caseIDMap[id],
               nextCase = (index != null) && (index < self.cases.length - 1)
@@ -218,6 +221,10 @@ export const DataSet = types.model("DataSet", {
       getValue(caseID: string, attributeID: string) {
         const attr = attrIDMap[attributeID],
               index = caseIDMap[caseID];
+        return attr && (index != null) ? attr.value(index) : undefined;
+      },
+      getValueAtIndex(index: number, attributeID: string) {
+        const attr = attrIDMap[attributeID];
         return attr && (index != null) ? attr.value(index) : undefined;
       },
       getCase(caseID: string): ICase | undefined {

--- a/src/models/tools/geometry/geometry-content.ts
+++ b/src/models/tools/geometry/geometry-content.ts
@@ -5,9 +5,10 @@ import { SelectionStoreModelType } from "../../stores/selection";
 import { addLinkedTable, removeLinkedTable } from "../table-links";
 import { registerToolContentInfo } from "../tool-content-info";
 import {
-  getAxisLabelsFromDataSet, getRowLabelFromLinkProps, getTableContent, IColumnProperties,
-  ICreateRowsProperties, IRowProperties, ITableChange, ITableLinkProperties, kLabelAttrName
-} from "../table/table-content";
+  getRowLabelFromLinkProps, IColumnProperties, ICreateRowsProperties, IRowProperties,
+  ITableChange, ITableLinkProperties
+} from "../table/table-change";
+import { getAxisLabelsFromDataSet, getTableContent, kLabelAttrName } from "../table/table-content";
 import { canonicalizeValue, linkedPointId } from "../table/table-model-types";
 import { getAxisAnnotations, getBaseAxisLabels, getObjectById, guessUserDesiredBoundingBox,
           kAxisBuffer, kGeometryDefaultAxisMin, kGeometryDefaultHeight, kGeometryDefaultWidth,
@@ -308,7 +309,7 @@ export const GeometryContentModel = types
       const linkedTiles = lastChangeLinks ? lastChangeLinks.tileIds : undefined;
       const linkedTile = linkedTiles && linkedTiles[0];
       const tableContent = linkedTile ? getTableContent(self, linkedTile) : undefined;
-      return tableContent ? tableContent.canUndoLinkedChange(lastChangeParsed) : false;
+      return tableContent ? tableContent.canUndoLinkedChange(/*lastChangeParsed*/) : false;
     },
     canUndoLinkedChange(change: ITableChange) {
       const hasUndoableChanges = self.changes.length > 1;

--- a/src/models/tools/geometry/jxg-board.ts
+++ b/src/models/tools/geometry/jxg-board.ts
@@ -1,9 +1,9 @@
+import { assign, each, find } from "lodash";
 import "./jxg";
 import { JXGChange, JXGChangeAgent, JXGProperties } from "./jxg-changes";
 import { isAxis, isBoard, isLinkedPoint, isPoint } from "./jxg-types";
 import { goodTickValue } from "../../../utilities/graph-utils";
-import { assign, each, find } from "lodash";
-import { ITableLinkProperties } from "../table/table-content";
+import { ITableLinkProperties } from "../table/table-change";
 
 const kScalerClasses = ["canvas-scaler", "scaled-list-item"];
 

--- a/src/models/tools/geometry/jxg-changes.ts
+++ b/src/models/tools/geometry/jxg-changes.ts
@@ -1,4 +1,6 @@
 import { castArray } from "lodash";
+import { ILinkProperties, ITableLinkProperties } from "../table-links";
+export { ILinkProperties, ITableLinkProperties };
 
 export type JXGOperation = "create" | "update" | "delete";
 export type JXGObjectType = "board" | "comment" | "image" | "linkedPoint" | "metadata" | "movableLine" |
@@ -27,11 +29,6 @@ export interface JXGProperties {
   unitX?: number;
   unitY?: number;
   [key: string]: any;
-}
-
-export interface ILinkProperties {
-  id: string;
-  tileIds: string[];
 }
 
 export interface JXGChange {

--- a/src/models/tools/geometry/jxg-object.ts
+++ b/src/models/tools/geometry/jxg-object.ts
@@ -1,7 +1,6 @@
 import { sortByCreation, kReverse, getObjectById, syncLinkedPoints } from "./jxg-board";
-import { JXGChangeAgent, JXGProperties, JXGCoordPair, JXGUnsafeCoordPair } from "./jxg-changes";
+import { ITableLinkProperties, JXGChangeAgent, JXGProperties, JXGCoordPair, JXGUnsafeCoordPair } from "./jxg-changes";
 import { isLinkedPoint, isText } from "./jxg-types";
-import { ITableLinkProperties } from "../table/table-content";
 import { castArrayCopy } from "../../../utilities/js-utils";
 import { castArray, size } from "lodash";
 

--- a/src/models/tools/geometry/jxg-table-link.ts
+++ b/src/models/tools/geometry/jxg-table-link.ts
@@ -1,8 +1,7 @@
 import { syncLinkedPoints } from "./jxg-board";
-import { ILinkProperties, JXGChange, JXGChangeAgent, JXGCoordPair } from "./jxg-changes";
+import { ILinkProperties, ITableLinkProperties, JXGChange, JXGChangeAgent, JXGCoordPair } from "./jxg-changes";
 import { createPoint, pointChangeAgent } from "./jxg-point";
 import { isPoint } from "./jxg-types";
-import { ITableLinkProperties } from "../table/table-content";
 import { splitLinkedPointId } from "../table/table-model-types";
 
 export function getTableIdFromLinkChange(change: JXGChange) {

--- a/src/models/tools/table-links.ts
+++ b/src/models/tools/table-links.ts
@@ -3,8 +3,31 @@ import { IObservableArray, observable } from "mobx";
 // cf. https://mattferderer.com/use-sass-variables-in-typescript-and-javascript
 import styles from "./table-links.scss";
 
+export interface ILinkProperties {
+  id: string;
+  tileIds: string[];
+}
+
+export interface IRowLabel {
+  id: string;
+  label: string;
+}
+
+export interface ITableLinkProperties extends ILinkProperties {
+  // labels should be included when adding/removing rows,
+  // so that clients can synchronize any label changes
+  labels?: IRowLabel[];
+}
+
+export function getRowLabelFromLinkProps(links: ITableLinkProperties, rowId: string) {
+  const found = links.labels?.find(entry => entry.id === rowId);
+  return found?.label;
+}
+
+// map from tableId to documentId
 const sTableDocumentMap: Map<string, string> = new Map();
 type LinkedTableIds = IObservableArray<string>;
+// map from documentId to array of linked tableIds
 const sDocumentLinkedTables: Map<string, LinkedTableIds> = new Map();
 
 export function getTableDocument(tableId: string) {

--- a/src/models/tools/table/table-change.ts
+++ b/src/models/tools/table/table-change.ts
@@ -1,0 +1,46 @@
+import { getRowLabelFromLinkProps, ILinkProperties, IRowLabel, ITableLinkProperties } from "../table-links";
+export { getRowLabelFromLinkProps, ILinkProperties, IRowLabel, ITableLinkProperties };
+
+export interface IColumnProperties {
+  name?: string;
+  expression?: string;
+  rawExpression?: string;
+}
+
+export interface IColumnCreationProperties extends IColumnProperties {
+  id?: string;
+  name: string;
+}
+
+export interface ICreateColumnsProperties {
+  columns?: IColumnCreationProperties[];
+}
+
+export type IUpdateColumnsProperties = IColumnProperties | IColumnProperties[];
+
+export interface IUpdateTableProperties {
+  name?: string;
+}
+export interface ICreateTableProperties extends IUpdateTableProperties, ICreateColumnsProperties {
+}
+
+export type IRowProperties = Record<string, string | number | null | undefined>;
+
+export interface ICreateRowsProperties {
+  rows: IRowProperties[];
+  beforeId?: string | string[];
+}
+
+export type IUpdateRowsProperties = IRowProperties | IRowProperties[];
+
+export type ITableChangeProperties = ICreateTableProperties | IUpdateTableProperties |
+                                      ICreateColumnsProperties | IUpdateColumnsProperties |
+                                      ICreateRowsProperties | IUpdateRowsProperties;
+
+export interface ITableChange {
+  action: "create" | "update" | "delete";
+  target: "table" | "rows" | "columns" | "geometryLink";
+  ids?: string | string[];
+  props?: ITableChangeProperties;
+  links?: ILinkProperties;
+}

--- a/src/utilities/omit-deep.ts
+++ b/src/utilities/omit-deep.ts
@@ -1,0 +1,28 @@
+// cf. https://github.com/lodash/lodash/issues/723#issuecomment-677383457
+const omitDeep = (input: Record<string, unknown>, excludes: string[]): Record<string, unknown> => {
+  return Object.entries(input).reduce((nextInput, [key, value]) => {
+    const shouldExclude = excludes.includes(key);
+    if (shouldExclude) return nextInput;
+
+    if (Array.isArray(value)) {
+      const arrValue = value;
+      const nextValue = arrValue.map((arrItem) => {
+        if (arrItem && typeof arrItem === "object") {
+          return omitDeep(arrItem, excludes);
+        }
+        return arrItem;
+      });
+      nextInput[key] = nextValue;
+      return nextInput;
+    } else if (value && typeof value === "object") {
+      nextInput[key] = omitDeep(value as Record<string, unknown>, excludes);
+      return nextInput;
+    }
+
+    nextInput[key] = value;
+
+    return nextInput;
+  }, {} as Record<string, unknown>);
+};
+
+export default omitDeep;


### PR DESCRIPTION
- Extend table import format to support expressions
- Implement `exportContentAsTileJson()` to support JSON export
- Add unit tests
- Improve/refactor table types

[[#176874316]](https://www.pivotaltracker.com/story/show/176874316)