### PR TITLE
Bump diagram-view to v0.0.24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@concord-consortium/diagram-view": "^0.0.23",
+        "@concord-consortium/diagram-view": "^0.0.24",
         "@concord-consortium/mobx-state-tree": "5.1.5-cc.1",
         "@concord-consortium/react-components": "^0.7.1",
         "@concord-consortium/react-modal-hook": "^3.0.0-cc.1",
@@ -1868,9 +1868,9 @@
       "license": "MIT"
     },
     "node_modules/@concord-consortium/diagram-view": {
-      "version": "0.0.23",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.23.tgz",
-      "integrity": "sha512-YWRYjk3BKzHHO0Qt/M5IhAFr+hEaL2lCTeay+avzBk9GP+m2m5H1AIyAbn9/zeDnzWVclVGKkNZ2+mUlH6XKbg==",
+      "version": "0.0.24",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.24.tgz",
+      "integrity": "sha512-m84DMbyud51hpanLpaAh+VdkGUeL959Xeum3XUxMdter3unH68cd1A9Hs3+Wz9NyT24qvuFjSEvmHquC+uV4xg==",
       "dependencies": {
         "iframe-phone": "^1.3.1",
         "mathjs": "^10.4.1",
@@ -20533,9 +20533,9 @@
       "dev": true
     },
     "@concord-consortium/diagram-view": {
-      "version": "0.0.23",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.23.tgz",
-      "integrity": "sha512-YWRYjk3BKzHHO0Qt/M5IhAFr+hEaL2lCTeay+avzBk9GP+m2m5H1AIyAbn9/zeDnzWVclVGKkNZ2+mUlH6XKbg==",
+      "version": "0.0.24",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.24.tgz",
+      "integrity": "sha512-m84DMbyud51hpanLpaAh+VdkGUeL959Xeum3XUxMdter3unH68cd1A9Hs3+Wz9NyT24qvuFjSEvmHquC+uV4xg==",
       "requires": {
         "iframe-phone": "^1.3.1",
         "mathjs": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
     "xhr-mock": "^2.5.1"
   },
   "dependencies": {
-    "@concord-consortium/diagram-view": "^0.0.23",
+    "@concord-consortium/diagram-view": "^0.0.24",
     "@concord-consortium/mobx-state-tree": "5.1.5-cc.1",
     "@concord-consortium/react-components": "^0.7.1",
     "@concord-consortium/react-modal-hook": "^3.0.0-cc.1",


### PR DESCRIPTION
The latest diagram-view includes a fix for a bug where using your keyboard to delete a card containing an expression would cause CLUE to crash.