### PR TITLE
Fix selection after inserting/editing variables via dialogs

### DIFF
--- a/src/components/tiles/text/text-toolbar.tsx
+++ b/src/components/tiles/text/text-toolbar.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from "react";
 import ReactDOM from "react-dom";
 import _ from "lodash";
-import { Editor, EFormat, ReactEditor } from "@concord-consortium/slate-editor";
+import { Editor, EFormat, ReactEditor, Transforms } from "@concord-consortium/slate-editor";
 
 import { IFloatingToolbarProps, useFloatingToolbarLocation } from "../hooks/use-floating-toolbar-location";
 import { useSettingFromStores } from "../../../hooks/use-stores";
@@ -62,6 +62,7 @@ function handleClose(editor: Editor) {
   // focus the editor after closing the dialog, which is what the user expects and
   // also required for certain slate selection synchronization mechanisms to work.
   // focusing twice shouldn't be necessary, but sometimes seems to help ¯\_(ツ)_/¯
+  Transforms.move(editor, { distance: 1, unit: "word" });
   ReactEditor.focus(editor);
   setTimeout(() => {
     ReactEditor.focus(editor);

--- a/src/components/tiles/text/text-toolbar.tsx
+++ b/src/components/tiles/text/text-toolbar.tsx
@@ -59,7 +59,13 @@ const handleMouseDown = (event: React.MouseEvent) => {
 };
 
 function handleClose(editor: Editor) {
+  // focus the editor after closing the dialog, which is what the user expects and
+  // also required for certain slate selection synchronization mechanisms to work.
+  // focusing twice shouldn't be necessary, but sometimes seems to help ¯\_(ツ)_/¯
   ReactEditor.focus(editor);
+  setTimeout(() => {
+    ReactEditor.focus(editor);
+  }, 10);
 }
 
 export const TextToolbarComponent: React.FC<IProps> = (props: IProps) => {

--- a/src/components/tiles/text/text-toolbar.tsx
+++ b/src/components/tiles/text/text-toolbar.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from "react";
 import ReactDOM from "react-dom";
 import _ from "lodash";
-import { Editor, EFormat } from "@concord-consortium/slate-editor";
+import { Editor, EFormat, ReactEditor } from "@concord-consortium/slate-editor";
 
 import { IFloatingToolbarProps, useFloatingToolbarLocation } from "../hooks/use-floating-toolbar-location";
 import { useSettingFromStores } from "../../../hooks/use-stores";
@@ -58,6 +58,10 @@ const handleMouseDown = (event: React.MouseEvent) => {
   event.preventDefault();
 };
 
+function handleClose(editor: Editor) {
+  ReactEditor.focus(editor);
+}
+
 export const TextToolbarComponent: React.FC<IProps> = (props: IProps) => {
   const { documentContent, editor, selectedButtons, onIsEnabled, ...others } = props;
   const toolbarSetting = useSettingFromStores("tools", "text") as unknown as string[];
@@ -77,19 +81,19 @@ export const TextToolbarComponent: React.FC<IProps> = (props: IProps) => {
   plugins.forEach(plugin => {
     if (plugin?.modalHook) {
       const { selfVariables, otherVariables, unusedVariables } = variableBuckets(textContent, sharedModel);
-      const [showDialog] = plugin.modalHook (
-        { variable: selectedVariable,
-          textContent,
-          sharedModel,
-          Icon: InsertVariableCardIcon,
-          addVariable: _.bind(insertTextVariable, null, _, editor),
-          namePrefill: highlightedText,
-          insertVariables: _.bind(insertTextVariables, null, _, editor),
-          otherVariables,
-          selfVariables,
-          unusedVariables
-        }
-      );
+      const [showDialog] = plugin.modalHook({
+        variable: selectedVariable,
+        textContent,
+        sharedModel,
+        Icon: InsertVariableCardIcon,
+        addVariable: _.bind(insertTextVariable, null, _, editor),
+        namePrefill: highlightedText,
+        insertVariables: _.bind(insertTextVariables, null, _, editor),
+        otherVariables,
+        selfVariables,
+        unusedVariables,
+        onClose: () => editor && handleClose(editor)
+      });
       const name = plugin.iconName;
       pluginModalHandlers[name] = showDialog;
     }

--- a/src/plugins/shared-variables/dialog/use-edit-variable-dialog.tsx
+++ b/src/plugins/shared-variables/dialog/use-edit-variable-dialog.tsx
@@ -9,8 +9,9 @@ import './variable-dialog.scss';
 
 interface IProps {
   variable?: VariableType;
+  onClose?: () => void;
 }
-export const useEditVariableDialog = ({ variable }: IProps) => {
+export const useEditVariableDialog = ({ variable, onClose }: IProps) => {
   const variableClone = useMemo(() => Variable.create(variable ? getSnapshot(variable) : {}), [variable]);
 
   const handleClick = () => {
@@ -31,7 +32,8 @@ export const useEditVariableDialog = ({ variable }: IProps) => {
         isDisabled: !variable,
         onClick: handleClick
       }
-    ]
+    ],
+    onClose
   }, [variable]);
 
   return [showModal, hideModal];

--- a/src/plugins/shared-variables/dialog/use-insert-variable-dialog.tsx
+++ b/src/plugins/shared-variables/dialog/use-insert-variable-dialog.tsx
@@ -78,15 +78,20 @@ interface IInsertVariableDialog {
   otherVariables: VariableType[]; // A list of variables used by other tiles
   selfVariables: VariableType[]; // A list of variables used by the tile showing this dialog
   unusedVariables: VariableType[]; // A list of variables not used by any tiles
+  onClose?: () => void;
 }
-export const useInsertVariableDialog =
-  ({ disallowSelf, Icon, insertVariables, otherVariables, selfVariables, unusedVariables }: IInsertVariableDialog) =>
+export const useInsertVariableDialog = ({
+  disallowSelf, Icon, insertVariables, otherVariables, selfVariables, unusedVariables, onClose
+}: IInsertVariableDialog) =>
 {
   const { clearSelectedVariables, selectedVariables, toggleVariable } = useSelectMultipleVariables();
 
   const handleOk = () => insertVariables(selectedVariables);
 
-  const onClose = clearSelectedVariables;
+  const handleClose = () => {
+    clearSelectedVariables();
+    onClose?.();
+  };
 
   const [showModal, hideModal] = useCustomModal({
     Icon: Icon || InsertVariableChipIcon,
@@ -108,7 +113,7 @@ export const useInsertVariableDialog =
         onClick: handleOk
       }
     ],
-    onClose
+    onClose: handleClose
   }, [selectedVariables, otherVariables, selfVariables, unusedVariables]);
 
   return [showModal, hideModal];

--- a/src/plugins/shared-variables/dialog/use-new-variable-dialog.tsx
+++ b/src/plugins/shared-variables/dialog/use-new-variable-dialog.tsx
@@ -9,9 +9,10 @@ import { SharedVariablesType } from "../shared-variables";
 interface IUseNewVariableDialog {
   addVariable: (variable: VariableType ) => void;
   sharedModel: SharedVariablesType;
-  namePrefill? : string
+  namePrefill? : string;
+  onClose?: () => void;
 }
-export const useNewVariableDialog = ({ addVariable, sharedModel, namePrefill }: IUseNewVariableDialog) => {
+export const useNewVariableDialog = ({ addVariable, sharedModel, namePrefill, onClose }: IUseNewVariableDialog) => {
   const [newVariable, setNewVariable] = useState(Variable.create({name: namePrefill || undefined}));
 
   const handleClick = () => {
@@ -35,7 +36,8 @@ export const useNewVariableDialog = ({ addVariable, sharedModel, namePrefill }: 
         isDisabled: false,
         onClick: handleClick
       }
-    ]
+    ],
+    onClose
   }, [addVariable, newVariable]);
 
   // Wrap useCustomModal's show so we can prefill with variable name

--- a/src/plugins/shared-variables/slate/variables-plugin.tsx
+++ b/src/plugins/shared-variables/slate/variables-plugin.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from "react";
 import classNames from "classnames/dedupe";
 
 import {
-  BaseElement, CustomEditor, CustomElement, Editor, kSlateVoidClass, registerElementComponent,
+  BaseElement, CustomEditor, CustomElement, Editor, kSlateVoidClass, ReactEditor, registerElementComponent,
   RenderElementProps, Transforms, useSelected, useSerializing,
 } from "@concord-consortium/slate-editor";
 import { VariableChip, VariableType } from "@concord-consortium/diagram-view";
@@ -36,6 +36,7 @@ export const insertTextVariable = (variable: VariableType, editor?: Editor) => {
   const reference = variable.id;
   const varElt: VariableElement = { type: kVariableFormat, reference, children: [{text: "" }]};
   Transforms.insertNodes(editor, varElt);
+  Transforms.move(editor, { distance: 1, unit: "word" });
 };
 
 export const findSelectedVariable = (selectedElements: any, variables: VariableType[]) => {

--- a/src/plugins/shared-variables/slate/variables-plugin.tsx
+++ b/src/plugins/shared-variables/slate/variables-plugin.tsx
@@ -36,7 +36,6 @@ export const insertTextVariable = (variable: VariableType, editor?: Editor) => {
   const reference = variable.id;
   const varElt: VariableElement = { type: kVariableFormat, reference, children: [{text: "" }]};
   Transforms.insertNodes(editor, varElt);
-  Transforms.move(editor, { distance: 1, unit: "word" });
 };
 
 export const findSelectedVariable = (selectedElements: any, variables: VariableType[]) => {

--- a/src/plugins/shared-variables/slate/variables-plugin.tsx
+++ b/src/plugins/shared-variables/slate/variables-plugin.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from "react";
 import classNames from "classnames/dedupe";
 
 import {
-  BaseElement, CustomEditor, CustomElement, Editor, kSlateVoidClass, ReactEditor, registerElementComponent,
+  BaseElement, CustomEditor, CustomElement, Editor, kSlateVoidClass, registerElementComponent,
   RenderElementProps, Transforms, useSelected, useSerializing,
 } from "@concord-consortium/slate-editor";
 import { VariableChip, VariableType } from "@concord-consortium/diagram-view";


### PR DESCRIPTION
Pair-programmed with @tealefristoe 

Tries to set the edit caret (selection) when closing any of the variable dialogs to the spot immediately after the affected variable. Generally sets the position of the caret correctly but doesn't always successfully activate the blinking caret, but even in this case typing will usually put the new characters where they belong. Without this fix, the caret would sometimes jump to the beginning of the text and typing new characters wouldn't work correctly. Thus, the new behavior is better than the previous behavior even when it doesn't work completely correctly.