### PR TITLE
Firebase/network status monitoring

### DIFF
--- a/s3_deploy.sh
+++ b/s3_deploy.sh
@@ -93,7 +93,7 @@ mv $SRC_DIR $DEPLOY_DEST
 
 # deploy the site contents
 echo Deploying "$BRANCH_OR_TAG" to "$S3_BUCKET:$S3_BUCKET_PREFIX$S3_DEPLOY_DIR"...
-JAVA_TOOL_OPTIONS="-Xms1g -Xmx2g" s3_website push --site _site
+JAVA_TOOL_OPTIONS="-Xms1g -Xmx3g" s3_website push --site _site
 
 # explicit CloudFront invalidation to workaround s3_website gem invalidation bug
 # with origin path (https://github.com/laurilehmijoki/s3_website/issues/207).

--- a/src/clue/components/clue-app-header.tsx
+++ b/src/clue/components/clue-app-header.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { EPanelId, IPanelGroupSpec } from "../../components/app-header";
 import { BaseComponent, IBaseProps } from "../../components/base";
 import { ClassMenuContainer } from "../../components/class-menu-container";
+import { NetworkStatus } from "../../components/network-status";
 import { ProblemMenuContainer } from "../../components/problem-menu-container";
 import { ToggleGroup } from "@concord-consortium/react-components";
 import { GroupModelType, GroupUserModelType } from "../../models/stores/groups";
@@ -55,6 +56,7 @@ export class ClueAppHeaderComponent extends BaseComponent<IProps> {
           {this.renderPanelButtons()}
         </div>
         <div className="right">
+          <NetworkStatus user={user}/>
           <div className="version">Version {appVersion}</div>
           {myGroup ? this.renderGroup(myGroup) : null}
           <div className="user">

--- a/src/components/network-status.scss
+++ b/src/components/network-status.scss
@@ -1,0 +1,29 @@
+.network-status {
+  height: 100%;
+  margin-right: 15px;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+
+  .status {
+    width: 70px;
+    height: 40px;
+    border-radius: 5px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: #D50103;
+    color: white;
+    font-weight: bold;
+
+    &.connected {
+      background-color: #00d700;
+      color: black;
+      font-weight: normal;
+    }
+  }
+}
+
+.custom-modal.error-alert.network-error {
+  height: 190px;
+}

--- a/src/components/network-status.tsx
+++ b/src/components/network-status.tsx
@@ -1,0 +1,78 @@
+import classNames from "classnames";
+import firebase from "firebase/app";
+import { observer } from "mobx-react";
+import React, { useState } from "react";
+import { UserModelType } from "../models/stores/user";
+import { useErrorAlert } from "./utilities/use-error-alert";
+import "./network-status.scss";
+
+interface IProps {
+  user: UserModelType;
+}
+export const NetworkStatus = observer(({ user }: IProps) => {
+  const { isFirebaseConnected } = user;
+  const maxAlertDelay = 60;
+  const alertDelaysSec = [1, 5, 10, 30, maxAlertDelay];
+  const [alertDelay, setAlertDelay] = useState(alertDelaysSec[0]);
+  const [timer, setTimer] = useState(0);
+  const [isShowingAlert, setIsShowingAlert] = useState(false);
+  const [showAlert, hideAlert] = useErrorAlert({
+    className: "network-error",
+    title: "Connection Problem",
+    content: "There is a problem with your network connection. " +
+              "Without an internet connection your work cannot be saved! " +
+              "Your connection status is displayed in the header bar above.",
+    onClose: () => setIsShowingAlert(false)
+  });
+
+  if (isFirebaseConnected) {
+    if (timer) {
+      clearTimeout(timer);
+      setTimer(0);
+    }
+    if (isShowingAlert) {
+      hideAlert();
+      setIsShowingAlert(false);
+    }
+    // reduce the delay if we're back online, but don't make it too short
+    // in case we're dealing with intermittent connection issues.
+    if (alertDelay > alertDelaysSec[1]) {
+      setAlertDelay(alertDelaysSec[1]);
+    }
+  }
+
+  if (!isFirebaseConnected && !isShowingAlert && !timer) {
+    // first detection of a network issue; wait a bit to see if it's for real
+    setTimer(window.setTimeout(() => {
+      if (!user.isFirebaseConnected) {
+        setAlertDelay(alertDelaysSec.find(delay => delay > alertDelay) || maxAlertDelay);
+        showAlert();
+        setIsShowingAlert(true);
+        setTimer(0);
+      }
+    }, 1000 * alertDelay));
+  }
+
+  // clicking on the status "button" resets the timer
+  const handleClick = () => {
+    setAlertDelay(alertDelaysSec[0]);
+    checkFirebaseConnection(user);
+  };
+
+  return (
+    <div className="network-status">
+      <div className={classNames("firebase status", { connected: isFirebaseConnected })}
+            onClick={handleClick}>
+        {isFirebaseConnected ? "Online" : "Offline!"}
+      </div>
+    </div>
+  );
+});
+
+const checkFirebaseConnection = (user: UserModelType) => {
+  firebase.database().ref(".info/connected")
+    .once("value", snapshot => {
+      const isConnected: boolean = snapshot.val();
+      user.setIsFirebaseConnected(isConnected);
+    });
+};

--- a/src/lib/db-listeners/index.ts
+++ b/src/lib/db-listeners/index.ts
@@ -255,6 +255,15 @@ export class DBListeners extends BaseListener {
                                   updateRef.update({
                                     content: JSON.stringify(newContent),
                                     changeCount: document.changeCount
+                                  })
+                                  .then(() => {
+                                    // console.log("Successful save", "document:", document.key,
+                                    //             "changeCount:", document.changeCount);
+                                  })
+                                  .catch(() => {
+                                    user.setIsFirebaseConnected(false);
+                                    // console.warn("Failed save!", "document:", document.key,
+                                    //             "changeCount:", document.changeCount);
                                   });
                                 });
   }

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -321,7 +321,7 @@ export class Firebase {
 
   private handleConnectedRef = (userRef: firebase.database.Reference, snapshot?: firebase.database.DataSnapshot, ) => {
     if (snapshot) {
-      const connected = snapshot.val();
+      const connected: boolean = snapshot.val();
       if (connected) {
         userRef.child("connectedTimestamp").set(firebase.database.ServerValue.TIMESTAMP);
       }
@@ -330,6 +330,7 @@ export class Firebase {
         // disconnect but might be helpful to know if only Firebase disconnected
         Logger.log(LogEventName.INTERNAL_FIREBASE_DISCONNECTED);
       }
+      this.db.stores.user.setIsFirebaseConnected(connected);
     }
   }
 

--- a/src/models/stores/user.ts
+++ b/src/models/stores/user.ts
@@ -41,6 +41,10 @@ export const UserModel = types
     lastSupportViewTimestamp: types.maybe(types.number),
     lastStickyNoteViewTimestamp: types.maybe(types.number)
   })
+  .volatile(self => ({
+    isFirebaseConnected: false,
+    isLoggingConnected: false
+  }))
   .actions((self) => ({
     setName(name: string) {
       self.name = name;
@@ -76,6 +80,12 @@ export const UserModel = types
       if (user.demoClassHashes?.length) {
         self.demoClassHashes.replace(user.demoClassHashes);
       }
+    },
+    setIsFirebaseConnected(connected: boolean) {
+      self.isFirebaseConnected = connected;
+    },
+    setIsLoggingConnected(connected: boolean) {
+      self.isLoggingConnected = connected;
     },
     setLastSupportViewTimestamp(timestamp: number) {
       self.lastSupportViewTimestamp = timestamp;


### PR DESCRIPTION
Add network/firebase status button to header
- put up error alert when network connection is lost
- initial alert is presented 1 sec after connection lost and then delay between showing dialog increases to 60 sec where it plateaus. The idea is to keep nagging the user but not so often that they can't take screen shots, etc.

<img width="304" alt="online-status" src="https://user-images.githubusercontent.com/235234/113368685-4c14e980-9314-11eb-9108-446a1e1ee0b8.png">

<img width="301" alt="offline-status" src="https://user-images.githubusercontent.com/235234/113368692-520aca80-9314-11eb-8263-19acc553e57d.png">

<img width="404" alt="network-error-alert" src="https://user-images.githubusercontent.com/235234/113368700-5800ab80-9314-11eb-885c-ca1b744d7957.png">
