### PR TITLE
build once, test multiple times, use cypress image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,33 +3,8 @@ name: Continuous Integration
 on: push
 
 jobs:
-  build:
-    name: Build using cypress action and upload the result
-    runs-on: ubuntu-latest
-    container: cypress/browsers:node16.14.2-slim-chrome103-ff102
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build
-        uses: cypress-io/github-action@v4
-        with:
-          runTests: false
-          build: npm run build
-        env:
-          # Turn on code coverage instrumentation in this build
-          # so it can be used by the cypress tests.
-          # This uses a webpack coverage-istanbul-loader.
-          # Try turning off code coverage to see how it effects
-          # the speed.
-          # CODE_COVERAGE: true
-      - name: Save build folder
-        uses: actions/upload-artifact@v3
-        with:
-          name: build
-          if-no-files-found: error
-          path: dist
-  jest:
-    name: Run Jest Tests
+  build_test:
+    name: Build and Run Jest Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -38,6 +13,8 @@ jobs:
           node-version: '16'
       - name: Install Dependencies
         run: npm ci
+      - name: Build
+        run: npm run build
       - name: Run Tests
         run: npm run test:coverage -- --runInBand
       - name: Upload coverage to Codecov
@@ -47,7 +24,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
   cypress:
     runs-on: ubuntu-latest
-    needs: build
     container: cypress/browsers:node16.14.2-slim-chrome103-ff102
     strategy:
       # when one test fails, DO NOT cancel the other
@@ -61,14 +37,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Download the build folder
-        uses: actions/download-artifact@v3
-        with:
-          name: build
-          path: dist
       - uses: cypress-io/github-action@v4
         with:
-          start: npx serve -l 8080 dist
+          start: npm start
           wait-on: 'http://localhost:8080'
           # only record the results to dashboard.cypress.io if CYPRESS_RECORD_KEY is set
           record: ${{ !!secrets.CYPRESS_RECORD_KEY }}
@@ -82,7 +53,12 @@ jobs:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           # pass GitHub token to allow accurately detecting a build vs a re-run build
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # turn on the code coverage tasks in cypress itself, these are disabled
+          # turn on code coverage when running npm start
+          # so far we've been using a webpack coverage-istanbul-loader for this
+          # but there has been work on using the code coverage support in the browser directly, 
+          # which should be much faster
+          CODE_COVERAGE: true
+          # Also turn on the code coverage tasks in cypress itself, these are disabled
           # by default.
           CYPRESS_coverage: true
       - name: Upload coverage to Codecov
@@ -93,7 +69,7 @@ jobs:
   s3-deploy:
     name: S3 Deploy
     needs:
-      - jest
+      - build_test
       - cypress
     runs-on: ubuntu-18.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,31 @@ name: Continuous Integration
 on: push
 
 jobs:
-  build_test:
-    name: Build and Run Jest Tests
+  build:
+    name: Build using cypress action and upload the result
+    runs-on: ubuntu-latest
+    container: cypress/browsers:node16.14.2-slim-chrome103-ff102
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Save build folder
+        uses: actions/upload-artifact@v2
+        with:
+          name: build
+          if-no-files-found: error
+          path: dist
+      - name: Build
+        uses: cypress-io/github-action@v4
+        with:
+          runTests: false
+          build: npm run build
+        env:
+          # Turn on code coverage instrumentation in this build
+          # so it can be used by the cypress tests.
+          # This uses a webpack coverage-istanbul-loader.
+          CODE_COVERAGE: true
+  jest:
+    name: Run Jest Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -13,8 +36,6 @@ jobs:
           node-version: '16'
       - name: Install Dependencies
         run: npm ci
-      - name: Build
-        run: npm run build
       - name: Run Tests
         run: npm run test:coverage -- --runInBand
       - name: Upload coverage to Codecov
@@ -24,6 +45,8 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
   cypress:
     runs-on: ubuntu-latest
+    needs: build
+    container: cypress/browsers:node16.14.2-slim-chrome103-ff102
     strategy:
       # when one test fails, DO NOT cancel the other
       # containers, because this will kill Cypress processes
@@ -36,9 +59,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Download the build folder
+        uses: actions/download-artifact@v2
+        with:
+          name: build
+          path: dist
       - uses: cypress-io/github-action@v4
         with:
-          start: npm start
+          start: npx serve -l 8080 dist
           wait-on: 'http://localhost:8080'
           # only record the results to dashboard.cypress.io if CYPRESS_RECORD_KEY is set
           record: ${{ !!secrets.CYPRESS_RECORD_KEY }}
@@ -52,12 +80,7 @@ jobs:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           # pass GitHub token to allow accurately detecting a build vs a re-run build
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # turn on code coverage when running npm start
-          # so far we've been using a webpack coverage-istanbul-loader for this
-          # but there has been work on using the code coverage support in the browser directly, 
-          # which should be much faster
-          CODE_COVERAGE: true
-          # Also turn on the code coverage tasks in cypress itself, these are disabled
+          # turn on the code coverage tasks in cypress itself, these are disabled
           # by default.
           CYPRESS_coverage: true
       - name: Upload coverage to Codecov
@@ -68,7 +91,7 @@ jobs:
   s3-deploy:
     name: S3 Deploy
     needs:
-      - build_test
+      - jest
       - cypress
     runs-on: ubuntu-18.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           start: npm start
           wait-on: 'http://localhost:8080'
+          wait-on-timeout: 180
           # only record the results to dashboard.cypress.io if CYPRESS_RECORD_KEY is set
           record: ${{ !!secrets.CYPRESS_RECORD_KEY }}
           # only do parallel if we have a record key

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Save build folder
-        uses: actions/upload-artifact@v2
-        with:
-          name: build
-          if-no-files-found: error
-          path: dist
       - name: Build
         uses: cypress-io/github-action@v4
         with:
@@ -26,6 +20,12 @@ jobs:
           # so it can be used by the cypress tests.
           # This uses a webpack coverage-istanbul-loader.
           CODE_COVERAGE: true
+      - name: Save build folder
+        uses: actions/upload-artifact@v3
+        with:
+          name: build
+          if-no-files-found: error
+          path: dist
   jest:
     name: Run Jest Tests
     runs-on: ubuntu-latest
@@ -60,7 +60,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Download the build folder
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: build
           path: dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,9 @@ jobs:
           # Turn on code coverage instrumentation in this build
           # so it can be used by the cypress tests.
           # This uses a webpack coverage-istanbul-loader.
-          CODE_COVERAGE: true
+          # Try turning off code coverage to see how it effects
+          # the speed.
+          # CODE_COVERAGE: true
       - name: Save build folder
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
splits the build step into its own job, it is based on the doc here:
https://docs.cypress.io/guides/continuous-integration/github-actions
I think the use of the cypress action to do the building will also
enable better caching.
The use of a cypress image could allow us to go back to chrome.
The image might also let us test locally on the same image.