### PR TITLE
Add placeholder thumbnail image

### DIFF
--- a/src/assets/document-placeholder-icon.svg
+++ b/src/assets/document-placeholder-icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
+    <g fill="none" fill-rule="evenodd">
+        <path d="M0 0h40v40H0z"/>
+        <path d="M11.5 21.5h17V24h-17v-2.5zm0 6h17V30h-17v-2.5zM24 3H9.5C7.575 3 6 4.53 6 6.4v27.2C6 35.47 7.558 37 9.482 37H30.5c1.925 0 3.5-1.53 3.5-3.4V13L24 3zm6.5 32h-21A1.5 1.5 0 0 1 8 33.5v-27A1.5 1.5 0 0 1 9.5 5H23v6a3 3 0 0 0 3 3h6v19.5a1.5 1.5 0 0 1-1.5 1.5z" fill="#0481A0"/>
+    </g>
+</svg>

--- a/src/components/chat/chat-panel-header.tsx
+++ b/src/components/chat/chat-panel-header.tsx
@@ -1,7 +1,7 @@
 import { observer } from "mobx-react";
 import React from "react";
-import  ChatIcon from "../../assets/chat-icon.svg";
-import  NotificationIcon from "../../assets/notifications-icon.svg";
+import ChatIcon from "../../assets/chat-icon.svg";
+import NotificationIcon from "../../assets/notifications-icon.svg";
 
 import "./chat-panel-header.scss";
 import "../themes.scss";

--- a/src/components/navigation/nav-tab-panel.sass
+++ b/src/components/navigation/nav-tab-panel.sass
@@ -105,8 +105,6 @@
         display: flex
         justify-content: center
 
-      .chat-button
-
     .top-tab-list
       display: flex
       align-items: center

--- a/src/components/thumbnail/thumbnail-document-item.tsx
+++ b/src/components/thumbnail/thumbnail-document-item.tsx
@@ -3,6 +3,7 @@ import { observer } from "mobx-react";
 import { CanvasComponent } from "../document/canvas";
 import { DocumentModelType } from "../../models/document/document";
 import { DocumentCaption } from "./document-caption";
+import { ThumbnailPlaceHolderIcon } from "./thumbnail-placeholder-icon";
 
 interface IProps {
   dataTestName: string;
@@ -41,23 +42,21 @@ export const ThumbnailDocumentItem = observer((props: IProps) => {
   };
 
   return (
-    <div
-      className={`list-item ${selectedClass}`}
-      data-test={dataTestName}
-      key={document.key}
-      onClick={handleDocumentClick} >
-      <div
-        className="scaled-list-item-container"
-        onDragStart={handleDocumentDragStart}
-        draggable={!!onDocumentDragStart} >
-        <div className="scaled-list-item">
-          <CanvasComponent
-            context={canvasContext}
-            document={document}
-            readOnly={true}
-            scale={scale}
-          />
-        </div>
+    <div className={`list-item ${selectedClass}`} data-test={dataTestName} key={document.key}
+      onClick={handleDocumentClick}>
+      <div className="scaled-list-item-container" onDragStart={handleDocumentDragStart}
+        draggable={!!onDocumentDragStart}>
+        { document.content
+          ? <div className="scaled-list-item">
+              <CanvasComponent
+                context={canvasContext}
+                document={document}
+                readOnly={true}
+                scale={scale}
+              />
+            </div>
+          : <ThumbnailPlaceHolderIcon />
+        }
       </div>
       { onDocumentStarClick &&
           <DocumentStar isStarred={onIsStarred()} onStarClick={handleDocumentStarClick} />

--- a/src/components/thumbnail/thumbnail-placeholder-icon.scss
+++ b/src/components/thumbnail/thumbnail-placeholder-icon.scss
@@ -1,0 +1,12 @@
+.thumbnail-placeholder {
+  display: flex;
+  height: 100%;
+  width: 100%;
+  justify-content: center;
+  align-items: center;
+
+  .placeholder-icon {
+    height: 40px;
+    width: 40px;
+  }
+}

--- a/src/components/thumbnail/thumbnail-placeholder-icon.tsx
+++ b/src/components/thumbnail/thumbnail-placeholder-icon.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import DocumentPlaceholderIcon from "../../assets/document-placeholder-icon.svg";
+
+import "./thumbnail-placeholder-icon.scss";
+
+export const ThumbnailPlaceHolderIcon: React.FC = () => {
+  return (
+    <div className="thumbnail-placeholder">
+      <DocumentPlaceholderIcon className="placeholder-icon" />
+    </div>
+  );
+};


### PR DESCRIPTION
This PR adds a placeholder thumbnail image that is shown when we do not have document content.  Changes include:
- add `ThumbnailPlaceHolderIcon` component
- display `ThumbnailPlaceHolderIcon` in left panel when we do not have document content

PT Stories: 
https://www.pivotaltracker.com/story/show/179346951

Deployed branch for testing:
https://collaborative-learning.concord.org/branch/canned-thumbnails/?demo

![image](https://user-images.githubusercontent.com/5126913/136311931-e74a4ae2-cbc3-4a0b-a5d8-b4fb7c7484c0.png)