### PR TITLE
Update diagram-view to latest version -- 0.0.32

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@concord-consortium/diagram-view": "^0.0.31",
+        "@concord-consortium/diagram-view": "^0.0.32",
         "@concord-consortium/mobx-state-tree": "5.1.5-cc.1",
         "@concord-consortium/react-components": "^0.7.1",
         "@concord-consortium/react-modal-hook": "^3.0.0-cc.1",
@@ -1863,9 +1863,9 @@
       "license": "MIT"
     },
     "node_modules/@concord-consortium/diagram-view": {
-      "version": "0.0.31",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.31.tgz",
-      "integrity": "sha512-eM2+l1Miz2pBldzxupUF+zxqpcmsu3Hot1D4dJ57QwPghtNvbtLBthbMEDgL1vmpWTiyAeYZJOzHoYXm01RGtA==",
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.32.tgz",
+      "integrity": "sha512-PkZz0zwfSmCDd1i9PjkKgmdD4fI8oBGQSR29hKk3MDzBmqt2H7Z2WSXGgnuFq5N17AERpQHKdtK3RxyCzr6dnQ==",
       "dependencies": {
         "iframe-phone": "^1.3.1",
         "mathjs": "^10.4.1",
@@ -20460,9 +20460,9 @@
       "dev": true
     },
     "@concord-consortium/diagram-view": {
-      "version": "0.0.31",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.31.tgz",
-      "integrity": "sha512-eM2+l1Miz2pBldzxupUF+zxqpcmsu3Hot1D4dJ57QwPghtNvbtLBthbMEDgL1vmpWTiyAeYZJOzHoYXm01RGtA==",
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.32.tgz",
+      "integrity": "sha512-PkZz0zwfSmCDd1i9PjkKgmdD4fI8oBGQSR29hKk3MDzBmqt2H7Z2WSXGgnuFq5N17AERpQHKdtK3RxyCzr6dnQ==",
       "requires": {
         "iframe-phone": "^1.3.1",
         "mathjs": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
     "xhr-mock": "^2.5.1"
   },
   "dependencies": {
-    "@concord-consortium/diagram-view": "^0.0.31",
+    "@concord-consortium/diagram-view": "^0.0.32",
     "@concord-consortium/mobx-state-tree": "5.1.5-cc.1",
     "@concord-consortium/react-components": "^0.7.1",
     "@concord-consortium/react-modal-hook": "^3.0.0-cc.1",


### PR DESCRIPTION
[Release notes for diagram-view 0.0.32](https://github.com/concord-consortium/quantity-playground/releases/tag/diagram-view-0.0.32)