### PR TITLE
184812191 Drag to Copy Table and Data Card Tiles with Shared Data Sets

### DIFF
--- a/cypress/e2e/clue/branch/student_tests/canvas_test_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/canvas_test_spec.js
@@ -346,8 +346,7 @@ context('Test Canvas', function () {
         imageToolTile.getImageTile().find('.editable-tile-title-text').contains('Did You Know?: Images in computer graphics');
         clueCanvas.deleteTile('image');
       });
-      // FIXME: enable below test when dragging multiple shared-model-backed tiles works
-      it.skip('will maintain positioning when copying multiple tiles', () => {
+      it('will maintain positioning when copying multiple tiles', () => {
         resourcesPanel.openBottomTab("Initial Challenge");
         const leftTile = type => cy.get(`.nav-tab-panel .problem-panel .${type}-tool-tile`);
 

--- a/cypress/e2e/clue/branch/student_tests/graph_table_integraton_test_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/graph_table_integraton_test_spec.js
@@ -252,20 +252,44 @@ context("Dragging to copy linked tiles", () => {
       textToolTile.deleteTextTile();
       cy.linkTableToGraph('Table 1', "Graph 1");
   
+      // Open the document on the left, then create a new document on the right
       resourcesPanel.openPrimaryWorkspaceTab("my-work");
       cy.get(".tab-panel-documents-section .list-item").first().click();
       canvas.createNewExtraDocumentFromFileMenuWithoutTabs("Test Document", "my-work");
 
+      // Select the table and geometry tiles on the left
       const leftTile = type => cy.get(`.nav-tab-panel .documents-panel .${type}-tool-tile`);
       leftTile('table').first().click({ shiftKey: true });
       leftTile('geometry').first().click({ shiftKey: true });
 
-      // Drag the selected copies to the workspace on the right
+      // Drag the selected tiles to the workspace on the right
       leftTile('geometry').first().trigger('dragstart', { dataTransfer });
       cy.get('.single-workspace .canvas .document-content').first()
         .trigger('drop', { force: true, dataTransfer });
       
+      // The copied geometry tile should have two points from its linked shared dataset
       graphToolTile.getGraphPoint().should("exist").and("have.length", 2);
+
+      // // Drag just the geometry tile from the left to the right
+      // leftTile('geometry').first().click();
+      // leftTile('geometry').first().trigger('dragstart', { dataTransfer });
+      // cy.get('.single-workspace .canvas .document-content').first()
+      //   .trigger('drop', { force: true, dataTransfer });
+
+      // // We should now have a total of four points, two in each table
+      // graphToolTile.getGraphPoint().should("exist").and("have.length", 4);
+
+      // // Add a new point to the table
+      // cy.get(".primary-workspace").within((workspace) => {
+      //   tableToolTile.getTableCell().eq(9).click();
+      //   tableToolTile.getTableCell().eq(9).type(x[2] + '{enter}');
+      //   tableToolTile.getTableCell().eq(10).click();
+      //   tableToolTile.getTableCell().eq(10).type(y[2] + '{enter}');
+      //   tableToolTile.getTableCell().eq(13).click();
+      // });
+
+      // // The new point should only appear in the first copied geometry tile, so we now have a total of five
+      // graphToolTile.getGraphPoint().should("exist").and("have.length", 5);
     });
   });
   

--- a/cypress/e2e/clue/branch/student_tests/graph_table_integraton_test_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/graph_table_integraton_test_spec.js
@@ -259,7 +259,7 @@ context("Dragging to copy linked tiles", () => {
 
       // Select the table and geometry tiles on the left
       const leftTile = type => cy.get(`.nav-tab-panel .documents-panel .${type}-tool-tile`);
-      leftTile('table').first().click({ shiftKey: true });
+      leftTile('table').first().click();
       leftTile('geometry').first().click({ shiftKey: true });
 
       // Drag the selected tiles to the workspace on the right
@@ -270,26 +270,26 @@ context("Dragging to copy linked tiles", () => {
       // The copied geometry tile should have two points from its linked shared dataset
       graphToolTile.getGraphPoint().should("exist").and("have.length", 2);
 
-      // // Drag just the geometry tile from the left to the right
-      // leftTile('geometry').first().click();
-      // leftTile('geometry').first().trigger('dragstart', { dataTransfer });
-      // cy.get('.single-workspace .canvas .document-content').first()
-      //   .trigger('drop', { force: true, dataTransfer });
+      // Drag just the geometry tile from the left to the right
+      leftTile('table').first().click({ shiftKey: true });
+      leftTile('geometry').first().trigger('dragstart', { dataTransfer });
+      cy.get('.single-workspace .canvas .document-content').first()
+        .trigger('drop', { force: true, dataTransfer });
 
-      // // We should now have a total of four points, two in each table
-      // graphToolTile.getGraphPoint().should("exist").and("have.length", 4);
+      // We should now have a total of four points, two in each table
+      graphToolTile.getGraphPoint().should("exist").and("have.length", 4);
 
-      // // Add a new point to the table
-      // cy.get(".primary-workspace").within((workspace) => {
-      //   tableToolTile.getTableCell().eq(9).click();
-      //   tableToolTile.getTableCell().eq(9).type(x[2] + '{enter}');
-      //   tableToolTile.getTableCell().eq(10).click();
-      //   tableToolTile.getTableCell().eq(10).type(y[2] + '{enter}');
-      //   tableToolTile.getTableCell().eq(13).click();
-      // });
+      // Add a new point to the table
+      cy.get(".primary-workspace").within((workspace) => {
+        tableToolTile.getTableCell().eq(9).click();
+        tableToolTile.getTableCell().eq(9).type(x[2] + '{enter}');
+        tableToolTile.getTableCell().eq(10).click();
+        tableToolTile.getTableCell().eq(10).type(y[2] + '{enter}');
+        tableToolTile.getTableCell().eq(13).click();
+      });
 
-      // // The new point should only appear in the first copied geometry tile, so we now have a total of five
-      // graphToolTile.getGraphPoint().should("exist").and("have.length", 5);
+      // The new point should only appear in the first copied geometry tile, so we now have a total of five
+      graphToolTile.getGraphPoint().should("exist").and("have.length", 5);
     });
   });
   

--- a/cypress/support/elements/common/Canvas.js
+++ b/cypress/support/elements/common/Canvas.js
@@ -71,7 +71,7 @@ class Canvas {
     this.openFileMenu();
     cy.get('[data-test=list-item-icon-open-workspace]').click();
     cy.get('[data-test=' + type + '-section-workspaces-documents] [data-test=my-work-new-document]').click();
-    dialog.getDialogTitle().should('exist').contains('Create Document');
+    dialog.getDialogTitle().should('exist');
     dialog.getDialogTextInput().click().clear().type(title);
     dialog.getDialogOKButton().click();
   }

--- a/src/models/document/base-document-content.ts
+++ b/src/models/document/base-document-content.ts
@@ -1067,7 +1067,9 @@ export const BaseDocumentContentModel = types
 
         // Update the tile's references to its shared models
         const updateFunction = getTileContentInfo(tile.tileType)?.updateContentWithNewSharedModelIds;
-        updateFunction?.(oldContent.content, sharedDataSetEntries, updatedSharedModelMap);
+        if (updateFunction) {
+          tileContent.content = updateFunction(oldContent.content, sharedDataSetEntries, updatedSharedModelMap);
+        }
 
         // Save the updated tile so we can add it to the document
         updatedTiles.push({ ...tile, newTileId: tileIdMap[tile.tileId], tileContent: JSON.stringify(tileContent) });
@@ -1081,7 +1083,7 @@ export const BaseDocumentContentModel = types
         if (result?.tileId) {
           const { oldTitle, newTitle } = self.updateDefaultTileTitle(result.tileId);
 
-          // If the tile title needed to be update, we assume we should also update the data set's name
+          // If the tile title needed to be updated, we assume we should also update the data set's name
           if (newTitle && sharedModelEntries) {
             newSharedModelEntries.forEach(sharedModelEntry => {
               if (sharedModelEntry.sharedModel.type === "SharedDataSet") {

--- a/src/models/document/base-document-content.ts
+++ b/src/models/document/base-document-content.ts
@@ -28,7 +28,7 @@ import {
   sharedModelFactory, UnknownSharedModel
 } from "../shared/shared-model-manager";
 import { IDocumentContentAddTileOptions, IDragTilesData, INewRowTile, INewTileOptions,
-   ITileCountsPerSection, NewRowTileArray, PartialSharedModelEntry } from "./document-content-types";
+   ITileCountsPerSection, NewRowTileArray, PartialSharedModelEntry, PartialTile } from "./document-content-types";
 import { SharedModelEntry, SharedModelEntryType, SharedModelEntrySnapshotType } from "./shared-model-entry";
 
 // Imports related to hard coding shared model duplication
@@ -1008,7 +1008,7 @@ export const BaseDocumentContentModel = types
       self.logCopyTileResults(tiles, results);
       return results;
     },
-    // If the tile with the given id has a default title, give it a new default title
+    // If the tile with the given id has a default title (like "Table 1"), give it a new default title
     // Note that this will update the tile's title, even if there are no other tiles with the same title
     // Returns { oldTitle, newTitle }, which are undefined if the title wasn't changed
     updateDefaultTileTitle(tileId: string) {
@@ -1027,7 +1027,6 @@ export const BaseDocumentContentModel = types
       }
       return { oldTitle: undefined, newTitle: undefined };
     }
-
   }))
   .actions(self => ({
     // Copies tiles and shared models into the specified row, giving them all new ids
@@ -1035,11 +1034,11 @@ export const BaseDocumentContentModel = types
       tiles: IDragTileItem[],
       sharedModelEntries: PartialSharedModelEntry[],
       rowInfo: IDropRowInfo,
-      insertTileFunction: (updatedTiles: any[], rowInfo: IDropRowInfo) => NewRowTileArray
+      insertTileFunction: (updatedTiles: IDropTileItem[], rowInfo: IDropRowInfo) => NewRowTileArray
     ) {
       // Update shared models with new ids
       const updatedSharedModelMap: Record<string, UpdatedSharedDataSetIds> = {};
-      const newSharedModelEntries: any[] = [];
+      const newSharedModelEntries: PartialSharedModelEntry[] = [];
       sharedModelEntries.forEach(sharedModelEntry => {
         // For now, only duplicate shared data sets
         if (sharedModelEntry.sharedModel.type === "SharedDataSet") {
@@ -1060,7 +1059,7 @@ export const BaseDocumentContentModel = types
 
       // Update tile content with new shared model ids
       const tileIdMap: Record<string, string> = {};
-      const updatedTiles: any[] = [];
+      const updatedTiles: IDropTileItem[] = [];
       tiles.forEach(tile => {
         const oldContent = JSON.parse(tile.tileContent);
         const tileContent = cloneDeep(oldContent);
@@ -1113,7 +1112,7 @@ export const BaseDocumentContentModel = types
 
       // Update tile ids for shared models and add copies to document
       newSharedModelEntries.forEach(sharedModelEntry => {
-        const updatedTileIds: string[] = sharedModelEntry.tiles.map((oldTile: any) => tileIdMap[oldTile.id])
+        const updatedTileIds: string[] = sharedModelEntry.tiles.map((oldTile: PartialTile) => tileIdMap[oldTile.id])
           .filter((tileId: string | undefined) => tileId !== undefined);
         const updatedSharedModel = { ...sharedModelEntry.sharedModel };
         if (sharedModelEntry.sharedModel.type === "SharedDataSet") {
@@ -1124,7 +1123,8 @@ export const BaseDocumentContentModel = types
       });
 
       // TODO: Make sure logging is correct
-      self.logCopyTileResults(tiles, results);}
+      self.logCopyTileResults(tiles, results);
+    }
   }))
   .actions(self => ({
     handleDragCopyTiles(dragTiles: IDragTilesData, rowInfo: IDropRowInfo) {
@@ -1161,7 +1161,7 @@ export const BaseDocumentContentModel = types
         tiles,
         sharedModelEntries,
         { rowInsertIndex: rowIndex },
-        (t: any[], rowInfo: IDropRowInfo) => self.copyTilesIntoNewRows(t, rowInfo.rowInsertIndex)
+        (t: IDropTileItem[], rowInfo: IDropRowInfo) => self.copyTilesIntoNewRows(t, rowInfo.rowInsertIndex)
       );
     }
   }));

--- a/src/models/document/base-document-content.ts
+++ b/src/models/document/base-document-content.ts
@@ -36,10 +36,6 @@ import {
   getSharedDataSetSnapshotWithUpdatedIds, getUpdatedSharedDataSetIds, SharedDataSetSnapshotType,
   UpdatedSharedDataSetIds, updateSharedDataSetSnapshotWithNewTileIds
 } from "../shared/shared-data-set";
-import { updateGeometryContentWithNewSharedModelIds } from "../tiles/geometry/geometry-content";
-import { updateTableContentWithNewSharedModelIds } from "../tiles/table/table-content";
-import { updateDataCardContentWithNewSharedModelIds } from "../../plugins/data-card/data-card-content";
-import { updateDataflowContentWithNewSharedModelIds } from "../../plugins/dataflow/model/dataflow-content";
 
 /**
  * This is one part of the DocumentContentModel. The other part is
@@ -1070,19 +1066,8 @@ export const BaseDocumentContentModel = types
           sharedModelEntries.filter(entry => entry.tiles?.map(t => t.id).includes(tile.tileId));
 
         // Update the tile's references to its shared models
-        if (tile.tileType === "Geometry") {
-          tileContent.content =
-            updateGeometryContentWithNewSharedModelIds(oldContent.content, sharedDataSetEntries, updatedSharedModelMap);
-        } else if (tile.tileType === "Table") {
-          tileContent.content =
-            updateTableContentWithNewSharedModelIds(oldContent.content, sharedDataSetEntries, updatedSharedModelMap);
-        } else if (tile.tileType === "DataCard") {
-          tileContent.content =
-            updateDataCardContentWithNewSharedModelIds(oldContent.content, sharedDataSetEntries, updatedSharedModelMap);
-        } else if (tile.tileType === "Dataflow") {
-          tileContent.content =
-            updateDataflowContentWithNewSharedModelIds(oldContent.content, sharedDataSetEntries, updatedSharedModelMap);
-        }
+        const updateFunction = getTileContentInfo(tile.tileType)?.updateContentWithNewSharedModelIds;
+        updateFunction?.(oldContent.content, sharedDataSetEntries, updatedSharedModelMap);
 
         // Save the updated tile so we can add it to the document
         updatedTiles.push({ ...tile, newTileId: tileIdMap[tile.tileId], tileContent: JSON.stringify(tileContent) });

--- a/src/models/document/base-document-content.ts
+++ b/src/models/document/base-document-content.ts
@@ -1001,69 +1001,251 @@ export const BaseDocumentContentModel = types
                       : self.copyTilesIntoNewRows(tiles, rowInfo.rowInsertIndex);
       self.logCopyTileResults(tiles, results);
       return results;
-    },
+    }
+  }))
+  .actions(self => ({
     handleDragCopyTiles(dragTiles: IDragTilesData, rowInfo: IDropRowInfo) {
       const { tiles, sharedModels } = dragTiles;
 
-      // We need to copy the contents of the tiles and the shared models to the destination.
-      // The ids of the tiles will be remapped as part of the copy process, however, so we
-      // need to make sure that the tile references in the shared models are remapped as well.
-      // To accomplish this, we first generate new ids for the tiles, then we update the
-      // shared models to make use of the new ids, then we copy the shared models into the
-      // document, then we copy the tiles, having modified the tile copying code to make
-      // use of the ids we generated at the beginning of the process.
-
-      // generate new tile ids for the dropped/copied tiles
-      const tileIdMap: Record<string, string> = {};
-      const dropTiles = tiles.map(tile => {
-        const newTileId = uniqueId();
-        tileIdMap[tile.tileId] = newTileId;
-        return { ...tile, newTileId };
-      });
-
-      // Copy the tiles, making use of the new ids generated above
-      // This has to be called first so that references in the shared
-      // model to these tiles are valid.
-      this.userCopyTiles(dropTiles, rowInfo);
-
-      // map tile ids within shared models and add them to the document
-      sharedModels?.forEach(sharedItem => {
-        // for now, if we already have this shared model, don't copy it again
-        // later, we can support other options (asking the user, auto-merging, etc.)
-        if (self.sharedModelMap.get(sharedItem.modelId)) return;
-
-        const providerId = sharedItem.providerId ? tileIdMap[sharedItem.providerId] : undefined;
-        const tileIds = sharedItem.tileIds.map(tileId => tileIdMap[tileId]);
+      // Convert IDragSharedModelItems to partial SharedModelEnries
+      interface PartialTile {
+        id: string;
+      }
+      interface PartialSharedModelEntry {
+        sharedModel: any;
+        tiles: PartialTile[];
+      }
+      const sharedModelEntries: PartialSharedModelEntry[] = [];
+      sharedModels.forEach(dragSharedModel => {
         try {
-          const content = JSON.parse(sharedItem.content, (key, value) => {
-            // some shared models, notably SharedDataSet, have an internal providerId that must be mapped
-            return key === "providerId" ? tileIdMap[value] : value;
-          });
+          const content = JSON.parse(dragSharedModel.content);
           const Model = sharedModelFactory(content);
           const sharedModel = Model !== UnknownSharedModel ? Model.create(content) : undefined;
           if (sharedModel) {
-            // TODO: try switching to a sharedModelManager.addSharedModel
-            const entry = SharedModelEntry.create({ sharedModel });
-            self.sharedModelMap.set(sharedItem.modelId, entry);
-            tileIds.forEach(tileId => {
-              const tile = self.getTile(tileId);
-              if (!tile) {
-                console.warn("Can't find tile for", tileId);
-                return;
-              }
-              entry.addTile(tile, tileId === providerId);
+            sharedModelEntries.push({
+              sharedModel,
+              tiles: dragSharedModel.tileIds.map(tileId => ({ id: tileId }))
             });
-            // TODO: add a mst test to see if we can simplify this by working with
-            // snapshots.  Can an we create an object with a safeReference
-            // to another object that doesn't exist during the create call? Then
-            // when we add it to a tree that has the object being referenced does
-            // the reference match up?
           }
-        }
-        catch(e) {
-          // ignore shared models with errors
+        } catch (e) {
+          console.log(`Unable to copy shared model with content`, dragSharedModel.content);
         }
       });
+      console.log(`1`);
+
+      // Update shared models with new ids
+      interface UpdatedSharedDataSetIds {
+        attributeIdMap: Record<string, string>;
+        caseIdMap: Record<string, string>;
+        dataSetId: string;
+        sharedModelId: string;
+      }
+      const updatedSharedModelMap: Record<string, UpdatedSharedDataSetIds> = {};
+      const newSharedModelEntries: any[] = [];
+      sharedModelEntries.forEach(sharedModelEntry => {
+        // For now, only duplicate shared data sets
+        if (sharedModelEntry.sharedModel.type === "SharedDataSet") {
+          // Determine new ids
+          const sharedDataSet = sharedModelEntry.sharedModel as SharedDataSetSnapshotType;
+          const updatedEntry: UpdatedSharedDataSetIds = {
+            attributeIdMap: {},
+            caseIdMap: {},
+            dataSetId: uniqueId(),
+            sharedModelId: uniqueId()
+          };
+          sharedDataSet.dataSet.attributes?.forEach(attr => {
+            updatedEntry.attributeIdMap[attr.id] = uniqueId();
+          });
+          sharedDataSet.dataSet.cases?.forEach(c => {
+            if (c.__id__) updatedEntry.caseIdMap[c.__id__] = newCaseId();
+          });
+          if (sharedDataSet.id) updatedSharedModelMap[sharedDataSet.id] = updatedEntry;
+
+          // Create a snapshot for the shared model with updated ids, which will be updated with new tile ids
+          // and added to the document later
+          const newAttributes = sharedDataSet.dataSet.attributes?.map(a => {
+            const formula = cloneDeep(a.formula);
+            return { ...a, id: updatedEntry.attributeIdMap[a.id], formula };
+          });
+          const newCases = sharedDataSet.dataSet.cases?.filter(c => c.__id__).map(c => (
+            c.__id__ && { ...c, __id__: updatedEntry.caseIdMap[c.__id__] }
+          ));
+          newSharedModelEntries.push({
+            tiles: sharedModelEntry.tiles,
+            sharedModel: {
+              ...sharedDataSet,
+              id: updatedEntry.sharedModelId,
+              dataSet: {
+                ...sharedDataSet.dataSet,
+                id: updatedEntry.dataSetId,
+                attributes: newAttributes,
+                cases: newCases
+              }
+            }
+          });
+        }
+      });
+      console.log(`2`);
+
+      // Update tile content with new shared model ids
+      const tileIdMap: Record<string, string> = {};
+      const updatedTiles: any[] = [];
+      tiles.forEach(tile => {
+        const oldContent = JSON.parse(tile.tileContent);
+        const tileContent = oldContent;
+        tileIdMap[tile.tileId] = uniqueId();
+
+        // Find the shared models for this tile
+        const sharedDataSetEntries = sharedModelEntries.filter(entry => (
+          entry.tiles?.map(t => t.id).includes(tile.tileId)
+        ));
+
+        // Update the tile's references to its shared models
+        if (tile.tileType === "Table") {
+          const columnWidths: Record<string, number> = {};
+          sharedDataSetEntries.forEach(sharedDataSetEntry => {
+            const originalSharedDataSetId = sharedDataSetEntry.sharedModel.id;
+            const attributeIdMap = updatedSharedModelMap[originalSharedDataSetId].attributeIdMap;
+            for (const entry of Object.entries(oldContent.content.columnWidths)) {
+              const originalId = entry[0];
+              const width = entry[1] as number;
+              if (width !== undefined && originalId && attributeIdMap[originalId]) {
+                  columnWidths[attributeIdMap[originalId]] = width;
+              }
+            }
+          });
+          tileContent.content = { ...oldContent.content, columnWidths };
+        } else if (tile.tileType === "DataCard") {
+          const oldAttributeId = oldContent.content.selectedSortAttributeId;
+          sharedDataSetEntries.forEach(sharedDataSetEntry => {
+            const originalSharedDataSetId = sharedDataSetEntry.sharedModel.id;
+            const attributeIdMap = updatedSharedModelMap[originalSharedDataSetId].attributeIdMap;
+            if (attributeIdMap[oldAttributeId]) {
+              const content = { ...oldContent.content, selectedSortAttributeId: attributeIdMap[oldAttributeId] };
+              tileContent.content = content;
+            }
+          });
+        }
+        console.log(`3`);
+
+        // Save the updated tile so we can add it to the document
+        updatedTiles.push({
+          ...tile,
+          newTileId: tileIdMap[tile.tileId],
+          tileContent: JSON.stringify(tileContent)
+        });
+      });
+
+      // Add copied tiles to document
+      const results = self.userCopyTiles(updatedTiles, rowInfo);
+      // const results = self.copyTilesIntoNewRows(updatedTiles, rowIndex);
+      console.log(`4`);
+
+      // Increment default titles when necessary
+      results.forEach((result, i) => {
+        const newTile = result?.tileId && self.getTile(result.tileId);
+        if (result && newTile) {
+          const tileContentInfo = getTileContentInfo(newTile.content.type);
+          if (tileContentInfo) {
+            const match = titleMatchesDefault(newTile.title, tileContentInfo.titleBase);
+            if (match) {
+              const newTitle = self.getNewTileTitle(newTile.content.type);
+
+              // If the tile title needed to be update, we assume we should also update the data set's name
+              newSharedModelEntries.forEach(sharedModelEntry => {
+                const oldName = sharedModelEntry.sharedModel.dataSet.name;
+                if (oldName === newTile.title) {
+                  sharedModelEntry.sharedModel.dataSet.name = newTitle;
+                }
+              });
+
+              newTile.setTitle(newTitle);
+            }
+          }
+        }
+      });
+      console.log(`5`);
+
+      // Update tile ids for shared models and add copies to document
+      newSharedModelEntries.forEach(sharedModelEntry => {
+        console.log(`- 1`);
+        const updatedTileIds: string[] = sharedModelEntry.tiles.map((oldTile: any) => tileIdMap[oldTile.id]);
+        console.log(`- 2`);
+        const updatedSharedModel = { ...sharedModelEntry.sharedModel };
+        console.log(`- 3`);
+        if (sharedModelEntry.sharedModel.type === "SharedDataSet") {
+          updatedSharedModel.providerId = tileIdMap[sharedModelEntry.sharedModel.providerId];
+        }
+        console.log(`- 4`);
+        console.log(`updatedSharedModel`, updatedSharedModel);
+        const newSharedModelEntry = self.addSharedModel(updatedSharedModel);
+        console.log(`- 5`);
+        updatedTileIds.forEach(tileId => newSharedModelEntry.tiles.push(tileId));
+      });
+      console.log(`6`);
+
+      // TODO: Make sure logging is correct
+      self.logCopyTileResults(tiles, results);
+
+      // // We need to copy the contents of the tiles and the shared models to the destination.
+      // // The ids of the tiles will be remapped as part of the copy process, however, so we
+      // // need to make sure that the tile references in the shared models are remapped as well.
+      // // To accomplish this, we first generate new ids for the tiles, then we update the
+      // // shared models to make use of the new ids, then we copy the shared models into the
+      // // document, then we copy the tiles, having modified the tile copying code to make
+      // // use of the ids we generated at the beginning of the process.
+
+      // // generate new tile ids for the dropped/copied tiles
+      // const tileIdMap: Record<string, string> = {};
+      // const dropTiles = tiles.map(tile => {
+      //   const newTileId = uniqueId();
+      //   tileIdMap[tile.tileId] = newTileId;
+      //   return { ...tile, newTileId };
+      // });
+
+      // // Copy the tiles, making use of the new ids generated above
+      // // This has to be called first so that references in the shared
+      // // model to these tiles are valid.
+      // self.userCopyTiles(dropTiles, rowInfo);
+
+      // // map tile ids within shared models and add them to the document
+      // sharedModels?.forEach(sharedItem => {
+      //   // for now, if we already have this shared model, don't copy it again
+      //   // later, we can support other options (asking the user, auto-merging, etc.)
+      //   if (self.sharedModelMap.get(sharedItem.modelId)) return;
+
+      //   const providerId = sharedItem.providerId ? tileIdMap[sharedItem.providerId] : undefined;
+      //   const tileIds = sharedItem.tileIds.map(tileId => tileIdMap[tileId]);
+      //   try {
+      //     const content = JSON.parse(sharedItem.content, (key, value) => {
+      //       // some shared models, notably SharedDataSet, have an internal providerId that must be mapped
+      //       return key === "providerId" ? tileIdMap[value] : value;
+      //     });
+      //     const Model = sharedModelFactory(content);
+      //     const sharedModel = Model !== UnknownSharedModel ? Model.create(content) : undefined;
+      //     if (sharedModel) {
+      //       // TODO: try switching to a sharedModelManager.addSharedModel
+      //       const entry = SharedModelEntry.create({ sharedModel });
+      //       self.sharedModelMap.set(sharedItem.modelId, entry);
+      //       tileIds.forEach(tileId => {
+      //         const tile = self.getTile(tileId);
+      //         if (!tile) {
+      //           console.warn("Can't find tile for", tileId);
+      //           return;
+      //         }
+      //         entry.addTile(tile, tileId === providerId);
+      //       });
+      //       // TODO: add a mst test to see if we can simplify this by working with
+      //       // snapshots.  Can an we create an object with a safeReference
+      //       // to another object that doesn't exist during the create call? Then
+      //       // when we add it to a tree that has the object being referenced does
+      //       // the reference match up?
+      //     }
+      //   }
+      //   catch(e) {
+      //     // ignore shared models with errors
+      //   }
+      // });
     },
     duplicateTiles(tiles: IDragTileItem[]) {
       // Determine the row to add the duplicated tiles into

--- a/src/models/document/base-document-content.ts
+++ b/src/models/document/base-document-content.ts
@@ -28,7 +28,7 @@ import {
   sharedModelFactory, UnknownSharedModel
 } from "../shared/shared-model-manager";
 import { IDocumentContentAddTileOptions, IDragTilesData, INewRowTile, INewTileOptions,
-   ITileCountsPerSection, NewRowTileArray } from "./document-content-types";
+   ITileCountsPerSection, NewRowTileArray, PartialSharedModelEntry } from "./document-content-types";
 import { SharedModelEntry, SharedModelEntryType, SharedModelEntrySnapshotType } from "./shared-model-entry";
 
 // Imports related to hard coding shared model duplication
@@ -1004,34 +1004,12 @@ export const BaseDocumentContentModel = types
     }
   }))
   .actions(self => ({
-    handleDragCopyTiles(dragTiles: IDragTilesData, rowInfo: IDropRowInfo) {
-      const { tiles, sharedModels } = dragTiles;
-
-      // Convert IDragSharedModelItems to partial SharedModelEnries
-      interface PartialTile {
-        id: string;
-      }
-      interface PartialSharedModelEntry {
-        sharedModel: any;
-        tiles: PartialTile[];
-      }
-      const sharedModelEntries: PartialSharedModelEntry[] = [];
-      sharedModels.forEach(dragSharedModel => {
-        try {
-          const content = JSON.parse(dragSharedModel.content);
-          const Model = sharedModelFactory(content);
-          const sharedModel = Model !== UnknownSharedModel ? Model.create(content) : undefined;
-          if (sharedModel) {
-            sharedModelEntries.push({
-              sharedModel,
-              tiles: dragSharedModel.tileIds.map(tileId => ({ id: tileId }))
-            });
-          }
-        } catch (e) {
-          console.log(`Unable to copy shared model with content`, dragSharedModel.content);
-        }
-      });
-      console.log(`1`);
+    copyTiles(
+      tiles: IDragTileItem[],
+      sharedModelEntries: PartialSharedModelEntry[],
+      rowInfo: IDropRowInfo,
+      insertTileFunction: (updatedTiles: any[], rowInfo: IDropRowInfo) => NewRowTileArray
+    ) {
 
       // Update shared models with new ids
       interface UpdatedSharedDataSetIds {
@@ -1085,7 +1063,6 @@ export const BaseDocumentContentModel = types
           });
         }
       });
-      console.log(`2`);
 
       // Update tile content with new shared model ids
       const tileIdMap: Record<string, string> = {};
@@ -1126,7 +1103,6 @@ export const BaseDocumentContentModel = types
             }
           });
         }
-        console.log(`3`);
 
         // Save the updated tile so we can add it to the document
         updatedTiles.push({
@@ -1137,9 +1113,7 @@ export const BaseDocumentContentModel = types
       });
 
       // Add copied tiles to document
-      const results = self.userCopyTiles(updatedTiles, rowInfo);
-      // const results = self.copyTilesIntoNewRows(updatedTiles, rowIndex);
-      console.log(`4`);
+      const results = insertTileFunction(updatedTiles, rowInfo);
 
       // Increment default titles when necessary
       results.forEach((result, i) => {
@@ -1164,88 +1138,44 @@ export const BaseDocumentContentModel = types
           }
         }
       });
-      console.log(`5`);
 
       // Update tile ids for shared models and add copies to document
       newSharedModelEntries.forEach(sharedModelEntry => {
-        console.log(`- 1`);
         const updatedTileIds: string[] = sharedModelEntry.tiles.map((oldTile: any) => tileIdMap[oldTile.id]);
-        console.log(`- 2`);
         const updatedSharedModel = { ...sharedModelEntry.sharedModel };
-        console.log(`- 3`);
         if (sharedModelEntry.sharedModel.type === "SharedDataSet") {
           updatedSharedModel.providerId = tileIdMap[sharedModelEntry.sharedModel.providerId];
         }
-        console.log(`- 4`);
-        console.log(`updatedSharedModel`, updatedSharedModel);
         const newSharedModelEntry = self.addSharedModel(updatedSharedModel);
-        console.log(`- 5`);
         updatedTileIds.forEach(tileId => newSharedModelEntry.tiles.push(tileId));
       });
-      console.log(`6`);
 
       // TODO: Make sure logging is correct
-      self.logCopyTileResults(tiles, results);
+      self.logCopyTileResults(tiles, results);}
+  }))
+  .actions(self => ({
+    handleDragCopyTiles(dragTiles: IDragTilesData, rowInfo: IDropRowInfo) {
+      const { tiles, sharedModels } = dragTiles;
 
-      // // We need to copy the contents of the tiles and the shared models to the destination.
-      // // The ids of the tiles will be remapped as part of the copy process, however, so we
-      // // need to make sure that the tile references in the shared models are remapped as well.
-      // // To accomplish this, we first generate new ids for the tiles, then we update the
-      // // shared models to make use of the new ids, then we copy the shared models into the
-      // // document, then we copy the tiles, having modified the tile copying code to make
-      // // use of the ids we generated at the beginning of the process.
+      // Convert IDragSharedModelItems to partial SharedModelEnries
+      const sharedModelEntries: PartialSharedModelEntry[] = [];
+      sharedModels.forEach(dragSharedModel => {
+        try {
+          const content = JSON.parse(dragSharedModel.content);
+          const Model = sharedModelFactory(content);
+          const sharedModel = Model !== UnknownSharedModel ? Model.create(content) : undefined;
+          if (sharedModel) {
+            sharedModelEntries.push({
+              sharedModel,
+              tiles: dragSharedModel.tileIds.map(tileId => ({ id: tileId }))
+            });
+          }
+        } catch (e) {
+          console.log(`Unable to copy shared model with content`, dragSharedModel.content);
+        }
+      });
 
-      // // generate new tile ids for the dropped/copied tiles
-      // const tileIdMap: Record<string, string> = {};
-      // const dropTiles = tiles.map(tile => {
-      //   const newTileId = uniqueId();
-      //   tileIdMap[tile.tileId] = newTileId;
-      //   return { ...tile, newTileId };
-      // });
-
-      // // Copy the tiles, making use of the new ids generated above
-      // // This has to be called first so that references in the shared
-      // // model to these tiles are valid.
-      // self.userCopyTiles(dropTiles, rowInfo);
-
-      // // map tile ids within shared models and add them to the document
-      // sharedModels?.forEach(sharedItem => {
-      //   // for now, if we already have this shared model, don't copy it again
-      //   // later, we can support other options (asking the user, auto-merging, etc.)
-      //   if (self.sharedModelMap.get(sharedItem.modelId)) return;
-
-      //   const providerId = sharedItem.providerId ? tileIdMap[sharedItem.providerId] : undefined;
-      //   const tileIds = sharedItem.tileIds.map(tileId => tileIdMap[tileId]);
-      //   try {
-      //     const content = JSON.parse(sharedItem.content, (key, value) => {
-      //       // some shared models, notably SharedDataSet, have an internal providerId that must be mapped
-      //       return key === "providerId" ? tileIdMap[value] : value;
-      //     });
-      //     const Model = sharedModelFactory(content);
-      //     const sharedModel = Model !== UnknownSharedModel ? Model.create(content) : undefined;
-      //     if (sharedModel) {
-      //       // TODO: try switching to a sharedModelManager.addSharedModel
-      //       const entry = SharedModelEntry.create({ sharedModel });
-      //       self.sharedModelMap.set(sharedItem.modelId, entry);
-      //       tileIds.forEach(tileId => {
-      //         const tile = self.getTile(tileId);
-      //         if (!tile) {
-      //           console.warn("Can't find tile for", tileId);
-      //           return;
-      //         }
-      //         entry.addTile(tile, tileId === providerId);
-      //       });
-      //       // TODO: add a mst test to see if we can simplify this by working with
-      //       // snapshots.  Can an we create an object with a safeReference
-      //       // to another object that doesn't exist during the create call? Then
-      //       // when we add it to a tree that has the object being referenced does
-      //       // the reference match up?
-      //     }
-      //   }
-      //   catch(e) {
-      //     // ignore shared models with errors
-      //   }
-      // });
+      self.copyTiles(tiles, sharedModelEntries, rowInfo, self.userCopyTiles);
     },
     duplicateTiles(tiles: IDragTileItem[]) {
       // Determine the row to add the duplicated tiles into
@@ -1254,145 +1184,11 @@ export const BaseDocumentContentModel = types
       // Find shared models used by tiles being duplicated
       const sharedModelEntries = Object.values(self.getSharedModelsUsedByTiles(tiles.map(tile => tile.tileId)));
 
-      // Update shared models with new ids
-      interface UpdatedSharedDataSetIds {
-        attributeIdMap: Record<string, string>;
-        caseIdMap: Record<string, string>;
-        dataSetId: string;
-        sharedModelId: string;
-      }
-      const updatedSharedModelMap: Record<string, UpdatedSharedDataSetIds> = {};
-      const newSharedModelEntries: any[] = [];
-      sharedModelEntries.forEach(sharedModelEntry => {
-        // For now, only duplicate shared data sets
-        if (sharedModelEntry.sharedModel.type === "SharedDataSet") {
-          // Determine new ids
-          const sharedDataSet = getSnapshot(sharedModelEntry.sharedModel) as SharedDataSetSnapshotType;
-          const updatedEntry: UpdatedSharedDataSetIds = {
-            attributeIdMap: {},
-            caseIdMap: {},
-            dataSetId: uniqueId(),
-            sharedModelId: uniqueId()
-          };
-          sharedDataSet.dataSet.attributes?.forEach(attr => {
-            updatedEntry.attributeIdMap[attr.id] = uniqueId();
-          });
-          sharedDataSet.dataSet.cases?.forEach(c => {
-            if (c.__id__) updatedEntry.caseIdMap[c.__id__] = newCaseId();
-          });
-          if (sharedDataSet.id) updatedSharedModelMap[sharedDataSet.id] = updatedEntry;
-
-          // Create a snapshot for the shared model with updated ids, which will be updated with new tile ids
-          // and added to the document later
-          const newAttributes = sharedDataSet.dataSet.attributes?.map(a => {
-            return { ...a, id: updatedEntry.attributeIdMap[a.id] };
-          });
-          const newCases = sharedDataSet.dataSet.cases?.filter(c => c.__id__).map(c => (
-            c.__id__ && { ...c, __id__: updatedEntry.caseIdMap[c.__id__] }
-          ));
-          newSharedModelEntries.push({
-            tiles: sharedModelEntry.tiles,
-            sharedModel: {
-              ...sharedDataSet,
-              id: updatedEntry.sharedModelId,
-              dataSet: {
-                ...sharedDataSet.dataSet,
-                id: updatedEntry.dataSetId,
-                attributes: newAttributes,
-                cases: newCases
-              }
-            }
-          });
-        }
-      });
-
-      // Update tile content with new shared model ids
-      const tileIdMap: Record<string, string> = {};
-      const updatedTiles: any[] = [];
-      tiles.forEach(tile => {
-        const oldContent = JSON.parse(tile.tileContent);
-        const tileContent = oldContent;
-        tileIdMap[tile.tileId] = uniqueId();
-
-        // Find the shared models for this tile
-        const sharedDataSetEntries = sharedModelEntries.filter(entry => (
-          entry.tiles.map(t => t.id).includes(tile.tileId)
-        ));
-
-        // Update the tile's references to its shared models
-        if (tile.tileType === "Table") {
-          const columnWidths: Record<string, number> = {};
-          sharedDataSetEntries.forEach(sharedDataSetEntry => {
-            const originalSharedDataSetId = sharedDataSetEntry.sharedModel.id;
-            const attributeIdMap = updatedSharedModelMap[originalSharedDataSetId].attributeIdMap;
-            for (const entry of Object.entries(oldContent.content.columnWidths)) {
-              const originalId = entry[0];
-              const width = entry[1] as number;
-              if (width !== undefined && originalId && attributeIdMap[originalId]) {
-                  columnWidths[attributeIdMap[originalId]] = width;
-              }
-            }
-          });
-          tileContent.content = { ...oldContent.content, columnWidths };
-        } else if (tile.tileType === "DataCard") {
-          const oldAttributeId = oldContent.content.selectedSortAttributeId;
-          sharedDataSetEntries.forEach(sharedDataSetEntry => {
-            const originalSharedDataSetId = sharedDataSetEntry.sharedModel.id;
-            const attributeIdMap = updatedSharedModelMap[originalSharedDataSetId].attributeIdMap;
-            if (attributeIdMap[oldAttributeId]) {
-              const content = { ...oldContent.content, selectedSortAttributeId: attributeIdMap[oldAttributeId] };
-              tileContent.content = content;
-            }
-          });
-        }
-
-        // Save the updated tile so we can add it to the document
-        updatedTiles.push({
-          ...tile,
-          newTileId: tileIdMap[tile.tileId],
-          tileContent: JSON.stringify(tileContent)
-        });
-      });
-
-      // Add copied tiles to document
-      const results = self.copyTilesIntoNewRows(updatedTiles, rowIndex);
-
-      // Increment default titles when necessary
-      results.forEach((result, i) => {
-        const newTile = result?.tileId && self.getTile(result.tileId);
-        if (result && newTile) {
-          const tileContentInfo = getTileContentInfo(newTile.content.type);
-          if (tileContentInfo) {
-            const match = titleMatchesDefault(newTile.title, tileContentInfo.titleBase);
-            if (match) {
-              const newTitle = self.getNewTileTitle(newTile.content.type);
-
-              // If the tile title needed to be update, we assume we should also update the data set's name
-              newSharedModelEntries.forEach(sharedModelEntry => {
-                const oldName = sharedModelEntry.sharedModel.dataSet.name;
-                if (oldName === newTile.title) {
-                  sharedModelEntry.sharedModel.dataSet.name = newTitle;
-                }
-              });
-
-              newTile.setTitle(newTitle);
-            }
-          }
-        }
-      });
-
-      // Update tile ids for shared models and add copies to document
-      newSharedModelEntries.forEach(sharedModelEntry => {
-        const updatedTileIds: string[] = sharedModelEntry.tiles.map((oldTile: any) => tileIdMap[oldTile.id]);
-        const updatedSharedModel = { ...sharedModelEntry.sharedModel };
-        if (sharedModelEntry.sharedModel.type === "SharedDataSet") {
-          updatedSharedModel.providerId = tileIdMap[sharedModelEntry.sharedModel.providerId];
-        }
-        const newSharedModelEntry = self.addSharedModel(updatedSharedModel);
-        updatedTileIds.forEach(tileId => newSharedModelEntry.tiles.push(tileId));
-      });
-
-      // TODO: Make sure logging is correct
-      self.logCopyTileResults(tiles, results);
+      self.copyTiles(
+        tiles,
+        sharedModelEntries,
+        { rowInsertIndex: rowIndex },
+        (t: any[], rowInfo: IDropRowInfo) => self.copyTilesIntoNewRows(t, rowInfo.rowInsertIndex)
+      );
     }
   }));

--- a/src/models/document/base-document-content.ts
+++ b/src/models/document/base-document-content.ts
@@ -33,7 +33,7 @@ import { SharedModelEntry, SharedModelEntryType, SharedModelEntrySnapshotType } 
 
 // Imports related to hard coding shared model duplication
 import {
-  getSharedDataSetSnapshotWithUpdatedIds, getUpdatedSharedDataSetIds, SharedDataSetSnapshotType,
+  getSharedDataSetSnapshotWithUpdatedIds, getUpdatedSharedDataSetIds, SharedDataSet, SharedDataSetSnapshotType,
   UpdatedSharedDataSetIds, updateSharedDataSetSnapshotWithNewTileIds
 } from "../shared/shared-data-set";
 
@@ -1087,9 +1087,10 @@ export const BaseDocumentContentModel = types
           if (newTitle && sharedModelEntries) {
             newSharedModelEntries.forEach(sharedModelEntry => {
               if (sharedModelEntry.sharedModel.type === "SharedDataSet") {
-                const oldName = sharedModelEntry.sharedModel.dataSet.name;
+                const sharedDataSet = (sharedModelEntry.sharedModel as SharedDataSetSnapshotType);
+                const oldName = sharedDataSet.dataSet.name;
                 if (oldName === oldTitle) {
-                  sharedModelEntry.sharedModel.dataSet.name = newTitle;
+                  sharedDataSet.dataSet.name = newTitle;
                 }
               }
             });
@@ -1103,9 +1104,10 @@ export const BaseDocumentContentModel = types
           .filter((tileId: string | undefined) => tileId !== undefined);
         const updatedSharedModel = { ...sharedModelEntry.sharedModel };
         if (sharedModelEntry.sharedModel.type === "SharedDataSet") {
-          updateSharedDataSetSnapshotWithNewTileIds(updatedSharedModel, tileIdMap);
+          updateSharedDataSetSnapshotWithNewTileIds(updatedSharedModel as SharedDataSetSnapshotType, tileIdMap);
         }
-        const newSharedModelEntry = self.addSharedModel(updatedSharedModel);
+        const newSharedModelEntry =
+          self.addSharedModel(SharedDataSet.create(updatedSharedModel as SharedDataSetSnapshotType));
         updatedTileIds.forEach(tileId => newSharedModelEntry.tiles.push(tileId));
       });
 

--- a/src/models/document/base-document-content.ts
+++ b/src/models/document/base-document-content.ts
@@ -36,8 +36,10 @@ import {
   getSharedDataSetSnapshotWithUpdatedIds, getUpdatedSharedDataSetIds, SharedDataSetSnapshotType,
   UpdatedSharedDataSetIds, updateSharedDataSetSnapshotWithNewTileIds
 } from "../shared/shared-data-set";
+import { updateGeometryContentWithNewSharedModelIds } from "../tiles/geometry/geometry-content";
 import { updateTableContentWithNewSharedModelIds } from "../tiles/table/table-content";
 import { updateDataCardContentWithNewSharedModelIds } from "../../plugins/data-card/data-card-content";
+import { updateDataflowContentWithNewSharedModelIds } from "../../plugins/dataflow/model/dataflow-content";
 
 /**
  * This is one part of the DocumentContentModel. The other part is
@@ -1069,12 +1071,18 @@ export const BaseDocumentContentModel = types
           sharedModelEntries.filter(entry => entry.tiles?.map(t => t.id).includes(tile.tileId));
 
         // Update the tile's references to its shared models
-        if (tile.tileType === "Table") {
+        if (tile.tileType === "Geometry") {
+          tileContent.content =
+            updateGeometryContentWithNewSharedModelIds(oldContent.content, sharedDataSetEntries, updatedSharedModelMap);
+        } else if (tile.tileType === "Table") {
           tileContent.content =
             updateTableContentWithNewSharedModelIds(oldContent.content, sharedDataSetEntries, updatedSharedModelMap);
         } else if (tile.tileType === "DataCard") {
           tileContent.content =
             updateDataCardContentWithNewSharedModelIds(oldContent.content, sharedDataSetEntries, updatedSharedModelMap);
+        } else if (tile.tileType === "Dataflow") {
+          tileContent.content =
+            updateDataflowContentWithNewSharedModelIds(oldContent.content, sharedDataSetEntries, updatedSharedModelMap);
         }
 
         // Save the updated tile so we can add it to the document

--- a/src/models/document/base-document-content.ts
+++ b/src/models/document/base-document-content.ts
@@ -34,7 +34,7 @@ import { SharedModelEntry, SharedModelEntryType, SharedModelEntrySnapshotType } 
 // Imports related to hard coding shared model duplication
 import {
   getSharedDataSetSnapshotWithUpdatedIds, getUpdatedSharedDataSetIds, isSharedDataSetSnapshot, SharedDataSet,
-  SharedDataSetSnapshotType, UpdatedSharedDataSetIds, updateSharedDataSetSnapshotWithNewTileIds
+  UpdatedSharedDataSetIds, updateSharedDataSetSnapshotWithNewTileIds
 } from "../shared/shared-data-set";
 
 /**
@@ -1039,7 +1039,7 @@ export const BaseDocumentContentModel = types
         // For now, only duplicate shared data sets
         if (isSharedDataSetSnapshot(sharedModelEntry.sharedModel)) {
           // Determine new ids
-          const sharedDataSet = sharedModelEntry.sharedModel as SharedDataSetSnapshotType;
+          const sharedDataSet = sharedModelEntry.sharedModel;
           const updatedIds = getUpdatedSharedDataSetIds(sharedDataSet);
           if (sharedDataSet.id) updatedSharedModelMap[sharedDataSet.id] = updatedIds;
 
@@ -1087,7 +1087,7 @@ export const BaseDocumentContentModel = types
           if (newTitle && sharedModelEntries) {
             newSharedModelEntries.forEach(sharedModelEntry => {
               if (isSharedDataSetSnapshot(sharedModelEntry.sharedModel)) {
-                const sharedDataSet = sharedModelEntry.sharedModel as SharedDataSetSnapshotType;
+                const sharedDataSet = sharedModelEntry.sharedModel;
                 const oldName = sharedDataSet.dataSet.name;
                 if (oldName === oldTitle) {
                   sharedDataSet.dataSet.name = newTitle;
@@ -1104,9 +1104,9 @@ export const BaseDocumentContentModel = types
           .filter((tileId: string | undefined) => tileId !== undefined);
         if (isSharedDataSetSnapshot(sharedModelEntry.sharedModel)) {
           const updatedSharedModel = { ...sharedModelEntry.sharedModel };
-          updateSharedDataSetSnapshotWithNewTileIds(updatedSharedModel as SharedDataSetSnapshotType, tileIdMap);
+          updateSharedDataSetSnapshotWithNewTileIds(updatedSharedModel, tileIdMap);
           const newSharedModelEntry =
-            self.addSharedModel(SharedDataSet.create(updatedSharedModel as SharedDataSetSnapshotType));
+            self.addSharedModel(SharedDataSet.create(updatedSharedModel));
           updatedTileIds.forEach(tileId => newSharedModelEntry.tiles.push(tileId));
         }
       });

--- a/src/models/document/base-document-content.ts
+++ b/src/models/document/base-document-content.ts
@@ -1113,7 +1113,8 @@ export const BaseDocumentContentModel = types
 
       // Update tile ids for shared models and add copies to document
       newSharedModelEntries.forEach(sharedModelEntry => {
-        const updatedTileIds: string[] = sharedModelEntry.tiles.map((oldTile: any) => tileIdMap[oldTile.id]);
+        const updatedTileIds: string[] = sharedModelEntry.tiles.map((oldTile: any) => tileIdMap[oldTile.id])
+          .filter((tileId: string | undefined) => tileId !== undefined);
         const updatedSharedModel = { ...sharedModelEntry.sharedModel };
         if (sharedModelEntry.sharedModel.type === "SharedDataSet") {
           updateSharedDataSetSnapshotWithNewTileIds(updatedSharedModel, tileIdMap);

--- a/src/models/document/document-content-tests/dc-shared-models.test.ts
+++ b/src/models/document/document-content-tests/dc-shared-models.test.ts
@@ -20,6 +20,18 @@ jest.mock("../../tiles/log/log-tile-copy-event", () => ({
 import sharedModelExample from "./shared-model-example.json";
 const srcContent: IDocumentImportSnapshot = sharedModelExample.content;
 
+// mock newCaseId so auto-generated IDs are consistent
+// IDs generated with uniqueId are already doing this, but I'm not sure why.
+// A similar mock function is defined for it in drag-tiles.test.ts
+let caseCount = 0;
+jest.mock("../../data/data-set", () => {
+  const { newCaseId, ...others } = jest.requireActual("../../data/data-set");
+  return {
+    newCaseId: () => `caseid-${caseCount++}`,
+    ...others
+  };
+});
+
 // Utility function to help with typing and also to setup the sharedModelManager
 function createDocumentContentModel(snapshot: IDocumentImportSnapshot) {
   const sharedModelManager = new SharedModelDocumentManager();
@@ -264,25 +276,25 @@ Object {
       expect(getSnapshot(targetDocument)).toMatchInlineSnapshot(`
 Object {
   "rowMap": Object {
-    "testid-28": Object {
+    "testid-32": Object {
       "height": undefined,
-      "id": "testid-28",
+      "id": "testid-32",
       "isSectionHeader": false,
       "sectionId": undefined,
       "tiles": Array [
         Object {
-          "tileId": "testid-27",
+          "tileId": "testid-31",
           "widthPct": undefined,
         },
       ],
     },
   },
   "rowOrder": Array [
-    "testid-28",
+    "testid-32",
   ],
   "sharedModelMap": Object {
-    "sharedDataSet1": Object {
-      "provider": "testid-27",
+    "testid-28": Object {
+      "provider": undefined,
       "sharedModel": Object {
         "dataSet": Object {
           "attributes": Array [
@@ -293,7 +305,7 @@ Object {
                 "display": undefined,
               },
               "hidden": false,
-              "id": "attribute1",
+              "id": "testid-29",
               "name": "x",
               "sourceID": undefined,
               "units": "",
@@ -310,7 +322,7 @@ Object {
                 "display": undefined,
               },
               "hidden": false,
-              "id": "attribute2",
+              "id": "testid-30",
               "name": "y",
               "sourceID": undefined,
               "units": "",
@@ -323,30 +335,30 @@ Object {
           ],
           "cases": Array [
             Object {
-              "__id__": "HR3at2-RqvnRaT9z",
+              "__id__": "caseid-0",
             },
             Object {
-              "__id__": "O3SmGUb4iRPw29HU",
+              "__id__": "caseid-1",
             },
             Object {
-              "__id__": "76WRbhQpTu2Wqy1c",
+              "__id__": "caseid-2",
             },
           ],
-          "id": "dataSet1",
+          "id": "testid-27",
           "name": "Demo Dataset",
           "sourceID": undefined,
         },
-        "id": "sharedDataSet1",
-        "providerId": "testid-27",
+        "id": "testid-28",
+        "providerId": "testid-31",
         "type": "SharedDataSet",
       },
       "tiles": Array [
-        "testid-27",
+        "testid-31",
       ],
     },
   },
   "tileMap": Object {
-    "testid-27": Object {
+    "testid-31": Object {
       "content": Object {
         "columnWidths": Object {},
         "importedDataSet": Object {
@@ -360,8 +372,8 @@ Object {
         "type": "Table",
       },
       "display": undefined,
-      "id": "testid-27",
-      "title": "Table 1",
+      "id": "testid-31",
+      "title": "Table 2",
     },
   },
 }
@@ -386,9 +398,9 @@ Object {
       expect(getSnapshot(targetDocument)).toMatchInlineSnapshot(`
 Object {
   "rowMap": Object {
-    "testid-40": Object {
+    "testid-44": Object {
       "height": undefined,
-      "id": "testid-40",
+      "id": "testid-44",
       "isSectionHeader": false,
       "sectionId": undefined,
       "tiles": Array [
@@ -397,18 +409,18 @@ Object {
           "widthPct": undefined,
         },
         Object {
-          "tileId": "testid-42",
+          "tileId": "testid-50",
           "widthPct": undefined,
         },
       ],
     },
   },
   "rowOrder": Array [
-    "testid-40",
+    "testid-44",
   ],
   "sharedModelMap": Object {
-    "sharedDataSet1": Object {
-      "provider": "testid-42",
+    "testid-47": Object {
+      "provider": undefined,
       "sharedModel": Object {
         "dataSet": Object {
           "attributes": Array [
@@ -419,7 +431,7 @@ Object {
                 "display": undefined,
               },
               "hidden": false,
-              "id": "attribute1",
+              "id": "testid-48",
               "name": "x",
               "sourceID": undefined,
               "units": "",
@@ -436,7 +448,7 @@ Object {
                 "display": undefined,
               },
               "hidden": false,
-              "id": "attribute2",
+              "id": "testid-49",
               "name": "y",
               "sourceID": undefined,
               "units": "",
@@ -449,36 +461,36 @@ Object {
           ],
           "cases": Array [
             Object {
-              "__id__": "HR3at2-RqvnRaT9z",
+              "__id__": "caseid-3",
             },
             Object {
-              "__id__": "O3SmGUb4iRPw29HU",
+              "__id__": "caseid-4",
             },
             Object {
-              "__id__": "76WRbhQpTu2Wqy1c",
+              "__id__": "caseid-5",
             },
           ],
-          "id": "dataSet1",
+          "id": "testid-46",
           "name": "Demo Dataset",
           "sourceID": undefined,
         },
-        "id": "sharedDataSet1",
-        "providerId": "testid-42",
+        "id": "testid-47",
+        "providerId": "testid-50",
         "type": "SharedDataSet",
       },
       "tiles": Array [
-        "testid-42",
+        "testid-50",
       ],
     },
   },
   "tileMap": Object {
-    "testid-42": Object {
+    "testid-50": Object {
       "content": Object {
         "columnWidths": Object {},
         "importedDataSet": Object {
           "attributes": Array [],
           "cases": Array [],
-          "id": "testid-33",
+          "id": "testid-37",
           "name": undefined,
           "sourceID": undefined,
         },
@@ -486,7 +498,7 @@ Object {
         "type": "Table",
       },
       "display": undefined,
-      "id": "testid-42",
+      "id": "testid-50",
       "title": undefined,
     },
     "textTool": Object {
@@ -519,29 +531,29 @@ Object {
       expect(getSnapshot(targetDocument)).toMatchInlineSnapshot(`
 Object {
   "rowMap": Object {
-    "testid-57": Object {
+    "testid-69": Object {
       "height": undefined,
-      "id": "testid-57",
+      "id": "testid-69",
       "isSectionHeader": false,
       "sectionId": undefined,
       "tiles": Array [
         Object {
-          "tileId": "testid-55",
+          "tileId": "testid-67",
           "widthPct": undefined,
         },
         Object {
-          "tileId": "testid-56",
+          "tileId": "testid-68",
           "widthPct": undefined,
         },
       ],
     },
   },
   "rowOrder": Array [
-    "testid-57",
+    "testid-69",
   ],
   "sharedModelMap": Object {
-    "sharedDataSet1": Object {
-      "provider": "testid-55",
+    "testid-64": Object {
+      "provider": undefined,
       "sharedModel": Object {
         "dataSet": Object {
           "attributes": Array [
@@ -552,7 +564,7 @@ Object {
                 "display": undefined,
               },
               "hidden": false,
-              "id": "attribute1",
+              "id": "testid-65",
               "name": "x",
               "sourceID": undefined,
               "units": "",
@@ -569,7 +581,7 @@ Object {
                 "display": undefined,
               },
               "hidden": false,
-              "id": "attribute2",
+              "id": "testid-66",
               "name": "y",
               "sourceID": undefined,
               "units": "",
@@ -582,37 +594,37 @@ Object {
           ],
           "cases": Array [
             Object {
-              "__id__": "HR3at2-RqvnRaT9z",
+              "__id__": "caseid-6",
             },
             Object {
-              "__id__": "O3SmGUb4iRPw29HU",
+              "__id__": "caseid-7",
             },
             Object {
-              "__id__": "76WRbhQpTu2Wqy1c",
+              "__id__": "caseid-8",
             },
           ],
-          "id": "dataSet1",
+          "id": "testid-63",
           "name": "Demo Dataset",
           "sourceID": undefined,
         },
-        "id": "sharedDataSet1",
-        "providerId": "testid-55",
+        "id": "testid-64",
+        "providerId": "testid-67",
         "type": "SharedDataSet",
       },
       "tiles": Array [
-        "testid-55",
-        "testid-56",
+        "testid-67",
+        "testid-68",
       ],
     },
   },
   "tileMap": Object {
-    "testid-55": Object {
+    "testid-67": Object {
       "content": Object {
         "columnWidths": Object {},
         "importedDataSet": Object {
           "attributes": Array [],
           "cases": Array [],
-          "id": "testid-47",
+          "id": "testid-55",
           "name": undefined,
           "sourceID": undefined,
         },
@@ -620,10 +632,10 @@ Object {
         "type": "Table",
       },
       "display": undefined,
-      "id": "testid-55",
-      "title": "Table 1",
+      "id": "testid-67",
+      "title": "Table 2",
     },
-    "testid-56": Object {
+    "testid-68": Object {
       "content": Object {
         "bgImage": undefined,
         "board": Object {
@@ -646,7 +658,7 @@ Object {
         "type": "Geometry",
       },
       "display": undefined,
-      "id": "testid-56",
+      "id": "testid-68",
       "title": undefined,
     },
   },

--- a/src/models/document/document-content-types.ts
+++ b/src/models/document/document-content-types.ts
@@ -42,3 +42,11 @@ export interface IDragTilesData {
   tiles: IDragTileItem[];
   sharedModels: IDragSharedModelItem[];
 }
+
+export interface PartialTile {
+  id: string;
+}
+export interface PartialSharedModelEntry {
+  sharedModel: any;
+  tiles: PartialTile[];
+}

--- a/src/models/document/document-content-types.ts
+++ b/src/models/document/document-content-types.ts
@@ -1,3 +1,4 @@
+import { SharedModelSnapshotType } from "../shared/shared-model";
 import { IDragSharedModelItem } from "../shared/shared-model-manager";
 import { IDragTileItem } from "../tiles/tile-model";
 import { IDropRowInfo } from "./tile-row";
@@ -47,6 +48,6 @@ export interface PartialTile {
   id: string;
 }
 export interface PartialSharedModelEntry {
-  sharedModel: any;
+  sharedModel: SharedModelSnapshotType;
   tiles: PartialTile[];
 }

--- a/src/models/shared/shared-data-set.ts
+++ b/src/models/shared/shared-data-set.ts
@@ -1,6 +1,9 @@
 import { Instance, SnapshotIn, types } from "mobx-state-tree";
-import { DataSet } from "../data/data-set";
+import { cloneDeep } from "lodash";
+
+import { DataSet, newCaseId } from "../data/data-set";
 import { SharedModel } from "./shared-model";
+import { uniqueId } from "../../utilities/js-utils";
 
 export const kSharedDataSetType = "SharedDataSet";
 
@@ -21,3 +24,54 @@ export const SharedDataSet = SharedModel
 }));
 export interface SharedDataSetType extends Instance<typeof SharedDataSet> {}
 export interface SharedDataSetSnapshotType extends SnapshotIn<typeof SharedDataSet> {}
+
+export interface UpdatedSharedDataSetIds {
+  attributeIdMap: Record<string, string>;
+  caseIdMap: Record<string, string>;
+  dataSetId: string;
+  sharedModelId: string;
+}
+
+export function getUpdatedSharedDataSetIds(sharedDataSet: SharedDataSetSnapshotType) {
+  const updatedIds: UpdatedSharedDataSetIds = {
+    attributeIdMap: {},
+    caseIdMap: {},
+    dataSetId: uniqueId(),
+    sharedModelId: uniqueId()
+  };
+  sharedDataSet.dataSet.attributes?.forEach(attr => {
+    updatedIds.attributeIdMap[attr.id] = uniqueId();
+  });
+  sharedDataSet.dataSet.cases?.forEach(c => {
+    if (c.__id__) updatedIds.caseIdMap[c.__id__] = newCaseId();
+  });
+  return updatedIds;
+}
+
+export function getSharedDataSetSnapshotWithUpdatedIds(
+  sharedDataSet: SharedDataSetSnapshotType, updatedIds: UpdatedSharedDataSetIds
+) {
+  const newAttributes = sharedDataSet.dataSet.attributes?.map(a => {
+    const formula = cloneDeep(a.formula);
+    return { ...a, id: updatedIds.attributeIdMap[a.id], formula };
+  });
+  const newCases = sharedDataSet.dataSet.cases?.filter(c => c.__id__).map(c => (
+    c.__id__ && { ...c, __id__: updatedIds.caseIdMap[c.__id__] }
+  ));
+  return {
+    ...sharedDataSet,
+    id: updatedIds.sharedModelId,
+    dataSet: {
+      ...sharedDataSet.dataSet,
+      id: updatedIds.dataSetId,
+      attributes: newAttributes,
+      cases: newCases
+    }
+  };
+}
+
+export function updateSharedDataSetSnapshotWithNewTileIds(
+  sharedDataSetSnapshot: any, tileIdMap: Record<string, string>
+) {
+  sharedDataSetSnapshot.providerId = tileIdMap[sharedDataSetSnapshot.providerId];
+}

--- a/src/models/shared/shared-data-set.ts
+++ b/src/models/shared/shared-data-set.ts
@@ -71,7 +71,9 @@ export function getSharedDataSetSnapshotWithUpdatedIds(
 }
 
 export function updateSharedDataSetSnapshotWithNewTileIds(
-  sharedDataSetSnapshot: any, tileIdMap: Record<string, string>
+  sharedDataSetSnapshot: SharedDataSetSnapshotType, tileIdMap: Record<string, string>
 ) {
-  sharedDataSetSnapshot.providerId = tileIdMap[sharedDataSetSnapshot.providerId];
+  if (sharedDataSetSnapshot.providerId) {
+    sharedDataSetSnapshot.providerId = tileIdMap[sharedDataSetSnapshot.providerId];
+  }
 }

--- a/src/models/shared/shared-data-set.ts
+++ b/src/models/shared/shared-data-set.ts
@@ -25,6 +25,10 @@ export const SharedDataSet = SharedModel
 export interface SharedDataSetType extends Instance<typeof SharedDataSet> {}
 export interface SharedDataSetSnapshotType extends SnapshotIn<typeof SharedDataSet> {}
 
+export function isSharedDataSetSnapshot(snapshot: any): snapshot is SharedDataSetSnapshotType {
+  return snapshot.type === kSharedDataSetType;
+}
+
 export interface UpdatedSharedDataSetIds {
   attributeIdMap: Record<string, string>;
   caseIdMap: Record<string, string>;

--- a/src/models/shared/shared-model.ts
+++ b/src/models/shared/shared-model.ts
@@ -1,4 +1,4 @@
-import { Instance, types } from "mobx-state-tree";
+import { Instance, SnapshotIn, types } from "mobx-state-tree";
 import { uniqueId } from "../../utilities/js-utils";
 
 export const kUnknownSharedModel = "unknownSharedModel";
@@ -40,3 +40,4 @@ export const SharedModel = types.model("SharedModel", {
 }));
 
 export interface SharedModelType extends Instance<typeof SharedModel> {}
+export type SharedModelSnapshotType = SnapshotIn<typeof SharedModel>;

--- a/src/models/tiles/geometry/geometry-content.ts
+++ b/src/models/tiles/geometry/geometry-content.ts
@@ -1,7 +1,7 @@
 import { castArray, difference, each, size as _size, union } from "lodash";
 import { reaction } from "mobx";
 import { addDisposer, applySnapshot, Instance, SnapshotIn, types } from "mobx-state-tree";
-import { SharedDataSet, SharedDataSetType } from "../../shared/shared-data-set";
+import { SharedDataSet, SharedDataSetType, UpdatedSharedDataSetIds } from "../../shared/shared-data-set";
 import { SelectionStoreModelType } from "../../stores/selection";
 import { ITableLinkProperties, linkedPointId } from "../table-link-types";
 import { ITileExportOptions, IDefaultContentOptions } from "../tile-content-info";
@@ -39,6 +39,7 @@ import { uniqueId } from "../../../utilities/js-utils";
 import { logTileChangeEvent } from "../log/log-tile-change-event";
 import { LogEventName } from "../../../lib/logger-types";
 import { gImageMap } from "../../image-map";
+import { PartialSharedModelEntry } from "../../document/document-content-types";
 
 export type onCreateCallback = (elt: JXG.GeometryElement) => void;
 
@@ -1151,3 +1152,11 @@ export type GeometryContentModelType = Instance<typeof GeometryContentModel>;
 export type GeometryContentSnapshotType = SnapshotIn<typeof GeometryContentModel>;
 
 export type GeometryMigratedContent = [GeometryContentModelType, { title: string }];
+
+export function updateGeometryContentWithNewSharedModelIds(
+  content: GeometryContentModelType,
+  sharedDataSetEntries: PartialSharedModelEntry[],
+  updatedSharedModelMap: Record<string, UpdatedSharedDataSetIds>
+) {
+  return content;
+}

--- a/src/models/tiles/geometry/geometry-content.ts
+++ b/src/models/tiles/geometry/geometry-content.ts
@@ -1,7 +1,7 @@
 import { castArray, difference, each, size as _size, union } from "lodash";
 import { reaction } from "mobx";
 import { addDisposer, applySnapshot, Instance, SnapshotIn, types } from "mobx-state-tree";
-import { SharedDataSet, SharedDataSetType, UpdatedSharedDataSetIds } from "../../shared/shared-data-set";
+import { SharedDataSet, SharedDataSetType } from "../../shared/shared-data-set";
 import { SelectionStoreModelType } from "../../stores/selection";
 import { ITableLinkProperties, linkedPointId } from "../table-link-types";
 import { ITileExportOptions, IDefaultContentOptions } from "../tile-content-info";
@@ -39,7 +39,6 @@ import { uniqueId } from "../../../utilities/js-utils";
 import { logTileChangeEvent } from "../log/log-tile-change-event";
 import { LogEventName } from "../../../lib/logger-types";
 import { gImageMap } from "../../image-map";
-import { PartialSharedModelEntry } from "../../document/document-content-types";
 
 export type onCreateCallback = (elt: JXG.GeometryElement) => void;
 
@@ -1152,12 +1151,3 @@ export type GeometryContentModelType = Instance<typeof GeometryContentModel>;
 export type GeometryContentSnapshotType = SnapshotIn<typeof GeometryContentModel>;
 
 export type GeometryMigratedContent = [GeometryContentModelType, { title: string }];
-
-export function updateGeometryContentWithNewSharedModelIds(
-  content: GeometryContentModelType,
-  sharedDataSetEntries: PartialSharedModelEntry[],
-  updatedSharedModelMap: Record<string, UpdatedSharedDataSetIds>
-) {
-  // Geometry content has no references to shared dataset ids, so we can just return the unmodified content
-  return content;
-}

--- a/src/models/tiles/geometry/geometry-content.ts
+++ b/src/models/tiles/geometry/geometry-content.ts
@@ -1158,5 +1158,6 @@ export function updateGeometryContentWithNewSharedModelIds(
   sharedDataSetEntries: PartialSharedModelEntry[],
   updatedSharedModelMap: Record<string, UpdatedSharedDataSetIds>
 ) {
+  // Geometry content has no references to shared dataset ids, so we can just return the unmodified content
   return content;
 }

--- a/src/models/tiles/table/table-content.ts
+++ b/src/models/tiles/table/table-content.ts
@@ -451,9 +451,10 @@ export const TableContentModel = TileContentModel
   }));
 
 export type TableContentModelType = Instance<typeof TableContentModel>;
+export type TableContentSnapshotType = SnapshotIn<typeof TableContentModel>;
 
 export function updateTableContentWithNewSharedModelIds(
-  content: TableContentModelType,
+  content: TableContentSnapshotType,
   sharedDataSetEntries: PartialSharedModelEntry[],
   updatedSharedModelMap: Record<string, UpdatedSharedDataSetIds>
 ) {
@@ -462,7 +463,7 @@ export function updateTableContentWithNewSharedModelIds(
   sharedDataSetEntries.forEach(sharedDataSetEntry => {
     const originalSharedDataSetId = sharedDataSetEntry.sharedModel.id;
     const attributeIdMap = updatedSharedModelMap[originalSharedDataSetId].attributeIdMap;
-    for (const entry of Object.entries(content.columnWidths)) {
+    for (const entry of Object.entries(content.columnWidths ?? {})) {
       const originalId = entry[0];
       const width = entry[1] as number;
       if (width !== undefined && originalId && attributeIdMap[originalId]) {

--- a/src/models/tiles/table/table-content.ts
+++ b/src/models/tiles/table/table-content.ts
@@ -12,7 +12,9 @@ import { tileModelHooks } from "../tile-model-hooks";
 import { setTileTitleFromContent } from "../tile-model";
 import { TileContentModel } from "../tile-content";
 import { addCanonicalCasesToDataSet, IDataSet, ICaseCreation, ICase, DataSet } from "../../data/data-set";
-import { kSharedDataSetType, SharedDataSet, SharedDataSetType, UpdatedSharedDataSetIds } from "../../shared/shared-data-set";
+import {
+  kSharedDataSetType, SharedDataSet, SharedDataSetType, UpdatedSharedDataSetIds
+} from "../../shared/shared-data-set";
 import { updateSharedDataSetColors } from "../../shared/shared-data-set-colors";
 import { SharedModelType } from "../../shared/shared-model";
 import { kMinColumnWidth } from "../../../components/tiles/table/table-types";
@@ -462,12 +464,14 @@ export function updateTableContentWithNewSharedModelIds(
   const columnWidths: Record<string, number> = {};
   sharedDataSetEntries.forEach(sharedDataSetEntry => {
     const originalSharedDataSetId = sharedDataSetEntry.sharedModel.id;
-    const attributeIdMap = updatedSharedModelMap[originalSharedDataSetId].attributeIdMap;
-    for (const entry of Object.entries(content.columnWidths ?? {})) {
-      const originalId = entry[0];
-      const width = entry[1] as number;
-      if (width !== undefined && originalId && attributeIdMap[originalId]) {
-          columnWidths[attributeIdMap[originalId]] = width;
+    if (originalSharedDataSetId) {
+      const attributeIdMap = updatedSharedModelMap[originalSharedDataSetId].attributeIdMap;
+      for (const entry of Object.entries(content.columnWidths ?? {})) {
+        const originalId = entry[0];
+        const width = entry[1] as number;
+        if (width !== undefined && originalId && attributeIdMap[originalId]) {
+            columnWidths[attributeIdMap[originalId]] = width;
+        }
       }
     }
   });

--- a/src/models/tiles/table/table-content.ts
+++ b/src/models/tiles/table/table-content.ts
@@ -457,6 +457,7 @@ export function updateTableContentWithNewSharedModelIds(
   sharedDataSetEntries: PartialSharedModelEntry[],
   updatedSharedModelMap: Record<string, UpdatedSharedDataSetIds>
 ) {
+  // Column widths uses attribute ids, so we have to update them when updating shared dataset ids
   const columnWidths: Record<string, number> = {};
   sharedDataSetEntries.forEach(sharedDataSetEntry => {
     const originalSharedDataSetId = sharedDataSetEntry.sharedModel.id;

--- a/src/models/tiles/table/table-registration.ts
+++ b/src/models/tiles/table/table-registration.ts
@@ -1,7 +1,8 @@
 import { registerTileComponentInfo } from "../tile-component-info";
 import { registerTileContentInfo } from "../tile-content-info";
 import {
-  kTableTileType, TableContentModel, TableMetadataModel, kTableDefaultHeight, defaultTableContent
+  kTableTileType, TableContentModel, TableMetadataModel, kTableDefaultHeight, defaultTableContent,
+  updateTableContentWithNewSharedModelIds
 } from "./table-content";
 import TableToolComponent from "../../../components/tiles/table/table-tile";
 import TableToolIcon from "../../../clue/assets/icons/table-tool.svg";
@@ -12,7 +13,8 @@ registerTileContentInfo({
   modelClass: TableContentModel,
   metadataClass: TableMetadataModel,
   defaultHeight: kTableDefaultHeight,
-  defaultContent: defaultTableContent
+  defaultContent: defaultTableContent,
+  updateContentWithNewSharedModelIds: updateTableContentWithNewSharedModelIds
 });
 
 registerTileComponentInfo({

--- a/src/models/tiles/tile-content-info.ts
+++ b/src/models/tiles/tile-content-info.ts
@@ -1,6 +1,8 @@
 import { ITileMetadataModel, TileMetadataModel } from "./tile-metadata";
 import { TileContentModel, ITileContentModel } from "./tile-content";
 import { AppConfigModelType } from "../stores/app-config-model";
+import { PartialSharedModelEntry } from "../document/document-content-types";
+import { UpdatedSharedDataSetIds } from "../shared/shared-data-set";
 
 export interface IDefaultContentOptions {
   // title is only currently used by the Geometry and Table tiles
@@ -17,6 +19,13 @@ type TileModelSnapshotPreProcessor = (tile: any) => any
 type TileContentSnapshotPostProcessor =
       (content: any, idMap: Record<string, string>, asTemplate?: boolean) => any;
 
+type TileContentNewSharedModelIdUpdater = (
+  content: any,
+  sharedModelEntries: PartialSharedModelEntry[],
+  updatedSharedModelMap: Record<string, UpdatedSharedDataSetIds>
+) => any;
+
+
 export interface ITileContentInfo {
   type: string;
   modelClass: typeof TileContentModel;
@@ -28,6 +37,7 @@ export interface ITileContentInfo {
   exportNonDefaultHeight?: boolean;
   tileSnapshotPreProcessor?: TileModelSnapshotPreProcessor;
   contentSnapshotPostProcessor?: TileContentSnapshotPostProcessor;
+  updateContentWithNewSharedModelIds?: TileContentNewSharedModelIdUpdater;
 }
 
 const gTileContentInfoMap: Record<string, ITileContentInfo> = {};

--- a/src/models/tiles/tile-content-info.ts
+++ b/src/models/tiles/tile-content-info.ts
@@ -25,7 +25,6 @@ type TileContentNewSharedModelIdUpdater = (
   updatedSharedModelMap: Record<string, UpdatedSharedDataSetIds>
 ) => any;
 
-
 export interface ITileContentInfo {
   type: string;
   modelClass: typeof TileContentModel;

--- a/src/plugins/data-card/data-card-content.ts
+++ b/src/plugins/data-card/data-card-content.ts
@@ -251,6 +251,7 @@ export function updateDataCardContentWithNewSharedModelIds(
   updatedSharedModelMap: Record<string, UpdatedSharedDataSetIds>
 ) {
   const updatedContent = cloneDeep(content);
+  // Datacard content uses an attribute id for sorting, which has to be updated with new shared dataset ids
   const oldAttributeId = content.selectedSortAttributeId;
   sharedDataSetEntries.forEach(sharedDataSetEntry => {
     const originalSharedDataSetId = sharedDataSetEntry.sharedModel.id;

--- a/src/plugins/data-card/data-card-content.ts
+++ b/src/plugins/data-card/data-card-content.ts
@@ -256,9 +256,11 @@ export function updateDataCardContentWithNewSharedModelIds(
   const oldAttributeId = content.selectedSortAttributeId;
   sharedDataSetEntries.forEach(sharedDataSetEntry => {
     const originalSharedDataSetId = sharedDataSetEntry.sharedModel.id;
-    const attributeIdMap = updatedSharedModelMap[originalSharedDataSetId].attributeIdMap;
-    if (oldAttributeId && attributeIdMap[oldAttributeId]) {
-      updatedContent.selectedSortAttributeId = attributeIdMap[oldAttributeId];
+    if (originalSharedDataSetId) {
+      const attributeIdMap = updatedSharedModelMap[originalSharedDataSetId].attributeIdMap;
+      if (oldAttributeId && attributeIdMap[oldAttributeId]) {
+        updatedContent.selectedSortAttributeId = attributeIdMap[oldAttributeId];
+      }
     }
   });
   return updatedContent;

--- a/src/plugins/data-card/data-card-content.ts
+++ b/src/plugins/data-card/data-card-content.ts
@@ -1,5 +1,5 @@
 import { reaction } from "mobx";
-import { addDisposer, getType, Instance, types } from "mobx-state-tree";
+import { addDisposer, getType, Instance, SnapshotIn, types } from "mobx-state-tree";
 import { cloneDeep } from "lodash";
 
 import { kDataCardTileType, kDefaultLabel, kDefaultLabelPrefix } from "./data-card-types";
@@ -244,9 +244,10 @@ export const DataCardContentModel = TileContentModel
   }));
 
 export interface DataCardContentModelType extends Instance<typeof DataCardContentModel> {}
+export type DataCardContentSnapshotType = SnapshotIn<typeof DataCardContentModel>;
 
 export function updateDataCardContentWithNewSharedModelIds(
-  content: DataCardContentModelType,
+  content: DataCardContentSnapshotType,
   sharedDataSetEntries: PartialSharedModelEntry[],
   updatedSharedModelMap: Record<string, UpdatedSharedDataSetIds>
 ) {

--- a/src/plugins/data-card/data-card-registration.ts
+++ b/src/plugins/data-card/data-card-registration.ts
@@ -4,7 +4,9 @@ import { TileMetadataModel } from "../../models/tiles/tile-metadata";
 import { kDataCardDefaultHeight, kDataCardTileType } from "./data-card-types";
 import DataCardToolIcon from "./assets/data-card-tool.svg";
 import { DataCardToolComponent } from "./data-card-tile";
-import { defaultDataCardContent, DataCardContentModel } from "./data-card-content";
+import {
+  defaultDataCardContent, DataCardContentModel, updateDataCardContentWithNewSharedModelIds
+} from "./data-card-content";
 
 registerTileContentInfo({
   type: kDataCardTileType,
@@ -12,7 +14,8 @@ registerTileContentInfo({
   titleBase: "Data Card Collection",
   metadataClass: TileMetadataModel,
   defaultContent: defaultDataCardContent,
-  defaultHeight: kDataCardDefaultHeight
+  defaultHeight: kDataCardDefaultHeight,
+  updateContentWithNewSharedModelIds: updateDataCardContentWithNewSharedModelIds
 });
 
 registerTileComponentInfo({

--- a/src/plugins/dataflow/model/dataflow-content.ts
+++ b/src/plugins/dataflow/model/dataflow-content.ts
@@ -11,14 +11,13 @@ import { tileModelHooks } from "../../../models/tiles/tile-model-hooks";
 import { TileContentModel } from "../../../models/tiles/tile-content";
 import { getTileModel, setTileTitleFromContent, getTileTitleFromContent } from "../../../models/tiles/tile-model";
 import {
-  SharedDataSet, kSharedDataSetType, SharedDataSetType, UpdatedSharedDataSetIds
+  SharedDataSet, kSharedDataSetType, SharedDataSetType,
 } from "../../../models/shared/shared-data-set";
 import { updateSharedDataSetColors } from "../../../models/shared/shared-data-set-colors";
 import { SharedModelType } from "../../../models/shared/shared-model";
 import { addAttributeToDataSet, addCasesToDataSet, DataSet } from "../../../models/data/data-set";
 import { uniqueId } from "../../../utilities/js-utils";
 import { getTileContentById } from "../../../utilities/mst-utils";
-import { PartialSharedModelEntry } from "../../../models/document/document-content-types";
 
 export const kDataflowTileType = "Dataflow";
 
@@ -260,12 +259,3 @@ export const DataflowContentModel = TileContentModel
   }));
 
 export type DataflowContentModelType = Instance<typeof DataflowContentModel>;
-
-export function updateDataflowContentWithNewSharedModelIds(
-  content: DataflowContentModelType,
-  sharedDataSetEntries: PartialSharedModelEntry[],
-  updatedSharedModelMap: Record<string, UpdatedSharedDataSetIds>
-) {
-  // Dataflow content has no references to shared dataset ids, so we can just return the unmodified content
-  return content;
-}

--- a/src/plugins/dataflow/model/dataflow-content.ts
+++ b/src/plugins/dataflow/model/dataflow-content.ts
@@ -266,5 +266,6 @@ export function updateDataflowContentWithNewSharedModelIds(
   sharedDataSetEntries: PartialSharedModelEntry[],
   updatedSharedModelMap: Record<string, UpdatedSharedDataSetIds>
 ) {
+  // Dataflow content has no references to shared dataset ids, so we can just return the unmodified content
   return content;
 }

--- a/src/plugins/dataflow/model/dataflow-content.ts
+++ b/src/plugins/dataflow/model/dataflow-content.ts
@@ -10,12 +10,15 @@ import { ITileMetadataModel } from "../../../models/tiles/tile-metadata";
 import { tileModelHooks } from "../../../models/tiles/tile-model-hooks";
 import { TileContentModel } from "../../../models/tiles/tile-content";
 import { getTileModel, setTileTitleFromContent, getTileTitleFromContent } from "../../../models/tiles/tile-model";
-import { SharedDataSet, kSharedDataSetType, SharedDataSetType  } from "../../../models/shared/shared-data-set";
+import {
+  SharedDataSet, kSharedDataSetType, SharedDataSetType, UpdatedSharedDataSetIds
+} from "../../../models/shared/shared-data-set";
 import { updateSharedDataSetColors } from "../../../models/shared/shared-data-set-colors";
 import { SharedModelType } from "../../../models/shared/shared-model";
 import { addAttributeToDataSet, addCasesToDataSet, DataSet } from "../../../models/data/data-set";
 import { uniqueId } from "../../../utilities/js-utils";
 import { getTileContentById } from "../../../utilities/mst-utils";
+import { PartialSharedModelEntry } from "../../../models/document/document-content-types";
 
 export const kDataflowTileType = "Dataflow";
 
@@ -257,3 +260,11 @@ export const DataflowContentModel = TileContentModel
   }));
 
 export type DataflowContentModelType = Instance<typeof DataflowContentModel>;
+
+export function updateDataflowContentWithNewSharedModelIds(
+  content: DataflowContentModelType,
+  sharedDataSetEntries: PartialSharedModelEntry[],
+  updatedSharedModelMap: Record<string, UpdatedSharedDataSetIds>
+) {
+  return content;
+}


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/184812191

This PR builds off of the tile duplicate code to make copying tiles by dragging them from another document also duplicate the tiles' shared models. It also better structures that code by breaking it into multiple functions and moving code related to specific tiles and shared models into their files rather than the generic document content file.

This code still involves a lot of hard coded references to specific tiles and shared models. It also only addresses shared data sets and the table, datacard, geometry, and dataflow tiles; it doesn't support shared variables or diagram, drawing, or text tiles.

I'm requesting a review now even though I'm hoping to add a couple of cypress tests that deal with dragging linked tables and geometry tiles. I don't plan on changing any of the actual code at this point, except to address PR feedback.