### PR TITLE
Fix multiplying personal documents for no-problem-document configurations

### DIFF
--- a/src/lib/db-listeners/db-other-docs-listener.ts
+++ b/src/lib/db-listeners/db-other-docs-listener.ts
@@ -39,7 +39,7 @@ export class DBOtherDocumentsListener extends BaseListener {
     this.documentsRef = documentsRef;
     documentsRef.once("value", snapshot => {
       if (size(snapshot.val()) === 0) {
-        this.db.stores.documents.resolveRequiredDocumentPromise(null, this.documentType);
+        this.db.stores.documents.resolveRequiredDocumentPromiseWithNull(this.documentType);
       }
       this.debugLogHandlers("#start", "adding", ["child_added", "child_changed", "child_removed"], documentsRef);
       documentsRef.on("child_added", this.handleDocumentAdded);

--- a/src/lib/db-listeners/db-problem-documents-listener.ts
+++ b/src/lib/db-listeners/db-problem-documents-listener.ts
@@ -61,8 +61,8 @@ export class DBProblemDocumentsListener extends BaseListener {
         this.handleOfferingUser(user);
       }
     });
-    // if the user doesn't exist in the DB, then there can't be any documents
-    !users?.[selfUserId] && documents.resolveAllRequiredDocumentPromisesWithNull();
+    // if the user doesn't exist in the offering, then there can't be any problem or planning documents
+    !users?.[selfUserId] && documents.resolveRequiredDocumentPromisesWithNull([ProblemDocument, PlanningDocument]);
   };
 
   private handleLoadOfferingUserAddedOrChanged = (eventType: string) => (snapshot: firebase.database.DataSnapshot) => {
@@ -80,7 +80,7 @@ export class DBProblemDocumentsListener extends BaseListener {
     const isOwnDocument = String(user.self.uid) === currentUser.id;
     // monitor problem documents
     if (isOwnDocument && (size(user.documents) === 0)) {
-      documents.resolveRequiredDocumentPromise(null, ProblemDocument);
+      documents.resolveRequiredDocumentPromiseWithNull(ProblemDocument);
     }
     forEach(user.documents, document => {
       if (!document?.documentKey || !document?.self?.uid) return;
@@ -110,7 +110,7 @@ export class DBProblemDocumentsListener extends BaseListener {
     });
     // monitor planning documents
     if (isOwnDocument && (size(user.planning) === 0)) {
-      documents.resolveRequiredDocumentPromise(null, PlanningDocument);
+      documents.resolveRequiredDocumentPromiseWithNull(PlanningDocument);
     }
     forEach(user.planning, document => {
       if (!document?.documentKey || !document?.self?.uid) return;

--- a/src/lib/db-listeners/index.test.ts
+++ b/src/lib/db-listeners/index.test.ts
@@ -26,14 +26,14 @@ describe("DBListeners", () => {
     db.disconnect();
   });
 
-  it("warns when monitoring the same document multiple times", () => {
+  it("no longer warns when monitoring the same document multiple times", () => {
     const listeners = new DBListeners(db);
     expect(listeners).toBeDefined();
 
     listeners.monitorDocument(document, Monitor.Local);
     jestSpyConsole("warn", mockConsole => {
       listeners.monitorDocument(document, Monitor.Local);
-      expect(mockConsole).toHaveBeenCalledTimes(1);
+      expect(mockConsole).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/lib/db-listeners/index.ts
+++ b/src/lib/db-listeners/index.ts
@@ -260,12 +260,10 @@ export class DBListeners extends BaseListener {
       return;
     }
 
-    const { type, key, content } = document;
+    const { key, content } = document;
 
     const docListener = this.db.listeners.getOrCreateModelListener(`document:${key}`);
     if (docListener.modelDisposer) {
-      console.warn("Warning: monitorDocumentModel is monitoring a document that was already being monitored!",
-                    "type:", type, "key:", key, "contentId:", content?.contentId);
       docListener.modelDisposer();
       docListener.modelDisposer = undefined;
     }

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -176,7 +176,7 @@ describe("db", () => {
       })
     }));
     stores.documents = createDocumentsModelWithRequiredDocuments([ProblemDocument, PlanningDocument]);
-    stores.documents.resolveAllRequiredDocumentPromisesWithNull();
+    stores.documents.resolveRequiredDocumentPromisesWithNull();
     await db.connect({appMode: "test", stores, dontStartListeners: true});
     expect((await db.guaranteeOpenDefaultDocument(ProblemDocument))?.type).toBe(ProblemDocument);
     expect(await stores.documents.requiredDocuments[ProblemDocument].promise).toEqual(newDocument);
@@ -206,7 +206,7 @@ describe("db", () => {
       })
     }));
     stores.documents = createDocumentsModelWithRequiredDocuments([ProblemDocument, PlanningDocument]);
-    stores.documents.resolveAllRequiredDocumentPromisesWithNull();
+    stores.documents.resolveRequiredDocumentPromisesWithNull();
     await db.connect({appMode: "test", stores, dontStartListeners: true});
     expect((await db.guaranteePlanningDocument([]))?.type).toBe(PlanningDocument);
     expect(await stores.documents.requiredDocuments[PlanningDocument].promise).toEqual(newDocument);

--- a/src/models/stores/documents.ts
+++ b/src/models/stores/documents.ts
@@ -197,18 +197,23 @@ export const DocumentsModel = types
       });
     };
 
-    const resolveRequiredDocumentPromise = (document: DocumentModelType | null, typeToNull?: string) => {
-      const type = document?.type || typeToNull;
-      if (type) {
-        const promise = self.requiredDocuments[type];
-        !promise.isResolved && promise.resolve(document);
-      }
+    const resolveRequiredDocumentPromise = (document: DocumentModelType) => {
+      const promise = self.requiredDocuments[document.type];
+      !promise?.isResolved && promise?.resolve(document);
     };
 
-    const resolveAllRequiredDocumentPromisesWithNull = () => {
-      forEach(self.requiredDocuments, (wrapper, type) => {
-        resolveRequiredDocumentPromise(null, type);
-      });
+    const resolveRequiredDocumentPromiseWithNull = (type: string) => {
+      const promise = self.requiredDocuments[type];
+      !promise.isResolved && promise.resolve(null);
+    };
+
+    const resolveRequiredDocumentPromisesWithNull = (requiredTypes?: string[]) => {
+      if (requiredTypes) {
+        requiredTypes.forEach(type => resolveRequiredDocumentPromiseWithNull(type));
+      }
+      else {
+        forEach(self.requiredDocuments, (p, type) => resolveRequiredDocumentPromiseWithNull(type));
+      }
     };
 
     const findDocumentOfTile = (tileId: string): DocumentModelType | null => {
@@ -226,7 +231,8 @@ export const DocumentsModel = types
       update,
       addRequiredDocumentPromises,
       resolveRequiredDocumentPromise,
-      resolveAllRequiredDocumentPromisesWithNull,
+      resolveRequiredDocumentPromiseWithNull,
+      resolveRequiredDocumentPromisesWithNull,
       findDocumentOfTile,
       setAppConfig
     };


### PR DESCRIPTION
The code was assuming that if the current user doesn't exist in the offering section of firebase that there couldn't be any documents. It is correct that such a user can't have any problem (or planning) documents, but such users can have personal documents and learning logs, so we shouldn't clear those promises in this case. This situation only arises in no-problem-document configurations, which have only been supported for a short time on the 2.2 branch and so real users should not have been affected.