### PR TITLE
Fix duplicate keys warning from redundant publication thumbnails

### DIFF
--- a/src/components/thumbnail/documents-type-collection.tsx
+++ b/src/components/thumbnail/documents-type-collection.tsx
@@ -43,13 +43,13 @@ function getNewDocumentLabel(section: NavTabSectionModelType , appConfigStore: A
 
 function getSectionDocs(section: NavTabSectionModelType, documents: DocumentsModelType, user: UserModelType,
   isTeacherDocument: (document: DocumentModelType) => boolean) {
-  const publishedDocs: { [source: string]: DocumentModelType } = {};
   let sectDocs: DocumentModelType[] = [];
   (section.documentTypes || []).forEach(type => {
     if (isUnpublishedType(type)) {
       sectDocs.push(...documents.byTypeForUser(type as any, user.id));
     }
     else if (isPublishedType(type)) {
+      const publishedDocs: { [source: string]: DocumentModelType } = {};
       // only show the most recent publication of each document
       documents
         .byType(type as any)


### PR DESCRIPTION
While testing an unrelated PR I noticed duplicate key warnings from React. Eventually, I tracked it down to redundant publications as a result of a long-standing temporary variable lifetime issue which results in adding two thumbnails for each problem document to the Class Work browser in some circumstances. Odd that we haven't noticed this before.