### PR TITLE
Each document is its own MST tree

### DIFF
--- a/src/hooks/use-document-sync-to-firebase.test.ts
+++ b/src/hooks/use-document-sync-to-firebase.test.ts
@@ -553,4 +553,16 @@ describe("useDocumentSyncToFirebase hook", () => {
       await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(2));
     });
   });
+
+  it("sets window.currentDocument when DOCUMENT_DEBUG is true", () => {
+    libDebug.DEBUG_DOCUMENT = true;
+    const { user, firebase, document } = specArgs(ProblemDocument, "xyz");
+    renderHook(() => useDocumentSyncToFirebase(user, firebase, document));
+    expect((window as any).currentDocument).toBe(document);
+
+    (window as any).currentDocument = undefined;
+    libDebug.DEBUG_DOCUMENT = false;
+    renderHook(() => useDocumentSyncToFirebase(user, firebase, document));
+    expect((window as any).currentDocument).toBeUndefined();
+  });
 });

--- a/src/hooks/use-document-sync-to-firebase.ts
+++ b/src/hooks/use-document-sync-to-firebase.ts
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useSyncMstNodeToFirebase } from "./use-sync-mst-node-to-firebase";
 import { useSyncMstPropToFirebase } from "./use-sync-mst-prop-to-firebase";
-import { DEBUG_SAVE } from "../lib/debug";
+import { DEBUG_DOCUMENT, DEBUG_SAVE } from "../lib/debug";
 import { Firebase } from "../lib/firebase";
 import { DocumentModelType } from "../models/document/document";
 import {
@@ -29,6 +29,10 @@ export function useDocumentSyncToFirebase(
   const { key, type, uid } = document;
   const { content: contentPath, typedMetadata } = firebase.getUserDocumentPaths(user, type, key, uid);
   !readOnly && (user.id !== uid) && console.warn("useDocumentSyncToFirebase monitoring another user's document?!?");
+
+  if (DEBUG_DOCUMENT) {
+    (window as any).currentDocument = document;
+  }
 
   // sync visibility (public/private) for problem documents
   useSyncMstPropToFirebase<typeof document.visibility>({

--- a/src/lib/debug.ts
+++ b/src/lib/debug.ts
@@ -10,3 +10,4 @@ export const DEBUG_LISTENERS = debugContains("listeners");
 export const DEBUG_CANVAS = debugContains("canvas");
 export const DEBUG_LOGGER = debugContains("logger");
 export const DEBUG_SAVE = debugContains("save");
+export const DEBUG_DOCUMENT = debugContains("document");

--- a/src/models/stores/documents.ts
+++ b/src/models/stores/documents.ts
@@ -1,7 +1,8 @@
 import { forEach } from "lodash";
 import { types } from "mobx-state-tree";
+import { observable } from "mobx";
 import { AppConfigModelType } from "./app-config-model";
-import { DocumentModel, DocumentModelType } from "../document/document";
+import { DocumentModelType } from "../document/document";
 import {
   DocumentType, LearningLogDocument, LearningLogPublication, OtherDocumentType, OtherPublicationType,
   PersonalDocument, PersonalPublication, PlanningDocument, ProblemDocument, ProblemPublication
@@ -31,11 +32,11 @@ export interface IRequiredDocumentPromise {
 
 export const DocumentsModel = types
   .model("Documents", {
-    all: types.array(DocumentModel)
   })
   .volatile(self => ({
     appConfig: undefined as AppConfigModelType | undefined,
-    requiredDocuments: {} as Record<string, IRequiredDocumentPromise>
+    requiredDocuments: {} as Record<string, IRequiredDocumentPromise>,
+    all: observable<DocumentModelType>([])
   }))
   .views(self => ({
     getDocument(documentKey: string) {


### PR DESCRIPTION
This will help when adding middleware that is specific to a document.
With this change, each documents middleware can record just the changes in that document.

Additionally if references are used and a document is copied, these references will still be vaild.
When there is just one tree all ids have to unique to the tree so a document and its copy will have conflicts unless the ids are changed during the copy.

This change was extracted out of a much larger PR so it is easier to review and get merged.