### PR TITLE
Clean up toolbar rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ To enable per component debugging set the "debug" localstorage key with one or m
 - `images` this will set `window.imageMap` so you can look at the status and URLs of images that have been loaded.
 - `listeners` console log the adding, removing, and firing of firebase listeners
 - `logger` console log all messages sent to the logging service
+- `sharedModels` console log messages about shared models, currently this is only used in the variables shared model
 - `stores` this will set `window.stores` so you can monitor the stores global from the browser console.
 - `undo` this will print information about each action that is added to the undo stack.
 

--- a/docs/text-tile-plugins.md
+++ b/docs/text-tile-plugins.md
@@ -44,4 +44,6 @@ TODO:
 - [x] merge master to resolve conflicts
 - [x] update text tile plugin documentation
 - [x] reduce the duplication in the built in tools
-- [ ] review all of the TODOs and FIXMEs
+- [x] review all of the TODOs and FIXMEs
+- [ ] prevent the re-rendering of the whole text tile when the editor value is updated. We really only need to refresh the toolbar at this point. Maybe the toolbar can just listen to the editor and update its state instead of relying on the text-tile to do this for it.
+- [ ] use context instead of props in text-toolbar.tsx for textContent and pluginInstances. Both of these are available in context.

--- a/docs/text-tile-plugins.md
+++ b/docs/text-tile-plugins.md
@@ -45,5 +45,5 @@ TODO:
 - [x] update text tile plugin documentation
 - [x] reduce the duplication in the built in tools
 - [x] review all of the TODOs and FIXMEs
-- [ ] prevent the re-rendering of the whole text tile when the editor value is updated. We really only need to refresh the toolbar at this point. Maybe the toolbar can just listen to the editor and update its state instead of relying on the text-tile to do this for it.
-- [ ] use context instead of props in text-toolbar.tsx for textContent and pluginInstances. Both of these are available in context.
+- [x] prevent the re-rendering of the whole text tile when the editor value is updated. We really only need to refresh the toolbar at this point. Maybe the toolbar can just listen to the editor and update its state instead of relying on the text-tile to do this for it.
+- [x] use context instead of props in text-toolbar.tsx for textContent and pluginInstances. Both of these are available in context.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@concord-consortium/react-components": "^0.7.1",
         "@concord-consortium/react-modal-hook": "^3.0.0-cc.1",
         "@concord-consortium/rete-react-render-plugin": "^0.2.1-cc.2",
-        "@concord-consortium/slate-editor": "^0.9.0-pre.5",
+        "@concord-consortium/slate-editor": "^0.9.0-pre.7",
         "@dnd-kit/core": "^6.0.5",
         "chart.js": "^2.9.4",
         "classnames": "^2.3.1",
@@ -1925,9 +1925,9 @@
       }
     },
     "node_modules/@concord-consortium/slate-editor": {
-      "version": "0.9.0-pre.5",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/slate-editor/-/slate-editor-0.9.0-pre.5.tgz",
-      "integrity": "sha512-VTg6XV4ec6MVgYXsFNoQ1hHNitQtacSDAvuMmEY8uYTiEn4izAWwgEZXxogeYvlVa7t7Nenez7jQdTeKYlEQ7Q==",
+      "version": "0.9.0-pre.7",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/slate-editor/-/slate-editor-0.9.0-pre.7.tgz",
+      "integrity": "sha512-UV3ie7DboC3/O+u3vbM+qs8etjedhlX+bBFG2m1xHRL1AV376CQw7dDLrvETD5wLsUrbf4D2zcMhKLxak59UQA==",
       "dependencies": {
         "@emotion/css": "^11.10.5",
         "classnames": "^2.3.2",
@@ -20488,9 +20488,9 @@
       "requires": {}
     },
     "@concord-consortium/slate-editor": {
-      "version": "0.9.0-pre.5",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/slate-editor/-/slate-editor-0.9.0-pre.5.tgz",
-      "integrity": "sha512-VTg6XV4ec6MVgYXsFNoQ1hHNitQtacSDAvuMmEY8uYTiEn4izAWwgEZXxogeYvlVa7t7Nenez7jQdTeKYlEQ7Q==",
+      "version": "0.9.0-pre.7",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/slate-editor/-/slate-editor-0.9.0-pre.7.tgz",
+      "integrity": "sha512-UV3ie7DboC3/O+u3vbM+qs8etjedhlX+bBFG2m1xHRL1AV376CQw7dDLrvETD5wLsUrbf4D2zcMhKLxak59UQA==",
       "requires": {
         "@emotion/css": "^11.10.5",
         "classnames": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
     "@concord-consortium/react-components": "^0.7.1",
     "@concord-consortium/react-modal-hook": "^3.0.0-cc.1",
     "@concord-consortium/rete-react-render-plugin": "^0.2.1-cc.2",
-    "@concord-consortium/slate-editor": "^0.9.0-pre.5",
+    "@concord-consortium/slate-editor": "^0.9.0-pre.7",
     "@dnd-kit/core": "^6.0.5",
     "chart.js": "^2.9.4",
     "classnames": "^2.3.1",

--- a/src/components/tiles/text/text-tile.tsx
+++ b/src/components/tiles/text/text-tile.tsx
@@ -80,14 +80,13 @@ import "./text-tile.sass";
 
 interface IState {
   value?: EditorValue;
-  valueRevision: number;
   editing?: boolean;
 }
 
 @inject("stores")
 @observer
 export default class TextToolComponent extends BaseComponent<ITileProps, IState> {
-  public state: IState = {valueRevision: 0};
+  public state: IState = {};
   private disposers: IReactionDisposer[];
   private prevText: any;
   private textTileDiv: HTMLElement | null;
@@ -104,8 +103,7 @@ export default class TextToolComponent extends BaseComponent<ITileProps, IState>
     this.prevText = initialTextContent.text;
     const initialValue = initialTextContent.asSlate();
     this.setState({
-      value: initialValue,
-      valueRevision: 0
+      value: initialValue
     });
     this.plugins = createTextPluginInstances(this.props.model.content as TextContentModelType);
     const options: any = {}; // FIXME: type. ICreateEditorOptions is not currently exported from slate
@@ -188,7 +186,7 @@ export default class TextToolComponent extends BaseComponent<ITileProps, IState>
 
   public render() {
     const { documentContent, tileElt, readOnly, scale } = this.props;
-    const { value: editorValue, valueRevision } = this.state;
+    const { value: editorValue } = this.state;
     const { appConfig: { placeholderText } } = this.stores;
     const editableClass = readOnly ? "read-only" : "editable";
     // Ideally this would just be 'text-tool-editor', but 'text-tool' has been
@@ -222,11 +220,8 @@ export default class TextToolComponent extends BaseComponent<ITileProps, IState>
               />
               <TextToolbarComponent
                 documentContent={documentContent}
-                valueRevision={valueRevision}
                 tileElt={tileElt}
                 scale={scale}
-                editor={this.editor}
-                pluginInstances={this.plugins}
                 onIsEnabled={this.handleIsEnabled}
                 onRegisterTileApi={this.handleRegisterToolApi}
                 onUnregisterTileApi={this.handleUnregisterToolApi}
@@ -268,8 +263,7 @@ export default class TextToolComponent extends BaseComponent<ITileProps, IState>
     if (content.type === "Text" && !readOnly) {
       content.setSlate(value);
       this.setState({
-        value,
-        valueRevision: this.state.valueRevision + 1
+        value
       });
     }
   };

--- a/src/models/tiles/text/text-plugin-info.ts
+++ b/src/models/tiles/text/text-plugin-info.ts
@@ -8,9 +8,7 @@ export interface ITextPlugin {
 }
 
 export interface IButtonDefProps {
-  editor: Editor;
   pluginInstance?: ITextPlugin;
-  valueRevision: number;
 }
 
 export type ButtonDefComponent = React.FC<IButtonDefProps>;

--- a/src/plugins/shared-variables/slate/text-tile-buttons.tsx
+++ b/src/plugins/shared-variables/slate/text-tile-buttons.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from "react";
 import { VariableType } from "@concord-consortium/diagram-view";
-import { Editor, ReactEditor, Transforms } from "@concord-consortium/slate-editor";
+import { Editor, ReactEditor, Transforms, useSlate } from "@concord-consortium/slate-editor";
 import { observer } from "mobx-react";
 import { IButtonDefProps, ITextPlugin } from "../../../models/tiles/text/text-plugin-info";
 import { TextToolbarButton } from "../../../components/tiles/text/text-toolbar-button";
@@ -81,8 +81,9 @@ function handleClose(editor: Editor) {
 }
 
 export const NewVariableTextButton = observer(function NewVariableTextButton(
-    {editor, pluginInstance}: IButtonDefProps) {
+    {pluginInstance}: IButtonDefProps) {
 
+  const editor = useSlate();
   const variablesPlugin = castToVariablesPlugin(pluginInstance);
 
   const isSelected = false;
@@ -110,7 +111,8 @@ export const NewVariableTextButton = observer(function NewVariableTextButton(
 });
 
 export const InsertVariableTextButton = observer(function InsertVariableTextButton(
-    {editor, pluginInstance}: IButtonDefProps) {
+    {pluginInstance}: IButtonDefProps) {
+  const editor = useSlate();
   const variablesPlugin = castToVariablesPlugin(pluginInstance);
 
   const isSelected = false;
@@ -140,8 +142,9 @@ export const InsertVariableTextButton = observer(function InsertVariableTextButt
 });
 
 export const EditVariableTextButton = observer(function EditVariableTextButton(
-    {editor, pluginInstance}: IButtonDefProps) {
-  const variablesPlugin = castToVariablesPlugin(pluginInstance);
+    {pluginInstance}: IButtonDefProps) {
+    const editor = useSlate();
+    const variablesPlugin = castToVariablesPlugin(pluginInstance);
 
   const isSelected = false;
   const selectedElements = editor?.selectedElements();


### PR DESCRIPTION
Here is what I want to try to do here:

- [x] prevent the re-rendering of the whole text tile when the editor value is updated. We really only need to refresh the toolbar at this point. Maybe the toolbar can just listen to the editor and update its state instead of relying on the text-tile to do this for it.
- [x] use context instead of props in text-toolbar.tsx for textContent and pluginInstances. Both of these are available in context.