### PR TITLE
FIX: publishing images added via a datacard tile

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,24 @@ $ npm run lint    # lint the functions code
 $ npm run test    # runs jest (unit) tests for the functions code
 $ npm run build   # build the functions code (transpile TypeScript)
 ```
-Note that there seems to be an uneasy relationship between the `node_modules` folder in the
+### Note 1
+There seems to be an uneasy relationship between the `node_modules` folder in the
 `functions` directory and the one in the parent directory. I had to explicitly specify the
 path to typescript in the `build` function. There's probably a better configuration available,
 but in the meantime this seems to mostly work.
+
+### Note 2
+When running `npm run test` with node 16, the following error is shown
+```
+TypeError: Cannot read properties of undefined (reading 'INTERNAL')
+```
+This error is triggered by the following line in `test-utils.ts`
+```
+import { useEmulators } from "@firebase/rules-unit-testing";
+```
+The current work around is to use node 14 to run the tests.
+
+See functions/dependency-notes.md for more on this.
 
 ### Testing cloud functions
 

--- a/functions/dependencies-notes.md
+++ b/functions/dependencies-notes.md
@@ -3,8 +3,21 @@
 Notes on dependencies, particularly reasons for not updating to their latest versions.
 
 We are currently stuck on older versions of the firebase packages until we update at least our unit testing code.
+It also seems we need to be using node version 14 to run the local tests.
+
+## Running on Node version 14
+There is some strange interaction with node 14, node 16, and probably the npm version and these libraries.
+
+If node 16 is used and `npm i` is run. Then when tests run, a `TypeError: Cannot read properties of undefined (reading 'INTERNAL')` occurs. If you go back to node 14 (I did this with `nvm use 14`), and then installed the dependencies again with `npm i`. Now the tests will run without errors. This also caused an update to package-lock.json perhaps because of an older version of npm. This updated package-lock.json is not committed because I don't fully understand what is going on, keep reading...
+
+If I switched back to node 16 with `nvm use 16`, then ran `npm i`, some of the tests pass without the above error. But if I run `npm i` a second time, now all the tests fail again.
+
+The point of documenting this, is to warn you if you are trying to get things to work in node 16. I think really the best approach is to update how we are running a function unit tests as described below.
 
 ## Upgrading `@firebase/rules-unit-testing` to `1.3.16` or higher
+
+** This information seems out of date:**
+The package.json specifies `~1.3.15` but in package-lock.json `1.3.16` is installed. The same error happens when bouncing between node version 14 and 16 so my guess is that the two issues got conflated.
 
 This causes:
 ```
@@ -32,7 +45,13 @@ Without changing the code the best thing I've found to keep most of the dependen
 
 The best solution is to upgrade all of the firebase dependencies. Then we have to refactor the way the tests are working with the emulator and mocking the firebase admin object.
 
-The official firebase documentation recommends unit testing firebase using a real firebase project. This is fragile, so we'd prefer to keep using our emulator based approach.
+The official firebase documentation recommends unit testing firebase using a real firebase project or mocking things so it can run offline:
+https://firebase.google.com/docs/functions/unit-testing
+However, both options are fragile, so we'd prefer to keep using our emulator based approach.
+
+If we want to stick with using the rules unit testing library to implement our function tests against the emulator, there is this page which talks about unit tests with the emulator:
+https://firebase.google.com/docs/rules/unit-tests
+It refers to the v9 and v8 javascript SDK. It isn't clear what these versions are referring too.
 
 I found this blog post and repo:
 https://timo-santi.medium.com/jest-testing-firebase-functions-with-emulator-suite-409907f31f39

--- a/functions/src/get-network-document.ts
+++ b/functions/src/get-network-document.ts
@@ -6,7 +6,7 @@ import { IGetNetworkDocumentUnionParams, isWarmUpParams } from "./shared";
 import { validateUserContext } from "./user-context";
 
 // update this when deploying updates to this function
-const version = "1.0.2";
+const version = "1.0.3";
 
 export async function getNetworkDocument(
                         params?: IGetNetworkDocumentUnionParams,

--- a/functions/src/publish-support.ts
+++ b/functions/src/publish-support.ts
@@ -7,7 +7,7 @@ import { parseFirebaseImageUrl } from "./shared-utils";
 import { validateUserContext } from "./user-context";
 
 // update this when deploying updates to this function
-const version = "1.0.3";
+const version = "1.0.4";
 
 export async function publishSupport(
                         params?: IPublishSupportUnionParams,

--- a/functions/src/shared.ts
+++ b/functions/src/shared.ts
@@ -138,10 +138,20 @@ export interface ITileMapEntry {
   id: string;
   content: ITileContent;
 }
+export interface ISharedModel {
+  type: string;
+  id: string;
+  // ... other shared-model specific properties
+}
+export interface ISharedModelMapEntry {
+  sharedModel: any;
+  tiles: Array<string>;
+}
 export interface IDocumentContent {
   rowMap: Record< string, IRowMapEntry>;
   rowOrder: string[];
   tileMap: Record<string, ITileMapEntry>;
+  sharedModelMap: Record<string, ISharedModelMapEntry>;
 }
 
 interface IFirebaseFunctionWarmUpParams {

--- a/functions/test/shared-dataset-example.ts
+++ b/functions/test/shared-dataset-example.ts
@@ -1,0 +1,54 @@
+export default {
+  "rowMap": {
+    "HRQ0VTl8sAzc6Nop": {
+      "id": "HRQ0VTl8sAzc6Nop",
+      "height": 364,
+      "isSectionHeader": false,
+      "tiles": [{"tileId": "7fuiu2dJ0xS9mWMK"}]
+    }
+  },
+  "rowOrder": ["HRQ0VTl8sAzc6Nop"],
+  "tileMap": {
+    "7fuiu2dJ0xS9mWMK": {
+      "id": "7fuiu2dJ0xS9mWMK",
+      "title": "Data Card Collection 1",
+      "content": {"type": "DataCard", "caseIndex": 0}
+    }
+  },
+  "sharedModelMap": {
+    "vBWVbWtn1GoltQGW": {
+      "sharedModel": {
+        "type": "SharedDataSet",
+        "id": "vBWVbWtn1GoltQGW",
+        "providerId": "7fuiu2dJ0xS9mWMK",
+        "dataSet": {
+          "id": "w5AZuLfbfZLWzFZd",
+          "attributes": [
+            {
+              "id": "bMYBVBByt_6bITo3",
+              "clientKey": "",
+              "name": "Label 1",
+              "hidden": false,
+              "units": "",
+              "formula": {},
+              "values": ["my image 1", "my image 2"],
+              "title": ""
+            },
+            {
+              "id": "TaRe_wjPNsHmSV01",
+              "clientKey": "",
+              "name": "Label 2",
+              "hidden": false,
+              "units": "",
+              "formula": {},
+              "values": ["ccimg://fbrtdb.concord.org/image-1", "ccimg://fbrtdb.concord.org/image-2"],
+              "title": ""
+            }
+          ],
+          "cases": [{"__id__": "01H4K13238DC631XCYADCE9RPZ"}, {"__id__": "02H4K13238DC631XCYADCE9RPZ"}]
+        }
+      },
+      "tiles": ["7fuiu2dJ0xS9mWMK"]
+    }
+  }
+};


### PR DESCRIPTION
these datacard images are stored in the data set, so the
parseDocumentContent function needed to be updated to handle this.

It would be better to make this more generic so we don't have
to update with new tiles or shared models. However there is
still support to avoid publishing multiple images from legacy content.
So until we migrate the legacy content (or give up on the optimization)
we can't make this fully generic.

I also tried to update the README to help others get the tests running.

PT-185502029