### PR TITLE
Fix teacher dashboard tests to only rely on active (not archived) classes

### DIFF
--- a/cypress/fixtures/teacher-dash-data.json
+++ b/cypress/fixtures/teacher-dash-data.json
@@ -557,16 +557,11 @@
         },
         {
             "classIndex" : 1,
-            "className": "CLUE 2"
+            "className": "CLUE A"
         },
         {
-            "classIndex" : 2
-        },
-        {
-            "classIndex" : 3
-        },
-        {
-            "classIndex" : 4
+            "classIndex" : 2,
+            "className": "CLUE B"
         }
     ]
 }

--- a/cypress/integration/clue/full/teacher_tests/teacher_dashboard_spec.js
+++ b/cypress/integration/clue/full/teacher_tests/teacher_dashboard_spec.js
@@ -59,7 +59,7 @@ context("Teacher Space", () => {
                     dashboard.getClassDropdown().should('contain',clueData.teacherName).and('contain',tempClass.className);
                     dashboard.getClassDropdown().should('be.visible').click({ force: true });
                     dashboard.getClassList().should('exist').and('have.class', 'show');
-                    dashboard.getClassList().find('.list-item').should('have.length', clueData.classes.length); // FIX THIS - currently shows all classes including inactive classes. Should only show active classes. Story in PT.
+                    dashboard.getClassList().find('.list-item').should('have.length', clueData.classes.length);
                     dashboard.getClassDropdown().click({ force: true });
                     dashboard.getClassList().should('not.have.class','show');
                     // //Check Teacher Username visibility and content
@@ -133,7 +133,7 @@ context("Teacher Space", () => {
                         cy.waitForLoad();
                     });
                     dashboard.getClassDropdown().should('contain', className);
-                    dashboard.getGroups().should('have.length',0);
+                    dashboard.getGroups().should('have.length', 1);
 
                     //switch back to original problem for later test
                     dashboard.getClassDropdown().click({force:true});


### PR DESCRIPTION
Recent portal changes mean that archived classes are no longer returned to clients. The teacher dashboard cypress test needs to be updated to accommodate the change.