### PR TITLE
Synchronize teacher's CLUE classes and offerings to firestore for network use [#179154344]

### DIFF
--- a/firebase-test/package-lock.json
+++ b/firebase-test/package-lock.json
@@ -19,20 +19,20 @@
       "dev": true
     },
     "@babel/core": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.0.tgz",
-      "integrity": "sha512-tXtmTminrze5HEUPn/a0JtOzzfp0nk+UEXQ/tqIJo3WDGypl/2OFQEMll/zSFU8f/lfmfLXvTaORHF3cfXIQMw==",
+      "version": "7.15.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.5.tgz",
+      "integrity": "sha512-pYgXxiwAgQpgM1bNkZsDEq85f0ggXMA5L7c+o3tskGMh2BunCI9QUwB9Z4jpvXUOuMdyGKiGKQiRe11VS6Jzvg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.0",
-        "@babel/helper-compilation-targets": "^7.15.0",
-        "@babel/helper-module-transforms": "^7.15.0",
-        "@babel/helpers": "^7.14.8",
-        "@babel/parser": "^7.15.0",
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.15.0",
-        "@babel/types": "^7.15.0",
+        "@babel/generator": "^7.15.4",
+        "@babel/helper-compilation-targets": "^7.15.4",
+        "@babel/helper-module-transforms": "^7.15.4",
+        "@babel/helpers": "^7.15.4",
+        "@babel/parser": "^7.15.5",
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -68,12 +68,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
-      "integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.4.tgz",
+      "integrity": "sha512-d3itta0tu+UayjEORPNz6e1T3FtvWlP5N4V5M+lhp/CxT4oAA7/NcScnpRyspUMLK6tu9MNHmQHxRykuN2R7hw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.0",
+        "@babel/types": "^7.15.4",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -87,9 +87,9 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.0.tgz",
-      "integrity": "sha512-h+/9t0ncd4jfZ8wsdAsoIxSa61qhBYlycXiHWqJaQBCXAhDCMbPRSMTGnZIkkmt1u4ag+UQmuqcILwqKzZ4N2A==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.4.tgz",
+      "integrity": "sha512-rMWPCirulnPSe4d+gwdWXLfAXTTBj8M3guAf5xFQJ0nvFY7tfNAFnWdqaHegHlgDZOCT4qvhF3BYlSJag8yhqQ==",
       "dev": true,
       "requires": {
         "@babel/compat-data": "^7.15.0",
@@ -99,75 +99,83 @@
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
-      "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
+      "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.14.5",
-        "@babel/template": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/helper-get-function-arity": "^7.15.4",
+        "@babel/template": "^7.15.4",
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
-      "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
+      "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
-      "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
+      "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.0.tgz",
-      "integrity": "sha512-Jq8H8U2kYiafuj2xMTPQwkTBnEEdGKpT35lJEQsRRjnG0LW3neucsaMWLgKcwu3OHKNeYugfw+Z20BXBSEs2Lg==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.4.tgz",
+      "integrity": "sha512-cokOMkxC/BTyNP1AlY25HuBWM32iCEsLPI4BHDpJCHHm1FU2E7dKWWIXJgQgSFiu4lp8q3bL1BIKwqkSUviqtA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.0"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
-      "integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz",
+      "integrity": "sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.0.tgz",
-      "integrity": "sha512-RkGiW5Rer7fpXv9m1B3iHIFDZdItnO2/BLfWVW/9q7+KqQSDY5kUfQEbzdXM1MVhJGcugKV7kRrNVzNxmk7NBg==",
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.7.tgz",
+      "integrity": "sha512-ZNqjjQG/AuFfekFTY+7nY4RgBSklgTu970c7Rj3m/JOhIu5KPBUuTA9AY6zaKcUvk4g6EbDXdBnhi35FAssdSw==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.14.5",
-        "@babel/helper-replace-supers": "^7.15.0",
-        "@babel/helper-simple-access": "^7.14.8",
-        "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/helper-validator-identifier": "^7.14.9",
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.15.0",
-        "@babel/types": "^7.15.0"
+        "@babel/helper-module-imports": "^7.15.4",
+        "@babel/helper-replace-supers": "^7.15.4",
+        "@babel/helper-simple-access": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4",
+        "@babel/helper-validator-identifier": "^7.15.7",
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.6"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.15.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+          "dev": true
+        }
       }
     },
     "@babel/helper-optimise-call-expression": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
-      "integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.15.4.tgz",
+      "integrity": "sha512-E/z9rfbAOt1vDW1DR7k4SzhzotVV5+qMciWV6LaG1g4jeFrkDlJedjtV4h0i4Q/ITnUu+Pk08M7fczsB9GXBDw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-plugin-utils": {
@@ -177,33 +185,33 @@
       "dev": true
     },
     "@babel/helper-replace-supers": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.0.tgz",
-      "integrity": "sha512-6O+eWrhx+HEra/uJnifCwhwMd6Bp5+ZfZeJwbqUTuqkhIT6YcRhiZCOOFChRypOIe0cV46kFrRBlm+t5vHCEaA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.4.tgz",
+      "integrity": "sha512-/ztT6khaXF37MS47fufrKvIsiQkx1LBRvSJNzRqmbyeZnTwU9qBxXYLaaT/6KaxfKhjs2Wy8kG8ZdsFUuWBjzw==",
       "dev": true,
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.15.0",
-        "@babel/helper-optimise-call-expression": "^7.14.5",
-        "@babel/traverse": "^7.15.0",
-        "@babel/types": "^7.15.0"
+        "@babel/helper-member-expression-to-functions": "^7.15.4",
+        "@babel/helper-optimise-call-expression": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.8.tgz",
-      "integrity": "sha512-TrFN4RHh9gnWEU+s7JloIho2T76GPwRHhdzOWLqTrMnlas8T9O7ec+oEDNsRXndOmru9ymH9DFrEOxpzPoSbdg==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.15.4.tgz",
+      "integrity": "sha512-UzazrDoIVOZZcTeHHEPYrr1MvTR/K+wgLg6MY6e1CJyaRhbibftF6fR2KU2sFRtI/nERUZR9fBd6aKgBlIBaPg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.8"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
-      "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
+      "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-validator-identifier": {
@@ -219,14 +227,14 @@
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.15.3",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.3.tgz",
-      "integrity": "sha512-HwJiz52XaS96lX+28Tnbu31VeFSQJGOeKHJeaEPQlTl7PnlhFElWPj8tUXtqFIzeN86XxXoBr+WFAyK2PPVz6g==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.4.tgz",
+      "integrity": "sha512-V45u6dqEJ3w2rlryYYXf6i9rQ5YMNu4FLS6ngs8ikblhu2VdR1AqAd6aJjBzmf2Qzh6KOLqKHxEN9+TFbAkAVQ==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.15.0",
-        "@babel/types": "^7.15.0"
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/highlight": {
@@ -299,9 +307,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.15.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.3.tgz",
-      "integrity": "sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA==",
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.7.tgz",
+      "integrity": "sha512-rycZXvQ+xS9QyIcJ9HXeDWf1uxqlbVFAUq0Rq0dbc50Zb/+wUe/ehyfzGfm9KZZF0kBejYgxltBXocP+gKdL2g==",
       "dev": true
     },
     "@babel/plugin-syntax-async-generators": {
@@ -422,14 +430,14 @@
       }
     },
     "@babel/template": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
-      "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
+      "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/parser": "^7.15.4",
+        "@babel/types": "^7.15.4"
       },
       "dependencies": {
         "@babel/code-frame": {
@@ -444,18 +452,18 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
-      "integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
+      "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.0",
-        "@babel/helper-function-name": "^7.14.5",
-        "@babel/helper-hoist-variables": "^7.14.5",
-        "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/parser": "^7.15.0",
-        "@babel/types": "^7.15.0",
+        "@babel/generator": "^7.15.4",
+        "@babel/helper-function-name": "^7.15.4",
+        "@babel/helper-hoist-variables": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4",
+        "@babel/parser": "^7.15.4",
+        "@babel/types": "^7.15.4",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -478,9 +486,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
-      "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.14.9",
@@ -534,17 +542,38 @@
       }
     },
     "@firebase/analytics": {
-      "version": "0.6.17",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.6.17.tgz",
-      "integrity": "sha512-Iiip24vQw7p+dBxoGWP2WvVqV2tOdLPjWw6OP6a+8vgss9PRsjKE2AAskruqveMUO4Ox5uPW65wdgeJxoFoMvQ==",
+      "version": "0.6.18",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.6.18.tgz",
+      "integrity": "sha512-FXNtYDxbs9ynPbzUVuG94BjFPOPpgJ7156660uvCBuKgoBCIVcNqKkJQQ7TH8384fqvGjbjdcgARY9jgAHbtog==",
       "dev": true,
       "requires": {
         "@firebase/analytics-types": "0.6.0",
-        "@firebase/component": "0.5.5",
-        "@firebase/installations": "0.4.31",
+        "@firebase/component": "0.5.6",
+        "@firebase/installations": "0.4.32",
         "@firebase/logger": "0.2.6",
-        "@firebase/util": "1.2.0",
+        "@firebase/util": "1.3.0",
         "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.6.tgz",
+          "integrity": "sha512-GyQJ+2lrhsDqeGgd1VdS7W+Y6gNYyI0B51ovNTxeZVG/W8I7t9MwEiCWsCvfm5wQgfsKp9dkzOcJrL5k8oVO/Q==",
+          "dev": true,
+          "requires": {
+            "@firebase/util": "1.3.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@firebase/util": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.3.0.tgz",
+          "integrity": "sha512-SESvmYwuKOVCZ1ZxLbberbx+9cnbxpCa4CG2FUSQYqN6Ab8KyltegMDIsqMw5KyIBZ4n1phfHoOa22xo5NzAlQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        }
       }
     },
     "@firebase/analytics-types": {
@@ -554,32 +583,74 @@
       "dev": true
     },
     "@firebase/app": {
-      "version": "0.6.29",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.29.tgz",
-      "integrity": "sha512-duCzk9/BSVVsb5Y9b0rnvGSuD5zQA/JghiQsccRl+lA4xiUYjFudTU4cVFftkw+0zzeYBHn4KiVxchsva1O9dA==",
+      "version": "0.6.30",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.30.tgz",
+      "integrity": "sha512-uAYEDXyK0mmpZ8hWQj5TNd7WVvfsU8PgsqKpGljbFBG/HhsH8KbcykWAAA+c1PqL7dt/dbt0Reh1y9zEdYzMhg==",
       "dev": true,
       "requires": {
         "@firebase/app-types": "0.6.3",
-        "@firebase/component": "0.5.5",
+        "@firebase/component": "0.5.6",
         "@firebase/logger": "0.2.6",
-        "@firebase/util": "1.2.0",
+        "@firebase/util": "1.3.0",
         "dom-storage": "2.1.0",
         "tslib": "^2.1.0",
         "xmlhttprequest": "1.8.0"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.6.tgz",
+          "integrity": "sha512-GyQJ+2lrhsDqeGgd1VdS7W+Y6gNYyI0B51ovNTxeZVG/W8I7t9MwEiCWsCvfm5wQgfsKp9dkzOcJrL5k8oVO/Q==",
+          "dev": true,
+          "requires": {
+            "@firebase/util": "1.3.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@firebase/util": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.3.0.tgz",
+          "integrity": "sha512-SESvmYwuKOVCZ1ZxLbberbx+9cnbxpCa4CG2FUSQYqN6Ab8KyltegMDIsqMw5KyIBZ4n1phfHoOa22xo5NzAlQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        }
       }
     },
     "@firebase/app-check": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.3.1.tgz",
-      "integrity": "sha512-5OWXzhXdtrmOqn2aN44FyNTwjlZJrip/3WC7UlMeUBPi3apuUgChHTolZ1oITszGdw52lP3r5SOCDtRsNtbkJg==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.3.2.tgz",
+      "integrity": "sha512-YjpsnV1xVTO1B836IKijRcDeceLgHQNJ/DWa+Vky9UHkm1Mi4qosddX8LZzldaWRTWKX7BN1MbZOLY8r7M/MZQ==",
       "dev": true,
       "requires": {
         "@firebase/app-check-interop-types": "0.1.0",
         "@firebase/app-check-types": "0.3.1",
-        "@firebase/component": "0.5.5",
+        "@firebase/component": "0.5.6",
         "@firebase/logger": "0.2.6",
-        "@firebase/util": "1.2.0",
+        "@firebase/util": "1.3.0",
         "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.6.tgz",
+          "integrity": "sha512-GyQJ+2lrhsDqeGgd1VdS7W+Y6gNYyI0B51ovNTxeZVG/W8I7t9MwEiCWsCvfm5wQgfsKp9dkzOcJrL5k8oVO/Q==",
+          "dev": true,
+          "requires": {
+            "@firebase/util": "1.3.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@firebase/util": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.3.0.tgz",
+          "integrity": "sha512-SESvmYwuKOVCZ1ZxLbberbx+9cnbxpCa4CG2FUSQYqN6Ab8KyltegMDIsqMw5KyIBZ4n1phfHoOa22xo5NzAlQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        }
       }
     },
     "@firebase/app-check-interop-types": {
@@ -656,39 +727,81 @@
       }
     },
     "@firebase/firestore": {
-      "version": "2.3.10",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-2.3.10.tgz",
-      "integrity": "sha512-O+XpaZVhDIBK2fMwBUBR2BuhaXF6zTmz+afAuXAx18DK+2rFfLefbALZLaUYw0Aabe9pryy0c7OenzRbHA8n4Q==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-2.4.0.tgz",
+      "integrity": "sha512-PQ6+lWNrvh74GvFTHT4gCutFipDmtu8D1tNNawKe+/SyL6XFgeuMYgZIpKQgkTSezVDogC7EGQTJBFnewF9pOg==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.5.5",
-        "@firebase/firestore-types": "2.3.0",
+        "@firebase/component": "0.5.6",
+        "@firebase/firestore-types": "2.4.0",
         "@firebase/logger": "0.2.6",
-        "@firebase/util": "1.2.0",
+        "@firebase/util": "1.3.0",
         "@firebase/webchannel-wrapper": "0.5.1",
         "@grpc/grpc-js": "^1.3.2",
         "@grpc/proto-loader": "^0.6.0",
         "node-fetch": "2.6.1",
         "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.6.tgz",
+          "integrity": "sha512-GyQJ+2lrhsDqeGgd1VdS7W+Y6gNYyI0B51ovNTxeZVG/W8I7t9MwEiCWsCvfm5wQgfsKp9dkzOcJrL5k8oVO/Q==",
+          "dev": true,
+          "requires": {
+            "@firebase/util": "1.3.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@firebase/util": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.3.0.tgz",
+          "integrity": "sha512-SESvmYwuKOVCZ1ZxLbberbx+9cnbxpCa4CG2FUSQYqN6Ab8KyltegMDIsqMw5KyIBZ4n1phfHoOa22xo5NzAlQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        }
       }
     },
     "@firebase/firestore-types": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-2.3.0.tgz",
-      "integrity": "sha512-QTW7NP7nDL0pgT/X53lyj+mIMh4nRQBBTBlRNQBt7eSyeqBf3ag3bxdQhCg358+5KbjYTC2/O6QtX9DlJZmh1A==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-2.4.0.tgz",
+      "integrity": "sha512-0dgwfuNP7EN6/OlK2HSNSQiQNGLGaRBH0gvgr1ngtKKJuJFuq0Z48RBMeJX9CGjV4TP9h2KaB+KrUKJ5kh1hMg==",
       "dev": true
     },
     "@firebase/functions": {
-      "version": "0.6.14",
-      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.6.14.tgz",
-      "integrity": "sha512-Gthru/wHPQqkn651MenVM+qKVFFqIyFcNT3qfJUacibqrKlvDtYtaCMjFGAkChuGnYzNVnXJIaNrIHkEIII4Hg==",
+      "version": "0.6.15",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.6.15.tgz",
+      "integrity": "sha512-b7RpLwFXi0N+HgkfK8cmkarSOoBeSrc1jNdadkCacQt+vIePkKM3E9EJXF4roWSa8GwTruodpBsvH+lK9iCAKQ==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.5.5",
+        "@firebase/component": "0.5.6",
         "@firebase/functions-types": "0.4.0",
         "@firebase/messaging-types": "0.5.0",
         "node-fetch": "2.6.1",
         "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.6.tgz",
+          "integrity": "sha512-GyQJ+2lrhsDqeGgd1VdS7W+Y6gNYyI0B51ovNTxeZVG/W8I7t9MwEiCWsCvfm5wQgfsKp9dkzOcJrL5k8oVO/Q==",
+          "dev": true,
+          "requires": {
+            "@firebase/util": "1.3.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@firebase/util": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.3.0.tgz",
+          "integrity": "sha512-SESvmYwuKOVCZ1ZxLbberbx+9cnbxpCa4CG2FUSQYqN6Ab8KyltegMDIsqMw5KyIBZ4n1phfHoOa22xo5NzAlQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        }
       }
     },
     "@firebase/functions-types": {
@@ -698,16 +811,37 @@
       "dev": true
     },
     "@firebase/installations": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.31.tgz",
-      "integrity": "sha512-qWolhAgMHvD3avsNCl+K8+untzoDDFQIRR8At8kyWMKKosy0vttdWTWzjvDoZbyKU6r0RNlxDUWAgV88Q8EudQ==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.32.tgz",
+      "integrity": "sha512-K4UlED1Vrhd2rFQQJih+OgEj8OTtrtH4+Izkx7ip2bhXSc+unk8ZhnF69D0kmh7zjXAqEDJrmHs9O5fI3rV6Tw==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.5.5",
+        "@firebase/component": "0.5.6",
         "@firebase/installations-types": "0.3.4",
-        "@firebase/util": "1.2.0",
+        "@firebase/util": "1.3.0",
         "idb": "3.0.2",
         "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.6.tgz",
+          "integrity": "sha512-GyQJ+2lrhsDqeGgd1VdS7W+Y6gNYyI0B51ovNTxeZVG/W8I7t9MwEiCWsCvfm5wQgfsKp9dkzOcJrL5k8oVO/Q==",
+          "dev": true,
+          "requires": {
+            "@firebase/util": "1.3.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@firebase/util": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.3.0.tgz",
+          "integrity": "sha512-SESvmYwuKOVCZ1ZxLbberbx+9cnbxpCa4CG2FUSQYqN6Ab8KyltegMDIsqMw5KyIBZ4n1phfHoOa22xo5NzAlQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        }
       }
     },
     "@firebase/installations-types": {
@@ -723,17 +857,38 @@
       "dev": true
     },
     "@firebase/messaging": {
-      "version": "0.7.15",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.7.15.tgz",
-      "integrity": "sha512-81t6iJtqMBJF5LHTjDhlHUpbPZOV6dKhW0TueAoON4omc0SaDXgf4nnk6JkvZRfdcuOaP8848Cv53tvZPFFAYQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.8.0.tgz",
+      "integrity": "sha512-hkFHDyVe1kMcY9KEG+prjCbvS6MtLUgVFUbbQqq7JQfiv58E07YCzRUcMrJolbNi/1QHH6Jv16DxNWjJB9+/qA==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.5.5",
-        "@firebase/installations": "0.4.31",
+        "@firebase/component": "0.5.6",
+        "@firebase/installations": "0.4.32",
         "@firebase/messaging-types": "0.5.0",
-        "@firebase/util": "1.2.0",
+        "@firebase/util": "1.3.0",
         "idb": "3.0.2",
         "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.6.tgz",
+          "integrity": "sha512-GyQJ+2lrhsDqeGgd1VdS7W+Y6gNYyI0B51ovNTxeZVG/W8I7t9MwEiCWsCvfm5wQgfsKp9dkzOcJrL5k8oVO/Q==",
+          "dev": true,
+          "requires": {
+            "@firebase/util": "1.3.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@firebase/util": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.3.0.tgz",
+          "integrity": "sha512-SESvmYwuKOVCZ1ZxLbberbx+9cnbxpCa4CG2FUSQYqN6Ab8KyltegMDIsqMw5KyIBZ4n1phfHoOa22xo5NzAlQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        }
       }
     },
     "@firebase/messaging-types": {
@@ -743,17 +898,38 @@
       "dev": true
     },
     "@firebase/performance": {
-      "version": "0.4.17",
-      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.4.17.tgz",
-      "integrity": "sha512-uhDs9rhdMrGraYHcd3CTRkGtcNap4hp6rAHTwJNIX56Z3RzQ1VW2ea9vvesl7EjFtEIPU0jfdrS32wV+qer5DQ==",
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.4.18.tgz",
+      "integrity": "sha512-lvZW/TVDne2TyOpWbv++zjRn277HZpbjxbIPfwtnmKjVY1gJ+H77Qi1c2avVIc9hg80uGX/5tNf4pOApNDJLVg==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.5.5",
-        "@firebase/installations": "0.4.31",
+        "@firebase/component": "0.5.6",
+        "@firebase/installations": "0.4.32",
         "@firebase/logger": "0.2.6",
         "@firebase/performance-types": "0.0.13",
-        "@firebase/util": "1.2.0",
+        "@firebase/util": "1.3.0",
         "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.6.tgz",
+          "integrity": "sha512-GyQJ+2lrhsDqeGgd1VdS7W+Y6gNYyI0B51ovNTxeZVG/W8I7t9MwEiCWsCvfm5wQgfsKp9dkzOcJrL5k8oVO/Q==",
+          "dev": true,
+          "requires": {
+            "@firebase/util": "1.3.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@firebase/util": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.3.0.tgz",
+          "integrity": "sha512-SESvmYwuKOVCZ1ZxLbberbx+9cnbxpCa4CG2FUSQYqN6Ab8KyltegMDIsqMw5KyIBZ4n1phfHoOa22xo5NzAlQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        }
       }
     },
     "@firebase/performance-types": {
@@ -774,17 +950,38 @@
       }
     },
     "@firebase/remote-config": {
-      "version": "0.1.42",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.42.tgz",
-      "integrity": "sha512-hWwtAZmYLB274bxjV2cdMYhyBCUUqbYErihGx3rMyab76D+VbIxOuKJb2z0DS67jQG+SA3pr9/MtWsTPHV/l9g==",
+      "version": "0.1.43",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.43.tgz",
+      "integrity": "sha512-laNM4MN0CfeSp7XCVNjYOC4DdV6mj0l2rzUh42x4v2wLTweCoJ/kc1i4oWMX9TI7Jw8Am5Wl71Awn1J2pVe5xA==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.5.5",
-        "@firebase/installations": "0.4.31",
+        "@firebase/component": "0.5.6",
+        "@firebase/installations": "0.4.32",
         "@firebase/logger": "0.2.6",
         "@firebase/remote-config-types": "0.1.9",
-        "@firebase/util": "1.2.0",
+        "@firebase/util": "1.3.0",
         "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.6.tgz",
+          "integrity": "sha512-GyQJ+2lrhsDqeGgd1VdS7W+Y6gNYyI0B51ovNTxeZVG/W8I7t9MwEiCWsCvfm5wQgfsKp9dkzOcJrL5k8oVO/Q==",
+          "dev": true,
+          "requires": {
+            "@firebase/util": "1.3.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@firebase/util": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.3.0.tgz",
+          "integrity": "sha512-SESvmYwuKOVCZ1ZxLbberbx+9cnbxpCa4CG2FUSQYqN6Ab8KyltegMDIsqMw5KyIBZ4n1phfHoOa22xo5NzAlQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        }
       }
     },
     "@firebase/remote-config-types": {
@@ -794,35 +991,77 @@
       "dev": true
     },
     "@firebase/rules-unit-testing": {
-      "version": "1.3.14",
-      "resolved": "https://registry.npmjs.org/@firebase/rules-unit-testing/-/rules-unit-testing-1.3.14.tgz",
-      "integrity": "sha512-wqPpdG1LMO7emDnW7mqgU0RAIoP8I191iQJ/0AftYLg0MIlTJoxTdHcoAbmRJNJS/xIraxF84pt1i1WHVxqwig==",
+      "version": "1.3.15",
+      "resolved": "https://registry.npmjs.org/@firebase/rules-unit-testing/-/rules-unit-testing-1.3.15.tgz",
+      "integrity": "sha512-OQOoME4FDkKbXduWYaKOYrV13tOWepH267vC4dhrLUBrQ0zOyvZuvmtM07F/aQSSuAmrdbBVSoM4BqcJiGzDeg==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.5.5",
+        "@firebase/component": "0.5.6",
         "@firebase/logger": "0.2.6",
-        "@firebase/util": "1.2.0",
-        "firebase": "8.9.1",
+        "@firebase/util": "1.3.0",
+        "firebase": "8.10.0",
         "request": "2.88.2"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.6.tgz",
+          "integrity": "sha512-GyQJ+2lrhsDqeGgd1VdS7W+Y6gNYyI0B51ovNTxeZVG/W8I7t9MwEiCWsCvfm5wQgfsKp9dkzOcJrL5k8oVO/Q==",
+          "dev": true,
+          "requires": {
+            "@firebase/util": "1.3.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@firebase/util": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.3.0.tgz",
+          "integrity": "sha512-SESvmYwuKOVCZ1ZxLbberbx+9cnbxpCa4CG2FUSQYqN6Ab8KyltegMDIsqMw5KyIBZ4n1phfHoOa22xo5NzAlQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        }
       }
     },
     "@firebase/storage": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.6.2.tgz",
-      "integrity": "sha512-qbYx+KOxnD5andWAtVPgMHFa/62jdLCgPGdfIRQIEgBoYibk3KigRYVdnfKRLcCO3Vip63BRUvyeqfiUHNNu2g==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.7.0.tgz",
+      "integrity": "sha512-ebDFKJbM5HOxVtZV+RhVEBVtlWHK+Z5L3kA5uDBA2jMYcn+8NV/crozJnEE+iRsGEco6dLK5JS+Er4qtKLpH5A==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.5.5",
-        "@firebase/storage-types": "0.4.1",
-        "@firebase/util": "1.2.0",
+        "@firebase/component": "0.5.6",
+        "@firebase/storage-types": "0.5.0",
+        "@firebase/util": "1.3.0",
         "node-fetch": "2.6.1",
         "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.6.tgz",
+          "integrity": "sha512-GyQJ+2lrhsDqeGgd1VdS7W+Y6gNYyI0B51ovNTxeZVG/W8I7t9MwEiCWsCvfm5wQgfsKp9dkzOcJrL5k8oVO/Q==",
+          "dev": true,
+          "requires": {
+            "@firebase/util": "1.3.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@firebase/util": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.3.0.tgz",
+          "integrity": "sha512-SESvmYwuKOVCZ1ZxLbberbx+9cnbxpCa4CG2FUSQYqN6Ab8KyltegMDIsqMw5KyIBZ4n1phfHoOa22xo5NzAlQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        }
       }
     },
     "@firebase/storage-types": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.4.1.tgz",
-      "integrity": "sha512-IM4cRzAnQ6QZoaxVZ5MatBzqXVcp47hOlE28jd9xXw1M9V7gfjhmW0PALGFQx58tPVmuUwIKyoEbHZjV4qRJwQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.5.0.tgz",
+      "integrity": "sha512-6Wv3Lu7s18hsgW7HG4BFwycTquZ3m/C8bjBoOsmPu0TD6M1GKwCzOC7qBdN7L6tRYPh8ipTj5+rPFrmhGfUVKA==",
       "dev": true
     },
     "@firebase/util": {
@@ -1040,64 +1279,65 @@
       "dev": true
     },
     "@jest/console": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-27.1.0.tgz",
-      "integrity": "sha512-+Vl+xmLwAXLNlqT61gmHEixeRbS4L8MUzAjtpBCOPWH+izNI/dR16IeXjkXJdRtIVWVSf9DO1gdp67B1XorZhQ==",
+      "version": "27.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-27.2.0.tgz",
+      "integrity": "sha512-35z+RqsK2CCgNxn+lWyK8X4KkaDtfL4BggT7oeZ0JffIiAiEYFYPo5B67V50ZubqDS1ehBrdCR2jduFnIrZOYw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.1.0",
+        "@jest/types": "^27.1.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "jest-message-util": "^27.1.0",
-        "jest-util": "^27.1.0",
+        "jest-message-util": "^27.2.0",
+        "jest-util": "^27.2.0",
         "slash": "^3.0.0"
       },
       "dependencies": {
-        "@jest/types": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
-          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+        "jest-util": {
+          "version": "27.2.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.2.0.tgz",
+          "integrity": "sha512-T5ZJCNeFpqcLBpx+Hl9r9KoxBCUqeWlJ1Htli+vryigZVJ1vuLB9j35grEBASp4R13KFkV7jM52bBGnArpJN6A==",
           "dev": true,
           "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
+            "@jest/types": "^27.1.1",
             "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^3.0.0",
+            "picomatch": "^2.2.3"
           }
         }
       }
     },
     "@jest/core": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.1.0.tgz",
-      "integrity": "sha512-3l9qmoknrlCFKfGdrmiQiPne+pUR4ALhKwFTYyOeKw6egfDwJkO21RJ1xf41rN8ZNFLg5W+w6+P4fUqq4EMRWA==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.2.1.tgz",
+      "integrity": "sha512-XcGt9UgPyzylThvezwUIMCNVp8xxN78Ic3WwhJZehZt4n2hPHR6Bd85A1nKFZBeqW58Vd+Cx/LaN6YL4n58KlA==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.1.0",
-        "@jest/reporters": "^27.1.0",
-        "@jest/test-result": "^27.1.0",
-        "@jest/transform": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/console": "^27.2.0",
+        "@jest/reporters": "^27.2.1",
+        "@jest/test-result": "^27.2.0",
+        "@jest/transform": "^27.2.1",
+        "@jest/types": "^27.1.1",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "emittery": "^0.8.1",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
-        "jest-changed-files": "^27.1.0",
-        "jest-config": "^27.1.0",
-        "jest-haste-map": "^27.1.0",
-        "jest-message-util": "^27.1.0",
+        "jest-changed-files": "^27.1.1",
+        "jest-config": "^27.2.1",
+        "jest-haste-map": "^27.2.0",
+        "jest-message-util": "^27.2.0",
         "jest-regex-util": "^27.0.6",
-        "jest-resolve": "^27.1.0",
-        "jest-resolve-dependencies": "^27.1.0",
-        "jest-runner": "^27.1.0",
-        "jest-runtime": "^27.1.0",
-        "jest-snapshot": "^27.1.0",
-        "jest-util": "^27.1.0",
-        "jest-validate": "^27.1.0",
-        "jest-watcher": "^27.1.0",
+        "jest-resolve": "^27.2.0",
+        "jest-resolve-dependencies": "^27.2.1",
+        "jest-runner": "^27.2.1",
+        "jest-runtime": "^27.2.1",
+        "jest-snapshot": "^27.2.1",
+        "jest-util": "^27.2.0",
+        "jest-validate": "^27.2.0",
+        "jest-watcher": "^27.2.0",
         "micromatch": "^4.0.4",
         "p-each-series": "^2.1.0",
         "rimraf": "^3.0.0",
@@ -1105,114 +1345,86 @@
         "strip-ansi": "^6.0.0"
       },
       "dependencies": {
-        "@jest/types": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
-          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+        "jest-util": {
+          "version": "27.2.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.2.0.tgz",
+          "integrity": "sha512-T5ZJCNeFpqcLBpx+Hl9r9KoxBCUqeWlJ1Htli+vryigZVJ1vuLB9j35grEBASp4R13KFkV7jM52bBGnArpJN6A==",
           "dev": true,
           "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
+            "@jest/types": "^27.1.1",
             "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^3.0.0",
+            "picomatch": "^2.2.3"
           }
         }
       }
     },
     "@jest/environment": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.1.0.tgz",
-      "integrity": "sha512-wRp50aAMY2w1U2jP1G32d6FUVBNYqmk8WaGkiIEisU48qyDV0WPtw3IBLnl7orBeggveommAkuijY+RzVnNDOQ==",
+      "version": "27.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.2.0.tgz",
+      "integrity": "sha512-iPWmQI0wRIYSZX3wKu4FXHK4eIqkfq6n1DCDJS+v3uby7SOXrHvX4eiTBuEdSvtDRMTIH2kjrSkjHf/F9JIYyQ==",
       "dev": true,
       "requires": {
-        "@jest/fake-timers": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/fake-timers": "^27.2.0",
+        "@jest/types": "^27.1.1",
         "@types/node": "*",
-        "jest-mock": "^27.1.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
-          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
-          }
-        }
+        "jest-mock": "^27.1.1"
       }
     },
     "@jest/fake-timers": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.1.0.tgz",
-      "integrity": "sha512-22Zyn8il8DzpS+30jJNVbTlm7vAtnfy1aYvNeOEHloMlGy1PCYLHa4PWlSws0hvNsMM5bON6GISjkLoQUV3oMA==",
+      "version": "27.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.2.0.tgz",
+      "integrity": "sha512-gSu3YHvQOoVaTWYGgHFB7IYFtcF2HBzX4l7s47VcjvkUgL4/FBnE20x7TNLa3W6ABERtGd5gStSwsA8bcn+c4w==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.1.0",
+        "@jest/types": "^27.1.1",
         "@sinonjs/fake-timers": "^7.0.2",
         "@types/node": "*",
-        "jest-message-util": "^27.1.0",
-        "jest-mock": "^27.1.0",
-        "jest-util": "^27.1.0"
+        "jest-message-util": "^27.2.0",
+        "jest-mock": "^27.1.1",
+        "jest-util": "^27.2.0"
       },
       "dependencies": {
-        "@jest/types": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
-          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+        "jest-util": {
+          "version": "27.2.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.2.0.tgz",
+          "integrity": "sha512-T5ZJCNeFpqcLBpx+Hl9r9KoxBCUqeWlJ1Htli+vryigZVJ1vuLB9j35grEBASp4R13KFkV7jM52bBGnArpJN6A==",
           "dev": true,
           "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
+            "@jest/types": "^27.1.1",
             "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^3.0.0",
+            "picomatch": "^2.2.3"
           }
         }
       }
     },
     "@jest/globals": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.1.0.tgz",
-      "integrity": "sha512-73vLV4aNHAlAgjk0/QcSIzzCZSqVIPbmFROJJv9D3QUR7BI4f517gVdJpSrCHxuRH3VZFhe0yGG/tmttlMll9g==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.2.1.tgz",
+      "integrity": "sha512-4P46Zr4cckSitsWtOMRvgMMn7mOKbBsQdYxHeGSIG3kpI4gNR2vk51balPulZHnBQCQb/XBptprtoSv1REfaew==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.1.0",
-        "@jest/types": "^27.1.0",
-        "expect": "^27.1.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
-          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
-          }
-        }
+        "@jest/environment": "^27.2.0",
+        "@jest/types": "^27.1.1",
+        "expect": "^27.2.1"
       }
     },
     "@jest/reporters": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.1.0.tgz",
-      "integrity": "sha512-5T/zlPkN2HnK3Sboeg64L5eC8iiaZueLpttdktWTJsvALEtP2YMkC5BQxwjRWQACG9SwDmz+XjjkoxXUDMDgdw==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.2.1.tgz",
+      "integrity": "sha512-ILqR+bIIBlhaHjDtQR/0Z20YkKAQVM+NVRuJLaWFCoRx/rKQQSxG01ZLiLV0MsA6wkBHf6J9fzFuXp0k5l7epw==",
       "dev": true,
       "requires": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^27.1.0",
-        "@jest/test-result": "^27.1.0",
-        "@jest/transform": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/console": "^27.2.0",
+        "@jest/test-result": "^27.2.0",
+        "@jest/transform": "^27.2.1",
+        "@jest/types": "^27.1.1",
         "chalk": "^4.0.0",
         "collect-v8-coverage": "^1.0.0",
         "exit": "^0.1.2",
@@ -1223,10 +1435,10 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.0.2",
-        "jest-haste-map": "^27.1.0",
-        "jest-resolve": "^27.1.0",
-        "jest-util": "^27.1.0",
-        "jest-worker": "^27.1.0",
+        "jest-haste-map": "^27.2.0",
+        "jest-resolve": "^27.2.0",
+        "jest-util": "^27.2.0",
+        "jest-worker": "^27.2.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -1234,17 +1446,18 @@
         "v8-to-istanbul": "^8.0.0"
       },
       "dependencies": {
-        "@jest/types": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
-          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+        "jest-util": {
+          "version": "27.2.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.2.0.tgz",
+          "integrity": "sha512-T5ZJCNeFpqcLBpx+Hl9r9KoxBCUqeWlJ1Htli+vryigZVJ1vuLB9j35grEBASp4R13KFkV7jM52bBGnArpJN6A==",
           "dev": true,
           "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
+            "@jest/types": "^27.1.1",
             "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^3.0.0",
+            "picomatch": "^2.2.3"
           }
         }
       }
@@ -1261,60 +1474,45 @@
       }
     },
     "@jest/test-result": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.1.0.tgz",
-      "integrity": "sha512-Aoz00gpDL528ODLghat3QSy6UBTD5EmmpjrhZZMK/v1Q2/rRRqTGnFxHuEkrD4z/Py96ZdOHxIWkkCKRpmnE1A==",
+      "version": "27.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.2.0.tgz",
+      "integrity": "sha512-JPPqn8h0RGr4HyeY1Km+FivDIjTFzDROU46iAvzVjD42ooGwYoqYO/MQTilhfajdz6jpVnnphFrKZI5OYrBONA==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/console": "^27.2.0",
+        "@jest/types": "^27.1.1",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
-          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
-          }
-        }
       }
     },
     "@jest/test-sequencer": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.1.0.tgz",
-      "integrity": "sha512-lnCWawDr6Z1DAAK9l25o3AjmKGgcutq1iIbp+hC10s/HxnB8ZkUsYq1FzjOoxxZ5hW+1+AthBtvS4x9yno3V1A==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.2.1.tgz",
+      "integrity": "sha512-fWcEgWQXgvU4DFY5YHfQsGwqfJWyuCUzdOzLZTYtyLB3WK1mFPQGYAszM7mCEZjyVon5XRuCa+2/+hif/uMucQ==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^27.1.0",
+        "@jest/test-result": "^27.2.0",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.1.0",
-        "jest-runtime": "^27.1.0"
+        "jest-haste-map": "^27.2.0",
+        "jest-runtime": "^27.2.1"
       }
     },
     "@jest/transform": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.1.0.tgz",
-      "integrity": "sha512-ZRGCA2ZEVJ00ubrhkTG87kyLbN6n55g1Ilq0X9nJb5bX3MhMp3O6M7KG+LvYu+nZRqG5cXsQnJEdZbdpTAV8pQ==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.2.1.tgz",
+      "integrity": "sha512-xmB5vh81KK8DiiCMtI5vI59mP+GggNmc9BiN+fg4mKdQHV369+WuZc1Lq2xWFCOCsRPHt24D9h7Idp4YaMB1Ww==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/types": "^27.1.1",
         "babel-plugin-istanbul": "^6.0.0",
         "chalk": "^4.0.0",
         "convert-source-map": "^1.4.0",
         "fast-json-stable-stringify": "^2.0.0",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.1.0",
+        "jest-haste-map": "^27.2.0",
         "jest-regex-util": "^27.0.6",
-        "jest-util": "^27.1.0",
+        "jest-util": "^27.2.0",
         "micromatch": "^4.0.4",
         "pirates": "^4.0.1",
         "slash": "^3.0.0",
@@ -1322,25 +1520,26 @@
         "write-file-atomic": "^3.0.0"
       },
       "dependencies": {
-        "@jest/types": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
-          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+        "jest-util": {
+          "version": "27.2.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.2.0.tgz",
+          "integrity": "sha512-T5ZJCNeFpqcLBpx+Hl9r9KoxBCUqeWlJ1Htli+vryigZVJ1vuLB9j35grEBASp4R13KFkV7jM52bBGnArpJN6A==",
           "dev": true,
           "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
+            "@jest/types": "^27.1.1",
             "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^3.0.0",
+            "picomatch": "^2.2.3"
           }
         }
       }
     },
     "@jest/types": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
-      "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
+      "version": "27.1.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.1.tgz",
+      "integrity": "sha512-yqJPDDseb0mXgKqmNqypCsb85C22K1aY5+LUxh7syIM9n/b0AsaltxNy+o6tt29VcfGDpYEve175bm3uOhcehA==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1495,9 +1694,9 @@
       "dev": true
     },
     "@types/babel__core": {
-      "version": "7.1.15",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.15.tgz",
-      "integrity": "sha512-bxlMKPDbY8x5h6HBwVzEOk2C8fb6SLfYQ5Jw3uBYuYF1lfWk/kbLd81la82vrIkBb0l+JdmrZaDikPrNxpS/Ew==",
+      "version": "7.1.16",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.16.tgz",
+      "integrity": "sha512-EAEHtisTMM+KaKwfWdC3oyllIqswlznXCIVCt7/oRNrh+DhgT4UEBNC/jlADNjvw7UnfbcdkGQcPVZ1xYiLcrQ==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
@@ -1630,9 +1829,9 @@
       }
     },
     "@types/jest": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.0.1.tgz",
-      "integrity": "sha512-HTLpVXHrY69556ozYkcq47TtQJXpcWAWfkoqz+ZGz2JnmZhzlRjprCIyFnetSy8gpDWwTTGBcRVv1J1I1vBrHw==",
+      "version": "27.0.2",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.0.2.tgz",
+      "integrity": "sha512-4dRxkS/AFX0c5XW6IPMNOydLn2tEhNhJV7DnYK+0bjoJZ+QTmfucBlihX7aoEsh/ocYtkLC73UbnBXBXIxsULA==",
       "dev": true,
       "requires": {
         "jest-diff": "^27.0.0",
@@ -1725,13 +1924,13 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.30.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.30.0.tgz",
-      "integrity": "sha512-NgAnqk55RQ/SD+tZFD9aPwNSeHmDHHe5rtUyhIq0ZeCWZEvo4DK9rYz7v9HDuQZFvn320Ot+AikaCKMFKLlD0g==",
+      "version": "4.31.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.31.2.tgz",
+      "integrity": "sha512-w63SCQ4bIwWN/+3FxzpnWrDjQRXVEGiTt9tJTRptRXeFvdZc/wLiz3FQUwNQ2CVoRGI6KUWMNUj/pk63noUfcA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.30.0",
-        "@typescript-eslint/scope-manager": "4.30.0",
+        "@typescript-eslint/experimental-utils": "4.31.2",
+        "@typescript-eslint/scope-manager": "4.31.2",
         "debug": "^4.3.1",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.1.0",
@@ -1751,55 +1950,55 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.30.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.30.0.tgz",
-      "integrity": "sha512-K8RNIX9GnBsv5v4TjtwkKtqMSzYpjqAQg/oSphtxf3xxdt6T0owqnpojztjjTcatSteH3hLj3t/kklKx87NPqw==",
+      "version": "4.31.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.31.2.tgz",
+      "integrity": "sha512-3tm2T4nyA970yQ6R3JZV9l0yilE2FedYg8dcXrTar34zC9r6JB7WyBQbpIVongKPlhEMjhQ01qkwrzWy38Bk1Q==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.7",
-        "@typescript-eslint/scope-manager": "4.30.0",
-        "@typescript-eslint/types": "4.30.0",
-        "@typescript-eslint/typescript-estree": "4.30.0",
+        "@typescript-eslint/scope-manager": "4.31.2",
+        "@typescript-eslint/types": "4.31.2",
+        "@typescript-eslint/typescript-estree": "4.31.2",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.30.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.30.0.tgz",
-      "integrity": "sha512-HJ0XuluSZSxeboLU7Q2VQ6eLlCwXPBOGnA7CqgBnz2Db3JRQYyBDJgQnop6TZ+rsbSx5gEdWhw4rE4mDa1FnZg==",
+      "version": "4.31.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.31.2.tgz",
+      "integrity": "sha512-EcdO0E7M/sv23S/rLvenHkb58l3XhuSZzKf6DBvLgHqOYdL6YFMYVtreGFWirxaU2mS1GYDby3Lyxco7X5+Vjw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.30.0",
-        "@typescript-eslint/types": "4.30.0",
-        "@typescript-eslint/typescript-estree": "4.30.0",
+        "@typescript-eslint/scope-manager": "4.31.2",
+        "@typescript-eslint/types": "4.31.2",
+        "@typescript-eslint/typescript-estree": "4.31.2",
         "debug": "^4.3.1"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.30.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.30.0.tgz",
-      "integrity": "sha512-VJ/jAXovxNh7rIXCQbYhkyV2Y3Ac/0cVHP/FruTJSAUUm4Oacmn/nkN5zfWmWFEanN4ggP0vJSHOeajtHq3f8A==",
+      "version": "4.31.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.31.2.tgz",
+      "integrity": "sha512-2JGwudpFoR/3Czq6mPpE8zBPYdHWFGL6lUNIGolbKQeSNv4EAiHaR5GVDQaLA0FwgcdcMtRk+SBJbFGL7+La5w==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.30.0",
-        "@typescript-eslint/visitor-keys": "4.30.0"
+        "@typescript-eslint/types": "4.31.2",
+        "@typescript-eslint/visitor-keys": "4.31.2"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.30.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.30.0.tgz",
-      "integrity": "sha512-YKldqbNU9K4WpTNwBqtAerQKLLW/X2A/j4yw92e3ZJYLx+BpKLeheyzoPfzIXHfM8BXfoleTdiYwpsvVPvHrDw==",
+      "version": "4.31.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.31.2.tgz",
+      "integrity": "sha512-kWiTTBCTKEdBGrZKwFvOlGNcAsKGJSBc8xLvSjSppFO88AqGxGNYtF36EuEYG6XZ9vT0xX8RNiHbQUKglbSi1w==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.30.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.30.0.tgz",
-      "integrity": "sha512-6WN7UFYvykr/U0Qgy4kz48iGPWILvYL34xXJxvDQeiRE018B7POspNRVtAZscWntEPZpFCx4hcz/XBT+erenfg==",
+      "version": "4.31.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.31.2.tgz",
+      "integrity": "sha512-ieBq8U9at6PvaC7/Z6oe8D3czeW5d//Fo1xkF/s9394VR0bg/UaMYPdARiWyKX+lLEjY3w/FNZJxitMsiWv+wA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.30.0",
-        "@typescript-eslint/visitor-keys": "4.30.0",
+        "@typescript-eslint/types": "4.31.2",
+        "@typescript-eslint/visitor-keys": "4.31.2",
         "debug": "^4.3.1",
         "globby": "^11.0.3",
         "is-glob": "^4.0.1",
@@ -1819,12 +2018,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.30.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.30.0.tgz",
-      "integrity": "sha512-pNaaxDt/Ol/+JZwzP7MqWc8PJQTUhZwoee/PVlQ+iYoYhagccvoHnC9e4l+C/krQYYkENxznhVSDwClIbZVxRw==",
+      "version": "4.31.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.31.2.tgz",
+      "integrity": "sha512-PrBId7EQq2Nibns7dd/ch6S6/M4/iwLM9McbgeEbCXfxdwRUNxJ4UNreJ6Gh3fI2GNKNrWnQxKL7oCPmngKBug==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.30.0",
+        "@typescript-eslint/types": "4.31.2",
         "eslint-visitor-keys": "^2.0.0"
       }
     },
@@ -2043,34 +2242,19 @@
       "dev": true
     },
     "babel-jest": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.1.0.tgz",
-      "integrity": "sha512-6NrdqzaYemALGCuR97QkC/FkFIEBWP5pw5TMJoUHZTVXyOgocujp6A0JE2V6gE0HtqAAv6VKU/nI+OCR1Z4gHA==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.2.1.tgz",
+      "integrity": "sha512-kkaekSJHew1zfDW3cA2QiSBPg4uiLpiW0OwJKqFv0r2/mFgym/IBn7hxPntL6FvS66G/ROh+lz4pRiCJAH1/UQ==",
       "dev": true,
       "requires": {
-        "@jest/transform": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/transform": "^27.2.1",
+        "@jest/types": "^27.1.1",
         "@types/babel__core": "^7.1.14",
         "babel-plugin-istanbul": "^6.0.0",
-        "babel-preset-jest": "^27.0.6",
+        "babel-preset-jest": "^27.2.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "slash": "^3.0.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
-          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
-          }
-        }
       }
     },
     "babel-plugin-istanbul": {
@@ -2087,9 +2271,9 @@
       }
     },
     "babel-plugin-jest-hoist": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-27.0.6.tgz",
-      "integrity": "sha512-CewFeM9Vv2gM7Yr9n5eyyLVPRSiBnk6lKZRjgwYnGKSl9M14TMn2vkN02wTF04OGuSDLEzlWiMzvjXuW9mB6Gw==",
+      "version": "27.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-27.2.0.tgz",
+      "integrity": "sha512-TOux9khNKdi64mW+0OIhcmbAn75tTlzKhxmiNXevQaPbrBYK7YKjP1jl6NHTJ6XR5UgUrJbCnWlKVnJn29dfjw==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.3.3",
@@ -2119,12 +2303,12 @@
       }
     },
     "babel-preset-jest": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-27.0.6.tgz",
-      "integrity": "sha512-WObA0/Biw2LrVVwZkF/2GqbOdzhKD6Fkdwhoy9ASIrOWr/zodcSpQh72JOkEn6NWyjmnPDjNSqaGN4KnpKzhXw==",
+      "version": "27.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-27.2.0.tgz",
+      "integrity": "sha512-z7MgQ3peBwN5L5aCqBKnF6iqdlvZvFUQynEhu0J+X9nHLU72jO3iY331lcYrg+AssJ8q7xsv5/3AICzVmJ/wvg==",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "^27.0.6",
+        "babel-plugin-jest-hoist": "^27.2.0",
         "babel-preset-current-node-syntax": "^1.0.0"
       }
     },
@@ -2183,16 +2367,16 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.16.8",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.8.tgz",
-      "integrity": "sha512-sc2m9ohR/49sWEbPj14ZSSZqp+kbi16aLao42Hmn3Z8FpjuMaq2xCA2l4zl9ITfyzvnvyE0hcg62YkIGKxgaNQ==",
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.1.tgz",
+      "integrity": "sha512-aLD0ZMDSnF4lUt4ZDNgqi5BUn9BZ7YdQdI/cYlILrhdSSZJLU9aNZoD5/NBmM4SK34APB2e83MOsRt1EnkuyaQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001251",
-        "colorette": "^1.3.0",
-        "electron-to-chromium": "^1.3.811",
+        "caniuse-lite": "^1.0.30001259",
+        "electron-to-chromium": "^1.3.846",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.75"
+        "nanocolors": "^0.1.5",
+        "node-releases": "^1.1.76"
       }
     },
     "bs-logger": {
@@ -2248,10 +2432,13 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001252",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz",
-      "integrity": "sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==",
-      "dev": true
+      "version": "1.0.30001260",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001260.tgz",
+      "integrity": "sha512-Fhjc/k8725ItmrvW5QomzxLeojewxvqiYCKeFcfFEhut28IVLdpHU19dneOmltZQIE5HNbawj1HYD+1f2bM1Dg==",
+      "dev": true,
+      "requires": {
+        "nanocolors": "^0.1.0"
+      }
     },
     "caseless": {
       "version": "0.12.0",
@@ -2344,12 +2531,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "colorette": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
-      "integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==",
       "dev": true
     },
     "combined-stream": {
@@ -2654,9 +2835,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.825",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.825.tgz",
-      "integrity": "sha512-BO3FfWVeH8GQ0DBbi4HCL09OPgvN+0goqWlgKOCmCXcnrlgL5GA69nb7ZyjpWgpFUacBftg8BrXU2WLOSuHAxQ==",
+      "version": "1.3.850",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.850.tgz",
+      "integrity": "sha512-ZzkDcdzePeF4dhoGZQT77V2CyJOpwfTZEOg4h0x6R/jQhGt/rIRpbRyVreWLtD7B/WsVxo91URm2WxMKR9JQZA==",
       "dev": true
     },
     "emittery": {
@@ -3114,32 +3295,19 @@
       "dev": true
     },
     "expect": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-27.1.0.tgz",
-      "integrity": "sha512-9kJngV5hOJgkFil4F/uXm3hVBubUK2nERVfvqNNwxxuW8ZOUwSTTSysgfzckYtv/LBzj/LJXbiAF7okHCXgdug==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-27.2.1.tgz",
+      "integrity": "sha512-ekOA2mBtT2phxcoPVHCXIzbJxCvRXhx2fr7m28IgGdZxUOh8UvxvoRz1FcPlfgZMpE92biHB6woIcAKXqR28hA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.1.0",
+        "@jest/types": "^27.1.1",
         "ansi-styles": "^5.0.0",
         "jest-get-type": "^27.0.6",
-        "jest-matcher-utils": "^27.1.0",
-        "jest-message-util": "^27.1.0",
+        "jest-matcher-utils": "^27.2.0",
+        "jest-message-util": "^27.2.0",
         "jest-regex-util": "^27.0.6"
       },
       "dependencies": {
-        "@jest/types": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
-          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
         "ansi-styles": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
@@ -3210,9 +3378,9 @@
       "optional": true
     },
     "fastq": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.12.0.tgz",
-      "integrity": "sha512-VNX0QkHK3RsXVKr9KrlUv/FoTa0NdbYoHHl7uXHv2rzyHSlxjdNAKug2twd9luJxpcyNeAgf5iPPMutJO67Dfg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -3281,26 +3449,72 @@
       }
     },
     "firebase": {
-      "version": "8.9.1",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-8.9.1.tgz",
-      "integrity": "sha512-4aKRynB0LSWneYTPwWlAUbcJbgSS11lZRIo9MLNQh1uCo9BxRIYq/r3CCDJOx59tI2nwyv4RXf7hdkgSTF5FYw==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-8.10.0.tgz",
+      "integrity": "sha512-GCABTbJdo88QgzX5OH/vsfKBWvTRbLUylGlYXtO7uYo1VErfGd2BWW9ATlJP5Gxx+ClDfyvVTvcs2rcNWn3uUA==",
       "dev": true,
       "requires": {
-        "@firebase/analytics": "0.6.17",
-        "@firebase/app": "0.6.29",
-        "@firebase/app-check": "0.3.1",
+        "@firebase/analytics": "0.6.18",
+        "@firebase/app": "0.6.30",
+        "@firebase/app-check": "0.3.2",
         "@firebase/app-types": "0.6.3",
         "@firebase/auth": "0.16.8",
-        "@firebase/database": "0.10.9",
-        "@firebase/firestore": "2.3.10",
-        "@firebase/functions": "0.6.14",
-        "@firebase/installations": "0.4.31",
-        "@firebase/messaging": "0.7.15",
-        "@firebase/performance": "0.4.17",
+        "@firebase/database": "0.11.0",
+        "@firebase/firestore": "2.4.0",
+        "@firebase/functions": "0.6.15",
+        "@firebase/installations": "0.4.32",
+        "@firebase/messaging": "0.8.0",
+        "@firebase/performance": "0.4.18",
         "@firebase/polyfill": "0.3.36",
-        "@firebase/remote-config": "0.1.42",
-        "@firebase/storage": "0.6.2",
-        "@firebase/util": "1.2.0"
+        "@firebase/remote-config": "0.1.43",
+        "@firebase/storage": "0.7.0",
+        "@firebase/util": "1.3.0"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.6.tgz",
+          "integrity": "sha512-GyQJ+2lrhsDqeGgd1VdS7W+Y6gNYyI0B51ovNTxeZVG/W8I7t9MwEiCWsCvfm5wQgfsKp9dkzOcJrL5k8oVO/Q==",
+          "dev": true,
+          "requires": {
+            "@firebase/util": "1.3.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@firebase/database": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.11.0.tgz",
+          "integrity": "sha512-b/kwvCubr6G9coPlo48PbieBDln7ViFBHOGeVt/bt82yuv5jYZBEYAac/mtOVSxpf14aMo/tAN+Edl6SWqXApw==",
+          "dev": true,
+          "requires": {
+            "@firebase/auth-interop-types": "0.1.6",
+            "@firebase/component": "0.5.6",
+            "@firebase/database-types": "0.8.0",
+            "@firebase/logger": "0.2.6",
+            "@firebase/util": "1.3.0",
+            "faye-websocket": "0.11.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@firebase/database-types": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.8.0.tgz",
+          "integrity": "sha512-7IdjAFRfPWyG3b4wcXyghb3Y1CLCSJFZIg1xl5GbTVMttSQFT4B5NYdhsfA34JwAsv5pMzPpjOaS3/K9XJ2KiA==",
+          "dev": true,
+          "requires": {
+            "@firebase/app-types": "0.6.3",
+            "@firebase/util": "1.3.0"
+          }
+        },
+        "@firebase/util": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.3.0.tgz",
+          "integrity": "sha512-SESvmYwuKOVCZ1ZxLbberbx+9cnbxpCa4CG2FUSQYqN6Ab8KyltegMDIsqMw5KyIBZ4n1phfHoOa22xo5NzAlQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        }
       }
     },
     "firebase-admin": {
@@ -3343,13 +3557,13 @@
       "dev": true
     },
     "form-data": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
+        "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
       }
     },
@@ -4035,9 +4249,9 @@
       "dev": true
     },
     "istanbul-lib-coverage": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
-      "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.1.tgz",
+      "integrity": "sha512-GvCYYTxaCPqwMjobtVcVKvSHtAGe48MNhGjpK8LtVF8K0ISX7hCKl85LgtuaSneWVyQmaGcW3iXVV3GaZSLpmQ==",
       "dev": true
     },
     "istanbul-lib-instrument": {
@@ -4085,209 +4299,161 @@
       }
     },
     "jest": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-27.1.0.tgz",
-      "integrity": "sha512-pSQDVwRSwb109Ss13lcMtdfS9r8/w2Zz8+mTUA9VORD66GflCdl8nUFCqM96geOD2EBwWCNURrNAfQsLIDNBdg==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-27.2.1.tgz",
+      "integrity": "sha512-0MyvNS7J1HbkeotYaqKNGioN+p1/AAPtI1Z8iwMtCBE+PwBT+M4l25D9Pve8/KdhktYLgZaGyyj9CoDytD+R2Q==",
       "dev": true,
       "requires": {
-        "@jest/core": "^27.1.0",
+        "@jest/core": "^27.2.1",
         "import-local": "^3.0.2",
-        "jest-cli": "^27.1.0"
+        "jest-cli": "^27.2.1"
       },
       "dependencies": {
-        "@jest/types": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
-          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
         "jest-cli": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.1.0.tgz",
-          "integrity": "sha512-h6zPUOUu+6oLDrXz0yOWY2YXvBLk8gQinx4HbZ7SF4V3HzasQf+ncoIbKENUMwXyf54/6dBkYXvXJos+gOHYZw==",
+          "version": "27.2.1",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.2.1.tgz",
+          "integrity": "sha512-IfxuGkBZS/ogY7yFvvD1dFidzQRXlSBHtUZQ3UTIHydzNMF4/ZRTdGFso6HkbCkemwLh4hnNybONexEqWmYwjw==",
           "dev": true,
           "requires": {
-            "@jest/core": "^27.1.0",
-            "@jest/test-result": "^27.1.0",
-            "@jest/types": "^27.1.0",
+            "@jest/core": "^27.2.1",
+            "@jest/test-result": "^27.2.0",
+            "@jest/types": "^27.1.1",
             "chalk": "^4.0.0",
             "exit": "^0.1.2",
             "graceful-fs": "^4.2.4",
             "import-local": "^3.0.2",
-            "jest-config": "^27.1.0",
-            "jest-util": "^27.1.0",
-            "jest-validate": "^27.1.0",
+            "jest-config": "^27.2.1",
+            "jest-util": "^27.2.0",
+            "jest-validate": "^27.2.0",
             "prompts": "^2.0.1",
             "yargs": "^16.0.3"
+          }
+        },
+        "jest-util": {
+          "version": "27.2.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.2.0.tgz",
+          "integrity": "sha512-T5ZJCNeFpqcLBpx+Hl9r9KoxBCUqeWlJ1Htli+vryigZVJ1vuLB9j35grEBASp4R13KFkV7jM52bBGnArpJN6A==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.1.1",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^3.0.0",
+            "picomatch": "^2.2.3"
           }
         }
       }
     },
     "jest-changed-files": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.1.0.tgz",
-      "integrity": "sha512-eRcb13TfQw0xiV2E98EmiEgs9a5uaBIqJChyl0G7jR9fCIvGjXovnDS6Zbku3joij4tXYcSK4SE1AXqOlUxjWg==",
+      "version": "27.1.1",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.1.1.tgz",
+      "integrity": "sha512-5TV9+fYlC2A6hu3qtoyGHprBwCAn0AuGA77bZdUgYvVlRMjHXo063VcWTEAyx6XAZ85DYHqp0+aHKbPlfRDRvA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.1.0",
+        "@jest/types": "^27.1.1",
         "execa": "^5.0.0",
         "throat": "^6.0.1"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
-          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
-          }
-        }
       }
     },
     "jest-circus": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.1.0.tgz",
-      "integrity": "sha512-6FWtHs3nZyZlMBhRf1wvAC5CirnflbGJAY1xssSAnERLiiXQRH+wY2ptBVtXjX4gz4AA2EwRV57b038LmifRbA==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.2.1.tgz",
+      "integrity": "sha512-9q/8X8DgJmW8IqXsJNnS2E28iarx990hf6D+frS3P0lB+avhFDD33alLwZzKgm45u0wvEi6iFh43WjNbp5fhjw==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.1.0",
-        "@jest/test-result": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/environment": "^27.2.0",
+        "@jest/test-result": "^27.2.0",
+        "@jest/types": "^27.1.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
         "dedent": "^0.7.0",
-        "expect": "^27.1.0",
+        "expect": "^27.2.1",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^27.1.0",
-        "jest-matcher-utils": "^27.1.0",
-        "jest-message-util": "^27.1.0",
-        "jest-runtime": "^27.1.0",
-        "jest-snapshot": "^27.1.0",
-        "jest-util": "^27.1.0",
-        "pretty-format": "^27.1.0",
+        "jest-each": "^27.2.0",
+        "jest-matcher-utils": "^27.2.0",
+        "jest-message-util": "^27.2.0",
+        "jest-runtime": "^27.2.1",
+        "jest-snapshot": "^27.2.1",
+        "jest-util": "^27.2.0",
+        "pretty-format": "^27.2.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3",
         "throat": "^6.0.1"
       },
       "dependencies": {
-        "@jest/types": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
-          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+        "jest-util": {
+          "version": "27.2.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.2.0.tgz",
+          "integrity": "sha512-T5ZJCNeFpqcLBpx+Hl9r9KoxBCUqeWlJ1Htli+vryigZVJ1vuLB9j35grEBASp4R13KFkV7jM52bBGnArpJN6A==",
           "dev": true,
           "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
+            "@jest/types": "^27.1.1",
             "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "ansi-styles": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-          "dev": true
-        },
-        "pretty-format": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.1.0.tgz",
-          "integrity": "sha512-4aGaud3w3rxAO6OXmK3fwBFQ0bctIOG3/if+jYEFGNGIs0EvuidQm3bZ9mlP2/t9epLNC/12czabfy7TZNSwVA==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^27.1.0",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^17.0.1"
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^3.0.0",
+            "picomatch": "^2.2.3"
           }
         }
       }
     },
     "jest-config": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.1.0.tgz",
-      "integrity": "sha512-GMo7f76vMYUA3b3xOdlcKeKQhKcBIgurjERO2hojo0eLkKPGcw7fyIoanH+m6KOP2bLad+fGnF8aWOJYxzNPeg==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.2.1.tgz",
+      "integrity": "sha512-BAOemP8udmFw9nkgaLAac7vXORdvrt4yrJWoh7uYb0nPZeSsu0kGwJU18SwtY4paq9fed5OgAssC3A+Bf4WMQA==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/test-sequencer": "^27.1.0",
-        "@jest/types": "^27.1.0",
-        "babel-jest": "^27.1.0",
+        "@jest/test-sequencer": "^27.2.1",
+        "@jest/types": "^27.1.1",
+        "babel-jest": "^27.2.1",
         "chalk": "^4.0.0",
         "deepmerge": "^4.2.2",
         "glob": "^7.1.1",
         "graceful-fs": "^4.2.4",
         "is-ci": "^3.0.0",
-        "jest-circus": "^27.1.0",
-        "jest-environment-jsdom": "^27.1.0",
-        "jest-environment-node": "^27.1.0",
+        "jest-circus": "^27.2.1",
+        "jest-environment-jsdom": "^27.2.0",
+        "jest-environment-node": "^27.2.0",
         "jest-get-type": "^27.0.6",
-        "jest-jasmine2": "^27.1.0",
+        "jest-jasmine2": "^27.2.1",
         "jest-regex-util": "^27.0.6",
-        "jest-resolve": "^27.1.0",
-        "jest-runner": "^27.1.0",
-        "jest-util": "^27.1.0",
-        "jest-validate": "^27.1.0",
+        "jest-resolve": "^27.2.0",
+        "jest-runner": "^27.2.1",
+        "jest-util": "^27.2.0",
+        "jest-validate": "^27.2.0",
         "micromatch": "^4.0.4",
-        "pretty-format": "^27.1.0"
+        "pretty-format": "^27.2.0"
       },
       "dependencies": {
-        "@jest/types": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
-          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+        "jest-util": {
+          "version": "27.2.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.2.0.tgz",
+          "integrity": "sha512-T5ZJCNeFpqcLBpx+Hl9r9KoxBCUqeWlJ1Htli+vryigZVJ1vuLB9j35grEBASp4R13KFkV7jM52bBGnArpJN6A==",
           "dev": true,
           "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
+            "@jest/types": "^27.1.1",
             "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "ansi-styles": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-          "dev": true
-        },
-        "pretty-format": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.1.0.tgz",
-          "integrity": "sha512-4aGaud3w3rxAO6OXmK3fwBFQ0bctIOG3/if+jYEFGNGIs0EvuidQm3bZ9mlP2/t9epLNC/12czabfy7TZNSwVA==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^27.1.0",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^17.0.1"
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^3.0.0",
+            "picomatch": "^2.2.3"
           }
         }
       }
     },
     "jest-diff": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.0.6.tgz",
-      "integrity": "sha512-Z1mqgkTCSYaFgwTlP/NUiRzdqgxmmhzHY1Tq17zL94morOHfHu3K4bgSgl+CR4GLhpV8VxkuOYuIWnQ9LnFqmg==",
+      "version": "27.2.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.2.0.tgz",
+      "integrity": "sha512-QSO9WC6btFYWtRJ3Hac0sRrkspf7B01mGrrQEiCW6TobtViJ9RWL0EmOs/WnBsZDsI/Y2IoSHZA2x6offu0sYw==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
         "diff-sequences": "^27.0.6",
         "jest-get-type": "^27.0.6",
-        "pretty-format": "^27.0.6"
+        "pretty-format": "^27.2.0"
       }
     },
     "jest-docblock": {
@@ -4300,106 +4466,91 @@
       }
     },
     "jest-each": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-27.1.0.tgz",
-      "integrity": "sha512-K/cNvQlmDqQMRHF8CaQ0XPzCfjP5HMJc2bIJglrIqI9fjwpNqITle63IWE+wq4p+3v+iBgh7Wq0IdGpLx5xjDg==",
+      "version": "27.2.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-27.2.0.tgz",
+      "integrity": "sha512-biDmmUQjg+HZOB7MfY2RHSFL3j418nMoC3TK3pGAj880fQQSxvQe1y2Wy23JJJNUlk6YXiGU0yWy86Le1HBPmA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.1.0",
+        "@jest/types": "^27.1.1",
         "chalk": "^4.0.0",
         "jest-get-type": "^27.0.6",
-        "jest-util": "^27.1.0",
-        "pretty-format": "^27.1.0"
+        "jest-util": "^27.2.0",
+        "pretty-format": "^27.2.0"
       },
       "dependencies": {
-        "@jest/types": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
-          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+        "jest-util": {
+          "version": "27.2.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.2.0.tgz",
+          "integrity": "sha512-T5ZJCNeFpqcLBpx+Hl9r9KoxBCUqeWlJ1Htli+vryigZVJ1vuLB9j35grEBASp4R13KFkV7jM52bBGnArpJN6A==",
           "dev": true,
           "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
+            "@jest/types": "^27.1.1",
             "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "ansi-styles": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-          "dev": true
-        },
-        "pretty-format": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.1.0.tgz",
-          "integrity": "sha512-4aGaud3w3rxAO6OXmK3fwBFQ0bctIOG3/if+jYEFGNGIs0EvuidQm3bZ9mlP2/t9epLNC/12czabfy7TZNSwVA==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^27.1.0",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^17.0.1"
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^3.0.0",
+            "picomatch": "^2.2.3"
           }
         }
       }
     },
     "jest-environment-jsdom": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-27.1.0.tgz",
-      "integrity": "sha512-JbwOcOxh/HOtsj56ljeXQCUJr3ivnaIlM45F5NBezFLVYdT91N5UofB1ux2B1CATsQiudcHdgTaeuqGXJqjJYQ==",
+      "version": "27.2.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-27.2.0.tgz",
+      "integrity": "sha512-wNQJi6Rd/AkUWqTc4gWhuTIFPo7tlMK0RPZXeM6AqRHZA3D3vwvTa9ktAktyVyWYmUoXdYstOfyYMG3w4jt7eA==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.1.0",
-        "@jest/fake-timers": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/environment": "^27.2.0",
+        "@jest/fake-timers": "^27.2.0",
+        "@jest/types": "^27.1.1",
         "@types/node": "*",
-        "jest-mock": "^27.1.0",
-        "jest-util": "^27.1.0",
+        "jest-mock": "^27.1.1",
+        "jest-util": "^27.2.0",
         "jsdom": "^16.6.0"
       },
       "dependencies": {
-        "@jest/types": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
-          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+        "jest-util": {
+          "version": "27.2.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.2.0.tgz",
+          "integrity": "sha512-T5ZJCNeFpqcLBpx+Hl9r9KoxBCUqeWlJ1Htli+vryigZVJ1vuLB9j35grEBASp4R13KFkV7jM52bBGnArpJN6A==",
           "dev": true,
           "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
+            "@jest/types": "^27.1.1",
             "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^3.0.0",
+            "picomatch": "^2.2.3"
           }
         }
       }
     },
     "jest-environment-node": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.1.0.tgz",
-      "integrity": "sha512-JIyJ8H3wVyM4YCXp7njbjs0dIT87yhGlrXCXhDKNIg1OjurXr6X38yocnnbXvvNyqVTqSI4M9l+YfPKueqL1lw==",
+      "version": "27.2.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.2.0.tgz",
+      "integrity": "sha512-WbW+vdM4u88iy6Q3ftUEQOSgMPtSgjm3qixYYK2AKEuqmFO2zmACTw1vFUB0qI/QN88X6hA6ZkVKIdIWWzz+yg==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.1.0",
-        "@jest/fake-timers": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/environment": "^27.2.0",
+        "@jest/fake-timers": "^27.2.0",
+        "@jest/types": "^27.1.1",
         "@types/node": "*",
-        "jest-mock": "^27.1.0",
-        "jest-util": "^27.1.0"
+        "jest-mock": "^27.1.1",
+        "jest-util": "^27.2.0"
       },
       "dependencies": {
-        "@jest/types": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
-          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+        "jest-util": {
+          "version": "27.2.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.2.0.tgz",
+          "integrity": "sha512-T5ZJCNeFpqcLBpx+Hl9r9KoxBCUqeWlJ1Htli+vryigZVJ1vuLB9j35grEBASp4R13KFkV7jM52bBGnArpJN6A==",
           "dev": true,
           "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
+            "@jest/types": "^27.1.1",
             "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^3.0.0",
+            "picomatch": "^2.2.3"
           }
         }
       }
@@ -4411,12 +4562,12 @@
       "dev": true
     },
     "jest-haste-map": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.1.0.tgz",
-      "integrity": "sha512-7mz6LopSe+eA6cTFMf10OfLLqRoIPvmMyz5/OnSXnHO7hB0aDP1iIeLWCXzAcYU5eIJVpHr12Bk9yyq2fTW9vg==",
+      "version": "27.2.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.2.0.tgz",
+      "integrity": "sha512-laFet7QkNlWjwZtMGHCucLvF8o9PAh2cgePRck1+uadSM4E4XH9J4gnx4do+a6do8ZV5XHNEAXEkIoNg5XUH2Q==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.1.0",
+        "@jest/types": "^27.1.1",
         "@types/graceful-fs": "^4.1.2",
         "@types/node": "*",
         "anymatch": "^3.0.3",
@@ -4425,199 +4576,105 @@
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^27.0.6",
         "jest-serializer": "^27.0.6",
-        "jest-util": "^27.1.0",
-        "jest-worker": "^27.1.0",
+        "jest-util": "^27.2.0",
+        "jest-worker": "^27.2.0",
         "micromatch": "^4.0.4",
         "walker": "^1.0.7"
       },
       "dependencies": {
-        "@jest/types": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
-          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+        "jest-util": {
+          "version": "27.2.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.2.0.tgz",
+          "integrity": "sha512-T5ZJCNeFpqcLBpx+Hl9r9KoxBCUqeWlJ1Htli+vryigZVJ1vuLB9j35grEBASp4R13KFkV7jM52bBGnArpJN6A==",
           "dev": true,
           "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
+            "@jest/types": "^27.1.1",
             "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^3.0.0",
+            "picomatch": "^2.2.3"
           }
         }
       }
     },
     "jest-jasmine2": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.1.0.tgz",
-      "integrity": "sha512-Z/NIt0wBDg3przOW2FCWtYjMn3Ip68t0SL60agD/e67jlhTyV3PIF8IzT9ecwqFbeuUSO2OT8WeJgHcalDGFzQ==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.2.1.tgz",
+      "integrity": "sha512-3vytj3+S49+XYsxGJyjlchDo4xblYzjDY4XK7pV2IAdspbMFOpmeNMOeDonYuvlbUtcV8yrFLA6XtliXapDmMA==",
       "dev": true,
       "requires": {
         "@babel/traverse": "^7.1.0",
-        "@jest/environment": "^27.1.0",
+        "@jest/environment": "^27.2.0",
         "@jest/source-map": "^27.0.6",
-        "@jest/test-result": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/test-result": "^27.2.0",
+        "@jest/types": "^27.1.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
-        "expect": "^27.1.0",
+        "expect": "^27.2.1",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^27.1.0",
-        "jest-matcher-utils": "^27.1.0",
-        "jest-message-util": "^27.1.0",
-        "jest-runtime": "^27.1.0",
-        "jest-snapshot": "^27.1.0",
-        "jest-util": "^27.1.0",
-        "pretty-format": "^27.1.0",
+        "jest-each": "^27.2.0",
+        "jest-matcher-utils": "^27.2.0",
+        "jest-message-util": "^27.2.0",
+        "jest-runtime": "^27.2.1",
+        "jest-snapshot": "^27.2.1",
+        "jest-util": "^27.2.0",
+        "pretty-format": "^27.2.0",
         "throat": "^6.0.1"
       },
       "dependencies": {
-        "@jest/types": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
-          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+        "jest-util": {
+          "version": "27.2.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.2.0.tgz",
+          "integrity": "sha512-T5ZJCNeFpqcLBpx+Hl9r9KoxBCUqeWlJ1Htli+vryigZVJ1vuLB9j35grEBASp4R13KFkV7jM52bBGnArpJN6A==",
           "dev": true,
           "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
+            "@jest/types": "^27.1.1",
             "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "ansi-styles": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-          "dev": true
-        },
-        "pretty-format": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.1.0.tgz",
-          "integrity": "sha512-4aGaud3w3rxAO6OXmK3fwBFQ0bctIOG3/if+jYEFGNGIs0EvuidQm3bZ9mlP2/t9epLNC/12czabfy7TZNSwVA==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^27.1.0",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^17.0.1"
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^3.0.0",
+            "picomatch": "^2.2.3"
           }
         }
       }
     },
     "jest-leak-detector": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.1.0.tgz",
-      "integrity": "sha512-oHvSkz1E80VyeTKBvZNnw576qU+cVqRXUD3/wKXh1zpaki47Qty2xeHg2HKie9Hqcd2l4XwircgNOWb/NiGqdA==",
+      "version": "27.2.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.2.0.tgz",
+      "integrity": "sha512-e91BIEmbZw5+MHkB4Hnrq7S86coTxUMCkz4n7DLmQYvl9pEKmRx9H/JFH87bBqbIU5B2Ju1soKxRWX6/eGFGpA==",
       "dev": true,
       "requires": {
         "jest-get-type": "^27.0.6",
-        "pretty-format": "^27.1.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
-          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "ansi-styles": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-          "dev": true
-        },
-        "pretty-format": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.1.0.tgz",
-          "integrity": "sha512-4aGaud3w3rxAO6OXmK3fwBFQ0bctIOG3/if+jYEFGNGIs0EvuidQm3bZ9mlP2/t9epLNC/12czabfy7TZNSwVA==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^27.1.0",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^17.0.1"
-          }
-        }
+        "pretty-format": "^27.2.0"
       }
     },
     "jest-matcher-utils": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.1.0.tgz",
-      "integrity": "sha512-VmAudus2P6Yt/JVBRdTPFhUzlIN8DYJd+et5Rd9QDsO/Z82Z4iwGjo43U8Z+PTiz8CBvKvlb6Fh3oKy39hykkQ==",
+      "version": "27.2.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.2.0.tgz",
+      "integrity": "sha512-F+LG3iTwJ0gPjxBX6HCyrARFXq6jjiqhwBQeskkJQgSLeF1j6ui1RTV08SR7O51XTUhtc8zqpDj8iCG4RGmdKw==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "jest-diff": "^27.1.0",
+        "jest-diff": "^27.2.0",
         "jest-get-type": "^27.0.6",
-        "pretty-format": "^27.1.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
-          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "ansi-styles": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-          "dev": true
-        },
-        "jest-diff": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.1.0.tgz",
-          "integrity": "sha512-rjfopEYl58g/SZTsQFmspBODvMSytL16I+cirnScWTLkQVXYVZfxm78DFfdIIXc05RCYuGjxJqrdyG4PIFzcJg==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.0.0",
-            "diff-sequences": "^27.0.6",
-            "jest-get-type": "^27.0.6",
-            "pretty-format": "^27.1.0"
-          }
-        },
-        "pretty-format": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.1.0.tgz",
-          "integrity": "sha512-4aGaud3w3rxAO6OXmK3fwBFQ0bctIOG3/if+jYEFGNGIs0EvuidQm3bZ9mlP2/t9epLNC/12czabfy7TZNSwVA==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^27.1.0",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^17.0.1"
-          }
-        }
+        "pretty-format": "^27.2.0"
       }
     },
     "jest-message-util": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.1.0.tgz",
-      "integrity": "sha512-Eck8NFnJ5Sg36R9XguD65cf2D5+McC+NF5GIdEninoabcuoOfWrID5qJhufq5FB0DRKoiyxB61hS7MKoMD0trQ==",
+      "version": "27.2.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.2.0.tgz",
+      "integrity": "sha512-y+sfT/94CiP8rKXgwCOzO1mUazIEdEhrLjuiu+RKmCP+8O/TJTSne9dqQRbFIHBtlR2+q7cddJlWGir8UATu5w==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^27.1.0",
+        "@jest/types": "^27.1.1",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "micromatch": "^4.0.4",
-        "pretty-format": "^27.1.0",
+        "pretty-format": "^27.2.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
@@ -4630,63 +4687,17 @@
           "requires": {
             "@babel/highlight": "^7.14.5"
           }
-        },
-        "@jest/types": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
-          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "ansi-styles": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-          "dev": true
-        },
-        "pretty-format": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.1.0.tgz",
-          "integrity": "sha512-4aGaud3w3rxAO6OXmK3fwBFQ0bctIOG3/if+jYEFGNGIs0EvuidQm3bZ9mlP2/t9epLNC/12czabfy7TZNSwVA==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^27.1.0",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^17.0.1"
-          }
         }
       }
     },
     "jest-mock": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.1.0.tgz",
-      "integrity": "sha512-iT3/Yhu7DwAg/0HvvLCqLvrTKTRMyJlrrfJYWzuLSf9RCAxBoIXN3HoymZxMnYsC3eD8ewGbUa9jUknwBenx2w==",
+      "version": "27.1.1",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.1.1.tgz",
+      "integrity": "sha512-SClsFKuYBf+6SSi8jtAYOuPw8DDMsTElUWEae3zq7vDhH01ayVSIHUSIa8UgbDOUalCFp6gNsaikN0rbxN4dbw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.1.0",
+        "@jest/types": "^27.1.1",
         "@types/node": "*"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
-          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
-          }
-        }
       }
     },
     "jest-pnp-resolver": {
@@ -4702,123 +4713,110 @@
       "dev": true
     },
     "jest-resolve": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.1.0.tgz",
-      "integrity": "sha512-TXvzrLyPg0vLOwcWX38ZGYeEztSEmW+cQQKqc4HKDUwun31wsBXwotRlUz4/AYU/Fq4GhbMd/ileIWZEtcdmIA==",
+      "version": "27.2.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.2.0.tgz",
+      "integrity": "sha512-v09p9Ib/VtpHM6Cz+i9lEAv1Z/M5NVxsyghRHRMEUOqwPQs3zwTdwp1xS3O/k5LocjKiGS0OTaJoBSpjbM2Jlw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.1.0",
+        "@jest/types": "^27.1.1",
         "chalk": "^4.0.0",
         "escalade": "^3.1.1",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.1.0",
+        "jest-haste-map": "^27.2.0",
         "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^27.1.0",
-        "jest-validate": "^27.1.0",
+        "jest-util": "^27.2.0",
+        "jest-validate": "^27.2.0",
         "resolve": "^1.20.0",
         "slash": "^3.0.0"
       },
       "dependencies": {
-        "@jest/types": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
-          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+        "jest-util": {
+          "version": "27.2.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.2.0.tgz",
+          "integrity": "sha512-T5ZJCNeFpqcLBpx+Hl9r9KoxBCUqeWlJ1Htli+vryigZVJ1vuLB9j35grEBASp4R13KFkV7jM52bBGnArpJN6A==",
           "dev": true,
           "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
+            "@jest/types": "^27.1.1",
             "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^3.0.0",
+            "picomatch": "^2.2.3"
           }
         }
       }
     },
     "jest-resolve-dependencies": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.1.0.tgz",
-      "integrity": "sha512-Kq5XuDAELuBnrERrjFYEzu/A+i2W7l9HnPWqZEeKGEQ7m1R+6ndMbdXCVCx29Se1qwLZLgvoXwinB3SPIaitMQ==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.2.1.tgz",
+      "integrity": "sha512-9bKEwmz4YshGPjGZAVZOVw6jt7pq2/FjWJmyhnWhvDuiRCHVZBcJhycinX+e/EJ7jafsq26bTpzBIQas3xql1g==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.1.0",
+        "@jest/types": "^27.1.1",
         "jest-regex-util": "^27.0.6",
-        "jest-snapshot": "^27.1.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
-          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
-          }
-        }
+        "jest-snapshot": "^27.2.1"
       }
     },
     "jest-runner": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.1.0.tgz",
-      "integrity": "sha512-ZWPKr9M5w5gDplz1KsJ6iRmQaDT/yyAFLf18fKbb/+BLWsR1sCNC2wMT0H7pP3gDcBz0qZ6aJraSYUNAGSJGaw==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.2.1.tgz",
+      "integrity": "sha512-USHitkUUzcB3Y5mRdzlp+KHgRRR2VsXDq5OeATuDmq1qXfT/RwwnQykUhn+KVx3FotxK3pID74UY7o6HYIR8vA==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.1.0",
-        "@jest/environment": "^27.1.0",
-        "@jest/test-result": "^27.1.0",
-        "@jest/transform": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/console": "^27.2.0",
+        "@jest/environment": "^27.2.0",
+        "@jest/test-result": "^27.2.0",
+        "@jest/transform": "^27.2.1",
+        "@jest/types": "^27.1.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "emittery": "^0.8.1",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
         "jest-docblock": "^27.0.6",
-        "jest-environment-jsdom": "^27.1.0",
-        "jest-environment-node": "^27.1.0",
-        "jest-haste-map": "^27.1.0",
-        "jest-leak-detector": "^27.1.0",
-        "jest-message-util": "^27.1.0",
-        "jest-resolve": "^27.1.0",
-        "jest-runtime": "^27.1.0",
-        "jest-util": "^27.1.0",
-        "jest-worker": "^27.1.0",
+        "jest-environment-jsdom": "^27.2.0",
+        "jest-environment-node": "^27.2.0",
+        "jest-haste-map": "^27.2.0",
+        "jest-leak-detector": "^27.2.0",
+        "jest-message-util": "^27.2.0",
+        "jest-resolve": "^27.2.0",
+        "jest-runtime": "^27.2.1",
+        "jest-util": "^27.2.0",
+        "jest-worker": "^27.2.0",
         "source-map-support": "^0.5.6",
         "throat": "^6.0.1"
       },
       "dependencies": {
-        "@jest/types": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
-          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+        "jest-util": {
+          "version": "27.2.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.2.0.tgz",
+          "integrity": "sha512-T5ZJCNeFpqcLBpx+Hl9r9KoxBCUqeWlJ1Htli+vryigZVJ1vuLB9j35grEBASp4R13KFkV7jM52bBGnArpJN6A==",
           "dev": true,
           "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
+            "@jest/types": "^27.1.1",
             "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^3.0.0",
+            "picomatch": "^2.2.3"
           }
         }
       }
     },
     "jest-runtime": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.1.0.tgz",
-      "integrity": "sha512-okiR2cpGjY0RkWmUGGado6ETpFOi9oG3yV0CioYdoktkVxy5Hv0WRLWnJFuArSYS8cHMCNcceUUMGiIfgxCO9A==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.2.1.tgz",
+      "integrity": "sha512-QJNnwL4iteDE/Jq4TfQK7AjhPoUZflBKTtUIkRnFYFkTAZTP/o8k7ekaROiVjmo+NYop5+DQPqX6pz4vWbZSOQ==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.1.0",
-        "@jest/environment": "^27.1.0",
-        "@jest/fake-timers": "^27.1.0",
-        "@jest/globals": "^27.1.0",
+        "@jest/console": "^27.2.0",
+        "@jest/environment": "^27.2.0",
+        "@jest/fake-timers": "^27.2.0",
+        "@jest/globals": "^27.2.1",
         "@jest/source-map": "^27.0.6",
-        "@jest/test-result": "^27.1.0",
-        "@jest/transform": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/test-result": "^27.2.0",
+        "@jest/transform": "^27.2.1",
+        "@jest/types": "^27.1.1",
         "@types/yargs": "^16.0.0",
         "chalk": "^4.0.0",
         "cjs-module-lexer": "^1.0.0",
@@ -4827,30 +4825,31 @@
         "exit": "^0.1.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.1.0",
-        "jest-message-util": "^27.1.0",
-        "jest-mock": "^27.1.0",
+        "jest-haste-map": "^27.2.0",
+        "jest-message-util": "^27.2.0",
+        "jest-mock": "^27.1.1",
         "jest-regex-util": "^27.0.6",
-        "jest-resolve": "^27.1.0",
-        "jest-snapshot": "^27.1.0",
-        "jest-util": "^27.1.0",
-        "jest-validate": "^27.1.0",
+        "jest-resolve": "^27.2.0",
+        "jest-snapshot": "^27.2.1",
+        "jest-util": "^27.2.0",
+        "jest-validate": "^27.2.0",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0",
         "yargs": "^16.0.3"
       },
       "dependencies": {
-        "@jest/types": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
-          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+        "jest-util": {
+          "version": "27.2.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.2.0.tgz",
+          "integrity": "sha512-T5ZJCNeFpqcLBpx+Hl9r9KoxBCUqeWlJ1Htli+vryigZVJ1vuLB9j35grEBASp4R13KFkV7jM52bBGnArpJN6A==",
           "dev": true,
           "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
+            "@jest/types": "^27.1.1",
             "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^3.0.0",
+            "picomatch": "^2.2.3"
           }
         },
         "strip-bom": {
@@ -4872,9 +4871,9 @@
       }
     },
     "jest-snapshot": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.1.0.tgz",
-      "integrity": "sha512-eaeUBoEjuuRwmiRI51oTldUsKOohB1F6fPqWKKILuDi/CStxzp2IWekVUXbuHHoz5ik33ioJhshiHpgPFbYgcA==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.2.1.tgz",
+      "integrity": "sha512-8CTg2YrgZuQbPHW7G0YvLTj4yTRXLmSeEO+ka3eC5lbu5dsTRyoDNS1L7x7EFUTyYQhFH9HQG1/TNlbUgR9Lug==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.7.2",
@@ -4883,67 +4882,38 @@
         "@babel/plugin-syntax-typescript": "^7.7.2",
         "@babel/traverse": "^7.7.2",
         "@babel/types": "^7.0.0",
-        "@jest/transform": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/transform": "^27.2.1",
+        "@jest/types": "^27.1.1",
         "@types/babel__traverse": "^7.0.4",
         "@types/prettier": "^2.1.5",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^27.1.0",
+        "expect": "^27.2.1",
         "graceful-fs": "^4.2.4",
-        "jest-diff": "^27.1.0",
+        "jest-diff": "^27.2.0",
         "jest-get-type": "^27.0.6",
-        "jest-haste-map": "^27.1.0",
-        "jest-matcher-utils": "^27.1.0",
-        "jest-message-util": "^27.1.0",
-        "jest-resolve": "^27.1.0",
-        "jest-util": "^27.1.0",
+        "jest-haste-map": "^27.2.0",
+        "jest-matcher-utils": "^27.2.0",
+        "jest-message-util": "^27.2.0",
+        "jest-resolve": "^27.2.0",
+        "jest-util": "^27.2.0",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^27.1.0",
+        "pretty-format": "^27.2.0",
         "semver": "^7.3.2"
       },
       "dependencies": {
-        "@jest/types": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
-          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+        "jest-util": {
+          "version": "27.2.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.2.0.tgz",
+          "integrity": "sha512-T5ZJCNeFpqcLBpx+Hl9r9KoxBCUqeWlJ1Htli+vryigZVJ1vuLB9j35grEBASp4R13KFkV7jM52bBGnArpJN6A==",
           "dev": true,
           "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
+            "@jest/types": "^27.1.1",
             "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "ansi-styles": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-          "dev": true
-        },
-        "jest-diff": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.1.0.tgz",
-          "integrity": "sha512-rjfopEYl58g/SZTsQFmspBODvMSytL16I+cirnScWTLkQVXYVZfxm78DFfdIIXc05RCYuGjxJqrdyG4PIFzcJg==",
-          "dev": true,
-          "requires": {
             "chalk": "^4.0.0",
-            "diff-sequences": "^27.0.6",
-            "jest-get-type": "^27.0.6",
-            "pretty-format": "^27.1.0"
-          }
-        },
-        "pretty-format": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.1.0.tgz",
-          "integrity": "sha512-4aGaud3w3rxAO6OXmK3fwBFQ0bctIOG3/if+jYEFGNGIs0EvuidQm3bZ9mlP2/t9epLNC/12czabfy7TZNSwVA==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^27.1.0",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^17.0.1"
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^3.0.0",
+            "picomatch": "^2.2.3"
           }
         },
         "semver": {
@@ -4987,92 +4957,62 @@
       }
     },
     "jest-validate": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.1.0.tgz",
-      "integrity": "sha512-QiJ+4XuSuMsfPi9zvdO//IrSRSlG6ybJhOpuqYSsuuaABaNT84h0IoD6vvQhThBOKT+DIKvl5sTM0l6is9+SRA==",
+      "version": "27.2.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.2.0.tgz",
+      "integrity": "sha512-uIEZGkFKk3+4liA81Xu0maG5aGDyPLdp+4ed244c+Ql0k3aLWQYcMbaMLXOIFcb83LPHzYzqQ8hwNnIxTqfAGQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.1.0",
+        "@jest/types": "^27.1.1",
         "camelcase": "^6.2.0",
         "chalk": "^4.0.0",
         "jest-get-type": "^27.0.6",
         "leven": "^3.1.0",
-        "pretty-format": "^27.1.0"
+        "pretty-format": "^27.2.0"
       },
       "dependencies": {
-        "@jest/types": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
-          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "ansi-styles": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-          "dev": true
-        },
         "camelcase": {
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
           "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
           "dev": true
-        },
-        "pretty-format": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.1.0.tgz",
-          "integrity": "sha512-4aGaud3w3rxAO6OXmK3fwBFQ0bctIOG3/if+jYEFGNGIs0EvuidQm3bZ9mlP2/t9epLNC/12czabfy7TZNSwVA==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^27.1.0",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^17.0.1"
-          }
         }
       }
     },
     "jest-watcher": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.1.0.tgz",
-      "integrity": "sha512-ivaWTrA46aHWdgPDgPypSHiNQjyKnLBpUIHeBaGg11U+pDzZpkffGlcB1l1a014phmG0mHgkOHtOgiqJQM6yKQ==",
+      "version": "27.2.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.2.0.tgz",
+      "integrity": "sha512-SjRWhnr+qO8aBsrcnYIyF+qRxNZk6MZH8TIDgvi+VlsyrvOyqg0d+Rm/v9KHiTtC9mGGeFi9BFqgavyWib6xLg==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/test-result": "^27.2.0",
+        "@jest/types": "^27.1.1",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
-        "jest-util": "^27.1.0",
+        "jest-util": "^27.2.0",
         "string-length": "^4.0.1"
       },
       "dependencies": {
-        "@jest/types": {
-          "version": "27.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
-          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+        "jest-util": {
+          "version": "27.2.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.2.0.tgz",
+          "integrity": "sha512-T5ZJCNeFpqcLBpx+Hl9r9KoxBCUqeWlJ1Htli+vryigZVJ1vuLB9j35grEBASp4R13KFkV7jM52bBGnArpJN6A==",
           "dev": true,
           "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
+            "@jest/types": "^27.1.1",
             "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^3.0.0",
+            "picomatch": "^2.2.3"
           }
         }
       }
     },
     "jest-worker": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.1.0.tgz",
-      "integrity": "sha512-mO4PHb2QWLn9yRXGp7rkvXLAYuxwhq1ZYUo0LoDhg8wqvv4QizP1ZWEJOeolgbEgAWZLIEU0wsku8J+lGWfBhg==",
+      "version": "27.2.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.2.0.tgz",
+      "integrity": "sha512-laB0ZVIBz+voh/QQy9dmUuuDsadixeerrKqyVpgPz+CCWiOYjOBabUXHIXZhsdvkWbLqSHbgkAHWl5cg24Q6RA==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -5158,10 +5098,32 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "8.4.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
-          "integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
+          "version": "8.5.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
+          "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
           "dev": true
+        },
+        "form-data": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "tough-cookie": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
+          "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+          "dev": true,
+          "requires": {
+            "psl": "^1.1.33",
+            "punycode": "^2.1.1",
+            "universalify": "^0.1.2"
+          }
         }
       }
     },
@@ -5590,6 +5552,12 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
+    "nanocolors": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.1.12.tgz",
+      "integrity": "sha512-2nMHqg1x5PU+unxX7PGY7AuYxl2qDx7PSrTRjizr8sxdd3l/3hBuWWaki62qmtYm2U5i4Z5E7GbjlyDFhs9/EQ==",
+      "dev": true
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -5627,9 +5595,9 @@
       "dev": true
     },
     "node-releases": {
-      "version": "1.1.75",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
-      "integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==",
+      "version": "1.1.76",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.76.tgz",
+      "integrity": "sha512-9/IECtNr8dXNmPWmFXepT0/7o5eolGesHUa3mtr0KlgnCvnZxwh2qensKL42JJY2vQKC3nIBXetFAqR+PW1CmA==",
       "dev": true
     },
     "normalize-package-data": {
@@ -5908,12 +5876,12 @@
       "dev": true
     },
     "pretty-format": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.6.tgz",
-      "integrity": "sha512-8tGD7gBIENgzqA+UBzObyWqQ5B778VIFZA/S66cclyd5YkFLYs2Js7gxDKf0MXtTc9zcS7t1xhdfcElJ3YIvkQ==",
+      "version": "27.2.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.2.0.tgz",
+      "integrity": "sha512-KyJdmgBkMscLqo8A7K77omgLx5PWPiXJswtTtFV7XgVZv2+qPk6UivpXXO+5k6ZEbWIbLoKdx1pZ6ldINzbwTA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.1.1",
         "ansi-regex": "^5.0.0",
         "ansi-styles": "^5.0.0",
         "react-is": "^17.0.1"
@@ -6114,27 +6082,6 @@
         "uuid": "^3.3.2"
       },
       "dependencies": {
-        "form-data": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-          "dev": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.6",
-            "mime-types": "^2.1.12"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-          "dev": true,
-          "requires": {
-            "psl": "^1.1.28",
-            "punycode": "^2.1.1"
-          }
-        },
         "uuid": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -6716,9 +6663,9 @@
       "dev": true
     },
     "source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "version": "0.5.20",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.20.tgz",
+      "integrity": "sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -6781,9 +6728,9 @@
       }
     },
     "stack-utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.3.tgz",
-      "integrity": "sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
+      "integrity": "sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^2.0.0"
@@ -7027,9 +6974,9 @@
       }
     },
     "tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
     },
     "to-fast-properties": {
@@ -7048,14 +6995,13 @@
       }
     },
     "tough-cookie": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
-      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "dev": true,
       "requires": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.1.2"
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
       }
     },
     "tr46": {
@@ -7218,9 +7164,9 @@
       }
     },
     "typescript": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
-      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
+      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
       "dev": true
     },
     "unbox-primitive": {
@@ -7469,9 +7415,9 @@
       }
     },
     "ws": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.4.tgz",
-      "integrity": "sha512-zP9z6GXm6zC27YtspwH99T3qTG7bBFv2VIkeHstMLrLlDJuzA7tQ5ls3OJ1hOGGCzTQPniNJoHXIAOS0Jljohg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
+      "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
       "dev": true
     },
     "xdg-basedir": {

--- a/firebase-test/package.json
+++ b/firebase-test/package.json
@@ -13,20 +13,20 @@
   "main": "lib/index.js",
   "dependencies": {},
   "devDependencies": {
-    "@firebase/rules-unit-testing": "^1.3.14",
-    "@types/jest": "^27.0.1",
+    "@firebase/rules-unit-testing": "^1.3.15",
+    "@types/jest": "^27.0.2",
     "@types/rewire": "^2.5.28",
-    "@typescript-eslint/eslint-plugin": "^4.30.0",
-    "@typescript-eslint/parser": "^4.30.0",
+    "@typescript-eslint/eslint-plugin": "^4.31.2",
+    "@typescript-eslint/parser": "^4.31.2",
     "eslint": "^7.32.0",
     "eslint-plugin-import": "^2.24.2",
-    "firebase": "^8.9.1",
+    "firebase": "^8.10.0",
     "firebase-admin": "^9.11.1",
-    "jest": "^27.1.0",
+    "jest": "^27.2.1",
     "rewire": "^5.0.0",
     "ts-jest": "^27.0.5",
     "ts-node": "^10.2.1",
-    "typescript": "^4.4.2"
+    "typescript": "^4.4.3"
   },
   "private": true
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -153,7 +153,7 @@ service cloud.firestore {
       }
 
       function isValidClassCreateRequest() {
-        let requiredFields = ["id", "name", "uri", "context_id", "teachers", "network"];
+        let requiredFields = ["id", "name", "uri", "context_id", "teacher", "teachers", "network"];
         return userInRequestTeachers() && requestInTeacherNetworks() &&
                 request.resource.data.keys().hasAll(requiredFields);
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7631,6 +7631,15 @@
         "cross-spawn": "^7.0.1"
       }
     },
+    "cross-fetch": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
+      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "2.6.1"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -13440,6 +13449,16 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "jest-fetch-mock": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz",
+      "integrity": "sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==",
+      "dev": true,
+      "requires": {
+        "cross-fetch": "^3.0.4",
+        "promise-polyfill": "^8.1.3"
       }
     },
     "jest-get-type": {

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "istanbul-instrumenter-loader": "^3.0.1",
     "istanbul-lib-coverage": "^3.0.0",
     "jest": "^27.0.6",
+    "jest-fetch-mock": "^3.0.3",
     "mini-css-extract-plugin": "^1.6.2",
     "nock": "^13.1.0",
     "node-sass": "^6.0.1",

--- a/src/components/class-menu-container.tsx
+++ b/src/components/class-menu-container.tsx
@@ -4,7 +4,7 @@ import { inject, observer } from "mobx-react";
 import { BaseComponent, IBaseProps } from "./base";
 import { LogEventName, Logger, LogEventMethod } from "../lib/logger";
 import { IDropdownItem } from "@concord-consortium/react-components";
-import { IPortalClassOffering } from "../models/stores/user";
+import { IUserPortalOffering } from "../models/stores/user";
 import { CustomSelect } from "../clue/components/custom-select";
 
 interface IProps extends IBaseProps {}
@@ -52,7 +52,7 @@ export class ClassMenuContainer extends BaseComponent <IProps> {
         window.location.replace(url);
       };
 
-      const addMenuItemForOffering = (offering: IPortalClassOffering, showProblemTitle: boolean) => {
+      const addMenuItemForOffering = (offering: IUserPortalOffering, showProblemTitle: boolean) => {
         // Note that the same problem can be assigned multiple times to the same class
         // (e.g. as a pre- and post-test), so we optionally include the activity title as well.
         const text = showProblemTitle && offering.activityTitle

--- a/src/hooks/document-comment-hooks.ts
+++ b/src/hooks/document-comment-hooks.ts
@@ -66,7 +66,7 @@ export const useCommentableDocument = (documentKeyOrSectionPath?: string) => {
   const documentMetadata = useDocumentOrCurriculumMetadata(documentKeyOrSectionPath);
   const validateDocumentMutation = useValidateCommentableDocument();
   return useQuery(documentPath, () => new Promise<DocumentQueryType>((resolve, reject) => {
-    const documentRef = firestore.docRef(documentPath);
+    const documentRef = firestore.doc(documentPath);
     const unsubscribeDocListener = documentRef?.onSnapshot({
       next: docSnapshot => {
         unsubscribeDocListener?.();

--- a/src/hooks/firestore-hooks.test.ts
+++ b/src/hooks/firestore-hooks.test.ts
@@ -34,7 +34,7 @@ var mockOnSnapshot = (callback: (snap: any) => void) => {
   }));
 };
 var mockDelete = jest.fn();
-var mockDocRef = jest.fn((path: string) => ({
+var mockDoc = jest.fn((path: string) => ({
   delete: mockDelete
 }));
 jest.mock("./use-stores", () => ({
@@ -54,7 +54,7 @@ jest.mock("./use-stores", () => ({
           };
         }
       }),
-      docRef: mockDocRef
+      doc: mockDoc
     }
   })
 }));
@@ -95,8 +95,8 @@ describe("Firestore hooks", () => {
       const { result } = renderHook(() => useDeleteDocument());
       const docPath = "doc/to/delete";
       result.current.mutate(docPath);
-      expect(mockDocRef).toHaveBeenCalled();
-      expect(mockDocRef.mock.calls[0][0]).toBe(docPath);
+      expect(mockDoc).toHaveBeenCalled();
+      expect(mockDoc.mock.calls[0][0]).toBe(docPath);
       expect(mockDelete).toHaveBeenCalled();
     });
   });

--- a/src/hooks/firestore-hooks.ts
+++ b/src/hooks/firestore-hooks.ts
@@ -58,7 +58,7 @@ export function useCollectionOrderedRealTimeQuery<T>(
 export const useDeleteDocument = () => {
   const [firestore] = useFirestore();
   const deleteDocument = useCallback((partialPath: string) => {
-    return firestore.docRef(partialPath).delete();
+    return firestore.doc(partialPath).delete();
   }, [firestore]);
   return useMutation(deleteDocument);
 };

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -4,13 +4,11 @@ import { authenticate,
         PORTAL_JWT_URL_SUFFIX,
         FIREBASE_JWT_URL_SUFFIX,
         FIREBASE_JWT_QUERY,
-        RawUser,
-        RawClassInfo,
         getAppMode,
         createFakeUser,
         getFirebaseJWTParams,
         generateDevAuthentication} from "./auth";
-import { PortalStudentJWT, PortalTeacherJWT } from "./portal-types";
+import { IPortalClassInfo, IPortalClassUser, PortalStudentJWT, PortalTeacherJWT } from "./portal-types";
 import { AppConfigModel } from "../models/stores/app-config-model";
 import nock from "nock";
 import { NUM_FAKE_STUDENTS, NUM_FAKE_TEACHERS } from "../components/demo/demo-creator";
@@ -71,31 +69,35 @@ const CLASSES_MINE_PATH = "/api/v1/classes/mine";
 const CLASS_INFO_URL = BASE_PORTAL_HOST + CLASS_INFO_PATH;
 const OFFERING_INFO_URL = BASE_PORTAL_HOST + OFFERING_INFO_PATH;
 
-const RAW_CORRECT_STUDENT: RawUser = {
+const RAW_CORRECT_STUDENT: IPortalClassUser = {
   id: STUDENT_PORTAL_JWT.user_id,
+  user_id: STUDENT_PORTAL_JWT.uid,
   first_name: "GoodFirst",
   last_name: "GoodLast",
 };
 
-const RAW_INCORRECT_STUDENT: RawUser = {
+const RAW_INCORRECT_STUDENT: IPortalClassUser = {
   id: "bad id",
+  user_id: 0,
   first_name: "BadFirst",
   last_name: "BadLast",
 };
 
-const RAW_CORRECT_TEACHER: RawUser = {
+const RAW_CORRECT_TEACHER: IPortalClassUser = {
   id: TEACHER_PORTAL_JWT.user_id,
+  user_id: TEACHER_PORTAL_JWT.uid,
   first_name: "GoodFirst",
   last_name: "GoodLast",
 };
 
-const RAW_CLASS_INFO: RawClassInfo = {
+const RAW_CLASS_INFO: IPortalClassInfo = {
+  id: 12345,
   uri: "https://foo.bar",
   name: "test name",
-  state: "test state",
   class_hash: CLASS_HASH,
   students: [RAW_CORRECT_STUDENT, RAW_INCORRECT_STUDENT ],
   teachers: [RAW_CORRECT_TEACHER],
+  offerings: []
 };
 
 const PARTIAL_RAW_OFFERING_INFO = {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -5,11 +5,11 @@ import { AppMode } from "../models/stores/store-types";
 import { QueryParams, urlParams as pageUrlParams } from "../utilities/url-params";
 import { NUM_FAKE_STUDENTS, NUM_FAKE_TEACHERS } from "../components/demo/demo-creator";
 import { AppConfigModelType } from "../models/stores/app-config-model";
-import { IPortalClassOffering } from "../models/stores/user";
+import { IUserPortalOffering } from "../models/stores/user";
 import { UserType } from "../models/stores/user-types";
 import { getErrorMessage } from "../utilities/super-agent-helpers";
 import { getPortalOfferings, getPortalClassOfferings,  getProblemIdForAuthenticatedUser } from "./portal-api";
-import { PortalJWT, PortalFirebaseJWT } from "./portal-types";
+import { PortalJWT, PortalFirebaseJWT, IPortalClassInfo } from "./portal-types";
 import { Logger, LogEventName } from "../lib/logger";
 
 export const PORTAL_JWT_URL_SUFFIX = "api/v1/jwt/portal";
@@ -49,12 +49,6 @@ export const DEV_CLASS_INFO: ClassInfo = {
   teachers: [DEV_TEACHER]
 };
 
-export interface RawUser {
-  id: string;
-  first_name: string;
-  last_name: string;
-}
-
 export type AuthenticatedUser = StudentUser | TeacherUser;
 export const isAuthenticatedTeacher = (u: AuthenticatedUser): u is TeacherUser => u.type === "teacher";
 
@@ -72,7 +66,7 @@ interface User {
   rawPortalJWT?: string;
   firebaseJWT?: PortalFirebaseJWT;
   rawFirebaseJWT?: string;
-  portalClassOfferings?: IPortalClassOffering[];
+  portalClassOfferings?: IUserPortalOffering[];
   demoClassHashes?: string[];
 }
 
@@ -84,15 +78,6 @@ export interface TeacherUser extends User {
   type: "teacher";
   network?: string;     // default network for teacher
   networks?: string[];  // list of networks available to teacher
-}
-
-export interface RawClassInfo {
-  uri: string;
-  name: string;
-  state: string;
-  class_hash: string;
-  teachers: RawUser[];
-  students: RawUser[];
 }
 
 export interface ClassInfo {
@@ -191,7 +176,7 @@ export const getClassInfo = (params: GetClassInfoParams) => {
       } else if (!res.body || !res.body.class_hash) {
         reject("Invalid class info response");
       } else {
-        const rawClassInfo: RawClassInfo = res.body;
+        const rawClassInfo: IPortalClassInfo = res.body;
 
         const classInfo: ClassInfo = {
           name: rawClassInfo.name,

--- a/src/lib/firestore-schema.ts
+++ b/src/lib/firestore-schema.ts
@@ -125,11 +125,12 @@ type OfferingsCollection = FSCollection<OfferingDocument>;
  * Networked access will be mediated by Firestore security rules which can check whether the requesting user and
  * one of the teachers of the class share a network.
  */
-interface ClassDocument {
+export interface ClassDocument {
   id: string;                 // portal class id
   name: string;               // portal class name
   uri: string;                // portal class info url
   context_id: string;         // portal class hash
+  teacher: string;            // name of primary(?) teacher
   teachers: string[];         // uids of teachers of class
   network: string;            // network of teacher creating class
 }

--- a/src/lib/firestore-schema.ts
+++ b/src/lib/firestore-schema.ts
@@ -124,6 +124,11 @@ type OfferingsCollection = FSCollection<OfferingDocument>;
  * Class resources are accessible to other teachers that share a network with one of the teachers of the class.
  * Networked access will be mediated by Firestore security rules which can check whether the requesting user and
  * one of the teachers of the class share a network.
+ *
+ * TODO: This declaration is redundantly specified in `firestore-rules/class-rules.test.ts` due to access rules.
+ * In the near term, changes to this interface should be synchronized there as well. Ultimately, we should figure
+ * out a way to share the declaration, which might be to combine the `firebase-test` and `functions` directories
+ * and then to move this file to a shared folder within the combined directory.
  */
 export interface ClassDocument {
   id: string;                 // portal class id

--- a/src/lib/firestore.test.ts
+++ b/src/lib/firestore.test.ts
@@ -1,0 +1,179 @@
+import { DB } from "./db";
+import { Firestore } from "./firestore";
+
+var mockStores = {
+  appMode: "authed",
+  demo: { name: "demo" },
+  user: { portal: "test-portal" }
+};
+var mockDB = {
+  stores: mockStores
+} as DB;
+var mockDocGet = jest.fn();
+var mockDocSet = jest.fn();
+var mockDoc = jest.fn((path: string) => ({
+      get: mockDocGet,
+      set: (obj: any) => mockDocSet(obj)
+    }));
+var mockCollection = jest.fn(() => ({ doc: mockDoc }));
+jest.mock("firebase/app", () => ({
+  firestore: () => ({
+    collection: mockCollection,
+    doc: mockDoc
+  })
+}));
+
+// permissions error is returned for document not found due to security rules
+class MockFirestorePermissionsError extends Error {
+  code: string;
+
+  constructor() {
+    super("Permission denied");
+    this.code = "permission-denied";
+  }
+}
+
+// class MockFirestoreOtherError extends Error {
+//   code: string;
+
+//   constructor() {
+//     super("Some other error");
+//     this.code = "other-error";
+//   }
+// }
+
+describe("Firestore class", () => {
+
+  function resetMocks() {
+    mockDocGet.mockReset();
+    mockDocSet.mockReset();
+    mockDoc.mockClear();
+    mockCollection.mockClear();
+  }
+
+  describe("initialization", () => {
+    beforeEach(() => resetMocks());
+    it("should create a valid Firestore object", () => {
+      const firestore = new Firestore(mockDB);
+      expect(firestore).toBeDefined();
+      expect(firestore.getRootFolder()).toBe("/authed/test-portal/");
+    });
+  });
+
+  describe("setFirebaseUser", () => {
+    beforeEach(() => resetMocks());
+    it("should update user information", () => {
+      const firestore = new Firestore(mockDB);
+      expect(firestore.userId).toBe("no-user-id");
+      expect(firestore.isConnected).toBe(false);
+      firestore.setFirebaseUser({ uid: "user-1"} as any);
+      expect(firestore.userId).toBe("user-1");
+      expect(firestore.isConnected).toBe(true);
+    });
+  });
+
+  describe("collectionRef", () => {
+    beforeEach(() => resetMocks());
+    it("should call the `collection()` method with an appropriate path", () => {
+      const firestore = new Firestore(mockDB);
+      firestore.collectionRef("/full/path");
+      expect(mockCollection).toHaveBeenCalledWith("/full/path");
+    });
+  });
+
+  describe("documentRef", () => {
+    beforeEach(() => resetMocks());
+    it("should call the `collection()` or `doc()` methods with an appropriate path", () => {
+      const firestore = new Firestore(mockDB);
+      firestore.documentRef("/full/path");
+      expect(mockDoc).toHaveBeenCalledWith("/full/path");
+      firestore.documentRef("/full/path", "doc-id");
+      expect(mockCollection).toHaveBeenCalledWith("/full/path");
+      expect(mockDoc).toHaveBeenLastCalledWith("doc-id");
+    });
+  });
+
+  describe("collection", () => {
+    beforeEach(() => resetMocks());
+    it("should call the `collection()` method with an appropriate path", () => {
+      const firestore = new Firestore(mockDB);
+      firestore.collection("partial/path");
+      expect(mockCollection).toHaveBeenCalledWith("/authed/test-portal/partial/path");
+    });
+  });
+
+  describe("doc", () => {
+    beforeEach(() => resetMocks());
+    it("should call the `doc()` method with an appropriate path", () => {
+      const firestore = new Firestore(mockDB);
+      firestore.doc("partial/path");
+      expect(mockDoc).toHaveBeenCalledWith("/authed/test-portal/partial/path");
+    });
+  });
+
+  describe("newDocumentRef", () => {
+    beforeEach(() => resetMocks());
+    it("should call the `collection()` method with an appropriate path", () => {
+      const firestore = new Firestore(mockDB);
+      firestore.newDocumentRef("/full/path");
+      expect(mockCollection).toHaveBeenCalledWith("/full/path");
+      expect(mockDoc).toHaveBeenCalled();
+    });
+  });
+
+  describe("getDocument", () => {
+    beforeEach(() => resetMocks());
+    it("should call the `collection()` and `doc()` methods with an appropriate path", () => {
+      const firestore = new Firestore(mockDB);
+      firestore.getDocument("/full/path", "doc-id");
+      expect(mockCollection).toHaveBeenCalledWith("/full/path");
+      expect(mockDoc).toHaveBeenLastCalledWith("doc-id");
+      expect(mockDocGet).toHaveBeenCalled();
+    });
+  });
+
+  interface Foo { foo: string }
+  describe("guaranteeDocument", () => {
+    beforeEach(() => resetMocks());
+
+    it("should `get()` the document if it exists", async () => {
+      const content = { foo: "bar" };
+      mockDocGet.mockImplementation(() => ({ data: () => Promise.resolve(content) }));
+      const firestore = new Firestore(mockDB);
+      const result = await firestore.guaranteeDocument<Foo>("partial/path", () => Promise.resolve(content));
+      expect(mockDocGet).toHaveBeenCalled();
+      expect(result).toEqual(content);
+      expect(mockDocSet).not.toHaveBeenCalled();
+    });
+
+    it("should create the document if it doesn't exist", async () => {
+      const content = { foo: "bar" };
+      mockDocGet.mockImplementation(() => { throw new MockFirestorePermissionsError(); });
+      const firestore = new Firestore(mockDB);
+      await firestore.guaranteeDocument<Foo>("partial/path", () => Promise.resolve(content));
+      expect(mockDocGet).toHaveBeenCalled();
+      expect(mockDocSet).toHaveBeenCalledWith(content);
+    });
+
+    it("should update the document if requested", async () => {
+      const content = { foo: "bar" };
+      mockDocGet.mockImplementation(() => ({ data: () => Promise.resolve(content) }));
+      const firestore = new Firestore(mockDB);
+      await firestore.guaranteeDocument<Foo>("partial/path", () => Promise.resolve(content), () => true);
+      expect(mockDocGet).toHaveBeenCalled();
+      expect(mockDocSet).toHaveBeenCalledWith(content);
+    });
+
+  });
+
+  describe("getFirestoreUser", () => {
+    beforeEach(() => resetMocks());
+    it("should call the `doc()` and `get()` methods with an appropriate path", () => {
+      const firestore = new Firestore(mockDB);
+      firestore.getFirestoreUser("user-1");
+      expect(mockDoc).toHaveBeenCalledWith(`/authed/test-portal/users/user-1`);
+      expect(mockDocGet).toHaveBeenCalled();
+    });
+  });
+
+});

--- a/src/lib/firestore.ts
+++ b/src/lib/firestore.ts
@@ -126,7 +126,8 @@ export class Firestore {
       const content: T | undefined = (await docRef.get()).data() as T | undefined;
       if (shouldUpdate?.(content)) {
         // update the document if client indicates the need to do so
-        return docRef.set(await writeContent(), { merge: true });
+        const _content = await writeContent();
+        return _content ? docRef.set(_content, { merge: true }) : undefined;
       }
       return content;
     }
@@ -135,7 +136,8 @@ export class Firestore {
       // rules depend on the contents of the document) are signaled as permissions errors
       if (isFirestorePermissionsError(e)) {
         // create the document if it doesn't already exist
-        return docRef.set(await writeContent());
+        const _content = await writeContent();
+        return _content ? docRef.set(_content) : undefined;
       }
     }
   }

--- a/src/lib/portal-api.test.ts
+++ b/src/lib/portal-api.test.ts
@@ -1,7 +1,8 @@
-import { getPortalOfferings, IPortalOffering, PortalOfferingParser } from "./portal-api";
 import nock from "nock";
+import { getPortalClassOfferings, getPortalOfferings, PortalOfferingParser } from "./portal-api";
+import { IPortalOffering } from "./portal-types";
 import { TeacherMineClasses, TeacherOfferings } from "../test-fixtures/sample-portal-offerings";
-import { AppConfigModel } from "../models/stores/app-config-model";
+import { AppConfigModel, AppConfigModelType } from "../models/stores/app-config-model";
 
 const userType = "teacher";
 const userID = 22;
@@ -95,6 +96,19 @@ describe("Portal Offerings", () => {
         const unitCode = getUnitCode(samplePortalOffering.activity_url, appConfig);
         expect(unitCode).toBeUndefined();
       });
+    });
+
+    describe("getPortalClassOfferings", () => {
+      const mockAppConfig = { defaultProblemOrdinal: "1.1", defaultUnit: "sas", unitCodeMap: {} } as AppConfigModelType;
+      const mockUrlParams = {
+              class: "https://learn.staging.concord.org/api/v1/classes/242",
+              offering: "https://collaborative-learning.concord.org/branch/master/?problem=1.2",
+              reportType: "report-type",
+              token: "token"
+            };
+      const offerings = getPortalClassOfferings(TeacherOfferings, mockAppConfig, mockUrlParams);
+      // TeacherOfferings has one non-CLUE activity
+      expect(offerings.length).toBe(TeacherOfferings.length - 1);
     });
   });
 });

--- a/src/lib/portal-types.ts
+++ b/src/lib/portal-types.ts
@@ -1,5 +1,52 @@
 export type UserType = "student" | "teacher";
 
+export interface IPortalReport {
+  url: string;
+  name: string;
+  id: number;
+}
+
+// The portal's native format of offerings API returns
+export interface IPortalOffering {
+  id: number;
+  clazz: string;
+  clazz_id: number;
+  clazz_hash?: string;  // added in recent portal versions
+  clazz_info_url: string;
+  activity: string;
+  activity_url: string;
+  external_report?: IPortalReport | null;
+  external_reports?: IPortalReport[];
+  teacher: string;
+}
+
+// portal's offerings format from classes API returns
+export interface IPortalClassOffering {
+  id: number;
+  name: string;
+  url: string;
+  active: boolean;
+  locked: boolean;
+}
+
+export interface IPortalClassUser {
+  id: string;               // e.g. "https://learn.staging.concord.org/users/5445"
+  user_id: number;          // e.g. 5445
+  first_name: string;
+  last_name: string;
+}
+
+// format of portal's `classes` api response
+export interface IPortalClassInfo {
+  id: number;               // e.g. 553
+  uri: string;              // "https://learn.staging.concord.org/api/v1/classes/553"
+  name: string;
+  class_hash: string;
+  teachers: IPortalClassUser[];
+  students: IPortalClassUser[];
+  offerings: IPortalClassOffering[];
+}
+
 export type PortalJWT = PortalStudentJWT | PortalTeacherJWT | PortalUserJWT;
 
 export interface BasePortalJWT {

--- a/src/lib/teacher-network.test.ts
+++ b/src/lib/teacher-network.test.ts
@@ -1,0 +1,258 @@
+import fetchMock from "jest-fetch-mock";
+import "firebase/firestore";
+import { Firestore } from "./firestore";
+import { ClassDocument, OfferingDocument } from "./firestore-schema";
+import { IPortalClassInfo, IPortalClassUser } from "./portal-types";
+import { UserModel, UserPortalOffering } from "../models/stores/user";
+import {
+  ClassWithoutTeachers, clearTeachersPromises, getProblemPath, OfferingWithoutTeachers,
+  syncClass, syncOffering, syncTeacherClassesAndOfferings
+} from "./teacher-network";
+
+var mockDocGet = jest.fn();
+var mockDocSet = jest.fn();
+var mockDoc = jest.fn((path: string) => ({ get: mockDocGet, set: mockDocSet }));
+const firestore = {
+  doc: mockDoc
+} as any as Firestore;
+
+class MockFirestorePermissionsError extends Error {
+  code: string;
+
+  constructor() {
+    super("Permission denied");
+    this.code = "permission-denied";
+  }
+}
+
+const kPortalJWT = "JWT";
+const kTeacher1IdNumeric = 11;
+const kTeacher1Id = `${kTeacher1IdNumeric}`;
+const kTeacher1Name = "Teacher 1";
+const kTeacher1User: IPortalClassUser = {
+        id: "https://concord.org/users/11", user_id: kTeacher1IdNumeric, first_name: "Teacher", last_name: "1"
+      };
+
+const kClass1IdNumeric = 1;
+const kClass1Id = `${kClass1IdNumeric}`;
+const kClass1Url = `https://concord.org/classes/${kClass1Id}`;
+const kClass1Name = "Class 1";
+const kClass1Hash = "class-hash-1";
+const portalClass1: IPortalClassInfo = {
+  id: kClass1IdNumeric,
+  uri: kClass1Url,
+  name: kClass1Name,
+  class_hash: kClass1Hash,
+  teachers: [kTeacher1User],
+  students: [],
+  offerings: []
+};
+const partClass1: ClassWithoutTeachers = {
+        id: kClass1Id,
+        name: kClass1Name,
+        uri: kClass1Url,
+        context_id: kClass1Hash,
+        teacher: "Teacher 1",
+        network: "test-network"
+      };
+const fsClass1: ClassDocument = { ...partClass1, teachers: [kTeacher1Id] };
+
+const kOffering1IdNumeric = 101;
+const kOffering1Id = `${kOffering1IdNumeric}`;
+const kOffering1Url = `https://concord.org/offerings/${kOffering1Id}`;
+const kOffering1Name = "Offering 101";
+const kOffering1Unit = "msa";
+const kOffering1Problem = "1.1";
+const kOffering2IdNumeric = 102;
+const kOffering2Id = `${kOffering2IdNumeric}`;
+const kOffering2Url = `https://concord.org/offerings/${kOffering2Id}`;
+const kOffering2Name = "Offering 102";
+const kOffering2Unit = "msa";
+const kOffering2Problem = "1.2";
+const userOffering1 = () => UserPortalOffering.create({
+        classId: kClass1Id,
+        classHash: kClass1Hash,
+        className: kClass1Name,
+        classUrl: kClass1Url,
+        teacher: kTeacher1Name,
+        activityTitle: kOffering1Name,
+        activityUrl: kOffering1Url,
+        problemOrdinal: kOffering1Problem,
+        unitCode: kOffering1Unit,
+        offeringId: kOffering1Id
+      });
+const userOffering2 = () => UserPortalOffering.create({
+        classId: kClass1Id,
+        classHash: kClass1Hash,
+        className: kClass1Name,
+        classUrl: kClass1Url,
+        teacher: kTeacher1Name,
+        activityTitle: kOffering2Name,
+        activityUrl: kOffering2Url,
+        problemOrdinal: kOffering2Problem,
+        unitCode: kOffering2Unit,
+        offeringId: kOffering2Id
+      });
+const partOffering1: OfferingWithoutTeachers = {
+        id: kOffering1Id,
+        name: kOffering1Name,
+        uri: kOffering1Url,
+        context_id: kClass1Hash,
+        unit: kOffering1Unit,
+        problem: kOffering1Problem,
+        problemPath: getProblemPath(kOffering1Unit, kOffering1Problem),
+        network: "test-network"
+      };
+const fsOffering1: OfferingDocument = { ...partOffering1, teachers: [kTeacher1Id] };
+
+describe("Teacher network functions", () => {
+
+  function resetMocks() {
+    mockDoc.mockClear();
+    mockDocGet.mockReset();
+    mockDocSet.mockClear();
+    fetchMock.resetMocks();
+    clearTeachersPromises();
+  }
+
+  describe("getProblemPath", () => {
+    it("should convert problem paths", () => {
+      expect(getProblemPath("sas", "1.2")).toBe("sas/1/2");
+    });
+  });
+
+  describe("syncClass", () => {
+    beforeEach(() => {
+      resetMocks();
+    });
+
+    it("should do nothing if the class already exists", async () => {
+      mockDocGet.mockImplementation(() => Promise.resolve(fsClass1));
+      const result = await syncClass(firestore, kPortalJWT, partClass1);
+      expect(mockDoc).toHaveBeenCalledWith("classes/test-network_class-hash-1");
+      expect(mockDocGet).toHaveBeenCalled();
+      expect(mockDocSet).not.toHaveBeenCalled();
+      return result;
+    });
+
+    it("should do nothing if the portal class api call response is not ok", async () => {
+      mockDocGet.mockImplementation(() => { throw new MockFirestorePermissionsError(); });
+      // !ok response from fetch
+      fetchMock.mockResponseOnce('{}', { status: 500, headers: { 'content-type': 'application/json' } });
+      const result = await syncClass(firestore, kPortalJWT, partClass1);
+      expect(mockDoc).toHaveBeenCalledWith("classes/test-network_class-hash-1");
+      expect(mockDocGet).toHaveBeenCalled();
+      expect(mockDocSet).not.toHaveBeenCalled();
+      return result;
+    });
+
+    it("should do nothing if the portal class api call fails", async () => {
+      mockDocGet.mockImplementation(() => { throw new MockFirestorePermissionsError(); });
+      fetchMock.mockRejectOnce(new Error());
+      const result = await syncClass(firestore, kPortalJWT, partClass1);
+      expect(mockDoc).toHaveBeenCalledWith("classes/test-network_class-hash-1");
+      expect(mockDocGet).toHaveBeenCalled();
+      expect(mockDocSet).not.toHaveBeenCalled();
+      return result;
+    });
+
+    it("should write class to firestore if it's not already there", async () => {
+      mockDocGet.mockImplementation(() => { throw new MockFirestorePermissionsError(); });
+      fetchMock.mockResponseOnce(JSON.stringify(portalClass1));
+      const result = await syncClass(firestore, kPortalJWT, partClass1);
+      expect(mockDoc).toHaveBeenCalledWith("classes/test-network_class-hash-1");
+      expect(mockDocGet).toHaveBeenCalled();
+      expect(mockDocSet).toHaveBeenCalledWith(fsClass1);
+      return result;
+    });
+  });
+
+
+  describe("syncOffering", () => {
+    beforeEach(() => {
+      resetMocks();
+    });
+
+    it("should do nothing if the offering already exists", async () => {
+      mockDocGet.mockImplementation(() => Promise.resolve(fsOffering1));
+      const result = await syncOffering(firestore, kPortalJWT, kClass1Url, partOffering1);
+      expect(mockDoc).toHaveBeenCalledWith("offerings/test-network_class-hash-1");
+      expect(mockDocGet).toHaveBeenCalled();
+      expect(mockDocSet).not.toHaveBeenCalled();
+      return result;
+    });
+
+    it("should do nothing if the portal class api call response is not ok", async () => {
+      mockDocGet.mockImplementation(() => { throw new MockFirestorePermissionsError(); });
+      // !ok response from fetch
+      fetchMock.mockResponseOnce('{}', { status: 500, headers: { 'content-type': 'application/json' } });
+      const result = await syncOffering(firestore, kPortalJWT, kClass1Url, partOffering1);
+      expect(mockDoc).toHaveBeenCalledWith("offerings/test-network_class-hash-1");
+      expect(mockDocGet).toHaveBeenCalled();
+      expect(mockDocSet).not.toHaveBeenCalled();
+      return result;
+    });
+
+    it("should do nothing if the portal class api call fails", async () => {
+      mockDocGet.mockImplementation(() => { throw new MockFirestorePermissionsError(); });
+      fetchMock.mockRejectOnce(new Error());
+      const result = await syncOffering(firestore, kPortalJWT, kClass1Url, partOffering1);
+      expect(mockDoc).toHaveBeenCalledWith("offerings/test-network_class-hash-1");
+      expect(mockDocGet).toHaveBeenCalled();
+      expect(mockDocSet).not.toHaveBeenCalled();
+      return result;
+    });
+
+    it("should write class to firestore if it's not already there", async () => {
+      mockDocGet.mockImplementation(() => { throw new MockFirestorePermissionsError(); });
+      fetchMock.mockResponseOnce(JSON.stringify(portalClass1));
+      const result = await syncOffering(firestore, kPortalJWT, kClass1Url, partOffering1);
+      expect(mockDoc).toHaveBeenCalledWith("offerings/test-network_class-hash-1");
+      expect(mockDocGet).toHaveBeenCalled();
+      expect(mockDocSet).toHaveBeenCalledWith(fsOffering1);
+      return result;
+    });
+  });
+
+  describe("syncTeacherClassesAndOfferings", () => {
+    beforeEach(() => {
+      resetMocks();
+    });
+
+    const completeTeacher = UserModel.create({ id: kTeacher1Id, type: "teacher", network: "test-network",
+                                                portalClassOfferings: [userOffering1(), userOffering2()] });
+
+    it("should do nothing if there is no portal JWT", async () => {
+      const user = UserModel.create({ id: kTeacher1Id, type: "teacher", network: "test-network" });
+      await syncTeacherClassesAndOfferings(firestore, user, "");
+      expect(mockDoc).not.toHaveBeenCalled();
+      expect(mockDocGet).not.toHaveBeenCalled();
+      expect(mockDocSet).not.toHaveBeenCalled();
+    });
+
+    it("should do nothing if the user has no offerings", async () => {
+      const user = UserModel.create({ id: kTeacher1Id, type: "teacher", network: "test-network" });
+      await syncTeacherClassesAndOfferings(firestore, user, kPortalJWT);
+      expect(mockDoc).not.toHaveBeenCalled();
+      expect(mockDocGet).not.toHaveBeenCalled();
+      expect(mockDocSet).not.toHaveBeenCalled();
+    });
+
+    it("should do nothing if the user has no network", async () => {
+      const user = UserModel.create({ id: kTeacher1Id, type: "teacher", portalClassOfferings: [userOffering1()] });
+      await syncTeacherClassesAndOfferings(firestore, user, kPortalJWT);
+      expect(mockDoc).not.toHaveBeenCalled();
+      expect(mockDocGet).not.toHaveBeenCalled();
+      expect(mockDocSet).not.toHaveBeenCalled();
+    });
+
+    it("should sync classes and offerings when appropriate", async () => {
+      mockDocGet.mockImplementation(() => { throw new MockFirestorePermissionsError(); });
+      fetchMock.mockResponseOnce(JSON.stringify(portalClass1));
+      await Promise.all(syncTeacherClassesAndOfferings(firestore, completeTeacher, kPortalJWT));
+      expect(mockDoc).toHaveBeenCalledTimes(3);
+      expect(mockDocGet).toHaveBeenCalledTimes(3);
+      expect(mockDocSet).toHaveBeenCalledTimes(3);
+    });
+  });
+});

--- a/src/lib/teacher-network.test.ts
+++ b/src/lib/teacher-network.test.ts
@@ -126,10 +126,12 @@ describe("Teacher network functions", () => {
       resetMocks();
     });
 
+    const classDocPath = `classes/test-network_${kClass1Hash}`;
+
     it("should do nothing if the class already exists", async () => {
       mockDocGet.mockImplementation(() => Promise.resolve(fsClass1));
       const result = await syncClass(firestore, kPortalJWT, partClass1);
-      expect(mockDoc).toHaveBeenCalledWith("classes/test-network_class-hash-1");
+      expect(mockDoc).toHaveBeenCalledWith(classDocPath);
       expect(mockDocGet).toHaveBeenCalled();
       expect(mockDocSet).not.toHaveBeenCalled();
       return result;
@@ -140,7 +142,7 @@ describe("Teacher network functions", () => {
       // !ok response from fetch
       fetchMock.mockResponseOnce('{}', { status: 500, headers: { 'content-type': 'application/json' } });
       const result = await syncClass(firestore, kPortalJWT, partClass1);
-      expect(mockDoc).toHaveBeenCalledWith("classes/test-network_class-hash-1");
+      expect(mockDoc).toHaveBeenCalledWith(classDocPath);
       expect(mockDocGet).toHaveBeenCalled();
       expect(mockDocSet).not.toHaveBeenCalled();
       return result;
@@ -150,7 +152,7 @@ describe("Teacher network functions", () => {
       mockDocGet.mockImplementation(() => { throw new MockFirestorePermissionsError(); });
       fetchMock.mockRejectOnce(new Error());
       const result = await syncClass(firestore, kPortalJWT, partClass1);
-      expect(mockDoc).toHaveBeenCalledWith("classes/test-network_class-hash-1");
+      expect(mockDoc).toHaveBeenCalledWith(classDocPath);
       expect(mockDocGet).toHaveBeenCalled();
       expect(mockDocSet).not.toHaveBeenCalled();
       return result;
@@ -160,7 +162,7 @@ describe("Teacher network functions", () => {
       mockDocGet.mockImplementation(() => { throw new MockFirestorePermissionsError(); });
       fetchMock.mockResponseOnce(JSON.stringify(portalClass1));
       const result = await syncClass(firestore, kPortalJWT, partClass1);
-      expect(mockDoc).toHaveBeenCalledWith("classes/test-network_class-hash-1");
+      expect(mockDoc).toHaveBeenCalledWith(classDocPath);
       expect(mockDocGet).toHaveBeenCalled();
       expect(mockDocSet).toHaveBeenCalledWith(fsClass1);
       return result;
@@ -173,10 +175,12 @@ describe("Teacher network functions", () => {
       resetMocks();
     });
 
+    const offeringDocPath = `offerings/test-network_${kOffering1Id}`;
+
     it("should do nothing if the offering already exists", async () => {
       mockDocGet.mockImplementation(() => Promise.resolve(fsOffering1));
       const result = await syncOffering(firestore, kPortalJWT, kClass1Url, partOffering1);
-      expect(mockDoc).toHaveBeenCalledWith("offerings/test-network_class-hash-1");
+      expect(mockDoc).toHaveBeenCalledWith(offeringDocPath);
       expect(mockDocGet).toHaveBeenCalled();
       expect(mockDocSet).not.toHaveBeenCalled();
       return result;
@@ -187,7 +191,7 @@ describe("Teacher network functions", () => {
       // !ok response from fetch
       fetchMock.mockResponseOnce('{}', { status: 500, headers: { 'content-type': 'application/json' } });
       const result = await syncOffering(firestore, kPortalJWT, kClass1Url, partOffering1);
-      expect(mockDoc).toHaveBeenCalledWith("offerings/test-network_class-hash-1");
+      expect(mockDoc).toHaveBeenCalledWith(offeringDocPath);
       expect(mockDocGet).toHaveBeenCalled();
       expect(mockDocSet).not.toHaveBeenCalled();
       return result;
@@ -197,7 +201,7 @@ describe("Teacher network functions", () => {
       mockDocGet.mockImplementation(() => { throw new MockFirestorePermissionsError(); });
       fetchMock.mockRejectOnce(new Error());
       const result = await syncOffering(firestore, kPortalJWT, kClass1Url, partOffering1);
-      expect(mockDoc).toHaveBeenCalledWith("offerings/test-network_class-hash-1");
+      expect(mockDoc).toHaveBeenCalledWith(offeringDocPath);
       expect(mockDocGet).toHaveBeenCalled();
       expect(mockDocSet).not.toHaveBeenCalled();
       return result;
@@ -207,7 +211,7 @@ describe("Teacher network functions", () => {
       mockDocGet.mockImplementation(() => { throw new MockFirestorePermissionsError(); });
       fetchMock.mockResponseOnce(JSON.stringify(portalClass1));
       const result = await syncOffering(firestore, kPortalJWT, kClass1Url, partOffering1);
-      expect(mockDoc).toHaveBeenCalledWith("offerings/test-network_class-hash-1");
+      expect(mockDoc).toHaveBeenCalledWith(offeringDocPath);
       expect(mockDocGet).toHaveBeenCalled();
       expect(mockDocSet).toHaveBeenCalledWith(fsOffering1);
       return result;

--- a/src/lib/teacher-network.ts
+++ b/src/lib/teacher-network.ts
@@ -1,6 +1,6 @@
 import { Optional } from "utility-types";
 import { UserModelType } from "../models/stores/user";
-import { Firestore, isFirestorePermissionsError } from "./firestore";
+import { Firestore } from "./firestore";
 import { ClassDocument, OfferingDocument } from "./firestore-schema";
 import { IPortalClassInfo } from "./portal-types";
 
@@ -88,8 +88,8 @@ export async function syncClass(firestore: Firestore, rawPortalJWT: string, aCla
       const teachers = await getClassTeachers(uri, rawPortalJWT);
       if (teachers) {
         aClass.teachers = teachers;
+        return aClass;
       }
-      return aClass;
     });
   }
 }
@@ -103,8 +103,8 @@ export async function syncOffering(
       const teachers = await getClassTeachers(classUrl, rawPortalJWT);
       if (teachers) {
         offering.teachers = teachers;
+        return offering;
       }
-      return offering;
     });
   }
 }

--- a/src/lib/teacher-network.ts
+++ b/src/lib/teacher-network.ts
@@ -1,0 +1,126 @@
+import { Optional } from "utility-types";
+import { UserModelType } from "../models/stores/user";
+import { Firestore, isFirestorePermissionsError } from "./firestore";
+import { ClassDocument, OfferingDocument } from "./firestore-schema";
+import { IPortalClassInfo } from "./portal-types";
+
+export type ClassWithoutTeachers = Optional<ClassDocument, "teachers">;
+export type OfferingWithoutTeachers = Optional<OfferingDocument, "teachers">;
+
+let classTeachersPromises: Record<string, Promise<string[] | undefined>> = {};
+
+// primarily for testing
+export function clearTeachersPromises() {
+  classTeachersPromises = {};
+}
+
+// returns a promise that resolves to the list of teacher user ids (or undefined on error)
+// uses the classTeachersPromises map to guarantee that each class is only requested once
+function getClassTeachers(classUri: string, rawPortalJWT: string) {
+  // return the existing promise if we've already created one
+  let promise = classTeachersPromises[classUri];
+  if (!promise) {
+    promise = classTeachersPromises[classUri] = new Promise((resolve, reject) => {
+      const fetchOptions: RequestInit = { headers: { Authorization: `Bearer/JWT ${rawPortalJWT}` } };
+      fetch(classUri, fetchOptions)
+        .then(response => {
+          if (response.ok) {
+            response.json().then((portalClass: IPortalClassInfo) => {
+              resolve(portalClass.teachers.map(t => `${t.user_id}`));
+            });
+          }
+          else {
+            resolve(undefined);
+          }
+        })
+        .catch(error => {
+          resolve(undefined);
+        });
+    });
+  }
+  return promise;
+}
+
+// converts "msa", "1.4" to "msa/1/4"
+export function getProblemPath(unit: string, problem: string) {
+  return [unit, ...problem.split(".")].join("/");
+}
+
+// synchronize the current teacher's classes and offerings to firestore
+export function syncTeacherClassesAndOfferings(firestore: Firestore, user: UserModelType, rawPortalJWT: string) {
+  const { network } = user;
+  if (!network) return [];
+
+  const promises: Promise<void>[] = [];
+
+  // map portal offerings to classes
+  const userClasses: Record<string, ClassWithoutTeachers> = {};
+  user.portalClassOfferings.forEach(offering => {
+    const { classId: id, classHash: context_id, className: name, classUrl: uri, teacher } = offering;
+    if (!userClasses[context_id]) {
+      userClasses[context_id] = { id, context_id, name, uri, teacher, network };
+    }
+  });
+
+  // synchronize the classes
+  Object.keys(userClasses).forEach(async classHash => {
+    promises.push(syncClass(firestore, rawPortalJWT, userClasses[classHash]));
+  });
+
+  // synchronize the offerings
+  user.portalClassOfferings.forEach(async offering => {
+    const {
+      offeringId: id, activityTitle: name, activityUrl: uri, classHash: context_id, classUrl,
+      unitCode: unit, problemOrdinal: problem
+    } = offering;
+    const problemPath = getProblemPath(unit, problem);
+    const fsOffering: OfferingWithoutTeachers = { id, name, uri, context_id, unit, problem, problemPath, network };
+    promises.push(syncOffering(firestore, rawPortalJWT, classUrl, fsOffering));
+  });
+
+  return promises;
+}
+
+export async function syncClass(firestore: Firestore, rawPortalJWT: string, aClass: ClassWithoutTeachers) {
+  const { uri, context_id, network } = aClass;
+  if (uri && context_id && network && rawPortalJWT) {
+    const classDoc = firestore.doc(`classes/${network}_${context_id}`);
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const fsClass = await classDoc.get();
+      // class already exists in firestore; could sync contents but we'll skip for now
+    }
+    catch(e) {
+      if (isFirestorePermissionsError(e)) {
+        const teachers = await getClassTeachers(uri, rawPortalJWT);
+        if (teachers) {
+          aClass.teachers = teachers;
+          classDoc.set(aClass);
+        }
+      }
+    }
+  }
+}
+
+export async function syncOffering(
+  firestore: Firestore, rawPortalJWT: string, classUrl: string, offering: OfferingWithoutTeachers)
+{
+  const { context_id, network } = offering;
+  if (classUrl && network && rawPortalJWT) {
+    const offeringDoc = firestore.doc(`offerings/${network}_${context_id}`);
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const fsOffering = await offeringDoc.get();
+      // offering already exists in firestore; could sync contents but we'll skip for now
+    }
+    catch(e) {
+      if (isFirestorePermissionsError(e)) {
+        const teachers = await getClassTeachers(classUrl, rawPortalJWT);
+        if (teachers) {
+          offering.teachers = teachers;
+          offeringDoc.set(offering);
+        }
+      }
+    }
+  }
+}

--- a/src/lib/teacher-network.ts
+++ b/src/lib/teacher-network.ts
@@ -124,3 +124,11 @@ export async function syncOffering(
     }
   }
 }
+
+export function getNetworkClassesThatAssignedProblem(firestore: Firestore, network: string, problemPath: string) {
+  return firestore
+          .collection("offerings")
+          .where("network", "==", network)
+          .where("problemPath", "==", problemPath)
+          .get();
+}

--- a/src/lib/teacher-network.ts
+++ b/src/lib/teacher-network.ts
@@ -105,9 +105,9 @@ export async function syncClass(firestore: Firestore, rawPortalJWT: string, aCla
 export async function syncOffering(
   firestore: Firestore, rawPortalJWT: string, classUrl: string, offering: OfferingWithoutTeachers)
 {
-  const { context_id, network } = offering;
+  const { network, id } = offering;
   if (classUrl && network && rawPortalJWT) {
-    const offeringDoc = firestore.doc(`offerings/${network}_${context_id}`);
+    const offeringDoc = firestore.doc(`offerings/${network}_${id}`);
     try {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const fsOffering = await offeringDoc.get();

--- a/src/models/stores/user.test.ts
+++ b/src/models/stores/user.test.ts
@@ -1,11 +1,11 @@
-import { PortalClassOffering, UserModel } from "./user";
+import { UserPortalOffering, UserModel } from "./user";
 import { AuthenticatedUser } from "../../lib/auth";
 import { PortalFirebaseStudentJWT } from "../../lib/portal-types";
 
-describe("PortalClassOffering", () => {
+describe("UserPortalOffering", () => {
 
   it("defaults to empty", () => {
-    const offering = PortalClassOffering.create();
+    const offering = UserPortalOffering.create();
     expect(offering.classId).toBe("");
     expect(offering.classHash).toBe("");
     expect(offering.problemPath).toBe("");
@@ -16,7 +16,7 @@ describe("PortalClassOffering", () => {
     const kClassHash = "class-hash";
     const kUnitCode = "unit";
     const kProblemOrdinal = "2.3";
-    const offering = PortalClassOffering.create({
+    const offering = UserPortalOffering.create({
                       classId: kClassId,
                       classHash: kClassHash,
                       unitCode: kUnitCode,
@@ -133,7 +133,7 @@ describe("user model", () => {
     const activityUrl = "https://concord.org/activity";
     const unitCode = "unit";
     const problemOrdinal = "3.4";
-    const offering = PortalClassOffering.create({ offeringId: "1", classHash, activityUrl, unitCode, problemOrdinal });
+    const offering = UserPortalOffering.create({ offeringId: "1", classHash, activityUrl, unitCode, problemOrdinal });
     const authenticatedUser: AuthenticatedUser = {
       type: "teacher",
       id: "1",
@@ -166,7 +166,7 @@ describe("user model", () => {
     const activityUrl = "https://concord.org/activity";
     const unitCode = "unit";
     const problemOrdinal = "3.4";
-    const offering = PortalClassOffering.create({ offeringId: "1", classHash, activityUrl, unitCode, problemOrdinal });
+    const offering = UserPortalOffering.create({ offeringId: "1", classHash, activityUrl, unitCode, problemOrdinal });
     const authenticatedUser: AuthenticatedUser = {
       type: "teacher",
       id: "1",

--- a/src/models/stores/user.ts
+++ b/src/models/stores/user.ts
@@ -1,14 +1,16 @@
 import initials from "initials";
-import { types } from "mobx-state-tree";
+import { Instance, types } from "mobx-state-tree";
 import { AuthenticatedUser, isAuthenticatedTeacher } from "../../lib/auth";
 import { PortalFirebaseStudentJWT } from "../../lib/portal-types";
 import { UserTypeEnum } from "./user-types";
 
-export const PortalClassOffering = types
-  .model("PortalClassOffering", {
+export const UserPortalOffering = types
+  .model("UserPortalOffering", {
     classId: "",
     classHash: "",
     className: "",
+    classUrl: "",
+    teacher: "",
     activityTitle: "",
     activityUrl: "",
     problemOrdinal: "",
@@ -23,7 +25,7 @@ export const PortalClassOffering = types
     }
   }));
 
-export type IPortalClassOffering = typeof PortalClassOffering.Type;
+export type IUserPortalOffering = Instance<typeof UserPortalOffering>;
 
 export const UserModel = types
   .model("User", {
@@ -39,7 +41,7 @@ export const UserModel = types
     network: types.maybe(types.string),
     networks: types.array(types.string),
     loggingRemoteEndpoint: types.maybe(types.string),
-    portalClassOfferings: types.array(PortalClassOffering),
+    portalClassOfferings: types.array(UserPortalOffering),
     demoClassHashes: types.array(types.string),
     lastSupportViewTimestamp: types.maybe(types.number),
     lastStickyNoteViewTimestamp: types.maybe(types.number)

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,4 +1,7 @@
 import "@testing-library/jest-dom";
+import { enableFetchMocks } from "jest-fetch-mock";
+// make fetch mocking available in all tests
+enableFetchMocks();
 
 /*
  * jestSpyConsole


### PR DESCRIPTION
[[#179154344]](https://www.pivotaltracker.com/story/show/179154344)

On launch by a teacher, we synchronize each of the teacher's CLUE offerings (assignments) and classes that have assigned those offerings to firestore so that they can be used for future network lookups. Currently, if a given class/offering is already in firestore we just leave it alone, assuming that it has already been synchronized. With a little more work we could actually update the information in firestore in case there have been changes to the set of teachers of the class or other non-static information, but those changes are likely to be infrequent at best and so we leave handling of updates for a future story. Most of the information we need was already available but for security rules purposes we need to request information for each class from the portal to determine the set of teachers associated with the class.

Along the way we also take care of a few odds and ends:
- update security rules for classes to account for the fact that we will need an additional `teacher` field to store the name of the primary teacher of the class because that will be used to label the class in the UI.
- update the dependencies in the `firebase-test` directory (where the rules-testing occurs).
- refactor/reorganize/rename some of the portal type definitions since they were scattered around in different places and had some inconsistent naming in those different places.
- add a unit test for the previously untested `portal-api.ts` function `getPortalClassOfferings()`.

As before, assigning @scytacki for review, but cc'ing @mklewandowski and @Concord-Jim.