### PR TITLE
simplify qaClear, add better logging

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -4,5 +4,9 @@
   "viewportWidth": 1400,
   "viewportHeight": 1000,
   "projectId": "3pbqac",
-  "chromeWebSecurity": false
+  "chromeWebSecurity": false,
+  "retries": {
+    "runMode": 2,
+    "openMode": 0
+  }
 }

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -40,6 +40,9 @@ function getEnvVariablesStartingWith (prefix) {
 // Also, it lets users overwrite any config value using environment variable.
 // Cypress lets you do it by default, but only for its own, predefined configuration.
 module.exports = (on, config) => {
+    // Add better reporting output
+    require('cypress-terminal-report/src/installLogsPrinter')(on);
+
     // Why do we need to read process.env again? Cypress preprocess environment variables. If it finds one with name
     // that matches one of the Cypress config options, it will update the config and remove this entry from environment
     // variables set. It would work fine unless the same option is specified in our own environments.json or user-config.json.

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -85,22 +85,6 @@ Cypress.Commands.add("clearQAData", (data)=>{ //clears data from Firebase (curre
         // The log shows the assertion passing and then shows it failing right after
         // using contains fixes this problem.
         cy.contains('span', 'QA Cleared: OK', {timeout: 60000});
-
-        // According to the firebase documentation and our implementation we shouldn't be showing
-        // QA Cleared: OK until the removal of the node in firebase is complete.
-        // However there are some randomly failing tests which could be explained if this
-        // removal on the firebase server happens later and triggers an event after the next
-        // visit command.
-        // So to be safe there is a wait here to give firebase more of a chance to process.
-        // cy.wait(1000);
-
-        // I've seen at least one failure where the QA Cleared, showed up right away. But then 
-        // then two other requests happened to firebase. One apparently resolved, the other never did.
-        // Then the wait finished, and the un-resolved request was canceled. The resolved request 
-        // turned red in cypress, but I don't know why.
-        // This was followed by the visit request that was checking for the .version class.
-        // The new visit finished loading but the page was blank.
-        // I think there might be a console log message at this point, but those aren't recorded.
     }
 });
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -92,7 +92,7 @@ Cypress.Commands.add("clearQAData", (data)=>{ //clears data from Firebase (curre
         // removal on the firebase server happens later and triggers an event after the next
         // visit command.
         // So to be safe there is a wait here to give firebase more of a chance to process.
-        cy.wait(1000);
+        // cy.wait(1000);
 
         // I've seen at least one failure where the QA Cleared, showed up right away. But then 
         // then two other requests happened to firebase. One apparently resolved, the other never did.

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -21,6 +21,13 @@ import './commands';
 // Alternatively you can use CommonJS syntax:
 // require('./commands'
 
+// From the install directions: https://github.com/archfz/cypress-terminal-report 
+// It recommends:
+//   require('cypress-terminal-report/src/installLogsCollector')();
+// This is switched to an import.
+import installLogsCollector from "cypress-terminal-report/src/installLogsCollector";
+installLogsCollector();
+
 Cypress.config('defaultCommandTimeout', 10000);
 
 // before(function(){ //Can't run this because full tests will not run due to website switching

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,6 +89,7 @@
         "cypress": "^9.5.0",
         "cypress-commands": "2.0.1",
         "cypress-file-upload": "^5.0.8",
+        "cypress-terminal-report": "^3.5.0",
         "enquirer": "^2.3.6",
         "eslint": "^8.9.0",
         "eslint-config-react": "^1.1.7",
@@ -8725,6 +8726,104 @@
       },
       "peerDependencies": {
         "cypress": ">3.0.0"
+      }
+    },
+    "node_modules/cypress-terminal-report": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/cypress-terminal-report/-/cypress-terminal-report-3.5.0.tgz",
+      "integrity": "sha512-dfjsOwVm5cGXdxwsMTx/C/zi66n9+rfflRKyZEhDXyqZPC6ffYV9pmr7kazVJuwJ2ws2jt8La3zVrJMeRKnCFQ==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^3.0.0",
+        "fs-extra": "^9.0.1",
+        "methods": "^1.1.2",
+        "semver": "^7.3.5",
+        "tv4": "^1.3.0"
+      },
+      "peerDependencies": {
+        "cypress": ">=4.10.0"
+      }
+    },
+    "node_modules/cypress-terminal-report/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cypress-terminal-report/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cypress-terminal-report/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/cypress-terminal-report/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/cypress-terminal-report/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cypress-terminal-report/node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cypress-terminal-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/cypress/node_modules/@types/node": {
@@ -20704,6 +20803,15 @@
         "node": "*"
       }
     },
+    "node_modules/tv4": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tv4/-/tv4-1.3.0.tgz",
+      "integrity": "sha1-0CDIRvrdUMhVq7JeuuzGj8EPeWM=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
@@ -29008,6 +29116,79 @@
       "integrity": "sha512-+8VzNabRk3zG6x8f8BWArF/xA/W0VK4IZNx3MV0jFWrJS/qKn8eHfa5nU73P9fOQAgwHFJx7zjg4lwOnljMO8g==",
       "dev": true,
       "requires": {}
+    },
+    "cypress-terminal-report": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/cypress-terminal-report/-/cypress-terminal-report-3.5.0.tgz",
+      "integrity": "sha512-dfjsOwVm5cGXdxwsMTx/C/zi66n9+rfflRKyZEhDXyqZPC6ffYV9pmr7kazVJuwJ2ws2jt8La3zVrJMeRKnCFQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^3.0.0",
+        "fs-extra": "^9.0.1",
+        "methods": "^1.1.2",
+        "semver": "^7.3.5",
+        "tv4": "^1.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "d3-color": {
       "version": "3.0.1",
@@ -38033,6 +38214,12 @@
       "requires": {
         "safe-buffer": "^5.0.1"
       }
+    },
+    "tv4": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tv4/-/tv4-1.3.0.tgz",
+      "integrity": "sha1-0CDIRvrdUMhVq7JeuuzGj8EPeWM=",
+      "dev": true
     },
     "tweetnacl": {
       "version": "0.14.5",

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "cypress": "^9.5.0",
     "cypress-commands": "2.0.1",
     "cypress-file-upload": "^5.0.8",
+    "cypress-terminal-report": "^3.5.0",
     "enquirer": "^2.3.6",
     "eslint": "^8.9.0",
     "eslint-config-react": "^1.1.7",

--- a/src/components/qa-clear.tsx
+++ b/src/components/qa-clear.tsx
@@ -1,0 +1,18 @@
+import React, { useEffect, useState } from "react";
+import { clearFirebaseAnonQAUser } from "../lib/db-clear";
+
+export const QAClear: React.FC = () => {
+  const [qaCleared, setQACleared] = useState(false);
+
+  useEffect(() => {
+    clearFirebaseAnonQAUser()
+      .then(() => setQACleared(true));
+  }, []);
+
+  return (
+    <span className="qa-clear">
+      {qaCleared ? `QA Cleared: OK` : "QA Clearing..."}
+    </span>
+  );
+};
+

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,6 +21,7 @@ const kEnableLivelinessChecking = false;
 
 import "./components/utilities/blueprint";
 import "./index.sass";
+import { QAClear } from "./components/qa-clear";
 
 const appConfig = AppConfigModel.create(appConfigSnapshot);
 
@@ -38,6 +39,14 @@ const initializeApp = async () => {
 
   const isPreviewing = !!(urlParams.domain && urlParams.domain_uid && !urlParams.token);
   const stores = createStores({ appMode, appVersion, appConfig, user, showDemoCreator, demoName, isPreviewing });
+
+  if (appMode === "qa" && urlParams.qaClear === "all") {
+    ReactDOM.render(
+      <QAClear />,
+      document.getElementById("app")
+    );
+    return;
+  }
 
   await setUnitAndProblem(stores, unitId, problemOrdinal);
 

--- a/src/lib/db-clear.ts
+++ b/src/lib/db-clear.ts
@@ -1,0 +1,53 @@
+import firebase from "firebase";
+
+// The problem with this approach is that it can't be used to clear a logged in
+// user's data. So we should check if QA is ever used to store a logged in user's
+// data.
+export const clearFirebaseAnonQAUser = async () => {
+  // FIXME: figure out how to share this with the db
+  // check for already being initialized for tests
+  if (firebase.apps.length === 0) {
+    const key = atob("QUl6YVN5QVV6T2JMblZESURYYTB4ZUxmSVpLV3BiLTJZSWpYSXBJ");
+    firebase.initializeApp({
+      apiKey: key,
+      authDomain: "collaborative-learning-ec215.firebaseapp.com",
+      databaseURL: "https://collaborative-learning-ec215.firebaseio.com",
+      projectId: "collaborative-learning-ec215",
+      storageBucket: "collaborative-learning-ec215.appspot.com",
+      messagingSenderId: "112537088884",
+      appId: "1:112537088884:web:c51b1b8432fff36faff221",
+      measurementId: "G-XP472LRY18"
+    });
+  }
+
+  let firebaseUser: firebase.User | undefined;
+
+  // FIXME: we might want to call the return value (authStateUnsubscribe) if there is 
+  // an error
+  firebase.auth().onAuthStateChanged((_firebaseUser) => {
+    if (_firebaseUser) {
+      firebaseUser = _firebaseUser;
+    }
+  });
+
+  await firebase.auth().signInAnonymously();
+
+  if (!firebaseUser) {
+    throw new Error("Firebase User not set after sign in");
+  }
+
+  // FIXME: This path is defined in db.ts we should find a way to share that here 
+  // so if the location changes we don't have to update it in 2 places. 
+  // Note that the firebaseUser will be picked from the local indexedDb in the browser
+  // this indexedDb is persistent across cypress test runs. 
+  const qaUser = firebase.database().ref(`/qa/${firebaseUser.uid}`);
+  if (qaUser) {
+    await qaUser.remove();
+
+    // If we made a firestore connection we should do the following things. So the 
+    // firestore connections are cleaned up.
+    // await firebase.firestore().terminate();
+    // // This will probably blow away the anonymous user id stored in the indexedDb
+    // await firebase.firestore().clearPersistence();
+  }
+};

--- a/src/lib/db-clear.ts
+++ b/src/lib/db-clear.ts
@@ -1,29 +1,20 @@
 import firebase from "firebase";
+import { firebaseConfig } from "./firebase-config";
 
 // The problem with this approach is that it can't be used to clear a logged in
 // user's data. So we should check if QA is ever used to store a logged in user's
 // data.
 export const clearFirebaseAnonQAUser = async () => {
-  // FIXME: figure out how to share this with the db
+
   // check for already being initialized for tests
   if (firebase.apps.length === 0) {
-    const key = atob("QUl6YVN5QVV6T2JMblZESURYYTB4ZUxmSVpLV3BiLTJZSWpYSXBJ");
-    firebase.initializeApp({
-      apiKey: key,
-      authDomain: "collaborative-learning-ec215.firebaseapp.com",
-      databaseURL: "https://collaborative-learning-ec215.firebaseio.com",
-      projectId: "collaborative-learning-ec215",
-      storageBucket: "collaborative-learning-ec215.appspot.com",
-      messagingSenderId: "112537088884",
-      appId: "1:112537088884:web:c51b1b8432fff36faff221",
-      measurementId: "G-XP472LRY18"
-    });
+    firebase.initializeApp(firebaseConfig());
   }
 
   let firebaseUser: firebase.User | undefined;
 
-  // FIXME: we might want to call the return value (authStateUnsubscribe) if there is 
-  // an error
+  // We are ignoring the unsubscribe method returned because this function is only
+  // used in a one-off way. 
   firebase.auth().onAuthStateChanged((_firebaseUser) => {
     if (_firebaseUser) {
       firebaseUser = _firebaseUser;
@@ -36,18 +27,15 @@ export const clearFirebaseAnonQAUser = async () => {
     throw new Error("Firebase User not set after sign in");
   }
 
-  // FIXME: This path is defined in db.ts we should find a way to share that here 
-  // so if the location changes we don't have to update it in 2 places. 
-  // Note that the firebaseUser will be picked from the local indexedDb in the browser
-  // this indexedDb is persistent across cypress test runs. 
+  // Notes: 
+  // 1. This path is defined in firebase.ts, there isn't an easy way to use the
+  //    Firebase class without causing additional Firestore connections So it is
+  //    duplicated here.
+  // 2. Firebase looks up the user from the browser's indexedDb. In cypress this
+  //    is not cleared between test runs. So the same anonymous user will be
+  //    used each time.
   const qaUser = firebase.database().ref(`/qa/${firebaseUser.uid}`);
   if (qaUser) {
     await qaUser.remove();
-
-    // If we made a firestore connection we should do the following things. So the 
-    // firestore connections are cleaned up.
-    // await firebase.firestore().terminate();
-    // // This will probably blow away the anonymous user id stored in the indexedDb
-    // await firebase.firestore().clearPersistence();
   }
 };

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -34,6 +34,7 @@ import { IStores } from "../models/stores/stores";
 import { TeacherSupportModelType, SectionTarget, AudienceModelType } from "../models/stores/supports";
 import { safeJsonParse } from "../utilities/js-utils";
 import { urlParams } from "../utilities/url-params";
+import { firebaseConfig } from "./firebase-config";
 
 export enum Monitor {
   None = "None",
@@ -117,17 +118,7 @@ export class DB {
 
       // check for already being initialized for tests
       if (firebase.apps.length === 0) {
-        const key = atob("QUl6YVN5QVV6T2JMblZESURYYTB4ZUxmSVpLV3BiLTJZSWpYSXBJ");
-        firebase.initializeApp({
-          apiKey: key,
-          authDomain: "collaborative-learning-ec215.firebaseapp.com",
-          databaseURL: "https://collaborative-learning-ec215.firebaseio.com",
-          projectId: "collaborative-learning-ec215",
-          storageBucket: "collaborative-learning-ec215.appspot.com",
-          messagingSenderId: "112537088884",
-          appId: "1:112537088884:web:c51b1b8432fff36faff221",
-          measurementId: "G-XP472LRY18"
-        });
+        firebase.initializeApp(firebaseConfig());
       }
 
       if (urlParams.firebase) {
@@ -680,7 +671,6 @@ export class DB {
   public clear(level: DBClearLevel) {
     return new Promise<void>((resolve, reject) => {
       const {user} = this.stores;
-      let qaUser;
       const clearPath = (path?: string) => {
         this.firebase.ref(path).remove().then(resolve).catch(reject);
       };
@@ -689,13 +679,11 @@ export class DB {
         return reject("db#clear is only available in qa mode");
       }
       
+      if (level === "all") {
+        return reject("clearing 'all' is handled by clearFirebaseAnonQAUser");
+      }
+
       switch (level) {
-        case "all":
-          qaUser = this.firebase.getQAUserRoot();
-          if (qaUser) {
-            qaUser.remove().then(resolve).catch(reject);
-          }
-          break;
         case "class":
           clearPath(this.firebase.getClassPath(user));
           break;

--- a/src/lib/firebase-config.ts
+++ b/src/lib/firebase-config.ts
@@ -1,0 +1,13 @@
+export function firebaseConfig() {
+  const key = atob("QUl6YVN5QVV6T2JMblZESURYYTB4ZUxmSVpLV3BiLTJZSWpYSXBJ");
+  return {
+    apiKey: key,
+    authDomain: "collaborative-learning-ec215.firebaseapp.com",
+    databaseURL: "https://collaborative-learning-ec215.firebaseio.com",
+    projectId: "collaborative-learning-ec215",
+    storageBucket: "collaborative-learning-ec215.appspot.com",
+    messagingSenderId: "112537088884",
+    appId: "1:112537088884:web:c51b1b8432fff36faff221",
+    measurementId: "G-XP472LRY18"
+  };
+}

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -88,11 +88,6 @@ export class Firebase {
     return `/${parts.join("/")}/`;
   }
   
-  public getQAUserRoot() {
-    // get the current QA user's folder
-    return firebase.database().ref(`/qa/${this.userId}`);
-  }
-
   //
   // Paths
   //


### PR DESCRIPTION
This PR has 3 changes:
- improvements to qaClear
- added console and command logging to cypress
- turned on "retries" in the cypress config

## qaClear
The previous approach to qaClear was using the DB and Firebase classes to clear the current anonymous users data from firebase. 

This approach caused several firestore requests to happen including the creation of local documents that would never be used. The change here is to extract this clearing logic out to its own file independent of the DB and Firesbase classes so we can be sure nothing else happens besides clearing the user.

To support this:
- the firebase configuration was extracted from db.ts.
- a new component was added to run the qa clear and display the results
- the index.tsx was updated to render this qa clear and do nothing afterward

## Cypress console and command logging

The https://github.com/archfz/cypress-terminal-report extension was added. This should record the console logs and errrors when a test fails. It should also record the commands (like what you see in the cypress tests runner) when a test fails.