### PR TITLE
Eliminate `any` from delete comment code

### DIFF
--- a/src/components/chat/comment-card.test.tsx
+++ b/src/components/chat/comment-card.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
 import { ModalProvider } from "react-modal-hook";
+import { WithId } from "../../hooks/firestore-hooks";
 import { CommentDocument } from "../../lib/firestore-schema";
 import { UserModelType } from "../../models/stores/user";
 import { CommentCard } from "./comment-card";
@@ -27,7 +28,7 @@ describe("CommentCard", () => {
     expect(screen.getByTestId("comment-card-header")).toBeInTheDocument();
   });
   it("should show the correct header icon when there are no comments", () => {
-    const postedComments: CommentDocument[] = [];
+    const postedComments: WithId<CommentDocument>[] = [];
     const commentThread = screen.queryByTestId("comment-thread");
     render((
       <ModalProvider>
@@ -39,8 +40,8 @@ describe("CommentCard", () => {
   });
   it("should show the correct header icon when there are comments and comment appears in card", () => {
     const testComment = "test comment";
-    const postedComments: CommentDocument[] = [
-            { uid: "1", name: "T1", createdAt: new Date(), content: testComment }
+    const postedComments: WithId<CommentDocument>[] = [
+            { id: "1", uid: "1", name: "T1", createdAt: new Date(), content: testComment }
           ];
     render((
       <ModalProvider>

--- a/src/components/chat/comment-card.tsx
+++ b/src/components/chat/comment-card.tsx
@@ -1,6 +1,7 @@
 import React, { useRef } from "react";
 import { UserModelType } from "../../models/stores/user";
 import { CommentTextBox } from "./comment-textbox";
+import { WithId } from "../../hooks/firestore-hooks";
 import { CommentDocument } from "../../lib/firestore-schema";
 import { getDisplayTimeDate } from "../../utilities/time";
 import { useCautionAlert } from "../utilities/use-caution-alert";
@@ -13,7 +14,7 @@ import "../themes.scss";
 interface IProps {
   user?: UserModelType;
   activeNavTab?: string;
-  postedComments?: CommentDocument[];
+  postedComments?: WithId<CommentDocument>[];
   onPostComment?: (comment: string) => void;
   onDeleteComment?: (commentId: string) => void;
 }
@@ -59,7 +60,7 @@ export const CommentCard: React.FC<IProps> = ({ activeNavTab, user, postedCommen
   return (
     <div className={`comment-card selected`} data-testid="comment-card">
       {renderThreadHeader()}
-      {postedComments?.map((comment: any, idx) => {
+      {postedComments?.map((comment, idx) => {
           const userInitialBackgroundColor = ["#f79999", "#ffc18a", "#99d099", "#ff9", "#b2b2ff", "#efa6ef"];
           const commenterInitial = comment.name.charAt(0);
           const userInitialBackgroundColorIndex = parseInt(comment.uid, 10) % 6;


### PR DESCRIPTION
@eireland:
- you were right that simply removing the `any` didn't work
- I was right back when we added the `id` to the returned snapshot in `useCollectionOrderedRealTimeQuery` when I said that we were going to have to fix the types somewhere down the road.

The issue is that the delete comment code relies on the fact that the query returns an `id` with each comment, but by declaring the `CommentCard` props to include `postedComments?: CommentDocument[]`, we were explicitly telling it that there would _not_ be an `id` property on the comments. The right fix is to have `useCollectionOrderedRealTimeQuery` type its return appropriately and then to change the type of `postedComments` to match.