### PR TITLE
Logging for playback

### DIFF
--- a/src/components/document/canvas.tsx
+++ b/src/components/document/canvas.tsx
@@ -16,6 +16,7 @@ import {
 import { HotKeys } from "../../utilities/hot-keys";
 import { DEBUG_CANVAS, DEBUG_DOCUMENT } from "../../lib/debug";
 import { DocumentError } from "./document-error";
+import { Logger } from "../../lib/logger";
 
 import "./canvas.sass";
 
@@ -184,7 +185,8 @@ export class CanvasComponent extends BaseComponent<IProps, IState> {
       if (prevState.historyDocumentCopy) {
         destroy(prevState.historyDocumentCopy);
       }
-
+      Logger.logHistoryEvent({documentId: this.props.document?.key || '',
+        action: showPlaybackControls ? "showControls": "hideControls" });
       return {
         showPlaybackControls,
         historyDocumentCopy

--- a/src/components/playback/playback-control.tsx
+++ b/src/components/playback/playback-control.tsx
@@ -5,6 +5,7 @@ import { Instance } from "mobx-state-tree";
 import { observer } from "mobx-react";
 import { useUIStore } from "../../hooks/use-stores";
 import { TreeManager } from "../../models/history/tree-manager";
+import { Logger } from "../../lib/logger";
 // import { PlaybackMarkerToolbar } from "./marker-toolbar";
 import Marker from "../../clue/assets/icons/playback/marker.svg";
 import PlayButton from "../../clue/assets/icons/playback/play-button.svg";
@@ -51,8 +52,16 @@ export const PlaybackControlComponent: React.FC<IProps> = observer((props: IProp
   const playbackDisabled = numHistoryEventsApplied === undefined || sliderValue === history.length;
 
   const handlePlayPauseToggle = useCallback((playing?: boolean) => {
-                                  setSliderPlaying(playing !== undefined ? playing : !sliderPlaying);
-                                },[sliderPlaying]);
+    const playStatus = playing !== undefined ? playing : !sliderPlaying;
+    Logger.logHistoryEvent({
+      documentId: treeManager.mainDocument?.key || '',
+      historyEventId: currentHistoryEvent?.id,
+      historyLength: history.length,
+      historyIndex: sliderValue,
+      action: playStatus ? "playStart": "playStop",
+    });
+    setSliderPlaying(playStatus);
+  },[sliderPlaying, sliderValue]);
 
   useEffect(() => {
     if (sliderPlaying) {
@@ -92,6 +101,15 @@ export const PlaybackControlComponent: React.FC<IProps> = observer((props: IProp
 
   const handleSliderValueChange = (value: any) => {
     treeManager.goToHistoryEntry(value);
+  };
+
+  const handleSliderAfterChange = (value: any) => {
+    Logger.logHistoryEvent({
+      documentId: treeManager.mainDocument?.key || '',
+      historyEventId: currentHistoryEvent?.id,
+      historyLength: history.length,
+      historyIndex: value,
+      action: "playSeek"});
   };
 
   const handleAddMarker = (value: any) => {
@@ -156,7 +174,7 @@ export const PlaybackControlComponent: React.FC<IProps> = observer((props: IProp
       <>
         <div className="slider-container" ref={sliderContainerRef} data-testid="playback-slider">
           <Slider min={0} max={history.length} step={1} value={sliderValue} ref={railRef}
-                  className={`${activeNavTab}`} onChange={handleSliderValueChange} />
+                  className={`${activeNavTab}`} onChange={handleSliderValueChange} onAfterChange={handleSliderAfterChange}/>
         </div>
         { markers.map(marker => {
           const markerLocation = getMarkerLocation(marker.location);

--- a/src/components/playback/playback-control.tsx
+++ b/src/components/playback/playback-control.tsx
@@ -51,7 +51,7 @@ export const PlaybackControlComponent: React.FC<IProps> = observer((props: IProp
   const eventCreatedTime = currentHistoryEvent?.created;
   const playbackDisabled = numHistoryEventsApplied === undefined || sliderValue === history.length;
 
-  const handlePlayPauseToggle = useCallback((playing?: boolean) => {
+  const handlePlayPauseToggle = (playing?: boolean) => {
     const playStatus = playing !== undefined ? playing : !sliderPlaying;
     Logger.logHistoryEvent({
       documentId: treeManager.mainDocument?.key || '',
@@ -61,7 +61,7 @@ export const PlaybackControlComponent: React.FC<IProps> = observer((props: IProp
       action: playStatus ? "playStart": "playStop",
     });
     setSliderPlaying(playStatus);
-  },[sliderPlaying, sliderValue]);
+  };
 
   useEffect(() => {
     if (sliderPlaying) {

--- a/src/lib/logger.test.ts
+++ b/src/lib/logger.test.ts
@@ -1,5 +1,5 @@
 import mockXhr from "xhr-mock";
-import { Logger, LogEventName, ILogComment } from "./logger";
+import { Logger, LogEventName, ILogComment, ILogHistory } from "./logger";
 import { createDocumentModel, DocumentModelType } from "../models/document/document";
 import { ProblemDocument } from "../models/document/document-types";
 import { InvestigationModel } from "../models/curriculum/investigation";
@@ -212,6 +212,128 @@ describe("authed logger", () => {
 
   });
 
+  describe ("log history events", () => {
+    const addDocument = (key: string) => {
+      const document = createDocumentModel({
+        type: ProblemDocument,
+        uid: "1",
+        key,
+        createdAt: 1,
+        content: {},
+        visibility: "public"
+      });
+      stores.documents.add(document);
+    };
+
+    it("logs event with history metadata", (done) => {
+      const documentKey = "source-document";
+      addDocument(documentKey);
+      const historyPayload: ILogHistory = {
+        documentId: documentKey,
+        historyIndex: 12,
+        historyLength: 99,
+        historyEventId: "history-id",
+        action: "playStart"
+      };
+
+      mockXhr.post(/.*/, (req, res) => {
+        const historyRequest = JSON.parse(req.body());
+        expect(historyRequest.event).toBe("HISTORY_PLAYBACK_START");
+        expect(historyRequest.parameters.documentKey).toBe(documentKey);
+        expect(historyRequest.parameters.historyEventId).toBe("history-id");
+        expect(historyRequest.parameters.historyLength).toBe(99);
+        expect(historyRequest.parameters.historyIndex).toBe(12);        
+        done();
+        return res.status(201);
+      });
+      Logger.logHistoryEvent(historyPayload);
+    });
+
+    it("logs showControl Event", (done) => {
+      const documentKey = "source-document";
+      addDocument(documentKey);
+      const historyPayload: ILogHistory = {
+        documentId: documentKey,
+        action: "showControls"
+      };
+
+      mockXhr.post(/.*/, (req, res) => {
+        const historyRequest = JSON.parse(req.body());
+        expect(historyRequest.event).toBe("HISTORY_SHOW_CONTROLS");
+        done();
+        return res.status(201);
+      });
+      Logger.logHistoryEvent(historyPayload);
+    });
+
+    it("logs showControl Event", (done) => {
+      const documentKey = "source-document";
+      addDocument(documentKey);
+      const historyPayload: ILogHistory = {
+        documentId: documentKey,
+        action: "hideControls"
+      };
+
+      mockXhr.post(/.*/, (req, res) => {
+        const historyRequest = JSON.parse(req.body());
+        expect(historyRequest.event).toBe("HISTORY_HIDE_CONTROLS");
+        done();
+        return res.status(201);
+      });
+      Logger.logHistoryEvent(historyPayload);
+    });
+    
+    it("logs playStart Event", (done) => {
+      const documentKey = "source-document";
+      addDocument(documentKey);
+      const historyPayload: ILogHistory = {
+        documentId: documentKey,
+        action: "playStart"
+      };
+
+      mockXhr.post(/.*/, (req, res) => {
+        const historyRequest = JSON.parse(req.body());
+        expect(historyRequest.event).toBe("HISTORY_PLAYBACK_START");
+        done();
+        return res.status(201);
+      });
+      Logger.logHistoryEvent(historyPayload);
+    });
+
+    it("logs playEnd Event", (done) => {
+      const documentKey = "source-document";
+      addDocument(documentKey);
+      const historyPayload: ILogHistory = {
+        documentId: documentKey,
+        action: "playStop"
+      };
+
+      mockXhr.post(/.*/, (req, res) => {
+        const historyRequest = JSON.parse(req.body());
+        done();
+        return res.status(201);
+      });
+      Logger.logHistoryEvent(historyPayload);
+    });
+
+    it("logs playSeek Event", (done) => {
+      const documentKey = "source-document";
+      addDocument(documentKey);
+      const historyPayload: ILogHistory = {
+        documentId: documentKey,
+        action: "playSeek"
+      };
+
+      mockXhr.post(/.*/, (req, res) => {
+        const historyRequest = JSON.parse(req.body());
+        expect(historyRequest.event).toBe("HISTORY_PLAYBACK_SEEK");
+        done();
+        return res.status(201);
+      });
+      Logger.logHistoryEvent(historyPayload);
+    });
+  });
+  
   describe ("log comment events", () => {
     const addDocument = (key: string)=> {
       const document = createDocumentModel({

--- a/src/lib/logger.test.ts
+++ b/src/lib/logger.test.ts
@@ -260,6 +260,7 @@ describe("authed logger", () => {
       mockXhr.post(/.*/, (req, res) => {
         const historyRequest = JSON.parse(req.body());
         expect(historyRequest.event).toBe("HISTORY_SHOW_CONTROLS");
+        expect(historyRequest.parameters.documentKey).toBe(documentKey);
         done();
         return res.status(201);
       });
@@ -310,6 +311,7 @@ describe("authed logger", () => {
 
       mockXhr.post(/.*/, (req, res) => {
         const historyRequest = JSON.parse(req.body());
+        expect(historyRequest.event).toBe("HISTORY_PLAYBACK_STOP");
         done();
         return res.status(201);
       });

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -273,10 +273,7 @@ export class Logger {
     Logger.log(event, parameters);
   }
   
-  public static logHistoryEvent(historyLogInfo: ILogHistory) {
-    const document = this._instance.stores.documents.getDocument(historyLogInfo.documentId) ||
-      this._instance.stores.networkDocuments.getDocument(historyLogInfo.documentId);
-    
+  public static logHistoryEvent(historyLogInfo: ILogHistory) { 
     const eventMap: Record<HistoryAction, LogEventName> = {
       showControls: LogEventName.HISTORY_SHOW_CONTROLS,
       hideControls: LogEventName.HISTORY_HIDE_CONTROLS,

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -133,6 +133,12 @@ export enum LogEventName {
 
   TEACHER_NETWORK_EXPAND_DOCUMENT_SECTION,
   TEACHER_NETWORK_COLLAPSE_DOCUMENT_SECTION,
+
+  HISTORY_SHOW_CONTROLS,
+  HISTORY_HIDE_CONTROLS,
+  HISTORY_PLAYBACK_START,
+  HISTORY_PLAYBACK_STOP,
+  HISTORY_PLAYBACK_SEEK
 }
 
 // This is the form the log events take
@@ -175,6 +181,15 @@ export interface ILogComment {
   isFirst?: boolean; // only used with "add"
   commentText: string;
   action: CommentAction;
+}
+
+type HistoryAction = "showControls" | "hideControls" | "playStart" | "playStop" | "playSeek";
+export interface ILogHistory {
+  documentId: string;
+  historyEventId?: string;  // The id of the history entry where the action took place. Used for start, stop and seek.
+  historyIndex?: number; // Index into history array. Used for start, stop, seek.
+  historyLength?: number; // Used for start, stop, seek
+  action: HistoryAction;
 }
 
 export class Logger {
@@ -256,6 +271,41 @@ export class Logger {
     // log the facet and section separately; they're embedded in the path, but could be useful independently
     const parameters = { curriculum, curriculumFacet: facet, curriculumSection: section, ...params };
     Logger.log(event, parameters);
+  }
+  
+  public static logHistoryEvent(historyLogInfo: ILogHistory) {
+    const document = this._instance.stores.documents.getDocument(historyLogInfo.documentId) ||
+      this._instance.stores.networkDocuments.getDocument(historyLogInfo.documentId);
+    
+    const eventMap: Record<HistoryAction, LogEventName> = {
+      showControls: LogEventName.HISTORY_SHOW_CONTROLS,
+      hideControls: LogEventName.HISTORY_HIDE_CONTROLS,
+      playStart: LogEventName.HISTORY_PLAYBACK_START,
+      playStop: LogEventName.HISTORY_PLAYBACK_STOP,
+      playSeek: LogEventName.HISTORY_PLAYBACK_SEEK
+    };
+    const event = eventMap[historyLogInfo.action];
+    if (isSectionPath(historyLogInfo.documentId)) {
+      Logger.logCurriculumEvent(event, historyLogInfo.documentId,
+        { historyLength: historyLogInfo.historyLength,
+          historyIndex: historyLogInfo.historyIndex,
+          historyEventId: historyLogInfo.historyEventId
+        });
+    }
+    else {
+      const document = this._instance.stores.documents.getDocument(historyLogInfo.documentId)
+                        || this._instance.stores.networkDocuments.getDocument(historyLogInfo.documentId);
+      if (document) {
+        Logger.logDocumentEvent(event, document, 
+          { historyLength: historyLogInfo.historyLength,
+            historyIndex: historyLogInfo.historyIndex,
+            historyEventId: historyLogInfo.historyEventId
+          });
+      }
+      else {
+        console.warn("Warning: couldn't log history event for document:", historyLogInfo.documentId);
+      }
+    }  
   }
 
   public static logDocumentEvent(event: LogEventName, document: DocumentModelType, params?: Record<string, any>) {


### PR DESCRIPTION
Logs events for opening and closing the history controls, starting and stoping playback and seeking with the slider.
The info logged about playback events is: document key, history id, length of history and history index.

I almost got a jest test working for canvas, but ran into trouble trying to mock about bits of TreeManger. If you think that's worth getting working, happy to spend a little more time on it.