### PR TITLE
Geometry: fix axis dialog contention [#180769939]

### DIFF
--- a/src/components/tools/geometry-tool/geometry-content.tsx
+++ b/src/components/tools/geometry-tool/geometry-content.tsx
@@ -1457,7 +1457,13 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
 
   private handleCreateAxis = (axis: JXG.Line) => {
     const handlePointerDown = (evt: any) => {
-      if (!this.props.readOnly) {
+      const { readOnly, scale } = this.props;
+      const { board } = this.state;
+      // Axis labels get the event preferentially even though we think of other potentially
+      // overlapping objects (like movable line labels) as being on top. Therefore, we only
+      // open the axis settings dialog if we consider the axis label to be the preferred
+      // clickable object at the position of the event.
+      if (board && !readOnly && (axis.label === getClickableObjectUnderMouse(board, evt, false, scale))) {
         this.handleOpenAxisSettings();
       }
     };


### PR DESCRIPTION
[[#180769939]](https://www.pivotaltracker.com/story/show/180769939)

Only present axis settings dialog when axis label is top-most clicked element.