### PR TITLE
Dataflow scroll

### DIFF
--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -172,7 +172,11 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
               className={editorClass}
               ref={(elt) => this.editorDomElement = elt}
             >
-              <div className="flow-tool" ref={elt => this.toolDiv = elt} onWheel={this.handleWheel} />
+              <div
+                className="flow-tool"
+                ref={elt => this.toolDiv = elt}
+                onWheel={e => this.handleWheel(e, this.toolDiv) }
+              />
               { this.shouldShowProgramCover() &&
                 <DataflowProgramCover editorClass={editorClassForDisplayState} /> }
               {showZoomControl &&
@@ -188,16 +192,10 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
     );
   }
 
-  private handleWheel(e: any) {
-    // console.log(`wheeling`, e);
-    const canvasAreas = document.getElementsByClassName("canvas-area");
-    // console.log(`canvasAreas`, canvasAreas);
-    if (canvasAreas.length > 0) {
-      const canvasArea = canvasAreas[0];
-      const canvas = canvasArea.children[0];
-      const documentContent = canvas.children[0];
-      // console.log(`documentContent`, documentContent);
-      documentContent.scrollBy(e.deltaX, e.deltaY);
+  private handleWheel(e: any, toolDiv: HTMLElement | null) {
+    if (toolDiv !== null) {
+      const documentContent = toolDiv.closest(".document-content");
+      documentContent?.scrollBy(e.deltaX, e.deltaY);
     }
   }
 
@@ -336,7 +334,6 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
 
       // remove rete double click zoom
       this.programEditor.on("zoom", ({ source }) => {
-
         return false;
       });
 

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -335,10 +335,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
       });
 
       // remove rete double click zoom
-      this.programEditor.on("zoom", ({ transform, zoom, source }) => {
-        console.log(`transform`, transform);
-        console.log(`zoom`, zoom);
-        console.log(`source`, source);
+      this.programEditor.on("zoom", ({ source }) => {
 
         return false;
       });

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -172,7 +172,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
               className={editorClass}
               ref={(elt) => this.editorDomElement = elt}
             >
-              <div className="flow-tool" ref={elt => this.toolDiv = elt}/>
+              <div className="flow-tool" ref={elt => this.toolDiv = elt} onWheel={this.handleWheel} />
               { this.shouldShowProgramCover() &&
                 <DataflowProgramCover editorClass={editorClassForDisplayState} /> }
               {showZoomControl &&
@@ -186,6 +186,15 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
         </div>
       </div>
     );
+  }
+
+  private handleWheel(e: any) {
+    console.log(`wheeling`, e);
+    document.onscroll?.(e);
+    // if (this.editorDomElement !== null) {
+    //   console.log(`wheeling`);
+    //   this.editorDomElement.onwheel?.(e);
+    // }
   }
 
   public componentDidMount() {
@@ -322,7 +331,11 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
       });
 
       // remove rete double click zoom
-      this.programEditor.on("zoom", ({ source }) => {
+      this.programEditor.on("zoom", ({ transform, zoom, source }) => {
+        console.log(`transform`, transform);
+        console.log(`zoom`, zoom);
+        console.log(`source`, source);
+
         return false;
       });
 

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -189,12 +189,16 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
   }
 
   private handleWheel(e: any) {
-    console.log(`wheeling`, e);
-    document.onscroll?.(e);
-    // if (this.editorDomElement !== null) {
-    //   console.log(`wheeling`);
-    //   this.editorDomElement.onwheel?.(e);
-    // }
+    // console.log(`wheeling`, e);
+    const canvasAreas = document.getElementsByClassName("canvas-area");
+    // console.log(`canvasAreas`, canvasAreas);
+    if (canvasAreas.length > 0) {
+      const canvasArea = canvasAreas[0];
+      const canvas = canvasArea.children[0];
+      const documentContent = canvas.children[0];
+      // console.log(`documentContent`, documentContent);
+      documentContent.scrollBy(e.deltaX, e.deltaY);
+    }
   }
 
   public componentDidMount() {

--- a/src/plugins/dataflow/components/ui/dataflow-program-zoom.tsx
+++ b/src/plugins/dataflow/components/ui/dataflow-program-zoom.tsx
@@ -10,7 +10,7 @@ interface ZoomProps {
 
 export const DataflowProgramZoom = (props: ZoomProps) => {
   return (
-    <div className="program-editor-zoom">
+    <div className="program-editor-zoom" onScroll={() => console.log(`zoom`)} >
       <button
         title={"Zoom In"}
         onClick={props.onZoomInClick}

--- a/src/plugins/dataflow/components/ui/dataflow-program-zoom.tsx
+++ b/src/plugins/dataflow/components/ui/dataflow-program-zoom.tsx
@@ -10,7 +10,7 @@ interface ZoomProps {
 
 export const DataflowProgramZoom = (props: ZoomProps) => {
   return (
-    <div className="program-editor-zoom" onScroll={() => console.log(`zoom`)} >
+    <div className="program-editor-zoom">
       <button
         title={"Zoom In"}
         onClick={props.onZoomInClick}


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/182890335

This PR allows the user to scroll the document when wheeling over the dataflow tile. This event is usually captured by Rete, preventing scrolling.