### PR TITLE
185532784 Prevent graphs from corrupting documents when all points are removed from a linked dataset.

### DIFF
--- a/src/plugins/graph/components/graph-axis.tsx
+++ b/src/plugins/graph/components/graph-axis.tsx
@@ -73,14 +73,14 @@ export const GraphAxis = observer(function GraphAxis({
           const axisModel = graphModel.getAxis(place);
 
           if (axisModel && isNumericAxisModel(axisModel)) {
-            if (xValues && place === "bottom") {
+            if (xValues?.length > 0 && place === "bottom") {
               const minX = Math.min(...xValues);
               const maxX = Math.max(...xValues);
               const newXBounds = computeNiceNumericBounds(minX, maxX);
               axisModel.setDomain(newXBounds.min, newXBounds.max);
             }
 
-            if (yValues && place === "left") {
+            if (yValues?.length > 0 && place === "left") {
               const minY = Math.min(...yValues);
               const maxY = Math.max(...yValues);
               const newYBounds = computeNiceNumericBounds(minY, maxY);

--- a/src/plugins/graph/components/graph-axis.tsx
+++ b/src/plugins/graph/components/graph-axis.tsx
@@ -73,14 +73,14 @@ export const GraphAxis = observer(function GraphAxis({
           const axisModel = graphModel.getAxis(place);
 
           if (axisModel && isNumericAxisModel(axisModel)) {
-            if (xValues?.length > 0 && place === "bottom") {
+            if (xValues.length > 0 && place === "bottom") {
               const minX = Math.min(...xValues);
               const maxX = Math.max(...xValues);
               const newXBounds = computeNiceNumericBounds(minX, maxX);
               axisModel.setDomain(newXBounds.min, newXBounds.max);
             }
 
-            if (yValues?.length > 0 && place === "left") {
+            if (yValues.length > 0 && place === "left") {
               const minY = Math.min(...yValues);
               const maxY = Math.max(...yValues);
               const newYBounds = computeNiceNumericBounds(minY, maxY);


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/185532784

This PR prevents the graph from recomputing its axes ranges when there are no points to plot. Previously, this was resulting in null values being assigned to the axes' mins and maxes, which resulted in corrupted documents.