### PR TITLE
remove contextId

### DIFF
--- a/functions/src/shared.ts
+++ b/functions/src/shared.ts
@@ -101,7 +101,6 @@ export function networkDocumentKey(uid: string, documentKey: string, network?: s
 }
 
 export interface IDocumentMetadata {
-  contextId: string;
   uid: string;
   type: string;
   key: string;
@@ -111,7 +110,7 @@ export interface IDocumentMetadata {
   properties?: Record<string, string>;
 }
 export function isDocumentMetadata(o: any): o is IDocumentMetadata {
-  return !!o?.contextId && !!o.uid && !!o.type && !!o.key;
+  return !!o.uid && !!o.type && !!o.key;
 }
 
 export interface ICurriculumMetadata {

--- a/functions/test/post-document-comment.test.ts
+++ b/functions/test/post-document-comment.test.ts
@@ -61,7 +61,7 @@ export interface IPartialPostCommentParams {
 const specPostDocumentComment = (overrides?: IPartialPostCommentParams): IPostDocumentCommentParams => {
   return {
     context: specUserContext(overrides?.context),
-    document: { contextId: kClassHash, uid: kUserId, type: kDocumentType, key: kDocumentKey, ...overrides?.document },
+    document: { uid: kUserId, type: kDocumentType, key: kDocumentKey, ...overrides?.document },
     comment: { content: kComment1, ...overrides?.comment }
   };
 };

--- a/functions/test/validate-commentable-document.test.ts
+++ b/functions/test/validate-commentable-document.test.ts
@@ -57,7 +57,7 @@ export interface IPartialValidateDocumentParams {
 const specValidateDocument = (overrides?: IPartialValidateDocumentParams): ICommentableDocumentParams => {
   return {
     context: specUserContext(overrides?.context),
-    document: { contextId: kClassHash, uid: kUserId, type: kDocumentType, key: kDocumentKey, ...overrides?.document }
+    document: { uid: kUserId, type: kDocumentType, key: kDocumentKey, ...overrides?.document }
   };
 };
 

--- a/src/hooks/document-comment-hooks.test.ts
+++ b/src/hooks/document-comment-hooks.test.ts
@@ -120,7 +120,7 @@ describe("Document comment hooks", () => {
     beforeEach(() => resetMocks());
 
     it("should post comment successfully with optimistic update", () => {
-      const document = { contextId: "class-hash", uid: "user-id", type: "problem", key: "key" };
+      const document = { uid: "user-id", type: "problem", key: "key" };
       // useDocumentComments() fills the commentsQueryKeyMap
       renderHook(() => useDocumentComments(document.key));
       expect(mockHttpsCallable).toHaveBeenCalled();
@@ -143,7 +143,7 @@ describe("Document comment hooks", () => {
         const mutationResult = new Error("Failed");
         options?.onError?.(mutationResult, params, context);
       });
-      const document = { contextId: "class-hash", uid: "user-id", type: "problem", key: "key" };
+      const document = { uid: "user-id", type: "problem", key: "key" };
       // useDocumentComments() fills the commentsQueryKeyMap
       renderHook(() => useDocumentComments(document.key));
       const { result: postCommentResult } = renderHook(() => usePostDocumentComment());

--- a/src/hooks/use-stores.ts
+++ b/src/hooks/use-stores.ts
@@ -48,21 +48,8 @@ export function useDocumentFromStore(key?: string) {
 }
 
 export function useDocumentMetadataFromStore(key?: string): IDocumentMetadata | undefined {
-  const { documents, networkDocuments, user } = useStores();
-  // for local documents, the context is the user's classHash
-  let contextId = user.classHash;
-  let document = key ? documents.getDocument(key) : undefined;
-  let metadata = document ? { contextId, ...document.getMetadata() } : undefined;
-  if (!document) {
-    document = key ? networkDocuments?.getDocument(key) : undefined;
-    // for network documents, the context is the document's remoteContext
-    document && (contextId = document.remoteContext);
-    metadata = document ? { contextId, ...document.getMetadata() } : undefined;
-  }
-  return useMemo(() => {
-    return metadata || undefined;
-    // updating when the key changes is sufficient
-  }, [key]);  // eslint-disable-line react-hooks/exhaustive-deps
+  const document = useDocumentFromStore(key);
+  return document?.metadata;
 }
 
 export function useDocumentOrCurriculumMetadata(key?: string): IDocumentMetadata | ICurriculumMetadata | undefined {

--- a/src/models/document/document.test.ts
+++ b/src/models/document/document.test.ts
@@ -196,6 +196,8 @@ describe("document model", () => {
 
   it("can get document metadata", () => {
     expect(document.metadata).toEqual({
+      // FIXME: the contextId was added here temporarily. See document.ts
+      contextId: "ignored",
       type: ProblemDocument,
       uid: "1",
       key: "test",

--- a/src/models/document/document.test.ts
+++ b/src/models/document/document.test.ts
@@ -195,7 +195,7 @@ describe("document model", () => {
   });
 
   it("can get document metadata", () => {
-    expect(document.getMetadata()).toEqual({
+    expect(document.metadata).toEqual({
       type: ProblemDocument,
       uid: "1",
       key: "test",

--- a/src/models/document/document.ts
+++ b/src/models/document/document.ts
@@ -98,7 +98,13 @@ export const DocumentModel = Tree.named("Document")
     },
     get metadata(): IDocumentMetadata {
       const { uid, type, key, createdAt, title, originDoc, properties } = self;
-      return { uid, type, key, createdAt, title, originDoc, properties: properties.toJSON() };
+      // FIXME: the contextId was added here temporarily. This metadata is sent
+      // up to the Firestore functions. The new functions do not require the
+      // contextId. However the old functions do. The old functions were just
+      // ignoring this contextId. So the contextId is added here so the client
+      // code can work with the old functions.
+      return { contextId: "ignored", uid, type, key, createdAt, title, 
+        originDoc, properties: properties.toJSON() } as IDocumentMetadata;
     },
     getProperty(key: string) {
       return self.properties.get(key);

--- a/src/models/document/document.ts
+++ b/src/models/document/document.ts
@@ -10,7 +10,9 @@ import {
 import { AppConfigModelType } from "../stores/app-config-model";
 import { TileCommentsModel, TileCommentsModelType } from "../tools/tile-comments";
 import { UserStarModel, UserStarModelType } from "../tools/user-star";
-import { IGetNetworkDocumentParams, IGetNetworkDocumentResponse, IUserContext } from "../../../functions/src/shared";
+import { 
+  IDocumentMetadata, IGetNetworkDocumentParams, IGetNetworkDocumentResponse, IUserContext 
+} from "../../../functions/src/shared";
 import { getFirebaseFunction } from "../../hooks/use-firebase-function";
 import { IDocumentProperties } from "../../lib/db-types";
 import { getLocalTimeStamp } from "../../utilities/time";
@@ -94,7 +96,7 @@ export const DocumentModel = Tree.named("Document")
     get hasContent() {
       return !!self.content;
     },
-    getMetadata() {
+    get metadata(): IDocumentMetadata {
       const { uid, type, key, createdAt, title, originDoc, properties } = self;
       return { uid, type, key, createdAt, title, originDoc, properties: properties.toJSON() };
     },

--- a/src/models/history/tree-manager.ts
+++ b/src/models/history/tree-manager.ts
@@ -60,12 +60,6 @@ export const TreeManager = types
   currentHistoryIndex: 0,
   // getUserContext(stores)
   userContext: undefined as IUserContext | undefined,
-  // const { documents, user } = useStores();
-  // let contextId = user.classHash;
-  // let document = key ? documents.getDocument(key) : undefined;
-  // let metadata = document ? { contextId, ...document.getMetadata() } : undefined;
-  // If we have to handle networkDocuments then look at useDocumentMetadataFromStore
-  // to see how it constructs the metadata
   documentMetadata: undefined as IDocumentMetadata | undefined,
   firestore: undefined as Firestore | undefined
 }))

--- a/src/models/stores/documents.ts
+++ b/src/models/stores/documents.ts
@@ -206,7 +206,7 @@ export const DocumentsModel = types
         treeManager.setPropsForFirestoreSaving({
           firestore,
           userContext,
-          documentMetadata: { contextId: userContext.classHash, ...document.getMetadata()}
+          documentMetadata: document.metadata
         });
       
       } else {


### PR DESCRIPTION
`contextId` was not read anywhere. In the Firestore rules and functions `context_id` is used instead. `context_id` is written by the firebase function from the request context.  However the Firestore functions were checking for the existence of `contextId` even though it wasn't used. So the tests of this PR can run against the old functions, a `contextId: "ignored"` has been added to the PR.  After the functions are updated we can remove this `contextId: "ignored"`.

The only sketchy thing that was removed was the logic in use-stores.ts. It was setting the value from either the remoteContext or user object. However since contextId is never read this logic still seemed safe to remove.

With the contextId removed, document.ts can construct the IDocumentMetadata by itself.

The `useMemo` isn't needed anymore in `useDocumentMetadataFromStore`.
MST will return the same metadata object from get metadata(), unless the properties making it up change.