### PR TITLE
179458436 tile comment highlight

### DIFF
--- a/cypress/integration/clue/branch/teacher_tests/teacher_workspace_spec.js
+++ b/cypress/integration/clue/branch/teacher_tests/teacher_workspace_spec.js
@@ -159,6 +159,7 @@ describe('Chat panel for networked teacher', () => {
     cy.wait(1000);
     cy.get(".comment-text").should("have.length", 2);
     cy.get(".comment-text").last().should("contain", "Send this comment after enter.");
+  });
   it("verify commenting on document only shows document comment, and tile only shows tile comments", () => {
     //setup
     cy.openTopTab("problems");
@@ -173,16 +174,20 @@ describe('Chat panel for networked teacher', () => {
     cy.get('[data-testid=comment-textarea]').click().type("This is the 4th tile comment.");
     cy.get('[data-testid=comment-post-button]').click();
     //test comments for tile
+    cy.get('.problem-panel .document-content .tile-row').find('.tool-tile').eq(3).should('have.class', 'selected-for-comment');
     cy.get('[data-testid=comment-thread] [data-testid=comment]').should('not.contain', "This is a document comment");
     cy.get('[data-testid=comment-thread] [data-testid=comment]').should('not.contain', "This is a tile comment for the first tile");
     cy.get('[data-testid=comment-thread] [data-testid=comment]').should('contain', "This is the 4th tile comment.");
     cy.get('.problem-panel .document-content .tile-row').first().click();
+    cy.get('.problem-panel .document-content .tile-row .tool-tile').first().should('have.class', 'selected-for-comment');
     cy.get('[data-testid=comment-thread] [data-testid=comment]').should('not.contain', "This is a document comment");
     cy.get('[data-testid=comment-thread] [data-testid=comment]').should('contain', "This is a tile comment for the first tile");
     cy.get('[data-testid=comment-thread] [data-testid=comment]').should('not.contain', "This is the 4th tile comment.");
-    cy.openTopTab("my-work"); //deselects the tile
-    cy.get("[data-test=subtab-workspaces] .editable-document-content [data-test=canvas] .document-content").click(); //should reselect the document again
-    cy.openTopTab("problems");
+    // It would be hard to click on document to deselect tile so instead we go to a different tab to deselect
+    cy.openProblemSection("Initial Challenge");
+    cy.openProblemSection("Introduction");
+    cy.get('.problem-panel .document-content').should('have.class', 'comment-select');
+    cy.get('.problem-panel .document-content .tile-row .tool-tile').first().should('not.have.class', 'selected-for-comment');
     cy.get('[data-testid=comment-thread] [data-testid=comment]').should('contain', "This is a document comment");
     cy.get('[data-testid=comment-thread] [data-testid=comment]').should('not.contain', "This is a tile comment for the first tile");
     cy.get('[data-testid=comment-thread] [data-testid=comment]').should('not.contain', "This is the 4th tile comment.");

--- a/cypress/integration/clue/branch/teacher_tests/teacher_workspace_spec.js
+++ b/cypress/integration/clue/branch/teacher_tests/teacher_workspace_spec.js
@@ -159,6 +159,33 @@ describe('Chat panel for networked teacher', () => {
     cy.wait(1000);
     cy.get(".comment-text").should("have.length", 2);
     cy.get(".comment-text").last().should("contain", "Send this comment after enter.");
+  it("verify commenting on document only shows document comment, and tile only shows tile comments", () => {
+    //setup
+    cy.openTopTab("problems");
+    cy.get('.problem-panel .document-content').should('have.class', 'comment-select');
+    cy.get('[data-testid=comment-textarea]').click().type("This is a document comment");
+    cy.get('[data-testid=comment-post-button]').click();
+    cy.wait(5000);
+    cy.get('.problem-panel .document-content .tile-row').first().click();
+    cy.get('[data-testid=comment-textarea]').click().type("This is a tile comment for the first tile");
+    cy.get('[data-testid=comment-post-button]').click();
+    cy.get('.problem-panel .document-content .tile-row').eq(3).click();
+    cy.get('[data-testid=comment-textarea]').click().type("This is the 4th tile comment.");
+    cy.get('[data-testid=comment-post-button]').click();
+    //test comments for tile
+    cy.get('[data-testid=comment-thread] [data-testid=comment]').should('not.contain', "This is a document comment");
+    cy.get('[data-testid=comment-thread] [data-testid=comment]').should('not.contain', "This is a tile comment for the first tile");
+    cy.get('[data-testid=comment-thread] [data-testid=comment]').should('contain', "This is the 4th tile comment.");
+    cy.get('.problem-panel .document-content .tile-row').first().click();
+    cy.get('[data-testid=comment-thread] [data-testid=comment]').should('not.contain', "This is a document comment");
+    cy.get('[data-testid=comment-thread] [data-testid=comment]').should('contain', "This is a tile comment for the first tile");
+    cy.get('[data-testid=comment-thread] [data-testid=comment]').should('not.contain', "This is the 4th tile comment.");
+    cy.openTopTab("my-work"); //deselects the tile
+    cy.get("[data-test=subtab-workspaces] .editable-document-content [data-test=canvas] .document-content").click(); //should reselect the document again
+    cy.openTopTab("problems");
+    cy.get('[data-testid=comment-thread] [data-testid=comment]').should('contain', "This is a document comment");
+    cy.get('[data-testid=comment-thread] [data-testid=comment]').should('not.contain', "This is a tile comment for the first tile");
+    cy.get('[data-testid=comment-thread] [data-testid=comment]').should('not.contain', "This is the 4th tile comment.");
   });
 });
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -120,6 +120,9 @@ Cypress.Commands.add("openResourceTabs", () => {
 Cypress.Commands.add("openTopTab", (tab) => {
   cy.get('.top-tab.tab-'+tab).click();
 } );
+Cypress.Commands.add("openProblemSection", (section) => {//doc-tab my-work workspaces problem-documents selected
+  cy.get('.prob-tab').contains(section).click({force:true});
+});
 Cypress.Commands.add("openSection", (tab, section) => {//doc-tab my-work workspaces problem-documents selected
   cy.get('.doc-tab.'+tab+'.'+section).click({force:true});
 });

--- a/src/components/chat/chat-panel.test.tsx
+++ b/src/components/chat/chat-panel.test.tsx
@@ -40,6 +40,10 @@ jest.mock("../../hooks/document-comment-hooks", () => ({
 jest.mock("../../hooks/use-stores", () => ({
   useDocumentOrCurriculumMetadata: (documentKey: string) => ({
     uid: "1", key: documentKey, type: "problem"
+  }),
+  useUIStore: () => ({
+    showChatPanel: true,
+    selectedTileIds: []
   })
 }));
 

--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -12,20 +12,24 @@ interface IProps {
   user?: UserModelType;
   activeNavTab: string;
   focusDocument?: string;
+  focusTileId?: string;
   onCloseChatPanel:(show:boolean) => void;
 }
 
-export const ChatPanel: React.FC<IProps> = ({ user, activeNavTab, focusDocument, onCloseChatPanel }) => {
+export const ChatPanel: React.FC<IProps> = ({ user, activeNavTab, focusDocument, focusTileId, onCloseChatPanel }) => {
   const document = useDocumentOrCurriculumMetadata(focusDocument);
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { isLoading, data: comments } = useDocumentComments(focusDocument);
   const { data: unreadComments } = useUnreadDocumentComments(focusDocument);
+  const documentComments = comments?.filter(comment => comment.tileId === null);
+  const tileComments = comments?.filter(comment => comment.tileId === focusTileId);
+  const postedComments = focusTileId? tileComments : documentComments;
   const postCommentMutation = usePostDocumentComment();
   const postComment = useCallback((comment: string) => {
     return document
-            ? postCommentMutation.mutate({ document, comment: { content: comment } })
+            ? postCommentMutation.mutate({ document, comment: { content: comment, tileId: focusTileId } })
             : undefined;
-  }, [document, postCommentMutation]);
+  }, [document, focusTileId, postCommentMutation]);
   const newCommentCount = unreadComments?.length || 0;
   return (
     <div className={`chat-panel ${activeNavTab}`} data-testid="chat-panel">
@@ -36,7 +40,7 @@ export const ChatPanel: React.FC<IProps> = ({ user, activeNavTab, focusDocument,
             user={user}
             activeNavTab={activeNavTab}
             onPostComment={postComment}
-            postedComments={comments}
+            postedComments={postedComments}
           />
         : <div className="select-doc-message" data-testid="select-doc-messsage">
             Open a document to begin or view comment threads

--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -23,7 +23,7 @@ export const ChatPanel: React.FC<IProps> = ({ user, activeNavTab, focusDocument,
   const { data: unreadComments } = useUnreadDocumentComments(focusDocument);
   const documentComments = comments?.filter(comment => comment.tileId === null);
   const tileComments = comments?.filter(comment => comment.tileId === focusTileId);
-  const postedComments = focusTileId? tileComments : documentComments;
+  const postedComments = focusTileId ? tileComments : documentComments;
   const postCommentMutation = usePostDocumentComment();
   const postComment = useCallback((comment: string) => {
     return document

--- a/src/components/chat/comment-card.test.tsx
+++ b/src/components/chat/comment-card.test.tsx
@@ -4,6 +4,13 @@ import { CommentDocument } from "../../lib/firestore-schema";
 import { UserModelType } from "../../models/stores/user";
 import { CommentCard } from "./comment-card";
 
+jest.mock("../../hooks/use-stores", () => ({
+  useUIStore: () => ({
+    showChatPanel: true,
+    selectedTileIds: []
+  })
+}));
+
 describe("CommentCard", () => {
   const testUser  = { id: "0", name: "Test Teacher" } as UserModelType;
   const activeNavTab = "my-work";

--- a/src/components/chat/comment-textbox.test.tsx
+++ b/src/components/chat/comment-textbox.test.tsx
@@ -4,8 +4,14 @@ import React from "react";
 import { act } from "react-dom/test-utils";
 import { CommentTextBox } from "./comment-textbox";
 
-describe("Comment Textbox", () => {
+jest.mock("../../hooks/use-stores", () => ({
+  useUIStore: () => ({
+    showChatPanel: true,
+    selectedTileIds: []
+  })
+}));
 
+describe("Comment Textbox", () => {
   it("should render successfully", () => {
     const activeNavTab = "problems";
     render((

--- a/src/components/chat/comment-textbox.tsx
+++ b/src/components/chat/comment-textbox.tsx
@@ -1,6 +1,5 @@
 import classNames from "classnames";
 import React, { useEffect, useRef, useState } from "react";
-import React, { useState } from "react";
 import { useUIStore } from "../../hooks/use-stores";
 import SendIcon from "../../assets/send-icon.svg";
 import "../themes.scss";

--- a/src/components/chat/comment-textbox.tsx
+++ b/src/components/chat/comment-textbox.tsx
@@ -1,5 +1,7 @@
 import classNames from "classnames";
 import React, { useEffect, useRef, useState } from "react";
+import React, { useState } from "react";
+import { useUIStore } from "../../hooks/use-stores";
 import SendIcon from "../../assets/send-icon.svg";
 import "../themes.scss";
 
@@ -19,6 +21,7 @@ export const CommentTextBox: React.FC<IProps> = ({ activeNavTab, numPostedCommen
   const textareaStyle = {height: commentTextAreaHeight};
   const postButtonClass = classNames("comment-footer-button", "themed-negative", activeNavTab,
                                      { disabled: !commentAdded, "no-action": !commentAdded });
+  const ui = useUIStore();
   // resize textarea when user deletes some text
   useEffect(() => {
     if (textareaRef?.current) {
@@ -89,12 +92,17 @@ export const CommentTextBox: React.FC<IProps> = ({ activeNavTab, numPostedCommen
     }
   };
 
+  const placeholderText = ui.selectedTileIds.length === 0 && numPostedComments < 1
+                            ? "Comment on this document..."
+                            : ui.selectedTileIds.length !== 0 && numPostedComments < 1
+                              ? "Comment on this tile..."
+                              : "Reply...";
   return (
     <div className="comment-textbox">
       <textarea
         ref={textareaRef}
         style={textareaStyle}
-        placeholder={numPostedComments < 1 ? "Comment on this document...": "Reply..."}
+        placeholder={placeholderText}
         value={commentText}
         data-testid="comment-textarea"
         onChange={handleCommentTextAreaChange}

--- a/src/components/chat/comment-textbox.tsx
+++ b/src/components/chat/comment-textbox.tsx
@@ -26,7 +26,8 @@ export const CommentTextBox: React.FC<IProps> = ({ activeNavTab, numPostedCommen
     if (textareaRef?.current) {
       textareaRef.current.style.height = minTextAreaHeight + "px"; //needed to resize text area when user partial delete
       const scrollHeight = textareaRef.current.scrollHeight;
-      textareaRef.current.style.height = scrollHeight + "px";
+      textareaRef.current.style.height = textareaRef.current?.value !== ""
+                                          ? scrollHeight + "px" : minTextAreaHeight + "px";
     }
   });
 

--- a/src/components/document/canvas.tsx
+++ b/src/components/document/canvas.tsx
@@ -26,7 +26,6 @@ interface IProps {
   overlayMessage?: string;
   selectedSectionId?: string | null;
   viaTeacherDashboard?: boolean;
-  documentSelectedForComment?: boolean;
 }
 
 @inject("stores")

--- a/src/components/document/document-content.tsx
+++ b/src/components/document/document-content.tsx
@@ -4,6 +4,7 @@ import { findDOMNode } from "react-dom";
 import { throttle } from "lodash";
 import classNames from "classnames";
 import { BaseComponent, IBaseProps } from "../base";
+import { urlParams } from "../../utilities/url-params";
 import { TileRowComponent, kDragResizeRowId, extractDragResizeRowId, extractDragResizeY,
         extractDragResizeModelHeight, extractDragResizeDomHeight } from "../document/tile-row";
 import { DocumentContentModelType, IDragToolCreateInfo, IDropRowInfo } from "../../models/document/document-content";
@@ -24,7 +25,6 @@ interface IProps extends IBaseProps {
   scale?: number;
   selectedSectionId?: string | null;
   viaTeacherDashboard?: boolean;
-  documentSelectedForComment?: boolean;
 }
 
 interface IDragResizeRow {
@@ -102,7 +102,10 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
   }
 
   public render() {
-    const {viaTeacherDashboard, documentSelectedForComment} = this.props;
+    const {viaTeacherDashboard} = this.props;
+    const {ui, user: {isNetworkedTeacher}} = this.stores;
+    const isChatEnabled = isNetworkedTeacher && urlParams.chat;
+    const documentSelectedForComment = isChatEnabled && ui.showChatPanel && ui.selectedTileIds.length === 0;
     const documentClass = classNames("document-content", {"document-content-smooth-scroll" : viaTeacherDashboard,
                                      "comment-select" : documentSelectedForComment});
     return (

--- a/src/components/document/editable-document-content.tsx
+++ b/src/components/document/editable-document-content.tsx
@@ -5,7 +5,8 @@ import { CanvasComponent } from "./canvas";
 import { DocumentContextReact } from "./document-context";
 import { FourUpComponent } from "../four-up";
 import { useDocumentContext } from "../../hooks/use-document-context";
-import { useGroupsStore } from "../../hooks/use-stores";
+import { useGroupsStore, useUIStore, useUserStore } from "../../hooks/use-stores";
+import { urlParams } from "../../utilities/url-params";
 import { ToolbarComponent, ToolbarConfig } from "../toolbar";
 import { EditableToolApiInterfaceRef, EditableToolApiInterfaceRefContext } from "../tools/tool-api";
 import { DocumentModelType } from "../../models/document/document";
@@ -63,7 +64,6 @@ const DocumentCanvas: React.FC<IDocumentCanvasProps> = props => {
         : <OneUpCanvas document={document} readOnly={readOnly} />}
     </div>
   );
-
 };
 
 export interface IProps {
@@ -72,12 +72,13 @@ export interface IProps {
   document: DocumentModelType;
   toolbar?: ToolbarConfig;
   readOnly?: boolean;
-  documentSelectedForComment?: boolean;
 }
 export const EditableDocumentContent: React.FC<IProps> = props => {
-  const { mode, isPrimary, document, toolbar, readOnly, documentSelectedForComment } = props;
+  const { mode, isPrimary, document, toolbar, readOnly } = props;
 
   const documentContext = useDocumentContext(document);
+  const ui = useUIStore();
+  const { isNetworkedTeacher } = useUserStore();
 
   // set by the canvas and used by the toolbar
   const editableToolApiInterfaceRef: EditableToolApiInterfaceRef = useRef(null);
@@ -85,6 +86,8 @@ export const EditableDocumentContent: React.FC<IProps> = props => {
   const isReadOnly = !isPrimary || readOnly || document.isPublished;
   const isShowingToolbar = !!toolbar && !isReadOnly;
   const showToolbarClass = isShowingToolbar ? "show-toolbar" : "hide-toolbar";
+  const isChatEnabled = isNetworkedTeacher && urlParams.chat;
+  const documentSelectedForComment = isChatEnabled && ui.showChatPanel && ui.selectedTileIds.length === 0;
   const editableDocContentClass = classNames("editable-document-content", showToolbarClass,
                                              {"comment-select" : documentSelectedForComment});
   return (

--- a/src/components/navigation/document-tab-content.sass
+++ b/src/components/navigation/document-tab-content.sass
@@ -70,7 +70,6 @@ $title-margin: 2px
       position: static
       height: 100%
       .comment-select
-        background-color: $comment-select-green
         .tool-tile.readonly
           border: 2px solid $comment-select-green
           &.selected

--- a/src/components/navigation/document-tab-content.tsx
+++ b/src/components/navigation/document-tab-content.tsx
@@ -25,6 +25,7 @@ export const DocumentTabContent: React.FC<IProps> = ({ tabSpec }) => {
   const handleTabClick = (title: string, type: string) => {
     setReferenceDocument(undefined);
     ui.updateFocusDocument();
+    ui.setSelectedTile();
     Logger.log(LogEventName.SHOW_TAB_SECTION, {
       tab_section_name: title,
       tab_section_type: type

--- a/src/components/navigation/document-tab-content.tsx
+++ b/src/components/navigation/document-tab-content.tsx
@@ -14,10 +14,9 @@ import "./document-tab-content.sass";
 
 interface IProps {
   tabSpec: NavTabSpec;
-  isChatOpen?: boolean;
 }
 
-export const DocumentTabContent: React.FC<IProps> = ({ tabSpec, isChatOpen }) => {
+export const DocumentTabContent: React.FC<IProps> = ({ tabSpec }) => {
   const [referenceDocument, setReferenceDocument] = useState<DocumentModelType>();
   const appConfigStore = useAppConfigStore();
   const problemStore = useProblemStore();
@@ -75,7 +74,6 @@ export const DocumentTabContent: React.FC<IProps> = ({ tabSpec, isChatOpen }) =>
         isPrimary={false}
         document={referenceDocument}
         readOnly={true}
-        documentSelectedForComment={isChatOpen}
       />
     </div>;
 
@@ -87,7 +85,6 @@ export const DocumentTabContent: React.FC<IProps> = ({ tabSpec, isChatOpen }) =>
         onTabClick={handleTabClick}
         onSelectDocument={handleSelectDocument}
         documentView={documentView}
-        isChatOpen={isChatOpen}
       />
     </div>
   );

--- a/src/components/navigation/nav-tab-panel.tsx
+++ b/src/components/navigation/nav-tab-panel.tsx
@@ -57,7 +57,7 @@ export class NavTabPanel extends BaseComponent<IProps, IState> {
     const resourceWidthStyle = {width: resourceWidth};
     const isChatEnabled = user.isNetworkedTeacher && urlParams.chat;
     const openChatPanel = isChatEnabled && showChatPanel;
-    const focusTileId = selectedTileIds?.length === 1 ? selectedTileIds[0]: undefined;
+    const focusTileId = selectedTileIds?.length === 1 ? selectedTileIds[0] : undefined;
 
     return (
       <div className={`resource-and-chat-panel ${isResourceExpanded ? "shown" : ""}`} style={resourceWidthStyle}>

--- a/src/components/navigation/nav-tab-panel.tsx
+++ b/src/components/navigation/nav-tab-panel.tsx
@@ -28,7 +28,6 @@ interface IProps extends IBaseProps {
 
 interface IState {
   tabLoadAllowed: { [tab: number]: boolean };
-  showChatColumn: boolean;
 }
 
 @inject("stores")
@@ -40,13 +39,13 @@ export class NavTabPanel extends BaseComponent<IProps, IState> {
     super(props);
     this.state = {
       tabLoadAllowed: {},
-      showChatColumn: false,
     };
   }
 
   public render() {
     const { tabs, isResourceExpanded } = this.props;
-    const { ui: { activeNavTab, dividerPosition, focusDocument }, user, supports } = this.stores;
+    const { ui: { activeNavTab, dividerPosition, focusDocument, showChatPanel },
+            user, supports } = this.stores;
     const selectedTabIndex = tabs?.findIndex(t => t.tab === activeNavTab);
     const resizePanelWidth = 4;
     const collapseTabWidth = 44;
@@ -57,7 +56,7 @@ export class NavTabPanel extends BaseComponent<IProps, IState> {
                               : `calc(${dividerPosition}% - ${resizePanelWidth}px)`;
     const resourceWidthStyle = {width: resourceWidth};
     const isChatEnabled = user.isNetworkedTeacher && urlParams.chat;
-    const showChatPanel = isChatEnabled && this.state.showChatColumn;
+    const openChatPanel = isChatEnabled && showChatPanel;
 
     return (
       <div className={`resource-and-chat-panel ${isResourceExpanded ? "shown" : ""}`} style={resourceWidthStyle}>
@@ -80,12 +79,12 @@ export class NavTabPanel extends BaseComponent<IProps, IState> {
                 }
               </TabList>
               { isChatEnabled
-                  ? !showChatPanel &&
+                  ? !openChatPanel &&
                     <div className={`chat-panel-toggle themed ${activeNavTab}`}>
                       <NewCommentsBadge documentKey={focusDocument} />
                       <ChatIcon
                         className={`chat-button ${activeNavTab}`}
-                        onClick={() => this.handleShowChatColumn(true)}
+                        onClick={this.handleShowChatColumn}
                       />
                     </div>
                   : <button className="close-button" onClick={this.handleCloseResources}/>
@@ -128,7 +127,7 @@ export class NavTabPanel extends BaseComponent<IProps, IState> {
 
   private renderDocuments = (tabSpec: NavTabSpec) => {
     return (
-      <DocumentTabContent tabSpec={tabSpec} isChatOpen={this.state.showChatColumn}/>
+      <DocumentTabContent tabSpec={tabSpec} />
     );
   }
 
@@ -137,8 +136,7 @@ export class NavTabPanel extends BaseComponent<IProps, IState> {
     return (
       <ProblemTabContent
         sections={sections}
-        showSolutionsSwitch={isTeacher}
-        isChatOpen={this.state.showChatColumn}/>
+        showSolutionsSwitch={isTeacher}/>
     );
   }
 
@@ -149,8 +147,7 @@ export class NavTabPanel extends BaseComponent<IProps, IState> {
       <ProblemTabContent
         context={ENavTab.kTeacherGuide}
         sections={sections}
-        showSolutionsSwitch={false}
-        isChatOpen={this.state.showChatColumn}/>
+        showSolutionsSwitch={false}/>
     );
   }
 
@@ -176,8 +173,9 @@ export class NavTabPanel extends BaseComponent<IProps, IState> {
     ui.setActiveStudentGroup(groupId);
   }
 
-  private handleShowChatColumn = (show: boolean) => {
-    this.setState({showChatColumn: show});
+  private handleShowChatColumn = () => {
+    const { ui } = this.stores;
+    ui.toggleShowChatPanel(!ui.showChatPanel);
   }
 
   private handleCloseResources = () => {

--- a/src/components/navigation/nav-tab-panel.tsx
+++ b/src/components/navigation/nav-tab-panel.tsx
@@ -44,7 +44,7 @@ export class NavTabPanel extends BaseComponent<IProps, IState> {
 
   public render() {
     const { tabs, isResourceExpanded } = this.props;
-    const { ui: { activeNavTab, dividerPosition, focusDocument, showChatPanel },
+    const { ui: { activeNavTab, dividerPosition, focusDocument, showChatPanel, selectedTileIds },
             user, supports } = this.stores;
     const selectedTabIndex = tabs?.findIndex(t => t.tab === activeNavTab);
     const resizePanelWidth = 4;
@@ -57,6 +57,7 @@ export class NavTabPanel extends BaseComponent<IProps, IState> {
     const resourceWidthStyle = {width: resourceWidth};
     const isChatEnabled = user.isNetworkedTeacher && urlParams.chat;
     const openChatPanel = isChatEnabled && showChatPanel;
+    const focusTileId = selectedTileIds?.length === 1 ? selectedTileIds[0]: undefined;
 
     return (
       <div className={`resource-and-chat-panel ${isResourceExpanded ? "shown" : ""}`} style={resourceWidthStyle}>
@@ -100,7 +101,7 @@ export class NavTabPanel extends BaseComponent<IProps, IState> {
             }
           </Tabs>
           {showChatPanel &&
-            <ChatPanel user={user} activeNavTab={activeNavTab} focusDocument={focusDocument}
+            <ChatPanel user={user} activeNavTab={activeNavTab} focusDocument={focusDocument} focusTileId={focusTileId}
                         onCloseChatPanel={this.handleShowChatColumn} />}
         </div>
       </div>

--- a/src/components/navigation/problem-panel.tsx
+++ b/src/components/navigation/problem-panel.tsx
@@ -9,7 +9,6 @@ import "./problem-panel.sass";
 
 interface IProps extends IBaseProps {
   section?: SectionModelType | null;
-  isChatOpen?: boolean;
 }
 
 @inject("stores")
@@ -36,9 +35,8 @@ export class ProblemPanelComponent extends BaseComponent<IProps> {
   }
 
   private renderContent(content: DocumentContentModelType) {
-    const { isChatOpen } = this.props;
     return (
-      <CanvasComponent context="left-nav" readOnly={true} content={content} documentSelectedForComment={isChatOpen}/>
+      <CanvasComponent context="left-nav" readOnly={true} content={content}/>
     );
   }
 

--- a/src/components/navigation/problem-tab-content.tsx
+++ b/src/components/navigation/problem-tab-content.tsx
@@ -14,16 +14,15 @@ interface IProps {
   context?: string;   // ENavTab.kTeacherGuide for teacher guide, blank otherwise
   sections: SectionModelType[];
   showSolutionsSwitch: boolean;
-  isChatOpen?: boolean
 }
 
 export const ProblemTabContent: React.FC<IProps>
-  = observer(({ context, sections, showSolutionsSwitch, isChatOpen}: IProps) => {
+  = observer(({ context, sections, showSolutionsSwitch }: IProps) => {
   const { isTeacher } = useUserStore();
   const ui = useUIStore();
   const problemPath = useProblemPathWithFacet(context);
   const { showTeacherContent } = ui;
-  const chatBorder = isChatOpen ? "chat-open" : "";
+  const chatBorder = ui.showChatPanel ? "chat-open" : "";
 
   const handleTabClick = (titleArgButReallyType: string, typeArgButReallyTitle: string) => {
     // TODO: this function has its argument names reversed (see caller for details.)
@@ -46,7 +45,7 @@ export const ProblemTabContent: React.FC<IProps>
     <Tabs className={classNames("problem-tabs", context, chatBorder)} selectedTabClassName="selected"
           data-focus-document={problemPath}>
       <div className="tab-header-row">
-        <TabList className={classNames("tab-list", {"chat-open" : isChatOpen})}>
+        <TabList className={classNames("tab-list", {"chat-open" : ui.showChatPanel})}>
           {sections.map((section) => {
             const sectionTitle = getSectionTitle(section.type);
             return (
@@ -63,7 +62,7 @@ export const ProblemTabContent: React.FC<IProps>
       {sections.map((section) => {
         return (
           <TabPanel key={`section-${section.type}`} data-focus-section={section.type}>
-            <ProblemPanelComponent section={section} key={`section-${section.type}`} isChatOpen={isChatOpen}/>
+            <ProblemPanelComponent section={section} key={`section-${section.type}`} />
           </TabPanel>
         );
       })}

--- a/src/components/navigation/problem-tab-content.tsx
+++ b/src/components/navigation/problem-tab-content.tsx
@@ -32,7 +32,7 @@ export const ProblemTabContent: React.FC<IProps>
       tab_section_name: titleArgButReallyType,
       tab_section_type: typeArgButReallyTitle
     });
-
+    ui.setSelectedTile();
     ui.updateFocusDocument();
 };
 

--- a/src/components/tools/tool-tile.sass
+++ b/src/components/tools/tool-tile.sass
@@ -81,5 +81,5 @@
     &.readonly
       border: $half-border-width solid $charcoal-light-2
 
-  &.selected-for-comment
+  &.selected-for-comment.readonly
     background-color: $comment-select-green

--- a/src/components/tools/tool-tile.sass
+++ b/src/components/tools/tool-tile.sass
@@ -80,3 +80,6 @@
 
     &.readonly
       border: $half-border-width solid $charcoal-light-2
+
+  &.selected-for-comment
+    background-color: $comment-select-green

--- a/src/components/tools/tool-tile.tsx
+++ b/src/components/tools/tool-tile.tsx
@@ -208,11 +208,13 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
     const { ToolComponent, toolTileClass } = kToolComponentMap[model.content.type];
     const isPlaceholderTile = ToolComponent === PlaceholderToolComponent;
     const isTileSelected = ui.isSelectedTile(model);
+    const tileSelectedForComment = isTileSelected && ui.showChatPanel;
     const classes = classNames("tool-tile", model.display, toolTileClass, {
                       placeholder: isPlaceholderTile,
                       readonly: readOnly,
                       hovered: this.state.hoverTile,
-                      selected: isTileSelected });
+                      selected: isTileSelected ,
+                      "selected-for-comment": tileSelectedForComment});
     const isDraggable = !isPlaceholderTile && !appConfig.disableTileDrags;
     const dragTileButton = isDraggable &&
                             <DragTileButton divRef={elt => this.dragElement = elt}

--- a/src/models/stores/ui.ts
+++ b/src/models/stores/ui.ts
@@ -34,6 +34,7 @@ export const UIModel = types
     showDemo: false,
     showDemoCreator: false,
     showTeacherContent: true,
+    showChatPanel: false,
     dialog: types.maybe(UIDialogModel),
     // document key or section path for reference (left) document
     focusDocument: types.maybe(types.string),
@@ -129,6 +130,9 @@ export const UIModel = types
       },
       toggleShowTeacherContent(show: boolean) {
         self.showTeacherContent = show;
+      },
+      toggleShowChatPanel(show:boolean) {
+        self.showChatPanel = show;
       },
       setError(error: string) {
         self.error = error ? error.toString() : error;


### PR DESCRIPTION
Adds ability to select a tile for comment. 
When user selects a tile with chat panel open, user can comment on selected tile. 
When user changes tile selection, chat panel updates to show comments for the new selection.
When user deselects tile, document is selected by default, and chat panel updates to show document comments only.
When user has selected a tile, and changes to a different tab, the tile is deselected, and the currently selected tab document is selected.
Moved chat panel state to ui stores.