### PR TITLE
feat: support shared  models in sections

### DIFF
--- a/src/models/curriculum/problem.ts
+++ b/src/models/curriculum/problem.ts
@@ -1,4 +1,4 @@
-import { clone, Instance, SnapshotIn, types } from "mobx-state-tree";
+import { clone, getSnapshot, Instance, SnapshotIn, types } from "mobx-state-tree";
 import { SectionModel, SectionModelType } from "./section";
 import { SettingsMstType } from "../stores/settings";
 import { SupportModel } from "./support";
@@ -41,7 +41,11 @@ const ModernProblemModel = types
         const environment: ITileEnvironment = {
           sharedModelManager
         };
-        const sectionCopy = clone(section, environment);
+        const sectionSnapshot = getSnapshot(section);
+        // We have to make a copy of the sectionSnapshot because child models modify
+        // their snapshots in place during preProcessor calls. The objects from
+        // getSnapshot are readonly
+        const sectionCopy = SectionModel.create(JSON.parse(JSON.stringify(sectionSnapshot)), environment);
         sectionCopy.setRealParent(self);
         if (sectionCopy.content) {
           sharedModelManager.setDocument(sectionCopy.content);

--- a/src/models/curriculum/problem.ts
+++ b/src/models/curriculum/problem.ts
@@ -1,4 +1,5 @@
-import { clone, getSnapshot, Instance, SnapshotIn, types } from "mobx-state-tree";
+import { getSnapshot, Instance, SnapshotIn, types } from "mobx-state-tree";
+import { cloneDeep } from "lodash";
 import { SectionModel, SectionModelType } from "./section";
 import { SettingsMstType } from "../stores/settings";
 import { SupportModel } from "./support";
@@ -22,6 +23,7 @@ const ModernProblemModel = types
     ordinal: types.integer,
     title: types.string,
     subtitle: "",
+    // loadedSections are part of the tree, but clients should use the sections view instead
     loadedSections: types.array(SectionModel),
     supports: types.array(SupportModel),
     config: types.maybe(types.frozen<Partial<ProblemConfiguration>>())
@@ -45,7 +47,7 @@ const ModernProblemModel = types
         // We have to make a copy of the sectionSnapshot because child models modify
         // their snapshots in place during preProcessor calls. The objects from
         // getSnapshot are readonly
-        const sectionCopy = SectionModel.create(JSON.parse(JSON.stringify(sectionSnapshot)), environment);
+        const sectionCopy = SectionModel.create(cloneDeep(sectionSnapshot), environment);
         sectionCopy.setRealParent(self);
         if (sectionCopy.content) {
           sharedModelManager.setDocument(sectionCopy.content);

--- a/src/models/curriculum/section.ts
+++ b/src/models/curriculum/section.ts
@@ -1,4 +1,4 @@
-import { types } from "mobx-state-tree";
+import { IAnyStateTreeNode, types } from "mobx-state-tree";
 import { parseSectionPath } from "../../../functions/src/shared";
 import { DocumentContentModel } from "../document/document-content";
 import { IAuthoredTileContent } from "../document/document-content-import-types";
@@ -87,6 +87,9 @@ export const SectionModel = types
     content: types.maybe(DocumentContentModel),
     supports: types.array(SupportModel),
   })
+  .volatile(self => ({
+    realParent: undefined as IAnyStateTreeNode | undefined
+  }))
   .preProcessSnapshot(snap => {
     return gSuspendSectionContentParsing
             ? { ...snap, content: undefined }
@@ -104,7 +107,12 @@ export const SectionModel = types
         return getSectionPlaceholder(self.type);
       }
     };
-  });
+  })
+  .actions(self => ({
+    setRealParent(parent: IAnyStateTreeNode) {
+      self.realParent = parent;
+    }
+  }));
 export type SectionModelType = typeof SectionModel.Type;
 
 export function findSectionIndex(sections: SectionModelType[], fullPath: string | undefined){

--- a/src/public/curriculum/example-curriculum/example-shared-data.json
+++ b/src/public/curriculum/example-curriculum/example-shared-data.json
@@ -253,22 +253,73 @@
             {
               "type": "taska",
               "content": {
+                "sharedModels":[
+                  {
+                    "sharedModel": {
+                      "type": "SharedDataSet",
+                      "id": "fa-wtBZBPtFPEk5e",
+                      "providerId": "ocE9IDDQyJInnvVH",
+                      "dataSet": {
+                        "id": "V8lj4GO-FCZ9NJrM",
+                        "name": "Table 1",
+                        "attributes": [
+                          {
+                            "id": "feRuv9gR6L9PoUYg",
+                            "clientKey": "",
+                            "name": "x",
+                            "hidden": false,
+                            "units": "",
+                            "formula": {},
+                            "values": ["0", "15", "0"]
+                          },
+                          {
+                            "id": "yGRYwwl0l_VBAvBB",
+                            "clientKey": "",
+                            "name": "y",
+                            "hidden": false,
+                            "units": "",
+                            "formula": {},
+                            "values": ["0", "0", "15"]
+                          }
+                        ],
+                        "cases": [
+                          {"__id__": "HR3at2-RqvnRaT9z"},
+                          {"__id__": "O3SmGUb4iRPw29HU"},
+                          {"__id__": "76WRbhQpTu2Wqy1c"}
+                        ]
+                      }
+                    },
+                    "tiles": ["ocE9IDDQyJInnvVH", "7PaV91x-dBRFVZsc"]
+                  }
+                ],
                 "tiles": [
                   {
                     "content": {
                       "type": "Text",
-                      "format": "html",
-                      "text": [
-                        "<p>Text tile on the left 1</p>"
-                      ]
+                      "text": "My plain text on the right 2"
                     }
                   },
                   {
+                    "id": "ocE9IDDQyJInnvVH",
+                    "title": "Table 1",
                     "content": {
-                      "type": "Text",
-                      "format": "html",
-                      "text": [
-                        "<p>text tile on the left 2</p>"
+                      "type": "Table",
+                      "name": "Table 1"
+                    }
+                  },
+                  {
+                    "id": "7PaV91x-dBRFVZsc",
+                    "title": "Graph 1",
+                    "content": {
+                      "type": "Geometry",
+                      "board": {
+                        "properties": {
+                          "axisMin": [-4.049, -2.232],
+                          "axisRange": [36.592, 19.71]
+                        }
+                      },
+                      "objects": [
+                        { "type": "polygon", "parents": ["HR3at2-RqvnRaT9z:yGRYwwl0l_VBAvBB", "O3SmGUb4iRPw29HU:yGRYwwl0l_VBAvBB", "76WRbhQpTu2Wqy1c:yGRYwwl0l_VBAvBB"],"properties": {"id":"cWoEx64CKz1q6gdJ"} }
                       ]
                     }
                   }

--- a/src/public/curriculum/example-curriculum/example-shared-data.json
+++ b/src/public/curriculum/example-curriculum/example-shared-data.json
@@ -257,11 +257,11 @@
                   {
                     "sharedModel": {
                       "type": "SharedDataSet",
-                      "id": "fa-wtBZBPtFPEk5e",
-                      "providerId": "ocE9IDDQyJInnvVH",
+                      "id": "shared-data-1",
+                      "providerId": "table-1",
                       "dataSet": {
                         "id": "V8lj4GO-FCZ9NJrM",
-                        "name": "Table 1",
+                        "name": "Table In Section",
                         "attributes": [
                           {
                             "id": "feRuv9gR6L9PoUYg",
@@ -289,7 +289,7 @@
                         ]
                       }
                     },
-                    "tiles": ["ocE9IDDQyJInnvVH", "7PaV91x-dBRFVZsc"]
+                    "tiles": ["table-1", "graph-1"]
                   }
                 ],
                 "tiles": [
@@ -300,16 +300,16 @@
                     }
                   },
                   {
-                    "id": "ocE9IDDQyJInnvVH",
-                    "title": "Table 1",
+                    "id": "table-1",
+                    "title": "Table in Section",
                     "content": {
                       "type": "Table",
-                      "name": "Table 1"
+                      "name": "Table in Section"
                     }
                   },
                   {
-                    "id": "7PaV91x-dBRFVZsc",
-                    "title": "Graph 1",
+                    "id": "graph-1",
+                    "title": "Graph in Section",
                     "content": {
                       "type": "Geometry",
                       "board": {

--- a/src/public/curriculum/m2studio/m2studio.json
+++ b/src/public/curriculum/m2studio/m2studio.json
@@ -212,6 +212,12 @@
         "title": "Redo",
         "iconId": "icon-redo-tool",
         "isTileTool": false
+      },
+      {
+        "id": "delete",
+        "title": "Delete",
+        "iconId": "icon-delete-tool",
+        "isTileTool": false
       }
     ]
   },

--- a/src/public/curriculum/mothed/mothed.json
+++ b/src/public/curriculum/mothed/mothed.json
@@ -685,6 +685,58 @@
             {
               "type": "pinning",
               "content": {
+                "sharedModels":[
+                  {
+                    "sharedModel": {
+                      "type": "SharedDataSet",
+                      "id": "2RLUYg5P96NDMIfI",
+                      "providerId": "Mf8F2TQ576QtCIkq",
+                      "dataSet": {
+                        "id": "pmBp0E-weI04bgsG",
+                        "attributes": [
+                          {
+                            "id": "lgQ-aHc3ENGlh4CC",
+                            "clientKey": "",
+                            "name": "Moth",
+                            "hidden": false,
+                            "units": "",
+                            "formula": {},
+                            "values": ["large"]
+                          },
+                          {
+                            "id": "nb9o6hyCZqVPYp9R",
+                            "clientKey": "",
+                            "name": "Date",
+                            "hidden": false,
+                            "units": "",
+                            "formula": {},
+                            "values": [""]
+                          },
+                          {
+                            "id": "jzCeWK-wTPkHjaui",
+                            "clientKey": "",
+                            "name": "image",
+                            "hidden": false,
+                            "units": "",
+                            "formula": {},
+                            "values": [""]
+                          },
+                          {
+                            "id": "mxFnkDHe2Xbceey_",
+                            "clientKey": "",
+                            "name": "Another Label ",
+                            "hidden": false,
+                            "units": "",
+                            "formula": {},
+                            "values": [""]
+                          }
+                        ],
+                        "cases": [{"__id__": "01GB97G7F4QR5TBZ4D1CB50G9K"}]
+                      }
+                    },
+                    "tiles": ["Mf8F2TQ576QtCIkq"]
+                  }
+                ],
                 "tiles": [
                   {
                     "id": "XejN-F7hDWsdjxpt",
@@ -724,12 +776,10 @@
                     }
                   },
                   {
-                    "id": "MJR4ZpqhE9UX0GH4",
-                    "title": "Data Cards - press the fourth toolbar button",
+                    "id": "Mf8F2TQ576QtCIkq",
+                    "title": "My Moths",
                     "content": {
-                      "type": "Image",
-                      "url": "curriculum/mothed/images/dataCard.png",
-                      "filename": "curriculum/mothed/images/dataCard.png"
+                      "type": "DataCard"
                     }
                   },
                   {


### PR DESCRIPTION
This is a simplified approach to supporting shared models in curriculum sections.

Ideally we wouldn't have duplicate shared model manager initialization code, but the approach in this PR is miminal and solves the problem.

As usual trying to avoid circular dependencies makes the code harder to read. 


PT-184583797