### PR TITLE
Comment UI synchronization

### DIFF
--- a/cypress/integration/clue/branch/student_tests/nav_panel_test_spec.js
+++ b/cypress/integration/clue/branch/student_tests/nav_panel_test_spec.js
@@ -150,7 +150,7 @@ describe('Test nav panel tabs', function () {
         cy.openDocumentThumbnail('problem-workspaces', this.title);
       });
       it('will verify that published canvas does not have Edit button', function () {
-        cy.get('.edit-button').should("not.exist");
+        cy.get('.edit-button').should("not.to.be.visible");
       });
     });
   });

--- a/src/components/chat/chat-panel-header.tsx
+++ b/src/components/chat/chat-panel-header.tsx
@@ -1,4 +1,4 @@
-import { inject, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import React from "react";
 import { BaseComponent } from "../base";
 import  ChatIcon from "../../assets/chat-icon.svg";
@@ -8,11 +8,11 @@ import "./chat-panel-header.scss";
 import "../themes.scss";
 
 interface IProps {
+  activeNavTab: string;
   newCommentCount: number;
   onCloseChatPanel:(show:boolean) => void;
 }
 
-@inject("stores")
 @observer
 export class ChatPanelHeader extends BaseComponent<IProps> {
 
@@ -20,14 +20,13 @@ export class ChatPanelHeader extends BaseComponent<IProps> {
     super(props);
   }
   render () {
-    const { onCloseChatPanel } = this.props;
-    const { ui } = this.stores;
+    const { activeNavTab, onCloseChatPanel } = this.props;
    return (
       <div className="chat-panel-header" data-testid="chat-panel-header">
-        <ChatIcon className={`chat-icon themed ${ui.activeNavTab} no-action`}/>
+        <ChatIcon className={`chat-icon themed ${activeNavTab} no-action`}/>
         Comments
         {this.renderNotification()}
-        <button className={`chat-close-button themed ${ui.activeNavTab}`}
+        <button className={`chat-close-button themed ${activeNavTab}`}
                 data-testid="chat-close-button"
                 onClick={() => onCloseChatPanel(false)}/>
       </div>
@@ -35,12 +34,11 @@ export class ChatPanelHeader extends BaseComponent<IProps> {
   }
 
   private renderNotification = () => {
-    const { newCommentCount } = this.props;
-    const { ui } = this.stores;
+    const { activeNavTab, newCommentCount } = this.props;
     return (
       <div className="notification-toggle">
-        <div className={`notification-icon themed-negative ${ui.activeNavTab}`}>
-          <NotificationIcon className={`icon-image themed-negative ${ui.activeNavTab}`}/>
+        <div className={`notification-icon themed-negative ${activeNavTab}`}>
+          <NotificationIcon className={`icon-image themed-negative ${activeNavTab}`}/>
         </div>
         <div className="new-comment-badge">{newCommentCount}</div>
       </div>

--- a/src/components/chat/chat-panel.test.tsx
+++ b/src/components/chat/chat-panel.test.tsx
@@ -1,21 +1,41 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { Provider } from "mobx-react";
 import React from "react";
-import { act } from "react-dom/test-utils";
 import { ENavTab } from "../../models/view/nav-tabs";
 import { ChatPanel } from "./chat-panel";
 
-describe("ChatPanel", () => {
+const mockPostComment = jest.fn();
 
-  const stores = { ui: { activeNavTab: ENavTab.kMyWork } };
+jest.mock("../../hooks/document-comment-hooks", () => ({
+  useDocumentComments: () => ({
+    isLoading: false,
+    isError: false,
+    data: {
+      docs: [
+        { data: () => ({ uid: "1", name: "Teacher 1", createdAt: new Date(), content: "Comment 1"}) },
+        { data: () => ({ uid: "1", name: "Teacher 1", createdAt: new Date(), content: "Comment 2"}) },
+        { data: () => ({ uid: "1", name: "Teacher 1", createdAt: new Date(), content: "Comment 3"}) },
+        { data: () => ({ uid: "1", name: "Teacher 1", createdAt: new Date(), content: "Comment 4"}) },
+        { data: () => ({ uid: "1", name: "Teacher 1", createdAt: new Date(), content: "Comment 5"}) },
+        { data: () => ({ uid: "1", name: "Teacher 1", createdAt: new Date(), content: "Comment 6"}) },
+        { data: () => ({ uid: "1", name: "Teacher 1", createdAt: new Date(), content: "Comment 7"}) },
+        { data: () => ({ uid: "1", name: "Teacher 1", createdAt: new Date(), content: "Comment 8"}) },
+      ]
+    },
+    error: undefined
+  }),
+  usePostDocumentComment: () => ({
+    mutate: () => mockPostComment()
+  })
+}));
+
+describe("ChatPanel", () => {
 
   it("should render successfully", () => {
     const mockCloseChatPanel = jest.fn();
+    const mockDocument = { key: "document-key" } as any;
     render((
-      <Provider stores={stores}>
-        <ChatPanel newCommentCount={8} onCloseChatPanel={mockCloseChatPanel}/>
-      </Provider>
+      <ChatPanel activeNavTab={ENavTab.kMyWork} document={mockDocument} onCloseChatPanel={mockCloseChatPanel}/>
     ));
     expect(screen.getByTestId("chat-panel")).toBeInTheDocument();
     expect(screen.getByTestId("chat-panel-header")).toBeInTheDocument();

--- a/src/components/chat/comment-card.test.tsx
+++ b/src/components/chat/comment-card.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
+import { CommentDocument } from "../../lib/firestore-schema";
 import { UserModelType } from "../../models/stores/user";
-import { CommentCard, ICommentData } from "./comment-card";
+import { CommentCard } from "./comment-card";
 
 describe("CommentCard", () => {
   const testUser  = { id: "0", name: "Test Teacher" } as UserModelType;
@@ -16,7 +17,7 @@ describe("CommentCard", () => {
     expect(screen.getByTestId("comment-card-header")).toBeInTheDocument();
   });
   it("should show the correct header icon when there are no comments", () => {
-    const postedComments:ICommentData[] = [];
+    const postedComments: CommentDocument[] = [];
     const commentThread = screen.queryByTestId("comment-thread");
     render((
       <CommentCard user={testUser} postedComments={postedComments}/>
@@ -26,7 +27,9 @@ describe("CommentCard", () => {
   });
   it("should show the correct header icon when there are comments and comment appears in card", () => {
     const testComment = "test comment";
-    const postedComments:ICommentData[] = [{comment: testComment, timePosted: 1573761933537, user: testUser}];
+    const postedComments: CommentDocument[] = [
+            { uid: "1", name: "T1", createdAt: new Date(), content: testComment }
+          ];
     render((
       <CommentCard user={testUser} postedComments={postedComments}/>
     ));

--- a/src/components/chat/comment-card.tsx
+++ b/src/components/chat/comment-card.tsx
@@ -1,21 +1,17 @@
 import React from "react";
 import { UserModelType } from "../../models/stores/user";
 import { CommentTextBox } from "./comment-textbox";
+import { CommentDocument } from "../../lib/firestore-schema";
+import { getDisplayTimeDate } from "../../utilities/time";
 import UserIcon from "../../assets/icons/clue-dashboard/teacher-student.svg";
 import DocumentCommentIcon from "../../assets/document-id.svg";
 import "./comment-card.scss";
 import "../themes.scss";
 
-export interface ICommentData {
-  comment: string;
-  timePosted: string | number;
-  user: UserModelType;
-}
-
 interface IProps {
   user?: UserModelType;
   activeNavTab?: string;
-  postedComments?: ICommentData[]
+  postedComments?: CommentDocument[];
   onPostComment?: (comment: string) => void;
 }
 
@@ -37,24 +33,22 @@ export const CommentCard: React.FC<IProps> = ({ activeNavTab, user, postedCommen
       {renderThreadHeader()}
       { postedComments?.map((comment, idx) => {
           const userInitialBackgroundColor = ["#f79999", "#ffc18a", "#99d099", "#ff9", "#b2b2ff", "#efa6ef"];
-          const commenterInitial = comment.user.name.charAt(0);
-          const userInitialBackgroundColorIndex = parseInt(comment.user.id, 10) % 6;
-          const backgroundStyle = user?.id === comment.user.id
+          const commenterInitial = comment.name.charAt(0);
+          const userInitialBackgroundColorIndex = parseInt(comment.uid, 10) % 6;
+          const backgroundStyle = user?.id === comment.uid
                                     ? {backgroundColor: "white"}
                                     : {backgroundColor: userInitialBackgroundColor[userInitialBackgroundColorIndex]};
           return (
             <div key={idx} className="comment-thread" data-testid="comment-thread">
               <div className="comment-text-header">
                 <div className="user-icon" style={backgroundStyle}>
-                  {user?.id === comment.user.id ? <UserIcon />
-                                                : commenterInitial
-                  }
+                  {user?.id === comment.uid ? <UserIcon /> : commenterInitial}
                 </div>
-                <div className="user-name">{comment.user.name}</div>
-                <div className="time-stamp">{comment.timePosted}</div>
+                <div className="user-name">{comment.name}</div>
+                <div className="time-stamp">{getDisplayTimeDate(comment.createdAt.getTime())}</div>
                 <div className="menu"></div>
               </div>
-              <div key={idx} className="comment-text" data-testid="comment">{comment.comment}</div>
+              <div key={idx} className="comment-text" data-testid="comment">{comment.content}</div>
             </div>
           );
         })

--- a/src/components/navigation/document-tab-content.tsx
+++ b/src/components/navigation/document-tab-content.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { DocumentModelType } from "../../models/document/document";
 import { isProblemType } from "../../models/document/document-types";
 import { AppConfigModelType } from "../../models/stores/app-config-model";
@@ -6,7 +6,7 @@ import { ProblemModelType } from "../../models/curriculum/problem";
 import { ENavTabSectionType, NavTabSpec } from "../../models/view/nav-tabs";
 import { DocumentTabPanel } from "./document-tab-panel";
 import { EditableDocumentContent } from "../document/editable-document-content";
-import { useAppConfigStore, useProblemStore, useUIStore } from "../../hooks/use-stores";
+import { useAppConfigStore, useDocumentFromStore, useProblemStore, useUIStore } from "../../hooks/use-stores";
 import { Logger, LogEventName } from "../../lib/logger";
 import EditIcon from "../../clue/assets/icons/edit-right-icon.svg";
 
@@ -18,13 +18,13 @@ interface IProps {
 }
 
 export const DocumentTabContent: React.FC<IProps> = ({ tabSpec, isChatOpen }) => {
-  const [referenceDocument, setReferenceDocument] = useState<DocumentModelType | undefined>(undefined);
   const appConfigStore = useAppConfigStore();
   const problemStore = useProblemStore();
-  const uiStore = useUIStore();
+  const ui = useUIStore();
+  const referenceDocument = useDocumentFromStore(ui.referenceDocument);
 
   const handleTabClick = (title: string, type: string) => {
-    setReferenceDocument(undefined);
+    ui.setReferenceDocument();
     Logger.log(LogEventName.SHOW_TAB_SECTION, {
       tab_section_name: title,
       tab_section_type: type
@@ -32,7 +32,7 @@ export const DocumentTabContent: React.FC<IProps> = ({ tabSpec, isChatOpen }) =>
   };
 
   const handleSelectDocument = (document: DocumentModelType) => {
-    setReferenceDocument(document);
+    ui.setReferenceDocument(document.key);
   };
 
   const documentTitle = (document: DocumentModelType, appConfig: AppConfigModelType, problem: ProblemModelType) => {
@@ -43,7 +43,7 @@ export const DocumentTabContent: React.FC<IProps> = ({ tabSpec, isChatOpen }) =>
   };
 
   function handleEditClick(document: DocumentModelType) {
-    uiStore.problemWorkspace.setPrimaryDocument(document);
+    ui.problemWorkspace.setPrimaryDocument(document);
   }
 
   const editButton = (type: string, sClass: string, document: DocumentModelType) => {

--- a/src/components/navigation/nav-tab-panel.tsx
+++ b/src/components/navigation/nav-tab-panel.tsx
@@ -42,7 +42,7 @@ export class NavTabPanel extends BaseComponent<IProps, IState> {
 
   public render() {
     const { tabs, isResourceExpanded } = this.props;
-    const { ui, user, supports } = this.stores;
+    const { ui, user, documents, supports } = this.stores;
     const selectedTabIndex = tabs?.findIndex(t => t.tab === ui.activeNavTab);
     const resizePanelWidth = 4;
     const collapseTabWidth = 44;
@@ -52,6 +52,7 @@ export class NavTabPanel extends BaseComponent<IProps, IState> {
                               ? `calc(100% - ${collapseTabWidth}px - ${resizePanelWidth}px)`
                               : `calc(${ui.dividerPosition}% - ${resizePanelWidth}px)`;
     const resourceWidthStyle = {width: resourceWidth};
+    const referenceDocument = ui.referenceDocument && documents.getDocument(ui.referenceDocument);
     const newCommentCount = 8;
     return (
       <div className={`resource-and-chat-panel ${isResourceExpanded ? "shown" : ""}`} style={resourceWidthStyle}>
@@ -92,8 +93,9 @@ export class NavTabPanel extends BaseComponent<IProps, IState> {
               })
             }
           </Tabs>
-          {this.state.showChatColumn &&
-            <ChatPanel onCloseChatPanel={this.handleShowChatColumn} newCommentCount={newCommentCount}/>}
+          {this.state.showChatColumn && referenceDocument &&
+            <ChatPanel activeNavTab={ui.activeNavTab} document={referenceDocument.getMetadata()}
+                        onCloseChatPanel={this.handleShowChatColumn} />}
         </div>
       </div>
     );

--- a/src/hooks/document-comment-hooks.ts
+++ b/src/hooks/document-comment-hooks.ts
@@ -1,0 +1,45 @@
+import { useCallback } from "react";
+
+/*
+ * usePostDocumentComment [STUB]
+ *
+ * Implemented via React Query's useMutation hook.
+ */
+interface IPostCommentInfo {
+  document: any;
+  comment: string;
+  tileId?: string;
+}
+export const usePostDocumentComment = () => {
+  const postComment = useCallback((postCommentInfo: IPostCommentInfo) => {
+    console.log("Posting comment:", JSON.stringify(postCommentInfo));
+  }, []);
+  return { mutate: (postCommentInfo: IPostCommentInfo) => postComment(postCommentInfo) };
+};
+
+/*
+ * useDocumentComments [STUB]
+ *
+ * Sets up a Firestore real-time query which returns the comments associated with the
+ * specified document. The returned results are managed by React Query, e.g. caching
+ * and reuse if multiple clients request the same comments.
+ */
+export const useDocumentComments = (documentKey: string) => {
+  return {
+    isLoading: false,
+    isError: false,
+    data: {
+      docs: [
+        { data: () => ({ uid: "1", name: "Teacher 1", createdAt: new Date(), content: "Comment 1"}) },
+        { data: () => ({ uid: "1", name: "Teacher 1", createdAt: new Date(), content: "Comment 2"}) },
+        { data: () => ({ uid: "1", name: "Teacher 1", createdAt: new Date(), content: "Comment 3"}) },
+        { data: () => ({ uid: "1", name: "Teacher 1", createdAt: new Date(), content: "Comment 4"}) },
+        { data: () => ({ uid: "1", name: "Teacher 1", createdAt: new Date(), content: "Comment 5"}) },
+        { data: () => ({ uid: "1", name: "Teacher 1", createdAt: new Date(), content: "Comment 6"}) },
+        { data: () => ({ uid: "1", name: "Teacher 1", createdAt: new Date(), content: "Comment 7"}) },
+        { data: () => ({ uid: "1", name: "Teacher 1", createdAt: new Date(), content: "Comment 8"}) },
+      ]
+    },
+    error: undefined
+  };
+};

--- a/src/hooks/use-stores.ts
+++ b/src/hooks/use-stores.ts
@@ -17,12 +17,29 @@ export function useAppConfigStore(): AppConfigModelType {
   return useStores().appConfig;
 }
 
-export function useGroupsStore(): GroupsModelType {
-  return useStores().groups;
+export function useAppMode() {
+  return useStores().appMode;
 }
 
-export function useUserStore(): UserModelType {
-  return useStores().user;
+export function useClassStore() {
+  return useStores().class;
+}
+
+export function useDemoStore() {
+  return useStores().demo;
+}
+
+export function useDocumentFromStore(key?: string) {
+  const stores = useStores();
+  return key ? stores.documents.getDocument(key) : undefined;
+}
+
+export function useFeatureFlag(feature: string) {
+  return isFeatureSupported(useStores(), feature);
+}
+
+export function useGroupsStore(): GroupsModelType {
+  return useStores().groups;
 }
 
 export function useProblemStore(): ProblemModelType {
@@ -41,6 +58,6 @@ export function useUIStore(): UIModelType {
   return useStores().ui;
 }
 
-export function useFeatureFlag(feature: string) {
-  return isFeatureSupported(useStores(), feature);
+export function useUserStore(): UserModelType {
+  return useStores().user;
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -393,7 +393,21 @@ export const generateDevAuthentication = (unitCode: string, problemOrdinal: stri
   DEV_CLASS_INFO.students.forEach((student) => student.offeringId = offeringId);
   DEV_CLASS_INFO.teachers.forEach((teacher) => teacher.offeringId = offeringId);
 
-  return {authenticatedUser: DEV_STUDENT, classInfo: DEV_CLASS_INFO};
+  let authenticatedUser: AuthenticatedUser = DEV_STUDENT;
+
+  const fakeUser = pageUrlParams.fakeUser;
+  if (fakeUser) {
+    const [role, fakeId] = fakeUser.split(":");
+    if (role === "teacher") {
+      authenticatedUser = DEV_TEACHER;
+      fakeId && (DEV_TEACHER.id = fakeId);
+    }
+    else {
+      fakeId && (DEV_STUDENT.id = fakeId);
+    }
+  }
+
+  return {authenticatedUser, classInfo: DEV_CLASS_INFO};
 };
 
 const createOfferingIdFromProblem = (unitCode: string, problemOrdinal: string) => {

--- a/src/lib/firestore-schema.ts
+++ b/src/lib/firestore-schema.ts
@@ -35,7 +35,7 @@ type UsersCollection = FSCollection<UserDocument>;
  * Subcollection of documents with a denormalized teacher name field with potential synchronization issues.
  * Comments associated with a document are accessible to any user with access to the document.
  */
-interface CommentDocument {
+export interface CommentDocument {
   uid: string;                // user id of author of comment
   name: string;               // [denormalized] name of user to avoid having to request user data separately
   createdAt: FSDate;          // timestamp used for sorting

--- a/src/models/document/document.test.ts
+++ b/src/models/document/document.test.ts
@@ -97,4 +97,14 @@ describe("document model", () => {
     expect(document.getProperty("foo")).toBeUndefined();
     expect(document.getProperty("bar")).toBe("baz");
   });
+
+  it("can get document metadata", () => {
+    expect(document.getMetadata()).toEqual({
+      type: ProblemDocument,
+      uid: "1",
+      key: "test",
+      createdAt: 1,
+      properties: {}
+    });
+  });
 });

--- a/src/models/document/document.ts
+++ b/src/models/document/document.ts
@@ -57,6 +57,10 @@ export const DocumentModel = types
               || (self.type === PersonalPublication)
               || (self.type === SupportPublication);
     },
+    getMetadata() {
+      const { uid, type, key, createdAt, title, originDoc, properties } = self;
+      return { uid, type, key, createdAt, title, originDoc, properties: properties.toJSON() };
+    },
     getProperty(key: string) {
       return self.properties.get(key);
     },

--- a/src/models/stores/ui.test.ts
+++ b/src/models/stores/ui.test.ts
@@ -21,7 +21,8 @@ describe("ui model", () => {
   it("has default values", () => {
     expect(ui.error).toBe(null);
     expect(ui.showDemoCreator).toBe(false);
-    expect(ui.dialog).toBe(undefined);
+    expect(ui.showTeacherContent).toBe(true);
+    expect(ui.dialog).toBeUndefined();
   });
 
   it("uses override values", () => {
@@ -60,16 +61,33 @@ describe("ui model", () => {
 
   it("allows selected tile to be set", () => {
     expect(ui.selectedTileIds).toStrictEqual([]);
-    ui.setSelectedTile(ToolTileModel.create({
+    const tile = ToolTileModel.create({
       id: "1",
       content: {
         type: "Text",
         text: "test"
       }
-    }));
+    });
+    ui.setSelectedTile(tile);
     expect(ui.selectedTileIds).toStrictEqual(["1"]);
+    expect(ui.isSelectedTile(tile)).toBe(true);
     ui.setSelectedTile();
     expect(ui.selectedTileIds).toStrictEqual([]);
+    expect(ui.isSelectedTile(tile)).toBe(false);
+  });
+
+  it("allows divider position to be set", () => {
+    expect(ui.navTabContentShown).toBe(false);
+    expect(ui.workspaceShown).toBe(true);
+    ui.setDividerPosition(50);
+    expect(ui.navTabContentShown).toBe(true);
+    expect(ui.workspaceShown).toBe(true);
+  });
+
+  it("allows reference document to be set", () => {
+    expect(ui.referenceDocument).toBeUndefined();
+    ui.setReferenceDocument("1234");
+    expect(ui.referenceDocument).toBe("1234");
   });
 
   it("allows alert dialogs", () => {
@@ -86,7 +104,7 @@ describe("ui model", () => {
     expect(dialog.title).toBe("Test Alert Title");
   });
 
-  it("allows comfirm dialogs", () => {
+  it("allows confirm dialogs", () => {
     expect(ui.dialog).toBe(undefined);
     ui.confirm("confirm test");
     let dialog = ui.dialog as UIDialogModelType;
@@ -98,6 +116,7 @@ describe("ui model", () => {
     ui.confirm("confirm test", "Test Confirm Title");
     dialog = ui.dialog as UIDialogModelType;
     expect(dialog.title).toBe("Test Confirm Title");
+    ui.closeDialog();
   });
 
   it("allows prompt dialogs", () => {
@@ -109,6 +128,7 @@ describe("ui model", () => {
     expect(dialog.text).toBe("prompt test");
     expect(dialog.defaultValue).toBe("");
     expect(dialog.title).toBe(undefined);
+    ui.closeDialog();
 
     ui.prompt("prompt test", "default value");
     dialog = ui.dialog as UIDialogModelType;

--- a/src/models/stores/ui.ts
+++ b/src/models/stores/ui.ts
@@ -35,6 +35,7 @@ export const UIModel = types
     showDemoCreator: false,
     showTeacherContent: true,
     dialog: types.maybe(UIDialogModel),
+    referenceDocument: types.maybe(types.string),
     problemWorkspace: WorkspaceModel,
     learningLogWorkspace: WorkspaceModel,
     teacherPanelKey: types.maybe(types.string)
@@ -154,7 +155,9 @@ export const UIModel = types
         self.showDemoCreator = showDemoCreator;
       },
       closeDialog,
-
+      setReferenceDocument(documentKey?: string) {
+        self.referenceDocument = documentKey;
+      },
       rightNavDocumentSelected(appConfig: AppConfigModelType, document: DocumentModelType) {
         if (!document.isPublished || appConfig.showPublishedDocsInPrimaryWorkspace) {
           self.problemWorkspace.setAvailableDocument(document);


### PR DESCRIPTION
These are the front-end changes required to hook up to the back-end work I've been doing to support posting new document comments and reading posted document comments. @eireland will take over further front-end refinements while I ready another PR with the back-end changes. The actual code for posting/reading comments has been stubbed out in this PR and will be part of the next PR.

Also with this PR, I took the opportunity to enable `dev`-mode users to be teachers. Previously, teacher-only features were only available in `authed`, `demo`, or `qa` modes. The same `fakeUser` url parameter that can be used to configure the current user in other modes is now also supported in `dev` mode, so `fakeUser=teacher` makes the current user a teacher and `fakeUser=teacher:2222` makes the current user a teacher with `uid` `2222`.

Reviewed synchronously with @eireland.