### PR TITLE
Only load teacher guide content for teachers

### DIFF
--- a/src/models/curriculum/unit.test.ts
+++ b/src/models/curriculum/unit.test.ts
@@ -1,3 +1,4 @@
+import { destroy, getSnapshot } from "mobx-state-tree";
 import { UnitModel, isDifferentUnitAndProblem } from "./unit";
 import { IStores } from "../stores/stores";
 
@@ -15,6 +16,26 @@ describe("UnitModel", () => {
                 title: "Unit 1",
                 investigations: [ inInvestigation1, inInvestigation2 ]
               });
+
+  it("installs user listener and calls reaction with true for teachers", () => {
+    const isTeacherFn = jest.fn(() => true);
+    const reactionFn = jest.fn();
+    const unit2 = UnitModel.create(getSnapshot(unit));
+    unit2.installUserListener(isTeacherFn, reactionFn);
+    expect(isTeacherFn).toHaveBeenCalled();
+    expect(reactionFn.mock.calls[0][0]).toBe(true);
+    destroy(unit2);
+  });
+
+  it("installs user listener and calls reaction with false for students", () => {
+    const isTeacherFn = jest.fn(() => false);
+    const reactionFn = jest.fn();
+    const unit2 = UnitModel.create(getSnapshot(unit));
+    unit2.installUserListener(isTeacherFn, reactionFn);
+    expect(isTeacherFn).toHaveBeenCalled();
+    expect(reactionFn.mock.calls[0][0]).toBe(false);
+    destroy(unit2);
+  });
 
   it("getInvestigation() should work as expected", () => {
     expect(unit.getInvestigation(0)).toBeUndefined();

--- a/src/models/stores/stores.ts
+++ b/src/models/stores/stores.ts
@@ -114,12 +114,18 @@ export const setUnitAndProblem = async (stores: IStores, unitId: string | undefi
   }
   stores.problemPath = getProblemPath(stores);
 
-  const guideJson = await getGuideJson(unitId, stores.appConfig);
-  const unitGuide = guideJson && UnitModel.create(guideJson);
-  const teacherGuide = unitGuide?.getProblem(problemOrdinal || stores.appConfig.defaultProblemOrdinal)?.problem;
-  if (teacherGuide) {
-    stores.teacherGuide = teacherGuide;
-  }
+  // need to use a listener because user type can be determined after unit initialization
+  unit.installUserListener(() => stores.user.isTeacher, async (isTeacher: boolean) => {
+    // only load the teacher guide content for teachers
+    if (isTeacher && !stores.teacherGuide) {
+      const guideJson = await getGuideJson(unitId, stores.appConfig);
+      const unitGuide = guideJson && UnitModel.create(guideJson);
+      const teacherGuide = unitGuide?.getProblem(problemOrdinal || stores.appConfig.defaultProblemOrdinal)?.problem;
+      if (teacherGuide) {
+        stores.teacherGuide = teacherGuide;
+      }
+    }
+  });
 };
 
 export function isShowingTeacherContent(stores: IStores) {


### PR DESCRIPTION
@lbondaryk recently asked about the performance implications of the tremendous amount of content that is built into CLUE, i.e. does having JSON for many different units present in the application, each of which contains references to many different images have any performance implications. The answer to both of those questions is no, thankfully, because we only load JSON files for the active unit and we only load images for displayed content. This investigation led me to discover one inefficiency, however, which can also be viewed as a security concern, namely that we were previously loading the teacher guide content for the unit unconditionally. We were only _displaying_ it for teachers, but the teacher guide content was still being loaded for students, which is both a performance issue and also a security concern in that a sophisticated student could potentially find the content intended only for teachers in the debugger. With this PR we make sure that we only load teacher guide content for teachers.