### PR TITLE
Add unit test for geometry import

### DIFF
--- a/src/components/tools/geometry-tool/geometry-content.tsx
+++ b/src/components/tools/geometry-tool/geometry-content.tsx
@@ -11,7 +11,7 @@ import { GeometryContentModelType, GeometryMetadataModelType, setElementColor, g
 import { copyCoords, getEventCoords, getAllObjectsUnderMouse, getClickableObjectUnderMouse,
           isDragTargetOrAncestor } from "../../../models/tools/geometry/geometry-utils";
 import { RotatePolygonIcon } from "./rotate-polygon-icon";
-import { getPointsByCaseId, kGeometryDefaultPixelsPerUnit } from "../../../models/tools/geometry/jxg-board";
+import { getPointsByCaseId } from "../../../models/tools/geometry/jxg-board";
 import { ESegmentLabelOption, ILinkProperties, JXGChange, JXGCoordPair
         } from "../../../models/tools/geometry/jxg-changes";
 import { kSnapUnit } from "../../../models/tools/geometry/jxg-point";
@@ -21,7 +21,7 @@ import {
 import {
   isAxis, isAxisLabel, isComment, isFreePoint, isGeometryElement, isImage, isLine, isMovableLine,
   isMovableLineControlPoint, isMovableLineLabel, isPoint, isPolygon, isVertexAngle, isVisibleEdge,
-  isVisibleMovableLine, isVisiblePoint
+  isVisibleMovableLine, isVisiblePoint, kGeometryDefaultPixelsPerUnit
 } from "../../../models/tools/geometry/jxg-types";
 import {
   getVertexAngle, updateVertexAngle, updateVertexAnglesFromObjects

--- a/src/models/tools/geometry/geometry-content.test.ts
+++ b/src/models/tools/geometry/geometry-content.test.ts
@@ -68,6 +68,7 @@ describe("GeometryContent", () => {
 
   it("can create with authored properties", () => {
     const authored = {
+            type: "Geometry" as const,
             board: {
               properties: {
                 axisNames: ["authorX", "authorY"]
@@ -302,7 +303,7 @@ describe("GeometryContent", () => {
     expect(JSON.parse(content.changes[1])).toEqual(change1);
   });
 
-  it("can pop a batch of change", () => {
+  it("can pop a batch of changes", () => {
     const change1 = { operation: "create", target: "foo" } as any as JXGChange;
     const change2 = { operation: "create", target: "bar", startBatch: true } as any as JXGChange;
     const change3 = { operation: "create", target: "baz" } as any as JXGChange;

--- a/src/models/tools/geometry/geometry-content.ts
+++ b/src/models/tools/geometry/geometry-content.ts
@@ -10,29 +10,26 @@ import {
 } from "../table/table-change";
 import { getAxisLabelsFromDataSet, getTableContent, kLabelAttrName } from "../table/table-content";
 import { canonicalizeValue, linkedPointId } from "../table/table-model-types";
+import { defaultGeometryBoardChange, preprocessImportFormat } from "./geometry-import";
 import { getAxisAnnotations, getBaseAxisLabels, getObjectById, guessUserDesiredBoundingBox,
-          kAxisBuffer, kGeometryDefaultAxisMin, kGeometryDefaultHeight, kGeometryDefaultWidth,
-          kGeometryDefaultPixelsPerUnit, syncAxisLabels, toObj } from "./jxg-board";
+          kAxisBuffer, syncAxisLabels } from "./jxg-board";
 import { ESegmentLabelOption, forEachNormalizedChange, ILinkProperties, JXGChange, JXGCoordPair,
-          JXGProperties, JXGParentType, JXGUnsafeCoordPair, JXGStringPair } from "./jxg-changes";
+          JXGProperties, JXGParentType, JXGUnsafeCoordPair } from "./jxg-changes";
 import { applyChange, applyChanges, IDispatcherChangeContext } from "./jxg-dispatcher";
 import {  kPointDefaults, kSnapUnit } from "./jxg-point";
 import { prepareToDeleteObjects } from "./jxg-polygon";
 import { getTableIdFromLinkChange } from "./jxg-table-link";
 import {
-  isAxisArray, isBoard, isComment, isFreePoint, isImage, isLinkedPoint, isMovableLine, isPoint,
-  isPointArray, isPolygon, isVertexAngle, isVisibleEdge
+  isAxisArray, isBoard, isComment, isFreePoint, isImage, isLinkedPoint, isMovableLine, isPoint, isPointArray,
+  isPolygon, isVertexAngle, isVisibleEdge, kGeometryDefaultHeight, kGeometryDefaultPixelsPerUnit, toObj
 } from "./jxg-types";
 import { IDataSet } from "../../data/data-set";
 import { assign, castArray, each, keys, omit, size as _size } from "lodash";
 import { safeJsonParse, uniqueId } from "../../../utilities/js-utils";
 import { getTileContentById } from "../../../utilities/mst-utils";
 import { Logger, LogEventName } from "../../../lib/logger";
-import { gImageMap } from "../../image-map";
 
 export const kGeometryToolID = "Geometry";
-
-export { kGeometryDefaultHeight };
 
 export type onCreateCallback = (elt: JXG.GeometryElement) => void;
 
@@ -45,50 +42,6 @@ export interface IAxesParams {
   yAnnotation?: string;
   yMin: number;
   yMax: number;
-}
-
-function getAxisUnits(protoRange: JXGCoordPair | undefined) {
-  const pRange = protoRange && castArray(protoRange);
-  if (!pRange || !pRange.length) return [kGeometryDefaultPixelsPerUnit, kGeometryDefaultPixelsPerUnit];
-  // a single value is treated as the y-range
-  if (pRange.length === 1) {
-    const [yProtoRange] = pRange;
-    const yUnit = kGeometryDefaultHeight / yProtoRange;
-    return [yUnit, yUnit];
-  }
-  else {
-    const [xProtoRange, yProtoRange] = pRange as JXGCoordPair;
-    return [kGeometryDefaultWidth / xProtoRange, kGeometryDefaultHeight / yProtoRange];
-  }
-}
-
-function getBoardBounds(axisMin?: JXGCoordPair, protoRange?: JXGCoordPair) {
-  const [xAxisMin, yAxisMin] = axisMin || [kGeometryDefaultAxisMin, kGeometryDefaultAxisMin];
-  const [xPixelsPerUnit, yPixelsPerUnit] = getAxisUnits(protoRange);
-  const xAxisMax = xAxisMin + kGeometryDefaultWidth / xPixelsPerUnit;
-  const yAxisMax = yAxisMin + kGeometryDefaultHeight / yPixelsPerUnit;
-  return [xAxisMin, yAxisMax, xAxisMax, yAxisMin];
-}
-
-function defaultGeometryBoardChange(overrides?: JXGProperties) {
-  const [xMin, yMax, xMax, yMin] = getBoardBounds();
-  const unitX = kGeometryDefaultPixelsPerUnit;
-  const unitY = kGeometryDefaultPixelsPerUnit;
-  const xBufferRange = kAxisBuffer / unitX;
-  const yBufferRange = kAxisBuffer / unitY;
-  const boundingBox = [xMin - (xBufferRange * 2), yMax + yBufferRange, xMax + xBufferRange, yMin - yBufferRange];
-  const change: JXGChange = {
-    operation: "create",
-    target: "board",
-    properties: {
-                  axis: true,
-                  boundingBox,
-                  unitX,
-                  unitY,
-                  ...overrides
-                }
-  };
-  return change;
 }
 
 export function defaultGeometryContent(overrides?: JXGProperties): GeometryContentModelType {
@@ -1347,168 +1300,6 @@ export const GeometryContentModel = types
   }));
 
 export type GeometryContentModelType = Instance<typeof GeometryContentModel>;
-
-interface IBoardImportProps {
-  axisNames?: JXGStringPair;
-  axisLabels?: JXGStringPair;
-  axisMin?: JXGCoordPair;
-  axisRange?: JXGCoordPair;
-  [prop: string]: any;
-}
-interface IBoardImportSpec {
-  properties?: IBoardImportProps;
-}
-
-interface IPointImportSpec {
-  type: "point";
-  parents: [number, number];
-  properties?: Record<string, unknown>;
-}
-
-interface IVertexImportSpec extends IPointImportSpec {
-  angleLabel?: boolean;
-}
-
-interface IPolygonImportSpec {
-  type: "polygon";
-  parents: IVertexImportSpec[];
-  properties?: Record<string, unknown>;
-}
-
-interface IImageImportSpec {
-  type: "image";
-  parents: {
-    url: string;
-    coords: JXGCoordPair;
-    size: JXGCoordPair;
-  };
-  properties?: Record<string, unknown>;
-}
-
-interface IMovableLineImportSpec {
-  type: "movableLine";
-  parents: [IPointImportSpec, IPointImportSpec];
-  properties?: Record<string, unknown>;
-  comment?: Record<string, unknown>;
-}
-
-type IObjectImportSpec = IPointImportSpec | IPolygonImportSpec | IImageImportSpec | IMovableLineImportSpec;
-
-interface IImportSpec {
-  title?: string;
-  board: IBoardImportSpec;
-  objects: IObjectImportSpec[];
-}
-
-function preprocessImportFormat(snapshot: any) {
-  if (!snapshot.objects) return snapshot;
-
-  const { title, board: boardSpecs, objects: objectSpecs } = snapshot as IImportSpec;
-  const changes: JXGChange[] = [];
-
-  if (title) {
-    changes.push({ operation: "update", target: "metadata", properties: { title } });
-  }
-
-  function addBoard(boardSpec: IBoardImportSpec) {
-    const { properties } = boardSpec || {} as IBoardImportSpec;
-    const { axisNames, axisLabels, axisMin, axisRange, ...others } = properties || {} as IBoardImportProps;
-    const boundingBox = getBoardBounds(axisMin, axisRange);
-    const [unitX, unitY] = getAxisUnits(axisRange);
-    changes.push(defaultGeometryBoardChange({
-                  unitX, unitY,
-                  ...toObj("xName", axisNames?.[0]), ...toObj("yName", axisNames?.[1]),
-                  ...toObj("xAnnotation", axisLabels?.[0]), ...toObj("yAnnotation", axisLabels?.[1]),
-                  boundingBox, ...others }));
-  }
-
-  addBoard(boardSpecs);
-
-  function addComment(props: Record<string, unknown>) {
-    const id = uniqueId();
-    changes.push({ operation: "create", target: "comment", properties: {id, ...props }});
-    return id;
-  }
-
-  function addPoint(pointSpec: IPointImportSpec) {
-    const { type, properties: _properties, ...others } = pointSpec;
-    const id = uniqueId();
-    const properties = { id, ..._properties };
-    changes.push({ operation: "create", target: "point", properties, ...others });
-    return id;
-  }
-
-  function addPolygon(polygonSpec: IPolygonImportSpec) {
-    const { parents: parentSpecs, properties: _properties } = polygonSpec;
-    const id = uniqueId();
-    const vertices: Array<{ id: string, angleLabel?: boolean }> = [];
-    const parents = parentSpecs.map(spec => {
-                      const ptId = addPoint(spec);
-                      vertices.push({ id: ptId, angleLabel: spec.angleLabel });
-                      return ptId;
-                    });
-    const properties = { id, ..._properties };
-    changes.push({ operation: "create", target: "polygon", parents, properties });
-    const lastIndex = vertices.length - 1;
-    vertices.forEach((pt, i) => {
-      let angleParents;
-      if (pt.angleLabel) {
-        const prev = i === 0 ? vertices[lastIndex].id : vertices[i - 1].id;
-        const self = vertices[i].id;
-        const next = i === lastIndex ? vertices[0].id : vertices[i + 1].id;
-        angleParents = [prev, self, next];
-      }
-      changes.push({ operation: "create", target: "vertexAngle", parents: angleParents });
-    });
-    return id;
-  }
-
-  function addImage(imageSpec: IImageImportSpec) {
-    const { type, parents: _parents, properties: _properties, ...others } = imageSpec;
-    const { url, coords, size: pxSize } = _parents;
-    const size = pxSize.map(s => s / kGeometryDefaultPixelsPerUnit) as JXGCoordPair;
-    const parents = [url, coords, size];
-    const id = uniqueId();
-    const properties = { id, ..._properties };
-    gImageMap.getImage(url);  // register with image map
-    changes.push({ operation: "create", target: "image", parents, properties, ...others });
-    return id;
-  }
-
-  function addMovableLine(movableLineSpec: IMovableLineImportSpec) {
-    const { type, parents: _parents, properties: _properties, ...others } = movableLineSpec;
-    const id = uniqueId();
-    const [pt1Spec, pt2Spec] = _parents;
-    const parents = _parents.map(ptSpec => ptSpec.parents);
-    const properties = { id, pt1: pt1Spec.properties, pt2: pt2Spec.properties, ..._properties };
-    changes.push({ operation: "create", target: "movableLine", parents, properties, ...others });
-    if (movableLineSpec.comment) {
-      addComment({ anchor: id, ...movableLineSpec.comment });
-    }
-    return id;
-  }
-
-  objectSpecs.forEach(spec => {
-    switch (spec.type) {
-      case "point":
-        addPoint(spec);
-        break;
-      case "polygon":
-        addPolygon(spec);
-        break;
-      case "image":
-        addImage(spec);
-        break;
-      case "movableLine":
-        addMovableLine(spec);
-        break;
-    }
-  });
-
-  return {
-    changes: changes.map(change => JSON.stringify(change))
-  };
-}
 
 export function mapTileIdsInGeometrySnapshot(snapshot: SnapshotOut<GeometryContentModelType>,
                                              idMap: { [id: string]: string }) {

--- a/src/models/tools/geometry/geometry-import.test.ts
+++ b/src/models/tools/geometry/geometry-import.test.ts
@@ -1,0 +1,245 @@
+import { preprocessImportFormat } from "./geometry-import";
+
+const getImageMock = jest.fn();
+jest.mock("../../image-map", () => ({
+  gImageMap: {
+    getImage: (...args: any[]) => getImageMock(...args)
+  }
+}));
+
+describe("Geometry import", () => {
+  it("ignores non-importable content", () => {
+    expect(preprocessImportFormat([])).toEqual([]);
+    expect(preprocessImportFormat({})).toEqual({});
+    expect(preprocessImportFormat({ foo: "bar" })).toEqual({ foo: "bar" });
+    expect(preprocessImportFormat({ type: "Geometry", changes: [] })).toEqual({ type: "Geometry", changes: [] });
+  });
+
+  it("imports titles", () => {
+    const input = {
+      type: "Geometry",
+      title: "MyTitle",
+      board: {},
+      objects: []
+    };
+    const result = preprocessImportFormat(input);
+
+    expect(result.changes.length).toBe(2);
+    expect(JSON.parse(result.changes[0]))
+      .toEqual({ operation: "update", target: "metadata", properties: { title: input.title }});
+  });
+
+  it("imports boards with single range value", () => {
+    const input = {
+      type: "Geometry",
+      board: {
+        properties: {
+          axisNames: ["xName", "yName"],
+          axisLabels: ["xLabel", "yLabel"],
+          axisMin: [0, 0],
+          axisRange: [10]
+        }
+      },
+      objects: []
+    };
+    const result = preprocessImportFormat(input);
+    expect(result.changes.length).toBe(1);
+    const change = JSON.parse(result.changes[0]);
+    const props = change.properties;
+
+    expect(result.changes.length).toBe(1);
+    expect(props.xName).toBe("xName");
+    expect(props.yName).toBe("yName");
+    expect(props.xAnnotation).toBe("xLabel");
+    expect(props.yAnnotation).toBe("yLabel");
+  });
+
+  it("imports boards with range value pair", () => {
+    const input = {
+      type: "Geometry",
+      board: {
+        properties: {
+          axisNames: ["xName", "yName"],
+          axisLabels: ["xLabel", "yLabel"],
+          axisMin: [0, 0],
+          axisRange: [10, 10]
+        }
+      },
+      objects: []
+    };
+    const result = preprocessImportFormat(input);
+    expect(result.changes.length).toBe(1);
+    const change = JSON.parse(result.changes[0]);
+    const props = change.properties;
+
+    expect(result.changes.length).toBe(1);
+    expect(props.xName).toBe("xName");
+    expect(props.yName).toBe("yName");
+    expect(props.xAnnotation).toBe("xLabel");
+    expect(props.yAnnotation).toBe("yLabel");
+  });
+
+  it ("imports points", () => {
+    const input = {
+      type: "Geometry",
+      objects: [
+        { type: "point", parents: [0, 0] },
+        { type: "point", parents: [5, 5], properties: { foo: "bar" }}
+      ]
+    };
+    const result = preprocessImportFormat(input);
+    expect(result.changes.length).toBe(3);
+    expect(JSON.parse(result.changes[2]).properties.foo).toBe("bar");
+  });
+
+  it ("imports points with comments", () => {
+    const input = {
+      type: "Geometry",
+      objects: [
+        { type: "point", parents: [0, 0], comment: { text: "Point Comment"} }
+      ]
+    };
+    const result = preprocessImportFormat(input);
+    expect(result.changes.length).toBe(3);
+    expect(JSON.parse(result.changes[2]).properties.text).toBe("Point Comment");
+  });
+
+  it("imports polygons", () => {
+    const input = {
+      type: "Geometry",
+      objects: [
+        { type: "polygon",
+          parents: [
+            { type: "point", parents: [0, 0] },
+            { type: "point", parents: [5, 0] },
+            { type: "point", parents: [5, 5] }
+          ]
+        }
+      ]
+    };
+    const result = preprocessImportFormat(input);
+    expect(result.changes.length).toBe(5);
+    expect(JSON.parse(result.changes[1]).parents).toEqual([0, 0]);
+    expect(JSON.parse(result.changes[2]).parents).toEqual([5, 0]);
+    expect(JSON.parse(result.changes[3]).parents).toEqual([5, 5]);
+  });
+
+  it("imports polygons with angle labels", () => {
+    const input = {
+      type: "Geometry",
+      objects: [
+        { type: "polygon",
+          parents: [
+            { type: "point", parents: [0, 0], angleLabel :true },
+            { type: "point", parents: [5, 0], angleLabel :true },
+            { type: "point", parents: [5, 5], angleLabel :true }
+          ]
+        }
+      ]
+    };
+    const result = preprocessImportFormat(input);
+    expect(result.changes.length).toBe(8);
+    expect(JSON.parse(result.changes[5]).target).toBe("vertexAngle");
+    expect(JSON.parse(result.changes[6]).target).toBe("vertexAngle");
+    expect(JSON.parse(result.changes[7]).target).toBe("vertexAngle");
+  });
+
+  it("imports polygons with comments", () => {
+    const input = {
+      type: "Geometry",
+      objects: [
+        { type: "polygon",
+          parents: [
+            { type: "point", parents: [0, 0] },
+            { type: "point", parents: [5, 0] },
+            { type: "point", parents: [5, 5] }
+          ],
+          comment: { text: "Polygon Comment" }
+        }
+      ]
+    };
+    const result = preprocessImportFormat(input);
+    expect(result.changes.length).toBe(6);
+    expect(JSON.parse(result.changes[1]).parents).toEqual([0, 0]);
+    expect(JSON.parse(result.changes[2]).parents).toEqual([5, 0]);
+    expect(JSON.parse(result.changes[3]).parents).toEqual([5, 5]);
+    expect(JSON.parse(result.changes[5]).properties.text).toBe("Polygon Comment");
+  });
+
+  it("imports images", () => {
+    const input = {
+      type: "Geometry",
+      objects: [
+        { type: "image",
+          parents: {
+            url: "image/url",
+            coords: [0, 0],
+            size: [100, 100]
+          }
+        }
+      ]
+    };
+    const result = preprocessImportFormat(input);
+    expect(result.changes.length).toBe(2);
+    expect(JSON.parse(result.changes[1]).parents[0]).toBe("image/url");
+    expect(JSON.parse(result.changes[1]).parents[1]).toEqual([0, 0]);
+  });
+
+  it("imports images with comments", () => {
+    const input = {
+      type: "Geometry",
+      objects: [
+        { type: "image",
+          parents: {
+            url: "image/url",
+            coords: [0, 0],
+            size: [100, 100]
+          },
+          comment: { text: "Image Comment" }
+        }
+      ]
+    };
+    const result = preprocessImportFormat(input);
+    expect(result.changes.length).toBe(3);
+    expect(JSON.parse(result.changes[1]).parents[0]).toBe("image/url");
+    expect(JSON.parse(result.changes[1]).parents[1]).toEqual([0, 0]);
+    expect(JSON.parse(result.changes[2]).properties.text).toBe("Image Comment");
+  });
+
+  it("imports movable lines", () => {
+    const input = {
+      type: "Geometry",
+      objects: [
+        { type: "movableLine",
+          parents: [
+            { type: "point", parents: [0, 0] },
+            { type: "point", parents: [5, 5] }
+          ]
+        }
+      ]
+    };
+    const result = preprocessImportFormat(input);
+    expect(result.changes.length).toBe(2);
+    expect(JSON.parse(result.changes[1]).target).toBe("movableLine");
+  });
+
+  it("imports movable lines with comments", () => {
+    const input = {
+      type: "Geometry",
+      objects: [
+        { type: "movableLine",
+          parents: [
+            { type: "point", parents: [0, 0] },
+            { type: "point", parents: [5, 5] }
+          ],
+          comment: { text: "Line Comment" }
+        }
+      ]
+    };
+    const result = preprocessImportFormat(input);
+    expect(result.changes.length).toBe(3);
+    expect(JSON.parse(result.changes[1]).target).toBe("movableLine");
+    expect(JSON.parse(result.changes[2]).target).toBe("comment");
+    expect(JSON.parse(result.changes[2]).properties.text).toBe("Line Comment");
+  });
+});

--- a/src/models/tools/geometry/geometry-import.ts
+++ b/src/models/tools/geometry/geometry-import.ts
@@ -145,18 +145,18 @@ export function preprocessImportFormat(snapshot: any) {
   }
 
   function addPoint(pointSpec: IPointImportSpec) {
-    const { type, properties: _properties, ...others } = pointSpec;
+    const { type, properties: _properties, comment, ...others } = pointSpec;
     const id = uniqueId();
     const properties = { id, ..._properties };
     changes.push({ operation: "create", target: "point", properties, ...others });
-    if (pointSpec.comment) {
-      addComment({ anchor: id, ...pointSpec.comment });
+    if (comment) {
+      addComment({ anchor: id, ...comment });
     }
     return id;
   }
 
   function addPolygon(polygonSpec: IPolygonImportSpec) {
-    const { parents: parentSpecs, properties: _properties } = polygonSpec;
+    const { parents: parentSpecs, properties: _properties, comment } = polygonSpec;
     const id = uniqueId();
     const vertices: Array<{ id: string, angleLabel?: boolean }> = [];
     const parents = parentSpecs.map(spec => {
@@ -177,14 +177,14 @@ export function preprocessImportFormat(snapshot: any) {
         changes.push({ operation: "create", target: "vertexAngle", parents: angleParents });
       }
     });
-    if (polygonSpec.comment) {
-      addComment({ anchor: id, ...polygonSpec.comment });
+    if (comment) {
+      addComment({ anchor: id, ...comment });
     }
     return id;
   }
 
   function addImage(imageSpec: IImageImportSpec) {
-    const { type, parents: _parents, properties: _properties, ...others } = imageSpec;
+    const { type, parents: _parents, properties: _properties, comment, ...others } = imageSpec;
     const { url, coords, size: pxSize } = _parents;
     const size = pxSize.map(s => s / kGeometryDefaultPixelsPerUnit) as JXGCoordPair;
     const parents = [url, coords, size];
@@ -192,21 +192,21 @@ export function preprocessImportFormat(snapshot: any) {
     const properties = { id, ..._properties };
     gImageMap.getImage(url);  // register with image map
     changes.push({ operation: "create", target: "image", parents, properties, ...others });
-    if (imageSpec.comment) {
-      addComment({ anchor: id, ...imageSpec.comment });
+    if (comment) {
+      addComment({ anchor: id, ...comment });
     }
     return id;
   }
 
   function addMovableLine(movableLineSpec: IMovableLineImportSpec) {
-    const { type, parents: _parents, properties: _properties, ...others } = movableLineSpec;
+    const { type, parents: _parents, properties: _properties, comment, ...others } = movableLineSpec;
     const id = uniqueId();
     const [pt1Spec, pt2Spec] = _parents;
     const parents = _parents.map(ptSpec => ptSpec.parents);
     const properties = { id, pt1: pt1Spec.properties, pt2: pt2Spec.properties, ..._properties };
     changes.push({ operation: "create", target: "movableLine", parents, properties, ...others });
-    if (movableLineSpec.comment) {
-      addComment({ anchor: id, ...movableLineSpec.comment });
+    if (comment) {
+      addComment({ anchor: id, ...comment });
     }
     return id;
   }

--- a/src/models/tools/geometry/geometry-import.ts
+++ b/src/models/tools/geometry/geometry-import.ts
@@ -1,0 +1,235 @@
+import { castArray } from "lodash";
+import { uniqueId } from "../../../utilities/js-utils";
+import { gImageMap } from "../../image-map";
+import { kAxisBuffer } from "./jxg-board";
+import { JXGChange, JXGCoordPair, JXGProperties, JXGStringPair } from "./jxg-changes";
+import {
+  kGeometryDefaultAxisMin, kGeometryDefaultHeight, kGeometryDefaultPixelsPerUnit, kGeometryDefaultWidth, toObj
+} from "./jxg-types";
+
+interface IBoardImportProps {
+  axisNames?: JXGStringPair;
+  axisLabels?: JXGStringPair;
+  axisMin?: JXGCoordPair;
+  axisRange?: JXGCoordPair;
+  [prop: string]: any;
+}
+interface IBoardImportSpec {
+  properties?: IBoardImportProps;
+}
+
+interface ICommentProps {
+  text?: string;
+  [prop: string]: any;
+}
+
+interface IPointImportSpec {
+  type: "point";
+  parents: [number, number];
+  properties?: Record<string, unknown>;
+  comment?: ICommentProps;
+}
+
+interface IVertexImportSpec extends IPointImportSpec {
+  angleLabel?: boolean;
+}
+
+interface IPolygonImportSpec {
+  type: "polygon";
+  parents: IVertexImportSpec[];
+  properties?: Record<string, unknown>;
+  comment?: ICommentProps;
+}
+
+interface IImageImportSpec {
+  type: "image";
+  parents: {
+    url: string;
+    coords: JXGCoordPair;
+    size: JXGCoordPair;
+  };
+  properties?: Record<string, unknown>;
+  comment?: ICommentProps;
+}
+
+interface IMovableLineImportSpec {
+  type: "movableLine";
+  parents: [IPointImportSpec, IPointImportSpec];
+  properties?: Record<string, unknown>;
+  comment?: ICommentProps;
+}
+
+type IObjectImportSpec = IPointImportSpec | IPolygonImportSpec | IImageImportSpec | IMovableLineImportSpec;
+
+interface IImportSpec {
+  title?: string;
+  board: IBoardImportSpec;
+  objects: IObjectImportSpec[];
+}
+
+export const isGeometryImportSpec = (obj: any): obj is IImportSpec =>
+              (obj.type === "Geometry") && (obj.changes == null) && (obj.objects != null);
+
+function getAxisUnits(protoRange: JXGCoordPair | undefined) {
+  const pRange = protoRange && castArray(protoRange);
+  if (!pRange?.length) return [kGeometryDefaultPixelsPerUnit, kGeometryDefaultPixelsPerUnit];
+  // a single value is treated as the y-range
+  if (pRange.length === 1) {
+    const [yProtoRange] = pRange;
+    const yUnit = kGeometryDefaultHeight / yProtoRange;
+    return [yUnit, yUnit];
+  }
+  else {
+    const [xProtoRange, yProtoRange] = pRange as JXGCoordPair;
+    return [kGeometryDefaultWidth / xProtoRange, kGeometryDefaultHeight / yProtoRange];
+  }
+}
+
+function getBoardBounds(axisMin?: JXGCoordPair, protoRange?: JXGCoordPair) {
+  const [xAxisMin, yAxisMin] = axisMin || [kGeometryDefaultAxisMin, kGeometryDefaultAxisMin];
+  const [xPixelsPerUnit, yPixelsPerUnit] = getAxisUnits(protoRange);
+  const xAxisMax = xAxisMin + kGeometryDefaultWidth / xPixelsPerUnit;
+  const yAxisMax = yAxisMin + kGeometryDefaultHeight / yPixelsPerUnit;
+  return [xAxisMin, yAxisMax, xAxisMax, yAxisMin];
+}
+
+export function defaultGeometryBoardChange(overrides?: JXGProperties) {
+  const [xMin, yMax, xMax, yMin] = getBoardBounds();
+  const unitX = kGeometryDefaultPixelsPerUnit;
+  const unitY = kGeometryDefaultPixelsPerUnit;
+  const xBufferRange = kAxisBuffer / unitX;
+  const yBufferRange = kAxisBuffer / unitY;
+  const boundingBox = [xMin - (xBufferRange * 2), yMax + yBufferRange, xMax + xBufferRange, yMin - yBufferRange];
+  const change: JXGChange = {
+    operation: "create",
+    target: "board",
+    properties: {
+                  axis: true,
+                  boundingBox,
+                  unitX,
+                  unitY,
+                  ...overrides
+                }
+  };
+  return change;
+}
+
+export function preprocessImportFormat(snapshot: any) {
+  if (!isGeometryImportSpec(snapshot)) return snapshot;
+
+  const { title, board: boardSpecs, objects: objectSpecs } = snapshot;
+  const changes: JXGChange[] = [];
+
+  if (title) {
+    changes.push({ operation: "update", target: "metadata", properties: { title } });
+  }
+
+  function addBoard(boardSpec: IBoardImportSpec) {
+    const { properties } = boardSpec || {} as IBoardImportSpec;
+    const { axisNames, axisLabels, axisMin, axisRange, ...others } = properties || {} as IBoardImportProps;
+    const boundingBox = getBoardBounds(axisMin, axisRange);
+    const [unitX, unitY] = getAxisUnits(axisRange);
+    changes.push(defaultGeometryBoardChange({
+                  unitX, unitY,
+                  ...toObj("xName", axisNames?.[0]), ...toObj("yName", axisNames?.[1]),
+                  ...toObj("xAnnotation", axisLabels?.[0]), ...toObj("yAnnotation", axisLabels?.[1]),
+                  boundingBox, ...others }));
+  }
+
+  addBoard(boardSpecs);
+
+  function addComment(props: Record<string, unknown>) {
+    const id = uniqueId();
+    changes.push({ operation: "create", target: "comment", properties: {id, ...props }});
+    return id;
+  }
+
+  function addPoint(pointSpec: IPointImportSpec) {
+    const { type, properties: _properties, ...others } = pointSpec;
+    const id = uniqueId();
+    const properties = { id, ..._properties };
+    changes.push({ operation: "create", target: "point", properties, ...others });
+    if (pointSpec.comment) {
+      addComment({ anchor: id, ...pointSpec.comment });
+    }
+    return id;
+  }
+
+  function addPolygon(polygonSpec: IPolygonImportSpec) {
+    const { parents: parentSpecs, properties: _properties } = polygonSpec;
+    const id = uniqueId();
+    const vertices: Array<{ id: string, angleLabel?: boolean }> = [];
+    const parents = parentSpecs.map(spec => {
+                      const ptId = addPoint(spec);
+                      vertices.push({ id: ptId, angleLabel: spec.angleLabel });
+                      return ptId;
+                    });
+    const properties = { id, ..._properties };
+    changes.push({ operation: "create", target: "polygon", parents, properties });
+    const lastIndex = vertices.length - 1;
+    vertices.forEach((pt, i) => {
+      let angleParents;
+      if (pt.angleLabel) {
+        const prev = i === 0 ? vertices[lastIndex].id : vertices[i - 1].id;
+        const self = vertices[i].id;
+        const next = i === lastIndex ? vertices[0].id : vertices[i + 1].id;
+        angleParents = [prev, self, next];
+        changes.push({ operation: "create", target: "vertexAngle", parents: angleParents });
+      }
+    });
+    if (polygonSpec.comment) {
+      addComment({ anchor: id, ...polygonSpec.comment });
+    }
+    return id;
+  }
+
+  function addImage(imageSpec: IImageImportSpec) {
+    const { type, parents: _parents, properties: _properties, ...others } = imageSpec;
+    const { url, coords, size: pxSize } = _parents;
+    const size = pxSize.map(s => s / kGeometryDefaultPixelsPerUnit) as JXGCoordPair;
+    const parents = [url, coords, size];
+    const id = uniqueId();
+    const properties = { id, ..._properties };
+    gImageMap.getImage(url);  // register with image map
+    changes.push({ operation: "create", target: "image", parents, properties, ...others });
+    if (imageSpec.comment) {
+      addComment({ anchor: id, ...imageSpec.comment });
+    }
+    return id;
+  }
+
+  function addMovableLine(movableLineSpec: IMovableLineImportSpec) {
+    const { type, parents: _parents, properties: _properties, ...others } = movableLineSpec;
+    const id = uniqueId();
+    const [pt1Spec, pt2Spec] = _parents;
+    const parents = _parents.map(ptSpec => ptSpec.parents);
+    const properties = { id, pt1: pt1Spec.properties, pt2: pt2Spec.properties, ..._properties };
+    changes.push({ operation: "create", target: "movableLine", parents, properties, ...others });
+    if (movableLineSpec.comment) {
+      addComment({ anchor: id, ...movableLineSpec.comment });
+    }
+    return id;
+  }
+
+  objectSpecs.forEach(spec => {
+    switch (spec.type) {
+      case "point":
+        addPoint(spec);
+        break;
+      case "polygon":
+        addPolygon(spec);
+        break;
+      case "image":
+        addImage(spec);
+        break;
+      case "movableLine":
+        addMovableLine(spec);
+        break;
+    }
+  });
+
+  return {
+    type: "Geometry",
+    changes: changes.map(change => JSON.stringify(change))
+  };
+}

--- a/src/models/tools/geometry/jxg-board.ts
+++ b/src/models/tools/geometry/jxg-board.ts
@@ -1,18 +1,14 @@
 import { assign, each, find } from "lodash";
 import "./jxg";
 import { JXGChange, JXGChangeAgent, JXGProperties } from "./jxg-changes";
-import { isAxis, isBoard, isLinkedPoint, isPoint } from "./jxg-types";
+import {
+  isAxis, isBoard, isLinkedPoint, isPoint,
+  kGeometryDefaultAxisMin, kGeometryDefaultHeight, kGeometryDefaultPixelsPerUnit, kGeometryDefaultWidth, toObj
+} from "./jxg-types";
 import { goodTickValue } from "../../../utilities/graph-utils";
 import { ITableLinkProperties } from "../table/table-change";
 
 const kScalerClasses = ["canvas-scaler", "scaled-list-item"];
-
-export const toObj = (p: string, v: any) => v != null ? { [p]: v } : undefined;
-
-export const kGeometryDefaultWidth = 480;
-export const kGeometryDefaultHeight = 320;
-export const kGeometryDefaultPixelsPerUnit = 18.3;  // matches S&S curriculum images
-export const kGeometryDefaultAxisMin = 0;
 
 export function getObjectById(board: JXG.Board, id: string): JXG.GeometryElement | undefined {
   let obj: JXG.GeometryElement | undefined = board.objects[id];

--- a/src/models/tools/geometry/jxg-types.ts
+++ b/src/models/tools/geometry/jxg-types.ts
@@ -1,5 +1,13 @@
 import { values } from "lodash";
 
+export const kGeometryDefaultWidth = 480;
+export const kGeometryDefaultHeight = 320;
+export const kGeometryDefaultPixelsPerUnit = 18.3;  // matches S&S curriculum images
+export const kGeometryDefaultAxisMin = 0;
+
+// utility for creating an object from a property/value pair
+export const toObj = (p: string, v: any) => v != null ? { [p]: v } : undefined;
+
 export const isBoard = (v: any): v is JXG.Board => v instanceof JXG.Board;
 export const isAxis = (v: any): v is JXG.Line => (v instanceof JXG.Line) && (v.elType === "axis");
 export const isAxisArray = (v: any): v is JXG.Line[] => Array.isArray(v) && v.every(isAxis);


### PR DESCRIPTION
- separate geometry import code from GeometryContent
- add full unit test suite for geometry import code

Reviewer note: mostly the import code just moved but there were a few changes:
- added support for comments on any object
- fixed a bug which caused empty `vertexAngle` changes (effectively NOPs) to be generated for polygon vertices without vertex angles (i.e. most of them).