### PR TITLE
184755026 Export Sections

### DIFF
--- a/src/components/document/canvas.tsx
+++ b/src/components/document/canvas.tsx
@@ -72,6 +72,7 @@ export class CanvasComponent extends BaseComponent<IProps, IState> {
 
     this.hotKeys.register({
       "cmd-shift-s": this.handleCopyDocumentJson,
+      "cmd-option-shift-s": this.handleExportSectionJson,
       "cmd-z": this.handleDocumentUndo,
       "cmd-shift-z": this.handleDocumentRedo
     });
@@ -153,17 +154,32 @@ export class CanvasComponent extends BaseComponent<IProps, IState> {
   private handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     this.hotKeys.dispatch(e);
   };
+  
+  private getDocumentContent = () => {
+    const { content, document } = this.props;
+    return document?.content ?? content;
+  };
 
-  private handleCopyDocumentJson = () => {
-    const {content, document } = this.props;
+  private getTransformImageUrl = () => {
     const { appConfig, unit } = this.stores;
     const unitBasePath = appConfig.getUnitBasePath(unit.code);
-    const documentContent = document?.content ?? content;
-    const transformImageUrl = (url?: string, filename?: string) => {
+    return (url?: string, filename?: string) => {
       return transformCurriculumImageUrl(url, unitBasePath, filename);
     };
+  };
+
+  private handleCopyDocumentJson = () => {
+    const documentContent = this.getDocumentContent();
+    const transformImageUrl = this.getTransformImageUrl();
     const json = documentContent?.exportAsJson({ includeTileIds: true, transformImageUrl });
     json && navigator.clipboard.writeText(json);
+  };
+
+  private handleExportSectionJson = () => {
+    const documentContent = this.getDocumentContent();
+    const transformImageUrl = this.getTransformImageUrl();
+    const json = documentContent?.exportSectionsAsJson({ includeTileIds: true, transformImageUrl });
+    console.log(`section json`, json);
   };
 
   private handleDocumentUndo = () => {

--- a/src/components/document/canvas.tsx
+++ b/src/components/document/canvas.tsx
@@ -175,7 +175,7 @@ export class CanvasComponent extends BaseComponent<IProps, IState> {
     json && navigator.clipboard.writeText(json);
   };
 
-  // Saves the currect document as separate section files on the user's hard drive.
+  // Saves the current document as separate section files on the user's hard drive.
   // Saved in [user selected folder]/CLUE Sections/[section type]/content.json
   private handleExportSectionJson = async () => {
     const documentContent = this.getDocumentContent();
@@ -196,9 +196,8 @@ export class CanvasComponent extends BaseComponent<IProps, IState> {
             await writableStream.close();
           });
         }
-        console.log(`Sections saved to CLUE Sections in selected folder.`);
       } catch (error) {
-        console.log(`Unable to export section json`, error);
+        console.error(`Unable to export section json`, error);
       }
     }
   };

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -365,10 +365,11 @@ export const DocumentContentModel = types
       });
       return counts;
     },
-    exportAsJson(options?: IDocumentExportOptions) {
+    exportRowsAsJson(rows: (TileRowModelType | undefined)[], options?: IDocumentExportOptions) {
       const builder = new StringBuilder();
       builder.pushLine("{");
 
+      // TODO Only include necessary shared models
       const sharedModelsArray = Array.from(self.sharedModelMap.values());
       if (sharedModelsArray.length > 0){
         builder.pushLine(`"sharedModels":${stringify(sharedModelsArray)},`, 2);
@@ -376,14 +377,8 @@ export const DocumentContentModel = types
 
       builder.pushLine(`"tiles": [`, 2);
 
-      // identify rows with exportable tiles
-      const rowsToExport = self.rowOrder.map(rowId => {
-        const row = self.getRow(rowId);
-        return row && !row.isSectionHeader && !row.isEmpty && !self.isPlaceholderRow(row) ? row : undefined;
-      }).filter(row => !!row);
-
-      const exportRowCount = rowsToExport.length;
-      rowsToExport.forEach((row, rowIndex) => {
+      const exportRowCount = rows.length;
+      rows.forEach((row, rowIndex) => {
         const isLastRow = rowIndex === exportRowCount - 1;
         // export each exportable tile
         const tileExports = row?.tiles.map((tileInfo, tileIndex) => {
@@ -412,54 +407,44 @@ export const DocumentContentModel = types
       builder.pushLine("]", 2);
       builder.pushLine("}");
       return builder.build();
+    }
+  }))
+  .views(self => ({
+    exportAsJson(options?: IDocumentExportOptions) {
+      // identify rows with exportable tiles
+      const rowsToExport = self.rowOrder.map(rowId => {
+        const row = self.getRow(rowId);
+        return row && !row.isSectionHeader && !row.isEmpty && !self.isPlaceholderRow(row) ? row : undefined;
+      }).filter(row => !!row);
+
+      return self.exportRowsAsJson(rowsToExport, options);
     },
     exportSectionsAsJson(options?: IDocumentExportOptions) {
-      const builder = new StringBuilder();
-      builder.pushLine("{");
+      const sections: Record<string, string> = {};
+      let section = "";
+      let rows: (TileRowModelType | undefined)[] = [];
 
-      const sharedModelsArray = Array.from(self.sharedModelMap.values());
-      if (sharedModelsArray.length > 0){
-        builder.pushLine(`"sharedModels":${stringify(sharedModelsArray)},`, 2);
-      }
-
-      builder.pushLine(`"tiles": [`, 2);
-
-      // identify rows with exportable tiles
-      const rowsToExport = self.rowOrder.map(rowId => {
+      self.rowOrder.forEach(rowId => {
         const row = self.getRow(rowId);
-        return row && !row.isSectionHeader && !row.isEmpty && !self.isPlaceholderRow(row) ? row : undefined;
-      }).filter(row => !!row);
-
-      const exportRowCount = rowsToExport.length;
-      rowsToExport.forEach((row, rowIndex) => {
-        const isLastRow = rowIndex === exportRowCount - 1;
-        // export each exportable tile
-        const tileExports = row?.tiles.map((tileInfo, tileIndex) => {
-          const isLastTile = tileIndex === row.tiles.length - 1;
-          const showComma = row.tiles.length > 1 ? !isLastTile : !isLastRow;
-          const rowHeight = self.rowHeightToExport(row, tileInfo.tileId);
-          const rowHeightOption = rowHeight ? { rowHeight } : undefined;
-          return self.exportTileAsJson(tileInfo, { ...options, appendComma: showComma, ...rowHeightOption });
-        }).filter(json => !!json);
-        if (tileExports?.length) {
-          // multiple tiles in a row are exported in an array
-          if (tileExports.length > 1) {
-            builder.pushLine("[", 4);
-            tileExports.forEach(tileExport => {
-              tileExport && builder.pushBlock(tileExport, 6);
-            });
-            builder.pushLine(`]${comma(!isLastRow)}`, 4);
-          }
-          // single tile rows are exported directly
-          else if (tileExports[0]) {
-            builder.pushBlock(tileExports[0], 4);
+        if (row) {
+          if (row.isSectionHeader) {
+            if (section !== "") {
+              // We've finished the last section
+              sections[section] = self.exportRowsAsJson(rows.filter(r => !!r), options);
+            }
+            section = row.sectionId ?? "unknown";
+            rows = [];
+          } else if (!row.isEmpty && !self.isPlaceholderRow(row)) {
+            rows.push(row);
           }
         }
       });
+      if (section !== "") {
+        // Save the final section
+        sections[section] = self.exportRowsAsJson(rows.filter(r => !!r), options);
+      }
 
-      builder.pushLine("]", 2);
-      builder.pushLine("}");
-      return builder.build();
+      return sections;
     }
   }))
   .views(self => ({

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -330,7 +330,7 @@ export const DocumentContentModel = types
       const tile = self.getTile(tileInfo.tileId);
       const json = tile?.exportJson(tileOptions);
       if (json) {
-        return json.concat(comma(!!options?.appendComma));
+        return json;
       }
     }
   }))

--- a/src/models/tiles/table/table-export.ts
+++ b/src/models/tiles/table/table-export.ts
@@ -29,7 +29,8 @@ export const exportTableContentAsJson = (
 
   const builder = new StringBuilder();
   builder.pushLine("{");
-  builder.pushLine(`"type": "Table"`, 2);
+  const typeComma = dataSet.name ? "," : "";
+  builder.pushLine(`"type": "Table"${typeComma}`, 2);
   dataSet.name && builder.pushLine(`"name": "${dataSet.name}"`, 2);
   builder.pushLine("}");
   return builder.build();

--- a/src/models/tiles/text/text-content.ts
+++ b/src/models/tiles/text/text-content.ts
@@ -6,7 +6,7 @@ import { ITileExportOptions } from "../tile-content-info";
 import { TileContentModel } from "../tile-content";
 import { SharedModelType } from "../../shared/shared-model";
 import { getAllTextPluginInfos } from "./text-plugin-info";
-import { escapeBackslashes, escapeDoubleQuotes } from "../../../utilities/string-utils";
+import { escapeBackslashes, escapeDoubleQuotes, removeNewlines } from "../../../utilities/string-utils";
 
 export const kTextTileType = "Text";
 
@@ -81,7 +81,8 @@ export const TextContentModel = TileContentModel
       const html = value ? slateToHtml(value) : "";
       // We need to escape both double quotes and backslashes, otherwise the curriculum json will break.
       const exportHtml = html.split("\n")
-        .map((line, i, arr) => `    "${escapeDoubleQuotes(escapeBackslashes(line))}"${i < arr.length - 1 ? "," : ""}`);
+        .map((line, i, arr) =>
+          `    "${removeNewlines(escapeDoubleQuotes(escapeBackslashes(line)))}"${i < arr.length - 1 ? "," : ""}`);
       return [
         `{`,
         `  "type": "Text",`,

--- a/src/models/tiles/tile-content-info.ts
+++ b/src/models/tiles/tile-content-info.ts
@@ -60,6 +60,7 @@ export interface ITileExportOptions {
   excludeTitle?: boolean;
   rowHeight?: number;
   transformImageUrl?: (url: string, filename?: string) => string;
+  appendComma?: boolean;
 }
 
 export interface IDocumentExportOptions extends ITileExportOptions {

--- a/src/models/tiles/tile-model.ts
+++ b/src/models/tiles/tile-model.ts
@@ -100,7 +100,8 @@ export const TileModel = types
       }
       builder.pushBlock(`"content": ${contentJson}`, 2);
       options?.rowHeight && builder.pushLine(`"layout": { "height": ${options.rowHeight} }`, 2);
-      builder.pushLine(`}`);
+      const comma = options?.appendComma ? ',' : '';
+      builder.pushLine(`}${comma}`);
       return builder.build();
     }
   }))

--- a/src/utilities/hot-keys.ts
+++ b/src/utilities/hot-keys.ts
@@ -50,7 +50,7 @@ function keyCodeToString(keyCode: number) {
   }
 }
 
-export type HotKeyHandler = (e: React.KeyboardEvent, keys: string) => boolean | void;
+export type HotKeyHandler = (e: React.KeyboardEvent, keys: string) => boolean | void | Promise<void>;
 
 export interface IHotKeyMap {
   [keys: string]: HotKeyHandler;

--- a/src/utilities/string-utils.ts
+++ b/src/utilities/string-utils.ts
@@ -1,2 +1,3 @@
 export const escapeBackslashes = (text: string) => text.replaceAll(`\\`, `\\\\`);
 export const escapeDoubleQuotes = (text: string) => text.replaceAll(`"`, `\\"`);
+export const removeNewlines = (text: string) => text.replaceAll(`\\n`, ``).replaceAll(`\\r`, ``);


### PR DESCRIPTION
Fulfills this PT story: https://www.pivotaltracker.com/story/show/184755026

Allows a user to press cmd+option+shift+e to save the current document's contents as files representing sections.

Also fixes these bugs:
- Commas between tiles in exported json no longer include an extra newline.
- Text tiles that contained carriage returns from pasted content would include those line breaks in exported json. These are now removed when exporting sections into files.
- Table tile json now include a comma when a table name is present.