### PR TITLE
Update firestore schema and security rules for classes and offerings

### DIFF
--- a/firebase-test/src/class-rules.test.ts
+++ b/firebase-test/src/class-rules.test.ts
@@ -1,0 +1,188 @@
+import firebase from "firebase";
+import {
+  adminWriteDoc, expectDeleteToFail, expectReadToFail, expectReadToSucceed, expectWriteToFail, expectWriteToSucceed,
+  genericAuth, initFirestore, network1, network2, prepareEachTest, studentAuth,
+  teacher2Auth, teacher2Id, teacher2Name, teacher3Auth, teacher3Id, teacher3Name, teacherAuth, teacherId, teacherName,
+  tearDownTests, thisClass
+} from "./setup-rules-tests";
+
+describe("Firestore security rules for offering (activity) documents", () => {
+
+  let db: firebase.firestore.Firestore;
+
+  beforeEach(async () => {
+    await prepareEachTest();
+
+    await adminWriteDoc(
+            `authed/myPortal/users/${teacherId}`,
+            { uid: teacherId, name: teacherName, type: "teacher", network: network1, networks: [network1] });
+    // teacher 2 is in same network as teacher 1, but a different class
+    await adminWriteDoc(
+            `authed/myPortal/users/${teacher2Id}`,
+            { uid: teacher2Id, name: teacher2Name, type: "teacher", network: network1, networks: [network1] });
+    // teacher 3 is in a different network than teachers 1 and 2
+    await adminWriteDoc(
+            `authed/myPortal/users/${teacher3Id}`,
+            { uid: teacher3Id, name: teacher3Name, type: "teacher", network: network2, networks: [network2] });
+  });
+
+  afterAll(async () => {
+    await tearDownTests();
+  });
+
+  function specClass(additions?: Record<string, string | string[]>, subtractions?: string[]) {
+    const offering: Record<string, string | string[]> = {
+            id: thisClass, name: "My Class", uri: "https://concord.org/class", context_id: thisClass,
+            teachers: [teacherId], network: network1, ...additions };
+    subtractions?.forEach(prop => delete offering[prop]);
+    return offering;
+  }
+
+  describe("class documents", () => {
+    const classKey = `${network1}_${thisClass}`;
+    const kClassDocPath = `authed/myPortal/classes/${classKey}`;
+
+    it("unauthenticated users can't read class documents", async () => {
+      db = initFirestore();
+      await expectReadToFail(db, kClassDocPath);
+    });
+
+    it("unauthenticated users can't write class documents", async () => {
+      db = initFirestore();
+      await expectWriteToFail(db, kClassDocPath, specClass());
+    });
+
+    it("authenticated generic users can't read class documents", async () => {
+      db = initFirestore(genericAuth);
+      await expectReadToFail(db, kClassDocPath);
+    });
+
+    it("authenticated generic users can't write class documents", async () => {
+      db = initFirestore(genericAuth);
+      await expectWriteToFail(db, kClassDocPath, specClass());
+    });
+
+    it("authenticated teachers can read their own class documents", async () => {
+      db = initFirestore(teacherAuth);
+      await adminWriteDoc(kClassDocPath, specClass());
+      await expectReadToSucceed(db, kClassDocPath);
+    });
+
+    it("authenticated teachers can read other class documents in the network", async () => {
+      db = initFirestore(teacher2Auth);
+      await adminWriteDoc(kClassDocPath, specClass());
+      await expectReadToSucceed(db, kClassDocPath);
+    });
+
+    it("authenticated teachers can't read other class documents from a different network", async () => {
+      db = initFirestore(teacher3Auth);
+      await adminWriteDoc(kClassDocPath, specClass());
+      await expectReadToFail(db, kClassDocPath);
+    });
+
+    it("authenticated teachers can write their own class documents", async () => {
+      db = initFirestore(teacherAuth);
+      await expectWriteToSucceed(db, kClassDocPath, specClass());
+    });
+
+    it("authenticated teachers can't write their own class documents without id", async () => {
+      db = initFirestore(teacherAuth);
+      await expectWriteToFail(db, kClassDocPath, specClass({}, ["id"]));
+    });
+
+    it("authenticated teachers can't write their own class documents without name", async () => {
+      db = initFirestore(teacherAuth);
+      await expectWriteToFail(db, kClassDocPath, specClass({}, ["name"]));
+    });
+
+    it("authenticated teachers can't write their own class documents without uri", async () => {
+      db = initFirestore(teacherAuth);
+      await expectWriteToFail(db, kClassDocPath, specClass({}, ["uri"]));
+    });
+
+    it("authenticated teachers can't write their own class documents without context_id", async () => {
+      db = initFirestore(teacherAuth);
+      await expectWriteToFail(db, kClassDocPath, specClass({}, ["context_id"]));
+    });
+
+    it("authenticated teachers can't write their own class documents without teachers", async () => {
+      db = initFirestore(teacherAuth);
+      await expectWriteToFail(db, kClassDocPath, specClass({}, ["teachers"]));
+    });
+
+    it("authenticated teachers can't write their own class documents if they're not one of the teachers", async () => {
+      db = initFirestore(teacherAuth);
+      await expectWriteToFail(db, kClassDocPath, specClass({ teachers: [teacher2Id] }));
+    });
+
+    it("authenticated teachers can't write their own class documents without network", async () => {
+      db = initFirestore(teacherAuth);
+      await expectWriteToFail(db, kClassDocPath, specClass({}, ["network"]));
+    });
+
+    it("authenticated teachers can update the name of their own class documents", async () => {
+      db = initFirestore(teacherAuth);
+      await adminWriteDoc(kClassDocPath, specClass());
+      await expectWriteToSucceed(db, kClassDocPath, specClass({ name: "Improved Class Name" }));
+    });
+
+    it("authenticated teachers can update the teachers of their own class documents", async () => {
+      db = initFirestore(teacherAuth);
+      await adminWriteDoc(kClassDocPath, specClass());
+      await expectWriteToSucceed(db, kClassDocPath, specClass({ teachers: [teacherId, teacher2Id] }));
+    });
+
+    it("authenticated teachers can't update the teachers of other teachers' class documents", async () => {
+      db = initFirestore(teacher2Auth);
+      await adminWriteDoc(kClassDocPath, specClass());
+      await expectWriteToFail(db, kClassDocPath, specClass({ teachers: [teacherId, teacher2Id] }));
+    });
+
+    it("authenticated teachers can't update the teachers of their own classes if they're no longer a teacher", async () => {
+      db = initFirestore(teacherAuth);
+      await adminWriteDoc(kClassDocPath, specClass());
+      await expectWriteToFail(db, kClassDocPath, specClass({ teachers: [teacher2Id] }));
+    });
+
+    it("authenticated teachers can't update read-only properties of class documents: id", async () => {
+      db = initFirestore(teacherAuth);
+      await adminWriteDoc(kClassDocPath, specClass());
+      await expectWriteToFail(db, kClassDocPath, specClass({ id: "better-id" }));
+    });
+
+    it("authenticated teachers can't update read-only properties of class documents: uri", async () => {
+      db = initFirestore(teacherAuth);
+      await adminWriteDoc(kClassDocPath, specClass());
+      await expectWriteToFail(db, kClassDocPath, specClass({ uri: "better-uri" }));
+    });
+
+    it("authenticated teachers can't update read-only properties of class documents: context_id", async () => {
+      db = initFirestore(teacherAuth);
+      await adminWriteDoc(kClassDocPath, specClass());
+      await expectWriteToFail(db, kClassDocPath, specClass({ context_id: "better-context-id" }));
+    });
+
+    it("authenticated teachers can't update read-only properties of class documents: network", async () => {
+      db = initFirestore(teacherAuth);
+      await adminWriteDoc(kClassDocPath, specClass());
+      await expectWriteToFail(db, kClassDocPath, specClass({ network: "better-network" }));
+    });
+
+    it("authenticated teachers can't delete their own class documents", async () => {
+      db = initFirestore(teacherAuth);
+      await adminWriteDoc(kClassDocPath, specClass());
+      await expectDeleteToFail(db, kClassDocPath);
+    });
+
+    it("authenticated students can't read class documents", async () => {
+      db = initFirestore(studentAuth);
+      await expectReadToFail(db, kClassDocPath);
+    });
+
+    it("authenticated students can't write class documents", async () => {
+      db = initFirestore(studentAuth);
+      await expectWriteToFail(db, kClassDocPath, specClass());
+    });
+  });
+
+});

--- a/firebase-test/src/offering-rules.test.ts
+++ b/firebase-test/src/offering-rules.test.ts
@@ -1,0 +1,221 @@
+import firebase from "firebase";
+import {
+  adminWriteDoc, expectDeleteToFail, expectReadToFail, expectReadToSucceed, expectWriteToFail, expectWriteToSucceed,
+  genericAuth, initFirestore, network1, network2, offeringId, prepareEachTest, studentAuth,
+  teacher2Auth, teacher2Id, teacher2Name, teacher3Auth, teacher3Id, teacher3Name, teacherAuth, teacherId, teacherName,
+  tearDownTests, thisClass
+} from "./setup-rules-tests";
+
+describe("Firestore security rules for offering (activity) documents", () => {
+
+  let db: firebase.firestore.Firestore;
+
+  beforeEach(async () => {
+    await prepareEachTest();
+
+    await adminWriteDoc(
+            `authed/myPortal/users/${teacherId}`,
+            { uid: teacherId, name: teacherName, type: "teacher", network: network1, networks: [network1] });
+    // teacher 2 is in same network as teacher 1, but a different class
+    await adminWriteDoc(
+            `authed/myPortal/users/${teacher2Id}`,
+            { uid: teacher2Id, name: teacher2Name, type: "teacher", network: network1, networks: [network1] });
+    // teacher 3 is in a different network than teachers 1 and 2
+    await adminWriteDoc(
+            `authed/myPortal/users/${teacher3Id}`,
+            { uid: teacher3Id, name: teacher3Name, type: "teacher", network: network2, networks: [network2] });
+  });
+
+  afterAll(async () => {
+    await tearDownTests();
+  });
+
+  function specOffering(additions?: Record<string, string | string[]>, subtractions?: string[]) {
+    const offering: Record<string, string | string[]> = {
+            id: offeringId, name: "Activity Offering", uri: "https://concord.org/offering", context_id: thisClass,
+            teachers: [teacherId], unit: "msa", problem: "1.4", problemPath: "msa/1/4", network: network1, ...additions };
+    subtractions?.forEach(prop => delete offering[prop]);
+    return offering;
+  }
+
+  describe("offering documents", () => {
+    const offeringKey = `${network1}_${offeringId}`;
+    const kOfferingDocPath = `authed/myPortal/offerings/${offeringKey}`;
+
+    it("unauthenticated users can't read offering documents", async () => {
+      db = initFirestore();
+      await expectReadToFail(db, kOfferingDocPath);
+    });
+
+    it("unauthenticated users can't write offering documents", async () => {
+      db = initFirestore();
+      await expectWriteToFail(db, kOfferingDocPath, specOffering());
+    });
+
+    it("authenticated generic users can't read offering documents", async () => {
+      db = initFirestore(genericAuth);
+      await expectReadToFail(db, kOfferingDocPath);
+    });
+
+    it("authenticated generic users can't write offering documents", async () => {
+      db = initFirestore(genericAuth);
+      await expectWriteToFail(db, kOfferingDocPath, specOffering());
+    });
+
+    it("authenticated teachers can read their own offering documents", async () => {
+      db = initFirestore(teacherAuth);
+      await adminWriteDoc(kOfferingDocPath, specOffering());
+      await expectReadToSucceed(db, kOfferingDocPath);
+    });
+
+    it("authenticated teachers can read other offering documents in the network", async () => {
+      db = initFirestore(teacher2Auth);
+      await adminWriteDoc(kOfferingDocPath, specOffering());
+      await expectReadToSucceed(db, kOfferingDocPath);
+    });
+
+    it("authenticated teachers can't read other offering documents from a different network", async () => {
+      db = initFirestore(teacher3Auth);
+      await adminWriteDoc(kOfferingDocPath, specOffering());
+      await expectReadToFail(db, kOfferingDocPath);
+    });
+
+    it("authenticated teachers can write their own offering documents", async () => {
+      db = initFirestore(teacherAuth);
+      await expectWriteToSucceed(db, kOfferingDocPath, specOffering());
+    });
+
+    it("authenticated teachers can't write their own offering documents without id", async () => {
+      db = initFirestore(teacherAuth);
+      await expectWriteToFail(db, kOfferingDocPath, specOffering({}, ["id"]));
+    });
+
+    it("authenticated teachers can't write their own offering documents without name", async () => {
+      db = initFirestore(teacherAuth);
+      await expectWriteToFail(db, kOfferingDocPath, specOffering({}, ["name"]));
+    });
+
+    it("authenticated teachers can't write their own offering documents without uri", async () => {
+      db = initFirestore(teacherAuth);
+      await expectWriteToFail(db, kOfferingDocPath, specOffering({}, ["uri"]));
+    });
+
+    it("authenticated teachers can't write their own offering documents without context_id", async () => {
+      db = initFirestore(teacherAuth);
+      await expectWriteToFail(db, kOfferingDocPath, specOffering({}, ["context_id"]));
+    });
+
+    it("authenticated teachers can't write their own offering documents without teachers", async () => {
+      db = initFirestore(teacherAuth);
+      await expectWriteToFail(db, kOfferingDocPath, specOffering({}, ["teachers"]));
+    });
+
+    it("authenticated teachers can't write their own offering documents if they're not one of the teachers", async () => {
+      db = initFirestore(teacherAuth);
+      await expectWriteToFail(db, kOfferingDocPath, specOffering({ teachers: [teacher2Id] }));
+    });
+
+    it("authenticated teachers can't write their own offering documents without unit", async () => {
+      db = initFirestore(teacherAuth);
+      await expectWriteToFail(db, kOfferingDocPath, specOffering({}, ["unit"]));
+    });
+
+    it("authenticated teachers can't write their own offering documents without problem", async () => {
+      db = initFirestore(teacherAuth);
+      await expectWriteToFail(db, kOfferingDocPath, specOffering({}, ["problem"]));
+    });
+
+    it("authenticated teachers can't write their own offering documents without problemPath", async () => {
+      db = initFirestore(teacherAuth);
+      await expectWriteToFail(db, kOfferingDocPath, specOffering({}, ["problemPath"]));
+    });
+
+    it("authenticated teachers can't write their own offering documents without network", async () => {
+      db = initFirestore(teacherAuth);
+      await expectWriteToFail(db, kOfferingDocPath, specOffering({}, ["network"]));
+    });
+
+    it("authenticated teachers can update the name of their own offering documents", async () => {
+      db = initFirestore(teacherAuth);
+      await adminWriteDoc(kOfferingDocPath, specOffering());
+      await expectWriteToSucceed(db, kOfferingDocPath, specOffering({ name: "Improved Activity Offering" }));
+    });
+
+    it("authenticated teachers can update the teachers of their own offering documents", async () => {
+      db = initFirestore(teacherAuth);
+      await adminWriteDoc(kOfferingDocPath, specOffering());
+      await expectWriteToSucceed(db, kOfferingDocPath, specOffering({ teachers: [teacherId, teacher2Id] }));
+    });
+
+    it("authenticated teachers can't update the teachers of other teachers' offering documents", async () => {
+      db = initFirestore(teacher2Auth);
+      await adminWriteDoc(kOfferingDocPath, specOffering());
+      await expectWriteToFail(db, kOfferingDocPath, specOffering({ teachers: [teacherId, teacher2Id] }));
+    });
+
+    it("authenticated teachers can't update the teachers of their own offerings if they're no longer a teacher", async () => {
+      db = initFirestore(teacherAuth);
+      await adminWriteDoc(kOfferingDocPath, specOffering());
+      await expectWriteToFail(db, kOfferingDocPath, specOffering({ teachers: [teacher2Id] }));
+    });
+
+    it("authenticated teachers can't update read-only properties of offering documents: id", async () => {
+      db = initFirestore(teacherAuth);
+      await adminWriteDoc(kOfferingDocPath, specOffering());
+      await expectWriteToFail(db, kOfferingDocPath, specOffering({ id: "better-id" }));
+    });
+
+    it("authenticated teachers can't update read-only properties of offering documents: uri", async () => {
+      db = initFirestore(teacherAuth);
+      await adminWriteDoc(kOfferingDocPath, specOffering());
+      await expectWriteToFail(db, kOfferingDocPath, specOffering({ uri: "better-uri" }));
+    });
+
+    it("authenticated teachers can't update read-only properties of offering documents: context_id", async () => {
+      db = initFirestore(teacherAuth);
+      await adminWriteDoc(kOfferingDocPath, specOffering());
+      await expectWriteToFail(db, kOfferingDocPath, specOffering({ context_id: "better-context-id" }));
+    });
+
+    it("authenticated teachers can't update read-only properties of offering documents: unit", async () => {
+      db = initFirestore(teacherAuth);
+      await adminWriteDoc(kOfferingDocPath, specOffering());
+      await expectWriteToFail(db, kOfferingDocPath, specOffering({ unit: "better-unit" }));
+    });
+
+    it("authenticated teachers can't update read-only properties of offering documents: problem", async () => {
+      db = initFirestore(teacherAuth);
+      await adminWriteDoc(kOfferingDocPath, specOffering());
+      await expectWriteToFail(db, kOfferingDocPath, specOffering({ problem: "better-problem" }));
+    });
+
+    it("authenticated teachers can't update read-only properties of offering documents: problemPath", async () => {
+      db = initFirestore(teacherAuth);
+      await adminWriteDoc(kOfferingDocPath, specOffering());
+      await expectWriteToFail(db, kOfferingDocPath, specOffering({ problemPath: "better-problem-path" }));
+    });
+
+    it("authenticated teachers can't update read-only properties of offering documents: network", async () => {
+      db = initFirestore(teacherAuth);
+      await adminWriteDoc(kOfferingDocPath, specOffering());
+      await expectWriteToFail(db, kOfferingDocPath, specOffering({ network: "better-network" }));
+    });
+
+    it("authenticated teachers can't delete their own offering documents", async () => {
+      db = initFirestore(teacherAuth);
+      await adminWriteDoc(kOfferingDocPath, specOffering());
+      await expectDeleteToFail(db, kOfferingDocPath);
+    });
+
+    it("authenticated students can't read offering documents", async () => {
+      db = initFirestore(studentAuth);
+      await expectReadToFail(db, kOfferingDocPath);
+    });
+
+    it("authenticated students can't write offering documents", async () => {
+      db = initFirestore(studentAuth);
+      await expectWriteToFail(db, kOfferingDocPath, specOffering());
+    });
+  });
+
+});

--- a/firebase-test/src/setup-rules-tests.ts
+++ b/firebase-test/src/setup-rules-tests.ts
@@ -7,6 +7,7 @@ export const kCLUEFirebaseProjectId = "collaborative-learning-ec215";
 export const genericAuth = { uid: "user-generic" };
 export const thisClass = "this-class";
 export const otherClass = "other-class";
+export const lastClass = "last-class";
 export const studentIdNumeric = 1;
 export const studentId = `${studentIdNumeric}`;
 export const studentAuth = { uid: studentId, platform_user_id: studentIdNumeric, user_type: "student", class_hash: thisClass };
@@ -21,6 +22,12 @@ export const teacher2IdNumeric = 12;
 export const teacher2Id = `${teacher2IdNumeric}`;
 export const teacher2Name = "John Teacher";
 export const teacher2Auth = { uid: teacher2Id, platform_user_id: teacher2IdNumeric, user_type: "teacher", class_hash: otherClass };
+export const teacher3IdNumeric = 13;
+export const teacher3Id = `${teacher3IdNumeric}`;
+export const teacher3Name = "Jade Teacher";
+export const teacher3Auth = { uid: teacher3Id, platform_user_id: teacher3IdNumeric, user_type: "teacher", class_hash: lastClass };
+export const offeringIdNumeric = 2000;
+export const offeringId = `${offeringIdNumeric}`;
 export const noNetwork = null;
 export const network1 = "network-1";
 export const network2 = "network-2";
@@ -41,8 +48,12 @@ export const prepareEachTest = async () => {
   await clearFirestoreData({ projectId: kCLUEFirebaseProjectId });
 }
 
-export const tearDownTests = async () => {
-  await clearFirestoreData({ projectId: kCLUEFirebaseProjectId });
+// Pass false to preserve the contents of the database after tests are run.
+// This is particularly useful in combination with `.only` to see what was
+// written to the database for a particular test.
+// The database contents can be viewed in the emulator UI at http://localhost:4000/firestore
+export const tearDownTests = async (clear = true) => {
+  clear && await clearFirestoreData({ projectId: kCLUEFirebaseProjectId });
   // https://firebase.google.com/docs/firestore/security/test-rules-emulator#run_local_tests
   await Promise.all(apps().map(app => app.delete()))
 };

--- a/firebase-test/src/setup-rules-tests.ts
+++ b/firebase-test/src/setup-rules-tests.ts
@@ -66,6 +66,18 @@ export const adminWriteDoc = async (docPath: string, value: any) => {
   await dbAdmin.doc(docPath).set(value);
 };
 
+export const expectQueryToFail = async (db: firebase.firestore.Firestore, query: firebase.firestore.Query) => {
+  // awaited writes via admin app don't always complete before the read occurs
+  await db.waitForPendingWrites();
+  expect(await assertFails(query.get())).toBeDefined();
+}
+
+export const expectQueryToSucceed = async (db: firebase.firestore.Firestore, query: firebase.firestore.Query) => {
+  // awaited writes via admin app don't always complete before the read occurs
+  await db.waitForPendingWrites();
+  expect(await assertSucceeds(query.get())).toBeDefined();
+}
+
 export const expectReadToFail = async (db: firebase.firestore.Firestore, docPath: string) => {
   // awaited writes via admin app don't always complete before the read occurs
   await db.waitForPendingWrites();

--- a/firestore.rules
+++ b/firestore.rules
@@ -46,25 +46,25 @@ service cloud.firestore {
     }
 
     // uid of submitted document must match user's platform_user_id
-    function requestMatchUserId() {
+    function userIsRequestUser() {
       return isAuthed() &&
         string(request.auth.token.platform_user_id) == request.resource.data.uid;
     }
 
     // user's platform_user_id must be in submitted document's list of teachers
-    function requestMatchTeachers() {
+    function userInRequestTeachers() {
       return isAuthed() &&
         string(request.auth.token.platform_user_id) in request.resource.data.teachers;
     }
 
     // uid of requested document must match user's platform_user_id
-    function resourceMatchUserId() {
+    function userIsResourceUser() {
       return isAuthed() &&
         string(request.auth.token.platform_user_id) == resource.data.uid;
     }
 
     // user's platform_user_id must be in requested document's list of teachers
-    function resourceMatchTeacher() {
+    function userInResourceTeachers() {
       return isAuthed() &&
         string(request.auth.token.platform_user_id) in resource.data.teachers;
     }
@@ -85,12 +85,12 @@ service cloud.firestore {
     }
 
     function isValidCurriculumCreateRequest() {
-      return requestMatchUserId() &&
+      return userIsRequestUser() &&
               request.resource.data.keys().hasAll(["uid", "unit", "problem", "section", "path", "network"]);
     }
 
     function isValidDocumentCreateRequest() {
-      return requestMatchTeachers() && classIsRequestContextId() &&
+      return userInRequestTeachers() && classIsRequestContextId() &&
               request.resource.data.keys().hasAll(["uid", "network", "type", "key", "createdAt"]);
     }
 
@@ -101,11 +101,11 @@ service cloud.firestore {
     }
 
     function isValidDocumentUpdateRequest() {
-      return resourceMatchTeacher() && preservesReadOnlyDocumentFields();
+      return userInResourceTeachers() && preservesReadOnlyDocumentFields();
     }
 
     function isValidSupportCreateRequest() {
-      return requestMatchUserId() &&
+      return userIsRequestUser() &&
               classInRequestClasses() &&
               classIsRequestContextId() &&
               (request.resource.data.content != null) &&
@@ -120,7 +120,7 @@ service cloud.firestore {
     }
 
     function isValidSupportUpdateRequest() {
-      return resourceMatchUserId() && preservesReadOnlySupportFields();
+      return userIsResourceUser() && preservesReadOnlySupportFields();
     }
 
     //
@@ -129,11 +129,18 @@ service cloud.firestore {
     match /authed/{portal} {
       allow read, write: if isAuthedTeacher();
 
+      // return list of networks available to the current teacher
       function getTeacherNetworks() {
         let platformUserId = string(request.auth.token.platform_user_id);
         return get(/databases/$(database)/documents/authed/$(portal)/users/$(platformUserId)).data.networks;
       }
 
+      // check whether the document being created/updated is associated with one of this teacher's networks
+      function requestInTeacherNetworks() {
+        return request.resource.data.network in getTeacherNetworks();
+      }
+
+      // check whether the document being read is associated with one of this teacher's networks
       function resourceInTeacherNetworks() {
         return resource.data.network in getTeacherNetworks();
       }
@@ -145,38 +152,103 @@ service cloud.firestore {
         allow write: if false;
       }
 
+      function isValidClassCreateRequest() {
+        let requiredFields = ["id", "name", "uri", "context_id", "teachers", "network"];
+        return userInRequestTeachers() && requestInTeacherNetworks() &&
+                request.resource.data.keys().hasAll(requiredFields);
+      }
+
+      function preservesReadOnlyClassFields() {
+        let readOnlyFieldsSet = ["id", "uri", "context_id", "network"].toSet();
+        let affectedFieldsSet = request.resource.data.diff(resource.data).affectedKeys();
+        return !affectedFieldsSet.hasAny(readOnlyFieldsSet);
+      }
+
+      function isValidClassUpdateRequest() {
+        return userInRequestTeachers() && userInResourceTeachers() &&
+                requestInTeacherNetworks() && preservesReadOnlyClassFields();
+      }
+
+      match /classes/{classId} {
+        // portal-authenticated teachers can create valid classes
+        allow create: if isAuthedTeacher() && isValidClassCreateRequest();
+        // teachers can only update their own classes and only if they're valid
+        allow update: if isAuthedTeacher() && isValidClassUpdateRequest();
+        // we don't support deleting classes at this time
+        allow delete: if false;
+        // teachers can read their own classes or any class in their network
+        allow read: if isAuthedTeacher() && (userInRequestTeachers() || resourceInTeacherNetworks());
+      }
+
+      function isValidOfferingCreateRequest() {
+        let requiredFields = ["id", "name", "uri", "context_id", "teachers",
+                              "unit", "problem", "problemPath", "network"];
+        return userInRequestTeachers() && requestInTeacherNetworks() &&
+                request.resource.data.keys().hasAll(requiredFields);
+      }
+
+      function preservesReadOnlyOfferingFields() {
+        let readOnlyFieldsSet = ["id", "uri", "context_id", "unit",
+                                "problem", "problemPath", "network"].toSet();
+        let affectedFieldsSet = request.resource.data.diff(resource.data).affectedKeys();
+        return !affectedFieldsSet.hasAny(readOnlyFieldsSet);
+      }
+
+      function isValidOfferingUpdateRequest() {
+        // teachers can update the list of teachers for the offering,
+        // but only if they were already a teacher and are still a teacher
+        return userInRequestTeachers() && userInResourceTeachers() &&
+                requestInTeacherNetworks() && preservesReadOnlyOfferingFields();
+      }
+
+      match /offerings/{offeringId} {
+        // portal-authenticated teachers can create valid offerings
+        allow create: if isAuthedTeacher() && isValidOfferingCreateRequest();
+        // teachers can only update their own documents and only if they're valid
+        allow update: if isAuthedTeacher() && isValidOfferingUpdateRequest();
+        // we don't support deleting offerings at this time
+        allow delete: if false;
+        // teachers can read offerings in their network
+        allow read: if isAuthedTeacher() && resourceInTeacherNetworks();
+      }
+
       match /curriculum/{pathId} {
         // portal-authenticated teachers can create valid curriculum documents
         allow create: if isAuthedTeacher() && isValidCurriculumCreateRequest();
         // curriculum documents can't be updated or deleted
         allow update, delete: if false;
         // teachers can read their own curriculum documents or others in their network
-        allow read: if isAuthedTeacher() && (resourceMatchUserId() || resourceInTeacherNetworks());
+        allow read: if isAuthedTeacher() && (userIsResourceUser() || resourceInTeacherNetworks());
 
+        // return the author/owner of the specified (curriculum) document
         function getCurriculumOwner() {
           return get(/databases/$(database)/documents/authed/$(portal)/curriculum/$(pathId)).data.uid;
         }
 
+        // return the network with which the specified (curriculum) document is associated
         function getCurriculumNetwork() {
           return get(/databases/$(database)/documents/authed/$(portal)/curriculum/$(pathId)).data.network;
         }
 
+        // check whether the (curriculum) document is associated with one of the teacher's networks
         function curriculumInTeacherNetworks() {
           let curriculumNetwork = getCurriculumNetwork();
           return exists(curriculumNetwork) && (curriculumNetwork in getTeacherNetworks());
         }
 
+        // check whether the teacher owns/created the curriculum document
         function teacherIsCurriculumOwner() {
           let curriculumOwner = getCurriculumOwner();
           return string(request.auth.token.platform_user_id) == curriculumOwner;
         }
 
+        // teachers can access (curriculum) documents that they own or are associated with one of their networks
         function teacherCanAccessCurriculum() {
-          return teacherIsCurriculumOwner() || curriculumInTeacherNetworks();
+          return isAuthedTeacher() && (teacherIsCurriculumOwner() || curriculumInTeacherNetworks());
         }
 
         function isValidCommentCreateRequest() {
-          return requestMatchUserId() &&
+          return userIsRequestUser() &&
                   // comments network must match network of parent document
                   (request.resource.data.network == getCurriculumNetwork()) &&
                   request.resource.data.keys().hasAll(["name", "createdAt", "content", "network"]);
@@ -189,18 +261,18 @@ service cloud.firestore {
         }
 
         function isValidCommentUpdateRequest() {
-          return requestMatchUserId() && preservesReadOnlyCommentFields();
+          return userIsRequestUser() && preservesReadOnlyCommentFields();
         }
 
         match /comments/{commentId} {
           // portal-authenticated teachers with access to the document can create valid comments
-          allow create: if isAuthedTeacher() && teacherCanAccessCurriculum() && isValidCommentCreateRequest();
+          allow create: if teacherCanAccessCurriculum() && isValidCommentCreateRequest();
           // teachers can only update their own comments and only if they're valid
-          allow update: if isAuthedTeacher() && teacherCanAccessCurriculum() && isValidCommentUpdateRequest();
+          allow update: if teacherCanAccessCurriculum() && isValidCommentUpdateRequest();
           // teachers can only delete their own comments
-          allow delete: if isAuthedTeacher() && teacherCanAccessCurriculum() && resourceMatchUserId();
-          // only teachers that "own" the document can read the comments (for now)
-          allow read: if isAuthedTeacher() && teacherCanAccessCurriculum();
+          allow delete: if teacherCanAccessCurriculum() && userIsResourceUser();
+          // teachers with access to the curriculum document can read the comments
+          allow read: if teacherCanAccessCurriculum();
         }
       }
 
@@ -210,34 +282,39 @@ service cloud.firestore {
         // teachers can only update their own documents and only if they're valid
         allow update: if isAuthedTeacher() && isValidDocumentUpdateRequest();
         // teachers can only delete their own documents
-        allow delete: if isAuthedTeacher() && resourceMatchUserId();
+        allow delete: if isAuthedTeacher() && userIsResourceUser();
         // teachers can read their own documents or other documents in their network
-        allow read: if isAuthedTeacher() && (resourceMatchTeacher() || resourceInTeacherNetworks());
+        allow read: if isAuthedTeacher() && (userInResourceTeachers() || resourceInTeacherNetworks());
 
+        // return the list of teachers associated with the specified document
         function getDocumentTeachers() {
           return get(/databases/$(database)/documents/authed/$(portal)/documents/$(docId)).data.teachers;
         }
 
+        // return the network with which the specified document is associated
         function getDocumentNetwork() {
           return get(/databases/$(database)/documents/authed/$(portal)/documents/$(docId)).data.network;
         }
 
+        // check whether the current teacher is one of the teachers associated with the document
         function teacherInDocumentTeachers() {
           return isAuthedTeacher() && (request.auth.uid in getDocumentTeachers());
         }
 
+        // check whether the document's network corresponds to one of the teacher's networks
         function documentInTeacherNetworks() {
           let docNetwork = getDocumentNetwork();
           return exists(docNetwork) && (docNetwork in getTeacherNetworks());
         }
 
+        // check whether the teacher can access the document
         function teacherCanAccessDocument() {
           return teacherInDocumentTeachers() || documentInTeacherNetworks();
         }
 
         function isValidCommentCreateRequest() {
-          return requestMatchUserId() &&
-                  // comments network must match network of parent document
+          return userIsRequestUser() &&
+                  // comment's network must match network of parent document
                   (request.resource.data.network == getDocumentNetwork()) &&
                   request.resource.data.keys().hasAll(["name", "createdAt", "content"]);
         }
@@ -249,7 +326,7 @@ service cloud.firestore {
         }
 
         function isValidCommentUpdateRequest() {
-          return requestMatchUserId() && preservesReadOnlyCommentFields();
+          return userIsRequestUser() && preservesReadOnlyCommentFields();
         }
 
         match /comments/{commentId} {
@@ -258,7 +335,7 @@ service cloud.firestore {
           // teachers can only update their own comments and only if they're valid
           allow update: if isAuthedTeacher() && teacherCanAccessDocument() && isValidCommentUpdateRequest();
           // teachers can only delete their own comments
-          allow delete: if isAuthedTeacher() && teacherCanAccessDocument() && resourceMatchUserId();
+          allow delete: if isAuthedTeacher() && teacherCanAccessDocument() && userIsResourceUser();
           // only teachers that "own" the document can read the comments (for now)
           allow read: if isAuthedTeacher() && teacherCanAccessDocument();
         }
@@ -270,9 +347,9 @@ service cloud.firestore {
         // teachers can only update their own supports and only if they're valid
         allow update: if isAuthedTeacher() && isValidSupportUpdateRequest();
         // teachers can only delete their own supports
-        allow delete: if isAuthedTeacher() && resourceMatchUserId();
+        allow delete: if isAuthedTeacher() && userIsResourceUser();
         // teachers and students in appropriate classes can read supports
-        allow read: if resourceMatchUserId() || classInResourceClasses();
+        allow read: if userIsResourceUser() || classInResourceClasses();
       }
     }
 

--- a/src/lib/firestore-schema.ts
+++ b/src/lib/firestore-schema.ts
@@ -95,6 +95,28 @@ export interface DocumentDocument {
 type DocumentsCollection = FSCollection<DocumentDocument>;
 
 /*
+ * offerings
+ *
+ * Subcollection of domain with several fields copied from portal.
+ * When viewing a particular problem in CLUE, the set of classes available via the network is limited to
+ * those classes that have assigned the same problem. In other words, it makes more sense to search for
+ * offerings first and then use that to determine the available classes.
+ */
+export interface OfferingDocument {
+  id: string;             // e.g. "2000"
+  name: string;           // name/title of activity
+  uri: string;            // e.g. "https://collaborative-learning.concord.org/branch/master/?unit=msa&problem=1.4"
+  context_id: string;     // portal class hash
+  teachers: string[];     // [denormalized] uids of teachers of class
+  unit: string;           // e.g. "msa"
+  problem: string;        // e.g. "1.4"
+  problemPath: string;    // e.g. "msa/1/4"
+  network: string;        // network within which this offering instance is available
+}
+// collection key is `${network}_${offering id}`
+type OfferingsCollection = FSCollection<OfferingDocument>;
+
+/*
  * classes
  *
  * Subcollection of domain with several fields copied from portal (e.g. name, teachers) with
@@ -106,11 +128,12 @@ type DocumentsCollection = FSCollection<DocumentDocument>;
 interface ClassDocument {
   id: string;                 // portal class id
   name: string;               // portal class name
+  uri: string;                // portal class info url
   context_id: string;         // portal class hash
   teachers: string[];         // uids of teachers of class
   network: string;            // network of teacher creating class
 }
-// collection key is context_id (class hash)
+// collection key is `${network}_${context_id (class hash)}`
 type ClassesCollection = FSCollection<ClassDocument>;
 
 /*
@@ -163,6 +186,7 @@ interface DomainDocument {
   users: UsersCollection;
   networks: NetworksCollection;
   classes: ClassesCollection;
+  offerings: OfferingsCollection;
   curriculum: CurriculumCollection;
   documents: DocumentsCollection;
   mcsupports: SupportsCollection;


### PR DESCRIPTION
[[#179154344]](https://www.pivotaltracker.com/story/show/179154344)

For those following along at home:

**class**: teacher's class created in learn portal

**activity**: an assignable/runnable interactive for student use defined in the learn portal (corresponds to a problem in CLUE)

**offering**: an assignment of an `activity` to a `class`. A given `activity` can be assigned to many classes and a `class` can have many assignments of different activities.

To implement the teacher network features, we need to get a list of the other classes available in the network that have assigned the same activity/problem, because individual documents are only generally relevant to a particular problem. Therefore, ultimately we want to be able to query for all `offerings` that are assignments of the teacher's current problem and are available in the teacher's current network. The first step, therefore is to populate the firestore database with sufficient information to perform the aforementioned query. Toward that end, with this PR we introduce the `classes` and `offerings` collections in firestore.

It is already the case that when launched by an authenticated teacher, CLUE requests information about all of the teacher's other assignments so that we can populate the existing class and problem switcher menus. I'm planning to utilize this existing information to have CLUE write the corresponding information to firestore for each teacher. As a result, launching CLUE for a given teacher will automatically populate that teacher's `classes` and `offerings` in firestore. One wrinkle in the implementation is that I'm storing the list of teachers redundantly (denormalized) in the `class` and the `offering`, so that the security rules can use whether or not the current teacher is a teacher of the `class`/`offering` as a gating mechanism. As a result, the security rules and unit tests for classes and offerings are similar.

Having talked recently about the benefits of smaller PRs, I'm taking this opportunity to submit the schema and security rules changes in a separate PR from the code that actually populates the firestore database. I'm assigning @scytacki for review since he's familiar with the existing schema and security rules testing, but I'll cc @mklewandowski and @Concord-Jim for informational value. I also did some renaming and commenting of the existing security rules, so you will see some changes (hopefully clarifying changes) not related to classes/offerings as well.

More general background information:
- these security rules are not deployed automatically when a PR is merged; there's a separate manual deploy step.
- the security rules unit tests are run within the firestore emulator, but are designed to be a thorough test of the conditions encountered in the deployed application.