### PR TITLE
183570161 Table Toolbar Configuration and Delete Button

### DIFF
--- a/cypress/e2e/clue/branch/student_tests/table_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/table_tool_spec.js
@@ -104,6 +104,13 @@ context('Table Tool Tile', function () {
         tableToolTile.getTableRow().should('have.length', 2);
       });
     });
+    it('delete button works', function () {
+      cy.get(".primary-workspace").within((workspace) => {
+        tableToolTile.getTableCell().eq(1).should('contain', '5');
+        tableToolTile.getTableToolbarButton('delete').click();
+        tableToolTile.getTableCell().eq(1).should('contain', '');
+      });
+    });
     it('will toggle index numbers', function () {
       tableToolTile.getIndexNumberToggle().click();
       cy.get(".primary-workspace").within(() => {

--- a/cypress/support/elements/clue/TableToolTile.js
+++ b/cypress/support/elements/clue/TableToolTile.js
@@ -65,7 +65,7 @@ class TableToolTile{
         cy.get('.modal-button').contains("Link Table").click();
       });
     }
-    getTableToolbarButton(button){// ['set-expression']
+    getTableToolbarButton(button){// ['set-expression', 'delete']
       return cy.get(`.table-toolbar .toolbar-button.${button}`);
     }
 }

--- a/src/components/tiles/table/table-tile.tsx
+++ b/src/components/tiles/table/table-tile.tsx
@@ -141,9 +141,10 @@ const TableToolComponent: React.FC<ITileProps> = observer(function TableToolComp
     setColumnEditingName: handleSetColumnEditingName, onShowExpressionsDialog: handleShowExpressionsDialog
   });
 
+  // deleteSelected is a function that clears the value of the currently selected cell
   // dataGridProps contains callbacks to pass to ReactDataGrid
   // hasLinkableRows is used to determine if the table can meaningfully be linked to a geometry tile
-  const { hasLinkableRows, ...dataGridProps } = useDataSet({
+  const { deleteSelected, hasLinkableRows, ...dataGridProps } = useDataSet({
     gridRef, model, dataSet, triggerColumnChange, rows, rowChanges, triggerRowChange,
     readOnly: !!readOnly, changeHandlers, columns, onColumnResize, selectedCell, inputRowId });
 
@@ -204,7 +205,7 @@ const TableToolComponent: React.FC<ITileProps> = observer(function TableToolComp
   return (
     <div className="table-tool">
       <TableToolbar documentContent={documentContent} tileElt={tileElt} {...toolbarProps}
-                    onSetExpression={showExpressionsDialog} scale={scale}/>
+                    deleteSelected={deleteSelected} onSetExpression={showExpressionsDialog} scale={scale}/>
       <div className="table-grid-container" ref={containerRef} onClick={handleBackgroundClick}>
         <EditableTableTitle
           content={content}

--- a/src/components/tiles/table/table-toolbar-buttons.tsx
+++ b/src/components/tiles/table/table-toolbar-buttons.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { Tooltip, TooltipProps } from "react-tippy";
+import DeleteSelectedIconSvg from "../../../assets/icons/delete/delete-selection-icon.svg";
+import SetExpressionIconSvg from "../../../clue/assets/icons/table/set-expression-icon.svg";
+import { useTooltipOptions } from "../../../hooks/use-tooltip-options";
+
+import "./table-toolbar.scss";
+
+interface ITableButtonProps {
+  icon: any;
+  onClick: () => void;
+  tooltipOptions: TooltipProps;
+}
+const TableButton = ({ icon, onClick, tooltipOptions}: ITableButtonProps) => {
+  const to = useTooltipOptions(tooltipOptions);
+  return (
+    <Tooltip {...to}>
+      <button className="toolbar-button set-expression" onClick={onClick}>
+        {icon}
+      </button>
+    </Tooltip>
+  );
+};
+interface IDeleteSelectedProps {
+  onClick: () => void;
+}
+export const DeleteSelectedButton = ({ onClick }: IDeleteSelectedProps) => (
+  <TableButton
+    icon={<DeleteSelectedIconSvg />}
+    onClick={onClick}
+    tooltipOptions={{ title: "Clear cell" }}
+  />
+);
+
+interface ISetExpressionButtonProps {
+  onClick: () => void;
+}
+export const SetExpressionButton = ({ onClick }: ISetExpressionButtonProps) => (
+  <TableButton
+    icon={<SetExpressionIconSvg />}
+    onClick={onClick}
+    tooltipOptions={{ title: "Set expression" }}
+  />
+);

--- a/src/components/tiles/table/table-toolbar-buttons.tsx
+++ b/src/components/tiles/table/table-toolbar-buttons.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { Tooltip, TooltipProps } from "react-tippy";
+import classNames from "classnames";
+
 import DeleteSelectedIconSvg from "../../../assets/icons/delete/delete-selection-icon.svg";
 import SetExpressionIconSvg from "../../../clue/assets/icons/table/set-expression-icon.svg";
 import { useTooltipOptions } from "../../../hooks/use-tooltip-options";
@@ -7,15 +9,17 @@ import { useTooltipOptions } from "../../../hooks/use-tooltip-options";
 import "./table-toolbar.scss";
 
 interface ITableButtonProps {
+  className?: string;
   icon: any;
   onClick: () => void;
   tooltipOptions: TooltipProps;
 }
-const TableButton = ({ icon, onClick, tooltipOptions}: ITableButtonProps) => {
+const TableButton = ({ className, icon, onClick, tooltipOptions}: ITableButtonProps) => {
   const to = useTooltipOptions(tooltipOptions);
+  const classes = classNames("toolbar-button", className);
   return (
     <Tooltip {...to}>
-      <button className="toolbar-button set-expression" onClick={onClick}>
+      <button className={classes} onClick={onClick}>
         {icon}
       </button>
     </Tooltip>
@@ -26,6 +30,7 @@ interface IDeleteSelectedProps {
 }
 export const DeleteSelectedButton = ({ onClick }: IDeleteSelectedProps) => (
   <TableButton
+    className="delete"
     icon={<DeleteSelectedIconSvg />}
     onClick={onClick}
     tooltipOptions={{ title: "Clear cell" }}
@@ -37,6 +42,7 @@ interface ISetExpressionButtonProps {
 }
 export const SetExpressionButton = ({ onClick }: ISetExpressionButtonProps) => (
   <TableButton
+    className="set-expression"
     icon={<SetExpressionIconSvg />}
     onClick={onClick}
     tooltipOptions={{ title: "Set expression" }}

--- a/src/components/tiles/table/table-toolbar.scss
+++ b/src/components/tiles/table/table-toolbar.scss
@@ -4,6 +4,7 @@
   position: absolute;
   border: $toolbar-border;
   border-radius: 0 0 $toolbar-border-radius $toolbar-border-radius;
+  display: flex;
   z-index: $toolbar-z-index;
 
   &.disabled {
@@ -12,8 +13,15 @@
 
   .toolbar-button {
     position: relative;
+    // These are button elements so we have to disable default button styles
+    // of border, padding, and display
+    border: 0;    
+    padding: 0;
+    display: block;
+    user-select: none;
     width: $toolbar-button-width;
     height: $toolbar-button-height;
+    cursor: pointer;
     background-color: $workspace-teal-light-9;
 
     &:hover {

--- a/src/components/tiles/table/table-toolbar.tsx
+++ b/src/components/tiles/table/table-toolbar.tsx
@@ -32,9 +32,9 @@ export const TableToolbar: React.FC<IProps> = observer(({
   const getToolbarButton = (toolName: string) => {
     switch (toolName) {
       case "set-expression":
-        return <SetExpressionButton onClick={onSetExpression} />;
+        return <SetExpressionButton key={toolName} onClick={onSetExpression} />;
       case "delete":
-        return <DeleteSelectedButton onClick={deleteSelected} />;
+        return <DeleteSelectedButton key={toolName} onClick={deleteSelected} />;
     }
   };
 

--- a/src/components/tiles/table/table-toolbar.tsx
+++ b/src/components/tiles/table/table-toolbar.tsx
@@ -1,35 +1,21 @@
 import { observer } from "mobx-react";
 import React from "react";
 import ReactDOM from "react-dom";
-import { Tooltip } from "react-tippy";
-import SetExpressionIconSvg from "../../../clue/assets/icons/table/set-expression-icon.svg";
+
+import { DeleteSelectedButton, SetExpressionButton } from "./table-toolbar-buttons";
 import { useSettingFromStores } from "../../../hooks/use-stores";
-import { useTooltipOptions } from "../../../hooks/use-tooltip-options";
 import { IFloatingToolbarProps, useFloatingToolbarLocation } from "../hooks/use-floating-toolbar-location";
 
 import "./table-toolbar.scss";
 
-interface ISetExpressionButtonProps {
-  onClick: () => void;
-}
-const SetExpressionButton: React.FC<ISetExpressionButtonProps> = ({ onClick }) => {
-  const tooltipOptions = useTooltipOptions({ title: "Set expression", distance: -34, offset: -19 });
-  return (
-    <Tooltip {...tooltipOptions}>
-      <div className="toolbar-button set-expression" onClick={onClick}>
-        <SetExpressionIconSvg />
-      </div>
-    </Tooltip>
-  );
-};
-
-const defaultButtons = ["set-expression"];
+const defaultButtons = ["set-expression", "delete"];
 
 interface IProps extends IFloatingToolbarProps {
+  deleteSelected: () => void;
   onSetExpression: () => void;
 }
 export const TableToolbar: React.FC<IProps> = observer(({
-  documentContent, onIsEnabled, onSetExpression, ...others
+  deleteSelected, documentContent, onIsEnabled, onSetExpression, ...others
 }) => {
   const enabled = onIsEnabled();
   const location = useFloatingToolbarLocation({
@@ -47,6 +33,8 @@ export const TableToolbar: React.FC<IProps> = observer(({
     switch (toolName) {
       case "set-expression":
         return <SetExpressionButton onClick={onSetExpression} />;
+      case "delete":
+        return <DeleteSelectedButton onClick={deleteSelected} />;
     }
   };
 

--- a/src/components/tiles/table/table-toolbar.tsx
+++ b/src/components/tiles/table/table-toolbar.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { Tooltip } from "react-tippy";
 import SetExpressionIconSvg from "../../../clue/assets/icons/table/set-expression-icon.svg";
+import { useSettingFromStores } from "../../../hooks/use-stores";
 import { useTooltipOptions } from "../../../hooks/use-tooltip-options";
 import { IFloatingToolbarProps, useFloatingToolbarLocation } from "../hooks/use-floating-toolbar-location";
 
@@ -22,6 +23,8 @@ const SetExpressionButton: React.FC<ISetExpressionButtonProps> = ({ onClick }) =
   );
 };
 
+const defaultButtons = ["set-expression"];
+
 interface IProps extends IFloatingToolbarProps {
   onSetExpression: () => void;
 }
@@ -36,11 +39,24 @@ export const TableToolbar: React.FC<IProps> = observer(({
                     enabled,
                     ...others
                   });
+
+  const buttonSettings = useSettingFromStores("tools", "table") as unknown as string[] | undefined;
+  const buttons = buttonSettings || defaultButtons;
+
+  const getToolbarButton = (toolName: string) => {
+    switch (toolName) {
+      case "set-expression":
+        return <SetExpressionButton onClick={onSetExpression} />;
+    }
+  };
+
   return documentContent
     ? ReactDOM.createPortal(
         <div className={`table-toolbar ${enabled && location ? "enabled" : "disabled"}`}
             style={location} onMouseDown={e => e.stopPropagation()}>
-          <SetExpressionButton onClick={onSetExpression} />
+          {buttons.map(button => {
+            return getToolbarButton(button);
+          })}
         </div>, documentContent)
     : null;
 });


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/183570161

This PR adds a new delete button to the table toolbar, which clears the contents of the currently selected cell. It also makes the table toolbar buttons configurable in curriculum json: `[unit].config.settings.table.tools = ["set-expression", "delete"]`, remove a button string from the array to remove the button from that unit.

Note on tests: I added a simple cypress test for the delete button, which works as expected. However, code coverage claims that many lines involved in this test are not being covered for some reason. So the code coverage percentage is misleadingly low. I didn't add tests for configuring the table toolbar.