### PR TITLE
184186983 pressure sensor send 0 instead of NaN

### DIFF
--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -603,7 +603,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
   }
 
   private postSerialModal(){
-    const lastMsg = localStorage.getItem('last-connect-message');
+    const lastMsg = localStorage.getItem("last-connect-message");
 
     let alertMessage = "";
 

--- a/src/plugins/dataflow/nodes/factories/sensor-rete-node-factory.tsx
+++ b/src/plugins/dataflow/nodes/factories/sensor-rete-node-factory.tsx
@@ -24,7 +24,7 @@ export class SensorReteNodeFactory extends DataflowReteNodeFactory {
 
   public worker(node: NodeData, inputs: any, outputs: any) {
 
-    const makeZero = node.data.type === "fsr-reading" && isNaN(node.data.nodeValue as number)
+    const makeZero = node.data.type === "fsr-reading" && isNaN(node.data.nodeValue as number);
     outputs.num = makeZero ? 0 : node.data.nodeValue;
 
     if (this.editor) {

--- a/src/plugins/dataflow/nodes/factories/sensor-rete-node-factory.tsx
+++ b/src/plugins/dataflow/nodes/factories/sensor-rete-node-factory.tsx
@@ -23,7 +23,7 @@ export class SensorReteNodeFactory extends DataflowReteNodeFactory {
   }
 
   public worker(node: NodeData, inputs: any, outputs: any) {
-    outputs.num = node.data.nodeValue;
+    outputs.num = isFinite(node.data.nodeValue as number) ? node.data.nodeValue : 0;
 
     if (this.editor) {
       const _node = this.editor.nodes.find((n: { id: any; }) => n.id === node.id);

--- a/src/plugins/dataflow/nodes/factories/sensor-rete-node-factory.tsx
+++ b/src/plugins/dataflow/nodes/factories/sensor-rete-node-factory.tsx
@@ -23,7 +23,9 @@ export class SensorReteNodeFactory extends DataflowReteNodeFactory {
   }
 
   public worker(node: NodeData, inputs: any, outputs: any) {
-    outputs.num = isFinite(node.data.nodeValue as number) ? node.data.nodeValue : 0;
+
+    const makeZero = node.data.type === "fsr-reading" && isNaN(node.data.nodeValue as number)
+    outputs.num = makeZero ? 0 : node.data.nodeValue;
 
     if (this.editor) {
       const _node = this.editor.nodes.find((n: { id: any; }) => n.id === node.id);


### PR DESCRIPTION
When a sensor block (rete node) receives a `NaN` from data interpreted from a sensor, it will convert it to a `0` before setting the node value.  