### PR TITLE
184816949 live output node displays hub selectors and hub status

### DIFF
--- a/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
@@ -8,7 +8,6 @@ context('Dataflow Tool Tile', function () {
   before(function () {
     const queryParams = "?appMode=qa&fakeClass=5&fakeUser=student:5&qaGroup=5&unit=dfe";
     cy.clearQAData('all');
-
     cy.visit(queryParams);
     cy.waitForLoad();
     cy.closeResourceTabs();
@@ -341,6 +340,11 @@ context('Dataflow Tool Tile', function () {
         dataflowToolTile.getDropdownOptions(nodeType, dropdown).should("have.length", 0);
         dataflowToolTile.getDropdown(nodeType, dropdown).contains("Heat Lamp").should("exist");
         dataflowToolTile.getOutputNodeValueText().should("contain", "off");
+      });
+      it("verify live output options", () => {
+        dataflowToolTile.getDropdown(nodeType, "hubSelect").should("exist");
+        dataflowToolTile.getDropdown(nodeType, "hubSelect").should("contain", "micro:bit hub a");
+        dataflowToolTile.getDropdown(nodeType, "hubSelect").get(".disabled").should("exist");
       });
       it("verify node inputs outputs", () => {
         dataflowToolTile.getNodeInput().should("exist");

--- a/src/plugins/dataflow-tool/microbit/hub.md
+++ b/src/plugins/dataflow-tool/microbit/hub.md
@@ -20,43 +20,43 @@ On radio recieved
 ```js
 radio.setGroup(1)
 
-let hubIds = ['x','a','b','c','d']
+let hubIds = ['x', 'a', 'b', 'c', 'd']
 let hubI = 0
-let readingInterval = 2000
-let messsageInterval = 100
 
-function getTempString(){
-  const t = Math.constrain(dht11_dht22.readData(dataType.temperature), 0, 100);
-  return `s${hubIds[hubI]}t${t}`;
+function getTempString() {
+    const t = Math.constrain(dht11_dht22.readData(dataType.temperature), 0, 100);
+    return `s${hubIds[hubI]}t${t}`;
 }
 
-function getHumidString(){
-  const h = Math.constrain(dht11_dht22.readData(dataType.humidity), 0, 100);
-  return `s${hubIds[hubI]}h${h}`;
+function getHumidString() {
+    const h = Math.constrain(dht11_dht22.readData(dataType.humidity), 0, 100);
+    return `s${hubIds[hubI]}h${h}`;
 }
 
 function readSendData() {
-  dht11_dht22.queryData(DHTtype.DHT11, DigitalPin.P15, false, false, false)
-  radio.sendString(getTempString())
-  pause(messageInterval)
-  radio.sendString(getHumidString())
+    dht11_dht22.queryData(DHTtype.DHT11, DigitalPin.P15, false, false, false)
+    radio.sendString(getTempString())
+    pause(1000)
+    radio.sendString(getHumidString())
 }
 
 basic.forever(function () {
-  basic.showString(hubIds[hubI])
-  if (hubI > 0){
-    pause(readingInterval)
-    readSendData()
-  }
+    basic.showString(hubIds[hubI])
+    if (hubI > 0) {
+        pause(2000)
+        readSendData()
+    }
 })
 
 input.onButtonPressed(Button.A, () => {
-  if (hubI > 0) hubI--;
+    if (hubI > 0) hubI--;
 })
 
 input.onButtonPressed(Button.B, () => {
-  if (hubI < 4) hubI++;
+    if (hubI < 4) hubI++;
 })
+
+
 
 
 ```

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -320,24 +320,6 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
         this.props.onProgramChange(this.programEditor.toJSON());
       });
 
-      this.programEditor.on("nodecreated", node => {
-        // trigger after each of the first six events
-        // add the current set of sensors node controls
-
-        // Lines below do not seem needed now as we are doing this next to updateChannels where it makes more sense
-        // but keep here for a momoment to see
-        // if (node.name === "Sensor") {
-        //   const sensorSelect = node.controls.get("sensorSelect") as SensorSelectControl;
-        //   sensorSelect.setChannels(this.channels);
-        //   console.log("onNodeCreate, sensorSelect has channel access: ", this, {sensorSelect})
-        // }
-        // if (node.name === "Live Output"){
-        //   const hubSelect = node.controls.get("hubSelect") as DropdownListControl;
-        //   hubSelect.setChannels(this.channels)
-        // }
-        return true;
-      });
-
       // remove rete double click zoom
       this.programEditor.on("zoom", ({ source }) => {
         return false;
@@ -428,9 +410,9 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
       }
       if (node.name === "Live Output"){
         const hubSelect = node.controls.get("hubSelect") as DropdownListControl;
-        hubSelect.setChannels(this.channels)
+        hubSelect.setChannels(this.channels);
       }
-    })
+    });
   };
 
   private shouldShowProgramCover() {

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -40,6 +40,7 @@ import { ICaseCreation, addCanonicalCasesToDataSet } from "../../../models/data/
 import { SensorValueControl } from "../nodes/controls/sensor-value-control";
 import { InputValueControl } from "../nodes/controls/input-value-control";
 import { DemoOutputControl } from "../nodes/controls/demo-output-control";
+import { DropdownListControl } from "../nodes/controls/dropdown-list-control";
 
 import "./dataflow-program.sass";
 interface NodeNameValuePair {
@@ -319,13 +320,21 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
         this.props.onProgramChange(this.programEditor.toJSON());
       });
 
-      this.programEditor.on("nodecreate", node => {
+      this.programEditor.on("nodecreated", node => {
         // trigger after each of the first six events
         // add the current set of sensors node controls
-        if (node.name === "Sensor") {
-          const sensorSelect = node.controls.get("sensorSelect") as SensorSelectControl;
-          sensorSelect.setChannels(this.channels);
-        }
+
+        // Lines below do not seem needed now as we are doing this next to updateChannels where it makes more sense
+        // but keep here for a momoment to see
+        // if (node.name === "Sensor") {
+        //   const sensorSelect = node.controls.get("sensorSelect") as SensorSelectControl;
+        //   sensorSelect.setChannels(this.channels);
+        //   console.log("onNodeCreate, sensorSelect has channel access: ", this, {sensorSelect})
+        // }
+        // if (node.name === "Live Output"){
+        //   const hubSelect = node.controls.get("hubSelect") as DropdownListControl;
+        //   hubSelect.setChannels(this.channels)
+        // }
         return true;
       });
 
@@ -412,6 +421,16 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
     this.channels = [];
     this.channels = [...virtualSensorChannels, ...serialSensorChannels];
     this.countSerialDataNodes(this.programEditor.nodes);
+    this.programEditor.nodes.forEach((node) => {
+      if (node.name === "Sensor") {
+        const sensorSelect = node.controls.get("sensorSelect") as SensorSelectControl;
+        sensorSelect.setChannels(this.channels);
+      }
+      if (node.name === "Live Output"){
+        const hubSelect = node.controls.get("hubSelect") as DropdownListControl;
+        hubSelect.setChannels(this.channels)
+      }
+    })
   };
 
   private shouldShowProgramCover() {

--- a/src/plugins/dataflow/model/utilities/channel.ts
+++ b/src/plugins/dataflow/model/utilities/channel.ts
@@ -60,7 +60,7 @@ interface MicroBitHubInfo {
   location?: string
 }
 
-const microBitHubs = [
+export const microBitHubs = [
   { microBitId: "a", relaysState: [0,0,0] },
   { microBitId: "b", relaysState: [0,0,0] },
   { microBitId: "c", relaysState: [0,0,0] },

--- a/src/plugins/dataflow/model/utilities/node.ts
+++ b/src/plugins/dataflow/model/utilities/node.ts
@@ -327,25 +327,21 @@ export const NodeLiveOutputTypes = [
 
 export const NodeMicroBitHubs = [
   {
-    id: 'a',
     name: "micro:bit hub a",
     icon: LightIcon,
     active: false
   },
   {
-    id: 'b',
     name: "micro:bit hub b",
     icon: LightIcon,
     active: false
   },
   {
-    id: 'c',
     name: "micro:bit hub c",
     icon: LightIcon,
     active: false
   },
   {
-    id: 'd',
     name: "micro:bit hub d",
     icon: LightIcon,
     active: false

--- a/src/plugins/dataflow/model/utilities/node.ts
+++ b/src/plugins/dataflow/model/utilities/node.ts
@@ -324,6 +324,34 @@ export const NodeLiveOutputTypes = [
   }
 ];
 
+
+export const NodeMicroBitHubs = [
+  {
+    id: 'a',
+    name: "micro:bit hub a",
+    icon: LightIcon,
+    active: false,
+  },
+  {
+    id: 'b',
+    name: "micro:bit hub b",
+    icon: LightIcon,
+    active: false,
+  },
+  {
+    id: 'c',
+    name: "micro:bit hub c",
+    icon: LightIcon,
+    active: true
+  },
+  {
+    id: 'd',
+    name: "micro:bit hub d",
+    icon: LightIcon,
+    active: false
+  }
+];
+
 export const NodeGeneratorTypes = [
   {
     name: "Sine",

--- a/src/plugins/dataflow/model/utilities/node.ts
+++ b/src/plugins/dataflow/model/utilities/node.ts
@@ -327,21 +327,25 @@ export const NodeLiveOutputTypes = [
 
 export const NodeMicroBitHubs = [
   {
+    id: 'a',
     name: "micro:bit hub a",
     icon: LightIcon,
     active: false
   },
   {
+    id: 'b',
     name: "micro:bit hub b",
     icon: LightIcon,
     active: false
   },
   {
+    id: 'c',
     name: "micro:bit hub c",
     icon: LightIcon,
     active: false
   },
   {
+    id: 'd',
     name: "micro:bit hub d",
     icon: LightIcon,
     active: false

--- a/src/plugins/dataflow/model/utilities/node.ts
+++ b/src/plugins/dataflow/model/utilities/node.ts
@@ -330,19 +330,19 @@ export const NodeMicroBitHubs = [
     id: 'a',
     name: "micro:bit hub a",
     icon: LightIcon,
-    active: false,
+    active: false
   },
   {
     id: 'b',
     name: "micro:bit hub b",
     icon: LightIcon,
-    active: false,
+    active: false
   },
   {
     id: 'c',
     name: "micro:bit hub c",
     icon: LightIcon,
-    active: true
+    active: false
   },
   {
     id: 'd',

--- a/src/plugins/dataflow/nodes/controls/dropdown-list-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/dropdown-list-control.tsx
@@ -5,6 +5,7 @@ import Rete, { NodeEditor, Node, Control } from "rete";
 import { useStopEventPropagation, useCloseDropdownOnOutsideEvent } from "./custom-hooks";
 import DropdownCaretIcon from "../../assets/icons/dropdown-caret.svg";
 import { dataflowLogEvent } from "../../dataflow-logger";
+import { NodeChannelInfo } from "../../model/utilities/channel";
 
 import "./dropdown-list-control.scss";
 
@@ -187,9 +188,7 @@ export class DropdownListControl extends Rete.Control {
   };
 
   public setActiveOption = (hubId: string, state: boolean) => {
-    console.log("this will be a function to set active option: ", this.props.optionArray)
     const targetHub = this.props.optionArray.filter((o: any) => o.id === hubId)
-    console.log("make this targetHub active or not: ", targetHub, state )
     targetHub[0].active = state;
   }
 

--- a/src/plugins/dataflow/nodes/controls/dropdown-list-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/dropdown-list-control.tsx
@@ -79,10 +79,14 @@ export class DropdownListControl extends Rete.Control {
       const option = options.find((opt) => optionValue(opt) === val);
       const name = option?.name ?? val;
       const icon = option?.icon?.({}) || null;
+      const activeHub = (option as any).active; // SERIAL: what we need to calculate from state
+      const liveNode = this.getNode().name.substring(0,4) === "Live"
+      const disableSelected = this.key === "hubSelect" && liveNode && !activeHub;
+      const labelClasses = disableSelected ? "disabled item top" : "item top"
 
       return (
         <div className={`node-select ${listClass}`} ref={divRef}>
-          <div className="item top" onMouseDown={handleChange(onItemClick)}>
+          <div className={labelClasses} onMouseDown={handleChange(onItemClick)}>
             { icon &&
             <svg className="icon top">
               {icon}
@@ -96,11 +100,15 @@ export class DropdownListControl extends Rete.Control {
           {showList ?
           <div className={`option-list ${listClass}`} ref={listRef}>
             {options.map((ops: any, i: any) => {
+              // console.log("ops to test: ", ops)
               let className = `item ${listClass}`;
               const disabled = isDisabled && isDisabled(ops);
+              if (ops.active === false){
+                className += " disabled"
+              }
               if (optionValue(ops) === val) {
                 className += " selected";
-              } else if (disabled) {
+              } else if (disabled || ops.active === false) {
                 className += " disabled";
               } else {
                 className += " selectable";
@@ -177,6 +185,13 @@ export class DropdownListControl extends Rete.Control {
   public setOptions = (options: any) => {
     this.props.optionArray = options;
   };
+
+  public setActiveOption = (hubId: string, state: boolean) => {
+    console.log("this will be a function to set active option: ", this.props.optionArray)
+    const targetHub = this.props.optionArray.filter((o: any) => o.id === hubId)
+    console.log("make this targetHub active or not: ", targetHub, state )
+    targetHub[0].active = state;
+  }
 
   /**
    * This is called both when we load (in case the options have changed, and the user

--- a/src/plugins/dataflow/nodes/controls/dropdown-list-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/dropdown-list-control.tsx
@@ -81,9 +81,9 @@ export class DropdownListControl extends Rete.Control {
       const name = option?.name ?? val;
       const icon = option?.icon?.({}) || null;
       const activeHub = (option as any).active;
-      const liveNode = this.getNode().name.substring(0,4) === "Live"
+      const liveNode = this.getNode().name.substring(0,4) === "Live";
       const disableSelected = this.key === "hubSelect" && liveNode && !activeHub;
-      const labelClasses = disableSelected ? "disabled item top" : "item top"
+      const labelClasses = disableSelected ? "disabled item top" : "item top";
 
       return (
         <div className={`node-select ${listClass}`} ref={divRef}>
@@ -105,7 +105,7 @@ export class DropdownListControl extends Rete.Control {
               const disabled = isDisabled && isDisabled(ops);
 
               if (ops.active === false || disabled){
-                className+= " disabled"
+                className+= " disabled";
               } else {
                 className += " selectable";
               }
@@ -189,12 +189,12 @@ export class DropdownListControl extends Rete.Control {
 
   public setActiveOption = (hubId: string, state: boolean) => {
     if (this.props.optionArray){
-      const targetHub = this.props.optionArray.filter((o: any) => o.id === hubId)
+      const targetHub = this.props.optionArray.filter((o: any) => o.id === hubId);
       if(targetHub[0]){
         targetHub[0].active = state;
       }
     }
-  }
+  };
 
   public setChannels = (channels: NodeChannelInfo[]) => {
     this.props.channels = channels;
@@ -202,7 +202,7 @@ export class DropdownListControl extends Rete.Control {
 
   public getChannels = () => {
     return this.props.channels;
-  }
+  };
 
   /**
    * This is called both when we load (in case the options have changed, and the user

--- a/src/plugins/dataflow/nodes/controls/dropdown-list-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/dropdown-list-control.tsx
@@ -80,7 +80,7 @@ export class DropdownListControl extends Rete.Control {
       const option = options.find((opt) => optionValue(opt) === val);
       const name = option?.name ?? val;
       const icon = option?.icon?.({}) || null;
-      const activeHub = (option as any).active; // SERIAL: what we need to calculate from state
+      const activeHub = (option as any).active;
       const liveNode = this.getNode().name.substring(0,4) === "Live"
       const disableSelected = this.key === "hubSelect" && liveNode && !activeHub;
       const labelClasses = disableSelected ? "disabled item top" : "item top"
@@ -101,19 +101,19 @@ export class DropdownListControl extends Rete.Control {
           {showList ?
           <div className={`option-list ${listClass}`} ref={listRef}>
             {options.map((ops: any, i: any) => {
-              // console.log("ops to test: ", ops)
               let className = `item ${listClass}`;
               const disabled = isDisabled && isDisabled(ops);
-              if (ops.active === false){
-                className += " disabled"
-              }
-              if (optionValue(ops) === val) {
-                className += " selected";
-              } else if (disabled || ops.active === false) {
-                className += " disabled";
+
+              if (ops.active === false || disabled){
+                className+= " disabled"
               } else {
                 className += " selectable";
               }
+
+              if (optionValue(ops) === val) {
+                className += " selected";
+              }
+
               return (
                 <div
                   className={className}
@@ -188,8 +188,20 @@ export class DropdownListControl extends Rete.Control {
   };
 
   public setActiveOption = (hubId: string, state: boolean) => {
-    const targetHub = this.props.optionArray.filter((o: any) => o.id === hubId)
-    targetHub[0].active = state;
+    if (this.props.optionArray){
+      const targetHub = this.props.optionArray.filter((o: any) => o.id === hubId)
+      if(targetHub[0]){
+        targetHub[0].active = state;
+      }
+    }
+  }
+
+  public setChannels = (channels: NodeChannelInfo[]) => {
+    this.props.channels = channels;
+  };
+
+  public getChannels = () => {
+    return this.props.channels;
   }
 
   /**

--- a/src/plugins/dataflow/nodes/controls/dropdown-list-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/dropdown-list-control.tsx
@@ -103,17 +103,14 @@ export class DropdownListControl extends Rete.Control {
             {options.map((ops: any, i: any) => {
               let className = `item ${listClass}`;
               const disabled = isDisabled && isDisabled(ops);
-
               if (ops.active === false || disabled){
                 className+= " disabled";
               } else {
                 className += " selectable";
               }
-
               if (optionValue(ops) === val) {
                 className += " selected";
               }
-
               return (
                 <div
                   className={className}

--- a/src/plugins/dataflow/nodes/controls/sensor-select-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/sensor-select-control.tsx
@@ -133,7 +133,7 @@ export class SensorSelectControl extends Rete.Control {
                                       this.props.showSensorList = false;
                                       (this as any).update();
                                     });
-
+                                        console.log("WHERE DID WE GET CHANNELS FROM?", channels)
       const channelsForType = channels.filter((ch: NodeChannelInfo) => {
         if (ch.type !== "relays"){
           return (ch.type === type) || (type === "none");

--- a/src/plugins/dataflow/nodes/controls/sensor-select-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/sensor-select-control.tsx
@@ -133,7 +133,6 @@ export class SensorSelectControl extends Rete.Control {
                                       this.props.showSensorList = false;
                                       (this as any).update();
                                     });
-                                        console.log("WHERE DID WE GET CHANNELS FROM?", channels)
       const channelsForType = channels.filter((ch: NodeChannelInfo) => {
         if (ch.type !== "relays"){
           return (ch.type === type) || (type === "none");

--- a/src/plugins/dataflow/nodes/factories/live-output-rete-node-factory.tsx
+++ b/src/plugins/dataflow/nodes/factories/live-output-rete-node-factory.tsx
@@ -5,6 +5,7 @@ import { InputValueControl } from "../controls/input-value-control";
 import { DropdownListControl } from "../controls/dropdown-list-control";
 import { NodeLiveOutputTypes, NodeMicroBitHubs } from "../../model/utilities/node";
 import { dataflowLogEvent } from "../../dataflow-logger";
+import { NodeChannelInfo } from "../../model/utilities/channel";
 
 export class LiveOutputReteNodeFactory extends DataflowReteNodeFactory {
   constructor(numSocket: Socket) {
@@ -40,8 +41,11 @@ export class LiveOutputReteNodeFactory extends DataflowReteNodeFactory {
         // 1 see if we can set active
         hubSelect.setActiveOption("a", true)
         // 2 see if we can get channel state
-
+        // for each hubId
+        // are all the sensor channels on this hub missing? if so set this to false
         // 3 do it
+
+        console.log("this editor: ", this.editor)
 
         const outputTypeControl = _node.controls.get("liveOutputType") as DropdownListControl;
         const outputType = outputTypeControl.getValue();

--- a/src/plugins/dataflow/nodes/factories/live-output-rete-node-factory.tsx
+++ b/src/plugins/dataflow/nodes/factories/live-output-rete-node-factory.tsx
@@ -35,18 +35,19 @@ export class LiveOutputReteNodeFactory extends DataflowReteNodeFactory {
       const _node = this.editor.nodes.find((n: { id: any; }) => n.id === node.id);
       if (_node) {
 
-        // 1 WORKER CAN SET AN OPTION SO NOW WE HAVE TO SET ACTIVE DEPENDING ON CHANNEL STATE
+        // handle appearance based on availibility of relevant devices
+        // const deviceSelect = _node.controls.get("liveOutputType") as DropdownListControl // <-- could do same at output type level?
         const hubSelect = _node.controls.get("hubSelect") as DropdownListControl
-        console.log("hubSelect: ", hubSelect);
-        // 1 see if we can set active
-        hubSelect.setActiveOption("a", true)
-        // 2 see if we can get channel state
-        // for each hubId
-        // are all the sensor channels on this hub missing? if so set this to false
-        // 3 do it
 
-        console.log("this editor: ", this.editor)
+        // check for status of temp channels to indicate whether this hub is active
+        const hubStatusArray = hubSelect.getChannels()
+          .filter((c:any) => c.type === "temperature" && c.deviceFamily === "microbit")
+          .map((c:any) => {
+            return { id: c.channelId.charAt(2), missing: c.missing}
+          })
+        hubStatusArray.forEach((s:any) => hubSelect.setActiveOption(s.id, !s.missing)) // "active" is !missing
 
+        // handle data and display of data
         const outputTypeControl = _node.controls.get("liveOutputType") as DropdownListControl;
         const outputType = outputTypeControl.getValue();
         const nodeValue = _node.inputs.get("nodeValue")?.control as InputValueControl;

--- a/src/plugins/dataflow/nodes/factories/sensor-rete-node-factory.tsx
+++ b/src/plugins/dataflow/nodes/factories/sensor-rete-node-factory.tsx
@@ -13,6 +13,7 @@ export class SensorReteNodeFactory extends DataflowReteNodeFactory {
   public builder(node: Node) {
     super.defaultBuilder(node);
     if (this.editor) {
+      console.log("WHO HERE HAS THE CHANNELS?", this.editor, node)
       const out1 = new Rete.Output("num", "Number", this.numSocket);
       return node
         .addControl(new SensorSelectControl(this.editor, "sensorSelect", node, true))

--- a/src/plugins/dataflow/nodes/factories/sensor-rete-node-factory.tsx
+++ b/src/plugins/dataflow/nodes/factories/sensor-rete-node-factory.tsx
@@ -13,7 +13,6 @@ export class SensorReteNodeFactory extends DataflowReteNodeFactory {
   public builder(node: Node) {
     super.defaultBuilder(node);
     if (this.editor) {
-      console.log("WHO HERE HAS THE CHANNELS?", this.editor, node)
       const out1 = new Rete.Output("num", "Number", this.numSocket);
       return node
         .addControl(new SensorSelectControl(this.editor, "sensorSelect", node, true))


### PR DESCRIPTION
This PR creates the functionality described in PT story  [DataFlow Live Output includes options based on micro:bit channels](https://www.pivotaltracker.com/story/show/184816949)
- Live Output node now includes a Hub Choice dropdown
- Hubs that are active on the network will show as colored in, hubs that are not will show as disabled
- The new outputs are all binary, so adopt the same value calculation as the Light Bulb