### PR TITLE
Release tweaks -- DataCard, warnings

### DIFF
--- a/src/models/tools/geometry/geometry-content.ts
+++ b/src/models/tools/geometry/geometry-content.ts
@@ -1163,7 +1163,7 @@ export const GeometryContentModel = GeometryBaseContentModel
       {name: "sharedModelSetup", fireImmediately: true}));
     },
     updateAfterSharedModelChanges(sharedModel?: SharedModelType) {
-      console.warn("updateAfterSharedModelChanges hasn't been implemented for geometry content.");
+      // console.warn("updateAfterSharedModelChanges hasn't been implemented for geometry content.");
     },
     syncLinkedChange(dataSet: IDataSet, links: ITableLinkProperties) {
       // TODO: handle update

--- a/src/models/tools/table/table-content.ts
+++ b/src/models/tools/table/table-content.ts
@@ -305,7 +305,7 @@ export const TableContentModel = ToolContentModel
       {name: "sharedModelSetup", fireImmediately: true}));
     },
     updateAfterSharedModelChanges(sharedModel?: SharedModelType) {
-      console.warn("updateAfterSharedModelChanges hasn't been implemented for table content.");
+      // console.warn("updateAfterSharedModelChanges hasn't been implemented for table content.");
 
       // TODO This was moved from doPostCreate and might need to be rethought.
       // if (self.dataSet.attributes.length >= 2) {

--- a/src/plugins/data-card-tool/components/case-attribute.tsx
+++ b/src/plugins/data-card-tool/components/case-attribute.tsx
@@ -135,7 +135,7 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
 
   return (
     <div className={pairClassNames}>
-      <div className={labelClassNames} onClick={handleClick}>
+      <div className={labelClassNames} onClick={handleClick} onDoubleClick={handleDoubleClick}>
         { !readOnly && editFacet === "name"
           ? <input
               type="text"

--- a/src/plugins/data-card-tool/data-card-content.ts
+++ b/src/plugins/data-card-tool/data-card-content.ts
@@ -11,7 +11,6 @@ import {
 import { SharedDataSet, SharedDataSetType } from "../../models/tools/shared-data-set";
 import { SharedModelType } from "../../models/tools/shared-model";
 import { uniqueId, uniqueTitle } from "../../utilities/js-utils";
-import { ControlReteNodeFactory } from "../dataflow-tool/nodes/factories/control-rete-node-factory";
 
 export function defaultDataSet() {
   // as per slack discussion, default attribute is added automatically

--- a/src/plugins/drawing-tool/model/drawing-content.ts
+++ b/src/plugins/drawing-tool/model/drawing-content.ts
@@ -241,7 +241,7 @@ export const DrawingContentModel = ToolContentModel
   })
   .actions(self => ({
     updateAfterSharedModelChanges() {
-      console.warn("TODO: need to implement yet");
+      // console.warn("TODO: need to implement yet");
     }
   }));
 
@@ -270,4 +270,3 @@ export function defaultDrawingContent(options?: IDefaultContentOptions) {
   }
   return createDrawingContent({ stamps });
 }
-

--- a/src/public/curriculum/example-curriculum/example-curriculum.json
+++ b/src/public/curriculum/example-curriculum/example-curriculum.json
@@ -44,6 +44,11 @@
         "isTileTool": true
       },
       {
+        "id": "DataCard",
+        "title": "Data Card",
+        "isTileTool": true
+      },
+      {
         "id": "Drawing",
         "title": "Drawing",
         "isTileTool": true

--- a/src/public/curriculum/mothed/mothed.json
+++ b/src/public/curriculum/mothed/mothed.json
@@ -45,11 +45,6 @@
         "isTileTool": true
       },
       {
-        "id": "DataCard",
-        "title": "Data Card",
-        "isTileTool": true
-      },
-      {
         "id": "Image",
         "title": "Image",
         "isTileTool": true


### PR DESCRIPTION
DataCard
- fix label editing
- remove from MothEd curriculum unit
- add to example curriculum unit

Comment out noisy console warnings from `updateAfterSharedModelChanges()`

Eliminate unused import