### PR TITLE
179152641 no preview group dialog

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -172,9 +172,10 @@ export class AppComponent extends BaseComponent<IProps, IState> {
       );
     }
 
+    const isPreviewing = urlParams.domain && urlParams.domain_uid && !urlParams.token;
     if (user.isStudent) {
       if (!groups.groupForUser(user.id)) {
-        if (appConfig.autoAssignStudentsToIndividualGroups) {
+        if (appConfig.autoAssignStudentsToIndividualGroups || isPreviewing) {
           // use userId as groupId
           db.joinGroup(user.id);
         }

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -184,7 +184,6 @@ export class AppComponent extends BaseComponent<IProps, IState> {
         }
       }
     }
-
     return this.renderApp(<AppContentContainerComponent />);
   }
 

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -172,7 +172,6 @@ export class AppComponent extends BaseComponent<IProps, IState> {
       );
     }
 
-    const isPreviewing = urlParams.domain && urlParams.domain_uid && !urlParams.token;
     if (user.isStudent) {
       if (!groups.groupForUser(user.id)) {
         if (appConfig.autoAssignStudentsToIndividualGroups || this.stores.isPreviewing) {

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -175,7 +175,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
     const isPreviewing = urlParams.domain && urlParams.domain_uid && !urlParams.token;
     if (user.isStudent) {
       if (!groups.groupForUser(user.id)) {
-        if (appConfig.autoAssignStudentsToIndividualGroups || isPreviewing) {
+        if (appConfig.autoAssignStudentsToIndividualGroups || this.stores.isPreviewing) {
           // use userId as groupId
           db.joinGroup(user.id);
         }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -36,7 +36,8 @@ const initializeApp = async () => {
   const showDemoCreator = urlParams.demo;
   const demoName = urlParams.demoName;
 
-  const stores = createStores({ appMode, appVersion, appConfig, user, showDemoCreator, demoName });
+  const isPreviewing = !!(urlParams.domain && urlParams.domain_uid && !urlParams.token);
+  const stores = createStores({ appMode, appVersion, appConfig, user, showDemoCreator, demoName, isPreviewing });
 
   await setUnitAndProblem(stores, unitId, problemOrdinal);
 

--- a/src/models/stores/groups.ts
+++ b/src/models/stores/groups.ts
@@ -31,7 +31,8 @@ export const GroupModel = types
 
 export const GroupsModel = types
   .model("Groups", {
-    allGroups: types.array(GroupModel)
+    allGroups: types.array(GroupModel),
+    acceptUnknownStudents: false
   })
   .actions((self) => ({
     updateFromDB(uid: string, groups: DBOfferingGroupMap, clazz: ClassModelType) {
@@ -46,12 +47,14 @@ export const GroupsModel = types
           // causing the disconnectedAt timestamp to be set at the groupUser level
           if (groupUser.self) {
             const student = clazz.getUserById(groupUser.self.uid);
-            // skip students who are not recognized members of the class
-            if (student) {
+            // skip students who are not recognized members of the class when authenticated
+            // this actually occurred in the classroom causing great consternation
+            // when previewing, however, we need to accept unknown students
+            if (student || self.acceptUnknownStudents) {
               users.push(GroupUserModel.create({
                 id: groupUserId,
-                name: student.fullName,
-                initials: student.initials,
+                name: student?.fullName || "Unknown",
+                initials: student?.initials || "??",
                 connectedTimestamp,
                 disconnectedTimestamp
               }));

--- a/src/models/stores/stores.ts
+++ b/src/models/stores/stores.ts
@@ -35,6 +35,7 @@ export interface IBaseStores {
   supports: SupportsModelType;
   clipboard: ClipboardModelType;
   selection: SelectionStoreModelType;
+  isPreviewing?: boolean;
 }
 
 export interface IStores extends IBaseStores {
@@ -43,7 +44,6 @@ export interface IStores extends IBaseStores {
 
 interface ICreateStores extends Partial<IStores> {
   demoName?: string;
-  isPreviewing?: boolean;
 }
 
 export function createStores(params?: ICreateStores): IStores {

--- a/src/models/stores/stores.ts
+++ b/src/models/stores/stores.ts
@@ -18,6 +18,7 @@ import { AppMode } from "./store-types";
 
 export interface IBaseStores {
   appMode: AppMode;
+  isPreviewing?: boolean;
   appVersion: string;
   appConfig: AppConfigModelType;
   unit: UnitModelType;
@@ -35,7 +36,6 @@ export interface IBaseStores {
   supports: SupportsModelType;
   clipboard: ClipboardModelType;
   selection: SelectionStoreModelType;
-  isPreviewing?: boolean;
 }
 
 export interface IStores extends IBaseStores {

--- a/src/models/stores/stores.ts
+++ b/src/models/stores/stores.ts
@@ -43,6 +43,7 @@ export interface IStores extends IBaseStores {
 
 interface ICreateStores extends Partial<IStores> {
   demoName?: string;
+  isPreviewing?: boolean;
 }
 
 export function createStores(params?: ICreateStores): IStores {
@@ -67,7 +68,7 @@ export function createStores(params?: ICreateStores): IStores {
         mode: "1-up"
       },
     }),
-    groups: params?.groups || GroupsModel.create({}),
+    groups: params?.groups || GroupsModel.create({ acceptUnknownStudents: params?.isPreviewing }),
     class: params?.class || ClassModel.create({ name: "Null Class", classHash: "" }),
     db: params?.db || new DB(),
     documents: params?.documents || DocumentsModel.create({}),


### PR DESCRIPTION
This PR auto assigns users to groups when in preview mode.  In doing so, the group chooser dialog is not shown.  Changes include:
- determine in App component if we are in preview mode.  If we are, do not show group chooser dialog and auto assign user to a group
- modify group store to allow students who are not members of a class to be added to the store when we are in preview mode

PT Story: 
https://www.pivotaltracker.com/story/show/179152641

Deployed branch for testing:
https://collaborative-learning.concord.org/branch/no-preview-group-dialog/?demo

Deployed branch with URL params that put us in preview mode:
https://collaborative-learning.concord.org/branch/no-preview-group-dialog/?unit=msa&problem=4.3&domain=https%3A%2F%2Flearn.staging.concord.org%2F&domain_uid=218
