### PR TITLE
Prevent tiles from being selected when displayed in thumbnail

### DIFF
--- a/src/components/thumbnail/tab-panel-documents-section.sass
+++ b/src/components/thumbnail/tab-panel-documents-section.sass
@@ -49,6 +49,7 @@ $section-padding: 6px
           transform-origin: 0 0
           height: $list-item-height
           width: $list-item-width
+          pointer-events: none
 
         &.new-document-button
           position: relative


### PR DESCRIPTION
This PR prevents tiles from being selected when inside of a thumbnail.  Previously, when a user clicked a thumbnail to open a document, the thumbnail was also getting mouse events that permitted a tile to be selected with the same action.  This was resulting in a seemingly random tile being selected when a document was opened.  Changes include:
- use `pointer-events: none` on div around thumbnail to prevent mouse events from getting to the thumbnail

PT story:
https://www.pivotaltracker.com/story/show/179822339

Deployed branch for testing:
https://collaborative-learning.concord.org/branch/clear-doc-selection-state/?demo 


