### PR TITLE
184679541 Export and Import Table Column Widths

### DIFF
--- a/src/models/tiles/table/table-content.test.ts
+++ b/src/models/tiles/table/table-content.test.ts
@@ -61,6 +61,24 @@ describe("TableContent", () => {
     expect(table.dataSet.cases.length).toBe(0);
   });
 
+  const colWidth = 200;
+  const biggerColWidth = 500;
+  it("can import column widths using the new export format", () => {
+    const kTableTitle = "Table Title";
+    const importData: TableContentTableImport = {
+      type: "Table",
+      columnWidths: {
+        "col1": colWidth,
+        "col2": biggerColWidth
+      },
+      name: kTableTitle
+    };
+    const table = TableContentModel.create(importData);
+    expect(table.type).toBe(kTableTileType);
+    expect(table.columnWidth("col1")).toBe(colWidth);
+    expect(table.columnWidth("col2")).toBe(biggerColWidth);
+  });
+
   it("can import an authored table with data", () => {
     const kTableTitle = "Table Title";
     const importData: TableContentTableImport = {
@@ -83,8 +101,6 @@ describe("TableContent", () => {
   });
 
   it("can import an authored table with column widths", () => {
-    const colWidth = 200;
-    const biggerColWidth = 500;
     const importData: TableContentTableImport = {
       type: "Table",
       name: "Table Title",

--- a/src/models/tiles/table/table-export.ts
+++ b/src/models/tiles/table/table-export.ts
@@ -29,8 +29,14 @@ export const exportTableContentAsJson = (
 
   const builder = new StringBuilder();
   builder.pushLine("{");
-  const typeComma = dataSet.name ? "," : "";
-  builder.pushLine(`"type": "Table"${typeComma}`, 2);
+  builder.pushLine(`"type": "Table",`, 2);
+  builder.pushLine(`"columnWidths": {`, 2);
+  dataSet.attributes.map((attr, attrIndex, attrs) => {
+    const widthComma = attrIndex < attrs.length - 1 ? "," : "";
+    builder.pushLine(`"${attr.id}": ${columnWidth(attr.id)}${widthComma}`, 4);
+  });
+  const nameComma = dataSet.name ? "," : "";
+  builder.pushLine(`}${nameComma}`, 2);
   dataSet.name && builder.pushLine(`"name": "${dataSet.name}"`, 2);
   builder.pushLine("}");
   return builder.build();


### PR DESCRIPTION
PT story: https://www.pivotaltracker.com/story/show/184679541

Previously, column width information was included with other column information when exporting/importing tables. A recent change moved the column information out of the tile json, and into shared model json. However, the column widths are a property of the table, not the shared model, so this information was lost in the transition. This PR addresses that issue by reintroducing the column widths into exported tables.