### PR TITLE
Set isPreviewing in store

### DIFF
--- a/src/models/stores/stores.ts
+++ b/src/models/stores/stores.ts
@@ -52,6 +52,7 @@ export function createStores(params?: ICreateStores): IStores {
   const demoName = params?.demoName || appConfig.appName;
   const stores: IBaseStores = {
     appMode: params?.appMode || "dev",
+    isPreviewing: params?.isPreviewing || false,
     appVersion: params?.appVersion || "unknown",
     appConfig,
     // for testing, we create a null problem or investigation if none is provided


### PR DESCRIPTION
Set the value of isPreviewing in our base store so that we can properly decide if we are in preview mode and need to show the group chooser dialog.