### PR TITLE
Rule fixes

### DIFF
--- a/firebase-test/src/documents-rules.test.ts
+++ b/firebase-test/src/documents-rules.test.ts
@@ -211,6 +211,11 @@ describe("Firestore security rules", () => {
       await adminWriteDoc(kDocumentHistoryDocPath, specHistoryEntryDoc());
       await expectReadToSucceed(db, kDocumentHistoryDocPath);
     });
+    it ("student can read parent if it already exists", async () => {
+      db = initFirestore(studentAuth);
+      await adminWriteDoc(kDocumentDocPath, specHistoryEntryParentDoc({add:{uid: studentId }}));
+      await expectReadToSucceed(db, kDocumentDocPath);
+    });
     
     it ("student cannot read their own history entries if no parent", async () => {
       db = initFirestore(studentAuth);

--- a/firestore.rules
+++ b/firestore.rules
@@ -294,7 +294,7 @@ service cloud.firestore {
         // teachers can only delete their own documents
         allow delete: if isAuthedTeacher() && userIsResourceUser();
         // teachers can read their own documents or other documents in their network
-        allow read: if  (isAuthed() &&  resource == null) || (isAuthedTeacher() && (userInResourceTeachers() || resourceInTeacherNetworks()));
+        allow read: if  (isAuthed() && (resource == null || userOwnsDocument())) || (isAuthedTeacher() && (userInResourceTeachers() || resourceInTeacherNetworks()));
 
         function getDocumentData() {
           return get(/databases/$(database)/documents/authed/$(portal)/documents/$(docId)).data;
@@ -316,7 +316,7 @@ service cloud.firestore {
 
         // check whether the current teacher is one of the teachers associated with the document
         function teacherInDocumentTeachers() {
-          return isAuthedTeacher() && (request.auth.uid in getDocumentTeachers());
+          return isAuthedTeacher() && (string(request.auth.token.platform_user_id) in getDocumentTeachers());
         }
 
         // check whether the document's network corresponds to one of the teacher's networks


### PR DESCRIPTION
- Allow students to read their own history documents when they already exist
- Change `teacherInDocumentTeachers` to use `platform_ui_id` to check the list since that's what actually is being set.