### PR TITLE
Table: Handle expression evaluation exceptions

### DIFF
--- a/src/models/tools/table/table-content.ts
+++ b/src/models/tools/table/table-content.ts
@@ -413,7 +413,13 @@ export const TableContentModel = ToolContentModel
             if (xVal == null || xVal === "") {
               attr.setValue(i, undefined);
             } else {
-              const expressionVal = parsedExpression.evaluate({[kSerializedXKey]: xVal});
+              let expressionVal: number;
+              try {
+                expressionVal = parsedExpression.evaluate({[kSerializedXKey]: xVal});
+              }
+              catch(e) {
+                expressionVal = NaN;
+              }
               attr.setValue(i, isFinite(expressionVal) ? expressionVal : NaN);
             }
           }


### PR DESCRIPTION
This expression evaluation exception was encountered in a user document in the field. The expression evaluator is documented as throwing exceptions if, for instance, an undefined variable is referenced in the expression. Given that, we should handle exceptions appropriately rather than letting them bubble up to callers.