### PR TITLE
Add logging of monitoring/unmonitoring user documents

### DIFF
--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -326,7 +326,7 @@ export class Firebase {
         userRef.child("connectedTimestamp").set(firebase.database.ServerValue.TIMESTAMP);
       }
       else {
-        // since the Logger currenly had no retry this won't be logged on a general network
+        // since the Logger currently has no retry this won't be logged on a general network
         // disconnect but might be helpful to know if only Firebase disconnected
         Logger.log(LogEventName.INTERNAL_FIREBASE_DISCONNECTED);
       }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -89,6 +89,8 @@ export enum LogEventName {
   // the following are for potential debugging purposes and are all marked "internal"
   INTERNAL_AUTHENTICATED,
   INTERNAL_FIREBASE_DISCONNECTED,
+  INTERNAL_MONITOR_DOCUMENT,
+  INTERNAL_UNMONITOR_DOCUMENT,
 
   DASHBOARD_SWITCH_CLASS,
   DASHBOARD_SWITCH_PROBLEM,


### PR DESCRIPTION
This is primarily for debugging purposes. We have had two recent reports of users being able to work locally without incident while their efforts are not saved to firebase. The mechanism by which this is supposed to happen is that we monitor the user's document such that any changes trigger a save to firebase. The reported symptoms are consistent with a failure of this monitoring mechanism, so we log it in hopes of learning something.