### PR TITLE
184873706 dataflow minigraph playback

### DIFF
--- a/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
@@ -561,16 +561,11 @@ context('Dataflow Tool Tile', function () {
         dataflowToolTile.getPlayButton().should("be.enabled");
         dataflowToolTile.verifyRecordingClearButtonText();
         dataflowToolTile.verifyRecordingClearButtonIcon();
-
-
-
         dataflowToolTile.getPlayButton().click();
-
         dataflowToolTile.verifyPauseButtonText();
         dataflowToolTile.verifyPauseButtonIcon();
         dataflowToolTile.getPauseButton().should("be.enabled");
         dataflowToolTile.getPauseButton().click();
-
         dataflowToolTile.getPlayButton().should("be.enabled");
         dataflowToolTile.getPlayButton().click();
         cy.wait(5000);

--- a/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
@@ -562,10 +562,12 @@ context('Dataflow Tool Tile', function () {
         dataflowToolTile.verifyRecordingClearButtonText();
         dataflowToolTile.verifyRecordingClearButtonIcon();
         dataflowToolTile.getPlayButton().click();
+
         dataflowToolTile.verifyPauseButtonText();
         dataflowToolTile.verifyPauseButtonIcon();
         dataflowToolTile.getPauseButton().should("be.enabled");
         dataflowToolTile.getPauseButton().click();
+
         dataflowToolTile.getPlayButton().should("be.enabled");
         dataflowToolTile.getPlayButton().click();
         cy.wait(5000);

--- a/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
@@ -532,6 +532,8 @@ context('Dataflow Tool Tile', function () {
         dataflowToolTile.getNodeTitle().should("contain", "Demo Output");
         dataflowToolTile.getNodeOutput().eq(0).click();
         dataflowToolTile.getNodeInput().eq(0).click();
+        dataflowToolTile.getShowGraphButton("demo-output").click();
+        dataflowToolTile.getMinigraph("demo-output").should("exist");
       });
       it("verify sampling rate", () => {
         const rate = "500";
@@ -559,6 +561,9 @@ context('Dataflow Tool Tile', function () {
         dataflowToolTile.getPlayButton().should("be.enabled");
         dataflowToolTile.verifyRecordingClearButtonText();
         dataflowToolTile.verifyRecordingClearButtonIcon();
+
+
+
         dataflowToolTile.getPlayButton().click();
 
         dataflowToolTile.verifyPauseButtonText();

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -585,7 +585,6 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
           switch (node.name){
             case "Transform":
               nodeControl = node.controls.get("nodeValue") as ValueControl;
-              console.log("| transform: ", nodeControl, valForNode);
               nodeControl.setSentence(` → ${valForNode}`);
               break;
             case "Sensor":

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import "regenerator-runtime/runtime";
-import { forEach, update } from "lodash";
+import { forEach } from "lodash";
 import { inject, observer } from "mobx-react";
 import { autorun } from "mobx";
 import { IDisposer, onSnapshot } from "mobx-state-tree";
@@ -27,7 +27,6 @@ import { DemoOutputReteNodeFactory } from "../nodes/factories/demo-output-rete-n
 import { LiveOutputReteNodeFactory } from "../nodes/factories/live-output-rete-node-factory";
 import { GeneratorReteNodeFactory } from "../nodes/factories/generator-rete-node-factory";
 import { TimerReteNodeFactory } from "../nodes/factories/timer-rete-node-factory";
-import { NumControl } from "../nodes/controls/num-control";
 import { ValueControl } from "../nodes/controls/value-control";
 import { getHubSelect, setLiveOutputOpts } from "../nodes/utilities/live-output-utilities";
 import {
@@ -611,9 +610,9 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
               break;
             case "Demo Output":
               nodeControl = node.controls.get("demoOutput") as DemoOutputControl;
-              nodeControl.setValue(valForNode); //---> shows correct animation
+              nodeControl.setValue(valForNode);
               nodeControl = node.inputs.get("nodeValue")?.control as InputValueControl;
-              nodeControl.setDisplayMessage(valForNode === 0 ? "off" : "on");
+              nodeControl.setDisplayMessage(`${valForNode}`);
               break;
             case "Live Output":
               nodeControl = node.inputs.get("nodeValue")?.control as InputValueControl;

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -571,7 +571,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
 
   private playbackNodesWithCaseData = (dataSet: IDataSet, playBackIndex: number) => {
     const currentCase = dataSet.getCaseAtIndex(playBackIndex);
-    const basicUpdateNodes = ["Number", "Generator", "Transform"];
+    const basicUpdateNodes = ["Number", "Generator"];
 
     if (currentCase){
       const {__id__} = currentCase; //this is the id of the case we are looking at for each frame
@@ -584,6 +584,11 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
         } else {
           let nodeControl;
           switch (node.name){
+            case "Transform":
+              nodeControl = node.controls.get("nodeValue") as ValueControl;
+              console.log("| transform: ", nodeControl, valForNode);
+              nodeControl.setSentence(` → ${valForNode}`);
+              break;
             case "Sensor":
               nodeControl = node.controls.get("nodeValue") as SensorValueControl;
               nodeControl.setValue(valForNode);

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -42,6 +42,7 @@ import { DataflowProgramCover } from "./ui/dataflow-program-cover";
 import { DataflowProgramZoom } from "./ui/dataflow-program-zoom";
 import { NodeChannelInfo, serialSensorChannels } from "../model/utilities/channel";
 import { ProgramDataRates } from "../model/utilities/node";
+import { getRecentValuesForNode } from "../utilities/playback-utils";
 import { getAttributeIdForNode, recordCase } from "../model/utilities/recording-utilities";
 import { virtualSensorChannels } from "../model/utilities/virtual-channel";
 import { DocumentContextReact } from "../../../components/document/document-context";
@@ -572,9 +573,8 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
       const {__id__} = currentCase; //this is the id of the case we are looking at for each frame
       this.programEditor.nodes.forEach((node, idx) => { //update each node in the frame
 
-
-        const fakeData = {
-          "nodeValue": Array.from({ length: 10 }, () => Math.floor(Math.random() * 19) + 2)
+        const calculatedRecentValues = {
+          "nodeValue": getRecentValuesForNode(node, dataSet, playBackIndex)
         };
 
         const attrId = getAttributeIdForNode(this.props.tileContent.dataSet, idx);
@@ -591,10 +591,8 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
             break;
           case "Generator":
             nodeControl = node.controls.get("nodeValue") as ValueControl;
-            node.data.recentValues = fakeData;
-            //console.log("updating recent values:", node.data.recentValues);
             nodeControl.setValue(valueToSendToNode);
-            //node.update();
+            node.data.recentValues = calculatedRecentValues;
             break;
           case "Timer":
             nodeControl = node.controls.get("nodeValue") as ValueControl; //not working
@@ -605,7 +603,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
           case "Logic":
             break;
           case "Transform":
-            node.data.recentValues = fakeData;
+            node.data.recentValues = calculatedRecentValues;
             nodeControl = node.controls.get("nodeValue") as ValueControl;
             nodeControl.setValue(valueToSendToNode);
             break;

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -591,16 +591,28 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
             nodeControl.setValue(valueToSendToNode);
             break;
           case "Timer":
-            nodeControl = node.controls.get("nodeValue") as ValueControl; //not working
-            nodeControl.setValue(valueToSendToNode);
+            nodeControl = node.controls.get("nodeValue") as ValueControl;
+            nodeControl.setSentence(valueToSendToNode === 0 ? "off" : "on");
             break;
           case "Math":
+            nodeControl = node.controls.get("nodeValue") as ValueControl;
+            nodeControl.setSentence(` → ${valueToSendToNode}`);
             break;
           case "Logic":
+            nodeControl = node.controls.get("nodeValue") as ValueControl;
+            // displays identical result as during real execution, but does not show function input values
+            // a further improvement would bring the n1, n2 socket values into the display as in real execution
+            nodeControl.setSentence(valueToSendToNode === 0 ? " ⇒ 0" : " ⇒ 1");
             break;
           case "Transform":
+            nodeControl = node.controls.get("nodeValue") as ValueControl;
+            nodeControl.setValue(valueToSendToNode);
             break;
           case "Control":
+            // displays identical result as during real execution, but does not show function input values
+            // a further improvement would bring the binary input value as (on/off) into the display
+            nodeControl = node.controls.get("nodeValue") as ValueControl;
+            nodeControl.setSentence(` → ${valueToSendToNode}`);
             break;
           case "Demo Output":
             nodeControl = node.controls.get("demoOutput") as DemoOutputControl;

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -52,8 +52,10 @@ import { InputValueControl } from "../nodes/controls/input-value-control";
 import { DemoOutputControl } from "../nodes/controls/demo-output-control";
 import { ProgramMode, UpdateMode } from "./types/dataflow-tile-types";
 import { ITileModel } from "../../../models/tiles/tile-model";
+import { IDataSet } from "../../../models/data/data-set";
 
 import "./dataflow-program.sass";
+
 
 export interface IStartProgramParams {
   runId: string;
@@ -567,7 +569,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
     this.programEditor.clear();
   };
 
-  private playbackNodesWithCaseData = (dataSet: any, playBackIndex: number) => {
+  private playbackNodesWithCaseData = (dataSet: IDataSet, playBackIndex: number) => {
     const currentCase = dataSet.getCaseAtIndex(playBackIndex);
     if (currentCase){
       const {__id__} = currentCase; //this is the id of the case we are looking at for each frame
@@ -615,7 +617,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
           default:
         }
         const calculatedRecentValues = {
-          "nodeValue": getRecentValuesForNode(node, dataSet, playBackIndex, idx)
+          "nodeValue": getRecentValuesForNode(dataSet, playBackIndex, idx)
         };
         node.data.recentValues = calculatedRecentValues;
         node.update();

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -599,8 +599,6 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
           case "Logic":
             break;
           case "Transform":
-            nodeControl = node.controls.get("nodeValue") as ValueControl;
-            nodeControl.setValue(valueToSendToNode);
             break;
           case "Control":
             break;

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -571,6 +571,12 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
     if (currentCase){
       const {__id__} = currentCase; //this is the id of the case we are looking at for each frame
       this.programEditor.nodes.forEach((node, idx) => { //update each node in the frame
+
+
+        const fakeData = {
+          "nodeValue": Array.from({ length: 10 }, () => Math.floor(Math.random() * 19) + 2)
+        };
+
         const attrId = getAttributeIdForNode(this.props.tileContent.dataSet, idx);
         const valueToSendToNode = dataSet.getValue(__id__, attrId) as number;
         let nodeControl;
@@ -585,8 +591,10 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
             break;
           case "Generator":
             nodeControl = node.controls.get("nodeValue") as ValueControl;
+            node.data.recentValues = fakeData;
+            console.log("updating recent values:", node.data.recentValues);
             nodeControl.setValue(valueToSendToNode);
-            console.log("| A valueToSendToNode", valueToSendToNode, "recentValues: ", (node.data.recentValues as any).nodeValue);
+            node.update();
             break;
           case "Timer":
             nodeControl = node.controls.get("nodeValue") as ValueControl; //not working

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -617,7 +617,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
           default:
         }
         const calculatedRecentValues = {
-          "nodeValue": getRecentValuesForNode(dataSet, playBackIndex, idx)
+          "nodeValue": getRecentValuesForNode(dataSet, playBackIndex, attrId)
         };
         node.data.recentValues = calculatedRecentValues;
         node.update();

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -574,10 +574,10 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
       this.programEditor.nodes.forEach((node, idx) => { //update each node in the frame
 
         const calculatedRecentValues = {
-          "nodeValue": getRecentValuesForNode(node, dataSet, playBackIndex)
+          "nodeValue": getRecentValuesForNode(node, dataSet, playBackIndex, idx)
         };
 
-        const attrId = getAttributeIdForNode(this.props.tileContent.dataSet, idx);
+        const attrId = getAttributeIdForNode(this.props.tileContent.dataSet, idx); //pass this one through
         const valueToSendToNode = dataSet.getValue(__id__, attrId) as number;
         let nodeControl;
         switch (node.name){
@@ -603,9 +603,9 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
           case "Logic":
             break;
           case "Transform":
-            node.data.recentValues = calculatedRecentValues;
             nodeControl = node.controls.get("nodeValue") as ValueControl;
             nodeControl.setValue(valueToSendToNode);
+            node.data.recentValues = calculatedRecentValues;
             break;
           case "Control":
             break;

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -586,6 +586,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
           case "Generator":
             nodeControl = node.controls.get("nodeValue") as ValueControl;
             nodeControl.setValue(valueToSendToNode);
+            console.log("| A valueToSendToNode", valueToSendToNode, "recentValues: ", (node.data.recentValues as any).nodeValue);
             break;
           case "Timer":
             nodeControl = node.controls.get("nodeValue") as ValueControl; //not working

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -572,12 +572,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
     if (currentCase){
       const {__id__} = currentCase; //this is the id of the case we are looking at for each frame
       this.programEditor.nodes.forEach((node, idx) => { //update each node in the frame
-
-        const calculatedRecentValues = {
-          "nodeValue": getRecentValuesForNode(node, dataSet, playBackIndex, idx)
-        };
-
-        const attrId = getAttributeIdForNode(this.props.tileContent.dataSet, idx); //pass this one through
+        const attrId = getAttributeIdForNode(this.props.tileContent.dataSet, idx);
         const valueToSendToNode = dataSet.getValue(__id__, attrId) as number;
         let nodeControl;
         switch (node.name){
@@ -592,7 +587,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
           case "Generator":
             nodeControl = node.controls.get("nodeValue") as ValueControl;
             nodeControl.setValue(valueToSendToNode);
-            node.data.recentValues = calculatedRecentValues;
+
             break;
           case "Timer":
             nodeControl = node.controls.get("nodeValue") as ValueControl; //not working
@@ -605,7 +600,6 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
           case "Transform":
             nodeControl = node.controls.get("nodeValue") as ValueControl;
             nodeControl.setValue(valueToSendToNode);
-            node.data.recentValues = calculatedRecentValues;
             break;
           case "Control":
             break;
@@ -621,6 +615,10 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
             break;
           default:
         }
+        const calculatedRecentValues = {
+          "nodeValue": getRecentValuesForNode(node, dataSet, playBackIndex, idx)
+        };
+        node.data.recentValues = calculatedRecentValues;
         node.update();
       });
     }

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -592,9 +592,9 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
           case "Generator":
             nodeControl = node.controls.get("nodeValue") as ValueControl;
             node.data.recentValues = fakeData;
-            console.log("updating recent values:", node.data.recentValues);
+            //console.log("updating recent values:", node.data.recentValues);
             nodeControl.setValue(valueToSendToNode);
-            node.update();
+            //node.update();
             break;
           case "Timer":
             nodeControl = node.controls.get("nodeValue") as ValueControl; //not working
@@ -605,6 +605,9 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
           case "Logic":
             break;
           case "Transform":
+            node.data.recentValues = fakeData;
+            nodeControl = node.controls.get("nodeValue") as ValueControl;
+            nodeControl.setValue(valueToSendToNode);
             break;
           case "Control":
             break;
@@ -620,6 +623,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
             break;
           default:
         }
+        node.update();
       });
     }
   };

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -587,7 +587,6 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
           case "Generator":
             nodeControl = node.controls.get("nodeValue") as ValueControl;
             nodeControl.setValue(valueToSendToNode);
-
             break;
           case "Timer":
             nodeControl = node.controls.get("nodeValue") as ValueControl; //not working

--- a/src/plugins/dataflow/nodes/dataflow-node-plot.tsx
+++ b/src/plugins/dataflow/nodes/dataflow-node-plot.tsx
@@ -46,8 +46,6 @@ export const DataflowNodePlot: React.FC<INodePlotProps> = (props) => {
 
   const scaleBtnColorClass= props.data.name.charAt(0).toLowerCase() + props.data.name.slice(1);
 
-  // console.log("| C DataflowNodePlot: props.data", props.data);
-
   return (
     <div className="node-bottom-section">
       <div className="node-bottom-buttons">

--- a/src/plugins/dataflow/nodes/dataflow-node-plot.tsx
+++ b/src/plugins/dataflow/nodes/dataflow-node-plot.tsx
@@ -46,7 +46,7 @@ export const DataflowNodePlot: React.FC<INodePlotProps> = (props) => {
 
   const scaleBtnColorClass= props.data.name.charAt(0).toLowerCase() + props.data.name.slice(1);
 
-  console.log("| C DataflowNodePlot: props.data", props.data);
+  // console.log("| C DataflowNodePlot: props.data", props.data);
 
   return (
     <div className="node-bottom-section">

--- a/src/plugins/dataflow/nodes/dataflow-node-plot.tsx
+++ b/src/plugins/dataflow/nodes/dataflow-node-plot.tsx
@@ -99,6 +99,7 @@ function lineData(node: any) {
       chartDataSets.push(dataset);
     }
   });
+
   stepY = (maxY(node) - minY(node)) / 2;
 
   const chartData: ChartData = {

--- a/src/plugins/dataflow/nodes/dataflow-node-plot.tsx
+++ b/src/plugins/dataflow/nodes/dataflow-node-plot.tsx
@@ -73,7 +73,6 @@ function lineData(node: any) {
   const chartDataSets: ChartDataSets[] = [];
   Object.keys(node.data.watchedValues).forEach((valueKey: string) => {
     const recentValues: any = node.data.recentValues?.[valueKey];
-
     if (recentValues !== undefined) {
       const customOptions = node.data.watchedValues?.[valueKey] || {};
       const dataset: ChartDataSets = {
@@ -100,7 +99,6 @@ function lineData(node: any) {
       chartDataSets.push(dataset);
     }
   });
-
   stepY = (maxY(node) - minY(node)) / 2;
 
   const chartData: ChartData = {

--- a/src/plugins/dataflow/nodes/dataflow-node-plot.tsx
+++ b/src/plugins/dataflow/nodes/dataflow-node-plot.tsx
@@ -46,6 +46,8 @@ export const DataflowNodePlot: React.FC<INodePlotProps> = (props) => {
 
   const scaleBtnColorClass= props.data.name.charAt(0).toLowerCase() + props.data.name.slice(1);
 
+  console.log("| C DataflowNodePlot: props.data", props.data);
+
   return (
     <div className="node-bottom-section">
       <div className="node-bottom-buttons">
@@ -73,6 +75,7 @@ function lineData(node: any) {
   const chartDataSets: ChartDataSets[] = [];
   Object.keys(node.data.watchedValues).forEach((valueKey: string) => {
     const recentValues: any = node.data.recentValues?.[valueKey];
+
     if (recentValues !== undefined) {
       const customOptions = node.data.watchedValues?.[valueKey] || {};
       const dataset: ChartDataSets = {
@@ -99,7 +102,7 @@ function lineData(node: any) {
       chartDataSets.push(dataset);
     }
   });
-  
+
   stepY = (maxY(node) - minY(node)) / 2;
 
   const chartData: ChartData = {

--- a/src/plugins/dataflow/nodes/dataflow-node.tsx
+++ b/src/plugins/dataflow/nodes/dataflow-node.tsx
@@ -35,8 +35,6 @@ export class DataflowNode extends Node {
 
     const inputClass = (s: string) => "input " + s.toLowerCase().replace(/ /g, "-");
 
-    //console.log("| B DataflowNode: node", node);
-
     return (
       <div className={`node ${node.name.toLowerCase().replace(/ /g, "-")} ${dynamicClasses}`}>
         <div className="top-bar">

--- a/src/plugins/dataflow/nodes/dataflow-node.tsx
+++ b/src/plugins/dataflow/nodes/dataflow-node.tsx
@@ -35,7 +35,7 @@ export class DataflowNode extends Node {
 
     const inputClass = (s: string) => "input " + s.toLowerCase().replace(/ /g, "-");
 
-    console.log("| B DataflowNode: node", node);
+    //console.log("| B DataflowNode: node", node);
 
     return (
       <div className={`node ${node.name.toLowerCase().replace(/ /g, "-")} ${dynamicClasses}`}>

--- a/src/plugins/dataflow/nodes/dataflow-node.tsx
+++ b/src/plugins/dataflow/nodes/dataflow-node.tsx
@@ -35,6 +35,8 @@ export class DataflowNode extends Node {
 
     const inputClass = (s: string) => "input " + s.toLowerCase().replace(/ /g, "-");
 
+    console.log("| B DataflowNode: node", node);
+
     return (
       <div className={`node ${node.name.toLowerCase().replace(/ /g, "-")} ${dynamicClasses}`}>
         <div className="top-bar">

--- a/src/plugins/dataflow/utilities/playback-utils.ts
+++ b/src/plugins/dataflow/utilities/playback-utils.ts
@@ -3,11 +3,8 @@ import { IDataSet } from "../../../models/data/data-set";
 import { kMaxNodeValues } from "../model/utilities/node";
 import { ValueControl } from "../nodes/controls/value-control";
 import { ICaseCreation } from "../../../models/data/data-set-types";
-import { SensorValueControl } from "../nodes/controls/sensor-value-control";
 import { InputValueControl } from "../nodes/controls/input-value-control";
 import { DemoOutputControl } from "../nodes/controls/demo-output-control";
-import { Value } from "expr-eval";
-
 
 function getPriorCases(dataSet: IDataSet, playhead: number){
   const offset = 1;

--- a/src/plugins/dataflow/utilities/playback-utils.ts
+++ b/src/plugins/dataflow/utilities/playback-utils.ts
@@ -15,52 +15,38 @@ function getPriorCases(dataSet: IDataSet, playhead: number){
   return dataSet.getCasesAtIndices(regionStart, countOfCasesToGet);
 }
 
+const asStrings = ["Generator", "Transform", "Math", "Control", "Timer", "Logic"];
+const asNumbers = ["Number", "Sensor"];
+const asOutputs = ["Demo Output", "Live Output"];
+
 export function runNodePlaybackUpdates(node: Node, valForNode: number){
-  let nodeControl;
-  switch (node.name){
-    case "Generator":
-      nodeControl = node.controls.get("nodeValue") as ValueControl;
-      nodeControl.setSentence(`${valForNode}`);
-      break;
-    case "Transform":
-      nodeControl = node.controls.get("nodeValue") as ValueControl;
-      nodeControl.setSentence(` → ${valForNode}`);
-      break;
-    case "Math":
-      nodeControl = node.controls.get("nodeValue") as ValueControl;
-      nodeControl.setSentence(` → ${valForNode}`);
-      break;
-    case "Control":
-      nodeControl = node.controls.get("nodeValue") as ValueControl;
-      nodeControl.setSentence(` → ${valForNode}`);
-      break;
-    case "Timer":
-      nodeControl = node.controls.get("nodeValue") as ValueControl;
-      nodeControl.setSentence(valForNode === 0 ? "off" : "on");
-      break;
-    case "Logic":
-      nodeControl = node.controls.get("nodeValue") as ValueControl;
-      nodeControl.setSentence(valForNode === 0 ? " ⇒ 0" : " ⇒ 1");
-      break;
-    case "Number":
-      nodeControl = node.controls.get("nodeValue") as ValueControl;
+  if (asStrings.includes(node.name)){
+    const nodeControl = node.controls.get("nodeValue") as ValueControl;
+    switch (node.name){
+      case "Generator": nodeControl.setSentence(`${valForNode}`); break;
+      case "Transform": nodeControl.setSentence(` → ${valForNode}`); break;
+      case "Math":      nodeControl.setSentence(` → ${valForNode}`); break;
+      case "Control":   nodeControl.setSentence(` → ${valForNode}`); break;
+      case "Timer":     nodeControl.setSentence(valForNode === 0 ? "off" : "on"); break;
+      case "Logic":     nodeControl.setSentence(valForNode === 0 ? " ⇒ 0" : " ⇒ 1"); break;
+    }
+  }
+
+  if (asNumbers.includes(node.name)){
+    const nodeControl = node.controls.get("nodeValue") as ValueControl;
+    nodeControl.setValue(valForNode);
+  }
+
+  if(asOutputs.includes(node.name)){
+    const inputControl = node.inputs.get("nodeValue")?.control as InputValueControl;
+    if (node.name === "Demo Output"){
+      const nodeControl = node.controls.get("demoOutput") as DemoOutputControl;
       nodeControl.setValue(valForNode);
-      break;
-    case "Sensor":
-      nodeControl = node.controls.get("nodeValue") as ValueControl;
-      nodeControl.setValue(valForNode);
-      break;
-    case "Demo Output":
-      nodeControl = node.controls.get("demoOutput") as DemoOutputControl;
-      nodeControl.setValue(valForNode);
-      nodeControl = node.inputs.get("nodeValue")?.control as InputValueControl;
-      nodeControl.setDisplayMessage(`${valForNode}`);
-      break;
-    case "Live Output":
-      nodeControl = node.inputs.get("nodeValue")?.control as InputValueControl;
-      nodeControl.setDisplayMessage(valForNode === 0 ? "off" : "on");
-      break;
-    default:
+      inputControl.setDisplayMessage(`${valForNode}`);
+    }
+    if (node.name === "Live Output"){
+      inputControl.setDisplayMessage(valForNode === 0 ? "off" : "on");
+    }
   }
 }
 

--- a/src/plugins/dataflow/utilities/playback-utils.ts
+++ b/src/plugins/dataflow/utilities/playback-utils.ts
@@ -6,6 +6,7 @@ import { ICaseCreation } from "../../../models/data/data-set-types";
 import { SensorValueControl } from "../nodes/controls/sensor-value-control";
 import { InputValueControl } from "../nodes/controls/input-value-control";
 import { DemoOutputControl } from "../nodes/controls/demo-output-control";
+import { Value } from "expr-eval";
 
 
 function getPriorCases(dataSet: IDataSet, playhead: number){
@@ -49,7 +50,7 @@ export function runNodePlaybackUpdates(node: Node, valForNode: number){
       nodeControl.setValue(valForNode);
       break;
     case "Sensor":
-      nodeControl = node.controls.get("nodeValue") as SensorValueControl;
+      nodeControl = node.controls.get("nodeValue") as ValueControl;
       nodeControl.setValue(valForNode);
       break;
     case "Demo Output":

--- a/src/plugins/dataflow/utilities/playback-utils.ts
+++ b/src/plugins/dataflow/utilities/playback-utils.ts
@@ -1,6 +1,15 @@
+import { Node } from "rete";
 import { IDataSet } from "../../../models/data/data-set";
 import { kMaxNodeValues } from "../model/utilities/node";
-import { getAttributeIdForNode } from "../model/utilities/recording-utilities";
+import { ValueControl } from "../nodes/controls/value-control";
+import { NumControl } from "../nodes/controls/num-control";
+import { SensorValueControl } from "../nodes/controls/sensor-value-control";
+
+const valueControl = (node: Node) => node.controls.get("nodeValue") as ValueControl;
+const inputControl = (node: Node) => node.controls.get("inputValue") as NumControl;
+
+const binaryToOnOff = (val: number) => val === 0 ? "off" : "on";
+const arrowedNumber = (val: number) => ` → ${val}`;
 
 function getPriorCases(dataSet: IDataSet, playhead: number){
   // kMaxNodeValues determines how many datapoints are plotted each time
@@ -22,3 +31,11 @@ export function getRecentValuesForNode(dataSet: IDataSet, playbackIndex: number,
   return calculatedRecentValues;
 }
 
+export function updatePlaybackValueControl(node: Node, value: string | number){
+  if (typeof value === "number") valueControl(node).setValue(value);
+  if (typeof value === "string") valueControl(node).setSentence(value);
+}
+
+export function updatePlaybackValueControlWithOnOff(valForNode: number, node: Node){
+  valueControl(node).setSentence(binaryToOnOff(valForNode));
+}

--- a/src/plugins/dataflow/utilities/playback-utils.ts
+++ b/src/plugins/dataflow/utilities/playback-utils.ts
@@ -7,8 +7,6 @@ import { SensorValueControl } from "../nodes/controls/sensor-value-control";
 import { InputValueControl } from "../nodes/controls/input-value-control";
 import { DemoOutputControl } from "../nodes/controls/demo-output-control";
 
-// const valueControl = (node: Node) => node.controls.get("nodeValue") as ValueControl;
-// const binaryToOnOff = (val: number) => val === 0 ? "off" : "on";
 
 function getPriorCases(dataSet: IDataSet, playhead: number){
   const offset = 1;
@@ -18,19 +16,6 @@ function getPriorCases(dataSet: IDataSet, playhead: number){
   const countOfCasesToGet = playhead < maxValues ? playhead : maxValues;
   return dataSet.getCasesAtIndices(regionStart, countOfCasesToGet);
 }
-
-// function updatePlaybackValueControl(node: Node, value: string | number){
-//   if (typeof value === "number") valueControl(node).setValue(value);
-//   if (typeof value === "string") valueControl(node).setSentence(value);
-// }
-
-// Each node has a nodeValue control that needs to be updated, but it comes in one of three types
-// This function allows us to pass the type rather than having to explicity get it AS each time
-// type ControlType = ValueControl | SensorValueControl | DemoOutputControl;
-
-// function getNodeControl<T extends ControlType>(node: Node, controlType: new () => T): T {
-//   return node.controls.get("nodeValue") as T;
-// }
 
 // TODO - display on demo is dependent on output type
 

--- a/src/plugins/dataflow/utilities/playback-utils.ts
+++ b/src/plugins/dataflow/utilities/playback-utils.ts
@@ -64,7 +64,6 @@ export function runNodePlaybackUpdates(node: Node, valForNode: number){
   }
 }
 
-
 export function calculatedRecentValues(dataSet: IDataSet, playbackIndex: number, attrId: string ){
   const vals: number[] = [];
   const priorCases = getPriorCases(dataSet, playbackIndex) as ICaseCreation[];

--- a/src/plugins/dataflow/utilities/playback-utils.ts
+++ b/src/plugins/dataflow/utilities/playback-utils.ts
@@ -2,7 +2,7 @@ import { Node } from "rete";
 import { IDataSet } from "../../../models/data/data-set";
 import { kMaxNodeValues } from "../model/utilities/node";
 import { ValueControl } from "../nodes/controls/value-control";
-import { ICaseCreation } from "../../../models/data/data-set-types";
+import { ICase } from "../../../models/data/data-set-types";
 import { InputValueControl } from "../nodes/controls/input-value-control";
 import { DemoOutputControl } from "../nodes/controls/demo-output-control";
 
@@ -67,8 +67,8 @@ export function runNodePlaybackUpdates(node: Node, valForNode: number){
 export function calculatedRecentValues(dataSet: IDataSet, playbackIndex: number, attrId: string ){
   const vals: number[] = [];
   const priorCases = getPriorCases(dataSet, playbackIndex);
-  priorCases.forEach((c: ICaseCreation | undefined) => {
-    if (c && c.__id__) {
+  priorCases.forEach((c: ICase | undefined) => {
+    if (c) {
       const caseNodeValue = dataSet.getValue(c.__id__, attrId) as number;
       if (isFinite(caseNodeValue)) vals.push(caseNodeValue);
     }

--- a/src/plugins/dataflow/utilities/playback-utils.ts
+++ b/src/plugins/dataflow/utilities/playback-utils.ts
@@ -3,6 +3,9 @@ import { IDataSet } from "../../../models/data/data-set";
 import { kMaxNodeValues } from "../model/utilities/node";
 import { ValueControl } from "../nodes/controls/value-control";
 import { ICaseCreation } from "../../../models/data/data-set-types";
+import { SensorValueControl } from "../nodes/controls/sensor-value-control";
+import { InputValueControl } from "../nodes/controls/input-value-control";
+import { DemoOutputControl } from "../nodes/controls/demo-output-control";
 
 const valueControl = (node: Node) => node.controls.get("nodeValue") as ValueControl;
 const binaryToOnOff = (val: number) => val === 0 ? "off" : "on";
@@ -17,15 +20,15 @@ function getPriorCases(dataSet: IDataSet, playhead: number){
   return dataSet.getCasesAtIndices(regionStart, countOfCasesToGet);
 }
 
-export function getRecentValuesForNode(dataSet: IDataSet, playbackIndex: number, attrId: string ){
-  const calculatedRecentValues: number[] = [];
+export function calculatedRecentValues(dataSet: IDataSet, playbackIndex: number, attrId: string ){
+  const vals: number[] = [];
   const priorCases = getPriorCases(dataSet, playbackIndex) as ICaseCreation[];
   const priorCasesIds = priorCases.map((c: ICaseCreation) => c.__id__);
   priorCasesIds.forEach((c) => {
     const caseNodeValue = dataSet.getValue(c as string, attrId) as number;
-    if (isFinite(caseNodeValue)) calculatedRecentValues.push(caseNodeValue);
+    if (isFinite(caseNodeValue)) vals.push(caseNodeValue);
   });
-  return calculatedRecentValues;
+  return { "nodeValue": vals };
 }
 
 export function updatePlaybackValueControl(node: Node, value: string | number){
@@ -35,4 +38,53 @@ export function updatePlaybackValueControl(node: Node, value: string | number){
 
 export function updatePlaybackValueControlWithOnOff(valForNode: number, node: Node){
   valueControl(node).setSentence(binaryToOnOff(valForNode));
+}
+
+export function updatePlaybackValueControlSpecialCases(node: Node, valForNode: number){
+  let nodeControl;
+  switch (node.name){
+    case "Transform":
+      nodeControl = node.controls.get("nodeValue") as ValueControl;
+      nodeControl.setSentence(` → ${valForNode}`);
+      break;
+    case "Sensor":
+      nodeControl = node.controls.get("nodeValue") as SensorValueControl;
+      nodeControl.setValue(valForNode);
+      break;
+    case "Timer":
+      nodeControl = node.controls.get("nodeValue") as ValueControl;
+      nodeControl.setSentence(valForNode === 0 ? "off" : "on");
+      break;
+    case "Math":
+      nodeControl = node.controls.get("nodeValue") as ValueControl;
+      nodeControl.setSentence(` → ${valForNode}`);
+      break;
+    case "Logic":
+      nodeControl = node.controls.get("nodeValue") as ValueControl;
+      nodeControl.setSentence(valForNode === 0 ? " ⇒ 0" : " ⇒ 1");
+      break;
+    case "Control":
+      nodeControl = node.controls.get("nodeValue") as ValueControl;
+      nodeControl.setSentence(` → ${valForNode}`);
+      break;
+    case "Demo Output":
+      nodeControl = node.controls.get("demoOutput") as DemoOutputControl;
+      nodeControl.setValue(valForNode);
+      nodeControl = node.inputs.get("nodeValue")?.control as InputValueControl;
+      nodeControl.setDisplayMessage(`${valForNode}`);
+      break;
+    case "Live Output":
+      nodeControl = node.inputs.get("nodeValue")?.control as InputValueControl;
+      nodeControl.setDisplayMessage(valForNode === 0 ? "off" : "on");
+      break;
+    default:
+  }
+}
+
+export function runNodePlaybackUpdates(node: Node, valForNode: number){
+  if (["Number", "Generator"].includes(node.name)){
+    updatePlaybackValueControl(node, valForNode);
+  } else {
+    updatePlaybackValueControlSpecialCases(node, valForNode);
+  }
 }

--- a/src/plugins/dataflow/utilities/playback-utils.ts
+++ b/src/plugins/dataflow/utilities/playback-utils.ts
@@ -1,0 +1,11 @@
+export function getRecentValuesForNode(node: any, dataSet: any, playbackIndex: number ){
+  console.log("| lets calc recent values for node |",
+    "\n          node:", node,
+    "\n       dataSet:", dataSet,
+    "\n playbackIndex:", playbackIndex
+  );
+
+
+  const randomDummyValues = Array.from({length: 10}, () => Math.floor(Math.random() * 10));
+  return randomDummyValues;
+}

--- a/src/plugins/dataflow/utilities/playback-utils.ts
+++ b/src/plugins/dataflow/utilities/playback-utils.ts
@@ -1,7 +1,8 @@
 import { Node } from "rete";
-import { ICase, IDataSet } from "../../../models/data/data-set";
+import { IDataSet } from "../../../models/data/data-set";
 import { kMaxNodeValues } from "../model/utilities/node";
 import { ValueControl } from "../nodes/controls/value-control";
+import { ICaseCreation } from "../../../models/data/data-set-types";
 
 const valueControl = (node: Node) => node.controls.get("nodeValue") as ValueControl;
 const binaryToOnOff = (val: number) => val === 0 ? "off" : "on";
@@ -17,11 +18,11 @@ function getPriorCases(dataSet: IDataSet, playhead: number){
 }
 
 export function getRecentValuesForNode(dataSet: IDataSet, playbackIndex: number, attrId: string ){
-  const priorCases = getPriorCases(dataSet, playbackIndex);
   const calculatedRecentValues: number[] = [];
-  priorCases.forEach((c: any) => {
-    console.log(typeof c);
-    const caseNodeValue = dataSet.getValue(c.__id__, attrId) as number;
+  const priorCases = getPriorCases(dataSet, playbackIndex) as ICaseCreation[];
+  const priorCasesIds = priorCases.map((c: ICaseCreation) => c.__id__);
+  priorCasesIds.forEach((c) => {
+    const caseNodeValue = dataSet.getValue(c as string, attrId) as number;
     if (isFinite(caseNodeValue)) calculatedRecentValues.push(caseNodeValue);
   });
   return calculatedRecentValues;

--- a/src/plugins/dataflow/utilities/playback-utils.ts
+++ b/src/plugins/dataflow/utilities/playback-utils.ts
@@ -1,36 +1,29 @@
 import { kMaxNodeValues } from "../model/utilities/node";
 
 function getPriorCases(index: number, dataSet: any, playhead: number){
-  // if we have less than 17 cases our region begins at 0
-  const offSet = 1; // I'm 99% sure we need this but math is hard
+  // kMaxNodeValues determines how many datapoints are plotted each time
+  const offSet = 1;
   const maxValues = kMaxNodeValues + offSet;
   const pastCalc = playhead - maxValues;
   const regionStart = pastCalc < 0 ? 0 : pastCalc;
+  const countOfCasesToGet = playhead < maxValues ? playhead : maxValues;
 
-  console.log("PB: 1 get the cases from ", regionStart, " to ", playhead);
-
-  // const fetchUs = [];
-  // for (let i = regionStart; i < playhead; i++) {
-  //   fetchUs.push(i);
-  // }
-
-  //console.log("PB: 2 which are indices: fetchUs:", fetchUs);
-
-  // thought we needed the playhead here but I think we just need the regionStart
-  //const cases = dataSet.getCasesAtIndices(regionStart, playhead);
-
-  const numberOfCasesToGet = playhead < maxValues ? playhead : maxValues;
-
-  const cases = dataSet.getCasesAtIndices(regionStart, numberOfCasesToGet);
+  const cases = dataSet.getCasesAtIndices(regionStart, countOfCasesToGet);
   return cases;
 }
 
 export function getRecentValuesForNode(node: any, dataSet: any, playbackIndex: number ){
 
   const priorCases = getPriorCases(playbackIndex, dataSet, playbackIndex);
+  console.log("priorCases", priorCases);
 
-  console.log("PB: 2 and now we have our priorCases:", priorCases, "\n");
-  console.log("\n");
+  const nodeValues = priorCases.map((c: any) => {
+    console.log("I need the attribute id for the node: ", node);
+    console.log("Then, I use that attribute to get the particular value from the case", c);
+  });
+
+  const nv = nodeValues.reverse();
+
 
   const randomDummyValues = Array.from({length: 10}, () => Math.floor(Math.random() * 10));
   return randomDummyValues;

--- a/src/plugins/dataflow/utilities/playback-utils.ts
+++ b/src/plugins/dataflow/utilities/playback-utils.ts
@@ -75,4 +75,3 @@ export function calculatedRecentValues(dataSet: IDataSet, playbackIndex: number,
   });
   return { "nodeValue": vals };
 }
-

--- a/src/plugins/dataflow/utilities/playback-utils.ts
+++ b/src/plugins/dataflow/utilities/playback-utils.ts
@@ -3,8 +3,8 @@ import { getAttributeIdForNode } from "../model/utilities/recording-utilities";
 
 function getPriorCases(index: number, dataSet: any, playhead: number){
   // kMaxNodeValues determines how many datapoints are plotted each time
-  const offSet = 1;
-  const maxValues = kMaxNodeValues + offSet;
+  const offset = 1;
+  const maxValues = kMaxNodeValues + offset;
   const pastCalc = playhead - maxValues;
   const regionStart = pastCalc < 0 ? 0 : pastCalc;
   const countOfCasesToGet = playhead < maxValues ? playhead : maxValues;

--- a/src/plugins/dataflow/utilities/playback-utils.ts
+++ b/src/plugins/dataflow/utilities/playback-utils.ts
@@ -17,15 +17,9 @@ function getPriorCases(dataSet: IDataSet, playhead: number){
   return dataSet.getCasesAtIndices(regionStart, countOfCasesToGet);
 }
 
-// TODO - display on demo is dependent on output type
-
 export function runNodePlaybackUpdates(node: Node, valForNode: number){
   let nodeControl;
   switch (node.name){
-    case "Number":
-      nodeControl = node.controls.get("nodeValue") as ValueControl;
-      nodeControl.setValue(valForNode);
-      break;
     case "Generator":
       nodeControl = node.controls.get("nodeValue") as ValueControl;
       nodeControl.setSentence(`${valForNode}`);
@@ -34,25 +28,29 @@ export function runNodePlaybackUpdates(node: Node, valForNode: number){
       nodeControl = node.controls.get("nodeValue") as ValueControl;
       nodeControl.setSentence(` → ${valForNode}`);
       break;
-    case "Sensor":
-      nodeControl = node.controls.get("nodeValue") as SensorValueControl;
-      nodeControl.setValue(valForNode);
+    case "Math":
+      nodeControl = node.controls.get("nodeValue") as ValueControl;
+      nodeControl.setSentence(` → ${valForNode}`);
+      break;
+    case "Control":
+      nodeControl = node.controls.get("nodeValue") as ValueControl;
+      nodeControl.setSentence(` → ${valForNode}`);
       break;
     case "Timer":
       nodeControl = node.controls.get("nodeValue") as ValueControl;
       nodeControl.setSentence(valForNode === 0 ? "off" : "on");
       break;
-    case "Math":
-      nodeControl = node.controls.get("nodeValue") as ValueControl;
-      nodeControl.setSentence(` → ${valForNode}`);
-      break;
     case "Logic":
       nodeControl = node.controls.get("nodeValue") as ValueControl;
       nodeControl.setSentence(valForNode === 0 ? " ⇒ 0" : " ⇒ 1");
       break;
-    case "Control":
+    case "Number":
       nodeControl = node.controls.get("nodeValue") as ValueControl;
-      nodeControl.setSentence(` → ${valForNode}`);
+      nodeControl.setValue(valForNode);
+      break;
+    case "Sensor":
+      nodeControl = node.controls.get("nodeValue") as SensorValueControl;
+      nodeControl.setValue(valForNode);
       break;
     case "Demo Output":
       nodeControl = node.controls.get("demoOutput") as DemoOutputControl;
@@ -68,6 +66,7 @@ export function runNodePlaybackUpdates(node: Node, valForNode: number){
   }
 }
 
+
 export function calculatedRecentValues(dataSet: IDataSet, playbackIndex: number, attrId: string ){
   const vals: number[] = [];
   const priorCases = getPriorCases(dataSet, playbackIndex) as ICaseCreation[];
@@ -79,10 +78,3 @@ export function calculatedRecentValues(dataSet: IDataSet, playbackIndex: number,
   return { "nodeValue": vals };
 }
 
-// export function runNodePlaybackUpdates(node: Node, valForNode: number){
-//   if (["Number", "Generator"].includes(node.name)){
-//     updatePlaybackValueControl(node, valForNode);
-//   } else {
-//     updatePlaybackValueControlSpecialCases(node, valForNode);
-//   }
-// }

--- a/src/plugins/dataflow/utilities/playback-utils.ts
+++ b/src/plugins/dataflow/utilities/playback-utils.ts
@@ -12,13 +12,13 @@ function getPriorCases(dataSet: IDataSet, playhead: number){
   return dataSet.getCasesAtIndices(regionStart, countOfCasesToGet);
 }
 
-export function getRecentValuesForNode(dataSet: IDataSet, playbackIndex: number, nodeIndex: number ){
-  const attributeId = getAttributeIdForNode(dataSet, nodeIndex);
+export function getRecentValuesForNode(dataSet: IDataSet, playbackIndex: number, attrId: string ){
   const priorCases = getPriorCases(dataSet, playbackIndex);
   const calculatedRecentValues: number[] = [];
   priorCases.forEach((c: any) => {
-    const caseNodeValue = dataSet.getValue(c.__id__, attributeId) as number;
+    const caseNodeValue = dataSet.getValue(c.__id__, attrId) as number;
     if (isFinite(caseNodeValue)) calculatedRecentValues.push(caseNodeValue);
   });
   return calculatedRecentValues;
 }
+

--- a/src/plugins/dataflow/utilities/playback-utils.ts
+++ b/src/plugins/dataflow/utilities/playback-utils.ts
@@ -1,5 +1,5 @@
 import { Node } from "rete";
-import { IDataSet } from "../../../models/data/data-set";
+import { ICase, IDataSet } from "../../../models/data/data-set";
 import { kMaxNodeValues } from "../model/utilities/node";
 import { ValueControl } from "../nodes/controls/value-control";
 
@@ -20,6 +20,7 @@ export function getRecentValuesForNode(dataSet: IDataSet, playbackIndex: number,
   const priorCases = getPriorCases(dataSet, playbackIndex);
   const calculatedRecentValues: number[] = [];
   priorCases.forEach((c: any) => {
+    console.log(typeof c);
     const caseNodeValue = dataSet.getValue(c.__id__, attrId) as number;
     if (isFinite(caseNodeValue)) calculatedRecentValues.push(caseNodeValue);
   });

--- a/src/plugins/dataflow/utilities/playback-utils.ts
+++ b/src/plugins/dataflow/utilities/playback-utils.ts
@@ -1,25 +1,24 @@
+import { IDataSet } from "../../../models/data/data-set";
 import { kMaxNodeValues } from "../model/utilities/node";
 import { getAttributeIdForNode } from "../model/utilities/recording-utilities";
 
-function getPriorCases(index: number, dataSet: any, playhead: number){
+function getPriorCases(dataSet: IDataSet, playhead: number){
   // kMaxNodeValues determines how many datapoints are plotted each time
   const offset = 1;
   const maxValues = kMaxNodeValues + offset;
   const pastCalc = playhead - maxValues;
   const regionStart = pastCalc < 0 ? 0 : pastCalc;
   const countOfCasesToGet = playhead < maxValues ? playhead : maxValues;
-
-  const cases = dataSet.getCasesAtIndices(regionStart, countOfCasesToGet);
-  return cases;
+  return dataSet.getCasesAtIndices(regionStart, countOfCasesToGet);
 }
 
-export function getRecentValuesForNode(node: any, dataSet: any, playbackIndex: number, nodeIndex: number ){
+export function getRecentValuesForNode(dataSet: IDataSet, playbackIndex: number, nodeIndex: number ){
   const attributeId = getAttributeIdForNode(dataSet, nodeIndex);
-  const priorCases = getPriorCases(playbackIndex, dataSet, playbackIndex);
-  const calculatedRecentValues: any[] = [];
+  const priorCases = getPriorCases(dataSet, playbackIndex);
+  const calculatedRecentValues: number[] = [];
   priorCases.forEach((c: any) => {
-    const valueOfNodeInCase = dataSet.getValue(c.__id__, attributeId);
-    calculatedRecentValues.push(valueOfNodeInCase);
+    const caseNodeValue = dataSet.getValue(c.__id__, attributeId) as number;
+    if (isFinite(caseNodeValue)) calculatedRecentValues.push(caseNodeValue);
   });
   return calculatedRecentValues;
 }

--- a/src/plugins/dataflow/utilities/playback-utils.ts
+++ b/src/plugins/dataflow/utilities/playback-utils.ts
@@ -1,4 +1,5 @@
 import { kMaxNodeValues } from "../model/utilities/node";
+import { getAttributeIdForNode } from "../model/utilities/recording-utilities";
 
 function getPriorCases(index: number, dataSet: any, playhead: number){
   // kMaxNodeValues determines how many datapoints are plotted each time
@@ -12,19 +13,35 @@ function getPriorCases(index: number, dataSet: any, playhead: number){
   return cases;
 }
 
-export function getRecentValuesForNode(node: any, dataSet: any, playbackIndex: number ){
+export function getRecentValuesForNode(node: any, dataSet: any, playbackIndex: number, nodeIndex: number ){ //idx from over there <--
+  const attributeId = getAttributeIdForNode(dataSet, nodeIndex);
+  console.log("PB 1: node: ", node.id, node.name, "-> ", attributeId);
+
 
   const priorCases = getPriorCases(playbackIndex, dataSet, playbackIndex);
-  console.log("priorCases", priorCases);
+  console.log("PB 2: prior cases: \n ", priorCases);
 
-  const nodeValues = priorCases.map((c: any) => {
-    console.log("I need the attribute id for the node: ", node);
-    console.log("Then, I use that attribute to get the particular value from the case", c);
+  const calculatedRecentValues: any[] = [];
+
+  priorCases.forEach((c: any) => {
+    console.log("   ....case:          ", c);
+    console.log("   & node ", node.id, node.name, attributeId);
+    const valueOfNodeInCase = dataSet.getValue(c.__id__, attributeId);
+    calculatedRecentValues.push(valueOfNodeInCase);
   });
 
-  const nv = nodeValues.reverse();
+  // const nodeValues = priorCases.map((c: any) => {
+  //   console.log("case node: ", node.id, node.name);
+  //   console.log("Then, I use that attribute to get the particular value from the case", c);
+  // });
 
+  //const nv = nodeValues.reverse();
 
   const randomDummyValues = Array.from({length: 10}, () => Math.floor(Math.random() * 10));
-  return randomDummyValues;
+
+  console.log("HEY whats the diff: ", calculatedRecentValues, " vs ", randomDummyValues);
+
+
+  //return randomDummyValues;
+  return calculatedRecentValues;
 }

--- a/src/plugins/dataflow/utilities/playback-utils.ts
+++ b/src/plugins/dataflow/utilities/playback-utils.ts
@@ -13,35 +13,13 @@ function getPriorCases(index: number, dataSet: any, playhead: number){
   return cases;
 }
 
-export function getRecentValuesForNode(node: any, dataSet: any, playbackIndex: number, nodeIndex: number ){ //idx from over there <--
+export function getRecentValuesForNode(node: any, dataSet: any, playbackIndex: number, nodeIndex: number ){
   const attributeId = getAttributeIdForNode(dataSet, nodeIndex);
-  console.log("PB 1: node: ", node.id, node.name, "-> ", attributeId);
-
-
   const priorCases = getPriorCases(playbackIndex, dataSet, playbackIndex);
-  console.log("PB 2: prior cases: \n ", priorCases);
-
   const calculatedRecentValues: any[] = [];
-
   priorCases.forEach((c: any) => {
-    console.log("   ....case:          ", c);
-    console.log("   & node ", node.id, node.name, attributeId);
     const valueOfNodeInCase = dataSet.getValue(c.__id__, attributeId);
     calculatedRecentValues.push(valueOfNodeInCase);
   });
-
-  // const nodeValues = priorCases.map((c: any) => {
-  //   console.log("case node: ", node.id, node.name);
-  //   console.log("Then, I use that attribute to get the particular value from the case", c);
-  // });
-
-  //const nv = nodeValues.reverse();
-
-  const randomDummyValues = Array.from({length: 10}, () => Math.floor(Math.random() * 10));
-
-  console.log("HEY whats the diff: ", calculatedRecentValues, " vs ", randomDummyValues);
-
-
-  //return randomDummyValues;
   return calculatedRecentValues;
 }

--- a/src/plugins/dataflow/utilities/playback-utils.ts
+++ b/src/plugins/dataflow/utilities/playback-utils.ts
@@ -1,40 +1,36 @@
-
+import { kMaxNodeValues } from "../model/utilities/node";
 
 function getPriorCases(index: number, dataSet: any, playhead: number){
   // if we have less than 17 cases our region begins at 0
-  const pastCalc = playhead - 17;
-  const regionStart = playhead - 17 < 0 ? 0 : pastCalc;
+  const offSet = 1; // I'm 99% sure we need this but math is hard
+  const maxValues = kMaxNodeValues + offSet;
+  const pastCalc = playhead - maxValues;
+  const regionStart = pastCalc < 0 ? 0 : pastCalc;
 
-  console.log("OK:, ",
-      // "   startI: ", regionStart,
-      // "   endI: ", playhead,
-      "get the cases from ", regionStart, " to ", playhead
-  );
+  console.log("PB: 1 get the cases from ", regionStart, " to ", playhead);
 
-  // const priorCases = [];
-  // for (let i = index; i > 17; i--){
-  //   const casee = dataSet.getCaseAtIndex(i);
-  //   priorCases.push(casee);
+  // const fetchUs = [];
+  // for (let i = regionStart; i < playhead; i++) {
+  //   fetchUs.push(i);
   // }
-  // //console.log("priorCases:", priorCases);
-  // return priorCases.slice(0, 10);
+
+  //console.log("PB: 2 which are indices: fetchUs:", fetchUs);
+
+  // thought we needed the playhead here but I think we just need the regionStart
+  //const cases = dataSet.getCasesAtIndices(regionStart, playhead);
+
+  const numberOfCasesToGet = playhead < maxValues ? playhead : maxValues;
+
+  const cases = dataSet.getCasesAtIndices(regionStart, numberOfCasesToGet);
+  return cases;
 }
 
 export function getRecentValuesForNode(node: any, dataSet: any, playbackIndex: number ){
-  // console.log("||| lets calc recent values for node |",
-  //   "\n        node:",          node,
-  //   "\n       dataSet:",        dataSet,
-  //   "\n       playbackIndex:",  playbackIndex
-  // );
 
-  // const attributeValuesInDataSet = dataSet.attributeValues;
-  // console.log("||| attributeValuesInDataSet:", attributeValuesInDataSet);
-
-  // const currentCase = dataSet.getCaseAtIndex(playbackIndex);
-  // const {__id__} = currentCase;
   const priorCases = getPriorCases(playbackIndex, dataSet, playbackIndex);
 
-  //console.log("\nzz priorCases:", priorCases);
+  console.log("PB: 2 and now we have our priorCases:", priorCases, "\n");
+  console.log("\n");
 
   const randomDummyValues = Array.from({length: 10}, () => Math.floor(Math.random() * 10));
   return randomDummyValues;

--- a/src/plugins/dataflow/utilities/playback-utils.ts
+++ b/src/plugins/dataflow/utilities/playback-utils.ts
@@ -1,10 +1,40 @@
-export function getRecentValuesForNode(node: any, dataSet: any, playbackIndex: number ){
-  console.log("| lets calc recent values for node |",
-    "\n          node:", node,
-    "\n       dataSet:", dataSet,
-    "\n playbackIndex:", playbackIndex
+
+
+function getPriorCases(index: number, dataSet: any, playhead: number){
+  // if we have less than 17 cases our region begins at 0
+  const pastCalc = playhead - 17;
+  const regionStart = playhead - 17 < 0 ? 0 : pastCalc;
+
+  console.log("OK:, ",
+      // "   startI: ", regionStart,
+      // "   endI: ", playhead,
+      "get the cases from ", regionStart, " to ", playhead
   );
 
+  // const priorCases = [];
+  // for (let i = index; i > 17; i--){
+  //   const casee = dataSet.getCaseAtIndex(i);
+  //   priorCases.push(casee);
+  // }
+  // //console.log("priorCases:", priorCases);
+  // return priorCases.slice(0, 10);
+}
+
+export function getRecentValuesForNode(node: any, dataSet: any, playbackIndex: number ){
+  // console.log("||| lets calc recent values for node |",
+  //   "\n        node:",          node,
+  //   "\n       dataSet:",        dataSet,
+  //   "\n       playbackIndex:",  playbackIndex
+  // );
+
+  // const attributeValuesInDataSet = dataSet.attributeValues;
+  // console.log("||| attributeValuesInDataSet:", attributeValuesInDataSet);
+
+  // const currentCase = dataSet.getCaseAtIndex(playbackIndex);
+  // const {__id__} = currentCase;
+  const priorCases = getPriorCases(playbackIndex, dataSet, playbackIndex);
+
+  //console.log("\nzz priorCases:", priorCases);
 
   const randomDummyValues = Array.from({length: 10}, () => Math.floor(Math.random() * 10));
   return randomDummyValues;

--- a/src/plugins/dataflow/utilities/playback-utils.ts
+++ b/src/plugins/dataflow/utilities/playback-utils.ts
@@ -2,14 +2,9 @@ import { Node } from "rete";
 import { IDataSet } from "../../../models/data/data-set";
 import { kMaxNodeValues } from "../model/utilities/node";
 import { ValueControl } from "../nodes/controls/value-control";
-import { NumControl } from "../nodes/controls/num-control";
-import { SensorValueControl } from "../nodes/controls/sensor-value-control";
 
 const valueControl = (node: Node) => node.controls.get("nodeValue") as ValueControl;
-const inputControl = (node: Node) => node.controls.get("inputValue") as NumControl;
-
 const binaryToOnOff = (val: number) => val === 0 ? "off" : "on";
-const arrowedNumber = (val: number) => ` → ${val}`;
 
 function getPriorCases(dataSet: IDataSet, playhead: number){
   // kMaxNodeValues determines how many datapoints are plotted each time


### PR DESCRIPTION
This adds minigraph rendering to Dataflow recorded program playback, as described in [PT#184873706](https://www.pivotaltracker.com/story/show/184873706) and [PT#184873784](https://www.pivotaltracker.com/story/show/184873784)

- Removes some logic to a utility function
- adds recorded value to nodes during playback.  For those nodes with a calculated output, the calculated value is displayed with an arrow before, indicating it's the result of an operation. 