### PR TITLE
Only store completed entries in the real history

### DIFF
--- a/src/models/history/tree-manager.ts
+++ b/src/models/history/tree-manager.ts
@@ -1,10 +1,10 @@
 import {
-  types, Instance, flow, IJsonPatch, isAlive, detach, destroy
+  types, Instance, flow, IJsonPatch, detach, destroy
 } from "mobx-state-tree";
 import { nanoid } from "nanoid";
 import { TreeAPI } from "./tree-api";
 import { IUndoManager, UndoStore } from "./undo-store";
-import { TreePatchRecord, HistoryEntry, TreePatchRecordSnapshot, HistoryOperation, HistoryEntryType } from "./history";
+import { TreePatchRecord, HistoryEntry, TreePatchRecordSnapshot, HistoryOperation } from "./history";
 import { DEBUG_HISTORY } from "../../lib/debug";
 
 /**

--- a/src/models/history/tree-manager.ts
+++ b/src/models/history/tree-manager.ts
@@ -133,13 +133,12 @@ export const TreeManager = types
 
       // Add the entry to the undo stack if it is undoable.
       //
-      // TODO: is it best to wait until the entry is complete like this?
-      // It might be better to add it earlier so it has the right position
-      // in the undo stack. For example if a user action caused some async
-      // behavior that takes a while, should its place in the stack be at
-      // the beginning or end of these changes?
-      // If we add it earlier the undo stack will have incomplete entry 
-      // in it at least for a little while.
+      // TODO: Is it best to wait until the entry is complete like this? It
+      // might be better to add it earlier so it has the right position in the
+      // undo stack. For example if a user action caused some async behavior
+      // that takes a while, should its place in the stack be at the beginning
+      // or end of these changes? As a downside, if we add it earlier the undo
+      // stack will have incomplete entries in sometimes.
       if (entry.undoable) {
         self.undoStore.addHistoryEntry(entry);
       }


### PR DESCRIPTION
When an entry is incomplete (active) it is stored in activeHistoryEntries.
When all of the activeExchanges are ended and it has patches, then it is added to the real history and the undo stack.

I first tried using volatile for activeHistoryEntries.  But that meant that it couldn't be modified by the TreeManager actions since it was a MST object that wasn't part of the same MST tree as the TreeManager.

So instead it is part of the actual model state. When we serialize the history we'll only serialize the treeManager.document object, so these incomplete entries will not be saved too.