### PR TITLE
Fix promise-handling bug in creation of planning documents

### DIFF
--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -1,4 +1,3 @@
-import firebase from "firebase/app";
 import { DB } from "./db";
 import { createDocumentsModelWithRequiredDocuments, DocumentsModel } from "../models/stores/documents";
 import { IStores, createStores } from "../models/stores/stores";
@@ -21,7 +20,6 @@ var mockFunctions = jest.fn();
 var mockAuthStateUnsubscribe = jest.fn();
 
 jest.mock("firebase/app", () => {
-  const actual = jest.requireActual("firebase/app");
   return {
     apps: [],
     initializeApp: () => null,

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -378,9 +378,9 @@ export class DB {
         })
         .then((newDocument) => {
           // reset the (presumably null) promise for this document type
-          documents.addRequiredDocumentPromises([ProblemDocument]);
+          documents.addRequiredDocumentPromises([type]);
           // return the promise, which will be resolved by the DB listener
-          return documents.requiredDocuments[ProblemDocument].promise;
+          return documents.requiredDocuments[type].promise;
         })
         .then(resolve)
         .catch(reject);


### PR DESCRIPTION
[[#181124054]](https://www.pivotaltracker.com/story/show/181124054)

Fixes a copy/paste/logic bug in planning document promise-handling which likely explains the occurrence of extraneous planning documents in some circumstances.

@scytacki I also added tests that would have caught the bug, officially closing the barn door. Adding the tests required setting up offline mocking of firebase that should prove useful for writing additional tests down the road.