### PR TITLE
feat: Edit Variable dialog displays read-only expressions (PT-183974159)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@concord-consortium/diagram-view": "^0.0.28",
+        "@concord-consortium/diagram-view": "^0.0.29",
         "@concord-consortium/mobx-state-tree": "5.1.5-cc.1",
         "@concord-consortium/react-components": "^0.7.1",
         "@concord-consortium/react-modal-hook": "^3.0.0-cc.1",
@@ -1863,9 +1863,9 @@
       "license": "MIT"
     },
     "node_modules/@concord-consortium/diagram-view": {
-      "version": "0.0.28",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.28.tgz",
-      "integrity": "sha512-hxBC0mMpSykzwzINr72W3KiRw+Gi0lQiYgx0FMfLo/E/HmLNHcVhzfUjJJ32Wi6DbeWD8lFk2VCd/7uCsDOTzQ==",
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.29.tgz",
+      "integrity": "sha512-WZwDt5OrDxfW8e2utkHylwosC9PuQZT10hKVexNqCr/RKnNoqJIk0Y5iF1WR2bW7p2xaGq/b12Hz9TpLu7rUtA==",
       "dependencies": {
         "iframe-phone": "^1.3.1",
         "mathjs": "^10.4.1",
@@ -1874,7 +1874,7 @@
       "peerDependencies": {
         "mobx": "^6.4.2",
         "mobx-react-lite": "^3.3.0",
-        "mobx-state-tree": "^5.1.3",
+        "mobx-state-tree": "5.1.5",
         "nanoid": "^3.3.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -20460,9 +20460,9 @@
       "dev": true
     },
     "@concord-consortium/diagram-view": {
-      "version": "0.0.28",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.28.tgz",
-      "integrity": "sha512-hxBC0mMpSykzwzINr72W3KiRw+Gi0lQiYgx0FMfLo/E/HmLNHcVhzfUjJJ32Wi6DbeWD8lFk2VCd/7uCsDOTzQ==",
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.29.tgz",
+      "integrity": "sha512-WZwDt5OrDxfW8e2utkHylwosC9PuQZT10hKVexNqCr/RKnNoqJIk0Y5iF1WR2bW7p2xaGq/b12Hz9TpLu7rUtA==",
       "requires": {
         "iframe-phone": "^1.3.1",
         "mathjs": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
     "xhr-mock": "^2.5.1"
   },
   "dependencies": {
-    "@concord-consortium/diagram-view": "^0.0.28",
+    "@concord-consortium/diagram-view": "^0.0.29",
     "@concord-consortium/mobx-state-tree": "5.1.5-cc.1",
     "@concord-consortium/react-components": "^0.7.1",
     "@concord-consortium/react-modal-hook": "^3.0.0-cc.1",

--- a/src/hooks/custom-modal.scss
+++ b/src/hooks/custom-modal.scss
@@ -94,6 +94,7 @@ $modal-footer-height: 45px;
     padding: $modal-padding;
 
     .modal-button {
+      cursor: pointer;
       height: $modal-control-height;
       min-width: $modal-button-min-width;
       margin-left: $modal-button-spacing;

--- a/src/plugins/shared-variables/dialog/use-edit-variable-dialog.tsx
+++ b/src/plugins/shared-variables/dialog/use-edit-variable-dialog.tsx
@@ -24,10 +24,13 @@ export const useEditVariableDialog = ({ variable, onClose }: IProps) => {
     Icon: VariableEditorIcon,
     title: "Variable Editor",
     Content: EditVariableDialogContent,
-    contentProps: { variable: variableClone },
+    // Because variableClone is created from a snapshot, it will not have computed values
+    // related to the original variable's inputs. We will need to get those values from the
+    // original variable. So pass both variable and variableClone to EditVariableDialogContent
+    contentProps: { variable, variableClone },
     buttons: [
       { label: "Cancel" },
-      { label: "OK",
+      { label: "Save",
         isDefault: true,
         isDisabled: !variable,
         onClick: handleClick

--- a/src/plugins/shared-variables/dialog/use-new-variable-dialog.tsx
+++ b/src/plugins/shared-variables/dialog/use-new-variable-dialog.tsx
@@ -24,10 +24,10 @@ export const useNewVariableDialog = ({ addVariable, sharedModel, namePrefill, on
     Icon: AddVariableChipIcon,
     title: "New Variable",
     Content: EditVariableDialogContent,
-    contentProps: { variable: newVariable },
+    contentProps: { variableClone: newVariable },
     buttons: [
       { label: "Cancel" },
-      { label: "OK",
+      { label: "Save",
         isDefault: true,
         isDisabled: false,
         onClick: handleClick


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/183974159

These changes will need to be made in light of [these changes](https://github.com/concord-consortium/quantity-playground/pull/58) to the diagram-view variable edit form.