### PR TITLE
fix: Undo of diagram tile variable card creation crashes CLUE (PT-184375871)

### DIFF
--- a/cypress/e2e/clue/branch/student_tests/diagram_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/diagram_tool_spec.js
@@ -96,16 +96,12 @@ context('Diagram Tool Tile', function () {
       diagramTile.getDiagramDialogCloseButton().click();
 
       // Can drag new variable button to create a new variable card
-      // TODO Couldn't figure out how to test dragging
-      const skipDragTest = true;
-      if (!skipDragTest) {
-        const dataTransfer = new DataTransfer;
-        const draggable = () => diagramTile.getDiagramToolbar(undefined, true).find("div").first();
-        draggable().trigger("dragstart", { dataTransfer });
-        diagramTile.getDiagramTile().trigger("drop", { force: true, dataTransfer });
-        draggable().trigger("dragend");
-        diagramTile.getVariableCard().should("exist");
-      }
+      const dataTransfer = new DataTransfer;
+      const draggable = () => diagramTile.getDiagramToolbar(undefined, true).find("div[role=button]").first();
+      draggable().focus().trigger("dragstart", { dataTransfer });
+      diagramTile.getDiagramTile().trigger("drop", { dataTransfer });
+      draggable().trigger("dragend");
+      diagramTile.getVariableCard().should("exist");
     });
 
     it("Drawing tile, toolbar, dialogs, and interactions between tiles", () => {

--- a/src/plugins/diagram-viewer/diagram-tile.tsx
+++ b/src/plugins/diagram-viewer/diagram-tile.tsx
@@ -98,12 +98,12 @@ export const DiagramToolComponent: React.FC<ITileProps> = observer((
         const clientX = pointerEvent.clientX + event.delta.x;
         const clientY = pointerEvent.clientY + event.delta.y;
         const position = diagramHelper?.convertClientToDiagramPosition({x: clientX, y: clientY});
-        const x = position.x;
-        const y = position.y;
 
         const variable = Variable.create({});
-        content.sharedModel?.addVariable(variable);
-        insertVariable(variable, x, y);
+        content.sharedModel?.addAndInsertVariable(
+          variable,
+          (v: VariableType, x?: number, y?: number) => insertVariable(variable, position.x, position.y)
+        );
       }
     }
   });

--- a/src/plugins/diagram-viewer/diagram-tile.tsx
+++ b/src/plugins/diagram-viewer/diagram-tile.tsx
@@ -98,11 +98,12 @@ export const DiagramToolComponent: React.FC<ITileProps> = observer((
         const clientX = pointerEvent.clientX + event.delta.x;
         const clientY = pointerEvent.clientY + event.delta.y;
         const position = diagramHelper?.convertClientToDiagramPosition({x: clientX, y: clientY});
+        const { x, y } = position;
 
         const variable = Variable.create({});
         content.sharedModel?.addAndInsertVariable(
           variable,
-          (v: VariableType, x?: number, y?: number) => insertVariable(variable, position.x, position.y)
+          (v: VariableType) => insertVariable(variable, x, y)
         );
       }
     }

--- a/src/plugins/shared-variables/shared-variables.ts
+++ b/src/plugins/shared-variables/shared-variables.ts
@@ -24,7 +24,7 @@ export const SharedVariables = SharedModel.named("SharedVariables")
 .actions(self => ({
   addAndInsertVariable(
     variable: VariableType,
-    insertVariable: (variable: VariableType, x?: number, y?: number) => void,
+    insertVariable: (variable: VariableType) => void,
     noUndo?: boolean
   ) {
     // In some cases, adding and inserting a new variable can add two undo steps to the undo stack,

--- a/src/plugins/shared-variables/shared-variables.ts
+++ b/src/plugins/shared-variables/shared-variables.ts
@@ -24,7 +24,7 @@ export const SharedVariables = SharedModel.named("SharedVariables")
 .actions(self => ({
   addAndInsertVariable(
     variable: VariableType,
-    insertVariable: (variable: VariableType) => void,
+    insertVariable: (variable: VariableType, x?: number, y?: number) => void,
     noUndo?: boolean
   ) {
     // In some cases, adding and inserting a new variable can add two undo steps to the undo stack,


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/184375871

Per comments in the PT story, although recent work fixed the crash caused by undoing adding a new variable to a diagram tile using the New Variable dialog, the diagram tile's drag-and-drop monitor was still using the `addVariable` action which can cause problems when using the Undo feature. These changes update the drag-and-drop monitor to use the `addAndInsertVariable` action instead like the New Variable dialog does.