### PR TITLE
fix: New variable dialog creates two undoable actions (PT-184406182)

### DIFF
--- a/src/plugins/shared-variables/dialog/use-new-variable-dialog.tsx
+++ b/src/plugins/shared-variables/dialog/use-new-variable-dialog.tsx
@@ -1,22 +1,30 @@
 import { useState, useCallback } from "react";
-import { useCustomModal } from "../../../hooks/use-custom-modal";
 import { EditVariableDialogContent, Variable, VariableType } from "@concord-consortium/diagram-view";
 
-import AddVariableChipIcon from "../assets/add-variable-chip-icon.svg";
-import './variable-dialog.scss';
+import { useCustomModal } from "../../../hooks/use-custom-modal";
 import { SharedVariablesType } from "../shared-variables";
+import AddVariableChipIcon from "../assets/add-variable-chip-icon.svg";
+
+import './variable-dialog.scss';
 
 interface IUseNewVariableDialog {
   addVariable: (variable: VariableType ) => void;
   sharedModel?: SharedVariablesType;
-  namePrefill? : string;
+  namePrefill?: string;
+  noUndo?: boolean;
   onClose?: () => void;
 }
-export const useNewVariableDialog = ({ addVariable, sharedModel, namePrefill, onClose }: IUseNewVariableDialog) => {
+export const useNewVariableDialog = ({
+  addVariable, sharedModel, namePrefill, noUndo = false, onClose
+}: IUseNewVariableDialog) => {
   const [newVariable, setNewVariable] = useState(Variable.create({name: namePrefill || undefined}));
 
   const handleClick = () => {
-    sharedModel?.addAndInsertVariable(newVariable, (variable: VariableType) => addVariable(variable));
+    sharedModel?.addAndInsertVariable(
+      newVariable,
+      (variable: VariableType) => addVariable(variable),
+      noUndo
+    );
     setNewVariable(Variable.create({name: namePrefill || undefined}));
   };
 

--- a/src/plugins/shared-variables/shared-variables.ts
+++ b/src/plugins/shared-variables/shared-variables.ts
@@ -27,6 +27,16 @@ export const SharedVariables = SharedModel.named("SharedVariables")
     insertVariable: (variable: VariableType) => void,
     noUndo?: boolean
   ) {
+    // In some cases, adding and inserting a new variable can add two undo steps to the undo stack,
+    // leading to unexpected behavior. The noUndo flag is available to prevent a second undo step by
+    // triggering a call to withoutUndo here when it is set to true.
+    //
+    // In the case of the text tile, for example, adding a new variable would add undo steps for both 
+    // the related call to setSlate and to addAndInsertVariable. The undo step for setSlate would be
+    // added before the one for addAndInsertVariable. So after adding a new variable to a text tile
+    // and then clicking undo, the variable was deleted but its chip in the text editor was replaced
+    // with an "invalid reference: [variable ID]" error because the text editor still contained a
+    // reference to the variable that no longer existed.
     if (noUndo) withoutUndo();
     self.addVariable(variable);
     const addedVariable = self.variables.find(v => v === variable);

--- a/src/plugins/shared-variables/shared-variables.ts
+++ b/src/plugins/shared-variables/shared-variables.ts
@@ -24,7 +24,7 @@ export const SharedVariables = SharedModel.named("SharedVariables")
 .actions(self => ({
   addAndInsertVariable(
     variable: VariableType,
-    insertVariable: (variable: VariableType, x?: number, y?: number) => void,
+    insertVariable: (variable: VariableType) => void,
     noUndo?: boolean
   ) {
     if (noUndo) withoutUndo();

--- a/src/plugins/shared-variables/shared-variables.ts
+++ b/src/plugins/shared-variables/shared-variables.ts
@@ -1,6 +1,7 @@
 import { destroy, Instance, types } from "mobx-state-tree";
 import { Variable, VariableType } from "@concord-consortium/diagram-view";
 import { SharedModel } from "../../models/shared/shared-model";
+import { withoutUndo } from "../../models/history/without-undo";
 
 export const kSharedVariablesID = "SharedVariables";
 
@@ -21,7 +22,12 @@ export const SharedVariables = SharedModel.named("SharedVariables")
   }
 }))
 .actions(self => ({
-  addAndInsertVariable(variable: VariableType, insertVariable: (variable: VariableType) => void) {
+  addAndInsertVariable(
+    variable: VariableType,
+    insertVariable: (variable: VariableType, x?: number, y?: number) => void,
+    noUndo?: boolean
+  ) {
+    if (noUndo) withoutUndo();
     self.addVariable(variable);
     const addedVariable = self.variables.find(v => v === variable);
     if (addedVariable) {

--- a/src/plugins/shared-variables/slate/text-tile-buttons.tsx
+++ b/src/plugins/shared-variables/slate/text-tile-buttons.tsx
@@ -97,6 +97,7 @@ export const NewVariableTextButton = observer(function NewVariableTextButton(
       insertTextVariable(variable, editor);
     },
     sharedModel, namePrefill,
+    noUndo: true,
     onClose: () => handleClose(editor)
   });
   const handleClick = (event: React.MouseEvent) => {


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/184406182

Adds a `noUndo` option to SharedVariable's `addAndInsertVariable` action. The new option is used to determine if `withoutUndo` should be called for the action.

In some cases (e.g., adding a new variable to a text tile), using the `addAndInsertVariable` action can result in two undoable actions being added to the undo history which can lead to confusing and unexpected behavior. Passing `true` for the `noUndo` option ensures that only one undo action is added to the undo history, preventing the unexpected behavior.