### PR TITLE
fix: Separate Content Repo Images (PT-184606497)

### DIFF
--- a/src/models/stores/app-config-model.test.ts
+++ b/src/models/stores/app-config-model.test.ts
@@ -50,6 +50,6 @@ describe("ConfigurationManager", () => {
       "guide": `https://curriculum.example.com/branch/main/${exampleUnitCode}/teacher-guide/content.json`
     };
     expect(appConfig.getUnit(exampleUnitCode)).toStrictEqual(exampleUnit);
-    expect(appConfig.getUnitBasePath(exampleUnitCode)).toBe(`https://curriculum.example.com/branch/main/${exampleUnitCode}`);
+    expect(appConfig.getUnitBasePath(exampleUnitCode)).toBe(exampleUnitCode);
   });
 });

--- a/src/models/stores/app-config-model.ts
+++ b/src/models/stores/app-config-model.ts
@@ -65,11 +65,7 @@ export const AppConfigModel = types
     getUnitBasePath(unitId: string) {
       const unitSpec = self.getUnit(unitId);
       if (!unitSpec) return "";
-      const parts = unitSpec.content.split("/");
-      if (parts.length > 0) {
-        parts.splice(parts.length - 1, 1);
-      }
-      return parts.join("/");
+      return `${unitId}`;
     }
   }))
   .views(self => ({


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/184606497

Fixes AppConfigModel's `getUnitBasePath` view so that exports contain relative paths for images instead of full URLs.