### PR TITLE
Logging improvements

### DIFF
--- a/src/lib/db-listeners/index.ts
+++ b/src/lib/db-listeners/index.ts
@@ -3,7 +3,7 @@ import { observable } from "mobx";
 import { IDisposer, onSnapshot } from "mobx-state-tree";
 
 import { DB, Monitor } from "../db";
-import { LogEventName, Logger } from "../logger";
+// import { LogEventName, Logger } from "../logger";
 import { DBLatestGroupIdListener } from "./db-latest-group-id-listener";
 import { DBGroupsListener } from "./db-groups-listener";
 import { DBOtherDocumentsListener } from "./db-other-docs-listener";
@@ -245,8 +245,8 @@ export class DBListeners extends BaseListener {
       // Only log the first time we monitor the document. We generally monitor/unmonitor/remonitor
       // several times during startup, but this function always adds monitoring as the last step,
       // so logging the first instance is sufficient for our purposes.
-      Logger.log(LogEventName.INTERNAL_MONITOR_DOCUMENT,
-                { type: document.type, key: document.key, uid: document.uid, groupId: document.groupId });
+      // Logger.log(LogEventName.INTERNAL_MONITOR_DOCUMENT,
+      //           { type: document.type, key: document.key, uid: document.uid, groupId: document.groupId });
     }
 
     const updatePath = this.db.firebase.getUserDocumentPath(user, key, document.uid);
@@ -274,8 +274,8 @@ export class DBListeners extends BaseListener {
     // if it were to be called for a user's own document the result would be not saving the user's work.
     const { user } = this.db.stores;
     if (user.id === document.uid) {
-      Logger.log(LogEventName.INTERNAL_UNMONITOR_DOCUMENT,
-                { type: document.type, key: document.key, uid: document.uid, groupId: document.groupId });
+      // Logger.log(LogEventName.INTERNAL_UNMONITOR_DOCUMENT,
+      //           { type: document.type, key: document.key, uid: document.uid, groupId: document.groupId });
     }
     const docListener = this.modelListeners[`document:${document.key}`];
     docListener?.modelDisposer?.();

--- a/src/lib/logger.test.ts
+++ b/src/lib/logger.test.ts
@@ -1,4 +1,4 @@
-import mock from "xhr-mock";
+import mockXhr from "xhr-mock";
 import { Logger, LogEventName } from "./logger";
 import { DocumentModel, DocumentModelType } from "../models/document/document";
 import { ProblemDocument } from "../models/document/document-types";
@@ -7,12 +7,15 @@ import { DocumentContentModel } from "../models/document/document-content";
 import { InvestigationModel } from "../models/curriculum/investigation";
 import { IStores, createStores } from "../models/stores/stores";
 import { UserModel } from "../models/stores/user";
-import { WorkspaceModel, ProblemWorkspace, WorkspaceModelType } from "../models/stores/workspace";
+import { WorkspaceModel, ProblemWorkspace, WorkspaceModelType, LearningLogWorkspace } from "../models/stores/workspace";
 import { defaultGeometryContent } from "../models/tools/geometry/geometry-content";
 import { JXGChange } from "../models/tools/geometry/jxg-changes";
 import { defaultTextContent } from "../models/tools/text/text-content";
 import { IDragTileItem, ToolTileModel } from "../models/tools/tool-tile";
 import { createSingleTileContent } from "../utilities/test-utils";
+import { ProblemModelType } from "../models/curriculum/problem";
+import { UIModel } from "../models/stores/ui";
+import { ENavTab } from "../models/view/nav-tabs";
 
 const investigation = InvestigationModel.create({
   ordinal: 1,
@@ -27,33 +30,138 @@ const problem = investigation.getProblem(1);
 // }));
 
 describe("uninitialized logger", () => {
-  it("throws exception if not initialized", () => {
-    expect(() => Logger.Instance).toThrow();
-  });
-});
-
-describe("logger", () => {
   let stores: IStores;
 
   beforeEach(() => {
-    mock.setup();
+    mockXhr.setup();
+    stores = createStores({
+      appMode: "authed",
+      appConfig: AppConfigModel.create({ appName: "TestLogger"}),
+      user: UserModel.create({id: "0", portal: "test"})
+    });
+  });
+
+  afterEach(() => {
+    mockXhr.reset();
+    mockXhr.teardown();
+  });
+
+  it("throws exception if not initialized", () => {
+    expect(() => Logger.Instance).toThrow();
+  });
+
+  it("does not log when not initialized", (done) => {
+    const TEST_LOG_MESSAGE = 999;
+    const mockPostHandler = jest.fn((req, res) => {
+      expect(mockPostHandler).toHaveBeenCalledTimes(1);
+      done();
+      return res.status(201);
+    });
+    mockXhr.use(mockPostHandler);
+
+    // should not log since we're not initialized
+    Logger.log(TEST_LOG_MESSAGE);
+    Logger.logTileEvent(TEST_LOG_MESSAGE);
+
+    Logger.initializeLogger(stores);
+
+    // should log now that we're initialized
+    Logger.logTileEvent(TEST_LOG_MESSAGE);
+  });
+});
+
+describe("dev/qa/test logger with DEBUG_LOGGER false", () => {
+  let stores: IStores;
+
+  beforeEach(() => {
+    mockXhr.setup();
     stores = createStores({
       appMode: "test",
       appConfig: AppConfigModel.create({ appName: "TestLogger"}),
-      user: UserModel.create({id: "0", portal: "test"})
+      ui: UIModel.create({
+        activeNavTab: ENavTab.kStudentWork,
+        problemWorkspace: {
+          type: ProblemWorkspace,
+          mode: "1-up"
+        },
+        learningLogWorkspace: {
+          type: LearningLogWorkspace,
+          mode: "1-up"
+        },
+      }),
+      user: UserModel.create({id: "0", type: "teacher", portal: "test"})
     });
 
     Logger.initializeLogger(stores, investigation, problem);
   });
 
   afterEach(() => {
-    mock.teardown();
+    mockXhr.reset();
+    mockXhr.teardown();
+  });
+
+  it("does not log in dev/qa/test modes", (done) => {
+    const TEST_LOG_MESSAGE = 999;
+    const mockPostHandler = jest.fn((req, res) => {
+      expect(mockPostHandler).toHaveBeenCalledTimes(1);
+      done();
+      return res.status(201);
+    });
+    mockXhr.use(mockPostHandler);
+
+    // should not be logged due to mode
+    Logger.log(TEST_LOG_MESSAGE);
+
+    // should be logged
+    Logger.isLoggingEnabled = true;
+    Logger.log(TEST_LOG_MESSAGE);
+  });
+
+});
+
+describe("authed logger", () => {
+  let stores: IStores;
+
+  beforeEach(() => {
+    mockXhr.setup();
+    stores = createStores({
+      appMode: "authed",
+      appConfig: AppConfigModel.create({ appName: "TestLogger"}),
+      user: UserModel.create({
+        id: "0", type: "student", portal: "test",
+        loggingRemoteEndpoint: "foo"
+      })
+    });
+
+    Logger.initializeLogger(stores, investigation, problem);
+  });
+
+  afterEach(() => {
+    mockXhr.teardown();
+  });
+
+  describe("updateProblem()", () => {
+
+    const _investigation = InvestigationModel.create({
+      ordinal: 2,
+      title: "Investigation 2",
+      problems: [ { ordinal: 1, title: "Problem 2.1" } ]
+    });
+    const _problem = investigation.getProblem(1) as ProblemModelType;
+
+    it("updateProblem()", () => {
+      Logger.updateProblem(_investigation, _problem);
+
+      expect((Logger as any)._instance.investigationTitle = "Investigation 2");
+      expect((Logger as any)._instance.problemTitle = "Problem 2.1");
+    });
+
   });
 
   describe ("tile CRUD events", () => {
 
     it("can log a simple message with all the appropriate properties", (done) => {
-      mock.post(/.*/, (req, res) => {
+      mockXhr.post(/.*/, (req, res) => {
         expect(req.header("Content-Type")).toEqual("application/json; charset=UTF-8");
 
         const request = JSON.parse(req.body());
@@ -78,7 +186,7 @@ describe("logger", () => {
     it("can log tile creation", (done) => {
       const tile = ToolTileModel.create({ content: defaultTextContent() });
 
-      mock.post(/.*/, (req, res) => {
+      mockXhr.post(/.*/, (req, res) => {
         const request = JSON.parse(req.body());
 
         expect(request.event).toBe("CREATE_TILE");
@@ -108,7 +216,7 @@ describe("logger", () => {
       });
       stores.documents.add(document);
 
-      mock.post(/.*/, (req, res) => {
+      mockXhr.post(/.*/, (req, res) => {
         const request = JSON.parse(req.body());
 
         expect(request.event).toBe("CREATE_TILE");
@@ -152,7 +260,7 @@ describe("logger", () => {
       stores.documents.add(sourceDocument);
       stores.documents.add(destinationDocument);
 
-      mock.post(/.*/, (req, res) => {
+      mockXhr.post(/.*/, (req, res) => {
         const request = JSON.parse(req.body());
 
         expect(request.event).toBe("COPY_TILE");
@@ -194,7 +302,7 @@ describe("logger", () => {
       const tile = ToolTileModel.create({ content: defaultGeometryContent() });
       const change: JXGChange = { operation: "create", target: "point" };
 
-      mock.post(/.*/, (req, res) => {
+      mockXhr.post(/.*/, (req, res) => {
         const request = JSON.parse(req.body());
 
         expect(request.event).toBe("GRAPH_TOOL_CHANGE");
@@ -241,7 +349,7 @@ describe("logger", () => {
     });
 
     it("can log opening the primary document", (done) => {
-      mock.post(/.*/, (req, res) => {
+      mockXhr.post(/.*/, (req, res) => {
         const request = JSON.parse(req.body());
 
         expect(request.event).toBe("VIEW_SHOW_DOCUMENT");
@@ -256,7 +364,7 @@ describe("logger", () => {
     });
 
     it("can log opening the comparison document", (done) => {
-      mock.post(/.*/, (req, res) => {
+      mockXhr.post(/.*/, (req, res) => {
         const request = JSON.parse(req.body());
 
         expect(request.event).toBe("VIEW_SHOW_COMPARISON_DOCUMENT");
@@ -271,7 +379,7 @@ describe("logger", () => {
     });
 
     it("can log toggling the comparison panel", (done) => {
-      mock.post(/.*/, (req, res) => {
+      mockXhr.post(/.*/, (req, res) => {
         const request = JSON.parse(req.body());
 
         expect(request.event).toBe("VIEW_SHOW_COMPARISON_PANEL");
@@ -284,7 +392,7 @@ describe("logger", () => {
     });
 
     it("can log toggling of mode", (done) => {
-      mock.post(/.*/, (req, res) => {
+      mockXhr.post(/.*/, (req, res) => {
         const request = JSON.parse(req.body());
 
         expect(request.event).toBe("VIEW_ENTER_FOUR_UP");

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -116,7 +116,13 @@ interface IDocumentInfo {
 }
 
 export class Logger {
+  public static isLoggingEnabled = false;
+
   public static initializeLogger(stores: IStores, investigation?: InvestigationModelType, problem?: ProblemModelType) {
+    const { appMode } = stores;
+    const noLogModes: Array<typeof appMode> = ["dev", "qa", "test"];
+    this.isLoggingEnabled = !noLogModes.includes(appMode) || DEBUG_LOGGER;
+
     if (DEBUG_LOGGER) {
       // eslint-disable-next-line no-console
       console.log("Logger#initializeLogger called.");
@@ -274,7 +280,7 @@ export class Logger {
     const document = this.stores.documents.findDocumentOfTile(tileId);
     if (document) {
       const { type, key, uid, title, changeCount, properties } = document;
-      return { type, key, uid, title, changeCount, properties: properties && properties.toJSON() || {} };
+      return { type, key, uid, title, changeCount, properties: properties?.toJSON() || {} };
     } else {
       return {
         type: "Instructions"        // eventually we will need to include copying from supports
@@ -288,6 +294,8 @@ function sendToLoggingService(data: LogMessage, user: UserModelType) {
     // eslint-disable-next-line no-console
     console.log("Logger#sendToLoggingService sending", JSON.stringify(data), "to", logManagerUrl);
   }
+  if (!Logger.isLoggingEnabled) return;
+
   const request = new XMLHttpRequest();
 
   request.upload.addEventListener("load", () => user.setIsLoggingConnected(true));


### PR DESCRIPTION
- Disable logging in dev/qa/test modes
    - @eireland reported that excessive logging was interfering with her cypress test debugging. We take this opportunity to disable logging in dev/qa/test modes.
- Enhance jest tests
    - Improve coverage of logging code.
- Comment out logging of `INTERNAL_MONITOR_DOCUMENT` and `INTERNAL_UNMONITOR_DOCUMENT`
    - These log messages were added to diagnose a potential cause of users losing data. Since adding them there has been no evidence that monitoring logic is at fault and they generate a boatload of spurious log messages so we simply comment them out for now.


