### PR TITLE
Fix tab switch bug introduced recently

### DIFF
--- a/cypress/integration/clue/branch/student_tests/nav_panel_test_spec.js
+++ b/cypress/integration/clue/branch/student_tests/nav_panel_test_spec.js
@@ -150,7 +150,7 @@ describe('Test nav panel tabs', function () {
         cy.openDocumentThumbnail('problem-workspaces', this.title);
       });
       it('will verify that published canvas does not have Edit button', function () {
-        cy.get('.edit-button').should("not.to.be.visible");
+        cy.get('.edit-button').should("not.exist");
       });
     });
   });

--- a/src/components/document/editable-document-content.tsx
+++ b/src/components/document/editable-document-content.tsx
@@ -87,7 +87,7 @@ export const EditableDocumentContent: React.FC<IProps> = props => {
     <DocumentContextReact.Provider value={documentContext}>
       <EditableToolApiInterfaceRefContext.Provider value={editableToolApiInterfaceRef}>
         <div key="editable-document" className={`editable-document-content ${showToolbarClass}`}
-              data-reference-document={document.key} >
+              data-focus-document={document.key} >
           {isShowingToolbar && <DocumentToolbar document={document} toolbar={toolbar} />}
           {isShowingToolbar && <div className="canvas-separator"/>}
           <DocumentCanvas mode={mode} isPrimary={isPrimary} document={document} readOnly={isReadOnly} />

--- a/src/components/navigation/document-tab-content.tsx
+++ b/src/components/navigation/document-tab-content.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { DocumentModelType } from "../../models/document/document";
 import { isProblemType } from "../../models/document/document-types";
 import { AppConfigModelType } from "../../models/stores/app-config-model";
@@ -6,7 +6,7 @@ import { ProblemModelType } from "../../models/curriculum/problem";
 import { ENavTabSectionType, NavTabSpec } from "../../models/view/nav-tabs";
 import { DocumentTabPanel } from "./document-tab-panel";
 import { EditableDocumentContent } from "../document/editable-document-content";
-import { useAppConfigStore, useDocumentFromStore, useProblemStore, useUIStore } from "../../hooks/use-stores";
+import { useAppConfigStore, useProblemStore, useUIStore } from "../../hooks/use-stores";
 import { Logger, LogEventName } from "../../lib/logger";
 import EditIcon from "../../clue/assets/icons/edit-right-icon.svg";
 
@@ -18,13 +18,14 @@ interface IProps {
 }
 
 export const DocumentTabContent: React.FC<IProps> = ({ tabSpec, isChatOpen }) => {
+  const [referenceDocument, setReferenceDocument] = useState<DocumentModelType>();
   const appConfigStore = useAppConfigStore();
   const problemStore = useProblemStore();
   const ui = useUIStore();
-  const referenceDocument = useDocumentFromStore(ui.referenceDocument);
 
   const handleTabClick = (title: string, type: string) => {
-    ui.setReferenceDocument();
+    setReferenceDocument(undefined);
+    ui.updateFocusDocument();
     Logger.log(LogEventName.SHOW_TAB_SECTION, {
       tab_section_name: title,
       tab_section_type: type
@@ -32,7 +33,8 @@ export const DocumentTabContent: React.FC<IProps> = ({ tabSpec, isChatOpen }) =>
   };
 
   const handleSelectDocument = (document: DocumentModelType) => {
-    ui.setReferenceDocument(document.key);
+    setReferenceDocument(document);
+    ui.updateFocusDocument();
   };
 
   const documentTitle = (document: DocumentModelType, appConfig: AppConfigModelType, problem: ProblemModelType) => {

--- a/src/components/navigation/document-tab-panel.tsx
+++ b/src/components/navigation/document-tab-panel.tsx
@@ -136,7 +136,7 @@ export class DocumentTabPanel extends BaseComponent<IProps, IState> {
 
   private handleTabSelect = (tabIndex: number) => {
     this.setState({ tabIndex });
-    this.stores.ui.updateReferenceDocument();
+    this.stores.ui.updateFocusDocument();
   }
 
   private renderSubSections(subTab: any) {

--- a/src/components/navigation/focus-document-tracker.tsx
+++ b/src/components/navigation/focus-document-tracker.tsx
@@ -4,7 +4,7 @@ import { usePrevious } from "../../hooks/use-previous";
 import { useUIStore } from "../../hooks/use-stores";
 
 /*
- * ReferenceDocumentTracker
+ * FocusDocumentTracker
  *
  * This component is basically a hook wrapped in a functional component so that
  * it can be called from a class component (NavTabPanel in this case). It's basic
@@ -15,25 +15,23 @@ import { useUIStore } from "../../hooks/use-stores";
  * but this was getting increasingly complicated and wasn't working very well. This
  * ties the behavior of the comments panel to what's actually visible to the user, as
  * it should be. The mechanism is that components that are responsible for presenting
- * documents or curriculum sections to the user add a `data-reference-document` or
- * `data-reference-section` attribute which can then be detected when we crawl the
+ * documents or curriculum sections to the user add a `data-focus-document` or
+ * `data-focus-section` attribute which can then be detected when we crawl the
  * DOM thus guaranteeing that we're finding the top-most visible documents/sections.
  */
 interface IProps {
   navTabPanelElt: HTMLDivElement | null;
 }
 export const FocusDocumentTracker = observer(({ navTabPanelElt }: IProps) => {
-  // this component is basically a hook wrapped in a functional component so that
-  // it can be called from a class component (NavTabPanel in this case).
   const ui = useUIStore();
-  const prevUpdates = usePrevious(ui.refDocUpdates);
+  const prevUpdates = usePrevious(ui.focusDocUpdates);
   useEffect(() => {
 
-    if (navTabPanelElt && (ui.refDocUpdates !== prevUpdates)) {
+    if (navTabPanelElt && (ui.focusDocUpdates !== prevUpdates)) {
       // set a timer to allow rendering to complete
       setTimeout(() => {
-        let referenceDocument: string | undefined;
-        let referenceSection: string | undefined;
+        let focusDocument: string | undefined;
+        let focusSection: string | undefined;
 
         // find elements at a point below the rows of tab headers
         const bounds = navTabPanelElt.getBoundingClientRect();
@@ -47,18 +45,18 @@ export const FocusDocumentTracker = observer(({ navTabPanelElt }: IProps) => {
         // loop through elements looking for data attributes
         // note that although it's not mentioned on MDN or other documentation sites,
         // the spec makes clear that the elements are returned in front-to-back order.
-        for (let i = 0; !referenceDocument && (i < elements.length); ++i) {
+        for (let i = 0; !focusDocument && (i < elements.length); ++i) {
           const elt = elements[i];
-          const refDoc = elt.getAttribute("data-reference-document");
-          const refSec = elt.getAttribute("data-reference-section");
-          refDoc && (referenceDocument = refDoc);
-          refSec && (referenceSection = refSec);
+          const focusDoc = elt.getAttribute("data-focus-document");
+          const focusSec = elt.getAttribute("data-focus-section");
+          focusDoc && (focusDocument = focusDoc);
+          focusSec && (focusSection = focusSec);
         }
-        ui.setFocusDocument(referenceSection
-                              ? `${referenceDocument}/${referenceSection}`
-                              : referenceDocument);
+        ui.setFocusDocument(focusSection
+                              ? `${focusDocument}/${focusSection}`
+                              : focusDocument);
       }, 30);
     }
-  }, [navTabPanelElt, prevUpdates, ui, ui.refDocUpdates]);
+  }, [navTabPanelElt, prevUpdates, ui, ui.focusDocUpdates]);
   return null;
 });

--- a/src/components/navigation/focus-document-tracker.tsx
+++ b/src/components/navigation/focus-document-tracker.tsx
@@ -22,7 +22,7 @@ import { useUIStore } from "../../hooks/use-stores";
 interface IProps {
   navTabPanelElt: HTMLDivElement | null;
 }
-export const ReferenceDocumentTracker = observer(({ navTabPanelElt }: IProps) => {
+export const FocusDocumentTracker = observer(({ navTabPanelElt }: IProps) => {
   // this component is basically a hook wrapped in a functional component so that
   // it can be called from a class component (NavTabPanel in this case).
   const ui = useUIStore();
@@ -54,9 +54,9 @@ export const ReferenceDocumentTracker = observer(({ navTabPanelElt }: IProps) =>
           refDoc && (referenceDocument = refDoc);
           refSec && (referenceSection = refSec);
         }
-        ui.setReferenceDocument(referenceSection
-                                  ? `${referenceDocument}/${referenceSection}`
-                                  : referenceDocument);
+        ui.setFocusDocument(referenceSection
+                              ? `${referenceDocument}/${referenceSection}`
+                              : referenceDocument);
       }, 30);
     }
   }, [navTabPanelElt, prevUpdates, ui, ui.refDocUpdates]);

--- a/src/components/navigation/nav-tab-panel.tsx
+++ b/src/components/navigation/nav-tab-panel.tsx
@@ -8,7 +8,7 @@ import { Logger, LogEventName } from "../../lib/logger";
 import { StudentGroupView } from "../document/student-group-view";
 import { ProblemTabContent } from "./problem-tab-content";
 import { DocumentTabContent } from "./document-tab-content";
-import { ReferenceDocumentTracker } from "./reference-document-tracker";
+import { FocusDocumentTracker } from "./focus-document-tracker";
 import { SupportBadge } from "./support-badge";
 import { NewCommentsBadge } from "./new-comments-badge";
 import { ChatPanel } from "../chat/chat-panel";
@@ -45,7 +45,7 @@ export class NavTabPanel extends BaseComponent<IProps, IState> {
 
   public render() {
     const { tabs, isResourceExpanded } = this.props;
-    const { ui: { activeNavTab, dividerPosition, referenceDocument }, user, supports } = this.stores;
+    const { ui: { activeNavTab, dividerPosition, focusDocument }, user, supports } = this.stores;
     const selectedTabIndex = tabs?.findIndex(t => t.tab === activeNavTab);
     const resizePanelWidth = 4;
     const collapseTabWidth = 44;
@@ -59,7 +59,7 @@ export class NavTabPanel extends BaseComponent<IProps, IState> {
       <div className={`resource-and-chat-panel ${isResourceExpanded ? "shown" : ""}`} style={resourceWidthStyle}>
         <div className={`nav-tab-panel ${this.state.showChatColumn ? "chat-open" : ""}`}
             ref={elt => this.navTabPanelElt = elt}>
-          <ReferenceDocumentTracker navTabPanelElt={this.navTabPanelElt} />
+          <FocusDocumentTracker navTabPanelElt={this.navTabPanelElt} />
           <Tabs selectedIndex={selectedTabIndex} onSelect={this.handleSelectTab} forceRenderTabPanel={true}>
             <div className="top-row">
               <TabList className="top-tab-list">
@@ -78,7 +78,7 @@ export class NavTabPanel extends BaseComponent<IProps, IState> {
               { user.isNetworkedTeacher
                   ? (!this.state.showChatColumn) &&
                     <div className={`chat-panel-toggle themed ${activeNavTab}`}>
-                      <NewCommentsBadge documentKey={referenceDocument} />
+                      <NewCommentsBadge documentKey={focusDocument} />
                       <ChatIcon
                         className={`chat-button ${activeNavTab}`}
                         onClick={() => this.handleShowChatColumn(true)}
@@ -96,8 +96,8 @@ export class NavTabPanel extends BaseComponent<IProps, IState> {
               })
             }
           </Tabs>
-          {this.state.showChatColumn && referenceDocument &&
-            <ChatPanel activeNavTab={activeNavTab} documentKey={referenceDocument}
+          {this.state.showChatColumn && focusDocument &&
+            <ChatPanel activeNavTab={activeNavTab} documentKey={focusDocument}
                         onCloseChatPanel={this.handleShowChatColumn} />}
         </div>
       </div>
@@ -157,7 +157,7 @@ export class NavTabPanel extends BaseComponent<IProps, IState> {
       const tabSpec = tabs[tabIndex];
       if (ui.activeNavTab !== tabSpec.tab) {
         ui.setActiveNavTab(tabSpec.tab);
-        ui.updateReferenceDocument();
+        ui.updateFocusDocument();
         const logParameters = {
           tab_name: tabSpec.tab.toString()
         };

--- a/src/components/navigation/problem-tab-content.tsx
+++ b/src/components/navigation/problem-tab-content.tsx
@@ -34,7 +34,7 @@ export const ProblemTabContent: React.FC<IProps>
       tab_section_type: typeArgButReallyTitle
     });
 
-    ui.updateReferenceDocument();
+    ui.updateFocusDocument();
 };
 
   const handleToggleSolutions = () => {

--- a/src/components/navigation/problem-tab-content.tsx
+++ b/src/components/navigation/problem-tab-content.tsx
@@ -44,7 +44,7 @@ export const ProblemTabContent: React.FC<IProps>
 
   return (
     <Tabs className={classNames("problem-tabs", context, chatBorder)} selectedTabClassName="selected"
-          data-reference-document={problemPath}>
+          data-focus-document={problemPath}>
       <div className="tab-header-row">
         <TabList className="tab-list">
           {sections.map((section) => {
@@ -62,7 +62,7 @@ export const ProblemTabContent: React.FC<IProps>
       </div>
       {sections.map((section) => {
         return (
-          <TabPanel key={`section-${section.type}`} data-reference-section={section.type}>
+          <TabPanel key={`section-${section.type}`} data-focus-section={section.type}>
             <ProblemPanelComponent section={section} key={`section-${section.type}`} />
           </TabPanel>
         );

--- a/src/hooks/document-comment-hooks.ts
+++ b/src/hooks/document-comment-hooks.ts
@@ -64,8 +64,8 @@ const commentConverter = {
  * key of a user document in Firebase. The returned results are managed by React Query,
  * e.g. caching and reuse if multiple clients request the same comments.
  */
-export const useDocumentComments = (documentKey?: string) => {
-  const path = useCommentsCollectionPath(documentKey || "");
+export const useDocumentComments = (documentKeyOrSectionPath?: string) => {
+  const path = useCommentsCollectionPath(documentKeyOrSectionPath || "");
   const converter = commentConverter;
   return useCollectionOrderedRealTimeQuery(path, { converter, orderBy: "createdAt" });
 };
@@ -79,7 +79,7 @@ export const useDocumentComments = (documentKey?: string) => {
  * based on a single timestamp, or a separate timestamp for each thread, or flags for each
  * message indicated which have been read, etc.
  */
-export const useUnreadDocumentComments = (documentKey?: string) => {
+export const useUnreadDocumentComments = (documentKeyOrSectionPath?: string) => {
   // TODO: figure this out; for now it's just a comment counter
-  return useDocumentComments(documentKey);
+  return useDocumentComments(documentKeyOrSectionPath);
 };

--- a/src/models/stores/ui.test.ts
+++ b/src/models/stores/ui.test.ts
@@ -85,9 +85,9 @@ describe("ui model", () => {
   });
 
   it("allows reference document to be set", () => {
-    expect(ui.referenceDocument).toBeUndefined();
-    ui.setReferenceDocument("1234");
-    expect(ui.referenceDocument).toBe("1234");
+    expect(ui.focusDocument).toBeUndefined();
+    ui.setFocusDocument("1234");
+    expect(ui.focusDocument).toBe("1234");
   });
 
   it("allows alert dialogs", () => {

--- a/src/models/stores/ui.ts
+++ b/src/models/stores/ui.ts
@@ -38,7 +38,7 @@ export const UIModel = types
     // document key or section path for reference (left) document
     focusDocument: types.maybe(types.string),
     // counter that serves to trigger updates
-    refDocUpdates: 0,
+    focusDocUpdates: 0,
     problemWorkspace: WorkspaceModel,
     learningLogWorkspace: WorkspaceModel,
     teacherPanelKey: types.maybe(types.string)
@@ -163,7 +163,7 @@ export const UIModel = types
       },
       updateFocusDocument() {
         // increment counter to trigger observers to update
-        ++self.refDocUpdates;
+        ++self.focusDocUpdates;
       },
       rightNavDocumentSelected(appConfig: AppConfigModelType, document: DocumentModelType) {
         if (!document.isPublished || appConfig.showPublishedDocsInPrimaryWorkspace) {

--- a/src/models/stores/ui.ts
+++ b/src/models/stores/ui.ts
@@ -36,7 +36,7 @@ export const UIModel = types
     showTeacherContent: true,
     dialog: types.maybe(UIDialogModel),
     // document key or section path for reference (left) document
-    referenceDocument: types.maybe(types.string),
+    focusDocument: types.maybe(types.string),
     // counter that serves to trigger updates
     refDocUpdates: 0,
     problemWorkspace: WorkspaceModel,
@@ -158,10 +158,10 @@ export const UIModel = types
         self.showDemoCreator = showDemoCreator;
       },
       closeDialog,
-      setReferenceDocument(documentKey?: string) {
-        self.referenceDocument = documentKey;
+      setFocusDocument(documentKey?: string) {
+        self.focusDocument = documentKey;
       },
-      updateReferenceDocument() {
+      updateFocusDocument() {
         // increment counter to trigger observers to update
         ++self.refDocUpdates;
       },


### PR DESCRIPTION
In #1014, we introduced a global notion of `referenceDocument` so that the comment panel would know which document to target. In doing so, we also removed the `DocumentTabPanel`'s local notion of `referenceDocument` under the assumption that the global instance could replace the local one. This assumption was incorrect. There are multiple `DocumentTabPanel`s and they each need to keep track of their own independent `referenceDocument`s. To fix the bug we simply restore the `referenceDocument` state to the `DocumentTabPanel` component and simply synchronize it with the global `referenceDocument` when appropriate. For clarity, we also rename the global to be the `focusDocument`.