### PR TITLE
refactor app initialization

### DIFF
--- a/docs/cms.md
+++ b/docs/cms.md
@@ -15,7 +15,7 @@ https://console.firebase.google.com/project/cms-github-auth/overview
 
 The code for this function is located here: https://github.com/Herohtar/netlify-cms-oauth-firebase
 
-It was configured using with the client ID and client secret from the GitHub OAuth app.
+It was configured with the client ID and client secret from the GitHub OAuth app.
 
 # Known Issues
 

--- a/docs/cms.md
+++ b/docs/cms.md
@@ -16,4 +16,17 @@ In its `componentDidMount` function, you can see it call `retrieveLocalBackup` a
 
 A possible fix would be to delay the call to `retrieveLocalBackup` until `loadEntry` has either completed successfully or it was not successful at finding an entry. This way it would not be possible for `loadEntry` to come in later and replace the entry.
 
+A useful way to confirm this behavior is to add console logs in ClueControl when the component is initialized and when when it is rendered and when it calls the CMS's onChange.
 
+# Wishlist
+
+## More flexible nested collection support
+We are using the [nested collection beta feature](https://decapcms.org/docs/beta-features/#nested-collections) of Decap. It allows authors to edit a nested set of folders containing the content. However it requires that each folder only contains a single file and the file has the same name. CLUE uses `content.json` for this filename. It would be better if a folder could contain multiple files with different names. There has been work in Decap towards this:
+- https://github.com/decaporg/decap-cms/issues/4972
+- https://github.com/decaporg/decap-cms/pull/6498
+
+## Mixed entry types in nested collections
+Our units have investigations, problems, and sections. We have broken apart the sections into separate files. It would be nice if we broke apart the other levels as well. That way information from these levels could be used by the CMS at least for naming and possibly ordering.
+
+## Ordering in nested collections
+The levels of hierarchy of a unit have an order defined by their parent object. It would be useful if the tree shown by the nested collection could be ordered based on this. This seems tricky since the nested collection is based just on the folder structure, and if we started putting multiple files in a single folder, it wouldn't be obvious which file in a parent folder is the parent of the current entry.

--- a/docs/cms.md
+++ b/docs/cms.md
@@ -1,4 +1,21 @@
-CLUE includes a CMS which can be accessed at `/admin.html`. It uses [Decap CMS](https://decapcms.org/). It is configured to edit the content in `clue-curriculum` repository. By default it edits the `author` branch. You can change the branch by passing a `curriculumBranch` parameter to admin.html.  By default it displays all of the units at the same time. It is better to work with a single unit at a time by using the `unit` param. This limits what is displayed in the CMS and it also configures the media library to show the images from that unit.
+CLUE includes a CMS which can be accessed at `/admin.html`. It uses [Decap CMS](https://decapcms.org/). It is configured to edit the content in `clue-curriculum` repository. It can be configured with the following URL params:
+- **`curriculumBranch`** By default the CMS edits the `author` branch. You can change the branch by passing a different branch name to this parameter. The CMS will not create this branch for you. You'll need to create it yourself.
+- **`unit`** By default the CMS displays all of the units at the same time. It is better to work with a single unit at a time by using the `unit` param. It should be passed the unit code. This limits what is displayed in the CMS and it also configures the media library to show the images from that unit.
+- **`localCMSBackend`** By default the CMS works with the `github` backend. This means even when doing local CLUE development the CMS will update the `clue-curriculum` repository directly. If you add the `localCMSBackend` parameter the CMS will attempt to work with a local git proxy running at localhost:8081. You can start this proxy with:
+
+  `cd ../clue-curriculum; npx netlify-cms-proxy-server`
+
+# Authorization
+The github backend used by the CMS requires a GitHub OAuth app and small service to handle getting a token from GitHub so the browser can talk directly to the GitHub API.
+
+The OAuth app is: [Concord Consortium CMS](https://github.com/organizations/concord-consortium/settings/applications/2137890)
+
+We are using a firebase function for the service. It is deployed to:
+https://console.firebase.google.com/project/cms-github-auth/overview
+
+The code for this function is located here: https://github.com/Herohtar/netlify-cms-oauth-firebase
+
+It was configured using with the client ID and client secret from the GitHub OAuth app.
 
 # Known Issues
 
@@ -16,7 +33,7 @@ In its `componentDidMount` function, you can see it call `retrieveLocalBackup` a
 
 A possible fix would be to delay the call to `retrieveLocalBackup` until `loadEntry` has either completed successfully or it was not successful at finding an entry. This way it would not be possible for `loadEntry` to come in later and replace the entry.
 
-A useful way to confirm this behavior is to add console logs in ClueControl when the component is initialized and when when it is rendered and when it calls the CMS's onChange.
+A useful way to confirm this behavior is to add console logs in ClueControl when the component is initialized and when when it is rendered and when it calls the CMS's onChange. It is also useful to look at the contents of the CMS's backup. That can be found in the browser Developer tools: `Application/IndexDB/localforage/keyvaluepairs`. In this database search for keys starting with `backup`.
 
 # Wishlist
 

--- a/docs/cms.md
+++ b/docs/cms.md
@@ -1,0 +1,19 @@
+CLUE includes a CMS which can be accessed at `/admin.html`. It uses [Decap CMS](https://decapcms.org/). It is configured to edit the content in `clue-curriculum` repository. By default it edits the `author` branch. You can change the branch by passing a `curriculumBranch` parameter to admin.html.  By default it displays all of the units at the same time. It is better to work with a single unit at a time by using the `unit` param. This limits what is displayed in the CMS and it also configures the media library to show the images from that unit.
+
+# Known Issues
+
+## Backup Draft
+The CMS has a feature for saving a draft of your work locally before you publish. If the page crashes or you reload the window without publishing, when you return the page the CMS will ask if you want to restore this draft. Unfortunately this doesn't work all of the time. If the entry you are looking at behind the dialog asking to restore the draft says it is "loading", then it typically won't work.
+
+As far as we can tell what happens is when the entry is loaded two async functions are started. One is loading the backup draft, the other is downloading the real entry from GitHub (or whatever backend you've configured). If the backup draft function completes first, the dialog will block the real entry loading from continue. If you say yes to restore the backup draft, it will be restored, but then the real entry loading will complete. When the real entry loading completes it replaces the backup draft with the real entry essentially blowing away your backup draft.
+
+If you are lucky and the real entry loads first, you will see this real entry behind the dialog asking about the backup draft. In this case if you choose to restore the backup draft it will stick.
+
+This issue describes basically the same problem: https://github.com/decaporg/decap-cms/issues/5055
+
+The place to look in the Decap code is the Editor component: `packages/netlify-cms-core/src/components/Editor/Editor.js`.
+In its `componentDidMount` function, you can see it call `retrieveLocalBackup` and then call `loadEntry`. Those are the 2 async functions. When the `retrieveLocalBackup` completes it will cause the Editors props to change which will trigger `componentDidUpdate`. In `componentDidUpdate` if the `localBackup` property is toggled on then the confirm dialog is shown. And if the user confirms then `loadLocalBackup` is called. This sets the `entryDraft.entry` to the backup contents. When `loadEntry` completes it also sets `entryDraft.entry` to the loaded entry.
+
+A possible fix would be to delay the call to `retrieveLocalBackup` until `loadEntry` has either completed successfully or it was not successful at finding an entry. This way it would not be possible for `loadEntry` to come in later and replace the entry.
+
+

--- a/src/cms/clue-control.tsx
+++ b/src/cms/clue-control.tsx
@@ -1,9 +1,10 @@
 import React from "react";
-import { QueryClient } from "react-query";
-
-import { EditorApp, IAppProperties, initializeApp } from "../initialize-app";
-import { editorModes } from "../components/doc-editor-app";
+import { IDisposer, onSnapshot } from "mobx-state-tree";
+import { appConfig, AppProvider, IAppProperties, initializeApp } from "../initialize-app";
 import { IStores } from "../models/stores/stores";
+import { createDocumentModel, DocumentModelType } from "../models/document/document";
+import { defaultDocumentModelParts } from "../components/doc-editor-app-defaults";
+import { EditableDocumentContent } from "../components/document/editable-document-content";
 
 import "./clue-control.scss";
 
@@ -21,38 +22,118 @@ interface IProps {
 }
 
 interface IState {
-  queryClient?: QueryClient;
   stores?: IStores;
+  document?: DocumentModelType;
 }
 
+const initializeAppPromise = initializeApp("dev");
+
 export class ClueControl extends React.Component<IProps, IState>  {
+  disposer: IDisposer;
+  // Notes on calls:
+  // - After publishing a CMS page, the component on the page is not
+  //   reconstructed. The existing component is reused. Because we are holding
+  //   onto our own value (the document) this works
+  // - When leaving (using the CMS ui) and coming back to the same page the
+  //   component is reconstructed.
+  // - When leaving (using the CMS ui) with unsaved changes, a message is shown,
+  //   and the control is reconstructed when returning to the page.
+  // - BUG: When leaving with unsaved changes by reloading the page in the
+  //   browser:
+  //   - a message is shown before reload confirming you want to lose your
+  //     changes
+  //   - a message is shown when the page is loaded again about an unsaved draft
+  //     Choosing the draft doesn't show the unsaved changes. My guess is that
+  //     the draft saving code might only work with string fields. This guess is
+  //     based on the behavior of onChange. Immediately after the ClueControl
+  //     calls onChange the ClueControl is re-rendered, but its value is JS
+  //     object not an immer object. Also looking at the CMS code there is
+  //     one place where the value is typed with typescript to be a string The
+  //     next place to look is at the CMS `Object` widget which must be saving a
+  //     js object instead of a string.
   constructor(props: IProps) {
     super(props);
+    console.log("ClueControl constructed", this.getValue());
     this.state = {};
 
-    initializeApp().then((appProperties: IAppProperties) => {
-      this.setState(appProperties);
+    // Based on functional component code it might be possible the
+    // value to start out falsy and then is set in a later render
+    // I haven't yet seen that in practice, so this approach is more
+    // simple for now.
+    const initialValue = this.getValue();
+
+    initializeAppPromise.then((appProperties: IAppProperties) => {
+
+      // Wait to construct the document until the main CLUE stuff is
+      // initialized. I'm not sure if this is necessary but it seems
+      // like the safest way to do things
+      const document = createDocumentModel({
+        ...defaultDocumentModelParts,
+        content: initialValue
+      });
+      this.setState({
+        stores: appProperties.stores,
+        document
+      });
+
+      // Update the widget's value whenever a change is made to the document's content
+      this.disposer = onSnapshot(document, snapshot => {
+        const json = document.content?.exportAsJson();
+        if (json) {
+          const parsedJson = JSON.parse(json);
+          const stringifiedJson = JSON.stringify(parsedJson);
+          // Only update when actual changes have been made.
+          // This approach has a few problems:
+          // - just loading the content and exporting it again often causes
+          //   changes to the content. So just opening a page will result in
+          //   the CMS saying there are "unsaved changes".
+          // - if the component is re-used without being re-initialized
+          //   this approach could be a problem, but I haven't seen that in practice.
+          // - if the user reverts the document to the initialValue that reversion
+          //   won't be sent to the CMS.
+          if (stringifiedJson !== JSON.stringify(initialValue)) {
+            console.log("ClueControl onChange", parsedJson);
+            this.props.onChange(parsedJson);
+          }
+        }
+      });
     });
   }
 
+  componentWillUnmount() {
+    this.disposer?.();
+  }
+
   render() {
-    if (this.state.stores && this.state.queryClient) {
-      const docEditorAppProps = {
-        contained: true,
-        editorMode: "cmsWidget" as editorModes,
-        initialValue: this.props.value.toJS?.(),
-        onChange: this.props.onChange
-      };
+    console.log("ClueControl rendered", this.getValue());
+
+    if (this.state.stores && this.state.document) {
       return (
-        <EditorApp
-          docEditorAppProps={docEditorAppProps}
-          queryClient={this.state.queryClient}
-          stores={this.state.stores}
-        />
+        <AppProvider stores={this.state.stores}>
+          <EditableDocumentContent
+            contained={true}
+            mode="1-up"
+            isPrimary={true}
+            readOnly={false}
+            document={this.state.document}
+            toolbar={appConfig.toolbar}
+          />
+        </AppProvider>
       );
     } else {
       return <div className="loading-box">Loading editor...</div>;
     }
   }
-}
 
+  // After onChange the value property is a plain JS object. When the component
+  // is first initialized and rendered the value is an immer object. This
+  // function handles both cases. It is currently only used for debugging since
+  // we don't use the value property after the constructor.
+  getValue() {
+    if (this.props.value?.toJS) {
+      return this.props.value.toJS();
+    } else {
+      return this.props.value;
+    }
+  }
+}

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -1,8 +1,5 @@
 import { inject, observer } from "mobx-react";
 import React from "react";
-import Modal from "react-modal";
-import { ModalProvider } from "react-modal-hook";
-import { QueryClient, QueryClientProvider } from "react-query";
 import { authenticate } from "../lib/auth";
 import { syncTeacherClassesAndOfferings } from "../lib/teacher-network";
 import { AppContentContainerComponent } from "./app-content";
@@ -145,10 +142,6 @@ export class AppComponent extends BaseComponent<IProps, IState> {
     authAndConnect(this.stores, (qaCleared, qaClearError) => {
       this.setState({qaCleared, qaClearError});
     });
-  }
-
-  public componentDidMount() {
-    Modal.setAppElement(".app");
   }
 
   public componentWillUnmount() {

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -130,8 +130,6 @@ export const authAndConnect = (stores: IStores, onQAClear?: (result: boolean, er
     });
 };
 
-const queryClient = new QueryClient();
-
 @inject("stores")
 @observer
 export class AppComponent extends BaseComponent<IProps, IState> {
@@ -156,6 +154,17 @@ export class AppComponent extends BaseComponent<IProps, IState> {
   public componentWillUnmount() {
     this.stores.db.disconnect();
   }
+
+  // TODO: it would be cleaner for render to
+  // just be:
+  // <div className="app">
+  //   {renderContents}
+  // </div>
+  //
+  // And then renderContents is basically the
+  // render method below but it just returns
+  // the results instead of calling renderApp each
+  // time.
 
   public render() {
     const {appConfig, user, ui, db, groups} = this.stores;
@@ -196,18 +205,10 @@ export class AppComponent extends BaseComponent<IProps, IState> {
   }
 
   private renderApp(children: JSX.Element | JSX.Element[]) {
-    // We use the ModalProvider from react-modal-hook to place modals at the top of
-    // the React component tree to minimize the potential that events propagating
-    // up the tree from modal dialogs will interact adversely with other content.
-    // cf. https://github.com/reactjs/react-modal/issues/699#issuecomment-496685847
     return (
-      <ModalProvider>
-        <QueryClientProvider client={queryClient}>
-          <div className="app">
-            {children}
-          </div>
-        </QueryClientProvider>
-      </ModalProvider>
+      <div className="app">
+        {children}
+      </div>
     );
   }
 

--- a/src/doc-editor.tsx
+++ b/src/doc-editor.tsx
@@ -8,7 +8,7 @@ import { appConfig, AppProvider, IAppProperties, initializeApp } from "./initial
 
 initializeApp("dev").then(({ stores }: IAppProperties) => {
   ReactDOM.render(
-    <AppProvider stores={stores}>
+    <AppProvider stores={stores} modalAppElement="#app">
       <DocEditorApp appConfig={appConfig}/>
     </AppProvider>,
     document.getElementById("app")

--- a/src/doc-editor.tsx
+++ b/src/doc-editor.tsx
@@ -1,20 +1,16 @@
 import React from "react";
 import ReactDOM from "react-dom";
+import { DocEditorApp } from "./components/doc-editor-app";
 
-import { EditorApp, IAppProperties, initializeApp } from "./initialize-app";
+import { appConfig, AppProvider, IAppProperties, initializeApp } from "./initialize-app";
 
 (window as any).DISABLE_FIREBASE_SYNC = true;
 
-initializeApp().then(({ queryClient, stores }: IAppProperties) => {
-  if (stores && queryClient) {
-    const docEditorAppProps = {};
-    ReactDOM.render(
-      <EditorApp
-        docEditorAppProps={docEditorAppProps}
-        queryClient={queryClient}
-        stores={stores}
-      />,
-      document.getElementById("app")
-    );
-  }
+initializeApp("dev").then(({ stores }: IAppProperties) => {
+  ReactDOM.render(
+    <AppProvider stores={stores}>
+      <DocEditorApp appConfig={appConfig}/>
+    </AppProvider>,
+    document.getElementById("app")
+  );
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,7 +6,6 @@ import { AppComponent } from "./components/app";
 import { getAppMode } from "./lib/auth";
 import { urlParams } from "./utilities/url-params";
 import { QAClear } from "./components/qa-clear";
-import { Logger } from "./lib/logger";
 import { setPageTitle } from "./lib/misc";
 
 const host = window.location.host.split(":")[0];
@@ -19,8 +18,6 @@ if (appMode === "qa" && urlParams.qaClear === "all") {
   );
 } else {
   initializeApp(appMode).then(({ stores }: IAppProperties) => {
-    Logger.initializeLogger(stores, { investigation: stores.investigation.title, problem: stores.problem.title });
-
     setPageTitle(stores);
     stores.ui.setShowDemoCreator(!!stores.showDemoCreator);
     stores.supports.createFromUnit({

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,7 +29,7 @@ if (appMode === "qa" && urlParams.qaClear === "all") {
     });
 
     ReactDOM.render(
-      <AppProvider stores={stores}>
+      <AppProvider stores={stores} modalAppElement="#app">
         <AppComponent />
       </AppProvider>,
       document.getElementById("app")

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,14 +3,39 @@ import ReactDOM from "react-dom";
 
 import { AppProvider, IAppProperties, initializeApp } from "./initialize-app";
 import { AppComponent } from "./components/app";
+import { getAppMode } from "./lib/auth";
+import { urlParams } from "./utilities/url-params";
+import { QAClear } from "./components/qa-clear";
+import { Logger } from "./lib/logger";
+import { setPageTitle } from "./lib/misc";
 
-initializeApp().then(({ stores }: IAppProperties) => {
-  if (stores) {
+const host = window.location.host.split(":")[0];
+const appMode = getAppMode(urlParams.appMode, urlParams.token, host);
+
+if (appMode === "qa" && urlParams.qaClear === "all") {
+  ReactDOM.render(
+    <QAClear />,
+    document.getElementById("app")
+  );
+} else {
+  initializeApp(appMode).then(({ stores }: IAppProperties) => {
+    Logger.initializeLogger(stores, { investigation: stores.investigation.title, problem: stores.problem.title });
+
+    setPageTitle(stores);
+    stores.ui.setShowDemoCreator(!!stores.showDemoCreator);
+    stores.supports.createFromUnit({
+      unit: stores.unit,
+      investigation: stores.investigation,
+      problem: stores.problem,
+      documents: stores.documents,
+      db: stores.db
+    });
+
     ReactDOM.render(
       <AppProvider stores={stores}>
         <AppComponent />
       </AppProvider>,
       document.getElementById("app")
     );
-  }
-});
+  });
+}

--- a/src/initialize-app.tsx
+++ b/src/initialize-app.tsx
@@ -18,6 +18,7 @@ import "./index.scss";
 import { AppMode } from "./models/stores/store-types";
 import { ModalProvider } from "@concord-consortium/react-modal-hook";
 import { QueryClient, QueryClientProvider } from "react-query";
+import { Logger } from "./lib/logger";
 
 // set to true to enable MST liveliness checking
 const kEnableLivelinessChecking = false;
@@ -68,6 +69,9 @@ export const initializeApp = async (appMode: AppMode) => {
     setLivelinessChecking("error");
   }
 
+  // The logger will only be enabled if the appMode is "authed", or DEBUG_LOGGER is true
+  Logger.initializeLogger(stores, { investigation: stores.investigation.title, problem: stores.problem.title });
+
   return { stores };
 };
 
@@ -80,7 +84,6 @@ interface IAppProviderProps {
 
 // FIXME: in some cases a warning is printed that the ModalProvider cannot find the
 // app in order to disable it and prevent input.
-// FIXME: perhaps related is that tiles cannot be deleted in the CMS
 export const AppProvider = ({ children, stores }: IAppProviderProps) => {
   // We use the ModalProvider from react-modal-hook to place modals at the top of
   // the React component tree to minimize the potential that events propagating

--- a/src/initialize-app.tsx
+++ b/src/initialize-app.tsx
@@ -1,9 +1,14 @@
 import "ts-polyfill";
 
-import React from "react";
+import React, { useEffect } from "react";
 import { Provider } from "mobx-react";
 import { setLivelinessChecking } from "mobx-state-tree";
+import Modal from "react-modal";
+import { ModalProvider } from "@concord-consortium/react-modal-hook";
+import { QueryClient, QueryClientProvider } from "react-query";
 
+import { AppMode } from "./models/stores/store-types";
+import { Logger } from "./lib/logger";
 import { appConfigSnapshot, appIcons, createStores } from "./app-config";
 import { AppConfigContext } from "./app-config-context";
 import { AppConfigModel } from "./models/stores/app-config-model";
@@ -15,10 +20,6 @@ import { gImageMap } from "./models/image-map";
 import PackageJson from "./../package.json";
 
 import "./index.scss";
-import { AppMode } from "./models/stores/store-types";
-import { ModalProvider } from "@concord-consortium/react-modal-hook";
-import { QueryClient, QueryClientProvider } from "react-query";
-import { Logger } from "./lib/logger";
 
 // set to true to enable MST liveliness checking
 const kEnableLivelinessChecking = false;
@@ -38,7 +39,7 @@ export interface IAppProperties {
  * - authoring (CMS clue-control.tsx)
  * - standalone doc editor (doc-editor.tsx)
  *
- * It is intended to only be run one time.
+ * It is intended to only be called one time.
  * It is basically an async wrapper around createStores
  *
  * @param appMode
@@ -80,11 +81,15 @@ const queryClient = new QueryClient();
 interface IAppProviderProps {
   children: any;
   stores: IStores;
+  modalAppElement: string;
 }
 
-// FIXME: in some cases a warning is printed that the ModalProvider cannot find the
-// app in order to disable it and prevent input.
-export const AppProvider = ({ children, stores }: IAppProviderProps) => {
+export const AppProvider = ({ children, stores, modalAppElement }: IAppProviderProps) => {
+  // react-modal needs to know the root element to hide it for accessibility when
+  // the modal is visible. The modalAppElement is a css selector for this root element.
+  // Typically this is the element that is passed to ReactDOM.render().
+  useEffect(() => Modal.setAppElement(modalAppElement), [modalAppElement]);
+
   // We use the ModalProvider from react-modal-hook to place modals at the top of
   // the React component tree to minimize the potential that events propagating
   // up the tree from modal dialogs will interact adversely with other content.


### PR DESCRIPTION
- move document handling into ClueControl
- keep DocEditorApp just for the doc editor entry point
- extract some parts of the initializeApp which are
only needed by the runtime (index.tsx)
- unify the ModalProvider and QueryClientProvider for all 3 entry points