### PR TITLE
Adds: "Noto Sans Math" and "Noto Sans Symbols 2" type faces to the font 'stack'

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -7,6 +7,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="shortcut icon" href="favicon.ico">
     <link href="https://fonts.googleapis.com/css?family=Lato:400,900&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Noto+Sans+Math&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Noto+Sans+Symbols+2&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
     <script>
       var hostPath = window.location.hostname + window.location.pathname,

--- a/src/index.sass
+++ b/src/index.sass
@@ -3,7 +3,7 @@ html, body
   padding: 0
 
 body
-  font-family: 'Lato', 'Noto Sans Symbols 2', 'Noto Sans Math', sans-serif;
+  font-family: 'Lato', 'Noto Sans Symbols 2', 'Noto Sans Math', sans-serif
   user-select: none
 
 .progress

--- a/src/index.sass
+++ b/src/index.sass
@@ -3,7 +3,7 @@ html, body
   padding: 0
 
 body
-  font-family: 'Lato', sans-serif;
+  font-family: 'Lato', 'Noto Sans Symbols 2', 'Noto Sans Math', sans-serif;
   user-select: none
 
 .progress


### PR DESCRIPTION
For ref., PT ticket: https://www.pivotaltracker.com/story/show/179843180

Please note the "Dashboard" caption in the toggle button, in the screen shot below:
<img width="820" alt="Screen Shot 2021-10-07 at 6 03 59 PM" src="https://user-images.githubusercontent.com/91078832/136469518-223fc07a-c0fc-47ce-8740-b379690596bb.png">

I tested with the four characters specifically mentioned in the ticket, but rendering is NOT limited to just those four glyphs. 
See:
https://fonts.google.com/noto/specimen/Noto+Sans+Math
and:
https://fonts.google.com/noto/specimen/Noto+Sans+Symbols+2

Note that we're retrieving the glyphs once from Google's CDN, but after that they are cached in the user's Web browser. This is the _same_ mechanism that is already being used for the existing 'Lato' type face:
<img width="630" alt="Screen Shot 2021-10-07 at 6 05 48 PM" src="https://user-images.githubusercontent.com/91078832/136469644-f8a01a71-bcb2-42d3-b3eb-2de897dd718f.png">


