### PR TITLE
move sharedModel tile link to sharedModelEntry

### DIFF
--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -53,22 +53,29 @@ export interface ITileCountsPerSection {
   [key: string]: number;
 }
 
-// This intermediate type is added so the SharedModelUnion 
-// can be evaluated late. The issues with using late and maps
-// is documented here: `src/models/mst.test.ts`
-const SharedModelDocEntry = types.model("SharedModelDocEntry", {
-  sharedModel: SharedModelUnion
-});
+// This intermediate type is added so we can store which tiles are using the
+// shared model. It is also necessary so the SharedModelUnion can be evaluated
+// late. If the sharedModelMap was a map directly to SharedModelUnion the late 
+// evaluation would happen immediately and not pick up the registered shared
+// model tiles. This issue with using late and maps is documented here:
+// `src/models/mst.test.ts`
+export const SharedModelEntry = types.model("SharedModelEntry", {
+  sharedModel: SharedModelUnion,
+  tiles: types.array(types.reference(ToolTileModel))
+})
+.actions(self => ({
+  addTile(toolTile: ToolTileModelType) {
+    self.tiles.push(toolTile);
+  }
+}));
 
 export const DocumentContentModel = types
   .model("DocumentContent", {
     rowMap: types.map(TileRowModel),
     rowOrder: types.array(types.string),
     tileMap: types.map(ToolTileModel),
-    // see SharedModelDocEntry above for why that is used instead of directly using
-    // SharedModelUnion. 
     // The keys to this map should be the id of the shared model
-    sharedModelMap: types.map(SharedModelDocEntry),
+    sharedModelMap: types.map(SharedModelEntry),
   })
   .preProcessSnapshot(snapshot => {
     return snapshot && (snapshot as any).tiles
@@ -869,9 +876,18 @@ export const DocumentContentModel = types
   }))
   .actions(self => ({
     addSharedModel(sharedModel: SharedModelType) {
-      self.sharedModelMap.set(sharedModel.id, 
-        SharedModelDocEntry.create({sharedModel}));
-    }
+      // we make sure there isn't an entry already otherwise adding a shared
+      // model twice would clobber the existing entry.
+      let sharedModelEntry = self.sharedModelMap.get(sharedModel.id);
+
+      if (!sharedModelEntry) {
+        sharedModelEntry = SharedModelEntry.create({sharedModel});
+        self.sharedModelMap.set(sharedModel.id, sharedModelEntry);
+      }
+
+      return sharedModelEntry;
+    },
+
   }));
 
 export type DocumentContentModelType = Instance<typeof DocumentContentModel>;

--- a/src/models/mst.test.ts
+++ b/src/models/mst.test.ts
@@ -1,4 +1,4 @@
-import { getType, isType, types } from "mobx-state-tree";
+import { getType, types } from "mobx-state-tree";
 
 describe("mst", () => {
   it("snapshotProcessor unexpectedly modifies the base type", () => {

--- a/src/models/tools/shared-model.ts
+++ b/src/models/tools/shared-model.ts
@@ -92,36 +92,54 @@ export interface ISharedModelManager {
   
   /**
    * Find the shared model at the container level. If the tile wants to use this
-   * shared model it should call `setTileSharedModel` to save a reference to it.
-   * The container needs to know which tiles reference which shared models so it
-   * can update them when the shared model changes.
+   * shared model it should call `addTileSharedModel`. This is necessary so the
+   * container knows call the tile's updateAfterSharedModelChanges action
+   * whenever the shared model changes.
    *
    * @param sharedModelType the MST model "class" of the shared model
    */
   findFirstSharedModelByType<IT extends typeof SharedModelUnion>(sharedModelType: IT): IT["Type"] | undefined;
 
   /**
-   * Get the shared model of this tile. They are labeled so a tile can have
-   * multiple shared models.
+   * Add a shared model to the container if it doesn't exist and add a link to
+   * the tile from the shared model. 
    *
-   * @param tileContentModel normally this would be `self` when called by a tile
-   * @param label a string labeling this shared model
-   */ 
-  getTileSharedModel(tileContentModel: IAnyStateTreeNode, label: string): SharedModelType | undefined;
+   * If the shared model was already part of this container it won't be added to
+   * the container twice. If the shared model already had a link to this tile it
+   * won't be added twice. 
+   *
+   * Tiles need to call this method when they use a shared model. This is how
+   * the container knows to call the tile's updateAfterSharedModelChanges when
+   * the shared model changes.
+   *
+   * Multiple shared models can be added to a single tile. All of these shared
+   * models will be returned by getTileSharedModels. If a tile is using multiple
+   * shared models of the same type, it might want to additionally keep its own
+   * references to these shared models. Without these extra references it would
+   * be hard to tell which shared model is which. 
+   *
+   * @param tileContentModel the tile content model that should be notified when
+   * this shared model changes 
+   *
+   * @param sharedModel the new or existing shared model that is going to be
+   * used by this tile.
+   */
+  addTileSharedModel(tileContentModel: IAnyStateTreeNode, sharedModel: SharedModelType): void;
 
   /**
-   * Tiles should call this after finding or creating shared model they want to
-   * use. If this is a new shared model instance, it will be added to the
-   * container level so other tiles can find it.
+   * Remove the link from the shared model to the tile.
    *
-   * It is important that tiles call this even if they find an existing shared
-   * model with `findFirstSharedModelByType`. The container needs to know which
-   * tiles are referencing which shared models.
-   *
-   * @param tileContentModel normally this would be `self` when called by a tile
-   * @param label a string labeling this shared model
-   * @param sharedModel a new shared model instance or one returned by
-   * `findFirstSharedModelByType`
+   * @param tileContentModel the tile content model that doesn't want to be
+   * notified anymore of shared model changes.
+   * 
+   * @param sharedModel an existing shared model
    */
-  setTileSharedModel(tileContentModel: IAnyStateTreeNode, label: string, sharedModel: SharedModelType): void;
+  removeTileSharedModel(tileContentModel: IAnyStateTreeNode, sharedModel: SharedModelType): void;
+
+  /**
+   * Get all of the shared models that link to this tile
+   * 
+   * @param tileContentModel 
+   */
+  getTileSharedModels(tileContentModel: IAnyStateTreeNode): SharedModelType[];
 }

--- a/src/models/tools/tool-tile.ts
+++ b/src/models/tools/tool-tile.ts
@@ -5,7 +5,6 @@ import { ITileExportOptions } from "./tool-content-info";
 import { findMetadata, ToolContentUnion } from "./tool-types";
 import { DisplayUserTypeEnum } from "../stores/user-types";
 import { uniqueId } from "../../utilities/js-utils";
-import { SharedModelType, SharedModelUnion } from "./shared-model";
 
 // generally negotiated with app, e.g. single column width for table
 export const kDefaultMinWidth = 60;
@@ -34,21 +33,6 @@ export function cloneTileSnapshotWithNewId(tile: ToolTileModelType, newId?: stri
   return { id: newId || uniqueId(), ...copy };
 }
 
-// To support labels, we need an intermediate object.
-// MST requires maps that contain objects with ids to use the id of the object 
-// as the key. So to work around this we've added an intermediate entry.
-// The resulting snapshot should look like:
-// { ...
-//   sharedModels: {
-//     "label1": { sharedModel: "id-of-shared-model"},
-//     "label2": { sharedModel: "id-of-another-shared-model"},
-//   }
-// } 
-const SharedModelEntry = types
-  .model("SharedModelEntry", {
-    sharedModel: types.reference(SharedModelUnion),
-  });
-
 export const ToolTileModel = types
   .model("ToolTile", {
     // if not provided, will be generated
@@ -57,7 +41,6 @@ export const ToolTileModel = types
     display: DisplayUserTypeEnum,
     // e.g. "GeometryContentModel", "ImageContentModel", "TableContentModel", "TextContentModel", ...
     content: ToolContentUnion,
-    sharedModels: types.map(SharedModelEntry),
   })
   .views(self => ({
     // generally negotiated with tool, e.g. single column width for table
@@ -99,11 +82,6 @@ export const ToolTileModel = types
       const metadata: any = findMetadata(self.content.type, self.id);
       metadata && metadata.setDisabledFeatures && metadata.setDisabledFeatures(disabled);
     }    
-  }))
-  .actions(self => ({
-    setSharedModel(label: string, sharedModel: SharedModelType) {
-      self.sharedModels.set(label, SharedModelEntry.create({sharedModel: sharedModel.id}));
-    }
   }));
 
 export type ToolTileModelType = Instance<typeof ToolTileModel>;

--- a/src/models/tools/tool-types.ts
+++ b/src/models/tools/tool-types.ts
@@ -1,5 +1,5 @@
-import { Instance, types } from "mobx-state-tree";
-import { SharedModelType } from "./shared-model";
+import { getEnv, Instance, types } from "mobx-state-tree";
+import { ISharedModelManager, SharedModelType } from "./shared-model";
 import { getToolContentModels, getToolContentInfoById } from "./tool-content-info";
 
 /**
@@ -21,6 +21,10 @@ export const ToolContentUnion = types.late<typeof ToolContentModel>(() => {
 });
 
 export const kUnknownToolID = "Unknown";
+
+export interface ITileEnvironment {
+  sharedModelManager?: ISharedModelManager;
+}
 
 // Generic "super class" of all tool content models
 export const ToolContentModel = types.model("ToolContentModel", {
@@ -50,6 +54,11 @@ export const ToolContentModel = types.model("ToolContentModel", {
     // if a sub type does not override it.
     type: types.optional(types.string, kUnknownToolID)
   })
+  .views(self => ({
+    get tileEnv() {
+      return getEnv(self) as ITileEnvironment | undefined;
+    }
+  }))
   .actions(self => ({
     updateAfterSharedModelChanges(sharedModel?: SharedModelType) {
       throw new Error("not implemented");

--- a/src/plugins/diagram-viewer/diagram-content.test.ts
+++ b/src/plugins/diagram-viewer/diagram-content.test.ts
@@ -16,11 +16,14 @@ const makeSharedModelManager = (variables?: SharedVariablesType): ISharedModelMa
     findFirstSharedModelByType<IT extends IAnyType>(sharedModelType: IT): IT["Type"] | undefined {
       return variables;
     },
-    getTileSharedModel(tileContentModel: IAnyStateTreeNode, label: string): SharedModelType | undefined {
+    addTileSharedModel(tileContentModel: IAnyStateTreeNode): SharedModelType | undefined {
       return variables;
     },
-    setTileSharedModel(tileContentModel: IAnyStateTreeNode, label: string, sharedModel: SharedModelType): void {
+    removeTileSharedModel(tileContentModel: IAnyStateTreeNode, sharedModel: SharedModelType): void {
       // ignore this for now
+    },
+    getTileSharedModels(tileContentModel: IAnyStateTreeNode): SharedModelType[] {
+      return variables ? [variables] : [];
     }
   };
 };
@@ -159,13 +162,13 @@ describe("DiagramContent", () => {
   it("creates the variables shared model, if there isn't one", () => {
     const content = createDiagramContent();
     const sharedModelManager = makeSharedModelManager();
-    const setTileSharedModelSpy = jest.spyOn(sharedModelManager, "setTileSharedModel");
+    const addTileSharedModelSpy = jest.spyOn(sharedModelManager, "addTileSharedModel");
     TestContainer.create(
       {content: castToSnapshot(content)},
       {sharedModelManager}
     );
   
-    expect(setTileSharedModelSpy).toHaveBeenCalled();
+    expect(addTileSharedModelSpy).toHaveBeenCalled();
   });
 
   it("handles off chance that updateAfterSharedModelChanges is called before things are ready", () => {

--- a/src/plugins/diagram-viewer/diagram-content.ts
+++ b/src/plugins/diagram-viewer/diagram-content.ts
@@ -1,12 +1,12 @@
 import { getSnapshot, types, Instance, destroy, SnapshotIn,
-  isValidReference, addDisposer, getPath, getEnv } from "mobx-state-tree";
+  isValidReference, addDisposer, isType, getType } from "mobx-state-tree";
 import { reaction } from "mobx";
 import { DQRoot, DQNode } from "@concord-consortium/diagram-view";
 import { ITileExportOptions, IDefaultContentOptions } from "../../models/tools/tool-content-info";
 import { ToolContentModel } from "../../models/tools/tool-types";
 import { kDiagramToolID, kDiagramToolStateVersion } from "./diagram-types";
 import { SharedVariables, SharedVariablesType } from "../shared-variables/shared-variables";
-import { ISharedModelManager } from "../../models/tools/shared-model";
+import { first } from "lodash";
 
 export const DiagramContentModel = ToolContentModel
   .named("DiagramTool")
@@ -14,6 +14,7 @@ export const DiagramContentModel = ToolContentModel
     type: types.optional(types.literal(kDiagramToolID), kDiagramToolID),
     version: types.optional(types.literal(kDiagramToolStateVersion), kDiagramToolStateVersion),
     root: types.optional(DQRoot, getSnapshot(DQRoot.create())),
+    // sharedModel: types.maybe(types.reference(SharedVariables))
   })
   .views(self => ({
     exportJson(options?: ITileExportOptions) {
@@ -26,10 +27,17 @@ export const DiagramContentModel = ToolContentModel
       return true;
     },
     get sharedModel() {
-      const sharedModelManager = getEnv(self)?.sharedModelManager as ISharedModelManager | undefined;
+      const sharedModelManager = self.tileEnv?.sharedModelManager;
       // Perhaps we should pass the type to getTileSharedModel, so it can return the right value
       // just like findFirstSharedModelByType does
-      return sharedModelManager?.getTileSharedModel(self, "variables") as SharedVariablesType | undefined;
+      //
+      // For now we are checking the type ourselves, and we are assuming the shared model we want
+      // is the first one.
+      const firstSharedModel = sharedModelManager?.getTileSharedModels(self)?.[0];
+      if (!firstSharedModel || getType(firstSharedModel) !== SharedVariables) {
+        return undefined;
+      }
+      return firstSharedModel as SharedVariablesType;
     },
     get positionForNewNode() {
       // In the future this can look at all of the existing nodes and find an empty spot.
@@ -43,24 +51,27 @@ export const DiagramContentModel = ToolContentModel
 
       // Monitor our parents and update our shared model when we have a document parent
       addDisposer(self, reaction(() => {
-        const sharedModelManager = getEnv(self)?.sharedModelManager as ISharedModelManager | undefined;
+        const sharedModelManager = self.tileEnv?.sharedModelManager;
 
-        const tileSharedModel = sharedModelManager?.isReady ? 
-          sharedModelManager?.getTileSharedModel(self, "variables") : undefined;
+        // const tileSharedModel = sharedModelManager?.isReady ? 
+        //   sharedModelManager?.getTileSharedModel(self, "variables") : undefined;
         const containerSharedModel = sharedModelManager?.isReady ?
           sharedModelManager?.findFirstSharedModelByType(SharedVariables) : undefined;
 
-        const values = {sharedModelManager, tileSharedModel, containerSharedModel};
+        const tileSharedModels = sharedModelManager?.isReady ? 
+          sharedModelManager?.getTileSharedModels(self) : undefined;
+
+        const values = {sharedModelManager, containerSharedModel, tileSharedModels};
         return values;
       },
-      ({sharedModelManager, tileSharedModel, containerSharedModel}) => {
+      ({sharedModelManager, containerSharedModel, tileSharedModels}) => {
         if (!sharedModelManager?.isReady) {
           // We aren't added to a document yet so we can't do anything yet
           return;
         }
 
-        if (tileSharedModel && tileSharedModel === containerSharedModel) {
-          // We already have a saved model so we skip some steps
+        if (containerSharedModel && tileSharedModels?.includes(containerSharedModel)) {
+          // We already have a shared model so we skip some steps
           // below. If we don't skip these steps we can get in an infinite 
           // loop.
         } else {
@@ -68,13 +79,23 @@ export const DiagramContentModel = ToolContentModel
             // The document doesn't have a shared model yet
             containerSharedModel = SharedVariables.create();
           } 
-  
-          // CHECKME: this might trigger an pre-mature update because the document's
-          // shared models will be updated first before the tiles. And the update to the
-          // document's shared models will trigger the document level autorun.
-          sharedModelManager.setTileSharedModel(self, "variables", containerSharedModel);  
+          
+          // Add the shared model to both the document and the tile
+          sharedModelManager.addTileSharedModel(self, containerSharedModel);
 
+          // TODO: It would be a better example for future shared model
+          // developers if this also stored a reference to the shared model in
+          // the tile content, this would demonstrate how tiles can work with
+          // multiple shared models at the same time.
+          //
+          // If we do that then this reference probably should be kept in sync
+          // with the tileSharedModels. So if it is removed from there then the 
+          // reference is cleaned up. 
         }
+
+        // We add the shared model as the variables API even if the shared model
+        // was already added to this tile. This is necessary when deserializing
+        // a document from storage.
         self.root.setVariablesAPI(containerSharedModel);
       }, 
       {name: "sharedModelSetup", fireImmediately: true}));


### PR DESCRIPTION
this also:
- adds a type checked getTileEnv view for tiles to use
- switches to a simple array of links to tiles (no more label)
- improves efficiently of notifying tiles of shared model changes
- updates the diagram-content to use the new approach