### PR TITLE
Add styling to commented document list

### DIFF
--- a/src/components/chat/commented-documents.scss
+++ b/src/components/chat/commented-documents.scss
@@ -1,18 +1,82 @@
 @import "../vars";
-.document-box{
-  width: 100%;
-  height: 20px;
-  border: 1px solid black;
-  font-size: small;
-  display: flex;
-  justify-content: space-between;
-  .title{
-
-  }
-  .numComments{
-
+.commented-document-list {
+  max-height: calc(100vh - (#{$header-height} + #{$problem-header-height} + #{$workspace-content-margin} * 2));
+  overflow-y: auto;
+  .document-box {
+    max-height: 51px;
+    margin: 2px;
+    padding: 0 2px;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    background-color: $charcoal-light-6;
+    color: $charcoal;
+    border: solid 1px #979797;
+    &:hover {
+      background-color: $charcoal-light-4;
+    }
+    &:active {
+      background-color: $charcoal-light-3;
+    }
+    &.problems {
+      background-color: $problem-orange-light-7;
+      &:hover {
+        background-color: $problem-orange-light-5;
+      }
+      &:active {
+        background-color: $problem-orange-light-4;
+      }
+    }
+    &.teacher-guide {
+      background-color: $learninglog-green-light-7;
+      &:hover {
+        background-color: $learninglog-green-light-5;
+      }
+      &:active {
+        background-color: $learninglog-green-light-4;
+      }
+    }
+    &.class-work {
+      background-color: $classwork-purple-light-7;
+      &:hover {
+        background-color: $classwork-purple-light-5;
+      }
+      &:active {
+        background-color: $classwork-purple-light-4;
+      }
+    }
+    &.my-work {
+      background-color: $workspace-teal-light-6;
+      &:hover {
+        background-color: $workspace-teal-light-4;
+      }
+      &:active {
+        background-color: $workspace-teal-light-3;
+      }
+    }
+    .title{
+      line-height: 1.29;
+      flex-grow: 1;
+      flex-basis: 130px;
+      margin: 0 5px;
+    }
+    .document-type-icon {
+      align-self: flex-start;
+      svg {
+        width: 18px;
+        height: 16.5px;
+      }
+    }
+    .numComments {
+      align-self: flex-start;
+      width: 24px;
+      margin: 3px 2px 2px;
+      padding: 1px 6px 2px;
+      border-radius: 7.5px;
+      background-color: white;
+      text-align: center;
+      font-size: 10px;
+    }
   }
 }
-
-
-

--- a/src/components/chat/commented-documents.tsx
+++ b/src/components/chat/commented-documents.tsx
@@ -7,6 +7,7 @@ import { UserModelType } from "../../models/stores/user";
 import { DocumentModelType } from "../../models/document/document";
 import { useDocumentCaption } from "../thumbnail/decorated-document-thumbnail-item";
 import { ENavTab } from "../../models/view/nav-tabs";
+import DocumentIcon from "../../assets/icons/document-icon.svg";
 import "./commented-documents.scss";
 import { getProblemOrdinal } from "../../models/stores/stores";
 
@@ -115,7 +116,7 @@ export const CommentedDocuments: React.FC<IProps> = ({user, handleDocView}) => {
   },[]);
 
   return (
-    <div>
+    <div className="commented-document-list">
       {
         docsCommentedOn &&
         (docsCommentedOn).map((doc: PromisedCurriculumDocument, index:number) => {
@@ -128,7 +129,7 @@ export const CommentedDocuments: React.FC<IProps> = ({user, handleDocView}) => {
           }
           return (
             <div
-              className={"document-box"}
+              className={`document-box ${navTab}`}
               key={index}
               onClick={() => {
                 ui.setActiveNavTab(navTab); //open correct NavTab
@@ -139,6 +140,9 @@ export const CommentedDocuments: React.FC<IProps> = ({user, handleDocView}) => {
                 }
               }}
             >
+              <div className="document-type-icon">
+                <DocumentIcon/>
+              </div>
               <div className={"title"}>
                 { doc.unit.toUpperCase() + " " + doc.problem + " " + doc.title}
               </div>
@@ -181,7 +185,7 @@ interface JProps {
 
 export const MyWorkDocuments: React.FC<JProps> = ({doc, index, sectionDoc, handleDocView}) => {
   const ui = useUIStore();
-  let navTab: string;
+  let navTab: string = '';
   const myWorkTypes = ["problem", "planning", "learningLog", "personal"];
   const classWorkTypes = ["publication", "learningLogPublication", "personalPublication", "supportPublication"];
   for (let i = 0; i < 4; i++){
@@ -196,7 +200,7 @@ export const MyWorkDocuments: React.FC<JProps> = ({doc, index, sectionDoc, handl
 
   return (
     <div
-      className={"document-box"}
+      className={`document-box my-work-document ${navTab}`}
       onClick={()=>{
         ui.setActiveNavTab(navTab); //open correct NavTab
         ui.setSelectedTile();
@@ -207,6 +211,9 @@ export const MyWorkDocuments: React.FC<JProps> = ({doc, index, sectionDoc, handl
         }
       }}
     >
+      <div className="document-type-icon">
+        <DocumentIcon/>
+      </div>
       <div className={"title"}>
         {title}
       </div>

--- a/src/components/chat/commented-documents.tsx
+++ b/src/components/chat/commented-documents.tsx
@@ -185,7 +185,7 @@ interface JProps {
 
 export const MyWorkDocuments: React.FC<JProps> = ({doc, index, sectionDoc, handleDocView}) => {
   const ui = useUIStore();
-  let navTab: string = '';
+  let navTab = '';
   const myWorkTypes = ["problem", "planning", "learningLog", "personal"];
   const classWorkTypes = ["publication", "learningLogPublication", "personalPublication", "supportPublication"];
   for (let i = 0; i < 4; i++){


### PR DESCRIPTION
Features this is still missing that are in the zeplin specs:
- icons to indicate a user has commented on a document
- icons indicate what kind of document it is (right now they're all the default)
- document icons color coded by the type.