### PR TITLE
Fix table/graph title incrementing [#177273772]

### DIFF
--- a/cypress/integration/clue/branch/teacher_tests/teacher_dashboard_spec.js
+++ b/cypress/integration/clue/branch/teacher_tests/teacher_dashboard_spec.js
@@ -84,8 +84,8 @@ context('Teacher Dashboard View', () => {
       dashboard.getNextPageButton().should('be.visible').and('not.have.class', 'disabled');
     });
   });
-  describe.skip('Header element functionality', () => {
-    it('verify dashboard/workspace switch changes workspace view', () => {
+  describe('Header element functionality', () => {
+    it.skip('verify dashboard/workspace switch changes workspace view', () => {
       dashboard.getViewToggle('Dashboard').should('be.visible').and('have.class', 'selected');
       clueCanvas.getSingleWorkspace().should('not.exist');
       dashboard.getViewToggle('Workspace').should('be.visible').and('not.have.class', 'selected');
@@ -217,7 +217,7 @@ context('Teacher Dashboard View', () => {
       dashboard.sendStudentNote(group, studentName, quadrant, textToStudent);
     });
 
-    it('verify student support note appears in student view', function () {
+    it.skip('verify student support note appears in student view', function () {
       cy.visit('/?appMode=demo&demoName=CLUE-Test&fakeClass=5&fakeOffering=5&problem=2.1&fakeUser=student:1&qaGroup=1');
       cy.wait(5000);
       cy.get('#icon-sticky-note').should('exist').click({force:true});

--- a/src/components/document/canvas.tsx
+++ b/src/components/document/canvas.tsx
@@ -4,7 +4,9 @@ import React from "react";
 import { DocumentContentComponent } from "./document-content";
 import { DocumentModelType } from "../../models/document/document";
 import { DocumentContentModelType } from "../../models/document/document-content";
-import { IToolApiMap, IToolApiInterface, IToolApi, ToolApiInterfaceContext } from "../tools/tool-api";
+import {
+  IToolApi, IToolApiInterface, IToolApiMap, ToolApiInterfaceContext, EditableToolApiInterfaceRefContext
+} from "../tools/tool-api";
 import { DEBUG_CANVAS } from "../../lib/debug";
 
 import "./canvas.sass";
@@ -29,6 +31,9 @@ export class CanvasComponent extends React.Component<IProps> {
   private toolApiMap: IToolApiMap = {};
   private toolApiInterface: IToolApiInterface;
 
+  static contextType = EditableToolApiInterfaceRefContext;
+  declare context: React.ContextType<typeof EditableToolApiInterfaceRefContext>;
+
   constructor(props: IProps) {
     super(props);
 
@@ -49,6 +54,10 @@ export class CanvasComponent extends React.Component<IProps> {
   }
 
   public render() {
+    if (this.context && !this.props.readOnly) {
+      // update the editable api interface used by the toolbar
+      this.context.current = this.toolApiInterface;
+    }
     return (
       <ToolApiInterfaceContext.Provider value={this.toolApiInterface}>
         <div key="canvas" className="canvas" data-test="canvas">

--- a/src/components/document/editable-document-content.tsx
+++ b/src/components/document/editable-document-content.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useContext, useRef } from "react";
 import { AppConfigContext } from "../../app-config-context";
 import { CanvasComponent } from "./canvas";
 import { DocumentContextReact } from "./document-context";
@@ -6,6 +6,7 @@ import { FourUpComponent } from "../four-up";
 import { useDocumentContext } from "../../hooks/use-document-context";
 import { useGroupsStore } from "../../hooks/use-stores";
 import { ToolbarComponent, ToolbarConfig } from "../toolbar";
+import { EditableToolApiInterfaceRef, EditableToolApiInterfaceRefContext } from "../tools/tool-api";
 import { DocumentModelType } from "../../models/document/document";
 import { ProblemDocument } from "../../models/document/document-types";
 import { WorkspaceMode } from "../../models/stores/workspace";
@@ -76,16 +77,21 @@ export const EditableDocumentContent: React.FC<IProps> = props => {
 
   const documentContext = useDocumentContext(document);
 
+  // set by the canvas and used by the toolbar
+  const editableToolApiInterfaceRef: EditableToolApiInterfaceRef = useRef(null);
+
   const isReadOnly = !isPrimary || readOnly || document.isPublished;
   const isShowingToolbar = !!toolbar && !isReadOnly;
   const showToolbarClass = isShowingToolbar ? "show-toolbar" : "hide-toolbar";
   return (
     <DocumentContextReact.Provider value={documentContext}>
-      <div key="editable-document" className={`editable-document-content ${showToolbarClass}`} >
-        {isShowingToolbar && <DocumentToolbar document={document} toolbar={toolbar} />}
-        {isShowingToolbar && <div className="canvas-separator"/>}
-        <DocumentCanvas mode={mode} isPrimary={isPrimary} document={document} readOnly={isReadOnly} />
-      </div>
+      <EditableToolApiInterfaceRefContext.Provider value={editableToolApiInterfaceRef}>
+        <div key="editable-document" className={`editable-document-content ${showToolbarClass}`} >
+          {isShowingToolbar && <DocumentToolbar document={document} toolbar={toolbar} />}
+          {isShowingToolbar && <div className="canvas-separator"/>}
+          <DocumentCanvas mode={mode} isPrimary={isPrimary} document={document} readOnly={isReadOnly} />
+        </div>
+      </EditableToolApiInterfaceRefContext.Provider>
     </DocumentContextReact.Provider>
   );
 };

--- a/src/components/toolbar.tsx
+++ b/src/components/toolbar.tsx
@@ -8,7 +8,7 @@ import { DocumentModelType, DocumentTool } from "../models/document/document";
 import { IDocumentContentAddTileOptions, IDragToolCreateInfo } from "../models/document/document-content";
 import { getToolContentInfoByTool, IToolContentInfo } from "../models/tools/tool-content-info";
 import { ToolButtonSnapshot } from "../models/tools/tool-types";
-import { ToolApiInterfaceContext } from "./tools/tool-api";
+import { EditableToolApiInterfaceRefContext } from "./tools/tool-api";
 import { kDragTileCreate  } from "./tools/tool-tile";
 
 import "./toolbar.sass";
@@ -90,8 +90,8 @@ const ToolButtonComponent: React.FC<IButtonProps> =
 @observer
 export class ToolbarComponent extends BaseComponent<IProps, IState> {
 
-  static contextType = ToolApiInterfaceContext;
-  declare context: React.ContextType<typeof ToolApiInterfaceContext>;
+  static contextType = EditableToolApiInterfaceRefContext;
+  declare context: React.ContextType<typeof EditableToolApiInterfaceRefContext>;
 
   state = {
     defaultTool: "",
@@ -161,7 +161,8 @@ export class ToolbarComponent extends BaseComponent<IProps, IState> {
   }
 
   private getUniqueTitle(toolContentInfo: IToolContentInfo) {
-    const toolApiInterface = this.context;
+    const toolApiInterface = this.context?.current;
+    if (!toolApiInterface) return;
     const { document } = this.props;
     const { id, titleBase } = toolContentInfo;
     const getTileTitle = (tileId: string) => toolApiInterface?.getToolApi(tileId)?.getTitle?.();
@@ -189,7 +190,8 @@ export class ToolbarComponent extends BaseComponent<IProps, IState> {
   }
 
   private handleDelete() {
-    const toolApiInterface = this.context;
+    const toolApiInterface = this.context?.current;
+    if (!toolApiInterface) return;
     const { document } = this.props;
     const { ui } = this.stores;
     ui.selectedTileIds.forEach(tileId => {

--- a/src/components/tools/tool-api.tsx
+++ b/src/components/tools/tool-api.tsx
@@ -25,3 +25,7 @@ export interface IToolApiInterface {
 export type IToolApiMap = Record<string, IToolApi>;
 
 export const ToolApiInterfaceContext = createContext<IToolApiInterface | null>(null);
+
+// set by the canvas and used by the toolbar
+export type EditableToolApiInterfaceRef = React.MutableRefObject<IToolApiInterface | null>;
+export const EditableToolApiInterfaceRefContext = createContext<EditableToolApiInterfaceRef | null>(null);


### PR DESCRIPTION
[[#177273772]](https://www.pivotaltracker.com/story/show/177273772)

The unique titling is mediated by the document's `ToolApiInterface`, which is made available to clients via React context. In the original implementation, tiles were created without titles and then were given dynamically generated titles when instantiated. If users didn't explicitly edit the title, however, this dynamically generated title was not saved, which meant that the same tile might get a different dynamically generated title the next time the same document was opened.

Recently, this mechanism was enhanced so that newly created tiles would get a persistent unique title on creation (in theory) rather than waiting for it to be dynamically generated at instantiation time. As a result, a given tile would be able to retain its unique title on every opening of the document. Unfortunately, the Toolbar (which provides the UI for the creation of new tiles) was not in a part of the React component tree that has access to the `ToolApiInterface` context, which resulted in the failure of the unique titling. 🤦

The fix here is to create another piece of React context that encompasses more of the React component tree and which allows the Canvas (which creates the `ToolApiInterface`) to set it so that the Toolbar can access it, which fixes the unique titling on tile creation.

Looking at the history, earlier the `ToolApiInterface` was only available in editable documents. This meant that tiles in curriculum content weren't given unique titles. To fix that, we recently made the change to create the `ToolApiInterface` in the Canvas and distribute it to all tiles (editable or not) via React context. It was in this transition that we inadvertently broke unique titling for editable documents due to the Toolbar not having access to the necessary context.