### PR TITLE
improve standalone doc editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ There are a number of URL parameters that can aid in testing:
 
 ### Standalone Document Editor
 
-There is an alternative entry point for CLUE available at `/doc-editor.html`. This can be used to save and open individual documents from the local file system. Remote documents can be loaded into this editor with the `document` URL parameter. The editor requires a `unit` parameter to configure the toolbar. The editor supports loading section documents or document content documents. It can load an exported document content which is typical or section documents. It can also load a raw document content which is the same thing stored in Firebase.
+There is an alternative entry point for CLUE available at `/doc-editor.html`. This can be used to save and open individual documents from the local file system. Remote documents can be loaded into this editor with the `document` URL parameter. The editor requires a `unit` parameter to configure the toolbar. The editor supports loading section documents or document content documents. It can load an exported document content which is typical for section documents. It can also load a raw document content which is the same format that is stored in Firebase.
 
 ### QA
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,10 @@ There are a number of URL parameters that can aid in testing:
 |`firestore`|`emulator` (for default) or `host:port`|Target emulator for firestore database calls.|
 |`functions`|`emulator` (for default) or `host:port`|Target emulator-hosted firebase functions.|
 
+### Standalone Document Editor
+
+There is an alternative entry point for CLUE available at `/doc-editor.html`. This can be used to save and open individual documents from the local file system. Remote documents can be loaded into this editor with the `document` URL parameter. The editor requires a `unit` parameter to configure the toolbar. The editor supports loading section documents or document content documents. It can load an exported document content which is typical or section documents. It can also load a raw document content which is the same thing stored in Firebase.
+
 ### QA
 
 Along with `dev`, `test`, `authed` and `demo` modes the app has a `qa` mode.  QA mode uses the same parameters as demo mode with two additional parameters:

--- a/src/components/doc-editor-app.tsx
+++ b/src/components/doc-editor-app.tsx
@@ -1,10 +1,13 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
+import stringify from "json-stringify-pretty-compact";
+import { getSnapshot } from "mobx-state-tree";
 
 import { defaultDocumentModel, defaultDocumentModelParts } from "./doc-editor-app-defaults";
 import { EditableDocumentContent } from "./document/editable-document-content";
 import { createDocumentModel } from "../models/document/document";
 import { AppConfigModelType } from "../models/stores/app-config-model";
 import { DocumentContentSnapshotType } from "../models/document/document-content";
+import { urlParams } from "../utilities/url-params";
 
 export interface IDocEditorAppProps {
   appConfig: AppConfigModelType;
@@ -16,51 +19,99 @@ export const DocEditorApp = ({ appConfig }: IDocEditorAppProps) => {
   });
   const [fileHandle, setFileHandle] = useState<FileSystemHandle|undefined>();
   const [sectionSnapshot, setSectionSnapshot] = useState<any>();
+  const [fileName, setFileName] = useState<string>("");
 
-  // The most useful files to edit like this are currently sections
-  // so lets work with those
-  async function handleOpen() {
-    const [_fileHandle] = await (window as any).showOpenFilePicker();
-    setFileHandle(_fileHandle);
-    const file = await _fileHandle.getFile();
-    const text = await file.text();
-    const _sectionSnapshot = JSON.parse(text);
-    setSectionSnapshot(_sectionSnapshot);
-    const documentContentSnapshot = _sectionSnapshot.content as DocumentContentSnapshotType;
+  function loadDocument(text: string) {
+    const _parsedText = JSON.parse(text);
+    let documentContentSnapshot;
+    if (_parsedText.content ) {
+      setSectionSnapshot(_parsedText);
+      documentContentSnapshot = _parsedText.content as DocumentContentSnapshotType;
+    } else {
+      documentContentSnapshot = _parsedText;
+    }
     setDocument(createDocumentModel({
       ...defaultDocumentModelParts,
       content: documentContentSnapshot
     }));
   }
 
+  // Handle opening both section documents with a content field
+  // and basic documents which are just the content itself
+  async function handleOpen() {
+    const [_fileHandle] = await (window as any).showOpenFilePicker();
+    setFileHandle(_fileHandle);
+    const file = await _fileHandle.getFile();
+    setFileName(file.name);
+    const text = await file.text();
+    loadDocument(text);
+  }
+
   async function handleSave() {
-    if (!fileHandle || !document.content) {
-      console.error("Can't save without a fileHandle or document.content");
+    if (!document.content) {
+      console.error("Can't save without document.content");
       return;
     }
 
-    if (!sectionSnapshot) {
-      console.error("Currently can't save without a section snapshot");
-      return;
+    let _fileHandle = fileHandle;
+    if (!_fileHandle) {
+      _fileHandle = await (window as any).showSaveFilePicker();
+      setFileHandle(_fileHandle);
+      if (_fileHandle) {
+        const file = await (_fileHandle as any).getFile();
+        setFileName(file.name);
+      }
+
     }
 
-    // construct the contents of the section
-    const docContentString = document.content.exportAsJson({ includeTileIds: true });
-    const docContentJSON = JSON.parse(docContentString);
-    sectionSnapshot.content = docContentJSON;
-    const contents = JSON.stringify(sectionSnapshot, undefined, 2);
+    let contents;
+    if (sectionSnapshot) {
+      // construct the contents of the section
+      const docContentString = document.content.exportAsJson({ includeTileIds: true });
+      const docContentJSON = JSON.parse(docContentString);
+      sectionSnapshot.content = docContentJSON;
+      contents = JSON.stringify(sectionSnapshot, undefined, 2);
+    } else {
+      // TODO: we probably want to keep track if we loaded an exported or raw file
+      // and then save it the same way
+      const contentJson = getSnapshot(document.content);
+      contents = stringify(contentJson, {maxLength: 100});
+    }
 
-    const writable = await (fileHandle as any).createWritable();
+    const writable = await (_fileHandle as any).createWritable();
     // Write the contents of the file to the stream.
     await writable.write(contents);
     // Close the file and write the contents to disk.
     await writable.close();
   }
 
+  useEffect(() => {
+    const {document: documentURL} = urlParams;
+    if (!documentURL) {
+      return;
+    }
+
+    fetch(documentURL)
+    .then(async response => {
+      if (response.ok) {
+        const documentText = await response.text();
+        loadDocument(documentText);
+      } else {
+        // If the document is not found, return the response so that the caller can
+        // handle it appropriately.
+        throw Error(`Request rejected with status ${response.status}`);
+      }
+    })
+    .catch(error => {
+      throw Error(`Request rejected with exception ${error}`);
+    });
+  }, []);
+
   return (
     <>
       <button onClick={handleOpen}>open</button>
       <button onClick={handleSave}>save</button>
+      <span>{fileName}</span>
       <EditableDocumentContent
         contained={false}
         mode="1-up"

--- a/src/components/doc-editor-app.tsx
+++ b/src/components/doc-editor-app.tsx
@@ -97,12 +97,11 @@ export const DocEditorApp = ({ appConfig }: IDocEditorAppProps) => {
         const documentText = await response.text();
         loadDocument(documentText);
       } else {
-        // If the document is not found, return the response so that the caller can
-        // handle it appropriately.
-        throw Error(`Request rejected with status ${response.status}`);
+        throw Error(`status ${response.status}`);
       }
     })
     .catch(error => {
+      // This error is printed in the console as an "Uncaught (in promise)..."
       throw Error(`Request rejected with exception ${error}`);
     });
   }, []);

--- a/src/components/document/canvas.tsx
+++ b/src/components/document/canvas.tsx
@@ -2,6 +2,7 @@ import { each } from "lodash";
 import { inject, observer } from "mobx-react";
 import { getSnapshot, destroy } from "mobx-state-tree";
 import React from "react";
+import stringify from "json-stringify-pretty-compact";
 import { DocumentLoadingSpinner } from "./document-loading-spinner";
 import { BaseComponent } from "../base";
 import { DocumentContentComponent } from "./document-content";
@@ -73,6 +74,7 @@ export class CanvasComponent extends BaseComponent<IProps, IState> {
 
     this.hotKeys.register({
       "cmd-shift-s": this.handleCopyDocumentJson,
+      "cmd-shift-p": this.handleCopyRawDocumentJson,
       "cmd-option-shift-s": this.handleExportSectionJson,
       "cmd-z": this.handleDocumentUndo,
       "cmd-shift-z": this.handleDocumentRedo
@@ -155,7 +157,7 @@ export class CanvasComponent extends BaseComponent<IProps, IState> {
   private handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     this.hotKeys.dispatch(e);
   };
-  
+
   private getDocumentContent = () => {
     const { content, document } = this.props;
     return document?.content ?? content;
@@ -174,6 +176,16 @@ export class CanvasComponent extends BaseComponent<IProps, IState> {
     const transformImageUrl = this.getTransformImageUrl();
     const json = documentContent?.exportAsJson({ includeTileIds: true, transformImageUrl });
     json && navigator.clipboard.writeText(json);
+  };
+
+  private handleCopyRawDocumentJson = () => {
+    const documentContent = this.getDocumentContent();
+    if (!documentContent) {
+      return;
+    }
+    const json = getSnapshot(documentContent);
+    const jsonString =  stringify(json, {maxLength: 100});
+    navigator.clipboard.writeText(jsonString);
   };
 
   // Saves the current document as separate section files on the user's hard drive.

--- a/src/models/document/document-content-import.ts
+++ b/src/models/document/document-content-import.ts
@@ -58,6 +58,14 @@ function migrateRow(content: DocumentContentModelType, tiles: OriginalTileModel[
   });
 }
 
+// FIXME: this does not handle tiles that refer to shared models correctly
+// the tiles are created first and if they have references to the shared
+// model then those references will be broken because the shared model
+// doesn't exist yet. Many tiles use "afterAttach" to work with their sharedModel
+// so that is also going to be run before the actual shared model is added.
+// For example the diagram-view might try to create a shared variables model when it is
+// first attached. However the shared model manager might not be ready yet at this
+// point so perhaps it won't do that.
 export function migrateSnapshot(snapshot: IDocumentImportSnapshot): any {
   const docContent = DocumentContentModel.create();
   const { tiles: tilesOrRows, sharedModels } = snapshot;

--- a/src/models/document/document-content-import.ts
+++ b/src/models/document/document-content-import.ts
@@ -58,14 +58,15 @@ function migrateRow(content: DocumentContentModelType, tiles: OriginalTileModel[
   });
 }
 
-// FIXME: this does not handle tiles that refer to shared models correctly
-// the tiles are created first and if they have references to the shared
-// model then those references will be broken because the shared model
+// FIXME: this does not handle tiles that refer to shared models correctly.
+// The tiles are created first and if they have references to the shared
+// model, then those references will be broken because the shared model
 // doesn't exist yet. Many tiles use "afterAttach" to work with their sharedModel
 // so that is also going to be run before the actual shared model is added.
 // For example the diagram-view might try to create a shared variables model when it is
-// first attached. However the shared model manager might not be ready yet at this
-// point so perhaps it won't do that.
+// first attached. However in practice this might not be an issue because the
+// the shared model manager might not be ready yet at this point, so the reaction
+// in after attach will wait for the shared model manager to be ready.
 export function migrateSnapshot(snapshot: IDocumentImportSnapshot): any {
   const docContent = DocumentContentModel.create();
   const { tiles: tilesOrRows, sharedModels } = snapshot;

--- a/src/utilities/url-params.ts
+++ b/src/utilities/url-params.ts
@@ -83,6 +83,13 @@ export interface QueryParams {
   localCMSBackend?: boolean;
   // mouse sensor can be enabled for cypress drag and drop tests for dnd-kit
   mouseSensor?: boolean;
+
+  //
+  // Standalone document editor options (doc-editor.html)
+  //
+
+  // URL to the document to open in the document editor
+  document?: string;
 }
 
 export const processUrlParams = (): QueryParams => {


### PR DESCRIPTION
- allow passing a document url as a param
- allow saving a document if the document wasn't opened
- allow loading basic documents, not section documents
- show the file name of the opened or saved document
- add new hot key for copying raw document content: non export document
  raw document content works with shared models better

Note: this isn't covered well by tests. Here is some rational why: 
- It hasn't been requested as a feature for end users, currently it is just useful for developers and demo'ers
- It should be useful for writing CLUE tile tests since it is now possible to load a pre populated document that has been crafted for a specific test case.  If we start using it this way then more of it will be covered.