### PR TITLE
Update postDocumentComment firebase function

### DIFF
--- a/functions/src/shared.ts
+++ b/functions/src/shared.ts
@@ -87,11 +87,13 @@ export interface IUserContext {
  * networkDocumentKey
  *
  * To accommodate the fact that the same document can be commented upon in multiple networks, the
- * id of a document in firestore is a mashup of the network and the document key.
+ * id of a document in firestore is a mashup of the network/uid and the document key.
  */
-export function networkDocumentKey(documentKey: string, network?: string) {
+export function networkDocumentKey(uid: string, documentKey: string, network?: string) {
   const escapedKey = escapeKey(documentKey);
-  return network ? `${network}_${escapedKey}` : escapedKey;
+  const escapedNetwork = network && escapeKey(network);
+  const prefix = escapedNetwork || `uid:${uid}`;
+  return `${prefix}_${escapedKey}`;
 }
 
 export interface IDocumentMetadata {

--- a/functions/test/shared.test.ts
+++ b/functions/test/shared.test.ts
@@ -1,4 +1,4 @@
-import { buildSectionPath, escapeKey, getCurriculumMetadata, isProblemPath, isSectionPath, parseProblemPath, parseSectionPath } from "../src/shared";
+import { buildSectionPath, escapeKey, getCurriculumMetadata, isProblemPath, isSectionPath, networkDocumentKey, parseProblemPath, parseSectionPath } from "../src/shared";
 
 describe("shared types and utilities", () => {
 
@@ -93,6 +93,13 @@ describe("shared types and utilities", () => {
               .toEqual({ unit: "foo", problem: "1.2", section: "intro", path: "foo/1/2/intro" });
       expect(getCurriculumMetadata("foo:facet/1/2/intro"))
               .toEqual({ unit: "foo", facet: "facet", problem: "1.2", section: "intro", path: "foo:facet/1/2/intro" });
+    });
+  });
+
+  describe("networkDocumentKey", () => {
+    it("should return appropriate document key combining network and uid as appropriate", () => {
+      expect(networkDocumentKey("user", "doc123")).toBe("uid:user_doc123");
+      expect(networkDocumentKey("user", "doc123", "network")).toBe("network_doc123");
     });
   });
 

--- a/src/hooks/use-stores.ts
+++ b/src/hooks/use-stores.ts
@@ -66,7 +66,8 @@ export function useGroupsStore(): GroupsModelType {
 }
 
 export function useNetworkDocumentKey(documentKey: string) {
-  return networkDocumentKey(documentKey, useUserStore().teacherNetwork);
+  const user = useUserStore();
+  return networkDocumentKey(user.id, documentKey, user.teacherNetwork);
 }
 
 export function useProblemPath() {

--- a/src/lib/firestore-schema.ts
+++ b/src/lib/firestore-schema.ts
@@ -54,6 +54,7 @@ type CommentsCollection = FSCollection<CommentDocument>;
  * comments can only be viewed by teachers in the same network.
  */
 interface CurriculumDocument {
+  uid: string;                        // uid of teacher making first comment, i.e. adding the record
   unit: string;                       // unit code, e.g. "sas", "msa", etc.
   facet?: string;                     // empty for regular curriculum; "guide" for teacher guide, etc.
   problem: string;                    // ordinal string, e.g. "2.1"
@@ -62,8 +63,8 @@ interface CurriculumDocument {
   network?: string;                   // network of teacher commenting on document
   comments: CommentsCollection;       // comments/chats subcollection
 }
-// collection key is {network}_{escapedProblemPath} because
-// the same document might get added in different networks over time
+// collection key is {network}_{escapedProblemPath} or {uid:userId}_{escapedProblemPath} because
+// the same document might get added in different networks or different un-networked teachers
 type CurriculumCollection = FSCollection<CurriculumDocument>;
 
 /*


### PR DESCRIPTION
- add uid field for curriculum documents
- include uid in path for non-networked teachers

To support different non-networked teachers ability to comment on individual curriculum "documents" without seeing each others' comments, we need to include the user id in the curriculum "document" path. Likewise, for non-networked teachers to have access to their own commented curriculum "documents" but not to those of other teachers, we need to associate each curriculum "document" with the teacher that created it.