### PR TITLE
Fix commenting on individual tiles in curriculum content [#179680306]

### DIFF
--- a/src/models/document/document-content.test.ts
+++ b/src/models/document/document-content.test.ts
@@ -2,13 +2,13 @@ import {
   cloneContentWithUniqueIds, createDefaultSectionedContent,
   DocumentContentModel, DocumentContentModelType, DocumentContentSnapshotType
 } from "./document-content";
+import { SectionModel, SectionModelType } from "../curriculum/section";
 import { IDropRowInfo } from "../../models/document/document-content";
 import { cloneTileSnapshotWithoutId, IDragTileItem } from "../../models/tools/tool-tile";
 import { defaultTextContent } from "../tools/text/text-content";
 import { IDocumentExportOptions } from "../tools/tool-content-info";
 import { safeJsonParse } from "../../utilities/js-utils";
 import placeholderImage from "../../assets/image_placeholder.png";
-import { SectionModel, SectionModelType } from "../curriculum/section";
 
 // mock uniqueId so we can recognize auto-generated IDs
 jest.mock("../../utilities/js-utils", () => {

--- a/src/models/document/document-content.test.ts
+++ b/src/models/document/document-content.test.ts
@@ -1,5 +1,6 @@
 import {
-  DocumentContentModel, DocumentContentModelType, cloneContentWithUniqueIds, DocumentContentSnapshotType
+  cloneContentWithUniqueIds, createDefaultSectionedContent,
+  DocumentContentModel, DocumentContentModelType, DocumentContentSnapshotType
 } from "./document-content";
 import { IDropRowInfo } from "../../models/document/document-content";
 import { cloneTileSnapshotWithoutId, IDragTileItem } from "../../models/tools/tool-tile";
@@ -7,6 +8,7 @@ import { defaultTextContent } from "../tools/text/text-content";
 import { IDocumentExportOptions } from "../tools/tool-content-info";
 import { safeJsonParse } from "../../utilities/js-utils";
 import placeholderImage from "../../assets/image_placeholder.png";
+import { SectionModel, SectionModelType } from "../curriculum/section";
 
 // mock uniqueId so we can recognize auto-generated IDs
 jest.mock("../../utilities/js-utils", () => {
@@ -696,6 +698,7 @@ describe("DocumentContentModel", () => {
     const row = content.getRowByIndex(1);
     expect(row!.tileCount).toBe(1);
     const tileId = row!.getTileIdAtIndex(0);
+    expect(tileId).toBe("Foo_Text_1");
     const tile = tileId ? content.tileMap.get(tileId) : undefined;
     const tileContent = tile!.content;
     expect(tileContent.type).toBe("Text");
@@ -1463,5 +1466,16 @@ describe("DocumentContentModel -- user-logging actions", () => {
     // deleting it again has no effect
     documentContent.userDeleteTile(newTileId!);
     expect(logTileEvent).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("DocumentContentModel -- createDefaultSectionedContent", () => {
+  it("creates sectioned content", () => {
+    const sections: SectionModelType[] = [
+            SectionModel.create({ type: "foo" }),
+            SectionModel.create({ type: "bar" })
+          ];
+    const content = createDefaultSectionedContent(sections);
+    expect(content.rowCount).toBe(4);
   });
 });

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -87,7 +87,9 @@ export const DocumentContentModel = types
   })
   .volatile(self => ({
     visibleRows: [] as string[],
-    highlightPendingDropLocation: -1
+    highlightPendingDropLocation: -1,
+    importContextCurrentSection: "",
+    importContextTileCounts: {} as Record<string, number>
   }))
   .views(self => {
     // used for drag/drop self-drop detection, for instance
@@ -363,6 +365,20 @@ export const DocumentContentModel = types
     }
   }))
   .actions(self => ({
+    setImportContext(section: string) {
+      self.importContextCurrentSection = section;
+      self.importContextTileCounts = {};
+    },
+    getNextTileId(tileType: string) {
+      if (!self.importContextTileCounts[tileType]) {
+        self.importContextTileCounts[tileType] = 1;
+      }
+      else {
+        ++self.importContextTileCounts[tileType];
+      }
+      const section = self.importContextCurrentSection || "document";
+      return `${section}_${tileType}_${self.importContextTileCounts[tileType]}`;
+    },
     insertRow(row: TileRowModelType, index?: number) {
       self.rowMap.put(row);
       if ((index != null) && (index < self.rowOrder.length)) {
@@ -910,23 +926,59 @@ interface OriginalTileLayoutModel {
   height?: number;
 }
 
+interface OriginalSectionHeaderContent {
+  isSectionHeader: true;
+  sectionId: string;
+}
+
+function isOriginalSectionHeaderContent(content: IAuthoredTileContent | OriginalSectionHeaderContent)
+          : content is OriginalSectionHeaderContent {
+  return !!content?.isSectionHeader && !!content.sectionId;
+}
+
 interface OriginalToolTileModel {
+  id?: string;
   display?: DisplayUserType;
   layout?: OriginalTileLayoutModel;
-  content: any;
+  content: IAuthoredTileContent | OriginalSectionHeaderContent;
 }
+interface OriginalAuthoredToolTileModel extends OriginalToolTileModel {
+  content: IAuthoredTileContent;
+}
+function isOriginalAuthoredToolTileModel(tile: OriginalToolTileModel): tile is OriginalAuthoredToolTileModel {
+  return !!(tile.content as IAuthoredTileContent)?.type && !tile.content.isSectionHeader;
+}
+
 type OriginalTilesSnapshot = Array<OriginalToolTileModel | OriginalToolTileModel[]>;
+
+function addImportedTileInNewRow(
+          content: DocumentContentModelType,
+          tile: OriginalAuthoredToolTileModel,
+          options: INewTileOptions) {
+  const id = tile.id || content.getNextTileId(tile.content.type);
+  const tileSnapshot = { id, ...tile };
+  return content.addTileSnapshotInNewRow(tileSnapshot as ToolTileSnapshotInType, options);
+}
+
+function addImportedTileInExistingRow(
+          content: DocumentContentModelType,
+          tile: OriginalAuthoredToolTileModel,
+          options: INewTileOptions) {
+  const id = tile.id || content.getNextTileId(tile.content.type);
+  const tileSnapshot = { id, ...tile };
+  return content.addTileSnapshotInExistingRow(tileSnapshot as ToolTileSnapshotInType, options);
+}
 
 function migrateTile(content: DocumentContentModelType, tile: OriginalToolTileModel) {
   const { layout, ...newTile } = cloneDeep(tile);
   const tileHeight = layout?.height;
-  const { isSectionHeader, sectionId } = newTile.content;
-  if (isSectionHeader && sectionId) {
+  if (isOriginalSectionHeaderContent(newTile.content)) {
+    const { sectionId } = newTile.content;
+    content.setImportContext(sectionId);
     content.addSectionHeaderRow(sectionId);
   }
-  else {
-    const options = { rowIndex: content.rowCount, rowHeight: tileHeight };
-    content.addTileSnapshotInNewRow(newTile, options);
+  else if (isOriginalAuthoredToolTileModel(newTile)) {
+    addImportedTileInNewRow(content, newTile, { rowIndex: content.rowCount, rowHeight: tileHeight });
   }
 }
 
@@ -936,13 +988,15 @@ function migrateRow(content: DocumentContentModelType, tiles: OriginalToolTileMo
     const { layout, ...newTile } = cloneDeep(tile);
     const tileHeight = layout?.height;
     const options = { rowIndex: insertRowIndex, rowHeight: tileHeight };
-    if (tileIndex === 0) {
-      const newRowInfo = content.addTileSnapshotInNewRow(newTile, options);
-      const newRowIndex = content.getRowIndex(newRowInfo.rowId);
-      (newRowIndex >= 0) && (insertRowIndex = newRowIndex);
-    }
-    else {
-      content.addTileSnapshotInExistingRow(newTile, options);
+    if (isOriginalAuthoredToolTileModel(newTile)) {
+      if (tileIndex === 0) {
+        const newRowInfo = addImportedTileInNewRow(content, newTile, options);
+        const newRowIndex = content.getRowIndex(newRowInfo.rowId);
+        (newRowIndex >= 0) && (insertRowIndex = newRowIndex);
+      }
+      else {
+        addImportedTileInExistingRow(content, newTile, options);
+      }
     }
   });
 }


### PR DESCRIPTION
[[#179680306]](https://www.pivotaltracker.com/story/show/179680306)

Assign predictable ids to tiles in imported curriculum content for use in tile commenting.

During import we keep track of the current section and the number of tiles of each type in the current section so that tiles can be given tile ids like `introduction_Text_1` and `what-if_Geometry_2`.

Along the way, also:
- improve the typing of the import code
- add a missing unit test for the `createDefaultSectionedContent()` function