### PR TITLE
fix: Expression variable behaviour (PT-184616625)

### DIFF
--- a/src/hooks/use-custom-modal.tsx
+++ b/src/hooks/use-custom-modal.tsx
@@ -33,9 +33,11 @@ interface IProps<IContentProps> {
   // defined left-to-right, e.g. Extra Button, Cancel, OK
   buttons: IModalButton[];
   onClose?: () => void;
+  setDialogPresent?: (present: boolean) => void;
 }
 export const useCustomModal = <IContentProps,>({
-  className, Icon, title, Content, contentProps, focusElement, canCancel, buttons, onClose
+  className, Icon, title, Content, contentProps, focusElement, canCancel, buttons,
+  onClose, setDialogPresent
 }: IProps<IContentProps>, dependencies?: any[]) => {
 
   const [contentElt, setContentElt] = useState<HTMLDivElement>();
@@ -67,6 +69,7 @@ export const useCustomModal = <IContentProps,>({
 
   const handleAfterOpen = ({overlayEl, contentEl}: { overlayEl: Element, contentEl: HTMLDivElement }) => {
     setContentElt(contentEl);
+    setDialogPresent?.(true);
 
     const element = focusElement && contentEl.querySelector(focusElement) as HTMLElement || contentEl;
     element && setTimeout(() => {
@@ -77,7 +80,8 @@ export const useCustomModal = <IContentProps,>({
 
   const handleClose = useCallback(() => {
     hideModalRef.current?.();
-  }, []);
+    setDialogPresent?.(false);
+  }, [setDialogPresent]);
   handleCloseRef.current = handleClose;
 
   const [showModal, hideModal] = useModal(() => {

--- a/src/plugins/diagram-viewer/diagram-tile.tsx
+++ b/src/plugins/diagram-viewer/diagram-tile.tsx
@@ -22,6 +22,7 @@ export const DiagramToolComponent: React.FC<ITileProps> = observer((
   { documentContent, model, onRegisterTileApi, onUnregisterTileApi, readOnly, scale, tileElt }
 ) => {
   const content = model.content as DiagramContentModelType;
+  const [dialogPresent, setDialogPresent] = useState(false); 
 
   const [diagramHelper, setDiagramHelper] = useState<DiagramHelper | undefined>();
   const [interactionLocked, setInteractionLocked] = useState(false);
@@ -40,7 +41,8 @@ export const DiagramToolComponent: React.FC<ITileProps> = observer((
   };
 
   const [showEditVariableDialog] = useEditVariableDialog({
-    variable: content.root.selectedNode?.variable
+    variable: content.root.selectedNode?.variable,
+    setDialogPresent
   });
   
   const insertVariables = (variablesToInsert: VariableType[], startX?: number, startY?: number) => {
@@ -69,8 +71,11 @@ export const DiagramToolComponent: React.FC<ITileProps> = observer((
   };
   const insertVariable = (variable: VariableType, x?: number, y?: number) => insertVariables([variable], x, y);
 
-  const [showNewVariableDialog] =
-    useNewVariableDialog({ addVariable: insertVariable, sharedModel: content.sharedModel as SharedVariablesType });
+  const [showNewVariableDialog] = useNewVariableDialog({
+    addVariable: insertVariable,
+    sharedModel: content.sharedModel as SharedVariablesType,
+    setDialogPresent
+  });
 
   const { selfVariables, otherVariables, unusedVariables } = variableBuckets(content, content.sharedModel);
   const [showInsertVariableDialog] = useInsertVariableDialog({
@@ -131,6 +136,7 @@ export const DiagramToolComponent: React.FC<ITileProps> = observer((
       />
       <div className="drop-target" ref={setNodeRef} style={dropTargetStyle}>
         <Diagram
+          dialogPresent={dialogPresent}
           dqRoot={content.root}
           hideControls={true}
           hideNavigator={!!content.hideNavigator}

--- a/src/plugins/shared-variables/dialog/use-edit-variable-dialog.tsx
+++ b/src/plugins/shared-variables/dialog/use-edit-variable-dialog.tsx
@@ -10,8 +10,9 @@ import './variable-dialog.scss';
 interface IProps {
   variable?: VariableType;
   onClose?: () => void;
+  setDialogPresent?: (present: boolean) => void;
 }
-export const useEditVariableDialog = ({ variable, onClose }: IProps) => {
+export const useEditVariableDialog = ({ variable, onClose, setDialogPresent }: IProps) => {
   // We use a clone of the variable for the edit dialog so the user can modify its properties, but those
   // changes won't be saved unless the Save button is pushed. We also cache variableClone with useMemo to
   // minimize the number of times it's recreated. These two things cause two side effects:
@@ -46,7 +47,8 @@ export const useEditVariableDialog = ({ variable, onClose }: IProps) => {
         onClick: handleClick
       }
     ],
-    onClose
+    onClose,
+    setDialogPresent
   }, [variable, variableClone, count]);
 
   const _showModal = () => {

--- a/src/plugins/shared-variables/dialog/use-new-variable-dialog.tsx
+++ b/src/plugins/shared-variables/dialog/use-new-variable-dialog.tsx
@@ -13,9 +13,10 @@ interface IUseNewVariableDialog {
   descriptionPrefill?: string;
   noUndo?: boolean;
   onClose?: () => void;
+  setDialogPresent?: (present: boolean) => void;
 }
 export const useNewVariableDialog = ({
-  addVariable, sharedModel, descriptionPrefill, noUndo = false, onClose
+  addVariable, sharedModel, descriptionPrefill, noUndo = false, onClose, setDialogPresent
 }: IUseNewVariableDialog) => {
   const [newVariable, setNewVariable] = useState(Variable.create({description: descriptionPrefill || undefined}));
 
@@ -41,7 +42,8 @@ export const useNewVariableDialog = ({
         onClick: handleClick
       }
     ],
-    onClose
+    onClose,
+    setDialogPresent
   }, [addVariable, newVariable]);
 
   // Wrap useCustomModal's show so we can prefill with variable description


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/184616625

BUG: When a variable card is selected in a diagram tile and the Edit Variable dialog is opened but none of its fields are in focus, hitting the keyboard Delete key results in the selected variable card being deleted.

This change prevents the bug by disabling the default Delete key behavior for variable cards when a dialog is present.

These changes build on [these related changes to diagram-view](https://github.com/concord-consortium/quantity-playground/pull/69).