### PR TITLE
Stop adding new lines when creating text tiles from html specified in curriculum

### DIFF
--- a/src/models/tiles/text/text-content.test.ts
+++ b/src/models/tiles/text/text-content.test.ts
@@ -54,7 +54,7 @@ describe("TextContentModel", () => {
     const text = ["some", "array", "strings"];
     const model = TextContentModel.create({ text });
     expect(model.text).toEqual(text);
-    expect(model.joinText).toBe(text.join(""));
+    expect(model.joinText).toBe(text.join("\n"));
 
     const flat = "flat string";
     model.setText(flat);

--- a/src/models/tiles/text/text-content.test.ts
+++ b/src/models/tiles/text/text-content.test.ts
@@ -54,7 +54,7 @@ describe("TextContentModel", () => {
     const text = ["some", "array", "strings"];
     const model = TextContentModel.create({ text });
     expect(model.text).toEqual(text);
-    expect(model.joinText).toBe(text.join("\n"));
+    expect(model.joinText).toBe(text.join(""));
 
     const flat = "flat string";
     model.setText(flat);

--- a/src/models/tiles/text/text-content.ts
+++ b/src/models/tiles/text/text-content.ts
@@ -27,9 +27,14 @@ export const TextContentModel = TileContentModel
   .views(self => ({
     get joinText() {
       return Array.isArray(self.text)
-              ? self.text.join("")
-              : self.text as string;
+        ? self.text.join("\n")
+        : self.text as string;
 
+    },
+    get joinHtml() {
+      return Array.isArray(self.text)
+        ? self.text.join("")
+        : self.text as string;
     },
     getSlate() {
       if (!self.text || Array.isArray(self.text)) {
@@ -59,7 +64,7 @@ export const TextContentModel = TileContentModel
         case "slate":
           return self.getSlate();
         case "html":
-          return htmlToSlate(self.joinText);
+          return htmlToSlate(self.joinHtml);
         case "markdown":
           // TODO: figure out what to do about markdown
           return []; // return self.joinText;

--- a/src/models/tiles/text/text-content.ts
+++ b/src/models/tiles/text/text-content.ts
@@ -27,7 +27,7 @@ export const TextContentModel = TileContentModel
   .views(self => ({
     get joinText() {
       return Array.isArray(self.text)
-              ? self.text.join("\n")
+              ? self.text.join("")
               : self.text as string;
 
     },


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/184366775

Stops adding "\n" between lines in text tiles specified via html in curriculum. This was causing slate to add text outside of paragraphs, which is illegal, and caused data loss and broken functionality when the tiles were copied and modified.