### PR TITLE
refactor: add `type` argument to handleAfterSharedModelChange() callback

### DIFF
--- a/src/models/document/shared-model-document-manager.ts
+++ b/src/models/document/shared-model-document-manager.ts
@@ -110,7 +110,7 @@ export class SharedModelDocumentManager implements ISharedModelDocumentManager {
     // the tile content model automatically by the tree monitor. However when
     // the list of shared models is changed like here addTileSharedModel, the
     // tree monitor doesn't pick that up, so we must call it directly.
-    tileContentModel.updateAfterSharedModelChanges(sharedModel);
+    tileContentModel.updateAfterSharedModelChanges(sharedModel, "link");
   }
 
   // This is not an action because it is deriving state.
@@ -182,6 +182,7 @@ export class SharedModelDocumentManager implements ISharedModelDocumentManager {
       return;
     }
 
+    tileContentModel.updateAfterSharedModelChanges(sharedModel, "unlink");
     sharedModelEntry.removeTile(tile);
   }
 }

--- a/src/models/history/tree.ts
+++ b/src/models/history/tree.ts
@@ -53,7 +53,7 @@ export const Tree = types.model("Tree", {
 
     // Run update function on the tiles
     for(const tile of tiles) {
-      tile.content.updateAfterSharedModelChanges(sharedModel);
+      tile.content.updateAfterSharedModelChanges(sharedModel, "change");
     }
   }
 }))

--- a/src/models/shared/shared-model-manager.ts
+++ b/src/models/shared/shared-model-manager.ts
@@ -44,6 +44,8 @@ export const UnknownSharedModel = types.snapshotProcessor(_UnknownSharedModel, {
   }
 });
 
+export type SharedModelChangeType = "link" | "change" | "unlink"
+
 export interface IDragSharedModelItem {
   modelId: string;
   providerId?: string;

--- a/src/models/tiles/text/text-content.test.ts
+++ b/src/models/tiles/text/text-content.test.ts
@@ -78,7 +78,7 @@ describe("TextContentModel", () => {
 
   it("calls updateTextContentAfterSharedModelChanges on each plugin that provides it", () => {
     const model = TextContentModel.create({ text: "foo" });
-    model.updateAfterSharedModelChanges();
+    model.updateAfterSharedModelChanges(undefined, "change");
     expect(testTextPluginInfoWithUpdate.updateTextContentAfterSharedModelChanges).toBeCalled();
   });
 });

--- a/src/models/tiles/text/text-content.ts
+++ b/src/models/tiles/text/text-content.ts
@@ -5,6 +5,7 @@ import {
 import { ITileExportOptions } from "../tile-content-info";
 import { TileContentModel } from "../tile-content";
 import { SharedModelType } from "../../shared/shared-model";
+import { SharedModelChangeType } from "../../shared/shared-model-manager";
 import { getAllTextPluginInfos } from "./text-plugin-info";
 import { escapeBackslashes, escapeDoubleQuotes, removeNewlines, removeTabs } from "../../../utilities/string-utils";
 
@@ -126,7 +127,7 @@ export const TextContentModel = TileContentModel
     }
   }))
   .actions(self => ({
-    updateAfterSharedModelChanges(sharedModel?: SharedModelType) {
+    updateAfterSharedModelChanges(sharedModel: SharedModelType | undefined, type: SharedModelChangeType) {
       getAllTextPluginInfos().forEach(pluginInfo => {
         pluginInfo?.updateTextContentAfterSharedModelChanges?.(self, sharedModel);
       });

--- a/src/models/tiles/tile-content.ts
+++ b/src/models/tiles/tile-content.ts
@@ -1,6 +1,6 @@
 import { getEnv, getSnapshot, Instance, types } from "mobx-state-tree";
 import { SharedModelType } from "../shared/shared-model";
-import { ISharedModelManager } from "../shared/shared-model-manager";
+import { ISharedModelManager, SharedModelChangeType } from "../shared/shared-model-manager";
 import { tileModelHooks } from "./tile-model-hooks";
 import { kUnknownTileType } from "./unknown-types";
 
@@ -60,8 +60,8 @@ export const TileContentModel = types.model("TileContentModel", {
      *
      * @param sharedModel
      */
-    updateAfterSharedModelChanges(sharedModel?: SharedModelType) {
-      throw new Error("not implemented");
+    updateAfterSharedModelChanges(sharedModel: SharedModelType | undefined, type: SharedModelChangeType) {
+      console.warn("updateAfterSharedModelChanges not implemented for:", self.type);
     }
   }))
   // Add an empty api so the api methods can be used on this generic type

--- a/src/plugins/diagram-viewer/diagram-content.test.ts
+++ b/src/plugins/diagram-viewer/diagram-content.test.ts
@@ -52,7 +52,7 @@ const setupContainer = (content: DiagramContentModelType, variables?: SharedVari
   // Need to monitor the variables just like sharedModelDocumentManager does
   if (variables) {
     onSnapshot(variables, () => {
-      content.updateAfterSharedModelChanges(variables);
+      content.updateAfterSharedModelChanges(variables, "change");
     });
   }
 


### PR DESCRIPTION
Some tiles may need to respond specially to linking to or unlinking from a shared model. This PR adds a second argument to the `updateAfterSharedModelChanges()` callback indicating the type of change that is occurring.

Note: I was sorely tempted to rename the `updateAfterSharedModelChanges()` function to something more conventional like `handleSharedModelChange()` but decided to refrain from the function rename in the interest of keeping this PR simpler. I'd still be in favor of a rename, but perhaps that should be left for a subsequent PR. One additional reason for the change is that in the case of `unlink`, the call happens _before_ the unlink, so that the tile has a chance to make use of the shared model before the unlink occurs. I also considered having three separate callbacks, `handleLinkToSharedModel()`, `handleSharedModelChange()`, and `handleUnlinkFromSharedModel()`, but some clients (e.g. the geometry tile) probably just want to perform the same invalidation step in all cases, so a single function is simpler for those clients.

@emcelroy This is the mechanism I think would be appropriate for the graph to auto-assign attributes at the time of linking to the shared model.