### PR TITLE
185453973 save node value fix

### DIFF
--- a/src/models/curriculum/problem.ts
+++ b/src/models/curriculum/problem.ts
@@ -1,5 +1,4 @@
 import { getSnapshot, Instance, SnapshotIn, types } from "mobx-state-tree";
-import { cloneDeep } from "lodash";
 import { SectionModel, SectionModelType } from "./section";
 import { SettingsMstType } from "../stores/settings";
 import { SupportModel } from "./support";

--- a/src/models/curriculum/problem.ts
+++ b/src/models/curriculum/problem.ts
@@ -44,10 +44,7 @@ const ModernProblemModel = types
           sharedModelManager
         };
         const sectionSnapshot = getSnapshot(section);
-        // We have to make a copy of the sectionSnapshot because child models modify
-        // their snapshots in place during preProcessor calls. The objects from
-        // getSnapshot are readonly
-        const sectionCopy = SectionModel.create(cloneDeep(sectionSnapshot), environment);
+        const sectionCopy = SectionModel.create(sectionSnapshot, environment);
         sectionCopy.setRealParent(self);
         if (sectionCopy.content) {
           sharedModelManager.setDocument(sectionCopy.content);

--- a/src/plugins/dataflow/model/dataflow-program-model.ts
+++ b/src/plugins/dataflow/model/dataflow-program-model.ts
@@ -164,7 +164,7 @@ export const DataflowProgramModel = types.
     }
   }))
   .preProcessSnapshot((snapshot: any) => {
-    const { nodes, ...rest } = snapshot;
+    const { nodes, ...rest } = cloneDeep(snapshot);
     const values: { [key: string]: any } = {};
     if (nodes) {
       const keys = Object.keys(nodes);


### PR DESCRIPTION
This is a change to address a bug that emerged when we updated mst to 5.1.8, as described in [PT#185453973](https://www.pivotaltracker.com/story/show/185453973) (Node values were not serializing). 
- In Dataflow, we make a copy of the snapshot before extracting the currentValues, rather than operating on it in place. 
- In the problem model, we no longer have to make the new copy

**leaving in draft until tests pass in cloud (already passed locally)**
