### PR TITLE
fix: Styling missing on links (PT-184882521)

### DIFF
--- a/src/cms/clue-control.scss
+++ b/src/cms/clue-control.scss
@@ -1,7 +1,13 @@
-.loading-box {
-  align-items: center;
-  display: flex;
-  height: 650px;
-  justify-content: center;
-  width: 100%;
+.clue-control {
+  // Override/revert Decap CMS style rules that adversely affect
+  // CLUE content styling in the editor.
+  a:active, a:link, a:hover, a:visited {
+    color: revert;
+    text-decoration: revert;
+  }
+  ul, ol {
+    color: rgb(49, 61, 62);
+    font-size: 15px;
+    padding-left: revert;
+  }
 }

--- a/src/cms/clue-control.tsx
+++ b/src/cms/clue-control.tsx
@@ -126,7 +126,7 @@ export class ClueControl extends React.Component<CmsWidgetControlProps, IState> 
       return (
         <AppProvider stores={this.state.stores} modalAppElement="#nc-root">
           <EditableDocumentContent
-            className="custom-widget"
+            className="custom-widget clue-control"
             contained={true}
             mode="1-up"
             isPrimary={true}

--- a/src/cms/custom-control.scss
+++ b/src/cms/custom-control.scss
@@ -1,26 +1,13 @@
+.loading-box {
+  align-items: center;
+  display: flex;
+  height: 650px;
+  justify-content: center;
+  width: 100%;
+}
 .custom-widget {
   border: 2px solid #ddd;
   border-bottom-left-radius: 5px;
   border-bottom-right-radius: 5px;
   border-top-right-radius: 5px;
-
-  /*
-   * To override or revert Decap CMS style rules that adversely affect
-   * CLUE content styling in the editor, place related style rules
-   * within the .canvas .document-content block below.
-   */
-  .canvas .document-content {
-    .text-tool-tile {
-      a {
-        color: revert;
-        text-decoration: revert;
-      }
-      ul, ol {
-        color: rgb(49, 61, 62);
-        font-size: 15px;
-        padding-left: revert;
-      }
-    }
-  }
-
 }

--- a/src/cms/custom-control.scss
+++ b/src/cms/custom-control.scss
@@ -5,12 +5,16 @@
   border-top-right-radius: 5px;
 
   /*
-   * To override or revert Decap CMS styling that adversely affects
-   * Clue content styling in the editor, place related style rules
+   * To override or revert Decap CMS style rules that adversely affect
+   * CLUE content styling in the editor, place related style rules
    * within the .canvas .document-content block below.
    */
   .canvas .document-content {
     .text-tool-tile {
+      a {
+        color: revert;
+        text-decoration: revert;
+      }
       ul, ol {
         color: rgb(49, 61, 62);
         font-size: 15px;


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/184882521

In the CMS, links are rendered in dark gray text and do not have an underline, which makes them difficult to see. These changes revert the color and text-decoration CSS rules for links within the CLUE canvas part of the CMS so links within tiles are more visible.