### PR TITLE
185633009-if-tags-are-enabled-able-to-post-empty-comment-and-display-with-tag

### DIFF
--- a/cypress/e2e/clue/branch/teacher_tests/teacher_chat_spec.js
+++ b/cypress/e2e/clue/branch/teacher_tests/teacher_chat_spec.js
@@ -45,6 +45,7 @@ context('Chat Panel', () => {
       chatPanel.getChatPanel().should('not.exist');
     });
     it('verify new comment card exits, card icon exists and Post button is disabled', () => {
+      cy.pause();
       chatPanel.getChatPanelToggle().click();
       cy.wait(2000);
       chatPanel.getCommentCard().should('exist');

--- a/cypress/e2e/clue/branch/teacher_tests/teacher_chat_spec.js
+++ b/cypress/e2e/clue/branch/teacher_tests/teacher_chat_spec.js
@@ -45,11 +45,10 @@ context('Chat Panel', () => {
       chatPanel.getChatPanel().should('not.exist');
     });
     it('verify new comment card exits, card icon exists and Post button is disabled', () => {
-      cy.pause();
       chatPanel.getChatPanelToggle().click();
       cy.wait(2000);
       chatPanel.getCommentCard().should('exist');
-      chatPanel.getCommentPostButton().should('have.class', 'disabled');
+      // chatPanel.getCommentPostButton().should('have.class', 'disabled');
     });
     it('verify the comment card and the document are highlighted', () => {
       chatPanel.verifyProblemCommentClass();

--- a/cypress/e2e/clue/branch/teacher_tests/teacher_chat_spec.js
+++ b/cypress/e2e/clue/branch/teacher_tests/teacher_chat_spec.js
@@ -48,7 +48,7 @@ context('Chat Panel', () => {
       chatPanel.getChatPanelToggle().click();
       cy.wait(2000);
       chatPanel.getCommentCard().should('exist');
-      // chatPanel.getCommentPostButton().should('have.class', 'disabled');
+      chatPanel.getCommentPostButton().should('have.class', 'disabled');
     });
     it('verify the comment card and the document are highlighted', () => {
       chatPanel.verifyProblemCommentClass();

--- a/src/components/chat/comment-card.tsx
+++ b/src/components/chat/comment-card.tsx
@@ -93,7 +93,7 @@ export const CommentCard: React.FC<IProps> = ({ activeNavTab, user, postedCommen
                 {
                   appConfig.showCommentTag && comment.tags &&
                   <div className="comment-dropdown-tag">
-                    { comment.tags }
+                    { comment.tags.join(", ") }
                   </div>
                 }
                 <div key={idx} className="comment-text" data-testid="comment">

--- a/src/components/chat/comment-card.tsx
+++ b/src/components/chat/comment-card.tsx
@@ -91,9 +91,9 @@ export const CommentCard: React.FC<IProps> = ({ activeNavTab, user, postedCommen
                   }
                 </div>
                 {
-                  appConfig.showCommentTag && comment.tag &&
+                  appConfig.showCommentTag && comment.tags &&
                   <div className="comment-dropdown-tag">
-                    { comment.tag }
+                    { comment.tags }
                   </div>
                 }
                 <div key={idx} className="comment-text" data-testid="comment">

--- a/src/components/chat/comment-textbox.tsx
+++ b/src/components/chat/comment-textbox.tsx
@@ -24,9 +24,11 @@ export const CommentTextBox: React.FC<IProps> = (props) => {
   const [commentText, setCommentText] = useState("");
   const [tagText, setTagText] = useState("");
   const textareaStyle = {height: commentTextAreaHeight};
+
+  const commentEmptyNoTags =  (!commentAdded && !showCommentTag);
   const postButtonClass = classNames("comment-footer-button", "themed-negative", activeNavTab,
-                                      { disabled: (!commentAdded && !showCommentTag), //disabled if empty and no tags
-                                      "no-action": (!commentAdded && !showCommentTag) });
+                                      { disabled: commentEmptyNoTags,
+                                      "no-action": commentEmptyNoTags });
 
   const ui = useUIStore();
 

--- a/src/components/chat/comment-textbox.tsx
+++ b/src/components/chat/comment-textbox.tsx
@@ -16,7 +16,6 @@ interface IProps {
 
 export const CommentTextBox: React.FC<IProps> = (props) => {
   const { activeNavTab, numPostedComments, onPostComment, showCommentTag, commentTags, tagPrompt } = props;
-
   const minTextAreaHeight = showCommentTag ? 100 : 35;
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const [commentTextAreaHeight, setCommentTextAreaHeight] = useState(minTextAreaHeight);
@@ -26,8 +25,9 @@ export const CommentTextBox: React.FC<IProps> = (props) => {
   const [tagText, setTagText] = useState("");
   const textareaStyle = {height: commentTextAreaHeight};
   const postButtonClass = classNames("comment-footer-button", "themed-negative", activeNavTab,
-                                     { disabled: (!commentAdded && !commentTags), //able to post empty comment with tags
-                                       "no-action": !commentAdded && !commentTags });
+                                      { disabled: (!commentAdded && !commentTags), //disabled if empty and no tags
+                                      "no-action": (!commentAdded && !commentTags) });
+
   const ui = useUIStore();
 
   // resize textarea when user deletes some text

--- a/src/components/chat/comment-textbox.tsx
+++ b/src/components/chat/comment-textbox.tsx
@@ -26,7 +26,8 @@ export const CommentTextBox: React.FC<IProps> = (props) => {
   const [tagText, setTagText] = useState("");
   const textareaStyle = {height: commentTextAreaHeight};
   const postButtonClass = classNames("comment-footer-button", "themed-negative", activeNavTab,
-                                     { disabled: !commentAdded, "no-action": !commentAdded });
+                                     { disabled: (!commentAdded && !commentTags), //able to post empty comment with tags
+                                       "no-action": !commentAdded && !commentTags });
   const ui = useUIStore();
 
   // resize textarea when user deletes some text
@@ -68,7 +69,7 @@ export const CommentTextBox: React.FC<IProps> = (props) => {
   const handlePostComment = () => {
     // do not send post if text area is empty, only has spaces or new lines
     const [trimmedText, isEmpty] = trimContent(commentText);
-    if (!isEmpty) {
+    if (!isEmpty || showCommentTag) {
       onPostComment?.(trimmedText, tagText);
       setCommentTextAreaHeight(minTextAreaHeight);
       setCommentAdded(false);

--- a/src/components/chat/comment-textbox.tsx
+++ b/src/components/chat/comment-textbox.tsx
@@ -25,8 +25,8 @@ export const CommentTextBox: React.FC<IProps> = (props) => {
   const [tagText, setTagText] = useState("");
   const textareaStyle = {height: commentTextAreaHeight};
   const postButtonClass = classNames("comment-footer-button", "themed-negative", activeNavTab,
-                                      { disabled: (!commentAdded && !commentTags), //disabled if empty and no tags
-                                      "no-action": (!commentAdded && !commentTags) });
+                                      { disabled: (!commentAdded && !showCommentTag), //disabled if empty and no tags
+                                      "no-action": (!commentAdded && !showCommentTag) });
 
   const ui = useUIStore();
 

--- a/src/lib/firestore-schema.ts
+++ b/src/lib/firestore-schema.ts
@@ -43,7 +43,7 @@ export interface CommentDocument {
   createdAt: FSDate;          // timestamp used for sorting
   tileId?: string;            // empty for document comments
   content: string;            // plain text for now; potentially html if we need rich text
-  tag?: string | undefined;   // AI tag selected for the commment
+  tags?: string[];            // AI tag selected for the commment
 }
 // collection key is Firestore-assigned id
 type CommentsCollection = FSCollection<CommentDocument>;

--- a/src/public/curriculum/stretching-and-shrinking/stretching-and-shrinking.json
+++ b/src/public/curriculum/stretching-and-shrinking/stretching-and-shrinking.json
@@ -36,9 +36,7 @@
       "guess-and-check": "Guess and Check",
       "none": "None"
     },
-    "tagPrompt": {
-      "default": "Select Student Strategy"
-    }
+    "tagPrompt": "Select Student Strategy"
   },
   "sections": {
     "introduction": {


### PR DESCRIPTION
CSS changes that enable the user to post an empty comment given that there are tags
Part of this ticket 
[ **[CLUEAI]** If Tags are enabled, able To Post Empty Comment and display with Tag.](https://www.pivotaltracker.com/n/projects/2441242/stories/185633009)

Changes to the firestore function `async function postDocumentComment` (that needs to be deployed) in `post-document-comment.ts `were in this previous PR (https://github.com/concord-consortium/collaborative-learning/pull/1803)

Timestamp: Jun 19th: 9:49AM PST: 
Currently in `master` there is no way the user can actually click the post button when there is an empty comment and tags, so this addresses that. 


Right now if you post an empty comment (where it has tags), it gives the following error
<img width="716" alt="image" src="https://github.com/concord-consortium/collaborative-learning/assets/521934/b6994273-80de-4de6-80be-0cc95dbb907a">

I'm assuming this will go away once Scott or Aden deploys the new function to FireStore.


______________________________________________________________________________________________

Example deployment link 

https://collaborative-learning.concord.org/branch/if-tags-are-enabled-able-to-post-empty-comment-and-display-with-tag-2/?appMode=demo&fakeUser=teacher:2&fakeClass=2&unit=https://collaborative-learning.concord.org/branch/if-tags-are-enabled-able-to-post-empty-comment-and-display-with-tag-2/curriculum/stretching-and-shrinking/stretching-and-shrinking.json

Note that in the URL instead of unit=msa or unit=clue which would normally read the JSON off the [clue-curriculum repo](https://github.com/concord-consortium/clue-curriculum) but instead it points to a local json curriculum file (specifically `stretching-and-shrinking/stretching-and-shrinking.json` )


