### PR TITLE
184755026 Remove new lines when exporting text

### DIFF
--- a/src/models/tiles/text/text-content.ts
+++ b/src/models/tiles/text/text-content.ts
@@ -82,7 +82,7 @@ export const TextContentModel = TileContentModel
       // We need to escape both double quotes and backslashes, otherwise the curriculum json will break.
       const exportHtml = html.split("\n")
         .map((line, i, arr) =>
-          `    "${removeNewlines(escapeDoubleQuotes(escapeBackslashes(line)))}"${i < arr.length - 1 ? "," : ""}`);
+          `    "${escapeDoubleQuotes(escapeBackslashes(removeNewlines(line)))}"${i < arr.length - 1 ? "," : ""}`);
       return [
         `{`,
         `  "type": "Text",`,

--- a/src/utilities/string-utils.ts
+++ b/src/utilities/string-utils.ts
@@ -1,4 +1,4 @@
 export const escapeBackslashes = (text: string) => text.replaceAll(`\\`, `\\\\`);
 export const escapeDoubleQuotes = (text: string) => text.replaceAll(`"`, `\\"`);
 // export const removeNewlines = (text: string) => text.replaceAll(`\\n`, ``).replaceAll(`\\r`, ``);
-export const removeNewLines = (text: string) => text.replace(/\r?\n|\r/g, "");
+export const removeNewlines = (text: string) => text.replace(/\r?\n|\r/g, "");

--- a/src/utilities/string-utils.ts
+++ b/src/utilities/string-utils.ts
@@ -1,4 +1,3 @@
 export const escapeBackslashes = (text: string) => text.replaceAll(`\\`, `\\\\`);
 export const escapeDoubleQuotes = (text: string) => text.replaceAll(`"`, `\\"`);
-// export const removeNewlines = (text: string) => text.replaceAll(`\\n`, ``).replaceAll(`\\r`, ``);
 export const removeNewlines = (text: string) => text.replace(/\r?\n|\r/g, "");

--- a/src/utilities/string-utils.ts
+++ b/src/utilities/string-utils.ts
@@ -1,3 +1,4 @@
 export const escapeBackslashes = (text: string) => text.replaceAll(`\\`, `\\\\`);
 export const escapeDoubleQuotes = (text: string) => text.replaceAll(`"`, `\\"`);
-export const removeNewlines = (text: string) => text.replaceAll(`\\n`, ``).replaceAll(`\\r`, ``);
+// export const removeNewlines = (text: string) => text.replaceAll(`\\n`, ``).replaceAll(`\\r`, ``);
+export const removeNewLines = (text: string) => text.replace(/\r?\n|\r/g, "");


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/184755026

When exporting text tiles, new line characters sometimes sneak into the final output, breaking the json. The source of these line breaks are unknown, but probably result from hidden characters pasted into the text tiles from Word. This PR attempts to address the issue by more aggressively removing newlines and carriage returns, and doing so before escaping backslashes.

These solutions seem to solve the problem, but I'm still not sure why previous solutions didn't work. I'm guessing that the issue is Windows line breaks, `\r\n`, are considered a single character, so splitting on `\n` did not leave the `\r`, which I was trying to filter out previously. The new reg expression I'm using covers all combinations of `\r` and `\n`, so I think it captured the `\r\n` my previous attempts must have missed.