### PR TITLE
Dynamic add tile

### DIFF
--- a/src/lib/logger.test.ts
+++ b/src/lib/logger.test.ts
@@ -10,7 +10,7 @@ import { UserModel } from "../models/stores/user";
 import { WorkspaceModel, ProblemWorkspace, WorkspaceModelType, LearningLogWorkspace } from "../models/stores/workspace";
 import { defaultGeometryContent } from "../models/tools/geometry/geometry-content";
 import { JXGChange } from "../models/tools/geometry/jxg-changes";
-import { defaultTextContent } from "../models/tools/text/text-content";
+import { TextContentModel } from "../models/tools/text/text-content";
 import { IDragTileItem, ToolTileModel } from "../models/tools/tool-tile";
 import { createSingleTileContent } from "../utilities/test-utils";
 import { ProblemModelType } from "../models/curriculum/problem";
@@ -184,7 +184,7 @@ describe("authed logger", () => {
     });
 
     it("can log tile creation", (done) => {
-      const tile = ToolTileModel.create({ content: defaultTextContent() });
+      const tile = ToolTileModel.create({ content: TextContentModel.create() });
 
       mockXhr.post(/.*/, (req, res) => {
         const request = JSON.parse(req.body());
@@ -215,7 +215,7 @@ describe("authed logger", () => {
         visibility: "public"
       });
       stores.documents.add(document);
-      const tile = ToolTileModel.create({ content: defaultTextContent() });
+      const tile = ToolTileModel.create({ content: TextContentModel.create() });
       const tileId = tile.id;
       const documentKey = document.key;
       const commentText = "TeSt";
@@ -250,7 +250,7 @@ describe("authed logger", () => {
         visibility: "public"
       });
       stores.documents.add(document);
-      const tile = ToolTileModel.create({ content: defaultTextContent() });
+      const tile = ToolTileModel.create({ content: TextContentModel.create() });
       const tileId = tile.id;
       const documentKey = document.key;
       const commentText = "TeSt";

--- a/src/models/document/document-content.test.ts
+++ b/src/models/document/document-content.test.ts
@@ -5,7 +5,7 @@ import {
 import { SectionModel, SectionModelType } from "../curriculum/section";
 import { IDropRowInfo } from "../../models/document/document-content";
 import { cloneTileSnapshotWithoutId, IDragTileItem } from "../../models/tools/tool-tile";
-import { defaultTextContent } from "../tools/text/text-content";
+import { TextContentModel } from "../tools/text/text-content";
 import { IDocumentExportOptions } from "../tools/tool-content-info";
 import { safeJsonParse } from "../../utilities/js-utils";
 import placeholderImage from "../../assets/image_placeholder.png";
@@ -359,7 +359,7 @@ describe("DocumentContentModel -- sectioned documents --", () => {
 
   it("will remove placeholder tiles when adding a new tile in the last section", () => {
     // [Header:A, Placeholder, Header:B, Placeholder]
-    content.addTile("text", { text: "foo" });
+    content.addTile("text");
     // [Header:A, Placeholder, Header:B, Text]
     expect(content.rowCount).toBe(4);
     expect(isPlaceholderSection("A")).toBe(true);
@@ -367,14 +367,14 @@ describe("DocumentContentModel -- sectioned documents --", () => {
     expect(content.defaultInsertRow).toBe(4);
     expect(parsedContentExport()).toEqual({
       tiles: [
-        { content: { type: "Text", format: "html", text: ["<p>foo</p>"] } }
+        { content: { type: "Text", format: "html", text: ["<p></p>"] } }
       ]
     });
   });
 
   it("will remove placeholder tiles when adding a new tile in an interior section", () => {
     // [Header:A, Placeholder, Header:B, Text]
-    content.addTileContentInNewRow(defaultTextContent({ text: "foo" }), { rowIndex: 1 });
+    content.addTileContentInNewRow(TextContentModel.create({ text: "foo" }), { rowIndex: 1 });
     // [Header:A, Text, Header:B, Text]
     expect(content.rowCount).toBe(4);
     expect(isContentSection("A")).toBe(true);
@@ -383,7 +383,7 @@ describe("DocumentContentModel -- sectioned documents --", () => {
     expect(parsedContentExport()).toEqual({
       tiles: [
         { content: { type: "Text", format: "html", text: ["<p>foo</p>"] } },
-        { content: { type: "Text", format: "html", text: ["<p>foo</p>"] } }
+        { content: { type: "Text", format: "html", text: ["<p></p>"] } }
       ]
     });
   });
@@ -399,7 +399,7 @@ describe("DocumentContentModel -- sectioned documents --", () => {
     expect(content.defaultInsertRow).toBe(4);
     expect(parsedContentExport()).toEqual({
       tiles: [
-        { content: { type: "Text", format: "html", text: ["<p>foo</p>"] } }
+        { content: { type: "Text", format: "html", text: ["<p></p>"] } }
       ]
     });
 });
@@ -418,7 +418,7 @@ describe("DocumentContentModel -- sectioned documents --", () => {
 
   it("will add/remove placeholder rows when moving entire rows (3 => 1)", () => {
     // [Header:A, Placeholder, Header:B, Placeholder]
-    content.addTile("text", { text: "foo" });
+    content.addTile("text");
     // [Header:A, Placeholder, Header:B, Text]
     content.moveRowToIndex(3, 1);
     // [Header:A, Text, Header:B, Placeholder]
@@ -430,7 +430,7 @@ describe("DocumentContentModel -- sectioned documents --", () => {
     expect(content.defaultInsertRow).toBe(2);
     expect(parsedContentExport()).toEqual({
       tiles: [
-        { content: { type: "Text", format: "html", text: ["<p>foo</p>"] } }
+        { content: { type: "Text", format: "html", text: ["<p></p>"] } }
       ]
     });
   });
@@ -445,7 +445,7 @@ describe("DocumentContentModel -- sectioned documents --", () => {
     expect(content.defaultInsertRow).toBe(4);
     expect(parsedContentExport()).toEqual({
       tiles: [
-        { content: { type: "Text", format: "html", text: ["<p>foo</p>"] } }
+        { content: { type: "Text", format: "html", text: ["<p></p>"] } }
       ]
     });
   });
@@ -461,7 +461,7 @@ describe("DocumentContentModel -- sectioned documents --", () => {
     expect(content.defaultInsertRow).toBe(2);
     expect(parsedContentExport()).toEqual({
       tiles: [
-        { content: { type: "Text", format: "html", text: ["<p>foo</p>"] } }
+        { content: { type: "Text", format: "html", text: ["<p></p>"] } }
       ]
     });
   });
@@ -477,7 +477,7 @@ describe("DocumentContentModel -- sectioned documents --", () => {
     expect(content.defaultInsertRow).toBe(4);
     expect(parsedContentExport()).toEqual({
       tiles: [
-        { content: { type: "Text", format: "html", text: ["<p>foo</p>"] } }
+        { content: { type: "Text", format: "html", text: ["<p></p>"] } }
       ]
     });
   });
@@ -493,7 +493,7 @@ describe("DocumentContentModel -- sectioned documents --", () => {
     expect(content.defaultInsertRow).toBe(2);
     expect(parsedContentExport()).toEqual({
       tiles: [
-        { content: { type: "Text", format: "html", text: ["<p>foo</p>"] } }
+        { content: { type: "Text", format: "html", text: ["<p></p>"] } }
       ]
     });
   });
@@ -508,7 +508,7 @@ describe("DocumentContentModel -- sectioned documents --", () => {
     expect(isContentSection("B")).toBe(true);
     expect(parsedContentExport()).toEqual({
       tiles: [
-        { content: { type: "Text", format: "html", text: ["<p>foo</p>"] } }
+        { content: { type: "Text", format: "html", text: ["<p></p>"] } }
       ]
     });
   });
@@ -673,7 +673,7 @@ describe("DocumentContentModel", () => {
 
   it("can cloneWithUniqueIds()", () => {
     const content = DocumentContentModel.create({});
-    content.addTile("text", { text: "foo" });
+    content.addTile("text");
     const srcTileId = content.getRowByIndex(0)!.getTileIdAtIndex(0);
 
     const copy = cloneContentWithUniqueIds(content);

--- a/src/models/document/document-content.test.ts
+++ b/src/models/document/document-content.test.ts
@@ -359,7 +359,7 @@ describe("DocumentContentModel -- sectioned documents --", () => {
 
   it("will remove placeholder tiles when adding a new tile in the last section", () => {
     // [Header:A, Placeholder, Header:B, Placeholder]
-    content.addTextTile({ text: "foo", rowIndex: content.rowCount });
+    content.addTile("text", { text: "foo" });
     // [Header:A, Placeholder, Header:B, Text]
     expect(content.rowCount).toBe(4);
     expect(isPlaceholderSection("A")).toBe(true);
@@ -374,7 +374,7 @@ describe("DocumentContentModel -- sectioned documents --", () => {
 
   it("will remove placeholder tiles when adding a new tile in an interior section", () => {
     // [Header:A, Placeholder, Header:B, Text]
-    content.addTileContentInNewRow(defaultTextContent("foo"), { rowIndex: 1 });
+    content.addTileContentInNewRow(defaultTextContent({ text: "foo" }), { rowIndex: 1 });
     // [Header:A, Text, Header:B, Text]
     expect(content.rowCount).toBe(4);
     expect(isContentSection("A")).toBe(true);
@@ -418,7 +418,7 @@ describe("DocumentContentModel -- sectioned documents --", () => {
 
   it("will add/remove placeholder rows when moving entire rows (3 => 1)", () => {
     // [Header:A, Placeholder, Header:B, Placeholder]
-    content.addTextTile({ text: "foo", rowIndex: content.rowCount });
+    content.addTile("text", { text: "foo" });
     // [Header:A, Placeholder, Header:B, Text]
     content.moveRowToIndex(3, 1);
     // [Header:A, Text, Header:B, Placeholder]
@@ -673,7 +673,7 @@ describe("DocumentContentModel", () => {
 
   it("can cloneWithUniqueIds()", () => {
     const content = DocumentContentModel.create({});
-    content.addTextTile({ text: "foo" });
+    content.addTile("text", { text: "foo" });
     const srcTileId = content.getRowByIndex(0)!.getTileIdAtIndex(0);
 
     const copy = cloneContentWithUniqueIds(content);

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -1,6 +1,6 @@
 import { cloneDeep, each } from "lodash";
 import { types, getSnapshot, Instance, SnapshotIn } from "mobx-state-tree";
-import { kPlaceholderToolID, PlaceholderContentModel } from "../tools/placeholder/placeholder-content";
+import { PlaceholderContentModel } from "../tools/placeholder/placeholder-content";
 import { kTextToolID } from "../tools/text/text-content";
 import { getToolContentInfoById, getToolContentInfoByTool, IDocumentExportOptions } from "../tools/tool-content-info";
 import { ToolContentModelType } from "../tools/tool-types";
@@ -24,22 +24,6 @@ export interface INewTileOptions {
   rowHeight?: number;
   rowIndex?: number;
   locationInRow?: string;
-}
-
-export interface INewTitledTileOptions extends INewTileOptions {
-  title?: string;
-}
-
-export interface INewGeometryTileOptions extends INewTitledTileOptions {
-  addSidecarNotes?: boolean;
-}
-
-export interface INewTextTileOptions extends INewTileOptions {
-  text?: string;
-}
-
-export interface INewImageTileOptions extends INewTileOptions {
-  url?: string;
 }
 
 export interface INewRowTile {
@@ -680,7 +664,7 @@ export const DocumentContentModel = types
         }
       },
       addTile(tool: DocumentTool, options?: IDocumentContentAddTileOptions) {
-        const { title, addSidecarNotes, url, text, insertRowInfo } = options || {};
+        const { title, addSidecarNotes, url, insertRowInfo } = options || {};
         // for historical reasons, this function initially places new rows at
         // the end of the content and then moves them to the desired location.
         const addTileOptions = { rowIndex: self.rowCount };
@@ -688,12 +672,7 @@ export const DocumentContentModel = types
         const documents = getParentWithTypeName(self, "Documents") as DocumentsModelType;
         const unit = documents?.unit;
 
-        const newContent = contentInfo?.defaultContent({
-          title,
-          url,
-          text,
-          unit
-        });
+        const newContent = contentInfo?.defaultContent({ title, url, unit });
         const tileInfo = self.addTileContentInNewRow(
                               newContent,
                               { rowHeight: contentInfo?.defaultHeight, ...addTileOptions });

--- a/src/models/document/document.ts
+++ b/src/models/document/document.ts
@@ -20,7 +20,6 @@ export interface IDocumentAddTileOptions {
   title?: string;
   addSidecarNotes?: boolean;
   url?: string;
-  text?: string;
 }
 
 export const DocumentToolEnum = types.enumeration("tool",

--- a/src/models/document/document.ts
+++ b/src/models/document/document.ts
@@ -20,6 +20,7 @@ export interface IDocumentAddTileOptions {
   title?: string;
   addSidecarNotes?: boolean;
   url?: string;
+  text?: string;
 }
 
 export const DocumentToolEnum = types.enumeration("tool",

--- a/src/models/tools/drawing/drawing-content.test.ts
+++ b/src/models/tools/drawing/drawing-content.test.ts
@@ -4,6 +4,7 @@ import {
 } from "./drawing-content";
 import { IDrawingTileImportSpec } from "./drawing-import";
 import { DefaultToolbarSettings, DrawingToolChange, kDrawingToolID } from "./drawing-types";
+import { UnitModel } from "../../curriculum/unit";
 
 // mock Logger calls
 jest.mock("../../../lib/logger", () => {
@@ -49,7 +50,11 @@ describe('defaultDrawingContent', () => {
   });
   it('should return content with optional stamps', () => {
     const myStamps = [{ url: "my/stamp/url", width: 10, height: 10 }];
-    const content = defaultDrawingContent({ stamps: myStamps });
+    const unit = UnitModel.create({
+      title: "fake title",
+      defaultStamps: myStamps
+    });
+    const content = defaultDrawingContent({ unit });
     expect(content.type).toBe(kDrawingToolID);
     expect(content.stamps).toEqual(myStamps);
     expect(content.changes).toEqual([]);

--- a/src/models/tools/drawing/drawing-content.ts
+++ b/src/models/tools/drawing/drawing-content.ts
@@ -2,7 +2,7 @@ import { types, getSnapshot, Instance } from "mobx-state-tree";
 import { exportDrawingTileSpec } from "./drawing-export";
 import { importDrawingTileSpec, isDrawingTileImportSpec } from "./drawing-import";
 import { DrawingObjectDataType } from "./drawing-objects";
-import { ITileExportOptions, registerToolContentInfo } from "../tool-content-info";
+import { ITileExportOptions, registerToolContentInfo, IDefaultContentOptions } from "../tool-content-info";
 import { ToolMetadataModel, ToolContentModel } from "../tool-types";
 import { safeJsonParse } from "../../../utilities/js-utils";
 import { Logger, LogEventName } from "../../../lib/logger";
@@ -10,7 +10,6 @@ import {
   DefaultToolbarSettings, DrawingToolChange, DrawingToolCreateChange, DrawingToolDeleteChange, DrawingToolMoveChange,
   DrawingToolUpdate, DrawingToolUpdateChange, kDrawingDefaultHeight, kDrawingToolID, ToolbarModalButton, ToolbarSettings
 } from "./drawing-types";
-import { UnitModelType } from "../../curriculum/unit";
 
 export const computeStrokeDashArray = (type?: string, strokeWidth?: string|number) => {
   const dotted = isFinite(Number(strokeWidth)) ? Number(strokeWidth) : 0;
@@ -79,13 +78,13 @@ export const DrawingToolMetadataModel = ToolMetadataModel
   }));
 export type DrawingToolMetadataModelType = Instance<typeof DrawingToolMetadataModel>;
 
-export function defaultDrawingContent(options?: {unit?: UnitModelType}) {
+// This is only used directly by tests.
+export function defaultDrawingContent(options?: IDefaultContentOptions) {
   let stamps: StampModelType[] = [];
   if (options?.unit) {
     stamps = getSnapshot(options.unit.defaultStamps);
   }
   return DrawingContentModel.create({
-    type: kDrawingToolID,
     stamps,
     changes: []
   });

--- a/src/models/tools/drawing/drawing-content.ts
+++ b/src/models/tools/drawing/drawing-content.ts
@@ -1,4 +1,4 @@
-import { types, Instance } from "mobx-state-tree";
+import { types, getSnapshot, Instance } from "mobx-state-tree";
 import { exportDrawingTileSpec } from "./drawing-export";
 import { importDrawingTileSpec, isDrawingTileImportSpec } from "./drawing-import";
 import { DrawingObjectDataType } from "./drawing-objects";
@@ -10,6 +10,7 @@ import {
   DefaultToolbarSettings, DrawingToolChange, DrawingToolCreateChange, DrawingToolDeleteChange, DrawingToolMoveChange,
   DrawingToolUpdate, DrawingToolUpdateChange, kDrawingDefaultHeight, kDrawingToolID, ToolbarModalButton, ToolbarSettings
 } from "./drawing-types";
+import { UnitModelType } from "../../curriculum/unit";
 
 export const computeStrokeDashArray = (type?: string, strokeWidth?: string|number) => {
   const dotted = isFinite(Number(strokeWidth)) ? Number(strokeWidth) : 0;
@@ -78,10 +79,14 @@ export const DrawingToolMetadataModel = ToolMetadataModel
   }));
 export type DrawingToolMetadataModelType = Instance<typeof DrawingToolMetadataModel>;
 
-export function defaultDrawingContent(options?: {stamps: StampModelType[]}) {
+export function defaultDrawingContent(options?: {unit?: UnitModelType}) {
+  let stamps: StampModelType[] = [];
+  if (options?.unit) {
+    stamps = getSnapshot(options.unit.defaultStamps);
+  }
   return DrawingContentModel.create({
     type: kDrawingToolID,
-    stamps: options?.stamps || [],
+    stamps,
     changes: []
   });
 }

--- a/src/models/tools/geometry/geometry-content.ts
+++ b/src/models/tools/geometry/geometry-content.ts
@@ -4,7 +4,7 @@ import { Lambda } from "mobx";
 import { Optional } from "utility-types";
 import { SelectionStoreModelType } from "../../stores/selection";
 import { addLinkedTable, removeLinkedTable } from "../table-links";
-import { ITileExportOptions, registerToolContentInfo } from "../tool-content-info";
+import { ITileExportOptions, registerToolContentInfo, IDefaultContentOptions } from "../tool-content-info";
 import { ToolContentModel, ToolMetadataModel } from "../tool-types";
 import {
   getRowLabelFromLinkProps, IColumnProperties, ICreateRowsProperties, IRowProperties,
@@ -46,14 +46,15 @@ export interface IAxesParams {
   yMax: number;
 }
 
-export function defaultGeometryContent(overrides?: JXGProperties): GeometryContentModelType {
-  const { title, ...boardProps } = overrides || {};
+// This is only used directly by tests
+export function defaultGeometryContent(options?: IDefaultContentOptions): GeometryContentModelType {
+  const { title } = options || {};
   const changes: string[] = [];
   if (title) {
     const titleChange: JXGChange = { operation: "update", target: "metadata", properties: { title } };
     changes.push(JSON.stringify(titleChange));
   }
-  const boardChange = defaultGeometryBoardChange(boardProps);
+  const boardChange = defaultGeometryBoardChange();
   changes.push(JSON.stringify(boardChange));
   return GeometryContentModel.create({ changes });
 }

--- a/src/models/tools/image/image-content.test.ts
+++ b/src/models/tools/image/image-content.test.ts
@@ -21,7 +21,7 @@ describe("ImageContent", () => {
   });
 
   it("should support default non-placeholder content", () => {
-    const content = defaultImageContent("my/image/url");
+    const content = defaultImageContent({ url: "my/image/url" });
     expect(content.isUserResizable).toBe(true);
     expect(content.changeCount).toBe(1);
     expect(content.filename).toBeUndefined();

--- a/src/models/tools/image/image-content.ts
+++ b/src/models/tools/image/image-content.ts
@@ -9,8 +9,8 @@ import placeholderImage from "../../../assets/image_placeholder.png";
 
 export const kImageToolID = "Image";
 
-export function defaultImageContent(url?: string) {
-  const change = createChange(url || placeholderImage);
+export function defaultImageContent(options?: {url?: string}) {
+  const change = createChange(options?.url || placeholderImage);
   return ImageContentModel.create({
                             type: "Image",
                             changes: [change]

--- a/src/models/tools/image/image-content.ts
+++ b/src/models/tools/image/image-content.ts
@@ -1,7 +1,7 @@
 import { types, Instance, SnapshotOut } from "mobx-state-tree";
 import { createChange, ImageToolChange } from "./image-change";
 import { exportImageTileSpec, importImageTileSpec, isImageTileImportSpec } from "./image-import-export";
-import { ITileExportOptions, registerToolContentInfo } from "../tool-content-info";
+import { ITileExportOptions, registerToolContentInfo, IDefaultContentOptions } from "../tool-content-info";
 import { ToolContentModel } from "../tool-types";
 import { isPlaceholderImage } from "../../../utilities/image-utils";
 import { safeJsonParse } from "../../../utilities/js-utils";
@@ -9,12 +9,10 @@ import placeholderImage from "../../../assets/image_placeholder.png";
 
 export const kImageToolID = "Image";
 
-export function defaultImageContent(options?: {url?: string}) {
+// This is only used directly by tests
+export function defaultImageContent(options?: IDefaultContentOptions) {
   const change = createChange(options?.url || placeholderImage);
-  return ImageContentModel.create({
-                            type: "Image",
-                            changes: [change]
-                          });
+  return ImageContentModel.create({ changes: [change] });
 }
 
 export const ImageContentModel = ToolContentModel

--- a/src/models/tools/placeholder/placeholder-content.ts
+++ b/src/models/tools/placeholder/placeholder-content.ts
@@ -4,11 +4,8 @@ import { ToolContentModel } from "../tool-types";
 
 export const kPlaceholderToolID = "Placeholder";
 
-export function defaultPlaceholderContent(sectionId = "") {
-  return PlaceholderContentModel.create({
-    type: kPlaceholderToolID,
-    sectionId
-  });
+function defaultPlaceholderContent() {
+  return PlaceholderContentModel.create();
 }
 
 export const PlaceholderContentModel = ToolContentModel

--- a/src/models/tools/table/table-content.ts
+++ b/src/models/tools/table/table-content.ts
@@ -3,7 +3,7 @@ import { castArray, each } from "lodash";
 import { types, IAnyStateTreeNode, Instance, SnapshotIn, SnapshotOut } from "mobx-state-tree";
 import { exportTableContentAsJson } from "./table-export";
 import { getRowLabel, kSerializedXKey, canonicalizeValue, isLinkableValue } from "./table-model-types";
-import { IDocumentExportOptions, registerToolContentInfo } from "../tool-content-info";
+import { IDocumentExportOptions, registerToolContentInfo, IDefaultContentOptions } from "../tool-content-info";
 import { ToolMetadataModel, ToolContentModel } from "../tool-types";
 import { addLinkedTable, removeLinkedTable } from "../table-links";
 import { IDataSet, ICaseCreation, ICase, DataSet } from "../../data/data-set";
@@ -23,14 +23,16 @@ export const kLabelAttrName = "__label__";
 
 export const kTableDefaultHeight = 160;
 
-export function defaultTableContent(props?: { title?: string }) {
+// This is only used directly by tests
+export function defaultTableContent(props?: IDefaultContentOptions) {
   return TableContentModel.create({
-                            type: "Table",
                             name: props?.title,
                             columns: [
                               { name: "x" },
                               { name: "y" }
                             ]
+                          // This type cast could probably go away if MST was upgraded and
+                          // types.snapshotProcessor(TableContentModel, ...) was used
                           } as SnapshotIn<typeof TableContentModel>);
 }
 

--- a/src/models/tools/text/text-content.ts
+++ b/src/models/tools/text/text-content.ts
@@ -9,8 +9,8 @@ import {
 
 export const kTextToolID = "Text";
 
-export function defaultTextContent(initialText?: string) {
-  return TextContentModel.create({ text: initialText || "" });
+export function defaultTextContent(options?: {text?: string}) {
+  return TextContentModel.create({ text: options?.text || "" });
 }
 
 const MarkdownSerializer = new Markdown();

--- a/src/models/tools/text/text-content.ts
+++ b/src/models/tools/text/text-content.ts
@@ -2,16 +2,15 @@ import { types, Instance } from "mobx-state-tree";
 import { Value } from "slate";
 import Plain from "slate-plain-serializer";
 import Markdown from "slate-md-serializer";
-import { ITileExportOptions, registerToolContentInfo, IDefaultContentOptions } from "../tool-content-info";
+import { ITileExportOptions, registerToolContentInfo } from "../tool-content-info";
 import {
   deserializeValueFromLegacy, htmlToSlate, serializeValueToLegacy, slateToHtml, textToSlate
 } from "@concord-consortium/slate-editor";
 
 export const kTextToolID = "Text";
 
-// This is only used directly by tests.
-export function defaultTextContent(options?: IDefaultContentOptions) {
-  return TextContentModel.create({ text: options?.text });
+function defaultTextContent() {
+  return TextContentModel.create();
 }
 
 const MarkdownSerializer = new Markdown();

--- a/src/models/tools/text/text-content.ts
+++ b/src/models/tools/text/text-content.ts
@@ -2,15 +2,16 @@ import { types, Instance } from "mobx-state-tree";
 import { Value } from "slate";
 import Plain from "slate-plain-serializer";
 import Markdown from "slate-md-serializer";
-import { ITileExportOptions, registerToolContentInfo } from "../tool-content-info";
+import { ITileExportOptions, registerToolContentInfo, IDefaultContentOptions } from "../tool-content-info";
 import {
   deserializeValueFromLegacy, htmlToSlate, serializeValueToLegacy, slateToHtml, textToSlate
 } from "@concord-consortium/slate-editor";
 
 export const kTextToolID = "Text";
 
-export function defaultTextContent(options?: {text?: string}) {
-  return TextContentModel.create({ text: options?.text || "" });
+// This is only used directly by tests.
+export function defaultTextContent(options?: IDefaultContentOptions) {
+  return TextContentModel.create({ text: options?.text });
 }
 
 const MarkdownSerializer = new Markdown();

--- a/src/models/tools/tool-content-info.ts
+++ b/src/models/tools/tool-content-info.ts
@@ -13,10 +13,6 @@ export interface IDefaultContentOptions {
   // url is added so the CLUE core can add a image tile to the document when a user
   // drops an image on the document.
   url?: string;
-  // text is really only added to help with tests so the tests can use this
-  // code: `content.addTile("text", { text: "foo" });`
-  // Perhaps we can remove this.`
-  text?: string;
   // unit is added so the drawing tool can use a default set of stamps defined in
   // the unit
   unit?: UnitModelType;

--- a/src/models/tools/tool-content-info.ts
+++ b/src/models/tools/tool-content-info.ts
@@ -1,10 +1,26 @@
 import { ToolContentModel, ToolContentModelType, ToolMetadataModel } from "./tool-types";
+import { UnitModelType } from "../curriculum/unit";
 
 export interface IDMap {
   [id: string]: string;
 }
 export type ToolTileModelContentSnapshotPostProcessor =
               (content: any, idMap: IDMap, asTemplate?: boolean) => any;
+
+export interface IDefaultContentOptions {
+  // title is only currently used by the Geometry and Table tiles
+  title?: string;
+  // url is added so the CLUE core can add a image tile to the document when a user
+  // drops an image on the document.
+  url?: string;
+  // text is really only added to help with tests so the tests can use this
+  // code: `content.addTile("text", { text: "foo" });`
+  // Perhaps we can remove this.`
+  text?: string;
+  // unit is added so the drawing tool can use a default set of stamps defined in
+  // the unit
+  unit?: UnitModelType;
+}
 
 export interface IToolContentInfo {
   id: string;
@@ -15,7 +31,7 @@ export interface IToolContentInfo {
   addSidecarNotes?: boolean;
   defaultHeight?: number;
   exportNonDefaultHeight?: boolean;
-  defaultContent: (input?: any) => ToolContentModelType;
+  defaultContent: (options?: IDefaultContentOptions) => ToolContentModelType;
   snapshotPostProcessor?: ToolTileModelContentSnapshotPostProcessor;
 }
 

--- a/src/models/tools/tool-content-info.ts
+++ b/src/models/tools/tool-content-info.ts
@@ -10,7 +10,7 @@ export type ToolTileModelContentSnapshotPostProcessor =
 export interface IDefaultContentOptions {
   // title is only currently used by the Geometry and Table tiles
   title?: string;
-  // url is added so the CLUE core can add a image tile to the document when a user
+  // url is added so the CLUE core can add an image tile to the document when a user
   // drops an image on the document.
   url?: string;
   // unit is added so the drawing tool can use a default set of stamps defined in

--- a/tool-tiles.md
+++ b/tool-tiles.md
@@ -285,13 +285,9 @@ interface IProps {
     - Child components access stores too `hub`, `ui`, `appMode`.
 
 ## Adding a tool tile
-New tool tiles are added to a document using an action in the `DocumentContentModel` such as `addPlaceholderTile` or `addGeometryTile`. For example:
+New tool tiles can be added to a document using the `DocumentContentModel#addTile` action. For example:
 ```typescript
-addPlaceholderTile(sectionId?: string) {
-  const placeholderContentInfo = getToolContentInfoById(kPlaceholderToolID);
-  const content = placeholderContentInfo?.defaultContent(sectionId);
-  return self.addTileContentInNewRow(content, { rowIndex: self.rowCount });
-}
+content.addTile("text")
 ```
 
-A new action must be created when a tool tile is added to the project.
+The implementation of `addTile` looks up the tool content info registered by the Tool. Then uses the `defaultContent` function of the tool content info to create a content model for the tile. And finally wraps the content model in a `ToolTileModel` and adds that to the document.


### PR DESCRIPTION
This is second in the series of PRs to extract the tool code from the core. The goal of these PRs it to make it possible to add a new tool to CLUE without changing the core code. The only thing that should be required is importing a javascript library including the tool, and adding a reference to it in the app-config.json

The first PR is here: https://github.com/concord-consortium/collaborative-learning/pull/1113

This PR builds on the first by changing the `addTile` action in the `DocumentContentModel` to work with any tool that has been registered.  However it is still limited by the `DocumentTool` type of its `tool` parameter. That will be addressed later.

Supporting this required the following changes:
- unified set of parameters passed to all defaultContent functions
- supporting addSidecarNotes for any tool
- passing the unit to every defaultContent function if available, this is so the drawing tool can look up the default stamps in the unit
- the construction of Placeholder tiles was changed from using defaultPlaceholderContent to instead call PlaceholderContentModel.create() directly. This mean the sectionId of placeholder tiles didn't need to be added as an option to defaultContent functions.
- I removed the passing of the type field to the create constructors in the defaultContent functions.
   This was unnecessary, and reduces one more place where the type id is used directly, and also provides a better example of code to copy. In the previous PR there is now a test to make sure all of the tool content models correctly handle being created without an explicit type.
- the geometry defaultContent function was made less flexible, it can't be passed overrides anymore. This override
   feature was not being used and could be unsafe if one of the `IDefaultcontentOptions` properties overlapped.
- the text content model defaultContent function was adding a default value for the text field, this was removed becaues it is already handled by the model definition itself.

TODO:
- [x] add type for the parameter of defaultContent
- [x] deal with placeholder tile which takes a section id parameter, but no other tool does
- [x] update Geometry defaultContent method to be safer
- [x] check test coverage