### PR TITLE
Ignore __label__ attribute when linking table to geometry

### DIFF
--- a/src/models/tools/geometry/geometry-content.ts
+++ b/src/models/tools/geometry/geometry-content.ts
@@ -700,7 +700,7 @@ export const GeometryContentModel = ToolContentModel
         const x = xAttr ? Number(dataSet.getValue(caseId, xAttr.id)) : undefined;
         for (let attrIndex = 1; attrIndex < dataSet.attributes.length; ++attrIndex) {
           const yAttr = dataSet.attributes[attrIndex];
-          if (caseId && yAttr) {
+          if (caseId && yAttr && (yAttr.id !== labelAttr?.id)) {
             const y = yAttr ? Number(dataSet.getValue(caseId, yAttr.id)) : undefined;
             ids.push(`${caseId}:${yAttr.id}`);
             points.push({ label, coords: [x, y] });


### PR DESCRIPTION
[[#180496888]](https://www.pivotaltracker.com/story/show/180496888) Extra points on a graph are created on duplication of a figure created from a linked table

Odd that this wasn't discovered before now. For implementation reasons we maintain a hidden internal `__label__` attribute to store the label of each linked point. When we made the transition from only supporting two columns (one y-attribute) to supporting multiple columns, the code for creating the linked points expanded from creating a single point for each row of the table to a loop which creates a single point for each y-attribute of the table. Unfortunately, this loop failed to account for the `__label__` attribute, and so we end up creating extraneous hidden points in JSXGraph, which then become visible on copy. The fix is to simply ignore the `__label__` attribute when creating linked points.

Demo: https://collaborative-learning.concord.org/branch/linked-points/?demo.