### PR TITLE
Use applySnapshot() in DocumentModel.setContent()

### DIFF
--- a/src/lib/db-listeners/index.ts
+++ b/src/lib/db-listeners/index.ts
@@ -10,7 +10,6 @@ import { DBOtherDocumentsListener } from "./db-other-docs-listener";
 import { DBProblemDocumentsListener } from "./db-problem-documents-listener";
 import { DBPublicationsListener } from "./db-publications-listener";
 import { DocumentModelType } from "../../models/document/document";
-import { DocumentContentModel } from "../../models/document/document-content";
 import { LearningLogDocument, OtherDocumentType, PersonalDocument } from "../../models/document/document-types";
 import { DBDocument, DatabaseType } from "../db-types";
 import { DBSupportsListener } from "./db-supports-listener";
@@ -215,7 +214,7 @@ export class DBListeners extends BaseListener {
         const updatedContent = this.db.parseDocumentContent(updatedDoc);
         const documentModel = documents.getDocument(documentKey);
         if (documentModel) {
-          documentModel.setContent(DocumentContentModel.create(updatedContent || {}));
+          documentModel.setContent(updatedContent || {});
           this.monitorDocumentModel(documentModel, monitor);
         }
       }

--- a/src/lib/logger.test.ts
+++ b/src/lib/logger.test.ts
@@ -3,7 +3,6 @@ import { Logger, LogEventName, ILogComment } from "./logger";
 import { DocumentModel, DocumentModelType } from "../models/document/document";
 import { ProblemDocument } from "../models/document/document-types";
 import { AppConfigModel } from "../models/stores/app-config-model";
-import { DocumentContentModel } from "../models/document/document-content";
 import { InvestigationModel } from "../models/curriculum/investigation";
 import { IStores, createStores } from "../models/stores/stores";
 import { UserModel } from "../models/stores/user";
@@ -458,8 +457,7 @@ describe("authed logger", () => {
         content: {},
         visibility: "public"
       });
-      const content = createSingleTileContent({ type: "Text", text: "test" });
-      sourceDocument.setContent(DocumentContentModel.create(content));
+      sourceDocument.setContent(createSingleTileContent({ type: "Text", text: "test" }));
 
       const destinationDocument = DocumentModel.create({
         type: ProblemDocument,

--- a/src/models/document/document.test.ts
+++ b/src/models/document/document.test.ts
@@ -1,6 +1,5 @@
 import { getSnapshot } from "mobx-state-tree";
 import { DocumentModel, DocumentModelType } from "./document";
-import { DocumentContentModel } from "./document-content";
 import { PersonalDocument, ProblemDocument } from "./document-types";
 import { createSingleTileContent } from "../../utilities/test-utils";
 import { TextContentModelType } from "../tools/text/text-content";
@@ -112,8 +111,7 @@ describe("document model", () => {
   });
 
   it("can set content", () => {
-    const content = createSingleTileContent({ type: "Text", text: "test" });
-    document.setContent(DocumentContentModel.create(content));
+    document.setContent(createSingleTileContent({ type: "Text", text: "test" }));
     expect(document.content!.tileMap.size).toBe(1);
     document.content!.tileMap.forEach(tile => {
       const textContent = tile.content as TextContentModelType;

--- a/src/models/document/document.test.ts
+++ b/src/models/document/document.test.ts
@@ -37,6 +37,7 @@ var mockQueryClient = {
 
 describe("document model", () => {
   let document: DocumentModelType;
+  let documentWithoutContent: DocumentModelType;
 
   beforeEach(() => {
     document = DocumentModel.create({
@@ -45,6 +46,13 @@ describe("document model", () => {
       key: "test",
       createdAt: 1,
       content: {},
+      visibility: "public"
+    });
+    documentWithoutContent = DocumentModel.create({
+      type: ProblemDocument,
+      uid: "1",
+      key: "test",
+      createdAt: 1,
       visibility: "public"
     });
   });
@@ -96,6 +104,12 @@ describe("document model", () => {
       },
       changeCount: 0
     });
+  });
+
+  it("can create documents without content and set the content later", () => {
+    expect(documentWithoutContent.content).toBeUndefined();
+    documentWithoutContent.setContent({});
+    expect(documentWithoutContent.content).toBeDefined();
   });
 
   it("can set creation date/time", () => {

--- a/src/models/document/document.ts
+++ b/src/models/document/document.ts
@@ -1,7 +1,7 @@
-import { types, Instance, SnapshotIn } from "mobx-state-tree";
+import { applySnapshot, types, Instance, SnapshotIn } from "mobx-state-tree";
 import { forEach } from "lodash";
 import { QueryClient, UseQueryResult } from "react-query";
-import { DocumentContentModel, DocumentContentModelType } from "./document-content";
+import { DocumentContentModel, DocumentContentSnapshotType } from "./document-content";
 import {
   DocumentType, DocumentTypeEnum, IDocumentContext, ISetProperties, LearningLogDocument, LearningLogPublication,
   PersonalDocument, PersonalPublication, PlanningDocument, ProblemDocument, ProblemPublication,
@@ -169,8 +169,13 @@ export const DocumentModel = types
       }
     },
 
-    setContent(content: DocumentContentModelType) {
-      self.content = content;
+    setContent(snapshot: DocumentContentSnapshotType) {
+      if (self.content) {
+        applySnapshot(self.content, snapshot);
+      }
+      else {
+        self.content = DocumentContentModel.create(snapshot);
+      }
     },
 
     toggleVisibility(visibility?: "public" | "private") {
@@ -233,7 +238,7 @@ export const DocumentModel = types
             const networkDocument = await getNetworkDocument({ context, context_id, uid, key });
             const { content, metadata } = networkDocument.data as IGetNetworkDocumentResponse;
             const _content = safeJsonParse(content.content);
-            _content && self.setContent(DocumentContentModel.create(_content));
+            _content && self.setContent(_content);
             self.setCreatedAt(metadata.createdAt);
             return { content, metadata };
           });


### PR DESCRIPTION
In debugging a separate issue, I encountered (again) the fact that the model objects used by our tile components frequently seem to get destroyed out from under them and then subsequently recreated. After looking into this further it appears that there is a relatively straightforward fix. Historically, our firebase listeners have essentially done the following upon receipt of a new document snapshot from firebase:
```typescript
documentModel.setContent(DocumentContentModel.create(snapshot));
```
i.e. every firebase snapshot gets turned into a new `DocumentContentModel` which then replaces the existing content model along with all of its internal tile models.

The simple fix here is to replace `DocumentModel.setContent()` with the following:
```typescript
if (self.content) {
  applySnapshot(self.content, snapshot);
}
else {
  self.content = DocumentContentModel.create(snapshot);
}
```
In other words, if we already have a content model we should deserialize the snapshot into the existing model rather than replacing it with a brand new model.

This frequent destruction/replacement of document contents can lead to MST console warnings about accessing objects after they've been destroyed and other noteworthy consequences (such as the other issue I was investigating when I found this), which this change should minimize.