### PR TITLE
179746600 left panel scrolling

### DIFF
--- a/src/components/navigation/document-tab-panel.sass
+++ b/src/components/navigation/document-tab-panel.sass
@@ -76,5 +76,6 @@
   .documents-panel
     height: calc(100vh - (#{$header-height} + #{$workspace-content-margin} * 2 + #{$nav-tab-height} * 2 + #{$tab-section-border-width} * 2))
     margin-top: $document-margin
+    overflow-y: auto
   &.chat-open
     border-right: 0

--- a/src/components/thumbnail/collapsible-document-section.tsx
+++ b/src/components/thumbnail/collapsible-document-section.tsx
@@ -25,7 +25,7 @@ interface IProps {
 
 export const CollapsibleDocumentsSection: React.FC<IProps> = observer(
   ({userName, classNameStr, sectionDocs, section, stores, tab, scale, selectedDocument, onSelectDocument}) => {
-  const [isOpen, setIsOpen] = useState(true);
+  const [isOpen, setIsOpen] = useState(false);
   const handleSectionToggle = () => {
     setIsOpen(!isOpen);
   };


### PR DESCRIPTION
This PR improves content visibility by adding scrolling to the left panel containing document thumbnails and by defaulting network collapsible content to closed.  In effect, this makes it so we can see all of the panel content as we add more and more content to the panel.  Changes include:
- add vertical scrolling to left panel containing document thumbnails
- default network collapsible content to closed

PT Story: 
https://www.pivotaltracker.com/story/show/179746600

Deployed branch for testing:
https://collaborative-learning.concord.org/branch/left-panel-scrolling/?demo

![scroll](https://user-images.githubusercontent.com/5126913/135386500-a61aed46-98be-4416-b580-9839e529a81a.gif)