### PR TITLE
Student name and document name to 1up view title bar in Student Workspaces

### DIFF
--- a/cypress/e2e/clue/branch/teacher_tests/teacher_workspace_spec.js
+++ b/cypress/e2e/clue/branch/teacher_tests/teacher_workspace_spec.js
@@ -86,6 +86,10 @@ context('Teacher Workspace', () => {
     });
 
     it('verify teacher guide', () => {
+      //There is race condition that sometimes doesn't load the teacher guide
+      //So we close the Resources panel, and re-open to force it to rerender
+      cy.collapseResourcesPanel();
+      cy.openResourceTabs();
       cy.get('.top-tab.tab-teacher-guide').should('exist').click({force:true});
       cy.get('.prob-tab.teacher-guide').should('exist').and('have.length', 4).each(function (subTab, index, subTabList) {
         const teacherGuideSubTabs = ["Launch", "Explore", "Summarize", "Unit Plan"];

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -217,6 +217,10 @@ Cypress.Commands.add("getDocumentToolTile", (tileIndex = 0) => {
 Cypress.Commands.add('closeResourceTabs', () => {
   cy.get('.nav-tab-panel .close-button').click();
 });
+Cypress.Commands.add('collapseResourcesPanel', () => {
+  cy.get('.divider').click({force:true});
+  cy.get('.divider-container .expand-handle.left').click();
+});
 Cypress.Commands.add('collapseWorkspace', () => {
   cy.get('.divider').click({force:true});
   cy.get('.divider-container .expand-handle.right').click();

--- a/src/components/document/student-group-view.scss
+++ b/src/components/document/student-group-view.scss
@@ -25,6 +25,8 @@
       background-color: white;
 
       .actions {
+        display: flex;
+        flex-direction: row;
         .icon.group-number {
           width: 32px;
           height: 26px;
@@ -44,6 +46,35 @@
           &.active {
             border: solid 1.5px white;
             background-color: $charcoal-dark-1;
+            pointer-events: none;
+          }
+        }
+        .member-button {
+          font-size: 12px;
+          border-radius: 5px;
+          border: solid 1.5px $charcoal-light-1;
+          box-sizing: border-box;
+          margin: 0 2px;
+          color: $charcoal-dark-3;
+          cursor: pointer;
+          text-align: center;
+          height: 26px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          padding: 5px;
+
+          &.four-up-nw {
+            background-color: $id-blue
+          }
+          &.four-up-ne {
+            background-color: $id-orange
+          }
+          &.four-up-se {
+            background-color: $id-green
+          }
+          &.four-up-sw {
+            background-color: $id-purple
           }
         }
       }

--- a/src/components/document/student-group-view.tsx
+++ b/src/components/document/student-group-view.tsx
@@ -53,9 +53,11 @@ export const StudentGroupView:React.FC<IProps> = ({ groupId, setGroupId }) => {
   };
   const handleFocusedGroupUserChange = (selectedGroupUser: GroupUserModelType | undefined) => {
     setFocusedGroupUser(selectedGroupUser);
+    // console.log("selectedGroupUser", selectedGroupUser, "focusedGroupUser", focusedGroupUser);
   };
 
   const handleToggleContext = (context: string | null, selectedGroupUser: GroupUserModelType | undefined) => {
+    // console.log("handleToggleContext", context, selectedGroupUser);
     setGroupViewContext(context);
     setFocusedGroupUser(selectedGroupUser);
   };
@@ -80,7 +82,8 @@ export const StudentGroupView:React.FC<IProps> = ({ groupId, setGroupId }) => {
     const problem = useProblemStore();
     const userInfo = groupUsers.find(gUser => gUser.user.id === groupUser?.id);
     const userDocTitle = userInfo?.doc?.title || "Document";
-    const titleText = groupUser && userInfo
+    console.log("userInfo", userInfo);
+    const titleText = focusedGroupUser && groupUser && userInfo
                         ? `${groupUser.name}: ${userInfo.doc?.type === "problem" ? problem.title : userDocTitle}`
                         : selectedId ? `Student Group ${selectedId}` : "No groups";
     return (
@@ -93,6 +96,7 @@ export const StudentGroupView:React.FC<IProps> = ({ groupId, setGroupId }) => {
       </div>
     );
   };
+
   return (
     <div key="student-group-view" className="document student-group-view">
       <GroupViewTitlebar selectedId={selectedGroupId} onSelectGroup={handleSelectGroup} />
@@ -103,7 +107,8 @@ export const StudentGroupView:React.FC<IProps> = ({ groupId, setGroupId }) => {
                          isGhostUser={true}
                          viaStudentGroupView={true}
                          groupViewContext={groupViewContext}
-                         setFocusedGroupUser={handleFocusedGroupUserChange}
+                         setFocusedGroupUser={setFocusedGroupUser}
+                        //  setFocusedGroupUser={handleFocusedGroupUserChange}
                          onToggleContext={handleToggleContext}
         />
       </div>

--- a/src/components/document/student-group-view.tsx
+++ b/src/components/document/student-group-view.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
-import { GroupUserModelType } from "src/models/stores/groups";
-import { useGroupsStore, useUserStore } from "../../hooks/use-stores";
+import { getGroupUsers } from "../../models/document/document-utils";
+import { GroupUserModelType } from "../../models/stores/groups";
+import { useProblemStore, useStores } from "../../hooks/use-stores";
 import { Logger } from "../../lib/logger";
 import { LogEventName } from "../../lib/logger-types";
 import { FourUpComponent } from "../four-up";
@@ -38,11 +39,11 @@ interface IProps {
   setGroupId: (groupId: string) => void;
 }
 export const StudentGroupView:React.FC<IProps> = ({ groupId, setGroupId }) => {
-  const user = useUserStore();
-  const groups = useGroupsStore();
+  const {user, groups, documents} = useStores();
   const [focusedGroupUser, setFocusedGroupUser] = useState<GroupUserModelType | undefined>();
   const [groupViewContext, setGroupViewContext] = useState<string | null>(null);
   const selectedGroupId = groupId || (groups.allGroups.length ? groups.allGroups[0].id : "");
+  const groupUsers = getGroupUsers(groups, documents, selectedGroupId);
 
   const handleSelectGroup = (id: string) => {
     Logger.log(LogEventName.VIEW_GROUP, {group: id, via: "group-document-titlebar"});
@@ -76,11 +77,17 @@ export const StudentGroupView:React.FC<IProps> = ({ groupId, setGroupId }) => {
   };
 
   const GroupTitlebar: React.FC<IGroupTitlebarProps> = ({selectedId, context, groupUser}) => {
+    const problem = useProblemStore();
+    const userInfo = groupUsers.find(gUser => gUser.user.id === groupUser?.id);
+    const userDocTitle = userInfo?.doc?.title || "Document";
+    const titleText = groupUser && userInfo
+                        ? `${groupUser.name}: ${userInfo.doc?.type === "problem" ? problem.title : userDocTitle}`
+                        : selectedId ? `Student Group ${selectedId}` : "No groups";
     return (
       <div className="group-title" data-test="group-title">
         <div className="group-title-center">
           <div className="group-name">
-            {selectedId ? `Student Group ${selectedId}` : "No groups"}
+            {titleText}
           </div>
         </div>
       </div>

--- a/src/components/document/student-group-view.tsx
+++ b/src/components/document/student-group-view.tsx
@@ -30,7 +30,7 @@ interface IGroupViewTitlebarProps {
 
 interface IGroupTitlebarProps {
   selectedId: string;
-  context: string | null;
+  // context: string | null;
   groupUser?: GroupUserModelType | undefined;
 }
 
@@ -41,7 +41,7 @@ interface IProps {
 export const StudentGroupView:React.FC<IProps> = ({ groupId, setGroupId }) => {
   const {user, groups, documents} = useStores();
   const [focusedGroupUser, setFocusedGroupUser] = useState<GroupUserModelType | undefined>();
-  const [groupViewContext, setGroupViewContext] = useState<string | null>(null);
+  // const [groupViewContext, setGroupViewContext] = useState<string | null>(null);
   const selectedGroupId = groupId || (groups.allGroups.length ? groups.allGroups[0].id : "");
   const groupUsers = getGroupUsers(groups, documents, selectedGroupId);
 
@@ -49,18 +49,18 @@ export const StudentGroupView:React.FC<IProps> = ({ groupId, setGroupId }) => {
     Logger.log(LogEventName.VIEW_GROUP, {group: id, via: "group-document-titlebar"});
     setGroupId(id);
     setFocusedGroupUser(undefined);
-    setGroupViewContext(null);
+    // setGroupViewContext(null);
   };
-  const handleFocusedGroupUserChange = (selectedGroupUser: GroupUserModelType | undefined) => {
-    setFocusedGroupUser(selectedGroupUser);
-    // console.log("selectedGroupUser", selectedGroupUser, "focusedGroupUser", focusedGroupUser);
-  };
+  // const handleFocusedGroupUserChange = (selectedGroupUser: GroupUserModelType | undefined) => {
+  //   setFocusedGroupUser(selectedGroupUser);
+  //   console.log("selectedGroupUser", selectedGroupUser, "focusedGroupUser", focusedGroupUser);
+  // };
 
-  const handleToggleContext = (context: string | null, selectedGroupUser: GroupUserModelType | undefined) => {
-    // console.log("handleToggleContext", context, selectedGroupUser);
-    setGroupViewContext(context);
-    setFocusedGroupUser(selectedGroupUser);
-  };
+  // const handleToggleContext = (context: string | null, selectedGroupUser: GroupUserModelType | undefined) => {
+  //   console.log("handleToggleContext", context, selectedGroupUser);
+  //   setGroupViewContext(context);
+  //   setFocusedGroupUser(selectedGroupUser);
+  // };
 
   const GroupViewTitlebar: React.FC<IGroupViewTitlebarProps> = ({ selectedId, onSelectGroup }) => {
     return (
@@ -78,11 +78,10 @@ export const StudentGroupView:React.FC<IProps> = ({ groupId, setGroupId }) => {
     );
   };
 
-  const GroupTitlebar: React.FC<IGroupTitlebarProps> = ({selectedId, context, groupUser}) => {
+  const GroupTitlebar: React.FC<IGroupTitlebarProps> = ({selectedId, groupUser}) => {
     const problem = useProblemStore();
     const userInfo = groupUsers.find(gUser => gUser.user.id === groupUser?.id);
     const userDocTitle = userInfo?.doc?.title || "Document";
-    console.log("userInfo", userInfo);
     const titleText = focusedGroupUser && groupUser && userInfo
                         ? `${groupUser.name}: ${userInfo.doc?.type === "problem" ? problem.title : userDocTitle}`
                         : selectedId ? `Student Group ${selectedId}` : "No groups";
@@ -100,16 +99,14 @@ export const StudentGroupView:React.FC<IProps> = ({ groupId, setGroupId }) => {
   return (
     <div key="student-group-view" className="document student-group-view">
       <GroupViewTitlebar selectedId={selectedGroupId} onSelectGroup={handleSelectGroup} />
-      <GroupTitlebar selectedId={selectedGroupId} context={groupViewContext} groupUser={focusedGroupUser}/>
+      <GroupTitlebar selectedId={selectedGroupId} groupUser={focusedGroupUser}/>
       <div className="canvas-area">
         <FourUpComponent userId={user.id}
                          groupId={selectedGroupId}
                          isGhostUser={true}
                          viaStudentGroupView={true}
-                         groupViewContext={groupViewContext}
+                        //  groupViewContext={groupViewContext}
                          setFocusedGroupUser={setFocusedGroupUser}
-                        //  setFocusedGroupUser={handleFocusedGroupUserChange}
-                         onToggleContext={handleToggleContext}
         />
       </div>
     </div>

--- a/src/components/document/student-group-view.tsx
+++ b/src/components/document/student-group-view.tsx
@@ -31,7 +31,6 @@ interface IGroupViewTitlebarProps {
 
 interface IGroupTitlebarProps {
   selectedId: string;
-  // context: string | null;
   groupUser?: GroupUserModelType | undefined;
 }
 
@@ -62,7 +61,7 @@ export const StudentGroupView:React.FC<IProps> = ({ groupId, setGroupId }) => {
                             selected={group.id === selectedId}
               />
               { groupUsers.map(u => {
-                  const className = classNames("member-button", "in-student-group-view", `${u.context}`);
+                  const className = classNames("member-button", "in-student-group-view", u.context);
                 return (
                   <div key={u.user.name} className={className} title={u.user.name}>{u.user.name}</div>
                 );
@@ -108,7 +107,6 @@ export const StudentGroupView:React.FC<IProps> = ({ groupId, setGroupId }) => {
                          groupId={selectedGroupId}
                          isGhostUser={true}
                          viaStudentGroupView={true}
-                        //  groupViewContext={groupViewContext}
                          setFocusedGroupUser={setFocusedGroupUser}
         />
       </div>

--- a/src/components/document/student-group-view.tsx
+++ b/src/components/document/student-group-view.tsx
@@ -43,7 +43,7 @@ export const StudentGroupView:React.FC<IProps> = ({ groupId, setGroupId }) => {
   const {user, groups, documents} = useStores();
   const [focusedGroupUser, setFocusedGroupUser] = useState<GroupUserModelType | undefined>();
   const selectedGroupId = groupId || (groups.allGroups.length ? groups.allGroups[0].id : "");
-  const groupUsers = getGroupUsers(groups, documents, selectedGroupId);
+  const groupUsers = getGroupUsers(user.id, groups, documents, selectedGroupId);
   const group = groups.getGroupById(selectedGroupId);
 
   const handleSelectGroup = (id: string) => {

--- a/src/components/four-up.tsx
+++ b/src/components/four-up.tsx
@@ -106,7 +106,7 @@ export class FourUpComponent extends BaseComponent<IProps, IState> {
 
   private getToggledContext () {
     const {toggledContextMap} = this.state;
-   return (this.props.groupId && toggledContextMap[this.props.groupId]) ?? null;
+    return (this.props.groupId && toggledContextMap[this.props.groupId]) ?? null;
   }
 
   public render() {
@@ -355,6 +355,7 @@ export class FourUpComponent extends BaseComponent<IProps, IState> {
     const { groupId, setFocusedGroupUser, onToggleContext } = this.props;
     const groupUser = this.userByContext[context];
     const toggledContext = this.getToggledContext();
+    console.log("groupUser", groupUser);
     this.setState(state => {
       if (groupId) {
         const current = state.toggledContextMap[groupId] ?? null;
@@ -366,8 +367,8 @@ export class FourUpComponent extends BaseComponent<IProps, IState> {
       const event = toggledContext ? LogEventName.DASHBOARD_SELECT_STUDENT : LogEventName.DASHBOARD_DESELECT_STUDENT;
       Logger.log(event, {groupId, studentId: groupUser.user.id});
     }
-    const focusedGroupUser = toggledContext ? groupUser?.user : undefined;
-    setFocusedGroupUser && setFocusedGroupUser(focusedGroupUser);
-    onToggleContext && onToggleContext(context, groupUser?.user);
+    const focusedGroupUser = groupUser?.user || undefined;
+    setFocusedGroupUser && setFocusedGroupUser(groupUser?.user);
+    onToggleContext && onToggleContext(context, context? groupUser?.user : undefined);
   };
 }

--- a/src/components/four-up.tsx
+++ b/src/components/four-up.tsx
@@ -132,14 +132,7 @@ export class FourUpComponent extends BaseComponent<IProps, IState> {
     const { groups, documents } = this.stores;
     const { userId, groupId, isGhostUser, toggleable, ...others } = this.props;
 
-    const groupUsers = getGroupUsers(groups, documents, groupId, documentViewMode);
-
-    // put the primary user's document first (i.e. in the upper-left corner)
-    groupUsers.sort((a, b) => {
-      if (a.user.id === userId) return -1;
-      if (b.user.id === userId) return 1;
-      return 0;
-    });
+    const groupUsers = getGroupUsers(userId, groups, documents, groupId, documentViewMode);
 
     // save reference to use for the username display in this render and logger in #handleOverlayClicked
     this.userByContext = {
@@ -188,7 +181,7 @@ export class FourUpComponent extends BaseComponent<IProps, IState> {
       (cell: FourUpGridCellModelType, corner: string) => (toggledContext === corner ? 2 : 1) * cell.scale;
 
     const memberName = (context: string) => {
-      const groupUser = groupUsers.find(u => u.context === context);
+      const groupUser = this.userByContext[context];
       const isToggled = context === toggledContext;
       if (groupUser) {
         const { name: fullName, initials } = groupUser.user;

--- a/src/components/four-up.tsx
+++ b/src/components/four-up.tsx
@@ -27,7 +27,6 @@ interface IProps extends IBaseProps {
   selectedSectionId?: string | null;
   viaTeacherDashboard?: boolean;
   viaStudentGroupView?: boolean
-  // groupViewContext?: string | null;
   setFocusedGroupUser?: (focusedGroupUser?: GroupUserModelType) => void;
 }
 

--- a/src/components/four-up.tsx
+++ b/src/components/four-up.tsx
@@ -38,6 +38,7 @@ interface IState {
 export interface FourUpUser {
   user: GroupUserModelType;
   doc?: DocumentModelType;
+  context: string;
 }
 
 interface ContextUserMap {
@@ -187,7 +188,7 @@ export class FourUpComponent extends BaseComponent<IProps, IState> {
       (cell: FourUpGridCellModelType, corner: string) => (toggledContext === corner ? 2 : 1) * cell.scale;
 
     const memberName = (context: string) => {
-      const groupUser = this.userByContext[context];
+      const groupUser = groupUsers.find(u => u.context === context);
       const isToggled = context === toggledContext;
       if (groupUser) {
         const { name: fullName, initials } = groupUser.user;

--- a/src/components/four-up.tsx
+++ b/src/components/four-up.tsx
@@ -27,13 +27,12 @@ interface IProps extends IBaseProps {
   selectedSectionId?: string | null;
   viaTeacherDashboard?: boolean;
   viaStudentGroupView?: boolean
-  groupViewContext?: string | null;
+  // groupViewContext?: string | null;
   setFocusedGroupUser?: (focusedGroupUser?: GroupUserModelType) => void;
-  onToggleContext?: (context: string | null, selectedGroupUser: GroupUserModelType | undefined) => void;
 }
 
 interface IState {
-  toggledContextMap: Record<string, string | null>
+  toggledContextMap: Record<string, string | undefined>
 }
 
 export interface FourUpUser {
@@ -197,8 +196,8 @@ export class FourUpComponent extends BaseComponent<IProps, IState> {
         const name = isToggled ? fullName : initials;
         return (
           isToggled && viaStudentGroupView
-            ?
-              <button className="restore-fourup-button" onClick={()=>this.handleOverlayClick(context)}>
+            ? //pass an undefined context to handleOverlayClick to null out selected quadrant
+              <button className="restore-fourup-button" onClick={()=>this.handleOverlayClick()}>
                 <FourUpIcon /> 4-Up
               </button>
             : <div className={className} title={fullName} onClick={()=>this.handleOverlayClick(context)}>
@@ -351,24 +350,22 @@ export class FourUpComponent extends BaseComponent<IProps, IState> {
     window.addEventListener("mouseup", handleMouseUp);
   };
 
-  private handleOverlayClick = (context: string) => {
-    const { groupId, setFocusedGroupUser, onToggleContext } = this.props;
-    const groupUser = this.userByContext[context];
+  private handleOverlayClick = (context?: string) => {
+    const { groupId, setFocusedGroupUser } = this.props;
+    const groupUser = context ? this.userByContext[context] : undefined;
     const toggledContext = this.getToggledContext();
-    console.log("groupUser", groupUser);
     this.setState(state => {
       if (groupId) {
         const current = state.toggledContextMap[groupId] ?? null;
-        state.toggledContextMap[groupId] = current ? null : context;
+        state.toggledContextMap[groupId] = current ? undefined : context;
       }
       return { toggledContextMap: clone(state.toggledContextMap) };
-     });
+    });
+    setFocusedGroupUser && setFocusedGroupUser(groupUser?.user);
+
     if (groupUser) {
       const event = toggledContext ? LogEventName.DASHBOARD_SELECT_STUDENT : LogEventName.DASHBOARD_DESELECT_STUDENT;
       Logger.log(event, {groupId, studentId: groupUser.user.id});
     }
-    const focusedGroupUser = groupUser?.user || undefined;
-    setFocusedGroupUser && setFocusedGroupUser(groupUser?.user);
-    onToggleContext && onToggleContext(context, context? groupUser?.user : undefined);
   };
 }

--- a/src/models/document/document-utils.ts
+++ b/src/models/document/document-utils.ts
@@ -50,16 +50,18 @@ export function getGroupUsers(groups: any, documents: any, groupId: string | und
                            ? documents.getLastPublishedProblemDocumentsForGroup(groupId)
                            : documents.getProblemDocumentsForGroup(groupId)
                          ) || [];
+  const quadrants = [ "four-up-nw", "four-up-ne", "four-up-se", "four-up-sw"];
   const groupUsers: FourUpUser[] = group
     ? group.users
-        .map((groupUser: any) => {
+        .map((groupUser: any, idx: number) => {
           const groupUserDoc = groupDocuments && groupDocuments.find((groupDocument: any) => {
             return groupDocument.uid === groupUser.id;
           });
           return {
             user: groupUser,
             doc: groupUserDoc,
-            initials: groupUser.initials
+            initials: groupUser.initials,
+            context: quadrants[idx]
           };
         })
     : [];

--- a/src/models/document/document-utils.ts
+++ b/src/models/document/document-utils.ts
@@ -1,4 +1,6 @@
 import { getParent } from "mobx-state-tree";
+import { DocumentViewMode } from "../../components/document/document";
+import { FourUpUser } from "../../components/four-up";
 import { ProblemModelType } from "../curriculum/problem";
 import { SectionModelType } from "../curriculum/section";
 import { getSectionPath } from "../curriculum/unit";
@@ -22,14 +24,14 @@ export function getDocumentDisplayTitle(
 
 /**
  * Returns the key for user documents or path for problem documents
- * @param document 
- * @returns 
+ * @param document
+ * @returns
  */
 export function getDocumentIdentifier(document?: DocumentContentModelType) {
   if (!document) {
     return undefined;
   }
-  
+
   const parent = getParent(document);
   if (Object.hasOwn(parent, "key")) {
     return (parent as DocumentModelType).key;
@@ -37,4 +39,29 @@ export function getDocumentIdentifier(document?: DocumentContentModelType) {
     const section = parent as SectionModelType;
     return getSectionPath(section);
   }
+}
+
+// Utility function that creates an array of dictionaries of students and their docs in a group
+export function getGroupUsers(groups: any, documents: any, groupId: string | undefined,
+    documentViewMode?: DocumentViewMode) {
+  const group = groups.getGroupById(groupId);
+  const groupDocuments = group && groupId &&
+                         (documentViewMode === DocumentViewMode.Published
+                           ? documents.getLastPublishedProblemDocumentsForGroup(groupId)
+                           : documents.getProblemDocumentsForGroup(groupId)
+                         ) || [];
+  const groupUsers: FourUpUser[] = group
+    ? group.users
+        .map((groupUser: any) => {
+          const groupUserDoc = groupDocuments && groupDocuments.find((groupDocument: any) => {
+            return groupDocument.uid === groupUser.id;
+          });
+          return {
+            user: groupUser,
+            doc: groupUserDoc,
+            initials: groupUser.initials
+          };
+        })
+    : [];
+  return groupUsers;
 }

--- a/src/models/document/document-utils.ts
+++ b/src/models/document/document-utils.ts
@@ -42,7 +42,7 @@ export function getDocumentIdentifier(document?: DocumentContentModelType) {
 }
 
 // Utility function that creates an array of dictionaries of students and their docs in a group
-export function getGroupUsers(groups: any, documents: any, groupId: string | undefined,
+export function getGroupUsers(userId: string | undefined, groups: any, documents: any, groupId: string | undefined,
     documentViewMode?: DocumentViewMode) {
   const group = groups.getGroupById(groupId);
   const groupDocuments = group && groupId &&
@@ -65,5 +65,12 @@ export function getGroupUsers(groups: any, documents: any, groupId: string | und
           };
         })
     : [];
+
+   // put the primary user's document first (i.e. in the upper-left corner)
+  groupUsers.sort((a, b) => {
+    if (a.user.id === userId) return -1;
+    if (b.user.id === userId) return 1;
+    return 0;
+  });
   return groupUsers;
 }


### PR DESCRIPTION
Replaces the group name with the student name and document name of the currently open 1up view title bar in Student Workspaces tab. When user clicks on 4up button, title bar shows the group name again.
Also moved the student's name from the document title bar to the group buttons area. The student name buttons are currently none functional.