### PR TITLE
184930324 expression read only

### DIFF
--- a/src/plugins/expression/expression-tile.scss
+++ b/src/plugins/expression/expression-tile.scss
@@ -24,9 +24,13 @@ $expression-title-width: 200px;
     }
   }
 
-  .expression-math-area math-field {
+  math-field {
     font-size:20px;
     border-width: 0px;
     padding:$expression-padding;
   }
+}
+
+.readonly math-field {
+  outline:none;
 }

--- a/src/plugins/expression/expression-tile.tsx
+++ b/src/plugins/expression/expression-tile.tsx
@@ -23,7 +23,6 @@ declare global {
 const undoKeys = ["cmd+z", "[Undo]", "ctrl+z"];
 
 export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) => {
-  console.log("| ExpressionToolComponent context: ", props.context, "title: ", props.model.title, "readOnly: ", props.readOnly);
   const content = props.model.content as ExpressionContentModelType;
   const mf = useRef<MathfieldElement>(null);
   const trackedCursorPos = useRef<number>(0);
@@ -38,7 +37,7 @@ export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) =>
     if (mf.current?.readOnly === undefined) return;
     if (props.readOnly === true) mf.current.readOnly = true;
     if (props.readOnly === false) mf.current.readOnly = false;
-  }, [props.readOnly])
+  }, [props.readOnly]);
 
   useEffect(() => {
     // when we change model via undo button, we need to update mathfield

--- a/src/plugins/expression/expression-tile.tsx
+++ b/src/plugins/expression/expression-tile.tsx
@@ -35,14 +35,9 @@ export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) =>
   }
 
   useEffect(() => {
-    if (mf.current?.readOnly !== undefined){
-      if (props.readOnly === true){
-        mf.current.readOnly = true;
-      } else if (props.readOnly === false){
-        mf.current.readOnly = false;
-      }
-      console.log("| mf.current.readOnly is ", mf.current?.readOnly, " and app.readOnly is ", props.readOnly)
-    }
+    if (mf.current?.readOnly === undefined) return;
+    if (props.readOnly === true) mf.current.readOnly = true;
+    if (props.readOnly === false) mf.current.readOnly = false;
   }, [props.readOnly])
 
   useEffect(() => {

--- a/src/plugins/expression/expression-tile.tsx
+++ b/src/plugins/expression/expression-tile.tsx
@@ -23,6 +23,7 @@ declare global {
 const undoKeys = ["cmd+z", "[Undo]", "ctrl+z"];
 
 export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) => {
+  console.log("| ExpressionToolComponent context: ", props.context, "title: ", props.model.title, "readOnly: ", props.readOnly);
   const content = props.model.content as ExpressionContentModelType;
   const mf = useRef<MathfieldElement>(null);
   const trackedCursorPos = useRef<number>(0);
@@ -32,6 +33,17 @@ export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) =>
       mf.current && replaceKeyBinding(mf.current.keybindings, key, "");
     });
   }
+
+  useEffect(() => {
+    if (mf.current?.readOnly !== undefined){
+      if (props.readOnly === true){
+        mf.current.readOnly = true;
+      } else if (props.readOnly === false){
+        mf.current.readOnly = false;
+      }
+      console.log("| mf.current.readOnly is ", mf.current?.readOnly, " and app.readOnly is ", props.readOnly)
+    }
+  }, [props.readOnly])
 
   useEffect(() => {
     // when we change model via undo button, we need to update mathfield

--- a/src/plugins/expression/expression-tile.tsx
+++ b/src/plugins/expression/expression-tile.tsx
@@ -35,8 +35,7 @@ export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) =>
 
   useEffect(() => {
     if (mf.current?.readOnly === undefined) return;
-    if (props.readOnly === true) mf.current.readOnly = true;
-    if (props.readOnly === false) mf.current.readOnly = false;
+    if (props.readOnly !== undefined) mf.current.readOnly = props.readOnly;
   }, [props.readOnly]);
 
   useEffect(() => {

--- a/src/plugins/expression/expression-tile.tsx
+++ b/src/plugins/expression/expression-tile.tsx
@@ -61,6 +61,7 @@ export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) =>
           ref={mf}
           value={content.latexStr}
           onInput={handleChange}
+          // MathLive only interprets undefined as false
           readOnly={props.readOnly === true ? true : undefined}
         />
       </div>

--- a/src/plugins/expression/expression-tile.tsx
+++ b/src/plugins/expression/expression-tile.tsx
@@ -10,6 +10,7 @@ import { CustomEditableTileTitle } from "../../components/tiles/custom-editable-
 import { replaceKeyBinding } from "./expression-tile-utils";
 
 import "./expression-tile.scss";
+import { calc } from "@chakra-ui/react";
 
 type CustomElement<T> = Partial<T & DOMAttributes<T>>;
 declare global {
@@ -32,11 +33,6 @@ export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) =>
       mf.current && replaceKeyBinding(mf.current.keybindings, key, "");
     });
   }
-
-  useEffect(() => {
-    if (mf.current?.readOnly === undefined) return;
-    if (props.readOnly !== undefined) mf.current.readOnly = props.readOnly;
-  }, [props.readOnly]);
 
   useEffect(() => {
     // when we change model via undo button, we need to update mathfield
@@ -67,6 +63,7 @@ export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) =>
           ref={mf}
           value={content.latexStr}
           onInput={handleChange}
+          readOnly={props.readOnly === true ? true : undefined}
         />
       </div>
     </div>

--- a/src/plugins/expression/expression-tile.tsx
+++ b/src/plugins/expression/expression-tile.tsx
@@ -8,9 +8,7 @@ import { ITileProps } from "../../components/tiles/tile-component";
 import { ExpressionContentModelType } from "./expression-content";
 import { CustomEditableTileTitle } from "../../components/tiles/custom-editable-tile-title";
 import { replaceKeyBinding } from "./expression-tile-utils";
-
 import "./expression-tile.scss";
-import { calc } from "@chakra-ui/react";
 
 type CustomElement<T> = Partial<T & DOMAttributes<T>>;
 declare global {


### PR DESCRIPTION
This implements [PT#184930324](https://www.pivotaltracker.com/story/show/184930324)
- The title field already implements readOnly
- This adds the functionality to the math-field itself
- The math-field element has a `readonly` property that we can set to match the component readonly prop 

_- Note: I set the math field `readonly` in an effect.  I did try to pass it directly in the `math-field` attribute, but found that did not work, even with a function inline.  (I think because either updates were stale because the underlying object is a ref and/or the presence of the readonly property, though its value was undefined, was evaluating as "truthy"_