### PR TITLE
182589896 image title json export

### DIFF
--- a/src/models/tools/image/image-content.ts
+++ b/src/models/tools/image/image-content.ts
@@ -42,7 +42,7 @@ export const ImageContentModel = ToolContentModel
       return !!url && !isPlaceholderImage(url);
     },
     exportJson(options?: ITileExportOptions) {
-      return exportImageTileSpec(self.url, self.filename, options);
+      return exportImageTileSpec(self.metadata.title, self.url, self.filename, options);
     }
   }))
   .actions(self => ({

--- a/src/models/tools/image/image-import-export.test.ts
+++ b/src/models/tools/image/image-import-export.test.ts
@@ -32,17 +32,19 @@ describe("convertImageTile", () => {
 
 describe("Image export with default options", () => {
   it("should export placeholder image when no image has been uploaded", () => {
+    const title = "Image 1";
     const url = "assets/images/image_placeholder.png";
-        expect(exportImageTileSpec(url))
-            .toEqual(`{\n  "type": "Image",\n  "url": "${url}"\n}`);
+        expect(exportImageTileSpec(title, url))
+          .toEqual(`{\n  "type": "Image",\n  "title": "${title}",\n  "url": "${url}"\n}`);
   });
 });
 
 describe("Image export with uploaded image", () => {
   it("should export uploaded image", () => {
+    const title = "Image 1";
     const url = "https://collaborative-learning.concord.org/uploaded-image.jpg";
     const filename = "https://collaborative-learning.concord.org/uploaded-image.jpg";
-        expect(exportImageTileSpec(url, filename))
-            .toEqual(`{\n  "type": "Image",\n  "url": "${url}",\n  "filename": "${filename}"\n}`);
+        expect(exportImageTileSpec(title, url, filename))
+          .toEqual(`{\n  "type": "Image",\n  "title": "${title}",\n  "url": "${url}",\n  "filename": "${filename}"\n}`);
   });
 });

--- a/src/models/tools/image/image-import-export.ts
+++ b/src/models/tools/image/image-import-export.ts
@@ -29,22 +29,19 @@ export const transformCurriculumImageUrl = (url?: string, unitBasePath?: string,
           : url || "";
 };
 
-export const exportImageTileSpec = (url?: string, filename?: string, options?: ITileExportOptions) => {
+export const exportImageTileSpec = (title?: string, url?: string, filename?: string, options?: ITileExportOptions) => {
   const transformedUrl = url && options?.transformImageUrl?.(url, filename) || url;
+  const jsonArray = [
+    `{`,
+    `  "type": "Image",`,
+    `  "title": "${title}",`,
+  ];
   if (filename) {
-    return [
-      `{`,
-      `  "type": "Image",`,
-      `  "url": "${transformedUrl}",`,
-      `  "filename": "${transformedUrl}"`,
-      `}`
-    ].join("\n");
+    jsonArray.push(`  "url": "${transformedUrl}",`);
+    jsonArray.push(`  "filename": "${transformedUrl}"`);
   } else {
-    return [
-      `{`,
-      `  "type": "Image",`,
-      `  "url": "${transformedUrl}"`,
-      `}`
-    ].join("\n");
+    jsonArray.push(`  "url": "${transformedUrl}"`);
   }
+  jsonArray.push(`}`);
+  return jsonArray.join("\n");
 };

--- a/src/models/tools/image/image-import-export.ts
+++ b/src/models/tools/image/image-import-export.ts
@@ -35,12 +35,10 @@ export const exportImageTileSpec = (title?: string, url?: string, filename?: str
     `{`,
     `  "type": "Image",`,
     `  "title": "${title}",`,
+    `  "url": "${transformedUrl}"${filename ? "," : ""}`
   ];
   if (filename) {
-    jsonArray.push(`  "url": "${transformedUrl}",`);
     jsonArray.push(`  "filename": "${transformedUrl}"`);
-  } else {
-    jsonArray.push(`  "url": "${transformedUrl}"`);
   }
   jsonArray.push(`}`);
   return jsonArray.join("\n");

--- a/src/public/curriculum/stretching-and-shrinking/stretching-and-shrinking.json
+++ b/src/public/curriculum/stretching-and-shrinking/stretching-and-shrinking.json
@@ -845,6 +845,7 @@
                   {
                     "content": {
                     "type": "Image",
+                    "title": "Disguised Teacher",
                     "url": "curriculum/stretching-and-shrinking/images/SS_1_1_06_magazine_rack_500w.png"
                     }
                   },


### PR DESCRIPTION
I figured out how to load titles, but I'm wondering if there's a more elegant solution. It's tricky because the titles aren't actually stored in the tile's MST model, so I don't think they can simply be added during `applySnapshot()`.

My solution was to create a `loadedTitle` property in the main model, set `title` to `loadedTitle` in `preProcessSnapshot`, then `self.setTitle(self.loadedTitle)` in `doPostCreate()` after setting the metadata. I wanted to make `loadedTitle` volatile, but I couldn't figure out how to access/manipulate volatile state in `preProcessSnapshot()`.

Is there a better way of doing this?