### PR TITLE
Update diagram-view to latest version -- 0.0.28

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@concord-consortium/diagram-view": "^0.0.27",
+        "@concord-consortium/diagram-view": "^0.0.28",
         "@concord-consortium/mobx-state-tree": "5.1.5-cc.1",
         "@concord-consortium/react-components": "^0.7.1",
         "@concord-consortium/react-modal-hook": "^3.0.0-cc.1",
@@ -1863,9 +1863,9 @@
       "license": "MIT"
     },
     "node_modules/@concord-consortium/diagram-view": {
-      "version": "0.0.27",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.27.tgz",
-      "integrity": "sha512-Z38Hle6fjArgwC5yf1GXOyMMsmXFVtoQgH8OIq7nWoGc4icIWPs5HmmWZTrxgkYS9m6G0LnfCYiKTKDJ/0gfJg==",
+      "version": "0.0.28",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.28.tgz",
+      "integrity": "sha512-hxBC0mMpSykzwzINr72W3KiRw+Gi0lQiYgx0FMfLo/E/HmLNHcVhzfUjJJ32Wi6DbeWD8lFk2VCd/7uCsDOTzQ==",
       "dependencies": {
         "iframe-phone": "^1.3.1",
         "mathjs": "^10.4.1",
@@ -20460,9 +20460,9 @@
       "dev": true
     },
     "@concord-consortium/diagram-view": {
-      "version": "0.0.27",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.27.tgz",
-      "integrity": "sha512-Z38Hle6fjArgwC5yf1GXOyMMsmXFVtoQgH8OIq7nWoGc4icIWPs5HmmWZTrxgkYS9m6G0LnfCYiKTKDJ/0gfJg==",
+      "version": "0.0.28",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.28.tgz",
+      "integrity": "sha512-hxBC0mMpSykzwzINr72W3KiRw+Gi0lQiYgx0FMfLo/E/HmLNHcVhzfUjJJ32Wi6DbeWD8lFk2VCd/7uCsDOTzQ==",
       "requires": {
         "iframe-phone": "^1.3.1",
         "mathjs": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
     "xhr-mock": "^2.5.1"
   },
   "dependencies": {
-    "@concord-consortium/diagram-view": "^0.0.27",
+    "@concord-consortium/diagram-view": "^0.0.28",
     "@concord-consortium/mobx-state-tree": "5.1.5-cc.1",
     "@concord-consortium/react-components": "^0.7.1",
     "@concord-consortium/react-modal-hook": "^3.0.0-cc.1",


### PR DESCRIPTION
[Release notes for diagram-view 0.0.28](https://github.com/concord-consortium/quantity-playground/releases/tag/diagram-view-0.0.28)