### PR TITLE
185477557 dataflow link button display

### DIFF
--- a/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
@@ -26,6 +26,13 @@ context('Dataflow Tool Tile', function () {
       dataflowToolTile.getDataflowTileTitle().type(newName + '{enter}');
       dataflowToolTile.getTileTitle().should("contain", newName);
     });
+    it("makes link button active when table is present", () => {
+      dataflowToolTile.getLinkTileButton().should("exist");
+      dataflowToolTile.getLinkTileButton().should("have.class", "disabled");
+      clueCanvas.addTile("table");
+      dataflowToolTile.getLinkTileButton().should("not.have.class", "disabled");
+      clueCanvas.deleteTile("table");
+    });
     describe("Number Node", () => {
       const nodeType = "number";
       it("can create number node", () => {

--- a/cypress/support/elements/clue/DataflowToolTile.js
+++ b/cypress/support/elements/clue/DataflowToolTile.js
@@ -183,6 +183,9 @@ class DataflowToolTile {
   getRecordingClearButton() {
     return cy.get(".primary-workspace .record-data-btn").contains("Clear").parent();
   }
+  getLinkTileButton() {
+    return cy.get(".primary-workspace .link-table-button");
+  }
   verifyClearButtonDoesNotExist() {
     cy.get(".primary-workspace .record-data-btn").should("not.have.text", "Clear");
   }

--- a/src/plugins/dataflow/components/dataflow-tile.tsx
+++ b/src/plugins/dataflow/components/dataflow-tile.tsx
@@ -156,8 +156,7 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IDatafl
 
   private renderTableLinkButton() {
     const { model, documentId, onRequestTilesOfType, onRequestLinkableTiles } = this.props;
-    const isLinkButtonEnabled = (this.determineProgramMode() === ProgramMode.Done);
-
+    const isLinkButtonEnabled = onRequestLinkableTiles && onRequestLinkableTiles().consumers.length > 0;
     const actionHandlers = {
                              handleRequestTableLink: this.handleRequestTableLink,
                              handleRequestTableUnlink: this.handleRequestTableUnlink


### PR DESCRIPTION
[PT#185477557](https://www.pivotaltracker.com/story/show/185477557) describes a number of features, most which are already implemented.  This PR addresses the only one not already implemented: 

-  Dataflow's existing tile link icon should not need to wait for recorded data to exist in order to be enabled. 
-  It should be enabled if there is an XY Plot or Table tile present in the document/

