### PR TITLE
handle tile removal better

### DIFF
--- a/src/components/tiles/image/image-tile.tsx
+++ b/src/components/tiles/image/image-tile.tsx
@@ -130,6 +130,7 @@ export default class ImageToolComponent extends BaseComponent<IProps, IState> {
   }
   public componentWillUnmount() {
     this.resizeObserver.disconnect();
+    this.handleResizeDebounced.cancel();
     this._isMounted = false;
   }
   public componentDidUpdate(prevProps: IProps, prevState: IState) {


### PR DESCRIPTION
When scrubbing history it is easy to quickly add, remove, add, remove... a tile.
This was causing a couple of warnings/errors in the console.
A MST warning was printed because the tile model was being accessed
after it was detached.
A React error was printed because the component state was updated
after the component was unmounted.

These issues happened in debounced methods which I believe were firing
after the tile had been removed.
After the fixes in this commit I cannot reproduce the console messages.