### PR TITLE
184824070 Include Tile Ids when Exporting JSON from CMS Widget and Doc Editor

### DIFF
--- a/src/cms/clue-control.tsx
+++ b/src/cms/clue-control.tsx
@@ -74,7 +74,7 @@ export class ClueControl extends React.Component<CmsWidgetControlProps, IState> 
 
       // Update the widget's value whenever a change is made to the document's content
       this.disposer = onSnapshot(document, snapshot => {
-        const json = document.content?.exportAsJson();
+        const json = document.content?.exportAsJson({ includeTileIds: true });
         if (json) {
           const parsedJson = JSON.parse(json);
           const stringifiedJson = JSON.stringify(parsedJson);

--- a/src/components/doc-editor-app.tsx
+++ b/src/components/doc-editor-app.tsx
@@ -45,7 +45,7 @@ export const DocEditorApp = ({ appConfig }: IDocEditorAppProps) => {
     }
 
     // construct the contents of the section
-    const docContentString = document.content.exportAsJson();
+    const docContentString = document.content.exportAsJson({ includeTileIds: true });
     const docContentJSON = JSON.parse(docContentString);
     sectionSnapshot.content = docContentJSON;
     const contents = JSON.stringify(sectionSnapshot, undefined, 2);


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/184824070