### PR TITLE
Refactor ToolContentModelHooks => ToolModelHooks

### DIFF
--- a/src/models/tools/geometry/geometry-content.ts
+++ b/src/models/tools/geometry/geometry-content.ts
@@ -6,7 +6,8 @@ import { SharedDataSet, SharedDataSetType } from "../../shared/shared-data-set";
 import { SelectionStoreModelType } from "../../stores/selection";
 import { ITableLinkProperties, linkedPointId } from "../table-link-types";
 import { ITileExportOptions, IDefaultContentOptions } from "../tool-content-info";
-import { toolContentModelHooks, ToolMetadataModel } from "../tool-types";
+import { ToolMetadataModel } from "../tool-metadata";
+import { toolModelHooks } from "../tool-model-hooks";
 import { ICreateRowsProperties, IRowProperties, ITableChange } from "../table/table-change";
 import { canonicalizeValue } from "../table/table-model-types";
 import { convertModelToChanges, exportGeometryJson } from "./geometry-migrate";
@@ -311,7 +312,7 @@ export const GeometryContentModel = GeometryBaseContentModel
       }
     }
   }))
-  .actions(self => toolContentModelHooks({
+  .actions(self => toolModelHooks({
     doPostCreate(metadata) {
       self.metadata = metadata as GeometryMetadataModelType;
     }

--- a/src/models/tools/image/image-content.ts
+++ b/src/models/tools/image/image-content.ts
@@ -1,8 +1,10 @@
 import { types, Instance, SnapshotOut } from "mobx-state-tree";
 import { exportImageTileSpec, isLegacyImageTileImport, convertLegacyImageTile } from "./image-import-export";
 import { ITileExportOptions, IDefaultContentOptions } from "../tool-content-info";
+import { ToolMetadataModelType } from "../tool-metadata";
+import { toolModelHooks } from "../tool-model-hooks";
 import { getToolTileModel, setTileTitleFromContent } from "../tool-tile";
-import { toolContentModelHooks, ToolContentModel, ToolMetadataModelType } from "../tool-types";
+import { ToolContentModel } from "../tool-types";
 import { isPlaceholderImage } from "../../../utilities/image-utils";
 import placeholderImage from "../../../assets/image_placeholder.png";
 
@@ -45,7 +47,7 @@ export const ImageContentModel = ToolContentModel
       return exportImageTileSpec(self.url, self.filename, options);
     }
   }))
-  .actions(self => toolContentModelHooks({
+  .actions(self => toolModelHooks({
       doPostCreate(metadata: ToolMetadataModelType) {
         self.metadata = metadata;
       },

--- a/src/models/tools/image/image-registration.ts
+++ b/src/models/tools/image/image-registration.ts
@@ -1,5 +1,5 @@
 import { registerToolContentInfo } from "../tool-content-info";
-import { ToolMetadataModel } from "../tool-types";
+import { ToolMetadataModel } from "../tool-metadata";
 import { kImageToolID, ImageContentModel, defaultImageContent } from "./image-content";
 import ImageToolComponent from "../../../components/tools/image-tool";
 import ImageToolIcon from "../../../clue/assets/icons/image-tool.svg";

--- a/src/models/tools/table/table-content.ts
+++ b/src/models/tools/table/table-content.ts
@@ -7,7 +7,9 @@ import {
   convertChangesToSnapshot, convertImportToSnapshot, convertLegacyDataSet, isTableImportSnapshot
 } from "./table-import";
 import { IDocumentExportOptions, IDefaultContentOptions } from "../tool-content-info";
-import { ToolMetadataModel, ToolContentModel, toolContentModelHooks } from "../tool-types";
+import { ToolMetadataModel } from "../tool-metadata";
+import { toolModelHooks } from "../tool-model-hooks";
+import { ToolContentModel } from "../tool-types";
 import { addCanonicalCasesToDataSet, IDataSet, ICaseCreation, ICase, DataSet } from "../../data/data-set";
 import { SharedDataSet, SharedDataSetType } from "../../shared/shared-data-set";
 import { SharedModelType } from "../../shared/shared-model";
@@ -231,7 +233,7 @@ export const TableContentModel = ToolContentModel
       return false;
     }
   }))
-  .actions(self => toolContentModelHooks({
+  .actions(self => toolModelHooks({
     doPostCreate(metadata) {
       self.metadata = metadata as TableMetadataModelType;
     }

--- a/src/models/tools/tool-content-info.ts
+++ b/src/models/tools/tool-content-info.ts
@@ -1,5 +1,6 @@
 import { FunctionComponent, SVGProps } from "react";
-import { ToolContentModel, ToolContentModelType, ToolMetadataModel } from "./tool-types";
+import { ToolMetadataModel } from "./tool-metadata";
+import { ToolContentModel, ToolContentModelType } from "./tool-types";
 import { IToolTileProps } from "../../components/tools/tool-tile";
 import { AppConfigModelType } from "../stores/app-config-model";
 

--- a/src/models/tools/tool-metadata.ts
+++ b/src/models/tools/tool-metadata.ts
@@ -1,0 +1,7 @@
+import { Instance, types } from "mobx-state-tree";
+
+export const ToolMetadataModel = types.model("ToolMetadataModel", {
+    // id of associated tile
+    id: types.string,
+  });
+export interface ToolMetadataModelType extends Instance<typeof ToolMetadataModel> {}

--- a/src/models/tools/tool-model-hooks.ts
+++ b/src/models/tools/tool-model-hooks.ts
@@ -1,0 +1,60 @@
+import { ISerializedActionCall } from "mobx-state-tree";
+import { ToolMetadataModelType } from "./tool-metadata";
+
+export interface IToolModelHooks {
+  /**
+   * This is called after the wrapper around the content model is created. This wrapper is
+   * a ToolTileModel. This should only be called once.
+   *
+   * @param metadata an instance of this model's metadata it might be shared by
+   * multiple instances of the model if the document of this model is open in
+   * more than one place.
+   */
+  doPostCreate(metadata: ToolMetadataModelType): void,
+
+  /**
+   * This is called for any action that is called on the wrapper (ToolTile) or one of
+   * its children. It can be used for logging or internal monitoring of action calls.
+   */
+  onTileAction(call: ISerializedActionCall): void,
+
+  /**
+   * This is called before the tile is removed from the row of the document.
+   * Immediately after the tile is removed from the row it is also removed from
+   * the tileMap which is the actual container of the tile.
+   */
+  willRemoveFromDocument(): void
+}
+
+// This is a way to work with MST action syntax
+// The input argument has to match the api and the result
+// is a literal object type which is compatible with the ModelActions
+// type that is required.
+
+/**
+ * A TypeScript helper method for adding hooks to a content model. It should be
+ * used like:
+ * ```
+ * .actions(self => toolContentModelHooks({
+ *   // add your hook functions here
+ * }))
+ * ```
+ * @param clientHooks the hook functions
+ * @returns the hook functions in a literal object format that is compatible
+ * with the ModelActions type of MST
+ */
+export function toolModelHooks(clientHooks: Partial<IToolModelHooks>) {
+  const hooks: IToolModelHooks = {
+    doPostCreate(metadata: ToolMetadataModelType) {
+      // no-op
+    },
+    onTileAction(call: ISerializedActionCall) {
+      // no-op
+    },
+    willRemoveFromDocument() {
+      // no-op
+    },
+    ...clientHooks
+  };
+  return {...hooks};
+}

--- a/src/models/tools/tool-types.ts
+++ b/src/models/tools/tool-types.ts
@@ -1,7 +1,9 @@
-import { getEnv, getSnapshot, Instance, ISerializedActionCall, types } from "mobx-state-tree";
+import { getEnv, getSnapshot, Instance, types } from "mobx-state-tree";
 import { SharedModelType } from "../shared/shared-model";
 import { ISharedModelManager } from "../shared/shared-model-manager";
 import { getToolContentModels, getToolContentInfoById } from "./tool-content-info";
+import { ToolMetadataModelType } from "./tool-metadata";
+import { toolModelHooks } from "./tool-model-hooks";
 
 /**
  * A dynamic union of tool/tile content models. Its typescript type is
@@ -25,59 +27,6 @@ export const kUnknownToolID = "Unknown";
 
 export interface ITileEnvironment {
   sharedModelManager?: ISharedModelManager;
-}
-
-export interface IToolContentModelHooks {
-  /**
-   * This is called after the wrapper around the content model is created. This wrapper is
-   * a ToolTileModel. This should only be called once.
-   *
-   * @param metadata an instance of this model's metadata it might be shared by
-   * multiple instances of the model if the document of this model is open in
-   * more than one place.
-   */
-  doPostCreate?(metadata: ToolMetadataModelType): void,
-
-  /**
-   * This is called for any action that is called on the wrapper (ToolTile) or one of
-   * its children. It can be used for logging or internal monitoring of action calls.
-   */
-  onTileAction?(call: ISerializedActionCall): void,
-
-  /**
-   * This is called before the tile is removed from the row of the document.
-   * Immediately after the tile is removed from the row it is also removed from
-   * the tileMap which is the actual container of the tile.
-   */
-  willRemoveFromDocument?(): void
-}
-
-// This is a way to work with MST action syntax
-// The input argument has to match the api and the result
-// is a literal object type which is compatible with the ModelActions
-// type that is required.
-// A downside is that when working with the specific model type
-// TS doesn't know which methods of the API it actually implements
-
-/**
- * A TypeScript helper method for adding hooks to a content model. It should be
- * used like:
- * ```
- * .actions(self => toolContentModelHooks({
- *   // add your hook functions here
- * }))
- * ```
- *
- * Unfortunately all hooks you define become optional. Because these hooks
- * should normally only be called by the framework, most likely this issue will
- * only come up in tests.
- *
- * @param hooks the hook functions
- * @returns the hook functions in a literal object format that is compatible
- * with the ModelActions type of MST
- */
-export function toolContentModelHooks(hooks: IToolContentModelHooks) {
-  return {...hooks};
 }
 
 // Generic "super class" of all tool content models
@@ -137,15 +86,9 @@ export const ToolContentModel = types.model("ToolContentModel", {
     }
   }))
   // Add an empty api so the api methods can be used on this generic type
-  .actions(self => toolContentModelHooks({}));
+  .actions(self => toolModelHooks({}));
 
 export interface ToolContentModelType extends Instance<typeof ToolContentModel> {}
-
-export const ToolMetadataModel = types.model("ToolMetadataModel", {
-    // id of associated tile
-    id: types.string,
-  });
-export interface ToolMetadataModelType extends Instance<typeof ToolMetadataModel> {}
 
 interface IPrivate {
   metadata: Record<string, ToolMetadataModelType>;

--- a/src/plugins/data-card-tool/data-card-content.ts
+++ b/src/plugins/data-card-tool/data-card-content.ts
@@ -3,8 +3,10 @@ import { addDisposer, getType, Instance, types } from "mobx-state-tree";
 import { kDataCardToolID, kDefaultLabel, kDefaultLabelPrefix } from "./data-card-types";
 import { withoutUndo } from "../../models/history/tree-monitor";
 import { IDefaultContentOptions, ITileExportOptions } from "../../models/tools/tool-content-info";
+import { ToolMetadataModelType } from "../../models/tools/tool-metadata";
+import { toolModelHooks } from "../../models/tools/tool-model-hooks";
 import { getToolTileModel, setTileTitleFromContent } from "../../models/tools/tool-tile";
-import { ToolContentModel, ToolMetadataModelType, toolContentModelHooks } from "../../models/tools/tool-types";
+import { ToolContentModel } from "../../models/tools/tool-types";
 import {
   addAttributeToDataSet, addCanonicalCasesToDataSet, addCasesToDataSet, DataSet
 } from "../../models/data/data-set";
@@ -121,7 +123,7 @@ export const DataCardContentModel = ToolContentModel
       ].join("\n");
     }
   }))
-  .actions(self => toolContentModelHooks({
+  .actions(self => toolModelHooks({
     doPostCreate(metadata: ToolMetadataModelType){
       self.metadata = metadata;
     }

--- a/src/plugins/data-card-tool/data-card-registration.ts
+++ b/src/plugins/data-card-tool/data-card-registration.ts
@@ -1,9 +1,9 @@
 import { registerToolContentInfo } from "../../models/tools/tool-content-info";
+import { ToolMetadataModel } from "../../models/tools/tool-metadata";
 import { kDataCardDefaultHeight, kDataCardToolID } from "./data-card-types";
 import DataCardToolIcon from "./assets/data-card-tool.svg";
 import { DataCardToolComponent } from "./data-card-tool";
 import { defaultDataCardContent, DataCardContentModel } from "./data-card-content";
-import { ToolMetadataModel } from "../../models/tools/tool-types";
 
 
 registerToolContentInfo({

--- a/src/plugins/dataflow-tool/dataflow-registration.ts
+++ b/src/plugins/dataflow-tool/dataflow-registration.ts
@@ -2,9 +2,9 @@ import {
   DataflowContentModel, defaultDataflowContent, kDataflowDefaultHeight, kDataflowToolID
 } from "./model/dataflow-content";
 import { registerToolContentInfo } from "../../models/tools/tool-content-info";
+import { ToolMetadataModel } from "../../models/tools/tool-metadata";
 import DataflowToolComponent from "./components/dataflow-tool";
 import DataflowToolIcon from "./assets/program.svg";
-import { ToolMetadataModel } from "../../../src/models/tools/tool-types";
 
 registerToolContentInfo({
   id: kDataflowToolID,

--- a/src/plugins/dataflow-tool/model/dataflow-content.ts
+++ b/src/plugins/dataflow-tool/model/dataflow-content.ts
@@ -1,9 +1,11 @@
 import { types, Instance, applySnapshot, getSnapshot } from "mobx-state-tree";
 import { cloneDeep } from "lodash";
 import stringify from "json-stringify-pretty-compact";
-import { ToolContentModel, ToolMetadataModelType, toolContentModelHooks } from "../../../models/tools/tool-types";
 import { DataflowProgramModel } from "./dataflow-program-model";
 import { ITileExportOptions } from "../../../models/tools/tool-content-info";
+import { ToolMetadataModelType } from "../../../models/tools/tool-metadata";
+import { toolModelHooks } from "../../../models/tools/tool-model-hooks";
+import { ToolContentModel } from "../../../models/tools/tool-types";
 import { DEFAULT_DATA_RATE } from "./utilities/node";
 import { getToolTileModel, setTileTitleFromContent } from "../../../models/tools/tool-tile";
 
@@ -71,7 +73,7 @@ export const DataflowContentModel = ToolContentModel
       ].join("\n");
     }
   }))
-  .actions(self => toolContentModelHooks({
+  .actions(self => toolModelHooks({
     doPostCreate(metadata: ToolMetadataModelType){
       self.metadata = metadata;
     }

--- a/src/plugins/drawing-tool/model/drawing-content.ts
+++ b/src/plugins/drawing-tool/model/drawing-content.ts
@@ -3,7 +3,9 @@ import { clone } from "lodash";
 import stringify from "json-stringify-pretty-compact";
 import { StampModel, StampModelType } from "./stamp";
 import { ITileExportOptions, IDefaultContentOptions } from "../../../models/tools/tool-content-info";
-import { ToolMetadataModel, ToolContentModel, toolContentModelHooks } from "../../../models/tools/tool-types";
+import { ToolMetadataModel } from "../../../models/tools/tool-metadata";
+import { toolModelHooks } from "../../../models/tools/tool-model-hooks";
+import { ToolContentModel } from "../../../models/tools/tool-types";
 import { kDrawingStateVersion, kDrawingToolID } from "./drawing-types";
 import { ImageObjectType, isImageObjectSnapshot } from "../objects/image";
 import { DefaultToolbarSettings, ToolbarSettings } from "./drawing-basic-types";
@@ -114,7 +116,7 @@ export const DrawingContentModel = ToolContentModel
       return stringify({type, objects}, {maxLength: 200});
     }
   }))
-  .actions(self => toolContentModelHooks({
+  .actions(self => toolModelHooks({
     doPostCreate(metadata) {
       self.metadata = metadata as DrawingToolMetadataModelType;
     },


### PR DESCRIPTION
- rename `ToolContentModelHooks` => `ToolModelHooks` as CODAP may be attaching them directly to the tile and eliminating the `content`
- separate `ToolModelHooks` and `ToolMetadataModel` into their own files for import flexibility