### PR TITLE
Hides Group from header and publish icon when configured in unit config

### DIFF
--- a/cypress/integration/clue/branch/student_tests/canvas_test_spec.js
+++ b/cypress/integration/clue/branch/student_tests/canvas_test_spec.js
@@ -385,6 +385,20 @@ context('Test Canvas', function () {
   });
 });
 
+describe("Canvas unit config test", function () {
+  before(function () {
+    cy.visit("??appMode=qa&fakeClass=5&fakeUser=student:5&fakeOffering=5&problem=3.3&qaGroup=5&unit=example-no-group-share");
+    cy.waitForLoad();
+  });
+
+  it("verify group section in header is not visible when unit is configured to auto assign students to groups", function () {
+    cy.get(".app-header .right .group").should("not.exist");
+  });
+  it("verify publish button is not visible when publish is disabled", function () {
+    cy.get(".icon-button.icon-publish").should("not.exist");
+  });
+});
+
 after(function () {
   cy.clearQAData('all');
 });

--- a/s3_deploy.sh
+++ b/s3_deploy.sh
@@ -93,7 +93,7 @@ mv $SRC_DIR $DEPLOY_DEST
 
 # deploy the site contents
 echo Deploying "$BRANCH_OR_TAG" to "$S3_BUCKET:$S3_BUCKET_PREFIX$S3_DEPLOY_DIR"...
-JAVA_TOOL_OPTIONS="-Xms1g -Xmx4g" s3_website push --site _site
+JAVA_TOOL_OPTIONS="-Xms2g -Xmx5g" s3_website push --site _site
 
 # explicit CloudFront invalidation to workaround s3_website gem invalidation bug
 # with origin path (https://github.com/laurilehmijoki/s3_website/issues/207).

--- a/src/clue/app-config.json
+++ b/src/clue/app-config.json
@@ -236,6 +236,9 @@
     "example": {
       "content": "curriculum/example-curriculum/example-curriculum.json"
     },
+    "example-no-group-share": {
+      "content": "curriculum/example-curriculum/example-no-group-share.json"
+    },
     "faw": {
       "content": "curriculum/filling-and-wrapping/filling-and-wrapping.json"
     },

--- a/src/clue/app-config.json
+++ b/src/clue/app-config.json
@@ -238,7 +238,7 @@
     },
     "example-no-group-share": {
       "content": "curriculum/example-curriculum/example-no-group-share.json"
-    }
+    },
     "example-show-nav-panel": {
       "content": "curriculum/example-curriculum/example-show-nav-panel.json"
     },

--- a/src/clue/components/clue-app-content.tsx
+++ b/src/clue/components/clue-app-content.tsx
@@ -20,7 +20,7 @@ export class ClueAppContentComponent extends BaseComponent<IProps> {
   }
 
   public render() {
-    const { user, ui } = this.stores;
+    const { appConfig: {autoAssignStudentsToIndividualGroups}, user, ui } = this.stores;
     const isTeacher = user && user.isTeacher;
 
     const panels: IPanelGroupSpec = [{
@@ -46,9 +46,9 @@ export class ClueAppContentComponent extends BaseComponent<IProps> {
       <div className="clue-app-content">
         <ClueAppHeaderComponent panels={panels}
                             current={teacherPanelKey} onPanelChange={this.handlePanelChange}
-                            showGroup={true} />
+                            showGroup={!autoAssignStudentsToIndividualGroups} />
         {currentPanelContent}
-        <DialogComponent dialog={this.stores.ui.dialog} />
+        <DialogComponent dialog={ui.dialog} />
       </div>
     );
   }

--- a/src/clue/components/clue-app-content.tsx
+++ b/src/clue/components/clue-app-content.tsx
@@ -46,6 +46,8 @@ export class ClueAppContentComponent extends BaseComponent<IProps> {
       <div className="clue-app-content">
         <ClueAppHeaderComponent panels={panels}
                             current={teacherPanelKey} onPanelChange={this.handlePanelChange}
+                            // This assumes that when we auto-assign students to groups,
+                            // we don't want to see the Groups in the header
                             showGroup={!autoAssignStudentsToIndividualGroups} />
         {currentPanelContent}
         <DialogComponent dialog={ui.dialog} />

--- a/src/components/document/document.tsx
+++ b/src/components/document/document.tsx
@@ -254,6 +254,8 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
   private showPublishButton(document: DocumentModelType) {
     const { appConfig } = this.stores;
     if (!appConfig.disablePublish) return true;
+    // When we disable publishing by setting disablePublish=true,
+    // we set showPublishButton to false to hide the Publish button
     if (document.type === "planning" || appConfig.disablePublish === true) return false;
     return appConfig.disablePublish
             .findIndex(spec => {

--- a/src/components/document/document.tsx
+++ b/src/components/document/document.tsx
@@ -254,7 +254,7 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
   private showPublishButton(document: DocumentModelType) {
     const { appConfig } = this.stores;
     if (!appConfig.disablePublish) return true;
-    if (document.type === "planning") return false;
+    if (document.type === "planning" || appConfig.disablePublish === true) return false;
     return appConfig.disablePublish
             .findIndex(spec => {
               return (document.type === spec.documentType) &&

--- a/src/models/stores/unit-configuration.ts
+++ b/src/models/stores/unit-configuration.ts
@@ -65,7 +65,7 @@ export interface UnitConfiguration extends ProblemConfiguration {
   // terminology for referencing documents
   documentLabels: Record<string, SnapshotIn<typeof DocumentLabelModel>>;
   // disables publishing documents of particular types or with particular properties
-  disablePublish: Array<SnapshotIn<typeof DocumentSpecModel>>;
+  disablePublish: Array<SnapshotIn<typeof DocumentSpecModel>> | boolean;
   // configures naming of copied documents
   copyPreferOriginTitle: boolean;
   // enable/disable dragging of tiles

--- a/src/public/curriculum/example-curriculum/example-no-group-share.json
+++ b/src/public/curriculum/example-curriculum/example-no-group-share.json
@@ -1,0 +1,136 @@
+{
+  "code": "example-no-group-share",
+  "abbrevTitle": "EX",
+  "title": "Example Curriculum",
+  "subtitle": "Demonstrating Curriculum Configuration",
+  "config": {
+    "placeholderText": "This is where users can type text",
+    "autoAssignStudentsToIndividualGroups": true,
+    "disablePublish": true,
+    "defaultDocumentType": "personal",
+    "settings": {
+      "table": { "numFormat": ".2~f" }
+    },
+    "navTabs": {
+      "showNavPanel": false,
+      "lazyLoadTabContents": true,
+      "tabSpecs": [
+        {
+          "tab": "my-work",
+          "label": "My Work",
+          "sections": [
+            {
+              "title": "Workspaces",
+              "type": "personal-documents",
+              "dataTestHeader": "my-work-section-workspaces",
+              "dataTestItem": "my-work-list-items",
+              "documentTypes": ["personal"],
+              "properties": ["!isDeleted"],
+              "showStars": ["student", "teacher"],
+              "addDocument": true
+            }
+          ]
+        }
+      ]
+    },
+    "toolbar": [
+      {
+        "id": "Text",
+        "title": "Text",
+        "isTileTool": true
+      },
+      {
+        "id": "Table",
+        "title": "Table",
+        "isTileTool": true
+      },
+      {
+        "id": "Drawing",
+        "title": "Drawing",
+        "isTileTool": true
+      },
+      {
+        "id": "delete",
+        "title": "Delete",
+        "iconId": "icon-delete-tool",
+        "isTileTool": false
+      }
+    ],
+    "stamps": []
+  },
+  "sections": {
+    "first": {
+      "initials": "FI",
+      "title": "First Section",
+      "placeholder": "Work area for\nFirst Section"
+    },
+    "second": {
+      "initials": "SE",
+      "title": "Second Section",
+      "placeholder": "Second Section Placeholder"
+    },
+    "third": {
+      "initials": "TH",
+      "title": "Third Section",
+      "placeholder": "Third Section content goes here"
+    }
+  },
+  "planningDocument": {
+    "enable": "teacher",
+    "default": true,
+    "sectionInfo": {
+      "plan": {
+        "initials": "PL",
+        "title": "Plan",
+        "placeholder": "Plan the work; work the plan"
+      }
+    },
+    "sections": [{ "type": "plan" }]
+  },
+  "investigations": [
+    {
+      "description": "Investigation 1",
+      "ordinal": 1,
+      "title": "Example Investigation 1",
+      "problems": [
+        {
+          "description": "Problem 1.1",
+          "ordinal": 1,
+          "title": "1.1 Unit Toolbar Configuration",
+          "subtitle": "Text, Table, Drawing",
+          "sections": [
+            { "type": "first", "content": { "tiles": [] }, "supports": [] },
+            { "type": "second", "content": { "tiles": [] }, "supports": [] },
+            { "type": "third", "content": { "tiles": [] }, "supports": [] }
+          ]
+        },
+        {
+          "description": "Problem 1.2",
+          "ordinal": 2,
+          "title": "1.2 Problem Toolbar Configuration",
+          "subtitle": "Text only",
+          "config": {
+            "toolbar": [
+              {
+                "id": "Text",
+                "title": "Text",
+                "isTileTool": true
+              },
+              {
+                "id": "delete",
+                "title": "Delete",
+                "iconId": "icon-delete-tool",
+                "isTileTool": false
+              }
+            ]
+          },
+          "sections": [
+            { "type": "first", "content": { "tiles": [] }, "supports": [] },
+            { "type": "second", "content": { "tiles": [] }, "supports": [] },
+            { "type": "third", "content": { "tiles": [] }, "supports": [] }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Hides Group from header when unit config auto assigns student to groups.
Hides publish icon from workspace when unit config disables publishing Adds example unit that hides publish and group
Adds cypress to verify visibility of publish icon and group in header