### PR TITLE
switch to real button elements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
   cypress:
     runs-on: ubuntu-latest
+    container: cypress/browsers:node16.14.2-slim-chrome103-ff102
     strategy:
       # when one test fails, DO NOT cancel the other
       # containers, because this will kill Cypress processes

--- a/cypress/e2e/clue/branch/student_tests/drawing_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/drawing_tool_spec.js
@@ -234,11 +234,22 @@ context('Draw Tool Tile', function () {
       });
       it("deletes rectangle drawings", () => {
         drawToolTile.getDrawTile().click();
-        for (let i=0; i<6; i++) {
+        // delete the first 4 with the toolbar button
+        for (let i=0; i<4; i++) {
           drawToolTile.getDrawToolSelect().click();
           drawToolTile.getRectangleDrawing().first().click({force:true, scrollBehavior: false});
           drawToolTile.getDrawToolDelete().click();
         }
+        // Delete with backspace key
+        drawToolTile.getDrawToolSelect().click();
+        drawToolTile.getRectangleDrawing().first().click({force:true, scrollBehavior: false});
+        drawToolTile.getDrawTileComponent().type("{backspace}");
+
+        // Delete with delete key
+        drawToolTile.getDrawToolSelect().click();
+        drawToolTile.getRectangleDrawing().first().click({force:true, scrollBehavior: false});
+        drawToolTile.getDrawTileComponent().type("{del}");
+
         drawToolTile.getRectangleDrawing().should("not.exist");
       });
     });

--- a/cypress/support/elements/clue/DrawToolTile.js
+++ b/cypress/support/elements/clue/DrawToolTile.js
@@ -5,6 +5,9 @@ class DrawToolTile{
     getTileTitle(workspaceClass){
       return cy.get(`${workspaceClass || ".primary-workspace"} .editable-tile-title-text`);
     }
+    getDrawTileComponent(){
+      return cy.get('.primary-workspace [data-testid=drawing-tool]');
+    }
     getDrawToolSelect(){
       return cy.get('.primary-workspace .drawing-tool-button.button-select');
     }
@@ -41,6 +44,7 @@ class DrawToolTile{
     getDrawToolDelete(){
       return cy.get('.primary-workspace .drawing-tool-button.button-delete');
     }
+    
     getFreehandDrawing(){
       return cy.get('.primary-workspace [data-testid=drawing-tool] .drawing-layer svg path');
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,7 +106,7 @@
         "cypress": "^10.7.0",
         "cypress-commands": "2.0.1",
         "cypress-file-upload": "^5.0.8",
-        "cypress-terminal-report": "^3.5.2",
+        "cypress-terminal-report": "^4.1.2",
         "enquirer": "^2.3.6",
         "eslint": "^8.22.0",
         "eslint-config-react": "^1.1.7",
@@ -8285,14 +8285,13 @@
       }
     },
     "node_modules/cypress-terminal-report": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/cypress-terminal-report/-/cypress-terminal-report-3.5.2.tgz",
-      "integrity": "sha512-06y4xTOnztyUOIwk3B+YoAYrK5DSwgCMZhUieUdU3EDXjIb4BgRs/wqPYbfCrH/N5/Yb9aV2hjO95pjzEClwqQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/cypress-terminal-report/-/cypress-terminal-report-4.1.2.tgz",
+      "integrity": "sha512-UyCR7AJXMJYt87JXBAxdZxWC+FXG1S7+ePVACcumUQZq5lH490pXPPg47KY/7J6yyFatT6da+Mb1/J6E7K8sLg==",
       "dev": true,
       "dependencies": {
-        "chalk": "^3.0.0",
-        "fs-extra": "^9.0.1",
-        "methods": "^1.1.2",
+        "chalk": "^4.0.0",
+        "fs-extra": "^10.1.0",
         "semver": "^7.3.5",
         "tv4": "^1.3.0"
       },
@@ -8316,16 +8315,19 @@
       }
     },
     "node_modules/cypress-terminal-report/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/cypress-terminal-report/node_modules/color-convert": {
@@ -8345,6 +8347,20 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/cypress-terminal-report/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/cypress-terminal-report/node_modules/has-flag": {
       "version": "4.0.0",
@@ -27667,14 +27683,13 @@
       "requires": {}
     },
     "cypress-terminal-report": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/cypress-terminal-report/-/cypress-terminal-report-3.5.2.tgz",
-      "integrity": "sha512-06y4xTOnztyUOIwk3B+YoAYrK5DSwgCMZhUieUdU3EDXjIb4BgRs/wqPYbfCrH/N5/Yb9aV2hjO95pjzEClwqQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/cypress-terminal-report/-/cypress-terminal-report-4.1.2.tgz",
+      "integrity": "sha512-UyCR7AJXMJYt87JXBAxdZxWC+FXG1S7+ePVACcumUQZq5lH490pXPPg47KY/7J6yyFatT6da+Mb1/J6E7K8sLg==",
       "dev": true,
       "requires": {
-        "chalk": "^3.0.0",
-        "fs-extra": "^9.0.1",
-        "methods": "^1.1.2",
+        "chalk": "^4.0.0",
+        "fs-extra": "^10.1.0",
         "semver": "^7.3.5",
         "tv4": "^1.3.0"
       },
@@ -27689,9 +27704,9 @@
           }
         },
         "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -27712,6 +27727,17 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
+        },
+        "fs-extra": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+          "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
         },
         "has-flag": {
           "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "cypress": "^10.7.0",
     "cypress-commands": "2.0.1",
     "cypress-file-upload": "^5.0.8",
-    "cypress-terminal-report": "^3.5.2",
+    "cypress-terminal-report": "^4.1.2",
     "enquirer": "^2.3.6",
     "eslint": "^8.22.0",
     "eslint-config-react": "^1.1.7",

--- a/src/plugins/drawing-tool/components/drawing-layer.tsx
+++ b/src/plugins/drawing-tool/components/drawing-layer.tsx
@@ -164,10 +164,6 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
     return drawingContent.currentStamp;
   }
 
-  public handleDelete() {
-    this.getContent().deleteObjects(this.getContent().selectedIds);
-  }
-
   public handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
     if (!this.props.readOnly && this.currentTool) {
       this.currentTool.handleMouseDown(e);

--- a/src/plugins/drawing-tool/components/drawing-layer.tsx
+++ b/src/plugins/drawing-tool/components/drawing-layer.tsx
@@ -79,8 +79,6 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
     this.setSvgRef = (element) => {
       this.svgRef = element;
     };
-
-    this.addListeners();
   }
 
   public componentDidMount() {
@@ -135,20 +133,6 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
 
     tool.setSettings(settings);
     this.setCurrentTool(tool);
-  }
-
-  public addListeners() {
-    window.addEventListener("keyup", (e) => {
-      if (!this.props.readOnly) {
-        switch (e.key) {
-          case "Backspace":
-          case "Delete":
-          case "Del":             // IE 9 and maybe Edge
-            this.handleDelete();
-            break;
-        }
-      }
-    });
   }
 
   public addNewDrawingObject(drawingObject: DrawingObjectSnapshotForAdd) {

--- a/src/plugins/drawing-tool/components/drawing-tool.scss
+++ b/src/plugins/drawing-tool/components/drawing-tool.scss
@@ -22,6 +22,11 @@
     text-align: center;
     .drawing-tool-button {
       position: relative;
+      // These are button elements so we have to disable default button styles
+      // of border, padding, and display
+      border: 0;    
+      padding: 0;
+      display: block;
       user-select: none;
       width: $toolbar-button-width;
       height: $toolbar-button-height;

--- a/src/plugins/drawing-tool/components/drawing-tool.tsx
+++ b/src/plugins/drawing-tool/components/drawing-tool.tsx
@@ -38,6 +38,8 @@ const DrawingToolComponent: React.FC<IProps> = (props) => {
     });
     hotKeys.current.register({
       "cmd-v": handlePaste, //allows user to paste image with cmd+v
+      "delete": handleDelete, // I'm not sure if this will handle "Del" IE 9 and Edge
+      "backspace": handleDelete,
     });
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -45,6 +47,10 @@ const DrawingToolComponent: React.FC<IProps> = (props) => {
     pasteClipboardImage(({ image }) => {
       setImageUrlToAdd(image.contentUrl || '');
     });
+  };
+
+  const handleDelete = () => {
+    contentRef.current.deleteObjects(contentRef.current.selectedIds);
   };
 
   const toolbarProps = useToolbarToolApi({ id: model.id, enabled: !readOnly, onRegisterToolApi, onUnregisterToolApi });

--- a/src/plugins/drawing-tool/components/drawing-tool.tsx
+++ b/src/plugins/drawing-tool/components/drawing-tool.tsx
@@ -36,11 +36,13 @@ const DrawingToolComponent: React.FC<IProps> = (props) => {
         return getTitle();
       }
     });
-    hotKeys.current.register({
-      "cmd-v": handlePaste, //allows user to paste image with cmd+v
-      "delete": handleDelete, // I'm not sure if this will handle "Del" IE 9 and Edge
-      "backspace": handleDelete,
-    });
+    if (!readOnly) {
+      hotKeys.current.register({
+        "cmd-v": handlePaste, //allows user to paste image with cmd+v
+        "delete": handleDelete, // I'm not sure if this will handle "Del" IE 9 and Edge
+        "backspace": handleDelete,
+      });  
+    }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handlePaste = () => {

--- a/src/plugins/drawing-tool/components/drawing-toolbar-buttons.tsx
+++ b/src/plugins/drawing-tool/components/drawing-toolbar-buttons.tsx
@@ -42,10 +42,11 @@ export const SvgToolbarButton: React.FC<ISvgToolbarButtonProps> = ({
   const tooltipOptions = useTooltipOptions();
   return SvgIcon
     ? <Tooltip title={title} {...tooltipOptions}>
-        <div className={buttonClasses({ disabled, selected, others: `button-${buttonClass}` })} onClick={onClick}>
+        <button className={buttonClasses({ disabled, selected, others: `button-${buttonClass}` })} 
+            onClick={onClick} type="button">
           <SvgIcon fill={fill} stroke={stroke} strokeWidth={strokeWidth}
               strokeDasharray={computeStrokeDashArray(strokeDashArray, strokeWidth)}/>
-        </div>
+        </button>
       </Tooltip>
     : null;
 };


### PR DESCRIPTION
This fixes an issue with the delete key causing errors after a drawing tile has been removed from the document.

The fix here is to replace the listeners on the window object with a listener on the top level drawing tile component. This listener will receive events from the drawing canvas as well as events from the toolbar. These keyboard events are only sent if an element is focusable. So for the toolbar buttons to work properly the were converted to `<button>` elements so they could would be focusable.

Also this PR:
- upgrades the version of cypress-terminal-report to be compatible with cypress 10.x.x.
- adds a test for using the keyboard to delete drawing tool objects.
- uses a container to run the cypress tests, this seems to help them be more reliable.