### PR TITLE
docs: Use iframe for CMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ MSU Inscriptions project.
 
 1. Clone this repo and `cd` into it
 2. Run `npm install` to pull dependencies
-3. Run `npm start` to run `webpack-dev-server` in development mode with hot module replacement
+3. `cd` into the `cms` subdirectory and run `npm install` to pull authoring dependencies (This is currently required even if you will not need to author content.)
+4. `cd` back to the repo's root directory, then run `npm start` to run `webpack-dev-server` in development mode with hot module replacement
 
 ### Building
 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/184919981

We were originally going to automatically install the CMS dependencies by adding `&& cd cms && npm install` to the `postinstall` script in the root package.json. That wouldn't work in the continuous integration process on GitHub, though, so we had to abandon that. Unfortunately, that meant developers and other users who want to use CLUE locally need to take the additional step of manually running `npm install` in the `cms` subdirectory. 

I neglected to update the readme with that information after we worked out the CI issue. This fixes that.

It'd be best, of course, to not require that additional step. I'm not currently aware of a solution, though, and think we should update the documentation with that additional step until a solution can be found.