### PR TITLE
feat: Loading unchanged image tiles should not register as change (PT-184824215)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ $ npm run deploy:firebase:rules     # deploys firebase (realtime database) rules
 To enable per component debugging set the "debug" localstorage key with one or more of the following:
 
 - `canvas` this will show the document key over the canvas, useful for looking up documents in Firebase
+- `cms` this will print info to the console as changes are made to authored content via the CMS
 - `document` this will add the active document as `window.currentDocument`, you can use MST's hidden toJSON() like `currentDocument.toJSON()` to views its content.
 - `history` this will print some info the console as the history system records changes in the document.
 - `images` this will set `window.imageMap` so you can look at the status and URLs of images that have been loaded.

--- a/docs/cms.md
+++ b/docs/cms.md
@@ -35,9 +35,6 @@ It would be helpful if the unit configuration could be edited in the CMS. Perhap
 ## Preview of a section on the right side of the CMS
 This would allow the author to see the section in its read-only mode like what is seen in the CLUE curriculum tabs.
 
-## Debug flag to log CMS onChange document export
-To help track down issues like the image tile changes, it would be useful to log each CMS onChange along with the value being sent. This should make it easy to see what changes are being sent. I suspect we'll routinely find things that cause unexpected changes in the export.
-
 # Known Issues
 
 ## Backup Draft

--- a/src/cms/clue-control.tsx
+++ b/src/cms/clue-control.tsx
@@ -8,6 +8,7 @@ import { EditableDocumentContent } from "../components/document/editable-documen
 import { appConfig, AppProvider, initializeApp } from "../initialize-app";
 import { IStores } from "../models/stores/stores";
 import { createDocumentModel, DocumentModelType } from "../models/document/document";
+import { DEBUG_CMS } from "../lib/debug";
 
 import "./clue-control.scss";
 import "./custom-control.scss";
@@ -93,9 +94,15 @@ export class ClueControl extends React.Component<CmsWidgetControlProps, IState> 
             // Looking at the CMS code it seems safer to pass an immutable object here
             // not a plain JS object. The plain JS object does get saved correctly,
             // but it also gets returned in the value property so it means sometimes the value
-            // is a immutable object and sometimes it is a plan JS object.
+            // is a immutable object and sometimes it is a plain JS object.
             const immutableValue = Map(parsedJson);
             this.props.onChange(immutableValue);
+            if (DEBUG_CMS) {
+              // eslint-disable
+              console.log("DEBUG: CMS ClueControl onChange called with new content value: ", parsedJson);
+              console.log("DEBUG: CMS ClueControl initial content value was: ", initialValue);
+              // eslint-enable
+            }
           }
         }
       });

--- a/src/cms/clue-control.tsx
+++ b/src/cms/clue-control.tsx
@@ -57,6 +57,11 @@ export class ClueControl extends React.Component<CmsWidgetControlProps, IState> 
 
     const initialValue = this.getValue();
 
+    if (DEBUG_CMS) {
+      // eslint-disable-next-line no-console
+      console.log("DEBUG: CMS ClueControl initial content value is: ", initialValue);
+    }
+
     initializeAppPromise.then((stores) => {
 
       // Wait to construct the document until the main CLUE stuff is
@@ -98,10 +103,8 @@ export class ClueControl extends React.Component<CmsWidgetControlProps, IState> 
             const immutableValue = Map(parsedJson);
             this.props.onChange(immutableValue);
             if (DEBUG_CMS) {
-              // eslint-disable
+              // eslint-disable-next-line no-console
               console.log("DEBUG: CMS ClueControl onChange called with new content value: ", parsedJson);
-              console.log("DEBUG: CMS ClueControl initial content value was: ", initialValue);
-              // eslint-enable
             }
           }
         }

--- a/src/lib/debug.ts
+++ b/src/lib/debug.ts
@@ -7,6 +7,7 @@ if (debug.length > 0) {
 const debugContains = (key: string) => debug.indexOf(key) !== -1;
 
 export const DEBUG_CANVAS = debugContains("canvas");
+export const DEBUG_CMS = debugContains("cms");
 export const DEBUG_DOCUMENT = debugContains("document");
 export const DEBUG_HISTORY = debugContains("history");
 export const DEBUG_IMAGES = debugContains("images");


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/184824215

Adds a `cms` debug flag for tracking content changes in the CMS.