### PR TITLE
fix a error from tab component

### DIFF
--- a/src/components/navigation/problem-tab-content.tsx
+++ b/src/components/navigation/problem-tab-content.tsx
@@ -57,16 +57,16 @@ export const ProblemTabContent: React.FC<IProps>
 
   const handleTabSelected = (index: number) => {
     const section = sections?.[index];
-    if (!section) { return; }
-    // TODO: The log event had its properties reversed. We don't want to introduce
-    // a breaking change in the log event stream, so the variables are named for
-    // clarity. It might be better to add a version property to the log event
-    // so we can fix this.
-    const titleArgButReallyType = section.type;    
-    const typeArgButReallyTitle = getSectionTitle(section.type);
+    if (!section) return;
+    // TODO: The log event properties have been reversed for quite a while now.
+    // We don't want to introduce a breaking change in the log event stream, so
+    // the variables are named for clarity. It might be better to add a version
+    // property to the log event so we can fix this.
+    const namePropButReallyType = section.type;    
+    const typePropButReallyTitle = getSectionTitle(section.type);
     Logger.log(LogEventName.SHOW_TAB_SECTION, {
-      tab_section_name: titleArgButReallyType,
-      tab_section_type: typeArgButReallyTitle
+      tab_section_name: namePropButReallyType,
+      tab_section_type: typePropButReallyTitle
     });
     // Clear any selected tiles when the tab changes
     ui.setSelectedTile();

--- a/src/components/navigation/problem-tab-content.tsx
+++ b/src/components/navigation/problem-tab-content.tsx
@@ -55,16 +55,23 @@ export const ProblemTabContent: React.FC<IProps>
 
   }, [ui, ui.focusDocument]);
 
-  const handleTabClick = (titleArgButReallyType: string, typeArgButReallyTitle: string) => {
-    // TODO: this function has its argument names reversed (see caller for details.)
-    // We can't simply switch it, however, because that would introduce a breaking change
-    // in the log event stream, so for now we just rename the arguments for clarity.
+  const handleTabSelected = (index: number) => {
+    const section = sections?.[index];
+    if (!section) { return; }
+    // TODO: The log event had its properties reversed. We don't want to introduce
+    // a breaking change in the log event stream, so the variables are named for
+    // clarity. It might be better to add a version property to the log event
+    // so we can fix this.
+    const titleArgButReallyType = section.type;    
+    const typeArgButReallyTitle = getSectionTitle(section.type);
     Logger.log(LogEventName.SHOW_TAB_SECTION, {
       tab_section_name: titleArgButReallyType,
       tab_section_type: typeArgButReallyTitle
     });
+    // Clear any selected tiles when the tab changes
     ui.setSelectedTile();
     ui.updateFocusDocument();
+    setActiveIndex(index);
   };
 
   function findSelectedSectionIndex(fullPath: string | undefined){
@@ -88,6 +95,7 @@ export const ProblemTabContent: React.FC<IProps>
     <Tabs className={classNames("problem-tabs", context, chatBorder)}
           selectedTabClassName="selected"
           selectedIndex={activeIndex || 0}
+          onSelect={handleTabSelected}
           data-focus-document={problemPath}
     >
       <div className={classNames("tab-header-row", {"no-sub-tabs": !hasSubTabs})}>
@@ -98,10 +106,6 @@ export const ProblemTabContent: React.FC<IProps>
               <Tab
                 className={classNames("prob-tab", context)}
                 key={`section-${section.type}`}
-                onClick={() => {
-                  handleTabClick(section.type, sectionTitle);
-                  setActiveIndex(index);
-                }}
               >
                 {sectionTitle}
               </Tab>

--- a/src/components/navigation/problem-tab-content.tsx
+++ b/src/components/navigation/problem-tab-content.tsx
@@ -3,7 +3,7 @@ import { observer } from "mobx-react";
 import React, { useEffect, useState } from "react";
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
 import { useProblemPathWithFacet, useUIStore, useUserStore } from "../../hooks/use-stores";
-import { getSectionTitle, SectionModelType } from "../../models/curriculum/section";
+import { getSectionTitle, SectionModelType, findSectionIndex } from "../../models/curriculum/section";
 import { ProblemPanelComponent } from "./problem-panel";
 import { Logger, LogEventName } from "../../lib/logger";
 import ToggleControl from "../utilities/toggle-control";
@@ -45,7 +45,7 @@ export const ProblemTabContent: React.FC<IProps>
       ui.updateFocusDocument();
     }
     setActiveIndex((prevState) => {
-      const newIndex = findSelectedSectionIndex(ui.focusDocument);
+      const newIndex = findSectionIndex(sections, ui.focusDocument);
       if (newIndex !== -1) {
         return newIndex;
       } else {
@@ -53,7 +53,7 @@ export const ProblemTabContent: React.FC<IProps>
       }
     });
 
-  }, [ui, ui.focusDocument]);
+  }, [sections, ui, ui.focusDocument]);
 
   const handleTabSelected = (index: number) => {
     const section = sections?.[index];
@@ -73,18 +73,6 @@ export const ProblemTabContent: React.FC<IProps>
     ui.updateFocusDocument();
     setActiveIndex(index);
   };
-
-  function findSelectedSectionIndex(fullPath: string | undefined){
-    if (fullPath !==undefined){
-      const lastSlashPosition = fullPath.split("/", 3).join("_").length + 1;
-      const sectionSelected =  fullPath.substring(lastSlashPosition, fullPath.length);
-      const index =  sections.findIndex((section: any) => section.type === sectionSelected);
-      return index;
-    }
-    else {
-      return 0;
-    }
-  }
 
   const handleToggleSolutions = () => {
     ui.toggleShowTeacherContent(!showTeacherContent);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,6 +11,7 @@ import { setUnitAndProblem } from "./models/stores/stores";
 import { UserModel } from "./models/stores/user";
 import { urlParams } from "./utilities/url-params";
 import { getAppMode } from "./lib/auth";
+import { DEBUG_STORES } from "./lib/debug";
 import { Logger } from "./lib/logger";
 import { setPageTitle } from "./lib/misc";
 import { gImageMap } from "./models/image-map";
@@ -38,6 +39,10 @@ const initializeApp = async () => {
 
   const isPreviewing = !!(urlParams.domain && urlParams.domain_uid && !urlParams.token);
   const stores = createStores({ appMode, appVersion, appConfig, user, showDemoCreator, demoName, isPreviewing });
+
+  if (DEBUG_STORES) {
+    (window as any).stores = stores;
+  }
 
   if (appMode === "qa" && urlParams.qaClear === "all") {
     ReactDOM.render(

--- a/src/lib/debug.ts
+++ b/src/lib/debug.ts
@@ -6,10 +6,11 @@ if (debug.length > 0) {
 
 const debugContains = (key: string) => debug.indexOf(key) !== -1;
 
-export const DEBUG_LISTENERS = debugContains("listeners");
 export const DEBUG_CANVAS = debugContains("canvas");
-export const DEBUG_LOGGER = debugContains("logger");
-export const DEBUG_SAVE = debugContains("save");
 export const DEBUG_DOCUMENT = debugContains("document");
 export const DEBUG_HISTORY = debugContains("history");
+export const DEBUG_LISTENERS = debugContains("listeners");
+export const DEBUG_LOGGER = debugContains("logger");
+export const DEBUG_SAVE = debugContains("save");
+export const DEBUG_STORES = debugContains("stores");
 export const DEBUG_UNDO = debugContains("undo");

--- a/src/models/curriculum/section.test.ts
+++ b/src/models/curriculum/section.test.ts
@@ -1,5 +1,5 @@
 import { getSectionInitials, getSectionPlaceholder, getSectionTitle,
-        kAllSectionType, SectionModel, registerSectionInfo, kDefaultPlaceholder } from "./section";
+        kAllSectionType, SectionModel, registerSectionInfo, kDefaultPlaceholder, findSectionIndex } from "./section";
 
 describe("SectionModel", () => {
 
@@ -42,4 +42,19 @@ describe("SectionModel", () => {
     expect(foo2Section.placeholder).toBe("Foo Placeholder");
   });
 
+});
+
+describe("findSelectedSectionIndex", () => {
+  it("finds section index", () => {
+    const sections = [
+      SectionModel.create({ type: "foo" }),
+      SectionModel.create({ type: "bar" })
+    ];
+
+    expect(findSectionIndex(sections, "msa/1/1/foo")).toBe(0);
+    expect(findSectionIndex(sections, "msa/1/1/bar")).toBe(1);
+    expect(findSectionIndex(sections, "msa/1/1/baz")).toBe(-1);
+    expect(findSectionIndex(sections, "invalid")).toBe(-1);
+    expect(findSectionIndex(sections, undefined)).toBe(0);
+  });
 });

--- a/src/models/curriculum/section.ts
+++ b/src/models/curriculum/section.ts
@@ -1,4 +1,5 @@
 import { types } from "mobx-state-tree";
+import { parseSectionPath } from "../../../functions/src/shared";
 import { DocumentContentModel } from "../document/document-content";
 import { IAuthoredTileContent } from "../document/document-content-import";
 import { SupportModel } from "./support";
@@ -105,3 +106,14 @@ export const SectionModel = types
     };
   });
 export type SectionModelType = typeof SectionModel.Type;
+
+export function findSectionIndex(sections: SectionModelType[], fullPath: string | undefined){
+  if (fullPath !==undefined) {
+    const [,,,,sectionSelected] = parseSectionPath(fullPath) || [];
+    const index =  sections.findIndex((section: any) => section.type === sectionSelected);
+    return index;
+  }
+  else {
+    return 0;
+  }
+}


### PR DESCRIPTION
The tab component was reporting an error because of onSelect was not provided.
I also added a DEBUG_STORES to make it easier to see if the focusDocument was being updated correctly.

The error was:
> Warning: Failed prop type: The prop `onSelect` is marked as required in `Tabs`, but its value is `undefined` or `null`.
> `onSelect` is required when `selectedIndex` is also set. Not doing so will make the tabs not do anything, as `selectedIndex` indicates that you want to handle the selected tab yourself.
> If you only want to set the inital tab replace `selectedIndex` with `defaultIndex`.