### PR TITLE
185046082 Use Table Tile Title Over Dataset Name

### DIFF
--- a/src/models/tiles/table/table-content.ts
+++ b/src/models/tiles/table/table-content.ts
@@ -9,7 +9,7 @@ import {
 import { IDocumentExportOptions, IDefaultContentOptions } from "../tile-content-info";
 import { TileMetadataModel } from "../tile-metadata";
 import { tileModelHooks } from "../tile-model-hooks";
-import { setTileTitleFromContent } from "../tile-model";
+import { getTileTitleFromContent, setTileTitleFromContent } from "../tile-model";
 import { TileContentModel } from "../tile-content";
 import { addCanonicalCasesToDataSet, IDataSet, ICaseCreation, ICase, DataSet } from "../../data/data-set";
 import {
@@ -227,7 +227,7 @@ export const TableContentModel = TileContentModel
   }))
   .views(self => ({
     get title() {
-      return self.dataSet.name;
+      return getTileTitleFromContent(self) ?? self.dataSet.name;
     }
   }))
   .views(self => ({
@@ -333,7 +333,6 @@ export const TableContentModel = TileContentModel
       // }
     },
     setTableName(name: string) {
-      self.dataSet.setName(name);
       setTileTitleFromContent(self, name);
       self.logChange({ action: "update", target: "table", props: { name } });
     },

--- a/src/models/tiles/table/table-registration.ts
+++ b/src/models/tiles/table/table-registration.ts
@@ -7,6 +7,13 @@ import {
 import TableToolComponent from "../../../components/tiles/table/table-tile";
 import TableToolIcon from "../../../clue/assets/icons/table-tool.svg";
 
+export function tileSnapshotPreProcessor(tileSnap: any) {
+  // Get the title from the dataSet if it's only there
+  return !("title" in tileSnap) && "name" in tileSnap.content
+    ? { ...tileSnap, title: tileSnap.content.name }
+    : tileSnap;
+}
+
 registerTileContentInfo({
   type: kTableTileType,
   titleBase: "Table",
@@ -14,6 +21,7 @@ registerTileContentInfo({
   metadataClass: TableMetadataModel,
   defaultHeight: kTableDefaultHeight,
   defaultContent: defaultTableContent,
+  tileSnapshotPreProcessor,
   updateContentWithNewSharedModelIds: updateTableContentWithNewSharedModelIds
 });
 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/185046082

The immediate reason for this work is that it's now possible to switch a table tile's dataset ((un)linking with a dataflow tile). Previously, the displayed title was the dataset's name, but that changes when switching datasets. This work prevents that by using the tile's title instead of the dataset's name. Additionally:
- The dataset's name no longer changes when the user changes the tile's title, so I don't think it's possible to change a dataset's name through CLUE any longer.
- An imported table tile will take its dataset's name if it doesn't have a title specified. This was required to make certain legacy units load properly for testing.

Unless there are requests for changes, this PR is ready to merge after the 4.0 release.