### PR TITLE
Prevent dragging of remote document thumbnail

### DIFF
--- a/src/components/thumbnail/tab-panel-documents-subsection-panel.tsx
+++ b/src/components/thumbnail/tab-panel-documents-subsection-panel.tsx
@@ -81,7 +81,8 @@ export const TabPanelDocumentsSubSectionPanel = ({section, sectionDocument, tab,
         scale={scale}
         isSelected={sectionDocument.key === selectedDocument}
         captionText={getDocumentCaption(stores, sectionDocument)}
-        onDocumentClick={handleDocumentClick} onDocumentDragStart={handleDocumentDragStart}
+        onDocumentClick={handleDocumentClick}
+        onDocumentDragStart={!sectionDocument.isRemote ? handleDocumentDragStart: undefined}
         onIsStarred={onIsStarred}
         onDocumentStarClick={_handleDocumentStarClick}
         onDocumentDeleteClick={_handleDocumentDeleteClick}


### PR DESCRIPTION
Prevent dragging and dropping of remote document thumbnails.  Blocking this prevents users from thinking they can drag a teacher network document thumbnail from the left to the right panel and open the document.  Changes include:
- prevent drag and drop of remote document

PT Story: 
https://www.pivotaltracker.com/story/show/179857663

Deployed branch for testing:
https://collaborative-learning.concord.org/branch/prevent-remote-doc-drag/?demo