### PR TITLE
185465688 hub dropdown display

### DIFF
--- a/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
@@ -386,15 +386,34 @@ context('Dataflow Tool Tile', function () {
           dataflowToolTile.getDropdownOptions(nodeType, dropdown).eq(0).click();
       });
       it("can connect and trigger modal connection warning", () => {
+        // vars for controlling click and drag to connect nodes
+        const startX = 306;
+        const startY = 182;
+        const deltaX = 70;  //  60 with fixed styles
+        const deltaY = -32; // -10 with fixed styles
         dataflowToolTile.getCreateNodeButton("number").click();
         dataflowToolTile.getNode("number").should("exist");
         dataflowToolTile.getNumberField().type("1{enter}");
         dataflowToolTile.getNumberNodeOutput().should("exist");
-        dataflowToolTile.getDataflowTile().click(306, 182)
-          .trigger("pointerdown", 306, 182, {force: true})
-          .trigger("pointermove", 366, 172, {force: true})
-          .trigger("pointerup", 366, 172, {force: true});
+        dataflowToolTile.getDataflowTile().click(startX, startY)
+          .trigger("pointerdown", startX, startY, {force: true})
+          .trigger("pointermove", startX + deltaX, startY + deltaY, {force: true})
+          .trigger("pointerup", startX + deltaX, startY + deltaY, {force: true});
         dataflowToolTile.getModalOkButton().click();
+      });
+      it("should not show hub selector when gripper is selected", () => {
+        const dropdown = "liveOutputType";
+        dataflowToolTile.getDropdown(nodeType, dropdown).click();
+        dataflowToolTile.getDropdownOptions(nodeType, dropdown).eq(2).click();
+        dataflowToolTile.getDropdown(nodeType, dropdown).contains("Gripper 2.0").should("exist");
+        dataflowToolTile.getDropdown(nodeType, "hubSelect").should("not.be.visible");
+      });
+      it("should show hub selector when humidifier is selected", () => {
+        const dropdown = "liveOutputType";
+        dataflowToolTile.getDropdown(nodeType, dropdown).click();
+        dataflowToolTile.getDropdownOptions(nodeType, dropdown).eq(3).click();
+        dataflowToolTile.getDropdown(nodeType, dropdown).contains("Humidifier").should("exist");
+        dataflowToolTile.getDropdown(nodeType, "hubSelect").should("be.visible");
       });
       it("can recieve a value from a connected block, and display correct on or off string", () => {
         dataflowToolTile.getNode("number").should("exist");

--- a/src/plugins/dataflow/model/utilities/node.ts
+++ b/src/plugins/dataflow/model/utilities/node.ts
@@ -364,25 +364,21 @@ export const NodeMicroBitHubs = [
   {
     id: 'a',
     name: "micro:bit hub a",
-    icon: LightIcon,
     active: false
   },
   {
     id: 'b',
     name: "micro:bit hub b",
-    icon: LightIcon,
     active: false
   },
   {
     id: 'c',
     name: "micro:bit hub c",
-    icon: LightIcon,
     active: false
   },
   {
     id: 'd',
     name: "micro:bit hub d",
-    icon: LightIcon,
     active: false
   }
 ];

--- a/src/plugins/dataflow/nodes/dataflow-node.tsx
+++ b/src/plugins/dataflow/nodes/dataflow-node.tsx
@@ -4,8 +4,9 @@ import { Node, Socket, Control } from "rete-react-render-plugin";
 import { DataflowNodePlot } from "./dataflow-node-plot";
 import { NodeType, NodeTypes } from "../model/utilities/node";
 import { hasFlowIn } from "./utilities/view-utilities";
+import { nodeUsesHub } from "./utilities/live-output-utilities";
 import "./dataflow-node.scss";
-import "./control-node-states.scss";
+import "./node-states.scss";
 
 export class DataflowNode extends Node {
 
@@ -27,7 +28,8 @@ export class DataflowNode extends Node {
 
     const dynamicClasses = classNames({
       "gate-active": node.data.gateActive,
-      "has-flow-in": hasFlowIn(node)
+      "has-flow-in": hasFlowIn(node),
+      "no-hub-outputs": !nodeUsesHub(node)
     });
 
     const inputClass = (s: string) => "input " + s.toLowerCase().replace(/ /g, "-");

--- a/src/plugins/dataflow/nodes/factories/live-output-rete-node-factory.tsx
+++ b/src/plugins/dataflow/nodes/factories/live-output-rete-node-factory.tsx
@@ -103,7 +103,9 @@ export class LiveOutputReteNodeFactory extends DataflowReteNodeFactory {
   private getHubRelaysChannel(node: Node){
     const hubSelect = getHubSelect(node);
     const selectedHubIdentifier = hubSelect.getSelectionId();
-    const relayChannels = hubSelect.getChannels().filter((c: NodeChannelInfo) => c.type === "relays");
+    const foundChannels = hubSelect.getChannels();
+    if (!foundChannels) return null;
+    const relayChannels = foundChannels.filter((c: NodeChannelInfo) => c.type === "relays");
     return relayChannels.find((c: NodeChannelInfo) => c.microbitId === selectedHubIdentifier);
   }
 

--- a/src/plugins/dataflow/nodes/node-states.scss
+++ b/src/plugins/dataflow/nodes/node-states.scss
@@ -60,3 +60,9 @@
     animation: none;
   }
 }
+
+.node.live-output.no-hub-outputs {
+  .hubSelect {
+    display: none;
+  }
+}

--- a/src/plugins/dataflow/nodes/utilities/live-output-utilities.ts
+++ b/src/plugins/dataflow/nodes/utilities/live-output-utilities.ts
@@ -1,5 +1,6 @@
 import { Node } from "rete";
 import { DropdownListControl } from "../controls/dropdown-list-control";
+import { kRelaysIndexed } from "../../model/utilities/node";
 
 interface NodeOutputValue {
   val: number;
@@ -12,11 +13,15 @@ export function getHubSelect(node: Node) {
 
 export function getOutputType(node: Node) {
   const outputTypeControl = node.controls.get("liveOutputType") as DropdownListControl;
-  return outputTypeControl.getValue();
+  if (outputTypeControl) return outputTypeControl.getValue();
 }
 
 export function getNodeValueWithType(node: Node): NodeOutputValue {
   const val = node.data.nodeValue as number;
   const outType = getOutputType(node);
   return { val, outType };
+}
+
+export function nodeUsesHub(node: Node) {
+  return kRelaysIndexed.includes(getOutputType(node));
 }


### PR DESCRIPTION
This PR implements the changes described in [PT#185465688](https://www.pivotaltracker.com/story/show/185465688):
- Microbit hub options should only show on fan, humidifier and heat lamp outputs
- adds config for four new microbits
- Remove icon next to micro:bit hubs

In addition, it adds a cypress test for the above, and makes configurable the drag/click locations for a test that connects nodes.  This test will need to be adjusted again when the styles or node locations are adjusted