### PR TITLE
Support planning document

### DIFF
--- a/cypress/integration/clue/branch/teacher_tests/teacher_workspace_spec.js
+++ b/cypress/integration/clue/branch/teacher_tests/teacher_workspace_spec.js
@@ -26,10 +26,10 @@ beforeEach(() => {
   cy.fixture("teacher-dash-data-msa-test.json").as("clueData");
 });
 
-describe.skip('teacher specific navigation tabs', () => {
+describe('teacher specific navigation tabs', () => {
   it('verify problem tab solution switch', () => {
     cy.get('.collapsed-resources-tab').click();
-    cy.get('.nav-tab.tab-problems').should('exist').click();
+    cy.get('.top-tab.tab-problems').should('exist').click();
     cy.get('.prob-tab').contains('What If...?').click();
     cy.get('[data-test=solutions-button]').should('have.class', "toggled");
     cy.get('.has-teacher-tiles').should("exist");
@@ -39,7 +39,7 @@ describe.skip('teacher specific navigation tabs', () => {
   });
 
   it('verify teacher guide', () => {
-    cy.get('.nav-tab.tab-teacher-guide').should('exist').click({force:true});
+    cy.get('.top-tab.tab-teacher-guide').should('exist').click({force:true});
     cy.get('.prob-tab.teacher-guide').should('exist').and('have.length', 4).each(function (subTab, index, subTabList) {
       const teacherGuideSubTabs = ["Overview", "Launch", "Explore", "Summarize"];
       cy.wrap(subTab).text().should('contain', teacherGuideSubTabs[index]);

--- a/src/clue/app-config.json
+++ b/src/clue/app-config.json
@@ -117,7 +117,7 @@
             "type": "problem-documents",
             "dataTestHeader": "my-work-section-investigations",
             "dataTestItem": "my-work-list-items",
-            "documentTypes": ["problem"],
+            "documentTypes": ["problem", "planning"],
             "showStars": ["student", "teacher"]
           },
           {

--- a/src/components/thumbnail/tab-panel-documents-section.tsx
+++ b/src/components/thumbnail/tab-panel-documents-section.tsx
@@ -3,7 +3,7 @@ import { observer } from "mobx-react";
 import { ThumbnailDocumentItem } from "./thumbnail-document-item";
 import { DocumentModelType, getDocumentContext } from "../../models/document/document";
 import {
-  isProblemType, isPublishedType, isUnpublishedType, PersonalDocument, SupportPublication
+  isPlanningType, isProblemType, isPublishedType, isUnpublishedType, PersonalDocument, SupportPublication
 } from "../../models/document/document-types";
 import { IStores } from "../../models/stores/stores";
 import { ENavTabOrder, NavTabSectionModelType  } from "../../models/view/nav-tabs";
@@ -47,7 +47,11 @@ function getDocumentCaption(stores: IStores, document: DocumentModelType) {
   const user = _class && _class.getUserById(uid);
   const userName = user && user.displayName;
   const namePrefix = isPublishedType(type) ? `${userName}: ` : "";
-  const title = isProblemType(type) ? problem.title : document.getDisplayTitle(appConfig);
+  const title = isProblemType(type)
+                  ? problem.title
+                  : isPlanningType(type)
+                      ? `${problem.title} Planning`
+                      : document.getDisplayTitle(appConfig);
   return `${namePrefix}${title}`;
 }
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -247,6 +247,9 @@ export const authenticate = (appMode: AppMode, appConfig: AppConfigModelType, ur
   }
   return new Promise<IAuthenticateResponse>((resolve, reject) => {
     urlParams = urlParams || pageUrlParams;
+    // TODO: we should be defaulting to appConfig.defaultUnit here rather than the empty string,
+    // but some cypress tests rely on the fact that in demo mode the offeringId is prefixed with
+    // the unit code, which results in an offeringId of `101` instead of `sas101`.
     const unitCode = urlParams.unit || "";
     // when launched as a report, the params will not contain the problemOrdinal
     const problemOrdinal = urlParams.problem || appConfig.defaultProblemOrdinal;
@@ -283,7 +286,7 @@ export const authenticate = (appMode: AppMode, appConfig: AppConfigModelType, ur
     }
 
     if (appMode !== "authed") {
-      return resolve(generateDevAuthentication(unitCode, problemOrdinal));
+      return resolve(generateDevAuthentication(unitCode || appConfig.defaultUnit, problemOrdinal));
     }
 
     if (!bearerToken) {

--- a/src/lib/db-listeners/db-problem-documents-listener.ts
+++ b/src/lib/db-listeners/db-problem-documents-listener.ts
@@ -2,7 +2,7 @@ import firebase from "firebase/app";
 import { forEach } from "lodash";
 import { DB, Monitor } from "../db";
 import { DBOfferingUser, DBOfferingUserMap } from "../db-types";
-import { ProblemDocument } from "../../models/document/document-types";
+import { PlanningDocument, ProblemDocument } from "../../models/document/document-types";
 import { BaseListener } from "./base-listener";
 import { syncStars } from "./sync-stars";
 
@@ -73,6 +73,7 @@ export class DBProblemDocumentsListener extends BaseListener {
   private handleOfferingUser = (user: DBOfferingUser) => {
     if (!user?.self?.uid) return;
     const { documents, user: currentUser, groups } = this.db.stores;
+    // monitor problem documents
     forEach(user.documents, document => {
       if (!document?.documentKey || !document?.self?.uid) return;
       const existingDoc = documents.getDocument(document.documentKey);
@@ -98,6 +99,15 @@ export class DBProblemDocumentsListener extends BaseListener {
             }
             return doc;
           })
+          .then(documents.add);
+      }
+    });
+    // monitor planning documents
+    forEach(user.planning, document => {
+      if (!document?.documentKey || !document?.self?.uid) return;
+      const existingDoc = documents.getDocument(document.documentKey);
+      if (!existingDoc) {
+        this.db.createDocumentModelFromProblemMetadata(PlanningDocument, document.self.uid, document, Monitor.Local)
           .then(documents.add);
       }
     });

--- a/src/lib/db-types.ts
+++ b/src/lib/db-types.ts
@@ -28,19 +28,21 @@ export interface DBDocumentMap {
 }
 
 export type DBDocumentType = "section" |
-                              "problem" | "publication" |
+                              "problem" | "planning" | "publication" |
                               "personal" | "personalPublication" |
                               "learningLog" | "learningLogPublication" |
                               "supportPublication";
 export type DBDocumentMetadata = DBSectionDocumentMetadataDEPRECATED |
                                  DBProblemDocumentMetadata |
                                  DBPersonalDocumentMetadata |
+                                 DBPlanningDocumentMetadata |
                                  DBLearningLogDocumentMetadata |
                                  DBPublicationDocumentMetadata |
                                  DBPersonalPublicationMetadata |
                                  DBLearningLogPublicationMetadata |
                                  DBSupportPublicationMetadata;
 
+// metadata written to {classHash}/users/{userId}/documentMetadata for all document types
 export interface DBBaseDocumentMetadata {
   version: "1.0";
   self: {
@@ -62,6 +64,9 @@ export interface DBSectionDocumentMetadataDEPRECATED extends DBBaseProblemDocume
 }
 export interface DBProblemDocumentMetadata extends DBBaseProblemDocumentMetadata {
   type: "problem";
+}
+export interface DBPlanningDocumentMetadata extends DBBaseProblemDocumentMetadata {
+  type: "planning";
 }
 export interface DBPersonalDocumentMetadata extends DBBaseDocumentMetadata {
   type: "personal";
@@ -89,7 +94,7 @@ export interface DBGroupUserConnections {
   [key /*userId*/: string]: boolean;
 }
 
-// section documents [deprecated] and problem documents
+// contents written to {classHash}/users/{userId}/documents for all document types
 export interface DBDocument {
   version: "1.0";
   self: {
@@ -106,7 +111,8 @@ export interface IDocumentProperties {
   [key: string]: string;
 }
 
-// personal documents and learning logs
+// metadata written to {classHash}/users/{userId}/personalDocs (for personal documents)
+// and {classHash}/users/{userId}/learningLogs (for learning logs)
 export interface DBOtherDocument {
   version: "1.0";
   self: {
@@ -118,7 +124,7 @@ export interface DBOtherDocument {
   properties?: IDocumentProperties;
 }
 
-// published section documents [deprecated] and problem documents
+// metadata written to {classHash}/publications for published section [deprecated] and problem documents
 export interface DBPublication {
   version: "1.0";
   self: {
@@ -131,7 +137,8 @@ export interface DBPublication {
   groupUserConnections?: DBGroupUserConnections;
 }
 
-// published personal documents and learning logs
+// metadata written to {classHash}/personalPublications for published personal documents
+// and to {classHash}/publications for learning logs ¯\_(ツ)_/¯
 export interface DBOtherPublication {
   version: "1.0";
   self: {
@@ -143,6 +150,14 @@ export interface DBOtherPublication {
   uid: string;
   originDoc: string;
 }
+
+export type DBUnpublishedTypedDocumentMetadata = DBOfferingUserProblemDocument | DBOtherDocument;
+export type DBPublishedTypedDocumentMetadata = DBPublication | DBOtherPublication;
+
+export type DBProblemOrPublishedDocumentMetadata = DBOfferingUserProblemDocument | DBPublication;
+export type DBOtherOrPublishedDocumentMetadata = DBOtherDocument | DBOtherPublication;
+
+export type DBTypedDocumentMetadata = DBUnpublishedTypedDocumentMetadata | DBPublishedTypedDocumentMetadata;
 
 export interface DBClass {
   version: "1.0";
@@ -182,10 +197,13 @@ export interface DBOfferingUser {
     uid: string;
   };
   documents?: DBOfferingUserProblemDocumentMap;
+  planning?: DBOfferingUserProblemDocumentMap;
   sectionDocuments?: DBOfferingUserSectionDocumentMapDEPRECATED;
   // TDB: store ui information here?
 }
 
+// metadata written to {classHash}/offerings/{offeringId}/users/{userId}/documents (for problem documents)
+// and to {classHash}/offerings/{offeringId}/users/{userId}/planning (for planning documents)
 export interface DBOfferingUserProblemDocument {
   version: "1.0";
   self: {

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -106,17 +106,17 @@ export class Firebase {
     return `${this.getClassPath(user)}/users/${userId || user.id}`;
   }
 
-  // Published learning logs
+  // Published problem documents and learning logs metadata
   public getClassPublicationsPath(user: UserModelType) {
     return `${this.getClassPath(user)}/publications`;
   }
 
-  // Published personal documents
+  // Published personal documents metadata
   public getClassPersonalPublicationsPath(user: UserModelType) {
     return `${this.getClassPath(user)}/personalPublications`;
   }
 
-  // All documents associated with this user
+  // Content of all documents associated with this user
   public getUserDocumentPath(user: UserModelType, documentKey?: string, userId?: string) {
     const suffix = documentKey ? `/${documentKey}` : "";
     return `${this.getUserPath(user, userId)}/documents${suffix}`;
@@ -135,25 +135,26 @@ export class Firebase {
     return `${this.getOfferingPath(user)}/commentaries/stars${docSuffix}${starSuffix}`;
   }
 
+  // Basic metadata for all document types (in addition to type-specific metadata stored elsewhere)
   public getUserDocumentMetadataPath(user: UserModelType, documentKey?: string, userId?: string) {
     const suffix = documentKey ? `/${documentKey}` : "";
     return `${this.getUserPath(user, userId)}/documentMetadata${suffix}`;
   }
 
-  // Unpublished personal document/learning log
+  // Unpublished personal document/learning log metadata
   public getOtherDocumentPath(user: UserModelType, documentType: OtherDocumentType, documentKey?: string) {
     const dir = documentType === PersonalDocument ? "personalDocs" : "learningLogs";
     const key = documentKey ? `/${documentKey}` : "";
     return `${this.getUserPath(user)}/${dir}${key}`;
   }
 
-  // Unpublished learning log
+  // Unpublished learning log metadata
   public getLearningLogPath(user: UserModelType, documentKey?: string, userId?: string) {
     const suffix = documentKey ? `/${documentKey}` : "";
     return `${this.getUserPath(user, userId)}/learningLogs${suffix}`;
   }
 
-  // Unpublished personal document
+  // Unpublished personal document metadata
   public getUserPersonalDocPath(user: UserModelType, documentKey?: string, userId?: string) {
     const suffix = documentKey ? `/${documentKey}` : "";
     return `${this.getUserPath(user, userId)}/personalDocs${suffix}`;
@@ -175,18 +176,31 @@ export class Firebase {
     return `${this.getOfferingPath(user)}/users`;
   }
 
+  // the path to the user folder for a particular problem (assignment)
+  // metadata for each user document is in the class/offerings/users/userId path, but
+  // the contents of all of a user's documents are in the class/users/userId/documents path.
   public getOfferingUserPath(user: UserModelType, userId?: string) {
     return `${this.getOfferingUsersPath(user)}/${userId || user.id}`;
   }
 
-  // Unpublished problem document
+  // Unpublished problem document metadata
   public getProblemDocumentPath(user: UserModelType, documentKey: string, userId?: string) {
     return `${this.getOfferingUserPath(user, userId)}/documents/${documentKey}`;
   }
 
-  // Unpublished problem documents
+  // Unpublished problem documents metadata folder
   public getProblemDocumentsPath(user: UserModelType, userId?: string) {
     return `${this.getOfferingUserPath(user, userId)}/documents`;
+  }
+
+  // Planning document metadata
+  public getPlanningDocumentPath(user: UserModelType, documentKey: string, userId?: string) {
+    return `${this.getOfferingUserPath(user, userId)}/planning/${documentKey}`;
+  }
+
+  // Planning documents metadata folder
+  public getPlanningDocumentsPath(user: UserModelType, userId?: string) {
+    return `${this.getOfferingUserPath(user, userId)}/planning`;
   }
 
   // Unpublished section documents [deprecated]
@@ -207,7 +221,7 @@ export class Firebase {
     return `${this.getGroupPath(user, groupId)}/users/${userId || user.id}`;
   }
 
-  // Published section/problem documents
+  // Published section [deprecated] and problem document metadata
   public getPublicationsPath(user: UserModelType) {
     return `${this.getOfferingPath(user)}/publications`;
   }

--- a/src/models/curriculum/section.test.ts
+++ b/src/models/curriculum/section.test.ts
@@ -1,5 +1,5 @@
 import { getSectionInitials, getSectionPlaceholder, getSectionTitle,
-        kAllSectionType, SectionModel, setSectionInfoMap, kDefaultPlaceholder } from "./section";
+        kAllSectionType, SectionModel, registerSectionInfo, kDefaultPlaceholder } from "./section";
 
 describe("SectionModel", () => {
 
@@ -16,8 +16,8 @@ describe("SectionModel", () => {
     expect(section.title).toBe("Unknown");
   });
 
-  it("supports setSectionInfoMap() to configure sections", () => {
-    setSectionInfoMap({ foo: { initials: "FS", title: "Foo Section", placeholder: "Foo Placeholder" } });
+  it("supports registerSectionInfo() to configure sections", () => {
+    registerSectionInfo({ foo: { initials: "FS", title: "Foo Section", placeholder: "Foo Placeholder" } });
 
     const fooSection = SectionModel.create({ type: "foo" });
     expect(fooSection.initials).toBe("FS");

--- a/src/models/curriculum/section.test.ts
+++ b/src/models/curriculum/section.test.ts
@@ -31,6 +31,15 @@ describe("SectionModel", () => {
 
     expect(getSectionInitials(kAllSectionType)).toBe("*");
     expect(getSectionTitle(kAllSectionType)).toBe("All");
+
+    // ignores re-registration of the same info
+    jestSpyConsole("warn", () => {
+      registerSectionInfo({ foo: { initials: "SF", title: "Section Foo", placeholder: "Placeholder Foo" } });
+    });
+    const foo2Section = SectionModel.create({ type: "foo" });
+    expect(foo2Section.initials).toBe("FS");
+    expect(foo2Section.title).toBe("Foo Section");
+    expect(foo2Section.placeholder).toBe("Foo Placeholder");
   });
 
 });

--- a/src/models/curriculum/section.ts
+++ b/src/models/curriculum/section.ts
@@ -11,19 +11,31 @@ export interface ISectionInfo {
   placeholder?: string;
 }
 
-export interface ISectionInfoMap {
-  [sectionId: string]: ISectionInfo;
-}
-
 export const kAllSectionType = "all";
 const kAllSectionInfo = { initials: "*", title: "All" };
 export const kUnknownSectionType = "unknown";
 export const kDefaultPlaceholder = "Create or drag tiles here";
 const kUnknownSectionInfo = { initials: "?", title: "Unknown", placeholder: kDefaultPlaceholder };
 
+/*
+ * SectionInfoMap
+ *
+ * Global map from sectionType to SectionInfo, e.g.
+ * "introduction" => { initials: "IN", title: "introduction", placeholder: ... }
+ *
+ * Problem document sections are loaded from the `sections` property of the curriculum unit JSON.
+ * Teacher guide sections were originally loaded from the `sections` property of the teacher guide unit JSON.
+ * Planning document shares the same sections as teacher guide (overview, launch, explore, summarize).
+ *
+ * Since not all curriculum has a teacher guide, however, we can't rely on teacher guide JSON to
+ * initialize the map for the planning document. Therefore, the non-curriculum sections are now
+ * configured via the curriculum unit JSON.
+ */
+export type ISectionInfoMap = Record<string, ISectionInfo>;
+
 const gSectionInfoMap: ISectionInfoMap = { [kAllSectionType]: kAllSectionInfo };
 
-export function setSectionInfoMap(sectionInfoMap?: ISectionInfoMap) {
+export function registerSectionInfo(sectionInfoMap?: ISectionInfoMap) {
   // regular content and teacher guide are two separate units, so we merge them into a single map
   // teacher guide section types should be unique from regular content; we don't replace existing entries
   each(sectionInfoMap, (sectionInfo, sectionType) => {
@@ -31,7 +43,7 @@ export function setSectionInfoMap(sectionInfoMap?: ISectionInfoMap) {
       gSectionInfoMap[sectionType] = sectionInfo;
     }
     else {
-      console.warn("setSectionInfoMap skipping redundant assignment of section type:",
+      console.warn("registerSectionInfo skipping redundant assignment of section type:",
                   `${sectionType} "${sectionInfo.title}"`);
     }
   });
@@ -56,6 +68,8 @@ export function getSectionPlaceholder(type: SectionType) {
 export const SectionModel = types
   .model("Section", {
     type: types.string, // sectionId corresponding to entry in unit
+    // list of features to be disabled for this section
+    // currently unused as features are only disabled at the problem level
     disabled: types.array(types.string),
     content: types.maybe(DocumentContentModel),
     supports: types.array(SupportModel),

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -15,6 +15,7 @@ import {
 import {
   TileRowModel, TileRowModelType, TileRowSnapshotType, TileRowSnapshotOutType, TileLayoutModelType
 } from "../document/tile-row";
+import { SectionModelType } from "../curriculum/section";
 import { Logger, LogEventName } from "../../lib/logger";
 import { IDragTileItem } from "../../models/tools/tool-tile";
 import { DocumentsModelType } from "../stores/documents";
@@ -962,6 +963,18 @@ function migrateSnapshot(snapshot: any): any {
 
 export type DocumentContentModelType = Instance<typeof DocumentContentModel>;
 export type DocumentContentSnapshotType = SnapshotIn<typeof DocumentContentModel>;
+
+export function createDefaultSectionedContent(sections: SectionModelType[]) {
+  const tiles: OriginalToolTileModel[] = [];
+  // for blank sectioned documents, default content is a section header row and a placeholder
+  // tile for each section that is present in the template (the passed sections)
+  sections.forEach(section => {
+    tiles.push({ content: { isSectionHeader: true, sectionId: section.type }});
+    tiles.push({ content: { type: "Placeholder", sectionId: section.type }});
+  });
+  // cast required because we're using the import format
+  return DocumentContentModel.create({ tiles } as any);
+}
 
 export function cloneContentWithUniqueIds(content?: DocumentContentModelType,
                                           asTemplate?: boolean): DocumentContentModelType | undefined {

--- a/src/models/document/document-types.ts
+++ b/src/models/document/document-types.ts
@@ -15,6 +15,9 @@ export const SupportPublication = "supportPublication";
 export function isProblemType(type: string) {
   return [ProblemDocument, ProblemPublication].indexOf(type) >= 0;
 }
+export function isPlanningType(type: string) {
+  return type === PlanningDocument;
+}
 export function isPersonalType(type: string) {
   return [PersonalDocument, PersonalPublication].indexOf(type) >= 0;
 }

--- a/src/models/document/document-types.ts
+++ b/src/models/document/document-types.ts
@@ -5,6 +5,7 @@ export const DocumentDragKey = "org.concord.clue.document.key";
 export const SectionDocumentDEPRECATED = "section";
 export const ProblemDocument = "problem";
 export const PersonalDocument = "personal";
+export const PlanningDocument = "planning";
 export const LearningLogDocument = "learningLog";
 export const ProblemPublication = "publication";
 export const PersonalPublication = "personalPublication";
@@ -20,20 +21,26 @@ export function isPersonalType(type: string) {
 export function isLearningLogType(type: string) {
   return [LearningLogDocument, LearningLogPublication].indexOf(type) >= 0;
 }
+// is this type of document associated with the offering (i.e. with a particular problem)
+export function isOfferingType(type: string) {
+  return [SectionDocumentDEPRECATED, PlanningDocument, ProblemDocument, ProblemPublication, SupportPublication]
+          .indexOf(type) >= 0;
+}
 export function isUnpublishedType(type: string) {
-  return [SectionDocumentDEPRECATED, ProblemDocument, PersonalDocument, LearningLogDocument]
+  return [SectionDocumentDEPRECATED, PlanningDocument, ProblemDocument, PersonalDocument, LearningLogDocument]
           .indexOf(type) >= 0;
 }
 export function isPublishedType(type: string) {
-  return [ProblemPublication, PersonalPublication, LearningLogPublication, SupportPublication].indexOf(type) >= 0;
+  return [ProblemPublication, PersonalPublication, LearningLogPublication, SupportPublication]
+          .indexOf(type) >= 0;
 }
 
 export const DocumentTypeEnum = types.enumeration("type",
               [SectionDocumentDEPRECATED,
-                ProblemDocument, PersonalDocument, LearningLogDocument,
-                ProblemPublication, PersonalPublication, LearningLogPublication,
-                SupportPublication]);
+                ProblemDocument, PersonalDocument, PlanningDocument, LearningLogDocument,
+                ProblemPublication, PersonalPublication, LearningLogPublication, SupportPublication]);
 export type DocumentType = Instance<typeof DocumentTypeEnum>;
+export type ProblemOrPlanningDocumentType = typeof ProblemDocument | typeof PlanningDocument;
 export type OtherDocumentType = typeof PersonalDocument | typeof LearningLogDocument;
 export type PublishableType = typeof ProblemDocument | OtherDocumentType;
 export type OtherPublicationType = typeof PersonalPublication | typeof LearningLogPublication;

--- a/src/models/stores/documents.ts
+++ b/src/models/stores/documents.ts
@@ -2,7 +2,7 @@ import { types } from "mobx-state-tree";
 import { DocumentModel, DocumentModelType } from "../document/document";
 import {
   DocumentType, LearningLogDocument, LearningLogPublication, OtherDocumentType, OtherPublicationType,
-  PersonalDocument, PersonalPublication, ProblemDocument, ProblemPublication
+  PersonalDocument, PersonalPublication, PlanningDocument, ProblemDocument, ProblemPublication
 } from "../document/document-types";
 import { UnitModel, UnitModelType } from "../curriculum/unit";
 import { ClassModelType } from "./class";
@@ -66,6 +66,12 @@ export const DocumentsModel = types
     getLearningLogDocument(userId: string) {
       return self.all.find((document) => {
         return (document.type === LearningLogDocument) && (document.uid === userId);
+      });
+    },
+
+    getPlanningDocument(userId: string) {
+      return self.all.find((document) => {
+        return (document.type === PlanningDocument) && (document.uid === userId);
       });
     },
 

--- a/src/public/curriculum/moving-straight-ahead/moving-straight-ahead.json
+++ b/src/public/curriculum/moving-straight-ahead/moving-straight-ahead.json
@@ -56,6 +56,38 @@
       "placeholder": "Work area for\nMathematical Reflection 4 section"
     }
   },
+  "planningDocument": {
+    "enable": "teacher",
+    "default": true,
+    "sectionMap": {
+      "overview": {
+        "initials": "OV",
+        "title": "Overview",
+        "placeholder": "Work area for\nOverview section"
+      },
+      "launch": {
+        "initials": "LC",
+        "title": "Launch",
+        "placeholder": "Work area for\nLaunch section"
+      },
+      "explore": {
+        "initials": "EX",
+        "title": "Explore",
+        "placeholder": "Work area for\nExplore section"
+      },
+      "summarize": {
+        "initials": "SM",
+        "title": "Summarize",
+        "placeholder": "Work area for\nSummarize section"
+      }
+    },
+    "sections": [
+      { "type": "overview" },
+      { "type": "launch" },
+      { "type": "explore" },
+      { "type": "summarize" }
+    ]
+  },
   "defaultStamps": [
     {
       "url": "curriculum/moving-straight-ahead/stamps/coin.png",

--- a/src/public/curriculum/moving-straight-ahead/msa-teacher-guide.json
+++ b/src/public/curriculum/moving-straight-ahead/msa-teacher-guide.json
@@ -13,12 +13,12 @@
     "overview": {
       "initials": "OV",
       "title": "Overview",
-      "placeholder": "Work area for\noverview section"
+      "placeholder": "Work area for\nOverview section"
     },
     "launch": {
       "initials": "LC",
       "title": "Launch",
-      "placeholder": "Work area for\nInitial Challenge section"
+      "placeholder": "Work area for\nLaunch section"
     },
     "explore": {
       "initials": "EX",

--- a/src/public/curriculum/stretching-and-shrinking/stretching-and-shrinking.json
+++ b/src/public/curriculum/stretching-and-shrinking/stretching-and-shrinking.json
@@ -51,6 +51,38 @@
       "placeholder": "Work area for\nMathematical Reflection 4 section"
     }
   },
+  "planningDocument": {
+    "enable": "teacher",
+    "default": true,
+    "sectionMap": {
+      "overview": {
+        "initials": "OV",
+        "title": "Overview",
+        "placeholder": "Work area for\nOverview section"
+      },
+      "launch": {
+        "initials": "LC",
+        "title": "Launch",
+        "placeholder": "Work area for\nLaunch section"
+      },
+      "explore": {
+        "initials": "EX",
+        "title": "Explore",
+        "placeholder": "Work area for\nExplore section"
+      },
+      "summarize": {
+        "initials": "SM",
+        "title": "Summarize",
+        "placeholder": "Work area for\nSummarize section"
+      }
+    },
+    "sections": [
+      { "type": "overview" },
+      { "type": "launch" },
+      { "type": "explore" },
+      { "type": "summarize" }
+    ]
+  },
   "lookingAhead": {
     "tiles": [
       {
@@ -254,7 +286,7 @@
                       "type": "Text",
                       "format": "html",
                       "text": [
-                        "Click the <strong>Geometry</strong> tool icon to create a geometry graph tile. Note that a Text tile will be created to the right of the graph at the same time. (Select and delete the Text tile if you would like the graph to extend full width, showing more of the x axis.) Drag the bottom of the tile lower if you want to show more on the y axis. To create shapes on the graph, first click to create single points. Then double-click the final point to connect all points (e.g., the third point in a triangle)." 
+                        "Click the <strong>Geometry</strong> tool icon to create a geometry graph tile. Note that a Text tile will be created to the right of the graph at the same time. (Select and delete the Text tile if you would like the graph to extend full width, showing more of the x axis.) Drag the bottom of the tile lower if you want to show more on the y axis. To create shapes on the graph, first click to create single points. Then double-click the final point to connect all points (e.g., the third point in a triangle)."
                       ]
                     }
                   },
@@ -341,7 +373,7 @@
                         "The Mystery Club at P.I. Middle School meets monthly. Members watch videos, discuss novels, play “whodunit” games, and talk about real-life mysteries. One day, a member announces that the school is having a contest. A teacher in disguise will appear for a few minutes at school each day for a week. Any student can pay $1 for a guess at the identity of the mystery teacher. The student with the first correct guess wins a prize."
                       ]
                     }
-                  }, 
+                  },
                   {
                     "content": {
                       "type": "Text",
@@ -414,7 +446,7 @@
                       "type": "Text",
                       "format": "markdown",
                       "text": [
-                        "Complete Daphne’s reasoning to estimate the height of the teacher." 
+                        "Complete Daphne’s reasoning to estimate the height of the teacher."
                       ]
                     }
                   },
@@ -2389,7 +2421,7 @@
                     "layout": {
                       "height": 260
                     },
-                    "content": {	
+                    "content": {
                       "type":"Geometry",
                       "objects": [
                         {
@@ -2674,7 +2706,7 @@
         }
       ],
       "supports": []
-    }, 
+    },
     {
       "description": "Investigation 4",
       "ordinal": 4,
@@ -2732,7 +2764,7 @@
                         "Recall that a ratio is a comparison of two quantities, such as two lengths. The rectangle around the original figure is about 10 centimeters tall and 8 centimeters wide. You can say, “The ratio of height to width is 10 to 8.”\n\nThis table gives the ratios of height to width for the images."
                       ]
                     }
-                  }, 
+                  },
                   {
                     "content": {
                       "type": "Image",
@@ -2751,7 +2783,7 @@
                       "type": "Image",
                       "url": "curriculum/stretching-and-shrinking/images/SS_4_1_In_31_proportion_350w.png"
                     }
-                  }, 
+                  },
                   {
                     "content": {
                       "type": "Text",
@@ -2804,7 +2836,7 @@
                   "text": "How are rectangles different from other parallelograms?"
                 }
               ]
-            }, 
+            },
             {
               "type": "whatIf",
               "content": {
@@ -2901,7 +2933,7 @@
                         "The pairs of figures in each set are similar.<ul><li>Find the missing side lengths in each pair. Explain how you know your answers are correct?</li><li>In Set 3 find the angle measures for each parallelogram. </li><ul>"
                       ]
                     }
-                  }, 
+                  },
                   {
                     "content": {
                       "type": "Image",
@@ -2912,7 +2944,7 @@
                       "type": "Image",
                       "url": "curriculum/stretching-and-shrinking/images/SS_4_2_IC_36_Q2B_350w.png"
                     }
-                  }, 
+                  },
                   {
                     "content": {
                       "type": "Image",
@@ -2923,9 +2955,9 @@
                     "layout": {
                       "height": 400
                     },
-                    "content": 
+                    "content":
                    {"type":"Geometry","changes":["{\"operation\":\"create\",\"target\":\"board\",\"properties\":{\"axis\":true,\"boundingBox\":[-1.0928961748633879,18.579234972677593,27.3224043715847,-1.0928961748633879],\"unitX\":18.3,\"unitY\":18.3}}","{\"operation\":\"create\",\"properties\":{\"id\":\"4f8ef2ab-7858-4630-a957-d68386bf19f6\",\"snapToGrid\":true,\"snapSizeX\":0.1,\"snapSizeY\":0.1,\"name\":\"A\"},\"target\":\"point\",\"parents\":[1,18],\"startBatch\":true}","{\"operation\":\"create\",\"properties\":{\"id\":\"16aa98cf-ca0b-4c2b-9876-6e5a8a840f8e\",\"snapToGrid\":true,\"snapSizeX\":0.1,\"snapSizeY\":0.1,\"name\":\"B\"},\"target\":\"point\",\"parents\":[13,17.900000000000002]}","{\"operation\":\"create\",\"properties\":{\"id\":\"f2aafbcc-1804-4e0d-9604-ea484480310d\",\"snapToGrid\":true,\"snapSizeX\":0.1,\"snapSizeY\":0.1,\"name\":\"C\"},\"target\":\"point\",\"parents\":[3,19.900000000000002]}","{\"operation\":\"create\",\"properties\":{\"id\":\"256679af-d72d-4b5c-b7aa-f6c90e3262c4\",\"name\":\"P_{a}\"},\"target\":\"polygon\",\"parents\":[\"4f8ef2ab-7858-4630-a957-d68386bf19f6\",\"16aa98cf-ca0b-4c2b-9876-6e5a8a840f8e\",\"f2aafbcc-1804-4e0d-9604-ea484480310d\"]}","{\"operation\":\"create\",\"properties\":{\"id\":\"879b78e8-9c8c-4f76-97ae-4ffa3d72f047\",\"snapToGrid\":false,\"snapSizeX\":0.1,\"snapSizeY\":0.1,\"name\":\"D\"},\"target\":\"point\",\"parents\":[15.089629018888035,15.004098305593704]}","{\"operation\":\"create\",\"properties\":{\"id\":\"3aa83b2e-3138-4c17-b7a8-88863c6f783b\",\"snapToGrid\":false,\"snapSizeX\":0.1,\"snapSizeY\":0.1,\"name\":\"F\"},\"target\":\"point\",\"parents\":[15.987508722202124,19.20663997326249]}","{\"operation\":\"create\",\"properties\":{\"id\":\"b46394a9-e997-46d4-bc53-a341d5aaeeee\",\"snapToGrid\":true,\"snapSizeX\":0.1,\"snapSizeY\":0.1,\"name\":\"A\"},\"target\":\"point\",\"parents\":[1,6.300000000000001]}","{\"operation\":\"create\",\"properties\":{\"id\":\"cb7f6ab0-09fd-47bd-a3d1-704c1644c6e4\",\"snapToGrid\":true,\"snapSizeX\":0.1,\"snapSizeY\":0.1,\"name\":\"B\"},\"target\":\"point\",\"parents\":[1.1,1.8]}","{\"operation\":\"create\",\"properties\":{\"id\":\"f9731cb1-bfae-44be-9a79-5b7690f5e810\",\"snapToGrid\":true,\"snapSizeX\":0.1,\"snapSizeY\":0.1,\"name\":\"C\"},\"target\":\"point\",\"parents\":[3.7,0.8]}","{\"operation\":\"create\",\"properties\":{\"id\":\"d764cd74-54ea-4caa-a9a6-80b80ce7ecc7\",\"snapToGrid\":true,\"snapSizeX\":0.1,\"snapSizeY\":0.1,\"name\":\"D\"},\"target\":\"point\",\"parents\":[3.7,5.2]}","{\"operation\":\"create\",\"properties\":{\"id\":\"d067f66c-ba4a-4334-a356-ab4430be843c\",\"name\":\"P_{a}\"},\"target\":\"polygon\",\"parents\":[\"b46394a9-e997-46d4-bc53-a341d5aaeeee\",\"cb7f6ab0-09fd-47bd-a3d1-704c1644c6e4\",\"f9731cb1-bfae-44be-9a79-5b7690f5e810\",\"d764cd74-54ea-4caa-a9a6-80b80ce7ecc7\"]}","{\"operation\":\"create\",\"properties\":{\"id\":\"a88e59a8-8b96-433e-b7ed-23dbe0d93852\",\"radius\":1},\"target\":\"vertexAngle\",\"parents\":[\"cb7f6ab0-09fd-47bd-a3d1-704c1644c6e4\",\"b46394a9-e997-46d4-bc53-a341d5aaeeee\",\"d764cd74-54ea-4caa-a9a6-80b80ce7ecc7\"]}","{\"operation\":\"create\",\"properties\":{\"id\":\"2a966325-8c55-41ad-be77-ea10db7807a7\",\"snapToGrid\":false,\"snapSizeX\":0.1,\"snapSizeY\":0.1,\"name\":\"E\"},\"target\":\"point\",\"parents\":[5.817308417645462,0.6483504047306452]}","{\"operation\":\"create\",\"properties\":{\"id\":\"9456f6f0-c71f-4091-a730-db092f41350d\",\"snapToGrid\":false,\"snapSizeX\":0.1,\"snapSizeY\":0.1,\"name\":\"F\"},\"target\":\"point\",\"parents\":[15.669500594976327,0.6624620872369071]}","{\"operation\":\"create\",\"properties\":{\"id\":\"a68b7cff-812f-41d0-b3fb-429c5547ba51\",\"snapToGrid\":false,\"snapSizeX\":0.1,\"snapSizeY\":0.1,\"name\":\"G\"},\"target\":\"point\",\"parents\":[18.193215922236906,6.8494638029196295]}","{\"operation\":\"create\",\"properties\":{\"id\":\"9eec3cf3-73c0-42c4-ae8a-5e540172aa53\",\"snapToGrid\":false,\"snapSizeX\":0.1,\"snapSizeY\":0.1,\"name\":\"H\"},\"target\":\"point\",\"parents\":[8.333707570993896,6.769491261270044]}","{\"operation\":\"create\",\"properties\":{\"id\":\"e80894ff-e77e-4cee-952e-718e09ad24c6\",\"name\":\"P_{b}\"},\"target\":\"polygon\",\"parents\":[\"2a966325-8c55-41ad-be77-ea10db7807a7\",\"9456f6f0-c71f-4091-a730-db092f41350d\",\"a68b7cff-812f-41d0-b3fb-429c5547ba51\",\"9eec3cf3-73c0-42c4-ae8a-5e540172aa53\"]}","{\"operation\":\"create\",\"properties\":{\"id\":\"c34e47b3-8769-465d-9caf-5c09194511e3\",\"radius\":1},\"target\":\"vertexAngle\",\"parents\":[\"9456f6f0-c71f-4091-a730-db092f41350d\",\"2a966325-8c55-41ad-be77-ea10db7807a7\",\"9eec3cf3-73c0-42c4-ae8a-5e540172aa53\"]}","{\"operation\":\"create\",\"properties\":{\"id\":\"6ac2f5f3-434f-4053-8a9a-1a8f39933c22\",\"snapToGrid\":true,\"snapSizeX\":0.1,\"snapSizeY\":0.1,\"name\":\"A\"},\"target\":\"point\",\"parents\":[3.5,9.9]}","{\"operation\":\"create\",\"properties\":{\"id\":\"c134b506-a474-477e-badd-6f3284e5f710\",\"snapToGrid\":true,\"snapSizeX\":0.1,\"snapSizeY\":0.1,\"name\":\"B\"},\"target\":\"point\",\"parents\":[5.1000000000000005,9.9]}","{\"operation\":\"create\",\"properties\":{\"id\":\"3ce6d325-a498-41ec-84dc-5a91e6a5812e\",\"snapToGrid\":true,\"snapSizeX\":0.1,\"snapSizeY\":0.1,\"name\":\"C\"},\"target\":\"point\",\"parents\":[5,12.4]}","{\"operation\":\"create\",\"properties\":{\"id\":\"9dc814a1-ea1c-4a92-a04e-a9ef02c2873b\",\"snapToGrid\":true,\"snapSizeX\":0.1,\"snapSizeY\":0.1,\"name\":\"D\"},\"target\":\"point\",\"parents\":[3.5,12.4]}","{\"operation\":\"create\",\"properties\":{\"id\":\"27b8354e-36e7-49fe-9749-aee6a9433fb3\",\"name\":\"P_{a}\"},\"target\":\"polygon\",\"parents\":[\"6ac2f5f3-434f-4053-8a9a-1a8f39933c22\",\"c134b506-a474-477e-badd-6f3284e5f710\",\"3ce6d325-a498-41ec-84dc-5a91e6a5812e\",\"9dc814a1-ea1c-4a92-a04e-a9ef02c2873b\"]}","{\"operation\":\"create\",\"properties\":{\"id\":\"738bc31d-087d-4249-bbf9-b1584656471b\",\"radius\":1},\"target\":\"vertexAngle\",\"parents\":[\"c134b506-a474-477e-badd-6f3284e5f710\",\"6ac2f5f3-434f-4053-8a9a-1a8f39933c22\",\"9dc814a1-ea1c-4a92-a04e-a9ef02c2873b\"]}","{\"operation\":\"create\",\"properties\":{\"id\":\"ca28a5f5-64ae-4749-8dd7-b828b6bdefa0\",\"snapToGrid\":true,\"snapSizeX\":0.1,\"snapSizeY\":0.1,\"name\":\"E\"},\"target\":\"point\",\"parents\":[8,14]}","{\"operation\":\"create\",\"properties\":{\"id\":\"b8433027-b84c-4807-8ad0-124e3dc851e7\",\"snapToGrid\":true,\"snapSizeX\":0.1,\"snapSizeY\":0.1,\"name\":\"F\"},\"target\":\"point\",\"parents\":[8,8]}","{\"operation\":\"create\",\"properties\":{\"id\":\"64ae1ef1-abec-419c-b5e7-1f6ee5a425d0\",\"snapToGrid\":true,\"snapSizeX\":0.1,\"snapSizeY\":0.1,\"name\":\"G\"},\"target\":\"point\",\"parents\":[18,8]}","{\"operation\":\"create\",\"properties\":{\"id\":\"b1285468-8ac9-4717-b8b3-cdfbbde82c79\",\"snapToGrid\":true,\"snapSizeX\":0.1,\"snapSizeY\":0.1,\"name\":\"H\"},\"target\":\"point\",\"parents\":[18,13.9]}","{\"operation\":\"create\",\"properties\":{\"id\":\"a72286d7-fac7-40a4-8e43-996de471d3d2\",\"name\":\"P_{b}\"},\"target\":\"polygon\",\"parents\":[\"ca28a5f5-64ae-4749-8dd7-b828b6bdefa0\",\"b8433027-b84c-4807-8ad0-124e3dc851e7\",\"64ae1ef1-abec-419c-b5e7-1f6ee5a425d0\",\"b1285468-8ac9-4717-b8b3-cdfbbde82c79\"]}","{\"operation\":\"create\",\"properties\":{\"id\":\"758ead0e-0d33-4daf-a707-622da638e34b\",\"radius\":1},\"target\":\"vertexAngle\",\"parents\":[\"64ae1ef1-abec-419c-b5e7-1f6ee5a425d0\",\"b8433027-b84c-4807-8ad0-124e3dc851e7\",\"ca28a5f5-64ae-4749-8dd7-b828b6bdefa0\"],\"endBatch\":true}","{\"operation\":\"delete\",\"target\":\"object\",\"targetID\":[\"3aa83b2e-3138-4c17-b7a8-88863c6f783b\"]}","{\"operation\":\"create\",\"properties\":{\"id\":\"dba7c89b-b4f6-4404-a480-c71d9d594ca4\",\"snapToGrid\":false,\"snapSizeX\":0.1,\"snapSizeY\":0.1,\"name\":\"D\"},\"target\":\"point\",\"parents\":[15.089629018888035,15.004098305593704],\"startBatch\":true}","{\"operation\":\"create\",\"properties\":{\"id\":\"2a07874b-eeea-4853-a4df-03a995ad782e\",\"snapToGrid\":false,\"snapSizeX\":0.1,\"snapSizeY\":0.1,\"name\":\"E\"},\"target\":\"point\",\"parents\":[15.06188023264823,20.20345894829196]}","{\"operation\":\"create\",\"properties\":{\"id\":\"2c3e3378-b10b-4c44-9feb-6924de25d960\",\"snapToGrid\":false,\"snapSizeX\":0.1,\"snapSizeY\":0.1,\"name\":\"F\"},\"target\":\"point\",\"parents\":[15.987508722202124,19.20663997326249]}","{\"operation\":\"create\",\"properties\":{\"id\":\"08cf2680-1c94-4f1c-9296-6ec2b779d23b\",\"name\":\"P_{b}\"},\"target\":\"polygon\",\"parents\":[\"dba7c89b-b4f6-4404-a480-c71d9d594ca4\",\"2a07874b-eeea-4853-a4df-03a995ad782e\",\"2c3e3378-b10b-4c44-9feb-6924de25d960\"],\"endBatch\":true}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"2a966325-8c55-41ad-be77-ea10db7807a7\",\"9456f6f0-c71f-4091-a730-db092f41350d\",\"a68b7cff-812f-41d0-b3fb-429c5547ba51\",\"9eec3cf3-73c0-42c4-ae8a-5e540172aa53\"],\"properties\":[{\"position\":[1,5.926598035131802,0.9762192571896611]},{\"position\":[1,15.778790212462667,0.990330939695923]},{\"position\":[1,18.302505539723246,7.177332655378645]},{\"position\":[1,8.442997188480236,7.09736011372906]}]}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"cb7f6ab0-09fd-47bd-a3d1-704c1644c6e4\"],\"properties\":[{\"position\":[1,1,1.8]}]}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"6ac2f5f3-434f-4053-8a9a-1a8f39933c22\",\"c134b506-a474-477e-badd-6f3284e5f710\",\"3ce6d325-a498-41ec-84dc-5a91e6a5812e\",\"9dc814a1-ea1c-4a92-a04e-a9ef02c2873b\"],\"properties\":[{\"snapToGrid\":false,\"position\":[3.0603141205063,11.865891487995759]},{\"snapToGrid\":false,\"position\":[3.0398895801024057,10.26602185638533]},{\"snapToGrid\":false,\"position\":[5.540962413268945,10.334100363979896]},{\"snapToGrid\":false,\"position\":[5.560110419897596,11.833978143614674]}]}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"a68b7cff-812f-41d0-b3fb-429c5547ba51\"],\"properties\":[{\"position\":[1,18.247860730980076,7.013398229149137]}]}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"dba7c89b-b4f6-4404-a480-c71d9d594ca4\"],\"properties\":[{\"position\":[1,15.034984210144865,15.004098305593702]}]}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"2a07874b-eeea-4853-a4df-03a995ad782e\"],\"properties\":[{\"position\":[1,15.00723542390506,20.20345894829196]}]}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"3ce6d325-a498-41ec-84dc-5a91e6a5812e\"],\"properties\":[{\"position\":[1,5.595607222012115,10.334100363979896]}]}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"6ac2f5f3-434f-4053-8a9a-1a8f39933c22\"],\"properties\":[{\"position\":[1,3.0603141205063005,11.865891487995759]}]}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"6ac2f5f3-434f-4053-8a9a-1a8f39933c22\"],\"properties\":[{\"position\":[1,3.0603141205063005,11.76589148799576]}]}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"6ac2f5f3-434f-4053-8a9a-1a8f39933c22\"],\"properties\":[{\"position\":[1,3.0603141205063005,11.865891487995759]}]}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"6ac2f5f3-434f-4053-8a9a-1a8f39933c22\"],\"properties\":[{\"position\":[1,2.9603141205063004,11.865891487995759]}]}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"6ac2f5f3-434f-4053-8a9a-1a8f39933c22\"],\"properties\":[{\"position\":[1,3.0603141205063005,11.865891487995759]}]}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"9dc814a1-ea1c-4a92-a04e-a9ef02c2873b\"],\"properties\":[{\"position\":[1,5.490710382513662,11.90928961748634]}]}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"3ce6d325-a498-41ec-84dc-5a91e6a5812e\"],\"properties\":[{\"position\":[1,5.486317604525776,10.334100363979896]}]}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"6ac2f5f3-434f-4053-8a9a-1a8f39933c22\"],\"properties\":[{\"position\":[1,2.9510245030199616,11.865891487995759]}]}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"c134b506-a474-477e-badd-6f3284e5f710\"],\"properties\":[{\"position\":[1,3.0000000000000004,10.3]}]}","{\"operation\":\"create\",\"target\":\"point\",\"parents\":[28.087431693989064,8.688524590163937],\"properties\":{\"id\":\"ace52739-3491-4954-a913-ba153d6abc19\",\"snapToGrid\":true,\"snapSizeX\":0.1,\"snapSizeY\":0.1}}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"ace52739-3491-4954-a913-ba153d6abc19\"],\"properties\":[{\"position\":[1,28.1,8.8]}]}","{\"operation\":\"delete\",\"target\":\"object\",\"targetID\":[\"ace52739-3491-4954-a913-ba153d6abc19\"]}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"6ac2f5f3-434f-4053-8a9a-1a8f39933c22\"],\"properties\":[{\"position\":[1,2.841734885533623,11.811246679252589]}]}","{\"operation\":\"create\",\"target\":\"point\",\"parents\":[1.5300546448087426,9.890710382513664],\"properties\":{\"id\":\"a9ca75c5-6326-4b5d-aca6-7df5931c2ab3\",\"snapToGrid\":true,\"snapSizeX\":0.1,\"snapSizeY\":0.1}}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"a9ca75c5-6326-4b5d-aca6-7df5931c2ab3\"],\"properties\":[{\"position\":[1,1.6,9.9]}]}","{\"operation\":\"delete\",\"target\":\"object\",\"targetID\":[\"a9ca75c5-6326-4b5d-aca6-7df5931c2ab3\"]}","{\"operation\":\"delete\",\"target\":\"object\",\"targetID\":[\"6ac2f5f3-434f-4053-8a9a-1a8f39933c22\",\"c134b506-a474-477e-badd-6f3284e5f710\",\"3ce6d325-a498-41ec-84dc-5a91e6a5812e\",\"9dc814a1-ea1c-4a92-a04e-a9ef02c2873b\",\"27b8354e-36e7-49fe-9749-aee6a9433fb3\",\"738bc31d-087d-4249-bbf9-b1584656471b\"]}","{\"operation\":\"create\",\"target\":\"point\",\"parents\":[4.918032786885245,10.000000000000004],\"properties\":{\"id\":\"761a73cc-640c-4786-a55f-910f1343ef11\",\"snapToGrid\":true,\"snapSizeX\":0.1,\"snapSizeY\":0.1}}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"761a73cc-640c-4786-a55f-910f1343ef11\"],\"properties\":[{\"position\":[1,5,10.100000000000001]}]}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"761a73cc-640c-4786-a55f-910f1343ef11\"],\"properties\":[{\"position\":[1,5,10.000000000000002]}]}","{\"operation\":\"create\",\"target\":\"point\",\"parents\":[3.55191256830601,10.000000000000004],\"properties\":{\"id\":\"0d952c5f-b94e-4037-9a09-cfe50700a1b8\",\"snapToGrid\":true,\"snapSizeX\":0.1,\"snapSizeY\":0.1}}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"0d952c5f-b94e-4037-9a09-cfe50700a1b8\"],\"properties\":[{\"position\":[1,3.7,10]}]}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"0d952c5f-b94e-4037-9a09-cfe50700a1b8\"],\"properties\":[{\"position\":[1,3.6,10]}]}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"0d952c5f-b94e-4037-9a09-cfe50700a1b8\"],\"properties\":[{\"position\":[1,3.5,10]}]}","{\"operation\":\"create\",\"target\":\"point\",\"parents\":[3.4426229508196715,12.568306010928964],\"properties\":{\"id\":\"38d2efb8-9485-4b74-8fbb-09aea8fd1ad0\",\"snapToGrid\":true,\"snapSizeX\":0.1,\"snapSizeY\":0.1}}","{\"operation\":\"create\",\"target\":\"point\",\"parents\":[4.972677595628414,12.677595628415304],\"properties\":{\"id\":\"5613b304-98e4-4ce8-8495-2917bc1ffd84\",\"snapToGrid\":true,\"snapSizeX\":0.1,\"snapSizeY\":0.1}}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"5613b304-98e4-4ce8-8495-2917bc1ffd84\"],\"properties\":[{\"position\":[1,5.1000000000000005,12.700000000000001]}]}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"5613b304-98e4-4ce8-8495-2917bc1ffd84\"],\"properties\":[{\"position\":[1,5.000000000000001,12.700000000000001]}]}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"5613b304-98e4-4ce8-8495-2917bc1ffd84\"],\"properties\":[{\"position\":[1,5.000000000000001,12.600000000000001]}]}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"5613b304-98e4-4ce8-8495-2917bc1ffd84\"],\"properties\":[{\"position\":[1,5.000000000000001,12.500000000000002]}]}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"38d2efb8-9485-4b74-8fbb-09aea8fd1ad0\"],\"properties\":[{\"position\":[1,3.4000000000000004,12.700000000000001]}]}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"38d2efb8-9485-4b74-8fbb-09aea8fd1ad0\"],\"properties\":[{\"position\":[1,3.4000000000000004,12.600000000000001]}]}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"38d2efb8-9485-4b74-8fbb-09aea8fd1ad0\"],\"properties\":[{\"position\":[1,3.4000000000000004,12.500000000000002]}]}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"38d2efb8-9485-4b74-8fbb-09aea8fd1ad0\"],\"properties\":[{\"position\":[1,3.5000000000000004,12.500000000000002]}]}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"38d2efb8-9485-4b74-8fbb-09aea8fd1ad0\"],\"properties\":[{\"position\":[1,3.55464480874317,12.500000000000002]}]}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"dba7c89b-b4f6-4404-a480-c71d9d594ca4\",\"2a07874b-eeea-4853-a4df-03a995ad782e\",\"2c3e3378-b10b-4c44-9feb-6924de25d960\"],\"properties\":[{\"position\":[1,15.034984210144865,14.949453496850532]},{\"position\":[1,15.00723542390506,20.14881413954879]},{\"position\":[1,15.987508722202124,19.15199516451932]}]}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"dba7c89b-b4f6-4404-a480-c71d9d594ca4\",\"2a07874b-eeea-4853-a4df-03a995ad782e\",\"2c3e3378-b10b-4c44-9feb-6924de25d960\"],\"properties\":[{\"position\":[1,16.073235576265084,14.949453496850532]},{\"position\":[1,16.04548679002528,20.14881413954879]},{\"position\":[1,17.025760088322343,19.15199516451932]}]}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"879b78e8-9c8c-4f76-97ae-4ffa3d72f047\"],\"properties\":[{\"position\":[1,15.136612021857923,15.081967213114757]}]}","{\"operation\":\"delete\",\"target\":\"object\",\"targetID\":[\"879b78e8-9c8c-4f76-97ae-4ffa3d72f047\"]}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"dba7c89b-b4f6-4404-a480-c71d9d594ca4\",\"2a07874b-eeea-4853-a4df-03a995ad782e\",\"2c3e3378-b10b-4c44-9feb-6924de25d960\"],\"properties\":[{\"position\":[1,15.034984210144867,15.004098305593699]},{\"position\":[1,15.007235423905062,20.203458948291956]},{\"position\":[1,15.987508722202126,19.206639973262487]}]}","{\"operation\":\"create\",\"target\":\"polygon\",\"parents\":[\"761a73cc-640c-4786-a55f-910f1343ef11\",\"0d952c5f-b94e-4037-9a09-cfe50700a1b8\",\"38d2efb8-9485-4b74-8fbb-09aea8fd1ad0\",\"5613b304-98e4-4ce8-8495-2917bc1ffd84\"],\"properties\":{\"id\":\"229fdb45-3397-46be-88a9-6a811cff5c4c\"}}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"38d2efb8-9485-4b74-8fbb-09aea8fd1ad0\"],\"properties\":[{\"position\":[1,3.5,12.5]}]}","{\"operation\":\"create\",\"target\":\"vertexAngle\",\"parents\":[\"761a73cc-640c-4786-a55f-910f1343ef11\",\"0d952c5f-b94e-4037-9a09-cfe50700a1b8\",\"38d2efb8-9485-4b74-8fbb-09aea8fd1ad0\"],\"properties\":{\"id\":\"0c35873c-4134-4536-a3cd-0c93dd9e557f\",\"radius\":1}}","{\"operation\":\"create\",\"target\":\"point\",\"parents\":[26.065573770491802,10.491803278688527],\"properties\":{\"id\":\"a266b80a-c47a-4b0c-8429-31b9d1155e59\",\"snapToGrid\":true,\"snapSizeX\":0.1,\"snapSizeY\":0.1}}","{\"operation\":\"delete\",\"target\":\"object\",\"targetID\":[\"a266b80a-c47a-4b0c-8429-31b9d1155e59\"]}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"b1285468-8ac9-4717-b8b3-cdfbbde82c79\"],\"properties\":[{\"position\":[1,18,14]}]}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"9eec3cf3-73c0-42c4-ae8a-5e540172aa53\"],\"properties\":[{\"position\":[1,8.442997188480236,6.99736011372906]}]}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"2a966325-8c55-41ad-be77-ea10db7807a7\"],\"properties\":[{\"position\":[1,5.981242843874971,0.9762192571896623]}]}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"2a966325-8c55-41ad-be77-ea10db7807a7\"],\"properties\":[{\"position\":[1,5.981242843874971,0.8762192571896623]}]}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"2a966325-8c55-41ad-be77-ea10db7807a7\"],\"properties\":[{\"position\":[1,5.981242843874971,0.9762192571896623]}]}","{\"operation\":\"create\",\"target\":\"point\",\"parents\":[32.349726775956285,10.819672131147543],\"properties\":{\"id\":\"9dd7ac4f-e63b-42e1-885f-a2d450d74f02\",\"snapToGrid\":true,\"snapSizeX\":0.1,\"snapSizeY\":0.1}}","{\"operation\":\"delete\",\"target\":\"object\",\"targetID\":[\"9dd7ac4f-e63b-42e1-885f-a2d450d74f02\"]}","{\"operation\":\"create\",\"target\":\"point\",\"parents\":[56.994535519125684,11.912568306010932],\"properties\":{\"id\":\"82b37f05-3244-4ce3-8750-b393d40ed41d\",\"snapToGrid\":true,\"snapSizeX\":0.1,\"snapSizeY\":0.1}}","{\"operation\":\"update\",\"target\":\"object\",\"targetID\":[\"82b37f05-3244-4ce3-8750-b393d40ed41d\"],\"properties\":[{\"position\":[1,56.900000000000006,11.9]}]}","{\"operation\":\"delete\",\"target\":\"object\",\"targetID\":[\"82b37f05-3244-4ce3-8750-b393d40ed41d\"]}"]}
-                  }  
+                  }
                 ]
               },
               "supports" : [
@@ -2949,7 +2981,7 @@
                       "type": "Image",
                       "url": "curriculum/stretching-and-shrinking/images/SS_4_2_WI_38_figs_500w.png"
                     }
-                  }, 
+                  },
                   {
                     "content": {
                       "type": "Text",
@@ -2962,7 +2994,7 @@
                 ]
               },
               "supports": [
-                { "text": "(1)  How do you know if these two figures are similar?"}, 
+                { "text": "(1)  How do you know if these two figures are similar?"},
                 { "text": "Would the scale factors or the ratios of adjacent side lengths help you find the missing values?"}
               ]
             }, {
@@ -3007,7 +3039,7 @@
                   }
                 ]
               }
-            }, 
+            },
             {
               "type": "initialChallenge",
               "content": {
@@ -3047,7 +3079,7 @@
               "supports" : [
                 {"text": "Are the two triangles similar? Why?"}
               ]
-            }, 
+            },
             {
               "type": "whatIf",
               "content": {
@@ -3093,7 +3125,7 @@
                   }
                 ]
               },
-              "supports": [ 
+              "supports": [
                 { "text": "Are the two triangles similar? Why?"},
                 { "text": "What are  the corresponding side lengths and corresponding angles?"}
               ]
@@ -3141,7 +3173,7 @@
                         "In this unit, we used proportional reasoning to investigate reasoning to investigate similar figures also called scale drawings. At the end of this Investigation, what do you know about similarity? What do you know about proportional reasoning?"
                       ]
                     }
-                  } 
+                  }
                 ]
               },
               "supports": [ ]
@@ -3158,7 +3190,7 @@
                         "In this unit, we used proportional reasoning to investigate reasoning to investigate similar figures also called scale drawings. At the end of this Investigation, what do you know about similarity? What do you know about proportional reasoning?"
                       ]
                     }
-                  } 
+                  }
                 ]
               },
               "supports": [ ]
@@ -3175,7 +3207,7 @@
                         "In this unit, we used proportional reasoning to investigate reasoning to investigate similar figures also called scale drawings. At the end of this Investigation, what do you know about similarity? What do you know about proportional reasoning?"
                       ]
                     }
-                  } 
+                  }
                 ]
               },
               "supports": [ ]
@@ -3192,7 +3224,7 @@
                         "In this unit, we used proportional reasoning to investigate reasoning to investigate similar figures also called scale drawings. At the end of this Investigation, what do you know about similarity? What do you know about proportional reasoning?"
                       ]
                     }
-                  } 
+                  }
                 ]
               },
               "supports": [ ]


### PR DESCRIPTION
This PR creates a default planning document (if one doesn't already exist) for each of a teacher's problems in a planning-document-enabled curriculum unit. ~~There is no UI for viewing or interacting with the planning document at this point, however. That will be provided in a subsequent PR.~~ The planning document shows in the document browser next to the problem document. There are still some issues, for instance the document header doesn't render when editing the planning document, but it basically functions like a normal document at this point.