### PR TITLE
Refactor left panel thumbs to change order and show all content

### DIFF
--- a/src/components/navigation/document-tab-panel.sass
+++ b/src/components/navigation/document-tab-panel.sass
@@ -78,3 +78,22 @@
     margin-top: $document-margin
   &.chat-open
     border-right: 0
+
+  .network-divider
+    width: 100%
+    border-top: solid 1px $charcoal-light-1
+    display: flex
+    justify-content: center
+    margin-top: 15px
+    background-color: rgba(250, 236, 141, 0.1)
+    .network-divider-label
+      display: flex
+      position: relative
+      top: -14px
+      justify-content: center
+      align-self: center
+      align-items: center
+      background-color: #faec8d
+      border: solid 1px $charcoal-light-1
+      width: 71px
+      height: 26px

--- a/src/components/navigation/document-tab-panel.tsx
+++ b/src/components/navigation/document-tab-panel.tsx
@@ -1,5 +1,6 @@
 import { inject, observer } from "mobx-react";
 import React from "react";
+import { uniq } from "lodash";
 import { BaseComponent, IBaseProps } from "../base";
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
 import { ENavTabSectionType, NavTabSectionSpec, NavTabSpec }
@@ -8,6 +9,7 @@ import { TabPanelDocumentsSection } from "../thumbnail/tab-panel-documents-secti
 import { DocumentModelType } from "../../models/document/document";
 import { DocumentDragKey, SupportPublication } from "../../models/document/document-types";
 import { LogEventName, Logger } from "../../lib/logger";
+import { CollapsibleDocumentsSection } from "../thumbnail/collapsible-document-section";
 
 import "./document-tab-panel.sass";
 
@@ -142,33 +144,56 @@ export class DocumentTabPanel extends BaseComponent<IProps, IState> {
   private renderSubSections(subTab: any) {
     const { selectedDocument, onSelectNewDocument, onSelectDocument } = this.props;
     const { user } = this.stores;
+    const isInNetwork = user.type === "teacher" && user.network;
+    const currentClass = this.stores.class.name;
+    const classNamesStrings = (uniq(user.portalClassOfferings.map(o => o.className))).filter(c => c !== currentClass);
     return (
       <div>
         { subTab.sections.map((section: any, index: any) => {
-          const _handleDocumentStarClick = section.showStarsForUser(user)
-            ? this.handleDocumentStarClick
-            : undefined;
-          const _handleDocumentDeleteClick = section.showDeleteForUser(user)
-            ? this.handleDocumentDeleteClick
-            : undefined;
-          return (
-            <TabPanelDocumentsSection
-              key={section.type}
-              tab={subTab.label}
-              section={section}
-              index={index}
-              numOfSections={subTab.sections.length}
-              stores={this.stores}
-              scale={kNavItemScale}
-              selectedDocument={selectedDocument}
-              onSelectNewDocument={onSelectNewDocument}
-              onSelectDocument={onSelectDocument}
-              onDocumentDragStart={this.handleDocumentDragStart}
-              onDocumentStarClick={_handleDocumentStarClick}
-              onDocumentDeleteClick={_handleDocumentDeleteClick}
-            />
-          );
-        })
+            const _handleDocumentStarClick = section.showStarsForUser(user)
+              ? this.handleDocumentStarClick
+              : undefined;
+            const _handleDocumentDeleteClick = section.showDeleteForUser(user)
+              ? this.handleDocumentDeleteClick
+              : undefined;
+            return (
+              <TabPanelDocumentsSection
+                key={section.type}
+                tab={subTab.label}
+                section={section}
+                index={index}
+                numOfSections={subTab.sections.length}
+                stores={this.stores}
+                scale={kNavItemScale}
+                selectedDocument={selectedDocument}
+                onSelectNewDocument={onSelectNewDocument}
+                onSelectDocument={onSelectDocument}
+                onDocumentDragStart={this.handleDocumentDragStart}
+                onDocumentStarClick={_handleDocumentStarClick}
+                onDocumentDeleteClick={_handleDocumentDeleteClick}
+              />
+            );
+          })
+        }
+        { isInNetwork &&
+          <>
+            <div className="network-divider">
+              <div className="network-divider-label">Network</div>
+            </div>
+            { classNamesStrings.map((classNameStr: string, idx: number) =>
+                <CollapsibleDocumentsSection
+                  key={idx}
+                  userName={user.name}
+                  stores={this.stores}
+                  tab={subTab.label}
+                  scale={kNavItemScale}
+                  classNameStr={classNameStr}
+                  selectedDocument={selectedDocument}
+                  onSelectDocument={onSelectDocument}
+                />
+              )
+            }
+          </>
         }
       </div>
     );

--- a/src/components/thumbnail/collapsible-document-section.scss
+++ b/src/components/thumbnail/collapsible-document-section.scss
@@ -48,11 +48,7 @@ $section-padding: 6px;
     flex-wrap: wrap;
     align-content: flex-start;
     overflow-y: auto;
-    &.top-panel {
-      height: $first-panel-height;
-      border-bottom: solid 1px $charcoal-light-1;
-      overflow-y: hidden;
-    }
+
     .list-item {
       position: relative;
       min-height: 120px;

--- a/src/components/thumbnail/collapsible-document-section.tsx
+++ b/src/components/thumbnail/collapsible-document-section.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { observer } from "mobx-react";
-import { NavTabSectionModelType } from "../../models/view/nav-tabs";
+// import { NavTabSectionModelType } from "../../models/view/nav-tabs";
 import { DocumentModelType } from "../../models/document/document";
 // import { DocumentCaption } from "./document-caption";
 import { IStores } from "../../models/stores/stores";
@@ -10,12 +10,9 @@ import ArrowIcon from "../../assets/icons/arrow/arrow.svg";
 import "./tab-panel-documents-section.sass";
 import "./collapsible-document-section.scss";
 
-
 interface IProps {
   userName: string;
   classNameStr: string;
-  sectionDocs: DocumentModelType[];
-  section: NavTabSectionModelType;
   stores: IStores;
   tab: string;
   scale: number;
@@ -24,7 +21,7 @@ interface IProps {
 }
 
 export const CollapsibleDocumentsSection: React.FC<IProps> = observer(
-  ({userName, classNameStr, sectionDocs, section, stores, tab, scale, selectedDocument, onSelectDocument}) => {
+  ({userName, classNameStr, stores, tab, scale, selectedDocument, onSelectDocument}) => {
   const [isOpen, setIsOpen] = useState(true);
   const handleSectionToggle = () => {
     setIsOpen(!isOpen);

--- a/src/components/thumbnail/tab-panel-documents-section.sass
+++ b/src/components/thumbnail/tab-panel-documents-section.sass
@@ -3,7 +3,6 @@
 $list-item-height: 660px
 $list-item-width: 880px
 $list-item-scale: 0.11
-$first-panel-height: 157px
 $section-padding: 6px
 
 .tab-panel-documents-section
@@ -19,7 +18,6 @@ $section-padding: 6px
     align-content: flex-start
     overflow-y: auto
     &.top-panel
-      height: $first-panel-height
       overflow-y: hidden
     &.bottom-panel
       border-top: solid 1px $charcoal-light-1
@@ -139,21 +137,3 @@ $section-padding: 6px
       background-color: $support-blue-light-8
     &:active, &.selected
       background-color: $support-blue-light-6
-
-  .network-divider
-    width: 100%
-    border-top: solid 1px $charcoal-light-1
-    display: flex
-    justify-content: center
-    background-color: rgba(250, 236, 141, 0.1)
-    .network-divider-label
-      display: flex
-      position: relative
-      top: -14px
-      justify-content: center
-      align-self: center
-      align-items: center
-      background-color: #faec8d
-      border: solid 1px $charcoal-light-1
-      width: 71px
-      height: 26px

--- a/src/components/thumbnail/tab-panel-documents-section.tsx
+++ b/src/components/thumbnail/tab-panel-documents-section.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { observer } from "mobx-react";
-import { uniq } from "lodash";
 import classNames from "classnames";
 import { DocumentModelType, getDocumentContext } from "../../models/document/document";
 import { isPublishedType, isUnpublishedType, PersonalDocument } from "../../models/document/document-types";
@@ -8,7 +7,6 @@ import { IStores } from "../../models/stores/stores";
 import { ENavTabOrder, NavTabSectionModelType  } from "../../models/view/nav-tabs";
 import { CanvasComponent } from "../document/canvas";
 import { DocumentContextReact } from "../document/document-context";
-import { CollapsibleDocumentsSection } from "./collapsible-document-section";
 import { TabPanelDocumentsSubSectionPanel } from "./tab-panel-documents-subsection-panel";
 import NewDocumentIcon from "../../assets/icons/new/add.svg";
 
@@ -93,7 +91,6 @@ export const TabPanelDocumentsSection = observer(({ tab, section, index, numOfSe
     const isBottomPanel = index === numOfSections - 1 && index > 0;
     const tabName = tab.toLowerCase().replace(' ', '-');
     const currentClass = stores.class.name;
-    const classNamesStrings = (uniq(user.portalClassOfferings.map(o => o.className))).filter(c => c !== currentClass);
     const sectionDocs: DocumentModelType[] = getSectionDocs(section, stores, currentClass);
 
     function handleNewDocumentClick() {
@@ -125,22 +122,6 @@ export const TabPanelDocumentsSection = observer(({ tab, section, index, numOfSe
             );
           })}
         </div>
-        { (isInNetwork && isTopPanel) &&
-          <>
-          <div className="network-divider">
-            <div className="network-divider-label">Network</div>
-          </div>
-          { classNamesStrings.map((classNameStr: string, idx: number) => {
-              return <CollapsibleDocumentsSection key={idx} userName={user.name} classNameStr={classNameStr}
-                                                  sectionDocs={sectionDocs}
-                                                  section={section} stores={stores} tab={tab} scale={scale}
-                                                  selectedDocument={selectedDocument}
-                                                  onSelectDocument={onSelectDocument}
-                     />;
-              })
-            }
-          </>
-        }
       </div>
     );
   });


### PR DESCRIPTION
This PR refactors the left panel thumb content to show all contents, show the proper content order, and better prepare the code for adding the network thumbs.  Changes include:
- remove explicit height of first `TabPanelDocumentsSection` so that content which requires more than one row of tiles can actually be seen (previously this content was being hidden due to the explicit height).
- change document order so network docs/sections always appear after non-network docs/sections. Under My Work, this moves the Personal docs up so they are next to the Problem/Planning docs.  In doing so we remove `CollapsibleDocumentsSection` from `TabPanelDocumentsSection` so we have more control over rendering order.  This will likely require more reworking as I move forward, but I wanted to clean some of this up before moving on.

PT Story: 
https://www.pivotaltracker.com/story/show/179185017

Deployed branch for testing:
https://collaborative-learning.concord.org/branch/improve-layout/?demo

![image](https://user-images.githubusercontent.com/5126913/135387139-d53c8cf5-ac71-47e1-a42a-05a17a2fc778.png)
