### PR TITLE
Load first program rather than dataset

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -254,7 +254,11 @@ export class DB {
     const personalDocumentsSnapshot = await personalDocumentsRef.once("value");
     const personalDocuments: DBOtherDocumentMap = personalDocumentsSnapshot &&
                                                   personalDocumentsSnapshot.val();
-    const lastPersonalDocument = findLast(personalDocuments, (pd) => !pd.properties || !pd.properties.isDeleted);
+    const lastProgramPersonalDocument = findLast(personalDocuments,
+      (pd) => !pd.properties || (!pd.properties.isDeleted && !pd.properties.dfHasRelay && !pd.properties.dfHasData));
+    const lastPersonalDocument = lastProgramPersonalDocument?.self?.documentKey
+      ? lastProgramPersonalDocument
+      : lastProgramPersonalDocument || findLast(personalDocuments, (pd) => !pd.properties || !pd.properties.isDeleted);
     return lastPersonalDocument?.self?.documentKey
       ? this.openOtherDocument(PersonalDocument, lastPersonalDocument.self.documentKey)
       : this.createPersonalDocument({ content: defaultContent });


### PR DESCRIPTION
This PR changes which document is autoloaded when Dataflow is first loaded in the browser.  Instead of loading the newest document, we first try to load the newest program document.  If there are no programs, then we load the newest document of any type.  If there are no documents, then we create a new document.