### PR TITLE
183368099 Fix geometry board export

### DIFF
--- a/src/components/tiles/geometry/geometry-content.tsx
+++ b/src/components/tiles/geometry/geometry-content.tsx
@@ -312,7 +312,8 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
       const geometryContent = content as GeometryContentModelType;
       if (size && size.width && size.height && (!prevProps.size ||
           ((size.width !== prevProps.size.width) || (size.height !== prevProps.size.height)))) {
-        geometryContent.resizeBoard(this.state.board, size.width, size.height, scale);
+        // console.log(`resizing`, this.props.model.id);
+        geometryContent.resizeBoard(this.state.board, size.width, size.height, scale, this.props.model.id);
       }
 
       // Handle new scale

--- a/src/models/tiles/geometry/geometry-content.ts
+++ b/src/models/tiles/geometry/geometry-content.ts
@@ -17,7 +17,7 @@ import {
   isPointModel, isPolygonModel, MovableLineModel, PointModel, PolygonModel, VertexAngleModel
 } from "./geometry-model";
 import {
-  getObjectById, guessUserDesiredBoundingBox, kAxisBuffer, kXAxisMinBuffer, kXAxisTotalBuffer, kYAxisTotalBuffer,
+  getBoardUnitsAndBuffers, getObjectById, guessUserDesiredBoundingBox, kXAxisTotalBuffer, kYAxisTotalBuffer,
   resumeBoardUpdates, suspendBoardUpdates
 } from "./jxg-board";
 import {
@@ -420,20 +420,17 @@ export const GeometryContentModel = GeometryBaseContentModel
       board && JXG.JSXGraph.freeBoard(board);
     }
 
-    function resizeBoard(board: JXG.Board, width: number, height: number, scale?: number) {
+    function resizeBoard(board: JXG.Board, width: number, height: number, scale?: number, id?: string) {
+      if (id === "1-rchbtK5TpKQlL-") debugger;
       // JSX Graph canvasWidth and canvasHeight are truncated to integers,
       // so we need to do the same to get the new canvasWidth and canvasHeight values
       const scaledWidth = Math.trunc(width) / (scale || 1);
       const scaledHeight = Math.trunc(height) / (scale || 1);
       const widthMultiplier = (scaledWidth - kXAxisTotalBuffer) / (board.canvasWidth - kXAxisTotalBuffer);
       const heightMultiplier = (scaledHeight - kYAxisTotalBuffer) / (board.canvasHeight - kYAxisTotalBuffer);
-      const unitX = board.unitX || kGeometryDefaultPixelsPerUnit;
-      const unitY = board.unitY || kGeometryDefaultPixelsPerUnit;
       // Remove the buffers to correct the graph proportions
       const [xMin, yMax, xMax, yMin] = guessUserDesiredBoundingBox(board);
-      const xMinBufferRange = kXAxisMinBuffer / unitX;
-      const xMaxBufferRange = kAxisBuffer / unitX;
-      const yBufferRange = kAxisBuffer / unitY;
+      const { xMinBufferRange, xMaxBufferRange, yBufferRange } = getBoardUnitsAndBuffers(board);
       // Add the buffers back post-scaling
       const newBoundingBox: JXG.BoundingBox = [
         xMin * widthMultiplier - xMinBufferRange,

--- a/src/models/tiles/geometry/geometry-content.ts
+++ b/src/models/tiles/geometry/geometry-content.ts
@@ -258,7 +258,7 @@ export const GeometryContentModel = GeometryBaseContentModel
       return board.objectsList.filter(obj => self.isSelected(obj.id));
     },
     exportJson(options?: ITileExportOptions) {
-      const changes = convertModelToChanges(self);
+      const changes = convertModelToChanges(self, false);
       const jsonChanges = changes.map(change => JSON.stringify(change));
       return exportGeometryJson(jsonChanges, options);
     }
@@ -395,7 +395,7 @@ export const GeometryContentModel = GeometryBaseContentModel
     // actions
     function initializeBoard(domElementID: string, onCreate?: onCreateCallback): JXG.Board | undefined {
       let board: JXG.Board | undefined;
-      const changes = convertModelToChanges(self);
+      const changes = convertModelToChanges(self, true);
       applyChanges(domElementID, changes, getDispatcherContext())
         .filter(result => result != null)
         .forEach(changeResult => {
@@ -421,7 +421,6 @@ export const GeometryContentModel = GeometryBaseContentModel
     }
 
     function resizeBoard(board: JXG.Board, width: number, height: number, scale?: number, id?: string) {
-      if (id === "1-rchbtK5TpKQlL-") debugger;
       // JSX Graph canvasWidth and canvasHeight are truncated to integers,
       // so we need to do the same to get the new canvasWidth and canvasHeight values
       const scaledWidth = Math.trunc(width) / (scale || 1);

--- a/src/models/tiles/geometry/geometry-import.ts
+++ b/src/models/tiles/geometry/geometry-import.ts
@@ -243,6 +243,11 @@ export function preprocessImportFormat(snapshot: any): GeometryExtrasContentSnap
       yAxis: { ...yAxisBase, name: axisNames?.[1], label: axisLabels?.[1] },
       ...others
     });
+    if (xAxisBase.range && xAxisBase.range < 26 && xAxisBase.range > 25) {
+      console.log(`axisRange`, axisRange);
+      console.log(`xAxisBase`, xAxisBase);
+      console.log(`board`, board);
+    }
   }
 
   addBoard(boardSpecs);

--- a/src/models/tiles/geometry/geometry-import.ts
+++ b/src/models/tiles/geometry/geometry-import.ts
@@ -178,16 +178,18 @@ function getBoardBounds(axisMin?: JXGCoordPair, protoRange?: JXGCoordPair) {
   return [xAxis.min, yAxisMax, xAxisMax, yAxis.min];
 }
 
-export function defaultGeometryBoardChange(xAxis: AxisModelType, yAxis: AxisModelType, overrides?: JXGProperties) {
+export function defaultGeometryBoardChange(
+  xAxis: AxisModelType, yAxis: AxisModelType, overrides?: JXGProperties, addBuffers?: boolean
+) {
   const axisMin: JXGCoordPair = [xAxis.min, yAxis.min];
   const axisRange: JXGCoordPair = [xAxis.range ?? kGeometryDefaultWidth / xAxis.unit,
                                    yAxis.range ?? kGeometryDefaultHeight / yAxis.unit];
   const [xMin, yMax, xMax, yMin] = getBoardBounds(axisMin, axisRange);
   const unitX = xAxis.unit || kGeometryDefaultPixelsPerUnit;
   const unitY = yAxis.unit || kGeometryDefaultPixelsPerUnit;
-  const xMinBufferRange = kXAxisMinBuffer / unitX;
-  const xMaxBufferRange = kAxisBuffer / unitX;
-  const yBufferRange = kAxisBuffer / unitY;
+  const xMinBufferRange = addBuffers ? kXAxisMinBuffer / unitX : 0;
+  const xMaxBufferRange = addBuffers ? kAxisBuffer / unitX : 0;
+  const yBufferRange = addBuffers ? kAxisBuffer / unitY : 0;
   const boundingBox = [xMin - xMinBufferRange, yMax + yBufferRange, xMax + xMaxBufferRange, yMin - yBufferRange];
   const change: JXGChange = {
     operation: "create",
@@ -195,8 +197,6 @@ export function defaultGeometryBoardChange(xAxis: AxisModelType, yAxis: AxisMode
     properties: {
       axis: true,
       boundingBox,
-      unitX,
-      unitY,
       ...overrides
     }
   };
@@ -243,11 +243,6 @@ export function preprocessImportFormat(snapshot: any): GeometryExtrasContentSnap
       yAxis: { ...yAxisBase, name: axisNames?.[1], label: axisLabels?.[1] },
       ...others
     });
-    if (xAxisBase.range && xAxisBase.range < 26 && xAxisBase.range > 25) {
-      console.log(`axisRange`, axisRange);
-      console.log(`xAxisBase`, xAxisBase);
-      console.log(`board`, board);
-    }
   }
 
   addBoard(boardSpecs);

--- a/src/models/tiles/geometry/geometry-migrate.ts
+++ b/src/models/tiles/geometry/geometry-migrate.ts
@@ -31,14 +31,14 @@ export const convertChangesToModel = (changes: JXGChange[]) => {
   return exportGeometryModel(changesJson);
 };
 
-export const convertModelToChanges = (model: GeometryBaseContentModelType): JXGChange[] => {
+export const convertModelToChanges = (model: GeometryBaseContentModelType, addBuffers?: boolean): JXGChange[] => {
   const { board, bgImage, objects } = model;
   const changes: JXGChange[] = [];
   // convert the board
   const { xAxis, yAxis } = board || BoardModel.create(kDefaultBoardModelOutputProps);
   const { name: xName, label: xAnnotation } = xAxis;
   const { name: yName, label: yAnnotation } = yAxis;
-  changes.push(defaultGeometryBoardChange(xAxis, yAxis, { xName, yName, xAnnotation, yAnnotation } ));
+  changes.push(defaultGeometryBoardChange(xAxis, yAxis, { xName, yName, xAnnotation, yAnnotation }, addBuffers ));
   // convert the background image (if any)
   if (bgImage) {
     changes.push(...convertModelObjectToChanges(bgImage));

--- a/src/models/tiles/geometry/jxg-board.ts
+++ b/src/models/tiles/geometry/jxg-board.ts
@@ -182,13 +182,19 @@ function scaleBoundingBoxToElement(domElementID: string, changeProps: any) {
   return [xMin, yMax, xMax, yMin] as JXG.BoundingBox;
 }
 
-export function guessUserDesiredBoundingBox(board: JXG.Board) {
-  const [xMin, yMax, xMax, yMin] = board.getBoundingBox();
-  const unitX = board.unitX;
-  const unitY = board.unitY;
+export function getBoardUnitsAndBuffers(board: JXG.Board) {
+  const unitX = board.unitX || kGeometryDefaultPixelsPerUnit;
+  const unitY = board.unitY || kGeometryDefaultPixelsPerUnit;
   const xMinBufferRange = kXAxisMinBuffer / unitX;
   const xMaxBufferRange = kAxisBuffer / unitX;
   const yBufferRange = kAxisBuffer / unitY;
+
+  return { unitX, unitY, xMinBufferRange, xMaxBufferRange, yBufferRange };
+}
+
+export function guessUserDesiredBoundingBox(board: JXG.Board) {
+  const [xMin, yMax, xMax, yMin] = board.getBoundingBox();
+  const { xMinBufferRange, xMaxBufferRange, yBufferRange } = getBoardUnitsAndBuffers(board);
 
   return [xMin + xMinBufferRange, yMax - yBufferRange, xMax - xMaxBufferRange, yMin + yBufferRange];
 }

--- a/src/models/tiles/geometry/jxg-board.ts
+++ b/src/models/tiles/geometry/jxg-board.ts
@@ -76,7 +76,7 @@ export function syncLinkedPoints(board: JXG.Board, links: ITableLinkProperties) 
 export const kAxisBuffer = 20;
 // twice as much buffer for left side of X axis for Y axis labels
 export const kXAxisMinBuffer = 2 * kAxisBuffer;
-export const kXAxisTotalBuffer = 3 * kAxisBuffer;
+export const kXAxisTotalBuffer = kXAxisMinBuffer + kAxisBuffer;
 export const kYAxisTotalBuffer = 2 * kAxisBuffer;
 
 export const getAxisType = (v: any) => {
@@ -307,7 +307,7 @@ export const boardChangeAgent: JXGChangeAgent = {
                           ...toObj("xAnnotation", xAnnotation), ...toObj("yAnnotation", yAnnotation)
                         });
     return [board, ...axes];
-},
+  },
 
   update: (board: JXG.Board, change: JXGChange) => {
     if (!change.properties) { return; }

--- a/src/public/curriculum/stretching-and-shrinking/stretching-and-shrinking.json
+++ b/src/public/curriculum/stretching-and-shrinking/stretching-and-shrinking.json
@@ -3525,8 +3525,8 @@
                         "type": "Geometry",
                         "board": {
                           "properties": {
-                            "axisMin": [-12.096, -15],
-                            "axisRange": [25.153, 16],
+                            "axisMin": [-9.9, -14],
+                            "axisRange": [11.9, 16],
                             "axisNames": ["x", "y"],
                             "axisLabels": ["x", "y"]
                           }

--- a/src/public/curriculum/stretching-and-shrinking/stretching-and-shrinking.json
+++ b/src/public/curriculum/stretching-and-shrinking/stretching-and-shrinking.json
@@ -3525,8 +3525,8 @@
                         "type": "Geometry",
                         "board": {
                           "properties": {
-                            "axisMin": [-10, -14],
-                            "axisRange": [10, 12],
+                            "axisMin": [-12.096, -15],
+                            "axisRange": [25.153, 16],
                             "axisNames": ["x", "y"],
                             "axisLabels": ["x", "y"]
                           }


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/183368099

The geometry tile adds some buffer to the user requested size in order to accommodate labels. This buffer is added and removed in different situations when the size of the tile changes and other contexts. Previously, the buffer was not being removed when exporting json, so when the tile was added to curriculum, the buffer was effectively being added twice. This, combined with how the tile will adjust what it shows based on size, made certain tiles show bizarre portions of the geometry space in curriculum.

This PR fixes the issue by removing the buffer when exporting json, as well as removing the units (since these can be computed based on the bounding box anyway). It also fixes the particular curriculum tile that was showing the problem in the first place.