### PR TITLE
Extend multi-class supports/images to networked teachers [#181147217]

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -8,16 +8,16 @@
       "dependencies": {
         "escape-string-regexp": "^4.0.0",
         "firebase-admin": "^9.12.0",
-        "firebase-functions": "^3.16.0"
+        "firebase-functions": "3.16.0"
       },
       "devDependencies": {
         "@firebase/app-types": "^0.7.0",
         "@firebase/rules-unit-testing": "^1.3.15",
         "@firebase/util": "^1.4.3",
         "@types/jest": "^27.4.0",
-        "@typescript-eslint/eslint-plugin": "^5.10.1",
-        "@typescript-eslint/parser": "^5.10.1",
-        "eslint": "^8.7.0",
+        "@typescript-eslint/eslint-plugin": "^5.10.2",
+        "@typescript-eslint/parser": "^5.10.2",
+        "eslint": "^8.8.0",
         "eslint-plugin-import": "^2.25.4",
         "firebase-functions-test": "^0.3.3",
         "jest": "^27.4.7",
@@ -2338,14 +2338,14 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.10.1.tgz",
-      "integrity": "sha512-xN3CYqFlyE/qOcy978/L0xLR2HlcAGIyIK5sMOasxaaAPfQRj/MmMV6OC3I7NZO84oEUdWCOju34Z9W8E0pFDQ==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.10.2.tgz",
+      "integrity": "sha512-4W/9lLuE+v27O/oe7hXJKjNtBLnZE8tQAFpapdxwSVHqtmIoPB1gph3+ahNwVuNL37BX7YQHyGF9Xv6XCnIX2Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.10.1",
-        "@typescript-eslint/type-utils": "5.10.1",
-        "@typescript-eslint/utils": "5.10.1",
+        "@typescript-eslint/scope-manager": "5.10.2",
+        "@typescript-eslint/type-utils": "5.10.2",
+        "@typescript-eslint/utils": "5.10.2",
         "debug": "^4.3.2",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.1.8",
@@ -2386,14 +2386,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.10.1.tgz",
-      "integrity": "sha512-GReo3tjNBwR5RnRO0K2wDIDN31cM3MmDtgyQ85oAxAmC5K3j/g85IjP+cDfcqDsDDBf1HNKQAD0WqOYL8jXqUA==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.10.2.tgz",
+      "integrity": "sha512-JaNYGkaQVhP6HNF+lkdOr2cAs2wdSZBoalE22uYWq8IEv/OVH0RksSGydk+sW8cLoSeYmC+OHvRyv2i4AQ7Czg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.10.1",
-        "@typescript-eslint/types": "5.10.1",
-        "@typescript-eslint/typescript-estree": "5.10.1",
+        "@typescript-eslint/scope-manager": "5.10.2",
+        "@typescript-eslint/types": "5.10.2",
+        "@typescript-eslint/typescript-estree": "5.10.2",
         "debug": "^4.3.2"
       },
       "engines": {
@@ -2413,13 +2413,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.10.1.tgz",
-      "integrity": "sha512-Lyvi559Gvpn94k7+ElXNMEnXu/iundV5uFmCUNnftbFrUbAJ1WBoaGgkbOBm07jVZa682oaBU37ao/NGGX4ZDg==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.10.2.tgz",
+      "integrity": "sha512-39Tm6f4RoZoVUWBYr3ekS75TYgpr5Y+X0xLZxXqcZNDWZdJdYbKd3q2IR4V9y5NxxiPu/jxJ8XP7EgHiEQtFnw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.10.1",
-        "@typescript-eslint/visitor-keys": "5.10.1"
+        "@typescript-eslint/types": "5.10.2",
+        "@typescript-eslint/visitor-keys": "5.10.2"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2430,12 +2430,12 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.10.1.tgz",
-      "integrity": "sha512-AfVJkV8uck/UIoDqhu+ptEdBoQATON9GXnhOpPLzkQRJcSChkvD//qsz9JVffl2goxX+ybs5klvacE9vmrQyCw==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.10.2.tgz",
+      "integrity": "sha512-uRKSvw/Ccs5FYEoXW04Z5VfzF2iiZcx8Fu7DGIB7RHozuP0VbKNzP1KfZkHBTM75pCpsWxIthEH1B33dmGBKHw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/utils": "5.10.1",
+        "@typescript-eslint/utils": "5.10.2",
         "debug": "^4.3.2",
         "tsutils": "^3.21.0"
       },
@@ -2456,9 +2456,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.10.1.tgz",
-      "integrity": "sha512-ZvxQ2QMy49bIIBpTqFiOenucqUyjTQ0WNLhBM6X1fh1NNlYAC6Kxsx8bRTY3jdYsYg44a0Z/uEgQkohbR0H87Q==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.10.2.tgz",
+      "integrity": "sha512-Qfp0qk/5j2Rz3p3/WhWgu4S1JtMcPgFLnmAKAW061uXxKSa7VWKZsDXVaMXh2N60CX9h6YLaBoy9PJAfCOjk3w==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2469,13 +2469,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.10.1.tgz",
-      "integrity": "sha512-PwIGnH7jIueXv4opcwEbVGDATjGPO1dx9RkUl5LlHDSe+FXxPwFL5W/qYd5/NHr7f6lo/vvTrAzd0KlQtRusJQ==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.10.2.tgz",
+      "integrity": "sha512-WHHw6a9vvZls6JkTgGljwCsMkv8wu8XU8WaYKeYhxhWXH/atZeiMW6uDFPLZOvzNOGmuSMvHtZKd6AuC8PrwKQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.10.1",
-        "@typescript-eslint/visitor-keys": "5.10.1",
+        "@typescript-eslint/types": "5.10.2",
+        "@typescript-eslint/visitor-keys": "5.10.2",
         "debug": "^4.3.2",
         "globby": "^11.0.4",
         "is-glob": "^4.0.3",
@@ -2511,15 +2511,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.10.1.tgz",
-      "integrity": "sha512-RRmlITiUbLuTRtn/gcPRi4202niF+q7ylFLCKu4c+O/PcpRvZ/nAUwQ2G00bZgpWkhrNLNnvhZLbDn8Ml0qsQw==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.10.2.tgz",
+      "integrity": "sha512-vuJaBeig1NnBRkf7q9tgMLREiYD7zsMrsN1DA3wcoMDvr3BTFiIpKjGiYZoKPllfEwN7spUjv7ZqD+JhbVjEPg==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.10.1",
-        "@typescript-eslint/types": "5.10.1",
-        "@typescript-eslint/typescript-estree": "5.10.1",
+        "@typescript-eslint/scope-manager": "5.10.2",
+        "@typescript-eslint/types": "5.10.2",
+        "@typescript-eslint/typescript-estree": "5.10.2",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -2535,12 +2535,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.10.1.tgz",
-      "integrity": "sha512-NjQ0Xinhy9IL979tpoTRuLKxMc0zJC7QVSdeerXs2/QvOy2yRkzX5dRb10X5woNUdJgU8G3nYRDlI33sq1K4YQ==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.10.2.tgz",
+      "integrity": "sha512-zHIhYGGGrFJvvyfwHk5M08C5B5K4bewkm+rrvNTKk1/S15YHR+SA/QUF8ZWscXSfEaB8Nn2puZj+iHcoxVOD/Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.10.1",
+        "@typescript-eslint/types": "5.10.2",
         "eslint-visitor-keys": "^3.0.0"
       },
       "engines": {
@@ -3873,9 +3873,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.7.0.tgz",
-      "integrity": "sha512-ifHYzkBGrzS2iDU7KjhCAVMGCvF6M3Xfs8X8b37cgrUlDt6bWRTpRh6T/gtSXv1HJ/BUGgmjvNvOEGu85Iif7w==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.8.0.tgz",
+      "integrity": "sha512-H3KXAzQGBH1plhYS3okDix2ZthuYJlQQEGE5k0IKuEqUSiyu4AmxxlJ2MtTYeJ3xB4jDhcYCwGOg2TXYdnDXlQ==",
       "dev": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.0.5",
@@ -11490,14 +11490,14 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.10.1.tgz",
-      "integrity": "sha512-xN3CYqFlyE/qOcy978/L0xLR2HlcAGIyIK5sMOasxaaAPfQRj/MmMV6OC3I7NZO84oEUdWCOju34Z9W8E0pFDQ==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.10.2.tgz",
+      "integrity": "sha512-4W/9lLuE+v27O/oe7hXJKjNtBLnZE8tQAFpapdxwSVHqtmIoPB1gph3+ahNwVuNL37BX7YQHyGF9Xv6XCnIX2Q==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.10.1",
-        "@typescript-eslint/type-utils": "5.10.1",
-        "@typescript-eslint/utils": "5.10.1",
+        "@typescript-eslint/scope-manager": "5.10.2",
+        "@typescript-eslint/type-utils": "5.10.2",
+        "@typescript-eslint/utils": "5.10.2",
         "debug": "^4.3.2",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.1.8",
@@ -11518,52 +11518,52 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.10.1.tgz",
-      "integrity": "sha512-GReo3tjNBwR5RnRO0K2wDIDN31cM3MmDtgyQ85oAxAmC5K3j/g85IjP+cDfcqDsDDBf1HNKQAD0WqOYL8jXqUA==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.10.2.tgz",
+      "integrity": "sha512-JaNYGkaQVhP6HNF+lkdOr2cAs2wdSZBoalE22uYWq8IEv/OVH0RksSGydk+sW8cLoSeYmC+OHvRyv2i4AQ7Czg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.10.1",
-        "@typescript-eslint/types": "5.10.1",
-        "@typescript-eslint/typescript-estree": "5.10.1",
+        "@typescript-eslint/scope-manager": "5.10.2",
+        "@typescript-eslint/types": "5.10.2",
+        "@typescript-eslint/typescript-estree": "5.10.2",
         "debug": "^4.3.2"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.10.1.tgz",
-      "integrity": "sha512-Lyvi559Gvpn94k7+ElXNMEnXu/iundV5uFmCUNnftbFrUbAJ1WBoaGgkbOBm07jVZa682oaBU37ao/NGGX4ZDg==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.10.2.tgz",
+      "integrity": "sha512-39Tm6f4RoZoVUWBYr3ekS75TYgpr5Y+X0xLZxXqcZNDWZdJdYbKd3q2IR4V9y5NxxiPu/jxJ8XP7EgHiEQtFnw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.10.1",
-        "@typescript-eslint/visitor-keys": "5.10.1"
+        "@typescript-eslint/types": "5.10.2",
+        "@typescript-eslint/visitor-keys": "5.10.2"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.10.1.tgz",
-      "integrity": "sha512-AfVJkV8uck/UIoDqhu+ptEdBoQATON9GXnhOpPLzkQRJcSChkvD//qsz9JVffl2goxX+ybs5klvacE9vmrQyCw==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.10.2.tgz",
+      "integrity": "sha512-uRKSvw/Ccs5FYEoXW04Z5VfzF2iiZcx8Fu7DGIB7RHozuP0VbKNzP1KfZkHBTM75pCpsWxIthEH1B33dmGBKHw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/utils": "5.10.1",
+        "@typescript-eslint/utils": "5.10.2",
         "debug": "^4.3.2",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.10.1.tgz",
-      "integrity": "sha512-ZvxQ2QMy49bIIBpTqFiOenucqUyjTQ0WNLhBM6X1fh1NNlYAC6Kxsx8bRTY3jdYsYg44a0Z/uEgQkohbR0H87Q==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.10.2.tgz",
+      "integrity": "sha512-Qfp0qk/5j2Rz3p3/WhWgu4S1JtMcPgFLnmAKAW061uXxKSa7VWKZsDXVaMXh2N60CX9h6YLaBoy9PJAfCOjk3w==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.10.1.tgz",
-      "integrity": "sha512-PwIGnH7jIueXv4opcwEbVGDATjGPO1dx9RkUl5LlHDSe+FXxPwFL5W/qYd5/NHr7f6lo/vvTrAzd0KlQtRusJQ==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.10.2.tgz",
+      "integrity": "sha512-WHHw6a9vvZls6JkTgGljwCsMkv8wu8XU8WaYKeYhxhWXH/atZeiMW6uDFPLZOvzNOGmuSMvHtZKd6AuC8PrwKQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.10.1",
-        "@typescript-eslint/visitor-keys": "5.10.1",
+        "@typescript-eslint/types": "5.10.2",
+        "@typescript-eslint/visitor-keys": "5.10.2",
         "debug": "^4.3.2",
         "globby": "^11.0.4",
         "is-glob": "^4.0.3",
@@ -11583,26 +11583,26 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.10.1.tgz",
-      "integrity": "sha512-RRmlITiUbLuTRtn/gcPRi4202niF+q7ylFLCKu4c+O/PcpRvZ/nAUwQ2G00bZgpWkhrNLNnvhZLbDn8Ml0qsQw==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.10.2.tgz",
+      "integrity": "sha512-vuJaBeig1NnBRkf7q9tgMLREiYD7zsMrsN1DA3wcoMDvr3BTFiIpKjGiYZoKPllfEwN7spUjv7ZqD+JhbVjEPg==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.10.1",
-        "@typescript-eslint/types": "5.10.1",
-        "@typescript-eslint/typescript-estree": "5.10.1",
+        "@typescript-eslint/scope-manager": "5.10.2",
+        "@typescript-eslint/types": "5.10.2",
+        "@typescript-eslint/typescript-estree": "5.10.2",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.10.1.tgz",
-      "integrity": "sha512-NjQ0Xinhy9IL979tpoTRuLKxMc0zJC7QVSdeerXs2/QvOy2yRkzX5dRb10X5woNUdJgU8G3nYRDlI33sq1K4YQ==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.10.2.tgz",
+      "integrity": "sha512-zHIhYGGGrFJvvyfwHk5M08C5B5K4bewkm+rrvNTKk1/S15YHR+SA/QUF8ZWscXSfEaB8Nn2puZj+iHcoxVOD/Q==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.10.1",
+        "@typescript-eslint/types": "5.10.2",
         "eslint-visitor-keys": "^3.0.0"
       }
     },
@@ -12637,9 +12637,9 @@
       }
     },
     "eslint": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.7.0.tgz",
-      "integrity": "sha512-ifHYzkBGrzS2iDU7KjhCAVMGCvF6M3Xfs8X8b37cgrUlDt6bWRTpRh6T/gtSXv1HJ/BUGgmjvNvOEGu85Iif7w==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.8.0.tgz",
+      "integrity": "sha512-H3KXAzQGBH1plhYS3okDix2ZthuYJlQQEGE5k0IKuEqUSiyu4AmxxlJ2MtTYeJ3xB4jDhcYCwGOg2TXYdnDXlQ==",
       "dev": true,
       "requires": {
         "@eslint/eslintrc": "^1.0.5",

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "escape-string-regexp": "^4.0.0",
         "firebase-admin": "^9.12.0",
-        "firebase-functions": "3.16.0"
+        "firebase-functions": "3.17.1"
       },
       "devDependencies": {
         "@firebase/app-types": "^0.7.0",
@@ -4606,15 +4606,18 @@
       "integrity": "sha512-zCclL4/rx+W5SQTzFs9wyvvyCwoK9QtBpratqz2IYJ3O8Umrn0m3nsTv0wQBk9sRGpvUe9CwPDrQFB10f1FIjQ=="
     },
     "node_modules/firebase-functions": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.16.0.tgz",
-      "integrity": "sha512-6ISOn0JckMtpA3aJ/+wCCGhThUhBUrpZD+tSkUeolx0Vr+NoYFXA0+2YzJZa/A2MDU8gotPzUtnauLSEQvfClQ==",
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.17.1.tgz",
+      "integrity": "sha512-6HKg7RuefjxB+ffLZeE11SXUBHHRKvKxS7JTdSROBEqrltzIOukiDS0JB4S7vFz+x9pa6fEwTaKg2hmd2FkM4g==",
       "dependencies": {
         "@types/cors": "^2.8.5",
         "@types/express": "4.17.3",
         "cors": "^2.8.5",
         "express": "^4.17.1",
         "lodash": "^4.17.14"
+      },
+      "bin": {
+        "firebase-functions": "lib/bin/firebase-functions.js"
       },
       "engines": {
         "node": "^8.13.0 || >=10.10.0"
@@ -13236,9 +13239,9 @@
       }
     },
     "firebase-functions": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.16.0.tgz",
-      "integrity": "sha512-6ISOn0JckMtpA3aJ/+wCCGhThUhBUrpZD+tSkUeolx0Vr+NoYFXA0+2YzJZa/A2MDU8gotPzUtnauLSEQvfClQ==",
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.17.1.tgz",
+      "integrity": "sha512-6HKg7RuefjxB+ffLZeE11SXUBHHRKvKxS7JTdSROBEqrltzIOukiDS0JB4S7vFz+x9pa6fEwTaKg2hmd2FkM4g==",
       "requires": {
         "@types/cors": "^2.8.5",
         "@types/express": "4.17.3",

--- a/functions/package.json
+++ b/functions/package.json
@@ -25,16 +25,16 @@
   "dependencies": {
     "escape-string-regexp": "^4.0.0",
     "firebase-admin": "^9.12.0",
-    "firebase-functions": "^3.16.0"
+    "firebase-functions": "3.16.0"
   },
   "devDependencies": {
     "@firebase/app-types": "^0.7.0",
     "@firebase/rules-unit-testing": "^1.3.15",
     "@firebase/util": "^1.4.3",
     "@types/jest": "^27.4.0",
-    "@typescript-eslint/eslint-plugin": "^5.10.1",
-    "@typescript-eslint/parser": "^5.10.1",
-    "eslint": "^8.7.0",
+    "@typescript-eslint/eslint-plugin": "^5.10.2",
+    "@typescript-eslint/parser": "^5.10.2",
+    "eslint": "^8.8.0",
     "eslint-plugin-import": "^2.25.4",
     "firebase-functions-test": "^0.3.3",
     "jest": "^27.4.7",

--- a/functions/package.json
+++ b/functions/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "escape-string-regexp": "^4.0.0",
     "firebase-admin": "^9.12.0",
-    "firebase-functions": "3.16.0"
+    "firebase-functions": "3.17.1"
   },
   "devDependencies": {
     "@firebase/app-types": "^0.7.0",

--- a/functions/src/get-image-data.ts
+++ b/functions/src/get-image-data.ts
@@ -4,7 +4,7 @@ import { IGetImageDataUnionParams, isWarmUpParams } from "./shared";
 import { validateUserContext } from "./user-context";
 
 // update this when deploying updates to this function
-const version = "1.0.0";
+const version = "1.0.1";
 
 function parseImageUrl(url: string) {
   const match = /ccimg:\/\/fbrtdb\.concord\.org\/([^/]+)(\/([^/]+))?/.exec(url);
@@ -20,7 +20,7 @@ export async function getImageData(
   if (isWarmUpParams(params)) return { version };
 
   const { context, url } = params || {};
-  const { classHash: userClassHash } = context || {};
+  const { classHash: userClassHash, network, type } = context || {};
   const { isValid, uid, classPath: userClassPath, firestoreRoot } = validateUserContext(context, callableContext?.auth);
   if (!isValid || !userClassHash || !uid) {
     throw new functions.https.HttpsError("invalid-argument", "The provided user context is not valid.");
@@ -55,27 +55,38 @@ export async function getImageData(
             .catch(() => null);
   }
 
+  function firestoreNetworkImagePromise(): Promise<string | null> {
+    return network && (type === "teacher")
+            ? admin.firestore()
+                .collection(`${firestoreRoot}/mcimages`)
+                .where("url", "==", legacyUrl)
+                .where("network", "==", network)
+                .get()
+                .then(snapshots => {
+                  const _imageClassPath = snapshots.docs.find(doc => !!doc.data()?.classPath)?.data()?.classPath;
+                  return _imageClassPath || null;
+                })
+                .catch(() => null)
+            : Promise.resolve(null);
+  }
+
   // if we have an image class hash and it's the same as the user class hash then just look it up
   if (imageClassHash === userClassHash) {
     return firebaseImageDataPromise(userClassPath);
   }
 
-  // if we have an image class hash and it's different from the user class hash
-  // then we have to look it up in the firestore mcimages to see if it's been published
-  // to this user's class.
-  if (imageClassHash) {
-    const _imageClassPath = await firestoreImagePathPromise();
-    return _imageClassPath ? await firebaseImageDataPromise(_imageClassPath) : null;
-  }
-
-  // if we don't have an image class hash, then we have to try both approaches,
-  // so we run the two initial queries in parallel.
-  const [imageData, imageClassPath] = await Promise.all([
-    firebaseImageDataPromise(userClassPath),
-    firestoreImagePathPromise()
+  // if we don't have an image class hash, or the image class hash doesn't match the user's class,
+  // then we have to try multiple approaches, so we run multiple queries in parallel.
+  const [imageData, imageClassPath1, imageClassPath2] = await Promise.all([
+    // if we have an imageClassHash, then it's not in the user's class (that case was handled above)
+    // if we don't have a class hash, then it could be in the user's class, so we have to check
+    imageClassHash ? Promise.resolve(null) : firebaseImageDataPromise(userClassPath),
+    firestoreImagePathPromise(),    // has it been published to this user's class?
+    firestoreNetworkImagePromise()  // has it been shared with this teacher's network?
   ]);
   // if we found the image data then return it
   if (imageData) return imageData;
   // if we retrieved the image path from firestore then use it to retrieve the image data
+  const imageClassPath = imageClassPath1 || imageClassPath2;
   return imageClassPath ? await firebaseImageDataPromise(imageClassPath) : null;
 }

--- a/functions/test/publish-support.test.ts
+++ b/functions/test/publish-support.test.ts
@@ -3,7 +3,8 @@ import { canonicalizeUrl, publishSupport } from "../src/publish-support";
 import { IPublishSupportParams } from "../src/shared";
 import { buildFirebaseImageUrl, parseFirebaseImageUrl, replaceAll } from "../src/shared-utils";
 import {
-  kCanonicalPortal, kClassHash, kOtherClassHash, kPortal, specAuth, specDocumentContent, specUserContext
+  kCanonicalPortal, kClassHash, kOtherClassHash, kPortal, kTeacherNetwork,
+  specAuth, specDocumentContent, specUserContext
 } from "./test-utils";
 
 useEmulators({
@@ -215,6 +216,7 @@ describe("publishSupport", () => {
     });
     const expectSupportProps = {
       appMode: "authed",
+      network: kTeacherNetwork,
       type: "supportPublication",
       originDoc: kOriginDoc,
       originDocType: "personal",
@@ -231,11 +233,11 @@ describe("publishSupport", () => {
     expect(imagesSnapshot.size).toBe(3);
     imagesSnapshot.docs.forEach((imageDoc, i) => {
       const legacyUrl = legacyUrls[i];
-      const { classes, classPath, platform_id, context_id, resource_link_id, resource_url } = supportDoc;
+      const { classes, classPath, network, platform_id, context_id, resource_link_id, resource_url } = supportDoc;
       const { imageKey } = parseFirebaseImageUrl(legacyUrl)
       expect(imageDoc.id).toBe(`${supportKey}_${imageKey}`)
       expect(imageDoc.data()).toEqual({
-        url: legacyUrl, classes, classPath, supportKey, platform_id, context_id, resource_link_id, resource_url
+        url: legacyUrl, classes, classPath, network, supportKey, platform_id, context_id, resource_link_id, resource_url
       });
     });
   });
@@ -268,6 +270,7 @@ describe("publishSupport", () => {
     });
     const expectSupportProps = {
       appMode: "authed",
+      network: kTeacherNetwork,
       type: "supportPublication",
       originDoc: kOriginDoc,
       originDocType: "personal",
@@ -284,14 +287,14 @@ describe("publishSupport", () => {
     expect(imagesSnapshot.size).toBe(3);
     imagesSnapshot.docs.forEach((imageDoc, i) => {
       const legacyUrl = legacyUrls[i];
-      const { classes, classPath: supportClassPath, platform_id, resource_link_id, resource_url } = supportDoc;
+      const { classes, classPath: supportClassPath, network, platform_id, resource_link_id, resource_url } = supportDoc;
       // image document paths differ from support document paths
       const classPath = supportClassPath.replace(kClassHash, kOtherClassHash);
       const context_id = kOtherClassHash;
       const { imageKey } = parseFirebaseImageUrl(legacyUrl)
       expect(imageDoc.id).toBe(`${supportKey}_${imageKey}`)
       expect(imageDoc.data()).toEqual({
-        url: legacyUrl, classes, classPath, supportKey, platform_id, context_id, resource_link_id, resource_url
+        url: legacyUrl, classes, classPath, network, supportKey, platform_id, context_id, resource_link_id, resource_url
       });
     });
   });

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -8,7 +8,8 @@
     "removeComments": true,
     "sourceMap": true,
     "strict": true,
-    "target": "es2017"
+    "target": "es2017",
+    "types": ["jest"]
   },
   "compileOnSave": true,
   "include": [

--- a/scripts/update-supports-images.ts
+++ b/scripts/update-supports-images.ts
@@ -12,6 +12,7 @@ interface IFirestoreMultiClassSupport {
   uid: string;
   classPath?: string; // frequently missing in supports published before 2.1.3 ¯\_(ツ)_/¯
   classes: string[];
+  network: string;
   content: string;
   originDoc: string;
   properties: Record<string, string>;
@@ -45,6 +46,7 @@ interface IFirestoreMultiClassImage {
   url: string;  // old-style without class hash
   classes: string[];
   classPath: string;
+  network: string;
   supportKey: string;
   // LTI fields
   platform_id: string;
@@ -329,7 +331,7 @@ admin.firestore()
       const docData: IFirestoreMultiClassSupport | undefined = (doc as any)?.data() as any;
       const {
         appMode, platform_id = "", uid, context_id: classHash,
-        classPath: docClassPath, content, originDoc, properties = {}
+        classPath: docClassPath, network, content, originDoc, properties = {}
       } = docData || {};
       // identify image-supporting tiles in this support document
       const imageTileMatches = [...(content?.matchAll(kImageTileRegex) || [])];
@@ -373,7 +375,8 @@ admin.firestore()
             const { classes = [], resource_link_id = "", resource_url = "" } = docData || {};
             const { classPath, context_id } = firestoreImages[key];
             return {
-              url: legacyUrl, classes, classPath, supportKey, platform_id, context_id, resource_link_id, resource_url
+              url: legacyUrl, classes, classPath, network, supportKey,
+              platform_id, context_id, resource_link_id, resource_url
             };
           });
         }


### PR DESCRIPTION
[[#181147217]](https://www.pivotaltracker.com/story/show/181147217)

In [[#180873340]](https://www.pivotaltracker.com/story/show/180873340), @tejal-shah pointed out that the existing solution for handling published supports/images doesn't work for networked teachers. In this PR we add the teacher's `network` to the properties written out for supports and images and then when determining whether a user has access to a particular image we check whether they're a teacher in the same network in addition to checking whether the requesting user is in a class to which the image has been published.

@tejal-shah For testing purposes, note that this solution does _not_ handle previously published supports. Handling those would require a migration that is probably not worth it. It should work for any newly published supports, however.