### PR TITLE
feat: add global appConfig to MST environment

### DIFF
--- a/cms/src/preview-link-control.tsx
+++ b/cms/src/preview-link-control.tsx
@@ -4,7 +4,7 @@ import { CmsWidgetControlProps } from "netlify-cms-core";
 import { defaultCurriculumBranch } from "./cms-constants";
 import { urlParams } from "../../src/utilities/url-params";
 import { getGuideJson, getUnitJson } from "../../src/models/curriculum/unit";
-import { appConfig } from "../../src/initialize-app";
+import { gAppConfig } from "../../src/global-app-config";
 import { DocumentModelType } from "../../src/models/document/document";
 
 import "./custom-control.scss";
@@ -28,7 +28,7 @@ export class PreviewLinkControl extends React.Component<CmsWidgetControlProps, I
   isTeacherGuide?: boolean;
   pathParts?: string[];
   unit?: string;
-  
+
   constructor(props: CmsWidgetControlProps) {
     super(props);
 
@@ -50,9 +50,9 @@ export class PreviewLinkControl extends React.Component<CmsWidgetControlProps, I
     // Finish setting up the preview link after reading the unit json
     this.isTeacherGuide = this.pathParts?.[2] === "teacher-guide";
     if (this.isTeacherGuide) {
-      getGuideJson(this.unit, appConfig).then((unitJson: DocumentModelType) => this.setPreviewLink(unitJson));
+      getGuideJson(this.unit, gAppConfig).then((unitJson: DocumentModelType) => this.setPreviewLink(unitJson));
     } else {
-      getUnitJson(this.unit, appConfig).then((unitJson: DocumentModelType) => this.setPreviewLink(unitJson));
+      getUnitJson(this.unit, gAppConfig).then((unitJson: DocumentModelType) => this.setPreviewLink(unitJson));
     }
 
     this.state = {

--- a/src/cms/document-editor.tsx
+++ b/src/cms/document-editor.tsx
@@ -3,7 +3,8 @@ import { IDisposer, onSnapshot } from "mobx-state-tree";
 import { Map } from "immutable";
 
 import { defaultDocumentModelParts } from "../components/doc-editor-app-defaults";
-import { appConfig, AppProvider, initializeApp } from "../initialize-app";
+import { gAppConfig } from "../global-app-config";
+import { AppProvider, initializeApp } from "../initialize-app";
 import { IStores } from "../models/stores/stores";
 import { createDocumentModel, DocumentModelType } from "../models/document/document";
 import { DEBUG_CMS } from "../lib/debug";
@@ -102,7 +103,7 @@ export class DocumentEditor extends React.Component<IProps, IState>  {
             isPrimary={true}
             readOnly={false}
             document={document}
-            toolbar={appConfig.authorToolbar}
+            toolbar={gAppConfig.authorToolbar}
           />
         </AppProvider>
       );

--- a/src/doc-editor.tsx
+++ b/src/doc-editor.tsx
@@ -1,15 +1,15 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import { DocEditorApp } from "./components/doc-editor-app";
-
-import { appConfig, AppProvider, initializeApp } from "./initialize-app";
+import { gAppConfig } from "./global-app-config";
+import { AppProvider, initializeApp } from "./initialize-app";
 
 (window as any).DISABLE_FIREBASE_SYNC = true;
 
 initializeApp("dev", true).then((stores) => {
   ReactDOM.render(
     <AppProvider stores={stores} modalAppElement="#app">
-      <DocEditorApp appConfig={appConfig}/>
+      <DocEditorApp appConfig={gAppConfig}/>
     </AppProvider>,
     document.getElementById("app")
   );

--- a/src/global-app-config.ts
+++ b/src/global-app-config.ts
@@ -1,0 +1,8 @@
+import { appConfigSnapshot } from "./app-config";
+import { AppConfigModel } from "./models/stores/app-config-model";
+
+/*
+ * The global appConfig is added to the stores in initializeApp() and to the
+ * MST environment in createDocumentModel().
+ */
+export const gAppConfig = AppConfigModel.create(appConfigSnapshot);

--- a/src/initialize-app.tsx
+++ b/src/initialize-app.tsx
@@ -11,7 +11,7 @@ import { AppMode } from "./models/stores/store-types";
 import { Logger } from "./lib/logger";
 import { appConfigSnapshot, appIcons, createStores } from "./app-config";
 import { AppConfigContext } from "./app-config-context";
-import { AppConfigModel } from "./models/stores/app-config-model";
+import { gAppConfig } from "./global-app-config";
 import { IStores, setUnitAndProblem } from "./models/stores/stores";
 import { UserModel } from "./models/stores/user";
 import { urlParams } from "./utilities/url-params";
@@ -23,8 +23,6 @@ import "./index.scss";
 
 // set to true to enable MST liveliness checking
 const kEnableLivelinessChecking = false;
-
-export const appConfig = AppConfigModel.create(appConfigSnapshot);
 
 /**
  * This function is used by the 3 different entry points supported
@@ -44,6 +42,7 @@ export const initializeApp = async (appMode: AppMode, authoring?: boolean): Prom
 
   const user = UserModel.create();
 
+  const appConfig = gAppConfig;
   const unitId = urlParams.unit || appConfigSnapshot.defaultUnit;
   const problemOrdinal = urlParams.problem || appConfigSnapshot.config.defaultProblemOrdinal;
   const showDemoCreator = urlParams.demo;

--- a/src/models/document/document.ts
+++ b/src/models/document/document.ts
@@ -9,6 +9,7 @@ import {
   LearningLogDocument, LearningLogPublication, PersonalDocument, PersonalPublication,
   PlanningDocument, ProblemDocument, ProblemPublication, SupportPublication
 } from "./document-types";
+import { gAppConfig } from "../../global-app-config";
 import { AppConfigModelType } from "../stores/app-config-model";
 import { TileCommentsModel, TileCommentsModelType } from "../tiles/tile-comments";
 import { UserStarModel, UserStarModelType } from "../tiles/user-star";
@@ -347,6 +348,7 @@ export const getDocumentContext = (document: DocumentModelType): IDocumentContex
 
 /**
  * Create a DocumentModel and add a new sharedModelManager into its environment
+ * TODO: move this function into its own module
  *
  * @param snapshot
  * @returns
@@ -354,6 +356,7 @@ export const getDocumentContext = (document: DocumentModelType): IDocumentContex
 export const createDocumentModel = (snapshot?: DocumentModelSnapshotType) => {
   const sharedModelManager = new SharedModelDocumentManager();
   const fullEnvironment: ITileEnvironment & {documentEnv: IDocumentEnvironment} = {
+    appConfig: gAppConfig,
     sharedModelManager,
     documentEnv: {}
   };

--- a/src/models/tiles/tile-content.ts
+++ b/src/models/tiles/tile-content.ts
@@ -1,10 +1,12 @@
 import { getEnv, getSnapshot, Instance, types } from "mobx-state-tree";
 import { SharedModelType } from "../shared/shared-model";
 import { ISharedModelManager, SharedModelChangeType } from "../shared/shared-model-manager";
+import { AppConfigModelType } from "../stores/app-config-model";
 import { tileModelHooks } from "./tile-model-hooks";
 import { kUnknownTileType } from "./unknown-types";
 
 export interface ITileEnvironment {
+  appConfig?: AppConfigModelType;
   sharedModelManager?: ISharedModelManager;
 }
 


### PR DESCRIPTION
In @emcelroy's work to port the CODAP graph into CLUE we have encountered the need to configure the behavior of the graph to accommodate the differing requirement of CLUE and CODAP. The natural place to handle such configuration is via the `AppConfigModel`. This works great for React components and other entities that have ready access to the `AppConfigModel` via the stores, but some MST models whose behavior should be configurable do not have such ready access. This PR addresses this by making the `AppConfigModel` available via the MST environment.