### PR TITLE
Eliminate history-related import cycles

### DIFF
--- a/src/models/document/document.ts
+++ b/src/models/document/document.ts
@@ -55,6 +55,7 @@ export const DocumentModel = Tree.named("Document")
     supportContentType: types.maybe(types.enumeration<ESupportType>("SupportType", Object.values(ESupportType)))
   })
   .volatile(self => ({
+    treeMonitor: undefined as TreeMonitor | undefined,
     queryPromise: undefined as Promise<UseQueryResult<IGetNetworkDocumentResponse>> | undefined,
     contentStatus: ContentStatus.Valid,
     invalidContent: undefined as object | undefined,

--- a/src/models/document/tile-row.ts
+++ b/src/models/document/tile-row.ts
@@ -1,7 +1,7 @@
 import { types, Instance, SnapshotIn, SnapshotOut } from "mobx-state-tree";
 import { ITileModel } from "../tiles/tile-model";
 import { uniqueId } from "../../utilities/js-utils";
-import { withoutUndo } from "../history/tree-monitor";
+import { withoutUndo } from "../history/without-undo";
 
 export interface IDropRowInfo {
   rowInsertIndex: number;

--- a/src/models/history/tree-types.ts
+++ b/src/models/history/tree-types.ts
@@ -1,0 +1,38 @@
+import { getPath, IActionContext, IPatchRecorder } from "@concord-consortium/mobx-state-tree";
+import { IActionTrackingMiddleware3Call } from "./create-action-tracking-middleware-3";
+
+export interface CallEnv {
+  recorder: IPatchRecorder;
+  sharedModelModifications: SharedModelModifications;
+  historyEntryId: string;
+  exchangeId: string;
+  undoable: boolean;
+}
+
+export type SharedModelModifications = Record<string, number>;
+
+export const runningCalls = new WeakMap<IActionContext, IActionTrackingMiddleware3Call<CallEnv>>();
+
+export function getActionPath(call: IActionTrackingMiddleware3Call<CallEnv>) {
+  return `${getPath(call.actionCall.context)}/${call.actionCall.name}`;
+}
+
+export const actionsFromManager = [
+  // Because we haven't implemented applySharedModelSnapshotFromManager
+  // yet, all calls to handleSharedModelChanges are actually internal
+  // calls. However we treat those calls as actions from the manager
+  // because we want any changes triggered by a shared model update added
+  // to the same history entry.
+  "handleSharedModelChanges",
+  "applyPatchesFromManager",
+  "startApplyingPatchesFromManager",
+  "finishApplyingPatchesFromManager",
+  // We haven't implemented this yet, it is needed to support two trees
+  // working with the same shared model
+  "applySharedModelSnapshotFromManager"
+];
+
+export function isActionFromManager(call: IActionTrackingMiddleware3Call<CallEnv>) {
+  const actionName = call.actionCall.name;
+  return actionsFromManager.includes(actionName);
+}

--- a/src/models/history/tree.ts
+++ b/src/models/history/tree.ts
@@ -4,14 +4,12 @@ import { DocumentContentModelType } from "../document/document-content";
 import { SharedModelType } from "../shared/shared-model";
 import { ITileModel } from "../tiles/tile-model";
 import { TreeManagerAPI } from "./tree-manager-api";
-import { TreeMonitor } from "./tree-monitor";
 
 export const Tree = types.model("Tree", {
 })
 .volatile(self => ({
   applyingManagerPatches: false,
-  treeManagerAPI: undefined as TreeManagerAPI | undefined,
-  treeMonitor: undefined as TreeMonitor | undefined
+  treeManagerAPI: undefined as TreeManagerAPI | undefined
 }))
 .views(self => ({
   get treeId(): string {

--- a/src/models/history/undo-store.test.ts
+++ b/src/models/history/undo-store.test.ts
@@ -1,4 +1,6 @@
+import { cloneDeep } from "lodash";
 import { flow, getSnapshot, getType, Instance, types } from "mobx-state-tree";
+import { nanoid } from "nanoid";
 import { ITileProps } from "src/components/tiles/tile-component";
 import { SharedModel, SharedModelType } from "../shared/shared-model";
 import { registerSharedModelInfo } from "../shared/shared-model-registry";
@@ -11,9 +13,7 @@ import { ProblemDocument } from "../document/document-types";
 import { when } from "mobx";
 import { CDocument, TreeManager } from "./tree-manager";
 import { HistoryEntrySnapshot } from "./history";
-import { nanoid } from "nanoid";
-import { cloneDeep } from "lodash";
-import { withoutUndo } from "./tree-monitor";
+import { withoutUndo } from "./without-undo";
 
 // way to get a writable reference to libDebug
 const libDebug = require("../../lib/debug");

--- a/src/models/history/without-undo.ts
+++ b/src/models/history/without-undo.ts
@@ -1,0 +1,58 @@
+import { getRoot, getRunningActionContext } from "@concord-consortium/mobx-state-tree";
+import { DEBUG_UNDO } from "../../lib/debug";
+import { runningCalls } from "./tree-types";
+
+export function withoutUndo() {
+  const actionCall = getRunningActionContext();
+  if (!actionCall) {
+    throw new Error("withoutUndo called outside of an MST action");
+  }
+
+  if (actionCall.parentActionEvent) {
+    // It is a little weird to print all this, but it seems like a good way to leave
+    // this part unimplemented.
+    console.warn([
+      "withoutUndo() called by a child action. If calling a child action " +
+      "with withoutUndo is something you need to do, update this code to support it. " +
+      "There are several options for supporting it:",
+      "   1. Ignore the call",
+      "   2. Apply the withoutUndo to the parent action",
+      "   3. Apply the withoutUndo just to the child action",
+      "Notes:",
+      "   - option 1 will be hard to debug, so if you do this, you should add a debug " +
+      "option to print out a message when it is ignored",
+      "   - option 3 will require changing the undo stack so it can record different " +
+      "entries from the history stack. It will also require changing the recordPatches " +
+      "function to somehow track this child action information."
+    ].join('\n'));
+    return;
+  }
+
+  const call = runningCalls.get(actionCall);
+  if (!call){
+    // It is normal for there to be no running calls. This can happen in two cases:
+    //   - the document isn't being edited so the tree monitor is disabled
+    //   - the document content is part of the authored unit. In this case there is no
+    //     DocumentModel so there is no middleware.
+    if (DEBUG_UNDO) {
+      try {
+        const {context} = actionCall;
+        const root = getRoot(context);
+        // Use duck typing to figure out if the root is a tree
+        // and its tree monitor is enabled
+        if ((root as any).treeMonitor?.enabled) {
+          console.warn("cannot find action tracking middleware call");
+        }
+      } catch ( error ) {
+        console.warn("cannot find action tracking middleware call, " +
+          "error thrown while trying to find the tree", error);
+      }
+    }
+    return;
+  }
+
+  if (!call.env) {
+    throw new Error("environment is not setup on action tracking middleware call");
+  }
+  call.env.undoable = false;
+}

--- a/src/plugins/data-card/data-card-content.ts
+++ b/src/plugins/data-card/data-card-content.ts
@@ -1,7 +1,7 @@
 import { reaction } from "mobx";
 import { addDisposer, getType, Instance, types } from "mobx-state-tree";
 import { kDataCardTileType, kDefaultLabel, kDefaultLabelPrefix } from "./data-card-types";
-import { withoutUndo } from "../../models/history/tree-monitor";
+import { withoutUndo } from "../../models/history/without-undo";
 import { IDefaultContentOptions, ITileExportOptions } from "../../models/tiles/tile-content-info";
 import { ITileMetadataModel } from "../../models/tiles/tile-metadata";
 import { tileModelHooks } from "../../models/tiles/tile-model-hooks";


### PR DESCRIPTION
- move `treeMonitor` volatile property from `Tree` to `DocumentModel`
- move shared types from `tree-monitor.ts` to new `tree-types.ts`
- move `withoutUndo()` from `tree-monitor.ts` to new `without-undo.ts`