### PR TITLE
fix: Initial load from production portal using qa log ingester (PT-184068699)

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -154,9 +154,11 @@ export class Logger {
 }
 
 function sendToLoggingService(data: LogMessage, user: UserModelType) {
+  const isProduction = user.portal === productionPortal || data.parameters?.portal === productionPortal;
+  const url = logManagerUrl[isProduction ? "production" : "dev"];
   if (DEBUG_LOGGER) {
     // eslint-disable-next-line no-console
-    console.log("Logger#sendToLoggingService sending", data, "to", logManagerUrl);
+    console.log("Logger#sendToLoggingService sending", data, "to", url);
   }
   if (!Logger.isLoggingEnabled) return;
 
@@ -166,7 +168,6 @@ function sendToLoggingService(data: LogMessage, user: UserModelType) {
   request.upload.addEventListener("error", () => user.setIsLoggingConnected(false));
   request.upload.addEventListener("abort", () => user.setIsLoggingConnected(false));
 
-  const url = logManagerUrl[user.portal === productionPortal ? "production" : "dev"];
   request.open("POST", url, true);
   request.setRequestHeader("Content-Type", "application/json; charset=UTF-8");
   request.send(JSON.stringify(data));


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/184068699

The `portal` property of `user` is initially empty when the app first loads, so `sendToLoggingService` was defaulting to using the QA URL. The `portal` property in `data.parameters` seems to contain the expected value (i.e., learn.concord.org) from the start, so these changes include an additional check for `data.parameters.portal` in case `user.portal` is empty.

Included is a change to the `console.log` statement when `DEBUG_LOGGER` is true. We were previously outputting the full `logManagerUrl` object instead of the specific log-ingester URL being used. Seems like we would want the specific URL, but I want to double check that.