### PR TITLE
fix: Undo in drawing tile undoes action in diagram tile (PT-184280949)

### DIFF
--- a/cypress/e2e/clue/branch/student_tests/diagram_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/diagram_tool_spec.js
@@ -109,11 +109,11 @@ context('Diagram Tool Tile', function () {
       draggable().trigger("dragend");
       diagramTile.getVariableCard().should("exist");
 
-      // Can undo previous step by pressing cmd-z on the keyboard
+      // Can undo previous step by pressing control+z or command+z on the keyboard
       cy.get("body").type(undoKeystroke);
       diagramTile.getVariableCard().should("not.exist");
 
-      // Can redo previous step by pressing cmd-shift-z on the keyboard
+      // Can redo previous step by pressing control+shift+z or command+shift+z on the keyboard
       cy.get("body").type(redoKeystroke);
       diagramTile.getVariableCard().should("exist");
     });
@@ -201,8 +201,8 @@ context('Diagram Tool Tile', function () {
       drawTile.getVariableChip().click();
       drawTile.getDrawToolDelete().click();
 
-      // Undoing previous step in diagram tile by pressing cmd-z on the keyboard
-      // does not undo the most recent step in a different tile
+      // Undoing previous step in diagram tile by pressing control+z or command+z on
+      // the keyboard does not undo the most recent step in a different tile
       diagramTile.getDiagramTile().click();
       diagramTile.getVariableCardField("name").should("have.value", newName);
       diagramTile.getVariableCardField("name").clear();

--- a/cypress/e2e/clue/branch/student_tests/diagram_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/diagram_tool_spec.js
@@ -7,6 +7,11 @@ let clueCanvas = new ClueCanvas,
   diagramTile = new DiagramToolTile,
   drawTile = new DrawToolTile,
   textTile = new TextToolTile;
+  
+const isMac = navigator.platform.indexOf("Mac") === 0;
+const cmdKey = isMac ? "cmd" : "ctrl";
+const undoKeystroke = `{${cmdKey}}z`;
+const redoKeystroke = `{${cmdKey}}{shift}z`;
 
 context('Diagram Tool Tile', function () {
   const dialogField = (field) => cy.get(`#evd-${field}`);
@@ -106,11 +111,11 @@ context('Diagram Tool Tile', function () {
       diagramTile.getVariableCard().should("exist");
 
       // Can undo previous step by pressing cmd-z on the keyboard
-      cy.get("body").type("{cmd}z");
+      cy.get("body").type(undoKeystroke);
       diagramTile.getVariableCard().should("not.exist");
 
       // Can redo previous step by pressing cmd-shift-z on the keyboard
-      cy.get("body").type("{cmd}{shift}z");
+      cy.get("body").type(redoKeystroke);
       diagramTile.getVariableCard().should("exist");
     });
 
@@ -204,7 +209,7 @@ context('Diagram Tool Tile', function () {
       diagramTile.getVariableCardField("name").clear();
       textTile.getTextTile().click();
       textTile.enterText("Hello");
-      cy.get("body").type("{cmd}z");
+      cy.get("body").type(undoKeystroke);
       diagramTile.getVariableCardField("name").should("have.value", "");
       textTile.getTextTile().should("contain", "Hell");
     });

--- a/cypress/e2e/clue/branch/student_tests/diagram_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/diagram_tool_spec.js
@@ -201,16 +201,14 @@ context('Diagram Tool Tile', function () {
 
       // Undoing previous step in diagram tile by pressing cmd-z on the keyboard
       // does not undo the most recent step in a different tile
-      textTile.getTextTile().click();
-      textTile.enterText("Hello");
       diagramTile.getDiagramTile().click();
       diagramTile.getVariableCardField("name").should("have.value", newName);
       diagramTile.getVariableCardField("name").clear();
-      diagramTile.getVariableCardField("name").should("have.value", "");
+      textTile.getTextTile().click();
+      textTile.enterText("Hello");
       cy.get("body").type("{cmd}z");
-      cy.get("body").type("{ctrl}z");
-      diagramTile.getVariableCardField("name").should("have.value", newName);
-      textTile.getTextTile().should('contain', 'Hello');
+      diagramTile.getVariableCardField("name").should("have.value", "");
+      textTile.getTextTile().should("contain", "Hell");
     });
   });
 });

--- a/cypress/e2e/clue/branch/student_tests/diagram_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/diagram_tool_spec.js
@@ -7,9 +7,8 @@ let clueCanvas = new ClueCanvas,
   diagramTile = new DiagramToolTile,
   drawTile = new DrawToolTile,
   textTile = new TextToolTile;
-  
-const isMac = navigator.platform.indexOf("Mac") === 0;
-const cmdKey = isMac ? "cmd" : "ctrl";
+
+const cmdKey = Cypress.platform === "darwin" ? "cmd" : "ctrl";
 const undoKeystroke = `{${cmdKey}}z`;
 const redoKeystroke = `{${cmdKey}}{shift}z`;
 

--- a/cypress/e2e/clue/branch/student_tests/diagram_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/diagram_tool_spec.js
@@ -107,10 +107,12 @@ context('Diagram Tool Tile', function () {
 
       // Can undo previous step by pressing cmd-z on the keyboard
       cy.get("body").type("{cmd}z");
+      cy.get("body").type("{ctrl}z");
       diagramTile.getVariableCard().should("not.exist");
 
       // Can redo previous step by pressing cmd-shift-z on the keyboard
       cy.get("body").type("{cmd}{shift}z");
+      cy.get("body").type("{ctrl}{shift}z");
       diagramTile.getVariableCard().should("exist");
     });
 
@@ -206,6 +208,7 @@ context('Diagram Tool Tile', function () {
       diagramTile.getVariableCardField("name").clear();
       diagramTile.getVariableCardField("name").should("have.value", "");
       cy.get("body").type("{cmd}z");
+      cy.get("body").type("{ctrl}z");
       diagramTile.getVariableCardField("name").should("have.value", newName);
       textTile.getTextTile().should('contain', 'Hello');
     });

--- a/cypress/e2e/clue/branch/student_tests/diagram_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/diagram_tool_spec.js
@@ -1,10 +1,12 @@
 import ClueCanvas from '../../../../support/elements/clue/cCanvas';
 import DiagramToolTile from '../../../../support/elements/clue/DiagramToolTile';
 import DrawToolTile from '../../../../support/elements/clue/DrawToolTile';
+import TextToolTile from '../../../../support/elements/clue/TextToolTile';
 
 let clueCanvas = new ClueCanvas,
   diagramTile = new DiagramToolTile,
-  drawTile = new DrawToolTile;
+  drawTile = new DrawToolTile,
+  textTile = new TextToolTile;
 
 context('Diagram Tool Tile', function () {
   const dialogField = (field) => cy.get(`#evd-${field}`);
@@ -102,11 +104,20 @@ context('Diagram Tool Tile', function () {
       diagramTile.getDiagramTile().trigger("drop", { dataTransfer });
       draggable().trigger("dragend");
       diagramTile.getVariableCard().should("exist");
+
+      // Can undo previous step by pressing cmd-z on the keyboard
+      cy.get("body").type("{cmd}z");
+      diagramTile.getVariableCard().should("not.exist");
+
+      // Can redo previous step by pressing cmd-shift-z on the keyboard
+      cy.get("body").type("{cmd}{shift}z");
+      diagramTile.getVariableCard().should("exist");
     });
 
-    it("Drawing tile, toolbar, dialogs, and interactions between tiles", () => {
+    it("Drawing tile, text tile, toolbar, dialogs, and interactions between tiles", () => {
       clueCanvas.addTile("diagram");
       clueCanvas.addTile("drawing");
+      clueCanvas.addTile("text");
 
       // Draw tile and toolbar buttons render
       drawTile.getDrawTile().should("exist");
@@ -114,10 +125,15 @@ context('Diagram Tool Tile', function () {
       drawTile.getDrawToolEditVariable().should("exist").should("be.disabled");
       drawTile.getDrawToolInsertVariable().should("exist").should("be.disabled");
 
+      // Text tile and editor render
+      textTile.getTextTile().should("exist");
+      textTile.getTextEditor().should("exist");
+
       // New variable dialog works
       const vName = "variable-name";
       const vValue = "1.2";
       const vUnit = "meter";
+      drawTile.getDrawTile().click();
       drawTile.getDrawToolNewVariable().click();
       cy.get(".custom-modal").should("exist");
       dialogField("name").type(vName);
@@ -180,6 +196,18 @@ context('Diagram Tool Tile', function () {
       drawTile.getVariableChip().should("exist");
       drawTile.getVariableChip().click();
       drawTile.getDrawToolDelete().click();
+
+      // Undoing previous step in diagram tile by pressing cmd-z on the keyboard
+      // does not undo the most recent step in a different tile
+      textTile.getTextTile().click();
+      textTile.enterText("Hello");
+      diagramTile.getDiagramTile().click();
+      diagramTile.getVariableCardField("name").should("have.value", newName);
+      diagramTile.getVariableCardField("name").clear();
+      diagramTile.getVariableCardField("name").should("have.value", "");
+      cy.get("body").type("{cmd}z");
+      diagramTile.getVariableCardField("name").should("have.value", newName);
+      textTile.getTextTile().should('contain', 'Hello');
     });
   });
 });

--- a/cypress/e2e/clue/branch/student_tests/diagram_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/diagram_tool_spec.js
@@ -107,12 +107,10 @@ context('Diagram Tool Tile', function () {
 
       // Can undo previous step by pressing cmd-z on the keyboard
       cy.get("body").type("{cmd}z");
-      cy.get("body").type("{ctrl}z");
       diagramTile.getVariableCard().should("not.exist");
 
       // Can redo previous step by pressing cmd-shift-z on the keyboard
       cy.get("body").type("{cmd}{shift}z");
-      cy.get("body").type("{ctrl}{shift}z");
       diagramTile.getVariableCard().should("exist");
     });
 

--- a/src/components/document/canvas.tsx
+++ b/src/components/document/canvas.tsx
@@ -166,14 +166,14 @@ export class CanvasComponent extends BaseComponent<IProps, IState> {
     json && navigator.clipboard.writeText(json);
   };
 
-  private handleDocumentUndo = (e: React.KeyboardEvent) => {
-    e.preventDefault();
+  private handleDocumentUndo = () => {
     this.props.document?.undoLastAction();
+    return true;
   };
 
-  private handleDocumentRedo = (e: React.KeyboardEvent) => {
-    e.preventDefault();
+  private handleDocumentRedo = () => {
     this.props.document?.redoLastAction();
+    return true;
   };
 
   private handleTogglePlaybackControlComponent = () => {

--- a/src/components/document/canvas.tsx
+++ b/src/components/document/canvas.tsx
@@ -166,11 +166,13 @@ export class CanvasComponent extends BaseComponent<IProps, IState> {
     json && navigator.clipboard.writeText(json);
   };
 
-  private handleDocumentUndo = () => {
+  private handleDocumentUndo = (e: React.KeyboardEvent) => {
+    e.preventDefault();
     this.props.document?.undoLastAction();
   };
 
-  private handleDocumentRedo = () => {
+  private handleDocumentRedo = (e: React.KeyboardEvent) => {
+    e.preventDefault();
     this.props.document?.redoLastAction();
   };
 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/184280949

This problem could happen with other tile/action combinations. For example, if you typed text into a text tile, then changed a drawing, undoing the drawing change would also undo the text tile change.

The reason for that was we were still allowing the browser's default handling of cmd+z and cmd+shift+z to occur in addition to our custom undo and redo handlers. These changes make sure we prevent the default.