### PR TITLE
unselect tiles when document header is clicked

### DIFF
--- a/src/components/navigation/document-tab-content.tsx
+++ b/src/components/navigation/document-tab-content.tsx
@@ -64,7 +64,7 @@ export const DocumentTabContent: React.FC<IProps> = ({ tabSpec }) => {
   const selectedSection = tabSpec.tab === "supports" ? ENavTabSectionType.kTeacherSupports : undefined;
   const documentView = referenceDocument && !referenceDocument?.getProperty("isDeleted") &&
     <div>
-      <div className={`document-header ${tabSpec.tab} ${sectionClass}`}>
+      <div className={`document-header ${tabSpec.tab} ${sectionClass}`} onClick={() => ui.setSelectedTile()}>
         <div className={`document-title`}>
           {documentTitle(referenceDocument, appConfigStore, problemStore)}
         </div>


### PR DESCRIPTION
This PR unselects tiles when the document header is clicked.  If a teacher user is adding comments, this effectively selects the document for commenting.  This change applies to all document types (original request was for learning log).  Changes include:
- unselect tiles when document header is clicked

PT Story: 
https://www.pivotaltracker.com/story/show/179660736

Deployed branch for testing:
https://collaborative-learning.concord.org/branch/document-selection-via-header/?appMode=demo&demoName=CLUE&fakeClass=1&fakeUser=teacher:2&unit=sas&problem=0.1&chat

![header-selection](https://user-images.githubusercontent.com/5126913/135139319-b1831e07-ad59-49eb-8bc2-d53ef946690d.gif)

