### PR TITLE
Image tile import/export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,7 @@ serviceAccountKey.json
 .vscode
 .yalc
 yalc.lock
+.nyc_output
+coverage-cypress
 cypress/screenshots
 *debug.log

--- a/cypress/integration/clue/branch/student_tests/image_tool_spec.js
+++ b/cypress/integration/clue/branch/student_tests/image_tool_spec.js
@@ -61,6 +61,20 @@ context('Test image functionalities', function(){
             // imageToolTile.getImageToolControl().last().click();
             cy.uploadFile(imageToolTile.imageChooseFileButton(), imageFilePath, 'image/png');
             cy.wait(2000);
+
+            let clipSpy;
+            cy.window().then((win) => {
+                // https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/stubbing-spying__window
+                clipSpy = cy.spy(win.navigator.clipboard, "writeText");
+            });
+            // platform test from hot-keys library
+            const isMac = navigator.platform.indexOf("Mac") === 0;
+            const cmdKey = isMac ? "meta" : "ctrl";
+            cy.get('.primary-workspace .tool-tile.image-tool-tile')
+                .type(`{${cmdKey}+option+e}`)
+                .then(() => {
+                    expect(clipSpy).to.have.been.called;
+                });
         });
 
         it('will upload jpg file from user computer', function(){

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@concord-consortium/slate-editor": "^0.7.2",
         "classnames": "^2.2.6",
         "color-string": "^1.5.4",
-        "copy-text-to-clipboard": "^2.2.0",
         "d3-format": "^2.0.0",
         "escape-string-regexp": "^4.0.0",
         "expr-eval": "^2.0.2",
@@ -13593,14 +13592,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/copy-text-to-clipboard": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-2.2.0.tgz",
-      "integrity": "sha512-WRvoIdnTs1rgPMkgA2pUOa/M4Enh2uzCwdKsOMYNAJiz/4ZvEJgmbF4OmninPmlFdAWisfeh0tH+Cpf7ni3RqQ==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/copy-webpack-plugin": {
@@ -48793,11 +48784,6 @@
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
-    },
-    "copy-text-to-clipboard": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-2.2.0.tgz",
-      "integrity": "sha512-WRvoIdnTs1rgPMkgA2pUOa/M4Enh2uzCwdKsOMYNAJiz/4ZvEJgmbF4OmninPmlFdAWisfeh0tH+Cpf7ni3RqQ=="
     },
     "copy-webpack-plugin": {
       "version": "6.4.1",

--- a/package.json
+++ b/package.json
@@ -179,7 +179,6 @@
     "@concord-consortium/slate-editor": "^0.7.2",
     "classnames": "^2.2.6",
     "color-string": "^1.5.4",
-    "copy-text-to-clipboard": "^2.2.0",
     "d3-format": "^2.0.0",
     "escape-string-regexp": "^4.0.0",
     "expr-eval": "^2.0.2",

--- a/src/components/tools/image-component.tsx
+++ b/src/components/tools/image-component.tsx
@@ -7,7 +7,7 @@ interface IProps {
   content: ImageContentModelType;
   style: React.CSSProperties;
   onMouseDown: (e: React.MouseEvent<HTMLDivElement>) => void;
-  onUrlChange: (url: string, context?: IDocumentContext) => void;
+  onUrlChange: (url: string, filename?: string, context?: IDocumentContext) => void;
 }
 
 export const ImageComponent =

--- a/src/components/tools/tool-tile.tsx
+++ b/src/components/tools/tool-tile.tsx
@@ -1,5 +1,4 @@
 import classNames from "classnames";
-import copyTextToClipboard from "copy-text-to-clipboard";
 import { observer, inject } from "mobx-react";
 import React from "react";
 import ResizeObserver from "resize-observer-polyfill";
@@ -332,7 +331,7 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
     const toolApiInterface = this.context;
     const toolApi = toolApiInterface?.getToolApi(this.modelId);
     const importJson = toolApi?.exportContentAsTileJson?.();
-    importJson && copyTextToClipboard(importJson);
+    importJson && navigator.clipboard.writeText(importJson);
     return true;
   }
 

--- a/src/components/tools/use-image-content-url.ts
+++ b/src/components/tools/use-image-content-url.ts
@@ -4,7 +4,7 @@ import { IDocumentContext } from "../../models/document/document-types";
 import { ImageContentModelType } from "../../models/tools/image/image-content";
 import { DocumentContextReact } from "../document/document-context";
 
-type OnUrlChangeFn = (url: string, context?: IDocumentContext) => void;
+type OnUrlChangeFn = (url: string, filename?: string, context?: IDocumentContext) => void;
 
 export function useImageContentUrl(content: ImageContentModelType, onUrlChange: OnUrlChangeFn) {
   const context = useContext(DocumentContextReact);
@@ -12,11 +12,11 @@ export function useImageContentUrl(content: ImageContentModelType, onUrlChange: 
   useEffect(() => {
     const dispose = autorun(() => {
       if (content.changeCount > syncedChanges.current) {
-        const url = content.url;
-        url && onUrlChange(url, context);
+        const { url, filename } = content;
+        url && onUrlChange(url, filename, context);
         syncedChanges.current = content.changeCount;
       }
     });
     return () => dispose();
-  }, [content]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [content, onUrlChange]); // eslint-disable-line react-hooks/exhaustive-deps
 }

--- a/src/models/image.ts
+++ b/src/models/image.ts
@@ -1,16 +1,5 @@
 import { types, Instance } from "mobx-state-tree";
 
-export function defaultImage() {
-  return ImageModel.create({
-    key: "",
-    imageData: "",
-    title: "Placeholder",
-    originalSource: "",
-    createdAt: 0,
-    createdBy: ""
-  });
-}
-
 export const ImageModel = types
   .model("Image", {
     key: types.string,
@@ -19,12 +8,6 @@ export const ImageModel = types
     originalSource: types.maybe(types.string),
     createdAt: types.number,
     createdBy: types.string
-  })
-  .actions((self) => ({
-    setKey(key: string) {
-      self.key = key;
-    }
-
-  }));
+  });
 
 export type ImageModelType = Instance<typeof ImageModel>;

--- a/src/models/stores/app-config-model.ts
+++ b/src/models/stores/app-config-model.ts
@@ -95,6 +95,17 @@ export const AppConfigModel = types
     getNavTabSpec(tabId: ENavTab): NavTabSpec | undefined {
       return self.navTabs.tabSpecs.find(tab => tabId === tab.tab);
     }
+  }))
+  .views(self => ({
+    getUnitBasePath(unitId: string) {
+      const unitSpec = self.getUnit(unitId);
+      if (!unitSpec) return "";
+      const parts = unitSpec.content.split("/");
+      if (parts.length > 0) {
+        parts.splice(parts.length - 1, 1);
+      }
+      return parts.join("/");
+    }
   }));
 export type AppConfigModelType = Instance<typeof AppConfigModel>;
 export type AppConfigSpec = SnapshotIn<typeof AppConfigModel>;

--- a/src/models/tools/image/image-change.ts
+++ b/src/models/tools/image/image-change.ts
@@ -1,0 +1,9 @@
+export interface ImageToolChange {
+  operation: "update";
+  url: string;
+  filename?: string
+}
+
+export function createChange(url: string, filename?: string) {
+  return JSON.stringify({ operation: "update", url, filename });
+}

--- a/src/models/tools/image/image-content.test.ts
+++ b/src/models/tools/image/image-content.test.ts
@@ -1,0 +1,61 @@
+import { defaultImageContent, ImageContentModel } from "./image-content";
+import placeholderImage from "../../../assets/image_placeholder.png";
+
+describe("ImageContent", () => {
+  it("should handle empty change lists", () => {
+    const content = ImageContentModel.create({ changes: [] });
+    expect(content.isUserResizable).toBe(true);
+    expect(content.changeCount).toBe(0);
+    expect(content.filename).toBeUndefined();
+    expect(content.url).toBeUndefined();
+    expect(content.hasValidImage).toBe(false);
+  });
+
+  it("should support default placeholder content", () => {
+    const content = defaultImageContent();
+    expect(content.isUserResizable).toBe(true);
+    expect(content.changeCount).toBe(1);
+    expect(content.filename).toBeUndefined();
+    expect(content.url).toBe(placeholderImage);
+    expect(content.hasValidImage).toBe(false);
+  });
+
+  it("should support default non-placeholder content", () => {
+    const content = defaultImageContent("my/image/url");
+    expect(content.isUserResizable).toBe(true);
+    expect(content.changeCount).toBe(1);
+    expect(content.filename).toBeUndefined();
+    expect(content.url).toBe("my/image/url");
+    expect(content.hasValidImage).toBe(true);
+  });
+
+  it("should add changes", () => {
+    const content = ImageContentModel.create({ changes: [] });
+    content.setUrl("my/image/url", "my/image/filename");
+    expect(content.isUserResizable).toBe(true);
+    expect(content.changeCount).toBe(1);
+    expect(content.filename).toBe("my/image/filename");
+    expect(content.url).toBe("my/image/url");
+    expect(content.hasValidImage).toBe(true);
+  });
+
+  it("should update changes", () => {
+    const content = ImageContentModel.create({ changes: [] });
+    content.setUrl("my/image/firstUrl");
+    content.setUrl("my/image/url");
+    const origChanges = content.changes.toJS();
+
+    content.updateImageUrl("my/image/url", "");
+    expect(content.changes.toJS()).toEqual(origChanges);
+    content.updateImageUrl("", "my/image/newUrl");
+    expect(content.changes.toJS()).toEqual(origChanges);
+    content.updateImageUrl("my/image/url", "my/image/url");
+    expect(content.changes.toJS()).toEqual(origChanges);
+
+    content.updateImageUrl("my/image/url", "my/image/newUrl");
+    expect(content.isUserResizable).toBe(true);
+    expect(content.changeCount).toBe(2);
+    expect(content.url).toBe("my/image/newUrl");
+    expect(content.hasValidImage).toBe(true);
+  });
+});

--- a/src/models/tools/image/image-import-export.test.ts
+++ b/src/models/tools/image/image-import-export.test.ts
@@ -1,0 +1,137 @@
+import { safeJsonParse } from "../../../utilities/js-utils";
+import { ImageToolChange } from "./image-change";
+import {
+  exportImageTileSpec, IExportImageTileOptions, IImageTileImportSpec, importImageTileSpec, isImageTileImportSpec
+} from "./image-import-export";
+
+const isImageToolChangeArray = (changes: ImageToolChange[] | string[]): changes is ImageToolChange[] =>
+        (changes.length > 0) && (typeof changes[0] === "object");
+
+const exportImageToolJson = (changes: ImageToolChange[] | string[], options?: IExportImageTileOptions) => {
+  const changesJson = isImageToolChangeArray(changes)
+                        ? changes.map(change => JSON.stringify(change))
+                        : changes;
+  const exportJson = exportImageTileSpec(changesJson, options);
+  // console.log("exportJson:", exportJson);
+  const exportJs = safeJsonParse(exportJson);
+  // log the JSON on error for debugging
+  !exportJs && console.log("JSON PARSE ERROR\n----------------\n", exportJson);
+  return exportJs;
+};
+
+describe("isImageTileImportSpec", () => {
+  it("should work as expected", () => {
+    expect(isImageTileImportSpec(null)).toBe(false);
+    expect(isImageTileImportSpec({})).toBe(false);
+    expect(isImageTileImportSpec({ type: "Image" })).toBe(false);
+    expect(isImageTileImportSpec({ type: "Image", url: "foo" })).toBe(true);
+    expect(isImageTileImportSpec({ type: "Image", url: "foo", changes: [] })).toBe(false);
+  });
+});
+
+describe("Image import", () => {
+  it("should import correctly", () => {
+    const input = {
+      type: "Image" as const,
+      url: "my/image/url"
+    };
+    const result = importImageTileSpec(input);
+    expect(result.type).toBe("Image");
+    expect(result.changes.length).toBe(1);
+    expect(safeJsonParse<IImageTileImportSpec>(result.changes[0]))
+            .toEqual({ operation: "update", url: "my/image/url" });
+  });
+});
+
+describe("Image export with default options", () => {
+  it("should export empty changes", () => {
+    const changes: ImageToolChange[] = [];
+    expect(exportImageToolJson(changes))
+            .toEqual({ type: "Image", url: "" });
+  });
+
+  it("should ignore invalid changes", () => {
+    const changes: string[] = [
+      "{ INVALID }"
+    ];
+    expect(exportImageToolJson(changes))
+            .toEqual({ type: "Image", url: "" });
+  });
+
+  it("should ignore incomplete changes", () => {
+    const changes: ImageToolChange[] = [
+      { operation: "update" } as any
+    ];
+    expect(exportImageToolJson(changes))
+            .toEqual({ type: "Image", url: "" });
+  });
+
+  it("should export tiles created without filename", () => {
+    const changes: ImageToolChange[] = [
+      { operation: "update", url: "my/img/url" }
+    ];
+    expect(exportImageToolJson(changes))
+            .toEqual({ type: "Image", url: "my/img/url" });
+  });
+
+  it("should export tiles created with filename", () => {
+    const changes: ImageToolChange[] = [
+      { operation: "update", url: "my/img/url", filename: "my/filename" }
+    ];
+    expect(exportImageToolJson(changes))
+            .toEqual({ type: "Image", url: "my/img/url", filename: "my/filename" });
+  });
+
+  it("should export updated tiles", () => {
+    const changes: ImageToolChange[] = [
+      { operation: "update", url: "my/img/url" },
+      { operation: "update", url: "my/updated/img/url" }
+    ];
+    expect(exportImageToolJson(changes))
+            .toEqual({ type: "Image", url: "my/updated/img/url" });
+  });
+
+  it("should export updated tiles with filenames", () => {
+    const changes: ImageToolChange[] = [
+      { operation: "update", url: "my/img/url" },
+      { operation: "update", url: "my/updated/img/url", filename: "my/updated/filename" }
+    ];
+    expect(exportImageToolJson(changes))
+            .toEqual({ type: "Image", url: "my/updated/img/url", filename: "my/updated/filename" });
+  });
+
+  it("should export updated tiles with filenames", () => {
+    const changes: ImageToolChange[] = [
+      { operation: "update", url: "my/img/url" },
+      { operation: "update", url: "my/updated/img/url", filename: "my/updated/filename" },
+      { operation: "update", url: "my/final/url" }
+    ];
+    expect(exportImageToolJson(changes))
+            .toEqual({ type: "Image", url: "my/final/url" });
+  });
+});
+
+describe('Image export with transformUrl option', () => {
+  const transformUrl = (url: string, filename?: string) => {
+    return filename
+            ? `curriculum/images/${filename}`
+            : url;
+  };
+
+  it("should export tiles created without filename", () => {
+    const changes: ImageToolChange[] = [
+      { operation: "update", url: "my/img/url" }
+    ];
+    expect(exportImageToolJson(changes, { transformUrl }))
+            .toEqual({ type: "Image", url: "my/img/url" });
+  });
+
+  it("should export tiles created with filename", () => {
+    const changes: ImageToolChange[] = [
+      { operation: "update", url: "my/img/url", filename: "my/filename" }
+    ];
+    expect(exportImageToolJson(changes, { transformUrl }))
+            .toEqual({ type: "Image", url: "curriculum/images/my/filename", filename: "my/filename" });
+  });
+
+});

--- a/src/models/tools/image/image-import-export.ts
+++ b/src/models/tools/image/image-import-export.ts
@@ -1,0 +1,41 @@
+import { createChange, ImageToolChange } from "./image-change";
+import { safeJsonParse } from "../../../utilities/js-utils";
+
+export interface IImageTileImportSpec {
+  type: "Image";
+  url: string;
+}
+
+const comma = (condition: boolean) => condition ? "," : "";
+
+export const isImageTileImportSpec = (snapshot: any): snapshot is IImageTileImportSpec =>
+              (snapshot?.type === "Image") && (snapshot.url != null) && !snapshot.changes;
+
+export const importImageTileSpec = (snapshot: IImageTileImportSpec) => {
+  const { url, ...others } = snapshot;
+  return { changes: [createChange(url)], ...others };
+};
+
+export interface IExportImageTileOptions {
+  transformUrl?: (url: string, filename?: string) => string;
+}
+
+export const exportImageTileSpec = (changes: string[], options?: IExportImageTileOptions) => {
+  const { transformUrl } = options || {};
+  let url = "";
+  let filename = "";
+  changes.forEach(change => {
+    const imageChange = safeJsonParse<ImageToolChange>(change);
+    if (imageChange?.url) {
+      url = imageChange.url;
+      filename = imageChange.filename || "";
+    }
+  });
+  return [
+    `{`,
+    `  "type": "Image",`,
+    `  "url": "${transformUrl?.(url, filename) || url}"${comma(!!filename)}`,
+    ...(filename ? [`  "filename": "${filename}"`] : []),
+    `}`
+  ].join("\n");
+};

--- a/src/utilities/image-utils.ts
+++ b/src/utilities/image-utils.ts
@@ -1,6 +1,7 @@
 import { DB } from "../lib/db";
 import { ImageModelType, ImageModel } from "../models/image";
-import { ImageContentSnapshotOutType, ImageToolChange } from "../models/tools/image/image-content";
+import { ImageToolChange } from "../models/tools/image/image-change";
+import { ImageContentSnapshotOutType } from "../models/tools/image/image-content";
 import { safeJsonParse } from "./js-utils";
 import placeholderImage from "../assets/image_placeholder.png";
 import orgPlaceholderImage from "../assets/image_placeholder_org.png";


### PR DESCRIPTION
[[#176874262]](https://www.pivotaltracker.com/story/show/176874262)

Implements export for image tile via keyboard shortcut (`cmd-option-e`). To simplify authoring, also adds tracking of filename for images imported from local files and then export uses the default filename when exporting. Also adds jest tests for much of the model code and a cypress test for the export via keyboard shortcut.