### PR TITLE
184755026 Fix Section Export

### DIFF
--- a/src/components/document/canvas.tsx
+++ b/src/components/document/canvas.tsx
@@ -14,6 +14,7 @@ import { PlaybackComponent } from "../playback/playback";
 import {
   ITileApi, ITileApiInterface, ITileApiMap, TileApiInterfaceContext, EditableTileApiInterfaceRefContext
 } from "../tiles/tile-api";
+import { StringBuilder } from "../../utilities/string-builder";
 import { HotKeys } from "../../utilities/hot-keys";
 import { DEBUG_CANVAS, DEBUG_DOCUMENT } from "../../lib/debug";
 import { DocumentError } from "./document-error";
@@ -192,7 +193,13 @@ export class CanvasComponent extends BaseComponent<IProps, IState> {
             const typeDir = await sectionDir.getDirectoryHandle(type, { create: true });
             const typeFile = await typeDir.getFileHandle("content.json", { create: true });
             const writableStream = await typeFile.createWritable();
-            await writableStream.write(json);
+            const builder = new StringBuilder();
+            builder.pushLine(`{`);
+            builder.pushLine(`"type": "${type}",`, 2);
+            builder.pushLine(`"content":`, 2);
+            builder.pushBlock(json, 4);
+            builder.pushLine(`}`);
+            await writableStream.write(builder.build());
             await writableStream.close();
           });
         }

--- a/src/models/tiles/text/text-content.ts
+++ b/src/models/tiles/text/text-content.ts
@@ -82,7 +82,7 @@ export const TextContentModel = TileContentModel
       // We need to escape both double quotes and backslashes, otherwise the curriculum json will break.
       const exportHtml = html.split("\n")
         .map((line, i, arr) =>
-          `    "${removeNewlines(escapeDoubleQuotes(escapeBackslashes(line)))}"${i < arr.length - 1 ? "," : ""}`);
+          `    "${escapeDoubleQuotes(escapeBackslashes(removeNewlines(line)))}"${i < arr.length - 1 ? "," : ""}`);
       return [
         `{`,
         `  "type": "Text",`,

--- a/src/models/tiles/text/text-content.ts
+++ b/src/models/tiles/text/text-content.ts
@@ -6,7 +6,7 @@ import { ITileExportOptions } from "../tile-content-info";
 import { TileContentModel } from "../tile-content";
 import { SharedModelType } from "../../shared/shared-model";
 import { getAllTextPluginInfos } from "./text-plugin-info";
-import { escapeBackslashes, escapeDoubleQuotes, removeNewlines } from "../../../utilities/string-utils";
+import { escapeBackslashes, escapeDoubleQuotes, removeNewlines, removeTabs } from "../../../utilities/string-utils";
 
 export const kTextTileType = "Text";
 
@@ -80,9 +80,10 @@ export const TextContentModel = TileContentModel
       const value = self.asSlate();
       const html = value ? slateToHtml(value) : "";
       // We need to escape both double quotes and backslashes, otherwise the curriculum json will break.
+      const processLine = (line: string) => escapeDoubleQuotes(escapeBackslashes(removeTabs(removeNewlines(line))));
       const exportHtml = html.split("\n")
         .map((line, i, arr) =>
-          `    "${escapeDoubleQuotes(escapeBackslashes(removeNewlines(line)))}"${i < arr.length - 1 ? "," : ""}`);
+          `    "${processLine(line)}"${i < arr.length - 1 ? "," : ""}`);
       return [
         `{`,
         `  "type": "Text",`,

--- a/src/utilities/string-utils.ts
+++ b/src/utilities/string-utils.ts
@@ -1,4 +1,4 @@
 export const escapeBackslashes = (text: string) => text.replaceAll(`\\`, `\\\\`);
 export const escapeDoubleQuotes = (text: string) => text.replaceAll(`"`, `\\"`);
 // export const removeNewlines = (text: string) => text.replaceAll(`\\n`, ``).replaceAll(`\\r`, ``);
-export const removeNewLines = (text: string) => text.replace(/\r?\n|\r/g, "");
+export const removeNewlines = (text: string) => text.replace(/\r?\n|\r/g, "");

--- a/src/utilities/string-utils.ts
+++ b/src/utilities/string-utils.ts
@@ -1,3 +1,4 @@
 export const escapeBackslashes = (text: string) => text.replaceAll(`\\`, `\\\\`);
 export const escapeDoubleQuotes = (text: string) => text.replaceAll(`"`, `\\"`);
 export const removeNewlines = (text: string) => text.replace(/\r?\n|\r/g, "");
+export const removeTabs = (text: string) => text.replace(/\t/g, "");

--- a/src/utilities/string-utils.ts
+++ b/src/utilities/string-utils.ts
@@ -1,4 +1,3 @@
 export const escapeBackslashes = (text: string) => text.replaceAll(`\\`, `\\\\`);
 export const escapeDoubleQuotes = (text: string) => text.replaceAll(`"`, `\\"`);
-// export const removeNewlines = (text: string) => text.replaceAll(`\\n`, ``).replaceAll(`\\r`, ``);
 export const removeNewlines = (text: string) => text.replace(/\r?\n|\r/g, "");

--- a/src/utilities/string-utils.ts
+++ b/src/utilities/string-utils.ts
@@ -1,3 +1,4 @@
 export const escapeBackslashes = (text: string) => text.replaceAll(`\\`, `\\\\`);
 export const escapeDoubleQuotes = (text: string) => text.replaceAll(`"`, `\\"`);
-export const removeNewlines = (text: string) => text.replaceAll(`\\n`, ``).replaceAll(`\\r`, ``);
+// export const removeNewlines = (text: string) => text.replaceAll(`\\n`, ``).replaceAll(`\\r`, ``);
+export const removeNewLines = (text: string) => text.replace(/\r?\n|\r/g, "");


### PR DESCRIPTION
Another PR for https://www.pivotaltracker.com/story/show/184755026

This PR addresses two issues:
- Previously, files only contained the content for a section. They now contain the entire section.
- Tabs are now being stripped out of text tiles on export. It's not clear is this was causing any actual problems, but it seems like it may have been and doesn't hurt.