### PR TITLE
bring in the latest diagram view library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@blueprintjs/core": "^3.53.0",
-        "@concord-consortium/diagram-view": "^0.0.9",
+        "@concord-consortium/diagram-view": "^0.0.10-beta.2",
         "@concord-consortium/jsxgraph": "^0.99.8-cc.1",
         "@concord-consortium/react-components": "^0.7.1",
         "@concord-consortium/slate-editor": "^0.7.3",
@@ -2056,9 +2056,9 @@
       "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
     },
     "node_modules/@concord-consortium/diagram-view": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.9.tgz",
-      "integrity": "sha512-0gnhYLYAQiDvu/2/gFqsFh/J9xfqd6RzGys19bYT8qWRcagD3n5Zf4id4bfY6oKwuoFda49urcyCw5Eju0VLEQ==",
+      "version": "0.0.10-beta.2",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.10-beta.2.tgz",
+      "integrity": "sha512-1gVwWvJEZUGfqnSs1RbHvoGd5PvmCDAuSeX0zrgWI2ZUHga/pbeWMDHV6fRCmU0LgBhJmI9AsqQluwHD595Q3A==",
       "dependencies": {
         "convert-units": "^3.0.0-beta.3",
         "iframe-phone": "^1.3.1",
@@ -23681,9 +23681,9 @@
       }
     },
     "@concord-consortium/diagram-view": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.9.tgz",
-      "integrity": "sha512-0gnhYLYAQiDvu/2/gFqsFh/J9xfqd6RzGys19bYT8qWRcagD3n5Zf4id4bfY6oKwuoFda49urcyCw5Eju0VLEQ==",
+      "version": "0.0.10-beta.2",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.10-beta.2.tgz",
+      "integrity": "sha512-1gVwWvJEZUGfqnSs1RbHvoGd5PvmCDAuSeX0zrgWI2ZUHga/pbeWMDHV6fRCmU0LgBhJmI9AsqQluwHD595Q3A==",
       "requires": {
         "convert-units": "^3.0.0-beta.3",
         "iframe-phone": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
   },
   "dependencies": {
     "@blueprintjs/core": "^3.53.0",
-    "@concord-consortium/diagram-view": "^0.0.9",
+    "@concord-consortium/diagram-view": "^0.0.10-beta.2",
     "@concord-consortium/jsxgraph": "^0.99.8-cc.1",
     "@concord-consortium/react-components": "^0.7.1",
     "@concord-consortium/slate-editor": "^0.7.3",

--- a/src/plugins/diagram-viewer/diagram-content.ts
+++ b/src/plugins/diagram-viewer/diagram-content.ts
@@ -1,9 +1,10 @@
 import { FlowTransform } from "react-flow-renderer";
-import { getSnapshot, types, Instance } from "mobx-state-tree";
+import { getSnapshot, types, Instance, destroy, flow } from "mobx-state-tree";
 import { ITileExportOptions, IDefaultContentOptions } from "../../models/tools/tool-content-info";
 import { ToolContentModel } from "../../models/tools/tool-types";
 import { kDiagramToolID } from "./diagram-types";
-import { DQRoot } from "@concord-consortium/diagram-view";
+import { DQRoot, VariableType } from "@concord-consortium/diagram-view";
+import { SharedVariables } from "../shared-variables/shared-variables";
 
 // This is only used directly by tests
 export function defaultDiagramContent(options?: IDefaultContentOptions) {
@@ -15,7 +16,8 @@ export const DiagramContentModel = ToolContentModel
   .props({
     type: types.optional(types.literal(kDiagramToolID), kDiagramToolID),
     root: types.optional(DQRoot, getSnapshot(DQRoot.create())),
-    transform: types.maybe(types.frozen<FlowTransform>())
+    transform: types.maybe(types.frozen<FlowTransform>()),
+    sharedModel: types.maybe(SharedVariables)
   })
   .views(self => ({
     exportJson(options?: ITileExportOptions) {
@@ -31,6 +33,50 @@ export const DiagramContentModel = ToolContentModel
   .actions(self => ({
     setTransform(transform: FlowTransform) {
       self.transform = transform;
+    }
+  }))
+  .actions(self => {
+    // This action is needed because the tree monitor and update code isn't in place
+    // yet.
+    const removeVariable = flow(function* removeVariable(variable?: VariableType) {
+      if (variable) {
+        const node = self.root.getNodeFromVariableId(variable.id);
+  
+        destroy(variable);
+  
+        // In order to emulate more of what will happen with the tree monitor
+        // this small delay is added.
+        yield new Promise((resolve) => {
+          setTimeout(resolve, 1);
+        });
+  
+        destroy(node);
+      }
+    });
+
+    return {removeVariable};
+  })
+  .actions(self => ({
+    afterAttach() {
+      if (!self.sharedModel) {
+        self.sharedModel = SharedVariables.create();
+      }
+
+      // When the tree monitor code is in place we can just set the sharedModel 
+      // as the variablesAPI. And the updating of the node when a variable is deleted
+      // will be handled by an update function. 
+      // In the meantime we emulate this effect with an async removeVariable implementation
+      self.root.setVariablesAPI({
+        createVariable(): VariableType {
+          if (!self.sharedModel) {
+            throw new Error("Need a sharedModel to create variables");
+          }
+          return self.sharedModel.createVariable();
+        },
+        removeVariable(variable?: VariableType): void {
+          self.removeVariable(variable);
+        }
+      });
     }
   }));
 

--- a/src/plugins/diagram-viewer/diagram-types.ts
+++ b/src/plugins/diagram-viewer/diagram-types.ts
@@ -1,7 +1,7 @@
 export const kDiagramToolID = "Diagram";
 
 // taken from most recent tag when code was last synced from quantity-playground repo
-export const kQPVersion = "demo-8+";
+export const kQPVersion = "0.0.10-beta.1";
 
 export const kDiagramDefaultWidth = 480;
 export const kDiagramDefaultHeight = 320;

--- a/src/plugins/shared-variables/shared-variables.ts
+++ b/src/plugins/shared-variables/shared-variables.ts
@@ -1,0 +1,29 @@
+import { destroy, Instance, types } from "mobx-state-tree";
+import { Variable, VariableType } from "@concord-consortium/diagram-view";
+
+export const kSharedVariablesID = "SharedVariables";
+
+export const SharedVariables = types
+.model("SharedVariables", {
+  type: types.optional(types.literal(kSharedVariablesID), kSharedVariablesID),
+  variables: types.array(Variable)
+})
+.actions(self => ({
+  addVariable(variable: VariableType) {
+    self.variables.push(variable);
+  },
+
+  removeVariable(variable?: VariableType) {
+    if (variable) {
+      destroy(variable);
+    }
+  }
+}))
+.actions(self => ({
+  createVariable(): VariableType {
+    const variable = Variable.create();
+    self.addVariable(variable);
+    return variable;
+  },
+}));
+export interface SharedVariablesType extends Instance<typeof SharedVariables> {}


### PR DESCRIPTION
To use this latest library it is necessary to have some basic shared variable support.
The state saved by the diagram tile using this interim shared variable support is not
compatible with the old diagram tile. And it also won't be compatible when the real
shared variable support is added.

TODO:
- figure out what to do with the incompatibility
- add test coverage