### PR TITLE
Don't show link button when linking is disabled

### DIFF
--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -40,8 +40,6 @@ function getEnvVariablesStartingWith (prefix) {
 // Also, it lets users overwrite any config value using environment variable.
 // Cypress lets you do it by default, but only for its own, predefined configuration.
 module.exports = (on, config) => {
-    require('@cypress/code-coverage/task')(on, config);
-
     // Why do we need to read process.env again? Cypress preprocess environment variables. If it finds one with name
     // that matches one of the Cypress config options, it will update the config and remove this entry from environment
     // variables set. It would work fine unless the same option is specified in our own environments.json or user-config.json.
@@ -55,5 +53,8 @@ module.exports = (on, config) => {
             // Pick correct set of values for given environment.
             const envSpecificConfig = content[environment] || {};
             return Object.assign(envSpecificConfig, unifiedCypressEnvVariables);
+        })
+        .then(envConfig => {
+            return require('@cypress/code-coverage/task')(on, { ...config, ...envConfig });
         });
 };

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -13,6 +13,8 @@
 // https://on.cypress.io/configuration
 // ***********************************************************
 
+import "@cypress/code-coverage/support";
+
 // Import commands.js using ES2015 syntax:
 import './commands';
 

--- a/src/components/tools/geometry-tool/link-table-button.false.test.tsx
+++ b/src/components/tools/geometry-tool/link-table-button.false.test.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { LinkTableButton } from "./link-table-button";
+
+// mocking is module-level, so we have separate modules to mock the different return values
+const useFeatureFlag = jest.fn().mockReturnValue(false);
+jest.mock("../../../hooks/use-stores", () => ({
+  useFeatureFlag: (...args: any) => useFeatureFlag(...args)
+}));
+
+describe("LinkTableButton with linking disabled", () => {
+
+  const onClick = jest.fn();
+
+  it("doesn't render when disabled", () => {
+    render(<LinkTableButton isEnabled={false} onClick={onClick} />);
+    expect(screen.queryByTestId("table-link-button")).toBeNull();
+  });
+
+  it("doesn't render when enabled", () => {
+    render(<LinkTableButton isEnabled={true} onClick={onClick} />);
+    expect(screen.queryByTestId("table-link-button")).toBeNull();
+  });
+});

--- a/src/components/tools/geometry-tool/link-table-button.true.test.tsx
+++ b/src/components/tools/geometry-tool/link-table-button.true.test.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { LinkTableButton } from "./link-table-button";
+import { act } from "react-dom/test-utils";
+
+// mocking is module-level, so we have separate modules to mock the different return values
+const useFeatureFlag = jest.fn().mockReturnValue(true);
+jest.mock("../../../hooks/use-stores", () => ({
+  useFeatureFlag: (...args: any) => useFeatureFlag(...args)
+}));
+
+describe("LinkTableButton with linking enabled", () => {
+
+  const onClick = jest.fn();
+
+  beforeEach(() => {
+    onClick.mockReset();
+  });
+
+  it("renders when disabled", () => {
+    const { unmount } = render(<LinkTableButton isEnabled={false} onClick={onClick} />);
+    expect(screen.getByTestId("table-link-button")).toBeInTheDocument();
+    act(() => {
+      userEvent.click(screen.getByTestId("table-link-button"));
+      unmount();
+    });
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("renders when enabled", () => {
+    const { unmount } = render(<LinkTableButton isEnabled={true} onClick={onClick} />);
+    expect(screen.getByTestId("table-link-button")).toBeInTheDocument();
+    act(() => {
+      userEvent.click(screen.getByTestId("table-link-button"));
+      unmount();
+    });
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders when enabled without onClick", () => {
+    const { unmount } = render(<LinkTableButton isEnabled={true} />);
+    expect(screen.getByTestId("table-link-button")).toBeInTheDocument();
+    act(() => {
+      userEvent.click(screen.getByTestId("table-link-button"));
+      unmount();
+    });
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/tools/geometry-tool/link-table-button.tsx
+++ b/src/components/tools/geometry-tool/link-table-button.tsx
@@ -1,6 +1,7 @@
 import classNames from "classnames";
 import React from "react";
 import LinkTableIcon from "../../../clue/assets/icons/geometry/link-table-icon.svg";
+import { useFeatureFlag } from "../../../hooks/use-stores";
 
 import "./link-table-button.scss";
 
@@ -14,9 +15,9 @@ export const LinkTableButton: React.FC<IProps> = ({ isEnabled, onClick }) => {
     isEnabled && onClick?.();
     e.stopPropagation();
   };
-  return (
-    <div key="table-link-button" className={classes} onClick={handleClick}>
-      <LinkTableIcon />
-    </div>
-  );
+  return useFeatureFlag("GeometryLinkedTables")
+          ? <div key="table-link-button" className={classes} data-testid="table-link-button" onClick={handleClick}>
+              <LinkTableIcon />
+            </div>
+          : null;
 };


### PR DESCRIPTION
While working on unrelated cypress test issues I noticed that the buttons for linking geometry tiles to table tiles were appearing even when the linking feature was disabled. This fixes that and adds unit tests. The unit tests were a bit trickier to write than I expected because of the module-level nature of mocking in jest. I ended up writing tests in two separate modules so that I could mock the `useFeatureFlag()` function to return `true` in one module and `false` in the other.

Separately, following a suggestion from @scytacki with this PR we enable cypress tests to feed into the Codecov coverage reports.