### PR TITLE
Add export for geometry tile content

### DIFF
--- a/src/components/tools/geometry-tool/geometry-content.tsx
+++ b/src/components/tools/geometry-tool/geometry-content.tsx
@@ -8,6 +8,7 @@ import { getTableContent } from "../../../models/tools/table/table-content";
 import { IGeometryProps, IActionHandlers } from "./geometry-shared";
 import { GeometryContentModelType, GeometryMetadataModelType, setElementColor, getImageUrl, IAxesParams
         } from "../../../models/tools/geometry/geometry-content";
+import { exportGeometryJson } from "../../../models/tools/geometry/geometry-export";
 import { copyCoords, getEventCoords, getAllObjectsUnderMouse, getClickableObjectUnderMouse,
           isDragTargetOrAncestor } from "../../../models/tools/geometry/geometry-utils";
 import { RotatePolygonIcon } from "./rotate-polygon-icon";
@@ -324,6 +325,13 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
       },
       getLinkedTables: () => {
         return metadata.linkedTableIds;
+      },
+      exportContentAsTileJson: () => {
+        const { board } = this.state;
+        if (!board) return "";
+        const changes = this.getContent().changes;
+        const json = exportGeometryJson(changes);
+        return json;
       }
     });
 

--- a/src/components/tools/geometry-tool/geometry-content.tsx
+++ b/src/components/tools/geometry-tool/geometry-content.tsx
@@ -327,11 +327,8 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
         return metadata.linkedTableIds;
       },
       exportContentAsTileJson: () => {
-        const { board } = this.state;
-        if (!board) return "";
         const changes = this.getContent().changes;
-        const json = exportGeometryJson(changes);
-        return json;
+        return exportGeometryJson(changes);
       }
     });
 

--- a/src/components/tools/tool-tile.tsx
+++ b/src/components/tools/tool-tile.tsx
@@ -167,7 +167,7 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
     const { appMode } = this.stores;
     if (appMode !== "authed") {
       this.hotKeys.register({
-        "cmd-option-c": this.handleCopyImportJson,
+        "cmd-option-e": this.handleCopyImportJson,
         "cmd-shift-c": this.handleCopyModelJson
       });
     }

--- a/src/models/tools/geometry/geometry-export.test.ts
+++ b/src/models/tools/geometry/geometry-export.test.ts
@@ -1,0 +1,629 @@
+import { safeJsonParse } from "../../../utilities/js-utils";
+import { exportGeometryJson } from "./geometry-export";
+import { preprocessImportFormat } from "./geometry-import";
+import { JXGChange } from "./jxg-changes";
+
+const exportGeometry = (changes: JXGChange[]) => {
+  const changesJson = changes.map(change => JSON.stringify(change));
+  const exportJson = exportGeometryJson(changesJson);
+  const exportJs = safeJsonParse(exportJson);
+  // log the JSON on error for debugging
+  !exportJs && console.log("JSON PARSE ERROR\n----------------\n", exportJson);
+  return exportJs;
+};
+
+// verify that export => import => export results in two identical exports
+export const testRoundTrip = (changes: JXGChange[]) => {
+  const exportJs = exportGeometry(changes);
+  const importResult = preprocessImportFormat(exportJs);
+  const importChanges = importResult.changes.map((change: string) => safeJsonParse(change));
+  return [exportGeometry(importChanges), exportJs];
+};
+
+describe("Geometry Export", () => {
+  it("should handle invalid exports", () => {
+    expect(exportGeometry([])).toEqual({ type: "Geometry", objects: [] });
+    expect(exportGeometry([null as any])).toEqual({ type: "Geometry", objects: [] });
+  });
+
+  it("should export board that has just been created", () => {
+    const changes: JXGChange[] = [
+      {
+        operation: "create",
+        target: "board",
+        properties: { axis: true, boundingBox: [-2, 15, 22, -1], unitX: 20, unitY: 20 }
+      }
+    ];
+    expect(exportGeometry(changes)).toEqual({
+      type: "Geometry",
+      board: { properties: { axisMin: [-2, -1], axisRange: [24, 16] } },
+      objects: []
+    });
+    const [received, expected] = testRoundTrip(changes);
+    expect(received).toEqual(expected);
+  });
+
+  it("should export board with default units if necessary", () => {
+    const changes: JXGChange[] = [
+      {
+        operation: "create",
+        target: "board",
+        properties: { axis: true, boundingBox: [-2, 15, 22, -1] }
+      }
+    ];
+    expect(exportGeometry(changes)).toEqual({
+      type: "Geometry",
+      board: { properties: { axisMin: [-2, -1], axisRange: [24, 16] } },
+      objects: []
+    });
+    const [received, expected] = testRoundTrip(changes);
+    expect(received).toEqual(expected);
+  });
+
+  it("should export board that has also been updated", () => {
+    const changes: JXGChange[] = [
+      {
+        operation: "create",
+        target: "board",
+        properties: { axis: true, boundingBox: [-2, 15, 22, -1], unitX: 20, unitY: 20 }
+      },
+      {
+        operation: "update",
+        target: "board",
+        properties: {
+          boardScale: {
+            xMin: -2,
+            yMin: -1,
+            unitX: 16,
+            unitY: 16,
+            canvasWidth: 800,
+            canvasHeight: 600,
+            xName: "xName",
+            yName: "yName",
+            xAnnotation: "xLabel",
+            yAnnotation: "yLabel"
+          }
+        }
+      }
+    ];
+    expect(exportGeometry(changes)).toEqual({
+      type: "Geometry",
+      board: {
+        properties: {
+          axisMin: [-2, -1],
+          axisRange: [30, 20],
+          axisNames: ["xName", "yName"],
+          axisLabels: ["xLabel", "yLabel"]
+        }
+      },
+      objects: []
+    });
+  });
+
+  it("should export board that has been partially updated", () => {
+    const changes: JXGChange[] = [
+      {
+        operation: "create",
+        target: "board",
+        properties: { axis: true, boundingBox: [-2, 15, 22, -1], unitX: 20, unitY: 20 }
+      },
+      {
+        operation: "update",
+        target: "board",
+        properties: {
+          boardScale: {
+            xMin: -2,
+            yMin: -1,
+            unitX: 16,
+            unitY: 16,
+            canvasWidth: 800,
+            canvasHeight: 600
+          }
+        }
+      }
+    ];
+    expect(exportGeometry(changes)).toEqual({
+      type: "Geometry",
+      board: {
+        properties: {
+          axisMin: [-2, -1],
+          axisRange: [30, 20]
+        }
+      },
+      objects: []
+    });
+  });
+
+  it("should export title", () => {
+    const changes: JXGChange[] = [
+      {
+        operation: "create",
+        target: "board",
+        properties: { axis: true, boundingBox: [-2, 15, 22, -1], unitX: 20, unitY: 20 }
+      },
+      { operation: "update", target: "metadata", properties: { title: "My Geometry" } }
+    ];
+    expect(exportGeometry(changes)).toEqual({
+      type: "Geometry",
+      title: "My Geometry",
+      board: { properties: { axisMin: [-2, -1], axisRange: [24, 16] } },
+      objects: []
+    });
+    const [received, expected] = testRoundTrip(changes);
+    expect(received).toEqual(expected);
+  });
+
+  it("should not export malformed title", () => {
+    const changes: JXGChange[] = [
+      {
+        operation: "create",
+        target: "board",
+        properties: { axis: true, boundingBox: [-2, 15, 22, -1], unitX: 20, unitY: 20 }
+      },
+      { operation: "update", target: "metadata" }
+    ];
+    expect(exportGeometry(changes)).toEqual({
+      type: "Geometry",
+      board: { properties: { axisMin: [-2, -1], axisRange: [24, 16] } },
+      objects: []
+    });
+    const [received, expected] = testRoundTrip(changes);
+    expect(received).toEqual(expected);
+  });
+
+  it("should export created points", () => {
+    const changes: JXGChange[] = [
+      {
+        operation: "create",
+        target: "board",
+        properties: { axis: true, boundingBox: [-2, 15, 22, -1], unitX: 20, unitY: 20 }
+      },
+      { operation: "create", target: "point", parents: [0, 0], properties: { id: "p1" } },
+      { operation: "create", target: "point", parents: [5, 5], properties: { id: "p2" } }
+    ];
+    expect(exportGeometry(changes)).toEqual({
+      type: "Geometry",
+      board: { properties: { axisMin: [-2, -1], axisRange: [24, 16] } },
+      objects: [
+        { type: "point", parents: [0, 0], properties: { id: "p1" } },
+        { type: "point", parents: [5, 5], properties: { id: "p2" } }
+      ]
+    });
+    const [received, expected] = testRoundTrip(changes);
+    expect(received).toEqual(expected);
+  });
+
+  it("should export multiple points created with a single change", () => {
+    const changes: JXGChange[] = [
+      {
+        operation: "create",
+        target: "board",
+        properties: { axis: true, boundingBox: [-2, 15, 22, -1], unitX: 20, unitY: 20 }
+      },
+      { operation: "create", target: "point", parents: [[0, 0], [5, 5]], properties: [{ id: "p1" }, { id: "p2" }] }
+    ];
+    expect(exportGeometry(changes)).toEqual({
+      type: "Geometry",
+      board: { properties: { axisMin: [-2, -1], axisRange: [24, 16] } },
+      objects: [
+        { type: "point", parents: [0, 0], properties: { id: "p1" } },
+        { type: "point", parents: [5, 5], properties: { id: "p2" } }
+      ]
+    });
+    const [received, expected] = testRoundTrip(changes);
+    expect(received).toEqual(expected);
+  });
+
+  it("should export updated points", () => {
+    const changes: JXGChange[] = [
+      {
+        operation: "create",
+        target: "board",
+        properties: { axis: true, boundingBox: [-2, 15, 22, -1], unitX: 20, unitY: 20 }
+      },
+      { operation: "create", target: "point", parents: [0, 0], properties: { id: "p1" } },
+      { operation: "create", target: "point", parents: [5, 5], properties: { id: "p2" } },
+      { operation: "update", target: "point", targetID: "p2", properties: { position: [2, 2] } }
+    ];
+    expect(exportGeometry(changes)).toEqual({
+      type: "Geometry",
+      board: { properties: { axisMin: [-2, -1], axisRange: [24, 16] } },
+      objects: [
+        { type: "point", parents: [0, 0], properties: { id: "p1" } },
+        { type: "point", parents: [2, 2], properties: { id: "p2" } }
+      ]
+    });
+    const [received, expected] = testRoundTrip(changes);
+    expect(received).toEqual(expected);
+  });
+
+  it("should export points with additional properties", () => {
+    const changes: JXGChange[] = [
+      {
+        operation: "create",
+        target: "board",
+        properties: { axis: true, boundingBox: [-2, 15, 22, -1], unitX: 20, unitY: 20 }
+      },
+      { operation: "create", target: "point", parents: [0, 0], properties: { id: "p1", foo: "bar" } },
+      { operation: "create", target: "point", parents: [5, 5], properties: { id: "p2" } }
+    ];
+    expect(exportGeometry(changes)).toEqual({
+      type: "Geometry",
+      board: { properties: { axisMin: [-2, -1], axisRange: [24, 16] } },
+      objects: [
+        { type: "point", parents: [0, 0], properties: { id: "p1", foo: "bar" } },
+        { type: "point", parents: [5, 5], properties: { id: "p2" } }
+      ]
+    });
+    const [received, expected] = testRoundTrip(changes);
+    expect(received).toEqual(expected);
+  });
+
+  it("should not export points without ids", () => {
+    const changes: JXGChange[] = [
+      {
+        operation: "create",
+        target: "board",
+        properties: { axis: true, boundingBox: [-2, 15, 22, -1], unitX: 20, unitY: 20 }
+      },
+      { operation: "create", target: "point", parents: [0, 0] },
+      { operation: "create", target: "point", parents: [5, 5] }
+    ];
+    expect(exportGeometry(changes)).toEqual({
+      type: "Geometry",
+      board: { properties: { axisMin: [-2, -1], axisRange: [24, 16] } },
+      objects: [
+      ]
+    });
+    const [received, expected] = testRoundTrip(changes);
+    expect(received).toEqual(expected);
+  });
+
+  it("should not export deleted points", () => {
+    const changes: JXGChange[] = [
+      {
+        operation: "create",
+        target: "board",
+        properties: { axis: true, boundingBox: [-2, 15, 22, -1], unitX: 20, unitY: 20 }
+      },
+      { operation: "create", target: "point", parents: [0, 0], properties: { id: "p1" } },
+      { operation: "create", target: "point", parents: [5, 5], properties: { id: "p2" } },
+      { operation: "delete", target: "point", targetID: "p2" }
+    ];
+    expect(exportGeometry(changes)).toEqual({
+      type: "Geometry",
+      board: { properties: { axisMin: [-2, -1], axisRange: [24, 16] } },
+      objects: [
+        { type: "point", parents: [0, 0], properties: { id: "p1" } }
+      ]
+    });
+    const [received, expected] = testRoundTrip(changes);
+    expect(received).toEqual(expected);
+  });
+
+  it("should export polygons", () => {
+    const changes: JXGChange[] = [
+      {
+        operation: "create",
+        target: "board",
+        properties: { axis: true, boundingBox: [-2, 15, 22, -1], unitX: 20, unitY: 20 }
+      },
+      { operation: "create", target: "point", parents: [0, 0], properties: { id: "v1" } },
+      { operation: "create", target: "point", parents: [5, 0], properties: { id: "v2" } },
+      { operation: "create", target: "point", parents: [0, 5], properties: { id: "v3" } },
+      { operation: "create", target: "polygon", parents: ["v1", "v2", "v3"], properties: { id: "p1" } },
+      { operation: "create", target: "polygon", parents: ["v1", "v2", "v3"], properties: { id: "p2" } }
+    ];
+    expect(exportGeometry(changes)).toEqual({
+      type: "Geometry",
+      board: { properties: { axisMin: [-2, -1], axisRange: [24, 16] } },
+      objects: [
+        { type: "point", parents: [0, 0], properties: { id: "v1" } },
+        { type: "point", parents: [5, 0], properties: { id: "v2" } },
+        { type: "point", parents: [0, 5], properties: { id: "v3" } },
+        { type: "polygon", parents: ["v1", "v2", "v3"], properties: { id: "p1" } },
+        { type: "polygon", parents: ["v1", "v2", "v3"], properties: { id: "p2" } }
+      ]
+    });
+    const [received, expected] = testRoundTrip(changes);
+    expect(received).toEqual(expected);
+  });
+
+  it("should not export deleted polygons", () => {
+    const changes: JXGChange[] = [
+      {
+        operation: "create",
+        target: "board",
+        properties: { axis: true, boundingBox: [-2, 15, 22, -1], unitX: 20, unitY: 20 }
+      },
+      { operation: "create", target: "point", parents: [0, 0], properties: { id: "v1" } },
+      { operation: "create", target: "point", parents: [5, 0], properties: { id: "v2" } },
+      { operation: "create", target: "point", parents: [0, 5], properties: { id: "v3" } },
+      { operation: "create", target: "polygon", parents: ["v1", "v2", "v3"], properties: { id: "p1" } },
+      { operation: "create", target: "polygon", parents: ["v1", "v2", "v3"], properties: { id: "p2" } },
+      { operation: "delete", target: "polygon", targetID: "p1" }
+    ];
+    expect(exportGeometry(changes)).toEqual({
+      type: "Geometry",
+      board: { properties: { axisMin: [-2, -1], axisRange: [24, 16] } },
+      objects: [
+        { type: "point", parents: [0, 0], properties: { id: "v1" } },
+        { type: "point", parents: [5, 0], properties: { id: "v2" } },
+        { type: "point", parents: [0, 5], properties: { id: "v3" } },
+        { type: "polygon", parents: ["v1", "v2", "v3"], properties: { id: "p2" } }
+      ]
+    });
+    const [received, expected] = testRoundTrip(changes);
+    expect(received).toEqual(expected);
+  });
+
+  it("should export polygon with only undeleted points", () => {
+    const changes: JXGChange[] = [
+      {
+        operation: "create",
+        target: "board",
+        properties: { axis: true, boundingBox: [-2, 15, 22, -1], unitX: 20, unitY: 20 }
+      },
+      { operation: "create", target: "point", parents: [0, 0], properties: { id: "v1" } },
+      { operation: "create", target: "point", parents: [5, 0], properties: { id: "v2" } },
+      { operation: "create", target: "point", parents: [0, 5], properties: { id: "v3" } },
+      { operation: "create", target: "point", parents: [5, 5], properties: { id: "v4" } },
+      { operation: "create", target: "polygon", parents: ["v1", "v2", "v3", "v4"], properties: { id: "p1" } },
+      { operation: "delete", target: "point", targetID: "v4" }
+    ];
+    expect(exportGeometry(changes)).toEqual({
+      type: "Geometry",
+      board: { properties: { axisMin: [-2, -1], axisRange: [24, 16] } },
+      objects: [
+        { type: "point", parents: [0, 0], properties: { id: "v1" } },
+        { type: "point", parents: [5, 0], properties: { id: "v2" } },
+        { type: "point", parents: [0, 5], properties: { id: "v3" } },
+        { type: "polygon", parents: ["v1", "v2", "v3"], properties: { id: "p1" } }
+      ]
+    });
+    const [received, expected] = testRoundTrip(changes);
+    expect(received).toEqual(expected);
+  });
+
+  it("should not export polygon with fewer than two points", () => {
+    const changes: JXGChange[] = [
+      {
+        operation: "create",
+        target: "board",
+        properties: { axis: true, boundingBox: [-2, 15, 22, -1], unitX: 20, unitY: 20 }
+      },
+      { operation: "create", target: "point", parents: [0, 0], properties: { id: "v1" } },
+      { operation: "create", target: "point", parents: [5, 0], properties: { id: "v2" } },
+      { operation: "create", target: "point", parents: [0, 5], properties: { id: "v3" } },
+      { operation: "create", target: "polygon", parents: ["v1", "v2", "v3"], properties: { id: "p1" } },
+      { operation: "delete", target: "point", targetID: "v2" },
+      { operation: "delete", target: "point", targetID: "v3" }
+    ];
+    expect(exportGeometry(changes)).toEqual({
+      type: "Geometry",
+      board: { properties: { axisMin: [-2, -1], axisRange: [24, 16] } },
+      objects: [
+        { type: "point", parents: [0, 0], properties: { id: "v1" } }
+      ]
+    });
+    const [received, expected] = testRoundTrip(changes);
+    expect(received).toEqual(expected);
+  });
+
+  it("should export vertex angles", () => {
+    const changes: JXGChange[] = [
+      {
+        operation: "create",
+        target: "board",
+        properties: { axis: true, boundingBox: [-2, 15, 22, -1], unitX: 20, unitY: 20 }
+      },
+      { operation: "create", target: "point", parents: [0, 0], properties: { id: "v1" } },
+      { operation: "create", target: "point", parents: [5, 0], properties: { id: "v2" } },
+      { operation: "create", target: "point", parents: [0, 5], properties: { id: "v3" } },
+      { operation: "create", target: "polygon", parents: ["v1", "v2", "v3"], properties: { id: "p1" } },
+      { operation: "create", target: "vertexAngle", parents: ["v1", "v2", "v3"], properties: { id: "a1" } }
+    ];
+    expect(exportGeometry(changes)).toEqual({
+      type: "Geometry",
+      board: { properties: { axisMin: [-2, -1], axisRange: [24, 16] } },
+      objects: [
+        { type: "point", parents: [0, 0], properties: { id: "v1" } },
+        { type: "point", parents: [5, 0], properties: { id: "v2" } },
+        { type: "point", parents: [0, 5], properties: { id: "v3" } },
+        { type: "polygon", parents: ["v1", "v2", "v3"], properties: { id: "p1" } },
+        { type: "vertexAngle", parents: ["v1", "v2", "v3"], properties: { id: "a1" } }
+      ]
+    });
+    const [received, expected] = testRoundTrip(changes);
+    expect(received).toEqual(expected);
+  });
+
+  it("should not export vertex angles with insufficient points", () => {
+    const changes: JXGChange[] = [
+      {
+        operation: "create",
+        target: "board",
+        properties: { axis: true, boundingBox: [-2, 15, 22, -1], unitX: 20, unitY: 20 }
+      },
+      { operation: "create", target: "point", parents: [0, 0], properties: { id: "v1" } },
+      { operation: "create", target: "point", parents: [5, 0], properties: { id: "v2" } },
+      { operation: "create", target: "point", parents: [0, 5], properties: { id: "v3" } },
+      { operation: "create", target: "polygon", parents: ["v1", "v2", "v3"], properties: { id: "p1" } },
+      { operation: "create", target: "vertexAngle", parents: ["v1", "v2", "v3"], properties: { id: "a1" } },
+      { operation: "delete", target: "point", targetID: "v1" }
+    ];
+    expect(exportGeometry(changes)).toEqual({
+      type: "Geometry",
+      board: { properties: { axisMin: [-2, -1], axisRange: [24, 16] } },
+      objects: [
+        { type: "point", parents: [5, 0], properties: { id: "v2" } },
+        { type: "point", parents: [0, 5], properties: { id: "v3" } },
+        { type: "polygon", parents: ["v2", "v3"], properties: { id: "p1" } }
+      ]
+    });
+    const [received, expected] = testRoundTrip(changes);
+    expect(received).toEqual(expected);
+  });
+
+  it("should not export vertex angles without polygons", () => {
+    const changes: JXGChange[] = [
+      {
+        operation: "create",
+        target: "board",
+        properties: { axis: true, boundingBox: [-2, 15, 22, -1], unitX: 20, unitY: 20 }
+      },
+      { operation: "create", target: "point", parents: [0, 0], properties: { id: "v1" } },
+      { operation: "create", target: "point", parents: [5, 0], properties: { id: "v2" } },
+      { operation: "create", target: "point", parents: [0, 5], properties: { id: "v3" } },
+      { operation: "create", target: "polygon", parents: ["v1", "v2", "v3"], properties: { id: "p1" } },
+      { operation: "create", target: "vertexAngle", parents: ["v1", "v2", "v3"], properties: { id: "a1" } },
+      { operation: "delete", target: "polygon", targetID: "p1" }
+    ];
+    expect(exportGeometry(changes)).toEqual({
+      type: "Geometry",
+      board: { properties: { axisMin: [-2, -1], axisRange: [24, 16] } },
+      objects: [
+        { type: "point", parents: [0, 0], properties: { id: "v1" } },
+        { type: "point", parents: [5, 0], properties: { id: "v2" } },
+        { type: "point", parents: [0, 5], properties: { id: "v3" } }
+      ]
+    });
+    const [received, expected] = testRoundTrip(changes);
+    expect(received).toEqual(expected);
+  });
+
+  it("should export movable lines", () => {
+    const changes: JXGChange[] = [
+      {
+        operation: "create",
+        target: "board",
+        properties: { axis: true, boundingBox: [-2, 15, 22, -1], unitX: 20, unitY: 20 }
+      },
+      { operation: "create", target: "movableLine", parents: [[0, 0], [5, 5]], properties: { id: "l1" } }
+    ];
+    expect(exportGeometry(changes)).toEqual({
+      type: "Geometry",
+      board: { properties: { axisMin: [-2, -1], axisRange: [24, 16] } },
+      objects: [
+        {
+          type: "movableLine",
+          parents: [
+            { "type": "point", "parents": [0, 0] },
+            { "type": "point", "parents": [5, 5] }
+          ],
+          properties: { id: "l1" }
+        }
+      ]
+    });
+    const [received, expected] = testRoundTrip(changes);
+    expect(received).toEqual(expected);
+  });
+
+  it("should export movable lines that have been moved", () => {
+    const changes: JXGChange[] = [
+      {
+        operation: "create",
+        target: "board",
+        properties: { axis: true, boundingBox: [-2, 15, 22, -1], unitX: 20, unitY: 20 }
+      },
+      { operation: "create", target: "movableLine", parents: [[0, 0], [5, 5]], properties: { id: "l1" } },
+      { operation :"update", target: "point", targetID: ["l1-point1", "l1-point2"],
+        properties: [{ position: [0, 5] }, { position: [5, 10] }] }
+    ];
+    expect(exportGeometry(changes)).toEqual({
+      type: "Geometry",
+      board: { properties: { axisMin: [-2, -1], axisRange: [24, 16] } },
+      objects: [
+        {
+          type: "movableLine",
+          parents: [
+            { "type": "point", "parents": [0, 5] },
+            { "type": "point", "parents": [5, 10] }
+          ],
+          properties: { id: "l1" } }
+      ]
+    });
+    const [received, expected] = testRoundTrip(changes);
+    expect(received).toEqual(expected);
+  });
+
+  it("should not export movable lines without ids", () => {
+    const changes: JXGChange[] = [
+      {
+        operation: "create",
+        target: "board",
+        properties: { axis: true, boundingBox: [-2, 15, 22, -1], unitX: 20, unitY: 20 }
+      },
+      { operation: "create", target: "movableLine", parents: [[0, 0], [5, 5]] }
+    ];
+    expect(exportGeometry(changes)).toEqual({
+      type: "Geometry",
+      board: { properties: { axisMin: [-2, -1], axisRange: [24, 16] } },
+      objects: [
+      ]
+    });
+    const [received, expected] = testRoundTrip(changes);
+    expect(received).toEqual(expected);
+  });
+
+  it("should not export movable lines (or their points) that have been deleted", () => {
+    const changes: JXGChange[] = [
+      {
+        operation: "create",
+        target: "board",
+        properties: { axis: true, boundingBox: [-2, 15, 22, -1], unitX: 20, unitY: 20 }
+      },
+      { operation: "create", target: "movableLine", parents: [[0, 0], [5, 5]], properties: { id: "l1" } },
+      { operation: "delete", target: "movableLine", targetID: "l1" }
+    ];
+    expect(exportGeometry(changes)).toEqual({
+      type: "Geometry",
+      board: { properties: { axisMin: [-2, -1], axisRange: [24, 16] } },
+      objects: [
+      ]
+    });
+    const [received, expected] = testRoundTrip(changes);
+    expect(received).toEqual(expected);
+  });
+
+  it("should export background images", () => {
+    const changes: JXGChange[] = [
+      {
+        operation: "create",
+        target: "board",
+        properties: { axis: true, boundingBox: [-2, 15, 22, -1], unitX: 20, unitY: 20 }
+      },
+      { operation: "create", target: "image", parents: ["my/image/url", [0, 0], [10, 10]], properties: { id: "i1" } }
+    ];
+    expect(exportGeometry(changes)).toEqual({
+      type: "Geometry",
+      board: { properties: { axisMin: [-2, -1], axisRange: [24, 16] } },
+      objects: [
+        { type: "image", parents: { url: "my/image/url", coords: [0, 0], size: [183, 183] }, properties: { id: "i1" } }
+      ]
+    });
+    const [received, expected] = testRoundTrip(changes);
+    expect(received).toEqual(expected);
+  });
+
+  it("should not export background images that have been deleted", () => {
+    const changes: JXGChange[] = [
+      {
+        operation: "create",
+        target: "board",
+        properties: { axis: true, boundingBox: [-2, 15, 22, -1], unitX: 20, unitY: 20 }
+      },
+      { operation: "create", target: "image", parents: ["my/image/url", [0, 0], [10, 10]], properties: { id: "i1" } },
+      { operation: "delete", target: "image", targetID: "i1" }
+    ];
+    expect(exportGeometry(changes)).toEqual({
+      type: "Geometry",
+      board: { properties: { axisMin: [-2, -1], axisRange: [24, 16] } },
+      objects: [
+      ]
+    });
+    const [received, expected] = testRoundTrip(changes);
+    expect(received).toEqual(expected);
+  });
+
+});

--- a/src/models/tools/geometry/geometry-export.test.ts
+++ b/src/models/tools/geometry/geometry-export.test.ts
@@ -301,6 +301,48 @@ describe("Geometry Export", () => {
     expect(received).toEqual(expected);
   });
 
+  it("should not export linked points or polygons", () => {
+    const changes: JXGChange[] = [
+      {
+        operation: "create",
+        target: "board",
+        properties: { axis: true, boundingBox: [-2, 15, 22, -1], unitX: 20, unitY: 20 }
+      },
+      { operation: "create", target: "tableLink", properties: { ids: ["lp1", "lp2", "lp3"] } },
+      { operation: "create", target: "polygon", parents: ["lp1", "lp2", "lp3"], properties: { id: "lpoly"} }
+    ];
+    expect(exportGeometry(changes)).toEqual({
+      type: "Geometry",
+      board: { properties: { axisMin: [-2, -1], axisRange: [24, 16] } },
+      objects: [
+      ]
+    });
+    const [received, expected] = testRoundTrip(changes);
+    expect(received).toEqual(expected);
+  });
+
+  it("should not export linked points or polygons", () => {
+    const changes: JXGChange[] = [
+      {
+        operation: "create",
+        target: "board",
+        properties: { axis: true, boundingBox: [-2, 15, 22, -1], unitX: 20, unitY: 20 }
+      },
+      { operation: "create", target: "linkedPoint", parents: [0, 0], properties: { id: "lp1" } },
+      { operation: "create", target: "linkedPoint", parents: [5, 5], properties: { id: "lp2" } },
+      { operation: "create", target: "linkedPoint", parents: [5, 0], properties: { id: "lp3" } },
+      { operation: "create", target: "polygon", parents: ["lp1", "lp2", "lp3"], properties: { id: "lpoly"} }
+    ];
+    expect(exportGeometry(changes)).toEqual({
+      type: "Geometry",
+      board: { properties: { axisMin: [-2, -1], axisRange: [24, 16] } },
+      objects: [
+      ]
+    });
+    const [received, expected] = testRoundTrip(changes);
+    expect(received).toEqual(expected);
+  });
+
   it("should export polygons", () => {
     const changes: JXGChange[] = [
       {
@@ -459,6 +501,33 @@ describe("Geometry Export", () => {
         { type: "point", parents: [5, 0], properties: { id: "v2" } },
         { type: "point", parents: [0, 5], properties: { id: "v3" } },
         { type: "polygon", parents: ["v2", "v3"], properties: { id: "p1" } }
+      ]
+    });
+    const [received, expected] = testRoundTrip(changes);
+    expect(received).toEqual(expected);
+  });
+
+  it("should not export vertex angles without parents", () => {
+    const changes: JXGChange[] = [
+      {
+        operation: "create",
+        target: "board",
+        properties: { axis: true, boundingBox: [-2, 15, 22, -1], unitX: 20, unitY: 20 }
+      },
+      { operation: "create", target: "point", parents: [0, 0], properties: { id: "v1" } },
+      { operation: "create", target: "point", parents: [5, 0], properties: { id: "v2" } },
+      { operation: "create", target: "point", parents: [0, 5], properties: { id: "v3" } },
+      { operation: "create", target: "polygon", parents: ["v1", "v2", "v3"], properties: { id: "p1" } },
+      { operation: "create", target: "vertexAngle", properties: { id: "a1" } }
+    ];
+    expect(exportGeometry(changes)).toEqual({
+      type: "Geometry",
+      board: { properties: { axisMin: [-2, -1], axisRange: [24, 16] } },
+      objects: [
+        { type: "point", parents: [0, 0], properties: { id: "v1" } },
+        { type: "point", parents: [5, 0], properties: { id: "v2" } },
+        { type: "point", parents: [0, 5], properties: { id: "v3" } },
+        { type: "polygon", parents: ["v1", "v2", "v3"], properties: { id: "p1" } }
       ]
     });
     const [received, expected] = testRoundTrip(changes);

--- a/src/models/tools/geometry/geometry-export.ts
+++ b/src/models/tools/geometry/geometry-export.ts
@@ -1,0 +1,370 @@
+import { castArray } from "lodash";
+import { safeJsonParse } from "../../../utilities/js-utils";
+import { JXGChange, JXGCoordPair, JXGImageParents, JXGObjectType, JXGProperties } from "./jxg-changes";
+import {
+  getMovableLinePointIds, kGeometryDefaultHeight, kGeometryDefaultPixelsPerUnit, kGeometryDefaultWidth
+} from "./jxg-types";
+
+// up to three decimal places; no trailing zeros
+const fix3 = (value: number) => {
+  let s = value.toFixed(3);
+  while (s[s.length - 1] === "0") {
+    s = s.substr(0, s.length - 1);
+  }
+  if (s[s.length - 1] === ".") {
+    s = s.substr(0, s.length - 1);
+  }
+  return s;
+};
+
+interface IGeomObjectInfo {
+  id: string;
+  type: JXGObjectType;
+  changes: JXGChange[];   // changes that affect this object
+  dependents: string[];   // ids of objects that depend on this object
+  dependencies: string[]; // ids of objects this objects depends upon
+  isDeleted?: boolean;    // true if the object has been deleted
+  noExport?: boolean;     // true if the object should not be exported individually
+}
+
+// change targets that don't correspond to objects in the JSXGraph board
+const specialTargets = ["board", "metadata"];
+
+function getTargetIdsFromChange(change: JXGChange) {
+  if (specialTargets.includes(change.target)) return [change.target];
+  if (change.targetID) return castArray(change.targetID);
+  if (!change.properties) return [];
+  return castArray(change.properties).map(props => props.id);
+}
+
+function getDependenciesFromChange(change: JXGChange, objectInfoMap: Record<string, IGeomObjectInfo>): string[] {
+  // polygon dependencies are the vertices
+  if ((change.operation === "create") && (change.target === "polygon")) {
+    return change.parents as string[];
+  }
+  // vertex angle dependencies are the vertices and the polygon
+  if ((change.operation === "create") && (change.target === "vertexAngle")) {
+    const vertices = change.parents as string[];
+    let polygonId = "";
+    const dependentCount: Record<string, number> = {};
+    vertices.forEach(vId => {
+      const vInfo = objectInfoMap[vId];
+      vInfo.dependents.forEach(depId => {
+        if (!dependentCount[depId]) {
+          dependentCount[depId] = 1;
+        }
+        else {
+          if (++dependentCount[depId] >= 3) {
+            polygonId = depId;
+          }
+        }
+      });
+    });
+    return polygonId ? [polygonId, ...vertices] : vertices;
+  }
+  // movable line dependencies are the control points
+  if ((change.operation === "create") && (change.target === "movableLine")) {
+    const lineId = (change.properties as JXGProperties)?.id;
+    const pointIds = lineId && getMovableLinePointIds(lineId);
+    return pointIds || [];
+  }
+  return [];
+}
+
+export const exportGeometryJson = (changes: string[]) => {
+  const objectInfoMap: Record<string, IGeomObjectInfo> = {};
+  const orderedIds: string[] = [];
+  const lines: string[] = [];
+
+  const pushLine = (line: string, indent: number) => {
+    let space = "";
+    for (; space.length < indent; space += " ");
+    lines.push(space + line);
+  };
+
+  const comma = (condition: boolean) => condition ? "," : "";
+
+  const exportBoard = () => {
+    if (!objectInfoMap.board) return;
+    let props: any = {};
+    objectInfoMap.board.changes.forEach(change => {
+      const changeProps = change.properties as JXGProperties;
+      const boardProps = changeProps.boardScale || changeProps;
+      props = { ...props, ...boardProps };
+    });
+    const xMin: number = props.xMin ?? props.boundingBox[0];
+    const yMin: number = props.yMin ?? props.boundingBox[3];
+    const xRange: number = props.unitX
+                            ? kGeometryDefaultWidth / props.unitX
+                            : props.boundingBox[2] - xMin;
+    const yRange: number = props.unitY
+                            ? kGeometryDefaultHeight / props.unitY
+                            : props.boundingBox[1] - yMin;
+    const hasNames = (props.xName != null) || (props.yName != null);
+    const hasLabels = (props.xAnnotation != null) || (props.yAnnotation != null);
+    pushLine(`"board": {`, 2);
+    pushLine(`"properties": {`, 4);
+    pushLine(`"axisMin": [${fix3(xMin)}, ${fix3(yMin)}],`, 6);
+    pushLine(`"axisRange": [${fix3(xRange)}, ${fix3(yRange)}]${comma(hasNames || hasLabels)}`, 6);
+    hasNames && pushLine(`"axisNames": ["${props.xName}", "${props.yName}"]${comma(hasLabels)}`, 6);
+    hasLabels && pushLine(`"axisLabels": ["${props.xAnnotation}", "${props.yAnnotation}"]`, 6);
+    pushLine(`}`, 4);
+    pushLine(`},`, 2);
+  };
+
+  const isValidId = (id: string) => objectInfoMap[id] && !objectInfoMap[id].isDeleted;
+
+  const isExportable = (id: string) => {
+    if (!isValidId(id)) return false;
+
+    const objInfo = objectInfoMap[id];
+    // can't export types without an export function
+    if (!exportFnMap[objInfo.type]) return false;
+    // don't export non-exportable types
+    if (objInfo.noExport) return false;
+
+    // must have valid/sufficient dependencies
+    if (["movableLine", "polygon", "vertexAngle"].includes(objInfo.type)) {
+      const minParentsMap: { [K in JXGObjectType]?: number } = { movableLine: 2, polygon: 2, vertexAngle: 3 };
+      const minParents = minParentsMap[objInfo.type];
+      const parents = validParentIds(id);
+      if (minParents && (parents.length < minParents)) return false;
+      if (objInfo.type !== "polygon") {
+        return objInfo.dependencies.every(isValidId);
+      }
+    }
+    return true;
+  };
+
+  const getParentsFromInitialChange = (id: string, change: JXGChange) => {
+    if (change.target === "point") {
+      if (Array.isArray(change.properties)) {
+        const ptIndex = change.properties.findIndex(props => props.id === id);
+        return (ptIndex >= 0) ? change.parents?.[ptIndex] as [number, number] : [];
+      }
+      return change.parents as [number, number];
+    }
+    if (change.target === "movableLine") {
+      if (/.+-point1/.test(id)) return change.parents?.[0] as [number, number];
+      if (/.+-point2/.test(id)) return change.parents?.[1] as [number, number];
+    }
+  };
+
+  const exportImage = (id: string, isLast: boolean) => {
+    const _changes = objectInfoMap[id].changes;
+    const inParents = _changes[0].parents as JXGImageParents;
+    const [url, coords, size] = inParents;
+    let props: any = {};
+    _changes.forEach(change => {
+      props = {...props, ...change.properties };
+    });
+    const { position, ...others } = props;
+    if (others.id !== id) others.id = id;
+    const x = position?.[0] ?? coords?.[0];
+    const y = position?.[1] ?? coords?.[1];
+    const pxSize = size.map(s => Math.round(s * kGeometryDefaultPixelsPerUnit));
+    const parents = `"parents": { "url": "${url}", "coords": [${x}, ${y}], "size": [${pxSize[0]}, ${pxSize[1]}] }`;
+    const otherProps = Object.keys(others).length > 0
+                        ? `"properties": ${JSON.stringify(others)}`
+                        : "";
+    return `{ "type": "image", ${parents}${comma(!!otherProps)}${otherProps} }${comma(!isLast)}`;
+  };
+
+  const getPointExportables = (id: string) => {
+    const _changes = objectInfoMap[id].changes;
+    let props: any = {};
+    _changes.forEach(change => {
+      if (Array.isArray(change.properties)) {
+        const ptIndex = Array.isArray(change.targetID)
+                          ? change.targetID.indexOf(id)
+                          : change.properties.findIndex(p => p.id === id);
+        (ptIndex >= 0) && (props = {...props, ...change.properties[ptIndex] });
+      }
+      else {
+        props = {...props, ...change.properties };
+      }
+    });
+    const { position, ...others } = props;
+    if (others.id !== id) others.id = id;
+    const changeParents = getParentsFromInitialChange(id, _changes[0]);
+    const xParent = position?.[0] ?? changeParents?.[0];
+    const yParent = position?.[1] ?? changeParents?.[1];
+    const parents = [xParent, yParent] as JXGCoordPair;
+    return { parents, others };
+  };
+
+  const exportPoint = (id: string, isLast: boolean) => {
+    const { parents: _parents, others } = getPointExportables(id);
+    const parents = `"parents": [${_parents[0]}, ${_parents[1]}]`;
+    const otherProps = Object.keys(others).length > 0
+                        ? ` "properties": ${JSON.stringify(others)}`
+                        : "";
+    return `{ "type": "point", ${parents}${comma(!!otherProps)}${otherProps} }${comma(!isLast)}`;
+  };
+
+  const validParentIds = (id: string) => {
+    const objInfo = objectInfoMap[id];
+    const _changes = objInfo.changes;
+    const parents = objInfo.type === "movableLine"
+                      ? getMovableLinePointIds(id)
+                      : _changes[0].parents;
+    return parents?.map(vId => {
+      const vertexId = vId as string;
+      return isValidId(vertexId) ? `"${vertexId}"` : undefined;
+    }).filter(vId => !!vId) || [];
+  };
+
+  const exportPolygon = (id: string, isLast: boolean) => {
+    const _changes = objectInfoMap[id].changes;
+    let props: any = {};
+    _changes.forEach(change => {
+      props = {...props, ...change.properties };
+    });
+    if (props.id !== id) props.id = id;
+    const parents = `"parents": [${validParentIds(id)?.join(", ")}]`;
+    const otherProps = Object.keys(props).length > 0
+                        ? `"properties": ${JSON.stringify(props)}`
+                        : "";
+    return `{ "type": "polygon", ${parents}${comma(!!otherProps)}${otherProps} }${comma(!isLast)}`;
+  };
+
+  const exportVertexAngle = (id: string, isLast: boolean) => {
+    const _changes = objectInfoMap[id].changes;
+    let props: any = {};
+    _changes.forEach(change => {
+      props = {...props, ...change.properties };
+    });
+    if (props.id !== id) props.id = id;
+    const type = `"type": "vertexAngle"`;
+    const parents = `"parents": [${validParentIds(id)?.join(", ")}]`;
+    const otherProps = Object.keys(props).length > 0
+                        ? `"properties": ${JSON.stringify(props)}`
+                        : "";
+    return `{ ${type}, ${parents}${comma(!!otherProps)}${otherProps} }${comma(!isLast)}`;
+  };
+
+  const exportMovableLinePoint = (position: JXGCoordPair) => {
+    return `{ "type": "point", "parents": [${position[0]}, ${position[1]}] }`;
+  };
+
+  const exportMovableLine = (id: string, isLast: boolean) => {
+    const _changes = objectInfoMap[id].changes;
+    let props: any = {};
+    _changes.forEach(change => {
+      props = {...props, ...change.properties };
+    });
+    if (props.id !== id) props.id = id;
+    const type = `"type": "movableLine"`;
+    const pointIds = getMovableLinePointIds(id);
+    const { parents: pt0Position } = getPointExportables(pointIds[0]);
+    const { parents: pt1Position } = getPointExportables(pointIds[1]);
+    const parents = `"parents": [${exportMovableLinePoint(pt0Position)}, ${exportMovableLinePoint(pt1Position)}]`;
+    const otherProps = Object.keys(props).length > 0
+                        ? `"properties": ${JSON.stringify(props)}`
+                        : "";
+    return `{ ${type}, ${parents}${comma(!!otherProps)}${otherProps} }${comma(!isLast)}`;
+  };
+
+  const exportFnMap: Partial<Record<JXGObjectType, (id: string, isLast: boolean) => string>> = {
+    image: exportImage,
+    movableLine: exportMovableLine,
+    point: exportPoint,
+    polygon: exportPolygon,
+    vertexAngle: exportVertexAngle
+  };
+
+  const exportObject = (id: string, isLast: boolean) => {
+    const type = objectInfoMap[id]?.type;
+    return type && exportFnMap[type]?.(id, isLast);
+  };
+
+  const exportObjects = () => {
+    pushLine(`"objects": [`, 2);
+    let lastExportedId: string;
+    orderedIds.forEach(id => {
+      if (isExportable(id)) {
+        lastExportedId = id;
+      }
+    });
+    orderedIds.forEach(id => {
+      if (isExportable(id)) {
+        const objLine = exportObject(id, id === lastExportedId);
+        objLine && castArray(objLine).forEach(line => pushLine(line, 4));
+      }
+    });
+    pushLine(`]`, 2);
+  };
+
+  // loop through each change, adding it to the set of changes that affect each object
+  changes.forEach(changeJson => {
+    const change = safeJsonParse<JXGChange>(changeJson);
+    if (change) {
+      const ids = getTargetIdsFromChange(change);
+      const dependencies = getDependenciesFromChange(change, objectInfoMap);
+      ids.forEach(id => {
+        // track movable line control points so we can track changes to them
+        if ((change.operation === "create") && (change.target === "movableLine")) {
+          getMovableLinePointIds(id).forEach(ptId => {
+            objectInfoMap[ptId] = {
+              id: ptId,
+              type: "point",
+              changes: [change],
+              dependents: [],
+              dependencies: [],
+              noExport: true  // movable line control points aren't individually exportable
+            };
+            orderedIds.push(ptId);
+          });
+        }
+        if (!objectInfoMap[id]) {
+          objectInfoMap[id] = {
+            id,
+            type: change.target,
+            changes: [change],
+            dependents: [],
+            dependencies
+          };
+          dependencies.forEach(independentId => {
+            const objectInfo = objectInfoMap[independentId];
+            objectInfo.dependents.push(id);
+          });
+          if (!specialTargets.includes(id)) {
+            orderedIds.push(id);
+          }
+        }
+        else {
+          objectInfoMap[id].changes.push(change);
+
+          // deleted objects and their dependents aren't exported
+          if (change.operation === "delete") {
+            objectInfoMap[id].isDeleted = true;
+            // deleting a movable line deletes its points
+            if (objectInfoMap[id].type === "movableLine") {
+              getMovableLinePointIds(id).forEach(ptId => {
+                objectInfoMap[ptId].changes.push(change);
+                objectInfoMap[ptId].isDeleted = true;
+              });
+            }
+          }
+        }
+      });
+    }
+  });
+
+  pushLine(`"type": "Geometry",`, 2);
+  if (objectInfoMap.metadata) {
+    let title = "";
+    objectInfoMap.metadata.changes.forEach(change => {
+      const changeTitle = (change.properties as JXGProperties)?.title;
+      changeTitle && (title = changeTitle);
+    });
+    title && pushLine(`"title": "${title}",`, 2);
+  }
+  exportBoard();
+  exportObjects();
+  return [
+    `{`,
+    ...lines,
+    `}`
+  ].join("\n");
+};

--- a/src/models/tools/geometry/jxg-changes.ts
+++ b/src/models/tools/geometry/jxg-changes.ts
@@ -35,6 +35,7 @@ export interface IBoardScale {
 
 export interface JXGProperties {
   id?: string;
+  ids?: string[]; // ids of linked points in tabeLink change
   labelOption?: ESegmentLabelOption;
   position?: JXGUnsafeCoordPair;
   title?: string; // metadata property

--- a/src/models/tools/geometry/jxg-changes.ts
+++ b/src/models/tools/geometry/jxg-changes.ts
@@ -10,12 +10,27 @@ export type JXGCoordPair = [number, number];
 export type JXGUnsafeCoordPair = [number?, number?];
 export type JXGStringPair = [string?, string?];
 
+export type JXGImageParents = [string, JXGCoordPair, JXGCoordPair];
+
 export type JXGParentType = string | number | JXGCoordPair | JXGUnsafeCoordPair;
 
 export enum ESegmentLabelOption {
   kNone = "none",
   kLabel = "label", // parents
   kLength = "length"
+}
+
+export interface IBoardScale {
+  xMin: number;
+  yMin: number;
+  unitX: number;
+  unitY: number;
+  canvasWidth: number;
+  canvasHeight: number;
+  xName?: string;
+  yName?: string;
+  xAnnotation?: string;
+  yAnnotation?: string;
 }
 
 export interface JXGProperties {
@@ -28,6 +43,7 @@ export interface JXGProperties {
   yMin?: number;
   unitX?: number;
   unitY?: number;
+  boardScale?: IBoardScale;
   [key: string]: any;
 }
 

--- a/src/models/tools/geometry/jxg-movable-line.ts
+++ b/src/models/tools/geometry/jxg-movable-line.ts
@@ -3,7 +3,9 @@ import { getBaseAxisLabels, getObjectById } from "./jxg-board";
 import { JXGChangeAgent } from "./jxg-changes";
 import { objectChangeAgent } from "./jxg-object";
 import { syncClientColors } from "./jxg-point";
-import { isBoard, isMovableLine, isMovableLineControlPoint, isMovableLineLabel, kMovableLineType } from "./jxg-types";
+import {
+  getMovableLinePointIds, isBoard, isMovableLine, isMovableLineControlPoint, isMovableLineLabel, kMovableLineType
+} from "./jxg-types";
 import { uniqueId } from "../../../utilities/js-utils";
 
 // Returns the two points where the given line intersects the given board, sorted from left to right
@@ -95,13 +97,14 @@ export const movableLineChangeAgent: JXGChangeAgent = {
     const props = syncClientColors({...sharedProps, ...shared });
     const lineProps = {...props, ...lineSpecificProps, ...line };
     const pointProps = {...props, ...pointSpecificProps};
+    const pointIds = getMovableLinePointIds(lineId);
 
     if (change.parents && change.parents.length === 2) {
       const interceptPoint = (board as JXG.Board).create(
         "point",
         change.parents[0],
         {
-          id: `${lineId}-point1`,
+          id: pointIds[0],
           ...pointProps,
           ...pt1,
         }
@@ -110,7 +113,7 @@ export const movableLineChangeAgent: JXGChangeAgent = {
         "point",
         change.parents[1],
         {
-          id: `${lineId}-point2`,
+          id: pointIds[1],
           ...pointProps,
           ...pt2,
         }

--- a/src/models/tools/geometry/jxg-types.ts
+++ b/src/models/tools/geometry/jxg-types.ts
@@ -65,3 +65,6 @@ export const isMovableLineControlPoint = (v: any): v is JXG.Point => {
 export const isMovableLineLabel = (v: any): v is JXG.Text => {
   return v instanceof JXG.Text && v.getAttribute("clientType") === kMovableLineType;
 };
+export const getMovableLinePointIds = (lineId: string) => {
+  return [`${lineId}-point1`, `${lineId}-point2`] as [string, string];
+};


### PR DESCRIPTION
[[#176874271]](https://www.pivotaltracker.com/story/show/176874271)

The exported content is copied to the clipboard on `[cmd/ctrl]-[option]-e`. (It was `[cmd/ctrl]-[option]-c` previously but that conflicts with a hard-coded Chrome shortcut.)