### PR TITLE
a test failed because text was not saved before the page navigation

### DIFF
--- a/cypress/support/elements/clue/TextToolTile.js
+++ b/cypress/support/elements/clue/TextToolTile.js
@@ -8,6 +8,11 @@ class TextToolTile {
     enterText(text){
         this.getTextTile().last().focus();
         this.getTextEditor().last().type(text);
+        // This doesn't guarantee the text has been saved to firebase. It would be best
+        // if there was a way to tell if it has been saved perhaps by some saving indicator
+        // in the UI. Or reaching into app to find some saving state.
+        // In the meantime a short wait is added to decrease the chances this might happen
+        cy.wait(300);
     }
 
     deleteText(text){


### PR DESCRIPTION
This adds a wait after typing the text.
There doesn't seem to be any debouncing of the text so it should be saved quickly.
In most cases this seemed to be working, hopefully the wait will decrease the failures.
As the comment says, ideally there would be a way to make sure the data was actually
saved.