### PR TITLE
add v2 gripper

### DIFF
--- a/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
@@ -357,9 +357,9 @@ context('Dataflow Tool Tile', function () {
       });
       it("verify live output types", () => {
         const dropdown = "liveOutputType";
-        const outputTypes = ["Light Bulb", "Grabber", "Humidifier", "Fan", "Heat Lamp"];
+        const outputTypes = ["Light Bulb", "Grabber", "Gripper v2", "Humidifier", "Fan", "Heat Lamp"];
         dataflowToolTile.getDropdown(nodeType, dropdown).click();
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).should("have.length", 5);
+        dataflowToolTile.getDropdownOptions(nodeType, dropdown).should("have.length", 6);
         dataflowToolTile.getDropdownOptions(nodeType, dropdown).each(($tab, index, $typeList) => {
           expect($tab.text()).to.contain(outputTypes[index]);
         });
@@ -372,7 +372,7 @@ context('Dataflow Tool Tile', function () {
       it("verify live binary outputs indicate hub not present if not connected", () => {
         const dropdown = "liveOutputType";
         dataflowToolTile.getDropdown(nodeType, dropdown).click();
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).eq(3).click();
+        dataflowToolTile.getDropdownOptions(nodeType, dropdown).eq(4).click();
         dataflowToolTile.getDropdown(nodeType, dropdown).contains("Fan").should("exist");
         dataflowToolTile.getOutputNodeValueText().should("contain", "(no hub)");
       });

--- a/src/models/stores/serial.ts
+++ b/src/models/stores/serial.ts
@@ -160,14 +160,11 @@ export class SerialDevice {
     this.writer.write(`${controlMessage}\n`);
   }
 
-  public writeToOutForBBGripper(n:number){
-    // "percent closed" is x% where 100% = 120deg and 0% = 180deg
-    const percent = n / 100;
-    let openTo = Math.round(180 - (percent * 60));
-    if (openTo > 160) openTo = 180;
-    if (openTo < 130) openTo = 120;
-
-    if(this.hasPort()){
+  public writeToOutForBBGripper(n:number, liveOutputType: string){
+    const gripperVer = NodeLiveOutputTypes.find(o => o.name === liveOutputType);
+    if (this.hasPort() && gripperVer?.angleBase){
+      const percent = n / 100;
+      const openTo = Math.round(gripperVer.angleBase - (percent * 60));
       this.writer.write(`${openTo.toString()}\n`);
     }
   }

--- a/src/plugins/dataflow/model/utilities/node.ts
+++ b/src/plugins/dataflow/model/utilities/node.ts
@@ -329,7 +329,13 @@ export const NodeLiveOutputTypes = [
   },
   {
     name: "Grabber",
-    icon: GrabberIcon
+    icon: GrabberIcon,
+    angleBase: 180,
+  },
+  {
+    name: "Gripper v2",
+    icon: GrabberIcon,
+    angleBase: 100
   },
   {
     name: "Humidifier",
@@ -466,4 +472,4 @@ export const kSensorMissingMessage = "⚠️";
 export const kAnimatedBinaryTypes = ["Fan", "Humidifier"];
 export const kRelaysIndexed =  ["Heat Lamp", "Fan", "Humidifier"];
 export const kBinaryOutputTypes = [...kRelaysIndexed, "Light Bulb"];
-export const kRoundedOutputTypes = ["Grabber"];
+export const kRoundedOutputTypes = ["Grabber", "Gripper v2"];

--- a/src/plugins/dataflow/model/utilities/simulated-output.ts
+++ b/src/plugins/dataflow/model/utilities/simulated-output.ts
@@ -1,6 +1,5 @@
 import { Node } from "rete";
 import { VariableType } from "@concord-consortium/diagram-view";
-
 import { getOutputType } from "../../nodes/utilities/live-output-utilities";
 
 export const kOutputVariablePrefix = "output_";

--- a/src/plugins/dataflow/nodes/factories/live-output-rete-node-factory.tsx
+++ b/src/plugins/dataflow/nodes/factories/live-output-rete-node-factory.tsx
@@ -57,7 +57,7 @@ export class LiveOutputReteNodeFactory extends DataflowReteNodeFactory {
         }
 
         if (kRoundedOutputTypes.includes(outputType)){
-          newValue = this.getNewValueForGrabber(n1);
+          newValue = this.getPercentageAsInt(n1);
           const roundedDisplayValue = Math.round((newValue / 10) * 10);
           nodeValue?.setDisplayMessage(`${roundedDisplayValue}% closed`);
         }
@@ -72,7 +72,7 @@ export class LiveOutputReteNodeFactory extends DataflowReteNodeFactory {
     }
   }
 
-  private getNewValueForGrabber(num: number){
+  private getPercentageAsInt(num: number){
     if (num > 1)  return 100;
     if (num < 0)  return 0;
     return parseInt((num * 100).toFixed(2), 10);

--- a/src/plugins/dataflow/nodes/factories/sensor-rete-node-factory.tsx
+++ b/src/plugins/dataflow/nodes/factories/sensor-rete-node-factory.tsx
@@ -23,7 +23,6 @@ export class SensorReteNodeFactory extends DataflowReteNodeFactory {
   }
 
   public worker(node: NodeData, inputs: any, outputs: any) {
-
     const makeZero = node.data.type === "fsr-reading" && isNaN(node.data.nodeValue as number);
     outputs.num = makeZero ? 0 : node.data.nodeValue;
 

--- a/src/plugins/dataflow/nodes/utilities/live-output-utilities.ts
+++ b/src/plugins/dataflow/nodes/utilities/live-output-utilities.ts
@@ -1,6 +1,11 @@
 import { Node } from "rete";
 import { DropdownListControl } from "../controls/dropdown-list-control";
 
+interface NodeOutputValue {
+  val: number;
+  outType: string;
+}
+
 export function getHubSelect(node: Node) {
   return node.controls.get("hubSelect") as DropdownListControl;
 }
@@ -8,4 +13,10 @@ export function getHubSelect(node: Node) {
 export function getOutputType(node: Node) {
   const outputTypeControl = node.controls.get("liveOutputType") as DropdownListControl;
   return outputTypeControl.getValue();
+}
+
+export function getNodeValueWithType(node: Node): NodeOutputValue {
+  const val = node.data.nodeValue as number;
+  const outType = getOutputType(node);
+  return { val, outType };
 }


### PR DESCRIPTION
This allows users to select and operate the BackyardBrains Gripper V2 with Dataflow, as described in [PT#185279553](https://www.pivotaltracker.com/story/show/185279553)

- Change the calculation of the angle based on the user choice of new or old gripper ( allowing us to use the same Arduino code for passing the angle data to the gripper's servo).

- This removes the "cheating" built into the calculation that caused the claw to "stick" when near max or minimum angles.