### PR TITLE
Expression Tile Editing, Save, Title

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -79,7 +79,7 @@ module.exports = {
     },
     overrides: [
       { // test files
-        files: ["*.test.*", "jest-resolver.js"],
+        files: ["*.test.*", "jest-resolver.js", "setupTests.ts"],
         env: {
           node: true,
           jest: true

--- a/cypress/e2e/clue/branch/student_tests/expression_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/expression_tool_spec.js
@@ -1,0 +1,35 @@
+import ClueCanvas from '../../../../support/elements/clue/cCanvas';
+import ExpressionToolTile from '../../../../support/elements/clue/ExpressionToolTile';
+
+let clueCanvas = new ClueCanvas;
+let exp = new ExpressionToolTile;
+
+context('Expression Tool Tile', function () {
+  before(function () {
+    const queryParams = "?appMode=qa&fakeClass=5&fakeUser=student:5&qaGroup=5&unit=example";
+    cy.clearQAData('all');
+    cy.visit(queryParams);
+    cy.waitForLoad();
+    //TODO - implement within a curriculum unit
+    //cy.closeResourceTabs();
+  });
+  describe("Expression Tool", () => {
+    it("renders expression tool tile", () => {
+      clueCanvas.addTile("expression");
+      exp.getExpressionTile().should("exist");
+    });
+    it("should have the correct default title", () => {
+      exp.getTileTitle().should("exist");
+      exp.getTileTitle().should("contain", "(Eq. 1)");
+    });
+    it("should contain a default value as latex string", () => {
+      exp.getMathArea().should("exist");
+      exp.getMathField().should("have.value", "a=\\pi r^2");
+      exp.getMathFieldLatex().should("eq", "a=\\pi r^2");
+    });
+    it("should render latex string as math characters", () => {
+      exp.getMathFieldMath().should("exist");
+      exp.getMathFieldMath().should("contain", "π");
+    });
+  });
+});

--- a/cypress/e2e/clue/branch/student_tests/expression_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/expression_tool_spec.js
@@ -31,5 +31,19 @@ context('Expression Tool Tile', function () {
       exp.getMathFieldMath().should("exist");
       exp.getMathFieldMath().should("contain", "π");
     });
+    it("should have an editable title", () => {
+      exp.getTileTitle().click();
+      exp.getTitleInput().should("exist");
+      exp.getTitleInput().should("have.value", "Eq. 1");
+      exp.getTitleInput().dblclick();
+      exp.getTitleInput().type("new title{enter}");
+      exp.getTileTitle().should("contain", "(new title)");
+    });
+    it("should name new expressions with an incrementing id", () => {
+      clueCanvas.addTile("expression");
+      cy.contains("(Eq. 1)").should("exist");
+      clueCanvas.addTile("expression");
+      cy.contains("(Eq. 2)").should("exist");
+    });
   });
 });

--- a/cypress/fixtures/teacher-dash-data-CLUE-test.json
+++ b/cypress/fixtures/teacher-dash-data-CLUE-test.json
@@ -5,7 +5,7 @@
         {
             "classIndex": 0,
             "className": "Class Menu",
-            "problemTotal": 14,
+            "problemTotal": 15,
             "problems": [
                 {
                     "problem": 2.1,

--- a/cypress/fixtures/teacher-dash-data-msa-test.json
+++ b/cypress/fixtures/teacher-dash-data-msa-test.json
@@ -5,7 +5,7 @@
         {
             "classIndex": 0,
             "className": "Class Menu",
-            "problemTotal": 14,
+            "problemTotal": 15,
             "problems": [
                 {
                     "problem": 2.1,

--- a/cypress/fixtures/teacher-dash-data.json
+++ b/cypress/fixtures/teacher-dash-data.json
@@ -5,7 +5,7 @@
         {
             "classIndex": 0,
             "className": "CLUE",
-            "problemTotal": 14,
+            "problemTotal": 15,
             "problems": [
                 {
                     "problem": 1.1,

--- a/cypress/support/elements/clue/ExpressionToolTile.js
+++ b/cypress/support/elements/clue/ExpressionToolTile.js
@@ -1,0 +1,34 @@
+const workspaceClass = Cypress.env("workspaceClass");
+
+let tileSelector;
+if (workspaceClass !== undefined){
+  tileSelector = `${workspaceClass} .canvas-area .expression-tool-tile`;
+} else {
+  tileSelector = ".primary-workspace .canvas-area .expression-tool-tile";
+}
+
+class ExpressionToolTile {
+  getExpressionTile = () => {
+    return cy.get(tileSelector);
+  };
+  getTileTitle = () => {
+    return cy.get(`${tileSelector} .editable-title-text`);
+  };
+  getMathArea = () => {
+    return cy.get(`${tileSelector} .expression-math-area`);
+  };
+  getMathField = () => {
+    const mathFieldSelector = `${tileSelector} .expression-math-area math-field`;
+    return cy.get(mathFieldSelector);
+  };
+  getMathFieldLatex = () => {
+    const mathFieldSelector = `${tileSelector} .expression-math-area math-field`;
+    return cy.get(mathFieldSelector).attribute("value");
+  };
+  getMathFieldMath = () => {
+    const mathFieldSelector = `${tileSelector} .expression-math-area math-field`;
+    return cy.get(mathFieldSelector).shadow().find("span");
+  };
+}
+
+export default ExpressionToolTile;

--- a/cypress/support/elements/clue/ExpressionToolTile.js
+++ b/cypress/support/elements/clue/ExpressionToolTile.js
@@ -14,6 +14,9 @@ class ExpressionToolTile {
   getTileTitle = () => {
     return cy.get(`${tileSelector} .editable-title-text`);
   };
+  getTitleInput = () => {
+    return cy.get(`${tileSelector} .title-input-editing`);
+  };
   getMathArea = () => {
     return cy.get(`${tileSelector} .expression-math-area`);
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "jsxgraph": "1.4.4",
         "jwt-decode": "^3.1.2",
         "lodash": "^4.17.21",
+        "mathlive": "^0.92.1",
         "mobx": "^6.6.1",
         "mobx-react": "^7.5.2",
         "nanoid": "^3.3.4",
@@ -14497,6 +14498,19 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/mathlive": {
+      "version": "0.92.1",
+      "resolved": "https://registry.npmjs.org/mathlive/-/mathlive-0.92.1.tgz",
+      "integrity": "sha512-i5aSk+Bt1o0JQ1fhVYfaiXBTlikP6KoDRagAuBg285891Y4J3I2LC+kvbRlrutIIfOkyQLdFu36WYbfBSsHV4A==",
+      "engines": {
+        "node": ">=16.14.2",
+        "npm": ">=8.5.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paypal.me/arnogourdol"
       }
     },
     "node_modules/mdn-data": {
@@ -28996,6 +29010,11 @@
         "tiny-emitter": "^2.1.0",
         "typed-function": "^2.1.0"
       }
+    },
+    "mathlive": {
+      "version": "0.92.1",
+      "resolved": "https://registry.npmjs.org/mathlive/-/mathlive-0.92.1.tgz",
+      "integrity": "sha512-i5aSk+Bt1o0JQ1fhVYfaiXBTlikP6KoDRagAuBg285891Y4J3I2LC+kvbRlrutIIfOkyQLdFu36WYbfBSsHV4A=="
     },
     "mdn-data": {
       "version": "2.0.14",

--- a/package.json
+++ b/package.json
@@ -210,6 +210,7 @@
     "jsxgraph": "1.4.4",
     "jwt-decode": "^3.1.2",
     "lodash": "^4.17.21",
+    "mathlive": "^0.92.1",
     "mobx": "^6.6.1",
     "mobx-react": "^7.5.2",
     "nanoid": "^3.3.4",

--- a/src/components/tiles/custom-editable-tile-title.tsx
+++ b/src/components/tiles/custom-editable-tile-title.tsx
@@ -15,7 +15,6 @@ interface IProps {
 export const CustomEditableTileTitle: React.FC<IProps> = observer((props) => {
   const { model, onRequestUniqueTitle, readOnly } = props;
   const content = model.content as SimpleTitleTileTypes;
-
   const [titleValue, setTitleValue] = useState(content.title);
   const [isEditingTitle, setIsEditingTitle] = useState(false);
 
@@ -73,6 +72,9 @@ export const CustomEditableTileTitle: React.FC<IProps> = observer((props) => {
     "title-text-element", {editing: isEditingTitle}
   );
 
+  const titleString = content.type === "Expression"
+    ? `(${content.title})` : content.title;
+
   return (
     <div className={elementClasses}>
       { isEditingTitle && !readOnly
@@ -86,7 +88,7 @@ export const CustomEditableTileTitle: React.FC<IProps> = observer((props) => {
           onDoubleClick={handleTitleInputDoubleClick}
       />
       : <div className="editable-title-text" onClick={handleTitleClick}>
-          { content.title }
+          { titleString }
         </div>
       }
     </div>

--- a/src/components/tiles/custom-editable-tile-title.tsx
+++ b/src/components/tiles/custom-editable-tile-title.tsx
@@ -1,7 +1,8 @@
+import classNames from "classnames";
 import { observer } from "mobx-react";
 import React, { useEffect, useState } from "react";
-import { ExpressionContentModelType } from "../../plugins/expression/expression-content"
-import { DataCardContentModelType } from "../../plugins/data-card/data-card-content"
+import { ExpressionContentModelType } from "../../plugins/expression/expression-content";
+import { DataCardContentModelType } from "../../plugins/data-card/data-card-content";
 
 type SimpleTitleTileTypes = DataCardContentModelType | ExpressionContentModelType;
 
@@ -11,7 +12,7 @@ interface IProps {
   readOnly: boolean | undefined;
 }
 
-export const EditableTileTitleText: React.FC<IProps> = observer((props) => {
+export const CustomEditableTileTitle: React.FC<IProps> = observer((props) => {
   const { model, onRequestUniqueTitle, readOnly } = props;
   const content = model.content as SimpleTitleTileTypes;
 
@@ -68,8 +69,12 @@ export const EditableTileTitleText: React.FC<IProps> = observer((props) => {
     setIsEditingTitle(false);
   };
 
+  const elementClasses = classNames(
+    "title-text-element", {editing: isEditingTitle}
+  );
+
   return (
-    <div className="title-text-element">
+    <div className={elementClasses}>
       { isEditingTitle && !readOnly
       ? <input
           className="title-input-editing"
@@ -87,4 +92,4 @@ export const EditableTileTitleText: React.FC<IProps> = observer((props) => {
     </div>
   );
 });
-EditableTileTitleText.displayName = "EditableTileTitleText";
+CustomEditableTileTitle.displayName = "CustomEditableTileTitle";

--- a/src/components/tiles/custom-editable-tile-title.tsx
+++ b/src/components/tiles/custom-editable-tile-title.tsx
@@ -1,0 +1,90 @@
+import { observer } from "mobx-react";
+import React, { useEffect, useState } from "react";
+import { ExpressionContentModelType } from "../../plugins/expression/expression-content"
+import { DataCardContentModelType } from "../../plugins/data-card/data-card-content"
+
+type SimpleTitleTileTypes = DataCardContentModelType | ExpressionContentModelType;
+
+interface IProps {
+  model: any;
+  onRequestUniqueTitle: any;
+  readOnly: boolean | undefined;
+}
+
+export const EditableTileTitleText: React.FC<IProps> = observer((props) => {
+  const { model, onRequestUniqueTitle, readOnly } = props;
+  const content = model.content as SimpleTitleTileTypes;
+
+  const [titleValue, setTitleValue] = useState(content.title);
+  const [isEditingTitle, setIsEditingTitle] = useState(false);
+
+  useEffect(() => {
+    if (!content.title) {
+      const title = onRequestUniqueTitle(model.id);
+      title && content.setTitle(title);
+    }
+  }, [content, model.id, onRequestUniqueTitle]);
+
+  const handleTitleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setTitleValue(event.target.value);
+  };
+
+  const handleTitleClick = () => {
+    if (!readOnly){
+      setIsEditingTitle(true);
+    }
+  };
+
+  const handleTitleInputClick = (event: React.MouseEvent<HTMLInputElement>) => {
+    event.currentTarget.focus();
+    const isHighlighted = event.currentTarget.selectionStart === 0;
+    const valLength = event.currentTarget.value.length;
+    if (isHighlighted && valLength > 0){
+        event.currentTarget.setSelectionRange(valLength, valLength, "forward");
+    }
+  };
+
+  const handleTitleInputDoubleClick = (event: React.MouseEvent<HTMLInputElement>) => {
+    event.currentTarget.select();
+  };
+
+  const handleTitleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    switch (event.key) {
+      case "Enter":
+        handleCompleteTitle();
+        setIsEditingTitle(false);
+        break;
+      case "Escape":
+        setTitleValue(content.title);
+        setIsEditingTitle(false);
+        break;
+    }
+  };
+
+  const handleCompleteTitle = () => {
+    if (titleValue){
+      content.setTitle(titleValue);
+    }
+    setIsEditingTitle(false);
+  };
+
+  return (
+    <div className="title-text-element">
+      { isEditingTitle && !readOnly
+      ? <input
+          className="title-input-editing"
+          value={titleValue}
+          onChange={handleTitleChange}
+          onKeyDown={handleTitleKeyDown}
+          onBlur={handleCompleteTitle}
+          onClick={handleTitleInputClick}
+          onDoubleClick={handleTitleInputDoubleClick}
+      />
+      : <div className="editable-title-text" onClick={handleTitleClick}>
+          { content.title }
+        </div>
+      }
+    </div>
+  );
+});
+EditableTileTitleText.displayName = "EditableTileTitleText";

--- a/src/plugins/data-card/data-card-tile.scss
+++ b/src/plugins/data-card/data-card-tile.scss
@@ -50,15 +50,23 @@ $default-button-border-color: #979797;
     font-style: italic;
     border-bottom-width: 0px;
 
-    .data-card-title-input-editing {
-      width: 100%;
+    .title-text-element {
+      .title-input-editing {
+        width: 100%;
+        height: 100%;
+        font-style: normal;
+        font-weight: 300;
+        text-align: center;
+        outline:1px solid $highlight-blue;
+      }
+    }
+    .title-text-element.editing {
+      width:100%;
       height: 100%;
-      font-style: normal;
-      font-weight: 300;
-      text-align: center;
-      outline:1px solid $highlight-blue;
     }
   }
+
+
 
   .panel.sort {
     background-color: $workspace-teal-light-6;

--- a/src/plugins/data-card/data-card-tile.tsx
+++ b/src/plugins/data-card/data-card-tile.tsx
@@ -15,6 +15,7 @@ import { EditFacet } from "./data-card-types";
 import { DataCardSortArea } from "./components/sort-area";
 
 import "./data-card-tile.scss";
+import { CustomEditableTileTitle } from "../../components/tiles/custom-editable-tile-title";
 
 export const DataCardToolComponent: React.FC<ITileProps> = observer((props) => {
   const { model, onRequestUniqueTitle, readOnly, documentContent, tileElt, onRegisterTileApi,
@@ -22,8 +23,6 @@ export const DataCardToolComponent: React.FC<ITileProps> = observer((props) => {
   const content = model.content as DataCardContentModelType;
   const ui = useUIStore();
   const isTileSelected = ui.selectedTileIds.findIndex(id => id === content.metadata.id) >= 0;
-  const [titleValue, setTitleValue] = useState(content.title);
-  const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [currEditAttrId, setCurrEditAttrId] = useState<string>("");
   const [currEditFacet, setCurrEditFacet] = useState<EditFacet>("");
   const [imageUrlToAdd, setImageUrlToAdd] = useState<string>("");
@@ -51,49 +50,6 @@ export const DataCardToolComponent: React.FC<ITileProps> = observer((props) => {
       content.setCaseIndex(content.caseIndex - 1);
     }
   }
-
-  const handleTitleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setTitleValue(event.target.value);
-  };
-
-  const handleTitleClick = () => {
-    if (!readOnly){
-      setIsEditingTitle(true);
-    }
-  };
-
-  const handleTitleInputClick = (event: React.MouseEvent<HTMLInputElement>) => {
-    event.currentTarget.focus();
-    const isHighlighted = event.currentTarget.selectionStart === 0;
-    const valLength = event.currentTarget.value.length;
-    if (isHighlighted && valLength > 0){
-        event.currentTarget.setSelectionRange(valLength, valLength, "forward");
-    }
-  };
-
-  const handleTitleInputDoubleClick = (event: React.MouseEvent<HTMLInputElement>) => {
-    event.currentTarget.select();
-  };
-
-  const handleTitleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    switch (event.key) {
-      case "Enter":
-        handleCompleteTitle();
-        setIsEditingTitle(false);
-        break;
-      case "Escape":
-        setTitleValue(content.title);
-        setIsEditingTitle(false);
-        break;
-    }
-  };
-
-  const handleCompleteTitle = () => {
-    if (titleValue){
-      content.setTitle(titleValue);
-    }
-    setIsEditingTitle(false);
-  };
 
   function setSort(event: React.ChangeEvent<HTMLSelectElement>){
     content.setSelectedSortAttributeId(event.target.value);
@@ -204,20 +160,11 @@ export const DataCardToolComponent: React.FC<ITileProps> = observer((props) => {
       <div className="data-card-content" onClick={handleBackgroundClick}>
         <div className="data-card-header-row">
           <div className="panel title">
-            { isEditingTitle && !readOnly
-            ? <input
-                className="data-card-title-input-editing"
-                value={titleValue}
-                onChange={handleTitleChange}
-                onKeyDown={handleTitleKeyDown}
-                onBlur={handleCompleteTitle}
-                onClick={handleTitleInputClick}
-                onDoubleClick={handleTitleInputDoubleClick}
+            <CustomEditableTileTitle
+              model={props.model}
+              onRequestUniqueTitle={props.onRequestUniqueTitle}
+              readOnly={props.readOnly}
             />
-            : <div className="editable-data-card-title-text" onClick={handleTitleClick}>
-                { content.title }
-              </div>
-            }
           </div>
         </div>
 

--- a/src/plugins/expression/expression-content.test.ts
+++ b/src/plugins/expression/expression-content.test.ts
@@ -1,15 +1,15 @@
 import { defaultExpressionContent, ExpressionContentModel } from "./expression-content";
 
 describe("ExpressionContent", () => {
-  it("has default content of 'hello world'", () => {
+  it("has default content of area of a circle formula", () => {
     const content = defaultExpressionContent();
-    expect(content.text).toBe("Math Expression");
+    expect(content.latexStr).toBe("a=\\pi r^2");
   });
 
   it("supports changing the text", () => {
     const content = ExpressionContentModel.create();
-    content.setText("New Text");
-    expect(content.text).toBe("New Text");
+    content.setLatexStr("abc");
+    expect(content.latexStr).toBe("abc");
   });
 
   it("is always user resizable", () => {

--- a/src/plugins/expression/expression-content.ts
+++ b/src/plugins/expression/expression-content.ts
@@ -2,10 +2,10 @@ import { types, Instance } from "mobx-state-tree";
 import { TileContentModel } from "../../models/tiles/tile-content";
 import { kExpressionTileType } from "./expression-types";
 import { getTileModel, setTileTitleFromContent } from "../../models/tiles/tile-model";
-import { IDefaultContentOptions } from "../../models/tiles/tile-content-info";
+import { IDefaultContentOptions, ITileExportOptions } from "../../models/tiles/tile-content-info";
 
 export function defaultExpressionContent(props?: IDefaultContentOptions): ExpressionContentModelType {
-  const content = ExpressionContentModel.create({text: "Math Expression"});
+  const content = ExpressionContentModel.create({latexStr: `a=\\pi r^2`});
   props?.title && content.setTitle(props.title);
   return content;
 }
@@ -14,7 +14,7 @@ export const ExpressionContentModel = TileContentModel
   .named("ExpressionTool")
   .props({
     type: types.optional(types.literal(kExpressionTileType), kExpressionTileType),
-    text: "",
+    latexStr: "",
   })
   .views(self => ({
     get title(): string | undefined {
@@ -22,14 +22,21 @@ export const ExpressionContentModel = TileContentModel
     },
     get isUserResizable() {
       return true;
+    },
+    exportJson(options?: ITileExportOptions){
+      return [
+        `{`,
+        `  "type": "Expression Tile"`,
+        `}`
+      ].join("\n");
     }
   }))
   .actions(self => ({
     setTitle(title: string) {
       setTileTitleFromContent(self, title);
     },
-    setText(text: string) {
-      self.text = text;
+    setLatexStr(text: string) {
+      self.latexStr = text;
     }
   }));
 

--- a/src/plugins/expression/expression-registration.ts
+++ b/src/plugins/expression/expression-registration.ts
@@ -5,6 +5,7 @@ import ExpressionToolIcon from "./expression-icon.svg";
 import { ExpressionToolComponent } from "./expression-tile";
 import { defaultExpressionContent, ExpressionContentModel } from "./expression-content";
 
+
 registerTileContentInfo({
   type: kExpressionTileType,
   modelClass: ExpressionContentModel,

--- a/src/plugins/expression/expression-registration.ts
+++ b/src/plugins/expression/expression-registration.ts
@@ -8,7 +8,7 @@ import { defaultExpressionContent, ExpressionContentModel } from "./expression-c
 registerTileContentInfo({
   type: kExpressionTileType,
   modelClass: ExpressionContentModel,
-  titleBase: "Expression",
+  titleBase: "Eq.",
   defaultContent: defaultExpressionContent,
   defaultHeight: kExpressionDefaultHeight
 });

--- a/src/plugins/expression/expression-tile.disable-test.tsx
+++ b/src/plugins/expression/expression-tile.disable-test.tsx
@@ -5,20 +5,15 @@ import { ITileApi } from "../../components/tiles/tile-api";
 import { TileModel } from "../../models/tiles/tile-model";
 import { defaultExpressionContent } from "./expression-content";
 import { ExpressionToolComponent } from "./expression-tile";
-
-import("mathlive")
-import * as mathlive from 'mathlive'
-
-// The expression tile needs to be registered so the TileModel.create
-// knows it is a supported tile type
 import "./expression-registration";
+import("mathlive");
 
-jest.mock('mathlive', () => {
-  return {
-    _esmodule: true,
-    mathlive: jest.fn()
-  }
-})
+// jest.mock("mathlive", () => {
+//   const mathlive = jest.requireActual("mathlive");
+//   return {
+//     mathlive: jest.fn(),
+//   };
+// });
 
 describe("ExpressionToolComponent", () => {
   const content = defaultExpressionContent();

--- a/src/plugins/expression/expression-tile.scss
+++ b/src/plugins/expression/expression-tile.scss
@@ -1,17 +1,31 @@
 @import "../../components/vars.sass";
 
+$expression-padding: 15px;
+$expression-title-width: 200px;
+
 .expression-tool {
   width: 100%;
   height: 100%;
   text-align: left;
   overflow: auto;
+  display:flex;
+  align-items: center;
+  border:1px solid silver;
 
-  &.editable {
-    border: 1px solid #cccccc;
+  .expression-title-area {
+    width:$expression-title-width;
+    justify-self: left;
+    padding:$expression-padding;
+    font-weight: bold;
+
+    div, input {
+      width:$expression-title-width - $expression-padding * 2;
+    }
   }
 
-  textarea {
-    width: 100%;
-    height: 100%;
+  .expression-math-area math-field {
+    font-size:20px;
+    border-width: 0px;
+    padding:$expression-padding;
   }
 }

--- a/src/plugins/expression/expression-tile.scss
+++ b/src/plugins/expression/expression-tile.scss
@@ -1,4 +1,5 @@
 @import "../../components/vars.sass";
+@import "../../../../collaborative-learning/node_modules/mathlive/dist/mathlive-fonts.css";
 
 $expression-padding: 15px;
 $expression-title-width: 200px;

--- a/src/plugins/expression/expression-tile.test.tsx
+++ b/src/plugins/expression/expression-tile.test.tsx
@@ -38,6 +38,17 @@ describe("ExpressionToolComponent", () => {
     }
   };
 
+  beforeEach(() => {
+    jest.spyOn(console, 'error')
+    // @ts-ignore jest.spyOn adds this functionallity
+    console.error.mockImplementation(() => null);
+  });
+
+  afterEach(() => {
+    // @ts-ignore jest.spyOn adds this functionallity
+    console.error.mockRestore()
+  })
+
   it("renders a math field web component", () => {
     render(<ExpressionToolComponent  {...defaultProps} {...{model}}></ExpressionToolComponent>);
     expect(document.querySelector("math-field")).toBeInTheDocument();
@@ -51,16 +62,18 @@ describe("ExpressionToolComponent", () => {
 
   it("the math field renders content in a shadow dom", () => {
     render(<ExpressionToolComponent  {...defaultProps} {...{model}}></ExpressionToolComponent>);
-    const shadowElement = document.querySelector("math-field")?.shadowRoot;
-    expect(shadowElement).toBeTruthy();
-    expect(shadowElement?.querySelector("span")).toBeInTheDocument();
+    const shadow = document.querySelector("math-field")?.shadowRoot;
+    const parentSpan = shadow?.querySelector("span");
+    expect(parentSpan).toBeInTheDocument();
   });
 
-  // it("renders the pi character in the math field", () => {
-  //   const { getByText, container, queryByText } = render(<ExpressionToolComponent  {...defaultProps} {...{model}}></ExpressionToolComponent>);
-  //   const mathShadow = document.querySelector("math-field")?.shadowRoot;
-  //   const mathEl = container.querySelector("math-field");
-  //   const mathSpan = mathEl?.shadowRoot?.querySelector("span.ML__content");
-  //   expect(mathSpan).toBeInTheDocument();
-  // });
+  it("renders the pi character in the math field", () => {
+    const { getByText, container, queryByText } = render(
+      <ExpressionToolComponent  {...defaultProps} {...{model}}></ExpressionToolComponent>
+    );
+    const mathField = container.querySelector("math-field");
+    const shadow = mathField?.shadowRoot;
+    const something = shadow?.children[1].childNodes.length;
+    console.log("something", something);
+  });
 });

--- a/src/plugins/expression/expression-tile.test.tsx
+++ b/src/plugins/expression/expression-tile.test.tsx
@@ -6,9 +6,19 @@ import { TileModel } from "../../models/tiles/tile-model";
 import { defaultExpressionContent } from "./expression-content";
 import { ExpressionToolComponent } from "./expression-tile";
 
+import("mathlive")
+import * as mathlive from 'mathlive'
+
 // The expression tile needs to be registered so the TileModel.create
 // knows it is a supported tile type
 import "./expression-registration";
+
+jest.mock('mathlive', () => {
+  return {
+    _esmodule: true,
+    mathlive: jest.fn()
+  }
+})
 
 describe("ExpressionToolComponent", () => {
   const content = defaultExpressionContent();

--- a/src/plugins/expression/expression-tile.test.tsx
+++ b/src/plugins/expression/expression-tile.test.tsx
@@ -54,7 +54,7 @@ describe("ExpressionToolComponent", () => {
       render(<ExpressionToolComponent  {...defaultProps} {...{model}}></ExpressionToolComponent>);
     expect(getByText("Math Expression")).toBeInTheDocument();
 
-    content.setText("New Text");
+    content.setLatexStr("New Text");
 
     expect(await findByText("New Text")).toBeInTheDocument();
   });
@@ -68,6 +68,6 @@ describe("ExpressionToolComponent", () => {
     userEvent.type(textBox, "{selectall}{del}Typed Text");
 
     expect(textBox).toHaveValue("Typed Text");
-    expect(content.text).toBe("Typed Text");
+    expect(content.latexStr).toBe("Typed Text");
   });
 });

--- a/src/plugins/expression/expression-tile.test.tsx
+++ b/src/plugins/expression/expression-tile.test.tsx
@@ -1,24 +1,14 @@
-import { render } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import React from "react";
+import { queryByText, render, screen } from "@testing-library/react";
 import { ITileApi } from "../../components/tiles/tile-api";
 import { TileModel } from "../../models/tiles/tile-model";
 import { defaultExpressionContent } from "./expression-content";
 import { ExpressionToolComponent } from "./expression-tile";
 import "./expression-registration";
-import("mathlive");
-
-// jest.mock("mathlive", () => {
-//   const mathlive = jest.requireActual("mathlive");
-//   return {
-//     mathlive: jest.fn(),
-//   };
-// });
 
 describe("ExpressionToolComponent", () => {
   const content = defaultExpressionContent();
   const model = TileModel.create({content});
-
   const defaultProps = {
     tileElt: null,
     context: "",
@@ -35,7 +25,7 @@ describe("ExpressionToolComponent", () => {
       throw new Error("Function not implemented.");
     },
     onRequestUniqueTitle: (tileId: string): string | undefined => {
-      throw new Error("Function not implemented.");
+      return tileId;
     },
     onRequestRowHeight: (tileId: string, height?: number, deltaHeight?: number): void => {
       throw new Error("Function not implemented.");
@@ -48,31 +38,29 @@ describe("ExpressionToolComponent", () => {
     }
   };
 
-  it("renders successfully", () => {
-    const {getByText} =
-      render(<ExpressionToolComponent  {...defaultProps} {...{model}}></ExpressionToolComponent>);
-    expect(getByText("Math Expression")).toBeInTheDocument();
+  it("renders a math field web component", () => {
+    render(<ExpressionToolComponent  {...defaultProps} {...{model}}></ExpressionToolComponent>);
+    expect(document.querySelector("math-field")).toBeInTheDocument();
+    expect(screen.getByRole("math")).toBeInTheDocument();
   });
 
-  it("updates the text when the model changes", async () => {
-    const {getByText, findByText} =
-      render(<ExpressionToolComponent  {...defaultProps} {...{model}}></ExpressionToolComponent>);
-    expect(getByText("Math Expression")).toBeInTheDocument();
-
-    content.setLatexStr("New Text");
-
-    expect(await findByText("New Text")).toBeInTheDocument();
+  it("renders with a LaTeX string in the math-field value", () => {
+    render(<ExpressionToolComponent  {...defaultProps} {...{model}}></ExpressionToolComponent>);
+    expect(document.querySelector("math-field")).toHaveAttribute("value", "a=\\pi r^2");
   });
 
-  it("updates the model when the user types", () => {
-    const {getByRole, getByText} =
-      render(<ExpressionToolComponent  {...defaultProps} {...{model}}></ExpressionToolComponent>);
-    expect(getByText("New Text")).toBeInTheDocument();
-
-    const textBox = getByRole("textbox");
-    userEvent.type(textBox, "{selectall}{del}Typed Text");
-
-    expect(textBox).toHaveValue("Typed Text");
-    expect(content.latexStr).toBe("Typed Text");
+  it("the math field renders content in a shadow dom", () => {
+    render(<ExpressionToolComponent  {...defaultProps} {...{model}}></ExpressionToolComponent>);
+    const shadowElement = document.querySelector("math-field")?.shadowRoot;
+    expect(shadowElement).toBeTruthy();
+    expect(shadowElement?.querySelector("span")).toBeInTheDocument();
   });
+
+  // it("renders the pi character in the math field", () => {
+  //   const { getByText, container, queryByText } = render(<ExpressionToolComponent  {...defaultProps} {...{model}}></ExpressionToolComponent>);
+  //   const mathShadow = document.querySelector("math-field")?.shadowRoot;
+  //   const mathEl = container.querySelector("math-field");
+  //   const mathSpan = mathEl?.shadowRoot?.querySelector("span.ML__content");
+  //   expect(mathSpan).toBeInTheDocument();
+  // });
 });

--- a/src/plugins/expression/expression-tile.test.tsx
+++ b/src/plugins/expression/expression-tile.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { queryByText, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { ITileApi } from "../../components/tiles/tile-api";
 import { TileModel } from "../../models/tiles/tile-model";
 import { defaultExpressionContent } from "./expression-content";
@@ -38,17 +38,6 @@ describe("ExpressionToolComponent", () => {
     }
   };
 
-  beforeEach(() => {
-    jest.spyOn(console, 'error')
-    // @ts-ignore jest.spyOn adds this functionallity
-    console.error.mockImplementation(() => null);
-  });
-
-  afterEach(() => {
-    // @ts-ignore jest.spyOn adds this functionallity
-    console.error.mockRestore()
-  })
-
   it("renders a math field web component", () => {
     render(<ExpressionToolComponent  {...defaultProps} {...{model}}></ExpressionToolComponent>);
     expect(document.querySelector("math-field")).toBeInTheDocument();
@@ -60,20 +49,31 @@ describe("ExpressionToolComponent", () => {
     expect(document.querySelector("math-field")).toHaveAttribute("value", "a=\\pi r^2");
   });
 
-  it("the math field renders content in a shadow dom", () => {
+  it("the math field element hosts a shadow dom", () => {
     render(<ExpressionToolComponent  {...defaultProps} {...{model}}></ExpressionToolComponent>);
     const shadow = document.querySelector("math-field")?.shadowRoot;
     const parentSpan = shadow?.querySelector("span");
     expect(parentSpan).toBeInTheDocument();
   });
 
-  it("renders the pi character in the math field", () => {
-    const { getByText, container, queryByText } = render(
-      <ExpressionToolComponent  {...defaultProps} {...{model}}></ExpressionToolComponent>
-    );
-    const mathField = container.querySelector("math-field");
-    const shadow = mathField?.shadowRoot;
-    const something = shadow?.children[1].childNodes.length;
-    console.log("something", something);
-  });
+  // TODO, get shadow dom to render in test context (below is a failed attempt)
+  // In the default, the shadow dom is only rendered as deep as the first three elements
+  // Everything below that is not rendered in the test context
+  // Below is a failed attempt to load mathlive and render the shadow dom
+
+  // it("renders the pi character in the math field", () => {
+  //   import("mathlive").then((mathlive) => {
+  //     const { getByText, container, queryByText } = render(
+  //       <ExpressionToolComponent  {...defaultProps} {...{model}}></ExpressionToolComponent>
+  //     );
+  //     const mathField = container.querySelector("math-field");
+  //     const shadow = mathField?.shadowRoot;
+  //     mathlive.renderMathInElement(mathField as HTMLElement);
+  //     mathlive.renderMathInDocument();
+  //     shadow?.childNodes.forEach((node) => {
+  //       console.log("child of top level span and children below: ", node);
+  //       console.log(node.hasChildNodes()) // each is empty
+  //     });
+  //   });
+  // });
 });

--- a/src/plugins/expression/expression-tile.tsx
+++ b/src/plugins/expression/expression-tile.tsx
@@ -4,7 +4,7 @@ import { ITileProps } from "../../components/tiles/tile-component";
 import { ExpressionContentModelType } from "./expression-content";
 import { MathfieldElementAttributes, MathfieldElement } from "mathlive";
 import { CustomEditableTileTitle } from "../../components/tiles/custom-editable-tile-title";
-import('mathlive');
+import("mathlive"); // passes linter, but results in MODULE_NOT_FOUND in jest test
 
 import "./expression-tile.scss";
 

--- a/src/plugins/expression/expression-tile.tsx
+++ b/src/plugins/expression/expression-tile.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react";
-import React, { BaseSyntheticEvent, DOMAttributes, useRef } from "react";
+import React, { DOMAttributes, useRef } from "react";
 import "mathlive"; // separate static import of library for initialization to run
 // eslint-disable-next-line no-duplicate-imports
 import type { MathfieldElementAttributes, MathfieldElement } from "mathlive";

--- a/src/plugins/expression/expression-tile.tsx
+++ b/src/plugins/expression/expression-tile.tsx
@@ -26,6 +26,11 @@ export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) =>
     content.setLatexStr(e.target.value);
   };
 
+  // This is an example of how we can access mathfield api
+  // const exampleApiUse = () => {
+  //   mathfieldRef.current?.setValue(`42\\frac12`)
+  // }
+
   return (
     <div className="expression-tool">
       <div className="expression-title-area">

--- a/src/plugins/expression/expression-tile.tsx
+++ b/src/plugins/expression/expression-tile.tsx
@@ -1,47 +1,47 @@
 import { observer } from "mobx-react";
-import React from "react";
+import React, { BaseSyntheticEvent, DOMAttributes, useRef } from "react";
 import { ITileProps } from "../../components/tiles/tile-component";
 import { ExpressionContentModelType } from "./expression-content";
-import { ToolTitleArea } from "../../components/tiles/tile-title-area";
-import { EditableTileTitle } from "../../components/tiles/editable-tile-title";
-import { defaultTileTitleFont } from "../../components/constants";
-import { measureText } from "../../components/tiles/hooks/use-measure-text";
+import { MathfieldElementAttributes, MathfieldElement } from "mathlive";
+import { CustomEditableTileTitle } from "../../components/tiles/custom-editable-tile-title";
+import('mathlive');
 
 import "./expression-tile.scss";
 
+type CustomElement<T> = Partial<T & DOMAttributes<T>>;
+
+declare global {
+  namespace JSX { // eslint-disable-line @typescript-eslint/no-namespace
+    interface IntrinsicElements {
+      ["math-field"]: CustomElement<MathfieldElementAttributes>;
+    }
+  }
+}
+
 export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) => {
   const content = props.model.content as ExpressionContentModelType;
+  const mathfieldRef = useRef<MathfieldElement>(null);
 
-  const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-    content.setText(event.target.value);
-  };
-
-  const handleTitleChange = (title: any): void => {
-    content.setTitle(title);
-  };
-
-  const renderTitle = () => {
-    const size = {width: null, height: null};
-    const { readOnly, scale } = props;
-    return (
-      <EditableTileTitle
-        key="expression-title"
-        size={size}
-        scale={scale}
-        getTitle={() => content.title}
-        readOnly={readOnly}
-        measureText={(text) => measureText(text, defaultTileTitleFont)}
-        onEndEdit={handleTitleChange}
-      />
-    );
+  const handleChange = (e: any) => {
+    content.setLatexStr(e.target.value);
   };
 
   return (
     <div className="expression-tool">
-      <ToolTitleArea>
-        {renderTitle()}
-      </ToolTitleArea>
-      <textarea value={content.text} onChange={handleChange} />
+      <div className="expression-title-area">
+        <CustomEditableTileTitle
+          model={props.model}
+          onRequestUniqueTitle={props.onRequestUniqueTitle}
+          readOnly={props.readOnly}
+        />
+      </div>
+      <div className="expression-math-area">
+        <math-field
+          ref={mathfieldRef}
+          value={content.latexStr}
+          onInput={(e:BaseSyntheticEvent) => handleChange(e)}
+        />
+      </div>
     </div>
   );
 });

--- a/src/plugins/expression/expression-tile.tsx
+++ b/src/plugins/expression/expression-tile.tsx
@@ -1,14 +1,15 @@
 import { observer } from "mobx-react";
 import React, { BaseSyntheticEvent, DOMAttributes, useRef } from "react";
+import "mathlive"; // separate static import of library for initialization to run
+// eslint-disable-next-line no-duplicate-imports
+import type { MathfieldElementAttributes, MathfieldElement } from "mathlive";
 import { ITileProps } from "../../components/tiles/tile-component";
 import { ExpressionContentModelType } from "./expression-content";
-import { MathfieldElementAttributes, MathfieldElement } from "mathlive";
 import { CustomEditableTileTitle } from "../../components/tiles/custom-editable-tile-title";
-import("mathlive");
+
 import "./expression-tile.scss";
 
 type CustomElement<T> = Partial<T & DOMAttributes<T>>;
-
 declare global {
   namespace JSX { // eslint-disable-line @typescript-eslint/no-namespace
     interface IntrinsicElements {
@@ -38,7 +39,7 @@ export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) =>
         <math-field
           ref={mathfieldRef}
           value={content.latexStr}
-          onInput={(e:BaseSyntheticEvent) => handleChange(e)}
+          onInput={handleChange}
         />
       </div>
     </div>

--- a/src/plugins/expression/expression-tile.tsx
+++ b/src/plugins/expression/expression-tile.tsx
@@ -4,8 +4,7 @@ import { ITileProps } from "../../components/tiles/tile-component";
 import { ExpressionContentModelType } from "./expression-content";
 import { MathfieldElementAttributes, MathfieldElement } from "mathlive";
 import { CustomEditableTileTitle } from "../../components/tiles/custom-editable-tile-title";
-import("mathlive"); // passes linter, but results in MODULE_NOT_FOUND in jest test
-
+import("mathlive");
 import "./expression-tile.scss";
 
 type CustomElement<T> = Partial<T & DOMAttributes<T>>;

--- a/src/plugins/expression/expression-types.ts
+++ b/src/plugins/expression/expression-types.ts
@@ -1,3 +1,3 @@
 export const kExpressionTileType = "Expression";
 
-export const kExpressionDefaultHeight = 320;
+export const kExpressionDefaultHeight = 100;

--- a/src/test/jest-resolver.js
+++ b/src/test/jest-resolver.js
@@ -23,7 +23,7 @@ module.exports = (path, options) => {
             // Once we're able to migrate our Jest config to ESM and a browser crypto
             // implementation is available for the browser+ESM version of uuid to use (eg, via
             // https://github.com/jsdom/jsdom/pull/3352 or a similar polyfill), this can go away.
-            if (["nanoid", "uuid"].includes(pkg.name)) {
+            if (["nanoid", "uuid", "mathlive"].includes(pkg.name)) {
                 delete pkg.exports;
                 delete pkg.module;
             }

--- a/src/test/setupTests.ts
+++ b/src/test/setupTests.ts
@@ -106,3 +106,6 @@ declare global {
   expect(value).toBeDefined();
   expect(value).not.toBeNull();
 };
+
+// required for ResizeObserver called in mathlive
+global.ResizeObserver = require('resize-observer-polyfill');

--- a/src/utilities/title-utils.ts
+++ b/src/utilities/title-utils.ts
@@ -1,5 +1,6 @@
 export function defaultTitle(titleBase: string, titleNumber: number) {
-  return `${titleBase} ${titleNumber}`;
+  const addParens = titleBase === "Eq.";
+  return addParens ? `(${titleBase} ${titleNumber})` : `${titleBase} ${titleNumber}`;
 }
 
 export function titleMatchesDefault(title?: string, titleBase?: string) {

--- a/src/utilities/title-utils.ts
+++ b/src/utilities/title-utils.ts
@@ -1,6 +1,5 @@
 export function defaultTitle(titleBase: string, titleNumber: number) {
-  const addParens = titleBase === "Eq.";
-  return addParens ? `(${titleBase} ${titleNumber})` : `${titleBase} ${titleNumber}`;
+  return `${titleBase} ${titleNumber}`;
 }
 
 export function titleMatchesDefault(title?: string, titleBase?: string) {


### PR DESCRIPTION
Updates the implementation for this PT story:
- [184851445](https://www.pivotaltracker.com/story/show/184851445): **Expression title default and editing** (This is reimplemented with a reusable component that is also swapped in to the Data Card tile).  
  
Adds functionality from these PT stories: 
- [184851442](https://www.pivotaltracker.com/story/show/184851442): **Expression saves and restores**
- [184851427](https://www.pivotaltracker.com/story/show/184851427): **Expression tile allows expression editing from Cortex**:

2. I'm leaving this in draft at the moment until a resolution of an issue with resolving mathlive in jest test.  

   - [x] Get mathlive module to be present for jest tests
   - [x] Reimplement basic jest tests

3. We got mathlive module into Jest environment, and I was able to get a few basic tests going.  However, I was not able to get the shadow dom to render in the test context.  There is an inline note in the Jest test about it.  It's worth mentioning that we are able to test shadow dom functionality in the cypress tests, but we should make a story for solving the same in the jest environment. 