### PR TITLE
Fix axis ticks crash [#180805779]

### DIFF
--- a/src/models/tools/geometry/jxg-board.ts
+++ b/src/models/tools/geometry/jxg-board.ts
@@ -309,12 +309,14 @@ export const boardChangeAgent: JXGChangeAgent = {
           const xRange = width / unitX;
           const yRange = height / unitY;
           const bbox: JXG.BoundingBox = [xMin, yMin + yRange, xMin + xRange, yMin];
-          board.setBoundingBox(bbox);
+          // remove old axes before resetting bounding box
           board.objectsList.forEach(el => {
             if (el.elType === "axis") {
               board.removeObject(el);
             }
           });
+          // set new bounding box and then create new axes
+          board.setBoundingBox(bbox);
           const axes = addAxes(board, {
                                 unitX, unitY,
                                 ...toObj("xName", xName), ...toObj("yName", yName),


### PR DESCRIPTION
PT: [[#180805779]](https://www.pivotaltracker.com/story/show/180805779)

Demo: https://collaborative-learning.concord.org/branch/fix-axis-ticks/?demo

A teacher reported that one of her students had a problem in which CLUE would crash every time he visited the four-up view. The real problem turned out to be that another student in his group had a geometry tile which would hang when viewed. Drilling down into the offending geometry tile indicated that the second student had changed the bounds to be enormous and that for some reason the code was hanging while trying to process thousands of axis ticks. Several hours of debugging later, the source of the trouble turned out to be the fact that when resizing axes we were:
1. Setting the new axis bounds
2. Removing the old axes
3. Creating the new axes

Unfortunately, JSXGraph has an odd behavior/bug in that when any object is deleted, it automatically updates the remaining objects. This is true not only for objects like axes, but also for child objects like tick marks. The result was that during the process of removing the old axes, existing objects were being updated, which resulted in the tick mark calculations being run with the new bounds but old tick mark distances, which resulted in the generation of thousands of tick marks. Leaving aside the question of the inefficiency of re-running tick mark calculations during the process of removing axes, the simple fix is to change the order of operations to:
1. Remove the old axes
2. Set the new axis bounds
3. Create the new axes

which prevents the generation of thousands of spurious ticks.