### PR TITLE
fix: Edit Variable dialog displays read only expressions (PT-183974159)

### DIFF
--- a/src/hooks/use-custom-modal.tsx
+++ b/src/hooks/use-custom-modal.tsx
@@ -49,7 +49,7 @@ export const useCustomModal = <IContentProps,>({
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Enter") {
+      if (e.key === "Enter" && !(e.target instanceof HTMLTextAreaElement)) {
         const defaultButton = buttons.find(b => b.isDefault);
         if (defaultButton && !defaultButton.isDisabled) {
           blurModal();


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/183974159

This fixes two issues related to [this previous PR](https://github.com/concord-consortium/collaborative-learning/pull/1566)

1) If changes were made in the edit dialog form but not saved, the changed values could reappear in the edit form.

2) Hitting the Return/Enter key while typing in a textarea in the edit dialog would cause the dialog to close.

