### PR TITLE
fix: four-up view allows editing other users' documents [PT-184276344]

### DIFF
--- a/src/components/four-up.tsx
+++ b/src/components/four-up.tsx
@@ -190,8 +190,11 @@ export class FourUpComponent extends BaseComponent<IProps, IState> {
       const cornerLabel = indexToCornerLabel[cornerIndex];
       const cell = this.grid.cells[cornerIndex];
       const document = groupDoc(cornerIndex);
+      // Only the user's document is editable, but not if they're a ghost user
+      // (Ghost users do not own group documents and cannot edit others')
+      const readOnly = cornerIndex !== 0 || isGhostUser;
       return <CanvasComponent context={cornerLabel} scale={cellScale(cell, cornerLabel)}
-                       readOnly={isGhostUser /* Ghost users do not own group documents and cannot edit others' */}
+                       readOnly={readOnly}
                        document={document} overlayMessage={canvasMessage(document)}
                        showPlayback={toggledContext === cornerLabel} {...others} overlay={overlay} />;
     };


### PR DESCRIPTION
The bug was introduced in #1400 when the four-up code was refactored. This would have appeared in version 3.1.0.