### PR TITLE
185631814 dataflow decimals

### DIFF
--- a/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
@@ -95,6 +95,35 @@ context('Dataflow Tool Tile', function () {
         dataflowToolTile.getNode(nodeType).should("not.exist");
       });
     });
+    describe("Manage Decimals", () => {
+      it('can create a number node and change it to a decimal', () => {
+        // create a number node
+        dataflowToolTile.getCreateNodeButton("number").click();
+        dataflowToolTile.getNode("number").should("exist");
+        dataflowToolTile.getNodeTitle().should("contain", "Number");
+        dataflowToolTile.getNumberField().type("1.8309{enter}");
+      });
+      it('values should be rounded to three decimals for display', () => {
+        // create transform node and drag to the right
+        dataflowToolTile.getCreateNodeButton("transform").click();
+        dataflowToolTile.getNode("transform").should("exist");
+        dataflowToolTile.getNodeTitle().should("contain", "Transform");
+        dataflowToolTile.getNode("transform").click(50, 10)
+          .trigger("pointerdown", 50, 10 )
+          .trigger("pointermove", dragXDestination, 10, { force: true } )
+          .trigger("pointerup", dragXDestination, 10, { force: true } );
+          cy.wait(2000);
+        // connect the number node to the transform node
+        dataflowToolTile.getNodeOutput().eq(0).click();
+        dataflowToolTile.getNodeInput().eq(0).click();
+        // verify the transform node has the correct value
+        dataflowToolTile.getNode("transform").should("contain", "1.831");
+        dataflowToolTile.getDeleteNodeButton("number").click();
+        dataflowToolTile.getDeleteNodeButton("transform").click();
+        dataflowToolTile.getNode("number").should("not.exist");
+        dataflowToolTile.getNode("transform").should("not.exist");
+      });
+    });
     describe("Generator Node", () => {
       const nodeType = "generator";
       it("can create generator node", () => {

--- a/src/plugins/dataflow/model/utilities/node.ts
+++ b/src/plugins/dataflow/model/utilities/node.ts
@@ -441,10 +441,6 @@ export const NodeTimerInfo =
   method: (t: number, tOn: number, tOff: number) => t % (tOn + tOff) < tOn ? 1 : 0,
 };
 
-export const roundNodeValue = (n: number) => {
-  return Math.round(n * 1000) / 1000;
-};
-
 export const ChartPlotColors = ["#d51eff", "#17ddd7", "#d3d114", "#3974ff", "#ff3d3d",
                                "#49d381", "#b05ecb", "#ffd56d", "#ffa56d", "#f57676",
                                "#fa73b0", "#eb80dc", "#cd88e4", "#d49600", "#d45200",

--- a/src/plugins/dataflow/nodes/controls/value-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/value-control.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import classNames from "classnames";
 import Rete, { NodeEditor, Node } from "rete";
-import { roundNodeValue } from "../../model/utilities/node";
 import "./value-control.sass";
+import { getNumDisplayStr } from "../utilities/view-utilities";
 
 export class ValueControl extends Rete.Control {
   private emitter: NodeEditor;
@@ -17,18 +17,17 @@ export class ValueControl extends Rete.Control {
 
     this.component = (compProps: { value: number; sentence: string, class: string }) => {
       const sentLen = compProps.sentence.length;
-      const dynamicClasses = classNames({
+      const fontSizeClasses = {
         "smallest": sentLen >= 15,
         "small": sentLen > 13 && sentLen < 15,
-        "medium": sentLen > 11 && sentLen <= 13
-      });
-
+        "medium": sentLen > 11 && sentLen <= 13,
+      };
+      const valueClasses = classNames(
+        "value-container", fontSizeClasses, compProps.class.toLowerCase().replace(/ /g, "-"),
+      );
       return (
-        <div className={`value-container ${compProps.class.toLowerCase().replace(/ /g, "-")} ${dynamicClasses}`}
-             title={"Node Value"}>
-          {compProps.sentence
-            ? compProps.sentence
-            : isFinite(compProps.value) ? roundNodeValue(compProps.value) : ""}
+        <div className={valueClasses} title={"Node Value"}>
+          {compProps.sentence ? compProps.sentence : getNumDisplayStr(compProps.value)}
         </div>
       );
     };

--- a/src/plugins/dataflow/nodes/factories/control-rete-node-factory.tsx
+++ b/src/plugins/dataflow/nodes/factories/control-rete-node-factory.tsx
@@ -1,10 +1,11 @@
 import Rete, { Node, Socket } from "rete";
 import { NodeData } from "rete/types/core/data";
-import { DataflowReteNodeFactory, kEmptyValueString } from "./dataflow-rete-node-factory";
+import { DataflowReteNodeFactory } from "./dataflow-rete-node-factory";
 import { ValueControl } from "../controls/value-control";
 import { DropdownListControl } from "../controls/dropdown-list-control";
-import { HoldFunctionOptions, roundNodeValue } from "../../model/utilities/node";
+import { HoldFunctionOptions } from "../../model/utilities/node";
 import { PlotButtonControl } from "../controls/plot-button-control";
+import { getNumDisplayStr } from "../utilities/view-utilities";
 
 export class ControlReteNodeFactory extends DataflowReteNodeFactory {
   constructor(numSocket: Socket) {
@@ -94,8 +95,8 @@ export class ControlReteNodeFactory extends DataflowReteNodeFactory {
     }
 
     // prepare string to display on node
-    const resultString = isNaN(result) ? kEmptyValueString : `${roundNodeValue(result)}`;
-    const cResultString = isNaN(cResult) ? kEmptyValueString : `${roundNodeValue(cResult)}`;
+    const resultString = getNumDisplayStr(result);
+    const cResultString = getNumDisplayStr(cResult);
     const onString = `on → ${cResultString}`;
     const offString = `off → ${resultString}`;
     const resultSentence = node.data.gateActive ? onString : offString;

--- a/src/plugins/dataflow/nodes/factories/logic-rete-node-factory.tsx
+++ b/src/plugins/dataflow/nodes/factories/logic-rete-node-factory.tsx
@@ -1,10 +1,11 @@
 import Rete, { Node, Socket } from "rete";
 import { NodeData } from "rete/types/core/data";
-import { DataflowReteNodeFactory, kEmptyValueString } from "./dataflow-rete-node-factory";
+import { DataflowReteNodeFactory } from "./dataflow-rete-node-factory";
 import { ValueControl } from "../controls/value-control";
 import { DropdownListControl } from "../controls/dropdown-list-control";
 import { NodeOperationTypes } from "../../model/utilities/node";
 import { PlotButtonControl } from "../controls/plot-button-control";
+import { getNumDisplayStr } from "../utilities/view-utilities";
 
 export class LogicReteNodeFactory extends DataflowReteNodeFactory {
   constructor(numSocket: Socket) {
@@ -51,9 +52,9 @@ export class LogicReteNodeFactory extends DataflowReteNodeFactory {
         result = nodeOperationTypes.method(n1, n2);
       }
 
-      const n1Str = isNaN(n1) ? kEmptyValueString : "" + n1;
-      const n2Str = isNaN(n2) ? kEmptyValueString : "" + n2;
-      const resultStr = isNaN(result) ? kEmptyValueString : result;
+      const n1Str = getNumDisplayStr(n1);
+      const n2Str = getNumDisplayStr(n2);
+      const resultStr = getNumDisplayStr(result);
       resultSentence = nodeOperationTypes.numberSentence(n1Str, n2Str) + resultStr;
     }
 

--- a/src/plugins/dataflow/nodes/factories/math-rete-node-factory.tsx
+++ b/src/plugins/dataflow/nodes/factories/math-rete-node-factory.tsx
@@ -1,10 +1,11 @@
 import Rete, { Node, Socket } from "rete";
 import { NodeData } from "rete/types/core/data";
-import { DataflowReteNodeFactory, kEmptyValueString } from "./dataflow-rete-node-factory";
+import { DataflowReteNodeFactory } from "./dataflow-rete-node-factory";
 import { ValueControl } from "../controls/value-control";
 import { DropdownListControl } from "../controls/dropdown-list-control";
-import { NodeOperationTypes, roundNodeValue } from "../../model/utilities/node";
+import { NodeOperationTypes } from "../../model/utilities/node";
 import { PlotButtonControl } from "../controls/plot-button-control";
+import { getNumDisplayStr } from "../utilities/view-utilities";
 
 export class MathReteNodeFactory extends DataflowReteNodeFactory {
   constructor(numSocket: Socket) {
@@ -51,9 +52,9 @@ export class MathReteNodeFactory extends DataflowReteNodeFactory {
         result = nodeOperationTypes.method(n1, n2) || 0;
       }
 
-      const n1Str = isNaN(n1) ? kEmptyValueString : "" + n1;
-      const n2Str = isNaN(n2) ? kEmptyValueString : "" + n2;
-      const resultStr = isNaN(result) ? kEmptyValueString : roundNodeValue(result);
+      const n1Str = getNumDisplayStr(n1);
+      const n2Str = getNumDisplayStr(n2);
+      const resultStr = getNumDisplayStr(result);
       resultSentence = nodeOperationTypes.numberSentence(n1Str, n2Str) + resultStr;
     }
 

--- a/src/plugins/dataflow/nodes/factories/transform-rete-node-factory.tsx
+++ b/src/plugins/dataflow/nodes/factories/transform-rete-node-factory.tsx
@@ -1,10 +1,11 @@
 import Rete, { Node, Socket } from "rete";
 import { NodeData } from "rete/types/core/data";
-import { DataflowReteNodeFactory, kEmptyValueString } from "./dataflow-rete-node-factory";
+import { DataflowReteNodeFactory } from "./dataflow-rete-node-factory";
 import { ValueControl } from "../controls/value-control";
 import { DropdownListControl } from "../controls/dropdown-list-control";
 import { NodeOperationTypes } from "../../model/utilities/node";
 import { PlotButtonControl } from "../controls/plot-button-control";
+import { getNumDisplayStr } from "../utilities/view-utilities";
 
 export class TransformReteNodeFactory extends DataflowReteNodeFactory {
   constructor(numSocket: Socket) {
@@ -47,8 +48,8 @@ export class TransformReteNodeFactory extends DataflowReteNodeFactory {
         result = nodeOperationTypes.method(n1, 0);
       }
 
-      const n1Str = isNaN(n1)  ? kEmptyValueString : "" + n1;
-      const resultStr = isNaN(result) ? kEmptyValueString : result;
+      const n1Str = getNumDisplayStr(n1);
+      const resultStr = getNumDisplayStr(result);
       resultSentence = nodeOperationTypes.numberSentence(n1Str, "") + resultStr;
    }
 

--- a/src/plugins/dataflow/nodes/utilities/view-utilities.ts
+++ b/src/plugins/dataflow/nodes/utilities/view-utilities.ts
@@ -66,10 +66,6 @@ export function hasFlowIn(node: Node){
   return inputs.some((input) => input.connections.length > 0);
 }
 
-export function getCleanDecimalString(n: number){
-  return n.toFixed(3).replace(/\.?0+$/, "");
-}
-
 export function getNumDisplayStr(n: number){
-  return isNaN(n) ? kEmptyValueString : getCleanDecimalString(n);
+  return isNaN(n) ? kEmptyValueString : n.toFixed(3).replace(/\.?0+$/, "");
 }

--- a/src/plugins/dataflow/nodes/utilities/view-utilities.ts
+++ b/src/plugins/dataflow/nodes/utilities/view-utilities.ts
@@ -1,6 +1,6 @@
 import { NodeEditor, Node } from "rete";
-
 import { Rect, scaleRect, unionRect } from "../../utilities/rect";
+import { kEmptyValueString } from "../factories/dataflow-rete-node-factory";
 
 function getBoundingRectOfNode(n: Node, editor: NodeEditor): Rect | undefined {
   const { k } = editor.view.area.transform;
@@ -64,4 +64,12 @@ export function hasFlowIn(node: Node){
   if (inputs.length === 0) return false;
   if (node.name === "Control") return inputs[0].connections.length > 0;
   return inputs.some((input) => input.connections.length > 0);
+}
+
+export function getCleanDecimalString(n: number){
+  return n.toFixed(3).replace(/\.?0+$/, "");
+}
+
+export function getNumDisplayStr(n: number){
+  return isNaN(n) ? kEmptyValueString : getCleanDecimalString(n);
 }


### PR DESCRIPTION
This improves the display of decimal numbers in the Dataflow nodes that take in numbers and return new numbers (Math, Logic Transform, Hold).  [PT#185631814](https://www.pivotaltracker.com/story/show/185631814)

- a new number-to-string function is defined in a utility file, and used in the factory of each node
- small cypress test