### PR TITLE
182835713 control block param fix

### DIFF
--- a/src/plugins/dataflow-tool/nodes/dataflow-node.scss
+++ b/src/plugins/dataflow-tool/nodes/dataflow-node.scss
@@ -283,6 +283,7 @@ $node-inner-width: 140px;
         transform:rotate(0deg);
         background-image: url("../assets/icons/control/gate.svg");
         transition: all .4s;
+        border-radius: 10px 4px 4px 10px;
       }
     }
     &.has-gate.gate-active .inputs {
@@ -290,6 +291,7 @@ $node-inner-width: 140px;
         transform:rotate(180deg);
         background-color: $control-green;
         transition: all .4s;
+        border-radius: 4px 10px 10px 4px;
       }
     }
     &.data-storage {

--- a/src/plugins/dataflow-tool/nodes/dataflow-node.scss
+++ b/src/plugins/dataflow-tool/nodes/dataflow-node.scss
@@ -280,13 +280,16 @@ $node-inner-width: 140px;
     }
     &.has-gate .inputs {
       div:first-of-type .socket {
-        transform:rotate(180deg);
+        transform:rotate(0deg);
         background-image: url("../assets/icons/control/gate.svg");
+        transition: all .4s;
       }
     }
     &.has-gate.gate-active .inputs {
       div:first-of-type .socket {
+        transform:rotate(180deg);
         background-color: $control-green;
+        transition: all .4s;
       }
     }
     &.data-storage {

--- a/src/plugins/dataflow-tool/nodes/factories/control-rete-node-factory.tsx
+++ b/src/plugins/dataflow-tool/nodes/factories/control-rete-node-factory.tsx
@@ -95,7 +95,7 @@ export class ControlReteNodeFactory extends DataflowReteNodeFactory {
     // prepare string to display on node
     const resultString = isNaN(result) ? kEmptyValueString : `${roundNodeValue(result)}`;
     const cResultString = isNaN(cResult) ? kEmptyValueString : `${roundNodeValue(cResult)}`;
-    const n1String = isNaN(n1) ? kEmptyValueString : `${roundNodeValue(n1)}`;
+    // const n1String = isNaN(n1) ? kEmptyValueString : `${roundNodeValue(n1)}`;
     const n2String = isNaN(n2) ? kEmptyValueString : `${roundNodeValue(n2)}`;
 
     const resultSentence = n1 === 1 ?
@@ -104,6 +104,7 @@ export class ControlReteNodeFactory extends DataflowReteNodeFactory {
       // alternative ui: rather than make any !== 1 appear as 0, show actual input
       // `${n1} ? ${cResultString} : ${n2String} ⇒ ${resultString}` :
       // `${n1} ? ${n2String} : ${cResultString} ⇒ ${resultString}`;
+      //  also needs n1String above
 
     // operate rete
     if (this.editor) {

--- a/src/plugins/dataflow-tool/nodes/factories/control-rete-node-factory.tsx
+++ b/src/plugins/dataflow-tool/nodes/factories/control-rete-node-factory.tsx
@@ -95,8 +95,15 @@ export class ControlReteNodeFactory extends DataflowReteNodeFactory {
     // prepare string to display on node
     const resultString = isNaN(result) ? kEmptyValueString : `${roundNodeValue(result)}`;
     const cResultString = isNaN(cResult) ? kEmptyValueString : `${roundNodeValue(cResult)}`;
+    const n1String = isNaN(n1) ? kEmptyValueString : `${roundNodeValue(n1)}`;
     const n2String = isNaN(n2) ? kEmptyValueString : `${roundNodeValue(n2)}`;
-    const resultSentence = `1 ? ${cResultString} : ${n2String} ⇒ ${resultString}`;
+
+    const resultSentence = n1 === 1 ?
+      `1 ? ${cResultString} : ${n2String} ⇒ ${resultString}` :
+      `0 ? ${n2String} : ${cResultString} ⇒ ${resultString}`;
+      // alternative ui: rather than make any !== 1 appear as 0, show actual input
+      // `${n1} ? ${cResultString} : ${n2String} ⇒ ${resultString}` :
+      // `${n1} ? ${n2String} : ${cResultString} ⇒ ${resultString}`;
 
     // operate rete
     if (this.editor) {


### PR DESCRIPTION
This makes it so input that `!==1` on the first parameter in hold block will show as a zero.  It also adds the "flipping" animation and shape to the gate socket on the node.  I left a commented-out version in place that will show the actual input in the first parameter. 