### PR TITLE
185182713 expression focus synced with other tiles

### DIFF
--- a/cypress/e2e/clue/branch/student_tests/expression_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/expression_tool_spec.js
@@ -58,5 +58,9 @@ context('Expression Tool Tile', function () {
       clueCanvas.addTile("expression");
       cy.contains("(Eq. 2)").should("exist");
     });
+    it("should become the active tile when equation is clicked", () => {
+      exp.getMathField().eq(1).click({force: true});
+      exp.getExpressionTile().eq(1).should("have.class", "selected");
+    });
   });
 });

--- a/cypress/e2e/clue/branch/student_tests/expression_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/expression_tool_spec.js
@@ -61,6 +61,7 @@ context('Expression Tool Tile', function () {
     it("should become the active tile when equation is clicked", () => {
       exp.getMathField().eq(1).click({force: true});
       exp.getExpressionTile().eq(1).should("have.class", "selected");
+      exp.getExpressionTile().eq(0).should("not.have.class", "selected");
     });
   });
 });

--- a/src/plugins/expression/expression-tile.test.tsx
+++ b/src/plugins/expression/expression-tile.test.tsx
@@ -12,6 +12,12 @@ jest.mock("../../models/tiles/log/log-tile-document-event", () => ({
   logTileDocumentEvent: (...args: any[]) => mockLogTileDocumentEvent()
 }));
 
+jest.mock("../../hooks/use-stores", () => ({
+  useUIStore: () => ({
+    selectedTileIds: []
+  })
+}));
+
 describe("ExpressionToolComponent", () => {
   const content = defaultExpressionContent();
   const model = TileModel.create({content});

--- a/src/plugins/expression/expression-tile.tsx
+++ b/src/plugins/expression/expression-tile.tsx
@@ -24,7 +24,14 @@ const undoKeys = ["cmd+z", "[Undo]", "ctrl+z"];
 export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) => {
   const content = props.model.content as ExpressionContentModelType;
   const mf = useRef<MathfieldElement>(null);
+  const toolRef = useRef<HTMLDivElement>(null);
   const trackedCursorPos = useRef<number>(0);
+
+  if(mf.current) {
+    mf.current.addEventListener("click", (e: any) => {
+      console.log("| click!", e, toolRef.current);
+    });
+  }
 
   if (mf.current?.keybindings){
     undoKeys.forEach((key: string) => {
@@ -48,7 +55,7 @@ export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) =>
   };
 
   return (
-    <div className="expression-tool">
+    <div className="expression-tool" ref={toolRef} onClick={() => console.log("| tool got the click!")}>
       <div className="expression-title-area">
         <CustomEditableTileTitle
           model={props.model}

--- a/src/plugins/expression/expression-tile.tsx
+++ b/src/plugins/expression/expression-tile.tsx
@@ -28,11 +28,8 @@ export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) =>
   const trackedCursorPos = useRef<number>(0);
   const ui = useUIStore();
 
-  if(mf.current) {
-    mf.current.addEventListener("focus", (e: any) => {
-      ui.clearSelectedTiles();
-      ui.setSelectedTileId(props.model.id);
-    });
+  if(mf.current && ui) {
+    mf.current.addEventListener("focus", () => ui.setSelectedTileId(props.model.id));
   }
 
   if (mf.current?.keybindings){

--- a/src/plugins/expression/expression-tile.tsx
+++ b/src/plugins/expression/expression-tile.tsx
@@ -29,7 +29,13 @@ export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) =>
 
   if(mf.current) {
     mf.current.addEventListener("click", (e: any) => {
-      console.log("| click!", e, toolRef.current);
+      console.log("| 👤 shadow click!", e);
+      // Each of 3 methods below works to trigger click that is registered
+      // by toolRef and body, but does not affect other tile toolbar as normal clicks do
+      // 1 document.body.click();
+      // 2 toolRef.current?.click();
+      // 3 const mockClick = new Event("click", {bubbles: true, cancelable: true, composed: true});
+      //   toolRef.current?.dispatchEvent(mockClick);
     });
   }
 
@@ -55,7 +61,7 @@ export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) =>
   };
 
   return (
-    <div className="expression-tool" ref={toolRef} onClick={() => console.log("| tool got the click!")}>
+    <div className="expression-tool" ref={toolRef} onClick={() => console.log("| 🔨 toolRef click!")}>
       <div className="expression-title-area">
         <CustomEditableTileTitle
           model={props.model}

--- a/src/plugins/expression/expression-tile.tsx
+++ b/src/plugins/expression/expression-tile.tsx
@@ -8,6 +8,7 @@ import { ITileProps } from "../../components/tiles/tile-component";
 import { ExpressionContentModelType } from "./expression-content";
 import { CustomEditableTileTitle } from "../../components/tiles/custom-editable-tile-title";
 import { replaceKeyBinding } from "./expression-tile-utils";
+import { useUIStore } from "../../hooks/use-stores";
 import "./expression-tile.scss";
 
 type CustomElement<T> = Partial<T & DOMAttributes<T>>;
@@ -24,18 +25,13 @@ const undoKeys = ["cmd+z", "[Undo]", "ctrl+z"];
 export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) => {
   const content = props.model.content as ExpressionContentModelType;
   const mf = useRef<MathfieldElement>(null);
-  const toolRef = useRef<HTMLDivElement>(null);
   const trackedCursorPos = useRef<number>(0);
+  const ui = useUIStore();
 
   if(mf.current) {
-    mf.current.addEventListener("click", (e: any) => {
-      console.log("| 👤 shadow click!", e);
-      // Each of 3 methods below works to trigger click that is registered
-      // by toolRef and body, but does not affect other tile toolbar as normal clicks do
-      // 1 document.body.click();
-      // 2 toolRef.current?.click();
-      // 3 const mockClick = new Event("click", {bubbles: true, cancelable: true, composed: true});
-      //   toolRef.current?.dispatchEvent(mockClick);
+    mf.current.addEventListener("focus", (e: any) => {
+      ui.clearSelectedTiles();
+      ui.setSelectedTileId(props.model.id);
     });
   }
 
@@ -61,7 +57,7 @@ export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) =>
   };
 
   return (
-    <div className="expression-tool" ref={toolRef} onClick={() => console.log("| 🔨 toolRef click!")}>
+    <div className="expression-tool">
       <div className="expression-title-area">
         <CustomEditableTileTitle
           model={props.model}


### PR DESCRIPTION
Functionality described in [PT#185182713]:(https://www.pivotaltracker.com/n/projects/2441242/stories/185182713)

- Since clicks on the equation editor itself do not propagate past the boundary of the shadow dom, we have to explicitly set the expression tile as the active tile in the ui store
- This is not necessary for clicks within the expression tile that are not within the boundaries of the shadow dom
- _Note: the failing cy test is the one that I believe is expected to fail at the moment_