### PR TITLE
fix: Use iframe for CMS (PT-184919981)

### DIFF
--- a/cms/src/iframe-control.tsx
+++ b/cms/src/iframe-control.tsx
@@ -61,7 +61,7 @@ export class IframeControl extends React.Component<CmsWidgetControlProps, IState
   render() {
     return (
       <div className="iframe-control custom-widget">
-        <iframe id="editor" src="/cms-editor.html" onLoad={this.sendInitialValueToEditor.bind(this)}></iframe>
+        <iframe id="editor" src="./cms-editor.html" onLoad={this.sendInitialValueToEditor.bind(this)}></iframe>
       </div>
     );
   }


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/184919981

Fixes the iframe src path value so the CMS editor is loaded correctly on branch URLs. This is a follow up to https://github.com/concord-consortium/collaborative-learning/pull/1688 which can't be tested at master branch URLs because the path `/cms-editor.html` returns a 404 when you try to access the CMS at URLs like https://collaborative-learning.concord.org/branch/master/admin.html.