### PR TITLE
184836795 Fix editable document content css.

### DIFF
--- a/src/components/document/editable-document-content.scss
+++ b/src/components/document/editable-document-content.scss
@@ -1,20 +1,22 @@
 @import "../vars";
 
+.full-screen-editable-document-content {
+  position: absolute;
+  top: $workspace-titlebar-height;
+  left: 0;
+  width: 100%;
+  height: calc(100% - #{$workspace-titlebar-height});
+}
+
+.contained-editable-document-content {
+  position: relative;
+  width: 100%;
+  height: 680px;
+  border-radius: 5px;
+  border: 2px solid #ddd;
+}
+
 .editable-document-content {
-  &.full-screen {
-    position: absolute;
-    top: $workspace-titlebar-height;
-    left: 0;
-    width: 100%;
-    height: calc(100% - #{$workspace-titlebar-height});
-  }
-  &.contained {
-    position: relative;
-    width: 100%;
-    height: 680px;
-    border-radius: 5px;
-    border: 2px solid #ddd;
-  }
   &.comment-select {
     .document-content {
       background-color: $comment-select-green;

--- a/src/components/document/editable-document-content.tsx
+++ b/src/components/document/editable-document-content.tsx
@@ -109,7 +109,8 @@ export const EditableDocumentContent: React.FC<IProps> = props => {
   const isChatEnabled = isNetworkedTeacher;
   const documentSelectedForComment = isChatEnabled && ui.showChatPanel && ui.selectedTileIds.length === 0 && !isPrimary;
   const editableDocContentClass = classNames("editable-document-content", showToolbarClass,
-    contained ? "contained" : "full-screen", {"comment-select" : documentSelectedForComment});
+    contained ? "contained-editable-document-content" : "full-screen-editable-document-content",
+    {"comment-select" : documentSelectedForComment});
 
   useDocumentSyncToFirebase(user, firebase, document, readOnly);
   return (


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/184836795

The recent document editor and CMS update required adjusting the css for `EditableDocumentContent`. This added an additional layer of classes that differentiated contained and full screen components, because the CMS component had to be contained within a widget. This broke some other css (`.document-tabs .editable-document-content`) that was previously overriding the single `.editable-document-content` class, but was no longer overriding the double `.editable-document-content.full-screen` pair of classes. This fix moves `.full-screen-editable-document-content` and `.contained-editable-document-content` to the top level, so as single classes they will be overridden by the pair of classes as was happening previously.