### PR TITLE
cleanup zombie components

### DIFF
--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -424,8 +424,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
 
   private destroyEditor() {
     this.reactElements.forEach(el => {
-      const success = ReactDOM.unmountComponentAtNode(el);
-      console.log("DataflowProgram unmounted", success, el);
+      ReactDOM.unmountComponentAtNode(el);
     });
     this.programEditor.destroy();
     this.reactElements = [];

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import ReactDOM from "react-dom";
 import "regenerator-runtime/runtime";
 import { inject, observer } from "mobx-react";
 import { BaseComponent } from "../../../components/base";
@@ -113,6 +114,8 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
   private disposers: IDisposer[] = [];
   private onSnapshotSetup = false;
   private processing = false;
+  private reactElements: HTMLElement[] = [];
+  private reactNodeElements = new Map<Node, HTMLElement>();
 
   constructor(props: IProps) {
     super(props);
@@ -211,6 +214,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
   public componentWillUnmount() {
     clearInterval(this.intervalHandle);
     this.disposers.forEach(disposer => disposer());
+    this.destroyEditor();
   }
 
   public componentDidUpdate(prevProps: IProps) {
@@ -287,6 +291,44 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
       this.programEditor = new Rete.NodeEditor(RETE_APP_IDENTIFIER, this.toolDiv);
       this.programEditor.use(ConnectionPlugin);
       this.programEditor.use(ReactRenderPlugin);
+
+      // Work around for cleaning up React components created
+      // by the react-render-plugin. The other part of this is
+      // in `destroyEditor`.
+      this.programEditor.on("rendercontrol", ({el, control}) => {
+        const extControl = control as any;
+        if (!extControl.render || extControl.render === "react") {
+          this.reactElements.push(el);
+        }
+      });
+
+      this.programEditor.on("rendernode", ({ el, node, component, bindSocket, bindControl }) => {
+        const extComponent = component as any;
+        if (!extComponent.render || extComponent.render === "react") {
+          this.reactElements.push(el);
+          this.reactNodeElements.set(node, el);
+        }
+      });
+
+      this.programEditor.on("noderemoved", node => {
+        const el = this.reactNodeElements.get(node);
+        if (el) {
+          this.reactNodeElements.delete(node);
+          this.reactElements = this.reactElements.filter(item => item !== el);
+
+          // Remove all the controls inside of this node
+          const childControls = el.getElementsByClassName("control");
+          for (let i=0; i<childControls.length; i++) {
+            const controlEl = childControls[i];
+            if (controlEl instanceof HTMLElement && this.reactElements.indexOf(controlEl)) {
+              this.reactElements = this.reactElements.filter(item => item !== controlEl);
+              ReactDOM.unmountComponentAtNode(controlEl);
+            }
+          }
+          ReactDOM.unmountComponentAtNode(el);
+        }
+      });
+      // End of work around for cleaning up React components
 
       this.components.map(c => {
         this.programEditor.register(c);
@@ -380,9 +422,23 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
     }
   }
 
+  private destroyEditor() {
+    this.reactElements.forEach(el => {
+      const success = ReactDOM.unmountComponentAtNode(el);
+      console.log("DataflowProgram unmounted", success, el);
+    });
+    this.programEditor.destroy();
+    this.reactElements = [];
+    this.reactNodeElements.clear();
+  }
+
   private updateProgramEditor = () => {
     // TODO: allow updates to write tiles for undo/redo
     if (this.toolDiv && this.props.readOnly) {
+      if (this.programEditor) {
+        // Clean up the old editor first
+        this.destroyEditor();
+      }
       this.toolDiv.innerHTML = "";
       this.initProgramEditor();
     }


### PR DESCRIPTION
Zombie components were being left around with these actions:
- when the programEditor is re-initialized in read-only DataflowProgram
- when the DataflowProgram was unmounted
- when a rete node was removed

Really this fix should be integrated into react-render-plugin,
but doing that would require changes in more places.