### PR TITLE
Improve handling of invalid problem documents in teacher dashboard

### DIFF
--- a/src/clue/components/progress-widget.tsx
+++ b/src/clue/components/progress-widget.tsx
@@ -54,7 +54,12 @@ export class ProgressWidget extends BaseComponent<IProps, IState> {
     const countsPerUser: {[key: string]: ITileCountsPerSection} = {};
     groups.allGroups.forEach(group => {
       documents.getProblemDocumentsForGroup(group.id).forEach(document => {
-        countsPerUser[document.uid] = document.content?.getTileCountsPerSection(sectionIds) || {};
+        // In the normal course of events there should only ever be one problem document per user,
+        // but we've had bugs in the past that resulted in writing additional spurious problem documents.
+        // Therefore, we only assign to countsPerUser for the first problem document we encounter for a user.
+        if (!countsPerUser[document.uid]) {
+          countsPerUser[document.uid] = document.content?.getTileCountsPerSection(sectionIds) || {};
+        }
       });
     });
 


### PR DESCRIPTION
This is another realization stemming from the investigation into #1148. At some point I encountered a failing cypress teacher dashboard test which turned out to be because some of the demo users in the demo class used for the teacher dashboard test had spurious invalid problem documents in addition to the expected problem document, presumably as the result of a prior bug. It is trivial to handle this case in the teacher dashboard code and seems worth doing given the likelihood that other such bugs may be encountered in the future. In this particular case, I also took the liberty of deleting the extraneous problem documents from the affected users, but I tested this code before doing so.