### PR TITLE
Catch exceptions when parsing expressions in table [#181360571]

### DIFF
--- a/src/components/tools/table-tool/use-expressions-dialog.tsx
+++ b/src/components/tools/table-tool/use-expressions-dialog.tsx
@@ -69,7 +69,7 @@ export const useExpressionsDialog = ({ metadata, dataSet, onSubmit }: IProps): I
     buttons: [
       { label: "Clear", onClick: handleClear },
       { label: "Cancel" },
-      { label: "OK", isDefault: true, onClick: handleSubmit }
+      { label: "OK", isDefault: true, isDisabled: !!errorMessage, onClick: handleSubmit }
     ]
   }, [currYAttrId, errorMessage, currentExpression]);
   blurModalRef.current = blurModal;

--- a/src/models/tools/table/table-content.test.ts
+++ b/src/models/tools/table/table-content.test.ts
@@ -149,7 +149,7 @@ describe("TableContent", () => {
     expect(changeRowValues(change2, 2)).toEqual([3, "y-3"]);
   });
 
-  it.only("can import multi-column authored data with invalid expressions", () => {
+  it("can import multi-column authored data with invalid expressions", () => {
     const kTableTitle = "Table Title";
     const importData: TableContentTableImport = {
             type: "Table",


### PR DESCRIPTION
Identified via rollbar error encountered by an in-class user of 2.1.3, although I think we've seen it locally as well without ever having logged it in PT.