### PR TITLE
ImageMap Refactor

### DIFF
--- a/docs/image-map.md
+++ b/docs/image-map.md
@@ -1,14 +1,14 @@
-## Image Map
+# Image Map
 
 The Image Map is a cache used by CLUE to handle image loading. To understand this document it is best to review the document about [images](images.md)
 
 The key of an entry in the cache is its URL. As described in the images doc these URL can be:
-- regular http/https
+- regular http/https URLs
 - "local" assets stored in this repository
 - special URLs pointing at Firebase Storage or an object in the Firebase Realtime DB.
 
 Entries in the cache have the following properties:
-- **contentUrl** the location to download the image from. If the key of the entry is a URL that was modified before downloading this contentUrl contains the modified version.
+- **contentUrl** the location to download the image from. This URL might not be something the browser can handle directly. If the key of the entry is a URL that was modified before downloading, this contentUrl contains the modified version.
 - **displayUrl** a url to render the actual image, it should be a URL that can be used by the browser. For example the `src` of an `img` or the background of a div in css.
 - **width, height** the dimension of the image
 - **filename** if the image was loaded from a file, this is the name of the file
@@ -20,43 +20,34 @@ Entries in the cache can have 4 status values:
 - **Ready**: the image has been stored successfully and the dimensions computed successfully
 - **Error**: something went wrong while storing or computing the dimensions
 
-### Methods for working with the cache
+## Methods for working with the cache
 
 There are 2 main ways to work with the cache. Using promises and using MobX observation.
 
-To work with promises, call `getImage` with the URL you want to load. Use `then` or `await` to get its resolved value. It will resolve to the cache entry with a status of either `Ready` or `Error`.  If some other code has called `getImage` before you, the second call will not download the image again, it will wait for the first image to load and then resolve to the same cache entry.
+To work with promises, call `getImage` with the URL you want to load. Use `then` or `await` to get its resolved value. It will resolve to the cache entry with a status of either `Ready` or `Error`.  If some other code has called `getImage` before you, the your call will not download the image again, it will wait for the first image to load and then resolve to the same cache entry.
 
 To work with MobX observation, call `getImage` with the URL you want to load. Do not wait for the promise. Instead call `getCachedImage`. The returned entry will initially have a status of `Storing`. This entry can be observed so your code will update when its status, displayURL, and width and height are updated.
 
-### Error Handling
+## Error Handling
 
 When an error occurs during storing or getting the dimensions, the cache entry will have a status of `Error`.
 
-This error might be because of a network issue, so it could be temporary. It could also indicate the URL is just invalid. Currently no error message is provided. Also the cache does not automatically retry if a store or dimension computation fails.  However code using the cache can call `getImage` again after getting an error and the cache will attempt to store and compute the dimensions again.
+This error might be because of a network issue, so it could be temporary. It could also indicate the URL is invalid. Currently no error message is provided. Also the cache does not automatically retry if a store or dimension computation fails.  However code using the cache can call `getImage` again and the cache will attempt to store and compute the dimensions again.
 
 If the error happened while computing the dimensions the entry should have a valid displayUrl and might also have a contentUrl.  If the error happened during the storage phase the entry will typically have no contentUrl and its displayUrl will the be the placeholder image.
 
-#### Error Recovery
+The promise should not be rejected unless there is a bug in the code. This is because getImage is intended to work both in the promise approach and in the observer approach. Using the observer approach there would be no catch block on getImage, so the browser would report an unhandled promise error if the promise was rejected.
+
+### Error Recovery
 If getImage is called again for an entry that has a status of Error, the entry will be reset to the storing status. Its properties will be cleared and displayUrl will be the placeholderUrl.
 
 If an error happens during computing dimensions phase, the currentUrl and displayUrl of the content might be set to valid values. However to keep things simple these values are still cleared out when getImage is called again.
 
-#### Current Implementation Notes
-
-The Image Tool has catch block on some getImage calls but not all of them.
-
-geometry-content.tsx has a catch block on one getImage call but not the one that happens during a drop.
-
-geometry-import.ts does not have a catch block on its getImage call. 
-FIXME: This brings a up a good point, using the API in observer mode would result in uncaught exceptions if getImage rejected the promise. So either it should not reject, or it needs an option to avoid the reject.
-
-drawing-layer.tsx doesn't have a catch block on all getImage calls
-
-### URL Conversion
+## URL Conversion
 
 In some cases the URL that is sent to `getImage` needs to be converted. Here are the current reasons why:
-1. the url is a firebase storage URL. This is a legacy way to store images, so each time one of these is loaded the content of image is uploaded to the firebase realtime database, and this new location has new URL
-2. the url is an external url (http/https) in these cases the content is downloaded if possible and then uploaded to the firebase realtime database, this new location has new URL
+1. the url is a firebase storage URL. This is a legacy way to store images, so each time one of these is loaded the content of image is uploaded to the firebase realtime database.
+2. the url is an external url (http/https) in these cases the content is downloaded if possible and then uploaded to the firebase realtime database.
 3. the url is a local asset url and the asset's path has changed. The old asset path might still exist in student documents, so the cache handles changing the old paths into the new ones.
 4. the url is a legacy firebase realtime database url that does not include the classhash in the url as described in the images doc. In this case the URL is updated to include the classhash.
 
@@ -64,59 +55,63 @@ When the URL is changed, the cache is updated to contain an entry for both the o
 
 In some cases it is possible there is a cache entry already at the new URL. This can happen if the new URL was requested directly by some other part of CLUE content. I believe in conversion cases 1 and 2 the new URL will be unique each time so it is not possible for it to conflict. In cases 3 and 4 the new URL could conflict. 
 
-The cache entry for the new URL could be in any of 5 states: undefined or the 4 entry states. And the cache entry being stored at this new location could be in 3 states: Computing Dimensions, Ready, Error. 
+The cache entry for the new URL could be in any of 5 states: undefined or the 4 status states described above. And the cache entry being stored at this new location could be in 3 states: Computing Dimensions, Ready, Error. When the cache entry has a status of `Storing`, the converted URL is not known yet.
 
-Below are the combination of states between the new entry and the existing entry. 
+Below are the combination of states between the updated entry and the existing entry. 
 
-### New cache entry is in Ready state
+### Updated cache entry is in Ready state
 If the existing entry is 
 - `Ready` do nothing
-- `Computing Dimensions` this could happen either if the existing entry was created directly by getImage or if the existing entry was created because it is a copy of the original entry due to a URL conversion.  If the existing entry is copy of the original entry then it should be updated.  If the entry existing is not a copy then it should be left alone because there should be another promise updating it. Unlike `Computing Dimensions` an existing entry in the `Storing` state should never be copied due to a URL conversion.
-- `Storing` this should mean the existing entry is being updated by another promise, do nothing. If we overwrote the entry we'd kind of be orphaning the promise that was working on updating then entry. And it might mean the entry flips states in an unpredictable manner.
-- `Error` update the existing entry with the new entry's fields
-- `undefined` store a copy of new entry
+- `Computing Dimensions` this could happen either if:
+  1. the existing entry was created directly by `getImage`. In this case the existing entry should be left alone because there should be another promise updating it.
+  2. the existing entry was created because it is a copy of the updated entry that was made after the updated entry was stored before its dimensions were computed. In this case the existing entry should be updated because it is essentially managed by the current promise.
+- `Storing` this should mean the existing entry is being updated by another promise, do nothing. Unlike `Computing Dimensions` an existing entry in the `Storing` state should never be a copy due to a URL conversion.
+- `Error` update the existing entry with the updated entry's fields
+- `undefined` store a copy of the updated entry
 
-### New cache entry is in the Error state
+### Updated cache entry is in the Computing Dimensions state
 If the existing entry is 
 - `Ready` do nothing, the entry was already downloaded successfully leave it alone
-- `Computing Dimensions` this could happen either if the existing entry was created directly by getImage or if the existing entry was created because it is a copy of the original entry due to a URL conversion. If the existing entry is copy of the original entry then it should be updated. If the existing entry is not a copy then it should be left alone because there should be another promise updating it.
-- `Storing` this should mean the existing entry is being updated right now, do nothing. Hopefully this update of the entry will succeed where the new entry failed. Unlike `Computing Dimensions` an existing entry in the `Storing` state should never be copied due to a URL conversion.
-- `Error` do nothing, no point in replacing an error with an error.
-- `undefined` do nothing, there isn't a best approach here, but doing nothing simplifies the logic.
-
-### New cache entry is in the Computing Dimensions state
-If the existing entry is 
-- `Ready` do nothing, the entry was already downloaded successfully leave it alone
-- `Computing Dimensions` and `Storing` this should mean the existing entry is being updated right now, do nothing. If we overwrote the entry we'd kind of be orphaning the promise that was working on updating then entry. And it might mean the entry flips states in an unpredictable manner.
-- `Error` update the existing entry with the new entry. Also update the promise map so the URL of the existing entry maps to the promise of the new entry. This way if a `getImage` request comes in for existing entry's URL. This request will wait until the new entry promise has resolved.
+- `Computing Dimensions` and `Storing` this should mean the existing entry is being updated right now by a different promise, do nothing. Unlike when the updated cache entry is in the error or ready state, in this case the updated cache entry should not have been copied yet, so it can't managed by the same promise.
+- `Error` update the existing entry with the new entry. Also update the promise map so the URL of the existing entry maps to the promise of the updated entry. This way if a `getImage` request comes in for existing entry's URL. This request will wait until the updated entry's promise has resolved.
 - `undefined` same as `Error`
+
+### Updated cache entry is in the Error state
+If the existing entry is 
+- `Ready` do nothing, the entry was already downloaded successfully leave it alone
+- `Computing Dimensions` this could happen either if:
+  1. the existing entry was created directly by `getImage`. In this case the existing entry should be left alone because there should be another promise updating it.
+  2. the existing entry was created because it is a copy of the updated entry that was made after the updated entry was stored before its dimensions were computed. In this case the existing entry should be updated because it is essentially managed by the current promise.
+- `Storing` this should mean the existing entry is being updated right now, do nothing. Hopefully this update of the entry will succeed where the new entry failed. Unlike `Computing Dimensions` an existing entry in the `Storing` state should never be a copy due to a URL conversion.
+- `Error` do nothing, no point in replacing an error with an error.
+- `undefined` do nothing, no point is adding a error entry where one didn't exist before.
 
 ## Placeholder image
 
-Currently there is a special placeholder image used by the Image Map and some of the lower level image loading code. The Image Map will set it as the displayUrl if there is an error.
+Currently there is a special placeholder image used by the Image Map and some of the lower level image loading code. The Image Map will set it as the displayUrl if there is an error during storing. If there is an error during computing the dimensions the displayUrl should be a URL that should represent the actual image content.
 
 ## Filename
 
 The filename of an entry is needed so images that are used more than once in a tile or between multiple tiles can also know the filename. 
 
-For example a student adds a file to the image tile. The ImageMap will upload this image to the firebase realtime database. The entry in the cache will be stored under the URL to the image in the firebase realtime database. The filename might be shown to the user in the image tile. At this point the image tile knows the filename itself so there isn't a need to put it in the image map.  The image tile should store both the URL and the filename in its serialized state so this filename can be shown when the document is reloaded.
+For example a student adds a file to the image tile. The ImageMap will upload this image to the firebase realtime database. The entry in the ImageMap cache will be stored under the URL to the image in the firebase realtime database. The filename might be shown to the user in the image tile. At this point the image tile knows the filename itself so there isn't a need to put it in the image map.  The image tile should store both the URL and the filename in its serialized state so this filename can be shown when the document is reloaded.
 
-Now if this image tile dragged to a new document. The only thing actually transferred is the "content" URL to the image. So this the firebase realtime database URL. The user should still see the filename in the new image tile. This is solved by putting the filename in the cache entry. Now when the new image tile looks up the image in the cache it will know the filename too. 
+Now if this image tile is dragged to a new document. The only thing actually transferred is the "content" URL to the image. This is the firebase realtime database URL. The user should still see the filename in the new image tile, this filename is taken from the ImageMap cache entry that was stored when the file was uploaded. Now when the new image tile looks up the image in the cache it will know the filename too. 
 
 Because the cache is used this way to transfer the filename, it means when the document is reloaded the cache entries for any of these file based images need to have their filename set again. To support all of this there are two ways the filename can be set:
 
 1. It will be set when an image is first loaded from a file by calling `ImageMap#addFileImage`. 
-2. When `getImage` is called the filename can be passed as an additional parameter.
+2. When `getImage` is called, the filename can be passed as an additional parameter.
 
-Any tile that stores image URLs in its serialized state also needs to store the filename if it is available. This is because any tile might be the first one to request the image from the image map cache. All following requests will just work with the parameters of the first request. 
+Any tile that stores image URLs in its serialized state also needs to store the filename if it is available. This is because any tile might be the first one to request the image from the ImageMap cache. All following requests will just work with the parameters of the first request. 
 
-For example, the same image is used by a geometry tile and an image tile. To illustrate this lets assume the geometry tile doesn't store the filename. When the document is reloaded, if the geometry tile requested the URL for the image first, an entry will be added to the cache that doesn't have a filename. When the image tile requests the same URL it would get back an entry without a filename. The original image tile could know the filename from its own state. However if the image was copied to another document the new image tile would only have access to the info in the cache entry, so it would not know the filename.
+For example, the same image is used by a geometry tile and an image tile. To illustrate this lets assume the geometry tile doesn't store the filename. When the document is reloaded, if the geometry tile requested the URL for the image first, an entry will be added to the cache that doesn't have a filename. When the image tile requests the same URL it would get back an entry without a filename. This original image tile could know the filename from its own state. However if the image was then copied to another document the new image tile would only have access to the info in the cache entry, so it would not know the filename.
 
 ## Dimensions
 
 The width and height of the image entry might not be set. This can happen if you are are observing an entry which has a status of `storing`, `computingDimensions`, or `error`. 
 
-The best approach is for the client using the image map to store the dimensions in its state when they are known. This way when the image is being reloaded the client's components can reserve this space. Now if the entry has a width and height those can be used, otherwise the component falls back to the ones in the state. If the entries width height are different than what is in the state the state should be updated.
+The best approach is for the client using the image map to store the dimensions in its state when they are known. This way when the image is being reloaded the client's components can reserve this space. Now if the entry has a width and height those can be used, otherwise the component falls back to the width and height in the state. If the entries width height are different than what is in the state the state should be updated.
 
 When there is an error the cache returns a displayUrl of the placeholder image. But it doesn't return its dimensions. This is intentional. The error might be temporary (network glitch), so this allows the client to stick with any known dimensions. This prevents resizing or shifting when the actual image is loaded.
 
@@ -131,13 +126,11 @@ geometry-content.tsx only partially handles image dimensions the code in the deb
 It assumes the width and height are set with: 
   `const width = image.width! / kGeometryDefaultPixelsPerUnit;`
 Because this is in a getImage handler, it should mean it won't get a entry computing dimensions. But it might get one that has error'd.  
-FIXME: We should update this code so it can handles unset this would be the only place that does this. And I think it is better if the error entry doesn't set them. That way clients can use their existing dimensions to display the displayURL (a placeholder if an error) when they aren't available. Currently the width and height will be set to NaN.
+FIXME: We should update this code so it can handles undefined width and height values. It seems best to work on this in follow up PR.
 
-jxg-image is getting a size from the internal object. it doesn't use the dimensions of the imageEntry that it gets using getCachedImage. Instead it just uses the size that was set above. 
+jxg-image (a part of the geometry tile) is getting a size from the internal object. it doesn't use the dimensions of the imageEntry that it gets using getCachedImage. Instead it just uses the size that was set above. 
 
-drawing-layer.tsx (old version) assumes the image has a width and height. MST will throw an error in this code if there is an error and an image is returned without width and height
+drawing-layer.tsx (old version) assumes the image has a width and height. MST will throw an error in this code if there is an error and an image is returned without width and height. FIXME: This issue should be fixed in the new version.
 
 drawing-tool/objects/image.tsx this handles the case when the map entry doesn't have a width or height. It only updates its own image object width and height if they are set. So otherwise the width and height of the saved entry should be used.
-
-## Error Catching
 

--- a/docs/image-map.md
+++ b/docs/image-map.md
@@ -39,7 +39,7 @@ If the error happened while computing the dimensions the entry should have a val
 The promise should not be rejected unless there is a bug in the code. This is because getImage is intended to work both in the promise approach and in the observer approach. Using the observer approach there would be no catch block on getImage, so the browser would report an unhandled promise error if the promise was rejected.
 
 ### Error Recovery
-If getImage is called again for an entry that has a status of Error, the entry will be reset to the storing status. Its properties will be cleared and displayUrl will be the placeholderUrl.
+If `getImage` is called again for an entry that has a status of `Error`, the entry will be reset to the `PendingStorage` status. Its properties will be cleared and `displayUrl` will be the `placeholderUrl`.
 
 If an error happens during the `PendingDimensions` phase, the currentUrl and displayUrl of the content might be set to valid values. However to keep things simple these values are still cleared out when getImage is called again.
 
@@ -72,7 +72,7 @@ If the existing entry is
 ### Updated cache entry is in the PendingDimensions state
 If the existing entry is 
 - `Ready` do nothing, the entry was already downloaded successfully leave it alone
-- `PendingDimensions` and `PendingStorage` this should mean the existing entry is being updated right now by a different promise, do nothing. Unlike when the updated cache entry is in the error or ready state, in this case the updated cache entry should not have been copied yet, so it can't managed by the same promise.
+- `PendingDimensions` and `PendingStorage` this should mean the existing entry is being updated right now by a different promise, do nothing. Unlike when the updated cache entry is in the `Error` or `Ready` state, in this case the updated cache entry should not have been copied yet, so it can't managed by the same promise.
 - `Error` update the existing entry with the new entry. Also update the promise map so the URL of the existing entry maps to the promise of the updated entry. This way if a `getImage` request comes in for the existing entry's URL, this request will wait until the updated entry's promise has resolved.
 - `undefined` same as `Error`
 
@@ -125,7 +125,7 @@ If the height is not set then the desired height is undefined so no request is m
 geometry-content.tsx only partially handles image dimensions the code in the debouncing update ignores them. But code in tile drop and uploading background image also handles them. 
 It assumes the width and height are set with: 
   `const width = image.width! / kGeometryDefaultPixelsPerUnit;`
-Because this is in a getImage handler, it should mean it won't get a entry with a status of `PendingDimensions`. But it might get one that has a status of `Error`.  
+Because this is in a `getImage` handler, it should mean it won't get a entry with a status of `PendingDimensions`. But it might get one that has a status of `Error`.  
 FIXME: We should update this code so it handles undefined width and height values. It seems best to work on this in follow up PR.
 
 jxg-image (a part of the geometry tile) is getting a size from the internal object. it doesn't use the dimensions of the imageEntry that it gets using getCachedImage. Instead it just uses the size that was set above. 

--- a/docs/image-map.md
+++ b/docs/image-map.md
@@ -1,10 +1,10 @@
 # Image Map
 
-The Image Map is a cache used by CLUE to handle image loading. To understand this document it is best to review the document about [images](images.md)
+The Image Map is a cache used by CLUE to handle image loading. To understand this document it is best to review the document about [images](images.md).
 
-The key of an entry in the cache is its URL. As described in the images doc these URL can be:
+The key of an entry in the cache is its URL. As described in the images doc these URLs can be:
 - regular http/https URLs
-- "local" assets stored in this repository
+- "local" assets stored in this repository (generally curriculum images)
 - special URLs pointing at Firebase Storage or an object in the Firebase Realtime DB.
 
 Entries in the cache have the following properties:
@@ -24,7 +24,7 @@ Entries in the cache can have 4 status values:
 
 There are 2 main ways to work with the cache. Using promises and using MobX observation.
 
-To work with promises, call `getImage` with the URL you want to load. Use `then` or `await` to get its resolved value. It will resolve to the cache entry with a status of either `Ready` or `Error`.  If some other code has called `getImage` before you, the your call will not download the image again, it will wait for the first image to load and then resolve to the same cache entry.
+To work with promises, call `getImage` with the URL you want to load. Use `then` or `await` to get its resolved value. It will resolve to the cache entry with a status of either `Ready` or `Error`.  If some other code has called `getImage` before you, the call will not download the image again. It will wait for the first image to load and then resolve to the same cache entry.
 
 To work with MobX observation, call `getImage` with the URL you want to load. Do not wait for the promise. Instead call `getCachedImage`. The returned entry will initially have a status of `Storing`. This entry can be observed so your code will update when its status, displayURL, and width and height are updated.
 
@@ -73,7 +73,7 @@ If the existing entry is
 If the existing entry is 
 - `Ready` do nothing, the entry was already downloaded successfully leave it alone
 - `Computing Dimensions` and `Storing` this should mean the existing entry is being updated right now by a different promise, do nothing. Unlike when the updated cache entry is in the error or ready state, in this case the updated cache entry should not have been copied yet, so it can't managed by the same promise.
-- `Error` update the existing entry with the new entry. Also update the promise map so the URL of the existing entry maps to the promise of the updated entry. This way if a `getImage` request comes in for existing entry's URL. This request will wait until the updated entry's promise has resolved.
+- `Error` update the existing entry with the new entry. Also update the promise map so the URL of the existing entry maps to the promise of the updated entry. This way if a `getImage` request comes in for the existing entry's URL, this request will wait until the updated entry's promise has resolved.
 - `undefined` same as `Error`
 
 ### Updated cache entry is in the Error state
@@ -105,7 +105,7 @@ Because the cache is used this way to transfer the filename, it means when the d
 
 Any tile that stores image URLs in its serialized state also needs to store the filename if it is available. This is because any tile might be the first one to request the image from the ImageMap cache. All following requests will just work with the parameters of the first request. 
 
-For example, the same image is used by a geometry tile and an image tile. To illustrate this lets assume the geometry tile doesn't store the filename. When the document is reloaded, if the geometry tile requested the URL for the image first, an entry will be added to the cache that doesn't have a filename. When the image tile requests the same URL it would get back an entry without a filename. This original image tile could know the filename from its own state. However if the image was then copied to another document the new image tile would only have access to the info in the cache entry, so it would not know the filename.
+For example, the same image is used by a geometry tile and an image tile. To illustrate this let's assume the geometry tile doesn't store the filename. When the document is reloaded, if the geometry tile requested the URL for the image first, an entry will be added to the cache that doesn't have a filename. When the image tile requests the same URL it would get back an entry without a filename. This original image tile could know the filename from its own state. However if the image was then copied to another document the new image tile would only have access to the info in the cache entry, so it would not know the filename.
 
 ## Dimensions
 
@@ -126,7 +126,7 @@ geometry-content.tsx only partially handles image dimensions the code in the deb
 It assumes the width and height are set with: 
   `const width = image.width! / kGeometryDefaultPixelsPerUnit;`
 Because this is in a getImage handler, it should mean it won't get a entry computing dimensions. But it might get one that has error'd.  
-FIXME: We should update this code so it can handles undefined width and height values. It seems best to work on this in follow up PR.
+FIXME: We should update this code so it handles undefined width and height values. It seems best to work on this in follow up PR.
 
 jxg-image (a part of the geometry tile) is getting a size from the internal object. it doesn't use the dimensions of the imageEntry that it gets using getCachedImage. Instead it just uses the size that was set above. 
 

--- a/docs/image-map.md
+++ b/docs/image-map.md
@@ -1,0 +1,92 @@
+## Image Map
+
+The Image Map is a cache used by CLUE to handle image loading. To understand this document it is best to review the document about [images](images.md)
+
+The key of an entry in the cache is its URL. As described in the images doc these URL can be:
+- regular http/https
+- "local" assets stored in this repository
+- special URLs pointing at Firebase Storage or an object in the Firebase Realtime DB.
+
+Entries in the cache have the following properties:
+- **contentUrl** the location to download the image from. If the key of the entry is a URL that was modified before downloading this contentUrl contains the modified version.
+- **displayUrl** a url to render the actual image, it should be a URL that can be used by the browser. For example the `src` of an `img` or the background of a div in css.
+- **width, height** the dimension of the image
+- **filename** if the image was loaded from a file, this is the name of the file
+- **status** what state the entry is in, see below
+
+Entries in the cache can have 4 status values:
+- **Storing**: `getImage` has been called with a URL and this URL is being processed to download and store the image data.
+- **ComputingDimensions**: after the image data has been stored, the image is rendered offscreen to find out its dimensions. The resulting dimensions are added as the width and height on the entry
+- **Ready**: the image has been stored successfully and the dimensions computed successfully
+- **Error**: something went wrong while storing or computing the dimensions
+
+### Methods for working with the cache
+
+There are 2 main ways to work with the cache. Using promises and using MobX observation.
+
+To work with promises, call `getImage` with the URL you want to load. Use `then` or `await` to get its resolved value. It will resolve to the cache entry with a status of either `Ready` or `Error`.  If some other code has called `getImage` before you, the second call will not download the image again, it will wait for the first image to load and then resolve to the same cache entry.
+
+To work with MobX observation, call `getImage` with the URL you want to load. Do not wait for the promise. Instead call `getCachedImage`. The returned entry will initially have a status of `Storing`. This entry can be observed so your code will update when its status, displayURL, and width and height are updated.
+
+### Error Handling
+
+When an error occurs during storing or getting the dimensions, the cache entry will have a status of `Error`.
+This error might be because of a network issue, so it could be temporary. It could also indicate the URL is just invalid. Currently no error message is provided. Also the cache does not automatically retry if a store or dimension computation fails.  However code using the cache can call `getImage` again after getting an error and the cache will attempt to store and compute the dimensions again.
+
+### URL Conversion
+
+In some cases the URL that is sent to `getImage` needs to be converted. Here are the current reasons why:
+1. the url is a firebase storage URL. This is a legacy way to store images, so each time one of these is loaded the content of image is uploaded to the firebase realtime database, and this new location has new URL
+2. the url is an external url (http/https) in these cases the content is downloaded if possible and then uploaded to the firebase realtime database, this new location has new URL
+3. the url is a local asset url and the asset's path has changed. The old asset path might still exist in student documents, so the cache handles changing the old paths into the new ones.
+4. the url is a legacy firebase realtime database url that does not include the classhash in the url as described in the images doc. In this case the URL is updated to include the classhash.
+
+When the URL is changed, the cache is updated to contain an entry for both the old URL and the new URL. Both entries will have the new URL as their `contentUrl`.
+
+In some cases it is possible there is a cache entry already at the new URL. This can happen if the new URL was requested directly by some other part of CLUE content. I believe in conversion cases 1 and 2 the new URL will be unique each time so it is not possible for it to conflict. In cases 3 and 4 the new URL could conflict. 
+
+The cache entry for the new URL could be in any of 5 states: undefined or the 4 entry states. And the cache entry being stored at this new location could be in 3 states: Computing Dimensions, Ready, Error. 
+
+Below are the combination of states between the new entry and the existing entry. 
+
+### New cache entry is in Ready state
+If the existing entry is 
+- `Ready` do nothing
+- `Computing Dimensions` and `Storing` this should mean the existing entry is being updated right now, do nothing. If we overwrote the entry we'd kind of be orphaning the promise that was working on updating then entry. And it might mean the entry flips states in an unpredictable manner.
+- `Error` update the existing entry with the new entry's fields
+- `undefined` store a copy of new entry
+
+### New cache entry is in the Error state
+If the existing entry is 
+- `Ready` do nothing, the entry was already downloaded successfully leave it alone
+- `Computing Dimensions` and `Storing` this should mean the existing entry is being updated right now, do nothing. Hopefully this update of the entry will succeed where the new entry failed.
+- `Error` do nothing, no point in replacing an error with an error.
+- `undefined` do nothing, there isn't a best approach here, but doing nothing simplifies the logic.
+
+### New cache entry is in the Computing Dimensions state
+If the existing entry is 
+- `Ready` do nothing, the entry was already downloaded successfully leave it alone
+- `Computing Dimensions` and `Storing` this should mean the existing entry is being updated right now, do nothing. If we overwrote the entry we'd kind of be orphaning the promise that was working on updating then entry. And it might mean the entry flips states in an unpredictable manner.
+- `Error` update the existing entry with the new entry. Also update the promise map so the URL of the existing entry maps to the promise of the new entry. This way if a `getImage` request comes in for existing entry's URL. This request will wait until the new entry promise has resolved.
+- `undefined` same as `Error`
+
+## Placeholder image
+
+Currently there is a special placeholder image used by the Image Map and some of the lower level image loading code. The Image Map will set it as the displayUrl if there is an error.
+
+## Filename
+
+The filename of an entry is needed so images that are used more than once in a tile or between multiple tiles can also know the filename. 
+
+For example a student adds a file to the image tile. The ImageMap will upload this image to the firebase realtime database. The entry in the cache will be stored under the URL to the image in the firebase realtime database. The filename might be shown to the user in the image tile. At this point the image tile knows the filename itself so there isn't a need to put it in the image map.  The image tile should store both the URL and the filename in its serialized state so this filename can be shown when the document is reloaded.
+
+Now if this image tile dragged to a new document. The only thing actually transferred is the "content" URL to the image. So this the firebase realtime database URL. The user should still see the filename in the new image tile. This is solved by putting the filename in the cache entry. Now when the new image tile looks up the image in the cache it will know the filename too. 
+
+Because the cache is used this way to transfer the filename, it means when the document is reloaded the cache entries for any of these file based images need to have their filename set again. To support all of this there are two ways the filename can be set:
+
+1. It will be set when an image is first loaded from a file by calling `ImageMap#addFileImage`. 
+2. When `getImage` is called the filename can be passed as an additional parameter.
+
+Any tile that stores image URLs in its serialized state also needs to store the filename if it is available. This is because any tile might be the first one to request the image from the image map cache. All following requests will just work with the parameters of the first request. 
+
+For example, the same image is used by a geometry tile and an image tile. To illustrate this lets assume the geometry tile doesn't store the filename. When the document is reloaded, if the geometry tile requested the URL for the image first, an entry will be added to the cache that doesn't have a filename. When the image tile requests the same URL it would get back an entry without a filename. The original image tile could know the filename from its own state. However if the image was copied to another document the new image tile would only have access to the info in the cache entry, so it would not know the filename.

--- a/docs/image-map.md
+++ b/docs/image-map.md
@@ -15,8 +15,8 @@ Entries in the cache have the following properties:
 - **status** what state the entry is in, see below
 
 Entries in the cache can have 4 status values:
-- **Storing**: `getImage` has been called with a URL and this URL is being processed to download and store the image data.
-- **ComputingDimensions**: after the image data has been stored, the image is rendered offscreen to find out its dimensions. The resulting dimensions are added as the width and height on the entry
+- **PendingStorage**: `getImage` has been called with a URL and this URL is being processed to download and store the image data.
+- **PendingDimensions**: after the image data has been stored, the image is rendered offscreen to find out its dimensions. The resulting dimensions are added as the width and height on the entry
 - **Ready**: the image has been stored successfully and the dimensions computed successfully
 - **Error**: something went wrong while storing or computing the dimensions
 
@@ -26,7 +26,7 @@ There are 2 main ways to work with the cache. Using promises and using MobX obse
 
 To work with promises, call `getImage` with the URL you want to load. Use `then` or `await` to get its resolved value. It will resolve to the cache entry with a status of either `Ready` or `Error`.  If some other code has called `getImage` before you, the call will not download the image again. It will wait for the first image to load and then resolve to the same cache entry.
 
-To work with MobX observation, call `getImage` with the URL you want to load. Do not wait for the promise. Instead call `getCachedImage`. The returned entry will initially have a status of `Storing`. This entry can be observed so your code will update when its status, displayURL, and width and height are updated.
+To work with MobX observation, call `getImage` with the URL you want to load. Do not wait for the promise. Instead call `getCachedImage`. The returned entry will initially have a status of `PendingStorage`. This entry can be observed so your code will update when its status, displayURL, and width and height are updated.
 
 ## Error Handling
 
@@ -41,7 +41,7 @@ The promise should not be rejected unless there is a bug in the code. This is be
 ### Error Recovery
 If getImage is called again for an entry that has a status of Error, the entry will be reset to the storing status. Its properties will be cleared and displayUrl will be the placeholderUrl.
 
-If an error happens during computing dimensions phase, the currentUrl and displayUrl of the content might be set to valid values. However to keep things simple these values are still cleared out when getImage is called again.
+If an error happens during the `PendingDimensions` phase, the currentUrl and displayUrl of the content might be set to valid values. However to keep things simple these values are still cleared out when getImage is called again.
 
 ## URL Conversion
 
@@ -55,34 +55,34 @@ When the URL is changed, the cache is updated to contain an entry for both the o
 
 In some cases it is possible there is a cache entry already at the new URL. This can happen if the new URL was requested directly by some other part of CLUE content. I believe in conversion cases 1 and 2 the new URL will be unique each time so it is not possible for it to conflict. In cases 3 and 4 the new URL could conflict. 
 
-The cache entry for the new URL could be in any of 5 states: undefined or the 4 status states described above. And the cache entry being stored at this new location could be in 3 states: Computing Dimensions, Ready, Error. When the cache entry has a status of `Storing`, the converted URL is not known yet.
+The cache entry for the new URL could be in any of 5 states: undefined or the 4 status states described above. And the cache entry being stored at this new location could be in 3 states: `PendingDimensions`, `Ready`, `Error`. When the cache entry has a status of `PendingStorage`, the converted URL is not known yet.
 
 Below are the combination of states between the updated entry and the existing entry. 
 
 ### Updated cache entry is in Ready state
 If the existing entry is 
 - `Ready` do nothing
-- `Computing Dimensions` this could happen either if:
+- `PendingDimensions` this could happen either if:
   1. the existing entry was created directly by `getImage`. In this case the existing entry should be left alone because there should be another promise updating it.
   2. the existing entry was created because it is a copy of the updated entry that was made after the updated entry was stored before its dimensions were computed. In this case the existing entry should be updated because it is essentially managed by the current promise.
-- `Storing` this should mean the existing entry is being updated by another promise, do nothing. Unlike `Computing Dimensions` an existing entry in the `Storing` state should never be a copy due to a URL conversion.
+- `PendingStorage` this should mean the existing entry is being updated by another promise, do nothing. Unlike `PendingDimensions` an existing entry in the `PendingStorage` state should never be a copy due to a URL conversion.
 - `Error` update the existing entry with the updated entry's fields
 - `undefined` store a copy of the updated entry
 
-### Updated cache entry is in the Computing Dimensions state
+### Updated cache entry is in the PendingDimensions state
 If the existing entry is 
 - `Ready` do nothing, the entry was already downloaded successfully leave it alone
-- `Computing Dimensions` and `Storing` this should mean the existing entry is being updated right now by a different promise, do nothing. Unlike when the updated cache entry is in the error or ready state, in this case the updated cache entry should not have been copied yet, so it can't managed by the same promise.
+- `PendingDimensions` and `PendingStorage` this should mean the existing entry is being updated right now by a different promise, do nothing. Unlike when the updated cache entry is in the error or ready state, in this case the updated cache entry should not have been copied yet, so it can't managed by the same promise.
 - `Error` update the existing entry with the new entry. Also update the promise map so the URL of the existing entry maps to the promise of the updated entry. This way if a `getImage` request comes in for the existing entry's URL, this request will wait until the updated entry's promise has resolved.
 - `undefined` same as `Error`
 
 ### Updated cache entry is in the Error state
 If the existing entry is 
 - `Ready` do nothing, the entry was already downloaded successfully leave it alone
-- `Computing Dimensions` this could happen either if:
+- `PendingDimensions` this could happen either if:
   1. the existing entry was created directly by `getImage`. In this case the existing entry should be left alone because there should be another promise updating it.
   2. the existing entry was created because it is a copy of the updated entry that was made after the updated entry was stored before its dimensions were computed. In this case the existing entry should be updated because it is essentially managed by the current promise.
-- `Storing` this should mean the existing entry is being updated right now, do nothing. Hopefully this update of the entry will succeed where the new entry failed. Unlike `Computing Dimensions` an existing entry in the `Storing` state should never be a copy due to a URL conversion.
+- `PendingStorage` this should mean the existing entry is being updated right now, do nothing. Hopefully this update of the entry will succeed where the new entry failed. Unlike `PendingDimensions` an existing entry in the `PendingStorage` state should never be a copy due to a URL conversion.
 - `Error` do nothing, no point in replacing an error with an error.
 - `undefined` do nothing, no point is adding a error entry where one didn't exist before.
 
@@ -109,7 +109,7 @@ For example, the same image is used by a geometry tile and an image tile. To ill
 
 ## Dimensions
 
-The width and height of the image entry might not be set. This can happen if you are are observing an entry which has a status of `storing`, `computingDimensions`, or `error`. 
+The width and height of the image entry might not be set. This can happen if you are are observing an entry which has a status of `PendingStorage`, `PendingDimensions`, or `Error`. 
 
 The best approach is for the client using the image map to store the dimensions in its state when they are known. This way when the image is being reloaded the client's components can reserve this space. Now if the entry has a width and height those can be used, otherwise the component falls back to the width and height in the state. If the entries width height are different than what is in the state the state should be updated.
 
@@ -125,7 +125,7 @@ If the height is not set then the desired height is undefined so no request is m
 geometry-content.tsx only partially handles image dimensions the code in the debouncing update ignores them. But code in tile drop and uploading background image also handles them. 
 It assumes the width and height are set with: 
   `const width = image.width! / kGeometryDefaultPixelsPerUnit;`
-Because this is in a getImage handler, it should mean it won't get a entry computing dimensions. But it might get one that has error'd.  
+Because this is in a getImage handler, it should mean it won't get a entry with a status of `PendingDimensions`. But it might get one that has a status of `Error`.  
 FIXME: We should update this code so it handles undefined width and height values. It seems best to work on this in follow up PR.
 
 jxg-image (a part of the geometry tile) is getting a size from the internal object. it doesn't use the dimensions of the imageEntry that it gets using getCachedImage. Instead it just uses the size that was set above. 

--- a/src/models/image-map.test.ts
+++ b/src/models/image-map.test.ts
@@ -356,7 +356,7 @@ describe("ImageMap", () => {
       await when(() => !!sImageMap.getCachedImage(kLocalImageUrl));
       
       const imageEntry = sImageMap.getCachedImage(kLocalImageUrl);
-      expect(imageEntry?.status).toBe(EntryStatus.ComputingDimensions);
+      expect(imageEntry?.status).toBe(EntryStatus.PendingDimensions);
   
       expect(dimSpy).toHaveBeenCalled();
       // We wait for 20ms just to give the javascript engine time to resolve
@@ -451,9 +451,9 @@ describe("ImageMap", () => {
       const getImagePromise2 = sImageMap.getImage(kLocalImageUrl);
       
       // TODO: it'd be good to check the intermediate state to see that the 
-      // main entry is has a storing status. And then when addImage is called
-      // the main entry and the copied entry have a computingDimensions state
-      // Doing this would require setting up a delayed 
+      // main entry has a `PendingStorage` status. And then when addImage is called
+      // the main entry and the copied entry have a `PendingDimensions` state
+      // Doing this would require setting up a delayed getDimensions like above
 
       const returnedEntry2 = await getImagePromise2;
       const expectedEntry2 = {
@@ -473,14 +473,14 @@ describe("ImageMap", () => {
       // Directly add an initial entry
       const initialEntry = {
         displayUrl: "bogus",
-        status: EntryStatus.Storing
+        status: EntryStatus.PendingStorage
       };
       unsafeUpdate(() => sImageMap.images.set(kLocalImageUrl, initialEntry));
 
       const consoleSpy = jest.spyOn(global.console, "warn").mockImplementation();
       const getImagePromise = sImageMap.getImage(kLocalImageUrl);
       expect(sImageMap.getCachedImage(kLocalImageUrl)).toEqual({
-        status: EntryStatus.Storing,
+        status: EntryStatus.PendingStorage,
         displayUrl: placeholderImage
       });
       expect(consoleSpy).toBeCalledTimes(1);
@@ -555,7 +555,7 @@ describe("ImageMap", () => {
       };
       unsafeUpdate(() => sImageMap.images.set(kLocalImageUrl, initialEntry));
   
-      // It synchronously updates the entry and changes the status to computingDimensions.
+      // It synchronously updates the entry and changes the status to `PendingDimensions`.
       const changedStoreResult = {
         contentUrl: kLocalImageUrl2,
         displayUrl: kLocalImageUrl2,
@@ -566,7 +566,7 @@ describe("ImageMap", () => {
       expect(sImageMap.getCachedImage(kLocalImageUrl)).toEqual({
         contentUrl: kLocalImageUrl2,
         displayUrl: kLocalImageUrl2,
-        status: EntryStatus.ComputingDimensions
+        status: EntryStatus.PendingDimensions
       });
   
       // Then asynchronously after the getImageDimensions call returns,
@@ -625,11 +625,11 @@ describe("ImageMap", () => {
       await sImageMap._addImage(kLocalImageUrl, storeResult);
       expect(entryInMap).toEqual(expectedEntry);
 
-      resetEntryInMap(EntryStatus.ComputingDimensions);
+      resetEntryInMap(EntryStatus.PendingDimensions);
       await sImageMap._addImage(kLocalImageUrl, storeResult);
       expect(entryInMap).toEqual(expectedEntry);
 
-      resetEntryInMap(EntryStatus.Storing);
+      resetEntryInMap(EntryStatus.PendingStorage);
       await sImageMap._addImage(kLocalImageUrl, storeResult);
       expect(entryInMap).toEqual(expectedEntry);
 

--- a/src/models/image-map.test.ts
+++ b/src/models/image-map.test.ts
@@ -1,3 +1,5 @@
+import { runInAction, when } from "mobx";
+import { applySnapshot, destroy, protect, unprotect } from "mobx-state-tree";
 import { externalUrlImagesHandler, localAssetsImagesHandler,
         firebaseRealTimeDBImagesHandler, firebaseStorageImagesHandler,
         IImageHandler, ImageMapEntry, ImageMapModel, ImageMapModelType, 
@@ -7,8 +9,6 @@ import { parseFirebaseImageUrl } from "../../functions/src/shared-utils";
 import { DB } from "../lib/db";
 import * as ImageUtils from "../utilities/image-utils";
 import placeholderImage from "../assets/image_placeholder.png";
-import { runInAction, when } from "mobx";
-import { applySnapshot, destroy, protect, unprotect } from "mobx-state-tree";
 
 let sImageMap: ImageMapModelType;
 

--- a/src/models/image-map.test.ts
+++ b/src/models/image-map.test.ts
@@ -1,7 +1,7 @@
 import { externalUrlImagesHandler, localAssetsImagesHandler,
         firebaseRealTimeDBImagesHandler, firebaseStorageImagesHandler,
         IImageHandler, ImageMapEntry, ImageMapModel, ImageMapModelType, 
-        EntryStatus, ImageMapEntrySnapshot, ImageMapEntryType, IImageHandlerStoreOptions, 
+        EntryStatus, IImageHandlerStoreOptions, 
         IImageHandlerStoreResult } from "./image-map";
 import { parseFirebaseImageUrl } from "../../functions/src/shared-utils";
 import { DB } from "../lib/db";
@@ -92,9 +92,9 @@ describe("ImageMap", () => {
   it("test localAssetsImagesHandler", () => {
     expectToMatch(localAssetsImagesHandler, [kLocalImageUrl]);
     return localAssetsImagesHandler.store(kLocalImageUrl)
-            .then(imageResult => {
-              expect(imageResult.contentUrl).toBe(kLocalImageUrl);
-              expect(imageResult.displayUrl).toBe(kLocalImageUrl);
+            .then(storeResult => {
+              expect(storeResult.contentUrl).toBe(kLocalImageUrl);
+              expect(storeResult.displayUrl).toBe(kLocalImageUrl);
             });
   });
 
@@ -109,21 +109,21 @@ describe("ImageMap", () => {
                             .mockImplementation(() =>
                               Promise.resolve({ imageUrl: kCCImgFBRTDBUrl, imageData: kBlobUrl}));
       p1 = externalUrlImagesHandler.store(kHttpsImageUrl, { db: createMockDB() })
-        .then(imageResult => {
+        .then(storeResult => {
           expect(storeSpy).toHaveBeenCalled();
-          expect(imageResult.contentUrl &&
-                  firebaseRealTimeDBImagesHandler.match(imageResult.contentUrl)).toBe(true);
-          expect(imageResult.displayUrl).toMatch(/^blob:/);
+          expect(storeResult.contentUrl &&
+                  firebaseRealTimeDBImagesHandler.match(storeResult.contentUrl)).toBe(true);
+          expect(storeResult.displayUrl).toMatch(/^blob:/);
         });
     }
     {
       const storeSpy = jest.spyOn(ImageUtils, "storeImage")
                             .mockImplementation(() => Promise.reject(new Error("Loading error")));
       p2 = externalUrlImagesHandler.store(kHttpsImageUrl, { db: createMockDB() })
-        .then(imageResult => {
+        .then(storeResult => {
           expect(storeSpy).toHaveBeenCalled();
-          expect(imageResult.contentUrl).toBe(kHttpsImageUrl);
-          expect(imageResult.displayUrl).toBe(kHttpsImageUrl);
+          expect(storeResult.contentUrl).toBe(kHttpsImageUrl);
+          expect(storeResult.displayUrl).toBe(kHttpsImageUrl);
         });
     }
     return Promise.all([p1, p2]);
@@ -139,10 +139,10 @@ describe("ImageMap", () => {
                             .mockImplementation(() =>
                               Promise.resolve({ imageUrl: placeholderImage, imageData: placeholderImage}));
       p1 = externalUrlImagesHandler.store(kHttpsImage2, { db: createMockDB() })
-        .then(imageResult => {
+        .then(storeResult => {
           expect(storeSpy).toHaveBeenCalled();
-          expect(imageResult.contentUrl).toBe(kHttpsImage2);
-          expect(imageResult.displayUrl).toBe(kHttpsImage2);
+          expect(storeResult.contentUrl).toBe(kHttpsImage2);
+          expect(storeResult.displayUrl).toBe(kHttpsImage2);
         });
     }
     {
@@ -151,10 +151,10 @@ describe("ImageMap", () => {
                             .mockImplementation(() =>
                               Promise.resolve({ imageUrl: placeholderImage, imageData: placeholderImage}));
       p2 = externalUrlImagesHandler.store(kHttpsImage3, { db: createMockDB({ stores: { user: { id: "" }} }) })
-        .then(imageResult => {
+        .then(storeResult => {
           expect(storeSpy).toHaveBeenCalled();
-          expect(imageResult.contentUrl).toBe(kHttpsImage3);
-          expect(imageResult.displayUrl).toBe(kHttpsImage3);
+          expect(storeResult.contentUrl).toBe(kHttpsImage3);
+          expect(storeResult.displayUrl).toBe(kHttpsImage3);
         });
     }
     return Promise.all([p1, p2]);
@@ -166,11 +166,11 @@ describe("ImageMap", () => {
     const storeSpy = jest.spyOn(ImageUtils, "storeCorsImage")
                           .mockImplementation(() => Promise.resolve({ imageUrl: kCCImgFBRTDBUrl, imageData: kBlobUrl}));
     return firebaseStorageImagesHandler.store(kFBStorageUrl, { db: createMockDB() })
-      .then(imageResult => {
+      .then(storeResult => {
         expect(storeSpy).toHaveBeenCalled();
-        expect(imageResult.contentUrl &&
-                firebaseRealTimeDBImagesHandler.match(imageResult.contentUrl)).toBe(true);
-        expect(imageResult.displayUrl).toMatch(/^blob:/);
+        expect(storeResult.contentUrl &&
+                firebaseRealTimeDBImagesHandler.match(storeResult.contentUrl)).toBe(true);
+        expect(storeResult.displayUrl).toMatch(/^blob:/);
       });
   });
 
@@ -178,11 +178,11 @@ describe("ImageMap", () => {
     const storeSpy = jest.spyOn(ImageUtils, "storeCorsImage")
                           .mockImplementation(() => Promise.resolve({ imageUrl: kCCImgFBRTDBUrl, imageData: kBlobUrl}));
     return firebaseStorageImagesHandler.store(kFBStorageRef, { db: createMockDB() })
-      .then(imageResult => {
+      .then(storeResult => {
         expect(storeSpy).toHaveBeenCalled();
-        expect(imageResult.contentUrl &&
-                firebaseRealTimeDBImagesHandler.match(imageResult.contentUrl)).toBe(true);
-        expect(imageResult.displayUrl).toMatch(/^blob:/);
+        expect(storeResult.contentUrl &&
+                firebaseRealTimeDBImagesHandler.match(storeResult.contentUrl)).toBe(true);
+        expect(storeResult.displayUrl).toMatch(/^blob:/);
       });
   });
 
@@ -193,21 +193,21 @@ describe("ImageMap", () => {
     // const storeSpy = jest.spyOn(ImageUtils, "storeImage")
     //                       .mockImplementation(() => Promise.resolve({ imageUrl: kCCImgFBRTDB, imageData: kBlobUrl}));
     firebaseStorageImagesHandler.store(kCCImgFBRTDBUrl, { db: mockDB })
-      .then(imageResult => {
+      .then(storeResult => {
         // expect(storeSpy).not.toHaveBeenCalled();
-        expect(imageResult.contentUrl).toBeUndefined();
-        expect(imageResult.displayUrl).toBe(placeholderImage);
-        expect(imageResult.success).toBe(false);
+        expect(storeResult.contentUrl).toBeUndefined();
+        expect(storeResult.displayUrl).toBe(placeholderImage);
+        expect(storeResult.success).toBe(false);
       });
 
     // handle invalid user Id
     mockDB.stores.user.id = "";
     firebaseStorageImagesHandler.store(kCCImgFBRTDBUrl, { db: mockDB })
-      .then(imageResult => {
+      .then(storeResult => {
         // expect(storeSpy).not.toHaveBeenCalled();
-        expect(imageResult.contentUrl).toBeUndefined();
-        expect(imageResult.displayUrl).toBe(placeholderImage);
-        expect(imageResult.success).toBe(false);
+        expect(storeResult.contentUrl).toBeUndefined();
+        expect(storeResult.displayUrl).toBe(placeholderImage);
+        expect(storeResult.success).toBe(false);
       });
   });
 
@@ -219,10 +219,10 @@ describe("ImageMap", () => {
     // const storeSpy = jest.spyOn(ImageUtils, "storeImage")
     //                       .mockImplementation(() => Promise.reject(new Error("Conversion error")));
     return firebaseStorageImagesHandler.store(kCCImgFBRTDBUrl, { db: mockDB })
-      .then(imageResult => {
+      .then(storeResult => {
         // expect(storeSpy).not.toHaveBeenCalled();
-        expect(imageResult.contentUrl).toBeUndefined();
-        expect(imageResult.displayUrl).toBe(placeholderImage);
+        expect(storeResult.contentUrl).toBeUndefined();
+        expect(storeResult.displayUrl).toBe(placeholderImage);
       });
   });
 
@@ -230,11 +230,11 @@ describe("ImageMap", () => {
     const storeSpy = jest.spyOn(ImageUtils, "storeCorsImage")
                           .mockImplementation(() => Promise.reject(new Error("Conversion error")));
     return firebaseStorageImagesHandler.store(kCCImgFBRTDBUrl, { db: createMockDB() })
-      .then(imageResult => {
+      .then(storeResult => {
         expect(storeSpy).toHaveBeenCalled();
-        expect(imageResult.contentUrl).toBeUndefined();
-        expect(imageResult.displayUrl).toBe(placeholderImage);
-        expect(imageResult.success).toBe(false);
+        expect(storeResult.contentUrl).toBeUndefined();
+        expect(storeResult.displayUrl).toBe(placeholderImage);
+        expect(storeResult.success).toBe(false);
       });
   });
 
@@ -248,39 +248,39 @@ describe("ImageMap", () => {
     {
       const mockDB = createMockDB();
       p1 = firebaseRealTimeDBImagesHandler.store(kCCImgOriginalUrl, { db: mockDB })
-        .then(imageResult => {
+        .then(storeResult => {
           // url doesn't include classHash, so we use the firebase function
           expect(mockDB.getCloudImageBlob).toHaveBeenCalledWith(kCCImgFBRTDBUrl);
-          expect(imageResult.contentUrl).toBe(kCCImgFBRTDBUrl);
-          expect(imageResult.displayUrl).toMatch(/^blob:/);
+          expect(storeResult.contentUrl).toBe(kCCImgFBRTDBUrl);
+          expect(storeResult.displayUrl).toMatch(/^blob:/);
         });
     }
     {
       const mockDB = createMockDB();
       p2 = firebaseRealTimeDBImagesHandler.store(kCCImgFBRTDBUrl, { db: mockDB })
-        .then(imageResult => {
+        .then(storeResult => {
           // url doesn't include classHash, so we use the firebase function
           expect(mockDB.getCloudImageBlob).toHaveBeenCalledWith(kCCImgFBRTDBUrl);
-          expect(imageResult.contentUrl).toBe(kCCImgFBRTDBUrl);
-          expect(imageResult.displayUrl).toMatch(/^blob:/);
+          expect(storeResult.contentUrl).toBe(kCCImgFBRTDBUrl);
+          expect(storeResult.displayUrl).toMatch(/^blob:/);
         });
     }
     {
       const mockDB = createMockDB();
       p3 = firebaseRealTimeDBImagesHandler.store(kCCImgClassFBRTDBUrl, { db: mockDB })
-        .then(imageResult => {
+        .then(storeResult => {
           // url does include classHash, so we can retrieve it locally
           expect(mockDB.getImageBlob).toHaveBeenCalledWith(imageKey);
-          expect(imageResult.contentUrl).toBe(kCCImgClassFBRTDBUrl);
-          expect(imageResult.displayUrl).toMatch(/^blob:/);
+          expect(storeResult.contentUrl).toBe(kCCImgClassFBRTDBUrl);
+          expect(storeResult.displayUrl).toMatch(/^blob:/);
         });
     }
     {
       p4 = firebaseRealTimeDBImagesHandler.store("", { db: createMockDB() })
-        .then(imageResult => {
-          expect(imageResult.contentUrl).toBeUndefined();
-          expect(imageResult.displayUrl).toBe(placeholderImage);
-          expect(imageResult.success).toBe(false);
+        .then(storeResult => {
+          expect(storeResult.contentUrl).toBeUndefined();
+          expect(storeResult.displayUrl).toBe(placeholderImage);
+          expect(storeResult.success).toBe(false);
         });
     }
     return Promise.all([p1, p2, p3, p4]);
@@ -471,10 +471,10 @@ describe("ImageMap", () => {
     it("should handle entries that are in invalid states", async () => {
       expect.assertions(3);
       // Directly add an initial entry
-      const initialEntry = ImageMapEntry.create({
+      const initialEntry = {
         displayUrl: "bogus",
         status: EntryStatus.Storing
-      });
+      };
       unsafeUpdate(() => sImageMap.images.set(kLocalImageUrl, initialEntry));
 
       const consoleSpy = jest.spyOn(global.console, "warn").mockImplementation();
@@ -541,27 +541,27 @@ describe("ImageMap", () => {
             });
   });
 
-  describe("addImage", () => {
+  describe("_addImage", () => {
     it("can update an image entry", () => {
       const kLocalImageUrl2 = kLocalImageUrl + "2";
   
       // Directly add an initial entry
-      const initialEntry = ImageMapEntry.create({
+      const initialEntry = {
         contentUrl: kLocalImageUrl,
         displayUrl: kLocalImageUrl,
         width: 20,
         height: 20,
         status: EntryStatus.Ready
-      });
+      };
       unsafeUpdate(() => sImageMap.images.set(kLocalImageUrl, initialEntry));
   
       // It synchronously updates the entry and changes the status to computingDimensions.
-      const changedEntry = {
+      const changedStoreResult = {
         contentUrl: kLocalImageUrl2,
         displayUrl: kLocalImageUrl2,
         success: true
       };
-      const addImagePromise = sImageMap.addImage(kLocalImageUrl, changedEntry);
+      const addImagePromise = sImageMap._addImage(kLocalImageUrl, changedStoreResult);
   
       expect(sImageMap.getCachedImage(kLocalImageUrl)).toEqual({
         contentUrl: kLocalImageUrl2,
@@ -595,7 +595,7 @@ describe("ImageMap", () => {
         displayUrl: kLocalImageUrl,
         success: false
       };
-      const addImagePromise = sImageMap.addImage(kLocalImageUrl, storeResult);
+      const addImagePromise = sImageMap._addImage(kLocalImageUrl, storeResult);
 
       const expectedEntry = {
         contentUrl: kLocalImageUrl,
@@ -622,30 +622,29 @@ describe("ImageMap", () => {
 
       // It updates entries regardless of their status
       resetEntryInMap(EntryStatus.Ready);
-      await sImageMap.addImage(kLocalImageUrl, storeResult);
+      await sImageMap._addImage(kLocalImageUrl, storeResult);
       expect(entryInMap).toEqual(expectedEntry);
 
       resetEntryInMap(EntryStatus.ComputingDimensions);
-      await sImageMap.addImage(kLocalImageUrl, storeResult);
+      await sImageMap._addImage(kLocalImageUrl, storeResult);
       expect(entryInMap).toEqual(expectedEntry);
 
       resetEntryInMap(EntryStatus.Storing);
-      await sImageMap.addImage(kLocalImageUrl, storeResult);
+      await sImageMap._addImage(kLocalImageUrl, storeResult);
       expect(entryInMap).toEqual(expectedEntry);
 
       resetEntryInMap(EntryStatus.Error);
-      await sImageMap.addImage(kLocalImageUrl, storeResult);
+      await sImageMap._addImage(kLocalImageUrl, storeResult);
       expect(entryInMap).toEqual(expectedEntry);
     });
 
     it("handles when there is no displayUrl set", async () => {
       expect.assertions(6);
       const consoleSpy = jest.spyOn(global.console, "error").mockImplementation();
-      const newEntry = {
+      const returnedEntry = await sImageMap._addImage(kLocalImageUrl, {
         contentUrl: kLocalImageUrl,
         success: false
-      };
-      const returnedEntry = await sImageMap.addImage(kLocalImageUrl, newEntry);
+      });
       expect(returnedEntry.status).toBe(EntryStatus.Error);
       expect(sImageMap.getCachedImage(kLocalImageUrl)).toBe(returnedEntry);
       expect(consoleSpy).toBeCalledTimes(1);
@@ -653,11 +652,10 @@ describe("ImageMap", () => {
       // Even error entries are expected to have an displayUrl
       jest.resetAllMocks();
       const otherUrl = "fake-url";
-      const newEntry2 = {
+      const returnedEntry2 = await sImageMap._addImage(otherUrl, {
         contentUrl: otherUrl,
         success: false
-      };
-      const returnedEntry2 = await sImageMap.addImage(otherUrl, newEntry2);
+      });
       expect(returnedEntry2.status).toBe(EntryStatus.Error);
       expect(sImageMap.getCachedImage(otherUrl)).toBe(returnedEntry2);
       expect(consoleSpy).toBeCalledTimes(1);
@@ -673,12 +671,11 @@ describe("ImageMap", () => {
         Promise.reject(new Error("mock error"))
       );
 
-      const newEntry = {
+      const returnedEntry = await sImageMap._addImage(kLocalImageUrl, {
         displayUrl: kLocalImageUrl,
         contentUrl: kLocalImageUrl,
         success: true
-      };
-      const returnedEntry = await sImageMap.addImage(kLocalImageUrl, newEntry);
+      });
       expect(returnedEntry.status).toBe(EntryStatus.Error);
       expect(sImageMap.getCachedImage(kLocalImageUrl)).toBe(returnedEntry);
       expect(dimSpy).toBeCalled();

--- a/src/models/image-map.ts
+++ b/src/models/image-map.ts
@@ -272,7 +272,7 @@ export const ImageMapModel = types
                     : Generator<PromiseLike<any>, ImageMapEntryType | Promise<ImageMapEntryType>, unknown> {
       if (!url) {
         // TODO: how often does this happen, should it be silently ignored like this?
-        console.warn("ImageMap#getImage called a falsy URL", url);
+        console.warn("ImageMap#getImage called with a falsy URL", url);
         return clone(self.images.get(placeholderImage)!);
       }
 

--- a/src/models/image-map.ts
+++ b/src/models/image-map.ts
@@ -1,4 +1,4 @@
-import { types, Instance, SnapshotIn, clone, getSnapshot, flow, applyPatch, applySnapshot } from "mobx-state-tree";
+import { types, Instance, SnapshotIn, clone, getSnapshot, flow } from "mobx-state-tree";
 import {
   getImageDimensions, IImageDimensions, ISimpleImage, isPlaceholderImage, storeCorsImage, storeFileImage, storeImage
 } from "../utilities/image-utils";
@@ -299,7 +299,7 @@ export const ImageMapModel = types
       }
 
       // If there is an existing entry we'll overwrite it so its status is
-      // storing and the displayUrl is the placeholder. In theory the
+      // `PendingStorage` and the `displayUrl` is the placeholder. In theory the
       // existingEntry could have a status of PendingStorage, PendingDimensions, or
       // Error. Because there is no existingStoringPromise the status should
       // really not be PendingStorage or PendingDimensions.

--- a/src/models/image-map.ts
+++ b/src/models/image-map.ts
@@ -95,7 +95,7 @@ export const ImageMapModel = types
         return;
       }
 
-      // See image-map.md "URL Conversion" for a full fleshed out description
+      // See image-map.md "URL Conversion" for a fully fleshed out description
       // of this logic.
       const existingEntry = self.images.get(entry.contentUrl);
       if (!existingEntry || existingEntry.status === EntryStatus.Error) {
@@ -294,7 +294,7 @@ export const ImageMapModel = types
         return clone(self.images.get(placeholderImage)!);
       }
 
-      // If there is an existing entry we'll overwrite it so it's status is
+      // If there is an existing entry we'll overwrite it so its status is
       // storing and the displayUrl is the placeholder. In theory the
       // existingEntry could have a status of Storing, ComputingDimensions, or
       // Error. Because there is no existingStoringPromise the status should
@@ -505,7 +505,7 @@ export const firebaseRealTimeDBImagesHandler: IImageHandler = {
              // Note: we used to return an empty image entry here. This used to cause
              // problems with some code that would then try to load the original url which
              // might be a ccimg: url.
-             // This empty entry seems to also be expected by jxg-image which was for for
+             // This empty entry seems to also be expected by jxg-image which was testing
              // for falsey displayUrl. It has been updated to also check the status of the
              // entry
              : kErrorStorageResult;

--- a/src/models/image-map.ts
+++ b/src/models/image-map.ts
@@ -280,32 +280,10 @@ export const ImageMapModel = types
       }
 
       const existingStoringPromise = self.storingPromises[url];      
-      if (existingStoringPromise) {
-        if (imageEntry?.status === EntryStatus.Error) {
-          // FIXME: maybe we should just get rid of this code?
-          // As long as we ignore the existing promise when the status is error
-          // it shouldn't hurt to leave it around.
-          // We can add functional tests first and then remove the code and make
-          // sure they still work
-          // The only downside I can think of is memory leaks, but if those are a problem
-          // we should clean up the promise when the error happens
-
-          // If the imageEntry has a status of Error.  We clear out the storingPromise.
-          delete self.storingPromises[url];
-
-          // If there is a contentUrl because of an error during computing
-          // dimensions there could be a storingPromise for the contentUrl that was
-          // added by syncContenUrl, to be complete we delete that too.
-          if (imageEntry.contentUrl && imageEntry.contentUrl !== url) {
-            const contentUrlEntry = self.images.get(imageEntry.contentUrl);
-            if (contentUrlEntry?.status === EntryStatus.Error) {
-              // delete the promise if it exists
-              delete self.storingPromises[imageEntry.contentUrl];
-            }
-          }
-        } else {
-          return existingStoringPromise;
-        }
+      if (existingStoringPromise && imageEntry?.status !== EntryStatus.Error) {
+        // If the imageEntry is errored we ignore the existing promise
+        // This way a second getImage request will try to store the image again
+        return existingStoringPromise;
       }
 
       const handler = self.getHandler(url);

--- a/src/models/image-map.ts
+++ b/src/models/image-map.ts
@@ -11,8 +11,8 @@ export const kFirebaseStorageHandlerName = "firebaseStorage";
 export const kFirebaseRealTimeDBHandlerName = "firebaseRealTimeDB";
 
 export enum EntryStatus { 
-  Storing = "storing",
-  ComputingDimensions = "computingDimensions",
+  PendingStorage = "pendingStorage",
+  PendingDimensions = "pendingDimensions",
   Ready = "ready", 
   Error = "error" 
 }
@@ -103,7 +103,7 @@ export const ImageMapModel = types
           // store or update the entry
           self.images.set(entry.contentUrl, getSnapshot(entry));
         }
-        else if (entry.status === EntryStatus.ComputingDimensions) {
+        else if (entry.status === EntryStatus.PendingDimensions) {
           // store or update the entry
           self.images.set(entry.contentUrl, getSnapshot(entry));
           // copy the storing promise incase some code calls 
@@ -112,7 +112,7 @@ export const ImageMapModel = types
         }
       }
 
-      if (existingEntry?.status === EntryStatus.ComputingDimensions && 
+      if (existingEntry?.status === EntryStatus.PendingDimensions && 
           (entry.status === EntryStatus.Error || entry.status === EntryStatus.Ready) && 
           self.storingPromises[url] === self.storingPromises[entry.contentUrl]) {
         // If the existingEntry is "managed" by the same promise as the entry
@@ -168,7 +168,7 @@ export const ImageMapModel = types
       const { success: successfulStore, ...otherProps} = storeResult; 
       const snapshot: ImageMapEntrySnapshot = {
         ...otherProps,
-        status: successfulStore ? EntryStatus.ComputingDimensions : EntryStatus.Error
+        status: successfulStore ? EntryStatus.PendingDimensions : EntryStatus.Error
       };
 
       // Update or add the entry. We do this whether there is an error or not.
@@ -272,6 +272,7 @@ export const ImageMapModel = types
                     : Generator<PromiseLike<any>, ImageMapEntryType | Promise<ImageMapEntryType>, unknown> {
       if (!url) {
         // TODO: how often does this happen, should it be silently ignored like this?
+        console.warn("ImageMap#getImage called a falsy URL", url);
         return clone(self.images.get(placeholderImage)!);
       }
 
@@ -285,6 +286,9 @@ export const ImageMapModel = types
       if (existingStoringPromise && imageEntry?.status !== EntryStatus.Error) {
         // If the imageEntry is errored we ignore the existing promise
         // This way a second getImage request will try to store the image again
+        // TODO: it might be necessary to keep track of how many times we have
+        // retried a particular URL. Otherwise there could be cases where we 
+        // go into a loop of retrying forever.
         return existingStoringPromise;
       }
 
@@ -296,15 +300,15 @@ export const ImageMapModel = types
 
       // If there is an existing entry we'll overwrite it so its status is
       // storing and the displayUrl is the placeholder. In theory the
-      // existingEntry could have a status of Storing, ComputingDimensions, or
+      // existingEntry could have a status of PendingStorage, PendingDimensions, or
       // Error. Because there is no existingStoringPromise the status should
-      // really not be Storing or ComputingDimensions.
-      if (imageEntry?.status === EntryStatus.Storing || 
-          imageEntry?.status === EntryStatus.ComputingDimensions) {
+      // really not be PendingStorage or PendingDimensions.
+      if (imageEntry?.status === EntryStatus.PendingStorage || 
+          imageEntry?.status === EntryStatus.PendingDimensions) {
         console.warn(`ImageMap.getImage found an entry with a status ${imageEntry.status} at ${url}`);
       }
       
-      self.images.set(url, {status: EntryStatus.Storing, displayUrl: placeholderImage});
+      self.images.set(url, {status: EntryStatus.PendingStorage, displayUrl: placeholderImage});
 
       const storingPromise = self._storeAndAddImage(url, handler, options);
 

--- a/src/models/image-map.ts
+++ b/src/models/image-map.ts
@@ -1,4 +1,4 @@
-import { types, Instance, SnapshotIn, clone, getSnapshot, flow } from "mobx-state-tree";
+import { types, Instance, SnapshotIn, clone, getSnapshot, flow, applyPatch, applySnapshot } from "mobx-state-tree";
 import {
   getImageDimensions, IImageDimensions, ISimpleImage, isPlaceholderImage, storeCorsImage, storeFileImage, storeImage
 } from "../utilities/image-utils";
@@ -10,13 +10,21 @@ export const kLocalAssetsHandlerName = "localAssets";
 export const kFirebaseStorageHandlerName = "firebaseStorage";
 export const kFirebaseRealTimeDBHandlerName = "firebaseRealTimeDB";
 
+export enum EntryStatus { 
+  Storing = "storing",
+  ComputingDimensions = "computingDimensions",
+  Ready = "ready", 
+  Error = "error" 
+}
+
 export const ImageMapEntry = types
   .model("ImageEntry", {
     filename: types.maybe(types.string),
     contentUrl: types.maybe(types.string),
     displayUrl: types.maybe(types.string),
     width: types.maybe(types.number),
-    height: types.maybe(types.number)
+    height: types.maybe(types.number),
+    status: types.enumeration<EntryStatus>("EntryStatus", Object.values(EntryStatus))
   });
 export type ImageMapEntryType = Instance<typeof ImageMapEntry>;
 export type ImageMapEntrySnapshot = SnapshotIn<typeof ImageMapEntry>;
@@ -31,11 +39,17 @@ export interface IImageBaseOptions {
 export interface IImageHandlerStoreOptions extends IImageBaseOptions{
   db?: DB;
 }
+export interface IImageHandlerStoreResult {
+  filename?: string;
+  contentUrl?: string;
+  displayUrl?: string;
+  success: boolean;
+}
 export interface IImageHandler {
   name: string;
   priority: number;
   match: (url: string) => boolean;
-  store: (url: string, options?: IImageHandlerStoreOptions) => Promise<ImageMapEntrySnapshot>;
+  store: (url: string, options?: IImageHandlerStoreOptions) => Promise<IImageHandlerStoreResult>;
 }
 // map from image url => component id => listener function
 export type ImageListenerMap = Record<string, Record<string, () => void>>;
@@ -46,14 +60,11 @@ export const ImageMapModel = types
   })
   .volatile(self => ({
     handlers: [] as IImageHandler[],
-    listeners: {} as ImageListenerMap
+    storingPromises: {} as Record<string, Promise<ImageMapEntryType>>
   }))
   .views(self => ({
     hasImage(url: string) {
       return self.images.has(url);
-    },
-    get imageCount() {
-      return self.images.size;
     },
     getHandler(url: string) {
       const index = self.handlers.findIndex(handler => handler.match(url));
@@ -72,21 +83,6 @@ export const ImageMapModel = types
     }
   }))
   .actions(self => ({
-    syncContentUrl(url: string, entry: ImageMapEntryType) {
-      if (entry.contentUrl && (url !== entry.contentUrl)) {
-        // if the url was changed, store or update it under the new url as well
-        self.images.set(entry.contentUrl, getSnapshot(entry));
-      }
-    },
-
-    setDimensions(url: string, width: number, height: number) {
-      const entry = self.images.get(url);
-      if (entry) {
-        entry.width = width;
-        entry.height = height;
-      }
-    },
-
     registerHandler(handler: IImageHandler) {
       self.handlers.push(handler);
       self.handlers.sort((a, b) => {
@@ -94,15 +90,38 @@ export const ImageMapModel = types
       });
     },
 
-    // listeners are called when a requested url is cached
-    registerListener(url: string, id: string, listener: () => void) {
-      if (!self.listeners[url]) {
-        self.listeners[url] = {};
+    _syncContentUrl(url: string, entry: ImageMapEntryType) {
+      if (!entry.contentUrl || (url === entry.contentUrl)) {
+        return;
       }
-      self.listeners[url][id] = listener;
-      // return disposer function
-      return () => delete self.listeners[url][id];
-    }
+
+      // See image-map.md "URL Conversion" for a full fleshed out description
+      // of this logic.
+      const existingEntry = self.images.get(entry.contentUrl);
+      if (!existingEntry || existingEntry.status === EntryStatus.Error) {
+        if (entry.status === EntryStatus.Ready) {
+          // store or update the entry
+          self.images.set(entry.contentUrl, getSnapshot(entry));
+        }
+        else if (entry.status === EntryStatus.ComputingDimensions) {
+          // store or update the entry
+          self.images.set(entry.contentUrl, getSnapshot(entry));
+          // copy the storing promise incase some code calls 
+          // getImage(entry.contentUrl)
+          self.storingPromises[entry.contentUrl] = self.storingPromises[url];
+        }
+      }
+
+      if (existingEntry?.status === EntryStatus.ComputingDimensions && 
+          (entry.status === EntryStatus.Error || entry.status === EntryStatus.Ready) && 
+          self.storingPromises[url] === self.storingPromises[entry.contentUrl]) {
+        // If the existingEntry is "managed" by the same promise as the entry
+        // we should updated it in some cases.
+        // See image-map.md "New Cache entry is in the Error state" and 
+        // "New cache entry is in Ready state"
+        self.images.set(entry.contentUrl, getSnapshot(entry));
+      }
+    },
   }))
   .actions(self => ({
     // Flows are the recommended way to deal with async actions in MobX and MobX State Tree.
@@ -132,55 +151,80 @@ export const ImageMapModel = types
     // There is also the yield* toGenerator approach https://mobx-state-tree.js.org/API/#togenerator which
     // provides a way to automatically type the return value of the yield. But that doesn't solve 
     // the problem of typing the return value of the flow.
-    addImage: flow(function* addImage(url: string, snapshot: ImageMapEntrySnapshot)
-                               : Generator<PromiseLike<any>, ImageMapEntryType, unknown> {
-      let entry: ImageMapEntryType | undefined;
+    addImage: flow(function* addImage(url: string, storeResult: IImageHandlerStoreResult)
+                              : Generator<PromiseLike<any>, ImageMapEntryType, unknown> {
 
-      // update existing entry
-      if (self.images.has(url)) {
-        entry = self.images.get(url);
-        if (entry && snapshot.contentUrl) {
-          entry.contentUrl = snapshot.contentUrl;
-        }
-        if (entry && snapshot.displayUrl) {
-          entry.displayUrl = snapshot.displayUrl;
-        }
-      }
-      // create new entry
-      else {
-        entry = ImageMapEntry.create(snapshot);
-        self.images.set(url, entry);
-        // notify any listeners that the url is now available
-        if (self.listeners[url]) {
-          for (const id in self.listeners[url]) {
-            self.listeners[url][id]();
-          }
-        }
-      }
-      self.syncContentUrl(url, entry!);
+      if (!storeResult.displayUrl) {
+        // As far as I can tell it should be an error if the displayUrl
+        // is not set. Even when there is an error the displayUrl should be
+        // set to the placeholderImage.
+        console.error(`addImage called with a storeResult without an displayUrl. ` + 
+          `url: ${url}, contentUrl: ${storeResult.contentUrl}, success: ${storeResult.success}`);
 
-      // If the getImageDimension image element never loads then we won't get
-      // past this line. 
-      // However the entry has already been added to the map, so there will be
-      // a dimensionless entry in this case.
-      // Also in most cases addImage is not called until the image has already been
-      // downloaded and displayUrl is actually a blob url.
-      // So it should be unlikely in these cases that getImageDimensions will fail.
-      const dimensions = (yield getImageDimensions(entry && entry.displayUrl || url)) as IImageDimensions;
-      const imageEntry = self.images.get(url);
-      if (!imageEntry) {
-        // This should really not happen, we just added an image entry above
-        // and there isn't a way to remove entries from the map
-        /* istanbul ignore next */
-        throw `missing image entry in cache for ${url}`;
+        // We have still store the entry but we update it to be errored.
+        storeResult.success = false;
       }
-      self.setDimensions(url, dimensions.width, dimensions.height);
-      // If this addImage is called more than once there could be multiple
-      // of these promises running at once. And the last one to finish will 
-      // clobber the imageEntry.contentUrl entry that was there before.
-      // The last one to finish might not be the right one if there are multiple.
-      self.syncContentUrl(url, imageEntry);
-      return imageEntry;
+
+      const { success: successfulStore, ...otherProps} = storeResult; 
+      const snapshot: ImageMapEntrySnapshot = {
+        ...otherProps,
+        status: successfulStore ? EntryStatus.ComputingDimensions : EntryStatus.Error
+      };
+
+      // Update or add the entry. We do this whether there is an error or not.
+      // If there is an error it is still recorded so observers of the entry
+      // will see the change
+      // Note: originally the contentUrl of the original entry was only updated if it was actually
+      // set in the snapshot. This approach complicates things and I don't see a benefit to it.
+      self.images.set(url, snapshot);
+
+      const entry = self.images.get(url)!;
+
+      if (entry.status === EntryStatus.Error) {
+        // This means the storage operation failed. 
+
+        // We could clear the storingPromise here, but instead we just leave it and
+        // rely on getImage to ignore and delete the storingPromise when it sees there is
+        // an entry with a status of error.
+
+        // Even if this entry has a contentUrl that is different than its url
+        // we do not update the entry at the contentUrl. 
+        // See image-map.md "New cache entry is in the Error state"
+
+        // We return so we don't sync and don't try to get the dimensions
+        // See image-map.md "Dimensions" for why we don't set the dimensions
+        return entry;  
+      } 
+
+      self._syncContentUrl(url, entry);
+
+      try {
+        // If the getImageDimension image element never loads or errors then we won't get
+        // past this line. However I'd hope that the browser will eventually trigger 
+        // one of those events.
+        // However in most cases addImage is not called until the image has already been
+        // downloaded and displayUrl is actually a blob url.
+        // So it should be unlikely in these cases that getImageDimensions will fail.
+        //
+        // We know the entry.displayUrl is defined because we made sure the snapshot.displayUrl
+        // is defined above.
+        const dimensions = (yield getImageDimensions(entry.displayUrl!)) as IImageDimensions;
+        entry.width = dimensions.width;
+        entry.height = dimensions.height;  
+        entry.status = EntryStatus.Ready;  
+      } catch (error) {
+        entry.status = EntryStatus.Error;
+        // If there is a contentUrl there could be a second entry that needs to be updated.
+        // syncContentUrl takes care of this
+
+        // Note: we are not updating or clearing the other fields of the entry here
+        // Its status will be Error, but it might have a contentUrl and a displayUrl.
+        // Leaving the contentUrl in place is necessary so syncContentUrl can work.
+        // Leaving displayUrl is less clear
+      }
+
+      self._syncContentUrl(url, entry);
+      return entry;
     })
   }))
   .actions(self => {
@@ -189,7 +233,7 @@ export const ImageMapModel = types
     return {
       afterCreate() {
         // placeholder doesn't have contentUrl
-        self.addImage(placeholderImage, { displayUrl: placeholderImage });
+        self.addImage(placeholderImage, { displayUrl: placeholderImage, success: true });
 
         self.registerHandler(firebaseRealTimeDBImagesHandler);
         self.registerHandler(firebaseStorageImagesHandler);
@@ -204,38 +248,92 @@ export const ImageMapModel = types
       addFileImage: flow(function* (file: File): Generator<PromiseLike<any>, Promise<ImageMapEntryType>, unknown> {
         const simpleImage = (yield storeFileImage(_db, file)) as ISimpleImage;
         const { normalized } = parseFauxFirebaseRTDBUrl(simpleImage.imageUrl);
-        const entry: ImageMapEntrySnapshot = {
+        const entry: IImageHandlerStoreResult = {
                 filename: file.name,
                 contentUrl: normalized,
-                displayUrl: simpleImage.imageData
+                displayUrl: simpleImage.imageData,
+                success: true
               };
         return self.addImage(entry.contentUrl!, entry);
       }),
 
-      getImage: flow(function* (url: string, options?: IImageBaseOptions)
+      _getImage: flow(function* (url: string, handler: IImageHandler, options?: IImageBaseOptions)
                        : Generator<PromiseLike<any>, ImageMapEntryType | Promise<ImageMapEntryType>, unknown> {
-        if (!url) {
-          return clone(self.images.get(placeholderImage)!);
-        }
-
-        const imageEntry = self.images.get(url);
-        if (imageEntry) {
-          // This might or might not have dimensions yet
-          return imageEntry;
-        }
-
-        const handler = self.getHandler(url);
-        if (handler) {
-          const imageEntrySnapshot = (yield handler.store(url, { db: _db, ...options })) as ImageMapEntrySnapshot;
-          return self.addImage(url, imageEntrySnapshot);
-        }
-        else {
-          return clone(self.images.get(placeholderImage)!);
-        }
-      })
-
+        const imageEntrySnapshot = (yield handler.store(url, { db: _db, ...options })) as IImageHandlerStoreResult;
+        return self.addImage(url, imageEntrySnapshot);
+      }),
     };
-  });
+  })
+  .actions(self => ({
+    // eslint-disable-next-line require-yield
+    getImage: flow(function* (url: string, options?: IImageBaseOptions)
+                    : Generator<PromiseLike<any>, ImageMapEntryType | Promise<ImageMapEntryType>, unknown> {
+      if (!url) {
+        // TODO: how often does this happen, should it be silently ignored like this?
+        return clone(self.images.get(placeholderImage)!);
+      }
+
+      const imageEntry = self.images.get(url);
+      if (imageEntry?.status === EntryStatus.Ready) {
+        // This image has been downloaded successfully already
+        return imageEntry;
+      }
+
+      const existingStoringPromise = self.storingPromises[url];      
+      if (existingStoringPromise) {
+        if (imageEntry?.status === EntryStatus.Error) {
+          // FIXME: maybe we should just get rid of this code?
+          // As long as we ignore the existing promise when the status is error
+          // it shouldn't hurt to leave it around.
+          // We can add functional tests first and then remove the code and make
+          // sure they still work
+          // The only downside I can think of is memory leaks, but if those are a problem
+          // we should clean up the promise when the error happens
+
+          // If the imageEntry has a status of Error.  We clear out the storingPromise.
+          delete self.storingPromises[url];
+
+          // If there is a contentUrl because of an error during computing
+          // dimensions there could be a storingPromise for the contentUrl that was
+          // added by syncContenUrl, to be complete we delete that too.
+          if (imageEntry.contentUrl && imageEntry.contentUrl !== url) {
+            const contentUrlEntry = self.images.get(imageEntry.contentUrl);
+            if (contentUrlEntry?.status === EntryStatus.Error) {
+              // delete the promise if it exists
+              delete self.storingPromises[imageEntry.contentUrl];
+            }
+          }
+        } else {
+          return existingStoringPromise;
+        }
+      }
+
+      const handler = self.getHandler(url);
+      if (!handler) {
+        console.warn(`No handler found for ${url}`);
+        return clone(self.images.get(placeholderImage)!);
+      }
+
+      // If there is an existing entry we'll overwrite it so it's status is
+      // storing and the displayUrl is the placeholder. In theory the
+      // existingEntry could have a status of Storing, ComputingDimensions, or
+      // Error. Because there is no existingStoringPromise the status should
+      // really not be Storing or ComputingDimensions.
+      if (imageEntry?.status === EntryStatus.Storing || 
+          imageEntry?.status === EntryStatus.ComputingDimensions) {
+        console.warn(`ImageMap.getImage found an entry with a status ${imageEntry.status} at ${url}`);
+      }
+      
+      self.images.set(url, {status: EntryStatus.Storing, displayUrl: placeholderImage});
+
+      const storingPromise = self._getImage(url, handler, options);
+
+      // keep track of the storingPromise
+      self.storingPromises[url] = storingPromise;
+
+      return storingPromise;      
+    })
+  }));
 export type ImageMapModelType = Instance<typeof ImageMapModel>;
 
 /*
@@ -249,7 +347,7 @@ export const externalUrlImagesHandler: IImageHandler = {
     return url ? /^(https?:\/\/|data:image\/)/.test(url) : false;
   },
 
-  async store(url: string, options?: IImageHandlerStoreOptions) {
+  async store(url: string, options?: IImageHandlerStoreOptions): Promise<IImageHandlerStoreResult> {
     const { db } = options || {};
     // upload images from external urls to our own firebase if possible
     // this may fail depending on CORS settings on target image.
@@ -268,22 +366,27 @@ export const externalUrlImagesHandler: IImageHandler = {
           // conversion errors are resolved to placeholder image
           // this generally occurs due to a CORS error, in which
           // case we just use the original url.
-          return { contentUrl: url, displayUrl: url };
+          //
+          // TODO: if we get a CORS error we'll likely get that same
+          // error again. So we should serialize that info and use it
+          // to not try to download the image again.
+          return { contentUrl: url, displayUrl: url, success: true };
         }
         else {
           const { normalized } = parseFauxFirebaseRTDBUrl(simpleImage.imageUrl);
-          return { contentUrl: normalized, displayUrl: simpleImage.imageData };
+          return { contentUrl: normalized, displayUrl: simpleImage.imageData,
+            success: true  };
         }
       } catch (error) {
           // If the silent upload has failed, do we retain the full url or
           // encourage the user to download a copy and re-upload?
           // For now, return the original image url.
-          return { contentUrl: url, displayUrl: url };
+          return { contentUrl: url, displayUrl: url, success: true  };
       }
     }
     else {
       // For now, return the original image url.
-      return { contentUrl: url, displayUrl: url };
+      return { contentUrl: url, displayUrl: url, success: true  };
     }
   }
 };
@@ -305,7 +408,7 @@ export const localAssetsImagesHandler: IImageHandler = {
                     // convert original drawing tool stamp paths
                     .replace("assets/tools/drawing-tool/stamps",
                              "curriculum/moving-straight-ahead/stamps");
-    return { contentUrl: _url, displayUrl: _url };
+    return { contentUrl: _url, displayUrl: _url, success: true  };
   }
 };
 
@@ -313,6 +416,16 @@ export const localAssetsImagesHandler: IImageHandler = {
  * firebaseStorageImagesHandler
  */
 const kFirebaseStorageUrlPrefix = "https://firebasestorage.googleapis.com";
+
+// The contentUrl is not set here.
+// This means any content that is referencing an image that cannot be downloaded
+// will not be updated. Modifying content like this seems kind of dangerous because
+// this could be a temporary network error.
+// By not setting the contentUrl, it also means that the default placeholder image 
+// entry will not be modified by syncContentUrl. That is a good thing.
+const kErrorImageEntrySnapshot: IImageHandlerStoreResult = { 
+  displayUrl: placeholderImage, success: false
+};
 
 export const firebaseStorageImagesHandler: IImageHandler = {
   name: kFirebaseStorageHandlerName,
@@ -324,7 +437,7 @@ export const firebaseStorageImagesHandler: IImageHandler = {
                           /^\/.+\/portals\/.+$/.test(url);
   },
 
-  async store(url: string, options?: IImageHandlerStoreOptions) {
+  async store(url: string, options?: IImageHandlerStoreOptions): Promise<IImageHandlerStoreResult> {
     const { db } = options || {};
     // All images from firebase storage must be migrated to realtime database
     const isStorageUrl = url.startsWith(kFirebaseStorageUrlPrefix);
@@ -342,17 +455,18 @@ export const firebaseStorageImagesHandler: IImageHandler = {
           // Image has been retrieved from Storage, now we can safely remove the old image
           // TODO: remove old images
           const { normalized } = parseFauxFirebaseRTDBUrl(simpleImage.imageUrl);
-          return { contentUrl: normalized, displayUrl: simpleImage.imageData };
+          return { contentUrl: normalized, displayUrl: simpleImage.imageData,
+            success: true };
         }
         else {
-          return { contentUrl: placeholderImage, displayUrl: placeholderImage };
+          return kErrorImageEntrySnapshot;
         }
       } catch (error) {
-        return { contentUrl: placeholderImage, displayUrl: placeholderImage };
+        return kErrorImageEntrySnapshot;
       }
     }
     else {
-      return { contentUrl: placeholderImage, displayUrl: placeholderImage };
+      return kErrorImageEntrySnapshot;
     }
   }
 };
@@ -395,7 +509,7 @@ export const firebaseRealTimeDBImagesHandler: IImageHandler = {
           (url.startsWith(`${kCCImageScheme}://`) && (url.indexOf("concord.org") < 0));
   },
 
-  async store(url: string, options?: IImageHandlerStoreOptions) {
+  async store(url: string, options?: IImageHandlerStoreOptions): Promise<IImageHandlerStoreResult> {
     const { db } = options || {};
     const { path, classHash, imageKey, normalized } = parseFauxFirebaseRTDBUrl(url);
 
@@ -406,11 +520,18 @@ export const firebaseRealTimeDBImagesHandler: IImageHandler = {
                             ? await db.getCloudImageBlob(normalized)
                             : await db.getImageBlob(imageKey);
       return blobUrl
-             ? { filename: options?.filename, contentUrl: normalized, displayUrl: blobUrl }
-             : {};
+             ? { filename: options?.filename, contentUrl: normalized, displayUrl: blobUrl,
+                 success: true }
+             // Note: we used to return an empty image entry here. This used to cause
+             // problems with some code that would then try to load the original url which
+             // might be a ccimg: url.
+             // This empty entry seems to also be expected by jxg-image which was for for
+             // for falsey displayUrl. It has been updated to also check the status of the
+             // entry
+             : kErrorImageEntrySnapshot;
     }
     else {
-      return {};
+      return kErrorImageEntrySnapshot;
     }
   }
 };

--- a/src/models/image-map.ts
+++ b/src/models/image-map.ts
@@ -117,8 +117,8 @@ export const ImageMapModel = types
           self.storingPromises[url] === self.storingPromises[entry.contentUrl]) {
         // If the existingEntry is "managed" by the same promise as the entry
         // we should updated it in some cases.
-        // See image-map.md "New Cache entry is in the Error state" and 
-        // "New cache entry is in Ready state"
+        // See image-map.md "Updated Cache entry is in the Error state" and 
+        // "Updated cache entry is in Ready state"
         self.images.set(entry.contentUrl, getSnapshot(entry));
       }
     },
@@ -187,7 +187,7 @@ export const ImageMapModel = types
 
         // Even if this entry has a contentUrl that is different than its url
         // we do not update the entry at the contentUrl. 
-        // See image-map.md "New cache entry is in the Error state"
+        // See image-map.md "Updated cache entry is in the Error state"
         // Note: when there is an error at this point the promise that is managing
         // this call to _addImage should not be responsible for the entry at 
         // contentUrl. 

--- a/src/models/tools/geometry/geometry-content.test.ts
+++ b/src/models/tools/geometry/geometry-content.test.ts
@@ -1,11 +1,19 @@
+import { clone } from "lodash";
+import { destroy } from "mobx-state-tree";
 import { GeometryContentModel, GeometryContentModelType,
           kGeometryToolID, defaultGeometryContent, GeometryMetadataModel } from "./geometry-content";
 import { JXGChange } from "./jxg-changes";
 import { isPointInPolygon, getPointsForVertexAngle } from "./jxg-polygon";
 import { canSupportVertexAngle, getVertexAngle, updateVertexAnglesFromObjects } from "./jxg-vertex-angle";
 import { isBoard, isFreePoint, isPoint, isPolygon } from "./jxg-types";
-import { clone } from "lodash";
-import { destroy } from "mobx-state-tree";
+
+// Need to mock this so the placeholder that is added to the cache
+// has dimensions
+jest.mock( "../../../utilities/image-utils", () => ({
+  ...(jest.requireActual("../../../utilities/image-utils") as any),
+  getImageDimensions: jest.fn(() =>
+    Promise.resolve({ src: "test-file-stub", width: 200, height: 150 }))
+}));
 
 import placeholderImage from "../../../assets/image_placeholder.png";
 

--- a/src/models/tools/geometry/geometry-export.test.ts
+++ b/src/models/tools/geometry/geometry-export.test.ts
@@ -3,6 +3,8 @@ import { exportGeometryJson } from "./geometry-export";
 import { preprocessImportFormat } from "./geometry-import";
 import { JXGChange } from "./jxg-changes";
 
+const kLocalImageUrl = "assets/logo_tw.png";
+
 const exportGeometry = (changes: JXGChange[]) => {
   const changesJson = changes.map(change => JSON.stringify(change));
   const exportJson = exportGeometryJson(changesJson);
@@ -852,13 +854,13 @@ describe("Geometry Export", () => {
         target: "board",
         properties: { axis: true, boundingBox: [-2, 15, 22, -1], unitX: 20, unitY: 20 }
       },
-      { operation: "create", target: "image", parents: ["my/image/url", [0, 0], [10, 10]], properties: { id: "i1" } }
+      { operation: "create", target: "image", parents: [kLocalImageUrl, [0, 0], [10, 10]], properties: { id: "i1" } }
     ];
     expect(exportGeometry(changes)).toEqual({
       type: "Geometry",
       board: { properties: { axisMin: [-2, -1], axisRange: [24, 16] } },
       objects: [
-        { type: "image", parents: { url: "my/image/url", coords: [0, 0], size: [183, 183] }, properties: { id: "i1" } }
+        { type: "image", parents: { url: kLocalImageUrl, coords: [0, 0], size: [183, 183] }, properties: { id: "i1" } }
       ]
     });
     const [received, expected] = testRoundTrip(changes);
@@ -872,7 +874,7 @@ describe("Geometry Export", () => {
         target: "board",
         properties: { axis: true, boundingBox: [-2, 15, 22, -1], unitX: 20, unitY: 20 }
       },
-      { operation: "create", target: "image", parents: ["my/image/url", [0, 0], [10, 10]], properties: { id: "i1" } },
+      { operation: "create", target: "image", parents: [kLocalImageUrl, [0, 0], [10, 10]], properties: { id: "i1" } },
       { operation: "delete", target: "image", targetID: "i1" }
     ];
     expect(exportGeometry(changes)).toEqual({

--- a/src/models/tools/geometry/jxg-image.ts
+++ b/src/models/tools/geometry/jxg-image.ts
@@ -2,7 +2,7 @@ import { getObjectById } from "./jxg-board";
 import { JXGChangeAgent } from "./jxg-changes";
 import { objectChangeAgent } from "./jxg-object";
 import { isImage } from "./jxg-types";
-import { gImageMap } from "../../image-map";
+import { EntryStatus, gImageMap } from "../../image-map";
 import { uniqueId } from "../../../utilities/js-utils";
 
 export const imageChangeAgent: JXGChangeAgent = {
@@ -10,8 +10,8 @@ export const imageChangeAgent: JXGChangeAgent = {
     const _board = board as JXG.Board;
     const parents = (change.parents || []).slice();
     const url = parents && parents[0] as string || "";
-    const imageEntry = url && gImageMap.getCachedImage(url);
-    const displayUrl = imageEntry && imageEntry.displayUrl || "";
+    const imageEntry = gImageMap.getCachedImage(url);
+    const displayUrl = imageEntry?.status === EntryStatus.Ready && imageEntry?.displayUrl || "";
     parents[0] = displayUrl;
     const props = { id: uniqueId(), fixed: true, ...change.properties };
     return parents && parents.length >= 3
@@ -30,7 +30,7 @@ export const imageChangeAgent: JXGChangeAgent = {
       if (image && objProps) {
         const { url, size } = objProps;
         const imageEntry = gImageMap.getCachedImage(url);
-        const displayUrl = imageEntry && imageEntry.displayUrl || "";
+        const displayUrl = imageEntry?.status === EntryStatus.Ready && imageEntry?.displayUrl || "";
         if (displayUrl) {
           image.url = displayUrl;
         }

--- a/src/plugins/drawing-tool/components/__snapshots__/drawing-layer.test.tsx.snap
+++ b/src/plugins/drawing-tool/components/__snapshots__/drawing-layer.test.tsx.snap
@@ -118,7 +118,7 @@ exports[`Drawing Layer Components Image moves a image 1`] = `
 >
   <image
     height="10"
-    href="test-file-stub"
+    href="assets/logo_tw.png"
     width="10"
     x="5"
     y="5"

--- a/src/plugins/drawing-tool/components/drawing-layer.test.tsx
+++ b/src/plugins/drawing-tool/components/drawing-layer.test.tsx
@@ -16,6 +16,8 @@ import "../drawing-registration";
 
 let content, drawingLayerProps, drawingLayer;
 
+const kLocalImageUrl = "assets/logo_tw.png";
+
 const getDrawingObject = (objectContent: DrawingContentModelType) => {
   drawingLayerProps = {
     model: ToolTileModel.create({content: objectContent}),
@@ -172,7 +174,7 @@ describe("Drawing Layer Components", () => {
     const imageData: ImageObjectSnapshot = {
       type: "image",
       id: "567",
-      url: "my/image/url",
+      url: kLocalImageUrl,
       x: 10, y: 10,
       width: 10, height: 10,
     };

--- a/src/utilities/image-utils.ts
+++ b/src/utilities/image-utils.ts
@@ -160,11 +160,14 @@ function resizeImage(imageUrl: string, maxWidth: number, maxHeight: number, cors
 }
 
 export function getImageDimensions(url: string): Promise<IImageDimensions> {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const image = new Image();
     image.onload = () => {
       const dimensions = { src: image.src, width: image.width, height: image.height };
       resolve(dimensions);
+    };
+    image.onerror = (e) => {
+      reject(new Error(`Error getting dimensions of image: ${url}`));
     };
     image.src = url;
   });


### PR DESCRIPTION
This makes several changes to the internal workings of the ImageMap.
Also the external API of the ImageMap has changed slightly.
More details can be seen in the image-map.md that is part of this PR.

Here are some of the changes
- additional calls to `getImage` will not start new storage operations if there is one currently on going.
- calls to `getCachedImage` will return an entry immediately after `getImage` is called. This entry will have a status of `storing`.
- when there is an error, `getCachedImage` will return an entry with a status of `error`.
- entries in the cache are always updated not replaced, this makes it possible for components to observe the entry. 
- the usage of `"my/image/url"` in tests was replaced with a valid local URL. Otherwise this resulted in a console warning because there is no handler for the `"my/image/url"`.

There are a couple of unresolved FIXMEs in this code:
- The geometry tile does not handle undefined width and height values in image map entries. This was the case before, so it shouldn't be worse than it was before. Also because the geometry tile is being worked on it seems best to improve this in the PR for that work or a follow on PR.
- The drawing tile also doesn't handle undefined width and height values. This should be fixed in the new drawing tile PR, so it doesn't seem worth fixing here.