### PR TITLE
Add `&chat` url parameter automatically for demo teachers 2 and 3

### DIFF
--- a/src/components/demo/demo-creator.tsx
+++ b/src/components/demo/demo-creator.tsx
@@ -99,8 +99,9 @@ export class DemoCreatorComponent extends BaseComponent<IProps> {
     const demoNameParam = demo.name ? `&demoName=${demo.name}` : "";
     const fakeUser = `${userType}:${userIndex}`;
     const unitStr = unit.code ? `&unit=${unit.code}` : "";
+    const chatStr = (userType === "teacher") && (userIndex > 1) ? "&chat" : "";
     // eslint-disable-next-line max-len
-    const href = `?appMode=demo${demoNameParam}&fakeClass=${demo.class.id}&fakeUser=${fakeUser}${unitStr}&problem=${demo.problemOrdinal}`;
+    const href = `?appMode=demo${demoNameParam}&fakeClass=${demo.class.id}&fakeUser=${fakeUser}${unitStr}&problem=${demo.problemOrdinal}${chatStr}`;
     return (
       <li key={userIndex}>
         <a href={href} target="_blank" rel="noreferrer">{userType} {userIndex}</a>


### PR DESCRIPTION
The need to add `&chat` for the networked demo teachers continues to be a source of confusion, so we eliminate it.