### PR TITLE
Hide edit button when showing network docs

### DIFF
--- a/src/components/navigation/document-tab-content.tsx
+++ b/src/components/navigation/document-tab-content.tsx
@@ -79,7 +79,7 @@ export const DocumentTabContent: React.FC<IProps> = ({ tabSpec }) => {
         <div className={`document-title`}>
           {documentTitle(referenceDocument, appConfigStore, problemStore)}
         </div>
-        {editButton(tabSpec.tab, sectionClass, referenceDocument)}
+        {!referenceDocument.isRemote && editButton(tabSpec.tab, sectionClass, referenceDocument)}
       </div>
       <EditableDocumentContent
         mode={"1-up"}


### PR DESCRIPTION
This PR hides the edit button in the header of the reference doc when the loaded reference doc is a network doc.

![image](https://user-images.githubusercontent.com/5126913/136477612-9823b2b9-c0e9-44b5-bdab-664952a055a2.png)
