### PR TITLE
Shows stars on all starred documents

### DIFF
--- a/src/components/thumbnail/decorated-document-thumbnail-item.tsx
+++ b/src/components/thumbnail/decorated-document-thumbnail-item.tsx
@@ -82,10 +82,14 @@ export const DecoratedDocumentThumbnailItem: React.FC<IProps> = observer(({
     // so that mobx-react triggers child render not parent render.
     const onIsStarred = () => {
       return section.showStarsForUser(user)
-              ? user.isTeacher
-                ? sectionDocument.isStarredByUser(user.id)
-                : sectionDocument.isStarred
-              : false;
+          // We weren't showing stars that a "co-teacher" has placed on a document even though the document
+          // is classified as "isStarred". We commented out lines 88-90 to show all starred documents regardless of who
+          // placed the star.
+              // ? user.isTeacher
+              //   ? sectionDocument.isStarredByUser(user.id)
+              //   : sectionDocument.isStarred
+                ? sectionDocument.isStarred
+                : false;
     };
     const _handleDocumentStarClick = section.showStarsForUser(user) && !sectionDocument.isRemote
                                       ? handleDocumentStarClick

--- a/src/components/thumbnail/thumbnail-document-item.tsx
+++ b/src/components/thumbnail/thumbnail-document-item.tsx
@@ -54,7 +54,7 @@ export const ThumbnailDocumentItem: React.FC<IProps> = observer((props: IProps) 
 
   return (
     <div className={classNames("list-item", selectedClass, privateClass, {"secondary": isSecondarySelected})}
-      data-test={dataTestName} key={document.key}
+      data-test={dataTestName} key={document.key} data-docKey={document.key}
       title={documentTitle} onClick={isPrivate ? undefined : handleDocumentClick}>
       <div className="scaled-list-item-container" onDragStart={handleDocumentDragStart}
         draggable={!!onDocumentDragStart && !isPrivate}>


### PR DESCRIPTION
Previously we only showed stars if the current user starred the documents. But documents that have been starred by a co-teacher are still shown in the Starred documents list for a class in Class Work tab, though they are shown "unstarred". We are changing the behavior so that any document that has been starred, regardless of who starred them, will show them "starred" in the Class Work tab.

This removes the logic that shows stars on documents only starred by current user. We now show stars for all the starred documents for a class that have been starred by anyone in the class.

Added a data attribute to document thumbnail with document id to aid in debugging.