### PR TITLE
185159335 Truncate Group Numbers

### DIFF
--- a/src/components/document/group-virtual-document.tsx
+++ b/src/components/document/group-virtual-document.tsx
@@ -37,7 +37,7 @@ export class GroupVirtualDocumentComponent extends BaseComponent<IProps, IState>
     );
   }
 
-  private groupButton(groupId: string) {
+  private groupButton(groupId: string, displayId: string) {
     const { document } = this.props;
     const thisId = document.id;
     const selected = thisId === groupId;
@@ -45,7 +45,7 @@ export class GroupVirtualDocumentComponent extends BaseComponent<IProps, IState>
     const clickHandler = () => this.handleGroupClicked(groupId);
     return(
       <div key={groupId} className={className} onClick={clickHandler}>
-        <div className="number">G{groupId}</div>
+        <div className="number">G{displayId}</div>
       </div>
     );
   }
@@ -58,7 +58,7 @@ export class GroupVirtualDocumentComponent extends BaseComponent<IProps, IState>
     return (
       <div className={`titlebar ${type}`}>
         <div className="actions">
-          { groups.allGroups.map( group => this.groupButton(group.id)) }
+          { groups.allGroups.map( group => this.groupButton(group.id, group.displayId)) }
         </div>
         <div className="group-title" data-test="document-title">
           Group {thisId}

--- a/src/components/document/student-group-view.tsx
+++ b/src/components/document/student-group-view.tsx
@@ -14,9 +14,10 @@ interface IGroupButtonProps {
 const GroupButton: React.FC<IGroupButtonProps> = ({ id, selected, onSelectGroup }) => {
   const className = `icon group-number ${selected ? "active" : ""}`;
   const handleClick = () => onSelectGroup(id);
+  const displayId = id.slice(id.length - 3);
   return(
     <div key={`group-${id}`} className={className} onClick={handleClick}>
-      <div className="number">G{id}</div>
+      <div className="number">G{displayId}</div>
     </div>
   );
 };

--- a/src/components/document/student-group-view.tsx
+++ b/src/components/document/student-group-view.tsx
@@ -7,14 +7,14 @@ import { FourUpComponent } from "../four-up";
 import "./student-group-view.scss";
 
 interface IGroupButtonProps {
+  displayId: string;
   id: string;
   selected: boolean;
   onSelectGroup: (id: string) => void;
 }
-const GroupButton: React.FC<IGroupButtonProps> = ({ id, selected, onSelectGroup }) => {
+const GroupButton: React.FC<IGroupButtonProps> = ({ displayId, id, selected, onSelectGroup }) => {
   const className = `icon group-number ${selected ? "active" : ""}`;
   const handleClick = () => onSelectGroup(id);
-  const displayId = id.slice(id.length - 3);
   return(
     <div key={`group-${id}`} className={className} onClick={handleClick}>
       <div className="number">G{displayId}</div>
@@ -66,7 +66,7 @@ export const StudentGroupView:React.FC<IProps> = ({ groupId, setGroupId }) => {
           { groups.allGroups
               .filter(group => group.users.length > 0)
               .map(group => {
-                return <GroupButton id={group.id} key={group.id}
+                return <GroupButton displayId={group.displayId} id={group.id} key={group.id}
                                     selected={group.id === selectedId}
                                     onSelectGroup={onSelectGroup} />;
               })}

--- a/src/models/stores/groups.ts
+++ b/src/models/stores/groups.ts
@@ -26,6 +26,9 @@ export const GroupModel = types
   .views((self) => ({
     getUserById(id?: string) {
       return self.users.find(user => user.id === id);
+    },
+    get displayId() {
+      return self.id.slice(self.id.length - 3);
     }
   }));
 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/185159335

It looks like CLUE is supposed to only allow group numbers from 1 to 99. But somewhere, this is broken, and some teachers have enormous group numbers (greater than a million). This probably causes multiple problems, but one in particular is that the numbers overflow the buttons that allow a teacher to switch between groups, which makes it difficult to see and switch to groups.

Ideally, we should figure out how groups with absurdly large numbers are being created. I tried to look into it a bit, but I couldn't figure it out. Additionally, someone should go back and clean up existing groups in the database that have become absurdly large.

This PR addresses the issue in a short term, imperfect way by truncating group ids to only show the final three characters.