### PR TITLE
Adjust X axis bounds to leave room for Y axis labels [#180817314]

### DIFF
--- a/cypress/integration/clue/branch/student_tests/graph_table_integraton_test_spec.js
+++ b/cypress/integration/clue/branch/student_tests/graph_table_integraton_test_spec.js
@@ -107,7 +107,7 @@ context('Tests for graph and table integration', function () {
         tableToolTile.getTableCell().eq(10).click();
         tableToolTile.getTableCell().eq(10).type(new_y + '{enter}');
       });
-      graphToolTile.getGraphPointCoordinates(2).should('contain', '(8, ' + new_y + ')');
+      graphToolTile.getGraphPointCoordinates(2).should('contain', '(6, ' + new_y + ')');
     });
     it('will delete a point in the table', function () {
       let point = 0; //the 4th point in the graph
@@ -161,13 +161,14 @@ context('Tests for graph and table integration', function () {
   describe('normal graph interactions', function () {
     it('will add a polygon directly onto the graph', function () {
       graphToolTile.getGraphTile().click();
-      graphToolTile.addPointToGraph(5, 5); //not sure why this isn't appearing
-      graphToolTile.addPointToGraph(10, 15);
-      graphToolTile.addPointToGraph(13, 10);
-      graphToolTile.addPointToGraph(5, 10);
+      graphToolTile.addPointToGraph(10, 10); //not sure why this isn't appearing
+      graphToolTile.addPointToGraph(10, 10);
+      graphToolTile.addPointToGraph(15, 10);
+      graphToolTile.addPointToGraph(10, 5);
       graphToolTile.getGraphPoint().last().click({ force: true }).click({ force: true });
     });
-    it('will add and angle to a point created from a table', function () {
+    it('will add an angle to a point created from a table', function () {
+      graphToolTile.getGraphPolygon().last().click({force: true});
       graphToolTile.showAngle();
       graphToolTile.getAngleAdornment().should('exist');
     });

--- a/cypress/integration/clue/branch/student_tests/graph_tool_spec.js
+++ b/cypress/integration/clue/branch/student_tests/graph_tool_spec.js
@@ -155,9 +155,9 @@ context('Test graph tool functionalities', function(){
                     .trigger('mousedown',{dataTransfer, force:true})
                     .trigger('mousemove',{clientX:transX, clientY:transY, dataTransfer, force:true})
                     .trigger('mouseup',{dataTransfer, force:true});
-                graphToolTile.getGraphPointCoordinates(0).should('contain', '(12, 6)');
+                graphToolTile.getGraphPointCoordinates(0).should('contain', '(12, 5)');
                 graphToolTile.getGraphPointCoordinates(1).should('contain', '(18, 11)');
-                graphToolTile.getGraphPointCoordinates(2).should('contain', '(21, 6)');
+                graphToolTile.getGraphPointCoordinates(2).should('contain', '(21, 5)');
             });
             it('verify rotate tool is visible when polygon is selected', function(){
                 graphToolTile.getGraphPolygon().click({force:true});

--- a/cypress/support/elements/clue/GraphToolTile.js
+++ b/cypress/support/elements/clue/GraphToolTile.js
@@ -1,22 +1,25 @@
-const graphUnit=18.33;
+const kGraphPixPerCoord = { x: 18.33, y: -18.33 };
+// determined by inspection
+const kGraphOriginCoordPix = { x: 40, y: 296 };
+
+function pointCoordsToPix(ptCoords, originPix) {
+    return { x: originPix.x + ptCoords.x * kGraphPixPerCoord.x,
+             y: originPix.y + ptCoords.y * kGraphPixPerCoord.y };
+}
+
+function pointPixToCoords(ptPix, originPix) {
+    const x = Math.round((ptPix.x - originPix.x) / kGraphPixPerCoord.x);
+    const y = Math.round((ptPix.y - originPix.y) / kGraphPixPerCoord.y);
+    return { x: x === 0 ? 0 : x, y: y === 0 ? 0 : y }; // convert -0 to 0
+}
 
 class GraphToolTile{
     transformFromCoordinate(axis, num){
-        if (axis==='x'){
-            return (num+1.05)*graphUnit;
-        }
-        if (axis==='y'){
-            // return 320-((num+1.2)*graphUnit);
-            return 316-((num+1.05)*graphUnit);
-        }
+        return kGraphOriginCoordPix[axis] + num * kGraphPixPerCoord[axis];
     }
     transformToCoordinate(axis, num){
-        if (axis==='x'){
-            return Math.round(((num-(graphUnit))/graphUnit));
-        }
-        if (axis==='y'){
-            return Math.round((((num-320+(graphUnit*1.2))/(-1*graphUnit))));
-        }
+        const coord = Math.round((num - kGraphOriginCoordPix[axis]) / kGraphPixPerCoord[axis]);
+        return coord === 0 ? 0 : coord; // convert -0 to 0
     }
     getGraphTile(workspaceClass){
         return cy.get(`${workspaceClass || ".primary-workspace"} .canvas-area .geometry-tool`);

--- a/src/models/tools/geometry/geometry-content.ts
+++ b/src/models/tools/geometry/geometry-content.ts
@@ -14,8 +14,10 @@ import { getAxisLabelsFromDataSet, getTableContent, kLabelAttrName } from "../ta
 import { canonicalizeValue, linkedPointId } from "../table/table-model-types";
 import { exportGeometryJson } from "./geometry-export";
 import { defaultGeometryBoardChange, preprocessImportFormat } from "./geometry-import";
-import { getAxisAnnotations, getBaseAxisLabels, getObjectById, guessUserDesiredBoundingBox,
-          kAxisBuffer, resumeBoardUpdates, suspendBoardUpdates, syncAxisLabels } from "./jxg-board";
+import {
+  getAxisAnnotations, getBaseAxisLabels, getObjectById, guessUserDesiredBoundingBox, kAxisBuffer,
+  kXAxisMinBuffer, kXAxisTotalBuffer, kYAxisTotalBuffer, resumeBoardUpdates, suspendBoardUpdates, syncAxisLabels
+} from "./jxg-board";
 import { ESegmentLabelOption, forEachNormalizedChange, ILinkProperties, JXGChange, JXGCoordPair,
           JXGProperties, JXGParentType, JXGUnsafeCoordPair } from "./jxg-changes";
 import { applyChange, applyChanges, IDispatcherChangeContext } from "./jxg-dispatcher";
@@ -451,19 +453,20 @@ export const GeometryContentModel = ToolContentModel
       // so we need to do the same to get the new canvasWidth and canvasHeight values
       const scaledWidth = Math.trunc(width) / (scale || 1);
       const scaledHeight = Math.trunc(height) / (scale || 1);
-      const widthMultiplier = (scaledWidth - kAxisBuffer * 2) / (board.canvasWidth - kAxisBuffer * 2);
-      const heightMultiplier = (scaledHeight - kAxisBuffer * 2) / (board.canvasHeight - kAxisBuffer * 2);
+      const widthMultiplier = (scaledWidth - kXAxisTotalBuffer) / (board.canvasWidth - kXAxisTotalBuffer);
+      const heightMultiplier = (scaledHeight - kYAxisTotalBuffer) / (board.canvasHeight - kYAxisTotalBuffer);
       const unitX = board.unitX || kGeometryDefaultPixelsPerUnit;
       const unitY = board.unitY || kGeometryDefaultPixelsPerUnit;
       // Remove the buffers to correct the graph proportions
       const [xMin, yMax, xMax, yMin] = guessUserDesiredBoundingBox(board);
-      const xBufferRange = kAxisBuffer / unitX;
+      const xMinBufferRange = kXAxisMinBuffer / unitX;
+      const xMaxBufferRange = kAxisBuffer / unitX;
       const yBufferRange = kAxisBuffer / unitY;
       // Add the buffers back post-scaling
       const newBoundingBox: JXG.BoundingBox = [
-        xMin * widthMultiplier - xBufferRange,
+        xMin * widthMultiplier - xMinBufferRange,
         yMax * heightMultiplier + yBufferRange,
-        xMax * widthMultiplier + xBufferRange,
+        xMax * widthMultiplier + xMaxBufferRange,
         yMin * heightMultiplier - yBufferRange
       ];
       board.resizeContainer(scaledWidth, scaledHeight, false, true);
@@ -474,8 +477,8 @@ export const GeometryContentModel = ToolContentModel
     function rescaleBoard(board: JXG.Board, params: IAxesParams) {
       const { canvasWidth, canvasHeight } = board;
       const { xName, xAnnotation, xMin, xMax, yName, yAnnotation, yMin, yMax } = params;
-      const width = canvasWidth - kAxisBuffer * 2;
-      const height = canvasHeight - kAxisBuffer * 2;
+      const width = canvasWidth - kXAxisTotalBuffer;
+      const height = canvasHeight - kYAxisTotalBuffer;
       const unitX = width / (xMax - xMin);
       const unitY = height / (yMax - yMin);
       const change: JXGChange = {

--- a/src/models/tools/geometry/geometry-import.ts
+++ b/src/models/tools/geometry/geometry-import.ts
@@ -1,7 +1,7 @@
 import { castArray } from "lodash";
 import { uniqueId } from "../../../utilities/js-utils";
 import { gImageMap } from "../../image-map";
-import { kAxisBuffer } from "./jxg-board";
+import { kAxisBuffer, kXAxisMinBuffer } from "./jxg-board";
 import { JXGChange, JXGCoordPair, JXGProperties, JXGStringPair } from "./jxg-changes";
 import {
   kGeometryDefaultAxisMin, kGeometryDefaultHeight, kGeometryDefaultPixelsPerUnit, kGeometryDefaultWidth, toObj
@@ -157,9 +157,10 @@ export function defaultGeometryBoardChange(overrides?: JXGProperties) {
   const [xMin, yMax, xMax, yMin] = getBoardBounds();
   const unitX = kGeometryDefaultPixelsPerUnit;
   const unitY = kGeometryDefaultPixelsPerUnit;
-  const xBufferRange = kAxisBuffer / unitX;
+  const xMinBufferRange = kXAxisMinBuffer / unitX;
+  const xMaxBufferRange = kAxisBuffer / unitX;
   const yBufferRange = kAxisBuffer / unitY;
-  const boundingBox = [xMin - (xBufferRange * 2), yMax + yBufferRange, xMax + xBufferRange, yMin - yBufferRange];
+  const boundingBox = [xMin - xMinBufferRange, yMax + yBufferRange, xMax + xMaxBufferRange, yMin - yBufferRange];
   const change: JXGChange = {
     operation: "create",
     target: "board",

--- a/src/models/tools/geometry/jxg-board.ts
+++ b/src/models/tools/geometry/jxg-board.ts
@@ -73,7 +73,13 @@ export function syncLinkedPoints(board: JXG.Board, links: ITableLinkProperties) 
   }
 }
 
+// Buffer space in pixels around the plot for labels, etc.
 export const kAxisBuffer = 20;
+// twice as much buffer for left side of X axis for Y axis labels
+export const kXAxisMinBuffer = 2 * kAxisBuffer;
+export const kXAxisTotalBuffer = 3 * kAxisBuffer;
+export const kYAxisTotalBuffer = 2 * kAxisBuffer;
+
 export const getAxisType = (v: any) => {
   // stdform encodes orientation of axes
   const [ , stdFormY, stdFormX] = v.stdform;
@@ -181,10 +187,11 @@ export function guessUserDesiredBoundingBox(board: JXG.Board) {
   const [xMin, yMax, xMax, yMin] = board.getBoundingBox();
   const unitX = board.unitX;
   const unitY = board.unitY;
-  const xBufferRange = kAxisBuffer / unitX;
+  const xMinBufferRange = kXAxisMinBuffer / unitX;
+  const xMaxBufferRange = kAxisBuffer / unitX;
   const yBufferRange = kAxisBuffer / unitY;
 
-  return [xMin + xBufferRange, yMax - yBufferRange, xMax - xBufferRange, yMin + yBufferRange];
+  return [xMin + xMinBufferRange, yMax - yBufferRange, xMax - xMaxBufferRange, yMin + yBufferRange];
 }
 
 function getAxisLabelsFromProps(props: JXGProperties) {
@@ -314,11 +321,11 @@ export const boardChangeAgent: JXGChangeAgent = {
         const yAnnotation = yPropAnnotation ?? yClientAnnotation;
         const width = board.canvasWidth;
         const height = board.canvasHeight;
-        const widthMultiplier = (width - kAxisBuffer * 2) / canvasWidth;
-        const heightMultiplier = (height - kAxisBuffer * 2) / canvasHeight;
+        const widthMultiplier = (width - kXAxisTotalBuffer) / canvasWidth;
+        const heightMultiplier = (height - kYAxisTotalBuffer) / canvasHeight;
         const unitX = boardScale.unitX;
         const unitY = boardScale.unitY;
-        const xBuffer = kAxisBuffer / unitX;
+        const xBuffer = kXAxisMinBuffer / unitX;
         const yBuffer = kAxisBuffer / unitY;
         // The change might have been performed on a different-sized tile due to a 2-up switch or reload
         // In that case, we need to scale the min/max to preserve user-intended ratios


### PR DESCRIPTION
PT: [[#180817314]](https://www.pivotaltracker.com/story/show/180817314)

Demo: https://collaborative-learning.concord.org/branch/axis-bounds/?demo

Increases the amount of space to the left of the requested axis bounds for axis labels. This additional space will always be present. Dynamically adjusting the space to accommodate the actual size of the Y axis labels is left for another day.