### PR TITLE
use pin A2 for fsr reading

### DIFF
--- a/src/plugins/dataflow-tool/arduino/ccemgfsr/ccemgfsr.ino
+++ b/src/plugins/dataflow-tool/arduino/ccemgfsr/ccemgfsr.ino
@@ -108,8 +108,9 @@
     }
 
     // 3 Collect EMG and FSR readings
+    // (note that A2 is pin used for FSR in newer Muscle SpikerShield)
     emgReading = analogRead(A0);
-    fsrReading = analogRead(A1);
+    fsrReading = analogRead(A2);
 
     // 4 Turn off LEDs, then light up 1 -6 of them to reflect sensitivity
     for(int j = 0; j < NUM_LED; j++){


### PR DESCRIPTION
This updates the code used on the Arduino for integration with BYB Muscle Spiker Shield.  The 2023 update of the shield and gripper hardwires the FSR to pin A2.  This is backwards compatible with the 2022 hardware setup, as that setup had a manually connected FSR