### PR TITLE
convert dataset values to strings

### DIFF
--- a/src/plugins/data-card/components/sort-area.tsx
+++ b/src/plugins/data-card/components/sort-area.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import { getSnapshot } from "mobx-state-tree";
 import { uniq, orderBy } from "lodash";
 import { ITileModel } from "../../../models/tiles/tile-model";
 import { DataCardContentModelType } from "../data-card-content";
@@ -16,11 +15,14 @@ export const DataCardSortArea: React.FC<IProps> = ({ model }) => {
   const content = model.content as DataCardContentModelType;
   const sortById = content.selectedSortAttributeId;
 
-  const attrsSnap = getSnapshot(content.attributes);
-  const allAttrValues = attrsSnap.filter((a) => a.id === sortById)[0].values;
+  const attribute = sortById ? content.dataSet.attrFromID(sortById) : undefined;
+  const allAttrValues = attribute?.strValues || [];
   const uniqueOrderedValues = orderBy(uniq(allAttrValues));
-  // if one of the categories is a category for no value, put this stack last
-  uniqueOrderedValues.includes("") && uniqueOrderedValues.push(uniqueOrderedValues.shift());
+  // orderBy will put "" first, we want it last
+  if (uniqueOrderedValues[0] === "") {
+    uniqueOrderedValues.shift();
+    uniqueOrderedValues.push("");
+  }
 
   const [sortDragActive, setSortDragActive] = useState(false);
 
@@ -58,7 +60,7 @@ export const DataCardSortArea: React.FC<IProps> = ({ model }) => {
               key={`${sortById}-${value}`}
               id={`${sortById}-${value}`}
               model={model}
-              stackValue={value as string}
+              stackValue={value}
               inAttributeId={sortById}
               draggingActive={sortDragActive}
             />

--- a/src/plugins/data-card/components/sort-card-attribute.tsx
+++ b/src/plugins/data-card/components/sort-card-attribute.tsx
@@ -13,7 +13,7 @@ interface IProps {
 export const SortCardAttribute: React.FC<IProps> = ({ model, caseId, attr }) => {
   const content = model.content as DataCardContentModelType;
   const attrName = content.dataSet.attrFromID(attr.id).name;
-  const value = content.dataSet.getValue(caseId, attr.id) as string;
+  const value = content.dataSet.getStrValue(caseId, attr.id);
   const isImage = gImageMap.isImageUrl(value);
   const [imageUrl, setImageUrl] = useState("");
 


### PR DESCRIPTION
This fixes a crash reported in this story: https://www.pivotaltracker.com/story/show/184376222

However the error looks like it has been there a little while before. I suspect it is because merging datasets resulted in undefined values which then cause the problem. According to the dataset typing undefined values are valid so this change seems the best way to handle things.