### PR TITLE
Hide data storage block from dataflow toolbar

### DIFF
--- a/src/plugins/dataflow-tool/components/dataflow-program.tsx
+++ b/src/plugins/dataflow-tool/components/dataflow-program.tsx
@@ -189,7 +189,19 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
             isDataStorageDisabled={this.state.disableDataStorage}
             disabled={readOnly || !this.isReady()}
           /> }
-          <div className="editor-graph-container" style={this.getEditorStyle()}>
+          <div
+            className="editor-graph-container"
+            style={this.getEditorStyle()}
+            onDragOver={event => {
+              event.preventDefault();
+              event.dataTransfer.dropEffect = "copy";
+            }}
+            onDrop={event => {
+              event.preventDefault();
+              const nodeType = event.dataTransfer.getData("text/plain");
+              console.log(`Adding ${nodeType}`);
+            }}
+          >
             <div
               className={editorClass}
               ref={(elt) => this.editorDomElement = elt}

--- a/src/plugins/dataflow-tool/components/ui/dataflow-program-toolbar.tsx
+++ b/src/plugins/dataflow-tool/components/ui/dataflow-program-toolbar.tsx
@@ -59,13 +59,33 @@ export class DataflowProgramToolbar extends React.Component<IProps> {
         nodeIcons.push(<div className="icon-node left mid" key={"icon-node-l-m" + i}/>);
         break;
     }
+    const nodeIcon = (
+      <div className={iconClass}>
+        {nodeIcons}
+      </div>
+    );
     return (
       <button
         disabled={nodeType === "Data Storage" && this.props.isDataStorageDisabled || this.props.disabled}
         key={i} title={`Add ${nodeType} Block`}
         onClick={handleAddNodeButtonClick}
+        draggable="true"
+        onDragStart={event => {
+          event.dataTransfer.setData("text/plain", nodeType);
+          // const image = new Image();
+          // image.src = "../../assets/lightbulb-on.png";
+          // event.dataTransfer.setDragImage(image, 10, 10);
+          event.dataTransfer.dropEffect = "copy";
+          console.log("Start drag");
+        }}
+        onDrag={event => {
+          console.log("Dragging");
+        }}
+        onDragEnd={event => {
+          console.log("End drag");
+        }}
       >
-        <div className={iconClass}>{nodeIcons}</div>
+        {nodeIcon}
         <div className="label">{nodeType}</div>
       </button>
     );

--- a/src/plugins/dataflow-tool/model/utilities/node.ts
+++ b/src/plugins/dataflow-tool/model/utilities/node.ts
@@ -77,10 +77,11 @@ export const NodeTypes: NodeType[] = [
     name: "Demo Output",
     displayName: "Demo Output",
   },
-  {
-    name: "Data Storage",
-    displayName: "Data Storage",
-  },
+  // TODO Remove, along with all references to data storage, when dead code is cleaned
+  // {
+  //   name: "Data Storage",
+  //   displayName: "Data Storage",
+  // },
   {
     name: "Live Output",
     displayName: "Live Output",


### PR DESCRIPTION
I just did the quickest thing to make this happen: removed the data storage block from the toolbar that lets you add new nodes. Actually removing the data storage block from code will be postponed until we can someday get to the clean dataflow code story.