### PR TITLE
185307242 expression toolbar placement fix

### DIFF
--- a/src/plugins/data-card/data-card-tile.tsx
+++ b/src/plugins/data-card/data-card-tile.tsx
@@ -21,7 +21,7 @@ import { CustomEditableTileTitle } from "../../components/tiles/custom-editable-
 
 export const DataCardToolComponent: React.FC<ITileProps> = observer((props) => {
   const { model, onRequestUniqueTitle, readOnly, documentContent, tileElt, onSetCanAcceptDrop, onRegisterTileApi,
-            onUnregisterTileApi } = props;
+            scale, onUnregisterTileApi } = props;
 
   const content = model.content as DataCardContentModelType;
   const ui = useUIStore();
@@ -230,7 +230,6 @@ export const DataCardToolComponent: React.FC<ITileProps> = observer((props) => {
     setCurrEditFacet("");
   };
 
-
   return (
     <div className={toolClasses}>
       <DataCardToolbar
@@ -242,6 +241,7 @@ export const DataCardToolComponent: React.FC<ITileProps> = observer((props) => {
         setImageUrlToAdd={setImageUrlToAdd} {...toolbarProps}
         handleDeleteValue={deleteSelectedValue}
         handleDuplicateCard={duplicateCard}
+        scale={scale}
       />
       <div
         className="data-card-content"

--- a/src/plugins/expression/expression-tile.tsx
+++ b/src/plugins/expression/expression-tile.tsx
@@ -26,14 +26,15 @@ declare global {
 const undoKeys = ["cmd+z", "[Undo]", "ctrl+z"];
 
 export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) => {
-  const { onRegisterTileApi, onUnregisterTileApi } = props;
-  const content = props.model.content as ExpressionContentModelType;
+  const { onRegisterTileApi, onRequestUniqueTitle, onUnregisterTileApi,
+    model, readOnly, documentContent, tileElt, scale } = props;
+  const content = model.content as ExpressionContentModelType;
   const mf = useRef<MathfieldElement>(null);
   const trackedCursorPos = useRef<number>(0);
   const ui = useUIStore();
 
   if(mf.current && ui) {
-    mf.current.addEventListener("focus", () => ui.setSelectedTileId(props.model.id));
+    mf.current.addEventListener("focus", () => ui.setSelectedTileId(model.id));
   }
 
   if (mf.current?.keybindings){
@@ -58,8 +59,8 @@ export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) =>
   };
 
   const toolbarProps = useToolbarTileApi({
-    id: props.model.id,
-    enabled: !props.readOnly,
+    id: model.id,
+    enabled: !readOnly,
     onRegisterTileApi,
     onUnregisterTileApi
   });
@@ -67,18 +68,18 @@ export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) =>
   return (
     <div className="expression-tool">
       <ExpressionToolbar
-        model={props.model}
-        documentContent={props.documentContent}
-        tileElt={props.tileElt}
-        scale={props.scale}
+        model={model}
+        documentContent={documentContent}
+        tileElt={tileElt}
+        scale={scale}
         {...toolbarProps}
         mf={mf}
       />
       <div className="expression-title-area">
         <CustomEditableTileTitle
-          model={props.model}
-          onRequestUniqueTitle={props.onRequestUniqueTitle}
-          readOnly={props.readOnly}
+          model={model}
+          onRequestUniqueTitle={onRequestUniqueTitle}
+          readOnly={readOnly}
         />
       </div>
       <div className="expression-math-area">
@@ -87,7 +88,7 @@ export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) =>
           value={content.latexStr}
           onInput={handleChange}
           // MathLive only interprets undefined as false
-          readOnly={props.readOnly === true ? true : undefined}
+          readOnly={readOnly === true ? true : undefined}
         />
       </div>
     </div>

--- a/src/plugins/expression/expression-tile.tsx
+++ b/src/plugins/expression/expression-tile.tsx
@@ -70,6 +70,7 @@ export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) =>
         model={props.model}
         documentContent={props.documentContent}
         tileElt={props.tileElt}
+        scale={props.scale}
         {...toolbarProps}
         mf={mf}
       />


### PR DESCRIPTION
PT#185307242 bug: DataCard and Expression tile toolbars were not rendering in correct location in 4-up view.  

- This passes scale prop to DataCard and Expression toolbars so that they have the correct value in hand when their locations are calculated.  
- This also destructures the props at the top of the Expression Tile