### PR TITLE
Mark event listeners passive to silence Chrome warnings

### DIFF
--- a/src/components/tools/tool-tile.tsx
+++ b/src/components/tools/tool-tile.tsx
@@ -179,8 +179,9 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
   }
 
   public componentDidMount() {
-    this.domElement?.addEventListener("touchstart", this.handlePointerDown, true);
-    this.domElement?.addEventListener("mousedown", this.handlePointerDown, true);
+    const options = { capture: true, passive: true };
+    this.domElement?.addEventListener("touchstart", this.handlePointerDown, options);
+    this.domElement?.addEventListener("mousedown", this.handlePointerDown, options);
   }
 
   public componentDidUpdate() {
@@ -202,8 +203,9 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
   public componentWillUnmount() {
     this.resizeObserver?.disconnect();
 
-    this.domElement?.removeEventListener("mousedown", this.handlePointerDown, true);
-    this.domElement?.removeEventListener("touchstart", this.handlePointerDown, true);
+    const options = { capture: true, passive: true };
+    this.domElement?.removeEventListener("mousedown", this.handlePointerDown, options);
+    this.domElement?.removeEventListener("touchstart", this.handlePointerDown, options);
   }
 
   public render() {


### PR DESCRIPTION
@lbondaryk pointed out that CLUE generates a number of warnings of the form `[Violation] Added non-passive event listener to a scroll-blocking <some> event. Consider marking event handler as 'passive' to make the page more responsive. See <URL>` when run in Chrome. (They've been there so long that the rest of us have essentially tuned them out.) I decided to take a quick look and it turns out that:

1. Most (all?) of them come from the `ToolTileComponent`
2. The event handler in question is, in fact, passive (i.e. it doesn't call `preventDefault()`).

Therefore, the fix is simply to mark the event handler passive, as suggested by the warning.
