### PR TITLE
need src and tsconig for functions deploy

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -32,9 +32,7 @@
       ".git",
       "coverage",
       "node_modules",
-      "src",
-      "test",
-      "tsconfig.*"
+      "test"
     ]
   }
 }


### PR DESCRIPTION
I'm not sure how this worked before, but when firebase now deploys
a function, it will compile it locally and then again in the cloud.
In order to compile it in the cloud the src folder is needed,
and the tsconfig files are needed.

PT-185502029