### PR TITLE
185309379 Set a simulated channel's type based on its name.

### DIFF
--- a/src/plugins/dataflow/model/utilities/simulated-channel.ts
+++ b/src/plugins/dataflow/model/utilities/simulated-channel.ts
@@ -3,7 +3,9 @@
 // A sensor using a simulated channel uses the shared variable's value as its own on every tick.
 
 import { VariableType } from "@concord-consortium/diagram-view";
+
 import { NodeChannelInfo } from "./channel";
+import { NodeSensorTypes } from "./node";
 
 export const kSimulatedChannelType = "simulated-channel";
 export const kInputVariablePrefix = "input_";
@@ -25,12 +27,16 @@ function simulatedChannelName(variable: VariableType) {
 }
 
 export function simulatedChannel(variable: VariableType): NodeChannelInfo {
+  const name = inputVariableNamePart(variable) ?? "";
+  const lowerName = name.toLowerCase();
+  const sensorType = NodeSensorTypes.find(nst => nst.name.toLowerCase() === lowerName);
+  const type = sensorType?.type ?? kSimulatedChannelType;
   return {
     hubId: "",
     hubName: "",
     channelId: simulatedChannelId(variable),
     missing: false,
-    type: kSimulatedChannelType,
+    type,
     units: variable.computedUnit ?? "",
     value: variable.computedValue ?? 0,
     name: simulatedChannelName(variable) || "",


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/185309379

This follow up PR makes it so input variables will appear in a sensor node's bottom dropdown when the appropriate sensor type is selected. It does this by trying to match the input variable's name with a sensor type's name, then giving the simulated channel the corresponding type.