### PR TITLE
Add `useTypeOfTileInDocumentOrCurriculum()` hook

### DIFF
--- a/src/hooks/use-stores.test.ts
+++ b/src/hooks/use-stores.test.ts
@@ -1,0 +1,115 @@
+import { ProblemModel } from "../models/curriculum/problem";
+import { AppConfigModel } from "../models/stores/app-config-model";
+import { ClassModel } from "../models/stores/class";
+import { DemoClassModel, DemoModel } from "../models/stores/demo";
+import { DocumentsModel } from "../models/stores/documents";
+import { GroupsModel } from "../models/stores/groups";
+import { SelectionStoreModel } from "../models/stores/selection";
+import { UIModel } from "../models/stores/ui";
+import { UserModel } from "../models/stores/user";
+import { LearningLogWorkspace, ProblemWorkspace, WorkspaceModel } from "../models/stores/workspace";
+import {
+  useAppConfigStore, useAppMode, useClassStore, useDemoStore, useGroupsStore, useNetworkDocumentKey, useProblemPath,
+  useProblemPathWithFacet, useProblemStore, useSharedSelectionStore, useTypeOfTileInDocumentOrCurriculum,
+  useUIStore, useUserStore
+} from "./use-stores";
+
+jest.mock("@concord-consortium/slate-editor", () => ({}));
+
+var mockUseContext = jest.fn();
+jest.mock("react", () => ({
+  ...jest.requireActual("react"),
+  useContext: () => mockUseContext()
+}));
+
+describe("useStores", () => {
+  function resetMocks() {
+    mockUseContext.mockReset();
+  }
+
+  describe("simple store hooks", () => {
+    beforeEach(() => resetMocks());
+    it("should return the requested store", () => {
+      const appConfig = AppConfigModel.create();
+      const _class = ClassModel.create({ name: "Class 1", classHash: "hash-1" });
+      const demo = DemoModel.create({ class : DemoClassModel.create({ id: "class-1", name: "Class 1" }) });
+      const groups = GroupsModel.create();
+      const problemPath = "sas/1/2";
+      const problemPathWithFacet = "sas:facet/1/2";
+      const problem = ProblemModel.create({ ordinal: 2, title: "1.2" });
+      const selection = SelectionStoreModel.create();
+      const ui = UIModel.create({
+        problemWorkspace: WorkspaceModel.create({ type: ProblemWorkspace, mode: "4-up" }),
+        learningLogWorkspace: WorkspaceModel.create({ type: LearningLogWorkspace, mode: "1-up" })
+      });
+      const user = UserModel.create({ id: "id-1", network: "network-1" });
+      mockUseContext.mockImplementation(() => ({
+        stores: {
+          appConfig,
+          appMode : "authed",
+          class: _class,
+          demo,
+          groups,
+          problemPath,
+          problem,
+          selection,
+          ui,
+          user
+        }
+      }));
+      expect(useAppConfigStore()).toBe(appConfig);
+      expect(useAppMode()).toBe("authed");
+      expect(useClassStore()).toBe(_class);
+      expect(useDemoStore()).toBe(demo);
+      expect(useGroupsStore()).toBe(groups);
+      expect(useNetworkDocumentKey("document-key")).toBe("network-1_document-key");
+      expect(useProblemPath()).toBe(problemPath);
+      expect(useProblemPathWithFacet("facet")).toBe(problemPathWithFacet);
+      expect(useProblemStore()).toBe(problem);
+      expect(useSharedSelectionStore()).toBe(selection);
+      expect(useUIStore()).toBe(ui);
+      expect(useUserStore()).toBe(user);
+    });
+  });
+
+  describe("useTypeOfTileInDocumentOrCurriculum", () => {
+    beforeEach(() => resetMocks());
+
+    it("should return undefined if specified document or tile doesn't exist", () => {
+      mockUseContext.mockImplementation(() => ({
+        stores: {
+          documents : DocumentsModel.create()
+        }
+      }));
+      expect(useTypeOfTileInDocumentOrCurriculum()).toBeUndefined();
+      expect(useTypeOfTileInDocumentOrCurriculum("key")).toBeUndefined();
+      expect(useTypeOfTileInDocumentOrCurriculum(undefined, "id")).toBeUndefined();
+      expect(useTypeOfTileInDocumentOrCurriculum("key", "id")).toBeUndefined();
+    });
+
+    it("should return type of tile from tile id for curriculum documents", () => {
+      mockUseContext.mockImplementation(() => ({
+        stores: {
+          documents : {
+            getTypeOfTileInDocument: () => "Text"
+          }
+        }
+      }));
+      expect(useTypeOfTileInDocumentOrCurriculum("sas/1/2/introduction", "foo")).toBeUndefined();
+      expect(useTypeOfTileInDocumentOrCurriculum("sas/1/2/introduction", "introduction_Text_1")).toBe("Text");
+      expect(useTypeOfTileInDocumentOrCurriculum("sas/1/2/introduction", "introduction_Geometry_1")).toBe("Geometry");
+    });
+
+    it("should return type of tile from content for user documents", () => {
+      mockUseContext.mockImplementation(() => ({
+        stores: {
+          documents : {
+            getTypeOfTileInDocument: () => "Text"
+          }
+        }
+      }));
+      expect(useTypeOfTileInDocumentOrCurriculum("document-key", "tile-id")).toBe("Text");
+    });
+  });
+
+});

--- a/src/hooks/use-stores.ts
+++ b/src/hooks/use-stores.ts
@@ -57,6 +57,19 @@ export function useDocumentOrCurriculumMetadata(key?: string): IDocumentMetadata
   }, [documentMetadata, key]);
 }
 
+export function useTypeOfTileInDocumentOrCurriculum(key?: string, tileId?: string) {
+  const { documents } = useStores();
+  if (!key || !tileId) return;
+  if (isSectionPath(key)) {
+    // for curriculum documents, tileId is `${section}_${tileType}_${index}`
+    const execResult = /.*_(.+)_\d+$/.exec(tileId);
+    return execResult?.[1];
+  }
+  else {
+    return documents.getTypeOfTileInDocument(key, tileId);
+  }
+}
+
 export function useFeatureFlag(feature: string) {
   return isFeatureSupported(useStores(), feature);
 }

--- a/src/models/stores/documents.ts
+++ b/src/models/stores/documents.ts
@@ -43,6 +43,9 @@ export const DocumentsModel = types
     }
   }))
   .views(self => ({
+    getTypeOfTileInDocument(documentKey: string, tileId: string) {
+      return self.getDocument(documentKey)?.content.getTileType(tileId);
+    },
     getNextPersonalDocumentTitle(user: UserModelType, base: string) {
       let maxUntitled = 0;
       self.byTypeForUser(PersonalDocument, user.id)


### PR DESCRIPTION
[[#179661807]](https://www.pivotaltracker.com/story/show/179661807)

For the comment card to show the correct icon, there must be a mechanism for getting from a document key/id and tile id to the type of the tile. This provides that mechanism.

Usage would look something like the following:
```typescript
interface IProps {
  documentKey?: string;
  tileId?: string;
}
export const ToolIconComponent: React.FC<IProps> = ({ documentKey, tileId }) => {
  const tileType = useTypeOfTileInDocumentOrCurriculum(documentKey, tileId);
  const { appIcons } = useContext(AppConfigContext);
  ...
};
```

Note: the coding of tile type into the tile id of curriculum documents is implemented in #1048, so this won't work _in situ_ until that PR is merged.