### PR TITLE
Temporary workaround for images copied from multi-class supports

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -773,7 +773,10 @@ export class DB {
 
   public getImageBlob(imageKey: string) {
     return this.getImage(imageKey)
-            .then(image => fetch(image.imageData))
+            .then(image => {
+              if (!image) throw new Error("Error: getImageBlob received invalid image!");
+              return fetch(image.imageData);
+            })
             .then(response => response.blob())
             .then(blob => URL.createObjectURL(blob));
   }


### PR DESCRIPTION
[[#175500575]](https://www.pivotaltracker.com/story/show/175500575)

This allows images copied from multi-class teacher supports to user documents to load successfully rather than showing the loading spinner indefinitely. I consider this to be a workaround rather than a proper fix because it doesn't prevent the initial error from occurring, which results in a console error and a Rollbar error report. It merely patches over the error from the user's perspective after the fact. But in the near term, it's an improvement in the user experience and so seems worth it until we find time to address the underlying issue.