### PR TITLE
Fix sensor Cypress test

### DIFF
--- a/cypress/integration/dataflow/branch/sensor_block_spec.js
+++ b/cypress/integration/dataflow/branch/sensor_block_spec.js
@@ -45,17 +45,16 @@ context('Sensor block tests',()=>{
             dfblock.getInputNodesNum(testBlock).should('not.exist');
         })
         it('verify changing sensor type changes the hub list selection',()=>{
-            var sensorTypes=['Humidity','Temperature','Particulates'];
+            var sensorTypes = ['Humidity','Temperature','Particulates'];
 
             cy.wrap(sensorTypes).each((sensor, index, sensorList)=>{
                 dfblock.selectSensorType(sensor);
                 cy.wait(10000)
                 dfblock.openHubSensorComboListDropdown();
-                dfblock.getHubSensorComboOptionList().each(($option, index, $optionList)=>{
-                    if(($optionList.length<2)) {
+                dfblock.getHubSensorComboOptionList().each(($option, index, $optionList) => {
+                    if (index === 0) {
                         expect($option).to.contain(sensor + " Demo Data");
-                    }
-                    else {
+                    } else {
                         expect($option).to.contain(sensor.toLowerCase());
                     }
                 })


### PR DESCRIPTION
Minor tweaks to Dataflow Cypress tests so that the tests succeed regardless of what sensors are on and running.  In the future, however, we should avoid tests like this that relay on the state of physical devices or external software that change from test to test.