### PR TITLE
182924194 dataflow default zoom

### DIFF
--- a/src/plugins/dataflow-tool/components/dataflow-program.tsx
+++ b/src/plugins/dataflow-tool/components/dataflow-program.tsx
@@ -612,16 +612,14 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
       const tooSmall = rect.width < (clientWidth * .25) || rect.height < (clientHeight * .25);
       const tooBig = newZoom < k && rect.right > 0 && newZoom > 0;
 
-      if (tooBig) {
-        this.programEditor.view.area.transform = {k: newZoom, x: transform.x, y: transform.y};
+      if (tooSmall) {
+        this.programEditor.view.area.transform = {k: .9, x: transform.x, y: transform.y};
         this.programEditor.view.area.update();
         return;
       }
 
-      // If the program is way too small for the current work area, reset zoom to 1
-      // checking both to avoid flicker-inducing race condition
-      if ( tooSmall && !tooBig ) {
-        this.programEditor.view.area.transform = {k: 1, x: transform.x, y: transform.y};
+      if (tooBig) {
+        this.programEditor.view.area.transform = {k: newZoom, x: transform.x, y: transform.y};
         this.programEditor.view.area.update();
       }
     }

--- a/src/plugins/dataflow-tool/components/dataflow-program.tsx
+++ b/src/plugins/dataflow-tool/components/dataflow-program.tsx
@@ -610,17 +610,17 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
       const newZoom = Math.min(widthQ, heightQ);
 
       const tooSmall = rect.width < (clientWidth * .25) || rect.height < (clientHeight * .25);
-      const shouldShrink = newZoom < k && rect.right > 0 && newZoom > 0;
+      const tooBig = newZoom < k && rect.right > 0 && newZoom > 0;
 
-      if (shouldShrink) {
+      if (tooBig) {
         this.programEditor.view.area.transform = {k: newZoom, x: transform.x, y: transform.y};
         this.programEditor.view.area.update();
         return;
       }
 
       //If the program is way too small for the current work area, reset zoom to 1
-      // checking for !shouldShrink to avoid flicker-inducing race condition
-      if ( tooSmall && !shouldShrink ) {
+      // checking both to avoid flicker-inducing race condition
+      if ( tooSmall && !tooBig ) {
         this.programEditor.view.area.transform = {k: 1, x: transform.x, y: transform.y};
         this.programEditor.view.area.update();
       }

--- a/src/plugins/dataflow-tool/components/dataflow-program.tsx
+++ b/src/plugins/dataflow-tool/components/dataflow-program.tsx
@@ -618,7 +618,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
         return;
       }
 
-      //If the program is way too small for the current work area, reset zoom to 1
+      // If the program is way too small for the current work area, reset zoom to 1
       // checking both to avoid flicker-inducing race condition
       if ( tooSmall && !tooBig ) {
         this.programEditor.view.area.transform = {k: 1, x: transform.x, y: transform.y};


### PR DESCRIPTION
- This maintains the "shrink-to-fit" functionality.  
- This adjusts the "zoom-to-fit" functionality such that it only zooms in when the program is excessively small.   
- Since multiple evaluations can happen across a single trigger when sizing down, we check for both conditions to avoid flicker. 
- Broke calculations into variables for clarity and possible future use, can change back if it is a performance hit or not desirable style