### PR TITLE
Fix divider click behavior

### DIFF
--- a/src/components/document/resize-panel-divider.scss
+++ b/src/components/document/resize-panel-divider.scss
@@ -56,9 +56,6 @@
       top: 50%;
       opacity: 0.01%;
       &:hover {
-        opacity: 50%;
-      }
-      &:active {
         opacity: 100%;
       }
 
@@ -69,6 +66,9 @@
         left: 0;
         z-index: 3;
         cursor: pointer;
+        &:not(:active) {
+          opacity: 50%;
+        }
         &.disabled {
           visibility: hidden;
         }
@@ -80,6 +80,9 @@
         right: 0;
         z-index: 3;
         cursor: pointer;
+        &:not(:active) {
+          opacity: 50%;
+        }
         &.disabled {
           visibility: hidden;
         }

--- a/src/components/document/resize-panel-divider.scss
+++ b/src/components/document/resize-panel-divider.scss
@@ -9,11 +9,18 @@
     height: calc(100vh - (#{$header-height} + #{$workspace-content-margin} * 2));
     transition-duration: .5s;
 
+    &.divider-min {
+      align-items: flex-start;
+    }
+    &.divider-max {
+      align-items: flex-end;
+    }
+
     .divider {
       position: absolute;
       width: 4px;
       height: 100%;
-      margin: 10px 2px 0;
+      margin: 4px 2px 0;
       border-radius: 2px;
       background-color: $charcoal-light-4;
       z-index: 1;
@@ -26,6 +33,18 @@
       margin-top: 9px;
       top: 50%;
     }
+
+    &.divider-min {
+      .drag-thumbnail {
+        margin-left: 2px;
+      }
+    }
+    &.divider-max {
+      .drag-thumbnail {
+        margin-right: 2px;
+      }
+    }
+
     .drag-handles {
       display: flex;
       flex-direction: row;
@@ -38,10 +57,11 @@
       opacity: 0.01%;
       &:hover {
         opacity: 50%;
+      }
       &:active {
         opacity: 100%;
       }
-    }
+
       .drag-left-handle {
         position: absolute;
         width: 21px;
@@ -63,6 +83,12 @@
         &.disabled {
           visibility: hidden;
         }
+      }
+    }
+
+    &.divider-min, &.divider-max {
+      .drag-handles {
+        width: 26px;
       }
     }
   }

--- a/src/components/document/resize-panel-divider.tsx
+++ b/src/components/document/resize-panel-divider.tsx
@@ -1,3 +1,4 @@
+import classNames from "classnames";
 import React from "react";
 import DragThumbnailIcon from "../../assets/drag-thumb-icon.svg";
 import LeftDragIcon from "../../assets/left-drag.svg";
@@ -13,16 +14,21 @@ interface IProps {
 }
 
 export const ResizePanelDivider: React.FC <IProps> =
-  ({isResourceExpanded, dividerPosition, onExpandWorkspace, onExpandResources}) => {
-    const dividerLeftOffset = 22;
+  ({dividerPosition, onExpandWorkspace, onExpandResources}) => {
+    const dividerMinLeftOffset = 39.5;
+    const dividerMidLeftOffset = 21;
+    const dividerMaxLeftOffset = 22;
     const tabWidth = 45;
     const dividerPositionStyle = dividerPosition  === kDividerMin
-                                  ? {left: dividerLeftOffset}
+                                  ? {left: dividerMinLeftOffset}
                                   : dividerPosition === kDividerMax
-                                      ? {left: `calc(${dividerPosition}% - ${tabWidth}px - ${dividerLeftOffset}px)`}
-                                      : {left: `calc(${dividerPosition}% - ${dividerLeftOffset}px)`};
+                                      ? {left: `calc(${dividerPosition}% - ${tabWidth}px - ${dividerMaxLeftOffset}px)`}
+                                      : {left: `calc(${dividerPosition}% - ${dividerMidLeftOffset}px)`};
+    const classes = classNames("resize-panel-divider", {
+                                "divider-min": dividerPosition  === kDividerMin,
+                                "divider-max": dividerPosition === kDividerMax });
   return (
-    <div className="resize-panel-divider" style={dividerPositionStyle}>
+    <div className={classes} style={dividerPositionStyle}>
       <div className="divider" />
       <div className="drag-handles">
         {!(dividerPosition === kDividerMin) &&


### PR DESCRIPTION
PT: [[#180731992]](https://www.pivotaltracker.com/story/show/180731992)

Demo: https://collaborative-learning.concord.org/branch/fix-divider/?demo

The essence of the fix here is that instead of having the divider always be as wide as the two arrow buttons, even when only one of the buttons is showing, now we shrink the divider to be only wide enough to contain one arrow button when only one is showing. In other words, in the min and max positions, the divider container no longer overlaps the sidebars which contain their own arrow buttons. To accomplish this we add new `divider-min` and `divider-max` classes to the `resize-panel-divider` and use those to tweak the styles for the min/max positions. The styling feels fragile here, but a larger refactor didn't seem warranted in this case.