### PR TITLE
remove "firestore and userContext" warning

### DIFF
--- a/src/models/stores/stores.ts
+++ b/src/models/stores/stores.ts
@@ -13,8 +13,7 @@ import { getUserContext } from "../../hooks/use-user-context";
 import { registerTools } from "../../register-tools";
 import { DemoModelType, DemoModel } from "./demo";
 import { SupportsModel, SupportsModelType } from "./supports";
-import { DocumentsModelType, createDocumentsModelWithRequiredDocuments, 
-  createNetworkDocumentsModel } from "./documents";
+import { DocumentsModelType, DocumentsModel, createDocumentsModelWithRequiredDocuments } from "./documents";
 import { LearningLogDocument, PersonalDocument, PlanningDocument, ProblemDocument } from "../document/document-types";
 import { LearningLogWorkspace, ProblemWorkspace } from "./workspace";
 import { ClipboardModel, ClipboardModelType } from "./clipboard";
@@ -85,7 +84,7 @@ export function createStores(params?: ICreateStores): IStores {
     class: params?.class || ClassModel.create({ name: "Null Class", classHash: "" }),
     db: params?.db || new DB(),
     documents: params?.documents || createDocumentsModelWithRequiredDocuments(requiredDocumentTypes),
-    networkDocuments: params?.networkDocuments || createNetworkDocumentsModel(),
+    networkDocuments: params?.networkDocuments || DocumentsModel.create({}),
     unit: params?.unit || UnitModel.create({code: "NULL", title: "Null Unit"}),
     demo: params?.demo || DemoModel.create({name: demoName, class: {id: "0", name: "Null Class"}}),
     showDemoCreator: params?.showDemoCreator || false,

--- a/src/models/stores/stores.ts
+++ b/src/models/stores/stores.ts
@@ -13,7 +13,8 @@ import { getUserContext } from "../../hooks/use-user-context";
 import { registerTools } from "../../register-tools";
 import { DemoModelType, DemoModel } from "./demo";
 import { SupportsModel, SupportsModelType } from "./supports";
-import { DocumentsModelType, DocumentsModel, createDocumentsModelWithRequiredDocuments } from "./documents";
+import { DocumentsModelType, createDocumentsModelWithRequiredDocuments, 
+  createNetworkDocumentsModel } from "./documents";
 import { LearningLogDocument, PersonalDocument, PlanningDocument, ProblemDocument } from "../document/document-types";
 import { LearningLogWorkspace, ProblemWorkspace } from "./workspace";
 import { ClipboardModel, ClipboardModelType } from "./clipboard";
@@ -84,7 +85,7 @@ export function createStores(params?: ICreateStores): IStores {
     class: params?.class || ClassModel.create({ name: "Null Class", classHash: "" }),
     db: params?.db || new DB(),
     documents: params?.documents || createDocumentsModelWithRequiredDocuments(requiredDocumentTypes),
-    networkDocuments: params?.networkDocuments || DocumentsModel.create({}),
+    networkDocuments: params?.networkDocuments || createNetworkDocumentsModel(),
     unit: params?.unit || UnitModel.create({code: "NULL", title: "Null Unit"}),
     demo: params?.demo || DemoModel.create({name: demoName, class: {id: "0", name: "Null Class"}}),
     showDemoCreator: params?.showDemoCreator || false,


### PR DESCRIPTION
To keep this simple I just removed the warning. 

When we work on:
https://www.pivotaltracker.com/story/show/183291353
> Safeguard the real documents from having their history changed by the history slider. This can be done by adding a flag or some other way to identify the history documents and only loading history into documents with this flag.

We can consider adding another "type" to this flag indicating the document should be read-only like a network/remote document. Then we can add back the warning if it looks like a document should be recording or playing back history.

Initially, in the first commit, I added a `kind` to the DocumentsModel. In the runtime there are only 2 instances of the DocumentsModel:
- class documents
- network documents

Adding this kind to the DocumentsModel improved some of the debugging messages and could be used for skipping the warning message.  But the DocumentsModel is also used for testing and perhaps it will be used outside of CLUE so adding this `kind` seems wrong. 
