### PR TITLE
Mst toolbar

### DIFF
--- a/src/components/delete-button.test.tsx
+++ b/src/components/delete-button.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import React from "react";
 import Modal from "react-modal";
 import { ModalProvider } from "react-modal-hook";
+import { ToolButtonModel } from "../models/tools/tool-button";
 import { DeleteButton } from "./delete-button";
 
 describe("DeleteButton", () => {
@@ -27,6 +28,7 @@ describe("DeleteButton", () => {
           isDefault: false,
           isTileTool: false
         };
+  const toolButton = ToolButtonModel.create(buttonConfig);
 
   it("renders when disabled", () => {
     render(
@@ -34,7 +36,7 @@ describe("DeleteButton", () => {
         <div className="app"/>
         <ModalProvider>
           <DeleteButton
-            config={buttonConfig}
+            toolButton={toolButton}
             isActive={false} isDisabled={true}
             onSetToolActive={onSetToolActive}
             onClick={onClick}
@@ -60,8 +62,7 @@ describe("DeleteButton", () => {
         <div className="app"/>
         <ModalProvider>
           <DeleteButton
-            config={buttonConfig}
-            ToolIcon={() => null}
+            toolButton={toolButton}
             isActive={false} isDisabled={false}
             onSetToolActive={onSetToolActive}
             onClick={onClick}
@@ -97,7 +98,7 @@ describe("DeleteButton", () => {
         <div className="app"/>
         <ModalProvider>
           <DeleteButton
-            config={buttonConfig}
+            toolButton={toolButton}
             isActive={false} isDisabled={false}
             onSetToolActive={onSetToolActive}
             onClick={handleClick}

--- a/src/components/delete-button.tsx
+++ b/src/components/delete-button.tsx
@@ -1,6 +1,5 @@
 import classNames from "classnames";
 import React from "react";
-import { DocumentTool } from "../models/document/document";
 import { IButtonProps } from "./tool-button";
 import { useCautionAlert } from "./utilities/use-caution-alert";
 
@@ -14,7 +13,6 @@ export const DeleteButton: React.FC<IProps> =
       onSetShowDeleteTilesConfirmationAlert, onDeleteSelectedTiles }) => {
 
   const { name, title, Icon } = toolButton;
-  const toolName = name as DocumentTool;
 
   const handleMouseDown = () => {
     !isDisabled && onSetToolActive(toolButton, true);
@@ -35,7 +33,7 @@ export const DeleteButton: React.FC<IProps> =
   });
   onSetShowDeleteTilesConfirmationAlert(showAlert);
 
-  const classes = classNames("tool", "delete-button", toolName,
+  const classes = classNames("tool", "delete-button", name,
                             { active: isActive }, isDisabled ? "disabled" : "enabled");
   return (
     <div className={classes} data-testid="delete-button"

--- a/src/components/delete-button.tsx
+++ b/src/components/delete-button.tsx
@@ -10,18 +10,18 @@ interface IProps extends IButtonProps {
 }
 
 export const DeleteButton: React.FC<IProps> =
-  ({ config, ToolIcon, isActive, isDisabled, onSetToolActive, onClick,
+  ({ toolButton, isActive, isDisabled, onSetToolActive, onClick,
       onSetShowDeleteTilesConfirmationAlert, onDeleteSelectedTiles }) => {
 
-  const { name, title } = config;
+  const { name, title, Icon } = toolButton;
   const toolName = name as DocumentTool;
 
   const handleMouseDown = () => {
-    !isDisabled && onSetToolActive(toolName, true);
+    !isDisabled && onSetToolActive(toolButton, true);
   };
 
   const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    !isDisabled && onClick(e, toolName);
+    !isDisabled && onClick(e, toolButton);
   };
 
   const AlertContent = () => {
@@ -43,7 +43,7 @@ export const DeleteButton: React.FC<IProps> =
         title={title}
         onMouseDown={handleMouseDown}
         onClick={handleClick}>
-      {ToolIcon && <ToolIcon />}
+      {Icon && <Icon />}
     </div>
   );
 };

--- a/src/components/document/document-workspace.tsx
+++ b/src/components/document/document-workspace.tsx
@@ -1,5 +1,4 @@
 import { inject, observer } from "mobx-react";
-import { getSnapshot } from "mobx-state-tree";
 import React from "react";
 import { DocumentComponent, WorkspaceSide } from "../../components/document/document";
 import { GroupVirtualDocumentComponent } from "../../components/document/group-virtual-document";
@@ -135,7 +134,8 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps> {
     const groupVirtualDocument = comparisonDocumentKey
       && groups.virtualDocumentForGroup(comparisonDocumentKey);
 
-    const toolbar = appConfig && getSnapshot(appConfig.toolbar);
+    // Switched to be the toolbar model object (which is really just a types.array)
+    const toolbar = appConfig.toolbar;
 
     if (!primaryDocument) {
       return this.renderDocument("single-workspace", "primary");

--- a/src/components/document/document-workspace.tsx
+++ b/src/components/document/document-workspace.tsx
@@ -134,7 +134,6 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps> {
     const groupVirtualDocument = comparisonDocumentKey
       && groups.virtualDocumentForGroup(comparisonDocumentKey);
 
-    // Switched to be the toolbar model object (which is really just a types.array)
     const toolbar = appConfig.toolbar;
 
     if (!primaryDocument) {

--- a/src/components/document/document.tsx
+++ b/src/components/document/document.tsx
@@ -6,7 +6,7 @@ import FileSaver from "file-saver";
 import { DocumentFileMenu } from "./document-file-menu";
 import { MyWorkDocumentOrBrowser } from "./document-or-browser";
 import { BaseComponent, IBaseProps } from "../base";
-import { ToolbarConfig } from "../toolbar";
+import { ToolbarModelType } from "../../models/stores/app-config-model";
 import { DocumentModelType } from "../../models/document/document";
 import { LearningLogDocument, LearningLogPublication } from "../../models/document/document-types";
 import { SupportType, TeacherSupportModelType, AudienceEnum } from "../../models/stores/supports";
@@ -32,7 +32,7 @@ interface IProps extends IBaseProps {
   onDeleteDocument?: (document: DocumentModelType) => void;
   onPublishSupport?: (document: DocumentModelType) => void;
   onPublishDocument?: (document: DocumentModelType) => void;
-  toolbar?: ToolbarConfig;
+  toolbar?: ToolbarModelType;
   side: WorkspaceSide;
   readOnly?: boolean;
 }

--- a/src/components/document/editable-document-content.tsx
+++ b/src/components/document/editable-document-content.tsx
@@ -1,5 +1,6 @@
 import React, { useContext, useRef, useState } from "react";
 import classNames from "classnames";
+import { clone } from "mobx-state-tree";
 import { AppConfigContext } from "../../app-config-context";
 import { CanvasComponent } from "./canvas";
 import { DocumentContextReact } from "./document-context";
@@ -11,7 +12,6 @@ import { EditableToolApiInterfaceRef, EditableToolApiInterfaceRefContext } from 
 import { DocumentModelType } from "../../models/document/document";
 import { ProblemDocument } from "../../models/document/document-types";
 import { WorkspaceMode } from "../../models/stores/workspace";
-import { clone } from "mobx-state-tree";
 import { ToolbarModelType } from "../../models/stores/app-config-model";
 
 import "./editable-document-content.scss";

--- a/src/components/document/editable-document-content.tsx
+++ b/src/components/document/editable-document-content.tsx
@@ -18,7 +18,7 @@ import "./editable-document-content.scss";
 
 interface IToolbarProps {
   document: DocumentModelType;
-  toolbar?: ToolbarModelType;
+  toolbar: ToolbarModelType;
 }
 
 const DocumentToolbar: React.FC<IToolbarProps> = ({ toolbar, ...others }) => {
@@ -26,17 +26,15 @@ const DocumentToolbar: React.FC<IToolbarProps> = ({ toolbar, ...others }) => {
 
   // The toolbar prop represents the app's configuration of the toolbar
   // It is cloned here in the document so changes to one document's toolbar
-  // to not effect another document's toolbar.
+  // do not effect another document's toolbar.
   // Currently the toolbar model is not modified, but it seems safer to do this.
   // The cloned model is stored in state so it isn't recreated on each render
-  const [toolbarModel] = useState<ToolbarModelType | undefined>(() => {
+  const [toolbarModel] = useState<ToolbarModelType>(() => {
       // The new model is passed the appIcons as its environment, so the model
       // can lookup an app level Icon if needed.
       return clone(toolbar, { appIcons: appConfig.appIcons });
   });
-  return toolbarModel
-          ? <ToolbarComponent key="toolbar" toolbarModel={toolbarModel} {...others} />
-          : null;
+  return <ToolbarComponent key="toolbar" toolbarModel={toolbarModel} {...others} />;
 };
 
 interface IOneUpCanvasProps {

--- a/src/components/document/editable-document-content.tsx
+++ b/src/components/document/editable-document-content.tsx
@@ -23,18 +23,15 @@ interface IToolbarProps {
 
 const DocumentToolbar: React.FC<IToolbarProps> = ({ toolbar, ...others }) => {
   const appConfig = useContext(AppConfigContext);
-  // cloning the workspace level toolbar model and adding in the appIcons into its
-  // environment is a way to make this more MST based
-  // However being a functional component, it means this clone will happen each time
-  // the component is re-rendered. One way to do this is to put computed using 
-  // const [toolbarModel] = useState(() => { // clone initial toolbar })
-  // that approach means it will only be computed once.
-  // I looked at moving this up a level and it doesn't seem good. Putting it here means the 
-  // clone will only happen the DocumentToolbar is added to a document.
+
+  // The toolbar prop represents the app's configuration of the toolbar
+  // It is cloned here in the document so changes to one document's toolbar
+  // to not effect another document's toolbar.
+  // Currently the toolbar model is not modified, but it seems safer to do this.
+  // The cloned model is stored in state so it isn't recreated on each render
   const [toolbarModel] = useState<ToolbarModelType | undefined>(() => {
-      // We clone the global toolbar configuration to make a model for each document
-      // this way the ToolbarComponent can modify its toolbar model without affecting 
-      // other documents
+      // The new model is passed the appIcons as its environment, so the model
+      // can lookup an app level Icon if needed.
       return clone(toolbar, { appIcons: appConfig.appIcons });
   });
   return toolbarModel

--- a/src/components/document/editable-document-content.tsx
+++ b/src/components/document/editable-document-content.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useRef, useState } from "react";
 import classNames from "classnames";
-import { AppConfigContext, IAppConfigContext } from "../../app-config-context";
+import { AppConfigContext } from "../../app-config-context";
 import { CanvasComponent } from "./canvas";
 import { DocumentContextReact } from "./document-context";
 import { FourUpComponent } from "../four-up";
@@ -11,8 +11,6 @@ import { EditableToolApiInterfaceRef, EditableToolApiInterfaceRefContext } from 
 import { DocumentModelType } from "../../models/document/document";
 import { ProblemDocument } from "../../models/document/document-types";
 import { WorkspaceMode } from "../../models/stores/workspace";
-import { getToolContentInfoByTool } from "../../models/tools/tool-content-info";
-import { IToolButtonConfig } from "../tool-button";
 import { clone } from "mobx-state-tree";
 import { ToolbarModelType } from "../../models/stores/app-config-model";
 

--- a/src/components/tool-button.test.tsx
+++ b/src/components/tool-button.test.tsx
@@ -1,6 +1,7 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
+import { ToolButtonModel } from "../models/tools/tool-button";
 import { ToolButtonComponent } from "./tool-button";
 
 describe("ToolButtonComponent", () => {
@@ -20,15 +21,17 @@ describe("ToolButtonComponent", () => {
   });
 
   it("renders disabled select tool", () => {
+    const toolButton = ToolButtonModel.create({
+      name: "select",
+      title: "Select",
+      iconId: "icon-select-tool",
+      isDefault: true,
+      isTileTool: false
+    });
+
     render(
       <ToolButtonComponent
-        config={{
-          name: "select",
-          title: "Select",
-          iconId: "icon-select-tool",
-          isDefault: true,
-          isTileTool: false
-        }}
+        toolButton={toolButton}
         isActive={false}
         isDisabled={true}
         onSetToolActive={onSetToolActive}
@@ -47,15 +50,16 @@ describe("ToolButtonComponent", () => {
   });
 
   it("renders enabled text tool", () => {
+    const toolButton = ToolButtonModel.create({
+      name: "text",
+      title: "Text",
+      isDefault: false,
+      isTileTool: true
+    });
+
     render(
       <ToolButtonComponent
-        config={{
-          name: "text",
-          title: "Text",
-          isDefault: false,
-          isTileTool: true
-        }}
-        ToolIcon={() => null}
+        toolButton={toolButton}
         isActive={false}
         isDisabled={false}
         onSetToolActive={onSetToolActive}

--- a/src/components/tool-button.test.tsx
+++ b/src/components/tool-button.test.tsx
@@ -4,6 +4,9 @@ import React from "react";
 import { ToolButtonModel } from "../models/tools/tool-button";
 import { ToolButtonComponent } from "./tool-button";
 
+// This is needed so the icon for the text tool can be found
+import "../register-tools";
+
 describe("ToolButtonComponent", () => {
 
   const onSetToolActive = jest.fn();

--- a/src/components/tool-button.tsx
+++ b/src/components/tool-button.tsx
@@ -1,42 +1,36 @@
 import classNames from "classnames";
 import React from "react";
-import { IconComponent } from "../app-config-context";
 import { DocumentTool } from "../models/document/document";
-import { ToolButtonSnapshot } from "../models/tools/tool-button";
-
-export type IToolButtonConfig = ToolButtonSnapshot & {
-  icon?: IconComponent;
-};
+import { ToolButtonModelType } from "../models/tools/tool-button";
 
 export interface IButtonProps {
-  config: IToolButtonConfig;
-  ToolIcon?: IconComponent;
+  toolButton: ToolButtonModelType;
   isActive: boolean;
   isDisabled: boolean;
-  onSetToolActive: (tool: DocumentTool, isActive: boolean) => void;
-  onClick: (e: React.MouseEvent<HTMLDivElement>, tool: DocumentTool) => void;
+  onSetToolActive: (tool: ToolButtonModelType, isActive: boolean) => void;
+  onClick: (e: React.MouseEvent<HTMLDivElement>, tool: ToolButtonModelType) => void;
 }
 
 export interface IToolButtonProps extends IButtonProps {
-  onDragStart: (e: React.DragEvent<HTMLDivElement>, tool: DocumentTool) => void;
+  onDragStart: (e: React.DragEvent<HTMLDivElement>, tool: ToolButtonModelType) => void;
   onShowDropHighlight: () => void;
   onHideDropHighlight: () => void;
 }
 
 export const ToolButtonComponent: React.FC<IToolButtonProps> =
-  ({ config, ToolIcon, isActive, isDisabled, onSetToolActive, onClick, onDragStart,
+  ({ toolButton, isActive, isDisabled, onSetToolActive, onClick, onDragStart,
       onShowDropHighlight, onHideDropHighlight }) => {
 
-  const { name, title, isTileTool } = config;
+  const { name, title, isTileTool, Icon } = toolButton;
   const toolName = name as DocumentTool;
 
   const handleMouseDown = () => {
     if (isDisabled) return;
 
-    onSetToolActive(toolName, true);
+    onSetToolActive(toolButton, true);
 
     const endActiveHandler = () => {
-      onSetToolActive(toolName, false);
+      onSetToolActive(toolButton, false);
       document.removeEventListener("mouseup", endActiveHandler, true);
       document.removeEventListener("dragend", endActiveHandler, true);
     };
@@ -46,11 +40,11 @@ export const ToolButtonComponent: React.FC<IToolButtonProps> =
   };
 
   const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    onClick(e, toolName);
+    onClick(e, toolButton);
   };
 
   const handleDrag = (e: React.DragEvent<HTMLDivElement>) => {
-    onDragStart(e, toolName);
+    onDragStart(e, toolButton);
   };
 
   return (
@@ -64,7 +58,7 @@ export const ToolButtonComponent: React.FC<IToolButtonProps> =
         draggable={isTileTool || false}
         onMouseEnter={isTileTool ? onShowDropHighlight : undefined}
         onMouseLeave={isTileTool ? onHideDropHighlight : undefined}>
-      {ToolIcon && <ToolIcon />}
+      {Icon && <Icon />}
     </div>
   );
 };

--- a/src/components/tool-button.tsx
+++ b/src/components/tool-button.tsx
@@ -2,7 +2,7 @@ import classNames from "classnames";
 import React from "react";
 import { IconComponent } from "../app-config-context";
 import { DocumentTool } from "../models/document/document";
-import { ToolButtonSnapshot } from "../models/tools/tool-types";
+import { ToolButtonSnapshot } from "../models/tools/tool-button";
 
 export type IToolButtonConfig = ToolButtonSnapshot & {
   icon?: IconComponent;

--- a/src/components/tool-button.tsx
+++ b/src/components/tool-button.tsx
@@ -1,6 +1,5 @@
 import classNames from "classnames";
 import React from "react";
-import { DocumentTool } from "../models/document/document";
 import { ToolButtonModelType } from "../models/tools/tool-button";
 
 export interface IButtonProps {
@@ -22,7 +21,6 @@ export const ToolButtonComponent: React.FC<IToolButtonProps> =
       onShowDropHighlight, onHideDropHighlight }) => {
 
   const { name, title, isTileTool, Icon } = toolButton;
-  const toolName = name as DocumentTool;
 
   const handleMouseDown = () => {
     if (isDisabled) return;
@@ -48,8 +46,8 @@ export const ToolButtonComponent: React.FC<IToolButtonProps> =
   };
 
   return (
-    <div className={classNames("tool", toolName, { active: isActive }, isDisabled ? "disabled" : "enabled")}
-        data-testid={`tool-${toolName}`}
+    <div className={classNames("tool", name, { active: isActive }, isDisabled ? "disabled" : "enabled")}
+        data-testid={`tool-${name}`}
         key={name}
         title={title}
         onMouseDown={handleMouseDown}

--- a/src/components/toolbar.test.tsx
+++ b/src/components/toolbar.test.tsx
@@ -7,10 +7,10 @@ import { DocumentModel } from "../models/document/document";
 import { DocumentContentModel } from "../models/document/document-content";
 import { createStores } from "../models/stores/stores";
 import { ToolbarComponent } from "./toolbar";
+import { ToolbarModel, ToolbarModelSnapshot } from "../models/stores/app-config-model";
 
 // This is needed so MST can deserialize snapshots referring to tools
 import "../register-tools";
-import { ToolbarModel, ToolbarModelSnapshot } from "../models/stores/app-config-model";
 
 describe("ToolbarComponent", () => {
 

--- a/src/components/toolbar.test.tsx
+++ b/src/components/toolbar.test.tsx
@@ -6,10 +6,11 @@ import { ModalProvider } from "react-modal-hook";
 import { DocumentModel } from "../models/document/document";
 import { DocumentContentModel } from "../models/document/document-content";
 import { createStores } from "../models/stores/stores";
-import { ToolbarComponent, ToolbarConfig } from "./toolbar";
+import { ToolbarComponent } from "./toolbar";
 
 // This is needed so MST can deserialize snapshots referring to tools
 import "../register-tools";
+import { ToolbarModel, ToolbarModelSnapshot } from "../models/stores/app-config-model";
 
 describe("ToolbarComponent", () => {
 
@@ -23,7 +24,7 @@ describe("ToolbarComponent", () => {
                     content: content as any
                   });
 
-  const config: ToolbarConfig = [
+  const config: ToolbarModelSnapshot = [
     {
       name: "select",
       title: "Select",
@@ -50,7 +51,7 @@ describe("ToolbarComponent", () => {
     render(
       <ModalProvider>
         <Provider stores={stores}>
-          <ToolbarComponent config={config} document={document}/>
+          <ToolbarComponent toolbarModel={ToolbarModel.create(config)} document={document}/>
         </Provider>
       </ModalProvider>
     );

--- a/src/components/toolbar.tsx
+++ b/src/components/toolbar.tsx
@@ -6,14 +6,13 @@ import { DocumentModelType, DocumentTool } from "../models/document/document";
 import { IDocumentContentAddTileOptions, IDragToolCreateInfo } from "../models/document/document-content";
 import { getToolContentInfoByTool, IToolContentInfo } from "../models/tools/tool-content-info";
 import { DeleteButton } from "./delete-button";
-import { IToolButtonConfig, IToolButtonProps, ToolButtonComponent } from "./tool-button";
+import { IToolButtonProps, ToolButtonComponent } from "./tool-button";
 import { EditableToolApiInterfaceRefContext } from "./tools/tool-api";
 import { kDragTileCreate  } from "./tools/tool-tile";
 import { ToolbarModelType } from "../models/stores/app-config-model";
 
 import "./toolbar.sass";
-
-export type ToolbarConfig = IToolButtonConfig[];
+import { ToolButtonModelType } from "../models/tools/tool-button";
 
 interface IProps extends IBaseProps {
   document: DocumentModelType;
@@ -21,8 +20,8 @@ interface IProps extends IBaseProps {
 }
 
 interface IState {
-  defaultTool: string;
-  activeTool: string;
+  defaultTool?: ToolButtonModelType;
+  activeTool?: ToolButtonModelType;
 }
 
 @inject("stores")
@@ -34,21 +33,18 @@ export class ToolbarComponent extends BaseComponent<IProps, IState> {
 
   private showDeleteTilesConfirmationAlert?: () => void;
 
-  state = {
-    defaultTool: "",
-    activeTool: ""
-  }
+  state: IState = {};
 
   public componentDidMount() {
     const defaultTool = this.props.toolbarModel.find(item => item.isDefault);
     if (defaultTool) {
-      this.setState({ defaultTool: defaultTool.name, activeTool: defaultTool.name });
+      this.setState({ defaultTool, activeTool: defaultTool });
     }
   }
 
   public render() {
-    const handleClickTool = (e: React.MouseEvent<HTMLDivElement>, tool: DocumentTool) => {
-      switch (tool) {
+    const handleClickTool = (e: React.MouseEvent<HTMLDivElement>, tool: ToolButtonModelType) => {
+      switch (tool.name) {
         case "select":
           this.handleSelect();
           break;
@@ -60,20 +56,19 @@ export class ToolbarComponent extends BaseComponent<IProps, IState> {
           break;
       }
     };
-    const handleSetActiveTool = (tool: DocumentTool, isActive: boolean) => {
+    const handleSetActiveTool = (tool: ToolButtonModelType, isActive: boolean) => {
       const { defaultTool } = this.state;
       this.setState({ activeTool: isActive && (tool !== defaultTool) ? tool : defaultTool });
     };
-    const handleDragTool = (e: React.DragEvent<HTMLDivElement>, tool: DocumentTool) => {
+    const handleDragTool = (e: React.DragEvent<HTMLDivElement>, tool: ToolButtonModelType) => {
       this.handleDragNewToolTile(tool, e);
     };
     const renderToolButtons = (toolbarModel: ToolbarModelType) => {
       const { ui: { selectedTileIds } } = this.stores;
       return toolbarModel.map(toolButton => {
         const buttonProps: IToolButtonProps = {
-          config: toolButton,
-          ToolIcon: toolButton.Icon,
-          isActive: toolButton.name === this.state.activeTool,
+          toolButton,
+          isActive: toolButton === this.state.activeTool,
           isDisabled: toolButton.name === "delete" && !selectedTileIds.length,
           onSetToolActive: handleSetActiveTool,
           onClick: handleClickTool,
@@ -115,16 +110,16 @@ export class ToolbarComponent extends BaseComponent<IProps, IState> {
     return titleBase && document.getUniqueTitle(id, titleBase, getTileTitle);
   }
 
-  private handleAddToolTile(tool: DocumentTool) {
+  private handleAddToolTile(tool: ToolButtonModelType) {
     const { document } = this.props;
     const { ui } = this.stores;
-    const toolContentInfo = getToolContentInfoByTool(tool);
+    const toolContentInfo = getToolContentInfoByTool(tool.name);
     const newTileOptions: IDocumentContentAddTileOptions = {
             title: this.getUniqueTitle(toolContentInfo),
             addSidecarNotes: !!toolContentInfo?.addSidecarNotes,
             insertRowInfo: { rowInsertIndex: document.content?.defaultInsertRow ?? 0 }
           };
-    const rowTile = document.addTile(tool, newTileOptions);
+    const rowTile = document.addTile(tool.name as DocumentTool, newTileOptions);
     if (rowTile && rowTile.tileId) {
       ui.setSelectedTileId(rowTile.tileId);
       this.setState(state => ({ activeTool: state.defaultTool }));
@@ -167,12 +162,13 @@ export class ToolbarComponent extends BaseComponent<IProps, IState> {
     });
   }
 
-  private handleDragNewToolTile = (tool: DocumentTool, e: React.DragEvent<HTMLDivElement>) => {
+  private handleDragNewToolTile = (tool: ToolButtonModelType, e: React.DragEvent<HTMLDivElement>) => {
     // remove hover-insert highlight when we start a tile drag
     this.removeDropRowHighlight();
 
-    const toolContentInfo = getToolContentInfoByTool(tool);
-    const dragInfo: IDragToolCreateInfo = { tool, title: this.getUniqueTitle(toolContentInfo) };
+    const toolContentInfo = getToolContentInfoByTool(tool.name);
+    const dragInfo: IDragToolCreateInfo = 
+      { tool: tool.name as DocumentTool, title: this.getUniqueTitle(toolContentInfo) };
     e.dataTransfer.setData(kDragTileCreate, JSON.stringify(dragInfo));
   }
 }

--- a/src/components/toolbar.tsx
+++ b/src/components/toolbar.tsx
@@ -10,9 +10,9 @@ import { IToolButtonProps, ToolButtonComponent } from "./tool-button";
 import { EditableToolApiInterfaceRefContext } from "./tools/tool-api";
 import { kDragTileCreate  } from "./tools/tool-tile";
 import { ToolbarModelType } from "../models/stores/app-config-model";
+import { ToolButtonModelType } from "../models/tools/tool-button";
 
 import "./toolbar.sass";
-import { ToolButtonModelType } from "../models/tools/tool-button";
 
 interface IProps extends IBaseProps {
   document: DocumentModelType;

--- a/src/components/toolbar.tsx
+++ b/src/components/toolbar.tsx
@@ -9,6 +9,7 @@ import { DeleteButton } from "./delete-button";
 import { IToolButtonConfig, IToolButtonProps, ToolButtonComponent } from "./tool-button";
 import { EditableToolApiInterfaceRefContext } from "./tools/tool-api";
 import { kDragTileCreate  } from "./tools/tool-tile";
+import { ToolbarModelType } from "../models/stores/app-config-model";
 
 import "./toolbar.sass";
 
@@ -16,7 +17,7 @@ export type ToolbarConfig = IToolButtonConfig[];
 
 interface IProps extends IBaseProps {
   document: DocumentModelType;
-  config: ToolbarConfig;
+  toolbarModel: ToolbarModelType;
 }
 
 interface IState {
@@ -39,7 +40,7 @@ export class ToolbarComponent extends BaseComponent<IProps, IState> {
   }
 
   public componentDidMount() {
-    const defaultTool = this.props.config.find(item => item.isDefault);
+    const defaultTool = this.props.toolbarModel.find(item => item.isDefault);
     if (defaultTool) {
       this.setState({ defaultTool: defaultTool.name, activeTool: defaultTool.name });
     }
@@ -66,23 +67,23 @@ export class ToolbarComponent extends BaseComponent<IProps, IState> {
     const handleDragTool = (e: React.DragEvent<HTMLDivElement>, tool: DocumentTool) => {
       this.handleDragNewToolTile(tool, e);
     };
-    const renderToolButtons = (toolbarConfig: ToolbarConfig) => {
+    const renderToolButtons = (toolbarModel: ToolbarModelType) => {
       const { ui: { selectedTileIds } } = this.stores;
-      return toolbarConfig.map(config => {
+      return toolbarModel.map(toolButton => {
         const buttonProps: IToolButtonProps = {
-          config,
-          ToolIcon: config.icon,
-          isActive: config.name === this.state.activeTool,
-          isDisabled: config.name === "delete" && !selectedTileIds.length,
+          config: toolButton,
+          ToolIcon: toolButton.Icon,
+          isActive: toolButton.name === this.state.activeTool,
+          isDisabled: toolButton.name === "delete" && !selectedTileIds.length,
           onSetToolActive: handleSetActiveTool,
           onClick: handleClickTool,
           onDragStart: handleDragTool,
           onShowDropHighlight: this.showDropRowHighlight,
           onHideDropHighlight: this.removeDropRowHighlight
         };
-        return config.name !== "delete"
-                ? <ToolButtonComponent key={config.name} {...buttonProps} />
-                : <DeleteButton key={config.name}
+        return toolButton.name !== "delete"
+                ? <ToolButtonComponent key={toolButton.name} {...buttonProps} />
+                : <DeleteButton key={toolButton.name}
                                 onSetShowDeleteTilesConfirmationAlert={this.setShowDeleteTilesConfirmationAlert}
                                 onDeleteSelectedTiles={this.handleDeleteSelectedTiles}
                                 {...buttonProps} />;
@@ -90,7 +91,7 @@ export class ToolbarComponent extends BaseComponent<IProps, IState> {
     };
     return (
       <div className="toolbar" data-testid="toolbar">
-        {renderToolButtons(this.props.config)}
+        {renderToolButtons(this.props.toolbarModel)}
       </div>
     );
   }

--- a/src/models/stores/app-config-model.ts
+++ b/src/models/stores/app-config-model.ts
@@ -1,7 +1,7 @@
 import { types, Instance, SnapshotIn } from "mobx-state-tree";
 import { DocumentContentModel, DocumentContentModelType, cloneContentWithUniqueIds
       } from "../document/document-content";
-import { ToolButtonModel } from "../tools/tool-types";
+import { ToolButtonModel } from "../tools/tool-button";
 import { ENavTab, NavTabModel, NavTabSpec } from "../view/nav-tabs";
 import { SettingsMstType } from "./settings";
 
@@ -47,6 +47,12 @@ const DocumentLabelModel = types
               : self.getUpperLabel(num);
     }
   }));
+
+// Probably this should be changed to something more complex
+export const ToolbarModel = types.array(ToolButtonModel);
+export interface ToolbarModelType extends Instance<typeof ToolbarModel> {}
+export type ToolbarModelSnapshot = SnapshotIn<typeof ToolbarModel>;
+
 export const AppConfigModel = types
   .model("AppConfig", {
     appName: "",
@@ -77,7 +83,7 @@ export const AppConfigModel = types
     showPublishedDocsInPrimaryWorkspace: false,
     comparisonPlaceholderContent: types.optional(types.union(types.string, types.array(types.string)), ""),
     navTabs: types.optional(NavTabsAppConfigModel, () => NavTabsAppConfigModel.create()),
-    toolbar: types.array(ToolButtonModel),
+    toolbar: ToolbarModel,
     settings: types.maybe(SettingsMstType)
   })
   .views(self => ({

--- a/src/models/tools/tool-button.ts
+++ b/src/models/tools/tool-button.ts
@@ -1,4 +1,4 @@
-import { getEnv, SnapshotOut, types } from "mobx-state-tree";
+import { getEnv, Instance, SnapshotOut, types } from "mobx-state-tree";
 import { getToolContentInfoByTool } from "./tool-content-info";
 
 const BaseToolButtonModel = types.model("BaseToolButton", {
@@ -36,4 +36,5 @@ export const ToolButtonModel = types.union(AppToolButtonModel, TileToolButtonMod
 
 // This can't be an interface because the type is a union which is not supported
 // by typescript interfaces
+export type ToolButtonModelType = Instance<typeof ToolButtonModel>;
 export type ToolButtonSnapshot = SnapshotOut<typeof ToolButtonModel>;

--- a/src/models/tools/tool-button.ts
+++ b/src/models/tools/tool-button.ts
@@ -1,0 +1,39 @@
+import { getEnv, SnapshotOut, types } from "mobx-state-tree";
+import { getToolContentInfoByTool } from "./tool-content-info";
+
+const BaseToolButtonModel = types.model("BaseToolButton", {
+  name: types.string,
+  title: types.string,
+  isDefault: false,
+});
+
+const AppToolButtonModel = BaseToolButtonModel.named("AppToolButtonModel")
+  .props({
+    iconId: types.string,
+    isTileTool: types.literal(false)
+  })
+  .views(self => ({
+    get Icon() {
+      // Get the appConfig from the environment
+      // Unfortunately the environment cannot be typed very well
+      //   https://github.com/mobxjs/mobx-state-tree/issues/431
+      const appIcons = getEnv(self).appIcons;
+      return appIcons?.[self.iconId];
+    }
+  }));
+
+const TileToolButtonModel = BaseToolButtonModel.named("TileToolButtonModel")
+  .props({
+    isTileTool: types.literal(true)
+  })
+  .views(self => ({
+    get Icon() {
+      return  getToolContentInfoByTool(self.name).Icon;
+    }
+  }));
+
+export const ToolButtonModel = types.union(AppToolButtonModel, TileToolButtonModel);
+
+// This can't be an interface because the type is a union which is not supported
+// by typescript interfaces
+export type ToolButtonSnapshot = SnapshotOut<typeof ToolButtonModel>;

--- a/src/models/tools/tool-types.ts
+++ b/src/models/tools/tool-types.ts
@@ -1,4 +1,4 @@
-import { Instance, SnapshotOut, types } from "mobx-state-tree";
+import { Instance, types } from "mobx-state-tree";
 import { getToolContentModels, getToolContentInfoById } from "./tool-content-info";
 
 // It isn't clear when 'late' is run. Currently it works.  It is running
@@ -48,28 +48,6 @@ export const ToolMetadataModel = types.model("ToolMetadataModel", {
     id: types.string
   });
 export interface ToolMetadataModelType extends Instance<typeof ToolMetadataModel> {}
-
-const BaseToolButtonModel = types.model("BaseToolButton", {
-  name: types.string,
-  title: types.string,
-  isDefault: false,
-});
-
-const AppToolButtonModel = BaseToolButtonModel.named("AppToolButtonModel")
-  .props({
-    iconId: types.string,
-    isTileTool: types.literal(false)
-  });
-
-const TileToolButtonModel = BaseToolButtonModel.named("TileToolButtonModel")
-  .props({
-    isTileTool: types.literal(true)
-  });
-export const ToolButtonModel = types.union(AppToolButtonModel, TileToolButtonModel);
-
-// This can't be an interface because the type is a union which is not supported
-// by typescript interfaces
-export type ToolButtonSnapshot = SnapshotOut<typeof ToolButtonModel>;
 
 interface IPrivate {
   metadata: Record<string, ToolMetadataModelType>;

--- a/src/utilities/mst-utils.test.ts
+++ b/src/utilities/mst-utils.test.ts
@@ -1,5 +1,5 @@
 import { getParentWithTypeName } from "./mst-utils";
-import { getParent, types, unprotect } from "mobx-state-tree";
+import { types, unprotect } from "mobx-state-tree";
 
 // reduce mobx strictness just for this test so we can use unprotect 
 // without seeing a warning


### PR DESCRIPTION
The main change here is to pass a MST model of the toolbar button instead of a plan JS object.

The reason to try doing this is because I'm trying to get rid of the usage of `DocumentTool` where possible.  By passing the ToolButtonModel instance to the ToolButton component it can use this model instead of the `DocumentTool` type.

This also made it possible to move the logic of figuring out the Icon component of a tool button into the model itself. So now the code using these models just uses `model.Icon`. 

Some specific changes:
- the toolbar prop passed to DocumentComponent is now just `appConfig.toolbar` instead of its snapshot
- the toolbar prop of DocumentToolbar is never undefined, this was the case before but the types didn't reflect it
- when the DocumentToolbar is first rendered it clones the toolbar model, this way each document's toolbar is disconnected from the other document.  Currently the toolbar components don't modify the toolbar model or its child button models, but this seems safer.
- the ToolButtonModel looks up the icon either from the `appConfig.appIcons` or from tool content info registry. This logic was happening before but it was in EditableDocumentContent.
- the tool-button.test.tsx needed to register the tools so it could render a text tool button
- the events of tool-button are switched from using `DocumentTool` to `ToolButtonModelType`.
- tests need to create ToolButtonModel objects instead of just passing simple objects
- the toolbar component stores the `defaultTool` and `activeTool` state values as ToolButtonModel objects. 
- the tool button models were extracted from `tool-types.ts` since they are now more complex.
- removed an unreferenced getParent from an un-related test