### PR TITLE
Removes tile drag in text tiles when dragged from the center.

### DIFF
--- a/src/components/tools/tool-tile.tsx
+++ b/src/components/tools/tool-tile.tsx
@@ -362,9 +362,9 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
     }
     // tile dragging can be disabled for individual tile contents,
     // which only allows those tiles to be dragged by their drag handle
-    if (target && target.querySelector(".disable-tile-content-drag")) {
+    if (target?.closest(".disable-tile-content-drag")) {
       const eltTarget = document.elementFromPoint(e.clientX, e.clientY);
-      if (!eltTarget || !eltTarget.closest(".tool-tile-drag-handle")) {
+      if (!eltTarget?.closest(".tool-tile-drag-handle")) {
         e.preventDefault();
         return;
       }

--- a/src/models/tools/text/text-registration.ts
+++ b/src/models/tools/text/text-registration.ts
@@ -8,7 +8,7 @@ registerToolContentInfo({
   modelClass: TextContentModel,
   defaultContent: defaultTextContent,
   Component: TextToolComponent,
-  toolTileClass: "text-tool-tile",
+  toolTileClass: "text-tool-tile disable-tile-content-drag",
   tileHandlesOwnSelection: true,
   Icon: TextToolIcon
 });


### PR DESCRIPTION
 Users can still drag text tile from the tile drag handle. Users can also select text for formatting, deleting, etc. This does not allow user to drag text to reposition.