### PR TITLE
Use optimistic update to show new comments promptly [#179862503]

### DIFF
--- a/src/components/chat/comment-card.tsx
+++ b/src/components/chat/comment-card.tsx
@@ -66,19 +66,22 @@ export const CommentCard: React.FC<IProps> = ({ activeNavTab, user, postedCommen
             const userInitialBackgroundColor = ["#f79999", "#ffc18a", "#99d099", "#ff9", "#b2b2ff", "#efa6ef"];
             const commenterInitial = comment.name.charAt(0);
             const userInitialBackgroundColorIndex = parseInt(comment.uid, 10) % 6;
-            const isCurrentUserComment = user?.id === comment.uid;
-            const backgroundStyle = isCurrentUserComment
+            const isOwnComment = user?.id === comment.uid;
+            const shouldShowUserIcon = isOwnComment;
+            // can't delete comment until we have a valid server-generated id
+            const shouldShowDeleteIcon = isOwnComment && !comment.id.startsWith("pending-");
+            const backgroundStyle = shouldShowUserIcon
                                       ? {backgroundColor: "white"}
                                       : {backgroundColor: userInitialBackgroundColor[userInitialBackgroundColorIndex]};
             return (
               <div key={idx} className="comment-thread" data-testid="comment-thread">
                 <div className="comment-text-header">
                   <div className="user-icon" style={backgroundStyle}>
-                    {isCurrentUserComment ? <UserIcon /> : commenterInitial}
+                    {shouldShowUserIcon ? <UserIcon /> : commenterInitial}
                   </div>
                   <div className="user-name">{comment.name}</div>
                   <div className="time-stamp">{getDisplayTimeDate(comment.createdAt.getTime())}</div>
-                  {isCurrentUserComment &&
+                  {shouldShowDeleteIcon &&
                     <div className="delete-message-icon-container" data-testid="delete-message-button"
                           onClick={() => handleDeleteComment(comment.id)}>
                       <DeleteMessageIcon />

--- a/src/hooks/firestore-hooks.test.ts
+++ b/src/hooks/firestore-hooks.test.ts
@@ -76,17 +76,17 @@ describe("Firestore hooks", () => {
     it("should install onSnapshot handler with default converter", () => {
       renderHook(() => useCollectionOrderedRealTimeQuery("foo"));
       expect(mockSetQueryData).toHaveBeenCalledTimes(1);
-      expect(mockSetQueryData.mock.calls[0][0]).toBe("root/foo");
+      expect(mockSetQueryData.mock.calls[0][0]).toBe("foo");
       expect(mockSetQueryData.mock.calls[0][1]).toEqual(mockData);
-      expect(mockUseQuery.mock.calls[0][0]).toBe("root/foo");
+      expect(mockUseQuery.mock.calls[0][0]).toBe("foo");
     });
 
     it("should install onSnapshot handler with default converter and orderBy", () => {
       renderHook(() => useCollectionOrderedRealTimeQuery("bar", { orderBy: "baz" }));
       expect(mockSetQueryData).toHaveBeenCalledTimes(1);
-      expect(mockSetQueryData.mock.calls[0][0]).toBe("root/bar");
+      expect(mockSetQueryData.mock.calls[0][0]).toBe("bar");
       expect(mockSetQueryData.mock.calls[0][1]).toEqual(mockData);
-      expect(mockUseQuery.mock.calls[0][0]).toBe("root/bar");
+      expect(mockUseQuery.mock.calls[0][0]).toBe("bar");
     });
   });
 

--- a/src/hooks/firestore-hooks.ts
+++ b/src/hooks/firestore-hooks.ts
@@ -43,16 +43,16 @@ export function useCollectionOrderedRealTimeQuery<T>(
       const unsubscribe = query.onSnapshot(querySnapshot => {
                             // add the id to the returned data
                             const docs = querySnapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
-                            queryClient.setQueryData(fsPath, docs);
+                            queryClient.setQueryData(partialPath, docs);
                           });
       return () => unsubscribe();
     }
-  }, [converter, db, fsPath, options?.orderBy, orderBy, queryClient]);
+  }, [converter, db, fsPath, options?.orderBy, orderBy, partialPath, queryClient]);
 
   // set staleTime to Infinity; we never need to re-run this query, since the listener handles updates
   const useQueryOptions: UseQueryOptions<WithId<T>[]> = { ..._useQueryOptions, staleTime: Infinity };
   // the actual query function here doesn't do anything; everything comes through the snapshot handler
-  return useQuery<WithId<T>[]>(fsPath || "__EMPTY__", () => new Promise(() => {/* nop */}), useQueryOptions);
+  return useQuery<WithId<T>[]>(partialPath || "__EMPTY__", () => new Promise(() => {/* nop */}), useQueryOptions);
 }
 
 export const useDeleteDocument = () => {


### PR DESCRIPTION
[[#179862503]](https://www.pivotaltracker.com/story/show/179862503)

With this PR we now use an [optimistic update](https://react-query.tanstack.com/guides/optimistic-updates) to render newly added comments promptly rather than waiting for a response from the server. This is made easier with support from ReactQuery. If the new comment is added successfully we silently update to the new server contents. If an error occurs, we roll back to the state of the comments before the new comment was added. This makes the act of adding a new comment essentially instantaneous. The only user-visible indication of the pending state of a new comment is that we don't render the delete (trash can) icon while the server response is pending. This is because we can't delete a comment without knowing its proper server-provided id.