### PR TITLE
Separate tool content registration from tool component registration

### DIFF
--- a/src/components/chat/chat-thread.tsx
+++ b/src/components/chat/chat-thread.tsx
@@ -6,7 +6,7 @@ import { WithId } from "../../hooks/firestore-hooks";
 import { useUIStore } from "../../hooks/use-stores";
 import { CommentDocument} from "../../lib/firestore-schema";
 import { CommentCard } from "./comment-card";
-import { getToolContentInfoById } from "../../models/tools/tool-content-info";
+import { getToolComponentInfo } from "../../models/tools/tool-component-info";
 import UserIcon from "../../assets/icons/clue-dashboard/teacher-student.svg";
 import {ChatCommentThread} from "./chat-comment-thread";
 import { ToolIconComponent } from "./tool-icon-component";
@@ -41,13 +41,13 @@ export const ChatThread: React.FC<IProps> = ({ activeNavTab, user, chatThreads,
     // Do the logging before we change expandedThread so we can tell whether the thread was expanded or collapsed.
     const eventPayload: ILogComment = {
       focusDocumentId: focusDocument || '',
-      focusTileId:  clickedId && clickedId !== "document" ? clickedId : undefined, // clicks on document do not have a focusTile
+      focusTileId: clickedId && clickedId !== "document" ? clickedId : undefined, // no focusTile for document clicks
       isFirst: false, // We're not adding a comment so this is irrelevant
       commentText: '', // This is about a thread not a single comment it doesn't make sense to log the text.
       action: clickedId === expandedThread ? "collapse" : "expand"
     };
     Logger.logCommentEvent(eventPayload);
-   
+
     if (clickedId === expandedThread) {
       // We're closing the thread so clear out expanded thread.
       // The tile should stay selected though.
@@ -70,7 +70,7 @@ export const ChatThread: React.FC<IProps> = ({ activeNavTab, user, chatThreads,
             commentThread.comments.some((comment: WithId<CommentDocument>) => user?.id === comment.uid);
           const numComments = commentThread.comments.length;
           const shouldBeFocused = commentThread.tileId === focusId;
-          const Icon = commentThread.tileType && getToolContentInfoById(commentThread.tileType)?.Icon;
+          const Icon = commentThread.tileType && getToolComponentInfo(commentThread.tileType)?.Icon;
           const key= commentThread.tileId || "document";
           return (
             <div key={key}

--- a/src/components/chat/tool-icon-component.tsx
+++ b/src/components/chat/tool-icon-component.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useTypeOfTileInDocumentOrCurriculum } from "../../hooks/use-stores";
 import DocumentIcon from "../../assets/icons/document-icon.svg";
-import { getToolContentInfoById } from "../../models/tools/tool-content-info";
+import { getToolComponentInfo } from "../../models/tools/tool-component-info";
 
 interface IProps {
   documentKey?: string;
@@ -10,6 +10,6 @@ interface IProps {
 
 export const ToolIconComponent: React.FC<IProps> = ({documentKey, tileId}) => {
   const tileType = useTypeOfTileInDocumentOrCurriculum(documentKey, tileId);
-  const Icon = tileType && getToolContentInfoById(tileType)?.Icon;
+  const Icon = tileType && getToolComponentInfo(tileType)?.Icon;
   return Icon ? <Icon/> : <DocumentIcon/>;
 };

--- a/src/components/tools/tool-tile.tsx
+++ b/src/components/tools/tool-tile.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import ResizeObserver from "resize-observer-polyfill";
 import { cloneTileSnapshotWithNewId, IDragTileItem, IDragTiles, ToolTileModelType } from "../../models/tools/tool-tile";
 import { transformCurriculumImageUrl } from "../../models/tools/image/image-import-export";
+import { getToolComponentInfo } from "../../models/tools/tool-component-info";
 import { getToolContentInfoById } from "../../models/tools/tool-content-info";
 import { BaseComponent } from "../base";
 import PlaceholderToolComponent from "./placeholder-tool/placeholder-tool";
@@ -187,7 +188,7 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
     const { model, readOnly, isUserResizable, widthPct } = this.props;
     const { hoverTile } = this.state;
     const { appConfig, ui } = this.stores;
-    const { Component: ToolComponent, toolTileClass } = getToolContentInfoById(model.content.type) || {};
+    const { Component: ToolComponent, toolTileClass } = getToolComponentInfo(model.content.type) || {};
     const isPlaceholderTile = ToolComponent === PlaceholderToolComponent;
     const isTileSelected = ui.isSelectedTile(model);
     const tileSelectedForComment = isTileSelected && ui.showChatPanel;
@@ -311,7 +312,7 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
     }
 
     // Select the tile if the tool doesn't handle the selection itself
-    const toolContentInfo = getToolContentInfoById(model.content.type);
+    const toolContentInfo = getToolComponentInfo(model.content.type);
     if (!toolContentInfo?.tileHandlesOwnSelection) {
       ui.setSelectedTile(model, {append: hasSelectionModifier(e)});
     }
@@ -368,7 +369,7 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
     }
     // set the drag data
     const { model, docId } = this.props;
-    const ToolComponent = getToolContentInfoById(model.content.type)?.Component;
+    const ToolComponent = getToolComponentInfo(model.content.type)?.Component;
     // can't drag placeholder tiles
     if (ToolComponent === PlaceholderToolComponent) {
       e.preventDefault();

--- a/src/components/tools/tool-tile.tsx
+++ b/src/components/tools/tool-tile.tsx
@@ -312,8 +312,7 @@ export class ToolTileComponent extends BaseComponent<IProps, IState> {
     }
 
     // Select the tile if the tool doesn't handle the selection itself
-    const toolContentInfo = getToolComponentInfo(model.content.type);
-    if (!toolContentInfo?.tileHandlesOwnSelection) {
+    if (!getToolComponentInfo(model.content.type)?.tileHandlesOwnSelection) {
       ui.setSelectedTile(model, {append: hasSelectionModifier(e)});
     }
   };

--- a/src/models/history/tree-manager.test.ts
+++ b/src/models/history/tree-manager.test.ts
@@ -3,6 +3,7 @@ import { IToolTileProps } from "src/components/tools/tool-tile";
 import { SharedModel, SharedModelType } from "../shared/shared-model";
 import { registerSharedModelInfo } from "../shared/shared-model-registry";
 import { ToolContentModel } from "../tools/tool-types";
+import { registerToolComponentInfo } from "../tools/tool-component-info";
 import { registerToolContentInfo } from "../tools/tool-content-info";
 import { DocumentContentModel, DocumentContentSnapshotType } from "../document/document-content";
 import { createDocumentModel } from "../document/document";
@@ -76,7 +77,10 @@ registerToolContentInfo({
   modelClass: TestTile,
   defaultContent(options) {
     return TestTile.create();
-  },
+  }
+});
+registerToolComponentInfo({
+  id: "TestTile",
   Component: TestTileComponent,
   toolTileClass: "test-tile"
 });

--- a/src/models/history/undo-store.test.ts
+++ b/src/models/history/undo-store.test.ts
@@ -3,6 +3,7 @@ import { IToolTileProps } from "src/components/tools/tool-tile";
 import { SharedModel, SharedModelType } from "../shared/shared-model";
 import { registerSharedModelInfo } from "../shared/shared-model-registry";
 import { ToolContentModel } from "../tools/tool-types";
+import { registerToolComponentInfo } from "../tools/tool-component-info";
 import { registerToolContentInfo } from "../tools/tool-content-info";
 import { DocumentContentModel, DocumentContentSnapshotType } from "../document/document-content";
 import { createDocumentModel } from "../document/document";
@@ -127,7 +128,10 @@ registerToolContentInfo({
   modelClass: TestTile,
   defaultContent(options) {
     return TestTile.create();
-  },
+  }
+});
+registerToolComponentInfo({
+  id: "TestTile",
   Component: TestTileComponent,
   toolTileClass: "test-tile"
 });

--- a/src/models/shared/shared-model-document-manager.test.ts
+++ b/src/models/shared/shared-model-document-manager.test.ts
@@ -4,6 +4,7 @@ import { IToolTileProps } from "../../components/tools/tool-tile";
 import { SharedModel, SharedModelType } from "./shared-model";
 import { SharedModelDocumentManager } from "./shared-model-document-manager";
 import { registerSharedModelInfo } from "./shared-model-registry";
+import { registerToolComponentInfo } from "../tools/tool-component-info";
 import { registerToolContentInfo } from "../tools/tool-content-info";
 import { ITileEnvironment, ToolContentModel } from "../tools/tool-types";
 import { DocumentContentModel } from "../document/document-content";
@@ -114,7 +115,10 @@ registerToolContentInfo({
   modelClass: TestTile,
   defaultContent(options) {
     throw new Error("Function not implemented.");
-  },
+  }
+});
+registerToolComponentInfo({
+  id: "TestTile",
   Component: TestTileComponent,
   toolTileClass: "test-tile"
 });

--- a/src/models/tools/geometry/geometry-registration.ts
+++ b/src/models/tools/geometry/geometry-registration.ts
@@ -1,3 +1,4 @@
+import { registerToolComponentInfo } from "../tool-component-info";
 import { registerToolContentInfo } from "../tool-content-info";
 import { GeometryContentModel, GeometryMetadataModel, defaultGeometryContent } from "./geometry-content";
 import { kGeometryToolID } from "./geometry-types";
@@ -13,7 +14,11 @@ registerToolContentInfo({
   addSidecarNotes: true,
   defaultHeight: kGeometryDefaultHeight,
   exportNonDefaultHeight: true,
-  defaultContent: defaultGeometryContent,
+  defaultContent: defaultGeometryContent
+});
+
+registerToolComponentInfo({
+  id: kGeometryToolID,
   Component: GeometryToolComponent,
   toolTileClass: "geometry-tool-tile",
   tileHandlesOwnSelection: true,

--- a/src/models/tools/image/image-registration.ts
+++ b/src/models/tools/image/image-registration.ts
@@ -1,3 +1,4 @@
+import { registerToolComponentInfo } from "../tool-component-info";
 import { registerToolContentInfo } from "../tool-content-info";
 import { ToolMetadataModel } from "../tool-metadata";
 import { kImageToolID, ImageContentModel, defaultImageContent } from "./image-content";
@@ -9,7 +10,11 @@ registerToolContentInfo({
   titleBase: "Image",
   modelClass: ImageContentModel,
   metadataClass: ToolMetadataModel,
-  defaultContent: defaultImageContent,
+  defaultContent: defaultImageContent
+});
+
+registerToolComponentInfo({
+  id: kImageToolID,
   Component: ImageToolComponent,
   toolTileClass: "image-tool-tile",
   tileHandlesOwnSelection: true,

--- a/src/models/tools/placeholder/placeholder-registration.ts
+++ b/src/models/tools/placeholder/placeholder-registration.ts
@@ -1,3 +1,4 @@
+import { registerToolComponentInfo } from "../tool-component-info";
 import { registerToolContentInfo } from "../tool-content-info";
 import { kPlaceholderToolID, PlaceholderContentModel } from "./placeholder-content";
 import PlaceholderToolComponent from "../../../components/tools/placeholder-tool/placeholder-tool";
@@ -9,7 +10,11 @@ function defaultPlaceholderContent() {
 registerToolContentInfo({
   id: kPlaceholderToolID,
   modelClass: PlaceholderContentModel,
-  defaultContent: defaultPlaceholderContent,
+  defaultContent: defaultPlaceholderContent
+});
+
+registerToolComponentInfo({
+  id: kPlaceholderToolID,
   Component: PlaceholderToolComponent,
   toolTileClass: "placeholder-tile",
   tileHandlesOwnSelection: true

--- a/src/models/tools/table/table-registration.ts
+++ b/src/models/tools/table/table-registration.ts
@@ -1,3 +1,4 @@
+import { registerToolComponentInfo } from "../tool-component-info";
 import { registerToolContentInfo } from "../tool-content-info";
 import {
   kTableToolID, TableContentModel, TableMetadataModel, kTableDefaultHeight, defaultTableContent
@@ -11,7 +12,11 @@ registerToolContentInfo({
   modelClass: TableContentModel,
   metadataClass: TableMetadataModel,
   defaultHeight: kTableDefaultHeight,
-  defaultContent: defaultTableContent,
+  defaultContent: defaultTableContent
+});
+
+registerToolComponentInfo({
+  id: kTableToolID,
   Component: TableToolComponent,
   toolTileClass: "table-tool-tile",
   Icon: TableToolIcon

--- a/src/models/tools/text/text-registration.ts
+++ b/src/models/tools/text/text-registration.ts
@@ -1,3 +1,4 @@
+import { registerToolComponentInfo } from "../tool-component-info";
 import { registerToolContentInfo } from "../tool-content-info";
 import { kTextToolID, TextContentModel, defaultTextContent } from "./text-content";
 import TextToolComponent from "../../../components/tools/text-tool";
@@ -6,9 +7,13 @@ import TextToolIcon from "../../../clue/assets/icons/text-tool.svg";
 registerToolContentInfo({
   id: kTextToolID,
   modelClass: TextContentModel,
-  defaultContent: defaultTextContent,
+  defaultContent: defaultTextContent
+});
+
+registerToolComponentInfo({
+  id: kTextToolID,
   Component: TextToolComponent,
   toolTileClass: "text-tool-tile disable-tile-content-drag",
-  tileHandlesOwnSelection: true,
-  Icon: TextToolIcon
+  Icon: TextToolIcon,
+  tileHandlesOwnSelection: true
 });

--- a/src/models/tools/tool-button.ts
+++ b/src/models/tools/tool-button.ts
@@ -1,5 +1,5 @@
 import { getEnv, Instance, SnapshotOut, types } from "mobx-state-tree";
-import { getToolContentInfoById } from "./tool-content-info";
+import { getToolComponentInfo } from "./tool-component-info";
 
 const BaseToolButtonModel = types.model("BaseToolButton", {
   id: types.string, // toolId in the case of tool buttons
@@ -34,7 +34,7 @@ const TileToolButtonModel = BaseToolButtonModel.named("TileToolButtonModel")
   .actions(self => ({
     initialize() {
       if (!self.Icon) {
-        const info = getToolContentInfoById(self.id);
+        const info = getToolComponentInfo(self.id);
         info?.Icon && (self.Icon = info.Icon);
       }
     }

--- a/src/models/tools/tool-component-info.ts
+++ b/src/models/tools/tool-component-info.ts
@@ -1,0 +1,32 @@
+import React, { SVGProps } from "react";
+import { IToolTileProps } from "../../components/tools/tool-tile";
+
+export interface IToolComponentInfo {
+  id: string;
+  Component: React.ComponentType<IToolTileProps>;
+  toolTileClass: string;
+  Icon?: React.FC<SVGProps<SVGSVGElement>>;
+  /**
+   * By default the tool tile wrapper ToolTileComponent will handle the selection of the
+   * the tile when it gets a mouse down or touch start.
+   *
+   * If the tool wants to manage its own selection by calling ui.setSelectedTile,
+   * it should set tileHandlesOwnSelection to true. This will prevent ToolTileComponent
+   * from trying to set the selection.
+   */
+  tileHandlesOwnSelection?: boolean;
+}
+
+const gToolComponentInfoMap = new Map<string, IToolComponentInfo>();
+
+export function registerToolComponentInfo(toolComponentInfo: IToolComponentInfo) {
+  // toLowerCase() for legacy support of tool names
+  gToolComponentInfoMap.set(toolComponentInfo.id.toLowerCase(), toolComponentInfo);
+}
+
+// Tool id, e.g. kDrawingToolID, kGeometryToolID, etc.
+// undefined is supported so callers do not need to check the id before passing it in
+export function getToolComponentInfo(id?: string) {
+  // toLowerCase() for legacy support of tool names
+  return id ? gToolComponentInfoMap.get(id.toLowerCase()) : undefined;
+}

--- a/src/models/tools/tool-content-info.ts
+++ b/src/models/tools/tool-content-info.ts
@@ -1,7 +1,5 @@
-import { FunctionComponent, SVGProps } from "react";
 import { ToolMetadataModel } from "./tool-metadata";
 import { ToolContentModel, ToolContentModelType } from "./tool-types";
-import { IToolTileProps } from "../../components/tools/tool-tile";
 import { AppConfigModelType } from "../stores/app-config-model";
 
 export interface IDMap {
@@ -20,30 +18,16 @@ export interface IDefaultContentOptions {
   appConfig?: AppConfigModelType;
 }
 
-type ToolComponentType = React.ComponentType<IToolTileProps>;
-
 export interface IToolContentInfo {
   id: string;
   modelClass: typeof ToolContentModel;
   defaultContent: (options?: IDefaultContentOptions) => ToolContentModelType;
-  Component: ToolComponentType;
-  toolTileClass: string;
-  Icon?: FunctionComponent<SVGProps<SVGSVGElement>>;
   titleBase?: string;
   metadataClass?: typeof ToolMetadataModel;
   addSidecarNotes?: boolean;
   defaultHeight?: number;
   exportNonDefaultHeight?: boolean;
   snapshotPostProcessor?: ToolTileModelContentSnapshotPostProcessor;
-  /**
-   * By default the tool tile wrapper ToolTileComponent will handle the selection of the
-   * the tile when it gets a mouse down or touch start.
-   *
-   * If the tool wants to manage its own selection by calling ui.setSelectedTile,
-   * it should set tileHandlesOwnSelection to true. This will prevent ToolTileComponent
-   * from trying to set the selection.
-   */
-  tileHandlesOwnSelection?: boolean;
 }
 
 const gToolContentInfoMapById: Record<string, IToolContentInfo> = {};

--- a/src/models/tools/unknown-content.ts
+++ b/src/models/tools/unknown-content.ts
@@ -1,3 +1,4 @@
+import { registerToolComponentInfo } from "./tool-component-info";
 import { registerToolContentInfo } from "./tool-content-info";
 import { kUnknownToolID, UnknownContentModel, UnknownContentModelType } from "./tool-types";
 import PlaceholderToolComponent from "../../components/tools/placeholder-tool/placeholder-tool";
@@ -9,8 +10,11 @@ export function defaultContent(): UnknownContentModelType {
 registerToolContentInfo({
   id: kUnknownToolID,
   modelClass: UnknownContentModel,
-  defaultContent,
-  // TODO: should really have a separate unknown tool that shows an "unknown tile" message
+  defaultContent
+});
+
+registerToolComponentInfo({
+  id: kUnknownToolID,
   Component: PlaceholderToolComponent,
   toolTileClass: "placeholder-tile",
   tileHandlesOwnSelection: true

--- a/src/plugins/data-card-tool/data-card-registration.ts
+++ b/src/plugins/data-card-tool/data-card-registration.ts
@@ -1,3 +1,4 @@
+import { registerToolComponentInfo } from "../../models/tools/tool-component-info";
 import { registerToolContentInfo } from "../../models/tools/tool-content-info";
 import { ToolMetadataModel } from "../../models/tools/tool-metadata";
 import { kDataCardDefaultHeight, kDataCardToolID } from "./data-card-types";
@@ -5,15 +6,18 @@ import DataCardToolIcon from "./assets/data-card-tool.svg";
 import { DataCardToolComponent } from "./data-card-tool";
 import { defaultDataCardContent, DataCardContentModel } from "./data-card-content";
 
-
 registerToolContentInfo({
   id: kDataCardToolID,
   modelClass: DataCardContentModel,
   titleBase: "Data Card Collection",
   metadataClass: ToolMetadataModel,
   defaultContent: defaultDataCardContent,
+  defaultHeight: kDataCardDefaultHeight
+});
+
+registerToolComponentInfo({
+  id: kDataCardToolID,
   Component: DataCardToolComponent,
-  defaultHeight: kDataCardDefaultHeight,
   toolTileClass: "data-card-tool-tile",
   Icon: DataCardToolIcon
 });

--- a/src/plugins/dataflow-tool/dataflow-registration.ts
+++ b/src/plugins/dataflow-tool/dataflow-registration.ts
@@ -1,6 +1,7 @@
 import {
   DataflowContentModel, defaultDataflowContent, kDataflowDefaultHeight, kDataflowToolID
 } from "./model/dataflow-content";
+import { registerToolComponentInfo } from "../../models/tools/tool-component-info";
 import { registerToolContentInfo } from "../../models/tools/tool-content-info";
 import { ToolMetadataModel } from "../../models/tools/tool-metadata";
 import DataflowToolComponent from "./components/dataflow-tool";
@@ -12,7 +13,11 @@ registerToolContentInfo({
   modelClass: DataflowContentModel,
   metadataClass: ToolMetadataModel,
   defaultHeight: kDataflowDefaultHeight,
-  defaultContent: defaultDataflowContent,
+  defaultContent: defaultDataflowContent
+});
+
+registerToolComponentInfo({
+  id: kDataflowToolID,
   Component: DataflowToolComponent,
   toolTileClass: "dataflow-tool-tile",
   Icon: DataflowToolIcon

--- a/src/plugins/diagram-viewer/diagram-registration.ts
+++ b/src/plugins/diagram-viewer/diagram-registration.ts
@@ -1,3 +1,4 @@
+import { registerToolComponentInfo } from "../../models/tools/tool-component-info";
 import { registerToolContentInfo } from "../../models/tools/tool-content-info";
 import { kDiagramDefaultHeight, kDiagramToolID } from "./diagram-types";
 import { defaultDiagramContent, DiagramContentModel } from "./diagram-content";
@@ -9,13 +10,17 @@ registerToolContentInfo({
   id: kDiagramToolID,
   // TODO: maybe there is there a better way to do this kind of casting?
   //   The issue is that modelClass prop has a type of `typeof ToolContentModel`,
-  //   That type is pretty restrictive and doesn't accommodate the return of 
-  //   types.snapshotProcessor. There might be a better way to get a 
+  //   That type is pretty restrictive and doesn't accommodate the return of
+  //   types.snapshotProcessor. There might be a better way to get a
   //   typescript type for a MST "Class" which is less restrictive
   modelClass: DiagramMigrator as typeof DiagramContentModel,
   defaultContent: defaultDiagramContent,
+  defaultHeight: kDiagramDefaultHeight
+});
+
+registerToolComponentInfo({
+  id: kDiagramToolID,
   Component: DiagramToolComponent,
-  defaultHeight: kDiagramDefaultHeight,
   toolTileClass: "diagram-tool-tile disable-tile-content-drag nowheel",
   Icon: DiagramToolIcon
 });

--- a/src/plugins/drawing-tool/drawing-registration.ts
+++ b/src/plugins/drawing-tool/drawing-registration.ts
@@ -1,3 +1,4 @@
+import { registerToolComponentInfo } from "../../models/tools/tool-component-info";
 import { registerToolContentInfo } from "../../models/tools/tool-content-info";
 import { DrawingContentModel, DrawingToolMetadataModel, defaultDrawingContent } from "./model/drawing-content";
 import { kDrawingToolID, kDrawingDefaultHeight } from "./model/drawing-types";
@@ -10,14 +11,18 @@ registerToolContentInfo({
   titleBase: "Drawing",
   // TODO: maybe there is a better way to do this kind of casting?
   //   The issue is that modelClass prop has a type of `typeof ToolContentModel`,
-  //   That type is pretty restrictive and doesn't accommodate the return of 
-  //   types.snapshotProcessor. There might be a better way to get a 
+  //   That type is pretty restrictive and doesn't accommodate the return of
+  //   types.snapshotProcessor. There might be a better way to get a
   //   typescript type for a MST "Class" which is less restrictive
   modelClass: DrawingMigrator as typeof DrawingContentModel,
   metadataClass: DrawingToolMetadataModel,
   defaultHeight: kDrawingDefaultHeight,
   exportNonDefaultHeight: true,
-  defaultContent: defaultDrawingContent,
+  defaultContent: defaultDrawingContent
+});
+
+registerToolComponentInfo({
+  id: kDrawingToolID,
   Component: DrawingToolComponent,
   toolTileClass: "drawing-tool-tile",
   Icon: DrawingToolIcon

--- a/src/plugins/starter/starter-registration.ts
+++ b/src/plugins/starter/starter-registration.ts
@@ -1,3 +1,4 @@
+import { registerToolComponentInfo } from "../../models/tools/tool-component-info";
 import { registerToolContentInfo } from "../../models/tools/tool-content-info";
 import { kStarterDefaultHeight, kStarterToolID } from "./starter-types";
 import StarterToolIcon from "./starter-icon.svg";
@@ -8,8 +9,12 @@ registerToolContentInfo({
   id: kStarterToolID,
   modelClass: StarterContentModel,
   defaultContent: defaultStarterContent,
+  defaultHeight: kStarterDefaultHeight
+});
+
+registerToolComponentInfo({
+  id: kStarterToolID,
   Component: StarterToolComponent,
-  defaultHeight: kStarterDefaultHeight,
   toolTileClass: "starter-tool-tile",
   Icon: StarterToolIcon
 });


### PR DESCRIPTION
Some clients (like CODAP) may want to adopt the content model without adopting the component model.