### PR TITLE
clean up moving objects, and selecting objects

### DIFF
--- a/cypress/integration/clue/branch/student_tests/drawing_tool_spec.js
+++ b/cypress/integration/clue/branch/student_tests/drawing_tool_spec.js
@@ -4,8 +4,20 @@ import ClueCanvas from '../../../../support/elements/clue/cCanvas';
 let clueCanvas = new ClueCanvas,
   drawToolTile = new DrawToolTile;
 
+// NOTE: For some reason cypres+chrome thinks that the SVG elements are in a scrollable
+// container. Because of this when cypress does an action on a SVG element like click 
+// or trigger by default it tries to scroll this element to the top of its visible area.
+// Likewise when looking at the tests results after a run is complete the cypress app will
+// automatically scroll this area when you select an cypress `get` that is selecting a
+// SVG element.
+// The first issue is address here by adding `scrollBehavior: false` to each action that
+// works with an SVG element.
+// The second issue has no simple solution, so you need to remember it when looking at the
+// results.
+// The best solution to both problems would be to figure out the CSS necessary so
+// cypress+chrome simply cannot scroll the container.
 
-context('Table Tool Tile', function () {
+context('Draw Tool Tile', function () {
   before(function () {
     const queryParams = "?appMode=qa&fakeClass=5&fakeUser=student:5&qaGroup=5&unit=msa";
     cy.clearQAData('all');
@@ -68,7 +80,7 @@ context('Table Tool Tile', function () {
       });
       it("deletes vector drawing", () => {
         drawToolTile.getDrawToolSelect().click();
-        drawToolTile.getVectorDrawing().click();
+        drawToolTile.getVectorDrawing().click({scrollBehavior: false});
         drawToolTile.getDrawToolDelete().click();
         drawToolTile.getVectorDrawing().should("not.exist");
       });
@@ -85,7 +97,7 @@ context('Table Tool Tile', function () {
       it("verify change outline color", () => {
         drawToolTile.getRectangleDrawing().first().should("have.attr", "stroke").and("eq", "#000000");
         drawToolTile.getDrawToolSelect().click();
-        drawToolTile.getRectangleDrawing().click({force:true});
+        drawToolTile.getRectangleDrawing().click({force:true, scrollBehavior: false});
         drawToolTile.getDrawToolStrokeColor().click();
         cy.get(".toolbar-palette.stroke-color .palette-buttons").should("be.visible");
         cy.get(".toolbar-palette.stroke-color .palette-buttons .color-swatch").last().click();
@@ -93,21 +105,69 @@ context('Table Tool Tile', function () {
       });
       it("verify change fill color", () => {
         drawToolTile.getRectangleDrawing().first().should("not.have.attr", "fill-color");
-        // The rectangle is already selected
-        // drawToolTile.getDrawToolSelect().click();
-        // drawToolTile.getRectangleDrawing().click({force:true});
+        // The rectangle is already selected, so we don't need to select it again
         drawToolTile.getDrawToolFillColor().click();
         cy.get(".toolbar-palette.fill-color .palette-buttons").should("be.visible");
         cy.get(".toolbar-palette.fill-color .palette-buttons .color-swatch").last().click();
         drawToolTile.getRectangleDrawing().first().should("have.attr", "fill").and("eq", "#d100d1");
       });
-      it("verify move object", () => {
+      it("verify moving pre-selected object", () => {
         drawToolTile.getDrawToolSelect().click();
         drawToolTile.getDrawTile()
           .trigger("mousedown", 100, 100)
           .trigger("mousemove", 200, 100)
           .trigger("mouseup", 200, 100);
-        drawToolTile.getRectangleDrawing().first().should("have.attr", "x").then(parseInt).and("within", 170, 220);
+        // For some reason the move isn't very accurate in cypress so often the final location off
+        drawToolTile.getRectangleDrawing().first().should("have.attr", "x").then(parseInt).and("within", 160, 220);
+      });
+      it("verify hovering objects", () => {
+        drawToolTile.getDrawTile()
+          // Un-select the rectangle
+          .trigger("mousedown", 500, 100)
+          .trigger("mouseup", 500, 100);
+        
+        drawToolTile.getRectangleDrawing().first()
+          // Get the rectangle to be hovered. In the code we are listening to
+          // `onMouseEnter` but in Cypress triggering a "mouseenter" event
+          // doesn't work. Triggering a "mouseover" does work for some reason.
+          // Cypress'.
+          .trigger("mouseover", {scrollBehavior: false});
+
+        // The hover box is rendered as a selection-box with a different color
+        drawToolTile.getSelectionBox().should("exist").should("have.attr", "stroke").and("eq", "#bbdd00");        
+
+        // The best way I found to remove the hover was to delete the rectangle
+        drawToolTile.getRectangleDrawing().first().click({force: true, scrollBehavior: false});
+        drawToolTile.getDrawToolDelete().click();
+        drawToolTile.getSelectionBox().should("not.exist");        
+
+      });
+      it("verify moving not selected object", () => {
+        drawToolTile.getDrawToolRectangle().click();
+        drawToolTile.getDrawTile()
+          .trigger("mousedown", 250,  50)
+          .trigger("mousemove", 100, 150)
+          .trigger("mouseup",   100, 150);
+        drawToolTile.getRectangleDrawing().should("exist").and("have.length", 1);
+
+        drawToolTile.getDrawToolSelect().click();
+
+        // Get the rectangle to be hovered, see above for more info.
+        drawToolTile.getRectangleDrawing()
+          .trigger("mouseover", {scrollBehavior: false});
+        drawToolTile.getSelectionBox().should("exist").should("have.attr", "stroke").and("eq", "#bbdd00");
+
+        drawToolTile.getDrawTile()
+          .trigger("mousedown", 100, 135)
+          .trigger("mousemove", 200, 135)
+          .trigger("mouseup", 200, 135);
+
+        drawToolTile.getRectangleDrawing().first().should("have.attr", "x").then(parseInt).and("within", 150, 250);
+
+        // The best way I found to remove the hover was to delete the rectangle
+        drawToolTile.getRectangleDrawing().first().click({force: true, scrollBehavior: false});
+        drawToolTile.getDrawToolDelete().click();
+        drawToolTile.getSelectionBox().should("not.exist");        
       });
       it("verify draw squares", () => {
         drawToolTile.getDrawToolRectangle().click();
@@ -115,26 +175,25 @@ context('Table Tool Tile', function () {
           .trigger("mousedown", 450, 50, {ctrlKey: true})
           .trigger("mousemove", 450, 100,{ctrlKey: true})
           .trigger("mouseup",   450, 100);
-        drawToolTile.getRectangleDrawing().should("exist").and("have.length", 2);
-        drawToolTile.getRectangleDrawing().last().should("have.attr", "width").and("eq", "46");
-        drawToolTile.getRectangleDrawing().last().should("have.attr", "height").and("eq", "46");
+
+        drawToolTile.getRectangleDrawing().should("exist").and("have.length", 1);
+        drawToolTile.getRectangleDrawing().last().should("have.attr", "width").and("eq", "50");
+        drawToolTile.getRectangleDrawing().last().should("have.attr", "height").and("eq", "50");
 
         drawToolTile.getDrawTile()
           .trigger("mousedown", 650, 50, {ctrlKey: true})
           .trigger("mousemove", 710, 50,{ctrlKey: true})
           .trigger("mouseup",   710, 50);
-        drawToolTile.getRectangleDrawing().should("exist").and("have.length", 3);
+        drawToolTile.getRectangleDrawing().should("exist").and("have.length", 2);
         drawToolTile.getRectangleDrawing().last().should("have.attr", "width").and("eq", "60");
         drawToolTile.getRectangleDrawing().last().should("have.attr", "height").and("eq", "60");  
       });
       it("deletes rectangle drawings", () => {
         drawToolTile.getDrawTile().click();
         drawToolTile.getDrawToolSelect().click();
-        drawToolTile.getRectangleDrawing().first().click({force:true});
+        drawToolTile.getRectangleDrawing().first().click({force:true, scrollBehavior: false});
         drawToolTile.getDrawToolDelete().click();
-        drawToolTile.getRectangleDrawing().first().click({force:true});
-        drawToolTile.getDrawToolDelete().click();
-        drawToolTile.getRectangleDrawing().first().click({force:true});
+        drawToolTile.getRectangleDrawing().first().click({force:true, scrollBehavior: false});
         drawToolTile.getDrawToolDelete().click();
         drawToolTile.getRectangleDrawing().should("not.exist");
       });
@@ -161,9 +220,9 @@ context('Table Tool Tile', function () {
       it("deletes ellipse drawing", () => {
         drawToolTile.getDrawTile().click();
         drawToolTile.getDrawToolSelect().click();
-        drawToolTile.getEllipseDrawing().first().click({force:true});
+        drawToolTile.getEllipseDrawing().first().click({force:true, scrollBehavior: false});
         drawToolTile.getDrawToolDelete().click();
-        drawToolTile.getEllipseDrawing().first().click({force:true});
+        drawToolTile.getEllipseDrawing().first().click({force:true, scrollBehavior: false});
         drawToolTile.getDrawToolDelete().click();
         drawToolTile.getEllipseDrawing().should("not.exist");
       });
@@ -178,7 +237,7 @@ context('Table Tool Tile', function () {
       });
       it("deletes stamp drawing", () => {
         drawToolTile.getDrawToolSelect().click();
-        drawToolTile.getImageDrawing().click({force:true});
+        drawToolTile.getImageDrawing().click({force:true, scrollBehavior: false});
         drawToolTile.getDrawToolDelete().click();
         drawToolTile.getImageDrawing().should("not.exist");
       });

--- a/cypress/integration/clue/branch/student_tests/drawing_tool_spec.js
+++ b/cypress/integration/clue/branch/student_tests/drawing_tool_spec.js
@@ -131,7 +131,6 @@ context('Draw Tool Tile', function () {
           // Get the rectangle to be hovered. In the code we are listening to
           // `onMouseEnter` but in Cypress triggering a "mouseenter" event
           // doesn't work. Triggering a "mouseover" does work for some reason.
-          // Cypress'.
           .trigger("mouseover", {scrollBehavior: false});
 
         // The hover box is rendered as a selection-box with a different color

--- a/cypress/integration/clue/branch/student_tests/drawing_tool_spec.js
+++ b/cypress/integration/clue/branch/student_tests/drawing_tool_spec.js
@@ -171,30 +171,70 @@ context('Draw Tool Tile', function () {
       });
       it("verify draw squares", () => {
         drawToolTile.getDrawToolRectangle().click();
+
+        // starting from top edge
         drawToolTile.getDrawTile()
-          .trigger("mousedown", 450, 50, {ctrlKey: true})
-          .trigger("mousemove", 450, 100,{ctrlKey: true})
-          .trigger("mouseup",   450, 100);
+          .trigger("mousedown", 100, 50, {ctrlKey: true})
+          .trigger("mousemove", 100, 70,{ctrlKey: true})
+          .trigger("mouseup",   100, 70);
 
         drawToolTile.getRectangleDrawing().should("exist").and("have.length", 1);
-        drawToolTile.getRectangleDrawing().last().should("have.attr", "width").and("eq", "50");
-        drawToolTile.getRectangleDrawing().last().should("have.attr", "height").and("eq", "50");
+        drawToolTile.getRectangleDrawing().last().should("have.attr", "width").and("eq", "20");
+        drawToolTile.getRectangleDrawing().last().should("have.attr", "height").and("eq", "20");
 
+        // starting from the left edge
         drawToolTile.getDrawTile()
-          .trigger("mousedown", 650, 50, {ctrlKey: true})
-          .trigger("mousemove", 710, 50,{ctrlKey: true})
-          .trigger("mouseup",   710, 50);
+          .trigger("mousedown", 200, 50, {ctrlKey: true})
+          .trigger("mousemove", 230, 50,{ctrlKey: true})
+          .trigger("mouseup",   230, 50);
         drawToolTile.getRectangleDrawing().should("exist").and("have.length", 2);
+        drawToolTile.getRectangleDrawing().last().should("have.attr", "width").and("eq", "30");
+        drawToolTile.getRectangleDrawing().last().should("have.attr", "height").and("eq", "30");  
+
+        // draw a square starting at the bottom edge
+        drawToolTile.getDrawTile()
+          .trigger("mousedown", 300, 90, {ctrlKey: true})
+          .trigger("mousemove", 300, 50,{ctrlKey: true})
+          .trigger("mouseup",   300, 50);
+        drawToolTile.getRectangleDrawing().should("exist").and("have.length", 3);
+        drawToolTile.getRectangleDrawing().last().should("have.attr", "width").and("eq", "40");
+        drawToolTile.getRectangleDrawing().last().should("have.attr", "height").and("eq", "40");  
+
+        // draw a square starting at the right edge
+        drawToolTile.getDrawTile()
+          .trigger("mousedown", 450, 50, {ctrlKey: true})
+          .trigger("mousemove", 400, 50,{ctrlKey: true})
+          .trigger("mouseup",   400, 50);
+        drawToolTile.getRectangleDrawing().should("exist").and("have.length", 4);
+        drawToolTile.getRectangleDrawing().last().should("have.attr", "width").and("eq", "50");
+        drawToolTile.getRectangleDrawing().last().should("have.attr", "height").and("eq", "50");        
+
+        // Diagonal from top right to bottom left with the width 60 and height 50
+        drawToolTile.getDrawTile()
+          .trigger("mousedown", 560, 50, {ctrlKey: true})
+          .trigger("mousemove", 500, 100,{ctrlKey: true})
+          .trigger("mouseup",   500, 100);
+        drawToolTile.getRectangleDrawing().should("exist").and("have.length", 5);
         drawToolTile.getRectangleDrawing().last().should("have.attr", "width").and("eq", "60");
-        drawToolTile.getRectangleDrawing().last().should("have.attr", "height").and("eq", "60");  
+        drawToolTile.getRectangleDrawing().last().should("have.attr", "height").and("eq", "60");        
+
+        // Diagonal from bottom right to top left with the width 50 and the height 70
+        drawToolTile.getDrawTile()
+          .trigger("mousedown", 650, 120, {ctrlKey: true})
+          .trigger("mousemove", 600, 50,{ctrlKey: true})
+          .trigger("mouseup",   600, 50);
+        drawToolTile.getRectangleDrawing().should("exist").and("have.length", 6);
+        drawToolTile.getRectangleDrawing().last().should("have.attr", "width").and("eq", "70");
+        drawToolTile.getRectangleDrawing().last().should("have.attr", "height").and("eq", "70");        
+
       });
       it("deletes rectangle drawings", () => {
         drawToolTile.getDrawTile().click();
-        drawToolTile.getDrawToolSelect().click();
-        drawToolTile.getRectangleDrawing().first().click({force:true, scrollBehavior: false});
-        drawToolTile.getDrawToolDelete().click();
-        drawToolTile.getRectangleDrawing().first().click({force:true, scrollBehavior: false});
-        drawToolTile.getDrawToolDelete().click();
+        for (let i=0; i<6; i++) {
+          drawToolTile.getDrawToolSelect().click();
+          drawToolTile.getRectangleDrawing().first().click({force:true, scrollBehavior: false});
+          drawToolTile.getDrawToolDelete().click();  
+        }
         drawToolTile.getRectangleDrawing().should("not.exist");
       });
     });

--- a/cypress/integration/clue/branch/student_tests/drawing_tool_spec.js
+++ b/cypress/integration/clue/branch/student_tests/drawing_tool_spec.js
@@ -4,18 +4,19 @@ import ClueCanvas from '../../../../support/elements/clue/cCanvas';
 let clueCanvas = new ClueCanvas,
   drawToolTile = new DrawToolTile;
 
-// NOTE: For some reason cypres+chrome thinks that the SVG elements are in a scrollable
-// container. Because of this when cypress does an action on a SVG element like click 
-// or trigger by default it tries to scroll this element to the top of its visible area.
-// Likewise when looking at the tests results after a run is complete the cypress app will
-// automatically scroll this area when you select an cypress `get` that is selecting a
-// SVG element.
-// The first issue is address here by adding `scrollBehavior: false` to each action that
-// works with an SVG element.
-// The second issue has no simple solution, so you need to remember it when looking at the
-// results.
-// The best solution to both problems would be to figure out the CSS necessary so
-// cypress+chrome simply cannot scroll the container.
+// NOTE: For some reason cypress+chrome thinks that the SVG elements are in a
+// scrollable container. Because of this when cypress does an action on a SVG
+// element like click or trigger, by default it tries to scroll this element to
+// the top of the containers visible area. Likewise when looking at the test
+// results after a run is complete the cypress app will automatically scroll
+// this area when you select a cypress `get` that is selecting a SVG element.
+//
+// - The first issue is addressed here by adding `scrollBehavior: false` to each
+//   action that works with an SVG element.
+// - The second issue has no simple solution, so you need to remember it when
+//   looking at the results.
+// - The best solution to both problems would be to figure out the CSS necessary
+//   so cypress+chrome simply cannot scroll the container.
 
 context('Draw Tool Tile', function () {
   before(function () {

--- a/src/plugins/drawing-tool/components/drawing-layer.tsx
+++ b/src/plugins/drawing-tool/components/drawing-layer.tsx
@@ -237,6 +237,11 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
         // we delay until we confirm that the user is dragging the objects before adding the hover object
         // to the selection, to avoid messing with the click to select/deselect logic
         this.setSelectedObjects(objectsToInteract);
+        // Note: the hoverObject could be kind of in a weird state here. It might
+        // be both selected and hovered at the same time. However it is more
+        // simple to keep the hoverObject independent of the selection. It just
+        // represents the current object the mouse is over regardless of whether
+        // it is selected or not.
         needToAddHoverToSelection = false;
       }
     };
@@ -245,8 +250,6 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
       e2.stopPropagation();
       window.removeEventListener("mousemove", handleMouseMove);
       window.removeEventListener("mouseup", handleMouseUp);
-      // FIXME: somewhere in here it seems like the hoverObject should be cleared, perhaps even
-      // on the mouse down?
       if (moved) {
         const moves: DrawingObjectMove[] = objectsToInteract.map((object, index) => {
           const draggedObject = objectsBeingDragged[index];

--- a/src/plugins/drawing-tool/components/drawing-layer.tsx
+++ b/src/plugins/drawing-tool/components/drawing-layer.tsx
@@ -222,7 +222,7 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
       if (!current) return;
       const dx = current.x - starting.x;
       const dy = current.y - starting.y;
-      moved = moved || ((dx !== 0) && (dy !== 0));
+      moved = moved || ((dx !== 0) || (dy !== 0));
 
       if (objectsBeingDragged.length === 0) {
         objectsBeingDragged = objectsToInteract.map(object => clone(object));

--- a/src/plugins/drawing-tool/components/drawing-layer.tsx
+++ b/src/plugins/drawing-tool/components/drawing-layer.tsx
@@ -194,6 +194,8 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
   };
 
   // handles dragging of selected/hovered objects
+  // TODO: it seems this could be cleaned up. Keeping the state variable objectsBeingDragged
+  // locally in this function and modifying the local variable is not safe.
   public handleSelectedObjectMouseDown = (e: React.MouseEvent<any>, obj: DrawingObjectType) => {
     if (this.props.readOnly) return;
     let moved = false;
@@ -209,7 +211,6 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
     }
     const starting = this.getWorkspacePoint(e);
     if (!starting) return;
-    const start = objectsToInteract.map(object => ({x: object.x, y: object.y}));
 
     e.stopPropagation();
 
@@ -229,7 +230,7 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
       }
 
       objectsBeingDragged.forEach((object, index) => {
-        object.setPosition(start[index].x + dx, start[index].y + dy);
+        object.setPosition(objectsToInteract[index].x + dx, objectsToInteract[index].y + dy);
       });
 
       if (needToAddHoverToSelection) {
@@ -351,6 +352,8 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
         : false;
 
     const idsBeingDragged = this.state.objectsBeingDragged.map(object => object.id);
+    const objectsToRenderSelected = this.state.objectsBeingDragged.length > 0 ? 
+      this.state.objectsBeingDragged : this.state.selectedObjects;
 
     return (
       <div className="drawing-layer"
@@ -364,12 +367,9 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
           {this.renderObjects(object => object.type === "image" && !idsBeingDragged.includes(object.id))}
           {this.renderObjects(object => object.type !== "image" && !idsBeingDragged.includes(object.id))}
           {this.state.objectsBeingDragged.map((object) => renderDrawingObject(object))}
-          {this.state.objectsBeingDragged.length > 0 ? 
-            this.renderSelectedObjects(this.state.objectsBeingDragged, SELECTION_COLOR)
-            : this.renderSelectedObjects(this.state.selectedObjects, SELECTION_COLOR)}
-          {this.state.hoverObject
-            ? this.renderSelectedObjects([this.state.hoverObject], hoveringOverAlreadySelectedObject
-              ? SELECTION_COLOR : HOVER_COLOR)
+          {this.renderSelectedObjects(objectsToRenderSelected, SELECTION_COLOR)}
+          {(this.state.hoverObject && !hoveringOverAlreadySelectedObject)
+            ? this.renderSelectedObjects([this.state.hoverObject], HOVER_COLOR)
             : null}
           {this.state.currentDrawingObject
             ? renderDrawingObject(this.state.currentDrawingObject)

--- a/src/plugins/drawing-tool/components/drawing-layer.tsx
+++ b/src/plugins/drawing-tool/components/drawing-layer.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { reaction, IReactionDisposer } from "mobx";
-import { clone } from "mobx-state-tree";
+import { clone, isAlive } from "mobx-state-tree";
 import { observer } from "mobx-react";
 import { extractDragTileType, kDragTileContent } from "../../../components/tools/tool-tile";
 import { DrawingContentModelType, DrawingObjectMove } from "../model/drawing-content";
@@ -245,6 +245,8 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
       e2.stopPropagation();
       window.removeEventListener("mousemove", handleMouseMove);
       window.removeEventListener("mouseup", handleMouseUp);
+      // FIXME: somewhere in here it seems like the hoverObject should be cleared, perhaps even
+      // on the mouse down?
       if (moved) {
         const moves: DrawingObjectMove[] = objectsToInteract.map((object, index) => {
           const draggedObject = objectsBeingDragged[index];
@@ -368,7 +370,7 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
           {this.renderObjects(object => object.type !== "image" && !idsBeingDragged.includes(object.id))}
           {this.state.objectsBeingDragged.map((object) => renderDrawingObject(object))}
           {this.renderSelectedObjects(objectsToRenderSelected, SELECTION_COLOR)}
-          {(this.state.hoverObject && !hoveringOverAlreadySelectedObject)
+          {(this.state.hoverObject && !hoveringOverAlreadySelectedObject && isAlive(this.state.hoverObject))
             ? this.renderSelectedObjects([this.state.hoverObject], HOVER_COLOR)
             : null}
           {this.state.currentDrawingObject


### PR DESCRIPTION
This is a little better. It could be improved more, but hopefully this is good enough for now.

It also fixes 3 bugs:
- while first dragging, the highlight of the hovered object was being rendered in its old location and its dragged object location at the same time.
- during the cypress tests the hover object would be set when clicking on an object, then this object would be deleted by clicking on the delete toolbar button. Because during the tests the mouse didn't move to the toolbar, the hover object in the react state was not cleared. So now on the next render the hover object would continue to render the outline of the deleted object, and MST would complain about a deleted object being referenced. 
- if a drawing object was moved perfectly horizontally or vertically the move would not stick

The cypress tests were updated to test:
- more ways to draw squares squares
- the hover state of objects
- moving an object that hasn't been selected before. This test uses an explicit hover (mouseover) event to get the object into the same state that it would be in if you moved the mouse over it then clicked and dragged it. 

It also fixes an issue with the cypress drawing tool tests where the drawing area would get scrolled in a way that was not possible in real life. This was fixed by adding `scrollBehavior: false` to several cypress commands. A better fix would be to figure out how to lock the scrolling in app's CSS.  There is a comment in the code about this.