### PR TITLE
Update diagram-view to latest version -- 0.0.34

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@concord-consortium/diagram-view": "^0.0.33",
+        "@concord-consortium/diagram-view": "^0.0.34",
         "@concord-consortium/mobx-state-tree": "5.1.5-cc.1",
         "@concord-consortium/react-components": "^0.7.1",
         "@concord-consortium/react-modal-hook": "^3.0.0-cc.1",
@@ -1863,9 +1863,9 @@
       "license": "MIT"
     },
     "node_modules/@concord-consortium/diagram-view": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.33.tgz",
-      "integrity": "sha512-6Il5ifLT8JmgusCMXtDuvALnkXXxDXNe6OS21+pSkdqiLySJTbS5NyvU5idR4LUF89SZwNI6RXzNrB9gZL3LEA==",
+      "version": "0.0.34",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.34.tgz",
+      "integrity": "sha512-QwmastXv90mofW+h8Sl9+qhIC3yD2KCE3apnvGyX+AwXEv228vRK6QCr47gTlURtxmySTYxCSBpNGIV6+YRZ1g==",
       "dependencies": {
         "iframe-phone": "^1.3.1",
         "mathjs": "^10.4.1",
@@ -20460,9 +20460,9 @@
       "dev": true
     },
     "@concord-consortium/diagram-view": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.33.tgz",
-      "integrity": "sha512-6Il5ifLT8JmgusCMXtDuvALnkXXxDXNe6OS21+pSkdqiLySJTbS5NyvU5idR4LUF89SZwNI6RXzNrB9gZL3LEA==",
+      "version": "0.0.34",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.34.tgz",
+      "integrity": "sha512-QwmastXv90mofW+h8Sl9+qhIC3yD2KCE3apnvGyX+AwXEv228vRK6QCr47gTlURtxmySTYxCSBpNGIV6+YRZ1g==",
       "requires": {
         "iframe-phone": "^1.3.1",
         "mathjs": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
     "xhr-mock": "^2.5.1"
   },
   "dependencies": {
-    "@concord-consortium/diagram-view": "^0.0.33",
+    "@concord-consortium/diagram-view": "^0.0.34",
     "@concord-consortium/mobx-state-tree": "5.1.5-cc.1",
     "@concord-consortium/react-components": "^0.7.1",
     "@concord-consortium/react-modal-hook": "^3.0.0-cc.1",


### PR DESCRIPTION
[Release notes for diagram-view 0.0.34](https://github.com/concord-consortium/quantity-playground/releases/tag/diagram-view-0.0.34)