### PR TITLE
removes teacher dashboard group header support button

### DIFF
--- a/src/clue/components/teacher/teacher-group-six-pack-fourup.sass
+++ b/src/clue/components/teacher/teacher-group-six-pack-fourup.sass
@@ -16,12 +16,6 @@
         height: 30px
       &:hover
         background-color: hsla(1, 0%, 0%, 0.1)
-      .support
-        background-image: url("../../../assets/icons/support/support.svg")
-        &:hover
-          background-image: url("../../../assets/icons/support/support-hover.svg")
-        &:active
-          background-image: url("../../../assets/icons/support/support-active.svg")
       .expand-group-view
         background-image: url("../../../assets/icons/clue-dashboard/expand-group-view.svg")
       .sticky-note

--- a/src/clue/components/teacher/teacher-group-six-pack-fourup.tsx
+++ b/src/clue/components/teacher/teacher-group-six-pack-fourup.tsx
@@ -81,11 +81,6 @@ export class TeacherGroupSixPackFourUp extends BaseComponent<IProps, IState> {
         }
       };
 
-      const showGroupSupportClickHandler = () => {
-        Logger.log(LogEventName.VIEW_GROUP, {group: group.id, via: "dashboard-show-comparison-group"});
-        ui.setTeacherPanelKey(EPanelId.workspace);
-        ui.setActiveStudentGroup(group.id);
-      };
 
       return(
         <div className="group-header">
@@ -97,12 +92,6 @@ export class TeacherGroupSixPackFourUp extends BaseComponent<IProps, IState> {
               icon="sticky-note"
               key={`sticky-note-${focusedGroupUser ? `user-${focusedGroupUser.id}` : "group"}`}
               onClickButton={messageClickHandler} />
-            <IconButton
-              title="Support"
-              className="icon"
-              icon="support"
-              key="support"
-              onClickButton={showGroupSupportClickHandler} />
           </div>
         </div>
       );

--- a/src/clue/components/teacher/teacher-group-six-pack-fourup.tsx
+++ b/src/clue/components/teacher/teacher-group-six-pack-fourup.tsx
@@ -1,6 +1,5 @@
 import { inject, observer } from "mobx-react";
 import React from "react";
-import { EPanelId } from "../../../components/app-header";
 import { BaseComponent, IBaseProps } from "../../../components/base";
 import { DocumentViewMode } from "../../../components/document/document";
 import { FourUpComponent } from "../../../components/four-up";


### PR DESCRIPTION
This removes the teacher support button and associated styles and click handler as described in pivotal story #183368003. 