### PR TITLE
Diagram Toolbar

### DIFF
--- a/cypress/e2e/clue/branch/student_tests/diagram_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/diagram_tool_spec.js
@@ -1,0 +1,25 @@
+import ClueCanvas from '../../../../support/elements/clue/cCanvas';
+import DiagramToolTile from '../../../../support/elements/clue/DiagramToolTile';
+
+let clueCanvas = new ClueCanvas,
+  diagramToolTile = new DiagramToolTile;
+
+context('Diagram Tool Tile', function () {
+  before(function () {
+    const queryParams = "?appMode=qa&fakeClass=5&fakeUser=student:5&qaGroup=5&unit=m2s";
+    cy.clearQAData('all');
+
+    cy.visit(queryParams);
+    cy.waitForLoad();
+    cy.closeResourceTabs();
+  });
+  describe("Dataflow Tool", () => {
+    it("renders dataflow tool tile", () => {
+      clueCanvas.addTile("diagram");
+      diagramToolTile.getDiagramTile().should("exist");
+      diagramToolTile.getDiagramToolbar().should("exist");
+      diagramToolTile.getDiagramToolbarButton("button-dialog").should("exist");
+      diagramToolTile.getDiagramToolbarButton("button-delete").should("exist");
+    });
+  });
+});

--- a/cypress/support/elements/clue/DiagramToolTile.js
+++ b/cypress/support/elements/clue/DiagramToolTile.js
@@ -1,0 +1,17 @@
+const canvasArea = (workspaceClass) => `${workspaceClass || ".primary-workspace"} .canvas-area`;
+
+class DiagramToolTile {
+  getDiagramTile(workspaceClass) {
+    return cy.get(`${canvasArea(workspaceClass)} .diagram-tool-tile`);
+  }
+  getDiagramToolbar(workspaceClass) {
+    this.getDiagramTile(workspaceClass).click();
+    return cy.get(`${canvasArea(workspaceClass)} .diagram-toolbar`);
+  }
+  getDiagramToolbarButton(buttonClass, workspaceClass) {
+    this.getDiagramTile(workspaceClass).click();
+    return cy.get(`${canvasArea(workspaceClass)} .diagram-toolbar .${buttonClass}`);
+  }
+}
+
+export default DiagramToolTile;

--- a/src/plugins/diagram-viewer/diagram-tool.tsx
+++ b/src/plugins/diagram-viewer/diagram-tool.tsx
@@ -1,26 +1,28 @@
-import React, { useState } from "react";
+import React from "react";
 import { IToolTileProps } from "../../components/tools/tool-tile";
 import { DiagramToolbar } from "./diagram-toolbar";
 import { DiagramContentModelType } from "./diagram-content";
 import { kQPVersion } from "./diagram-types";
-import { IToolApi } from "src/components/tools/tool-api";
+import { useToolbarToolApi } from "../../components/tools/hooks/use-toolbar-tool-api";
 import { Diagram } from "@concord-consortium/diagram-view";
 import "@concord-consortium/diagram-view/dist/index.css";
+
 import "./diagram-tool.scss";
 
-export const DiagramToolComponent: React.FC<IToolTileProps> = ({ documentContent, model }) => {
+export const DiagramToolComponent: React.FC<IToolTileProps> = (
+  { documentContent, model, onRegisterToolApi, onUnregisterToolApi, readOnly, scale, toolTile }
+) => {
   const content = model.content as DiagramContentModelType;
-  const [toolbarToolApi, setToolbarToolApi] = useState<any>();
 
+  const toolbarProps = useToolbarToolApi({ id: model.id, enabled: !readOnly, onRegisterToolApi, onUnregisterToolApi });
+  
   return (
     <div className="diagram-tool">
       <DiagramToolbar
-        onRegisterToolApi={(toolApi: IToolApi) => setToolbarToolApi(toolApi)}
-        onUnregisterToolApi={() => setToolbarToolApi(undefined)}
         documentContent={documentContent}
-        toolTile={undefined}
-        scale={1}
-        onIsEnabled={() => true}
+        toolTile={toolTile}
+        scale={scale}
+        { ...toolbarProps }
       />
       <Diagram dqRoot={content.root} />
       <div className="qp-version">{`version: ${kQPVersion}`}</div>

--- a/src/plugins/diagram-viewer/diagram-tool.tsx
+++ b/src/plugins/diagram-viewer/diagram-tool.tsx
@@ -1,16 +1,27 @@
-import React from "react";
+import React, { useState } from "react";
 import { IToolTileProps } from "../../components/tools/tool-tile";
+import { DiagramToolbar } from "./diagram-toolbar";
 import { DiagramContentModelType } from "./diagram-content";
 import { kQPVersion } from "./diagram-types";
+import { IToolApi } from "src/components/tools/tool-api";
 import { Diagram } from "@concord-consortium/diagram-view";
 import "@concord-consortium/diagram-view/dist/index.css";
 import "./diagram-tool.scss";
 
-export const DiagramToolComponent: React.FC<IToolTileProps> = ({ model }) => {
+export const DiagramToolComponent: React.FC<IToolTileProps> = ({ documentContent, model }) => {
   const content = model.content as DiagramContentModelType;
+  const [toolbarToolApi, setToolbarToolApi] = useState<any>();
 
   return (
     <div className="diagram-tool">
+      <DiagramToolbar
+        onRegisterToolApi={(toolApi: IToolApi) => setToolbarToolApi(toolApi)}
+        onUnregisterToolApi={() => setToolbarToolApi(undefined)}
+        documentContent={documentContent}
+        toolTile={undefined}
+        scale={1}
+        onIsEnabled={() => true}
+      />
       <Diagram dqRoot={content.root} />
       <div className="qp-version">{`version: ${kQPVersion}`}</div>
     </div>

--- a/src/plugins/diagram-viewer/diagram-toolbar.scss
+++ b/src/plugins/diagram-viewer/diagram-toolbar.scss
@@ -1,6 +1,6 @@
 @import "../../components/vars.sass";
 
-.image-toolbar {
+.diagram-toolbar {
   position: absolute;
   border: $toolbar-border;
   border-radius: 0 0 $toolbar-border-radius $toolbar-border-radius;

--- a/src/plugins/diagram-viewer/diagram-toolbar.scss
+++ b/src/plugins/diagram-viewer/diagram-toolbar.scss
@@ -1,0 +1,39 @@
+@import "../../components/vars.sass";
+
+.image-toolbar {
+  position: absolute;
+  border: $toolbar-border;
+  border-radius: 0 0 $toolbar-border-radius $toolbar-border-radius;
+  z-index: $toolbar-z-index;
+
+  &.disabled {
+    display: none;
+  }
+
+  .toolbar-button {
+    position: relative;
+    width: $toolbar-button-width;
+    height: $toolbar-button-height;
+    background-color: $workspace-teal-light-9;
+
+    &:hover {
+      background-color: $workspace-teal-light-6;
+    }
+
+    &:active {
+      background-color: $workspace-teal-light-4;
+
+      svg path {
+        fill: $workspace-teal-dark-1;
+      }
+    }
+
+    input {
+      position: absolute;
+      left: 0;
+      top: 0;
+      width: $toolbar-button-width;
+      height: $toolbar-button-height;
+    }
+  }
+}

--- a/src/plugins/diagram-viewer/diagram-toolbar.scss
+++ b/src/plugins/diagram-viewer/diagram-toolbar.scss
@@ -6,34 +6,53 @@
   border-radius: 0 0 $toolbar-border-radius $toolbar-border-radius;
   z-index: $toolbar-z-index;
 
+  display: flex;
+
   &.disabled {
     display: none;
   }
 
-  .toolbar-button {
+  .diagram-tool-button {
     position: relative;
+    // These are button elements so we have to disable default button styles
+    // of border, padding, and display
+    border: 0;    
+    padding: 0;
+    display: block;
+    user-select: none;
     width: $toolbar-button-width;
     height: $toolbar-button-height;
-    background-color: $workspace-teal-light-9;
-
+    cursor: pointer;
+    &.selected {
+      background-color: $workspace-teal-light-4;
+      &.button-select {
+        svg path {
+          fill: $workspace-teal-dark-1;
+        }
+      }
+    }
     &:hover {
       background-color: $workspace-teal-light-6;
     }
-
     &:active {
       background-color: $workspace-teal-light-4;
-
-      svg path {
-        fill: $workspace-teal-dark-1;
+      &.button-select {
+        svg path {
+          fill: $workspace-teal-dark-1;
+        }
       }
     }
 
-    input {
-      position: absolute;
-      left: 0;
-      top: 0;
-      width: $toolbar-button-width;
-      height: $toolbar-button-height;
+    &.button-dialog {
+      border-bottom-left-radius: 3px;
+    }
+    &.button-delete {
+      border-bottom-right-radius: 3px;
+    }
+
+    &.disabled {
+      opacity: 25%;
+      cursor: default;
     }
   }
 }

--- a/src/plugins/diagram-viewer/diagram-toolbar.tsx
+++ b/src/plugins/diagram-viewer/diagram-toolbar.tsx
@@ -77,9 +77,8 @@ export const DiagramToolbar: React.FC<IProps> = observer(({
   });
   return documentContent
     ? ReactDOM.createPortal(
-        <div className={`image-toolbar ${enabled && location ? "enabled" : "disabled"}`}
-            style={location}
-            onMouseDown={e => e.stopPropagation()}>
+        <div className={`diagram-toolbar ${enabled && location ? "enabled" : "disabled"}`}
+            style={location} onMouseDown={e => e.stopPropagation()}>
           <DialogButton />
           <DeleteButton />
         </div>, documentContent)

--- a/src/plugins/diagram-viewer/diagram-toolbar.tsx
+++ b/src/plugins/diagram-viewer/diagram-toolbar.tsx
@@ -1,0 +1,79 @@
+import classNames from "classnames";
+import { observer } from "mobx-react";
+import React from "react";
+import ReactDOM from "react-dom";
+import { Tooltip } from "react-tippy";
+import UploadButtonSvg from "../../assets/icons/upload-image/upload-image-icon.svg";
+import { useTooltipOptions } from "../../hooks/use-tooltip-options";
+import { IFloatingToolbarProps, useFloatingToolbarLocation }
+  from "../../components/tools/hooks/use-floating-toolbar-location";
+
+import "./diagram-toolbar.scss";
+
+// TODO The ImageUploadButton is now being used by three different tiles.
+// It would be good to move it into a more generic location.
+interface IImageUploadButtonProps {
+  tooltipOffset?: { x?: number, y?: number };
+  onUploadImageFile?: (file: File) => void;
+  extraClasses?: string;
+}
+export const ImageUploadButton: React.FC<IImageUploadButtonProps> =
+  ({ tooltipOffset, onUploadImageFile, extraClasses }) => {
+  // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file
+  // Next, we hide the <input> element — we do this because file inputs tend to be ugly, difficult
+  // to style, and inconsistent in their design across browsers. Opacity is used to hide the file
+  // input instead of visibility: hidden or display: none, because assistive technology interprets
+  // the latter two styles to mean the file input isn't interactive.
+  const hideFileInputStyle = { opacity: 0 };
+  const handleFileInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.currentTarget.files;
+    if (files?.length) {
+      onUploadImageFile?.(files[0]);
+    }
+  };
+  const tooltipOptions = useTooltipOptions({
+                          distance: tooltipOffset?.y || 0,
+                          offset: tooltipOffset?.x || 0
+                        });
+  const classes = classNames("toolbar-button", "image-upload", extraClasses);
+  return (
+    <Tooltip title="Upload image" {...tooltipOptions}>
+      <div className={classes}>
+        <UploadButtonSvg />
+        <input
+          type="file"
+          style={hideFileInputStyle}
+          accept="image/png, image/jpeg"
+          title=""
+          onChange={handleFileInputChange}
+          className="input-for-upload"
+        />
+      </div>
+    </Tooltip>
+  );
+};
+
+interface IProps extends IFloatingToolbarProps {
+}
+export const DiagramToolbar: React.FC<IProps> = observer(({
+  documentContent, onIsEnabled, ...others
+}) => {
+  const enabled = onIsEnabled();
+  const location = useFloatingToolbarLocation({
+                    documentContent,
+                    toolbarHeight: 34,
+                    toolbarTopOffset: 2,
+                    enabled,
+                    ...others
+                  });
+  // required for proper placement and label centering
+  const tooltipOffset = { x: -19, y: -32 };
+  return documentContent
+    ? ReactDOM.createPortal(
+        <div className={`image-toolbar ${enabled && location ? "enabled" : "disabled"}`}
+            style={location}
+            onMouseDown={e => e.stopPropagation()}>
+          <ImageUploadButton tooltipOffset={tooltipOffset} />
+        </div>, documentContent)
+    : null;
+});


### PR DESCRIPTION
Adds a toolbar to the diagram tile with two buttons that currently just console log.

This work is mostly based on the drawing tile toolbar. I think there would be a lot of benefit to trying to unify the code for tile toolbars, but it seems outside the scope of this story.