### PR TITLE
try to fix a flakey test where delete dialog wasn't showing

### DIFF
--- a/cypress/support/elements/clue/cCanvas.js
+++ b/cypress/support/elements/clue/cCanvas.js
@@ -205,25 +205,33 @@ class ClueCanvas {
             });
     }
 
+    selectLastTileOfType(tileType) {
+      let tileElement = null;
+
+      switch (tileType) {
+          case 'text':
+              textToolTile.getTextTile().last().focus();
+              tileElement = cy.get('.text-tool-wrapper').parent();
+              break;
+          case 'graph':
+              tileElement = graphToolTile.getGraphTile().last().click({ force: true }).parent();
+              break;
+          case 'image':
+              tileElement = imageToolTile.getImageTile().last().click({ force: true }).parent();
+              break;
+          case 'draw':
+              // For some reason the getDrawTile returns the tool tile component
+              tileElement = drawToolTile.getDrawTile().last().click({ force: true });
+              break;
+          case 'table':
+              tileElement = tableToolTile.getTableTile().last().click({ force: true }).parent();
+              break;
+      }
+      tileElement.should('have.class','selected');
+    }
+
     deleteTile(tile) {
-        switch (tile) {
-            case 'text':
-                textToolTile.getTextTile().last().focus();
-                cy.get('.text-tool-wrapper').parent().should('have.class','selected');
-                break;
-            case 'graph':
-                graphToolTile.getGraphTile().last().click({ force: true });
-                break;
-            case 'image':
-                imageToolTile.getImageTile().last().click({ force: true });
-                break;
-            case 'draw':
-                drawToolTile.getDrawTile().last().click({ force: true });
-                break;
-            case 'table':
-                tableToolTile.getTableTile().last().click({ force: true });
-                break;
-        }
+        this.selectLastTileOfType(tile);
         this.getDeleteTool().click({ force: true });
         cy.get('.ReactModalPortal .modal-footer .modal-button.default').click();
     }


### PR DESCRIPTION
I'm not sure this change will fix the flakey-ness, but it is my best guess.

Here is the dashboard run where it couldn't find the delete dialog
https://dashboard.cypress.io/projects/3pbqac/runs/2218/test-results/215e4e23-6f88-483f-ad02-3b5505cfaf20

The fix here is to confirm the element is selected before clicking the delete tool.
It seems possible that the click on the tile followed by the delete tool click happened too fast.