### PR TITLE
clean up dataflow playback

### DIFF
--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -81,7 +81,6 @@ interface IProps extends SizeMeProps {
   handleChangeIsPlaying: () => void;
   updatePlayBackIndex: (update: string) => void;
   updateRecordIndex: (update: string) => void;
-  numNodes: number;
   tileContent: DataflowContentModelType;
 }
 
@@ -128,8 +127,8 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
   }
 
   public render() {
-    const { readOnly, documentProperties, numNodes, tileContent, programDataRate, onProgramDataRateChange,
-            isPlaying, handleChangeIsPlaying, handleChangeOfProgramMode, programMode} = this.props;
+    const { readOnly, documentProperties, tileContent, programDataRate, onProgramDataRateChange,
+            isPlaying, playBackIndex, handleChangeIsPlaying, handleChangeOfProgramMode, programMode} = this.props;
 
     const editorClassForDisplayState = "full";
     const editorClass = `editor ${editorClassForDisplayState}`;
@@ -152,9 +151,9 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
           lastIntervalDuration={this.state.lastIntervalDuration}
           serialDevice={this.stores.serialDevice}
           programMode={programMode}
+          playBackIndex={playBackIndex}
           isPlaying={isPlaying}
           handleChangeIsPlaying={handleChangeIsPlaying}
-          numNodes={numNodes}
           tileContent={tileContent}
           handleChangeOfProgramMode={handleChangeOfProgramMode}
         />

--- a/src/plugins/dataflow/components/ui/dataflow-program-topbar.tsx
+++ b/src/plugins/dataflow/components/ui/dataflow-program-topbar.tsx
@@ -25,15 +25,16 @@ interface TopbarProps {
   serialDevice: SerialDevice;
   handleChangeOfProgramMode: () => void;
   programMode: ProgramMode;
+  playBackIndex: number;
   isPlaying: boolean;
   handleChangeIsPlaying: () => void;
-  numNodes: number;
   tileContent: DataflowContentModelType;
 }
 
 export const DataflowProgramTopbar = (props: TopbarProps) => {
   const { onSerialRefreshDevices, readOnly, serialDevice, programDataRates, dataRate, onRateSelectClick,
-          handleChangeOfProgramMode, programMode, isPlaying, handleChangeIsPlaying, numNodes, tileContent} = props;
+          handleChangeOfProgramMode, programMode, playBackIndex, isPlaying,
+          handleChangeIsPlaying, tileContent} = props;
 
   return (
     <div className="program-editor-topbar">
@@ -59,10 +60,7 @@ export const DataflowProgramTopbar = (props: TopbarProps) => {
             onRateSelectClick={onRateSelectClick}
             readOnly={readOnly}
             programMode={programMode}
-            isPlaying={isPlaying}
-            handleChangeIsPlaying={handleChangeIsPlaying}
-            numNodes={numNodes}
-            handleChangeOfProgramMode={handleChangeOfProgramMode}
+            playBackIndex={playBackIndex}
             tileContent={tileContent}
           />
           <RecordStopOrClearButton

--- a/src/plugins/dataflow/components/ui/dataflow-rateselector-playback.tsx
+++ b/src/plugins/dataflow/components/ui/dataflow-rateselector-playback.tsx
@@ -1,12 +1,11 @@
-import React, { useEffect, useRef } from "react";
+import React, { useRef } from "react";
 import Slider from "rc-slider";
+import { observer } from "mobx-react";
 import { ProgramDataRate } from "../../model/utilities/node";
-import { DataflowContentModelType } from "../../model/dataflow-content";
+import { DataflowContentModelType, formatTime } from "../../model/dataflow-content";
 import { ProgramMode } from "../types/dataflow-tile-types";
 
 import "./dataflow-rateselector-playback.scss";
-
-const totalSamples = 10000;
 
 /* ==[ Sampling Rate Selector ] == */
 interface IRateSelectorProps {
@@ -15,128 +14,35 @@ interface IRateSelectorProps {
   onRateSelectClick: (rate: number) => void;
   readOnly: boolean;
   programMode: number;
-  isPlaying: boolean; //for playback of data
-  handleChangeIsPlaying: () => void;
-  numNodes: number;
-  handleChangeOfProgramMode: () => void;
+  playBackIndex: number;
   tileContent: DataflowContentModelType;
 }
 
-function formatTime(seconds: number) {
-  const minutes = Math.floor(seconds / 60);
-  const remainingSeconds = seconds % 60;
-  const formattedMinutes = minutes.toString().padStart(3, '0');
-  const formattedSeconds = remainingSeconds.toString().padStart(2, '0');
-  return `${formattedMinutes}:${formattedSeconds}`;
-}
+export const RateSelectorOrPlayBack = observer(function RateSelectorOrPlayBack(props: IRateSelectorProps) {
+  const { onRateSelectClick, readOnly, dataRate, rateOptions, programMode, playBackIndex,
+          tileContent } = props;
 
-export const RateSelectorOrPlayBack = (props: IRateSelectorProps) => {
-  const { onRateSelectClick, readOnly, dataRate, rateOptions, programMode, isPlaying,
-          handleChangeIsPlaying, numNodes, handleChangeOfProgramMode, tileContent } = props;
+  /* Max Recording Duration: */
+  const maxRecordingDuration = Math.floor((dataRate / 1000) * tileContent.maxRecordableCases);
+  const maxRecordingDurationFormatted = formatTime(maxRecordingDuration);
 
-  /* ==[ Total Recording Time  - Calculate] format as "MMM:SS" */
-  const totalTimeSec = Math.floor((dataRate / 1000) * (totalSamples/numNodes));
-  const totalTimeFormatted = formatTime(totalTimeSec);
+  const { durationOfRecording: lengthOfRecording } = tileContent;
 
-  /* ==[ Timer Recording Time  - Calculate] format as "MMM:SS" */
-  const timerMin = useRef(0);
-  const sliderSec = useRef(0); //this does not wrap around 60 and is used for the slider/total seconds
-  const timerSec = useRef(0); //seconds that have passed after hitting Record
-  const formattedMin = timerMin.current.toString().padStart(3, "0");
-  const formattedSec = timerSec.current.toString().padStart(2, "0");
-  const formattedTime = `${formattedMin}:${formattedSec}`;
-
-  /* ==[ Playback Recording Time  - Calculate] format as "MMM:SS" */
-  // seperate timer for when programMode is stopped (2), and Play button is hit
-  const playBackTimerMin = useRef(0);
-  const playBackTimerSec = useRef(0);
-  const playBackFormattedMin = playBackTimerMin.current.toString().padStart(3, "0");
-  const playBackFormattedSec = playBackTimerSec.current.toString().padStart(2, "0");
-  const playBackFormattedTime = `${playBackFormattedMin}:${playBackFormattedSec}`;
+  /* Playback Time based on playBackIndex */
+  const playBackTime = tileContent.getTimeAtRecordedIndex(playBackIndex);
+  const playBackFormattedTime = formatTime(playBackTime);
 
   /* ==[ Timer - Enable ] == */
-  const timerRunning = numNodes > 0 && sliderSec.current < totalTimeSec && (programMode === ProgramMode.Recording);
-  const playBackTimerRunning = !timerRunning && isPlaying;
-  const playBackIsFinished = (playBackTimerSec.current === timerSec.current) && (playBackTimerSec.current !== 0);
+  const isRecording = programMode === ProgramMode.Recording;
 
-  /* ==[ Slider Max Value ] == */
-  const condition = (playBackTimerRunning || (!isPlaying && !playBackIsFinished && programMode === ProgramMode.Done))
-  || playBackIsFinished;
-  let sliderMaxValue = condition ? timerSec.current : totalTimeSec;
-
-  /* ==[ Timer for Play, Timer for Playback ] == */
-  useEffect(()=>{
-    if (timerRunning){
-      const timer = setInterval(() => {
-        timerSec.current++;
-        sliderSec.current++;
-        if (timerSec.current === 60){
-          timerMin.current++;
-          timerSec.current = 0;
-        }
-      }, 1000);
-      return () => clearInterval(timer);
-    }
-    if (playBackTimerRunning && !playBackIsFinished){
-      const playBackTimer = setInterval(() => {
-        playBackTimerSec.current++;
-        sliderSec.current++;
-        if (playBackTimerSec.current === 60){
-          playBackTimerMin.current++;
-          playBackTimerSec.current = 0;
-        }
-      }, 1000);
-      return () => clearInterval(playBackTimer);
-    }
-  }, [timerSec, timerRunning, sliderSec, playBackTimerRunning, programMode, playBackIsFinished]);
-
-  /* ==[ Stop Mode - Reset slider and counter to 0 ] == */
-  useEffect(()=>{
-    /* ==[ Timer - Reset ] == */
-    if (programMode === ProgramMode.Ready) {
-      timerSec.current = 0;
-      timerMin.current = 0;
-      sliderSec.current = 0;
-    }
-    if (programMode === ProgramMode.Done){
-      playBackTimerSec.current = 0;
-      sliderSec.current = 0;
-    }
-  }, [programMode]);
-
-  useEffect(()=>{
-    if (playBackIsFinished && isPlaying) {
-      handleChangeIsPlaying(); //go from pause to play
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  },[playBackIsFinished, isPlaying]);
-
-  useEffect(()=>{
-    if (!isPlaying && playBackIsFinished){
-      playBackTimerSec.current = 0;
-      sliderSec.current = 0;
-    }
-  }, [isPlaying, playBackIsFinished]);
-
-  if(sliderSec.current === totalTimeSec && programMode === ProgramMode.Recording){
-    handleChangeOfProgramMode();
-  }
+  const sliderMaxValue = isRecording ? maxRecordingDuration: lengthOfRecording;
+  const sliderSec = isRecording ? lengthOfRecording : playBackTime;
 
   const railRef = useRef<HTMLDivElement>(null);
 
   const handleSelectChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     onRateSelectClick(Number(event.target.value));
   };
-
-  /* ==[ For Refresh -  Store Value Into Model ] == */
-  if (programMode === ProgramMode.Recording ){ //write into model to keep value upon refresh
-    tileContent.setFormattedTime(formattedTime);
-  }
-  /* ==[ For Refresh -  Reset sliderMaxValue] == */
-  if (tileContent.formattedTime !== "000:00" && programMode === ProgramMode.Done){
-    sliderMaxValue = stringToSeconds(tileContent.formattedTime) + 1;
-    timerSec.current = sliderMaxValue;
-  }
 
   return (
     <>
@@ -148,7 +54,7 @@ export const RateSelectorOrPlayBack = (props: IRateSelectorProps) => {
               min={0}
               max={sliderMaxValue}
               step={1}
-              value={sliderSec.current}
+              value={sliderSec}
               ref={railRef}
             />
           </div>
@@ -174,11 +80,11 @@ export const RateSelectorOrPlayBack = (props: IRateSelectorProps) => {
                 ))
               }
             </select> :
-            numNodes > 0 &&
             <div className="countdown-timer">
               {
-                programMode === ProgramMode.Recording ? `${formattedTime} / ${totalTimeFormatted}`
-                : `${playBackFormattedTime}/${tileContent.formattedTime}` //store formattedTime upon refresh =
+                programMode === ProgramMode.Recording
+                  ? `${tileContent.durationOfRecordingFormatted} / ${maxRecordingDurationFormatted}`
+                  : `${playBackFormattedTime} / ${tileContent.durationOfRecordingFormatted}`
               }
             </div>
           }
@@ -186,13 +92,4 @@ export const RateSelectorOrPlayBack = (props: IRateSelectorProps) => {
       </div>
     </>
   );
-};
-
-//convert "MMM:SS" -> number of seconds
-const stringToSeconds = (formattedTime: string) => {
-    const [minutes, seconds] = formattedTime.split(':');
-    const numMinutes = parseInt(minutes, 10);
-    const numSeconds = parseInt(seconds, 10);
-    const totalSeconds = (numMinutes * 60) + numSeconds;
-    return totalSeconds;
-};
+});


### PR DESCRIPTION
- remove redundant timers, and redundant state
- move end of playback and end of recording handling to the tick function
- group actions so there are single undo and history events for
  clear, start, and adding cases

The redundant timers and state were removed by passing in existing state like playBackIndex, and computing the duration of the recording from the values in the dataset. The computing of the duration is in dataflow-content.ts.

The stopping of the playback and recording when they hit their limits was moved into the update functions in `dataflow-tile.tsx`. This way no extra points will be recorded or played back. And this control is closer to the tick function. This also means the handlers don't have to be passed into RateSelectorOrPlayBack. 

The actions for clear and start now in dataflow-content.ts: 
- `resetRecording`
- `prepareRecording`

Because duration of the recording is a computed value, the `RateSelectorOrPlayBack` has to be an observer component now. This way the component is re-rendered as duration changes.

In the future it would be better to extract the `programMode`, `playBackIndex`, `tick`, and `update*` functions into a MobX object. Perhaps called something like `DataFlowEngine`. Then an instance of the engine can be passed to the components that need it. This will reduce the number of properties that need to be passed around and should reduce some unnecessary re-rendering that happens when these properties change.