### PR TITLE
Change thumbnail preview order of planning and problem docs

### DIFF
--- a/src/clue/app-config.json
+++ b/src/clue/app-config.json
@@ -118,6 +118,7 @@
             "dataTestHeader": "my-work-section-investigations",
             "dataTestItem": "my-work-list-items",
             "documentTypes": ["problem", "planning"],
+            "order": "original",
             "showStars": ["student", "teacher"]
           },
           {


### PR DESCRIPTION
This PR changes the order of the teacher document preview so that in the document thumbnails under My Work > Workspaces, the planning document is shown after the problem document.  Changes include:
- change section ordering in `app-config` file so original order is used and the planning document is shown after the problem document

PT Story: 
https://www.pivotaltracker.com/story/show/179427590

Deployed branch for testing:
https://collaborative-learning.concord.org/branch/planning-doc-order/?appMode=demo&demoName=CLUE&fakeClass=1&fakeUser=teacher:2&unit=sas&problem=0.1&chat

![image](https://user-images.githubusercontent.com/5126913/134411262-9189363c-556a-40e3-8024-36a3ea8b5291.png)
