### PR TITLE
feat: Log tile titles (PT-#184428587)

### DIFF
--- a/src/lib/logger-utils.ts
+++ b/src/lib/logger-utils.ts
@@ -1,0 +1,8 @@
+import { DocumentModelType } from "../models/document/document";
+import { SectionModelType } from "../models/curriculum/section";
+
+type ModelTypeUnion = DocumentModelType | SectionModelType | null;
+
+export const getTileTitleForLogging = (tileId: string, docOrSection?: ModelTypeUnion) => {
+  return docOrSection?.content?.getTile(tileId)?.title ?? "<no title>";
+};

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -133,6 +133,9 @@ export const DocumentContentModel = types
       getTileType(tileId: string) {
         return self.tileMap.get(tileId)?.content.type;
       },
+      getTileTitle(tileId: string) {
+        return self.tileMap.get(tileId)?.title ?? "<no title>";
+      },
       get rowCount() {
         return self.rowOrder.length;
       },

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -133,9 +133,6 @@ export const DocumentContentModel = types
       getTileType(tileId: string) {
         return self.tileMap.get(tileId)?.content.type;
       },
-      getTileTitle(tileId: string) {
-        return self.tileMap.get(tileId)?.title ?? "<no title>";
-      },
       get rowCount() {
         return self.rowOrder.length;
       },

--- a/src/models/tiles/log/log-comment-event.ts
+++ b/src/models/tiles/log/log-comment-event.ts
@@ -1,6 +1,7 @@
 import { isSectionPath, parseSectionPath } from "../../../../functions/src/shared";
 import { ProblemModelType } from "../../curriculum/problem";
 import { Logger } from "../../../lib/logger";
+import { getTileTitleForLogging } from "../../../lib/logger-utils";
 import { LogEventName } from "../../../lib/logger-types";
 import { isDocumentLogEvent, logDocumentEvent } from "../../document/log-document-event";
 import { isCurriculumLogEvent, logCurriculumEvent } from "../../curriculum/log-curriculum-event";
@@ -27,14 +28,14 @@ function processCommentEventParams(params: ILogComment, context: IContext) {
     const [_unit, facet, _investigation, _problem, section] = parseSectionPath(documentId) || [];
     const curriculumStore = facet === "guide" ?  context.teacherGuide : context.problem;
     const tileType = tileId && curriculumStore?.getSectionById(section)?.content?.getTileType(tileId);
-    const tileTitle = tileId && curriculumStore?.getSectionById(section)?.content?.getTileTitle(tileId);
+    const tileTitle = tileId && getTileTitleForLogging(tileId, curriculumStore?.getSectionById(section));
     return { curriculum: documentId, tileId, tileTitle, tileType, ...others };
   }
 
   const document = documents.getDocument(documentId) || networkDocuments.getDocument(documentId);
   if (document) {
     const tileType = tileId ? document.content?.getTileType(tileId) : undefined;
-    const tileTitle = document?.content?.getTileTitle(tileId);
+    const tileTitle = tileId && getTileTitleForLogging(tileId, document);
     return { document, tileId, tileTitle, tileType, ...others };
   }
 

--- a/src/models/tiles/log/log-comment-event.ts
+++ b/src/models/tiles/log/log-comment-event.ts
@@ -27,7 +27,7 @@ function processCommentEventParams(params: ILogComment, context: IContext) {
     const [_unit, facet, _investigation, _problem, section] = parseSectionPath(documentId) || [];
     const curriculumStore = facet === "guide" ?  context.teacherGuide : context.problem;
     const tileType = tileId && curriculumStore?.getSectionById(section)?.content?.getTileType(tileId);
-    const tileTitle = tileId && curriculumStore?.getSectionById(section)?.content?.getTileTitle(tileId) || "<no title>";
+    const tileTitle = tileId && curriculumStore?.getSectionById(section)?.content?.getTileTitle(tileId);
     return { curriculum: documentId, tileId, tileTitle, tileType, ...others };
   }
 

--- a/src/models/tiles/log/log-comment-event.ts
+++ b/src/models/tiles/log/log-comment-event.ts
@@ -34,7 +34,7 @@ function processCommentEventParams(params: ILogComment, context: IContext) {
   const document = documents.getDocument(documentId) || networkDocuments.getDocument(documentId);
   if (document) {
     const tileType = tileId ? document.content?.getTileType(tileId) : undefined;
-    const tileTitle = document?.content?.getTileTitle(tileId) ?? "<no title>";
+    const tileTitle = document?.content?.getTileTitle(tileId);
     return { document, tileId, tileTitle, tileType, ...others };
   }
 

--- a/src/models/tiles/log/log-comment-event.ts
+++ b/src/models/tiles/log/log-comment-event.ts
@@ -27,13 +27,15 @@ function processCommentEventParams(params: ILogComment, context: IContext) {
     const [_unit, facet, _investigation, _problem, section] = parseSectionPath(documentId) || [];
     const curriculumStore = facet === "guide" ?  context.teacherGuide : context.problem;
     const tileType = tileId && curriculumStore?.getSectionById(section)?.content?.getTileType(tileId);
-    return { curriculum: documentId, tileId, tileType, ...others };
+    const tileTitle = tileId && curriculumStore?.getSectionById(section)?.content?.getTileTitle(tileId) || "<no title>";
+    return { curriculum: documentId, tileId, tileTitle, tileType, ...others };
   }
 
   const document = documents.getDocument(documentId) || networkDocuments.getDocument(documentId);
   if (document) {
     const tileType = tileId ? document.content?.getTileType(tileId) : undefined;
-    return { document, tileId, tileType, ...others };
+    const tileTitle = document?.content?.getTileTitle(tileId) ?? "<no title>";
+    return { document, tileId, tileTitle, tileType, ...others };
   }
 
   console.warn("Warning: couldn't transform log comment event params for document:", documentId);

--- a/src/models/tiles/log/log-tile-base-event.ts
+++ b/src/models/tiles/log/log-tile-base-event.ts
@@ -15,7 +15,9 @@ export function isTileBaseEvent(params: Record<string, any>): params is ITileBas
 function processTileBaseEventParams(params: ITileBaseLogEvent) {
   const { document, tileId, ...others } = params;
   const sectionId = document?.content?.getSectionIdForTile(tileId);
-  return { document, tileId, sectionId, ...others };
+  const tile = document?.content?.getTile(tileId);
+  const tileTitle = tile?.title ?? "<no title>";
+  return { document, tileId, sectionId, tileTitle, ...others };
 }
 
 export function logTileBaseEvent(event: LogEventName, _params: ITileBaseLogEvent) {

--- a/src/models/tiles/log/log-tile-base-event.ts
+++ b/src/models/tiles/log/log-tile-base-event.ts
@@ -15,8 +15,7 @@ export function isTileBaseEvent(params: Record<string, any>): params is ITileBas
 function processTileBaseEventParams(params: ITileBaseLogEvent) {
   const { document, tileId, ...others } = params;
   const sectionId = document?.content?.getSectionIdForTile(tileId);
-  const tile = document?.content?.getTile(tileId);
-  const tileTitle = tile?.title ?? "<no title>";
+  const tileTitle = document?.content?.getTileTitle(tileId) ?? "<no title>";
   return { document, tileId, sectionId, tileTitle, ...others };
 }
 

--- a/src/models/tiles/log/log-tile-base-event.ts
+++ b/src/models/tiles/log/log-tile-base-event.ts
@@ -1,5 +1,6 @@
 import { Logger } from "../../../lib/logger";
 import { LogEventName } from "../../../lib/logger-types";
+import { getTileTitleForLogging } from "../../../lib/logger-utils";
 import { DocumentModelType } from "../../document/document";
 import { isDocumentLogEvent, logDocumentEvent } from "../../document/log-document-event";
 
@@ -15,7 +16,7 @@ export function isTileBaseEvent(params: Record<string, any>): params is ITileBas
 function processTileBaseEventParams(params: ITileBaseLogEvent) {
   const { document, tileId, ...others } = params;
   const sectionId = document?.content?.getSectionIdForTile(tileId);
-  const tileTitle = document?.content?.getTileTitle(tileId);
+  const tileTitle = getTileTitleForLogging(tileId, document);
   return { document, tileId, sectionId, tileTitle, ...others };
 }
 

--- a/src/models/tiles/log/log-tile-base-event.ts
+++ b/src/models/tiles/log/log-tile-base-event.ts
@@ -15,7 +15,7 @@ export function isTileBaseEvent(params: Record<string, any>): params is ITileBas
 function processTileBaseEventParams(params: ITileBaseLogEvent) {
   const { document, tileId, ...others } = params;
   const sectionId = document?.content?.getSectionIdForTile(tileId);
-  const tileTitle = document?.content?.getTileTitle(tileId) ?? "<no title>";
+  const tileTitle = document?.content?.getTileTitle(tileId);
   return { document, tileId, sectionId, tileTitle, ...others };
 }
 

--- a/src/models/tiles/log/log-tile-change-event.ts
+++ b/src/models/tiles/log/log-tile-change-event.ts
@@ -20,8 +20,7 @@ function processTileChangeEvent(params: ITileChangeLogEvent, context: IContext) 
   const document = context.documents.findDocumentOfTile(tileId) ||
                     context.networkDocuments.findDocumentOfTile(tileId);
   const legacyChangeProps = { toolId: tileId, operation, ...change };
-  const tile = document?.content?.getTile(tileId);
-  const tileTitle = tile?.title ?? "<no title>";
+  const tileTitle = document?.content?.getTileTitle(tileId) ?? "<no title>";
   return { document, tileId, ...legacyChangeProps, tileTitle, ...others };
 }
 

--- a/src/models/tiles/log/log-tile-change-event.ts
+++ b/src/models/tiles/log/log-tile-change-event.ts
@@ -20,7 +20,9 @@ function processTileChangeEvent(params: ITileChangeLogEvent, context: IContext) 
   const document = context.documents.findDocumentOfTile(tileId) ||
                     context.networkDocuments.findDocumentOfTile(tileId);
   const legacyChangeProps = { toolId: tileId, operation, ...change };
-  return { document, tileId, ...legacyChangeProps, ...others };
+  const tile = document?.content?.getTile(tileId);
+  const tileTitle = tile?.title ?? "<no title>";
+  return { document, tileId, ...legacyChangeProps, tileTitle, ...others };
 }
 
 export function logTileChangeEvent(event: LogEventName, _params: ITileChangeLogEvent) {

--- a/src/models/tiles/log/log-tile-change-event.ts
+++ b/src/models/tiles/log/log-tile-change-event.ts
@@ -20,7 +20,7 @@ function processTileChangeEvent(params: ITileChangeLogEvent, context: IContext) 
   const document = context.documents.findDocumentOfTile(tileId) ||
                     context.networkDocuments.findDocumentOfTile(tileId);
   const legacyChangeProps = { toolId: tileId, operation, ...change };
-  const tileTitle = document?.content?.getTileTitle(tileId) ?? "<no title>";
+  const tileTitle = document?.content?.getTileTitle(tileId);
   return { document, tileId, ...legacyChangeProps, tileTitle, ...others };
 }
 

--- a/src/models/tiles/log/log-tile-change-event.ts
+++ b/src/models/tiles/log/log-tile-change-event.ts
@@ -1,4 +1,5 @@
 import { Logger } from "../../../lib/logger";
+import { getTileTitleForLogging } from "../../../lib/logger-utils";
 import { LogEventMethod, LogEventName } from "../../../lib/logger-types";
 import { DocumentsModelType } from "../../stores/documents";
 import { isTileBaseEvent, logTileBaseEvent } from "./log-tile-base-event";
@@ -20,7 +21,7 @@ function processTileChangeEvent(params: ITileChangeLogEvent, context: IContext) 
   const document = context.documents.findDocumentOfTile(tileId) ||
                     context.networkDocuments.findDocumentOfTile(tileId);
   const legacyChangeProps = { toolId: tileId, operation, ...change };
-  const tileTitle = document?.content?.getTileTitle(tileId);
+  const tileTitle = getTileTitleForLogging(tileId, document);
   return { document, tileId, ...legacyChangeProps, tileTitle, ...others };
 }
 

--- a/src/models/tiles/log/log-tile-copy-event.ts
+++ b/src/models/tiles/log/log-tile-copy-event.ts
@@ -18,8 +18,7 @@ function processTileCopyEventParams(params: ITileCopyLogEvent, context: IContext
   const { originalTileId, ...others } = params;
   const srcDocument = context.documents.findDocumentOfTile(originalTileId) ||
                       context.networkDocuments.findDocumentOfTile(originalTileId);
-  const originalTile = srcDocument?.content?.getTile(originalTileId);
-  const originalTileTitle = originalTile?.title ?? "<no title>";
+  const originalTileTitle = srcDocument?.content?.getTileTitle(originalTileId) ?? "<no title>";
   const srcProps = srcDocument
                     ? {
                       sourceUsername: srcDocument.uid,

--- a/src/models/tiles/log/log-tile-copy-event.ts
+++ b/src/models/tiles/log/log-tile-copy-event.ts
@@ -18,7 +18,7 @@ function processTileCopyEventParams(params: ITileCopyLogEvent, context: IContext
   const { originalTileId, ...others } = params;
   const srcDocument = context.documents.findDocumentOfTile(originalTileId) ||
                       context.networkDocuments.findDocumentOfTile(originalTileId);
-  const originalTileTitle = srcDocument?.content?.getTileTitle(originalTileId) ?? "<no title>";
+  const originalTileTitle = srcDocument?.content?.getTileTitle(originalTileId);
   const srcProps = srcDocument
                     ? {
                       sourceUsername: srcDocument.uid,

--- a/src/models/tiles/log/log-tile-copy-event.ts
+++ b/src/models/tiles/log/log-tile-copy-event.ts
@@ -1,5 +1,6 @@
 import { Logger } from "../../../lib/logger";
 import { LogEventName } from "../../../lib/logger-types";
+import { getTileTitleForLogging } from "../../../lib/logger-utils";
 import { DocumentsModelType } from "../../stores/documents";
 import { ITileModel } from "../tile-model";
 import { logTileDocumentEvent } from "./log-tile-document-event";
@@ -18,7 +19,7 @@ function processTileCopyEventParams(params: ITileCopyLogEvent, context: IContext
   const { originalTileId, ...others } = params;
   const srcDocument = context.documents.findDocumentOfTile(originalTileId) ||
                       context.networkDocuments.findDocumentOfTile(originalTileId);
-  const originalTileTitle = srcDocument?.content?.getTileTitle(originalTileId);
+  const originalTileTitle = getTileTitleForLogging(originalTileId, srcDocument);
   const srcProps = srcDocument
                     ? {
                       sourceUsername: srcDocument.uid,

--- a/src/models/tiles/log/log-tile-copy-event.ts
+++ b/src/models/tiles/log/log-tile-copy-event.ts
@@ -18,10 +18,13 @@ function processTileCopyEventParams(params: ITileCopyLogEvent, context: IContext
   const { originalTileId, ...others } = params;
   const srcDocument = context.documents.findDocumentOfTile(originalTileId) ||
                       context.networkDocuments.findDocumentOfTile(originalTileId);
+  const originalTile = srcDocument?.content?.getTile(originalTileId);
+  const originalTileTitle = originalTile?.title ?? "<no title>";
   const srcProps = srcDocument
                     ? {
                       sourceUsername: srcDocument.uid,
                       sourceObjectId: originalTileId,
+                      sourceObjectTitle: originalTileTitle,
                       sourceDocumentKey: srcDocument.key,
                       sourceDocumentType: srcDocument.type,
                       sourceDocumentTitle: srcDocument.title || "",

--- a/src/models/tiles/log/log-tile-document-event.ts
+++ b/src/models/tiles/log/log-tile-document-event.ts
@@ -21,7 +21,7 @@ function processTileDocumentEventParams(params: ITileDocumentLogEvent, context: 
   const document = context.documents.findDocumentOfTile(tileId) ||
                     context.networkDocuments.findDocumentOfTile(tileId);
   const legacyTileProps = { objectId: tileId, objectType: tileType, serializedObject: getSnapshot(content) };
-  const tileTitle = document?.content?.getTileTitle(tileId) ?? "<no title>";
+  const tileTitle = document?.content?.getTileTitle(tileId);
   return { document, tileId, tileType, ...legacyTileProps, tileTitle, ...others };
 }
 

--- a/src/models/tiles/log/log-tile-document-event.ts
+++ b/src/models/tiles/log/log-tile-document-event.ts
@@ -21,7 +21,9 @@ function processTileDocumentEventParams(params: ITileDocumentLogEvent, context: 
   const document = context.documents.findDocumentOfTile(tileId) ||
                     context.networkDocuments.findDocumentOfTile(tileId);
   const legacyTileProps = { objectId: tileId, objectType: tileType, serializedObject: getSnapshot(content) };
-  return { document, tileId, tileType, ...legacyTileProps, ...others };
+  const tile = document?.content?.getTile(tileId);
+  const tileTitle = tile?.title ?? "<no title>";
+  return { document, tileId, tileType, ...legacyTileProps, tileTitle, ...others };
 }
 
 export function logTileDocumentEvent(event: LogEventName, _params: ITileDocumentLogEvent) {

--- a/src/models/tiles/log/log-tile-document-event.ts
+++ b/src/models/tiles/log/log-tile-document-event.ts
@@ -21,8 +21,7 @@ function processTileDocumentEventParams(params: ITileDocumentLogEvent, context: 
   const document = context.documents.findDocumentOfTile(tileId) ||
                     context.networkDocuments.findDocumentOfTile(tileId);
   const legacyTileProps = { objectId: tileId, objectType: tileType, serializedObject: getSnapshot(content) };
-  const tile = document?.content?.getTile(tileId);
-  const tileTitle = tile?.title ?? "<no title>";
+  const tileTitle = document?.content?.getTileTitle(tileId) ?? "<no title>";
   return { document, tileId, tileType, ...legacyTileProps, tileTitle, ...others };
 }
 

--- a/src/models/tiles/log/log-tile-document-event.ts
+++ b/src/models/tiles/log/log-tile-document-event.ts
@@ -1,6 +1,7 @@
 import { getSnapshot } from "mobx-state-tree";
 import { Logger } from "../../../lib/logger";
 import { LogEventName } from "../../../lib/logger-types";
+import { getTileTitleForLogging } from "../../../lib/logger-utils";
 import { DocumentsModelType } from "../../stores/documents";
 import { ITileModel } from "../tile-model";
 import { isTileBaseEvent, logTileBaseEvent } from "./log-tile-base-event";
@@ -21,7 +22,7 @@ function processTileDocumentEventParams(params: ITileDocumentLogEvent, context: 
   const document = context.documents.findDocumentOfTile(tileId) ||
                     context.networkDocuments.findDocumentOfTile(tileId);
   const legacyTileProps = { objectId: tileId, objectType: tileType, serializedObject: getSnapshot(content) };
-  const tileTitle = document?.content?.getTileTitle(tileId);
+  const tileTitle = getTileTitleForLogging(tileId, document);
   return { document, tileId, tileType, ...legacyTileProps, tileTitle, ...others };
 }
 

--- a/src/models/tiles/table/table-content.ts
+++ b/src/models/tiles/table/table-content.ts
@@ -9,6 +9,7 @@ import {
 import { IDocumentExportOptions, IDefaultContentOptions } from "../tile-content-info";
 import { TileMetadataModel } from "../tile-metadata";
 import { tileModelHooks } from "../tile-model-hooks";
+import { setTileTitleFromContent } from "../tile-model";
 import { TileContentModel } from "../tile-content";
 import { addCanonicalCasesToDataSet, IDataSet, ICaseCreation, ICase, DataSet } from "../../data/data-set";
 import { kSharedDataSetType, SharedDataSet, SharedDataSetType } from "../../shared/shared-data-set";
@@ -333,7 +334,7 @@ export const TableContentModel = TileContentModel
     },
     setTableName(name: string) {
       self.dataSet.setName(name);
-
+      setTileTitleFromContent(self, name);
       self.logChange({ action: "update", target: "table", props: { name } });
     },
     setColumnWidth(attrId: string, width: number) {


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/184428587

Add tile titles to tile event logs for easier reference by researchers. If a tile has no title, use `<no title>` as a placeholder.