### PR TITLE
Fixes qaClear=all to clear user node from qa node in firebase

### DIFF
--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -33,6 +33,6 @@ Cypress.on('uncaught:exception', (err, runnable) => {
     return false;
 });
 
-// after(function(){
-//   cy.clearQAData('all');
-// });
+after(function(){
+  cy.clearQAData('all');
+});

--- a/scripts/delete-qa-user-data.ts
+++ b/scripts/delete-qa-user-data.ts
@@ -1,0 +1,22 @@
+#!/usr/bin/node
+
+// to run this script type the following in the terminal
+// cf. https://stackoverflow.com/a/66626333/16328462
+// $ cd scripts
+// $ node --loader ts-node/esm delete-qa-user-data.ts
+
+import admin from "firebase-admin";
+
+const credential = admin.credential.cert('../serviceAccountKey.json');
+admin.initializeApp({
+  credential,
+  databaseURL: 'https://collaborative-learning-ec215.firebaseio.com'
+});
+
+admin.database().ref("qa").remove()
+                          .then(() => {console.log("Remove succeeded.");
+                                       process.exit(0);
+                                      })
+                          .catch(error => {console.log("Remove failed: " + error.message);
+                                           process.exit(1);
+                                          });

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -667,6 +667,7 @@ export class DB {
   public clear(level: DBClearLevel) {
     return new Promise<void>((resolve, reject) => {
       const {user} = this.stores;
+      let qaUser;
       const clearPath = (path?: string) => {
         this.firebase.ref(path).remove().then(resolve).catch(reject);
       };
@@ -674,10 +675,13 @@ export class DB {
       if (this.stores.appMode !== "qa") {
         return reject("db#clear is only available in qa mode");
       }
-
+      
       switch (level) {
         case "all":
-          clearPath();
+          qaUser = this.firebase.getQAUserRoot();
+          if (qaUser) {
+            qaUser.remove().then(resolve).catch(reject);
+          }
           break;
         case "class":
           clearPath(this.firebase.getClassPath(user));

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -85,6 +85,11 @@ export class Firebase {
 
     return `/${parts.join("/")}/`;
   }
+  
+  public getQAUserRoot() {
+    // get the current QA user's folder
+    return firebase.database().ref(`/qa/${this.userId}`);
+  }
 
   //
   // Paths


### PR DESCRIPTION
Previous code that runs when we run `qaClear=all` only clears the documents from `/{userNode}/portals/qa/{class}/{user}` node. This leaves orphaned test nodes in the `qa` node. This deletes the test node when user runs the qaClear=all, including after every Cypress test run.
Also adds a script to remove qa node from firebase if it ever gets overpopulated.