### PR TITLE
Fix `getFirestoreUser()` test so it doesn't throw an exception

### DIFF
--- a/src/lib/firestore.test.ts
+++ b/src/lib/firestore.test.ts
@@ -168,11 +168,14 @@ describe("Firestore class", () => {
 
   describe("getFirestoreUser", () => {
     beforeEach(() => resetMocks());
-    it("should call the `doc()` and `get()` methods with an appropriate path", () => {
+    it("should call the `doc()` and `get()` methods with an appropriate path", async () => {
+      const content = { uid: "user-1", name: "Jane Teacher", type: "teacher" };
+      mockDocGet.mockImplementation(() => ({ data: () => Promise.resolve(content) }));
       const firestore = new Firestore(mockDB);
-      firestore.getFirestoreUser("user-1");
+      const result = await firestore.getFirestoreUser("user-1");
       expect(mockDoc).toHaveBeenCalledWith(`/authed/test-portal/users/user-1`);
       expect(mockDocGet).toHaveBeenCalled();
+      expect(result).toEqual(content);
     });
   });
 


### PR DESCRIPTION
Mocking was incomplete for the `getFirestoreUser()` test, leading to an exception being thrown which was an ignorable warning in node 14 but @Concord-Jim noted that it causes the test to fail in node 16.