### PR TITLE
184524377 sort card display

### DIFF
--- a/cypress/e2e/clue/branch/student_tests/data_card_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/data_card_tool_spec.js
@@ -35,7 +35,7 @@ context('Data Card Tool Tile', function () {
       dc.getSortSelect().select("None");
       dc.getSingleCardView().should('exist');
     });
-    it("attribute names stays in sync on menu and card", () => {
+    it("has attribute names that stay in sync on menu and card", () => {
       dc.getAttrName().dblclick().type("Attr1 Renamed{enter}");
       dc.getAttrName().contains("Attr1 Renamed");
       dc.getSortSelect().select("Attr1 Renamed");

--- a/cypress/e2e/clue/branch/student_tests/data_card_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/data_card_tool_spec.js
@@ -35,7 +35,7 @@ context('Data Card Tool Tile', function () {
       dc.getSortSelect().select("None");
       dc.getSingleCardView().should('exist');
     });
-    it("has attribute names that stay in sync on menu and card", () => {
+    it("has attribute names that stay in sync on sort menu and card", () => {
       dc.getAttrName().dblclick().type("Attr1 Renamed{enter}");
       dc.getAttrName().contains("Attr1 Renamed");
       dc.getSortSelect().select("Attr1 Renamed");
@@ -43,6 +43,18 @@ context('Data Card Tool Tile', function () {
       dc.getSortSelect().select("None");
       dc.getSingleCardView().should('exist');
     });
+    it("can add new cards", () =>{
+      dc.getSortSelect().select("None");
+      dc.getAddCardButton().click();
+      dc.getCardNofTotalListing().contains("Card 2 of 2");
+      dc.getAddCardButton().click();
+      dc.getCardNofTotalListing().contains("Card 3 of 3");
+    });
+    it("can advance from card to card in both directions", () =>{
+      dc.getPreviousCardButton().click();
+      dc.getCardNofTotalListing().contains("Card 2 of 3");
+      dc.getNextCardButton().click();
+      dc.getCardNofTotalListing().contains("Card 3 of 3");
+    });
   });
 });
-

--- a/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
@@ -162,7 +162,7 @@ context('Dataflow Tool Tile', function () {
       });
       it("verify node inputs outputs", () => {
         dataflowToolTile.getNodeInput().should("exist");
-        dataflowToolTile.getNodeInput().should('have.length', 2)
+        dataflowToolTile.getNodeInput().should('have.length', 2);
         dataflowToolTile.getNodeOutput().should("exist");
       });
       it("can delete math node", () => {
@@ -197,7 +197,7 @@ context('Dataflow Tool Tile', function () {
       });
       it("verify node inputs outputs", () => {
         dataflowToolTile.getNodeInput().should("exist");
-        dataflowToolTile.getNodeInput().should('have.length', 2)
+        dataflowToolTile.getNodeInput().should('have.length', 2);
         dataflowToolTile.getNodeOutput().should("exist");
       });
       it("can delete logic node", () => {
@@ -232,7 +232,7 @@ context('Dataflow Tool Tile', function () {
       });
       it("verify node inputs outputs", () => {
         dataflowToolTile.getNodeInput().should("exist");
-        dataflowToolTile.getNodeInput().should('have.length', 1)
+        dataflowToolTile.getNodeInput().should('have.length', 1);
         dataflowToolTile.getNodeOutput().should("exist");
       });
       it("can delete transform node", () => {
@@ -295,7 +295,7 @@ context('Dataflow Tool Tile', function () {
 
         dataflowToolTile.getOutputNodeValueText().should("contain", "0% closed");
 
-        // verify light bulb 
+        // verify light bulb
         dataflowToolTile.getDropdown(nodeType, dropdown).click();
         dataflowToolTile.getDropdownOptions(nodeType, dropdown).first().click();
         dataflowToolTile.getLightBulbImage();
@@ -344,7 +344,7 @@ context('Dataflow Tool Tile', function () {
       });
       it("verify node inputs outputs", () => {
         dataflowToolTile.getNodeInput().should("exist");
-        dataflowToolTile.getNodeInput().should('have.length', 1)
+        dataflowToolTile.getNodeInput().should('have.length', 1);
         dataflowToolTile.getNodeOutput().should("not.exist");
       });
       it("can delete live output node", () => {
@@ -379,7 +379,7 @@ context('Dataflow Tool Tile', function () {
       });
       it("verify node inputs outputs", () => {
         dataflowToolTile.getNodeInput().should("exist");
-        dataflowToolTile.getNodeInput().should('have.length', 2)
+        dataflowToolTile.getNodeInput().should('have.length', 2);
         dataflowToolTile.getNodeOutput().should("exist");
       });
       it("can delete control node", () => {

--- a/cypress/e2e/clue/branch/student_tests/table_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/table_tool_spec.js
@@ -152,7 +152,7 @@ context('Table Tool Tile', function () {
     it('verify clear button functionality', function(){
       cy.get('.modal-button').contains('Clear').click();
       cy.get('#expression-input').should('not.contain', formula);
-    })
+    });
     it('verify cancel does not enter in a formula', function(){
       cy.get('#expression-input').click().type(formula );
       cy.get('.modal-button').contains('Cancel').click();
@@ -162,14 +162,14 @@ context('Table Tool Tile', function () {
         .siblings('.expression-cell.has-expression')
         .should('not.exist');
     });
-    it('verify selection of y2 axis and will enter a formula',function(){     
+    it('verify selection of y2 axis and will enter a formula',function(){
       cy.get(".primary-workspace").within((workspace) => {
         tableToolTile.getTableToolbarButton('set-expression').click();
       });
       cy.get('.modal-title').should('contain', "Set Expression");
       cy.get('.modal-content .prompt select').should('exist');
       cy.get('.modal-content .prompt select').select('y2');
-      cy.get('.modal-content .prompt').should('contain', "y2");
+      cy.get('.modal-content .prompt').should('contain', 'y2');
       cy.get('#expression-input').click().type(`${headerX}+2` + '{enter}');
     });
     it('verify value caluculated based on formula correctly', function () {
@@ -236,7 +236,7 @@ context('Table Tool Tile Undo Redo', function () {
       tableToolTile.getTableTile().should("exist");
       clueCanvas.getRedoTool().click();
       tableToolTile.getTableTile().should('not.exist');
-    });       
+    });
     it('will undo redo table field content', function () {
       clueCanvas.addTile('table');
       tableToolTile.getAddColumnButton().click();
@@ -252,6 +252,6 @@ context('Table Tool Tile Undo Redo', function () {
       cy.get('.primary-workspace').within(function () {
         tableToolTile.getColumnHeader().should('have.length', 3);
       });
-    }); 
+    });
   });
 });

--- a/cypress/support/elements/clue/DataCardToolTile.js
+++ b/cypress/support/elements/clue/DataCardToolTile.js
@@ -32,5 +32,18 @@ class DataCardToolTile {
     const itemsSelector = ".sort-select-input > option";
     return cy.get(`${workspaceClass || ".primary-workspace"} ${itemsSelector}`);
   }
+  getAddCardButton(workspaceClass){
+    const selector = ".add-remove-card-buttons .add-card";
+    return cy.get(`${workspaceClass || ".primary-workspace"} ${selector}`);
+  }
+  getCardNofTotalListing(workspaceClass){
+    return cy.get(`${workspaceClass || ".primary-workspace"} .card-number-of-listing`);
+  }
+  getNextCardButton(workspaceClass){
+    return cy.get(`${workspaceClass || ".primary-workspace"} .card-nav.next`);
+  }
+  getPreviousCardButton(workspaceClass){
+    return cy.get(`${workspaceClass || ".primary-workspace"} .card-nav.previous`);
+  }
 }
 export default DataCardToolTile;

--- a/cypress/support/elements/clue/DataCardToolTile.js
+++ b/cypress/support/elements/clue/DataCardToolTile.js
@@ -45,5 +45,12 @@ class DataCardToolTile {
   getPreviousCardButton(workspaceClass){
     return cy.get(`${workspaceClass || ".primary-workspace"} .card-nav.previous`);
   }
+  getSortCardHeading(workspaceClass){
+    return cy.get(`${workspaceClass || ".primary-workspace"} .sortable .heading`);
+  }
+  getSortCardData(workspaceClass){
+    const selector = ".sortable.expanded .attribute-value-row";
+    return cy.get(`${workspaceClass || ".primary-workspace"} ${selector}`);
+  }
 }
 export default DataCardToolTile;

--- a/src/plugins/data-card/components/data-card-rows.tsx
+++ b/src/plugins/data-card/components/data-card-rows.tsx
@@ -6,7 +6,7 @@ import { CaseAttribute } from "./case-attribute";
 import { EditFacet } from "../data-card-types";
 
 interface IProps {
-  caseIndex: any;
+  caseIndex: number;
   model: ITileModel;
   totalCases: number;
   readOnly?: boolean;

--- a/src/plugins/data-card/components/sort-area.scss
+++ b/src/plugins/data-card/components/sort-area.scss
@@ -16,7 +16,7 @@ $sort-view-width: ($sort-view-card-width * $cards-per-row );
 
   .sorting-cards-data-area {
     width: $sort-view-width;
-    border: solid 1px $charcoal-light-1;
+    border: $card-border;
 
     .sort-area-grid {
       display: grid;
@@ -38,7 +38,7 @@ $sort-view-width: ($sort-view-card-width * $cards-per-row );
         width: $sort-view-card-width;
         background-color: $workspace-teal-light-4;
         height:26px;
-        border-bottom: 1px $charcoal-light-1;
+        border-bottom: $card-border;
       }
     }
 
@@ -46,33 +46,23 @@ $sort-view-width: ($sort-view-card-width * $cards-per-row );
       display: grid;
       border-radius:$card-space-factor;
       margin:3px;
-      transition: all .4s ease-in-out;
-      //transform: translateX(1px);
 
       .heading {
-        padding:4px;
+        border: $card-border;
+        padding:$card-space-factor;
         color: tungsten;
         font-style: italic;
         text-align: right;
         border-radius: 5px 5px 0px 0px;
-        border: 1px solid $charcoal-light-1;
-        //border-bottom: 0px;
         display:flex;
         align-items: flex-end;
 
         .card-count-info {
           width:90%;
-          text-align: right;
-          justify-self: end;
         }
       }
 
-      .no-content {
-         border-bottom: $card-border;
-      }
-
       .content > div {
-        //padding: $card-space-factor;
         background-color: white;
         border-left: $card-border;
         border-right: $card-border;
@@ -83,39 +73,42 @@ $sort-view-width: ($sort-view-card-width * $cards-per-row );
         border-left: $card-border;
         border-right: $card-border;
         border-bottom: $card-border;
-        height:5px;
+        height:$card-space-factor;
         border-radius: 0px 0px 5px 5px;
       }
 
       .attribute-value-row {
+        display:flex;
         .attribute {
-          border-right:1px solid $charcoal-light-1;
+          border-right:$card-border;
           width:60px;
-          padding:5px;
+          padding:$card-space-factor;
+          background-color: $workspace-teal-light-4;
+          font-weight: bold;
         }
         .value {
           width:106px;
-          padding:5px;
+          padding:$card-space-factor;
         }
         .image-value {
           width: 100%;
         }
       }
-
-    }
-
-    .collapsed .heading {
-      border-bottom: 0px !important;
-    }
-
-    .expand-toggle {
-      cursor:pointer;
-      background-color: transparent;
-      border:0px;
-      padding: 0px;
-      margin-right:2px;
-      font-size: 10px;
-      text-align: left;
+      .expand-toggle {
+        cursor:pointer;
+        border:0px;
+        padding: 0px;
+        margin-right:2px;
+        font-size: 10px;
+        text-align: left;
+        transition: all .4s;
+        color:$charcoal-dark-2;
+        background-color: transparent;
+        translate: 0px 1px;
+      }
+      &.expanded .expand-toggle {
+        transform: rotate(90deg);
+      }
     }
   }
 }

--- a/src/plugins/data-card/components/sort-area.scss
+++ b/src/plugins/data-card/components/sort-area.scss
@@ -6,7 +6,7 @@ $card-border: 1px solid $charcoal-light-1;
 $sort-view-column-width: $sort-view-card-width + 10px;
 $sort-view-font-size:10px;
 $cards-per-row: 3; // this may be dynamic in the future
-$sort-view-width: ($sort-view-card-width * $cards-per-row );
+$sort-view-width: ($sort-view-card-width * $cards-per-row ) + 3;
 
 .data-card-tool.display-as-sorted {
   font-size: $sort-view-font-size;
@@ -16,11 +16,12 @@ $sort-view-width: ($sort-view-card-width * $cards-per-row );
 
   .sorting-cards-data-area {
     width: $sort-view-width;
-    border: $card-border;
 
     .sort-area-grid {
       display: grid;
       grid-template-columns: $sort-view-card-width $sort-view-card-width $sort-view-card-width;
+      border-left: $card-border;
+      border-right: $card-border;
 
       .stack {
         width: $sort-view-card-width;
@@ -31,14 +32,16 @@ $sort-view-width: ($sort-view-card-width * $cards-per-row );
           text-align: center;
           padding-top: $card-space-factor;
           padding-bottom: $card-space-factor;
+          border-top: $card-border;
+          height: 27px;
         }
       }
 
       .empty.cell {
         width: $sort-view-card-width;
         background-color: $workspace-teal-light-4;
-        height:26px;
-        border-bottom: $card-border;
+        height:27px;
+        border-top: $card-border;
       }
     }
 
@@ -99,15 +102,18 @@ $sort-view-width: ($sort-view-card-width * $cards-per-row );
         border:0px;
         padding: 0px;
         margin-right:2px;
-        font-size: 10px;
+        font-size: 12px;
         text-align: left;
         transition: all .4s;
         color:$charcoal-dark-2;
         background-color: transparent;
         translate: 0px 1px;
+        height:13px;
+        width:13px;
       }
       &.expanded .expand-toggle {
         transform: rotate(90deg);
+        translate: -1px 3px;
       }
     }
   }

--- a/src/plugins/data-card/components/sort-area.scss
+++ b/src/plugins/data-card/components/sort-area.scss
@@ -1,6 +1,8 @@
 @import "../../../components/vars.sass";
 
 $sort-view-card-width: 177px;
+$card-space-factor: 5px;
+$card-border: 1px solid $charcoal-light-1;
 $sort-view-column-width: $sort-view-card-width + 10px;
 $sort-view-font-size:10px;
 $cards-per-row: 3; // this may be dynamic in the future
@@ -27,26 +29,93 @@ $sort-view-width: ($sort-view-card-width * $cards-per-row );
           font-size: 13px;
           font-weight: bold;
           text-align: center;
-          padding-top: 3px;
-          padding-bottom: 3px;
+          padding-top: $card-space-factor;
+          padding-bottom: $card-space-factor;
         }
       }
 
       .empty.cell {
         width: $sort-view-card-width;
         background-color: $workspace-teal-light-4;
-        height:23px;
+        height:26px;
+        border-bottom: 1px $charcoal-light-1;
       }
     }
 
     .sortable.card {
       display: grid;
-      // temporary styles for dev
+      border-radius:$card-space-factor;
       margin:3px;
-      padding:3px;
-      font-family: monospace;
-      border: 1px solid $charcoal-light-1;
-      transform: translateX(-1px);
+      transition: all .4s ease-in-out;
+      //transform: translateX(1px);
+
+      .heading {
+        padding:4px;
+        color: tungsten;
+        font-style: italic;
+        text-align: right;
+        border-radius: 5px 5px 0px 0px;
+        border: 1px solid $charcoal-light-1;
+        //border-bottom: 0px;
+        display:flex;
+        align-items: flex-end;
+
+        .card-count-info {
+          width:90%;
+          text-align: right;
+          justify-self: end;
+        }
+      }
+
+      .no-content {
+         border-bottom: $card-border;
+      }
+
+      .content > div {
+        //padding: $card-space-factor;
+        background-color: white;
+        border-left: $card-border;
+        border-right: $card-border;
+        border-bottom: $card-border;
+      }
+
+      .footer {
+        border-left: $card-border;
+        border-right: $card-border;
+        border-bottom: $card-border;
+        height:5px;
+        border-radius: 0px 0px 5px 5px;
+      }
+
+      .attribute-value-row {
+        .attribute {
+          border-right:1px solid $charcoal-light-1;
+          width:60px;
+          padding:5px;
+        }
+        .value {
+          width:106px;
+          padding:5px;
+        }
+        .image-value {
+          width: 100%;
+        }
+      }
+
+    }
+
+    .collapsed .heading {
+      border-bottom: 0px !important;
+    }
+
+    .expand-toggle {
+      cursor:pointer;
+      background-color: transparent;
+      border:0px;
+      padding: 0px;
+      margin-right:2px;
+      font-size: 10px;
+      text-align: left;
     }
   }
 }

--- a/src/plugins/data-card/components/sort-area.tsx
+++ b/src/plugins/data-card/components/sort-area.tsx
@@ -39,8 +39,8 @@ export const DataCardSortArea: React.FC<IProps> = ({ model }) => {
             <SortStack
               key={i}
               model={model}
-              stackValue={v as any}
-              inAttributeId={ sortById }
+              stackValue={v as string}
+              inAttributeId={sortById}
             />
           );
         })

--- a/src/plugins/data-card/components/sort-card-attribute.tsx
+++ b/src/plugins/data-card/components/sort-card-attribute.tsx
@@ -9,11 +9,14 @@ interface IProps {
   attr: any
 }
 
-// TODO improve this to break on nearest word ending
 const getTruncated = (val:string) => {
   if (!val) return;
-  if (val.length > 50) return val.slice(0, 48) + "...";
-  return val;
+
+  const charTarget = 48;
+  if (val.length < charTarget + 1) return val;
+
+  const firstRelevantSpace = val.indexOf(" ", charTarget) + 1;
+  return val.slice(0, firstRelevantSpace) + "...";
 };
 
 export const SortCardAttribute: React.FC<IProps> = ({ model, caseId, attr }) => {
@@ -28,8 +31,8 @@ export const SortCardAttribute: React.FC<IProps> = ({ model, caseId, attr }) => 
   });
 
   return (
-    <div className="attribute-value-row" style={{ display: "flex"}}>
-      <div className="attribute" style={{ width: "60px"}}>{attrName}</div>
+    <div className="attribute-value-row">
+      <div className="attribute">{attrName}</div>
       <div className="value">
         { !isImage && getTruncated(value as string) }
         { isImage && <img src={imageUrl} className="image-value" /> }

--- a/src/plugins/data-card/components/sort-card-attribute.tsx
+++ b/src/plugins/data-card/components/sort-card-attribute.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from "react";
+import { ITileModel } from "../../../models/tiles/tile-model";
+import { DataCardContentModelType } from "../data-card-content";
+import { gImageMap } from "../../../models/image-map";
+
+interface IProps {
+  caseId: string;
+  model: ITileModel;
+  attr: any
+}
+
+// TODO improve this to break on nearest word ending
+const getTruncated = (val:string) => {
+  if (!val) return;
+  if (val.length > 50) return val.slice(0, 48) + "...";
+  return val;
+};
+
+export const SortCardAttribute: React.FC<IProps> = ({ model, caseId, attr }) => {
+  const content = model.content as DataCardContentModelType;
+  const attrName = content.dataSet.attrFromID(attr.id).name;
+  const value = content.dataSet.getValue(caseId, attr.id) as string;
+  const isImage = gImageMap.isImageUrl(value);
+  const [imageUrl, setImageUrl] = useState("");
+
+  isImage && gImageMap.getImage(value).then((image)=>{
+    setImageUrl(image.displayUrl || "");
+  });
+
+  return (
+    <div className="attribute-value-row" style={{ display: "flex"}}>
+      <div className="attribute" style={{ width: "60px"}}>{attrName}</div>
+      <div className="value">
+        { !isImage && getTruncated(value as string) }
+        { isImage && <img src={imageUrl} className="image-value" /> }
+      </div>
+    </div>
+  );
+};

--- a/src/plugins/data-card/components/sort-card-attribute.tsx
+++ b/src/plugins/data-card/components/sort-card-attribute.tsx
@@ -10,16 +10,6 @@ interface IProps {
   attr: IAttribute;
 }
 
-const getTruncated = (val:string) => {
-  if (!val) return;
-
-  const charTarget = 48;
-  if (val.length < charTarget + 1) return val;
-
-  const firstRelevantSpace = val.indexOf(" ", charTarget) + 1;
-  return val.slice(0, firstRelevantSpace) + "...";
-};
-
 export const SortCardAttribute: React.FC<IProps> = ({ model, caseId, attr }) => {
   const content = model.content as DataCardContentModelType;
   const attrName = content.dataSet.attrFromID(attr.id).name;
@@ -35,7 +25,7 @@ export const SortCardAttribute: React.FC<IProps> = ({ model, caseId, attr }) => 
     <div className="attribute-value-row">
       <div className="attribute">{attrName}</div>
       <div className="value">
-        { !isImage && getTruncated(value as string) }
+        { !isImage && value }
         { isImage && <img src={imageUrl} className="image-value" /> }
       </div>
     </div>

--- a/src/plugins/data-card/components/sort-card-attribute.tsx
+++ b/src/plugins/data-card/components/sort-card-attribute.tsx
@@ -2,11 +2,12 @@ import React, { useState } from "react";
 import { ITileModel } from "../../../models/tiles/tile-model";
 import { DataCardContentModelType } from "../data-card-content";
 import { gImageMap } from "../../../models/image-map";
+import { IAttribute } from "../../../models/data/attribute";
 
 interface IProps {
   caseId: string;
   model: ITileModel;
-  attr: any
+  attr: IAttribute;
 }
 
 const getTruncated = (val:string) => {

--- a/src/plugins/data-card/components/sort-card.tsx
+++ b/src/plugins/data-card/components/sort-card.tsx
@@ -11,7 +11,7 @@ interface IProps {
   totalInStack: number;
 }
 
-const getShade = (index: number) => {
+const getShadeRGB = (index: number) => {
   const fadeBy = 12;
   const base =  { r: 111, g: 198, b: 218 }; // $workspace-teal-light-2
   return {
@@ -25,28 +25,20 @@ export const SortCard: React.FC<IProps> = ({ model, caseId, indexInStack, totalI
   const content = model.content as DataCardContentModelType;
   const deckCardNumberDisplay = content.dataSet.caseIndexFromID(caseId) + 1;
   const stackCardNumberDisplay = indexInStack + 1;
-  const { r, g, b } = getShade(indexInStack);
-  const shade = `rgb(${r},${g},${b})`;
+  const { r, g, b } = getShadeRGB(indexInStack);
+  const shadeStr = `rgb(${r},${g},${b})`;
   const atStackTop = stackCardNumberDisplay === totalInStack;
 
   const [expanded, setExpanded] = useState(false);
-
-  useEffect(()=>{
-    if (atStackTop) setExpanded(true);
-  },[atStackTop]);
-
+  useEffect(()=> setExpanded(atStackTop), [atStackTop]); // "top" card loads expanded
   const toggleExpanded = () => setExpanded(!expanded);
-
   const cardClasses = classNames("sortable", "card", { collapsed: !expanded }, { expanded });
 
   return (
     <div className={cardClasses} id={caseId}>
-      <div className="heading" style={{ backgroundColor: shade }}>
+      <div className="heading" style={{ backgroundColor: shadeStr }}>
         <div className="expand-toggle-area">
-          <button className="expand-toggle" onClick={toggleExpanded}>
-            { expanded && <span>🔽</span>}
-            { !expanded && <span>▶️</span>}
-          </button>
+          <button className="expand-toggle" onClick={toggleExpanded}>▶</button>
         </div>
         <div className="card-count-info">
           { `Card ${ deckCardNumberDisplay } of ${ content.totalCases } `}
@@ -68,9 +60,7 @@ export const SortCard: React.FC<IProps> = ({ model, caseId, indexInStack, totalI
         </div>
       }
 
-      { !expanded && <div className="no-content"></div> }
-
-      <div className="footer" style={{ backgroundColor: shade }}></div>
+      <div className="footer" style={{ backgroundColor: shadeStr }}></div>
 
     </div>
   );

--- a/src/plugins/data-card/components/sort-card.tsx
+++ b/src/plugins/data-card/components/sort-card.tsx
@@ -1,6 +1,8 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
+import classNames from "classnames";
 import { ITileModel } from "../../../models/tiles/tile-model";
 import { DataCardContentModelType } from "../data-card-content";
+import { SortCardAttribute } from "./sort-card-attribute";
 
 interface IProps {
   caseId: string;
@@ -9,16 +11,67 @@ interface IProps {
   totalInStack: number;
 }
 
+const getShade = (index: number) => {
+  const fadeBy = 12;
+  const base =  { r: 111, g: 198, b: 218 }; // $workspace-teal-light-2
+  return {
+    r: base.r,
+    g: base.g + (index * fadeBy),
+    b: base.b + (index * fadeBy)
+  };
+};
+
 export const SortCard: React.FC<IProps> = ({ model, caseId, indexInStack, totalInStack }) => {
   const content = model.content as DataCardContentModelType;
   const deckCardNumberDisplay = content.dataSet.caseIndexFromID(caseId) + 1;
   const stackCardNumberDisplay = indexInStack + 1;
+  const { r, g, b } = getShade(indexInStack);
+  const shade = `rgb(${r},${g},${b})`;
+  const atStackTop = stackCardNumberDisplay === totalInStack;
+
+  const [expanded, setExpanded] = useState(false);
+
+  useEffect(()=>{
+    if (atStackTop) setExpanded(true);
+  },[atStackTop]);
+
+  const toggleExpanded = () => setExpanded(!expanded);
+
+  const cardClasses = classNames("sortable", "card", { collapsed: !expanded }, { expanded });
 
   return (
-    <div className="card sortable">
-      {caseId}<br/>
-      { `${ stackCardNumberDisplay } of ${ totalInStack } cards in stack`}<br/>
-      { `${ deckCardNumberDisplay } of ${ content.totalCases } cards in deck`}
+    <div className={cardClasses} id={caseId}>
+      <div className="heading" style={{ backgroundColor: shade }}>
+        <div className="expand-toggle-area">
+          <button className="expand-toggle" onClick={toggleExpanded}>
+            { expanded && <span>🔽</span>}
+            { !expanded && <span>▶️</span>}
+          </button>
+        </div>
+        <div className="card-count-info">
+          { `Card ${ deckCardNumberDisplay } of ${ content.totalCases } `}
+        </div>
+      </div>
+
+      { expanded &&
+        <div className="content">
+          { content.dataSet.attributes.map((attr)=>{
+            return (
+              <SortCardAttribute
+                key={attr.id}
+                model={model}
+                caseId={caseId}
+                attr={attr}
+              />
+            );
+          })}
+        </div>
+      }
+
+      { !expanded && <div className="no-content"></div> }
+
+      <div className="footer" style={{ backgroundColor: shade }}></div>
+
     </div>
   );
 };

--- a/src/plugins/data-card/components/sort-card.tsx
+++ b/src/plugins/data-card/components/sort-card.tsx
@@ -34,8 +34,13 @@ export const SortCard: React.FC<IProps> = ({ model, caseId, indexInStack, totalI
   const toggleExpanded = () => setExpanded(!expanded);
   const cardClasses = classNames("sortable", "card", { collapsed: !expanded }, { expanded });
 
+  const loadAsSingle = () => {
+    content.setSelectedSortAttributeId("");
+    content.setCaseIndex(content.dataSet.caseIndexFromID(caseId));
+  };
+
   return (
-    <div className={cardClasses} id={caseId}>
+    <div className={cardClasses} id={caseId} onDoubleClick={loadAsSingle}>
       <div className="heading" style={{ backgroundColor: shadeStr }}>
         <div className="expand-toggle-area">
           <button className="expand-toggle" onClick={toggleExpanded}>▶</button>

--- a/src/plugins/data-card/components/sort-select.tsx
+++ b/src/plugins/data-card/components/sort-select.tsx
@@ -3,16 +3,19 @@ import { ITileModel } from "../../../models/tiles/tile-model";
 import { DataCardContentModelType } from "../data-card-content";
 import { orderBy } from "lodash";
 
+interface IAttrIdNamePair {
+  attrName: string,
+  attrId: string
+}
 interface IProps {
   model: ITileModel;
   onSortAttrChange: (event: React.ChangeEvent<HTMLSelectElement>) => void;
-  attrIdNamePairs: any[];
+  attrIdNamePairs: IAttrIdNamePair[];
 }
 
 export const SortSelect: React.FC<IProps> = ({ model, attrIdNamePairs, onSortAttrChange }) => {
   const content = model.content as DataCardContentModelType;
   const alphaAttrs = orderBy(attrIdNamePairs, [attr => attr.attrName.toLowerCase()]);
-
   return (
     <div className="sort-select">
       <label>

--- a/src/plugins/data-card/components/sort-select.tsx
+++ b/src/plugins/data-card/components/sort-select.tsx
@@ -9,10 +9,6 @@ interface IProps {
   attrIdNamePairs: any[];
 }
 
-// TODO - refactor this so that it gets currentSortId and attrsWithNames
-// as props - then it will update on time and prevent ability to choose
-// an attribute that no longer exists
-
 export const SortSelect: React.FC<IProps> = ({ model, attrIdNamePairs, onSortAttrChange }) => {
   const content = model.content as DataCardContentModelType;
   const alphaAttrs = orderBy(attrIdNamePairs, [attr => attr.attrName.toLowerCase()]);

--- a/src/plugins/data-card/components/sort-stack.tsx
+++ b/src/plugins/data-card/components/sort-stack.tsx
@@ -12,9 +12,9 @@ interface IProps {
 }
 
 const getStackValueDisplay = (value: string) => {
-  if(value === "") return "(no value)";
-  if(gImageMap.isImageUrl(value)) return "(image)";
-  if(value.length < 14) return value;
+  if (value === "") return "(no value)";
+  if (gImageMap.isImageUrl(value)) return "(image)";
+  if (value.length < 14) return value;
   return value.slice(0, 13) + '... ';
 };
 
@@ -28,7 +28,7 @@ export const SortStack: React.FC<IProps> = ({ model, stackValue, inAttributeId }
   return (
     <div className="stack cell">
       <div className="stack-heading">
-         {stackValueDisplay}: {caseIds.length} {units}
+        {stackValueDisplay}: {caseIds.length} {units}
       </div>
       <div className={stackClasses}>
         {

--- a/src/plugins/data-card/components/sort-stack.tsx
+++ b/src/plugins/data-card/components/sort-stack.tsx
@@ -11,7 +11,6 @@ interface IProps {
   model: ITileModel;
 }
 
-// TODO improve this to break on nearest word ending
 const getStackValueDisplay = (value: string) => {
   if(value === "") return "(no value)";
   if(gImageMap.isImageUrl(value)) return "(image)";
@@ -27,7 +26,7 @@ export const SortStack: React.FC<IProps> = ({ model, stackValue, inAttributeId }
   const stackClasses = classNames("stack-cards", inAttributeId);
 
   return (
-    <div className="stack cell" /*style={{ height: "290px"}}*/>
+    <div className="stack cell">
       <div className="stack-heading">
          {stackValueDisplay}: {caseIds.length} {units}
       </div>

--- a/src/plugins/data-card/components/sort-stack.tsx
+++ b/src/plugins/data-card/components/sort-stack.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { ITileModel } from "../../../models/tiles/tile-model";
 import { DataCardContentModelType } from "../data-card-content";
 import { SortCard } from "./sort-card";
+import classNames from "classnames";
+import { gImageMap } from "../../../models/image-map";
 
 interface IProps {
   stackValue: string;
@@ -9,17 +11,27 @@ interface IProps {
   model: ITileModel;
 }
 
+// TODO improve this to break on nearest word ending
+const getStackValueDisplay = (value: string) => {
+  if(value === "") return "(no value)";
+  if(gImageMap.isImageUrl(value)) return "(image)";
+  if(value.length < 14) return value;
+  return value.slice(0, 13) + '... ';
+};
+
 export const SortStack: React.FC<IProps> = ({ model, stackValue, inAttributeId }) => {
   const content = model.content as DataCardContentModelType;
-  const caseIds = content.caseIdsWithAttributeValue(inAttributeId, stackValue);
+  const caseIds = content.caseIdsFromAttributeValue(inAttributeId, stackValue);
   const units = caseIds.length > 1 ? "cards" : "card";
-  const stackValueDisplay = stackValue !== "" ? stackValue : "(no value)";
+  const stackValueDisplay = getStackValueDisplay(stackValue);
+  const stackClasses = classNames("stack-cards", inAttributeId);
+
   return (
-    <div className="stack cell">
+    <div className="stack cell" /*style={{ height: "290px"}}*/>
       <div className="stack-heading">
-        {stackValueDisplay}: {caseIds.length} {units}
+         {stackValueDisplay}: {caseIds.length} {units}
       </div>
-      <div className="stack-cards">
+      <div className={stackClasses}>
         {
           caseIds.map((cid, i) => {
             return <SortCard

--- a/src/plugins/data-card/data-card-content.ts
+++ b/src/plugins/data-card/data-card-content.ts
@@ -116,7 +116,7 @@ export const DataCardContentModel = TileContentModel
       });
       return attributesWithValues === 0;
     },
-    caseIdsWithAttributeValue(attrId: string, value: string){
+    caseIdsFromAttributeValue(attrId: string, value: string){
       const allCases = this.allCases();
       const foundCases: string[] = [];
       allCases.forEach((c) => c && c[attrId] === value && foundCases.push(c.__id__));


### PR DESCRIPTION
This implements a display for sorted data cards.   Cards appear in their sorted-by-attribute-value category, and can be individually toggled open or closed.  

`SortCard` now displays a styled card, and can toggle open and closed.  `SortCardAttribute` displays an individual attribute name/value pair.  Styling was cleaned up and consolidated a little bit.  

I also added a little more cypress test coverage.  Randomly the linter brought to the surface some small issues in some unrelated cypress tests, and those are in this PR as well. 

PT #184524377 should be updated to reflect the fact that the PIs now prefer the toggle-any-card view deployed here. 

