### PR TITLE
Update diagram view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@concord-consortium/diagram-view": "^0.0.19",
+        "@concord-consortium/diagram-view": "^0.0.20",
         "@concord-consortium/mobx-state-tree": "5.1.5-cc.1",
         "@concord-consortium/react-components": "^0.7.1",
         "@concord-consortium/react-modal-hook": "^3.0.0-cc.1",
@@ -2009,9 +2009,9 @@
       "dev": true
     },
     "node_modules/@concord-consortium/diagram-view": {
-      "version": "0.0.19",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.19.tgz",
-      "integrity": "sha512-Au2t5oPBfFki2hqc6IEmsSSUTNoQZEADJHhdERYnR1jUXMJDE2b29Fv3iQ7mEsUIAF5yNkw4oHsY/S5k1tT8WQ==",
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.20.tgz",
+      "integrity": "sha512-6p+iKMzR17vzYmGe85V0XaSHIs1f8aX9/c+pm3yBoa3UBZloZytt9V2sRhzYcd9/b88tvOR9cKsuQcnHvYQGmQ==",
       "dependencies": {
         "iframe-phone": "^1.3.1",
         "mathjs": "^10.4.1",
@@ -22574,9 +22574,9 @@
       "dev": true
     },
     "@concord-consortium/diagram-view": {
-      "version": "0.0.19",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.19.tgz",
-      "integrity": "sha512-Au2t5oPBfFki2hqc6IEmsSSUTNoQZEADJHhdERYnR1jUXMJDE2b29Fv3iQ7mEsUIAF5yNkw4oHsY/S5k1tT8WQ==",
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.20.tgz",
+      "integrity": "sha512-6p+iKMzR17vzYmGe85V0XaSHIs1f8aX9/c+pm3yBoa3UBZloZytt9V2sRhzYcd9/b88tvOR9cKsuQcnHvYQGmQ==",
       "requires": {
         "iframe-phone": "^1.3.1",
         "mathjs": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
     "xhr-mock": "^2.5.1"
   },
   "dependencies": {
-    "@concord-consortium/diagram-view": "^0.0.19",
+    "@concord-consortium/diagram-view": "^0.0.20",
     "@concord-consortium/mobx-state-tree": "5.1.5-cc.1",
     "@concord-consortium/react-components": "^0.7.1",
     "@concord-consortium/react-modal-hook": "^3.0.0-cc.1",

--- a/src/plugins/diagram-viewer/diagram-migrator.test.ts
+++ b/src/plugins/diagram-viewer/diagram-migrator.test.ts
@@ -1,25 +1,36 @@
+import { types } from "mobx-state-tree";
+import { Variable } from "@concord-consortium/diagram-view";
 import { DiagramMigrator } from "./diagram-migrator";
 import { kDiagramToolStateVersion } from "./diagram-types";
 
+const NodeContainer = types.model("NodeContainer", {
+  variable: Variable,
+  diagramMigrator: DiagramMigrator
+});
+
 describe("DiagramMigrator", () => {
+  const variable = { id: "v1", name: "variable1" };
   const basicDiagram = {
     root: {
       nodes: {
         "node1": {
           x: 1,
           y: 1,
-          variable: "variable1"
+          variable: "v1"
         }
       }
     },
   };
 
   it("loads modern state", () => {
-    const migrated = DiagramMigrator.create({
-      version: kDiagramToolStateVersion,
-      ...basicDiagram
+    const dc = NodeContainer.create({
+      variable,
+      diagramMigrator: {
+        version: kDiagramToolStateVersion,
+        ...basicDiagram
+      }
     });
-    expect(migrated.root?.nodes.size).toBe(1);
+    expect(dc.diagramMigrator.root?.nodes.size).toBe(1);
   });
 
   it("blanks out state without a version", () => {


### PR DESCRIPTION
Gets a quick fix to avoid a bug that was causing crashes when documents were loading that had diagram tiles with nodes referencing non-existent variables.

The change to diagram view involved checking each node after the root is created, and destroying any that don't have a valid variable.

I also had to modify the diagram migrator test.