### PR TITLE
update diagram view, revise overrides

### DIFF
--- a/dependencies-notes.md
+++ b/dependencies-notes.md
@@ -26,9 +26,10 @@ Notes on dependencies, particularly reasons for not updating to their latest ver
 |firebase            |8.10.1         |9.9.3         |Version 9 requires substantial migration; attempted update with `compat` imports failed.|
 |immutable           |3.8.2          |4.1.0         |Major version update not attempted; only required by legacy slate versions.          |
 |jsxgraph            |1.4.4          |1.4.5         |1.4.5 broke scaled rendering, e.g. in 4-up views                                     |
-|mob-state-tree      |5.1.5          |5.1.6         |Latest version changes TS types for arrays which broke a number of our models.       |
+|mob-state-tree      |5.1.5-cc.1     |5.1.6         |We are using a concord fork which fixes a bug. Additionally latest version changes TS types for arrays which broke a number of our models.|
+|nanoid              |3.3.4          |4.0.0         |v4 switched to ESM and dependencies such as postcss break with v4
 |react               |17.0.2         |18.2.0        |React 18                                                                             |
 |react-chartjs-2     |2.11.2         |4.3.1         |Major version update not attempted; may not be used any more (was used by Dataflow)  |
-|react-data-grid     |7.0.0-canary.46|7.0.0-beta.16 |Canary.47 changed the RowFormatter props requiring some additional refactoring. Note that `beta` versions come after `canary` versions.|
+|react-data-grid     |7.0.0-canary.46|7.0.0-beta.16 |Canary.47 changed the RowFormatter props requiring some additional refactoring. Note that `beta` versions come after `canary` versions. We are patching react-data-grid and our patch only applies to 7.0.0-canary.46|
 |react-dom           |17.0.2         |18.2.0        |React 18                                                                             |
 |react-tabs          |3.2.3          |5.1.0         |Version 4 not attempted; Version 5 requires React 18                                 |

--- a/dependencies-notes.md
+++ b/dependencies-notes.md
@@ -27,7 +27,7 @@ Notes on dependencies, particularly reasons for not updating to their latest ver
 |immutable           |3.8.2          |4.1.0         |Major version update not attempted; only required by legacy slate versions.          |
 |jsxgraph            |1.4.4          |1.4.5         |1.4.5 broke scaled rendering, e.g. in 4-up views                                     |
 |mob-state-tree      |5.1.5-cc.1     |5.1.6         |We are using a concord fork which fixes a bug. Additionally latest version changes TS types for arrays which broke a number of our models.|
-|nanoid              |3.3.4          |4.0.0         |v4 switched to ESM and dependencies such as postcss break with v4
+|nanoid              |3.3.4          |4.0.0         |v4 switched to ESM and dependencies such as postcss break with v4                    |
 |react               |17.0.2         |18.2.0        |React 18                                                                             |
 |react-chartjs-2     |2.11.2         |4.3.1         |Major version update not attempted; may not be used any more (was used by Dataflow)  |
 |react-data-grid     |7.0.0-canary.46|7.0.0-beta.16 |Canary.47 changed the RowFormatter props requiring some additional refactoring. Note that `beta` versions come after `canary` versions. We are patching react-data-grid and our patch only applies to 7.0.0-canary.46|

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@concord-consortium/diagram-view": "^0.0.16",
+        "@concord-consortium/diagram-view": "^0.0.17",
         "@concord-consortium/mobx-state-tree": "5.1.5-cc.1",
         "@concord-consortium/react-components": "^0.7.1",
         "@concord-consortium/react-modal-hook": "^3.0.0-cc.1",
@@ -32,14 +32,14 @@
         "lodash": "^4.17.21",
         "mobx": "^6.6.1",
         "mobx-react": "^7.5.2",
-        "nanoid": "^4.0.0",
+        "nanoid": "^3.3.4",
         "object-hash": "^3.0.0",
         "patch-package": "^6.4.7",
         "query-string": "7.1.1",
         "rc-slider": "^10.0.1",
         "react": "^17.0.2",
         "react-chartjs-2": "^2.11.2",
-        "react-data-grid": "^7.0.0-canary.46",
+        "react-data-grid": "7.0.0-canary.46",
         "react-dom": "^17.0.2",
         "react-dom-factories": "^1.0.2",
         "react-modal": "^3.15.1",
@@ -1990,9 +1990,9 @@
       "dev": true
     },
     "node_modules/@concord-consortium/diagram-view": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.16.tgz",
-      "integrity": "sha512-55qroZwNWVU+xh7VVLOVSySNXqlWppsnc+ITNSOFdj0mvYyEHJ8Cd3UKy+BmXJnmZFKD7wY9rsUQ59I43+SqJw==",
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.17.tgz",
+      "integrity": "sha512-+eojupkK3rdsmuDRZp+7rkqCiXijNSjFIifTFf0GfFyzaKsAPMD0P6jYoT1UWz7fsTpG4B+JmQ4pmShwZT1Yqg==",
       "dependencies": {
         "iframe-phone": "^1.3.1",
         "mathjs": "^10.4.1",
@@ -2007,9 +2007,6 @@
         "react-dom": "^17.0.2",
         "tslib": "^2.3.1"
       }
-    },
-    "node_modules/@concord-consortium/diagram-view/@concord-consortium/mobx-state-tree": {
-      "peer": true
     },
     "node_modules/@concord-consortium/mobx-state-tree": {
       "version": "5.1.5-cc.1",
@@ -2120,9 +2117,6 @@
         "slate": "^0.47.9",
         "slate-react": "^0.22.9"
       }
-    },
-    "node_modules/@concord-consortium/slate-react-placeholder/@concord-consortium/slate-react": {
-      "peer": true
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -16209,8 +16203,18 @@
       }
     },
     "node_modules/mobx-state-tree": {
-      "resolved": "node_modules/@concord-consortium/diagram-view/@concord-consortium/mobx-state-tree",
-      "link": true
+      "name": "@concord-consortium/mobx-state-tree",
+      "version": "5.1.5-cc.1",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/mobx-state-tree/-/mobx-state-tree-5.1.5-cc.1.tgz",
+      "integrity": "sha512-TeymuYqHIA1c1HIzn+I9ufLgBvzvcpQfcTdBmWGXD/ojgVuuGLhrjvzRXIZM6Rtx2lAXPofrkpZCyuc4hM77hg==",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mobx"
+      },
+      "peerDependencies": {
+        "mobx": "^6.3.0"
+      }
     },
     "node_modules/moment": {
       "version": "2.29.4",
@@ -16255,14 +16259,14 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.0.tgz",
-      "integrity": "sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
       "bin": {
-        "nanoid": "bin/nanoid.js"
+        "nanoid": "bin/nanoid.cjs"
       },
       "engines": {
-        "node": "^14 || ^16 || >=18"
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/natural-compare": {
@@ -17444,18 +17448,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
-    },
-    "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-      "dev": true,
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -19108,8 +19100,35 @@
       }
     },
     "node_modules/slate-react": {
-      "resolved": "node_modules/@concord-consortium/slate-react-placeholder/@concord-consortium/slate-react",
-      "link": true
+      "name": "@concord-consortium/slate-react",
+      "version": "0.22.10-cc.6",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/slate-react/-/slate-react-0.22.10-cc.6.tgz",
+      "integrity": "sha512-MGYWEvFHgnaw9YSUHf/0kMqvDAsxndg/hFD7t1UMYZl75kpr5LGJcD0CdBArIls6Ep8YScNymdpbv29wQlSyfg==",
+      "peer": true,
+      "dependencies": {
+        "@concord-consortium/slate-react-placeholder": "^0.2.9-cc.1",
+        "debug": "^3.1.0",
+        "get-window": "^1.1.1",
+        "is-window": "^1.0.2",
+        "lodash": "^4.1.1",
+        "memoize-one": "^4.0.0",
+        "prop-types": "^15.5.8",
+        "react-immutable-proptypes": "^2.1.0",
+        "selection-is-backward": "^1.0.0",
+        "slate-base64-serializer": "^0.2.112",
+        "slate-dev-environment": "^0.2.2",
+        "slate-hotkeys": "^0.2.9",
+        "slate-plain-serializer": "^0.7.11",
+        "slate-prop-types": "^0.5.42",
+        "tiny-invariant": "^1.0.1",
+        "tiny-warning": "^0.0.3"
+      },
+      "peerDependencies": {
+        "immutable": ">=3.8.1 || >4.0.0-rc",
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0",
+        "slate": "^0.47.9"
+      }
     },
     "node_modules/slice-ansi": {
       "version": "3.0.0",
@@ -22916,9 +22935,9 @@
       "dev": true
     },
     "@concord-consortium/diagram-view": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.16.tgz",
-      "integrity": "sha512-55qroZwNWVU+xh7VVLOVSySNXqlWppsnc+ITNSOFdj0mvYyEHJ8Cd3UKy+BmXJnmZFKD7wY9rsUQ59I43+SqJw==",
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.17.tgz",
+      "integrity": "sha512-+eojupkK3rdsmuDRZp+7rkqCiXijNSjFIifTFf0GfFyzaKsAPMD0P6jYoT1UWz7fsTpG4B+JmQ4pmShwZT1Yqg==",
       "requires": {
         "iframe-phone": "^1.3.1",
         "mathjs": "^10.4.1",
@@ -33787,7 +33806,11 @@
       "requires": {}
     },
     "mobx-state-tree": {
-      "version": "file:node_modules/@concord-consortium/diagram-view/@concord-consortium/mobx-state-tree"
+      "version": "npm:@concord-consortium/mobx-state-tree@5.1.5-cc.1",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/mobx-state-tree/-/mobx-state-tree-5.1.5-cc.1.tgz",
+      "integrity": "sha512-TeymuYqHIA1c1HIzn+I9ufLgBvzvcpQfcTdBmWGXD/ojgVuuGLhrjvzRXIZM6Rtx2lAXPofrkpZCyuc4hM77hg==",
+      "peer": true,
+      "requires": {}
     },
     "moment": {
       "version": "2.29.4",
@@ -33826,9 +33849,9 @@
       }
     },
     "nanoid": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.0.tgz",
-      "integrity": "sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg=="
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -34623,16 +34646,9 @@
       "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
       "dev": true,
       "requires": {
-        "nanoid": "^4.0.0",
+        "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
-      },
-      "dependencies": {
-        "nanoid": {
-          "version": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-          "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-          "dev": true
-        }
       }
     },
     "postcss-loader": {
@@ -35983,7 +35999,28 @@
       "requires": {}
     },
     "slate-react": {
-      "version": "file:node_modules/@concord-consortium/slate-react-placeholder/@concord-consortium/slate-react"
+      "version": "npm:@concord-consortium/slate-react@0.22.10-cc.6",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/slate-react/-/slate-react-0.22.10-cc.6.tgz",
+      "integrity": "sha512-MGYWEvFHgnaw9YSUHf/0kMqvDAsxndg/hFD7t1UMYZl75kpr5LGJcD0CdBArIls6Ep8YScNymdpbv29wQlSyfg==",
+      "peer": true,
+      "requires": {
+        "@concord-consortium/slate-react-placeholder": "^0.2.9-cc.1",
+        "debug": "^3.1.0",
+        "get-window": "^1.1.1",
+        "is-window": "^1.0.2",
+        "lodash": "^4.1.1",
+        "memoize-one": "^4.0.0",
+        "prop-types": "^15.5.8",
+        "react-immutable-proptypes": "^2.1.0",
+        "selection-is-backward": "^1.0.0",
+        "slate-base64-serializer": "^0.2.112",
+        "slate-dev-environment": "^0.2.2",
+        "slate-hotkeys": "^0.2.9",
+        "slate-plain-serializer": "^0.7.11",
+        "slate-prop-types": "^0.5.42",
+        "tiny-invariant": "^1.0.1",
+        "tiny-warning": "^0.0.3"
+      }
     },
     "slice-ansi": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -102,9 +102,9 @@
   },
   "homepage": "https://github.com/concord-consortium/collaborative-learning#readme",
   "overrides": {
-    "mobx-state-tree": "@concord-consortium/mobx-state-tree",
-    "nanoid@<4.0.0": "^4.0.0",
-    "slate-react": "@concord-consortium/slate-react",
+    "mobx-state-tree": "npm:@concord-consortium/mobx-state-tree@5.1.5-cc.1",
+    
+    "slate-react": "npm:@concord-consortium/slate-react",
     "slate-react-placeholder": "@concord-consortium/slate-react-placeholder"
   },
   "devDependencies": {
@@ -193,7 +193,7 @@
     "xhr-mock": "^2.5.1"
   },
   "dependencies": {
-    "@concord-consortium/diagram-view": "^0.0.16",
+    "@concord-consortium/diagram-view": "^0.0.17",
     "@concord-consortium/mobx-state-tree": "5.1.5-cc.1",
     "@concord-consortium/react-components": "^0.7.1",
     "@concord-consortium/react-modal-hook": "^3.0.0-cc.1",
@@ -215,14 +215,14 @@
     "lodash": "^4.17.21",
     "mobx": "^6.6.1",
     "mobx-react": "^7.5.2",
-    "nanoid": "^4.0.0",
+    "nanoid": "^3.3.4",
     "object-hash": "^3.0.0",
     "patch-package": "^6.4.7",
     "query-string": "7.1.1",
     "rc-slider": "^10.0.1",
     "react": "^17.0.2",
     "react-chartjs-2": "^2.11.2",
-    "react-data-grid": "^7.0.0-canary.46",
+    "react-data-grid": "7.0.0-canary.46",
     "react-dom": "^17.0.2",
     "react-dom-factories": "^1.0.2",
     "react-modal": "^3.15.1",


### PR DESCRIPTION
- this downgrades nanoid to avoid an dependency issue
- uses a different format for overriding mobx-state-tree and slate-react
- bumps diagram-view to 0.0.17
- locks react-data-grid to the version that our patch is assuming

This might require clearing your `node_modules` folder. It was also tested with the latest npm version 8.19.2. But I'd suspect it to work with any version of npm `>8.3`