### PR TITLE
Fix import/export issues [#178747097]

### DIFF
--- a/src/components/document/canvas.test.tsx
+++ b/src/components/document/canvas.test.tsx
@@ -26,7 +26,11 @@ describe("Canvas Component", () => {
   });
 
   it("can render without a document or content", () => {
-    const wrapper = mount(<CanvasComponent context="test" />);
+    const stores = createStores();
+    const wrapper = mount(
+      <Provider stores={stores}>
+        <CanvasComponent context="test" />
+      </Provider>);
     expect(wrapper.find(DocumentContentComponent).length).toEqual(0);
   });
 

--- a/src/components/document/canvas.tsx
+++ b/src/components/document/canvas.tsx
@@ -1,9 +1,11 @@
 import { each } from "lodash";
-import { observer } from "mobx-react";
+import { inject, observer } from "mobx-react";
 import React from "react";
+import { BaseComponent } from "../base";
 import { DocumentContentComponent } from "./document-content";
 import { DocumentModelType } from "../../models/document/document";
 import { DocumentContentModelType } from "../../models/document/document-content";
+import { transformCurriculumImageUrl } from "../../models/tools/image/image-import-export";
 import {
   IToolApi, IToolApiInterface, IToolApiMap, ToolApiInterfaceContext, EditableToolApiInterfaceRefContext
 } from "../tools/tool-api";
@@ -26,8 +28,9 @@ interface IProps {
   viaTeacherDashboard?: boolean;
 }
 
+@inject("stores")
 @observer
-export class CanvasComponent extends React.Component<IProps> {
+export class CanvasComponent extends BaseComponent<IProps> {
 
   private toolApiMap: IToolApiMap = {};
   private toolApiInterface: IToolApiInterface;
@@ -132,8 +135,13 @@ export class CanvasComponent extends React.Component<IProps> {
 
   private handleCopyDocumentJson = () => {
     const {content, document } = this.props;
+    const { appConfig, unit } = this.stores;
+    const unitBasePath = appConfig.getUnitBasePath(unit.code);
     const documentContent = document?.content ?? content;
-    const json = documentContent?.exportAsJson({ includeTileIds: true });
+    const transformImageUrl = (url: string, filename?: string) => {
+      return transformCurriculumImageUrl(url, unitBasePath, filename);
+    };
+    const json = documentContent?.exportAsJson({ includeTileIds: true, transformImageUrl });
     json && navigator.clipboard.writeText(json);
   }
 }

--- a/src/components/tools/drawing-tool/drawing-layer.tsx
+++ b/src/components/tools/drawing-tool/drawing-layer.tsx
@@ -1060,6 +1060,7 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
         const image: ImageObject = new ImageObject({
           type: "image",
           url,
+          filename: imageEntry.filename,
           x: 0,
           y: 0,
           width: imageEntry.width!,

--- a/src/components/tools/drawing-tool/drawing-layer.tsx
+++ b/src/components/tools/drawing-tool/drawing-layer.tsx
@@ -968,11 +968,11 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
     );
   }
 
-  private updateLoadingImages = (url: string) => {
+  private updateLoadingImages = (url: string, filename?: string) => {
     if (this.fetchingImages.indexOf(url) > -1) return;
     this.fetchingImages.push(url);
 
-    gImageMap.getImage(url)
+    gImageMap.getImage(url, { filename })
       .then(image => {
         if (!this._isMounted) return;
         // update all images with this originalUrl that have not been updated
@@ -1112,7 +1112,7 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
         drawingObject = new ImageObject(assign({}, data, { url: displayUrl }));
         if (!imageEntry) {
           drawingObject.model.originalUrl = data.url;
-          this.updateImageUrl(data.url);
+          this.updateImageUrl(data.url, data.filename);
         }
         break;
       }
@@ -1137,11 +1137,11 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
     }
   }
 
-  private updateImageUrl(url: string) {
+  private updateImageUrl(url: string, filename?: string) {
     if (!this.state.isLoading) {
       this.setState({ isLoading: true });
     }
-    this.updateLoadingImages(url);
+    this.updateLoadingImages(url, filename);
   }
 
   private updateDrawingObjects(update: DrawingToolUpdate) {

--- a/src/components/tools/drawing-tool/drawing-tool.tsx
+++ b/src/components/tools/drawing-tool/drawing-tool.tsx
@@ -7,6 +7,7 @@ import { useToolbarToolApi } from "../hooks/use-toolbar-tool-api";
 import { DrawingContentModelType } from "../../../models/tools/drawing/drawing-content";
 import { useCurrent } from "../../../hooks/use-current";
 import { exportDrawingTileSpec } from "../../../models/tools/drawing/drawing-export";
+import { ITileExportOptions } from "../../../models/tools/tool-content-info";
 
 import "./drawing-tool.sass";
 
@@ -22,8 +23,8 @@ const DrawingToolComponent: React.FC<IProps> = (props) => {
     }
 
     onRegisterToolApi({
-      exportContentAsTileJson: () => {
-        return exportDrawingTileSpec(contentRef.current.changes);
+      exportContentAsTileJson: (options?: ITileExportOptions) => {
+        return exportDrawingTileSpec(contentRef.current.changes, options);
       }
     });
 

--- a/src/components/tools/image-tool.tsx
+++ b/src/components/tools/image-tool.tsx
@@ -13,7 +13,7 @@ import { IDocumentContext } from "../../models/document/document-types";
 import { debouncedSelectTile } from "../../models/stores/ui";
 import { gImageMap, IImageContext, ImageMapEntryType } from "../../models/image-map";
 import { ImageContentModelType } from "../../models/tools/image/image-content";
-import { exportImageTileSpec } from "../../models/tools/image/image-import-export";
+import { ITileExportOptions } from "../../models/tools/tool-content-info";
 import { hasSelectionModifier } from "../../utilities/event-utils";
 import { ImageDragDrop } from "../utilities/image-drag-drop";
 import { isPlaceholderImage } from "../../utilities/image-utils";
@@ -127,18 +127,8 @@ export default class ImageToolComponent extends BaseComponent<IProps, IState> {
     this.imageElt && this.resizeObserver.observe(this.imageElt);
 
     this.props.onRegisterToolApi({
-      exportContentAsTileJson: () => {
-        const changes = this.getContent().changes;
-        // for authoring, convert to curriculum-relative URL on export
-        const transformUrl = (url: string) => {
-          const { appConfig, unit } = this.stores;
-          const basePath = appConfig.getUnitBasePath(unit.code);
-          const filename = this.state.imageEntry?.filename;
-          return basePath && filename
-                  ? `${basePath}/images/${filename}`
-                  : url;
-        };
-        return exportImageTileSpec(changes, { transformUrl });
+      exportContentAsTileJson: (options?: ITileExportOptions) => {
+        return this.getContent().exportJson(options);
       },
       handleDocumentScroll: (x: number, y: number) => {
         this.toolbarToolApi?.handleDocumentScroll?.(x, y);

--- a/src/components/tools/tool-api.tsx
+++ b/src/components/tools/tool-api.tsx
@@ -1,5 +1,6 @@
 import { createContext } from "react";
 import { Optional } from "utility-types";
+import { ITileExportOptions } from "../../models/tools/tool-content-info";
 
 export type TileResizeEntry = Optional<ResizeObserverEntry, "borderBoxSize" | "contentBoxSize">;
 export interface IToolApi {
@@ -12,7 +13,7 @@ export interface IToolApi {
   getLinkIndex?: (index?: number) => number;
   getLinkedTables?: () => string[] | undefined;
   getContentHeight?: () => number | undefined;
-  exportContentAsTileJson?: () => string;
+  exportContentAsTileJson?: (options?: ITileExportOptions) => string;
   handleDocumentScroll?: (x: number, y: number) => void;
   handleTileResize?: (entry: TileResizeEntry) => void;
 }

--- a/src/components/tools/tool-tile.tsx
+++ b/src/components/tools/tool-tile.tsx
@@ -9,6 +9,7 @@ import { kGeometryToolID } from "../../models/tools/geometry/geometry-content";
 import { kTableToolID } from "../../models/tools/table/table-content";
 import { kTextToolID } from "../../models/tools/text/text-content";
 import { kImageToolID } from "../../models/tools/image/image-content";
+import { transformCurriculumImageUrl } from "../../models/tools/image/image-import-export";
 import { kPlaceholderToolID } from "../../models/tools/placeholder/placeholder-content";
 import { kUnknownToolID } from "../../models/tools/unknown-content";
 import { getToolContentInfoById } from "../../models/tools/tool-content-info";
@@ -328,9 +329,14 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
   }
 
   private handleCopyImportJson = () => {
+    const { appConfig, unit } = this.stores;
+    const unitBasePath = appConfig.getUnitBasePath(unit.code);
+    const transformImageUrl = (url: string, filename?: string) => {
+      return transformCurriculumImageUrl(url, unitBasePath, filename);
+    };
     const toolApiInterface = this.context;
     const toolApi = toolApiInterface?.getToolApi(this.modelId);
-    const importJson = toolApi?.exportContentAsTileJson?.();
+    const importJson = toolApi?.exportContentAsTileJson?.({ transformImageUrl });
     importJson && navigator.clipboard.writeText(importJson);
     return true;
   }

--- a/src/models/document/document-content.test.ts
+++ b/src/models/document/document-content.test.ts
@@ -993,7 +993,8 @@ describe("DocumentContentModel -- move/copy tiles --", () => {
     expect(parsedExport(documentContent)).toEqual({
       tiles: [
         { content: { type: "Text", format: "html", text: ["<p>Some text</p>"] } },
-        { content: { type: "Drawing", objects: [] } },
+        // explicit row height exported since it differs from drawing tool default
+        { content: { type: "Drawing", objects: [] }, layout: { height: 320 } },
         [
           {
             content: {
@@ -1009,7 +1010,8 @@ describe("DocumentContentModel -- move/copy tiles --", () => {
         [
           { content: { type: "Geometry", objects: [] } },
           { content: { type: "Text", format: "html", text: ["<p>More text</p>"] } },
-          { content: { type: "Drawing", objects: [] } }
+          // explicit row height exported since it differs from drawing tool default
+          { content: { type: "Drawing", objects: [] }, layout: { height: 320 } }
         ]
       ]
     });

--- a/src/models/document/document-content.test.ts
+++ b/src/models/document/document-content.test.ts
@@ -420,6 +420,8 @@ describe("DocumentContentModel -- sectioned documents --", () => {
     // [Header:A, Placeholder, Header:B, Text]
     content.moveRowToIndex(3, 1);
     // [Header:A, Text, Header:B, Placeholder]
+    // moving to row 0 when row 0 is a section header is a no-op
+    content.moveRowToIndex(1, 0);
     expect(content.rowCount).toBe(4);
     expect(isContentSection("A")).toBe(true);
     expect(isPlaceholderSection("B")).toBe(true);
@@ -983,13 +985,20 @@ describe("DocumentContentModel -- move/copy tiles --", () => {
     }
   */
 
-  it("can export more complicated content", () => {
+  it("can query content", () => {
     expect(documentContent.isEmpty).toBe(false);
+    expect(documentContent.contentId).toBeDefined();
     expect(documentContent.firstTile!.id).toBe("textTool1");
+    expect(documentContent.getTileType("drawingTool1")).toBe("Drawing");
+    expect(documentContent.getTileContent("drawingTool1")?.type).toBe("Drawing");
     expect(documentContent.getTileCountsPerSection(["introduction"])).toEqual({ introduction: 2 });
     expect(documentContent.getTileCountsPerSection(["initialChallenge"])).toEqual({ initialChallenge: 5 });
     expect(documentContent.getTilesOfType("Text")).toEqual(["textTool1", "textTool2"]);
     expect(documentContent.getTilesOfType("Drawing")).toEqual(["drawingTool1", "drawingTool2"]);
+    expect(documentContent.getUniqueTitle("Geometry", "Graph", () => "Graph 1")).toBe("Graph 2");
+  });
+
+  it("can export more complicated content", () => {
     expect(parsedExport(documentContent)).toEqual({
       tiles: [
         { content: { type: "Text", format: "html", text: ["<p>Some text</p>"] } },

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -118,8 +118,10 @@ export const DocumentContentModel = types
         return tileId ? self.tileMap.get(tileId) : undefined;
       },
       getTileContent(tileId: string): ToolContentUnionType | undefined {
-        const tile = self.tileMap.get(tileId);
-        return tile?.content;
+        return self.tileMap.get(tileId)?.content;
+      },
+      getTileType(tileId: string) {
+        return self.tileMap.get(tileId)?.content.type;
       },
       get rowCount() {
         return self.rowOrder.length;
@@ -252,8 +254,7 @@ export const DocumentContentModel = types
       self.rowOrder.forEach(rowId => {
         const row = self.getRow(rowId);
         each(row?.tiles, tileEntry => {
-          const tile = self.getTile(tileEntry.tileId);
-          if (tile?.content.type === type) {
+          if (self.getTileType(tileEntry.tileId) === type) {
             tiles.push(tileEntry.tileId);
           }
         });
@@ -290,7 +291,7 @@ export const DocumentContentModel = types
     rowHeightToExport(row: TileRowModelType, tileId: string) {
       if (!row?.height) return;
       // we only export heights for specific tiles configured to do so
-      const tileType = self.getTile(tileId)?.content.type;
+      const tileType = self.getTileType(tileId);
       const tileContentInfo = tileType && getToolContentInfoById(tileType);
       if (!tileContentInfo?.exportNonDefaultHeight) return;
       // we only export heights when they differ from the default height for the tile
@@ -424,8 +425,7 @@ export const DocumentContentModel = types
     },
     removePlaceholderTilesFromRow(rowIndex: number) {
       const isPlaceholderTile = (tileId: string) => {
-        const tile = self.tileMap.get(tileId);
-        return tile?.content.type === "Placeholder";
+        return self.getTileType(tileId) === "Placeholder";
       };
       const row = self.getRowByIndex(rowIndex);
       row?.removeTilesFromRow(isPlaceholderTile);

--- a/src/models/document/tile-row.ts
+++ b/src/models/document/tile-row.ts
@@ -53,6 +53,14 @@ export const TileRowModel = types
     },
     indexOfTile(tileId: string) {
       return self.tiles.findIndex(tileRef => tileRef.tileId === tileId);
+    },
+    getContentHeight(getTileHeight?: (tileId: string) => number | undefined) {
+      let rowHeight: number | undefined;
+      self.tiles.forEach(tileInfo => {
+        const tileHeight = getTileHeight?.(tileInfo.tileId);
+        tileHeight && (rowHeight = Math.max(tileHeight, rowHeight || 0));
+      });
+      return rowHeight;
     }
   }))
   .actions(self => ({

--- a/src/models/tools/drawing/drawing-content.ts
+++ b/src/models/tools/drawing/drawing-content.ts
@@ -129,7 +129,7 @@ export const DrawingContentModel = types
       return { stroke, fill, strokeDashArray, strokeWidth };
     },
     exportJson(options?: ITileExportOptions) {
-      return exportDrawingTileSpec(self.changes);
+      return exportDrawingTileSpec(self.changes, options);
     }
   }))
   .extend(self => {

--- a/src/models/tools/drawing/drawing-content.ts
+++ b/src/models/tools/drawing/drawing-content.ts
@@ -264,5 +264,6 @@ registerToolContentInfo({
   tool: "drawing",
   modelClass: DrawingContentModel,
   defaultHeight: kDrawingDefaultHeight,
+  exportNonDefaultHeight: true,
   defaultContent: defaultDrawingContent
 });

--- a/src/models/tools/drawing/drawing-export.ts
+++ b/src/models/tools/drawing/drawing-export.ts
@@ -1,6 +1,7 @@
 import { safeJsonParse } from "../../../utilities/js-utils";
 import { comma, StringBuilder } from "../../../utilities/string-builder";
-import { DrawingObjectDataType } from "./drawing-objects";
+import { ITileExportOptions } from "../tool-content-info";
+import { DrawingObjectDataType, ImageDrawingObjectData } from "./drawing-objects";
 import { DrawingToolChange } from "./drawing-types";
 
 export interface IDrawingObjectInfo {
@@ -10,7 +11,7 @@ export interface IDrawingObjectInfo {
   isDeleted?: boolean;          // true if the object has been deleted
 }
 
-export const exportDrawingTileSpec = (changes: string[]) => {
+export const exportDrawingTileSpec = (changes: string[], options?: ITileExportOptions) => {
   const objectInfoMap: Record<string, IDrawingObjectInfo> = {};
   const orderedIds: string[] = [];
   const builder = new StringBuilder();
@@ -45,6 +46,12 @@ export const exportDrawingTileSpec = (changes: string[]) => {
       }
     }
     const { id: idData, type, ...others } = data;
+    if ((data.type === "image") && options?.transformImageUrl) {
+      if (data.filename) {
+        (others as Partial<ImageDrawingObjectData>).url = options.transformImageUrl(data.url, data.filename);
+        delete (others as Partial<ImageDrawingObjectData>).filename;
+      }
+    }
     const othersJson = JSON.stringify(others);
     const othersStr = othersJson.slice(1, othersJson.length - 1);
     builder.pushLine(`{ "type": "${objInfo.type}", "id": "${id}", ${othersStr} }${comma(!isLast)}`, 4);

--- a/src/models/tools/drawing/drawing-objects.ts
+++ b/src/models/tools/drawing/drawing-objects.ts
@@ -64,6 +64,7 @@ export interface ImageDrawingObjectData {
   id?: string;
   url: string;
   originalUrl?: string;
+  filename?: string;
   x: number;
   y: number;
   width: number;

--- a/src/models/tools/geometry/geometry-content.ts
+++ b/src/models/tools/geometry/geometry-content.ts
@@ -1340,6 +1340,7 @@ registerToolContentInfo({
   metadataClass: GeometryMetadataModel,
   addSidecarNotes: true,
   defaultHeight: kGeometryDefaultHeight,
+  exportNonDefaultHeight: true,
   defaultContent: defaultGeometryContent,
   snapshotPostProcessor: mapTileIdsInGeometrySnapshot
 });

--- a/src/models/tools/geometry/geometry-content.ts
+++ b/src/models/tools/geometry/geometry-content.ts
@@ -285,7 +285,7 @@ export const GeometryContentModel = types
       return board.objectsList.filter(obj => self.isSelected(obj.id));
     },
     exportJson(options?: ITileExportOptions) {
-      return exportGeometryJson(self.changes);
+      return exportGeometryJson(self.changes, options);
     }
   }))
   .actions(self => ({
@@ -1049,13 +1049,13 @@ export const GeometryContentModel = types
         getOneSelectedSegment,
         getOneSelectedComment,
         getCommentAnchor,
-        getLastImageUrl(): string | undefined{
+        getLastImageUrl(): string[] | undefined {
           for (let i = self.changes.length - 1; i >= 0; --i) {
             const jsonChange = self.changes[i];
             const change = safeJsonParse<JXGChange>(jsonChange);
-            const imageUrl = getImageUrl(change);
+            const [imageUrl, filename] = getImageUrl(change) || [];
             if (imageUrl) {
-              return imageUrl;
+              return [imageUrl, filename];
             }
           }
         }
@@ -1322,13 +1322,14 @@ export function mapTileIdsInGeometrySnapshot(snapshot: SnapshotOut<GeometryConte
   return snapshot;
 }
 
-export function getImageUrl(change?: JXGChange) {
+export function getImageUrl(change?: JXGChange): string[] | undefined {
   if (!change) return;
 
   if (change.operation === "create" && change.target === "image" && change.parents) {
-    return change.parents[0] as string;
-  } else if (change.operation === "update" && change.properties && !Array.isArray(change.properties)) {
-    return change.properties.url;
+    return [change.parents[0] as string, (change.properties as JXGProperties)?.filename];
+  } else if (change.operation === "update" && change.properties &&
+              !Array.isArray(change.properties) && change.properties.url) {
+    return [change.properties.url, change.properties.filename];
   }
 }
 

--- a/src/models/tools/image/image-content.ts
+++ b/src/models/tools/image/image-content.ts
@@ -52,7 +52,7 @@ export const ImageContentModel = types
       return !!url && !isPlaceholderImage(url);
     },
     exportJson(options?: ITileExportOptions) {
-      return exportImageTileSpec(self.changes);
+      return exportImageTileSpec(self.changes, options);
     }
   }))
   .actions(self => ({

--- a/src/models/tools/image/image-import-export.test.ts
+++ b/src/models/tools/image/image-import-export.test.ts
@@ -1,13 +1,14 @@
 import { safeJsonParse } from "../../../utilities/js-utils";
+import { ITileExportOptions } from "../tool-content-info";
 import { ImageToolChange } from "./image-change";
 import {
-  exportImageTileSpec, IExportImageTileOptions, IImageTileImportSpec, importImageTileSpec, isImageTileImportSpec
+  exportImageTileSpec, IImageTileImportSpec, importImageTileSpec, isImageTileImportSpec, transformCurriculumImageUrl
 } from "./image-import-export";
 
 const isImageToolChangeArray = (changes: ImageToolChange[] | string[]): changes is ImageToolChange[] =>
         (changes.length > 0) && (typeof changes[0] === "object");
 
-const exportImageToolJson = (changes: ImageToolChange[] | string[], options?: IExportImageTileOptions) => {
+const exportImageToolJson = (changes: ImageToolChange[] | string[], options?: ITileExportOptions) => {
   const changesJson = isImageToolChangeArray(changes)
                         ? changes.map(change => JSON.stringify(change))
                         : changes;
@@ -79,7 +80,7 @@ describe("Image export with default options", () => {
       { operation: "update", url: "my/img/url", filename: "my/filename" }
     ];
     expect(exportImageToolJson(changes))
-            .toEqual({ type: "Image", url: "my/img/url", filename: "my/filename" });
+            .toEqual({ type: "Image", url: "my/img/url" });
   });
 
   it("should export updated tiles", () => {
@@ -97,7 +98,7 @@ describe("Image export with default options", () => {
       { operation: "update", url: "my/updated/img/url", filename: "my/updated/filename" }
     ];
     expect(exportImageToolJson(changes))
-            .toEqual({ type: "Image", url: "my/updated/img/url", filename: "my/updated/filename" });
+            .toEqual({ type: "Image", url: "my/updated/img/url" });
   });
 
   it("should export updated tiles with filenames", () => {
@@ -112,17 +113,17 @@ describe("Image export with default options", () => {
 });
 
 describe('Image export with transformUrl option', () => {
-  const transformUrl = (url: string, filename?: string) => {
-    return filename
-            ? `curriculum/images/${filename}`
-            : url;
+  const unitBasePath = "curriculum";
+
+  const transformImageUrl = (url: string, filename?: string) => {
+    return transformCurriculumImageUrl(url, unitBasePath, filename);
   };
 
   it("should export tiles created without filename", () => {
     const changes: ImageToolChange[] = [
       { operation: "update", url: "my/img/url" }
     ];
-    expect(exportImageToolJson(changes, { transformUrl }))
+    expect(exportImageToolJson(changes, { transformImageUrl }))
             .toEqual({ type: "Image", url: "my/img/url" });
   });
 
@@ -130,8 +131,8 @@ describe('Image export with transformUrl option', () => {
     const changes: ImageToolChange[] = [
       { operation: "update", url: "my/img/url", filename: "my/filename" }
     ];
-    expect(exportImageToolJson(changes, { transformUrl }))
-            .toEqual({ type: "Image", url: "curriculum/images/my/filename", filename: "my/filename" });
+    expect(exportImageToolJson(changes, { transformImageUrl }))
+            .toEqual({ type: "Image", url: "curriculum/images/my/filename" });
   });
 
 });

--- a/src/models/tools/image/image-import-export.ts
+++ b/src/models/tools/image/image-import-export.ts
@@ -1,12 +1,11 @@
 import { createChange, ImageToolChange } from "./image-change";
+import { ITileExportOptions } from "../tool-content-info";
 import { safeJsonParse } from "../../../utilities/js-utils";
 
 export interface IImageTileImportSpec {
   type: "Image";
   url: string;
 }
-
-const comma = (condition: boolean) => condition ? "," : "";
 
 export const isImageTileImportSpec = (snapshot: any): snapshot is IImageTileImportSpec =>
               (snapshot?.type === "Image") && (snapshot.url != null) && !snapshot.changes;
@@ -16,12 +15,13 @@ export const importImageTileSpec = (snapshot: IImageTileImportSpec) => {
   return { changes: [createChange(url)], ...others };
 };
 
-export interface IExportImageTileOptions {
-  transformUrl?: (url: string, filename?: string) => string;
-}
+export const transformCurriculumImageUrl = (url: string, unitBasePath?: string, filename?: string) => {
+  return unitBasePath && filename
+          ? `${unitBasePath}/images/${filename}`
+          : url;
+};
 
-export const exportImageTileSpec = (changes: string[], options?: IExportImageTileOptions) => {
-  const { transformUrl } = options || {};
+export const exportImageTileSpec = (changes: string[], options?: ITileExportOptions) => {
   let url = "";
   let filename = "";
   changes.forEach(change => {
@@ -31,11 +31,11 @@ export const exportImageTileSpec = (changes: string[], options?: IExportImageTil
       filename = imageChange.filename || "";
     }
   });
+  const transformedUrl = options?.transformImageUrl?.(url, filename) || url;
   return [
     `{`,
     `  "type": "Image",`,
-    `  "url": "${transformUrl?.(url, filename) || url}"${comma(!!filename)}`,
-    ...(filename ? [`  "filename": "${filename}"`] : []),
+    `  "url": "${transformedUrl}"`,
     `}`
   ].join("\n");
 };

--- a/src/models/tools/tool-content-info.ts
+++ b/src/models/tools/tool-content-info.ts
@@ -40,6 +40,7 @@ export function getToolContentInfoByTool(tool: string) {
 
 export interface ITileExportOptions {
   rowHeight?: number;
+  transformImageUrl?: (url: string, filename?: string) => string;
 }
 
 export interface IDocumentExportOptions extends ITileExportOptions {

--- a/src/models/tools/tool-content-info.ts
+++ b/src/models/tools/tool-content-info.ts
@@ -12,6 +12,7 @@ export interface IToolContentInfo {
   metadataClass?: any;
   addSidecarNotes?: boolean;
   defaultHeight?: number;
+  exportNonDefaultHeight?: boolean;
   defaultContent: (input?: any) => any;
   snapshotPostProcessor?: ToolTileModelContentSnapshotPostProcessor;
 }
@@ -38,6 +39,7 @@ export function getToolContentInfoByTool(tool: string) {
 }
 
 export interface ITileExportOptions {
+  rowHeight?: number;
 }
 
 export interface IDocumentExportOptions extends ITileExportOptions {


### PR DESCRIPTION
[[#178747097]](https://www.pivotaltracker.com/story/show/178747097)

Two main issues were identified and reproducible:
1. Export of image urls
    - The goal is to replace internal firebase urls for images imported from files on the assumption that those file would be added to the curriculum assets.
    - This transformation was sometimes happening for image tiles but the implementation was buggy so it didn't work consistently.
    - It wasn't happening at all for geometry tiles with background images or for drawing tiles with imported images.
    - The new implementation centralizes the code as much as possible so that it can be shared between tiles.
2. Tile/row heights weren't being exported and appropriate defaults weren't being respected so that exported content would often be displayed with odd (frequently too small) tile/row heights.
    - There is now code in place to export tile heights for tiles that aren't currently able to choose an appropriate default height and whose height at the time of export differs from the default height.