### PR TITLE
onTileAction hook

### DIFF
--- a/src/models/mst.test.ts
+++ b/src/models/mst.test.ts
@@ -191,8 +191,7 @@ describe("mst", () => {
       afterCreate() {
         addDisposer(self, autorun(() => {
           autorunCount++;
-          const root = getRoot(self);
-          console.log("root", (root as any).toJSON());
+          getRoot(self);
         }));
       }
     }));
@@ -231,11 +230,9 @@ describe("mst", () => {
       afterCreate() {
         addDisposer(self, autorun(() => {
           autorunCount++;
-          let parent;
           if (hasParent(self)) {
-            parent = getParent(self);
+            getParent(self);
           }
-          console.log("parent", (parent as any)?.toJSON());
         }));
       }
     }));

--- a/src/models/tools/tool-tile.ts
+++ b/src/models/tools/tool-tile.ts
@@ -1,8 +1,9 @@
 import { cloneDeep } from "lodash";
-import { getParent, getSnapshot, getType, Instance, SnapshotIn, SnapshotOut, types } from "mobx-state-tree";
+import { getParent, getSnapshot, getType, 
+  Instance, SnapshotIn, SnapshotOut, types, ISerializedActionCall } from "mobx-state-tree";
 import { isPlaceholderContent } from "./placeholder/placeholder-content";
 import { ITileExportOptions } from "./tool-content-info";
-import { findMetadata, IToolContentModelHooks, ToolContentModelType, ToolContentUnion } from "./tool-types";
+import { findMetadata, ToolContentModelType, ToolContentUnion } from "./tool-types";
 import { DisplayUserTypeEnum } from "../stores/user-types";
 import { uniqueId } from "../../utilities/js-utils";
 
@@ -91,6 +92,9 @@ export const ToolTileModel = types
       if (metadata && content.doPostCreate) {
         content.doPostCreate(metadata);
       }
+    },
+    onTileAction(call: ISerializedActionCall) {
+      self.content.onTileAction?.(call);
     },
     willRemoveFromDocument() {
       const willRemoveFromDocument = self.content.willRemoveFromDocument;

--- a/src/models/tools/tool-tile.ts
+++ b/src/models/tools/tool-tile.ts
@@ -97,8 +97,7 @@ export const ToolTileModel = types
       self.content.onTileAction?.(call);
     },
     willRemoveFromDocument() {
-      const willRemoveFromDocument = self.content.willRemoveFromDocument;
-      return willRemoveFromDocument && willRemoveFromDocument();
+      return self.content.willRemoveFromDocument?.();
     },
     setDisabledFeatures(disabled: string[]) {
       const metadata: any = findMetadata(self.content.type, self.id);

--- a/src/models/tools/tool-types.ts
+++ b/src/models/tools/tool-types.ts
@@ -1,4 +1,4 @@
-import { getEnv, Instance, types, getParent, getType, SnapshotIn } from "mobx-state-tree";
+import { getEnv, Instance, ISerializedActionCall, types } from "mobx-state-tree";
 import { ISharedModelManager, SharedModelType } from "./shared-model";
 import { getToolContentModels, getToolContentInfoById } from "./tool-content-info";
 
@@ -36,6 +36,12 @@ export interface IToolContentModelHooks {
    * more than one place.
    */
   doPostCreate?(metadata: ToolMetadataModelType): void,
+
+  /**
+   * This is called for any action that is called on the wrapper (ToolTile) or one of
+   * its children. It can be used for logging or internal monitoring of action calls.
+   */
+  onTileAction?(call: ISerializedActionCall): void,
 
   /**
    * This is called before the tile is removed from the row of the document.


### PR DESCRIPTION
This will be used so tiles can log actions.
It also adds some new MST tests that were written to invalidate an earlier approach I was trying to take. The tests seem like useful documentation so I left them.

There are no new tests for this. However it is covered by existing tests anytime an action happens on a tile.  We really should have a suite of tests that covers the `IToolContentModelHooks` by adding a mock tile and then checking that the hooks are called at the appropriate time. Given the current craziness of the LARA migration and trying to get this CLUE stuff done at the same time, I'm going to skip adding those 😦 But at least the code is covered so it means it doesn't syntax errors not caught by the compiler. 

This is based on this PR: https://github.com/concord-consortium/collaborative-learning/pull/1308