### PR TITLE
184186985-dataflow-serial-indicator

### DIFF
--- a/src/plugins/dataflow/components/ui/dataflow-program-topbar.tsx
+++ b/src/plugins/dataflow/components/ui/dataflow-program-topbar.tsx
@@ -67,7 +67,7 @@ export const DataflowProgramTopbar = (props: TopbarProps) => {
   function serialMessage(){
     // nodes that use serial, but no device physically connected
     if (lastMsg !== "connect" && serialDevice.serialNodesCount > 0){
-      return knownBoard ? "connect a device" : ""
+      return knownBoard ? "connect a device" : "";
     }
     // physical connection has been made but user action needed
     if (lastMsg === "connect"
@@ -77,7 +77,7 @@ export const DataflowProgramTopbar = (props: TopbarProps) => {
       return "click to finish connecting";
     }
     else {
-      return ""
+      return "";
     }
   }
 

--- a/src/plugins/dataflow/components/ui/dataflow-program-topbar.tsx
+++ b/src/plugins/dataflow/components/ui/dataflow-program-topbar.tsx
@@ -54,6 +54,9 @@ interface TopbarProps {
 
 export const DataflowProgramTopbar = (props: TopbarProps) => {
   const { serialDevice } = props;
+  // Of the boards tested, only authentic Arduinos (usbProductId === 67) raise the browser `connect` event
+  // Which we use to track physical connection independently of port state
+  // So we only warn of a lack of physical connection when using an known board
   const knownBoard = serialDevice.deviceInfo?.usbProductId === 67;
   const lastMsg = localStorage.getItem("last-connect-message");
   const classes = classNames(

--- a/src/plugins/dataflow/components/ui/dataflow-program-topbar.tsx
+++ b/src/plugins/dataflow/components/ui/dataflow-program-topbar.tsx
@@ -54,11 +54,12 @@ interface TopbarProps {
 
 export const DataflowProgramTopbar = (props: TopbarProps) => {
   const { serialDevice } = props;
+  const knownBoard = serialDevice.deviceInfo?.usbProductId === 67;
   const lastMsg = localStorage.getItem("last-connect-message");
   const classes = classNames(
     "icon-serial",
     { "physical-connection": lastMsg === "connect"},
-    { "no-physical-connection": lastMsg === "disconnect"},
+    { "no-physical-connection": lastMsg === "disconnect" && knownBoard},
     serialDevice.serialNodesCount > 0 ? "nodes-in-need" : "no-serial-needed",
     serialDevice.hasPort() ? "has-port" : "no-port"
   );
@@ -66,7 +67,7 @@ export const DataflowProgramTopbar = (props: TopbarProps) => {
   function serialMessage(){
     // nodes that use serial, but no device physically connected
     if (lastMsg !== "connect" && serialDevice.serialNodesCount > 0){
-      return "connect a device";
+      return knownBoard ? "connect a device" : ""
     }
     // physical connection has been made but user action needed
     if (lastMsg === "connect"
@@ -74,6 +75,9 @@ export const DataflowProgramTopbar = (props: TopbarProps) => {
         && serialDevice.serialNodesCount > 0
     ){
       return "click to finish connecting";
+    }
+    else {
+      return ""
     }
   }
 


### PR DESCRIPTION
184186985-dataflow-serial-indicator

This changes the behavior of the serial connection button/indicator in the upper left corner of a Dataflow tile so that users of non-Arduino-manufactured boards do not get false error messages about the state of their physical connection, (but also do not get the intermediary prompt).  

**Known Arduino-manufactured board:**
1. flashes orange to warn for connection
2. physical connection made - flashes yellow, message to click to finish connection process
3. user clicks button to approve connection - turns green

**Unknown Arduino-manufactured board:**
1. flashes orange to warn for connection
2. physical connection made - continues flashing orange
3. user clicks button to approve connection - turns green
