### PR TITLE
Support `action` as typed string when logging comment actions

### DIFF
--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from "react";
-import {  Logger } from "../../lib/logger";
+import { ILogComment, Logger } from "../../lib/logger";
 import { UserModelType } from "../../models/stores/user";
 import { ChatPanelHeader } from "./chat-panel-header";
 import { CommentCard } from "./comment-card";
@@ -31,12 +31,12 @@ export const ChatPanel: React.FC<IProps> = ({ user, activeNavTab, focusDocument,
     if (focusDocument) {
       const numComments = postedComments ? postedComments.length : 0;
       const focusDocumentId = focusDocument;
-      const eventPayload = {
+      const eventPayload: ILogComment = {
         focusDocumentId,
         focusTileId,
         isFirst: (numComments < 1),
         commentText: comment,
-        isAdding: true
+        action: "add"
       };
       Logger.logCommentEvent(eventPayload);
     }
@@ -52,11 +52,11 @@ export const ChatPanel: React.FC<IProps> = ({ user, activeNavTab, focusDocument,
 
   const deleteComment = useCallback((commentId: string, commentText: string) => {
     if (focusDocument) {
-      const eventPayload = {
+      const eventPayload: ILogComment = {
         focusDocumentId: focusDocument,
         focusTileId,
         commentText,
-        isAdding: false
+        action: "delete"
       };
       Logger.logCommentEvent(eventPayload);
     }

--- a/src/lib/logger.test.ts
+++ b/src/lib/logger.test.ts
@@ -208,7 +208,69 @@ describe("authed logger", () => {
       Logger.logTileEvent(LogEventName.CREATE_TILE, tile);
     });
 
-    it("can log an ADD comment event", (done) => {
+    it("can log an ADD a document initial comment event", (done) => {
+      const document = DocumentModel.create({
+        type: ProblemDocument,
+        uid: "1",
+        key: "source-document",
+        createdAt: 1,
+        content: {},
+        visibility: "public"
+      });
+      stores.documents.add(document);
+      const documentKey = document.key;
+      const commentText = "TeSt";
+      const addEventPayload: ILogComment = {
+        focusDocumentId: document.key,
+        isFirst: true,
+        commentText,
+        action: "add"
+      };
+
+      mockXhr.post(/.*/, (req, res) => {
+        const addCommentRequest = JSON.parse(req.body());
+        expect(addCommentRequest.event).toBe("ADD_INITIAL_COMMENT_FOR_DOCUMENT");
+        expect(addCommentRequest.parameters.commentText).toBe(commentText);
+        expect(addCommentRequest.parameters.documentKey).toBe(documentKey);
+        done();
+        return res.status(201);
+      });
+
+      Logger.logCommentEvent(addEventPayload);
+    });
+
+    it("can log an ADD a document response comment event", (done) => {
+      const document = DocumentModel.create({
+        type: ProblemDocument,
+        uid: "1",
+        key: "source-document",
+        createdAt: 1,
+        content: {},
+        visibility: "public"
+      });
+      stores.documents.add(document);
+      const documentKey = document.key;
+      const commentText = "TeSt";
+      const addEventPayload: ILogComment = {
+        focusDocumentId: document.key,
+        isFirst: false,
+        commentText,
+        action: "add"
+      };
+
+      mockXhr.post(/.*/, (req, res) => {
+        const addCommentRequest = JSON.parse(req.body());
+        expect(addCommentRequest.event).toBe("ADD_RESPONSE_COMMENT_FOR_DOCUMENT");
+        expect(addCommentRequest.parameters.commentText).toBe(commentText);
+        expect(addCommentRequest.parameters.documentKey).toBe(documentKey);
+        done();
+        return res.status(201);
+      });
+
+      Logger.logCommentEvent(addEventPayload);
+    });
+
+    it("can log an ADD a tile comment event", (done) => {
       const document = DocumentModel.create({
         type: ProblemDocument,
         uid: "1",
@@ -243,7 +305,37 @@ describe("authed logger", () => {
       Logger.logCommentEvent(addEventPayload);
     });
 
-    it("can log a DELETE comment event", (done) => {
+    it("can log a DELETE document comment event", (done) => {
+      const document = DocumentModel.create({
+        type: ProblemDocument,
+        uid: "1",
+        key: "source-document",
+        createdAt: 1,
+        content: {},
+        visibility: "public"
+      });
+      stores.documents.add(document);
+      const documentKey = document.key;
+      const commentText = "TeSt";
+      const deleteEventPayload: ILogComment = {
+        focusDocumentId: document.key,
+        isFirst: false,
+        commentText,
+        action: "delete"
+      };
+
+      mockXhr.post(/.*/, (req, res) => {
+        const deleteCommentRequest = JSON.parse(req.body());
+        expect(deleteCommentRequest.event).toBe("DELETE_COMMENT_FOR_DOCUMENT");
+        expect(deleteCommentRequest.parameters.commentText).toBe(commentText);
+        expect(deleteCommentRequest.parameters.documentKey).toBe(documentKey);
+        done();
+        return res.status(201);
+      });
+      Logger.logCommentEvent(deleteEventPayload);
+    });
+
+    it("can log a DELETE tile comment event", (done) => {
       const document = DocumentModel.create({
         type: ProblemDocument,
         uid: "1",

--- a/src/lib/logger.test.ts
+++ b/src/lib/logger.test.ts
@@ -1,5 +1,5 @@
 import mockXhr from "xhr-mock";
-import { Logger, LogEventName } from "./logger";
+import { Logger, LogEventName, ILogComment } from "./logger";
 import { DocumentModel, DocumentModelType } from "../models/document/document";
 import { ProblemDocument } from "../models/document/document-types";
 import { AppConfigModel } from "../models/stores/app-config-model";
@@ -222,12 +222,12 @@ describe("authed logger", () => {
       const tileId = tile.id;
       const documentKey = document.key;
       const commentText = "TeSt";
-      const addEventPayload = {
+      const addEventPayload: ILogComment = {
         focusDocumentId: document.key,
         focusTileId: tile.id,
         isFirst: false,
-        commentText: "TeSt",
-        isAdding: true
+        commentText,
+        action: "add"
       };
 
       mockXhr.post(/.*/, (req, res) => {
@@ -257,12 +257,12 @@ describe("authed logger", () => {
       const tileId = tile.id;
       const documentKey = document.key;
       const commentText = "TeSt";
-      const deleteEventPayload = {
+      const deleteEventPayload: ILogComment = {
         focusDocumentId: document.key,
         focusTileId: tile.id,
         isFirst: false,
-        commentText: "TeSt",
-        isAdding: false
+        commentText,
+        action: "delete"
       };
 
       mockXhr.post(/.*/, (req, res) => {

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -143,12 +143,13 @@ interface ITeacherNetworkInfo {
   networkUsername?: string;
 }
 
-interface ILogComment {
+type CommentAction = "add" | "delete";  // | "edit"
+export interface ILogComment {
   focusDocumentId: string;
   focusTileId?: string;
-  isFirst?: boolean; // actual argument is ignored, when isAdding is falsey
+  isFirst?: boolean; // only used with "add"
   commentText: string;
-  isAdding: boolean
+  action: CommentAction;
 }
 
 export class Logger {
@@ -250,28 +251,20 @@ export class Logger {
     Logger.log(event, parameters);
   }
 
-  public static logCommentEvent({
-    focusDocumentId,
-    focusTileId,
-    isFirst,
-    commentText,
-    isAdding
-    }: ILogComment) {
-    let event: LogEventName;
-
-    if (isAdding) {
-      event = focusTileId
-        ? isFirst
-          ? LogEventName.ADD_INITIAL_COMMENT_FOR_TILE
-          : LogEventName.ADD_RESPONSE_COMMENT_FOR_TILE
-        : isFirst
-          ? LogEventName.ADD_INITIAL_COMMENT_FOR_DOCUMENT
-          : LogEventName.ADD_RESPONSE_COMMENT_FOR_DOCUMENT;
-    } else {
-      event = focusTileId
-        ? LogEventName.DELETE_COMMENT_FOR_TILE
-        : LogEventName.DELETE_COMMENT_FOR_DOCUMENT;
-    }
+  public static logCommentEvent({ focusDocumentId, focusTileId, isFirst, commentText, action }: ILogComment) {
+    const eventMap: Record<CommentAction, LogEventName> = {
+      add: focusTileId
+            ? isFirst
+                ? LogEventName.ADD_INITIAL_COMMENT_FOR_TILE
+                : LogEventName.ADD_RESPONSE_COMMENT_FOR_TILE
+            : isFirst
+                ? LogEventName.ADD_INITIAL_COMMENT_FOR_DOCUMENT
+                : LogEventName.ADD_RESPONSE_COMMENT_FOR_DOCUMENT,
+      delete: focusTileId
+                ? LogEventName.DELETE_COMMENT_FOR_TILE
+                : LogEventName.DELETE_COMMENT_FOR_DOCUMENT
+    };
+    const event = eventMap[action];
 
     if (isSectionPath(focusDocumentId)) {
       Logger.logCurriculumEvent(event, focusDocumentId, { tileId: focusTileId, commentText });


### PR DESCRIPTION
~~Putting this up as a draft PR in the interest of not losing it. This was discussed as a possible enhancement for #1102, but it was decided not to include it there. As such, this PR should remain in draft mode and not be merged until after the 2.0.0 release.~~

Now that 2.0.0 is out the door I believe the time has come.