### PR TITLE
Re-enabling 4-up cypress tests that were recently disabled

### DIFF
--- a/cypress/e2e/clue/branch/teacher_tests/teacher_dashboard_4_quadrants_spec.js
+++ b/cypress/e2e/clue/branch/teacher_tests/teacher_dashboard_4_quadrants_spec.js
@@ -51,7 +51,7 @@ context('Teacher Dashboard View 4 Quadrants', () => {
       });
 
       // FIXME: this test was crashing my local cypress.
-      it.skip('verify toggling the 4 quardrants in a 4 up view', () => {
+      it('verify toggling the 4 quardrants in a 4 up view', () => {
 
         //North West Quardrants
         dashboard.getGroups().eq(0).within(() => {


### PR DESCRIPTION
@scytacki , I have re-enabled the 4-up view test in this PR; It didn't crash on my machine and it looks like it also din't crash in github.