### PR TITLE
fix diagram migration

### DIFF
--- a/src/models/mst.test.ts
+++ b/src/models/mst.test.ts
@@ -15,7 +15,10 @@ describe("mst", () => {
     expect(todo2.text).toBe("todo2 text");
 
     const todo1b = Todo1.create();
-    // Is this really expected??
+    // When the type created by the snapshotProcessor (Todo2) is instantiated,
+    // the base type's (Todo1's) create method is modified so it actually goes 
+    // through the processor. This is bug in MST and has been reported here:
+    // https://github.com/mobxjs/mobx-state-tree/issues/1897
     expect(todo1b.text).toBe("todo2 text");
   });
 });

--- a/src/models/mst.test.ts
+++ b/src/models/mst.test.ts
@@ -1,7 +1,7 @@
 import { types } from "mobx-state-tree";
 
 describe("mst", () => {
-  it("does something weird with the snapshotProcessor", () => {
+  it("snapshotProcessor unexpectedly modifies the base type", () => {
     const Todo1 = types.model({ text: types.maybe(types.string) });
     const Todo2 = types.snapshotProcessor(Todo1, {
       preProcessor(sn) {

--- a/src/models/mst.test.ts
+++ b/src/models/mst.test.ts
@@ -1,0 +1,21 @@
+import { types } from "mobx-state-tree";
+
+describe("mst", () => {
+  it("does something weird with the snapshotProcessor", () => {
+    const Todo1 = types.model({ text: types.maybe(types.string) });
+    const Todo2 = types.snapshotProcessor(Todo1, {
+      preProcessor(sn) {
+        return {text: "todo2 text"};
+      }
+    });
+    const todo1a = Todo1.create();
+    expect(todo1a.text).toBeUndefined();
+
+    const todo2 =Todo2.create();
+    expect(todo2.text).toBe("todo2 text");
+
+    const todo1b = Todo1.create();
+    // Is this really expected??
+    expect(todo1b.text).toBe("todo2 text");
+  });
+});

--- a/src/models/tools/tool-tile.test.ts
+++ b/src/models/tools/tool-tile.test.ts
@@ -35,10 +35,12 @@ describe("ToolTileModel", () => {
   const uniqueToolIds = new Set([...registeredToolIds, ...builtInToolIds]);
 
   uniqueToolIds.forEach(toolID => {
+    // It would be useful to extend this with additional tests verifying that tiles
+    // and their content info follow the right patterns
     it(`supports the tool: ${toolID}`, () => {
-      const SpecificToolContentModel = getToolContentInfoById(toolID)?.modelClass;
+      const toolDefaultContent = getToolContentInfoById(toolID)?.defaultContent;
 
-      assertIsDefined(SpecificToolContentModel);
+      assertIsDefined(toolDefaultContent);
 
       // can create a model with each type of tool
       const content: any = { type: toolID };
@@ -47,8 +49,9 @@ describe("ToolTileModel", () => {
       if (toolID === kUnknownToolID) {
         content.originalType = "foo";
       }
+
       let toolTile = ToolTileModel.create({
-                      content: SpecificToolContentModel.create(content)
+                      content: toolDefaultContent()
                     });
       expect(toolTile.content.type).toBe(toolID);
 
@@ -60,21 +63,6 @@ describe("ToolTileModel", () => {
       toolTile = ToolTileModel.create(snapshot);
       expect(toolTile.content.type).toBe(toolID);
 
-    });
-
-    // If we have more tests verifying that Tools follow the right patterns this test
-    // should be moved next to them.
-    it(`${toolID} content models can be created without the type`, () => {
-      const SpecificToolContentModel = getToolContentInfoById(toolID)?.modelClass;
-
-      // can create the model without passing the type
-      const typelessContent: any = {};
-      // UnknownToolModel has required property
-      if (toolID === kUnknownToolID) {
-        typelessContent.originalType = "foo";
-      }
-      const toolContentModel = SpecificToolContentModel?.create(typelessContent);
-      expect(toolContentModel?.type).toBe(toolID);
     });
   });
 

--- a/src/plugins/diagram-viewer/diagram-content.test.ts
+++ b/src/plugins/diagram-viewer/diagram-content.test.ts
@@ -1,6 +1,6 @@
 import { castToSnapshot, isAlive, types } from "mobx-state-tree";
 import { when } from "mobx";
-import { defaultDiagramContent, DiagramContentModel } from "./diagram-content";
+import { createDiagramContent, defaultDiagramContent, DiagramContentModel } from "./diagram-content";
 
 const TestContainer = types.model("TestContainer", {
   content: DiagramContentModel
@@ -13,18 +13,18 @@ describe("DiagramContent", () => {
   });
 
   it("can export content", () => {
-    const content = DiagramContentModel.create();
+    const content = createDiagramContent();
     const expected = JSON.stringify({nodes: {}});
     expect(content.exportJson()).toEqual(expected);
   });
 
   it("is always user resizable", () => {
-    const content = DiagramContentModel.create();
+    const content = createDiagramContent();
     expect(content.isUserResizable).toBe(true);
   });
 
   it("sets up variables api after being attached", () => {
-    const content = DiagramContentModel.create();
+    const content = createDiagramContent();
     const container = TestContainer.create({content: castToSnapshot(content)});
     expect(container.content.root.variablesAPI).toBeDefined();
   });
@@ -32,7 +32,7 @@ describe("DiagramContent", () => {
   // This is more of an integration test because it is testing the innards of 
   // DQRoot, but it exercises code provided by the diagram-content in the process
   it("supports creating Nodes", () => {
-    const content = DiagramContentModel.create();
+    const content = createDiagramContent();
     TestContainer.create({content: castToSnapshot(content)});
 
     expect(content.root.nodes.size).toBe(0);
@@ -49,7 +49,7 @@ describe("DiagramContent", () => {
   });
 
   it("createVariable in the variables api adds a variable", () => {
-    const content = DiagramContentModel.create();
+    const content = createDiagramContent();
     const container = TestContainer.create({content: castToSnapshot(content)});
     const variablesAPI = container.content.root.variablesAPI;
     assertIsDefined(variablesAPI);
@@ -59,7 +59,7 @@ describe("DiagramContent", () => {
   });
 
   const createBasicModel = () => {
-    const content = DiagramContentModel.create({
+    const content = createDiagramContent({
       root: {
         nodes: {
           "node1": {

--- a/src/plugins/diagram-viewer/diagram-content.ts
+++ b/src/plugins/diagram-viewer/diagram-content.ts
@@ -74,7 +74,7 @@ export interface DiagramContentModelType extends Instance<typeof DiagramContentM
 // The migrator sometimes modifies the diagram content model so that its create 
 // method actually goes through the migrator. When that happens if the snapshot doesn't
 // have a version the snapshot will be ignored.
-// This weird migrator behavior is documented here: src/models/mst.test.ts
+// This weird migrator behavior is demonstrated here: src/models/mst.test.ts
 // So because of that this method should be used instead of directly calling create
 export function createDiagramContent(snapshot?: SnapshotIn<typeof DiagramContentModel>) {
   return DiagramContentModel.create({

--- a/src/plugins/diagram-viewer/diagram-content.ts
+++ b/src/plugins/diagram-viewer/diagram-content.ts
@@ -1,14 +1,9 @@
-import { getSnapshot, types, Instance, destroy, flow } from "mobx-state-tree";
+import { getSnapshot, types, Instance, destroy, flow, SnapshotIn } from "mobx-state-tree";
 import { ITileExportOptions, IDefaultContentOptions } from "../../models/tools/tool-content-info";
 import { ToolContentModel } from "../../models/tools/tool-types";
 import { kDiagramToolID, kDiagramToolStateVersion } from "./diagram-types";
 import { DQRoot, VariableType } from "@concord-consortium/diagram-view";
 import { SharedVariables } from "../shared-variables/shared-variables";
-
-// This is only used directly by tests
-export function defaultDiagramContent(options?: IDefaultContentOptions) {
-  return DiagramContentModel.create({ root: getSnapshot(DQRoot.create()) });
-}
 
 export const DiagramContentModel = ToolContentModel
   .named("DiagramTool")
@@ -75,3 +70,21 @@ export const DiagramContentModel = ToolContentModel
   }));
 
 export interface DiagramContentModelType extends Instance<typeof DiagramContentModel> {}
+
+// The migrator sometimes modifies the diagram content model so that its create 
+// method actually goes through the migrator. When that happens if the snapshot doesn't
+// have a version the snapshot will be ignored.
+// This weird migrator behavior is documented here: src/models/mst.test.ts
+// So because of that this method should be used instead of directly calling create
+export function createDiagramContent(snapshot?: SnapshotIn<typeof DiagramContentModel>) {
+  return DiagramContentModel.create({
+    version: kDiagramToolStateVersion,
+    ...snapshot
+  });
+}
+
+export function defaultDiagramContent(options?: IDefaultContentOptions) {
+  return createDiagramContent({ root: getSnapshot(DQRoot.create()) });
+}
+
+

--- a/src/plugins/diagram-viewer/diagram-migrator.ts
+++ b/src/plugins/diagram-viewer/diagram-migrator.ts
@@ -3,7 +3,7 @@ import { DiagramContentModel } from "./diagram-content";
 import { kDiagramToolStateVersion } from "./diagram-types";
 
 // When this model is instantiated it will actually modify DiagramContentModel
-// This is unexpected and is documented here: 
+// This is unexpected and is demonstrated here: 
 // `src/models/mst.test.ts` 
 export const DiagramMigrator = types.snapshotProcessor(DiagramContentModel, {
   preProcessor(snapshot: any) {

--- a/src/plugins/diagram-viewer/diagram-migrator.ts
+++ b/src/plugins/diagram-viewer/diagram-migrator.ts
@@ -2,6 +2,9 @@ import { types } from "mobx-state-tree";
 import { DiagramContentModel } from "./diagram-content";
 import { kDiagramToolStateVersion } from "./diagram-types";
 
+// When this model is instantiated it will actually modify DiagramContentModel
+// This is unexpected and is documented here: 
+// `src/models/mst.test.ts` 
 export const DiagramMigrator = types.snapshotProcessor(DiagramContentModel, {
   preProcessor(snapshot: any) {
     // In the future this can do migration of older states


### PR DESCRIPTION
this also removes a test that was over zealous.
CLUE does not try to create a ContentModel directly it always either:
- loads the state from the document
- uses the content model's defaultContentModel function