### PR TITLE
fix: Images do not appear in data cards (PT-185149154)

### DIFF
--- a/src/models/image-map.ts
+++ b/src/models/image-map.ts
@@ -397,7 +397,7 @@ export const externalUrlImagesHandler: IImageHandler = {
     // 4. the data uri is "fetched" to turn it into a blob and then blob url
     // 5. the resulting imageData value will be the blob url
     // 6. the displayUrl is set to this blob url
-    if (db?.stores.user.id) {
+    if (db?.stores?.user.id) {
       try {
         const simpleImage = await storeImage(db, url);
         if (isPlaceholderImage(simpleImage.imageUrl)) {

--- a/src/models/image-map.ts
+++ b/src/models/image-map.ts
@@ -397,6 +397,8 @@ export const externalUrlImagesHandler: IImageHandler = {
     // 4. the data uri is "fetched" to turn it into a blob and then blob url
     // 5. the resulting imageData value will be the blob url
     // 6. the displayUrl is set to this blob url
+    // In the context of authoring, db.stores is undefined and we consequently
+    // do not upload any images added via the CMS.
     if (db?.stores?.user.id) {
       try {
         const simpleImage = await storeImage(db, url);


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/185149154

In the context of authoring, `db.stores` is undefined. This change adds a check for that, and in the case `db.stores` is undefined, skips the attempt to store an image when it's added to a data card. (The original image URL will be saved instead.)