### PR TITLE
fix: Table and Graph do not synchronize in 4-up view (PT-184609260)

### DIFF
--- a/src/models/tiles/geometry/jxg-point.ts
+++ b/src/models/tiles/geometry/jxg-point.ts
@@ -26,10 +26,10 @@ const defaultProps = {
 // colors for linked points are derived from the link color map
 export function syncClientColors(props: any) {
   const { selectedFillColor, selectedStrokeColor, ...p } = props || {} as any;
-  const colorMapEntry = getColorMapEntry(p.linkedTableId);
+  const colorMapEntry = p.linkedTableId && getColorMapEntry(p.linkedTableId);
 
-  if (colorMapEntry) {
-    const { colorSet: { fill, stroke, selectedFill, selectedStroke } } = colorMapEntry;
+  if (colorMapEntry.colorSet) {
+    const { fill, stroke, selectedFill, selectedStroke } = colorMapEntry.colorSet;
     p.fillColor = p.clientFillColor = fill;
     p.strokeColor = p.clientStrokeColor = stroke;
     p.clientSelectedFillColor = selectedFill;

--- a/src/models/tiles/geometry/jxg-point.ts
+++ b/src/models/tiles/geometry/jxg-point.ts
@@ -26,9 +26,9 @@ const defaultProps = {
 // colors for linked points are derived from the link color map
 export function syncClientColors(props: any) {
   const { selectedFillColor, selectedStrokeColor, ...p } = props || {} as any;
-  const colorMapEntry = p.linkedTableId && getColorMapEntry(p.linkedTableId);
+  const colorMapEntry = getColorMapEntry(p.linkedTableId);
 
-  if (colorMapEntry.colorSet) {
+  if (colorMapEntry?.colorSet) {
     const { fill, stroke, selectedFill, selectedStroke } = colorMapEntry.colorSet;
     p.fillColor = p.clientFillColor = fill;
     p.strokeColor = p.clientStrokeColor = stroke;


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/184609260

BUG: While a teacher is viewing a student's work in the 4-up view, if the student links a graph and a table, the data from the table does not appear in the graph in the teacher's view (it does appear for the student). If the teacher reloads the page and navigates back to the view of the student's work, the graph is then populated.

When the link is first made, an error appears in the teacher's browser console: `Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'fill')`.

These changes prevent that error by checking if `colorMapEntry.colorset` is defined instead of just checking for `colorMapEntry` since `colorMapEntry` can exist with an undefined `colorSet`. With that error prevented, the graph is populated immediately in the teacher's view.