### PR TITLE
Make `safeJsonParse()` type-safe

### DIFF
--- a/src/components/document/document-content.tsx
+++ b/src/components/document/document-content.tsx
@@ -403,9 +403,7 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
     const { ui } = this.stores;
 
     const createTileInfoStr = e.dataTransfer.getData(kDragTileCreate);
-    const createTileInfo = createTileInfoStr
-                            ? safeJsonParse(createTileInfoStr) as IDragToolCreateInfo
-                            : undefined;
+    const createTileInfo = safeJsonParse<IDragToolCreateInfo>(createTileInfoStr);
     if (!content || !createTileInfo) return;
 
     const { tool, title } = createTileInfo;

--- a/src/components/tools/table-tool/use-content-change-handlers.ts
+++ b/src/components/tools/table-tool/use-content-change-handlers.ts
@@ -53,7 +53,7 @@ export const useContentChangeHandlers = ({
 
   const syncChangeToLinkedClient = useCallback((clientTileId: string, linkId: string) => {
     const tableContent = getContent();
-    const lastChange: ITableChange | undefined = safeJsonParse(tableContent.changes[tableContent.changes.length - 1]);
+    const lastChange = safeJsonParse<ITableChange>(tableContent.changes[tableContent.changes.length - 1]);
     // eventually we'll presumably need to support other clients
     const clientContent = getGeometryContent(getContent(), clientTileId);
     // link information attached to individual client changes/actions

--- a/src/components/tools/use-image-content-url.ts
+++ b/src/components/tools/use-image-content-url.ts
@@ -12,7 +12,8 @@ export function useImageContentUrl(content: ImageContentModelType, onUrlChange: 
   useEffect(() => {
     const dispose = autorun(() => {
       if (content.changeCount > syncedChanges.current) {
-        onUrlChange(content.url, context);
+        const url = content.url;
+        url && onUrlChange(url, context);
         syncedChanges.current = content.changeCount;
       }
     });

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -723,8 +723,8 @@ export class DB {
     });
   }
 
-  public parseDocumentContent(document: DBDocument): DocumentContentSnapshotType|undefined {
-    return safeJsonParse(document.content);
+  public parseDocumentContent(document: DBDocument) {
+    return safeJsonParse<DocumentContentSnapshotType>(document.content);
   }
 
   public addImage(imageModel: ImageModelType) {

--- a/src/models/tools/drawing/drawing-content.ts
+++ b/src/models/tools/drawing/drawing-content.ts
@@ -240,8 +240,8 @@ export const DrawingContentModel = types
           // identify change entries to be modified
           const updates: Array<{ index: number, change: string }> = [];
           self.changes.forEach((changeJson, index) => {
-            const change: DrawingToolChange = safeJsonParse(changeJson);
-            switch (change && change.action) {
+            const change = safeJsonParse<DrawingToolChange>(changeJson);
+            switch (change?.action) {
               case "create": {
                 const createData = change.data as DrawingObjectDataType;
                 if ((createData.type === "image") && (createData.url === oldUrl)) {

--- a/src/models/tools/geometry/geometry-content.ts
+++ b/src/models/tools/geometry/geometry-content.ts
@@ -301,12 +301,12 @@ export const GeometryContentModel = types
       const hasUndoableChanges = self.changes.length > 1;
       if (!hasUndoableChanges) return false;
       const lastChange = hasUndoableChanges ? self.changes[self.changes.length - 1] : undefined;
-      const lastChangeParsed: JXGChange = lastChange && safeJsonParse(lastChange);
-      if (!isUndoableChange(lastChangeParsed)) return false;
-      const lastChangeLinks = lastChangeParsed && lastChangeParsed.links;
+      const lastChangeParsed = safeJsonParse<JXGChange>(lastChange);
+      if (!lastChangeParsed || !isUndoableChange(lastChangeParsed)) return false;
+      const lastChangeLinks = lastChangeParsed.links;
       if (!lastChangeLinks) return true;
-      const linkedTiles = lastChangeLinks ? lastChangeLinks.tileIds : undefined;
-      const linkedTile = linkedTiles && linkedTiles[0];
+      const linkedTiles = lastChangeLinks.tileIds;
+      const linkedTile = linkedTiles?.[0];
       const tableContent = linkedTile ? getTableContent(self, linkedTile) : undefined;
       return tableContent ? tableContent.canUndoLinkedChange(lastChangeParsed) : false;
     },
@@ -314,11 +314,11 @@ export const GeometryContentModel = types
       const hasUndoableChanges = self.changes.length > 1;
       if (!hasUndoableChanges) return false;
       const lastChange = hasUndoableChanges ? self.changes[self.changes.length - 1] : undefined;
-      const lastChangeParsed = lastChange && safeJsonParse(lastChange);
-      const lastChangeLinks = lastChangeParsed && lastChangeParsed.links;
+      const lastChangeParsed = safeJsonParse<JXGChange>(lastChange);
+      const lastChangeLinks = lastChangeParsed?.links;
       if (!lastChangeLinks) return false;
-      const geometryActionLinkId = lastChangeLinks && lastChangeLinks.id;
-      const tableActionLinkId = change.links && change.links.id;
+      const geometryActionLinkId = lastChangeLinks.id;
+      const tableActionLinkId = change.links?.id;
       return geometryActionLinkId && tableActionLinkId && (geometryActionLinkId === tableActionLinkId);
     }
   }))
@@ -561,14 +561,14 @@ export const GeometryContentModel = types
           // earlier changes go earlier in the array to maintain order
           changes.unshift(changeStr);
 
-          let change = safeJsonParse(changeStr);
-          if (change.endBatch) {
+          let change = safeJsonParse<JXGChange>(changeStr);
+          if (change?.endBatch) {
             while (change && !change.startBatch) {
               changeStr = self.changes.pop();
               if (changeStr) {
                 changes.unshift(changeStr);
               }
-              change = safeJsonParse(changeStr);
+              change = safeJsonParse<JXGChange>(changeStr);
             }
           }
         }
@@ -894,13 +894,15 @@ export const GeometryContentModel = types
       selectedIds.forEach(id => { properties[id] = {}; });
 
       self.changes.forEach(chg => {
-        const parsedChange: JXGChange = safeJsonParse(chg);
-        forEachNormalizedChange(parsedChange, change => {
-          const id = change.targetID as string;
-          if (id && properties[id]) {
-            assign(properties[id], omit(change.properties, ["position"]));
-          }
-        });
+        const parsedChange = safeJsonParse<JXGChange>(chg);
+        if (parsedChange) {
+          forEachNormalizedChange(parsedChange, change => {
+            const id = change.targetID;
+            if (id && properties[id]) {
+              assign(properties[id], omit(change.properties, ["position"]));
+            }
+          });
+        }
       });
       return properties;
     }
@@ -1092,7 +1094,7 @@ export const GeometryContentModel = types
         getLastImageUrl(): string | undefined{
           for (let i = self.changes.length - 1; i >= 0; --i) {
             const jsonChange = self.changes[i];
-            const change: JXGChange = safeJsonParse(jsonChange);
+            const change = safeJsonParse<JXGChange>(jsonChange);
             const imageUrl = getImageUrl(change);
             if (imageUrl) {
               return imageUrl;
@@ -1141,8 +1143,8 @@ export const GeometryContentModel = types
           // identify change entries to be modified
           const updates: Array<{ index: number, change: string }> = [];
           self.changes.forEach((changeJson, index) => {
-            const change: JXGChange = safeJsonParse(changeJson);
-            switch (change && change.operation) {
+            const change = safeJsonParse<JXGChange>(changeJson);
+            switch (change?.operation) {
               case "create":
                 if (change.parents) {
                   const createUrl = change.parents[0];
@@ -1510,13 +1512,13 @@ function preprocessImportFormat(snapshot: any) {
 export function mapTileIdsInGeometrySnapshot(snapshot: SnapshotOut<GeometryContentModelType>,
                                              idMap: { [id: string]: string }) {
   snapshot.changes = snapshot.changes.map((changeJson: any) => {
-    const change: JXGChange = safeJsonParse(changeJson);
-    if ((change.target === "tableLink") && change.targetID) {
+    const change = safeJsonParse<JXGChange>(changeJson);
+    if ((change?.target === "tableLink") && change.targetID) {
       change.targetID = Array.isArray(change.targetID)
                           ? change.targetID.map(id => idMap[id])
                           : idMap[change.targetID];
     }
-    if (change.links) {
+    if (change?.links) {
       change.links.tileIds = change.links.tileIds.map(id => idMap[id]);
     }
     return JSON.stringify(change);

--- a/src/models/tools/geometry/jxg-changes.ts
+++ b/src/models/tools/geometry/jxg-changes.ts
@@ -41,6 +41,8 @@ export interface JXGChange {
   parents?: JXGParentType[];
   properties?: JXGProperties | JXGProperties[];
   links?: ILinkProperties;
+  startBatch?: boolean;
+  endBatch?: boolean;
 }
 
 export interface JXGNormalizedChange {

--- a/src/models/tools/image/image-content.ts
+++ b/src/models/tools/image/image-content.ts
@@ -49,7 +49,7 @@ export const ImageContentModel = types
     get url() {
       if (!self.changes.length) return;
       const lastChangeJson = self.changes[self.changes.length - 1];
-      const lastChange = safeJsonParse(lastChangeJson);
+      const lastChange = safeJsonParse<ImageToolChange>(lastChangeJson);
       return lastChange?.url;
     }
   }))
@@ -67,8 +67,8 @@ export const ImageContentModel = types
       // identify change entries to be modified
       const updates: Array<{ index: number, change: string }> = [];
       self.changes.forEach((changeJson, index) => {
-        const change: ImageToolChange = safeJsonParse(changeJson);
-        switch (change && change.operation) {
+        const change = safeJsonParse<ImageToolChange>(changeJson);
+        switch (change?.operation) {
           case "update":
             if (change.url && (change.url === oldUrl)) {
               change.url = newUrl;

--- a/src/utilities/image-utils.ts
+++ b/src/utilities/image-utils.ts
@@ -1,6 +1,6 @@
 import { DB } from "../lib/db";
 import { ImageModelType, ImageModel } from "../models/image";
-import { ImageContentSnapshotOutType } from "../models/tools/image/image-content";
+import { ImageContentSnapshotOutType, ImageToolChange } from "../models/tools/image/image-content";
 import { safeJsonParse } from "./js-utils";
 import placeholderImage from "../assets/image_placeholder.png";
 import orgPlaceholderImage from "../assets/image_placeholder_org.png";
@@ -37,8 +37,8 @@ export function isPlaceholderImage(url?: string) {
 export function getUrlFromImageContent(content: ImageContentSnapshotOutType) {
   const changes = content.changes;
   for (let i = changes.length - 1; i >= 0; --i) {
-    const change = safeJsonParse(changes[i]);
-    const url = change && change.url ? change.url as string : undefined;
+    const change = safeJsonParse<ImageToolChange>(changes[i]);
+    const url = change?.url;
     if (url) return url;
   }
 }

--- a/src/utilities/js-utils.ts
+++ b/src/utilities/js-utils.ts
@@ -32,10 +32,10 @@ export function safeDecodeURI(uriOrComponent: string) {
  *
  * returns undefined on error rather than throwing an exception
  */
-export function safeJsonParse(json?: string) {
+export function safeJsonParse<T = any>(json?: string) {
   let parsed;
   try {
-    parsed = json ? JSON.parse(json) : undefined;
+    parsed = json ? JSON.parse(json) as T: undefined;
   }
   catch (e) {
     // swallow errors


### PR DESCRIPTION
In working on the export capability for geometry tiles, I am frequently working with the changes array, which involves parsing JSON (because the changes are `JSON.stringify`ed). `JSON.parse()` is inherently not type-safe, as its return value is `any` and it throws an exception if it encounters anything it doesn't recognize. We have our own `safeJsonParse()` utility function which converts the exception into an `undefined` return value but doesn't do anything to address the lack of type-safety. A common usage pattern for `safeJsonParse()` looks something like:
```typescript
  const foo = safeJsonParse(fooJson) as Foo;
```

This has the advantage of providing type information immediately, but unfortunately it loses the fact that `undefined` is a possible return value. Thus,
```typescript
  const foo = safeJsonParse(fooJson) as Foo | undefined;
```
would be more accurate, but it's easy to forget that, which just indicates that type-safe use of `safeJsonParse()` is error-prone at best and non-existent at worst.

With this PR we add a generic type parameter to `safeJsonParse()` so that the preceding can be written as:
```typescript
  const foo = safeJsonParse<Foo>(fooJson);
```
which maintains proper type-safety. Further, this PR also visits most uses of `safeJsonParse()` to update to the type-safe usage. In many cases this is just a syntactic change with no other code change required, but in others the possibility of an `undefined` return value was not being handled correctly and so minor code changes were required to account for that possibility.

Rather than rolling these changes into the geometry export PR I thought it made sense to handle them separately.