### PR TITLE
181363573 publish document versioning bug

### DIFF
--- a/src/components/thumbnail/decorated-document-thumbnail-item.tsx
+++ b/src/components/thumbnail/decorated-document-thumbnail-item.tsx
@@ -30,10 +30,10 @@ function useDocumentCaption(document: DocumentModelType) {
   const classStore = useClassStore();
   const user = useUserStore();
   const { type, uid } = document;
+  const pubVersion = document.pubVersion;
   const teacher = useFirestoreTeacher(uid, user.network || "");
   if (type === SupportPublication) {
     const caption = document.getProperty("caption") || "Support";
-    const pubVersion = document.pubVersion;
     return pubVersion ? `${caption} v${pubVersion}` : `${caption}`;
   }
   const userName = classStore.getUserById(uid)?.displayName || teacher?.name ||
@@ -41,8 +41,8 @@ function useDocumentCaption(document: DocumentModelType) {
   const namePrefix = document.isRemote || isPublishedType(type) ? `${userName}: ` : "";
   const dateSuffix = document.isRemote && document.createdAt
                       ? ` (${new Date(document.createdAt).toLocaleDateString()})`
-                      : isPublishedType(type)
-                          ? ` v${document.pubVersion}`
+                      : isPublishedType(type) && pubVersion
+                          ? ` v${pubVersion}`
                           : "";
   const title = getDocumentDisplayTitle(document, appConfig, problem);
   return `${namePrefix}${title}${dateSuffix}`;

--- a/src/components/thumbnail/documents-type-collection.tsx
+++ b/src/components/thumbnail/documents-type-collection.tsx
@@ -110,7 +110,7 @@ export const DocumentCollectionByType = observer(({ topTab, tab, section, index,
     <div className={tabPanelDocumentSectionClass}
           key={`${tab}-${section.type}`}
           data-test={`${section.dataTestHeader}-documents`}>
-      {(classStore.isTeacher(sectionDocs[0]?.uid) && topTab === ENavTab.kClassWork)
+      {(classStore.isTeacher(sectionDocs[0]?.uid) && topTab === ENavTab.kClassWork && !isBottomPanel)
         && <div className="document-divider">
               <div className="document-divider-label">Teacher Documents</div>
            </div>


### PR DESCRIPTION
Fixes bug where previously unversioned published documents show "vundefined" in the footer title.
Fixes document sectioning in Classwork tab for teacher documents. This should now look like this
<img width="1456" alt="image" src="https://user-images.githubusercontent.com/7716653/186528113-4a44326a-4183-45df-bad8-e55822b910a5.png">
