### PR TITLE
Fix mothed curriculum

### DIFF
--- a/src/models/curriculum/unit.test.ts
+++ b/src/models/curriculum/unit.test.ts
@@ -72,4 +72,34 @@ describe("UnitModel", () => {
     expect(isDifferentUnitAndProblem(stores, "u2", "1.1")).toBe(true);
     expect(isDifferentUnitAndProblem(stores, "u2", "2.2")).toBe(true);
   });
+
+  it("can import legacy snapshots", () => {
+    const legacyPlaceholder = "Legacy Placeholder";
+    const snap = {
+      code: "code",
+      title: "Title",
+      placeholderText: legacyPlaceholder
+    };
+    const _unit = UnitModel.create(snap);
+    expect(_unit.config?.placeholderText).toBe(legacyPlaceholder);
+  });
+
+  it("treats ambiguous snapshots as modern rather than legacy", done => {
+    const legacyPlaceholder = "Legacy Placeholder";
+    const modernPlaceholder = "Modern Placeholder";
+    const snap = {
+      code: "code",
+      title: "Title",
+      placeholderText: legacyPlaceholder,
+      config: {
+        placeholderText: modernPlaceholder
+      }
+    };
+    jestSpyConsole("warn", spy => {
+      const _unit = UnitModel.create(snap);
+      expect(_unit.config?.placeholderText).toBe(modernPlaceholder);
+      expect(spy).toHaveBeenCalled();
+      done();
+    });
+  });
 });

--- a/src/models/curriculum/unit.ts
+++ b/src/models/curriculum/unit.ts
@@ -106,9 +106,19 @@ const ModernUnitModel = types
 interface LegacySnapshot extends SnapshotIn<typeof LegacyUnitModel> {}
 interface ModernSnapshot extends SnapshotIn<typeof ModernUnitModel> {}
 
-const isLegacySnapshot = (sn: ModernSnapshot | LegacySnapshot): sn is LegacySnapshot => {
+const hasLegacySnapshotProperties = (sn: ModernSnapshot | LegacySnapshot) => {
   const s = sn as LegacySnapshot;
   return !!s.disabled || !!s.navTabs || !!s.placeholderText || !!s.defaultStamps || !!s.settings;
+};
+
+const isLegacySnapshot = (sn: ModernSnapshot | LegacySnapshot): sn is LegacySnapshot => {
+  const s = sn as ModernSnapshot;
+  return !s.config && hasLegacySnapshotProperties(sn);
+};
+
+const isAmbiguousSnapshot = (sn: ModernSnapshot | LegacySnapshot): sn is LegacySnapshot => {
+  const s = sn as ModernSnapshot;
+  return !!s.config && hasLegacySnapshotProperties(sn);
 };
 
 export const UnitModel = types.snapshotProcessor(ModernUnitModel, {
@@ -118,6 +128,9 @@ export const UnitModel = types.snapshotProcessor(ModernUnitModel, {
         disabled: disabledFeatures, navTabs, placeholderText, defaultStamps: stamps, settings, ...others
       } = sn;
       return { ...others, config: { disabledFeatures, navTabs, placeholderText, stamps, settings } };
+    }
+    else if (isAmbiguousSnapshot(sn)) {
+      console.warn("UnitModel ignoring legacy top-level properties!");
     }
     return sn;
   }

--- a/src/public/curriculum/mothed/mothed.json
+++ b/src/public/curriculum/mothed/mothed.json
@@ -150,48 +150,6 @@
       }
     ]
   },
-  "navTabs": {
-    "lazyLoadTabContents": true,
-    "showNavPanel": true,
-    "tabSpecs": [
-      {
-        "tab": "problems",
-        "label": "Activity",
-        "sections": [
-          {
-            "initials": "GS",
-            "title": "Get Started",
-            "type": "problem-documents"
-          },
-          {
-            "initials": "FN",
-            "title": "Field Notes",
-            "type": "problem-documents"
-          },
-          {
-            "initials": "SH",
-            "title": "Share",
-            "type": "problem-documents"
-          }
-        ]
-      },
-      {
-        "tab": "class-work",
-        "label": "Class Activities",
-        "sections": [
-          {
-            "className": "section problem published",
-            "title": "Shared Activities",
-            "type": "published-problem-documents",
-            "dataTestHeader": "class-work-section-published",
-            "dataTestItem": "class-work-list-items",
-            "documentTypes": ["publication"],
-            "showStars": ["teacher"]
-          }
-        ]
-      }
-    ]
-  },
   "sections": {
     "getStarted": {
       "initials": "GS",


### PR DESCRIPTION
Eliminate top-level `navTabs` property which triggered legacy import.
Default to "modern" import format in case of ambiguous content.
Add unit tests to validate import behavior.