### PR TITLE
Update diagram-view to v0.0.26

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@concord-consortium/diagram-view": "^0.0.25",
+        "@concord-consortium/diagram-view": "^0.0.26",
         "@concord-consortium/mobx-state-tree": "5.1.5-cc.1",
         "@concord-consortium/react-components": "^0.7.1",
         "@concord-consortium/react-modal-hook": "^3.0.0-cc.1",
@@ -1863,9 +1863,9 @@
       "license": "MIT"
     },
     "node_modules/@concord-consortium/diagram-view": {
-      "version": "0.0.25",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.25.tgz",
-      "integrity": "sha512-hXvuPb5CKZbbPL8UFuF/GrmSKHk4Ze32iPIDLL+IZxqfZyRirlKDGqaVaVAAeQu1whSpzBSVpGRt5VJJ9o4qOw==",
+      "version": "0.0.26",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.26.tgz",
+      "integrity": "sha512-qQNDu92EhpiIolZZm2hoKkPE3ebdtRI3MGouNRcXdWI5jMzU9wGmB6wvLcvfPVHD3gnxORUMP356EhzVe6mIUA==",
       "dependencies": {
         "iframe-phone": "^1.3.1",
         "mathjs": "^10.4.1",
@@ -20460,9 +20460,9 @@
       "dev": true
     },
     "@concord-consortium/diagram-view": {
-      "version": "0.0.25",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.25.tgz",
-      "integrity": "sha512-hXvuPb5CKZbbPL8UFuF/GrmSKHk4Ze32iPIDLL+IZxqfZyRirlKDGqaVaVAAeQu1whSpzBSVpGRt5VJJ9o4qOw==",
+      "version": "0.0.26",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.26.tgz",
+      "integrity": "sha512-qQNDu92EhpiIolZZm2hoKkPE3ebdtRI3MGouNRcXdWI5jMzU9wGmB6wvLcvfPVHD3gnxORUMP356EhzVe6mIUA==",
       "requires": {
         "iframe-phone": "^1.3.1",
         "mathjs": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
     "xhr-mock": "^2.5.1"
   },
   "dependencies": {
-    "@concord-consortium/diagram-view": "^0.0.25",
+    "@concord-consortium/diagram-view": "^0.0.26",
     "@concord-consortium/mobx-state-tree": "5.1.5-cc.1",
     "@concord-consortium/react-components": "^0.7.1",
     "@concord-consortium/react-modal-hook": "^3.0.0-cc.1",


### PR DESCRIPTION
Updates diagram-view to the latest version.

[Release notes for diagram-view 0.0.26](https://github.com/concord-consortium/quantity-playground/releases/tag/diagram-view-0.0.26)