### PR TITLE
getParentWithTypeName was not working as expected

### DIFF
--- a/src/utilities/mst-utils.test.ts
+++ b/src/utilities/mst-utils.test.ts
@@ -1,0 +1,76 @@
+import { getParentWithTypeName } from "./mst-utils";
+import { types, unprotect } from "mobx-state-tree";
+
+describe("getParentWithTypeName", () => {
+
+  it("works with direct child", () => {
+
+    const ChildModel = types.model("ChildModel", {});
+    const ParentModel = types.model("ParentModel", {
+      child: ChildModel
+    });
+
+    const child = ChildModel.create();
+    const parent = ParentModel.create({ child });
+
+    const result = getParentWithTypeName(child, "ParentModel");
+    expect(result).toEqual(parent);
+  });
+
+  it("works with intermediate node", () => {
+
+    const ChildModel = types.model("ChildModel", {});
+    const ParentModel = types.model("ParentModel", {
+      child: ChildModel
+    });
+    const GrandParentModel = types.model("GrandParentModel", {
+      child: ParentModel
+    });
+
+    const child = ChildModel.create();
+    const parent = ParentModel.create({ child });
+    const grandParent = GrandParentModel.create({ child: parent });
+
+    const result = getParentWithTypeName(child, "GrandParentModel");
+    expect(result).toEqual(grandParent);
+  });
+
+  it("works with intermediate array", () => {
+    const ChildModel = types.model("ChildModel", {});
+    const ParentModel = types.model("ParentModel", {
+      children: types.optional(types.array(ChildModel), [])
+    });
+
+    const child = ChildModel.create();
+    const parent = ParentModel.create();
+    // The parent is being modified outside of an action so it needs to be unprotected
+    unprotect(parent);
+    parent.children.push(child);
+
+    const result = getParentWithTypeName(child, "ParentModel");
+    expect(result).toEqual(parent);
+  });
+
+  it("returns undefined with a parentless child", () => {
+    const ChildModel = types.model("ChildModel", {});
+
+    const child = ChildModel.create();
+
+    const result = getParentWithTypeName(child, "ParentModel");
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined with an unmatched parent", () => {
+    const ChildModel = types.model("ChildModel", {});
+    const ParentModel = types.model("ParentModel", {
+      child: ChildModel
+    });
+
+    const child = ChildModel.create();
+    ParentModel.create({ child });
+
+    const result = getParentWithTypeName(child, "OtherModel");
+    expect(result).toBeUndefined();
+  });
+
+});

--- a/src/utilities/mst-utils.ts
+++ b/src/utilities/mst-utils.ts
@@ -1,4 +1,4 @@
-import { IAnyStateTreeNode, getParent, getType } from "mobx-state-tree";
+import { IAnyStateTreeNode, getParent, getType, hasParent } from "mobx-state-tree";
 import { DocumentContentModelType } from "../models/document/document-content";
 
 /**
@@ -7,11 +7,12 @@ import { DocumentContentModelType } from "../models/document/document-content";
  * parent type, which can cause circular reference errors in MST.
  */
 export function getParentWithTypeName(target: IAnyStateTreeNode, typeName: string): IAnyStateTreeNode | undefined {
-  let parent: IAnyStateTreeNode | null = getParent(target);
-  while (parent) {
+  let current = target;
+  while (hasParent(current)) {
+      const parent = getParent(current);
       const type = getType(parent);
       if (type.name === typeName) return parent;
-      parent = getParent(parent);
+      current = parent;
   }
   return undefined;
 }


### PR DESCRIPTION
Previously it would throw an exception if the typeName was not found.
This is because the MST getParent function would throw if there was no parent.