### PR TITLE
Ensure existence of document before requesting comments for it [#179540693]

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -10,6 +10,7 @@
     "deploy:all": "firebase deploy --only functions",
     "deploy:getImageData": "firebase deploy --only functions:getImageData",
     "deploy:postDocumentComment": "firebase deploy --only functions:postDocumentComment_v1",
+    "deploy:validateCommentableDocument": "firebase deploy --only functions:validateCommentableDocument_v1",
     "logs": "firebase functions:log",
     "test": "ts-node node_modules/jest/bin/jest.js --detectOpenHandles"
   },

--- a/functions/package.json
+++ b/functions/package.json
@@ -4,6 +4,7 @@
     "lint": "eslint \"src/**/*\"",
     "build": "./node_modules/typescript/bin/tsc",
     "serve": "npm run build && firebase emulators:start",
+    "serve:functions": "npm run build && firebase emulators:start --only functions",
     "shell": "npm run build && firebase functions:shell",
     "start": "npm run shell",
     "deploy:all": "firebase deploy --only functions",

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,8 +1,8 @@
-
 import * as admin from "firebase-admin";
 import * as functions from "firebase-functions";
 import { PortalFirebaseJWTClaims } from "./portal-types";
 import { postDocumentComment } from "./post-document-comment";
+import { validateCommentableDocument } from "./validate-commentable-document";
 
 // set to true to enable additional logging
 const DEBUG = false;
@@ -33,6 +33,14 @@ const firestore = app.firestore();
 
 // contents of context.auth?.token in firebase callable functions
 type IDecodedIdToken = admin.auth.DecodedIdToken & Partial<PortalFirebaseJWTClaims>;
+
+/*
+ * validateCommentableDocument
+ *
+ * Checks whether a specific commentable document exists in firestore and creates it if necessary.
+ * The _v1 suffix allows us to version the API if necessary moving forward.
+ */
+export const validateCommentableDocument_v1 = functions.https.onCall(validateCommentableDocument);
 
 /*
  * postDocumentComment

--- a/functions/src/shared.ts
+++ b/functions/src/shared.ts
@@ -136,8 +136,12 @@ export interface IClientCommentParams {
   content: string;    // plain text for now; potentially html if we need rich text
 }
 
-export interface IPostDocumentCommentParams extends IFirebaseFunctionBaseParams {
+export interface ICommentableDocumentParams extends IFirebaseFunctionBaseParams {
   document: IDocumentMetadata | ICurriculumMetadata;
+}
+export type ICommentableDocumentUnionParams = ICommentableDocumentParams | IFirebaseFunctionWarmUpParams;
+
+export interface IPostDocumentCommentParams extends ICommentableDocumentParams {
   comment: IClientCommentParams;
 }
 export type IPostDocumentCommentUnionParams = IPostDocumentCommentParams | IFirebaseFunctionWarmUpParams;

--- a/functions/src/validate-commentable-document.ts
+++ b/functions/src/validate-commentable-document.ts
@@ -1,0 +1,74 @@
+import * as admin from "firebase-admin";
+import * as functions from "firebase-functions";
+import {
+  ICommentableDocumentParams,
+  ICommentableDocumentUnionParams, isCurriculumMetadata, isDocumentMetadata, isWarmUpParams, networkDocumentKey
+} from "./shared";
+import { validateUserContext } from "./user-context";
+
+// update this when deploying updates to this function
+const version = "1.0.0";
+
+export async function validateCommentableDocument(
+                        params?: ICommentableDocumentUnionParams,
+                        callableContext?: functions.https.CallableContext) {
+  if (isWarmUpParams(params)) return { version };
+
+  const { context, document } = params || {};
+  const { isValid, uid, firestoreRoot } = validateUserContext(context, callableContext?.auth);
+  if (!isValid || !context?.classHash || !uid) {
+    throw new functions.https.HttpsError("invalid-argument", "The provided user context is not valid.");
+  };
+
+  if (!context?.name || !context.teachers?.length) {
+    throw new functions.https.HttpsError("invalid-argument", "Some required teacher information was not provided.");
+  }
+
+  if (!isDocumentMetadata(document) && !isCurriculumMetadata(document)) {
+    throw new functions.https.HttpsError("invalid-argument", "Some required document information was not provided.");
+  }
+
+  const result = await createCommentableDocumentIfNecessary({ context, document, firestoreRoot, uid });
+
+  return { version, id: result?.ref.id, data: result?.data };
+};
+
+export interface ICreateCommentableDocumentParams extends ICommentableDocumentParams {
+  firestoreRoot: string;
+  uid: string;
+}
+export async function createCommentableDocumentIfNecessary(params?: ICreateCommentableDocumentParams) {
+  const { context, document, firestoreRoot, uid } = params || {};
+  if (!context || !document || !firestoreRoot || !uid) return null;
+  const firestore = admin.firestore();
+  const kCollection = isCurriculumMetadata(document) ? "curriculum" : "documents";
+  const kBaseDocumentKey = isCurriculumMetadata(document) ? document.path : document.key;
+  const kDocumentKey = networkDocumentKey(uid, kBaseDocumentKey, context.network);
+  const kDocumentDocPath = `${firestoreRoot}/${kCollection}/${kDocumentKey}`;
+  const documentRef = firestore.doc(kDocumentDocPath);
+
+  // see if the document is already in firestore
+  const docReadResponse = await documentRef.get();
+  let documentContent = docReadResponse.data();
+  if (!documentContent) {
+    // convert empty/falsy networks to null
+    const network = context.network || null;
+    // if not already present, create it
+    documentContent = isDocumentMetadata(document)
+                        ? {
+                          // we could pull some of the document metadata from the realtime database,
+                          // but for now we trust the client to provide valid values.
+                          ...document,
+                          context_id: context.classHash,
+                          teachers: context.teachers,
+                          network
+                        }
+                        : {
+                          ...document,
+                          uid,
+                          network
+                        };
+    await documentRef.set(documentContent);
+  }
+  return { ref: documentRef, data: documentContent };
+}

--- a/functions/test/validate-commentable-document.test.ts
+++ b/functions/test/validate-commentable-document.test.ts
@@ -1,0 +1,211 @@
+import {
+  apps, clearFirestoreData, initializeAdminApp, useEmulators
+} from "@firebase/rules-unit-testing";
+import {
+  ICommentableDocumentParams, ICurriculumMetadata, IDocumentMetadata, isCurriculumMetadata,
+  IUserContext, networkDocumentKey
+} from "../src/shared";
+import { validateCommentableDocument } from "../src/validate-commentable-document";
+import {
+  kCanonicalPortal, kCreatedAt, kCurriculumKey, kDemoName, kDocumentKey, kDocumentType, kFirebaseUserId,
+  kTeacherNetwork, kUserId, specAuth, specUserContext
+} from "./test-utils";
+
+useEmulators({
+  database: { host: "localhost", port: 9000 },
+  firestore: { host: "localhost", port: 8088 }
+});
+
+// Considerable trial and error was required to come up with this mock
+// Initialize the mock admin app using initializeAdminApp from @firebase/rules-unit-testing
+const kCLUEFirebaseProjectId = "collaborative-learning-ec215";
+const mockAdmin = initializeAdminApp({ projectId: kCLUEFirebaseProjectId });
+// Mock the actual "firebase-admin" module so that clients get our mock instead
+jest.mock('firebase-admin', () => {
+  const actualAdmin = jest.requireActual("firebase-admin");
+  // These lines are patterned after code in the "firebase-admin" module which attaches namespace
+  // properties from the original namespaces (e.g. Timestamp) to the returned functions.
+  // This allows admin.firestore() to be used as a function that returns the firestore instance
+  // as well as a namespace (e.g admin.firestore.Timestamp). The mock is replacing the function
+  // but attaching the original namespace contents.
+  const mockDatabase = () => mockAdmin.database();
+  Object.assign(mockDatabase, actualAdmin.database);
+  const mockFirestore = () => mockAdmin.firestore();
+  Object.assign(mockFirestore, actualAdmin.firestore);
+  return {
+    // We pass through calls to initializeApp to the original implementation so that the call
+    // to initializeAdminApp above (which calls initializeApp under the hood) will succeed.
+    initializeApp: (...args: any[]) => actualAdmin.initializeApp(...args),
+    // Mock the APIs used by the cloud functions
+    database: mockDatabase,
+    firestore: mockFirestore
+  };
+});
+
+const dbAdmin = mockAdmin.firestore();
+
+const authWithNoClaims = { auth: { uid: kFirebaseUserId, token: {} } };
+const authWithTeacherClaims = { auth: specAuth({ token: { user_type: "teacher" } }) };
+
+export interface IPartialValidateDocumentParams {
+  context?: Partial<IUserContext>,
+  document?: Partial<IDocumentMetadata | ICurriculumMetadata>,
+  firestoreRoot?: string;
+  uid?: string;
+}
+
+const specValidateDocument = (overrides?: IPartialValidateDocumentParams): ICommentableDocumentParams => {
+  return {
+    context: specUserContext(overrides?.context),
+    document: { uid: kUserId, type: kDocumentType, key: kDocumentKey, createdAt: kCreatedAt, ...overrides?.document }
+  };
+};
+
+const specValidateCurriculum = (overrides?: IPartialValidateDocumentParams): ICommentableDocumentParams => {
+  return {
+    context: specUserContext(overrides?.context),
+    document: { unit: "abc", problem: "1.2", section: "introduction", path: kCurriculumKey, ...overrides?.document }
+  };
+};
+
+const kExpectedAssertions = 8;
+
+async function testValidateDocument(documentPath : string, authContext: any, context?: Partial<IUserContext>) {
+  // can validate a document that doesn't yet exist in Firestore
+  const isCurriculumComment = documentPath.includes("curriculum");
+  const docKey = isCurriculumComment ? kCurriculumKey : kDocumentKey;
+  expect(documentPath).toContain(networkDocumentKey(kUserId, docKey, kTeacherNetwork));
+  const docParams = isCurriculumComment
+                        ? specValidateCurriculum({ context })
+                        : specValidateDocument({ context })
+  const validateResult = await validateCommentableDocument(docParams, authContext);
+  expect(validateResult).toHaveProperty("id");
+  expect(validateResult).toHaveProperty("version");
+  expect(validateResult).toHaveProperty("data");
+
+  // the document should be at the expected path
+  const docResult = await dbAdmin.doc(documentPath).get();
+  const docData = isCurriculumComment
+                    ? docResult.data() as ICurriculumMetadata
+                    : docResult.data() as IDocumentMetadata;
+  if (isCurriculumMetadata(docData)) {
+    // not part of metadata, but added by firebase function
+    expect((docData as any).uid).toBe(kUserId);
+  }
+  else {
+    expect(docData.uid).toBe(kUserId);
+  }
+
+  // can validate a document that already exists
+  const validate2Result = await validateCommentableDocument(docParams, authContext);
+  expect(validate2Result).toHaveProperty("id");
+  expect(validate2Result).toHaveProperty("version");
+  expect(validateResult).toHaveProperty("data");
+}
+
+describe("validateCommentableDocument", () => {
+  beforeEach(async () => {
+    await clearFirestoreData({ projectId: kCLUEFirebaseProjectId });
+  });
+
+  afterAll(async () => {
+    // comment out the next line to observe the firebase contents in the visual emulator at the end of the tests
+    await clearFirestoreData({ projectId: kCLUEFirebaseProjectId });
+    // https://firebase.google.com/docs/firestore/security/test-rules-emulator#run_local_tests
+    await Promise.all(apps().map(app => app.delete()));
+  });
+
+  it("should fail without sufficient arguments", async () => {
+    await expect(validateCommentableDocument()).rejects.toBeDefined();
+  });
+
+  it("should succeed when asked to warm up", async () => {
+    await expect(validateCommentableDocument({ warmUp: true })).resolves.toHaveProperty("version");
+  });
+
+  it("should fail without valid arguments", async () => {
+    await expect(validateCommentableDocument({} as any, {} as any)).rejects.toBeDefined();
+  });
+
+  it("should fail without valid teacher name", async () => {
+    await expect(validateCommentableDocument(specValidateDocument({
+      context: { name: "", teachers: [kUserId], network: "" }
+    }), authWithTeacherClaims as any)).rejects.toBeDefined();
+  });
+
+  it("should fail without valid teacher list", async () => {
+    await expect(validateCommentableDocument(specValidateDocument({
+      context: { teachers: [] }
+    }), authWithTeacherClaims as any)).rejects.toBeDefined();
+  });
+
+  it("should fail without valid document uid", async () => {
+    await expect(validateCommentableDocument(specValidateDocument({
+      document: { uid: "", type: kDocumentType, key: kDocumentKey, createdAt: Date.now() }
+    }), authWithTeacherClaims as any)).rejects.toBeDefined();
+  });
+
+  it("should fail without valid document type", async () => {
+    await expect(validateCommentableDocument(specValidateDocument({
+      document: { uid: kUserId, type: "", key: kDocumentKey, createdAt: Date.now() }
+    }), authWithTeacherClaims as any)).rejects.toBeDefined();
+  });
+
+  it("should fail without valid document key", async () => {
+    await expect(validateCommentableDocument(specValidateDocument({
+      document: { uid: kUserId, type: kDocumentType, key: "", createdAt: Date.now() }
+    }), authWithTeacherClaims as any)).rejects.toBeDefined();
+  });
+
+  it("should fail without valid claims", async () => {
+    await expect(validateCommentableDocument(specValidateDocument(), authWithNoClaims as any)).rejects.toBeDefined();
+  });
+
+  it("should validate documents for authenticated users", async () => {
+    expect.assertions(kExpectedAssertions);
+
+    const docKey = networkDocumentKey(kUserId, kDocumentKey, kTeacherNetwork);
+    const documentCollectionPath = `authed/${kCanonicalPortal}/documents/${docKey}`;
+    await testValidateDocument(documentCollectionPath, authWithTeacherClaims);
+  });
+
+  it("should validate documents for demo users", async () => {
+    expect.assertions(kExpectedAssertions);
+
+    const docKey = networkDocumentKey(kUserId, kDocumentKey, kTeacherNetwork);
+    const documentCollectionPath = `demo/${kDemoName}/documents/${docKey}`;
+    await testValidateDocument(documentCollectionPath, authWithNoClaims, { appMode: "demo" });
+  });
+
+  it("should validate documents for qa users", async () => {
+    expect.assertions(kExpectedAssertions);
+
+    const docKey = networkDocumentKey(kUserId, kDocumentKey, kTeacherNetwork);
+    const documentCollectionPath = `qa/${kFirebaseUserId}/documents/${docKey}`;
+    await testValidateDocument(documentCollectionPath, authWithNoClaims, { appMode: "qa" });
+  });
+
+  it("should validate curriculum documents for authenticated users", async () => {
+    expect.assertions(kExpectedAssertions);
+
+    const docKey = networkDocumentKey(kUserId, kCurriculumKey, kTeacherNetwork);
+    const documentCollectionPath = `authed/${kCanonicalPortal}/curriculum/${docKey}`;
+    await testValidateDocument(documentCollectionPath, authWithTeacherClaims);
+  });
+
+  it("should validate curriculum documents for demo users", async () => {
+    expect.assertions(kExpectedAssertions);
+
+    const docKey = networkDocumentKey(kUserId, kCurriculumKey, kTeacherNetwork);
+    const documentCollectionPath = `demo/${kDemoName}/curriculum/${docKey}`;
+    await testValidateDocument(documentCollectionPath, authWithNoClaims, { appMode: "demo" });
+  });
+
+  it("should validate curriculum documents for qa users", async () => {
+    expect.assertions(kExpectedAssertions);
+
+    const docKey = networkDocumentKey(kUserId, kCurriculumKey, kTeacherNetwork);
+    const documentCollectionPath = `qa/${kFirebaseUserId}/curriculum/${docKey}`;
+    await testValidateDocument(documentCollectionPath, authWithNoClaims, { appMode: "qa" });
+  });
+});

--- a/src/lib/firestore-schema.ts
+++ b/src/lib/firestore-schema.ts
@@ -54,7 +54,7 @@ type CommentsCollection = FSCollection<CommentDocument>;
  * Since curriculum "documents" are available to anyone, the only access restriction is that
  * comments can only be viewed by teachers in the same network.
  */
-interface CurriculumDocument {
+export interface CurriculumDocument {
   uid: string;                        // uid of teacher making first comment, i.e. adding the record
   unit: string;                       // unit code, e.g. "sas", "msa", etc.
   facet?: string;                     // empty for regular curriculum; "guide" for teacher guide, etc.
@@ -78,7 +78,7 @@ type CurriculumCollection = FSCollection<CurriculumDocument>;
  * Networked access will be mediated by Firestore security rules which can check whether the requesting user
  * is in the appropriate network.
  */
-interface DocumentDocument {
+export interface DocumentDocument {
   context_id: string;                 // class hash for document context
   teachers: string[];                 // [denormalized] uids of teachers of class
   network?: string;                   // network of teacher commenting on document


### PR DESCRIPTION
Previously, we only created the entry for a given document in Firestore when the first comment was added. This seemed to make sense since there's currently no other reason to have the document entry beyond providing a place to store comments. Unfortunately, when attempting to read the comments for a document this led to an attempt to add Firestore listeners to a non-existent document, which Firestore didn't take too kindly to.

The new approach is to create the document entry in Firestore (if it doesn't already exist) before the first read attempt, so that when the time comes to install the comment listener the document already exists. To accomplish this, there is a new Firebase Function, `validateCommentableDocument`, which checks whether the specified document exists in Firestore and creates it if it's not already there.

We then use ReactQuery's `useQuery` hook to attempt to read the document and the `useMutation` hook to create the document if necessary. The mutation uses the `validateCommentableDocument` function under the hood. Since previously document creation was handled by the `postDocumentComment` function, the code for creating the document was separated so that it can be shared by both functions.