### PR TITLE
Bump diagram-view to v0.0.25

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@concord-consortium/diagram-view": "^0.0.24",
+        "@concord-consortium/diagram-view": "^0.0.25",
         "@concord-consortium/mobx-state-tree": "5.1.5-cc.1",
         "@concord-consortium/react-components": "^0.7.1",
         "@concord-consortium/react-modal-hook": "^3.0.0-cc.1",
@@ -1868,9 +1868,9 @@
       "license": "MIT"
     },
     "node_modules/@concord-consortium/diagram-view": {
-      "version": "0.0.24",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.24.tgz",
-      "integrity": "sha512-m84DMbyud51hpanLpaAh+VdkGUeL959Xeum3XUxMdter3unH68cd1A9Hs3+Wz9NyT24qvuFjSEvmHquC+uV4xg==",
+      "version": "0.0.25",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.25.tgz",
+      "integrity": "sha512-hXvuPb5CKZbbPL8UFuF/GrmSKHk4Ze32iPIDLL+IZxqfZyRirlKDGqaVaVAAeQu1whSpzBSVpGRt5VJJ9o4qOw==",
       "dependencies": {
         "iframe-phone": "^1.3.1",
         "mathjs": "^10.4.1",
@@ -20533,9 +20533,9 @@
       "dev": true
     },
     "@concord-consortium/diagram-view": {
-      "version": "0.0.24",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.24.tgz",
-      "integrity": "sha512-m84DMbyud51hpanLpaAh+VdkGUeL959Xeum3XUxMdter3unH68cd1A9Hs3+Wz9NyT24qvuFjSEvmHquC+uV4xg==",
+      "version": "0.0.25",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.25.tgz",
+      "integrity": "sha512-hXvuPb5CKZbbPL8UFuF/GrmSKHk4Ze32iPIDLL+IZxqfZyRirlKDGqaVaVAAeQu1whSpzBSVpGRt5VJJ9o4qOw==",
       "requires": {
         "iframe-phone": "^1.3.1",
         "mathjs": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
     "xhr-mock": "^2.5.1"
   },
   "dependencies": {
-    "@concord-consortium/diagram-view": "^0.0.24",
+    "@concord-consortium/diagram-view": "^0.0.25",
     "@concord-consortium/mobx-state-tree": "5.1.5-cc.1",
     "@concord-consortium/react-components": "^0.7.1",
     "@concord-consortium/react-modal-hook": "^3.0.0-cc.1",


### PR DESCRIPTION
Updates diagram-view to the latest version.

[Release notes for diagram-view 0.0.25](https://github.com/concord-consortium/quantity-playground/releases)