### PR TITLE
fix issues with history loading

### DIFF
--- a/cypress/e2e/clue/branch/teacher_tests/teacher_workspace_spec.js
+++ b/cypress/e2e/clue/branch/teacher_tests/teacher_workspace_spec.js
@@ -52,24 +52,15 @@ context('Teacher Workspace', () => {
     });
 
     describe('verify playback', () => {
-      it('verify playback is disabled if there is not history', function() {
+      it('verify playback shows no history if there is no history', function() {
         cy.openTopTab('my-work');
         cy.openDocumentThumbnail('workspaces', this.investigationTitle);
-        // FIXME-HISTORY: the following line is skipped for now because it is
-        // easier to always show the playback and then attempt to download the
-        // history when it is clicked. Story to fix this:
-        // https://www.pivotaltracker.com/story/show/183291329 
-        //
-        // The whole test isn't skipped because the 2 above lines are needed for
-        // the later tests.
-        // cy.get('[data-testid="playback-component"]').should('have.class',
-        // 'disabled');
+        cy.get('[data-testid="playback-component-button"]').click();
+        cy.get('.playback-controls').contains("This document has no history");
+        cy.get('[data-testid="playback-component-button"]').click();
       });
-      it('verify playback button enables when there is a history', () => {
+      it('verify playback controls open with slider when there is history', () => {
         clueCanvas.addTile('drawing');
-        cy.get('[data-testid="playback-component"]').should('not.have.class', 'disabled');
-      });
-      it('verify playback controls open', () => {
         cy.get('[data-testid="playback-component-button"]').click();
         cy.get('[data-testid="playback-slider"]').should('be.visible');
         cy.get('[data-testid="playback-time-info"]').should('be.visible');

--- a/src/components/playback/playback.tsx
+++ b/src/components/playback/playback.tsx
@@ -21,10 +21,6 @@ export const PlaybackComponent: React.FC<IProps> = observer((props: IProps) => {
   const { document, showPlaybackControls, onTogglePlaybackControls  } = props;
   const { activeNavTab } = useUIStore();
   const treeManager = document?.treeManagerAPI as Instance<typeof TreeManager>;
-  // FIXME-HISTORY: hack for always enabling playback. Story to fix this:
-  // https://www.pivotaltracker.com/story/show/183291329
-  //
-  // const history = treeManager?.document.history;
 
   const renderPlaybackToolbarButton = () => {
     const playbackToolbarButtonComponentStyle =
@@ -47,11 +43,6 @@ export const PlaybackComponent: React.FC<IProps> = observer((props: IProps) => {
 
   const actuallyShowPlaybackControls = showPlaybackControls && (historyLength !== undefined) && (historyLength > 0);
 
-  // const disablePlayback = history.length < 1;
-
-  // FIXME-HISTORY: HACK for now always enable playback so we can use the
-  // opening of the playback to trigger the load of the history.  Story to fix
-  // this: https://www.pivotaltracker.com/story/show/183291329
   const disablePlayback = false;
   const playbackComponentClass = classNames("playback-component", activeNavTab,
                                             {"show-control" : showPlaybackControls,
@@ -59,13 +50,8 @@ export const PlaybackComponent: React.FC<IProps> = observer((props: IProps) => {
   return (
     <div className={playbackComponentClass} data-testid="playback-component">
       {renderPlaybackToolbarButton()}
-      {actuallyShowPlaybackControls
-        // If we've found history, display the playback control
-        ? <PlaybackControlComponent treeManager={treeManager} />
-        : showPlaybackControls
-        // If we're loading the history or couldn't find any, display the loading component
-        ? <LoadDocumentHistory document={document} />
-        : ''}
+      {showPlaybackControls && <LoadDocumentHistory document={document} />}
+      {actuallyShowPlaybackControls && <PlaybackControlComponent treeManager={treeManager} />}
     </div>
   );
 });


### PR DESCRIPTION
- update the cypress test to reflect the new behavior
- remove the FIXMEs that are relevant anymore
- add dependencies to the useEffect so it doesn't cause a render loop
- always render the LoadDocumentHistory otherwise it would get disposed too soon