### PR TITLE
fix: XYplot default axis limits and tick behavior

### DIFF
--- a/src/plugins/graph/axis/components/axis.tsx
+++ b/src/plugins/graph/axis/components/axis.tsx
@@ -27,7 +27,7 @@ export const Axis = ({
     [axisElt, setAxisElt] = useState<SVGGElement | null>(null);
 
   useAxis({
-    axisModel, axisElt, axisTitle: label, centerCategoryLabels
+    getAxisModel, axisElt, axisTitle: label, centerCategoryLabels
   });
 
   const getSubAxes = () => {

--- a/src/plugins/graph/axis/models/axis-model.ts
+++ b/src/plugins/graph/axis/models/axis-model.ts
@@ -1,4 +1,5 @@
-import {Instance, SnapshotIn, types} from "mobx-state-tree";
+import {Instance, isAlive, SnapshotIn, types} from "mobx-state-tree";
+import { kDefaultNumericAxisBounds } from "../../graph-types";
 import {AxisOrientation, AxisPlaces, IScaleType, ScaleTypes} from "../axis-types";
 
 export const AxisModel = types.model("AxisModel", {
@@ -68,7 +69,10 @@ export const NumericAxisModel = AxisModel
   })
   .views(self => ({
     get domain() {
-      return [self.min, self.max] as const;
+      // TODO: figure out why this is sometimes called on defunct objects during linking, etc.
+      if (isAlive(self)) return [self.min, self.max] as const;
+      console.warn("NumericAxisModel.domain", "attempt to access defunct axis model domain");
+      return kDefaultNumericAxisBounds;
     }
   }))
   .actions(self => ({

--- a/src/plugins/graph/components/graph-axis.tsx
+++ b/src/plugins/graph/components/graph-axis.tsx
@@ -1,4 +1,4 @@
-import React, {MutableRefObject, useEffect} from "react";
+import React, {MutableRefObject, useCallback, useEffect} from "react";
 import {observer} from "mobx-react-lite";
 import {isAlive} from "mobx-state-tree";
 import {Active} from "@dnd-kit/core";
@@ -18,7 +18,7 @@ import {useDropHintString} from "../hooks/use-drop-hint-string";
 import {useAxisBoundsProvider} from "../axis/hooks/use-axis-bounds";
 import { isAddCasesAction, isSetCaseValuesAction } from "../../../models/data/data-set-actions";
 import { computeNiceNumericBounds } from "../utilities/graph-utils";
-import { isNumericAxisModel } from "../axis/models/axis-model";
+import { IAxisModel, isNumericAxisModel } from "../axis/models/axis-model";
 import { useSettingFromStores } from "../../../hooks/use-stores";
 
 interface IProps {
@@ -102,9 +102,14 @@ export const GraphAxis = observer(function GraphAxis({
     };
   }, [layout, place, graphModel]);
 
+  const getAxisModel = useCallback((): IAxisModel | undefined => {
+    if (isAlive(graphModel)) return graphModel.getAxis(place);
+    console.warn("GraphAxis.getAxisModel", "attempt to access defunct graph model");
+  }, [graphModel, place]);
+
   return (
     <g className='axis-wrapper' ref={elt => setWrapperElt(elt)}>
-      <Axis getAxisModel={() => graphModel.getAxis(place)}
+      <Axis getAxisModel={getAxisModel}
             label={''}  // Remove
             enableAnimation={enableAnimation}
             showScatterPlotGridLines={axisShouldShowGridlines}
@@ -128,4 +133,3 @@ export const GraphAxis = observer(function GraphAxis({
     </g>
   );
 });
-

--- a/src/plugins/graph/graph-types.ts
+++ b/src/plugins/graph/graph-types.ts
@@ -89,3 +89,6 @@ export type PlotType = typeof PlotTypes[number];
 
 export const kGraphClass = "graph-plot";
 export const kGraphClassSelector = `.${kGraphClass}`;
+
+// TODO: determine this via configuration, e.g. appConfig, since apps may prefer different defaults
+export const kDefaultNumericAxisBounds = [-10, 11] as const;

--- a/src/plugins/graph/hooks/use-graph-model.ts
+++ b/src/plugins/graph/hooks/use-graph-model.ts
@@ -16,7 +16,6 @@ interface IProps {
 export function useGraphModel(props: IProps) {
   const {graphModel, enableAnimation, dotsRef, instanceId} = props,
     dataConfig = graphModel.config,
-    yAxisModel = graphModel.getAxis('left'),
     yAttrID = graphModel.getAttributeID('y'),
     dataset = useDataSetContext();
 
@@ -44,13 +43,14 @@ export function useGraphModel(props: IProps) {
         startAnimation(enableAnimation);
         // In case the y-values have changed we rescale
         if (newPlotType === 'scatterPlot') {
+          const yAxisModel = graphModel.getAxis('left');
           const values = dataConfig.caseDataArray.map(({ caseID }) => dataset?.getNumeric(caseID, yAttrID)) as number[];
           setNiceDomain(values || [], yAxisModel as INumericAxisModel);
         }
       }
     });
     return () => disposer();
-  }, [dataConfig.caseDataArray, dataset, enableAnimation, graphModel, yAttrID, yAxisModel]);
+  }, [dataConfig.caseDataArray, dataset, enableAnimation, graphModel, yAttrID]);
 
   // respond to point properties change
   useEffect(function respondToGraphPointVisualAction() {

--- a/src/plugins/graph/models/graph-controller.ts
+++ b/src/plugins/graph/models/graph-controller.ts
@@ -5,7 +5,9 @@ import {AxisPlace, AxisPlaces} from "../axis/axis-types";
 import {
   CategoricalAxisModel, EmptyAxisModel, isCategoricalAxisModel, isNumericAxisModel, NumericAxisModel
 } from "../axis/models/axis-model";
-import {axisPlaceToAttrRole, graphPlaceToAttrRole, IDotsRef, PlotType} from "../graph-types";
+import {
+  axisPlaceToAttrRole, graphPlaceToAttrRole, IDotsRef, kDefaultNumericAxisBounds, PlotType
+} from "../graph-types";
 import {GraphPlace} from "../axis-graph-shared";
 import {matchCirclesToData, setNiceDomain} from "../utilities/graph-utils";
 import { getAppConfig } from "../../../models/tiles/tile-environment";
@@ -129,11 +131,12 @@ export class GraphController {
         attr = attributeID ? dataset?.attrFromID(attributeID) : undefined,
         attrType = dataConfig.attributeType(attrRole) ?? 'empty',
         currAxisModel = graphModel.getAxis(place),
-        currentType = currAxisModel?.type ?? 'empty';
+        currentType = currAxisModel?.type ?? 'empty',
+        [min, max] = kDefaultNumericAxisBounds;
       switch (attrType) {
         case 'numeric': {
           if (!currAxisModel || !isNumericAxisModel(currAxisModel)) {
-            const newAxisModel = NumericAxisModel.create({place, min: 0, max: 1});
+            const newAxisModel = NumericAxisModel.create({place, min, max});
             graphModel.setAxis(place, newAxisModel);
             layout.setAxisScaleType(place, 'linear');
             setNiceDomain(attr?.numValues || [], newAxisModel);
@@ -160,7 +163,7 @@ export class GraphController {
             }
             else {
               const newAxisModel = emptyPlotIsNumeric
-                                     ? NumericAxisModel.create({place, min: 0, max: 1})
+                                     ? NumericAxisModel.create({place, min, max})
                                      : EmptyAxisModel.create({place});
               graphModel.setAxis(place, newAxisModel);
             }

--- a/src/plugins/graph/models/graph-model.ts
+++ b/src/plugins/graph/models/graph-model.ts
@@ -5,7 +5,7 @@ import stringify from "json-stringify-pretty-compact";
 import {AxisPlace} from "../axis/axis-types";
 import {AxisModelUnion, EmptyAxisModel, IAxisModelUnion, NumericAxisModel} from "../axis/models/axis-model";
 import {
-  GraphAttrRole, hoverRadiusFactor, PlotType, PlotTypes, kGraphTileType,
+  GraphAttrRole, hoverRadiusFactor, kDefaultNumericAxisBounds, kGraphTileType, PlotType, PlotTypes,
   pointRadiusLogBase, pointRadiusMax, pointRadiusMin, pointRadiusSelectionAddend
 } from "../graph-types";
 import {DataConfigurationModel} from "./data-configuration-model";
@@ -188,12 +188,13 @@ export interface IGraphModel extends Instance<typeof GraphModel> {}
 export interface IGraphModelSnapshot extends SnapshotIn<typeof GraphModel> {}
 
 export function createGraphModel(snap?: IGraphModelSnapshot, appConfig?: AppConfigModelType) {
+  const [min, max] = kDefaultNumericAxisBounds;
   const emptyPlotIsNumeric = appConfig?.getSetting("emptyPlotIsNumeric", "graph");
   const bottomAxisModel = emptyPlotIsNumeric
-                            ? NumericAxisModel.create({place: "bottom", min: -10, max: 11})
+                            ? NumericAxisModel.create({place: "bottom", min, max})
                             : EmptyAxisModel.create({place: "bottom"});
   const leftAxisModel = emptyPlotIsNumeric
-                          ? NumericAxisModel.create({place: "left", min: -10, max: 11})
+                          ? NumericAxisModel.create({place: "left", min, max})
                           : EmptyAxisModel.create({place: "left"});
   return GraphModel.create({
     axes: {


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/184867297

These changes fix a bug where connecting an XY Plot tile to an empty Table tile and then adding data to the table would lead to the XY Plot tile not placing the corresponding data dots properly. The GraphController's `setPrimaryRoleAndPlotType` function has been updated to use `numeric` as the default plot type instead of `empty` in the case that the `emptyPlotIsNumeric` setting is `true`.