### PR TITLE
chore: enable isolatedModules in tsconfig.json and ts-jest configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,14 @@
       "/firebase-test/",
       "/functions/test/(?!(shared\\.test\\.ts)$).*$"
     ],
+    "transform": {
+      "^.+\\.tsx?$": [
+        "ts-jest",
+        {
+          "isolatedModules": true
+        }
+      ]
+    },
     "transformIgnorePatterns": [
       "/node_modules/(?!(d3-format|escape-string-regexp|json-stringify-pretty-compact|nanoid)/)"
     ],

--- a/src/app-config.ts
+++ b/src/app-config.ts
@@ -3,7 +3,7 @@ import { AppConfigModelSnapshot } from "./models/stores/app-config-model.js";
 import appConfigJson from "./clue/app-config.json";
 export const appConfigSnapshot = appConfigJson as AppConfigModelSnapshot;
 export { createStores } from "./models/stores/stores";
-export { BaseComponent, IBaseProps } from "./components/base";
+export { BaseComponent, type IBaseProps } from "./components/base";
 import { ClueAppContentComponent } from "./clue/components/clue-app-content";
 export const AppContentComponent = ClueAppContentComponent;
 export { appIcons } from "./clue/app-icons";

--- a/src/components/tiles/table/data-table.tsx
+++ b/src/components/tiles/table/data-table.tsx
@@ -1,3 +1,5 @@
+export {};
+
 // import React from "react";
 // import { onSnapshot, getSnapshot, types } from "mobx-state-tree";
 // import { ISerializedActionCall } from "mobx-state-tree/dist/middlewares/on-action";

--- a/src/components/tiles/table/data-table.tsx
+++ b/src/components/tiles/table/data-table.tsx
@@ -1,4 +1,4 @@
-export {};
+export {};  // isolatedModules compatibility
 
 // import React from "react";
 // import { onSnapshot, getSnapshot, types } from "mobx-state-tree";

--- a/src/components/tiles/table/linked-table-cell-editor.tsx
+++ b/src/components/tiles/table/linked-table-cell-editor.tsx
@@ -1,4 +1,4 @@
-export {};
+export {};  // isolatedModules compatibility
 
 // import { ICellEditorParams, TextCellEditor } from "@ag-grid-community/core";
 // import { TableMetadataModelType } from "../../../models/tools/table/table-content";

--- a/src/components/tiles/table/linked-table-cell-editor.tsx
+++ b/src/components/tiles/table/linked-table-cell-editor.tsx
@@ -1,3 +1,5 @@
+export {};
+
 // import { ICellEditorParams, TextCellEditor } from "@ag-grid-community/core";
 // import { TableMetadataModelType } from "../../../models/tools/table/table-content";
 

--- a/src/models/tiles/geometry/jxg-changes.ts
+++ b/src/models/tiles/geometry/jxg-changes.ts
@@ -1,6 +1,6 @@
 import { castArray } from "lodash";
 import { ILinkProperties, ITableLinkProperties } from "../table-link-types";
-export { ILinkProperties, ITableLinkProperties };
+export { type ILinkProperties, type ITableLinkProperties };
 
 export type JXGOperation = "create" | "update" | "delete";
 export type JXGObjectType = "board" | "comment" | "image" | "linkedPoint" | "metadata" | "movableLine" |

--- a/src/test/setupTests.test.ts
+++ b/src/test/setupTests.test.ts
@@ -1,3 +1,5 @@
+export {};
+
 describe("setupTests", () => {
   describe("assertIsDefined", () => {
     it("handles undefined values", () => {
@@ -16,28 +18,28 @@ describe("setupTests", () => {
       }).toThrow();
     });
 
-    it("handles defined values", () => {      
-      // `as any` is used here to verify that assertIsDefined is working 
-      // with Typescript correctly. Without `as any` typescript ignores 
+    it("handles defined values", () => {
+      // `as any` is used here to verify that assertIsDefined is working
+      // with Typescript correctly. Without `as any` typescript ignores
       // the `number | undefined` and just uses `number`. So then `value + 1`
       // is fine even without the `assertIsDefined`.
       const value: number | undefined = 1 as any;
 
-      // Without this, the next line should have a type error because value could 
+      // Without this, the next line should have a type error because value could
       // be undefined
       assertIsDefined(value);
 
       expect(value + 1).toBe(2);
     });
 
-    it("handles non-null values", () => {      
-      // `as any` is used here to verify that assertIsDefined is working 
-      // with Typescript correctly. Without `as any` typescript ignores 
+    it("handles non-null values", () => {
+      // `as any` is used here to verify that assertIsDefined is working
+      // with Typescript correctly. Without `as any` typescript ignores
       // the `number | undefined` and just uses `number`. So then `value + 1`
-      // is fine even without the `assertIsDefined`.      
+      // is fine even without the `assertIsDefined`.
       const value: number | null = 1 as any;
 
-      // Without this, the next line should have a type error because value could 
+      // Without this, the next line should have a type error because value could
       // be null
       assertIsDefined(value);
 

--- a/src/test/setupTests.test.ts
+++ b/src/test/setupTests.test.ts
@@ -1,4 +1,4 @@
-export {};
+export {};  // isolatedModules compatibility
 
 describe("setupTests", () => {
   describe("assertIsDefined", () => {

--- a/src/utilities/dom-utils.ts
+++ b/src/utilities/dom-utils.ts
@@ -1,4 +1,4 @@
-export {};
+export {};  // isolatedModules compatibility
 
 // cf. https://developer.mozilla.org/en-US/docs/Web/API/Element/matches#Polyfill
 if (!Element.prototype.matches) {

--- a/src/utilities/dom-utils.ts
+++ b/src/utilities/dom-utils.ts
@@ -1,3 +1,5 @@
+export {};
+
 // cf. https://developer.mozilla.org/en-US/docs/Web/API/Element/matches#Polyfill
 if (!Element.prototype.matches) {
   Element.prototype.matches = (Element.prototype as any).msMatchesSelector ||

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "module": "ESNext",
     "esModuleInterop": true,
+    "isolatedModules": true,
     "importHelpers": true,
     "moduleResolution": "node",
     "allowJs": true,


### PR DESCRIPTION
- Enabling `isolatedModules` in the jest configuration should speed up the jest tests
- Enabling `isolatedModules` in the `tsconfig.json` just issues an error if there's any code that wouldn't work with `isolatedModules`