### PR TITLE
fix: Use iframe for CMS

### DIFF
--- a/cms/src/iframe-control.tsx
+++ b/cms/src/iframe-control.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Map } from "immutable";
 import { CmsWidgetControlProps } from "netlify-cms-core";
 
+import { urlParams } from "../../src/utilities/url-params";
 import { DEBUG_CMS } from "../../src/lib/debug";
 
 import "./iframe-control.scss";
@@ -9,6 +10,7 @@ import "./iframe-control.scss";
 (window as any).DISABLE_FIREBASE_SYNC = true;
 interface IState {
   initialValue?: string;
+  unit?: string;
   validOrigin: string;
 }
 export class IframeControl extends React.Component<CmsWidgetControlProps, IState>  {
@@ -16,6 +18,7 @@ export class IframeControl extends React.Component<CmsWidgetControlProps, IState
     super(props);
     this.state = {
       initialValue: this.getValue(),
+      unit: urlParams.unit,
       validOrigin: `${window.location.protocol}//${window.location.host}`
     };
   }
@@ -59,9 +62,10 @@ export class IframeControl extends React.Component<CmsWidgetControlProps, IState
   };
 
   render() {
+    const iframeUrl = `./cms-editor.html?unit=${this.state.unit}`;
     return (
       <div className="iframe-control custom-widget">
-        <iframe id="editor" src="./cms-editor.html" onLoad={this.sendInitialValueToEditor.bind(this)}></iframe>
+        <iframe id="editor" src={iframeUrl} onLoad={this.sendInitialValueToEditor.bind(this)}></iframe>
       </div>
     );
   }

--- a/cms/src/iframe-control.tsx
+++ b/cms/src/iframe-control.tsx
@@ -10,7 +10,6 @@ import "./iframe-control.scss";
 (window as any).DISABLE_FIREBASE_SYNC = true;
 interface IState {
   initialValue?: string;
-  unit?: string;
   validOrigin: string;
 }
 export class IframeControl extends React.Component<CmsWidgetControlProps, IState>  {
@@ -18,7 +17,6 @@ export class IframeControl extends React.Component<CmsWidgetControlProps, IState
     super(props);
     this.state = {
       initialValue: this.getValue(),
-      unit: urlParams.unit,
       validOrigin: `${window.location.protocol}//${window.location.host}`
     };
   }
@@ -62,7 +60,7 @@ export class IframeControl extends React.Component<CmsWidgetControlProps, IState
   };
 
   render() {
-    const iframeUrl = `./cms-editor.html?unit=${this.state.unit}`;
+    const iframeUrl = urlParams.unit ? `./cms-editor.html?unit=${urlParams.unit}` : "./cms-editor.html";
     return (
       <div className="iframe-control custom-widget">
         <iframe id="editor" src={iframeUrl} onLoad={this.sendInitialValueToEditor.bind(this)}></iframe>


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/184919981

Adds the `unit` URL param to the iframed CMS editor. This corrects a problem where the editor wasn't displaying the correct toolbar items specified in a unit's settings.