### PR TITLE
Make import of problem configuration more robust

### DIFF
--- a/src/models/curriculum/problem.test.ts
+++ b/src/models/curriculum/problem.test.ts
@@ -103,4 +103,70 @@ describe("problem model", () => {
     expect(lastSection.type).toBe("initialChallenge");
 
   });
+
+  it("can import legacy snapshots", () => {
+    const problem = ProblemModel.create({
+      ordinal: 1,
+      title: "Test",
+      disabled: ["foo"],
+      settings: { foo: "bar" }
+    });
+    expect(problem).toEqual({
+      ordinal: 1,
+      title: "Test",
+      subtitle: "",
+      sections: [],
+      supports: [],
+      config: {
+        disabledFeatures: ["foo"],
+        settings: { foo: "bar" }
+      }
+    });
+  });
+
+  it("can import mixed legacy/modern snapshots", () => {
+    const problem = ProblemModel.create({
+      ordinal: 1,
+      title: "Test",
+      disabled: ["foo"],
+      config: {
+        settings: { foo: "bar" }
+      }
+    });
+    expect(problem).toEqual({
+      ordinal: 1,
+      title: "Test",
+      subtitle: "",
+      sections: [],
+      supports: [],
+      config: {
+        disabledFeatures: ["foo"],
+        settings: { foo: "bar" }
+      }
+    });
+  });
+
+  it("prioritizes modern config when importing mixed legacy/modern snapshots", () => {
+    const problem = ProblemModel.create({
+      ordinal: 1,
+      title: "Test",
+      disabled: ["roo"],
+      settings: { roo: "baz"},
+      config: {
+        disabledFeatures: ["foo"],
+        settings: { foo: "bar" }
+      }
+    });
+    expect(problem).toEqual({
+      ordinal: 1,
+      title: "Test",
+      subtitle: "",
+      sections: [],
+      supports: [],
+      config: {
+        disabledFeatures: ["foo"],
+        settings: { foo: "bar" }
+      }
+    });
+  });
 });

--- a/src/models/curriculum/problem.ts
+++ b/src/models/curriculum/problem.ts
@@ -39,18 +39,15 @@ const ModernProblemModel = types
 interface LegacySnapshot extends SnapshotIn<typeof LegacyProblemModel> {}
 interface ModernSnapshot extends SnapshotIn<typeof ModernProblemModel> {}
 
-const isLegacySnapshot = (sn: ModernSnapshot | LegacySnapshot): sn is LegacySnapshot => {
-  const s = sn as LegacySnapshot;
-  return !!s.disabled || !!s.settings;
-};
-
 export const ProblemModel = types.snapshotProcessor(ModernProblemModel, {
-  preProcessor(sn: ModernSnapshot | LegacySnapshot) {
-    if (isLegacySnapshot(sn)) {
-      const { disabled: disabledFeatures, settings, ...others } = sn;
-      return { ...others, config: { disabledFeatures, settings } };
-    }
-    return sn;
+  preProcessor(sn: ModernSnapshot & LegacySnapshot) {
+    const { disabled: _disabled, settings: _settings, config: _config, ...others } = sn;
+    const disabledFeatures = _disabled ? { disabledFeatures: _disabled } : undefined;
+    const settings = _settings ? { settings: _settings } : undefined;
+    const config = _config || disabledFeatures || settings
+                    ? { config: { ...disabledFeatures, ...settings, ..._config } }
+                    : undefined;
+    return { ...others, ...config };
   }
 });
 export interface ProblemModelType extends Instance<typeof ModernProblemModel> {}


### PR DESCRIPTION
Previously, if a `ProblemModel` encountered a configuration which had both legacy and modern properties, it would import it as though it were a legacy configuration, thus ignoring the modern properties, which led to confusion when authoring.

With this PR we now merge the legacy and modern properties with the modern configuration taking precedence in case of conflict.