### PR TITLE
Remove undo/redo handlers on geometry tile.  

### DIFF
--- a/src/components/tools/geometry-tool/geometry-content.tsx
+++ b/src/components/tools/geometry-tool/geometry-content.tsx
@@ -185,8 +185,6 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
         handlePaste: this.handlePaste,
         handleDuplicate: this.handleDuplicate,
         handleDelete: this.handleDelete,
-        handleUndo: this.handleUndo,
-        handleRedo: this.handleRedo,
         handleToggleVertexAngle: this.handleToggleVertexAngle,
         handleCreateLineLabel: this.handleCreateLineLabel,
         handleCreateMovableLine: this.handleCreateMovableLine,
@@ -778,14 +776,6 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
       const hash = objectHash(copiedObjects.map(obj => getSnapshot(obj)), { excludeKeys });
       this.pasteObjects({ pasteId: hash, isSameTile: true, objects: copiedObjects });
     }
-  };
-
-  private handleUndo = () => {
-    return true;
-  };
-
-  private handleRedo = () => {
-    return true;
   };
 
   private copySelectedObjects() {

--- a/src/components/tools/geometry-tool/geometry-shared.tsx
+++ b/src/components/tools/geometry-tool/geometry-shared.tsx
@@ -17,8 +17,6 @@ export interface IActionHandlers extends IToolbarActionHandlers {
   handleCut: () => void;
   handleCopy: () => void;
   handlePaste: () => void;
-  handleUndo: () => void;
-  handleRedo: () => void;
 }
 
 export type IGeometryProps = IToolTileProps;

--- a/src/components/tools/geometry-tool/geometry-tool.tsx
+++ b/src/components/tools/geometry-tool/geometry-tool.tsx
@@ -37,8 +37,6 @@ const _GeometryToolComponent: React.FC<IGeometryProps> = ({
       "cmd-c": handlers.handleCopy,
       "cmd-x": handlers.handleCut,
       "cmd-v": handlers.handlePaste,
-      "cmd-z": handlers.handleUndo,
-      "cmd-shift-z": handlers.handleRedo,
     });
     setActionHandlers(handlers);
   };


### PR DESCRIPTION
Removing these undo/redo handlers seems to let the Treemanager version take over and do the right thing.
Fixes 183544050