### PR TITLE
Dynamic tool component

### DIFF
--- a/src/app-config.ts
+++ b/src/app-config.ts
@@ -8,3 +8,5 @@ import { ClueAppContentComponent } from "./clue/components/clue-app-content";
 export const AppContentComponent = ClueAppContentComponent;
 export { appIcons } from "./clue/app-icons";
 import "./clue/clue.sass";
+
+import "./register-tools";

--- a/src/app-config.ts
+++ b/src/app-config.ts
@@ -9,4 +9,5 @@ export const AppContentComponent = ClueAppContentComponent;
 export { appIcons } from "./clue/app-icons";
 import "./clue/clue.sass";
 
+// register the tools built into the application
 import "./register-tools";

--- a/src/components/document/canvas.test.tsx
+++ b/src/components/document/canvas.test.tsx
@@ -8,6 +8,9 @@ import { ProblemDocument } from "../../models/document/document-types";
 import { createStores } from "../../models/stores/stores";
 import { createSingleTileContent } from "../../utilities/test-utils";
 
+// This is needed so MST can deserialize snapshots referring to tools
+import "../../register-tools";
+
 var mockGetQueryState = jest.fn();
 jest.mock("react-query", () => ({
   useQueryClient: () => ({

--- a/src/components/toolbar.test.tsx
+++ b/src/components/toolbar.test.tsx
@@ -8,6 +8,9 @@ import { DocumentContentModel } from "../models/document/document-content";
 import { createStores } from "../models/stores/stores";
 import { ToolbarComponent, ToolbarConfig } from "./toolbar";
 
+// This is needed so MST can deserialize snapshots referring to tools
+import "../register-tools";
+
 describe("ToolbarComponent", () => {
 
   const stores = createStores();

--- a/src/components/tools/drawing-tool/drawing-tool.tsx
+++ b/src/components/tools/drawing-tool/drawing-tool.tsx
@@ -43,5 +43,4 @@ const DrawingToolComponent: React.FC<IProps> = (props) => {
     </div>
   );
 };
-(DrawingToolComponent as any).tileHandlesSelection = true;
 export default DrawingToolComponent;

--- a/src/components/tools/placeholder-tool/placeholder-tool.tsx
+++ b/src/components/tools/placeholder-tool/placeholder-tool.tsx
@@ -2,15 +2,11 @@ import React from "react";
 import { BaseComponent } from "../../base";
 import { getSectionPlaceholder } from "../../../models/curriculum/section";
 import { PlaceholderContentModelType } from "../../../models/tools/placeholder/placeholder-content";
-import { ToolTileModelType } from "../../../models/tools/tool-tile";
+import { IToolTileProps } from "../tool-tile";
 
 import "./placeholder-tool.sass";
 
-interface IProps {
-  model: ToolTileModelType;
-}
-
-export default class PlaceholderToolComponent extends BaseComponent<IProps> {
+export default class PlaceholderToolComponent extends BaseComponent<IToolTileProps> {
   public render() {
     return (
       <div className="placeholder-tool" onMouseDown={this.handleMouseDown} >

--- a/src/components/tools/table-tool/table-tool.tsx
+++ b/src/components/tools/table-tool/table-tool.tsx
@@ -144,7 +144,6 @@ const TableToolComponent: React.FC<IToolTileProps> = observer(({
   );
 });
 export default TableToolComponent;
-(TableToolComponent as any).tileHandlesSelection = true;
 
 // import { observer, inject } from "mobx-react";
 // import { Alert, Intent } from "@blueprintjs/core";

--- a/src/components/tools/table-tool/table-tool.tsx
+++ b/src/components/tools/table-tool/table-tool.tsx
@@ -186,7 +186,7 @@ export default TableToolComponent;
 // @observer
 // export default class TableToolComponent extends BaseComponent<IToolTileProps, IState> {
 
-//   public static tileHandlesSelection = true;
+//   public static tileHandlesOwnSelection = false;
 
 //   public state: IState = {
 //                   dataSet: DataSet.create()

--- a/src/components/tools/tool-tile.tsx
+++ b/src/components/tools/tool-tile.tsx
@@ -304,8 +304,12 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
       return;
     }
 
-    const ToolComponent = getToolContentInfoById(model.content.type).Component;
-    if (ToolComponent?.tileHandlesSelection) {
+    // Only select the tile if the tool doesn't handle it
+    // The name tileHandlesSelection is deceiving here it, it means the 
+    // tool doesn't handle it, so let the tile wrapper (this) handle 
+    // it.
+    const toolContentInfo = getToolContentInfoById(model.content.type);
+    if (toolContentInfo.tileHandlesSelection) {
       ui.setSelectedTile(model, {append: hasSelectionModifier(e)});
     }
   }

--- a/src/components/tools/tool-tile.tsx
+++ b/src/components/tools/tool-tile.tsx
@@ -56,7 +56,7 @@ interface IToolTileBaseProps {
   docId: string;  // ephemeral contentId for the DocumentContent
   documentContent: HTMLElement | null;
   isUserResizable: boolean;
-  scale?: number;
+  scale?: number; // This isn't used anymore as far as I can tell
   widthPct?: number;
   height?: number;
   model: ToolTileModelType;
@@ -363,7 +363,7 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
       }
     }
     // set the drag data
-    const { model, docId, scale } = this.props;
+    const { model, docId } = this.props;
     const ToolComponent = getToolContentInfoById(model.content.type).Component;
     // can't drag placeholder tiles
     if (ToolComponent === PlaceholderToolComponent) {
@@ -412,17 +412,9 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
     // TODO: should we create an array of drag images here?
 
     // set the drag image
-    const dragElt = e.target as HTMLElement;
-    // tool components can provide alternate dom node for drag image
-    // use default drag image for all tiles that don't specify drag image
-    const useToolDragImage = !!(ToolComponent && ToolComponent.getDragImageNode);
-    const dragImage = useToolDragImage
-                        ? ToolComponent!.getDragImageNode!(dragElt)
-                        : defaultDragImage;
-    const clientRect = dragElt.getBoundingClientRect();
-    const offsetX = useToolDragImage ? (e.clientX - clientRect.left) / (scale || 1): kDefaultDragImageWidth;
-    const offsetY = useToolDragImage ? (e.clientY - clientRect.top) / (scale || 1) : 0;
-    e.dataTransfer.setDragImage(dragImage, offsetX, offsetY);
+    const offsetX = kDefaultDragImageWidth;
+    const offsetY = 0;
+    e.dataTransfer.setDragImage(defaultDragImage, offsetX, offsetY);
   }
 
   private getDragTileItems(dragSrcContentId: string, tileIds: string[]) {

--- a/src/components/tools/tool-tile.tsx
+++ b/src/components/tools/tool-tile.tsx
@@ -3,22 +3,10 @@ import { observer, inject } from "mobx-react";
 import React from "react";
 import ResizeObserver from "resize-observer-polyfill";
 import { getDisabledFeaturesOfTile } from "../../models/stores/stores";
-import { kDrawingToolID } from "../../models/tools/drawing/drawing-types";
 import { cloneTileSnapshotWithNewId, IDragTileItem, IDragTiles, ToolTileModelType } from "../../models/tools/tool-tile";
-import { kGeometryToolID } from "../../models/tools/geometry/geometry-content";
-import { kTableToolID } from "../../models/tools/table/table-content";
-import { kTextToolID } from "../../models/tools/text/text-content";
-import { kImageToolID } from "../../models/tools/image/image-content";
 import { transformCurriculumImageUrl } from "../../models/tools/image/image-import-export";
-import { kPlaceholderToolID } from "../../models/tools/placeholder/placeholder-content";
-import { kUnknownToolID } from "../../models/tools/tool-types";
 import { getToolContentInfoById } from "../../models/tools/tool-content-info";
 import { BaseComponent } from "../base";
-import GeometryToolComponent from "./geometry-tool/geometry-tool";
-import TableToolComponent from "./table-tool/table-tool";
-import TextToolComponent from "./text-tool";
-import ImageToolComponent from "./image-tool";
-import DrawingToolComponent from "./drawing-tool/drawing-tool";
 import PlaceholderToolComponent from "./placeholder-tool/placeholder-tool";
 import { IToolApi, TileResizeEntry, ToolApiInterfaceContext } from "./tool-api";
 import { HotKeys } from "../../utilities/hot-keys";
@@ -91,21 +79,6 @@ export interface IToolTileProps extends IToolTileBaseProps, IRegisterToolApiProp
 
 interface IProps extends IToolTileBaseProps {
 }
-
-interface ToolComponentInfo {
-  ToolComponent: any;
-  toolTileClass: string;
-}
-const kToolComponentMap: Record<string, ToolComponentInfo> = {
-        [kPlaceholderToolID]: { ToolComponent: PlaceholderToolComponent, toolTileClass: "placeholder-tile" },
-        [kDrawingToolID]: { ToolComponent: DrawingToolComponent, toolTileClass: "drawing-tool-tile" },
-        [kGeometryToolID]: { ToolComponent: GeometryToolComponent, toolTileClass: "geometry-tool-tile" },
-        [kImageToolID]: { ToolComponent: ImageToolComponent, toolTileClass: "image-tool-tile" },
-        [kTableToolID]: { ToolComponent: TableToolComponent, toolTileClass: "table-tool-tile" },
-        [kTextToolID]: { ToolComponent: TextToolComponent, toolTileClass: "text-tool-tile" },
-        // TODO: should really have a separate unknown tool that shows an "unknown tile" message
-        [kUnknownToolID]: { ToolComponent: PlaceholderToolComponent, toolTileClass: "placeholder-tile" }
-      };
 
 interface IDragTileButtonProps {
   divRef: (instance: HTMLDivElement | null) => void;
@@ -212,7 +185,7 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
     const { model, readOnly, isUserResizable, widthPct } = this.props;
     const { hoverTile } = this.state;
     const { appConfig, ui } = this.stores;
-    const { ToolComponent, toolTileClass } = kToolComponentMap[model.content.type];
+    const { Component: ToolComponent, toolTileClass } = getToolContentInfoById(model.content.type);
     const isPlaceholderTile = ToolComponent === PlaceholderToolComponent;
     const isTileSelected = ui.isSelectedTile(model);
     const tileSelectedForComment = isTileSelected && ui.showChatPanel;
@@ -331,7 +304,7 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
       return;
     }
 
-    const ToolComponent = kToolComponentMap[model.content.type].ToolComponent;
+    const ToolComponent = getToolContentInfoById(model.content.type).Component;
     if (ToolComponent?.tileHandlesSelection) {
       ui.setSelectedTile(model, {append: hasSelectionModifier(e)});
     }
@@ -391,7 +364,7 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
     }
     // set the drag data
     const { model, docId, scale } = this.props;
-    const ToolComponent = kToolComponentMap[model.content.type].ToolComponent;
+    const ToolComponent = getToolContentInfoById(model.content.type).Component;
     // can't drag placeholder tiles
     if (ToolComponent === PlaceholderToolComponent) {
       e.preventDefault();
@@ -444,7 +417,7 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
     // use default drag image for all tiles that don't specify drag image
     const useToolDragImage = !!(ToolComponent && ToolComponent.getDragImageNode);
     const dragImage = useToolDragImage
-                        ? ToolComponent.getDragImageNode(dragElt)
+                        ? ToolComponent!.getDragImageNode!(dragElt)
                         : defaultDragImage;
     const clientRect = dragElt.getBoundingClientRect();
     const offsetX = useToolDragImage ? (e.clientX - clientRect.left) / (scale || 1): kDefaultDragImageWidth;

--- a/src/components/tools/tool-tile.tsx
+++ b/src/components/tools/tool-tile.tsx
@@ -50,13 +50,17 @@ export function extractDragTileType(dataTransfer: DataTransfer) {
   }
 }
 
+/**
+ * These props are used both by the ToolTileComponent and the components provided by the
+ * individual tools.
+ */
 interface IToolTileBaseProps {
   context: string;
   documentId?: string;  // permanent id (key) of the containing document
   docId: string;  // ephemeral contentId for the DocumentContent
   documentContent: HTMLElement | null;
   isUserResizable: boolean;
-  scale?: number; // This isn't used anymore as far as I can tell
+  scale?: number;
   widthPct?: number;
   height?: number;
   model: ToolTileModelType;
@@ -304,12 +308,9 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
       return;
     }
 
-    // Only select the tile if the tool doesn't handle it
-    // The name tileHandlesSelection is deceiving here it, it means the 
-    // tool doesn't handle it, so let the tile wrapper (this) handle 
-    // it.
+    // Select the tile if the tool doesn't handle the selection itself
     const toolContentInfo = getToolContentInfoById(model.content.type);
-    if (toolContentInfo.tileHandlesSelection) {
+    if (!toolContentInfo.tileHandlesOwnSelection) {
       ui.setSelectedTile(model, {append: hasSelectionModifier(e)});
     }
   }

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -8,6 +8,10 @@ import { TextContentModelType } from "../models/tools/text/text-content";
 import { createSingleTileContent } from "../utilities/test-utils";
 import { ToolTileModelType } from "../models/tools/tool-tile";
 import * as UrlParams from "../utilities/url-params";
+
+// This is needed so MST can deserialize snapshots referring to tools
+import "../register-tools";
+
 type QueryParams = UrlParams.QueryParams;
 
 describe("db", () => {

--- a/src/lib/logger.test.ts
+++ b/src/lib/logger.test.ts
@@ -17,6 +17,9 @@ import { ProblemModelType } from "../models/curriculum/problem";
 import { UIModel } from "../models/stores/ui";
 import { ENavTab } from "../models/view/nav-tabs";
 
+// This is needed so MST can deserialize snapshots referring to tools
+import "../register-tools";
+
 const investigation = InvestigationModel.create({
   ordinal: 1,
   title: "Investigation 1",

--- a/src/models/document/document-content.test.ts
+++ b/src/models/document/document-content.test.ts
@@ -10,6 +10,9 @@ import { IDocumentExportOptions } from "../tools/tool-content-info";
 import { safeJsonParse } from "../../utilities/js-utils";
 import placeholderImage from "../../assets/image_placeholder.png";
 
+// This is needed so MST can deserialize snapshots referring to tools
+import "../../register-tools";
+
 // mock uniqueId so we can recognize auto-generated IDs
 jest.mock("../../utilities/js-utils", () => {
   const { uniqueId, ...others } = jest.requireActual("../../utilities/js-utils");

--- a/src/models/document/document.test.ts
+++ b/src/models/document/document.test.ts
@@ -5,6 +5,9 @@ import { PersonalDocument, ProblemDocument } from "./document-types";
 import { createSingleTileContent } from "../../utilities/test-utils";
 import { TextContentModelType } from "../tools/text/text-content";
 
+// This is needed so MST can deserialize snapshots referring to tools
+import "../../register-tools";
+
 var mockUserContext = { appMode: "authed", classHash: "class-1" };
 var mockQueryData = { content: {}, metadata: { createdAt: 10 } };
 

--- a/src/models/stores/ui.test.ts
+++ b/src/models/stores/ui.test.ts
@@ -2,6 +2,9 @@ import { UIModel, UIModelType, UIDialogModelType } from "./ui";
 import { ProblemWorkspace, LearningLogWorkspace } from "./workspace";
 import { ToolTileModel } from "../tools/tool-tile";
 
+// This is needed so MST can deserialize snapshots referring to tools
+import "../../register-tools";
+
 describe("ui model", () => {
   let ui: UIModelType;
 

--- a/src/models/tools/drawing/drawing-content.ts
+++ b/src/models/tools/drawing/drawing-content.ts
@@ -2,14 +2,15 @@ import { types, getSnapshot, Instance } from "mobx-state-tree";
 import { exportDrawingTileSpec } from "./drawing-export";
 import { importDrawingTileSpec, isDrawingTileImportSpec } from "./drawing-import";
 import { DrawingObjectDataType } from "./drawing-objects";
-import { ITileExportOptions, registerToolContentInfo, IDefaultContentOptions } from "../tool-content-info";
+import { ITileExportOptions, IDefaultContentOptions } from "../tool-content-info";
 import { ToolMetadataModel, ToolContentModel } from "../tool-types";
 import { safeJsonParse } from "../../../utilities/js-utils";
 import { Logger, LogEventName } from "../../../lib/logger";
 import {
   DefaultToolbarSettings, DrawingToolChange, DrawingToolCreateChange, DrawingToolDeleteChange, DrawingToolMoveChange,
-  DrawingToolUpdate, DrawingToolUpdateChange, kDrawingDefaultHeight, kDrawingToolID, ToolbarModalButton, ToolbarSettings
+  DrawingToolUpdate, DrawingToolUpdateChange, kDrawingToolID, ToolbarModalButton, ToolbarSettings
 } from "./drawing-types";
+
 
 export const computeStrokeDashArray = (type?: string, strokeWidth?: string|number) => {
   const dotted = isFinite(Number(strokeWidth)) ? Number(strokeWidth) : 0;
@@ -78,7 +79,6 @@ export const DrawingToolMetadataModel = ToolMetadataModel
   }));
 export type DrawingToolMetadataModelType = Instance<typeof DrawingToolMetadataModel>;
 
-// This is only used directly by tests.
 export function defaultDrawingContent(options?: IDefaultContentOptions) {
   let stamps: StampModelType[] = [];
   if (options?.unit) {
@@ -264,13 +264,3 @@ export const DrawingContentModel = ToolContentModel
   });
 
 export type DrawingContentModelType = Instance<typeof DrawingContentModel>;
-
-registerToolContentInfo({
-  id: kDrawingToolID,
-  tool: "drawing",
-  modelClass: DrawingContentModel,
-  metadataClass: DrawingToolMetadataModel,
-  defaultHeight: kDrawingDefaultHeight,
-  exportNonDefaultHeight: true,
-  defaultContent: defaultDrawingContent
-});

--- a/src/models/tools/drawing/drawing-registration.ts
+++ b/src/models/tools/drawing/drawing-registration.ts
@@ -12,5 +12,6 @@ registerToolContentInfo({
   exportNonDefaultHeight: true,
   defaultContent: defaultDrawingContent,
   Component: DrawingToolComponent,
-  toolTileClass: "drawing-tool-tile"
+  toolTileClass: "drawing-tool-tile",
+  tileHandlesSelection: true
 });

--- a/src/models/tools/drawing/drawing-registration.ts
+++ b/src/models/tools/drawing/drawing-registration.ts
@@ -1,0 +1,16 @@
+import { registerToolContentInfo } from "../tool-content-info";
+import { DrawingContentModel, DrawingToolMetadataModel, defaultDrawingContent } from "./drawing-content";
+import { kDrawingToolID, kDrawingDefaultHeight } from "./drawing-types";
+import DrawingToolComponent from "../../../components/tools/drawing-tool/drawing-tool";
+
+registerToolContentInfo({
+  id: kDrawingToolID,
+  tool: "drawing",
+  modelClass: DrawingContentModel,
+  metadataClass: DrawingToolMetadataModel,
+  defaultHeight: kDrawingDefaultHeight,
+  exportNonDefaultHeight: true,
+  defaultContent: defaultDrawingContent,
+  Component: DrawingToolComponent,
+  toolTileClass: "drawing-tool-tile"
+});

--- a/src/models/tools/drawing/drawing-registration.ts
+++ b/src/models/tools/drawing/drawing-registration.ts
@@ -12,6 +12,5 @@ registerToolContentInfo({
   exportNonDefaultHeight: true,
   defaultContent: defaultDrawingContent,
   Component: DrawingToolComponent,
-  toolTileClass: "drawing-tool-tile",
-  tileHandlesSelection: true
+  toolTileClass: "drawing-tool-tile"
 });

--- a/src/models/tools/geometry/geometry-content.ts
+++ b/src/models/tools/geometry/geometry-content.ts
@@ -4,7 +4,7 @@ import { Lambda } from "mobx";
 import { Optional } from "utility-types";
 import { SelectionStoreModelType } from "../../stores/selection";
 import { addLinkedTable, removeLinkedTable } from "../table-links";
-import { ITileExportOptions, registerToolContentInfo, IDefaultContentOptions } from "../tool-content-info";
+import { ITileExportOptions, IDefaultContentOptions } from "../tool-content-info";
 import { ToolContentModel, ToolMetadataModel } from "../tool-types";
 import {
   getRowLabelFromLinkProps, IColumnProperties, ICreateRowsProperties, IRowProperties,
@@ -24,7 +24,7 @@ import { prepareToDeleteObjects } from "./jxg-polygon";
 import { getTableIdFromLinkChange } from "./jxg-table-link";
 import {
   isAxisArray, isBoard, isComment, isFreePoint, isImage, isLinkedPoint, isMovableLine, isPoint, isPointArray,
-  isPolygon, isVertexAngle, isVisibleEdge, kGeometryDefaultHeight, kGeometryDefaultPixelsPerUnit, toObj
+  isPolygon, isVertexAngle, isVisibleEdge, kGeometryDefaultPixelsPerUnit, toObj
 } from "./jxg-types";
 import { IDataSet } from "../../data/data-set";
 import { safeJsonParse, uniqueId } from "../../../utilities/js-utils";
@@ -1335,16 +1335,3 @@ export function getImageUrl(change?: JXGChange): string[] | undefined {
     return [change.properties.url, change.properties.filename];
   }
 }
-
-registerToolContentInfo({
-  id: kGeometryToolID,
-  tool: "geometry",
-  titleBase: "Graph",
-  modelClass: GeometryContentModel,
-  metadataClass: GeometryMetadataModel,
-  addSidecarNotes: true,
-  defaultHeight: kGeometryDefaultHeight,
-  exportNonDefaultHeight: true,
-  defaultContent: defaultGeometryContent,
-  snapshotPostProcessor: mapTileIdsInGeometrySnapshot
-});

--- a/src/models/tools/geometry/geometry-registration.ts
+++ b/src/models/tools/geometry/geometry-registration.ts
@@ -1,0 +1,20 @@
+import { registerToolContentInfo } from "../tool-content-info";
+import { kGeometryToolID, GeometryContentModel, GeometryMetadataModel,
+  defaultGeometryContent, mapTileIdsInGeometrySnapshot } from "./geometry-content";
+import { kGeometryDefaultHeight } from "./jxg-types";
+import GeometryToolComponent from "../../../components/tools/geometry-tool/geometry-tool";
+
+registerToolContentInfo({
+  id: kGeometryToolID,
+  tool: "geometry",
+  titleBase: "Graph",
+  modelClass: GeometryContentModel,
+  metadataClass: GeometryMetadataModel,
+  addSidecarNotes: true,
+  defaultHeight: kGeometryDefaultHeight,
+  exportNonDefaultHeight: true,
+  defaultContent: defaultGeometryContent,
+  snapshotPostProcessor: mapTileIdsInGeometrySnapshot,
+  Component: GeometryToolComponent,
+  toolTileClass: "geometry-tool-tile"
+});

--- a/src/models/tools/geometry/geometry-registration.ts
+++ b/src/models/tools/geometry/geometry-registration.ts
@@ -16,5 +16,6 @@ registerToolContentInfo({
   defaultContent: defaultGeometryContent,
   snapshotPostProcessor: mapTileIdsInGeometrySnapshot,
   Component: GeometryToolComponent,
-  toolTileClass: "geometry-tool-tile"
+  toolTileClass: "geometry-tool-tile",
+  tileHandlesOwnSelection: true
 });

--- a/src/models/tools/image/image-content.ts
+++ b/src/models/tools/image/image-content.ts
@@ -1,7 +1,7 @@
 import { types, Instance, SnapshotOut } from "mobx-state-tree";
 import { createChange, ImageToolChange } from "./image-change";
 import { exportImageTileSpec, importImageTileSpec, isImageTileImportSpec } from "./image-import-export";
-import { ITileExportOptions, registerToolContentInfo, IDefaultContentOptions } from "../tool-content-info";
+import { ITileExportOptions, IDefaultContentOptions } from "../tool-content-info";
 import { ToolContentModel } from "../tool-types";
 import { isPlaceholderImage } from "../../../utilities/image-utils";
 import { safeJsonParse } from "../../../utilities/js-utils";
@@ -83,10 +83,3 @@ export const ImageContentModel = ToolContentModel
 
 export type ImageContentModelType = Instance<typeof ImageContentModel>;
 export type ImageContentSnapshotOutType = SnapshotOut<typeof ImageContentModel>;
-
-registerToolContentInfo({
-  id: kImageToolID,
-  tool: "image",
-  modelClass: ImageContentModel,
-  defaultContent: defaultImageContent
-});

--- a/src/models/tools/image/image-registration.ts
+++ b/src/models/tools/image/image-registration.ts
@@ -8,5 +8,6 @@ registerToolContentInfo({
   modelClass: ImageContentModel,
   defaultContent: defaultImageContent,
   Component: ImageToolComponent,
-  toolTileClass: "image-tool-tile"
+  toolTileClass: "image-tool-tile",
+  tileHandlesOwnSelection: true
 });

--- a/src/models/tools/image/image-registration.ts
+++ b/src/models/tools/image/image-registration.ts
@@ -1,0 +1,12 @@
+import { registerToolContentInfo } from "../tool-content-info";
+import { kImageToolID, ImageContentModel, defaultImageContent } from "./image-content";
+import ImageToolComponent from "../../../components/tools/image-tool";
+
+registerToolContentInfo({
+  id: kImageToolID,
+  tool: "image",
+  modelClass: ImageContentModel,
+  defaultContent: defaultImageContent,
+  Component: ImageToolComponent,
+  toolTileClass: "image-tool-tile"
+});

--- a/src/models/tools/placeholder/placeholder-content.ts
+++ b/src/models/tools/placeholder/placeholder-content.ts
@@ -1,12 +1,7 @@
 import { types, Instance, SnapshotOut } from "mobx-state-tree";
-import { registerToolContentInfo } from "../tool-content-info";
 import { ToolContentModel } from "../tool-types";
 
 export const kPlaceholderToolID = "Placeholder";
-
-function defaultPlaceholderContent() {
-  return PlaceholderContentModel.create();
-}
 
 export const PlaceholderContentModel = ToolContentModel
   .named("PlaceholderContent")
@@ -22,10 +17,3 @@ export const PlaceholderContentModel = ToolContentModel
 
 export type PlaceholderContentModelType = Instance<typeof PlaceholderContentModel>;
 export type PlaceholderContentSnapshotOutType = SnapshotOut<typeof PlaceholderContentModel>;
-
-registerToolContentInfo({
-  id: kPlaceholderToolID,
-  tool: "placeholder",
-  modelClass: PlaceholderContentModel,
-  defaultContent: defaultPlaceholderContent
-});

--- a/src/models/tools/placeholder/placeholder-registration.ts
+++ b/src/models/tools/placeholder/placeholder-registration.ts
@@ -12,5 +12,6 @@ registerToolContentInfo({
   modelClass: PlaceholderContentModel,
   defaultContent: defaultPlaceholderContent,
   Component: PlaceholderToolComponent,
-  toolTileClass: "placeholder-tile"
+  toolTileClass: "placeholder-tile",
+  tileHandlesOwnSelection: true
 });

--- a/src/models/tools/placeholder/placeholder-registration.ts
+++ b/src/models/tools/placeholder/placeholder-registration.ts
@@ -1,0 +1,16 @@
+import { registerToolContentInfo } from "../tool-content-info";
+import { kPlaceholderToolID, PlaceholderContentModel } from "./placeholder-content";
+import PlaceholderToolComponent from "../../../components/tools/placeholder-tool/placeholder-tool";
+
+function defaultPlaceholderContent() {
+  return PlaceholderContentModel.create();
+}
+
+registerToolContentInfo({
+  id: kPlaceholderToolID,
+  tool: "placeholder",
+  modelClass: PlaceholderContentModel,
+  defaultContent: defaultPlaceholderContent,
+  Component: PlaceholderToolComponent,
+  toolTileClass: "placeholder-tile"
+});

--- a/src/models/tools/table/table-content.ts
+++ b/src/models/tools/table/table-content.ts
@@ -3,7 +3,7 @@ import { castArray, each } from "lodash";
 import { types, IAnyStateTreeNode, Instance, SnapshotIn, SnapshotOut } from "mobx-state-tree";
 import { exportTableContentAsJson } from "./table-export";
 import { getRowLabel, kSerializedXKey, canonicalizeValue, isLinkableValue } from "./table-model-types";
-import { IDocumentExportOptions, registerToolContentInfo, IDefaultContentOptions } from "../tool-content-info";
+import { IDocumentExportOptions, IDefaultContentOptions } from "../tool-content-info";
 import { ToolMetadataModel, ToolContentModel } from "../tool-types";
 import { addLinkedTable, removeLinkedTable } from "../table-links";
 import { IDataSet, ICaseCreation, ICase, DataSet } from "../../data/data-set";
@@ -720,14 +720,3 @@ export function mapTileIdsInTableSnapshot(snapshot: SnapshotOut<TableContentMode
   });
   return snapshot;
 }
-
-registerToolContentInfo({
-  id: kTableToolID,
-  tool: "table",
-  titleBase: "Table",
-  modelClass: TableContentModel,
-  metadataClass: TableMetadataModel,
-  defaultHeight: kTableDefaultHeight,
-  defaultContent: defaultTableContent,
-  snapshotPostProcessor: mapTileIdsInTableSnapshot
-});

--- a/src/models/tools/table/table-registration.ts
+++ b/src/models/tools/table/table-registration.ts
@@ -1,0 +1,18 @@
+import { registerToolContentInfo } from "../tool-content-info";
+import { kTableToolID, TableContentModel, TableMetadataModel, kTableDefaultHeight,
+  defaultTableContent, mapTileIdsInTableSnapshot } from "./table-content";
+  import TableToolComponent from "../../../components/tools/table-tool/table-tool";
+
+
+registerToolContentInfo({
+  id: kTableToolID,
+  tool: "table",
+  titleBase: "Table",
+  modelClass: TableContentModel,
+  metadataClass: TableMetadataModel,
+  defaultHeight: kTableDefaultHeight,
+  defaultContent: defaultTableContent,
+  snapshotPostProcessor: mapTileIdsInTableSnapshot,
+  Component: TableToolComponent,
+  toolTileClass: "table-tool-tile"
+});

--- a/src/models/tools/table/table-registration.ts
+++ b/src/models/tools/table/table-registration.ts
@@ -3,7 +3,6 @@ import { kTableToolID, TableContentModel, TableMetadataModel, kTableDefaultHeigh
   defaultTableContent, mapTileIdsInTableSnapshot } from "./table-content";
   import TableToolComponent from "../../../components/tools/table-tool/table-tool";
 
-
 registerToolContentInfo({
   id: kTableToolID,
   tool: "table",
@@ -14,6 +13,5 @@ registerToolContentInfo({
   defaultContent: defaultTableContent,
   snapshotPostProcessor: mapTileIdsInTableSnapshot,
   Component: TableToolComponent,
-  toolTileClass: "table-tool-tile",
-  tileHandlesSelection: true
+  toolTileClass: "table-tool-tile"
 });

--- a/src/models/tools/table/table-registration.ts
+++ b/src/models/tools/table/table-registration.ts
@@ -14,5 +14,6 @@ registerToolContentInfo({
   defaultContent: defaultTableContent,
   snapshotPostProcessor: mapTileIdsInTableSnapshot,
   Component: TableToolComponent,
-  toolTileClass: "table-tool-tile"
+  toolTileClass: "table-tool-tile",
+  tileHandlesSelection: true
 });

--- a/src/models/tools/text/text-content.ts
+++ b/src/models/tools/text/text-content.ts
@@ -2,10 +2,11 @@ import { types, Instance } from "mobx-state-tree";
 import { Value } from "slate";
 import Plain from "slate-plain-serializer";
 import Markdown from "slate-md-serializer";
-import { ITileExportOptions, registerToolContentInfo } from "../tool-content-info";
+import { ITileExportOptions } from "../tool-content-info";
 import {
   deserializeValueFromLegacy, htmlToSlate, serializeValueToLegacy, slateToHtml, textToSlate
 } from "@concord-consortium/slate-editor";
+
 
 export const kTextToolID = "Text";
 
@@ -85,10 +86,3 @@ export const TextContentModel = types
   }));
 
 export type TextContentModelType = Instance<typeof TextContentModel>;
-
-registerToolContentInfo({
-  id: kTextToolID,
-  tool: "text",
-  modelClass: TextContentModel,
-  defaultContent: defaultTextContent
-});

--- a/src/models/tools/text/text-content.ts
+++ b/src/models/tools/text/text-content.ts
@@ -10,7 +10,7 @@ import {
 
 export const kTextToolID = "Text";
 
-function defaultTextContent() {
+export function defaultTextContent() {
   return TextContentModel.create();
 }
 

--- a/src/models/tools/text/text-registration.ts
+++ b/src/models/tools/text/text-registration.ts
@@ -1,0 +1,12 @@
+import { registerToolContentInfo } from "../tool-content-info";
+import { kTextToolID, TextContentModel, defaultTextContent } from "./text-content";
+import TextToolComponent from "../../../components/tools/text-tool";
+
+registerToolContentInfo({
+  id: kTextToolID,
+  tool: "text",
+  modelClass: TextContentModel,
+  defaultContent: defaultTextContent,
+  Component: TextToolComponent,
+  toolTileClass: "text-tool-tile"
+});

--- a/src/models/tools/text/text-registration.ts
+++ b/src/models/tools/text/text-registration.ts
@@ -8,5 +8,6 @@ registerToolContentInfo({
   modelClass: TextContentModel,
   defaultContent: defaultTextContent,
   Component: TextToolComponent,
-  toolTileClass: "text-tool-tile"
+  toolTileClass: "text-tool-tile",
+  tileHandlesOwnSelection: true
 });

--- a/src/models/tools/tool-content-info.ts
+++ b/src/models/tools/tool-content-info.ts
@@ -21,9 +21,6 @@ export interface IDefaultContentOptions {
 
 type ToolComponentType = React.ComponentType<IToolTileProps> & {
   tileHandlesSelection?: boolean;
-  // This doesn't seem to be implemented anywhere, but perhaps it is added by a
-  // 3rd party library
-  getDragImageNode?: (dragElt: HTMLElement) => HTMLElement;
 };
 
 export interface IToolContentInfo {

--- a/src/models/tools/tool-content-info.ts
+++ b/src/models/tools/tool-content-info.ts
@@ -35,17 +35,14 @@ export interface IToolContentInfo {
   exportNonDefaultHeight?: boolean;
   snapshotPostProcessor?: ToolTileModelContentSnapshotPostProcessor;
   /**
-   * If the tile component doesn't call ui.setSelectedTile itself, then it can
-   * add  tileHandlesSelection: true and the tool-tile wrapper will handle the
-   * selection instead
-   * I think the name of this property is referring to ToolTileComponent as the "tile".
-   * So a tool is saying I don't handle my selection let my "tile" do it for me.
-   * Currently this is used by the table and drawing tools.
+   * By default the tool tile wrapper ToolTileComponent will handle the selection of the
+   * the tile when it gets a mouse down or touch start.
    *
-   * This approach was first added in the commit below, this helps clarify its purpose:
-   * https://github.com/concord-consortium/collaborative-learning/commit/d19b201dfd2c635aae2f30672c50610f90ba07a5
+   * If the tool wants to manage its own selection by calling ui.setSelectedTile,
+   * it should set tileHandlesOwnSelection to true. This will prevent ToolTileComponent
+   * from trying to set the selection.
    */
-  tileHandlesSelection?: boolean;
+  tileHandlesOwnSelection?: boolean;
 }
 
 interface IToolContentInfoMap {

--- a/src/models/tools/tool-content-info.ts
+++ b/src/models/tools/tool-content-info.ts
@@ -19,9 +19,7 @@ export interface IDefaultContentOptions {
   unit?: UnitModelType;
 }
 
-type ToolComponentType = React.ComponentType<IToolTileProps> & {
-  tileHandlesSelection?: boolean;
-};
+type ToolComponentType = React.ComponentType<IToolTileProps>;
 
 export interface IToolContentInfo {
   id: string;
@@ -36,6 +34,18 @@ export interface IToolContentInfo {
   defaultHeight?: number;
   exportNonDefaultHeight?: boolean;
   snapshotPostProcessor?: ToolTileModelContentSnapshotPostProcessor;
+  /**
+   * If the tile component doesn't call ui.setSelectedTile itself, then it can
+   * add  tileHandlesSelection: true and the tool-tile wrapper will handle the
+   * selection instead
+   * I think the name of this property is referring to ToolTileComponent as the "tile".
+   * So a tool is saying I don't handle my selection let my "tile" do it for me.
+   * Currently this is used by the table and drawing tools.
+   *
+   * This approach was first added in the commit below, this helps clarify its purpose:
+   * https://github.com/concord-consortium/collaborative-learning/commit/d19b201dfd2c635aae2f30672c50610f90ba07a5
+   */
+  tileHandlesSelection?: boolean;
 }
 
 interface IToolContentInfoMap {

--- a/src/models/tools/tool-content-info.ts
+++ b/src/models/tools/tool-content-info.ts
@@ -1,5 +1,6 @@
 import { ToolContentModel, ToolContentModelType, ToolMetadataModel } from "./tool-types";
 import { UnitModelType } from "../curriculum/unit";
+import { IToolTileProps } from "../../components/tools/tool-tile";
 
 export interface IDMap {
   [id: string]: string;
@@ -18,16 +19,25 @@ export interface IDefaultContentOptions {
   unit?: UnitModelType;
 }
 
+type ToolComponentType = React.ComponentType<IToolTileProps> & {
+  tileHandlesSelection?: boolean;
+  // This doesn't seem to be implemented anywhere, but perhaps it is added by a
+  // 3rd party library
+  getDragImageNode?: (dragElt: HTMLElement) => HTMLElement;
+};
+
 export interface IToolContentInfo {
   id: string;
   tool: string;
-  titleBase?: string;
   modelClass: typeof ToolContentModel;
+  defaultContent: (options?: IDefaultContentOptions) => ToolContentModelType;
+  Component: ToolComponentType;
+  toolTileClass: string;
+  titleBase?: string;
   metadataClass?: typeof ToolMetadataModel;
   addSidecarNotes?: boolean;
   defaultHeight?: number;
   exportNonDefaultHeight?: boolean;
-  defaultContent: (options?: IDefaultContentOptions) => ToolContentModelType;
   snapshotPostProcessor?: ToolTileModelContentSnapshotPostProcessor;
 }
 

--- a/src/models/tools/tool-tile.test.ts
+++ b/src/models/tools/tool-tile.test.ts
@@ -3,6 +3,9 @@ import { kDefaultMinWidth, ToolTileModel } from "./tool-tile";
 import { kUnknownToolID, UnknownContentModelType } from "./tool-types";
 import { getToolIds, getToolContentInfoById } from "./tool-content-info";
 
+// This is needed so we can check which tools are registered below
+import "../../register-tools";
+
 describe("ToolTileModel", () => {
 
   // Define the built in tool ids explicitly as strings.

--- a/src/models/tools/tool-tile.ts
+++ b/src/models/tools/tool-tile.ts
@@ -5,14 +5,7 @@ import { findMetadata, ToolContentUnion } from "./tool-types";
 import { DisplayUserTypeEnum } from "../stores/user-types";
 import { uniqueId } from "../../utilities/js-utils";
 
-// import all tools so they are registered
-import "./unknown-content";
 import { kPlaceholderToolID } from "./placeholder/placeholder-content";
-import "./geometry/geometry-content";
-import "./image/image-content";
-import "./table/table-content";
-import "./text/text-content";
-import "./drawing/drawing-content";
 
 // generally negotiated with app, e.g. single column width for table
 export const kDefaultMinWidth = 60;

--- a/src/models/tools/tool-types.test.ts
+++ b/src/models/tools/tool-types.test.ts
@@ -1,6 +1,9 @@
 import { isToolType } from "./tool-types";
 import { kTextToolID } from "./text/text-content";
 
+// This is needed so isToolType knows about the text tool
+import "../../register-tools";
+
 describe("ToolTypes", () => {
 
   it("isToolType() works as expected", () => {

--- a/src/models/tools/unknown-content.ts
+++ b/src/models/tools/unknown-content.ts
@@ -1,5 +1,6 @@
 import { registerToolContentInfo } from "./tool-content-info";
 import { kUnknownToolID, UnknownContentModel, UnknownContentModelType } from "./tool-types";
+import PlaceholderToolComponent from "../../components/tools/placeholder-tool/placeholder-tool";
 
 export function defaultContent(): UnknownContentModelType {
   return UnknownContentModel.create();
@@ -9,5 +10,8 @@ registerToolContentInfo({
   id: kUnknownToolID,
   tool: "unknown",
   modelClass: UnknownContentModel,
-  defaultContent
+  defaultContent,
+  // TODO: should really have a separate unknown tool that shows an "unknown tile" message
+  Component: PlaceholderToolComponent,
+  toolTileClass: "placeholder-tile"
 });

--- a/src/models/tools/unknown-content.ts
+++ b/src/models/tools/unknown-content.ts
@@ -13,5 +13,6 @@ registerToolContentInfo({
   defaultContent,
   // TODO: should really have a separate unknown tool that shows an "unknown tile" message
   Component: PlaceholderToolComponent,
-  toolTileClass: "placeholder-tile"
+  toolTileClass: "placeholder-tile",
+  tileHandlesOwnSelection: true
 });

--- a/src/register-tools.ts
+++ b/src/register-tools.ts
@@ -1,0 +1,8 @@
+// import all tools so they are registered
+import "./models/tools/unknown-content";
+import "./models/tools/placeholder/placeholder-registration";
+import "./models/tools/drawing/drawing-registration";
+import "./models/tools/text/text-registration";
+import "./models/tools/table/table-registration";
+import "./models/tools/image/image-registration";
+import "./models/tools/geometry/geometry-registration";


### PR DESCRIPTION
Part 3 of a series of PRs to extract the tool code from the core. The goal of these PRs it to make it possible to add a new tool to CLUE without changing the core code. The only thing that should be required is importing a javascript library including the tool, and adding a reference to it in the app-config.json

The previous PRs are:
- https://github.com/concord-consortium/collaborative-learning/pull/1113
- https://github.com/concord-consortium/collaborative-learning/pull/1115

The main feature of this PR is to use the tool content info registry to store and lookup the tool component and css class used by the tool component.  

Taking that approach resulted in a several other things that needed to be changed:
- the registration of tools with the tool content info registry needed to be split from the tool's content model module. This was because the addition of the tool's component meant importing it, and that started a circular dependency loop. Mainly because the tool components load in other models and stores which in turn load in the tool's content.
- the registration of all of the tools is moved to its own module which is only imported after the rest of the app is initialized in `app-config.ts`. This prevents other circular dependencies. Previously this tool registration happened when the `tool-tile.ts` module imported each of the tool content model modules.
- because the registrations are moved to their own top level module, several tests had to be updated to explicitly import this module so the tools would be registered. Otherwise the test could not use MST to create a document from a snapshot that includes a tool.
- create a ToolComponent type so core code working with these components knows what to expect including which properties it can pass to the component. And likewise this helps tool implementations to make sure they support the required properties.
- move the `tileHandlesSelection` from a static field on tool components into the tool content info. This wasn't strictly necessary, but it makes the definition of the tool component type easier.  The name of this property is confusing, the current PR has a comment describing it. Perhaps the PR should rename this property. The 2 tools using this are the table tool and drawing tool.
- remove the `getDragImageNode` static function on tool components. This function was being conditionally called, but none of the tool components provided an implementation. If this or something like it is needed it could be probably be re-implemented using a property on the tool content info.

TODO:
- [ ] resolve issue with the name of `tileHandlesSelection`
- [ ] resolve issue with the `scale` property of ToolTileComponent, this property is not used anymore now that the `getDragImageNode` is removed.