### PR TITLE
184552058 sort deck control

### DIFF
--- a/cypress/e2e/clue/branch/student_tests/data_card_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/data_card_tool_spec.js
@@ -20,11 +20,11 @@ context('Data Card Tool Tile', function () {
       dc.getTile().contains("Data Card Collection");
     });
     it("can create a new attribute", () => {
-      dc.getNameInputAsInactive().dblclick().type("Foo{enter}")
+      dc.getNameInputAsInactive().dblclick().type("Hello{enter}");
     });
     it("can toggle between single and sort views", () => {
       cy.get('.single-card-data-area').should('exist');
-      dc.getSortSelect().select("Foo");
+      dc.getSortSelect().select("Hello");
       cy.get('.sorting-cards-data-area').should('exist');
       dc.getSortSelect().select("None");
       cy.get('.single-card-data-area').should('exist');

--- a/cypress/e2e/clue/branch/student_tests/data_card_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/data_card_tool_spec.js
@@ -1,0 +1,34 @@
+import ClueCanvas from '../../../../support/elements/clue/cCanvas';
+import DataCardToolTile from '../../../../support/elements/clue/DataCardToolTile';
+
+let clueCanvas = new ClueCanvas;
+let dc = new DataCardToolTile;
+
+context('Data Card Tool Tile', function () {
+  before(function () {
+    const queryParams = "?appMode=qa&fakeClass=5&fakeUser=student:5&qaGroup=5&unit=moth";
+    cy.clearQAData('all');
+    cy.visit(queryParams);
+    cy.waitForLoad();
+  });
+  describe("Data Card Tool", () => {
+    it("renders Data Card tool tile", () => {
+      clueCanvas.addTile("datacard");
+      dc.getTile().should("exist");
+    });
+    it("has a default title", () => {
+      dc.getTile().contains("Data Card Collection");
+    });
+    it("can create a new attribute", () => {
+      dc.getNameInputAsInactive().dblclick().type("Foo{enter}")
+    });
+    it("can toggle between single and sort views", () => {
+      cy.get('.single-card-data-area').should('exist');
+      dc.getSortSelect().select("Foo");
+      cy.get('.sorting-cards-data-area').should('exist');
+      dc.getSortSelect().select("None");
+      cy.get('.single-card-data-area').should('exist');
+    });
+  });
+});
+

--- a/cypress/e2e/clue/branch/student_tests/text_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/text_tool_spec.js
@@ -10,12 +10,12 @@ const textToolTile = new TextToolTile;
 context('Text tool tile functionalities', function(){
     before(function(){
         const queryParams = `${Cypress.config("queryParams")}`;
-    
+
         cy.clearQAData('all');
         cy.visit(queryParams);
         cy.waitForLoad();
     });
-        
+
     let title;
     before(()=>{
         clueCanvas.getInvestigationCanvasTitle()

--- a/cypress/support/elements/clue/DataCardToolTile.js
+++ b/cypress/support/elements/clue/DataCardToolTile.js
@@ -1,0 +1,16 @@
+class DataCardToolTile {
+  getTile(workspaceClass) {
+    return cy.get(`${workspaceClass || ".primary-workspace"} .canvas-area .data-card-tool-tile`);
+  }
+  getTileTitle(workspaceClass){
+    return cy.get(`${workspaceClass || ".primary-workspace"} .editable-data-card-title-text`);
+  }
+  getSortSelect(workspaceClass){
+    return cy.get(`${workspaceClass || ".primary-workspace"} .sort-select-input`);
+  }
+  getNameInputAsInactive(workspaceClass){
+    const nameInputSelector = ".attribute-name-value-pair .name";
+    return cy.get(`${workspaceClass || ".primary-workspace"} ${nameInputSelector}`);
+  }
+}
+export default DataCardToolTile;

--- a/src/plugins/data-card/components/case-attribute.tsx
+++ b/src/plugins/data-card/components/case-attribute.tsx
@@ -109,18 +109,18 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
       if (!names.includes(labelCandidate)){
         caseId && content.setAttName(attrKey, labelCandidate);
       } else {
-        showUniqueAttributeAlert();
+        showRequireUniqueAlert();
       }
     }
   };
 
-  const UniqueAttributeAlertContent = () => {
+  const RequireUniqueAlert = () => {
     return <p> Attribute names must be unique.</p>;
   };
 
-  const [showUniqueAttributeAlert] = useCautionAlert({
+  const [showRequireUniqueAlert] = useCautionAlert({
     title: "Delete Attribute",
-    content: UniqueAttributeAlertContent,
+    content: RequireUniqueAlert,
     confirmLabel: "OK",
     onConfirm: () => deleteAttribute()
   });

--- a/src/plugins/data-card/components/case-attribute.tsx
+++ b/src/plugins/data-card/components/case-attribute.tsx
@@ -122,7 +122,7 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
     title: "Delete Attribute",
     content: RequireUniqueAlert,
     confirmLabel: "OK",
-    onConfirm: () => deleteAttribute()
+    onConfirm: () => {}
   });
 
   const handleCompleteValue = () => {

--- a/src/plugins/data-card/components/case-attribute.tsx
+++ b/src/plugins/data-card/components/case-attribute.tsx
@@ -7,7 +7,7 @@ import { DataCardContentModelType } from "../data-card-content";
 import { looksLikeDefaultLabel, EditFacet } from "../data-card-types";
 import { RemoveIconButton } from "./add-remove-icons";
 import { useCautionAlert } from "../../../components/utilities/use-caution-alert";
-import { useErrorAlert } from "../../../components/utilities/use-error-alert"
+import { useErrorAlert } from "../../../components/utilities/use-error-alert";
 
 import '../data-card-tile.scss';
 

--- a/src/plugins/data-card/components/case-attribute.tsx
+++ b/src/plugins/data-card/components/case-attribute.tsx
@@ -7,6 +7,7 @@ import { DataCardContentModelType } from "../data-card-content";
 import { looksLikeDefaultLabel, EditFacet } from "../data-card-types";
 import { RemoveIconButton } from "./add-remove-icons";
 import { useCautionAlert } from "../../../components/utilities/use-caution-alert";
+import { useErrorAlert } from "../../../components/utilities/use-error-alert"
 
 import '../data-card-tile.scss';
 
@@ -115,14 +116,12 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
   };
 
   const RequireUniqueAlert = () => {
-    return <p> Attribute names must be unique.</p>;
+    return <p>Each field should have a unique name.  Enter a name that is not already in use in this collection.</p>;
   };
 
-  const [showRequireUniqueAlert] = useCautionAlert({
-    title: "Delete Attribute",
-    content: RequireUniqueAlert,
-    confirmLabel: "OK",
-    onConfirm: () => {}
+  const [showRequireUniqueAlert] = useErrorAlert({
+    title: "Error Naming Data Card Field",
+    content: RequireUniqueAlert
   });
 
   const handleCompleteValue = () => {

--- a/src/plugins/data-card/components/case-attribute.tsx
+++ b/src/plugins/data-card/components/case-attribute.tsx
@@ -105,9 +105,25 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
 
   const handleCompleteName = () => {
     if (labelCandidate !== getLabel()) {
-      caseId && content.setAttName(attrKey, labelCandidate);
+      const names = content.existingAttributesWithNames().map(a => a.attrName);
+      if (!names.includes(labelCandidate)){
+        caseId && content.setAttName(attrKey, labelCandidate);
+      } else {
+        showUniqueAttributeAlert();
+      }
     }
   };
+
+  const UniqueAttributeAlertContent = () => {
+    return <p> Attribute names must be unique.</p>;
+  };
+
+  const [showUniqueAttributeAlert] = useCautionAlert({
+    title: "Delete Attribute",
+    content: UniqueAttributeAlertContent,
+    confirmLabel: "OK",
+    onConfirm: () => deleteAttribute()
+  });
 
   const handleCompleteValue = () => {
     if (valueCandidate !== getValue()) {
@@ -121,7 +137,7 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
     }
   }
 
-  const AlertContent = () => {
+  const DeleteAttributeAlertContent = () => {
     return (
       <p>
         Are you sure you want to remove the <em style={{ fontWeight: "bold"}}>{ getLabel() }</em>&nbsp;
@@ -131,15 +147,15 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
     );
   };
 
-  const [showAlert] = useCautionAlert({
+  const [showDeleteAttributeAlert] = useCautionAlert({
     title: "Delete Attribute",
-    content: AlertContent,
+    content: DeleteAttributeAlertContent,
     confirmLabel: "Delete Attribute",
     onConfirm: () => deleteAttribute()
   });
 
   const handleDeleteAttribute = () => {
-    showAlert();
+    showDeleteAttributeAlert();
   };
 
   const valueIsImage = () => {

--- a/src/plugins/data-card/components/sort-area.tsx
+++ b/src/plugins/data-card/components/sort-area.tsx
@@ -8,10 +8,11 @@ interface IProps {
 
 export const DataCardSortArea: React.FC<IProps> = ({ model }) => {
   const content = model.content as DataCardContentModelType;
-
+  const sortById = content.selectedSortAttributeId;
+  const sortByName = sortById ? content.dataSet.attrFromID(sortById).name : " ";
   return (
     <div className="sort-grid">
-      <pre>cards sorted by { content.selectedSortAttributeName }</pre>
+      <pre>cards sorted by: { sortByName }</pre>
     </div>
   );
 };

--- a/src/plugins/data-card/components/sort-area.tsx
+++ b/src/plugins/data-card/components/sort-area.tsx
@@ -11,7 +11,7 @@ export const DataCardSortArea: React.FC<IProps> = ({ model }) => {
 
   return (
     <div className="sort-grid">
-      <pre>cards sorted by { content.sortByAttributeName }</pre>
+      <pre>cards sorted by { content.selectedSortAttributeName }</pre>
     </div>
   );
 };

--- a/src/plugins/data-card/components/sort-area.tsx
+++ b/src/plugins/data-card/components/sort-area.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { ITileModel } from "../../../models/tiles/tile-model";
+import { DataCardContentModelType } from "../data-card-content";
+
+interface IProps {
+  model: ITileModel;
+}
+
+export const DataCardSortArea: React.FC<IProps> = ({ model }) => {
+  const content = model.content as DataCardContentModelType;
+
+  return (
+    <div className="sort-grid">
+      <pre>cards sorted by { content.sortByAttributeName }</pre>
+    </div>
+  );
+};

--- a/src/plugins/data-card/components/sort-select.tsx
+++ b/src/plugins/data-card/components/sort-select.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { ITileModel } from "../../../models/tiles/tile-model";
 import { DataCardContentModelType } from "../data-card-content";
+import { orderBy } from "lodash";
 
 interface IProps {
   model: ITileModel;
@@ -9,7 +10,8 @@ interface IProps {
 
 export const SortSelect: React.FC<IProps> = ({ model, onSortAttrChange }) => {
   const content = model.content as DataCardContentModelType;
-  const attrNames = content.existingAttributesWithNames();
+  const attrs = content.existingAttributesWithNames();
+  const alphaAttrs = orderBy(attrs, [attr => attr.attrName.toLowerCase()]);
 
   return (
     <div className="sort-select">
@@ -21,7 +23,7 @@ export const SortSelect: React.FC<IProps> = ({ model, onSortAttrChange }) => {
           value={content.sortByAttributeName}
         >
           <option value="none">None</option>
-          { attrNames.map((a) => {
+          { alphaAttrs.map((a) => {
             return <option key={a.attrId} value={a.attrName}>{a.attrName}</option>;
           })}
         </select>

--- a/src/plugins/data-card/components/sort-select.tsx
+++ b/src/plugins/data-card/components/sort-select.tsx
@@ -18,6 +18,7 @@ export const SortSelect: React.FC<IProps> = ({ model, onSortAttrChange }) => {
       <label>
         Sort
         <select
+          className="sort-select-input"
           name="selectedSortAttribute"
           onChange={onSortAttrChange}
           value={content.selectedSortAttributeId}

--- a/src/plugins/data-card/components/sort-select.tsx
+++ b/src/plugins/data-card/components/sort-select.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { ITileModel } from "../../../models/tiles/tile-model";
+import { DataCardContentModelType } from "../data-card-content";
+
+interface IProps {
+  model: ITileModel;
+  onSortAttrChange: (event: React.ChangeEvent<HTMLSelectElement>) => void;
+}
+
+export const SortSelect: React.FC<IProps> = ({ model, onSortAttrChange }) => {
+  const content = model.content as DataCardContentModelType;
+  const attrNames = content.existingAttributesWithNames();
+
+  return (
+    <div className="sort-select">
+      <label>
+        Sort
+        <select
+          name="selectedSortAttribute"
+          onChange={onSortAttrChange}
+          value={content.sortByAttributeName}
+        >
+          <option value="none">None</option>
+          { attrNames.map((a) => {
+            return <option key={a.attrId} value={a.attrName}>{a.attrName}</option>;
+          })}
+        </select>
+      </label>
+    </div>
+  );
+};

--- a/src/plugins/data-card/components/sort-select.tsx
+++ b/src/plugins/data-card/components/sort-select.tsx
@@ -20,7 +20,7 @@ export const SortSelect: React.FC<IProps> = ({ model, onSortAttrChange }) => {
         <select
           name="selectedSortAttribute"
           onChange={onSortAttrChange}
-          value={content.sortByAttributeName}
+          value={content.selectedSortAttributeName}
         >
           <option value="none">None</option>
           { alphaAttrs.map((a) => {

--- a/src/plugins/data-card/components/sort-select.tsx
+++ b/src/plugins/data-card/components/sort-select.tsx
@@ -20,11 +20,11 @@ export const SortSelect: React.FC<IProps> = ({ model, onSortAttrChange }) => {
         <select
           name="selectedSortAttribute"
           onChange={onSortAttrChange}
-          value={content.selectedSortAttributeName}
+          value={content.selectedSortAttributeId}
         >
-          <option value="none">None</option>
+          <option value="">None</option>
           { alphaAttrs.map((a) => {
-            return <option key={a.attrId} value={a.attrName}>{a.attrName}</option>;
+            return <option key={a.attrId} value={a.attrId}>{a.attrName}</option>;
           })}
         </select>
       </label>

--- a/src/plugins/data-card/data-card-content.ts
+++ b/src/plugins/data-card/data-card-content.ts
@@ -34,7 +34,7 @@ export const DataCardContentModel = TileContentModel
   .props({
     type: types.optional(types.literal(kDataCardTileType), kDataCardTileType),
     caseIndex: 0,
-    selectedSortAttributeName: 'none'
+    selectedSortAttributeId: types.maybe(types.string)//'none'
   })
   .volatile(self => ({
     metadata: undefined as any as ITileMetadataModel,
@@ -190,9 +190,9 @@ export const DataCardContentModel = TileContentModel
       withoutUndo();
       self.caseIndex = caseIndex;
     },
-    setselectedSortAttributeName(attrName: string){
+    setSelectedSortAttributeId(attrId: string){
       withoutUndo();
-      self.selectedSortAttributeName = attrName;
+      self.selectedSortAttributeId = attrId;
     },
     setAttName(attrId: string, name: string){
      self.dataSet.setAttributeName(attrId, name);

--- a/src/plugins/data-card/data-card-content.ts
+++ b/src/plugins/data-card/data-card-content.ts
@@ -34,7 +34,7 @@ export const DataCardContentModel = TileContentModel
   .props({
     type: types.optional(types.literal(kDataCardTileType), kDataCardTileType),
     caseIndex: 0,
-    sortByAttributeName: 'none'
+    selectedSortAttributeName: 'none'
   })
   .volatile(self => ({
     metadata: undefined as any as ITileMetadataModel,
@@ -190,9 +190,9 @@ export const DataCardContentModel = TileContentModel
       withoutUndo();
       self.caseIndex = caseIndex;
     },
-    setsortByAttributeName(attrName: string){
+    setselectedSortAttributeName(attrName: string){
       withoutUndo();
-      self.sortByAttributeName = attrName;
+      self.selectedSortAttributeName = attrName;
     },
     setAttName(attrId: string, name: string){
      self.dataSet.setAttributeName(attrId, name);

--- a/src/plugins/data-card/data-card-content.ts
+++ b/src/plugins/data-card/data-card-content.ts
@@ -33,7 +33,8 @@ export const DataCardContentModel = TileContentModel
   .named("DataCardTool")
   .props({
     type: types.optional(types.literal(kDataCardTileType), kDataCardTileType),
-    caseIndex: 0
+    caseIndex: 0,
+    sortByAttributeName: 'none'
   })
   .volatile(self => ({
     metadata: undefined as any as ITileMetadataModel,
@@ -188,6 +189,10 @@ export const DataCardContentModel = TileContentModel
       // current case is serialized, but navigation is not undoable
       withoutUndo();
       self.caseIndex = caseIndex;
+    },
+    setsortByAttributeName(attrName: string){
+      withoutUndo();
+      self.sortByAttributeName = attrName;
     },
     setAttName(attrId: string, name: string){
      self.dataSet.setAttributeName(attrId, name);

--- a/src/plugins/data-card/data-card-tile.scss
+++ b/src/plugins/data-card/data-card-tile.scss
@@ -30,130 +30,136 @@ $default-button-border-color: #979797;
     height: 100%;
   }
 
-  /* Data Card Title and Card Navigation */
-  .data-card-header-row {
-    .panel {
-      border: solid 1px $charcoal-light-1;
-      width: $card-width;
-      height: 34px;
-      font-family: Lato;
-      font-size: 14px;
-      font-weight: bold;
-      color: $cell-text-color;
-      line-height: normal;
-      letter-spacing: normal;
-      display:flex;
-      align-items: center;
-      justify-content: center;
+  .panel {
+    border: solid 1px $charcoal-light-1;
+    width: $card-width;
+    height: 34px;
+    font-family: Lato;
+    font-size: 14px;
+    font-weight: bold;
+    color: $cell-text-color;
+    line-height: normal;
+    letter-spacing: normal;
+    display:flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .panel.title {
+    background-color: $workspace-teal-light-7;
+    border-radius: 3px 3px 0px 0px;
+    font-style: italic;
+    border-bottom-width: 0px;
+
+    .data-card-title-input-editing {
+      width: 100%;
+      height: 100%;
+      font-style: normal;
+      font-weight: 300;
+      text-align: center;
+      outline:1px solid $highlight-blue;
     }
-    .panel.title {
-      background-color: $workspace-teal-light-7;
-      border-radius: 3px 3px 0px 0px;
-      font-style: italic;
-      border-bottom-width: 0px;
+  }
 
-      .data-card-title-input-editing {
-        width: 100%;
-        height: 100%;
-        font-style: normal;
-        font-weight: 300;
-        text-align: center;
-        outline:1px solid $highlight-blue;
-      }
+  .panel.sort {
+    background-color: $workspace-teal-light-6;
+    border-bottom:0px;
+    select {
+      margin-left: 8px;
+      width: 145px;
     }
-    .panel.nav {
-      background-color: $workspace-teal-light-5;
-      display: flex;
-      justify-content: space-between;
+  }
 
-      .card-number-of-listing {
-        width: $name-width;
-        text-align: right;
-        justify-content: flex-start;
+  .panel.nav {
+    background-color: $workspace-teal-light-5;
+    display: flex;
+    justify-content: space-between;
 
-        .cell-text {
-          padding: $cell-padding;
-        }
-      }
+    .card-number-of-listing {
+      width: $name-width;
+      text-align: right;
+      justify-content: flex-start;
 
-      .card-nav-buttons {
-        flex-grow: 1;
-        padding-left: 5px;
-        .card-nav {
-          color:$workspace-teal;
-          width:26px;
-          height:26px;
-          border: 1.5px solid $default-button-border-color;
-          background-color: $workspace-teal-light-9;
-          margin:3px;
-          padding:$quarter-padding;
-          border-radius: 5px;
-        }
-        .previous {
-          background-image: url('./assets/arrow-back-icon.svg');
-          background-position-x: -1px;
-        }
-        .next {
-          background-image: url('./assets/arrow-back-icon.svg');
-          transform: rotateY(180deg);
-          background-position-x: -1px;
-        }
-        .active {
-          border-color:$default-button-border-color;
-          &:hover {
-            background-color: $workspace-teal-light-4;
-            cursor:pointer;
-          }
-          &:active {
-            background-color: $workspace-teal-light-3;
-          }
-        }
-
-        .next.disabled, .previous.disabled {
-          border-color:#d8d8d8;
-          color:$workspace-teal-light-4;
-          background-image: url('./assets/arrow-back-faded.svg');
-        }
+      .cell-text {
+        padding: $cell-padding;
       }
     }
 
-    .add-remove-card-buttons {
-      width: 30%;
-      display: flex;
-      justify-content: flex-end;
-      padding-right: 5px;
-      text-align: end;
-
-      button {
-        background-color: transparent;
-        height:26px;
+    .card-nav-buttons {
+      flex-grow: 1;
+      padding-left: 5px;
+      .card-nav {
+        color:$workspace-teal;
         width:26px;
-        cursor:pointer;
-        border:none;
-        margin-top:1px;
-        padding:0px;
-        left:9px;
-        top:1px;
+        height:26px;
+        border: 1.5px solid $default-button-border-color;
+        background-color: $workspace-teal-light-9;
+        margin:3px;
+        padding:$quarter-padding;
+        border-radius: 5px;
+      }
+      .previous {
+        background-image: url('./assets/arrow-back-icon.svg');
+        background-position-x: -1px;
+      }
+      .next {
+        background-image: url('./assets/arrow-back-icon.svg');
+        transform: rotateY(180deg);
+        background-position-x: -1px;
+      }
+      .active {
+        border-color:$default-button-border-color;
+        &:hover {
+          background-color: $workspace-teal-light-4;
+          cursor:pointer;
+        }
+        &:active {
+          background-color: $workspace-teal-light-3;
+        }
+      }
 
-        svg {
-          fill:$workspace-teal;
-          height:24px;
-          width:24px;
-          &:hover {
-            background-color: $workspace-teal-light-3;
-          }
-          &:active {
-            background-color: $workspace-teal;
-            fill: $workspace-teal;
-            border-color:white;
-          }
+      .next.disabled, .previous.disabled {
+        border-color:#d8d8d8;
+        color:$workspace-teal-light-4;
+        background-image: url('./assets/arrow-back-faded.svg');
+      }
+    }
+  }
+
+  .add-remove-card-buttons {
+    width: 30%;
+    display: flex;
+    justify-content: flex-end;
+    padding-right: 5px;
+    text-align: end;
+
+    button {
+      background-color: transparent;
+      height:26px;
+      width:26px;
+      cursor:pointer;
+      border:none;
+      margin-top:1px;
+      padding:0px;
+      left:9px;
+      top:1px;
+
+      svg {
+        fill:$workspace-teal;
+        height:24px;
+        width:24px;
+        &:hover {
+          background-color: $workspace-teal-light-3;
+        }
+        &:active {
+          background-color: $workspace-teal;
+          fill: $workspace-teal;
+          border-color:white;
         }
       }
     }
   }
 
-  /* attributes and their values */
-  .data-area {
+  .single-card-data-area {
     width: $card-width;
 
     /* saved state attributes */
@@ -256,4 +262,14 @@ $default-button-border-color: #979797;
     // half of 35% minus half the width of the icon
     margin-left: ($card-width * 0.175) - 12px;
   }
+
+  .sorting-cards-data-area {
+    // each card is specified as 160px, plus 6 * 10px margins over three columns
+    width: 540px;
+    background-color: $workspace-teal-light-4;
+    border: solid 1px $charcoal-light-1;
+    padding:$cell-padding;
+  }
+
+
 }

--- a/src/plugins/data-card/data-card-tile.tsx
+++ b/src/plugins/data-card/data-card-tile.tsx
@@ -16,7 +16,6 @@ import { DataCardSortArea } from "./components/sort-area";
 
 import "./data-card-tile.scss";
 
-
 export const DataCardToolComponent: React.FC<ITileProps> = observer((props) => {
   const { model, onRequestUniqueTitle, readOnly, documentContent, tileElt, onRegisterTileApi,
             onUnregisterTileApi } = props;
@@ -30,8 +29,8 @@ export const DataCardToolComponent: React.FC<ITileProps> = observer((props) => {
   const [imageUrlToAdd, setImageUrlToAdd] = useState<string>("");
   const shouldShowAddCase = !readOnly && isTileSelected;
   const shouldShowDeleteCase = !readOnly && isTileSelected && content.dataSet.cases.length > 1;
-  const displayAs = !content.selectedSortAttributeId ? "single" : "sorted";
-  const shouldShowAddField = !readOnly && isTileSelected && displayAs === "single";
+  const displaySingle = !content.selectedSortAttributeId;
+  const shouldShowAddField = !readOnly && isTileSelected && displaySingle;
 
   useEffect(() => {
     if (!content.title) {
@@ -221,7 +220,7 @@ export const DataCardToolComponent: React.FC<ITileProps> = observer((props) => {
           <SortSelect model={model} onSortAttrChange={setSort} />
         </div>
 
-        { displayAs === "single" &&
+        { displaySingle &&
           <div className="panel nav">
             <div className="card-number-of-listing">
               <div className="cell-text">
@@ -242,7 +241,7 @@ export const DataCardToolComponent: React.FC<ITileProps> = observer((props) => {
             }
           </div>
         }
-        { displayAs === "single" &&
+        { displaySingle &&
           <div className="single-card-data-area">
             { content.totalCases > 0 &&
               <DataCardRows
@@ -263,7 +262,7 @@ export const DataCardToolComponent: React.FC<ITileProps> = observer((props) => {
         { shouldShowAddField && !readOnly &&
           <AddIconButton className="add-field" onClick={handleAddField} />
         }
-        { displayAs === "sorted" &&
+        { !displaySingle &&
           <div className="sorting-cards-data-area">
             <DataCardSortArea model={model} />
           </div>

--- a/src/plugins/data-card/data-card-tile.tsx
+++ b/src/plugins/data-card/data-card-tile.tsx
@@ -30,7 +30,7 @@ export const DataCardToolComponent: React.FC<ITileProps> = observer((props) => {
   const [imageUrlToAdd, setImageUrlToAdd] = useState<string>("");
   const shouldShowAddCase = !readOnly && isTileSelected;
   const shouldShowDeleteCase = !readOnly && isTileSelected && content.dataSet.cases.length > 1;
-  const displayAs = content.selectedSortAttributeName === "none" ? "single" : "sorted";
+  const displayAs = !content.selectedSortAttributeId ? "single" : "sorted";
   const shouldShowAddField = !readOnly && isTileSelected && displayAs === "single";
 
   useEffect(() => {
@@ -96,7 +96,7 @@ export const DataCardToolComponent: React.FC<ITileProps> = observer((props) => {
   };
 
   function setSort(event: React.ChangeEvent<HTMLSelectElement>){
-    content.setselectedSortAttributeName(event.target.value);
+    content.setSelectedSortAttributeId(event.target.value);
   }
 
   function addNewCase(){

--- a/src/plugins/data-card/data-card-tile.tsx
+++ b/src/plugins/data-card/data-card-tile.tsx
@@ -29,7 +29,7 @@ export const DataCardToolComponent: React.FC<ITileProps> = observer((props) => {
   const [imageUrlToAdd, setImageUrlToAdd] = useState<string>("");
   const shouldShowAddCase = !readOnly && isTileSelected;
   const shouldShowDeleteCase = !readOnly && isTileSelected && content.dataSet.cases.length > 1;
-  const displayAs = content.sortByAttributeName === "none" ? "single" : "sorted";
+  const displayAs = content.selectedSortAttributeName === "none" ? "single" : "sorted";
   const shouldShowAddField = !readOnly && isTileSelected && displayAs === "single";
 
   useEffect(() => {
@@ -95,7 +95,7 @@ export const DataCardToolComponent: React.FC<ITileProps> = observer((props) => {
   };
 
   function setSort(event: React.ChangeEvent<HTMLSelectElement>){
-    content.setsortByAttributeName(event.target.value);
+    content.setselectedSortAttributeName(event.target.value);
   }
 
   function addNewCase(){

--- a/src/plugins/data-card/data-card-tile.tsx
+++ b/src/plugins/data-card/data-card-tile.tsx
@@ -7,12 +7,14 @@ import { addCanonicalCasesToDataSet } from "../../models/data/data-set";
 import { DataCardContentModelType } from "./data-card-content";
 import { DataCardRows } from "./components/data-card-rows";
 import { DataCardToolbar } from "./data-card-toolbar";
+import { SortSelect } from "./components/sort-select";
 import { useToolbarTileApi } from "../../components/tiles/hooks/use-toolbar-tile-api";
 import { AddIconButton, RemoveIconButton } from "./components/add-remove-icons";
 import { useCautionAlert } from "../../components/utilities/use-caution-alert";
 import { EditFacet } from "./data-card-types";
 
 import "./data-card-tile.scss";
+import { DataCardSortArea } from "./components/sort-area";
 
 export const DataCardToolComponent: React.FC<ITileProps> = observer((props) => {
   const { model, onRequestUniqueTitle, readOnly, documentContent, tileElt, onRegisterTileApi,
@@ -27,7 +29,8 @@ export const DataCardToolComponent: React.FC<ITileProps> = observer((props) => {
   const [imageUrlToAdd, setImageUrlToAdd] = useState<string>("");
   const shouldShowAddCase = !readOnly && isTileSelected;
   const shouldShowDeleteCase = !readOnly && isTileSelected && content.dataSet.cases.length > 1;
-  const shouldShowAddField = !readOnly && isTileSelected;
+  const displayAs = content.sortByAttributeName === "none" ? "single" : "sorted";
+  const shouldShowAddField = !readOnly && isTileSelected && displayAs === "single";
 
   useEffect(() => {
     if (!content.title) {
@@ -90,6 +93,10 @@ export const DataCardToolComponent: React.FC<ITileProps> = observer((props) => {
     }
     setIsEditingTitle(false);
   };
+
+  function setSort(event: React.ChangeEvent<HTMLSelectElement>){
+    content.setsortByAttributeName(event.target.value);
+  }
 
   function addNewCase(){
     content.addNewCaseFromAttrKeys(content.existingAttributes());
@@ -207,6 +214,13 @@ export const DataCardToolComponent: React.FC<ITileProps> = observer((props) => {
               </div>
             }
           </div>
+        </div>
+
+        <div className="panel sort">
+          <SortSelect model={model} onSortAttrChange={(e) => setSort(e)} />
+        </div>
+
+        { displayAs === "single" &&
           <div className="panel nav">
             <div className="card-number-of-listing">
               <div className="cell-text">
@@ -226,25 +240,33 @@ export const DataCardToolComponent: React.FC<ITileProps> = observer((props) => {
               </div>
             }
           </div>
-        </div>
-        <div className="data-area">
-          { content.totalCases > 0 &&
-            <DataCardRows
-              caseIndex={content.caseIndex}
-              model={model}
-              totalCases={content.totalCases}
-              readOnly={readOnly}
-              currEditAttrId={currEditAttrId}
-              currEditFacet={currEditFacet}
-              setCurrEditAttrId={setCurrEditAttrId}
-              setCurrEditFacet={setCurrEditFacet}
-              imageUrlToAdd={imageUrlToAdd}
-              setImageUrlToAdd={setImageUrlToAdd}
-            />
-          }
-        </div>
+        }
+        { displayAs === "single" &&
+          <div className="single-card-data-area">
+            { content.totalCases > 0 &&
+              <DataCardRows
+                caseIndex={content.caseIndex}
+                model={model}
+                totalCases={content.totalCases}
+                readOnly={readOnly}
+                currEditAttrId={currEditAttrId}
+                currEditFacet={currEditFacet}
+                setCurrEditAttrId={setCurrEditAttrId}
+                setCurrEditFacet={setCurrEditFacet}
+                imageUrlToAdd={imageUrlToAdd}
+                setImageUrlToAdd={setImageUrlToAdd}
+              />
+            }
+          </div>
+        }
         { shouldShowAddField && !readOnly &&
-          <AddIconButton className="add-field" onClick={handleAddField} /> }
+          <AddIconButton className="add-field" onClick={handleAddField} />
+        }
+        { displayAs === "sorted" &&
+          <div className="sorting-cards-data-area">
+            <DataCardSortArea model={model} />
+          </div>
+        }
       </div>
     </div>
   );

--- a/src/plugins/data-card/data-card-tile.tsx
+++ b/src/plugins/data-card/data-card-tile.tsx
@@ -12,9 +12,10 @@ import { useToolbarTileApi } from "../../components/tiles/hooks/use-toolbar-tile
 import { AddIconButton, RemoveIconButton } from "./components/add-remove-icons";
 import { useCautionAlert } from "../../components/utilities/use-caution-alert";
 import { EditFacet } from "./data-card-types";
+import { DataCardSortArea } from "./components/sort-area";
 
 import "./data-card-tile.scss";
-import { DataCardSortArea } from "./components/sort-area";
+
 
 export const DataCardToolComponent: React.FC<ITileProps> = observer((props) => {
   const { model, onRequestUniqueTitle, readOnly, documentContent, tileElt, onRegisterTileApi,
@@ -217,7 +218,7 @@ export const DataCardToolComponent: React.FC<ITileProps> = observer((props) => {
         </div>
 
         <div className="panel sort">
-          <SortSelect model={model} onSortAttrChange={(e) => setSort(e)} />
+          <SortSelect model={model} onSortAttrChange={setSort} />
         </div>
 
         { displayAs === "single" &&


### PR DESCRIPTION
This implements a basic select menu for Data Card sorting, as described in  [PT #184552058](https://www.pivotaltracker.com/n/projects/2441242/stories/184552058)

- A sort selector includes all fields added by the user to the deck
- When fields are added to a card, the new field shows up on the sort in alphabetical order
- When a field is removed from the deck, the field name is removed from the list
- The sort by selection persists in the model (across reloads)