### PR TITLE
183053771 shared data polygon and axis rescale

### DIFF
--- a/src/components/tiles/geometry/geometry-content.tsx
+++ b/src/components/tiles/geometry/geometry-content.tsx
@@ -612,13 +612,18 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
   }
 
   // remove/recreate all linked points
-  // TODO: A more tailored response would match up the existing points with the data set and only
+  // Shared points are deleted, and in the process, so are the polygons that depend on them
+  // This is built into JSXGraph's Board#removeObject function, which descends through and deletes all children:
+  // https://github.com/jsxgraph/jsxgraph/blob/60a2504ed66b8c6fea30ef67a801e86877fb2e9f/src/base/board.js#L4775
+  // Ids persist in their recreation because they are ultimately derived from canonical values
+  // NOTE: A more tailored response would match up the existing points with the data set and only
   // change the affected points, which would eliminate some visual flashing that occurs when
-  // unchanged points are re-created and would allow derived polygons to be preserved.
+  // unchanged points are re-created and would allow derived polygons to be preserved rather than created anew.
   recreateSharedPoints(board: JXG.Board){
     const ids = getAllLinkedPoints(board);
-    applyChange(board, { operation: "delete", target: "linkedPoint", targetID: ids });
-
+    if (ids.length > 0){
+      applyChange(board, { operation: "delete", target: "linkedPoint", targetID: ids });
+    }
     this.getContent().linkedDataSets.forEach(link => {
       const links: ILinkProperties = { tileIds: [link.providerId] };
       const parents: JXGCoordPair[] = [];

--- a/src/components/tiles/geometry/geometry-content.tsx
+++ b/src/components/tiles/geometry/geometry-content.tsx
@@ -14,14 +14,14 @@ import {
 } from "../../../models/tiles/geometry/geometry-content";
 import { convertModelObjectsToChanges } from "../../../models/tiles/geometry/geometry-migrate";
 import {
-  cloneGeometryObject, GeometryObjectModelType, isPointModel, createObject
+  cloneGeometryObject, GeometryObjectModelType, isPointModel
 } from "../../../models/tiles/geometry/geometry-model";
 import { copyCoords, getEventCoords, getAllObjectsUnderMouse, getClickableObjectUnderMouse,
           isDragTargetOrAncestor } from "../../../models/tiles/geometry/geometry-utils";
 import { RotatePolygonIcon } from "./rotate-polygon-icon";
 import { getPointsByCaseId } from "../../../models/tiles/geometry/jxg-board";
 import {
-  ESegmentLabelOption, ILinkProperties, JXGCoordPair, JXGChange
+  ESegmentLabelOption, ILinkProperties, JXGCoordPair
 } from "../../../models/tiles/geometry/jxg-changes";
 import { applyChange, applyChanges } from "../../../models/tiles/geometry/jxg-dispatcher";
 import { kSnapUnit } from "../../../models/tiles/geometry/jxg-point";
@@ -44,7 +44,6 @@ import { ITileExportOptions } from "../../../models/tiles/tile-content-info";
 import { getParentWithTypeName } from "../../../utilities/mst-utils";
 import { safeJsonParse, uniqueId } from "../../../utilities/js-utils";
 import { hasSelectionModifier } from "../../../utilities/event-utils";
-import { getDataSetBounds, IDataSet } from "../../../models/data/data-set";
 import AxisSettingsDialog from "./axis-settings-dialog";
 import { EditableTileTitle } from "../editable-tile-title";
 import LabelSegmentDialog from "./label-segment-dialog";
@@ -583,18 +582,16 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
 
     board.objectsList.forEach((obj: any) => {
       if (obj.elType === "point"){
-        const pointX = obj.coords.usrCoords[1]
-        const pointY = obj.coords.usrCoords[2]
-
+        const pointX = obj.coords.usrCoords[1];
+        const pointY = obj.coords.usrCoords[2];
         // leave a proportional amount of room for title
-        const extraY = Math.abs(pointY) * .15
-
+        const extraY = Math.abs(pointY) * .15;
         if (pointX < xMin) xMin = pointX - 1;
         if (pointX > xMax) xMax = pointX + 1;
         if (pointY < yMin) yMin = pointY - 1;
         if (pointY > yMax) yMax = pointY + 1 + extraY;
       }
-    })
+    });
     return { xMax, yMax, xMin, yMin };
   }
 
@@ -604,19 +601,19 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
 
     this.recreateSharedPoints(board);
 
-    const syncCheck = this.checkCleanJXG(board)
+    const syncCheck = this.checkCleanJXG(board);
     if (syncCheck.jxgMissing.length > 0){
       const modelObjectsToConvert: GeometryObjectModelType[] = [];
       syncCheck.jxgMissing.forEach((o: ObjectSummary) => {
-        const modelObject = this.getContent().getObject(o.id)
-        if (modelObject) modelObjectsToConvert.push(modelObject)
-      })
-      const changesToApply = convertModelObjectsToChanges(modelObjectsToConvert)
-      applyChanges(board, changesToApply)
+        const modelObject = this.getContent().getObject(o.id);
+        if (modelObject) modelObjectsToConvert.push(modelObject);
+      });
+      const changesToApply = convertModelObjectsToChanges(modelObjectsToConvert);
+      applyChanges(board, changesToApply);
     }
 
-    const extents = this.getBoardPointsExtents(board)
-    this.rescaleBoardAndAxes(extents)
+    const extents = this.getBoardPointsExtents(board);
+    this.rescaleBoardAndAxes(extents);
   }
 
   recreateSharedPoints(board: JXG.Board){
@@ -658,15 +655,15 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
     const allJXGObjects = this.getContent().findObjects(board, matchAll);
     allJXGObjects.forEach(o => jxgSummary.push({ id: o.id, type: o.elType }));
 
-    const uniques = uniq(allJXGObjects)
-    const jxgHasRedundancies = allJXGObjects.length > uniques.length
+    const uniques = uniq(allJXGObjects);
+    const jxgHasRedundancies = allJXGObjects.length > uniques.length;
 
     modelSummary.forEach((modelSummaryItem: ObjectSummary) => {
       const foundMatchingJXG = jxgSummary.find((jxgItem: any) => jxgItem.id === modelSummaryItem.id);
       if (!foundMatchingJXG) jxgMissing.push(modelSummaryItem);
     });
 
-    return { jxgMissing, jxgHasRedundancies }
+    return { jxgMissing, jxgHasRedundancies };
   }
 
   private handleArrowKeys = (e: React.KeyboardEvent, keys: string) => {

--- a/src/components/tiles/geometry/geometry-content.tsx
+++ b/src/components/tiles/geometry/geometry-content.tsx
@@ -558,15 +558,15 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
 
   private rescaleBoardAndAxes(params: IAxesParams) {
     const { board } = this.state;
-    if (board) {
-      this.applyChange(() => {
-        const content = this.getContent();
-        const axes = content.rescaleBoard(board, params);
-        if (axes) {
-          axes.forEach(this.handleCreateAxis);
-        }
-      });
-    }
+    if (!board) return;
+
+    this.applyChange(() => {
+      const content = this.getContent();
+      const axes = content.rescaleBoard(board, params);
+      if (axes) {
+        axes.forEach(this.handleCreateAxis);
+      }
+    });
   }
 
   private getBoardPointsExtents(board: JXG.Board){
@@ -579,12 +579,10 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
       if (obj.elType === "point"){
         const pointX = obj.coords.usrCoords[1];
         const pointY = obj.coords.usrCoords[2];
-        // leave a proportional amount of room for title
-        const extraY = Math.abs(pointY) * .15;
         if (pointX < xMin) xMin = pointX - 1;
         if (pointX > xMax) xMax = pointX + 1;
         if (pointY < yMin) yMin = pointY - 1;
-        if (pointY > yMax) yMax = pointY + 1 + extraY;
+        if (pointY > yMax) yMax = pointY + 1;
       }
     });
     return { xMax, yMax, xMin, yMin };


### PR DESCRIPTION
This restores functionality in which polygons, comments, and vertex angle markers made from shared data persist after page reload.  

This restores functionality in which the graph axes rescale as shared points are added and changed, and also accounts for native points so that all points remain in view as data changes and rescales. 

1. `syncLinkedPoints` becomes `syncLinkedGeometry`.  
2. I left in place the functionality that deletes and recreate shared points, but compartmentalized it into a function `recreateSharedPoints`.  I was not able to easily pick out and reconstitute the change objects for cases when one of a set of shared points changes.  
3. It uses `checkCleanJXG` to see if there are any objects in model state that are not in JXG state (and also checks for duplicates, though I have not yet had to handle such a case, as I did not find duplicates before nor after sync)
4. It then leverages an existing `convertModelObjectsToChanges` to create/recreate the model objects (polygons, comments, vertex markers) that need to be synced into JXG state.   
5. `getBoardPointExtents` calculates board min and max values for rescaling, using the JXG board, not the model, and then calls `rescaleBoardAndAxes`  It also makes some extra room at the top so that points in the upper limits of Y don't get lost under the title.