### PR TITLE
Comment selection and expansion.

### DIFF
--- a/src/assets/expand-toggle-icon.svg
+++ b/src/assets/expand-toggle-icon.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24"  fill-rule="nonzero" xmlns="http://www.w3.org/2000/svg">
+  <path d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"/> 
+</svg>

--- a/src/components/chat/chat-panel-header.tsx
+++ b/src/components/chat/chat-panel-header.tsx
@@ -1,7 +1,6 @@
 import { observer } from "mobx-react";
 import React from "react";
 import ChatIcon from "../../assets/chat-icon.svg";
-//import ChatIcon from "../../assets/expand-toggle-icon.svg";
 import NotificationIcon from "../../assets/notifications-icon.svg";
 
 import "./chat-panel-header.scss";

--- a/src/components/chat/chat-panel-header.tsx
+++ b/src/components/chat/chat-panel-header.tsx
@@ -1,6 +1,7 @@
 import { observer } from "mobx-react";
 import React from "react";
 import ChatIcon from "../../assets/chat-icon.svg";
+//import ChatIcon from "../../assets/expand-toggle-icon.svg";
 import NotificationIcon from "../../assets/notifications-icon.svg";
 
 import "./chat-panel-header.scss";

--- a/src/components/chat/chat-thread-toggle.scss
+++ b/src/components/chat/chat-thread-toggle.scss
@@ -1,9 +1,7 @@
 @import "../vars";
-
 .chat-thread-toggle {
   transform: rotate(270deg);
-
- &.problems {
+  &.problems {
     border-color: $problem-orange-light-3;
   }
   &.my-work {

--- a/src/components/chat/chat-thread-toggle.scss
+++ b/src/components/chat/chat-thread-toggle.scss
@@ -1,0 +1,27 @@
+@import "../vars";
+
+.chat-thread-toggle {
+  transform: rotate(270deg);
+
+ &.problems {
+    border-color: $problem-orange-light-3;
+  }
+  &.my-work {
+    border-color: $workspace-teal;
+  }
+  &.class-work {
+    border-color: $classwork-purple;
+  }
+  &.supports {
+    border-color: $support-blue;
+  }
+  &.student-work {
+    border-color: $charcoal-dark-1;
+  }
+  .themed {
+    background-color: inherit;
+  }
+}
+.chat-thread-toggle.expanded  {
+  transform: rotate(0);
+}

--- a/src/components/chat/chat-thread-toggle.test.tsx
+++ b/src/components/chat/chat-thread-toggle.test.tsx
@@ -12,7 +12,6 @@ describe("Comment Textbox", () => {
   });
   
   it("Chat toggle collapsed", () => {
-    const activeNavTab = "problems";
     render((
       <ChatThreadToggle  isThreadExpanded={false} />
     ));

--- a/src/components/chat/chat-thread-toggle.test.tsx
+++ b/src/components/chat/chat-thread-toggle.test.tsx
@@ -4,7 +4,6 @@ import { ChatThreadToggle } from "./chat-thread-toggle";
 
 describe("Comment Textbox", () => {
   it("Chat toggle expanded", () => {
-    const activeNavTab = "problems";
     render((
       <ChatThreadToggle  isThreadExpanded={true} />
     ));

--- a/src/components/chat/chat-thread-toggle.test.tsx
+++ b/src/components/chat/chat-thread-toggle.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { ChatThreadToggle } from "./chat-thread-toggle";
+
+describe("Comment Textbox", () => {
+  it("Chat toggle expanded", () => {
+    const activeNavTab = "problems";
+    render((
+      <ChatThreadToggle  isThreadExpanded={true} />
+    ));
+    expect(screen.getByTestId("chat-thread-toggle")).toBeInTheDocument();
+    expect(screen.getByTestId("chat-thread-toggle")).toHaveClass("expanded");
+  });
+  
+  it("Chat toggle collapsed", () => {
+    const activeNavTab = "problems";
+    render((
+      <ChatThreadToggle  isThreadExpanded={false} />
+    ));
+    expect(screen.getByTestId("chat-thread-toggle")).toBeInTheDocument();
+    expect(screen.getByTestId("chat-thread-toggle")).not.toHaveClass("expanded");
+  });  
+});

--- a/src/components/chat/chat-thread-toggle.tsx
+++ b/src/components/chat/chat-thread-toggle.tsx
@@ -5,8 +5,8 @@ import ExpandIndicatorIcon from "../../assets/expand-toggle-icon.svg";
 import "./chat-thread-toggle.scss";
 
 interface IProps {
-    isThreadExpanded: boolean;
-    activeNavTab?: string;
+  isThreadExpanded: boolean;
+  activeNavTab?: string;
 }
 
 export const ChatThreadToggle: React.FC<IProps> = ({ isThreadExpanded, activeNavTab}) => {

--- a/src/components/chat/chat-thread-toggle.tsx
+++ b/src/components/chat/chat-thread-toggle.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import classNames from "classnames";
+import ExpandIndicatorIcon from "../../assets/expand-toggle-icon.svg";
+
+import "./chat-thread-toggle.scss";
+
+interface IProps {
+    isThreadExpanded: boolean;
+    activeNavTab?: string;
+}
+
+export const ChatThreadToggle: React.FC<IProps> = ({ isThreadExpanded, activeNavTab}) => {
+  return (
+    <div className={classNames(`chat-thread-toggle ${activeNavTab}`, {
+          expanded: isThreadExpanded
+        })}
+        data-testid="chat-thread-toggle">
+      <ExpandIndicatorIcon className={`icon-image themed ${activeNavTab}`}/>
+    </div>
+  );
+};

--- a/src/components/chat/chat-thread.tsx
+++ b/src/components/chat/chat-thread.tsx
@@ -2,6 +2,7 @@ import React, {useEffect, useState} from "react";
 import classNames from "classnames";
 import { UserModelType } from "../../models/stores/user";
 import { WithId } from "../../hooks/firestore-hooks";
+import { useUIStore } from "../../hooks/use-stores";
 import { CommentDocument } from "../../lib/firestore-schema";
 import { CommentCard } from "./comment-card";
 import { getToolContentInfoById } from "../../models/tools/tool-content-info";
@@ -33,13 +34,15 @@ export const ChatThread: React.FC<IProps> = ({ activeNavTab, user, chatThreads,
   const focusId = focusTileId === undefined ? null : focusTileId;
   const focusedItemHasNoComments = !chatThreads?.find(item => (item.tileId === focusId));
   const [expandedThread, setExpandedThread] = useState(focusId || '');
-  
+  const ui = useUIStore();
   const handleThreadClick = (clickedId: string | null) => {
     if (clickedId === expandedThread) {
       // We're closing the thread so clear it out.
       setExpandedThread('');
+      ui.setSelectedTileId('');
     } else {
       setExpandedThread(clickedId || "document");
+      ui.setSelectedTileId(clickedId || '');
     }
   };
 

--- a/src/components/chat/chat-thread.tsx
+++ b/src/components/chat/chat-thread.tsx
@@ -63,8 +63,7 @@ export const ChatThread: React.FC<IProps> = ({ activeNavTab, user, chatThreads,
               "chat-thread-focused": shouldBeFocused,
             })}
             data-testid="chat-thread">
-            <div className="chat-thread-header"
-              onClick={() => handleThreadClick(key)}> 
+            <div className="chat-thread-header" onClick={() => handleThreadClick(key)}> 
               <div className="chat-thread-tile-info">
                 {Icon && <Icon/>}
                 <div className="chat-thread-title"> {title} </div>

--- a/src/components/chat/chat-thread.tsx
+++ b/src/components/chat/chat-thread.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, {useEffect, useState} from "react";
 import classNames from "classnames";
 import { UserModelType } from "../../models/stores/user";
 import { WithId } from "../../hooks/firestore-hooks";
@@ -8,6 +8,7 @@ import { getToolContentInfoById } from "../../models/tools/tool-content-info";
 import UserIcon from "../../assets/icons/clue-dashboard/teacher-student.svg";
 import {ChatCommentThread} from "./chat-comment-thread";
 import { ToolIconComponent } from "./tool-icon-component";
+import { ChatThreadToggle } from "./chat-thread-toggle";
 
 import "./chat-thread.scss";
 
@@ -21,14 +22,27 @@ interface IProps {
   focusTileId?: string;
 }
 
-
 export const ChatThread: React.FC<IProps> = ({ activeNavTab, user, chatThreads, 
   onPostComment, onDeleteComment,
   focusDocument, focusTileId }) => {
+  useEffect(() => {
+    setExpandedThread(focusTileId || 'document');
+  },[focusTileId]);
+
   // make focusId null if undefined so it can be compared with tileId below.
   const focusId = focusTileId === undefined ? null : focusTileId;
   const focusedItemHasNoComments = !chatThreads?.find(item => (item.tileId === focusId));
+  const [expandedThread, setExpandedThread] = useState(focusId || '');
   
+  const handleThreadClick = (clickedId: string | null) => {
+    if (clickedId === expandedThread) {
+      // We're closing the thread so clear it out.
+      setExpandedThread('');
+    } else {
+      setExpandedThread(clickedId || "document");
+    }
+  };
+
   return (
     <div className="chat-list" data-testid="chat-list">
       {chatThreads?.map((commentThread: ChatCommentThread) => {
@@ -46,7 +60,8 @@ export const ChatThread: React.FC<IProps> = ({ activeNavTab, user, chatThreads,
               "chat-thread-focused": shouldBeFocused,
             })}
             data-testid="chat-thread">
-            <div className="chat-thread-header"> 
+            <div className="chat-thread-header"
+              onClick={() => handleThreadClick(key)}> 
               <div className="chat-thread-tile-info">
                 {Icon && <Icon/>}
                 <div className="chat-thread-title"> {title} </div>
@@ -55,18 +70,22 @@ export const ChatThread: React.FC<IProps> = ({ activeNavTab, user, chatThreads,
                 {shouldShowUserIcon &&
                   <div className="user-icon" data-testid="chat-thread-user-icon"><UserIcon /></div>
                 }
-                <div className="chat-thread-num">{numComments}</div>  
+                <div className="chat-thread-num">{numComments}</div>
+                <ChatThreadToggle
+                  isThreadExpanded={expandedThread === key}
+                  activeNavTab={activeNavTab}
+                    />
               </div>
             </div> 
-            {shouldBeFocused &&              
+            {expandedThread === key &&
               <CommentCard
-                  user={user}
-                  activeNavTab={activeNavTab}
-                  onPostComment={onPostComment}
-                  onDeleteComment={onDeleteComment}
-                  postedComments={commentThread.comments}
-                  focusDocument={focusDocument}
-                  focusTileId={focusTileId}
+                user={user}
+                activeNavTab={activeNavTab}
+                onPostComment={onPostComment}
+                onDeleteComment={onDeleteComment}
+                postedComments={commentThread.comments}
+                focusDocument={focusDocument}
+                focusTileId={focusTileId}
               />}
           </div>
           );


### PR DESCRIPTION
183182552 - Adds toggle to chat header to expand/collapse it. When clicked in the chat panel, the comment selects the tile in the document. When a tile is clicked in the document, it expands the chat panel.