### PR TITLE
Firebase/MST listener improvements

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -82,6 +82,9 @@ module.exports = {
         files: ["**/*.test.*"],
         rules: {
           "@typescript-eslint/no-non-null-assertion": "off",
+          // require() can be useful in mocking
+          "@typescript-eslint/no-require-imports": "off",
+          "@typescript-eslint/no-var-requires": "off",
           // var is useful in mocking due to its hoisting semantics
           "no-var": "off"
         }

--- a/src/components/document/editable-document-content.tsx
+++ b/src/components/document/editable-document-content.tsx
@@ -7,7 +7,7 @@ import { DocumentContextReact } from "./document-context";
 import { FourUpComponent } from "../four-up";
 import { useDocumentContext } from "../../hooks/use-document-context";
 import { useDocumentSyncToFirebase } from "../../hooks/use-document-sync-to-firebase";
-import { useGroupsStore, useStores, useUIStore, useUserStore } from "../../hooks/use-stores";
+import { useGroupsStore, useStores } from "../../hooks/use-stores";
 import { ToolbarComponent } from "../toolbar";
 import { EditableToolApiInterfaceRef, EditableToolApiInterfaceRefContext } from "../tools/tool-api";
 import { DocumentModelType } from "../../models/document/document";

--- a/src/components/document/editable-document-content.tsx
+++ b/src/components/document/editable-document-content.tsx
@@ -6,7 +6,8 @@ import { CanvasComponent } from "./canvas";
 import { DocumentContextReact } from "./document-context";
 import { FourUpComponent } from "../four-up";
 import { useDocumentContext } from "../../hooks/use-document-context";
-import { useGroupsStore, useUIStore, useUserStore } from "../../hooks/use-stores";
+import { useDocumentSyncToFirebase } from "../../hooks/use-document-sync-to-firebase";
+import { useGroupsStore, useStores, useUIStore, useUserStore } from "../../hooks/use-stores";
 import { ToolbarComponent } from "../toolbar";
 import { EditableToolApiInterfaceRef, EditableToolApiInterfaceRefContext } from "../tools/tool-api";
 import { DocumentModelType } from "../../models/document/document";
@@ -87,8 +88,8 @@ export const EditableDocumentContent: React.FC<IProps> = props => {
   const { mode, isPrimary, document, toolbar, readOnly } = props;
 
   const documentContext = useDocumentContext(document);
-  const ui = useUIStore();
-  const { isNetworkedTeacher } = useUserStore();
+  const { db: { firebase }, ui, user } = useStores();
+  const { isNetworkedTeacher } = user;
 
   // set by the canvas and used by the toolbar
   const editableToolApiInterfaceRef: EditableToolApiInterfaceRef = useRef(null);
@@ -100,6 +101,9 @@ export const EditableDocumentContent: React.FC<IProps> = props => {
   const documentSelectedForComment = isChatEnabled && ui.showChatPanel && ui.selectedTileIds.length === 0 && !isPrimary;
   const editableDocContentClass = classNames("editable-document-content", showToolbarClass,
                                              {"comment-select" : documentSelectedForComment});
+
+  useDocumentSyncToFirebase(user, firebase, document, readOnly);
+
   return (
     <DocumentContextReact.Provider value={documentContext}>
       <EditableToolApiInterfaceRefContext.Provider value={editableToolApiInterfaceRef}>

--- a/src/hooks/network-resources.test.ts
+++ b/src/hooks/network-resources.test.ts
@@ -100,11 +100,10 @@ describe("Network resources hooks", () => {
           }
         });
       });
-      jestSpyConsole("warn", async (mockConsoleFn, mockRestore) => {
-        await renderHook(() => useNetworkResources());
-        expect(mockConsoleFn).toHaveBeenCalledTimes(2);
-        mockRestore();
-      }, { asyncRestore: true });
+      jestSpyConsole("warn", async spy => {
+        const { waitFor } = renderHook(() => useNetworkResources());
+        await waitFor(() => expect(spy).toHaveBeenCalledTimes(2));
+      });
       expect(mockGetNetworkResources).toHaveBeenCalled();
     });
   });

--- a/src/hooks/use-document-sync-to-firebase.test.ts
+++ b/src/hooks/use-document-sync-to-firebase.test.ts
@@ -1,0 +1,556 @@
+import { renderHook } from "@testing-library/react-hooks";
+import { observable, reaction, runInAction } from "mobx";
+import { SnapshotIn } from "mobx-state-tree";
+import { UseMutationOptions } from "react-query";
+import { Firebase } from "../lib/firebase";
+import { DocumentModel } from "../models/document/document";
+import {
+  LearningLogDocument, PersonalDocument, PlanningDocument, ProblemDocument
+} from "../models/document/document-types";
+import { UserModel, UserModelType } from "../models/stores/user";
+import { useDocumentSyncToFirebase } from "./use-document-sync-to-firebase";
+const libDebug = require("../lib/debug");
+
+import "../models/tools/text/text-registration";
+
+var mockUseMutation = jest.fn((callback: (vars: any) => Promise<any>, options?: UseMutationOptions) => {
+  return {
+    mutate: (vars: any) => {
+      callback(vars)
+        .then(data => { options?.onSuccess?.(data, vars, {}); })
+        .catch(err => {
+          options?.onError?.(err, vars, {});
+          if (((typeof options?.retry === "boolean") && options.retry) ||
+              ((typeof options?.retry === "function") && options.retry(1, "error"))) {
+            const delay = ((typeof options?.retryDelay === "number") && options.retryDelay) ||
+                          ((typeof options?.retryDelay === "function") && options.retryDelay(1, "error"));
+            // make it async, but minimal delay for testing purposes
+            setTimeout(() => {
+              try {
+                callback(vars);
+              }
+              catch(e) {
+                // ignore any errors on retry
+              }
+            }, delay || 0);
+          }
+        });
+    }
+  };
+});
+jest.mock("react-query", () => ({
+  useMutation: (callback: (vars: any) => Promise<any>, options?: any) => mockUseMutation(callback, options)
+}));
+
+var mockUpdate = jest.fn();
+var mockRef = jest.fn();
+
+const specUser = (overrides?: Partial<SnapshotIn<typeof UserModel>>) => {
+  return UserModel.create({ id: "1", ...overrides });
+};
+
+const specFirebase = (type: string, key: string) => {
+  return {
+    getUserDocumentPaths: (user: UserModelType) => {
+      return {
+        content: `${user.id}/content/${key}`,
+        metadata: `${user.id}/metadata/${key}`,
+        typedMetadata: `${user.id}/${type}/${key}`
+      };
+    },
+    ref: (path: string) => mockRef(path)
+  } as unknown as Firebase;
+};
+
+const specDocument = (overrides?: Partial<SnapshotIn<typeof DocumentModel>>) => {
+  const props: SnapshotIn<typeof DocumentModel> = {
+    type: "problem", key: "doc-key", uid: "1", content: {}, ...overrides };
+  return DocumentModel.create(props);
+};
+
+const specArgs = (type: string, key: string,
+                  userOverrides?: Partial<SnapshotIn<typeof UserModel>>,
+                  documentOverrides?: Partial<SnapshotIn<typeof DocumentModel>>) => {
+  const user = specUser(userOverrides);
+  const { id: uid } = user;
+  const firebase = specFirebase(type, key);
+  const document = specDocument({ type: type as any, key, uid, ...documentOverrides });
+  return { user, firebase, document };
+};
+
+describe("useDocumentSyncToFirebase hook", () => {
+
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  beforeEach(() => {
+    mockUpdate.mockReset();
+    mockRef.mockReset();
+    mockRef.mockImplementation((path: string) => {
+      return {
+        update: (value: any) => Promise.resolve(mockUpdate(value))
+      };
+    });
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it("verifies MobX/MST assumptions", () => {
+    const value = observable({ foo: "bar" });
+    const responder = jest.fn();
+
+    // . access on MobX observable triggers reaction
+    const disposer1 = reaction(() => value.foo, () => responder());
+    runInAction(() => value.foo = "baz");
+    disposer1();
+    expect(responder).toHaveBeenCalledTimes(1);
+
+    // [] access on MobX observable triggers reaction
+    const prop = "foo";
+    const disposer2 = reaction(() => value[prop], () => responder());
+    runInAction(() => value.foo = "roo");
+    expect(responder).toHaveBeenCalledTimes(2);
+
+    // no reaction if value doesn't change
+    runInAction(() => value.foo = "roo");
+    disposer2();
+    expect(responder).toHaveBeenCalledTimes(2);
+
+    // . access on MST model property triggers reaction
+    const document = specDocument();
+    const disposer3 = reaction(() => document.visibility, () => responder());
+    runInAction(() => document.setVisibility("public"));
+    disposer3();
+    expect(responder).toHaveBeenCalledTimes(3);
+
+    // [] access on MST model property triggers reaction
+    const prop2 = "visibility";
+    const disposer4 = reaction(() => document[prop2], () => responder());
+    runInAction(() => document.setVisibility("private"));
+    expect(responder).toHaveBeenCalledTimes(4);
+
+    // no reaction if value doesn't change
+    runInAction(() => document.setVisibility("private"));
+    expect(responder).toHaveBeenCalledTimes(4);
+    disposer4();
+  });
+
+  it("doesn't monitor read-only documents", () => {
+    const { user, firebase, document } = specArgs(PlanningDocument, "xyz");
+    renderHook(() => useDocumentSyncToFirebase(user, firebase, document, true));
+    expect(mockRef).toHaveBeenCalledTimes(0);
+    expect(mockUpdate).toHaveBeenCalledTimes(0);
+
+    // doesn't respond to visibility change in read-only documents
+    document.setVisibility("public");
+    expect(mockRef).toHaveBeenCalledTimes(0);
+    expect(mockUpdate).toHaveBeenCalledTimes(0);
+
+    // doesn't respond to content change in read-only documents
+    document.content?.addTile("text");
+    expect(mockRef).toHaveBeenCalledTimes(0);
+    expect(mockUpdate).toHaveBeenCalledTimes(0);
+
+    // doesn't respond to title change in read-only documents
+    document.setTitle("New Title");
+    expect(mockRef).toHaveBeenCalledTimes(0);
+    expect(mockUpdate).toHaveBeenCalledTimes(0);
+
+    // doesn't respond to properties change in read-only documents
+    document.setProperty("foo", "bar");
+    expect(mockRef).toHaveBeenCalledTimes(0);
+    expect(mockUpdate).toHaveBeenCalledTimes(0);
+  });
+
+  it("monitors problem documents", async () => {
+    const { user, firebase, document } = specArgs(ProblemDocument, "xyz");
+    renderHook(() => useDocumentSyncToFirebase(user, firebase, document));
+    expect(mockRef).toHaveBeenCalledTimes(0);
+    expect(mockUpdate).toHaveBeenCalledTimes(0);
+
+    // updates public/private status on visibility change
+    document.setVisibility("public");
+    expect(mockRef).toBeCalledTimes(1);
+    expect(mockRef).toHaveBeenCalledWith(`${user.id}/problem/${document.key}`);
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+
+    // saves when content changes
+    document.content?.addTile("text");
+    expect(mockRef).toHaveBeenCalledTimes(2);
+    expect(mockRef).toHaveBeenCalledWith(`${user.id}/content/${document.key}`);
+    expect(mockUpdate).toHaveBeenCalledTimes(2);
+
+    // doesn't respond to title change (problem documents don't have user-settable titles)
+    document.setTitle("New Title");
+    expect(mockRef).toHaveBeenCalledTimes(2);
+    expect(mockUpdate).toHaveBeenCalledTimes(2);
+
+    // doesn't respond to properties change (problem documents don't have user-settable properties)
+    document.setProperty("foo", "bar");
+    expect(mockRef).toHaveBeenCalledTimes(2);
+    expect(mockUpdate).toHaveBeenCalledTimes(2);
+  });
+
+  it("monitors planning documents", () => {
+    const { user, firebase, document } = specArgs(PlanningDocument, "xyz");
+    renderHook(() => useDocumentSyncToFirebase(user, firebase, document));
+    expect(mockRef).toHaveBeenCalledTimes(0);
+    expect(mockUpdate).toHaveBeenCalledTimes(0);
+
+    // doesn't respond to visibility change (planning documents are always private)
+    document.setVisibility("public");
+    expect(mockRef).toHaveBeenCalledTimes(0);
+    expect(mockUpdate).toHaveBeenCalledTimes(0);
+
+    // saves when content changes
+    document.content?.addTile("text");
+    expect(mockRef).toHaveBeenCalledTimes(1);
+    expect(mockRef).toHaveBeenCalledWith(`${user.id}/content/${document.key}`);
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+
+    // doesn't respond to title change (planning documents don't have user-settable titles)
+    document.setTitle("New Title");
+    expect(mockRef).toHaveBeenCalledTimes(1);
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+
+    // doesn't respond to properties change (planning documents don't have user-settable properties)
+    document.setProperty("foo", "bar");
+    expect(mockRef).toHaveBeenCalledTimes(1);
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("monitors personal documents", () => {
+    const { user, firebase, document } = specArgs(PersonalDocument, "xyz");
+    renderHook(() => useDocumentSyncToFirebase(user, firebase, document));
+    expect(mockRef).toHaveBeenCalledTimes(0);
+    expect(mockUpdate).toHaveBeenCalledTimes(0);
+
+    // doesn't respond to visibility change (personal documents don't have visibility)
+    document.setVisibility("public");
+    expect(mockRef).toHaveBeenCalledTimes(0);
+    expect(mockUpdate).toHaveBeenCalledTimes(0);
+
+    // saves when content changes
+    document.content?.addTile("text");
+    expect(mockRef).toHaveBeenCalledTimes(1);
+    expect(mockRef).toHaveBeenCalledWith(`${user.id}/content/${document.key}`);
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+
+    // updates title when it changes
+    document.setTitle("New Title");
+    expect(mockRef).toHaveBeenCalledTimes(2);
+    expect(mockRef).toHaveBeenCalledWith(`${user.id}/personal/${document.key}`);
+    expect(mockUpdate).toHaveBeenCalledTimes(2);
+
+    // updates properties when they change
+    document.setProperty("foo", "bar");
+    expect(mockRef).toHaveBeenCalledTimes(3);
+    expect(mockRef).toHaveBeenCalledWith(`${user.id}/personal/${document.key}`);
+    expect(mockUpdate).toHaveBeenCalledTimes(3);
+  });
+
+  it("monitors learning log documents", () => {
+    const { user, firebase, document } = specArgs(LearningLogDocument, "xyz");
+    renderHook(() => useDocumentSyncToFirebase(user, firebase, document));
+    expect(mockRef).toHaveBeenCalledTimes(0);
+    expect(mockUpdate).toHaveBeenCalledTimes(0);
+
+    // doesn't respond to visibility change (learning logs don't have visibility)
+    document.setVisibility("public");
+    expect(mockRef).toHaveBeenCalledTimes(0);
+    expect(mockUpdate).toHaveBeenCalledTimes(0);
+
+    // saves when content changes
+    document.content?.addTile("text");
+    expect(mockRef).toHaveBeenCalledTimes(1);
+    expect(mockRef).toHaveBeenCalledWith(`${user.id}/content/${document.key}`);
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+
+    // updates title when it changes
+    document.setTitle("New Title");
+    expect(mockRef).toHaveBeenCalledTimes(2);
+    expect(mockRef).toHaveBeenCalledWith(`${user.id}/learningLog/${document.key}`);
+    expect(mockUpdate).toHaveBeenCalledTimes(2);
+
+    // updates properties when they change
+    document.setProperty("foo", "bar");
+    expect(mockRef).toHaveBeenCalledTimes(3);
+    expect(mockRef).toHaveBeenCalledWith(`${user.id}/learningLog/${document.key}`);
+    expect(mockUpdate).toHaveBeenCalledTimes(3);
+  });
+
+  it("monitors problem documents with additional logging when DEBUG_SAVE == true", async () => {
+    libDebug.DEBUG_SAVE = true;
+    const { user, firebase, document } = specArgs(ProblemDocument, "xyz");
+
+    expect.assertions(18);
+
+    // logs monitoring of document
+    let unmount: () => void;
+    let waitFor: (callback: () => boolean | void) => Promise<void>;
+    await jestSpyConsole("log", async spy => {
+      const { unmount: _unmount, waitFor: _waitFor } =
+        renderHook(() => useDocumentSyncToFirebase(user, firebase, document));
+      unmount = _unmount;
+      waitFor = _waitFor;
+      await waitFor(() => expect(spy).toBeCalledTimes(1));
+      expect(mockRef).toHaveBeenCalledTimes(0);
+      expect(mockUpdate).toHaveBeenCalledTimes(0);
+    });
+
+    // saves when visibility changes with additional logging
+    mockRef.mockClear();
+    mockUpdate.mockClear();
+    await jestSpyConsole("log", async spy => {
+      document.setVisibility("public");
+      await waitFor(() => expect(mockRef).toHaveBeenCalledTimes(1));
+      expect(mockRef).toHaveBeenCalledWith(`${user.id}/problem/${document.key}`);
+      await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(spy).toBeCalledTimes(1));
+    });
+
+    // doesn't respond to title change
+    mockRef.mockClear();
+    mockUpdate.mockClear();
+    await jestSpyConsole("log", spy => {
+      document.setTitle("New Title");
+      expect(mockRef).toHaveBeenCalledTimes(0);
+      expect(mockUpdate).toHaveBeenCalledTimes(0);
+      expect(spy).not.toBeCalled();
+    });
+
+    // doesn't respond to properties change
+    mockRef.mockClear();
+    mockUpdate.mockClear();
+    await jestSpyConsole("log", spy => {
+      document.setProperty("foo", "bar");
+      expect(mockRef).toHaveBeenCalledTimes(0);
+      expect(mockUpdate).toHaveBeenCalledTimes(0);
+      expect(spy).not.toBeCalled();
+    });
+
+    // saves when content changes with additional logging
+    mockRef.mockClear();
+    mockUpdate.mockClear();
+    await jestSpyConsole("log", async spy => {
+      document.content?.addTile("text");
+      await waitFor(() => expect(mockRef).toHaveBeenCalledTimes(1));
+      expect(mockRef).toHaveBeenCalledWith(`${user.id}/content/${document.key}`);
+      await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(spy).toBeCalledTimes(1));
+    });
+
+    // logs unmonitoring of document
+    await jestSpyConsole("log", async spy => {
+      unmount();
+      await waitFor(() => expect(spy).toBeCalledTimes(1));
+    });
+  });
+
+  it("monitors personal documents with additional logging when DEBUG_SAVE == true", async () => {
+    libDebug.DEBUG_SAVE = true;
+    const { user, firebase, document } = specArgs(PersonalDocument, "xyz");
+
+    expect.assertions(19);
+
+    // logs monitoring of document
+    let unmount: () => void;
+    let waitFor: (callback: () => boolean | void) => Promise<void>;
+    await jestSpyConsole("log", async spy => {
+      const { unmount: _unmount, waitFor: _waitFor } =
+        renderHook(() => useDocumentSyncToFirebase(user, firebase, document));
+      unmount = _unmount;
+      waitFor = _waitFor;
+      await waitFor(() => expect(spy).toBeCalledTimes(1));
+      expect(mockRef).toHaveBeenCalledTimes(0);
+      expect(mockUpdate).toHaveBeenCalledTimes(0);
+    });
+
+    // doesn't respond to visibility change
+    await jestSpyConsole("log", spy => {
+      document.setVisibility("public");
+      jest.runAllTimers();
+      expect(spy).not.toBeCalled();
+    });
+    expect(mockRef).toHaveBeenCalledTimes(0);
+    expect(mockUpdate).toHaveBeenCalledTimes(0);
+
+    // saves when title changes with additional logging
+    mockRef.mockClear();
+    mockUpdate.mockClear();
+    await jestSpyConsole("log", async spy => {
+      document.setTitle("New Title");
+      await waitFor(() => expect(mockRef).toHaveBeenCalledTimes(1));
+      expect(mockRef).toHaveBeenCalledWith(`${user.id}/personal/${document.key}`);
+      await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(spy).toBeCalledTimes(1));
+    });
+
+    // saves when properties change with additional logging
+    mockRef.mockClear();
+    mockUpdate.mockClear();
+    await jestSpyConsole("log", async spy => {
+      document.setProperty("foo", "bar");
+      await waitFor(() => expect(mockRef).toHaveBeenCalledTimes(1));
+      expect(mockRef).toHaveBeenCalledWith(`${user.id}/personal/${document.key}`);
+      await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(spy).toBeCalledTimes(1));
+    });
+
+    // saves when content changes with additional logging
+    mockRef.mockClear();
+    mockUpdate.mockClear();
+    await jestSpyConsole("log", async spy => {
+      document.content?.addTile("text");
+      await waitFor(() => expect(mockRef).toHaveBeenCalledTimes(1));
+      expect(mockRef).toHaveBeenCalledWith(`${user.id}/content/${document.key}`);
+      await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(spy).toBeCalledTimes(1));
+    });
+
+    // logs unmonitoring of document
+    await jestSpyConsole("log", async spy => {
+      unmount();
+      await waitFor(() => expect(spy).toBeCalledTimes(1));
+    });
+  });
+
+  it("warns when asked to monitor another user's document", async () => {
+    libDebug.DEBUG_SAVE = false;
+
+    const { user, firebase, document } = specArgs(PersonalDocument, "xyz", {}, { uid: "2" });
+    jestSpyConsole("warn", mockConsole => {
+      renderHook(() => useDocumentSyncToFirebase(user, firebase, document));
+      expect(mockConsole).toHaveBeenCalledTimes(1);
+    });
+    expect(mockRef).toHaveBeenCalledTimes(0);
+    expect(mockUpdate).toHaveBeenCalledTimes(0);
+  });
+
+  it("fails gracefully on problem document save errors", async () => {
+    libDebug.DEBUG_SAVE = false;
+
+    expect.assertions(16);
+
+    // alternate failures and success (on retry)
+    mockUpdate
+      .mockImplementationOnce(() => Promise.reject("No save for you!"))
+      .mockImplementationOnce(value => Promise.resolve(value))
+      .mockImplementationOnce(() => Promise.reject("No save for you!"))
+      .mockImplementationOnce(value => Promise.resolve(value));
+
+    const { user, firebase, document } = specArgs(ProblemDocument, "xyz");
+    const { waitFor } = renderHook(() => useDocumentSyncToFirebase(user, firebase, document));
+    expect(mockRef).toHaveBeenCalledTimes(0);
+    expect(mockUpdate).toHaveBeenCalledTimes(0);
+
+    // handles visibility change errors
+    mockRef.mockClear();
+    mockUpdate.mockClear();
+    await jestSpyConsole("warn", async spy => {
+      document.setVisibility("public");
+      // assert initial (failed) attempt
+      await waitFor(() => expect(mockRef).toHaveBeenCalledTimes(1));
+      expect(mockRef).toHaveBeenCalledWith(`${user.id}/problem/${document.key}`);
+      await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(spy).toBeCalledTimes(1));
+      // trigger retry (successful) attempt
+      jest.runAllTimers();
+      await waitFor(() => expect(mockRef).toHaveBeenCalledTimes(2));
+      expect(mockRef).toHaveBeenCalledWith(`${user.id}/problem/${document.key}`);
+      await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(2));
+    });
+
+    // handles content change errors
+    mockRef.mockClear();
+    mockUpdate.mockClear();
+    await jestSpyConsole("warn", async spy => {
+      document.content?.addTile("text");
+      // assert initial (failed) attempt
+      await waitFor(() => expect(mockRef).toHaveBeenCalledTimes(1));
+      expect(mockRef).toHaveBeenCalledWith(`${user.id}/content/${document.key}`);
+      await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(spy).toBeCalledTimes(1));
+      // trigger retry (successful) attempt
+      jest.runAllTimers();
+      await waitFor(() => expect(mockRef).toHaveBeenCalledTimes(2));
+      expect(mockRef).toHaveBeenCalledWith(`${user.id}/content/${document.key}`);
+      await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(2));
+    });
+  });
+
+  it("fails gracefully on personal document save errors", async () => {
+    libDebug.DEBUG_SAVE = false;
+
+    expect.assertions(23);
+
+    // alternate failures and success (on retry)
+    mockUpdate
+      .mockImplementationOnce(() => Promise.reject("No save for you!"))
+      .mockImplementationOnce(value => Promise.resolve(value))
+      .mockImplementationOnce(() => Promise.reject("No save for you!"))
+      .mockImplementationOnce(value => Promise.resolve(value))
+      .mockImplementationOnce(() => Promise.reject("No save for you!"))
+      .mockImplementationOnce(value => Promise.resolve(value));
+
+    const { user, firebase, document } = specArgs(PersonalDocument, "xyz");
+    const { waitFor } =
+      renderHook(() => useDocumentSyncToFirebase(user, firebase, document));
+    expect(mockRef).toHaveBeenCalledTimes(0);
+    expect(mockUpdate).toHaveBeenCalledTimes(0);
+
+    // handles title change errors
+    mockRef.mockClear();
+    mockUpdate.mockClear();
+    await jestSpyConsole("warn", async spy => {
+      document.setTitle("New Title");
+      // assert initial (failed) attempt
+      await waitFor(() => expect(mockRef).toHaveBeenCalledTimes(1));
+      expect(mockRef).toHaveBeenCalledWith(`${user.id}/personal/${document.key}`);
+      await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(spy).toBeCalledTimes(1));
+      // trigger retry (successful) attempt
+      jest.runAllTimers();
+      await waitFor(() => expect(mockRef).toHaveBeenCalledTimes(2));
+      expect(mockRef).toHaveBeenCalledWith(`${user.id}/personal/${document.key}`);
+      await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(2));
+    });
+
+    // handles property change errors
+    mockRef.mockClear();
+    mockUpdate.mockClear();
+    await jestSpyConsole("warn", async spy => {
+      document.setProperty("foo", "bar");
+      // assert initial (failed) attempt
+      await waitFor(() => expect(mockRef).toHaveBeenCalledTimes(1));
+      expect(mockRef).toHaveBeenCalledWith(`${user.id}/personal/${document.key}`);
+      await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(spy).toBeCalledTimes(1));
+      // trigger retry (successful) attempt
+      jest.runAllTimers();
+      await waitFor(() => expect(mockRef).toHaveBeenCalledTimes(2));
+      expect(mockRef).toHaveBeenCalledWith(`${user.id}/personal/${document.key}`);
+      await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(2));
+    });
+
+    // handles content change errors
+    mockRef.mockClear();
+    mockUpdate.mockClear();
+    await jestSpyConsole("warn", async spy => {
+      document.content?.addTile("text");
+      // assert initial (failed) attempt
+      await waitFor(() => expect(mockRef).toHaveBeenCalledTimes(1));
+      expect(mockRef).toHaveBeenCalledWith(`${user.id}/content/${document.key}`);
+      await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(spy).toBeCalledTimes(1));
+      // trigger retry (successful) attempt
+      jest.runAllTimers();
+      await waitFor(() => expect(mockRef).toHaveBeenCalledTimes(2));
+      expect(mockRef).toHaveBeenCalledWith(`${user.id}/content/${document.key}`);
+      await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(2));
+    });
+  });
+});

--- a/src/hooks/use-document-sync-to-firebase.ts
+++ b/src/hooks/use-document-sync-to-firebase.ts
@@ -1,0 +1,74 @@
+import { throttle } from "lodash";
+import { reaction } from "mobx";
+import { onSnapshot } from "mobx-state-tree";
+import { useEffect, useMemo } from "react";
+import { Firebase } from "../lib/firebase";
+import { DocumentModelType } from "../models/document/document";
+import {
+  isPublishedType, LearningLogDocument, PersonalDocument, ProblemDocument
+} from "../models/document/document-types";
+import { UserModelType } from "../models/stores/user";
+
+/*
+ * useDocumentSyncToFirebase
+ *
+ * Prior to 2.1.3 all handlers in both directions were handled in the DBListeners class.
+ * From 2.1.3 on the DBListeners class handles firebase => local synchronization, while this
+ * custom hook handles local => firebase synchronization. This hook should be used by any
+ * component that allows firebase document content or metadata to be edited. This means that
+ * we're only actively listening to the document the user is looking at/working on rather than
+ * trying to keep track of listeners on all of a user's documents simultaneously.
+ */
+export function useDocumentSyncToFirebase(
+                  user: UserModelType, firebase: Firebase, document: DocumentModelType, readOnly = false) {
+  const { key, type, uid } = document;
+  const { content: contentPath, typedMetadata } = firebase.getUserDocumentPaths(user, type, key, uid);
+  (user.id !== uid) && console.warn("useDocumentSyncToFirebase monitoring another user's document?!?");
+
+  const throttledContentUpdate = useMemo(() => throttle((changeCount: number, content: string) => {
+    firebase.ref(contentPath).update({ changeCount, content })
+      .then(() => {
+        // console.log("Successful save", "document:", key, "changeCount:", changeCount);
+      })
+      .catch(() => {
+        user.setIsFirebaseConnected(false);
+        console.warn("Failed save!", "document:", key, "changeCount:", changeCount);
+      });
+  }, 2000, { trailing: true }), [contentPath, firebase, key, user]);
+
+  useEffect(() => {
+    console.log(`useDocumentSyncToFirebase installing listeners for ${type} document ${key} (${readOnly})`);
+    const visibilityListenerDisposer = !readOnly && (type === ProblemDocument)
+            ? reaction(() => document.visibility, visibility => {
+                console.log(`Updating document visibility for ${type} document ${key}:`, visibility);
+                firebase.ref(typedMetadata).update({ visibility });
+              })
+            : undefined;
+    const titleListenerDisposer = !readOnly && [PersonalDocument, LearningLogDocument].includes(type)
+            ? reaction(() => document.title, title => {
+                console.log(`Updating document title for ${type} document ${key}:`, title);
+                firebase.ref(typedMetadata).update({ title });
+              })
+            : undefined;
+    const propsListenerDisposer = !readOnly && [PersonalDocument, LearningLogDocument].includes(type)
+            ? onSnapshot(document.properties, properties => {
+                console.log(`Updating document properties for ${type} document ${key}:`, JSON.stringify(properties));
+                firebase.ref(typedMetadata).update({ properties });
+              })
+            : undefined;
+    const contentListenerDisposer = !readOnly && document.content && !isPublishedType(type)
+            ? onSnapshot(document.content, contentSnapshot => {
+                const changeCount = document.incChangeCount();
+                console.log(`Updating document content for ${type} document ${key}:`, changeCount);
+                contentSnapshot && throttledContentUpdate(changeCount, JSON.stringify(contentSnapshot));
+              })
+            : undefined;
+    return () => {
+      console.log(`useDocumentSyncToFirebase removing listeners for ${type} document ${key} (${readOnly})`);
+      visibilityListenerDisposer?.();
+      titleListenerDisposer?.();
+      propsListenerDisposer?.();
+      contentListenerDisposer?.();
+    };
+  }, [document, firebase, key, readOnly, throttledContentUpdate, type, typedMetadata, user]);
+}

--- a/src/hooks/use-sync-mst-node-to-firebase.ts
+++ b/src/hooks/use-sync-mst-node-to-firebase.ts
@@ -22,19 +22,19 @@ interface IProps<T> {
   transform?: (snapshot: SnapshotOut<T>) => any;
 }
 export function useSyncMstNodeToFirebase<T extends IAnyStateTreeNode>({
-  firebase, model, path, enabled = true, options, throttle = 1000, transform
+  firebase, model, path, enabled = true, options: clientOptions, throttle = 1000, transform
 }: IProps<T>) {
 
-  const finalOptions: Omit<UseMutationOptions<unknown, unknown, SnapshotOut<T>>, 'mutationFn'> = {
+  const options: Omit<UseMutationOptions<unknown, unknown, SnapshotOut<T>>, 'mutationFn'> = {
     // default is to retry with linear back-off to a maximum
     retry: true,
     retryDelay: (attempt) => Math.min(attempt * 5, 30),
     // but clients may override the defaults
-    ...options
+    ...clientOptions
   };
   const mutation = useMutation((snapshot: SnapshotOut<T>) => {
     return firebase.ref(path).update(transform?.(snapshot) ?? snapshot);
-  }, finalOptions);
+  }, options);
   const throttledMutate = useMemo(() => _throttle(mutation.mutate, throttle), [mutation.mutate, throttle]);
 
   useEffect(() => {

--- a/src/hooks/use-sync-mst-node-to-firebase.ts
+++ b/src/hooks/use-sync-mst-node-to-firebase.ts
@@ -1,0 +1,52 @@
+import { throttle as _throttle } from "lodash";
+import { IAnyStateTreeNode, onSnapshot, SnapshotOut } from "mobx-state-tree";
+import { useEffect, useMemo } from "react";
+import { useMutation, UseMutationOptions } from "react-query";
+import { Firebase } from "../lib/firebase";
+
+/*
+ * useSyncMstNodeToFirebase
+ *
+ * Custom hook for synchronizing a complex property (e.g. MST model or types.map) to firebase.
+ * Uses MST's onSnapshot handler to respond to changes and ReactQuery's useMutation hook to
+ * handle retries, etc. Updates are throttled to 1 sec by default but is client-configurable.
+ * Automatically retries on error with a linear back-off which maxes at 30 sec by default.
+ */
+interface IProps<T> {
+  firebase: Firebase;
+  model: T; // MST model or complex type (e.g. types.map())
+  path: string;
+  enabled?: boolean;
+  options?: Omit<UseMutationOptions<unknown, unknown, SnapshotOut<T>>, 'mutationFn'>;
+  throttle?: number;
+  transform?: (snapshot: SnapshotOut<T>) => any;
+}
+export function useSyncMstNodeToFirebase<T extends IAnyStateTreeNode>({
+  firebase, model, path, enabled = true, options, throttle = 1000, transform
+}: IProps<T>) {
+
+  const finalOptions: Omit<UseMutationOptions<unknown, unknown, SnapshotOut<T>>, 'mutationFn'> = {
+    // default is to retry with linear back-off to a maximum
+    retry: true,
+    retryDelay: (attempt) => Math.min(attempt * 5, 30),
+    // but clients may override the defaults
+    ...options
+  };
+  const mutation = useMutation((snapshot: SnapshotOut<T>) => {
+    return firebase.ref(path).update(transform?.(snapshot) ?? snapshot);
+  }, finalOptions);
+  const throttledMutate = useMemo(() => _throttle(mutation.mutate, throttle), [mutation.mutate, throttle]);
+
+  useEffect(() => {
+    const cleanup = enabled
+            ? onSnapshot<SnapshotOut<T>>(model, snapshot => {
+                // reset (e.g. stop retrying and restart) when value changes
+                mutation.isError && mutation.reset();
+                throttledMutate(snapshot);
+              })
+            : undefined;
+    return () => cleanup?.();
+  }, [enabled, model, mutation, throttledMutate]);
+
+  return mutation;
+}

--- a/src/hooks/use-sync-mst-prop-to-firebase.ts
+++ b/src/hooks/use-sync-mst-prop-to-firebase.ts
@@ -22,18 +22,18 @@ interface IProps<T> {
   throttle?: number;
 }
 export function useSyncMstPropToFirebase<T extends string | number | boolean | undefined>({
-  firebase, model, prop, path, enabled = true, options, throttle = 1000 }: IProps<T>) {
+  firebase, model, prop, path, enabled = true, options: clientOptions, throttle = 1000 }: IProps<T>) {
 
-  const finalOptions: Omit<UseMutationOptions<unknown, unknown, T>, 'mutationFn'> = {
+  const options: Omit<UseMutationOptions<unknown, unknown, T>, 'mutationFn'> = {
     // default is to retry with linear back-off to a maximum
     retry: true,
     retryDelay: (attempt) => Math.min(attempt * 5, 30),
     // but clients may override the defaults
-    ...options
+    ...clientOptions
   };
   const mutation = useMutation((value: T) => {
     return firebase.ref(path).update({ [prop]: value });
-  }, finalOptions);
+  }, options);
   const throttledMutate = useMemo(() => _throttle(mutation.mutate, throttle), [mutation.mutate, throttle]);
 
   useEffect(() => {

--- a/src/hooks/use-sync-mst-prop-to-firebase.ts
+++ b/src/hooks/use-sync-mst-prop-to-firebase.ts
@@ -1,0 +1,51 @@
+import { throttle as _throttle } from "lodash";
+import { reaction } from "mobx";
+import { IAnyStateTreeNode } from "mobx-state-tree";
+import { useEffect, useMemo } from "react";
+import { useMutation, UseMutationOptions } from "react-query";
+import { Firebase } from "../lib/firebase";
+
+/*
+ * useSyncMstPropToFirebase
+ *
+ * Custom hook for synchronizing a simple property of an MST model to firebase.
+ * Uses a MobX reaction and ReactQuery's useMutation hook to handle retries, etc.
+ * Automatically retries on error with a linear back-off which maxes at 30 sec by default.
+ */
+interface IProps<T> {
+  firebase: Firebase;
+  model: IAnyStateTreeNode;
+  prop: string;
+  path: string;
+  enabled?: boolean;
+  options?: Omit<UseMutationOptions<unknown, unknown, T>, 'mutationFn'>;
+  throttle?: number;
+}
+export function useSyncMstPropToFirebase<T extends string | number | boolean | undefined>({
+  firebase, model, prop, path, enabled = true, options, throttle = 1000 }: IProps<T>) {
+
+  const finalOptions: Omit<UseMutationOptions<unknown, unknown, T>, 'mutationFn'> = {
+    // default is to retry with linear back-off to a maximum
+    retry: true,
+    retryDelay: (attempt) => Math.min(attempt * 5, 30),
+    // but clients may override the defaults
+    ...options
+  };
+  const mutation = useMutation((value: T) => {
+    return firebase.ref(path).update({ [prop]: value });
+  }, finalOptions);
+  const throttledMutate = useMemo(() => _throttle(mutation.mutate, throttle), [mutation.mutate, throttle]);
+
+  useEffect(() => {
+    const cleanup = enabled
+            ? reaction(() => model[prop], value => {
+                // reset (e.g. stop retrying and restart) when value changes
+                mutation.isError && mutation.reset();
+                throttledMutate(value);
+              })
+            : undefined;
+    return () => cleanup?.();
+  }, [enabled, model, mutation, prop, throttledMutate]);
+
+  return mutation;
+}

--- a/src/lib/db-listeners/db-other-docs-listener.ts
+++ b/src/lib/db-listeners/db-other-docs-listener.ts
@@ -27,12 +27,12 @@ export class DBOtherDocumentsListener extends BaseListener {
     if (this.documentType === PersonalDocument) {
       this.publicationType = PersonalPublication;
       this.documentsPath = this.db.firebase.getUserPersonalDocPath(this.db.stores.user);
-      this.publicationsPath = this.db.firebase.getClassPersonalPublicationsPath(this.db.stores.user);
+      this.publicationsPath = this.db.firebase.getPersonalPublicationsPath(this.db.stores.user);
     }
     else {
       this.publicationType = LearningLogPublication;
       this.documentsPath = this.db.firebase.getLearningLogPath(this.db.stores.user);
-      this.publicationsPath = this.db.firebase.getClassPublicationsPath(this.db.stores.user);
+      this.publicationsPath = this.db.firebase.getLearningLogPublicationsPath(this.db.stores.user);
     }
 
     const documentsRef = this.db.firebase.ref(this.documentsPath);
@@ -71,7 +71,6 @@ export class DBOtherDocumentsListener extends BaseListener {
     this.debugLogSnapshot("#handleDocumentAdded", snapshot);
     if (dbDoc) {
       this.db.createDocumentModelFromOtherDocument(dbDoc, this.documentType)
-        .then(this.db.listeners.monitorOtherDocumentMetadata)
         .then(doc => {
           if (doc.uid === user.id) {
             !doc.getProperty("isDeleted") && documents.resolveRequiredDocumentPromise(doc);

--- a/src/lib/db-listeners/db-other-docs-listener.ts
+++ b/src/lib/db-listeners/db-other-docs-listener.ts
@@ -71,9 +71,7 @@ export class DBOtherDocumentsListener extends BaseListener {
     this.debugLogSnapshot("#handleDocumentAdded", snapshot);
     if (dbDoc) {
       this.db.createDocumentModelFromOtherDocument(dbDoc, this.documentType)
-        .then(this.documentType === PersonalDocument
-                ? this.db.listeners.monitorPersonalDocument
-                : this.db.listeners.monitorLearningLogDocument)
+        .then(this.db.listeners.monitorOtherDocumentMetadata)
         .then(doc => {
           if (doc.uid === user.id) {
             !doc.getProperty("isDeleted") && documents.resolveRequiredDocumentPromise(doc);

--- a/src/lib/db-listeners/db-problem-documents-listener.ts
+++ b/src/lib/db-listeners/db-problem-documents-listener.ts
@@ -103,7 +103,6 @@ export class DBProblemDocumentsListener extends BaseListener {
             if (isOwnDocument) {
               documents.resolveRequiredDocumentPromise(doc);
               syncStars(doc, this.db);
-              this.db.listeners.monitorDocumentVisibility(doc);
             }
           });
       }

--- a/src/lib/db-listeners/db-publications-listener.ts
+++ b/src/lib/db-listeners/db-publications-listener.ts
@@ -18,7 +18,7 @@ export class DBPublicationsListener extends BaseListener {
   public start() {
     return new Promise<void>((resolve, reject) => {
       const publicationsRef = this.publicationsRef = this.db.firebase.ref(
-        this.db.firebase.getPublicationsPath(this.db.stores.user)
+        this.db.firebase.getProblemPublicationsPath(this.db.stores.user)
       );
       // use once() so we are ensured that publications are set before we resolve
       this.debugLogHandler("#start", "adding", "once", publicationsRef);

--- a/src/lib/db-listeners/db-supports-listener.ts
+++ b/src/lib/db-listeners/db-supports-listener.ts
@@ -109,7 +109,7 @@ export class DBSupportsListener extends BaseListener {
               // teachers sync their support document properties to Firebase to track isDeleted
               const {audience, sectionTarget, key} = teacherSupport;
               const path = this.db.firebase.getSupportsPath(user, audience, sectionTarget, key);
-              this.db.listeners.syncDocumentProperties(document, "firebase", path);
+              this.db.listeners.syncSupportDocumentProperties(document, "firebase", path);
             }
           }
         }
@@ -160,7 +160,7 @@ export class DBSupportsListener extends BaseListener {
           const teacherSupport = support as TeacherSupportModelType;
           if (teacherSupport.uid === user.id) {
             // teachers sync their support document properties to Firebase to track isDeleted
-            this.db.listeners.syncDocumentProperties(document, "firestore");
+            this.db.listeners.syncSupportDocumentProperties(document, "firestore");
           }
         }
       }

--- a/src/lib/db-listeners/index.test.ts
+++ b/src/lib/db-listeners/index.test.ts
@@ -24,14 +24,14 @@ describe("DBListeners", () => {
     db.disconnect();
   });
 
-  it("warns when monitoring the same document multiple times", () => {
+  it("no longer warns when monitoring the same document multiple times", () => {
     const listeners = new DBListeners(db);
     expect(listeners).toBeDefined();
 
     listeners.monitorDocument(document, Monitor.Local);
     jestSpyConsole("warn", mockConsole => {
       listeners.monitorDocument(document, Monitor.Local);
-      expect(mockConsole).toHaveBeenCalledTimes(1);
+      expect(mockConsole).toHaveBeenCalledTimes(0);
     });
   });
 });

--- a/src/lib/db-listeners/index.ts
+++ b/src/lib/db-listeners/index.ts
@@ -1,7 +1,6 @@
 import firebase from "firebase/app";
-import { throttle } from "lodash";
-import { makeObservable, observable, reaction, runInAction } from "mobx";
-import { getSnapshot, IDisposer, onPatch, onSnapshot } from "mobx-state-tree";
+import { makeObservable, observable, runInAction } from "mobx";
+import { onSnapshot } from "mobx-state-tree";
 
 import { DB, Monitor } from "../db";
 import { DBLatestGroupIdListener } from "./db-latest-group-id-listener";
@@ -11,29 +10,17 @@ import { DBProblemDocumentsListener } from "./db-problem-documents-listener";
 import { DBPublicationsListener } from "./db-publications-listener";
 import { DocumentModelType } from "../../models/document/document";
 import { LearningLogDocument, PersonalDocument } from "../../models/document/document-types";
-import { DBDocument, DatabaseType } from "../db-types";
+import { DatabaseType, DBDocument } from "../db-types";
 import { DBSupportsListener } from "./db-supports-listener";
 import { DBCommentsListener } from "./db-comments-listener";
 import { DBStarsListener } from "./db-stars-listener";
 import { BaseListener } from "./base-listener";
 
-// only one of these should be present at a time; if it's our document
-// we sync local model => firebase, otherwise we sync firebase => local model
-interface IModelOrFirebaseListener {
-  // firebase path to which listeners can be attached
-  ref?: firebase.database.Reference;
-  // disposer for MST listener which responds to MST model changes
-  handlerDisposer?: IDisposer;
-}
-// keyed by strings like `document:${document.key}` for document contents
-export type ModelListeners = Record<string, IModelOrFirebaseListener | undefined>;
-
 export class DBListeners extends BaseListener {
   @observable public isListening = false;
   private db: DB;
 
-  private modelListeners: ModelListeners = {};
-  private documentVisibilityDisposers: Record<string, IDisposer> = {};
+  private firebaseUnlisteners: Record<string, () => void> = {};
 
   private latestGroupIdListener: DBLatestGroupIdListener;
   private groupsListener: DBGroupsListener;
@@ -84,8 +71,7 @@ export class DBListeners extends BaseListener {
   public stop() {
     runInAction(() => this.isListening = false);
 
-    this.stopModelListeners();
-    this.callDocumentVisibilityDisposers();
+    this.stopFirebaseListeners();
 
     this.starsListener.stop();
     this.commentsListener.stop();
@@ -98,64 +84,28 @@ export class DBListeners extends BaseListener {
     this.latestGroupIdListener.stop();
   }
 
-  public getOrCreateModelListener(uniqueKeyForModel: string) {
-    return this.modelListeners[uniqueKeyForModel] || (this.modelListeners[uniqueKeyForModel] = {});
+  private stopFirebaseListeners() {
+    Object.values(this.firebaseUnlisteners).forEach(unlistener => unlistener?.());
   }
-
-  // synchronize local problem document visibility (public/private) to firebase
-  public monitorDocumentVisibility = (document: DocumentModelType) => {
-    const { user } = this.db.stores;
-    const updateRef = this.db.firebase.ref(this.db.firebase.getProblemDocumentPath(user, document.key));
-    // use MobX reaction() to update document visibility in firebase whenever it changes locally
-    this.documentVisibilityDisposers[document.key] =
-      reaction(() => document.visibility, visibility => updateRef.update({ visibility }));
-  };
-
-  // synchronize local document metadata to firebase for personal documents and learning logs
-  public monitorOtherDocumentMetadata = (document: DocumentModelType) => {
-    const { user } = this.db.stores;
-    const { key, type } = document;
-
-    const listenerKey = type === PersonalDocument
-                          ? `personalDocument:${key}`
-                          : `learningLogWorkspace:${key}`;
-    const listener = this.getOrCreateModelListener(listenerKey);
-    listener.handlerDisposer?.();
-
-    const updatePath = type === PersonalDocument
-                        ? this.db.firebase.getUserPersonalDocPath(user, key)
-                        : this.db.firebase.getLearningLogPath(user, key);
-    const updateRef = this.db.firebase.ref(updatePath);
-
-    const titleHandlerDisposer = reaction(() => document.title, title => updateRef.update({ title }));
-    const propsHandlerDisposer = onSnapshot(document.properties, properties => updateRef.update({ properties }));
-    listener.handlerDisposer = () => {
-      titleHandlerDisposer();
-      propsHandlerDisposer();
-    };
-
-    return document;
-  };
 
   public monitorDocument = (document: DocumentModelType, monitor: Monitor) => {
     this.debugLog("#monitorDocument", `document: ${document.key} type: ${document.type} monitor: ${monitor}`);
     this.monitorDocumentRef(document, monitor);
-    this.monitorDocumentModel(document, monitor);
   };
 
   public unmonitorDocument = (document: DocumentModelType, monitor: Monitor) => {
     this.debugLog("#unmonitorDocument", `document: ${document.key} type: ${document.type} monitor: ${monitor}`);
     this.unmonitorDocumentRef(document);
-    this.unmonitorDocumentModel(document);
   };
 
   // sync local support document properties to firebase (teachers only)
-  public syncDocumentProperties = (document: DocumentModelType, dbType: DatabaseType, path?: string) => {
+  // TODO: move this to client-side hook as was done with other document monitoring
+  public syncSupportDocumentProperties = (document: DocumentModelType, dbType: DatabaseType, path?: string) => {
     const { user } = this.db.stores;
     const { key } = document;
 
     if (dbType === "firebase") {
-      const updatePath = path || this.db.firebase.getUserDocumentPath(user, key, document.uid);
+      const updatePath = path || this.db.firebase.getUserDocumentMetadataPath(user, key, document.uid);
       const updateRef = this.db.firebase.ref(updatePath);
       // synchronize document property changes to firebase
       onSnapshot(document.properties, properties => updateRef.update({ properties }));
@@ -177,86 +127,28 @@ export class DBListeners extends BaseListener {
       return;
     }
 
-    const docListener = this.db.listeners.getOrCreateModelListener(`document:${documentKey}`);
-    docListener.ref?.off("value");
-    docListener.ref = documentRef;
-
-    documentRef.on("value", snapshot => {
+    const snapshotHandler = (snapshot: firebase.database.DataSnapshot) => {
       if (snapshot?.val()) {
         const updatedDoc: DBDocument = snapshot.val();
         const updatedContent = this.db.parseDocumentContent(updatedDoc);
         const documentModel = documents.getDocument(documentKey);
         documentModel?.setContent(updatedContent || {});
       }
-    });
+    };
+
+    // remove any previous listener
+    this.firebaseUnlisteners[documentPath]?.();
+    // install the new listener
+    documentRef.on("value", snapshotHandler);
+    // register the cleanup function
+    this.firebaseUnlisteners[documentPath] = () => documentRef.off("value", snapshotHandler);
   };
 
   private unmonitorDocumentRef = (document: DocumentModelType) => {
-    const docListener = this.modelListeners[`document:${document.key}`];
-    docListener?.ref?.off("value");
-  };
-
-  private throttledSaveDocument = throttle((document: DocumentModelType) => {
     const { user } = this.db.stores;
-    const { key, changeCount, content } = document;
-    if (content) {
-      const updatePath = this.db.firebase.getUserDocumentPath(user, key, document.uid);
-      this.db.firebase.ref(updatePath)
-        .update({ changeCount, content: JSON.stringify(getSnapshot(content)) })
-        .then(() => {
-          // console.log("Successful save", "document:", key, "changeCount:", changeCount);
-        })
-        .catch(() => {
-          user.setIsFirebaseConnected(false);
-          console.warn("Failed save!", "document:", key, "changeCount:", changeCount);
-        });
-    }
-    // two-second throttle on the trailing edge so that with continued changes we save
-    // at least and at most once every two seconds
-  }, 2000, { trailing: true });
-
-  private monitorDocumentModel = (document: DocumentModelType, monitor: Monitor) => {
-    // skip if not monitoring local changes
-    if (monitor !== Monitor.Local) {
-      return;
-    }
-
-    const { type, key, content } = document;
-
-    const docListener = this.db.listeners.getOrCreateModelListener(`document:${key}`);
-    if (docListener.handlerDisposer) {
-      console.warn("Warning: monitorDocumentModel is monitoring a document that was already being monitored!",
-                    "type:", type, "key:", key, "contentId:", content?.contentId);
-      docListener.handlerDisposer();
-      docListener.handlerDisposer = undefined;
-    }
-
-    if (content) {
-      docListener.handlerDisposer = onPatch(content, (patch) => {
-        document.incChangeCount();
-        this.throttledSaveDocument(document);
-      });
-    }
+    const documentPath = this.db.firebase.getUserDocumentPath(user, document.key, document.uid);
+    this.firebaseUnlisteners[documentPath]?.();
+    if (this.firebaseUnlisteners[documentPath]) delete this.firebaseUnlisteners[documentPath];
   };
 
-  private unmonitorDocumentModel = (document: DocumentModelType) => {
-    // This is currently only called for unmonitoring remote documents as a result of group changes, but
-    // if it were to be called for a user's own document the result would be not saving the user's work.
-    const docListener = this.modelListeners[`document:${document.key}`];
-    docListener?.handlerDisposer?.();
-  };
-
-  private stopModelListeners() {
-    Object.keys(this.modelListeners).forEach((docKey) => {
-      const listeners = this.modelListeners[docKey];
-      listeners?.handlerDisposer?.();
-      listeners?.ref?.off();
-    });
-  }
-
-  private callDocumentVisibilityDisposers() {
-    Object.keys(this.documentVisibilityDisposers).forEach((documentKey) => {
-      this.documentVisibilityDisposers[documentKey]();
-    });
-  }
 }

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -223,17 +223,25 @@ describe("db", () => {
   it("logs errors when asked to open default documents without required document promises", async () => {
     await db.connect({appMode: "test", stores, dontStartListeners: true});
 
-    jestSpyConsole("error", async (mockConsole, mockRestore) => {
+    await jestSpyConsole("error", async spy => {
       await db.guaranteeOpenDefaultDocument(ProblemDocument);
-      expect(mockConsole).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    await jestSpyConsole("error", async spy => {
       await db.guaranteeOpenDefaultDocument(PersonalDocument);
-      expect(mockConsole).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    await jestSpyConsole("error", async spy => {
       await db.guaranteePlanningDocument([]);
-      expect(mockConsole).toHaveBeenCalledTimes(3);
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    await jestSpyConsole("error", async spy => {
       await db.guaranteeLearningLog();
-      expect(mockConsole).toHaveBeenCalledTimes(4);
-      mockRestore();
-    }, { asyncRestore: true });
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
   });
 
 });

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -441,7 +441,7 @@ export class DB {
     }
     return new Promise<{document: DBDocument, metadata: DBPublicationDocumentMetadata}>((resolve, reject) => {
       this.createDocument({ type: ProblemPublication, content }).then(({document, metadata}) => {
-        const publicationRef = this.firebase.ref(this.firebase.getPublicationsPath(user)).push();
+        const publicationRef = this.firebase.ref(this.firebase.getProblemPublicationsPath(user)).push();
         const userGroup = groups.groupForUser(user.id)!;
         const groupUserConnections: DBGroupUserConnections = userGroup && userGroup.users
           .filter(groupUser => groupUser.id !== user.id)
@@ -481,8 +481,8 @@ export class DB {
     return new Promise<{document: DBDocument, metadata: DBPublicationDocumentMetadata}>((resolve, reject) => {
       this.createDocument({ type: publicationType, content }).then(({document, metadata}) => {
         const publicationPath = publicationType === "personalPublication"
-                                ? this.firebase.getClassPersonalPublicationsPath(user)
-                                : this.firebase.getClassPublicationsPath(user);
+                                ? this.firebase.getPersonalPublicationsPath(user)
+                                : this.firebase.getLearningLogPublicationsPath(user);
         const publicationRef = this.firebase.ref(publicationPath).push();
         const publication: DBOtherPublication = {
           version: "1.0",

--- a/src/lib/debug.ts
+++ b/src/lib/debug.ts
@@ -9,3 +9,4 @@ const debugContains = (key: string) => debug.indexOf(key) !== -1;
 export const DEBUG_LISTENERS = debugContains("listeners");
 export const DEBUG_CANVAS = debugContains("canvas");
 export const DEBUG_LOGGER = debugContains("logger");
+export const DEBUG_SAVE = debugContains("save");

--- a/src/models/document/document.ts
+++ b/src/models/document/document.ts
@@ -220,7 +220,7 @@ export const DocumentModel = types
     },
 
     incChangeCount() {
-      self.changeCount += 1;
+      return ++self.changeCount;
     },
 
     setGroupId(groupId?: string) {


### PR DESCRIPTION
Update: after starting out with some minor refactoring described below I ended up moving on to a radical reimplementation of the code for synchronizing changes from MST models to firebase with the help of three custom hooks and using ReactQuery's useMutation hook under the hood. Rather than attempting to install MST listeners on all of a user's documents the first time we encounter them we instead just install listeners on the document the user is interacting with during the period of interaction. This should be much more robust and easier to reason about and if anything ever goes wrong the user can fix it be visiting a different document and then returning to the document of interest. The hardest part of the refactor was getting the tests to work, particularly the test of retrying on error and logging when additional debug logging is requested.

I have no particular reason to believe that any of these could explain incidences of documents not saving, but every time I look closely at our system of firebase/MST listeners/handlers I find things that are at least inelegant and sometimes downright squirrelly and that seem worth fixing. Maybe they contribute to the data loss problem in some way that I just don't comprehend. 🤷 🤞 

Changes include:
- Update document visibility in firebase when user changes document visibility (not whenever the document changes)
- Simplify/clean up listener/handler implementation; eliminate duplicate document monitoring
  - In a previous data loss investigation I considered the possibility that we could be replacing a working listener with a non-working one, and so I added a console warning when a listener replacement occurred. This turned out to generate a lot of false-positives because it seems that we were regularly installing a listener and then immediately replacing it with another one for no particular reason. This redundancy has been eliminated which cleans up the console log if nothing else.
- Eliminate MobX warnings about changing model outside of actions

@scytacki I just pushed an implementation of the latest approach we talked about: MST listeners are now installed/removed in a custom hook that is called from the component/document the user is working on, so we only monitor the user's current document. I still need to add some tests and do something about the `console.log`s ~~but I don't expect the implementation to change much at this point~~.

@scytacki Ok, I was wrong about not making further changes. Over the weekend I realized that I could refactor the code into a couple of reusable custom hooks that would make it easier to implement elsewhere in the code and I also adopted ReactQuery's `useMutation` hook to help with error-handling and make retries automatic. It's the same basic approach as before but the `useDocumentSyncToFirebase` hook has been refactored to use two reusable custom hooks.