### PR TITLE
182820037 Fix link exports

### DIFF
--- a/src/models/tiles/text/text-content.ts
+++ b/src/models/tiles/text/text-content.ts
@@ -6,7 +6,7 @@ import { ITileExportOptions } from "../tile-content-info";
 import { TileContentModel } from "../tile-content";
 import { SharedModelType } from "../../shared/shared-model";
 import { getAllTextPluginInfos } from "./text-plugin-info";
-import { escapeBackslashes } from "../../../utilities/string-utils";
+import { escapeBackslashes, escapeDoubleQuotes } from "../../../utilities/string-utils";
 
 export const kTextTileType = "Text";
 
@@ -79,10 +79,9 @@ export const TextContentModel = TileContentModel
     exportJson(options?: ITileExportOptions) {
       const value = self.asSlate();
       const html = value ? slateToHtml(value) : "";
-      // slateToHtml changes double quotes (") into `&quot;`. If this changes, we'll need to explicitly
-      // escape double quotes here, because unescaped double quotes will break the curriculum json.
+      // We need to escape both double quotes and backslashes, otherwise the curriculum json will break.
       const exportHtml = html.split("\n")
-        .map((line, i, arr) => `    "${escapeBackslashes(line)}"${i < arr.length - 1 ? "," : ""}`);
+        .map((line, i, arr) => `    "${escapeDoubleQuotes(escapeBackslashes(line))}"${i < arr.length - 1 ? "," : ""}`);
       return [
         `{`,
         `  "type": "Text",`,

--- a/src/utilities/string-utils.ts
+++ b/src/utilities/string-utils.ts
@@ -1,1 +1,2 @@
 export const escapeBackslashes = (text: string) => text.replaceAll(`\\`, `\\\\`);
+export const escapeDoubleQuotes = (text: string) => text.replaceAll(`"`, `\\"`);


### PR DESCRIPTION
Turns out we did need to escape double quotes after all! In my recent tests, I was only checking quotes in the actual text field, which were automatically being converted to `& quot ;`. However, double quotes within html tags (like the href of a link) were not being converted automatically.