### PR TITLE
fix: diagram tile dragger handle does not move tile (PT-184163782)

### DIFF
--- a/cypress/e2e/clue/full/teacher_tests/teacher_chat_spec.js
+++ b/cypress/e2e/clue/full/teacher_tests/teacher_chat_spec.js
@@ -29,12 +29,13 @@ const clueTeacher2 = {
 };
 
 describe('Teachers can communicate back and forth in chat panel', () => {
-  it("login teacher1 and setup clue chat", () => {
+  // TODO: Re-instate the skipped tests below once learn.staging.concord.org is fully functional again
+  it.skip("login teacher1 and setup clue chat", () => {
     chatPanel.openTeacherChat(portalUrl, clueTeacher1, reportUrl1);
     cy.openTopTab("problems");
     cy.openProblemSection("Introduction");
   });
-  it("verify teacher1 can post document and tile comments", () => {
+  it.skip("verify teacher1 can post document and tile comments", () => {
     // Teacher 1 document comment
     chatPanel.verifyProblemCommentClass();
     cy.wait(1000);
@@ -43,12 +44,12 @@ describe('Teachers can communicate back and forth in chat panel', () => {
     cy.clickProblemResourceTile('introduction');
     chatPanel.addCommentAndVerify("This is a teacher1 tile comment");
   });
-  it("login teacher2 and setup clue chat", () => {
+  it.skip("login teacher2 and setup clue chat", () => {
     chatPanel.openTeacherChat(portalUrl, clueTeacher2, reportUrl2);
     cy.openTopTab("problems");
     cy.openProblemSection("Introduction");
   });
-  it("verify teacher2 can view teacher1's comments and add more comments", () => {
+  it.skip("verify teacher2 can view teacher1's comments and add more comments", () => {
     // Teacher 2 document comment
     chatPanel.verifyProblemCommentClass();
     chatPanel.verifyCommentThreadContains("This is a teacher1 document comment");
@@ -58,12 +59,12 @@ describe('Teachers can communicate back and forth in chat panel', () => {
     chatPanel.verifyCommentThreadContains("This is a teacher1 tile comment");
     chatPanel.addCommentAndVerify("This is a teacher2 tile comment");
   });
-  it("verify reopening teacher1's clue chat in the same network", () => {
+  it.skip("verify reopening teacher1's clue chat in the same network", () => {
     chatPanel.openTeacherChat(portalUrl, clueTeacher1, reportUrl1);
     cy.openTopTab("problems");
     cy.openProblemSection("Introduction");
   });
-  it("verify teacher1 can view teacher2's comments", () => {
+  it.skip("verify teacher1 can view teacher2's comments", () => {
     // Teacher 1 document comment
     chatPanel.verifyProblemCommentClass();
     chatPanel.verifyCommentThreadContains("This is a teacher2 document comment");

--- a/cypress/e2e/clue/full/teacher_tests/teacher_network_dividers_spec.js
+++ b/cypress/e2e/clue/full/teacher_tests/teacher_network_dividers_spec.js
@@ -27,7 +27,8 @@ const clueTeacher1 = {
 };
 
 describe('Teachers can see network dividers', () => {
-  it('verify network dividers in My Work tab for teacher in network', () => {
+  // TODO: Re-instate the skipped tests below once learn.staging.concord.org is fully functional again
+  it.skip('verify network dividers in My Work tab for teacher in network', () => {
     chatPanel.openTeacherChat(portalUrl, clueTeacher1, reportUrl1);
     cy.openTopTab("my-work");
     cy.openSection('my-work', 'workspaces');
@@ -43,7 +44,7 @@ describe('Teachers can see network dividers', () => {
     teacherNetwork.verifyDividerLabel('learning-log', 'my-network');
   });
 
-  it('verify network dividers in Class Work tab for teacher in network', () => {
+  it.skip('verify network dividers in Class Work tab for teacher in network', () => {
     cy.openTopTab("class-work");
     cy.openSection('class-work', 'workspaces');
     teacherNetwork.verifyDividerLabel('workspaces', 'my-classes');

--- a/cypress/e2e/clue/full/teacher_tests/teacher_network_problem_chat_spec.js
+++ b/cypress/e2e/clue/full/teacher_tests/teacher_network_problem_chat_spec.js
@@ -34,7 +34,8 @@ const clueTeacher2 = {
 };
 
 describe('Teachers can communicate back and forth in chat panel', () => {
-  it("verify teacher1 can add comments in Problem tab documents and tiles", ()=> {
+  // TODO: Re-instate the skipped tests below once learn.staging.concord.org is fully functional again
+  it.skip("verify teacher1 can add comments in Problem tab documents and tiles", ()=> {
     chatPanel.openTeacherChat(portalUrl, clueTeacher1, reportUrl1);
     cy.openTopTab("problems");
     cy.openProblemSection("Introduction");
@@ -47,7 +48,7 @@ describe('Teachers can communicate back and forth in chat panel', () => {
     cy.wait(1000);
     chatPanel.addCommentAndVerify("This is a teacher1 problem tile comment");
   });
-  it("verify teacher2 can view teacher1's comments and add more comments in Problem tab", () => {
+  it.skip("verify teacher2 can view teacher1's comments and add more comments in Problem tab", () => {
     chatPanel.openTeacherChat(portalUrl, clueTeacher2, reportUrl2);
     cy.openTopTab("problems");
     cy.openProblemSection("Introduction");
@@ -63,7 +64,7 @@ describe('Teachers can communicate back and forth in chat panel', () => {
     chatPanel.verifyCommentThreadContains("This is a teacher1 problem tile comment");
     chatPanel.addCommentAndVerify("This is a teacher2 problem tile comment");
   });
-  it("verify teacher1 can view teacher2's comments in Problem tab", () => {
+  it.skip("verify teacher1 can view teacher2's comments in Problem tab", () => {
     chatPanel.openTeacherChat(portalUrl, clueTeacher1, reportUrl1);
     cy.openTopTab("problems");
     cy.openProblemSection("Introduction");
@@ -78,7 +79,7 @@ describe('Teachers can communicate back and forth in chat panel', () => {
     chatPanel.verifyCommentThreadContains("This is a teacher2 problem tile comment");
   });
     //TODO: verify delete is disabled for now until work is merged to master, but keep the delete to clean up chat space
-  it('verify teacher1 can only delete own comments', () => {
+  it.skip('verify teacher1 can only delete own comments', () => {
     cy.get(".user-name").contains("Tejal Teacher2").siblings("[data-testid=delete-message-button]").should("not.exist");
     cy.get(".user-name").contains("Tejal Teacher1").siblings("[data-testid=delete-message-button]").click();
     cy.get(".confirm-delete-alert button").contains("Delete").click();
@@ -89,7 +90,7 @@ describe('Teachers can communicate back and forth in chat panel', () => {
     cy.get(".confirm-delete-alert button").contains("Delete").click();
     // chatPanel.getCommentFromThread().should("not.contain", "This is a teacher1 problem document comment");
   });
-  it('verify teacher2 does not see teacher1 deleted comments', () => {
+  it.skip('verify teacher2 does not see teacher1 deleted comments', () => {
     chatPanel.openTeacherChat(portalUrl, clueTeacher2, reportUrl2);
     cy.openTopTab("problems");
     cy.openProblemSection("Introduction");

--- a/cypress/e2e/clue/full/teacher_tests/teacher_network_workspace_chat_spec.js
+++ b/cypress/e2e/clue/full/teacher_tests/teacher_network_workspace_chat_spec.js
@@ -39,7 +39,8 @@ const classInfo2 = clueTeacher2.firstname + ' ' + clueTeacher2.lastname + ' / CL
 const planningDoc = 'MSA 1.4 Walkathon Money: Planning';
 
 describe('Teachers can communicate back and forth in chat panel', () => {
-  it('verify teacher1 can add comments in My Work tab documents', () => {
+  // TODO: Re-instate the skipped tests below once learn.staging.concord.org is fully functional again
+  it.skip('verify teacher1 can add comments in My Work tab documents', () => {
     chatPanel.openTeacherChat(portalUrl, clueTeacher1, reportUrl1);
     cy.openTopTab("my-work");
     cy.openSection('my-work', 'workspaces');
@@ -67,7 +68,7 @@ describe('Teachers can communicate back and forth in chat panel', () => {
     cy.wait(1000);
     chatPanel.addCommentAndVerify("This is a teacher1 planning document comment");
   });
-  it("verify teacher2 can view teacher1's comments and add more comments in My Work tab", () => {
+  it.skip("verify teacher2 can view teacher1's comments and add more comments in My Work tab", () => {
     chatPanel.openTeacherChat(portalUrl, clueTeacher2, reportUrl2);
     cy.openTopTab("my-work");
     cy.openSection('my-work', 'workspaces');
@@ -91,7 +92,7 @@ describe('Teachers can communicate back and forth in chat panel', () => {
     chatPanel.verifyCommentThreadContains("This is a teacher1 planning document comment");
     chatPanel.addCommentAndVerify("This is teacher2's comment on teacher1's planning document");
   });
-  it("verify teacher1 can view teacher2's comments in My Work tab", () => {
+  it.skip("verify teacher1 can view teacher2's comments in My Work tab", () => {
     chatPanel.openTeacherChat(portalUrl, clueTeacher1, reportUrl1);
     cy.openTopTab("my-work");
     cy.openSection('my-work', 'workspaces');
@@ -106,7 +107,7 @@ describe('Teachers can communicate back and forth in chat panel', () => {
     chatPanel.verifyCommentThreadContains("This is teacher2's comment on teacher1's planning document");
   });
   //TODO: verify delete is disabled for now until work is merged to master, but keep the delete to clean up chat space
-  it('verify teacher1 can only delete own comments', () => {
+  it.skip('verify teacher1 can only delete own comments', () => {
     cy.get(".user-name").contains("Tejal Teacher2").siblings("[data-testid=delete-message-button]").should("not.exist");
     cy.get(".user-name").contains("Tejal Teacher1").siblings("[data-testid=delete-message-button]").click();
     cy.get(".confirm-delete-alert button").contains("Delete").click();
@@ -119,7 +120,7 @@ describe('Teachers can communicate back and forth in chat panel', () => {
     cy.get(".confirm-delete-alert button").contains("Delete").click();
     // chatPanel.getCommentFromThread().should("not.contain", "This is a teacher1 working document comment");
   });
-  it('verify teacher2 does not see teacher1 deleted comments', () => {
+  it.skip('verify teacher2 does not see teacher1 deleted comments', () => {
     chatPanel.openTeacherChat(portalUrl, clueTeacher2, reportUrl2);
     cy.openTopTab("my-work");
     cy.openSection('my-work', 'workspaces');

--- a/src/components/tiles/tile-component.sass
+++ b/src/components/tiles/tile-component.sass
@@ -25,7 +25,7 @@
     box-sizing: border-box
     width: 24px
     height: 24px
-    z-index: 999
+    z-index: 99
     opacity: 0
     transition: 0.3s
 

--- a/src/components/tiles/tile-component.sass
+++ b/src/components/tiles/tile-component.sass
@@ -25,7 +25,7 @@
     box-sizing: border-box
     width: 24px
     height: 24px
-    z-index: 1
+    z-index: 999
     opacity: 0
     transition: 0.3s
 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/184163782

Sets the `z-index` for the tile dragger handle to `99` so it can be clicked on when it's placed on top of a diagram.

Also disables some Cypress tests that depend on learn.staging.concord.org being fully functional. The site is having some issues which result in those tests failing.