### PR TITLE
Allow virtual sensors blocks to function correctly when a program is running

### DIFF
--- a/src/dataflow/components/dataflow-program.tsx
+++ b/src/dataflow/components/dataflow-program.tsx
@@ -730,7 +730,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
     let hasValidRelay = false;
     let hasLightbulb = false;
     this.programEditor.nodes.forEach((n: Node) => {
-      if (n.name === "Sensor" && n.data.sensor) {
+      if (n.name === "Sensor" && n.data.sensor && !n.data.virtual) {
         const chInfo = this.channels.find(ci => ci.channelId === n.data.sensor);
         if (chInfo) {
           // only add hubs once
@@ -983,9 +983,9 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
       const chInfo = this.channels.find(ci => ci.channelId === n.data.sensor);
 
       // update virtual sensors
-      if (chInfo?.virtual) {
+      if (chInfo?.virtualValueMethod) {
         const time = Math.floor(Date.now() / 1000);
-        chInfo.value = chInfo.method ? chInfo.method(time) : 0;
+        chInfo.value = chInfo.virtualValueMethod(time);
       }
 
       if (chInfo && chInfo.value) {

--- a/src/dataflow/components/nodes/controls/sensor-select-control.tsx
+++ b/src/dataflow/components/nodes/controls/sensor-select-control.tsx
@@ -193,9 +193,11 @@ export class SensorSelectControl extends Rete.Control {
 
     const initialType = node.data.type || "none";
     const initialSensor = node.data.sensor || "none";
+    const initialVirtual = node.data.virtual || false;
     node.data.type = initialType;
     node.data.sensor = initialSensor;
     node.data.nodeValue = NaN;
+    node.data.virtual = initialVirtual;
 
     this.props = {
       readonly,
@@ -258,6 +260,7 @@ export class SensorSelectControl extends Rete.Control {
   public setSensor = (val: any) => {
     const nch: NodeChannelInfo = this.props.channels.find((ch: any) => ch.channelId === val);
     this.setSensorValue(nch ? nch.value : NaN);
+    this.setSensorVirtualState(!!nch?.virtual);
 
     if (nch && nch.type && this.getData("type") !== nch.type) {
       this.props.type = nch.type;
@@ -272,6 +275,12 @@ export class SensorSelectControl extends Rete.Control {
   public setSensorValue = (val: any) => {
     this.props.value = val;
     this.putData("nodeValue", val);
+    (this as any).update();
+  }
+
+  public setSensorVirtualState = (val: boolean) => {
+    this.props.value = val;
+    this.putData("virtual", val);
     (this as any).update();
   }
 

--- a/src/dataflow/utilities/node.ts
+++ b/src/dataflow/utilities/node.ts
@@ -267,9 +267,9 @@ export interface NodeChannelInfo {
   units: string;
   plug: number;
   value: number;
-  virtual?: boolean;
   name: string;
-  method?: (t: number) => number;
+  virtual?: boolean;
+  virtualValueMethod?: (t: number) => number;
 }
 
 export const roundNodeValue = (n: number) => {
@@ -388,42 +388,42 @@ export const kSensorMissingMessage = "Finding";
 const virtualTempChannel: NodeChannelInfo = {
   hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "Temperature", channelId: "00001-VIR",
   missing: false, type: "temperature", units: "°C", plug: 1, value: 0, virtual: true,
-  method: (t: number) => {
+  virtualValueMethod: (t: number) => {
     const vals = [20, 20, 20, 21, 21, 21, 20, 20, 21, 21, 21, 21, 21, 21, 21];
     return vals[t % vals.length];
   } };
 const virtualHumidChannel: NodeChannelInfo = {
   hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "Humidity", channelId: "00002-VIR",
   missing: false, type: "humidity", units: "%", plug: 2, value: 0, virtual: true,
-  method: (t: number) => {
+  virtualValueMethod: (t: number) => {
     const vals = [60, 60, 60, 61, 61, 61, 62, 62, 62, 61, 61, 61, 61, 61, 61, 61];
     return vals[t % vals.length];
   } };
 const virtualCO2Channel: NodeChannelInfo = {
   hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "CO2", channelId: "00003-VIR",
   missing: false, type: "CO2", units: "PPM", plug: 3, value: 0, virtual: true,
-  method: (t: number) => {
+  virtualValueMethod: (t: number) => {
     const vals = [409, 409, 410, 410, 410, 410, 411, 411, 410, 410, 410, 409, 409, 411, 411];
     return vals[t % vals.length];
   } };
 const virtualO2Channel: NodeChannelInfo = {
   hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "O2", channelId: "00004-VIR",
   missing: false, type: "O2", units: "PPM", plug: 4, value: 0, virtual: true,
-  method: (t: number) => {
+  virtualValueMethod: (t: number) => {
     const vals = [21, 21, 21, 22, 22, 22, 21, 21, 21, 21, 22, 22, 22, 22, 22];
     return vals[t % vals.length];
   } };
 const virtualLightChannel: NodeChannelInfo = {
   hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "Light", channelId: "00005-VIR",
   missing: false, type: "light", units: "lux", plug: 5, value: 0, virtual: true,
-  method: (t: number) => {
+  virtualValueMethod: (t: number) => {
     const vals = [9000, 9000, 9001, 9001, 9002, 9002, 9002, 9001, 9001, 9001, 9000, 9001, 9001, 9002, 9002];
     return vals[t % vals.length];
   } };
 const virtualPartChannel: NodeChannelInfo = {
   hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "Particulates", channelId: "00007VIR",
   missing: false, type: "particulates", units: "PM2.5", plug: 7, value: 0, virtual: true,
-  method: (t: number) => {
+  virtualValueMethod: (t: number) => {
     const vals = [10, 10, 10, 10, 10, 10, 11, 11, 11, 11, 11, 11, 11, 11, 11];
     return vals[t % vals.length];
   } };


### PR DESCRIPTION
This PR adds the ability for virtual sensors to be run in the lambda program executor (these are the "demo data" entries in the sensor list).  A `virtual` flag is included in the program node data section which indicates that a virtual value creation method should be used instead of attempting to get sensor values from a live sensor.

The changes in this PR only work with related changes in the dataflow-execution-framework repo.

![run-virtaul-sensor](https://user-images.githubusercontent.com/5126913/126838560-2ce26594-c78d-4066-b8a7-1c7644fd21f8.gif)