### PR TITLE
Scale the program up when the containing element resizes.

### DIFF
--- a/src/plugins/dataflow-tool/components/dataflow-program.tsx
+++ b/src/plugins/dataflow-tool/components/dataflow-program.tsx
@@ -597,15 +597,38 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
 
   private keepNodesInView = () => {
     const margin = 5;
-    const { k } = this.programEditor.view.area.transform;
+    let { k } = this.programEditor.view.area.transform;
+    const clientWidth = this.programEditor.view.container.clientWidth;
+    const clientHeight = this.programEditor.view.container.clientHeight;
+    const currentTransform = this.programEditor.view.area.transform;
+
+    // If we're at zero scale but have any window to fill,
+    // give a little scale to we can tell the program's proportions with a valid rect
+    if (k === 0 && clientWidth > 0 && clientHeight > 0) {
+      this.programEditor.view.area.transform = {k: .01, x: currentTransform.x, y: currentTransform.y};
+      this.programEditor.view.area.update();
+      k = this.programEditor.view.area.transform.k;
+    }
+
     const rect = this.getBoundingRectOfNodes();
     if (rect?.isValid) {
-      const newZoom = Math.min(k * this.programEditor.view.container.clientWidth / ( rect.right + margin),
-                               k * this.programEditor.view.container.clientHeight / ( rect.bottom + margin));
+      // Handle program too large for client
+      const newZoom = Math.min(k * clientWidth / ( rect.right + margin),
+                               k * clientHeight / ( rect.bottom + margin));
       if (newZoom < k && rect.right > 0 && newZoom > 0) {
-        const currentTransform = this.programEditor.view.area.transform;
         this.programEditor.view.area.transform = {k: newZoom, x: currentTransform.x, y: currentTransform.y};
         this.programEditor.view.area.update();
+        return;
+      }
+
+      // Handle program too small for client
+      const targetPercentage = .9;
+      if (rect.width < clientWidth * targetPercentage
+        || rect.height < clientHeight * targetPercentage) {
+          const newerZoom = Math.min(k * clientWidth * targetPercentage / rect.width,
+            k * clientHeight * targetPercentage / rect.height);
+          this.programEditor.view.area.transform = {k: newerZoom, x: currentTransform.x, y: currentTransform.y};
+          this.programEditor.view.area.update();
       }
     }
   };


### PR DESCRIPTION
Previously, the program would scale down when its containing element resized, but it would never scale up. This would cause the scale to go down to 0 when the containing element was completely flattened.

This fix makes the program scale up to 90% of its containing element's size when the element changes size.