### PR TITLE
Don't let image tile override row height of multi-tile rows

### DIFF
--- a/src/components/document/tile-row.tsx
+++ b/src/components/document/tile-row.tsx
@@ -187,11 +187,14 @@ export class TileRowComponent extends BaseComponent<IProps, IState> {
   };
 
   private handleRequestRowHeight = (tileId: string, height?: number, deltaHeight?: number) => {
-    const rowHeight = this.props.model.height;
+    const { height: modelHeight, tileCount, setRowHeight } = this.props.model;
+    const rowHeight = modelHeight;
     const newHeight = rowHeight != null && deltaHeight != null
                         ? rowHeight + deltaHeight
                         : height;
-    (newHeight != null) && this.props.model.setRowHeight(newHeight);
+    // don't shrink the height of a multi-tile row based on a request from a single tile
+    if ((tileCount > 1) && (rowHeight != null) && (newHeight != null) && (newHeight < rowHeight)) return;
+    (newHeight != null) && setRowHeight(newHeight);
   };
 
   private handleStartResizeRow = (e: React.DragEvent<HTMLDivElement>) => {

--- a/src/components/document/tile-row.tsx
+++ b/src/components/document/tile-row.tsx
@@ -187,8 +187,7 @@ export class TileRowComponent extends BaseComponent<IProps, IState> {
   };
 
   private handleRequestRowHeight = (tileId: string, height?: number, deltaHeight?: number) => {
-    const { height: modelHeight, tileCount, setRowHeight } = this.props.model;
-    const rowHeight = modelHeight;
+    const { height: rowHeight, tileCount, setRowHeight } = this.props.model;
     const newHeight = rowHeight != null && deltaHeight != null
                         ? rowHeight + deltaHeight
                         : height;

--- a/src/public/curriculum/stretching-and-shrinking/stretching-and-shrinking.json
+++ b/src/public/curriculum/stretching-and-shrinking/stretching-and-shrinking.json
@@ -300,6 +300,9 @@
                   [
                     {
                       "id": "jVu0lyX6VmWRgOhY",
+                      "layout": {
+                        "height": 120
+                      },
                       "content": {
                         "type": "Text",
                         "format": "html",
@@ -662,6 +665,9 @@
                 [
                   {
                     "id": "xNSvm1tfNTblOYgf",
+                    "layout": {
+                      "height": 250
+                    },
                     "content": {
                       "type": "Text",
                       "format": "html",


### PR DESCRIPTION
When a text tile is next to an image tile in curriculum content, the height of the image tile was overriding the height of the row regardless of the height of the text tile. With this change, we no longer allow image tiles in multi-tile rows to override an authored height. The fix is narrow enough that it seems safe to make this change close to the upcoming release.

This is used in this case to fix the height of a "Text" tile in the `Initial Challenge` section of SAS 0.1 ("When you click into a text tile...") and a "Text" tile in the `What If...?` section of SAS 0.1 ("The Share slider makes your work...").

Testable at https://collaborative-learning.concord.org/branch/row-height-fix/?demo.