### PR TITLE
184916018 live output node matches sent state with received state

### DIFF
--- a/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
@@ -329,7 +329,7 @@ context('Dataflow Tool Tile', function () {
       });
       it("verify live output types", () => {
         const dropdown = "liveOutputType";
-        const outputTypes = ["Light Bulb", "Grabber", "Sprinkler", "Fan", "Heat Lamp"];
+        const outputTypes = ["Light Bulb", "Grabber", "Humidifier", "Fan", "Heat Lamp"];
         dataflowToolTile.getDropdown(nodeType, dropdown).click();
         dataflowToolTile.getDropdownOptions(nodeType, dropdown).should("have.length", 5);
         dataflowToolTile.getDropdownOptions(nodeType, dropdown).each(($tab, index, $typeList) => {

--- a/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
@@ -1,8 +1,10 @@
 import ClueCanvas from '../../../../support/elements/clue/cCanvas';
 import DataflowToolTile from '../../../../support/elements/clue/DataflowToolTile';
 
-let clueCanvas = new ClueCanvas,
-  dataflowToolTile = new DataflowToolTile;
+let clueCanvas = new ClueCanvas;
+let dataflowToolTile = new DataflowToolTile;
+let dragXDestination = 300;
+
 
 context('Dataflow Tool Tile', function () {
   before(function () {
@@ -347,6 +349,23 @@ context('Dataflow Tool Tile', function () {
         dataflowToolTile.getDropdownOptions(nodeType, dropdown).eq(3).click();
         dataflowToolTile.getDropdown(nodeType, dropdown).contains("Fan").should("exist");
         dataflowToolTile.getOutputNodeValueText().should("contain", "(no hub)");
+      });
+      it("can be dragged to the right", () => {
+        dataflowToolTile.getNode(nodeType).click(50, 10)
+          .trigger("pointerdown", 50, 10 )
+          .trigger("pointermove", dragXDestination, 10, { force: true } )
+          .trigger("pointerup", dragXDestination, 10, { force: true } );
+      });
+      it("can get a value from a number node", () => {
+        dataflowToolTile.getCreateNodeButton("number").click();
+        dataflowToolTile.getNode("number").should("exist");
+        dataflowToolTile.getNumberField().type("1{enter}");
+        //dataflowToolTile.getNode("number").getNodeOutput().click()
+          // .trigger("pointerdown", { force: true })
+          // .trigger("pointermove", 40, 40, { force: true } );
+
+
+        dataflowToolTile.getDeleteNodeButton("number").click();
       });
       it("verify live output options", () => {
         dataflowToolTile.getDropdown(nodeType, "hubSelect").should("exist");

--- a/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
@@ -17,7 +17,7 @@ context('Dataflow Tool Tile', function () {
   describe("Dataflow Tool", () => {
     it("renders dataflow tool tile", () => {
       clueCanvas.addTile("dataflow");
-      dataflowToolTile.getDrawTile().should("exist");
+      dataflowToolTile.getDataflowTile().should("exist");
       dataflowToolTile.getTileTitle().should("exist");
     });
     it("edit tile title", () => {
@@ -364,7 +364,7 @@ context('Dataflow Tool Tile', function () {
         dataflowToolTile.getNode("number").should("exist");
         dataflowToolTile.getNumberField().type("1{enter}");
         dataflowToolTile.getNumberNodeOutput().should("exist");
-        dataflowToolTile.getDrawTile().click(306, 182)
+        dataflowToolTile.getDataflowTile().click(306, 182)
           .trigger("pointerdown", 306, 182, {force: true})
           .trigger("pointermove", 366, 172, {force: true})
           .trigger("pointerup", 366, 172, {force: true});

--- a/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
@@ -350,13 +350,16 @@ context('Dataflow Tool Tile', function () {
         dataflowToolTile.getDropdown(nodeType, dropdown).contains("Fan").should("exist");
         dataflowToolTile.getOutputNodeValueText().should("contain", "(no hub)");
       });
-      it("can be dragged to the right", () => {
+      it("can be dragged to the right and set back to light bulb", () => {
+        const dropdown = "liveOutputType";
         dataflowToolTile.getNode(nodeType).click(50, 10)
           .trigger("pointerdown", 50, 10 )
           .trigger("pointermove", dragXDestination, 10, { force: true } )
           .trigger("pointerup", dragXDestination, 10, { force: true } );
+          dataflowToolTile.getDropdown(nodeType, dropdown).click();
+          dataflowToolTile.getDropdownOptions(nodeType, dropdown).eq(0).click();
       });
-      it("can get a value from a number node", () => {
+      it("can connect and trigger modal connection warning", () => {
         dataflowToolTile.getCreateNodeButton("number").click();
         dataflowToolTile.getNode("number").should("exist");
         dataflowToolTile.getNumberField().type("1{enter}");
@@ -365,12 +368,14 @@ context('Dataflow Tool Tile', function () {
           .trigger("pointerdown", 306, 182, {force: true})
           .trigger("pointermove", 366, 172, {force: true})
           .trigger("pointerup", 366, 172, {force: true});
-        // dataflowToolTile.getNumberNodeOutput().click()
-        //   .trigger("pointerdown", "center", { force: true })
-        //   .trigger("pointermove", 40, 10, { force: true } )
-        //   .trigger("pointerup", 40, 10, { force: true } );
-
-
+        dataflowToolTile.getModalOkButton().click();
+      });
+      it("can recieve a value from a connected block, and display correct on or off string", () => {
+        dataflowToolTile.getNode("number").should("exist");
+        dataflowToolTile.getOutputNodeValueText().should("contain", "on");
+        dataflowToolTile.getNumberField().type("{backspace}0{enter}");
+        dataflowToolTile.getNumberNodeOutput().should("exist");
+        dataflowToolTile.getOutputNodeValueText().should("contain", "off");
         dataflowToolTile.getDeleteNodeButton("number").click();
       });
       it("verify live output options", () => {

--- a/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
@@ -341,6 +341,13 @@ context('Dataflow Tool Tile', function () {
         dataflowToolTile.getDropdown(nodeType, dropdown).contains("Heat Lamp").should("exist");
         dataflowToolTile.getOutputNodeValueText().should("contain", "off");
       });
+      it("verify live binary outputs indicate hub not present if not connected", () => {
+        const dropdown = "liveOutputType";
+        dataflowToolTile.getDropdown(nodeType, dropdown).click();
+        dataflowToolTile.getDropdownOptions(nodeType, dropdown).eq(3).click();
+        dataflowToolTile.getDropdown(nodeType, dropdown).contains("Fan").should("exist");
+        dataflowToolTile.getOutputNodeValueText().should("contain", "(no hub)");
+      });
       it("verify live output options", () => {
         dataflowToolTile.getDropdown(nodeType, "hubSelect").should("exist");
         dataflowToolTile.getDropdown(nodeType, "hubSelect").should("contain", "micro:bit hub a");

--- a/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
@@ -360,9 +360,15 @@ context('Dataflow Tool Tile', function () {
         dataflowToolTile.getCreateNodeButton("number").click();
         dataflowToolTile.getNode("number").should("exist");
         dataflowToolTile.getNumberField().type("1{enter}");
-        //dataflowToolTile.getNode("number").getNodeOutput().click()
-          // .trigger("pointerdown", { force: true })
-          // .trigger("pointermove", 40, 40, { force: true } );
+        dataflowToolTile.getNumberNodeOutput().should("exist");
+        dataflowToolTile.getDrawTile().click(306, 182)
+          .trigger("pointerdown", 306, 182, {force: true})
+          .trigger("pointermove", 366, 172, {force: true})
+          .trigger("pointerup", 366, 172, {force: true});
+        // dataflowToolTile.getNumberNodeOutput().click()
+        //   .trigger("pointerdown", "center", { force: true })
+        //   .trigger("pointermove", 40, 10, { force: true } )
+        //   .trigger("pointerup", 40, 10, { force: true } );
 
 
         dataflowToolTile.getDeleteNodeButton("number").click();

--- a/cypress/support/elements/clue/DataflowToolTile.js
+++ b/cypress/support/elements/clue/DataflowToolTile.js
@@ -1,7 +1,7 @@
 const getNodeText = (nodeType) => `.primary-workspace .node.${nodeType}`;
 
 class DataflowToolTile {
-  getDrawTile(workspaceClass) {
+  getDataflowTile(workspaceClass) {
     return cy.get(`${workspaceClass || ".primary-workspace"} .canvas-area .dataflow-tool-tile`);
   }
   getTileTitle(workspaceClass){
@@ -64,8 +64,6 @@ class DataflowToolTile {
   getModalOkButton() {
     return cy.get('.dialog-contents #okButton');
   }
-  //Dataflow Tile
-
   getDataflowTileTitle(workspaceClass){
     return cy.get(`${workspaceClass || ".primary-workspace"} .editable-tile-title`);
   }
@@ -73,12 +71,10 @@ class DataflowToolTile {
   getAmplitudeField() {
     return cy.get(`${getNodeText("generator")} [title='Set Amplitude']`);
   }
-
   //Timer
   getLabel(value) {
     return cy.get(`${getNodeText("timer")} [title='Set Time ${value}'] label`);
   }
-
   //Demo Output
   getAdvancedGrabberImages() {
     cy.get('.demo-output-image.grabber-paddle-image').should("exist");

--- a/cypress/support/elements/clue/DataflowToolTile.js
+++ b/cypress/support/elements/clue/DataflowToolTile.js
@@ -61,7 +61,9 @@ class DataflowToolTile {
   getNumberNodeOutput() {
     return cy.get(".flow-tool .node.number .node-output");
   }
-
+  getModalOkButton() {
+    return cy.get('.dialog-contents #okButton');
+  }
   //Dataflow Tile
 
   getDataflowTileTitle(workspaceClass){

--- a/cypress/support/elements/clue/DataflowToolTile.js
+++ b/cypress/support/elements/clue/DataflowToolTile.js
@@ -58,6 +58,9 @@ class DataflowToolTile {
   getZoomOutButton() {
     return cy.get(`.primary-workspace [title='Zoom Out']`);
   }
+  getNumberNodeOutput() {
+    return cy.get(".flow-tool .node.number .node-output");
+  }
 
   //Dataflow Tile
 

--- a/src/models/stores/serial.ts
+++ b/src/models/stores/serial.ts
@@ -124,7 +124,7 @@ export class SerialDevice {
           // handle message about relays state
           targetChannel.relaysState = reading.split('').map(s => Number(s));
           targetChannel.lastMessageRecievedAt = Date.now();
-          console.log("| recieving relay state and setting i t on targetChannel: ", targetChannel);
+          // console.log(`| ${targetChannel.hubName} has relays state as ${targetChannel.relaysState}`)
         }
       }
     } while (match);

--- a/src/models/stores/serial.ts
+++ b/src/models/stores/serial.ts
@@ -119,7 +119,7 @@ export class SerialDevice {
           // handle message from a humidity or temperature sensor
           const newValue = Number(reading);
           if (isFinite(newValue) && newValue > 0){
-            targetChannel.value = Number(reading)
+            targetChannel.value = Number(reading);
           }
           targetChannel.lastMessageRecievedAt = Date.now();
         }

--- a/src/models/stores/serial.ts
+++ b/src/models/stores/serial.ts
@@ -117,14 +117,16 @@ export class SerialDevice {
       if (targetChannel && signalType === "s" ){
         if (["h", "t"].includes(element)){
           // handle message from a humidity or temperature sensor
-          targetChannel.value = Number(reading);
+          const newValue = Number(reading);
+          if (isFinite(newValue) && newValue > 0){
+            targetChannel.value = Number(reading)
+          }
           targetChannel.lastMessageRecievedAt = Date.now();
         }
         if (["r"].includes(element)){
           // handle message about relays state
           targetChannel.relaysState = reading.split('').map(s => Number(s));
           targetChannel.lastMessageRecievedAt = Date.now();
-          // console.log(`| ${targetChannel.hubName} has relays state as ${targetChannel.relaysState}`)
         }
       }
     } while (match);

--- a/src/models/stores/serial.ts
+++ b/src/models/stores/serial.ts
@@ -117,8 +117,7 @@ export class SerialDevice {
       if (targetChannel && signalType === "s" ){
         if (["h", "t"].includes(element)){
           // handle message from a humidity or temperature sensor
-          const newValue = Number(reading);
-          if (isFinite(newValue) && newValue > 0){
+          if (isFinite(Number(reading))){
             targetChannel.value = Number(reading);
           }
           targetChannel.lastMessageRecievedAt = Date.now();

--- a/src/models/stores/serial.ts
+++ b/src/models/stores/serial.ts
@@ -124,6 +124,7 @@ export class SerialDevice {
           // handle message about relays state
           targetChannel.relaysState = reading.split('').map(s => Number(s));
           targetChannel.lastMessageRecievedAt = Date.now();
+          console.log("| recieving relay state and setting i t on targetChannel: ", targetChannel);
         }
       }
     } while (match);

--- a/src/plugins/dataflow-tool/microbit/communicator.md
+++ b/src/plugins/dataflow-tool/microbit/communicator.md
@@ -1,18 +1,16 @@
 # Communicator
 
 The program for the micro:bit attached to the computer
+- It takes data received from the hub and sends it to the computer via serial.
+- It takes data received from the computer and sends it to the hub via radio.
+- You can toggle this on and off by pressing the A and B buttons.
 
-On received string via radio
-  - assemble the string
-  - write it to serial
-
-On received command string via serial
-  - broadcast it to targeted hub
 
 ```js
 /**
  * micro:bit + Dataflow: "Communicator"
- * This is the basic program for the micro:bit physically attached to the computer.
+ * This is the basic program for the "Communicator"
+ * micro:bit physically attached to the computer.
  */
 
 let mode = 0
@@ -49,6 +47,5 @@ serial.onDataReceived(serial.delimiters(Delimiters.NewLine), function () {
     readFromSerial = serial.readLine()
     radio.sendString(readFromSerial)
 })
-
 
 ```

--- a/src/plugins/dataflow-tool/microbit/communicator.md
+++ b/src/plugins/dataflow-tool/microbit/communicator.md
@@ -37,7 +37,7 @@ input.onButtonPressed(Button.B, function () {
 })
 
 radio.onReceivedString(function (receivedString) {
-    if (mode == 1){
+    if (mode == 1) {
         const signalType = receivedString.substr(0, 1)
         if (signalType == "s" || signalType == "r") {
             serial.writeLine(receivedString)
@@ -45,12 +45,10 @@ radio.onReceivedString(function (receivedString) {
     }
 })
 
-// works
 serial.onDataReceived(serial.delimiters(Delimiters.NewLine), function () {
     readFromSerial = serial.readLine()
     radio.sendString(readFromSerial)
 })
-
 
 
 ```

--- a/src/plugins/dataflow-tool/microbit/hub.md
+++ b/src/plugins/dataflow-tool/microbit/hub.md
@@ -6,9 +6,9 @@ Downloadable link: https://makecode.microbit.org/_YpoCfzeTwCWP
 
 #### Outgoing strings to write,
 e.g. : `sat20.31`
-- `s`: "sensor"
+- `s`: "signal"
 - `a`: "hub A"
-- `t`: "temperature reading"
+- `t`: "temperature reading" (or `h` for humidity, or `r` for relays state),
 - `<n>`: the reading as a string of num chars
 
 #### Incoming strings to read
@@ -81,7 +81,7 @@ function operateRelay(relayIndex: number, state: number) {
 }
 
 function sendAggregatedRelayState(){
-    const relayStateString = `r${hubIds[hubI]}${relayStates.join('')}`;
+    const relayStateString = `s${hubIds[hubI]}r${relayStates.join('')}`;
     radio.sendString(relayStateString);
 }
 

--- a/src/plugins/dataflow-tool/microbit/hub.md
+++ b/src/plugins/dataflow-tool/microbit/hub.md
@@ -20,7 +20,7 @@ e.g. : `ca11`
 
 #### Pins
 - `15`    dht sensor (should change to `16`?):
-- `8`     relay 2 (sprinkler) (green)
+- `8`     relay 2 (Humidifier) (green)
 - `9`     relay 1 (fan) (yellow)
 - `12`    relay 0 (heat) (red)
 
@@ -31,7 +31,7 @@ let hubIds = ['x', 'a', 'b', 'c', 'd']
 let hubI = 0
 
 // pins chosen based on https://makecode.microbit.org/device/pins
-// relays       0 Heat           1 Fan          2 Sprinkler
+// relays       0 Heat           1 Fan          2 Humidifier
 let relayPins = [DigitalPin.P12, DigitalPin.P9, DigitalPin.P8]
 let relayStates = [0, 0, 0]
 

--- a/src/plugins/dataflow-tool/microbit/hub.md
+++ b/src/plugins/dataflow-tool/microbit/hub.md
@@ -33,6 +33,7 @@ let hubI = 0
 // pins chosen based on https://makecode.microbit.org/device/pins
 // relays       0 Heat           1 Fan          2 Sprinkler
 let relayPins = [DigitalPin.P12, DigitalPin.P9, DigitalPin.P8]
+let relayStates = [0, 0, 0]
 
 function getTempString() {
     const t = Math.constrain(dht11_dht22.readData(dataType.temperature), 0, 100);
@@ -56,6 +57,8 @@ function operateRelay(relayIndex: number, state: number) {
     const validRelaySignal = state === 0 || state === 1;
     if (validRelay && validRelaySignal){
         pins.digitalWritePin(relayPins[relayIndex], state)
+        relayStates[relayIndex] = state
+        sendAggregatedRelayState();
     }
 
     // show one of three LEDs to indicate index 0, 1, or 2
@@ -78,8 +81,8 @@ function operateRelay(relayIndex: number, state: number) {
 }
 
 function sendAggregatedRelayState(){
-    // UPCOMING PT STORY #184916018 "Live Output Node Displays sent and received state"
-    // e.g. sendString ra001 over radio
+    const relayStateString = `r${hubIds[hubI]}${relayStates.join('')}`;
+    radio.sendString(relayStateString);
 }
 
 basic.forever(function () {

--- a/src/plugins/dataflow-tool/microbit/hub.md
+++ b/src/plugins/dataflow-tool/microbit/hub.md
@@ -4,27 +4,37 @@ The program for the micro:bit attached to the sensors/relays
 
 Downloadable link: https://makecode.microbit.org/_YpoCfzeTwCWP
 
-#### Outgoing strings to write,
-e.g. : `sat20.31`
-- `s`: "signal"
-- `a`: "hub A"
-- `t`: "temperature reading" (or `h` for humidity, or `r` for relays state),
+#### Place value decoder for outgoing strings
+e.g. : `sat20.31` translates to "signal from hub A, temperature reading 20.31"
+- `s`: indicates this is a "signal" from the hub
+- `a`: specifies hub: (`a`, `b`, `c`, `d`, or `x` for ignorable)
+- `t`: specifies sensor type (`t` for temperature, `h` for humidity)
 - `<n>`: the reading as a string of num chars
 
 #### Incoming strings to read
-e.g. : `ca11`
-- `c`: "control"
-- `a`: "hub A"
-- `1`: "relay at index 1"
-- `1`: "turn on"
+e.g. : `ca11` translates to "control message for hub A, relay at index 1, turn on"
+- `c`: indicates this is a "control" message
+- `a`: specifies hub: (`a`, `b`, `c`, `d`)
+- `1`: specifies index of relay: (`0`, `1`, `2`)
+- `1`: specifies on or off: (`0`, `1`)
 
-#### Pins
-- `15`    dht sensor (should change to `16`?):
-- `8`     relay 2 (Humidifier) (green)
-- `9`     relay 1 (fan) (yellow)
+#### Pins needed for connecting micro:bit
+colors are a convention for making it easier to debug
+- `15`    dht sensor
+- `8`     relay 2 (Humidifier) (yellow)
+- `9`     relay 1 (fan) (orange)
 - `12`    relay 0 (heat) (red)
 
+#### makecode javascript
+load this code onto hub micro:bit via mnakecode.microbit.org
+
 ```js
+/**
+ * micro:bit + Dataflow: "Hub"
+ * This is the basic program for the Hub micro:bit
+ * that is connected to sensors and relays.
+ */
+
 radio.setGroup(1)
 
 let hubIds = ['x', 'a', 'b', 'c', 'd']

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -759,7 +759,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
       Devices differ, but it may contain the words "usbserial" or "usbmodem"`;
 
     if (lastMsg !== "connect" && this.stores.serialDevice.serialNodesCount > 0){
-      alertMessage += `1. Connect the arduino to your computer.  2.${btnMsg}`;
+      alertMessage += `1. Connect the arduino or micro:bit to your computer.  2.${btnMsg}`;
     }
 
     // physical connection has been made but user action needed

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -743,7 +743,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
       const hubSelect = n.controls.get("hubSelect") as DropdownListControl;
       if (hubSelect.getChannels()){
         const relayType = hubSelect.getData("liveOutputType") as string;
-        const hubId = hubSelect.getValue().charAt(14);
+        const hubId = hubSelect.getSelectionId();
         const state = n.data.nodeValue as number;
         this.stores.serialDevice.writeToOutForMicroBitRelayHub(state, hubId, relayType );
       }

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -631,6 +631,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
         this.updateNodeSensorValue(n);
       },
       "Live Output": (n: Node) => {
+        this.updateNodeChannelInfo(n);
         this.sendDataToSerialDevice(n);
       }
     };

--- a/src/plugins/dataflow/model/utilities/channel.ts
+++ b/src/plugins/dataflow/model/utilities/channel.ts
@@ -16,7 +16,8 @@ export interface NodeChannelInfo {
   timeFactor?: number;
   deviceFamily?: string;
   lastMessageRecievedAt?: number | null;
-  relaysState?: number[]
+  relaysState?: number[];
+  microbitId?: string;
 }
 
 const emgSensorChannel: NodeChannelInfo = {
@@ -92,6 +93,7 @@ function createMicroBitSensorChannels(sensors: MicroBitSensorChannelInfo[] ){
   const channels = sensors.map((s) => {
     return {
       ...basis,
+      microbitId: s.microBitId,
       hubId: `MICROBIT-RADIO-${s.microBitId}`,
       hubName: `microbit ${s.microBitId}`,
       name: `${s.type}-microbit-${s.microBitId}`,
@@ -117,6 +119,7 @@ function createMicroBitRelayInfoChannels(hubs: MicroBitHubInfo[] ){
   const channels = hubs.map((h) => {
     return {
       ...basis,
+      microbitId: h.microBitId,
       hubId: `MICROBIT-RADIO-${h.microBitId}`,
       hubName: `microbit ${h.microBitId}`,
       name: `relays-microbit-${h.microBitId}`,

--- a/src/plugins/dataflow/model/utilities/node.ts
+++ b/src/plugins/dataflow/model/utilities/node.ts
@@ -311,7 +311,7 @@ export const NodeLiveOutputTypes = [
     icon: GrabberIcon
   },
   {
-    name: "Sprinkler",
+    name: "Humidifier",
     icon: GrabberIcon,
     relayIndex: 2
   },
@@ -442,3 +442,7 @@ export const ProgramDataRates: ProgramDataRate[] = [
 
 export const kSensorSelectMessage = "Select a sensor";
 export const kSensorMissingMessage = "⚠️";
+export const kRelayMappings = ["Heat Lamp", "Fan", "Humidifier"];
+export const kBinaryOutputTypes = ["Heat Lamp", "Fan", "Humidifier", "Light Bulb"];
+export const kRelayOutputTypes =  ["Heat Lamp", "Fan", "Humidifier"]
+export const kRoundedOutputTypes = ["Grabber"];

--- a/src/plugins/dataflow/model/utilities/node.ts
+++ b/src/plugins/dataflow/model/utilities/node.ts
@@ -442,7 +442,6 @@ export const ProgramDataRates: ProgramDataRate[] = [
 
 export const kSensorSelectMessage = "Select a sensor";
 export const kSensorMissingMessage = "⚠️";
-export const kRelayMappings = ["Heat Lamp", "Fan", "Humidifier"];
-export const kBinaryOutputTypes = ["Heat Lamp", "Fan", "Humidifier", "Light Bulb"];
-export const kRelayOutputTypes =  ["Heat Lamp", "Fan", "Humidifier"];
+export const kRelaysIndexed =  ["Heat Lamp", "Fan", "Humidifier"];
+export const kBinaryOutputTypes = [...kRelaysIndexed, "Light Bulb"];
 export const kRoundedOutputTypes = ["Grabber"];

--- a/src/plugins/dataflow/model/utilities/node.ts
+++ b/src/plugins/dataflow/model/utilities/node.ts
@@ -444,5 +444,5 @@ export const kSensorSelectMessage = "Select a sensor";
 export const kSensorMissingMessage = "⚠️";
 export const kRelayMappings = ["Heat Lamp", "Fan", "Humidifier"];
 export const kBinaryOutputTypes = ["Heat Lamp", "Fan", "Humidifier", "Light Bulb"];
-export const kRelayOutputTypes =  ["Heat Lamp", "Fan", "Humidifier"]
+export const kRelayOutputTypes =  ["Heat Lamp", "Fan", "Humidifier"];
 export const kRoundedOutputTypes = ["Grabber"];

--- a/src/plugins/dataflow/nodes/controls/dropdown-list-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/dropdown-list-control.tsx
@@ -170,6 +170,10 @@ export class DropdownListControl extends Rete.Control {
     return this.props.value;
   };
 
+  public getSelectionId = () => {
+    return this.props.optionArray.find((opt: any) => optionValue(opt) === this.props.value).id;
+  };
+
   /**
    * Is passed a function that will check each list option to see if it should
    * be disabled

--- a/src/plugins/dataflow/nodes/controls/sensor-value-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/sensor-value-control.tsx
@@ -38,13 +38,6 @@ export class SensorValueControl extends Rete.Control {
   }
 
   public setValue = (val: number) => {
-    // SERIAL and RADIO data note:
-    // with a lot of radio signals coming in, we may fail to parse data from more packets
-    // rather than update node with NaN (and probably breaking student program logic)
-    // we will leave the current value in the node until a new isFinite value is received
-    // use this console log to see how many NaN values are reaching this point or
-    // keep in view while debugging sample program behavior
-    // console.log("| SensorValueControl.setValue(val): ", val);
     if (isFinite(val)) {
       this.props.value = val;
       this.putData(this.key, val);

--- a/src/plugins/dataflow/nodes/controls/sensor-value-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/sensor-value-control.tsx
@@ -38,10 +38,19 @@ export class SensorValueControl extends Rete.Control {
   }
 
   public setValue = (val: number) => {
-    this.props.value = val;
-    this.putData(this.key, val);
-    this.updateUnits();
-    (this as any).update();
+    // SERIAL and RADIO data note:
+    // with a lot of radio signals coming in, we may fail to parse data from more packets
+    // rather than update node with NaN (and probably breaking student program logic)
+    // we will leave the current value in the node until a new isFinite value is received
+    // use this console log to see how many NaN values are reaching this point or
+    // keep in view while debugging sample program behavior
+    // console.log("| SensorValueControl.setValue(val): ", val);
+    if (isFinite(val)) {
+      this.props.value = val;
+      this.putData(this.key, val);
+      this.updateUnits();
+      (this as any).update();
+    }
   };
 
   public getValue = () => {

--- a/src/plugins/dataflow/nodes/factories/live-output-rete-node-factory.tsx
+++ b/src/plugins/dataflow/nodes/factories/live-output-rete-node-factory.tsx
@@ -125,7 +125,7 @@ export class LiveOutputReteNodeFactory extends DataflowReteNodeFactory {
     const relayReportedValue = relayChannel.relaysState[selectedOutputRelayIndex];
     if (relayReportedValue === valueShown) return "(received)";
     if (relayReportedValue !== valueShown) return "(sent)";
-    // TODO: channel "missing" attribute sometimes innacurate here, causing hub to appear as missing until reconnect
+    // TODO: channel "missing" attribute innacurrate without sensor block
   }
 
   // TODO IMPROVEMENT - this is a duplicate method - abstract for all factories?

--- a/src/plugins/dataflow/nodes/factories/live-output-rete-node-factory.tsx
+++ b/src/plugins/dataflow/nodes/factories/live-output-rete-node-factory.tsx
@@ -63,8 +63,6 @@ export class LiveOutputReteNodeFactory extends DataflowReteNodeFactory {
         if (kRoundedOutputTypes.includes(outputType)){
           newValue = this.getNewValueForGrabber(n1);
           const roundedDisplayValue = Math.round((newValue / 10) * 10);
-          // Swap commented/uncommented below to change to display of nearest 1%
-          // nodeValue?.setDisplayMessage(`${newValue}% closed`);
           nodeValue?.setDisplayMessage(`${roundedDisplayValue}% closed`);
         }
 
@@ -90,23 +88,23 @@ export class LiveOutputReteNodeFactory extends DataflowReteNodeFactory {
     return hubSelect.getChannels().filter((c: NodeChannelInfo) => c.channelId.charAt(2) === selectedHubIdentifier);
   }
 
-  // NEXT - you need below to know the relay index for the selected output type, so you can call this down in getRelayMessageReceived
   private getSelectedRelayIndex(node: Node){
     const outputTypeControl = node.controls.get("liveOutputType") as DropdownListControl;
     return kRelayMappings.indexOf(outputTypeControl.getValue());
   }
 
-  private updateHubsStatusReport(n: Node){
-    // use existing missing state information to figure out & display if hub is active
-    const hubSelect = n.controls.get("hubSelect") as DropdownListControl;
+  private updateHubsStatusReport(node: Node){
+    const hubSelect = node.controls.get("hubSelect") as DropdownListControl;
     const hubStatusArray: HubStatus[] = hubSelect.getChannels()
-      .filter((c: NodeChannelInfo) => c.type === "temperature" && c.deviceFamily === "microbit")
+      .filter((c: NodeChannelInfo) => c.deviceFamily === "microbit")
       .map((c: NodeChannelInfo) => {
-        return { id: c.channelId.charAt(2), missing: c.missing};
+        return {
+          id: c.channelId.charAt(2), // this char is hub identifier
+          missing: c.missing
+        };
       });
 
     hubStatusArray.forEach((s: HubStatus) => {
-      // "active" is !missing
       hubSelect.setActiveOption(s.id, !s.missing);
     });
   }
@@ -157,6 +155,5 @@ export class LiveOutputReteNodeFactory extends DataflowReteNodeFactory {
       node.removeInput(input);
     }
   }
-
 }
 

--- a/src/plugins/dataflow/nodes/factories/live-output-rete-node-factory.tsx
+++ b/src/plugins/dataflow/nodes/factories/live-output-rete-node-factory.tsx
@@ -114,11 +114,18 @@ export class LiveOutputReteNodeFactory extends DataflowReteNodeFactory {
   }
 
   private getRelayMessageReceived(node: Node) {
-    const hubRelaysState =  this.getHubChannelsForNode(node);
-    if (hubRelaysState.length === 0) return "";
-    hubRelaysState.filter((c: NodeChannelInfo) => c.type === "relays")[0].relaysState;
-    const valueOfRelayAtIndex = hubRelaysState[this.getSelectedRelayIndex(node)];
-    return node.data.nodeValue === valueOfRelayAtIndex ? "(recieved)" : "(sent)";
+    const valueShown = node.data.nodeValue;
+    const hubRelayChannels =  this.getHubChannelsForNode(node)
+      .filter((c: NodeChannelInfo) => c.type === "relays");
+
+    if (hubRelayChannels.length === 0) return "(no hub)";
+    const relayChannel = hubRelayChannels[0];
+    if (!relayChannel.relaysState) return "(no hub)";
+    const selectedOutputRelayIndex = this.getSelectedRelayIndex(node);
+    const relayReportedValue = relayChannel.relaysState[selectedOutputRelayIndex];
+    if (relayReportedValue === valueShown) return "(received)";
+    if (relayReportedValue !== valueShown) return "(sent)";
+    // TODO: channel "missing" attribute sometimes innacurate here, causing hub to appear as missing until reconnect
   }
 
   // TODO IMPROVEMENT - this is a duplicate method - abstract for all factories?

--- a/src/plugins/dataflow/nodes/factories/live-output-rete-node-factory.tsx
+++ b/src/plugins/dataflow/nodes/factories/live-output-rete-node-factory.tsx
@@ -125,7 +125,7 @@ export class LiveOutputReteNodeFactory extends DataflowReteNodeFactory {
     const relayReportedValue = relayChannel.relaysState[selectedOutputRelayIndex];
     if (relayReportedValue === valueShown) return "(received)";
     if (relayReportedValue !== valueShown) return "(sent)";
-    // TODO: channel "missing" attribute innacurrate without sensor block
+    return " ";
   }
 
   // TODO IMPROVEMENT - this is a duplicate method - abstract for all factories?

--- a/src/plugins/dataflow/nodes/factories/live-output-rete-node-factory.tsx
+++ b/src/plugins/dataflow/nodes/factories/live-output-rete-node-factory.tsx
@@ -109,7 +109,7 @@ export class LiveOutputReteNodeFactory extends DataflowReteNodeFactory {
   }
 
   private getRelayMessageReceived(node: Node) {
-    const hubRelaysChannel = this.getHubRelaysChannel(node)
+    const hubRelaysChannel = this.getHubRelaysChannel(node);
     if (!hubRelaysChannel || !hubRelaysChannel.relaysState) return "(no hub)";
     const rIndex = this.getSelectedRelayIndex(node);
     const reportedValue = hubRelaysChannel.relaysState[rIndex];

--- a/src/plugins/dataflow/nodes/factories/live-output-rete-node-factory.tsx
+++ b/src/plugins/dataflow/nodes/factories/live-output-rete-node-factory.tsx
@@ -11,6 +11,11 @@ interface HubStatus {
   id: string,
   missing: boolean
 }
+
+function getRelayMessageReceived(node: Node) {
+  console.log("| given the node, can we determne if the relay state has been receieved?")
+  return "(sent) or (received)";
+}
 export class LiveOutputReteNodeFactory extends DataflowReteNodeFactory {
   constructor(numSocket: Socket) {
     super("Live Output", numSocket);
@@ -45,11 +50,19 @@ export class LiveOutputReteNodeFactory extends DataflowReteNodeFactory {
         const nodeValue = _node.inputs.get("nodeValue")?.control as InputValueControl;
         let newValue = isNaN(n1) ? 0 : n1;
 
-        const binaryOutputTypes = ["Light Bulb", "Heat Lamp", "Fan", "Sprinkler"];
+        const binaryOutputTypes = ["Heat Lamp", "Fan", "Sprinkler", "Light Bulb"];
+        const relayOutputTypes =  ["Heat Lamp", "Fan", "Sprinkler"]
 
         if (binaryOutputTypes.includes(outputType)){
           newValue = isNaN(n1) ? 0 : +(n1 !== 0);
-          nodeValue?.setDisplayMessage(newValue === 0 ? "off" : "on");
+          const offOnString = newValue === 0 ? "off" : "on";
+          if (!relayOutputTypes.includes(outputType)) {
+            nodeValue?.setDisplayMessage(offOnString);
+          }
+          // handle relay outputs, which are binarty but must also display if the relay state has been received
+          else if (relayOutputTypes.includes(outputType)) {
+            nodeValue?.setDisplayMessage(offOnString + " " + getRelayMessageReceived(_node));
+          }
         }
 
         if (outputType === "Grabber"){

--- a/src/plugins/dataflow/nodes/factories/live-output-rete-node-factory.tsx
+++ b/src/plugins/dataflow/nodes/factories/live-output-rete-node-factory.tsx
@@ -85,7 +85,9 @@ export class LiveOutputReteNodeFactory extends DataflowReteNodeFactory {
   private getHubChannelsForNode(node: Node){
     const hubSelect = node.controls.get("hubSelect") as DropdownListControl;
     const selectedHubIdentifier = hubSelect.getValue().slice(-1); // "micro:bit hub a" => "a"
-    return hubSelect.getChannels().filter((c: NodeChannelInfo) => c.channelId.charAt(2) === selectedHubIdentifier);
+    const hubSelectChannels = hubSelect.getChannels();
+    if (!hubSelectChannels) return [];
+    return hubSelectChannels.filter((c: NodeChannelInfo) => c.channelId.charAt(2) === selectedHubIdentifier);
   }
 
   private getSelectedRelayIndex(node: Node){
@@ -95,7 +97,9 @@ export class LiveOutputReteNodeFactory extends DataflowReteNodeFactory {
 
   private updateHubsStatusReport(node: Node){
     const hubSelect = node.controls.get("hubSelect") as DropdownListControl;
-    const hubStatusArray: HubStatus[] = hubSelect.getChannels()
+    const hubsChannels = hubSelect.getChannels();
+    if (!hubsChannels) return;
+    const hubStatusArray: HubStatus[] = hubsChannels
       .filter((c: NodeChannelInfo) => c.deviceFamily === "microbit")
       .map((c: NodeChannelInfo) => {
         return {
@@ -110,8 +114,9 @@ export class LiveOutputReteNodeFactory extends DataflowReteNodeFactory {
   }
 
   private getRelayMessageReceived(node: Node) {
-    const hubRelaysState =  this.getHubChannelsForNode(node)
-      .filter((c: NodeChannelInfo) => c.type === "relays")[0].relaysState;
+    const hubRelaysState =  this.getHubChannelsForNode(node);
+    if (hubRelaysState.length === 0) return "";
+    hubRelaysState.filter((c: NodeChannelInfo) => c.type === "relays")[0].relaysState;
     const valueOfRelayAtIndex = hubRelaysState[this.getSelectedRelayIndex(node)];
     return node.data.nodeValue === valueOfRelayAtIndex ? "(recieved)" : "(sent)";
   }


### PR DESCRIPTION
Functionality is here for [PT#184916018](https://www.pivotaltracker.com/n/projects/2441242/stories/184916018)
- Relays send their aggregated state back to Dataflow
- Live output node indicates (sent) if the state of the selected relay does not match the state of the relay in the report
- Live sensors will no longer accept `NaN` values coming up from failed parse of serial stream.  They retain the last set value until a new, valid, positive number is read from sensor. 

There are a few to-do items that are potentially keeping this in draft for the moment
- [x] revisit the reasoning for the greater than zero condition above, and consider removing it
- [x] right now we derive an identity of a given hub using various slices of various values to arrive at the `a`, `b`, `c`, or `d` character to identify the hub.  This should probably just be a field we can reliably check, or we should build a query string using an existing field... but let's make sure it's not a gigantic refactor. 
- [x] I have a feeling the nested ifs in the Live Output `worker` under `if (kBinaryOutputTypes.includes(outputType))` and their friends, the overlapping `kBinaryOutputTypes` and `kRelayOutputTypes` could be made cleaner. 

Changes above are made below.  I also added some cypress tests that touch:
- Dragging nodes
- Connecting nodes
- The modal serial connection warning
- Data flowing from one node to the next