### PR TITLE
Only truncate group ids when they are too long.

### DIFF
--- a/src/models/stores/groups.ts
+++ b/src/models/stores/groups.ts
@@ -28,7 +28,8 @@ export const GroupModel = types
       return self.users.find(user => user.id === id);
     },
     get displayId() {
-      return self.id.slice(self.id.length - 3);
+      const maxChars = 3;
+      return self.id.length > maxChars ? self.id.slice(self.id.length - maxChars) : self.id;
     }
   }));
 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/185484498

Fixes a bug where group numbers with two digits would only show their final digit.