### PR TITLE
185279553 gripper v2 output

### DIFF
--- a/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
@@ -357,9 +357,9 @@ context('Dataflow Tool Tile', function () {
       });
       it("verify live output types", () => {
         const dropdown = "liveOutputType";
-        const outputTypes = ["Light Bulb", "Grabber", "Humidifier", "Fan", "Heat Lamp"];
+        const outputTypes = ["Light Bulb", "Grabber", "Gripper 2.0", "Humidifier", "Fan", "Heat Lamp"];
         dataflowToolTile.getDropdown(nodeType, dropdown).click();
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).should("have.length", 5);
+        dataflowToolTile.getDropdownOptions(nodeType, dropdown).should("have.length", 6);
         dataflowToolTile.getDropdownOptions(nodeType, dropdown).each(($tab, index, $typeList) => {
           expect($tab.text()).to.contain(outputTypes[index]);
         });
@@ -372,7 +372,7 @@ context('Dataflow Tool Tile', function () {
       it("verify live binary outputs indicate hub not present if not connected", () => {
         const dropdown = "liveOutputType";
         dataflowToolTile.getDropdown(nodeType, dropdown).click();
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).eq(3).click();
+        dataflowToolTile.getDropdownOptions(nodeType, dropdown).eq(4).click();
         dataflowToolTile.getDropdown(nodeType, dropdown).contains("Fan").should("exist");
         dataflowToolTile.getOutputNodeValueText().should("contain", "(no hub)");
       });

--- a/src/models/stores/serial.ts
+++ b/src/models/stores/serial.ts
@@ -1,5 +1,5 @@
 import { NodeChannelInfo } from "src/plugins/dataflow/model/utilities/channel";
-import { NodeLiveOutputTypes, kAngleBases } from "../../plugins/dataflow/model/utilities/node";
+import { NodeLiveOutputTypes, kGripperVersions } from "../../plugins/dataflow/model/utilities/node";
 
 export class SerialDevice {
   localBuffer: string;
@@ -161,11 +161,10 @@ export class SerialDevice {
   }
 
   public writeToOutForBBGripper(n:number, liveOutputType: string){
-    const percent = n / 100;
-    const angleBase: number = kAngleBases[liveOutputType];
-    const openTo = Math.round(angleBase - (percent * 60));
-
-    if(this.hasPort()){
+    const gripperVer = NodeLiveOutputTypes.find(o => o.name === liveOutputType);
+    if (this.hasPort() && gripperVer?.angleBase){
+      const percent = n / 100;
+      const openTo = Math.round(gripperVer.angleBase - (percent * 60));
       this.writer.write(`${openTo.toString()}\n`);
     }
   }

--- a/src/models/stores/serial.ts
+++ b/src/models/stores/serial.ts
@@ -1,5 +1,5 @@
 import { NodeChannelInfo } from "src/plugins/dataflow/model/utilities/channel";
-import { NodeLiveOutputTypes, kGripperVersions } from "../../plugins/dataflow/model/utilities/node";
+import { NodeLiveOutputTypes } from "../../plugins/dataflow/model/utilities/node";
 
 export class SerialDevice {
   localBuffer: string;

--- a/src/models/stores/serial.ts
+++ b/src/models/stores/serial.ts
@@ -161,20 +161,10 @@ export class SerialDevice {
   }
 
   public writeToOutForBBGripper(n:number){
-    console.log("2 | serial.ts | writeToOut(n):    ", n);
-
     const percent = n / 100;
-    console.log("3 | serial.ts |  ...calcs pct:    ", percent);
-
     let openTo = Math.round(180 - (percent * 60));
-    // if (openTo > 160) openTo = 180;
-    // if (openTo < 130) openTo = 120;
-    console.log("4 | serial.ts |  ...calcs openTo:  ", openTo);
-
-
     if(this.hasPort()){
       this.writer.write(`${openTo.toString()}\n`);
-      console.log("5 | serial.ts |  ...sends it out...      ");
     }
   }
 }

--- a/src/models/stores/serial.ts
+++ b/src/models/stores/serial.ts
@@ -1,5 +1,5 @@
 import { NodeChannelInfo } from "src/plugins/dataflow/model/utilities/channel";
-import { NodeLiveOutputTypes } from "../../plugins/dataflow/model/utilities/node";
+import { NodeLiveOutputTypes, angleBases } from "../../plugins/dataflow/model/utilities/node";
 
 export class SerialDevice {
   localBuffer: string;
@@ -162,10 +162,8 @@ export class SerialDevice {
 
   public writeToOutForBBGripper(n:number, liveOutputType: string){
     const percent = n / 100;
-    // temporary hard code version for testing
-    const gripperVersion = 2;
 
-    const angleBase = gripperVersion === 2 ? 100 : 180;
+    const angleBase = angleBases[liveOutputType as keyof typeof angleBases];
     const openTo = Math.round(angleBase - (percent * 60));
 
     if(this.hasPort()){

--- a/src/models/stores/serial.ts
+++ b/src/models/stores/serial.ts
@@ -161,57 +161,15 @@ export class SerialDevice {
   }
 
   public writeToOutForBBGripper(n:number, liveOutputType: string){
-    //const gripperVersion = liveOutputType === "Grabber" ? 1 : 2;
-    // temporary for testing
+    const percent = n / 100;
+    // temporary hard code version for testing
     const gripperVersion = 2;
-    let openTo = this.getOpenToForBBGripper(n, gripperVersion);
+
+    const angleBase = gripperVersion === 2 ? 100 : 180;
+    const openTo = Math.round(angleBase - (percent * 60));
+
     if(this.hasPort()){
       this.writer.write(`${openTo.toString()}\n`);
-      console.log("| percent: ", n, " | openTo: ", openTo, " | gripperVersion: ", gripperVersion);
-    }
-  }
-
-  public getOpenToForBBGripper(n:number, gripperVersion: number){
-    const percent = n / 100;
-    switch (gripperVersion){
-      case 1:
-        return Math.round(180 - (percent * 60));
-      case 2:
-        const min = 924;
-        const max = 1583;
-        const scaled = min + (percent * (max - min));
-        return Math.round(scaled);
-      default:
-        return Math.round(180 - (percent * 60));
     }
   }
 }
-
-/*
-
-TEMPORARY
- dummy servo program for figuring out angles on new BB gripper
-
-#include <Servo.h>
-//angle constant can take value in range from 750 to 2250
-#define MIN_SERVO_ANGLE 924
-#define MAX_SERVO_ANGLE 1583
-#define MODE_NORMAL_OPEN 0
-#define MODE_NORMAL_CLOSED 1
-int servoPin = 2;
-Servo Gripper;
-
-void setup() {
-  Serial.begin(9600);
-  Gripper.attach(servoPin);
-  Gripper.write(MIN_SERVO_ANGLE);
-}
-
-void loop() {
-  delay(1000);
-  Gripper.write(MAX_SERVO_ANGLE);
-  delay(1000);
-  Gripper.write(MIN_SERVO_ANGLE);
-}
-
-*/

--- a/src/models/stores/serial.ts
+++ b/src/models/stores/serial.ts
@@ -167,8 +167,8 @@ export class SerialDevice {
     console.log("3 | serial.ts |  ...calcs pct:    ", percent);
 
     let openTo = Math.round(180 - (percent * 60));
-    if (openTo > 160) openTo = 180;
-    if (openTo < 130) openTo = 120;
+    // if (openTo > 160) openTo = 180;
+    // if (openTo < 130) openTo = 120;
     console.log("4 | serial.ts |  ...calcs openTo:  ", openTo);
 
 

--- a/src/models/stores/serial.ts
+++ b/src/models/stores/serial.ts
@@ -162,16 +162,19 @@ export class SerialDevice {
 
   public writeToOutForBBGripper(n:number){
     console.log("2 | serial.ts | writeToOut(n):    ", n);
-    console.log("3 | serial.ts |  ...calcs pct:    ", n / 100);
-    console.log("4 | serial.ts |  ...calcs openTo: ", Math.round(180 - (n / 100 * 60)));
+
     const percent = n / 100;
+    console.log("3 | serial.ts |  ...calcs pct:    ", percent);
+
     let openTo = Math.round(180 - (percent * 60));
     if (openTo > 160) openTo = 180;
     if (openTo < 130) openTo = 120;
+    console.log("4 | serial.ts |  ...calcs openTo:  ", openTo);
+
 
     if(this.hasPort()){
       this.writer.write(`${openTo.toString()}\n`);
-
+      console.log("5 | serial.ts |  ...sends it out...      ");
     }
   }
 }

--- a/src/models/stores/serial.ts
+++ b/src/models/stores/serial.ts
@@ -161,10 +161,13 @@ export class SerialDevice {
   }
 
   public writeToOutForBBGripper(n:number, liveOutputType: string){
-    const gripperVersion = liveOutputType === "Grabber" ? 1 : 2;
+    //const gripperVersion = liveOutputType === "Grabber" ? 1 : 2;
+    // temporary for testing
+    const gripperVersion = 2;
     let openTo = this.getOpenToForBBGripper(n, gripperVersion);
     if(this.hasPort()){
       this.writer.write(`${openTo.toString()}\n`);
+      console.log("| percent: ", n, " | openTo: ", openTo, " | gripperVersion: ", gripperVersion);
     }
   }
 
@@ -174,9 +177,41 @@ export class SerialDevice {
       case 1:
         return Math.round(180 - (percent * 60));
       case 2:
-        return Math.round(180 - (percent * 90));
+        const min = 924;
+        const max = 1583;
+        const scaled = min + (percent * (max - min));
+        return Math.round(scaled);
       default:
         return Math.round(180 - (percent * 60));
     }
   }
 }
+
+/*
+
+TEMPORARY
+ dummy servo program for figuring out angles on new BB gripper
+
+#include <Servo.h>
+//angle constant can take value in range from 750 to 2250
+#define MIN_SERVO_ANGLE 924
+#define MAX_SERVO_ANGLE 1583
+#define MODE_NORMAL_OPEN 0
+#define MODE_NORMAL_CLOSED 1
+int servoPin = 2;
+Servo Gripper;
+
+void setup() {
+  Serial.begin(9600);
+  Gripper.attach(servoPin);
+  Gripper.write(MIN_SERVO_ANGLE);
+}
+
+void loop() {
+  delay(1000);
+  Gripper.write(MAX_SERVO_ANGLE);
+  delay(1000);
+  Gripper.write(MIN_SERVO_ANGLE);
+}
+
+*/

--- a/src/models/stores/serial.ts
+++ b/src/models/stores/serial.ts
@@ -1,5 +1,5 @@
 import { NodeChannelInfo } from "src/plugins/dataflow/model/utilities/channel";
-import { NodeLiveOutputTypes, angleBases } from "../../plugins/dataflow/model/utilities/node";
+import { NodeLiveOutputTypes, kAngleBases } from "../../plugins/dataflow/model/utilities/node";
 
 export class SerialDevice {
   localBuffer: string;
@@ -162,8 +162,7 @@ export class SerialDevice {
 
   public writeToOutForBBGripper(n:number, liveOutputType: string){
     const percent = n / 100;
-
-    const angleBase = angleBases[liveOutputType as keyof typeof angleBases];
+    const angleBase: number = kAngleBases[liveOutputType];
     const openTo = Math.round(angleBase - (percent * 60));
 
     if(this.hasPort()){

--- a/src/models/stores/serial.ts
+++ b/src/models/stores/serial.ts
@@ -160,11 +160,23 @@ export class SerialDevice {
     this.writer.write(`${controlMessage}\n`);
   }
 
-  public writeToOutForBBGripper(n:number){
-    const percent = n / 100;
-    let openTo = Math.round(180 - (percent * 60));
+  public writeToOutForBBGripper(n:number, liveOutputType: string){
+    const gripperVersion = liveOutputType === "Grabber" ? 1 : 2;
+    let openTo = this.getOpenToForBBGripper(n, gripperVersion);
     if(this.hasPort()){
       this.writer.write(`${openTo.toString()}\n`);
+    }
+  }
+
+  public getOpenToForBBGripper(n:number, gripperVersion: number){
+    const percent = n / 100;
+    switch (gripperVersion){
+      case 1:
+        return Math.round(180 - (percent * 60));
+      case 2:
+        return Math.round(180 - (percent * 90));
+      default:
+        return Math.round(180 - (percent * 60));
     }
   }
 }

--- a/src/models/stores/serial.ts
+++ b/src/models/stores/serial.ts
@@ -161,7 +161,9 @@ export class SerialDevice {
   }
 
   public writeToOutForBBGripper(n:number){
-    // "percent closed" is x% where 100% = 120deg and 0% = 180deg
+    console.log("2 | serial.ts | writeToOut(n):    ", n);
+    console.log("3 | serial.ts |  ...calcs pct:    ", n / 100);
+    console.log("4 | serial.ts |  ...calcs openTo: ", Math.round(180 - (n / 100 * 60)));
     const percent = n / 100;
     let openTo = Math.round(180 - (percent * 60));
     if (openTo > 160) openTo = 180;
@@ -169,7 +171,7 @@ export class SerialDevice {
 
     if(this.hasPort()){
       this.writer.write(`${openTo.toString()}\n`);
+
     }
   }
 }
-

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -802,7 +802,6 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
     const { deviceFamily } = this.stores.serialDevice;
 
     if (deviceFamily === "arduino" && isNumberOutput){
-      console.log("\n\n1 | tick | sendDataToSerialDevice |", n.data.nodeValue);
       this.stores.serialDevice.writeToOutForBBGripper(n.data.nodeValue as number);
     }
     if (deviceFamily === "microbit"){

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -701,6 +701,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
       "Live Output": (n: Node) => {
         this.updateNodeChannelInfo(n);
         this.sendDataToSerialDevice(n);
+        // NOTE this probably be the spot to send data to wherever the simuulator plans to find it
       }
     };
     let processNeeded = false;

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -726,7 +726,6 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
   };
 
   private tick = () => {
-    console.log("\n| tick |")
     const { readOnly, tileContent: tileModel, playBackIndex, programMode,
             isPlaying, updateRecordIndex, updatePlayBackIndex } = this.props;
 
@@ -802,10 +801,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
     const { deviceFamily } = this.stores.serialDevice;
 
     if (deviceFamily === "arduino" && isNumberOutput){
-      // console.log("1 | program | sendDataToSerialDevice |",
-      // "\n    recieved: node: ", n,
-      // "\n    sending n.data.nodeValue: ", n.data.nodeValue,
-      // )
+      console.log("\n\n1 | tick | sendDataToSerialDevice |", n.data.nodeValue);
       this.stores.serialDevice.writeToOutForBBGripper(n.data.nodeValue as number);
     }
     if (deviceFamily === "microbit"){

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -798,11 +798,12 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
   }
 
   private sendDataToSerialDevice(n: Node){
+    const liveOutputType = n.controls.get("hubSelect")?.getData("liveOutputType") as string;
     const isNumberOutput = isFinite(n.data.nodeValue as number);
     const { deviceFamily } = this.stores.serialDevice;
 
     if (deviceFamily === "arduino" && isNumberOutput){
-      this.stores.serialDevice.writeToOutForBBGripper(n.data.nodeValue as number);
+      this.stores.serialDevice.writeToOutForBBGripper(n.data.nodeValue as number, liveOutputType);
     }
     if (deviceFamily === "microbit"){
       const hubSelect = n.controls.get("hubSelect") as DropdownListControl;

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -726,6 +726,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
   };
 
   private tick = () => {
+    console.log("\n| tick |")
     const { readOnly, tileContent: tileModel, playBackIndex, programMode,
             isPlaying, updateRecordIndex, updatePlayBackIndex } = this.props;
 
@@ -801,6 +802,10 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
     const { deviceFamily } = this.stores.serialDevice;
 
     if (deviceFamily === "arduino" && isNumberOutput){
+      // console.log("1 | program | sendDataToSerialDevice |",
+      // "\n    recieved: node: ", n,
+      // "\n    sending n.data.nodeValue: ", n.data.nodeValue,
+      // )
       this.stores.serialDevice.writeToOutForBBGripper(n.data.nodeValue as number);
     }
     if (deviceFamily === "microbit"){

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -798,11 +798,11 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
   }
 
   private sendDataToSerialDevice(n: Node){
-    const liveOutputType = n.controls.get("hubSelect")?.getData("liveOutputType") as string;
     const isNumberOutput = isFinite(n.data.nodeValue as number);
     const { deviceFamily } = this.stores.serialDevice;
 
     if (deviceFamily === "arduino" && isNumberOutput){
+      const liveOutputType = n.controls.get("hubSelect")?.getData("liveOutputType") as string;
       this.stores.serialDevice.writeToOutForBBGripper(n.data.nodeValue as number, liveOutputType);
     }
     if (deviceFamily === "microbit"){

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -701,7 +701,6 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
       "Live Output": (n: Node) => {
         this.updateNodeChannelInfo(n);
         this.sendDataToSerialDevice(n);
-        // NOTE this probably be the spot to send data to wherever the simuulator plans to find it
       }
     };
     let processNeeded = false;
@@ -803,7 +802,9 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
 
     if (deviceFamily === "arduino" && isNumberOutput){
       const liveOutputType = n.controls.get("hubSelect")?.getData("liveOutputType") as string;
-      this.stores.serialDevice.writeToOutForBBGripper(n.data.nodeValue as number, liveOutputType);
+      if (["Gripper v2", "Grabber"].includes(liveOutputType)){
+        this.stores.serialDevice.writeToOutForBBGripper(n.data.nodeValue as number, liveOutputType);
+      }
     }
     if (deviceFamily === "microbit"){
       const hubSelect = n.controls.get("hubSelect") as DropdownListControl;

--- a/src/plugins/dataflow/model/utilities/node.ts
+++ b/src/plugins/dataflow/model/utilities/node.ts
@@ -454,10 +454,14 @@ export const ProgramDataRates: ProgramDataRate[] = [
   }
 ];
 
-export const angleBases = {
+export type AngleBases = {
+  [key: string]: number;
+};
+
+export const kAngleBases: AngleBases = {
   "Gripper 2.0": 100,
   "Grabber": 180
-}
+};
 
 export const kSensorSelectMessage = "Select a sensor";
 export const kSensorMissingMessage = "⚠️";

--- a/src/plugins/dataflow/model/utilities/node.ts
+++ b/src/plugins/dataflow/model/utilities/node.ts
@@ -318,11 +318,13 @@ export const NodeLiveOutputTypes = [
   },
   {
     name: "Grabber",
-    icon: GrabberIcon
+    icon: GrabberIcon,
+    angleBase: 180
   },
   {
-    name: "Gripper 2.0",
-    icon: GrabberIcon
+    name: "Gripper v2",
+    icon: GrabberIcon,
+    angleBase: 100
   },
   {
     name: "Humidifier",
@@ -454,18 +456,9 @@ export const ProgramDataRates: ProgramDataRate[] = [
   }
 ];
 
-export type AngleBases = {
-  [key: string]: number;
-};
-
-export const kAngleBases: AngleBases = {
-  "Gripper 2.0": 100,
-  "Grabber": 180
-};
-
 export const kSensorSelectMessage = "Select a sensor";
 export const kSensorMissingMessage = "⚠️";
 export const kAnimatedBinaryTypes = ["Fan", "Humidifier"];
 export const kRelaysIndexed =  ["Heat Lamp", "Fan", "Humidifier"];
 export const kBinaryOutputTypes = [...kRelaysIndexed, "Light Bulb"];
-export const kRoundedOutputTypes = ["Grabber", "Gripper 2.0"];
+export const kRoundedOutputTypes = ["Grabber", "Gripper v2"];

--- a/src/plugins/dataflow/model/utilities/node.ts
+++ b/src/plugins/dataflow/model/utilities/node.ts
@@ -321,6 +321,10 @@ export const NodeLiveOutputTypes = [
     icon: GrabberIcon
   },
   {
+    name: "Gripper 2.0",
+    icon: GrabberIcon
+  },
+  {
     name: "Humidifier",
     icon: HumidIcon,
     relayIndex: 2
@@ -450,9 +454,14 @@ export const ProgramDataRates: ProgramDataRate[] = [
   }
 ];
 
+export const angleBases = {
+  "Gripper 2.0": 100,
+  "Grabber": 180
+}
+
 export const kSensorSelectMessage = "Select a sensor";
 export const kSensorMissingMessage = "⚠️";
 export const kAnimatedBinaryTypes = ["Fan", "Humidifier"];
 export const kRelaysIndexed =  ["Heat Lamp", "Fan", "Humidifier"];
 export const kBinaryOutputTypes = [...kRelaysIndexed, "Light Bulb"];
-export const kRoundedOutputTypes = ["Grabber"];
+export const kRoundedOutputTypes = ["Grabber", "Gripper 2.0"];

--- a/src/plugins/dataflow/nodes/factories/live-output-rete-node-factory.tsx
+++ b/src/plugins/dataflow/nodes/factories/live-output-rete-node-factory.tsx
@@ -8,7 +8,6 @@ import { NodeLiveOutputTypes, NodeMicroBitHubs,
 } from "../../model/utilities/node";
 import { dataflowLogEvent } from "../../dataflow-logger";
 import { NodeChannelInfo } from "../../model/utilities/channel";
-import { parse } from "initials";
 
 interface HubStatus {
   id: string,
@@ -34,12 +33,9 @@ export class LiveOutputReteNodeFactory extends DataflowReteNodeFactory {
   }
 
   public worker(node: NodeData, inputs: any, outputs: any) {
-
     // This node type is a "live" output and does not output a value into a rete outputs
     // Then the default NodeProcess takes the updated data and sends it out via Serial.
     const n1 = inputs.nodeValue.length ? inputs.nodeValue[0] : node.data.nodeValue;
-
-    console.log("| A | worker recieved: ", n1);
 
     if (this.editor) {
       const _node = this.editor.nodes.find((n: { id: any; }) => n.id === node.id);
@@ -49,7 +45,6 @@ export class LiveOutputReteNodeFactory extends DataflowReteNodeFactory {
         // handle data and display of data
         const outputTypeControl = _node.controls.get("liveOutputType") as DropdownListControl;
         const outputType = outputTypeControl.getValue();
-        console.log("| B | factory | outputType:  ", outputType);
         const nodeValue = _node.inputs.get("nodeValue")?.control as InputValueControl;
         let newValue = isNaN(n1) ? 0 : n1;
 
@@ -65,7 +60,6 @@ export class LiveOutputReteNodeFactory extends DataflowReteNodeFactory {
         if (kRoundedOutputTypes.includes(outputType)){
           newValue = this.getNewValueForGrabber(n1);
           const roundedDisplayValue = Math.round((newValue / 10) * 10);
-          console.log("| D | factory | roundedVal: ", roundedDisplayValue);
           nodeValue?.setDisplayMessage(`${roundedDisplayValue}% closed`);
         }
 
@@ -83,7 +77,6 @@ export class LiveOutputReteNodeFactory extends DataflowReteNodeFactory {
     if (num > 1)  return 100;
     if (num < 0)  return 0;
     const specialValue = parseInt((num * 100).toFixed(2), 10);
-    console.log("| C | factory | specialVal: ", specialValue);
     return specialValue;
   }
 

--- a/src/plugins/dataflow/nodes/factories/live-output-rete-node-factory.tsx
+++ b/src/plugins/dataflow/nodes/factories/live-output-rete-node-factory.tsx
@@ -58,7 +58,7 @@ export class LiveOutputReteNodeFactory extends DataflowReteNodeFactory {
         }
 
         if (kRoundedOutputTypes.includes(outputType)){
-          newValue = this.getNewValueForGrabber(n1);
+          newValue = this.getPercentageAsInteger(n1);
           const roundedDisplayValue = Math.round((newValue / 10) * 10);
           nodeValue?.setDisplayMessage(`${roundedDisplayValue}% closed`);
         }
@@ -73,11 +73,10 @@ export class LiveOutputReteNodeFactory extends DataflowReteNodeFactory {
     }
   }
 
-  private getNewValueForGrabber(num: number){
+  private getPercentageAsInteger(num: number){
     if (num > 1)  return 100;
     if (num < 0)  return 0;
-    const specialValue = parseInt((num * 100).toFixed(2), 10);
-    return specialValue;
+    return parseInt((num * 100).toFixed(2), 10);
   }
 
   private getSelectedRelayIndex(node: Node){

--- a/src/plugins/dataflow/nodes/factories/live-output-rete-node-factory.tsx
+++ b/src/plugins/dataflow/nodes/factories/live-output-rete-node-factory.tsx
@@ -8,6 +8,7 @@ import { NodeLiveOutputTypes, NodeMicroBitHubs,
 } from "../../model/utilities/node";
 import { dataflowLogEvent } from "../../dataflow-logger";
 import { NodeChannelInfo } from "../../model/utilities/channel";
+import { parse } from "initials";
 
 interface HubStatus {
   id: string,
@@ -36,6 +37,9 @@ export class LiveOutputReteNodeFactory extends DataflowReteNodeFactory {
     // This node type is a "live" output and does not output a value into a rete outputs
     // Then the default NodeProcess takes the updated data and sends it out via Serial.
     const n1 = inputs.nodeValue.length ? inputs.nodeValue[0] : node.data.nodeValue;
+
+    console.log("| A | factory | nodeValue:  ", n1);
+
     if (this.editor) {
       const _node = this.editor.nodes.find((n: { id: any; }) => n.id === node.id);
       if (_node) {
@@ -59,6 +63,7 @@ export class LiveOutputReteNodeFactory extends DataflowReteNodeFactory {
         if (kRoundedOutputTypes.includes(outputType)){
           newValue = this.getNewValueForGrabber(n1);
           const roundedDisplayValue = Math.round((newValue / 10) * 10);
+          console.log("| C | factory | roundedVal: ", roundedDisplayValue);
           nodeValue?.setDisplayMessage(`${roundedDisplayValue}% closed`);
         }
 
@@ -75,7 +80,9 @@ export class LiveOutputReteNodeFactory extends DataflowReteNodeFactory {
   private getNewValueForGrabber(num: number){
     if (num > 1)  return 100;
     if (num < 0)  return 0;
-    return parseInt((num * 100).toFixed(2), 10);
+    const specialValue = parseInt((num * 100).toFixed(2), 10);
+    console.log("| B | factory | specialVal: ", specialValue);
+    return specialValue;
   }
 
   private getSelectedRelayIndex(node: Node){

--- a/src/plugins/dataflow/nodes/factories/live-output-rete-node-factory.tsx
+++ b/src/plugins/dataflow/nodes/factories/live-output-rete-node-factory.tsx
@@ -34,11 +34,12 @@ export class LiveOutputReteNodeFactory extends DataflowReteNodeFactory {
   }
 
   public worker(node: NodeData, inputs: any, outputs: any) {
+
     // This node type is a "live" output and does not output a value into a rete outputs
     // Then the default NodeProcess takes the updated data and sends it out via Serial.
     const n1 = inputs.nodeValue.length ? inputs.nodeValue[0] : node.data.nodeValue;
 
-    console.log("| A | factory | nodeValue:  ", n1);
+    console.log("| A | worker recieved: ", n1);
 
     if (this.editor) {
       const _node = this.editor.nodes.find((n: { id: any; }) => n.id === node.id);
@@ -48,6 +49,7 @@ export class LiveOutputReteNodeFactory extends DataflowReteNodeFactory {
         // handle data and display of data
         const outputTypeControl = _node.controls.get("liveOutputType") as DropdownListControl;
         const outputType = outputTypeControl.getValue();
+        console.log("| B | factory | outputType:  ", outputType);
         const nodeValue = _node.inputs.get("nodeValue")?.control as InputValueControl;
         let newValue = isNaN(n1) ? 0 : n1;
 
@@ -63,7 +65,7 @@ export class LiveOutputReteNodeFactory extends DataflowReteNodeFactory {
         if (kRoundedOutputTypes.includes(outputType)){
           newValue = this.getNewValueForGrabber(n1);
           const roundedDisplayValue = Math.round((newValue / 10) * 10);
-          console.log("| C | factory | roundedVal: ", roundedDisplayValue);
+          console.log("| D | factory | roundedVal: ", roundedDisplayValue);
           nodeValue?.setDisplayMessage(`${roundedDisplayValue}% closed`);
         }
 
@@ -81,7 +83,7 @@ export class LiveOutputReteNodeFactory extends DataflowReteNodeFactory {
     if (num > 1)  return 100;
     if (num < 0)  return 0;
     const specialValue = parseInt((num * 100).toFixed(2), 10);
-    console.log("| B | factory | specialVal: ", specialValue);
+    console.log("| C | factory | specialVal: ", specialValue);
     return specialValue;
   }
 


### PR DESCRIPTION
This allows users to select and operate the BackyardBrains Gripper V2 with Dataflow, as described in [PT#185279553](https://www.pivotaltracker.com/story/show/185279553)
- We change the calculation of the angle based on the user choice of new or old gripper ( allowing us to use the same Arduino code for passing the angle data to the gripper's servo). 
- This removes the "cheating" built into the calculation that caused the claw to "stick" when near max or minimum angles. 
- This includes a note about upcoming integration with the simulation tile