### PR TITLE
181363573 publish delete multiple versions

### DIFF
--- a/cypress/integration/clue/smoke/single_student_canvas_test.js
+++ b/cypress/integration/clue/smoke/single_student_canvas_test.js
@@ -143,11 +143,17 @@ context('single student functional test',()=>{
         });
         // TODO: Class Work changed with new feature changes.
         describe('publish canvas', ()=>{
+            it('verify published canvas thumbnail', () => {
+              cy.openTopTab('class-work');
+              cy.openSection('class-work','workspaces');
+              cy.getCanvasItemTitle('workspaces').should('have.length',1);
+            });
             it('verify publish canvas thumbnail appears in Class Work Published List',()=>{
                 canvas.publishCanvas("investigation");
                 cy.openTopTab('class-work');
                 cy.openSection('class-work','workspaces');
-                cy.getCanvasItemTitle('workspaces').should('have.length',1);
+                cy.getCanvasItemTitle('workspaces').should('have.length',2);
+                cy.getCanvasItemTitle('workspaces').first().should('contain', 'v2');
             });
             it('verify student name appears under thumbnail',()=>{
                 cy.get('[data-test=user-name]').then(($el)=>{
@@ -160,7 +166,7 @@ context('single student functional test',()=>{
               cy.openSection("class-work", "workspaces");
                 cy.get('[data-test=user-name]').then(($el)=>{
                     const user = $el.text();
-                    cy.getCanvasItemTitle('workspaces', user).click();
+                    cy.getCanvasItemTitle('workspaces', user).first().click();
                 });
                 cy.get(".document-tabs.class-work .documents-panel .canvas-area").find('.text-tool').should('exist').and('contain','This is a smoke test');
                 cy.get(".document-tabs.class-work .documents-panel .canvas-area").find('.geometry-content').should('exist');

--- a/docs/document-types.md
+++ b/docs/document-types.md
@@ -29,6 +29,8 @@ export interface DBBaseDocumentMetadata {
   };
   createdAt: number;
   type: DBDocumentType;
+  // previously in DBOtherDocument
+  properties?: IDocumentProperties;
 }
 
 export interface DBBaseProblemDocumentMetadata extends DBBaseDocumentMetadata {
@@ -88,6 +90,7 @@ export interface DBOtherDocument {
     documentKey: string;
   };
   title: string;
+  // legacy properties; in DBBaseDocumentMetadata since ~2.2
   properties?: IDocumentProperties;
 }
 ```

--- a/functions/src/shared.ts
+++ b/functions/src/shared.ts
@@ -167,6 +167,7 @@ export interface IPublishSupportParams extends IFirebaseFunctionBaseParams {
   originDocType: string;
   resource_link_id: string;
   resource_url: string;
+  pubVersion?: number;
 }
 export type IPublishSupportUnionParams = IPublishSupportParams | IFirebaseFunctionWarmUpParams;
 

--- a/src/clue/app-config.json
+++ b/src/clue/app-config.json
@@ -159,7 +159,8 @@
               "type": "published-learning-logs",
               "dataTestHeader": "class-work-section-learning-log",
               "dataTestItem": "class-work-list-items",
-              "documentTypes": ["learningLogPublication"]
+              "documentTypes": ["learningLogPublication"],
+              "properties": ["!isDeleted"]
             },
             {
               "className": "section problem starred",
@@ -167,7 +168,7 @@
               "type": "starred-problem-documents",
               "dataTestHeader": "class-work-section-starred",
               "documentTypes": ["publication"],
-              "properties": ["starred"],
+              "properties": ["starred", "!isDeleted"],
               "showStars": ["teacher"]
             }
           ]

--- a/src/clue/app-config.json
+++ b/src/clue/app-config.json
@@ -124,7 +124,7 @@
               "dataTestItem": "class-work-list-items",
               "documentTypes": ["publication"],
               "showStars": ["teacher"],
-              "properties": ["!isTeacherDocument"]
+              "properties": ["!isTeacherDocument", "!isDeleted"]
             },
             {
               "className": "section personal published",
@@ -133,7 +133,7 @@
               "dataTestHeader": "class-work-section-personal",
               "dataTestItem": "class-work-list-items",
               "documentTypes": ["personalPublication"],
-              "properties": ["!isTeacherDocument"]
+              "properties": ["!isTeacherDocument", "!isDeleted"]
             },
             {
               "className": "section teacher published-documents",

--- a/src/components/navigation/section-document-or-browser.tsx
+++ b/src/components/navigation/section-document-or-browser.tsx
@@ -162,9 +162,6 @@ export const SectionDocumentOrBrowser: React.FC<IProps> = ({ tabSpec, reset, sel
             const _handleDocumentStarClick = section.showStarsForUser(user)
               ? handleDocumentStarClick
               : undefined;
-            const _handleDocumentDeleteClick = section.showDeleteForUser(user)
-              ? handleDocumentDeleteClick
-              : undefined;
             return (
               <DocumentCollectionByType
                 key={`${section.type}_${index}`}
@@ -179,7 +176,7 @@ export const SectionDocumentOrBrowser: React.FC<IProps> = ({ tabSpec, reset, sel
                 onSelectDocument={onSelectDocument || handleSelectDocument}
                 onDocumentDragStart={handleDocumentDragStart}
                 onDocumentStarClick={_handleDocumentStarClick}
-                onDocumentDeleteClick={_handleDocumentDeleteClick}
+                onDocumentDeleteClick={handleDocumentDeleteClick}
               />
             );
           })

--- a/src/components/thumbnail/decorated-document-thumbnail-item.tsx
+++ b/src/components/thumbnail/decorated-document-thumbnail-item.tsx
@@ -36,7 +36,7 @@ function useDocumentCaption(document: DocumentModelType) {
     const pubVersion = document.pubVersion;
     return pubVersion ? `${caption} v${pubVersion}` : `${caption}`;
   }
-  const userName = classStore.getUserById(uid)?.displayName || (teacher?.name) ||
+  const userName = classStore.getUserById(uid)?.displayName || teacher?.name ||
                     (document.isRemote ? teacher?.name : "") || "Unknown User";
   const namePrefix = document.isRemote || isPublishedType(type) ? `${userName}: ` : "";
   const dateSuffix = document.isRemote && document.createdAt

--- a/src/components/thumbnail/decorated-document-thumbnail-item.tsx
+++ b/src/components/thumbnail/decorated-document-thumbnail-item.tsx
@@ -31,7 +31,11 @@ function useDocumentCaption(document: DocumentModelType) {
   const user = useUserStore();
   const { type, uid } = document;
   const teacher = useFirestoreTeacher(uid, user.network || "");
-  if (type === SupportPublication) return document.getProperty("caption") || "Support";
+  if (type === SupportPublication) {
+    const caption = document.getProperty("caption") || "Support";
+    const pubVersion = document.pubVersion;
+    return pubVersion ? `${caption} v${pubVersion}` : `${caption}`;
+  }
   const userName = classStore.getUserById(uid)?.displayName || (teacher?.name) ||
                     (document.isRemote ? teacher?.name : "") || "Unknown User";
   const namePrefix = document.isRemote || isPublishedType(type) ? `${userName}: ` : "";

--- a/src/components/thumbnail/decorated-document-thumbnail-item.tsx
+++ b/src/components/thumbnail/decorated-document-thumbnail-item.tsx
@@ -77,7 +77,7 @@ export const DecoratedDocumentThumbnailItem = observer(({
     const _handleDocumentStarClick = section.showStarsForUser(user) && !sectionDocument.isRemote
                                       ? handleDocumentStarClick
                                       : undefined;
-    const _handleDocumentDeleteClick = section.showDeleteForUser(user)
+    const _handleDocumentDeleteClick = section.showDeleteForUser(user, sectionDocument)
                                         ? handleDocumentDeleteClick
                                         : undefined;
 

--- a/src/components/thumbnail/decorated-document-thumbnail-item.tsx
+++ b/src/components/thumbnail/decorated-document-thumbnail-item.tsx
@@ -32,11 +32,14 @@ function useDocumentCaption(document: DocumentModelType) {
   const { type, uid } = document;
   const teacher = useFirestoreTeacher(uid, user.network || "");
   if (type === SupportPublication) return document.getProperty("caption") || "Support";
-  const userName = classStore.getUserById(uid)?.displayName ||
+  const userName = classStore.getUserById(uid)?.displayName || (teacher?.name) ||
                     (document.isRemote ? teacher?.name : "") || "Unknown User";
   const namePrefix = document.isRemote || isPublishedType(type) ? `${userName}: ` : "";
   const dateSuffix = document.isRemote && document.createdAt
-                      ? ` (${new Date(document.createdAt).toLocaleDateString()})` : "";
+                      ? ` (${new Date(document.createdAt).toLocaleDateString()})`
+                      : isPublishedType(type)
+                          ? ` v${document.pubVersion}`
+                          : "";
   const title = getDocumentDisplayTitle(document, appConfig, problem);
   return `${namePrefix}${title}${dateSuffix}`;
 }

--- a/src/components/thumbnail/decorated-document-thumbnail-item.tsx
+++ b/src/components/thumbnail/decorated-document-thumbnail-item.tsx
@@ -1,12 +1,13 @@
 import { observer } from "mobx-react";
 import React from "react";
 import { ThumbnailDocumentItem } from "./thumbnail-document-item";
+import { useDocumentSyncToFirebase } from "../../hooks/use-document-sync-to-firebase";
 import { useFirestoreTeacher } from "../../hooks/firestore-hooks";
 import { useLastSupportViewTimestamp } from "../../hooks/use-last-support-view-timestamp";
 import { DocumentModelType } from "../../models/document/document";
 import { isPublishedType, SupportPublication } from "../../models/document/document-types";
 import { getDocumentDisplayTitle } from "../../models/document/document-utils";
-import { useAppConfig, useClassStore, useProblemStore, useUserStore } from "../../hooks/use-stores";
+import { useAppConfig, useClassStore, useDBStore, useProblemStore, useUserStore } from "../../hooks/use-stores";
 import { NavTabSectionModelType } from "../../models/view/nav-tabs";
 
 import "./document-type-collection.sass";
@@ -46,8 +47,12 @@ export const DecoratedDocumentThumbnailItem = observer(({
   onSelectDocument, onDocumentDragStart, onDocumentStarClick, onDocumentDeleteClick
 }: IProps) => {
     const user = useUserStore();
+    const dbStore = useDBStore();
     const tabName = tab.toLowerCase().replace(' ', '-');
     const caption = useDocumentCaption(sectionDocument);
+
+    // sync delete a publication to firebase
+    useDocumentSyncToFirebase(user, dbStore.firebase, sectionDocument, true);
 
     // sync user's last support view time stamp to firebase
     useLastSupportViewTimestamp(section.type === "teacher-supports");

--- a/src/components/thumbnail/documents-type-collection.tsx
+++ b/src/components/thumbnail/documents-type-collection.tsx
@@ -50,7 +50,6 @@ function getSectionDocs(section: NavTabSectionModelType, documents: DocumentsMod
     }
     else if (isPublishedType(type)) {
       const publishedDocs: { [source: string]: DocumentModelType[] } = {};
-      // only show the most recent publication of each document
       documents
         .byType(type as any)
         .forEach(doc => {
@@ -60,17 +59,14 @@ function getSectionDocs(section: NavTabSectionModelType, documents: DocumentsMod
           // shouldn't be published documents from other problems.
           const source = doc.originDoc || doc.uid;
           if (source) {
-            if (publishedDocs.source) {
-              publishedDocs.source.push(doc);
-            } else {
+            if (!publishedDocs.source) {
               publishedDocs.source = [];
-              publishedDocs.source.push(doc);
             }
+            publishedDocs.source.push(doc);
           }
         });
       for (const sourceId in publishedDocs) {
-        const docsFromSource = publishedDocs[sourceId];
-        docsFromSource.forEach(d => sectDocs.push(d));
+        sectDocs.push(...publishedDocs[sourceId]);
       }
     }
   });

--- a/src/components/thumbnail/documents-type-collection.tsx
+++ b/src/components/thumbnail/documents-type-collection.tsx
@@ -49,7 +49,29 @@ function getSectionDocs(section: NavTabSectionModelType, documents: DocumentsMod
       sectDocs.push(...documents.byTypeForUser(type as any, user.id));
     }
     else if (isPublishedType(type)) {
-        sectDocs.push(...documents.byType(type as any));
+      const publishedDocs: { [source: string]: DocumentModelType[] } = {};
+      // only show the most recent publication of each document
+      documents
+        .byType(type as any)
+        .forEach(doc => {
+          // personal documents and learning logs have originDocs.
+          // problem documents only have the uids of their creator,
+          // but as long as we're scoped to a single problem, there
+          // shouldn't be published documents from other problems.
+          const source = doc.originDoc || doc.uid;
+          if (source) {
+            if (publishedDocs.source) {
+              publishedDocs.source.push(doc);
+            } else {
+              publishedDocs.source = [];
+              publishedDocs.source.push(doc);
+            }
+          }
+        });
+      for (const sourceId in publishedDocs) {
+        const docsFromSource = publishedDocs[sourceId];
+        docsFromSource.forEach(d => sectDocs.push(d));
+      }
     }
   });
   // Reverse the order to approximate a most-recently-used ordering.

--- a/src/components/thumbnail/documents-type-collection.tsx
+++ b/src/components/thumbnail/documents-type-collection.tsx
@@ -49,24 +49,7 @@ function getSectionDocs(section: NavTabSectionModelType, documents: DocumentsMod
       sectDocs.push(...documents.byTypeForUser(type as any, user.id));
     }
     else if (isPublishedType(type)) {
-      const publishedDocs: { [source: string]: DocumentModelType } = {};
-      // only show the most recent publication of each document
-      documents
-        .byType(type as any)
-        .forEach(doc => {
-          // personal documents and learning logs have originDocs.
-          // problem documents only have the uids of their creator,
-          // but as long as we're scoped to a single problem, there
-          // shouldn't be published documents from other problems.
-          const source = doc.originDoc || doc.uid;
-          if (source) {
-            const entry = publishedDocs[source];
-            if (!entry || (entry.createdAt < doc.createdAt)) {
-              publishedDocs[source] = doc;
-            }
-          }
-        });
-        sectDocs.push(...Object.values(publishedDocs));
+        sectDocs.push(...documents.byType(type as any));
     }
   });
   // Reverse the order to approximate a most-recently-used ordering.

--- a/src/components/thumbnail/thumbnail-document-item.tsx
+++ b/src/components/thumbnail/thumbnail-document-item.tsx
@@ -5,6 +5,7 @@ import { DocumentModelType } from "../../models/document/document";
 import { DocumentCaption } from "./document-caption";
 import { ThumbnailPlaceHolderIcon } from "./thumbnail-placeholder-icon";
 import { ThumbnailPrivateIcon } from "./thumbnail-private-icon";
+import { useStores } from "../../hooks/use-stores";
 
 interface IProps {
   dataTestName: string;
@@ -25,6 +26,8 @@ export const ThumbnailDocumentItem = observer((props: IProps) => {
           onDocumentClick, onDocumentDragStart, onDocumentStarClick,
           onDocumentDeleteClick } = props;
   const selectedClass = isSelected ? "selected" : "";
+  const stores = useStores();
+  const appMode = stores.appMode;
 
   const handleDocumentClick = (e: React.MouseEvent<HTMLDivElement>) => {
     onDocumentClick?.(document);
@@ -44,10 +47,12 @@ export const ThumbnailDocumentItem = observer((props: IProps) => {
   // TODO: add proper state of isPrivate based on document properties
   const isPrivate = false; // document.visibility === "private" && document.isRemote;
   const privateClass = isPrivate ? "private" : "";
+  const documentTitle = appMode !== "authed" && appMode !== "demo"
+                          ? `Firebase UID: ${document.key}` : undefined;
 
   return (
     <div className={`list-item ${selectedClass} ${privateClass}`} data-test={dataTestName} key={document.key}
-      onClick={isPrivate ? undefined : handleDocumentClick}>
+      title={documentTitle} onClick={isPrivate ? undefined : handleDocumentClick}>
       <div className="scaled-list-item-container" onDragStart={handleDocumentDragStart}
         draggable={!!onDocumentDragStart && !isPrivate}>
         { isPrivate

--- a/src/components/thumbnail/thumbnail-document-item.tsx
+++ b/src/components/thumbnail/thumbnail-document-item.tsx
@@ -5,7 +5,7 @@ import { DocumentModelType } from "../../models/document/document";
 import { DocumentCaption } from "./document-caption";
 import { ThumbnailPlaceHolderIcon } from "./thumbnail-placeholder-icon";
 import { ThumbnailPrivateIcon } from "./thumbnail-private-icon";
-import { useStores } from "../../hooks/use-stores";
+import { useAppMode } from "../../hooks/use-stores";
 
 interface IProps {
   dataTestName: string;
@@ -26,8 +26,7 @@ export const ThumbnailDocumentItem = observer((props: IProps) => {
           onDocumentClick, onDocumentDragStart, onDocumentStarClick,
           onDocumentDeleteClick } = props;
   const selectedClass = isSelected ? "selected" : "";
-  const stores = useStores();
-  const appMode = stores.appMode;
+  const appMode = useAppMode();
 
   const handleDocumentClick = (e: React.MouseEvent<HTMLDivElement>) => {
     onDocumentClick?.(document);

--- a/src/hooks/use-document-sync-to-firebase.test.ts
+++ b/src/hooks/use-document-sync-to-firebase.test.ts
@@ -395,7 +395,7 @@ describe("useDocumentSyncToFirebase hook", () => {
     await jestSpyConsole("log", async spy => {
       document.setProperty("foo", "bar");
       await waitFor(() => expect(mockRef).toHaveBeenCalledTimes(1));
-      expect(mockRef).toHaveBeenCalledWith(`${user.id}/personal/${document.key}`);
+      expect(mockRef).toHaveBeenCalledWith(`${user.id}/metadata/${document.key}/properties`);
       await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
       await waitFor(() => expect(spy).toBeCalledTimes(1));
     });
@@ -526,13 +526,13 @@ describe("useDocumentSyncToFirebase hook", () => {
       document.setProperty("foo", "bar");
       // assert initial (failed) attempt
       await waitFor(() => expect(mockRef).toHaveBeenCalledTimes(1));
-      expect(mockRef).toHaveBeenCalledWith(`${user.id}/personal/${document.key}`);
+      expect(mockRef).toHaveBeenCalledWith(`${user.id}/metadata/${document.key}/properties`);
       await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
       await waitFor(() => expect(spy).toBeCalledTimes(1));
       // trigger retry (successful) attempt
       jest.runAllTimers();
       await waitFor(() => expect(mockRef).toHaveBeenCalledTimes(2));
-      expect(mockRef).toHaveBeenCalledWith(`${user.id}/personal/${document.key}`);
+      expect(mockRef).toHaveBeenCalledWith(`${user.id}/metadata/${document.key}/properties`);
       await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(2));
     });
 

--- a/src/hooks/use-document-sync-to-firebase.test.ts
+++ b/src/hooks/use-document-sync-to-firebase.test.ts
@@ -190,8 +190,8 @@ describe("useDocumentSyncToFirebase hook", () => {
 
     // doesn't respond to properties change (problem documents don't have user-settable properties)
     document.setProperty("foo", "bar");
-    expect(mockRef).toHaveBeenCalledTimes(2);
-    expect(mockUpdate).toHaveBeenCalledTimes(2);
+    expect(mockRef).toHaveBeenCalledTimes(3);
+    expect(mockUpdate).toHaveBeenCalledTimes(3);
   });
 
   it("monitors planning documents", () => {
@@ -322,13 +322,13 @@ describe("useDocumentSyncToFirebase hook", () => {
       expect(spy).not.toBeCalled();
     });
 
-    // doesn't respond to properties change
+    // responds to properties change when we publish problem documents (pubCount)
     mockRef.mockClear();
     mockUpdate.mockClear();
     await jestSpyConsole("log", spy => {
       document.setProperty("foo", "bar");
-      expect(mockRef).toHaveBeenCalledTimes(0);
-      expect(mockUpdate).toHaveBeenCalledTimes(0);
+      expect(mockRef).toHaveBeenCalledTimes(1);
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
       expect(spy).not.toBeCalled();
     });
 

--- a/src/hooks/use-document-sync-to-firebase.ts
+++ b/src/hooks/use-document-sync-to-firebase.ts
@@ -80,7 +80,7 @@ export function useDocumentSyncToFirebase(
     // sync properties for published documents
     useSyncMstNodeToFirebase({
       firebase, model: document.properties, path: `${metadata}/properties`,
-      enabled: readOnly && (user.id === uid) &&
+      enabled: readOnly && (user.id === uid) && document.supportContentType !== "multiclass" &&
         [ProblemPublication, PersonalPublication, LearningLogPublication, SupportPublication ].includes(type),
       options: {
         onSuccess: (data, properties) => {

--- a/src/hooks/use-document-sync-to-firebase.ts
+++ b/src/hooks/use-document-sync-to-firebase.ts
@@ -4,9 +4,9 @@ import { useSyncMstPropToFirebase } from "./use-sync-mst-prop-to-firebase";
 import { DEBUG_DOCUMENT, DEBUG_SAVE } from "../lib/debug";
 import { Firebase } from "../lib/firebase";
 import { DocumentModelType } from "../models/document/document";
-import {
-  isPublishedType, LearningLogDocument, PersonalDocument, ProblemDocument
-} from "../models/document/document-types";
+import { isPublishedType, LearningLogDocument, LearningLogPublication, PersonalDocument,
+         PersonalPublication, ProblemDocument, ProblemPublication, SupportPublication
+        } from "../models/document/document-types";
 import { UserModelType } from "../models/stores/user";
 
 function debugLog(...args: any[]) {
@@ -27,7 +27,7 @@ function debugLog(...args: any[]) {
 export function useDocumentSyncToFirebase(
                   user: UserModelType, firebase: Firebase, document: DocumentModelType, readOnly = false) {
   const { key, type, uid } = document;
-  const { content: contentPath, typedMetadata } = firebase.getUserDocumentPaths(user, type, key, uid);
+  const { content: contentPath, metadata, typedMetadata } = firebase.getUserDocumentPaths(user, type, key, uid);
   !readOnly && (user.id !== uid) && console.warn("useDocumentSyncToFirebase monitoring another user's document?!?");
 
   if (DEBUG_DOCUMENT) {
@@ -64,7 +64,7 @@ export function useDocumentSyncToFirebase(
 
   // sync properties for personal and learning log documents
   useSyncMstNodeToFirebase({
-    firebase, model: document.properties, path: typedMetadata,
+    firebase, model: document.properties, path: `${metadata}/properties`,
     enabled: !readOnly && [PersonalDocument, LearningLogDocument].includes(type),
     options: {
       onSuccess: (data, properties) => {
@@ -76,6 +76,22 @@ export function useDocumentSyncToFirebase(
       }
     }
   });
+
+    // sync properties for published documents
+    useSyncMstNodeToFirebase({
+      firebase, model: document.properties, path: `${metadata}/properties`,
+      enabled: readOnly && (user.id === uid) &&
+        [ProblemPublication, PersonalPublication, LearningLogPublication, SupportPublication ].includes(type),
+      options: {
+        onSuccess: (data, properties) => {
+          debugLog(`DEBUG: Updated document properties for ${type} document ${key}:`, JSON.stringify(properties));
+        },
+        onError: (err, properties) => {
+          console.warn(`ERROR: Failed to update document properties for ${type} document ${key}:`,
+                      JSON.stringify(properties));
+        }
+      }
+    });
 
   // sync content for editable document types
   useSyncMstNodeToFirebase({

--- a/src/hooks/use-document-sync-to-firebase.ts
+++ b/src/hooks/use-document-sync-to-firebase.ts
@@ -62,10 +62,10 @@ export function useDocumentSyncToFirebase(
     }
   });
 
-  // sync properties for personal and learning log documents
+  // sync properties for problem, personal, and learning log documents
   useSyncMstNodeToFirebase({
     firebase, model: document.properties, path: `${metadata}/properties`,
-    enabled: !readOnly && [PersonalDocument, LearningLogDocument].includes(type),
+    enabled: !readOnly && [ProblemDocument, PersonalDocument, LearningLogDocument].includes(type),
     options: {
       onSuccess: (data, properties) => {
         debugLog(`DEBUG: Updated document properties for ${type} document ${key}:`, JSON.stringify(properties));

--- a/src/lib/db-listeners/db-supports-listener.ts
+++ b/src/lib/db-listeners/db-supports-listener.ts
@@ -176,7 +176,8 @@ export class DBSupportsListener extends BaseListener {
       authoredTime: authoredDate.getTime(),
       originDoc: dbSupport.originDoc,
       caption: dbSupport.properties?.caption,
-      deleted: dbSupport.deleted || !!dbSupport.properties?.isDeleted
+      deleted: dbSupport.deleted || !!dbSupport.properties?.isDeleted,
+      pubVersion: dbSupport.pubVersion
     });
   }
 

--- a/src/lib/db-types.ts
+++ b/src/lib/db-types.ts
@@ -139,6 +139,7 @@ export interface DBPublication {
   groupId?: string;
   userId: string;
   groupUserConnections?: DBGroupUserConnections;
+  pubVersion: number;
 }
 
 // metadata written to {classHash}/personalPublications for published personal documents
@@ -153,6 +154,7 @@ export interface DBOtherPublication {
   properties: IDocumentProperties;
   uid: string;
   originDoc: string;
+  pubVersion: number
 }
 
 export type DBUnpublishedTypedDocumentMetadata = DBOfferingUserProblemDocument | DBOtherDocument;

--- a/src/lib/db-types.ts
+++ b/src/lib/db-types.ts
@@ -52,6 +52,8 @@ export interface DBBaseDocumentMetadata {
   };
   createdAt: number;
   type: DBDocumentType;
+  // previously in DBOtherDocument
+  properties?: IDocumentProperties;
 }
 
 export interface DBBaseProblemDocumentMetadata extends DBBaseDocumentMetadata {
@@ -121,6 +123,7 @@ export interface DBOtherDocument {
     documentKey: string;
   };
   title: string;
+  // legacy properties; in DBBaseDocumentMetadata since ~2.2
   properties?: IDocumentProperties;
 }
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -557,7 +557,7 @@ export class DB {
             return createDocumentModel({
               type,
               title,
-              properties,
+              properties: { ...properties, ...metadata.properties },
               groupId,
               visibility,
               uid: userId,
@@ -686,7 +686,7 @@ export class DB {
       if (this.stores.appMode !== "qa") {
         return reject("db#clear is only available in qa mode");
       }
-      
+
       if (level === "all") {
         return reject("clearing 'all' is handled by clearFirebaseAnonQAUser");
       }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -510,10 +510,8 @@ export class DB {
     const { problemPath, user } = this.stores;
     const { offeringId: resource_link_id, activityUrl: resource_url = "" } = user;
     const content = documentModel.content?.publish();
-    const pubCount = documentModel.getNumericProperty("pubCount");
-    const newPubCount = pubCount+1;
-    documentModel.setNumericProperty("pubCount", newPubCount);
-    const pubVersion = pubCount > 1 ? pubCount : 1;
+    let pubCount = documentModel.getNumericProperty("pubCount");
+    documentModel.setNumericProperty("pubCount", ++pubCount);
     if (!content) {
       throw new Error("Could not publish the specified document because its content is not available.");
     }
@@ -528,7 +526,7 @@ export class DB {
       content,
       resource_link_id,
       resource_url,
-      pubVersion,
+      pubVersion: pubCount,
     });
   }
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -88,6 +88,7 @@ export interface OpenDocumentOptions {
   properties?: IDocumentProperties;
   groupUserConnections?: Record<string, unknown>;
   originDoc?: string;
+  pubVersion?: number;
 }
 
 export class DB {
@@ -432,6 +433,8 @@ export class DB {
     if (!content) {
       throw new Error("Could not publish the specified document because its content is not available.");
     }
+    let pubCount = documentModel.getNumericProperty("pubCount");
+    documentModel.setNumericProperty("pubCount", ++pubCount);
     return new Promise<{document: DBDocument, metadata: DBPublicationDocumentMetadata}>((resolve, reject) => {
       this.createDocument({ type: ProblemPublication, content }).then(({document, metadata}) => {
         const publicationRef = this.firebase.ref(this.firebase.getProblemPublicationsPath(user)).push();
@@ -451,6 +454,7 @@ export class DB {
           },
           documentKey: document.self.documentKey,
           userId: user.id,
+          pubVersion: pubCount,
           ...groupProps
         };
 
@@ -471,6 +475,8 @@ export class DB {
       throw new Error("Could not publish the specified document because its content is not available.");
     }
     const publicationType = documentModel.type + "Publication" as DBDocumentType;
+    let pubCount = documentModel.getNumericProperty("pubCount");
+    documentModel.setNumericProperty("pubCount", ++pubCount);
     return new Promise<{document: DBDocument, metadata: DBPublicationDocumentMetadata}>((resolve, reject) => {
       this.createDocument({ type: publicationType, content }).then(({document, metadata}) => {
         const publicationPath = publicationType === "personalPublication"
@@ -486,9 +492,9 @@ export class DB {
           uid: user.id,
           title: documentModel.title || "",
           properties: documentModel.copyProperties(),
-          originDoc: documentModel.key
+          originDoc: documentModel.key,
+          pubVersion: pubCount,
         };
-
         publicationRef.set(publication)
           .then(() => {
             Logger.logDocumentEvent(LogEventName.PUBLISH_DOCUMENT, documentModel);
@@ -504,6 +510,10 @@ export class DB {
     const { problemPath, user } = this.stores;
     const { offeringId: resource_link_id, activityUrl: resource_url = "" } = user;
     const content = documentModel.content?.publish();
+    const pubCount = documentModel.getNumericProperty("pubCount");
+    const newPubCount = pubCount+1;
+    documentModel.setNumericProperty("pubCount", newPubCount);
+    const pubVersion = pubCount > 1 ? pubCount : 1;
     if (!content) {
       throw new Error("Could not publish the specified document because its content is not available.");
     }
@@ -517,13 +527,14 @@ export class DB {
       originDocType: documentModel.type,
       content,
       resource_link_id,
-      resource_url
+      resource_url,
+      pubVersion,
     });
   }
 
   public openDocument(options: OpenDocumentOptions) {
     const { documents } = this.stores;
-    const {documentKey, type, title, properties, userId, groupId, visibility, originDoc} = options;
+    const {documentKey, type, title, properties, userId, groupId, visibility, originDoc, pubVersion} = options;
     return new Promise<DocumentModelType>((resolve, reject) => {
       const {user} = this.stores;
       const documentPath = this.firebase.getUserDocumentPath(user, documentKey, userId);
@@ -548,7 +559,7 @@ export class DB {
                         `document '${documentKey}' of type '${type}' for user '${userId}'`;
             console.warn(msg);
             return createDocumentModel({
-                                  type, title, properties, groupId, visibility, uid: userId, originDoc,
+                                  type, title, properties, groupId, visibility, uid: userId, originDoc, pubVersion,
                                   key: documentKey, createdAt: metadata.createdAt, content: {}, changeCount: 0 });
           }
 
@@ -565,7 +576,8 @@ export class DB {
               key: document.self.documentKey,
               createdAt: metadata.createdAt,
               content: content ? content : {},
-              changeCount: document.changeCount
+              changeCount: document.changeCount,
+              pubVersion
             });
           } catch (e) {
             const msg = "Could not open " +
@@ -744,15 +756,15 @@ export class DB {
 
   // handles published personal documents and published learning logs
   public createDocumentModelFromOtherPublication(publication: DBOtherPublication, type: OtherPublicationType) {
-    const {title, properties, uid, originDoc, self: {documentKey}} = publication;
+    const {title, properties, uid, originDoc, self: {documentKey}, pubVersion} = publication;
+
     const group = this.stores.groups.groupForUser(uid);
     const groupId = group && group.id;
-    return this.openDocument({type, userId: uid, documentKey, groupId, title, properties, originDoc});
+    return this.openDocument({type, userId: uid, documentKey, groupId, title, properties, originDoc, pubVersion});
   }
 
   public createDocumentFromPublication(publication: DBPublication) {
-    const {groupId, groupUserConnections, userId, documentKey} = publication;
-
+    const {groupId, groupUserConnections, userId, documentKey, pubVersion} = publication;
     // groupUserConnections returns as an array and must be converted back to a map
     const groupUserConnectionsMap = Object.keys(groupUserConnections || [])
       .reduce((allUsers, groupUserId) => {
@@ -769,6 +781,7 @@ export class DB {
       groupId,
       visibility: "public",
       groupUserConnections: groupUserConnectionsMap,
+      pubVersion
     });
   }
 

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -134,8 +134,7 @@ export class Firebase {
       [PersonalDocument]: () => this.getOtherDocumentPath(user, PersonalDocument, documentKey),
       [LearningLogDocument]: () => this.getOtherDocumentPath(user, LearningLogDocument, documentKey),
       [ProblemPublication]: () => `${this.getProblemPublicationsPath(user)}/${documentKey}`,
-      [PersonalPublication]: () => `${this.getPersonalPublicationsPath(user)}/${documentKey}`,
-      [LearningLogPublication]: () => `${this.getLearningLogPublicationsPath(user)}/${documentKey}`
+       // typed metadata for published personal documents and learning logs is stored under a different key
     };
     const typedMetadata = typedMetadataMap[documentType]?.() || "";
     return { content, metadata, typedMetadata };

--- a/src/models/document/document.ts
+++ b/src/models/document/document.ts
@@ -38,7 +38,8 @@ export const DocumentModel = types
     visibility: types.maybe(types.enumeration("VisibilityType", ["public", "private"])),
     groupUserConnections: types.map(types.boolean),
     originDoc: types.maybe(types.string),
-    changeCount: types.optional(types.number, 0)
+    changeCount: types.optional(types.number, 0),
+    pubVersion: types.maybe(types.number)
   })
   .volatile(self => ({
     queryPromise: undefined as Promise<UseQueryResult<IGetNetworkDocumentResponse>> | undefined
@@ -82,6 +83,14 @@ export const DocumentModel = types
     },
     getProperty(key: string) {
       return self.properties.get(key);
+    },
+    getNumericProperty(key: string) {
+      const val = self.properties.get(key);
+      if (val !== undefined) {
+        return Number(self.properties.get(key));
+      } else {
+        return 0;
+      }
     },
     copyProperties(): IDocumentProperties {
       return self.properties.toJSON();
@@ -168,6 +177,9 @@ export const DocumentModel = types
       else if (self.getProperty(key) !== value) {
         self.properties.set(key, value);
       }
+    },
+    setNumericProperty(key: string, value?: number) {
+      this.setProperty(key, value == null ? value : `${value}`);
     },
 
     setContent(snapshot: DocumentContentSnapshotType) {

--- a/src/models/document/document.ts
+++ b/src/models/document/document.ts
@@ -86,11 +86,7 @@ export const DocumentModel = types
     },
     getNumericProperty(key: string) {
       const val = self.properties.get(key);
-      if (val !== undefined) {
-        return Number(self.properties.get(key));
-      } else {
-        return 0;
-      }
+      return val != null ? Number(val) : 0;
     },
     copyProperties(): IDocumentProperties {
       return self.properties.toJSON();

--- a/src/models/document/document.ts
+++ b/src/models/document/document.ts
@@ -17,6 +17,7 @@ import { getLocalTimeStamp } from "../../utilities/time";
 import { safeJsonParse } from "../../utilities/js-utils";
 import { createSharedModelDocumentManager, ISharedModelDocumentManager } from "../tools/shared-model-document-manager";
 import { ITileEnvironment } from "../tools/tool-types";
+import { ESupportType } from "../curriculum/support";
 
 interface IMatchPropertiesOptions {
   isTeacherDocument?: boolean;
@@ -39,7 +40,8 @@ export const DocumentModel = types
     groupUserConnections: types.map(types.boolean),
     originDoc: types.maybe(types.string),
     changeCount: types.optional(types.number, 0),
-    pubVersion: types.maybe(types.number)
+    pubVersion: types.maybe(types.number),
+    supportContentType: types.maybe(types.enumeration<ESupportType>("SupportType", Object.values(ESupportType)))
   })
   .volatile(self => ({
     queryPromise: undefined as Promise<UseQueryResult<IGetNetworkDocumentResponse>> | undefined

--- a/src/models/stores/supports.ts
+++ b/src/models/stores/supports.ts
@@ -79,7 +79,8 @@ export const TeacherSupportModel = types
     authoredTime: types.number,
     originDoc: types.maybe(types.string),
     caption: types.maybe(types.string),
-    deleted: false
+    deleted: false,
+    pubVersion: types.maybe(types.number)
   })
   .views(self => ({
     // excludes sticky notes
@@ -136,7 +137,8 @@ export const CurricularSupportModel = types
     support: SupportModel,
     type: types.enumeration<SupportTarget>("SupportTarget", Object.values(SupportTarget)),
     visible: false,
-    sectionId: types.maybe(types.string)
+    sectionId: types.maybe(types.string),
+    pubVersion: types.maybe(types.number)
   })
   .actions((self) => {
     return {
@@ -311,9 +313,10 @@ function getTeacherSupportCaption(support: TeacherSupportModelType,
   const sectionPart = sectionId ? " " + getSectionInitials(sectionId) : "";
   const prefix = `${investigationPart}.${problemPart}${sectionPart}`;
   const caption = support.caption || "Untitled";
+  const version = support.pubVersion ? `v${support.pubVersion}` : "";
   return caption.includes(prefix)
-          ? caption
-          : `${prefix} ${caption}`;
+          ? `${caption} ${version}`
+          : `${prefix} ${caption} ${version}`;
 }
 
 function getCurricularSupportCaption(support: CurricularSupportModelType, index: number,
@@ -322,7 +325,8 @@ function getCurricularSupportCaption(support: CurricularSupportModelType, index:
   const problemPart = problem ? `${problem.ordinal}` : "*";
   const { sectionId } = support;
   const sectionPart = sectionId ? " " + getSectionTitle(sectionId) : "";
-  return `${investigationPart}.${problemPart}${sectionPart} Support ${index}`;
+  const version = support.pubVersion ? `v${support.pubVersion}` : "";
+  return `${investigationPart}.${problemPart}${sectionPart} Support ${index} ${version}`;
 }
 
 function getSupportCaption(support: UnionSupportModelType, index: number,

--- a/src/models/stores/supports.ts
+++ b/src/models/stores/supports.ts
@@ -313,10 +313,9 @@ function getTeacherSupportCaption(support: TeacherSupportModelType,
   const sectionPart = sectionId ? " " + getSectionInitials(sectionId) : "";
   const prefix = `${investigationPart}.${problemPart}${sectionPart}`;
   const caption = support.caption || "Untitled";
-  const version = support.pubVersion ? `v${support.pubVersion}` : "";
   return caption.includes(prefix)
-          ? `${caption} ${version}`
-          : `${prefix} ${caption} ${version}`;
+          ? `${caption}`
+          : `${prefix} ${caption}` ;
 }
 
 function getCurricularSupportCaption(support: CurricularSupportModelType, index: number,
@@ -357,6 +356,9 @@ export function addSupportDocumentsToStore(params: ICreateFromUnitParams) {
       index = 1;
       lastSection = sectionId;
     }
+    const supportUid = support.supportType === SupportType.teacher
+                        ? support.uid
+                        : "curriculum";
     const supportCaption = getSupportCaption(support, index, investigation, problem);
     const supportKey = support.supportType === SupportType.teacher
                         ? support.key || supportCaption
@@ -400,13 +402,14 @@ export function addSupportDocumentsToStore(params: ICreateFromUnitParams) {
       const content = await getDocumentContentForSupport(support.support, db);
       if (content) {
         document = createDocumentModel({
-                     uid: "curriculum",
+                     uid: supportUid,
                      type: SupportPublication,
                      key: supportKey,
                      originDoc,
                      properties,
                      createdAt: Date.now(),
-                     content: getSnapshot(content)
+                     content: getSnapshot(content),
+                     pubVersion: support.pubVersion
                    });
         documents.add(document);
         onDocumentCreated?.(support, document);

--- a/src/models/stores/supports.ts
+++ b/src/models/stores/supports.ts
@@ -405,6 +405,7 @@ export function addSupportDocumentsToStore(params: ICreateFromUnitParams) {
                      uid: supportUid,
                      type: SupportPublication,
                      key: supportKey,
+                     supportContentType: support.support.type,
                      originDoc,
                      properties,
                      createdAt: Date.now(),

--- a/src/models/view/nav-tabs.ts
+++ b/src/models/view/nav-tabs.ts
@@ -63,7 +63,6 @@ export const NavTabSectionModel =
         ENavTabSectionType.kPublishedProblemDocuments,
         ENavTabSectionType.kPublishedLearningLogs,
         ENavTabSectionType.kTeacherSupports,
-        ENavTabSectionType.kCurricularSupports,
        ];
       return (deletableTypes.includes(self.type) && userOwnsDocument);
     },

--- a/src/models/view/nav-tabs.ts
+++ b/src/models/view/nav-tabs.ts
@@ -57,12 +57,13 @@ export const NavTabSectionModel =
       return user.type && (self.showStars.indexOf(user.type) !== -1);
     },
     showDeleteForUser(user: UserModelType, userDocument?: any) { //DocumentModelType is a circular logic?
-      const userOwnsDocument = userDocument && (user.id === userDocument || user.id === userDocument.uid);
+      const userOwnsDocument = (userDocument && (user.id === userDocument || user.id === userDocument.uid));
       // allow users to delete published document
       const deletableTypes = [ENavTabSectionType.kPublishedPersonalDocuments,
         ENavTabSectionType.kPublishedProblemDocuments,
         ENavTabSectionType.kPublishedLearningLogs,
         ENavTabSectionType.kTeacherSupports,
+        ENavTabSectionType.kCurricularSupports,
        ];
       return (deletableTypes.includes(self.type) && userOwnsDocument);
     },

--- a/src/models/view/nav-tabs.ts
+++ b/src/models/view/nav-tabs.ts
@@ -57,7 +57,7 @@ export const NavTabSectionModel =
       return user.type && (self.showStars.indexOf(user.type) !== -1);
     },
     showDeleteForUser(user: UserModelType, userDocument?: any) { //DocumentModelType is a circular logic?
-      const userOwnsDocument = userDocument && user.id === userDocument.uid;
+      const userOwnsDocument = userDocument && (user.id === userDocument || user.id === userDocument.uid);
       // allow users to delete published document
       const deletableTypes = [ENavTabSectionType.kPublishedPersonalDocuments,
         ENavTabSectionType.kPublishedProblemDocuments,

--- a/src/models/view/nav-tabs.ts
+++ b/src/models/view/nav-tabs.ts
@@ -56,9 +56,15 @@ export const NavTabSectionModel =
     showStarsForUser(user: UserModelType) {
       return user.type && (self.showStars.indexOf(user.type) !== -1);
     },
-    showDeleteForUser(user: UserModelType) {
-      // allow teachers to delete supports
-      return (user.type === "teacher") && (self.type === ENavTabSectionType.kTeacherSupports);
+    showDeleteForUser(user: UserModelType, userDocument?: any) { //DocumentModelType is a circular logic?
+      const userOwnsDocument = userDocument && user.id === userDocument.uid;
+      // allow users to delete published document
+      const deletableTypes = [ENavTabSectionType.kPublishedPersonalDocuments,
+        ENavTabSectionType.kPublishedProblemDocuments,
+        ENavTabSectionType.kPublishedLearningLogs,
+        ENavTabSectionType.kTeacherSupports,
+       ];
+      return (deletableTypes.includes(self.type) && userOwnsDocument);
     },
   }));
 export type NavTabSectionSpec = SnapshotIn<typeof NavTabSectionModel>;


### PR DESCRIPTION
Show multiple version of publications. Document titles show version number of published document based on the number of times the document has been published. Note that original documents publish to one class vs publish to multiple classes will have sequential number because the version numbers depend on how many times a document has been published in total rather than how times a document has been published by type.
Allows deletion of user owned publications. Version numbers do not change when documents are deleted.
