### PR TITLE
add titles to geometry and data-card tiles

### DIFF
--- a/src/components/tiles/geometry/geometry-content.tsx
+++ b/src/components/tiles/geometry/geometry-content.tsx
@@ -272,6 +272,9 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
       },
       exportContentAsTileJson: (options?: ITileExportOptions) => {
         return this.getContent().exportJson(options);
+      },
+      getTitle: () => {
+        return this.props.model.title;
       }
     });
 

--- a/src/plugins/data-card/data-card-tile.tsx
+++ b/src/plugins/data-card/data-card-tile.tsx
@@ -45,6 +45,14 @@ export const DataCardToolComponent: React.FC<ITileProps> = observer((props) => {
     }
   }, [model, onRequestUniqueTitle]);
 
+  useEffect(() => {
+    onRegisterTileApi({
+      getTitle: () => {
+        return model.title;
+      }
+    });
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
   /* ==[ Drag and Drop ] == */
 
   const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {


### PR DESCRIPTION
The linking dialog is using these titles

We could almost get rid of this `getTitle` on the API, and replace it with a `tileModel.title`. But the table tile has logic to support an unset `tileModel.title`. If it isn't set then it uses its `dataset.name`. So this makes it look like the `getTitle` API is still required. 

However there are places that set the tileModel.title on tile creation even if it is table. So it is probably inconsistent when table tiles do and don't have tileModel.titles

Also, I looked around and there are a few places that are currently assuming `tileModel.tile` has the right title:
- getTileTitleForLogging
- makeChatThreads

An intermediate step would be to change DocumentContent#getTileTitle so it falls back to `tileModel.title` if the tile doesn't implement its own getTitle.  Then we could get rid of almost all of these getTitle implementations. At least until we can sort out the right thing to do with the table

Or if we think we need to support this dynamic titling of the table then we should add `computedTitle` view on tileModel that looks to see if its content has a title. If it does, then use that, otherwise use the title of the tileModel. This way the places above that need titles can use `computedTitle` and get the right thing. 