### PR TITLE
183447406 comments styling

### DIFF
--- a/cypress/e2e/clue/branch/teacher_tests/teacher_chat_spec.js
+++ b/cypress/e2e/clue/branch/teacher_tests/teacher_chat_spec.js
@@ -59,6 +59,7 @@ context('Chat Panel', () => {
     });
     it('verify the comment card and tile are highlighted', () => {
       cy.clickProblemResourceTile('introduction');
+      cy.wait(2000);
       chatPanel.getSelectedCommentThreadHeader().should('be.visible').should('have.css', 'background-color').and('eq', expandedChatBackground);
       chatPanel.getToolTile().should('be.visible').should('have.css', 'background-color').and('eq', selectedChatBackground);
     });
@@ -110,7 +111,7 @@ context('Chat Panel', () => {
       const msgToDelete = "Send this comment after enter.";
       chatPanel.getDeleteMessageButton(msgToDelete).click();
       chatPanel.getDeleteConfirmModalButton().contains("Delete").click();
-      cy.wait(1000);
+      cy.wait(2000);
       chatPanel.verifyCommentThreadLength(1);
       chatPanel.verifyCommentThreadDoesNotContain(msgToDelete);
     });
@@ -162,7 +163,7 @@ context('Chat Panel', () => {
     it("verify chat is available on Problem section - Introduction tab", () => {
       cy.openTopTab("problems");
       cy.openProblemSection("Introduction");
-      cy.wait(1000);
+      cy.wait(2000);
       // document comment
       chatPanel.addCommentAndVerify("This is document comment for problems-section introduction-subsection");
       // click first tile
@@ -173,84 +174,84 @@ context('Chat Panel', () => {
     it("verify chat is available on Problem section - Initial Challenge tab", () => {
       cy.openTopTab("problems");
       cy.openProblemSection("Initial Challenge");
-      cy.wait(1000);
+      cy.wait(2000);
       // document comment
       chatPanel.addCommentAndVerify("This is document comment for problems-section initial-challenge-subsection");
       // click first tile
       cy.clickProblemResourceTile('initialChallenge');
-      cy.wait(1000);
+      cy.wait(2000);
       // tile comment
       chatPanel.addCommentAndVerify("This is tile comment for problems-section initial-challenge-subsection");
     });
     it("verify chat is available on Problem section - What If... tab", () => {
       cy.openTopTab("problems");
       cy.openProblemSection("What If...?");
-      cy.wait(1000);
+      cy.wait(2000);
       // document comment
       chatPanel.addCommentAndVerify("This is document comment for problems-section what-if-subsection");
       // click first tile
       cy.clickProblemResourceTile('whatIf');
-      cy.wait(1000);
+      cy.wait(2000);
       // tile comment
       chatPanel.addCommentAndVerify("This is tile comment for problems-section what-if-subsection");
     });
     it("verify chat is available on Problem section - Now What Do You Know? tab", () => {
       cy.openTopTab("problems");
       cy.openProblemSection("Now What Do You Know?");
-      cy.wait(1000);
+      cy.wait(2000);
       // document comment
       chatPanel.addCommentAndVerify("This is document comment for problems-section now-what-subsection");
       // click first tile
       cy.clickProblemResourceTile('nowWhatDoYouKnow');
-      cy.wait(1000);
+      cy.wait(2000);
       // tile comment
       chatPanel.addCommentAndVerify("This is tile comment for problems-section now-what-subsection");
     });
     it("verify chat is available on Teacher Guide section - Overview tab", () => {
       cy.openTopTab("teacher-guide");
       cy.openProblemSection('Overview');
-      cy.wait(1000);
+      cy.wait(2000);
       // document comment
       chatPanel.addCommentAndVerify("This is document comment for teacher-guide-section overview-subsection");
       // click first tile
       cy.clickProblemResourceTile('overview');
-      cy.wait(1000);
+      cy.wait(2000);
       // tile comment
       chatPanel.addCommentAndVerify("This is tile comment for teacher-guide-section overview-subsection");
     });
     it("verify chat is available on Teacher Guide section - Launch tab", () => {
       cy.openTopTab("teacher-guide");
       cy.openProblemSection('Launch');
-      cy.wait(1000);
+      cy.wait(2000);
       // document comment
       chatPanel.addCommentAndVerify("This is document comment for teacher-guide-section launch-subsection");
       // click first tile
       cy.clickProblemResourceTile('launch');
-      cy.wait(1000);
+      cy.wait(2000);
       // tile comment
       chatPanel.addCommentAndVerify("This is tile comment for teacher-guide-section launch-subsection");
     });
     it("verify chat is available on Teacher Guide section - Explore tab", () => {
       cy.openTopTab("teacher-guide");
       cy.openProblemSection('Explore');
-      cy.wait(1000);
+      cy.wait(2000);
       // document comment
       chatPanel.addCommentAndVerify("This is document comment for teacher-guide-section explore-subsection");
       // click first tile
       cy.clickProblemResourceTile('explore');
-      cy.wait(1000);
+      cy.wait(2000);
       // tile comment
       chatPanel.addCommentAndVerify("This is tile comment for teacher-guide-section explore-subsection");
     });
     it("verify chat is available on Teacher Guide section - Summarize tab", () => {
       cy.openTopTab("teacher-guide");
       cy.openProblemSection('Summarize');
-      cy.wait(1000);
+      cy.wait(2000);
       // document comment
       chatPanel.addCommentAndVerify("This is document comment for teacher-guide-section summarize-subsection");
       // click first tile
       cy.clickProblemResourceTile('summarize');
-      cy.wait(1000);
+      cy.wait(2000);
       // tile comment
       chatPanel.addCommentAndVerify("This is tile comment for teacher-guide-section summarize-subsection");
     });
@@ -259,7 +260,7 @@ context('Chat Panel', () => {
         cy.openTopTab('my-work');
         cy.openSection('my-work', 'workspaces');
         cy.openDocumentThumbnail('workspaces', title);
-        cy.wait(1000);
+        cy.wait(2000);
         // document comment
         chatPanel.addCommentAndVerify("This is document comment for teacher-my-work workspaces-subsection");
       });
@@ -268,7 +269,7 @@ context('Chat Panel', () => {
       cy.openTopTab('my-work');
       cy.openSection('my-work', 'learning-log');
       cy.openDocumentWithIndex('my-work', 'learning-log', 0);
-      cy.wait(1000);
+      cy.wait(2000);
       // document comment
       chatPanel.addCommentAndVerify("This is document comment for teacher-my-work learning-log-subsection");
     });
@@ -279,11 +280,11 @@ context('Chat Panel', () => {
       cy.openTopTab("problems");
       cy.openProblemSection("Introduction");
       chatPanel.verifyProblemCommentClass();
-      cy.wait(1000);
+      cy.wait(2000);
       chatPanel.addCommentAndVerify("This is a teacher7 document comment");
       // Teacher 7 tile comment
       cy.clickProblemResourceTile('introduction');
-      cy.wait(1000);
+      cy.wait(2000);
       chatPanel.addCommentAndVerify("This is a teacher7 tile comment");
     });
     it("verify teacher8 can open clue chat in the same network", () => {
@@ -303,7 +304,7 @@ context('Chat Panel', () => {
       chatPanel.addCommentAndVerify("This is a teacher8 document comment");
       // Teacher 8 tile comment
       cy.clickProblemResourceTile('introduction');
-      cy.wait(1000);
+      cy.wait(2000);
       chatPanel.verifyCommentThreadContains("This is a teacher7 tile comment");
       chatPanel.addCommentAndVerify("This is a teacher8 tile comment");
     });
@@ -315,7 +316,7 @@ context('Chat Panel', () => {
       cy.wait(2000);
       // resourcesPanel.getCollapsedResourcesTab().click();
       cy.openTopTab("problems");
-      cy.wait(1000);
+      cy.wait(2000);
       chatPanel.getChatPanelToggle().click();
     });
     it("verify teacher7 can view teacher8's comments", () => {
@@ -324,7 +325,7 @@ context('Chat Panel', () => {
       chatPanel.verifyCommentThreadContains("This is a teacher8 document comment");
       // Teacher 7 tile comment
       cy.clickProblemResourceTile('introduction');
-      cy.wait(1000);
+      cy.wait(2000);
       chatPanel.verifyCommentThreadContains("This is a teacher8 tile comment");
     });
  });

--- a/cypress/e2e/clue/branch/teacher_tests/teacher_chat_spec.js
+++ b/cypress/e2e/clue/branch/teacher_tests/teacher_chat_spec.js
@@ -9,6 +9,7 @@ let chatPanel = new ChatPanel;
 let resourcesPanel = new ResourcesPanel;
 
 let selectedChatBackground = 'rgb(215, 255, 204)';
+let expandedChatBackground = 'rgb(193, 243, 179)';
 
 const queryParams = "/?appMode=qa&fakeClass=5&fakeOffering=5&problem=2.1&fakeUser=teacher:7&unit=msa";
 
@@ -53,17 +54,21 @@ context('Chat Panel', () => {
     it('verify the comment card and the document are highlighted', () => {
       chatPanel.verifyProblemCommentClass();
       chatPanel.getProblemDocumentContent().should('be.visible').should('have.css', 'background-color').and('eq', selectedChatBackground);
-      chatPanel.getCommentCardContent().should('be.visible').should('have.css', 'background-color').and('eq', selectedChatBackground);
+      chatPanel.getSelectedCommentThreadHeader().should('have.css', 'background-color');
+      chatPanel.getSelectedCommentThreadHeader().should('have.css', 'background-color').and('eq', expandedChatBackground);
+      cy.pause();
     });
     it('verify the comment card and tile are highlighted', () => {
       cy.clickProblemResourceTile('introduction');
-      chatPanel.getCommentCardContent().should('be.visible').should('have.css', 'background-color').and('eq', selectedChatBackground);
+      chatPanel.getSelectedCommentThreadHeader().should('be.visible').should('have.css', 'background-color').and('eq', expandedChatBackground);
       chatPanel.getToolTile().should('be.visible').should('have.css', 'background-color').and('eq', selectedChatBackground);
     });
     it('verify user can cancel a comment', () => {
       cy.openProblemSection("Introduction");
       const documentComment = "This comment is for the document.";
+      cy.wait(2000);
       chatPanel.typeInCommentArea(documentComment);
+      chatPanel.getCommentCancelButton().scrollIntoView();
       chatPanel.verifyCommentAreaContains(documentComment);
       chatPanel.getCommentCancelButton().scrollIntoView().click();
       chatPanel.verifyCommentAreaDoesNotContain(documentComment);
@@ -158,6 +163,7 @@ context('Chat Panel', () => {
     it("verify chat is available on Problem section - Introduction tab", () => {
       cy.openTopTab("problems");
       cy.openProblemSection("Introduction");
+      cy.wait(1000);
       // document comment
       chatPanel.addCommentAndVerify("This is document comment for problems-section introduction-subsection");
       // click first tile
@@ -168,70 +174,84 @@ context('Chat Panel', () => {
     it("verify chat is available on Problem section - Initial Challenge tab", () => {
       cy.openTopTab("problems");
       cy.openProblemSection("Initial Challenge");
+      cy.wait(1000);
       // document comment
       chatPanel.addCommentAndVerify("This is document comment for problems-section initial-challenge-subsection");
       // click first tile
       cy.clickProblemResourceTile('initialChallenge');
+      cy.wait(1000);
       // tile comment
       chatPanel.addCommentAndVerify("This is tile comment for problems-section initial-challenge-subsection");
     });
     it("verify chat is available on Problem section - What If... tab", () => {
       cy.openTopTab("problems");
       cy.openProblemSection("What If...?");
+      cy.wait(1000);
       // document comment
       chatPanel.addCommentAndVerify("This is document comment for problems-section what-if-subsection");
       // click first tile
       cy.clickProblemResourceTile('whatIf');
+      cy.wait(1000);
       // tile comment
       chatPanel.addCommentAndVerify("This is tile comment for problems-section what-if-subsection");
     });
     it("verify chat is available on Problem section - Now What Do You Know? tab", () => {
       cy.openTopTab("problems");
       cy.openProblemSection("Now What Do You Know?");
+      cy.wait(1000);
       // document comment
       chatPanel.addCommentAndVerify("This is document comment for problems-section now-what-subsection");
       // click first tile
       cy.clickProblemResourceTile('nowWhatDoYouKnow');
+      cy.wait(1000);
       // tile comment
       chatPanel.addCommentAndVerify("This is tile comment for problems-section now-what-subsection");
     });
     it("verify chat is available on Teacher Guide section - Overview tab", () => {
       cy.openTopTab("teacher-guide");
       cy.openProblemSection('Overview');
+      cy.wait(1000);
       // document comment
       chatPanel.addCommentAndVerify("This is document comment for teacher-guide-section overview-subsection");
       // click first tile
       cy.clickProblemResourceTile('overview');
+      cy.wait(1000);
       // tile comment
       chatPanel.addCommentAndVerify("This is tile comment for teacher-guide-section overview-subsection");
     });
     it("verify chat is available on Teacher Guide section - Launch tab", () => {
       cy.openTopTab("teacher-guide");
       cy.openProblemSection('Launch');
+      cy.wait(1000);
       // document comment
       chatPanel.addCommentAndVerify("This is document comment for teacher-guide-section launch-subsection");
       // click first tile
       cy.clickProblemResourceTile('launch');
+      cy.wait(1000);
       // tile comment
       chatPanel.addCommentAndVerify("This is tile comment for teacher-guide-section launch-subsection");
     });
     it("verify chat is available on Teacher Guide section - Explore tab", () => {
       cy.openTopTab("teacher-guide");
       cy.openProblemSection('Explore');
+      cy.wait(1000);
       // document comment
       chatPanel.addCommentAndVerify("This is document comment for teacher-guide-section explore-subsection");
       // click first tile
       cy.clickProblemResourceTile('explore');
+      cy.wait(1000);
       // tile comment
       chatPanel.addCommentAndVerify("This is tile comment for teacher-guide-section explore-subsection");
     });
     it("verify chat is available on Teacher Guide section - Summarize tab", () => {
       cy.openTopTab("teacher-guide");
       cy.openProblemSection('Summarize');
+      cy.wait(1000);
       // document comment
       chatPanel.addCommentAndVerify("This is document comment for teacher-guide-section summarize-subsection");
       // click first tile
       cy.clickProblemResourceTile('summarize');
+      cy.wait(1000);
       // tile comment
       chatPanel.addCommentAndVerify("This is tile comment for teacher-guide-section summarize-subsection");
     });
@@ -240,6 +260,7 @@ context('Chat Panel', () => {
         cy.openTopTab('my-work');
         cy.openSection('my-work', 'workspaces');
         cy.openDocumentThumbnail('workspaces', title);
+        cy.wait(1000);
         // document comment
         chatPanel.addCommentAndVerify("This is document comment for teacher-my-work workspaces-subsection");
       });
@@ -248,6 +269,7 @@ context('Chat Panel', () => {
       cy.openTopTab('my-work');
       cy.openSection('my-work', 'learning-log');
       cy.openDocumentWithIndex('my-work', 'learning-log', 0);
+      cy.wait(1000);
       // document comment
       chatPanel.addCommentAndVerify("This is document comment for teacher-my-work learning-log-subsection");
     });
@@ -258,9 +280,11 @@ context('Chat Panel', () => {
       cy.openTopTab("problems");
       cy.openProblemSection("Introduction");
       chatPanel.verifyProblemCommentClass();
+      cy.wait(1000);
       chatPanel.addCommentAndVerify("This is a teacher7 document comment");
       // Teacher 7 tile comment
       cy.clickProblemResourceTile('introduction');
+      cy.wait(1000);
       chatPanel.addCommentAndVerify("This is a teacher7 tile comment");
     });
     it("verify teacher8 can open clue chat in the same network", () => {
@@ -280,6 +304,7 @@ context('Chat Panel', () => {
       chatPanel.addCommentAndVerify("This is a teacher8 document comment");
       // Teacher 8 tile comment
       cy.clickProblemResourceTile('introduction');
+      cy.wait(1000);
       chatPanel.verifyCommentThreadContains("This is a teacher7 tile comment");
       chatPanel.addCommentAndVerify("This is a teacher8 tile comment");
     });
@@ -291,6 +316,7 @@ context('Chat Panel', () => {
       cy.wait(2000);
       // resourcesPanel.getCollapsedResourcesTab().click();
       cy.openTopTab("problems");
+      cy.wait(1000);
       chatPanel.getChatPanelToggle().click();
     });
     it("verify teacher7 can view teacher8's comments", () => {
@@ -299,7 +325,8 @@ context('Chat Panel', () => {
       chatPanel.verifyCommentThreadContains("This is a teacher8 document comment");
       // Teacher 7 tile comment
       cy.clickProblemResourceTile('introduction');
+      cy.wait(1000);
       chatPanel.verifyCommentThreadContains("This is a teacher8 tile comment");
     });
-  });
+ });
 });

--- a/cypress/e2e/clue/branch/teacher_tests/teacher_chat_spec.js
+++ b/cypress/e2e/clue/branch/teacher_tests/teacher_chat_spec.js
@@ -54,7 +54,6 @@ context('Chat Panel', () => {
     it('verify the comment card and the document are highlighted', () => {
       chatPanel.verifyProblemCommentClass();
       chatPanel.getProblemDocumentContent().should('be.visible').should('have.css', 'background-color').and('eq', selectedChatBackground);
-      chatPanel.getSelectedCommentThreadHeader().should('have.css', 'background-color');
       chatPanel.getSelectedCommentThreadHeader().should('have.css', 'background-color').and('eq', expandedChatBackground);
     });
     it('verify the comment card and tile are highlighted and have tile icon', () => {

--- a/cypress/e2e/clue/branch/teacher_tests/teacher_chat_spec.js
+++ b/cypress/e2e/clue/branch/teacher_tests/teacher_chat_spec.js
@@ -56,7 +56,6 @@ context('Chat Panel', () => {
       chatPanel.getProblemDocumentContent().should('be.visible').should('have.css', 'background-color').and('eq', selectedChatBackground);
       chatPanel.getSelectedCommentThreadHeader().should('have.css', 'background-color');
       chatPanel.getSelectedCommentThreadHeader().should('have.css', 'background-color').and('eq', expandedChatBackground);
-      cy.pause();
     });
     it('verify the comment card and tile are highlighted', () => {
       cy.clickProblemResourceTile('introduction');

--- a/cypress/e2e/clue/branch/teacher_tests/teacher_chat_spec.js
+++ b/cypress/e2e/clue/branch/teacher_tests/teacher_chat_spec.js
@@ -45,11 +45,11 @@ context('Chat Panel', () => {
       chatPanel.getChatPanelToggle().should('exist');
       chatPanel.getChatPanel().should('not.exist');
     });
-    it('verify new comment card is visible, card icon is visible and Post button is disabled', () => {
+    it('verify new comment card exits, card icon exists and Post button is disabled', () => {
       chatPanel.getChatPanelToggle().click();
-      chatPanel.getCommentCard().should('be.visible');
+      cy.wait(2000);
+      chatPanel.getCommentCard().should('exist');
       chatPanel.getCommentPostButton().should('have.class', 'disabled');
-      chatPanel.getCommentCardHeaderIcon().should('be.visible');
     });
     it('verify the comment card and the document are highlighted', () => {
       chatPanel.verifyProblemCommentClass();
@@ -57,10 +57,11 @@ context('Chat Panel', () => {
       chatPanel.getSelectedCommentThreadHeader().should('have.css', 'background-color');
       chatPanel.getSelectedCommentThreadHeader().should('have.css', 'background-color').and('eq', expandedChatBackground);
     });
-    it('verify the comment card and tile are highlighted', () => {
+    it('verify the comment card and tile are highlighted and have tile icon', () => {
       cy.clickProblemResourceTile('introduction');
       cy.wait(2000);
-      chatPanel.getSelectedCommentThreadHeader().should('be.visible').should('have.css', 'background-color').and('eq', expandedChatBackground);
+      chatPanel.getSelectedCommentThreadHeader().should('exist').should('have.css', 'background-color').and('eq', expandedChatBackground);
+      chatPanel.getCommentTileTypeIcon().should('exist');
       chatPanel.getToolTile().should('be.visible').should('have.css', 'background-color').and('eq', selectedChatBackground);
     });
     it('verify user can cancel a comment', () => {

--- a/cypress/e2e/clue/full/teacher_tests/teacher_network_problem_chat_spec.js
+++ b/cypress/e2e/clue/full/teacher_tests/teacher_network_problem_chat_spec.js
@@ -51,6 +51,7 @@ describe('Teachers can communicate back and forth in chat panel', () => {
     chatPanel.openTeacherChat(portalUrl, clueTeacher2, reportUrl2);
     cy.openTopTab("problems");
     cy.openProblemSection("Introduction");
+    cy.wait(2000);
 
     // Teacher 2 document comment
     chatPanel.verifyProblemCommentClass();
@@ -58,6 +59,7 @@ describe('Teachers can communicate back and forth in chat panel', () => {
     chatPanel.addCommentAndVerify("This is a teacher2 problem document comment");
     // Teacher 2 tile comment
     cy.clickProblemResourceTile('introduction');
+    cy.wait(2000);
     chatPanel.verifyCommentThreadContains("This is a teacher1 problem tile comment");
     chatPanel.addCommentAndVerify("This is a teacher2 problem tile comment");
   });
@@ -65,12 +67,14 @@ describe('Teachers can communicate back and forth in chat panel', () => {
     chatPanel.openTeacherChat(portalUrl, clueTeacher1, reportUrl1);
     cy.openTopTab("problems");
     cy.openProblemSection("Introduction");
+    cy.wait(2000);
 
     // Teacher 1 document comment
     chatPanel.verifyProblemCommentClass();
     chatPanel.verifyCommentThreadContains("This is a teacher2 problem document comment");
     // Teacher 1 tile comment
     cy.clickProblemResourceTile('introduction');
+    cy.wait(2000);
     chatPanel.verifyCommentThreadContains("This is a teacher2 problem tile comment");
   });
     //TODO: verify delete is disabled for now until work is merged to master, but keep the delete to clean up chat space

--- a/cypress/support/elements/clue/ChatPanel.js
+++ b/cypress/support/elements/clue/ChatPanel.js
@@ -40,7 +40,7 @@ class ChatPanel{
       return cy.get('[data-testid=comment-cancel-button]');
     }
     getSelectedCommentThreadHeader(){
-      return cy.get('.chat-thread-focused').find('[data-testid=chat-thread-header]')
+      return cy.get('.chat-thread-focused').find('[data-testid=chat-thread-header]');
     }
     getCommentFromThread() {
       return cy.get('[data-testid=comment-thread] [data-testid=comment]');

--- a/cypress/support/elements/clue/ChatPanel.js
+++ b/cypress/support/elements/clue/ChatPanel.js
@@ -39,6 +39,9 @@ class ChatPanel{
     getCommentCancelButton(){
       return cy.get('[data-testid=comment-cancel-button]');
     }
+    getSelectedCommentThreadHeader(){
+      return cy.get('.chat-thread-focused').find('[data-testid=chat-thread-header]')
+    }
     getCommentFromThread() {
       return cy.get('[data-testid=comment-thread] [data-testid=comment]');
     }
@@ -62,11 +65,11 @@ class ChatPanel{
     }
     typeInCommentArea(commentText) {
       // If the comment list is long, the text box is off screen so force.
-      cy.get("[data-testid=comment-textarea]").type(commentText, {force: true});
+      cy.get("[data-testid=comment-textarea]").scrollIntoView().type(commentText, {force: true});
     }
     clickPostCommentButton() {
       // If the comment list is long, the button is off screen so force.
-      cy.get("[data-testid=comment-post-button]").click({force: true});
+      cy.get("[data-testid=comment-post-button]").scrollIntoView().click({force: true});
       cy.wait(5000);
     }
     useEnterToPostComment() {
@@ -92,10 +95,10 @@ class ChatPanel{
       cy.getToolTile(tileIndex).should('not.have.class', TILE_COMMENT_CLASS);
     }
     verifyCommentAreaContains(commentText) {
-      this.getCommentTextArea().should('contain', commentText);
+      this.getCommentTextArea().scrollIntoView().should('contain', commentText);
     }
     verifyCommentAreaDoesNotContain(commentText) {
-      this.getCommentTextArea().should('not.contain', commentText);
+      this.getCommentTextArea().scrollIntoView().should('not.contain', commentText);
     }
     verifyCommentThreadLength(length) {
       this.getCommentFromThread().should("have.length", length);

--- a/cypress/support/elements/clue/ChatPanel.js
+++ b/cypress/support/elements/clue/ChatPanel.js
@@ -24,8 +24,8 @@ class ChatPanel{
     getCommentCard() {
       return cy.get('[data-testid=comment-card]');
     }
-    getCommentCardHeaderIcon() {
-      return cy.get('[data-testid=comment-card-header-icon]');
+    getCommentTileTypeIcon() {
+      return cy.get('[data-testid=chat-thread-tile-type]').find('svg');
     }
     getCommentTextArea() {
       return cy.get('[data-testid=comment-textarea]');

--- a/src/components/chat/chat-thread.scss
+++ b/src/components/chat/chat-thread.scss
@@ -1,9 +1,9 @@
 @import "../vars";
 
 .chat-list {
-  height: 100%;
-  overflow-y: scroll;
-  overflow-x: hidden;
+  max-height: calc(100vh - (#{$header-height} + #{$problem-header-height} + #{$workspace-content-margin} * 2));
+  overflow-y: auto;
+
   .chat-thread {
     margin: 2px;
     white-space: pre-wrap;

--- a/src/components/chat/chat-thread.scss
+++ b/src/components/chat/chat-thread.scss
@@ -8,7 +8,6 @@
     width: 100%;
     margin: 2px;
     white-space: pre-wrap;
-    background-color: $classwork-purple-light-7;
     .user-icon {
       display: flex;
       align-items: center;
@@ -33,6 +32,32 @@
       border: solid 2px var(--charcoal-light-2);
       align-items: center;
       justify-content: space-between;
+      background-color: $charcoal-light-8;
+      color: $charcoal;
+      &.selected {
+        background-color: $comment-select-green-dark;
+      }
+      &.problems {
+        background-color: $problem-orange-light-7;
+      }
+      &.teacher-guide {
+        background-color: $learninglog-green-light-7;
+      }
+      &.my-work {
+        background-color: $workspace-teal-light-6;
+      }
+      &.class-work {
+        background-color: $classwork-purple-light-7;
+      }
+      &.supports {
+        background-color: $support-blue-light-7;
+      }
+      .comment-card-header-icon {
+        height: 34px;
+      }
+      &.selected {
+        background-color: $comment-select-green-dark;
+      }
     }
     .chat-thread-title {
         line-height: 1.29;
@@ -56,8 +81,5 @@
       background-color: white;
       text-align: center;
     }
-  }
-  .chat-thread.chat-thread-focused {
-    background-color: $learninglog-green-light-7
   }
 }

--- a/src/components/chat/chat-thread.scss
+++ b/src/components/chat/chat-thread.scss
@@ -12,17 +12,16 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      margin: 2px;
+      margin: 3px 2px 2px 5px;
+      padding: 2px 3px 3px 2px;
       border-radius: 4px;
       border: solid 1px $charcoal-light-1-c;
       background-color: white;
-      width: 21px;
-      height: 21px;
-      font-size: 14px;
-      font-weight: bold;
+      width: 15px;
+      height: 15px;
       svg {
-        width: 14px;
-        height: 14px;
+        width: 10px;
+        height: 10px;
         fill: $problem-orange;
       }
     }
@@ -88,6 +87,7 @@
       border-radius: 7.5px;
       background-color: white;
       text-align: center;
+      font-size: 10px;
     }
   }
 }

--- a/src/components/chat/chat-thread.scss
+++ b/src/components/chat/chat-thread.scss
@@ -25,17 +25,22 @@
         fill: $problem-orange;
       }
     }
+    &.chat-thread-focused {
+      border: solid 1px $charcoal-light-2;
+    }
     .chat-thread-header {
-      margin: 0 2px;
+      padding: 0 2px;
       display: flex;
       flex-direction: row;
-      border: solid 2px var(--charcoal-light-2);
       align-items: center;
       justify-content: space-between;
       background-color: $charcoal-light-8;
       color: $charcoal;
+      border: solid 1px $charcoal-light-2;
+
       &.selected {
         background-color: $comment-select-green-dark;
+        border: none;
       }
       &.problems {
         background-color: $problem-orange-light-7;

--- a/src/components/chat/chat-thread.scss
+++ b/src/components/chat/chat-thread.scss
@@ -7,6 +7,7 @@
   .chat-thread {
     margin: 2px;
     white-space: pre-wrap;
+    
     .user-icon {
       display: flex;
       align-items: center;
@@ -37,7 +38,9 @@
       background-color: $charcoal-light-8;
       color: $charcoal;
       border: solid 1px $charcoal-light-2;
-
+      &:hover {
+        opacity: .5;
+      }
       &.selected {
         background-color: $comment-select-green-dark;
         border: none;

--- a/src/components/chat/chat-thread.scss
+++ b/src/components/chat/chat-thread.scss
@@ -5,7 +5,6 @@
   overflow-y: scroll;
   overflow-x: hidden;
   .chat-thread {
-    width: 100%;
     margin: 2px;
     white-space: pre-wrap;
     .user-icon {
@@ -27,6 +26,7 @@
       }
     }
     .chat-thread-header {
+      margin: 0 2px;
       display: flex;
       flex-direction: row;
       border: solid 2px var(--charcoal-light-2);

--- a/src/components/chat/chat-thread.tsx
+++ b/src/components/chat/chat-thread.tsx
@@ -72,7 +72,7 @@ export const ChatThread: React.FC<IProps> = ({ activeNavTab, user, chatThreads,
             > 
               <div className="chat-thread-tile-info">
                {Icon && (
-                <div data-testid="chat-thread-tile-type"><Icon/></div>
+                  <Icon data-testid="chat-thread-tile-type"/>
                )}
                 <div className="chat-thread-title"> {title} </div>
               </div>
@@ -110,9 +110,9 @@ export const ChatThread: React.FC<IProps> = ({ activeNavTab, user, chatThreads,
             <div className="chat-thread-tile-info">
               <div className="comment-card-header comment-select" data-testid="comment-card-header">
                 <div className="comment-card-header-icon" data-testid="comment-card-header-icon">
-                <div data-testid="chat-thread-tile-type">
-                  <ToolIconComponent documentKey={focusDocument} tileId={focusTileId}/>
-                </div>
+                  <div data-testid="chat-thread-tile-type">
+                    <ToolIconComponent documentKey={focusDocument} tileId={focusTileId}/>
+                  </div>
                 </div>
               </div>
               <div className="chat-thread-comment-info">  

--- a/src/components/chat/chat-thread.tsx
+++ b/src/components/chat/chat-thread.tsx
@@ -71,7 +71,9 @@ export const ChatThread: React.FC<IProps> = ({ activeNavTab, user, chatThreads,
               onClick={() => handleThreadClick(key)}
             > 
               <div className="chat-thread-tile-info">
-                {Icon && <Icon/>}
+               {Icon && (
+                <div data-testid="chat-thread-tile-type"><Icon/></div>
+               )}
                 <div className="chat-thread-title"> {title} </div>
               </div>
               <div className="chat-thread-comment-info">  
@@ -111,7 +113,7 @@ export const ChatThread: React.FC<IProps> = ({ activeNavTab, user, chatThreads,
                 </div>
               </div>
               <div className="chat-thread-comment-info">  
-                <div className="chat-thread-num">{0}</div>  
+                <div className="chat-thread-num">{0}</div>
               </div>
             </div> 
           </div>

--- a/src/components/chat/chat-thread.tsx
+++ b/src/components/chat/chat-thread.tsx
@@ -41,12 +41,10 @@ export const ChatThread: React.FC<IProps> = ({ activeNavTab, user, chatThreads,
       // The tile should stay selected though.
       setExpandedThread('');
     } else {
+      // If the clickedId was the document, the selectedTile should be set to empty.
+      const selectedTileId = clickedId === "document" ? '' : clickedId;
+      ui.setSelectedTileId(selectedTileId || '');
       setExpandedThread(clickedId || '');
-      // Don't change the selected tile when we clicked on the document
-      // isntead of a tile.
-      if (clickedId !== "document") {
-        ui.setSelectedTileId(clickedId || '');
-      }
     }
   };
 

--- a/src/components/chat/chat-thread.tsx
+++ b/src/components/chat/chat-thread.tsx
@@ -103,13 +103,16 @@ export const ChatThread: React.FC<IProps> = ({ activeNavTab, user, chatThreads,
       }
       {focusedItemHasNoComments  &&
         <div key={focusTileId ? focusTileId : "document"}
-          className="chat-thread should-be-focused"
+          className="chat-thread chat-thread-focused"
           data-testid="chat-thread">
-          <div className={`chat-thread-header ${activeNavTab} selected`}> 
+          <div className={`chat-thread-header ${activeNavTab} selected`}
+            data-testid="chat-thread-header"> 
             <div className="chat-thread-tile-info">
               <div className="comment-card-header comment-select" data-testid="comment-card-header">
                 <div className="comment-card-header-icon" data-testid="comment-card-header-icon">
+                <div data-testid="chat-thread-tile-type">
                   <ToolIconComponent documentKey={focusDocument} tileId={focusTileId}/>
+                </div>
                 </div>
               </div>
               <div className="chat-thread-comment-info">  

--- a/src/components/chat/chat-thread.tsx
+++ b/src/components/chat/chat-thread.tsx
@@ -63,7 +63,12 @@ export const ChatThread: React.FC<IProps> = ({ activeNavTab, user, chatThreads,
               "chat-thread-focused": shouldBeFocused,
             })}
             data-testid="chat-thread">
-            <div className="chat-thread-header" onClick={() => handleThreadClick(key)}> 
+            <div className={classNames(`chat-thread-header ${activeNavTab}`,
+            {
+             "selected": shouldBeFocused 
+            })
+            }
+            onClick={() => handleThreadClick(key)}> 
               <div className="chat-thread-tile-info">
                 {Icon && <Icon/>}
                 <div className="chat-thread-title"> {title} </div>
@@ -97,7 +102,7 @@ export const ChatThread: React.FC<IProps> = ({ activeNavTab, user, chatThreads,
         <div key={focusTileId ? focusTileId : "document"}
           className="chat-thread should-be-focused"
           data-testid="chat-thread">
-          <div className="chat-thread-header"> 
+          <div className={`chat-thread-header ${activeNavTab} selected`}> 
             <div className="chat-thread-tile-info">
               <div className="comment-card-header comment-select" data-testid="comment-card-header">
                 <div className="comment-card-header-icon" data-testid="comment-card-header-icon">

--- a/src/components/chat/chat-thread.tsx
+++ b/src/components/chat/chat-thread.tsx
@@ -37,12 +37,16 @@ export const ChatThread: React.FC<IProps> = ({ activeNavTab, user, chatThreads,
   const ui = useUIStore();
   const handleThreadClick = (clickedId: string | null) => {
     if (clickedId === expandedThread) {
-      // We're closing the thread so clear it out.
+      // We're closing the thread so clear out expanded thread.
+      // The tile should stay selected though.
       setExpandedThread('');
-      ui.setSelectedTileId('');
     } else {
-      setExpandedThread(clickedId || "document");
-      ui.setSelectedTileId(clickedId || '');
+      setExpandedThread(clickedId || '');
+      // Don't change the selected tile when we clicked on the document
+      // isntead of a tile.
+      if (clickedId !== "document") {
+        ui.setSelectedTileId(clickedId || '');
+      }
     }
   };
 

--- a/src/components/chat/chat-thread.tsx
+++ b/src/components/chat/chat-thread.tsx
@@ -66,11 +66,10 @@ export const ChatThread: React.FC<IProps> = ({ activeNavTab, user, chatThreads,
             })}
             data-testid="chat-thread">
             <div className={classNames(`chat-thread-header ${activeNavTab}`,
-            {
-             "selected": shouldBeFocused 
-            })
-            }
-            onClick={() => handleThreadClick(key)}> 
+              { "selected": shouldBeFocused })}
+              data-testid="chat-thread-header"
+              onClick={() => handleThreadClick(key)}
+            > 
               <div className="chat-thread-tile-info">
                 {Icon && <Icon/>}
                 <div className="chat-thread-title"> {title} </div>

--- a/src/components/chat/comment-card.scss
+++ b/src/components/chat/comment-card.scss
@@ -1,23 +1,18 @@
 @import "../vars";
 
 .comment-card {
-  width: calc(100% - 4px);
   height: calc(100% - 38px);
   min-height: 106px;
-  margin: 2px;
-  border: solid 2px $charcoal-light-2;
   overflow-y: auto;
   white-space: pre-wrap;
+  margin: 0 2px;
 
-  .comment-card-content {
-    padding-bottom: 2px;
-    &.selected {
-      background-color: $comment-select-green;
-    }
+  &.selected {
+    background-color: $comment-select-green;
   }
 
   .comment-thread {
-    margin: 3px 0 2px 5px;
+    margin: 0 0px 0 5px;
     .comment-text-header {
       display: flex;
       flex-direction: row;

--- a/src/components/chat/comment-card.scss
+++ b/src/components/chat/comment-card.scss
@@ -16,36 +16,6 @@
     }
   }
 
-  .comment-card-header {
-    display: flex;
-    align-items: center;
-    width: 100%;
-    height: fit-content;
-    padding: 0;
-    background-color: $charcoal-light-8;
-    color: $charcoal;
-    &.comment-select {
-      background-color: $comment-select-green-dark;
-    }
-    &.problems {
-      background-color: $problem-orange-light-7;
-    }
-    &.teacher-guide {
-      background-color: $learninglog-green-light-7;
-    }
-    &.my-work {
-      background-color: $workspace-teal-light-6;
-    }
-    &.class-work {
-      background-color: $classwork-purple-light-7;
-    }
-    &.supports {
-      background-color: $support-blue-light-7;
-    }
-    .comment-card-header-icon {
-      height: 34px;
-    }
-  }
   .comment-thread {
     margin: 3px 0 2px 5px;
     .comment-text-header {

--- a/src/components/chat/comment-card.scss
+++ b/src/components/chat/comment-card.scss
@@ -5,7 +5,7 @@
   min-height: 106px;
   overflow-y: auto;
   white-space: pre-wrap;
-  margin: 0 2px;
+  padding: 0 2px;
 
   &.selected {
     background-color: $comment-select-green;

--- a/src/components/chat/comment-card.tsx
+++ b/src/components/chat/comment-card.tsx
@@ -55,7 +55,7 @@ export const CommentCard: React.FC<IProps> = ({ activeNavTab, user, postedCommen
     }
   };
   return (
-    <div className="comment-card" data-testid="comment-card">
+    <div className="comment-card selected" data-testid="comment-card">
       <div className="comment-card-content selected" data-testid="comment-card-content">
         {postedComments?.map((comment, idx) => {
             const userInitialBackgroundColor = ["#f79999", "#ffc18a", "#99d099", "#ff9", "#b2b2ff", "#efa6ef"];


### PR DESCRIPTION
Fixing a bunch of styling for comments
- Shows the selected comment as green or the color of the problem, mywork, etc.
   - This led me to finding and fixing a bug to keep the thread selection and document selection in sync when the document or document comment thread was selected (see logic change in `handleThreadClick`)
- fixes spacing between comments and threads
- Fixes the chat count spacing

Fixing the styling (mainly removing some styles/ids at the individual comment level and moving them up to the thread tickled the cypress tests. I also added a bunch of waits when a new set of comments is loaded because I was finding that the tests were pretty flaky when I was running them locally. 
