### PR TITLE
Set proper document type on network planning document

### DIFF
--- a/src/hooks/network-resources.ts
+++ b/src/hooks/network-resources.ts
@@ -5,7 +5,7 @@ import { IGetNetworkResourcesParams, IGetNetworkResourcesResponse } from "../../
 import { DBOfferingUserProblemDocument, DBOtherDocument, DBOtherPublication, DBPublication } from "../lib/db-types";
 import { DocumentModel } from "../models/document/document";
 import {
-  LearningLogDocument, PersonalDocument, PersonalPublication, ProblemDocument, ProblemPublication
+  LearningLogDocument, PersonalDocument, PersonalPublication, PlanningDocument, ProblemDocument, ProblemPublication
 } from "../models/document/document-types";
 import { useFirebaseFunction } from "./use-firebase-function";
 import { useNetworkDocuments, useProblemPath } from "./use-stores";
@@ -58,7 +58,7 @@ export function useNetworkResources() {
           });
           each(teacher.planningDocuments, (metadata: DBOfferingUserProblemDocument, key: string) => {
             const { self: { uid }, visibility } = metadata;
-            const type = ProblemDocument;
+            const type = PlanningDocument;
             documents.add(DocumentModel.create({ uid, type, key, remoteContext, visibility }));
           });
         });


### PR DESCRIPTION
This PR sets the proper type on a network planning document (was previously set to a problem doc).  In turn, this allows the proper thumbnail caption to be shown.

![image](https://user-images.githubusercontent.com/5126913/136477000-490b6f36-e96b-467f-bf12-a3eaa3af3a14.png)
