### PR TITLE
176599280-shared-model-color-map

### DIFF
--- a/src/components/tiles/link-indicator.tsx
+++ b/src/components/tiles/link-indicator.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import SvgLinkedTileIcon from "../../assets/icons/linked-tile-icon";
-import { getTableLinkColors } from "../../models/tiles/table-links";
+import { getColorMapEntry } from "../../models/shared/shared-data-set-colors";
 import { IconButtonSvg } from "../utilities/icon-button-svg";
-import { getColorMapEntry } from "../../models/tiles/geometry/shared-model-color-map";
 
 // cf. https://mattferderer.com/use-sass-variables-in-typescript-and-javascript
 import styles from "./link-indicator.scss";

--- a/src/components/tiles/link-indicator.tsx
+++ b/src/components/tiles/link-indicator.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import SvgLinkedTileIcon from "../../assets/icons/linked-tile-icon";
 import { getTableLinkColors } from "../../models/tiles/table-links";
 import { IconButtonSvg } from "../utilities/icon-button-svg";
+import { getColorMapEntry } from "../../models/tiles/geometry/shared-model-color-map";
 
 // cf. https://mattferderer.com/use-sass-variables-in-typescript-and-javascript
 import styles from "./link-indicator.scss";
@@ -12,7 +13,8 @@ interface IProps {
 }
 
 export const LinkIndicatorComponent: React.FC<IProps> = ({ id, index }: IProps) => {
-  const linkColors = getTableLinkColors(id);
+  const colorMapEntry = getColorMapEntry(id);
+  const linkColors = colorMapEntry?.colorSet;
   const svgLinkIcon = linkColors &&
                         <SvgLinkedTileIcon
                           className={`button-icon link-indicator link-icon`}

--- a/src/components/tiles/table/use-geometry-linking.ts
+++ b/src/components/tiles/table/use-geometry-linking.ts
@@ -8,6 +8,7 @@ import {
 } from "../../../models/tiles/table-links";
 import { ITileModel } from "../../../models/tiles/tile-model";
 import { useLinkGeometryDialog } from "./use-link-geometry-dialog";
+import { getColorMapEntry } from "../../../models/tiles/geometry/shared-model-color-map";
 
 interface IProps {
   documentId?: string;
@@ -24,7 +25,8 @@ export const useGeometryLinking = ({
   const showLinkButton = useFeatureFlag("GeometryLinkedTables");
   const geometryTiles = useLinkableGeometryTiles({ model, onRequestTilesOfType });
   const isLinkEnabled = hasLinkableRows && (geometryTiles.length > 0);
-  const linkColors = getTableLinkColors(modelId);
+  const colorMapEntry = getColorMapEntry(modelId);
+  const linkColors = colorMapEntry?.colorSet;
 
   const [showLinkGeometryDialog] =
           useLinkGeometryDialog({ geometryTiles, model, onLinkGeometryTile, onUnlinkGeometryTile });

--- a/src/components/tiles/table/use-geometry-linking.ts
+++ b/src/components/tiles/table/use-geometry-linking.ts
@@ -1,14 +1,14 @@
 import { useCallback, useEffect } from "react";
 import { useCurrent } from "../../../hooks/use-current";
 import { useFeatureFlag } from "../../../hooks/use-stores";
+import { getColorMapEntry } from "../../../models/shared/shared-data-set-colors";
 import { kGeometryTileType } from "../../../models/tiles/geometry/geometry-types";
 import { ITileLinkMetadata } from "../../../models/tiles/table-link-types";
 import {
-  addTableToDocumentMap, getLinkedTableIndex, getTableLinkColors, removeTableFromDocumentMap
+  addTableToDocumentMap, getLinkedTableIndex, removeTableFromDocumentMap
 } from "../../../models/tiles/table-links";
 import { ITileModel } from "../../../models/tiles/tile-model";
 import { useLinkGeometryDialog } from "./use-link-geometry-dialog";
-import { getColorMapEntry } from "../../../models/tiles/geometry/shared-model-color-map";
 
 interface IProps {
   documentId?: string;

--- a/src/models/shared/shared-data-set-colors.ts
+++ b/src/models/shared/shared-data-set-colors.ts
@@ -1,6 +1,5 @@
-import { SharedModelType } from "../../shared/shared-model";
-import { DocumentContentModelType } from "../../document/document-content";
-import styles from "../table-links.scss";
+import { SharedDataSetType } from "./shared-data-set";
+import styles from "../tiles/table-links.scss";
 
 interface ColorSet {
   fill: string,
@@ -9,21 +8,12 @@ interface ColorSet {
   selectedStroke: string
 }
 
-interface colorMapping {
+interface ColorMapEntry {
   tableId?: string,
   sharedModelId: string,
   colorSet: ColorSet
   indexOfType: number
 }
-
-export interface SharedModelWithProvider extends SharedModelType {
-  providerId: string
-}
-
-const fallBackColorSet = {
-  fill: styles.linkColor0Light, stroke: styles.linkColor0Dark,
-  selectedFill: styles.linkColor0Dark, selectedStroke: styles.linkColor0Dark
-};
 
 // TODO - did original behavior specify a hover state color?
 const colorSets = [
@@ -53,23 +43,23 @@ const colorSets = [
   }
 ];
 
-export const colorMap = new Map<string, colorMapping>;
+const colorMap = new Map<string, ColorMapEntry>;
 
-export function setColorMapEntry(anyId: string, mappingObj: colorMapping){
-  return colorMap.set(anyId, mappingObj) || fallBackColorSet;
+function setColorMapEntry(anyId: string, mappingObj: ColorMapEntry) {
+  colorMap.set(anyId, mappingObj);
 }
 
-export function getColorMapEntry(anyId: string){
+export function getColorMapEntry(anyId: string) {
   return colorMap.get(anyId);
 }
 
-export function maintainSharedModelsColorMap(sharedModels: SharedModelWithProvider[]){
-  sharedModels.forEach((m:any) => {
+export function updateSharedDataSetColors(sharedModels: SharedDataSetType[]) {
+  sharedModels.forEach(m => {
     setColorMapEntryPair(m);
   });
 }
 
-export function setColorMapEntryPair(sharedModel: SharedModelWithProvider) {
+function setColorMapEntryPair(sharedModel: SharedDataSetType) {
   const mappingObj = {
     tableId: sharedModel.providerId,
     sharedModelId: sharedModel.id,
@@ -78,26 +68,6 @@ export function setColorMapEntryPair(sharedModel: SharedModelWithProvider) {
   };
   // set entries with duplicate values - one with tableId as key, one with sharedModel as key
   // This is in anticipation of future access from non-table originated models
-  setColorMapEntry(sharedModel.providerId, mappingObj);
+  sharedModel.providerId && setColorMapEntry(sharedModel.providerId, mappingObj);
   setColorMapEntry(sharedModel.id, mappingObj);
-}
-
-export function assignIndexOfType(sharedModel: SharedModelWithProvider, document: DocumentContentModelType) {
-  if (sharedModel.indexOfType < 0) {
-    const usedIndices = new Set<number>();
-    const sharedModels = document.getSharedModelsByType(sharedModel.type);
-    sharedModels?.forEach(model => {
-      if (model.indexOfType >= 0) {
-        usedIndices.add(model.indexOfType);
-      }
-    });
-
-    for (let i = 1; sharedModel.indexOfType < 0; ++i) {
-      if (!usedIndices.has(i)) {
-        // reassignment of existing indexOfType
-        sharedModel.setIndexOfType(i);
-        break;
-      }
-    }
-  }
 }

--- a/src/models/tiles/geometry/geometry-content.ts
+++ b/src/models/tiles/geometry/geometry-content.ts
@@ -39,7 +39,6 @@ import { uniqueId } from "../../../utilities/js-utils";
 import { logTileChangeEvent } from "../log/log-tile-change-event";
 import { LogEventName } from "../../../lib/logger-types";
 import { gImageMap } from "../../image-map";
-import { maintainSharedModelsColorMap, getColorMapEntry } from "./shared-model-color-map";
 
 export type onCreateCallback = (elt: JXG.GeometryElement) => void;
 
@@ -125,16 +124,10 @@ export type GeometryMetadataModelType = Instance<typeof GeometryMetadataModel>;
 export function setElementColor(board: JXG.Board, id: string, selected: boolean) {
   const element = getObjectById(board, id);
   if (element) {
-    const { linkedtableid } = element.visProp;
-    const foundColorSet = getColorMapEntry(linkedtableid)?.colorSet;
-    const fillColor = foundColorSet?.fill || kPointDefaults.fillColor;
-    const strokeColor = foundColorSet?.stroke || kPointDefaults.strokeColor;
-    const selectedFillColor = foundColorSet?.selectedFill || kPointDefaults.selectedFillColor;
-    const selectedStrokeColor = foundColorSet?.selectedStroke || kPointDefaults.selectedStrokeColor;
-
-    // Previously, we looked for "clientFillColor", e.g.
-    // const fillColor = element.getAttribute("clientFillColor") || kPointDefaults.fillColor;
-    // TODO - remove other implementations of that if possible?
+    const fillColor = element.getAttribute("clientFillColor") || kPointDefaults.fillColor;
+    const strokeColor = element.getAttribute("clientStrokeColor") || kPointDefaults.strokeColor;
+    const selectedFillColor = element.getAttribute("clientSelectedFillColor") || kPointDefaults.selectedFillColor;
+    const selectedStrokeColor = element.getAttribute("clientSelectedStrokeColor") || kPointDefaults.selectedStrokeColor;
     const clientCssClass = selected
                             ? element.getAttribute("clientSelectedCssClass")
                             : element.getAttribute("clientCssClass");
@@ -176,7 +169,6 @@ export const GeometryContentModel = GeometryBaseContentModel
       const foundSharedModels = sharedModelManager?.isReady
         ? sharedModelManager.getTileSharedModels(self) as SharedDataSetType[]
         : [];
-      maintainSharedModelsColorMap(foundSharedModels); // TODO - side effect, consider moving to sharedModelManager?
       return foundSharedModels;
     }
   }))

--- a/src/models/tiles/geometry/jxg-point.ts
+++ b/src/models/tiles/geometry/jxg-point.ts
@@ -3,6 +3,7 @@ import { uniqueId } from "../../../utilities/js-utils";
 import { JXGChangeAgent, JXGCoordPair, JXGUnsafeCoordPair } from "./jxg-changes";
 import { objectChangeAgent, isPositionGraphable, getGraphablePosition } from "./jxg-object";
 import { prepareToDeleteObjects } from "./jxg-polygon";
+import { getColorMapEntry } from "./shared-model-color-map";
 
 // For snap to grid
 const kPrevSnapUnit = 0.2;
@@ -21,13 +22,23 @@ const defaultProps = {
       };
 
 // fillColor/strokeColor are ephemeral properties that change with selection;
-// we store the desired colors in clientFillColor/clientStrokeColor for persistence.
+// we stored the desired colors in clientFillColor/clientStrokeColor for persistence
+// now they are replaced by colors from shared-table-colors map
+// TODO: find where client colors can be removed
 export function syncClientColors(props: any) {
+  const colorMapEntry = getColorMapEntry(props.linkedTableId);
   const { selectedFillColor, selectedStrokeColor, ...p } = props || {} as any;
-  if (p.fillColor) p.clientFillColor = p.fillColor;
-  if (p.strokeColor) p.clientStrokeColor = p.strokeColor;
-  if (selectedFillColor) p.clientSelectedFillColor = selectedFillColor;
-  if (selectedStrokeColor) p.clientSelectedStrokeColor = selectedStrokeColor;
+  p.fillColor = colorMapEntry?.colorSet.fill;
+  p.strokeColor = colorMapEntry?.colorSet.stroke;
+  p.clientFillColor = colorMapEntry?.colorSet.fill;
+  p.clientStrokeColor = colorMapEntry?.colorSet.stroke;
+
+  // if(selectedFillColor) p.clientSelectedFillColor = selectedFill
+  // if(selectedStrokeColor) p.clientSelectedStrokeColor = selectedStroke
+  // if (p.fillColor) p.clientFillColor = p.fillColor;
+  // if (p.strokeColor) p.clientStrokeColor = p.strokeColor;
+  // if (selectedFillColor) p.clientSelectedFillColor = selectedFillColor;
+  // if (selectedStrokeColor) p.clientSelectedStrokeColor = selectedStrokeColor;
   return p;
 }
 

--- a/src/models/tiles/geometry/jxg-point.ts
+++ b/src/models/tiles/geometry/jxg-point.ts
@@ -1,9 +1,9 @@
 import { castArray } from "lodash";
+import { getColorMapEntry } from "../../shared/shared-data-set-colors";
 import { uniqueId } from "../../../utilities/js-utils";
 import { JXGChangeAgent, JXGCoordPair, JXGUnsafeCoordPair } from "./jxg-changes";
 import { objectChangeAgent, isPositionGraphable, getGraphablePosition } from "./jxg-object";
 import { prepareToDeleteObjects } from "./jxg-polygon";
-import { getColorMapEntry } from "./shared-model-color-map";
 
 // For snap to grid
 const kPrevSnapUnit = 0.2;
@@ -22,23 +22,25 @@ const defaultProps = {
       };
 
 // fillColor/strokeColor are ephemeral properties that change with selection;
-// we stored the desired colors in clientFillColor/clientStrokeColor for persistence
-// now they are replaced by colors from shared-table-colors map
-// TODO: find where client colors can be removed
+// we store the desired colors in clientFillColor/clientStrokeColor for persistence
+// colors for linked points are derived from the link color map
 export function syncClientColors(props: any) {
-  const colorMapEntry = getColorMapEntry(props.linkedTableId);
   const { selectedFillColor, selectedStrokeColor, ...p } = props || {} as any;
-  p.fillColor = colorMapEntry?.colorSet.fill;
-  p.strokeColor = colorMapEntry?.colorSet.stroke;
-  p.clientFillColor = colorMapEntry?.colorSet.fill;
-  p.clientStrokeColor = colorMapEntry?.colorSet.stroke;
+  const colorMapEntry = getColorMapEntry(p.linkedTableId);
 
-  // if(selectedFillColor) p.clientSelectedFillColor = selectedFill
-  // if(selectedStrokeColor) p.clientSelectedStrokeColor = selectedStroke
-  // if (p.fillColor) p.clientFillColor = p.fillColor;
-  // if (p.strokeColor) p.clientStrokeColor = p.strokeColor;
-  // if (selectedFillColor) p.clientSelectedFillColor = selectedFillColor;
-  // if (selectedStrokeColor) p.clientSelectedStrokeColor = selectedStrokeColor;
+  if (colorMapEntry) {
+    const { colorSet: { fill, stroke, selectedFill, selectedStroke } } = colorMapEntry;
+    p.fillColor = p.clientFillColor = fill;
+    p.strokeColor = p.clientStrokeColor = stroke;
+    p.clientSelectedFillColor = selectedFill;
+    p.clientSelectedStrokeColor = selectedStroke;
+  }
+  else {
+    if (p.fillColor) p.clientFillColor = p.fillColor;
+    if (p.strokeColor) p.clientStrokeColor = p.strokeColor;
+    if (selectedFillColor) p.clientSelectedFillColor = selectedFillColor;
+    if (selectedStrokeColor) p.clientSelectedStrokeColor = selectedStrokeColor;
+  }
   return p;
 }
 

--- a/src/models/tiles/geometry/shared-model-color-map.ts
+++ b/src/models/tiles/geometry/shared-model-color-map.ts
@@ -1,0 +1,103 @@
+import { SharedModelType } from "../../shared/shared-model";
+import { DocumentContentModelType } from "../../document/document-content";
+import styles from "../table-links.scss";
+
+interface ColorSet {
+  fill: string,
+  stroke: string,
+  selectedFill: string,
+  selectedStroke: string
+}
+
+interface colorMapping {
+  tableId?: string,
+  sharedModelId: string,
+  colorSet: ColorSet
+  indexOfType: number
+}
+
+export interface SharedModelWithProvider extends SharedModelType {
+  providerId: string
+}
+
+const fallBackColorSet = {
+  fill: styles.linkColor0Light, stroke: styles.linkColor0Dark,
+  selectedFill: styles.linkColor0Dark, selectedStroke: styles.linkColor0Dark
+};
+
+// TODO - did original behavior specify a hover state color?
+const colorSets = [
+  {
+    fill: styles.linkColor0Light, stroke: styles.linkColor0Dark,
+    selectedFill: styles.linkColor0Dark, selectedStroke: styles.linkColor0Dark
+  },
+  {
+    fill: styles.linkColor1Light, stroke: styles.linkColor1Dark,
+    selectedFill: styles.linkColor1Dark, selectedStroke: styles.linkColor1Dark
+  },
+  {
+    fill: styles.linkColor2Light, stroke: styles.linkColor2Dark,
+    selectedFill: styles.linkColor2Dark, selectedStroke: styles.linkColor2Dark
+  },
+  {
+    fill: styles.linkColor3Light, stroke: styles.linkColor3Dark,
+    selectedFill: styles.linkColor3Dark, selectedStroke: styles.linkColor3Dark
+  },
+  {
+    fill: styles.linkColor4Light, stroke: styles.linkColor4Dark,
+    selectedFill: styles.linkColor4Dark, selectedStroke: styles.linkColor4Dark
+  },
+  {
+    fill: styles.linkColor5Light, stroke: styles.linkColor5Dark,
+    selectedFill: styles.linkColor5Dark, selectedStroke: styles.linkColor5Dark
+  }
+];
+
+export const colorMap = new Map<string, colorMapping>;
+
+export function setColorMapEntry(anyId: string, mappingObj: colorMapping){
+  return colorMap.set(anyId, mappingObj) || fallBackColorSet;
+}
+
+export function getColorMapEntry(anyId: string){
+  return colorMap.get(anyId);
+}
+
+export function maintainSharedModelsColorMap(sharedModels: SharedModelWithProvider[]){
+  sharedModels.forEach((m:any) => {
+    setColorMapEntryPair(m);
+  });
+}
+
+export function setColorMapEntryPair(sharedModel: SharedModelWithProvider) {
+  const mappingObj = {
+    tableId: sharedModel.providerId,
+    sharedModelId: sharedModel.id,
+    indexOfType: sharedModel.indexOfType,
+    colorSet: colorSets[sharedModel.indexOfType]
+  };
+  // set entries with duplicate values - one with tableId as key, one with sharedModel as key
+  // This is in anticipation of future access from non-table originated models
+  setColorMapEntry(sharedModel.providerId, mappingObj);
+  setColorMapEntry(sharedModel.id, mappingObj);
+}
+
+export function assignIndexOfType(sharedModel: SharedModelWithProvider, document: DocumentContentModelType) {
+  if (sharedModel.indexOfType < 0) {
+    const usedIndices = new Set<number>();
+    const sharedModels = document.getSharedModelsByType(sharedModel.type);
+    sharedModels?.forEach(model => {
+      if (model.indexOfType >= 0) {
+        usedIndices.add(model.indexOfType);
+      }
+    });
+
+    for (let i = 1; sharedModel.indexOfType < 0; ++i) {
+      if (!usedIndices.has(i)) {
+        // reassignment of existing indexOfType
+        sharedModel.setIndexOfType(i);
+        break;
+      }
+    }
+  }
+}

--- a/src/models/tiles/table/table-content.ts
+++ b/src/models/tiles/table/table-content.ts
@@ -11,7 +11,8 @@ import { TileMetadataModel } from "../tile-metadata";
 import { tileModelHooks } from "../tile-model-hooks";
 import { TileContentModel } from "../tile-content";
 import { addCanonicalCasesToDataSet, IDataSet, ICaseCreation, ICase, DataSet } from "../../data/data-set";
-import { SharedDataSet, SharedDataSetType } from "../../shared/shared-data-set";
+import { kSharedDataSetType, SharedDataSet, SharedDataSetType } from "../../shared/shared-data-set";
+import { updateSharedDataSetColors } from "../../shared/shared-data-set-colors";
 import { SharedModelType } from "../../shared/shared-model";
 import { kMinColumnWidth } from "../../../components/tiles/table/table-types";
 import { canonicalizeExpression, kSerializedXKey } from "../../data/expression-utils";
@@ -299,6 +300,10 @@ export const TableContentModel = TileContentModel
           // Add the shared model to both the document and the tile
           sharedModelManager.addTileSharedModel(self, sharedDataSet);
         }
+
+        // update the colors
+        const dataSets = sharedModelManager.getSharedModelsByType(kSharedDataSetType) as SharedDataSetType[];
+        updateSharedDataSetColors(dataSets);
       },
       {name: "sharedModelSetup", fireImmediately: true}));
     },

--- a/src/plugins/data-card/data-card-content.ts
+++ b/src/plugins/data-card/data-card-content.ts
@@ -10,7 +10,8 @@ import { TileContentModel } from "../../models/tiles/tile-content";
 import {
   addAttributeToDataSet, addCanonicalCasesToDataSet, addCasesToDataSet, DataSet
 } from "../../models/data/data-set";
-import { SharedDataSet, SharedDataSetType } from "../../models/shared/shared-data-set";
+import { kSharedDataSetType, SharedDataSet, SharedDataSetType } from "../../models/shared/shared-data-set";
+import { updateSharedDataSetColors } from "../../models/shared/shared-data-set-colors";
 import { SharedModelType } from "../../models/shared/shared-model";
 import { uniqueId, uniqueTitle } from "../../utilities/js-utils";
 
@@ -169,6 +170,10 @@ export const DataCardContentModel = TileContentModel
           // Add the shared model to both the document and the tile
           sharedModelManager.addTileSharedModel(self, sharedDataSet);
         }
+
+        // update the colors
+        const dataSets = sharedModelManager.getSharedModelsByType(kSharedDataSetType) as SharedDataSetType[];
+        updateSharedDataSetColors(dataSets);
       },
       {name: "sharedModelSetup", fireImmediately: true}));
     },


### PR DESCRIPTION
This restores some of the functionality of colored points representing cases in a table shared to a Geometry tile.  Now, points belonging to tables are colored according to an index stored as a volatile property on the shared model.  Row highlights on the corresponding table point also highlight. 
(stories #184187751 and #184187751)

**Changes**
- `shared-model-color-map.ts` instantiates a global map that stores entries that pair a given table id or shared model id with a `colorSet` - specifying how to color points and link symbols when they appear in the context of a Geometry tile. 
- This global map is accessed by `jxg-point` and the geometry model to set and maintain colors on load and through interactions

**Items still open + notes**
- Since this is only used in the context of the Geometry Tile now, it is built within that context, but could be made more general in the future
- `providerId` is not a property in the current shared model, as it appears that shared models may not always have that, and some functions are passed an `isProvider` flag
- Since this implementation requires that SharedModels have the id of an existing table as their `providerId`, I extended the `SharedModelType` and created an interface that includes the `providerId` called `SharedModelWithProvider`
- My guess is this is not the optimum way to do this, but thought it would work for the purposes of restoring the functionality in a type-protected way
- I left in some commented-out lines that stored `client-*` values for various colors.   I was not sure where else this notion is implemented, and didn't want to lose evidence of it in the places that might matter or need to be referenced in the future. 
- Right now, the Geometry model calls the maintainer function as a "side effect" of a view.  This might be a better fit in the shared model document manager. 