### PR TITLE
Adds logic to hide group chooser when in preview mode

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -168,7 +168,10 @@ export class AppComponent extends BaseComponent<IProps, IState> {
           // use userId as groupId
           db.joinGroup(user.id);
         }
-        else {
+        //only show the group chooser if the logged in user is a student with no group
+        //right now the only difference between the preview URL and the student URL is that the
+        //student url has the `learner` query param, and a token.
+        else if (urlParams === "learner") {
           return this.renderApp(<GroupChooserComponent />);
         }
       }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,7 +26,8 @@ const appConfig = AppConfigModel.create(appConfigSpec);
 
 const initializeApp = async () => {
   const host = window.location.host.split(":")[0];
-  const appMode = getAppMode(urlParams.appMode, urlParams.token, host);
+  const inPreviewMode = !urlParams.appMode && !urlParams.token && !!urlParams.domain && !!urlParams.domain_uid;
+  const appMode = getAppMode(urlParams.appMode, urlParams.token, host, inPreviewMode);
   const appVersion = PackageJson.version;
 
   const user = UserModel.create();
@@ -35,7 +36,7 @@ const initializeApp = async () => {
   const problemOrdinal = urlParams.problem || appConfigSpec.defaultProblemOrdinal;
   const showDemoCreator = urlParams.demo;
   const demoName = urlParams.demoName;
-
+  
   const stores = createStores({ appMode, appVersion, appConfig, user, showDemoCreator, demoName });
 
   await setUnitAndProblem(stores, unitId, problemOrdinal);
@@ -46,6 +47,9 @@ const initializeApp = async () => {
 
   if (kEnableLivelinessChecking) {
     setLivelinessChecking("error");
+  }
+  if (inPreviewMode) {
+    stores.appConfig.setAutoAssignStudentsToIndividualGroups(true);
   }
 
   setPageTitle(stores);

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -109,10 +109,13 @@ export interface AuthQueryParams {
 // An explicitly set appMode takes priority
 // Otherwise, assume that local users are devs, unless a token is specified,
 // in which authentication is likely being tested
-export const getAppMode = (appModeParam?: AppMode, token?: string, host?: string) => {
+export const getAppMode = (appModeParam?: AppMode, token?: string, host?: string, inPreviewMode?: boolean) => {
+  const isLocalhost = host === "localhost" || host === "127.0.0.1";
+  //For now, we will be treating Portal Preview mode as being in dev mode.
+  //Eventually, we may need to create a preview mode
   return appModeParam != null
            ? appModeParam
-           : (token == null && (host === "localhost" || host === "127.0.0.1") ? "dev" : "authed");
+           : (token == null && (isLocalhost || inPreviewMode) ? "dev" : "authed");
 };
 
 export const getPortalJWTWithBearerToken = (basePortalUrl: string, type: string, rawToken: string) => {

--- a/src/models/stores/app-config-model.ts
+++ b/src/models/stores/app-config-model.ts
@@ -94,7 +94,8 @@ export const AppConfigModel = types
     },
     getNavTabSpec(tabId: ENavTab): NavTabSpec | undefined {
       return self.navTabs.tabSpecs.find(tab => tabId === tab.tab);
-    }
+    },
+
   }))
   .views(self => ({
     getUnitBasePath(unitId: string) {
@@ -105,6 +106,11 @@ export const AppConfigModel = types
         parts.splice(parts.length - 1, 1);
       }
       return parts.join("/");
+    }
+  }))
+  .actions(self => ({
+    setAutoAssignStudentsToIndividualGroups(auto: boolean) {
+      self.autoAssignStudentsToIndividualGroups = auto;
     }
   }));
 export type AppConfigModelType = Instance<typeof AppConfigModel>;


### PR DESCRIPTION
As a logged in teacher, I can preview that CLUE activity but it presents me with the group chooser. 
This skips showing the group chooser if user is not a logged in student.
Currently the preview URL looks like this: 
`https://collaborative-learning.concord.org/branch/master/?unit=msa&problem=4.3&domain=https%3A%2F%2Flearn.staging.concord.org%2F&domain_uid=218`
The student URL look like this:
`https://collaborative-learning.concord.org/branch/master/?unit=msa&problem=4.3&learner=2243&token=xxxxxxxxxxxxxxxxxxxx&domain=https://learn.staging.concord.org/&domain_uid=446.
Since one of the differences is the `learner` query param, we check to see if the query param is present to show the group chooser.