### PR TITLE
Update ReactDataGrid library

### DIFF
--- a/dependencies-notes.md
+++ b/dependencies-notes.md
@@ -33,5 +33,5 @@ Notes on dependencies and in particular on what's keeping particular dependencie
 |firebase|8.10.0|9.4.1|v9 contains substantial API changes|
 |immutable|3.8.2|4.0.0|Major version update not attempted|
 |react|16.14.0|17.0.2|React 17/Library dependencies: slate-editor, blueprintjs|
-|react-data-grid|7.0.0-canary.34|7.0.0-canary.49|Canary.35 changed the styling implementation so that some of our CSS overrides no longer work. Need to figure out how to achieve the same results in the new system, e.g. inline editing styles.|
+|react-data-grid|7.0.0-canary.46|7.0.0-beta.7|Canary.47 changed the RowFormatter props requiring some additional refactoring.|
 |react-dom|16.14.0|17.0.2|React 17/Library dependencies: slate-editor, blueprintjs|

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "nanoid": "^3.1.30",
         "query-string": "7.0.1",
         "react": "^16.14.0",
-        "react-data-grid": "^7.0.0-canary.34",
+        "react-data-grid": "^7.0.0-canary.46",
         "react-dom": "^16.14.0",
         "react-dom-factories": "^1.0.2",
         "react-modal": "^3.14.4",
@@ -24969,9 +24969,9 @@
       }
     },
     "node_modules/react-data-grid": {
-      "version": "7.0.0-canary.34",
-      "resolved": "https://registry.npmjs.org/react-data-grid/-/react-data-grid-7.0.0-canary.34.tgz",
-      "integrity": "sha512-ZBWb4uH2lSmDEf0SofOrJGt8hplHLgbppKGec0fJcVQHPATEFaLscyFI2Ki0aQSJYWvKCJDwyvJgEVkwqY7jUQ==",
+      "version": "7.0.0-canary.46",
+      "resolved": "https://registry.npmjs.org/react-data-grid/-/react-data-grid-7.0.0-canary.46.tgz",
+      "integrity": "sha512-LCMOALZWDrMjVKrf0HwulOoSXLMQ4haB6u9yQRmWAIqr8sYhfryNwwv0lGMGJxMsDM2e0k8+IW4arjww/+LLQQ==",
       "dependencies": {
         "clsx": "^1.1.1"
       },
@@ -50505,9 +50505,9 @@
       }
     },
     "react-data-grid": {
-      "version": "7.0.0-canary.34",
-      "resolved": "https://registry.npmjs.org/react-data-grid/-/react-data-grid-7.0.0-canary.34.tgz",
-      "integrity": "sha512-ZBWb4uH2lSmDEf0SofOrJGt8hplHLgbppKGec0fJcVQHPATEFaLscyFI2Ki0aQSJYWvKCJDwyvJgEVkwqY7jUQ==",
+      "version": "7.0.0-canary.46",
+      "resolved": "https://registry.npmjs.org/react-data-grid/-/react-data-grid-7.0.0-canary.46.tgz",
+      "integrity": "sha512-LCMOALZWDrMjVKrf0HwulOoSXLMQ4haB6u9yQRmWAIqr8sYhfryNwwv0lGMGJxMsDM2e0k8+IW4arjww/+LLQQ==",
       "requires": {
         "clsx": "^1.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -195,7 +195,7 @@
     "nanoid": "^3.1.30",
     "query-string": "7.0.1",
     "react": "^16.14.0",
-    "react-data-grid": "^7.0.0-canary.34",
+    "react-data-grid": "^7.0.0-canary.46",
     "react-dom": "^16.14.0",
     "react-dom-factories": "^1.0.2",
     "react-modal": "^3.14.4",

--- a/src/components/tools/table-tool/cell-text-editor.tsx
+++ b/src/components/tools/table-tool/cell-text-editor.tsx
@@ -2,12 +2,37 @@ import React, { useEffect } from "react";
 import { EditorProps } from "react-data-grid";
 import { TColumn } from "./table-types";
 
+// Starting with ReactDataGrid 7.0.0-canary.35, RDG started using Linaria CSS-in-JS for its internal
+// styling. As with CSS Modules and other CSS-in-JS solutions, this involves dynamically generating
+// class names on the fly. Separately, the `CellTextEditor` class below is a modified version of
+// RDG's internal `TextEditor` class which extends its functionality in ways that aren't relevant
+// to this discussion. The important point is that we would like whatever styling is applied to
+// the internal `TextEditor` class to be applied to our `CellTextEditor` variant. Furthermore, in
+// addition to using the `CellTextEditor` class in the body of the table, as RDG does with its
+// TextEditor component internally, we also use it for editing column header cells and the table
+// title with the intent that the styling should be consistent across all of these instances.
+// Unfortunately, with the switch to Linaria, instead of tying their internal CSS to the public
+// class names RDG ties its internal CSS to the dynamically generated class names. Therefore,
+// to preserve the prior behavior we must give our instances of these components the same
+// classes as the components they're replacing, including the dynamically generated classes.
+// This degree of coupling is clearly not ideal, but the alternative would be to copy the CSS
+// from RDG and maintain a redundant copy of it which is potentially an even more challenging
+// synchronization task. At least this way, we can (theoretically) add a unit test to validate
+// that the correct CSS was applied and potentially even automate the process of extracting
+// the dynamically generated class names. It turns out that the first part of each class name
+// is stable for a given component and the last part of the class name is just a coded instance
+// of the version number. Therefore, we stick with this approach for now. Down the road we may
+// be able to submit a PR which would obviate the need for some of our overrides.
+export const RDG_INTERNAL_EDITOR_CONTAINER_CLASS = "e1d24x2700-canary46";
+export const RDG_INTERNAL_TEXT_EDITOR_CLASS = "t16y9g8l700-canary46";
+
 function autoFocusAndSelect(input: HTMLInputElement | null) {
   input?.focus();
   input?.select();
 }
 
 // patterned after TextEditor from "react-data-grid"
+// extended to call our onBeginBodyCellEdit()/onEndBodyCellEdit() functions
 export default function CellTextEditor<TRow, TSummaryRow = unknown>({
   row, column, onRowChange, onClose
 }: EditorProps<TRow, TSummaryRow>) {
@@ -26,7 +51,7 @@ export default function CellTextEditor<TRow, TSummaryRow = unknown>({
   const value = raw == null ? "" : raw;
   return (
     <input
-      className="rdg-text-editor"
+      className={`rdg-text-editor ${RDG_INTERNAL_TEXT_EDITOR_CLASS}`}
       ref={autoFocusAndSelect}
       value={value as unknown as string}
       onChange={event => onRowChange({ ...row, [column.key]: event.target.value })}

--- a/src/components/tools/table-tool/column-header-cell.scss
+++ b/src/components/tools/table-tool/column-header-cell.scss
@@ -7,14 +7,23 @@ $column-header-padding: 10px;
   width: 100%;
   height: 100%;
 
+  &.show-expression {
+    .flex-container {
+      .editable-header-cell {
+        height: calc(var(--header-row-height) / 2);
+        line-height: calc(var(--header-row-height) / 2); // https://tutorialdeep.com/knowhow/align-text-vertically-center-css/
+      }
+    }
+  }
+
   .flex-container {
     display: flex;
     flex-direction: column;
 
     .editable-header-cell {
       width: 100%;
-      height: var(--row-height);
-      line-height: var(--row-height); // https://tutorialdeep.com/knowhow/align-text-vertically-center-css/
+      height: var(--header-row-height);
+      line-height: var(--header-row-height); // https://tutorialdeep.com/knowhow/align-text-vertically-center-css/
 
       &.table-title-editing {
         padding: 0 !important;
@@ -32,8 +41,8 @@ $column-header-padding: 10px;
 
     .expression-cell {
       width: 100%;
-      height: var(--row-height);
-      line-height: var(--row-height); // https://tutorialdeep.com/knowhow/align-text-vertically-center-css/
+      height: calc(var(--header-row-height) / 2);
+      line-height: calc(var(--header-row-height) / 2); // https://tutorialdeep.com/knowhow/align-text-vertically-center-css/
       font-style: italic;
       white-space: nowrap;
       overflow: hidden;
@@ -72,7 +81,7 @@ $column-header-padding: 10px;
     position: absolute;
     left: -$column-header-padding;
     right: -$column-header-padding;
-    top: var(--row-height);
+    top: calc(var(--header-row-height) / 2);
     height: 1px;
     background-color: white;
   }

--- a/src/components/tools/table-tool/editable-header-cell.tsx
+++ b/src/components/tools/table-tool/editable-header-cell.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { TColumn, THeaderRendererProps } from "./table-types";
+import { kRowHeight, TColumn, THeaderRendererProps } from "./table-types";
 import { HeaderCellInput } from "./header-cell-input";
 
 interface IProps extends THeaderRendererProps {
@@ -37,11 +37,25 @@ export const EditableHeaderCell: React.FC<IProps> = ({ column: _column }) => {
   const handleClose = (accept: boolean) => {
     onEndHeaderCellEdit?.(accept ? nameValue : undefined);
   };
-  const style = { width: column.width };
+  const style: React.CSSProperties = { width: column.width };
+  // ReactDataGrid's styling of the cell editor relies on an interesting interplay between the container
+  // (.rdg-editor-container), which has `{ display: "contents" }` in its CSS, which according to MDN means:
+  //
+  // These elements don't produce a specific box by themselves.
+  // They are replaced by their pseudo-box and their child boxes.
+  //
+  // Essentially, the container should figure out its own box from its children. But then the child <input>
+  // element specifies `{ height: 100% }`, so the height of the parent is determined from the children at
+  // the same time that the height of the child depends on the parent. Hmmm. In any case, this seems to
+  // work just fine in most circumstances and in most browsers, but starting with 7.0.0-canary.44, the
+  // height calculation no longer works for the column header cells in Chrome, although it continues to
+  // work for the title cell and the table body cells in Chrome as well as in all three contexts in Firefox.
+  // ¯\_(ツ)_/¯ The fix is to force the <input> to be the height of the row with an inline style.
+  const inputStyle: React.CSSProperties = { height: kRowHeight };
   return (
     <div className={"editable-header-cell"} onClick={handleClick} onDoubleClick={handleDoubleClick}>
       {isEditing
-        ? <HeaderCellInput style={style} value={nameValue}
+        ? <HeaderCellInput style={style} inputStyle={inputStyle} value={nameValue}
             onKeyDown={handleKeyDown} onChange={handleChange} onClose={handleClose} />
         : name}
     </div>

--- a/src/components/tools/table-tool/header-cell-input.tsx
+++ b/src/components/tools/table-tool/header-cell-input.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { RDG_INTERNAL_EDITOR_CONTAINER_CLASS, RDG_INTERNAL_TEXT_EDITOR_CLASS } from "./cell-text-editor";
 
 function autoFocusAndSelect(input: HTMLInputElement | null) {
   input?.focus();
@@ -7,16 +8,19 @@ function autoFocusAndSelect(input: HTMLInputElement | null) {
 
 interface IProps {
   style?: React.CSSProperties;
+  inputStyle?: React.CSSProperties;
   value: string;
   onKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => void;
   onChange: (value: string) => void;
   onClose: (accept: boolean) => void;
 }
-export const HeaderCellInput: React.FC<IProps> = ({ style, value, onKeyDown, onChange, onClose }) => {
+export const HeaderCellInput: React.FC<IProps> = ({ style, inputStyle, value, onKeyDown, onChange, onClose }) => {
+  const containerClasses = `rdg-editor-container clue-editor-container ${RDG_INTERNAL_EDITOR_CONTAINER_CLASS}`;
+  const editorClasses = `rdg-text-editor ${RDG_INTERNAL_TEXT_EDITOR_CLASS}`;
   return (
-    <div className="rdg-editor-container clue-editor-container" style={style}>
+    <div className={containerClasses} style={style}>
       <input
-        className="rdg-text-editor"
+        className={editorClasses} style={inputStyle}
         ref={autoFocusAndSelect}
         value={value}
         onKeyDown={onKeyDown}

--- a/src/components/tools/table-tool/table-tool.scss
+++ b/src/components/tools/table-tool/table-tool.scss
@@ -145,6 +145,9 @@ $controls-hover-background: #c0dfe7;
         &.selected-column {
           background-color: var(--header-selected-background-color);
         }
+        &.rdg-cell-editing {
+          padding: 0;
+        }
         input {
           background-color: inherit;
         }

--- a/src/components/tools/table-tool/table-tool.tsx
+++ b/src/components/tools/table-tool/table-tool.tsx
@@ -21,7 +21,6 @@ import { useMeasureText } from "../hooks/use-measure-text";
 import { useToolbarToolApi } from "../hooks/use-toolbar-tool-api";
 import { lightenColor } from "../../../utilities/color-utils";
 
-import "react-data-grid/dist/react-data-grid.css";
 import "./table-tool.scss";
 
 // observes row selection from shared selection store


### PR DESCRIPTION
For some time now we've been stuck on version `7.0.0-canary.34` because of some styling changes introduced in `7.0.0-canary.35` that broke the styling of our inline cell editors. With this PR we introduce a fix for those styling changes which allows us to update to `7.0.0-canary.46`. Unfortunately, `7.0.0-canary.47` introduces some API changes for the `RowFormatter` classes that will require some refactoring of our code. Therefore, discretion being the better part of valor and all that, we'll leave the `RowFormatter` refactoring for another day. Along the way we also have to deal with some row-height-handling changes introduced in `7.0.0-canary.44` that required some changes to the way we handle the layout of column header cells with formulas.

The fixes introduce some uncomfortably tight coupling with some implementation details of the library, but I don't see a better solution in the short term. See extensive comments in the code for details.