### PR TITLE
update diagram view to 0.0.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@blueprintjs/core": "^3.53.0",
-        "@concord-consortium/diagram-view": "^0.0.11",
+        "@concord-consortium/diagram-view": "^0.0.12",
         "@concord-consortium/jsxgraph": "^0.99.8-cc.1",
         "@concord-consortium/react-components": "^0.7.1",
         "@concord-consortium/slate-editor": "^0.7.3",
@@ -2056,9 +2056,9 @@
       "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
     },
     "node_modules/@concord-consortium/diagram-view": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.11.tgz",
-      "integrity": "sha512-UBuvvyvSm52CQZk/bkqtIO1tOYfJXBXPJ70UOn8y2ZY9nf8KKv1oNjf+k9FlJtkZcDgeM/PXq3Fmc1pXed4PYg==",
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.12.tgz",
+      "integrity": "sha512-IXbSa5IuSCneGR4WEQEpxbzC4CLX2lRXO/kb3O4xDECfRNOyuNlWP582HNq2mzCVPlZxtT1qwrc7ascOjrMfGg==",
       "dependencies": {
         "iframe-phone": "^1.3.1",
         "mathjs": "^10.4.1",
@@ -23675,9 +23675,9 @@
       }
     },
     "@concord-consortium/diagram-view": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.11.tgz",
-      "integrity": "sha512-UBuvvyvSm52CQZk/bkqtIO1tOYfJXBXPJ70UOn8y2ZY9nf8KKv1oNjf+k9FlJtkZcDgeM/PXq3Fmc1pXed4PYg==",
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.12.tgz",
+      "integrity": "sha512-IXbSa5IuSCneGR4WEQEpxbzC4CLX2lRXO/kb3O4xDECfRNOyuNlWP582HNq2mzCVPlZxtT1qwrc7ascOjrMfGg==",
       "requires": {
         "iframe-phone": "^1.3.1",
         "mathjs": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
   },
   "dependencies": {
     "@blueprintjs/core": "^3.53.0",
-    "@concord-consortium/diagram-view": "^0.0.11",
+    "@concord-consortium/diagram-view": "^0.0.12",
     "@concord-consortium/jsxgraph": "^0.99.8-cc.1",
     "@concord-consortium/react-components": "^0.7.1",
     "@concord-consortium/slate-editor": "^0.7.3",

--- a/src/plugins/diagram-viewer/diagram-migrator.test.ts
+++ b/src/plugins/diagram-viewer/diagram-migrator.test.ts
@@ -1,4 +1,5 @@
 import { DiagramMigrator } from "./diagram-migrator";
+import { kDiagramToolStateVersion } from "./diagram-types";
 
 describe("DiagramMigrator", () => {
   const basicDiagram = {
@@ -15,7 +16,7 @@ describe("DiagramMigrator", () => {
 
   it("loads modern state", () => {
     const migrated = DiagramMigrator.create({
-      version: "0.0.2",
+      version: kDiagramToolStateVersion,
       ...basicDiagram
     });
     expect(migrated.root?.nodes.size).toBe(1);
@@ -24,6 +25,17 @@ describe("DiagramMigrator", () => {
   it("blanks out state without a version", () => {
     jestSpyConsole("warn", mockConsole => {
       const migrated = DiagramMigrator.create(basicDiagram);
+      expect(mockConsole).toHaveBeenCalled();
+      expect(migrated.root?.nodes.size).toBe(0);
+    });
+  });
+
+  it("blanks out state with old version", () => {
+    jestSpyConsole("warn", mockConsole => {
+      const migrated = DiagramMigrator.create({
+        version: "0.0.2",
+        ...basicDiagram
+      });
       expect(mockConsole).toHaveBeenCalled();
       expect(migrated.root?.nodes.size).toBe(0);
     });

--- a/src/plugins/diagram-viewer/diagram-types.ts
+++ b/src/plugins/diagram-viewer/diagram-types.ts
@@ -4,12 +4,12 @@ export const kDiagramToolID = "Diagram";
 // Currently it is just the version of the diagram-view library.
 // TODO: include a version in the diagram-view library so we can reference that
 // instead
-export const kQPVersion = "0.0.11";
+export const kQPVersion = "0.0.12";
 
 // This is a version stored in the state of the tile
 // Currently any state with a different version will be ignored.
 // In the future we can hopefully support migrating older state
-export const kDiagramToolStateVersion = "0.0.2";
+export const kDiagramToolStateVersion = "0.0.3";
 
 export const kDiagramDefaultWidth = 480;
 export const kDiagramDefaultHeight = 320;


### PR DESCRIPTION
this adds multiple input support
It also changes the version of the state stored for the tile.
The new state has an array of inputs so it isn't compatible with the old version.