### PR TITLE
#184717210 drag and drop of data cards between sort stacks

### DIFF
--- a/cypress/e2e/clue/branch/student_tests/data_card_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/data_card_tool_spec.js
@@ -56,5 +56,20 @@ context('Data Card Tool Tile', function () {
       dc.getNextCardButton().click();
       dc.getCardNofTotalListing().contains("Card 3 of 3");
     });
+    it("can delete a card", () => {
+      dc.getDeleteCardButton().click();
+      cy.wait(100);
+      dc.getDeleteCardButton().click();
+      cy.wait(100);
+      dc.getCardNofTotalListing().contains("Card 1 of 1");
+    });
+    it("can expand and collapse a card in sort view", () =>{
+      dc.getSortSelect().select("Attr1 Renamed");
+      dc.getSortView().should('exist');
+      dc.getSortCardCollapseToggle().click();
+      dc.getSortCardData().should('not.exist');
+      dc.getSortCardCollapseToggle().click();
+      dc.getSortCardData().should('exist');
+    });
   });
 });

--- a/cypress/support/elements/clue/DataCardToolTile.js
+++ b/cypress/support/elements/clue/DataCardToolTile.js
@@ -36,6 +36,10 @@ class DataCardToolTile {
     const selector = ".add-remove-card-buttons .add-card";
     return cy.get(`${workspaceClass || ".primary-workspace"} ${selector}`);
   }
+  getDeleteCardButton(workspaceClass){
+    const selector = ".add-remove-card-buttons .remove-card";
+    return cy.get(`${workspaceClass || ".primary-workspace"} ${selector}`);
+  }
   getCardNofTotalListing(workspaceClass){
     return cy.get(`${workspaceClass || ".primary-workspace"} .card-number-of-listing`);
   }
@@ -48,8 +52,16 @@ class DataCardToolTile {
   getSortCardHeading(workspaceClass){
     return cy.get(`${workspaceClass || ".primary-workspace"} .sortable .heading`);
   }
+  getSortCardCollapseToggle(workspaceClass){
+    const selector = ".expand-toggle-area button.expand-toggle";
+    return cy.get(`${workspaceClass || ".primary-workspace"} ${selector}`);
+  }
   getSortCardData(workspaceClass){
     const selector = ".sortable.expanded .attribute-value-row";
+    return cy.get(`${workspaceClass || ".primary-workspace"} ${selector}`);
+  }
+  getConfirmDeleteButton(workspaceClass){
+    const selector = ".button.modal-button.default";
     return cy.get(`${workspaceClass || ".primary-workspace"} ${selector}`);
   }
 }

--- a/src/plugins/data-card/components/sort-area.scss
+++ b/src/plugins/data-card/components/sort-area.scss
@@ -22,6 +22,7 @@ $sort-view-width: ($sort-view-card-width * $cards-per-row ) + 3;
       grid-template-columns: $sort-view-card-width $sort-view-card-width $sort-view-card-width;
       border-left: $card-border;
       border-right: $card-border;
+      border-bottom: $card-border;
 
       .stack {
         width: $sort-view-card-width;

--- a/src/plugins/data-card/components/sort-area.scss
+++ b/src/plugins/data-card/components/sort-area.scss
@@ -35,6 +35,16 @@ $sort-view-width: ($sort-view-card-width * $cards-per-row ) + 3;
           border-top: $card-border;
           height: 27px;
         }
+        .stack-drop-zone.show-droppable {
+          background-color: $workspace-teal-light-6;
+          height:40px;
+          border:3px dotted $workspace-teal-light-2;
+          border-radius: 5px;
+          margin:3px;
+        }
+        .stack-drop-zone.show-droppable.is-over {
+          background-color: $workspace-teal-light-4;
+        }
       }
 
       .empty.cell {
@@ -58,10 +68,22 @@ $sort-view-width: ($sort-view-card-width * $cards-per-row ) + 3;
         text-align: right;
         border-radius: 5px 5px 0px 0px;
         display:flex;
-        align-items: flex-end;
+        align-items: center;
+        text-align: center;
 
         .card-count-info {
-          width:90%;
+          translate: 3px .5px;
+        }
+
+        svg {
+          cursor: pointer;
+          background-color: transparent;
+          left: 168px;
+          translate: 74px 0px;
+          height: 20px;
+          path {
+            fill: transparent;
+          }
         }
       }
 

--- a/src/plugins/data-card/components/sort-area.tsx
+++ b/src/plugins/data-card/components/sort-area.tsx
@@ -22,7 +22,7 @@ export const DataCardSortArea: React.FC<IProps> = ({ model }) => {
    // if one of the categories is a category for no value, put this stack last
   uniqueOrderedValues.includes("") && uniqueOrderedValues.push(uniqueOrderedValues.shift());
 
-  const [draggingActive, setDraggingActive] = useState(false);
+  const [sortDragActive, setSortDragActive] = useState(false);
 
   const renderPlaceholderCells = () => {
     const columnsCount = 3; // local constant now, but may be dynamic in future
@@ -35,16 +35,16 @@ export const DataCardSortArea: React.FC<IProps> = ({ model }) => {
   };
 
   useDndMonitor({
-    onDragStart: (event) => {
-      setDraggingActive(true);
+    onDragStart: (e) => {
+      e.active.data.current?.sortDrag && setSortDragActive(true);
     },
-    onDragEnd: (event) => {
+    onDragEnd: (e) => {
       // set the value of the attribute to the value in the stack we landed on
-      const draggingId = event.active?.data?.current?.caseId;
-      const attrId = event.active?.data?.current?.sortedByAttrId;
-      const draggedToValue = event.over?.data?.current?.stackValue;
+      const draggingId = e.active?.data?.current?.caseId;
+      const attrId = e.active?.data?.current?.sortedByAttrId;
+      const draggedToValue = e.over?.data?.current?.stackValue;
       draggedToValue && content.setAttValue(draggingId, attrId, draggedToValue);
-      setDraggingActive(false);
+      e.active.data.current?.sortDrag && setSortDragActive(false);
     }
   });
 
@@ -59,7 +59,7 @@ export const DataCardSortArea: React.FC<IProps> = ({ model }) => {
               model={model}
               stackValue={value as string}
               inAttributeId={sortById}
-              draggingActive={draggingActive}
+              draggingActive={sortDragActive}
             />
           );
         })

--- a/src/plugins/data-card/components/sort-area.tsx
+++ b/src/plugins/data-card/components/sort-area.tsx
@@ -1,4 +1,4 @@
-import React, { useState} from "react";
+import React, { useState } from "react";
 import { getSnapshot } from "@concord-consortium/mobx-state-tree";
 import { uniq, orderBy } from "lodash";
 import { ITileModel } from "../../../models/tiles/tile-model";
@@ -19,7 +19,7 @@ export const DataCardSortArea: React.FC<IProps> = ({ model }) => {
   const attrsSnap = getSnapshot(content.attributes);
   const allAttrValues = attrsSnap.filter((a) => a.id === sortById)[0].values;
   const uniqueOrderedValues = orderBy(uniq(allAttrValues));
-   // if one of the categories is a category for no value, put this stack last
+  // if one of the categories is a category for no value, put this stack last
   uniqueOrderedValues.includes("") && uniqueOrderedValues.push(uniqueOrderedValues.shift());
 
   const [sortDragActive, setSortDragActive] = useState(false);
@@ -39,18 +39,19 @@ export const DataCardSortArea: React.FC<IProps> = ({ model }) => {
       e.active.data.current?.sortDrag && setSortDragActive(true);
     },
     onDragEnd: (e) => {
-      // set the value of the attribute to the value in the stack we landed on
-      const draggingId = e.active?.data?.current?.caseId;
-      const attrId = e.active?.data?.current?.sortedByAttrId;
-      const draggedToValue = e.over?.data?.current?.stackValue;
-      draggedToValue && content.setAttValue(draggingId, attrId, draggedToValue);
-      e.active.data.current?.sortDrag && setSortDragActive(false);
+      if (e.active.data.current?.sortDrag) {
+        const draggingId = e.active?.data?.current?.caseId;
+        const attrId = e.active?.data?.current?.sortedByAttrId;
+        const draggedToValue = e.over?.data?.current?.stackValue;
+        draggedToValue && content.setAttValue(draggingId, attrId, draggedToValue);
+        setSortDragActive(false);
+      }
     }
   });
 
   return (
     <div className="sort-area-grid">
-      { uniqueOrderedValues.length > 0 && sortById &&
+      {uniqueOrderedValues.length > 0 && sortById &&
         uniqueOrderedValues.map((value, i) => {
           return (
             <SortStack
@@ -64,7 +65,7 @@ export const DataCardSortArea: React.FC<IProps> = ({ model }) => {
           );
         })
       }
-      { renderPlaceholderCells() }
+      {renderPlaceholderCells()}
     </div>
   );
 };

--- a/src/plugins/data-card/components/sort-area.tsx
+++ b/src/plugins/data-card/components/sort-area.tsx
@@ -1,9 +1,10 @@
-import React from "react";
+import React, { useState} from "react";
 import { getSnapshot } from "@concord-consortium/mobx-state-tree";
 import { uniq, orderBy } from "lodash";
 import { ITileModel } from "../../../models/tiles/tile-model";
 import { DataCardContentModelType } from "../data-card-content";
 import { SortStack, SortStackPlaceholder } from "./sort-stack";
+import { useDndMonitor } from "@dnd-kit/core";
 
 import "./sort-area.scss";
 
@@ -21,6 +22,8 @@ export const DataCardSortArea: React.FC<IProps> = ({ model }) => {
    // if one of the categories is a category for no value, put this stack last
   uniqueOrderedValues.includes("") && uniqueOrderedValues.push(uniqueOrderedValues.shift());
 
+  const [draggingActive, setDraggingActive] = useState(false);
+
   const renderPlaceholderCells = () => {
     const columnsCount = 3; // local constant now, but may be dynamic in future
     const rowsNeeded = Math.ceil(uniqueOrderedValues.length / columnsCount);
@@ -31,16 +34,32 @@ export const DataCardSortArea: React.FC<IProps> = ({ model }) => {
     return placeholders;
   };
 
+  useDndMonitor({
+    onDragStart: (event) => {
+      setDraggingActive(true);
+    },
+    onDragEnd: (event) => {
+      // set the value of the attribute to the value in the stack we landed on
+      const draggingId = event.active?.data?.current?.caseId;
+      const attrId = event.active?.data?.current?.sortedByAttrId;
+      const draggedToValue = event.over?.data?.current?.stackValue;
+      draggedToValue && content.setAttValue(draggingId, attrId, draggedToValue);
+      setDraggingActive(false);
+    }
+  });
+
   return (
     <div className="sort-area-grid">
       { uniqueOrderedValues.length > 0 && sortById &&
-        uniqueOrderedValues.map((v, i) => {
+        uniqueOrderedValues.map((value, i) => {
           return (
             <SortStack
-              key={i}
+              key={`${sortById}-${value}`}
+              id={`${sortById}-${value}`}
               model={model}
-              stackValue={v as string}
+              stackValue={value as string}
               inAttributeId={sortById}
+              draggingActive={draggingActive}
             />
           );
         })

--- a/src/plugins/data-card/components/sort-card.tsx
+++ b/src/plugins/data-card/components/sort-card.tsx
@@ -3,12 +3,15 @@ import classNames from "classnames";
 import { ITileModel } from "../../../models/tiles/tile-model";
 import { DataCardContentModelType } from "../data-card-content";
 import { SortCardAttribute } from "./sort-card-attribute";
+import { useDraggable } from "@dnd-kit/core";
+import TileDragHandle from "../../../assets/icons/drag-tile/move.svg";
 
 interface IProps {
   caseId: string;
   model: ITileModel;
   indexInStack: number;
   totalInStack: number;
+  id?: string;
 }
 
 const getShadeRGB = (index: number) => {
@@ -31,8 +34,26 @@ export const SortCard: React.FC<IProps> = ({ model, caseId, indexInStack, totalI
 
   const [expanded, setExpanded] = useState(false);
   useEffect(()=> setExpanded(atStackTop), [atStackTop]); // "top" card loads expanded
-  const toggleExpanded = () => setExpanded(!expanded);
-  const cardClasses = classNames("sortable", "card", { collapsed: !expanded }, { expanded });
+
+  const toggleExpanded = (e: React.MouseEvent) => {
+    setExpanded(!expanded);
+  };
+
+  const cardClasses = classNames(
+    "sortable", "card",
+    { collapsed: !expanded }, { expanded }
+  );
+
+  const {attributes, listeners, setNodeRef, transform} = useDraggable({
+    id: `draggable-sort-card-${caseId}`,
+    data: { caseId, sortedByAttrId: content.selectedSortAttributeId }
+  });
+
+  const style = transform ? {
+    transform: `translate3d(${transform.x}px, ${transform.y -25}px, 0)`,
+    zIndex: 1000,
+    opacity: 0.8
+  } : undefined;
 
   const loadAsSingle = () => {
     content.setSelectedSortAttributeId("");
@@ -40,13 +61,21 @@ export const SortCard: React.FC<IProps> = ({ model, caseId, indexInStack, totalI
   };
 
   return (
-    <div className={cardClasses} id={caseId} onDoubleClick={loadAsSingle}>
+    <div
+      className={cardClasses} id={caseId}
+      onDoubleClick={loadAsSingle}
+      ref={setNodeRef}
+      style={style}
+    >
       <div className="heading" style={{ backgroundColor: shadeStr }}>
         <div className="expand-toggle-area">
           <button className="expand-toggle" onClick={toggleExpanded}>▶</button>
         </div>
         <div className="card-count-info">
           { `Card ${ deckCardNumberDisplay } of ${ content.totalCases } `}
+        </div>
+        <div className="drag-handle" {...listeners} {...attributes}>
+          <TileDragHandle />
         </div>
       </div>
 
@@ -64,9 +93,8 @@ export const SortCard: React.FC<IProps> = ({ model, caseId, indexInStack, totalI
           })}
         </div>
       }
-
       <div className="footer" style={{ backgroundColor: shadeStr }}></div>
-
     </div>
   );
 };
+

--- a/src/plugins/data-card/components/sort-card.tsx
+++ b/src/plugins/data-card/components/sort-card.tsx
@@ -46,7 +46,7 @@ export const SortCard: React.FC<IProps> = ({ model, caseId, indexInStack, totalI
 
   const {attributes, listeners, setNodeRef, transform} = useDraggable({
     id: `draggable-sort-card-${caseId}`,
-    data: { caseId, sortedByAttrId: content.selectedSortAttributeId }
+    data: { caseId, sortedByAttrId: content.selectedSortAttributeId, sortDrag: true }
   });
 
   const style = transform ? {

--- a/src/plugins/data-card/components/sort-stack.tsx
+++ b/src/plugins/data-card/components/sort-stack.tsx
@@ -60,7 +60,7 @@ export const SortStack: React.FC<IProps> = ({ model, stackValue, inAttributeId, 
         }
       </div>
     </div>
-);
+  );
 };
 
 export const SortStackPlaceholder: React.FC = () => {

--- a/src/plugins/data-card/components/sort-stack.tsx
+++ b/src/plugins/data-card/components/sort-stack.tsx
@@ -4,11 +4,15 @@ import { DataCardContentModelType } from "../data-card-content";
 import { SortCard } from "./sort-card";
 import classNames from "classnames";
 import { gImageMap } from "../../../models/image-map";
+import { useDroppable } from "@dnd-kit/core";
 
 interface IProps {
   stackValue: string;
   inAttributeId: string;
   model: ITileModel;
+  id?: string;
+  passedRef?:any;
+  draggingActive?: boolean;
 }
 
 const getStackValueDisplay = (value: string) => {
@@ -18,18 +22,30 @@ const getStackValueDisplay = (value: string) => {
   return value.slice(0, 13) + '... ';
 };
 
-export const SortStack: React.FC<IProps> = ({ model, stackValue, inAttributeId }) => {
+export const SortStack: React.FC<IProps> = ({ model, stackValue, inAttributeId, draggingActive }) => {
   const content = model.content as DataCardContentModelType;
   const caseIds = content.caseIdsFromAttributeValue(inAttributeId, stackValue);
   const units = caseIds.length > 1 ? "cards" : "card";
   const stackValueDisplay = getStackValueDisplay(stackValue);
   const stackClasses = classNames("stack-cards", inAttributeId);
 
+  const { isOver, setNodeRef } = useDroppable({
+    id: `droppable-sort-stack-${inAttributeId}-${stackValue}}`,
+    data: { stackValue, inAttributeId }
+  });
+
+  const dropZoneClasses = classNames(
+   "stack-drop-zone",
+   {"show-droppable": draggingActive },
+   { "is-over" : isOver}
+  );
+
   return (
-    <div className="stack cell">
+    <div className="cell stack">
       <div className="stack-heading">
         {stackValueDisplay}: {caseIds.length} {units}
       </div>
+      <div className={dropZoneClasses} ref={setNodeRef}></div>
       <div className={stackClasses}>
         {
           caseIds.map((cid, i) => {
@@ -44,7 +60,7 @@ export const SortStack: React.FC<IProps> = ({ model, stackValue, inAttributeId }
         }
       </div>
     </div>
-  );
+);
 };
 
 export const SortStackPlaceholder: React.FC = () => {


### PR DESCRIPTION
Implements drag and drop of data cards between sort categories as described in PT story: https://www.pivotaltracker.com/n/projects/2441242/stories/184717210

- Dragging a card from one column to another in the sort view will change the value of the attribute and the card will appear in the new stack
- Drop zones appear at the top of sort stacks when any card is dragged
- Leverages `dnd-kit`: `useDraggable`, `useDroppable`, and `useDndMonitor`

