### PR TITLE
Multiple document monitoring/saving-related improvements

### DIFF
--- a/cypress/integration/clue/branch/student_tests/workspace_test_spec.js
+++ b/cypress/integration/clue/branch/student_tests/workspace_test_spec.js
@@ -61,6 +61,8 @@ context('Test the overall workspace', function () {
       clueCanvas.addTile('text');
       textToolTile.enterText('This is the ' + tab1 + ' in Problem ' + problem1 + '{enter}');
       textToolTile.getTextTile().last().should('contain', 'Problem ' + problem1);
+      // the save to firebase is debounced, so we need to wait for it to complete
+      cy.wait(3000);
 
       cy.visit('?appMode=qa&fakeClass=5&fakeUser=student:1&qaGroup=1&problem=' + problem2);
       cy.waitForLoad();

--- a/src/hooks/network-resources.test.ts
+++ b/src/hooks/network-resources.test.ts
@@ -86,13 +86,25 @@ describe("Network resources hooks", () => {
                   planningDocuments: {
                     "planning-1": { self: { uid: "user-1" }, documentKey: "planning-1", visibility: "private" }
                   }
+                }, {  // should handle documents with invalid metadata
+                  uid: "user-2",
+                  problemDocuments: {
+                    "problem-2": { visibility: "public" }
+                  },
+                  planningDocuments: {
+                    "planning-2": { visibility: "private" }
+                  }
                 }]
               }]
             }]
           }
         });
       });
-      renderHook(() => useNetworkResources());
+      jestSpyConsole("warn", async (mockConsoleFn, mockRestore) => {
+        await renderHook(() => useNetworkResources());
+        expect(mockConsoleFn).toHaveBeenCalledTimes(2);
+        mockRestore();
+      }, { asyncRestore: true });
       expect(mockGetNetworkResources).toHaveBeenCalled();
     });
   });

--- a/src/hooks/network-resources.ts
+++ b/src/hooks/network-resources.ts
@@ -75,18 +75,30 @@ export function useNetworkResources() {
         offering.teachers?.forEach(teacher => {
           keys = [];
           each(teacher.problemDocuments, (metadata: DBOfferingUserProblemDocument) => {
-            const { self: { uid }, documentKey: key, visibility } = metadata;
+            const { self: { uid } = { uid: null }, documentKey: key, visibility } = metadata || {};
             const type = ProblemDocument;
-            documents.add(DocumentModel.create({ uid, type, key, remoteContext, visibility }));
-            keys.push(key);
+            if (uid && key) {
+              documents.add(DocumentModel.create({ uid, type, key, remoteContext, visibility }));
+              keys.push(key);
+            }
+            else {
+              console.warn("Warning: useNetworkResources encountered invalid problem document metadata:",
+                            JSON.stringify(metadata));
+            }
           });
           teacher.problemDocuments && (teacher.problemDocuments = keys);
           keys = [];
           each(teacher.planningDocuments, (metadata: DBOfferingUserProblemDocument) => {
-            const { self: { uid }, documentKey: key, visibility } = metadata;
+            const { self: { uid } = { uid: null }, documentKey: key, visibility } = metadata;
             const type = PlanningDocument;
-            documents.add(DocumentModel.create({ uid, type, key, remoteContext, visibility }));
-            keys.push(key);
+            if (uid && key) {
+              documents.add(DocumentModel.create({ uid, type, key, remoteContext, visibility }));
+              keys.push(key);
+            }
+            else {
+              console.warn("Warning: useNetworkResources encountered invalid problem document metadata:",
+                            JSON.stringify(metadata));
+            }
           });
           teacher.planningDocuments && (teacher.planningDocuments = keys);
         });

--- a/src/lib/db-listeners/db-problem-documents-listener.ts
+++ b/src/lib/db-listeners/db-problem-documents-listener.ts
@@ -76,8 +76,9 @@ export class DBProblemDocumentsListener extends BaseListener {
   private handleOfferingUser = (user: DBOfferingUser) => {
     if (!user?.self?.uid) return;
     const { documents, user: currentUser, groups } = this.db.stores;
+    const isOwnDocument = user.self.uid === currentUser.id;
     // monitor problem documents
-    if (size(user.documents) === 0) {
+    if (isOwnDocument && (size(user.documents) === 0)) {
       documents.resolveRequiredDocumentPromise(null, ProblemDocument);
     }
     forEach(user.documents, document => {
@@ -89,7 +90,6 @@ export class DBProblemDocumentsListener extends BaseListener {
         // both teachers and students listen to all problem documents
         // but only teachers listen to all content.  students only listen
         // to content of users in their group to reduce network traffic
-        const isOwnDocument = user.self.uid === currentUser.id;
         const userInGroup = groups.userInGroup(document.self.uid, currentUser.latestGroupId);
         // Local changes take precedence over remote changes
         const monitor = isOwnDocument
@@ -109,14 +109,13 @@ export class DBProblemDocumentsListener extends BaseListener {
       }
     });
     // monitor planning documents
-    if (size(user.planning) === 0) {
+    if (isOwnDocument && (size(user.planning) === 0)) {
       documents.resolveRequiredDocumentPromise(null, PlanningDocument);
     }
     forEach(user.planning, document => {
       if (!document?.documentKey || !document?.self?.uid) return;
       const existingDoc = documents.getDocument(document.documentKey);
       if (!existingDoc) {
-        const isOwnDocument = user.self.uid === currentUser.id;
         this.db.createDocumentModelFromProblemMetadata(PlanningDocument, document.self.uid, document, Monitor.Local)
           .then(doc => {
             documents.add(doc);

--- a/src/lib/db-listeners/db-problem-documents-listener.ts
+++ b/src/lib/db-listeners/db-problem-documents-listener.ts
@@ -105,7 +105,6 @@ export class DBProblemDocumentsListener extends BaseListener {
               syncStars(doc, this.db);
               this.db.listeners.monitorDocumentVisibility(doc);
             }
-            return doc;
           });
       }
     });
@@ -117,8 +116,12 @@ export class DBProblemDocumentsListener extends BaseListener {
       if (!document?.documentKey || !document?.self?.uid) return;
       const existingDoc = documents.getDocument(document.documentKey);
       if (!existingDoc) {
+        const isOwnDocument = user.self.uid === currentUser.id;
         this.db.createDocumentModelFromProblemMetadata(PlanningDocument, document.self.uid, document, Monitor.Local)
-          .then(documents.add);
+          .then(doc => {
+            documents.add(doc);
+            isOwnDocument && documents.resolveRequiredDocumentPromise(doc);
+          });
       }
     });
   };

--- a/src/lib/db-listeners/index.test.ts
+++ b/src/lib/db-listeners/index.test.ts
@@ -1,0 +1,37 @@
+import { DBListeners } from ".";
+import { DocumentModel } from "../../models/document/document";
+import { ProblemDocument } from "../../models/document/document-types";
+import { DocumentsModel } from "../../models/stores/documents";
+import { createStores } from "../../models/stores/stores";
+import { UserModel } from "../../models/stores/user";
+import { DB, Monitor } from "../db";
+
+describe("DBListeners", () => {
+  const stores = createStores({
+    appMode: "test",
+    documents: DocumentsModel.create(),
+    user: UserModel.create({id: "1", portal: "example.com"})
+  });
+  const db = new DB();
+  const document = DocumentModel.create({
+                    uid: "1", type: ProblemDocument, key: "doc-1", content: {} });
+
+  beforeEach(async () => {
+    await db.connect({appMode: "test", stores, dontStartListeners: true});
+  });
+
+  afterEach(() => {
+    db.disconnect();
+  });
+
+  it("warns when monitoring the same document multiple times", () => {
+    const listeners = new DBListeners(db);
+    expect(listeners).toBeDefined();
+
+    listeners.monitorDocument(document, Monitor.Local);
+    jestSpyConsole("warn", mockConsole => {
+      listeners.monitorDocument(document, Monitor.Local);
+      expect(mockConsole).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/lib/db-listeners/index.ts
+++ b/src/lib/db-listeners/index.ts
@@ -260,13 +260,14 @@ export class DBListeners extends BaseListener {
       return;
     }
 
-    const { key, content } = document;
+    const { type, key, content } = document;
 
     const docListener = this.db.listeners.getOrCreateModelListener(`document:${key}`);
     if (docListener.modelDisposer) {
       console.warn("Warning: monitorDocumentModel is monitoring a document that was already being monitored!",
-                    "key:", key, "contentId:", content?.contentId);
+                    "type:", type, "key:", key, "contentId:", content?.contentId);
       docListener.modelDisposer();
+      docListener.modelDisposer = undefined;
     }
 
     if (content) {

--- a/src/lib/db-listeners/index.ts
+++ b/src/lib/db-listeners/index.ts
@@ -1,9 +1,9 @@
 import firebase from "firebase/app";
+import { debounce } from "lodash";
 import { observable, makeObservable } from "mobx";
-import { IDisposer, onSnapshot } from "mobx-state-tree";
+import { getSnapshot, IDisposer, onPatch, onSnapshot } from "mobx-state-tree";
 
 import { DB, Monitor } from "../db";
-// import { LogEventName, Logger } from "../logger";
 import { DBLatestGroupIdListener } from "./db-latest-group-id-listener";
 import { DBGroupsListener } from "./db-groups-listener";
 import { DBOtherDocumentsListener } from "./db-other-docs-listener";
@@ -235,57 +235,49 @@ export class DBListeners extends BaseListener {
     }
   };
 
+  private debouncedSaveDocument = debounce((document: DocumentModelType) => {
+    const { user } = this.db.stores;
+    const { key, changeCount, content } = document;
+    if (content) {
+      const updatePath = this.db.firebase.getUserDocumentPath(user, key, document.uid);
+      this.db.firebase.ref(updatePath)
+        // convert undefined values to null before sending to firebase
+        .update({ changeCount, content: JSON.stringify(getSnapshot(content)) })
+        .then(() => {
+          // console.log("Successful save", "document:", key, "changeCount:", changeCount);
+        })
+        .catch(() => {
+          user.setIsFirebaseConnected(false);
+          console.warn("Failed save!", "document:", key, "changeCount:", changeCount);
+        });
+    }
+    // two-second debounce so that, for instance, we save when the user pauses while typing
+  }, 2000);
+
   private monitorDocumentModel = (document: DocumentModelType, monitor: Monitor) => {
     // skip if not monitoring local changes
     if (monitor !== Monitor.Local) {
       return;
     }
 
-    const { user } = this.db.stores;
     const { key, content } = document;
 
     const docListener = this.db.listeners.getOrCreateModelListener(`document:${key}`);
     if (docListener.modelDisposer) {
       docListener.modelDisposer();
     }
-    else {
-      // Only log the first time we monitor the document. We generally monitor/unmonitor/remonitor
-      // several times during startup, but this function always adds monitoring as the last step,
-      // so logging the first instance is sufficient for our purposes.
-      // Logger.log(LogEventName.INTERNAL_MONITOR_DOCUMENT,
-      //           { type: document.type, key: document.key, uid: document.uid, groupId: document.groupId });
-    }
 
-    const updatePath = this.db.firebase.getUserDocumentPath(user, key, document.uid);
-    const updateRef = this.db.firebase.ref(updatePath);
     if (content) {
-      docListener.modelDisposer = onSnapshot(content, (newContent) => {
-                                    document.incChangeCount();
-                                    updateRef.update({
-                                      content: JSON.stringify(newContent),
-                                      changeCount: document.changeCount
-                                    })
-                                    .then(() => {
-                                      // console.log("Successful save", "document:", document.key,
-                                      //             "changeCount:", document.changeCount);
-                                    })
-                                    .catch(() => {
-                                      user.setIsFirebaseConnected(false);
-                                      // console.warn("Failed save!", "document:", document.key,
-                                      //             "changeCount:", document.changeCount);
-                                    });
-                                  });
+      docListener.modelDisposer = onPatch(content, (patch) => {
+        document.incChangeCount();
+        this.debouncedSaveDocument(document);
+      });
     }
   };
 
   private unmonitorDocumentModel = (document: DocumentModelType) => {
     // This is currently only called for unmonitoring remote documents as a result of group changes, but
     // if it were to be called for a user's own document the result would be not saving the user's work.
-    const { user } = this.db.stores;
-    if (user.id === document.uid) {
-      // Logger.log(LogEventName.INTERNAL_UNMONITOR_DOCUMENT,
-      //           { type: document.type, key: document.key, uid: document.uid, groupId: document.groupId });
-    }
     const docListener = this.modelListeners[`document:${document.key}`];
     docListener?.modelDisposer?.();
   };

--- a/src/lib/db-listeners/index.ts
+++ b/src/lib/db-listeners/index.ts
@@ -241,7 +241,6 @@ export class DBListeners extends BaseListener {
     if (content) {
       const updatePath = this.db.firebase.getUserDocumentPath(user, key, document.uid);
       this.db.firebase.ref(updatePath)
-        // convert undefined values to null before sending to firebase
         .update({ changeCount, content: JSON.stringify(getSnapshot(content)) })
         .then(() => {
           // console.log("Successful save", "document:", key, "changeCount:", changeCount);
@@ -265,6 +264,8 @@ export class DBListeners extends BaseListener {
 
     const docListener = this.db.listeners.getOrCreateModelListener(`document:${key}`);
     if (docListener.modelDisposer) {
+      console.warn("Warning: monitorDocumentModel is monitoring a document that was already being monitored!",
+                    "key:", key, "contentId:", content?.contentId);
       docListener.modelDisposer();
     }
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -292,11 +292,12 @@ export class DB {
       }
       else {
         console.error("ERROR: Can't create required problem document without an appropriate promise!");
+        return Promise.resolve(null);
       }
     }
 
     // personal document
-    const requiredPersonalDocument = documents.requiredDocuments[ProblemDocument];
+    const requiredPersonalDocument = documents.requiredDocuments[PersonalDocument];
     if (requiredPersonalDocument) {
       // The promise is resolved with the first non-deleted personal document. More work will be
       // required if we are to, for instance, return the most recently created/modified document.
@@ -313,6 +314,10 @@ export class DB {
         ? this.openOtherDocument(PersonalDocument, lastPersonalDocument.self.documentKey)
         // if we didn't find one then create a new one
         : this.createPersonalDocument({ content: defaultContent });
+    }
+    else {
+      console.error("ERROR: Can't create required personal document without an appropriate promise!");
+      return Promise.resolve(null);
     }
   }
 

--- a/src/models/stores/documents.test.ts
+++ b/src/models/stores/documents.test.ts
@@ -1,18 +1,47 @@
 import { DocumentModel, DocumentModelType } from "../document/document";
-import { ProblemDocument, DocumentType} from "../document/document-types";
+import {
+  DocumentType, LearningLogDocument, PersonalDocument, PlanningDocument, ProblemDocument
+} from "../document/document-types";
 import { DocumentsModelType, DocumentsModel } from "./documents";
 import { ClassModelType, ClassModel, ClassUserModel } from "./class";
+
+const kUserId = "1";
 
 describe("documents model", () => {
   let documents: DocumentsModelType;
   let document: DocumentModelType;
+  let personalDocument: DocumentModelType;
+  let planningDocument: DocumentModelType;
+  let learningLog: DocumentModelType;
 
   beforeEach(() => {
     document = DocumentModel.create({
       type: ProblemDocument,
-      title: "test",
-      uid: "1",
+      uid: kUserId,
       key: "test",
+      createdAt: 1,
+      content: {}
+    });
+    personalDocument = DocumentModel.create({
+      type: PersonalDocument,
+      title: "Personal",
+      uid: kUserId,
+      key: "test-personal",
+      createdAt: 1,
+      content: {}
+    });
+    planningDocument = DocumentModel.create({
+      type: PlanningDocument,
+      uid: kUserId,
+      key: "test-planning",
+      createdAt: 1,
+      content: {}
+    });
+    learningLog = DocumentModel.create({
+      type: LearningLogDocument,
+      title: "LearningLog",
+      uid: kUserId,
+      key: "test-learning-log",
       createdAt: 1,
       content: {}
     });
@@ -23,9 +52,37 @@ describe("documents model", () => {
     expect(documents.all.length).toBe(0);
   });
 
-  it("allows documents to be added", () => {
+  it("allows documents to be added and retrieved by key", () => {
     documents.add(document);
+    documents.add(personalDocument);
+    documents.add(planningDocument);
+    documents.add(learningLog);
     expect(documents.getDocument("test")).toBe(document);
+    expect(documents.getDocument("test-personal")).toBe(personalDocument);
+    expect(documents.getDocument("test-planning")).toBe(planningDocument);
+    expect(documents.getDocument("test-learning-log")).toBe(learningLog);
+  });
+
+  it("allows documents to be added and retrieved by type", () => {
+    documents.add(document);
+    documents.add(personalDocument);
+    documents.add(planningDocument);
+    documents.add(learningLog);
+    expect(documents.getProblemDocument(kUserId)).toBe(document);
+    expect(documents.getPersonalDocument(kUserId)).toBe(personalDocument);
+    expect(documents.getPlanningDocument(kUserId)).toBe(planningDocument);
+    expect(documents.getLearningLogDocument(kUserId)).toBe(learningLog);
+  });
+
+  it("allows documents to be added and filtered by type", () => {
+    documents.add(document);
+    documents.add(personalDocument);
+    documents.add(planningDocument);
+    documents.add(learningLog);
+    expect(documents.byTypeForUser(ProblemDocument, kUserId)).toEqual([document]);
+    expect(documents.byTypeForUser(PersonalDocument, kUserId)).toEqual([personalDocument]);
+    expect(documents.byTypeForUser(PlanningDocument, kUserId)).toEqual([planningDocument]);
+    expect(documents.byTypeForUser(LearningLogDocument, kUserId)).toEqual([learningLog]);
   });
 
   it("does not allow duplicate documents to be added", () => {

--- a/src/models/stores/stores.ts
+++ b/src/models/stores/stores.ts
@@ -9,7 +9,8 @@ import { ClassModel, ClassModelType } from "./class";
 import { DB } from "../../lib/db";
 import { DemoModelType, DemoModel } from "./demo";
 import { SupportsModel, SupportsModelType } from "./supports";
-import { DocumentsModelType, DocumentsModel } from "./documents";
+import { DocumentsModelType, DocumentsModel, createDocumentsModelWithRequiredDocuments } from "./documents";
+import { LearningLogDocument, PersonalDocument, PlanningDocument, ProblemDocument } from "../document/document-types";
 import { LearningLogWorkspace, ProblemWorkspace } from "./workspace";
 import { ClipboardModel, ClipboardModelType } from "./clipboard";
 import { SelectionStoreModel, SelectionStoreModelType } from "./selection";
@@ -47,6 +48,9 @@ interface ICreateStores extends Partial<IStores> {
   demoName?: string;
 }
 
+// all possible required document types; not all applications/instances require all documents
+const requiredDocumentTypes = [PersonalDocument, PlanningDocument, ProblemDocument, LearningLogDocument];
+
 export function createStores(params?: ICreateStores): IStores {
   const user = params?.user || UserModel.create({ id: "0" });
   const appConfig = params?.appConfig || AppConfigModel.create();
@@ -73,7 +77,7 @@ export function createStores(params?: ICreateStores): IStores {
     groups: params?.groups || GroupsModel.create({ acceptUnknownStudents: params?.isPreviewing }),
     class: params?.class || ClassModel.create({ name: "Null Class", classHash: "" }),
     db: params?.db || new DB(),
-    documents: params?.documents || DocumentsModel.create({}),
+    documents: params?.documents || createDocumentsModelWithRequiredDocuments(requiredDocumentTypes),
     networkDocuments: params?.networkDocuments || DocumentsModel.create({}),
     unit: params?.unit || UnitModel.create({code: "NULL", title: "Null Unit"}),
     demo: params?.demo || DemoModel.create({name: demoName, class: {id: "0", name: "Null Class"}}),

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -21,17 +21,21 @@ enableFetchMocks();
 
  */
 type ConsoleMethod = "log" | "warn" | "error";
-(global as any).jestSpyConsole = (method: ConsoleMethod, fn: (spyFn: jest.SpyInstance) => void) => {
+type JestSpyConsoleFn = (spyFn: jest.SpyInstance, mockRestore: () => void) => void;
+interface IJestSpyConsoleOptions {
+  asyncRestore?: boolean;
+}
+(global as any).jestSpyConsole = (method: ConsoleMethod, fn: JestSpyConsoleFn, options?: IJestSpyConsoleOptions) => {
   // intercept and suppress console methods
   const mockConsoleFn = jest.spyOn(global.console, method).mockImplementation(() => null);
 
   // call the client's code
-  fn(mockConsoleFn);
+  fn(mockConsoleFn, () => mockConsoleFn.mockRestore());
 
   // restore console behavior
-  mockConsoleFn.mockRestore();
+  !options?.asyncRestore && mockConsoleFn.mockRestore();
 };
 
 declare global {
-  function jestSpyConsole(method: ConsoleMethod, fn: (spyFn: jest.SpyInstance) => void): void;
+  function jestSpyConsole(method: ConsoleMethod, fn: JestSpyConsoleFn, options?: IJestSpyConsoleOptions): void;
 }


### PR DESCRIPTION
- Use onPatch() and throttledSaveDocument() for local document monitoring rather than onSnapshot()
- Fix several race conditions and redundant document instances

In my investigation of recent data loss reports, I did some experimenting with MST's `onPatch` and `onSnapshot` handlers. During this investigation, I encountered some situations in which the `onSnapshot` handler did not fire but the `onPatch` handler did. In fact, the `onPatch` handler often fires multiple times for a single change in situations when the `onSnapshot` handler doesn't fire at all. Therefore, we replace the `onSnapshot` handler we were using previously for detecting document content changes with an `onPatch` handler and we then throttle the saving so that multiple patches in succession will only trigger a single save. With throttling, a continuous stream of changes will still save every two seconds so that, for instance, other students in the group should see updates at least every two seconds. There's no smoking gun that links this to the students that reported data loss recently, but this seems like an improvement in an area that could be plausibly involved.

Further investigation revealed that the switch from `onSnapshot` to `onPatch` was insufficient to fix the problems. To understand the next piece it helps to review how the system is supposed to work. A document is represented by a record in firebase. When a user launches CLUE, we create a MobX-State-Tree (MST) model to represent the document within the application. We then monitor the MST document for changes using an MST mechanism such as `onPatch` mentioned above. When we detect that changes have occurred to the document, we save it back to firebase. The working assumption for the data-loss issues that have been reported over the years has been that something is disrupting this change-detection mechanism. In other words, changes are being made to the MST document instance, but something has detached or disrupted the change-detection mechanism so that the corresponding save to firebase is never triggered.

It now appears that this hypothesis was mistaken. The problem is not that something is interfering with the monitoring of the document and saving it to firebase -- the problem is with the assumption that there is a single MST document instance to begin with. It turns out that essentially from the beginning there have been redundant code paths for converting firebase documents to MST documents and concomitant race conditions that influenced which (if any) of the resulting documents would be successfully monitored/saved. Our monitoring system can only monitor one instance of a given document at a time. If the one we are monitoring is not the one being edited by the user, then changes to that document instance will not trigger a save. The problem is not with the monitoring mechanism itself, but with the decision-making around which document instance to monitor. There is a moment in many elaborate debugging sagas in which the question switches from being _"How can this possibly not work?"_ to _"How did this ever work?!?"_ This is that moment.

My best guess is that pre-2.0 we had managed to build a system that depended on these redundant code paths and race conditions falling out in a certain way for its correct behavior, but that somehow the system fell out that way the vast majority of the time. We were still creating multiple document instances, but the resulting race conditions almost always resulted in the same document instance being both edited by the user and monitored for saving purposes. In 2.0 I fixed some unrelated issues, notably the fact that we were loading some documents multiple times. I suspect that these improvements changed the delicate/fragile timing so that the failure paths became more likely. With this PR I hope to stamp them out once and for all. 🤞 

Before we get to the fix itself, it is useful to go into the details of some of the failure paths as that will provide context for understanding the fix.

- For a user launching CLUE for the first time, when we detect that the user does not yet have a problem document, we create one in firebase, create the corresponding MST document instance, and add it to our store of MST documents. But the act of creating the document in firebase also triggers one of our DB listeners, which responds by creating its own corresponding MST document instance and adding it to the `documents` store as well. One of these two document instances will be created before the other, one of them will be edited by the user, and one of them will be monitored. But which will be which? (The new user scenario isn't terribly common in practice, given that it only happens once for each user, but it's a common scenario in cypress tests.)
- When a returning user launches CLUE, part of the launch process is loading the user's documents from firebase and creating a corresponding MST document instance for each of them. Separately, there is code to check whether the required documents (problem and learning log documents for students, plus a planning document for teachers) already exist and to create them if they don't. These two processes weren't synchronized so if the required document code checks whether the documents exists before the document loading code has loaded them, the former will create document instances that are redundant with those being loaded at the same time by the latter.

There are probably other failure paths as well, but this is sufficient to provide the necessary context. All of the code for creating/loading firebase documents and for creating/monitoring MST document instances must be synchronized so that we don't create redundant document instances and always monitor the correct document instances.

To accomplish this we start with a set of promises, one for each required document type, that are managed by the `documents` store. Every client with the ability to create one of these documents must await the corresponding promise to determine whether one already exists. Every client with the ability to create or load one of these documents must update the corresponding promise appropriately. MST document instances should either be created procedurally _or_ by the corresponding DB listener, but _not both_.

@mklewandowski @scytacki I hope that this epic PR introduction is sufficient for the code changes to make sense. Given the multiple reports of data loss last week I'd like to get this into production as soon as possible. I believe I'm done making changes to the code itself but I'm planning to flesh out the test coverage a bit.

Testable at https://collaborative-learning.concord.org/branch/on-patch-document/?demo