### PR TITLE
Geometry: handle axis bounds changes more efficiently

### DIFF
--- a/src/components/tools/geometry-tool/geometry-content.tsx
+++ b/src/components/tools/geometry-tool/geometry-content.tsx
@@ -11,7 +11,7 @@ import { GeometryContentModelType, GeometryMetadataModelType, setElementColor, g
 import { copyCoords, getEventCoords, getAllObjectsUnderMouse, getClickableObjectUnderMouse,
           isDragTargetOrAncestor } from "../../../models/tools/geometry/geometry-utils";
 import { RotatePolygonIcon } from "./rotate-polygon-icon";
-import { getPointsByCaseId } from "../../../models/tools/geometry/jxg-board";
+import { getPointsByCaseId, resumeBoardUpdates, suspendBoardUpdates } from "../../../models/tools/geometry/jxg-board";
 import { ESegmentLabelOption, ILinkProperties, JXGChange, JXGCoordPair
         } from "../../../models/tools/geometry/jxg-changes";
 import { kSnapUnit } from "../../../models/tools/geometry/jxg-point";
@@ -109,7 +109,7 @@ function syncBoardChanges(board: JXG.Board, content: GeometryContentModelType,
   const newElements: JXG.GeometryElement[] = [];
   const changedElements: JXG.GeometryElement[] = [];
   const syncedChanges = content.changes.length;
-  board.suspendUpdate();
+  suspendBoardUpdates(board);
   for (let i = prevSyncedChanges || 0; i < syncedChanges; ++i) {
     try {
       const change: JXGChange = JSON.parse(content.changes[i]);
@@ -129,7 +129,7 @@ function syncBoardChanges(board: JXG.Board, content: GeometryContentModelType,
 
   // update vertex angles affected by changed points
   updateVertexAnglesFromObjects(changedElements);
-  board.unsuspendUpdate();
+  resumeBoardUpdates(board);
 
   return { newElements: newElements.length ? newElements : undefined };
 }
@@ -358,14 +358,14 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
         // If the incoming list of changes is shorter, an undo has occurred.
         // In this case, clear the board and replay it.
         if (this.syncedChanges > geometryContent.changes.length) {
-          board.suspendUpdate();
+          suspendBoardUpdates(board);
           // Board initialization creates 2 objects: the info box and the grid.
           // These won't be recreated if the board already exists so we don't delete them.
           const kDefaultBoardObjects = 2;
           for (let i = board.objectsList.length - 1; i >= kDefaultBoardObjects; i--) {
             board.removeObject(board.objectsList[i]);
           }
-          board.unsuspendUpdate();
+          resumeBoardUpdates(board);
         }
         const syncedChanges = this.syncedChanges > geometryContent.changes.length
                                 ? 0

--- a/src/models/tools/geometry/geometry-content.ts
+++ b/src/models/tools/geometry/geometry-content.ts
@@ -15,7 +15,7 @@ import { canonicalizeValue, linkedPointId } from "../table/table-model-types";
 import { exportGeometryJson } from "./geometry-export";
 import { defaultGeometryBoardChange, preprocessImportFormat } from "./geometry-import";
 import { getAxisAnnotations, getBaseAxisLabels, getObjectById, guessUserDesiredBoundingBox,
-          kAxisBuffer, syncAxisLabels } from "./jxg-board";
+          kAxisBuffer, resumeBoardUpdates, suspendBoardUpdates, syncAxisLabels } from "./jxg-board";
 import { ESegmentLabelOption, forEachNormalizedChange, ILinkProperties, JXGChange, JXGCoordPair,
           JXGProperties, JXGParentType, JXGUnsafeCoordPair } from "./jxg-changes";
 import { applyChange, applyChanges, IDispatcherChangeContext } from "./jxg-dispatcher";
@@ -429,7 +429,7 @@ export const GeometryContentModel = ToolContentModel
           changeElems.forEach(changeElem => {
             if (isBoard(changeElem)) {
               board = changeElem;
-              board.suspendUpdate();
+              suspendBoardUpdates(board);
             }
             else if (onCreate) {
               onCreate(changeElem);
@@ -437,7 +437,7 @@ export const GeometryContentModel = ToolContentModel
           });
         });
       if (board) {
-        board.unsuspendUpdate();
+        resumeBoardUpdates(board);
       }
       return board;
     }

--- a/src/models/tools/geometry/jsxgraph.d.ts
+++ b/src/models/tools/geometry/jsxgraph.d.ts
@@ -36,6 +36,7 @@ declare namespace JXG {
     containerObj: HTMLElement;
     cssTransMat: number[][];
     isSuspendedUpdate: boolean;
+    suspendCount: number | undefined; // CC addition
     keepaspectratio: boolean;
     origin: {
       usrCoords: [number, number, number],

--- a/src/models/tools/geometry/jxg-board.test.ts
+++ b/src/models/tools/geometry/jxg-board.test.ts
@@ -1,0 +1,47 @@
+import { resumeBoardUpdates, suspendBoardUpdates } from "./jxg-board";
+
+describe("suspendBoardUpdates/resumeBoardUpdates", () => {
+
+  const suspendUpdate = jest.fn();
+  const unsuspendUpdate = jest.fn();
+
+  let board: any;
+
+  beforeEach(() => {
+    suspendUpdate.mockReset();
+    unsuspendUpdate.mockReset();
+    board = { suspendCount: 0, suspendUpdate, unsuspendUpdate };
+  });
+
+  it("ignores requests to resume updates for a board that hasn't been suspended", () => {
+    jestSpyConsole("warn", spy => {
+      resumeBoardUpdates(board);
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(unsuspendUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  it("non-nested suspend/resume of updates should work", () => {
+    suspendBoardUpdates(board);
+    expect(suspendUpdate).toHaveBeenCalledTimes(1);
+    expect(unsuspendUpdate).not.toHaveBeenCalled();
+    resumeBoardUpdates(board);
+    expect(suspendUpdate).toHaveBeenCalledTimes(1);
+    expect(unsuspendUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("nested suspend/resume of updates should work", () => {
+    suspendBoardUpdates(board);
+    expect(suspendUpdate).toHaveBeenCalledTimes(1);
+    expect(unsuspendUpdate).not.toHaveBeenCalled();
+    suspendBoardUpdates(board);
+    expect(suspendUpdate).toHaveBeenCalledTimes(1);
+    expect(unsuspendUpdate).not.toHaveBeenCalled();
+    resumeBoardUpdates(board);
+    expect(suspendUpdate).toHaveBeenCalledTimes(1);
+    expect(unsuspendUpdate).not.toHaveBeenCalled();
+    resumeBoardUpdates(board);
+    expect(suspendUpdate).toHaveBeenCalledTimes(1);
+    expect(unsuspendUpdate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/models/tools/geometry/jxg-dispatcher.ts
+++ b/src/models/tools/geometry/jxg-dispatcher.ts
@@ -1,6 +1,8 @@
 import { JXGChange, JXGChangeAgent, JXGChangeResult, JXGCreateHandler, JXGObjectType, IChangeContext
         } from "./jxg-changes";
-import { boardChangeAgent, getObjectById, kReverse, sortByCreation } from "./jxg-board";
+import {
+  boardChangeAgent, getObjectById, kReverse, resumeBoardUpdates, sortByCreation, suspendBoardUpdates
+} from "./jxg-board";
 import { commentChangeAgent } from "./jxg-comment";
 import { imageChangeAgent } from "./jxg-image";
 import { movableLineChangeAgent } from "./jxg-movable-line";
@@ -46,12 +48,12 @@ export function applyChanges(board: JXG.Board|string, changes: JXGChange[],
                     const resultBoard = castArray(result).find(isBoard);
                     if ((typeof board === "string") && resultBoard) {
                       _board = resultBoard;
-                      _board.suspendUpdate();
+                      suspendBoardUpdates(_board);
                     }
                     return result;
                   });
   if (_board) {
-    _board.unsuspendUpdate();
+    resumeBoardUpdates(_board);
   }
   return results;
 }

--- a/src/models/tools/geometry/jxg-table-link.ts
+++ b/src/models/tools/geometry/jxg-table-link.ts
@@ -1,4 +1,4 @@
-import { syncLinkedPoints } from "./jxg-board";
+import { resumeBoardUpdates, suspendBoardUpdates, syncLinkedPoints } from "./jxg-board";
 import { ILinkProperties, ITableLinkProperties, JXGChange, JXGChangeAgent, JXGCoordPair } from "./jxg-changes";
 import { createPoint, pointChangeAgent } from "./jxg-point";
 import { isPoint } from "./jxg-types";
@@ -99,9 +99,9 @@ export const tableLinkChangeAgent: JXGChangeAgent = {
       const pts = board.objectsList.filter(elt => {
                     return isPoint(elt) && tableId && (elt.getAttribute("linkedTableId") === tableId);
                   });
-      board.suspendUpdate();
+      suspendBoardUpdates(board);
       pts.reverse().forEach(pt => board.removeObject(pt));
-      board.unsuspendUpdate();
+      resumeBoardUpdates(board);
     }
   }
 };


### PR DESCRIPTION
PT: arose from investigation of [[#180805779]](https://www.pivotaltracker.com/story/show/180805779)

Demo: https://collaborative-learning.concord.org/branch/nested-suspend/?demo

- suspend updates while handling axis bounds changes
- support nested suspension of updates

Note: this PR is _not_ expected to be merged for release 2.1.2. I think we should give it more time for testing and then release it in the _next_ release.