### PR TITLE
extract document monitoring to its own class

### DIFF
--- a/src/lib/db-listeners/db-doc-content-listener.ts
+++ b/src/lib/db-listeners/db-doc-content-listener.ts
@@ -1,0 +1,138 @@
+import firebase from "firebase/app";
+import { autorun, IReactionDisposer } from "mobx";
+import { DocumentModelType } from "../../models/document/document";
+import { ProblemDocument } from "../../models/document/document-types";
+import { DB } from "../db";
+import { DBDocument } from "../db-types";
+import { BaseListener } from "./base-listener";
+
+class DocumentMonitor {
+  public document: DocumentModelType;
+  ref: firebase.database.Reference;
+  db: DB;
+  path: string;
+
+  constructor(document: DocumentModelType, path: string, db: DB) {
+    this.document = document;
+    this.db = db;
+    this.path = path;
+
+    this.ref = this.db.firebase.ref(path);
+    this.ref.on("value", this.snapshotHandler);
+  }
+
+  private snapshotHandler = (snapshot: firebase.database.DataSnapshot) => {
+    if (snapshot?.val()) {
+      const updatedDoc: DBDocument = snapshot.val();
+      const updatedContent = this.db.parseDocumentContent(updatedDoc);
+      this.document?.setContent(updatedContent || {});
+    }
+  };
+
+  public get description() {
+    return `document: ${this.document.key} type: ${this.document.type} path: ${this.path}`;
+  }
+
+  public off() {
+    this.ref.off("value", this.snapshotHandler);
+  }
+}
+
+export class DBDocumentContentListener extends BaseListener {
+  private db: DB;
+  private monitoredDocuments: Record<string, DocumentMonitor> = {};
+  private disposer: IReactionDisposer;
+
+  constructor(db: DB) {
+    super("DBDocumentContentListener");
+    this.db = db;
+  }
+
+  public start() {
+    this.disposer = autorun(() => {
+      const {documents, groups, user} = this.db.stores;
+
+      const userGroupIds: any = {};
+      groups.allGroups.forEach((group) => {
+        group.users.forEach((groupUser) => {
+          userGroupIds[groupUser.id] = group.id;
+        });
+      });
+
+      const documentsToMonitor: DocumentModelType[] = [];
+
+      documents.byType(ProblemDocument).forEach((document) => {
+        // Besides collecting the documents to monitor, we also update the group
+        // id of the document. A new document could be added with an out of date
+        // group id. Or a user's group can change. In both cases the document
+        // should be updated.
+        document.setGroupId(userGroupIds[document.uid]);
+
+        // Users don't monitor their own documents
+        if ((document.uid === user.id)) {
+          return;
+        }
+
+        // teacher monitor all problem documents
+        // students only monitor documents in their group to save bandwidth
+        if (user.isTeacher || document.groupId === user.latestGroupId) {
+          documentsToMonitor.push(document);
+        }
+      });
+
+      // Stop monitoring any documents we shouldn't be
+      // This could happen if a user changes groups
+      Object.keys(this.monitoredDocuments).forEach(monitoredDocPath => {
+        // Should this document be monitored?
+        if(!documentsToMonitor.find((document) => this.getDocumentPath(document) === monitoredDocPath)) {
+          this.unmonitorDocumentByPath(monitoredDocPath);
+        }
+      });
+
+      // Ensure we are monitoring any new documents
+      documentsToMonitor.forEach(document => {
+        // If the document is already monitored it will not be monitored twice
+        this.monitorDocument(document);
+      });
+    });
+
+  }
+
+  public stop() {
+    this.disposer?.();
+    this.unmonitorAllDocuments();
+  }
+
+  private getDocumentPath = (document: DocumentModelType) => {
+    const { user } = this.db.stores;
+    const documentKey = document.key;
+    return this.db.firebase.getUserDocumentPath(user, documentKey, document.uid);
+  };
+
+  private monitorDocument = (document: DocumentModelType) => {
+    const documentPath = this.getDocumentPath(document);
+
+    if (this.monitoredDocuments[documentPath]) {
+      // We are already monitoring this document
+      return;
+    }
+
+    const documentMonitor = new DocumentMonitor(document, documentPath, this.db);
+    this.debugLog("#monitorDocument", documentMonitor.description);
+    this.monitoredDocuments[documentPath] = documentMonitor;
+  };
+
+  private unmonitorDocumentByPath = (documentPath: string) => {
+    const documentMonitor = this.monitoredDocuments[documentPath];
+    if (documentMonitor) {
+      this.debugLog("#unmonitorDocument", documentMonitor.description);
+      documentMonitor.off();
+      delete this.monitoredDocuments[documentPath];
+    }
+  };
+
+  private unmonitorAllDocuments() {
+    Object.keys(this.monitoredDocuments).forEach(documentPath => this.unmonitorDocumentByPath(documentPath));
+  }
+
+}

--- a/src/lib/db-listeners/index.test.ts
+++ b/src/lib/db-listeners/index.test.ts
@@ -1,11 +1,9 @@
 import { DBListeners } from ".";
-import { createDocumentModel } from "../../models/document/document";
-import { ProblemDocument } from "../../models/document/document-types";
 import { DocumentsModel } from "../../models/stores/documents";
 import { specAppConfig } from "../../models/stores/spec-app-config";
 import { createStores } from "../../models/stores/stores";
 import { UserModel } from "../../models/stores/user";
-import { DB, Monitor } from "../db";
+import { DB } from "../db";
 
 describe("DBListeners", () => {
   const stores = createStores({
@@ -15,8 +13,6 @@ describe("DBListeners", () => {
     user: UserModel.create({id: "1", portal: "example.com"})
   });
   const db = new DB();
-  const document = createDocumentModel({
-                    uid: "1", type: ProblemDocument, key: "doc-1", content: {} });
 
   beforeEach(async () => {
     await db.connect({appMode: "test", stores, dontStartListeners: true});
@@ -26,14 +22,10 @@ describe("DBListeners", () => {
     db.disconnect();
   });
 
-  it("no longer warns when monitoring the same document multiple times", () => {
+  it("can create all of the listeners", () => {
     const listeners = new DBListeners(db);
-    expect(listeners).toBeDefined();
-
-    listeners.monitorDocument(document, Monitor.Local);
-    jestSpyConsole("warn", mockConsole => {
-      listeners.monitorDocument(document, Monitor.Local);
-      expect(mockConsole).not.toHaveBeenCalled();
-    });
+    expect(listeners.isListening).toBeFalsy();
   });
+
+  // TODO: add more tests of these listeners
 });

--- a/src/lib/db-listeners/index.ts
+++ b/src/lib/db-listeners/index.ts
@@ -1,8 +1,7 @@
-import firebase from "firebase/app";
 import { makeObservable, observable, runInAction } from "mobx";
 import { onSnapshot } from "mobx-state-tree";
 
-import { DB, Monitor } from "../db";
+import { DB } from "../db";
 import { DBLatestGroupIdListener } from "./db-latest-group-id-listener";
 import { DBGroupsListener } from "./db-groups-listener";
 import { DBOtherDocumentsListener } from "./db-other-docs-listener";
@@ -10,17 +9,16 @@ import { DBProblemDocumentsListener } from "./db-problem-documents-listener";
 import { DBPublicationsListener } from "./db-publications-listener";
 import { DocumentModelType } from "../../models/document/document";
 import { LearningLogDocument, PersonalDocument } from "../../models/document/document-types";
-import { DatabaseType, DBDocument } from "../db-types";
+import { DatabaseType } from "../db-types";
 import { DBSupportsListener } from "./db-supports-listener";
 import { DBCommentsListener } from "./db-comments-listener";
 import { DBStarsListener } from "./db-stars-listener";
 import { BaseListener } from "./base-listener";
+import { DBDocumentContentListener } from "./db-doc-content-listener";
 
 export class DBListeners extends BaseListener {
   @observable public isListening = false;
   private db: DB;
-
-  private firebaseUnlisteners: Record<string, () => void> = {};
 
   private latestGroupIdListener: DBLatestGroupIdListener;
   private groupsListener: DBGroupsListener;
@@ -31,6 +29,7 @@ export class DBListeners extends BaseListener {
   private supportsListener: DBSupportsListener;
   private commentsListener: DBCommentsListener;
   private starsListener: DBStarsListener;
+  private documentContentListener: DBDocumentContentListener;
 
   constructor(db: DB) {
     super("DBListeners");
@@ -45,6 +44,7 @@ export class DBListeners extends BaseListener {
     this.supportsListener = new DBSupportsListener(db);
     this.commentsListener = new DBCommentsListener(db);
     this.starsListener = new DBStarsListener(db);
+    this.documentContentListener = new DBDocumentContentListener(db);
   }
 
   public async start() {
@@ -62,7 +62,8 @@ export class DBListeners extends BaseListener {
     // start listeners that depend on documents
     await Promise.all([
       this.commentsListener.start(),
-      this.starsListener.start()
+      this.starsListener.start(),
+      this.documentContentListener.start()
     ]);
 
     runInAction(() => this.isListening = true);
@@ -71,8 +72,7 @@ export class DBListeners extends BaseListener {
   public stop() {
     runInAction(() => this.isListening = false);
 
-    this.stopFirebaseListeners();
-
+    this.documentContentListener.stop();
     this.starsListener.stop();
     this.commentsListener.stop();
     this.supportsListener.stop();
@@ -83,20 +83,6 @@ export class DBListeners extends BaseListener {
     this.groupsListener.stop();
     this.latestGroupIdListener.stop();
   }
-
-  private stopFirebaseListeners() {
-    Object.values(this.firebaseUnlisteners).forEach(unlistener => unlistener?.());
-  }
-
-  public monitorDocument = (document: DocumentModelType, monitor: Monitor) => {
-    this.debugLog("#monitorDocument", `document: ${document.key} type: ${document.type} monitor: ${monitor}`);
-    this.monitorDocumentRef(document, monitor);
-  };
-
-  public unmonitorDocument = (document: DocumentModelType, monitor: Monitor) => {
-    this.debugLog("#unmonitorDocument", `document: ${document.key} type: ${document.type} monitor: ${monitor}`);
-    this.unmonitorDocumentRef(document);
-  };
 
   // sync local support document properties to firebase (teachers only)
   // TODO: move this to client-side hook as was done with other document monitoring
@@ -115,40 +101,6 @@ export class DBListeners extends BaseListener {
       // synchronize document property changes to firestore
       onSnapshot(document.properties, properties => docRef.update({ properties }));
     }
-  };
-
-  private monitorDocumentRef = (document: DocumentModelType, monitor: Monitor) => {
-    const { user, documents } = this.db.stores;
-    const documentKey = document.key;
-    const documentPath = this.db.firebase.getUserDocumentPath(user, documentKey, document.uid);
-    const documentRef = this.db.firebase.ref(documentPath);
-
-    if (monitor !== Monitor.Remote) {
-      return;
-    }
-
-    const snapshotHandler = (snapshot: firebase.database.DataSnapshot) => {
-      if (snapshot?.val()) {
-        const updatedDoc: DBDocument = snapshot.val();
-        const updatedContent = this.db.parseDocumentContent(updatedDoc);
-        const documentModel = documents.getDocument(documentKey);
-        documentModel?.setContent(updatedContent || {});
-      }
-    };
-
-    // remove any previous listener
-    this.firebaseUnlisteners[documentPath]?.();
-    // install the new listener
-    documentRef.on("value", snapshotHandler);
-    // register the cleanup function
-    this.firebaseUnlisteners[documentPath] = () => documentRef.off("value", snapshotHandler);
-  };
-
-  private unmonitorDocumentRef = (document: DocumentModelType) => {
-    const { user } = this.db.stores;
-    const documentPath = this.db.firebase.getUserDocumentPath(user, document.key, document.uid);
-    this.firebaseUnlisteners[documentPath]?.();
-    if (this.firebaseUnlisteners[documentPath]) delete this.firebaseUnlisteners[documentPath];
   };
 
 }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -37,12 +37,6 @@ import { safeJsonParse } from "../utilities/js-utils";
 import { urlParams } from "../utilities/url-params";
 import { firebaseConfig } from "./firebase-config";
 
-export enum Monitor {
-  None = "None",
-  Local = "Local",
-  Remote = "Remote",
-}
-
 export type IDBConnectOptions = IDBAuthConnectOptions | IDBNonAuthConnectOptions;
 export interface IDBBaseConnectOptions {
   stores: IStores;
@@ -721,22 +715,16 @@ export class DB {
 
   public createDocumentModelFromProblemMetadata(
           type: ProblemOrPlanningDocumentType, userId: string,
-          metadata: DBOfferingUserProblemDocument, monitor: Monitor) {
+          metadata: DBOfferingUserProblemDocument) {
     const {documentKey} = metadata;
     const group = this.stores.groups.groupForUser(userId);
     return this.openDocument({
-        type,
-        userId,
-        groupId: group?.id,
-        documentKey,
-        visibility: metadata.visibility
-      })
-      .then((document) => {
-        if (monitor !== Monitor.None) {
-          this.listeners.monitorDocument(document, monitor);
-        }
-        return document;
-      });
+      type,
+      userId,
+      groupId: group?.id,
+      documentKey,
+      visibility: metadata.visibility
+    });
   }
 
   public updateDocumentFromProblemDocument(document: DocumentModelType,
@@ -749,11 +737,7 @@ export class DB {
     const {title, properties, self: {uid, documentKey}} = dbDocument;
     const group = this.stores.groups.groupForUser(uid);
     const groupId = group && group.id;
-    return this.openDocument({type, userId: uid, documentKey, groupId, title, properties})
-      .then((documentModel) => {
-        this.listeners.monitorDocument(documentModel, Monitor.Local);
-        return documentModel;
-      });
+    return this.openDocument({type, userId: uid, documentKey, groupId, title, properties});
   }
 
   // handles published personal documents and published learning logs


### PR DESCRIPTION
This uses a MobX autorun to monitor both the documents and groups
This approach consolidates the logic for deciding which documents
to monitor into one place instead of having it in both the
problem-documents-listener and groups-listener.

It also reduces the firebase listener churn that happening before.
Listeners would be added and then removed and then added again.