### PR TITLE
Fix resource view tile drag bug

### DIFF
--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -834,9 +834,10 @@ export const DocumentContentModel = types
     },
     userCopyTiles(tiles: IDragTileItem[], rowInfo: IDropRowInfo) {
       const dropRow = (rowInfo.rowDropIndex != null) ? self.getRowByIndex(rowInfo.rowDropIndex) : undefined;
-      const results = dropRow?.acceptsTileDrops
-                        ? self.copyTilesIntoExistingRow(tiles, rowInfo)
-                        : self.copyTilesIntoNewRows(tiles, rowInfo.rowInsertIndex);
+      const rowDropLocation = rowInfo.rowDropLocation;
+      const results = dropRow?.acceptsTileDrops && ((rowDropLocation === "left") || (rowDropLocation === "right"))
+                      ? self.copyTilesIntoExistingRow(tiles, rowInfo)
+                      : self.copyTilesIntoNewRows(tiles, rowInfo.rowInsertIndex);
       results.forEach((result, i) => {
         const newTile = result?.tileId && self.getTile(result.tileId);
         if (result && newTile) {

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -834,8 +834,7 @@ export const DocumentContentModel = types
     },
     userCopyTiles(tiles: IDragTileItem[], rowInfo: IDropRowInfo) {
       const dropRow = (rowInfo.rowDropIndex != null) ? self.getRowByIndex(rowInfo.rowDropIndex) : undefined;
-      const rowDropLocation = rowInfo.rowDropLocation;
-      const results = dropRow?.acceptsTileDrops && ((rowDropLocation === "left") || (rowDropLocation === "right"))
+      const results = dropRow?.acceptTileDrop(rowInfo)
                       ? self.copyTilesIntoExistingRow(tiles, rowInfo)
                       : self.copyTilesIntoNewRows(tiles, rowInfo.rowInsertIndex);
       results.forEach((result, i) => {

--- a/src/models/document/tile-row.ts
+++ b/src/models/document/tile-row.ts
@@ -1,5 +1,6 @@
 import { types, Instance, SnapshotIn, SnapshotOut } from "mobx-state-tree";
 import { ToolTileModelType } from "../tools/tool-tile";
+import { IDropRowInfo } from "../document/document-content";
 import { uniqueId } from "../../utilities/js-utils";
 
 export const TileLayoutModel = types
@@ -38,11 +39,12 @@ export const TileRowModel = types
     get isUserResizable() {
       return !self.isSectionHeader && self.tiles.some(tileRef => tileRef.isUserResizable);
     },
-    get acceptsTileDrops() {
-      return !self.isSectionHeader;
-    },
     get tileIds() {
       return self.tiles.map(tile => tile.tileId).join(", ");
+    },
+    acceptTileDrop(rowInfo: IDropRowInfo) {
+      const rowDropLocation = rowInfo.rowDropLocation;
+      return !self.isSectionHeader && ((rowDropLocation === "left") || (rowDropLocation === "right"));
     },
     getTileIdAtIndex(index: number) {
       const layout = (index >= 0) && (index < self.tiles.length) ? self.tiles[index] : undefined;


### PR DESCRIPTION
This PR fixes a bug that caused all tile drags from the resource area (the left) to the main workspace to place the tile in an existing row (side by side with another tile) instead of making a new row when the drag preview highlight indicates a new row will be made.

Test branch:
https://collaborative-learning.concord.org/branch/resource-drag/?demo

PT story:
https://www.pivotaltracker.com/story/show/181271011

![drag](https://user-images.githubusercontent.com/5126913/154181253-2b23c3d7-a71a-4491-8d0c-b277ea954fcc.gif)


