### PR TITLE
Fix spurious references to S&S teacher guide

### DIFF
--- a/src/models/stores/stores.ts
+++ b/src/models/stores/stores.ts
@@ -110,6 +110,11 @@ export const setUnitAndProblem = async (stores: IStores, unitId: string | undefi
   const unit = UnitModel.create(unitJson);
   const {investigation, problem} = unit.getProblem(problemOrdinal || stores.appConfig.defaultProblemOrdinal);
 
+  // if unit changes, clear references to prior teacher guide
+  if (unit.code !== stores.unit.code) {
+    stores.teacherGuide = undefined;
+  }
+
   stores.unit = unit;
   stores.documents.setUnit(stores.unit);
   if (investigation && problem) {


### PR DESCRIPTION
In some paths, CLUE loads the default unit (S&S) before identifying and loading the actual desired unit. In this case we were not replacing the S&S teacher guide with the correct unit-specific teacher guide.