### PR TITLE
182942227 dataflow UI fixes

### DIFF
--- a/src/plugins/dataflow-tool/components/dataflow-program.tsx
+++ b/src/plugins/dataflow-tool/components/dataflow-program.tsx
@@ -180,6 +180,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
           showRateUI={showRateUI}
           lastIntervalDuration={this.state.lastIntervalDuration}
           serialDevice={this.stores.serialDevice}
+          showRecordUI={false}
         />}
         <div className={toolbarEditorContainerClass}>
           { showProgramToolbar && <DataflowProgramToolbar

--- a/src/plugins/dataflow-tool/components/ui/dataflow-program-topbar.tsx
+++ b/src/plugins/dataflow-tool/components/ui/dataflow-program-topbar.tsx
@@ -21,6 +21,7 @@ interface TopbarProps {
   showRateUI: boolean;
   lastIntervalDuration: number;
   serialDevice: SerialDevice;
+  showRecordUI: boolean;
 }
 
 // const kProgressWidth = 76;
@@ -115,7 +116,6 @@ export const DataflowProgramTopbar = (props: TopbarProps) => {
   );
 
   function serialMessage(){
-
     // nodes that use serial, but no device physically connected
     if (lastMsg !== "connect" && serialDevice.serialNodesCount > 0){
       return "connect a device";
@@ -145,22 +145,30 @@ export const DataflowProgramTopbar = (props: TopbarProps) => {
         </div>
       </div>
       <div className="topbar-center">
+
         <RateSelectorComponent
           rateOptions={props.programDataRates}
           dataRate={props.dataRate}
           onRateSelectClick={props.onRateSelectClick}
           readOnly={props.readOnly}
         />
-        <RecordButton readOnly={props.readOnly} />
-        <button
-          className="program-state-button"
-          title="Stop Program"
-          onClick={props.onStopProgramClick}
-          disabled={!props.runningProgram || !props.readOnly}
-        >
-          <div className="icon stop" />
-          <div className="text">Stop</div>
-        </button>
+
+        { props.showRecordUI &&
+          <RecordButton readOnly={props.readOnly} />
+        }
+
+        { props.showRecordUI &&
+          <button
+            className="program-state-button"
+            title="Stop Program"
+            onClick={props.onStopProgramClick}
+            disabled={!props.runningProgram || !props.readOnly}
+          >
+            <div className="icon stop" />
+            <div className="text">Stop</div>
+          </button>
+        }
+
       </div>
       <div className="topbar-right">
         {props.showRateUI && <span className={"rate-ui"}>{`${props.lastIntervalDuration}ms`}</span>}

--- a/src/plugins/dataflow-tool/components/ui/dataflow-program-topbar.tsx
+++ b/src/plugins/dataflow-tool/components/ui/dataflow-program-topbar.tsx
@@ -154,19 +154,18 @@ export const DataflowProgramTopbar = (props: TopbarProps) => {
         />
 
         { props.showRecordUI &&
-          <RecordButton readOnly={props.readOnly} />
-        }
-
-        { props.showRecordUI &&
-          <button
-            className="program-state-button"
-            title="Stop Program"
-            onClick={props.onStopProgramClick}
-            disabled={!props.runningProgram || !props.readOnly}
-          >
-            <div className="icon stop" />
-            <div className="text">Stop</div>
-          </button>
+          <>
+            <RecordButton readOnly={props.readOnly} />
+            <button
+              className="program-state-button"
+              title="Stop Program"
+              onClick={props.onStopProgramClick}
+              disabled={!props.runningProgram || !props.readOnly}
+            >
+              <div className="icon stop" />
+              <div className="text">Stop</div>
+            </button>
+          </>
         }
 
       </div>

--- a/src/plugins/dataflow-tool/dataflow-registration.ts
+++ b/src/plugins/dataflow-tool/dataflow-registration.ts
@@ -8,7 +8,7 @@ import { ToolMetadataModel } from "../../../src/models/tools/tool-types";
 
 registerToolContentInfo({
   id: kDataflowToolID,
-  titleBase: "Dataflow",
+  titleBase: "Program",
   modelClass: DataflowContentModel,
   metadataClass: ToolMetadataModel,
   defaultHeight: kDataflowDefaultHeight,


### PR DESCRIPTION
- Hides the Record/Play buttons in Dataflow tile
   - adds a `showRecordUI` prop to the `DataflowProgramTopbar`
   - sets it to `false` so buttons do not render
   - this preserves markup and css in case this feature is brought back
 
- Changes the `titleBase` for a Dataflow tile to `Program`.  This only affects the default title