### PR TITLE
18477441 Fix geometry tile display

### DIFF
--- a/src/models/tiles/geometry/geometry-content.ts
+++ b/src/models/tiles/geometry/geometry-content.ts
@@ -258,7 +258,7 @@ export const GeometryContentModel = GeometryBaseContentModel
       return board.objectsList.filter(obj => self.isSelected(obj.id));
     },
     exportJson(options?: ITileExportOptions) {
-      const changes = convertModelToChanges(self, false);
+      const changes = convertModelToChanges(self, false, false);
       const jsonChanges = changes.map(change => JSON.stringify(change));
       return exportGeometryJson(jsonChanges, options);
     }
@@ -395,7 +395,7 @@ export const GeometryContentModel = GeometryBaseContentModel
     // actions
     function initializeBoard(domElementID: string, onCreate?: onCreateCallback): JXG.Board | undefined {
       let board: JXG.Board | undefined;
-      const changes = convertModelToChanges(self, true);
+      const changes = convertModelToChanges(self, true, true);
       applyChanges(domElementID, changes, getDispatcherContext())
         .filter(result => result != null)
         .forEach(changeResult => {
@@ -421,15 +421,19 @@ export const GeometryContentModel = GeometryBaseContentModel
     }
 
     function resizeBoard(board: JXG.Board, width: number, height: number, scale?: number) {
+      // console.log(`--- resizeBoard`, JSON.stringify({width, height, scale}, null, 2));
       // JSX Graph canvasWidth and canvasHeight are truncated to integers,
       // so we need to do the same to get the new canvasWidth and canvasHeight values
       const scaledWidth = Math.trunc(width) / (scale || 1);
       const scaledHeight = Math.trunc(height) / (scale || 1);
       const widthMultiplier = (scaledWidth - kXAxisTotalBuffer) / (board.canvasWidth - kXAxisTotalBuffer);
       const heightMultiplier = (scaledHeight - kYAxisTotalBuffer) / (board.canvasHeight - kYAxisTotalBuffer);
+      // console.log(`  - multipliers`, JSON.stringify({ widthMultiplier, heightMultiplier}, null, 2));
       // Remove the buffers to correct the graph proportions
       const [xMin, yMax, xMax, yMin] = guessUserDesiredBoundingBox(board);
+      // console.log(`  - guessed bb`, JSON.stringify({xMin, yMax, xMax, yMin}, null, 2));
       const { xMinBufferRange, xMaxBufferRange, yBufferRange } = getBoardUnitsAndBuffers(board);
+      // console.log(`  - units and buffers`, JSON.stringify({ xMinBufferRange, xMaxBufferRange, yBufferRange }, null, 2));
       // Add the buffers back post-scaling
       const newBoundingBox: JXG.BoundingBox = [
         xMin * widthMultiplier - xMinBufferRange,
@@ -437,12 +441,14 @@ export const GeometryContentModel = GeometryBaseContentModel
         xMax * widthMultiplier + xMaxBufferRange,
         yMin * heightMultiplier - yBufferRange
       ];
+      // console.log(`  - newBoundingBox`, JSON.stringify(newBoundingBox, null, 2));
       board.resizeContainer(scaledWidth, scaledHeight, false, true);
       board.setBoundingBox(newBoundingBox, false);
       board.update();
     }
 
     function rescaleBoard(board: JXG.Board, params: IAxesParams) {
+      // console.log(`ooo rescaleBoard`);
       const { canvasWidth, canvasHeight } = board;
       const { xName, xAnnotation, xMin, xMax, yName, yAnnotation, yMin, yMax } = params;
       const width = canvasWidth - kXAxisTotalBuffer;

--- a/src/models/tiles/geometry/geometry-content.ts
+++ b/src/models/tiles/geometry/geometry-content.ts
@@ -258,7 +258,7 @@ export const GeometryContentModel = GeometryBaseContentModel
       return board.objectsList.filter(obj => self.isSelected(obj.id));
     },
     exportJson(options?: ITileExportOptions) {
-      const changes = convertModelToChanges(self, false, false);
+      const changes = convertModelToChanges(self, { addBuffers: false, includeUnits: false});
       const jsonChanges = changes.map(change => JSON.stringify(change));
       return exportGeometryJson(jsonChanges, options);
     }
@@ -395,7 +395,7 @@ export const GeometryContentModel = GeometryBaseContentModel
     // actions
     function initializeBoard(domElementID: string, onCreate?: onCreateCallback): JXG.Board | undefined {
       let board: JXG.Board | undefined;
-      const changes = convertModelToChanges(self, true, true);
+      const changes = convertModelToChanges(self, { addBuffers: true, includeUnits: true});
       applyChanges(domElementID, changes, getDispatcherContext())
         .filter(result => result != null)
         .forEach(changeResult => {

--- a/src/models/tiles/geometry/geometry-content.ts
+++ b/src/models/tiles/geometry/geometry-content.ts
@@ -421,19 +421,15 @@ export const GeometryContentModel = GeometryBaseContentModel
     }
 
     function resizeBoard(board: JXG.Board, width: number, height: number, scale?: number) {
-      // console.log(`--- resizeBoard`, JSON.stringify({width, height, scale}, null, 2));
       // JSX Graph canvasWidth and canvasHeight are truncated to integers,
       // so we need to do the same to get the new canvasWidth and canvasHeight values
       const scaledWidth = Math.trunc(width) / (scale || 1);
       const scaledHeight = Math.trunc(height) / (scale || 1);
       const widthMultiplier = (scaledWidth - kXAxisTotalBuffer) / (board.canvasWidth - kXAxisTotalBuffer);
       const heightMultiplier = (scaledHeight - kYAxisTotalBuffer) / (board.canvasHeight - kYAxisTotalBuffer);
-      // console.log(`  - multipliers`, JSON.stringify({ widthMultiplier, heightMultiplier}, null, 2));
       // Remove the buffers to correct the graph proportions
       const [xMin, yMax, xMax, yMin] = guessUserDesiredBoundingBox(board);
-      // console.log(`  - guessed bb`, JSON.stringify({xMin, yMax, xMax, yMin}, null, 2));
       const { xMinBufferRange, xMaxBufferRange, yBufferRange } = getBoardUnitsAndBuffers(board);
-      // console.log(`  - units and buffers`, JSON.stringify({ xMinBufferRange, xMaxBufferRange, yBufferRange }, null, 2));
       // Add the buffers back post-scaling
       const newBoundingBox: JXG.BoundingBox = [
         xMin * widthMultiplier - xMinBufferRange,
@@ -441,14 +437,12 @@ export const GeometryContentModel = GeometryBaseContentModel
         xMax * widthMultiplier + xMaxBufferRange,
         yMin * heightMultiplier - yBufferRange
       ];
-      // console.log(`  - newBoundingBox`, JSON.stringify(newBoundingBox, null, 2));
       board.resizeContainer(scaledWidth, scaledHeight, false, true);
       board.setBoundingBox(newBoundingBox, false);
       board.update();
     }
 
     function rescaleBoard(board: JXG.Board, params: IAxesParams) {
-      // console.log(`ooo rescaleBoard`);
       const { canvasWidth, canvasHeight } = board;
       const { xName, xAnnotation, xMin, xMax, yName, yAnnotation, yMin, yMax } = params;
       const width = canvasWidth - kXAxisTotalBuffer;

--- a/src/models/tiles/geometry/geometry-import.ts
+++ b/src/models/tiles/geometry/geometry-import.ts
@@ -182,12 +182,17 @@ function getBoardBounds(axisMin?: JXGCoordPair, protoRange?: JXGCoordPair) {
   return [xAxis.min, yAxisMax, xAxisMax, yAxis.min];
 }
 
+export interface IGeometryBoardChangeOptions {
+  addBuffers?: boolean;
+  includeUnits?: boolean;
+}
 export function defaultGeometryBoardChange(
-  xAxis: AxisModelType, yAxis: AxisModelType, overrides?: JXGProperties, addBuffers?: boolean, includeUnits?: boolean
+  xAxis: AxisModelType, yAxis: AxisModelType, overrides?: JXGProperties, options?: IGeometryBoardChangeOptions
 ) {
   // console.log(`--- defaultGeometryBoardChange`);
   // console.log(`  - xAxis`, JSON.stringify(xAxis, null, 2));
   // console.log(`  - yAxis`, JSON.stringify(yAxis, null, 2));
+  const { addBuffers, includeUnits } = options ?? {};
   const axisMin: JXGCoordPair = [xAxis.min, yAxis.min];
   const axisRange: JXGCoordPair = [xAxis.range ?? kGeometryDefaultWidth / xAxis.unit,
                                    yAxis.range ?? kGeometryDefaultHeight / yAxis.unit];

--- a/src/models/tiles/geometry/geometry-import.ts
+++ b/src/models/tiles/geometry/geometry-import.ts
@@ -163,24 +163,31 @@ function getBaseAxes(protoMin?: JXGCoordPair, protoRange?: JXGCoordPair): AxisTu
       return [{ min: xMin, unit: yUnit, range: xRange }, { min: yMin, unit: yUnit, range: yRange }];
     }
     default: {
+      // console.log(`--- getBaseAxes`, JSON.stringify([protoMin, protoRange], null, 2));
       const [xRange, yRange] = pRange as JXGCoordPair;
       const xUnit = kGeometryDefaultWidth / xRange;
       const yUnit = kGeometryDefaultHeight / yRange;
+      // console.log(`  - units`, JSON.stringify([xUnit, yUnit], null, 2));
       return [{ min: xMin, unit: xUnit, range: xRange }, { min: yMin, unit: yUnit, range: yRange }];
     }
   }
 }
 
 function getBoardBounds(axisMin?: JXGCoordPair, protoRange?: JXGCoordPair) {
+  // console.log(`--- getBoardBounds`, JSON.stringify([axisMin, protoRange], null, 2));
   const [xAxis, yAxis] = getBaseAxes(axisMin, protoRange);
   const xAxisMax = xAxis.min + kGeometryDefaultWidth / (xAxis.unit ?? kGeometryDefaultPixelsPerUnit);
   const yAxisMax = yAxis.min + kGeometryDefaultHeight / (yAxis.unit ?? kGeometryDefaultPixelsPerUnit);
+  // console.log(`  - max`, JSON.stringify([xAxisMax, yAxisMax], null, 2));
   return [xAxis.min, yAxisMax, xAxisMax, yAxis.min];
 }
 
 export function defaultGeometryBoardChange(
-  xAxis: AxisModelType, yAxis: AxisModelType, overrides?: JXGProperties, addBuffers?: boolean
+  xAxis: AxisModelType, yAxis: AxisModelType, overrides?: JXGProperties, addBuffers?: boolean, includeUnits?: boolean
 ) {
+  // console.log(`--- defaultGeometryBoardChange`);
+  // console.log(`  - xAxis`, JSON.stringify(xAxis, null, 2));
+  // console.log(`  - yAxis`, JSON.stringify(yAxis, null, 2));
   const axisMin: JXGCoordPair = [xAxis.min, yAxis.min];
   const axisRange: JXGCoordPair = [xAxis.range ?? kGeometryDefaultWidth / xAxis.unit,
                                    yAxis.range ?? kGeometryDefaultHeight / yAxis.unit];
@@ -191,12 +198,15 @@ export function defaultGeometryBoardChange(
   const xMaxBufferRange = addBuffers ? kAxisBuffer / unitX : 0;
   const yBufferRange = addBuffers ? kAxisBuffer / unitY : 0;
   const boundingBox = [xMin - xMinBufferRange, yMax + yBufferRange, xMax + xMaxBufferRange, yMin - yBufferRange];
+  // console.log(`  - boundingBox`, JSON.stringify(boundingBox, null, 2));
+  const units = includeUnits ? { unitX, unitY } : {};
   const change: JXGChange = {
     operation: "create",
     target: "board",
     properties: {
       axis: true,
       boundingBox,
+      ...units,
       ...overrides
     }
   };

--- a/src/models/tiles/geometry/geometry-import.ts
+++ b/src/models/tiles/geometry/geometry-import.ts
@@ -163,22 +163,18 @@ function getBaseAxes(protoMin?: JXGCoordPair, protoRange?: JXGCoordPair): AxisTu
       return [{ min: xMin, unit: yUnit, range: xRange }, { min: yMin, unit: yUnit, range: yRange }];
     }
     default: {
-      // console.log(`--- getBaseAxes`, JSON.stringify([protoMin, protoRange], null, 2));
       const [xRange, yRange] = pRange as JXGCoordPair;
       const xUnit = kGeometryDefaultWidth / xRange;
       const yUnit = kGeometryDefaultHeight / yRange;
-      // console.log(`  - units`, JSON.stringify([xUnit, yUnit], null, 2));
       return [{ min: xMin, unit: xUnit, range: xRange }, { min: yMin, unit: yUnit, range: yRange }];
     }
   }
 }
 
 function getBoardBounds(axisMin?: JXGCoordPair, protoRange?: JXGCoordPair) {
-  // console.log(`--- getBoardBounds`, JSON.stringify([axisMin, protoRange], null, 2));
   const [xAxis, yAxis] = getBaseAxes(axisMin, protoRange);
   const xAxisMax = xAxis.min + kGeometryDefaultWidth / (xAxis.unit ?? kGeometryDefaultPixelsPerUnit);
   const yAxisMax = yAxis.min + kGeometryDefaultHeight / (yAxis.unit ?? kGeometryDefaultPixelsPerUnit);
-  // console.log(`  - max`, JSON.stringify([xAxisMax, yAxisMax], null, 2));
   return [xAxis.min, yAxisMax, xAxisMax, yAxis.min];
 }
 
@@ -189,9 +185,6 @@ export interface IGeometryBoardChangeOptions {
 export function defaultGeometryBoardChange(
   xAxis: AxisModelType, yAxis: AxisModelType, overrides?: JXGProperties, options?: IGeometryBoardChangeOptions
 ) {
-  // console.log(`--- defaultGeometryBoardChange`);
-  // console.log(`  - xAxis`, JSON.stringify(xAxis, null, 2));
-  // console.log(`  - yAxis`, JSON.stringify(yAxis, null, 2));
   const { addBuffers, includeUnits } = options ?? {};
   const axisMin: JXGCoordPair = [xAxis.min, yAxis.min];
   const axisRange: JXGCoordPair = [xAxis.range ?? kGeometryDefaultWidth / xAxis.unit,
@@ -203,7 +196,6 @@ export function defaultGeometryBoardChange(
   const xMaxBufferRange = addBuffers ? kAxisBuffer / unitX : 0;
   const yBufferRange = addBuffers ? kAxisBuffer / unitY : 0;
   const boundingBox = [xMin - xMinBufferRange, yMax + yBufferRange, xMax + xMaxBufferRange, yMin - yBufferRange];
-  // console.log(`  - boundingBox`, JSON.stringify(boundingBox, null, 2));
   const units = includeUnits ? { unitX, unitY } : {};
   const change: JXGChange = {
     operation: "create",

--- a/src/models/tiles/geometry/geometry-migrate.ts
+++ b/src/models/tiles/geometry/geometry-migrate.ts
@@ -31,14 +31,19 @@ export const convertChangesToModel = (changes: JXGChange[]) => {
   return exportGeometryModel(changesJson);
 };
 
-export const convertModelToChanges = (model: GeometryBaseContentModelType, addBuffers?: boolean): JXGChange[] => {
+export const convertModelToChanges = (
+  model: GeometryBaseContentModelType, addBuffers?: boolean, includeUnits?: boolean
+): JXGChange[] => {
+  // console.log(`ooo convertModelToChanges`);
   const { board, bgImage, objects } = model;
   const changes: JXGChange[] = [];
   // convert the board
   const { xAxis, yAxis } = board || BoardModel.create(kDefaultBoardModelOutputProps);
   const { name: xName, label: xAnnotation } = xAxis;
   const { name: yName, label: yAnnotation } = yAxis;
-  changes.push(defaultGeometryBoardChange(xAxis, yAxis, { xName, yName, xAnnotation, yAnnotation }, addBuffers ));
+  changes.push(
+    defaultGeometryBoardChange(xAxis, yAxis, { xName, yName, xAnnotation, yAnnotation }, addBuffers, includeUnits )
+  );
   // convert the background image (if any)
   if (bgImage) {
     changes.push(...convertModelObjectToChanges(bgImage));

--- a/src/models/tiles/geometry/geometry-migrate.ts
+++ b/src/models/tiles/geometry/geometry-migrate.ts
@@ -13,7 +13,7 @@ import {
 } from "./jxg-changes";
 import { getMovableLinePointIds, kGeometryDefaultHeight, kGeometryDefaultWidth } from "./jxg-types";
 import { kDefaultBoardModelOutputProps, kGeometryTileType } from "./geometry-types";
-import { defaultGeometryBoardChange } from "./geometry-import";
+import { defaultGeometryBoardChange, IGeometryBoardChangeOptions } from "./geometry-import";
 
 export const isGeometryChangesContent = (snap: any) => {
   return (snap?.type === kGeometryTileType) && Array.isArray(snap.changes);
@@ -32,7 +32,7 @@ export const convertChangesToModel = (changes: JXGChange[]) => {
 };
 
 export const convertModelToChanges = (
-  model: GeometryBaseContentModelType, addBuffers?: boolean, includeUnits?: boolean
+  model: GeometryBaseContentModelType, boardOptions?: IGeometryBoardChangeOptions
 ): JXGChange[] => {
   // console.log(`ooo convertModelToChanges`);
   const { board, bgImage, objects } = model;
@@ -42,7 +42,7 @@ export const convertModelToChanges = (
   const { name: xName, label: xAnnotation } = xAxis;
   const { name: yName, label: yAnnotation } = yAxis;
   changes.push(
-    defaultGeometryBoardChange(xAxis, yAxis, { xName, yName, xAnnotation, yAnnotation }, addBuffers, includeUnits )
+    defaultGeometryBoardChange(xAxis, yAxis, { xName, yName, xAnnotation, yAnnotation }, boardOptions )
   );
   // convert the background image (if any)
   if (bgImage) {

--- a/src/models/tiles/geometry/geometry-migrate.ts
+++ b/src/models/tiles/geometry/geometry-migrate.ts
@@ -34,7 +34,6 @@ export const convertChangesToModel = (changes: JXGChange[]) => {
 export const convertModelToChanges = (
   model: GeometryBaseContentModelType, boardOptions?: IGeometryBoardChangeOptions
 ): JXGChange[] => {
-  // console.log(`ooo convertModelToChanges`);
   const { board, bgImage, objects } = model;
   const changes: JXGChange[] = [];
   // convert the board

--- a/src/models/tiles/geometry/jxg-board.ts
+++ b/src/models/tiles/geometry/jxg-board.ts
@@ -169,21 +169,16 @@ function getCanvasScale(eltOrId: string | HTMLElement | null) {
 }
 
 function scaleBoundingBoxToElement(domElementID: string, changeProps: any) {
-  // console.log(`xxx scaleBoundingBoxToElement`);
-  // console.log(`  x changeProps`, JSON.stringify(changeProps, null, 2));
   const elt = document.getElementById(domElementID);
   const eltBounds = elt?.getBoundingClientRect();
-  // console.log(`  x eltBounds`, JSON.stringify(eltBounds, null, 2));
   const eltWidth = eltBounds?.width || kGeometryDefaultWidth;
   const eltHeight = eltBounds?.height || kGeometryDefaultHeight;
   const { boundingBox }: { boundingBox: JXG.BoundingBox } = changeProps;
   const [unitX, unitY] = getAxisUnitsFromProps(changeProps, getCanvasScale(elt));
-  // console.log(`  x units`, JSON.stringify({ unitX, unitY }, null, 2));
   // eslint-disable-next-line no-sparse-arrays
   const [xMin, , , yMin] = boundingBox || [kGeometryDefaultXAxisMin, , , kGeometryDefaultYAxisMin];
   const xMax = xMin + eltWidth / unitX;
   const yMax = yMin + eltHeight / unitY;
-  // console.log(`  x bb`, JSON.stringify({ xMin, yMax, xMax, yMin }, null, 2));
   return [xMin, yMax, xMax, yMin] as JXG.BoundingBox;
 }
 
@@ -198,11 +193,8 @@ export function getBoardUnitsAndBuffers(board: JXG.Board) {
 }
 
 export function guessUserDesiredBoundingBox(board: JXG.Board) {
-  // console.log(`+++ guessUserDesiredBoundingBox`);
   const [xMin, yMax, xMax, yMin] = board.getBoundingBox();
-  // console.log(`  + bb`, JSON.stringify({ xMin, yMax, xMax, yMin }, null, 2));
   const { xMinBufferRange, xMaxBufferRange, yBufferRange } = getBoardUnitsAndBuffers(board);
-  // console.log(`  + units and buffers`, JSON.stringify({ xMinBufferRange, xMaxBufferRange, yBufferRange }, null, 2));
 
   return [xMin + xMinBufferRange, yMax - yBufferRange, xMax - xMaxBufferRange, yMin + yBufferRange];
 }

--- a/src/models/tiles/geometry/jxg-board.ts
+++ b/src/models/tiles/geometry/jxg-board.ts
@@ -169,16 +169,21 @@ function getCanvasScale(eltOrId: string | HTMLElement | null) {
 }
 
 function scaleBoundingBoxToElement(domElementID: string, changeProps: any) {
+  // console.log(`xxx scaleBoundingBoxToElement`);
+  // console.log(`  x changeProps`, JSON.stringify(changeProps, null, 2));
   const elt = document.getElementById(domElementID);
   const eltBounds = elt?.getBoundingClientRect();
+  // console.log(`  x eltBounds`, JSON.stringify(eltBounds, null, 2));
   const eltWidth = eltBounds?.width || kGeometryDefaultWidth;
   const eltHeight = eltBounds?.height || kGeometryDefaultHeight;
   const { boundingBox }: { boundingBox: JXG.BoundingBox } = changeProps;
   const [unitX, unitY] = getAxisUnitsFromProps(changeProps, getCanvasScale(elt));
+  // console.log(`  x units`, JSON.stringify({ unitX, unitY }, null, 2));
   // eslint-disable-next-line no-sparse-arrays
   const [xMin, , , yMin] = boundingBox || [kGeometryDefaultXAxisMin, , , kGeometryDefaultYAxisMin];
   const xMax = xMin + eltWidth / unitX;
   const yMax = yMin + eltHeight / unitY;
+  // console.log(`  x bb`, JSON.stringify({ xMin, yMax, xMax, yMin }, null, 2));
   return [xMin, yMax, xMax, yMin] as JXG.BoundingBox;
 }
 
@@ -193,8 +198,11 @@ export function getBoardUnitsAndBuffers(board: JXG.Board) {
 }
 
 export function guessUserDesiredBoundingBox(board: JXG.Board) {
+  // console.log(`+++ guessUserDesiredBoundingBox`);
   const [xMin, yMax, xMax, yMin] = board.getBoundingBox();
+  // console.log(`  + bb`, JSON.stringify({ xMin, yMax, xMax, yMin }, null, 2));
   const { xMinBufferRange, xMaxBufferRange, yBufferRange } = getBoardUnitsAndBuffers(board);
+  // console.log(`  + units and buffers`, JSON.stringify({ xMinBufferRange, xMaxBufferRange, yBufferRange }, null, 2));
 
   return [xMin + xMinBufferRange, yMax - yBufferRange, xMax - xMaxBufferRange, yMin + yBufferRange];
 }


### PR DESCRIPTION
This PR fixes a bug introduced in a previous fix. The issue is that a single function, `defaultGeometryBoardChange`, is used in two contexts, when initializing the board and when exporting json. But there are slight differences in requirements for these cases. Originally they were both doing the same thing, which caused the geometry view to shift when loading from exported json. But part of the fix for this was no longer including the units when converting the model to changes. However, this broke the case when we needed to initialize the board. The fix is to conditionally include the units, so they are present when initializing the board but absent when exporting json.