### PR TITLE
add a retry limit of 2 to the image map

### DIFF
--- a/docs/image-map.md
+++ b/docs/image-map.md
@@ -13,6 +13,7 @@ Entries in the cache have the following properties:
 - **width, height** the dimension of the image
 - **filename** if the image was loaded from a file, this is the name of the file
 - **status** what state the entry is in, see below
+- **retries** how many times getImage has tried to store the image after a previous attempt
 
 Entries in the cache can have 4 status values:
 - **PendingStorage**: `getImage` has been called with a URL and this URL is being processed to download and store the image data.


### PR DESCRIPTION
Finally a PR with a small number of files changed.

This adds more complexity, but it seems the easiest way to cut off infinite loops.

There could be an additional test which is more simple and just calls getImage multiple times and checks the response each time. However the autorun looping test is what will be used in practice, so that is the only one I added for now.