### PR TITLE
179661807 comment icon as with tile

### DIFF
--- a/cypress/integration/clue/branch/teacher_tests/teacher_workspace_spec.js
+++ b/cypress/integration/clue/branch/teacher_tests/teacher_workspace_spec.js
@@ -126,7 +126,6 @@ describe('Chat panel for networked teacher', () => {
     cy.get('[data-testid=comment-thread] [data-testid=comment]').should('contain', documentComment);
   });
   it('verify teacher name and initial appear on comment correctly', () => {
-    cy.get('[data-testid=teacher-initial]').should('contain', "T");
     cy.get('.comment-text-header .user-name').should('contain', "Teacher 7");
   });
   it("verify problem document is hightlighted", () => {

--- a/src/assets/icons/document-icon.svg
+++ b/src/assets/icons/document-icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="-4 -2 36 34">
+    <g fill="none" fill-rule="evenodd">
+        <path fill="#707070" d="M24.923 0c1.53 0 2.77 1.24 2.77 2.77v18.46c0 1.53-1.24 2.77-2.77 2.77H2.77C1.24 24 0 22.76 0 21.23V2.77C0 1.24 1.24 0 2.77 0zm.923 4.615h-24v16.616c0 .51.415.923.923.923h22.154c.51 0 .923-.414.923-.923V4.615z" transform="translate(2.153 4)"/>
+        <path fill="#707070" d="M24 6.462v13.846H3.692V6.462H24zm-.923.923H4.615v12h18.462v-12z" transform="translate(2.153 4)"/>
+    </g>
+</svg>

--- a/src/components/chat/chat-panel.test.tsx
+++ b/src/components/chat/chat-panel.test.tsx
@@ -49,6 +49,7 @@ jest.mock("react-query", () => ({
 }));
 
 jest.mock("../../hooks/use-stores", () => ({
+  useTypeOfTileInDocumentOrCurriculum: () => "Text",
   useDBStore: () => ({
     firestore: {
       getRootFolder: () => "firestore/root"

--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -7,9 +7,8 @@ import {
 } from "../../hooks/document-comment-hooks";
 import { useDeleteDocument } from "../../hooks/firestore-hooks";
 import { useDocumentOrCurriculumMetadata } from "../../hooks/use-stores";
-
-import "./chat-panel.scss";
 import { isDocumentMetadata } from "../../../functions/src/shared";
+import "./chat-panel.scss";
 
 interface IProps {
   user?: UserModelType;

--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -43,8 +43,6 @@ export const ChatPanel: React.FC<IProps> = ({ user, activeNavTab, focusDocument,
 
   const newCommentCount = unreadComments?.length || 0;
 
-// console.log('chat-panel:focusTileId', focusTileId);
-
   const documentKey = (document && isDocumentMetadata(document)) ? document.key : undefined;
 
   return (

--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -7,7 +7,9 @@ import {
 } from "../../hooks/document-comment-hooks";
 import { useDeleteDocument } from "../../hooks/firestore-hooks";
 import { useDocumentOrCurriculumMetadata } from "../../hooks/use-stores";
+
 import "./chat-panel.scss";
+import { isDocumentMetadata } from "../../../functions/src/shared";
 
 interface IProps {
   user?: UserModelType;
@@ -40,6 +42,11 @@ export const ChatPanel: React.FC<IProps> = ({ user, activeNavTab, focusDocument,
   }, [document, deleteCommentMutation, commentsPath]);
 
   const newCommentCount = unreadComments?.length || 0;
+
+// console.log('chat-panel:focusTileId', focusTileId);
+
+  const documentKey = (document && isDocumentMetadata(document)) ? document.key : undefined;
+
   return (
     <div className={`chat-panel ${activeNavTab}`} data-testid="chat-panel">
       <ChatPanelHeader activeNavTab={activeNavTab} newCommentCount={newCommentCount}
@@ -51,6 +58,8 @@ export const ChatPanel: React.FC<IProps> = ({ user, activeNavTab, focusDocument,
             onPostComment={postComment}
             onDeleteComment={deleteComment}
             postedComments={postedComments}
+            documentKey={documentKey}
+            focusTileId={focusTileId}
           />
         : <div className="select-doc-message" data-testid="select-doc-message">
             Open a document to begin or view comment threads

--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -7,7 +7,6 @@ import {
 } from "../../hooks/document-comment-hooks";
 import { useDeleteDocument } from "../../hooks/firestore-hooks";
 import { useDocumentOrCurriculumMetadata } from "../../hooks/use-stores";
-import { isDocumentMetadata } from "../../../functions/src/shared";
 import "./chat-panel.scss";
 
 interface IProps {
@@ -42,8 +41,6 @@ export const ChatPanel: React.FC<IProps> = ({ user, activeNavTab, focusDocument,
 
   const newCommentCount = unreadComments?.length || 0;
 
-  const documentKey = (document && isDocumentMetadata(document)) ? document.key : undefined;
-
   return (
     <div className={`chat-panel ${activeNavTab}`} data-testid="chat-panel">
       <ChatPanelHeader activeNavTab={activeNavTab} newCommentCount={newCommentCount}
@@ -55,7 +52,7 @@ export const ChatPanel: React.FC<IProps> = ({ user, activeNavTab, focusDocument,
             onPostComment={postComment}
             onDeleteComment={deleteComment}
             postedComments={postedComments}
-            documentKey={documentKey}
+            focusDocument={focusDocument}
             focusTileId={focusTileId}
           />
         : <div className="select-doc-message" data-testid="select-doc-message">

--- a/src/components/chat/comment-card.scss
+++ b/src/components/chat/comment-card.scss
@@ -15,8 +15,8 @@
     display: flex;
     align-items: center;
     width: 100%;
-    height: 25px;
-    padding: 4px;
+    height: fit-content;
+    padding: 0;
     background-color: $charcoal-light-8;
     color: $charcoal;
     &.comment-select {
@@ -37,19 +37,22 @@
     &.supports {
       background-color: $support-blue-light-7;
     }
-    .new-thread-header-icon {
-      fill: $charcoal;
-    }
-    .initial {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      border: 1px solid $charcoal;
-      border-radius: 3px;
-      width: 18px;
-      height: 18px;
-      padding: 1px 0 0;
-      margin-right: 5px;
+    // .new-thread-header-icon {
+    //   fill: $charcoal;
+    // }
+    // .initial {
+    //   display: flex;
+    //   align-items: center;
+    //   justify-content: center;
+    //   border: 1px solid $charcoal;
+    //   border-radius: 3px;
+    //   width: 18px;
+    //   height: 18px;
+    //   padding: 1px 0 0;
+    //   margin-right: 5px;
+    // }
+    .comment-card-header-icon {
+      height: 34px;
     }
   }
   .comment-thread {

--- a/src/components/chat/comment-card.scss
+++ b/src/components/chat/comment-card.scss
@@ -37,20 +37,6 @@
     &.supports {
       background-color: $support-blue-light-7;
     }
-    // .new-thread-header-icon {
-    //   fill: $charcoal;
-    // }
-    // .initial {
-    //   display: flex;
-    //   align-items: center;
-    //   justify-content: center;
-    //   border: 1px solid $charcoal;
-    //   border-radius: 3px;
-    //   width: 18px;
-    //   height: 18px;
-    //   padding: 1px 0 0;
-    //   margin-right: 5px;
-    // }
     .comment-card-header-icon {
       height: 34px;
     }

--- a/src/components/chat/comment-card.test.tsx
+++ b/src/components/chat/comment-card.test.tsx
@@ -35,7 +35,6 @@ describe("CommentCard", () => {
         <CommentCard user={testUser} postedComments={postedComments}/>
       </ModalProvider>
     ));
-    // expect(screen.getByTestId("document-comment-icon")).toBeInTheDocument();
     expect(commentThread).toBeNull();
   });
   it("should show the correct header icon when there are comments and comment appears in card", () => {
@@ -48,7 +47,6 @@ describe("CommentCard", () => {
         <CommentCard user={testUser} postedComments={postedComments}/>
       </ModalProvider>
     ));
-    // expect(screen.getByTestId("teacher-initial")).toHaveTextContent("T");
     expect(screen.getByTestId("comment-thread")).toBeInTheDocument();
     expect(screen.getByTestId("comment")).toHaveTextContent(testComment);
   });

--- a/src/components/chat/comment-card.test.tsx
+++ b/src/components/chat/comment-card.test.tsx
@@ -35,7 +35,7 @@ describe("CommentCard", () => {
         <CommentCard user={testUser} postedComments={postedComments}/>
       </ModalProvider>
     ));
-    expect(screen.getByTestId("document-comment-icon")).toBeInTheDocument();
+    // expect(screen.getByTestId("document-comment-icon")).toBeInTheDocument();
     expect(commentThread).toBeNull();
   });
   it("should show the correct header icon when there are comments and comment appears in card", () => {
@@ -48,7 +48,7 @@ describe("CommentCard", () => {
         <CommentCard user={testUser} postedComments={postedComments}/>
       </ModalProvider>
     ));
-    expect(screen.getByTestId("teacher-initial")).toHaveTextContent("T");
+    // expect(screen.getByTestId("teacher-initial")).toHaveTextContent("T");
     expect(screen.getByTestId("comment-thread")).toBeInTheDocument();
     expect(screen.getByTestId("comment")).toHaveTextContent(testComment);
   });

--- a/src/components/chat/comment-card.test.tsx
+++ b/src/components/chat/comment-card.test.tsx
@@ -7,6 +7,7 @@ import { UserModelType } from "../../models/stores/user";
 import { CommentCard } from "./comment-card";
 
 jest.mock("../../hooks/use-stores", () => ({
+  useTypeOfTileInDocumentOrCurriculum: () => "Text",
   useUIStore: () => ({
     showChatPanel: true,
     selectedTileIds: []

--- a/src/components/chat/comment-card.tsx
+++ b/src/components/chat/comment-card.tsx
@@ -17,13 +17,13 @@ interface IProps {
   postedComments?: WithId<CommentDocument>[];
   onPostComment?: (comment: string) => void;
   onDeleteComment?: (commentId: string) => void;
-  documentKey?: string;
+  focusDocument?: string;
   focusTileId?: string;
 }
 
 export const CommentCard: React.FC<IProps> = ({ activeNavTab, user, postedComments,
                                                 onPostComment, onDeleteComment,
-                                                documentKey, focusTileId }) => {
+                                                focusDocument, focusTileId }) => {
   const commentIdRef = useRef<string>();
   const alertContent = () => {
     return (
@@ -52,7 +52,7 @@ export const CommentCard: React.FC<IProps> = ({ activeNavTab, user, postedCommen
     return (
       <div className="comment-card-header comment-select" data-testid="comment-card-header">
         <div className="comment-card-header-icon" data-testid="comment-card-header-icon">
-          <ToolIconComponent documentKey={documentKey} tileId={focusTileId}/>
+          <ToolIconComponent documentKey={focusDocument} tileId={focusTileId}/>
         </div>
       </div>
     );

--- a/src/components/chat/comment-card.tsx
+++ b/src/components/chat/comment-card.tsx
@@ -8,7 +8,6 @@ import { useCautionAlert } from "../utilities/use-caution-alert";
 import UserIcon from "../../assets/icons/clue-dashboard/teacher-student.svg";
 import DeleteMessageIcon from "../../assets/delete-message-icon.svg";
 import { ToolIconComponent } from "./tool-icon-component";
-// import DocumentIcon from "../../assets/icons/document-icon.svg";
 import "./comment-card.scss";
 import "../themes.scss";
 
@@ -54,10 +53,6 @@ export const CommentCard: React.FC<IProps> = ({ activeNavTab, user, postedCommen
       <div className="comment-card-header comment-select" data-testid="comment-card-header">
         <div className="comment-card-header-icon" data-testid="comment-card-header-icon">
           <ToolIconComponent documentKey={documentKey} tileId={focusTileId}/>
-          {/* { (!documentKey || !focusTileId) && <DocumentIcon/>}
-          { documentKey && focusTileId
-             && <ToolIconComponent documentKey={documentKey} tileId={focusTileId}/>
-          } */}
         </div>
       </div>
     );

--- a/src/components/chat/comment-card.tsx
+++ b/src/components/chat/comment-card.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { useRef, useContext } from "react";
 import { UserModelType } from "../../models/stores/user";
 import { CommentTextBox } from "./comment-textbox";
 import { WithId } from "../../hooks/firestore-hooks";
@@ -6,10 +6,12 @@ import { CommentDocument } from "../../lib/firestore-schema";
 import { getDisplayTimeDate } from "../../utilities/time";
 import { useCautionAlert } from "../utilities/use-caution-alert";
 import UserIcon from "../../assets/icons/clue-dashboard/teacher-student.svg";
-import DocumentCommentIcon from "../../assets/document-id.svg";
 import DeleteMessageIcon from "../../assets/delete-message-icon.svg";
 import "./comment-card.scss";
 import "../themes.scss";
+import { ToolIconComponent } from "./tool-icon-component";
+import { AppConfigContext } from "../../app-config-context";
+import OpenWorkspaceIcon from "../../assets/icons/1-4-up/1-up-icon-default.svg";
 
 interface IProps {
   user?: UserModelType;
@@ -17,10 +19,13 @@ interface IProps {
   postedComments?: WithId<CommentDocument>[];
   onPostComment?: (comment: string) => void;
   onDeleteComment?: (commentId: string) => void;
+  documentKey?: string;
+  focusTileId?: string;
 }
 
 export const CommentCard: React.FC<IProps> = ({ activeNavTab, user, postedComments,
-                                                onPostComment, onDeleteComment }) => {
+                                                onPostComment, onDeleteComment,
+                                                documentKey, focusTileId }) => {
   const commentIdRef = useRef<string>();
   const alertContent = () => {
     return (
@@ -45,21 +50,27 @@ export const CommentCard: React.FC<IProps> = ({ activeNavTab, user, postedCommen
     }
   };
 
-  const renderThreadHeader = () => {
-    const teacherInitial = user?.name.charAt(0);
+  const renderThreadHeader = (documentKey: string | undefined, focusTileId: string | undefined) => {
+    const { appIcons } = useContext(AppConfigContext);
+    // console.log('coment-card:appIcons', appIcons);
+    // console.log('coment-card:documentKey', documentKey);
+    // console.log('coment-card:focusTileId', focusTileId);
+
     return (
       <div className="comment-card-header comment-select" data-testid="comment-card-header">
-        {postedComments && postedComments.length < 1
-          ? <DocumentCommentIcon className="new-thread-header-icon" data-testid="document-comment-icon"/>
-          : <div className="initial" data-testid="teacher-initial">{teacherInitial}</div>
-        }
+        <div className="comment-card-header-icon" data-testid="comment-card-header-icon">
+          { (!documentKey || !focusTileId) && <OpenWorkspaceIcon/>}
+          { documentKey && focusTileId
+             &&  <ToolIconComponent documentKey={documentKey} tileId={focusTileId}/>
+          }
+        </div>
       </div>
     );
   };
 
   return (
     <div className={`comment-card selected`} data-testid="comment-card">
-      {renderThreadHeader()}
+      {renderThreadHeader(documentKey, focusTileId)}
       {postedComments?.map((comment, idx) => {
           const userInitialBackgroundColor = ["#f79999", "#ffc18a", "#99d099", "#ff9", "#b2b2ff", "#efa6ef"];
           const commenterInitial = comment.name.charAt(0);

--- a/src/components/chat/comment-card.tsx
+++ b/src/components/chat/comment-card.tsx
@@ -10,7 +10,6 @@ import DeleteMessageIcon from "../../assets/delete-message-icon.svg";
 import "./comment-card.scss";
 import "../themes.scss";
 import { ToolIconComponent } from "./tool-icon-component";
-import { AppConfigContext } from "../../app-config-context";
 import OpenWorkspaceIcon from "../../assets/icons/1-4-up/1-up-icon-default.svg";
 
 interface IProps {
@@ -51,11 +50,6 @@ export const CommentCard: React.FC<IProps> = ({ activeNavTab, user, postedCommen
   };
 
   const renderThreadHeader = (documentKey: string | undefined, focusTileId: string | undefined) => {
-    const { appIcons } = useContext(AppConfigContext);
-    // console.log('coment-card:appIcons', appIcons);
-    // console.log('coment-card:documentKey', documentKey);
-    // console.log('coment-card:focusTileId', focusTileId);
-
     return (
       <div className="comment-card-header comment-select" data-testid="comment-card-header">
         <div className="comment-card-header-icon" data-testid="comment-card-header-icon">

--- a/src/components/chat/comment-card.tsx
+++ b/src/components/chat/comment-card.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useContext } from "react";
+import React, { useRef } from "react";
 import { UserModelType } from "../../models/stores/user";
 import { CommentTextBox } from "./comment-textbox";
 import { WithId } from "../../hooks/firestore-hooks";
@@ -49,7 +49,7 @@ export const CommentCard: React.FC<IProps> = ({ activeNavTab, user, postedCommen
     }
   };
 
-  const renderThreadHeader = (documentKey: string | undefined, focusTileId: string | undefined) => {
+  const renderThreadHeader = () => {
     return (
       <div className="comment-card-header comment-select" data-testid="comment-card-header">
         <div className="comment-card-header-icon" data-testid="comment-card-header-icon">
@@ -64,7 +64,7 @@ export const CommentCard: React.FC<IProps> = ({ activeNavTab, user, postedCommen
 
   return (
     <div className={`comment-card selected`} data-testid="comment-card">
-      {renderThreadHeader(documentKey, focusTileId)}
+      {renderThreadHeader()}
       {postedComments?.map((comment, idx) => {
           const userInitialBackgroundColor = ["#f79999", "#ffc18a", "#99d099", "#ff9", "#b2b2ff", "#efa6ef"];
           const commenterInitial = comment.name.charAt(0);

--- a/src/components/chat/comment-card.tsx
+++ b/src/components/chat/comment-card.tsx
@@ -7,10 +7,10 @@ import { getDisplayTimeDate } from "../../utilities/time";
 import { useCautionAlert } from "../utilities/use-caution-alert";
 import UserIcon from "../../assets/icons/clue-dashboard/teacher-student.svg";
 import DeleteMessageIcon from "../../assets/delete-message-icon.svg";
-import "./comment-card.scss";
-import "../themes.scss";
 import { ToolIconComponent } from "./tool-icon-component";
 import OpenWorkspaceIcon from "../../assets/icons/1-4-up/1-up-icon-default.svg";
+import "./comment-card.scss";
+import "../themes.scss";
 
 interface IProps {
   user?: UserModelType;
@@ -55,7 +55,7 @@ export const CommentCard: React.FC<IProps> = ({ activeNavTab, user, postedCommen
         <div className="comment-card-header-icon" data-testid="comment-card-header-icon">
           { (!documentKey || !focusTileId) && <OpenWorkspaceIcon/>}
           { documentKey && focusTileId
-             &&  <ToolIconComponent documentKey={documentKey} tileId={focusTileId}/>
+             && <ToolIconComponent documentKey={documentKey} tileId={focusTileId}/>
           }
         </div>
       </div>

--- a/src/components/chat/comment-card.tsx
+++ b/src/components/chat/comment-card.tsx
@@ -8,7 +8,7 @@ import { useCautionAlert } from "../utilities/use-caution-alert";
 import UserIcon from "../../assets/icons/clue-dashboard/teacher-student.svg";
 import DeleteMessageIcon from "../../assets/delete-message-icon.svg";
 import { ToolIconComponent } from "./tool-icon-component";
-import OpenWorkspaceIcon from "../../assets/icons/1-4-up/1-up-icon-default.svg";
+// import DocumentIcon from "../../assets/icons/document-icon.svg";
 import "./comment-card.scss";
 import "../themes.scss";
 
@@ -53,10 +53,11 @@ export const CommentCard: React.FC<IProps> = ({ activeNavTab, user, postedCommen
     return (
       <div className="comment-card-header comment-select" data-testid="comment-card-header">
         <div className="comment-card-header-icon" data-testid="comment-card-header-icon">
-          { (!documentKey || !focusTileId) && <OpenWorkspaceIcon/>}
+          <ToolIconComponent documentKey={documentKey} tileId={focusTileId}/>
+          {/* { (!documentKey || !focusTileId) && <DocumentIcon/>}
           { documentKey && focusTileId
              && <ToolIconComponent documentKey={documentKey} tileId={focusTileId}/>
-          }
+          } */}
         </div>
       </div>
     );

--- a/src/components/chat/tool-icon-component.tsx
+++ b/src/components/chat/tool-icon-component.tsx
@@ -12,18 +12,6 @@ export const ToolIconComponent: React.FC<IProps> = ({documentKey, tileId}) => {
 
   const tileType = useTypeOfTileInDocumentOrCurriculum(documentKey, tileId);
   const { appIcons } = useContext(AppConfigContext);
-
-  // if (!documentKey || !tileId || !appIcons) {
-  //   return null;
-  // }
-
-  // if (!tileType) {
-  //   return <div>{appIcons?.["icon-open-workspace"]}</div>;
-  // }
-
-  // const iconName = `icon-${tileType.toLowerCase()}-tool`;
-  // const TheIcon = appIcons?.[iconName];
-  // return <div><TheIcon/></div>;
   const iconName = tileType ? `icon-${tileType.toLowerCase()}-tool` : undefined;
   const Icon = iconName ? appIcons?.[iconName] : undefined;
   return Icon ? <Icon/> : <DocumentIcon/>;

--- a/src/components/chat/tool-icon-component.tsx
+++ b/src/components/chat/tool-icon-component.tsx
@@ -11,8 +11,6 @@ export const ToolIconComponent: React.FC<IProps> = ({documentKey, tileId}) => {
 
   const tileType = useTypeOfTileInDocumentOrCurriculum(documentKey, tileId);
   const { appIcons } = useContext(AppConfigContext);
-console.log('tool-icon-component:tileType', tileType);
-console.log('tool-icon-component:appIcons', appIcons);
   
   if (!documentKey || !tileId || !appIcons ) {
     return null;
@@ -23,7 +21,6 @@ console.log('tool-icon-component:appIcons', appIcons);
   }
 
   const iconName = `icon-${tileType.toLowerCase()}-tool`;
-console.log('tool-icon-component:iconName', iconName);
   const TheIcon = appIcons?.[iconName];
   return <div><TheIcon/></div>;
 };

--- a/src/components/chat/tool-icon-component.tsx
+++ b/src/components/chat/tool-icon-component.tsx
@@ -11,8 +11,8 @@ export const ToolIconComponent: React.FC<IProps> = ({documentKey, tileId}) => {
 
   const tileType = useTypeOfTileInDocumentOrCurriculum(documentKey, tileId);
   const { appIcons } = useContext(AppConfigContext);
-  
-  if (!documentKey || !tileId || !appIcons ) {
+
+  if (!documentKey || !tileId || !appIcons) {
     return null;
   }
 

--- a/src/components/chat/tool-icon-component.tsx
+++ b/src/components/chat/tool-icon-component.tsx
@@ -1,0 +1,29 @@
+import React, { useContext } from "react";
+import { useTypeOfTileInDocumentOrCurriculum } from "../../hooks/use-stores";
+import { AppConfigContext } from "../../app-config-context";
+
+interface IProps {
+  documentKey?: string;
+  tileId?: string;
+}
+
+export const ToolIconComponent: React.FC<IProps> = ({documentKey, tileId}) => {
+
+  const tileType = useTypeOfTileInDocumentOrCurriculum(documentKey, tileId);
+  const { appIcons } = useContext(AppConfigContext);
+console.log('tool-icon-component:tileType', tileType);
+console.log('tool-icon-component:appIcons', appIcons);
+  
+  if (!documentKey || !tileId || !appIcons ) {
+    return null;
+  }
+
+  if (!tileType) {
+    return <div>{appIcons?.["icon-open-workspace"]}</div>;
+  }
+
+  const iconName = `icon-${tileType.toLowerCase()}-tool`;
+console.log('tool-icon-component:iconName', iconName);
+  const TheIcon = appIcons?.[iconName];
+  return <div><TheIcon/></div>;
+};

--- a/src/components/chat/tool-icon-component.tsx
+++ b/src/components/chat/tool-icon-component.tsx
@@ -1,6 +1,7 @@
 import React, { useContext } from "react";
 import { useTypeOfTileInDocumentOrCurriculum } from "../../hooks/use-stores";
 import { AppConfigContext } from "../../app-config-context";
+import DocumentIcon from "../../assets/icons/document-icon.svg";
 
 interface IProps {
   documentKey?: string;
@@ -12,15 +13,18 @@ export const ToolIconComponent: React.FC<IProps> = ({documentKey, tileId}) => {
   const tileType = useTypeOfTileInDocumentOrCurriculum(documentKey, tileId);
   const { appIcons } = useContext(AppConfigContext);
 
-  if (!documentKey || !tileId || !appIcons) {
-    return null;
-  }
+  // if (!documentKey || !tileId || !appIcons) {
+  //   return null;
+  // }
 
-  if (!tileType) {
-    return <div>{appIcons?.["icon-open-workspace"]}</div>;
-  }
+  // if (!tileType) {
+  //   return <div>{appIcons?.["icon-open-workspace"]}</div>;
+  // }
 
-  const iconName = `icon-${tileType.toLowerCase()}-tool`;
-  const TheIcon = appIcons?.[iconName];
-  return <div><TheIcon/></div>;
+  // const iconName = `icon-${tileType.toLowerCase()}-tool`;
+  // const TheIcon = appIcons?.[iconName];
+  // return <div><TheIcon/></div>;
+  const iconName = tileType ? `icon-${tileType.toLowerCase()}-tool` : undefined;
+  const Icon = iconName ? appIcons?.[iconName] : undefined;
+  return Icon ? <Icon/> : <DocumentIcon/>;
 };

--- a/src/components/document/document-file-menu.scss
+++ b/src/components/document/document-file-menu.scss
@@ -29,6 +29,7 @@
           color: white;
         }
       }
+
       .arrow {
         fill: $workspace-teal-dark-1;
       }


### PR DESCRIPTION
In the chat panel, when a particular type of tile is selected, the icon corresponding to that type of tile is shown in the chat header area.

With a table tile selected:
<img width="1171" alt="179661807_with_table_tile_selected" src="https://user-images.githubusercontent.com/91078832/135911569-dd1794df-272e-4778-b538-5385be097560.png">

With a text tile selected:
<img width="1359" alt="179661807_with_text_tile_selected" src="https://user-images.githubusercontent.com/91078832/135911588-caeb4ee9-dd42-4661-81a2-7f86e46765c5.png">


