### PR TITLE
185415226 Add title to diagram tile

### DIFF
--- a/cypress/e2e/clue/branch/student_tests/diagram_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/diagram_tool_spec.js
@@ -47,6 +47,13 @@ context('Diagram Tool Tile', function () {
       hideNavigatorButton().should("exist");
       diagramDeleteButton().should("exist").should("be.disabled");
 
+      // Title
+      const newName = "Test Diagram";
+      diagramTile.getTileTitleText().should("contain", "Diagram 1");
+      diagramTile.getTileTitleContainer().click();
+      diagramTile.getTileTitleContainer().type(newName + '{enter}');
+      diagramTile.getTileTitleText().should("contain", newName);
+
       // Navigator can be hidden and shown
       const navigator = () => diagramTile.getDiagramTile().find(".react-flow__minimap");
       navigator().should("exist");

--- a/cypress/support/elements/clue/DataflowToolTile.js
+++ b/cypress/support/elements/clue/DataflowToolTile.js
@@ -7,6 +7,9 @@ class DataflowToolTile {
   getTileTitle(workspaceClass){
     return cy.get(`${workspaceClass || ".primary-workspace"} .editable-tile-title-text`);
   }
+  getDataflowTileTitle(workspaceClass){
+    return cy.get(`${workspaceClass || ".primary-workspace"} .editable-tile-title`);
+  }
   getCreateNodeButton(nodeType) {
     return cy.get(`.primary-workspace .icon-block.${nodeType}`);
   }
@@ -63,9 +66,6 @@ class DataflowToolTile {
   }
   getModalOkButton() {
     return cy.get('.dialog-contents #okButton');
-  }
-  getDataflowTileTitle(workspaceClass){
-    return cy.get(`${workspaceClass || ".primary-workspace"} .editable-tile-title`);
   }
   //Generator
   getAmplitudeField() {

--- a/cypress/support/elements/clue/DiagramToolTile.js
+++ b/cypress/support/elements/clue/DiagramToolTile.js
@@ -6,6 +6,12 @@ class DiagramToolTile {
   getDiagramTile(workspaceClass) {
     return cy.get(`${canvasArea(workspaceClass)} .diagram-tool-tile`);
   }
+  getTileTitleText(workspaceClass){
+    return cy.get(`${workspaceClass || ".primary-workspace"} .editable-tile-title-text`);
+  }
+  getTileTitleContainer(workspaceClass){
+    return cy.get(`${workspaceClass || ".primary-workspace"} .editable-tile-title`);
+  }
   getDiagramToolbar(workspaceClass, skipClick) {
     if (!skipClick) {
       this.getDiagramTile(workspaceClass).click();

--- a/src/components/tiles/basic-editable-tile-title.tsx
+++ b/src/components/tiles/basic-editable-tile-title.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+
+import { ToolTitleArea } from "./tile-title-area";
+import { EditableTileTitle } from "./editable-tile-title";
+import { measureText } from "./hooks/use-measure-text";
+import { defaultTileTitleFont } from "../constants";
+import { ITileModel } from "../../models/tiles/tile-model";
+
+interface IBasicEditableTileTitleProps {
+  key: string;
+  model: ITileModel;
+  readOnly?: boolean;
+  scale?: number;
+}
+export function BasicEditableTileTitle({ key, model, readOnly, scale }: IBasicEditableTileTitleProps) {
+  const getTitle  = () => {
+    return model.title || "";
+  };
+  const handleTitleChange = (title?: string) => {
+    title && model.setTitle(title);
+  };
+
+  return (
+    <ToolTitleArea>
+      <EditableTileTitle
+        key={key}
+        size={{width:null, height:null}}
+        scale={scale}
+        getTitle={getTitle}
+        readOnly={readOnly}
+        measureText={(text) => measureText(text, defaultTileTitleFont)}
+        onEndEdit={handleTitleChange}
+    />
+    </ToolTitleArea>
+  );
+}

--- a/src/components/tiles/basic-editable-tile-title.tsx
+++ b/src/components/tiles/basic-editable-tile-title.tsx
@@ -7,12 +7,12 @@ import { defaultTileTitleFont } from "../constants";
 import { ITileModel } from "../../models/tiles/tile-model";
 
 interface IBasicEditableTileTitleProps {
-  key: string;
   model: ITileModel;
   readOnly?: boolean;
   scale?: number;
+  titleKey?: string;
 }
-export function BasicEditableTileTitle({ key, model, readOnly, scale }: IBasicEditableTileTitleProps) {
+export function BasicEditableTileTitle({ model, readOnly, scale, titleKey }: IBasicEditableTileTitleProps) {
   const getTitle  = () => {
     return model.title || "";
   };
@@ -23,7 +23,7 @@ export function BasicEditableTileTitle({ key, model, readOnly, scale }: IBasicEd
   return (
     <ToolTitleArea>
       <EditableTileTitle
-        key={key}
+        key={titleKey}
         size={{width:null, height:null}}
         scale={scale}
         getTitle={getTitle}

--- a/src/plugins/diagram-viewer/diagram-tile.tsx
+++ b/src/plugins/diagram-viewer/diagram-tile.tsx
@@ -14,10 +14,7 @@ import { useNewVariableDialog } from "../shared-variables/dialog/use-new-variabl
 import { ITileProps } from "../../components/tiles/tile-component";
 import { useToolbarTileApi } from "../../components/tiles/hooks/use-toolbar-tile-api";
 import { useUIStore } from "../../hooks/use-stores";
-import { ToolTitleArea } from "../../components/tiles/tile-title-area";
-import { EditableTileTitle } from "../../components/tiles/editable-tile-title";
-import { measureText } from "../../components/tiles/hooks/use-measure-text";
-import { defaultTileTitleFont } from "../../components/constants";
+import { BasicEditableTileTitle } from "../../components/tiles/basic-editable-tile-title";
 
 import InsertVariableCardIcon from "./src/assets/insert-variable-card-icon.svg";
 import "@concord-consortium/diagram-view/dist/index.css";
@@ -129,28 +126,15 @@ export const DiagramToolComponent: React.FC<ITileProps> = observer((
     }
   });
 
-  const getTitle  = () => {
-    return model.title || "";
-  };
-
-  const handleTitleChange = (title?: string) => {
-    title && model.setTitle(title);
-  };
-
   const preventKeyboardDelete = dialogOpen || !isTileSelected || readOnly;
   return (
     <div className="diagram-tool">
-      <ToolTitleArea>
-        <EditableTileTitle
-          key="drawing-title"
-          size={{width:null, height:null}}
-          scale={scale}
-          getTitle={getTitle}
-          readOnly={readOnly}
-          measureText={(text) => measureText(text, defaultTileTitleFont)}
-          onEndEdit={handleTitleChange}
-       />
-      </ToolTitleArea>
+      <BasicEditableTileTitle
+        key="diagram-title"
+        model={model}
+        readOnly={readOnly}
+        scale={scale}
+      />
       <DiagramToolbar
         content={content}
         diagramHelper={diagramHelper}

--- a/src/plugins/diagram-viewer/diagram-tile.tsx
+++ b/src/plugins/diagram-viewer/diagram-tile.tsx
@@ -14,6 +14,10 @@ import { useNewVariableDialog } from "../shared-variables/dialog/use-new-variabl
 import { ITileProps } from "../../components/tiles/tile-component";
 import { useToolbarTileApi } from "../../components/tiles/hooks/use-toolbar-tile-api";
 import { useUIStore } from "../../hooks/use-stores";
+import { ToolTitleArea } from "../../components/tiles/tile-title-area";
+import { EditableTileTitle } from "../../components/tiles/editable-tile-title";
+import { measureText } from "../../components/tiles/hooks/use-measure-text";
+import { defaultTileTitleFont } from "../../components/constants";
 
 import InsertVariableCardIcon from "./src/assets/insert-variable-card-icon.svg";
 import "@concord-consortium/diagram-view/dist/index.css";
@@ -125,9 +129,28 @@ export const DiagramToolComponent: React.FC<ITileProps> = observer((
     }
   });
 
+  const getTitle  = () => {
+    return model.title || "";
+  };
+
+  const handleTitleChange = (title?: string) => {
+    title && model.setTitle(title);
+  };
+
   const preventKeyboardDelete = dialogOpen || !isTileSelected || readOnly;
   return (
     <div className="diagram-tool">
+      <ToolTitleArea>
+        <EditableTileTitle
+          key="drawing-title"
+          size={{width:null, height:null}}
+          scale={scale}
+          getTitle={getTitle}
+          readOnly={readOnly}
+          measureText={(text) => measureText(text, defaultTileTitleFont)}
+          onEndEdit={handleTitleChange}
+       />
+      </ToolTitleArea>
       <DiagramToolbar
         content={content}
         diagramHelper={diagramHelper}

--- a/src/plugins/diagram-viewer/diagram-tile.tsx
+++ b/src/plugins/diagram-viewer/diagram-tile.tsx
@@ -130,7 +130,6 @@ export const DiagramToolComponent: React.FC<ITileProps> = observer((
   return (
     <div className="diagram-tool">
       <BasicEditableTileTitle
-        key="diagram-title"
         model={model}
         readOnly={readOnly}
         scale={scale}

--- a/src/plugins/drawing/components/drawing-tile.tsx
+++ b/src/plugins/drawing/components/drawing-tile.tsx
@@ -8,10 +8,7 @@ import { DrawingContentModelType } from "../model/drawing-content";
 import { useCurrent } from "../../../hooks/use-current";
 import { ITileExportOptions } from "../../../models/tiles/tile-content-info";
 import { DrawingContentModelContext } from "./drawing-content-context";
-import { ToolTitleArea } from "../../../components/tiles/tile-title-area";
-import { EditableTileTitle } from "../../../components/tiles/editable-tile-title";
-import { measureText } from "../../../components/tiles/hooks/use-measure-text";
-import { defaultTileTitleFont } from "../../../components/constants";
+import { BasicEditableTileTitle } from "../../../components/tiles/basic-editable-tile-title";
 import { HotKeys } from "../../../utilities/hot-keys";
 import { getClipboardContent, pasteClipboardImage } from "../../../utilities/clipboard-utils";
 import "./drawing-tile.scss";
@@ -31,9 +28,6 @@ const DrawingToolComponent: React.FC<IProps> = (props) => {
     onRegisterTileApi({
       exportContentAsTileJson: (options?: ITileExportOptions) => {
         return contentRef.current.exportJson(options);
-      },
-      getTitle: () => {
-        return getTitle();
       }
     });
     if (!readOnly) {
@@ -59,27 +53,15 @@ const DrawingToolComponent: React.FC<IProps> = (props) => {
   };
 
   const toolbarProps = useToolbarTileApi({ id: model.id, enabled: !readOnly, onRegisterTileApi, onUnregisterTileApi });
-  const getTitle  = () => {
-    return model.title || "";
-  };
-
-  const handleTitleChange = (title?: string) => {
-    title && model.setTitle(title);
-  };
 
   return (
     <DrawingContentModelContext.Provider value={contentRef.current} >
-      <ToolTitleArea>
-        <EditableTileTitle
-          key="drawing-title"
-          size={{width:null, height:null}}
-          scale={scale}
-          getTitle={getTitle}
-          readOnly={readOnly}
-          measureText={(text) => measureText(text, defaultTileTitleFont)}
-          onEndEdit={handleTitleChange}
-       />
-      </ToolTitleArea>
+      <BasicEditableTileTitle
+        key="drawing-title"
+        model={model}
+        readOnly={readOnly}
+        scale={scale}
+      />
       <div
         className={classNames("drawing-tool", { "read-only": readOnly })}
         data-testid="drawing-tool"

--- a/src/plugins/drawing/components/drawing-tile.tsx
+++ b/src/plugins/drawing/components/drawing-tile.tsx
@@ -57,7 +57,6 @@ const DrawingToolComponent: React.FC<IProps> = (props) => {
   return (
     <DrawingContentModelContext.Provider value={contentRef.current} >
       <BasicEditableTileTitle
-        key="drawing-title"
         model={model}
         readOnly={readOnly}
         scale={scale}

--- a/src/plugins/graph/components/graph-wrapper-component.tsx
+++ b/src/plugins/graph/components/graph-wrapper-component.tsx
@@ -3,10 +3,7 @@ import classNames from "classnames";
 
 import { GraphComponent } from "./graph-component";
 import { ITileProps } from "../../../components/tiles/tile-component";
-import { ToolTitleArea } from "../../../components/tiles/tile-title-area";
-import { EditableTileTitle } from "../../../components/tiles/editable-tile-title";
-import { measureText } from "../../../components/tiles/hooks/use-measure-text";
-import { defaultTileTitleFont } from "../../../components/constants";
+import { BasicEditableTileTitle } from "../../../components/tiles/basic-editable-tile-title";
 import { ITileExportOptions } from "../../../models/tiles/tile-content-info";
 import { useCurrent } from "../../../hooks/use-current";
 import { IGraphModel } from "../models/graph-model";
@@ -45,10 +42,6 @@ export const GraphWrapperComponent: React.FC<ITileProps> = (props) => {
     return model.title || "";
   };
 
-  const handleTitleChange = (title?: string) => {
-    title && model.setTitle(title);
-  };
-
   return (
     <div className={classNames("graph-wrapper", { "read-only": readOnly })}>
       <GraphToolbar
@@ -62,17 +55,11 @@ export const GraphWrapperComponent: React.FC<ITileProps> = (props) => {
         onLinkTableButtonClick={showLinkTileDialog}
         onRequestTilesOfType={onRequestTilesOfType}
       />
-      <ToolTitleArea>
-        <EditableTileTitle
-          key="drawing-title"
-          size={{width:null, height:null}}
-          scale={scale}
-          getTitle={getTitle}
-          readOnly={readOnly}
-          measureText={(text) => measureText(text, defaultTileTitleFont)}
-          onEndEdit={handleTitleChange}
-       />
-      </ToolTitleArea>
+      <BasicEditableTileTitle
+        model={model}
+        readOnly={readOnly}
+        scale={scale}
+      />
       <GraphComponent tile={model} />
     </div>
   );


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/185415226

This PR adds a title component to the diagram tile. It also introduces a new basic title component that can be used by many tiles. In this PR it's only used for the diagram, drawing, and graph tiles.