### PR TITLE
Add private doc thumbnail, disabled for now

### DIFF
--- a/src/components/thumbnail/collapsible-document-section.scss
+++ b/src/components/thumbnail/collapsible-document-section.scss
@@ -63,6 +63,9 @@ $section-padding: 6px;
       overflow: hidden;
       background-color:rgba(250, 236, 141, 0.0);
       cursor: pointer;
+      &.private {
+        cursor: auto;
+      }
       .scaled-list-item-container {
         border-radius: 5px;
         border: solid 1.5px $charcoal-light-1;
@@ -74,21 +77,6 @@ $section-padding: 6px;
           transform-origin: 0 0;
           height: $list-item-height;
           width: $list-item-width;
-        }
-      }
-      .not-shared {
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        border-radius: 5px;
-        border: solid 1.5px $charcoal-light-1;
-        height: 74px;
-        width: 96px;
-        fill: $workspace-teal-dark-1;
-        .not-shared-icon {
-          height: 26px;
-          width: 30px;
-          fill: $workspace-teal-dark-1
         }
       }
       .info {

--- a/src/components/thumbnail/collapsible-document-section.tsx
+++ b/src/components/thumbnail/collapsible-document-section.tsx
@@ -10,8 +10,6 @@ import { useNetworkDocuments } from "../../hooks/use-stores";
 import { TabPanelDocumentsSubSectionPanel } from "./tab-panel-documents-subsection-panel";
 import { NavTabSectionModelType } from "../../models/view/nav-tabs";
 import { Logger, LogEventName } from "../../lib/logger";
-// import NotSharedIcon from "../../assets/icons/share/not-share.svg";
-// import { DocumentCaption } from "./document-caption";
 
 import "./tab-panel-documents-section.sass";
 import "./collapsible-document-section.scss";
@@ -108,44 +106,8 @@ export const CollapsibleDocumentsSection: React.FC<IProps> = observer(
             })
             : <div style={{padding: "5px 10px"}}>No Documents Found</div>
           }
-          {/* {sectionDocs.map(document => {
-            const documentContext = getDocumentContext(document);
-            const docNotShared = document.visibility === "private";
-            const docLabel = document?.title || "Untitled";
-            return (
-              <DocumentContextReact.Provider key={document.key} value={documentContext}>
-                { docNotShared
-                  ? <DocumentNoSharedThumbnail label={docLabel} notShared={docNotShared} />
-                  : <TabPanelDocumentsSubSectionPanel section={section} sectionDocument={document} tab={tab}
-                      stores={stores} scale={scale} selectedDocument={selectedDocument}
-                      onSelectDocument={onSelectDocument}
-                    />
-                }
-              </DocumentContextReact.Provider>
-            );
-          })} */}
         </div>
       }
     </div>
   );
 });
-
-// interface IDocumentNotSharedProps {
-//   label: string;
-//   notShared?: boolean;
-// }
-// const DocumentNoSharedThumbnail: React.FC<IDocumentNotSharedProps> = ({ label, notShared }) => {
-//   return (
-//     <div className="list-item not-shared" data-test="my-work-new-document" >
-//       { notShared
-//           ? <div className="not-shared">
-//               <NotSharedIcon className="not-shared-icon" />
-//             </div>
-//           : <div className="scaled-list-item-container new-document-button" >
-//               <div className="scaled-list-item"></div>
-//             </div>
-//       }
-//       <DocumentCaption captionText={label} />
-//     </div>
-//   );
-// };

--- a/src/components/thumbnail/thumbnail-document-item.tsx
+++ b/src/components/thumbnail/thumbnail-document-item.tsx
@@ -4,6 +4,7 @@ import { CanvasComponent } from "../document/canvas";
 import { DocumentModelType } from "../../models/document/document";
 import { DocumentCaption } from "./document-caption";
 import { ThumbnailPlaceHolderIcon } from "./thumbnail-placeholder-icon";
+import { ThumbnailPrivateIcon } from "./thumbnail-private-icon";
 
 interface IProps {
   dataTestName: string;
@@ -40,22 +41,27 @@ export const ThumbnailDocumentItem = observer((props: IProps) => {
     onDocumentDeleteClick?.(document);
     e.stopPropagation();
   };
+  // TODO: add proper state of isPrivate based on document properties
+  const isPrivate = false; // document.visibility === "private" && document.isRemote;
+  const privateClass = isPrivate ? "private" : "";
 
   return (
-    <div className={`list-item ${selectedClass}`} data-test={dataTestName} key={document.key}
-      onClick={handleDocumentClick}>
+    <div className={`list-item ${selectedClass} ${privateClass}`} data-test={dataTestName} key={document.key}
+      onClick={isPrivate ? undefined : handleDocumentClick}>
       <div className="scaled-list-item-container" onDragStart={handleDocumentDragStart}
-        draggable={!!onDocumentDragStart}>
-        { document.content
-          ? <div className="scaled-list-item">
-              <CanvasComponent
-                context={canvasContext}
-                document={document}
-                readOnly={true}
-                scale={scale}
-              />
-            </div>
-          : <ThumbnailPlaceHolderIcon />
+        draggable={!!onDocumentDragStart && !isPrivate}>
+        { isPrivate
+          ? <ThumbnailPrivateIcon />
+          : document.content
+            ? <div className="scaled-list-item">
+                <CanvasComponent
+                  context={canvasContext}
+                  document={document}
+                  readOnly={true}
+                  scale={scale}
+                />
+              </div>
+            : <ThumbnailPlaceHolderIcon />
         }
       </div>
       { onDocumentStarClick &&

--- a/src/components/thumbnail/thumbnail-private-icon.scss
+++ b/src/components/thumbnail/thumbnail-private-icon.scss
@@ -1,0 +1,15 @@
+@import "../vars";
+
+.thumbnail-private {
+  display: flex;
+  height: 100%;
+  width: 100%;
+  justify-content: center;
+  align-items: center;
+
+  .private-icon {
+    height: 40px;
+    width: 40px;
+    fill: $workspace-teal-dark-1;
+  }
+}

--- a/src/components/thumbnail/thumbnail-private-icon.tsx
+++ b/src/components/thumbnail/thumbnail-private-icon.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import DocumentPrivateIcon from "../../assets/icons/share/not-share.svg";
+
+import "./thumbnail-private-icon.scss";
+
+export const ThumbnailPrivateIcon: React.FC = () => {
+  return (
+    <div className="thumbnail-private">
+      <DocumentPrivateIcon className="private-icon" />
+    </div>
+  );
+};


### PR DESCRIPTION
This PR add the ability to show a private document thumbnail which is currently disabled until this feature is fully fleshed out. 
 Changes include:
- add `ThumbnailPrivateIcon` React component
- add code to conditionally show `ThumbnailPrivateIcon` - turned off for now
- remove obsolete code

PT story:
https://www.pivotaltracker.com/story/show/179857750

Deployed branch for testing:
https://collaborative-learning.concord.org/branch/private-doc-handling/?demo 

![image](https://user-images.githubusercontent.com/5126913/137816925-6dd8b084-5ed9-41c8-9c63-92e273c42abc.png)
