### PR TITLE
refactor tile drag code and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ To enable per component debugging set the "debug" localstorage key with one or m
 - `canvas` this will show the document key over the canvas, useful for looking up documents in Firebase
 - `cms` this will print info to the console as changes are made to authored content via the CMS
 - `document` this will add the active document as `window.currentDocument`, you can use MST's hidden toJSON() like `currentDocument.toJSON()` to views its content.
+- `drop` console log the dataTransfer object from drop events on the document.
 - `history` this will print some info the console as the history system records changes in the document.
 - `images` this will set `window.imageMap` so you can look at the status and URLs of images that have been loaded.
 - `listeners` console log the adding, removing, and firing of firebase listeners

--- a/src/components/document/document-content.tsx
+++ b/src/components/document/document-content.tsx
@@ -12,6 +12,7 @@ import { DocumentContentModelType, IDragTilesData, IDragToolCreateInfo } from ".
 import { getTileContentInfo } from "../../models/tiles/tile-content-info";
 import { getDocumentIdentifier } from "../../models/document/document-utils";
 import { IDropRowInfo } from "../../models/document/tile-row";
+import { logDataTransfer } from "../../models/document/drag-tiles";
 import { TileApiInterfaceContext } from "../tiles/tile-api";
 import { dragTileSrcDocId, kDragTileCreate, kDragTiles } from "../tiles/tile-component";
 import { safeJsonParse } from "../../utilities/js-utils";
@@ -427,6 +428,8 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
     content?.showPendingInsertHighlight(false);
 
     if (!e.dataTransfer || !content || readOnly) return;
+
+    logDataTransfer(e.dataTransfer);
 
     if (this.hasDragType(e.dataTransfer, kDragResizeRowId)) {
       this.handleRowResizeDrop(e);

--- a/src/lib/debug.ts
+++ b/src/lib/debug.ts
@@ -9,6 +9,7 @@ const debugContains = (key: string) => debug.indexOf(key) !== -1;
 export const DEBUG_CANVAS = debugContains("canvas");
 export const DEBUG_CMS = debugContains("cms");
 export const DEBUG_DOCUMENT = debugContains("document");
+export const DEBUG_DROP = debugContains("drop");
 export const DEBUG_HISTORY = debugContains("history");
 export const DEBUG_IMAGES = debugContains("images");
 export const DEBUG_LISTENERS = debugContains("listeners");

--- a/src/models/document/document-content-import-types.ts
+++ b/src/models/document/document-content-import-types.ts
@@ -7,7 +7,7 @@
  */
 
 import { DisplayUserType } from "../stores/user-types";
-import { SharedModelEntryType } from "./document-content";
+import { SharedModelEntrySnapshotType } from "./document-content";
 
 // authored content is converted to current content on the fly
 export interface IAuthoredBaseTileContent {
@@ -42,6 +42,7 @@ export function isOriginalSectionHeaderContent(content: IAuthoredTileContent | O
 
 export interface OriginalTileModel {
   id?: string;
+  title?: string;
   display?: DisplayUserType;
   layout?: OriginalTileLayoutModel;
   content: IAuthoredTileContent | OriginalSectionHeaderContent;
@@ -56,7 +57,7 @@ export function isOriginalAuthoredTileModel(tile: OriginalTileModel): tile is Or
 export type OriginalTilesSnapshot = Array<OriginalTileModel | OriginalTileModel[]>;
 
 export interface IDocumentImportSnapshot {
-  sharedModels?: SharedModelEntryType[];
+  sharedModels?: SharedModelEntrySnapshotType[];
   tiles: OriginalTilesSnapshot;
 }
 

--- a/src/models/document/document-content-import.ts
+++ b/src/models/document/document-content-import.ts
@@ -2,7 +2,7 @@ import { cloneDeep } from "lodash";
 import { getSnapshot } from "mobx-state-tree";
 import { ITileModelSnapshotIn } from "../tiles/tile-model";
 import {
-  DocumentContentModel, DocumentContentModelType, INewTileOptions, SharedModelEntryType
+  DocumentContentModel, DocumentContentModelType, INewTileOptions
 } from "./document-content";
 import {
   IDocumentImportSnapshot, isOriginalAuthoredTileModel, isOriginalSectionHeaderContent,

--- a/src/models/document/document-content-import.ts
+++ b/src/models/document/document-content-import.ts
@@ -71,8 +71,12 @@ export function migrateSnapshot(snapshot: IDocumentImportSnapshot): any {
     }
   });
 
-  sharedModels?.forEach((entry:SharedModelEntryType) => {
+  sharedModels?.forEach((entry) => {
     const id = entry.sharedModel.id;
+    if (!id) {
+      console.warn("cannot import a shared model without an id", entry.sharedModel);
+      return;
+    }
     docContent.addSharedModelFromImport(id, entry);
   });
 

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -6,7 +6,7 @@ import {
 } from "../tiles/placeholder/placeholder-content";
 import { kTextTileType } from "../tiles/text/text-content";
 import { getTileContentInfo, IDocumentExportOptions } from "../tiles/tile-content-info";
-import { ITileContentModel } from "../tiles/tile-content";
+import { ITileContentModel, ITileEnvironment } from "../tiles/tile-content";
 import {
   IDragTileItem, TileModel, ITileModel, ITileModelSnapshotIn, ITileModelSnapshotOut
 } from "../tiles/tile-model";
@@ -79,6 +79,7 @@ export const SharedModelEntry = types.model("SharedModelEntry", {
   }
 }));
 export interface SharedModelEntryType extends Instance<typeof SharedModelEntry> {}
+export interface  SharedModelEntrySnapshotType extends SnapshotIn<typeof SharedModelEntry> {}
 
 export interface IDragTilesData {
   sourceDocId: string;
@@ -116,6 +117,9 @@ export const DocumentContentModel = types
     }
 
     return {
+      get tileEnv() {
+        return getEnv(self) as ITileEnvironment | undefined;
+      },
       get isEmpty() {
         return self.tileMap.size === 0;
       },
@@ -1043,7 +1047,7 @@ export const DocumentContentModel = types
 
       return sharedModelEntry;
     },
-    addSharedModelFromImport(id: string, sharedModelEntry: SharedModelEntryType){
+    addSharedModelFromImport(id: string, sharedModelEntry: SharedModelEntrySnapshotType){
       if (self.sharedModelMap){
         self.sharedModelMap.set(id, sharedModelEntry);
       }

--- a/src/models/document/drag-tiles.test.ts
+++ b/src/models/document/drag-tiles.test.ts
@@ -9,7 +9,7 @@ import { SharedModelDocumentManager } from "./shared-model-document-manager";
 import { ITileEnvironment } from "../tiles/tile-content";
 registerTileTypes(["Text"]);
 
-// mock uniqueId so we auto-generated IDs are consistent
+// mock uniqueId so auto-generated IDs are consistent
 let idCount = 0;
 jest.mock("../../utilities/js-utils", () => {
   const { uniqueId, ...others } = jest.requireActual("../../utilities/js-utils");

--- a/src/models/document/drag-tiles.test.ts
+++ b/src/models/document/drag-tiles.test.ts
@@ -107,7 +107,14 @@ describe("tile dragging", () => {
   });
 
   describe("getDragTileItems", () => {
-    describe("when one tile selected", () => {
+    describe("when a non-existent tile is selected", () => {
+      it("returns an empty array", () => {
+        const items = getDragTileItems(documentContent, ["foo"]);
+
+        expect(items).toHaveLength(0);
+      });
+    });
+    describe("when one tile is selected", () => {
       it("returns an array of one IDragTileItem object", () => {
         const items = getDragTileItems(documentContent, ["tile1"]);
 
@@ -130,7 +137,7 @@ Array [
         /*eslint-enable max-len*/
       });
     });
-    describe("when two tiles selected", () => {
+    describe("when two tiles are selected", () => {
       it("returns an array of both IDragTileItem objects", () => {
         const items = getDragTileItems(documentContent, ["tile1", "tile2"]);
 
@@ -187,8 +194,8 @@ Array [
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   describe("getDragTiles", () => {
-    describe("with one tile selected", () => {
-      it("returns that tile", () => {
+    describe("when one tile is selected", () => {
+      it("returns that tile and an the other IDragTiles properties", () => {
         const model = documentContent.getTile("tile1");
         expect(model).toBeDefined();
         const dragTiles = getDragTiles(documentContent, model!, ["tile1"]);

--- a/src/models/document/drag-tiles.test.ts
+++ b/src/models/document/drag-tiles.test.ts
@@ -1,0 +1,325 @@
+import { DocumentContentModel, DocumentContentModelType, DocumentContentSnapshotType } from "./document-content";
+import { getDragTileItems, getDragTiles } from "./drag-tiles";
+
+// This is needed so MST can deserialize snapshots referring to tools
+import { registerTileTypes } from "../../register-tile-types";
+import { IDocumentImportSnapshot } from "./document-content-import-types";
+import { SharedDataSetSnapshotType } from "../shared/shared-data-set";
+import { SharedModelDocumentManager } from "./shared-model-document-manager";
+import { ITileEnvironment } from "../tiles/tile-content";
+registerTileTypes(["Text"]);
+
+// mock uniqueId so we auto-generated IDs are consistent
+let idCount = 0;
+jest.mock("../../utilities/js-utils", () => {
+  const { uniqueId, ...others } = jest.requireActual("../../utilities/js-utils");
+  return {
+    uniqueId: () => `testid-${idCount++}`,
+    ...others
+  };
+});
+
+// Utility function to help with typing and also to setup the sharedModelManager
+function createDocumentContentModel(snapshot: IDocumentImportSnapshot) {
+  const sharedModelManager = new SharedModelDocumentManager();
+  const environment: ITileEnvironment = { sharedModelManager };
+  const content = DocumentContentModel.create(snapshot as DocumentContentSnapshotType, environment);
+  sharedModelManager.setDocument(content);
+  return content;
+}
+
+describe("tile dragging", () => {
+
+  // registerTileTypes returns a promise so Jest will wait for this promise to resolve
+  // before running later `before*` calls and the tests.
+  beforeAll(() => registerTileTypes(["Text", "Table"]));
+
+  let documentContent: DocumentContentModelType;
+  beforeEach(() => {
+    // The DocumentContentModel.create will trigger a calls to uniqueId which
+    // increment idCount. So all of these ids will start at 0.
+    idCount = 0;
+
+    // This has to happen after the types have been registered
+    // Jest takes care of this because registerTileTypes is async and
+    // is in an earlier beforeAll
+    const sharedDataSet: SharedDataSetSnapshotType = {
+      "type": "SharedDataSet",
+      "id": "shared-data-set-1",
+      "providerId": "tile3",
+      "dataSet": {
+        "id": "data-set-1",
+        "name": "Table 1",
+        "attributes": [
+          {
+            "id": "attribute-1",
+            "name": "x",
+            "values": ["0"]
+          },
+          {
+            "id": "attribute-2",
+            "name": "y",
+            "values": ["1"]
+          }
+        ],
+        "cases": [
+          {"__id__": "case-1"}
+        ]
+      }
+    };
+
+    documentContent = createDocumentContentModel({
+      tiles: [
+        {
+          id: "tile1",
+          title: "tile 1",
+          content: {
+            type: "Text"
+          }
+        },
+        {
+          id: "tile2",
+          title: "tile 2",
+          content: {
+            type: "Text",
+          }
+        },
+        {
+          id: "tile3",
+          title: "tile 3",
+          content: {
+            type: "Table",
+          }
+        }
+      ],
+      sharedModels: [
+        {
+          tiles: ["tile3"],
+          sharedModel: sharedDataSet,
+        }
+      ]
+    });
+
+    // set the idCount to 1000, this way any future uniqueIds created will be
+    // consistent regardless of how many uniqueIds the
+    // createDocumentContentModel called
+    idCount = 1000;
+  });
+
+  describe("getDragTileItems", () => {
+    describe("when one tile selected", () => {
+      it("returns an array of one IDragTileItem object", () => {
+        const items = getDragTileItems(documentContent, ["tile1"]);
+
+        // Jest messes up the indentation when it writes out the snapshots with
+        // --updateSnapshot (see https://jestjs.io/docs/snapshot-testing)
+        // But having them inline seems more valuable than consistent indentation
+        /*eslint-disable max-len*/
+        expect(items).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "rowHeight": undefined,
+    "rowIndex": 0,
+    "tileContent": "{\\"id\\":\\"testid-1000\\",\\"title\\":\\"tile 1\\",\\"content\\":{\\"type\\":\\"Text\\",\\"text\\":\\"\\"}}",
+    "tileId": "tile1",
+    "tileIndex": 0,
+    "tileType": "Text",
+  },
+]
+`);
+        /*eslint-enable max-len*/
+      });
+    });
+    describe("when two tiles selected", () => {
+      it("returns an array of both IDragTileItem objects", () => {
+        const items = getDragTileItems(documentContent, ["tile1", "tile2"]);
+
+        /*eslint-disable max-len*/
+        expect(items).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "rowHeight": undefined,
+    "rowIndex": 0,
+    "tileContent": "{\\"id\\":\\"testid-1000\\",\\"title\\":\\"tile 1\\",\\"content\\":{\\"type\\":\\"Text\\",\\"text\\":\\"\\"}}",
+    "tileId": "tile1",
+    "tileIndex": 0,
+    "tileType": "Text",
+  },
+  Object {
+    "rowHeight": undefined,
+    "rowIndex": 1,
+    "tileContent": "{\\"id\\":\\"testid-1001\\",\\"title\\":\\"tile 2\\",\\"content\\":{\\"type\\":\\"Text\\",\\"text\\":\\"\\"}}",
+    "tileId": "tile2",
+    "tileIndex": 0,
+    "tileType": "Text",
+  },
+]
+`);
+        /*eslint-enable max-len*/
+      });
+    });
+
+    describe("when a table using a shared dataset is selected", () => {
+      it("returns the table IDragTileItem object", () => {
+        const items = getDragTileItems(documentContent, ["tile3"]);
+
+        // TODO: The exported table here includes importedDataSet property.
+        // Since we are going to include the actual shared dataset too, the
+        // importedDataSet should not be here.
+
+        /*eslint-disable max-len*/
+        expect(items).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "rowHeight": undefined,
+    "rowIndex": 2,
+    "tileContent": "{\\"id\\":\\"testid-1000\\",\\"title\\":\\"tile 3\\",\\"content\\":{\\"type\\":\\"Table\\",\\"isImported\\":false,\\"importedDataSet\\":{\\"id\\":\\"data-set-1\\",\\"name\\":\\"Table 1\\",\\"attributes\\":[{\\"id\\":\\"attribute-1\\",\\"clientKey\\":\\"\\",\\"name\\":\\"x\\",\\"hidden\\":false,\\"units\\":\\"\\",\\"formula\\":{},\\"values\\":[\\"0\\"]},{\\"id\\":\\"attribute-2\\",\\"clientKey\\":\\"\\",\\"name\\":\\"y\\",\\"hidden\\":false,\\"units\\":\\"\\",\\"formula\\":{},\\"values\\":[\\"1\\"]}],\\"cases\\":[{\\"__id__\\":\\"case-1\\"}]},\\"columnWidths\\":{}}}",
+    "tileId": "tile3",
+    "tileIndex": 0,
+    "tileType": "Table",
+  },
+]
+`);
+        /*eslint-enable max-len*/
+      });
+    });
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  describe("getDragTiles", () => {
+    describe("with one tile selected", () => {
+      it("returns that tile", () => {
+        const model = documentContent.getTile("tile1");
+        expect(model).toBeDefined();
+        const dragTiles = getDragTiles(documentContent, model!, ["tile1"]);
+        /*eslint-disable max-len*/
+        expect(dragTiles).toMatchInlineSnapshot(`
+Object {
+  "sharedModels": Array [],
+  "sourceDocId": "testid-10",
+  "tiles": Array [
+    Object {
+      "rowHeight": undefined,
+      "rowIndex": 0,
+      "tileContent": "{\\"id\\":\\"testid-1000\\",\\"title\\":\\"tile 1\\",\\"content\\":{\\"type\\":\\"Text\\",\\"text\\":\\"\\"}}",
+      "tileId": "tile1",
+      "tileIndex": 0,
+      "tileType": "Text",
+    },
+  ],
+}
+`);
+        /*eslint-enable max-len*/
+
+      });
+    });
+    describe("with two tiles selected", () => {
+      it("returns both tiles in document order", () => {
+        const model = documentContent.getTile("tile2");
+        expect(model).toBeDefined();
+        const dragTiles = getDragTiles(documentContent, model!, ["tile2", "tile1"]);
+        /*eslint-disable max-len*/
+        expect(dragTiles).toMatchInlineSnapshot(`
+Object {
+  "sharedModels": Array [],
+  "sourceDocId": "testid-10",
+  "tiles": Array [
+    Object {
+      "rowHeight": undefined,
+      "rowIndex": 0,
+      "tileContent": "{\\"id\\":\\"testid-1001\\",\\"title\\":\\"tile 1\\",\\"content\\":{\\"type\\":\\"Text\\",\\"text\\":\\"\\"}}",
+      "tileId": "tile1",
+      "tileIndex": 0,
+      "tileType": "Text",
+    },
+    Object {
+      "rowHeight": undefined,
+      "rowIndex": 1,
+      "tileContent": "{\\"id\\":\\"testid-1000\\",\\"title\\":\\"tile 2\\",\\"content\\":{\\"type\\":\\"Text\\",\\"text\\":\\"\\"}}",
+      "tileId": "tile2",
+      "tileIndex": 0,
+      "tileType": "Text",
+    },
+  ],
+}
+`);
+        /*eslint-enable max-len*/
+
+      });
+    });
+    describe("with a tile using a shared model", () => {
+      it("returns the tile and the shared model", () => {
+        const model = documentContent.getTile("tile3");
+        expect(model).toBeDefined();
+        const dragTiles = getDragTiles(documentContent, model!, ["tile3"]);
+
+        /*eslint-disable max-len*/
+        expect(dragTiles).toMatchInlineSnapshot(`
+Object {
+  "sharedModels": Array [
+    Object {
+      "dataSet": Object {
+        "attributes": Array [
+          Object {
+            "clientKey": "",
+            "formula": Object {
+              "canonical": undefined,
+              "display": undefined,
+            },
+            "hidden": false,
+            "id": "attribute-1",
+            "name": "x",
+            "sourceID": undefined,
+            "units": "",
+            "values": Array [
+              "0",
+            ],
+          },
+          Object {
+            "clientKey": "",
+            "formula": Object {
+              "canonical": undefined,
+              "display": undefined,
+            },
+            "hidden": false,
+            "id": "attribute-2",
+            "name": "y",
+            "sourceID": undefined,
+            "units": "",
+            "values": Array [
+              "1",
+            ],
+          },
+        ],
+        "cases": Array [
+          Object {
+            "__id__": "case-1",
+          },
+        ],
+        "id": "data-set-1",
+        "name": "Table 1",
+        "sourceID": undefined,
+      },
+      "id": "shared-data-set-1",
+      "providerId": "tile3",
+      "type": "SharedDataSet",
+    },
+  ],
+  "sourceDocId": "testid-10",
+  "tiles": Array [
+    Object {
+      "rowHeight": undefined,
+      "rowIndex": 2,
+      "tileContent": "{\\"id\\":\\"testid-1000\\",\\"title\\":\\"tile 3\\",\\"content\\":{\\"type\\":\\"Table\\",\\"isImported\\":false,\\"importedDataSet\\":{\\"id\\":\\"data-set-1\\",\\"name\\":\\"Table 1\\",\\"attributes\\":[{\\"id\\":\\"attribute-1\\",\\"clientKey\\":\\"\\",\\"name\\":\\"x\\",\\"hidden\\":false,\\"units\\":\\"\\",\\"formula\\":{},\\"values\\":[\\"0\\"]},{\\"id\\":\\"attribute-2\\",\\"clientKey\\":\\"\\",\\"name\\":\\"y\\",\\"hidden\\":false,\\"units\\":\\"\\",\\"formula\\":{},\\"values\\":[\\"1\\"]}],\\"cases\\":[{\\"__id__\\":\\"case-1\\"}]},\\"columnWidths\\":{}}}",
+      "tileId": "tile3",
+      "tileIndex": 0,
+      "tileType": "Table",
+    },
+  ],
+}
+`);
+        /*eslint-enable max-len*/
+      });
+    });
+  });
+});

--- a/src/models/document/drag-tiles.test.ts
+++ b/src/models/document/drag-tiles.test.ts
@@ -192,7 +192,6 @@ Array [
     });
   });
 
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
   describe("getDragTiles", () => {
     describe("when one tile is selected", () => {
       it("returns that tile and an the other IDragTiles properties", () => {

--- a/src/models/document/drag-tiles.ts
+++ b/src/models/document/drag-tiles.ts
@@ -122,5 +122,6 @@ export function logDataTransfer(_dataTransfer: DataTransfer) {
     dataTransfer.dataValues[type] = _dataTransfer.getData(type);
   }
 
+  // eslint-disable-next-line no-console
   console.log("Dropped", dataTransfer);
 }

--- a/src/models/document/drag-tiles.ts
+++ b/src/models/document/drag-tiles.ts
@@ -67,10 +67,6 @@ export function getDragTiles(
   // will change on each load of the document
   const sourceDocId = documentContent.contentId;
 
-  if (!sourceDocId) {
-    throw new Error("Can't find the id of the source document");
-  }
-
   const dragTiles: IDragTilesData = {
     sourceDocId,
     tiles: getDragTileItems(documentContent, tileIds),
@@ -89,6 +85,7 @@ export function getDragTiles(
   return dragTiles;
 }
 
+/* istanbul ignore next: this only used for debugging */
 export function logDataTransfer(_dataTransfer: DataTransfer) {
   if (!DEBUG_DROP) {
     return;

--- a/src/models/document/drag-tiles.ts
+++ b/src/models/document/drag-tiles.ts
@@ -1,0 +1,129 @@
+import { uniqueId } from "../../utilities/js-utils";
+import { cloneTileSnapshotWithNewId, IDragTileItem, ITileModel } from "../tiles/tile-model";
+import { DocumentContentModelType, IDragTilesData } from "./document-content";
+import { getTileContentInfo } from "../tiles/tile-content-info";
+import { DEBUG_DROP } from "../../lib/debug";
+
+// TODO: move the drop tile logic here too
+
+export function getDragTileItems(documentContent: DocumentContentModelType, tileIds: string[]) {
+  const dragTileItems: IDragTileItem[] = [];
+
+  const idMap: { [id: string]: string } = {};
+  tileIds.forEach(tileId => idMap[tileId] = uniqueId());
+
+  tileIds.forEach(tileId => {
+    // Note: previously this function would be passed the tileModel being
+    // dragged. It would accept a tileId if it matched the tileModel.id even if
+    // `documentContent.getTile(tileId)` did not return a tile model. This seems
+    // like it would mask an error and also complicates the code.
+    const srcTile = documentContent.getTile(tileId);
+    if (!srcTile) {
+      return;
+    }
+
+    // Note: previously this would look up the "contentId" of the srcTile using
+    // `getContentIdFromNode`. If it didn't exist or was different from
+    // `documentContent.contentId` the tile would be skipped. This contentId is
+    // found by looking up the contentDocument parent of the tile and getting is
+    // `contentId`. Because srcTile is found via `documentContent.getTile` this
+    // should guarantee that the contentId return by `getContentIdFromNode`
+    // always matches the dragSrcContentId.
+    const rowId = documentContent?.findRowContainingTile(srcTile.id);
+    const rowIndex = rowId && documentContent?.getRowIndex(rowId) || 0;
+    const row = rowId ? documentContent?.getRow(rowId) : undefined;
+    const rowHeight = row?.height;
+    const tileIndex = row?.tiles.findIndex(t => t.tileId === tileId) || 0;
+    const clonedTile = cloneTileSnapshotWithNewId(srcTile, idMap[srcTile.id]);
+    getTileContentInfo(clonedTile.content.type)?.contentSnapshotPostProcessor?.(clonedTile.content, idMap);
+    dragTileItems.push({
+      rowIndex, rowHeight, tileIndex,
+      tileId: srcTile.id,
+      tileContent: JSON.stringify(clonedTile),
+      tileType: srcTile.content.type
+    });
+  });
+
+  return dragTileItems;
+}
+
+/**
+ *
+ * @param documentContent
+ * @param model this parameter will be removed when support is added for shared
+ * models of multiple tiles
+ * @param tileIds
+ * @returns
+ */
+export function getDragTiles(
+  documentContent: DocumentContentModelType,
+  model: ITileModel,
+  tileIds: string[]): IDragTilesData {
+
+  const sharedManager = documentContent.tileEnv?.sharedModelManager;
+
+  // This is an ephemeral id DocumentContent#contentId
+  // it is like an instance id for the document content it
+  // will change on each load of the document
+  const sourceDocId = documentContent.contentId;
+
+  if (!sourceDocId) {
+    throw new Error("Can't find the id of the source document");
+  }
+
+  const dragTiles: IDragTilesData = {
+    sourceDocId,
+    tiles: getDragTileItems(documentContent, tileIds),
+    sharedModels: sharedManager?.getTileSharedModels(model.content) ?? []
+  };
+
+  // create a sorted array of selected tiles
+  dragTiles.tiles.sort((a, b) => {
+    if (a.rowIndex < b.rowIndex) return -1;
+    if (a.rowIndex > b.rowIndex) return 1;
+    if (a.tileIndex < b.tileIndex) return -1;
+    if (a.tileIndex > b.tileIndex) return 1;
+    return 0;
+  });
+
+  return dragTiles;
+}
+
+export function logDataTransfer(_dataTransfer: DataTransfer) {
+  if (!DEBUG_DROP) {
+    return;
+  }
+
+  const dataTransfer = {} as any;
+  dataTransfer.dropEffect = _dataTransfer.dropEffect;
+  dataTransfer.effectAllowed = _dataTransfer.effectAllowed;
+  dataTransfer.types = _dataTransfer.types.map(type => type);
+
+  dataTransfer.items = {} as any;
+  for (const _item of _dataTransfer.items) {
+    const item = {
+      kind: _item.kind,
+      type: _item.type,
+      stringValue: undefined as string | undefined
+    };
+    // This is asynchronous, however Chrome's console.log will update any objects printed to console
+    // if it is changed after being logged. However you have to ask for all of the values "synchronously"
+    // otherwise the browser clears out the dataTransfer and any delayed requests will return nothing.
+    // In other words doing an `await` between each getAsString call will fail.
+    //
+    // Because the incoming _dataTransfer.items are cleared out after this function returns
+    // _item.type will become undefined or an empty string after the function returns
+    // So we have to make sure not to refer `_item` in the asynchronous callback below.
+    _item.getAsString((value) => item.stringValue = value);
+
+    dataTransfer.items[item.type] = item;
+  }
+
+  // As far as I can tell getData(type) is the same as the value passed to callback of getAsString
+  dataTransfer.dataValues = {} as Record<string,string>;
+  for (const type of dataTransfer.types) {
+    dataTransfer.dataValues[type] = _dataTransfer.getData(type);
+  }
+
+  console.log("Dropped", dataTransfer);
+}

--- a/src/models/shared/shared-data-set.ts
+++ b/src/models/shared/shared-data-set.ts
@@ -1,4 +1,4 @@
-import { Instance, types } from "mobx-state-tree";
+import { Instance, SnapshotIn, types } from "mobx-state-tree";
 import { DataSet } from "../data/data-set";
 import { SharedModel } from "./shared-model";
 
@@ -20,3 +20,4 @@ export const SharedDataSet = SharedModel
   },
 }));
 export interface SharedDataSetType extends Instance<typeof SharedDataSet> {}
+export interface SharedDataSetSnapshotType extends SnapshotIn<typeof SharedDataSet> {}


### PR DESCRIPTION
This is Part 1 of hopefully a set of 3 PRs to address this story: PT-184869601
- It pulls the drag code out of `tile-component.tsx` and adds tests for the extracted code.
- It includes some type changes to the document content import.
Those types are not used much so didn't expose the issues.
- It adds a new debug flag `drop` which prints the dataTransfer of the drop event. This turned out to be more tricky than just logging the object because of how the dataTransfer object is only fully available during the event itself.


The second PR will be https://github.com/concord-consortium/collaborative-learning/pull/1611, that had minimal changes on the drag side of the code that was refactored here, so there should be minial merge conflicts.

The third PR will be to refactor the drop side of the code and bring it into the new `drag-tiles.ts`.  Hopefully this will reduce the size of the very large `document-content.ts` and also put the drag and drop sides of the code next to each other.
