### PR TITLE
Improve captions of network documents [#180876987]

### DIFF
--- a/src/components/thumbnail/tab-panel-documents-subsection-panel.tsx
+++ b/src/components/thumbnail/tab-panel-documents-subsection-panel.tsx
@@ -25,12 +25,13 @@ function getDocumentCaption(stores: IStores, document: DocumentModelType) {
   const { appConfig, problem, class: _class } = stores;
   const { type, uid } = document;
   if (type === SupportPublication) return document.getProperty("caption") || "Support";
-  const userName = document.isRemote
-                    ? "Network User"
-                    : _class?.getUserById(uid)?.displayName || "Unknown User";
-  const namePrefix = isPublishedType(type) ? `${userName}: ` : "";
+  const userName = _class?.getUserById(uid)?.displayName ||
+                    (document.isRemote ? "Network User" : "Unknown User");
+  const namePrefix = document.isRemote || isPublishedType(type) ? `${userName}: ` : "";
+  const dateSuffix = document.isRemote && document.createdAt
+                      ? ` (${new Date(document.createdAt).toLocaleDateString()})` : "";
   const title = getDocumentDisplayTitle(document, appConfig, problem);
-  return `${namePrefix}${title}`;
+  return `${namePrefix}${title}${dateSuffix}`;
 }
 
 export const TabPanelDocumentsSubSectionPanel = ({section, sectionDocument, tab, stores, scale, selectedDocument,

--- a/src/lib/portal-api.ts
+++ b/src/lib/portal-api.ts
@@ -20,7 +20,7 @@ const isClueAssignment = (offering: IPortalOffering) => {
     return true;
   }
   if (externalReports && externalReports.length > 0) {
-    return externalReports.find((report) => clueDashboardRegex.test(report.name));
+    return !!externalReports.find((report) => clueDashboardRegex.test(report.name));
   }
   return false;
 };


### PR DESCRIPTION
[[#180876987]](https://www.pivotaltracker.com/story/show/180876987)

When viewing the contents of networked classes, it can be confusing to see more than one personal or planning document with the same caption. This PR alleviates that by adding the user name and creation date (if known) to the caption shown for networked documents.

<img width="746" alt="NetworkedCaptions" src="https://user-images.githubusercontent.com/235234/152105024-1a67fa32-182d-4a88-ae89-93357d8e2e6a.png">