### PR TITLE
Release 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Version 2.1.1 - released December 13, 2021
+
+### Bugs Fixed
+- Fixed bug which could prevent some documents from saving correctly in some circumstances #1148
+- Other stability improvements #1147
+
+### Asset Sizes
+
+| File | Size | % Change from Previous Release |
+|---|---|---|
+| index.css | 420,985 bytes | 0.0% |
+| index.js | 4,032,012 bytes | 0.0% |
+
 ## Version 2.1.0 - released December 8, 2021
 
 ### Features/Improvements

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "collaborative-learning",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "collaborative-learning",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
         "@blueprintjs/core": "^3.51.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collaborative-learning",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Collaborative Learning environment",
   "main": "index.js",
   "config": {


### PR DESCRIPTION
## Version 2.1.1 - released December 13, 2021

### Bugs Fixed
- Fixed bug which could prevent some documents from saving correctly in some circumstances #1148
- Other stability improvements #1147

### Asset Sizes

| File | Size | % Change from Previous Release |
|---|---|---|
| index.css | 420,985 bytes | 0.0% |
| index.js | 4,032,012 bytes | 0.0% |