### PR TITLE
Dataflow use micro:bit network data via serial: PT#184753679, PT#184770831

### DIFF
--- a/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
@@ -330,17 +330,17 @@ context('Dataflow Tool Tile', function () {
       });
       it("verify live output types", () => {
         const dropdown = "liveOutputType";
-        const outputTypes = ["Light Bulb", "Grabber"];
+        const outputTypes = ["Light Bulb", "Grabber", "Sprinkler", "Fan", "Heat Lamp"];
         dataflowToolTile.getDropdown(nodeType, dropdown).click();
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).should("have.length", 2);
+        dataflowToolTile.getDropdownOptions(nodeType, dropdown).should("have.length", 5);
         dataflowToolTile.getDropdownOptions(nodeType, dropdown).each(($tab, index, $typeList) => {
           expect($tab.text()).to.contain(outputTypes[index]);
         });
         dataflowToolTile.getOutputNodeValueText().should("contain", "off");
         dataflowToolTile.getDropdownOptions(nodeType, dropdown).last().click();
         dataflowToolTile.getDropdownOptions(nodeType, dropdown).should("have.length", 0);
-        dataflowToolTile.getDropdown(nodeType, dropdown).contains("Grabber").should("exist");
-        dataflowToolTile.getOutputNodeValueText().should("contain", "0% closed");
+        dataflowToolTile.getDropdown(nodeType, dropdown).contains("Heat Lamp").should("exist");
+        dataflowToolTile.getOutputNodeValueText().should("contain", "off");
       });
       it("verify node inputs outputs", () => {
         dataflowToolTile.getNodeInput().should("exist");
@@ -415,11 +415,23 @@ context('Dataflow Tool Tile', function () {
       });
       it("verify sensor select", () => {
         const dropdown = "sensor-select";
-        const sensorSelect = ["Temperature Demo Data", "Humidity Demo Data", "CO2 Demo Data", "O2 Demo Data", "Light Demo Data", "Particulates Demo Data",
-         "EMG - Varied Clenches Demo Data", "EMG - Long Clench and Hold Demo Data", "EMG - Short Clench and Hold Demo Data", "FSR Demo Data", "⚠️ connect for live emg", "⚠️ connect for live fsr"];
+        const sensorSelect = [
+          "Temperature Demo Data", "Humidity Demo Data", "CO2 Demo Data", "O2 Demo Data", "Light Demo Data", "Particulates Demo Data",
+         "EMG - Varied Clenches Demo Data", "EMG - Long Clench and Hold Demo Data", "EMG - Short Clench and Hold Demo Data", "FSR Demo Data",
+         "⚠️ connect arduino for emg",
+         "⚠️ connect arduino for fsr",
+         "⚠️ connect microbit for temperature-microbit-a",
+         "⚠️ connect microbit for humidity-microbit-a",
+         "⚠️ connect microbit for temperature-microbit-b",
+         "⚠️ connect microbit for humidity-microbit-b",
+         "⚠️ connect microbit for temperature-microbit-c",
+         "⚠️ connect microbit for humidity-microbit-c",
+         "⚠️ connect microbit for temperature-microbit-d",
+         "⚠️ connect microbit for humidity-microbit-d",
+        ];
         dataflowToolTile.getCreateNodeButton(nodeType).click();
         dataflowToolTile.getDropdown(nodeType, dropdown).click();
-        dataflowToolTile.getSensorDropdownOptions(nodeType).should("have.length", 12);
+        dataflowToolTile.getSensorDropdownOptions(nodeType).should("have.length", 20);
         dataflowToolTile.getSensorDropdownOptions(nodeType).each(($tab, index, $typeList) => {
           expect($tab.text()).to.contain(sensorSelect[index]);
         });

--- a/src/plugins/dataflow-tool/microbit/communicator.md
+++ b/src/plugins/dataflow-tool/microbit/communicator.md
@@ -1,0 +1,46 @@
+# Communicator
+
+The program for the micro:bit attached to the computer
+
+On received string via radio
+  - assemble the string
+  - write it to serial
+
+On received command string via serial
+  - broadcast it to targeted hub
+
+```js
+/**
+ * micro:bit + Dataflow: "Communicator"
+ * This is the basic program for the micro:bit physically attached to the computer.
+ */
+
+let mode = 0
+
+radio.setGroup(1)
+serial.redirect(
+    SerialPin.USB_TX,
+    SerialPin.USB_RX,
+    BaudRate.BaudRate9600
+)
+basic.showIcon(IconNames.Asleep)
+
+input.onButtonPressed(Button.A, function () {
+    mode = 1
+    basic.showIcon(IconNames.Happy)
+})
+
+input.onButtonPressed(Button.B, function () {
+    mode = 0
+    basic.showIcon(IconNames.Asleep)
+})
+
+radio.onReceivedString(function (receivedString) {
+    if (mode == 1) {
+        serial.writeLine(receivedString)
+    }
+})
+
+
+```
+

--- a/src/plugins/dataflow-tool/microbit/hub.md
+++ b/src/plugins/dataflow-tool/microbit/hub.md
@@ -1,0 +1,60 @@
+# Hub
+
+The program for the micro:bit attached to the sensors/relays
+
+Every two seconds
+  - Get a temp reading
+  - Get a humidity reading
+  - Make a packet for temp
+  - Make a packet for humidity
+  - Send temp packet
+  - Send humidity packet
+
+
+On radio recieved
+  - If message type == `c` and addressed to my id
+  - Change relay states accordingly
+  - Send confirmation of relay states back as an `s`
+
+
+```js
+radio.setGroup(1)
+
+let hubIds = ['x','a','b','c','d']
+let hubI = 0
+
+function getTempString(){
+  const t = Math.constrain(dht11_dht22.readData(dataType.temperature), 0, 100);
+  return `s${hubIds[hubI]}t${t}`;
+}
+
+function getHumidString(){
+  const h = Math.constrain(dht11_dht22.readData(dataType.humidity), 0, 100);
+  return `s${hubIds[hubI]}h${h}`;
+}
+
+function readSendData() {
+  dht11_dht22.queryData(DHTtype.DHT11, DigitalPin.P15, false, false, false)
+  radio.sendString(getTempString())
+  pause(1000)
+  radio.sendString(getTempString())
+}
+
+basic.forever(function () {
+  basic.showString(hubIds[hubI])
+  if (hubI > 0){
+    pause(2000)
+    readSendData()
+  }
+})
+
+input.onButtonPressed(Button.A, () => {
+  if (hubI > 0) hubI--;
+})
+
+input.onButtonPressed(Button.B, () => {
+  if (hubI < 4) hubI++;
+})
+
+
+```

--- a/src/plugins/dataflow-tool/microbit/mock_communicator.md
+++ b/src/plugins/dataflow-tool/microbit/mock_communicator.md
@@ -1,0 +1,89 @@
+# Mock Communicator
+
+```js
+/**
+ * micro:bit + Dataflow: "Mock Communicator"
+ *
+ * This is a program for the micro:bit physically attached to the computer, used for development on the dataflow side.
+ * This is designed to mock output from the communicator micro:bit that connects to a world of radio networked sensor/actuator hubs
+ * Readings begin as numbers and strings are are concatenated before sending to serial
+ *
+ *  (name: sat, value: 20.4)     sat20.2      "the temperature reading on microbit a is 20.2 degrees"
+ *  (name: sbt, value: 17.32)    sbt17.32     "the temperature reading on microbit b is 17.32 degrees"
+ *  (name: sah, value: 40)       sah40        "the humidity reading on microbit a is 40 percent"
+ *  (name: sar, value: "010")    sar010       "the state of relays on microbit a is [off, on, off]"
+ *
+ * [ A ] - on - send mock messages
+ * [ B ] - off - don't send messages
+ */
+
+let mode = 0
+let mIndex = 0
+
+
+function turnOn() {
+    mode = 1
+    basic.showIcon(IconNames.Happy)
+}
+
+function turnOff() {
+    mode = 0
+    basic.showIcon(IconNames.Asleep)
+}
+
+let messageObjects = [
+    { name: "sar", value: "000" }, // relays on a: off, off, off
+    { name: "sat", value: 10.4 },  // temp a rising...
+    { name: "sat", value: 10.5 },
+    { name: "sat", value: 10.6 },
+    { name: "sbt", value: 11.32 }, // temb b falling...
+    { name: "sbt", value: 11.22 },
+    { name: "sbt", value: 11.12 },
+    { name: "sar", value: "010" }, // relays on a: off, on, off
+    { name: "sah", value: 40 },    // humididty a falling...
+    { name: "sah", value: 20 },
+    { name: "sah", value: 10 },
+
+]
+
+function startUp() {
+    serial.redirect(
+        SerialPin.USB_TX,
+        SerialPin.USB_RX,
+        BaudRate.BaudRate9600
+    )
+    mode = 0
+    mIndex = 0
+    basic.showIcon(IconNames.Asleep)
+}
+
+function nextIndex() {
+    mIndex = mIndex + 1;
+    if (mIndex > messageObjects.length - 1) {
+        mIndex = 0
+    }
+}
+
+function sendStreamMessage(name: string, value: string | number) {
+    if (mode == 1) {
+        serial.writeLine(`${name}${value}`)
+    }
+}
+
+startUp()
+
+input.onButtonPressed(Button.A, function () { turnOn() })
+input.onButtonPressed(Button.B, function () { turnOff() })
+
+basic.forever(function () {
+    if (mode == 1) {
+        nextIndex()
+        for (let i = 0; i < 6; i++) {
+            sendStreamMessage(messageObjects[mIndex].name, messageObjects[mIndex].value)
+        }
+
+    } else {
+        basic.showIcon(IconNames.Asleep)
+    }
+})
+```

--- a/src/plugins/dataflow-tool/serial.md
+++ b/src/plugins/dataflow-tool/serial.md
@@ -1,0 +1,37 @@
+# serial connections to Dataflow
+
+## Serial.ts
+
+`serial.ts` is an object manages the current serial connection, and keeps track of information programs need to interact with the serial port.
+
+```ts
+
+  localBuffer: string;                       // we create our own buffer to scan and "chomp" off complete messages
+  private port: SerialPort | null;           // points to browser instance of a serial port
+  connectChangeStamp: number | null;         // the last time the connection status changed, see below
+  lastConnectMessage: string | null;         // we track the last connection message
+  deviceInfo: SerialPortInfo | null;         // vendor and device id are presented on connection, and we store here
+  serialNodesCount: number;                  // we want to know how many nodes we have that need a serial connection
+  writer: WritableStreamDefaultWriter;       // points to an instance browsers writing utility
+  serialModalShown: boolean | null;          // we may not want to show the modal over and over
+  deviceFamily: string | null;               // at the moment, we only need to know if it's an arduino or a micro:bit
+
+```
+
+`requestAndSetPort`
+This is called whenever the connection is refreshed, (when the connect button is clicked).  This results in the browsers serial connection dialog, and gives us the opportunity to learn and store what device is connected, so we can run the correct code later on.
+
+The filters commented out were set up so that only Arduino boards (and close-match non-Arduinos such as the DFRobot one) will show as options for users to connect.  It turns out that there are working Arduino clones that do not match these filters, one of which is being shipped with the latest generation of BB hardware. Rather than attempt to match every non-standard board, we are removing the filters for now and adding a message to the dialog that should help users make the right selection. A TODO item would be to import an updatable and comprehensive list and use it to dynamically create filters.
+
+Additionally, we now work with a set of programs designed to be used with specific micro:bit programs. We can reliably identify a micro:bit using `deviceInfo`.   Therefore, for now in Dataflow we assume that if we are connected to something other than a micro:bit, it as an arduino.
+
+`handleStream`
+Given the stream from the port, and the channels, `handleStream` is responsible for three things:
+1. Setting up the reader.
+2. Sets up the writer to be used later.
+3. Listens to incoming data at the serial port, and while the port is readable, it sends each `value` to either `handleArduinoStreamObj` or `handleMicroBitStreamObj`, depending on the `deviceInfo`.
+
+`handleArduinoStreamObj` or `handleMicroBitStreamObj`
+When each of these functions gets the value from the stream, it is a malformed string representation of any number of whole or partial serial messages, chomped off the stream at unpredictable spots that do not respect the original boundaries of the data.  So, it has to reconstitute sensible messages.  To do so, it appends the value to a local buffer.  Then, it scans that local buffer looking for a match of a legitimate value.  The matching expression is closely paired with the devices and the sensors and actuators that we are using with Dataflow.
+
+When it finds a match, it parses out the values it needs, including an indicator of which channel this value should be headed to.  It searches for the corerect channel, and if it finds it, sets the value on the channel.

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -28,8 +28,9 @@ import { DataflowProgramToolbar } from "./ui/dataflow-program-toolbar";
 import { DataflowProgramTopbar } from "./ui/dataflow-program-topbar";
 import { DataflowProgramCover } from "./ui/dataflow-program-cover";
 import { DataflowProgramZoom } from "./ui/dataflow-program-zoom";
-import { NodeChannelInfo, NodeGeneratorTypes, ProgramDataRates, NodeTimerInfo,
-         virtualSensorChannels, serialSensorChannels} from "../model/utilities/node";
+import { NodeChannelInfo, serialSensorChannels } from "../model/utilities/channel";
+import { NodeGeneratorTypes, ProgramDataRates, NodeTimerInfo } from "../model/utilities/node";
+import { virtualSensorChannels } from "../model/utilities/virtual-channel";
 import { Rect, scaleRect, unionRect } from "../utilities/rect";
 import { DocumentContextReact } from "../../../components/document/document-context";
 import { SerialDevice } from "../../../models/stores/serial";
@@ -558,8 +559,12 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
   private passSerialStateToChannel(sd: SerialDevice, channel: NodeChannelInfo){
     if (sd.hasPort()){
       channel.serialConnected = true;
-      channel.missing = false;
-    } else {
+      const deviceMismatch = sd.deviceFamily !== channel.deviceFamily;
+      const timeSinceActive = channel.usesSerial && channel.lastMessageRecievedAt
+        ? Date.now() - channel.lastMessageRecievedAt: 0;
+      channel.missing = deviceMismatch || timeSinceActive > 5000;
+    }
+    else {
       channel.serialConnected = false;
       channel.missing = true;
     }
@@ -569,12 +574,11 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
     // implementing with a "count" of 1 or 0 in case we need to count nodes in future
     let serialNodesCt = 0;
 
-    //sensor will need serial once these particular sensors are chosen
     nodes.forEach((n) => {
-      if(n.data.sensor === "emg" || n.data.sensor === "fsr"){
+      const isLiveSensor = /fsr|emg|[th]-[abcd]/; // match ids any live sensor channels
+      if(isLiveSensor.test(n.data.sensor as string)){
         serialNodesCt++;
       }
-
       //live output block will alert need for serial
       // only after connection to another node is made
       // this allows user to drag a block out and work on program before connecting
@@ -597,8 +601,15 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
   }
 
   private sendDataToSerialDevice(n: Node){
-    if (isFinite(n.data.nodeValue as number)){
-      this.stores.serialDevice.writeToOut(n.data.nodeValue as number);
+    const isNumberOutput = isFinite(n.data.nodeValue as number);
+    const { deviceFamily } = this.stores.serialDevice;
+
+    if (deviceFamily === "arduino" && isNumberOutput){
+      this.stores.serialDevice.writeToOutForArduino(n.data.nodeValue as number);
+    }
+    if (deviceFamily === "microbit"){
+      // UPCOMING PT: #184753741 control messages out to hubs
+      this.stores.serialDevice.writeToOutForMicroBit(n.data.nodeValue as any);
     }
   }
 
@@ -611,7 +622,6 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
       Click the ⚡️ button on the upper left, then select your device in the popup.
       Devices differ, but it may contain the words "usbserial" or "usbmodem"`;
 
-      // no physical connection
     if (lastMsg !== "connect" && this.stores.serialDevice.serialNodesCount > 0){
       alertMessage += `1. Connect the arduino to your computer.  2.${btnMsg}`;
     }
@@ -746,5 +756,4 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
     const { transform } = this.programEditor.view.area;
     this.props.onZoomChange(transform.x, transform.y, transform.k);
   };
-
 }

--- a/src/plugins/dataflow/model/dataflow-content.ts
+++ b/src/plugins/dataflow/model/dataflow-content.ts
@@ -74,7 +74,7 @@ export const DataflowContentModel = TileContentModel
     }
   }))
   .actions(self => tileModelHooks({
-    doPostCreate(metadata: ITileMetadataModel){
+    doPostCreate(metadata: ITileMetadataModel) {
       self.metadata = metadata;
     }
   }))

--- a/src/plugins/dataflow/model/utilities/channel.ts
+++ b/src/plugins/dataflow/model/utilities/channel.ts
@@ -1,0 +1,135 @@
+export interface NodeChannelInfo {
+  hubId: string;
+  hubName: string;
+  channelId: string;
+  missing: boolean;
+  type: string;
+  units: string;
+  value: number;
+  name: string;
+  virtual?: boolean;
+  virtualValueMethod?: (t: number) => number;
+  usesSerial?:boolean;
+  serialConnected?:boolean | null;
+  outputTargetDevice?: string;
+  outputTargetActuator?: string;
+  timeFactor?: number;
+  deviceFamily?: string;
+  lastMessageRecievedAt?: number | null;
+  relaysState?: number[]
+}
+
+const emgSensorChannel: NodeChannelInfo = {
+  hubId: "SERIAL-ARDUINO",
+  hubName: "Arduino",
+  name: "emg",
+  channelId: "emg",
+  missing: true,
+  type: "emg-reading",
+  units: "f(mv)",
+  value: 0,
+  virtual: false,
+  usesSerial: true,
+  serialConnected: null,
+  deviceFamily: "arduino"
+};
+
+export const fsrSensorChannel: NodeChannelInfo = {
+  hubId: "SERIAL-ARDUINO",
+  hubName: "Arduino",
+  name: "fsr",
+  channelId: "fsr",
+  missing: true,
+  type: "fsr-reading",
+  units: "n",
+  value: 0,
+  virtual: false,
+  usesSerial: true,
+  serialConnected: null,
+  deviceFamily: "arduino"
+};
+
+interface MicroBitSensorChannelInfo {
+  microBitId: string,
+  type: string,
+  units: string
+}
+
+interface MicroBitHubInfo {
+  microBitId: string,
+  location?: string
+}
+
+const microBitHubs = [
+  { microBitId: "a", relaysState: [0,0,0] },
+  { microBitId: "b", relaysState: [0,0,0] },
+  { microBitId: "c", relaysState: [0,0,0] },
+  { microBitId: "d", relaysState: [0,0,0] },
+];
+
+const microBitSensors: MicroBitSensorChannelInfo[] = [
+ { microBitId: "a", type: "temperature", units: "°C" },
+ { microBitId: "a", type: "humidity", units: "%" },
+ { microBitId: "b", type: "temperature", units: "°C" },
+ { microBitId: "b", type: "humidity", units: "%" },
+ { microBitId: "c", type: "temperature", units: "°C" },
+ { microBitId: "c", type: "humidity", units: "%" },
+ { microBitId: "d", type: "temperature", units: "°C" },
+ { microBitId: "d", type: "humidity", units: "%" }
+];
+
+function createMicroBitSensorChannels(sensors: MicroBitSensorChannelInfo[] ){
+  const basis = {
+    missing: true,
+    value: 0,
+    virtual: false,
+    usesSerial: true,
+    serialConnected: null,
+    deviceFamily: "microbit",
+    lastMessageRecievedAt: Date.now()
+  };
+
+  const channels = sensors.map((s) => {
+    return {
+      ...basis,
+      hubId: `MICROBIT-RADIO-${s.microBitId}`,
+      hubName: `microbit ${s.microBitId}`,
+      name: `${s.type}-microbit-${s.microBitId}`,
+      channelId: `${s.type.substring(0,1)}-${s.microBitId}`,
+      type: `${s.type}`,
+      units: `${s.units}`    };
+  });
+  return channels;
+}
+
+function createMicroBitRelayInfoChannels(hubs: MicroBitHubInfo[] ){
+  const basis = {
+    missing: true,
+    value: 0,
+    virtual: false,
+    type: "relays",
+    usesSerial: true,
+    serialConnected: null,
+    deviceFamily: "microbit",
+    lastMessageRecievedAt: Date.now()
+  };
+
+  const channels = hubs.map((h) => {
+    return {
+      ...basis,
+      hubId: `MICROBIT-RADIO-${h.microBitId}`,
+      hubName: `microbit ${h.microBitId}`,
+      name: `relays-microbit-${h.microBitId}`,
+      channelId: `r-${h.microBitId}`,
+      units: `b`
+    };
+  });
+  return channels;
+}
+
+const microBitSensorChannels = createMicroBitSensorChannels(microBitSensors);
+const microBitRelayChannels = createMicroBitRelayInfoChannels(microBitHubs);
+
+export const serialSensorChannels: NodeChannelInfo[] = [
+  emgSensorChannel, fsrSensorChannel, ...microBitSensorChannels, ...microBitRelayChannels
+];

--- a/src/plugins/dataflow/model/utilities/node.ts
+++ b/src/plugins/dataflow/model/utilities/node.ts
@@ -40,8 +40,6 @@ import CurrentValueIcon from "../../assets/icons/control/control-current-value.s
 import PreviousValueIcon from "../../assets/icons/control/control-previous-value.svg";
 import ZeroValueIcon from "../../assets/icons/control/control-zero-value.svg";
 
-import { demoStreams } from "./demo-data";
-
 export interface NodeType {
   name: string;
   displayName: string;
@@ -311,6 +309,18 @@ export const NodeLiveOutputTypes = [
   {
     name: "Grabber",
     icon: GrabberIcon
+  },
+  {
+    name: "Sprinkler",
+    icon: GrabberIcon
+  },
+  {
+    name: "Fan",
+    icon: GrabberIcon
+  },
+  {
+    name: "Heat Lamp",
+    icon: GrabberIcon
   }
 ];
 
@@ -351,23 +361,6 @@ export const NodeTimerInfo =
 {
   method: (t: number, tOn: number, tOff: number) => t % (tOn + tOff) < tOn ? 1 : 0,
 };
-
-export interface NodeChannelInfo {
-  hubId: string;
-  hubName: string;
-  channelId: string;
-  missing: boolean;
-  type: string;
-  units: string;
-  plug: number;
-  value: number;
-  name: string;
-  virtual?: boolean;
-  virtualValueMethod?: (t: number) => number;
-  usesSerial?:boolean;
-  serialConnected?:boolean | null;
-  timeFactor?: number;
-}
 
 export const roundNodeValue = (n: number) => {
   return Math.round(n * 1000) / 1000;
@@ -418,115 +411,3 @@ export const ProgramDataRates: ProgramDataRate[] = [
 
 export const kSensorSelectMessage = "Select a sensor";
 export const kSensorMissingMessage = "⚠️";
-
-const virtualTempChannel: NodeChannelInfo = {
-  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "Temperature", channelId: "00001-VIR",
-  missing: false, type: "temperature", units: "°C", plug: 1, value: 0, virtual: true, timeFactor: 1000,
-  virtualValueMethod: (t: number) => {
-    const vals = [20, 20, 20, 21, 21, 21, 20, 20, 21, 21, 21, 21, 21, 21, 21];
-    return vals[t % vals.length];
-  } };
-const virtualHumidChannel: NodeChannelInfo = {
-  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "Humidity", channelId: "00002-VIR",
-  missing: false, type: "humidity", units: "%", plug: 2, value: 0, virtual: true, timeFactor: 1000,
-  virtualValueMethod: (t: number) => {
-    const vals = [60, 60, 60, 61, 61, 61, 62, 62, 62, 61, 61, 61, 61, 61, 61, 61];
-    return vals[t % vals.length];
-  } };
-const virtualCO2Channel: NodeChannelInfo = {
-  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "CO2", channelId: "00003-VIR",
-  missing: false, type: "CO2", units: "PPM", plug: 3, value: 0, virtual: true, timeFactor: 1000,
-  virtualValueMethod: (t: number) => {
-    const vals = [409, 409, 410, 410, 410, 410, 411, 411, 410, 410, 410, 409, 409, 411, 411];
-    return vals[t % vals.length];
-  } };
-const virtualO2Channel: NodeChannelInfo = {
-  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "O2", channelId: "00004-VIR",
-  missing: false, type: "O2", units: "PPM", plug: 4, value: 0, virtual: true, timeFactor: 1000,
-  virtualValueMethod: (t: number) => {
-    const vals = [21, 21, 21, 22, 22, 22, 21, 21, 21, 21, 22, 22, 22, 22, 22];
-    return vals[t % vals.length];
-  } };
-const virtualLightChannel: NodeChannelInfo = {
-  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "Light", channelId: "00005-VIR",
-  missing: false, type: "light", units: "lux", plug: 5, value: 0, virtual: true, timeFactor: 1000,
-  virtualValueMethod: (t: number) => {
-    const vals = [9000, 9000, 9001, 9001, 9002, 9002, 9002, 9001, 9001, 9001, 9000, 9001, 9001, 9002, 9002];
-    return vals[t % vals.length];
-  } };
-const virtualPartChannel: NodeChannelInfo = {
-  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "Particulates", channelId: "00006VIR",
-  missing: false, type: "particulates", units: "PM2.5", plug: 7, value: 0, virtual: true, timeFactor: 1000,
-  virtualValueMethod: (t: number) => {
-    const vals = [10, 10, 10, 10, 10, 10, 11, 11, 11, 11, 11, 11, 11, 11, 11];
-    return vals[t % vals.length];
-  } };
-const virtualEmgChannelVaried: NodeChannelInfo = {
-  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "EMG - Varied Clenches", channelId: "00007VIR",
-  missing: false, type: "emg-reading", units: "f(mv)", plug: 8, value: 0, virtual: true, timeFactor: 100,
-  virtualValueMethod: (t: number) => {
-    const vals = demoStreams.emgVariedPulses;
-    return vals[t % vals.length];
-} };
-const virtualEmgChannelLongHold: NodeChannelInfo = {
-  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "EMG - Long Clench and Hold", channelId: "00008VIR",
-  missing: false, type: "emg-reading", units: "f(mv)", plug: 9, value: 0, virtual: true, timeFactor: 100,
-  virtualValueMethod: (t: number) => {
-    const vals = demoStreams.emgLongHold;
-    return vals[t % vals.length];
-} };
-const virtualEmgChannelShortHold: NodeChannelInfo = {
-  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "EMG - Short Clench and Hold", channelId: "00009VIR",
-  missing: false, type: "emg-reading", units: "f(mv)", plug: 10, value: 0, virtual: true, timeFactor: 100,
-  virtualValueMethod: (t: number) => {
-    const vals = demoStreams.emgShortHold;
-    return vals[t % vals.length];
-} };
-const virtualFsrChannel: NodeChannelInfo = {
-  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "FSR", channelId: "00010VIR",
-  missing: false, type: "fsr-reading", units: "f(n)", plug: 11, value: 0, virtual: true, timeFactor: 100,
-  virtualValueMethod: (t: number) => {
-    const vals = demoStreams.fsrSqueeze;
-    return vals[t % vals.length];
-} };
-
-export const virtualSensorChannels: NodeChannelInfo[] = [
-  virtualTempChannel, virtualHumidChannel, virtualCO2Channel, virtualO2Channel,
-  virtualLightChannel, virtualPartChannel,
-  virtualEmgChannelVaried, virtualEmgChannelLongHold, virtualEmgChannelShortHold,
-  virtualFsrChannel
-];
-
-const emgSensorChannel: NodeChannelInfo = {
-  hubId: "SERIAL-ARDUINO",
-  hubName: "Arduino",
-  name: "emg",
-  channelId: "emg",
-  missing: true,
-  type: "emg-reading",
-  units: "f(mv)",
-  plug: 9,
-  value: 0,
-  virtual: false,
-  usesSerial: true,
-  serialConnected: null
-};
-
-const fsrSensorChannel: NodeChannelInfo = {
-  hubId: "SERIAL-ARDUINO",
-  hubName: "Arduino",
-  name: "fsr",
-  channelId: "fsr",
-  missing: true,
-  type: "fsr-reading",
-  units: "n",
-  plug: 10,
-  value: 0,
-  virtual: false,
-  usesSerial: true,
-  serialConnected: null
-};
-
-export const serialSensorChannels: NodeChannelInfo[] = [
-  emgSensorChannel, fsrSensorChannel
-];

--- a/src/plugins/dataflow/model/utilities/virtual-channel.ts
+++ b/src/plugins/dataflow/model/utilities/virtual-channel.ts
@@ -1,0 +1,80 @@
+import { NodeChannelInfo } from "./channel";
+import { demoStreams } from "./demo-data";
+
+const virtualTempChannel: NodeChannelInfo = {
+  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "Temperature", channelId: "00001-VIR",
+  missing: false, type: "temperature", units: "°C", value: 0, virtual: true, timeFactor: 1000,
+  virtualValueMethod: (t: number) => {
+    const vals = [20, 20, 20, 21, 21, 21, 20, 20, 21, 21, 21, 21, 21, 21, 21];
+    return vals[t % vals.length];
+  } };
+const virtualHumidChannel: NodeChannelInfo = {
+  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "Humidity", channelId: "00002-VIR",
+  missing: false, type: "humidity", units: "%", value: 0, virtual: true, timeFactor: 1000,
+  virtualValueMethod: (t: number) => {
+    const vals = [60, 60, 60, 61, 61, 61, 62, 62, 62, 61, 61, 61, 61, 61, 61, 61];
+    return vals[t % vals.length];
+  } };
+const virtualCO2Channel: NodeChannelInfo = {
+  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "CO2", channelId: "00003-VIR",
+  missing: false, type: "CO2", units: "PPM", value: 0, virtual: true, timeFactor: 1000,
+  virtualValueMethod: (t: number) => {
+    const vals = [409, 409, 410, 410, 410, 410, 411, 411, 410, 410, 410, 409, 409, 411, 411];
+    return vals[t % vals.length];
+  } };
+const virtualO2Channel: NodeChannelInfo = {
+  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "O2", channelId: "00004-VIR",
+  missing: false, type: "O2", units: "PPM", value: 0, virtual: true, timeFactor: 1000,
+  virtualValueMethod: (t: number) => {
+    const vals = [21, 21, 21, 22, 22, 22, 21, 21, 21, 21, 22, 22, 22, 22, 22];
+    return vals[t % vals.length];
+  } };
+const virtualLightChannel: NodeChannelInfo = {
+  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "Light", channelId: "00005-VIR",
+  missing: false, type: "light", units: "lux", value: 0, virtual: true, timeFactor: 1000,
+  virtualValueMethod: (t: number) => {
+    const vals = [9000, 9000, 9001, 9001, 9002, 9002, 9002, 9001, 9001, 9001, 9000, 9001, 9001, 9002, 9002];
+    return vals[t % vals.length];
+  } };
+const virtualPartChannel: NodeChannelInfo = {
+  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "Particulates", channelId: "00006VIR",
+  missing: false, type: "particulates", units: "PM2.5", value: 0, virtual: true, timeFactor: 1000,
+  virtualValueMethod: (t: number) => {
+    const vals = [10, 10, 10, 10, 10, 10, 11, 11, 11, 11, 11, 11, 11, 11, 11];
+    return vals[t % vals.length];
+  } };
+const virtualEmgChannelVaried: NodeChannelInfo = {
+  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "EMG - Varied Clenches", channelId: "00007VIR",
+  missing: false, type: "emg-reading", units: "f(mv)", value: 0, virtual: true, timeFactor: 100,
+  virtualValueMethod: (t: number) => {
+    const vals = demoStreams.emgVariedPulses;
+    return vals[t % vals.length];
+} };
+const virtualEmgChannelLongHold: NodeChannelInfo = {
+  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "EMG - Long Clench and Hold", channelId: "00008VIR",
+  missing: false, type: "emg-reading", units: "f(mv)", value: 0, virtual: true, timeFactor: 100,
+  virtualValueMethod: (t: number) => {
+    const vals = demoStreams.emgLongHold;
+    return vals[t % vals.length];
+} };
+const virtualEmgChannelShortHold: NodeChannelInfo = {
+  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "EMG - Short Clench and Hold", channelId: "00009VIR",
+  missing: false, type: "emg-reading", units: "f(mv)", value: 0, virtual: true, timeFactor: 100,
+  virtualValueMethod: (t: number) => {
+    const vals = demoStreams.emgShortHold;
+    return vals[t % vals.length];
+} };
+const virtualFsrChannel: NodeChannelInfo = {
+  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "FSR", channelId: "00010VIR",
+  missing: false, type: "fsr-reading", units: "f(n)", value: 0, virtual: true, timeFactor: 100,
+  virtualValueMethod: (t: number) => {
+    const vals = demoStreams.fsrSqueeze;
+    return vals[t % vals.length];
+} };
+
+export const virtualSensorChannels: NodeChannelInfo[] = [
+  virtualTempChannel, virtualHumidChannel, virtualCO2Channel, virtualO2Channel,
+  virtualLightChannel, virtualPartChannel,
+  virtualEmgChannelVaried, virtualEmgChannelLongHold, virtualEmgChannelShortHold,
+  virtualFsrChannel
+];

--- a/src/plugins/dataflow/nodes/controls/sensor-select-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/sensor-select-control.tsx
@@ -2,8 +2,8 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import React, { useRef }  from "react";
 import Rete, { NodeEditor, Node } from "rete";
-import { NodeSensorTypes, NodeChannelInfo,
-         kSensorSelectMessage, kSensorMissingMessage } from "../../model/utilities/node";
+import { NodeSensorTypes, kSensorSelectMessage, kSensorMissingMessage } from "../../model/utilities/node";
+import { NodeChannelInfo } from "../../model/utilities/channel";
 import { useStopEventPropagation, useCloseDropdownOnOutsideEvent } from "./custom-hooks";
 import DropdownCaretIcon from "../../assets/icons/dropdown-caret.svg";
 import { dataflowLogEvent } from "../../dataflow-logger";
@@ -135,20 +135,22 @@ export class SensorSelectControl extends Rete.Control {
                                     });
 
       const channelsForType = channels.filter((ch: NodeChannelInfo) => {
-        return (ch.type === type) || (type === "none");
+        if (ch.type !== "relays"){
+          return (ch.type === type) || (type === "none");
+        }
       });
       const selectedChannel = channelsForType.find((ch: any) => ch.channelId === id);
 
       const getChannelString = (ch?: NodeChannelInfo | "none") => {
-        if (!ch && (!id || id === "none")) return kSensorSelectMessage;
         if (ch === "none") return "None Available";
+        if (!ch && (!id || id === "none")) return kSensorSelectMessage;
         if (!ch) return `${kSensorMissingMessage} ${id}`;
-        if (ch.missing) return `${kSensorMissingMessage} connect for live ${ch.name}`;
+        if (ch.missing) return `${kSensorMissingMessage} connect ${ch.deviceFamily} for ${ch.name}`;
         let count = 0;
         channelsForType.forEach( c => { if (c.type === ch.type && ch.hubId === c.hubId) count++; } );
         const chStr = ch.virtual
           ? `${ch.name} Demo Data`
-          : `${ch.hubName}:${ch.type}${ch.plug > 0 && count > 1 ? `(plug ${ch.plug})` : ""}`;
+          : `${ch.hubName}:${ch.type}`;
         return chStr;
       };
 


### PR DESCRIPTION
This creates functionality described in [PT#184753679](https://www.pivotaltracker.com/n/projects/2441242/stories/184753679), and [PT#184770831](https://www.pivotaltracker.com/n/projects/2441242/stories/184770831)

#### overall functionality
- Dataflow sensor node works with both Arduino and micro:bit connected sensor setups
- Given various streams of data coming in through serial port, Dataflow can indicate which sensors are available.  
- Dataflow can parse and display the stream of sensor readings and relay states from multiple sensor sources
- If a sensor is not heard from in over 5 seconds it is indicated as missing until we get a fresh signal. 
- Dataflow can parse messages about the state of remote relays

#### micro:bit programs and api
-  `mock_communicator` can be loaded onto a micro:bit and simulates data coming in from a network of numerous micro:bits and sends it through to the computer's serial port.   It can be used for developing and debugging on the Dataflow side without the need to set up a network of micro:bits
- `communicator`  is the program to run on the computer-connected "communicator" micro:bit. This story includes the serial -> dataflow stage, and the dataflow -> serial stage will be in a future story (though some functions are stubbed in this PR)
- `hub` is the program to run on the "hub" micro:bit(s) connected to sensors (relay functionality coming in a later story)

#### notes

`node.ts`
- Channel definitions and instantiations are moved from `node.ts` to new files, `channel.ts`, and `virtual-channel.ts`

 `serial.ts:` 
- `requestAndSetPort` now stores `deviceFamily` in order to determine what to do with incoming serial data
- `handleStream` handles all input, and then passes it to an implementation of a local buffer/parser depending on the `deviceFamily`
- The notion of `plug` has been removed from the channel api.  It was not being used. 

`dataflow-program`
- the existing `passSerialStateToChannel` function now also tests to see if it has been "a long time" since receiving a reading from the given channel.  If it has, it set's the channel's `missing` property to true.  `missing` is an existing pattern that is inherited from the original system. 

`serial.md`
- This file was added to replace the lengthy comment about device filters that was inline in `serial.ts`