### PR TITLE
183040970 data card delete modal

### DIFF
--- a/src/plugins/data-card-tool/components/case-attribute.tsx
+++ b/src/plugins/data-card-tool/components/case-attribute.tsx
@@ -112,7 +112,7 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
   };
 
   const handleDeleteAttribute = () => {
-    // confirmation dialogue
+    // confirmation dialog
   };
 
   const pairClassNames = classNames(

--- a/src/plugins/data-card-tool/components/case-attribute.tsx
+++ b/src/plugins/data-card-tool/components/case-attribute.tsx
@@ -5,6 +5,7 @@ import { gImageMap } from "../../../models/image-map";
 import { ToolTileModelType } from "../../../models/tools/tool-tile";
 import { DataCardContentModelType } from "../data-card-content";
 import { looksLikeDefaultLabel } from "../data-card-types";
+import { RemoveIconButton } from "./add-remove-icons";
 
 import '../data-card-tool.scss';
 
@@ -110,6 +111,10 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
     setCurrEditAttrId(attrKey);
   };
 
+  const handleDeleteAttribute = () => {
+    alert('ask user for confirmation...');
+  };
+
   const pairClassNames = classNames(
     `attribute-name-value-pair ${attrKey}`,
     {"editing": editFacet === "name" || "value"}
@@ -123,6 +128,11 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
   const valueClassNames = classNames(
     `value ${attrKey}`,
     { "editing": editFacet === "value" }
+  );
+
+  const deleteAttrButtonClassNames = classNames(
+    `delete-attribute ${attrKey}`,
+    { "show": editFacet === "value" || editFacet === "name" }
   );
 
   const isDefaultLabel = looksLikeDefaultLabel(getLabel());
@@ -165,6 +175,7 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
             : <div className="cell-value">{valueStr}</div>
         }
       </div>
+        <RemoveIconButton className={deleteAttrButtonClassNames} onClick={handleDeleteAttribute} />
     </div>
   );
 });

--- a/src/plugins/data-card-tool/components/case-attribute.tsx
+++ b/src/plugins/data-card-tool/components/case-attribute.tsx
@@ -175,7 +175,7 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
             : <div className="cell-value">{valueStr}</div>
         }
       </div>
-        <RemoveIconButton className={deleteAttrButtonClassNames} onClick={handleDeleteAttribute} />
+      <RemoveIconButton className={deleteAttrButtonClassNames} onClick={handleDeleteAttribute} />
     </div>
   );
 });

--- a/src/plugins/data-card-tool/components/case-attribute.tsx
+++ b/src/plugins/data-card-tool/components/case-attribute.tsx
@@ -112,7 +112,7 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
   };
 
   const handleDeleteAttribute = () => {
-    alert('ask user for confirmation...');
+    // confirmation dialogue
   };
 
   const pairClassNames = classNames(

--- a/src/plugins/data-card-tool/data-card-content.ts
+++ b/src/plugins/data-card-tool/data-card-content.ts
@@ -105,7 +105,8 @@ export const DataCardContentModel = ToolContentModel
     isEmptyCase(caseId: string){
       let attributesWithValues = 0;
       this.existingAttributes().forEach((attr) => {
-        if (self.dataSet.getValue(caseId, attr) !== "" || undefined){
+        const value = self.dataSet.getValue(caseId, attr);
+        if (value !== "" && value != null) {
           attributesWithValues++;
         }
       });

--- a/src/plugins/data-card-tool/data-card-content.ts
+++ b/src/plugins/data-card-tool/data-card-content.ts
@@ -102,6 +102,15 @@ export const DataCardContentModel = ToolContentModel
     attrById(str: string){
       return self.dataSet.attrFromID(str);
     },
+    isCaseWithNoValues(caseId: string){
+      let empties = 0;
+      this.existingAttributes().forEach((attr) => {
+        if (self.dataSet.getValue(caseId, attr) === "" || undefined){
+          empties++;
+        }
+      });
+      return empties !== 0;
+    },
     exportJson(options?: ITileExportOptions){
       this.allAttributesJsonString();
       return [

--- a/src/plugins/data-card-tool/data-card-content.ts
+++ b/src/plugins/data-card-tool/data-card-content.ts
@@ -102,14 +102,14 @@ export const DataCardContentModel = ToolContentModel
     attrById(str: string){
       return self.dataSet.attrFromID(str);
     },
-    isCaseWithNoValues(caseId: string){
-      let empties = 0;
+    isEmptyCase(caseId: string){
+      let attributesWithValues = 0;
       this.existingAttributes().forEach((attr) => {
-        if (self.dataSet.getValue(caseId, attr) === "" || undefined){
-          empties++;
+        if (self.dataSet.getValue(caseId, attr) !== "" || undefined){
+          attributesWithValues++;
         }
       });
-      return empties !== 0;
+      return attributesWithValues === 0;
     },
     exportJson(options?: ITileExportOptions){
       this.allAttributesJsonString();

--- a/src/plugins/data-card-tool/data-card-tool.scss
+++ b/src/plugins/data-card-tool/data-card-tool.scss
@@ -212,9 +212,9 @@ $default-button-border-color: #979797;
       .delete-attribute {
         display:none;
         transform: translateX(30px);
-        &.show {
-          display: block;
-        }
+        // &.show {
+        //   display: block;
+        // }
       }
 
       input {

--- a/src/plugins/data-card-tool/data-card-tool.scss
+++ b/src/plugins/data-card-tool/data-card-tool.scss
@@ -209,6 +209,14 @@ $default-button-border-color: #979797;
         }
       }
 
+      .delete-attribute {
+        display:none;
+        transform: translateX(30px);
+        &.show {
+          display: block;
+        }
+      }
+
       input {
         width: 100%;
         height: 100%;

--- a/src/plugins/data-card-tool/data-card-tool.test.tsx
+++ b/src/plugins/data-card-tool/data-card-tool.test.tsx
@@ -1,10 +1,10 @@
-import { render } from "@testing-library/react";
 import React from "react";
+import { render } from "@testing-library/react";
+import { ModalProvider } from "@concord-consortium/react-modal-hook";
 import { IToolApi } from "../../components/tools/tool-api";
 import { ToolTileModel } from "../../models/tools/tool-tile";
 import { defaultDataCardContent } from "./data-card-content";
 import { DataCardToolComponent } from "./data-card-tool";
-import { ModalProvider } from "@concord-consortium/react-modal-hook";
 
 // The data card tile needs to be registered so the ToolTileModel.create
 // knows it is a supported tile type

--- a/src/plugins/data-card-tool/data-card-tool.test.tsx
+++ b/src/plugins/data-card-tool/data-card-tool.test.tsx
@@ -4,6 +4,7 @@ import { IToolApi } from "../../components/tools/tool-api";
 import { ToolTileModel } from "../../models/tools/tool-tile";
 import { defaultDataCardContent } from "./data-card-content";
 import { DataCardToolComponent } from "./data-card-tool";
+import { ModalProvider } from "@concord-consortium/react-modal-hook";
 
 // The data card tile needs to be registered so the ToolTileModel.create
 // knows it is a supported tile type
@@ -51,7 +52,11 @@ describe("DataCardToolComponent", () => {
 
   it("renders successfully", () => {
     const {getByText} =
-      render(<DataCardToolComponent  {...defaultProps} {...{model}}></DataCardToolComponent>);
+      render(
+        <ModalProvider>
+          <DataCardToolComponent  {...defaultProps} {...{model}}></DataCardToolComponent>
+        </ModalProvider>
+      );
       expect(getByText("Data Card Collection 1")).toBeInTheDocument();
   });
 });

--- a/src/plugins/data-card-tool/data-card-tool.tsx
+++ b/src/plugins/data-card-tool/data-card-tool.tsx
@@ -89,7 +89,7 @@ export const DataCardToolComponent: React.FC<IToolTileProps> = observer((props) 
   }
 
   const AlertContent = () => {
-    return <p>Remove the current Data Card from the document?</p>;
+    return <p>Remove the current Data Card?</p>;
   };
 
   const [showAlert] = useCautionAlert({

--- a/src/plugins/data-card-tool/data-card-tool.tsx
+++ b/src/plugins/data-card-tool/data-card-tool.tsx
@@ -102,7 +102,7 @@ export const DataCardToolComponent: React.FC<IToolTileProps> = observer((props) 
   function handleDeleteCardClick(){
     const thisCaseId = content.dataSet.caseIDFromIndex(content.caseIndex);
     if (thisCaseId){
-      if (content.isCaseWithNoValues(thisCaseId)){
+      if (content.isEmptyCase(thisCaseId)){
         deleteCase();
       } else {
         showAlert();

--- a/src/plugins/data-card-tool/data-card-tool.tsx
+++ b/src/plugins/data-card-tool/data-card-tool.tsx
@@ -25,7 +25,6 @@ export const DataCardToolComponent: React.FC<IToolTileProps> = observer((props) 
   const shouldShowAddCase = !readOnly && isTileSelected;
   const shouldShowDeleteCase = !readOnly && isTileSelected && content.dataSet.cases.length > 1;
   const shouldShowAddField = !readOnly && isTileSelected;
-  // const shouldShowDeleteField = !readOnly && isTileSelected && content.dataSet.attributes.length > 1;
 
   useEffect(() => {
     if (!content.title) {
@@ -90,7 +89,7 @@ export const DataCardToolComponent: React.FC<IToolTileProps> = observer((props) 
   }
 
   const AlertContent = () => {
-    return <p>Remove the current Data Card from the document? This action is not undoable.</p>;
+    return <p>Remove the current Data Card from the document?</p>;
   };
 
   const [showAlert] = useCautionAlert({
@@ -99,6 +98,17 @@ export const DataCardToolComponent: React.FC<IToolTileProps> = observer((props) 
     confirmLabel: "Delete Card",
     onConfirm: () => deleteCase()
   });
+
+  function handleDeleteCardClick(){
+    const thisCaseId = content.dataSet.caseIDFromIndex(content.caseIndex);
+    if (thisCaseId){
+      if (content.isCaseWithNoValues(thisCaseId)){
+        deleteCase();
+      } else {
+        showAlert();
+      }
+    }
+  }
 
   const handleAddField = () => {
     content.addNewAttr();
@@ -153,7 +163,7 @@ export const DataCardToolComponent: React.FC<IToolTileProps> = observer((props) 
           </div>
           <div className="add-remove-card-buttons">
             <AddIconButton className={addCardClasses} onClick={addNewCase} />
-            <RemoveIconButton className={removeCardClasses} onClick={showAlert} />
+            <RemoveIconButton className={removeCardClasses} onClick={handleDeleteCardClick} />
           </div>
         </div>
       </div>

--- a/src/plugins/data-card-tool/data-card-tool.tsx
+++ b/src/plugins/data-card-tool/data-card-tool.tsx
@@ -8,6 +8,7 @@ import { DataCardRows } from "./components/data-card-rows";
 import { DataCardToolbar } from "./data-card-toolbar";
 import { useToolbarToolApi } from "../../components/tools/hooks/use-toolbar-tool-api";
 import { AddIconButton, RemoveIconButton } from "./components/add-remove-icons";
+import { useCautionAlert } from "../../components/utilities/use-caution-alert";
 
 import "./data-card-tool.scss";
 
@@ -81,13 +82,23 @@ export const DataCardToolComponent: React.FC<IToolTileProps> = observer((props) 
   }
 
   function deleteCase(){
-    // TODO modal (see src/components/delete-button)
     const thisCaseId = content.dataSet.caseIDFromIndex(content.caseIndex);
     if (thisCaseId) {
       content.dataSet.removeCases([thisCaseId]);
     }
     previousCase();
   }
+
+  const AlertContent = () => {
+    return <p>Remove the current Data Card from the document? This action is not undoable.</p>;
+  };
+
+  const [showAlert] = useCautionAlert({
+    title: "Delete Card",
+    content: AlertContent,
+    confirmLabel: "Delete Card",
+    onConfirm: () => deleteCase()
+  });
 
   const handleAddField = () => {
     content.addNewAttr();
@@ -142,7 +153,7 @@ export const DataCardToolComponent: React.FC<IToolTileProps> = observer((props) 
           </div>
           <div className="add-remove-card-buttons">
             <AddIconButton className={addCardClasses} onClick={addNewCase} />
-            <RemoveIconButton className={removeCardClasses} onClick={deleteCase} />
+            <RemoveIconButton className={removeCardClasses} onClick={showAlert} />
           </div>
         </div>
       </div>

--- a/src/plugins/data-card-tool/data-card-tool.tsx
+++ b/src/plugins/data-card-tool/data-card-tool.tsx
@@ -89,7 +89,7 @@ export const DataCardToolComponent: React.FC<IToolTileProps> = observer((props) 
   }
 
   const AlertContent = () => {
-    return <p>Remove the current Data Card?</p>;
+    return <p>Delete the current Data Card?</p>;
   };
 
   const [showAlert] = useCautionAlert({


### PR DESCRIPTION
 **1.  Adds confirmation dialogue to the delete card action on the Data Card**

In `data-card-content.ts`:
- a new view on the model, `isEmptyCase` can test for a case that has no value in any attribute.  This is used to determine whether or not the warning modal will need to show when a user takes action to delete a card.

In `data-card-tool.tsx`:
- the `useCautionAlert` hook is imported and used to create a `showAlert` function
- The `deleteCase` function was renamed `handleDeleteCardClick` as it does not necessarily delete.  It leverages the `isEmptyCase` test above: If the card has any values in any attributes, it puts up the alert.  If the card is empty of values, it deletes without interruption.
- an existing bit of setup work a commented out stub for `shouldShowDeleteField` was removed as that (still not completely implemented) functionality is moved into `case-attribute.tsx` (see item 2 below). 

In `data-card-tool.test.tsx`:
- The Tool Component is rendered within a `<ModalProvider>` so that `useCautionAlert` can be called within the test

**2. Adds initial setup work for the to-be-implemented delete attribute action.**  

In `case-attribute.tsx`:
- Inclusion of the `RemoveIconButton`
- Dynamic `show` class that is turned on when the attribute is being edited
- Binding of an empty `handleDeleteAtrribute` function to the button's `onClick` attribute

In `data-card-tool.scss`: 
- styles for laying out the button
- styles for the `show` class that will be implemented when attributes can be deleted

**3.Related To-Do**

- Work on this revealed a few bugs in the layout when text in either attribute name or attribute value is longer than the original width.  Those will be addressed in a separate PR
