### PR TITLE
fix: Changes to variable cards not saved unless click away (PT-184474083)

### DIFF
--- a/src/plugins/shared-variables/dialog/use-edit-variable-dialog.tsx
+++ b/src/plugins/shared-variables/dialog/use-edit-variable-dialog.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { getSnapshot } from "mobx-state-tree";
 import { EditVariableDialogContent, updateVariable, Variable, VariableType } from "@concord-consortium/diagram-view";
 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/184474083

These changes fix a problem with creating `variableClone` from `variable` that was causing the edit dialog to contain stale values. `variable` is included in the dependency array of the call to useMemo used for `variableClone`, but because useMemo only does a shallow comparison of objects, changes to `variable`'s properties in the variable cards were not triggering an update of `variableClone`.

To fix that, we modified the solution included in [these changes to fix how edited values in the dialog remained after the dialog's Cancel button was clicked](https://github.com/concord-consortium/collaborative-learning/pull/1576). The main change is to increment `count` when the modal is opened instead of when it's closed. This can cause a duplicate render, but for the time being that was determined to be an acceptable tradeoff.