### PR TITLE
Add class hash to image urls

### DIFF
--- a/src/hooks/use-user-context.test.ts
+++ b/src/hooks/use-user-context.test.ts
@@ -2,25 +2,35 @@ import { renderHook } from "@testing-library/react-hooks";
 import { useUserContext } from "./use-user-context";
 
 jest.mock("./use-stores", () => ({
-  useAppMode: () => "test",
-  useClassStore: () => ({
-    users: [
-      { id: "1", type: "student" },
-      { id: "2", type: "student" },
-      { id: "3", type: "teacher" },
-      { id: "4", type: "teacher" },
-    ]
-  }),
-  useDemoStore: () => ({ name: "" }),
-  useUserStore: () => ({
-    id: "1", portal: "portal", type: "student", name: "Me", teacherNetwork: "", classHash: "class-hash"
+  useStores: () => ({
+    appMode: "test",
+    class: {
+      users: [
+        { id: "1", type: "student" },
+        { id: "2", type: "student" },
+        { id: "3", type: "teacher" },
+        { id: "4", type: "teacher" },
+      ]
+    },
+    demo: { name: "" },
+    user: {
+      id: "1", portal: "portal", type: "student", name: "Me", teacherNetwork: "", classHash: "class-hash"
+    }
   })
 }));
 
 describe("useUserContext", () => {
-  it("should return a valid context", () => {
+  it("should return a valid user context", () => {
     const { result } = renderHook(() => useUserContext());
-    expect(result.current.appMode).toBe("test");
-    expect(result.current.teachers).toEqual(["3", "4"]);
+    expect(result.current).toEqual({
+      appMode: "test",
+      demoName: "",
+      portal: "portal",
+      uid: "1",
+      type: "student",
+      name: "Me",
+      classHash: "class-hash",
+      teachers: ["3", "4"]
+    });
   });
 });

--- a/src/hooks/use-user-context.ts
+++ b/src/hooks/use-user-context.ts
@@ -1,18 +1,21 @@
 import { useMemo } from "react";
 import { IUserContext } from "../../functions/src/shared";
-import { useAppMode, useClassStore, useDemoStore, useUserStore } from "./use-stores";
+import { IStores } from "../models/stores/stores";
+import { useStores } from "./use-stores";
+
+export const getUserContext = (stores: IStores): IUserContext => {
+  const appMode = stores.appMode;
+  const { name: demoName } = stores.demo;
+  const classInfo = stores.class;
+  const { id: uid, portal, type, name, network, classHash } = stores.user;
+  const teachers: string[] = [];
+  classInfo.users.forEach(user => (user.type === "teacher") && teachers.push(user.id));
+  return {
+    appMode, demoName, portal, uid, type, name, network, classHash, teachers
+  };
+};
 
 export const useUserContext = (): IUserContext => {
-  const appMode = useAppMode();
-  const { name: demoName } = useDemoStore();
-  const classInfo = useClassStore();
-  const { id: uid, portal, type, name, network, classHash } = useUserStore();
-  return useMemo(() => {
-    const teachers: string[] = [];
-    classInfo.users.forEach(user => (user.type === "teacher") && teachers.push(user.id));
-    return {
-      appMode, demoName, portal, uid, type, name, network, classHash, teachers
-    };
-    // user context never changes during a session
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  const stores = useStores();
+  return useMemo(() => getUserContext(stores), [stores]);
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -41,7 +41,7 @@ const initializeApp = async () => {
 
   await setUnitAndProblem(stores, unitId, problemOrdinal);
 
-  gImageMap.initialize(stores.db, user.id);
+  gImageMap.initialize(stores.db);
 
   Logger.initializeLogger(stores, stores.investigation, stores.problem);
 


### PR DESCRIPTION
This is step one in improving our image support and extending it to better handle multi-class image access via publication of multi-class supports. The root cause of some of the complexities in handling multi-class images is that historically image ids/urls have included only the firebase-generated key, which doesn't provide any indication of _where_ within firebase the image data might be found. We can't fix this problem historically without taking on an epic migration of all existing content. We can, however, address the problem moving forward by including the class hash in the id/url we use to refer to newly uploaded images. This will provide a straightforward means of determining whether access to any particular image requires multi-class permissions and the `getImageData()` firebase function or not.

While in the neighborhood we also address one other issue: Some APIs were taking both a `DB` and a `userId`. The `userId` can be determined from the db's `stores` property, so there's no need to pass it separately.