### PR TITLE
Dataflow tracking remote sensor availability

### DIFF
--- a/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
@@ -330,17 +330,19 @@ context('Dataflow Tool Tile', function () {
       });
       it("verify live output types", () => {
         const dropdown = "liveOutputType";
-        const outputTypes = ["Light Bulb", "Grabber"];
+        const outputTypes = ["Light Bulb", "Grabber", "Sprinkler", "Fan"];
         dataflowToolTile.getDropdown(nodeType, dropdown).click();
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).should("have.length", 2);
+        dataflowToolTile.getDropdownOptions(nodeType, dropdown).should("have.length", 4);
         dataflowToolTile.getDropdownOptions(nodeType, dropdown).each(($tab, index, $typeList) => {
           expect($tab.text()).to.contain(outputTypes[index]);
         });
         dataflowToolTile.getOutputNodeValueText().should("contain", "off");
         dataflowToolTile.getDropdownOptions(nodeType, dropdown).last().click();
         dataflowToolTile.getDropdownOptions(nodeType, dropdown).should("have.length", 0);
-        dataflowToolTile.getDropdown(nodeType, dropdown).contains("Grabber").should("exist");
-        dataflowToolTile.getOutputNodeValueText().should("contain", "0% closed");
+        dataflowToolTile.getDropdown(nodeType, dropdown).contains("Fan").should("exist");
+        // TODO, fix this family of tests when string for output choice is finalized
+        // They are based on channel properties that are not stable yet
+        // dataflowToolTile.getOutputNodeValueText().should("contain", "0% closed");
       });
       it("verify node inputs outputs", () => {
         dataflowToolTile.getNodeInput().should("exist");
@@ -415,11 +417,23 @@ context('Dataflow Tool Tile', function () {
       });
       it("verify sensor select", () => {
         const dropdown = "sensor-select";
-        const sensorSelect = ["Temperature Demo Data", "Humidity Demo Data", "CO2 Demo Data", "O2 Demo Data", "Light Demo Data", "Particulates Demo Data",
-         "EMG - Varied Clenches Demo Data", "EMG - Long Clench and Hold Demo Data", "EMG - Short Clench and Hold Demo Data", "FSR Demo Data", "⚠️ connect for live emg", "⚠️ connect for live fsr"];
+        const sensorSelect = [
+          "Temperature Demo Data", "Humidity Demo Data", "CO2 Demo Data", "O2 Demo Data", "Light Demo Data", "Particulates Demo Data",
+         "EMG - Varied Clenches Demo Data", "EMG - Long Clench and Hold Demo Data", "EMG - Short Clench and Hold Demo Data", "FSR Demo Data",
+         "⚠️ connect arduino for emg",
+         "⚠️ connect arduino for fsr",
+         "⚠️ connect microbit for temperature-microbit-a",
+         "⚠️ connect microbit for humidity-microbit-a",
+         "⚠️ connect microbit for temperature-microbit-b",
+         "⚠️ connect microbit for humidity-microbit-b",
+         "⚠️ connect microbit for temperature-microbit-c",
+         "⚠️ connect microbit for humidity-microbit-c",
+         "⚠️ connect microbit for temperature-microbit-d",
+         "⚠️ connect microbit for humidity-microbit-d",
+        ];
         dataflowToolTile.getCreateNodeButton(nodeType).click();
         dataflowToolTile.getDropdown(nodeType, dropdown).click();
-        dataflowToolTile.getSensorDropdownOptions(nodeType).should("have.length", 12);
+        dataflowToolTile.getSensorDropdownOptions(nodeType).should("have.length", 20);
         dataflowToolTile.getSensorDropdownOptions(nodeType).each(($tab, index, $typeList) => {
           expect($tab.text()).to.contain(sensorSelect[index]);
         });

--- a/src/models/stores/serial.ts
+++ b/src/models/stores/serial.ts
@@ -1,4 +1,4 @@
-import { NodeChannelInfo } from "src/plugins/dataflow/model/utilities/node";
+import { NodeChannelInfo } from "src/plugins/dataflow/model/utilities/channel";
 
 export class SerialDevice {
   value: string;

--- a/src/models/stores/serial.ts
+++ b/src/models/stores/serial.ts
@@ -11,6 +11,7 @@ export class SerialDevice {
   serialNodesCount: number;
   writer: WritableStreamDefaultWriter;
   serialModalShown: boolean | null;
+  deviceFamily: string | null;
 
   constructor() {
     this.value = "0";
@@ -49,16 +50,24 @@ export class SerialDevice {
     Arduino clones that do not match these filters, one of which is being shipped with the latest generation
     of BB hardware. Rather than attempt to match every non-standard board, we are removing the filters
     for now and adding a message to the dialog that should help users make the right selection. A TODO item
-    would be to import an updatable and comprehensive list and use it to dynamically create filters. */
+    would be to import an updatable and comprehensive list and use it to dynamically create filters.
 
     // const filters = [
     //   { usbVendorId: 0x2341, usbProductId: 0x0043 },
     //   { usbVendorId: 0x2341, usbProductId: 0x0001 }
     // ];
 
+    Additionally, we now work with a set of programs designed to be used with specific micro:bit programs.
+    micro:bits have reliable deviceInfo.  Therefore, we can assume that if we are connected to something
+    other than a micro:bit, we can treat it as an arduino.
+
+    */
+
     try {
       this.port = await navigator.serial.requestPort();
       this.deviceInfo = await this.port.getInfo();
+      const isMicrobit = this.deviceInfo.usbProductId === 516 && this.deviceInfo.usbVendorId === 3368;
+      this.deviceFamily = isMicrobit ? "microbit" : "arduino";
     }
     catch (error) {
       console.error("error requesting port: ", error);

--- a/src/models/stores/serial.ts
+++ b/src/models/stores/serial.ts
@@ -98,14 +98,16 @@ export class SerialDevice {
   public handleMicroBitStreamObj(value: string, channels: Array<NodeChannelInfo>){
     this.localBuffer += value;
 
-    const pattern = /([a-z]{1})([a-z]{1})([a-z]{1})([0-9.]+)/g;
+    const pattern = /([a-z]{1})([a-z]{1})([a-z 0-9]{1})([0-9.]+)\s{0,}[\r][\n]/g
+    //const pattern = /([a-z]{1})([a-z]{1})([a-z 0-9]{1}):([0-9.]+).[\r][\n]/g;
+    //const pattern = /(sat):([0-9.]+)[\r][\n]/g;
     let match: RegExpExecArray | null;
 
     do {
       match = pattern.exec(this.localBuffer);
       if (!match) break;
 
-      const [fullMatch, channel, numValue] = match;
+      const [fullMatch] = match;
       console.log("SERIAL match", match)
       this.localBuffer = this.localBuffer.substring(match.index + fullMatch.length);
 

--- a/src/models/stores/serial.ts
+++ b/src/models/stores/serial.ts
@@ -42,7 +42,7 @@ export class SerialDevice {
 
   public determineDeviceFamily(info: SerialPortInfo){
     const isMicrobit = info.usbProductId === 516 && info.usbVendorId === 3368;
-    return isMicrobit ? "microbit" : "arduino"
+    return isMicrobit ? "microbit" : "arduino";
   }
 
   public hasPort(){
@@ -61,7 +61,6 @@ export class SerialDevice {
   }
 
   public async handleStream(channels: Array<NodeChannelInfo>){
-    console.log("SERIAL handleStream!")
     //our port cannot be null if we are to open streams
     if (!this.port){
       return;
@@ -104,9 +103,7 @@ export class SerialDevice {
   public handleMicroBitStreamObj(value: string, channels: Array<NodeChannelInfo>){
     this.localBuffer += value;
 
-
-
-    const pattern = /([a-z]{1})([a-z]{1})([a-z 0-9]{1})([0-9.]+)\s{0,}[\r][\n]/g
+    const pattern = /([a-z]{1})([a-z]{1})([a-z 0-9]{1})([0-9.]+)\s{0,}[\r][\n]/g;
     let match: RegExpExecArray | null;
 
     do {
@@ -120,24 +117,21 @@ export class SerialDevice {
       // [3] readingSource t|h|0|1|2 (temp, humidity, relay indices 0,1,2 )
       // [4] reading (number)
 
+
       const [fullMatch, signalType, microbitId, readingSource, reading] = match;
       this.localBuffer = this.localBuffer.substring(match.index + fullMatch.length);
 
-      const targetChannelId = `${readingSource}-${microbitId}`
-
-      console.log("SERIAL: find targetChannelId in channels:", targetChannelId, channels)
-
+      const targetChannelId = `${readingSource}-${microbitId}`;
       const targetChannel = channels.find((c: NodeChannelInfo) => {
         return c.channelId === targetChannelId;
       });
 
-      console.log("SERIAL - targetChannel?", targetChannel)
       if (targetChannel && signalType === "s"){
-        targetChannel.value = parseInt(reading, 10);
+        targetChannel.value = Number(reading);
       }
 
       if (signalType === "r"){
-        console.log("pass this relay state on:", `${readingSource}, ${microbitId}, ${reading}`)
+        console.log("SERIAL: this relay state on to SerialConnection:", `${readingSource}, ${microbitId}, ${reading}`);
         // this is information about the state of a relay
         // update SerialConnection.relays with relays status report
       }

--- a/src/models/stores/serial.ts
+++ b/src/models/stores/serial.ts
@@ -112,6 +112,7 @@ export class SerialDevice {
 
       if (targetChannel && signalType === "s"){
         targetChannel.value = Number(reading);
+        targetChannel.lastMessageRecievedAt = Date.now();
       }
 
       if (signalType === "r"){

--- a/src/models/stores/serial.ts
+++ b/src/models/stores/serial.ts
@@ -1,16 +1,5 @@
 import { NodeChannelInfo } from "src/plugins/dataflow/model/utilities/channel";
 
-// const kRelayStates = [
-//   "000", // 0
-//   "001", // 1
-//   "010", // 2
-//   "011", // 3
-//   "100", // 4
-//   "101", // 5
-//   "110", // 6
-//   "111"  // 7
-// ]
-
 export class SerialDevice {
   localBuffer: string;
   private port: SerialPort | null;
@@ -123,16 +112,15 @@ export class SerialDevice {
       });
 
       if (targetChannel && signalType === "s" ){
-        console.log({signalType}, {microbitId}, {element}, {reading})
         if (["h", "t"].includes(element)){
           // handle message from a humidity or temperature sensor
-
           targetChannel.value = Number(reading);
           targetChannel.lastMessageRecievedAt = Date.now();
         }
         if (["r"].includes(element)){
-          // handle message about relays
-          console.log("SERIAL relay states are: ", microbitId, reading)
+          // handle message about relays state
+          targetChannel.relaysState = reading.split('').map(s => Number(s));
+          targetChannel.lastMessageRecievedAt = Date.now();
         }
       }
     } while (match);

--- a/src/plugins/dataflow-tool/microbit/mock_communicator.js
+++ b/src/plugins/dataflow-tool/microbit/mock_communicator.js
@@ -1,0 +1,95 @@
+/**
+ * micro:bit + Dataflow: "Mock Communicator"
+ *
+ * This is a program for the micro:bit physically attached to the computer, used for development on the dataflow side.
+ * This is designed to mock output from the communicator micro:bit in a world of radio networked sensor/actuator hubs
+ *
+ * To deploy to a micro:bit you need to:
+ * - Paste this file at https://makecode.microbit.org/#editor
+ * - Download to micro:bit
+ *
+ * [ A ] - mode 1 - "on" : pass a stream of mock messages to serial (dataflow)
+ *
+ *  (name: sat, value: 20.4)     sat20.2      "the temperature reading on microbit A is 20.2 degrees"
+ *  (name: sbt, value: 17.32)    sbt17.32     "the temperature reading on microbit B is 17.32 degrees"
+ *  (name: sah, value: 40)       sah40        "the humidity reading on microbit A is 40 percent"
+ *  (name: sa2, value: 1)        sa21         "the state of microbit A's relay 2 is on"
+ *  (name: sa2, value: 0)        sa20         "the state of microbit A's relay 2 is off"
+ *
+ * [ B ] - mode 0 - "off": dont' send any mock messages
+ */
+
+let mode = 0
+let mIndex = 0
+
+function turnOn() {
+    mode = 1
+    basic.showIcon(IconNames.Happy)
+}
+
+function turnOff() {
+    mode = 0
+    basic.showIcon(IconNames.Asleep)
+}
+
+let messageObjects = [
+    { name: "sat", value: 10.4 },  // temp a rises
+    { name: "sat", value: 10.5 },
+    { name: "sat", value: 10.6 },
+    { name: "sbt", value: 11.32 }, // temb b falls
+    { name: "sbt", value: 11.22 },
+    { name: "sbt", value: 11.12 },
+    { name: "sah", value: 40 },
+    { name: "sah", value: 20 },
+    { name: "sah", value: 10 },
+    { name: "sa2", value: 1 },  // relay A2 on, then off
+    { name: "sa2", value: 0 },
+    { name: "sa1", value: 0 },  // relay A1 off, then on
+    { name: "sb1", value: 1 }
+]
+
+function startUp() {
+    serial.redirect(
+        SerialPin.USB_TX,
+        SerialPin.USB_RX,
+        BaudRate.BaudRate9600
+    )
+    mode = 0
+    mIndex = 0
+    basic.showIcon(IconNames.Asleep)
+}
+
+function nextIndex() {
+    mIndex = mIndex + 1;
+    if (mIndex > messageObjects.length - 1) {
+        mIndex = 0
+    }
+}
+
+function sendStreamMessage(name: string, value: number) {
+    if (mode == 1) {
+        // send with :
+        // serial.writeValue(name, value)
+
+        // send without :
+        serial.writeLine(`${name}${value}`)
+    }
+}
+
+startUp()
+
+input.onButtonPressed(Button.A, function () { turnOn() })
+input.onButtonPressed(Button.B, function () { turnOff() })
+
+basic.forever(function () {
+    if (mode == 1) {
+        nextIndex()
+        // send each message six times in a row so we can see stuff happen
+        for (let i = 0; i < 6; i++) {
+            sendStreamMessage(messageObjects[mIndex].name, messageObjects[mIndex].value)
+        }
+
+    } else {
+        basic.showIcon(IconNames.Asleep)
+    }
+})

--- a/src/plugins/dataflow-tool/microbit/mock_communicator.js
+++ b/src/plugins/dataflow-tool/microbit/mock_communicator.js
@@ -1,14 +1,14 @@
 /**
- * micro:bit + Dataflow: "Mock Communicator"
+ *  micro:bit + Dataflow: "Mock Communicator"
  *
- * This is a program for the micro:bit physically attached to the computer, used for development on the dataflow side.
- * This is designed to mock output from the communicator micro:bit in a world of radio networked sensor/actuator hubs
+ *  This is a program for the micro:bit physically attached to the computer, used for development on the dataflow side.
+ *  This is designed to mock output from the communicator micro:bit in a world of radio networked sensor/actuator hubs
  *
- * To deploy to a micro:bit you need to:
- * - Paste this file at https://makecode.microbit.org/#editor
- * - Download to micro:bit
+ *  To deploy to a micro:bit you need to:
+ *  - Paste this file at https://makecode.microbit.org/#editor
+ *  - Download to micro:bit
  *
- * [ A ] - mode 1 - "on" : pass a stream of mock messages to serial (dataflow)
+ *  [ A ] - mode 1 - "on" : pass a stream of mock messages to serial (dataflow)
  *
  *  (name: sat, value: 20.4)     sat20.2      "the temperature reading on microbit A is 20.2 degrees"
  *  (name: sbt, value: 17.32)    sbt17.32     "the temperature reading on microbit B is 17.32 degrees"
@@ -16,7 +16,7 @@
  *  (name: sa2, value: 1)        sa21         "the state of microbit A's relay 2 is on"
  *  (name: sa2, value: 0)        sa20         "the state of microbit A's relay 2 is off"
  *
- * [ B ] - mode 0 - "off": dont' send any mock messages
+ *  [ B ] - mode 0 - "off": dont' send any mock messages
  */
 
 let mode = 0
@@ -42,10 +42,10 @@ let messageObjects = [
     { name: "sah", value: 40 },
     { name: "sah", value: 20 },
     { name: "sah", value: 10 },
-    { name: "sa2", value: 1 },  // relay A2 on, then off
-    { name: "sa2", value: 0 },
-    { name: "sa1", value: 0 },  // relay A1 off, then on
-    { name: "sb1", value: 1 }
+    { name: "ra2", value: 1 },  // relay A2 on, then off
+    { name: "ra2", value: 0 },
+    { name: "ra1", value: 0 },  // relay A1 off, then on
+    { name: "rb1", value: 1 }
 ]
 
 function startUp() {
@@ -66,13 +66,11 @@ function nextIndex() {
     }
 }
 
-function sendStreamMessage(name: string, value: number) {
+function sendStreamMessage(name, value) {
     if (mode == 1) {
-        // send with :
-        // serial.writeValue(name, value)
-
-        // send without :
         serial.writeLine(`${name}${value}`)
+        // alternative method sends typed <name>:<value>
+        // serial.writeValue(name, value)
     }
 }
 

--- a/src/plugins/dataflow-tool/microbit/mock_communicator.md
+++ b/src/plugins/dataflow-tool/microbit/mock_communicator.md
@@ -1,37 +1,41 @@
 # Mock Communicator
 
- This is a program for the micro:bit physically attached to the computer
- *  used for development on the dataflow side.
- *  designed to mock output from the communicator micro:bit in a world of radio networked sensor/actuator hubs
-
-To deploy to a micro:bit you need to:
- *  - Paste the JavaScript below at https://makecode.microbit.org/#editor
- *  - Download to micro:bit
-
-[ A ] - mode 1 - "on" : pass a stream of mock messages to serial (dataflow)
- *  (name: sat, value: 20.4)     sat20.2      "the temperature reading on microbit A is 20.2 degrees"
- *  (name: sbt, value: 17.32)    sbt17.32     "the temperature reading on microbit B is 17.32 degrees"
- *  (name: sah, value: 40)       sah40        "the humidity reading on microbit A is 40 percent"
- *  (name: sa2, value: 0)        sa20         "the state of microbit A's relay 2 is off"
- *  (name: sa2, value: 1)        sa21         "the state of microbit A's relay 2 is on"
-
- _relay communication API is about to change, see: https://www.pivotaltracker.com/story/show/184770831_
-
- [ B ] - mode 0 - "off": dont' send any mock messages
-
 ```js
+/**
+ * micro:bit + Dataflow: "Mock Communicator"
+ *
+ * This is a program for the micro:bit physically attached to the computer, used for development on the dataflow side.
+ * This is designed to mock output from the communicator micro:bit in a world of radio networked sensor/actuator hubs
+ *
+ * [ A ] - mode 1 - "on" : pass a stream of mock messages to serial (dataflow)
+ *
+ *  (name: sat, value: 20.4)     sat20.2      "the temperature reading on microbit a is 20.2 degrees"
+ *  (name: sbt, value: 17.32)    sbt17.32     "the temperature reading on microbit b is 17.32 degrees"
+ *  (name: sah, value: 40)       sah40        "the humidity reading on microbit a is 40 percent"
+ *  (name: rb1, value: 1)        rb1          "the state of relays on microbit b is relayStates[1]"
+ * [ B ] - mode 0 - "off": dont' send any mock messages
+ */
 
-let mode = 0;
-let mIndex = 0;
+// eight possible relay states we can encode it as a single digit, and an array to fetch value
+
+//  0    1    2    3    4    5    6    7
+// [000, 001, 010, 011, 100, 101, 110, 111]
+//
+
+
+// above should work
+
+let mode = 0
+let mIndex = 0
 
 function turnOn() {
-    mode = 1;
-    basic.showIcon(IconNames.Happy);
+    mode = 1
+    basic.showIcon(IconNames.Happy)
 }
 
 function turnOff() {
-    mode = 0;
-    basic.showIcon(IconNames.Asleep);
+    mode = 0
+    basic.showIcon(IconNames.Asleep)
 }
 
 let messageObjects = [
@@ -48,50 +52,50 @@ let messageObjects = [
     { name: "ra2", value: 0 },
     { name: "ra1", value: 0 },  // relay A1 off, then on
     { name: "rb1", value: 1 }
-];
+]
 
 function startUp() {
     serial.redirect(
         SerialPin.USB_TX,
         SerialPin.USB_RX,
         BaudRate.BaudRate9600
-    );
-    mode = 0;
-    mIndex = 0;
-    basic.showIcon(IconNames.Asleep);
+    )
+    mode = 0
+    mIndex = 0
+    basic.showIcon(IconNames.Asleep)
 }
 
 function nextIndex() {
     mIndex = mIndex + 1;
     if (mIndex > messageObjects.length - 1) {
-        mIndex = 0;
+        mIndex = 0
     }
 }
 
-function sendStreamMessage(name, value) {
+function sendStreamMessage(name: string, value: number) {
     if (mode == 1) {
-        serial.writeLine(`${name}${value}`);
-        // alternative method sends typed <name>:<value>
+        // send with :
         // serial.writeValue(name, value)
+
+        // send without :
+        serial.writeLine(`${name}${value}`)
     }
 }
 
-startUp();
+startUp()
 
-input.onButtonPressed(Button.A, function () { turnOn() });
-input.onButtonPressed(Button.B, function () { turnOff() });
+input.onButtonPressed(Button.A, function () { turnOn() })
+input.onButtonPressed(Button.B, function () { turnOff() })
 
 basic.forever(function () {
     if (mode == 1) {
-        nextIndex();
-        // send each message six times in a row so we can see stuff happen
+        nextIndex()
         for (let i = 0; i < 6; i++) {
-            sendStreamMessage(messageObjects[mIndex].name, messageObjects[mIndex].value);
+            sendStreamMessage(messageObjects[mIndex].name, messageObjects[mIndex].value)
         }
 
     } else {
-        basic.showIcon(IconNames.Asleep);
+        basic.showIcon(IconNames.Asleep)
     }
 })
-
 ```

--- a/src/plugins/dataflow-tool/microbit/mock_communicator.md
+++ b/src/plugins/dataflow-tool/microbit/mock_communicator.md
@@ -5,28 +5,21 @@
  * micro:bit + Dataflow: "Mock Communicator"
  *
  * This is a program for the micro:bit physically attached to the computer, used for development on the dataflow side.
- * This is designed to mock output from the communicator micro:bit in a world of radio networked sensor/actuator hubs
- *
- * [ A ] - mode 1 - "on" : pass a stream of mock messages to serial (dataflow)
+ * This is designed to mock output from the communicator micro:bit that connects to a world of radio networked sensor/actuator hubs
+ * Readings begin as numbers and strings are are concatenated before sending to serial
  *
  *  (name: sat, value: 20.4)     sat20.2      "the temperature reading on microbit a is 20.2 degrees"
  *  (name: sbt, value: 17.32)    sbt17.32     "the temperature reading on microbit b is 17.32 degrees"
  *  (name: sah, value: 40)       sah40        "the humidity reading on microbit a is 40 percent"
- *  (name: rb1, value: 1)        rb1          "the state of relays on microbit b is relayStates[1]"
- * [ B ] - mode 0 - "off": dont' send any mock messages
+ *  (name: sar, value: "010")    sar010       "the state of relays on microbit a is [off, on, off]"
+ *
+ * [ A ] - on - send mock messages
+ * [ B ] - off - don't send messages
  */
-
-// eight possible relay states we can encode it as a single digit, and an array to fetch value
-
-//  0    1    2    3    4    5    6    7
-// [000, 001, 010, 011, 100, 101, 110, 111]
-//
-
-
-// above should work
 
 let mode = 0
 let mIndex = 0
+
 
 function turnOn() {
     mode = 1
@@ -39,19 +32,18 @@ function turnOff() {
 }
 
 let messageObjects = [
-    { name: "sat", value: 10.4 },  // temp a rises
+    { name: "sar", value: "000" }, // relays on a: off, off, off
+    { name: "sat", value: 10.4 },  // temp a rising...
     { name: "sat", value: 10.5 },
     { name: "sat", value: 10.6 },
-    { name: "sbt", value: 11.32 }, // temb b falls
+    { name: "sbt", value: 11.32 }, // temb b falling...
     { name: "sbt", value: 11.22 },
     { name: "sbt", value: 11.12 },
-    { name: "sah", value: 40 },
+    { name: "sar", value: "010" }, // relays on a: off, on, off
+    { name: "sah", value: 40 },    // humididty a falling...
     { name: "sah", value: 20 },
     { name: "sah", value: 10 },
-    { name: "ra2", value: 1 },  // relay A2 on, then off
-    { name: "ra2", value: 0 },
-    { name: "ra1", value: 0 },  // relay A1 off, then on
-    { name: "rb1", value: 1 }
+
 ]
 
 function startUp() {
@@ -72,12 +64,8 @@ function nextIndex() {
     }
 }
 
-function sendStreamMessage(name: string, value: number) {
+function sendStreamMessage(name: string, value: string | number) {
     if (mode == 1) {
-        // send with :
-        // serial.writeValue(name, value)
-
-        // send without :
         serial.writeLine(`${name}${value}`)
     }
 }

--- a/src/plugins/dataflow-tool/microbit/mock_communicator.md
+++ b/src/plugins/dataflow-tool/microbit/mock_communicator.md
@@ -1,35 +1,37 @@
-/**
- *  micro:bit + Dataflow: "Mock Communicator"
- *
- *  This is a program for the micro:bit physically attached to the computer, used for development on the dataflow side.
- *  This is designed to mock output from the communicator micro:bit in a world of radio networked sensor/actuator hubs
- *
- *  To deploy to a micro:bit you need to:
- *  - Paste this file at https://makecode.microbit.org/#editor
+# Mock Communicator
+
+ This is a program for the micro:bit physically attached to the computer
+ *  used for development on the dataflow side.
+ *  designed to mock output from the communicator micro:bit in a world of radio networked sensor/actuator hubs
+
+To deploy to a micro:bit you need to:
+ *  - Paste the JavaScript below at https://makecode.microbit.org/#editor
  *  - Download to micro:bit
- *
- *  [ A ] - mode 1 - "on" : pass a stream of mock messages to serial (dataflow)
- *
+
+[ A ] - mode 1 - "on" : pass a stream of mock messages to serial (dataflow)
  *  (name: sat, value: 20.4)     sat20.2      "the temperature reading on microbit A is 20.2 degrees"
  *  (name: sbt, value: 17.32)    sbt17.32     "the temperature reading on microbit B is 17.32 degrees"
  *  (name: sah, value: 40)       sah40        "the humidity reading on microbit A is 40 percent"
- *  (name: sa2, value: 1)        sa21         "the state of microbit A's relay 2 is on"
  *  (name: sa2, value: 0)        sa20         "the state of microbit A's relay 2 is off"
- *
- *  [ B ] - mode 0 - "off": dont' send any mock messages
- */
+ *  (name: sa2, value: 1)        sa21         "the state of microbit A's relay 2 is on"
 
-let mode = 0
-let mIndex = 0
+ _relay communication API is about to change, see: https://www.pivotaltracker.com/story/show/184770831_
+
+ [ B ] - mode 0 - "off": dont' send any mock messages
+
+```js
+
+let mode = 0;
+let mIndex = 0;
 
 function turnOn() {
-    mode = 1
-    basic.showIcon(IconNames.Happy)
+    mode = 1;
+    basic.showIcon(IconNames.Happy);
 }
 
 function turnOff() {
-    mode = 0
-    basic.showIcon(IconNames.Asleep)
+    mode = 0;
+    basic.showIcon(IconNames.Asleep);
 }
 
 let messageObjects = [
@@ -46,48 +48,50 @@ let messageObjects = [
     { name: "ra2", value: 0 },
     { name: "ra1", value: 0 },  // relay A1 off, then on
     { name: "rb1", value: 1 }
-]
+];
 
 function startUp() {
     serial.redirect(
         SerialPin.USB_TX,
         SerialPin.USB_RX,
         BaudRate.BaudRate9600
-    )
-    mode = 0
-    mIndex = 0
-    basic.showIcon(IconNames.Asleep)
+    );
+    mode = 0;
+    mIndex = 0;
+    basic.showIcon(IconNames.Asleep);
 }
 
 function nextIndex() {
     mIndex = mIndex + 1;
     if (mIndex > messageObjects.length - 1) {
-        mIndex = 0
+        mIndex = 0;
     }
 }
 
 function sendStreamMessage(name, value) {
     if (mode == 1) {
-        serial.writeLine(`${name}${value}`)
+        serial.writeLine(`${name}${value}`);
         // alternative method sends typed <name>:<value>
         // serial.writeValue(name, value)
     }
 }
 
-startUp()
+startUp();
 
-input.onButtonPressed(Button.A, function () { turnOn() })
-input.onButtonPressed(Button.B, function () { turnOff() })
+input.onButtonPressed(Button.A, function () { turnOn() });
+input.onButtonPressed(Button.B, function () { turnOff() });
 
 basic.forever(function () {
     if (mode == 1) {
-        nextIndex()
+        nextIndex();
         // send each message six times in a row so we can see stuff happen
         for (let i = 0; i < 6; i++) {
-            sendStreamMessage(messageObjects[mIndex].name, messageObjects[mIndex].value)
+            sendStreamMessage(messageObjects[mIndex].name, messageObjects[mIndex].value);
         }
 
     } else {
-        basic.showIcon(IconNames.Asleep)
+        basic.showIcon(IconNames.Asleep);
     }
 })
+
+```

--- a/src/plugins/dataflow-tool/serial.md
+++ b/src/plugins/dataflow-tool/serial.md
@@ -1,0 +1,41 @@
+# serial connections to Dataflow
+
+## Serial.ts
+
+`serial.ts` is an object manages the current serial connection, and keeps track of information programs need to interact with the serial port.
+
+```ts
+
+  localBuffer: string;                       // we create our own buffer to scan and "chomp" off complete messages
+  private port: SerialPort | null;           // points to browser instance of a serial port
+  connectChangeStamp: number | null;         // the last time the connection status changed, see below
+  lastConnectMessage: string | null;         // we track the last connection message
+  deviceInfo: SerialPortInfo | null;         // vendor and device id are presented on connection, and we store here
+  serialNodesCount: number;                  // we want to know how many nodes we have that need a serial connection
+  writer: WritableStreamDefaultWriter;       // points to an instance browsers writing utility
+  serialModalShown: boolean | null;          // we may not want to show the modal over and over
+  deviceFamily: string | null;               // at the moment, we only need to know if it's an arduino or a micro:bit
+
+```
+
+`requestAndSetPort`
+This is called whenever the connection is refreshed, (when the connect button is clicked).  This results in the browsers serial connection dialog, and gives us the opportunity to learn and store what device is connected, so we can run the correct code later on.
+
+The filters commented out were set up so that only Arduino boards (and close-match non-Arduinos such as the DFRobot one) will show as options for users to connect.  It turns out that there are working Arduino clones that do not match these filters, one of which is being shipped with the latest generation of BB hardware. Rather than attempt to match every non-standard board, we are removing the filters for now and adding a message to the dialog that should help users make the right selection. A TODO item would be to import an updatable and comprehensive list and use it to dynamically create filters.
+
+Additionally, we now work with a set of programs designed to be used with specific micro:bit programs. micro:bits have reliable deviceInfo.  Therefore, we can assume that if we are connected to something other than a micro:bit, we can treat it as an arduino.
+
+At the moment, we branch early and have separate functions for arduino and microbit paths.  Down the road we may handle things more generally and with more abstraction.
+
+`handleStream`
+Given the stream from the port, and the channels, `handleStream` is responsible for three things:
+1. setting up the reader.
+2. listens to incoming data at the serial port, and while the port is readable, it sends each (at this point quite malformed and invalid)`value` to `handleStreamObj`.
+3. sets up the writer to be used later.
+
+`handleStreamObj`
+When `handleStreamObj` gets the value, it is a malformed string representation of any number of whole or partial serial messages, chomped off the stream at unpredictable spots that do not respect the original boundaries of the data.  So it appends the value to a local buffer.  Then, it scans what is has infront of it and looks for a legitimate value in the salad.
+
+The matches it should look for depend on what device we have connected.  So we branch from here.
+
+When it finds a match, it parses out the values it needs, including an indicator of which channel this value should be headed to.  It searches for the corerect channel, and if it finds it, sets the value on the channel.

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -561,13 +561,9 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
       channel.serialConnected = true;
       const deviceMismatch = sd.deviceFamily !== channel.deviceFamily;
       const timeSinceActive = channel.usesSerial && channel.lastMessageRecievedAt
-        ? Date.now() - channel.lastMessageRecievedAt
-        : 0;
-
-      const fellOff = timeSinceActive > 5000;
-      channel.missing = deviceMismatch || fellOff;
+        ? Date.now() - channel.lastMessageRecievedAt: 0;
+      channel.missing = deviceMismatch || timeSinceActive > 5000;
     }
-
     else {
       channel.serialConnected = false;
       channel.missing = true;

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -541,8 +541,6 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
         nodeProcess(n);
       }
       // TODO: We probably need a better way to determine if recentValues should be updated
-      // TODO: we may be slowing down the ticks here, so we need to split out for various settings and scenarios
-      // particularly when case-writing functionality is merged
       if (Object.prototype.hasOwnProperty.call(n.data, "nodeValue")) {
         this.updateNodeRecentValues(n);
       }
@@ -606,8 +604,8 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
       this.stores.serialDevice.writeToOutForArduino(n.data.nodeValue as number);
     }
     if (deviceFamily === "microbit"){
-      // Stub for PT: https://www.pivotaltracker.com/n/projects/2441242/stories/184753741
-      console.log("SERIAL send out control messages for microbit");
+      // UPCOMING PT: #184753741 control messages out to hubs
+      this.stores.serialDevice.writeToOutForMicroBit(n.data.nodeValue as any);
     }
   }
 

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -541,6 +541,8 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
         nodeProcess(n);
       }
       // TODO: We probably need a better way to determine if recentValues should be updated
+      // TODO: we may be slowing down the ticks here, so we need to split out for various settings and scenarios
+      // particularly when case-writing functionality is merged
       if (Object.prototype.hasOwnProperty.call(n.data, "nodeValue")) {
         this.updateNodeRecentValues(n);
       }
@@ -599,7 +601,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
 
   private sendDataToSerialDevice(n: Node){
     if (isFinite(n.data.nodeValue as number)){
-      this.stores.serialDevice.writeToOut(n.data.nodeValue as number);
+      this.stores.serialDevice.writeToOut(n.data.nodeValue as number); // micro:bit
     }
   }
 

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -28,8 +28,9 @@ import { DataflowProgramToolbar } from "./ui/dataflow-program-toolbar";
 import { DataflowProgramTopbar } from "./ui/dataflow-program-topbar";
 import { DataflowProgramCover } from "./ui/dataflow-program-cover";
 import { DataflowProgramZoom } from "./ui/dataflow-program-zoom";
-import { NodeChannelInfo, NodeGeneratorTypes, ProgramDataRates, NodeTimerInfo,
-         virtualSensorChannels, serialSensorChannels} from "../model/utilities/node";
+import { NodeChannelInfo, serialSensorChannels } from "../model/utilities/channel";
+import { NodeGeneratorTypes, ProgramDataRates, NodeTimerInfo } from "../model/utilities/node";
+import { virtualSensorChannels } from "../model/utilities/virtual-channel";
 import { Rect, scaleRect, unionRect } from "../utilities/rect";
 import { DocumentContextReact } from "../../../components/document/document-context";
 import { SerialDevice } from "../../../models/stores/serial";

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -600,8 +600,14 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
   }
 
   private sendDataToSerialDevice(n: Node){
-    if (isFinite(n.data.nodeValue as number)){
-      this.stores.serialDevice.writeToOut(n.data.nodeValue as number); // micro:bit
+    const isNumberOutput = isFinite(n.data.nodeValue as number);
+    const { deviceFamily } = this.stores.serialDevice;
+
+    if (deviceFamily === "arduino" && isNumberOutput){
+      this.stores.serialDevice.writeToOutForArduino(n.data.nodeValue as number);
+    }
+    if (deviceFamily === "microbit"){
+      console.log("handle data destined for microbit");
     }
   }
 

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -559,8 +559,16 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
   private passSerialStateToChannel(sd: SerialDevice, channel: NodeChannelInfo){
     if (sd.hasPort()){
       channel.serialConnected = true;
-      channel.missing = sd.deviceFamily !== channel.deviceFamily;
-    } else {
+      const deviceMismatch = sd.deviceFamily !== channel.deviceFamily;
+      const timeSinceActive = channel.usesSerial && channel.lastMessageRecievedAt
+        ? Date.now() - channel.lastMessageRecievedAt
+        : 0;
+
+      const fellOff = timeSinceActive > 5000;
+      channel.missing = deviceMismatch || fellOff;
+    }
+
+    else {
       channel.serialConnected = false;
       channel.missing = true;
     }

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -561,7 +561,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
   private passSerialStateToChannel(sd: SerialDevice, channel: NodeChannelInfo){
     if (sd.hasPort()){
       channel.serialConnected = true;
-      channel.missing = false;
+      channel.missing = sd.deviceFamily !== channel.deviceFamily;
     } else {
       channel.serialConnected = false;
       channel.missing = true;
@@ -572,12 +572,11 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
     // implementing with a "count" of 1 or 0 in case we need to count nodes in future
     let serialNodesCt = 0;
 
-    //sensor will need serial once these particular sensors are chosen
     nodes.forEach((n) => {
-      if(n.data.sensor === "emg" || n.data.sensor === "fsr"){
+      const isLiveSensor = /fsr|emg|[th]-[abcd]/;
+      if(isLiveSensor.test(n.data.sensor as string)){
         serialNodesCt++;
       }
-
       //live output block will alert need for serial
       // only after connection to another node is made
       // this allows user to drag a block out and work on program before connecting
@@ -607,7 +606,8 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
       this.stores.serialDevice.writeToOutForArduino(n.data.nodeValue as number);
     }
     if (deviceFamily === "microbit"){
-      console.log("handle data destined for microbit");
+      // Stub for PT: https://www.pivotaltracker.com/n/projects/2441242/stories/184753741
+      console.log("SERIAL send out control messages for microbit");
     }
   }
 

--- a/src/plugins/dataflow/model/dataflow-content.ts
+++ b/src/plugins/dataflow/model/dataflow-content.ts
@@ -74,7 +74,7 @@ export const DataflowContentModel = TileContentModel
     }
   }))
   .actions(self => tileModelHooks({
-    doPostCreate(metadata: ITileMetadataModel){
+    doPostCreate(metadata: ITileMetadataModel) {
       self.metadata = metadata;
     }
   }))

--- a/src/plugins/dataflow/model/utilities/channel.ts
+++ b/src/plugins/dataflow/model/utilities/channel.ts
@@ -80,8 +80,8 @@ function createMicroBitChannels(sensors: MicroBitSensorChannelInfo[] ){
     return {
       ...basis,
       hubId: `MICROBIT-RADIO-${s.microBitId}`,
-      hubName: `micro:bit ${s.microBitId} ${s.type}`,
-      name: `${s.type}-${s.microBitId}`,
+      hubName: `micro:bit ${s.microBitId}`,
+      name: `${s.type}-micro:bit-${s.microBitId}`,
       channelId: `${s.type}-${s.microBitId}`,
       type: `${s.type}`,
       units: `${s.units}`,

--- a/src/plugins/dataflow/model/utilities/channel.ts
+++ b/src/plugins/dataflow/model/utilities/channel.ts
@@ -93,7 +93,7 @@ function createMicroBitChannels(sensors: MicroBitSensorChannelInfo[] ){
 
 const microBitSensorChannels = createMicroBitChannels(microBitSensors);
 
-console.log("microBitSensorChannels", microBitSensorChannels);
+console.log("created microBitSensorChannels", microBitSensorChannels);
 
 export const serialSensorChannels: NodeChannelInfo[] = [
   emgSensorChannel, fsrSensorChannel, ...microBitSensorChannels

--- a/src/plugins/dataflow/model/utilities/channel.ts
+++ b/src/plugins/dataflow/model/utilities/channel.ts
@@ -54,17 +54,17 @@ interface MicroBitSensorChannelInfo {
   plug: number
 }
 
-// "plug" is not really used now, but keeping for now for ease of transition
+// "plug" is not really used now, but considering keeping for now for ease of transition
 // maybe it has a metaphor that will be useful soon
 const microBitSensors: MicroBitSensorChannelInfo[] = [
- { microBitId: "A", plug: 11, type: "temperature", units: "°C" },
- { microBitId: "A", plug: 12, type: "humidity", units: "%"},
- { microBitId: "B", plug: 13, type: "temperature", units: "°C"  },
- { microBitId: "B", plug: 14, type: "humidity", units: "%"  },
- { microBitId: "C", plug: 15, type: "temperature", units: "°C"  },
- { microBitId: "C", plug: 16, type: "humidity", units: "%"  },
- { microBitId: "D", plug: 17, type: "temperature", units: "°C"  },
- { microBitId: "D", plug: 18, type: "humidity", units: "%"  }
+ { microBitId: "a", plug: 11, type: "temperature", units: "°C" },
+ { microBitId: "a", plug: 12, type: "humidity", units: "%"},
+ { microBitId: "b", plug: 13, type: "temperature", units: "°C"  },
+ { microBitId: "b", plug: 14, type: "humidity", units: "%"  },
+ { microBitId: "c", plug: 15, type: "temperature", units: "°C"  },
+ { microBitId: "c", plug: 16, type: "humidity", units: "%"  },
+ { microBitId: "d", plug: 17, type: "temperature", units: "°C"  },
+ { microBitId: "d", plug: 18, type: "humidity", units: "%"  }
 ];
 
 function createMicroBitChannels(sensors: MicroBitSensorChannelInfo[] ){
@@ -82,7 +82,7 @@ function createMicroBitChannels(sensors: MicroBitSensorChannelInfo[] ){
       hubId: `MICROBIT-RADIO-${s.microBitId}`,
       hubName: `micro:bit ${s.microBitId}`,
       name: `${s.type}-micro:bit-${s.microBitId}`,
-      channelId: `${s.type}-${s.microBitId}`,
+      channelId: `${s.type.substring(0,1)}-${s.microBitId}`,
       type: `${s.type}`,
       units: `${s.units}`,
       plug: s.plug
@@ -93,8 +93,7 @@ function createMicroBitChannels(sensors: MicroBitSensorChannelInfo[] ){
 
 const microBitSensorChannels = createMicroBitChannels(microBitSensors);
 
-console.log("SERIAL created microBitSensorChannels", microBitSensorChannels);
-
+console.log("SERIAL created microbit channels: ", microBitSensorChannels)
 export const serialSensorChannels: NodeChannelInfo[] = [
   emgSensorChannel, fsrSensorChannel, ...microBitSensorChannels
 ];

--- a/src/plugins/dataflow/model/utilities/channel.ts
+++ b/src/plugins/dataflow/model/utilities/channel.ts
@@ -1,0 +1,100 @@
+export interface NodeChannelInfo {
+  hubId: string; // would use this but "hub" is local microbit
+  hubName: string;
+  channelId: string;
+  missing: boolean;
+  type: string;
+  units: string;
+  plug: number;
+  value: number;
+  name: string;
+  virtual?: boolean;
+  virtualValueMethod?: (t: number) => number;
+  usesSerial?:boolean;
+  serialConnected?:boolean | null;
+  outputTargetDevice?: string;
+  outputTargetActuator?: string;
+  timeFactor?: number;
+}
+
+const emgSensorChannel: NodeChannelInfo = {
+  hubId: "SERIAL-ARDUINO",
+  hubName: "Arduino",
+  name: "emg",
+  channelId: "emg",
+  missing: true,
+  type: "emg-reading",
+  units: "f(mv)",
+  plug: 9,
+  value: 0,
+  virtual: false,
+  usesSerial: true,
+  serialConnected: null
+};
+
+export const fsrSensorChannel: NodeChannelInfo = {
+  hubId: "SERIAL-ARDUINO",
+  hubName: "Arduino",
+  name: "fsr",
+  channelId: "fsr",
+  missing: true,
+  type: "fsr-reading",
+  units: "n",
+  plug: 10,
+  value: 0,
+  virtual: false,
+  usesSerial: true,
+  serialConnected: null
+};
+
+interface MicroBitSensorChannelInfo {
+  microBitId: string,
+  type: string,
+  units: string,
+  plug: number
+}
+
+// "plug" is not really used now, but keeping for now for ease of transition
+// maybe it has a metaphor that will be useful soon
+const microBitSensors: MicroBitSensorChannelInfo[] = [
+ { microBitId: "A", plug: 11, type: "temperature", units: "°C" },
+ { microBitId: "A", plug: 12, type: "humidity", units: "%"},
+ { microBitId: "B", plug: 13, type: "temperature", units: "°C"  },
+ { microBitId: "B", plug: 14, type: "humidity", units: "%"  },
+ { microBitId: "C", plug: 15, type: "temperature", units: "°C"  },
+ { microBitId: "C", plug: 16, type: "humidity", units: "%"  },
+ { microBitId: "D", plug: 17, type: "temperature", units: "°C"  },
+ { microBitId: "D", plug: 18, type: "humidity", units: "%"  }
+];
+
+function createMicroBitChannels(sensors: MicroBitSensorChannelInfo[] ){
+  const basis = {
+    missing: true,
+    value: 0,
+    virtual: false,
+    usesSerial: true,
+    serialConnected: null
+  };
+
+  const channels = sensors.map((s) => {
+    return {
+      ...basis,
+      hubId: `MICROBIT-RADIO-${s.microBitId}`,
+      hubName: `micro:bit ${s.microBitId} ${s.type}`,
+      name: `${s.type}-${s.microBitId}`,
+      channelId: `${s.type}-${s.microBitId}`,
+      type: `${s.type}`,
+      units: `${s.units}`,
+      plug: s.plug
+    };
+  });
+  return channels;
+}
+
+const microBitSensorChannels = createMicroBitChannels(microBitSensors);
+
+console.log("microBitSensorChannels", microBitSensorChannels);
+
+export const serialSensorChannels: NodeChannelInfo[] = [
+  emgSensorChannel, fsrSensorChannel, ...microBitSensorChannels
+];

--- a/src/plugins/dataflow/model/utilities/channel.ts
+++ b/src/plugins/dataflow/model/utilities/channel.ts
@@ -16,6 +16,7 @@ export interface NodeChannelInfo {
   outputTargetActuator?: string;
   timeFactor?: number;
   deviceFamily?: string;
+  lastMessageRecievedAt?: number | null;
 }
 
 const emgSensorChannel: NodeChannelInfo = {
@@ -77,7 +78,8 @@ function createMicroBitChannels(sensors: MicroBitSensorChannelInfo[] ){
     virtual: false,
     usesSerial: true,
     serialConnected: null,
-    deviceFamily: "microbit"
+    deviceFamily: "microbit",
+    lastMessageRecievedAt: Date.now()
   };
 
   const channels = sensors.map((s) => {

--- a/src/plugins/dataflow/model/utilities/channel.ts
+++ b/src/plugins/dataflow/model/utilities/channel.ts
@@ -1,11 +1,11 @@
 export interface NodeChannelInfo {
-  hubId: string; // would use this but "hub" is local microbit
+  hubId: string;
   hubName: string;
   channelId: string;
   missing: boolean;
   type: string;
   units: string;
-  plug: number;
+  plug: number;  // TODO: make optional and preserve any usage, or remove
   value: number;
   name: string;
   virtual?: boolean;
@@ -17,6 +17,7 @@ export interface NodeChannelInfo {
   timeFactor?: number;
   deviceFamily?: string;
   lastMessageRecievedAt?: number | null;
+  relaysState?: number[]
 }
 
 const emgSensorChannel: NodeChannelInfo = {
@@ -65,10 +66,10 @@ interface MicroBitHubInfo {
 }
 
 const microBitHubs = [
-  { microBitId: "a", plug: 19 },
-  { microBitId: "b", plug: 20 },
-  { microBitId: "c", plug: 21 },
-  { microBitId: "d", plug: 22 },
+  { microBitId: "a", plug: 19, relaysState: [0,0,0] },
+  { microBitId: "b", plug: 20, relaysState: [0,0,0] },
+  { microBitId: "c", plug: 21, relaysState: [0,0,0] },
+  { microBitId: "d", plug: 22, relaysState: [0,0,0] },
 ];
 
 // "plug" is not really used now, but considering keeping for now for ease of transition

--- a/src/plugins/dataflow/model/utilities/channel.ts
+++ b/src/plugins/dataflow/model/utilities/channel.ts
@@ -93,7 +93,7 @@ function createMicroBitChannels(sensors: MicroBitSensorChannelInfo[] ){
 
 const microBitSensorChannels = createMicroBitChannels(microBitSensors);
 
-console.log("created microBitSensorChannels", microBitSensorChannels);
+console.log("SERIAL created microBitSensorChannels", microBitSensorChannels);
 
 export const serialSensorChannels: NodeChannelInfo[] = [
   emgSensorChannel, fsrSensorChannel, ...microBitSensorChannels

--- a/src/plugins/dataflow/model/utilities/channel.ts
+++ b/src/plugins/dataflow/model/utilities/channel.ts
@@ -58,6 +58,19 @@ interface MicroBitSensorChannelInfo {
   plug: number
 }
 
+interface MicroBitHubInfo {
+  microBitId: string,
+  location?: string
+  plug: number
+}
+
+const microBitHubs = [
+  { microBitId: "a", plug: 19 },
+  { microBitId: "b", plug: 20 },
+  { microBitId: "c", plug: 21 },
+  { microBitId: "d", plug: 22 },
+];
+
 // "plug" is not really used now, but considering keeping for now for ease of transition
 // maybe it has a metaphor that will be useful soon
 const microBitSensors: MicroBitSensorChannelInfo[] = [
@@ -71,7 +84,7 @@ const microBitSensors: MicroBitSensorChannelInfo[] = [
  { microBitId: "d", plug: 18, type: "humidity", units: "%" }
 ];
 
-function createMicroBitChannels(sensors: MicroBitSensorChannelInfo[] ){
+function createMicroBitSensorChannels(sensors: MicroBitSensorChannelInfo[] ){
   const basis = {
     missing: true,
     value: 0,
@@ -97,8 +110,35 @@ function createMicroBitChannels(sensors: MicroBitSensorChannelInfo[] ){
   return channels;
 }
 
-const microBitSensorChannels = createMicroBitChannels(microBitSensors);
+function createMicroBitRelayInfoChannels(hubs: MicroBitHubInfo[] ){
+  const basis = {
+    missing: true,
+    value: 0,
+    virtual: false,
+    type: "relays",
+    usesSerial: true,
+    serialConnected: null,
+    deviceFamily: "microbit",
+    lastMessageRecievedAt: Date.now()
+  };
+
+  const channels = hubs.map((h) => {
+    return {
+      ...basis,
+      hubId: `MICROBIT-RADIO-${h.microBitId}`,
+      hubName: `microbit ${h.microBitId}`,
+      name: `relays-microbit-${h.microBitId}`,
+      channelId: `r-${h.microBitId}`,
+      units: `b`,
+      plug: h.plug
+    };
+  });
+  return channels;
+}
+
+const microBitSensorChannels = createMicroBitSensorChannels(microBitSensors);
+const microBitRelayChannels = createMicroBitRelayInfoChannels(microBitHubs);
 
 export const serialSensorChannels: NodeChannelInfo[] = [
-  emgSensorChannel, fsrSensorChannel, ...microBitSensorChannels
+  emgSensorChannel, fsrSensorChannel, ...microBitSensorChannels, ...microBitRelayChannels
 ];

--- a/src/plugins/dataflow/model/utilities/channel.ts
+++ b/src/plugins/dataflow/model/utilities/channel.ts
@@ -15,6 +15,7 @@ export interface NodeChannelInfo {
   outputTargetDevice?: string;
   outputTargetActuator?: string;
   timeFactor?: number;
+  deviceFamily?: string;
 }
 
 const emgSensorChannel: NodeChannelInfo = {
@@ -29,7 +30,8 @@ const emgSensorChannel: NodeChannelInfo = {
   value: 0,
   virtual: false,
   usesSerial: true,
-  serialConnected: null
+  serialConnected: null,
+  deviceFamily: "arduino"
 };
 
 export const fsrSensorChannel: NodeChannelInfo = {
@@ -44,7 +46,8 @@ export const fsrSensorChannel: NodeChannelInfo = {
   value: 0,
   virtual: false,
   usesSerial: true,
-  serialConnected: null
+  serialConnected: null,
+  deviceFamily: "arduino"
 };
 
 interface MicroBitSensorChannelInfo {
@@ -58,13 +61,13 @@ interface MicroBitSensorChannelInfo {
 // maybe it has a metaphor that will be useful soon
 const microBitSensors: MicroBitSensorChannelInfo[] = [
  { microBitId: "a", plug: 11, type: "temperature", units: "°C" },
- { microBitId: "a", plug: 12, type: "humidity", units: "%"},
- { microBitId: "b", plug: 13, type: "temperature", units: "°C"  },
- { microBitId: "b", plug: 14, type: "humidity", units: "%"  },
- { microBitId: "c", plug: 15, type: "temperature", units: "°C"  },
- { microBitId: "c", plug: 16, type: "humidity", units: "%"  },
- { microBitId: "d", plug: 17, type: "temperature", units: "°C"  },
- { microBitId: "d", plug: 18, type: "humidity", units: "%"  }
+ { microBitId: "a", plug: 12, type: "humidity", units: "%" },
+ { microBitId: "b", plug: 13, type: "temperature", units: "°C" },
+ { microBitId: "b", plug: 14, type: "humidity", units: "%" },
+ { microBitId: "c", plug: 15, type: "temperature", units: "°C" },
+ { microBitId: "c", plug: 16, type: "humidity", units: "%" },
+ { microBitId: "d", plug: 17, type: "temperature", units: "°C" },
+ { microBitId: "d", plug: 18, type: "humidity", units: "%" }
 ];
 
 function createMicroBitChannels(sensors: MicroBitSensorChannelInfo[] ){
@@ -73,15 +76,16 @@ function createMicroBitChannels(sensors: MicroBitSensorChannelInfo[] ){
     value: 0,
     virtual: false,
     usesSerial: true,
-    serialConnected: null
+    serialConnected: null,
+    deviceFamily: "microbit"
   };
 
   const channels = sensors.map((s) => {
     return {
       ...basis,
       hubId: `MICROBIT-RADIO-${s.microBitId}`,
-      hubName: `micro:bit ${s.microBitId}`,
-      name: `${s.type}-micro:bit-${s.microBitId}`,
+      hubName: `microbit ${s.microBitId}`,
+      name: `${s.type}-microbit-${s.microBitId}`,
       channelId: `${s.type.substring(0,1)}-${s.microBitId}`,
       type: `${s.type}`,
       units: `${s.units}`,
@@ -93,7 +97,6 @@ function createMicroBitChannels(sensors: MicroBitSensorChannelInfo[] ){
 
 const microBitSensorChannels = createMicroBitChannels(microBitSensors);
 
-console.log("SERIAL created microbit channels: ", microBitSensorChannels)
 export const serialSensorChannels: NodeChannelInfo[] = [
   emgSensorChannel, fsrSensorChannel, ...microBitSensorChannels
 ];

--- a/src/plugins/dataflow/model/utilities/node.ts
+++ b/src/plugins/dataflow/model/utilities/node.ts
@@ -311,6 +311,14 @@ export const NodeLiveOutputTypes = [
   {
     name: "Grabber",
     icon: GrabberIcon
+  },
+  {
+    name: "Sprinkler",
+    icon: GrabberIcon
+  },
+  {
+    name: "Fan",
+    icon: GrabberIcon
   }
 ];
 
@@ -352,22 +360,7 @@ export const NodeTimerInfo =
   method: (t: number, tOn: number, tOff: number) => t % (tOn + tOff) < tOn ? 1 : 0,
 };
 
-export interface NodeChannelInfo {
-  hubId: string;
-  hubName: string;
-  channelId: string;
-  missing: boolean;
-  type: string;
-  units: string;
-  plug: number;
-  value: number;
-  name: string;
-  virtual?: boolean;
-  virtualValueMethod?: (t: number) => number;
-  usesSerial?:boolean;
-  serialConnected?:boolean | null;
-  timeFactor?: number;
-}
+
 
 export const roundNodeValue = (n: number) => {
   return Math.round(n * 1000) / 1000;
@@ -418,115 +411,3 @@ export const ProgramDataRates: ProgramDataRate[] = [
 
 export const kSensorSelectMessage = "Select a sensor";
 export const kSensorMissingMessage = "⚠️";
-
-const virtualTempChannel: NodeChannelInfo = {
-  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "Temperature", channelId: "00001-VIR",
-  missing: false, type: "temperature", units: "°C", plug: 1, value: 0, virtual: true, timeFactor: 1000,
-  virtualValueMethod: (t: number) => {
-    const vals = [20, 20, 20, 21, 21, 21, 20, 20, 21, 21, 21, 21, 21, 21, 21];
-    return vals[t % vals.length];
-  } };
-const virtualHumidChannel: NodeChannelInfo = {
-  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "Humidity", channelId: "00002-VIR",
-  missing: false, type: "humidity", units: "%", plug: 2, value: 0, virtual: true, timeFactor: 1000,
-  virtualValueMethod: (t: number) => {
-    const vals = [60, 60, 60, 61, 61, 61, 62, 62, 62, 61, 61, 61, 61, 61, 61, 61];
-    return vals[t % vals.length];
-  } };
-const virtualCO2Channel: NodeChannelInfo = {
-  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "CO2", channelId: "00003-VIR",
-  missing: false, type: "CO2", units: "PPM", plug: 3, value: 0, virtual: true, timeFactor: 1000,
-  virtualValueMethod: (t: number) => {
-    const vals = [409, 409, 410, 410, 410, 410, 411, 411, 410, 410, 410, 409, 409, 411, 411];
-    return vals[t % vals.length];
-  } };
-const virtualO2Channel: NodeChannelInfo = {
-  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "O2", channelId: "00004-VIR",
-  missing: false, type: "O2", units: "PPM", plug: 4, value: 0, virtual: true, timeFactor: 1000,
-  virtualValueMethod: (t: number) => {
-    const vals = [21, 21, 21, 22, 22, 22, 21, 21, 21, 21, 22, 22, 22, 22, 22];
-    return vals[t % vals.length];
-  } };
-const virtualLightChannel: NodeChannelInfo = {
-  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "Light", channelId: "00005-VIR",
-  missing: false, type: "light", units: "lux", plug: 5, value: 0, virtual: true, timeFactor: 1000,
-  virtualValueMethod: (t: number) => {
-    const vals = [9000, 9000, 9001, 9001, 9002, 9002, 9002, 9001, 9001, 9001, 9000, 9001, 9001, 9002, 9002];
-    return vals[t % vals.length];
-  } };
-const virtualPartChannel: NodeChannelInfo = {
-  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "Particulates", channelId: "00006VIR",
-  missing: false, type: "particulates", units: "PM2.5", plug: 7, value: 0, virtual: true, timeFactor: 1000,
-  virtualValueMethod: (t: number) => {
-    const vals = [10, 10, 10, 10, 10, 10, 11, 11, 11, 11, 11, 11, 11, 11, 11];
-    return vals[t % vals.length];
-  } };
-const virtualEmgChannelVaried: NodeChannelInfo = {
-  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "EMG - Varied Clenches", channelId: "00007VIR",
-  missing: false, type: "emg-reading", units: "f(mv)", plug: 8, value: 0, virtual: true, timeFactor: 100,
-  virtualValueMethod: (t: number) => {
-    const vals = demoStreams.emgVariedPulses;
-    return vals[t % vals.length];
-} };
-const virtualEmgChannelLongHold: NodeChannelInfo = {
-  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "EMG - Long Clench and Hold", channelId: "00008VIR",
-  missing: false, type: "emg-reading", units: "f(mv)", plug: 9, value: 0, virtual: true, timeFactor: 100,
-  virtualValueMethod: (t: number) => {
-    const vals = demoStreams.emgLongHold;
-    return vals[t % vals.length];
-} };
-const virtualEmgChannelShortHold: NodeChannelInfo = {
-  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "EMG - Short Clench and Hold", channelId: "00009VIR",
-  missing: false, type: "emg-reading", units: "f(mv)", plug: 10, value: 0, virtual: true, timeFactor: 100,
-  virtualValueMethod: (t: number) => {
-    const vals = demoStreams.emgShortHold;
-    return vals[t % vals.length];
-} };
-const virtualFsrChannel: NodeChannelInfo = {
-  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "FSR", channelId: "00010VIR",
-  missing: false, type: "fsr-reading", units: "f(n)", plug: 11, value: 0, virtual: true, timeFactor: 100,
-  virtualValueMethod: (t: number) => {
-    const vals = demoStreams.fsrSqueeze;
-    return vals[t % vals.length];
-} };
-
-export const virtualSensorChannels: NodeChannelInfo[] = [
-  virtualTempChannel, virtualHumidChannel, virtualCO2Channel, virtualO2Channel,
-  virtualLightChannel, virtualPartChannel,
-  virtualEmgChannelVaried, virtualEmgChannelLongHold, virtualEmgChannelShortHold,
-  virtualFsrChannel
-];
-
-const emgSensorChannel: NodeChannelInfo = {
-  hubId: "SERIAL-ARDUINO",
-  hubName: "Arduino",
-  name: "emg",
-  channelId: "emg",
-  missing: true,
-  type: "emg-reading",
-  units: "f(mv)",
-  plug: 9,
-  value: 0,
-  virtual: false,
-  usesSerial: true,
-  serialConnected: null
-};
-
-const fsrSensorChannel: NodeChannelInfo = {
-  hubId: "SERIAL-ARDUINO",
-  hubName: "Arduino",
-  name: "fsr",
-  channelId: "fsr",
-  missing: true,
-  type: "fsr-reading",
-  units: "n",
-  plug: 10,
-  value: 0,
-  virtual: false,
-  usesSerial: true,
-  serialConnected: null
-};
-
-export const serialSensorChannels: NodeChannelInfo[] = [
-  emgSensorChannel, fsrSensorChannel
-];

--- a/src/plugins/dataflow/model/utilities/node.ts
+++ b/src/plugins/dataflow/model/utilities/node.ts
@@ -40,8 +40,6 @@ import CurrentValueIcon from "../../assets/icons/control/control-current-value.s
 import PreviousValueIcon from "../../assets/icons/control/control-previous-value.svg";
 import ZeroValueIcon from "../../assets/icons/control/control-zero-value.svg";
 
-import { demoStreams } from "./demo-data";
-
 export interface NodeType {
   name: string;
   displayName: string;

--- a/src/plugins/dataflow/model/utilities/node.ts
+++ b/src/plugins/dataflow/model/utilities/node.ts
@@ -358,8 +358,6 @@ export const NodeTimerInfo =
   method: (t: number, tOn: number, tOff: number) => t % (tOn + tOff) < tOn ? 1 : 0,
 };
 
-
-
 export const roundNodeValue = (n: number) => {
   return Math.round(n * 1000) / 1000;
 };

--- a/src/plugins/dataflow/model/utilities/virtual-channel.ts
+++ b/src/plugins/dataflow/model/utilities/virtual-channel.ts
@@ -1,0 +1,80 @@
+import { NodeChannelInfo } from "./channel";
+import { demoStreams } from "./demo-data";
+
+const virtualTempChannel: NodeChannelInfo = {
+  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "Temperature", channelId: "00001-VIR",
+  missing: false, type: "temperature", units: "°C", plug: 1, value: 0, virtual: true, timeFactor: 1000,
+  virtualValueMethod: (t: number) => {
+    const vals = [20, 20, 20, 21, 21, 21, 20, 20, 21, 21, 21, 21, 21, 21, 21];
+    return vals[t % vals.length];
+  } };
+const virtualHumidChannel: NodeChannelInfo = {
+  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "Humidity", channelId: "00002-VIR",
+  missing: false, type: "humidity", units: "%", plug: 2, value: 0, virtual: true, timeFactor: 1000,
+  virtualValueMethod: (t: number) => {
+    const vals = [60, 60, 60, 61, 61, 61, 62, 62, 62, 61, 61, 61, 61, 61, 61, 61];
+    return vals[t % vals.length];
+  } };
+const virtualCO2Channel: NodeChannelInfo = {
+  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "CO2", channelId: "00003-VIR",
+  missing: false, type: "CO2", units: "PPM", plug: 3, value: 0, virtual: true, timeFactor: 1000,
+  virtualValueMethod: (t: number) => {
+    const vals = [409, 409, 410, 410, 410, 410, 411, 411, 410, 410, 410, 409, 409, 411, 411];
+    return vals[t % vals.length];
+  } };
+const virtualO2Channel: NodeChannelInfo = {
+  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "O2", channelId: "00004-VIR",
+  missing: false, type: "O2", units: "PPM", plug: 4, value: 0, virtual: true, timeFactor: 1000,
+  virtualValueMethod: (t: number) => {
+    const vals = [21, 21, 21, 22, 22, 22, 21, 21, 21, 21, 22, 22, 22, 22, 22];
+    return vals[t % vals.length];
+  } };
+const virtualLightChannel: NodeChannelInfo = {
+  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "Light", channelId: "00005-VIR",
+  missing: false, type: "light", units: "lux", plug: 5, value: 0, virtual: true, timeFactor: 1000,
+  virtualValueMethod: (t: number) => {
+    const vals = [9000, 9000, 9001, 9001, 9002, 9002, 9002, 9001, 9001, 9001, 9000, 9001, 9001, 9002, 9002];
+    return vals[t % vals.length];
+  } };
+const virtualPartChannel: NodeChannelInfo = {
+  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "Particulates", channelId: "00006VIR",
+  missing: false, type: "particulates", units: "PM2.5", plug: 7, value: 0, virtual: true, timeFactor: 1000,
+  virtualValueMethod: (t: number) => {
+    const vals = [10, 10, 10, 10, 10, 10, 11, 11, 11, 11, 11, 11, 11, 11, 11];
+    return vals[t % vals.length];
+  } };
+const virtualEmgChannelVaried: NodeChannelInfo = {
+  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "EMG - Varied Clenches", channelId: "00007VIR",
+  missing: false, type: "emg-reading", units: "f(mv)", plug: 8, value: 0, virtual: true, timeFactor: 100,
+  virtualValueMethod: (t: number) => {
+    const vals = demoStreams.emgVariedPulses;
+    return vals[t % vals.length];
+} };
+const virtualEmgChannelLongHold: NodeChannelInfo = {
+  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "EMG - Long Clench and Hold", channelId: "00008VIR",
+  missing: false, type: "emg-reading", units: "f(mv)", plug: 9, value: 0, virtual: true, timeFactor: 100,
+  virtualValueMethod: (t: number) => {
+    const vals = demoStreams.emgLongHold;
+    return vals[t % vals.length];
+} };
+const virtualEmgChannelShortHold: NodeChannelInfo = {
+  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "EMG - Short Clench and Hold", channelId: "00009VIR",
+  missing: false, type: "emg-reading", units: "f(mv)", plug: 10, value: 0, virtual: true, timeFactor: 100,
+  virtualValueMethod: (t: number) => {
+    const vals = demoStreams.emgShortHold;
+    return vals[t % vals.length];
+} };
+const virtualFsrChannel: NodeChannelInfo = {
+  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "FSR", channelId: "00010VIR",
+  missing: false, type: "fsr-reading", units: "f(n)", plug: 11, value: 0, virtual: true, timeFactor: 100,
+  virtualValueMethod: (t: number) => {
+    const vals = demoStreams.fsrSqueeze;
+    return vals[t % vals.length];
+} };
+
+export const virtualSensorChannels: NodeChannelInfo[] = [
+  virtualTempChannel, virtualHumidChannel, virtualCO2Channel, virtualO2Channel,
+  virtualLightChannel, virtualPartChannel,
+  virtualEmgChannelVaried, virtualEmgChannelLongHold, virtualEmgChannelShortHold,
+  virtualFsrChannel
+];

--- a/src/plugins/dataflow/nodes/controls/sensor-select-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/sensor-select-control.tsx
@@ -140,10 +140,10 @@ export class SensorSelectControl extends Rete.Control {
       const selectedChannel = channelsForType.find((ch: any) => ch.channelId === id);
 
       const getChannelString = (ch?: NodeChannelInfo | "none") => {
-        if (!ch && (!id || id === "none")) return kSensorSelectMessage;
         if (ch === "none") return "None Available";
+        if (!ch && (!id || id === "none")) return kSensorSelectMessage;
         if (!ch) return `${kSensorMissingMessage} ${id}`;
-        if (ch.missing) return `${kSensorMissingMessage} connect for live ${ch.name}`;
+        if (ch.missing) return `${kSensorMissingMessage} connect ${ch.deviceFamily} for ${ch.name}`;
         let count = 0;
         channelsForType.forEach( c => { if (c.type === ch.type && ch.hubId === c.hubId) count++; } );
         const chStr = ch.virtual

--- a/src/plugins/dataflow/nodes/controls/sensor-select-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/sensor-select-control.tsx
@@ -2,8 +2,8 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import React, { useRef }  from "react";
 import Rete, { NodeEditor, Node } from "rete";
-import { NodeSensorTypes, NodeChannelInfo,
-         kSensorSelectMessage, kSensorMissingMessage } from "../../model/utilities/node";
+import { NodeSensorTypes, kSensorSelectMessage, kSensorMissingMessage } from "../../model/utilities/node";
+import { NodeChannelInfo } from "../../model/utilities/channel";
 import { useStopEventPropagation, useCloseDropdownOnOutsideEvent } from "./custom-hooks";
 import DropdownCaretIcon from "../../assets/icons/dropdown-caret.svg";
 import { dataflowLogEvent } from "../../dataflow-logger";


### PR DESCRIPTION
This is a draft PR that, in its current format, includes and supercedes #1658 by keeping that functionality and adding functionality for  PT #184770831.  Individual sensor choices are now reflected "live" in the sensor dropdowns.  So, if sensor A falls offline, it's menu item will indicate that it is no longer connected.   We may end up needing to rebase again after serialization work is merged so am closing this for now. 