### PR TITLE
Fixes the overlapping click control between the collapsed tabs and te drag handles

### DIFF
--- a/src/assets/left-drag.svg
+++ b/src/assets/left-drag.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="22" height="44" viewBox="0 0 22 44">
+  <g fill="none" fill-rule="evenodd">
+    <path fill="#FFF" d="M22 44V0C9.85 0 0 9.85 0 22s9.85 22 22 22z" transform="translate(-772.000000, -2140.000000) translate(548.000000, 2060.000000) translate(224.000000, 80.000000)"/>
+    <path fill="#CFCFCF" d="M22 42V2C10.954 2 2 10.954 2 22s8.954 20 20 20z" transform="translate(-772.000000, -2140.000000) translate(548.000000, 2060.000000) translate(224.000000, 80.000000)"/>
+    <path fill="#545454" d="M10 18L15 26 5 26z" transform="translate(-772.000000, -2140.000000) translate(548.000000, 2060.000000) translate(224.000000, 80.000000) translate(10.000000, 22.000000) rotate(-90.000000) translate(-10.000000, -22.000000)"/>
+  </g>
+</svg>

--- a/src/assets/right-drag.svg
+++ b/src/assets/right-drag.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="22" height="44" viewBox="0 0 22 44">
+  <g fill="none" fill-rule="evenodd">
+    <path fill="#FFF" d="M0 44c12.15 0 22-9.85 22-22S12.15 0 0 0v44z" transform="translate(-794.000000, -2140.000000) translate(548.000000, 2060.000000) translate(245.999882, 80.000000)"/>
+    <path fill="#CFCFCF" d="M0 42c11.046 0 20-8.954 20-20S11.046 2 0 2v40z" transform="translate(-794.000000, -2140.000000) translate(548.000000, 2060.000000) translate(245.999882, 80.000000)"/>
+    <path fill="#545454" d="M12 18L17 26 7 26z" transform="translate(-794.000000, -2140.000000) translate(548.000000, 2060.000000) translate(245.999882, 80.000000) translate(12.000118, 22.000000) scale(-1, 1) rotate(-90.000000) translate(-12.000118, -22.000000)"/>
+  </g>
+</svg>

--- a/src/components/document/collapsed-workspace-tab.scss
+++ b/src/components/document/collapsed-workspace-tab.scss
@@ -12,6 +12,7 @@
   box-sizing: border-box;
   border-width: 2px;
   border-style: solid;
+  z-index: 2;
   display: flex;
   &.problem {
     border-color: $workspace-teal;

--- a/src/components/document/resize-panel-divider.scss
+++ b/src/components/document/resize-panel-divider.scss
@@ -22,7 +22,7 @@
 
     .drag-thumbnail {
       position: absolute;
-      z-index: 3;
+      z-index: 1;
       margin-top: 9px;
       top: 50%;
     }
@@ -33,7 +33,7 @@
       left: 0;
       width: 44px;
       height: 44px;
-      z-index: 1;
+      z-index: 3;
       top: 50%;
       opacity: 0.01%;
       &:hover {

--- a/src/components/document/resize-panel-divider.scss
+++ b/src/components/document/resize-panel-divider.scss
@@ -30,9 +30,10 @@
       display: flex;
       flex-direction: row;
       position: relative;
+      left: 0;
       width: 44px;
       height: 44px;
-      z-index: 3;
+      z-index: 1;
       top: 50%;
       opacity: 0.01%;
       &:hover {
@@ -41,27 +42,27 @@
         opacity: 100%;
       }
     }
-
-      .left-right-drag {
-        position: absolute;
-        left: 0;
-        z-index: 2;
-      }
       .drag-left-handle {
-        position: relative;
+        position: absolute;
         width: 21px;
         height: 100%;
         left: 0;
         z-index: 3;
         cursor: pointer;
+        &.disabled {
+          visibility: hidden;
+        }
       }
       .drag-right-handle {
-        position: relative;
+        position: absolute;
         width: 21px;
         height: 100%;
         right: 0;
         z-index: 3;
         cursor: pointer;
+        &.disabled {
+          visibility: hidden;
+        }
       }
     }
   }

--- a/src/components/document/resize-panel-divider.tsx
+++ b/src/components/document/resize-panel-divider.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import DragThumbnailIcon from "../../assets/drag-thumb-icon.svg";
-import LeftRightDragIcon from "../../assets/left-right-drag.svg";
+import LeftDragIcon from "../../assets/left-drag.svg";
+import RightDragIcon from "../../assets/right-drag.svg";
 import { kDividerMax, kDividerMin } from "../../models/stores/ui-types";
 import "./resize-panel-divider.scss";
 
@@ -24,9 +25,14 @@ export const ResizePanelDivider: React.FC <IProps> =
     <div className="resize-panel-divider" style={dividerPositionStyle}>
       <div className="divider" />
       <div className="drag-handles">
-        <div className="drag-left-handle" onClick={() => onExpandWorkspace()}></div>
-        <LeftRightDragIcon className="left-right-drag"/>
-        <div className="drag-right-handle" onClick={() => onExpandResources()}></div>
+        {!(dividerPosition  === kDividerMin) &&
+          <LeftDragIcon className={`drag-left-handle ${dividerPosition  === kDividerMin ? "disabled" : "" }`}
+                        onClick={() => onExpandWorkspace()} />
+        }
+        {!(dividerPosition  === kDividerMax) &&
+          <RightDragIcon className={`drag-right-handle ${dividerPosition  === kDividerMax ? "disabled" : ""}`}
+                         onClick={() => onExpandResources()} />
+        }
       </div>
       <DragThumbnailIcon className="drag-thumbnail"/>
     </div>

--- a/src/components/document/resize-panel-divider.tsx
+++ b/src/components/document/resize-panel-divider.tsx
@@ -25,12 +25,12 @@ export const ResizePanelDivider: React.FC <IProps> =
     <div className="resize-panel-divider" style={dividerPositionStyle}>
       <div className="divider" />
       <div className="drag-handles">
-        {!(dividerPosition  === kDividerMin) &&
-          <LeftDragIcon className={`drag-left-handle ${dividerPosition  === kDividerMin ? "disabled" : "" }`}
+        {!(dividerPosition === kDividerMin) &&
+          <LeftDragIcon className={`drag-left-handle ${dividerPosition === kDividerMin ? "disabled" : "" }`}
                         onClick={() => onExpandWorkspace()} />
         }
-        {!(dividerPosition  === kDividerMax) &&
-          <RightDragIcon className={`drag-right-handle ${dividerPosition  === kDividerMax ? "disabled" : ""}`}
+        {!(dividerPosition === kDividerMax) &&
+          <RightDragIcon className={`drag-right-handle ${dividerPosition === kDividerMax ? "disabled" : ""}`}
                          onClick={() => onExpandResources()} />
         }
       </div>

--- a/src/components/navigation/collapsed-resources-tab.scss
+++ b/src/components/navigation/collapsed-resources-tab.scss
@@ -13,6 +13,7 @@
   border-width: 2px;
   border-style: solid;
   display: flex;
+  z-index: 2;
   visibility: hidden;
   &.shown {
     visibility: visible;


### PR DESCRIPTION
When divider is on the side of a collapsed tab, the drag handler that collapses that side is hidden so that the tab captures the mouse event.