### PR TITLE
remove some console log messages from jest

### DIFF
--- a/src/models/stores/documents.test.ts
+++ b/src/models/stores/documents.test.ts
@@ -88,7 +88,10 @@ describe("documents model", () => {
   it("does not allow duplicate documents to be added", () => {
     documents.add(document);
     expect(documents.all.length).toBe(1);
-    documents.add(document);
+    jestSpyConsole("warn", spy => {
+      documents.add(document);
+      expect(spy).toBeCalledWith("Document with the same key already exists");
+    });
     expect(documents.all.length).toBe(1);
   });
 

--- a/src/plugins/diagram-viewer/diagram-content.test.ts
+++ b/src/plugins/diagram-viewer/diagram-content.test.ts
@@ -184,6 +184,9 @@ describe("DiagramContent", () => {
 
   it("handles off chance that updateAfterSharedModelChanges is called before things are ready", () => {
     const content = createDiagramContent();
-    expect(() => content.updateAfterSharedModelChanges()).not.toThrow();
+    jestSpyConsole("warn", spy => {
+      expect(() => content.updateAfterSharedModelChanges()).not.toThrow();
+      expect(spy).toBeCalledWith("updateAfterSharedModelChanges was called with no shared model present");
+    });
   });
 });

--- a/src/plugins/drawing/components/__snapshots__/drawing-layer-legacy.test.tsx.snap
+++ b/src/plugins/drawing/components/__snapshots__/drawing-layer-legacy.test.tsx.snap
@@ -98,7 +98,7 @@ exports[`Drawing Layer Components Image adds an image 1`] = `
 >
   <image
     height="10"
-    href="test-file-stub"
+    href="my/image/url"
     width="10"
     x="10"
     y="10"
@@ -122,7 +122,7 @@ exports[`Drawing Layer Components Image moves a image 1`] = `
 >
   <image
     height="10"
-    href="test-file-stub"
+    href="my/image/url"
     width="10"
     x="5"
     y="5"


### PR DESCRIPTION
This fixes:
- Document with the same key already exists
- updateAfterSharedModelChanges was called...
- errors from image map when it was trying to load fake URLs

There are still some console messages and errors not fixed by this PR:
```
 PASS  src/plugins/data-card/data-card-tile.test.tsx
  ● Console

    console.warn
      [mobx] Out of bounds read: 0

      115 |
      116 |   function getCaseAtIndex(index: number) {
    > 117 |     const aCase = self.cases[index],
          |                             ^
      118 |           id = aCase && aCase.__id__;
      119 |     return id ? getCase(id) : undefined;
      120 |   }
...
    console.error
      Error: Uncaught [Error: Function not implemented.]
          at reportException (/Users/scott/Development/collaborative-learning/node_modules/jsdom/lib/jsdom/living/helpers/runtime-script-errors.js:66:24)
          ...
          at unstable_runWithPriority (/Users/scott/Development/collaborative-learning/node_modules/scheduler/cjs/scheduler.development.js:468:12) {
        detail: Error: Function not implemented.
            at onUnregisterTileApi (/Users/scott/Development/collaborative-learning/src/plugins/data-card/data-card-tile.test.tsx:49:13)
            at /Users/scott/Development/collaborative-learning/src/components/tiles/hooks/use-toolbar-tile-api.ts:29:18
            ...
```
And
```
 PASS  src/components/tiles/link-indicator.test.tsx
  ● Console

    console.error
      Warning: `NaN` is an invalid value for the `right` css style property.
          at button
          at IconButtonSvg (/Users/scott/Development/collaborative-learning/src/components/utilities/icon-button-svg.tsx:17:20)
          at LinkIndicatorComponent (/Users/scott/Development/collaborative-learning/src/components/tiles/link-indicator.tsx:14:60)

      at printWarning (node_modules/react-dom/cjs/react-dom.development.js:67:30)
      ...
      at finalizeInitialChildren (node_modules/react-dom/cjs/react-dom.development.js:10201:3)
```