### PR TITLE
Improve network status logging

### DIFF
--- a/src/components/network-status.test.tsx
+++ b/src/components/network-status.test.tsx
@@ -5,15 +5,6 @@ import { ModalProvider } from "react-modal-hook";
 import { NetworkStatus } from "./network-status";
 import { UserModel } from "../models/stores/user";
 
-// mock Logger calls
-const log = jest.fn();
-jest.mock("../lib/logger", () => ({
-  ...(jest.requireActual("../lib/logger") as any),
-  Logger: {
-    log: (...args: any) => log(...args)
-  }
-}));
-
 describe("NetworkStatus", () => {
 
   beforeEach(() => {
@@ -39,7 +30,7 @@ describe("NetworkStatus", () => {
 
     const { rerender } = render(jsx);
     expect(screen.getByTestId("network-status")).toBeInTheDocument();
-    expect(log).not.toHaveBeenCalled();
+    expect(user.networkStatusAlerts).toBe(0);
 
     act(() => {
       Modal.setAppElement(".app");
@@ -47,7 +38,7 @@ describe("NetworkStatus", () => {
     });
     rerender(jsx);
     expect(screen.getByTestId("network-status")).toBeInTheDocument();
-    expect(log).not.toHaveBeenCalled();
+    expect(user.networkStatusAlerts).toBe(0);
 
     act(() => {
       user.setIsFirebaseConnected(false);
@@ -55,7 +46,7 @@ describe("NetworkStatus", () => {
     });
     rerender(jsx);
     expect(screen.getByTestId("network-status")).toBeInTheDocument();
-    expect(log).toHaveBeenCalledTimes(1);
+    expect(user.networkStatusAlerts).toBe(1);
 
     act(() => {
       user.setIsFirebaseConnected(true);

--- a/src/components/network-status.tsx
+++ b/src/components/network-status.tsx
@@ -2,7 +2,6 @@ import classNames from "classnames";
 import firebase from "firebase/app";
 import { observer } from "mobx-react";
 import React, { useState } from "react";
-import { LogEventName, Logger } from "../lib/logger";
 import { UserModelType } from "../models/stores/user";
 import { useErrorAlert } from "./utilities/use-error-alert";
 import "./network-status.scss";
@@ -50,9 +49,8 @@ export const NetworkStatus = observer(({ user }: IProps) => {
         showAlert();
         setIsShowingAlert(true);
         setTimer(0);
-        // since the Logger currently has no retry this won't be logged on a general network
-        // disconnect but might be helpful to know if only Firebase disconnected
-        Logger.log(LogEventName.INTERNAL_NETWORK_STATUS_ALERTED);
+        // increment our internal occurrence count
+        user.incrementNetworkStatusAlertCount();
       }
     }, 1000 * alertDelay));
   }

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -5,7 +5,6 @@ import { UserModelType } from "../models/stores/user";
 import { DB } from "./db";
 import { escapeKey } from "./fire-utils";
 import { urlParams } from "../utilities/url-params";
-import { Logger, LogEventName } from "../lib/logger";
 
 // Set this during database testing in combination with the urlParam testMigration=true to
 // override the top-level Firebase key regardless of mode. For example, setting this to "authed-copy"
@@ -342,11 +341,6 @@ export class Firebase {
       const connected: boolean = snapshot.val();
       if (connected) {
         userRef.child("connectedTimestamp").set(firebase.database.ServerValue.TIMESTAMP);
-      }
-      else {
-        // since the Logger currently has no retry this won't be logged on a general network
-        // disconnect but might be helpful to know if only Firebase disconnected
-        Logger.log(LogEventName.INTERNAL_FIREBASE_DISCONNECTED);
       }
       this.db.stores.user.setIsFirebaseConnected(connected);
     }

--- a/src/lib/logger.test.ts
+++ b/src/lib/logger.test.ts
@@ -602,16 +602,18 @@ describe("authed logger", () => {
       workspace.toggleComparisonVisible();
     });
 
-    it("can log toggling of mode", (done) => {
+    it("can log toggling of mode with disconnects", (done) => {
       mockXhr.post(/.*/, (req, res) => {
         const request = JSON.parse(req.body());
 
         expect(request.event).toBe("VIEW_ENTER_FOUR_UP");
+        expect(request.disconnects).toBe("0/0/1");
 
         done();
         return res.status(201);
       });
 
+      stores.user.incrementNetworkStatusAlertCount();
       workspace.toggleMode();
     });
   });

--- a/src/models/stores/user.ts
+++ b/src/models/stores/user.ts
@@ -48,7 +48,13 @@ export const UserModel = types
   })
   .volatile(self => ({
     isFirebaseConnected: false,
-    isLoggingConnected: false
+    // number of firebase disconnects encountered during the current session
+    firebaseDisconnects: 0,
+    isLoggingConnected: false,
+    // number of logging disconnects encountered during the current session
+    loggingDisconnects: 0,
+    // number of network status alerts presented during the current session
+    networkStatusAlerts: 0
   }))
   .actions((self) => ({
     setName(name: string) {
@@ -97,10 +103,15 @@ export const UserModel = types
       }
     },
     setIsFirebaseConnected(connected: boolean) {
+      if (self.isFirebaseConnected && !connected) ++self.firebaseDisconnects;
       self.isFirebaseConnected = connected;
     },
     setIsLoggingConnected(connected: boolean) {
+      if (self.isLoggingConnected && !connected) ++self.loggingDisconnects;
       self.isLoggingConnected = connected;
+    },
+    incrementNetworkStatusAlertCount() {
+      ++self.networkStatusAlerts;
     },
     setLastSupportViewTimestamp(timestamp: number) {
       self.lastSupportViewTimestamp = timestamp;


### PR DESCRIPTION
Previously, if we detected a network failure we would log an `INTERNAL_FIREBASE_DISCONNECTED` event and then if we presented a network status alert we would log an `INTERNAL_NETWORK_STATUS_ALERTED` event. Unfortunately, these are both unreliable indicators. If the network goes down then log messages won't go out either, so the set of circumstances under which these events would actually be logged has never been entirely clear. Even when they did get sent, it was necessary to scan the log history for a given user to determine whether there had been any network interruptions in a given time period. For the purposes of determining whether network interruption could be a factor in a forensic data loss investigation (for instance), it would be most useful to know for a given user at a given point in time whether any network interruptions had occurred prior to that. Stated that way, it's clear that a better implementation would be to track the number of such disconnections internally and then include that information with each log message, which is what we do in this PR.

If there have been any disconnections (there's no need to bloat a log message if there haven't been any), we add a field of the following form to the log message:
```
  disconnects: `${firebaseDisconnects}/${loggingDisconnects}/${networkStatusAlerts}`
```
so an entry like `3/2/1` would mean that three firebase disconnects and two logging disconnects had been detected during the current session and the network status alert had been presented once. This is both more reliable and more useful than the previous approach to logging the same information.