### PR TITLE
Only show network docs in left, reference panel

### DIFF
--- a/src/components/navigation/document-tab-content.tsx
+++ b/src/components/navigation/document-tab-content.tsx
@@ -97,6 +97,7 @@ export const DocumentTabContent: React.FC<IProps> = ({ tabSpec }) => {
         onTabClick={handleTabClick}
         onSelectDocument={handleSelectDocument}
         documentView={documentView}
+        showNetworkDocuments={true}
       />
     </div>
   );

--- a/src/components/navigation/document-tab-panel.tsx
+++ b/src/components/navigation/document-tab-panel.tsx
@@ -21,6 +21,7 @@ interface IProps extends IBaseProps {
   onTabClick?: (title: string, type: string) => void;
   documentView?: React.ReactNode;
   isChatOpen?: boolean;
+  showNetworkDocuments?: boolean;
 }
 
 interface IState {
@@ -151,7 +152,7 @@ export class DocumentTabPanel extends BaseComponent<IProps, IState> {
   }
 
   private renderSubSections(subTab: any) {
-    const { selectedDocument, onSelectNewDocument } = this.props;
+    const { selectedDocument, onSelectNewDocument, showNetworkDocuments } = this.props;
     const { user } = this.stores;
     const classHash = this.stores.class.classHash;
     return (
@@ -182,7 +183,7 @@ export class DocumentTabPanel extends BaseComponent<IProps, IState> {
             );
           })
         }
-        {user.isNetworkedTeacher &&
+        {(user.isNetworkedTeacher && showNetworkDocuments) &&
           <NetworkDocumentsSection
             currentClassHash={classHash}
             currentTeacherName={user.name}


### PR DESCRIPTION
This PR prevents teacher network documents from being shown in the right panel:.  Changes include:
- allow `NetworkDocumentsSection` to be conditionally shown depending on context

PT story:
https://www.pivotaltracker.com/story/show/179986559

Deployed branch for testing:
https://collaborative-learning.concord.org/branch/hide-network-docs-in-right-panel/?demo 

![image](https://user-images.githubusercontent.com/5126913/137815828-bb9a3cc6-4413-4c3c-bc4c-14e69d50ec12.png)

