### PR TITLE
183053771 shared data polygon

### DIFF
--- a/src/components/tiles/geometry/geometry-content.tsx
+++ b/src/components/tiles/geometry/geometry-content.tsx
@@ -622,7 +622,7 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
       }
       const pts = applyChange(board, { operation: "create", target: "linkedPoint", parents, properties, links });
       castArray(pts || []).forEach(pt => !isBoard(pt) && this.handleCreateElements(pt));
-      this.syncLinkedPolygons(board) // call from here, or go up a level and call from a few locations?
+      this.syncLinkedPolygons(board); // call from here, or go up a level and call from a few locations?
     });
   }
 
@@ -631,34 +631,26 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
     const allObjectsArr = Array.from(objectsMap, ([key, value]) => ({key,value}));
 
     // If object is a polygon, extract its id and dependent point ids
-    const polygonIdSets: any[] = []
+    const changes: JXGChange[] = [];
     allObjectsArr.forEach((o) => {
       if (o.value.type === "polygon"){
         const ids: string[] = [];
-        const idSet = {
-          polygonId: o.value.id,
-          pointIds: ids
-        };
+        const idSet = { polygonId: o.value.id, pointIds: ids };
         (o.value as any).points.forEach((k:string) => {
           const pointId = k;
           idSet.pointIds.push(pointId);
-        })
-        polygonIdSets.push(idSet);
+        });
+        // convert idSet to a change
+        const polygonChangeObject: JXGChange = {
+          operation: "create",
+          target: "polygon",
+          targetID: idSet.polygonId,
+          parents: idSet.pointIds,
+          properties: { id: idSet.polygonId }
+        };
+        changes.push(polygonChangeObject);
       }
-    })
-
-    // convert idSets to changes
-    const changes: JXGChange[] = []
-    polygonIdSets.forEach((idSet:any) => {
-      const polygonChangeObject: JXGChange = {
-        operation: "create",
-        target: "polygon",
-        targetID: idSet.polygonId,
-        parents: idSet.pointIds,
-        properties: { id: idSet.polygonId }
-      };
-      changes.push(polygonChangeObject);
-    })
+    });
     applyChanges(board, changes);
   }
 

--- a/src/components/tiles/geometry/geometry-content.tsx
+++ b/src/components/tiles/geometry/geometry-content.tsx
@@ -51,6 +51,7 @@ import placeholderImage from "../../../assets/image_placeholder.png";
 import { LinkTableButton } from "./link-table-button";
 import ErrorAlert from "../../utilities/error-alert";
 import SingleStringDialog from "../../utilities/single-string-dialog";
+import { getBoardModelDiff, getBoardObjectIds, updateBoardPoints, updateBoardPolygons } from "./update-with-shared-data";
 
 import "./geometry-tile.sass";
 
@@ -277,7 +278,7 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
     // respond to linked table/shared model changes
     this.disposers.push(reaction(
       () => this.getContent().updateSharedModels,
-      () => this.syncLinkedPoints()
+      () => this.contentSyncLinkedPoints()
     ));
 
     this.disposers.push(onSnapshot(this.getContent(), () => {
@@ -505,6 +506,7 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
   }
 
   private async initializeBoard(): Promise<JXG.Board> {
+    console.log("all1: initialize board!")
     return new Promise((resolve, reject) => {
       isGeometryContentReady(this.getContent()).then(() => {
         const board = this.getContent().initializeBoard(this.elementId, this.handleCreateElements);
@@ -514,7 +516,7 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
           if (url) {
             this.updateImageUrl(url, filename);
           }
-          this.syncLinkedPoints(board);
+          this.contentSyncLinkedPoints(board);
           this.setState({ board });
           resolve(board);
         }
@@ -523,11 +525,13 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
   }
 
   private destroyBoard() {
+    console.log("all1: destroy board!")
     const { board } = this.state;
     board && JXG.JSXGraph.freeBoard(board);
   }
 
   private async initializeContent() {
+    console.log("all1: initialize content!")
     const content = this.getContent();
     content.metadata.setSharedSelection(this.stores.selection);
     const domElt = document.getElementById(this.elementId);
@@ -556,6 +560,7 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
   }
 
   private rescaleBoardAndAxes(params: IAxesParams) {
+    console.log("all1: rescaleBoardAndAxes!")
     const { board } = this.state;
     if (board) {
       this.applyChange(() => {
@@ -590,7 +595,8 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
     }
   }
 
-  syncLinkedPoints(_board?: JXG.Board) {
+  // defines-sync-linked-points
+  contentSyncLinkedPoints(_board?: JXG.Board) {
     const board = _board || this.state.board;
     if (!board) return;
 
@@ -600,6 +606,15 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
     // unchanged points are re-created and would allow derived polygons to be preserved.
     // for now, derived polygons persist in model, and are now sent to JXG as changes
     // on each load/creation so that they render
+
+    // REALIZED
+    // GOING TO PACKAGE ALL THIS IN A FUNCTION THAT IS CALLED INSTEAD OF zyncLInkedPoints
+    // it would be called from same spot, but called syncGeometryWithSharedData - which will have sub functions
+    // it will combine all the stuff
+    // I will write it in another file
+    // I looked through all this and nothing else (except few "linked" moments, are about shared)
+    // it will need applyChanges, access to model.getContent() and board
+    // search "const content" and u will find examples of bringing model in
 
     // like this , this only has a value to delete at the moment a share happens. Even with the applyChange(delete change) below commented out.
     const ids = getAllLinkedPoints(board);

--- a/src/components/tiles/geometry/geometry-content.tsx
+++ b/src/components/tiles/geometry/geometry-content.tsx
@@ -642,7 +642,7 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
         });
         // convert idSet to a change
         const polygonChangeObject: JXGChange = {
-          operation: "create",
+          operation: "create", // not "update" at the moment. This does not create a duplicate
           target: "polygon",
           targetID: idSet.polygonId,
           parents: idSet.pointIds,
@@ -653,7 +653,6 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
     });
     applyChanges(board, changes);
   }
-
 
   private handleArrowKeys = (e: React.KeyboardEvent, keys: string) => {
     const { board } = this.state;

--- a/src/components/tiles/geometry/geometry-content.tsx
+++ b/src/components/tiles/geometry/geometry-content.tsx
@@ -20,7 +20,9 @@ import { copyCoords, getEventCoords, getAllObjectsUnderMouse, getClickableObject
           isDragTargetOrAncestor } from "../../../models/tiles/geometry/geometry-utils";
 import { RotatePolygonIcon } from "./rotate-polygon-icon";
 import { getPointsByCaseId } from "../../../models/tiles/geometry/jxg-board";
-import { ESegmentLabelOption, ILinkProperties, JXGCoordPair, JXGChange, JXGObjectType } from "../../../models/tiles/geometry/jxg-changes";
+import {
+  ESegmentLabelOption, ILinkProperties, JXGCoordPair, JXGChange
+} from "../../../models/tiles/geometry/jxg-changes";
 import { applyChange, applyChanges } from "../../../models/tiles/geometry/jxg-dispatcher";
 import { kSnapUnit } from "../../../models/tiles/geometry/jxg-point";
 import {
@@ -34,7 +36,7 @@ import {
 import {
   getVertexAngle, updateVertexAngle, updateVertexAnglesFromObjects
 } from "../../../models/tiles/geometry/jxg-vertex-angle";
-import { getAllLinkedPoints, injectGetTableLinkColorsFunction } from "../../../models/tiles/geometry/jxg-table-link";
+import { injectGetTableLinkColorsFunction } from "../../../models/tiles/geometry/jxg-table-link";
 import { extractDragTileType, kDragTileContent, kDragTileId, dragTileSrcDocId } from "../tile-component";
 import { ImageMapEntryType, gImageMap } from "../../../models/image-map";
 import { linkedPointId } from "../../../models/tiles/table-link-types";
@@ -506,7 +508,6 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
   }
 
   private async initializeBoard(): Promise<JXG.Board> {
-    console.log("all1: initialize board!")
     return new Promise((resolve, reject) => {
       isGeometryContentReady(this.getContent()).then(() => {
         const board = this.getContent().initializeBoard(this.elementId, this.handleCreateElements);
@@ -525,13 +526,11 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
   }
 
   private destroyBoard() {
-    console.log("all1: destroy board!")
     const { board } = this.state;
     board && JXG.JSXGraph.freeBoard(board);
   }
 
   private async initializeContent() {
-    console.log("all1: initialize content!")
     const content = this.getContent();
     content.metadata.setSharedSelection(this.stores.selection);
     const domElt = document.getElementById(this.elementId);
@@ -560,7 +559,6 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
   }
 
   private rescaleBoardAndAxes(params: IAxesParams) {
-    console.log("all1: rescaleBoardAndAxes!")
     const { board } = this.state;
     if (board) {
       this.applyChange(() => {
@@ -597,23 +595,23 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
 
   modelJXGCleanCheck(board: JXG.Board){
     // find any points or polygons in model but not in JXG and/or any redundancies
-    let missingFromJXG: Array<any> = [];
+    const missingFromJXG: Array<any> = [];
     let hasRedundancies = false;
 
-    let jxgSummary: Array<any> = [];
-    const matchAll = (obj: JXG.GeometryElement) => obj.elType !== undefined
-    const allJXGObjects = this.getContent().findObjects(board, matchAll)
+    const jxgSummary: Array<any> = [];
+    const matchAll = (obj: JXG.GeometryElement) => obj.elType !== undefined;
+    const allJXGObjects = this.getContent().findObjects(board, matchAll);
     allJXGObjects.forEach((o) => {
-      jxgSummary.push({ id: o.id, type: o.elType })
-    })
+      jxgSummary.push({ id: o.id, type: o.elType });
+    });
 
-    hasRedundancies = uniq(jxgSummary) as any === jxgSummary.length
+    hasRedundancies = uniq(jxgSummary) as any === jxgSummary.length;
 
-    let modelSummary: Array<object> = [];
-    for (let [key, value] of this.getContent().objects){
-      const mo = this.getContent().getObject(key)
+    const modelSummary: Array<object> = [];
+    for (const [key, value] of this.getContent().objects){
+      const mo = this.getContent().getObject(key);
       if (mo){
-        modelSummary.push({id: key, type: mo.type})
+        modelSummary.push({id: key, type: mo.type});
       }
     }
 
@@ -622,22 +620,14 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
       if (!foundMatchingJXG){
         missingFromJXG.push(modelSummaryItem);
       }
-    })
-    console.log("found object(s) missing from jxg? : ", missingFromJXG)
-
-    //return !hasRedundancies && missingFromJXG.length === 0;
-    return { hasRedundancies, missingList: missingFromJXG, missingCount: missingFromJXG.length }
+    });
+    return { hasRedundancies, missingList: missingFromJXG, missingCount: missingFromJXG.length };
   }
 
 
   contentSyncGeometry(_board?: JXG.Board) {
     const board = _board || this.state.board;
     if (!board) return;
-
-
-    const report1 = this.modelJXGCleanCheck(board)
-    const missingAtStart = report1.missingList;
-    console.log("missingAtStart: ", missingAtStart)
 
     // Find points through linked data and create them
     // Checks for missing are accurate, but running this on condition of missing polygons
@@ -658,7 +648,7 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
           }
         }
       }
-      const ptsChange = { operation: "create", target: "linkedPoint", parents, properties, links }
+      const ptsChange = { operation: "create", target: "linkedPoint", parents, properties, links };
       const pts = applyChange(board, ptsChange as JXGChange);
       castArray(pts || []).forEach(pt => !isBoard(pt) && this.handleCreateElements(pt));
     });
@@ -689,16 +679,17 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
     applyChanges(board, changes);
 
     // account for all points, shared and native, and rescale accordingly
-    const boardMap = getBoardObjectsMap(board)
-    const extents = getBoardDataExtents(boardMap)
+    const boardMap = getBoardObjectsMap(board);
+    const extents = getBoardDataExtents(boardMap);
     this.rescaleBoardAndAxes(extents);
 
 
-    const report2 = this.modelJXGCleanCheck(board)
+    const report2 = this.modelJXGCleanCheck(board);
     const missingAtEnd = report2.missingList;
     const anyRedundancies = report2.hasRedundancies;
-    console.log("missingAtEnd: ", missingAtEnd, "anyRedundancies: ", anyRedundancies)
-
+    if (missingAtEnd.length > 0 || anyRedundancies){
+      console.warn(report2);
+    }
   }
 
 

--- a/src/components/tiles/geometry/geometry-content.tsx
+++ b/src/components/tiles/geometry/geometry-content.tsx
@@ -600,7 +600,10 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
     // unchanged points are re-created and would allow derived polygons to be preserved.
     // for now, derived polygons persist in model, and are now sent to JXG as changes
     // on each load/creation so that they render
+
+    // like this , this only has a value to delete at the moment a share happens. Even with the applyChange(delete change) below commented out.
     const ids = getAllLinkedPoints(board);
+    console.log("theIds here: ", ids)
     applyChange(board, { operation: "delete", target: "linkedPoint", targetID: ids });
 
     // set up to track found minimums and maximums among all shared points
@@ -640,11 +643,7 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
 
   syncLinkedPolygons(board: JXG.Board){
     const justThePoints = board.objectsList.filter((o) => o.elType === "point")
-    console.log("NOICE found ", justThePoints.length, " points")
-
     const sharedPointIds = getAllLinkedPoints(board)
-    console.log("NOICE found ", sharedPointIds.length, " shared points")
-
     const objectsMap = this.getContent().objects;
     const allObjectsArr = Array.from(objectsMap, ([key, value]) => ({key,value}));
 

--- a/src/components/tiles/geometry/update-with-shared-data.ts
+++ b/src/components/tiles/geometry/update-with-shared-data.ts
@@ -1,0 +1,120 @@
+import { GeometryContentSnapshotType } from "../../../models/tiles/geometry/geometry-content";
+import { applyChange, applyChanges } from "../../../models/tiles/geometry/jxg-dispatcher";
+import { getAllLinkedPoints, injectGetTableLinkColorsFunction } from "../../../models/tiles/geometry/jxg-table-link";
+
+/**
+ * Get an object of points and polygons by source
+ */
+
+export function getBoardModelDiff(board: JXG.Board, modelData: any){
+  console.log("all1: getBoardModelDiff")
+}
+
+export function getBoardObjectIds(board: JXG.Board){
+  console.log("all1: getBoardObjectIds")
+}
+
+export function updateBoardPoints(board: JXG.Board, modelData: any /*GeometryContentSnapshotType */){
+  console.log("all1: updateBoardPoints")
+}
+
+export function updateBoardPolygons(board: JXG.Board, modelData: any /*GeometryContentSnapshotType */){
+  console.log("all1: updateBoardPolygons")
+}
+
+
+
+
+/*
+
+zyncLinkedPoints(_board?: JXG.Board) {
+  const board = _board || this.state.board;
+  if (!board) return;
+
+  // remove/recreate all linked points
+  // TODO: A more tailored response would match up the existing points with the data set and only
+  // change the affected points, which would eliminate some visual flashing that occurs when
+  // unchanged points are re-created and would allow derived polygons to be preserved.
+  // for now, derived polygons persist in model, and are now sent to JXG as changes
+  // on each load/creation so that they render
+
+  // REALIZED
+  // GOING TO PACKAGE ALL THIS IN A FUNCTION THAT IS CALLED INSTEAD OF zyncLInkedPoints
+  // it would be called from same spot, but called syncGeometryWithSharedData - which will have sub functions
+  // it will combine all the stuff
+  // I will write it in another file
+  // I looked through all this and nothing else (except few "linked" moments, are about shared)
+  // it will need applyChanges, access to model.getContent() and board
+  // search "const content" and u will find examples of bringing model in
+
+  // like this , this only has a value to delete at the moment a share happens. Even with the applyChange(delete change) below commented out.
+  const ids = getAllLinkedPoints(board);
+  console.log("theIds here: ", ids)
+  applyChange(board, { operation: "delete", target: "linkedPoint", targetID: ids });
+
+  // set up to track found minimums and maximums among all shared points
+  let xMin = -1
+  let xMax = 1
+  let yMin = -1
+  let yMax = 1
+
+  // create new points for each linked table
+  this.getContent().linkedDataSets.forEach(link => {
+    const links: ILinkProperties = { tileIds: [link.providerId] };
+    const parents: JXGCoordPair[] = [];
+    const properties: Array<{ id: string }> = [];
+    for (let ci = 0; ci < link.dataSet.cases.length; ++ci) {
+      const x = link.dataSet.attributes[0]?.numericValue(ci);
+      for (let ai = 1; ai < link.dataSet.attributes.length; ++ai) {
+        const attr = link.dataSet.attributes[ai];
+        const id = linkedPointId(link.dataSet.cases[ci].__id__, attr.id);
+        const y = attr.numericValue(ci);
+        if (isFinite(x) && isFinite(y)) {
+          if ( x < xMin ) xMin = x - 1
+          if ( x > xMax ) xMax = x + 1
+          if ( x < yMin ) yMin = y - 1
+          if ( x > yMax ) yMax = y + 1
+          parents.push([x, y]);
+          properties.push({ id });
+        }
+      }
+    }
+    const pts = applyChange(board, { operation: "create", target: "linkedPoint", parents, properties, links });
+    castArray(pts || []).forEach(pt => !isBoard(pt) && this.handleCreateElements(pt));
+  });
+
+  this.rescaleBoardAndAxes({ xMax, yMax, xMin, yMin });
+  this.syncLinkedPolygons(board);
+}
+
+syncLinkedPolygons(board: JXG.Board){
+  const justThePoints = board.objectsList.filter((o) => o.elType === "point")
+  const sharedPointIds = getAllLinkedPoints(board)
+  const objectsMap = this.getContent().objects;
+  const allObjectsArr = Array.from(objectsMap, ([key, value]) => ({key,value}));
+
+  // If object is a polygon, extract its id and dependent point ids
+  const changes: JXGChange[] = [];
+  allObjectsArr.forEach((o) => {
+    if (o.value.type === "polygon"){
+      const ids: string[] = [];
+      const idSet = { polygonId: o.value.id, pointIds: ids };
+      (o.value as any).points.forEach((k:string) => {
+        const pointId = k;
+        idSet.pointIds.push(pointId);
+      });
+      // convert idSet to a change
+      const polygonChangeObject: JXGChange = {
+        operation: "create", // not "update" at the moment. This does not create a duplicate
+        target: "polygon",
+        targetID: idSet.polygonId,
+        parents: idSet.pointIds,
+        properties: { id: idSet.polygonId }
+      };
+      changes.push(polygonChangeObject);
+    }
+  });
+  applyChanges(board, changes);
+}
+
+*/

--- a/src/components/tiles/geometry/update-with-shared-data.ts
+++ b/src/components/tiles/geometry/update-with-shared-data.ts
@@ -40,6 +40,7 @@ export function getBoardDataExtents(objectsMap: Map<string, ObjectMapEntry>){
   return { xMax, yMax, xMin, yMin } // can be passed to rescaleBoardAndAxes()
 }
 
+// this will still be useful, but call after you create the points and polygons that need to be created
 export function getBoardObjectMap(board: JXG.Board){
   const boardObjectMap = new Map<string, ObjectMapEntry>;
 
@@ -78,6 +79,24 @@ export function getBoardObjectMap(board: JXG.Board){
 
   return boardObjectMap
 }
+
+// export function checkJXGForModelContent(objectsMap: any){
+//   let inModelButNotInJXG = [];
+
+//   for (let [key, value] of objectsMap) {
+//     if (value.type === "point"){
+//       //console.log("all17 a point in the model: ", value.id)
+//       const modelPointInJXG = this.getContent().getObject(key)?.id === key
+//       !modelPointInJXG && inModelButNotInJXG.push(key)
+//     }
+
+//     if (value.type === "polygon"){
+//       //console.log("all17 a polygon in the model: ", value.id)
+//       const modelPolygonInJXG = this.getContent().getObject(key)?.id === key
+//       !modelPolygonInJXG && inModelButNotInJXG.push(key)
+//     }
+//   }
+// }
 
 export function updateBoardPoints(board: JXG.Board, linkedData: any /*GeometryContentSnapshotType */){
   console.log("all1: updateBoardPoints", {board}, {linkedData})

--- a/src/components/tiles/geometry/update-with-shared-data.ts
+++ b/src/components/tiles/geometry/update-with-shared-data.ts
@@ -1,8 +1,3 @@
-import { GeometryContentSnapshotType } from "../../../models/tiles/geometry/geometry-content";
-import { applyChange, applyChanges } from "../../../models/tiles/geometry/jxg-dispatcher";
-import { getAllLinkedPoints, injectGetTableLinkColorsFunction } from "../../../models/tiles/geometry/jxg-table-link";
-import { JXGCoordPair, ILinkProperties } from "../../../models/tiles/geometry/jxg-changes";
-import { linkedPointId } from "../../../models/tiles/table-link-types";
 
 export interface ObjectMapEntry {
   id: string,
@@ -31,13 +26,6 @@ export function getBoardDataExtents(objectsMap: Map<string, ObjectMapEntry>){
     }
   }
   return { xMax, yMax, xMin, yMin } // matches type that can be passed to rescaleBoardAndAxes()
-}
-
-export function getModelObjectMap(modelContent:any){
-  const modelObjectsMap = new Map<string, ObjectMapEntry>;
-  for (let [key, value] of modelContent.data_){
-    console.log("nice value to be: ", value.value_)
-  }
 }
 
 export function getBoardObjectsMap(board: JXG.Board){
@@ -77,15 +65,4 @@ export function getBoardObjectsMap(board: JXG.Board){
 
   return boardObjectsMap
 }
-
-export function updateBoardPoints(board: JXG.Board, linkedData: any){
-  console.log("all1: updateBoardPoints", {board}, {linkedData})
-}
-
-export function updateBoardPolygons(board: JXG.Board, linkedData: any){
-  console.log("all1: updateBoardPolygons", {board}, {linkedData})
-}
-
-
-
 

--- a/src/components/tiles/geometry/update-with-shared-data.ts
+++ b/src/components/tiles/geometry/update-with-shared-data.ts
@@ -1,21 +1,15 @@
 import { GeometryContentSnapshotType } from "../../../models/tiles/geometry/geometry-content";
 import { applyChange, applyChanges } from "../../../models/tiles/geometry/jxg-dispatcher";
 import { getAllLinkedPoints, injectGetTableLinkColorsFunction } from "../../../models/tiles/geometry/jxg-table-link";
+import { JXGCoordPair, ILinkProperties } from "../../../models/tiles/geometry/jxg-changes";
+import { linkedPointId } from "../../../models/tiles/table-link-types";
 
-interface ObjectMapEntry {
+export interface ObjectMapEntry {
   id: string,
   elType: string,
   dataSource: string,
   x?: number | undefined,
   y?: number | undefined
-}
-
-/**
- * some of these may return updated stuff...
- */
-
-export function getBoardModelDiff(board: JXG.Board, linkedData: any){
-  console.log("all1: getBoardModelDiff: ",   {board}, {linkedData});
 }
 
 export function getBoardDataExtents(objectsMap: Map<string, ObjectMapEntry>){
@@ -36,15 +30,19 @@ export function getBoardDataExtents(objectsMap: Map<string, ObjectMapEntry>){
       if (pointY > yMax) yMax = pointY + 1
     }
   }
-
-  return { xMax, yMax, xMin, yMin } // can be passed to rescaleBoardAndAxes()
+  return { xMax, yMax, xMin, yMin } // matches type that can be passed to rescaleBoardAndAxes()
 }
 
-// this will still be useful, but call after you create the points and polygons that need to be created
-export function getBoardObjectMap(board: JXG.Board){
-  const boardObjectMap = new Map<string, ObjectMapEntry>;
+export function getModelObjectMap(modelContent:any){
+  const modelObjectsMap = new Map<string, ObjectMapEntry>;
+  for (let [key, value] of modelContent.data_){
+    console.log("nice value to be: ", value.value_)
+  }
+}
 
-  // collect info on all points
+export function getBoardObjectsMap(board: JXG.Board){
+  const boardObjectsMap = new Map<string, ObjectMapEntry>;
+
   const points = board.objectsList.filter((o) => o.elType === "point");
   points.forEach((point:any) => {
     const hasSharedPointId = point.id.includes(":");
@@ -56,7 +54,7 @@ export function getBoardObjectMap(board: JXG.Board){
     if (hasAxisPointId) pointSource = "axis";
     if (hasLocalCreatedId) pointSource = "local";
 
-    boardObjectMap.set(point.id, {
+    boardObjectsMap.set(point.id, {
       id: point.id,
       elType: "point",
       dataSource: pointSource,
@@ -70,39 +68,21 @@ export function getBoardObjectMap(board: JXG.Board){
     const constituentPoints = polygon.inherits[0]
     const isShared = constituentPoints.find((pt:any) => pt.id.includes(":"))
 
-    boardObjectMap.set(polygon.id, {
+    boardObjectsMap.set(polygon.id, {
       id: polygon.id,
       elType: "polygon",
       dataSource: isShared ? "shared" : "local"
     })
   })
 
-  return boardObjectMap
+  return boardObjectsMap
 }
 
-// export function checkJXGForModelContent(objectsMap: any){
-//   let inModelButNotInJXG = [];
-
-//   for (let [key, value] of objectsMap) {
-//     if (value.type === "point"){
-//       //console.log("all17 a point in the model: ", value.id)
-//       const modelPointInJXG = this.getContent().getObject(key)?.id === key
-//       !modelPointInJXG && inModelButNotInJXG.push(key)
-//     }
-
-//     if (value.type === "polygon"){
-//       //console.log("all17 a polygon in the model: ", value.id)
-//       const modelPolygonInJXG = this.getContent().getObject(key)?.id === key
-//       !modelPolygonInJXG && inModelButNotInJXG.push(key)
-//     }
-//   }
-// }
-
-export function updateBoardPoints(board: JXG.Board, linkedData: any /*GeometryContentSnapshotType */){
+export function updateBoardPoints(board: JXG.Board, linkedData: any){
   console.log("all1: updateBoardPoints", {board}, {linkedData})
 }
 
-export function updateBoardPolygons(board: JXG.Board, linkedData: any /*GeometryContentSnapshotType */){
+export function updateBoardPolygons(board: JXG.Board, linkedData: any){
   console.log("all1: updateBoardPolygons", {board}, {linkedData})
 }
 

--- a/src/components/tiles/geometry/update-with-shared-data.ts
+++ b/src/components/tiles/geometry/update-with-shared-data.ts
@@ -13,19 +13,19 @@ export function getBoardDataExtents(objectsMap: Map<string, ObjectMapEntry>){
   let xMin = -1;
   let yMin = -1;
 
-  for (let [key, value] of objectsMap){
-    const validPoint = value.elType === "point"
-    const graphable = value.dataSource === "shared" || value.dataSource === "local"
+  for (const [key, value] of objectsMap){
+    const validPoint = value.elType === "point";
+    const graphable = value.dataSource === "shared" || value.dataSource === "local";
     if (validPoint && graphable){
-      const pointX = value.x || 0
-      const pointY = value.y || 0
-      if (pointX < xMin) xMin = pointX - 1
-      if (pointX > xMax) xMax = pointX + 1
-      if (pointY < yMin) yMin = pointY - 1
-      if (pointY > yMax) yMax = pointY + 1
+      const pointX = value.x || 0;
+      const pointY = value.y || 0;
+      if (pointX < xMin) xMin = pointX - 1;
+      if (pointX > xMax) xMax = pointX + 1;
+      if (pointY < yMin) yMin = pointY - 1;
+      if (pointY > yMax) yMax = pointY + 1;
     }
   }
-  return { xMax, yMax, xMin, yMin } // matches type that can be passed to rescaleBoardAndAxes()
+  return { xMax, yMax, xMin, yMin }; // matches type that can be passed to rescaleBoardAndAxes()
 }
 
 export function getBoardObjectsMap(board: JXG.Board){
@@ -37,7 +37,7 @@ export function getBoardObjectsMap(board: JXG.Board){
     const hasAxisPointId = point.id.includes("jxgBoard");
     const hasLocalCreatedId = !hasSharedPointId && !hasAxisPointId && point.id.length === 16;
 
-    let pointSource = "" // these possible values should be enumerated in a type of some kind?
+    let pointSource = ""; // these possible values should be enumerated in a type of some kind?
     if (hasSharedPointId) pointSource = "shared";
     if (hasAxisPointId) pointSource = "axis";
     if (hasLocalCreatedId) pointSource = "local";
@@ -51,18 +51,18 @@ export function getBoardObjectsMap(board: JXG.Board){
     });
   });
 
-  const polygons = board.objectsList.filter((o) => o.elType === "polygon")
+  const polygons = board.objectsList.filter((o) => o.elType === "polygon");
   polygons.forEach((polygon:any) => {
-    const constituentPoints = polygon.inherits[0]
-    const isShared = constituentPoints.find((pt:any) => pt.id.includes(":"))
+    const constituentPoints = polygon.inherits[0];
+    const isShared = constituentPoints.find((pt:any) => pt.id.includes(":"));
 
     boardObjectsMap.set(polygon.id, {
       id: polygon.id,
       elType: "polygon",
       dataSource: isShared ? "shared" : "local"
-    })
-  })
+    });
+  });
 
-  return boardObjectsMap
+  return boardObjectsMap;
 }
 

--- a/src/models/tiles/geometry/jxg-board.ts
+++ b/src/models/tiles/geometry/jxg-board.ts
@@ -48,7 +48,8 @@ export function getPointsByCaseId(board: JXG.Board, caseId: string) {
   return board.objectsList.filter(obj => isPoint(obj) && (obj.id.split(":")[0] === caseId));
 }
 
-export function syncLinkedPoints(board: JXG.Board, links: ITableLinkProperties) {
+// defines-sync-linked-points
+export function boardSyncLinkedPoints(board: JXG.Board, links: ITableLinkProperties) {
   if (board && links?.labels) {
     // build map of points associated with each case
     const ptsForCaseMap: Record<string, JXG.GeometryElement[]> = {};

--- a/src/models/tiles/geometry/jxg-object.ts
+++ b/src/models/tiles/geometry/jxg-object.ts
@@ -1,4 +1,4 @@
-import { sortByCreation, kReverse, getObjectById, syncLinkedPoints } from "./jxg-board";
+import { sortByCreation, kReverse, getObjectById, boardSyncLinkedPoints } from "./jxg-board";
 import {
   ITableLinkProperties, JXGChangeAgent, JXGCoordPair, JXGPositionProperty, JXGProperties
 } from "./jxg-changes";
@@ -87,7 +87,7 @@ export const objectChangeAgent: JXGChangeAgent = {
         }
       }
     });
-    if (hasLinkedPoints) syncLinkedPoints(board, change.links as ITableLinkProperties);
+    if (hasLinkedPoints) boardSyncLinkedPoints(board, change.links as ITableLinkProperties);
     if (hasSuspendedTextUpdates) board.suspendUpdate();
     board.update();
     return undefined;

--- a/src/models/tiles/geometry/jxg-table-link.ts
+++ b/src/models/tiles/geometry/jxg-table-link.ts
@@ -1,5 +1,5 @@
 import { splitLinkedPointId } from "../table-link-types";
-import { resumeBoardUpdates, suspendBoardUpdates, syncLinkedPoints } from "./jxg-board";
+import { resumeBoardUpdates, suspendBoardUpdates, boardSyncLinkedPoints } from "./jxg-board";
 import { ILinkProperties, ITableLinkProperties, JXGChange, JXGChangeAgent, JXGCoordPair } from "./jxg-changes";
 import { createPoint, pointChangeAgent } from "./jxg-point";
 import { isPoint } from "./jxg-types";
@@ -72,7 +72,7 @@ export const linkedPointChangeAgent: JXGChangeAgent = {
       result = createLinkedPoint(board as JXG.Board, change.parents as JXGCoordPair, change.properties, change.links);
     }
 
-    syncLinkedPoints(board as JXG.Board, change.links as ITableLinkProperties);
+    boardSyncLinkedPoints(board as JXG.Board, change.links as ITableLinkProperties);
 
     return result;
   },
@@ -82,7 +82,7 @@ export const linkedPointChangeAgent: JXGChangeAgent = {
   delete: (board, change) => {
     pointChangeAgent.delete(board, change);
 
-    syncLinkedPoints(board, change.links as ITableLinkProperties);
+    boardSyncLinkedPoints(board, change.links as ITableLinkProperties);
   }
 };
 

--- a/src/models/tiles/geometry/jxg-table-link.ts
+++ b/src/models/tiles/geometry/jxg-table-link.ts
@@ -48,7 +48,10 @@ function createLinkedPoint(board: JXG.Board, parents: JXGCoordPair, props: any, 
 export function getAllLinkedPoints(board: JXG.Board) {
   const ids: string[] = [];
   board.objectsList.forEach(obj => {
-    if (obj.elType === "point" && obj.getAttribute("clientType") === "linkedPoint") {
+    const clientTypeIsLinked = obj.getAttribute("clientType") === "linkedPoint";
+    const hasLinkedStyleId = obj.id.indexOf(":") === 16; // not sure if ^^^ will always be true?
+    const isLinkedPoint = clientTypeIsLinked || hasLinkedStyleId;
+    if (obj.elType === "point" && isLinkedPoint) {
       ids.push(obj.id);
     }
   });


### PR DESCRIPTION
This causes user-created polygons based on points from a shared table to be rendered on creation, and on page reload. 
`syncLinkedPoints` now calls a new function `syncLinkedPolygons`.  This function finds the Polygons that exist on the model and re-renders them. 

Some questions/thoughts that are keeping this in "draft" for the moment. 

- Should this function be called from one or more or all of the locations that syncLinkedPoints is called from? (instead of being called from within `syncLinkedPoints`). 
- I could condition the re-render on this being a polygon derived from a shared model, (checking for the `:` in the id) Right now I do not, (it just overwrites, kind of like the points) but it might make sense to scaffold out code that is smarter as we talked about - as we will have Geometry Tiles encountering more types of data as they render, and they should be able to know/track what they are rendering, especially since a soon-coming story involves serializing in such a way that elements derived from shared data will persist on import. 
- I could not get it to work by using `operation: "update"` in the change object.  I don't know if its necessary. 