### PR TITLE
fix: Renaming Table attrs not showing in linked XYPlot (PT-185317045)

### DIFF
--- a/src/plugins/graph/components/attribute-label.tsx
+++ b/src/plugins/graph/components/attribute-label.tsx
@@ -52,10 +52,10 @@ export const AttributeLabel = observer(
     }, [dataConfiguration, graphModel.plotType, place]);
 
     const getLabel = useCallback(() => {
-      if (defaultAxisLabels?.[place]) {
-        return defaultAxisLabels[place];
-      }
       if (useClickHereCue) {
+        if (defaultAxisLabels?.[place]) {
+          return defaultAxisLabels[place];
+        }
         return t('DG.AxisView.emptyGraphCue');
       }
       const attrIDs = getAttributeIDs();

--- a/src/plugins/graph/components/attribute-label.tsx
+++ b/src/plugins/graph/components/attribute-label.tsx
@@ -53,10 +53,8 @@ export const AttributeLabel = observer(
 
     const getLabel = useCallback(() => {
       if (useClickHereCue) {
-        if (defaultAxisLabels?.[place]) {
-          return defaultAxisLabels[place];
-        }
-        return t('DG.AxisView.emptyGraphCue');
+        // empty axis shows the default axis label (if configured) or the click here prompt
+        return defaultAxisLabels?.[place] || t('DG.AxisView.emptyGraphCue');
       }
       const attrIDs = getAttributeIDs();
       return attrIDs.map(anID => dataset?.attrFromID(anID)?.name)


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/185317045

Move the `defaultAxisLabels` check within the `useClickHereCue` check in AttributeLabel so the default labels are only shown when there is no linked data source. This allows the axis label values to be updated when the associated attribute names are changed in a linked data source.