### PR TITLE
185382726 student button functionality

### DIFF
--- a/src/components/document/student-group-view.scss
+++ b/src/components/document/student-group-view.scss
@@ -65,16 +65,44 @@
           padding: 5px;
 
           &.four-up-nw {
-            background-color: $id-blue
+            background-color: $id-blue-light;
+            &:hover {
+              background-color: $id-blue-medium;;
+            }
+            &.focused {
+              background-color: $id-blue;
+              border-color: white;
+            }
           }
           &.four-up-ne {
-            background-color: $id-orange
+            background-color: $id-orange-light;
+            &:hover {
+              background-color: $id-orange-medium;;
+            }
+            &.focused {
+              background-color: $id-orange;
+              border-color: white;
+            }
           }
           &.four-up-se {
-            background-color: $id-green
+            background-color: $id-green-light;
+            &:hover {
+              background-color: $id-green-medium;;
+            }
+            &.focused {
+              background-color: $id-green;
+              border-color: white;
+            }
           }
           &.four-up-sw {
-            background-color: $id-purple
+            background-color: $id-purple-light;
+            &:hover {
+              background-color: $id-purple-medium;;
+            }
+            &.focused {
+              background-color: $id-purple;
+              border-color: white;
+            }
           }
         }
       }

--- a/src/components/document/student-group-view.tsx
+++ b/src/components/document/student-group-view.tsx
@@ -5,8 +5,7 @@ import { GroupUserModelType } from "../../models/stores/groups";
 import { useProblemStore, useUIStore, useStores } from "../../hooks/use-stores";
 import { Logger } from "../../lib/logger";
 import { LogEventName } from "../../lib/logger-types";
-import { FourUpComponent } from "../four-up";
-
+import { FourUpComponent, FourUpUser } from "../four-up";
 import "./student-group-view.scss";
 
 interface IGroupButtonProps {
@@ -40,7 +39,7 @@ interface IProps {
   setGroupId: (groupId: string) => void;
 }
 export const StudentGroupView:React.FC<IProps> = ({ groupId, setGroupId }) => {
-  const {user, groups, documents} = useStores();
+  const {groups, documents} = useStores();
   const [focusedGroupUser, setFocusedGroupUser] = useState<GroupUserModelType | undefined>();
   const selectedGroupId = groupId || (groups.allGroups.length ? groups.allGroups[0].id : "");
   const groupUsers = getGroupUsers(user.id, groups, documents, selectedGroupId);
@@ -57,6 +56,11 @@ export const StudentGroupView:React.FC<IProps> = ({ groupId, setGroupId }) => {
     setGroupId(id);
     setFocusedGroupUser(undefined);
   };
+
+  const handleFocusedUserChange = (selectedUser: FourUpUser) => {
+    setFocusedGroupUser(selectedUser.user);
+  };
+
   const GroupViewTitlebar: React.FC<IGroupViewTitlebarProps> = ({ selectedId, onSelectGroup }) => {
     return (
       <div className={`titlebar student-group group`}>
@@ -67,9 +71,13 @@ export const StudentGroupView:React.FC<IProps> = ({ groupId, setGroupId }) => {
                             selected={group.id === selectedId}
               />
               { groupUsers.map(u => {
-                  const className = classNames("member-button", "in-student-group-view", u.context);
+                  const className = classNames("member-button", "in-student-group-view", u.context,
+                                                {focused: u.user.id === focusedGroupUser.id});
                 return (
-                  <div key={u.user.name} className={className} title={u.user.name}>{u.user.name}</div>
+                  <button key={u.user.name} className={className} title={u.user.name}
+                      onClick={()=>handleFocusedUserChange(u)}>
+                    {u.user.name}
+                  </button>
                 );
               })}
             </>
@@ -86,7 +94,7 @@ export const StudentGroupView:React.FC<IProps> = ({ groupId, setGroupId }) => {
     );
   };
 
-  const GroupTitlebar: React.FC<IGroupTitlebarProps> = ({selectedId, groupUser}) => {
+  const GroupTitlebar: React.FC<IGroupTitlebarProps> = ({groupUser}) => {
     const problem = useProblemStore();
     const userInfo = groupUsers.find(gUser => gUser.user.id === groupUser?.id);
     const userDocTitle = userInfo?.doc?.title || "Document";
@@ -109,7 +117,7 @@ export const StudentGroupView:React.FC<IProps> = ({ groupId, setGroupId }) => {
       <GroupViewTitlebar selectedId={selectedGroupId} onSelectGroup={handleSelectGroup} />
       <GroupTitlebar selectedId={selectedGroupId} groupUser={focusedGroupUser}/>
       <div className="canvas-area">
-        <FourUpComponent userId={user.id}
+        <FourUpComponent userId={focusedGroupUser?.id}
                          groupId={selectedGroupId}
                          isGhostUser={true}
                          viaStudentGroupView={true}

--- a/src/components/document/student-group-view.tsx
+++ b/src/components/document/student-group-view.tsx
@@ -112,15 +112,17 @@ export const StudentGroupView:React.FC<IProps> = ({ groupId, setGroupId }) => {
     );
   };
 
+  const focusedUserContext = (groupUsers.find(u => u.user.id === focusedGroupUser?.id))?.context;
+
   return (
     <div key="student-group-view" className={classes}>
       <GroupViewTitlebar selectedId={selectedGroupId} onSelectGroup={handleSelectGroup} />
       <GroupTitlebar selectedId={selectedGroupId} groupUser={focusedGroupUser}/>
       <div className="canvas-area">
-        <FourUpComponent userId={focusedGroupUser?.id}
-                         groupId={selectedGroupId}
+        <FourUpComponent groupId={selectedGroupId}
                          isGhostUser={true}
                          viaStudentGroupView={true}
+                         focusedUserContext={focusedUserContext}
                          setFocusedGroupUser={setFocusedGroupUser}
         />
       </div>

--- a/src/components/document/student-group-view.tsx
+++ b/src/components/document/student-group-view.tsx
@@ -39,7 +39,7 @@ interface IProps {
   setGroupId: (groupId: string) => void;
 }
 export const StudentGroupView:React.FC<IProps> = ({ groupId, setGroupId }) => {
-  const {groups, documents} = useStores();
+  const {user, groups, documents} = useStores();
   const [focusedGroupUser, setFocusedGroupUser] = useState<GroupUserModelType | undefined>();
   const selectedGroupId = groupId || (groups.allGroups.length ? groups.allGroups[0].id : "");
   const groupUsers = getGroupUsers(user.id, groups, documents, selectedGroupId);

--- a/src/components/four-up.tsx
+++ b/src/components/four-up.tsx
@@ -180,7 +180,7 @@ export class FourUpComponent extends BaseComponent<IProps, IState> {
       (cell: FourUpGridCellModelType, corner: string) => (toggledContext === corner ? 2 : 1) * cell.scale;
 
     const memberName = (context: string) => {
-      const groupUser = groupUsers.find(u => u.context === context);
+      const groupUser = this.userByContext[context];
       const isToggled = context === toggledContext;
       if (groupUser) {
         const { name: fullName, initials } = groupUser.user;

--- a/src/components/four-up.tsx
+++ b/src/components/four-up.tsx
@@ -180,7 +180,7 @@ export class FourUpComponent extends BaseComponent<IProps, IState> {
       (cell: FourUpGridCellModelType, corner: string) => (toggledContext === corner ? 2 : 1) * cell.scale;
 
     const memberName = (context: string) => {
-      const groupUser = this.userByContext[context];
+      const groupUser = groupUsers.find(u => u.context === context);
       const isToggled = context === toggledContext;
       if (groupUser) {
         const { name: fullName, initials } = groupUser.user;

--- a/src/components/four-up.tsx
+++ b/src/components/four-up.tsx
@@ -26,7 +26,8 @@ interface IProps extends IBaseProps {
   documentViewMode?: DocumentViewMode;
   selectedSectionId?: string | null;
   viaTeacherDashboard?: boolean;
-  viaStudentGroupView?: boolean
+  viaStudentGroupView?: boolean;
+  focusedUserContext?: string;
   setFocusedGroupUser?: (focusedGroupUser?: GroupUserModelType) => void;
 }
 
@@ -109,8 +110,9 @@ export class FourUpComponent extends BaseComponent<IProps, IState> {
   }
 
   public render() {
-    const {documentViewMode, viaStudentGroupView} = this.props;
-    const toggledContext = this.getToggledContext();
+    const {focusedUserContext, documentViewMode, viaStudentGroupView,
+        userId, groupId, isGhostUser, toggleable, ...others } = this.props;
+    const toggledContext = focusedUserContext || this.getToggledContext();
     const {width, height} = this.grid;
     const nwCell = this.grid.cells[CellPositions.NorthWest];
     const neCell = this.grid.cells[CellPositions.NorthEast];
@@ -129,8 +131,6 @@ export class FourUpComponent extends BaseComponent<IProps, IState> {
     };
 
     const { groups, documents } = this.stores;
-    const { userId, groupId, isGhostUser, toggleable, ...others } = this.props;
-
     const groupUsers = getGroupUsers(userId, groups, documents, groupId, documentViewMode);
 
     // save reference to use for the username display in this render and logger in #handleOverlayClicked
@@ -214,7 +214,7 @@ export class FourUpComponent extends BaseComponent<IProps, IState> {
           document={document}
         />;
 
-      // If we are looking at a specific student toggledContext equals the cornerLabel
+      // If we are looking at a specific student, toggledContext equals the cornerLabel
       // of that student. When we are looking at a specific student we need the overlay
       // to be inside of the Canvas so the canvas can put its history UI on top of the
       // overlay. When we are not looking at a specific student we need the overlay

--- a/src/components/four-up.tsx
+++ b/src/components/four-up.tsx
@@ -347,7 +347,6 @@ export class FourUpComponent extends BaseComponent<IProps, IState> {
     const { groupId, setFocusedGroupUser } = this.props;
     const groupUser = context ? this.userByContext[context] : undefined;
     const toggledContext = this.getToggledContext();
-    console.log("groupUser", groupUser);
     this.setState(state => {
       if (groupId) {
         const current = state.toggledContextMap[groupId] ?? null;

--- a/src/components/four-up.tsx
+++ b/src/components/four-up.tsx
@@ -347,6 +347,7 @@ export class FourUpComponent extends BaseComponent<IProps, IState> {
     const { groupId, setFocusedGroupUser } = this.props;
     const groupUser = context ? this.userByContext[context] : undefined;
     const toggledContext = this.getToggledContext();
+    console.log("groupUser", groupUser);
     this.setState(state => {
       if (groupId) {
         const current = state.toggledContextMap[groupId] ?? null;

--- a/src/components/vars.sass
+++ b/src/components/vars.sass
@@ -310,9 +310,17 @@ $charcoal-light-6: #eeeeee
 $charcoal-light-7: #f2f2f2
 $charcoal-light-8: #f6f6f6
 $charcoal-light-9: #f8f8f8
+$id-blue-light: #dff7ff
+$id-blue-medium: #aceaff
 $id-blue: #80e0ff
+$id-orange-light: #fff1e6
+$id-orange-medium: #ffdbbf
 $id-orange: #ffc89c
+$id-purple-light: #fff0fa
+$id-purple-medium: #ffd7f2
 $id-purple: #ffc1eb
+$id-green-light: #e4f9e8
+$id-green-medium: #b8f0c3
 $id-green: #91e7a2
 $new-comment-notice: #5fff32
 


### PR DESCRIPTION
Adds functionality the the student name buttons in Student Workspaces tab.
When in 1up view of a student's document, teacher should be able to switch student documents by clicking on the student name.
Note that clicking on the group button does not do anything when in student 1up view. But should still switch groups when in 4up view.