### PR TITLE
convert all var to const or let in tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -88,8 +88,6 @@ module.exports = {
           // require() can be useful in mocking
           "@typescript-eslint/no-require-imports": "off",
           "@typescript-eslint/no-var-requires": "off",
-          // var is useful in mocking due to its hoisting semantics
-          "no-var": "off"
         }
       },
       { // eslint configs

--- a/src/components/chat/chat-panel.test.tsx
+++ b/src/components/chat/chat-panel.test.tsx
@@ -41,7 +41,7 @@ jest.mock("../../hooks/document-comment-hooks", () => ({
   })
 }));
 
-var mockUseMutation = jest.fn((callback: (...args: any[]) => void) => {
+const mockUseMutation = jest.fn((callback: (...args: any[]) => void) => {
   return { mutate: (...args: any[]) => callback(...args) };
 });
 jest.mock("react-query", () => ({

--- a/src/components/document/canvas.test.tsx
+++ b/src/components/document/canvas.test.tsx
@@ -13,7 +13,7 @@ import { registerTools } from "../../register-tools";
 import { ModalProvider } from "react-modal-hook";
 registerTools(["Text"]);
 
-var mockGetQueryState = jest.fn();
+const mockGetQueryState = jest.fn();
 jest.mock("react-query", () => ({
   useQueryClient: () => ({
     getQueryState: mockGetQueryState

--- a/src/components/four-up.test.tsx
+++ b/src/components/four-up.test.tsx
@@ -11,7 +11,7 @@ import { UserModel } from "../models/stores/user";
 
 configure({testIdAttribute: "data-test"});
 
-var mockGetQueryState = jest.fn();
+const mockGetQueryState = jest.fn();
 jest.mock("react-query", () => ({
   useQueryClient: () => ({
     getQueryState: mockGetQueryState

--- a/src/hooks/document-comment-hooks.test.ts
+++ b/src/hooks/document-comment-hooks.test.ts
@@ -4,9 +4,9 @@ import {
   DocumentQueryType, useDocumentComments, usePostDocumentComment, useUnreadDocumentComments
 } from "./document-comment-hooks";
 
-var mockValidateCommentableDocument_v1 = jest.fn();
-var mockPostDocumentComment_v1 = jest.fn();
-var mockHttpsCallable = jest.fn((fn: string) => {
+const mockValidateCommentableDocument_v1 = jest.fn();
+const mockPostDocumentComment_v1 = jest.fn();
+const mockHttpsCallable = jest.fn((fn: string) => {
   switch(fn) {
     case "validateCommentableDocument_v1":
       return mockValidateCommentableDocument_v1;
@@ -28,11 +28,11 @@ jest.mock("firebase/app", () => ({
 }));
 
 // mock QueryClient methods
-var mockGetQueryData = jest.fn();
-var mockSetQueryData = jest.fn();
+const mockGetQueryData = jest.fn();
+const mockSetQueryData = jest.fn();
 // tests may override implementation to simulate mutation succeeding (default) or failing
-var mockMutateSuccessOrError = jest.fn();
-var mockUseMutation = jest.fn((mutateFn: (params: any) => void, options: any) => {
+const mockMutateSuccessOrError = jest.fn();
+const mockUseMutation = jest.fn((mutateFn: (params: any) => void, options: any) => {
   return {
     mutate: async (params: any) => {
       mutateFn(params);
@@ -41,8 +41,8 @@ var mockUseMutation = jest.fn((mutateFn: (params: any) => void, options: any) =>
     }
   };
 });
-var mockCurriculumDocument = { unit: "unit", problem: "1.1", section: "intro", path: "unit/1/1/intro" };
-var mockUseQuery = jest.fn((key: string, fn: () => Promise<DocumentQueryType>, options: any) => ({
+const mockCurriculumDocument = { unit: "unit", problem: "1.1", section: "intro", path: "unit/1/1/intro" };
+const mockUseQuery = jest.fn((key: string, fn: () => Promise<DocumentQueryType>, options: any) => ({
   isLoading: false,
   isError: false,
   isSuccess: true,
@@ -57,7 +57,7 @@ jest.mock("react-query", () => ({
   })
 }));
 
-var mockUseDocumentOrCurriculumMetadata = jest.fn((docKeyOrSectionPath: string) => {
+const mockUseDocumentOrCurriculumMetadata = jest.fn((docKeyOrSectionPath: string) => {
   return mockCurriculumDocument;
 });
 jest.mock("./use-stores", () => ({
@@ -70,7 +70,7 @@ jest.mock("./use-user-context", () => ({
   useUserContext: () => ({ appMode: "test", classHash: "class-hash" })
 }));
 
-var mockUseCollectionOrderedRealTimeQuery = jest.fn((path: string, options?: any) => {
+const mockUseCollectionOrderedRealTimeQuery = jest.fn((path: string, options?: any) => {
   if (options?.converter) {
     let jsComment: CommentDocument = {
       uid: "1", name: "T", network: "foo", content: "bar"

--- a/src/hooks/firestore-hooks.test.ts
+++ b/src/hooks/firestore-hooks.test.ts
@@ -2,18 +2,18 @@ import firebase from "firebase/app";
 import { renderHook } from "@testing-library/react-hooks";
 import { useCollectionOrderedRealTimeQuery, useDeleteDocument, useFirestoreTeacher } from "./firestore-hooks";
 
-var mockData = [
+const mockData = [
   { id: 1, value: "foo" },
   { id: 2, value: "bar" }
 ];
-var mockSetQueryData = jest.fn();
-var mockUseQuery = jest.fn((...args) => ({
+const mockSetQueryData = jest.fn();
+const mockUseQuery = jest.fn((...args) => ({
   isLoading: false,
   isError: false,
   data: mockData,
   error: undefined
 }));
-var mockUseMutation = jest.fn((callback: (...args: any[]) => void) => {
+const mockUseMutation = jest.fn((callback: (...args: any[]) => void) => {
   return { mutate: (...args: any[]) => callback(...args) };
 });
 jest.mock("react-query", () => ({
@@ -24,8 +24,8 @@ jest.mock("react-query", () => ({
   useMutation: (callback: () => void) => mockUseMutation(callback),
 }));
 
-var mockRootCounter = 0;
-var mockOnSnapshot = (callback: (snap: any) => void) => {
+let mockRootCounter = 0;
+const mockOnSnapshot = (callback: (snap: any) => void) => {
   callback(({
     docs: [
       { id: 1, data: () => ({ value: "foo" }) },
@@ -33,9 +33,9 @@ var mockOnSnapshot = (callback: (snap: any) => void) => {
     ]
   }));
 };
-var mockDelete = jest.fn();
-var mockGet = jest.fn();
-var mockDoc = jest.fn((path: string) => ({
+const mockDelete = jest.fn();
+const mockGet = jest.fn();
+const mockDoc = jest.fn((path: string) => ({
   delete: mockDelete,
   get: mockGet
 }));

--- a/src/hooks/network-resources.test.ts
+++ b/src/hooks/network-resources.test.ts
@@ -2,10 +2,10 @@ import { renderHook } from "@testing-library/react-hooks";
 import { INetworkResourceClassResponse } from "../../functions/src/shared";
 import { useNetworkResources } from "./network-resources";
 
-var mockGetNetworkResources = jest.fn(() => Promise.resolve({
+const mockGetNetworkResources = jest.fn(() => Promise.resolve({
   data: { version: "1.0", response: [] as any }
 }));
-var mockHttpsCallable = jest.fn((fn: string) => {
+const mockHttpsCallable = jest.fn((fn: string) => {
   switch(fn) {
     case "getNetworkResources_v1":
       return mockGetNetworkResources;
@@ -17,8 +17,8 @@ jest.mock("firebase/app", () => ({
   })
 }));
 
-var mockData: INetworkResourceClassResponse[] = [];
-var mockUseQuery = jest.fn(async (key: string, fn: () => Promise<INetworkResourceClassResponse[]>) => {
+const mockData: INetworkResourceClassResponse[] = [];
+const mockUseQuery = jest.fn(async (key: string, fn: () => Promise<INetworkResourceClassResponse[]>) => {
   await fn();
   return {
     isLoading: false,
@@ -33,7 +33,7 @@ jest.mock("react-query", () => ({
   }
 }));
 
-var mockAddDocument = jest.fn();
+const mockAddDocument = jest.fn();
 jest.mock("./use-stores", () => ({
   useNetworkDocuments: () => ({ add: mockAddDocument }),
   useProblemPath: () => "abc/1/2"

--- a/src/hooks/use-document-sync-to-firebase.test.ts
+++ b/src/hooks/use-document-sync-to-firebase.test.ts
@@ -13,7 +13,7 @@ const libDebug = require("../lib/debug");
 
 import "../models/tools/text/text-registration";
 
-var mockUseMutation = jest.fn((callback: (vars: any) => Promise<any>, options?: UseMutationOptions) => {
+const mockUseMutation = jest.fn((callback: (vars: any) => Promise<any>, options?: UseMutationOptions) => {
   return {
     mutate: (vars: any) => {
       callback(vars)
@@ -42,8 +42,8 @@ jest.mock("react-query", () => ({
   useMutation: (callback: (vars: any) => Promise<any>, options?: any) => mockUseMutation(callback, options)
 }));
 
-var mockUpdate = jest.fn();
-var mockRef = jest.fn();
+const mockUpdate = jest.fn();
+const mockRef = jest.fn();
 
 const specUser = (overrides?: Partial<SnapshotIn<typeof UserModel>>) => {
   return UserModel.create({ id: "1", ...overrides });

--- a/src/hooks/use-stores.test.ts
+++ b/src/hooks/use-stores.test.ts
@@ -17,7 +17,7 @@ import {
 
 jest.mock("@concord-consortium/slate-editor", () => ({}));
 
-var mockUseContext = jest.fn();
+const mockUseContext = jest.fn();
 jest.mock("react", () => ({
   ...jest.requireActual("react"),
   useContext: () => mockUseContext(),

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -16,10 +16,10 @@ import * as UrlParams from "../utilities/url-params";
 import { registerTools } from "../register-tools";
 registerTools(["Text"]);
 
-var mockDatabase = jest.fn();
-var mockFirestore = jest.fn();
-var mockFunctions = jest.fn();
-var mockAuthStateUnsubscribe = jest.fn();
+const mockDatabase = jest.fn();
+const mockFirestore = jest.fn();
+const mockFunctions = jest.fn();
+const mockAuthStateUnsubscribe = jest.fn();
 
 jest.mock("firebase/app", () => {
   return {

--- a/src/lib/firestore.test.ts
+++ b/src/lib/firestore.test.ts
@@ -1,21 +1,21 @@
 import { DB } from "./db";
 import { Firestore } from "./firestore";
 
-var mockStores = {
+const mockStores = {
   appMode: "authed",
   demo: { name: "demo" },
   user: { portal: "test-portal" }
 };
-var mockDB = {
+const mockDB = {
   stores: mockStores
 } as DB;
-var mockDocGet = jest.fn();
-var mockDocSet = jest.fn();
-var mockDoc = jest.fn((path: string) => ({
+const mockDocGet = jest.fn();
+const mockDocSet = jest.fn();
+const mockDoc = jest.fn((path: string) => ({
       get: mockDocGet,
       set: (obj: any) => mockDocSet(obj)
     }));
-var mockCollection = jest.fn(() => ({ doc: mockDoc }));
+const mockCollection = jest.fn(() => ({ doc: mockDoc }));
 jest.mock("firebase/app", () => ({
   firestore: () => ({
     collection: mockCollection,

--- a/src/lib/teacher-network.test.ts
+++ b/src/lib/teacher-network.test.ts
@@ -10,23 +10,23 @@ import {
 } from "./teacher-network";
 import { DB } from "./db";
 
-var mockStores = {
+const mockStores = {
   appMode: "authed",
   demo: { name: "demo" },
   user: { portal: "test-portal" }
 };
-var mockDB = {
+const mockDB = {
   stores: mockStores
 } as DB;
-var mockDocGet = jest.fn();
-var mockDocSet = jest.fn();
-var mockDoc = jest.fn((path: string) => ({
+const mockDocGet = jest.fn();
+const mockDocSet = jest.fn();
+const mockDoc = jest.fn((path: string) => ({
       get: mockDocGet,
       set: (obj: any) => mockDocSet(obj)
     }));
-var mockCollectionGet = jest.fn();
-var mockCollectionWhere = jest.fn();
-var mockCollection = jest.fn((path: string) => {
+const mockCollectionGet = jest.fn();
+const mockCollectionWhere = jest.fn();
+const mockCollection = jest.fn((path: string) => {
   const mockObject = { doc: mockDoc, get: mockCollectionGet, where: mockCollectionWhere };
   mockObject.where.mockImplementation(() => mockObject);
   return mockObject;

--- a/src/models/document/document.test.ts
+++ b/src/models/document/document.test.ts
@@ -8,13 +8,13 @@ import { TextContentModelType } from "../tools/text/text-content";
 import { registerTools } from "../../register-tools";
 registerTools(["Geometry", "Text"]);
 
-var mockUserContext = { appMode: "authed", classHash: "class-1" };
-var mockQueryData = { content: {}, metadata: { createdAt: 10 } };
+const mockUserContext = { appMode: "authed", classHash: "class-1" };
+const mockQueryData = { content: {}, metadata: { createdAt: 10 } };
 
-var mockGetNetworkDocument = jest.fn(() => {
+const mockGetNetworkDocument = jest.fn(() => {
   return Promise.resolve({ data: { version: "1.0", ...mockQueryData } });
 });
-var mockHttpsCallable = jest.fn((fn: string) => {
+const mockHttpsCallable = jest.fn((fn: string) => {
   switch(fn) {
     case "getNetworkDocument_v1":
       return mockGetNetworkDocument;
@@ -26,12 +26,12 @@ jest.mock("firebase/app", () => ({
   })
 }));
 
-var mockFetchQuery = jest.fn((queryKey: any, queryFn: () => Promise<any>) => {
+const mockFetchQuery = jest.fn((queryKey: any, queryFn: () => Promise<any>) => {
   queryFn();
   return Promise.resolve({ isLoading: false, isError: false, data: mockQueryData });
 });
-var mockInvalidateQueries = jest.fn();
-var mockQueryClient = {
+const mockInvalidateQueries = jest.fn();
+const mockQueryClient = {
   fetchQuery: mockFetchQuery,
   invalidateQueries: mockInvalidateQueries
 } as any;


### PR DESCRIPTION
var was being used to help with hoisting above jest.mock.
but everything seems to work fine now without it.