### PR TITLE
185231699 expression toolbar setup 2

### DIFF
--- a/cypress/e2e/clue/branch/student_tests/expression_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/expression_tool_spec.js
@@ -63,5 +63,18 @@ context('Expression Tool Tile', function () {
       exp.getExpressionTile().eq(1).should("have.class", "selected");
       exp.getExpressionTile().eq(0).should("not.have.class", "selected");
     });
+    it("should have a toggleable toolbar", () => {
+      exp.getExpressionToolbar().eq(1).should("be.visible");
+      exp.getExpressionToolbar().eq(0).should("not.be.visible");
+      exp.getMathField().eq(0).click({force: true});
+      exp.getExpressionToolbar().eq(0).should("be.visible");
+      exp.getExpressionToolbar().eq(1).should("not.be.visible");
+     // exp.getNthExpressionToolbar()
+      // exp.getNthExpressionToolbar(1).should("be.visible");
+      // exp.getNthExpressionToolbar(0).should("not.be.visible");
+      // exp.getMathField().eq(0).click({force: true});
+      // exp.getNthExpressionToolbar(0).should("be.visible");
+      // exp.getNthExpressionToolbar(1).should("not.be.visible");
+    });
   });
 });

--- a/cypress/e2e/clue/branch/student_tests/expression_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/expression_tool_spec.js
@@ -69,12 +69,12 @@ context('Expression Tool Tile', function () {
       exp.getMathField().eq(0).click({force: true});
       exp.getExpressionToolbar().eq(0).should("be.visible");
       exp.getExpressionToolbar().eq(1).should("not.be.visible");
-     // exp.getNthExpressionToolbar()
-      // exp.getNthExpressionToolbar(1).should("be.visible");
-      // exp.getNthExpressionToolbar(0).should("not.be.visible");
-      // exp.getMathField().eq(0).click({force: true});
-      // exp.getNthExpressionToolbar(0).should("be.visible");
-      // exp.getNthExpressionToolbar(1).should("not.be.visible");
+    });
+    it("delete expression button deletes the whole expression", () => {
+      exp.getMathField().eq(0).click({force: true});
+      exp.getDeleteExpressionButton().eq(0).click();
+      exp.getMathFieldMath().eq(0).should("not.contain.text");
+      exp.getMathField().should("not.have.value", "a=\\pi r^2");
     });
   });
 });

--- a/cypress/support/elements/clue/ExpressionToolTile.js
+++ b/cypress/support/elements/clue/ExpressionToolTile.js
@@ -11,9 +11,6 @@ class ExpressionToolTile {
   getExpressionTile = () => {
     return cy.get(tileSelector);
   };
-  getNthExpressionTile(nth) {
-    return cy.get(tileSelector).eq(nth - 1);
-  }
   getTileTitle = () => {
     return cy.get(`${tileSelector} .editable-title-text`);
   };
@@ -38,6 +35,9 @@ class ExpressionToolTile {
   getMathKeyboardToggle = () => {
     const mathFieldSelector = `${tileSelector} .expression-math-area math-field`;
     return cy.get(mathFieldSelector).shadow().find("div");
+  };
+  getExpressionToolbar = () => {
+    return cy.get(`.canvas-area .expression-toolbar`);
   };
 }
 

--- a/cypress/support/elements/clue/ExpressionToolTile.js
+++ b/cypress/support/elements/clue/ExpressionToolTile.js
@@ -39,6 +39,9 @@ class ExpressionToolTile {
   getExpressionToolbar = () => {
     return cy.get(`.canvas-area .expression-toolbar`);
   };
+  getDeleteExpressionButton = () => {
+    return cy.get(`.canvas-area .expression-toolbar .delete-expression`);
+  };
 }
 
 export default ExpressionToolTile;

--- a/src/plugins/expression/expression-buttons.scss
+++ b/src/plugins/expression/expression-buttons.scss
@@ -1,0 +1,14 @@
+@import "../../components/vars.sass";
+
+.expression-button {
+  display: flex;
+  &:hover {
+    background-color: $workspace-teal-light-5 !important;
+    border-radius: 0px 0px 2px 2px;
+  }
+
+  svg {
+    fill: white;
+    stroke: $workspace-teal-dark-1;
+  }
+}

--- a/src/plugins/expression/expression-buttons.tsx
+++ b/src/plugins/expression/expression-buttons.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { Tooltip } from "react-tippy";
+// icon assets are the ones developed for the table tile
+import DeleteSelectionIcon from "../../assets/icons/delete/delete-selection-icon.svg";
+import { useTooltipOptions } from "../../hooks/use-tooltip-options";
+
+import "./expression-buttons.scss";
+
+interface IconButtonProps {
+  className?: string;
+  onClick: (evt: React.MouseEvent) => void;
+}
+
+export const DeleteExpressionButton = (props: IconButtonProps) => {
+  const tooltipOptions = useTooltipOptions({
+    distance: 5,
+    offset: 5
+  });
+
+  return (
+    <Tooltip title="Delete Expression" {...tooltipOptions}>
+      <ExpressionButton {...props}>
+        <DeleteSelectionIcon />
+      </ExpressionButton>
+    </Tooltip>
+  );
+};
+
+const ExpressionButton: React.FC<IconButtonProps> = ({ children, className, ...others }) => {
+  return (
+    <div className={`expression-button ${className}`} {...others}>{children}</div>
+  );
+};

--- a/src/plugins/expression/expression-tile.scss
+++ b/src/plugins/expression/expression-tile.scss
@@ -4,33 +4,37 @@
 $expression-padding: 15px;
 $expression-title-width: 200px;
 
-.expression-tool {
-  width: 100%;
-  height: 100%;
-  text-align: left;
-  overflow: auto;
-  display:flex;
-  align-items: center;
-  border:1px solid silver;
+.expression-tool-tile {
+  .expression-tool {
+    width: 100%;
+    height: 100%;
+    text-align: left;
+    overflow: auto;
+    display:flex;
+    align-items: center;
+    border:1px solid silver;
 
-  .expression-title-area {
-    width:$expression-title-width;
-    justify-self: left;
-    padding:$expression-padding;
-    font-weight: bold;
+    .expression-title-area {
+      width:$expression-title-width;
+      justify-self: left;
+      padding:$expression-padding;
+      font-weight: bold;
 
-    div, input {
-      width:$expression-title-width - $expression-padding * 2;
+      div, input {
+        width:$expression-title-width - $expression-padding * 2;
+      }
+    }
+
+    math-field {
+      font-size:20px;
+      border-width: 0px;
+      border:1px solid silver;
+      padding:$expression-padding;
+    }
+
+    // https://cortexjs.io/mathlive/guides/virtual-keyboards/
+    math-field::part(virtual-keyboard-toggle) {
+      display: none;
     }
   }
-
-  math-field {
-    font-size:20px;
-    border-width: 0px;
-    padding:$expression-padding;
-  }
-}
-
-.readonly math-field {
-  outline:none;
 }

--- a/src/plugins/expression/expression-tile.test.tsx
+++ b/src/plugins/expression/expression-tile.test.tsx
@@ -43,7 +43,7 @@ describe("ExpressionToolComponent", () => {
       throw new Error("Function not implemented.");
     },
     onRegisterTileApi: (tileApi: ITileApi, facet?: string): void => {
-      throw new Error("Function not implemented.");
+      // throw new Error("Function not implemented.");
     },
     onUnregisterTileApi: (facet?: string): void => {
       throw new Error("Function not implemented.");

--- a/src/plugins/expression/expression-tile.tsx
+++ b/src/plugins/expression/expression-tile.tsx
@@ -9,8 +9,7 @@ import { ExpressionContentModelType } from "./expression-content";
 import { CustomEditableTileTitle } from "../../components/tiles/custom-editable-tile-title";
 import { replaceKeyBinding } from "./expression-tile-utils";
 import { useUIStore } from "../../hooks/use-stores";
-import { ITileApi } from "../../components/tiles/tile-api";
-// import { useToolbarTileApi } from "../../components/tiles/hooks/use-toolbar-tile-api";
+import { useToolbarTileApi } from "../../components/tiles/hooks/use-toolbar-tile-api";
 import { ExpressionToolbar } from "./expression-toolbar";
 
 import "./expression-tile.scss";
@@ -27,6 +26,7 @@ declare global {
 const undoKeys = ["cmd+z", "[Undo]", "ctrl+z"];
 
 export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) => {
+  const { onRegisterTileApi, onUnregisterTileApi } = props;
   const content = props.model.content as ExpressionContentModelType;
   const mf = useRef<MathfieldElement>(null);
   const trackedCursorPos = useRef<number>(0);
@@ -41,14 +41,6 @@ export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) =>
       mf.current && replaceKeyBinding(mf.current.keybindings, key, "");
     });
   }
-
-  const handleIsEnabled = () => {
-    if (ui) {
-      return ui.selectedTileIds.includes(props.model.id) && !props.readOnly;
-    } else {
-      return false;
-    }
-  };
 
   useEffect(() => {
     // when we change model via undo button, we need to update mathfield
@@ -65,8 +57,22 @@ export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) =>
     content.setLatexStr((e.target as any).value);
   };
 
+  const toolbarProps = useToolbarTileApi({
+    id: props.model.id,
+    enabled: !props.readOnly,
+    onRegisterTileApi,
+    onUnregisterTileApi
+  });
+
   return (
     <div className="expression-tool">
+      <ExpressionToolbar
+        model={props.model}
+        documentContent={props.documentContent}
+        tileElt={props.tileElt}
+        handleDeleteValue={() => console.log("| delete value!")}
+        {...toolbarProps}
+      />
       <div className="expression-title-area">
         <CustomEditableTileTitle
           model={props.model}
@@ -83,15 +89,6 @@ export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) =>
           readOnly={props.readOnly === true ? true : undefined}
         />
       </div>
-      <ExpressionToolbar
-        model={props.model}
-        documentContent={props.documentContent}
-        tileElt={props.tileElt}
-        handleDeleteValue={() => console.log("| delete value func should be passed down?")}
-        onIsEnabled={handleIsEnabled}
-        onRegisterTileApi={(tileApi: ITileApi) => console.log("| register tileApi", tileApi)}
-        onUnregisterTileApi={() => console.log("| unregister tileApi")}
-      />
     </div>
   );
 });

--- a/src/plugins/expression/expression-tile.tsx
+++ b/src/plugins/expression/expression-tile.tsx
@@ -57,10 +57,6 @@ export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) =>
     content.setLatexStr((e.target as any).value);
   };
 
-  const deleteValue = () => {
-    content.setLatexStr("");
-  };
-
   const toolbarProps = useToolbarTileApi({
     id: props.model.id,
     enabled: !props.readOnly,
@@ -74,7 +70,6 @@ export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) =>
         model={props.model}
         documentContent={props.documentContent}
         tileElt={props.tileElt}
-        handleDeleteValue={deleteValue}
         {...toolbarProps}
       />
       <div className="expression-title-area">

--- a/src/plugins/expression/expression-tile.tsx
+++ b/src/plugins/expression/expression-tile.tsx
@@ -71,6 +71,7 @@ export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) =>
         documentContent={props.documentContent}
         tileElt={props.tileElt}
         {...toolbarProps}
+        mf={mf}
       />
       <div className="expression-title-area">
         <CustomEditableTileTitle

--- a/src/plugins/expression/expression-tile.tsx
+++ b/src/plugins/expression/expression-tile.tsx
@@ -57,6 +57,10 @@ export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) =>
     content.setLatexStr((e.target as any).value);
   };
 
+  const deleteValue = () => {
+    content.setLatexStr("");
+  };
+
   const toolbarProps = useToolbarTileApi({
     id: props.model.id,
     enabled: !props.readOnly,
@@ -70,7 +74,7 @@ export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) =>
         model={props.model}
         documentContent={props.documentContent}
         tileElt={props.tileElt}
-        handleDeleteValue={() => console.log("| delete value!")}
+        handleDeleteValue={deleteValue}
         {...toolbarProps}
       />
       <div className="expression-title-area">

--- a/src/plugins/expression/expression-tile.tsx
+++ b/src/plugins/expression/expression-tile.tsx
@@ -9,6 +9,10 @@ import { ExpressionContentModelType } from "./expression-content";
 import { CustomEditableTileTitle } from "../../components/tiles/custom-editable-tile-title";
 import { replaceKeyBinding } from "./expression-tile-utils";
 import { useUIStore } from "../../hooks/use-stores";
+import { ITileApi } from "../../components/tiles/tile-api";
+// import { useToolbarTileApi } from "../../components/tiles/hooks/use-toolbar-tile-api";
+import { ExpressionToolbar } from "./expression-toolbar";
+
 import "./expression-tile.scss";
 
 type CustomElement<T> = Partial<T & DOMAttributes<T>>;
@@ -37,6 +41,14 @@ export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) =>
       mf.current && replaceKeyBinding(mf.current.keybindings, key, "");
     });
   }
+
+  const handleIsEnabled = () => {
+    if (ui) {
+      return ui.selectedTileIds.includes(props.model.id);
+    } else {
+      return false;
+    }
+  };
 
   useEffect(() => {
     // when we change model via undo button, we need to update mathfield
@@ -71,6 +83,15 @@ export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) =>
           readOnly={props.readOnly === true ? true : undefined}
         />
       </div>
+      <ExpressionToolbar
+        model={props.model}
+        documentContent={props.documentContent}
+        tileElt={props.tileElt}
+        handleDeleteValue={() => console.log("| delete value func should be passed down?")}
+        onIsEnabled={handleIsEnabled}
+        onRegisterTileApi={(tileApi: ITileApi) => console.log("| register tileApi", tileApi)}
+        onUnregisterTileApi={() => console.log("| unregister tileApi")}
+      />
     </div>
   );
 });

--- a/src/plugins/expression/expression-tile.tsx
+++ b/src/plugins/expression/expression-tile.tsx
@@ -44,7 +44,7 @@ export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) =>
 
   const handleIsEnabled = () => {
     if (ui) {
-      return ui.selectedTileIds.includes(props.model.id);
+      return ui.selectedTileIds.includes(props.model.id) && !props.readOnly;
     } else {
       return false;
     }

--- a/src/plugins/expression/expression-toolbar.scss
+++ b/src/plugins/expression/expression-toolbar.scss
@@ -1,13 +1,12 @@
 @import "../../components/vars.sass";
 
 .expression-toolbar {
-  padding: 5px;
   position: absolute;
-  display:flex;
   border: $toolbar-border;
   border-radius: 0 0 $toolbar-border-radius $toolbar-border-radius;
   z-index: $toolbar-z-index;
   background-color: $workspace-teal-light-9;
+  display:flex;
   &.disabled {
     display:none;
   }

--- a/src/plugins/expression/expression-toolbar.scss
+++ b/src/plugins/expression/expression-toolbar.scss
@@ -2,6 +2,8 @@
 
 .expression-toolbar {
   position: absolute;
+  display:flex;
+  border: $toolbar-border;
   &.disabled {
     display:none;
   }

--- a/src/plugins/expression/expression-toolbar.scss
+++ b/src/plugins/expression/expression-toolbar.scss
@@ -1,9 +1,13 @@
 @import "../../components/vars.sass";
 
 .expression-toolbar {
+  padding: 5px;
   position: absolute;
   display:flex;
   border: $toolbar-border;
+  border-radius: 0 0 $toolbar-border-radius $toolbar-border-radius;
+  z-index: $toolbar-z-index;
+  background-color: $workspace-teal-light-9;
   &.disabled {
     display:none;
   }

--- a/src/plugins/expression/expression-toolbar.scss
+++ b/src/plugins/expression/expression-toolbar.scss
@@ -1,0 +1,8 @@
+@import "../../components/vars.sass";
+
+.expression-toolbar {
+  position: absolute;
+  &.disabled {
+    display:none;
+  }
+}

--- a/src/plugins/expression/expression-toolbar.tsx
+++ b/src/plugins/expression/expression-toolbar.tsx
@@ -12,11 +12,10 @@ import "./expression-toolbar.scss";
 
 interface IProps extends IFloatingToolbarProps {
   model: ITileModel;
-  handleDeleteValue: () => void;
 }
 
 export const ExpressionToolbar: React.FC<IProps> = observer((
-  {model, documentContent, tileElt, onIsEnabled, handleDeleteValue, ...others}: IProps) => {
+  {model, documentContent, tileElt, onIsEnabled, ...others}: IProps) => {
     const content = model.content as ExpressionContentModelType;
     const enabled = onIsEnabled();
 
@@ -34,11 +33,15 @@ export const ExpressionToolbar: React.FC<IProps> = observer((
     enabled && location ? "enabled" : "disabled",
   );
 
+  const deleteValue = () => {
+    content.setLatexStr("");
+  };
+
   return documentContent
     ? ReactDOM.createPortal(
       <div className={toolbarClasses} style={location}>
         <div className="toolbar-content">TOOLBAR</div>
-        <button onClick={handleDeleteValue}>Delete</button>
+        <button onClick={deleteValue}>Delete</button>
       </div>, documentContent)
   : null;
 });

--- a/src/plugins/expression/expression-toolbar.tsx
+++ b/src/plugins/expression/expression-toolbar.tsx
@@ -9,6 +9,7 @@ import { ExpressionContentModelType } from "./expression-content";
 import { ITileModel } from "../../models/tiles/tile-model";
 
 import "./expression-toolbar.scss";
+import { DeleteExpressionButton } from "./expression-buttons";
 
 interface IProps extends IFloatingToolbarProps {
   model: ITileModel;
@@ -34,6 +35,11 @@ export const ExpressionToolbar: React.FC<IProps> = observer((
     enabled && location ? "enabled" : "disabled",
   );
 
+  const deleteButtonClasses = classNames(
+    "delete-expression",
+    enabled ? "enabled" : "disabled",
+  );
+
   const deleteExpression = () => {
     content.setLatexStr("");
     mf.current.focus();
@@ -43,7 +49,7 @@ export const ExpressionToolbar: React.FC<IProps> = observer((
     ? ReactDOM.createPortal(
       <div className={toolbarClasses} style={location}>
         <div className="toolbar-content">
-          <button onClick={deleteExpression}>❌</button>
+          <DeleteExpressionButton onClick={deleteExpression} className={deleteButtonClasses} />
         </div>
       </div>, documentContent)
   : null;

--- a/src/plugins/expression/expression-toolbar.tsx
+++ b/src/plugins/expression/expression-toolbar.tsx
@@ -5,7 +5,7 @@ import ReactDOM from "react-dom";
 import {
   IFloatingToolbarProps, useFloatingToolbarLocation
 } from "../../components/tiles/hooks/use-floating-toolbar-location";
-//import { ExpressionContentModelType } from "./expression-content";
+import { ExpressionContentModelType } from "./expression-content";
 import { ITileModel } from "../../models/tiles/tile-model";
 
 import "./expression-toolbar.scss";
@@ -17,13 +17,13 @@ interface IProps extends IFloatingToolbarProps {
 
 export const ExpressionToolbar: React.FC<IProps> = observer((
   {model, documentContent, tileElt, onIsEnabled, ...others}: IProps) => {
-    // const content = model.content as ExpressionContentModelType;
+    const content = model.content as ExpressionContentModelType;
     const enabled = onIsEnabled();
 
     const location = useFloatingToolbarLocation({
       documentContent,
       tileElt,
-      toolbarHeight: 24,
+      toolbarHeight: 14,
       toolbarTopOffset: 2,
       enabled,
       ...others

--- a/src/plugins/expression/expression-toolbar.tsx
+++ b/src/plugins/expression/expression-toolbar.tsx
@@ -16,7 +16,7 @@ interface IProps extends IFloatingToolbarProps {
 }
 
 export const ExpressionToolbar: React.FC<IProps> = observer((
-  {model, documentContent, tileElt, onIsEnabled, ...others}: IProps) => {
+  {model, documentContent, tileElt, onIsEnabled, handleDeleteValue, ...others}: IProps) => {
     const content = model.content as ExpressionContentModelType;
     const enabled = onIsEnabled();
 
@@ -38,6 +38,7 @@ export const ExpressionToolbar: React.FC<IProps> = observer((
     ? ReactDOM.createPortal(
       <div className={toolbarClasses} style={location}>
         <div className="toolbar-content">TOOLBAR</div>
+        <button onClick={handleDeleteValue}>Delete</button>
       </div>, documentContent)
   : null;
 });

--- a/src/plugins/expression/expression-toolbar.tsx
+++ b/src/plugins/expression/expression-toolbar.tsx
@@ -12,10 +12,11 @@ import "./expression-toolbar.scss";
 
 interface IProps extends IFloatingToolbarProps {
   model: ITileModel;
+  mf: any;
 }
 
 export const ExpressionToolbar: React.FC<IProps> = observer((
-  {model, documentContent, tileElt, onIsEnabled, ...others}: IProps) => {
+  {model, documentContent, mf, tileElt, onIsEnabled, ...others}: IProps) => {
     const content = model.content as ExpressionContentModelType;
     const enabled = onIsEnabled();
 
@@ -33,15 +34,17 @@ export const ExpressionToolbar: React.FC<IProps> = observer((
     enabled && location ? "enabled" : "disabled",
   );
 
-  const deleteValue = () => {
+  const deleteExpression = () => {
     content.setLatexStr("");
+    mf.current.focus();
   };
 
   return documentContent
     ? ReactDOM.createPortal(
       <div className={toolbarClasses} style={location}>
-        <div className="toolbar-content">TOOLBAR</div>
-        <button onClick={deleteValue}>Delete</button>
+        <div className="toolbar-content">
+          <button onClick={deleteExpression}>❌</button>
+        </div>
       </div>, documentContent)
   : null;
 });

--- a/src/plugins/expression/expression-toolbar.tsx
+++ b/src/plugins/expression/expression-toolbar.tsx
@@ -1,0 +1,43 @@
+import { observer } from "mobx-react";
+import classNames from "classnames";
+import React from "react";
+import ReactDOM from "react-dom";
+import {
+  IFloatingToolbarProps, useFloatingToolbarLocation
+} from "../../components/tiles/hooks/use-floating-toolbar-location";
+//import { ExpressionContentModelType } from "./expression-content";
+import { ITileModel } from "../../models/tiles/tile-model";
+
+import "./expression-toolbar.scss";
+
+interface IProps extends IFloatingToolbarProps {
+  model: ITileModel;
+  handleDeleteValue: () => void;
+}
+
+export const ExpressionToolbar: React.FC<IProps> = observer((
+  {model, documentContent, tileElt, onIsEnabled, ...others}: IProps) => {
+    // const content = model.content as ExpressionContentModelType;
+    const enabled = onIsEnabled();
+
+    const location = useFloatingToolbarLocation({
+      documentContent,
+      tileElt,
+      toolbarHeight: 24,
+      toolbarTopOffset: 2,
+      enabled,
+      ...others
+  });
+
+  const toolbarClasses = classNames(
+    "expression-toolbar",
+    enabled && location ? "enabled" : "disabled",
+  );
+
+  return documentContent
+    ? ReactDOM.createPortal(
+      <div className={toolbarClasses} style={location}>
+        <div className="toolbar-content">TOOLBAR</div>
+      </div>, documentContent)
+  : null;
+});


### PR DESCRIPTION
This sets up the toolbar for the Expression Tile, and adds a delete button as described in [PT#185231699](https://www.pivotaltracker.com/story/show/185231699)

I'm marking as a "draft" because I have a few questions/possible fixes. 

1. In the jest test I have had to do this: 
```ts
    onRegisterTileApi: (tileApi: ITileApi, facet?: string): void => {
      // throw new Error("Function not implemented.");
    },
```
I need to understand better how all of this is meant to work in this context. 

2. I wanted to check and see if the pattern I am starting on for the buttons looks generalized enough, and like it will be the right way to manage state. 

  - I am passing down the mathfield object inside a ref `mf` from the tile component to the toolbar.  
  - Then, operations on the mathfield to be performed by the buttons would be defined in this toolbar file, and longer more involved functions might end up in dedicated files
  - Those functions are passed as props to dedicated button components, which are defined with their tooltips and other layout/display stuff in `expression-buttons`. 

Tasks to get out of draft:
- [ ] figure out what I should/could do about onRegisterTileApi in jest, if anything
- [ ] verify the pattern above is good for now or refactor accordingly
