### PR TITLE
Networked teachers can access images in unpublished network documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,15 @@ To deploy a production release:
 
 ## Developing/deploying cloud functions
 
-CLUE uses a google cloud function to retrieve certain images from the firebase realtime database that
-would otherwise not be allowed by security rules, notably to allow users in other classes to retrieve
-images that were stored as part of a cross-class teacher support. Down the road we may encounter uses
-for additional cloud functions.
+CLUE uses several Google cloud functions to implement certain features that would be difficult (or impossible) to implement entirely client-side.
+|Function|Purpose|
+|--------|-------|
+|_getImageData_|Retrieves image data that may reside in other classes and hence is not accessible client-side, e.g. for supports published to multiple classes or documents retrieved via the teacher network.|
+|_getNetworkDocument_|Retrieves the contents of a document accessible to a teacher via the teacher network.|
+|_getNetworkResources_|Retrieves the list of resources (documents) available to a teacher via the teacher network.|
+|_postDocumentComment_|Posts a comment to a document in firestore, adding metadata for the document to firestore if necessary.|
+|_publishSupport_|Publishes a document as a support that is accessible to all of a teacher's classes (including any referenced images).|
+|_validateCommentableDocument_|Checks whether a specific commentable document exists in firestore and creates it if necessary.|
 
 The code for the functions is in the `functions` directory. You should be able to cd into the
 `functions` directory and perform basic development operations:
@@ -75,6 +80,8 @@ Google recommends (requires?) that [firebase-tools](https://www.npmjs.com/packag
 ```
 $ npm install -g firebase-tools
 ```
+This should be run periodically to make sure you're running the latest version of the tools.
+
 #### Running tests locally (without running functions in the emulator)
 ```
 $ npm run serve                 # build and then start the emulators

--- a/functions/jest.config.js
+++ b/functions/jest.config.js
@@ -1,5 +1,8 @@
 // cf. https://medium.com/@leejh3224/testing-firebase-cloud-functions-with-jest-4156e65c7d29
 module.exports = {
+  "setupFilesAfterEnv": [
+    "<rootDir>/../src/setupTests.ts"
+  ],
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -17,6 +17,7 @@
         "@types/jest": "^27.4.0",
         "@typescript-eslint/eslint-plugin": "^5.10.2",
         "@typescript-eslint/parser": "^5.10.2",
+        "cross-env": "^7.0.3",
         "eslint": "^8.8.0",
         "eslint-plugin-import": "^2.25.4",
         "firebase-functions-test": "^0.3.3",
@@ -3422,6 +3423,24 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -12290,6 +12309,15 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
     },
     "cross-spawn": {
       "version": "7.0.3",

--- a/functions/package.json
+++ b/functions/package.json
@@ -15,8 +15,8 @@
     "deploy:publishSupport": "firebase deploy --only functions:publishSupport_v1",
     "deploy:validateCommentableDocument": "firebase deploy --only functions:validateCommentableDocument_v1",
     "logs": "firebase functions:log",
-    "test": "ts-node node_modules/jest/bin/jest.js --detectOpenHandles",
-    "test:coverage": "ts-node node_modules/jest/bin/jest.js --coverage --detectOpenHandles"
+    "test": "cross-env FIREBASE_CONFIG={} ts-node node_modules/jest/bin/jest.js --detectOpenHandles",
+    "test:coverage": "cross-env FIREBASE_CONFIG={} ts-node node_modules/jest/bin/jest.js --coverage --detectOpenHandles"
   },
   "engines": {
     "node": "16"
@@ -34,6 +34,7 @@
     "@types/jest": "^27.4.0",
     "@typescript-eslint/eslint-plugin": "^5.10.2",
     "@typescript-eslint/parser": "^5.10.2",
+    "cross-env": "^7.0.3",
     "eslint": "^8.8.0",
     "eslint-plugin-import": "^2.25.4",
     "firebase-functions-test": "^0.3.3",

--- a/functions/src/canonicalize-url.ts
+++ b/functions/src/canonicalize-url.ts
@@ -1,0 +1,12 @@
+import * as admin from "firebase-admin";
+import { buildFirebaseImageUrl, parseFirebaseImageUrl } from "./shared-utils";
+
+export async function canonicalizeUrl(url: string, defaultClassHash: string, firestoreRoot: string) {
+  const { imageClassHash, imageKey } = parseFirebaseImageUrl(url);
+  // if it's already in canonical form (or can't be canonicalized) just return it
+  if (imageClassHash || !imageKey) return url;
+  // check for an entry in our `images` collection which maps legacy image urls to their classes
+  const imageDoc = (await admin.firestore().doc(`${firestoreRoot}/images/${imageKey}`).get()).data();
+  const classHash = imageDoc ? imageDoc.context_id : defaultClassHash;
+  return buildFirebaseImageUrl(classHash, imageKey);
+}

--- a/functions/src/parse-document-content.ts
+++ b/functions/src/parse-document-content.ts
@@ -14,7 +14,7 @@ interface IImageInfo {
   key: string;
 }
 
-export async function parseSupportContent(contentJson: string, canonicalizeUrl: (url: string) => Promise<string>) {
+export async function parseDocumentContent(contentJson: string, canonicalizeUrl: (url: string) => Promise<string>) {
 
   const content = safeJsonParse<IDocumentContent>(contentJson);
 

--- a/functions/test/canonicalize-url.test.ts
+++ b/functions/test/canonicalize-url.test.ts
@@ -1,0 +1,14 @@
+import { canonicalizeUrl } from "../src/canonicalize-url";
+import { buildFirebaseImageUrl } from "../src/shared-utils";
+
+describe("canonicalizeUrl", () => {
+  it("should simply return invalid urls", async () => {
+    expect(await canonicalizeUrl("", "", "")).toBe("");
+    expect(await canonicalizeUrl("bogus", "class-hash", "firestore-root")).toBe("bogus");
+  });
+
+  it("should simply return canonical urls", async () => {
+    const canonicalUrl = buildFirebaseImageUrl("image-class-hash", "image-key");
+    expect(await canonicalizeUrl(canonicalUrl, "class-hash", "firestore-root")).toBe(canonicalUrl);
+  });
+});

--- a/functions/test/parse-document-content.test.ts
+++ b/functions/test/parse-document-content.test.ts
@@ -1,18 +1,18 @@
-import { parseSupportContent } from "../src/parse-support-content";
+import { parseDocumentContent } from "../src/parse-document-content";
 import { buildFirebaseImageUrl, parseFirebaseImageUrl, replaceAll } from "../src/shared-utils";
 import { specDocumentContent } from "./test-utils";
 
-describe("parseSupportContent", () => {
+describe("parseDocumentContent", () => {
 
   const identityCanonicalize = (url: string) => Promise.resolve(url);
 
   it("should parse empty content", async () => {
-    expect(await parseSupportContent("", identityCanonicalize)).toEqual({ content: "", images: {} });
+    expect(await parseDocumentContent("", identityCanonicalize)).toEqual({ content: "", images: {} });
   });
 
   it("should parse content without images", async () => {
     const kEmptyContent = specDocumentContent();
-    expect(await parseSupportContent(kEmptyContent, identityCanonicalize)).toEqual({ content: kEmptyContent, images: {} });
+    expect(await parseDocumentContent(kEmptyContent, identityCanonicalize)).toEqual({ content: kEmptyContent, images: {} });
   });
 
   it("should parse a single Image tile with legacy url", async () => {
@@ -27,7 +27,7 @@ describe("parseSupportContent", () => {
       const { imageKey = "" } = parseFirebaseImageUrl(url);
       return Promise.resolve(buildFirebaseImageUrl(kClassHash, imageKey));
     };
-    expect(await parseSupportContent(originalContent, canonicalize))
+    expect(await parseDocumentContent(originalContent, canonicalize))
       .toEqual({ content: updatedContent, images: { [legacyUrl]: canonicalUrl } });
   });
 
@@ -45,7 +45,7 @@ describe("parseSupportContent", () => {
       const { imageKey = "" } = parseFirebaseImageUrl(url);
       return Promise.resolve(buildFirebaseImageUrl(kClassHash, imageKey));
     };
-    expect(await parseSupportContent(originalContent, canonicalize))
+    expect(await parseDocumentContent(originalContent, canonicalize))
       .toEqual({ content: updatedContent, images: { [legacyUrl2]: canonicalUrl2 } });
   });
 
@@ -63,7 +63,7 @@ describe("parseSupportContent", () => {
       const { imageKey = "" } = parseFirebaseImageUrl(url);
       return Promise.resolve(buildFirebaseImageUrl(kClassHash, imageKey));
     };
-    expect(await parseSupportContent(originalContent, canonicalize))
+    expect(await parseDocumentContent(originalContent, canonicalize))
       .toEqual({ content: updatedContent, images: { [legacyUrl1]: canonicalUrl1, [legacyUrl2]: canonicalUrl2 } });
   });
 
@@ -85,7 +85,7 @@ describe("parseSupportContent", () => {
       const { imageKey = "" } = parseFirebaseImageUrl(url);
       return Promise.resolve(buildFirebaseImageUrl(kClassHash, imageKey));
     };
-    expect(await parseSupportContent(originalContent, canonicalize))
+    expect(await parseDocumentContent(originalContent, canonicalize))
       .toEqual({ content: updatedContent, images });
   });
 

--- a/functions/test/publish-support.test.ts
+++ b/functions/test/publish-support.test.ts
@@ -1,5 +1,5 @@
 import { apps, clearFirestoreData, initializeAdminApp, useEmulators } from "@firebase/rules-unit-testing";
-import { canonicalizeUrl, publishSupport } from "../src/publish-support";
+import { publishSupport } from "../src/publish-support";
 import { IPublishSupportParams } from "../src/shared";
 import { buildFirebaseImageUrl, parseFirebaseImageUrl, replaceAll } from "../src/shared-utils";
 import {
@@ -106,18 +106,6 @@ async function writeImageRecordToFirestore(overrides?: any) {
   };
   return await firestoreAdmin.doc(`${firestoreRoot}/images/${imageKey}`).set(image);
 }
-
-describe("canonicalizeUrl", () => {
-  it("should simply return invalid urls", async () => {
-    expect(await canonicalizeUrl("", "", "")).toBe("");
-    expect(await canonicalizeUrl("bogus", "class-hash", "firestore-root")).toBe("bogus");
-  });
-
-  it("should simply return canonical urls", async () => {
-    const canonicalUrl = buildFirebaseImageUrl("image-class-hash", "image-key");
-    expect(await canonicalizeUrl(canonicalUrl, "class-hash", "firestore-root")).toBe(canonicalUrl);
-  });
-});
 
 describe("publishSupport", () => {
 


### PR DESCRIPTION
Once more unto the breach...

In #1190 we extended the image access solution to images in supports _published_ to classes accessible via the teacher network. But, of course, images also reside in _unpublished_ documents, and for those we can't rely on `mcimages` entries in firestore. Instead, the `getNetworkDocument()` function uses our existing code for canonicalizing image urls in content to return canonicalized content and then the `getImageData()` function returns the image data if its class is accessible via a teacher's network.