### PR TITLE
feat: Restrict to One Diagram Tile (PT-184008021)

### DIFF
--- a/src/components/toolbar-button.test.tsx
+++ b/src/components/toolbar-button.test.tsx
@@ -84,38 +84,4 @@ describe("ToolButtonComponent", () => {
     });
     expect(onDragStart).toHaveBeenCalledTimes(1);
   });
-
-  it("renders disabled diagram tool button", () => {
-    const toolButton = ToolbarButtonModel.create({
-      id: "Diagram",
-      title: "Diagram",
-      isDefault: false,
-      isTileTool: true
-    });
-
-    render(
-      <ToolbarButtonComponent
-        toolButton={toolButton}
-        isActive={false}
-        isDisabled={true}
-        onSetToolActive={onSetToolActive}
-        onClick={onClick}
-        onDragStart={onDragStart}
-        onShowDropHighlight={onShowDropHighlight}
-        onHideDropHighlight={onHideDropHighlight}
-        />
-    );
-    expect(screen.getByTestId("tool-diagram")).toBeInTheDocument();
-    act(() => {
-      userEvent.click(screen.getByTestId("tool-diagram"));
-    });
-    expect(onSetToolActive).toHaveBeenCalledTimes(0);
-    expect(onClick).toHaveBeenCalledTimes(0);
-    act(() => {
-      fireEvent.dragStart(screen.getByTestId("tool-diagram"));
-      fireEvent.dragEnd(screen.getByTestId("tool-diagram"));
-    });
-    expect(onDragStart).toHaveBeenCalledTimes(0);
-  });
-
 });

--- a/src/components/toolbar-button.test.tsx
+++ b/src/components/toolbar-button.test.tsx
@@ -85,4 +85,37 @@ describe("ToolButtonComponent", () => {
     expect(onDragStart).toHaveBeenCalledTimes(1);
   });
 
+  it("renders disabled diagram tool button", () => {
+    const toolButton = ToolbarButtonModel.create({
+      id: "Diagram",
+      title: "Diagram",
+      isDefault: false,
+      isTileTool: true
+    });
+
+    render(
+      <ToolbarButtonComponent
+        toolButton={toolButton}
+        isActive={false}
+        isDisabled={true}
+        onSetToolActive={onSetToolActive}
+        onClick={onClick}
+        onDragStart={onDragStart}
+        onShowDropHighlight={onShowDropHighlight}
+        onHideDropHighlight={onHideDropHighlight}
+        />
+    );
+    expect(screen.getByTestId("tool-diagram")).toBeInTheDocument();
+    act(() => {
+      userEvent.click(screen.getByTestId("tool-diagram"));
+    });
+    expect(onSetToolActive).toHaveBeenCalledTimes(0);
+    expect(onClick).toHaveBeenCalledTimes(0);
+    act(() => {
+      fireEvent.dragStart(screen.getByTestId("tool-diagram"));
+      fireEvent.dragEnd(screen.getByTestId("tool-diagram"));
+    });
+    expect(onDragStart).toHaveBeenCalledTimes(0);
+  });
+
 });

--- a/src/components/toolbar-button.tsx
+++ b/src/components/toolbar-button.tsx
@@ -38,6 +38,7 @@ export const ToolbarButtonComponent: React.FC<IToolbarButtonProps> =
   };
 
   const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (isTileTool && isDisabled) return;
     onClick(e, toolButton);
   };
 
@@ -53,10 +54,10 @@ export const ToolbarButtonComponent: React.FC<IToolbarButtonProps> =
         title={title}
         onMouseDown={handleMouseDown}
         onClick={handleClick}
-        onDragStart={isTileTool ? handleDrag : undefined}
-        draggable={isTileTool || false}
-        onMouseEnter={isTileTool ? onShowDropHighlight : undefined}
-        onMouseLeave={isTileTool ? onHideDropHighlight : undefined}>
+        onDragStart={isTileTool && !isDisabled ? handleDrag : undefined}
+        draggable={(isTileTool && !isDisabled) || false}
+        onMouseEnter={isTileTool && !isDisabled ? onShowDropHighlight : undefined}
+        onMouseLeave={isTileTool && !isDisabled ? onHideDropHighlight : undefined}>
       {Icon && <Icon />}
     </div>
   );

--- a/src/components/toolbar.tsx
+++ b/src/components/toolbar.tsx
@@ -72,10 +72,14 @@ export class ToolbarComponent extends BaseComponent<IProps, IState> {
     const renderToolButtons = (toolbarModel: IToolbarModel) => {
       const { ui: { selectedTileIds } } = this.stores;
       return toolbarModel.map(toolButton => {
+        const { document } = this.props;
+        const diagramTileCount = document.content?.getTilesOfType("Diagram").length || 0;
+        const isDisabled = (toolButton.id === "Diagram" && diagramTileCount > 0) ||
+                           (toolButton.id === "delete" && !selectedTileIds.length);
         const buttonProps: IToolbarButtonProps = {
           toolButton,
           isActive: toolButton === this.state.activeTool,
-          isDisabled: toolButton.id === "delete" && !selectedTileIds.length,
+          isDisabled,
           onSetToolActive: handleSetActiveTool,
           onClick: handleClickTool,
           onDragStart: handleDragTool,

--- a/src/components/toolbar.tsx
+++ b/src/components/toolbar.tsx
@@ -70,11 +70,14 @@ export class ToolbarComponent extends BaseComponent<IProps, IState> {
       this.handleDragNewTile(tool, e);
     };
     const renderToolButtons = (toolbarModel: IToolbarModel) => {
-      const { ui: { selectedTileIds } } = this.stores;
+      const { problem, ui: { selectedTileIds } } = this.stores;
+      const { document } = this.props;
       return toolbarModel.map(toolButton => {
-        const { document } = this.props;
-        const diagramTileCount = document.content?.getTilesOfType("Diagram").length || 0;
-        const isDisabled = (toolButton.id === "Diagram" && diagramTileCount > 0) ||
+        const tilesOfTypeCount = document.content?.getTilesOfType(toolButton.id).length || 0;
+        const limitedTileTypes = problem.config?.settings?.limitedTileTypes as Record<string, number>;
+        const limitTileInstances = limitedTileTypes &&
+                                   tilesOfTypeCount >= limitedTileTypes[toolButton.id];
+        const isDisabled = limitTileInstances ||
                            (toolButton.id === "delete" && !selectedTileIds.length);
         const buttonProps: IToolbarButtonProps = {
           toolButton,

--- a/src/components/toolbar.tsx
+++ b/src/components/toolbar.tsx
@@ -70,19 +70,11 @@ export class ToolbarComponent extends BaseComponent<IProps, IState> {
       this.handleDragNewTile(tool, e);
     };
     const renderToolButtons = (toolbarModel: IToolbarModel) => {
-      const { problem, ui: { selectedTileIds } } = this.stores;
-      const { document } = this.props;
       return toolbarModel.map(toolButton => {
-        const tilesOfTypeCount = document.content?.getTilesOfType(toolButton.id).length || 0;
-        const limitedTileTypes = problem.config?.settings?.limitedTileTypes as Record<string, number>;
-        const limitTileInstances = limitedTileTypes &&
-                                   tilesOfTypeCount >= limitedTileTypes[toolButton.id];
-        const isDisabled = limitTileInstances ||
-                           (toolButton.id === "delete" && !selectedTileIds.length);
         const buttonProps: IToolbarButtonProps = {
           toolButton,
           isActive: toolButton === this.state.activeTool,
-          isDisabled,
+          isDisabled: this.isButtonDisabled(toolButton),
           onSetToolActive: handleSetActiveTool,
           onClick: handleClickTool,
           onDragStart: handleDragTool,
@@ -122,6 +114,25 @@ export class ToolbarComponent extends BaseComponent<IProps, IState> {
     const { type, titleBase } = tileContentInfo;
     const getTileTitle = (tileId: string) => tileApiInterface?.getTileApi(tileId)?.getTitle?.();
     return titleBase && document.getUniqueTitle(type, titleBase, getTileTitle);
+  }
+
+  private isButtonDisabled(toolButton: IToolbarButtonModel) {
+    const { document: { content } } = this.props;
+    const { appConfig: { settings }, ui: { selectedTileIds } } = this.stores;
+
+    // If no tiles are selected, disable the delete button.
+    if (toolButton.id === "delete" && !selectedTileIds.length) return true;
+
+    if (toolButton.isTileTool && settings) {
+      // If a limit on the number of tiles of a certain type has been specified in settings,
+      // disable the related tile button when that limit is reached.
+      const tilesOfTypeCount = content?.getTilesOfType(toolButton.id).length || 0;
+      const tileSettings = settings[toolButton.id.toLowerCase()] as Record<string, any>;
+      const maxTilesOfType = tileSettings ? tileSettings.maxTiles : undefined;
+      if (maxTilesOfType && tilesOfTypeCount >= maxTilesOfType) return true;
+    }
+
+    return false;
   }
 
   private handleAddTile(tool: IToolbarButtonModel) {

--- a/src/public/curriculum/m2studio/m2studio.json
+++ b/src/public/curriculum/m2studio/m2studio.json
@@ -33,7 +33,10 @@
       "text": {
         "tools": ["bold", "italic", "list-ul", "subscript", "superscript", "m2s-variables"]
       },
-      "drawing": {"tools": ["select", "line", "vector", "rectangle", "ellipse", "stamp", "stroke-color", "fill-color", "image-upload", "new-variable", "insert-variable", "edit-variable", "delete"]}
+      "drawing": {"tools": ["select", "line", "vector", "rectangle", "ellipse", "stamp", "stroke-color", "fill-color", "image-upload", "new-variable", "insert-variable", "edit-variable", "delete"]},
+      "diagram": {
+        "maxTiles": 1
+      }
     },
     "defaultStamps": [],
     "navTabs": {
@@ -508,11 +511,6 @@
               "supports": []
             }
           ],
-          "config": {
-            "settings": {
-              "limitedTileTypes": { "Diagram": 1 }
-            }
-          },
           "supports": []
         },
         {

--- a/src/public/curriculum/m2studio/m2studio.json
+++ b/src/public/curriculum/m2studio/m2studio.json
@@ -508,6 +508,11 @@
               "supports": []
             }
           ],
+          "config": {
+            "settings": {
+              "limitedTileTypes": { "Diagram": 1 }
+            }
+          },
           "supports": []
         },
         {


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/184008021

Checks the number of existing diagram tiles and if there is already at least one, disables the diagram tile button.