### PR TITLE
184623254-minigraph-tick-decimal-fix

### DIFF
--- a/src/plugins/dataflow/nodes/dataflow-node-plot.tsx
+++ b/src/plugins/dataflow/nodes/dataflow-node-plot.tsx
@@ -99,7 +99,7 @@ function lineData(node: any) {
       chartDataSets.push(dataset);
     }
   });
-  
+
   stepY = (maxY(node) - minY(node)) / 2;
 
   const chartData: ChartData = {
@@ -136,6 +136,9 @@ function lineOptions(node: any) {
           maxTicksLimit: 3,
           minRotation: 0,
           maxRotation: 0,
+          callback: (value: number) => {
+            return Number(value.toFixed(1));
+          }
         },
         gridLines: {
           display: false,


### PR DESCRIPTION
This rounds the tick values on the y axis of the Dataflow minigraph to one decimal point, as described in [PT#184623254](https://www.pivotaltracker.com/story/show/184623254)