### PR TITLE
Fix planning document title and "Network User" in resources

### DIFF
--- a/src/components/navigation/document-tab-content.tsx
+++ b/src/components/navigation/document-tab-content.tsx
@@ -1,9 +1,7 @@
 import React, { useState } from "react";
 import { useQueryClient } from 'react-query';
 import { DocumentModelType } from "../../models/document/document";
-import { isProblemType } from "../../models/document/document-types";
-import { AppConfigModelType } from "../../models/stores/app-config-model";
-import { ProblemModelType } from "../../models/curriculum/problem";
+import { getDocumentDisplayTitle } from "../../models/document/document-utils";
 import { ENavTabSectionType, NavTabSpec } from "../../models/view/nav-tabs";
 import { DocumentTabPanel } from "./document-tab-panel";
 import { EditableDocumentContent } from "../document/editable-document-content";
@@ -49,13 +47,6 @@ export const DocumentTabContent: React.FC<IProps> = ({ tabSpec }) => {
     await document.fetchRemoteContent(queryClient, context);
   };
 
-  const documentTitle = (document: DocumentModelType, appConfig: AppConfigModelType, problem: ProblemModelType) => {
-    const { type } = document;
-    return document.isSupport
-      ? document.getProperty("caption") || "Support"
-      : isProblemType(type) ? problem.title : document.getDisplayTitle(appConfig);
-  };
-
   function handleEditClick(document: DocumentModelType) {
     ui.problemWorkspace.setPrimaryDocument(document);
   }
@@ -78,7 +69,7 @@ export const DocumentTabContent: React.FC<IProps> = ({ tabSpec }) => {
     <div>
       <div className={`document-header ${tabSpec.tab} ${sectionClass}`} onClick={() => ui.setSelectedTile()}>
         <div className={`document-title`}>
-          {documentTitle(referenceDocument, appConfigStore, problemStore)}
+          {getDocumentDisplayTitle(referenceDocument, appConfigStore, problemStore)}
         </div>
         {!referenceDocument.isRemote && editButton(tabSpec.tab, sectionClass, referenceDocument)}
       </div>

--- a/src/components/thumbnail/tab-panel-documents-subsection-panel.tsx
+++ b/src/components/thumbnail/tab-panel-documents-subsection-panel.tsx
@@ -1,9 +1,8 @@
 import React from "react";
 import { ThumbnailDocumentItem } from "./thumbnail-document-item";
 import { DocumentModelType } from "../../models/document/document";
-import {
-  isPlanningType, isProblemType, isPublishedType, SupportPublication
-} from "../../models/document/document-types";
+import { isPublishedType, SupportPublication } from "../../models/document/document-types";
+import { getDocumentDisplayTitle } from "../../models/document/document-utils";
 import { IStores } from "../../models/stores/stores";
 import { NavTabSectionModelType } from "../../models/view/nav-tabs";
 
@@ -29,11 +28,7 @@ function getDocumentCaption(stores: IStores, document: DocumentModelType) {
   const user = _class?.getUserById(uid);
   const userName = user?.displayName;
   const namePrefix = isPublishedType(type) ? `${userName}: ` : "";
-  const title = isProblemType(type)
-                  ? problem.title
-                  : isPlanningType(type)
-                      ? `${problem.title}: Planning`
-                      : document.getDisplayTitle(appConfig);
+  const title = getDocumentDisplayTitle(document, appConfig, problem);
   return `${namePrefix}${title}`;
 }
 

--- a/src/components/thumbnail/tab-panel-documents-subsection-panel.tsx
+++ b/src/components/thumbnail/tab-panel-documents-subsection-panel.tsx
@@ -25,8 +25,9 @@ function getDocumentCaption(stores: IStores, document: DocumentModelType) {
   const { appConfig, problem, class: _class } = stores;
   const { type, uid } = document;
   if (type === SupportPublication) return document.getProperty("caption") || "Support";
-  const user = _class?.getUserById(uid);
-  const userName = user?.displayName;
+  const userName = document.isRemote
+                    ? "Network User"
+                    : _class?.getUserById(uid)?.displayName || "Unknown User";
   const namePrefix = isPublishedType(type) ? `${userName}: ` : "";
   const title = getDocumentDisplayTitle(document, appConfig, problem);
   return `${namePrefix}${title}`;

--- a/src/models/document/document-utils.ts
+++ b/src/models/document/document-utils.ts
@@ -1,0 +1,17 @@
+import { ProblemModelType } from "../curriculum/problem";
+import { AppConfigModelType } from "../stores/app-config-model";
+import { DocumentModelType } from "./document";
+import { isPlanningType, isProblemType } from "./document-types";
+
+export function getDocumentDisplayTitle(
+  document: DocumentModelType, appConfig: AppConfigModelType, problem: ProblemModelType
+) {
+  const { type } = document;
+  return document.isSupport
+    ? document.getProperty("caption") || "Support"
+    : isProblemType(type)
+        ? problem.title
+        : isPlanningType(type)
+            ? `${problem.title}: Planning`
+            : document.getDisplayTitle(appConfig);
+}


### PR DESCRIPTION
[[#180463778]](https://www.pivotaltracker.com/story/show/180463778) Show planning document title in Resources
[[#180484449]](https://www.pivotaltracker.com/story/show/180484449) Show "Network User" for caption of published documents viewed via teacher network

Demo: https://collaborative-learning.concord.org/branch/planning-title/?demo

For the planning document title, this is a classic case of redundant code in two different places where one was updated to account for the possibility of planning documents while the other wasn't. The fix here is to consolidate the two usages into one utility function to avoid this from happening in the future.

For the "Network User", we just need to test whether the document is a remote document (i.e. loaded over the network). Note that the original request was for the string to be "Network Student", but we don't actually know whether the document was published by a student or a teacher so "Network User" is the best we can do.