### PR TITLE
Update security rules to support networked teachers commenting on curriculum "documents" [#179361057]

### DIFF
--- a/firebase-test/package-lock.json
+++ b/firebase-test/package-lock.json
@@ -50,6 +50,15 @@
             "@babel/highlight": "^7.14.5"
           }
         },
+        "json5": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+          "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -850,15 +859,15 @@
       }
     },
     "@google-cloud/firestore": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-4.14.1.tgz",
-      "integrity": "sha512-ecPxrwsk3IWfyILHhVtRJXFcn+CFnlYRbnM6vwS+eEwHAfSFoy4tNXlsvh7c4YihuojAkvgl4+iBxPMwy5X09A==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-4.15.0.tgz",
+      "integrity": "sha512-0hJnzkGeEGcFtyJ6PWYOzBT5xYcm7V1xZCQIeG0dIH989OPnWGJoM2ZUZGFNIxRB24KtbRasoy75+8dyYpKAyw==",
       "dev": true,
       "optional": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "functional-red-black-tree": "^1.0.1",
-        "google-gax": "^2.17.1",
+        "google-gax": "^2.24.1",
         "protobufjs": "^6.8.6"
       }
     },
@@ -888,9 +897,9 @@
       "optional": true
     },
     "@google-cloud/storage": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.13.0.tgz",
-      "integrity": "sha512-LN3Cv7NRBbjwdwcrIFbEaKEEUCUr7aIoBa7j1HXeuBLjC1lQ5VGVGEbaLRP6uwgBKVnf5rFYSTA545C1GR+e/A==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.14.0.tgz",
+      "integrity": "sha512-tc8IrD1ZfKOm0WoC2r3+YG8K7NdaxsubedM3KYOf0m2QqqD4j9gYuEqIegs+jGoV2fr1XMibb9g/4DLp5Sv5kg==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -900,7 +909,7 @@
         "arrify": "^2.0.0",
         "async-retry": "^1.3.1",
         "compressible": "^2.0.12",
-        "date-and-time": "^1.0.0",
+        "date-and-time": "^2.0.0",
         "duplexify": "^4.0.0",
         "extend": "^3.0.2",
         "gcs-resumable-upload": "^3.3.0",
@@ -908,7 +917,6 @@
         "hash-stream-validation": "^0.2.2",
         "mime": "^2.2.0",
         "mime-types": "^2.0.8",
-        "onetime": "^5.1.0",
         "p-limit": "^3.0.1",
         "pumpify": "^2.0.0",
         "snakeize": "^0.1.0",
@@ -1032,104 +1040,179 @@
       "dev": true
     },
     "@jest/console": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-27.0.6.tgz",
-      "integrity": "sha512-fMlIBocSHPZ3JxgWiDNW/KPj6s+YRd0hicb33IrmelCcjXo/pXPwvuiKFmZz+XuqI/1u7nbUK10zSsWL/1aegg==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-27.1.0.tgz",
+      "integrity": "sha512-+Vl+xmLwAXLNlqT61gmHEixeRbS4L8MUzAjtpBCOPWH+izNI/dR16IeXjkXJdRtIVWVSf9DO1gdp67B1XorZhQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.1.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "jest-message-util": "^27.0.6",
-        "jest-util": "^27.0.6",
+        "jest-message-util": "^27.1.0",
+        "jest-util": "^27.1.0",
         "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "@jest/core": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.0.6.tgz",
-      "integrity": "sha512-SsYBm3yhqOn5ZLJCtccaBcvD/ccTLCeuDv8U41WJH/V1MW5eKUkeMHT9U+Pw/v1m1AIWlnIW/eM2XzQr0rEmow==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.1.0.tgz",
+      "integrity": "sha512-3l9qmoknrlCFKfGdrmiQiPne+pUR4ALhKwFTYyOeKw6egfDwJkO21RJ1xf41rN8ZNFLg5W+w6+P4fUqq4EMRWA==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.0.6",
-        "@jest/reporters": "^27.0.6",
-        "@jest/test-result": "^27.0.6",
-        "@jest/transform": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/console": "^27.1.0",
+        "@jest/reporters": "^27.1.0",
+        "@jest/test-result": "^27.1.0",
+        "@jest/transform": "^27.1.0",
+        "@jest/types": "^27.1.0",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "emittery": "^0.8.1",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
-        "jest-changed-files": "^27.0.6",
-        "jest-config": "^27.0.6",
-        "jest-haste-map": "^27.0.6",
-        "jest-message-util": "^27.0.6",
+        "jest-changed-files": "^27.1.0",
+        "jest-config": "^27.1.0",
+        "jest-haste-map": "^27.1.0",
+        "jest-message-util": "^27.1.0",
         "jest-regex-util": "^27.0.6",
-        "jest-resolve": "^27.0.6",
-        "jest-resolve-dependencies": "^27.0.6",
-        "jest-runner": "^27.0.6",
-        "jest-runtime": "^27.0.6",
-        "jest-snapshot": "^27.0.6",
-        "jest-util": "^27.0.6",
-        "jest-validate": "^27.0.6",
-        "jest-watcher": "^27.0.6",
+        "jest-resolve": "^27.1.0",
+        "jest-resolve-dependencies": "^27.1.0",
+        "jest-runner": "^27.1.0",
+        "jest-runtime": "^27.1.0",
+        "jest-snapshot": "^27.1.0",
+        "jest-util": "^27.1.0",
+        "jest-validate": "^27.1.0",
+        "jest-watcher": "^27.1.0",
         "micromatch": "^4.0.4",
         "p-each-series": "^2.1.0",
         "rimraf": "^3.0.0",
         "slash": "^3.0.0",
         "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "@jest/environment": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.0.6.tgz",
-      "integrity": "sha512-4XywtdhwZwCpPJ/qfAkqExRsERW+UaoSRStSHCCiQTUpoYdLukj+YJbQSFrZjhlUDRZeNiU9SFH0u7iNimdiIg==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.1.0.tgz",
+      "integrity": "sha512-wRp50aAMY2w1U2jP1G32d6FUVBNYqmk8WaGkiIEisU48qyDV0WPtw3IBLnl7orBeggveommAkuijY+RzVnNDOQ==",
       "dev": true,
       "requires": {
-        "@jest/fake-timers": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/fake-timers": "^27.1.0",
+        "@jest/types": "^27.1.0",
         "@types/node": "*",
-        "jest-mock": "^27.0.6"
+        "jest-mock": "^27.1.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "@jest/fake-timers": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.0.6.tgz",
-      "integrity": "sha512-sqd+xTWtZ94l3yWDKnRTdvTeZ+A/V7SSKrxsrOKSqdyddb9CeNRF8fbhAU0D7ZJBpTTW2nbp6MftmKJDZfW2LQ==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.1.0.tgz",
+      "integrity": "sha512-22Zyn8il8DzpS+30jJNVbTlm7vAtnfy1aYvNeOEHloMlGy1PCYLHa4PWlSws0hvNsMM5bON6GISjkLoQUV3oMA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.1.0",
         "@sinonjs/fake-timers": "^7.0.2",
         "@types/node": "*",
-        "jest-message-util": "^27.0.6",
-        "jest-mock": "^27.0.6",
-        "jest-util": "^27.0.6"
+        "jest-message-util": "^27.1.0",
+        "jest-mock": "^27.1.0",
+        "jest-util": "^27.1.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "@jest/globals": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.0.6.tgz",
-      "integrity": "sha512-DdTGCP606rh9bjkdQ7VvChV18iS7q0IMJVP1piwTWyWskol4iqcVwthZmoJEf7obE1nc34OpIyoVGPeqLC+ryw==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.1.0.tgz",
+      "integrity": "sha512-73vLV4aNHAlAgjk0/QcSIzzCZSqVIPbmFROJJv9D3QUR7BI4f517gVdJpSrCHxuRH3VZFhe0yGG/tmttlMll9g==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.0.6",
-        "@jest/types": "^27.0.6",
-        "expect": "^27.0.6"
+        "@jest/environment": "^27.1.0",
+        "@jest/types": "^27.1.0",
+        "expect": "^27.1.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "@jest/reporters": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.0.6.tgz",
-      "integrity": "sha512-TIkBt09Cb2gptji3yJXb3EE+eVltW6BjO7frO7NEfjI9vSIYoISi5R3aI3KpEDXlB1xwB+97NXIqz84qYeYsfA==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.1.0.tgz",
+      "integrity": "sha512-5T/zlPkN2HnK3Sboeg64L5eC8iiaZueLpttdktWTJsvALEtP2YMkC5BQxwjRWQACG9SwDmz+XjjkoxXUDMDgdw==",
       "dev": true,
       "requires": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^27.0.6",
-        "@jest/test-result": "^27.0.6",
-        "@jest/transform": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/console": "^27.1.0",
+        "@jest/test-result": "^27.1.0",
+        "@jest/transform": "^27.1.0",
+        "@jest/types": "^27.1.0",
         "chalk": "^4.0.0",
         "collect-v8-coverage": "^1.0.0",
         "exit": "^0.1.2",
@@ -1140,15 +1223,30 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.0.2",
-        "jest-haste-map": "^27.0.6",
-        "jest-resolve": "^27.0.6",
-        "jest-util": "^27.0.6",
-        "jest-worker": "^27.0.6",
+        "jest-haste-map": "^27.1.0",
+        "jest-resolve": "^27.1.0",
+        "jest-util": "^27.1.0",
+        "jest-worker": "^27.1.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
         "terminal-link": "^2.0.0",
         "v8-to-istanbul": "^8.0.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "@jest/source-map": {
@@ -1163,50 +1261,80 @@
       }
     },
     "@jest/test-result": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.0.6.tgz",
-      "integrity": "sha512-ja/pBOMTufjX4JLEauLxE3LQBPaI2YjGFtXexRAjt1I/MbfNlMx0sytSX3tn5hSLzQsR3Qy2rd0hc1BWojtj9w==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.1.0.tgz",
+      "integrity": "sha512-Aoz00gpDL528ODLghat3QSy6UBTD5EmmpjrhZZMK/v1Q2/rRRqTGnFxHuEkrD4z/Py96ZdOHxIWkkCKRpmnE1A==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/console": "^27.1.0",
+        "@jest/types": "^27.1.0",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "@jest/test-sequencer": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.0.6.tgz",
-      "integrity": "sha512-bISzNIApazYOlTHDum9PwW22NOyDa6VI31n6JucpjTVM0jD6JDgqEZ9+yn575nDdPF0+4csYDxNNW13NvFQGZA==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.1.0.tgz",
+      "integrity": "sha512-lnCWawDr6Z1DAAK9l25o3AjmKGgcutq1iIbp+hC10s/HxnB8ZkUsYq1FzjOoxxZ5hW+1+AthBtvS4x9yno3V1A==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^27.0.6",
+        "@jest/test-result": "^27.1.0",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.0.6",
-        "jest-runtime": "^27.0.6"
+        "jest-haste-map": "^27.1.0",
+        "jest-runtime": "^27.1.0"
       }
     },
     "@jest/transform": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.0.6.tgz",
-      "integrity": "sha512-rj5Dw+mtIcntAUnMlW/Vju5mr73u8yg+irnHwzgtgoeI6cCPOvUwQ0D1uQtc/APmWgvRweEb1g05pkUpxH3iCA==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.1.0.tgz",
+      "integrity": "sha512-ZRGCA2ZEVJ00ubrhkTG87kyLbN6n55g1Ilq0X9nJb5bX3MhMp3O6M7KG+LvYu+nZRqG5cXsQnJEdZbdpTAV8pQ==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.1.0",
         "babel-plugin-istanbul": "^6.0.0",
         "chalk": "^4.0.0",
         "convert-source-map": "^1.4.0",
         "fast-json-stable-stringify": "^2.0.0",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.0.6",
+        "jest-haste-map": "^27.1.0",
         "jest-regex-util": "^27.0.6",
-        "jest-util": "^27.0.6",
+        "jest-util": "^27.1.0",
         "micromatch": "^4.0.4",
         "pirates": "^4.0.1",
         "slash": "^3.0.0",
         "source-map": "^0.6.1",
         "write-file-atomic": "^3.0.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "@jest/types": {
@@ -1517,6 +1645,12 @@
       "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
       "dev": true
     },
+    "@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
+    },
     "@types/long": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
@@ -1591,13 +1725,13 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.29.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.29.2.tgz",
-      "integrity": "sha512-x4EMgn4BTfVd9+Z+r+6rmWxoAzBaapt4QFqE+d8L8sUtYZYLDTK6VG/y/SMMWA5t1/BVU5Kf+20rX4PtWzUYZg==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.30.0.tgz",
+      "integrity": "sha512-NgAnqk55RQ/SD+tZFD9aPwNSeHmDHHe5rtUyhIq0ZeCWZEvo4DK9rYz7v9HDuQZFvn320Ot+AikaCKMFKLlD0g==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.29.2",
-        "@typescript-eslint/scope-manager": "4.29.2",
+        "@typescript-eslint/experimental-utils": "4.30.0",
+        "@typescript-eslint/scope-manager": "4.30.0",
         "debug": "^4.3.1",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.1.0",
@@ -1617,55 +1751,55 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.29.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.29.2.tgz",
-      "integrity": "sha512-P6mn4pqObhftBBPAv4GQtEK7Yos1fz/MlpT7+YjH9fTxZcALbiiPKuSIfYP/j13CeOjfq8/fr9Thr2glM9ub7A==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.30.0.tgz",
+      "integrity": "sha512-K8RNIX9GnBsv5v4TjtwkKtqMSzYpjqAQg/oSphtxf3xxdt6T0owqnpojztjjTcatSteH3hLj3t/kklKx87NPqw==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.7",
-        "@typescript-eslint/scope-manager": "4.29.2",
-        "@typescript-eslint/types": "4.29.2",
-        "@typescript-eslint/typescript-estree": "4.29.2",
+        "@typescript-eslint/scope-manager": "4.30.0",
+        "@typescript-eslint/types": "4.30.0",
+        "@typescript-eslint/typescript-estree": "4.30.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.29.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.29.2.tgz",
-      "integrity": "sha512-WQ6BPf+lNuwteUuyk1jD/aHKqMQ9jrdCn7Gxt9vvBnzbpj7aWEf+aZsJ1zvTjx5zFxGCt000lsbD9tQPEL8u6g==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.30.0.tgz",
+      "integrity": "sha512-HJ0XuluSZSxeboLU7Q2VQ6eLlCwXPBOGnA7CqgBnz2Db3JRQYyBDJgQnop6TZ+rsbSx5gEdWhw4rE4mDa1FnZg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.29.2",
-        "@typescript-eslint/types": "4.29.2",
-        "@typescript-eslint/typescript-estree": "4.29.2",
+        "@typescript-eslint/scope-manager": "4.30.0",
+        "@typescript-eslint/types": "4.30.0",
+        "@typescript-eslint/typescript-estree": "4.30.0",
         "debug": "^4.3.1"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.29.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.29.2.tgz",
-      "integrity": "sha512-mfHmvlQxmfkU8D55CkZO2sQOueTxLqGvzV+mG6S/6fIunDiD2ouwsAoiYCZYDDK73QCibYjIZmGhpvKwAB5BOA==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.30.0.tgz",
+      "integrity": "sha512-VJ/jAXovxNh7rIXCQbYhkyV2Y3Ac/0cVHP/FruTJSAUUm4Oacmn/nkN5zfWmWFEanN4ggP0vJSHOeajtHq3f8A==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.29.2",
-        "@typescript-eslint/visitor-keys": "4.29.2"
+        "@typescript-eslint/types": "4.30.0",
+        "@typescript-eslint/visitor-keys": "4.30.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.29.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.29.2.tgz",
-      "integrity": "sha512-K6ApnEXId+WTGxqnda8z4LhNMa/pZmbTFkDxEBLQAbhLZL50DjeY0VIDCml/0Y3FlcbqXZrABqrcKxq+n0LwzQ==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.30.0.tgz",
+      "integrity": "sha512-YKldqbNU9K4WpTNwBqtAerQKLLW/X2A/j4yw92e3ZJYLx+BpKLeheyzoPfzIXHfM8BXfoleTdiYwpsvVPvHrDw==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.29.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.2.tgz",
-      "integrity": "sha512-TJ0/hEnYxapYn9SGn3dCnETO0r+MjaxtlWZ2xU+EvytF0g4CqTpZL48SqSNn2hXsPolnewF30pdzR9a5Lj3DNg==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.30.0.tgz",
+      "integrity": "sha512-6WN7UFYvykr/U0Qgy4kz48iGPWILvYL34xXJxvDQeiRE018B7POspNRVtAZscWntEPZpFCx4hcz/XBT+erenfg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.29.2",
-        "@typescript-eslint/visitor-keys": "4.29.2",
+        "@typescript-eslint/types": "4.30.0",
+        "@typescript-eslint/visitor-keys": "4.30.0",
         "debug": "^4.3.1",
         "globby": "^11.0.3",
         "is-glob": "^4.0.1",
@@ -1685,12 +1819,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.29.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.2.tgz",
-      "integrity": "sha512-bDgJLQ86oWHJoZ1ai4TZdgXzJxsea3Ee9u9wsTAvjChdj2WLcVsgWYAPeY7RQMn16tKrlQaBnpKv7KBfs4EQag==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.30.0.tgz",
+      "integrity": "sha512-pNaaxDt/Ol/+JZwzP7MqWc8PJQTUhZwoee/PVlQ+iYoYhagccvoHnC9e4l+C/krQYYkENxznhVSDwClIbZVxRw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.29.2",
+        "@typescript-eslint/types": "4.30.0",
         "eslint-visitor-keys": "^2.0.0"
       }
     },
@@ -1881,13 +2015,13 @@
       "dev": true
     },
     "async-retry": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.1.tgz",
-      "integrity": "sha512-aiieFW/7h3hY0Bq5d+ktDBejxuwR78vRu9hDUdR8rNhSaQ29VzPL4AoIRG7D/c7tdenwOcKvgPM6tIxB3cB6HA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
       "dev": true,
       "optional": true,
       "requires": {
-        "retry": "0.12.0"
+        "retry": "0.13.1"
       }
     },
     "asynckit": {
@@ -1909,19 +2043,34 @@
       "dev": true
     },
     "babel-jest": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.0.6.tgz",
-      "integrity": "sha512-iTJyYLNc4wRofASmofpOc5NK9QunwMk+TLFgGXsTFS8uEqmd8wdI7sga0FPe2oVH3b5Agt/EAK1QjPEuKL8VfA==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.1.0.tgz",
+      "integrity": "sha512-6NrdqzaYemALGCuR97QkC/FkFIEBWP5pw5TMJoUHZTVXyOgocujp6A0JE2V6gE0HtqAAv6VKU/nI+OCR1Z4gHA==",
       "dev": true,
       "requires": {
-        "@jest/transform": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/transform": "^27.1.0",
+        "@jest/types": "^27.1.0",
         "@types/babel__core": "^7.1.14",
         "babel-plugin-istanbul": "^6.0.0",
         "babel-preset-jest": "^27.0.6",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "babel-plugin-istanbul": {
@@ -2034,16 +2183,16 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.16.7",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.7.tgz",
-      "integrity": "sha512-7I4qVwqZltJ7j37wObBe3SoTz+nS8APaNcrBOlgoirb6/HbEU2XxW/LpUDTCngM6iauwFqmRTuOMfyKnFGY5JA==",
+      "version": "4.16.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.8.tgz",
+      "integrity": "sha512-sc2m9ohR/49sWEbPj14ZSSZqp+kbi16aLao42Hmn3Z8FpjuMaq2xCA2l4zl9ITfyzvnvyE0hcg62YkIGKxgaNQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001248",
-        "colorette": "^1.2.2",
-        "electron-to-chromium": "^1.3.793",
+        "caniuse-lite": "^1.0.30001251",
+        "colorette": "^1.3.0",
+        "electron-to-chromium": "^1.3.811",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.73"
+        "node-releases": "^1.1.75"
       }
     },
     "bs-logger": {
@@ -2099,9 +2248,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001251",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
-      "integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==",
+      "version": "1.0.30001252",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz",
+      "integrity": "sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==",
       "dev": true
     },
     "caseless": {
@@ -2340,9 +2489,9 @@
       }
     },
     "date-and-time": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-1.0.1.tgz",
-      "integrity": "sha512-7u+uNfnjWkX+YFQfivvW24TjaJG6ahvTrfw1auq7KlC7osuGcZBIWGBvB9UcENjH6JnLVhMqlRripk1dSHjAUA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-2.0.0.tgz",
+      "integrity": "sha512-HJSzj25iPm8E01nt+rSmCIlwjsmjvKfUivG/kXBglpymcHF1FolWAqWwTEV4FvN1Lx5UjPf0J1W4H8yQsVBfFg==",
       "dev": true,
       "optional": true
     },
@@ -2505,9 +2654,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.805",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.805.tgz",
-      "integrity": "sha512-uUJF59M6pNSRHQaXwdkaNB4BhSQ9lldRdG1qCjlrAFkynPGDc5wPoUcYEQQeQGmKyAWJPvGkYAWmtVrxWmDAkg==",
+      "version": "1.3.825",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.825.tgz",
+      "integrity": "sha512-BO3FfWVeH8GQ0DBbi4HCL09OPgvN+0goqWlgKOCmCXcnrlgL5GA69nb7ZyjpWgpFUacBftg8BrXU2WLOSuHAxQ==",
       "dev": true
     },
     "emittery": {
@@ -2748,9 +2897,9 @@
       }
     },
     "eslint-import-resolver-node": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.5.tgz",
-      "integrity": "sha512-XMoPKjSpXbkeJ7ZZ9icLnJMTY5Mc1kZbCakHquaFsXPpyWOwK0TK6CODO+0ca54UoM9LKOxyUNnoVZRl8TeaAg==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
+      "integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
       "dev": true,
       "requires": {
         "debug": "^3.2.7",
@@ -2790,26 +2939,26 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.24.0.tgz",
-      "integrity": "sha512-Kc6xqT9hiYi2cgybOc0I2vC9OgAYga5o/rAFinam/yF/t5uBqxQbauNPMC6fgb640T/89P0gFoO27FOilJ/Cqg==",
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.24.2.tgz",
+      "integrity": "sha512-hNVtyhiEtZmpsabL4neEj+6M5DCLgpYyG9nzJY8lZQeQXEn5UPW1DpUdsMHMXsq98dbNm7nt1w9ZMSVpfJdi8Q==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.3",
         "array.prototype.flat": "^1.2.4",
         "debug": "^2.6.9",
         "doctrine": "^2.1.0",
-        "eslint-import-resolver-node": "^0.3.5",
+        "eslint-import-resolver-node": "^0.3.6",
         "eslint-module-utils": "^2.6.2",
         "find-up": "^2.0.0",
         "has": "^1.0.3",
-        "is-core-module": "^2.4.0",
+        "is-core-module": "^2.6.0",
         "minimatch": "^3.0.4",
-        "object.values": "^1.1.3",
+        "object.values": "^1.1.4",
         "pkg-up": "^2.0.0",
         "read-pkg-up": "^3.0.0",
         "resolve": "^1.20.0",
-        "tsconfig-paths": "^3.9.0"
+        "tsconfig-paths": "^3.11.0"
       },
       "dependencies": {
         "debug": {
@@ -2965,19 +3114,32 @@
       "dev": true
     },
     "expect": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-27.0.6.tgz",
-      "integrity": "sha512-psNLt8j2kwg42jGBDSfAlU49CEZxejN1f1PlANWDZqIhBOVU/c2Pm888FcjWJzFewhIsNWfZJeLjUjtKGiPuSw==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-27.1.0.tgz",
+      "integrity": "sha512-9kJngV5hOJgkFil4F/uXm3hVBubUK2nERVfvqNNwxxuW8ZOUwSTTSysgfzckYtv/LBzj/LJXbiAF7okHCXgdug==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.1.0",
         "ansi-styles": "^5.0.0",
         "jest-get-type": "^27.0.6",
-        "jest-matcher-utils": "^27.0.6",
-        "jest-message-util": "^27.0.6",
+        "jest-matcher-utils": "^27.1.0",
+        "jest-message-util": "^27.1.0",
         "jest-regex-util": "^27.0.6"
       },
       "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
         "ansi-styles": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
@@ -3048,9 +3210,9 @@
       "optional": true
     },
     "fastq": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.1.tgz",
-      "integrity": "sha512-HOnr8Mc60eNYl1gzwp6r5RoUyAn5/glBolUzP/Ez6IFVPMPirxn/9phgL6zhOtaTy7ISwPvQ+wT+hfcRZh/bzw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.12.0.tgz",
+      "integrity": "sha512-VNX0QkHK3RsXVKr9KrlUv/FoTa0NdbYoHHl7uXHv2rzyHSlxjdNAKug2twd9luJxpcyNeAgf5iPPMutJO67Dfg==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -3142,9 +3304,9 @@
       }
     },
     "firebase-admin": {
-      "version": "9.11.0",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-9.11.0.tgz",
-      "integrity": "sha512-68fXdwcKF99LkWBE33M5hnLwjvGpbCRznIOtZVsiBqZdM9iwxlTfNEpAckh++o3GdJcSLRUWmIN+MKqPUsxoCA==",
+      "version": "9.11.1",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-9.11.1.tgz",
+      "integrity": "sha512-Y9fjelljy6MKqwsSbM/UN1k8gBQh5zfm5fCTe0Z6Gch2T3nDUIPsTcf+jfe4o40/MPYuybili9XJjTMmM2e5MQ==",
       "dev": true,
       "requires": {
         "@firebase/database": "^0.10.0",
@@ -3348,9 +3510,9 @@
       }
     },
     "google-auth-library": {
-      "version": "7.6.1",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.6.1.tgz",
-      "integrity": "sha512-aP/WTx+rE3wQ3zPgiCZsJ1EIb2v7P+QwxVwAqrKjcPz4SK57kyAfcX75VoAgjtwZzl70upcNlvFn8FSmC4nMBQ==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.8.0.tgz",
+      "integrity": "sha512-I2DPwbBbQicoLqPbUOcq7oxtWewbLO6Za2jZ5QM9Lz1hXxPJVXYXBUrb8lP9626SRTQQWIzNSWJuEDtu0pI4ag==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -3366,9 +3528,9 @@
       }
     },
     "google-gax": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-2.24.0.tgz",
-      "integrity": "sha512-PtE/Zk3jPrUIAL9YsIq5e+04U3aqEg6/0DmtR/tXKhbcS7SRA1sbPZja+vevuUavIdCXEiBbaKkrBqcQvSxXmw==",
+      "version": "2.24.3",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-2.24.3.tgz",
+      "integrity": "sha512-0Rb2i2GWCEEYi1/EjQt1QsFW2Jwzm1ob21kYc7UpOmkfsmTXuyhzK7Aeyxxpo7QT/Qh+50vqER1b2ruq6WGDXg==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -3378,7 +3540,7 @@
         "abort-controller": "^3.0.0",
         "duplexify": "^4.0.0",
         "fast-text-encoding": "^1.0.3",
-        "google-auth-library": "^7.3.0",
+        "google-auth-library": "^7.6.1",
         "is-stream-ended": "^0.1.4",
         "node-fetch": "^2.6.1",
         "object-hash": "^2.1.1",
@@ -3735,9 +3897,9 @@
       }
     },
     "is-core-module": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
-      "integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
+      "integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
@@ -3923,32 +4085,45 @@
       }
     },
     "jest": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-27.0.6.tgz",
-      "integrity": "sha512-EjV8aETrsD0wHl7CKMibKwQNQc3gIRBXlTikBmmHUeVMKaPFxdcUIBfoDqTSXDoGJIivAYGqCWVlzCSaVjPQsA==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-27.1.0.tgz",
+      "integrity": "sha512-pSQDVwRSwb109Ss13lcMtdfS9r8/w2Zz8+mTUA9VORD66GflCdl8nUFCqM96geOD2EBwWCNURrNAfQsLIDNBdg==",
       "dev": true,
       "requires": {
-        "@jest/core": "^27.0.6",
+        "@jest/core": "^27.1.0",
         "import-local": "^3.0.2",
-        "jest-cli": "^27.0.6"
+        "jest-cli": "^27.1.0"
       },
       "dependencies": {
-        "jest-cli": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.0.6.tgz",
-          "integrity": "sha512-qUUVlGb9fdKir3RDE+B10ULI+LQrz+MCflEH2UJyoUjoHHCbxDrMxSzjQAPUMsic4SncI62ofYCcAvW6+6rhhg==",
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
           "dev": true,
           "requires": {
-            "@jest/core": "^27.0.6",
-            "@jest/test-result": "^27.0.6",
-            "@jest/types": "^27.0.6",
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "jest-cli": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.1.0.tgz",
+          "integrity": "sha512-h6zPUOUu+6oLDrXz0yOWY2YXvBLk8gQinx4HbZ7SF4V3HzasQf+ncoIbKENUMwXyf54/6dBkYXvXJos+gOHYZw==",
+          "dev": true,
+          "requires": {
+            "@jest/core": "^27.1.0",
+            "@jest/test-result": "^27.1.0",
+            "@jest/types": "^27.1.0",
             "chalk": "^4.0.0",
             "exit": "^0.1.2",
             "graceful-fs": "^4.2.4",
             "import-local": "^3.0.2",
-            "jest-config": "^27.0.6",
-            "jest-util": "^27.0.6",
-            "jest-validate": "^27.0.6",
+            "jest-config": "^27.1.0",
+            "jest-util": "^27.1.0",
+            "jest-validate": "^27.1.0",
             "prompts": "^2.0.1",
             "yargs": "^16.0.3"
           }
@@ -3956,70 +4131,151 @@
       }
     },
     "jest-changed-files": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.0.6.tgz",
-      "integrity": "sha512-BuL/ZDauaq5dumYh5y20sn4IISnf1P9A0TDswTxUi84ORGtVa86ApuBHqICL0vepqAnZiY6a7xeSPWv2/yy4eA==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.1.0.tgz",
+      "integrity": "sha512-eRcb13TfQw0xiV2E98EmiEgs9a5uaBIqJChyl0G7jR9fCIvGjXovnDS6Zbku3joij4tXYcSK4SE1AXqOlUxjWg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.1.0",
         "execa": "^5.0.0",
         "throat": "^6.0.1"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "jest-circus": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.0.6.tgz",
-      "integrity": "sha512-OJlsz6BBeX9qR+7O9lXefWoc2m9ZqcZ5Ohlzz0pTEAG4xMiZUJoacY8f4YDHxgk0oKYxj277AfOk9w6hZYvi1Q==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.1.0.tgz",
+      "integrity": "sha512-6FWtHs3nZyZlMBhRf1wvAC5CirnflbGJAY1xssSAnERLiiXQRH+wY2ptBVtXjX4gz4AA2EwRV57b038LmifRbA==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.0.6",
-        "@jest/test-result": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/environment": "^27.1.0",
+        "@jest/test-result": "^27.1.0",
+        "@jest/types": "^27.1.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
         "dedent": "^0.7.0",
-        "expect": "^27.0.6",
+        "expect": "^27.1.0",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^27.0.6",
-        "jest-matcher-utils": "^27.0.6",
-        "jest-message-util": "^27.0.6",
-        "jest-runtime": "^27.0.6",
-        "jest-snapshot": "^27.0.6",
-        "jest-util": "^27.0.6",
-        "pretty-format": "^27.0.6",
+        "jest-each": "^27.1.0",
+        "jest-matcher-utils": "^27.1.0",
+        "jest-message-util": "^27.1.0",
+        "jest-runtime": "^27.1.0",
+        "jest-snapshot": "^27.1.0",
+        "jest-util": "^27.1.0",
+        "pretty-format": "^27.1.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3",
         "throat": "^6.0.1"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.1.0.tgz",
+          "integrity": "sha512-4aGaud3w3rxAO6OXmK3fwBFQ0bctIOG3/if+jYEFGNGIs0EvuidQm3bZ9mlP2/t9epLNC/12czabfy7TZNSwVA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.1.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^17.0.1"
+          }
+        }
       }
     },
     "jest-config": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.0.6.tgz",
-      "integrity": "sha512-JZRR3I1Plr2YxPBhgqRspDE2S5zprbga3swYNrvY3HfQGu7p/GjyLOqwrYad97tX3U3mzT53TPHVmozacfP/3w==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.1.0.tgz",
+      "integrity": "sha512-GMo7f76vMYUA3b3xOdlcKeKQhKcBIgurjERO2hojo0eLkKPGcw7fyIoanH+m6KOP2bLad+fGnF8aWOJYxzNPeg==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/test-sequencer": "^27.0.6",
-        "@jest/types": "^27.0.6",
-        "babel-jest": "^27.0.6",
+        "@jest/test-sequencer": "^27.1.0",
+        "@jest/types": "^27.1.0",
+        "babel-jest": "^27.1.0",
         "chalk": "^4.0.0",
         "deepmerge": "^4.2.2",
         "glob": "^7.1.1",
         "graceful-fs": "^4.2.4",
         "is-ci": "^3.0.0",
-        "jest-circus": "^27.0.6",
-        "jest-environment-jsdom": "^27.0.6",
-        "jest-environment-node": "^27.0.6",
+        "jest-circus": "^27.1.0",
+        "jest-environment-jsdom": "^27.1.0",
+        "jest-environment-node": "^27.1.0",
         "jest-get-type": "^27.0.6",
-        "jest-jasmine2": "^27.0.6",
+        "jest-jasmine2": "^27.1.0",
         "jest-regex-util": "^27.0.6",
-        "jest-resolve": "^27.0.6",
-        "jest-runner": "^27.0.6",
-        "jest-util": "^27.0.6",
-        "jest-validate": "^27.0.6",
+        "jest-resolve": "^27.1.0",
+        "jest-runner": "^27.1.0",
+        "jest-util": "^27.1.0",
+        "jest-validate": "^27.1.0",
         "micromatch": "^4.0.4",
-        "pretty-format": "^27.0.6"
+        "pretty-format": "^27.1.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.1.0.tgz",
+          "integrity": "sha512-4aGaud3w3rxAO6OXmK3fwBFQ0bctIOG3/if+jYEFGNGIs0EvuidQm3bZ9mlP2/t9epLNC/12czabfy7TZNSwVA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.1.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^17.0.1"
+          }
+        }
       }
     },
     "jest-diff": {
@@ -4044,45 +4300,108 @@
       }
     },
     "jest-each": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-27.0.6.tgz",
-      "integrity": "sha512-m6yKcV3bkSWrUIjxkE9OC0mhBZZdhovIW5ergBYirqnkLXkyEn3oUUF/QZgyecA1cF1QFyTE8bRRl8Tfg1pfLA==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-27.1.0.tgz",
+      "integrity": "sha512-K/cNvQlmDqQMRHF8CaQ0XPzCfjP5HMJc2bIJglrIqI9fjwpNqITle63IWE+wq4p+3v+iBgh7Wq0IdGpLx5xjDg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.1.0",
         "chalk": "^4.0.0",
         "jest-get-type": "^27.0.6",
-        "jest-util": "^27.0.6",
-        "pretty-format": "^27.0.6"
+        "jest-util": "^27.1.0",
+        "pretty-format": "^27.1.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.1.0.tgz",
+          "integrity": "sha512-4aGaud3w3rxAO6OXmK3fwBFQ0bctIOG3/if+jYEFGNGIs0EvuidQm3bZ9mlP2/t9epLNC/12czabfy7TZNSwVA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.1.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^17.0.1"
+          }
+        }
       }
     },
     "jest-environment-jsdom": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-27.0.6.tgz",
-      "integrity": "sha512-FvetXg7lnXL9+78H+xUAsra3IeZRTiegA3An01cWeXBspKXUhAwMM9ycIJ4yBaR0L7HkoMPaZsozCLHh4T8fuw==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-27.1.0.tgz",
+      "integrity": "sha512-JbwOcOxh/HOtsj56ljeXQCUJr3ivnaIlM45F5NBezFLVYdT91N5UofB1ux2B1CATsQiudcHdgTaeuqGXJqjJYQ==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.0.6",
-        "@jest/fake-timers": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/environment": "^27.1.0",
+        "@jest/fake-timers": "^27.1.0",
+        "@jest/types": "^27.1.0",
         "@types/node": "*",
-        "jest-mock": "^27.0.6",
-        "jest-util": "^27.0.6",
+        "jest-mock": "^27.1.0",
+        "jest-util": "^27.1.0",
         "jsdom": "^16.6.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "jest-environment-node": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.0.6.tgz",
-      "integrity": "sha512-+Vi6yLrPg/qC81jfXx3IBlVnDTI6kmRr08iVa2hFCWmJt4zha0XW7ucQltCAPhSR0FEKEoJ3i+W4E6T0s9is0w==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.1.0.tgz",
+      "integrity": "sha512-JIyJ8H3wVyM4YCXp7njbjs0dIT87yhGlrXCXhDKNIg1OjurXr6X38yocnnbXvvNyqVTqSI4M9l+YfPKueqL1lw==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.0.6",
-        "@jest/fake-timers": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/environment": "^27.1.0",
+        "@jest/fake-timers": "^27.1.0",
+        "@jest/types": "^27.1.0",
         "@types/node": "*",
-        "jest-mock": "^27.0.6",
-        "jest-util": "^27.0.6"
+        "jest-mock": "^27.1.0",
+        "jest-util": "^27.1.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "jest-get-type": {
@@ -4092,12 +4411,12 @@
       "dev": true
     },
     "jest-haste-map": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.0.6.tgz",
-      "integrity": "sha512-4ldjPXX9h8doB2JlRzg9oAZ2p6/GpQUNAeiYXqcpmrKbP0Qev0wdZlxSMOmz8mPOEnt4h6qIzXFLDi8RScX/1w==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.1.0.tgz",
+      "integrity": "sha512-7mz6LopSe+eA6cTFMf10OfLLqRoIPvmMyz5/OnSXnHO7hB0aDP1iIeLWCXzAcYU5eIJVpHr12Bk9yyq2fTW9vg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.1.0",
         "@types/graceful-fs": "^4.1.2",
         "@types/node": "*",
         "anymatch": "^3.0.3",
@@ -4106,73 +4425,199 @@
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^27.0.6",
         "jest-serializer": "^27.0.6",
-        "jest-util": "^27.0.6",
-        "jest-worker": "^27.0.6",
+        "jest-util": "^27.1.0",
+        "jest-worker": "^27.1.0",
         "micromatch": "^4.0.4",
         "walker": "^1.0.7"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "jest-jasmine2": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.0.6.tgz",
-      "integrity": "sha512-cjpH2sBy+t6dvCeKBsHpW41mjHzXgsavaFMp+VWRf0eR4EW8xASk1acqmljFtK2DgyIECMv2yCdY41r2l1+4iA==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.1.0.tgz",
+      "integrity": "sha512-Z/NIt0wBDg3przOW2FCWtYjMn3Ip68t0SL60agD/e67jlhTyV3PIF8IzT9ecwqFbeuUSO2OT8WeJgHcalDGFzQ==",
       "dev": true,
       "requires": {
         "@babel/traverse": "^7.1.0",
-        "@jest/environment": "^27.0.6",
+        "@jest/environment": "^27.1.0",
         "@jest/source-map": "^27.0.6",
-        "@jest/test-result": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/test-result": "^27.1.0",
+        "@jest/types": "^27.1.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
-        "expect": "^27.0.6",
+        "expect": "^27.1.0",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^27.0.6",
-        "jest-matcher-utils": "^27.0.6",
-        "jest-message-util": "^27.0.6",
-        "jest-runtime": "^27.0.6",
-        "jest-snapshot": "^27.0.6",
-        "jest-util": "^27.0.6",
-        "pretty-format": "^27.0.6",
+        "jest-each": "^27.1.0",
+        "jest-matcher-utils": "^27.1.0",
+        "jest-message-util": "^27.1.0",
+        "jest-runtime": "^27.1.0",
+        "jest-snapshot": "^27.1.0",
+        "jest-util": "^27.1.0",
+        "pretty-format": "^27.1.0",
         "throat": "^6.0.1"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.1.0.tgz",
+          "integrity": "sha512-4aGaud3w3rxAO6OXmK3fwBFQ0bctIOG3/if+jYEFGNGIs0EvuidQm3bZ9mlP2/t9epLNC/12czabfy7TZNSwVA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.1.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^17.0.1"
+          }
+        }
       }
     },
     "jest-leak-detector": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.0.6.tgz",
-      "integrity": "sha512-2/d6n2wlH5zEcdctX4zdbgX8oM61tb67PQt4Xh8JFAIy6LRKUnX528HulkaG6nD5qDl5vRV1NXejCe1XRCH5gQ==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.1.0.tgz",
+      "integrity": "sha512-oHvSkz1E80VyeTKBvZNnw576qU+cVqRXUD3/wKXh1zpaki47Qty2xeHg2HKie9Hqcd2l4XwircgNOWb/NiGqdA==",
       "dev": true,
       "requires": {
         "jest-get-type": "^27.0.6",
-        "pretty-format": "^27.0.6"
+        "pretty-format": "^27.1.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.1.0.tgz",
+          "integrity": "sha512-4aGaud3w3rxAO6OXmK3fwBFQ0bctIOG3/if+jYEFGNGIs0EvuidQm3bZ9mlP2/t9epLNC/12czabfy7TZNSwVA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.1.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^17.0.1"
+          }
+        }
       }
     },
     "jest-matcher-utils": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.0.6.tgz",
-      "integrity": "sha512-OFgF2VCQx9vdPSYTHWJ9MzFCehs20TsyFi6bIHbk5V1u52zJOnvF0Y/65z3GLZHKRuTgVPY4Z6LVePNahaQ+tA==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.1.0.tgz",
+      "integrity": "sha512-VmAudus2P6Yt/JVBRdTPFhUzlIN8DYJd+et5Rd9QDsO/Z82Z4iwGjo43U8Z+PTiz8CBvKvlb6Fh3oKy39hykkQ==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "jest-diff": "^27.0.6",
+        "jest-diff": "^27.1.0",
         "jest-get-type": "^27.0.6",
-        "pretty-format": "^27.0.6"
+        "pretty-format": "^27.1.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "dev": true
+        },
+        "jest-diff": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.1.0.tgz",
+          "integrity": "sha512-rjfopEYl58g/SZTsQFmspBODvMSytL16I+cirnScWTLkQVXYVZfxm78DFfdIIXc05RCYuGjxJqrdyG4PIFzcJg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "diff-sequences": "^27.0.6",
+            "jest-get-type": "^27.0.6",
+            "pretty-format": "^27.1.0"
+          }
+        },
+        "pretty-format": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.1.0.tgz",
+          "integrity": "sha512-4aGaud3w3rxAO6OXmK3fwBFQ0bctIOG3/if+jYEFGNGIs0EvuidQm3bZ9mlP2/t9epLNC/12czabfy7TZNSwVA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.1.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^17.0.1"
+          }
+        }
       }
     },
     "jest-message-util": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.0.6.tgz",
-      "integrity": "sha512-rBxIs2XK7rGy+zGxgi+UJKP6WqQ+KrBbD1YMj517HYN3v2BG66t3Xan3FWqYHKZwjdB700KiAJ+iES9a0M+ixw==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.1.0.tgz",
+      "integrity": "sha512-Eck8NFnJ5Sg36R9XguD65cf2D5+McC+NF5GIdEninoabcuoOfWrID5qJhufq5FB0DRKoiyxB61hS7MKoMD0trQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.1.0",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "micromatch": "^4.0.4",
-        "pretty-format": "^27.0.6",
+        "pretty-format": "^27.1.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
@@ -4185,17 +4630,63 @@
           "requires": {
             "@babel/highlight": "^7.14.5"
           }
+        },
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.1.0.tgz",
+          "integrity": "sha512-4aGaud3w3rxAO6OXmK3fwBFQ0bctIOG3/if+jYEFGNGIs0EvuidQm3bZ9mlP2/t9epLNC/12czabfy7TZNSwVA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.1.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^17.0.1"
+          }
         }
       }
     },
     "jest-mock": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.0.6.tgz",
-      "integrity": "sha512-lzBETUoK8cSxts2NYXSBWT+EJNzmUVtVVwS1sU9GwE1DLCfGsngg+ZVSIe0yd0ZSm+y791esiuo+WSwpXJQ5Bw==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.1.0.tgz",
+      "integrity": "sha512-iT3/Yhu7DwAg/0HvvLCqLvrTKTRMyJlrrfJYWzuLSf9RCAxBoIXN3HoymZxMnYsC3eD8ewGbUa9jUknwBenx2w==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.1.0",
         "@types/node": "*"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "jest-pnp-resolver": {
@@ -4211,97 +4702,157 @@
       "dev": true
     },
     "jest-resolve": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.0.6.tgz",
-      "integrity": "sha512-yKmIgw2LgTh7uAJtzv8UFHGF7Dm7XfvOe/LQ3Txv101fLM8cx2h1QVwtSJ51Q/SCxpIiKfVn6G2jYYMDNHZteA==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.1.0.tgz",
+      "integrity": "sha512-TXvzrLyPg0vLOwcWX38ZGYeEztSEmW+cQQKqc4HKDUwun31wsBXwotRlUz4/AYU/Fq4GhbMd/ileIWZEtcdmIA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.1.0",
         "chalk": "^4.0.0",
         "escalade": "^3.1.1",
         "graceful-fs": "^4.2.4",
+        "jest-haste-map": "^27.1.0",
         "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^27.0.6",
-        "jest-validate": "^27.0.6",
+        "jest-util": "^27.1.0",
+        "jest-validate": "^27.1.0",
         "resolve": "^1.20.0",
         "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "jest-resolve-dependencies": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.0.6.tgz",
-      "integrity": "sha512-mg9x9DS3BPAREWKCAoyg3QucCr0n6S8HEEsqRCKSPjPcu9HzRILzhdzY3imsLoZWeosEbJZz6TKasveczzpJZA==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.1.0.tgz",
+      "integrity": "sha512-Kq5XuDAELuBnrERrjFYEzu/A+i2W7l9HnPWqZEeKGEQ7m1R+6ndMbdXCVCx29Se1qwLZLgvoXwinB3SPIaitMQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.1.0",
         "jest-regex-util": "^27.0.6",
-        "jest-snapshot": "^27.0.6"
+        "jest-snapshot": "^27.1.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "jest-runner": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.0.6.tgz",
-      "integrity": "sha512-W3Bz5qAgaSChuivLn+nKOgjqNxM7O/9JOJoKDCqThPIg2sH/d4A/lzyiaFgnb9V1/w29Le11NpzTJSzga1vyYQ==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.1.0.tgz",
+      "integrity": "sha512-ZWPKr9M5w5gDplz1KsJ6iRmQaDT/yyAFLf18fKbb/+BLWsR1sCNC2wMT0H7pP3gDcBz0qZ6aJraSYUNAGSJGaw==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.0.6",
-        "@jest/environment": "^27.0.6",
-        "@jest/test-result": "^27.0.6",
-        "@jest/transform": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/console": "^27.1.0",
+        "@jest/environment": "^27.1.0",
+        "@jest/test-result": "^27.1.0",
+        "@jest/transform": "^27.1.0",
+        "@jest/types": "^27.1.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "emittery": "^0.8.1",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
         "jest-docblock": "^27.0.6",
-        "jest-environment-jsdom": "^27.0.6",
-        "jest-environment-node": "^27.0.6",
-        "jest-haste-map": "^27.0.6",
-        "jest-leak-detector": "^27.0.6",
-        "jest-message-util": "^27.0.6",
-        "jest-resolve": "^27.0.6",
-        "jest-runtime": "^27.0.6",
-        "jest-util": "^27.0.6",
-        "jest-worker": "^27.0.6",
+        "jest-environment-jsdom": "^27.1.0",
+        "jest-environment-node": "^27.1.0",
+        "jest-haste-map": "^27.1.0",
+        "jest-leak-detector": "^27.1.0",
+        "jest-message-util": "^27.1.0",
+        "jest-resolve": "^27.1.0",
+        "jest-runtime": "^27.1.0",
+        "jest-util": "^27.1.0",
+        "jest-worker": "^27.1.0",
         "source-map-support": "^0.5.6",
         "throat": "^6.0.1"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "jest-runtime": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.0.6.tgz",
-      "integrity": "sha512-BhvHLRVfKibYyqqEFkybsznKwhrsu7AWx2F3y9G9L95VSIN3/ZZ9vBpm/XCS2bS+BWz3sSeNGLzI3TVQ0uL85Q==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.1.0.tgz",
+      "integrity": "sha512-okiR2cpGjY0RkWmUGGado6ETpFOi9oG3yV0CioYdoktkVxy5Hv0WRLWnJFuArSYS8cHMCNcceUUMGiIfgxCO9A==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.0.6",
-        "@jest/environment": "^27.0.6",
-        "@jest/fake-timers": "^27.0.6",
-        "@jest/globals": "^27.0.6",
+        "@jest/console": "^27.1.0",
+        "@jest/environment": "^27.1.0",
+        "@jest/fake-timers": "^27.1.0",
+        "@jest/globals": "^27.1.0",
         "@jest/source-map": "^27.0.6",
-        "@jest/test-result": "^27.0.6",
-        "@jest/transform": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/test-result": "^27.1.0",
+        "@jest/transform": "^27.1.0",
+        "@jest/types": "^27.1.0",
         "@types/yargs": "^16.0.0",
         "chalk": "^4.0.0",
         "cjs-module-lexer": "^1.0.0",
         "collect-v8-coverage": "^1.0.0",
+        "execa": "^5.0.0",
         "exit": "^0.1.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.0.6",
-        "jest-message-util": "^27.0.6",
-        "jest-mock": "^27.0.6",
+        "jest-haste-map": "^27.1.0",
+        "jest-message-util": "^27.1.0",
+        "jest-mock": "^27.1.0",
         "jest-regex-util": "^27.0.6",
-        "jest-resolve": "^27.0.6",
-        "jest-snapshot": "^27.0.6",
-        "jest-util": "^27.0.6",
-        "jest-validate": "^27.0.6",
+        "jest-resolve": "^27.1.0",
+        "jest-snapshot": "^27.1.0",
+        "jest-util": "^27.1.0",
+        "jest-validate": "^27.1.0",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0",
         "yargs": "^16.0.3"
       },
       "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
         "strip-bom": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
@@ -4321,9 +4872,9 @@
       }
     },
     "jest-snapshot": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.0.6.tgz",
-      "integrity": "sha512-NTHaz8He+ATUagUgE7C/UtFcRoHqR2Gc+KDfhQIyx+VFgwbeEMjeP+ILpUTLosZn/ZtbNdCF5LkVnN/l+V751A==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.1.0.tgz",
+      "integrity": "sha512-eaeUBoEjuuRwmiRI51oTldUsKOohB1F6fPqWKKILuDi/CStxzp2IWekVUXbuHHoz5ik33ioJhshiHpgPFbYgcA==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.7.2",
@@ -4332,26 +4883,69 @@
         "@babel/plugin-syntax-typescript": "^7.7.2",
         "@babel/traverse": "^7.7.2",
         "@babel/types": "^7.0.0",
-        "@jest/transform": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/transform": "^27.1.0",
+        "@jest/types": "^27.1.0",
         "@types/babel__traverse": "^7.0.4",
         "@types/prettier": "^2.1.5",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^27.0.6",
+        "expect": "^27.1.0",
         "graceful-fs": "^4.2.4",
-        "jest-diff": "^27.0.6",
+        "jest-diff": "^27.1.0",
         "jest-get-type": "^27.0.6",
-        "jest-haste-map": "^27.0.6",
-        "jest-matcher-utils": "^27.0.6",
-        "jest-message-util": "^27.0.6",
-        "jest-resolve": "^27.0.6",
-        "jest-util": "^27.0.6",
+        "jest-haste-map": "^27.1.0",
+        "jest-matcher-utils": "^27.1.0",
+        "jest-message-util": "^27.1.0",
+        "jest-resolve": "^27.1.0",
+        "jest-util": "^27.1.0",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^27.0.6",
+        "pretty-format": "^27.1.0",
         "semver": "^7.3.2"
       },
       "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "dev": true
+        },
+        "jest-diff": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.1.0.tgz",
+          "integrity": "sha512-rjfopEYl58g/SZTsQFmspBODvMSytL16I+cirnScWTLkQVXYVZfxm78DFfdIIXc05RCYuGjxJqrdyG4PIFzcJg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "diff-sequences": "^27.0.6",
+            "jest-get-type": "^27.0.6",
+            "pretty-format": "^27.1.0"
+          }
+        },
+        "pretty-format": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.1.0.tgz",
+          "integrity": "sha512-4aGaud3w3rxAO6OXmK3fwBFQ0bctIOG3/if+jYEFGNGIs0EvuidQm3bZ9mlP2/t9epLNC/12czabfy7TZNSwVA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.1.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^17.0.1"
+          }
+        },
         "semver": {
           "version": "7.3.5",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -4364,60 +4958,121 @@
       }
     },
     "jest-util": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.0.6.tgz",
-      "integrity": "sha512-1JjlaIh+C65H/F7D11GNkGDDZtDfMEM8EBXsvd+l/cxtgQ6QhxuloOaiayt89DxUvDarbVhqI98HhgrM1yliFQ==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.1.0.tgz",
+      "integrity": "sha512-edSLD2OneYDKC6gZM1yc+wY/877s/fuJNoM1k3sOEpzFyeptSmke3SLnk1dDHk9CgTA+58mnfx3ew3J11Kes/w==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.1.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "is-ci": "^3.0.0",
         "picomatch": "^2.2.3"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "jest-validate": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.0.6.tgz",
-      "integrity": "sha512-yhZZOaMH3Zg6DC83n60pLmdU1DQE46DW+KLozPiPbSbPhlXXaiUTDlhHQhHFpaqIFRrInko1FHXjTRpjWRuWfA==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.1.0.tgz",
+      "integrity": "sha512-QiJ+4XuSuMsfPi9zvdO//IrSRSlG6ybJhOpuqYSsuuaABaNT84h0IoD6vvQhThBOKT+DIKvl5sTM0l6is9+SRA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.1.0",
         "camelcase": "^6.2.0",
         "chalk": "^4.0.0",
         "jest-get-type": "^27.0.6",
         "leven": "^3.1.0",
-        "pretty-format": "^27.0.6"
+        "pretty-format": "^27.1.0"
       },
       "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "dev": true
+        },
         "camelcase": {
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
           "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
           "dev": true
+        },
+        "pretty-format": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.1.0.tgz",
+          "integrity": "sha512-4aGaud3w3rxAO6OXmK3fwBFQ0bctIOG3/if+jYEFGNGIs0EvuidQm3bZ9mlP2/t9epLNC/12czabfy7TZNSwVA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.1.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^17.0.1"
+          }
         }
       }
     },
     "jest-watcher": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.0.6.tgz",
-      "integrity": "sha512-/jIoKBhAP00/iMGnTwUBLgvxkn7vsOweDrOTSPzc7X9uOyUtJIDthQBTI1EXz90bdkrxorUZVhJwiB69gcHtYQ==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.1.0.tgz",
+      "integrity": "sha512-ivaWTrA46aHWdgPDgPypSHiNQjyKnLBpUIHeBaGg11U+pDzZpkffGlcB1l1a014phmG0mHgkOHtOgiqJQM6yKQ==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/test-result": "^27.1.0",
+        "@jest/types": "^27.1.0",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
-        "jest-util": "^27.0.6",
+        "jest-util": "^27.1.0",
         "string-length": "^4.0.1"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "jest-worker": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.6.tgz",
-      "integrity": "sha512-qupxcj/dRuA3xHPMUd40gr2EaAurFbkwzOh7wfPaeE9id7hyjURRQoqNfHifHK3XjJU6YJJUQKILGUnwGPEOCA==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.1.0.tgz",
+      "integrity": "sha512-mO4PHb2QWLn9yRXGp7rkvXLAYuxwhq1ZYUo0LoDhg8wqvv4QizP1ZWEJOeolgbEgAWZLIEU0wsku8J+lGWfBhg==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -4557,12 +5212,12 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.5"
+        "minimist": "^1.2.0"
       }
     },
     "jsonwebtoken": {
@@ -4972,9 +5627,9 @@
       "dev": true
     },
     "node-releases": {
-      "version": "1.1.74",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.74.tgz",
-      "integrity": "sha512-caJBVempXZPepZoZAPCWRTNxYQ+xtG/KAi4ozTA5A+nJ7IU+kLQCbqaUjb5Rwy14M9upBWiQ4NutcmW04LJSRw==",
+      "version": "1.1.75",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
+      "integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==",
       "dev": true
     },
     "normalize-package-data": {
@@ -5295,9 +5950,9 @@
       }
     },
     "proto3-json-serializer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-0.1.1.tgz",
-      "integrity": "sha512-Wucuvf7SqAw1wcai0zV+3jW3QZJiO/W9wZoJaTheebYdwfj2k9VfF3Gw9r2vGAaTeslhMbkVbojJG0+LjpgLxQ==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-0.1.3.tgz",
+      "integrity": "sha512-X0DAtxCBsy1NDn84huVFGOFgBslT2gBmM+85nY6/5SOAaCon1jzVNdvi74foIyFvs5CjtSbQsepsM5TsyNhqQw==",
       "dev": true,
       "optional": true
     },
@@ -5544,9 +6199,9 @@
       }
     },
     "retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
       "dev": true,
       "optional": true
     },
@@ -6413,28 +7068,29 @@
       }
     },
     "ts-jest": {
-      "version": "27.0.4",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.0.4.tgz",
-      "integrity": "sha512-c4E1ECy9Xz2WGfTMyHbSaArlIva7Wi2p43QOMmCqjSSjHP06KXv+aT+eSY+yZMuqsMi3k7pyGsGj2q5oSl5WfQ==",
+      "version": "27.0.5",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.0.5.tgz",
+      "integrity": "sha512-lIJApzfTaSSbtlksfFNHkWOzLJuuSm4faFAfo5kvzOiRAuoN4/eKxVJ2zEAho8aecE04qX6K1pAzfH5QHL1/8w==",
       "dev": true,
       "requires": {
         "bs-logger": "0.x",
-        "buffer-from": "1.x",
         "fast-json-stable-stringify": "2.x",
         "jest-util": "^27.0.0",
         "json5": "2.x",
         "lodash": "4.x",
         "make-error": "1.x",
-        "mkdirp": "1.x",
         "semver": "7.x",
         "yargs-parser": "20.x"
       },
       "dependencies": {
-        "mkdirp": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-          "dev": true
+        "json5": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+          "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
         },
         "semver": {
           "version": "7.3.5",
@@ -6448,9 +7104,9 @@
       }
     },
     "ts-node": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.2.0.tgz",
-      "integrity": "sha512-FstYHtQz6isj8rBtYMN4bZdnXN1vq4HCbqn9vdNQcInRqtB86PePJQIxE6es0PhxKWhj2PHuwbG40H+bxkZPmg==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.2.1.tgz",
+      "integrity": "sha512-hCnyOyuGmD5wHleOQX6NIjJtYVIO8bPP8F2acWkB4W06wdlkgyvJtubO/I9NkI88hCFECbsEgoLc0VNkYmcSfw==",
       "dev": true,
       "requires": {
         "@cspotcode/source-map-support": "0.6.1",
@@ -6482,12 +7138,13 @@
       }
     },
     "tsconfig-paths": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.10.1.tgz",
-      "integrity": "sha512-rETidPDgCpltxF7MjBZlAFPUHv5aHH2MymyPvh+vEyWAED4Eb/WeMbsnD/JDr4OKPOA1TssDHgIcpTN5Kh0p6Q==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.11.0.tgz",
+      "integrity": "sha512-7ecdYDnIdmv639mmDwslG6KQg1Z9STTz1j7Gcz0xa+nshh/gKDAHcPxRbWOsA3SPp0tXP2leTcY9Kw+NAkfZzA==",
       "dev": true,
       "requires": {
-        "json5": "^2.2.0",
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.1",
         "minimist": "^1.2.0",
         "strip-bom": "^3.0.0"
       }
@@ -6561,9 +7218,9 @@
       }
     },
     "typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
+      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
       "dev": true
     },
     "unbox-primitive": {
@@ -6812,9 +7469,9 @@
       }
     },
     "ws": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
-      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.4.tgz",
+      "integrity": "sha512-zP9z6GXm6zC27YtspwH99T3qTG7bBFv2VIkeHstMLrLlDJuzA7tQ5ls3OJ1hOGGCzTQPniNJoHXIAOS0Jljohg==",
       "dev": true
     },
     "xdg-basedir": {

--- a/firebase-test/package.json
+++ b/firebase-test/package.json
@@ -16,17 +16,17 @@
     "@firebase/rules-unit-testing": "^1.3.14",
     "@types/jest": "^27.0.1",
     "@types/rewire": "^2.5.28",
-    "@typescript-eslint/eslint-plugin": "^4.29.2",
-    "@typescript-eslint/parser": "^4.29.2",
+    "@typescript-eslint/eslint-plugin": "^4.30.0",
+    "@typescript-eslint/parser": "^4.30.0",
     "eslint": "^7.32.0",
-    "eslint-plugin-import": "^2.24.0",
+    "eslint-plugin-import": "^2.24.2",
     "firebase": "^8.9.1",
-    "firebase-admin": "^9.11.0",
-    "jest": "^27.0.6",
+    "firebase-admin": "^9.11.1",
+    "jest": "^27.1.0",
     "rewire": "^5.0.0",
-    "ts-jest": "^27.0.4",
-    "ts-node": "^10.2.0",
-    "typescript": "^4.3.5"
+    "ts-jest": "^27.0.5",
+    "ts-node": "^10.2.1",
+    "typescript": "^4.4.2"
   },
   "private": true
 }

--- a/firebase-test/src/curriculum-rules.test.ts
+++ b/firebase-test/src/curriculum-rules.test.ts
@@ -1,0 +1,531 @@
+import firebase from "firebase";
+import {
+  adminWriteDoc, cPath, cProblem, cSection, cUnit, expectDeleteToFail, expectDeleteToSucceed,
+  expectReadToFail, expectReadToSucceed, expectUpdateToFail, expectUpdateToSucceed,
+  expectWriteToFail, expectWriteToSucceed, genericAuth, initFirestore, mockTimestamp, network1, network2, noNetwork,
+  prepareEachTest, studentAuth, teacher2Auth, teacher2Id, teacher2Name, teacherAuth, teacherId, teacherName, tearDownTests
+} from "./setup-rules-tests";
+
+describe("Firestore security rules", () => {
+
+  let db: firebase.firestore.Firestore;
+
+  beforeEach(async () => {
+    await prepareEachTest();
+  });
+
+  afterAll(async () => {
+    await tearDownTests();
+  });
+
+  const kCurriculumDocPath = "authed/myPortal/curriculum/myCurriculum";
+  // const kTeacher1UserDocPath = `authed/myPortal/users/${teacherId}`;
+  const kTeacher2UserDocPath = `authed/myPortal/users/${teacher2Id}`;
+
+  interface ISpecCurriculumDoc {
+    add?: Record<string, string | string[] | object>;
+    remove?: string[];
+  }
+  function specCurriculumDoc(options?: ISpecCurriculumDoc) {
+    // a valid document specification
+    const curriculumDoc = { uid: teacherId, unit: cUnit, problem: cProblem, section: cSection, path: cPath, network: noNetwork };
+    // remove specified props for validating the tests that require them
+    options?.remove?.forEach(prop => delete (curriculumDoc as any)[prop]);
+    // add additional props to test behavior of additional props
+    options?.add && Object.keys(options.add).forEach(prop => {
+      (curriculumDoc as any)[prop] = options.add?.[prop];
+    });
+    return curriculumDoc;
+  }
+
+  describe("non-networked curriculum documents", () => {
+    it("unauthenticated users can't read authenticated user curriculum documents", async () => {
+      db = initFirestore();
+      await expectReadToFail(db, kCurriculumDocPath);
+    });
+
+    it("unauthenticated users can't write user curriculum documents", async () => {
+      db = initFirestore();
+      await expectWriteToFail(db, kCurriculumDocPath, specCurriculumDoc());
+    });
+
+    it("authenticated generic users can't read authenticated user documents", async () => {
+      db = initFirestore(genericAuth);
+      await expectReadToFail(db, kCurriculumDocPath);
+    });
+
+    it("authenticated generic users can't write user documents", async () => {
+      db = initFirestore(genericAuth);
+      await expectWriteToFail(db, kCurriculumDocPath, specCurriculumDoc());
+    });
+
+    it("authenticated teachers can read their own user documents", async () => {
+      db = initFirestore(teacherAuth);
+      await adminWriteDoc(kCurriculumDocPath, specCurriculumDoc());
+      await expectReadToSucceed(db, kCurriculumDocPath);
+    });
+
+    it("authenticated teachers can't read other teachers curriculum documents outside a network", async () => {
+      db = initFirestore(teacherAuth);
+      await adminWriteDoc(kCurriculumDocPath, specCurriculumDoc({ add: { uid: teacher2Id }}));
+      await expectReadToFail(db, kCurriculumDocPath);
+    });
+
+    it("authenticated teachers can't read other teachers curriculum documents outside a network", async () => {
+      db = initFirestore(teacherAuth);
+      await adminWriteDoc(kCurriculumDocPath, specCurriculumDoc({ add: { uid: teacher2Id }}));
+      await expectReadToFail(db, kCurriculumDocPath);
+    });
+
+    it("authenticated teachers can't write user documents without required unit", async () => {
+      db = initFirestore(teacherAuth);
+      await expectWriteToFail(db, kCurriculumDocPath, specCurriculumDoc({ remove: ["unit"] }));
+    });
+
+    it("authenticated teachers can't write user documents without required problem", async () => {
+      db = initFirestore(teacherAuth);
+      await expectWriteToFail(db, kCurriculumDocPath, specCurriculumDoc({ remove: ["problem"] }));
+    });
+
+    it("authenticated teachers can't write user documents without required section", async () => {
+      db = initFirestore(teacherAuth);
+      await expectWriteToFail(db, kCurriculumDocPath, specCurriculumDoc({ remove: ["section"] }));
+    });
+
+    it("authenticated teachers can't write user documents without required path", async () => {
+      db = initFirestore(teacherAuth);
+      await expectWriteToFail(db, kCurriculumDocPath, specCurriculumDoc({ remove: ["path"] }));
+    });
+
+    it("authenticated teachers can't write user documents without required network", async () => {
+      db = initFirestore(teacherAuth);
+      await expectWriteToFail(db, kCurriculumDocPath, specCurriculumDoc({ remove: ["network"] }));
+    });
+
+    it("authenticated teachers can write user documents", async () => {
+      db = initFirestore(teacherAuth);
+      await expectWriteToSucceed(db, kCurriculumDocPath, specCurriculumDoc());
+    });
+
+    it("authenticated teachers can't update user documents' read-only fields", async () => {
+      db = initFirestore(teacherAuth);
+      await adminWriteDoc(kCurriculumDocPath, specCurriculumDoc());
+      await expectUpdateToFail(db, kCurriculumDocPath, { unit: "new-unit" });
+    });
+
+    it("authenticated teachers can't delete user documents", async () => {
+      db = initFirestore(teacherAuth);
+      await adminWriteDoc(kCurriculumDocPath, specCurriculumDoc());
+      await expectDeleteToFail(db, kCurriculumDocPath);
+    });
+
+    it("authenticated teachers can't delete other teachers' documents", async () => {
+      db = initFirestore(teacher2Auth);
+      await adminWriteDoc(kCurriculumDocPath, specCurriculumDoc());
+      await expectDeleteToFail(db, kCurriculumDocPath);
+    });
+
+    it("authenticated students can't read user documents", async () => {
+      db = initFirestore(studentAuth);
+      await adminWriteDoc(kCurriculumDocPath, specCurriculumDoc());
+      await expectReadToFail(db, kCurriculumDocPath);
+    });
+
+    it("authenticated students can't write user documents", async () => {
+      db = initFirestore(studentAuth);
+      await expectWriteToFail(db, kCurriculumDocPath, specCurriculumDoc());
+    });
+
+  });
+
+  describe("non-networked teacher curriculum document comments", () => {
+    const kCurriculumCommentDocPath = `${kCurriculumDocPath}/comments/myComment`;
+
+    interface ISpecCommentDoc {
+      add?: Record<string, string | string[] | object>;
+      remove?: string[];
+    }
+    function specCommentDoc(options?: ISpecCommentDoc) {
+      // a valid comment document specification
+      const commentDoc = { uid: teacherId, name: teacherName, network: noNetwork,
+                            content: "A comment!", createdAt: mockTimestamp() };
+      // remove specified props for validating the tests that require them
+      options?.remove?.forEach(prop => delete (commentDoc as any)[prop]);
+      // add additional props to test behavior of additional props
+      options?.add && Object.keys(options.add).forEach(prop => {
+        (commentDoc as any)[prop] = options.add?.[prop];
+      });
+      return commentDoc;
+    }
+
+    const initFirestoreWithUserDocument = async (auth?: any) => {
+      db = initFirestore(auth);
+      await adminWriteDoc(kCurriculumDocPath, specCurriculumDoc());
+    };
+
+    it("unauthenticated users can't read document comments", async () => {
+      await initFirestoreWithUserDocument();
+      await adminWriteDoc(kCurriculumCommentDocPath, specCommentDoc());
+      await expectReadToFail(db, kCurriculumCommentDocPath);
+    });
+
+    it("unauthenticated users can't write document comments", async () => {
+      await initFirestoreWithUserDocument();
+      await expectWriteToFail(db, kCurriculumCommentDocPath, specCommentDoc());
+    });
+
+    it("authenticated generic users can't read document comments", async () => {
+      await initFirestoreWithUserDocument(genericAuth);
+      await adminWriteDoc(kCurriculumCommentDocPath, specCommentDoc());
+      await expectReadToFail(db, kCurriculumCommentDocPath);
+    });
+
+    it("authenticated generic users can't write document comments", async () => {
+      await initFirestoreWithUserDocument(genericAuth);
+      await expectWriteToFail(db, kCurriculumCommentDocPath, specCommentDoc());
+    });
+
+    it("authenticated teachers can read their own document comments", async () => {
+      await initFirestoreWithUserDocument(teacherAuth);
+      await adminWriteDoc(kCurriculumCommentDocPath, specCommentDoc());
+      await expectReadToSucceed(db, kCurriculumCommentDocPath);
+    });
+
+    it("authenticated teachers can't write document comments without required uid", async () => {
+      await initFirestoreWithUserDocument(teacherAuth);
+      await expectWriteToFail(db, kCurriculumCommentDocPath, specCommentDoc({ remove: ["uid"] }));
+    });
+
+    it("authenticated teachers can't write document comments without required name", async () => {
+      await initFirestoreWithUserDocument(teacherAuth);
+      await expectWriteToFail(db, kCurriculumCommentDocPath, specCommentDoc({ remove: ["name"] }));
+    });
+
+    it("authenticated teachers can't write document comments without required name", async () => {
+      await initFirestoreWithUserDocument(teacherAuth);
+      await expectWriteToFail(db, kCurriculumCommentDocPath, specCommentDoc({ remove: ["content"] }));
+    });
+
+    it("authenticated teachers can't write document comments with inconsistent network", async () => {
+      await initFirestoreWithUserDocument(teacherAuth);
+      await expectWriteToFail(db, kCurriculumCommentDocPath, specCommentDoc({ add: { network: "other-network" } }));
+    });
+
+    it("authenticated teachers can write document comments", async () => {
+      await initFirestoreWithUserDocument(teacherAuth);
+      await expectWriteToSucceed(db, kCurriculumCommentDocPath, specCommentDoc());
+    });
+
+    it("authenticated teachers can't update document comments' read-only uid field", async () => {
+      await initFirestoreWithUserDocument(teacherAuth);
+      await adminWriteDoc(kCurriculumCommentDocPath, specCommentDoc());
+      await expectUpdateToFail(db, kCurriculumCommentDocPath, { content: "A new comment!", uid: teacher2Id });
+    });
+
+    it("authenticated teachers can't update document comments' read-only network field", async () => {
+      await initFirestoreWithUserDocument(teacherAuth);
+      await adminWriteDoc(kCurriculumCommentDocPath, specCommentDoc());
+      await expectUpdateToFail(db, kCurriculumCommentDocPath, { content: "A new comment!", network: "other-network" });
+    });
+
+    it("authenticated teachers can update document comments", async () => {
+      await initFirestoreWithUserDocument(teacherAuth);
+      await adminWriteDoc(kCurriculumCommentDocPath, specCommentDoc());
+      await expectUpdateToSucceed(db, kCurriculumCommentDocPath, { content: "A new comment!" });
+    });
+
+    it("authenticated teachers can't update other teachers' document comments", async () => {
+      await initFirestoreWithUserDocument(teacher2Auth);
+      await adminWriteDoc(kCurriculumCommentDocPath, specCommentDoc());
+      await expectUpdateToFail(db, kCurriculumCommentDocPath, { content: "A new comment!" });
+    });
+
+    it("authenticated teachers can delete document comments", async () => {
+      await initFirestoreWithUserDocument(teacherAuth);
+      await adminWriteDoc(kCurriculumCommentDocPath, specCommentDoc());
+      await expectDeleteToSucceed(db, kCurriculumCommentDocPath);
+    });
+
+    it("authenticated teachers can't delete other teachers' document comments", async () => {
+      await initFirestoreWithUserDocument(teacher2Auth);
+      await adminWriteDoc(kCurriculumCommentDocPath, specCommentDoc());
+      await expectDeleteToFail(db, kCurriculumCommentDocPath);
+    });
+
+    it("authenticated students can't read document comments", async () => {
+      await initFirestoreWithUserDocument(studentAuth);
+      await adminWriteDoc(kCurriculumCommentDocPath, specCommentDoc());
+      await expectReadToFail(db, kCurriculumCommentDocPath);
+    });
+
+    it("authenticated students can't write document comments", async () => {
+      await initFirestoreWithUserDocument(studentAuth);
+      await expectWriteToFail(db, kCurriculumCommentDocPath, specCommentDoc());
+    });
+
+  });
+
+  describe("networked curriculum documents", () => {
+    it("unauthenticated users can't read authenticated user curriculum documents", async () => {
+      db = initFirestore();
+      await expectReadToFail(db, kCurriculumDocPath);
+    });
+
+    it("unauthenticated users can't write user curriculum documents", async () => {
+      db = initFirestore();
+      await expectWriteToFail(db, kCurriculumDocPath, specCurriculumDoc({ add: { network: network1 } }));
+    });
+
+    it("authenticated generic users can't read authenticated user documents", async () => {
+      db = initFirestore(genericAuth);
+      await expectReadToFail(db, kCurriculumDocPath);
+    });
+
+    it("authenticated generic users can't write user documents", async () => {
+      db = initFirestore(genericAuth);
+      await expectWriteToFail(db, kCurriculumDocPath, specCurriculumDoc({ add: { network: network1 } }));
+    });
+
+    it("authenticated teachers can read their own user documents", async () => {
+      db = initFirestore(teacherAuth);
+      await adminWriteDoc(kCurriculumDocPath, specCurriculumDoc());
+      await expectReadToSucceed(db, kCurriculumDocPath);
+    });
+
+    it("authenticated teachers can't read other teachers curriculum documents outside a network", async () => {
+      db = initFirestore(teacherAuth);
+      await adminWriteDoc(kCurriculumDocPath, specCurriculumDoc({ add: { uid: teacher2Id, network: network1 }}));
+      await expectReadToFail(db, kCurriculumDocPath);
+    });
+
+    it("authenticated teachers can't read other teachers curriculum documents outside a network", async () => {
+      db = initFirestore(teacherAuth);
+      await adminWriteDoc(kCurriculumDocPath, specCurriculumDoc({ add: { uid: teacher2Id, network: network1 }}));
+      await expectReadToFail(db, kCurriculumDocPath);
+    });
+
+    it("authenticated teachers can't write user documents without required unit", async () => {
+      db = initFirestore(teacherAuth);
+      await expectWriteToFail(db, kCurriculumDocPath, specCurriculumDoc({ add: { network: network1 }, remove: ["unit"] }));
+    });
+
+    it("authenticated teachers can't write user documents without required problem", async () => {
+      db = initFirestore(teacherAuth);
+      await expectWriteToFail(db, kCurriculumDocPath, specCurriculumDoc({ add: { network: network1 }, remove: ["problem"] }));
+    });
+
+    it("authenticated teachers can't write user documents without required section", async () => {
+      db = initFirestore(teacherAuth);
+      await expectWriteToFail(db, kCurriculumDocPath, specCurriculumDoc({ add: { network: network1 }, remove: ["section"] }));
+    });
+
+    it("authenticated teachers can't write user documents without required path", async () => {
+      db = initFirestore(teacherAuth);
+      await expectWriteToFail(db, kCurriculumDocPath, specCurriculumDoc({ add: { network: network1 }, remove: ["path"] }));
+    });
+
+    it("authenticated teachers can't write user documents without required network", async () => {
+      db = initFirestore(teacherAuth);
+      await expectWriteToFail(db, kCurriculumDocPath, specCurriculumDoc({ remove: ["network"] }));
+    });
+
+    it("authenticated teachers can write user documents", async () => {
+      db = initFirestore(teacherAuth);
+      await expectWriteToSucceed(db, kCurriculumDocPath, specCurriculumDoc({ add: { network: network1 } }));
+    });
+
+    it("authenticated teachers can't update user documents' read-only fields", async () => {
+      db = initFirestore(teacherAuth);
+      await adminWriteDoc(kCurriculumDocPath, specCurriculumDoc({ add: { network: network1 } }));
+      await expectUpdateToFail(db, kCurriculumDocPath, { unit: "new-unit" });
+    });
+
+    it("authenticated teachers can't delete user documents", async () => {
+      db = initFirestore(teacherAuth);
+      await adminWriteDoc(kCurriculumDocPath, specCurriculumDoc({ add: { network: network1 } }));
+      await expectDeleteToFail(db, kCurriculumDocPath);
+    });
+
+    it("authenticated teachers can't delete other teachers' documents", async () => {
+      db = initFirestore(teacher2Auth);
+      await adminWriteDoc(kCurriculumDocPath, specCurriculumDoc({ add: { network: network1 } }));
+      await expectDeleteToFail(db, kCurriculumDocPath);
+    });
+
+    it("authenticated students can't read user documents", async () => {
+      db = initFirestore(studentAuth);
+      await adminWriteDoc(kCurriculumDocPath, specCurriculumDoc({ add: { network: network1 } }));
+      await expectReadToFail(db, kCurriculumDocPath);
+    });
+
+    it("authenticated students can't write user documents", async () => {
+      db = initFirestore(studentAuth);
+      await expectWriteToFail(db, kCurriculumDocPath, specCurriculumDoc({ add: { network: network1 } }));
+    });
+
+  });
+
+  describe("networked teacher curriculum document comments", () => {
+    const kCurriculumCommentDocPath = `${kCurriculumDocPath}/comments/myComment`;
+
+    interface ISpecCommentDoc {
+      add?: Record<string, string | string[] | object>;
+      remove?: string[];
+    }
+    function specCommentDoc(options?: ISpecCommentDoc) {
+      // a valid comment document specification
+      const commentDoc = { uid: teacherId, name: teacherName, network: network1,
+                            content: "A comment!", createdAt: mockTimestamp() };
+      // remove specified props for validating the tests that require them
+      options?.remove?.forEach(prop => delete (commentDoc as any)[prop]);
+      // add additional props to test behavior of additional props
+      options?.add && Object.keys(options.add).forEach(prop => {
+        (commentDoc as any)[prop] = options.add?.[prop];
+      });
+      return commentDoc;
+    }
+
+    const initFirestoreWithUserDocument = async (auth?: any) => {
+      db = initFirestore(auth);
+      await adminWriteDoc(kCurriculumDocPath, specCurriculumDoc({ add: { network: network1 } }));
+    };
+
+    it("unauthenticated users can't read document comments", async () => {
+      await initFirestoreWithUserDocument();
+      await adminWriteDoc(kCurriculumCommentDocPath, specCommentDoc());
+      await expectReadToFail(db, kCurriculumCommentDocPath);
+    });
+
+    it("unauthenticated users can't write document comments", async () => {
+      await initFirestoreWithUserDocument();
+      await expectWriteToFail(db, kCurriculumCommentDocPath, specCommentDoc());
+    });
+
+    it("authenticated generic users can't read document comments", async () => {
+      await initFirestoreWithUserDocument(genericAuth);
+      await adminWriteDoc(kCurriculumCommentDocPath, specCommentDoc());
+      await expectReadToFail(db, kCurriculumCommentDocPath);
+    });
+
+    it("authenticated generic users can't write document comments", async () => {
+      await initFirestoreWithUserDocument(genericAuth);
+      await expectWriteToFail(db, kCurriculumCommentDocPath, specCommentDoc());
+    });
+
+    it("authenticated teachers can read their own document comments", async () => {
+      await initFirestoreWithUserDocument(teacherAuth);
+      await adminWriteDoc(kCurriculumCommentDocPath, specCommentDoc());
+      await expectReadToSucceed(db, kCurriculumCommentDocPath);
+    });
+
+    it("authenticated teachers can't write document comments without required uid", async () => {
+      await initFirestoreWithUserDocument(teacherAuth);
+      await expectWriteToFail(db, kCurriculumCommentDocPath, specCommentDoc({ remove: ["uid"] }));
+    });
+
+    it("authenticated teachers can't write document comments without required name", async () => {
+      await initFirestoreWithUserDocument(teacherAuth);
+      await expectWriteToFail(db, kCurriculumCommentDocPath, specCommentDoc({ remove: ["name"] }));
+    });
+
+    it("authenticated teachers can't write document comments without required name", async () => {
+      await initFirestoreWithUserDocument(teacherAuth);
+      await expectWriteToFail(db, kCurriculumCommentDocPath, specCommentDoc({ remove: ["content"] }));
+    });
+
+    it("authenticated teachers can't write document comments with inconsistent network", async () => {
+      await initFirestoreWithUserDocument(teacherAuth);
+      await expectWriteToFail(db, kCurriculumCommentDocPath, specCommentDoc({ add: { network: "other-network" } }));
+    });
+
+    it("authenticated teachers can write document comments", async () => {
+      await initFirestoreWithUserDocument(teacherAuth);
+      await expectWriteToSucceed(db, kCurriculumCommentDocPath, specCommentDoc());
+    });
+
+    it("authenticated teachers can't write document comments to other teachers' documents outside the network", async () => {
+      await initFirestoreWithUserDocument(teacher2Auth);
+      // write user information for teacher 2 that puts them in the same network as teacher 1
+      await adminWriteDoc(kTeacher2UserDocPath, { uid: teacher2Id, name: teacher2Name, type: "teacher", networks: [network2] });
+      await expectWriteToFail(db, kCurriculumCommentDocPath, specCommentDoc({ add: { uid: teacher2Id } }));
+    });
+
+    it("authenticated teachers can read document comments on other teachers' documents in the network", async () => {
+      await initFirestoreWithUserDocument(teacher2Auth);
+      // write user information for teacher 2 that puts them in the same network as teacher 1
+      await adminWriteDoc(kTeacher2UserDocPath, { uid: teacher2Id, name: teacher2Name, type: "teacher", networks: [network1] });
+      await expectReadToSucceed(db, kCurriculumCommentDocPath);
+    });
+
+    it("authenticated teachers can write document comments to other teachers' documents in the network", async () => {
+      await initFirestoreWithUserDocument(teacher2Auth);
+      // write user information for teacher 2 that puts them in the same network as teacher 1
+      await adminWriteDoc(kTeacher2UserDocPath, { uid: teacher2Id, name: teacher2Name, type: "teacher", networks: [network1] });
+      await expectWriteToSucceed(db, kCurriculumCommentDocPath, specCommentDoc({ add: { uid: teacher2Id } }));
+    });
+
+    it("authenticated teachers can update their own comments to other teachers' documents in the network", async () => {
+      await initFirestoreWithUserDocument(teacher2Auth);
+      // write user information for teacher 2 that puts them in the same network as teacher 1
+      await adminWriteDoc(kTeacher2UserDocPath, { uid: teacher2Id, name: teacher2Name, type: "teacher", networks: [network1] });
+      await expectWriteToSucceed(db, kCurriculumCommentDocPath, specCommentDoc({ add: { uid: teacher2Id, content: "Updated comment" } }));
+    });
+
+    it("authenticated teachers can delete their own comments to other teachers' documents in the network", async () => {
+      await initFirestoreWithUserDocument(teacher2Auth);
+      // write user information for teacher 2 that puts them in the same network as teacher 1
+      await adminWriteDoc(kTeacher2UserDocPath, { uid: teacher2Id, name: teacher2Name, type: "teacher", networks: [network1] });
+      await adminWriteDoc(kCurriculumCommentDocPath, specCommentDoc({ add: { uid: teacher2Id } }));
+      await expectDeleteToSucceed(db, kCurriculumCommentDocPath);
+    });
+
+    it("authenticated teachers can't update document comments' read-only uid field", async () => {
+      await initFirestoreWithUserDocument(teacherAuth);
+      await adminWriteDoc(kCurriculumCommentDocPath, specCommentDoc());
+      await expectUpdateToFail(db, kCurriculumCommentDocPath, { content: "A new comment!", uid: teacher2Id });
+    });
+
+    it("authenticated teachers can't update document comments' read-only network field", async () => {
+      await initFirestoreWithUserDocument(teacherAuth);
+      await adminWriteDoc(kCurriculumCommentDocPath, specCommentDoc());
+      await expectUpdateToFail(db, kCurriculumCommentDocPath, { content: "A new comment!", network: "other-network" });
+    });
+
+    it("authenticated teachers can update document comments", async () => {
+      await initFirestoreWithUserDocument(teacherAuth);
+      await adminWriteDoc(kCurriculumCommentDocPath, specCommentDoc());
+      await expectUpdateToSucceed(db, kCurriculumCommentDocPath, { content: "A new comment!" });
+    });
+
+    it("authenticated teachers can't update other teachers' document comments", async () => {
+      await initFirestoreWithUserDocument(teacher2Auth);
+      await adminWriteDoc(kCurriculumCommentDocPath, specCommentDoc());
+      await expectUpdateToFail(db, kCurriculumCommentDocPath, { content: "A new comment!" });
+    });
+
+    it("authenticated teachers can delete document comments", async () => {
+      await initFirestoreWithUserDocument(teacherAuth);
+      await adminWriteDoc(kCurriculumCommentDocPath, specCommentDoc());
+      await expectDeleteToSucceed(db, kCurriculumCommentDocPath);
+    });
+
+    it("authenticated teachers can't delete other teachers' document comments", async () => {
+      await initFirestoreWithUserDocument(teacher2Auth);
+      await adminWriteDoc(kCurriculumCommentDocPath, specCommentDoc());
+      await expectDeleteToFail(db, kCurriculumCommentDocPath);
+    });
+
+    it("authenticated students can't read document comments", async () => {
+      await initFirestoreWithUserDocument(studentAuth);
+      await adminWriteDoc(kCurriculumCommentDocPath, specCommentDoc());
+      await expectReadToFail(db, kCurriculumCommentDocPath);
+    });
+
+    it("authenticated students can't write document comments", async () => {
+      await initFirestoreWithUserDocument(studentAuth);
+      await expectWriteToFail(db, kCurriculumCommentDocPath, specCommentDoc());
+    });
+
+  });
+
+});

--- a/firebase-test/src/setup-rules-tests.ts
+++ b/firebase-test/src/setup-rules-tests.ts
@@ -17,6 +17,15 @@ export const teacherAuth = { uid: teacherId, platform_user_id: teacherId, user_t
 export const teacher2Id = "user-teacher2";
 export const teacher2Name = "John Teacher";
 export const teacher2Auth = { uid: teacher2Id, platform_user_id: teacher2Id, user_type: "teacher", class_hash: otherClass };
+export const noNetwork = null;
+export const network1 = "network-1";
+export const network2 = "network-2";
+export const cUnit = "abc";
+export const cFacet = "facet";
+export const cProblem = "1.2";
+export const cSection = "intro";
+export const cPath = `${cUnit}/1/2/intro`;
+export const cPathWithFacet = `${cUnit}:${cFacet}/1/2/intro`;
 
 // @firebase/rules-unit-testing doesn't support firebase.firestore.FieldValue.serverTimestamp()
 export const mockTimestamp = () => Date.now();

--- a/firebase-test/src/user-rules.test.ts
+++ b/firebase-test/src/user-rules.test.ts
@@ -1,0 +1,67 @@
+import firebase from "firebase";
+import {
+  expectReadToFail, expectReadToSucceed, expectWriteToFail, genericAuth,
+  initFirestore, network1, prepareEachTest, studentAuth, teacherAuth, teacherId, tearDownTests
+} from "./setup-rules-tests";
+
+describe("Firestore security rules for user documents", () => {
+
+  let db: firebase.firestore.Firestore;
+
+  beforeEach(async () => {
+    await prepareEachTest();
+  });
+
+  afterAll(async () => {
+    await tearDownTests();
+  });
+
+  function specUser() {
+    return { uid: teacherId, name: "Jane Teacher", type: "teacher", networks: [network1] };
+  }
+
+  describe("user documents", () => {
+    const kUserDocPath = `authed/myPortal/users/${teacherId}`;
+
+    it("unauthenticated users can't read user documents", async () => {
+      db = initFirestore();
+      await expectReadToFail(db, kUserDocPath);
+    });
+
+    it("unauthenticated users can't write user documents", async () => {
+      db = initFirestore();
+      await expectWriteToFail(db, kUserDocPath, specUser());
+    });
+
+    it("authenticated generic users can't read user documents", async () => {
+      db = initFirestore(genericAuth);
+      await expectReadToFail(db, kUserDocPath);
+    });
+
+    it("authenticated generic users can't write user documents", async () => {
+      db = initFirestore(genericAuth);
+      await expectWriteToFail(db, kUserDocPath, specUser());
+    });
+
+    it("authenticated teachers can read their own user documents", async () => {
+      db = initFirestore(teacherAuth);
+      await expectReadToSucceed(db, kUserDocPath);
+    });
+
+    it("authenticated teachers can't write their own user documents (only admins)", async () => {
+      db = initFirestore(teacherAuth);
+      await expectWriteToFail(db, kUserDocPath, specUser());
+    });
+
+    it("authenticated students can't read user documents", async () => {
+      db = initFirestore(studentAuth);
+      await expectReadToFail(db, kUserDocPath);
+    });
+
+    it("authenticated students can't write user documents", async () => {
+      db = initFirestore(studentAuth);
+      await expectWriteToFail(db, kUserDocPath, specUser());
+    });
+  });
+
+});

--- a/firestore.rules
+++ b/firestore.rules
@@ -9,6 +9,10 @@ service cloud.firestore {
       allow read, write: if false;
     }
 
+    function exists(s) {
+      return (s != null) && (s != "");
+    }
+
     function isAuthed() {
       return request.auth != null;
     }
@@ -80,34 +84,24 @@ service cloud.firestore {
       return isAuthed() && request.auth.token.class_hash in resource.data.classes;
     }
 
+    function isValidCurriculumCreateRequest() {
+      return requestMatchUserId() &&
+              request.resource.data.keys().hasAll(["uid", "unit", "problem", "section", "path", "network"]);
+    }
+
     function isValidDocumentCreateRequest() {
       return requestMatchTeachers() && classIsRequestContextId() &&
-              request.resource.data.keys().hasAll(["uid", "type", "key", "createdAt"]);
+              request.resource.data.keys().hasAll(["uid", "network", "type", "key", "createdAt"]);
     }
 
     function preservesReadOnlyDocumentFields() {
-      let readOnlyFieldsSet = ["uid", "type", "key", "createdAt"].toSet();
+      let readOnlyFieldsSet = ["uid", "network", "type", "key", "createdAt"].toSet();
       let affectedFieldsSet = request.resource.data.diff(resource.data).affectedKeys();
       return !affectedFieldsSet.hasAny(readOnlyFieldsSet);
     }
 
     function isValidDocumentUpdateRequest() {
       return resourceMatchTeacher() && preservesReadOnlyDocumentFields();
-    }
-
-    function isValidCommentCreateRequest() {
-      return requestMatchUserId() &&
-              request.resource.data.keys().hasAll(["name", "createdAt", "content"]);
-    }
-
-    function preservesReadOnlyCommentFields() {
-      let readOnlyFieldsSet = ["uid", "createdAt", "tileId"].toSet();
-      let affectedFieldsSet = request.resource.data.diff(resource.data).affectedKeys();
-      return !affectedFieldsSet.hasAny(readOnlyFieldsSet);
-    }
-
-    function isValidCommentUpdateRequest() {
-      return requestMatchUserId() && preservesReadOnlyCommentFields();
     }
 
     function isValidSupportCreateRequest() {
@@ -135,6 +129,81 @@ service cloud.firestore {
     match /authed/{portal} {
       allow read, write: if isAuthedTeacher();
 
+      function getTeacherNetworks() {
+        let platformUserId = request.auth.token.platform_user_id;
+        return get(/databases/$(database)/documents/authed/$(portal)/users/$(platformUserId)).data.networks;
+      }
+
+      function resourceInTeacherNetworks() {
+        return resource.data.network in getTeacherNetworks();
+      }
+
+      match /users/{userId} {
+        // teachers can read their own user documents
+        allow read: if isAuthedTeacher() && (request.auth.token.platform_user_id == userId);
+        // currently, only admins can write user information
+        allow write: if false;
+      }
+
+      match /curriculum/{pathId} {
+        // portal-authenticated teachers can create valid curriculum documents
+        allow create: if isAuthedTeacher() && isValidCurriculumCreateRequest();
+        // curriculum documents can't be updated or deleted
+        allow update, delete: if false;
+        // teachers can read their own curriculum documents or others in their network
+        allow read: if isAuthedTeacher() && (resourceMatchUserId() || resourceInTeacherNetworks());
+
+        function getCurriculumOwner() {
+          return get(/databases/$(database)/documents/authed/$(portal)/curriculum/$(pathId)).data.uid;
+        }
+
+        function getCurriculumNetwork() {
+          return get(/databases/$(database)/documents/authed/$(portal)/curriculum/$(pathId)).data.network;
+        }
+
+        function curriculumInTeacherNetworks() {
+          let curriculumNetwork = getCurriculumNetwork();
+          return exists(curriculumNetwork) && (curriculumNetwork in getTeacherNetworks());
+        }
+
+        function teacherIsCurriculumOwner() {
+          let curriculumOwner = getCurriculumOwner();
+          return request.auth.token.platform_user_id == curriculumOwner;
+        }
+
+        function teacherCanAccessCurriculum() {
+          return teacherIsCurriculumOwner() || curriculumInTeacherNetworks();
+        }
+
+        function isValidCommentCreateRequest() {
+          return requestMatchUserId() &&
+                  // comments network must match network of parent document
+                  (request.resource.data.network == getCurriculumNetwork()) &&
+                  request.resource.data.keys().hasAll(["name", "createdAt", "content", "network"]);
+        }
+
+        function preservesReadOnlyCommentFields() {
+          let readOnlyFieldsSet = ["uid", "network", "createdAt", "tileId"].toSet();
+          let affectedFieldsSet = request.resource.data.diff(resource.data).affectedKeys();
+          return !affectedFieldsSet.hasAny(readOnlyFieldsSet);
+        }
+
+        function isValidCommentUpdateRequest() {
+          return requestMatchUserId() && preservesReadOnlyCommentFields();
+        }
+
+        match /comments/{commentId} {
+          // portal-authenticated teachers with access to the document can create valid comments
+          allow create: if isAuthedTeacher() && teacherCanAccessCurriculum() && isValidCommentCreateRequest();
+          // teachers can only update their own comments and only if they're valid
+          allow update: if isAuthedTeacher() && teacherCanAccessCurriculum() && isValidCommentUpdateRequest();
+          // teachers can only delete their own comments
+          allow delete: if isAuthedTeacher() && teacherCanAccessCurriculum() && resourceMatchUserId();
+          // only teachers that "own" the document can read the comments (for now)
+          allow read: if isAuthedTeacher() && teacherCanAccessCurriculum();
+        }
+      }
+
       match /documents/{docId} {
         // portal-authenticated teachers can create valid documents
         allow create: if isAuthedTeacher() && isValidDocumentCreateRequest();
@@ -142,26 +211,56 @@ service cloud.firestore {
         allow update: if isAuthedTeacher() && isValidDocumentUpdateRequest();
         // teachers can only delete their own documents
         allow delete: if isAuthedTeacher() && resourceMatchUserId();
-        // only teachers that "own" the document can read it (for now)
-        allow read: if isAuthedTeacher() && resourceMatchTeacher();
+        // teachers can read their own documents or other documents in their network
+        allow read: if isAuthedTeacher() && (resourceMatchTeacher() || resourceInTeacherNetworks());
 
         function getDocumentTeachers() {
           return get(/databases/$(database)/documents/authed/$(portal)/documents/$(docId)).data.teachers;
+        }
+
+        function getDocumentNetwork() {
+          return get(/databases/$(database)/documents/authed/$(portal)/documents/$(docId)).data.network;
         }
 
         function teacherInDocumentTeachers() {
           return isAuthedTeacher() && (request.auth.uid in getDocumentTeachers());
         }
 
+        function documentInTeacherNetworks() {
+          let docNetwork = getDocumentNetwork();
+          return exists(docNetwork) && (docNetwork in getTeacherNetworks());
+        }
+
+        function teacherCanAccessDocument() {
+          return teacherInDocumentTeachers() || documentInTeacherNetworks();
+        }
+
+        function isValidCommentCreateRequest() {
+          return requestMatchUserId() &&
+                  // comments network must match network of parent document
+                  (request.resource.data.network == getDocumentNetwork()) &&
+                  request.resource.data.keys().hasAll(["name", "createdAt", "content"]);
+        }
+
+        function preservesReadOnlyCommentFields() {
+          let readOnlyFieldsSet = ["uid", "network", "createdAt", "tileId"].toSet();
+          let affectedFieldsSet = request.resource.data.diff(resource.data).affectedKeys();
+          return !affectedFieldsSet.hasAny(readOnlyFieldsSet);
+        }
+
+        function isValidCommentUpdateRequest() {
+          return requestMatchUserId() && preservesReadOnlyCommentFields();
+        }
+
         match /comments/{commentId} {
           // portal-authenticated teachers with access to the document can create valid comments
-          allow create: if teacherInDocumentTeachers() && isValidCommentCreateRequest();
+          allow create: if isAuthedTeacher() && teacherCanAccessDocument() && isValidCommentCreateRequest();
           // teachers can only update their own comments and only if they're valid
-          allow update: if teacherInDocumentTeachers() && isValidCommentUpdateRequest();
+          allow update: if isAuthedTeacher() && teacherCanAccessDocument() && isValidCommentUpdateRequest();
           // teachers can only delete their own comments
-          allow delete: if teacherInDocumentTeachers() && resourceMatchUserId();
+          allow delete: if isAuthedTeacher() && teacherCanAccessDocument() && resourceMatchUserId();
           // only teachers that "own" the document can read the comments (for now)
-          allow read: if teacherInDocumentTeachers();
+          allow read: if isAuthedTeacher() && teacherCanAccessDocument();
         }
       }
 

--- a/src/lib/firestore-schema.ts
+++ b/src/lib/firestore-schema.ts
@@ -24,6 +24,7 @@ interface UserDocument {
   uid: string;                // portal user id
   name: string;               // teacher name
   type: string;               // "teacher" for now although maybe students eventually
+  network: string;            // id of primary/default network for this teacher
   networks: string[];         // ids of networks this teacher is part of
 }
 // collection key is portal uid


### PR DESCRIPTION
Note: as written these rules only work for curriculum "documents". Firebase documents will require some additional attention, including potentially sharing some code between the two.