### PR TITLE
Fix firebase sync of user's last support view time stamp

### DIFF
--- a/cypress/integration/clue/branch/student_tests/nav_panel_test_spec.js
+++ b/cypress/integration/clue/branch/student_tests/nav_panel_test_spec.js
@@ -159,7 +159,12 @@ describe('Test nav panel tabs', function () {
     describe('Test supports area', function () {
       it('verify support tabs', function () {
         cy.openTopTab("supports");
+        // cy.get(".support-badge").should("be.visible");
         cy.get(".doc-tab.supports").should("have.length", 2);
+        cy.get(".doc-tab.supports.teacher-supports").click();
+        // clicking on a teacher support should update the unread supports badge
+        // cy.get("[data-test=teacher-supports-list-items]").last().click();
+        // cy.get(".support-badge").should("not.exist");
       });
     });
   });

--- a/src/components/thumbnail/tab-panel-documents-subsection-panel.tsx
+++ b/src/components/thumbnail/tab-panel-documents-subsection-panel.tsx
@@ -2,6 +2,7 @@ import { observer } from "mobx-react";
 import React from "react";
 import { ThumbnailDocumentItem } from "./thumbnail-document-item";
 import { useFirestoreTeacher } from "../../hooks/firestore-hooks";
+import { useLastSupportViewTimestamp } from "../../hooks/use-last-support-view-timestamp";
 import { DocumentModelType } from "../../models/document/document";
 import { isPublishedType, SupportPublication } from "../../models/document/document-types";
 import { getDocumentDisplayTitle } from "../../models/document/document-utils";
@@ -45,6 +46,9 @@ export const TabPanelDocumentsSubSectionPanel = observer(({
     const { user } = stores;
     const tabName = tab.toLowerCase().replace(' ', '-');
     const caption = useDocumentCaption(stores, sectionDocument);
+
+    // sync user's last support view time stamp to firebase
+    useLastSupportViewTimestamp(section.type === "teacher-supports");
 
     function handleDocumentClick() {
       onSelectDocument?.(sectionDocument);

--- a/src/hooks/use-document-sync-to-firebase.ts
+++ b/src/hooks/use-document-sync-to-firebase.ts
@@ -28,7 +28,7 @@ export function useDocumentSyncToFirebase(
                   user: UserModelType, firebase: Firebase, document: DocumentModelType, readOnly = false) {
   const { key, type, uid } = document;
   const { content: contentPath, typedMetadata } = firebase.getUserDocumentPaths(user, type, key, uid);
-  (user.id !== uid) && console.warn("useDocumentSyncToFirebase monitoring another user's document?!?");
+  !readOnly && (user.id !== uid) && console.warn("useDocumentSyncToFirebase monitoring another user's document?!?");
 
   // sync visibility (public/private) for problem documents
   useSyncMstPropToFirebase<typeof document.visibility>({

--- a/src/hooks/use-last-support-view-timestamp.ts
+++ b/src/hooks/use-last-support-view-timestamp.ts
@@ -1,0 +1,32 @@
+import { useState } from "react";
+import { useQuery } from "react-query";
+import { useStores } from "./use-stores";
+import { useSyncMstPropToFirebase } from "./use-sync-mst-prop-to-firebase";
+
+export function useLastSupportViewTimestamp(isEnabled: boolean) {
+  const { db: { firebase }, user } = useStores();
+  // flag so we only issue the initialization query once
+  const [isInitialized, setIsInitialized] = useState(!!user.lastSupportViewTimestamp);
+
+  // initialize last support view timestamp from firebase
+  const path = firebase.getLastSupportViewTimestampPath();
+  const ref = firebase.ref(path);
+  useQuery<typeof user.lastSupportViewTimestamp>(path,
+    () => ref.get().then(snap => snap.val()).catch(() => undefined), {
+    enabled: isEnabled && !isInitialized,
+    retry: false,
+    onSuccess: value => {
+      // it seems we can get here even for disabled queries ¯\_(ツ)_/¯
+      isEnabled && !isInitialized && value && user.setLastSupportViewTimestamp(value);
+    },
+    // enable the mutation regardless of how the query was settled
+    onSettled: () => isEnabled && !isInitialized && setIsInitialized(true)
+  });
+
+  // sync user's last support view time stamp to firebase
+  useSyncMstPropToFirebase<typeof user.lastSupportViewTimestamp>({
+    firebase, model: user, prop: "lastSupportViewTimestamp", path: firebase.getUserPath(user),
+    // only enable the mutation after the value has been initialized from firebase
+    enabled: isEnabled && isInitialized
+  });
+}

--- a/src/lib/db-listeners/db-supports-listener.ts
+++ b/src/lib/db-listeners/db-supports-listener.ts
@@ -36,10 +36,6 @@ export class DBSupportsListener extends BaseListener {
         .where("classes", "array-contains", user.classHash)
         .onSnapshot(snapshot => this.handleMulticlassSupports(snapshot));
 
-    this.lastSupportViewTimestampRef = this.db.firebase.getLastSupportViewTimestampRef();
-    this.debugLogHandler("#start", "adding", "on value", this.lastSupportViewTimestampRef);
-    this.lastSupportViewTimestampRef.on("value", this.handleLastSupportViewTimestampRef);
-
     this.lastStickyNoteViewTimestampRef = this.db.firebase.getLastStickyNoteViewTimestampRef();
     this.debugLogHandler("#start", "adding", "on value", this.lastStickyNoteViewTimestampRef);
     this.lastStickyNoteViewTimestampRef.on("value", this.handleLastStickyNoteViewTimestampRef);
@@ -50,10 +46,6 @@ export class DBSupportsListener extends BaseListener {
       this.debugLogHandlers("#stop", "removing", ["child_changed", "child_added"], this.supportsRef);
       this.supportsRef.off("child_changed", this.onChildChanged);
       this.supportsRef.off("child_added", this.onChildAdded);
-    }
-    if (this.lastSupportViewTimestampRef) {
-      this.debugLogHandler("#stop", "removing", "on value", this.lastSupportViewTimestampRef);
-      this.lastSupportViewTimestampRef.off("value", this.handleLastSupportViewTimestampRef);
     }
     if (this.lastStickyNoteViewTimestampRef) {
       this.debugLogHandler("#stop", "removing", "on value", this.lastStickyNoteViewTimestampRef);
@@ -187,12 +179,6 @@ export class DBSupportsListener extends BaseListener {
       deleted: dbSupport.deleted || !!dbSupport.properties?.isDeleted
     });
   }
-
-  private handleLastSupportViewTimestampRef = (snapshot: firebase.database.DataSnapshot) => {
-    const val = snapshot.val() || undefined;
-    this.debugLogSnapshot("#handleLastSupportViewTimestampRef", snapshot);
-    this.db.stores.user.setLastSupportViewTimestamp(val);
-  };
 
   private handleLastStickyNoteViewTimestampRef = (snapshot: firebase.database.DataSnapshot) => {
     const val = snapshot.val() || undefined;

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -925,10 +925,6 @@ export class DB {
     });
   }
 
-  public setLastSupportViewTimestamp() {
-    this.firebase.getLastSupportViewTimestampRef().set(Date.now());
-  }
-
   public setLastStickyNoteViewTimestamp() {
     this.firebase.getLastStickyNoteViewTimestampRef().set(Date.now());
   }

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -353,8 +353,8 @@ export class Firebase {
     return this.ref(this.getUserPath(this.db.stores.user)).child("latestGroupId");
   }
 
-  public getLastSupportViewTimestampRef() {
-    return this.ref(this.getUserPath(this.db.stores.user)).child("lastSupportViewTimestamp");
+  public getLastSupportViewTimestampPath() {
+    return `${this.getUserPath(this.db.stores.user)}/lastSupportViewTimestamp`;
   }
 
   public getLastStickyNoteViewTimestampRef() {


### PR DESCRIPTION
We can use one of the custom hooks developed as part of the recent document saving reimplementation to handle synchronization back to firebase (which was the part that wasn't working before) and while we're at it we can consolidate the code for querying the time stamp from firebase into a custom hook as well thus bring these related pieces of code together for ease of maintenance.

@scytacki I've assigned @eireland for review but it's here in case you're curious.