### PR TITLE
fix: Separate Content Repo Images (PT-184606497)

### DIFF
--- a/src/clue/app-config.json
+++ b/src/clue/app-config.json
@@ -233,7 +233,7 @@
     "stamps": [],
     "settings": {}
   },
-  "curriculumBaseUrl": "https://models-resources.concord.org/clue-curriculum/",
+  "curriculumBaseUrl": "https://models-resources.concord.org/clue-curriculum",
   "unitCodeMap": {
     "bio4community": "bio",
     "completely-rational": "cr",

--- a/src/models/image-map.test.ts
+++ b/src/models/image-map.test.ts
@@ -21,8 +21,8 @@ function unsafeUpdate(func: () => void) {
 }
 
 describe("ImageMap", () => {
-  const kCurriculumUnitBaseUrl = "https://example.com/clue-curriculum/branch/main/sas/";
-  const kCurriculumUnitUrl = `${kCurriculumUnitBaseUrl}config.json`;
+  const kCurriculumUnitBaseUrl = "https://example.com/clue-curriculum/branch/main/sas";
+  const kCurriculumUnitUrl = `${kCurriculumUnitBaseUrl}/config.json`;
   const kLocalImageUrl = "assets/logo_tw.png";
   const kHttpImageUrl = "http://icon.cat/img/icon_loop.png";
   const kHttpsImageUrl = "https://icon.cat/img/icon_loop.png";
@@ -102,7 +102,7 @@ describe("ImageMap", () => {
             });
     await localAssetsImagesHandler.store("curriculum/stretching-and-shrinking/images/image.png")
              .then(storeResult => {
-               expect(storeResult.displayUrl).toBe(`${kCurriculumUnitBaseUrl}images/image.png`);
+               expect(storeResult.displayUrl).toBe(`${kCurriculumUnitBaseUrl}/images/image.png`);
              });
   });
 

--- a/src/models/image-map.test.ts
+++ b/src/models/image-map.test.ts
@@ -21,7 +21,8 @@ function unsafeUpdate(func: () => void) {
 }
 
 describe("ImageMap", () => {
-  const kCurriculumBaseUrl = "https://example.com/clue-curriculum/";
+  const kCurriculumUnitBaseUrl = "https://example.com/clue-curriculum/branch/main/sas/";
+  const kCurriculumUnitUrl = `${kCurriculumUnitBaseUrl}config.json`;
   const kLocalImageUrl = "assets/logo_tw.png";
   const kHttpImageUrl = "http://icon.cat/img/icon_loop.png";
   const kHttpsImageUrl = "https://icon.cat/img/icon_loop.png";
@@ -50,7 +51,7 @@ describe("ImageMap", () => {
           Promise.resolve({ src: placeholderImage, width: 200, height: 150 }));
     if (sImageMap) { destroy(sImageMap); }
     sImageMap = ImageMapModel.create();
-    sImageMap.setCurriculumBaseUrl(kCurriculumBaseUrl);
+    sImageMap.setUnitUrl(kCurriculumUnitUrl);
     sImageMap.setUnitCodeMap({"stretching-and-shrinking": "sas"});
   });
           
@@ -97,11 +98,11 @@ describe("ImageMap", () => {
     await localAssetsImagesHandler.store(kLocalImageUrl)
             .then(storeResult => {
               expect(storeResult.contentUrl).toBe(kLocalImageUrl);
-              expect(storeResult.displayUrl).toBe(`${kCurriculumBaseUrl}branch/main/${kLocalImageUrl}`);
+              expect(storeResult.displayUrl).toBe(`${kLocalImageUrl}`);
             });
     await localAssetsImagesHandler.store("curriculum/stretching-and-shrinking/images/image.png")
              .then(storeResult => {
-               expect(storeResult.displayUrl).toBe(`${kCurriculumBaseUrl}branch/main/sas/images/image.png`);
+               expect(storeResult.displayUrl).toBe(`${kCurriculumUnitBaseUrl}images/image.png`);
              });
   });
 
@@ -395,7 +396,7 @@ describe("ImageMap", () => {
   
       const image = await firstGetImagePromise;
       expect(image.contentUrl).toBe(kLocalImageUrl);
-      expect(image.displayUrl).toBe(`${kCurriculumBaseUrl}branch/main/${kLocalImageUrl}`);
+      expect(image.displayUrl).toBe(`${kLocalImageUrl}`);
       expect(image.width).toBe(200);
       expect(image.height).toBe(150);
       expect(image.status).toBe(EntryStatus.Ready);
@@ -514,7 +515,7 @@ describe("ImageMap", () => {
       expect(returnedEntry).toEqual({
         status: EntryStatus.Ready,
         contentUrl: kLocalImageUrl,
-        displayUrl: `${kCurriculumBaseUrl}branch/main/${kLocalImageUrl}`,
+        displayUrl: `${kLocalImageUrl}`,
         height: 150,
         width: 200,
         retries: 1

--- a/src/models/image-map.ts
+++ b/src/models/image-map.ts
@@ -38,8 +38,6 @@ export interface IImageContext {
 }
 export interface IImageBaseOptions {
   filename?: string;
-  unitCodeMap?: Record<string, string>;
-  uniturl?: string;
 }
 export interface IImageHandlerStoreOptions extends IImageBaseOptions {
   db?: DB;
@@ -52,7 +50,6 @@ export interface IImageHandlerStoreResult {
 }
 interface IImageMap {
   unitCodeMap?: IMSTMap<ISimpleType<string>>;
-  unitUrl?: string;
   curriculumUrl?: string;
 }
 export interface IImageHandler {
@@ -469,7 +466,7 @@ export const localAssetsImagesHandler: IImageHandler = {
     // If curriculumUrl is defined and the image isn't in CLUE's own assets directory,
     // build an absolute URL for the displayUrl.
     const displayUrl = this.imageMap.curriculumUrl && !/^assets\//.test(_url)
-                         ? new URL(`../${_url}`, this.imageMap.unitUrl).href
+                         ? new URL(_url, this.imageMap.curriculumUrl).href
                          : getAssetUrl(_url);
     return { contentUrl: _url, displayUrl, success: true };
   },

--- a/src/models/stores/app-config-model.test.ts
+++ b/src/models/stores/app-config-model.test.ts
@@ -41,7 +41,7 @@ describe("ConfigurationManager", () => {
 
   it("can get URLs for remote curriculum content from a unit code", () => {
     const appConfig = AppConfigModel.create({
-      curriculumBaseUrl: "https://curriculum.example.com/",
+      curriculumBaseUrl: "https://curriculum.example.com",
       config: unitConfigDefaults
     });
     const exampleUnitCode = "example-unit-code";

--- a/src/models/stores/app-config-model.ts
+++ b/src/models/stores/app-config-model.ts
@@ -45,20 +45,11 @@ export const AppConfigModel = types
     getUnit(unitId: string) {
       const unitCode = self.unitCodeMap.get(unitId) || unitId;
       const unitCodeIsUrl = isValidHttpUrl(unitCode);
-      gImageMap.setCurriculumBaseUrl(self.curriculumBaseUrl);
+      const unitUrl = unitCodeIsUrl ? unitCode : `${self.curriculumBaseUrl}branch/main/${unitCode}/content.json`;
+      const teacherGuideUrl = unitUrl.replace(/content\.json$/, "teacher-guide/content.json");
+      gImageMap.setUnitUrl(unitUrl);
       gImageMap.setUnitCodeMap(getSnapshot(self.unitCodeMap));
-      if (unitCodeIsUrl) {
-        const teacherGuideUrl = unitCode.replace(/content\.json$/, "teacher-guide/content.json");
-        return {
-          "content": unitCode,
-          "guide": teacherGuideUrl
-        };
-      } else {
-        return {
-          "content": `${self.curriculumBaseUrl}branch/main/${unitCode}/content.json`,
-          "guide": `${self.curriculumBaseUrl}branch/main/${unitCode}/teacher-guide/content.json`
-        };
-      }
+      return {"content": unitUrl, "guide": teacherGuideUrl};
     }
   }))
   .views(self => ({

--- a/src/models/stores/app-config-model.ts
+++ b/src/models/stores/app-config-model.ts
@@ -45,7 +45,7 @@ export const AppConfigModel = types
     getUnit(unitId: string) {
       const unitCode = self.unitCodeMap.get(unitId) || unitId;
       const unitCodeIsUrl = isValidHttpUrl(unitCode);
-      const unitUrl = unitCodeIsUrl ? unitCode : `${self.curriculumBaseUrl}branch/main/${unitCode}/content.json`;
+      const unitUrl = unitCodeIsUrl ? unitCode : `${self.curriculumBaseUrl}/branch/main/${unitCode}/content.json`;
       const teacherGuideUrl = unitUrl.replace(/content\.json$/, "teacher-guide/content.json");
       gImageMap.setUnitUrl(unitUrl);
       gImageMap.setUnitCodeMap(getSnapshot(self.unitCodeMap));

--- a/src/utilities/asset-utils.ts
+++ b/src/utilities/asset-utils.ts
@@ -1,0 +1,9 @@
+declare const __webpack_public_path__: string;
+
+export function getAssetUrl(url: string) {
+  if (typeof __webpack_public_path__ === "undefined") {
+    return url;
+  }
+  const urlObj = new URL(url, __webpack_public_path__);
+  return urlObj.href;  
+}

--- a/src/utilities/url-utils.test.ts
+++ b/src/utilities/url-utils.test.ts
@@ -1,4 +1,4 @@
-import { isValidHttpUrl, getUnitCodeFromUrl, getCurriculumBranchFromUrl } from './url-utils';
+import { isValidHttpUrl, getUnitCodeFromUrl } from './url-utils';
 
 describe("isValidHttpUrl", () => {
   const validUrl = "https://concord.org";
@@ -18,10 +18,4 @@ describe("getUnitCodeFromUrl", () => {
   const urlWithUnitCode = "https://concord.org/curriculum/unitcode/content.json";
   const unitCode = getUnitCodeFromUrl(urlWithUnitCode);
   expect(unitCode).toBe("unitcode");
-});
-
-describe("getCurriculumBranchFromUrl", () => {
-  const urlWithBranch = "https://concord.org/curriculum/branch/branch-name/unitcode/content.json";
-  const branch = getCurriculumBranchFromUrl(urlWithBranch);
-  expect(branch).toBe("branch-name");
 });

--- a/src/utilities/url-utils.ts
+++ b/src/utilities/url-utils.ts
@@ -13,8 +13,3 @@ export const getUnitCodeFromUrl = (url: string) => {
   const unitCode = urlParts[urlParts.length-2];
   return unitCode;
 };
-
-export const getCurriculumBranchFromUrl = (url: string) => {
-  const urlPieces = url.match(/branch\/([^/]+)\/(.*)/);
-  return urlPieces?.[1];
-};


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/184606497

These changes fix an issue where image assets in CLUE's own assets folder were being incorrectly modifed. They also  add support for passing URLs from locations other than models-resources.concord.org/clue-curriculum via the `unit` URL param value. This will allow developers to have a local instance of CLUE consume data from a local instance of clue-curriculum.