### PR TITLE
add assertIsDefined to mix typescript and Jest checking

### DIFF
--- a/src/models/tools/tool-tile.test.ts
+++ b/src/models/tools/tool-tile.test.ts
@@ -38,13 +38,7 @@ describe("ToolTileModel", () => {
     it(`supports the tool: ${toolID}`, () => {
       const SpecificToolContentModel = getToolContentInfoById(toolID)?.modelClass;
 
-      if (!SpecificToolContentModel) {
-        // We are throwing here instead of using an expect, so typescript picks
-        // this up as a type guard. 
-        // Perhaps in the future Jest's expect statements can act as assertions
-        // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/41179
-        throw new Error(`Can't find content model for: ${toolID}`);
-      }
+      assertIsDefined(SpecificToolContentModel);
 
       // can create a model with each type of tool
       const content: any = { type: toolID };

--- a/src/plugins/diagram-viewer/diagram-content.test.ts
+++ b/src/plugins/diagram-viewer/diagram-content.test.ts
@@ -41,9 +41,7 @@ describe("DiagramContent", () => {
     content.root.createNode({x: 1, y: 1});
     expect(content.root.nodes.size).toBe(1);
     const newNode = Array.from(content.root.nodes.values())[0]; 
-    if (!newNode) {
-      throw new Error("can't find node that was just added");
-    }
+    assertIsDefined(newNode);
 
     expect(content.sharedModel?.variables.length).toBe(1);
     expect(newNode.x).toBe(1);
@@ -54,9 +52,8 @@ describe("DiagramContent", () => {
     const content = DiagramContentModel.create();
     const container = TestContainer.create({content: castToSnapshot(content)});
     const variablesAPI = container.content.root.variablesAPI;
-    if (!variablesAPI) {
-      throw new Error("variablesAPI not valid");
-    }
+    assertIsDefined(variablesAPI);
+
     const variable = variablesAPI.createVariable();
     expect(variable).toBeDefined();
   });
@@ -89,9 +86,7 @@ describe("DiagramContent", () => {
 
     expect(content.root.nodes.size).toBe(1);
     const firstNode = Array.from(content.root.nodes.values())[0]; 
-    if (!firstNode) {
-      throw new Error("can't find node");
-    }
+    assertIsDefined(firstNode);
 
     expect(content.sharedModel?.variables.length).toBe(1);
     expect(firstNode.variable).toBeDefined();
@@ -100,14 +95,10 @@ describe("DiagramContent", () => {
   it("removeVariable in the variables api removes a variable", (done) => {
     const content = createBasicModel();
     const variablesAPI = content.root.variablesAPI;
-    if (!variablesAPI) {
-      throw new Error("variablesAPI not valid");
-    }
+    assertIsDefined(variablesAPI);
 
     const firstNode = Array.from(content.root.nodes.values())[0]; 
-    if (!firstNode) {
-      throw new Error("can't find node");
-    }
+    assertIsDefined(firstNode);
 
     variablesAPI.removeVariable(firstNode.variable);
 

--- a/src/setupTests.test.ts
+++ b/src/setupTests.test.ts
@@ -17,9 +17,13 @@ describe("setupTests", () => {
     });
 
     it("handled not undefined values", () => {      
+      // `as any` is used here to verify that assertIsDefined is working 
+      // with Typescript correctly. Without `as any` typescript ignores 
+      // the `number | undefined` and just uses `number`. So then `value + 1`
+      // is fine even without the `assertIsDefined`.
       const value: number | undefined = 1 as any;
 
-      // Without this, the next line would have a type error because value could 
+      // Without this, the next line should have a type error because value could 
       // be undefined
       assertIsDefined(value);
 
@@ -27,9 +31,13 @@ describe("setupTests", () => {
     });
 
     it("handled not null values", () => {      
+      // `as any` is used here to verify that assertIsDefined is working 
+      // with Typescript correctly. Without `as any` typescript ignores 
+      // the `number | undefined` and just uses `number`. So then `value + 1`
+      // is fine even without the `assertIsDefined`.      
       const value: number | null = 1 as any;
 
-      // Without this, the next line would have a type error because value could 
+      // Without this, the next line should have a type error because value could 
       // be null
       assertIsDefined(value);
 

--- a/src/setupTests.test.ts
+++ b/src/setupTests.test.ts
@@ -16,7 +16,7 @@ describe("setupTests", () => {
       }).toThrow();
     });
 
-    it("handled not undefined values", () => {      
+    it("handles defined values", () => {      
       // `as any` is used here to verify that assertIsDefined is working 
       // with Typescript correctly. Without `as any` typescript ignores 
       // the `number | undefined` and just uses `number`. So then `value + 1`
@@ -30,7 +30,7 @@ describe("setupTests", () => {
       expect(value + 1).toBe(2);
     });
 
-    it("handled not null values", () => {      
+    it("handles non-null values", () => {      
       // `as any` is used here to verify that assertIsDefined is working 
       // with Typescript correctly. Without `as any` typescript ignores 
       // the `number | undefined` and just uses `number`. So then `value + 1`

--- a/src/setupTests.test.ts
+++ b/src/setupTests.test.ts
@@ -1,0 +1,40 @@
+describe("setupTests", () => {
+  describe("assertIsDefined", () => {
+    it("handles undefined values", () => {
+      const value = undefined;
+
+      expect(() => {
+        assertIsDefined(value);
+      }).toThrow();
+    });
+
+    it("handles null values", () => {
+      const value = null;
+
+      expect(() => {
+        assertIsDefined(value);
+      }).toThrow();
+    });
+
+    it("handled not undefined values", () => {      
+      const value: number | undefined = 1 as any;
+
+      // Without this, the next line would have a type error because value could 
+      // be undefined
+      assertIsDefined(value);
+
+      expect(value + 1).toBe(2);
+    });
+
+    it("handled not null values", () => {      
+      const value: number | null = 1 as any;
+
+      // Without this, the next line would have a type error because value could 
+      // be null
+      assertIsDefined(value);
+
+      expect(value + 1).toBe(2);
+    });
+
+  });
+});

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -55,6 +55,24 @@ interface IJestSpyConsoleOptions {
 declare global {
   // eslint-disable-next-line max-len
   function jestSpyConsole(method: ConsoleMethod, fn: JestSpyConsoleFn, options?: IJestSpyConsoleOptions): Promise<jest.SpyInstance>;
+
+  /**
+   * Use this helper to make sure a variable is defined and not null. 
+   * 
+   * Jest's `expect(value).toBeDefined()` does not tell Typescript that the variable
+   * is guaranteed to be defined afterward. By using assertIsDefined Typescript will 
+   * know the variable is defined and not null. The not null check is included
+   * because the only way I found to do this is using Typescript's NonNullable<T>. 
+   * 
+   * This is based on this: 
+   * https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#assertion-functions
+   * 
+   * Perhaps in the future Jest will support these assertions:
+   * https://github.com/DefinitelyTyped/DefinitelyTyped/issues/41179
+   * 
+   * @param value value to make sure it is defined
+   */
+  function assertIsDefined<T>(value: T): asserts value is NonNullable<T>;
 }
 global.jestSpyConsole = async (method: ConsoleMethod, fn: JestSpyConsoleFn, options?: IJestSpyConsoleOptions) => {
   // intercept and suppress console methods
@@ -80,4 +98,9 @@ global.jestSpyConsole = async (method: ConsoleMethod, fn: JestSpyConsoleFn, opti
   // cast so typescript doesn't complain about legitimate usage
   // using the mock after restore will still generate an error at runtime
   return undefined as any as typeof consoleMethodSpy;
+};
+
+global.assertIsDefined = (value: unknown) => {
+  expect(value).toBeDefined();
+  expect(value).not.toBeNull();
 };


### PR DESCRIPTION
Jest's matches like `expect(value).toBeDefined()` do not tell typescript that the value will be defined afterward. So in future code lines you have to use things like `value.?`

Typescript has support for assertions like this:
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#assertion-functions

The `assertIsDefined` uses this to assert its value is not undefined and not null.
It uses Typescript's assert feature above, and it uses Jest's `toBeDefined` and `not.toBeNull`.

Perhaps in the future Jest's expect statements can act as typescript assertions:
https://github.com/DefinitelyTyped/DefinitelyTyped/issues/41179