### PR TITLE
Support `network` and `chat` url parameters

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,8 +1,8 @@
 import initials from "initials";
 import jwt from "jsonwebtoken";
 import superagent from "superagent";
-import { AppMode } from "../models/stores/stores";
-import { QueryParams, DefaultUrlParams } from "../utilities/url-params";
+import { AppMode } from "../models/stores/store-types";
+import { QueryParams, urlParams as pageUrlParams } from "../utilities/url-params";
 import { NUM_FAKE_STUDENTS, NUM_FAKE_TEACHERS } from "../components/demo/demo-creator";
 import { AppConfigModelType } from "../models/stores/app-config-model";
 import { IPortalClassOffering } from "../models/stores/user";
@@ -244,7 +244,7 @@ export const authenticate = (appMode: AppMode, appConfig: AppConfigModelType, ur
     unitCode?: string;
   }
   return new Promise<IAuthenticateResponse>((resolve, reject) => {
-    urlParams = urlParams || DefaultUrlParams;
+    urlParams = urlParams || pageUrlParams;
     const unitCode = urlParams.unit || "";
     // when launched as a report, the params will not contain the problemOrdinal
     const problemOrdinal = urlParams.problem || appConfig.defaultProblemOrdinal;

--- a/src/models/stores/store-types.ts
+++ b/src/models/stores/store-types.ts
@@ -1,0 +1,2 @@
+export const AppModes = ["authed", "dev", "test", "demo", "qa"] as const;
+export type AppMode = typeof AppModes[number];

--- a/src/models/stores/stores.test.ts
+++ b/src/models/stores/stores.test.ts
@@ -1,4 +1,5 @@
-import { createStores, AppMode, isFeatureSupported, getDisabledFeaturesOfTile } from "./stores";
+import { AppMode } from "./store-types";
+import { createStores, isFeatureSupported, getDisabledFeaturesOfTile } from "./stores";
 import { UnitModel } from "../curriculum/unit";
 import { InvestigationModel } from "../curriculum/investigation";
 import { ProblemModel } from "../curriculum/problem";

--- a/src/models/stores/stores.ts
+++ b/src/models/stores/stores.ts
@@ -14,8 +14,7 @@ import { LearningLogWorkspace, ProblemWorkspace } from "./workspace";
 import { ClipboardModel, ClipboardModelType } from "./clipboard";
 import { SelectionStoreModel, SelectionStoreModelType } from "./selection";
 import { getSetting } from "./settings";
-
-export type AppMode = "authed" | "dev" | "test" | "demo" | "qa";
+import { AppMode } from "./store-types";
 
 export interface IBaseStores {
   appMode: AppMode;

--- a/src/models/stores/user.ts
+++ b/src/models/stores/user.ts
@@ -2,6 +2,7 @@ import initials from "initials";
 import { types } from "mobx-state-tree";
 import { AuthenticatedUser } from "../../lib/auth";
 import { PortalFirebaseStudentJWT } from "../../lib/portal-types";
+import { urlParams } from "../../utilities/url-params";
 import { UserTypeEnum } from "./user-types";
 
 export const PortalClassOffering = types
@@ -35,6 +36,7 @@ export const UserModel = types
     offeringId: "",
     latestGroupId: types.maybe(types.string),
     portal: "",
+    teacherNetwork: types.maybe(types.string),
     loggingRemoteEndpoint: types.maybe(types.string),
     portalClassOfferings: types.array(PortalClassOffering),
     demoClassHashes: types.array(types.string),
@@ -68,6 +70,8 @@ export const UserModel = types
       self.id = user.id;
       self.portal = user.portal;
       self.type = user.type;
+      // TODO: replace this with real implementation
+      self.teacherNetwork = user.type === "teacher" ? urlParams.network : undefined;
       self.className = user.className;
       self.classHash = user.classHash;
       self.offeringId = user.offeringId;
@@ -100,6 +104,9 @@ export const UserModel = types
     },
     get isTeacher() {
       return self.type === "teacher";
+    },
+    get isNetworkedTeacher() {
+      return (self.type === "teacher") && !!self.teacherNetwork;
     },
     get initials() {
       return initials(self.name);

--- a/src/models/tools/text/text-content.test.ts
+++ b/src/models/tools/text/text-content.test.ts
@@ -79,9 +79,15 @@ describe("TextContentModel", () => {
     const model = TextContentModel.create({ text: foo });
     expect(Plain.serialize(model.asSlate())).toBe(foo);
 
-    model.setMarkdown("foo");
-    expect(model.format).toBe("markdown");
-    expect(Plain.serialize(model.asSlate())).toBe(foo);
+    jestSpyConsole("warn", mockConsole => {
+      // triggers console warning about "the `leaves` property of Text nodes has been removed"
+      model.setMarkdown("foo");
+      expect(model.format).toBe("markdown");
+      expect(Plain.serialize(model.asSlate())).toBe(foo);
+
+      // failure of this test => the console mock can be removed
+      expect(mockConsole).toHaveBeenCalled();
+    });
 
     const fooValue = Value.fromJSON(fooJson);
     model.setSlate(fooValue);

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,1 +1,34 @@
 import "@testing-library/jest-dom";
+
+/*
+ * jestSpyConsole
+ *
+ * Utility function for mocking/suppressing console messages during tests
+ *
+ * Usage:
+
+  it("suppresses console messages while capturing calls", () => {
+    jestSpyConsole("warn", mockConsoleFn => {
+      // doesn't log to console
+      console.warn("Warning!");
+      // but does capture calls to console
+      expect(mockConsoleFn).toHaveBeenCalled();
+    });
+  });
+
+ */
+type ConsoleMethod = "log" | "warn" | "error";
+(global as any).jestSpyConsole = (method: ConsoleMethod, fn: (spyFn: jest.SpyInstance) => void) => {
+  // intercept and suppress console methods
+  const mockConsoleFn = jest.spyOn(global.console, method).mockImplementation(() => null);
+
+  // call the client's code
+  fn(mockConsoleFn);
+
+  // restore console behavior
+  mockConsoleFn.mockRestore();
+};
+
+declare global {
+  function jestSpyConsole(method: ConsoleMethod, fn: (spyFn: jest.SpyInstance) => void): void;
+}

--- a/src/utilities/url-params.test.ts
+++ b/src/utilities/url-params.test.ts
@@ -1,0 +1,49 @@
+import { processUrlParams } from "./url-params";
+
+describe("urlParams", () => {
+  const originalLocation = window.location;
+
+  const mockWindowLocation = (newLocation: Location | URL) => {
+    delete (window as any).location;
+    window.location = newLocation as Location;
+  };
+
+  const setLocation = (url: string) => {
+    mockWindowLocation(new URL(url));
+  };
+
+  const setQueryParams = (params?: string) => {
+    setLocation(`https://concord.org${params ? `?${params}` : ""}`);
+  };
+
+  const processQueryParams = (params?: string) => {
+    setQueryParams(params);
+    return processUrlParams();
+  };
+
+  afterEach(() => {
+    mockWindowLocation(originalLocation);
+  });
+
+  it("appMode defaults to dev but can be overridden", () => {
+    expect(processQueryParams().appMode).toBe("dev");
+    expect(processQueryParams("appMode").appMode).toBe("dev");
+    expect(processQueryParams("appMode=bogus").appMode).toBe("dev");
+    expect(processQueryParams("appMode=authed").appMode).toBe("authed");
+  });
+
+  it("demo param accepts but does not require value", () => {
+    expect(processQueryParams().demo).toBe(false);
+    expect(processQueryParams("demo").demo).toBe(true);
+    expect(processQueryParams("demo=true").demo).toBe(true);
+    expect(processQueryParams("demo=yes").demo).toBe(true);
+  });
+
+  it("chat param accepts but does not require value", () => {
+    expect(processQueryParams().chat).toBe(false);
+    expect(processQueryParams("chat").chat).toBe(true);
+    expect(processQueryParams("chat=true").chat).toBe(true);
+    expect(processQueryParams("chat=yes").chat).toBe(true);
+    expect(processQueryParams("chat=fixtures").chat).toBe("fixtures");
+  });
+});

--- a/src/utilities/url-params.ts
+++ b/src/utilities/url-params.ts
@@ -1,5 +1,5 @@
 import { parse } from "query-string";
-import { AppMode } from "../models/stores/stores";
+import { AppMode, AppModes } from "../models/stores/store-types";
 import { DBClearLevel } from "../lib/db";
 
 export interface QueryParams {
@@ -42,6 +42,16 @@ export interface QueryParams {
   reportType?: string;
 
   //
+  // teacher network development features
+  //
+
+  // name of teacher network to associate teacher with (until we have a real implementation)
+  network?: string;
+  // if present without a value show actual (under development) chat implementation
+  // if present with value "fixtures" include fake messages for development purposes
+  chat?: boolean | "fixtures";
+
+  //
   // demo or qa mode parameters
   //
 
@@ -60,24 +70,23 @@ export interface QueryParams {
   qaClear?: DBClearLevel;
 }
 
-const params = parse(location.search);
-
-export const DefaultUrlParams: QueryParams = {
-  appMode: "dev",
-  unit: undefined,
-  problem: undefined,
-  token: undefined,
-  domain: undefined,
-  demo: undefined,
-  demoName: undefined,
-  class: undefined,
-  offering: undefined,
-  reportType: undefined,
-  fakeClass: undefined,
-  fakeUser: undefined,
-  qaGroup: undefined,
-  qaClear: undefined,
-  testMigration: undefined,
+export const processUrlParams = (): QueryParams => {
+  const params = parse(location.search);
+  return {
+    ...params,
+    // defaults to dev mode if not specified or not valid
+    appMode: (typeof params.appMode === "string") && AppModes.includes(params.appMode as AppMode)
+              ? params.appMode as AppMode
+              : "dev",
+    // allows use of ?demo without a value for demo mode
+    demo: params.demo !== undefined,
+    // allows use of ?chat without a value to enable chat feature
+    chat: params.chat === undefined
+            ? false
+            : params.chat === "fixtures"
+                ? params.chat
+                : true  // any other value simply enables the feature
+  };
 };
-                                                    // allows use of ?demo for url
-export const urlParams: QueryParams = { ...params, ...{ demo: typeof params.demo !== "undefined" } };
+
+export const urlParams = processUrlParams();


### PR DESCRIPTION
plus:
- general improvements to url handling
- add jest tests
- add jestSpyConsole() utility function
- use it to suppress console warning during tests