### PR TITLE
Display network doc thumbs and load content when clicked

### DIFF
--- a/src/components/navigation/document-tab-content.tsx
+++ b/src/components/navigation/document-tab-content.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useQueryClient } from 'react-query';
 import { DocumentModelType } from "../../models/document/document";
 import { isProblemType } from "../../models/document/document-types";
 import { AppConfigModelType } from "../../models/stores/app-config-model";
@@ -9,6 +10,7 @@ import { EditableDocumentContent } from "../document/editable-document-content";
 import { useAppConfigStore, useProblemStore, useUIStore } from "../../hooks/use-stores";
 import { Logger, LogEventName } from "../../lib/logger";
 import EditIcon from "../../clue/assets/icons/edit-right-icon.svg";
+import { useUserContext } from "../../hooks/use-user-context";
 
 import "./document-tab-content.sass";
 
@@ -20,6 +22,8 @@ export const DocumentTabContent: React.FC<IProps> = ({ tabSpec }) => {
   const [referenceDocument, setReferenceDocument] = useState<DocumentModelType>();
   const appConfigStore = useAppConfigStore();
   const problemStore = useProblemStore();
+  const context = useUserContext();
+  const queryClient = useQueryClient();
   const ui = useUIStore();
 
   const handleTabClick = (title: string, type: string) => {
@@ -33,8 +37,15 @@ export const DocumentTabContent: React.FC<IProps> = ({ tabSpec }) => {
   };
 
   const handleSelectDocument = (document: DocumentModelType) => {
+    if (!document.hasContent && document.isRemote) {
+      loadDocumentContent(document);
+    }
     setReferenceDocument(document);
     ui.updateFocusDocument();
+  };
+
+  const loadDocumentContent = async (document: DocumentModelType) => {
+    await document.fetchRemoteContent(queryClient, context);
   };
 
   const documentTitle = (document: DocumentModelType, appConfig: AppConfigModelType, problem: ProblemModelType) => {

--- a/src/components/navigation/document-tab-panel.tsx
+++ b/src/components/navigation/document-tab-panel.tsx
@@ -178,6 +178,9 @@ export class DocumentTabPanel extends BaseComponent<IProps, IState> {
           currentTeacherId={user.id}
           subTab={subTab}
           problemTitle={this.stores.problem.title}
+          stores={this.stores}
+          scale={kNavItemScale}
+          onSelectDocument={onSelectDocument}
         />
       </div>
     );

--- a/src/components/navigation/network-documents-section.tsx
+++ b/src/components/navigation/network-documents-section.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { INetworkResourceClassResponse } from "../../../functions/src/shared";
 import { useNetworkResources } from "../../hooks/network-resources";
+import { DocumentModelType } from "../../models/document/document";
+import { IStores } from "../../models/stores/stores";
 import { CollapsibleDocumentsSection } from "../thumbnail/collapsible-document-section";
 import { ISubTabSpec } from "./document-tab-panel";
 
@@ -12,6 +14,9 @@ interface IProps {
   currentTeacherName: string;
   subTab: ISubTabSpec;
   problemTitle: string;
+  stores: IStores;
+  scale: number;
+  onSelectDocument?: (document: DocumentModelType) => void;
 }
 
 export enum NetworkSectionType {
@@ -20,7 +25,7 @@ export enum NetworkSectionType {
 }
 
 export const NetworkDocumentsSection: React.FC<IProps> = ({ currentClassHash, currentTeacherName,
-  currentTeacherId, subTab, problemTitle }) => {
+  currentTeacherId, subTab, problemTitle, stores, scale, onSelectDocument }) => {
   const { data, status } = useNetworkResources();
   const statusMessage = `${status} network data`;
 
@@ -65,6 +70,9 @@ export const NetworkDocumentsSection: React.FC<IProps> = ({ currentClassHash, cu
                 subTab={subTab}
                 networkResource={c}
                 problemTitle={problemTitle}
+                stores={stores}
+                scale={scale}
+                onSelectDocument={onSelectDocument}
               />;
             })
         }

--- a/src/components/thumbnail/collapsible-document-section.scss
+++ b/src/components/thumbnail/collapsible-document-section.scss
@@ -46,7 +46,7 @@ $section-padding: 6px;
 
   .list {
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
     flex-wrap: wrap;
     align-content: flex-start;
     overflow-y: auto;

--- a/src/components/thumbnail/collapsible-document-section.tsx
+++ b/src/components/thumbnail/collapsible-document-section.tsx
@@ -92,7 +92,7 @@ export const CollapsibleDocumentsSection: React.FC<IProps> = observer(
           { documentKeys.length > 0
             ? documentKeys.map((key, i) => {
               const document = networkDocuments.getDocument(key);
-              if (!document) return <div>Documen Missing</div>;
+              if (!document) return <div>Document Missing</div>;
               const documentContext = getDocumentContext(document);
               return (
                 <DocumentContextReact.Provider key={document.key} value={documentContext}>

--- a/src/components/thumbnail/collapsible-document-section.tsx
+++ b/src/components/thumbnail/collapsible-document-section.tsx
@@ -1,12 +1,16 @@
 import React, { useState } from "react";
 import { observer } from "mobx-react";
+import { DocumentContextReact } from "../document/document-context";
 import { INetworkResourceClassResponse } from "../../../functions/src/shared";
-import { DocumentModelType } from "../../models/document/document";
-// import { DocumentCaption } from "./document-caption";
+import { DocumentModelType, getDocumentContext } from "../../models/document/document";
 import { IStores } from "../../models/stores/stores";
 import ArrowIcon from "../../assets/icons/arrow/arrow.svg";
-// import NotSharedIcon from "../../assets/icons/share/not-share.svg";
 import { ISubTabSpec } from "../navigation/document-tab-panel";
+import { useNetworkDocuments } from "../../hooks/use-stores";
+import { TabPanelDocumentsSubSectionPanel } from "./tab-panel-documents-subsection-panel";
+import { NavTabSectionModelType } from "../../models/view/nav-tabs";
+// import NotSharedIcon from "../../assets/icons/share/not-share.svg";
+// import { DocumentCaption } from "./document-caption";
 
 import "./tab-panel-documents-section.sass";
 import "./collapsible-document-section.scss";
@@ -14,9 +18,8 @@ import "./collapsible-document-section.scss";
 interface IProps {
   userName: string;
   classNameStr: string;
-  stores?: IStores;
-  tab?: string;
-  scale?: number;
+  stores: IStores;
+  scale: number;
   selectedDocument?: string;
   onSelectDocument?: (document: DocumentModelType) => void;
   subTab: ISubTabSpec;
@@ -25,21 +28,21 @@ interface IProps {
 }
 
 export const CollapsibleDocumentsSection: React.FC<IProps> = observer(
-  ({userName, classNameStr, stores, tab, scale, selectedDocument, onSelectDocument, subTab,
+  ({userName, classNameStr, stores, scale, selectedDocument, onSelectDocument, subTab,
     networkResource, problemTitle}) => {
   const [isOpen, setIsOpen] = useState(false);
   const handleSectionToggle = () => {
     setIsOpen(!isOpen);
   };
 
-  const documentNames: string[] = [];
+  const documentKeys: string[] = [];
   subTab.sections.forEach(section => {
     if (section.type === "personal-documents") {
       // get the personal documents
       networkResource.teachers?.forEach((teacher) => {
         if (teacher.personalDocuments) {
           for (const [key, document] of Object.entries(teacher.personalDocuments)) {
-            documentNames.push(`${document.title} (${key})`);
+            documentKeys.push(key);
           }
         }
       });
@@ -49,12 +52,12 @@ export const CollapsibleDocumentsSection: React.FC<IProps> = observer(
         resource.teachers?.forEach((teacher) => {
           if (teacher.problemDocuments) {
             for (const [key, document] of Object.entries(teacher.problemDocuments)) {
-              documentNames.push(`${problemTitle} (${key})`);
+              documentKeys.push(key);
             }
           }
           if (teacher.planningDocuments) {
             for (const [key, document] of Object.entries(teacher.planningDocuments)) {
-              documentNames.push(`${problemTitle}: planning (${key})`);
+              documentKeys.push(key);
             }
           }
         });
@@ -64,13 +67,16 @@ export const CollapsibleDocumentsSection: React.FC<IProps> = observer(
       networkResource.teachers?.forEach((teacher) => {
         if (teacher.learningLogs) {
           for (const [key, document] of Object.entries(teacher.learningLogs)) {
-            documentNames.push(`${document.title} (${key})`);
+            documentKeys.push(key);
           }
         }
       });
     }
   });
 
+  const networkDocuments = useNetworkDocuments();
+
+  const currentSection = subTab.sections[0] as NavTabSectionModelType;
 
   return (
     <div className="collapsible-documents-section">
@@ -82,10 +88,22 @@ export const CollapsibleDocumentsSection: React.FC<IProps> = observer(
       </div>
       { isOpen &&
         <div className="list">
-          { documentNames.length > 0
-            ? documentNames.map((docName, i) =>
-                <div key={i} style={{padding: "5px 10px"}}>{`DOCUMENT: ${docName}`}</div>)
-            : <div style={{padding: "5px 10px"}}>No Documents</div>
+
+          { documentKeys.length > 0
+            ? documentKeys.map((key, i) => {
+              const document = networkDocuments.getDocument(key);
+              if (!document) return <div>Documen Missing</div>;
+              const documentContext = getDocumentContext(document);
+              return (
+                <DocumentContextReact.Provider key={document.key} value={documentContext}>
+                  <TabPanelDocumentsSubSectionPanel section={currentSection} sectionDocument={document} tab={subTab.label}
+                    stores={stores} scale={scale} selectedDocument={selectedDocument}
+                    onSelectDocument={onSelectDocument}
+                  />
+                </DocumentContextReact.Provider>
+              );
+            })
+            : <div style={{padding: "5px 10px"}}>No Documents Found</div>
           }
           {/* {sectionDocs.map(document => {
             const documentContext = getDocumentContext(document);

--- a/src/components/thumbnail/tab-panel-documents-section.sass
+++ b/src/components/thumbnail/tab-panel-documents-section.sass
@@ -5,7 +5,7 @@ $list-item-width: 880px
 $list-item-scale: 0.11
 $section-padding: 6px
 
-.tab-panel-documents-section
+.tab-panel-documents-section, .collapsible-documents-section
   display: flex
   flex-direction: column
   padding: $section-padding


### PR DESCRIPTION
This PR displays thumbnails for the personal, problem, planning, and learning log teacher network docs for each class that appears in the My Classes and My Network sections in the left panel.  Changes include:
- display a thumbnail for teacher network docs
- thumbnail is in canned state when we do not have the document content, and in the normal thumb state when we have the document content
- load content when clicked (note we are NOT properly restoring the tile content, but I believe that can be handled in another story and is unrelated to the UI)

WARNING: we are NOT properly restoring the tile content when we call `fetchRemoteContent`.  The call is successful, the tile content appears to be retrieved from the DB, we add content to the document model, but the tile content is not being restored.  I believe that can and should be handled in another story and is unrelated to the UI.

PT Stories: 
https://www.pivotaltracker.com/story/show/179346951

Deployed branch for testing:
https://collaborative-learning.concord.org/branch/add-network-doc-thumbs/?demo

![image](https://user-images.githubusercontent.com/5126913/136437314-7ddba976-5019-4887-82d2-e534640da366.png)