### PR TITLE
Fix drawing stamp tool

### DIFF
--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -1,5 +1,5 @@
 import { cloneDeep, each } from "lodash";
-import { types, getSnapshot, Instance, SnapshotIn, getType } from "mobx-state-tree";
+import { types, getSnapshot, Instance, SnapshotIn, getType, getEnv } from "mobx-state-tree";
 import { PlaceholderContentModel } from "../tools/placeholder/placeholder-content";
 import { kTextToolID } from "../tools/text/text-content";
 import { getToolContentInfoById, IDocumentExportOptions } from "../tools/tool-content-info";
@@ -14,11 +14,10 @@ import { migrateSnapshot } from "./document-content-import";
 import { IDocumentAddTileOptions } from "./document-types";
 import { Logger, LogEventName } from "../../lib/logger";
 import { IDragTileItem } from "../../models/tools/tool-tile";
-import { DocumentsModelType } from "../stores/documents";
 import { safeJsonParse, uniqueId } from "../../utilities/js-utils";
-import { getParentWithTypeName } from "../../utilities/mst-utils";
 import { comma, StringBuilder } from "../../utilities/string-builder";
 import { SharedModel, SharedModelType, SharedModelUnion } from "../tools/shared-model";
+import { IDocumentEnvironment } from "./document";
 
 export interface INewTileOptions {
   rowHeight?: number;
@@ -708,8 +707,8 @@ export const DocumentContentModel = types
         const contentInfo = getToolContentInfoById(toolId);
         if (!contentInfo) return;
 
-        const documents = getParentWithTypeName(self, "Documents") as DocumentsModelType;
-        const appConfig = documents?.appConfig;
+        const documentEnv = getEnv(self)?.documentEnv as IDocumentEnvironment | undefined;
+        const appConfig = documentEnv?.appConfig;
 
         const newContent = contentInfo?.defaultContent({ title, url, appConfig });
         const tileInfo = self.addTileContentInNewRow(

--- a/src/models/document/document.ts
+++ b/src/models/document/document.ts
@@ -276,6 +276,10 @@ export const getDocumentContext = (document: DocumentModelType): IDocumentContex
   };
 };
 
+export interface IDocumentEnvironment {
+  appConfig?: AppConfigModelType;
+}
+
 /**
  * Create a DocumentModel and add a new sharedModelManager into its environment
  * 
@@ -284,7 +288,8 @@ export const getDocumentContext = (document: DocumentModelType): IDocumentContex
  */
 export const createDocumentModel = (snapshot?: DocumentModelSnapshotType) => {
   const sharedModelManager = createSharedModelDocumentManager();
-  const document = DocumentModel.create(snapshot, {sharedModelManager});
+  const documentEnv: IDocumentEnvironment = {};
+  const document = DocumentModel.create(snapshot, {sharedModelManager, documentEnv});
   if (document.content) {
     sharedModelManager.setDocument(document.content);
   }

--- a/src/models/stores/documents.ts
+++ b/src/models/stores/documents.ts
@@ -1,8 +1,8 @@
 import { forEach } from "lodash";
-import { types } from "mobx-state-tree";
+import { getEnv, types } from "mobx-state-tree";
 import { observable } from "mobx";
 import { AppConfigModelType } from "./app-config-model";
-import { DocumentModelType } from "../document/document";
+import { DocumentModelType, IDocumentEnvironment } from "../document/document";
 import {
   DocumentType, LearningLogDocument, LearningLogPublication, OtherDocumentType, OtherPublicationType,
   PersonalDocument, PersonalPublication, PlanningDocument, ProblemDocument, ProblemPublication
@@ -163,6 +163,10 @@ export const DocumentsModel = types
     const add = (document: DocumentModelType) => {
       if (!self.getDocument(document.key)) {
         self.all.push(document);
+        const documentEnv = getEnv(document)?.documentEnv as IDocumentEnvironment | undefined;
+        if (documentEnv) {
+          documentEnv.appConfig = self.appConfig;
+        }
       }
     };
 

--- a/src/plugins/drawing-tool/components/drawing-toolbar.tsx
+++ b/src/plugins/drawing-tool/components/drawing-toolbar.tsx
@@ -31,7 +31,8 @@ interface IProps extends IFloatingToolbarProps, IRegisterToolApiProps {
   model: ToolTileModelType;
 }
 
-const defaultButtons = ["select", "line", "vector", "rectangle", "ellipse", "delete"];
+const defaultButtons = ["select", "line", "vector", "rectangle", "ellipse", 
+  "stamp", "stroke-color", "fill-color", "delete"];
 
 export const ToolbarView: React.FC<IProps> = (
               { documentContent, model, onIsEnabled, ...others }: IProps) => {


### PR DESCRIPTION
The stamps were not showing up in the drawing tool. This happened because of 2 issues:
1. the default content for the drawing tile was not being passed an appConfig so it couldn't find the configured stamps
2. the stamp tool was not enabled by default on the drawing toolbar

Issue 1 started happened when the document model was made the root of the MST tree. Previously the documents (plural) model was the root of the tree. The appConfig was being looked up by finding a `Documents` parent of the document model. With the change there was no such parent. The fix for this was by using the MST environment to pass the appConfig. 
I wasn't super careful with this approach, but it seems OK.  Perhaps the definition of `IDocumentEnvironment` should be moved.

Issue 2 started happening when the drawing tool was made configurable. For some reason the stroke-color, fill-color, and stamp tools were left out of the default list of tools.  So these tools were all added back into the defaults. Note that the stamp tool will only show up if there are some stamps configured.

[#182287732]