### PR TITLE
Allow authed users to know whether a resource/document exists

### DIFF
--- a/firebase-test/src/documents-rules.test.ts
+++ b/firebase-test/src/documents-rules.test.ts
@@ -50,6 +50,7 @@ describe("Firestore security rules", () => {
 
     it("authenticated generic users can't read authenticated user documents", async () => {
       db = initFirestore(genericAuth);
+      await adminWriteDoc(kDocumentDocPath, specDocumentDoc());
       await expectReadToFail(db, kDocumentDocPath);
     });
 
@@ -62,6 +63,32 @@ describe("Firestore security rules", () => {
       db = initFirestore(teacherAuth);
       await adminWriteDoc(kDocumentDocPath, specDocumentDoc());
       await expectReadToSucceed(db, kDocumentDocPath);
+    });
+
+    it("teacher can tell if document exists", async () => {
+      db = initFirestore(teacherAuth);
+      await expectReadToSucceed(db, kDocumentDocPath);
+      await adminWriteDoc(kDocumentDocPath, specDocumentDoc());
+      await expectReadToSucceed(db, kDocumentDocPath);
+    });
+
+    it("student can tell if document exists, but not read it", async () => {
+      db = initFirestore(studentAuth);
+      await expectReadToSucceed(db, kDocumentDocPath);
+      await adminWriteDoc(kDocumentDocPath, specDocumentDoc());
+      await expectReadToFail(db, kDocumentDocPath);
+    });
+
+    it("generic auth can tell if document exists, but not read it", async () => {
+      db = initFirestore(genericAuth);
+      await expectReadToSucceed(db, kDocumentDocPath);
+      await adminWriteDoc(kDocumentDocPath, specDocumentDoc());
+      await expectReadToFail(db, kDocumentDocPath);
+    });
+
+    it("un auth'd can't tell if document exists", async () => {
+      db = initFirestore();
+      await expectReadToFail(db, kDocumentDocPath);
     });
 
     it("authenticated teachers can't write user documents without required uid", async () => {

--- a/firestore.rules
+++ b/firestore.rules
@@ -294,7 +294,7 @@ service cloud.firestore {
         // teachers can only delete their own documents
         allow delete: if isAuthedTeacher() && userIsResourceUser();
         // teachers can read their own documents or other documents in their network
-        allow read: if isAuthedTeacher() && (userInResourceTeachers() || resourceInTeacherNetworks());
+        allow read: if  (isAuthed() &&  resource == null) || (isAuthedTeacher() && (userInResourceTeachers() || resourceInTeacherNetworks()));
 
         // return the list of teachers associated with the specified document
         function getDocumentTeachers() {


### PR DESCRIPTION
Change the rules for document reads to allow all auth'd users to know whether a document exists.  The same rules should still apply to actually reading the document contents though.
