### PR TITLE
Stop history playing when end of history is reached

### DIFF
--- a/src/components/playback/playback-control.tsx
+++ b/src/components/playback/playback-control.tsx
@@ -49,13 +49,14 @@ export const PlaybackControlComponent: React.FC<IProps> = observer((props: IProp
   useEffect(() => {
     if (sliderValue > history.length) {
       setSliderValue(history.length);
+      handlePlayPauseToggle(false);
     }
-  },[history.length, sliderValue]);
+  },[handlePlayPauseToggle, history.length, sliderValue]);
 
   useEffect(() => {
     if (sliderPlaying) {
       const slider = setTimeout(()=>{
-        if (sliderValue < history.length) {
+        if (sliderValue <= history.length) {
           treeManager.goToHistoryEntry(sliderValue)
             .then(()=>{
               treeManager.setCurrentHistoryIndex(sliderValue);

--- a/src/components/playback/playback-control.tsx
+++ b/src/components/playback/playback-control.tsx
@@ -40,7 +40,7 @@ export const PlaybackControlComponent: React.FC<IProps> = observer((props: IProp
   const playbackDisabled = treeManager.currentHistoryIndex === undefined || sliderValue === history.length;
 
   const handlePlayPauseToggle = useCallback((playing?: boolean) => {
-                                  setSliderPlaying(playing || !sliderPlaying);
+                                  setSliderPlaying(playing !== undefined ? playing : !sliderPlaying);
                                 },[sliderPlaying]);
 
   // If our slider value is ever beyond the end of the known history, rein it in.
@@ -55,7 +55,7 @@ export const PlaybackControlComponent: React.FC<IProps> = observer((props: IProp
   useEffect(() => {
     if (sliderPlaying) {
       const slider = setTimeout(()=>{
-        if (sliderValue <= history.length) {
+        if (sliderValue < history.length) {
           treeManager.goToHistoryEntry(sliderValue)
             .then(()=>{
               treeManager.setCurrentHistoryIndex(sliderValue);


### PR DESCRIPTION
This PR switches the the playback controls to paused when the end of history is reached. I also fixed a bug where explicitly setting the playback to pause would instead toggle it (potentially starting to play it instead).

It still seems like there are bugs associated with the playback timeline. If you play the history, you'll notice that the point is at the right end of the track for both of the last two history steps.