### PR TITLE
fix: Expression variable behaviour (PT-184616625)

### DIFF
--- a/src/hooks/use-custom-modal.tsx
+++ b/src/hooks/use-custom-modal.tsx
@@ -33,11 +33,10 @@ interface IProps<IContentProps> {
   // defined left-to-right, e.g. Extra Button, Cancel, OK
   buttons: IModalButton[];
   onClose?: () => void;
-  setDialogPresent?: (present: boolean) => void;
 }
 export const useCustomModal = <IContentProps,>({
   className, Icon, title, Content, contentProps, focusElement, canCancel, buttons,
-  onClose, setDialogPresent
+  onClose
 }: IProps<IContentProps>, dependencies?: any[]) => {
 
   const [contentElt, setContentElt] = useState<HTMLDivElement>();
@@ -51,13 +50,13 @@ export const useCustomModal = <IContentProps,>({
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      e.stopPropagation();
       if (e.key === "Enter" && !(e.target instanceof HTMLTextAreaElement)) {
         const defaultButton = buttons.find(b => b.isDefault);
         if (defaultButton && !defaultButton.isDisabled) {
           blurModal();
           // useRef to avoid circular dependencies
           invokeButton(defaultButton, handleCloseRef.current);
-          e.stopPropagation();
           e.preventDefault();
         }
       }
@@ -69,7 +68,6 @@ export const useCustomModal = <IContentProps,>({
 
   const handleAfterOpen = ({overlayEl, contentEl}: { overlayEl: Element, contentEl: HTMLDivElement }) => {
     setContentElt(contentEl);
-    setDialogPresent?.(true);
 
     const element = focusElement && contentEl.querySelector(focusElement) as HTMLElement || contentEl;
     element && setTimeout(() => {
@@ -80,8 +78,7 @@ export const useCustomModal = <IContentProps,>({
 
   const handleClose = useCallback(() => {
     hideModalRef.current?.();
-    setDialogPresent?.(false);
-  }, [setDialogPresent]);
+  }, []);
   handleCloseRef.current = handleClose;
 
   const [showModal, hideModal] = useModal(() => {

--- a/src/plugins/diagram-viewer/diagram-tile.tsx
+++ b/src/plugins/diagram-viewer/diagram-tile.tsx
@@ -22,7 +22,6 @@ export const DiagramToolComponent: React.FC<ITileProps> = observer((
   { documentContent, model, onRegisterTileApi, onUnregisterTileApi, readOnly, scale, tileElt }
 ) => {
   const content = model.content as DiagramContentModelType;
-  const [dialogPresent, setDialogPresent] = useState(false); 
 
   const [diagramHelper, setDiagramHelper] = useState<DiagramHelper | undefined>();
   const [interactionLocked, setInteractionLocked] = useState(false);
@@ -41,8 +40,7 @@ export const DiagramToolComponent: React.FC<ITileProps> = observer((
   };
 
   const [showEditVariableDialog] = useEditVariableDialog({
-    variable: content.root.selectedNode?.variable,
-    setDialogPresent
+    variable: content.root.selectedNode?.variable
   });
   
   const insertVariables = (variablesToInsert: VariableType[], startX?: number, startY?: number) => {
@@ -73,8 +71,7 @@ export const DiagramToolComponent: React.FC<ITileProps> = observer((
 
   const [showNewVariableDialog] = useNewVariableDialog({
     addVariable: insertVariable,
-    sharedModel: content.sharedModel as SharedVariablesType,
-    setDialogPresent
+    sharedModel: content.sharedModel as SharedVariablesType
   });
 
   const { selfVariables, otherVariables, unusedVariables } = variableBuckets(content, content.sharedModel);
@@ -136,7 +133,6 @@ export const DiagramToolComponent: React.FC<ITileProps> = observer((
       />
       <div className="drop-target" ref={setNodeRef} style={dropTargetStyle}>
         <Diagram
-          dialogPresent={dialogPresent}
           dqRoot={content.root}
           hideControls={true}
           hideNavigator={!!content.hideNavigator}

--- a/src/plugins/shared-variables/dialog/use-edit-variable-dialog.tsx
+++ b/src/plugins/shared-variables/dialog/use-edit-variable-dialog.tsx
@@ -10,9 +10,8 @@ import './variable-dialog.scss';
 interface IProps {
   variable?: VariableType;
   onClose?: () => void;
-  setDialogPresent?: (present: boolean) => void;
 }
-export const useEditVariableDialog = ({ variable, onClose, setDialogPresent }: IProps) => {
+export const useEditVariableDialog = ({ variable, onClose }: IProps) => {
   // We use a clone of the variable for the edit dialog so the user can modify its properties, but those
   // changes won't be saved unless the Save button is pushed. We also cache variableClone with useMemo to
   // minimize the number of times it's recreated. These two things cause two side effects:
@@ -47,8 +46,7 @@ export const useEditVariableDialog = ({ variable, onClose, setDialogPresent }: I
         onClick: handleClick
       }
     ],
-    onClose,
-    setDialogPresent
+    onClose
   }, [variable, variableClone, count]);
 
   const _showModal = () => {

--- a/src/plugins/shared-variables/dialog/use-new-variable-dialog.tsx
+++ b/src/plugins/shared-variables/dialog/use-new-variable-dialog.tsx
@@ -13,10 +13,9 @@ interface IUseNewVariableDialog {
   descriptionPrefill?: string;
   noUndo?: boolean;
   onClose?: () => void;
-  setDialogPresent?: (present: boolean) => void;
 }
 export const useNewVariableDialog = ({
-  addVariable, sharedModel, descriptionPrefill, noUndo = false, onClose, setDialogPresent
+  addVariable, sharedModel, descriptionPrefill, noUndo = false, onClose
 }: IUseNewVariableDialog) => {
   const [newVariable, setNewVariable] = useState(Variable.create({description: descriptionPrefill || undefined}));
 
@@ -42,8 +41,7 @@ export const useNewVariableDialog = ({
         onClick: handleClick
       }
     ],
-    onClose,
-    setDialogPresent
+    onClose
   }, [addVariable, newVariable]);
 
   // Wrap useCustomModal's show so we can prefill with variable description


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/184616625

BUG: When a variable card is selected in a diagram tile and an Edit Variable dialog is opened but none of its fields are in focus, hitting the keyboard Delete key results in the selected variable card being deleted. This can happen even when the Edit Variabe dialog is opened from a different tile that contains variable chips.

This change prevents the bug by stopping propagation of keydown events from the dialog. It undoes the [previous changes addressing this bug](https://github.com/concord-consortium/collaborative-learning/pull/1616) because those only worked in the case that the dialog was opened from the diagram tile. If this solution is accepted, [these diagram-view changes](https://github.com/concord-consortium/quantity-playground/pull/69) related to [this previous CLUE PR](https://github.com/concord-consortium/collaborative-learning/pull/1616) should probably be undone as well.