### PR TITLE
Eliminate duplicate image tile ids in SAS teacher's guide

### DIFF
--- a/src/public/curriculum/stretching-and-shrinking/sas-teacher-guide.json
+++ b/src/public/curriculum/stretching-and-shrinking/sas-teacher-guide.json
@@ -518,14 +518,12 @@
                     }
                   },
                   {
-                    "id": "DPMOfLD2PxQ3Lz_t",
                     "content": {
                       "type": "Image",
                       "url": "curriculum/stretching-and-shrinking/images/SASTG_1-2_presenting_the_challenge_2.png"
                     }
                   },
                   {
-                    "id": "DPMOfLD2PxQ3Lz_t",
                     "content": {
                       "type": "Image",
                       "url": "curriculum/stretching-and-shrinking/images/SASTG_1-2_presenting_the_challenge_3.png"


### PR DESCRIPTION
While investigating the same set of issues that led to #1138 and #1139, I noticed that even after fixing those two issues there was still an image tile being destroyed/recreated. It turns out that the authored content for the SAS teacher's guide included two image tiles with the same id, which meant that the second one replaced the first. The practical consequence of this was that only the left-handed image was shown rather than both the left- and right-handed images which presumably was the intent. The fix here is simply to remove the ids, as they will be assigned automatically if they're not present.

This is in the SAS teacher guide, problem 1.2, Launch section.