### PR TITLE
Tile lifecycle typing

### DIFF
--- a/src/components/tools/geometry-tool/geometry-toolbar.test.tsx
+++ b/src/components/tools/geometry-tool/geometry-toolbar.test.tsx
@@ -6,7 +6,7 @@ import { GeometryContentModel, GeometryMetadataModel } from "../../../models/too
 describe("GeometryToolbar", () => {
   const content = GeometryContentModel.create();
   const metadata = GeometryMetadataModel.create({ id: "test-metadata" });
-  content.doPostCreate(metadata);
+  content.doPostCreate!(metadata);
 
   it("renders successfully", () => {
     render(<div className="document-content" data-testid="document-content"/>);

--- a/src/models/document/document.ts
+++ b/src/models/document/document.ts
@@ -16,6 +16,7 @@ import { IDocumentProperties } from "../../lib/db-types";
 import { getLocalTimeStamp } from "../../utilities/time";
 import { safeJsonParse } from "../../utilities/js-utils";
 import { createSharedModelDocumentManager, ISharedModelDocumentManager } from "../tools/shared-model-document-manager";
+import { ITileEnvironment } from "../tools/tool-types";
 
 interface IMatchPropertiesOptions {
   isTeacherDocument?: boolean;
@@ -175,8 +176,8 @@ export const DocumentModel = types
       }
       else {
         self.content = DocumentContentModel.create(snapshot);
-        const sharedModelManager = getEnv(self).sharedModelManager as ISharedModelDocumentManager;
-        sharedModelManager.setDocument(self.content);
+        const sharedModelManager = (getEnv(self) as ITileEnvironment).sharedModelManager;
+        (sharedModelManager as ISharedModelDocumentManager).setDocument(self.content);
       }
     },
 
@@ -296,8 +297,11 @@ export interface IDocumentEnvironment {
  */
 export const createDocumentModel = (snapshot?: DocumentModelSnapshotType) => {
   const sharedModelManager = createSharedModelDocumentManager();
-  const documentEnv: IDocumentEnvironment = {};
-  const document = DocumentModel.create(snapshot, {sharedModelManager, documentEnv});
+  const fullEnvironment: ITileEnvironment & {documentEnv: IDocumentEnvironment} = {
+    sharedModelManager,
+    documentEnv: {}
+  };
+  const document = DocumentModel.create(snapshot, fullEnvironment);
   if (document.content) {
     sharedModelManager.setDocument(document.content);
   }

--- a/src/models/tools/geometry/geometry-content.test.ts
+++ b/src/models/tools/geometry/geometry-content.test.ts
@@ -55,7 +55,7 @@ describe("GeometryContent", () => {
               { content: GeometryContentModelType, board: JXG.Board } {
     const content = defaultGeometryContent();
     const metadata = GeometryMetadataModel.create({ id: "geometry-1" });
-    content.doPostCreate(metadata);
+    content.doPostCreate!(metadata);
     if (configContent) configContent(content);
     const board = createDefaultBoard(content);
     return { content, board };

--- a/src/models/tools/geometry/geometry-content.ts
+++ b/src/models/tools/geometry/geometry-content.ts
@@ -5,7 +5,7 @@ import { Optional } from "utility-types";
 import { SelectionStoreModelType } from "../../stores/selection";
 import { addLinkedTable, removeLinkedTable } from "../table-links";
 import { ITileExportOptions, IDefaultContentOptions } from "../tool-content-info";
-import { ToolContentModel, ToolMetadataModel } from "../tool-types";
+import { toolContentModelHooks, ToolContentModel, ToolMetadataModel } from "../tool-types";
 import {
   getRowLabelFromLinkProps, IColumnProperties, ICreateRowsProperties, IRowProperties,
   ITableChange, ITableLinkProperties
@@ -318,9 +318,9 @@ export const GeometryContentModel = ToolContentModel
       }
     }
   }))
-  .actions(self => ({
-    doPostCreate(metadata: GeometryMetadataModelType) {
-      self.metadata = metadata;
+  .actions(self => toolContentModelHooks({
+    doPostCreate(metadata) {
+      self.metadata = metadata as GeometryMetadataModelType;
     },
     willRemoveFromDocument() {
       self.metadata.linkedTables.forEach(({ id: tableId }) => {
@@ -328,7 +328,9 @@ export const GeometryContentModel = ToolContentModel
         tableContent && tableContent.removeGeometryLink(self.metadata.id);
       });
       self.metadata.clearLinkedTables();
-    },
+    }
+  }))
+  .actions(self => ({
     selectObjects(board: JXG.Board, ids: string | string[]) {
       const _ids = Array.isArray(ids) ? ids : [ids];
       _ids.forEach(id => {

--- a/src/models/tools/image/image-content.ts
+++ b/src/models/tools/image/image-content.ts
@@ -2,7 +2,7 @@ import { types, Instance, SnapshotOut } from "mobx-state-tree";
 import { exportImageTileSpec, isLegacyImageTileImport, convertLegacyImageTile } from "./image-import-export";
 import { ITileExportOptions, IDefaultContentOptions } from "../tool-content-info";
 import { setTileTitleFromContent } from "../tool-tile";
-import { ToolContentModel, ToolMetadataModelType } from "../tool-types";
+import { toolContentModelHooks, ToolContentModel, ToolMetadataModelType } from "../tool-types";
 import { isPlaceholderImage } from "../../../utilities/image-utils";
 import placeholderImage from "../../../assets/image_placeholder.png";
 
@@ -45,10 +45,12 @@ export const ImageContentModel = ToolContentModel
       return exportImageTileSpec(self.url, self.filename, options);
     }
   }))
+  .actions(self => toolContentModelHooks({
+      doPostCreate(metadata: ToolMetadataModelType) {
+        self.metadata = metadata;
+      },
+  }))
   .actions(self => ({
-    doPostCreate(metadata: ToolMetadataModelType) {
-      self.metadata = metadata;
-    },
     setUrl(url: string, filename?: string) {
       self.url = url;
       self.filename = filename;

--- a/src/models/tools/table/table-content.test.ts
+++ b/src/models/tools/table/table-content.test.ts
@@ -161,7 +161,7 @@ describe("TableContent", () => {
           };
     const table = TableContentModel.create(importData);
     const metadata = TableMetadataModel.create({ id: "table-1" });
-    table.doPostCreate(metadata);
+    table.doPostCreate!(metadata);
 
     expect(table.type).toBe(kTableToolID);
     expect(table.isImported).toBe(true);
@@ -344,7 +344,7 @@ describe("TableContent", () => {
     const snapshot = { changes: changes.map(change => JSON.stringify(change)) };
     const table = TableContentModel.create(snapshot);
     const metadata = TableMetadataModel.create({ id: "table-1" });
-    table.doPostCreate(metadata);
+    table.doPostCreate!(metadata);
     table.setAttributeName("zCol", "newZ");
     expect(table.changes.length).toBe(3);
     const change3 = safeJsonParse(table.changes[2]);
@@ -421,7 +421,7 @@ describe("TableContent", () => {
     const snapshot = { changes: changes.map(change => JSON.stringify(change)) };
     const table = TableContentModel.create(snapshot);
     const metadata = TableMetadataModel.create({ id: "table-1" });
-    table.doPostCreate(metadata);
+    table.doPostCreate!(metadata);
     table.setExpression("y1Col", kSerializedXKey, "x");
     table.setExpression("y2Col", "foo", "foo");
 

--- a/src/models/tools/table/table-content.ts
+++ b/src/models/tools/table/table-content.ts
@@ -4,7 +4,7 @@ import { types, IAnyStateTreeNode, Instance, SnapshotIn, SnapshotOut } from "mob
 import { exportTableContentAsJson } from "./table-export";
 import { getRowLabel, kSerializedXKey, canonicalizeValue, isLinkableValue } from "./table-model-types";
 import { IDocumentExportOptions, IDefaultContentOptions } from "../tool-content-info";
-import { ToolMetadataModel, ToolContentModel } from "../tool-types";
+import { ToolMetadataModel, ToolContentModel, toolContentModelHooks } from "../tool-types";
 import { addLinkedTable, removeLinkedTable } from "../table-links";
 import { IDataSet, ICaseCreation, ICase, DataSet } from "../../data/data-set";
 import { canonicalizeExpression } from "../../../components/tools/table-tool/expression-utils";
@@ -286,9 +286,9 @@ export const TableContentModel = ToolContentModel
       // return tableActionLinkId && geometryActionLinkId && (tableActionLinkId === geometryActionLinkId);
     }
   }))
-  .actions(self => ({
-    doPostCreate(metadata: TableMetadataModelType) {
-      self.metadata = metadata;
+  .actions(self => toolContentModelHooks({
+    doPostCreate(metadata) {
+      self.metadata = metadata as TableMetadataModelType;
     },
     willRemoveFromDocument() {
       self.metadata.linkedGeometries.forEach(geometryId => {
@@ -296,7 +296,9 @@ export const TableContentModel = ToolContentModel
         geometryContent?.removeTableLink(undefined, self.metadata.id);
       });
       self.metadata.clearLinkedGeometries();
-    },
+    }
+  }))
+  .actions(self => ({
     appendChange(change: ITableChange) {
       self.changes.push(JSON.stringify(change));
 

--- a/src/models/tools/tool-tile.ts
+++ b/src/models/tools/tool-tile.ts
@@ -2,7 +2,7 @@ import { cloneDeep } from "lodash";
 import { getParent, getSnapshot, getType, Instance, SnapshotIn, SnapshotOut, types } from "mobx-state-tree";
 import { isPlaceholderContent } from "./placeholder/placeholder-content";
 import { ITileExportOptions } from "./tool-content-info";
-import { findMetadata, ToolContentModelType, ToolContentUnion } from "./tool-types";
+import { findMetadata, IToolContentModelHooks, ToolContentModelType, ToolContentUnion } from "./tool-types";
 import { DisplayUserTypeEnum } from "../stores/user-types";
 import { uniqueId } from "../../utilities/js-utils";
 
@@ -87,13 +87,13 @@ export const ToolTileModel = types
   .actions(self => ({
     afterCreate() {
       const metadata = findMetadata(self.content.type, self.id, self.title);
-      const content = self.content as any;
+      const content = self.content;
       if (metadata && content.doPostCreate) {
         content.doPostCreate(metadata);
       }
     },
     willRemoveFromDocument() {
-      const willRemoveFromDocument = (self.content as any).willRemoveFromDocument;
+      const willRemoveFromDocument = self.content.willRemoveFromDocument;
       return willRemoveFromDocument && willRemoveFromDocument();
     },
     setDisabledFeatures(disabled: string[]) {

--- a/src/models/tools/tool-types.ts
+++ b/src/models/tools/tool-types.ts
@@ -1,4 +1,4 @@
-import { getEnv, Instance, types, getParent, getType } from "mobx-state-tree";
+import { getEnv, Instance, types, getParent, getType, SnapshotIn } from "mobx-state-tree";
 import { ISharedModelManager, SharedModelType } from "./shared-model";
 import { getToolContentModels, getToolContentInfoById } from "./tool-content-info";
 
@@ -24,6 +24,53 @@ export const kUnknownToolID = "Unknown";
 
 export interface ITileEnvironment {
   sharedModelManager?: ISharedModelManager;
+}
+
+export interface IToolContentModelHooks {
+  /**
+   * This is called after the wrapper around the content model is created. This wrapper is
+   * a ToolTileModel. This should only be called once.
+   *
+   * @param metadata an instance of this model's metadata it might be shared by
+   * multiple instances of the model if the document of this model is open in
+   * more than one place.
+   */
+  doPostCreate?(metadata: ToolMetadataModelType): void,
+
+  /**
+   * This is called before the tile is removed from the row of the document.
+   * Immediately after the tile is removed from the row it is also removed from
+   * the tileMap which is the actual container of the tile. 
+   */
+  willRemoveFromDocument?(): void
+}
+
+// This is a way to work with MST action syntax
+// The input argument has to match the api and the result
+// is a literal object type which is compatible with the ModelActions
+// type that is required.
+// A downside is that when working with the specific model type
+// TS doesn't know which methods of the API it actually implements
+
+/**
+ * A TypeScript helper method for adding hooks to a content model. It should be
+ * used like:
+ * ```
+ * .actions(self => toolContentModelHooks({
+ *   // add your hook functions here
+ * }))
+ * ```
+ *
+ * Unfortunately all hooks you define become optional. Because these hooks
+ * should normally only be called by the framework, most likely this issue will
+ * only come up in tests.
+ *
+ * @param hooks the hook functions
+ * @returns the hook functions in a literal object format that is compatible
+ * with the ModelActions type of MST
+ */
+export function toolContentModelHooks(hooks: IToolContentModelHooks) {
+  return {...hooks};
 }
 
 // Generic "super class" of all tool content models
@@ -63,7 +110,9 @@ export const ToolContentModel = types.model("ToolContentModel", {
     updateAfterSharedModelChanges(sharedModel?: SharedModelType) {
       throw new Error("not implemented");
     }
-  }));
+  }))
+  // Add an empty api so the api methods can be used on this generic type
+  .actions(self => toolContentModelHooks({}));
 
 export interface ToolContentModelType extends Instance<typeof ToolContentModel> {}
 

--- a/src/plugins/drawing-tool/model/drawing-content.test.ts
+++ b/src/plugins/drawing-tool/model/drawing-content.test.ts
@@ -67,7 +67,7 @@ describe("DrawingContentModel", () => {
   function createDrawingContentWithMetadata(options?: DrawingContentModelSnapshot) {
     const model = createDrawingContent(options);
     const metadata = DrawingToolMetadataModel.create({ id: "drawing-1" });
-    model.doPostCreate(metadata);
+    model.doPostCreate!(metadata);
     return model;
   }
 

--- a/src/plugins/drawing-tool/model/drawing-content.ts
+++ b/src/plugins/drawing-tool/model/drawing-content.ts
@@ -3,7 +3,7 @@ import { clone } from "lodash";
 import stringify from "json-stringify-pretty-compact";
 import { StampModel, StampModelType } from "./stamp";
 import { ITileExportOptions, IDefaultContentOptions } from "../../../models/tools/tool-content-info";
-import { ToolMetadataModel, ToolContentModel } from "../../../models/tools/tool-types";
+import { ToolMetadataModel, ToolContentModel, toolContentModelHooks } from "../../../models/tools/tool-types";
 import { kDrawingStateVersion, kDrawingToolID } from "./drawing-types";
 import { ImageObjectType, isImageObjectSnapshot } from "../objects/image";
 import { DefaultToolbarSettings, ToolbarSettings } from "./drawing-basic-types";
@@ -119,6 +119,11 @@ export const DrawingContentModel = ToolContentModel
       return stringify({type, objects}, {maxLength: 200});
     }
   }))
+  .actions(self => toolContentModelHooks({
+    doPostCreate(metadata) {
+      self.metadata = metadata as DrawingToolMetadataModelType;
+    },
+  }))
   .extend(self => {
 
     // FIXME: need to deal with logging the events
@@ -196,10 +201,6 @@ export const DrawingContentModel = ToolContentModel
 
     return {
       actions: {
-        doPostCreate(metadata: DrawingToolMetadataModelType) {
-          self.metadata = metadata;
-        },
-
         addObject(object: DrawingObjectType) {
           self.objects.push(object);
         },


### PR DESCRIPTION
This improves the typing of the tile container model hooks and tileEnv.  I started on this because I wanted to add a new hook (which will be in a different PR).

The hook typing was very painful to figure out. I think what I ended up on was good, but getting there was really hard. 

It isn't perfect because it makes all hooks optional even when we know they are defined. But here is what it helps with:

- calling of hooks doesn't need to use any or any casting.
- implementers of hooks now have typing and  documentation available.
- searches for references of hooks in VSCode now work.

The trickiness of this was to solve the following problems:
- not allowing unknown or mis-spelled hooks when tiles are implementing them
- keeping the conditional calling of a hook as simple as `model.hook?()`
- making sure the resulting instance type of at least the specific content model included the hook functions. And if possible make sure that `ToolTileModel` also includes these hook functions as optional.

MST's `actions` method requires the return value of the function to be a dictionary. So it won't allow returning something of type `ITileContentModelHooks`.  And if I simply cast an object of type `ITileContentModelHooks` to  `ModelActions` before returning it, this makes the return value generic, so then the type of the instance does not know about the actual hooks. Another way to look at this is that MST "classes" don't have a concept of "implements" like TS classes do.  One of the nuances of "implements" is that it doesn't actually change the type of the class it just makes sure the class has the methods in the interface.