### PR TITLE
Fix commenting on network documents

### DIFF
--- a/functions/src/post-document-comment.ts
+++ b/functions/src/post-document-comment.ts
@@ -7,7 +7,7 @@ import { validateUserContext } from "./user-context";
 import { createCommentableDocumentIfNecessary } from "./validate-commentable-document";
 
 // update this when deploying updates to this function
-const version = "1.1.3";
+const version = "1.1.4";
 
 export async function postDocumentComment(
                         params?: IPostDocumentCommentUnionParams,

--- a/functions/src/shared.ts
+++ b/functions/src/shared.ts
@@ -97,16 +97,17 @@ export function networkDocumentKey(uid: string, documentKey: string, network?: s
 }
 
 export interface IDocumentMetadata {
+  contextId: string;
   uid: string;
   type: string;
   key: string;
-  createdAt: number;
+  createdAt?: number;
   title?: string;
   originDoc?: string;
   properties?: Record<string, string>;
 }
 export function isDocumentMetadata(o: any): o is IDocumentMetadata {
-  return !!o?.uid && !!o.type && !!o.key && !!o.createdAt;
+  return !!o?.contextId && !!o.uid && !!o.type && !!o.key;
 }
 
 export interface ICurriculumMetadata {

--- a/functions/src/validate-commentable-document.ts
+++ b/functions/src/validate-commentable-document.ts
@@ -1,13 +1,13 @@
 import * as admin from "firebase-admin";
 import * as functions from "firebase-functions";
 import {
-  ICommentableDocumentParams,
-  ICommentableDocumentUnionParams, isCurriculumMetadata, isDocumentMetadata, isWarmUpParams, networkDocumentKey
+  ICommentableDocumentParams, ICommentableDocumentUnionParams, isCurriculumMetadata, isDocumentMetadata,
+  isWarmUpParams, networkDocumentKey
 } from "./shared";
 import { validateUserContext } from "./user-context";
 
 // update this when deploying updates to this function
-const version = "1.0.0";
+const version = "1.0.1";
 
 export async function validateCommentableDocument(
                         params?: ICommentableDocumentUnionParams,

--- a/functions/test/post-document-comment.test.ts
+++ b/functions/test/post-document-comment.test.ts
@@ -7,7 +7,7 @@ import {
   IUserContext, networkDocumentKey
 } from "../src/shared";
 import {
-  kCanonicalPortal, kCreatedAt, kCurriculumKey, kDemoName, kDocumentKey, kDocumentType, kFirebaseUserId,
+  kCanonicalPortal, kClassHash, kCurriculumKey, kDemoName, kDocumentKey, kDocumentType, kFirebaseUserId,
   kTeacherName, kTeacherNetwork, kUserId, specAuth, specUserContext
 } from "./test-utils";
 
@@ -61,7 +61,7 @@ export interface IPartialPostCommentParams {
 const specPostDocumentComment = (overrides?: IPartialPostCommentParams): IPostDocumentCommentParams => {
   return {
     context: specUserContext(overrides?.context),
-    document: { uid: kUserId, type: kDocumentType, key: kDocumentKey, createdAt: kCreatedAt, ...overrides?.document },
+    document: { contextId: kClassHash, uid: kUserId, type: kDocumentType, key: kDocumentKey, ...overrides?.document },
     comment: { content: kComment1, ...overrides?.comment }
   };
 };

--- a/functions/test/validate-commentable-document.test.ts
+++ b/functions/test/validate-commentable-document.test.ts
@@ -7,7 +7,7 @@ import {
 } from "../src/shared";
 import { validateCommentableDocument } from "../src/validate-commentable-document";
 import {
-  kCanonicalPortal, kCreatedAt, kCurriculumKey, kDemoName, kDocumentKey, kDocumentType, kFirebaseUserId,
+  kCanonicalPortal, kClassHash, kCurriculumKey, kDemoName, kDocumentKey, kDocumentType, kFirebaseUserId,
   kTeacherNetwork, kUserId, specAuth, specUserContext
 } from "./test-utils";
 
@@ -57,7 +57,7 @@ export interface IPartialValidateDocumentParams {
 const specValidateDocument = (overrides?: IPartialValidateDocumentParams): ICommentableDocumentParams => {
   return {
     context: specUserContext(overrides?.context),
-    document: { uid: kUserId, type: kDocumentType, key: kDocumentKey, createdAt: kCreatedAt, ...overrides?.document }
+    document: { contextId: kClassHash, uid: kUserId, type: kDocumentType, key: kDocumentKey, ...overrides?.document }
   };
 };
 


### PR DESCRIPTION
[[#179652167]](https://www.pivotaltracker.com/story/show/179652167)

- `useDocumentFromStore()`, `useDocumentMetadataFromStore()`, and `useTypeOfTileInDocumentOrCurriculum()` now consider network documents as well as local documents
- add `contextId` to `IDocumentMetadata`

With these changes, commenting on network documents or on tiles within network documents works like commenting on local documents.

@Concord-Jim Since Matt's not available today, sync review probably makes sense.