### PR TITLE
Refresh teacher names in network document captions when necessary

### DIFF
--- a/src/components/thumbnail/tab-panel-documents-subsection-panel.tsx
+++ b/src/components/thumbnail/tab-panel-documents-subsection-panel.tsx
@@ -1,3 +1,4 @@
+import { observer } from "mobx-react";
 import React from "react";
 import { ThumbnailDocumentItem } from "./thumbnail-document-item";
 import { useFirestoreTeacher } from "../../hooks/firestore-hooks";
@@ -36,9 +37,11 @@ function useDocumentCaption(stores: IStores, document: DocumentModelType) {
   return `${namePrefix}${title}${dateSuffix}`;
 }
 
-export const TabPanelDocumentsSubSectionPanel = ({section, sectionDocument, tab, stores, scale, selectedDocument,
-                                                  onSelectDocument, onDocumentDragStart,
-                                                  onDocumentStarClick, onDocumentDeleteClick}: IProps) => {
+// observes teacher names via useDocumentCaption()
+export const TabPanelDocumentsSubSectionPanel = observer(({
+  section, sectionDocument, tab, stores, scale, selectedDocument,
+  onSelectDocument, onDocumentDragStart, onDocumentStarClick, onDocumentDeleteClick
+}: IProps) => {
     const { user } = stores;
     const tabName = tab.toLowerCase().replace(' ', '-');
     const caption = useDocumentCaption(stores, sectionDocument);
@@ -88,4 +91,4 @@ export const TabPanelDocumentsSubSectionPanel = ({section, sectionDocument, tab,
         onDocumentDeleteClick={_handleDocumentDeleteClick}
       />
     );
-};
+});

--- a/src/hooks/firestore-hooks.test.ts
+++ b/src/hooks/firestore-hooks.test.ts
@@ -86,10 +86,11 @@ describe("Firestore hooks", () => {
       expect(mockGet).toHaveBeenCalledTimes(1);
       // initial response is the default response
       expect(result.current).toEqual(kDefaultTeacher);
-      rerender();
-      // second request for same teacher doesn't hit the network due to caching
-      expect(mockGet).toHaveBeenCalledTimes(1);
+      // wait for promise to resolve
       setTimeout(() => {
+        rerender();
+        // second request for same teacher doesn't hit the network due to caching
+        expect(mockGet).toHaveBeenCalledTimes(1);
         // actual teacher available once promise resolves
         expect(result.current).toEqual(kRealTeacher);
         done();

--- a/src/hooks/firestore-hooks.ts
+++ b/src/hooks/firestore-hooks.ts
@@ -1,5 +1,6 @@
 import firebase from "firebase/app";
-import { useCallback, useEffect, useState } from 'react';
+import { observable } from "mobx";
+import { useCallback, useEffect } from 'react';
 import { useMutation, useQuery, useQueryClient, UseQueryOptions } from 'react-query';
 import { UserDocument } from "../lib/firestore-schema";
 import { useDBStore } from './use-stores';
@@ -16,30 +17,28 @@ export function useFirestore() {
   return [db.firestore, root] as const;
 }
 
-const firestoreTeachers: Record<string, UserDocument> = {};
+const firestoreTeachers = observable.map<string, UserDocument>();
 
 export function useFirestoreTeacher(uid: string, network: string) {
   const [firestore] = useFirestore();
-  const [ , setCount] = useState(0);
-  if (firestoreTeachers[uid]) return firestoreTeachers[uid];
+  const cachedTeacher = firestoreTeachers.get(uid);
+  if (cachedTeacher) return cachedTeacher;
 
   // default response until promise resolves
-  firestoreTeachers[uid] = { uid, name: "Network User", type: "teacher", network, networks: [network] };
+  firestoreTeachers.set(uid, { uid, name: "Network User", type: "teacher", network, networks: [network] });
 
   firestore.doc(`users/${uid}`).get()
     .then(snap => {
       const teacher = snap.data() as UserDocument | undefined;
       if (teacher) {
-        firestoreTeachers[uid] = teacher;
-        // trigger re-render when we get the results
-        setCount(count => ++count);
+        firestoreTeachers.set(uid, teacher);
       }
     })
     .catch(() => {
       // ignore errors
     });
 
-  return firestoreTeachers[uid];
+  return firestoreTeachers.get(uid);
 }
 
 // https://medium.com/swlh/using-firestore-with-typescript-65bd2a602945


### PR DESCRIPTION
Use mobx observable map to ensure that captions redraw when teacher names change. The previous approach which relied on React state didn't refresh all captions that needed refreshing.