### PR TITLE
fix: Text tiles should display bulleted lists (PT-184851232)

### DIFF
--- a/src/cms/custom-control.scss
+++ b/src/cms/custom-control.scss
@@ -7,13 +7,15 @@
   /*
    * To override or revert Decap CMS styling that adversely affects
    * Clue content styling in the editor, place related style rules
-   * within the .canvas .tool-tile block below.
+   * within the .canvas .document-content block below.
    */
-  .canvas .tool-tile {
-    ul, ol {
-      color: rgb(49, 61, 62);
-      font-size: 15px;
-      padding-left: revert;
+  .canvas .document-content {
+    .text-tool-tile {
+      ul, ol {
+        color: rgb(49, 61, 62);
+        font-size: 15px;
+        padding-left: revert;
+      }
     }
   }
 

--- a/src/cms/custom-control.scss
+++ b/src/cms/custom-control.scss
@@ -3,4 +3,18 @@
   border-bottom-left-radius: 5px;
   border-bottom-right-radius: 5px;
   border-top-right-radius: 5px;
+
+  /*
+   * To override or revert Decap CMS styling that adversely affects
+   * Clue content styling in the editor, place related style rules
+   * within the .canvas .tool-tile block below.
+   */
+  .canvas .tool-tile {
+    ul, ol {
+      color: rgb(49, 61, 62);
+      font-size: 15px;
+      padding-left: revert;
+    }
+  }
+
 }


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/184851232

Decap CMS sets styling for unordered and ordered lists that adversely affects their appearance in CLUE text tiles that appear in the CMS content editor (no bullets or indentation, seemingly arbitrary text color change and size). There doesn't appear to be an option to get Decap to not apply styling to certain elements in the editor section, so this fix adds a section to custom-control.scss where Decap's stye rules can be overridden or reverted when necessary.