### PR TITLE
disable inline shortcuts

### DIFF
--- a/src/plugins/expression/expression-tile.tsx
+++ b/src/plugins/expression/expression-tile.tsx
@@ -38,6 +38,7 @@ export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) =>
     undoKeys.forEach((key: string) => {
       mf.current?.keybindings && replaceKeyBinding(mf.current.keybindings, key, "");
     });
+    if (mf.current) mf.current.inlineShortcuts = {};
   }, [model.id, ui]);
 
   useEffect(() => {


### PR DESCRIPTION
This PR addresses [#PT185394587](https://www.pivotaltracker.com/story/show/185394587)

Inline shortcuts such as `pi` and `th` get in the way when people are trying to type variable names that may include those strings, e.g. “pizza", or "moth" 

This disables all inline shortcuts.  

Note that this does not disable \ commands - e.g. a person can still type the π symbol by typing `\pi`.