### PR TITLE
Drawing Tile Plugin support

### DIFF
--- a/src/plugins/drawing-tool/components/drawing-layer.tsx
+++ b/src/plugins/drawing-tool/components/drawing-layer.tsx
@@ -77,7 +77,9 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
     this.tools = {};
     const drawingToolInfos = getDrawingToolInfos();
     drawingToolInfos.forEach(info => {
-      this.tools[info.name] = new info.toolClass(this);
+      if (info.toolClass) {
+        this.tools[info.name] = new info.toolClass(this);
+      }
     });
 
     this.currentTool = this.tools.select!;

--- a/src/plugins/drawing-tool/components/drawing-layer.tsx
+++ b/src/plugins/drawing-tool/components/drawing-layer.tsx
@@ -11,10 +11,11 @@ import { observer } from "mobx-react";
 import { ImageContentSnapshotOutType } from "../../../models/tools/image/image-content";
 import { gImageMap } from "../../../models/image-map";
 import { SelectionBox } from "./selection-box";
-import { DrawingObjectType, DrawingTool, HandleObjectHover, IDrawingLayer } from "../objects/drawing-object";
+import { DrawingObjectSnapshot, DrawingObjectType, DrawingTool, 
+  HandleObjectHover, IDrawingLayer } from "../objects/drawing-object";
 import { Point, ToolbarSettings } from "../model/drawing-basic-types";
 import { applyAction, getMembers, getSnapshot, SnapshotOut } from "mobx-state-tree";
-import { DrawingObjectMSTUnion, DrawingObjectSnapshotUnion, 
+import { DrawingObjectMSTUnion,
   getDrawingToolInfos, renderDrawingObject } from "./drawing-object-manager";
 import { ImageObject } from "../objects/image";
 
@@ -207,7 +208,7 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
   public addNewDrawingObject(drawingObject: DrawingObjectType) {
     // FIXME: for now we just get a snapshot to minimize the code changes
     // in the future we'll want to just store the object directly
-    this.sendChange({action: "create", data: getSnapshot(drawingObject) as DrawingObjectSnapshotUnion});
+    this.sendChange({action: "create", data: getSnapshot(drawingObject)});
   }
 
   public setSelectedObjects(selectedObjects: DrawingObjectType[]) {
@@ -559,7 +560,7 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
     }
   }
 
-  private createDrawingObject(data: DrawingObjectSnapshotUnion) {
+  private createDrawingObject(data: DrawingObjectSnapshot) {
     const drawingObjectMST = DrawingObjectMSTUnion.create(data);
     switch (data.type) {
       case "image": {

--- a/src/plugins/drawing-tool/components/drawing-layer.tsx
+++ b/src/plugins/drawing-tool/components/drawing-layer.tsx
@@ -12,7 +12,7 @@ import { ImageContentSnapshotOutType } from "../../../models/tools/image/image-c
 import { gImageMap } from "../../../models/image-map";
 import { SelectionBox } from "./selection-box";
 import { DrawingObjectSnapshot, DrawingObjectType, DrawingTool, 
-  HandleObjectHover, IDrawingLayer } from "../objects/drawing-object";
+  HandleObjectHover } from "../objects/drawing-object";
 import { Point, ToolbarSettings } from "../model/drawing-basic-types";
 import { applyAction, getMembers, getSnapshot, SnapshotOut } from "mobx-state-tree";
 import { DrawingObjectMSTUnion,
@@ -25,54 +25,6 @@ const SELECTION_BOX_PADDING = 10;
 
 function makeSetter(prop: string) {
   return "set" + prop.charAt(0).toUpperCase() + prop.slice(1);
-}
-
-/**  ======= Drawing Tools ======= */
-class SelectionDrawingTool extends DrawingTool {
-  constructor(drawingLayer: IDrawingLayer) {
-    super(drawingLayer);
-  }
-
-  public handleMouseDown(e: React.MouseEvent<HTMLDivElement>) {
-    // We are internal so we can use some private stuff not exposed by 
-    // IDrawingLayer
-    const drawingLayerView = this.drawingLayer as DrawingLayerView;
-    const addToSelectedObjects = e.ctrlKey || e.metaKey;
-    const start = this.drawingLayer.getWorkspacePoint(e);
-    if (!start) return;
-    drawingLayerView.startSelectionBox(start);
-
-    const handleMouseMove = (e2: MouseEvent) => {
-      e2.preventDefault();
-      const p = this.drawingLayer.getWorkspacePoint(e2);
-      if (!p) return;
-      drawingLayerView.updateSelectionBox(p);
-    };
-    const handleMouseUp = (e2: MouseEvent) => {
-      e2.preventDefault();
-      drawingLayerView.endSelectionBox(addToSelectedObjects);
-      window.removeEventListener("mousemove", handleMouseMove);
-      window.removeEventListener("mouseup", handleMouseUp);
-    };
-
-    window.addEventListener("mousemove", handleMouseMove);
-    window.addEventListener("mouseup", handleMouseUp);
-  }
-
-  public handleObjectClick(e: React.MouseEvent<HTMLDivElement>, obj: DrawingObjectType) {
-    // We are internal so we can use some private stuff not exposed by 
-    // IDrawingLayer
-    const drawingLayerView = this.drawingLayer as DrawingLayerView;
-    const {selectedObjects} = drawingLayerView.state;
-    const index = selectedObjects.indexOf(obj);
-    if (index === -1) {
-      selectedObjects.push(obj);
-    }
-    else {
-      selectedObjects.splice(index, 1);
-    }
-    drawingLayerView.setSelectedObjects(selectedObjects);
-  }
 }
 
 /**  ======= Drawing Layer ======= */
@@ -122,15 +74,13 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
       hoverObject: null,
     };
 
-    this.tools = {
-      selection: new SelectionDrawingTool(this)
-    };
+    this.tools = {};
     const drawingToolInfos = getDrawingToolInfos();
     drawingToolInfos.forEach(info => {
       this.tools[info.name] = new info.toolClass(this);
     });
 
-    this.currentTool = this.tools.selection!;
+    this.currentTool = this.tools.select!;
 
     this.objects = {};
 
@@ -178,9 +128,7 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
 
   public syncCurrentTool(selectedButton: string) {
     const settings = this.getContent().toolbarSettings;
-
-    const toolName = selectedButton === "select" ? "selection" : selectedButton;
-    const tool = this.tools[toolName];
+    const tool = this.tools[selectedButton];
     
     if (!tool) {
       console.warn("Unknown tool selected", selectedButton);
@@ -254,7 +202,7 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
   };
 
   public handleObjectHover: HandleObjectHover = (e, obj, hovering) => {
-    if (!this.props.readOnly && this.currentTool === this.tools.selection) {
+    if (!this.props.readOnly && this.currentTool === this.tools.select) {
       this.setState({hoverObject: hovering ? obj : null});
     }
   };

--- a/src/plugins/drawing-tool/components/drawing-object-manager.tsx
+++ b/src/plugins/drawing-tool/components/drawing-object-manager.tsx
@@ -1,28 +1,27 @@
-import { types } from "mobx-state-tree";
+import { SnapshotIn, types } from "mobx-state-tree";
 import React from "react";
-import { VariableChipComponent, VariableChipObject, 
+import {  
   VariableChipObjectSnapshot, 
-  VariableDrawingTool} from "../../shared-variables/drawing/variable-object";
+} from "../../shared-variables/drawing/variable-object";
 import { DrawingContentModelType } from "../model/drawing-content";
 import { DrawingComponentType, DrawingObject, DrawingObjectType, 
   DrawingTool, HandleObjectHover, IDrawingLayer, IToolbarButtonProps } from "../objects/drawing-object";
-import { EllipseComponent, EllipseDrawingTool, EllipseObject, EllipseObjectSnapshot } from "../objects/ellipse";
+import { EllipseComponent, EllipseDrawingTool, EllipseObject, 
+  EllipseObjectSnapshot, EllipseToolbarButton } from "../objects/ellipse";
 import { ImageComponent, ImageObject, ImageObjectSnapshot, 
   StampDrawingTool, StampToolbarButton } from "../objects/image";
 import { LineComponent, LineDrawingTool, LineObject, LineObjectSnapshot, LineToolbarButton } from "../objects/line";
 import { RectangleComponent, RectangleDrawingTool, RectangleObject, 
-  RectangleObjectSnapshot } from "../objects/rectangle";
-import { VectorComponent, VectorDrawingTool, VectorObject, VectorObjectSnapshot } from "../objects/vector";
+  RectangleObjectSnapshot, 
+  RectangleToolbarButton} from "../objects/rectangle";
+import { VectorComponent, VectorDrawingTool, VectorObject, 
+  VectorObjectSnapshot, VectorToolbarButton } from "../objects/vector";
 
 // FIXME: the other info object should be renamed
 export interface IDrawingObjectInfo2 {
   type: string;
   component: DrawingComponentType;
   modelClass: typeof DrawingObject;
-  // using a simple `typeof DrawingTool` can't be used because that type
-  // is an abstract class so can't be instantiated. 
-  toolClass: { new(drawingLayer: IDrawingLayer): DrawingTool };
-  toolbarButtons?: Record<string, React.ComponentType<IToolbarButtonProps>>
 }
 
 export interface IDrawingToolInfo {
@@ -38,37 +37,26 @@ const gDrawingObjectInfos: Record<string, IDrawingObjectInfo2 | undefined> = {
     type: "line",
     component: LineComponent,
     modelClass: LineObject,
-    toolClass: LineDrawingTool,
-    toolbarButtons: {
-      "line": LineToolbarButton
-    }
   },
   vector: {
     type: "vector",
     component: VectorComponent,
     modelClass: VectorObject,
-    toolClass: VectorDrawingTool
   },
   rectangle: {
     type: "rectangle",
     component: RectangleComponent,
     modelClass: RectangleObject,
-    toolClass: RectangleDrawingTool
   },
   ellipse: {
     type: "ellipse",
     component: EllipseComponent,
     modelClass: EllipseObject,
-    toolClass: EllipseDrawingTool
   },
   image: {
     type: "image",
     component: ImageComponent,
     modelClass: ImageObject,
-    toolClass: StampDrawingTool,
-    toolbarButtons: {
-      "stamp": StampToolbarButton
-    }
   }
 };
 
@@ -80,15 +68,18 @@ const gDrawingToolInfos: Record<string, IDrawingToolInfo | undefined> = {
   },
   vector: {
     name: "vector",
-    toolClass: VectorDrawingTool
+    toolClass: VectorDrawingTool,
+    buttonComponent: VectorToolbarButton
   },
   rectangle: {
     name: "rectangle",
-    toolClass: RectangleDrawingTool
+    toolClass: RectangleDrawingTool,
+    buttonComponent: RectangleToolbarButton
   },
   ellipse: {
     name: "ellipse",
-    toolClass: EllipseDrawingTool
+    toolClass: EllipseDrawingTool,
+    buttonComponent: EllipseToolbarButton
   },
   stamp: {
     name: "stamp",
@@ -101,17 +92,6 @@ export function getDrawingToolInfos() {
   return Object.values(gDrawingToolInfos).filter(value => value) as IDrawingToolInfo[];
 }
 
-export function registerDrawingObjectInfo(drawingObjectInfo: IDrawingObjectInfo2) {
-  gDrawingObjectInfos[drawingObjectInfo.type] = drawingObjectInfo;
-}
-
-registerDrawingObjectInfo({
-  type: "variable",
-  component:VariableChipComponent,
-  modelClass: VariableChipObject,
-  toolClass: VariableDrawingTool
-});
-
 export function getDrawingObjectInfos() {
   return Object.values(gDrawingObjectInfos).filter(value => value) as IDrawingObjectInfo2[];
 }
@@ -119,6 +99,18 @@ export function getDrawingObjectInfos() {
 export function getDrawingObjectComponent(drawingObject: DrawingObjectType) {
   const info = gDrawingObjectInfos[drawingObject.type];
   return info?.component;
+}
+
+export function getDrawingToolButtonComponent(toolName: string) {
+  return gDrawingToolInfos[toolName]?.buttonComponent;
+}
+
+export function registerDrawingObjectInfo(drawingObjectInfo: IDrawingObjectInfo2) {
+  gDrawingObjectInfos[drawingObjectInfo.type] = drawingObjectInfo;
+}
+
+export function registerDrawingToolInfo(drawingToolInfo: IDrawingToolInfo) {
+  gDrawingToolInfos[drawingToolInfo.name] = drawingToolInfo;
 }
 
 export function renderDrawingObject(drawingObject: DrawingObjectType, drawingContent: DrawingContentModelType, 

--- a/src/plugins/drawing-tool/components/drawing-object-manager.tsx
+++ b/src/plugins/drawing-tool/components/drawing-object-manager.tsx
@@ -9,7 +9,7 @@ import { LineComponent, LineDrawingTool, LineObject, LineToolbarButton } from ".
 import { RectangleComponent, RectangleDrawingTool, RectangleObject,  
   RectangleToolbarButton} from "../objects/rectangle";
 import { VectorComponent, VectorDrawingTool, VectorObject, VectorToolbarButton } from "../objects/vector";
-import { SelectToolbarButton } from "./drawing-toolbar-buttons";
+import { DeleteButton, SelectToolbarButton } from "./drawing-toolbar-buttons";
 import { SelectionDrawingTool } from "./selection-drawing-tool";
 
 export interface IDrawingObjectInfo {
@@ -22,7 +22,7 @@ export interface IDrawingToolInfo {
   name: string;
   // using a simple `typeof DrawingTool` can't be used because that type
   // is an abstract class so can't be instantiated. 
-  toolClass: { new(drawingLayer: IDrawingLayer): DrawingTool };
+  toolClass?: { new(drawingLayer: IDrawingLayer): DrawingTool };
   buttonComponent: React.ComponentType<IToolbarButtonProps>;
 }
 
@@ -84,6 +84,10 @@ const gDrawingToolInfos: Record<string, IDrawingToolInfo | undefined> = {
     name: "stamp",
     toolClass: StampDrawingTool,
     buttonComponent: StampToolbarButton
+  },
+  delete: {
+    name: "delete",
+    buttonComponent: DeleteButton
   }
 };
 

--- a/src/plugins/drawing-tool/components/drawing-object-manager.tsx
+++ b/src/plugins/drawing-tool/components/drawing-object-manager.tsx
@@ -23,7 +23,7 @@ export interface IDrawingToolInfo {
   // using a simple `typeof DrawingTool` can't be used because that type
   // is an abstract class so can't be instantiated. 
   toolClass: { new(drawingLayer: IDrawingLayer): DrawingTool };
-  buttonComponent?: React.ComponentType<IToolbarButtonProps>;
+  buttonComponent: React.ComponentType<IToolbarButtonProps>;
 }
 
 const gDrawingObjectInfos: Record<string, IDrawingObjectInfo | undefined> = {

--- a/src/plugins/drawing-tool/components/drawing-object-manager.tsx
+++ b/src/plugins/drawing-tool/components/drawing-object-manager.tsx
@@ -9,6 +9,8 @@ import { LineComponent, LineDrawingTool, LineObject, LineToolbarButton } from ".
 import { RectangleComponent, RectangleDrawingTool, RectangleObject,  
   RectangleToolbarButton} from "../objects/rectangle";
 import { VectorComponent, VectorDrawingTool, VectorObject, VectorToolbarButton } from "../objects/vector";
+import { SelectToolbarButton } from "./drawing-toolbar-buttons";
+import { SelectionDrawingTool } from "./selection-drawing-tool";
 
 export interface IDrawingObjectInfo {
   type: string;
@@ -53,6 +55,11 @@ const gDrawingObjectInfos: Record<string, IDrawingObjectInfo | undefined> = {
 };
 
 const gDrawingToolInfos: Record<string, IDrawingToolInfo | undefined> = {
+  select: {
+    name: "select",
+    toolClass: SelectionDrawingTool,
+    buttonComponent: SelectToolbarButton
+  },
   line: {
     name: "line",
     toolClass: LineDrawingTool,

--- a/src/plugins/drawing-tool/components/drawing-object-manager.tsx
+++ b/src/plugins/drawing-tool/components/drawing-object-manager.tsx
@@ -1,24 +1,16 @@
-import { SnapshotIn, types } from "mobx-state-tree";
+import { types } from "mobx-state-tree";
 import React from "react";
-import {  
-  VariableChipObjectSnapshot, 
-} from "../../shared-variables/drawing/variable-object";
 import { DrawingContentModelType } from "../model/drawing-content";
 import { DrawingComponentType, DrawingObject, DrawingObjectType, 
   DrawingTool, HandleObjectHover, IDrawingLayer, IToolbarButtonProps } from "../objects/drawing-object";
-import { EllipseComponent, EllipseDrawingTool, EllipseObject, 
-  EllipseObjectSnapshot, EllipseToolbarButton } from "../objects/ellipse";
-import { ImageComponent, ImageObject, ImageObjectSnapshot, 
-  StampDrawingTool, StampToolbarButton } from "../objects/image";
-import { LineComponent, LineDrawingTool, LineObject, LineObjectSnapshot, LineToolbarButton } from "../objects/line";
-import { RectangleComponent, RectangleDrawingTool, RectangleObject, 
-  RectangleObjectSnapshot, 
+import { EllipseComponent, EllipseDrawingTool, EllipseObject, EllipseToolbarButton } from "../objects/ellipse";
+import { ImageComponent, ImageObject, StampDrawingTool, StampToolbarButton } from "../objects/image";
+import { LineComponent, LineDrawingTool, LineObject, LineToolbarButton } from "../objects/line";
+import { RectangleComponent, RectangleDrawingTool, RectangleObject,  
   RectangleToolbarButton} from "../objects/rectangle";
-import { VectorComponent, VectorDrawingTool, VectorObject, 
-  VectorObjectSnapshot, VectorToolbarButton } from "../objects/vector";
+import { VectorComponent, VectorDrawingTool, VectorObject, VectorToolbarButton } from "../objects/vector";
 
-// FIXME: the other info object should be renamed
-export interface IDrawingObjectInfo2 {
+export interface IDrawingObjectInfo {
   type: string;
   component: DrawingComponentType;
   modelClass: typeof DrawingObject;
@@ -32,7 +24,7 @@ export interface IDrawingToolInfo {
   buttonComponent?: React.ComponentType<IToolbarButtonProps>;
 }
 
-const gDrawingObjectInfos: Record<string, IDrawingObjectInfo2 | undefined> = {
+const gDrawingObjectInfos: Record<string, IDrawingObjectInfo | undefined> = {
   line: {
     type: "line",
     component: LineComponent,
@@ -93,7 +85,7 @@ export function getDrawingToolInfos() {
 }
 
 export function getDrawingObjectInfos() {
-  return Object.values(gDrawingObjectInfos).filter(value => value) as IDrawingObjectInfo2[];
+  return Object.values(gDrawingObjectInfos).filter(value => value) as IDrawingObjectInfo[];
 }
 
 export function getDrawingObjectComponent(drawingObject: DrawingObjectType) {
@@ -105,7 +97,7 @@ export function getDrawingToolButtonComponent(toolName: string) {
   return gDrawingToolInfos[toolName]?.buttonComponent;
 }
 
-export function registerDrawingObjectInfo(drawingObjectInfo: IDrawingObjectInfo2) {
+export function registerDrawingObjectInfo(drawingObjectInfo: IDrawingObjectInfo) {
   gDrawingObjectInfos[drawingObjectInfo.type] = drawingObjectInfo;
 }
 
@@ -121,18 +113,6 @@ export function renderDrawingObject(drawingObject: DrawingObjectType, drawingCon
       drawingContent={drawingContent} handleHover={handleHover}/> 
     : null;
 }
-
-
-
-// FIXME: this is temporary, to support plugin based objects
-// we can't use a static union. 
-export type DrawingObjectSnapshotUnion = 
-  LineObjectSnapshot  |
-  VectorObjectSnapshot  |
-  RectangleObjectSnapshot  |
-  EllipseObjectSnapshot  |
-  ImageObjectSnapshot  |
-  VariableChipObjectSnapshot;
 
 export const DrawingObjectMSTUnion = types.late<typeof DrawingObject>(() => {
   const drawingObjectModels = Object.values(gDrawingObjectInfos).map(info => info!.modelClass);

--- a/src/plugins/drawing-tool/components/drawing-toolbar-buttons.tsx
+++ b/src/plugins/drawing-tool/components/drawing-toolbar-buttons.tsx
@@ -4,27 +4,14 @@ import { Tooltip } from "react-tippy";
 import { computeStrokeDashArray, DrawingContentModelType } from "../model/drawing-content";
 import { ToolbarModalButton } from "../model/drawing-types";
 import { ToolbarSettings } from "../model/drawing-basic-types";
+import SelectToolIcon from "../../../clue/assets/icons/select-tool.svg";
 import ColorFillIcon from "../../../clue/assets/icons/drawing/color-fill-icon.svg";
 import ColorStrokeIcon from "../../../clue/assets/icons/drawing/color-stroke-icon.svg";
 import DeleteSelectionIcon from "../../../assets/icons/delete/delete-selection-icon.svg";
-import FreehandToolIcon from "../../../clue/assets/icons/drawing/freehand-icon.svg";
-import EllipseToolIcon from "../../../clue/assets/icons/drawing/ellipse-icon.svg";
-import LineToolIcon from "../../../clue/assets/icons/drawing/line-icon.svg";
-import RectToolIcon from "../../../clue/assets/icons/drawing/rectangle-icon.svg";
-import SelectToolIcon from "../../../clue/assets/icons/select-tool.svg";
-import VariableToolIcon from "../../../clue/assets/icons/variable-tool.svg";
 import { useTooltipOptions } from "../../../hooks/use-tooltip-options";
 import { isLightColorRequiringContrastOffset } from "../../../utilities/color-utils";
 import { observer } from "mobx-react";
-
-const svgIcons: Record<string, React.FC<React.SVGProps<SVGSVGElement>>> = {
-  ellipse: EllipseToolIcon,
-  line: FreehandToolIcon,
-  rectangle: RectToolIcon,
-  select: SelectToolIcon,
-  vector: LineToolIcon,
-  variable: VariableToolIcon,
-};
+import { IToolbarButtonProps } from "../objects/drawing-object";
 
 interface IButtonClasses {
   modalButton?: ToolbarModalButton;
@@ -73,26 +60,6 @@ export const SvgToolbarButton: React.FC<ISvgToolbarButtonProps> = ({
 /*
  * SvgToolModeButton
  */
-interface ISvgToolModeButtonProps {
-  modalButton: ToolbarModalButton;
-  selected?: boolean;
-  settings: Partial<ToolbarSettings>;
-  title: string;
-  onSetSelectedButton: (modalButton: ToolbarModalButton) => void;
-}
-export const SvgToolModeButton: React.FC<ISvgToolModeButtonProps> = ({
-  modalButton, onSetSelectedButton, ...others
-}) => {
-  const SvgIcon = modalButton && svgIcons[modalButton];
-  const handleClick = () => onSetSelectedButton?.(modalButton);
-  return SvgIcon
-    ? <SvgToolbarButton SvgIcon={SvgIcon} buttonClass={modalButton} onClick={handleClick} {...others} />
-    : null;
-};
-
-/*
- * SvgToolModeButton
- */
 interface ISvgToolModeButtonProps2 {
   SvgIcon: React.FC<React.SVGProps<SVGSVGElement>>;
   drawingContent: DrawingContentModelType;
@@ -112,6 +79,11 @@ export const SvgToolModeButton2: React.FC<ISvgToolModeButtonProps2> = observer(f
   return <SvgToolbarButton SvgIcon={SvgIcon} buttonClass={modalButton} onClick={handleClick} 
     selected={selected} settings={_settings} {...others} />;
 });
+
+export const SelectToolbarButton: React.FC<IToolbarButtonProps> = ({drawingContent}) => {
+  return <SvgToolModeButton2 modalButton="select" title="Select"
+    drawingContent={drawingContent} SvgIcon={SelectToolIcon} settings={{}}/>;
+};
 
 interface IColorButtonProps {
   settings: Partial<ToolbarSettings>;
@@ -137,13 +109,4 @@ interface IDeleteToolButtonProps {
 }
 export const DeleteButton: React.FC<IDeleteToolButtonProps> = (props) => {
   return <SvgToolbarButton SvgIcon={DeleteSelectionIcon} buttonClass="delete" title="Delete" {...props} />;
-};
-
-interface IVariableToolButtonProps {
-  disabled?: boolean;
-  onClick: () => void;
-}
-
-export const VariableButton: React.FC<IVariableToolButtonProps> = (props) => {
-  return <SvgToolbarButton SvgIcon={VariableToolIcon} buttonClass="variable" title="Variable" {...props} />;
 };

--- a/src/plugins/drawing-tool/components/drawing-toolbar-buttons.tsx
+++ b/src/plugins/drawing-tool/components/drawing-toolbar-buttons.tsx
@@ -24,12 +24,6 @@ export const buttonClasses = ({ modalButton, disabled, selected, others }: IButt
   return classNames("drawing-tool-button", modalButtonClass, { disabled, selected }, others);
 };
 
-export const modalButtonProps = (type: ToolbarModalButton, drawingContent: DrawingContentModelType, 
-                                 settings?: Partial<ToolbarSettings>) => {
-  const { selectedButton, toolbarSettings } = drawingContent;
-  return { modalButton: type, selected: selectedButton === type, settings: settings || toolbarSettings };
-};
-
 /*
  * SvgToolbarButton
  */
@@ -104,9 +98,16 @@ export const StrokeColorButton: React.FC<IColorButtonProps> = ({ settings, onCli
 };
 
 interface IDeleteToolButtonProps {
-  disabled?: boolean;
-  onClick: () => void;
+  drawingContent: DrawingContentModelType;
 }
-export const DeleteButton: React.FC<IDeleteToolButtonProps> = (props) => {
-  return <SvgToolbarButton SvgIcon={DeleteSelectionIcon} buttonClass="delete" title="Delete" {...props} />;
-};
+export const DeleteButton: React.FC<IDeleteToolButtonProps> = observer(function DeleteButton({
+  drawingContent
+}) {
+  const onClick = () => {
+    drawingContent.deleteSelectedObjects();
+  };
+  const disabled = !drawingContent.hasSelectedObjects;
+
+  return <SvgToolbarButton SvgIcon={DeleteSelectionIcon} buttonClass="delete" title="Delete" 
+    onClick={onClick} disabled={disabled} />;
+});

--- a/src/plugins/drawing-tool/components/drawing-toolbar-buttons.tsx
+++ b/src/plugins/drawing-tool/components/drawing-toolbar-buttons.tsx
@@ -60,7 +60,7 @@ export const SvgToolbarButton: React.FC<ISvgToolbarButtonProps> = ({
 /*
  * SvgToolModeButton
  */
-interface ISvgToolModeButtonProps2 {
+interface ISvgToolModeButtonProps {
   SvgIcon: React.FC<React.SVGProps<SVGSVGElement>>;
   drawingContent: DrawingContentModelType;
   modalButton: ToolbarModalButton;
@@ -68,7 +68,7 @@ interface ISvgToolModeButtonProps2 {
   settings?: Partial<ToolbarSettings>;
   title: string;
 }
-export const SvgToolModeButton2: React.FC<ISvgToolModeButtonProps2> = observer(function SvgToolModeButton2({
+export const SvgToolModeButton: React.FC<ISvgToolModeButtonProps> = observer(function SvgToolModeButton({
   SvgIcon, drawingContent, modalButton, settings, ...others
 }) {
   const handleClick = () =>  drawingContent.setSelectedButton(modalButton);
@@ -81,7 +81,7 @@ export const SvgToolModeButton2: React.FC<ISvgToolModeButtonProps2> = observer(f
 });
 
 export const SelectToolbarButton: React.FC<IToolbarButtonProps> = ({drawingContent}) => {
-  return <SvgToolModeButton2 modalButton="select" title="Select"
+  return <SvgToolModeButton modalButton="select" title="Select"
     drawingContent={drawingContent} SvgIcon={SelectToolIcon} settings={{}}/>;
 };
 

--- a/src/plugins/drawing-tool/components/drawing-toolbar-buttons.tsx
+++ b/src/plugins/drawing-tool/components/drawing-toolbar-buttons.tsx
@@ -1,11 +1,9 @@
 import classNames from "classnames";
 import React from "react";
 import { Tooltip } from "react-tippy";
-import { computeStrokeDashArray } from "../model/drawing-content";
+import { computeStrokeDashArray, DrawingContentModelType } from "../model/drawing-content";
 import { ToolbarModalButton } from "../model/drawing-types";
 import { ToolbarSettings } from "../model/drawing-basic-types";
-import { StampModelType } from "../model/stamp";
-import SmallCornerTriangle from "../../../assets/icons/small-corner-triangle.svg";
 import ColorFillIcon from "../../../clue/assets/icons/drawing/color-fill-icon.svg";
 import ColorStrokeIcon from "../../../clue/assets/icons/drawing/color-stroke-icon.svg";
 import DeleteSelectionIcon from "../../../assets/icons/delete/delete-selection-icon.svg";
@@ -16,8 +14,8 @@ import RectToolIcon from "../../../clue/assets/icons/drawing/rectangle-icon.svg"
 import SelectToolIcon from "../../../clue/assets/icons/select-tool.svg";
 import VariableToolIcon from "../../../clue/assets/icons/variable-tool.svg";
 import { useTooltipOptions } from "../../../hooks/use-tooltip-options";
-import { useTouchHold } from "../../../hooks/use-touch-hold";
 import { isLightColorRequiringContrastOffset } from "../../../utilities/color-utils";
+import { observer } from "mobx-react";
 
 const svgIcons: Record<string, React.FC<React.SVGProps<SVGSVGElement>>> = {
   ellipse: EllipseToolIcon,
@@ -37,6 +35,12 @@ interface IButtonClasses {
 export const buttonClasses = ({ modalButton, disabled, selected, others }: IButtonClasses) => {
   const modalButtonClass = modalButton ? `button-${modalButton}` : undefined;
   return classNames("drawing-tool-button", modalButtonClass, { disabled, selected }, others);
+};
+
+export const modalButtonProps = (type: ToolbarModalButton, drawingContent: DrawingContentModelType, 
+                                 settings?: Partial<ToolbarSettings>) => {
+  const { selectedButton, toolbarSettings } = drawingContent;
+  return { modalButton: type, selected: selectedButton === type, settings: settings || toolbarSettings };
 };
 
 /*
@@ -86,37 +90,28 @@ export const SvgToolModeButton: React.FC<ISvgToolModeButtonProps> = ({
     : null;
 };
 
-interface IStampModeButtonProps {
-  selected: boolean;
-  stamp: StampModelType;
-  stampCount: number;
+/*
+ * SvgToolModeButton
+ */
+interface ISvgToolModeButtonProps2 {
+  SvgIcon: React.FC<React.SVGProps<SVGSVGElement>>;
+  drawingContent: DrawingContentModelType;
+  modalButton: ToolbarModalButton;
+  selected?: boolean;
+  settings?: Partial<ToolbarSettings>;
   title: string;
-  onClick: () => void;
-  onTouchHold: () => void;
 }
-export const StampModeButton: React.FC<IStampModeButtonProps> = ({
-  selected, stamp, stampCount, title, onClick, onTouchHold
-}) => {
-  const { didTouchHold, ...handlers } = useTouchHold(onTouchHold, onClick);
-  const handleExpandCollapseClick = (e: React.MouseEvent) => {
-    if (!didTouchHold()) {
-      onTouchHold();
-      e.stopPropagation();
-    }
-  };
-  const tooltipOptions = useTooltipOptions();
-  return (
-    <Tooltip title={title} {...tooltipOptions}>
-      <div className={buttonClasses({ modalButton: "stamp", selected })} {...handlers}>
-        <img src={stamp.url} draggable="false" />
-        {stampCount > 1 &&
-          <div className="expand-collapse" onClick={handleExpandCollapseClick}>
-            <SmallCornerTriangle />
-          </div>}
-      </div>
-    </Tooltip>
-  );
-};
+export const SvgToolModeButton2: React.FC<ISvgToolModeButtonProps2> = observer(function SvgToolModeButton2({
+  SvgIcon, drawingContent, modalButton, settings, ...others
+}) {
+  const handleClick = () =>  drawingContent.setSelectedButton(modalButton);
+  const { selectedButton, toolbarSettings } = drawingContent;
+  const selected = selectedButton === modalButton;
+  const _settings = settings || toolbarSettings;
+
+  return <SvgToolbarButton SvgIcon={SvgIcon} buttonClass={modalButton} onClick={handleClick} 
+    selected={selected} settings={_settings} {...others} />;
+});
 
 interface IColorButtonProps {
   settings: Partial<ToolbarSettings>;

--- a/src/plugins/drawing-tool/components/drawing-toolbar-buttons.tsx
+++ b/src/plugins/drawing-tool/components/drawing-toolbar-buttons.tsx
@@ -1,5 +1,6 @@
 import classNames from "classnames";
 import React from "react";
+import { observer } from "mobx-react";
 import { Tooltip } from "react-tippy";
 import { computeStrokeDashArray, DrawingContentModelType } from "../model/drawing-content";
 import { ToolbarModalButton } from "../model/drawing-types";
@@ -10,7 +11,6 @@ import ColorStrokeIcon from "../../../clue/assets/icons/drawing/color-stroke-ico
 import DeleteSelectionIcon from "../../../assets/icons/delete/delete-selection-icon.svg";
 import { useTooltipOptions } from "../../../hooks/use-tooltip-options";
 import { isLightColorRequiringContrastOffset } from "../../../utilities/color-utils";
-import { observer } from "mobx-react";
 import { IToolbarButtonProps } from "../objects/drawing-object";
 
 interface IButtonClasses {
@@ -65,7 +65,7 @@ interface ISvgToolModeButtonProps {
 export const SvgToolModeButton: React.FC<ISvgToolModeButtonProps> = observer(function SvgToolModeButton({
   SvgIcon, drawingContent, modalButton, settings, ...others
 }) {
-  const handleClick = () =>  drawingContent.setSelectedButton(modalButton);
+  const handleClick = () => drawingContent.setSelectedButton(modalButton);
   const { selectedButton, toolbarSettings } = drawingContent;
   const selected = selectedButton === modalButton;
   const _settings = settings || toolbarSettings;

--- a/src/plugins/drawing-tool/components/drawing-toolbar.tsx
+++ b/src/plugins/drawing-tool/components/drawing-toolbar.tsx
@@ -1,15 +1,13 @@
 import classNames from "classnames";
 import React, { useCallback, useState } from "react";
 import ReactDOM from "react-dom";
-import { DeleteButton, FillColorButton, SelectToolbarButton, StrokeColorButton} from "./drawing-toolbar-buttons";
+import { FillColorButton, StrokeColorButton} from "./drawing-toolbar-buttons";
 import { StampsPalette } from "./stamps-palette";
 import { StrokeColorPalette } from "./stroke-color-palette";
 import { FillColorPalette } from "./fill-color-palette";
 import {
   IFloatingToolbarProps, useFloatingToolbarLocation
 } from "../../../components/tools/hooks/use-floating-toolbar-location";
-import { useForceUpdate } from "../../../components/tools/hooks/use-force-update";
-import { useMobXOnChange } from "../../../components/tools/hooks/use-mobx-on-change";
 import { IRegisterToolApiProps } from "../../../components/tools/tool-tile";
 import { DrawingContentModelType } from "../model//drawing-content";
 import { ToolTileModelType } from "../../../models/tools/tool-tile";
@@ -44,7 +42,6 @@ export const ToolbarView: React.FC<IProps> = (
     });
   }, [stampCount]);
   const isEnabled = onIsEnabled();
-  const forceUpdate = useForceUpdate();
   const { flipPalettes, ...location } = useFloatingToolbarLocation({
                                           documentContent,
                                           toolbarHeight: 38,
@@ -70,16 +67,6 @@ export const ToolbarView: React.FC<IProps> = (
     }
   };
 
-  // update toolbar when object selection changes
-  useMobXOnChange(
-    () => drawingContent.hasSelectedObjects,
-    () => forceUpdate()
-  );
-
-  const handleDeleteButton = () => {
-    drawingContent.deleteSelectedObjects();
-  };
-
   const handleStrokeColorChange = (color: string) => {
     isEnabled && drawingContent.setStroke(color);
     clearPaletteState();
@@ -102,18 +89,12 @@ export const ToolbarView: React.FC<IProps> = (
     }
 
     switch (toolName) {
-      case "select":
-        // TODO: if we can move the select tool out of drawing-layer
-        // then this button just be added to the drawing-object-manager
-        return <SelectToolbarButton key="select" {...toolbarButtonProps} />;
       case "stroke-color":
         return <StrokeColorButton key="stroke" settings={drawingContent.toolbarSettings}
           onClick={() => handleToggleShowStrokeColorPalette()} />;
       case "fill-color":
         return <FillColorButton key="fill" settings={drawingContent.toolbarSettings}
           onClick={() => handleToggleShowFillColorPalette()} />;
-      case "delete":
-        return <DeleteButton key="delete" disabled={!drawingContent.hasSelectedObjects} onClick={handleDeleteButton} />;
     }
   };
 

--- a/src/plugins/drawing-tool/components/selection-drawing-tool.tsx
+++ b/src/plugins/drawing-tool/components/selection-drawing-tool.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { DrawingObjectType, DrawingTool, IDrawingLayer } from "../objects/drawing-object";
+import { DrawingLayerView } from "./drawing-layer";
+
+export class SelectionDrawingTool extends DrawingTool {
+  constructor(drawingLayer: IDrawingLayer) {
+    super(drawingLayer);
+  }
+
+  public handleMouseDown(e: React.MouseEvent<HTMLDivElement>) {
+    // We are internal so we can use some private stuff not exposed by 
+    // IDrawingLayer
+    const drawingLayerView = this.drawingLayer as DrawingLayerView;
+    const addToSelectedObjects = e.ctrlKey || e.metaKey;
+    const start = this.drawingLayer.getWorkspacePoint(e);
+    if (!start) return;
+    drawingLayerView.startSelectionBox(start);
+
+    const handleMouseMove = (e2: MouseEvent) => {
+      e2.preventDefault();
+      const p = this.drawingLayer.getWorkspacePoint(e2);
+      if (!p) return;
+      drawingLayerView.updateSelectionBox(p);
+    };
+    const handleMouseUp = (e2: MouseEvent) => {
+      e2.preventDefault();
+      drawingLayerView.endSelectionBox(addToSelectedObjects);
+      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("mouseup", handleMouseUp);
+    };
+
+    window.addEventListener("mousemove", handleMouseMove);
+    window.addEventListener("mouseup", handleMouseUp);
+  }
+
+  public handleObjectClick(e: React.MouseEvent<HTMLDivElement>, obj: DrawingObjectType) {
+    // We are internal so we can use some private stuff not exposed by 
+    // IDrawingLayer
+    const drawingLayerView = this.drawingLayer as DrawingLayerView;
+    const { selectedObjects } = drawingLayerView.state;
+    const index = selectedObjects.indexOf(obj);
+    if (index === -1) {
+      selectedObjects.push(obj);
+    }
+    else {
+      selectedObjects.splice(index, 1);
+    }
+    drawingLayerView.setSelectedObjects(selectedObjects);
+  }
+}

--- a/src/plugins/drawing-tool/model/drawing-content.test.ts
+++ b/src/plugins/drawing-tool/model/drawing-content.test.ts
@@ -7,6 +7,8 @@ import { DrawingToolChange, kDrawingToolID } from "./drawing-types";
 import { DefaultToolbarSettings } from "./drawing-basic-types";
 import { StampModel } from "./stamp";
 import { AppConfigModel } from "../../../models/stores/app-config-model";
+import { ImageObjectSnapshot } from "../objects/image";
+import { RectangleObjectSnapshot } from "../objects/rectangle";
 
 // mock Logger calls
 jest.mock("../../../lib/logger", () => {
@@ -80,7 +82,9 @@ describe("DrawingContentModel", () => {
 
   it("imports the drawing tool import format", () => {
     const model = createDrawingContent({
-      type: "Drawing", objects: [ { type: "rectangle", x: 10, y: 10, width: 100, height: 100 }]
+      type: "Drawing", objects: [ 
+        { type: "rectangle", x: 10, y: 10, width: 100, height: 100 } as RectangleObjectSnapshot
+      ]
     } as IDrawingTileImportSpec);
     expect(model.type).toBe(kDrawingToolID);
     expect(model.changes.length).toBe(1);
@@ -183,8 +187,11 @@ describe("DrawingContentModel", () => {
   });
 
   it("can update image urls", () => {
+    const initialImage: ImageObjectSnapshot = {
+      type: "image", id: "img1", url: "my/image/url", x: 0, y: 0, width: 10, height: 10
+    };
     const changes: DrawingToolChange[] = [
-      { action: "create", data: { type: "image", id: "img1", url: "my/image/url", x: 0, y: 0, width: 10, height: 10 }},
+      { action: "create", data: initialImage },
       { action: "update", data: { ids: ["img1"], update: { prop: "url", newValue: "my/image/url2" }}}
     ];
     const model = createDrawingContent({

--- a/src/plugins/drawing-tool/model/drawing-content.ts
+++ b/src/plugins/drawing-tool/model/drawing-content.ts
@@ -11,7 +11,6 @@ import {
   DrawingToolUpdate, DrawingToolUpdateChange, kDrawingToolID, ToolbarModalButton
 } from "./drawing-types";
 import { ImageObjectSnapshot } from "../objects/image";
-import { DrawingObjectSnapshotUnion } from "../components/drawing-object-manager";
 import { DefaultToolbarSettings, ToolbarSettings } from "./drawing-basic-types";
 
 

--- a/src/plugins/drawing-tool/model/drawing-export.ts
+++ b/src/plugins/drawing-tool/model/drawing-export.ts
@@ -3,19 +3,17 @@ import { comma, StringBuilder } from "../../../utilities/string-builder";
 import { ITileExportOptions } from "../../../models/tools/tool-content-info";
 import { DrawingToolChange } from "./drawing-types";
 import { ImageObjectSnapshot } from "../objects/image";
-import { DrawingObjectSnapshotUnion } from "../components/drawing-object-manager";
+import { DrawingObjectSnapshot } from "../objects/drawing-object";
 
-export interface IDrawingObjectInfo {
+interface IDrawingObjectChanges {
   id: string;
-  // this used to be DrawingObjectDataType["type"] but we relax it to support
-  // plugin based drawing object types
   type: string;
   changes: DrawingToolChange[]; // changes that affect this object
   isDeleted?: boolean;          // true if the object has been deleted
 }
 
 export const exportDrawingTileSpec = (changes: string[], options?: ITileExportOptions) => {
-  const objectInfoMap: Record<string, IDrawingObjectInfo> = {};
+  const objectInfoMap: Record<string, IDrawingObjectChanges> = {};
   const orderedIds: string[] = [];
   const builder = new StringBuilder();
 
@@ -26,7 +24,7 @@ export const exportDrawingTileSpec = (changes: string[], options?: ITileExportOp
 
   const exportObject = (id: string, isLast: boolean) => {
     const objInfo = objectInfoMap[id];
-    let data = { ...objInfo.changes[0].data } as DrawingObjectSnapshotUnion;
+    let data = { ...objInfo.changes[0].data } as DrawingObjectSnapshot;
     for (let i = 1; i < objInfo.changes.length; ++i) {
       const change = objInfo.changes[i];
       switch (change.action) {

--- a/src/plugins/drawing-tool/model/drawing-import.ts
+++ b/src/plugins/drawing-tool/model/drawing-import.ts
@@ -1,9 +1,9 @@
 import { uniqueId } from "../../../utilities/js-utils";
-import { DrawingObjectSnapshotUnion } from "../components/drawing-object-manager";
+import { DrawingObjectSnapshot } from "../objects/drawing-object";
 
 export interface IDrawingTileImportSpec {
   type: "Drawing";
-  objects: DrawingObjectSnapshotUnion[];
+  objects: DrawingObjectSnapshot[];
 }
 
 export const isDrawingTileImportSpec = (snapshot: any): snapshot is IDrawingTileImportSpec =>

--- a/src/plugins/drawing-tool/model/drawing-types.ts
+++ b/src/plugins/drawing-tool/model/drawing-types.ts
@@ -1,4 +1,4 @@
-import { DrawingObjectSnapshotUnion } from "../components/drawing-object-manager";
+import { DrawingObjectSnapshot } from "../objects/drawing-object";
 import { Point } from "./drawing-basic-types";
 
 export const kDrawingToolID = "Drawing";
@@ -19,7 +19,7 @@ export type DrawingToolDeletion = string[];
 
 export interface DrawingToolCreateChange {
   action: "create";
-  data: DrawingObjectSnapshotUnion;
+  data: DrawingObjectSnapshot;
 }
 export interface DrawingToolMoveChange {
   action: "move";

--- a/src/plugins/drawing-tool/objects/drawing-object.ts
+++ b/src/plugins/drawing-tool/objects/drawing-object.ts
@@ -80,6 +80,22 @@ export interface IDrawingComponentProps {
   handleHover?: HandleObjectHover;
 }
 
+// TODO: the support for palettes is hard coded to specific tools
+export interface IPaletteState {
+  showStamps: boolean;
+  showStroke: boolean;
+  showFill: boolean;
+}
+export type PaletteKey = keyof IPaletteState;
+export const kClosedPalettesState = { showStamps: false, showStroke: false, showFill: false };
+
+export interface IToolbarButtonProps {
+  drawingContent: DrawingContentModelType;
+  // TODO: the support for palettes is hard coded to specific tools
+  togglePaletteState: (palette: PaletteKey, show?: boolean) => void;  
+  clearPaletteState: () => void;
+}
+
 export type DrawingComponentType = React.ComponentType<IDrawingComponentProps>;
 
 export interface IDrawingLayer {

--- a/src/plugins/drawing-tool/objects/drawing-object.ts
+++ b/src/plugins/drawing-tool/objects/drawing-object.ts
@@ -1,4 +1,4 @@
-import { Instance, types } from "mobx-state-tree";
+import { Instance, SnapshotIn, types } from "mobx-state-tree";
 import { uniqueId } from "../../../utilities/js-utils";
 import { SelectionBox } from "../components/selection-box";
 import { BoundingBox, DefaultToolbarSettings, Point, ToolbarSettings } from "../model/drawing-basic-types";
@@ -41,7 +41,7 @@ export const DrawingObject = types.model("DrawingObject", {
   }
 }));
 export interface DrawingObjectType extends Instance<typeof DrawingObject> {}
-
+export interface DrawingObjectSnapshot extends SnapshotIn<typeof DrawingObject> {} 
 
 export const StrokedObject = DrawingObject.named("StrokedObject")
 .props({

--- a/src/plugins/drawing-tool/objects/ellipse.tsx
+++ b/src/plugins/drawing-tool/objects/ellipse.tsx
@@ -2,8 +2,10 @@ import { Instance, SnapshotIn, types } from "mobx-state-tree";
 import React from "react";
 import { computeStrokeDashArray } from "../model/drawing-content";
 import { DrawingTool, FilledObject, IDrawingComponentProps, IDrawingLayer, 
-  StrokedObject, typeField } from "./drawing-object";
+  IToolbarButtonProps, StrokedObject, typeField } from "./drawing-object";
 import { Point } from "../model/drawing-basic-types";
+import { SvgToolModeButton2 } from "../components/drawing-toolbar-buttons";
+import EllipseToolIcon from "../../../clue/assets/icons/drawing/ellipse-icon.svg";
 
 export const EllipseObject = types.compose("EllipseObject", StrokedObject, FilledObject)
   .props({
@@ -90,3 +92,7 @@ export class EllipseDrawingTool extends DrawingTool {
   }
 }
 
+export function EllipseToolbarButton({drawingContent}: IToolbarButtonProps) {
+  return <SvgToolModeButton2 modalButton="ellipse" title="Ellipse"
+      drawingContent={drawingContent} SvgIcon={EllipseToolIcon} />;
+}

--- a/src/plugins/drawing-tool/objects/ellipse.tsx
+++ b/src/plugins/drawing-tool/objects/ellipse.tsx
@@ -4,7 +4,7 @@ import { computeStrokeDashArray } from "../model/drawing-content";
 import { DrawingObjectType, DrawingTool, FilledObject, IDrawingComponentProps, IDrawingLayer, 
   IToolbarButtonProps, StrokedObject, typeField } from "./drawing-object";
 import { Point } from "../model/drawing-basic-types";
-import { SvgToolModeButton2 } from "../components/drawing-toolbar-buttons";
+import { SvgToolModeButton } from "../components/drawing-toolbar-buttons";
 import EllipseToolIcon from "../../../clue/assets/icons/drawing/ellipse-icon.svg";
 
 export const EllipseObject = types.compose("EllipseObject", StrokedObject, FilledObject)
@@ -97,6 +97,6 @@ export class EllipseDrawingTool extends DrawingTool {
 }
 
 export function EllipseToolbarButton({drawingContent}: IToolbarButtonProps) {
-  return <SvgToolModeButton2 modalButton="ellipse" title="Ellipse"
+  return <SvgToolModeButton modalButton="ellipse" title="Ellipse"
       drawingContent={drawingContent} SvgIcon={EllipseToolIcon} />;
 }

--- a/src/plugins/drawing-tool/objects/image.tsx
+++ b/src/plugins/drawing-tool/objects/image.tsx
@@ -2,13 +2,13 @@ import { addDisposer, Instance, SnapshotIn, types } from "mobx-state-tree";
 import React, { useCallback } from "react";
 import { observer } from "mobx-react";
 import { autorun } from "mobx";
+import { Tooltip } from "react-tippy";
 import { gImageMap } from "../../../models/image-map";
 import { DrawingObject, DrawingTool, IDrawingComponentProps, IDrawingLayer, 
   IToolbarButtonProps, typeField } from "./drawing-object";
 import { Point } from "../model/drawing-basic-types";
 import placeholderImage from "../../../assets/image_placeholder.png";
 import SmallCornerTriangle from "../../../assets/icons/small-corner-triangle.svg";
-import { Tooltip } from "react-tippy";
 import { useTooltipOptions } from "../../../hooks/use-tooltip-options";
 import { buttonClasses } from "../components/drawing-toolbar-buttons";
 import { useTouchHold } from "../../../hooks/use-touch-hold";

--- a/src/plugins/drawing-tool/objects/image.tsx
+++ b/src/plugins/drawing-tool/objects/image.tsx
@@ -1,11 +1,17 @@
 import { addDisposer, Instance, SnapshotIn, types } from "mobx-state-tree";
-import React from "react";
+import React, { useCallback } from "react";
 import { gImageMap } from "../../../models/image-map";
-import { DrawingObject, DrawingTool, IDrawingComponentProps, IDrawingLayer, typeField } from "./drawing-object";
+import { DrawingObject, DrawingTool, IDrawingComponentProps, IDrawingLayer, 
+  IToolbarButtonProps, typeField } from "./drawing-object";
 import { Point } from "../model/drawing-basic-types";
 import placeholderImage from "../../../assets/image_placeholder.png";
+import SmallCornerTriangle from "../../../assets/icons/small-corner-triangle.svg";
 import { observer } from "mobx-react";
 import { autorun } from "mobx";
+import { Tooltip } from "react-tippy";
+import { useTooltipOptions } from "../../../hooks/use-tooltip-options";
+import { buttonClasses } from "../components/drawing-toolbar-buttons";
+import { useTouchHold } from "../../../hooks/use-touch-hold";
 
 export const ImageObject = DrawingObject.named("ImageObject")
   .props({
@@ -114,3 +120,47 @@ export class StampDrawingTool extends DrawingTool {
   }
 }
 
+export const StampToolbarButton: React.FC<IToolbarButtonProps> = ({
+  drawingContent, togglePaletteState, clearPaletteState
+}) => {
+  const tooltipOptions = useTooltipOptions();
+  const { selectedButton, stamps } = drawingContent;
+  const { currentStamp } = drawingContent;
+  const stampCount = stamps.length;
+
+  const modalButton = "stamp";
+  const selected = selectedButton === modalButton;
+
+  const handleStampsButtonClick = useCallback(() => {
+    drawingContent.setSelectedButton("stamp");
+    togglePaletteState("showStamps", false);
+  }, [drawingContent, togglePaletteState]);
+
+  const handleStampsButtonTouchHold = useCallback(() => {
+    drawingContent.setSelectedButton("stamp");
+    togglePaletteState("showStamps");
+  }, [drawingContent, togglePaletteState]);
+
+  const { didTouchHold, ...handlers } = useTouchHold(handleStampsButtonTouchHold, handleStampsButtonClick);
+
+  const handleExpandCollapseClick = (e: React.MouseEvent) => {
+    if (!didTouchHold()) {
+      handleStampsButtonTouchHold();
+      e.stopPropagation();
+    }
+  };
+
+  return (
+    currentStamp 
+      ? <Tooltip title="Stamp" {...tooltipOptions}>
+          <div className={buttonClasses({ modalButton, selected })} {...handlers}>
+            <img src={currentStamp.url} draggable="false" />
+            {stampCount > 1 &&
+              <div className="expand-collapse" onClick={handleExpandCollapseClick}>
+                <SmallCornerTriangle />
+              </div>}
+          </div>
+        </Tooltip>
+      : null
+  );
+};

--- a/src/plugins/drawing-tool/objects/line.tsx
+++ b/src/plugins/drawing-tool/objects/line.tsx
@@ -3,8 +3,10 @@ import React from "react";
 import { SelectionBox } from "../components/selection-box";
 import { computeStrokeDashArray } from "../model/drawing-content";
 import { DeltaPoint, DrawingTool, IDrawingComponentProps, IDrawingLayer, 
-  StrokedObject, typeField } from "./drawing-object";
+  IToolbarButtonProps, StrokedObject, typeField } from "./drawing-object";
 import { Point } from "../model/drawing-basic-types";
+import { SvgToolModeButton2 } from "../components/drawing-toolbar-buttons";
+import FreehandToolIcon from "../../../clue/assets/icons/drawing/freehand-icon.svg";
 
 function* pointIterator(line: LineObjectType): Generator<Point, string, unknown> {
   const {x, y, deltaPoints} = line;
@@ -117,4 +119,9 @@ export class LineDrawingTool extends DrawingTool {
     window.addEventListener("mousemove", handleMouseMove);
     window.addEventListener("mouseup", handleMouseUp);
   }
+}
+
+export function LineToolbarButton({drawingContent}: IToolbarButtonProps) {
+  return <SvgToolModeButton2 modalButton="line" settings={{ fill: drawingContent.stroke }}
+    title="Freehand" drawingContent={drawingContent} SvgIcon={FreehandToolIcon} />;
 }

--- a/src/plugins/drawing-tool/objects/line.tsx
+++ b/src/plugins/drawing-tool/objects/line.tsx
@@ -5,7 +5,7 @@ import { computeStrokeDashArray } from "../model/drawing-content";
 import { DeltaPoint, DrawingTool, IDrawingComponentProps, IDrawingLayer, 
   IToolbarButtonProps, StrokedObject, typeField } from "./drawing-object";
 import { Point } from "../model/drawing-basic-types";
-import { SvgToolModeButton2 } from "../components/drawing-toolbar-buttons";
+import { SvgToolModeButton } from "../components/drawing-toolbar-buttons";
 import FreehandToolIcon from "../../../clue/assets/icons/drawing/freehand-icon.svg";
 
 function* pointIterator(line: LineObjectType): Generator<Point, string, unknown> {
@@ -121,6 +121,6 @@ export class LineDrawingTool extends DrawingTool {
 }
 
 export function LineToolbarButton({drawingContent}: IToolbarButtonProps) {
-  return <SvgToolModeButton2 modalButton="line" settings={{ fill: drawingContent.stroke }}
+  return <SvgToolModeButton modalButton="line" settings={{ fill: drawingContent.stroke }}
     title="Freehand" drawingContent={drawingContent} SvgIcon={FreehandToolIcon} />;
 }

--- a/src/plugins/drawing-tool/objects/rectangle.tsx
+++ b/src/plugins/drawing-tool/objects/rectangle.tsx
@@ -5,7 +5,7 @@ import { DrawingTool, FilledObject, IDrawingComponentProps, IDrawingLayer,
   IToolbarButtonProps, StrokedObject, typeField } from "./drawing-object";
 import { Point } from "../model/drawing-basic-types";
 import RectToolIcon from "../../../clue/assets/icons/drawing/rectangle-icon.svg";
-import { SvgToolModeButton2 } from "../components/drawing-toolbar-buttons";
+import { SvgToolModeButton } from "../components/drawing-toolbar-buttons";
 
 export const RectangleObject = types.compose("RectangleObject", StrokedObject, FilledObject)
   .props({
@@ -114,6 +114,6 @@ export class RectangleDrawingTool extends DrawingTool {
 }
 
 export function RectangleToolbarButton({drawingContent}: IToolbarButtonProps) {
-  return <SvgToolModeButton2 modalButton="rectangle" title="Rectangle" 
+  return <SvgToolModeButton modalButton="rectangle" title="Rectangle" 
     drawingContent={drawingContent} SvgIcon={RectToolIcon}  />;
 }

--- a/src/plugins/drawing-tool/objects/rectangle.tsx
+++ b/src/plugins/drawing-tool/objects/rectangle.tsx
@@ -2,8 +2,10 @@ import { Instance, SnapshotIn, types } from "mobx-state-tree";
 import React from "react";
 import { computeStrokeDashArray } from "../model/drawing-content";
 import { DrawingTool, FilledObject, IDrawingComponentProps, IDrawingLayer, 
-  StrokedObject, typeField } from "./drawing-object";
+  IToolbarButtonProps, StrokedObject, typeField } from "./drawing-object";
 import { Point } from "../model/drawing-basic-types";
+import RectToolIcon from "../../../clue/assets/icons/drawing/rectangle-icon.svg";
+import { SvgToolModeButton2 } from "../components/drawing-toolbar-buttons";
 
 export const RectangleObject = types.compose("RectangleObject", StrokedObject, FilledObject)
   .props({
@@ -109,4 +111,9 @@ export class RectangleDrawingTool extends DrawingTool {
     window.addEventListener("mousemove", handleMouseMove);
     window.addEventListener("mouseup", handleMouseUp);
   }
+}
+
+export function RectangleToolbarButton({drawingContent}: IToolbarButtonProps) {
+  return <SvgToolModeButton2 modalButton="rectangle" title="Rectangle" 
+    drawingContent={drawingContent} SvgIcon={RectToolIcon}  />;
 }

--- a/src/plugins/drawing-tool/objects/vector.tsx
+++ b/src/plugins/drawing-tool/objects/vector.tsx
@@ -1,8 +1,11 @@
 import { Instance, SnapshotIn, types } from "mobx-state-tree";
 import React from "react";
 import { computeStrokeDashArray } from "../model/drawing-content";
-import { DrawingTool, IDrawingComponentProps, IDrawingLayer, StrokedObject, typeField } from "./drawing-object";
+import { DrawingTool, IDrawingComponentProps, IDrawingLayer, 
+  IToolbarButtonProps, StrokedObject, typeField } from "./drawing-object";
 import { Point } from "../model/drawing-basic-types";
+import { SvgToolModeButton2 } from "../components/drawing-toolbar-buttons";
+import LineToolIcon from "../../../clue/assets/icons/drawing/line-icon.svg";
 
 // simple line
 export const VectorObject = StrokedObject.named("VectorObject")
@@ -91,4 +94,9 @@ export class VectorDrawingTool extends DrawingTool {
     window.addEventListener("mousemove", handleMouseMove);
     window.addEventListener("mouseup", handleMouseUp);
   }
+}
+
+export function VectorToolbarButton({drawingContent}: IToolbarButtonProps) {
+  return <SvgToolModeButton2 modalButton="vector" title="Line"
+    drawingContent={drawingContent} SvgIcon={LineToolIcon} />;
 }

--- a/src/plugins/drawing-tool/objects/vector.tsx
+++ b/src/plugins/drawing-tool/objects/vector.tsx
@@ -4,7 +4,7 @@ import { computeStrokeDashArray } from "../model/drawing-content";
 import { DrawingTool, IDrawingComponentProps, IDrawingLayer, 
   IToolbarButtonProps, StrokedObject, typeField } from "./drawing-object";
 import { Point } from "../model/drawing-basic-types";
-import { SvgToolModeButton2 } from "../components/drawing-toolbar-buttons";
+import { SvgToolModeButton } from "../components/drawing-toolbar-buttons";
 import LineToolIcon from "../../../clue/assets/icons/drawing/line-icon.svg";
 
 // simple line
@@ -97,6 +97,6 @@ export class VectorDrawingTool extends DrawingTool {
 }
 
 export function VectorToolbarButton({drawingContent}: IToolbarButtonProps) {
-  return <SvgToolModeButton2 modalButton="vector" title="Line"
+  return <SvgToolModeButton modalButton="vector" title="Line"
     drawingContent={drawingContent} SvgIcon={LineToolIcon} />;
 }

--- a/src/plugins/shared-variables/drawing/variable-object.tsx
+++ b/src/plugins/shared-variables/drawing/variable-object.tsx
@@ -1,10 +1,13 @@
 import { Instance, SnapshotIn, types } from "mobx-state-tree";
 import React from "react";
-import { DrawingObject, DrawingTool, IDrawingComponentProps, IDrawingLayer, typeField } 
+import { DrawingObject, DrawingTool, IDrawingComponentProps, IDrawingLayer, IToolbarButtonProps, typeField } 
   from "../../drawing-tool/objects/drawing-object";
 import { Point } from "../../drawing-tool/model/drawing-basic-types";
 import { VariableChip } from "../slate/variable-chip";
 import { findVariable } from "./drawing-utils";
+import { useVariableDialog } from "./use-variable-dialog";
+import VariableToolIcon from "../../../clue/assets/icons/variable-tool.svg";
+import { SvgToolbarButton } from "../../drawing-tool/components/drawing-toolbar-buttons";
 
 export const VariableChipObject = DrawingObject.named("VariableObject")
   .props({
@@ -64,4 +67,15 @@ export class VariableDrawingTool extends DrawingTool {
   constructor(drawingLayer: IDrawingLayer) {
     super(drawingLayer);
   }
+}
+
+export function VariableChipToolbarButton({drawingContent}: IToolbarButtonProps) {
+  const [showVariableDialog] = useVariableDialog({ drawingContent });
+
+  const handleShowVariableDialog = () => {
+    showVariableDialog();
+  };
+
+  return <SvgToolbarButton SvgIcon={VariableToolIcon} buttonClass="variable"
+    title="Variable" onClick={handleShowVariableDialog} />;
 }

--- a/src/plugins/shared-variables/shared-variables-registration.ts
+++ b/src/plugins/shared-variables/shared-variables-registration.ts
@@ -4,6 +4,9 @@ import { kSharedVariablesID, SharedVariables } from "./shared-variables";
 import VariablesToolIcon from "./slate/variables.svg";
 import { VariablesPlugin } from "./slate/variables-plugin";
 import { updateAfterSharedModelChanges } from "./slate/variables-text-content";
+import { registerDrawingObjectInfo, registerDrawingToolInfo } from "../drawing-tool/components/drawing-object-manager";
+import { VariableChipComponent, VariableChipObject, VariableChipToolbarButton, 
+  VariableDrawingTool } from "./drawing/variable-object";
 
 registerSharedModelInfo({
   type: kSharedVariablesID,
@@ -18,3 +21,17 @@ registerTextPluginInfo({
   command: "configureVariable",
   updateTextContentAfterSharedModelChanges: updateAfterSharedModelChanges
 });
+
+registerDrawingObjectInfo({
+  type: "variable",
+  component:VariableChipComponent,
+  modelClass: VariableChipObject
+});
+
+registerDrawingToolInfo({
+  name: "variable",
+  toolClass: VariableDrawingTool,
+  buttonComponent: VariableChipToolbarButton
+});
+
+


### PR DESCRIPTION
## Summary
The main goal of this PR was to break the direct link between the drawing tile code and the diagram-view package. This link existed because the variable chip drawing tool and drawing object depend on the diagram-view package and were hard coded into the drawing tile code.

To get to this goal, I tried to abstract all drawing objects and drawing tools from the core of the drawing tile. I was not completely successful, but most of the tools and objects are now setup declaratively by the drawing-object-manager.

## Changes related to the core:
- **Tool and Object Registry**: 
  - the list of tools available in the drawing-layer is now based on a registry of IDrawingToolInfo objects
  - the list of object types is now maintained by the drawing-object-manager using IDrawingObjectInfo objects, it is used to make a MST Union type which handles deserializing the tools
  - now that the tools are added dynamically, the static DrawingObjectSnapshotUnion was replaced with just DrawingObjectSnapshot
  - because of the DrawingObjectSnapshotUnion, some of the tests had to be updated
- **Toolbar Buttons**: 
  - the toolbar buttons are created on demand based on the settings. Previously every toolbar button was created and then only some where rendered.
  - the modal/mode buttons used by the drawing objects were simplified.  Each object provides its own buttonComponent which includes the icon, so no extra lookup is necessary. Most object button components use the updated `SvgToolModeButton` which takes care of selecting the button on click and using default toolbar settings.
- **Stamp Tool**: The biggest of the toolbar button changes was the stamp tool. This involved moving several handlers from `drawing-toolbar.tsx`, and exposing some palette state functions as properties.  Fully abstracting the palettes was punted (see below). The palette types were moved to `drawing-object.ts` this way drawing tools like the stamp tool, that work with these types, do not need to depend on `drawing-toolbar`
- **Selection Tool**: it was partially extracted from the drawing-layer. The selection tool's name was unified to just be "select".
- **Delete Tool**: the Delete button now observes the `drawingContent` model itself, so the whole toolbar doesn't need to be re-rendered when the selection changes.
- **Misc**: the existing IDrawingObjectInfo was renamed to IDrawingObjectChanges, I think this name is more descriptive and I wanted to use IDrawingObjectInfo for the registry.

## Variable Changes
- the Variable button component was extracted in the shared-variables plugin
- the Variable button was changed from being a modal/mode button to just a simple button. This way if th existing tool was the select tool, then after adding a variable it can be moved around right away.
- the variable drawing object and drawing tool are now registered by `shared-variables-registration.ts`. This should break the link between the core code and the diagram-view package which provides the shared variable code.

## Registry types
IDrawingToolInfo has:
- name
- toolClass
- buttonComponent

IDrawingObjectInfo has:
- type
- component
- modelClass

## Things that were punted:
- the palettes that are shown by the stamp, fill, and stroke toolbar buttons are still hard coded in the drawing-toolbar. I ran out of time to refactor this into something any toolbar button could use. 
- the selection tool has code living both in `selection-drawing-tool.tsx` and `drawing-layer.tsx`. A few more changes could be made so the selection tool could be implemented as a generic tool, and this would also reduce the size of `drawing-layer.tsx` quite a bit.

