### PR TITLE
Change primary doc comment highlighting

### DIFF
--- a/src/components/document/editable-document-content.tsx
+++ b/src/components/document/editable-document-content.tsx
@@ -87,7 +87,7 @@ export const EditableDocumentContent: React.FC<IProps> = props => {
   const isShowingToolbar = !!toolbar && !isReadOnly;
   const showToolbarClass = isShowingToolbar ? "show-toolbar" : "hide-toolbar";
   const isChatEnabled = isNetworkedTeacher && urlParams.chat;
-  const documentSelectedForComment = isChatEnabled && ui.showChatPanel && ui.selectedTileIds.length === 0;
+  const documentSelectedForComment = isChatEnabled && ui.showChatPanel && ui.selectedTileIds.length === 0 && !isPrimary;
   const editableDocContentClass = classNames("editable-document-content", showToolbarClass,
                                              {"comment-select" : documentSelectedForComment});
   return (


### PR DESCRIPTION
This PR changes the document comment highlighting so the primary document on the right is not highlighted with the green comment highlight background color.  Changes include:
- change how CSS class is added to container based on if we are viewing primary doc

PT Story: 
https://www.pivotaltracker.com/story/show/179660593

Deployed branch for testing:
https://collaborative-learning.concord.org/branch/fix-comment-highlight/?demo

![image](https://user-images.githubusercontent.com/5126913/134991577-0dc640d0-feee-4c00-b0f7-331e619d2075.png)

