### PR TITLE
Tile copy to clipboard: put all exported content in a top-level object, under key: "content"

### DIFF
--- a/src/components/tools/tool-tile.tsx
+++ b/src/components/tools/tool-tile.tsx
@@ -351,7 +351,7 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
       tileJsonString = (tileJsonString.slice(-1) === "\n")
         ? tileJsonString.slice(0, -1) // Remove trailing new line char.
         : tileJsonString;
-      tileJsonString = `{\n  "content": ${tileJsonString.replaceAll("\n", "\n  ")}` + "\n}\n";
+      tileJsonString = `{\n  "content": ${tileJsonString.replace(/\n/g, "\n  ")}\n}\n`;
     }
     tileJsonString && navigator.clipboard.writeText(tileJsonString);
     return true;

--- a/src/components/tools/tool-tile.tsx
+++ b/src/components/tools/tool-tile.tsx
@@ -345,9 +345,13 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
     const toolApi = toolApiInterface?.getToolApi(this.modelId);
     let tileJsonString = toolApi?.exportContentAsTileJson?.({ transformImageUrl });
     if (tileJsonString) {
-      // Put all exported content in a top-level object, under key: "content"
-      const tileJson = JSON.parse(tileJsonString);
-      tileJsonString = JSON.stringify({ content: tileJson }, null, "  ");
+      // Put all exported content in a top-level object, under key: "content",
+      // but _preserve_ existing formatting (which collapses some elements
+      // into a single line; no: indent). But DO indent w.r.t. the new key.
+      tileJsonString = (tileJsonString.slice(-1) === "\n")
+        ? tileJsonString.slice(0, -1) // Remove trailing new line char.
+        : tileJsonString;
+      tileJsonString = `{\n  "content": ${tileJsonString.replaceAll("\n", "\n  ")}` + "\n}\n";
     }
     tileJsonString && navigator.clipboard.writeText(tileJsonString);
     return true;

--- a/src/components/tools/tool-tile.tsx
+++ b/src/components/tools/tool-tile.tsx
@@ -173,7 +173,7 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
     model.setDisabledFeatures(getDisabledFeaturesOfTile(this.stores, type));
 
     this.hotKeys.register({
-      "cmd-option-e": this.handleCopyImportJson,
+      "cmd-option-e": this.handleCopyImportJsonToClipboard,
       "cmd-shift-c": this.handleCopyModelJson
     });
   }
@@ -335,7 +335,7 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
     }
   }
 
-  private handleCopyImportJson = () => {
+  private handleCopyImportJsonToClipboard = () => {
     const { appConfig, unit } = this.stores;
     const unitBasePath = appConfig.getUnitBasePath(unit.code);
     const transformImageUrl = (url: string, filename?: string) => {
@@ -343,8 +343,13 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
     };
     const toolApiInterface = this.context;
     const toolApi = toolApiInterface?.getToolApi(this.modelId);
-    const importJson = toolApi?.exportContentAsTileJson?.({ transformImageUrl });
-    importJson && navigator.clipboard.writeText(importJson);
+    let tileJsonString = toolApi?.exportContentAsTileJson?.({ transformImageUrl });
+    if (tileJsonString) {
+      // Put all exported content in a top-level object, under key: "content"
+      const tileJson = JSON.parse(tileJsonString);
+      tileJsonString = JSON.stringify({ content: tileJson }, null, "  ");
+    }
+    tileJsonString && navigator.clipboard.writeText(tileJsonString);
     return true;
   }
 


### PR DESCRIPTION
Sample content, before:
```
{

	"type": "Text",
	"format": "html",
	"text": [
	  "<p>S&amp;S 0.1 Teacher Support</p>"
	]
}
```

After:
```
{
	"content": {
	  "type": "Text",
	  "format": "html",
	  "text": [
		"<p>S&amp;S 0.1 Teacher Support</p>"
	  ]
	}
}
```