### PR TITLE
feat: Author/upload images (PT-184755020)

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -14,9 +14,6 @@ export default defineConfig({
   },
   env: {
     coverage: false,
-    browserPermissions: {
-      "clipboard": "allow",
-    },
   },
   queryParams:
     '?appMode=qa&fakeClass=5&fakeUser=student:5&demoOffering=5&problem=2.1&qaGroup=5',

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -14,6 +14,9 @@ export default defineConfig({
   },
   env: {
     coverage: false,
+    browserPermissions: {
+      "clipboard": "allow",
+    },
   },
   queryParams:
     '?appMode=qa&fakeClass=5&fakeUser=student:5&demoOffering=5&problem=2.1&qaGroup=5',

--- a/cypress/e2e/clue/branch/student_tests/canvas_test_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/canvas_test_spec.js
@@ -307,29 +307,28 @@ context('Test Canvas', function () {
     });
   });
 
-  // FIXME: This test broke
-  // context('delete elements from canvas', function () {
-  //   before(() => {
-  //     //star a document to verify delete
-  //     cy.openSection("my-work", "workspaces");
-  //     cy.get('.list.workspaces [data-test=workspaces-list-items] .footer').contains(renameTitlePencil).parents().siblings('.icon-holder').find('.icon-star').click();
-  //     cy.openDocumentWithTitle('my-work', 'workspaces', 'SAS 2.1 Drawing Wumps');
-  //   });
-  //   it('will delete elements from canvas', function () {
-  //     // //Delete elements in the canvas
-  //     clueCanvas.deleteTile('graph');
-  //     clueCanvas.deleteTile('image');
-  //     clueCanvas.deleteTile('draw');
-  //     clueCanvas.deleteTile('table');
-  //     clueCanvas.deleteTile('text');
-  //     clueCanvas.deleteTile('text');
-  //     textToolTile.getTextTile().should('not.exist');
-  //     graphToolTile.getGraphTile().should('not.exist');
-  //     drawToolTile.getDrawTile().should('not.exist');
-  //     imageToolTile.getImageTile().should('not.exist');
-  //     tableToolTile.getTableTile().should('not.exist');
-  //   });
-  // });
+  context('delete elements from canvas', function () {
+    before(() => {
+      //star a document to verify delete
+      cy.openSection("my-work", "workspaces");
+      cy.get('.list.workspaces [data-test=workspaces-list-items] .footer').contains(renameTitlePencil).parents().siblings('.icon-holder').find('.icon-star').click();
+      cy.openDocumentWithTitle('my-work', 'workspaces', 'SAS 2.1 Drawing Wumps');
+    });
+    it('will delete elements from canvas', function () {
+      // //Delete elements in the canvas
+      clueCanvas.deleteTile('graph');
+      clueCanvas.deleteTile('image');
+      clueCanvas.deleteTile('draw');
+      clueCanvas.deleteTile('table');
+      clueCanvas.deleteTile('text');
+      clueCanvas.deleteTile('text');
+      textToolTile.getTextTile().should('not.exist');
+      graphToolTile.getGraphTile().should('not.exist');
+      drawToolTile.getDrawTile().should('not.exist');
+      imageToolTile.getImageTile().should('not.exist');
+      tableToolTile.getTableTile().should('not.exist');
+    });
+  });
 
   context('Dragging elements from different locations to canvas', function () {
     describe('Drag element from left nav', function () {

--- a/cypress/e2e/clue/branch/student_tests/drawing_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/drawing_tool_spec.js
@@ -350,6 +350,19 @@ context('Draw Tool Tile', function () {
         // Uploading images doesn't seem to be working at the moment.
         // drawToolTile.getImageDrawing().should("exist").and("have.length", 1);
       });
+      it('will accept a valid image URL pasted from the clipboard', function(){
+        // For the drawing tool, this path needs to correspond to an actual file in the curriculum repository.
+        const imageFilePath = "curriculum/sas/images/survey.png";
+        cy.window().then((win) => {
+            win.navigator.clipboard.write([new win.ClipboardItem({
+                "text/plain": new Blob([imageFilePath], { type: "text/plain" }),
+            })]);
+        });
+        const isMac = navigator.platform.indexOf("Mac") === 0;
+        const cmdKey = isMac ? "meta" : "ctrl";
+        drawToolTile.getDrawTileComponent().last().type(`{${cmdKey}+v}`);
+        drawToolTile.getImageDrawing().last().should("exist").invoke("attr", "href").should("contain", "sas/images/survey.png");
+    });
     });
   });
 });

--- a/cypress/e2e/clue/branch/student_tests/drawing_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/drawing_tool_spec.js
@@ -350,19 +350,31 @@ context('Draw Tool Tile', function () {
         // Uploading images doesn't seem to be working at the moment.
         // drawToolTile.getImageDrawing().should("exist").and("have.length", 1);
       });
-      it('will accept a valid image URL pasted from the clipboard', function(){
+      // TODO: Figure out how to get the clipboard paste check below to work when the tests 
+      // are run using Chrome. It will pass when using Electron, but not Chrome. In Chrome 
+      // the attempt to write to the clipboard results in an error: "Must be handling a user 
+      // gesture to use custom clipboard." See https://github.com/cypress-io/cypress/issues/2752
+      // for more background. Apparently, the basic problem is that Cypress "currently uses 
+      // programmatic browser APIs which Chrome doesn't consider as genuine user interaction."
+      it.skip('will accept a valid image URL pasted from the clipboard', function(){
         // For the drawing tool, this path needs to correspond to an actual file in the curriculum repository.
         const imageFilePath = "curriculum/sas/images/survey.png";
-        cy.window().then((win) => {
-            win.navigator.clipboard.write([new win.ClipboardItem({
-                "text/plain": new Blob([imageFilePath], { type: "text/plain" }),
-            })]);
-        });
+        Cypress.automation("remote:debugger:protocol", {
+          command: "Browser.grantPermissions",
+          params: {
+            permissions: ["clipboardReadWrite", "clipboardSanitizedWrite"],
+            origin: window.location.origin,
+          },
+        }).then(cy.window().then((win) => {
+          win.navigator.clipboard.write([new win.ClipboardItem({
+              "text/plain": new Blob([imageFilePath], { type: "text/plain" }),
+          })]);
+        }));
         const isMac = navigator.platform.indexOf("Mac") === 0;
         const cmdKey = isMac ? "meta" : "ctrl";
         drawToolTile.getDrawTileComponent().last().type(`{${cmdKey}+v}`);
         drawToolTile.getImageDrawing().last().should("exist").invoke("attr", "href").should("contain", "sas/images/survey.png");
-    });
+      });
     });
   });
 });

--- a/cypress/e2e/clue/branch/student_tests/graph_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/graph_tool_spec.js
@@ -16,297 +16,307 @@ const problemDoc = '2.1 Drawing Wumps';
 const ptsDoc = 'Points';
 const polyDoc = 'Polygon';
 
-        describe('adding points and polygons to a graph', function(){
-            it('dummy test', function () {
-                expect(true).to.equal(true);
-            });
-        });
-        // FIXME: These tests seem to be failing because
-        // text tile deletion isn't working.
-            // it('will add a point to the origin', function(){
-            //     clueCanvas.addTile('geometry');
-            //     graphToolTile.addPointToGraph(0,0);
-            //     graphToolTile.getGraphPointCoordinates().should('contain', '(0, 0)');
-            // });
-            // it('will add points to a graph', function(){
-            //     canvas.createNewExtraDocumentFromFileMenu(ptsDoc, "my-work");
-            //     clueCanvas.addTile('geometry');
-            //     cy.get('.spacer').click();
-            //     clueCanvas.deleteTile('text');
-            //     graphToolTile.getGraphTile().last().click();
-            //     graphToolTile.addPointToGraph(5,5);
-            //     graphToolTile.addPointToGraph(10,5);
-            //     graphToolTile.addPointToGraph(10,10);
-            // });
-            // it('will add a polygon to a graph', function(){
-            //     canvas.createNewExtraDocumentFromFileMenu(polyDoc, "my-work");
-            //     clueCanvas.addTile('geometry');
-            //     cy.get('.spacer').click();
-            //     clueCanvas.deleteTile('text');
-            //     graphToolTile.getGraphTile().last().click();
-            //     graphToolTile.addPointToGraph(4.2,2);
-            //     graphToolTile.addPointToGraph(10.4, 7.2);
-            //     graphToolTile.addPointToGraph(13.2,2);
-            //     graphToolTile.addPointToGraph(13.2,2);
-            //     graphToolTile.getGraphPoint().last().click({force:true}).click({force:true});
-            //     graphToolTile.getGraphPolygon().should('exist');
-            // });
-
-        // describe('restore points to canvas', function(){
-        //     it('will verify restore of point at origin', function(){
-        //         primaryWorkspace.openResourceTab();
-        //         resourcePanel.openPrimaryWorkspaceTab("my-work");
-        //         cy.openDocumentWithTitle('my-work','workspaces', problemDoc);
-        //         graphToolTile.getGraphPointCoordinates().should('contain', '(0, 0)');
-        //     });
-        //     it('will verify restore of multiple points', function(){
-        //         cy.openDocumentWithTitle('my-work','workspaces', ptsDoc);
-        //         graphToolTile.getGraphPoint().should('have.length',3);
-        //     });
-        //     it('will verify restore of polygon', function(){
-        //         cy.openDocumentWithTitle('my-work','workspaces', polyDoc);
-        //         graphToolTile.getGraphPolygon().should('exist');
-        //     });
-        // });
-
-        // context('Graph Toolbar', function(){
-        //     describe('interact with points and polygons', function(){
-        //         it('will select a point', function(){
-        //             let point=4;
-        //             cy.openDocumentWithTitle('my-work','workspaces', ptsDoc);
-        //             resourcePanel.closePrimaryWorkspaceTabs();
-        //             graphToolTile.getGraphTile().click({multiple: true});
-        //             graphToolTile.selectGraphPoint(10,10);
-        //             graphToolTile.getGraphPointID(point)
-        //                 .then((id)=>{
-        //                     id='#'.concat(id);
-        //                     cy.get(id).then(($el)=>{
-        //                         // expect($el).to.have.text('(13.20, 5)');
-        //                         expect($el).to.have.text('');
-        //                     });
-        //                 });
-        //             // graphToolTile.getGraphPointCoordinates().should('contain', '(13.20, 5)');
-        //             graphToolTile.getGraphPointCoordinates().should('contain', '(10, 10)');
-        //         });
-        //         it.skip('will drag a point to a new location', function(){
-        //             const dataTransfer = new DataTransfer;
-        //             const graphUnit = 18.33;
-        //             let x= 15, y=2;
-        //             let transX=(graphToolTile.transformFromCoordinate('x', x))+(8*graphUnit),
-        //                 transY=(graphToolTile.transformFromCoordinate('y', y))+(5*graphUnit);
-
-        //             graphToolTile.getGraphPoint().last()
-        //                 .trigger('mousedown',{dataTransfer, force:true})
-        //                 .trigger('mousemove',{clientX:transX, clientY:transY, dataTransfer, force:true})
-        //                 .trigger('mouseup',{dataTransfer, force:true});
-        //             // graphToolTile.getGraphPointCoordinates().should('contain', '('+x+', '+y+')');
-        //             graphToolTile.getGraphPointCoordinates().should('contain', '(18, 2)');
-        //         });
-        //         it('will duplicate a point', function(){ //cannot send keyboard commands to non-text fields
-
-        //         });
-        //         it('will show and hide angles to a polygon', function(){
-        //             let numAngles=1;
-        //             primaryWorkspace.openResourceTab();
-        //             resourcePanel.openPrimaryWorkspaceTab("my-work");
-        //             // primaryWorkspace.openPrimaryWorkspaceTab("my-work");
-        //             cy.openDocumentWithTitle('my-work','workspaces', polyDoc);
-        //             resourcePanel.closePrimaryWorkspaceTabs();
-        //             graphToolTile.selectGraphPoint(4.2,2);
-        //             graphToolTile.selectGraphPoint(4.2,2);
-        //             graphToolTile.showAngle();
-        //             graphToolTile.getAngleAdornment().should('exist').and('have.length',numAngles);
-        //             graphToolTile.selectGraphPoint(10.4, 7.2);
-        //             graphToolTile.showAngle();
-        //             graphToolTile.getAngleAdornment().should('exist').and('have.length',numAngles+1);
-        //             graphToolTile.selectGraphPoint(13.2,2);
-        //             graphToolTile.showAngle();
-        //             graphToolTile.getAngleAdornment().should('exist').and('have.length',numAngles+2);
-        //             graphToolTile.selectGraphPoint(13.2,2);
-        //             graphToolTile.hideAngle();
-        //             graphToolTile.getAngleAdornment().should('exist').and('have.length',numAngles+1);
-        //             graphToolTile.selectGraphPoint(10.4, 7.2);
-        //             graphToolTile.hideAngle();
-        //             graphToolTile.getAngleAdornment().should('exist').and('have.length',numAngles);
-        //             graphToolTile.selectGraphPoint(4.2,2);
-        //             graphToolTile.hideAngle();
-        //             graphToolTile.getAngleAdornment().should('not.exist');
-
-        //             //Add the angles angle for the restore test later
-        //             graphToolTile.selectGraphPoint(13.2,2);
-        //             graphToolTile.showAngle();
-        //             graphToolTile.selectGraphPoint(10.4, 7.2);
-        //             graphToolTile.showAngle();
-        //             graphToolTile.selectGraphPoint(4.2,2);
-        //             graphToolTile.showAngle();
-        //             graphToolTile.selectGraphPoint(4.2,2);
-
-        //         });
-        //         it.skip('will drag a polygon to a new location', function(){
-        //             const dataTransfer = new DataTransfer;
-        //             const graphUnit = 18.33;
-        //             let x= 18, y=5;
-
-        //             let transX=(graphToolTile.transformFromCoordinate('x', x))+(8*graphUnit),
-        //                 transY=(graphToolTile.transformFromCoordinate('y', y))+(5*graphUnit);
-        //             graphToolTile.getGraphPolygon().click({force:true});
-        //             graphToolTile.getGraphPoint().last()
-        //                 .trigger('mousedown',{dataTransfer, force:true})
-        //                 .trigger('mousemove',{clientX:transX, clientY:transY, dataTransfer, force:true})
-        //                 .trigger('mouseup',{dataTransfer, force:true});
-        //             graphToolTile.getGraphPointCoordinates(0).should('contain', '(12, 5)');
-        //             graphToolTile.getGraphPointCoordinates(1).should('contain', '(18, 11)');
-        //             graphToolTile.getGraphPointCoordinates(2).should('contain', '(21, 5)');
-        //         });
-        //         it('verify rotate tool is visible when polygon is selected', function(){
-        //             graphToolTile.getGraphPolygon().click({force:true});
-        //             graphToolTile.getRotateTool().should('be.visible');
-        //         });
-        //         it('will rotate a polygon', function(){
-        //             //not sure how to verify the rotation
-        //             graphToolTile.getRotateTool()
-        //                 .trigger('mousedown')
-        //                 .trigger('dragstart')
-        //                 .trigger('mousemove',18, 73, {force:true})
-        //                 .trigger('dragend')
-        //                 .trigger('drop')
-        //                 .trigger('mouseup');
-        //             //TODO verify points are in new location
-        //         });
-        //         it('will duplicate a polygon', function(){
-        //             graphToolTile.getGraphPolygon().click({force: true});
-        //             graphToolTile.copyGraphElement();
-        //             graphToolTile.getGraphPolygon().should('have.length',2);
-        //             graphToolTile.getAngleAdornment().should('have.length',6);
-        //             graphToolTile.getGraphPoint().should('have.length',6);
-        //         });
-        //         it('will restore changes to a graph', function(){
-        //             primaryWorkspace.openResourceTab();
-        //             resourcePanel.openPrimaryWorkspaceTab("my-work");
-        //             cy.openDocumentWithTitle('my-work','workspaces', polyDoc);
-        //             graphToolTile.getAngleAdornment().should('exist').and('have.length',6);
-        //         });
-        //     });
-
-        //     describe('delete points and polygons', function(){
-        //         it.skip('verify delete points with delete tool', function(){ //current behavior of text deletes the entire graph tool tile. Point selection has to be forced
-        //             let basePointCount = 3; // number of points already in doc2
-        //             cy.openDocumentWithTitle('my-work','workspaces', ptsDoc);
-        //             primaryWorkspace.getResizePanelDivider().click();
-        //             primaryWorkspace.getResizeLeftPanelHandle().click();
-        //             graphToolTile.selectGraphPoint(15,2);
-        //             graphToolTile.deleteGraphElement();
-        //             graphToolTile.getGraphPoint().should('have.length', basePointCount -1);
-        //             graphToolTile.selectGraphPoint(10,5);
-        //             graphToolTile.deleteGraphElement();
-        //             graphToolTile.getGraphPoint().should('have.length', basePointCount -2);
-        //             graphToolTile.selectGraphPoint(5,5);
-        //             // graphToolTile.deleteGraphElement();
-        //             // graphToolTile.getGraphPoint().should('have.length', basePointCount-3)
-        //         });
-        //         it.skip('verify delete polygon',()=>{
-        //             primaryWorkspace.getResizePanelDivider().click();
-        //             primaryWorkspace.getResizeRightPanelHandle().click();
-        //             cy.openDocumentWithTitle('my-work','workspaces', polyDoc);
-        //             graphToolTile.getGraphPolygon().last().click({force:true});
-        //             graphToolTile.deleteGraphElement();
-        //             graphToolTile.getGraphPolygon().should('have.length',1);
-        //         });
-        //         it.skip('verify delete points alters polygon',()=>{
-        //             let basePointCount = 3, baseAngleCount=3; // number of points already in doc
-
-        //             graphToolTile.getGraphPoint().should('have.length', basePointCount);
-        //             graphToolTile.selectGraphPoint(16, 3.5);
-        //             graphToolTile.getAngleAdornment().should('have.length',baseAngleCount);
-        //             graphToolTile.deleteGraphElement();
-        //             graphToolTile.getGraphPoint().should('have.length', basePointCount-1);
-        //             // graphToolTile.selectGraphPoint(16.2, 9.5);
-        //             graphToolTile.getGraphPoint().last().click({force: true});
-        //             graphToolTile.deleteGraphElement();
-        //             graphToolTile.getGraphPoint().should('have.length', basePointCount -2);
-        //             graphToolTile.selectGraphPoint(8, 8);
-        //             graphToolTile.deleteGraphElement();
-        //             graphToolTile.getGraphPoint().should('have.length', basePointCount-3);
-        //         });
-        //     });
-
-            // describe.skip('movable line tests',()=>{
-            //     // it('verify add a movable line', function(){
-            //     //     canvas.createNewExtraDocumentFromFileMenu(lineDoc, "my-work");
-            //     //     clueCanvas.addTile('geometry');
-            //     //     graphToolTile.addMovableLine();
-
-            //     // });
-            //     // it.skip('verify move the movable line', function () {
-
-            //     // });
-            //     // it.skip('verify rotate the movable line', function () {
-
-            //     // });
-            //     // it.skip('verify movable line equation edit', function () {
-
-            //     // });
-            // });
-
-
-context('Test undo redo functionalities', function(){
+context('Graph Tool', function() {
     before(function(){
         const queryParams = `${Cypress.config("queryParams")}`;
         cy.clearQAData('all');
+    
         cy.visit(queryParams);
         cy.waitForLoad();
         cy.closeResourceTabs();
     });
+    
+    context('Test graph tool functionalities', function(){
+        describe('adding points and polygons to a graph', function(){
 
-    describe('Graph tile undo redo',()=>{
-        it('will undo redo graph tile creation/deletion', function () {
-            // Creation - Undo/Redo
-            clueCanvas.addTile('geometry');
-            graphToolTile.getGraph().should("exist");
-            textToolTile.getTextTile().should("exist");
-            clueCanvas.getUndoTool().should("not.have.class", "disabled");
-            clueCanvas.getRedoTool().should("have.class", "disabled");
-            clueCanvas.getUndoTool().click();
-            graphToolTile.getGraph().should("not.exist");
-            textToolTile.getTextTile().should("not.exist");
-            clueCanvas.getUndoTool().should("have.class", "disabled");
-            clueCanvas.getRedoTool().should("not.have.class", "disabled");
-            clueCanvas.getRedoTool().click();
-            graphToolTile.getGraph().should("exist");
-            textToolTile.getTextTile().should("exist");
-            clueCanvas.getUndoTool().should("not.have.class", "disabled");
-            clueCanvas.getRedoTool().should("have.class", "disabled");
-      
-            // Deletion - Undo/Redo
-            clueCanvas.deleteTile('geometry');
-            graphToolTile.getGraph().should("not.exist");
-            textToolTile.getTextTile().should("exist");
-            clueCanvas.getUndoTool().click();
-            graphToolTile.getGraph().should("exist");
-            textToolTile.getTextTile().should("exist");
-            clueCanvas.getRedoTool().click();
-            graphToolTile.getGraph().should("not.exist");
-            textToolTile.getTextTile().should("exist");
-            clueCanvas.getUndoTool().click();
-        });
-        it("edit tile title", () => {
-            const newName = "Graph Tile";
-            graphToolTile.getGraphTitle().first().should("contain", "Graph 1");
-            graphToolTile.getGraphTileTitle().first().click();
-            graphToolTile.getGraphTileTitle().first().type(newName + '{enter}');
-            graphToolTile.getGraphTitle().should("contain", newName);
-        });
-        it("undo redo actions", () => {
-            clueCanvas.getUndoTool().click();
-            graphToolTile.getGraphTitle().first().should("contain", "Graph 1");
-            clueCanvas.getRedoTool().click();
-            graphToolTile.getGraphTitle().should("contain", "Graph Tile");
-        });
-        it('verify delete graph', function () {
-            clueCanvas.deleteTile('geometry');
-            graphToolTile.getGraph().should("not.exist");
-            textToolTile.getTextTile().should("exist");
+            it('will add a point to the origin', function(){
+                clueCanvas.addTile('geometry');
+                graphToolTile.addPointToGraph(0,0);
+                graphToolTile.getGraphPointCoordinates().should('contain', '(0, 0)');
+            });
+            it('will add points to a graph', function(){
+                canvas.createNewExtraDocumentFromFileMenu(ptsDoc, "my-work");
+                clueCanvas.addTile('geometry');
+                cy.get('.spacer').click();
+                clueCanvas.deleteTile('text');
+                graphToolTile.getGraphTile().last().click();
+                graphToolTile.addPointToGraph(5,5);
+                graphToolTile.addPointToGraph(10,5);
+                graphToolTile.addPointToGraph(10,10);
+            });
+            it('will add a polygon to a graph', function(){
+                canvas.createNewExtraDocumentFromFileMenu(polyDoc, "my-work");
+                clueCanvas.addTile('geometry');
+                cy.get('.spacer').click();
+                clueCanvas.deleteTile('text');
+                graphToolTile.getGraphTile().last().click();
+                graphToolTile.addPointToGraph(4.2,2);
+                graphToolTile.addPointToGraph(10.4, 7.2);
+                graphToolTile.addPointToGraph(13.2,2);
+                graphToolTile.addPointToGraph(13.2,2);
+                graphToolTile.getGraphPoint().last().click({force:true}).click({force:true});
+                graphToolTile.getGraphPolygon().should('exist');
+            });
+
+            describe('restore points to canvas', function(){
+                it('will verify restore of point at origin', function(){
+                    primaryWorkspace.openResourceTab();
+                    resourcePanel.openPrimaryWorkspaceTab("my-work");
+                    cy.openDocumentWithTitle('my-work','workspaces', problemDoc);
+                    graphToolTile.getGraphPointCoordinates().should('contain', '(0, 0)');
+                });
+                it('will verify restore of multiple points', function(){
+                    cy.openDocumentWithTitle('my-work','workspaces', ptsDoc);
+                    graphToolTile.getGraphPoint().should('have.length',3);
+                });
+                it('will verify restore of polygon', function(){
+                    cy.openDocumentWithTitle('my-work','workspaces', polyDoc);
+                    graphToolTile.getGraphPolygon().should('exist');
+                });
+            });
+
+            context('Graph Toolbar', function(){
+                describe('interact with points and polygons', function(){
+                    it('will select a point', function(){
+                        let point=4;
+                        cy.openDocumentWithTitle('my-work','workspaces', ptsDoc);
+                        resourcePanel.closePrimaryWorkspaceTabs();
+                        graphToolTile.getGraphTile().click({multiple: true});
+                        graphToolTile.selectGraphPoint(10,10);
+                        graphToolTile.getGraphPointID(point)
+                            .then((id)=>{
+                                id='#'.concat(id);
+                                cy.get(id).then(($el)=>{
+                                    // expect($el).to.have.text('(13.20, 5)');
+                                    expect($el).to.have.text('');
+                                });
+                            });
+                        // graphToolTile.getGraphPointCoordinates().should('contain', '(13.20, 5)');
+                        graphToolTile.getGraphPointCoordinates().should('contain', '(10, 10)');
+                    });
+                    it.skip('will drag a point to a new location', function(){
+                        const dataTransfer = new DataTransfer;
+                        const graphUnit = 18.33;
+                        let x = 15, y = 2;
+                        let transX=(graphToolTile.transformFromCoordinate('x', x))+(8*graphUnit),
+                            transY=(graphToolTile.transformFromCoordinate('y', y))+(5*graphUnit);
+
+                        graphToolTile.getGraphPoint().last()
+                            .trigger('mousedown',{dataTransfer, force:true})
+                            .trigger('mousemove',{clientX:transX, clientY:transY, dataTransfer, force:true})
+                            .trigger('mouseup',{dataTransfer, force:true});
+                        // graphToolTile.getGraphPointCoordinates().should('contain', '('+x+', '+y+')');
+                        graphToolTile.getGraphPointCoordinates().should('contain', '(18, 2)');
+                    });
+                    it('will duplicate a point', function(){ //cannot send keyboard commands to non-text fields
+
+                    });
+                    it.skip('will show and hide angles to a polygon', function(){
+                        let numAngles=1;
+                        primaryWorkspace.openResourceTab();
+                        resourcePanel.openPrimaryWorkspaceTab("my-work");
+                        // primaryWorkspace.openPrimaryWorkspaceTab("my-work");
+                        cy.openDocumentWithTitle('my-work','workspaces', polyDoc);
+                        resourcePanel.closePrimaryWorkspaceTabs();
+                        graphToolTile.selectGraphPoint(4.2,2);
+                        graphToolTile.selectGraphPoint(4.2,2);
+                        graphToolTile.showAngle();
+                        graphToolTile.getAngleAdornment().should('exist').and('have.length',numAngles);
+                        graphToolTile.selectGraphPoint(10.4, 7.2);
+                        graphToolTile.showAngle();
+                        graphToolTile.getAngleAdornment().should('exist').and('have.length',numAngles+1);
+                        graphToolTile.selectGraphPoint(13.2,2);
+                        graphToolTile.showAngle();
+                        graphToolTile.getAngleAdornment().should('exist').and('have.length',numAngles+2);
+                        graphToolTile.selectGraphPoint(13.2,2);
+                        graphToolTile.hideAngle();
+                        graphToolTile.getAngleAdornment().should('exist').and('have.length',numAngles+1);
+                        graphToolTile.selectGraphPoint(10.4, 7.2);
+                        graphToolTile.hideAngle();
+                        graphToolTile.getAngleAdornment().should('exist').and('have.length',numAngles);
+                        graphToolTile.selectGraphPoint(4.2,2);
+                        graphToolTile.hideAngle();
+                        graphToolTile.getAngleAdornment().should('not.exist');
+
+                        //Add the angles angle for the restore test later
+                        graphToolTile.selectGraphPoint(13.2,2);
+                        graphToolTile.showAngle();
+                        graphToolTile.selectGraphPoint(10.4, 7.2);
+                        graphToolTile.showAngle();
+                        graphToolTile.selectGraphPoint(4.2,2);
+                        graphToolTile.showAngle();
+                        graphToolTile.selectGraphPoint(4.2,2);
+
+                    });
+                    it.skip('will drag a polygon to a new location', function(){
+                        const dataTransfer = new DataTransfer;
+                        const graphUnit = 18.33;
+                        let x= 18, y=5;
+
+                        let transX=(graphToolTile.transformFromCoordinate('x', x))+(8*graphUnit),
+                            transY=(graphToolTile.transformFromCoordinate('y', y))+(5*graphUnit);
+                        graphToolTile.getGraphPolygon().click({force:true});
+                        graphToolTile.getGraphPoint().last()
+                            .trigger('mousedown',{dataTransfer, force:true})
+                            .trigger('mousemove',{clientX:transX, clientY:transY, dataTransfer, force:true})
+                            .trigger('mouseup',{dataTransfer, force:true});
+                        // graphToolTile.getGraphPointCoordinates(0).should('contain', '(12, 5)');
+                        graphToolTile.getGraphPointCoordinates(1).should('contain', '(18, 11)');
+                        graphToolTile.getGraphPointCoordinates(2).should('contain', '(21, 5)');
+                    });
+                    it.skip('verify rotate tool is visible when polygon is selected', function(){
+                        graphToolTile.getGraphPolygon().click({force:true});
+                        graphToolTile.getRotateTool().should('be.visible');
+                    });
+                    // it('will rotate a polygon', function(){
+                    //     //not sure how to verify the rotation
+                    //     graphToolTile.getRotateTool()
+                    //         .trigger('mousedown')
+                    //         .trigger('dragstart')
+                    //         .trigger('mousemove',18, 73, {force:true})
+                    //         .trigger('dragend')
+                    //         .trigger('drop')
+                    //         .trigger('mouseup');
+                    //     //TODO verify points are in new location
+                    // });
+                    // it('will duplicate a polygon', function(){
+                    //     graphToolTile.getGraphPolygon().click({force: true});
+                    //     graphToolTile.copyGraphElement();
+                    //     graphToolTile.getGraphPolygon().should('have.length',2);
+                    //     graphToolTile.getAngleAdornment().should('have.length',6);
+                    //     graphToolTile.getGraphPoint().should('have.length',6);
+                    // });
+                    // it('will restore changes to a graph', function(){
+                    //     primaryWorkspace.openResourceTab();
+                    //     resourcePanel.openPrimaryWorkspaceTab("my-work");
+                    //     cy.openDocumentWithTitle('my-work','workspaces', polyDoc);
+                    //     graphToolTile.getAngleAdornment().should('exist').and('have.length',6);
+                    // });
+                });
+
+                describe('delete points and polygons', function(){
+                    it('verify delete points with delete tool', function(){ //current behavior of text deletes the entire graph tool tile. Point selection has to be forced
+                        let basePointCount = 3; // number of points already in doc2
+                        primaryWorkspace.openResourceTab();
+                        cy.openDocumentWithTitle('my-work','workspaces', ptsDoc);
+                        primaryWorkspace.getResizePanelDivider().trigger('mouseover');
+                        primaryWorkspace.getResizeLeftPanelHandle().click();
+                        graphToolTile.selectGraphPoint(15,2);
+                        graphToolTile.deleteGraphElement();
+                        graphToolTile.getGraphPoint().should('have.length', basePointCount - 1);
+                        // graphToolTile.selectGraphPoint(10,5);
+                        // graphToolTile.deleteGraphElement();
+                        // graphToolTile.getGraphPoint().should('have.length', basePointCount - 2);
+                        // graphToolTile.selectGraphPoint(5,5);
+                        // graphToolTile.deleteGraphElement();
+                        // graphToolTile.getGraphPoint().should('have.length', basePointCount-3)
+                    });
+                    it.skip('verify delete polygon',()=>{
+                        primaryWorkspace.openResourceTab();
+                        cy.openDocumentWithTitle('my-work','workspaces', polyDoc);
+                        primaryWorkspace.getResizePanelDivider().trigger('mouseover');
+                        primaryWorkspace.getResizeLeftPanelHandle().click();
+                        graphToolTile.getGraphPolygon().last().click({force:true});
+                        graphToolTile.deleteGraphElement();
+                        graphToolTile.getGraphPolygon().should('have.length',1);
+                    });
+                    it.skip('verify delete points alters polygon',()=>{
+                        let basePointCount = 3, baseAngleCount=3; // number of points already in doc
+
+                        graphToolTile.getGraphPoint().should('have.length', basePointCount);
+                        graphToolTile.selectGraphPoint(16, 3.5);
+                        graphToolTile.getAngleAdornment().should('have.length',baseAngleCount);
+                        graphToolTile.deleteGraphElement();
+                        graphToolTile.getGraphPoint().should('have.length', basePointCount-1);
+                        // graphToolTile.selectGraphPoint(16.2, 9.5);
+                        graphToolTile.getGraphPoint().last().click({force: true});
+                        graphToolTile.deleteGraphElement();
+                        graphToolTile.getGraphPoint().should('have.length', basePointCount -2);
+                        graphToolTile.selectGraphPoint(8, 8);
+                        graphToolTile.deleteGraphElement();
+                        graphToolTile.getGraphPoint().should('have.length', basePointCount-3);
+                    });
+                });
+
+                describe.skip('movable line tests',()=>{
+                    // it('verify add a movable line', function(){
+                    //     canvas.createNewExtraDocumentFromFileMenu(lineDoc, "my-work");
+                    //     clueCanvas.addTile('geometry');
+                    //     graphToolTile.addMovableLine();
+
+                    // });
+                    // it.skip('verify move the movable line', function () {
+
+                    // });
+                    // it.skip('verify rotate the movable line', function () {
+
+                    // });
+                    // it.skip('verify movable line equation edit', function () {
+
+                    // });
+                });
+            });
         });
     });
-    
+
+    context('Test undo redo functionalities', function(){
+        before(function(){
+            const queryParams = `${Cypress.config("queryParams")}`;
+            cy.clearQAData('all');
+            cy.visit(queryParams);
+            cy.waitForLoad();
+            cy.closeResourceTabs();
+        });
+
+        describe('Graph tile undo redo',()=>{
+            it('will undo redo graph tile creation/deletion', function () {
+                // Creation - Undo/Redo
+                clueCanvas.addTile('geometry');
+                graphToolTile.getGraph().should("exist");
+                textToolTile.getTextTile().should("exist");
+                clueCanvas.getUndoTool().should("not.have.class", "disabled");
+                clueCanvas.getRedoTool().should("have.class", "disabled");
+                clueCanvas.getUndoTool().click();
+                graphToolTile.getGraph().should("not.exist");
+                textToolTile.getTextTile().should("not.exist");
+                clueCanvas.getUndoTool().should("have.class", "disabled");
+                clueCanvas.getRedoTool().should("not.have.class", "disabled");
+                clueCanvas.getRedoTool().click();
+                graphToolTile.getGraph().should("exist");
+                textToolTile.getTextTile().should("exist");
+                clueCanvas.getUndoTool().should("not.have.class", "disabled");
+                clueCanvas.getRedoTool().should("have.class", "disabled");
+        
+                // Deletion - Undo/Redo
+                clueCanvas.deleteTile('geometry');
+                graphToolTile.getGraph().should("not.exist");
+                textToolTile.getTextTile().should("exist");
+                clueCanvas.getUndoTool().click();
+                graphToolTile.getGraph().should("exist");
+                textToolTile.getTextTile().should("exist");
+                clueCanvas.getRedoTool().click();
+                graphToolTile.getGraph().should("not.exist");
+                textToolTile.getTextTile().should("exist");
+                clueCanvas.getUndoTool().click();
+            });
+            it("edit tile title", () => {
+                const newName = "Graph Tile";
+                graphToolTile.getGraphTitle().first().should("contain", "Graph 1");
+                graphToolTile.getGraphTileTitle().first().click();
+                graphToolTile.getGraphTileTitle().first().type(newName + '{enter}');
+                graphToolTile.getGraphTitle().should("contain", newName);
+            });
+            it("undo redo actions", () => {
+                clueCanvas.getUndoTool().click();
+                graphToolTile.getGraphTitle().first().should("contain", "Graph 1");
+                clueCanvas.getRedoTool().click();
+                graphToolTile.getGraphTitle().should("contain", "Graph Tile");
+            });
+            it('verify delete graph', function () {
+                clueCanvas.deleteTile('geometry');
+                graphToolTile.getGraph().should("not.exist");
+                textToolTile.getTextTile().should("exist");
+            });
+        });
+    });
 });

--- a/cypress/e2e/clue/branch/student_tests/graph_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/graph_tool_spec.js
@@ -57,6 +57,21 @@ context('Graph Tool', function() {
                 graphToolTile.getGraphPoint().last().click({force:true}).click({force:true});
                 graphToolTile.getGraphPolygon().should('exist');
             });
+            it('will copy a point to the clipboard', function(){
+                let clipSpy;
+                cy.window().then((win) => {
+                    clipSpy = cy.spy(win.navigator.clipboard, "write");
+                });
+
+                // platform test from hot-keys library
+                const isMac = navigator.platform.indexOf("Mac") === 0;
+                const cmdKey = isMac ? "meta" : "ctrl";
+                graphToolTile.getGraphPoint().last().click({force:true}).click({force:true})
+                    .type(`{${cmdKey}+c}`)
+                    .then(() => {
+                        expect(clipSpy.callCount).to.be.eq(1);
+                    });
+            });
 
             describe('restore points to canvas', function(){
                 it('will verify restore of point at origin', function(){

--- a/cypress/e2e/clue/branch/student_tests/image_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/image_tool_spec.js
@@ -51,6 +51,18 @@ context('Test image functionalities', function(){
             cy.uploadFile(imageToolTile.imageChooseFileButton(), imageFilePath, 'image/gif');
             cy.wait(2000);
         });
+        it('will accept a valid image URL pasted from the clipboard', function(){
+            const imageFilePath = "curriculum/test/images/image.png";
+            cy.window().then((win) => {
+                win.navigator.clipboard.write([new win.ClipboardItem({
+                    "text/plain": new Blob([imageFilePath], { type: "text/plain" }),
+                })]);
+            });
+            const isMac = navigator.platform.indexOf("Mac") === 0;
+            const cmdKey = isMac ? "meta" : "ctrl";
+            imageToolTile.getImageToolTile().last().type(`{${cmdKey}+v}`);
+            imageToolTile.getImageToolImage().last().should("have.css", "background-image").and("contain", "test/images/image.png");
+        });
     });
     describe.skip('restore of images', function(){
         before(()=>{ //reopen the first canvas

--- a/cypress/e2e/clue/branch/student_tests/image_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/image_tool_spec.js
@@ -51,13 +51,25 @@ context('Test image functionalities', function(){
             cy.uploadFile(imageToolTile.imageChooseFileButton(), imageFilePath, 'image/gif');
             cy.wait(2000);
         });
+        // TODO: Figure out how to get the clipboard paste check below to work when the tests 
+        // are run using Chrome. It will pass when using Electron, but not Chrome. In Chrome 
+        // the attempt to write to the clipboard results in an error: "Must be handling a user 
+        // gesture to use custom clipboard." See https://github.com/cypress-io/cypress/issues/2752
+        // for more background. Apparently, the basic problem is that Cypress "currently uses 
+        // programmatic browser APIs which Chrome doesn't consider as genuine user interaction."
         it('will accept a valid image URL pasted from the clipboard', function(){
             const imageFilePath = "curriculum/test/images/image.png";
-            cy.window().then((win) => {
+            Cypress.automation("remote:debugger:protocol", {
+                command: "Browser.grantPermissions",
+                params: {
+                  permissions: ["clipboardReadWrite", "clipboardSanitizedWrite"],
+                  origin: window.location.origin,
+                },
+              }).then(cy.window().then((win) => {
                 win.navigator.clipboard.write([new win.ClipboardItem({
                     "text/plain": new Blob([imageFilePath], { type: "text/plain" }),
                 })]);
-            });
+            }));
             const isMac = navigator.platform.indexOf("Mac") === 0;
             const cmdKey = isMac ? "meta" : "ctrl";
             imageToolTile.getImageToolTile().last().type(`{${cmdKey}+v}`);

--- a/cypress/e2e/clue/branch/student_tests/image_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/image_tool_spec.js
@@ -57,7 +57,7 @@ context('Test image functionalities', function(){
         // gesture to use custom clipboard." See https://github.com/cypress-io/cypress/issues/2752
         // for more background. Apparently, the basic problem is that Cypress "currently uses 
         // programmatic browser APIs which Chrome doesn't consider as genuine user interaction."
-        it('will accept a valid image URL pasted from the clipboard', function(){
+        it.skip('will accept a valid image URL pasted from the clipboard', function(){
             const imageFilePath = "curriculum/test/images/image.png";
             Cypress.automation("remote:debugger:protocol", {
                 command: "Browser.grantPermissions",

--- a/cypress/e2e/clue/branch/student_tests/text_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/text_tool_spec.js
@@ -40,37 +40,33 @@ context('Text tool tile functionalities', function(){
         textToolTile.deleteText('{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}...');
         textToolTile.getTextTile().last().should('not.contain', 'delete');
     });
-    // FIXME: For some reason that only seems present in these tests, we have to add seemingly
-    // superfluous spaces and line breaks before applying each text format. If we don't, the
-    // elements we're checking for either don't get added, or get added in a somewhat meaningless
-    // way (e.g., `<em></em> This should be italic`). This issue doesn't exist in the browser.
     it('has a toolbar that can be used', function(){
         textToolTile.clickToolbarTool("Bold");
         textToolTile.enterText('{end} {enter}');
-        textToolTile.enterText('{end}This should be bold.');
+        textToolTile.enterText('{end}This should be bold. ');
         textToolTile.getTextEditor().last().should('have.descendants', 'strong');
         textToolTile.clickToolbarTool("Bold");
 
         textToolTile.clickToolbarTool("Italic");
-        textToolTile.enterText('{end} {enter}');
-        textToolTile.enterText('{end} {enter}This should be italic.');
+        textToolTile.enterText('This should be italicized. ');
         textToolTile.getTextEditor().last().should('have.descendants', 'em');
         textToolTile.clickToolbarTool("Italic");
 
         textToolTile.clickToolbarTool("Underline");
-        textToolTile.enterText('{end} {enter}');
-        textToolTile.enterText('{end} {enter}This should be underlined.');
+        textToolTile.enterText('This should be underlined. ');
         textToolTile.getTextEditor().last().should('have.descendants', 'u');
         textToolTile.clickToolbarTool("Underline");
 
         textToolTile.clickToolbarTool("Subscript");
-        textToolTile.enterText('{end} {enter}');
-        textToolTile.enterText('{end} {enter}This should be subscript.');
+        textToolTile.enterText('This should be subscript. ');
         textToolTile.getTextEditor().last().should('have.descendants', 'sub');
         textToolTile.clickToolbarTool("Subscript");
 
+        // FIXME: For some reason that only seems present in these tests, we have to add seemingly
+        // superfluous spaces and line breaks before applying each text format. If we don't, the
+        // elements we're checking for either don't get added, or get added in a somewhat meaningless
+        // way (e.g., `<em></em> This should be italic`). This issue doesn't exist in the browser.
         textToolTile.clickToolbarTool("Superscript");
-        textToolTile.enterText('{end} {enter}');
         textToolTile.enterText('{end} {enter}This should be superscript.');
         textToolTile.getTextEditor().last().should('have.descendants', 'sup');
         textToolTile.clickToolbarTool("Superscript");
@@ -114,11 +110,10 @@ context('Text tool tile functionalities', function(){
         textToolTile.getTextEditor().last().should('have.descendants', 'ul');
         canvas.deleteDocument();
     });
-    // FIXME: This test broke post slate upgrade.
-    // it('delete text tile',()=>{
-    //     clueCanvas.deleteTile('text');
-    //     textToolTile.getTextTile().should('not.exist');
-    // });
+    it('delete text tile',()=>{
+        clueCanvas.deleteTile('text');
+        textToolTile.getTextTile().should('not.exist');
+    });
 });
 context('Text Tool Tile selection', function () {
     before(function () {

--- a/cypress/e2e/clue/branch/student_tests/text_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/text_tool_spec.js
@@ -40,33 +40,37 @@ context('Text tool tile functionalities', function(){
         textToolTile.deleteText('{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}...');
         textToolTile.getTextTile().last().should('not.contain', 'delete');
     });
+    // FIXME: For some reason that only seems present in these tests, we have to add seemingly
+    // superfluous spaces and line breaks before applying each text format. If we don't, the
+    // elements we're checking for either don't get added, or get added in a somewhat meaningless
+    // way (e.g., `<em></em> This should be italic`). This issue doesn't exist in the browser.
     it('has a toolbar that can be used', function(){
         textToolTile.clickToolbarTool("Bold");
         textToolTile.enterText('{end} {enter}');
-        textToolTile.enterText('{end}This should be bold. ');
+        textToolTile.enterText('{end}This should be bold.');
         textToolTile.getTextEditor().last().should('have.descendants', 'strong');
         textToolTile.clickToolbarTool("Bold");
 
         textToolTile.clickToolbarTool("Italic");
-        textToolTile.enterText('This should be italicized. ');
+        textToolTile.enterText('{end} {enter}');
+        textToolTile.enterText('{end} {enter}This should be italic.');
         textToolTile.getTextEditor().last().should('have.descendants', 'em');
         textToolTile.clickToolbarTool("Italic");
 
         textToolTile.clickToolbarTool("Underline");
-        textToolTile.enterText('This should be underlined. ');
+        textToolTile.enterText('{end} {enter}');
+        textToolTile.enterText('{end} {enter}This should be underlined.');
         textToolTile.getTextEditor().last().should('have.descendants', 'u');
         textToolTile.clickToolbarTool("Underline");
 
         textToolTile.clickToolbarTool("Subscript");
-        textToolTile.enterText('This should be subscript. ');
+        textToolTile.enterText('{end} {enter}');
+        textToolTile.enterText('{end} {enter}This should be subscript.');
         textToolTile.getTextEditor().last().should('have.descendants', 'sub');
         textToolTile.clickToolbarTool("Subscript");
 
-        // FIXME: For some reason that only seems present in these tests, we have to add seemingly
-        // superfluous spaces and line breaks before applying each text format. If we don't, the
-        // elements we're checking for either don't get added, or get added in a somewhat meaningless
-        // way (e.g., `<em></em> This should be italic`). This issue doesn't exist in the browser.
         textToolTile.clickToolbarTool("Superscript");
+        textToolTile.enterText('{end} {enter}');
         textToolTile.enterText('{end} {enter}This should be superscript.');
         textToolTile.getTextEditor().last().should('have.descendants', 'sup');
         textToolTile.clickToolbarTool("Superscript");

--- a/cypress/support/elements/clue/ImageToolTile.js
+++ b/cypress/support/elements/clue/ImageToolTile.js
@@ -6,7 +6,7 @@ class ImageToolTile{
         return ('.toolbar-button.image-upload input');
     }
     getImageToolImage(){
-        return cy.get('.image-tool.editable > .image-tool-image');
+        return cy.get('.image-tool.editable .image-tool-image');
     }
     getImageToolTile(workspaceClass) {
         return cy.get('.image-tool-tile');

--- a/cypress/support/elements/clue/cCanvas.js
+++ b/cypress/support/elements/clue/cCanvas.js
@@ -224,7 +224,7 @@ class ClueCanvas {
       switch (tileType) {
           case 'text':
               textToolTile.getTextTile().last().focus();
-              tileElement = cy.get('.text-tool-wrapper').parent();
+              tileElement = cy.get('.text-tool-wrapper').last().click({ force: true }).parent();
               break;
           case 'graph':
               tileElement = graphToolTile.getGraphTile().last().click({ force: true }).parent();

--- a/src/components/tiles/image/image-tile.tsx
+++ b/src/components/tiles/image/image-tile.tsx
@@ -198,23 +198,23 @@ export default class ImageToolComponent extends BaseComponent<IProps, IState> {
 
   private handlePaste = () => {
     this.setState({ isLoading: true }, () => {
-      pasteClipboardImage(({ file, image }) => this.handleNewImage(file, image));
+      pasteClipboardImage(({ image }) => this.handleNewImage(image));
     });
   };
 
   private handleUploadImageFile = (file: File) => {
     this.setState({ isLoading: true }, () => {
       gImageMap.addFileImage(file)
-        .then(image => this.handleNewImage(file, image));
+        .then(image => this.handleNewImage(image));
     });
   };
 
-  private handleNewImage = (file: File, image: ImageMapEntryType) => {
+  private handleNewImage = (image: ImageMapEntryType) => {
     if (this._isMounted) {
       const content = this.getContent();
       this.setState({ isLoading: false, imageEntry: image });
       if (image.contentUrl && (image.contentUrl !== content.url)) {
-        content.setUrl(image.contentUrl, file.name);
+        content.setUrl(image.contentUrl, image.filename);
       }
     }
   };

--- a/src/components/tiles/image/image-tile.tsx
+++ b/src/components/tiles/image/image-tile.tsx
@@ -22,7 +22,7 @@ import { ImageDragDrop } from "../../utilities/image-drag-drop";
 import { isPlaceholderImage } from "../../../utilities/image-utils";
 import placeholderImage from "../../../assets/image_placeholder.png";
 import { HotKeys } from "../../../utilities/hot-keys";
-import { pasteClipboardImage } from "../../../utilities/clipboard-utils";
+import { getClipboardContent, pasteClipboardImage } from "../../../utilities/clipboard-utils";
 
 import "./image-tile.sass";
 
@@ -197,8 +197,11 @@ export default class ImageToolComponent extends BaseComponent<IProps, IState> {
   }
 
   private handlePaste = () => {
-    this.setState({ isLoading: true }, () => {
-      pasteClipboardImage(({ image }) => this.handleNewImage(image));
+    this.setState({ isLoading: true }, async () => {
+      const osClipboardContents = await getClipboardContent();
+      if (osClipboardContents) {
+        pasteClipboardImage(osClipboardContents, ({ image }) => this.handleNewImage(image));
+      }
     });
   };
 

--- a/src/models/image-map.ts
+++ b/src/models/image-map.ts
@@ -448,7 +448,7 @@ export const localAssetsImagesHandler: IImageHandler = {
            /\.[a-z0-9]+$/i.test(url);
   },
 
-  async store(url: string) {
+  async store(url: string, options?: IImageHandlerStoreOptions): Promise<IImageHandlerStoreResult> {
     // Legacy curriculum units lived in the defunct "curriculum" directory in subfolders
     // named after the unit title, e.g. "curriculum/stretching-and-shrinking". References
     // to files in those directories need to be converted to use the new file structure
@@ -468,7 +468,7 @@ export const localAssetsImagesHandler: IImageHandler = {
     const displayUrl = this.imageMap.curriculumUrl && !/^assets\//.test(_url)
                          ? new URL(_url, this.imageMap.curriculumUrl).href
                          : getAssetUrl(_url);
-    return { contentUrl: _url, displayUrl, success: true };
+    return { filename: options?.filename, contentUrl: _url, displayUrl, success: true };
   },
   imageMap: {}
 };

--- a/src/plugins/drawing/components/drawing-tile.tsx
+++ b/src/plugins/drawing/components/drawing-tile.tsx
@@ -13,7 +13,7 @@ import { EditableTileTitle } from "../../../components/tiles/editable-tile-title
 import { measureText } from "../../../components/tiles/hooks/use-measure-text";
 import { defaultTileTitleFont } from "../../../components/constants";
 import { HotKeys } from "../../../utilities/hot-keys";
-import { pasteClipboardImage } from "../../../utilities/clipboard-utils";
+import { getClipboardContent, pasteClipboardImage } from "../../../utilities/clipboard-utils";
 import "./drawing-tile.scss";
 
 type IProps = ITileProps;
@@ -45,10 +45,13 @@ const DrawingToolComponent: React.FC<IProps> = (props) => {
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const handlePaste = () => {
-    pasteClipboardImage(({ image }) => {
-      setImageUrlToAdd(image.contentUrl || '');
-    });
+  const handlePaste = async () => {
+    const osClipboardContents = await getClipboardContent();
+    if (osClipboardContents) {
+      pasteClipboardImage(osClipboardContents, ({ image }) => {
+        setImageUrlToAdd(image.contentUrl || '');
+      });
+    }
   };
 
   const handleDelete = () => {

--- a/src/utilities/clipboard-utils.test.ts
+++ b/src/utilities/clipboard-utils.test.ts
@@ -1,0 +1,81 @@
+import { EntryStatus, gImageMap } from "../models/image-map";
+import { getClipboardContent, pasteClipboardImage } from "./clipboard-utils";
+
+describe("getClipboardContent", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+  it("returns null values when the clipboard is empty", async () => {
+    Object.assign(navigator, {
+      clipboard: {
+        read: () => { return []; }
+      },
+    });
+    jest.spyOn(navigator.clipboard, "read");
+    const clipboardContent = await getClipboardContent();
+    expect(clipboardContent.image).toBe(null);
+    expect(clipboardContent.text).toBe(null);
+  });
+  it("returns a text item when the clipboard contains a text item", async () => {
+    const mockBlob = {
+      arrayBuffer: jest.fn(),
+      size: 1024,
+      text: jest.fn().mockResolvedValue("test"),
+      type: "text/plain",
+      slice: jest.fn(),
+      stream: jest.fn()
+    };
+    const mockReturnValue = {
+      types: ["text/plain"], getType: jest.fn().mockResolvedValue(mockBlob)
+    };
+    jest.spyOn(navigator.clipboard, "read").mockResolvedValue([mockReturnValue]);
+    jest.spyOn(global, "Blob").mockImplementation(() => mockBlob);
+    const clipboardContent = await getClipboardContent();
+    expect(clipboardContent.image).toBe(null);
+    expect(clipboardContent.text).not.toBe(null);
+  });
+  it("returns an image item when the clipboard contains an image item", async () => {
+    const mockReturnValue = {
+      types: ["image/png"], getType: jest.fn()
+    };
+    jest.spyOn(navigator.clipboard, "read").mockResolvedValue([mockReturnValue]);
+    const clipboardContent = await getClipboardContent();
+    expect(clipboardContent.image).not.toBe(null);
+    expect(clipboardContent.text).toBe(null);
+  });
+});
+
+describe("pasteClipboardImage", () => {
+  it ("calls addFileImage when the clipboard contains an image item", () => {
+    const image = { image: "test.png" };
+    const mockImageResponse = {
+      contentUrl: "test/test.png",
+      displayUrl: "https://example.com/test/test.png",
+      filename: "test.png",
+      height: 100,
+      retries: 0,
+      status: EntryStatus.Ready,
+      width: 100
+    };
+    const onComplete = jest.fn();
+    jest.spyOn(gImageMap, "addFileImage").mockResolvedValue(mockImageResponse);
+    pasteClipboardImage(image, onComplete);
+    expect(gImageMap.addFileImage).toHaveBeenCalled();
+  });
+  it ("calls getImage when the clipboard contains a text item", () => {
+    const image = { text: "curriculum/test/images/test.png" };
+    const mockImageResponse = {
+      contentUrl: "test/test.png",
+      displayUrl: "https://example.com/test/test.png",
+      filename: "test.png",
+      height: 100,
+      retries: 0,
+      status: EntryStatus.Ready,
+      width: 100
+    };
+    const onComplete = jest.fn();
+    jest.spyOn(gImageMap, "getImage").mockResolvedValue(mockImageResponse);
+    pasteClipboardImage(image, onComplete);
+    expect(gImageMap.getImage).toHaveBeenCalled();
+  });
+});

--- a/src/utilities/clipboard-utils.ts
+++ b/src/utilities/clipboard-utils.ts
@@ -1,7 +1,6 @@
 import { gImageMap, ImageMapEntryType } from "../models/image-map";
 
 interface IOnCompleteParams {
-  file: File;
   image: ImageMapEntryType;
 }
 type OnComplete = (params: IOnCompleteParams) => void;
@@ -9,13 +8,33 @@ type OnComplete = (params: IOnCompleteParams) => void;
 export const pasteClipboardImage = async (onComplete: OnComplete) => {
   const clipboardContents = await navigator.clipboard.read();
   if (clipboardContents.length > 0) {
-    if (clipboardContents[0].types.includes("image/png")) {
-      clipboardContents[0].getType("image/png").then(blob => {
-        const blobToFile = new File([blob], "clipboard-image");
-        gImageMap.addFileImage(blobToFile).then(image => {
-          onComplete({ file: blobToFile, image });
+    switch (clipboardContents[0].types[0]) {
+      case "image/png": {
+        clipboardContents[0].getType("image/png").then(blob => {
+          const blobToFile = new File([blob], "clipboard-image.png");
+          gImageMap.addFileImage(blobToFile).then(image => {
+            onComplete({ image });
+          });
         });
-      });
+        break;
+      }
+      case "text/plain": {
+        const textBlob = await clipboardContents[0].getType("text/plain");
+        const text = await textBlob.text();
+        const url = text.match(/curriculum\/([^/]+\/images\/.*)/);
+        if (!url) {
+          console.error("ERROR: invalid image URL");
+          break;
+        }
+        const fileUrl = url[1];
+        const filename = fileUrl.split("/").pop();
+        const imageEntry = await gImageMap.getImage(fileUrl, {filename});
+        onComplete({ image: imageEntry });
+        break;
+      }
+      default: {
+        console.error("ERROR: unknown clipboard content type");
+      }
     }
   }
 };

--- a/src/utilities/clipboard-utils.ts
+++ b/src/utilities/clipboard-utils.ts
@@ -38,7 +38,7 @@ export const getClipboardContent = async () => {
         clipboardContent.image = await item.getType("image/png");
       }
       if (item.types.includes("text/plain")) {
-        const textBlob = await clipboardContents[0].getType("text/plain");
+        const textBlob = await item.getType("text/plain");
         clipboardContent.text = await textBlob.text();
       }
     }


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/184755020

Adds support for pasting image URLs copied from the CMS media library into the Image, Drawing, and Geometry tiles. When pasted into a tile, the image URLs are automatically converted to a rendered image, or background image in the case of the Geometry tile.