### PR TITLE
fix MST errors caused by dataSet caching

### DIFF
--- a/src/components/tools/table-tool/table-tool.tsx
+++ b/src/components/tools/table-tool/table-tool.tsx
@@ -53,7 +53,7 @@ const TableToolComponent: React.FC<IToolTileProps> = observer(({
   // Functions for determining the height of rows, including the header
   // These require knowledge of the column widths
   const { rowHeight, headerHeight, headerRowHeight } = useRowHeight({
-    dataSet: dataSet.current, measureColumnWidth, model });
+    dataSet, measureColumnWidth, model });
 
   // A function to generate a unique title for the tile
   // TODO The table tile should switch to the new CLUE wide method of determining titles, and this should be removed
@@ -75,17 +75,17 @@ const TableToolComponent: React.FC<IToolTileProps> = observer(({
   // rows are required by ReactDataGrid and are used by other hooks as well
   // rowProps are expanded and passed to ReactDataGrid
   const { rows, ...rowProps } = useRowsFromDataSet({
-    dataSet: dataSet.current, readOnly: !!readOnly, inputRowId: inputRowId.current,
+    dataSet, readOnly: !!readOnly, inputRowId: inputRowId.current,
     rowChanges, context: gridContext});
 
   // columns are required by ReactDataGrid and are used by other hooks as well
   const { columns, controlsColumn, columnEditingName, handleSetColumnEditingName } = useColumnsFromDataSet({
-    gridContext, dataSet: dataSet.current, metadata, readOnly: !!readOnly, columnChanges, headerHeight, rowHeight,
+    gridContext, dataSet, metadata, readOnly: !!readOnly, columnChanges, headerHeight, rowHeight,
     ...rowLabelProps, measureColumnWidth });
 
   // The size of the title bar
   const { titleCellWidth, getTitleHeight } =
-    useTitleSize({ readOnly, columns, measureColumnWidth, dataSet: dataSet.current, rowChanges });
+    useTitleSize({ readOnly, columns, measureColumnWidth, dataSet, rowChanges });
 
   // A function to update the height of the tile based on the content size
   const heightRef = useCurrent(height);
@@ -100,7 +100,7 @@ const TableToolComponent: React.FC<IToolTileProps> = observer(({
 
   // Various callbacks to use when the table needs to be modified
   const changeHandlers = useContentChangeHandlers({
-    model, dataSet: dataSet.current, rows, rowHeight, headerHeight, getTitleHeight,
+    model, dataSet, rows, rowHeight, headerHeight, getTitleHeight,
     onRequestRowHeight: handleRequestRowHeight, triggerColumnChange, triggerRowChange
   });
   const { onSetTableTitle, onSetColumnExpressions, onLinkGeometryTile, onUnlinkGeometryTile,
@@ -115,18 +115,18 @@ const TableToolComponent: React.FC<IToolTileProps> = observer(({
 
   // Functions for getting and modifying the title
   const { getTitle, onBeginTitleEdit, onEndTitleEdit } = useTableTitle({
-    gridContext, dataSet: dataSet.current, readOnly,
+    gridContext, model, readOnly,
     onSetTableTitle, onRequestUniqueTitle: handleRequestUniqueTitle, requestRowHeight
   });
 
   // Functions for setting and displaying expressions
   const handleSubmitExpressions = (expressions: Map<string, string>) => {
-    if (dataSet.current.attributes.length && expressions.size) {
-      onSetColumnExpressions(expressions, dataSet.current.attributes[0].name);
+    if (dataSet.attributes.length && expressions.size) {
+      onSetColumnExpressions(expressions, dataSet.attributes[0].name);
     }
   };
   const [showExpressionsDialog, , setCurrYAttrId] = useExpressionsDialog({
-    metadata, dataSet: dataSet.current, onSubmit: handleSubmitExpressions
+    metadata, dataSet, onSubmit: handleSubmitExpressions
   });
   const handleShowExpressionsDialog = (attrId?: string) => {
     attrId && setCurrYAttrId(attrId);
@@ -142,7 +142,7 @@ const TableToolComponent: React.FC<IToolTileProps> = observer(({
   // dataGridProps contains callbacks to pass to ReactDataGrid
   // hasLinkableRows is used to determine if the table can meaningfully be linked to a geometry tile
   const { hasLinkableRows, ...dataGridProps } = useDataSet({
-    gridRef, model, dataSet: dataSet.current, triggerColumnChange, rows, rowChanges, triggerRowChange,
+    gridRef, model, dataSet, triggerColumnChange, rows, rowChanges, triggerRowChange,
     readOnly: !!readOnly, changeHandlers, columns, onColumnResize, selectedCell, inputRowId });
 
   // Variables for handling linking to geometry tiles
@@ -169,7 +169,7 @@ const TableToolComponent: React.FC<IToolTileProps> = observer(({
     });
   }, [rows, rowHeight, headerHeight, getTitleHeight, getContent, modelRef, readOnly]);
   const exportContentAsTileJson = useCallback(() => {
-    return exportTableContentAsJson(content.metadata, dataSet.current, content.columnWidth);
+    return exportTableContentAsJson(content.metadata, dataSet, content.columnWidth);
   }, [dataSet, content]);
   useToolApi({ content: getContent(), getTitle, getContentHeight, exportContentAsTileJson,
                 onRegisterToolApi, onUnregisterToolApi });

--- a/src/components/tools/table-tool/table-tool.tsx
+++ b/src/components/tools/table-tool/table-tool.tsx
@@ -45,7 +45,7 @@ const TableToolComponent: React.FC<IToolTileProps> = observer(({
   // Basic operations based on the model
   const {
     dataSet, columnChanges, triggerColumnChange, rowChanges, triggerRowChange, ...gridModelProps
-  } = useModelDataSet(model);
+  } = useModelDataSet(content);
 
   // Set up user specified columns and function to measure a column
   const { measureColumnWidth, resizeColumn, resizeColumnWidth } = useMeasureColumnWidth({ content });
@@ -115,7 +115,7 @@ const TableToolComponent: React.FC<IToolTileProps> = observer(({
 
   // Functions for getting and modifying the title
   const { getTitle, onBeginTitleEdit, onEndTitleEdit } = useTableTitle({
-    gridContext, model, readOnly,
+    gridContext, content, readOnly,
     onSetTableTitle, onRequestUniqueTitle: handleRequestUniqueTitle, requestRowHeight
   });
 

--- a/src/components/tools/table-tool/use-model-data-set.ts
+++ b/src/components/tools/table-tool/use-model-data-set.ts
@@ -1,10 +1,8 @@
 import classNames from "classnames";
 import { useCallback, useState } from "react";
 import { TableContentModelType } from "../../../models/tools/table/table-content";
-import { ToolTileModelType } from "../../../models/tools/tool-tile";
 
-export const useModelDataSet = (model: ToolTileModelType) => {
-  const content = (model.content as TableContentModelType);
+export const useModelDataSet = (content: TableContentModelType) => {
   const dataSet = content.dataSet;
   const [columnChanges, setColumnChanges] = useState(0);
   const triggerColumnChange = useCallback(() => setColumnChanges(state => ++state), []);

--- a/src/components/tools/table-tool/use-model-data-set.ts
+++ b/src/components/tools/table-tool/use-model-data-set.ts
@@ -1,24 +1,21 @@
 import classNames from "classnames";
 import { useCallback, useState } from "react";
-import { useCurrent } from "../../../hooks/use-current";
 import { TableContentModelType } from "../../../models/tools/table/table-content";
 import { ToolTileModelType } from "../../../models/tools/tool-tile";
 
 export const useModelDataSet = (model: ToolTileModelType) => {
-  const modelRef = useCurrent(model);
-  const getContent = useCallback(() => modelRef.current.content as TableContentModelType, [modelRef]);
-  const dataSet = useCurrent(getContent().dataSet);
+  const content = (model.content as TableContentModelType);
+  const dataSet = content.dataSet;
   const [columnChanges, setColumnChanges] = useState(0);
   const triggerColumnChange = useCallback(() => setColumnChanges(state => ++state), []);
   const [rowChanges, setRowChanges] = useState(0);
   const triggerRowChange = useCallback(() => setRowChanges(state => ++state), []);
 
   const setTableTitle = useCallback((title: string) => {
-    (title != null) && getContent().setTableName(title);
+    (title != null) && content.setTableName(title);
     triggerColumnChange();
-  }, [getContent, triggerColumnChange]);
+  }, [content, triggerColumnChange]);
 
-  const content = getContent();
   const className = classNames("rdg-light", { "show-expressions": content.hasExpressions });
 
   return { dataSet, columnChanges, triggerColumnChange, rowChanges, triggerRowChange,

--- a/src/components/tools/table-tool/use-table-title.ts
+++ b/src/components/tools/table-tool/use-table-title.ts
@@ -1,21 +1,23 @@
 import { useCallback, useEffect, useRef } from "react";
+import { ToolTileModelType } from "../../../models/tools/tool-tile";
 import { useCurrent } from "../../../hooks/use-current";
-import { IDataSet } from "../../../models/data/data-set";
 import { IGridContext } from "./table-types";
+import { TableContentModelType } from "../../../models/tools/table/table-content";
 
 interface IProps {
   gridContext: IGridContext;
-  dataSet: IDataSet;
+  model: ToolTileModelType;
   readOnly?: boolean;
   onRequestUniqueTitle?: () => string | undefined;
   onSetTableTitle?: (title: string) => void;
   requestRowHeight: () => void;
 }
 export const useTableTitle = ({
-  gridContext, dataSet, readOnly, onRequestUniqueTitle, onSetTableTitle, requestRowHeight
+  gridContext, model, readOnly, onRequestUniqueTitle, onSetTableTitle, requestRowHeight
 }: IProps) => {
-
-  const getTitle = useCallback(() => dataSet.name, [dataSet.name]);
+  
+  const tableContent = model.content as TableContentModelType;
+  const getTitle = useCallback(() => tableContent.dataSet.name, [tableContent]);
   const editingTitle = useCurrent(getTitle());
 
   const onBeginTitleEdit = () => {
@@ -33,12 +35,12 @@ export const useTableTitle = ({
   // request a default title if we don't already have one
   const onRequestUniqueTitleRef = useRef(onRequestUniqueTitle);
   useEffect(() => {
-    if (!dataSet.name) {
+    if (!tableContent.dataSet.name) {
       // wait for all tiles to have registered their callbacks
       setTimeout(() => {
         const _title = onRequestUniqueTitleRef.current?.();
         if (_title) {
-          dataSet.setName(_title);
+          tableContent.dataSet.setName(_title);
         }
       }, 100);
     }

--- a/src/components/tools/table-tool/use-table-title.ts
+++ b/src/components/tools/table-tool/use-table-title.ts
@@ -6,18 +6,17 @@ import { TableContentModelType } from "../../../models/tools/table/table-content
 
 interface IProps {
   gridContext: IGridContext;
-  model: ToolTileModelType;
+  content: TableContentModelType;
   readOnly?: boolean;
   onRequestUniqueTitle?: () => string | undefined;
   onSetTableTitle?: (title: string) => void;
   requestRowHeight: () => void;
 }
 export const useTableTitle = ({
-  gridContext, model, readOnly, onRequestUniqueTitle, onSetTableTitle, requestRowHeight
+  gridContext, content, readOnly, onRequestUniqueTitle, onSetTableTitle, requestRowHeight
 }: IProps) => {
   
-  const tableContent = model.content as TableContentModelType;
-  const getTitle = useCallback(() => tableContent.dataSet.name, [tableContent]);
+  const getTitle = useCallback(() => content.dataSet.name, [content]);
   const editingTitle = useCurrent(getTitle());
 
   const onBeginTitleEdit = () => {
@@ -35,12 +34,12 @@ export const useTableTitle = ({
   // request a default title if we don't already have one
   const onRequestUniqueTitleRef = useRef(onRequestUniqueTitle);
   useEffect(() => {
-    if (!tableContent.dataSet.name) {
+    if (!content.dataSet.name) {
       // wait for all tiles to have registered their callbacks
       setTimeout(() => {
         const _title = onRequestUniqueTitleRef.current?.();
         if (_title) {
-          tableContent.dataSet.setName(_title);
+          content.dataSet.setName(_title);
         }
       }, 100);
     }

--- a/src/models/tools/shared-model-document-manager.ts
+++ b/src/models/tools/shared-model-document-manager.ts
@@ -27,7 +27,6 @@ export class SharedModelDocumentManager implements ISharedModelDocumentManager {
       setDocument: action,
       findFirstSharedModelByType: action,
       addTileSharedModel: action,
-      getTileSharedModels: action,
       removeTileSharedModel: action
     });
   }
@@ -100,6 +99,7 @@ export class SharedModelDocumentManager implements ISharedModelDocumentManager {
     tileContentModel.updateAfterSharedModelChanges(sharedModel);
   }
 
+  // This is not an action because it is deriving state.
   getTileSharedModels(tileContentModel: IAnyStateTreeNode): SharedModelType[] {
     if (!this.document) {
       console.warn("getTileSharedModels has no document");


### PR DESCRIPTION
This removes MST warnings that were shown when a document with a legacy table tile was loaded by a teacher from the student workspace tab. In this case the document would be first created with the document state and a shared model dataset would be created. And then a firebase listener would fire and the document content would be updated with applySnapshot using the original document from firebase. This series of 2 loads of the document exposed issues with the components.

I choose to fix the components instead trying to deal with this other ways. For example we could probably prevent the firebase listener from firing when the document hasn't changed after the first load. However the generalized version of this problem is how to deal with migrated content. In that generalized case two users could have different versions of CLUE so it is possible for one user to be generating "old" documents that another user is then migrating on every change. So it seems best to establish patterns where the components can handle the state changing out from underneath them. This approach might also help in some cases of replaying history or undo because the state will be changing in a similar way.

I used this environment to track down the multiple causes of the warnings: http://localhost:8080/?appMode=demo&demoName=DataSetError&fakeClass=1&fakeUser=teacher:1&unit=sas&problem=0.1
The problematic document is in "Student Workspaces", G1, S1. The content of this document was copied from a document in the test class used by the cypress tests which is only available via portal login. As far as I can tell the document has to be a "Student Workspaces" document because those documents are monitored for changes.

One thing I found was the `SharedModelDocumentManager.getTileSharedModels` was not observable. When the shared model of the table tile changed that did not trigger an invalidation of the cached dataSet view in the TableContentModel. The fix for that was to remove the `action` annotation from `getTileSharedModels`. This change might fix other problems we were seeing around shared model updating, I can't remember exactly but I think we had to do some work-arounds because of this.

With `getTileSharedModels` fixed most of the warnings will still happening, but at least I could see via debugging that the updated dataset was being accessed.

The next set of issues all came from the `TableToolComponent` saving the dataSet in a reference object. I'm not sure why it was doing this. This reference was setup by `useModelDataSet`. In addition to the reference `useModelDataSet` was creating a memoized callback `getContent`. `getContent` was not used outside of the hook, so the only reason I can see to memoize was to use it as unchanging dependency on the `setTableTile` `useCallback`.  `setTableTile` is passed outside of the `useModelDataSet` hook, making it unchanging might help prevent some re-renders.
With my changes if the table content object is a new instance then the `setTableTile` callback will also be a new instance. The table content object should not change even in the case that triggered this whole investigation. The applySnapshot is called on the content object which will just update it not create a new instance.

Since the dataset is no longer a reference any hooks that list `dataSet` as a dependency will now get updated more often. The only place it is a dependency is in: `exportContentAsTileJson = useCallback(...` I'd guess it will be OK for `exportContentAsTileJson`  to change when the `dataSet` changes. This is used by the tool api, and as far as I can tell it is fine for new tool apis to be registered with the same tile id. The new tool api will just replace the old one.

The last change is to pass `content` to `useTableTile`. It creates and outputs a `getTitle` callback. This callback had a dependency on `dataSet.name`. So if the name of the dataSet wasn't changing then the callback would not be updated. In the case causing problems the new dataSet would have the same name as the old dataSet, so the callback would continue to reference the old dataSet.  By passing the content and then having the callback get to the dataSet from the model it is safer. The content object should not change, when new data comes from firebase the content is updated not recreated by `applySnapshot(content, data)`,  so the callback should almost never change. And because the callback is dereferencing the dataSet from the content, the dataSet should always be the most recent dataSet. 

I might have missed something here that will break without a dataSet reference, so this should be tested more.