### PR TITLE
Eliminate DocumentTool enumeration in favor of existing tool ids

### DIFF
--- a/src/clue/app-config.json
+++ b/src/clue/app-config.json
@@ -180,39 +180,39 @@
     "disabledFeatures": [],
     "toolbar": [
       {
-        "name": "select",
+        "id": "select",
         "title": "Select",
         "iconId": "icon-select-tool",
         "isTileTool": false,
         "isDefault": true
       },
       {
-        "name": "text",
+        "id": "Text",
         "title": "Text",
         "isTileTool": true
       },
       {
-        "name": "table",
+        "id": "Table",
         "title": "Table",
         "isTileTool": true
       },
       {
-        "name": "geometry",
+        "id": "Geometry",
         "title": "Geometry",
         "isTileTool": true
       },
       {
-        "name": "image",
+        "id": "Image",
         "title": "Image",
         "isTileTool": true
       },
       {
-        "name": "drawing",
+        "id": "Drawing",
         "title": "Drawing",
         "isTileTool": true
       },
       {
-        "name": "delete",
+        "id": "delete",
         "title": "Delete",
         "iconId": "icon-delete-tool",
         "isTileTool": false

--- a/src/components/delete-button.test.tsx
+++ b/src/components/delete-button.test.tsx
@@ -22,9 +22,9 @@ describe("DeleteButton", () => {
   });
 
   const buttonConfig = {
-          "name": "delete",
-          "title": "Delete",
-          "iconId": "icon-delete-tool",
+          id: "delete",
+          title: "Delete",
+          iconId: "icon-delete-tool",
           isDefault: false,
           isTileTool: false
         };

--- a/src/components/delete-button.tsx
+++ b/src/components/delete-button.tsx
@@ -12,7 +12,7 @@ export const DeleteButton: React.FC<IProps> =
   ({ toolButton, isActive, isDisabled, onSetToolActive, onClick,
       onSetShowDeleteTilesConfirmationAlert, onDeleteSelectedTiles }) => {
 
-  const { name, title, Icon } = toolButton;
+  const { id, title, Icon } = toolButton;
 
   const handleMouseDown = () => {
     !isDisabled && onSetToolActive(toolButton, true);
@@ -33,11 +33,11 @@ export const DeleteButton: React.FC<IProps> =
   });
   onSetShowDeleteTilesConfirmationAlert(showAlert);
 
-  const classes = classNames("tool", "delete-button", name,
+  const classes = classNames("tool", "delete-button", id,
                             { active: isActive }, isDisabled ? "disabled" : "enabled");
   return (
     <div className={classes} data-testid="delete-button"
-        key={name}
+        key={id}
         title={title}
         onMouseDown={handleMouseDown}
         onClick={handleClick}>

--- a/src/components/document/document-content.tsx
+++ b/src/components/document/document-content.tsx
@@ -414,12 +414,12 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
     const createTileInfo = safeJsonParse<IDragToolCreateInfo>(createTileInfoStr);
     if (!content || !createTileInfo) return;
 
-    const { tool, title } = createTileInfo;
+    const { toolId, title } = createTileInfo;
     const insertRowInfo = this.getDropRowInfo(e);
     const isInsertingInExistingRow = insertRowInfo?.rowDropLocation &&
                                       (["left", "right"].indexOf(insertRowInfo.rowDropLocation) >= 0);
-    const addSidecarNotes = (tool === "geometry") && !isInsertingInExistingRow;
-    const rowTile = content.userAddTile(tool, {title, addSidecarNotes, insertRowInfo});
+    const addSidecarNotes = (toolId.toLowerCase() === "geometry") && !isInsertingInExistingRow;
+    const rowTile = content.userAddTile(toolId, {title, addSidecarNotes, insertRowInfo});
 
     if (rowTile?.tileId) {
       ui.setSelectedTileId(rowTile.tileId);

--- a/src/components/tool-button.test.tsx
+++ b/src/components/tool-button.test.tsx
@@ -25,7 +25,7 @@ describe("ToolButtonComponent", () => {
 
   it("renders disabled select tool", () => {
     const toolButton = ToolButtonModel.create({
-      name: "select",
+      id: "select",
       title: "Select",
       iconId: "icon-select-tool",
       isDefault: true,
@@ -54,7 +54,7 @@ describe("ToolButtonComponent", () => {
 
   it("renders enabled text tool", () => {
     const toolButton = ToolButtonModel.create({
-      name: "text",
+      id: "Text",
       title: "Text",
       isDefault: false,
       isTileTool: true

--- a/src/components/tool-button.tsx
+++ b/src/components/tool-button.tsx
@@ -20,7 +20,7 @@ export const ToolButtonComponent: React.FC<IToolButtonProps> =
   ({ toolButton, isActive, isDisabled, onSetToolActive, onClick, onDragStart,
       onShowDropHighlight, onHideDropHighlight }) => {
 
-  const { name, title, isTileTool, Icon } = toolButton;
+  const { id, title, isTileTool, Icon } = toolButton;
 
   const handleMouseDown = () => {
     if (isDisabled) return;
@@ -45,10 +45,11 @@ export const ToolButtonComponent: React.FC<IToolButtonProps> =
     onDragStart(e, toolButton);
   };
 
+  const toolTileClass = id.toLowerCase();
   return (
-    <div className={classNames("tool", name, { active: isActive }, isDisabled ? "disabled" : "enabled")}
-        data-testid={`tool-${name}`}
-        key={name}
+    <div className={classNames("tool", toolTileClass, { active: isActive }, isDisabled ? "disabled" : "enabled")}
+        data-testid={`tool-${toolTileClass}`}
+        key={id}
         title={title}
         onMouseDown={handleMouseDown}
         onClick={handleClick}

--- a/src/components/toolbar.test.tsx
+++ b/src/components/toolbar.test.tsx
@@ -26,20 +26,20 @@ describe("ToolbarComponent", () => {
 
   const config: ToolbarModelSnapshot = [
     {
-      name: "select",
+      id: "select",
       title: "Select",
       iconId: "icon-select-tool",
       isDefault: true,
       isTileTool: false
     },
     {
-      name: "text",
+      id: "Text",
       title: "Text",
       isDefault: false,
       isTileTool: true
     },
     {
-      name: "delete",
+      id: "delete",
       title: "Delete",
       iconId: "icon-delete-tool",
       isDefault: false,

--- a/src/components/toolbar.tsx
+++ b/src/components/toolbar.tsx
@@ -114,6 +114,8 @@ export class ToolbarComponent extends BaseComponent<IProps, IState> {
     const { document } = this.props;
     const { ui } = this.stores;
     const toolContentInfo = getToolContentInfoById(tool.id);
+    if (!toolContentInfo) return;
+
     const newTileOptions: IDocumentContentAddTileOptions = {
             title: this.getUniqueTitle(toolContentInfo),
             addSidecarNotes: !!toolContentInfo?.addSidecarNotes,
@@ -167,8 +169,10 @@ export class ToolbarComponent extends BaseComponent<IProps, IState> {
     this.removeDropRowHighlight();
 
     const toolContentInfo = getToolContentInfoById(tool.id);
-    const dragInfo: IDragToolCreateInfo =
-      { toolId: tool.id, title: this.getUniqueTitle(toolContentInfo) };
-    e.dataTransfer.setData(kDragTileCreate, JSON.stringify(dragInfo));
+    if (toolContentInfo) {
+      const dragInfo: IDragToolCreateInfo =
+        { toolId: tool.id, title: this.getUniqueTitle(toolContentInfo) };
+      e.dataTransfer.setData(kDragTileCreate, JSON.stringify(dragInfo));
+    }
   };
 }

--- a/src/components/toolbar.tsx
+++ b/src/components/toolbar.tsx
@@ -6,7 +6,7 @@ import { DocumentModelType } from "../models/document/document";
 import { IDocumentContentAddTileOptions, IDragToolCreateInfo } from "../models/document/document-content";
 import { ToolbarModelType } from "../models/stores/problem-configuration";
 import { ToolButtonModelType } from "../models/tools/tool-button";
-import { getToolContentInfoByTool, IToolContentInfo } from "../models/tools/tool-content-info";
+import { getToolContentInfoById, IToolContentInfo } from "../models/tools/tool-content-info";
 import { DeleteButton } from "./delete-button";
 import { IToolButtonProps, ToolButtonComponent } from "./tool-button";
 import { EditableToolApiInterfaceRefContext } from "./tools/tool-api";
@@ -44,7 +44,7 @@ export class ToolbarComponent extends BaseComponent<IProps, IState> {
 
   public render() {
     const handleClickTool = (e: React.MouseEvent<HTMLDivElement>, tool: ToolButtonModelType) => {
-      switch (tool.name) {
+      switch (tool.id) {
         case "select":
           this.handleSelect();
           break;
@@ -69,16 +69,16 @@ export class ToolbarComponent extends BaseComponent<IProps, IState> {
         const buttonProps: IToolButtonProps = {
           toolButton,
           isActive: toolButton === this.state.activeTool,
-          isDisabled: toolButton.name === "delete" && !selectedTileIds.length,
+          isDisabled: toolButton.id === "delete" && !selectedTileIds.length,
           onSetToolActive: handleSetActiveTool,
           onClick: handleClickTool,
           onDragStart: handleDragTool,
           onShowDropHighlight: this.showDropRowHighlight,
           onHideDropHighlight: this.removeDropRowHighlight
         };
-        return toolButton.name !== "delete"
-                ? <ToolButtonComponent key={toolButton.name} {...buttonProps} />
-                : <DeleteButton key={toolButton.name}
+        return toolButton.id !== "delete"
+                ? <ToolButtonComponent key={toolButton.id} {...buttonProps} />
+                : <DeleteButton key={toolButton.id}
                                 onSetShowDeleteTilesConfirmationAlert={this.setShowDeleteTilesConfirmationAlert}
                                 onDeleteSelectedTiles={this.handleDeleteSelectedTiles}
                                 {...buttonProps} />;
@@ -113,13 +113,13 @@ export class ToolbarComponent extends BaseComponent<IProps, IState> {
   private handleAddToolTile(tool: ToolButtonModelType) {
     const { document } = this.props;
     const { ui } = this.stores;
-    const toolContentInfo = getToolContentInfoByTool(tool.name);
+    const toolContentInfo = getToolContentInfoById(tool.id);
     const newTileOptions: IDocumentContentAddTileOptions = {
             title: this.getUniqueTitle(toolContentInfo),
             addSidecarNotes: !!toolContentInfo?.addSidecarNotes,
             insertRowInfo: { rowInsertIndex: document.content?.defaultInsertRow ?? 0 }
           };
-    const rowTile = document.addTile(tool.name, newTileOptions);
+    const rowTile = document.addTile(tool.id, newTileOptions);
     if (rowTile && rowTile.tileId) {
       ui.setSelectedTileId(rowTile.tileId);
       this.setState(state => ({ activeTool: state.defaultTool }));
@@ -166,9 +166,9 @@ export class ToolbarComponent extends BaseComponent<IProps, IState> {
     // remove hover-insert highlight when we start a tile drag
     this.removeDropRowHighlight();
 
-    const toolContentInfo = getToolContentInfoByTool(tool.name);
+    const toolContentInfo = getToolContentInfoById(tool.id);
     const dragInfo: IDragToolCreateInfo =
-      { tool: tool.name, title: this.getUniqueTitle(toolContentInfo) };
+      { toolId: tool.id, title: this.getUniqueTitle(toolContentInfo) };
     e.dataTransfer.setData(kDragTileCreate, JSON.stringify(dragInfo));
   };
 }

--- a/src/components/toolbar.tsx
+++ b/src/components/toolbar.tsx
@@ -2,7 +2,7 @@ import { inject, observer } from "mobx-react";
 import React from "react";
 
 import { BaseComponent, IBaseProps } from "./base";
-import { DocumentModelType, DocumentTool } from "../models/document/document";
+import { DocumentModelType } from "../models/document/document";
 import { IDocumentContentAddTileOptions, IDragToolCreateInfo } from "../models/document/document-content";
 import { ToolbarModelType } from "../models/stores/problem-configuration";
 import { ToolButtonModelType } from "../models/tools/tool-button";
@@ -119,7 +119,7 @@ export class ToolbarComponent extends BaseComponent<IProps, IState> {
             addSidecarNotes: !!toolContentInfo?.addSidecarNotes,
             insertRowInfo: { rowInsertIndex: document.content?.defaultInsertRow ?? 0 }
           };
-    const rowTile = document.addTile(tool.name as DocumentTool, newTileOptions);
+    const rowTile = document.addTile(tool.name, newTileOptions);
     if (rowTile && rowTile.tileId) {
       ui.setSelectedTileId(rowTile.tileId);
       this.setState(state => ({ activeTool: state.defaultTool }));
@@ -168,7 +168,7 @@ export class ToolbarComponent extends BaseComponent<IProps, IState> {
 
     const toolContentInfo = getToolContentInfoByTool(tool.name);
     const dragInfo: IDragToolCreateInfo =
-      { tool: tool.name as DocumentTool, title: this.getUniqueTitle(toolContentInfo) };
+      { tool: tool.name, title: this.getUniqueTitle(toolContentInfo) };
     e.dataTransfer.setData(kDragTileCreate, JSON.stringify(dragInfo));
   };
 }

--- a/src/components/tools/tool-tile.tsx
+++ b/src/components/tools/tool-tile.tsx
@@ -187,7 +187,7 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
     const { model, readOnly, isUserResizable, widthPct } = this.props;
     const { hoverTile } = this.state;
     const { appConfig, ui } = this.stores;
-    const { Component: ToolComponent, toolTileClass } = getToolContentInfoById(model.content.type);
+    const { Component: ToolComponent, toolTileClass } = getToolContentInfoById(model.content.type) || {};
     const isPlaceholderTile = ToolComponent === PlaceholderToolComponent;
     const isTileSelected = ui.isSelectedTile(model);
     const tileSelectedForComment = isTileSelected && ui.showChatPanel;
@@ -312,7 +312,7 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
 
     // Select the tile if the tool doesn't handle the selection itself
     const toolContentInfo = getToolContentInfoById(model.content.type);
-    if (!toolContentInfo.tileHandlesOwnSelection) {
+    if (!toolContentInfo?.tileHandlesOwnSelection) {
       ui.setSelectedTile(model, {append: hasSelectionModifier(e)});
     }
   };
@@ -371,7 +371,7 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
     }
     // set the drag data
     const { model, docId } = this.props;
-    const ToolComponent = getToolContentInfoById(model.content.type).Component;
+    const ToolComponent = getToolContentInfoById(model.content.type)?.Component;
     // can't drag placeholder tiles
     if (ToolComponent === PlaceholderToolComponent) {
       e.preventDefault();

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -678,13 +678,15 @@ export const DocumentContentModel = types
         // the end of the content and then moves them to the desired location.
         const addTileOptions = { rowIndex: self.rowCount };
         const contentInfo = getToolContentInfoById(toolId);
+        if (!contentInfo) return;
+
         const documents = getParentWithTypeName(self, "Documents") as DocumentsModelType;
         const appConfig = documents?.appConfig;
 
         const newContent = contentInfo?.defaultContent({ title, url, appConfig });
         const tileInfo = self.addTileContentInNewRow(
                               newContent,
-                              { rowHeight: contentInfo?.defaultHeight, ...addTileOptions });
+                              { rowHeight: contentInfo.defaultHeight, ...addTileOptions });
         if (addSidecarNotes) {
           const { rowId } = tileInfo;
           const row = self.rowMap.get(rowId);

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -2,7 +2,7 @@ import { cloneDeep, each } from "lodash";
 import { types, getSnapshot, Instance, SnapshotIn } from "mobx-state-tree";
 import { PlaceholderContentModel } from "../tools/placeholder/placeholder-content";
 import { kTextToolID } from "../tools/text/text-content";
-import { getToolContentInfoById, getToolContentInfoByTool, IDocumentExportOptions } from "../tools/tool-content-info";
+import { getToolContentInfoById, IDocumentExportOptions } from "../tools/tool-content-info";
 import { ToolContentModelType } from "../tools/tool-types";
 import {
   ToolTileModel, ToolTileModelType, ToolTileSnapshotInType, ToolTileSnapshotOutType
@@ -10,6 +10,7 @@ import {
 import {
   TileRowModel, TileRowModelType, TileRowSnapshotType, TileRowSnapshotOutType, TileLayoutModelType
 } from "../document/tile-row";
+import { IDocumentAddTileOptions } from "./document-types";
 import { SectionModelType } from "../curriculum/section";
 import { Logger, LogEventName } from "../../lib/logger";
 import { IDragTileItem } from "../../models/tools/tool-tile";
@@ -18,7 +19,6 @@ import { DisplayUserType } from "../stores/user-types";
 import { safeJsonParse, uniqueId } from "../../utilities/js-utils";
 import { getParentWithTypeName } from "../../utilities/mst-utils";
 import { comma, StringBuilder } from "../../utilities/string-builder";
-import { IDocumentAddTileOptions } from "./document";
 
 export interface INewTileOptions {
   rowHeight?: number;
@@ -45,7 +45,7 @@ export interface IDocumentContentAddTileOptions extends IDocumentAddTileOptions 
 }
 
 export interface IDragToolCreateInfo {
-  tool: string;
+  toolId: string;
   title?: string;
 }
 
@@ -672,12 +672,12 @@ export const DocumentContentModel = types
           }
         }
       },
-      addTile(tool: string, options?: IDocumentContentAddTileOptions) {
+      addTile(toolId: string, options?: IDocumentContentAddTileOptions) {
         const { title, addSidecarNotes, url, insertRowInfo } = options || {};
         // for historical reasons, this function initially places new rows at
         // the end of the content and then moves them to the desired location.
         const addTileOptions = { rowIndex: self.rowCount };
-        const contentInfo = getToolContentInfoByTool(tool);
+        const contentInfo = getToolContentInfoById(toolId);
         const documents = getParentWithTypeName(self, "Documents") as DocumentsModelType;
         const appConfig = documents?.appConfig;
 
@@ -814,8 +814,8 @@ export const DocumentContentModel = types
     }
   }))
   .actions(self => ({
-    userAddTile(tool: string, options?: IDocumentContentAddTileOptions) {
-      const result = self.addTile(tool, options);
+    userAddTile(toolId: string, options?: IDocumentContentAddTileOptions) {
+      const result = self.addTile(toolId, options);
       const newTile = result?.tileId && self.getTile(result.tileId);
       if (newTile) {
         Logger.logTileEvent(LogEventName.CREATE_TILE, newTile);

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -18,7 +18,7 @@ import { DisplayUserType } from "../stores/user-types";
 import { safeJsonParse, uniqueId } from "../../utilities/js-utils";
 import { getParentWithTypeName } from "../../utilities/mst-utils";
 import { comma, StringBuilder } from "../../utilities/string-builder";
-import { DocumentTool, IDocumentAddTileOptions } from "./document";
+import { IDocumentAddTileOptions } from "./document";
 
 export interface INewTileOptions {
   rowHeight?: number;
@@ -45,7 +45,7 @@ export interface IDocumentContentAddTileOptions extends IDocumentAddTileOptions 
 }
 
 export interface IDragToolCreateInfo {
-  tool: DocumentTool;
+  tool: string;
   title?: string;
 }
 
@@ -672,7 +672,7 @@ export const DocumentContentModel = types
           }
         }
       },
-      addTile(tool: DocumentTool, options?: IDocumentContentAddTileOptions) {
+      addTile(tool: string, options?: IDocumentContentAddTileOptions) {
         const { title, addSidecarNotes, url, insertRowInfo } = options || {};
         // for historical reasons, this function initially places new rows at
         // the end of the content and then moves them to the desired location.
@@ -814,7 +814,7 @@ export const DocumentContentModel = types
     }
   }))
   .actions(self => ({
-    userAddTile(tool: DocumentTool, options?: IDocumentContentAddTileOptions) {
+    userAddTile(tool: string, options?: IDocumentContentAddTileOptions) {
       const result = self.addTile(tool, options);
       const newTile = result?.tileId && self.getTile(result.tileId);
       if (newTile) {

--- a/src/models/document/document-types.ts
+++ b/src/models/document/document-types.ts
@@ -59,3 +59,9 @@ export interface IDocumentContext {
   getProperty: (key: string) => string | undefined;
   setProperties: (properties: ISetProperties) => void;
 }
+
+export interface IDocumentAddTileOptions {
+  title?: string;
+  addSidecarNotes?: boolean;
+  url?: string;
+}

--- a/src/models/document/document.ts
+++ b/src/models/document/document.ts
@@ -22,10 +22,6 @@ export interface IDocumentAddTileOptions {
   url?: string;
 }
 
-export const DocumentToolEnum = types.enumeration("tool",
-                                ["delete", "drawing", "geometry", "image", "select", "table", "text", "placeholder"]);
-export type DocumentTool = typeof DocumentToolEnum.Type;
-
 export const DocumentModel = types
   .model("Document", {
     uid: types.string,
@@ -188,7 +184,7 @@ export const DocumentModel = types
       self.visibility = visibility;
     },
 
-    addTile(tool: DocumentTool, options?: IDocumentAddTileOptions) {
+    addTile(tool: string, options?: IDocumentAddTileOptions) {
       return self.content?.userAddTile(tool, options);
     },
 

--- a/src/models/document/document.ts
+++ b/src/models/document/document.ts
@@ -3,9 +3,9 @@ import { forEach } from "lodash";
 import { QueryClient, UseQueryResult } from "react-query";
 import { DocumentContentModel, DocumentContentSnapshotType } from "./document-content";
 import {
-  DocumentType, DocumentTypeEnum, IDocumentContext, ISetProperties, LearningLogDocument, LearningLogPublication,
-  PersonalDocument, PersonalPublication, PlanningDocument, ProblemDocument, ProblemPublication,
-  SupportPublication
+  DocumentType, DocumentTypeEnum, IDocumentAddTileOptions, IDocumentContext, ISetProperties,
+  LearningLogDocument, LearningLogPublication, PersonalDocument, PersonalPublication,
+  PlanningDocument, ProblemDocument, ProblemPublication, SupportPublication
 } from "./document-types";
 import { AppConfigModelType } from "../stores/app-config-model";
 import { TileCommentsModel, TileCommentsModelType } from "../tools/tile-comments";
@@ -15,12 +15,6 @@ import { getFirebaseFunction } from "../../hooks/use-firebase-function";
 import { IDocumentProperties } from "../../lib/db-types";
 import { getLocalTimeStamp } from "../../utilities/time";
 import { safeJsonParse } from "../../utilities/js-utils";
-
-export interface IDocumentAddTileOptions {
-  title?: string;
-  addSidecarNotes?: boolean;
-  url?: string;
-}
 
 export const DocumentModel = types
   .model("Document", {
@@ -184,8 +178,8 @@ export const DocumentModel = types
       self.visibility = visibility;
     },
 
-    addTile(tool: string, options?: IDocumentAddTileOptions) {
-      return self.content?.userAddTile(tool, options);
+    addTile(toolId: string, options?: IDocumentAddTileOptions) {
+      return self.content?.userAddTile(toolId, options);
     },
 
     deleteTile(tileId: string) {

--- a/src/models/stores/configuration-manager.test.ts
+++ b/src/models/stores/configuration-manager.test.ts
@@ -1,0 +1,91 @@
+import { ConfigurationManager } from "./configuration-manager";
+import { UnitConfiguration } from "./unit-configuration";
+
+describe("ConfigurationManager", () => {
+
+  const defaults: UnitConfiguration = {
+    appName: "Test",
+    pageTitle: "Test Page Title",
+    demoProblemTitle: "Demo Problem Title",
+    defaultProblemOrdinal: "1.1",
+    autoAssignStudentsToIndividualGroups: false,
+    defaultDocumentType: "personal",
+    defaultDocumentTitle: "Untitled Document",
+    docTimeStampPropertyName: "timeStamp",
+    docDisplayIdPropertyName: "displayId",
+    defaultDocumentTemplate: undefined,
+    defaultLearningLogTitle: "Default LL Title",
+    initialLearningLogTitle: "Initial LL Title",
+    defaultLearningLogDocument: false,
+    autoSectionProblemDocuments: false,
+    documentLabelProperties: [] as any,
+    documentLabels: {},
+    disablePublish: [] as any,
+    copyPreferOriginTitle: true,
+    disableTileDrags: true,
+    showClassSwitcher: false,
+    supportStackedTwoUpView: false,
+    showPublishedDocsInPrimaryWorkspace: false,
+    comparisonPlaceholderContent: "foo",
+    navTabs: {} as any,
+    disabledFeatures: ["foo"],
+    toolbar: [] as any,
+    placeholderText: "Placeholder Text",
+    stamps: [] as any,
+    settings: {}
+  } as UnitConfiguration;
+
+  const overrides: UnitConfiguration = {
+    appName: "New Test",
+    pageTitle: "New Test Page Title",
+    demoProblemTitle: "New Demo Problem Title",
+    defaultProblemOrdinal: "9.9",
+    autoAssignStudentsToIndividualGroups: true,
+    defaultDocumentType: "problem",
+    defaultDocumentTitle: "Untitled Problem",
+    docTimeStampPropertyName: "dateStamp",
+    docDisplayIdPropertyName: "displayIdName",
+    defaultDocumentTemplate: undefined,
+    defaultLearningLogTitle: "New Default LL Title",
+    initialLearningLogTitle: "New Initial LL Title",
+    defaultLearningLogDocument: true,
+    autoSectionProblemDocuments: true,
+    documentLabelProperties: [] as any,
+    documentLabels: {},
+    disablePublish: [] as any,
+    copyPreferOriginTitle: false,
+    disableTileDrags: false,
+    showClassSwitcher: true,
+    supportStackedTwoUpView: true,
+    showPublishedDocsInPrimaryWorkspace: true,
+    comparisonPlaceholderContent: "bar",
+    navTabs: {} as any,
+    disabledFeatures: ["bar"],
+    toolbar: [] as any,
+    placeholderText: "New Placeholder Text",
+    stamps: [] as any,
+    settings: {}
+  } as UnitConfiguration;
+
+  const keys = Object.keys(defaults) as Array<keyof typeof defaults>;
+
+  it("can be constructed with just defaults and return those defaults", () => {
+    const config = new ConfigurationManager(defaults, []);
+    keys.forEach((prop: keyof typeof defaults) => {
+      expect(config[prop]).toEqual(defaults[prop]);
+    });
+  });
+
+  it("can be constructed with defaults and overrides and return the overrides", () => {
+    const config = new ConfigurationManager(defaults, [overrides]);
+    keys.forEach((prop: keyof typeof defaults) => {
+      if (prop === "disabledFeatures") {
+        // disabledFeatures are merged
+        expect(config[prop]).toEqual(["foo", "bar"]);
+      }
+      else {
+        expect(config[prop]).toEqual(overrides[prop]);
+      }
+    });
+  });
+});

--- a/src/models/stores/configuration-manager.ts
+++ b/src/models/stores/configuration-manager.ts
@@ -16,7 +16,8 @@ export class ConfigurationManager implements UnitConfiguration {
   }
 
   getProp<T>(prop: keyof UnitConfiguration) {
-    return (this.configs.find(config => !!config[prop])?.[prop] || this.defaults[prop]) as T;
+    const found = this.configs.find(config => config[prop] != null)?.[prop];
+    return (found != null ? found : this.defaults[prop]) as T;
   }
 
   /*

--- a/src/models/tools/drawing/drawing-registration.ts
+++ b/src/models/tools/drawing/drawing-registration.ts
@@ -6,7 +6,6 @@ import DrawingToolIcon from "../../../clue/assets/icons/draw-tool.svg";
 
 registerToolContentInfo({
   id: kDrawingToolID,
-  tool: "drawing",
   modelClass: DrawingContentModel,
   metadataClass: DrawingToolMetadataModel,
   defaultHeight: kDrawingDefaultHeight,

--- a/src/models/tools/geometry/geometry-registration.ts
+++ b/src/models/tools/geometry/geometry-registration.ts
@@ -7,7 +7,6 @@ import GeometryToolIcon from "../../../clue/assets/icons/graph-tool.svg";
 
 registerToolContentInfo({
   id: kGeometryToolID,
-  tool: "geometry",
   titleBase: "Graph",
   modelClass: GeometryContentModel,
   metadataClass: GeometryMetadataModel,

--- a/src/models/tools/image/image-registration.ts
+++ b/src/models/tools/image/image-registration.ts
@@ -5,7 +5,6 @@ import ImageToolIcon from "../../../clue/assets/icons/image-tool.svg";
 
 registerToolContentInfo({
   id: kImageToolID,
-  tool: "image",
   modelClass: ImageContentModel,
   defaultContent: defaultImageContent,
   Component: ImageToolComponent,

--- a/src/models/tools/placeholder/placeholder-registration.ts
+++ b/src/models/tools/placeholder/placeholder-registration.ts
@@ -8,7 +8,6 @@ function defaultPlaceholderContent() {
 
 registerToolContentInfo({
   id: kPlaceholderToolID,
-  tool: "placeholder",
   modelClass: PlaceholderContentModel,
   defaultContent: defaultPlaceholderContent,
   Component: PlaceholderToolComponent,

--- a/src/models/tools/table/table-registration.ts
+++ b/src/models/tools/table/table-registration.ts
@@ -6,7 +6,6 @@ import TableToolIcon from "../../../clue/assets/icons/table-tool.svg";
 
 registerToolContentInfo({
   id: kTableToolID,
-  tool: "table",
   titleBase: "Table",
   modelClass: TableContentModel,
   metadataClass: TableMetadataModel,

--- a/src/models/tools/text/text-registration.ts
+++ b/src/models/tools/text/text-registration.ts
@@ -5,7 +5,6 @@ import TextToolIcon from "../../../clue/assets/icons/text-tool.svg";
 
 registerToolContentInfo({
   id: kTextToolID,
-  tool: "text",
   modelClass: TextContentModel,
   defaultContent: defaultTextContent,
   Component: TextToolComponent,

--- a/src/models/tools/tool-button.ts
+++ b/src/models/tools/tool-button.ts
@@ -28,7 +28,7 @@ const TileToolButtonModel = BaseToolButtonModel.named("TileToolButtonModel")
   })
   .views(self => ({
     get Icon() {
-      return  getToolContentInfoById(self.id).Icon;
+      return getToolContentInfoById(self.id)?.Icon;
     }
   }));
 

--- a/src/models/tools/tool-button.ts
+++ b/src/models/tools/tool-button.ts
@@ -1,8 +1,8 @@
 import { getEnv, Instance, SnapshotOut, types } from "mobx-state-tree";
-import { getToolContentInfoByTool } from "./tool-content-info";
+import { getToolContentInfoById } from "./tool-content-info";
 
 const BaseToolButtonModel = types.model("BaseToolButton", {
-  name: types.string,
+  id: types.string, // toolId in the case of tool buttons
   title: types.string,
   isDefault: false,
 });
@@ -28,7 +28,7 @@ const TileToolButtonModel = BaseToolButtonModel.named("TileToolButtonModel")
   })
   .views(self => ({
     get Icon() {
-      return  getToolContentInfoByTool(self.name).Icon;
+      return  getToolContentInfoById(self.id).Icon;
     }
   }));
 

--- a/src/models/tools/tool-content-info.ts
+++ b/src/models/tools/tool-content-info.ts
@@ -58,7 +58,7 @@ export function registerToolContentInfo(toolContentInfo: IToolContentInfo) {
 // ToolContent id, e.g. kDrawingToolID, kGeometryToolID, etc.
 export function getToolContentInfoById(id: string) {
   // toLowerCase() for legacy support of tool names
-  return gToolContentInfoMapById[id.toLowerCase()];
+  return id ? gToolContentInfoMapById[id.toLowerCase()] : undefined;
 }
 
 export function getToolContentModels() {
@@ -66,7 +66,7 @@ export function getToolContentModels() {
 }
 
 export function getToolIds() {
-  return Object.keys(gToolContentInfoMapById);
+  return Object.keys(gToolContentInfoMapById).map(toolId => gToolContentInfoMapById[toolId].id);
 }
 
 

--- a/src/models/tools/tool-content-info.ts
+++ b/src/models/tools/tool-content-info.ts
@@ -66,7 +66,8 @@ export function getToolContentModels() {
 }
 
 export function getToolIds() {
-  return Object.keys(gToolContentInfoMapById).map(toolId => gToolContentInfoMapById[toolId].id);
+  // the keys are toLowerCased(), so we look up the actual id
+  return Object.values(gToolContentInfoMapById).map(info => info.id);
 }
 
 

--- a/src/models/tools/tool-content-info.ts
+++ b/src/models/tools/tool-content-info.ts
@@ -23,7 +23,6 @@ type ToolComponentType = React.ComponentType<IToolTileProps>;
 
 export interface IToolContentInfo {
   id: string;
-  tool: string;
   modelClass: typeof ToolContentModel;
   defaultContent: (options?: IDefaultContentOptions) => ToolContentModelType;
   Component: ToolComponentType;
@@ -50,21 +49,16 @@ interface IToolContentInfoMap {
   [id: string]: IToolContentInfo;
 }
 const gToolContentInfoMapById: IToolContentInfoMap = {};
-const gToolContentInfoMapByTool: IToolContentInfoMap = {};
 
 export function registerToolContentInfo(toolContentInfo: IToolContentInfo) {
-  gToolContentInfoMapById[toolContentInfo.id] = toolContentInfo;
-  gToolContentInfoMapByTool[toolContentInfo.tool] = toolContentInfo;
+  // toLowerCase() for legacy support of tool names
+  gToolContentInfoMapById[toolContentInfo.id.toLowerCase()] = toolContentInfo;
 }
 
 // ToolContent id, e.g. kDrawingToolID, kGeometryToolID, etc.
 export function getToolContentInfoById(id: string) {
-  return gToolContentInfoMapById[id];
-}
-
-// tool name used in a few places, e.g. "drawing", "geometry", etc.
-export function getToolContentInfoByTool(tool: string) {
-  return gToolContentInfoMapByTool[tool];
+  // toLowerCase() for legacy support of tool names
+  return gToolContentInfoMapById[id.toLowerCase()];
 }
 
 export function getToolContentModels() {

--- a/src/models/tools/tool-tile.test.ts
+++ b/src/models/tools/tool-tile.test.ts
@@ -34,7 +34,7 @@ describe("ToolTileModel", () => {
 
   uniqueToolIds.forEach(toolID => {
     it(`supports the tool: ${toolID}`, () => {
-      const SpecificToolContentModel = getToolContentInfoById(toolID).modelClass;
+      const SpecificToolContentModel = getToolContentInfoById(toolID)?.modelClass;
 
       // can create a model with each type of tool
       const content: any = { type: toolID };
@@ -44,7 +44,7 @@ describe("ToolTileModel", () => {
         content.originalType = "foo";
       }
       let toolTile = ToolTileModel.create({
-                      content: SpecificToolContentModel.create(content)
+                      content: SpecificToolContentModel?.create(content)
                     });
       expect(toolTile.content.type).toBe(toolID);
 
@@ -61,7 +61,7 @@ describe("ToolTileModel", () => {
     // If we have more tests verifying that Tools follow the right patterns this test
     // should be moved next to them.
     it(`${toolID} content models can be created without the type`, () => {
-      const SpecificToolContentModel = getToolContentInfoById(toolID).modelClass;
+      const SpecificToolContentModel = getToolContentInfoById(toolID)?.modelClass;
 
       // can create the model without passing the type
       const typelessContent: any = {};
@@ -69,8 +69,8 @@ describe("ToolTileModel", () => {
       if (toolID === kUnknownToolID) {
         typelessContent.originalType = "foo";
       }
-      const toolContentModel = SpecificToolContentModel.create(typelessContent);
-      expect(toolContentModel.type).toBe(toolID);
+      const toolContentModel = SpecificToolContentModel?.create(typelessContent);
+      expect(toolContentModel?.type).toBe(toolID);
     });
   });
 

--- a/src/models/tools/tool-types.ts
+++ b/src/models/tools/tool-types.ts
@@ -67,7 +67,7 @@ export function toolFactory(snapshot: any) {
 }
 
 export function findMetadata(type: string, id: string) {
-  const MetadataType = getToolContentInfoById(type).metadataClass;
+  const MetadataType = getToolContentInfoById(type)?.metadataClass;
   if (!MetadataType) return;
 
   if (!_private.metadata[id]) {

--- a/src/models/tools/unknown-content.ts
+++ b/src/models/tools/unknown-content.ts
@@ -8,7 +8,6 @@ export function defaultContent(): UnknownContentModelType {
 
 registerToolContentInfo({
   id: kUnknownToolID,
-  tool: "unknown",
   modelClass: UnknownContentModel,
   defaultContent,
   // TODO: should really have a separate unknown tool that shows an "unknown tile" message

--- a/tool-tiles.md
+++ b/tool-tiles.md
@@ -17,11 +17,7 @@ Each tile type has a unique tool id. Here is an example of a tool tile id defini
 ```typescript
 export const kPlaceholderToolID = "Placeholder";
 ```
-These ids are used in several places. They are added as an enumerated type to `ToolTypeEnum` which is defined in `tool-types.ts` and used in `ToolTileComponent` to determine which tile type to render. Similarly, a tile specific string must also be added to `DocumentToolEnum` in `document.ts`:
-```typescript
-export const DocumentToolEnum = types.enumeration("tool",
- ["delete", "drawing", "geometry", "image", "select", "table", "text", "dataflow", "placeholder"]);
-```
+These ids are used in several places. These ids are used in several places. They are defined when the tool is registered with `registerToolContentInfo`.
 
 ## Tool Tile Models
 Each tool defines a tile content model. This content model is specified as a MobX State Tree (MST) model and contains properties and actions specific to the tool. Each of the tool tile content models is unioned together to define the `ToolContentUnion` type.

--- a/tool-tiles.md
+++ b/tool-tiles.md
@@ -17,7 +17,7 @@ Each tile type has a unique tool id. Here is an example of a tool tile id defini
 ```typescript
 export const kPlaceholderToolID = "Placeholder";
 ```
-These ids are used in several places. These ids are used in several places. They are defined when the tool is registered with `registerToolContentInfo`.
+These ids are used in several places. They are defined when the tool is registered with `registerToolContentInfo`.
 
 ## Tool Tile Models
 Each tool defines a tile content model. This content model is specified as a MobX State Tree (MST) model and contains properties and actions specific to the tool. Each of the tool tile content models is unioned together to define the `ToolContentUnion` type.


### PR DESCRIPTION
now that tools added by calling the registerToolContentInfo method,
we cannot use static typing with the tool ids.

I'd also note that the places where the tool value is passed to the changed
methods it was just being casted from a string. So there wan't much type
safety here.

It was nice to know the type of the argument should be a tool id. And it would
be possible to just alias string as DocumentTool. But doing this kind of
creates a false sense of security. Typescript would take a string or a
DocumentTool in this case it would not even require it to be casted.
Because of this false security it seems better to just use string.