### PR TITLE
More robust handling of errors when opening an invalid or corrupted firebase document

### DIFF
--- a/src/lib/db-listeners/db-other-docs-listener.ts
+++ b/src/lib/db-listeners/db-other-docs-listener.ts
@@ -75,7 +75,6 @@ export class DBOtherDocumentsListener extends BaseListener {
                 ? this.db.listeners.monitorPersonalDocument
                 : this.db.listeners.monitorLearningLogDocument)
         .then(doc => {
-          documents.add(doc);
           if (doc.uid === user.id) {
             !doc.getProperty("isDeleted") && documents.resolveRequiredDocumentPromise(doc);
             (doc.type === PersonalDocument) && syncStars(doc, this.db);
@@ -86,12 +85,10 @@ export class DBOtherDocumentsListener extends BaseListener {
   };
 
   private handlePublicationAdded = (snapshot: firebase.database.DataSnapshot) => {
-    const {documents} = this.db.stores;
     const dbDoc: DBOtherPublication|null = snapshot.val();
     this.debugLogSnapshot("#handlePublicationAdded", snapshot);
     if (dbDoc) {
-      this.db.createDocumentModelFromOtherPublication(dbDoc, this.publicationType)
-        .then(documents.add);
+      this.db.createDocumentModelFromOtherPublication(dbDoc, this.publicationType);
     }
   };
 

--- a/src/lib/db-listeners/db-problem-documents-listener.ts
+++ b/src/lib/db-listeners/db-problem-documents-listener.ts
@@ -99,7 +99,6 @@ export class DBProblemDocumentsListener extends BaseListener {
                             : Monitor.None;
         this.db.createDocumentModelFromProblemMetadata(ProblemDocument, document.self.uid, document, monitor)
           .then((doc) => {
-            documents.add(doc);
             if (isOwnDocument) {
               documents.resolveRequiredDocumentPromise(doc);
               syncStars(doc, this.db);
@@ -118,7 +117,6 @@ export class DBProblemDocumentsListener extends BaseListener {
       if (!existingDoc) {
         this.db.createDocumentModelFromProblemMetadata(PlanningDocument, document.self.uid, document, Monitor.Local)
           .then(doc => {
-            documents.add(doc);
             isOwnDocument && documents.resolveRequiredDocumentPromise(doc);
           });
       }

--- a/src/lib/db-listeners/db-publications-listener.ts
+++ b/src/lib/db-listeners/db-publications-listener.ts
@@ -58,11 +58,9 @@ export class DBPublicationsListener extends BaseListener {
   };
 
   private handlePublication = (publication: DBPublication|null) => {
-    const {documents} = this.db.stores;
     if (publication) {
       this.db.createDocumentFromPublication(publication)
         .then(doc => {
-          documents.add(doc);
           syncStars(doc, this.db);
           onPatch(doc.comments, patch => {
             const [, tileId, , index, replaceKey] = patch.path.split("/");

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -607,8 +607,21 @@ export class DB {
         .then(([documentSnapshot, metadataSnapshot]) => {
           const document: DBDocument|null = documentSnapshot.val();
           const metadata: DBDocumentMetadata|null = metadataSnapshot.val();
-          if (!document || !metadata) {
-            throw new Error("Unable to open document");
+          if (!metadata) {
+            // if we have no metadata, there's nothing we can do
+            const msg = `Error retrieving metadata for ` +
+                        `document '${documentKey}' of type '${type}' for user '${userId}'`;
+            throw new Error(msg);
+          }
+          if (!document) {
+            // If we have metadata but no document content, we can return a valid empty document.
+            // This has been seen to occur in the wild, presumably as a result of a prior bug.
+            const msg = "Warning: Reconstituting empty contents for " +
+                        `document '${documentKey}' of type '${type}' for user '${userId}'`;
+            console.warn(msg);
+            return DocumentModel.create({
+                                  type, title, properties, groupId, visibility, uid: userId, originDoc,
+                                  key: documentKey, createdAt: metadata.createdAt, content: {}, changeCount: 0 });
           }
 
           const content = this.parseDocumentContent(document);

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -595,6 +595,7 @@ export class DB {
   }
 
   public openDocument(options: OpenDocumentOptions) {
+    const { documents } = this.stores;
     const {documentKey, type, title, properties, userId, groupId, visibility, originDoc} = options;
     return new Promise<DocumentModelType>((resolve, reject) => {
       const {user} = this.stores;
@@ -640,6 +641,7 @@ export class DB {
           });
         })
         .then((document) => {
+          documents.add(document);
           resolve(document);
         })
         .catch(reject);
@@ -798,10 +800,7 @@ export class DB {
     const {title, properties, uid, originDoc, self: {documentKey}} = publication;
     const group = this.stores.groups.groupForUser(uid);
     const groupId = group && group.id;
-    return this.openDocument({type, userId: uid, documentKey, groupId, title, properties, originDoc})
-      .then((document) => {
-        return document;
-      });
+    return this.openDocument({type, userId: uid, documentKey, groupId, title, properties, originDoc});
   }
 
   public createDocumentFromPublication(publication: DBPublication) {


### PR DESCRIPTION
In investigating #1148, I came across a demo user with a number of documents with correctly saved metadata but no document contents. The change in this PR turns that error condition into a warning.