### PR TITLE
fix: XYPlot - Link Table to XYPlot (PT-184667373)

### DIFF
--- a/src/models/document/shared-model-document-manager.ts
+++ b/src/models/document/shared-model-document-manager.ts
@@ -4,6 +4,7 @@ import { DocumentContentModelType } from "./document-content";
 import { SharedModelType } from "../shared/shared-model";
 import { IDragSharedModelItem, ISharedModelManager, SharedModelUnion } from "../shared/shared-model-manager";
 import { ITileModel, TileModel } from "../tiles/tile-model";
+import { isTileLinkedToOtherDataSet, unlinkTileFromDataSets } from "../../utilities/shared-data-utils";
 
 function getTileModel(tileContentModel: IAnyStateTreeNode) {
   if (!hasParentOfType(tileContentModel, TileModel)) {
@@ -120,6 +121,22 @@ export class SharedModelDocumentManager implements ISharedModelDocumentManager {
       return;
     }
 
+    // If the tile is of type Graph, remove it from any shared data sets it's already linked
+    // to before linking it to a new data set. We're checking the sharedModel's type property
+    // instead of using isSharedDataSet because we don't want to introduce a dependency on the
+    // data set types here. We should ultimately make this behavior configurable from outside
+    // the SharedModelDocumentManager to eliminate this issue.
+    if (tileContentModel.type === "Graph" && sharedModel.type === "SharedDataSet") {
+      // Related to the comment above, although we know the type of sharedModel is
+      // SharedDataSetType, TypeScript will throw an error if we try to access the dataSet
+      // property on it without first using isSharedDataSet to check the type. So we cast 
+      // sharedModel to any (again we don't want to introduce the data set types here).
+      const sm = sharedModel as any;
+      if (isTileLinkedToOtherDataSet(tileContentModel, sm.dataSet)) {
+        unlinkTileFromDataSets(tileContentModel);
+      }
+    }
+
     // assign an indexOfType if necessary
     this.assignIndexOfType(sharedModel);
 
@@ -193,6 +210,7 @@ export class SharedModelDocumentManager implements ISharedModelDocumentManager {
   }
 
   removeTileSharedModel(tileContentModel: IAnyStateTreeNode, sharedModel: SharedModelType): void {
+    console.log("removeTileSharedModel", tileContentModel, sharedModel);
     if (!this.document) {
       console.warn("removeTileSharedModel has no document");
       return;

--- a/src/models/document/shared-model-document-manager.ts
+++ b/src/models/document/shared-model-document-manager.ts
@@ -210,7 +210,6 @@ export class SharedModelDocumentManager implements ISharedModelDocumentManager {
   }
 
   removeTileSharedModel(tileContentModel: IAnyStateTreeNode, sharedModel: SharedModelType): void {
-    console.log("removeTileSharedModel", tileContentModel, sharedModel);
     if (!this.document) {
       console.warn("removeTileSharedModel has no document");
       return;

--- a/src/plugins/graph/components/graph-wrapper-component.tsx
+++ b/src/plugins/graph/components/graph-wrapper-component.tsx
@@ -29,12 +29,16 @@ export const GraphWrapperComponent: React.FC<ITileProps> = (props) => {
   const content = model.content as IGraphModel;
   const toolbarProps = useToolbarTileApi({ id: model.id, enabled, onRegisterTileApi, onUnregisterTileApi });
 
-  const handleTileLinkRequest = (tableId: string) => {
+  const handleTileLinkRequest = (tileId: string) => {
     if (enabled) {
       const consumerTile = getTileContentById(model.content, model.id);
       const sharedModelManager = getSharedModelManager(model);
       if (sharedModelManager?.isReady) {
-        const providerDataSet = sharedModelManager?.findFirstSharedModelByType(SharedDataSet, tableId);
+        const existingConsumerDataset = sharedModelManager.findFirstSharedModelByType(SharedDataSet);
+        if (existingConsumerDataset) {
+          sharedModelManager.removeTileSharedModel(consumerTile, existingConsumerDataset);
+        }
+        const providerDataSet = sharedModelManager?.findFirstSharedModelByType(SharedDataSet, tileId);
         providerDataSet && sharedModelManager?.addTileSharedModel(consumerTile, providerDataSet);
       }
     }

--- a/src/plugins/graph/components/graph-wrapper-component.tsx
+++ b/src/plugins/graph/components/graph-wrapper-component.tsx
@@ -14,8 +14,9 @@ import { useToolbarTileApi } from "../../../components/tiles/hooks/use-toolbar-t
 import { GraphToolbar } from "./graph-toolbar";
 import { useProviderTileLinking } from "../../../hooks/use-provider-tile-linking";
 import { getTileContentById } from "../../../utilities/mst-utils";
-import { SharedDataSet } from "../../../models/shared/shared-data-set";
+import { isSharedDataSet, SharedDataSet } from "../../../models/shared/shared-data-set";
 import { getSharedModelManager } from "../../../models/tiles/tile-environment";
+import { getTileSharedModels } from "../../../utilities/shared-data-utils";
 
 import "./graph-wrapper-component.scss";
 
@@ -34,7 +35,7 @@ export const GraphWrapperComponent: React.FC<ITileProps> = (props) => {
       const consumerTile = getTileContentById(model.content, model.id);
       const sharedModelManager = getSharedModelManager(model);
       if (sharedModelManager?.isReady) {
-        const existingConsumerDataset = sharedModelManager.findFirstSharedModelByType(SharedDataSet);
+        const existingConsumerDataset = getTileSharedModels(model).find(m => isSharedDataSet(m));
         if (existingConsumerDataset) {
           sharedModelManager.removeTileSharedModel(consumerTile, existingConsumerDataset);
         }

--- a/src/plugins/graph/graph-registration.ts
+++ b/src/plugins/graph/graph-registration.ts
@@ -7,7 +7,7 @@ import { createGraphModel, GraphModel } from "./models/graph-model";
 import GraphToolIcon from "./graph-icon.svg";
 
 registerTileContentInfo({
-  defaultContent: () => createGraphModel(),
+  defaultContent: (options) => createGraphModel(undefined, options?.appConfig),
   defaultHeight: kGraphDefaultHeight,
   modelClass: GraphModel,
   titleBase: "X-Y Plot",

--- a/src/plugins/graph/models/graph-controller.ts
+++ b/src/plugins/graph/models/graph-controller.ts
@@ -8,7 +8,7 @@ import {
 import {axisPlaceToAttrRole, graphPlaceToAttrRole, IDotsRef, PlotType} from "../graph-types";
 import {GraphPlace} from "../axis-graph-shared";
 import {matchCirclesToData, setNiceDomain} from "../utilities/graph-utils";
-import { appConfig } from "../../../initialize-app";
+import { getAppConfig } from "../../../models/tiles/tile-environment";
 
 // keys are [primaryAxisType][secondaryAxisType]
 const plotChoices: Record<string, Record<string, PlotType>> = {
@@ -156,10 +156,8 @@ export class GraphController {
               graphModel.removeAxis(place);
             }
             else {
-              // TODO: Right now we're importing appConfig directly. It would be better if it
-              // were accessed through the MST environment, but that doesn't seem possible
-              // from here right
-              const emptyPlotIsNumeric = appConfig.getSetting("emptyPlotIsNumeric", "graph");
+              const appConfig = getAppConfig(graphModel);
+              const emptyPlotIsNumeric = appConfig?.getSetting("emptyPlotIsNumeric", "graph");
               const newAxisModel = emptyPlotIsNumeric
                                      ? NumericAxisModel.create({place, min: 0, max: 1})
                                      : EmptyAxisModel.create({place});

--- a/src/plugins/graph/models/graph-model.ts
+++ b/src/plugins/graph/models/graph-model.ts
@@ -22,7 +22,7 @@ import {
   kellyColors
 } from "../../../utilities/color-utils";
 import { SharedModelChangeType } from "../../../models/shared/shared-model-manager";
-import { appConfig } from "../../../initialize-app";
+import { AppConfigModelType } from "../../../models/stores/app-config-model";
 
 export type SharedModelChangeHandler = (sharedModel: SharedModelType | undefined, type: string) => void;
 
@@ -187,11 +187,8 @@ export const GraphModel = TileContentModel
 export interface IGraphModel extends Instance<typeof GraphModel> {}
 export interface IGraphModelSnapshot extends SnapshotIn<typeof GraphModel> {}
 
-export function createGraphModel(snap?: IGraphModelSnapshot) {
-  // TODO: Right now we're importing appConfig directly. It would be better if it
-  // were accessed through the MST environment, but that doesn't seem possible
-  // from here right now.
-  const emptyPlotIsNumeric = appConfig.getSetting("emptyPlotIsNumeric", "graph");
+export function createGraphModel(snap?: IGraphModelSnapshot, appConfig?: AppConfigModelType) {
+  const emptyPlotIsNumeric = appConfig?.getSetting("emptyPlotIsNumeric", "graph");
   const bottomAxisModel = emptyPlotIsNumeric
                             ? NumericAxisModel.create({place: "bottom", min: -10, max: 11})
                             : EmptyAxisModel.create({place: "bottom"});

--- a/src/utilities/shared-data-utils.ts
+++ b/src/utilities/shared-data-utils.ts
@@ -1,6 +1,12 @@
-import { SharedDataSet } from "../models/shared/shared-data-set";
+import { IDataSet } from "../models/data/data-set";
+import { isSharedDataSet, SharedDataSet } from "../models/shared/shared-data-set";
 import { getSharedModelManager } from "../models/tiles/tile-environment";
 import { ITileModel } from "../models/tiles/tile-model";
+
+export function getTileSharedModels(tile: ITileModel) {
+  const sharedModelManager = getSharedModelManager(tile);
+  return sharedModelManager?.getTileSharedModels(tile) ?? [];
+}
 
 export const isLinkedToTile = (model: ITileModel, tileId: string) => {
   const sharedModelManager = getSharedModelManager(model);
@@ -13,3 +19,18 @@ export const isLinkedToTile = (model: ITileModel, tileId: string) => {
   }
   return false;
 };
+
+export function isTileLinkedToOtherDataSet(tile: ITileModel, dataSet: IDataSet) {
+  const sharedModels = getTileSharedModels(tile);
+  return !!sharedModels.find(sharedModel => isSharedDataSet(sharedModel) && sharedModel.dataSet.id !== dataSet.id);
+}
+
+export function unlinkTileFromDataSets(tile: ITileModel) {
+  const sharedModelManager = getSharedModelManager(tile);
+  const sharedModels = sharedModelManager?.getTileSharedModels(tile);
+  sharedModels?.forEach(sharedModel => {
+    if (sharedModel.type === "SharedDataSet") {
+      sharedModelManager?.removeTileSharedModel(tile, sharedModel);
+    }
+  });
+}


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/184667373

These changes do two things:

1) Make it so Graph tiles can only be connected to one shared data set at a time. This fixes a bug where if you link a graph to a data provider, and then delete the data provider, the graph will continue to show the old data even if you try linking it to a new data provider.

2) Fix a small, unrelated issue where we were directly importing `appConfig` into the Graph model