### PR TITLE
review tile metadata and document tracking

### DIFF
--- a/docs/document-registry.md
+++ b/docs/document-registry.md
@@ -1,0 +1,15 @@
+CLUE keeps track of loaded documents using `DocumentsModel` instances, I'll call them registries for short.
+
+There are two registries in a CLUE application:
+- `documents`
+- `networkDocuments`
+
+These two instances are created by `createStores`, which is called by `initializeApp`.
+`initializeApp` is called one time globally when `index.tsx` is loaded.
+
+Documents are added to the registry via an `add` action. This makes sure there isn't a document already added to the registry with the same key. However it does not provide a warning if there is one it just silently doesn't add it. 
+
+Documents are added to the `networkDocuments` registry in `network-resources.ts`.
+Documents are added to the `documents` registry in `db.ts` and `supports.ts`
+
+From what I can tell with the code it is possible to have multiple document instances of the same document at the same time. However there will only be one in the documents registry. So the extra documents could be seen as orphans.

--- a/docs/document-registry.md
+++ b/docs/document-registry.md
@@ -10,7 +10,7 @@ These two instances are created by `createStores`, which is called by `initializ
 Documents are added to the registry via an `add` action. This makes sure there isn't a document already added to the registry with the same key. It will print a console warning if a document exists with the same key.
 
 Documents are added to the `networkDocuments` registry in `network-resources.ts`.
-Documents are added to the `documents` registry in `db.ts` and `supports.ts`
+Documents are added to the `documents` registry in `db.ts` and `supports.ts`, which are triggered by firebase listeners in the `db-listeners` folder.
 
 From what I can tell with the code it is possible to have multiple document instances of the same document at the same time. However there will only be one in the documents registry. So the extra documents could be seen as orphans. While experimenting with the application I could not make this case happen. This case of multiple documents with the same key will cause problems if unexpected. This is why there is now a warning printed when a second doc is added to the registry with the same key.
 
@@ -18,5 +18,5 @@ From what I can tell with the code it is possible to have multiple document inst
 
 We are planning to support rendering documents that are not part of the registry. This will be used for the time travel slider.  Here are some places that will be a problem:
 
-- `DataflowToolCompoent.getDocument` - this is assuming the document of this dataflow tool is the primary document of the stores.  That will not be the right document if it is being rendered in a document on the left. It will also be a problem with the time travel slider.
+- `DataflowToolComponent.getDocument` - this is assuming the document of this dataflow tool is the primary document of the stores.  That will not be the right document if it is being rendered in a document on the left. It will also be a problem with the time travel slider.
 

--- a/docs/document-registry.md
+++ b/docs/document-registry.md
@@ -7,9 +7,16 @@ There are two registries in a CLUE application:
 These two instances are created by `createStores`, which is called by `initializeApp`.
 `initializeApp` is called one time globally when `index.tsx` is loaded.
 
-Documents are added to the registry via an `add` action. This makes sure there isn't a document already added to the registry with the same key. However it does not provide a warning if there is one it just silently doesn't add it. 
+Documents are added to the registry via an `add` action. This makes sure there isn't a document already added to the registry with the same key. It will print a console warning if a document exists with the same key.
 
 Documents are added to the `networkDocuments` registry in `network-resources.ts`.
 Documents are added to the `documents` registry in `db.ts` and `supports.ts`
 
-From what I can tell with the code it is possible to have multiple document instances of the same document at the same time. However there will only be one in the documents registry. So the extra documents could be seen as orphans.
+From what I can tell with the code it is possible to have multiple document instances of the same document at the same time. However there will only be one in the documents registry. So the extra documents could be seen as orphans. While experimenting with the application I could not make this case happen. This case of multiple documents with the same key will cause problems if unexpected. This is why there is now a warning printed when a second doc is added to the registry with the same key.
+
+## Issues
+
+We are planning to support rendering documents that are not part of the registry. This will be used for the time travel slider.  Here are some places that will be a problem:
+
+- `DataflowToolCompoent.getDocument` - this is assuming the document of this dataflow tool is the primary document of the stores.  That will not be the right document if it is being rendered in a document on the left. It will also be a problem with the time travel slider.
+

--- a/src/hooks/use-document-sync-to-firebase.ts
+++ b/src/hooks/use-document-sync-to-firebase.ts
@@ -31,7 +31,7 @@ export function useDocumentSyncToFirebase(
   !readOnly && (user.id !== uid) && console.warn("useDocumentSyncToFirebase monitoring another user's document?!?");
 
   if (DEBUG_DOCUMENT && !readOnly) {
-    // The only update the currentDocument with writable documents
+    // Only update the currentDocument with writable documents
     // useDocumentSyncToFirebase is called with readOnly documents too
     (window as any).currentDocument = document;
   }

--- a/src/hooks/use-document-sync-to-firebase.ts
+++ b/src/hooks/use-document-sync-to-firebase.ts
@@ -30,7 +30,9 @@ export function useDocumentSyncToFirebase(
   const { content: contentPath, metadata, typedMetadata } = firebase.getUserDocumentPaths(user, type, key, uid);
   !readOnly && (user.id !== uid) && console.warn("useDocumentSyncToFirebase monitoring another user's document?!?");
 
-  if (DEBUG_DOCUMENT) {
+  if (DEBUG_DOCUMENT && !readOnly) {
+    // The only update the currentDocument with writable documents
+    // useDocumentSyncToFirebase is called with readOnly documents too
     (window as any).currentDocument = document;
   }
 

--- a/src/models/stores/documents.ts
+++ b/src/models/stores/documents.ts
@@ -9,6 +9,7 @@ import {
 } from "../document/document-types";
 import { ClassModelType } from "./class";
 import { UserModelType } from "./user";
+import { DEBUG_DOCUMENT } from "../../lib/debug";
 
 const extractLatestPublications = (publications: DocumentModelType[], attr: "uid" | "originDoc") => {
   const latestPublications: DocumentModelType[] = [];
@@ -161,12 +162,18 @@ export const DocumentsModel = types
   }))
   .actions((self) => {
     const add = (document: DocumentModelType) => {
+      if (DEBUG_DOCUMENT) {
+        // eslint-disable-next-line no-console
+        console.log("adding document to DocumentsModel. Key", document.key, document.title);
+      }
       if (!self.getDocument(document.key)) {
         self.all.push(document);
         const documentEnv = getEnv(document)?.documentEnv as IDocumentEnvironment | undefined;
         if (documentEnv) {
           documentEnv.appConfig = self.appConfig;
         }
+      } else {
+        console.warn("Document with the same key already exists");
       }
     };
 

--- a/src/models/stores/documents.ts
+++ b/src/models/stores/documents.ts
@@ -174,21 +174,6 @@ export const DocumentsModel = types
       self.all.remove(document);
     };
 
-    const update = (document: DocumentModelType) => {
-      if (!self.getDocument(document.key)) {
-        add(document);
-      }
-      else {
-        const i = self.all.findIndex((currDoc) => currDoc.key === document.key);
-        if (i !== -1) {
-          const oldDoc = self.all[i];
-          if (oldDoc && oldDoc.changeCount > document.changeCount) return;
-
-          self.all[i] = document;
-        }
-      }
-    };
-
     /*
      * The required document promises are used to facilitate the creation of required documents
      * while preventing the creation of redundant documents. Depending on the configuration, any
@@ -254,7 +239,6 @@ export const DocumentsModel = types
     return {
       add,
       remove,
-      update,
       addRequiredDocumentPromises,
       resolveRequiredDocumentPromise,
       resolveRequiredDocumentPromiseWithNull,

--- a/tool-tiles.md
+++ b/tool-tiles.md
@@ -38,13 +38,19 @@ We also specify `ToolTileModel`, a general content model which is the base conte
 
 ### ToolMetadataModel
 
-Each tile content model can use a metadata model. This is used to store information that is shared across multiple instances of a document. It is also preserved across reloads. 
+Each tile content model can use a metadata model. This is used to store information that is shared across multiple instances of a document. It is also preserved across tile content reloads. 
 
 When a tool is registered it provides a metadata MST "class". When needed the metadata is looked up in a global map from tile id to metadata instance. If a metadata instance is not found, then one is created and added for this tile id. This code is in `tool-types.ts`.
 
 The metadata is provided to the tile content model via a `doPostCreate` action called on the tile content model.
 
-**NOTE**: If the same tile id is used in different documents, they will share the same metadata instance. This is uncommon with user created documents tile ids are random strings. When a document is copied its tile ids are updated to new random strings (**TODO** is this true?). However it can happen with authored content, and there is nothing preventing multiple documents from being stored in the database with duplicate tile ids.
+The metadata model was introduced at a time when the response to a remote (i.e. firebase) content change was to replace the document content with a brand new `DocumentContent` instance, which meant that all local state associated with a content instance was regularly lost. We have since moved to use `applySnapshot()` in this situation, which preserves the content instance, so the metadata model should no longer be needed for that purpose.
+
+The metadata model is also used to communicate tile-specific information useful to the tile, notably the tile's id and title. The title is now accessible via the `getToolTileModel()` function and the id could be stored in a volatile property and set with a simple `setTileId()` action.
+
+In short, the notion of tile metadata may have outlived its usefulness and we should endeavor to replace its use with more appropriate mechanisms where possible.
+
+**NOTE**: If the same tile id is used in different documents, they will share the same metadata instance. This is uncommon with user created documents in which tile ids are random strings. When a document or set of tiles is copied the tile ids are updated to new random strings. However it can happen with authored content, and there is nothing preventing multiple documents from being stored in the database with duplicate tile ids.
 
 ## ToolTileComponent
 `ToolTileComponent` is a React component that serves as the main container for each tile. Tool tile types are used in `ToolTileComponent` to determine which tool component will be rendered (a tool component is the unique React parent component created for each tool tile type). A tool component for each tool tile type is imported into `ToolTileComponent` and conditionally rendered based on the tool tile type.

--- a/tool-tiles.md
+++ b/tool-tiles.md
@@ -36,6 +36,16 @@ export const ToolContentUnion = types.union(
 
 We also specify `ToolTileModel`, a general content model which is the base content model used by all tool tiles. This model contains a `content` property of type `ToolContentUnion`. This allows us to access the `content` property of `ToolTileModel` for any tile, cast it to the unique content model for that tile, and then access properties and methods specific to that tile type.
 
+### ToolMetadataModel
+
+Each tile content model can use a metadata model. This is used to store information that is shared across multiple instances of a document. It is also preserved across reloads. 
+
+When a tool is registered it provides a metadata MST "class". When needed the metadata is looked up in a global map from tile id to metadata instance. If a metadata instance is not found, then one is created and added for this tile id. This code is in `tool-types.ts`.
+
+The metadata is provided to the tile content model via a `doPostCreate` action called on the tile content model.
+
+**NOTE**: If the same tile id is used in different documents, they will share the same metadata instance. This is uncommon with user created documents tile ids are random strings. When a document is copied its tile ids are updated to new random strings (**TODO** is this true?). However it can happen with authored content, and there is nothing preventing multiple documents from being stored in the database with duplicate tile ids.
+
 ## ToolTileComponent
 `ToolTileComponent` is a React component that serves as the main container for each tile. Tool tile types are used in `ToolTileComponent` to determine which tool component will be rendered (a tool component is the unique React parent component created for each tool tile type). A tool component for each tool tile type is imported into `ToolTileComponent` and conditionally rendered based on the tool tile type.
 ```typescript


### PR DESCRIPTION
This adds documentation on:
- tile metadata: how a tile can use it, and a caveat about it
- document registry: this is the DocumentsModel, it describes the two instances of this and how they are setup. It also explores the issue of duplicate document instances for the same document in the database.

It removes an unused action called `update`.

It fixes an issue with `window.currentDocument` which is useful for debugging.