### PR TITLE
Expression export 185246854

### DIFF
--- a/cypress/support/elements/clue/DataflowToolTile.js
+++ b/cypress/support/elements/clue/DataflowToolTile.js
@@ -212,13 +212,13 @@ class DataflowToolTile {
   recordData(samplingRate, timer) {
     this.selectSamplingRate(samplingRate);
     this.getRecordButton().click();
-    this.getCountdownTimer().should("contain", "000:0" + timer.toString())
+    this.getCountdownTimer().should("contain", "000:0" + timer.toString());
     this.getStopButton().click();
   }
   recordDataWithoutStop(samplingRate, timer) {
     this.selectSamplingRate(samplingRate);
     this.getRecordButton().click();
-    this.getCountdownTimer().should("contain", "000:0" + timer.toString())
+    this.getCountdownTimer().should("contain", "000:0" + timer.toString());
   }
   clearRecordedData() {
     this.getRecordingClearButton().click();

--- a/src/plugins/expression/expression-content.ts
+++ b/src/plugins/expression/expression-content.ts
@@ -1,8 +1,7 @@
-import { types, Instance } from "mobx-state-tree";
+import { types, Instance, getSnapshot } from "mobx-state-tree";
 import { TileContentModel } from "../../models/tiles/tile-content";
 import { kExpressionTileType } from "./expression-types";
 import { IDefaultContentOptions, ITileExportOptions } from "../../models/tiles/tile-content-info";
-import { getSnapshot } from "mobx-state-tree";
 
 export function defaultExpressionContent(props?: IDefaultContentOptions): ExpressionContentModelType {
   return ExpressionContentModel.create({latexStr: `a=\\pi r^2`});

--- a/src/plugins/expression/expression-content.ts
+++ b/src/plugins/expression/expression-content.ts
@@ -18,9 +18,11 @@ export const ExpressionContentModel = TileContentModel
       return true;
     },
     exportJson(options?: ITileExportOptions){
+      const escapedLatexStr = self.latexStr.replace(/\\/g, "\\\\");
       return [
         `{`,
-        `  "type": "Expression Tile"`,
+        `  "type": "Expression",`,
+        `  "latexStr": "${escapedLatexStr}"`,
         `}`
       ].join("\n");
     }

--- a/src/plugins/expression/expression-content.ts
+++ b/src/plugins/expression/expression-content.ts
@@ -2,6 +2,7 @@ import { types, Instance } from "mobx-state-tree";
 import { TileContentModel } from "../../models/tiles/tile-content";
 import { kExpressionTileType } from "./expression-types";
 import { IDefaultContentOptions, ITileExportOptions } from "../../models/tiles/tile-content-info";
+import { getSnapshot } from "mobx-state-tree";
 
 export function defaultExpressionContent(props?: IDefaultContentOptions): ExpressionContentModelType {
   return ExpressionContentModel.create({latexStr: `a=\\pi r^2`});
@@ -18,13 +19,7 @@ export const ExpressionContentModel = TileContentModel
       return true;
     },
     exportJson(options?: ITileExportOptions){
-      const escapedLatexStr = self.latexStr.replace(/\\/g, "\\\\");
-      return [
-        `{`,
-        `  "type": "Expression",`,
-        `  "latexStr": "${escapedLatexStr}"`,
-        `}`
-      ].join("\n");
+      return JSON.stringify(getSnapshot(self), null, 2);
     }
   }))
   .actions(self => ({


### PR DESCRIPTION
Expression Tile Export: [PT#185246854](https://www.pivotaltracker.com/n/projects/2441242/stories/185246854)

- This adds the latex field to the expression tile export format, with each backslash escaped for serialization
- I tested the results of the export commands on left-side and right-side content