### PR TITLE
feat: Tables can link to other tables (PT-185316977)

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -219,8 +219,9 @@ Cypress.Commands.add('collapseWorkspace', () => {
   // cy.get('.divider-container .expand-handle.right').click(); // to ensure workspace is collapsed regardless of initial position
 });
 Cypress.Commands.add('linkTableToGraph', (table, graph) => {
-  cy.get('.primary-workspace .table-title').contains(table).within(() => {
-    cy.get('.link-tile-button').click();
+  cy.get('.primary-workspace .table-title').contains(table).click();
+  cy.get(".primary-workspace").within((workspace) => {
+    cy.get(".table-toolbar .toolbar-button.link-tile-button").click();
   });
   cy.get('.ReactModalPortal').within(() => {
     cy.get('[data-test=link-tile-select]').select(graph);
@@ -228,8 +229,9 @@ Cypress.Commands.add('linkTableToGraph', (table, graph) => {
   });
 });
 Cypress.Commands.add('unlinkTableToGraph', (table, graph) => {
-  cy.get('.primary-workspace .table-title').contains(table).within(() => {
-    cy.get('.link-tile-button').click();
+  cy.get('.primary-workspace .table-title').contains(table).click();
+  cy.get(".primary-workspace").within((workspace) => {
+    cy.get(".table-toolbar .toolbar-button.link-tile-button").click();
   });
   cy.get('.ReactModalPortal').within(() => {
     cy.get('[data-test=link-tile-select]').select(graph);

--- a/src/components/tiles/table/editable-table-title.tsx
+++ b/src/components/tiles/table/editable-table-title.tsx
@@ -4,7 +4,6 @@ import React, { useState } from "react";
 import { TableContentModelType } from "../../../models/tiles/table/table-content";
 import { verifyAlive } from "../../../utilities/mst-utils";
 import { HeaderCellInput } from "./header-cell-input";
-import { LinkTileButton } from "./link-tile-button";
 
 interface IProps {
   content: TableContentModelType;

--- a/src/components/tiles/table/editable-table-title.tsx
+++ b/src/components/tiles/table/editable-table-title.tsx
@@ -65,9 +65,6 @@ export const EditableTableTitle: React.FC<IProps> = observer(function EditableTa
         ? <HeaderCellInput style={style} value={editingTitle || ""}
             onKeyDown={handleKeyDown} onChange={setEditingTitle} onClose={handleClose} />
         : title}
-      {showLinkButton && !isEditing &&
-        <LinkTileButton isEnabled={!readOnly && isLinkEnabled} getLinkIndex={getLinkIndex}
-                            onClick={onLinkGeometryClick} />}
     </div>
   );
 });

--- a/src/components/tiles/table/table-tile.tsx
+++ b/src/components/tiles/table/table-tile.tsx
@@ -151,7 +151,7 @@ const TableToolComponent: React.FC<ITileProps> = observer(function TableToolComp
     readOnly: !!readOnly, changeHandlers, columns, onColumnResize, selectedCell, inputRowId });
 
   // Variables for handling linking to geometry tiles
-  const { isLinkEnabled, linkColors, getLinkIndex, showLinkTileDialog: showLinkGeometryDialog } =
+  const { isLinkEnabled, linkColors, getLinkIndex, showLinkTileDialog } =
     useConsumerTileLinking({ documentId, model, hasLinkableRows,
                           onRequestTilesOfType, onRequestLinkableTiles, onLinkTile, onUnlinkTile });
 
@@ -206,8 +206,17 @@ const TableToolComponent: React.FC<ITileProps> = observer(function TableToolComp
   const toolbarProps = useToolbarTileApi({ id: model.id, enabled: !readOnly, onRegisterTileApi, onUnregisterTileApi });
   return (
     <div className="table-tool">
-      <TableToolbar documentContent={documentContent} tileElt={tileElt} {...toolbarProps}
-                    deleteSelected={deleteSelected} onSetExpression={showExpressionsDialog} scale={scale}/>
+      <TableToolbar
+        documentContent={documentContent}
+        tileElt={tileElt}
+        {...toolbarProps}
+        deleteSelected={deleteSelected}
+        onSetExpression={showExpressionsDialog}
+        scale={scale}
+        isLinkEnabled={isLinkEnabled}
+        getLinkIndex={getLinkIndex}
+        showLinkGeometryDialog={showLinkTileDialog}
+      />
       <div className="table-grid-container" ref={containerRef} onClick={handleBackgroundClick}>
         <EditableTableTitle
           content={content}
@@ -216,7 +225,7 @@ const TableToolComponent: React.FC<ITileProps> = observer(function TableToolComp
           showLinkButton={true}
           isLinkEnabled={isLinkEnabled}
           getLinkIndex={getLinkIndex}
-          onLinkGeometryClick={showLinkGeometryDialog}
+          onLinkGeometryClick={showLinkTileDialog}
           titleCellWidth={titleCellWidth}
           titleCellHeight={getTitleHeight()}
           onBeginEdit={onBeginTitleEdit}

--- a/src/components/tiles/table/table-tile.tsx
+++ b/src/components/tiles/table/table-tile.tsx
@@ -215,7 +215,7 @@ const TableToolComponent: React.FC<ITileProps> = observer(function TableToolComp
         scale={scale}
         isLinkEnabled={isLinkEnabled}
         getLinkIndex={getLinkIndex}
-        showLinkGeometryDialog={showLinkTileDialog}
+        showLinkDialog={showLinkTileDialog}
       />
       <div className="table-grid-container" ref={containerRef} onClick={handleBackgroundClick}>
         <EditableTableTitle

--- a/src/components/tiles/table/table-toolbar-buttons.tsx
+++ b/src/components/tiles/table/table-toolbar-buttons.tsx
@@ -56,11 +56,9 @@ interface ILinkTableButtonProps {
   onClick?: () => void;
 }
 export const LinkTileButton = ({ isEnabled, getLinkIndex, onClick }: ILinkTableButtonProps) => {
-  console.log("isEnabled", isEnabled);
   const linkIndex = getLinkIndex();
   const classes = classNames("link-tile-button", `link-color-${linkIndex}`, { disabled: !isEnabled });
   const handleClick = (e: React.MouseEvent) => {
-    console.log("handleClick");
     isEnabled && onClick?.();
     e.stopPropagation();
   };

--- a/src/components/tiles/table/table-toolbar-buttons.tsx
+++ b/src/components/tiles/table/table-toolbar-buttons.tsx
@@ -4,6 +4,7 @@ import classNames from "classnames";
 
 import DeleteSelectedIconSvg from "../../../assets/icons/delete/delete-selection-icon.svg";
 import SetExpressionIconSvg from "../../../clue/assets/icons/table/set-expression-icon.svg";
+import LinkGraphIcon from "../../../clue/assets/icons/table/link-graph-icon.svg";
 import { useTooltipOptions } from "../../../hooks/use-tooltip-options";
 
 import "./table-toolbar.scss";
@@ -11,7 +12,7 @@ import "./table-toolbar.scss";
 interface ITableButtonProps {
   className?: string;
   icon: any;
-  onClick: () => void;
+  onClick: (e: React.MouseEvent) => void;
   tooltipOptions: TooltipProps;
 }
 const TableButton = ({ className, icon, onClick, tooltipOptions}: ITableButtonProps) => {
@@ -48,3 +49,27 @@ export const SetExpressionButton = ({ onClick }: ISetExpressionButtonProps) => (
     tooltipOptions={{ title: "Set expression" }}
   />
 );
+
+interface ILinkTableButtonProps {
+  isEnabled?: boolean;
+  getLinkIndex: () => number;
+  onClick?: () => void;
+}
+export const LinkTileButton = ({ isEnabled, getLinkIndex, onClick }: ILinkTableButtonProps) => {
+  console.log("isEnabled", isEnabled);
+  const linkIndex = getLinkIndex();
+  const classes = classNames("link-tile-button", `link-color-${linkIndex}`, { disabled: !isEnabled });
+  const handleClick = (e: React.MouseEvent) => {
+    console.log("handleClick");
+    isEnabled && onClick?.();
+    e.stopPropagation();
+  };
+  return (
+    <TableButton
+      className={classes}
+      icon={<LinkGraphIcon />}
+      onClick={handleClick}
+      tooltipOptions={{ title: "Link table" }}
+    />
+  );
+};

--- a/src/components/tiles/table/table-toolbar.scss
+++ b/src/components/tiles/table/table-toolbar.scss
@@ -31,6 +31,10 @@
     &:active {
       background-color: $workspace-teal-light-4;
     }
+
+    &.link-tile-button {
+      padding-top: 4px;
+    }
   }
 
   .toolbar-button:first-child {

--- a/src/components/tiles/table/table-toolbar.scss
+++ b/src/components/tiles/table/table-toolbar.scss
@@ -2,6 +2,7 @@
 
 .table-toolbar {
   position: absolute;
+  background-color: $workspace-teal-light-9;
   border: $toolbar-border;
   border-radius: 0 0 $toolbar-border-radius $toolbar-border-radius;
   display: flex;
@@ -32,6 +33,10 @@
       background-color: $workspace-teal-light-4;
     }
 
+    &.disabled {
+      opacity: 35%;
+      pointer-events: none;
+    }
     &.link-tile-button {
       padding-top: 4px;
     }

--- a/src/components/tiles/table/table-toolbar.tsx
+++ b/src/components/tiles/table/table-toolbar.tsx
@@ -15,11 +15,11 @@ interface IProps extends IFloatingToolbarProps {
   deleteSelected: () => void;
   getLinkIndex: () => number;
   onSetExpression: () => void;
-  showLinkGeometryDialog?: () => void;
+  showLinkDialog?: () => void;
 }
 export const TableToolbar: React.FC<IProps> = observer(({
   documentContent, isLinkEnabled, deleteSelected, getLinkIndex, onIsEnabled, 
-  onSetExpression, showLinkGeometryDialog, ...others
+  onSetExpression, showLinkDialog, ...others
 }) => {
   const enabled = onIsEnabled();
   const location = useFloatingToolbarLocation({
@@ -44,7 +44,7 @@ export const TableToolbar: React.FC<IProps> = observer(({
                  key={toolName}
                  isEnabled={isLinkEnabled}
                  getLinkIndex={getLinkIndex}
-                 onClick={showLinkGeometryDialog}
+                 onClick={showLinkDialog}
                />;
     }
   };

--- a/src/components/tiles/table/table-toolbar.tsx
+++ b/src/components/tiles/table/table-toolbar.tsx
@@ -2,20 +2,24 @@ import { observer } from "mobx-react";
 import React from "react";
 import ReactDOM from "react-dom";
 
-import { DeleteSelectedButton, SetExpressionButton } from "./table-toolbar-buttons";
+import { DeleteSelectedButton, LinkTileButton, SetExpressionButton } from "./table-toolbar-buttons";
 import { useSettingFromStores } from "../../../hooks/use-stores";
 import { IFloatingToolbarProps, useFloatingToolbarLocation } from "../hooks/use-floating-toolbar-location";
 
 import "./table-toolbar.scss";
 
-const defaultButtons = ["set-expression", "delete"];
+const defaultButtons = ["set-expression", "link-tile", "delete"];
 
 interface IProps extends IFloatingToolbarProps {
+  isLinkEnabled: boolean;
   deleteSelected: () => void;
+  getLinkIndex: () => number;
   onSetExpression: () => void;
+  showLinkGeometryDialog?: () => void;
 }
 export const TableToolbar: React.FC<IProps> = observer(({
-  deleteSelected, documentContent, onIsEnabled, onSetExpression, ...others
+  documentContent, isLinkEnabled, deleteSelected, getLinkIndex, onIsEnabled, 
+  onSetExpression, showLinkGeometryDialog, ...others
 }) => {
   const enabled = onIsEnabled();
   const location = useFloatingToolbarLocation({
@@ -35,6 +39,13 @@ export const TableToolbar: React.FC<IProps> = observer(({
         return <SetExpressionButton key={toolName} onClick={onSetExpression} />;
       case "delete":
         return <DeleteSelectedButton key={toolName} onClick={deleteSelected} />;
+      case "link-tile":
+        return <LinkTileButton
+                 key={toolName}
+                 isEnabled={isLinkEnabled}
+                 getLinkIndex={getLinkIndex}
+                 onClick={showLinkGeometryDialog}
+               />;
     }
   };
 

--- a/src/components/tiles/table/use-content-change-handlers.ts
+++ b/src/components/tiles/table/use-content-change-handlers.ts
@@ -124,6 +124,10 @@ export const useContentChangeHandlers = ({
     if (!readOnly && consumerTile) {
       const sharedModelManager = consumerTile.tileEnv?.sharedModelManager;
       if (sharedModelManager?.isReady) {
+        const existingSharedTable = sharedModelManager?.findFirstSharedModelByType(SharedDataSet, tileInfo.id);
+        if (existingSharedTable) {
+          sharedModelManager?.removeTileSharedModel(consumerTile, existingSharedTable);
+        }
         const sharedTable = sharedModelManager?.findFirstSharedModelByType(SharedDataSet, modelRef.current.id);
         sharedTable && sharedModelManager?.addTileSharedModel(consumerTile, sharedTable);
       }

--- a/src/components/tiles/table/use-content-change-handlers.ts
+++ b/src/components/tiles/table/use-content-change-handlers.ts
@@ -127,7 +127,7 @@ export const useContentChangeHandlers = ({
       if (sharedModelManager?.isReady) {
         // If the consumer tile does not support multiple shared data sets, remove it from
         // any existing shared data set before linking.
-        if (!getTileContentInfo(consumerTile.type)?.supportsMultipleDataSets) {
+        if (!getTileContentInfo(consumerTile.type)?.consumesMultipleDataSets) {
           const existingSharedTable = sharedModelManager?.findFirstSharedModelByType(SharedDataSet, tileInfo.id);
           if (existingSharedTable) {
             sharedModelManager?.removeTileSharedModel(consumerTile, existingSharedTable);
@@ -145,16 +145,16 @@ export const useContentChangeHandlers = ({
       const sharedModelManager = linkedTile.tileEnv?.sharedModelManager;
       if (sharedModelManager?.isReady) {
         const sharedTable = sharedModelManager?.findFirstSharedModelByType(SharedDataSet, modelRef.current.id);
-        // If providerId matches model.id, we're the data provider and should remove the other tile
+        // If providerId matches model id, we're the data provider and should remove the other tile
         // from the shared data set. Otherwise, we're the consumer and should remove ourselves.
-        if (sharedTable && sharedTable.providerId === model.id) {
+        if (sharedTable && sharedTable.providerId === modelRef.current.id) {
           sharedModelManager?.removeTileSharedModel(linkedTile, sharedTable);
         } else if (sharedTable) {
-          sharedModelManager?.removeTileSharedModel(model.content, sharedTable);
+          sharedModelManager?.removeTileSharedModel(modelRef.current.content, sharedTable);
         }
       }
     }
-  }, [getContent, readOnly, modelRef, model.id, model.content]);
+  }, [getContent, readOnly, modelRef]);
 
   return { onSetTableTitle: setTableTitle, onSetColumnName: setColumnName, onSetColumnExpressions: setColumnExpressions,
           onAddColumn: addColumn, onRemoveColumn: removeColumn, requestRowHeight,

--- a/src/components/tiles/table/use-content-change-handlers.ts
+++ b/src/components/tiles/table/use-content-change-handlers.ts
@@ -10,6 +10,7 @@ import { uniqueId, uniqueName } from "../../../utilities/js-utils";
 import { TColumn, TRow } from "./table-types";
 import { getTileContentById } from "../../../utilities/mst-utils";
 import { SharedDataSet } from "../../../models/shared/shared-data-set";
+import { getTileContentInfo } from "../../../models/tiles/tile-content-info";
 
 export interface IContentChangeHandlers {
   onSetTableTitle: (title: string) => void;
@@ -124,9 +125,13 @@ export const useContentChangeHandlers = ({
     if (!readOnly && consumerTile) {
       const sharedModelManager = consumerTile.tileEnv?.sharedModelManager;
       if (sharedModelManager?.isReady) {
-        const existingSharedTable = sharedModelManager?.findFirstSharedModelByType(SharedDataSet, tileInfo.id);
-        if (existingSharedTable) {
-          sharedModelManager?.removeTileSharedModel(consumerTile, existingSharedTable);
+        // If the consumer tile does not support multiple shared data sets, remove it from
+        // any existing shared data set before linking.
+        if (!getTileContentInfo(consumerTile.type)?.supportsMultipleDataSets) {
+          const existingSharedTable = sharedModelManager?.findFirstSharedModelByType(SharedDataSet, tileInfo.id);
+          if (existingSharedTable) {
+            sharedModelManager?.removeTileSharedModel(consumerTile, existingSharedTable);
+          }
         }
         const sharedTable = sharedModelManager?.findFirstSharedModelByType(SharedDataSet, modelRef.current.id);
         sharedTable && sharedModelManager?.addTileSharedModel(consumerTile, sharedTable);

--- a/src/components/tiles/table/use-data-set.ts
+++ b/src/components/tiles/table/use-data-set.ts
@@ -81,7 +81,7 @@ export const useDataSet = ({
     }
   };
 
-  const hasLinkableRows = getContent().hasLinkableCases(dataSet);
+  const hasLinkableRows = dataSet.attributes.length > 1;
 
   const getUpdatedRowAndColumn = (_rows?: TRow[], _columns?: TColumn[]) => {
     const rs = _rows ?? rows;

--- a/src/components/tiles/table/use-data-set.ts
+++ b/src/components/tiles/table/use-data-set.ts
@@ -1,8 +1,6 @@
 import { useCallback } from "react";
 import { DataGridHandle } from "react-data-grid";
-import { useCurrent } from "../../../hooks/use-current";
 import { ICase, IDataSet } from "../../../models/data/data-set";
-import { TableContentModelType } from "../../../models/tiles/table/table-content";
 import { ITileModel } from "../../../models/tiles/tile-model";
 import { uniqueId } from "../../../utilities/js-utils";
 import { formatValue } from "./cell-formatter";
@@ -35,8 +33,6 @@ export const useDataSet = ({
   changeHandlers, columns, onColumnResize
 }: IUseDataSet) => {
   const { onAddRows, onUpdateRow } = changeHandlers;
-  const modelRef = useCurrent(model);
-  const getContent = useCallback(() => modelRef.current.content as TableContentModelType, [modelRef]);
   const onSelectedCellChange = (position: TPosition) => {
     const forward = (selectedCell.current.rowIdx < position.rowIdx) ||
                     ((selectedCell.current.rowIdx === position.rowIdx) &&

--- a/src/models/document/shared-model-document-manager.ts
+++ b/src/models/document/shared-model-document-manager.ts
@@ -51,11 +51,11 @@ export class SharedModelDocumentManager implements ISharedModelDocumentManager {
   // Also this cannot be marked as an `action`. Doing that will cause it to not watch the
   // stuff it reads.
   findFirstSharedModelByType<IT extends typeof SharedModelUnion>(
-    sharedModelType: IT, providerId?: string): IT["Type"] | undefined {
+    sharedModelType: IT, tileId?: string): IT["Type"] | undefined {
     if (!this.document) {
       console.warn("findFirstSharedModelByType has no document");
     }
-    return this.document?.getFirstSharedModelByType(sharedModelType, providerId);
+    return this.document?.getFirstSharedModelByType(sharedModelType, tileId);
   }
 
   getSharedModelsByType<IT extends typeof SharedModelUnion>(type: string): IT["Type"][] {

--- a/src/models/shared/shared-model-manager.ts
+++ b/src/models/shared/shared-model-manager.ts
@@ -71,7 +71,7 @@ export interface ISharedModelManager {
    * @param sharedModelType the MST model "class" of the shared model
    */
   findFirstSharedModelByType<IT extends typeof SharedModelUnion>(
-    sharedModelType: IT, providerId?: string): IT["Type"] | undefined;
+    sharedModelType: IT, tileId?: string): IT["Type"] | undefined;
 
   /**
    * Return an array of all models of the specified type.

--- a/src/models/tiles/geometry/geometry-registration.ts
+++ b/src/models/tiles/geometry/geometry-registration.ts
@@ -22,6 +22,7 @@ registerTileContentInfo({
   defaultHeight: kGeometryDefaultHeight,
   exportNonDefaultHeight: true,
   isDataConsumer: true,
+  supportsMultipleDataSets: true,
   defaultContent: defaultGeometryContent,
   tileSnapshotPreProcessor
 });

--- a/src/models/tiles/geometry/geometry-registration.ts
+++ b/src/models/tiles/geometry/geometry-registration.ts
@@ -22,7 +22,7 @@ registerTileContentInfo({
   defaultHeight: kGeometryDefaultHeight,
   exportNonDefaultHeight: true,
   isDataConsumer: true,
-  supportsMultipleDataSets: true,
+  consumesMultipleDataSets: true,
   defaultContent: defaultGeometryContent,
   tileSnapshotPreProcessor
 });

--- a/src/models/tiles/tile-content-info.ts
+++ b/src/models/tiles/tile-content-info.ts
@@ -36,6 +36,7 @@ export interface ITileContentInfo {
   exportNonDefaultHeight?: boolean;
   isDataConsumer?: boolean;
   isDataProvider?: boolean;
+  supportsMultipleDataSets?: boolean;
   tileSnapshotPreProcessor?: TileModelSnapshotPreProcessor;
   contentSnapshotPostProcessor?: TileContentSnapshotPostProcessor;
   updateContentWithNewSharedModelIds?: TileContentNewSharedModelIdUpdater;

--- a/src/models/tiles/tile-content-info.ts
+++ b/src/models/tiles/tile-content-info.ts
@@ -36,7 +36,7 @@ export interface ITileContentInfo {
   exportNonDefaultHeight?: boolean;
   isDataConsumer?: boolean;
   isDataProvider?: boolean;
-  supportsMultipleDataSets?: boolean;
+  consumesMultipleDataSets?: boolean;
   tileSnapshotPreProcessor?: TileModelSnapshotPreProcessor;
   contentSnapshotPostProcessor?: TileContentSnapshotPostProcessor;
   updateContentWithNewSharedModelIds?: TileContentNewSharedModelIdUpdater;

--- a/src/plugins/dataflow/model/dataflow-content.ts
+++ b/src/plugins/dataflow/model/dataflow-content.ts
@@ -218,11 +218,6 @@ export const DataflowContentModel = TileContentModel
         const tableTileModel = getTileModelById(self, tableId); //get tableTile contents given a tableId
         const tableTileContent = tableTileModel?.content;
         self.sharedModel && sharedModelManager.removeTileSharedModel(tableTileContent, self.sharedModel);
-        //create a dataSet with two attributes with X / Y, link table tile to this dataSet
-        const title = tableTileModel?.title;
-        const newDataSet = createDefaultDataSet(title);
-        const newSharedDataSet = newDataSet && SharedDataSet.create({ providerId: tableId, dataSet: newDataSet });
-        sharedModelManager.addTileSharedModel(tableTileContent, newSharedDataSet);
       }
       else {
         console.warn("DataflowContent.addLinkedTable unable to unlink table");

--- a/src/plugins/dataflow/model/dataflow-content.ts
+++ b/src/plugins/dataflow/model/dataflow-content.ts
@@ -3,7 +3,6 @@ import { reaction } from "mobx";
 import { cloneDeep} from "lodash";
 import stringify from "json-stringify-pretty-compact";
 import { DataflowProgramModel } from "./dataflow-program-model";
-import { createDefaultDataSet } from "./utilities/create-default-data-set";
 import { DEFAULT_DATA_RATE } from "./utilities/node";
 import { ITileExportOptions } from "../../../models/tiles/tile-content-info";
 import { ITileMetadataModel } from "../../../models/tiles/tile-metadata";

--- a/src/utilities/shared-data-utils.ts
+++ b/src/utilities/shared-data-utils.ts
@@ -12,8 +12,8 @@ export const isLinkedToTile = (model: ITileModel, tileId: string) => {
   const sharedModelManager = getSharedModelManager(model);
   if (sharedModelManager?.isReady) {
     const modelDataSet = sharedModelManager?.findFirstSharedModelByType(SharedDataSet, model.id);
-    const sourceTileDataSet = sharedModelManager?.findFirstSharedModelByType(SharedDataSet, tileId);
-    if (sourceTileDataSet?.id === modelDataSet?.id) {
+    const sharedModelTileIds = sharedModelManager?.getSharedModelTileIds(modelDataSet);
+    if (sharedModelTileIds?.includes(tileId)) {
       return true;
     }
   }


### PR DESCRIPTION
PT Stories: 

- [Tables can link to other tables, data decks](https://www.pivotaltracker.com/story/show/185316977)
- [Data Sources with strings are linkable](https://www.pivotaltracker.com/story/show/185250327)

The two stories above have a lot of overlap so the work was combined in this one PR. 

These changes make it possible to link a Table tile to another Table tile, move the linking button from the Table tile's header to its toolbar, and remove the check/requirement for numerical data before allowing linking between tiles.