### PR TITLE
182799776 data card delete attribute

### DIFF
--- a/src/plugins/data-card-tool/components/case-attribute.tsx
+++ b/src/plugins/data-card-tool/components/case-attribute.tsx
@@ -86,6 +86,7 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
   };
 
   const handleDoubleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    console.log("? handleDoubleClick: ", event);
     const [facet] = event.currentTarget.classList;
     activateInput(facet as EditFacet);
   };
@@ -140,7 +141,6 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
     confirmLabel: "Delete Attribute",
     onConfirm: () => deleteAttribute()
   });
-
 
   const handleDeleteAttribute = () => {
     showAlert();

--- a/src/plugins/data-card-tool/components/case-attribute.tsx
+++ b/src/plugins/data-card-tool/components/case-attribute.tsx
@@ -133,7 +133,7 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
   const AlertContent = () => {
     return (
       <p>
-        Are you sure you want to remove the (<b>{ getLabel() }</b>) attribute from the Data Card?
+        Are you sure you want to remove the <em style={{ fontWeight: "bold"}}>{ getLabel() }</em> attribute from the Data Card?
         If you remove it from this card it will delete the data in the field,
         and it will also be removed from all the Cards in this collection.
       </p>

--- a/src/plugins/data-card-tool/components/case-attribute.tsx
+++ b/src/plugins/data-card-tool/components/case-attribute.tsx
@@ -127,8 +127,8 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
   const AlertContent = () => {
     return (
       <p>
-        Are you sure you want to remove this attribute from the Data Card?
-        If you remove it from this card it will also be removed from all the Cards in this collection.
+        Are you sure you want to remove the (<b>"{ getLabel() }"</b>) attribute from the Data Card?
+        If you remove it from this card it will delete the data in the field and it will also be removed from all the Cards in this collection.
       </p>
     );
   };

--- a/src/plugins/data-card-tool/components/case-attribute.tsx
+++ b/src/plugins/data-card-tool/components/case-attribute.tsx
@@ -82,7 +82,8 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
 
   const handleClick = (event: React.MouseEvent<HTMLInputElement | HTMLDivElement>) => {
     setCurrEditAttrId(attrKey);
-    const [facet, id, editing] = event.currentTarget.classList;
+    const facet = event.currentTarget.classList[0];
+    const editing = event.currentTarget.classList[2];
     activateInput(facet as EditFacet, editing === "editing");
 
     // allow to toggle on and off highlight of all text
@@ -134,8 +135,8 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
   const AlertContent = () => {
     return (
       <p>
-        Are you sure you want to remove the <em style={{ fontWeight: "bold"}}>{ getLabel() }</em> attribute from the Data Card?
-        If you remove it from this card it will delete the data in the field,
+        Are you sure you want to remove the <em style={{ fontWeight: "bold"}}>{ getLabel() }</em>&nbsp;
+        attribute from the Data Card? If you remove it from this card it will delete the data in the field,
         and it will also be removed from all the Cards in this collection.
       </p>
     );

--- a/src/plugins/data-card-tool/components/case-attribute.tsx
+++ b/src/plugins/data-card-tool/components/case-attribute.tsx
@@ -37,9 +37,6 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
   const [editFacet, setEditFacet] = useState<EditFacet>("");
   const [imageUrl, setImageUrl] = useState("");
 
-  console.log("rendering: ", attrKey);
-
-
   useEffect(() => {
     if (currEditAttrId !== attrKey) {
       setEditFacet("");
@@ -81,24 +78,14 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
     caseId && content.setAttValue(caseId, attrKey, "");
   };
 
-  /**
-   *
-   * this is where you are right now...
-   * notice the second click event that "breaks" things is on the input
-   *
-   */
-  const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
-    console.log("HANDLE CLICK EVENT: ", event.target, event.currentTarget);
+  const handleClick = (event: any) => {
     setCurrEditAttrId(attrKey);
-    console.log("1 handleClick: attrKey:", attrKey);
     const [facet] = event.currentTarget.classList;
+    const isInput = event.target.className === "input";
     activateInput(facet as EditFacet);
-  };
-
-  const handleDoubleClick = (event: React.MouseEvent<HTMLDivElement>) => {
-    console.log("? handleDoubleClick: ", event);
-    // const [facet] = event.currentTarget.classList;
-    // activateInput(facet as EditFacet);
+    if (isInput){
+      event.target.select();
+    }
   };
 
   const handleNameBlur = () => {
@@ -116,7 +103,6 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
   };
 
   const activateInput = (facet: EditFacet) => {
-    console.log("2 start activateInput:", attrKey);
     setEditFacet(facet);
     if (facet === "name"){
       setLabelCandidate(getLabel());
@@ -125,7 +111,6 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
       setValueCandidate(getValue());
     }
     setCurrEditAttrId(attrKey);
-    console.log("3 finish activateInput:", attrKey);
   };
 
   function deleteAttribute(){
@@ -184,16 +169,13 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
        setImageUrl(image.displayUrl || "");
      });
 
-  function focusOne(e: any){
-    console.log(e);
-  }
-
   return (
     <div className={pairClassNames}>
-      <div className={labelClassNames} onClick={handleClick} onDoubleClick={handleDoubleClick}>
+      <div className={labelClassNames} onClick={handleClick}>
         { !readOnly && editFacet === "name"
           ? <input
               type="text"
+              className="input"
               value={labelCandidate}
               onChange={handleChange}
               onKeyDown={handleKeyDown}
@@ -203,10 +185,11 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
         }
       </div>
 
-      <div className={valueClassNames} onClick={handleClick} onDoubleClick={handleDoubleClick}>
+      <div className={valueClassNames} onClick={handleClick}>
         { editFacet === "value" && !readOnly
           ? <input
               type="text"
+              className="input"
               value={valueCandidate}
               onChange={handleChange}
               onKeyDown={handleKeyDown}
@@ -221,12 +204,6 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
         }
       </div>
       <RemoveIconButton className={deleteAttrButtonClassNames} onClick={handleDeleteAttribute} />
-      {/* <button onClick={focusOne} >Focus 1</button> */}
     </div>
   );
 });
-
-/**
- * When it goes to second stage of selection, delete it stops working
- * Why - what is that second stage of selection?
- */

--- a/src/plugins/data-card-tool/components/case-attribute.tsx
+++ b/src/plugins/data-card-tool/components/case-attribute.tsx
@@ -39,6 +39,7 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
 
   console.log("rendering: ", attrKey);
 
+
   useEffect(() => {
     if (currEditAttrId !== attrKey) {
       setEditFacet("");
@@ -80,15 +81,24 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
     caseId && content.setAttValue(caseId, attrKey, "");
   };
 
+  /**
+   *
+   * this is where you are right now...
+   * notice the second click event that "breaks" things is on the input
+   *
+   */
   const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    console.log("HANDLE CLICK EVENT: ", event.target, event.currentTarget);
     setCurrEditAttrId(attrKey);
     console.log("1 handleClick: attrKey:", attrKey);
+    const [facet] = event.currentTarget.classList;
+    activateInput(facet as EditFacet);
   };
 
   const handleDoubleClick = (event: React.MouseEvent<HTMLDivElement>) => {
     console.log("? handleDoubleClick: ", event);
-    const [facet] = event.currentTarget.classList;
-    activateInput(facet as EditFacet);
+    // const [facet] = event.currentTarget.classList;
+    // activateInput(facet as EditFacet);
   };
 
   const handleNameBlur = () => {
@@ -174,6 +184,10 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
        setImageUrl(image.displayUrl || "");
      });
 
+  function focusOne(e: any){
+    console.log(e);
+  }
+
   return (
     <div className={pairClassNames}>
       <div className={labelClassNames} onClick={handleClick} onDoubleClick={handleDoubleClick}>
@@ -207,6 +221,12 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
         }
       </div>
       <RemoveIconButton className={deleteAttrButtonClassNames} onClick={handleDeleteAttribute} />
+      {/* <button onClick={focusOne} >Focus 1</button> */}
     </div>
   );
 });
+
+/**
+ * When it goes to second stage of selection, delete it stops working
+ * Why - what is that second stage of selection?
+ */

--- a/src/plugins/data-card-tool/components/case-attribute.tsx
+++ b/src/plugins/data-card-tool/components/case-attribute.tsx
@@ -37,7 +37,7 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
   const [editFacet, setEditFacet] = useState<EditFacet>("");
   const [imageUrl, setImageUrl] = useState("");
 
-  console.log("rendering: ", attrKey)
+  console.log("rendering: ", attrKey);
 
   useEffect(() => {
     if (currEditAttrId !== attrKey) {
@@ -118,7 +118,7 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
   };
 
   function deleteAttribute(){
-    console.log("? deleteAttribute: ", attrKey)
+    console.log("? deleteAttribute: ", attrKey);
     if(attrKey){
       content.dataSet.removeAttribute(attrKey);
     }
@@ -127,8 +127,9 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
   const AlertContent = () => {
     return (
       <p>
-        Are you sure you want to remove the (<b>"{ getLabel() }"</b>) attribute from the Data Card?
-        If you remove it from this card it will delete the data in the field and it will also be removed from all the Cards in this collection.
+        Are you sure you want to remove the (<b>{ getLabel() }</b>) attribute from the Data Card?
+        If you remove it from this card it will delete the data in the field,
+        and it will also be removed from all the Cards in this collection.
       </p>
     );
   };

--- a/src/plugins/data-card-tool/components/case-attribute.tsx
+++ b/src/plugins/data-card-tool/components/case-attribute.tsx
@@ -78,11 +78,11 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
     caseId && content.setAttValue(caseId, attrKey, "");
   };
 
+
   const handleClick = (event: React.MouseEvent<HTMLInputElement | HTMLDivElement>) => {
     setCurrEditAttrId(attrKey);
     const [facet, id, editing] = event.currentTarget.classList;
     activateInput(facet as EditFacet, editing === "editing");
-
     // allow to toggle on and off highlight of all text
     const myInput = event.currentTarget.children[0] as HTMLInputElement;
     if(myInput.tagName === "INPUT"){
@@ -153,7 +153,8 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
 
   const pairClassNames = classNames(
     `attribute-name-value-pair ${attrKey}`,
-    {"editing": editFacet === "name" || "value"}
+    {"editing": editFacet === "name" || "value"},
+    {"has-image": gImageMap.isImageUrl(valueStr)}
   );
 
   const labelClassNames = classNames(
@@ -197,7 +198,8 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
       </div>
 
       <div className={valueClassNames} onClick={handleClick}>
-        { editFacet === "value" && !readOnly
+        {/* TODO - image delete */}
+        { editFacet === "value" && !readOnly // && !gImageMap.isImageUrl(valueStr)
           ? <input
               type="text"
               className="input"

--- a/src/plugins/data-card-tool/components/case-attribute.tsx
+++ b/src/plugins/data-card-tool/components/case-attribute.tsx
@@ -59,6 +59,7 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
     switch (key) {
       case "Enter":
         handleCompleteValue();
+        handleCompleteName();
         setEditFacet("");
         break;
       case "Escape":
@@ -83,6 +84,7 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
     setCurrEditAttrId(attrKey);
     const [facet, id, editing] = event.currentTarget.classList;
     activateInput(facet as EditFacet, editing === "editing");
+
     // allow to toggle on and off highlight of all text
     const myInput = event.currentTarget.children[0] as HTMLInputElement;
     if(myInput.tagName === "INPUT"){
@@ -98,9 +100,9 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
     event.currentTarget.select();
   };
 
-  const handleNameBlur = () => {
+  const handleCompleteName = () => {
     if (labelCandidate !== getLabel()) {
-      content.setAttName(attrKey, labelCandidate);
+      caseId && content.setAttName(attrKey, labelCandidate);
     }
     setEditFacet("");
   };
@@ -124,7 +126,6 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
   };
 
   function deleteAttribute(){
-    console.log("? deleteAttribute: ", attrKey);
     if(attrKey){
       content.dataSet.removeAttribute(attrKey);
     }
@@ -153,7 +154,7 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
 
   const pairClassNames = classNames(
     `attribute-name-value-pair ${attrKey}`,
-    {"editing": editFacet === "name" || "value"},
+    {"editing": editFacet === "name" || editFacet === "value"},
     {"has-image": gImageMap.isImageUrl(valueStr)}
   );
 
@@ -190,7 +191,7 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
               value={labelCandidate}
               onChange={handleChange}
               onKeyDown={handleKeyDown}
-              onBlur={handleNameBlur}
+              onBlur={handleCompleteName}
               onDoubleClick={handleInputDoubleClick}
             />
           : <div className={cellLabelClasses}>{getLabel()}</div>

--- a/src/plugins/data-card-tool/components/case-attribute.tsx
+++ b/src/plugins/data-card-tool/components/case-attribute.tsx
@@ -37,6 +37,10 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
   const [editFacet, setEditFacet] = useState<EditFacet>("");
   const [imageUrl, setImageUrl] = useState("");
 
+  /** TODO
+   *  make title act the same way
+   */
+
   useEffect(() => {
     if (currEditAttrId !== attrKey) {
       setEditFacet("");
@@ -78,15 +82,26 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
     caseId && content.setAttValue(caseId, attrKey, "");
   };
 
-  const handleClick = (event: any) => {
+  const handleClick = (event: React.MouseEvent<HTMLInputElement | HTMLDivElement>) => {
     setCurrEditAttrId(attrKey);
-    const [facet] = event.currentTarget.classList;
-    const isInput = event.target.className === "input";
-    activateInput(facet as EditFacet);
-    if (isInput){
-      event.target.select();
+    const [facet, id, editing] = event.currentTarget.classList;
+    activateInput(facet as EditFacet, editing === "editing");
+
+    // allow to toggle on and off highlight of all text
+    const childEl = event.currentTarget.children[0] as any;
+    if(childEl.tagName === "INPUT"){
+      const myInput = childEl as HTMLInputElement;
+      const isHighlighted = myInput.selectionStart === 0;
+      const valLength = myInput.value.length;
+      if (isHighlighted && valLength > 0){
+        myInput.setSelectionRange(valLength, valLength, "forward");
+      }
     }
   };
+
+  const handleInputDoubleClick = (event: React.MouseEvent<HTMLInputElement>) => {
+    event.currentTarget.select();
+  }
 
   const handleNameBlur = () => {
     if (labelCandidate !== getLabel()) {
@@ -102,12 +117,12 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
     setEditFacet("");
   };
 
-  const activateInput = (facet: EditFacet) => {
+  const activateInput = (facet: EditFacet, editing: boolean) => {
     setEditFacet(facet);
-    if (facet === "name"){
+    if (facet === "name" && !editing){
       setLabelCandidate(getLabel());
     }
-    if (facet === "value"){
+    if (facet === "value" && !editing){
       setValueCandidate(getValue());
     }
     setCurrEditAttrId(attrKey);
@@ -180,6 +195,7 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
               onChange={handleChange}
               onKeyDown={handleKeyDown}
               onBlur={handleNameBlur}
+              onDoubleClick={handleInputDoubleClick}
             />
           : <div className={cellLabelClasses}>{getLabel()}</div>
         }
@@ -194,6 +210,7 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
               onChange={handleChange}
               onKeyDown={handleKeyDown}
               onBlur={handleCompleteValue}
+              onDoubleClick={handleInputDoubleClick}
             />
           : gImageMap.isImageUrl(valueStr)
             ?   <div className="image-wrapper">

--- a/src/plugins/data-card-tool/components/case-attribute.tsx
+++ b/src/plugins/data-card-tool/components/case-attribute.tsx
@@ -37,10 +37,6 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
   const [editFacet, setEditFacet] = useState<EditFacet>("");
   const [imageUrl, setImageUrl] = useState("");
 
-  /** TODO
-   *  make title act the same way
-   */
-
   useEffect(() => {
     if (currEditAttrId !== attrKey) {
       setEditFacet("");
@@ -88,9 +84,8 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
     activateInput(facet as EditFacet, editing === "editing");
 
     // allow to toggle on and off highlight of all text
-    const childEl = event.currentTarget.children[0] as any;
-    if(childEl.tagName === "INPUT"){
-      const myInput = childEl as HTMLInputElement;
+    const myInput = event.currentTarget.children[0] as HTMLInputElement;
+    if(myInput.tagName === "INPUT"){
       const isHighlighted = myInput.selectionStart === 0;
       const valLength = myInput.value.length;
       if (isHighlighted && valLength > 0){
@@ -101,7 +96,7 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
 
   const handleInputDoubleClick = (event: React.MouseEvent<HTMLInputElement>) => {
     event.currentTarget.select();
-  }
+  };
 
   const handleNameBlur = () => {
     if (labelCandidate !== getLabel()) {

--- a/src/plugins/data-card-tool/components/case-attribute.tsx
+++ b/src/plugins/data-card-tool/components/case-attribute.tsx
@@ -6,6 +6,7 @@ import { ToolTileModelType } from "../../../models/tools/tool-tile";
 import { DataCardContentModelType } from "../data-card-content";
 import { looksLikeDefaultLabel } from "../data-card-types";
 import { RemoveIconButton } from "./add-remove-icons";
+import { useCautionAlert } from "../../../components/utilities/use-caution-alert";
 
 import '../data-card-tool.scss';
 
@@ -35,6 +36,8 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
   const [valueCandidate, setValueCandidate] = useState(() => getValue());
   const [editFacet, setEditFacet] = useState<EditFacet>("");
   const [imageUrl, setImageUrl] = useState("");
+
+  console.log("rendering: ", attrKey)
 
   useEffect(() => {
     if (currEditAttrId !== attrKey) {
@@ -79,6 +82,7 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
 
   const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
     setCurrEditAttrId(attrKey);
+    console.log("1 handleClick: attrKey:", attrKey);
   };
 
   const handleDoubleClick = (event: React.MouseEvent<HTMLDivElement>) => {
@@ -101,6 +105,7 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
   };
 
   const activateInput = (facet: EditFacet) => {
+    console.log("2 start activateInput:", attrKey);
     setEditFacet(facet);
     if (facet === "name"){
       setLabelCandidate(getLabel());
@@ -109,10 +114,35 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
       setValueCandidate(getValue());
     }
     setCurrEditAttrId(attrKey);
+    console.log("3 finish activateInput:", attrKey);
   };
 
+  function deleteAttribute(){
+    console.log("? deleteAttribute: ", attrKey)
+    if(attrKey){
+      content.dataSet.removeAttribute(attrKey);
+    }
+  }
+
+  const AlertContent = () => {
+    return (
+      <p>
+        Are you sure you want to remove this attribute from the Data Card?
+        If you remove it from this card it will also be removed from all the Cards in this collection.
+      </p>
+    );
+  };
+
+  const [showAlert] = useCautionAlert({
+    title: "Delete Attribute",
+    content: AlertContent,
+    confirmLabel: "Delete Attribute",
+    onConfirm: () => deleteAttribute()
+  });
+
+
   const handleDeleteAttribute = () => {
-    // confirmation dialog
+    showAlert();
   };
 
   const pairClassNames = classNames(

--- a/src/plugins/data-card-tool/data-card-tool.scss
+++ b/src/plugins/data-card-tool/data-card-tool.scss
@@ -133,8 +133,6 @@ $default-button-border-color: #979797;
           fill:$workspace-teal;
           height:24px;
           width:24px;
-          // transform: translateX(-6px);
-          // border-radius:26px;
           &:hover {
             background-color: $workspace-teal-light-3;
           }
@@ -224,15 +222,17 @@ $default-button-border-color: #979797;
         padding: $cell-padding;
         font-style: normal;
         font-weight: 300;
-        border: 2px solid black;
+        border: 0px;
         background-color: $workspace-teal-light-8;
         font-family: Lato;
-        &:focus {
-          outline: 1px solid red;
-        }
+        outline: 0;
       }
       .name input {
         text-align: right;
+      }
+
+      .editing input {
+        border: 2px solid $highlight-blue;
       }
     }
 

--- a/src/plugins/data-card-tool/data-card-tool.scss
+++ b/src/plugins/data-card-tool/data-card-tool.scss
@@ -234,6 +234,10 @@ $default-button-border-color: #979797;
       .editing input {
         border: 2px solid $highlight-blue;
       }
+
+      .value .cell-value:hover {
+        background:rgba(245, 245, 245);
+      }
     }
 
     /* when attribute is in "about to be created" state */

--- a/src/plugins/data-card-tool/data-card-tool.scss
+++ b/src/plugins/data-card-tool/data-card-tool.scss
@@ -210,11 +210,12 @@ $default-button-border-color: #979797;
       }
 
       .delete-attribute {
+        position: absolute;
         display:none;
-        transform: translateX(30px);
-        // &.show {
-        //   display: block;
-        // }
+        transform: translateX(351px);
+        &.show {
+          display: inherit;
+        }
       }
 
       input {

--- a/src/plugins/data-card-tool/data-card-tool.scss
+++ b/src/plugins/data-card-tool/data-card-tool.scss
@@ -52,6 +52,7 @@ $default-button-border-color: #979797;
         font-style: normal;
         font-weight: 300;
         text-align: center;
+        outline:1px solid $highlight-blue;
       }
     }
     .panel.nav {
@@ -125,7 +126,6 @@ $default-button-border-color: #979797;
         border:none;
         margin-top:1px;
         padding:0px;
-        // position: relative;
         left:9px;
         top:1px;
 

--- a/src/plugins/data-card-tool/data-card-tool.scss
+++ b/src/plugins/data-card-tool/data-card-tool.scss
@@ -224,11 +224,11 @@ $default-button-border-color: #979797;
         padding: $cell-padding;
         font-style: normal;
         font-weight: 300;
-        border: none;
+        border: 2px solid black;
         background-color: $workspace-teal-light-8;
         font-family: Lato;
         &:focus {
-          outline: 1px solid blue;
+          outline: 1px solid red;
         }
       }
       .name input {

--- a/src/plugins/data-card-tool/data-card-tool.tsx
+++ b/src/plugins/data-card-tool/data-card-tool.tsx
@@ -55,6 +55,19 @@ export const DataCardToolComponent: React.FC<IToolTileProps> = observer((props) 
     }
   };
 
+  const handleTitleInputClick = (event: React.MouseEvent<HTMLInputElement>) => {
+    event.currentTarget.focus();
+    const isHighlighted = event.currentTarget.selectionStart === 0;
+    const valLength = event.currentTarget.value.length;
+    if (isHighlighted && valLength > 0){
+        event.currentTarget.setSelectionRange(valLength, valLength, "forward");
+    }
+  };
+
+  const handleTitleInputDoubleClick = (event: React.MouseEvent<HTMLInputElement>) => {
+    event.currentTarget.select();
+  };
+
   const handleTitleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     switch (event.key) {
       case "Enter":
@@ -143,6 +156,8 @@ export const DataCardToolComponent: React.FC<IToolTileProps> = observer((props) 
               onChange={handleTitleChange}
               onKeyDown={handleTitleKeyDown}
               onBlur={handleCompleteTitle}
+              onClick={handleTitleInputClick}
+              onDoubleClick={handleTitleInputDoubleClick}
           />
           : <div className="editable-data-card-title-text" onClick={handleTitleClick}>
               { content.title }


### PR DESCRIPTION
**This PR adds** 
- Functionality for deleting an attribute from a Data Card
- Fixes for the look of an active/editing value in the Data Card title, and the Data Card attribute title and value

**UI Notes:**

on the _existing_ table tile:
- a single click in a cell results in a blue outline
- the next single click OR double-click highlights the entire current value
- a double-click highlights the entire current value

in this PR, on the Data Card:
- the above behavior is replicated
- additionally, a single click on an entirely-highlighted value will result in an active cursor at the end of the value string

**Note on related features in progress**
- This PR does not address some layout issues that exist on the Data Card in terms of column width and text wrapping
- This PR does not address the image edit/delete workflow