### PR TITLE
184851423 expression tile

### DIFF
--- a/src/plugins/dataflow/nodes/controls/demo-output-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/demo-output-control.tsx
@@ -5,7 +5,7 @@ import {
   lightBulbOn, lightBulbOff, grabberFrames, grabberPaddle,
   advancedGrabberFrames, grabberCordFrames,
   fanHousing, fanMotor, fanFrames,
-  humidifier, humidAnimationPhases
+  humidifier
 } from "./demo-output-control-assets";
 import { HumidiferAnimation } from "./humidifier-animation";
 

--- a/src/plugins/expression/README.md
+++ b/src/plugins/expression/README.md
@@ -1,0 +1,5 @@
+
+# Expression Tile
+
+This tile can be demo'd with these URL params:
+`?demo&unit=example`

--- a/src/plugins/expression/expression-content.test.ts
+++ b/src/plugins/expression/expression-content.test.ts
@@ -4,7 +4,7 @@ import { defaultExpressionContent, ExpressionContentModel } from "./expression-c
 describe("ExpressionContent", () => {
   it("has default content of 'hello world'", () => {
     const content = defaultExpressionContent();
-    expect(content.text).toBe("Hello World");
+    expect(content.text).toBe("Math Expression");
   });
 
   it("supports changing the text", () => {

--- a/src/plugins/expression/expression-content.test.ts
+++ b/src/plugins/expression/expression-content.test.ts
@@ -1,4 +1,3 @@
-import { defaultBoldFont } from "../../components/constants";
 import { defaultExpressionContent, ExpressionContentModel } from "./expression-content";
 
 describe("ExpressionContent", () => {

--- a/src/plugins/expression/expression-content.test.ts
+++ b/src/plugins/expression/expression-content.test.ts
@@ -1,0 +1,22 @@
+import { defaultBoldFont } from "../../components/constants";
+import { defaultExpressionContent, ExpressionContentModel } from "./expression-content";
+
+describe("ExpressionContent", () => {
+  it("has default content of 'hello world'", () => {
+    const content = defaultExpressionContent();
+    expect(content.text).toBe("Hello World");
+  });
+
+  it("supports changing the text", () => {
+    const content = ExpressionContentModel.create();
+    content.setText("New Text");
+    expect(content.text).toBe("New Text");
+  });
+
+  it("is always user resizable", () => {
+    const content = ExpressionContentModel.create();
+    expect(content.isUserResizable).toBe(true);
+  });
+});
+
+

--- a/src/plugins/expression/expression-content.ts
+++ b/src/plugins/expression/expression-content.ts
@@ -2,8 +2,7 @@ import { types, Instance } from "mobx-state-tree";
 import { TileContentModel } from "../../models/tiles/tile-content";
 import { kExpressionTileType } from "./expression-types";
 import { getTileModel, setTileTitleFromContent } from "../../models/tiles/tile-model";
-import { uniqueId, uniqueTitle } from "../../utilities/js-utils";
-import { IDefaultContentOptions, ITileExportOptions } from "../../models/tiles/tile-content-info";
+import { IDefaultContentOptions } from "../../models/tiles/tile-content-info";
 
 export function defaultExpressionContent(props?: IDefaultContentOptions): ExpressionContentModelType {
   const content = ExpressionContentModel.create({text: "Math Expression"});

--- a/src/plugins/expression/expression-content.ts
+++ b/src/plugins/expression/expression-content.ts
@@ -1,9 +1,14 @@
 import { types, Instance } from "mobx-state-tree";
 import { TileContentModel } from "../../models/tiles/tile-content";
 import { kExpressionTileType } from "./expression-types";
+import { getTileModel, setTileTitleFromContent } from "../../models/tiles/tile-model";
+import { uniqueId, uniqueTitle } from "../../utilities/js-utils";
+import { IDefaultContentOptions, ITileExportOptions } from "../../models/tiles/tile-content-info";
 
-export function defaultExpressionContent(): ExpressionContentModelType {
-  return ExpressionContentModel.create({text: "Math Expression"});
+export function defaultExpressionContent(props?: IDefaultContentOptions): ExpressionContentModelType {
+  const content = ExpressionContentModel.create({text: "Math Expression"});
+  props?.title && content.setTitle(props.title);
+  return content;
 }
 
 export const ExpressionContentModel = TileContentModel
@@ -13,11 +18,17 @@ export const ExpressionContentModel = TileContentModel
     text: "",
   })
   .views(self => ({
+    get title(): string | undefined {
+      return getTileModel(self)?.title;
+    },
     get isUserResizable() {
       return true;
     }
   }))
   .actions(self => ({
+    setTitle(title: string) {
+      setTileTitleFromContent(self, title);
+    },
     setText(text: string) {
       self.text = text;
     }

--- a/src/plugins/expression/expression-content.ts
+++ b/src/plugins/expression/expression-content.ts
@@ -1,0 +1,26 @@
+import { types, Instance } from "mobx-state-tree";
+import { TileContentModel } from "../../models/tiles/tile-content";
+import { kExpressionTileType } from "./expression-types";
+
+export function defaultExpressionContent(): ExpressionContentModelType {
+  return ExpressionContentModel.create({text: "Hello World"});
+}
+
+export const ExpressionContentModel = TileContentModel
+  .named("ExpressionTool")
+  .props({
+    type: types.optional(types.literal(kExpressionTileType), kExpressionTileType),
+    text: "",
+  })
+  .views(self => ({
+    get isUserResizable() {
+      return true;
+    }
+  }))
+  .actions(self => ({
+    setText(text: string) {
+      self.text = text;
+    }
+  }));
+
+export interface ExpressionContentModelType extends Instance<typeof ExpressionContentModel> {}

--- a/src/plugins/expression/expression-content.ts
+++ b/src/plugins/expression/expression-content.ts
@@ -3,7 +3,7 @@ import { TileContentModel } from "../../models/tiles/tile-content";
 import { kExpressionTileType } from "./expression-types";
 
 export function defaultExpressionContent(): ExpressionContentModelType {
-  return ExpressionContentModel.create({text: "Hello World"});
+  return ExpressionContentModel.create({text: "Math Expression"});
 }
 
 export const ExpressionContentModel = TileContentModel

--- a/src/plugins/expression/expression-icon.svg
+++ b/src/plugins/expression/expression-icon.svg
@@ -1,3 +1,18 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="36" height="34" viewBox="0 0 36 34">
-    <text text-anchor="middle" x="50%" y="25">Ex</text>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="36px" height="34px" viewBox="0 0 36 34" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>expressions-tool</title>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Draft-Area" transform="translate(-2026.000000, -1743.000000)">
+            <g id="expressions-tool" transform="translate(2026.000000, 1743.000000)">
+                <polygon id="Path" points="0 0 36 0 36 34 0 34"></polygon>
+                <path d="M27,6 C28.65,6 30,7.35 30,9 L30,25 C30,26.65 28.65,28 27,28 L9,28 C7.35,28 6,26.65 6,25 L6,9 C6,7.35 7.35,6 9,6 L27,6 Z M27,8 L9,8 C8.458,8 8,8.458 8,9 L8,25 C8,25.542 8.458,26 9,26 L27,26 C27.542,26 28,25.542 28,25 L28,9 C28,8.458 27.542,8 27,8 Z" id="Shape" fill="#707070" fill-rule="nonzero"></path>
+                <g id="expressions-icon" transform="translate(10.000000, 10.000000)" fill="#707070">
+                    <text id="2+" font-family="Lato-Bold, Lato" font-size="10" font-weight="bold">
+                        <tspan x="0" y="10">2+</tspan>
+                    </text>
+                    <rect id="Rectangle" x="12" y="2" width="4.09090909" height="9" rx="1"></rect>
+                </g>
+            </g>
+        </g>
+    </g>
 </svg>

--- a/src/plugins/expression/expression-icon.svg
+++ b/src/plugins/expression/expression-icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="36" height="34" viewBox="0 0 36 34">
+    <text text-anchor="middle" x="50%" y="25">Ex</text>
+</svg>

--- a/src/plugins/expression/expression-registration.ts
+++ b/src/plugins/expression/expression-registration.ts
@@ -1,0 +1,20 @@
+import { registerTileComponentInfo } from "../../models/tiles/tile-component-info";
+import { registerTileContentInfo } from "../../models/tiles/tile-content-info";
+import { kExpressionDefaultHeight, kExpressionTileType } from "./expression-types";
+import ExpressionToolIcon from "./expression-icon.svg";
+import { ExpressionToolComponent } from "./expression-tile";
+import { defaultExpressionContent, ExpressionContentModel } from "./expression-content";
+
+registerTileContentInfo({
+  type: kExpressionTileType,
+  modelClass: ExpressionContentModel,
+  defaultContent: defaultExpressionContent,
+  defaultHeight: kExpressionDefaultHeight
+});
+
+registerTileComponentInfo({
+  type: kExpressionTileType,
+  Component: ExpressionToolComponent,
+  tileEltClass: "expression-tool-tile",
+  Icon: ExpressionToolIcon
+});

--- a/src/plugins/expression/expression-registration.ts
+++ b/src/plugins/expression/expression-registration.ts
@@ -8,6 +8,7 @@ import { defaultExpressionContent, ExpressionContentModel } from "./expression-c
 registerTileContentInfo({
   type: kExpressionTileType,
   modelClass: ExpressionContentModel,
+  titleBase: "Expression",
   defaultContent: defaultExpressionContent,
   defaultHeight: kExpressionDefaultHeight
 });

--- a/src/plugins/expression/expression-tile.scss
+++ b/src/plugins/expression/expression-tile.scss
@@ -1,0 +1,17 @@
+@import "../../components/vars.sass";
+
+.expression-tool {
+  width: 100%;
+  height: 100%;
+  text-align: left;
+  overflow: auto;
+
+  &.editable {
+    border: 1px solid #cccccc;
+  }
+
+  textarea {
+    width: 100%;
+    height: 100%;
+  }
+}

--- a/src/plugins/expression/expression-tile.test.tsx
+++ b/src/plugins/expression/expression-tile.test.tsx
@@ -46,13 +46,13 @@ describe("ExpressionToolComponent", () => {
   it("renders successfully", () => {
     const {getByText} =
       render(<ExpressionToolComponent  {...defaultProps} {...{model}}></ExpressionToolComponent>);
-    expect(getByText("Hello World")).toBeInTheDocument();
+    expect(getByText("Math Expression")).toBeInTheDocument();
   });
 
   it("updates the text when the model changes", async () => {
     const {getByText, findByText} =
       render(<ExpressionToolComponent  {...defaultProps} {...{model}}></ExpressionToolComponent>);
-    expect(getByText("Hello World")).toBeInTheDocument();
+    expect(getByText("Math Expression")).toBeInTheDocument();
 
     content.setText("New Text");
 

--- a/src/plugins/expression/expression-tile.test.tsx
+++ b/src/plugins/expression/expression-tile.test.tsx
@@ -1,0 +1,73 @@
+import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { ITileApi } from "../../components/tiles/tile-api";
+import { TileModel } from "../../models/tiles/tile-model";
+import { defaultExpressionContent } from "./expression-content";
+import { ExpressionToolComponent } from "./expression-tile";
+
+// The expression tile needs to be registered so the TileModel.create
+// knows it is a supported tile type
+import "./expression-registration";
+
+describe("ExpressionToolComponent", () => {
+  const content = defaultExpressionContent();
+  const model = TileModel.create({content});
+
+  const defaultProps = {
+    tileElt: null,
+    context: "",
+    docId: "",
+    documentContent: null,
+    isUserResizable: true,
+    onResizeRow: (e: React.DragEvent<HTMLDivElement>): void => {
+      throw new Error("Function not implemented.");
+    },
+    onSetCanAcceptDrop: (tileId?: string): void => {
+      throw new Error("Function not implemented.");
+    },
+    onRequestTilesOfType: (tileType: string): { id: string; title?: string | undefined; }[] => {
+      throw new Error("Function not implemented.");
+    },
+    onRequestUniqueTitle: (tileId: string): string | undefined => {
+      throw new Error("Function not implemented.");
+    },
+    onRequestRowHeight: (tileId: string, height?: number, deltaHeight?: number): void => {
+      throw new Error("Function not implemented.");
+    },
+    onRegisterTileApi: (tileApi: ITileApi, facet?: string): void => {
+      throw new Error("Function not implemented.");
+    },
+    onUnregisterTileApi: (facet?: string): void => {
+      throw new Error("Function not implemented.");
+    }
+  };
+
+  it("renders successfully", () => {
+    const {getByText} =
+      render(<ExpressionToolComponent  {...defaultProps} {...{model}}></ExpressionToolComponent>);
+    expect(getByText("Hello World")).toBeInTheDocument();
+  });
+
+  it("updates the text when the model changes", async () => {
+    const {getByText, findByText} =
+      render(<ExpressionToolComponent  {...defaultProps} {...{model}}></ExpressionToolComponent>);
+    expect(getByText("Hello World")).toBeInTheDocument();
+
+    content.setText("New Text");
+
+    expect(await findByText("New Text")).toBeInTheDocument();
+  });
+
+  it("updates the model when the user types", () => {
+    const {getByRole, getByText} =
+      render(<ExpressionToolComponent  {...defaultProps} {...{model}}></ExpressionToolComponent>);
+    expect(getByText("New Text")).toBeInTheDocument();
+
+    const textBox = getByRole("textbox");
+    userEvent.type(textBox, "{selectall}{del}Typed Text");
+
+    expect(textBox).toHaveValue("Typed Text");
+    expect(content.text).toBe("Typed Text");
+  });
+});

--- a/src/plugins/expression/expression-tile.tsx
+++ b/src/plugins/expression/expression-tile.tsx
@@ -1,0 +1,25 @@
+import { observer } from "mobx-react";
+import React from "react";
+import { ITileProps } from "../../components/tiles/tile-component";
+import { ExpressionContentModelType } from "./expression-content";
+import "./expression-tile.scss";
+
+export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) => {
+  // Note: capturing the content here and using it in handleChange() below may run the risk
+  // of encountering a stale closure issue depending on the order in which content changes,
+  // component renders, and calls to handleChange() occur. See the PR discussion at
+  // (https://github.com/concord-consortium/collaborative-learning/pull/1222/files#r824873678
+  // and following comments) for details. We should be on the lookout for such issues.
+  const content = props.model.content as ExpressionContentModelType;
+
+  const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    content.setText(event.target.value);
+  };
+
+  return (
+    <div className="expression-tool">
+      <textarea value={content.text} onChange={handleChange} />
+    </div>
+  );
+});
+ExpressionToolComponent.displayName = "ExpressionToolComponent";

--- a/src/plugins/expression/expression-tile.tsx
+++ b/src/plugins/expression/expression-tile.tsx
@@ -16,13 +16,8 @@ export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) =>
     content.setText(event.target.value);
   };
 
-  const handleBeginEditTitle = () => {
-    console.log("| begin edit title");
-  };
-
   const handleTitleChange = (title: any): void => {
     content.setTitle(title);
-    console.log("| title change", title);
   };
 
   const renderTitle = () => {
@@ -36,7 +31,6 @@ export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) =>
         getTitle={() => content.title}
         readOnly={readOnly}
         measureText={(text) => measureText(text, defaultTileTitleFont)}
-        onBeginEdit={handleBeginEditTitle}
         onEndEdit={handleTitleChange}
       />
     );

--- a/src/plugins/expression/expression-tile.tsx
+++ b/src/plugins/expression/expression-tile.tsx
@@ -2,22 +2,52 @@ import { observer } from "mobx-react";
 import React from "react";
 import { ITileProps } from "../../components/tiles/tile-component";
 import { ExpressionContentModelType } from "./expression-content";
+import { ToolTitleArea } from "../../components/tiles/tile-title-area";
+import { EditableTileTitle } from "../../components/tiles/editable-tile-title";
+import { defaultTileTitleFont } from "../../components/constants";
+import { measureText } from "../../components/tiles/hooks/use-measure-text";
+
 import "./expression-tile.scss";
 
 export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) => {
-  // Note: capturing the content here and using it in handleChange() below may run the risk
-  // of encountering a stale closure issue depending on the order in which content changes,
-  // component renders, and calls to handleChange() occur. See the PR discussion at
-  // (https://github.com/concord-consortium/collaborative-learning/pull/1222/files#r824873678
-  // and following comments) for details. We should be on the lookout for such issues.
   const content = props.model.content as ExpressionContentModelType;
+  const { onRequestUniqueTitle } = props;
 
   const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     content.setText(event.target.value);
   };
 
+  const handleBeginEditTitle = () => {
+    console.log("| begin edit title");
+  }
+
+  const handleTitleChange = (title: any): void => {
+    content.setTitle(title);
+    console.log("| title change", title);
+  }
+
+  const renderTitle = () => {
+    const size = {width: null, height: null};
+    const { readOnly, scale } = props;
+    return (
+      <EditableTileTitle
+        key="expression-title"
+        size={size}
+        scale={scale}
+        getTitle={() => content.title}
+        readOnly={readOnly}
+        measureText={(text) => measureText(text, defaultTileTitleFont)}
+        onBeginEdit={handleBeginEditTitle}
+        onEndEdit={handleTitleChange}
+      />
+    );
+  }
+
   return (
     <div className="expression-tool">
+      <ToolTitleArea>
+        {renderTitle()}
+      </ToolTitleArea>
       <textarea value={content.text} onChange={handleChange} />
     </div>
   );

--- a/src/plugins/expression/expression-tile.tsx
+++ b/src/plugins/expression/expression-tile.tsx
@@ -11,7 +11,6 @@ import "./expression-tile.scss";
 
 export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) => {
   const content = props.model.content as ExpressionContentModelType;
-  const { onRequestUniqueTitle } = props;
 
   const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     content.setText(event.target.value);
@@ -19,12 +18,12 @@ export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) =>
 
   const handleBeginEditTitle = () => {
     console.log("| begin edit title");
-  }
+  };
 
   const handleTitleChange = (title: any): void => {
     content.setTitle(title);
     console.log("| title change", title);
-  }
+  };
 
   const renderTitle = () => {
     const size = {width: null, height: null};
@@ -41,7 +40,7 @@ export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) =>
         onEndEdit={handleTitleChange}
       />
     );
-  }
+  };
 
   return (
     <div className="expression-tool">

--- a/src/plugins/expression/expression-types.ts
+++ b/src/plugins/expression/expression-types.ts
@@ -1,0 +1,3 @@
+export const kExpressionTileType = "Expression";
+
+export const kExpressionDefaultHeight = 320;

--- a/src/register-tile-types.ts
+++ b/src/register-tile-types.ts
@@ -10,6 +10,7 @@ const gTileRegistration: Record<string, () => void> = {
     import(/* webpackChunkName: "SharedVariables" */"./plugins/shared-variables/shared-variables-registration")
   ]),
   "Drawing": () => import(/* webpackChunkName: "Drawing" */"./plugins/drawing/drawing-registration"),
+  "Expression": () => import(/* webpackChunkName: "Expression" */"./plugins/expression/expression-registration"),
   "Geometry": () => Promise.all([
     import(/* webpackChunkName: "Geometry" */"./models/tiles/geometry/geometry-registration"),
     import(/* webpackChunkName: "SharedDataSet" */"./models/shared/shared-data-set-registration")


### PR DESCRIPTION
This comprises 
[PT#184851423 expression tile](https://www.pivotaltracker.com/story/show/184851423)
- Uses the starter tile template to create an expression tile
- Adds icon

[PT#184851445 expression tile title](https://www.pivotaltracker.com/story/show/184851445)
- Adds title edit/save functionality
- One unrelated, unused import removed from Demo Output