### PR TITLE
handle published image urls in new tile state

### DIFF
--- a/functions/src/get-network-document.ts
+++ b/functions/src/get-network-document.ts
@@ -6,7 +6,7 @@ import { IGetNetworkDocumentUnionParams, isWarmUpParams } from "./shared";
 import { validateUserContext } from "./user-context";
 
 // update this when deploying updates to this function
-const version = "1.0.1";
+const version = "1.0.2";
 
 export async function getNetworkDocument(
                         params?: IGetNetworkDocumentUnionParams,

--- a/functions/src/publish-support.ts
+++ b/functions/src/publish-support.ts
@@ -7,7 +7,7 @@ import { parseFirebaseImageUrl } from "./shared-utils";
 import { validateUserContext } from "./user-context";
 
 // update this when deploying updates to this function
-const version = "1.0.2";
+const version = "1.0.3";
 
 export async function publishSupport(
                         params?: IPublishSupportUnionParams,

--- a/functions/test/parse-document-content.test.ts
+++ b/functions/test/parse-document-content.test.ts
@@ -15,13 +15,30 @@ describe("parseDocumentContent", () => {
     expect(await parseDocumentContent(kEmptyContent, identityCanonicalize)).toEqual({ content: kEmptyContent, images: {} });
   });
 
-  it("should parse a single Image tile with legacy url", async () => {
+  it("should parse a old single Image tile with legacy url", async () => {
     const kClassHash = "class-hash";
     const canonicalUrl = buildFirebaseImageUrl(kClassHash, "image-key");
     const { legacyUrl } = parseFirebaseImageUrl(canonicalUrl);
     const originalContent = specDocumentContent([
       { type: "Image", changes: [{ url: legacyUrl }] }
     ]);
+    const updatedContent = originalContent.replace(legacyUrl, canonicalUrl);
+    const canonicalize = (url: string) => {
+      const { imageKey = "" } = parseFirebaseImageUrl(url);
+      return Promise.resolve(buildFirebaseImageUrl(kClassHash, imageKey));
+    };
+    expect(await parseDocumentContent(originalContent, canonicalize))
+      .toEqual({ content: updatedContent, images: { [legacyUrl]: canonicalUrl } });
+  });
+
+  it("should parse a new single Image tile with legacy url", async () => {
+    const kClassHash = "class-hash";
+    const canonicalUrl = buildFirebaseImageUrl(kClassHash, "image-key");
+    const { legacyUrl } = parseFirebaseImageUrl(canonicalUrl);
+    const originalContent = specDocumentContent([
+      { type: "Image", url: legacyUrl }
+    ]);
+
     const updatedContent = originalContent.replace(legacyUrl, canonicalUrl);
     const canonicalize = (url: string) => {
       const { imageKey = "" } = parseFirebaseImageUrl(url);
@@ -49,7 +66,7 @@ describe("parseDocumentContent", () => {
       .toEqual({ content: updatedContent, images: { [legacyUrl2]: canonicalUrl2 } });
   });
 
-  it("should support multiple images in a Drawing tile", async () => {
+  it("should support multiple images in an old Drawing tile", async () => {
     const kClassHash = "class-hash";
     const canonicalUrl1 = buildFirebaseImageUrl(kClassHash, "image-1");
     const canonicalUrl2 = buildFirebaseImageUrl(kClassHash, "image-2");
@@ -67,13 +84,66 @@ describe("parseDocumentContent", () => {
       .toEqual({ content: updatedContent, images: { [legacyUrl1]: canonicalUrl1, [legacyUrl2]: canonicalUrl2 } });
   });
 
+  it("should support multiple images in an new Drawing tile", async () => {
+    const kClassHash = "class-hash";
+    const canonicalUrl1 = buildFirebaseImageUrl(kClassHash, "image-1");
+    const canonicalUrl2 = buildFirebaseImageUrl(kClassHash, "image-2");
+    const { legacyUrl: legacyUrl1 } = parseFirebaseImageUrl(canonicalUrl1);
+    const { legacyUrl: legacyUrl2 } = parseFirebaseImageUrl(canonicalUrl2);
+    const originalContent = specDocumentContent([
+      { type: "Drawing", objects: [
+        { type: "image", url: legacyUrl1, width: 100, height: 100 },
+        { type: "image", url: legacyUrl2, width: 100, height: 100 }
+      ]}
+    ]);
+    const updatedContent = originalContent.replace(legacyUrl1, canonicalUrl1).replace(legacyUrl2, canonicalUrl2);
+    const canonicalize = (url: string) => {
+      const { imageKey = "" } = parseFirebaseImageUrl(url);
+      return Promise.resolve(buildFirebaseImageUrl(kClassHash, imageKey));
+    };
+    expect(await parseDocumentContent(originalContent, canonicalize))
+      .toEqual({ content: updatedContent, images: { [legacyUrl1]: canonicalUrl1, [legacyUrl2]: canonicalUrl2 } });
+  });
+
+  it("should support an image in an new Geometry tile", async () => {
+    const kClassHash = "class-hash";
+    const canonicalUrl1 = buildFirebaseImageUrl(kClassHash, "image-1");
+    const { legacyUrl: legacyUrl1 } = parseFirebaseImageUrl(canonicalUrl1);
+    const originalContent = specDocumentContent([
+      { type: "Geometry",
+        board: {
+          xAxis: { name: "x", label: "x", min: -2, unit: 18.3, range: 26.2 },
+          yAxis: { name: "y", label: "y", min: -1, unit: 18.3, range: 17.5 }
+        },
+        bgImage: { type: "image", id: "WlCWbMo8jT79iCkO", x: 0, y: 0,
+                   url: legacyUrl1, width: 27.3, height: 23.8
+        },
+        objects: {}
+      }
+    ]);
+    const updatedContent = originalContent.replace(legacyUrl1, canonicalUrl1);
+    const canonicalize = (url: string) => {
+      const { imageKey = "" } = parseFirebaseImageUrl(url);
+      return Promise.resolve(buildFirebaseImageUrl(kClassHash, imageKey));
+    };
+    expect(await parseDocumentContent(originalContent, canonicalize))
+      .toEqual({ content: updatedContent, images: { [legacyUrl1]: canonicalUrl1 } });
+  });
+
   it("should support multiple images in multiple tiles", async () => {
     const kClassHash = "class-hash";
-    const canonicalUrls = [1, 2, 3].map(i => buildFirebaseImageUrl(kClassHash, `image-${i}`));
+    const canonicalUrls = [0, 1, 2, 3, 4, 5].map(i => buildFirebaseImageUrl(kClassHash, `image-${i}`));
     const legacyUrls = canonicalUrls.map(url => parseFirebaseImageUrl(url).legacyUrl);
+    const unconvertedCanonicalUrl = buildFirebaseImageUrl(kClassHash, "image-unconverted");
+    const unconvertedLegacyUrl = parseFirebaseImageUrl(unconvertedCanonicalUrl).legacyUrl;
     const originalContent = specDocumentContent([
       { type: "Drawing", changes: [{ url: legacyUrls[0] }, { url: legacyUrls[1] }] },
-      { type: "Image", changes: [{ url: legacyUrls[0] }, { url: legacyUrls[2] }] }
+      { type: "Drawing", objects: [
+        { type: "image", url: legacyUrls[2], width: 100, height: 100 },
+        { type: "image", url: legacyUrls[3], width: 100, height: 100 }
+      ]},
+      { type: "Image", changes: [{ url: unconvertedLegacyUrl }, { url: legacyUrls[4] }] },
+      { type: "Image", url: legacyUrls[5] }
     ]);
     let updatedContent = originalContent;
     const images: Record<string, string> = {};

--- a/functions/test/parse-document-content.test.ts
+++ b/functions/test/parse-document-content.test.ts
@@ -15,7 +15,7 @@ describe("parseDocumentContent", () => {
     expect(await parseDocumentContent(kEmptyContent, identityCanonicalize)).toEqual({ content: kEmptyContent, images: {} });
   });
 
-  it("should parse a old single Image tile with legacy url", async () => {
+  it("should parse an old single Image tile with legacy url", async () => {
     const kClassHash = "class-hash";
     const canonicalUrl = buildFirebaseImageUrl(kClassHash, "image-key");
     const { legacyUrl } = parseFirebaseImageUrl(canonicalUrl);
@@ -84,7 +84,7 @@ describe("parseDocumentContent", () => {
       .toEqual({ content: updatedContent, images: { [legacyUrl1]: canonicalUrl1, [legacyUrl2]: canonicalUrl2 } });
   });
 
-  it("should support multiple images in an new Drawing tile", async () => {
+  it("should support multiple images in a new Drawing tile", async () => {
     const kClassHash = "class-hash";
     const canonicalUrl1 = buildFirebaseImageUrl(kClassHash, "image-1");
     const canonicalUrl2 = buildFirebaseImageUrl(kClassHash, "image-2");
@@ -105,7 +105,7 @@ describe("parseDocumentContent", () => {
       .toEqual({ content: updatedContent, images: { [legacyUrl1]: canonicalUrl1, [legacyUrl2]: canonicalUrl2 } });
   });
 
-  it("should support an image in an new Geometry tile", async () => {
+  it("should support an image in a new Geometry tile", async () => {
     const kClassHash = "class-hash";
     const canonicalUrl1 = buildFirebaseImageUrl(kClassHash, "image-1");
     const { legacyUrl: legacyUrl1 } = parseFirebaseImageUrl(canonicalUrl1);

--- a/functions/test/publish-support.test.ts
+++ b/functions/test/publish-support.test.ts
@@ -184,8 +184,11 @@ describe("publishSupport", () => {
     const canonicalUrls = [1, 2, 3].map(i => buildFirebaseImageUrl(kClassHash, `image-${i}`));
     const legacyUrls = canonicalUrls.map(url => parseFirebaseImageUrl(url).legacyUrl);
     const content = specDocumentContent([
-      { type: "Drawing", changes: [{ url: legacyUrls[0] }, { url: legacyUrls[1] }] },
-      { type: "Image", changes: [{ url: legacyUrls[0] }, { url: legacyUrls[2] }] }
+      { type: "Drawing", objects: [
+        { type: "image", url: legacyUrls[0], width: 100, height: 100 },
+        { type: "image", url: legacyUrls[1], width: 100, height: 100 }
+      ]},
+      { type: "Image", url: legacyUrls[2] }
     ]);
     const specSupportDoc = specPublicationRequest({ add: { content } });
     const params: IPublishSupportParams = { context, ...specSupportDoc };
@@ -238,8 +241,11 @@ describe("publishSupport", () => {
     });
     await Promise.all(imagePromises);
     const content = specDocumentContent([
-        { type: "Drawing", changes: [{ url: legacyUrls[0] }, { url: legacyUrls[1] }] },
-        { type: "Image", changes: [{ url: legacyUrls[0] }, { url: legacyUrls[2] }] }
+        { type: "Drawing", objects: [
+          { type: "image", url: legacyUrls[0], width: 100, height: 100 },
+          { type: "image", url: legacyUrls[1], width: 100, height: 100 }
+        ]},
+        { type: "Image", url: legacyUrls[2] }
       ]);
     const specSupportDoc = specPublicationRequest({ add: { content } });
     const params: IPublishSupportParams = { context, ...specSupportDoc };

--- a/functions/test/test-utils.ts
+++ b/functions/test/test-utils.ts
@@ -110,15 +110,32 @@ export const specAuth = (overrides?: DeepPartial<AuthData>, exclude?: string[]):
   };
 };
 
-export function specDocumentContent(tiles: Array<{ type: string, changes: Object[] }> = []) {
+interface ITileSpec {
+  type: string;
+  changes?: Object[];
+  [otherProperties: string]: unknown;
+}
+
+/**
+ * This will generate a document content from an array of tiles If the tile
+ * contains a `changes` property it will be converted to strings. This `changes`
+ * property was used in the old state format of tiles.
+ *
+ * @param tiles
+ * @returns
+ */
+export function specDocumentContent(tiles: Array<ITileSpec> = []) {
   const rowMap: Record<string, IRowMapEntry> = {};
   const rowOrder: string[] = [];
   const tileMap: Record<string, ITileMapEntry> = {};
   tiles.forEach((tile, i) => {
     // single tile per row for simplicity
-    const tileId = `tile-${i}`
-    const tileChanges = tile.changes.map(change => JSON.stringify(change));
-    const tileContent = { type: tile.type, changes: tileChanges };
+    const tileId = `tile-${i}`;
+    const tileContent = tile;
+    if (tile.changes) {
+      const tileChanges = tile.changes.map(change => JSON.stringify(change));
+      tile.changes = tileChanges;
+    }
     const row: IRowMapEntry = { id: `row-${i}`, tiles: [{ tileId }]};
     rowMap[row.id] = row;
     rowOrder.push(row.id);


### PR DESCRIPTION
This should fix part of the image issue that we've been seeing: PT-184215310

There are 2 more parts that need to fixed:
- there needs to be a migration which finds all of the images that were not "published" correctly.
- there is still the possibility that a document will be loaded by a teacher before the teacher's network is known by CLUE. And if the teacher can only access the images in the document because of this network, the images will not be loaded correctly.

For the migration, I think I can basically use the existing image migration script. It does more than necessary, but I think it will correctly find any unpublished images and publish them.