### PR TITLE
Fix bugs when dragging to copy tiles from one document to another

### DIFF
--- a/cypress/e2e/clue/branch/student_tests/canvas_test_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/canvas_test_spec.js
@@ -308,26 +308,6 @@ context('Test Canvas', function () {
     });
   });
 
-  context.skip('Dragging elements from different locations to canvas', function () {
-    describe('Drag element from left nav', function () {
-      const dataTransfer = new DataTransfer;
-      // TODO: Unable to get elements
-      it('will drag image from resource panel to canvas', () => {
-        resourcesPanel.openResourcesPanel('Introduction');
-        resourcesPanel.getResourcesPanelExpandedSpace().find('.image-tool').first()
-          .trigger('dragstart', { dataTransfer });
-        cy.get('.single-workspace .canvas .document-content').first()
-          .trigger('drop', { force: true, dataTransfer });
-        resourcesPanel.getResourcesPanelExpandedSpace().find('.image-tool').first()
-          .trigger('dragend');
-        resourcesPanel.closeResourcesPanel('Introduction');
-        imageToolTile.getImageTile().first().should('exist');
-      });
-    });
-    //TODO add a test for dragging rightside canvas to the left side workspace
-
-  });
-
   context('delete elements from canvas', function () {
     before(() => {
       //star a document to verify delete
@@ -349,6 +329,50 @@ context('Test Canvas', function () {
       imageToolTile.getImageTile().should('not.exist');
       tableToolTile.getTableTile().should('not.exist');
     });
+  });
+
+  context('Dragging elements from different locations to canvas', function () {
+    describe('Drag element from left nav', function () {
+      const dataTransfer = new DataTransfer;
+      it('will drag image from resource panel to canvas', () => {
+        resourcesPanel.openTopTab('problems');
+        resourcesPanel.openBottomTab("Now What Do You Know?");
+        resourcesPanel.getResourcesPanelExpandedSpace().find('.image-tool').first()
+          .trigger('dragstart', { dataTransfer });
+        cy.get('.single-workspace .canvas .document-content').first()
+          .trigger('drop', { force: true, dataTransfer });
+        resourcesPanel.getResourcesPanelExpandedSpace().find('.image-tool').first()
+          .trigger('dragend');
+        imageToolTile.getImageTile().should('exist');
+        imageToolTile.getImageTile().find('.editable-tile-title-text').contains('Did You Know?: Images in computer graphics');
+        clueCanvas.deleteTile('image');
+      });
+      it('will maintain positioning when copying multiple tiles', () => {
+        resourcesPanel.openBottomTab("Initial Challenge");
+        const leftTile = type => cy.get(`.nav-tab-panel .problem-panel .${type}-tool-tile`);
+
+        // Select three table tiles on the left
+        leftTile('table').first().click({ shiftKey: true });
+        leftTile('table').eq(1).click({ shiftKey: true });
+        leftTile('table').eq(2).click({ shiftKey: true });
+
+        // Drag the selected copies to the workspace on the right
+        leftTile('table').eq(2).trigger('dragstart', { dataTransfer });
+        cy.get('.single-workspace .canvas .document-content').first()
+          .trigger('drop', { force: true, dataTransfer });
+
+        // Make sure the tiles were copied in the correct order
+        tableToolTile.getTableTile().first().find('.editable-header-cell').contains('Mug Wump');
+        tableToolTile.getTableTile().eq(1).find('.editable-header-cell').contains('Mug Wump Part 2');
+        tableToolTile.getTableTile().eq(2).find('.editable-header-cell').contains('Mug Wump Part 3');
+
+        // Clean up
+        clueCanvas.deleteTile('table');
+        clueCanvas.deleteTile('table');
+        clueCanvas.deleteTile('table');
+      });
+    });
+
   });
 
   context('delete workspaces', function () {

--- a/cypress/support/elements/clue/ResourcesPanel.js
+++ b/cypress/support/elements/clue/ResourcesPanel.js
@@ -4,8 +4,16 @@ class ResourcesPanel{
         cy.get('.top-tab.tab-'+tab).click();
     }
 
+    openBottomTab(tabName) {
+        cy.get('.prob-tab').contains(tabName).click();
+    }
+
     getPrimaryWorkspaceTab(tab){
         return cy.get('.top-tab.tab-'+tab);
+    }
+
+    getResourcesPanelExpandedSpace() {
+        return cy.get('.nav-tab-panel .problem-panel .canvas');
     }
 
     openPrimaryWorkspaceTab(tab){

--- a/src/components/workspace/workspace.tsx
+++ b/src/components/workspace/workspace.tsx
@@ -27,7 +27,7 @@ export const WorkspaceComponent: React.FC<IProps> = observer((props) => {
   let imageDragDrop: ImageDragDrop;
 
   const handleDragOverWorkspace = (e: React.DragEvent<HTMLDivElement>) => {
-    imageDragDrop.dragOver(e);
+    imageDragDrop?.dragOver(e);
   };
 
   const toggleExpandWorkspace = () => {

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -23,7 +23,8 @@ import { SectionModelType } from "../curriculum/section";
 export interface INewTileOptions {
   locationInRow?: string;
   rowHeight?: number;
-  rowIndex?: number;
+  rowId?: string; // The id of the row to add the tile to
+  rowIndex?: number; // The position to add a new row
   title?: string;
 }
 
@@ -543,7 +544,7 @@ export const DocumentContentModel = types
         // by default, insert new tiles after last visible on screen
         o.rowIndex = self.defaultInsertRow;
       }
-      const row = self.getRowByIndex(o.rowIndex);
+      const row = o.rowId ? self.getRow(o.rowId) : self.getRowByIndex(o.rowIndex);
       if (row) {
         const indexInRow = o.locationInRow === "left" ? 0 : undefined;
         self.insertNewTileInRow(tile, row, indexInRow);
@@ -595,6 +596,7 @@ export const DocumentContentModel = types
       if (tiles.length > 0) {
         let rowDelta = -1;
         let lastRowIndex = -1;
+        let lastRowId = "";
         tiles.forEach(tile => {
           let result: INewRowTile | undefined;
           const parsedTile = safeJsonParse(tile.tileContent);
@@ -604,6 +606,7 @@ export const DocumentContentModel = types
               rowDelta++;
             }
             const tileOptions: INewTileOptions = {
+              rowId: lastRowId,
               rowIndex: rowIndex + rowDelta,
               title: parsedTile.title
             };
@@ -613,6 +616,7 @@ export const DocumentContentModel = types
             if (tile.rowIndex !== lastRowIndex) {
               result = self.addTileContentInNewRow(content, tileOptions);
               lastRowIndex = tile.rowIndex;
+              lastRowId = result.rowId;
             }
             else {
               result = self.addTileSnapshotInExistingRow({ content, title: parsedTile.title }, tileOptions);
@@ -906,6 +910,7 @@ export const DocumentContentModel = types
       self.moveTiles(tiles, rowInfo);
     },
     userCopyTiles(tiles: IDragTileItem[], rowInfo: IDropRowInfo) {
+      console.log(`userCopy`, tiles);
       const dropRow = (rowInfo.rowDropIndex != null) ? self.getRowByIndex(rowInfo.rowDropIndex) : undefined;
       const results = dropRow?.acceptTileDrop(rowInfo)
                       ? self.copyTilesIntoExistingRow(tiles, rowInfo)

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -910,7 +910,6 @@ export const DocumentContentModel = types
       self.moveTiles(tiles, rowInfo);
     },
     userCopyTiles(tiles: IDragTileItem[], rowInfo: IDropRowInfo) {
-      console.log(`userCopy`, tiles);
       const dropRow = (rowInfo.rowDropIndex != null) ? self.getRowByIndex(rowInfo.rowDropIndex) : undefined;
       const results = dropRow?.acceptTileDrop(rowInfo)
                       ? self.copyTilesIntoExistingRow(tiles, rowInfo)

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -21,9 +21,10 @@ import { DocumentModelType, IDocumentEnvironment } from "./document";
 import { SectionModelType } from "../curriculum/section";
 
 export interface INewTileOptions {
+  locationInRow?: string;
   rowHeight?: number;
   rowIndex?: number;
-  locationInRow?: string;
+  title?: string;
 }
 
 export interface INewRowTile {
@@ -528,8 +529,8 @@ export const DocumentContentModel = types
     }
   }))
   .actions(self => ({
-    addTileContentInNewRow(content: ToolContentModelType, options?: INewTileOptions, tileTitle?: string): INewRowTile {
-      const title = tileTitle || self.getNewTileTitle(content);
+    addTileContentInNewRow(content: ToolContentModelType, options?: INewTileOptions): INewRowTile {
+      const title = options?.title || self.getNewTileTitle(content);
       return self.addTileInNewRow(ToolTileModel.create({ title, content }), options);
     },
     addTileSnapshotInNewRow(snapshot: ToolTileSnapshotInType, options?: INewTileOptions): INewRowTile {
@@ -602,18 +603,19 @@ export const DocumentContentModel = types
             if (tile.rowIndex !== lastRowIndex) {
               rowDelta++;
             }
-            const rowOptions: INewTileOptions = {
-              rowIndex: rowIndex + rowDelta
+            const tileOptions: INewTileOptions = {
+              rowIndex: rowIndex + rowDelta,
+              title: parsedTile.title
             };
             if (tile.rowHeight) {
-              rowOptions.rowHeight = tile.rowHeight;
+              tileOptions.rowHeight = tile.rowHeight;
             }
             if (tile.rowIndex !== lastRowIndex) {
-              result = self.addTileContentInNewRow(content, rowOptions, parsedTile.title);
+              result = self.addTileContentInNewRow(content, tileOptions);
               lastRowIndex = tile.rowIndex;
             }
             else {
-              result = self.addTileSnapshotInExistingRow({ content, title: parsedTile.title }, rowOptions);
+              result = self.addTileSnapshotInExistingRow({ content, title: parsedTile.title }, tileOptions);
             }
           }
           results.push(result);


### PR DESCRIPTION
This PR fixes two bugs when dragging tiles between documents to copy them.
- Titles are now being copied.
- The order of the tiles is properly retained.

I also added a couple of tests for dragging files to copy them.