### PR TITLE
Program editor virtual sensors

### DIFF
--- a/cypress/integration/dataflow/branch/sensor_block_spec.js
+++ b/cypress/integration/dataflow/branch/sensor_block_spec.js
@@ -53,7 +53,7 @@ context('Sensor block tests',()=>{
                 dfblock.openHubSensorComboListDropdown();
                 dfblock.getHubSensorComboOptionList().each(($option, index, $optionList)=>{
                     if(($optionList.length<2)) {
-                        expect($option).to.contain('None Available');
+                        expect($option).to.contain(sensor + " Demo Data");
                     }
                     else {
                         expect($option).to.contain(sensor.toLowerCase());

--- a/src/dataflow/components/nodes/controls/sensor-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/sensor-select-control.tsx
@@ -141,7 +141,10 @@ export class SensorSelectControl extends Rete.Control {
         if (ch.missing) return `${kSensorMissingMessage} ${ch.channelId}`;
         let count = 0;
         channelsForType.forEach( c => { if (c.type === ch.type && ch.hubId === c.hubId) count++; } );
-        return `${ch.hubName}:${ch.type}${ch.plug > 0 && count > 1 ? `(plug ${ch.plug})` : ""}`;
+        const chStr = ch.virtual
+          ? `${ch.name} Demo Data`
+          : `${ch.hubName}:${ch.type}${ch.plug > 0 && count > 1 ? `(plug ${ch.plug})` : ""}`;
+        return chStr;
       };
 
       const options: any = [...channelsForType];

--- a/src/dataflow/utilities/node.ts
+++ b/src/dataflow/utilities/node.ts
@@ -267,6 +267,9 @@ export interface NodeChannelInfo {
   units: string;
   plug: number;
   value: number;
+  virtual?: boolean;
+  name: string;
+  method?: (t: number) => number;
 }
 
 export const roundNodeValue = (n: number) => {
@@ -381,3 +384,50 @@ export const kRelaySelectMessage = "Select a relay";
 export const kSensorSelectMessage = "Select a sensor";
 export const kRelayMissingMessage = "Finding";
 export const kSensorMissingMessage = "Finding";
+
+const virtualTempChannel: NodeChannelInfo = {
+  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "Temperature", channelId: "00001-VIR",
+  missing: false, type: "temperature", units: "°C", plug: 1, value: 0, virtual: true,
+  method: (t: number) => {
+    const vals = [20, 20, 20, 21, 21, 21, 20, 20, 21, 21, 21, 21, 21, 21, 21];
+    return vals[t % vals.length];
+  } };
+const virtualHumidChannel: NodeChannelInfo = {
+  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "Humidity", channelId: "00002-VIR",
+  missing: false, type: "humidity", units: "%", plug: 2, value: 0, virtual: true,
+  method: (t: number) => {
+    const vals = [60, 60, 60, 61, 61, 61, 62, 62, 62, 61, 61, 61, 61, 61, 61, 61];
+    return vals[t % vals.length];
+  } };
+const virtualCO2Channel: NodeChannelInfo = {
+  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "CO2", channelId: "00003-VIR",
+  missing: false, type: "CO2", units: "PPM", plug: 3, value: 0, virtual: true,
+  method: (t: number) => {
+    const vals = [409, 409, 410, 410, 410, 410, 411, 411, 410, 410, 410, 409, 409, 411, 411];
+    return vals[t % vals.length];
+  } };
+const virtualO2Channel: NodeChannelInfo = {
+  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "O2", channelId: "00004-VIR",
+  missing: false, type: "O2", units: "PPM", plug: 4, value: 0, virtual: true,
+  method: (t: number) => {
+    const vals = [21, 21, 21, 22, 22, 22, 21, 21, 21, 21, 22, 22, 22, 22, 22];
+    return vals[t % vals.length];
+  } };
+const virtualLightChannel: NodeChannelInfo = {
+  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "Light", channelId: "00005-VIR",
+  missing: false, type: "light", units: "lux", plug: 5, value: 0, virtual: true,
+  method: (t: number) => {
+    const vals = [9000, 9000, 9001, 9001, 9002, 9002, 9002, 9001, 9001, 9001, 9000, 9001, 9001, 9002, 9002];
+    return vals[t % vals.length];
+  } };
+const virtualPartChannel: NodeChannelInfo = {
+  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "Particulates", channelId: "00007VIR",
+  missing: false, type: "particulates", units: "PM2.5", plug: 7, value: 0, virtual: true,
+  method: (t: number) => {
+    const vals = [10, 10, 10, 10, 10, 10, 11, 11, 11, 11, 11, 11, 11, 11, 11];
+    return vals[t % vals.length];
+  } };
+
+export const virtualSensorChannels: NodeChannelInfo[] = [
+  virtualTempChannel, virtualHumidChannel, virtualCO2Channel, virtualO2Channel,
+  virtualLightChannel, virtualPartChannel ];


### PR DESCRIPTION
This PR adds 6 virtual sensors that always appear in the sensor block.  There is one sensor for all of the sensor types other than soil moisture (which is intentionally ignored since we don't know enough about the sensor's expected values).  These virtual sensors display predefined data from an array of values (we will try to make this more sophisticated in later work tied to this story) and update on the program heartbeat (similar to the generators).  A user can select any of these sensors and see the values in the program block.  

This work DOES NOT include allowing the user to run a program and record the sensor data - that will be in a subsequent PR.

![sesnors](https://user-images.githubusercontent.com/5126913/126566318-60fbb8bd-f3d3-42cf-8c87-5d2b2258639a.gif)
