### PR TITLE
Drawing Tool Logging

### DIFF
--- a/cypress/integration/clue/branch/student_tests/drawing_tool_spec.js
+++ b/cypress/integration/clue/branch/student_tests/drawing_tool_spec.js
@@ -101,6 +101,14 @@ context('Table Tool Tile', function () {
         cy.get(".toolbar-palette.fill-color .palette-buttons .color-swatch").last().click();
         drawToolTile.getRectangleDrawing().first().should("have.attr", "fill").and("eq", "#d100d1");
       });
+      it("verify move object", () => {
+        drawToolTile.getDrawToolSelect().click();
+        drawToolTile.getDrawTile()
+          .trigger("mousedown", 100, 100)
+          .trigger("mousemove", 200, 100)
+          .trigger("mouseup", 200, 100);
+        drawToolTile.getRectangleDrawing().first().should("have.attr", "x").then(parseInt).and("within", 170, 220);
+      });
       it("verify draw squares", () => {
         drawToolTile.getDrawToolRectangle().click();
         drawToolTile.getDrawTile()

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -8,7 +8,7 @@ import { InvestigationModelType } from "../models/curriculum/investigation";
 import { ProblemModelType } from "../models/curriculum/problem";
 import { DocumentModelType } from "../models/document/document";
 import { JXGChange } from "../models/tools/geometry/jxg-changes";
-import { DrawingToolChange } from "../plugins/drawing-tool/model/drawing-types";
+import { DrawingToolChange, DrawingToolLogEvent } from "../plugins/drawing-tool/model/drawing-types";
 import { ITableChange } from "../models/tools/table/table-change";
 import { ENavTab } from "../models/view/nav-tabs";
 import { DEBUG_LOGGER } from "../lib/debug";
@@ -131,7 +131,7 @@ export enum LogEventName {
 }
 
 type LoggableToolChangeEvent = Optional<JXGChange, "operation"> |
-                                Partial<DrawingToolChange> |
+                                DrawingToolLogEvent |
                                 Optional<ITableChange, "action">;
 
 interface IDocumentInfo {

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -406,7 +406,7 @@ export class Logger {
 function sendToLoggingService(data: LogMessage, user: UserModelType) {
   if (DEBUG_LOGGER) {
     // eslint-disable-next-line no-console
-    console.log("Logger#sendToLoggingService sending", JSON.stringify(data), "to", logManagerUrl);
+    console.log("Logger#sendToLoggingService sending", data, "to", logManagerUrl);
   }
   if (!Logger.isLoggingEnabled) return;
 

--- a/src/models/mst.test.ts
+++ b/src/models/mst.test.ts
@@ -1,6 +1,7 @@
 import { autorun } from "mobx";
 import { addDisposer, applySnapshot, getType, isAlive, types, getRoot, 
-  Instance, getParent, destroy, hasParent } from "mobx-state-tree";
+  isStateTreeNode, SnapshotOut, Instance, getParent, destroy, hasParent,
+  getSnapshot } from "mobx-state-tree";
 
 describe("mst", () => {
   it("snapshotProcessor unexpectedly modifies the base type", () => {
@@ -263,4 +264,42 @@ describe("mst", () => {
     });
   });
 
+
+  test("instances can be passed to snapshot methods", () => {
+    const Todo = types.model({
+      name: types.string
+    })
+    .actions(self => ({
+      doSomething () {
+        return false;
+      }
+    }));
+    interface TodoSnapshot extends SnapshotOut<typeof Todo> {}
+
+    const todo1 = Todo.create({name: "hello"});
+    const todo2 = Todo.create({name: "bye"});
+    applySnapshot(todo1, todo2);
+    expect(todo1.name).toBe("bye");
+
+    const TodoList = types.model({
+      todos: types.array(Todo)
+    })
+    .actions(self => ({
+      addTodo(todo: TodoSnapshot) {
+        if (isStateTreeNode(todo as any)) {
+          throw new Error("passed in todo is not a snapshot");
+        }
+        self.todos.push(todo);
+      }
+    }));
+
+    const todoList = TodoList.create();
+    todoList.addTodo(getSnapshot(todo1));
+    expect(todoList.todos[0]).toEqual(todo1);
+    expect(todoList.todos[0]).not.toBe(todo1);
+
+    expect(() => {
+      todoList.addTodo(todo1);
+    }).toThrow();
+  });
 });

--- a/src/plugins/drawing-tool/components/drawing-layer.test.tsx
+++ b/src/plugins/drawing-tool/components/drawing-layer.test.tsx
@@ -52,7 +52,7 @@ describe("Drawing Layer Components", () => {
       expect(getDrawingObject(content)).toMatchSnapshot();
     });
     it("deletes a freehand line", () => {
-      content.removeObject(line);
+      content.deleteObjects([line.id]);
       expect(getDrawingObject(content)).toMatchSnapshot();
     });
   });
@@ -78,7 +78,7 @@ describe("Drawing Layer Components", () => {
       expect(getDrawingObject(content)).toMatchSnapshot();
     });
     it("deletes a vector line", () => {
-      content.removeObject(vector);
+      content.deleteObjects([vector.id]);
       expect(getDrawingObject(content)).toMatchSnapshot();
     });
   });
@@ -105,7 +105,7 @@ describe("Drawing Layer Components", () => {
       expect(getDrawingObject(content)).toMatchSnapshot();
     });
     it("deletes a rectangle", () => {
-      content.removeObject(rect);
+      content.deleteObjects([rect.id]);
       expect(getDrawingObject(content)).toMatchSnapshot();
     });
   });
@@ -132,7 +132,7 @@ describe("Drawing Layer Components", () => {
       expect(getDrawingObject(content)).toMatchSnapshot();
     });
     it("deletes a ellipse", () => {
-      content.removeObject(ellipse);
+      content.deleteObjects([ellipse.id]);
       expect(getDrawingObject(content)).toMatchSnapshot();
     });
   });
@@ -156,7 +156,7 @@ describe("Drawing Layer Components", () => {
       expect(getDrawingObject(content)).toMatchSnapshot();
     });
     it("deletes a image", () => {
-      content.removeObject(image);
+      content.deleteObjects([image.id]);
       expect(getDrawingObject(content)).toMatchSnapshot();
     });
   });

--- a/src/plugins/drawing-tool/components/drawing-layer.tsx
+++ b/src/plugins/drawing-tool/components/drawing-layer.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { reaction, IReactionDisposer } from "mobx";
 import { observer } from "mobx-react";
 import { extractDragTileType, kDragTileContent } from "../../../components/tools/tool-tile";
-import { DrawingContentModelType } from "../model/drawing-content";
+import { DrawingContentModelType, DrawingObjectMove } from "../model/drawing-content";
 import { ToolTileModelType } from "../../../models/tools/tool-tile";
 import { safeJsonParse } from "../../../utilities/js-utils";
 import { ImageContentSnapshotOutType } from "../../../models/tools/image/image-content";
@@ -253,10 +253,14 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
         // FIXME it would be better for logging if we had a setPosition that took
         // a list of ids here
         // For that we need the cumulative dx and dy
-        objectsToInteract.forEach((object, index) => {
+        const moves: DrawingObjectMove[] = objectsToInteract.map((object, index) => {
           const draggedObject = objectsBeingDragged[index];
-          object.setPosition(draggedObject.x, draggedObject.y);
+          return {
+            id: object.id,
+            destination: {x: draggedObject.x, y: draggedObject.y}
+          };
         });
+        this.getContent().moveObjects(moves);
       }
       else {
         this.handleObjectClick(e2, obj);

--- a/src/plugins/drawing-tool/components/drawing-layer.tsx
+++ b/src/plugins/drawing-tool/components/drawing-layer.tsx
@@ -229,11 +229,6 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
       }
 
       objectsBeingDragged.forEach((object, index) => {
-        // FIXME: this will change the state of the model during the move
-        // previously the state was only changed on mouse up
-        // we probably need to emulate this behavior, both for undo/redo
-        // and to avoid sending too much state. This is the same problem 
-        // we will have with typing characters into a text field.
         object.setPosition(start[index].x + dx, start[index].y + dy);
       });
 
@@ -250,9 +245,6 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
       window.removeEventListener("mousemove", handleMouseMove);
       window.removeEventListener("mouseup", handleMouseUp);
       if (moved) {
-        // FIXME it would be better for logging if we had a setPosition that took
-        // a list of ids here
-        // For that we need the cumulative dx and dy
         const moves: DrawingObjectMove[] = objectsToInteract.map((object, index) => {
           const draggedObject = objectsBeingDragged[index];
           return {

--- a/src/plugins/drawing-tool/components/drawing-layer.tsx
+++ b/src/plugins/drawing-tool/components/drawing-layer.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { reaction, IReactionDisposer } from "mobx";
+import { clone } from "mobx-state-tree";
 import { observer } from "mobx-react";
 import { extractDragTileType, kDragTileContent } from "../../../components/tools/tool-tile";
 import { DrawingContentModelType, DrawingObjectMove } from "../model/drawing-content";
@@ -14,7 +15,6 @@ import { DrawingObjectSnapshotForAdd, DrawingObjectType, DrawingTool,
 import { Point, ToolbarSettings } from "../model/drawing-basic-types";
 import { getDrawingToolInfos, renderDrawingObject } from "./drawing-object-manager";
 import { ImageObject } from "../objects/image";
-import { clone } from "mobx-state-tree";
 
 const SELECTION_COLOR = "#777";
 const HOVER_COLOR = "#bbdd00";

--- a/src/plugins/drawing-tool/components/drawing-layer.tsx
+++ b/src/plugins/drawing-tool/components/drawing-layer.tsx
@@ -8,11 +8,13 @@ import { safeJsonParse } from "../../../utilities/js-utils";
 import { ImageContentSnapshotOutType } from "../../../models/tools/image/image-content";
 import { gImageMap } from "../../../models/image-map";
 import { SelectionBox } from "./selection-box";
-import { DrawingObjectType, DrawingTool, 
-  HandleObjectHover } from "../objects/drawing-object";
+import { DrawingObjectSnapshotForAdd, DrawingObjectType, DrawingTool, 
+  HandleObjectHover, 
+  IDrawingLayer} from "../objects/drawing-object";
 import { Point, ToolbarSettings } from "../model/drawing-basic-types";
 import { getDrawingToolInfos, renderDrawingObject } from "./drawing-object-manager";
 import { ImageObject } from "../objects/image";
+import { clone } from "mobx-state-tree";
 
 const SELECTION_COLOR = "#777";
 const HOVER_COLOR = "#bbdd00";
@@ -37,10 +39,12 @@ interface DrawingLayerViewState {
   selectedObjects: DrawingObjectType[];
   selectionBox: SelectionBox|null;
   hoverObject: DrawingObjectType|null;
+  objectsBeingDragged: DrawingObjectType[];
 }
 
 @observer
-export class DrawingLayerView extends React.Component<DrawingLayerViewProps, DrawingLayerViewState> {
+export class DrawingLayerView extends React.Component<DrawingLayerViewProps, DrawingLayerViewState> 
+    implements IDrawingLayer {
   public currentTool: DrawingTool|null;
   public tools: DrawingToolMap;
   private svgRef: React.RefObject<any>|null;
@@ -56,6 +60,7 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
       selectionBox: null,
       selectedObjects: [],
       hoverObject: null,
+      objectsBeingDragged: [],
     };
 
     this.tools = {};
@@ -81,7 +86,7 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
     this.disposers = [];
 
     this.disposers.push(reaction(
-      () => this.getContent().metadata.selectedButton,
+      () => this.getContent().selectedButton,
       selectedButton => this.syncCurrentTool(selectedButton)
     ));
 
@@ -90,7 +95,7 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
     // too. There are still a few places working with this list of selected objects from the
     // state instead of the model. 
     this.disposers.push(reaction(
-      () => this.getContent().metadata.selection.toJSON(),
+      () => this.getContent().selectedIds,
       selectedIds => {
         const selectedObjects = selectedIds.map(
           id => this.getContent().objectMap[id]).filter(obj => !!obj) as DrawingObjectType[];
@@ -137,7 +142,7 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
     });
   }
 
-  public addNewDrawingObject(drawingObject: DrawingObjectType) {
+  public addNewDrawingObject(drawingObject: DrawingObjectSnapshotForAdd) {
     this.getContent().addObject(drawingObject);
   }
 
@@ -167,7 +172,7 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
   }
 
   public handleDelete() {
-    this.getContent().deleteSelectedObjects();
+    this.getContent().deleteObjects(this.getContent().selectedIds);
   }
 
   public handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
@@ -192,7 +197,8 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
   public handleSelectedObjectMouseDown = (e: React.MouseEvent<any>, obj: DrawingObjectType) => {
     if (this.props.readOnly) return;
     let moved = false;
-    const {selectedObjects, hoverObject} = this.state;
+    const {selectedObjects, hoverObject } = this.state;
+    let { objectsBeingDragged } = this.state;
     let objectsToInteract: DrawingObjectType[];
     let needToAddHoverToSelection = false;
     if (hoverObject && !selectedObjects.some(object => object.id === hoverObject.id)) {
@@ -217,7 +223,12 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
       const dy = current.y - starting.y;
       moved = moved || ((dx !== 0) && (dy !== 0));
 
-      objectsToInteract.forEach((object, index) => {
+      if (objectsBeingDragged.length === 0) {
+        objectsBeingDragged = objectsToInteract.map(object => clone(object));
+        this.setState( {objectsBeingDragged});
+      }
+
+      objectsBeingDragged.forEach((object, index) => {
         // FIXME: this will change the state of the model during the move
         // previously the state was only changed on mouse up
         // we probably need to emulate this behavior, both for undo/redo
@@ -239,12 +250,18 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
       window.removeEventListener("mousemove", handleMouseMove);
       window.removeEventListener("mouseup", handleMouseUp);
       if (moved) {
-        // Regarding the FIXME above, this is where we'd want to trigger the end 
-        // of the undo-able event
+        // FIXME it would be better for logging if we had a setPosition that took
+        // a list of ids here
+        // For that we need the cumulative dx and dy
+        objectsToInteract.forEach((object, index) => {
+          const draggedObject = objectsBeingDragged[index];
+          object.setPosition(draggedObject.x, draggedObject.y);
+        });
       }
       else {
         this.handleObjectClick(e2, obj);
       }
+      this.setState({ objectsBeingDragged: []});
     };
 
     window.addEventListener("mousemove", handleMouseMove);
@@ -337,6 +354,8 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
         ? this.state.selectedObjects.indexOf(this.state.hoverObject) !== -1
         : false;
 
+    const idsBeingDragged = this.state.objectsBeingDragged.map(object => object.id);
+
     return (
       <div className="drawing-layer"
           data-testid="drawing-layer"
@@ -346,9 +365,12 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
           onDrop={this.handleDrop} >
 
         <svg xmlnsXlink="http://www.w3.org/1999/xlink" width={1500} height={1500} ref={this.setSvgRef}>
-          {this.renderObjects(object => object.type === "image")}
-          {this.renderObjects(object => object.type !== "image")}
-          {this.renderSelectedObjects(this.state.selectedObjects, SELECTION_COLOR)}
+          {this.renderObjects(object => object.type === "image" && !idsBeingDragged.includes(object.id))}
+          {this.renderObjects(object => object.type !== "image" && !idsBeingDragged.includes(object.id))}
+          {this.state.objectsBeingDragged.map((object) => renderDrawingObject(object))}
+          {this.state.objectsBeingDragged.length > 0 ? 
+            this.renderSelectedObjects(this.state.objectsBeingDragged, SELECTION_COLOR)
+            : this.renderSelectedObjects(this.state.selectedObjects, SELECTION_COLOR)}
           {this.state.hoverObject
             ? this.renderSelectedObjects([this.state.hoverObject], hoveringOverAlreadySelectedObject
               ? SELECTION_COLOR : HOVER_COLOR)

--- a/src/plugins/drawing-tool/components/drawing-toolbar-buttons.tsx
+++ b/src/plugins/drawing-tool/components/drawing-toolbar-buttons.tsx
@@ -103,7 +103,7 @@ export const DeleteButton: React.FC<IDeleteToolButtonProps> = observer(function 
   toolbarManager
 }) {
   const onClick = () => {
-    toolbarManager.deleteSelectedObjects();
+    toolbarManager.deleteObjects(toolbarManager.selectedIds);
   };
   const disabled = !toolbarManager.hasSelectedObjects;
 

--- a/src/plugins/drawing-tool/components/drawing-toolbar.tsx
+++ b/src/plugins/drawing-tool/components/drawing-toolbar.tsx
@@ -68,11 +68,11 @@ export const ToolbarView: React.FC<IProps> = (
   };
 
   const handleStrokeColorChange = (color: string) => {
-    isEnabled && drawingContent.setStroke(color);
+    isEnabled && drawingContent.setStroke(color, drawingContent.selectedIds);
     clearPaletteState();
   };
   const handleFillColorChange = (color: string) => {
-    isEnabled && drawingContent.setFill(color);
+    isEnabled && drawingContent.setFill(color, drawingContent.selectedIds);
     clearPaletteState();
   };
 

--- a/src/plugins/drawing-tool/model/drawing-content.test.ts
+++ b/src/plugins/drawing-tool/model/drawing-content.test.ts
@@ -13,7 +13,6 @@ import { RectangleObject, RectangleObjectSnapshot, RectangleObjectSnapshotForAdd
 import { computeStrokeDashArray } from "../objects/drawing-object";
 import { LogEventName, Logger } from "../../../lib/logger";
 
-// mock Logger calls
 jest.mock("../../../lib/logger", () => {
   return {
     ...(jest.requireActual("../../../lib/logger") as any),
@@ -22,6 +21,7 @@ jest.mock("../../../lib/logger", () => {
     }
   };
 });
+const logToolChange = Logger.logToolChange as jest.Mock;
 
 describe("computeStrokeDashArray", () => {
   it("should return expected results", () => {
@@ -148,9 +148,7 @@ describe("DrawingContentModel", () => {
   it("can delete a set of selected drawing objects", () => {
     const model = createDrawingContentWithMetadata();
 
-    // TODO: maybe we want to just reset the one function, but TS doesn't like us calling resetMock
-    // on Logger.logToolChange
-    jest.resetAllMocks();
+    logToolChange.mockReset();
 
     const rectSnapshot1: RectangleObjectSnapshotForAdd = {...baseRectangleSnapshot, id:"a", x:0, y:0};
     model.addObject(rectSnapshot1);
@@ -168,9 +166,9 @@ describe("DrawingContentModel", () => {
 
     model.deleteObjects(model.selectedIds);
     expect(model.objects.length).toBe(0);
-    // Note: Normally the path will start at the root of the document, but for this test we are
+    // Note: Normally the path will start at the root of the document, but for this test we
     // are mocking the onTileAction so the path is just blank
-    expect(Logger.logToolChange).toHaveBeenNthCalledWith(1,
+    expect(logToolChange).toHaveBeenNthCalledWith(1,
       LogEventName.DRAWING_TOOL_CHANGE, "addObject", { args: [ {
         fill: "#666666",
         height: 10,
@@ -183,7 +181,7 @@ describe("DrawingContentModel", () => {
         x: 0,
         y: 0
       } ], path: ""}, "drawing-1");
-    expect(Logger.logToolChange).toHaveBeenNthCalledWith(2,
+    expect(logToolChange).toHaveBeenNthCalledWith(2,
       LogEventName.DRAWING_TOOL_CHANGE, "addObject", { args: [ {
         fill: "#666666",
         height: 10,
@@ -196,11 +194,11 @@ describe("DrawingContentModel", () => {
         x: 20,
         y: 20
       } ], path: ""}, "drawing-1");
-    expect(Logger.logToolChange).toHaveBeenNthCalledWith(3,
+    expect(logToolChange).toHaveBeenNthCalledWith(3,
       LogEventName.DRAWING_TOOL_CHANGE, "deleteObjects", { args: [ [] ], path: ""}, "drawing-1");
-    expect(Logger.logToolChange).toHaveBeenNthCalledWith(4,
+    expect(logToolChange).toHaveBeenNthCalledWith(4,
       LogEventName.DRAWING_TOOL_CHANGE, "setSelection", { args: [ ["a", "b"] ], path: ""}, "drawing-1");
-    expect(Logger.logToolChange).toHaveBeenNthCalledWith(5,
+    expect(logToolChange).toHaveBeenNthCalledWith(5,
       LogEventName.DRAWING_TOOL_CHANGE, "deleteObjects", { args: [ ["a", "b"] ], path: ""}, "drawing-1");
   });
 
@@ -214,7 +212,7 @@ describe("DrawingContentModel", () => {
     const rectSnapshot2: RectangleObjectSnapshotForAdd = {...baseRectangleSnapshot, id:"b", x:10, y:10};
     model.addObject(rectSnapshot2);
 
-    jest.resetAllMocks();
+    logToolChange.mockReset();
     model.setSelection(["a", "b"]);
     model.setStroke("#000000", model.selectedIds);
     model.setStrokeWidth(2, model.selectedIds);
@@ -231,13 +229,13 @@ describe("DrawingContentModel", () => {
     expect(rect2.stroke).toBe("#000000");
     expect(rect2.strokeWidth).toBe(2);
 
-    expect(Logger.logToolChange).toHaveBeenNthCalledWith(1,
+    expect(logToolChange).toHaveBeenNthCalledWith(1,
       LogEventName.DRAWING_TOOL_CHANGE, "setSelection", { args: [["a", "b"]], path: "" }, "drawing-1");
-    expect(Logger.logToolChange).toHaveBeenNthCalledWith(2,
+    expect(logToolChange).toHaveBeenNthCalledWith(2,
       LogEventName.DRAWING_TOOL_CHANGE, "setStroke", { args: ["#000000", ["a", "b"]], path: "" }, "drawing-1");
-    expect(Logger.logToolChange).toHaveBeenNthCalledWith(3,
+    expect(logToolChange).toHaveBeenNthCalledWith(3,
       LogEventName.DRAWING_TOOL_CHANGE, "setStrokeWidth", { args: [2, ["a", "b"]], path: "" }, "drawing-1");
-    expect(Logger.logToolChange).toHaveBeenNthCalledWith(4,
+    expect(logToolChange).toHaveBeenNthCalledWith(4,
       LogEventName.DRAWING_TOOL_CHANGE, "setStrokeDashArray", { args: ["3,3", ["a", "b"]], path: "" }, "drawing-1");
   });
 
@@ -250,12 +248,12 @@ describe("DrawingContentModel", () => {
     const rectSnapshot2: RectangleObjectSnapshotForAdd = {...baseRectangleSnapshot, id:"b", x:10, y:10};
     model.addObject(rectSnapshot2);
 
-    jest.resetAllMocks();
+    logToolChange.mockReset();
     model.moveObjects([
       {id: "a", destination: {x: 20, y: 20}},
       {id: "b", destination: {x: 30, y: 30}} 
     ]);
-    expect(Logger.logToolChange).toHaveBeenNthCalledWith(1,
+    expect(logToolChange).toHaveBeenNthCalledWith(1,
       LogEventName.DRAWING_TOOL_CHANGE, "moveObjects", { args: [[
         {id: "a", destination: {x: 20, y: 20}},
         {id: "b", destination: {x: 30, y: 30}} 

--- a/src/plugins/drawing-tool/model/drawing-content.test.ts
+++ b/src/plugins/drawing-tool/model/drawing-content.test.ts
@@ -8,7 +8,7 @@ import { DefaultToolbarSettings } from "./drawing-basic-types";
 import { StampModel } from "./stamp";
 import { AppConfigModel } from "../../../models/stores/app-config-model";
 import { ImageObject } from "../objects/image";
-import { RectangleObjectSnapshot, RectangleObjectSnapshotForAdd, 
+import { RectangleObject, RectangleObjectSnapshot, RectangleObjectSnapshotForAdd, 
   RectangleObjectType } from "../objects/rectangle";
 import { computeStrokeDashArray } from "../objects/drawing-object";
 import { LogEventName, Logger } from "../../../lib/logger";
@@ -218,6 +218,7 @@ describe("DrawingContentModel", () => {
     model.setSelection(["a", "b"]);
     model.setStroke("#000000", model.selectedIds);
     model.setStrokeWidth(2, model.selectedIds);
+    model.setStrokeDashArray("3,3", model.selectedIds);
 
     expect(model.objects[0].type).toBe("rectangle");
     const rect1 = model.objects[0] as RectangleObjectType;
@@ -236,6 +237,8 @@ describe("DrawingContentModel", () => {
       LogEventName.DRAWING_TOOL_CHANGE, "setStroke", { args: ["#000000", ["a", "b"]], path: "" }, "drawing-1");
     expect(Logger.logToolChange).toHaveBeenNthCalledWith(3,
       LogEventName.DRAWING_TOOL_CHANGE, "setStrokeWidth", { args: [2, ["a", "b"]], path: "" }, "drawing-1");
+    expect(Logger.logToolChange).toHaveBeenNthCalledWith(4,
+      LogEventName.DRAWING_TOOL_CHANGE, "setStrokeDashArray", { args: ["3,3", ["a", "b"]], path: "" }, "drawing-1");
   });
 
   it("can move objects", () => {
@@ -303,5 +306,12 @@ describe("DrawingContentModel", () => {
 
     model.updateImageUrl("my/image/url", "my/image/newUrl");
     expect(image.url).toBe("my/image/newUrl");
+  });
+
+  test("addObject throws when an instance is passed to it", () => {
+    const model = createDrawingContentWithMetadata();
+    const rect = RectangleObject.create(baseRectangleSnapshot);
+    
+    expect(() => model.addObject(rect)).toThrow();
   });
 });

--- a/src/plugins/drawing-tool/model/drawing-content.ts
+++ b/src/plugins/drawing-tool/model/drawing-content.ts
@@ -147,6 +147,12 @@ export const DrawingContentModel = ToolContentModel
     return {
       actions: {
         addObject(object: DrawingObjectSnapshotForAdd) {
+          // The reason only snapshots are allowed is so the logged action
+          // includes the snapshot in the `call` that is passed to `onAction`. 
+          // If a instance is passed instead of a snapshot, then MST will just 
+          // log something like:
+          // `{ $MST_UNSERIALIZABLE: true, type: "someType" }`. 
+          // More details can be found here: https://mobx-state-tree.js.org/API/#onaction
           if (isStateTreeNode(object as any)) {
             throw new Error("addObject requires a snapshot");
           }

--- a/src/plugins/drawing-tool/model/drawing-content.ts
+++ b/src/plugins/drawing-tool/model/drawing-content.ts
@@ -10,6 +10,7 @@ import { DefaultToolbarSettings, ToolbarSettings } from "./drawing-basic-types";
 import { DrawingObjectMSTUnion } from "../components/drawing-object-manager";
 import { DrawingObjectSnapshotForAdd, DrawingObjectType, isFilledObject, 
   isStrokedObject, ToolbarModalButton } from "../objects/drawing-object";
+import { LogEventName, Logger } from "../../../lib/logger";
 
 // interface LoggedEventProperties {
 //   properties?: string[];
@@ -136,7 +137,13 @@ export const DrawingContentModel = ToolContentModel
       self.metadata = metadata as DrawingToolMetadataModelType;
     },
     onTileAction(call) {
-      console.log("Action was called", call);
+      const {name, ...loggedChangeProps} = call;
+      // FIXME: what do we do with the typing of log events here?
+      // We could specify the known types, but this will easily get out of date
+      // and it would be easy to miss one.
+      // I think the main point of these actions is or documentation
+      Logger.logToolChange(LogEventName.DRAWING_TOOL_CHANGE, name, 
+        loggedChangeProps as any, self.metadata?.id ?? "");
     }
   }))
   .extend(self => {

--- a/src/plugins/drawing-tool/model/drawing-content.ts
+++ b/src/plugins/drawing-tool/model/drawing-content.ts
@@ -149,7 +149,7 @@ export const DrawingContentModel = ToolContentModel
         addObject(object: DrawingObjectSnapshotForAdd) {
           // The reason only snapshots are allowed is so the logged action
           // includes the snapshot in the `call` that is passed to `onAction`. 
-          // If a instance is passed instead of a snapshot, then MST will just 
+          // If an instance is passed instead of a snapshot, then MST will just 
           // log something like:
           // `{ $MST_UNSERIALIZABLE: true, type: "someType" }`. 
           // More details can be found here: https://mobx-state-tree.js.org/API/#onaction

--- a/src/plugins/drawing-tool/model/drawing-content.ts
+++ b/src/plugins/drawing-tool/model/drawing-content.ts
@@ -54,6 +54,11 @@ interface ObjectMap {
   [key: string]: DrawingObjectType|null;
 }
 
+export interface DrawingObjectMove {
+  id: string, 
+  destination: {x: number, y: number}
+}
+
 export const DrawingContentModel = ToolContentModel
   .named("DrawingTool")
   .props({
@@ -247,6 +252,13 @@ export const DrawingContentModel = ToolContentModel
               self.objects.remove(object);
               self.metadata?.unselectId(id);
             }
+          });
+        },
+
+        moveObjects(moves: DrawingObjectMove[]) {
+          moves.forEach(move => {
+            const object = self.objectMap[move.id];
+            object?.setPosition(move.destination.x, move.destination.y);
           });
         },
 

--- a/src/plugins/drawing-tool/model/drawing-content.ts
+++ b/src/plugins/drawing-tool/model/drawing-content.ts
@@ -12,20 +12,6 @@ import { DrawingObjectSnapshotForAdd, DrawingObjectType, isFilledObject,
   isStrokedObject, ToolbarModalButton } from "../objects/drawing-object";
 import { LogEventName, Logger } from "../../../lib/logger";
 
-// interface LoggedEventProperties {
-//   properties?: string[];
-// }
-// interface DrawingToolLoggedCreateEvent extends Partial<DrawingToolCreateChange>, LoggedEventProperties {
-// }
-// interface DrawingToolLoggedMoveEvent extends Partial<DrawingToolMoveChange>, LoggedEventProperties {
-// }
-// interface DrawingToolLoggedUpdateEvent extends Partial<DrawingToolUpdateChange>, LoggedEventProperties {
-// }
-// interface DrawingToolLoggedDeleteEvent extends Partial<DrawingToolDeleteChange>, LoggedEventProperties {
-// }
-// type DrawingToolChangeLoggedEvent = DrawingToolLoggedCreateEvent | DrawingToolLoggedMoveEvent |
-//                                       DrawingToolLoggedUpdateEvent | DrawingToolLoggedDeleteEvent;
-
 // track selection in metadata object so it is not saved to firebase but
 // also is preserved across document/content reloads
 export const DrawingToolMetadataModel = ToolMetadataModel
@@ -93,7 +79,7 @@ export const DrawingContentModel = ToolContentModel
       return button === self.metadata?.selectedButton;
     },
     get selectedButton() {
-      return self.metadata ? self.metadata.selectedButton : "select";
+      return self.metadata?.selectedButton || "select";
     },
     get hasSelectedObjects() {
       return self.metadata ? self.metadata.selection.length > 0 : false;
@@ -138,36 +124,13 @@ export const DrawingContentModel = ToolContentModel
     },
     onTileAction(call) {
       const {name, ...loggedChangeProps} = call;
-      // FIXME: what do we do with the typing of log events here?
-      // We could specify the known types, but this will easily get out of date
-      // and it would be easy to miss one.
-      // I think the main point of these actions is or documentation
+      // TODO: logToolChange includes an explicit DrawingToolLogEvent
+      // this isn't a good pattern to support generic plugins logging events
       Logger.logToolChange(LogEventName.DRAWING_TOOL_CHANGE, name, 
-        loggedChangeProps as any, self.metadata?.id ?? "");
+        loggedChangeProps, self.metadata?.id ?? "");
     }
   }))
   .extend(self => {
-
-    // FIXME: need to deal with logging the events
-    // function applyChange(change: DrawingToolChange) {
-    //   self.changes.push(JSON.stringify(change));
-
-    //   let loggedChangeProps = {...change} as DrawingToolChangeLoggedEvent;
-    //   delete loggedChangeProps.data;
-    //   if (!Array.isArray(change.data)) {
-    //     // flatten change.properties
-    //     loggedChangeProps = {
-    //       ...loggedChangeProps,
-    //       ...change.data
-    //     };
-    //   } else {
-    //     // or clean up MST array
-    //     loggedChangeProps.properties = Array.from(change.data as string[]);
-    //   }
-    //   delete loggedChangeProps.action;
-    //   Logger.logToolChange(LogEventName.DRAWING_TOOL_CHANGE, change.action,
-    //     loggedChangeProps, self.metadata?.id ?? "");
-    // }
 
     function forEachObjectId(ids: string[], func: (object: DrawingObjectType, id: string) => void) {
       if (ids.length === 0) return;
@@ -180,23 +143,6 @@ export const DrawingContentModel = ToolContentModel
         }
       });
     }
-
-    // Keeping this around to help when adding back logging
-    // function updateSelectedObjects(prop: string, newValue: string|number) {
-    //   if (self.metadata.selection.length > 0) {
-    //     const updateChange: DrawingToolChange = {
-    //       action: "update",
-    //       data: {
-    //         ids: self.metadata.selection,
-    //         update: {
-    //           prop,
-    //           newValue
-    //         }
-    //       }
-    //     };
-    //     applyChange(updateChange);
-    //   }
-    // }
 
     return {
       actions: {

--- a/src/plugins/drawing-tool/model/drawing-export.test.ts
+++ b/src/plugins/drawing-tool/model/drawing-export.test.ts
@@ -61,7 +61,7 @@ describe("exportDrawingTileSpec", () => {
     const drawing3 = createDrawingContent({ objects: [
       v1Data, v2Data
     ]});
-    drawing3.removeObject(drawing3.objects[0]);
+    drawing3.deleteObjects([drawing3.objects[0].id]);
     expect(exportDrawing2(drawing3)).toEqual({ type: "Drawing", objects: [v2Data] });
   });
 
@@ -94,7 +94,7 @@ describe("exportDrawingTileSpec", () => {
     const drawing3 = createDrawingContent({ objects: [
       l1Data, l2Data
     ]});
-    drawing3.removeObject(drawing3.objects[0]);
+    drawing3.deleteObjects([drawing3.objects[0].id]);
     expect(exportDrawing2(drawing3)).toEqual({ type: "Drawing", objects: [l2Data] });
   });
 
@@ -133,9 +133,7 @@ describe("exportDrawingTileSpec", () => {
     const drawing3 = createDrawingContent({ objects: [
       r1Data, r2Data, r3Data
     ]});
-    drawing3.removeObject(drawing3.objects[1]);
-    // Old objects[2] is now objects[1]
-    drawing3.removeObject(drawing3.objects[1]);
+    drawing3.deleteObjects([drawing3.objects[1].id, drawing3.objects[2].id]);
     expect(exportDrawing2(drawing3)).toEqual({ type: "Drawing", objects: [r1Data] });
   });
 
@@ -174,9 +172,7 @@ describe("exportDrawingTileSpec", () => {
     const drawing3 = createDrawingContent({ objects: [
       e1Data, e2Data, e3Data
     ]});
-    drawing3.removeObject(drawing3.objects[1]);
-    // Old objects[2] is now objects[1]
-    drawing3.removeObject(drawing3.objects[1]);
+    drawing3.deleteObjects([drawing3.objects[1].id, drawing3.objects[2].id]);
     expect(exportDrawing2(drawing3)).toEqual({ type: "Drawing", objects: [e1Data] });
   });
 
@@ -208,7 +204,7 @@ describe("exportDrawingTileSpec", () => {
     const drawing3 = createDrawingContent({ objects: [
       i1Data, i2Data, i3Data
     ]});
-    drawing3.removeObject(drawing3.objects[1]);
+    drawing3.deleteObjects([drawing3.objects[1].id]);
     expect(exportDrawing2(drawing3)).toEqual({ type: "Drawing", objects: [i1Data, i3Data] });
   });
 
@@ -259,7 +255,7 @@ describe("exportDrawingTileSpec", () => {
     const drawing3 = createDrawingContent({ objects: [
       i1Data, i2Data, i3Data
     ]});
-    drawing3.removeObject(drawing3.objects[1]);
+    drawing3.deleteObjects([drawing3.objects[1].id]);
     expect(exportDrawingWithTransform(drawing3))
             .toEqual({ type: "Drawing", objects: [i1OutData, i3OutData] });
   });

--- a/src/plugins/drawing-tool/model/drawing-types.ts
+++ b/src/plugins/drawing-tool/model/drawing-types.ts
@@ -8,6 +8,12 @@ export const kDrawingToolID = "Drawing";
 export const kDrawingStateVersion = "1.0.0";
 export const kDrawingDefaultHeight = 180;
 
+// This is the form the log events take  
+export interface DrawingToolLogEvent {
+  path?: string;
+  args?: Array<any>;
+}
+
 // These types are used by legacy import code in drawing-change-playback.ts
 export type DrawingToolMove = Array<{id: string, destination: Point}>;
 export interface DrawingToolUpdate {

--- a/src/plugins/drawing-tool/objects/drawing-object.ts
+++ b/src/plugins/drawing-tool/objects/drawing-object.ts
@@ -57,8 +57,8 @@ export const DrawingObject = types.model("DrawingObject", {
   }
 }));
 export interface DrawingObjectType extends Instance<typeof DrawingObject> {}
-export interface DrawingObjectSnapshot extends SnapshotIn<typeof DrawingObject> {} 
-// Snapshots being passed to add need to have a type so the MST Union can figure out 
+export interface DrawingObjectSnapshot extends SnapshotIn<typeof DrawingObject> {}
+// Snapshots being passed to addNewDrawingObject need to have a type so the MST Union can figure out
 // what they are.  They do not need an id because object will add that when it is created
 export interface DrawingObjectSnapshotForAdd extends SnapshotIn<typeof DrawingObject> {type: string} 
 

--- a/src/plugins/drawing-tool/objects/drawing-object.ts
+++ b/src/plugins/drawing-tool/objects/drawing-object.ts
@@ -14,8 +14,8 @@ export interface IToolbarManager {
   selectedButton: string;
   toolbarSettings: ToolbarSettings;
   hasSelectedObjects: boolean;
-  addObject(object: DrawingObjectType): void;
-  deleteSelectedObjects(): void;
+  selectedIds: string [];
+  deleteObjects(ids: string[]): void;
   stamps: StampModelType[];
   currentStamp: StampModelType | null;
   stroke: string;
@@ -58,6 +58,9 @@ export const DrawingObject = types.model("DrawingObject", {
 }));
 export interface DrawingObjectType extends Instance<typeof DrawingObject> {}
 export interface DrawingObjectSnapshot extends SnapshotIn<typeof DrawingObject> {} 
+// Snapshots being passed to add need to have a type so the MST Union can figure out 
+// what they are.  They do not need an id because object will add that when it is created
+export interface DrawingObjectSnapshotForAdd extends SnapshotIn<typeof DrawingObject> {type: string} 
 
 export const StrokedObject = DrawingObject.named("StrokedObject")
 .props({
@@ -133,7 +136,7 @@ export type DrawingComponentType = React.ComponentType<IDrawingComponentProps>;
 export interface IDrawingLayer {
   getWorkspacePoint: (e:MouseEvent|React.MouseEvent) => Point|null;
   setCurrentDrawingObject: (object: DrawingObjectType|null) => void;
-  addNewDrawingObject: (object: DrawingObjectType) => void;
+  addNewDrawingObject: (object: DrawingObjectSnapshotForAdd) => void;
   getCurrentStamp: () => StampModelType|null;
   startSelectionBox: (start: Point) => void;
   updateSelectionBox: (p: Point) => void;

--- a/src/plugins/drawing-tool/objects/ellipse.tsx
+++ b/src/plugins/drawing-tool/objects/ellipse.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react";
-import { Instance, SnapshotIn, types } from "mobx-state-tree";
+import { Instance, SnapshotIn, types, getSnapshot } from "mobx-state-tree";
 import React from "react";
 import { computeStrokeDashArray, DrawingObjectType, DrawingTool, FilledObject, IDrawingComponentProps, IDrawingLayer, 
   IToolbarButtonProps, StrokedObject, typeField } from "./drawing-object";
@@ -83,7 +83,7 @@ export class EllipseDrawingTool extends DrawingTool {
     const handleMouseUp = (e2: MouseEvent) => {
       e2.preventDefault();
       if ((ellipse.rx > 0) && (ellipse.ry > 0)) {
-        this.drawingLayer.addNewDrawingObject(ellipse);
+        this.drawingLayer.addNewDrawingObject(getSnapshot(ellipse));
       }
       this.drawingLayer.setCurrentDrawingObject(null);
       window.removeEventListener("mousemove", handleMouseMove);

--- a/src/plugins/drawing-tool/objects/image.tsx
+++ b/src/plugins/drawing-tool/objects/image.tsx
@@ -89,6 +89,7 @@ export const ImageObject = DrawingObject.named("ImageObject")
   }));
 export interface ImageObjectType extends Instance<typeof ImageObject> {}
 export interface ImageObjectSnapshot extends SnapshotIn<typeof ImageObject> {}
+export interface ImageObjectSnapshotForAdd extends SnapshotIn<typeof ImageObject> {type: string}
 
 export function isImageObjectSnapshot(object: DrawingObjectSnapshot): object is ImageObjectSnapshot {
   return object.type === "image";
@@ -120,13 +121,14 @@ export class StampDrawingTool extends DrawingTool {
     if (!start) return;
     const stamp = this.drawingLayer.getCurrentStamp();
     if (stamp) {
-      const stampImage = ImageObject.create({
+      const stampImage: ImageObjectSnapshotForAdd = {
+        type: "image",
         url: stamp.url,
         x: start.x - (stamp.width / 2),
         y: start.y - (stamp.height / 2),
         width: stamp.width,
         height: stamp.height
-      });
+      };
 
       this.drawingLayer.addNewDrawingObject(stampImage);
     }

--- a/src/plugins/drawing-tool/objects/line.tsx
+++ b/src/plugins/drawing-tool/objects/line.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react";
-import { Instance, SnapshotIn, types } from "mobx-state-tree";
+import { Instance, SnapshotIn, types, getSnapshot } from "mobx-state-tree";
 import React from "react";
 import { SelectionBox } from "../components/selection-box";
 import { computeStrokeDashArray, DeltaPoint, DrawingTool, IDrawingComponentProps, IDrawingLayer, 
@@ -107,7 +107,7 @@ export class LineDrawingTool extends DrawingTool {
       e2.preventDefault();
       if (line.deltaPoints.length > 0) {
         addPoint(e2);
-        this.drawingLayer.addNewDrawingObject(line);
+        this.drawingLayer.addNewDrawingObject(getSnapshot(line));
       }
       this.drawingLayer.setCurrentDrawingObject(null);
       window.removeEventListener("mousemove", handleMouseMove);

--- a/src/plugins/drawing-tool/objects/rectangle.tsx
+++ b/src/plugins/drawing-tool/objects/rectangle.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react";
-import { Instance, SnapshotIn, types } from "mobx-state-tree";
+import { Instance, SnapshotIn, types, getSnapshot } from "mobx-state-tree";
 import React from "react";
 import { computeStrokeDashArray, DrawingTool, FilledObject, IDrawingComponentProps, IDrawingLayer, 
   IToolbarButtonProps, StrokedObject, typeField } from "./drawing-object";
@@ -52,6 +52,7 @@ export const RectangleObject = types.compose("RectangleObject", StrokedObject, F
   }));
 export interface RectangleObjectType extends Instance<typeof RectangleObject> {}
 export interface RectangleObjectSnapshot extends SnapshotIn<typeof RectangleObject> {}
+export interface RectangleObjectSnapshotForAdd extends SnapshotIn<typeof RectangleObject> {type: string}
 
 export const RectangleComponent = observer(function RectangleComponent({model, handleHover} : IDrawingComponentProps) {
   if (model.type !== "rectangle") return null;
@@ -100,7 +101,7 @@ export class RectangleDrawingTool extends DrawingTool {
     const handleMouseUp = (e2: MouseEvent) => {
       e2.preventDefault();
       if ((rectangle.width > 0) && (rectangle.height > 0)) {
-        this.drawingLayer.addNewDrawingObject(rectangle);
+        this.drawingLayer.addNewDrawingObject(getSnapshot(rectangle));
       }
       this.drawingLayer.setCurrentDrawingObject(null);
       window.removeEventListener("mousemove", handleMouseMove);

--- a/src/plugins/drawing-tool/objects/vector.tsx
+++ b/src/plugins/drawing-tool/objects/vector.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react";
-import { Instance, SnapshotIn, types } from "mobx-state-tree";
+import { Instance, SnapshotIn, types, getSnapshot } from "mobx-state-tree";
 import React from "react";
 import { computeStrokeDashArray, DrawingTool, IDrawingComponentProps, IDrawingLayer, 
   IToolbarButtonProps, StrokedObject, typeField } from "./drawing-object";
@@ -83,7 +83,7 @@ export class VectorDrawingTool extends DrawingTool {
     const handleMouseUp = (e2: MouseEvent) => {
       e2.preventDefault();
       if ((vector.dx !== 0) || (vector.dy !== 0)) {
-        this.drawingLayer.addNewDrawingObject(vector);
+        this.drawingLayer.addNewDrawingObject(getSnapshot(vector));
       }
       this.drawingLayer.setCurrentDrawingObject(null);
       window.removeEventListener("mousemove", handleMouseMove);

--- a/src/plugins/shared-variables/drawing/use-variable-dialog.tsx
+++ b/src/plugins/shared-variables/drawing/use-variable-dialog.tsx
@@ -2,7 +2,7 @@ import React, { useContext, useState } from "react";
 import Select from "react-select";
 import { Variable } from "@concord-consortium/diagram-view";
 import { useCustomModal } from "../../../hooks/use-custom-modal";
-import { VariableChipObject } from "./variable-object";
+import { VariableChipObjectSnapshotForAdd } from "./variable-object";
 import { findVariable, getVariables, getOrFindSharedModel } from "./drawing-utils";
 import { DrawingContentModelContext } from "../../drawing-tool/components/drawing-content-context";
 
@@ -132,13 +132,14 @@ export const useVariableDialog = () => {
       dialogVarId = selectedVariable.id;
     }
     if (dialogVarId) {
-      const variableObject = VariableChipObject.create({
+
+      const variableChipSnapshot: VariableChipObjectSnapshotForAdd = {
         type: "variable",
         x: 250,
         y: 50,
         variableId: dialogVarId
-      });
-      drawingContent.addObject(variableObject);
+      };
+      drawingContent.addObject(variableChipSnapshot);
     }
     selectedVariableId = undefined;
   };

--- a/src/plugins/shared-variables/drawing/variable-object.tsx
+++ b/src/plugins/shared-variables/drawing/variable-object.tsx
@@ -34,6 +34,7 @@ export const VariableChipObject = DrawingObject.named("VariableObject")
   }));
 export interface VariableChipObjectType extends Instance<typeof VariableChipObject> {}
 export interface VariableChipObjectSnapshot extends SnapshotIn<typeof VariableChipObject> {}
+export interface VariableChipObjectSnapshotForAdd extends SnapshotIn<typeof VariableChipObject> {type: string}
 
 export const VariableChipComponent: React.FC<IDrawingComponentProps> = function ({model, handleHover}){
   const drawingContent = useContext(DrawingContentModelContext);


### PR DESCRIPTION
This logs all MST actions on the drawing tile to the CLUE logging system.

The key actions of add, move, delete have been updated so they log more useful information. 

In order to record the objects being added, the addObject action now requires a snapshot. There isn't a MST+TS way of checking this at compile time. 
To enforce this constraint there is a check added at runtime. This is aggressive, but it did help me find something I forgot so I think it is worth it. As long as we keep our test coverage up, we should see failing tests if the code changes and an object is passed instead of a snapshot.

TODO
- [x] tests documenting the logged events