### PR TITLE
Fix export handling of normalized coordinates

### DIFF
--- a/src/models/tools/geometry/geometry-export.test.ts
+++ b/src/models/tools/geometry/geometry-export.test.ts
@@ -237,6 +237,29 @@ describe("Geometry Export", () => {
     expect(received).toEqual(expected);
   });
 
+  it("should export updated points using normalized coordinates", () => {
+    const changes: JXGChange[] = [
+      {
+        operation: "create",
+        target: "board",
+        properties: { axis: true, boundingBox: [-2, 15, 22, -1], unitX: 20, unitY: 20 }
+      },
+      { operation: "create", target: "point", parents: [0, 0], properties: { id: "p1" } },
+      { operation: "create", target: "point", parents: [5, 5], properties: { id: "p2" } },
+      { operation: "update", target: "point", targetID: "p2", properties: { position: [1, 2, 2] } }
+    ];
+    expect(exportGeometry(changes)).toEqual({
+      type: "Geometry",
+      board: { properties: { axisMin: [-2, -1], axisRange: [24, 16] } },
+      objects: [
+        { type: "point", parents: [0, 0], properties: { id: "p1" } },
+        { type: "point", parents: [2, 2], properties: { id: "p2" } }
+      ]
+    });
+    const [received, expected] = testRoundTrip(changes);
+    expect(received).toEqual(expected);
+  });
+
   it("should export point with comment at default location", () => {
     const changes: JXGChange[] = [
       {

--- a/src/models/tools/geometry/geometry-export.ts
+++ b/src/models/tools/geometry/geometry-export.ts
@@ -221,8 +221,16 @@ export const exportGeometryJson = (changes: string[], options?: ITileExportOptio
     const { position, ...others } = props;
     if (others.id !== id) others.id = id;
     const changeParents = getParentsFromInitialChange(id, _changes[0]);
-    const xParent = position?.[0] ?? changeParents?.[0];
-    const yParent = position?.[1] ?? changeParents?.[1];
+    let xPos, yPos: number;
+    // some operations used normalized coordinates, which take the form [1, x, y]
+    if (Array.isArray(position) && (position.length === 3)) {
+      [, xPos, yPos] = position;
+    }
+    else {
+      [xPos, yPos] = position || [];
+    }
+    const xParent = xPos ?? changeParents?.[0];
+    const yParent = yPos ?? changeParents?.[1];
     const parents = [xParent, yParent] as JXGCoordPair;
     return { parents, others };
   };

--- a/src/models/tools/geometry/jxg-changes.ts
+++ b/src/models/tools/geometry/jxg-changes.ts
@@ -7,7 +7,9 @@ export type JXGObjectType = "board" | "comment" | "image" | "linkedPoint" | "met
                               "object" | "point" | "polygon" | "tableLink" | "vertexAngle";
 
 export type JXGCoordPair = [number, number];
+export type JXGNormalizedCoordPair = [1, number, number];
 export type JXGUnsafeCoordPair = [number?, number?];
+export type JXGPositionProperty = JXGUnsafeCoordPair | JXGNormalizedCoordPair;
 export type JXGStringPair = [string?, string?];
 
 export type JXGImageParents = [string, JXGCoordPair, JXGCoordPair];
@@ -35,9 +37,9 @@ export interface IBoardScale {
 
 export interface JXGProperties {
   id?: string;
-  ids?: string[]; // ids of linked points in tabeLink change
+  ids?: string[]; // ids of linked points in tableLink change
   labelOption?: ESegmentLabelOption;
-  position?: JXGUnsafeCoordPair;
+  position?: JXGPositionProperty;
   title?: string; // metadata property
   url?: string;
   xMin?: number;

--- a/src/models/tools/geometry/jxg-object.ts
+++ b/src/models/tools/geometry/jxg-object.ts
@@ -1,5 +1,7 @@
 import { sortByCreation, kReverse, getObjectById, syncLinkedPoints } from "./jxg-board";
-import { ITableLinkProperties, JXGChangeAgent, JXGProperties, JXGCoordPair, JXGUnsafeCoordPair } from "./jxg-changes";
+import {
+  ITableLinkProperties, JXGChangeAgent, JXGCoordPair, JXGPositionProperty, JXGProperties
+} from "./jxg-changes";
 import { isLinkedPoint, isText } from "./jxg-types";
 import { castArrayCopy } from "../../../utilities/js-utils";
 import { castArray, size } from "lodash";
@@ -11,11 +13,22 @@ function validateTransformations(elt: JXG.GeometryElement) {
   elt.transformations = (elt.transformations || []).filter(t => t != null);
 }
 
-export function isPositionGraphable(pos: JXGUnsafeCoordPair) {
-  return pos[0] != null && pos[1] != null && isFinite(pos[0]) && isFinite(pos[1]);
+export function isPositionGraphable(pos: JXGPositionProperty) {
+  let xPos: number | undefined;
+  let yPos: number | undefined;
+  // some operations used normalized coordinates, which take the form [1, x, y]
+  if (pos.length === 3) {
+    [, xPos, yPos] = pos;
+  }
+  else {
+    [xPos, yPos] = pos;
+  }
+  return xPos != null && yPos != null && isFinite(xPos) && isFinite(yPos);
 }
 
-export function getGraphablePosition(pos: JXGUnsafeCoordPair) {
+export function getGraphablePosition(position: JXGPositionProperty) {
+  // some operations used normalized coordinates, which take the form [1, x, y]
+  const pos = position.length === 3 ? position.slice(1) : position;
   return pos.map(val => {
     if (val == null) return 0;
     const num = Number(val);


### PR DESCRIPTION
[[#179876830]](https://www.pivotaltracker.com/story/show/179876830)

For historical reasons related to JSXGraph internals, positions of points are sometimes represented in "normalized" coordinates, which take the form [1, x, y] rather than the traditional [x, y]. The export code was not taking this into account, leading to a lot of points plotted with an x-value of 1 and a y-value that corresponded to that point's x-value. The fix is simply to detect such normalized coordinates and handle them appropriately.