### PR TITLE
remove cypress global before and after hooks

### DIFF
--- a/cypress/integration/clue/branch/student_tests/canvas_test_spec.js
+++ b/cypress/integration/clue/branch/student_tests/canvas_test_spec.js
@@ -398,7 +398,3 @@ describe("Canvas unit config test", function () {
     cy.get(".icon-button.icon-publish").should("not.exist");
   });
 });
-
-after(function () {
-  cy.clearQAData('all');
-});

--- a/cypress/integration/clue/branch/student_tests/graph_table_integraton_test_spec.js
+++ b/cypress/integration/clue/branch/student_tests/graph_table_integraton_test_spec.js
@@ -8,202 +8,205 @@ const clueCanvas = new ClueCanvas;
 const graphToolTile = new GraphToolTile;
 const tableToolTile = new TableToolTile;
 
-before(function () {
-  const queryParams = "?appMode=qa&fakeClass=5&fakeUser=student:5&problem=2.3&qaGroup=5"; //using different problem bec. 2.1 disables graph table integration
-  cy.clearQAData('all');
-
-  cy.visit(queryParams);
-  cy.waitForLoad();
-  clueCanvas.getInvestigationCanvasTitle().text().as('investigationTitle');
-});
-
-context('Tests for graph and table integration', function () {
-  const x = ['3', '7', '6', '0'];
-  const y = ['2.5', '5', '1', '0'];
+context('Graph Table Integration', function () {
   before(function () {
-    clueCanvas.addTile('table');
-    cy.get(".primary-workspace").within((workspace) => {
-      tableToolTile.getTableCell().eq(1).click().type(x[0] +'{enter}');
-      tableToolTile.getTableCell().eq(2).click();
-      tableToolTile.getTableCell().eq(2).type(y[0] +'{enter}');
-      tableToolTile.getTableCell().eq(5).click();
-      tableToolTile.getTableCell().eq(5).type(x[1] + '{enter}');
-      tableToolTile.getTableCell().eq(6).click();
-      cy.wait(500);
-      tableToolTile.getTableCell().eq(6).type(y[1] + '{enter}');
-      tableToolTile.getTableCell().eq(9).click();
-      tableToolTile.getTableCell().eq(9).type(x[2] + '{enter}');
-      tableToolTile.getTableCell().eq(10).click();
-      tableToolTile.getTableCell().eq(10).type(y[2] + '{enter}');
-      tableToolTile.getTableCell().eq(13).click();
-      tableToolTile.getTableCell().eq(13).type(x[3] + '{enter}');
-      tableToolTile.getTableCell().eq(14).click();
-      tableToolTile.getTableCell().eq(14).type(y[3] + '{enter}');
-      tableToolTile.getTableCell().eq(17).click();
-    });
-    clueCanvas.addTile('geometry');
-    clueCanvas.deleteTile('text');
+    const queryParams = "?appMode=qa&fakeClass=5&fakeUser=student:5&problem=2.3&qaGroup=5"; //using different problem bec. 2.1 disables graph table integration
+    cy.clearQAData('all');
+  
+    cy.visit(queryParams);
+    cy.waitForLoad();
+    clueCanvas.getInvestigationCanvasTitle().text().as('investigationTitle');
   });
-  describe('Link graph dialog', () => {
-    it('verify correct graph names appear in selection list', function () {
-      tableToolTile.getTableTile().click();
-      cy.get('.primary-workspace .link-geometry-button').click();
+  
+  context('Tests for graph and table integration', function () {
+    const x = ['3', '7', '6', '0'];
+    const y = ['2.5', '5', '1', '0'];
+    before(function () {
+      clueCanvas.addTile('table');
+      cy.get(".primary-workspace").within((workspace) => {
+        tableToolTile.getTableCell().eq(1).click().type(x[0] +'{enter}');
+        tableToolTile.getTableCell().eq(2).click();
+        tableToolTile.getTableCell().eq(2).type(y[0] +'{enter}');
+        tableToolTile.getTableCell().eq(5).click();
+        tableToolTile.getTableCell().eq(5).type(x[1] + '{enter}');
+        tableToolTile.getTableCell().eq(6).click();
+        cy.wait(500);
+        tableToolTile.getTableCell().eq(6).type(y[1] + '{enter}');
+        tableToolTile.getTableCell().eq(9).click();
+        tableToolTile.getTableCell().eq(9).type(x[2] + '{enter}');
+        tableToolTile.getTableCell().eq(10).click();
+        tableToolTile.getTableCell().eq(10).type(y[2] + '{enter}');
+        tableToolTile.getTableCell().eq(13).click();
+        tableToolTile.getTableCell().eq(13).type(x[3] + '{enter}');
+        tableToolTile.getTableCell().eq(14).click();
+        tableToolTile.getTableCell().eq(14).type(y[3] + '{enter}');
+        tableToolTile.getTableCell().eq(17).click();
+      });
+      clueCanvas.addTile('geometry');
+      clueCanvas.deleteTile('text');
+    });
+    describe('Link graph dialog', () => {
+      it('verify correct graph names appear in selection list', function () {
+        tableToolTile.getTableTile().click();
+        cy.get('.primary-workspace .link-geometry-button').click();
+        cy.wait(2000);
+        // cy.get('[data-test=link-graph-select]').select('Second One');
+        cy.get('[data-test=link-graph-select]').select('Graph 1');
+      });
+      after(function () {
+        cy.get('.ReactModalPortal button').contains('Cancel').click();
+      });
+    });
+    describe("connect and disconnect table and graph after coordinates have been added", function () {
+      it('verify link icon appears when table and graph are connected', function () {
+        cy.get(clueCanvas.linkIconEl()).should('not.exist');
+        cy.linkTableToGraph('Table 1', "Graph 1");
+        tableToolTile.getTableTile().scrollIntoView();
+        graphToolTile.getGraphTile().siblings(clueCanvas.linkIconEl()).should('exist');
+        // verifies that values exported from .scss file were successfully imported
+        graphToolTile.getGraphTile().siblings(clueCanvas.linkIconEl()).children('svg').attribute('data-indicator-width').should('exist');
+        graphToolTile.getGraph().should('have.class', 'is-linked');
+      });
+      it('verify points added has p1 label in table and graph', function () {
+        tableToolTile.getIndexNumberToggle().click();
+        tableToolTile.getTableIndexColumnCell().first().should('contain', '1');
+        graphToolTile.getGraphPointLabel().contains('p1').should('exist');
+      });
+      it('verify table can be linked to two graphs', function () {
+        clueCanvas.addTile('geometry');
+        cy.linkTableToGraph('Table 1', "Graph 2");
+        graphToolTile.getGraphTile().siblings(clueCanvas.linkIconEl()).should('have.length', 2);
+      });
+      it('verify unlink of graph and table', function () {
+        cy.unlinkTableToGraph('Table 1', "Graph 2");
+        graphToolTile.getGraphTile().siblings(clueCanvas.linkIconEl()).should('have.length', 1);
+        graphToolTile.getGraph().last().should('not.have.class', 'is-linked');
+      });
+      it('verify point no longer has p1 in table and graph', function () {
+        graphToolTile.getGraphPointLabel().contains('p1').should('have.length', 1);
+      });
+      after(function () {
+        clueCanvas.deleteTile('graph');
+      });
+    });
+    describe('test creating a polygon', function () {
+      it('will create a polygon', function () {
+        graphToolTile.getGraphPoint().last().click({ force: true }).dblclick({ force: true });
+        graphToolTile.getGraphPolygon().should('exist');
+      });
+      it('will add angle to a table point', function () {
+        tableToolTile.getTableIndexColumnCell().contains('3').click({ force: true });
+        graphToolTile.getGraphPoint().first().click({ force: true }).dblclick({ force: true });
+        graphToolTile.showAngle();
+        graphToolTile.getAngleAdornment().should('exist');
+  
+      });
+      it('will move a point by changing coordinates on the table', function () {
+        let new_y = '8';
+        tableToolTile.getTableTile().click();
+        cy.get(".primary-workspace").within((workspace) => {
+          tableToolTile.getTableCell().eq(10).click();
+          tableToolTile.getTableCell().eq(10).type(new_y + '{enter}');
+        });
+        graphToolTile.getGraphPointCoordinates(2).should('contain', '(6, ' + new_y + ')');
+      });
+      it('will delete a point in the table', function () {
+        let point = 0; //the 4th point in the graph
+        tableToolTile.getTableTile().click();
+        tableToolTile.removeRow(point);
+  
+        //verifies p1 no longer exist in table and graph
+        tableToolTile.getTableRow().should('have.length', 4);
+        tableToolTile.getTableIndexColumnCell().eq(2).should('contain', '3');
+        tableToolTile.getTableIndexColumnCell().eq(3).should('not.contain', 'p4');
+        graphToolTile.getGraphPointLabel().contains('p4').should('not.exist');
+        graphToolTile.getGraphPointID(point)
+          .then((id) => {
+            id = '#'.concat(id);
+            cy.get(id).then(($el) => {
+              expect($el).to.not.be.visible;
+            });
+          });
+        //verifies angle adornment no longer exists
+        // graphToolTile.getAngleAdornment().should('not.exist'); TODO
+      });
+    });
+    describe('text axes changes', function () {
+      it('will change the name of the x-axis in the table', function () {
+        tableToolTile.getTableTile().click();
+        cy.get(".primary-workspace").within((workspace) => {
+          tableToolTile.renameColumn('x', 'mars');
+        });
+        graphToolTile.getGraphAxisLabelId('x')
+          .then((id) => {
+            id = '#'.concat(id);
+            cy.get(id).then(($el) => {
+              expect($el.text()).to.contain('mars');
+            });
+          });
+      });
+      it('will change the name of the y-axis in the table', function () {
+        tableToolTile.getTableTile().click();
+        cy.get(".primary-workspace").within((workspace) => {
+          tableToolTile.renameColumn('y', 'venus');
+        });
+        graphToolTile.getGraphAxisLabelId('y')
+          .then((id) => {
+            id = '#'.concat(id);
+            cy.get(id).then(($el) => {
+              expect($el.text()).to.contain('venus');
+            });
+          });
+      });
+    });
+    describe('normal graph interactions', function () {
+      it('will add a polygon directly onto the graph', function () {
+        graphToolTile.getGraphTile().click();
+        graphToolTile.addPointToGraph(10, 10); //not sure why this isn't appearing
+        graphToolTile.addPointToGraph(10, 10);
+        graphToolTile.addPointToGraph(15, 10);
+        graphToolTile.addPointToGraph(10, 5);
+        graphToolTile.getGraphPoint().last().click({ force: true }).click({ force: true });
+      });
+      it('will add an angle to a point created from a table', function () {
+        graphToolTile.getGraphPolygon().last().click({force: true});
+        graphToolTile.showAngle();
+        graphToolTile.getAngleAdornment().should('exist');
+      });
+    });
+    describe.skip('test non-numeric entries in table', function () {
+      it('will enter non-numeric number in the table', function () {
+        tableToolTile.getTableCellWithColIndex(2, 6).scrollIntoView();
+        tableToolTile.getTableCellWithColIndex(2, 6).click({force: true}).type(9);
+        tableToolTile.getTableCell().eq(3).should('contain', x[1]);
+      });
+    });
+  
+  });
+  context('Save and restore keeps the connection between table and graph', function () {
+    before(function () {
+      let title = '2.3 Mouthing Off and Nosing Around';
+      canvas.createNewExtraDocumentFromFileMenu("empty",'my-work');
       cy.wait(2000);
-      // cy.get('[data-test=link-graph-select]').select('Second One');
-      cy.get('[data-test=link-graph-select]').select('Graph 1');
+      cy.openResourceTabs();
+      cy.openTopTab('my-work');
+      cy.openDocumentWithTitle('my-work', 'workspaces', title);
+      cy.closeTabs();
     });
-    after(function () {
-      cy.get('.ReactModalPortal button').contains('Cancel').click();
-    });
-  });
-  describe("connect and disconnect table and graph after coordinates have been added", function () {
-    it('verify link icon appears when table and graph are connected', function () {
-      cy.get(clueCanvas.linkIconEl()).should('not.exist');
-      cy.linkTableToGraph('Table 1', "Graph 1");
-      tableToolTile.getTableTile().scrollIntoView();
-      graphToolTile.getGraphTile().siblings(clueCanvas.linkIconEl()).should('exist');
-      // verifies that values exported from .scss file were successfully imported
-      graphToolTile.getGraphTile().siblings(clueCanvas.linkIconEl()).children('svg').attribute('data-indicator-width').should('exist');
-      graphToolTile.getGraph().should('have.class', 'is-linked');
-    });
-    it('verify points added has p1 label in table and graph', function () {
-      tableToolTile.getIndexNumberToggle().click();
-      tableToolTile.getTableIndexColumnCell().first().should('contain', '1');
+    it('verify connection of table and graph on restored canvas', function () {
       graphToolTile.getGraphPointLabel().contains('p1').should('exist');
     });
-    it('verify table can be linked to two graphs', function () {
-      clueCanvas.addTile('geometry');
-      cy.linkTableToGraph('Table 1', "Graph 2");
-      graphToolTile.getGraphTile().siblings(clueCanvas.linkIconEl()).should('have.length', 2);
-    });
-    it('verify unlink of graph and table', function () {
-      cy.unlinkTableToGraph('Table 1', "Graph 2");
-      graphToolTile.getGraphTile().siblings(clueCanvas.linkIconEl()).should('have.length', 1);
-      graphToolTile.getGraph().last().should('not.have.class', 'is-linked');
-    });
-    it('verify point no longer has p1 in table and graph', function () {
-      graphToolTile.getGraphPointLabel().contains('p1').should('have.length', 1);
-    });
-    after(function () {
-      clueCanvas.deleteTile('graph');
-    });
   });
-  describe('test creating a polygon', function () {
-    it('will create a polygon', function () {
-      graphToolTile.getGraphPoint().last().click({ force: true }).dblclick({ force: true });
-      graphToolTile.getGraphPolygon().should('exist');
+  context('Delete connected table', function () {
+    it('will delete connected table', function () {
+      clueCanvas.deleteTile('table');
+      graphToolTile.getGraphPointLabel().contains('p1').should('not.exist');
     });
-    it('will add angle to a table point', function () {
-      tableToolTile.getTableIndexColumnCell().contains('3').click({ force: true });
-      graphToolTile.getGraphPoint().first().click({ force: true }).dblclick({ force: true });
-      graphToolTile.showAngle();
-      graphToolTile.getAngleAdornment().should('exist');
-
-    });
-    it('will move a point by changing coordinates on the table', function () {
-      let new_y = '8';
-      tableToolTile.getTableTile().click();
-      cy.get(".primary-workspace").within((workspace) => {
-        tableToolTile.getTableCell().eq(10).click();
-        tableToolTile.getTableCell().eq(10).type(new_y + '{enter}');
-      });
-      graphToolTile.getGraphPointCoordinates(2).should('contain', '(6, ' + new_y + ')');
-    });
-    it('will delete a point in the table', function () {
-      let point = 0; //the 4th point in the graph
-      tableToolTile.getTableTile().click();
-      tableToolTile.removeRow(point);
-
-      //verifies p1 no longer exist in table and graph
-      tableToolTile.getTableRow().should('have.length', 4);
-      tableToolTile.getTableIndexColumnCell().eq(2).should('contain', '3');
-      tableToolTile.getTableIndexColumnCell().eq(3).should('not.contain', 'p4');
-      graphToolTile.getGraphPointLabel().contains('p4').should('not.exist');
-      graphToolTile.getGraphPointID(point)
-        .then((id) => {
-          id = '#'.concat(id);
-          cy.get(id).then(($el) => {
-            expect($el).to.not.be.visible;
-          });
-        });
-      //verifies angle adornment no longer exists
-      // graphToolTile.getAngleAdornment().should('not.exist'); TODO
-    });
-  });
-  describe('text axes changes', function () {
-    it('will change the name of the x-axis in the table', function () {
-      tableToolTile.getTableTile().click();
-      cy.get(".primary-workspace").within((workspace) => {
-        tableToolTile.renameColumn('x', 'mars');
-      });
-      graphToolTile.getGraphAxisLabelId('x')
-        .then((id) => {
-          id = '#'.concat(id);
-          cy.get(id).then(($el) => {
-            expect($el.text()).to.contain('mars');
-          });
-        });
-    });
-    it('will change the name of the y-axis in the table', function () {
-      tableToolTile.getTableTile().click();
-      cy.get(".primary-workspace").within((workspace) => {
-        tableToolTile.renameColumn('y', 'venus');
-      });
-      graphToolTile.getGraphAxisLabelId('y')
-        .then((id) => {
-          id = '#'.concat(id);
-          cy.get(id).then(($el) => {
-            expect($el.text()).to.contain('venus');
-          });
-        });
-    });
-  });
-  describe('normal graph interactions', function () {
-    it('will add a polygon directly onto the graph', function () {
+    it('will verify graph is still functional after connected table is deleted', function () {
       graphToolTile.getGraphTile().click();
-      graphToolTile.addPointToGraph(10, 10); //not sure why this isn't appearing
-      graphToolTile.addPointToGraph(10, 10);
-      graphToolTile.addPointToGraph(15, 10);
-      graphToolTile.addPointToGraph(10, 5);
-      graphToolTile.getGraphPoint().last().click({ force: true }).click({ force: true });
-    });
-    it('will add an angle to a point created from a table', function () {
-      graphToolTile.getGraphPolygon().last().click({force: true});
-      graphToolTile.showAngle();
-      graphToolTile.getAngleAdornment().should('exist');
+      graphToolTile.addPointToGraph(2, 6);
+      graphToolTile.getGraphPoint().should('exist').and('have.length', 3);
     });
   });
-  describe.skip('test non-numeric entries in table', function () {
-    it('will enter non-numeric number in the table', function () {
-      tableToolTile.getTableCellWithColIndex(2, 6).scrollIntoView();
-      tableToolTile.getTableCellWithColIndex(2, 6).click({force: true}).type(9);
-      tableToolTile.getTableCell().eq(3).should('contain', x[1]);
-    });
-  });
+});
 
-});
-context('Save and restore keeps the connection between table and graph', function () {
-  before(function () {
-    let title = '2.3 Mouthing Off and Nosing Around';
-    canvas.createNewExtraDocumentFromFileMenu("empty",'my-work');
-    cy.wait(2000);
-    cy.openResourceTabs();
-    cy.openTopTab('my-work');
-    cy.openDocumentWithTitle('my-work', 'workspaces', title);
-    cy.closeTabs();
-  });
-  it('verify connection of table and graph on restored canvas', function () {
-    graphToolTile.getGraphPointLabel().contains('p1').should('exist');
-  });
-});
-context('Delete connected table', function () {
-  it('will delete connected table', function () {
-    clueCanvas.deleteTile('table');
-    graphToolTile.getGraphPointLabel().contains('p1').should('not.exist');
-  });
-  it('will verify graph is still functional after connected table is deleted', function () {
-    graphToolTile.getGraphTile().click();
-    graphToolTile.addPointToGraph(2, 6);
-    graphToolTile.getGraphPoint().should('exist').and('have.length', 3);
-  });
-});

--- a/cypress/integration/clue/branch/student_tests/graph_tool_spec.js
+++ b/cypress/integration/clue/branch/student_tests/graph_tool_spec.js
@@ -14,241 +14,241 @@ const problemDoc = '2.1 Drawing Wumps';
 const ptsDoc = 'Points';
 const polyDoc = 'Polygon';
 
-before(function(){
-    const queryParams = `${Cypress.config("queryParams")}`;
-    cy.clearQAData('all');
-
-    cy.visit(queryParams);
-    cy.waitForLoad();
-});
-context('Test graph tool functionalities', function(){
-    describe('adding points and polygons to a graph', function(){
-        it('will add a point to the origin', function(){
-            clueCanvas.addTile('geometry');
-            graphToolTile.addPointToGraph(0,0);
-            graphToolTile.getGraphPointCoordinates().should('contain', '(0, 0)');
-        });
-        it('will add points to a graph', function(){
-            canvas.createNewExtraDocumentFromFileMenu(ptsDoc, "my-work");
-            clueCanvas.addTile('geometry');
-            cy.get('.spacer').click();
-            clueCanvas.deleteTile('text');
-            graphToolTile.getGraphTile().last().click();
-            graphToolTile.addPointToGraph(5,5);
-            graphToolTile.addPointToGraph(10,5);
-            graphToolTile.addPointToGraph(10,10);
-        });
-        it('will add a polygon to a graph', function(){
-            canvas.createNewExtraDocumentFromFileMenu(polyDoc, "my-work");
-            clueCanvas.addTile('geometry');
-            cy.get('.spacer').click();
-            clueCanvas.deleteTile('text');
-            graphToolTile.getGraphTile().last().click();
-            graphToolTile.addPointToGraph(4.2,2);
-            graphToolTile.addPointToGraph(10.4, 7.2);
-            graphToolTile.addPointToGraph(13.2,2);
-            graphToolTile.addPointToGraph(13.2,2);
-            graphToolTile.getGraphPoint().last().click({force:true}).click({force:true});
-            graphToolTile.getGraphPolygon().should('exist');
-        });
+context('Graph Tool', function() {
+    before(function(){
+        const queryParams = `${Cypress.config("queryParams")}`;
+        cy.clearQAData('all');
+    
+        cy.visit(queryParams);
+        cy.waitForLoad();
     });
-
-    describe('restore points to canvas', function(){
-        it('will verify restore of point at origin', function(){
-            primaryWorkspace.getResizePanelDivider().click();
-            resourcePanel.openPrimaryWorkspaceTab("my-work");
-            cy.openDocumentWithTitle('my-work','workspaces', problemDoc);
-            graphToolTile.getGraphPointCoordinates().should('contain', '(0, 0)');
+    
+    context('Test graph tool functionalities', function(){
+        describe('adding points and polygons to a graph', function(){
+            it('will add a point to the origin', function(){
+                clueCanvas.addTile('geometry');
+                graphToolTile.addPointToGraph(0,0);
+                graphToolTile.getGraphPointCoordinates().should('contain', '(0, 0)');
+            });
+            it('will add points to a graph', function(){
+                canvas.createNewExtraDocumentFromFileMenu(ptsDoc, "my-work");
+                clueCanvas.addTile('geometry');
+                cy.get('.spacer').click();
+                clueCanvas.deleteTile('text');
+                graphToolTile.getGraphTile().last().click();
+                graphToolTile.addPointToGraph(5,5);
+                graphToolTile.addPointToGraph(10,5);
+                graphToolTile.addPointToGraph(10,10);
+            });
+            it('will add a polygon to a graph', function(){
+                canvas.createNewExtraDocumentFromFileMenu(polyDoc, "my-work");
+                clueCanvas.addTile('geometry');
+                cy.get('.spacer').click();
+                clueCanvas.deleteTile('text');
+                graphToolTile.getGraphTile().last().click();
+                graphToolTile.addPointToGraph(4.2,2);
+                graphToolTile.addPointToGraph(10.4, 7.2);
+                graphToolTile.addPointToGraph(13.2,2);
+                graphToolTile.addPointToGraph(13.2,2);
+                graphToolTile.getGraphPoint().last().click({force:true}).click({force:true});
+                graphToolTile.getGraphPolygon().should('exist');
+            });
         });
-        it('will verify restore of multiple points', function(){
-            cy.openDocumentWithTitle('my-work','workspaces', ptsDoc);
-            graphToolTile.getGraphPoint().should('have.length',3);
-        });
-        it('will verify restore of polygon', function(){
-            cy.openDocumentWithTitle('my-work','workspaces', polyDoc);
-            graphToolTile.getGraphPolygon().should('exist');
-        });
-    });
-
-    context('Graph Toolbar', function(){
-        describe('interact with points and polygons', function(){
-            it('will select a point', function(){
-                let point=4;
+    
+        describe('restore points to canvas', function(){
+            it('will verify restore of point at origin', function(){
+                primaryWorkspace.getResizePanelDivider().click();
+                resourcePanel.openPrimaryWorkspaceTab("my-work");
+                cy.openDocumentWithTitle('my-work','workspaces', problemDoc);
+                graphToolTile.getGraphPointCoordinates().should('contain', '(0, 0)');
+            });
+            it('will verify restore of multiple points', function(){
                 cy.openDocumentWithTitle('my-work','workspaces', ptsDoc);
-                resourcePanel.closePrimaryWorkspaceTabs();
-                graphToolTile.getGraphTile().click({multiple: true});
-                graphToolTile.selectGraphPoint(10,10);
-                graphToolTile.getGraphPointID(point)
-                    .then((id)=>{
-                        id='#'.concat(id);
-                        cy.get(id).then(($el)=>{
-                            // expect($el).to.have.text('(13.20, 5)');
-                            expect($el).to.have.text('');
+                graphToolTile.getGraphPoint().should('have.length',3);
+            });
+            it('will verify restore of polygon', function(){
+                cy.openDocumentWithTitle('my-work','workspaces', polyDoc);
+                graphToolTile.getGraphPolygon().should('exist');
+            });
+        });
+    
+        context('Graph Toolbar', function(){
+            describe('interact with points and polygons', function(){
+                it('will select a point', function(){
+                    let point=4;
+                    cy.openDocumentWithTitle('my-work','workspaces', ptsDoc);
+                    resourcePanel.closePrimaryWorkspaceTabs();
+                    graphToolTile.getGraphTile().click({multiple: true});
+                    graphToolTile.selectGraphPoint(10,10);
+                    graphToolTile.getGraphPointID(point)
+                        .then((id)=>{
+                            id='#'.concat(id);
+                            cy.get(id).then(($el)=>{
+                                // expect($el).to.have.text('(13.20, 5)');
+                                expect($el).to.have.text('');
+                            });
                         });
-                    });
-                // graphToolTile.getGraphPointCoordinates().should('contain', '(13.20, 5)');
-                graphToolTile.getGraphPointCoordinates().should('contain', '(10, 10)');
+                    // graphToolTile.getGraphPointCoordinates().should('contain', '(13.20, 5)');
+                    graphToolTile.getGraphPointCoordinates().should('contain', '(10, 10)');
+                });
+                it('will drag a point to a new location', function(){
+                    const dataTransfer = new DataTransfer;
+                    const graphUnit = 18.33;
+                    let x= 15, y=2;
+                    let transX=(graphToolTile.transformFromCoordinate('x', x))+(8*graphUnit),
+                        transY=(graphToolTile.transformFromCoordinate('y', y))+(5*graphUnit);
+    
+                    graphToolTile.getGraphPoint().last()
+                        .trigger('mousedown',{dataTransfer, force:true})
+                        .trigger('mousemove',{clientX:transX, clientY:transY, dataTransfer, force:true})
+                        .trigger('mouseup',{dataTransfer, force:true});
+                    // graphToolTile.getGraphPointCoordinates().should('contain', '('+x+', '+y+')');
+                    graphToolTile.getGraphPointCoordinates().should('contain', '(18, 2)');
+                });
+                it('will copy and paste a point', function(){ //cannot send keyboard commands to non-text fields
+    
+                });
+                it('will show and hide angles to a polygon', function(){
+                    let numAngles=1;
+                    primaryWorkspace.getResizePanelDivider().click();
+                    resourcePanel.openPrimaryWorkspaceTab("my-work");
+                    // primaryWorkspace.openPrimaryWorkspaceTab("my-work");
+                    cy.openDocumentWithTitle('my-work','workspaces', polyDoc);
+                    resourcePanel.closePrimaryWorkspaceTabs();
+                    graphToolTile.selectGraphPoint(4.2,2);
+                    graphToolTile.selectGraphPoint(4.2,2);
+                    graphToolTile.showAngle();
+                    graphToolTile.getAngleAdornment().should('exist').and('have.length',numAngles);
+                    graphToolTile.selectGraphPoint(10.4, 7.2);
+                    graphToolTile.showAngle();
+                    graphToolTile.getAngleAdornment().should('exist').and('have.length',numAngles+1);
+                    graphToolTile.selectGraphPoint(13.2,2);
+                    graphToolTile.showAngle();
+                    graphToolTile.getAngleAdornment().should('exist').and('have.length',numAngles+2);
+                    graphToolTile.selectGraphPoint(13.2,2);
+                    graphToolTile.hideAngle();
+                    graphToolTile.getAngleAdornment().should('exist').and('have.length',numAngles+1);
+                    graphToolTile.selectGraphPoint(10.4, 7.2);
+                    graphToolTile.hideAngle();
+                    graphToolTile.getAngleAdornment().should('exist').and('have.length',numAngles);
+                    graphToolTile.selectGraphPoint(4.2,2);
+                    graphToolTile.hideAngle();
+                    graphToolTile.getAngleAdornment().should('not.exist');
+    
+                    //Add the angles angle for the restore test later
+                    graphToolTile.selectGraphPoint(13.2,2);
+                    graphToolTile.showAngle();
+                    graphToolTile.selectGraphPoint(10.4, 7.2);
+                    graphToolTile.showAngle();
+                    graphToolTile.selectGraphPoint(4.2,2);
+                    graphToolTile.showAngle();
+                    graphToolTile.selectGraphPoint(4.2,2);
+    
+                });
+                it('will drag a polygon to a new location', function(){
+                    const dataTransfer = new DataTransfer;
+                    const graphUnit = 18.33;
+                    let x= 18, y=5;
+    
+                    let transX=(graphToolTile.transformFromCoordinate('x', x))+(8*graphUnit),
+                        transY=(graphToolTile.transformFromCoordinate('y', y))+(5*graphUnit);
+                    graphToolTile.getGraphPolygon().click({force:true});
+                    graphToolTile.getGraphPoint().last()
+                        .trigger('mousedown',{dataTransfer, force:true})
+                        .trigger('mousemove',{clientX:transX, clientY:transY, dataTransfer, force:true})
+                        .trigger('mouseup',{dataTransfer, force:true});
+                    graphToolTile.getGraphPointCoordinates(0).should('contain', '(12, 5)');
+                    graphToolTile.getGraphPointCoordinates(1).should('contain', '(18, 11)');
+                    graphToolTile.getGraphPointCoordinates(2).should('contain', '(21, 5)');
+                });
+                it('verify rotate tool is visible when polygon is selected', function(){
+                    graphToolTile.getGraphPolygon().click({force:true});
+                    graphToolTile.getRotateTool().should('be.visible');
+                });
+                it('will rotate a polygon', function(){
+                    //not sure how to verify the rotation
+                    graphToolTile.getRotateTool()
+                        .trigger('mousedown')
+                        .trigger('dragstart')
+                        .trigger('mousemove',18, 73, {force:true})
+                        .trigger('dragend')
+                        .trigger('drop')
+                        .trigger('mouseup');
+                    //TODO verify points are in new location
+                });
+                it('will copy and paste a polygon', function(){
+                    graphToolTile.getGraphPolygon().click({force: true});
+                    graphToolTile.copyGraphElement();
+                    graphToolTile.getGraphPolygon().should('have.length',2);
+                    graphToolTile.getAngleAdornment().should('have.length',6);
+                    graphToolTile.getGraphPoint().should('have.length',6);
+                });
+                it('will restore changes to a graph', function(){
+                    primaryWorkspace.getResizePanelDivider().click();
+                    resourcePanel.openPrimaryWorkspaceTab("my-work");
+                    cy.openDocumentWithTitle('my-work','workspaces', polyDoc);
+                    graphToolTile.getAngleAdornment().should('exist').and('have.length',6);
+                });
             });
-            it('will drag a point to a new location', function(){
-                const dataTransfer = new DataTransfer;
-                const graphUnit = 18.33;
-                let x= 15, y=2;
-                let transX=(graphToolTile.transformFromCoordinate('x', x))+(8*graphUnit),
-                    transY=(graphToolTile.transformFromCoordinate('y', y))+(5*graphUnit);
-
-                graphToolTile.getGraphPoint().last()
-                    .trigger('mousedown',{dataTransfer, force:true})
-                    .trigger('mousemove',{clientX:transX, clientY:transY, dataTransfer, force:true})
-                    .trigger('mouseup',{dataTransfer, force:true});
-                // graphToolTile.getGraphPointCoordinates().should('contain', '('+x+', '+y+')');
-                graphToolTile.getGraphPointCoordinates().should('contain', '(18, 2)');
+    
+            describe('delete points and polygons', function(){
+                it.skip('verify delete points with delete tool', function(){ //current behavior of text deletes the entire graph tool tile. Point selection has to be forced
+                    let basePointCount = 3; // number of points already in doc2
+                    cy.openDocumentWithTitle('my-work','workspaces', ptsDoc);
+                    primaryWorkspace.getResizeLeftPanelHandle().click();
+                    graphToolTile.selectGraphPoint(15,2);
+                    graphToolTile.deleteGraphElement();
+                    graphToolTile.getGraphPoint().should('have.length', basePointCount -1);
+                    graphToolTile.selectGraphPoint(10,5);
+                    graphToolTile.deleteGraphElement();
+                    graphToolTile.getGraphPoint().should('have.length', basePointCount -2);
+                    graphToolTile.selectGraphPoint(5,5);
+                    // graphToolTile.deleteGraphElement();
+                    // graphToolTile.getGraphPoint().should('have.length', basePointCount-3)
+                });
+                it.skip('verify delete polygon',()=>{
+                    primaryWorkspace.getResizeRightPanelHandle().click();
+                    cy.openDocumentWithTitle('my-work','workspaces', polyDoc);
+                    graphToolTile.getGraphPolygon().last().click({force:true});
+                    graphToolTile.deleteGraphElement();
+                    graphToolTile.getGraphPolygon().should('have.length',1);
+                });
+                it.skip('verify delete points alters polygon',()=>{
+                    let basePointCount = 3, baseAngleCount=3; // number of points already in doc
+    
+                    graphToolTile.getGraphPoint().should('have.length', basePointCount);
+                    graphToolTile.selectGraphPoint(16, 3.5);
+                    graphToolTile.getAngleAdornment().should('have.length',baseAngleCount);
+                    graphToolTile.deleteGraphElement();
+                    graphToolTile.getGraphPoint().should('have.length', basePointCount-1);
+                    // graphToolTile.selectGraphPoint(16.2, 9.5);
+                    graphToolTile.getGraphPoint().last().click({force: true});
+                    graphToolTile.deleteGraphElement();
+                    graphToolTile.getGraphPoint().should('have.length', basePointCount -2);
+                    graphToolTile.selectGraphPoint(8, 8);
+                    graphToolTile.deleteGraphElement();
+                    graphToolTile.getGraphPoint().should('have.length', basePointCount-3);
+                });
             });
-            it('will copy and paste a point', function(){ //cannot send keyboard commands to non-text fields
-
-            });
-            it('will show and hide angles to a polygon', function(){
-                let numAngles=1;
-                primaryWorkspace.getResizePanelDivider().click();
-                resourcePanel.openPrimaryWorkspaceTab("my-work");
-                // primaryWorkspace.openPrimaryWorkspaceTab("my-work");
-                cy.openDocumentWithTitle('my-work','workspaces', polyDoc);
-                resourcePanel.closePrimaryWorkspaceTabs();
-                graphToolTile.selectGraphPoint(4.2,2);
-                graphToolTile.selectGraphPoint(4.2,2);
-                graphToolTile.showAngle();
-                graphToolTile.getAngleAdornment().should('exist').and('have.length',numAngles);
-                graphToolTile.selectGraphPoint(10.4, 7.2);
-                graphToolTile.showAngle();
-                graphToolTile.getAngleAdornment().should('exist').and('have.length',numAngles+1);
-                graphToolTile.selectGraphPoint(13.2,2);
-                graphToolTile.showAngle();
-                graphToolTile.getAngleAdornment().should('exist').and('have.length',numAngles+2);
-                graphToolTile.selectGraphPoint(13.2,2);
-                graphToolTile.hideAngle();
-                graphToolTile.getAngleAdornment().should('exist').and('have.length',numAngles+1);
-                graphToolTile.selectGraphPoint(10.4, 7.2);
-                graphToolTile.hideAngle();
-                graphToolTile.getAngleAdornment().should('exist').and('have.length',numAngles);
-                graphToolTile.selectGraphPoint(4.2,2);
-                graphToolTile.hideAngle();
-                graphToolTile.getAngleAdornment().should('not.exist');
-
-                //Add the angles angle for the restore test later
-                graphToolTile.selectGraphPoint(13.2,2);
-                graphToolTile.showAngle();
-                graphToolTile.selectGraphPoint(10.4, 7.2);
-                graphToolTile.showAngle();
-                graphToolTile.selectGraphPoint(4.2,2);
-                graphToolTile.showAngle();
-                graphToolTile.selectGraphPoint(4.2,2);
-
-            });
-            it('will drag a polygon to a new location', function(){
-                const dataTransfer = new DataTransfer;
-                const graphUnit = 18.33;
-                let x= 18, y=5;
-
-                let transX=(graphToolTile.transformFromCoordinate('x', x))+(8*graphUnit),
-                    transY=(graphToolTile.transformFromCoordinate('y', y))+(5*graphUnit);
-                graphToolTile.getGraphPolygon().click({force:true});
-                graphToolTile.getGraphPoint().last()
-                    .trigger('mousedown',{dataTransfer, force:true})
-                    .trigger('mousemove',{clientX:transX, clientY:transY, dataTransfer, force:true})
-                    .trigger('mouseup',{dataTransfer, force:true});
-                graphToolTile.getGraphPointCoordinates(0).should('contain', '(12, 5)');
-                graphToolTile.getGraphPointCoordinates(1).should('contain', '(18, 11)');
-                graphToolTile.getGraphPointCoordinates(2).should('contain', '(21, 5)');
-            });
-            it('verify rotate tool is visible when polygon is selected', function(){
-                graphToolTile.getGraphPolygon().click({force:true});
-                graphToolTile.getRotateTool().should('be.visible');
-            });
-            it('will rotate a polygon', function(){
-                //not sure how to verify the rotation
-                graphToolTile.getRotateTool()
-                    .trigger('mousedown')
-                    .trigger('dragstart')
-                    .trigger('mousemove',18, 73, {force:true})
-                    .trigger('dragend')
-                    .trigger('drop')
-                    .trigger('mouseup');
-                //TODO verify points are in new location
-            });
-            it('will copy and paste a polygon', function(){
-                graphToolTile.getGraphPolygon().click({force: true});
-                graphToolTile.copyGraphElement();
-                graphToolTile.getGraphPolygon().should('have.length',2);
-                graphToolTile.getAngleAdornment().should('have.length',6);
-                graphToolTile.getGraphPoint().should('have.length',6);
-            });
-            it('will restore changes to a graph', function(){
-                primaryWorkspace.getResizePanelDivider().click();
-                resourcePanel.openPrimaryWorkspaceTab("my-work");
-                cy.openDocumentWithTitle('my-work','workspaces', polyDoc);
-                graphToolTile.getAngleAdornment().should('exist').and('have.length',6);
+    
+            describe.skip('movable line tests',()=>{
+                // it('verify add a movable line', function(){
+                //     canvas.createNewExtraDocumentFromFileMenu(lineDoc, "my-work");
+                //     clueCanvas.addTile('geometry');
+                //     graphToolTile.addMovableLine();
+    
+                // });
+                // it.skip('verify move the movable line', function () {
+    
+                // });
+                // it.skip('verify rotate the movable line', function () {
+    
+                // });
+                // it.skip('verify movable line equation edit', function () {
+    
+                // });
             });
         });
-
-        describe('delete points and polygons', function(){
-            it.skip('verify delete points with delete tool', function(){ //current behavior of text deletes the entire graph tool tile. Point selection has to be forced
-                let basePointCount = 3; // number of points already in doc2
-                cy.openDocumentWithTitle('my-work','workspaces', ptsDoc);
-                primaryWorkspace.getResizeLeftPanelHandle().click();
-                graphToolTile.selectGraphPoint(15,2);
-                graphToolTile.deleteGraphElement();
-                graphToolTile.getGraphPoint().should('have.length', basePointCount -1);
-                graphToolTile.selectGraphPoint(10,5);
-                graphToolTile.deleteGraphElement();
-                graphToolTile.getGraphPoint().should('have.length', basePointCount -2);
-                graphToolTile.selectGraphPoint(5,5);
-                // graphToolTile.deleteGraphElement();
-                // graphToolTile.getGraphPoint().should('have.length', basePointCount-3)
-            });
-            it.skip('verify delete polygon',()=>{
-                primaryWorkspace.getResizeRightPanelHandle().click();
-                cy.openDocumentWithTitle('my-work','workspaces', polyDoc);
-                graphToolTile.getGraphPolygon().last().click({force:true});
-                graphToolTile.deleteGraphElement();
-                graphToolTile.getGraphPolygon().should('have.length',1);
-            });
-            it.skip('verify delete points alters polygon',()=>{
-                let basePointCount = 3, baseAngleCount=3; // number of points already in doc
-
-                graphToolTile.getGraphPoint().should('have.length', basePointCount);
-                graphToolTile.selectGraphPoint(16, 3.5);
-                graphToolTile.getAngleAdornment().should('have.length',baseAngleCount);
-                graphToolTile.deleteGraphElement();
-                graphToolTile.getGraphPoint().should('have.length', basePointCount-1);
-                // graphToolTile.selectGraphPoint(16.2, 9.5);
-                graphToolTile.getGraphPoint().last().click({force: true});
-                graphToolTile.deleteGraphElement();
-                graphToolTile.getGraphPoint().should('have.length', basePointCount -2);
-                graphToolTile.selectGraphPoint(8, 8);
-                graphToolTile.deleteGraphElement();
-                graphToolTile.getGraphPoint().should('have.length', basePointCount-3);
-            });
-        });
-
-        describe.skip('movable line tests',()=>{
-            // it('verify add a movable line', function(){
-            //     canvas.createNewExtraDocumentFromFileMenu(lineDoc, "my-work");
-            //     clueCanvas.addTile('geometry');
-            //     graphToolTile.addMovableLine();
-
-            // });
-            // it.skip('verify move the movable line', function () {
-
-            // });
-            // it.skip('verify rotate the movable line', function () {
-
-            // });
-            // it.skip('verify movable line equation edit', function () {
-
-            // });
-        });
-    });
+    });    
 });
 
-after(function(){
-  cy.clearQAData('all');
-});

--- a/cypress/integration/clue/branch/student_tests/group_test_spec.js
+++ b/cypress/integration/clue/branch/student_tests/group_test_spec.js
@@ -5,11 +5,11 @@ const clueCanvas = new ClueCanvas;
 const textToolTile = new TextToolTile;
 
 const baseUrl = `${Cypress.config("baseUrl")}`;
-before(()=>{
-  cy.clearQAData('all');
-});
-
 context('Test group functionalities', function(){
+    before(()=>{
+        cy.clearQAData('all');
+    });
+      
     let qaClass = 10,
         qaGroup = 10,
         problem = 3.3,
@@ -144,7 +144,3 @@ context('Test group functionalities', function(){
         // });
     });
 });
-
-// after(function(){
-//     cy.clearQAData('all');
-//   });

--- a/cypress/integration/clue/branch/student_tests/image_tool_spec.js
+++ b/cypress/integration/clue/branch/student_tests/image_tool_spec.js
@@ -13,15 +13,15 @@ const resourcesPanel = new ResourcesPanel;
 
 let userCanvas = 'Uploaded Images';
 
-before(function(){
-    const queryParams = `${Cypress.config("queryParams")}`;
-    cy.clearQAData('all');
-
-    cy.visit(queryParams);
-    cy.waitForLoad();
-});
-
 context('Test image functionalities', function(){
+    before(function(){
+        const queryParams = `${Cypress.config("queryParams")}`;
+        cy.clearQAData('all');
+    
+        cy.visit(queryParams);
+        cy.waitForLoad();
+    });
+    
     describe('upload image from user computer',()=>{
         before(()=>{ //create a new doc so that save and restore can be tested
             canvas.createNewExtraDocumentFromFileMenu(userCanvas, "my-work");
@@ -86,6 +86,3 @@ context('Test image functionalities', function(){
     });
 });
 
-after(function(){
-  cy.clearQAData('all');
-});

--- a/cypress/integration/clue/branch/student_tests/nav_panel_test_spec.js
+++ b/cypress/integration/clue/branch/student_tests/nav_panel_test_spec.js
@@ -9,220 +9,219 @@ const canvas = new Canvas;
 const clueCanvas = new ClueCanvas;
 const problemSubTabTitles = ['Introduction', 'Initial Challenge', 'What If', 'Now What'];
 
-before(()=>{
-      cy.clearQAData('all');
-});
-
-describe('Test nav panel tabs', function () {
-  let copyDocumentTitle = 'copy Investigation';
-
-  before(function () {
-    const queryParams = `${Cypress.config("queryParams")}`;
+context('Nav Panel', function () {
+  before(()=>{
     cy.clearQAData('all');
-
-    cy.visit(queryParams);
-    cy.waitForLoad();
-    clueCanvas.getInvestigationCanvasTitle().text().as('title');
   });
-  describe("Investigation Tab tests", function () {
-    describe("Problem tabs", function () {
-      it('verify tab names are visible', () => {
-        cy.get(".collapsed-resources-tab.my-work").click();
-        cy.openTopTab("problems");
-        cy.get(".problem-tabs .tab-list .prob-tab").each(($tab, index, $tabList) => {
-          expect($tab.text()).to.contain(problemSubTabTitles[index]);
+
+  describe('Test nav panel tabs', function () {
+    let copyDocumentTitle = 'copy Investigation';
+
+    before(function () {
+      const queryParams = `${Cypress.config("queryParams")}`;
+      cy.clearQAData('all');
+
+      cy.visit(queryParams);
+      cy.waitForLoad();
+      clueCanvas.getInvestigationCanvasTitle().text().as('title');
+    });
+    describe("Investigation Tab tests", function () {
+      describe("Problem tabs", function () {
+        it('verify tab names are visible', () => {
+          cy.get(".collapsed-resources-tab.my-work").click();
+          cy.openTopTab("problems");
+          cy.get(".problem-tabs .tab-list .prob-tab").each(($tab, index, $tabList) => {
+            expect($tab.text()).to.contain(problemSubTabTitles[index]);
+          });
+        });
+      });
+    });
+    describe('My Work tab tests', function () {
+      describe('Investigation section', function () {
+        it('verify that a problem workspace thumbnail is visible in the My Work/Workspaces nav panel', function () {
+          cy.openTopTab('my-work');
+          cy.openSection('my-work', 'workspaces');
+          cy.getCanvasItemTitle('workspaces').contains(this.title).should('exist');
+          // cy.closeTabs();
+        });
+        it('verify publish Investigation', function () {
+          canvas.publishCanvas("investigation");
+          cy.openTopTab('class-work');
+          cy.getCanvasItemTitle('workspaces').should('contain', this.title);
+        });
+        it('verify make a copy of a canvas', function () {
+          canvas.copyDocument(copyDocumentTitle);
+          canvas.getPersonalDocTitle().find('span').text().should('contain', copyDocumentTitle);
+        });
+        it('verify copied investigation appears in the workspaces section', function () {
+          cy.openTopTab("my-work");
+          cy.getCanvasItemTitle('workspaces').contains(copyDocumentTitle).should('be.visible');
+        });
+        it('verify publish of personal workspace', function () {
+          canvas.publishCanvas("personal");
+          cy.openTopTab('class-work');
+          cy.openSection('class-work', 'workspaces');
+          cy.getCanvasItemTitle('workspaces').should('contain', copyDocumentTitle);
+        });
+        it('verify delete document reverts nav-tab panel to show thumbnails', function () {
+          const deleteDocument = "Delete me";
+          canvas.copyDocument(deleteDocument);
+          cy.openTopTab('my-work');
+          cy.wait(1000);
+          cy.getCanvasItemTitle('workspaces').should('contain', deleteDocument);
+          cy.openDocumentWithTitle('my-work', 'workspaces', copyDocumentTitle);
+          cy.openDocumentWithTitle('my-work', 'workspaces', deleteDocument);
+          canvas.deleteDocument();
+          cy.getCanvasItemTitle('workspaces').should('not.contain', deleteDocument);
+        });
+      });
+      describe('Workspaces section', function () {
+        it('verify open the correct canvas selected from Investigations section', function () {
+          cy.openTopTab("my-work");
+          cy.openDocumentWithTitle('my-work', 'workspaces', this.title);
+          clueCanvas.getInvestigationCanvasTitle().should('contain', this.title);
+        });
+        it('verify open the correct canvas selected from Extra Workspace section', function () {
+          cy.openTopTab("my-work");
+          cy.openDocumentWithTitle('my-work', 'workspaces', copyDocumentTitle);
+          canvas.getPersonalDocTitle().should('contain', copyDocumentTitle);
+        });
+        after(()=>{
+          cy.closeTabs();
+        });
+      });
+      describe('Starred section', function () {
+        before(() => {
+          cy.get(".collapsed-resources-tab.my-work").click();
+          cy.openTopTab('my-work');
+          cy.openSection("my-work", "workspaces");
+          resourcesPanel.starCanvasItem('my-work', 'workspaces', copyDocumentTitle);
+        });
+        it('verify starred document star is highlighted', function () {
+          resourcesPanel.getCanvasStarIcon('my-work', 'workspaces', copyDocumentTitle).should('have.class', 'starred');
+        });
+        it('verify starred document appears in the Starred section', function () {
+          cy.openSection('my-work', 'starred');
+          cy.getCanvasItemTitle('starred').contains(copyDocumentTitle).should('exist');
+        });
+      });
+      describe('Learning Log Section', function () {
+        it('verify investigation canvas is not listed in Learning Log ', function () { //still need to verify the titles match the titles from opened canvases
+          cy.openTopTab('my-work');
+          cy.openSection('my-work', 'learning-log');
+          cy.getCanvasItemTitle('learning-log').contains(this.title).should('not.exist');
+          cy.getCanvasItemTitle('learning-log').should('have.length', 1);
+        });
+        it('verify user starter learning log canvas exists', function () {
+          cy.getCanvasItemTitle('learning-log').contains("My First Learning Log").should('be.visible');
+        });
+        it('verify open of learning log canvas into main workspace', function () {
+          cy.openDocumentWithTitle('my-work', 'learning-log', "My First Learning Log");
+          cy.get("[data-test=learning-log-title]").should('contain', "My First Learning Log");
+        });
+        it('verify Learning Log copy appears in Learning Log section', function () {
+          canvas.copyDocument("Learning Log Copy");
+          cy.openSection("my-work","learning-log");
+          cy.wait(2500);
+          cy.getCanvasItemTitle('learning-log').contains("Learning Log Copy").should("be.visible");
+        });
+        it('verify publish learning log', function () {
+          canvas.publishCanvas("personal");
+          cy.openTopTab("class-work");
+          cy.openSection("class-work", "learning-logs");
+          cy.getCanvasItemTitle("learning-logs", "Learning Log Copy");
+        });
+      });
+      after(function () {
+        cy.closeTabs(); // clean up
+      });
+    });
+
+    describe('Class Work tab tests', function () { //uses publish documents from earlier tests
+      before(() => {
+        cy.get(".collapsed-resources-tab.class-work").click();
+        cy.openTopTab('class-work');
+      });
+      describe('Open correct canvas from correct section', function () {
+        it('verify open published canvas from Workspace list', function () { //this assumes there are published work
+          cy.openSection("class-work", "workspaces");
+          cy.openDocumentThumbnail('workspaces', copyDocumentTitle);
+        });
+        it('verify open published canvas from Investigations list', function () { //this assumes there are published work
+          cy.openSection("class-work", "workspaces");
+          cy.openDocumentThumbnail('workspaces', this.title);
+        });
+        it('will verify that published canvas does not have Edit button', function () {
+          cy.get('.edit-button').should("not.be.visible");
+        });
+      });
+    });
+    describe('Supports Tab', function () {
+      describe('Test supports area', function () {
+        it('verify support tabs', function () {
+          cy.openTopTab("supports");
+          // cy.get(".support-badge").should("be.visible");
+          cy.get(".doc-tab.supports").should("have.length", 2);
+          cy.get(".doc-tab.supports.teacher-supports").click();
+          // clicking on a teacher support should update the unread supports badge
+          // cy.get("[data-test=teacher-supports-list-items]").last().click();
+          // cy.get(".support-badge").should("not.exist");
         });
       });
     });
   });
-  describe('My Work tab tests', function () {
-    describe('Investigation section', function () {
-      it('verify that a problem workspace thumbnail is visible in the My Work/Workspaces nav panel', function () {
-        cy.openTopTab('my-work');
-        cy.openSection('my-work', 'workspaces');
-        cy.getCanvasItemTitle('workspaces').contains(this.title).should('exist');
-        // cy.closeTabs();
-      });
-      it('verify publish Investigation', function () {
-        canvas.publishCanvas("investigation");
-        cy.openTopTab('class-work');
-        cy.getCanvasItemTitle('workspaces').should('contain', this.title);
-      });
-      it('verify make a copy of a canvas', function () {
-        canvas.copyDocument(copyDocumentTitle);
-        canvas.getPersonalDocTitle().find('span').text().should('contain', copyDocumentTitle);
-      });
-      it('verify copied investigation appears in the workspaces section', function () {
-        cy.openTopTab("my-work");
-        cy.getCanvasItemTitle('workspaces').contains(copyDocumentTitle).should('be.visible');
-      });
-      it('verify publish of personal workspace', function () {
-        canvas.publishCanvas("personal");
-        cy.openTopTab('class-work');
-        cy.openSection('class-work', 'workspaces');
-        cy.getCanvasItemTitle('workspaces').should('contain', copyDocumentTitle);
-      });
-      it('verify delete document reverts nav-tab panel to show thumbnails', function () {
-        const deleteDocument = "Delete me";
-        canvas.copyDocument(deleteDocument);
-        cy.openTopTab('my-work');
-        cy.wait(1000);
-        cy.getCanvasItemTitle('workspaces').should('contain', deleteDocument);
-        cy.openDocumentWithTitle('my-work', 'workspaces', copyDocumentTitle);
-        cy.openDocumentWithTitle('my-work', 'workspaces', deleteDocument);
-        canvas.deleteDocument();
-        cy.getCanvasItemTitle('workspaces').should('not.contain', deleteDocument);
-      });
+
+  describe('Nav panel tab configs', function () {
+    const baseQueryParam = "?appMode=qa&fakeClass=10&fakeUser=student:11&fakeOffering=10&qaGroup=10";
+    it('Single Top tab with visible resource tab panel', function () {
+      cy.visit(`${baseQueryParam}&unit=example`);
+      cy.waitForLoad();
+      cy.get(".collapsed-resources-tab.my-work").should('not.exist');
+      canvas.openFileMenu();
+      cy.get ("[data-test=list-item-icon-open-workspace]").click();
+      cy.get(".tab-header-row").should("not.be.visible");
     });
-    describe('Workspaces section', function () {
-      it('verify open the correct canvas selected from Investigations section', function () {
-        cy.openTopTab("my-work");
-        cy.openDocumentWithTitle('my-work', 'workspaces', this.title);
-        clueCanvas.getInvestigationCanvasTitle().should('contain', this.title);
-      });
-      it('verify open the correct canvas selected from Extra Workspace section', function () {
-        cy.openTopTab("my-work");
-        cy.openDocumentWithTitle('my-work', 'workspaces', copyDocumentTitle);
-        canvas.getPersonalDocTitle().should('contain', copyDocumentTitle);
-      });
-      after(()=>{
-        cy.closeTabs();
-      });
+    it('Single Top tab with visible resource tab panel', function () {
+      cy.visit(`${baseQueryParam}&unit=example-show-nav-panel`);
+      cy.waitForLoad();
+      cy.get(".collapsed-resources-tab.my-work").click();
+      cy.get(".top-tab").should("have.length", 1);
+      cy.get(".document-tabs.my-work .tab-header-row").should("not.be.visible");
+      canvas.openFileMenu();
+      cy.get ("[data-test=list-item-icon-open-workspace]").click();
+      cy.get(".tab-header-row").should("not.be.visible");
     });
-    describe('Starred section', function () {
-      before(() => {
-        cy.get(".collapsed-resources-tab.my-work").click();
-        cy.openTopTab('my-work');
-        cy.openSection("my-work", "workspaces");
-        resourcesPanel.starCanvasItem('my-work', 'workspaces', copyDocumentTitle);
-      });
-      it('verify starred document star is highlighted', function () {
-        resourcesPanel.getCanvasStarIcon('my-work', 'workspaces', copyDocumentTitle).should('have.class', 'starred');
-      });
-      it('verify starred document appears in the Starred section', function () {
-        cy.openSection('my-work', 'starred');
-        cy.getCanvasItemTitle('starred').contains(copyDocumentTitle).should('exist');
-      });
+    it('Problem Tabs with no sub tabs', function () {
+      cy.visit(`${baseQueryParam}&unit=example-no-section-problem-tab`);
+      cy.waitForLoad();
+      cy.get(".collapsed-resources-tab.my-work").click();
+      cy.openTopTab("problems");
+      cy.get(".problem-tabs .tab-header-row").should("not.be.visible");
     });
-    describe('Learning Log Section', function () {
-      it('verify investigation canvas is not listed in Learning Log ', function () { //still need to verify the titles match the titles from opened canvases
-        cy.openTopTab('my-work');
-        cy.openSection('my-work', 'learning-log');
-        cy.getCanvasItemTitle('learning-log').contains(this.title).should('not.exist');
-        cy.getCanvasItemTitle('learning-log').should('have.length', 1);
+    it('Problem Tabs with no sub tabs', function () {
+      const exampleProblemSubTabTitles = ["First Section", "Second Section", "Third Section"];
+      const exampleMyWorkSubTabTitles = ["Workspaces", "Starred"];
+      const exampleClassWorkSubTabTitles = ["Workspaces", "Starred"];
+
+      cy.visit(`${baseQueryParam}&unit=example-config-subtabs`);
+      cy.waitForLoad();
+      cy.get(".collapsed-resources-tab.my-work").click();
+      cy.openTopTab("problems");
+      cy.get(".problem-tabs .tab-list .prob-tab").each(($tab, index, $tabList) => {
+        expect($tabList).to.have.lengthOf(3);
+        expect($tab.text()).to.contain(exampleProblemSubTabTitles[index]);
       });
-      it('verify user starter learning log canvas exists', function () {
-        cy.getCanvasItemTitle('learning-log').contains("My First Learning Log").should('be.visible');
+      cy.openTopTab("my-work");
+      cy.get(".document-tabs .tab-list .doc-tab.my-work").each(($tab, index, $tabList) => {
+        expect($tabList).to.have.lengthOf(2);
+        expect($tab.text()).to.contain(exampleMyWorkSubTabTitles[index]);
       });
-      it('verify open of learning log canvas into main workspace', function () {
-        cy.openDocumentWithTitle('my-work', 'learning-log', "My First Learning Log");
-        cy.get("[data-test=learning-log-title]").should('contain', "My First Learning Log");
+      cy.openTopTab("class-work");
+      cy.get(".document-tabs .tab-list .doc-tab.class-work").each(($tab, index, $tabList) => {
+        expect($tabList).to.have.lengthOf(2);
+        expect($tab.text()).to.contain(exampleClassWorkSubTabTitles[index]);
       });
-      it('verify Learning Log copy appears in Learning Log section', function () {
-        canvas.copyDocument("Learning Log Copy");
-        cy.openSection("my-work","learning-log");
-        cy.wait(2500);
-        cy.getCanvasItemTitle('learning-log').contains("Learning Log Copy").should("be.visible");
-      });
-      it('verify publish learning log', function () {
-        canvas.publishCanvas("personal");
-        cy.openTopTab("class-work");
-        cy.openSection("class-work", "learning-logs");
-        cy.getCanvasItemTitle("learning-logs", "Learning Log Copy");
-      });
-    });
-    after(function () {
-      cy.closeTabs(); // clean up
     });
   });
 
-  describe('Class Work tab tests', function () { //uses publish documents from earlier tests
-    before(() => {
-      cy.get(".collapsed-resources-tab.class-work").click();
-      cy.openTopTab('class-work');
-    });
-    describe('Open correct canvas from correct section', function () {
-      it('verify open published canvas from Workspace list', function () { //this assumes there are published work
-        cy.openSection("class-work", "workspaces");
-        cy.openDocumentThumbnail('workspaces', copyDocumentTitle);
-      });
-      it('verify open published canvas from Investigations list', function () { //this assumes there are published work
-        cy.openSection("class-work", "workspaces");
-        cy.openDocumentThumbnail('workspaces', this.title);
-      });
-      it('will verify that published canvas does not have Edit button', function () {
-        cy.get('.edit-button').should("not.be.visible");
-      });
-    });
-  });
-  describe('Supports Tab', function () {
-    describe('Test supports area', function () {
-      it('verify support tabs', function () {
-        cy.openTopTab("supports");
-        // cy.get(".support-badge").should("be.visible");
-        cy.get(".doc-tab.supports").should("have.length", 2);
-        cy.get(".doc-tab.supports.teacher-supports").click();
-        // clicking on a teacher support should update the unread supports badge
-        // cy.get("[data-test=teacher-supports-list-items]").last().click();
-        // cy.get(".support-badge").should("not.exist");
-      });
-    });
-  });
-});
-
-describe.only('Nav panel tab configs', function () {
-  const baseQueryParam = "?appMode=qa&fakeClass=10&fakeUser=student:11&fakeOffering=10&qaGroup=10";
-  it('Single Top tab with visible resource tab panel', function () {
-    cy.visit(`${baseQueryParam}&unit=example`);
-    cy.waitForLoad();
-    cy.get(".collapsed-resources-tab.my-work").should('not.exist');
-    canvas.openFileMenu();
-    cy.get ("[data-test=list-item-icon-open-workspace]").click();
-    cy.get(".tab-header-row").should("not.be.visible");
-  });
-  it('Single Top tab with visible resource tab panel', function () {
-    cy.visit(`${baseQueryParam}&unit=example-show-nav-panel`);
-    cy.waitForLoad();
-    cy.get(".collapsed-resources-tab.my-work").click();
-    cy.get(".top-tab").should("have.length", 1);
-    cy.get(".document-tabs.my-work .tab-header-row").should("not.be.visible");
-    canvas.openFileMenu();
-    cy.get ("[data-test=list-item-icon-open-workspace]").click();
-    cy.get(".tab-header-row").should("not.be.visible");
-  });
-  it('Problem Tabs with no sub tabs', function () {
-    cy.visit(`${baseQueryParam}&unit=example-no-section-problem-tab`);
-    cy.waitForLoad();
-    cy.get(".collapsed-resources-tab.my-work").click();
-    cy.openTopTab("problems");
-    cy.get(".problem-tabs .tab-header-row").should("not.be.visible");
-  });
-  it('Problem Tabs with no sub tabs', function () {
-    const exampleProblemSubTabTitles = ["First Section", "Second Section", "Third Section"];
-    const exampleMyWorkSubTabTitles = ["Workspaces", "Starred"];
-    const exampleClassWorkSubTabTitles = ["Workspaces", "Starred"];
-
-    cy.visit(`${baseQueryParam}&unit=example-config-subtabs`);
-    cy.waitForLoad();
-    cy.get(".collapsed-resources-tab.my-work").click();
-    cy.openTopTab("problems");
-    cy.get(".problem-tabs .tab-list .prob-tab").each(($tab, index, $tabList) => {
-      expect($tabList).to.have.lengthOf(3);
-      expect($tab.text()).to.contain(exampleProblemSubTabTitles[index]);
-    });
-    cy.openTopTab("my-work");
-    cy.get(".document-tabs .tab-list .doc-tab.my-work").each(($tab, index, $tabList) => {
-      expect($tabList).to.have.lengthOf(2);
-      expect($tab.text()).to.contain(exampleMyWorkSubTabTitles[index]);
-    });
-    cy.openTopTab("class-work");
-    cy.get(".document-tabs .tab-list .doc-tab.class-work").each(($tab, index, $tabList) => {
-      expect($tabList).to.have.lengthOf(2);
-      expect($tab.text()).to.contain(exampleClassWorkSubTabTitles[index]);
-    });
-  });
-});
-
-after(function () {
-  cy.clearQAData('all');
 });

--- a/cypress/integration/clue/branch/student_tests/nav_panel_test_spec.js
+++ b/cypress/integration/clue/branch/student_tests/nav_panel_test_spec.js
@@ -156,7 +156,7 @@ context('Nav Panel', function () {
         });
       });
     });
-    describe('Supports Tab', function () {
+    describe.skip('Supports Tab', function () {
       describe('Test supports area', function () {
         it('verify support tabs', function () {
           cy.openTopTab("supports");

--- a/cypress/integration/clue/branch/student_tests/student_test_spec.js
+++ b/cypress/integration/clue/branch/student_tests/student_test_spec.js
@@ -9,6 +9,7 @@ let student = '5',
     classroom = '5',
     group = '5';
 
+describe('Check header area for correctness', function(){
     before(function(){
         const queryParams = `${Cypress.config("queryParams")}`;
 
@@ -16,7 +17,7 @@ let student = '5',
         cy.visit(queryParams);
         cy.waitForLoad();
     });
-describe('Check header area for correctness', function(){
+
     it('will verify if class name is correct', function(){
         header.getClassName().should('contain','Class '+classroom);
     });
@@ -29,8 +30,6 @@ describe('Check header area for correctness', function(){
     it('will verify student name is correct', function(){
         header.getUserName().should('contain','Student '+student);
     });
+
 });
 
-after(function(){
-  cy.clearQAData('all');
-});

--- a/cypress/integration/clue/branch/student_tests/table_tool_spec.js
+++ b/cypress/integration/clue/branch/student_tests/table_tool_spec.js
@@ -7,15 +7,15 @@ let clueCanvas = new ClueCanvas,
 let headerX = 'pluto';
 let headerY = 'mars';
 
-before(function () {
-  const queryParams = `${Cypress.config("queryParams")}`;
-  cy.clearQAData('all');
-
-  cy.visit(queryParams);
-  cy.waitForLoad();
-});
-
 context('Table Tool Tile', function () {
+  before(function () {
+    const queryParams = `${Cypress.config("queryParams")}`;
+    cy.clearQAData('all');
+  
+    cy.visit(queryParams);
+    cy.waitForLoad();
+  });  
+
   describe('Test table functions', function () {
     it('will add a table to canvas', function () {
       clueCanvas.addTile('table');
@@ -82,88 +82,86 @@ context('Table Tool Tile', function () {
       });
     });
   });
-});
-describe('edit table entries', function () {
-  // TODO: Found 1, expected 3
-  it('will add content to table', function () {
-    cy.get(".primary-workspace").within((workspace) => {
-      tableToolTile.getTableCell().eq(1).click().type('3{enter}');
-      tableToolTile.getTableCell().eq(2).click();
-      // cy.wait(100);
-      tableToolTile.getTableCell().eq(1).should('contain', '3');
-      tableToolTile.getTableCell().eq(2).type('2.5{enter}');
-      tableToolTile.getTableCell().eq(5).click();
-      // cy.wait(100);
-      tableToolTile.getTableCell().eq(2).should('contain', '2.5');
-      tableToolTile.getTableCell().eq(1).click().type('5{enter}');
-      tableToolTile.getTableCell().eq(5).click();
-      // cy.wait(100);
-      tableToolTile.getTableCell().eq(1).should('contain', '5');
-      tableToolTile.getTableRow().should('have.length', 2);
+
+  describe('edit table entries', function () {
+    // TODO: Found 1, expected 3
+    it('will add content to table', function () {
+      cy.get(".primary-workspace").within((workspace) => {
+        tableToolTile.getTableCell().eq(1).click().type('3{enter}');
+        tableToolTile.getTableCell().eq(2).click();
+        // cy.wait(100);
+        tableToolTile.getTableCell().eq(1).should('contain', '3');
+        tableToolTile.getTableCell().eq(2).type('2.5{enter}');
+        tableToolTile.getTableCell().eq(5).click();
+        // cy.wait(100);
+        tableToolTile.getTableCell().eq(2).should('contain', '2.5');
+        tableToolTile.getTableCell().eq(1).click().type('5{enter}');
+        tableToolTile.getTableCell().eq(5).click();
+        // cy.wait(100);
+        tableToolTile.getTableCell().eq(1).should('contain', '5');
+        tableToolTile.getTableRow().should('have.length', 2);
+      });
+    });
+    it('will toggle index numbers', function () {
+      tableToolTile.getIndexNumberToggle().click();
+      cy.get(".primary-workspace").within(() => {
+        cy.get(".index-cell-contents").eq(0).should('contain', 1);
+        cy.get(".index-cell-contents").eq(1).should('contain', "");
+      });
+    });
+    it('will remove a row', function () {
+      tableToolTile.removeRow("0");
+      tableToolTile.getTableRow().should('have.length', 1);
+      cy.get(".index-cell-contents").eq(0).should('contain', "");
     });
   });
-  it('will toggle index numbers', function () {
-    tableToolTile.getIndexNumberToggle().click();
-    cy.get(".primary-workspace").within(() => {
-      cy.get(".index-cell-contents").eq(0).should('contain', 1);
-      cy.get(".index-cell-contents").eq(1).should('contain', "");
+  describe("formulas", function () {
+    let formula = "3*pluto+2";
+    it('will verify formula modal', function () {
+      cy.get(".primary-workspace").within((workspace) => {
+        tableToolTile.getTableToolbarButton('set-expression').click();
+      });
+      cy.get('.modal-title').should('contain', "Set Expression");
+      cy.get('.modal-content .prompt select').should('not.exist');
+      cy.get('.modal-content .prompt').should('contain', "y2");
     });
-  });
-  it('will remove a row', function () {
-    tableToolTile.removeRow("0");
-    tableToolTile.getTableRow().should('have.length', 1);
-    cy.get(".index-cell-contents").eq(0).should('contain', "");
-  });
-});
-describe("formulas", function () {
-  let formula = "3*pluto+2";
-  it('will verify formula modal', function () {
-    cy.get(".primary-workspace").within((workspace) => {
-      tableToolTile.getTableToolbarButton('set-expression').click();
+    it('will enter a formula', function () {
+      cy.get('#expression-input').click().type(formula + '{enter}');
+      cy.get('.ReactModalPortal').should('not.exist');
     });
-    cy.get('.modal-title').should('contain', "Set Expression");
-    cy.get('.modal-content .prompt select').should('not.exist');
-    cy.get('.modal-content .prompt').should('contain', "y2");
-  });
-  it('will enter a formula', function () {
-    cy.get('#expression-input').click().type(formula + '{enter}');
-    cy.get('.ReactModalPortal').should('not.exist');
-  });
-  it('verify formula appears under correct column header', function () {
-    cy.get('.editable-header-cell')
-      .contains('y2')
-      .first()
-      .siblings('.expression-cell.has-expression')
-      .should('contain', formula);
-  });
-  it('verify selection of y axis when there is more than one',function(){
-    cy.get(".primary-workspace").within((workspace) => {
-      tableToolTile.getAddColumnButton().click();
-      tableToolTile.renameColumn('y', headerY); //makes it easier to find the correct column header
-      tableToolTile.getTableToolbarButton('set-expression').click();
+    it('verify formula appears under correct column header', function () {
+      cy.get('.editable-header-cell')
+        .contains('y2')
+        .first()
+        .siblings('.expression-cell.has-expression')
+        .should('contain', formula);
     });
-    cy.get('.modal-title').should('contain', "Set Expression");
-    cy.get('.modal-content .prompt select').should('exist');
-    cy.get('.modal-content .prompt select').select(headerY);
-    cy.get('.expression label').should('contain', headerY);
-  });
-  it('verify cancel does not enter in a formula', function(){
-    cy.get('#expression-input').click().type(formula );
-    cy.get('.modal-button').contains('Cancel').click();
-    cy.get('.editable-header-cell')
-      .contains('y')
-      .first()
-      .siblings('.expression-cell.has-expression')
-      .should('not.exist');
+    it('verify selection of y axis when there is more than one',function(){
+      cy.get(".primary-workspace").within((workspace) => {
+        tableToolTile.getAddColumnButton().click();
+        tableToolTile.renameColumn('y', headerY); //makes it easier to find the correct column header
+        tableToolTile.getTableToolbarButton('set-expression').click();
+      });
+      cy.get('.modal-title').should('contain', "Set Expression");
+      cy.get('.modal-content .prompt select').should('exist');
+      cy.get('.modal-content .prompt select').select(headerY);
+      cy.get('.expression label').should('contain', headerY);
     });
-});
-describe('delete table', function () {
-  it('verify delete table', function () {
-    tableToolTile.getTableTile().click();
-    clueCanvas.deleteTile('table');
+    it('verify cancel does not enter in a formula', function(){
+      cy.get('#expression-input').click().type(formula );
+      cy.get('.modal-button').contains('Cancel').click();
+      cy.get('.editable-header-cell')
+        .contains('y')
+        .first()
+        .siblings('.expression-cell.has-expression')
+        .should('not.exist');
+      });
+  });
+  describe('delete table', function () {
+    it('verify delete table', function () {
+      tableToolTile.getTableTile().click();
+      clueCanvas.deleteTile('table');
+    });
   });
 });
 
-after(function () {
-  cy.clearQAData('all');
-});

--- a/cypress/integration/clue/branch/student_tests/text_tool_spec.js
+++ b/cypress/integration/clue/branch/student_tests/text_tool_spec.js
@@ -7,15 +7,15 @@ const clueCanvas = new ClueCanvas;
 const textToolTile = new TextToolTile;
 
 
-before(function(){
-    const queryParams = `${Cypress.config("queryParams")}`;
-
-    cy.clearQAData('all');
-    cy.visit(queryParams);
-    cy.waitForLoad();
-});
-
 context('Text tool tile functionalities', function(){
+    before(function(){
+        const queryParams = `${Cypress.config("queryParams")}`;
+    
+        cy.clearQAData('all');
+        cy.visit(queryParams);
+        cy.waitForLoad();
+    });
+        
     let title;
     before(()=>{
         clueCanvas.getInvestigationCanvasTitle()
@@ -50,8 +50,4 @@ context('Text tool tile functionalities', function(){
         clueCanvas.deleteTile('text');
         textToolTile.getTextTile().should('not.exist');
     });
-});
-
-after(function(){
-  cy.clearQAData('all');
 });

--- a/cypress/integration/clue/branch/student_tests/workspace_test_spec.js
+++ b/cypress/integration/clue/branch/student_tests/workspace_test_spec.js
@@ -5,13 +5,14 @@ const queryParams = `${Cypress.config("queryParams")}`;
 let clueCanvas = new ClueCanvas,
     textToolTile = new TextToolTile;
 
-before(function () {
-  cy.clearQAData('all');
-
-  cy.visit(queryParams);
-  cy.waitForLoad();
-});
 context('Test the overall workspace', function () {
+  before(function () {
+    cy.clearQAData('all');
+  
+    cy.visit(queryParams);
+    cy.waitForLoad();
+  });
+  
   describe('Desktop functionalities', function () {
     it('will verify that clicking on collapsed resource tab opens the nav area', function () {
       cy.get(".collapsed-resources-tab.my-work").click();
@@ -78,8 +79,4 @@ context('Test the overall workspace', function () {
     });
 
   });
-});
-
-after(function () {
-  cy.clearQAData('all');
 });

--- a/cypress/integration/clue/branch/teacher_tests/teacher_chat_spec.js
+++ b/cypress/integration/clue/branch/teacher_tests/teacher_chat_spec.js
@@ -12,294 +12,296 @@ let selectedChatBackground = 'rgb(215, 255, 204)';
 
 const queryParams = "/?appMode=qa&fakeClass=5&fakeOffering=5&problem=2.1&fakeUser=teacher:7&unit=msa";
 
-before(() => {
-  cy.clearQAData('all');
+context('Chat Panel', () => {
+  before(() => {
+    cy.clearQAData('all');
 
-  cy.visit(queryParams);
-  cy.waitForLoad();
-  dashboard.switchView("Workspace & Resources");
-  cy.wait(2000);
-  clueCanvas.getInvestigationCanvasTitle().text().as('investigationTitle');
-});
-beforeEach(() => {
-  cy.fixture("teacher-dash-data-msa-test.json").as("clueData");
-});
-
-describe('Chat panel for networked teacher', () => {
-  it('verify chat panel is accessible if teacher is in network (via url params)', () => {
-    cy.visit("/?appMode=qa&fakeClass=5&fakeOffering=5&problem=2.1&fakeUser=teacher:7&unit=msa&network=foo");
+    cy.visit(queryParams);
     cy.waitForLoad();
     dashboard.switchView("Workspace & Resources");
     cy.wait(2000);
-    resourcesPanel.getCollapsedResourcesTab().click();
-    cy.openTopTab("problems");
-    chatPanel.getChatPanelToggle().should('exist');
+    clueCanvas.getInvestigationCanvasTitle().text().as('investigationTitle');
   });
-  it('verify chat panel opens', () => {
-    chatPanel.getChatPanelToggle().click();
-    chatPanel.getChatPanel().should('exist');
-    chatPanel.getNotificationToggle().should('exist');
-    chatPanel.getChatCloseButton().should('exist').click();
-    chatPanel.getChatPanelToggle().should('exist');
-    chatPanel.getChatPanel().should('not.exist');
+  beforeEach(() => {
+    cy.fixture("teacher-dash-data-msa-test.json").as("clueData");
   });
-  it('verify new comment card is visible, card icon is visible and Post button is disabled', () => {
-    chatPanel.getChatPanelToggle().click();
-    chatPanel.getCommentCard().should('be.visible');
-    chatPanel.getCommentPostButton().should('have.class', 'disabled');
-    chatPanel.getCommentCardHeaderIcon().should('be.visible');
-  });
-  it('verify the comment card and the document are highlighted', () => {
-    chatPanel.verifyProblemCommentClass();
-    chatPanel.getProblemDocumentContent().should('be.visible').should('have.css', 'background-color').and('eq', selectedChatBackground);
-    chatPanel.getCommentCardContent().should('be.visible').should('have.css', 'background-color').and('eq', selectedChatBackground);
-  });
-  it('verify the comment card and tile are highlighted', () => {
-    cy.clickProblemResourceTile('introduction');
-    chatPanel.getCommentCardContent().should('be.visible').should('have.css', 'background-color').and('eq', selectedChatBackground);
-    chatPanel.getToolTile().should('be.visible').should('have.css', 'background-color').and('eq', selectedChatBackground);
-  });
-  it('verify user can cancel a comment', () => {
-    cy.openProblemSection("Introduction");
-    const documentComment = "This comment is for the document.";
-    chatPanel.typeInCommentArea(documentComment);
-    chatPanel.verifyCommentAreaContains(documentComment);
-    chatPanel.getCommentCancelButton().scrollIntoView().click();
-    chatPanel.verifyCommentAreaDoesNotContain(documentComment);
-  });
-  it('verify user can post a comment', () => {
-    const documentComment = "An alert should show this document comment.";
-    chatPanel.addCommentAndVerify(documentComment);
-  });
-  it('verify teacher name and initial appear on comment correctly', () => {
-    chatPanel.getUsernameFromCommentHeader().should('contain', "Teacher 7");
-  });
-  it('verify workspace tab document is highlighted', () => {
-    clueCanvas.getInvestigationCanvasTitle().text().then((title)=>{
-      cy.openTopTab('my-work');
-      cy.openSection('my-work', 'workspaces');
-      cy.openDocumentThumbnail('workspaces', title);
-      chatPanel.verifyDocumentCommentClass();
+
+  describe('Chat panel for networked teacher', () => {
+    it('verify chat panel is accessible if teacher is in network (via url params)', () => {
+      cy.visit("/?appMode=qa&fakeClass=5&fakeOffering=5&problem=2.1&fakeUser=teacher:7&unit=msa&network=foo");
+      cy.waitForLoad();
+      dashboard.switchView("Workspace & Resources");
+      cy.wait(2000);
+      resourcesPanel.getCollapsedResourcesTab().click();
+      cy.openTopTab("problems");
+      chatPanel.getChatPanelToggle().should('exist');
+    });
+    it('verify chat panel opens', () => {
+      chatPanel.getChatPanelToggle().click();
+      chatPanel.getChatPanel().should('exist');
+      chatPanel.getNotificationToggle().should('exist');
+      chatPanel.getChatCloseButton().should('exist').click();
+      chatPanel.getChatPanelToggle().should('exist');
+      chatPanel.getChatPanel().should('not.exist');
+    });
+    it('verify new comment card is visible, card icon is visible and Post button is disabled', () => {
+      chatPanel.getChatPanelToggle().click();
+      chatPanel.getCommentCard().should('be.visible');
+      chatPanel.getCommentPostButton().should('have.class', 'disabled');
+      chatPanel.getCommentCardHeaderIcon().should('be.visible');
+    });
+    it('verify the comment card and the document are highlighted', () => {
+      chatPanel.verifyProblemCommentClass();
+      chatPanel.getProblemDocumentContent().should('be.visible').should('have.css', 'background-color').and('eq', selectedChatBackground);
+      chatPanel.getCommentCardContent().should('be.visible').should('have.css', 'background-color').and('eq', selectedChatBackground);
+    });
+    it('verify the comment card and tile are highlighted', () => {
+      cy.clickProblemResourceTile('introduction');
+      chatPanel.getCommentCardContent().should('be.visible').should('have.css', 'background-color').and('eq', selectedChatBackground);
+      chatPanel.getToolTile().should('be.visible').should('have.css', 'background-color').and('eq', selectedChatBackground);
+    });
+    it('verify user can cancel a comment', () => {
+      cy.openProblemSection("Introduction");
+      const documentComment = "This comment is for the document.";
+      chatPanel.typeInCommentArea(documentComment);
+      chatPanel.verifyCommentAreaContains(documentComment);
+      chatPanel.getCommentCancelButton().scrollIntoView().click();
+      chatPanel.verifyCommentAreaDoesNotContain(documentComment);
+    });
+    it('verify user can post a comment', () => {
+      const documentComment = "An alert should show this document comment.";
+      chatPanel.addCommentAndVerify(documentComment);
+    });
+    it('verify teacher name and initial appear on comment correctly', () => {
+      chatPanel.getUsernameFromCommentHeader().should('contain', "Teacher 7");
+    });
+    it('verify workspace tab document is highlighted', () => {
+      clueCanvas.getInvestigationCanvasTitle().text().then((title)=>{
+        cy.openTopTab('my-work');
+        cy.openSection('my-work', 'workspaces');
+        cy.openDocumentThumbnail('workspaces', title);
+        chatPanel.verifyDocumentCommentClass();
+      });
+    });
+    it("verify escape key empties textarea", () => {
+      chatPanel.typeInCommentArea("this should be erased. {esc}");
+      chatPanel.verifyCommentAreaContains("");
+      chatPanel.verifyCommentThreadDoesNotExist();
+    });
+    it('verify user can use shift+enter to go to the next line and not post', () => {
+      chatPanel.typeInCommentArea("this is the first line. {shift}{enter}");
+      chatPanel.verifyCommentThreadDoesNotExist();
+      chatPanel.typeInCommentArea("this is the second line.");
+      chatPanel.clickPostCommentButton();
+      chatPanel.verifyCommentThreadLength(1);
+      chatPanel.verifyCommentThreadContains("this is the first line.\nthis is the second line.");
+    });
+    it('verify user can use enter to send post', () => {
+      chatPanel.typeInCommentArea("Send this comment after enter.");
+      chatPanel.useEnterToPostComment();
+      chatPanel.verifyCommentThreadLength(2);
+      chatPanel.verifyCommentThreadContains("Send this comment after enter.");
+    });
+    it('verify user can delete a post', () => {
+      const msgToDelete = "Send this comment after enter.";
+      chatPanel.getDeleteMessageButton(msgToDelete).click();
+      chatPanel.getDeleteConfirmModalButton().contains("Delete").click();
+      cy.wait(1000);
+      chatPanel.verifyCommentThreadLength(1);
+      chatPanel.verifyCommentThreadDoesNotContain(msgToDelete);
+    });
+    it("verify commenting on document only shows document comment", () => {
+      cy.openTopTab("problems");
+      chatPanel.verifyProblemCommentClass();
+      chatPanel.addCommentAndVerify("This is a document comment");
+      cy.clickProblemResourceTile('introduction');
+      chatPanel.addCommentAndVerify("This is a tile comment for the first tile");
+      cy.clickProblemResourceTile('introduction', 2);
+      chatPanel.addCommentAndVerify("This is the 3rd tile comment.");
+    });
+    it("verify commenting on tile only shows tile comment", () => {
+      chatPanel.showAndVerifyTileCommentClass(3);
+      chatPanel.verifyCommentThreadDoesNotContain("This is a document comment");
+      chatPanel.verifyCommentThreadDoesNotContain("This is a tile comment for the first tile");
+      chatPanel.verifyCommentThreadContains("This is the 3rd tile comment.");
+      cy.clickProblemResourceTile('introduction');
+      chatPanel.showAndVerifyTileCommentClass();
+      chatPanel.verifyCommentThreadDoesNotContain("This is a document comment");
+      chatPanel.verifyCommentThreadContains("This is a tile comment for the first tile");
+      chatPanel.verifyCommentThreadDoesNotContain("This is the 3rd tile comment.");
+    });
+    it("verify clicking problem section tab shows document comment", () => {
+      cy.openProblemSection("Introduction");
+      chatPanel.verifyProblemCommentClass();
+      chatPanel.verifyTileCommentDoesNotHaveClass();
+      chatPanel.verifyCommentThreadContains("This is a document comment");
+      chatPanel.verifyCommentThreadDoesNotContain("This is a tile comment for the first tile");
+      chatPanel.verifyCommentThreadDoesNotContain("This is the 3rd tile comment.");
+    });
+    it("verify document is selected when switching between tabs", () => {
+      cy.openTopTab("problems");
+      // Open Introduction tab and show tile comment
+      cy.openProblemSection("Introduction");
+      chatPanel.verifyProblemCommentClass();
+      cy.clickProblemResourceTile('introduction');
+      chatPanel.showAndVerifyTileCommentClass();
+      // Open Initial Challenge tab and show tile comment
+      cy.openProblemSection("Initial Challenge");
+      chatPanel.verifyProblemCommentClass();
+      cy.clickProblemResourceTile('initialChallenge');
+      chatPanel.showAndVerifyTileCommentClass();
+      // Return to Introduction tab and make sure document comment and not tile comment is shown
+      cy.openProblemSection("Introduction");
+      chatPanel.verifyProblemCommentClass();
+      chatPanel.verifyTileCommentDoesNotHaveClass();
     });
   });
-  it("verify escape key empties textarea", () => {
-    chatPanel.typeInCommentArea("this should be erased. {esc}");
-    chatPanel.verifyCommentAreaContains("");
-    chatPanel.verifyCommentThreadDoesNotExist();
-  });
-  it('verify user can use shift+enter to go to the next line and not post', () => {
-    chatPanel.typeInCommentArea("this is the first line. {shift}{enter}");
-    chatPanel.verifyCommentThreadDoesNotExist();
-    chatPanel.typeInCommentArea("this is the second line.");
-    chatPanel.clickPostCommentButton();
-    chatPanel.verifyCommentThreadLength(1);
-    chatPanel.verifyCommentThreadContains("this is the first line.\nthis is the second line.");
-  });
-  it('verify user can use enter to send post', () => {
-    chatPanel.typeInCommentArea("Send this comment after enter.");
-    chatPanel.useEnterToPostComment();
-    chatPanel.verifyCommentThreadLength(2);
-    chatPanel.verifyCommentThreadContains("Send this comment after enter.");
-  });
-  it('verify user can delete a post', () => {
-    const msgToDelete = "Send this comment after enter.";
-    chatPanel.getDeleteMessageButton(msgToDelete).click();
-    chatPanel.getDeleteConfirmModalButton().contains("Delete").click();
-    cy.wait(1000);
-    chatPanel.verifyCommentThreadLength(1);
-    chatPanel.verifyCommentThreadDoesNotContain(msgToDelete);
-  });
-  it("verify commenting on document only shows document comment", () => {
-    cy.openTopTab("problems");
-    chatPanel.verifyProblemCommentClass();
-    chatPanel.addCommentAndVerify("This is a document comment");
-    cy.clickProblemResourceTile('introduction');
-    chatPanel.addCommentAndVerify("This is a tile comment for the first tile");
-    cy.clickProblemResourceTile('introduction', 2);
-    chatPanel.addCommentAndVerify("This is the 3rd tile comment.");
-  });
-  it("verify commenting on tile only shows tile comment", () => {
-    chatPanel.showAndVerifyTileCommentClass(3);
-    chatPanel.verifyCommentThreadDoesNotContain("This is a document comment");
-    chatPanel.verifyCommentThreadDoesNotContain("This is a tile comment for the first tile");
-    chatPanel.verifyCommentThreadContains("This is the 3rd tile comment.");
-    cy.clickProblemResourceTile('introduction');
-    chatPanel.showAndVerifyTileCommentClass();
-    chatPanel.verifyCommentThreadDoesNotContain("This is a document comment");
-    chatPanel.verifyCommentThreadContains("This is a tile comment for the first tile");
-    chatPanel.verifyCommentThreadDoesNotContain("This is the 3rd tile comment.");
-  });
-  it("verify clicking problem section tab shows document comment", () => {
-    cy.openProblemSection("Introduction");
-    chatPanel.verifyProblemCommentClass();
-    chatPanel.verifyTileCommentDoesNotHaveClass();
-    chatPanel.verifyCommentThreadContains("This is a document comment");
-    chatPanel.verifyCommentThreadDoesNotContain("This is a tile comment for the first tile");
-    chatPanel.verifyCommentThreadDoesNotContain("This is the 3rd tile comment.");
-  });
-  it("verify document is selected when switching between tabs", () => {
-    cy.openTopTab("problems");
-    // Open Introduction tab and show tile comment
-    cy.openProblemSection("Introduction");
-    chatPanel.verifyProblemCommentClass();
-    cy.clickProblemResourceTile('introduction');
-    chatPanel.showAndVerifyTileCommentClass();
-    // Open Initial Challenge tab and show tile comment
-    cy.openProblemSection("Initial Challenge");
-    chatPanel.verifyProblemCommentClass();
-    cy.clickProblemResourceTile('initialChallenge');
-    chatPanel.showAndVerifyTileCommentClass();
-    // Return to Introduction tab and make sure document comment and not tile comment is shown
-    cy.openProblemSection("Introduction");
-    chatPanel.verifyProblemCommentClass();
-    chatPanel.verifyTileCommentDoesNotHaveClass();
-  });
-});
-describe('Chat panel for all resources', () => {
-  it("verify chat is available on Problem section - Introduction tab", () => {
-    cy.openTopTab("problems");
-    cy.openProblemSection("Introduction");
-    // document comment
-    chatPanel.addCommentAndVerify("This is document comment for problems-section introduction-subsection");
-    // click first tile
-    cy.clickProblemResourceTile('introduction');
-    // tile comment
-    chatPanel.addCommentAndVerify("This is tile comment for problems-section introduction-subsection");
-  });
-  it("verify chat is available on Problem section - Initial Challenge tab", () => {
-    cy.openTopTab("problems");
-    cy.openProblemSection("Initial Challenge");
-    // document comment
-    chatPanel.addCommentAndVerify("This is document comment for problems-section initial-challenge-subsection");
-    // click first tile
-    cy.clickProblemResourceTile('initialChallenge');
-    // tile comment
-    chatPanel.addCommentAndVerify("This is tile comment for problems-section initial-challenge-subsection");
-  });
-  it("verify chat is available on Problem section - What If... tab", () => {
-    cy.openTopTab("problems");
-    cy.openProblemSection("What If...?");
-    // document comment
-    chatPanel.addCommentAndVerify("This is document comment for problems-section what-if-subsection");
-    // click first tile
-    cy.clickProblemResourceTile('whatIf');
-    // tile comment
-    chatPanel.addCommentAndVerify("This is tile comment for problems-section what-if-subsection");
-  });
-  it("verify chat is available on Problem section - Now What Do You Know? tab", () => {
-    cy.openTopTab("problems");
-    cy.openProblemSection("Now What Do You Know?");
-    // document comment
-    chatPanel.addCommentAndVerify("This is document comment for problems-section now-what-subsection");
-    // click first tile
-    cy.clickProblemResourceTile('nowWhatDoYouKnow');
-    // tile comment
-    chatPanel.addCommentAndVerify("This is tile comment for problems-section now-what-subsection");
-  });
-  it("verify chat is available on Teacher Guide section - Overview tab", () => {
-    cy.openTopTab("teacher-guide");
-    cy.openProblemSection('Overview');
-    // document comment
-    chatPanel.addCommentAndVerify("This is document comment for teacher-guide-section overview-subsection");
-    // click first tile
-    cy.clickProblemResourceTile('overview');
-    // tile comment
-    chatPanel.addCommentAndVerify("This is tile comment for teacher-guide-section overview-subsection");
-  });
-  it("verify chat is available on Teacher Guide section - Launch tab", () => {
-    cy.openTopTab("teacher-guide");
-    cy.openProblemSection('Launch');
-    // document comment
-    chatPanel.addCommentAndVerify("This is document comment for teacher-guide-section launch-subsection");
-    // click first tile
-    cy.clickProblemResourceTile('launch');
-    // tile comment
-    chatPanel.addCommentAndVerify("This is tile comment for teacher-guide-section launch-subsection");
-  });
-  it("verify chat is available on Teacher Guide section - Explore tab", () => {
-    cy.openTopTab("teacher-guide");
-    cy.openProblemSection('Explore');
-    // document comment
-    chatPanel.addCommentAndVerify("This is document comment for teacher-guide-section explore-subsection");
-    // click first tile
-    cy.clickProblemResourceTile('explore');
-    // tile comment
-    chatPanel.addCommentAndVerify("This is tile comment for teacher-guide-section explore-subsection");
-  });
-  it("verify chat is available on Teacher Guide section - Summarize tab", () => {
-    cy.openTopTab("teacher-guide");
-    cy.openProblemSection('Summarize');
-    // document comment
-    chatPanel.addCommentAndVerify("This is document comment for teacher-guide-section summarize-subsection");
-    // click first tile
-    cy.clickProblemResourceTile('summarize');
-    // tile comment
-    chatPanel.addCommentAndVerify("This is tile comment for teacher-guide-section summarize-subsection");
-  });
-  it("verify chat is available on My Work section - Workspaces tab", () => {
-    clueCanvas.getInvestigationCanvasTitle().text().then((title)=>{
-      cy.openTopTab('my-work');
-      cy.openSection('my-work', 'workspaces');
-      cy.openDocumentThumbnail('workspaces', title);
+  describe('Chat panel for all resources', () => {
+    it("verify chat is available on Problem section - Introduction tab", () => {
+      cy.openTopTab("problems");
+      cy.openProblemSection("Introduction");
       // document comment
-      chatPanel.addCommentAndVerify("This is document comment for teacher-my-work workspaces-subsection");
+      chatPanel.addCommentAndVerify("This is document comment for problems-section introduction-subsection");
+      // click first tile
+      cy.clickProblemResourceTile('introduction');
+      // tile comment
+      chatPanel.addCommentAndVerify("This is tile comment for problems-section introduction-subsection");
+    });
+    it("verify chat is available on Problem section - Initial Challenge tab", () => {
+      cy.openTopTab("problems");
+      cy.openProblemSection("Initial Challenge");
+      // document comment
+      chatPanel.addCommentAndVerify("This is document comment for problems-section initial-challenge-subsection");
+      // click first tile
+      cy.clickProblemResourceTile('initialChallenge');
+      // tile comment
+      chatPanel.addCommentAndVerify("This is tile comment for problems-section initial-challenge-subsection");
+    });
+    it("verify chat is available on Problem section - What If... tab", () => {
+      cy.openTopTab("problems");
+      cy.openProblemSection("What If...?");
+      // document comment
+      chatPanel.addCommentAndVerify("This is document comment for problems-section what-if-subsection");
+      // click first tile
+      cy.clickProblemResourceTile('whatIf');
+      // tile comment
+      chatPanel.addCommentAndVerify("This is tile comment for problems-section what-if-subsection");
+    });
+    it("verify chat is available on Problem section - Now What Do You Know? tab", () => {
+      cy.openTopTab("problems");
+      cy.openProblemSection("Now What Do You Know?");
+      // document comment
+      chatPanel.addCommentAndVerify("This is document comment for problems-section now-what-subsection");
+      // click first tile
+      cy.clickProblemResourceTile('nowWhatDoYouKnow');
+      // tile comment
+      chatPanel.addCommentAndVerify("This is tile comment for problems-section now-what-subsection");
+    });
+    it("verify chat is available on Teacher Guide section - Overview tab", () => {
+      cy.openTopTab("teacher-guide");
+      cy.openProblemSection('Overview');
+      // document comment
+      chatPanel.addCommentAndVerify("This is document comment for teacher-guide-section overview-subsection");
+      // click first tile
+      cy.clickProblemResourceTile('overview');
+      // tile comment
+      chatPanel.addCommentAndVerify("This is tile comment for teacher-guide-section overview-subsection");
+    });
+    it("verify chat is available on Teacher Guide section - Launch tab", () => {
+      cy.openTopTab("teacher-guide");
+      cy.openProblemSection('Launch');
+      // document comment
+      chatPanel.addCommentAndVerify("This is document comment for teacher-guide-section launch-subsection");
+      // click first tile
+      cy.clickProblemResourceTile('launch');
+      // tile comment
+      chatPanel.addCommentAndVerify("This is tile comment for teacher-guide-section launch-subsection");
+    });
+    it("verify chat is available on Teacher Guide section - Explore tab", () => {
+      cy.openTopTab("teacher-guide");
+      cy.openProblemSection('Explore');
+      // document comment
+      chatPanel.addCommentAndVerify("This is document comment for teacher-guide-section explore-subsection");
+      // click first tile
+      cy.clickProblemResourceTile('explore');
+      // tile comment
+      chatPanel.addCommentAndVerify("This is tile comment for teacher-guide-section explore-subsection");
+    });
+    it("verify chat is available on Teacher Guide section - Summarize tab", () => {
+      cy.openTopTab("teacher-guide");
+      cy.openProblemSection('Summarize');
+      // document comment
+      chatPanel.addCommentAndVerify("This is document comment for teacher-guide-section summarize-subsection");
+      // click first tile
+      cy.clickProblemResourceTile('summarize');
+      // tile comment
+      chatPanel.addCommentAndVerify("This is tile comment for teacher-guide-section summarize-subsection");
+    });
+    it("verify chat is available on My Work section - Workspaces tab", () => {
+      clueCanvas.getInvestigationCanvasTitle().text().then((title)=>{
+        cy.openTopTab('my-work');
+        cy.openSection('my-work', 'workspaces');
+        cy.openDocumentThumbnail('workspaces', title);
+        // document comment
+        chatPanel.addCommentAndVerify("This is document comment for teacher-my-work workspaces-subsection");
+      });
+    });
+    it("verify chat is available on My Work section - Learning Log tab", () => {
+      cy.openTopTab('my-work');
+      cy.openSection('my-work', 'learning-log');
+      cy.openDocumentWithIndex('my-work', 'learning-log', 0);
+      // document comment
+      chatPanel.addCommentAndVerify("This is document comment for teacher-my-work learning-log-subsection");
     });
   });
-  it("verify chat is available on My Work section - Learning Log tab", () => {
-    cy.openTopTab('my-work');
-    cy.openSection('my-work', 'learning-log');
-    cy.openDocumentWithIndex('my-work', 'learning-log', 0);
-    // document comment
-    chatPanel.addCommentAndVerify("This is document comment for teacher-my-work learning-log-subsection");
-  });
-});
-describe('Teachers can communicate back and forth in chat panel', () => {
-  it("verify teacher7 can post document and tile comments", () => {
-    // Teacher 7 document comment
-    cy.openTopTab("problems");
-    cy.openProblemSection("Introduction");
-    chatPanel.verifyProblemCommentClass();
-    chatPanel.addCommentAndVerify("This is a teacher7 document comment");
-    // Teacher 7 tile comment
-    cy.clickProblemResourceTile('introduction');
-    chatPanel.addCommentAndVerify("This is a teacher7 tile comment");
-  });
-  it("verify teacher8 can open clue chat in the same network", () => {
-    // Open clue chat for Teacher 8
-    cy.visit("/?appMode=qa&fakeClass=5&fakeOffering=5&problem=2.1&fakeUser=teacher:8&unit=msa&network=foo");
-    cy.waitForLoad();
-    dashboard.switchView("Workspace & Resources");
-    cy.wait(2000);
-    resourcesPanel.getCollapsedResourcesTab().click();
-    cy.openTopTab("problems");
-    chatPanel.getChatPanelToggle().click();
-  });
-  it("verify teacher8 can view teacher7's comments and add more comments", () => {
-    // Teacher 8 document comment
-    chatPanel.verifyProblemCommentClass();
-    chatPanel.verifyCommentThreadContains("This is a teacher7 document comment");
-    chatPanel.addCommentAndVerify("This is a teacher8 document comment");
-    // Teacher 8 tile comment
-    cy.clickProblemResourceTile('introduction');
-    chatPanel.verifyCommentThreadContains("This is a teacher7 tile comment");
-    chatPanel.addCommentAndVerify("This is a teacher8 tile comment");
-  });
-  it("verify reopening teacher7's clue chat in the same network", () => {
-    // Open clue chat for Teacher 7
-    cy.visit("/?appMode=qa&fakeClass=5&fakeOffering=5&problem=2.1&fakeUser=teacher:7&unit=msa&network=foo");
-    cy.waitForLoad();
-    dashboard.switchView("Workspace & Resources");
-    cy.wait(2000);
-    resourcesPanel.getCollapsedResourcesTab().click();
-    cy.openTopTab("problems");
-    chatPanel.getChatPanelToggle().click();
-  });
-  it("verify teacher7 can view teacher8's comments", () => {
-    // Teacher 7 document comment
-    chatPanel.verifyProblemCommentClass();
-    chatPanel.verifyCommentThreadContains("This is a teacher8 document comment");
-    // Teacher 7 tile comment
-    cy.clickProblemResourceTile('introduction');
-    chatPanel.verifyCommentThreadContains("This is a teacher8 tile comment");
+  describe('Teachers can communicate back and forth in chat panel', () => {
+    it("verify teacher7 can post document and tile comments", () => {
+      // Teacher 7 document comment
+      cy.openTopTab("problems");
+      cy.openProblemSection("Introduction");
+      chatPanel.verifyProblemCommentClass();
+      chatPanel.addCommentAndVerify("This is a teacher7 document comment");
+      // Teacher 7 tile comment
+      cy.clickProblemResourceTile('introduction');
+      chatPanel.addCommentAndVerify("This is a teacher7 tile comment");
+    });
+    it("verify teacher8 can open clue chat in the same network", () => {
+      // Open clue chat for Teacher 8
+      cy.visit("/?appMode=qa&fakeClass=5&fakeOffering=5&problem=2.1&fakeUser=teacher:8&unit=msa&network=foo");
+      cy.waitForLoad();
+      dashboard.switchView("Workspace & Resources");
+      cy.wait(2000);
+      resourcesPanel.getCollapsedResourcesTab().click();
+      cy.openTopTab("problems");
+      chatPanel.getChatPanelToggle().click();
+    });
+    it("verify teacher8 can view teacher7's comments and add more comments", () => {
+      // Teacher 8 document comment
+      chatPanel.verifyProblemCommentClass();
+      chatPanel.verifyCommentThreadContains("This is a teacher7 document comment");
+      chatPanel.addCommentAndVerify("This is a teacher8 document comment");
+      // Teacher 8 tile comment
+      cy.clickProblemResourceTile('introduction');
+      chatPanel.verifyCommentThreadContains("This is a teacher7 tile comment");
+      chatPanel.addCommentAndVerify("This is a teacher8 tile comment");
+    });
+    it("verify reopening teacher7's clue chat in the same network", () => {
+      // Open clue chat for Teacher 7
+      cy.visit("/?appMode=qa&fakeClass=5&fakeOffering=5&problem=2.1&fakeUser=teacher:7&unit=msa&network=foo");
+      cy.waitForLoad();
+      dashboard.switchView("Workspace & Resources");
+      cy.wait(2000);
+      resourcesPanel.getCollapsedResourcesTab().click();
+      cy.openTopTab("problems");
+      chatPanel.getChatPanelToggle().click();
+    });
+    it("verify teacher7 can view teacher8's comments", () => {
+      // Teacher 7 document comment
+      chatPanel.verifyProblemCommentClass();
+      chatPanel.verifyCommentThreadContains("This is a teacher8 document comment");
+      // Teacher 7 tile comment
+      cy.clickProblemResourceTile('introduction');
+      chatPanel.verifyCommentThreadContains("This is a teacher8 tile comment");
+    });
   });
 });

--- a/cypress/integration/clue/branch/teacher_tests/teacher_curation_spec.js
+++ b/cypress/integration/clue/branch/teacher_tests/teacher_curation_spec.js
@@ -4,48 +4,48 @@ import ResourcesPanel from "../../../../support/elements/clue/ResourcesPanel";
 import ClueCanvas from "../../../../support/elements/clue/cCanvas";
 
 
-    let dashboard = new TeacherDashboard();
-    // let primaryWorkspace = new PrimaryWorkspace();
-    let resourcesPanel = new ResourcesPanel();
-    let clueCanvas = new ClueCanvas;
+let dashboard = new TeacherDashboard();
+// let primaryWorkspace = new PrimaryWorkspace();
+let resourcesPanel = new ResourcesPanel();
+let clueCanvas = new ClueCanvas;
 
+describe.skip('verify document curation', function() {//adding a star to a student document
     before(function() {
         const queryParams = "?appMode=demo&demoName=CLUE-Test&fakeClass=5&fakeOffering=5&problem=2.1&fakeUser=teacher:6";
         cy.clearQAData('all');
-
+    
         cy.visit(queryParams);
         cy.waitForLoad();
         dashboard.switchView("Workspace & Resources");
         cy.wait(2000);
         clueCanvas.getInvestigationCanvasTitle().text().as('investigationTitle');
     });
+        
+    let studentDoc = "Student 5: SAS 2.1 Drawing Wumps";
 
-    describe.skip('verify document curation', function() {//adding a star to a student document
-        let studentDoc = "Student 5: SAS 2.1 Drawing Wumps";
-
-        it('verify starring a student published investigation',function(){
-            cy.openResourceTab();
-            cy.openTopTab('class-work');
-            cy.openSection('class-work','workspaces');
-            resourcesPanel.starCanvasItem('class-work','workspaces',studentDoc);
-            resourcesPanel.getCanvasStarIcon('class-work','workspaces',studentDoc).should('have.class','starred');
-            //make sure only one canvas is starred,
-            // but length 2 because there is one in published section and one in Starred section
-            cy.get('.icon-star.starred').should('have.length',2);
-        });
-        it('verify starred document has a star in the dashboard', function(){
-            dashboard.switchView('Dashboard');
-            dashboard.switchWorkView('Published');
-            dashboard.getGroup(1).find('.four-up-overlay .icon-star').should('have.class', 'starred');
-        });
-        it('verify unstar in dashboard unstars in workspace', function(){
-            dashboard.clearAllStarsFromPublishedWork();
-            cy.wait(1000);
-            dashboard.switchView('Workspace & Resources');
-            cy.openTopTab('class-work');
-            cy.openSection('class-work','starred');
-            cy.getCanvasItemTitle('class-work', 'starred', studentDoc).should('not.exist');
-            cy.openSection('class-work','workspaces');
-            resourcesPanel.getCanvasStarIcon('class-work','workspaces',studentDoc).should('not.have.class','starred');
-        });
+    it('verify starring a student published investigation',function(){
+        cy.openResourceTab();
+        cy.openTopTab('class-work');
+        cy.openSection('class-work','workspaces');
+        resourcesPanel.starCanvasItem('class-work','workspaces',studentDoc);
+        resourcesPanel.getCanvasStarIcon('class-work','workspaces',studentDoc).should('have.class','starred');
+        //make sure only one canvas is starred,
+        // but length 2 because there is one in published section and one in Starred section
+        cy.get('.icon-star.starred').should('have.length',2);
     });
+    it('verify starred document has a star in the dashboard', function(){
+        dashboard.switchView('Dashboard');
+        dashboard.switchWorkView('Published');
+        dashboard.getGroup(1).find('.four-up-overlay .icon-star').should('have.class', 'starred');
+    });
+    it('verify unstar in dashboard unstars in workspace', function(){
+        dashboard.clearAllStarsFromPublishedWork();
+        cy.wait(1000);
+        dashboard.switchView('Workspace & Resources');
+        cy.openTopTab('class-work');
+        cy.openSection('class-work','starred');
+        cy.getCanvasItemTitle('class-work', 'starred', studentDoc).should('not.exist');
+        cy.openSection('class-work','workspaces');
+        resourcesPanel.getCanvasStarIcon('class-work','workspaces',studentDoc).should('not.have.class','starred');
+    });
+});

--- a/cypress/integration/clue/branch/teacher_tests/teacher_dashboard_spec.js
+++ b/cypress/integration/clue/branch/teacher_tests/teacher_dashboard_spec.js
@@ -4,22 +4,22 @@ import ClueCanvas from "../../../../support/elements/clue/cCanvas";
 let dashboard = new TeacherDashboard();
 let clueCanvas = new ClueCanvas;
 
-before(() => {
-  const queryParams = "/?appMode=demo&demoName=CLUE-Test&fakeClass=5&fakeOffering=5&problem=2.1&fakeUser=teacher:6";
-  cy.clearQAData('all');
-  cy.visit(queryParams);
-  cy.waitForLoad();
-  dashboard.switchWorkView('Published');
-  cy.wait(8000);
-  dashboard.clearAllStarsFromPublishedWork();
-  dashboard.switchWorkView('Current');
-});
-
-beforeEach(() => {
-  cy.fixture("teacher-dash-data-CLUE-test.json").as("clueData");
-});
-
 context.skip('Teacher Dashboard View', () => {
+  before(() => {
+    const queryParams = "/?appMode=demo&demoName=CLUE-Test&fakeClass=5&fakeOffering=5&problem=2.1&fakeUser=teacher:6";
+    cy.clearQAData('all');
+    cy.visit(queryParams);
+    cy.waitForLoad();
+    dashboard.switchWorkView('Published');
+    cy.wait(8000);
+    dashboard.clearAllStarsFromPublishedWork();
+    dashboard.switchWorkView('Current');
+  });
+  
+  beforeEach(() => {
+    cy.fixture("teacher-dash-data-CLUE-test.json").as("clueData");
+  });
+  
   describe('UI visibility', () => {
     it('verify header elements', () => {
       cy.get('@clueData').then((clueData) => {

--- a/cypress/integration/clue/branch/teacher_tests/teacher_network_spec.js
+++ b/cypress/integration/clue/branch/teacher_tests/teacher_network_spec.js
@@ -8,20 +8,21 @@ let teacherNetwork = new TeacherNetwork;
 
 const queryParams = "/?appMode=qa&fakeClass=5&fakeOffering=5&problem=2.1&fakeUser=teacher:7&unit=msa";
 
-before(() => {
-  cy.clearQAData('all');
-
-  cy.visit(queryParams);
-  cy.waitForLoad();
-  dashboard.switchView("Workspace & Resources");
-  cy.wait(2000);
-  clueCanvas.getInvestigationCanvasTitle().text().as('investigationTitle');
-});
-beforeEach(() => {
-  cy.fixture("teacher-dash-data-msa-test.json").as("clueData");
-});
-
 describe('Networked dividers for networked teacher', () => {
+  before(() => {
+    cy.clearQAData('all');
+  
+    cy.visit(queryParams);
+    cy.waitForLoad();
+    dashboard.switchView("Workspace & Resources");
+    cy.wait(2000);
+    clueCanvas.getInvestigationCanvasTitle().text().as('investigationTitle');
+  });
+  
+  beforeEach(() => {
+    cy.fixture("teacher-dash-data-msa-test.json").as("clueData");
+  });
+    
   it('verify network dividers for teacher in network (via url params)', () => {
     cy.visit("/?appMode=qa&fakeClass=5&fakeOffering=5&problem=2.1&fakeUser=teacher:7&unit=msa&network=foo");
     cy.waitForLoad();

--- a/cypress/integration/clue/branch/teacher_tests/teacher_support_spec.js
+++ b/cypress/integration/clue/branch/teacher_tests/teacher_support_spec.js
@@ -3,6 +3,7 @@ import TeacherDashboard from "../../../../support/elements/clue/TeacherDashboard
 import ClueCanvas from "../../../../support/elements/clue/cCanvas";
 import ResourcesPanel from "../../../../support/elements/clue/ResourcesPanel";
 
+context('Teacher Support', function() {
     let dashboard = new TeacherDashboard();
     // let primaryWorkspace = new PrimaryWorkspace();
     let resourcesPanel = new ResourcesPanel();
@@ -44,10 +45,4 @@ import ResourcesPanel from "../../../../support/elements/clue/ResourcesPanel";
             });
     });
 
-after(function(){
-        const queryParams = `${Cypress.config("teacherQueryParams")}`;
-
-        cy.visit(queryParams);
-        cy.waitForLoad();
-        cy.clearQAData('all');
 });

--- a/cypress/integration/clue/branch/teacher_tests/teacher_workspace_spec.js
+++ b/cypress/integration/clue/branch/teacher_tests/teacher_workspace_spec.js
@@ -15,95 +15,99 @@ let primaryWorkSpace = new PrimaryWorkspace;
 let teacherDoc = "Teacher Investigation Copy";
 const queryParams = "/?appMode=qa&fakeClass=5&fakeOffering=5&problem=2.1&fakeUser=teacher:7&unit=msa";
 
-before(() => {
-  cy.clearQAData('all');
+context('Teacher Workspace', () => {
 
-  cy.visit(queryParams);
-  cy.waitForLoad();
-  dashboard.switchView("Workspace & Resources");
-  cy.wait(2000);
-  clueCanvas.getInvestigationCanvasTitle().text().as('investigationTitle');
-});
-beforeEach(() => {
-  cy.fixture("teacher-dash-data-msa-test.json").as("clueData");
-});
+  before(() => {
+    cy.clearQAData('all');
 
-describe('teacher specific navigation tabs', () => {
-  it('verify problem tab solution switch', () => {
-    cy.get('.collapsed-resources-tab').click();
-    cy.wait(500);
-    cy.get('.top-tab.tab-problems').should('exist').click();
-    cy.get('.prob-tab').contains('What If...?').click();
-    cy.get('[data-test=solutions-button]').should('have.class', "toggled");
-    cy.get('.has-teacher-tiles').should("exist");
-    cy.get('[data-test=solutions-button]').click();
-    cy.get('[data-test=solutions-button]').should('have.not.class', "toggled");
-    cy.get('.has-teacher-tiles').should("not.exist");
-  });
-
-  it('verify teacher guide', () => {
-    cy.get('.top-tab.tab-teacher-guide').should('exist').click({force:true});
-    cy.get('.prob-tab.teacher-guide').should('exist').and('have.length', 4).each(function (subTab, index, subTabList) {
-      const teacherGuideSubTabs = ["Overview", "Launch", "Explore", "Summarize"];
-      cy.wrap(subTab).text().should('contain', teacherGuideSubTabs[index]);
-    });
-  });
-});
-
-describe('teacher document functionality', function () {
-  before(function () {
-    clueCanvas.addTile('table');
-    clueCanvas.addTile('drawing');
-    canvas.copyDocument(teacherDoc);
-    cy.wait(2000);
-    cy.openTopTab("my-work");
-    cy.openDocumentWithTitle('my-work', 'workspaces', teacherDoc);
-    clueCanvas.addTile('table');
-  });
-  it('verify save and restore investigation', function () {
-    cy.openSection("my-work", "workspaces");
-    cy.wait(2000);
-    tableToolTile.getTableTile().should('exist');
-    drawToolTile.getDrawTile().should('exist');
-  });
-  it('verify save and restore extra workspace', function () {
-    cy.openTopTab("my-work");
-    cy.openSection("my-work", "workspaces");
-    cy.getCanvasItemTitle("workspaces").contains(teacherDoc).should('exist');
-    cy.openDocumentWithTitle("my-work", "workspaces", teacherDoc);
-    cy.wait(2000);
-    tableToolTile.getTableTile().should('exist');
-    drawToolTile.getDrawTile().should('exist');
-  });
-  after(function () { //Clean up teacher document and copy
-    canvas.deleteDocument();
-    cy.openTopTab("my-work");
-    cy.openSection('my-work', 'workspaces');
-    clueCanvas.deleteTile('draw');
-    clueCanvas.deleteTile('table');
-  });
-});
-
-describe.skip('Student Workspace', () => { //flaky -- could be because it is trying to connect to firebase?
-  it('verify student workspace tab', () => {
-    cy.visit("/?appMode=demo&demoName=CLUE-Test&fakeClass=5&fakeOffering=5&problem=2.1&fakeUser=teacher:7&unit=msa");
+    cy.visit(queryParams);
     cy.waitForLoad();
     dashboard.switchView("Workspace & Resources");
-    primaryWorkSpace.getResizeRightPanelHandle().click();
     cy.wait(2000);
-    cy.get('@clueData').then((clueData) => {
-      const groups = clueData.classes[0].problems[0].groups;
-      cy.get('.top-tab.tab-student-work').should('exist').click({force:true});
-      cy.get('.student-group-view').should('be.visible');
-      cy.get('.student-group .group-number').should('be.visible').and('have.length', groups.length);
-      cy.get('.student-group .group-number').eq(0).should('have.class', 'active');
-      cy.get('.group-title').should('contain', 'Group 1');
-      cy.get('.canvas-area .four-up .member').should('have.length', 4);
-      cy.get('.canvas-area .four-up .member').eq(0).should('contain', 'S1');
-      cy.get('.student-group .group-number').contains('G3').click();
-      cy.get('.student-group .group-number').eq(2).should('have.class', 'active');
-      cy.get('.group-title').should('contain', 'Group 3');
-      cy.get('.canvas-area .four-up .member').eq(0).should('contain', 'S9');
+    clueCanvas.getInvestigationCanvasTitle().text().as('investigationTitle');
+  });
+  beforeEach(() => {
+    cy.fixture("teacher-dash-data-msa-test.json").as("clueData");
+  });
+
+  describe('teacher specific navigation tabs', () => {
+    it('verify problem tab solution switch', () => {
+      cy.get('.collapsed-resources-tab').click();
+      cy.wait(500);
+      cy.get('.top-tab.tab-problems').should('exist').click();
+      cy.get('.prob-tab').contains('What If...?').click();
+      cy.get('[data-test=solutions-button]').should('have.class', "toggled");
+      cy.get('.has-teacher-tiles').should("exist");
+      cy.get('[data-test=solutions-button]').click();
+      cy.get('[data-test=solutions-button]').should('have.not.class', "toggled");
+      cy.get('.has-teacher-tiles').should("not.exist");
+    });
+
+    it('verify teacher guide', () => {
+      cy.get('.top-tab.tab-teacher-guide').should('exist').click({force:true});
+      cy.get('.prob-tab.teacher-guide').should('exist').and('have.length', 4).each(function (subTab, index, subTabList) {
+        const teacherGuideSubTabs = ["Overview", "Launch", "Explore", "Summarize"];
+        cy.wrap(subTab).text().should('contain', teacherGuideSubTabs[index]);
+      });
     });
   });
+
+  describe('teacher document functionality', function () {
+    before(function () {
+      clueCanvas.addTile('table');
+      clueCanvas.addTile('drawing');
+      canvas.copyDocument(teacherDoc);
+      cy.wait(2000);
+      cy.openTopTab("my-work");
+      cy.openDocumentWithTitle('my-work', 'workspaces', teacherDoc);
+      clueCanvas.addTile('table');
+    });
+    it('verify save and restore investigation', function () {
+      cy.openSection("my-work", "workspaces");
+      cy.wait(2000);
+      tableToolTile.getTableTile().should('exist');
+      drawToolTile.getDrawTile().should('exist');
+    });
+    it('verify save and restore extra workspace', function () {
+      cy.openTopTab("my-work");
+      cy.openSection("my-work", "workspaces");
+      cy.getCanvasItemTitle("workspaces").contains(teacherDoc).should('exist');
+      cy.openDocumentWithTitle("my-work", "workspaces", teacherDoc);
+      cy.wait(2000);
+      tableToolTile.getTableTile().should('exist');
+      drawToolTile.getDrawTile().should('exist');
+    });
+    after(function () { //Clean up teacher document and copy
+      canvas.deleteDocument();
+      cy.openTopTab("my-work");
+      cy.openSection('my-work', 'workspaces');
+      clueCanvas.deleteTile('draw');
+      clueCanvas.deleteTile('table');
+    });
+  });
+
+  describe.skip('Student Workspace', () => { //flaky -- could be because it is trying to connect to firebase?
+    it('verify student workspace tab', () => {
+      cy.visit("/?appMode=demo&demoName=CLUE-Test&fakeClass=5&fakeOffering=5&problem=2.1&fakeUser=teacher:7&unit=msa");
+      cy.waitForLoad();
+      dashboard.switchView("Workspace & Resources");
+      primaryWorkSpace.getResizeRightPanelHandle().click();
+      cy.wait(2000);
+      cy.get('@clueData').then((clueData) => {
+        const groups = clueData.classes[0].problems[0].groups;
+        cy.get('.top-tab.tab-student-work').should('exist').click({force:true});
+        cy.get('.student-group-view').should('be.visible');
+        cy.get('.student-group .group-number').should('be.visible').and('have.length', groups.length);
+        cy.get('.student-group .group-number').eq(0).should('have.class', 'active');
+        cy.get('.group-title').should('contain', 'Group 1');
+        cy.get('.canvas-area .four-up .member').should('have.length', 4);
+        cy.get('.canvas-area .four-up .member').eq(0).should('contain', 'S1');
+        cy.get('.student-group .group-number').contains('G3').click();
+        cy.get('.student-group .group-number').eq(2).should('have.class', 'active');
+        cy.get('.group-title').should('contain', 'Group 3');
+        cy.get('.canvas-area .four-up .member').eq(0).should('contain', 'S9');
+      });
+    });
+  });
+
 });

--- a/cypress/integration/clue/full/student_tests/group_chooser_spec.js
+++ b/cypress/integration/clue/full/student_tests/group_chooser_spec.js
@@ -4,10 +4,6 @@ import ClueHeader from '../../../../support/elements/clue/cHeader';
 const header = new Header;
 const clueHeader = new ClueHeader;
 
-before(() => {
-      cy.clearQAData('all');
-});
-
 describe('Test student join a group', function(){
     let student1 = '20',
         student2 = '21',
@@ -20,7 +16,10 @@ describe('Test student join a group', function(){
         group1='20',
         group2='21';
 
-
+    before(() => {
+        cy.clearQAData('all');
+    });
+      
     function setup(student, alreadyInGroup=false){
         cy.visit('?appMode=qa&fakeClass='+fakeClass+'&fakeUser=student:'+student+'&problem='+problem);
         if (alreadyInGroup) {
@@ -123,7 +122,3 @@ describe('Test student join a group', function(){
         clueHeader.getGroupMembers().should('contain','S'+student1).and('contain','S'+student2).and('contain','S'+student4).and('contain','S'+student6);
     });
 });
-
-after(function(){
-    cy.clearQAData('all');
-  });

--- a/cypress/integration/common/header_test_spec.js
+++ b/cypress/integration/common/header_test_spec.js
@@ -28,8 +28,6 @@ context('Test header elements',()=>{
         header.getUserName().should('exist').and('contain', ((headerInfoObj.fakeUser).split(":"))[1]);
         header.getGroupNumber().should('exist').and('contain', headerInfoObj.qaGroup);
       });
-      // intentional failure
-      cy.get('.foo').should("exist");
     });
   });
 });

--- a/cypress/integration/common/header_test_spec.js
+++ b/cypress/integration/common/header_test_spec.js
@@ -2,34 +2,34 @@ import Header from '../../support/elements/common/Header';
 
 const header = new Header;
 
-before(function(){
+context('Test header elements',()=>{
+  before(function(){
     const baseUrl = `${Cypress.config("baseUrl")}`;
     const queryParams = `${Cypress.config("queryParams")}`;
     cy.clearQAData('all');
 
     cy.visit(baseUrl+queryParams);
-});
-context('Test header elements',()=>{
-    describe('Test header UI',()=>{
-        it('verify correct information is in header elements',()=>{
-          cy.location('search').then((queryParam)=>{
-            const params = (queryParam.split('&'));
-            let headerInfoObj = {};
-            params.forEach((param)=>{
-              let query = (param.split("="));
-              headerInfoObj[query[0]] = query[1];
-            });
-            header.getVersionNumber().should('exist');
-            header.getClassName().should('exist').and('contain', headerInfoObj.fakeClass);
-            header.getUnitTitle().should('exist').and('contain', "Stretching and Shrinking");
-            header.getInvestigationTitle().should('exist').and('contain', 'The Mug Wump Family');
-            header.getProblemTitle().should('exist').and('contain', headerInfoObj.problem);
-            header.getUserName().should('exist').and('contain', ((headerInfoObj.fakeUser).split(":"))[1]);
-            header.getGroupNumber().should('exist').and('contain', headerInfoObj.qaGroup);
-          });
-        });
-    });
-});
-after(function(){
-    cy.clearQAData('all');
   });
+
+  describe('Test header UI',()=>{
+    it('verify correct information is in header elements',()=>{
+      cy.location('search').then((queryParam)=>{
+        const params = (queryParam.split('&'));
+        let headerInfoObj = {};
+        params.forEach((param)=>{
+          let query = (param.split("="));
+          headerInfoObj[query[0]] = query[1];
+        });
+        header.getVersionNumber().should('exist');
+        header.getClassName().should('exist').and('contain', headerInfoObj.fakeClass);
+        header.getUnitTitle().should('exist').and('contain', "Stretching and Shrinking");
+        header.getInvestigationTitle().should('exist').and('contain', 'The Mug Wump Family');
+        header.getProblemTitle().should('exist').and('contain', headerInfoObj.problem);
+        header.getUserName().should('exist').and('contain', ((headerInfoObj.fakeUser).split(":"))[1]);
+        header.getGroupNumber().should('exist').and('contain', headerInfoObj.qaGroup);
+      });
+      // intentional failure
+      cy.get('.foo').should("exist");
+    });
+  });
+});


### PR DESCRIPTION
The specs were using top level before and after hooks in many places. 
When multiple specs are run at the same time, all of these top level hooks are grouped together and run before any of the tests are run.  This blog post describes this in more detail: https://glebbahmutov.com/blog/run-all-specs/

This PR moves all of these into describe or context blocks inside of the spec. It also removes the after blocks, which hopefully aren't really needed. The global after block that is added in `support/index.js` should run after all specs have been run.

Unfortunately, I don't think this will fix any of the CI flakey-ness. I think in that case each spec is run independently.  But maybe I'm wrong, so then this should help somewhat.