### PR TITLE
184409509 sort deck layout

### DIFF
--- a/cypress/e2e/clue/branch/student_tests/data_card_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/data_card_tool_spec.js
@@ -20,28 +20,28 @@ context('Data Card Tool Tile', function () {
       dc.getTile().contains("Data Card Collection");
     });
     it("can create a new attribute", () => {
-      dc.getNameInputAsInactive().dblclick().type("Hello{enter}");
-      dc.getNameInputAsInactive().contains("Hello");
+      dc.getAttrName().dblclick().type("Attr1 Name{enter}");
+      dc.getAttrName().contains("Attr1 Name");
     });
     it("can add a value to an attribute", () => {
-      dc.getValueInputAsInactive().dblclick().type("Hi{enter}");
-      // FIXME / TODO not sure why below assertion fails, I can see it is there in cy test runner
-      // dc.getValueInputAsInactive().should("contain","Hi");
+      dc.getAttrValue().click().type("Attr1 Value{enter}");
+      dc.getTile().click();
+      dc.getAttrValueInput().invoke('val').should('eq', 'Attr1 Value');
     });
     it("can toggle between single and sort views", () => {
-      cy.get('.single-card-data-area').should('exist');
-      dc.getSortSelect().select("Hello");
-      cy.get('.sorting-cards-data-area').should('exist');
+      dc.getSingleCardView().should('exist');
+      dc.getSortSelect().select("Attr1 Name");
+      dc.getSortView().should('exist');
       dc.getSortSelect().select("None");
-      cy.get('.single-card-data-area').should('exist');
+      dc.getSingleCardView().should('exist');
     });
-    it("has sort menu with same attributes as card", () => {
-      dc.getNameInputAsInactive().dblclick().type("Attribute Two{enter}");
-      dc.getSortSelect().select("Attribute Two");
-      cy.get('.sorting-cards-data-area').should('exist');
+    it("attribute names stays in sync on menu and card", () => {
+      dc.getAttrName().dblclick().type("Attr1 Renamed{enter}");
+      dc.getAttrName().contains("Attr1 Renamed");
+      dc.getSortSelect().select("Attr1 Renamed");
+      dc.getSortView().should('exist');
       dc.getSortSelect().select("None");
-
-      // TODO - find the correct one, delete it, and make sure it is not in the menu
+      dc.getSingleCardView().should('exist');
     });
   });
 });

--- a/cypress/e2e/clue/branch/student_tests/data_card_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/data_card_tool_spec.js
@@ -21,6 +21,12 @@ context('Data Card Tool Tile', function () {
     });
     it("can create a new attribute", () => {
       dc.getNameInputAsInactive().dblclick().type("Hello{enter}");
+      dc.getNameInputAsInactive().contains("Hello");
+    });
+    it("can add a value to an attribute", () => {
+      dc.getValueInputAsInactive().dblclick().type("Hi{enter}");
+      //TODO not sure why below fails, I can see it is there in cy test runner
+      // dc.getValueInputAsInactive().should("contain","Hi");
     });
     it("can toggle between single and sort views", () => {
       cy.get('.single-card-data-area').should('exist');
@@ -28,6 +34,10 @@ context('Data Card Tool Tile', function () {
       cy.get('.sorting-cards-data-area').should('exist');
       dc.getSortSelect().select("None");
       cy.get('.single-card-data-area').should('exist');
+    });
+    it("attributes deleted from dataset should immediately dissapear from sort menu", () => {
+      // above is what causes a crash
+      // see TODO item in sort-select
     });
   });
 });

--- a/cypress/e2e/clue/branch/student_tests/data_card_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/data_card_tool_spec.js
@@ -25,7 +25,7 @@ context('Data Card Tool Tile', function () {
     });
     it("can add a value to an attribute", () => {
       dc.getValueInputAsInactive().dblclick().type("Hi{enter}");
-      //TODO not sure why below fails, I can see it is there in cy test runner
+      // FIXME / TODO not sure why below assertion fails, I can see it is there in cy test runner
       // dc.getValueInputAsInactive().should("contain","Hi");
     });
     it("can toggle between single and sort views", () => {
@@ -35,9 +35,13 @@ context('Data Card Tool Tile', function () {
       dc.getSortSelect().select("None");
       cy.get('.single-card-data-area').should('exist');
     });
-    it("attributes deleted from dataset should immediately dissapear from sort menu", () => {
-      // above is what causes a crash
-      // see TODO item in sort-select
+    it("has sort menu with same attributes as card", () => {
+      dc.getNameInputAsInactive().dblclick().type("Attribute Two{enter}");
+      dc.getSortSelect().select("Attribute Two");
+      cy.get('.sorting-cards-data-area').should('exist');
+      dc.getSortSelect().select("None");
+
+      // TODO - find the correct one, delete it, and make sure it is not in the menu
     });
   });
 });

--- a/cypress/support/elements/clue/DataCardToolTile.js
+++ b/cypress/support/elements/clue/DataCardToolTile.js
@@ -9,8 +9,12 @@ class DataCardToolTile {
     return cy.get(`${workspaceClass || ".primary-workspace"} .sort-select-input`);
   }
   getNameInputAsInactive(workspaceClass){
-    const nameInputSelector = ".attribute-name-value-pair .name";
-    return cy.get(`${workspaceClass || ".primary-workspace"} ${nameInputSelector}`);
+    const nameSelector = ".attribute-name-value-pair .name";
+    return cy.get(`${workspaceClass || ".primary-workspace"} ${nameSelector}`);
+  }
+  getValueInputAsInactive(workspaceClass){
+    const valueSelector = ".attribute-name-value-pair .value";
+    return cy.get(`${workspaceClass || ".primary-workspace"} ${valueSelector}`);
   }
 }
 export default DataCardToolTile;

--- a/cypress/support/elements/clue/DataCardToolTile.js
+++ b/cypress/support/elements/clue/DataCardToolTile.js
@@ -8,13 +8,29 @@ class DataCardToolTile {
   getSortSelect(workspaceClass){
     return cy.get(`${workspaceClass || ".primary-workspace"} .sort-select-input`);
   }
-  getNameInputAsInactive(workspaceClass){
+  getAttrName(workspaceClass){
     const nameSelector = ".attribute-name-value-pair .name";
     return cy.get(`${workspaceClass || ".primary-workspace"} ${nameSelector}`);
   }
-  getValueInputAsInactive(workspaceClass){
+  getAttrValue(workspaceClass){
     const valueSelector = ".attribute-name-value-pair .value";
     return cy.get(`${workspaceClass || ".primary-workspace"} ${valueSelector}`);
+  }
+  getAttrValueInput(workspaceClass){
+    const valueSelector = ".attribute-name-value-pair .value .value-input";
+    return cy.get(`${workspaceClass || ".primary-workspace"} ${valueSelector}`);
+  }
+  getSingleCardView(workspaceClass){
+    const selector = ".data-card-tool-tile .single-card-data-area";
+    return cy.get(`${workspaceClass || ".primary-workspace"} ${selector}`);
+  }
+  getSortView(workspaceClass){
+    const selector = ".data-card-tool-tile .sorting-cards-data-area";
+    return cy.get(`${workspaceClass || ".primary-workspace"} ${selector}`);
+  }
+  getSortMenuItems(workspaceClass){
+    const itemsSelector = ".sort-select-input > option";
+    return cy.get(`${workspaceClass || ".primary-workspace"} ${itemsSelector}`);
   }
 }
 export default DataCardToolTile;

--- a/src/plugins/data-card/components/sort-area.scss
+++ b/src/plugins/data-card/components/sort-area.scss
@@ -1,0 +1,57 @@
+@import "../../../components/vars.sass";
+
+$sort-view-card-width: 177px;
+$sort-view-column-width: $sort-view-card-width + 10px;
+$sort-view-font-size:10px;
+$sort-view-width: ($sort-view-card-width * 3 );
+
+.data-card-tool.display-as-sorted {
+  font-size: $sort-view-font-size;
+  .panel {
+    width: ($sort-view-card-width * 3 );
+  }
+
+  .sorting-cards-data-area {
+    width: ($sort-view-card-width * 3 );
+    //background-color: $workspace-teal-light-4;
+    border: solid 1px $charcoal-light-1;
+
+    .sort-area-grid {
+      display: grid;
+      grid-template-columns: $sort-view-card-width $sort-view-card-width $sort-view-card-width;
+
+      .stack {
+        width: $sort-view-card-width;
+        .stack-heading {
+          background-color: $workspace-teal-light-4;
+          font-size: 13px;
+          font-weight: bold;
+          text-align: center;
+          padding-top: 3px;
+          padding-bottom: 3px;
+        }
+      }
+
+      .empty.cell {
+        width: $sort-view-card-width;
+        background-color: $workspace-teal-light-4;
+        height:23px;
+      }
+    }
+
+    .sortable.card {
+      border:1px solid $charcoal-light-1;
+      display: grid;
+      grid-template-columns: 40px auto;
+    }
+  }
+}
+
+
+// .sorting-cards-data-area {
+//   // each card is specified as 160px, plus 6 * 10px margins over three columns
+//   width: 540px;
+//   background-color: $workspace-teal-light-4;
+//   border: solid 1px $charcoal-light-1;
+//   padding:$cell-padding;
+// }

--- a/src/plugins/data-card/components/sort-area.scss
+++ b/src/plugins/data-card/components/sort-area.scss
@@ -40,18 +40,13 @@ $sort-view-width: ($sort-view-card-width * 3 );
     }
 
     .sortable.card {
-      border:1px solid $charcoal-light-1;
       display: grid;
-      grid-template-columns: 40px auto;
+      // temporary styles for dev
+      margin:3px;
+      padding:3px;
+      font-family: monospace;
+      border: 1px solid $charcoal-light-1;
+      transform: translateX(-1px);
     }
   }
 }
-
-
-// .sorting-cards-data-area {
-//   // each card is specified as 160px, plus 6 * 10px margins over three columns
-//   width: 540px;
-//   background-color: $workspace-teal-light-4;
-//   border: solid 1px $charcoal-light-1;
-//   padding:$cell-padding;
-// }

--- a/src/plugins/data-card/components/sort-area.tsx
+++ b/src/plugins/data-card/components/sort-area.tsx
@@ -5,8 +5,7 @@ import { ITileModel } from "../../../models/tiles/tile-model";
 import { DataCardContentModelType } from "../data-card-content";
 import { SortStack, SortStackPlaceholder } from "./sort-stack";
 
-import "./sort-area.scss"
-import { render } from "@testing-library/react";
+import "./sort-area.scss";
 
 interface IProps {
   model: ITileModel;
@@ -15,7 +14,6 @@ interface IProps {
 export const DataCardSortArea: React.FC<IProps> = ({ model }) => {
   const content = model.content as DataCardContentModelType;
   const sortById = content.selectedSortAttributeId;
-  const sortByName = sortById ? content.dataSet.attrFromID(sortById).name : " "; //TODO handle unfinished attr
 
   const attrsSnap = getSnapshot(content.attributes);
   const allAttrValues = attrsSnap.filter((a) => a.id === sortById)[0].values;

--- a/src/plugins/data-card/components/sort-area.tsx
+++ b/src/plugins/data-card/components/sort-area.tsx
@@ -21,6 +21,9 @@ export const DataCardSortArea: React.FC<IProps> = ({ model }) => {
   const allAttrValues = attrsSnap.filter((a) => a.id === sortById)[0].values;
   const uniqeOrderedValues = orderBy(uniq(allAttrValues));
 
+   // if one of the categories is a category for no value, put this stack last
+   uniqeOrderedValues.includes("") && uniqeOrderedValues.push(uniqeOrderedValues.shift());
+
   const renderPlaceholderCells = () => {
     const rowsNeeded = Math.ceil(uniqeOrderedValues.length / 3);
     const placeholders = (rowsNeeded * 3) - uniqeOrderedValues.length;

--- a/src/plugins/data-card/components/sort-area.tsx
+++ b/src/plugins/data-card/components/sort-area.tsx
@@ -1,6 +1,12 @@
 import React from "react";
+import { getSnapshot } from "@concord-consortium/mobx-state-tree";
+import { uniq, orderBy } from "lodash";
 import { ITileModel } from "../../../models/tiles/tile-model";
 import { DataCardContentModelType } from "../data-card-content";
+import { SortStack, SortStackPlaceholder } from "./sort-stack";
+
+import "./sort-area.scss"
+import { render } from "@testing-library/react";
 
 interface IProps {
   model: ITileModel;
@@ -9,10 +15,38 @@ interface IProps {
 export const DataCardSortArea: React.FC<IProps> = ({ model }) => {
   const content = model.content as DataCardContentModelType;
   const sortById = content.selectedSortAttributeId;
-  const sortByName = sortById ? content.dataSet.attrFromID(sortById).name : " ";
+  const sortByName = sortById ? content.dataSet.attrFromID(sortById).name : " "; //TODO handle unfinished attr
+
+  const attrsSnap = getSnapshot(content.attributes);
+  const allAttrValues = attrsSnap.filter((a) => a.id === sortById)[0].values;
+  const uniqeOrderedValues = orderBy(uniq(allAttrValues));
+
+  const renderPlaceholderCells = () => {
+    const rowsNeeded = Math.ceil(uniqeOrderedValues.length / 3);
+    const placeholders = (rowsNeeded * 3) - uniqeOrderedValues.length;
+    return (
+      <>
+        { placeholders > 0 && <SortStackPlaceholder /> }
+        { placeholders === 2 && <SortStackPlaceholder /> }
+      </>
+    );
+  };
+
   return (
-    <div className="sort-grid">
-      <pre>cards sorted by: { sortByName }</pre>
+    <div className="sort-area-grid">
+      { uniqeOrderedValues.length > 0 && sortById &&
+        uniqeOrderedValues.map((v, i) => {
+          return (
+            <SortStack
+              key={i}
+              model={model}
+              stackValue={v as any}
+              inAttributeId={ sortById }
+            />
+          );
+        })
+      }
+      { renderPlaceholderCells() }
     </div>
   );
 };

--- a/src/plugins/data-card/components/sort-area.tsx
+++ b/src/plugins/data-card/components/sort-area.tsx
@@ -20,7 +20,7 @@ export const DataCardSortArea: React.FC<IProps> = ({ model }) => {
   const uniqeOrderedValues = orderBy(uniq(allAttrValues));
 
    // if one of the categories is a category for no value, put this stack last
-   uniqeOrderedValues.includes("") && uniqeOrderedValues.push(uniqeOrderedValues.shift());
+  uniqeOrderedValues.includes("") && uniqeOrderedValues.push(uniqeOrderedValues.shift());
 
   const renderPlaceholderCells = () => {
     const rowsNeeded = Math.ceil(uniqeOrderedValues.length / 3);

--- a/src/plugins/data-card/components/sort-card.tsx
+++ b/src/plugins/data-card/components/sort-card.tsx
@@ -5,15 +5,20 @@ import { DataCardContentModelType } from "../data-card-content";
 interface IProps {
   caseId: string;
   model: ITileModel;
-  stackSpot: number;
+  indexInStack: number;
+  totalInStack: number;
 }
 
-export const SortCard: React.FC<IProps> = ({ model, caseId, stackSpot }) => {
+export const SortCard: React.FC<IProps> = ({ model, caseId, indexInStack, totalInStack }) => {
   const content = model.content as DataCardContentModelType;
+  const deckCardNumberDisplay = content.dataSet.caseIndexFromID(caseId) + 1;
+  const stackCardNumberDisplay = indexInStack + 1;
 
   return (
     <div className="card sortable">
-      <div style={{ fontFamily: 'monospace', padding: "2px"}}>{caseId}</div>
+      {caseId}<br/>
+      { `${ stackCardNumberDisplay } of ${ totalInStack } cards in stack`}<br/>
+      { `${ deckCardNumberDisplay } of ${ content.totalCases } cards in deck`}
     </div>
   );
 };

--- a/src/plugins/data-card/components/sort-card.tsx
+++ b/src/plugins/data-card/components/sort-card.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { ITileModel } from "../../../models/tiles/tile-model";
+import { DataCardContentModelType } from "../data-card-content";
+
+interface IProps {
+  caseId: string;
+  model: ITileModel;
+  stackSpot: number;
+}
+
+export const SortCard: React.FC<IProps> = ({ model, caseId, stackSpot }) => {
+  const content = model.content as DataCardContentModelType;
+
+  return (
+    <div className="card sortable">
+      <div style={{ fontFamily: 'monospace', padding: "2px"}}>{caseId}</div>
+    </div>
+  );
+};

--- a/src/plugins/data-card/components/sort-select.tsx
+++ b/src/plugins/data-card/components/sort-select.tsx
@@ -8,6 +8,10 @@ interface IProps {
   onSortAttrChange: (event: React.ChangeEvent<HTMLSelectElement>) => void;
 }
 
+// TODO - refactor this so that it gets currentSortId and attrsWithNames
+// as props - then it will update on time and prevent ability to choose
+// an attribute that no longer exists
+
 export const SortSelect: React.FC<IProps> = ({ model, onSortAttrChange }) => {
   const content = model.content as DataCardContentModelType;
   const attrs = content.existingAttributesWithNames();

--- a/src/plugins/data-card/components/sort-select.tsx
+++ b/src/plugins/data-card/components/sort-select.tsx
@@ -6,16 +6,16 @@ import { orderBy } from "lodash";
 interface IProps {
   model: ITileModel;
   onSortAttrChange: (event: React.ChangeEvent<HTMLSelectElement>) => void;
+  attrIdNamePairs: any[];
 }
 
 // TODO - refactor this so that it gets currentSortId and attrsWithNames
 // as props - then it will update on time and prevent ability to choose
 // an attribute that no longer exists
 
-export const SortSelect: React.FC<IProps> = ({ model, onSortAttrChange }) => {
+export const SortSelect: React.FC<IProps> = ({ model, attrIdNamePairs, onSortAttrChange }) => {
   const content = model.content as DataCardContentModelType;
-  const attrs = content.existingAttributesWithNames();
-  const alphaAttrs = orderBy(attrs, [attr => attr.attrName.toLowerCase()]);
+  const alphaAttrs = orderBy(attrIdNamePairs, [attr => attr.attrName.toLowerCase()]);
 
   return (
     <div className="sort-select">

--- a/src/plugins/data-card/components/sort-stack.tsx
+++ b/src/plugins/data-card/components/sort-stack.tsx
@@ -13,7 +13,7 @@ export const SortStack: React.FC<IProps> = ({ model, stackValue, inAttributeId }
   const content = model.content as DataCardContentModelType;
   const caseIds = content.caseIdsWithAttributeValue(inAttributeId, stackValue);
   const units = caseIds.length > 1 ? "cards" : "card";
-  const stackValueDisplay = stackValue !== "" ? stackValue : "(no value)"
+  const stackValueDisplay = stackValue !== "" ? stackValue : "(no value)";
   return (
     <div className="stack cell">
       <div className="stack-heading">
@@ -26,8 +26,9 @@ export const SortStack: React.FC<IProps> = ({ model, stackValue, inAttributeId }
               key={cid}
               model={model}
               caseId={cid}
-              stackSpot={i}
-            />
+              indexInStack={i}
+              totalInStack={caseIds.length}
+            />;
           })
         }
       </div>

--- a/src/plugins/data-card/components/sort-stack.tsx
+++ b/src/plugins/data-card/components/sort-stack.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { ITileModel } from "../../../models/tiles/tile-model";
+import { DataCardContentModelType } from "../data-card-content";
+import { SortCard } from "./sort-card";
+
+interface IProps {
+  stackValue: string;
+  inAttributeId: string;
+  model: ITileModel;
+}
+
+export const SortStack: React.FC<IProps> = ({ model, stackValue, inAttributeId }) => {
+  const content = model.content as DataCardContentModelType;
+  const caseIds = content.caseIdsWithAttributeValue(inAttributeId, stackValue);
+  const units = caseIds.length > 1 ? "cards" : "card";
+  const stackValueDisplay = stackValue !== "" ? stackValue : "(no value)"
+  return (
+    <div className="stack cell">
+      <div className="stack-heading">
+        {stackValueDisplay}: {caseIds.length} {units}
+      </div>
+      <div className="stack-cards">
+        {
+          caseIds.map((cid, i) => {
+            return <SortCard
+              key={cid}
+              model={model}
+              caseId={cid}
+              stackSpot={i}
+            />
+          })
+        }
+      </div>
+    </div>
+  );
+};
+
+export const SortStackPlaceholder: React.FC = () => {
+  return <div className="empty cell"></div>;
+};

--- a/src/plugins/data-card/data-card-content.ts
+++ b/src/plugins/data-card/data-card-content.ts
@@ -34,7 +34,7 @@ export const DataCardContentModel = TileContentModel
   .props({
     type: types.optional(types.literal(kDataCardTileType), kDataCardTileType),
     caseIndex: 0,
-    selectedSortAttributeId: types.maybe(types.string)//'none'
+    selectedSortAttributeId: types.maybe(types.string)
   })
   .volatile(self => ({
     metadata: undefined as any as ITileMetadataModel,
@@ -115,6 +115,12 @@ export const DataCardContentModel = TileContentModel
         }
       });
       return attributesWithValues === 0;
+    },
+    caseIdsWithAttributeValue(attrId: string, value: string){
+      const allCases = this.allCases();
+      const foundCases: string[] = [];
+      allCases.forEach((c) => c && c[attrId] === value && foundCases.push(c.__id__));
+      return foundCases;
     },
     exportJson(options?: ITileExportOptions){
       return [

--- a/src/plugins/data-card/data-card-tile.scss
+++ b/src/plugins/data-card/data-card-tile.scss
@@ -1,6 +1,6 @@
 @import "../../components/vars.sass";
 
-$card-width: 359px;
+$single-view-card-width: 359px;
 $name-width: 34%;
 $value-width: 66%;
 $data-row-min-height: 24px;
@@ -32,7 +32,7 @@ $default-button-border-color: #979797;
 
   .panel {
     border: solid 1px $charcoal-light-1;
-    width: $card-width;
+    width: $single-view-card-width;
     height: 34px;
     font-family: Lato;
     font-size: 14px;
@@ -160,7 +160,7 @@ $default-button-border-color: #979797;
   }
 
   .single-card-data-area {
-    width: $card-width;
+    width: $single-view-card-width;
 
     /* saved state attributes */
     .attribute-name-value-pair {
@@ -260,16 +260,6 @@ $default-button-border-color: #979797;
   .add-field {
     margin-top: 5px;
     // half of 35% minus half the width of the icon
-    margin-left: ($card-width * 0.175) - 12px;
+    margin-left: ($single-view-card-width * 0.175) - 12px;
   }
-
-  .sorting-cards-data-area {
-    // each card is specified as 160px, plus 6 * 10px margins over three columns
-    width: 540px;
-    background-color: $workspace-teal-light-4;
-    border: solid 1px $charcoal-light-1;
-    padding:$cell-padding;
-  }
-
-
 }

--- a/src/plugins/data-card/data-card-tile.tsx
+++ b/src/plugins/data-card/data-card-tile.tsx
@@ -31,6 +31,7 @@ export const DataCardToolComponent: React.FC<ITileProps> = observer((props) => {
   const shouldShowDeleteCase = !readOnly && isTileSelected && content.dataSet.cases.length > 1;
   const displaySingle = !content.selectedSortAttributeId;
   const shouldShowAddField = !readOnly && isTileSelected && displaySingle;
+  const attrIdsNames = content.existingAttributesWithNames();
 
   useEffect(() => {
     if (!content.title) {
@@ -221,7 +222,11 @@ export const DataCardToolComponent: React.FC<ITileProps> = observer((props) => {
         </div>
 
         <div className="panel sort">
-          <SortSelect model={model} onSortAttrChange={setSort} />
+          <SortSelect
+            model={model}
+            onSortAttrChange={setSort}
+            attrIdNamePairs={attrIdsNames}
+          />
         </div>
 
         { displaySingle &&

--- a/src/plugins/data-card/data-card-tile.tsx
+++ b/src/plugins/data-card/data-card-tile.tsx
@@ -170,6 +170,10 @@ export const DataCardToolComponent: React.FC<ITileProps> = observer((props) => {
   const addCardClasses = classNames("add-card", "teal-bg", { hidden: !shouldShowAddCase });
   const removeCardClasses = classNames("remove-card", { hidden: !shouldShowDeleteCase });
 
+  const toolClasses = classNames(
+    "data-card-tool", `display-as-${ displaySingle ? 'single' : 'sorted'}`
+  );
+
   const toolbarProps = useToolbarTileApi(
     {
       id: model.id,
@@ -185,7 +189,7 @@ export const DataCardToolComponent: React.FC<ITileProps> = observer((props) => {
   };
 
   return (
-    <div className="data-card-tool">
+    <div className={toolClasses}>
       <DataCardToolbar
         model={model}
         documentContent={documentContent}


### PR DESCRIPTION
This sets up the underlying, basic layout and sorting mechanism for the DataCard deck sort layout, as described in [PT #184409509](https://www.pivotaltracker.com/n/projects/2441242/stories/184409509)

- When a sort is selected other than "None" the sort view is shown. 
- Sorted cards organize into three columns and as many rows as are required to reflect all the data. 
- Each column/row cell has a header with the value of the sort field and the number of cards with that value
- cards with a blank for the sort field form their own column.

At this point the cards only display the data that we need to compute the layout: cardId, and 1-based index within the sorted "pile" and the deck as a whole. 

`DataCardSortArea` arranges the cases into an array of `SortStack`s. Each has an array of `SortCard`s. 