### PR TITLE
Allow hiding of my work panel/browser

### DIFF
--- a/src/clue/app-config.json
+++ b/src/clue/app-config.json
@@ -239,6 +239,9 @@
     "example-no-group-share": {
       "content": "curriculum/example-curriculum/example-no-group-share.json"
     },
+    "example-no-my-work": {
+      "content": "curriculum/example-curriculum/example-no-my-work.json"
+    },
     "example-show-nav-panel": {
       "content": "curriculum/example-curriculum/example-show-nav-panel.json"
     },

--- a/src/components/document/document-or-browser.tsx
+++ b/src/components/document/document-or-browser.tsx
@@ -17,7 +17,7 @@ function getSectionForDocument(document: DocumentModelType) {
 
 interface IDocumentOrBrowserProps extends IEditableDocumentContentProps {
   showBrowser: boolean;
-  tabSpec: NavTabSpec;
+  tabSpec?: NavTabSpec;
   onSelectNewDocument?: (type: string) => void;
   onSelectDocument?: (document: DocumentModelType) => void;
 }
@@ -39,5 +39,5 @@ function useTabSpec(tab: ENavTab) {
 type IMyWorkDocumentOrBrowserProps = Omit<IDocumentOrBrowserProps, "tabSpec">;
 export const MyWorkDocumentOrBrowser: React.FC<IMyWorkDocumentOrBrowserProps> = props => {
   const myWorkTabSpec = useTabSpec(ENavTab.kMyWork);
-  return myWorkTabSpec ? <DocumentOrBrowser tabSpec={myWorkTabSpec} {...props} /> : null;
+  return <DocumentOrBrowser tabSpec={myWorkTabSpec} {...props} />;
 };

--- a/src/components/document/document.tsx
+++ b/src/components/document/document.tsx
@@ -11,6 +11,7 @@ import { LearningLogDocument, LearningLogPublication } from "../../models/docume
 import { ToolbarModelType } from "../../models/stores/problem-configuration";
 import { SupportType, TeacherSupportModelType, AudienceEnum } from "../../models/stores/supports";
 import { WorkspaceModelType } from "../../models/stores/workspace";
+import { ENavTab } from "../../models/view/nav-tabs";
 import { IconButton } from "../utilities/icon-button";
 import ToggleControl from "../utilities/toggle-control";
 import { Logger, LogEventName } from "../../lib/logger";
@@ -192,6 +193,12 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
     }
   }
 
+  private showFileMenu() {
+    const { appConfig: { navTabs } } = this.stores;
+    // show the File menu if my work navigation is enabled
+    return !!navTabs.getNavTabSpec(ENavTab.kMyWork);
+  }
+
   private renderTitleBar(type: string) {
     const { document, side } = this.props;
     const hideButtons = (side === "comparison") || document.isPublished;
@@ -211,6 +218,7 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
     const problemTitle = problem.title;
     const { document, workspace } = this.props;
     const isShared = document.visibility === "public";
+    const showFileMenu = this.showFileMenu();
     const show4up = !workspace.comparisonVisible && !isTeacher;
     const downloadButton = (appMode !== "authed") && clipboard.hasJsonTileContent()
                             ? <DownloadButton key="download" onClick={this.handleDownloadTileJson} />
@@ -219,11 +227,12 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
       <div className={`titlebar ${type}`}>
         {!hideButtons &&
           <div className="actions left">
-            <DocumentFileMenu document={document}
-              onOpenDocument={this.handleOpenDocumentClick}
-              onCopyDocument={this.handleCopyDocumentClick}
-              isDeleteDisabled={true}
-              onAdminDestroyDocument={this.handleAdminDestroyDocument} />
+            {showFileMenu &&
+              <DocumentFileMenu document={document}
+                onOpenDocument={this.handleOpenDocumentClick}
+                onCopyDocument={this.handleCopyDocumentClick}
+                isDeleteDisabled={true}
+                onAdminDestroyDocument={this.handleAdminDestroyDocument} />}
             {this.showPublishButton(document) &&
               <PublishButton document={document} />}
           </div>

--- a/src/public/curriculum/example-curriculum/example-no-my-work.json
+++ b/src/public/curriculum/example-curriculum/example-no-my-work.json
@@ -1,0 +1,187 @@
+{
+  "code": "example-no-my-work",
+  "abbrevTitle": "EXNMW",
+  "title": "Example Curriculum",
+  "subtitle": "Demonstrating Curriculum Configuration",
+  "config": {
+    "placeholderText": "This is where users can type text",
+    "defaultDocumentType": "problem",
+    "autoSectionProblemDocuments": false,
+    "settings": {
+      "table": { "numFormat": ".2~f" }
+    },
+    "navTabs": {
+      "showNavPanel": true,
+      "lazyLoadTabContents": true,
+      "tabSpecs": [
+        {
+          "tab": "problems",
+          "label": "Activity",
+          "sections": []
+        },
+        {
+          "tab": "class-work",
+          "label": "Class Work",
+          "sections": [
+            {
+              "className": "section problem published",
+              "title": "Workspaces",
+              "type": "published-problem-documents",
+              "dataTestHeader": "class-work-section-published",
+              "dataTestItem": "class-work-list-items",
+              "documentTypes": ["publication"],
+              "showStars": ["teacher"]
+            },
+            {
+              "className": "section personal published",
+              "title": "Workspaces",
+              "type": "published-personal-documents",
+              "dataTestHeader": "class-work-section-personal",
+              "dataTestItem": "class-work-list-items",
+              "documentTypes": ["personalPublication"]
+            }
+          ]
+        }
+      ]
+    },
+    "toolbar": [
+      {
+        "id": "Text",
+        "title": "Text",
+        "isTileTool": true
+      },
+      {
+        "id": "Table",
+        "title": "Table",
+        "isTileTool": true
+      },
+      {
+        "id": "Drawing",
+        "title": "Drawing",
+        "isTileTool": true
+      },
+      {
+        "id": "delete",
+        "title": "Delete",
+        "iconId": "icon-delete-tool",
+        "isTileTool": false
+      }
+    ],
+    "stamps": []
+  },
+  "planningDocument": {
+    "enable": "teacher",
+    "default": true,
+    "sectionInfo": {
+      "plan": {
+        "initials": "PL",
+        "title": "Plan",
+        "placeholder": "Plan the work; work the plan"
+      }
+    },
+    "sections": [{ "type": "plan" }]
+  },
+  "investigations": [
+    {
+      "description": "Investigation 1",
+      "ordinal": 1,
+      "title": "Example Investigation 1",
+      "problems": [
+        {
+          "description": "Problem 1.1",
+          "ordinal": 1,
+          "title": "1.1 Unit Toolbar Configuration",
+          "subtitle": "Text, Table, Drawing",
+          "sections": [
+            { "type": "first",
+              "content": {
+                "tiles": [
+                  {
+                    "content": {
+                      "type": "Text",
+                      "format": "html",
+                      "text": [
+                        "<p>Get Started Tab for 5th grade:</p>",
+                        "<p>Our town is part of the <strong>US Eastern deciduous forest </strong>region. What evidence of that can we observe outside? </p>",
+                        "<p>Divide your team  into roles: Recorder;  (2-3)Researchers; Presenter</p>",
+                        "<p><strong>Activity:</strong> </p>",
+                        "<p><strong>Get Started: </strong>Work with your group and use a<em><strong> text box</strong></em> (click the &#x27;A&#x27; tool on left ) to make a list in your <strong>Workspace</strong> of what you expect to find when you go outside to look. Format your list using the options below.</p>",
+                        "<p>To gather ideas, <strong>Researchers </strong>can...</p>",
+                        "<ul><li>view out the window, </li><li>look around your classroom/home for books  or magazines,</li><li>drag images from your computer onto your  <strong>Workspace </strong>by opening an <em><strong>image </strong></em>tile using that icon on the left. The upload button appears. Only one image per tile. You can resize your image by dragging the bottom right corner of the tile.</li></ul>",
+                        "<p>Your <strong>Recorder </strong>can record everyone&#x27;s ideas  in  their CLUE workspace.</p>"
+                      ]
+                    }
+                  },
+                  {
+                    "content": {
+                      "type": "Text",
+                      "format": "html",
+                      "text": [
+                        "<p>For the teacher:</p>",
+                        "<p><strong>Welcome to CLUE</strong>! Clue is short for <em>Collaborative Learning User Environment. </em>This environment is designed to make it easy for groups of up to four students to share their work and learn from each other. </p>",
+                        "<p>When the class starts an activity, CLUE drops students into groups randomly. If you prefer to assign students to groups, have them switch groups by clicking on the group number at upper right. </p>",
+                        "<p></p>",
+                        "<p></p>",
+                        "<p></p>"
+                      ]
+                    }
+                  },
+                  {
+                    "content": {
+                      "type": "Text",
+                      "format": "html",
+                      "text": [
+                        "<p>Field Notes tab for 5th grade:</p>",
+                        "<p><strong>Field Notes</strong>: Let&#x27;s go outside! Bring your science notebook  to make notes and drawings of what you find.</p>",
+                        "<p>When you come back  inside add  your top three observations to the <strong>Field Notes</strong> space on your <strong>Workspace</strong> .</p>",
+                        "<p></p>",
+                        "<p>You can make drawings of what you found  by choosing the  <strong><em>pencil</em></strong>   tool in the Workspace. If you counted the number of certain  items you discovered, use the <strong>table </strong>tool to create a table to share. </p>"
+                      ]
+                    }
+                  },
+                  {
+                    "content": {
+                      "type": "Table",
+                      "name": "Field Notes",
+                      "columns": [
+                        {"name":"x","values":["acorns","leaves","puffy clouds","sun AND moon!"]},
+                        {"name":"y","values":["25","lots","3","both"]}
+                      ]
+                    }
+                  },
+                  {
+                    "content": {
+                      "type": "Text",
+                      "format": "html",
+                      "text": [
+                        "<p>Share tab for 5th grade:</p>",
+                        "<p><strong>Share</strong> - Share to compare notes with your teammates! </p>",
+                        "<p>Click on the Share switch to share and discuss your ideas in the group view.</p>",
+                        "<p></p>",
+                        "<p>What different types of evidence of <strong>Eastern deciduous forest</strong> did your groupmates observe?</p>",
+                        "<ul><li>What did you expect to see that you did not see?</li><li>What did you see that you didn&#x27;t expect (didn’t list in <strong>Get Started</strong>?)</li><li>What did you observe that isn&#x27;t actually evidence of a forest ecosystem?</li></ul>",
+                        "<p>What might you expect to see looking different in four weeks? Why? </p>",
+                        "<p>Work with your group and use a <strong>table </strong> to list your findings and the changes you expect to see a month from now. Your <strong>Recorder</strong> can list all all ideas in their space to  share with the class. Add a text box if you have more questions as you imagine the schoolyard in 4 weeks. Select a <strong>Presenter </strong>to share your teamwork with the class.</p>"
+                      ]
+                    }
+                  },
+                  {
+                    "content": {
+                      "type": "Table",
+                      "name": "Our Comparison",
+                      "columns": [
+                        {"name":"Now"},
+                        {"name":"In 4 weeks "}
+                      ]
+                    }
+                  }
+                ]
+              },
+              "supports": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Demo: https://collaborative-learning.concord.org/branch/no-my-work/?appMode=dev&unit=example-no-my-work

Previously, the primary/editable workspace would not be displayed if my-work navigation was disabled. @lbondaryk asked about the feasibility of this configuration. While looking into it I realized it shouldn't be hard to implement, as this experiment demonstrates.