### PR TITLE
185647872 xy connect dots

### DIFF
--- a/src/plugins/graph/components/scatterdots.tsx
+++ b/src/plugins/graph/components/scatterdots.tsx
@@ -17,6 +17,7 @@ import {
   startAnimation
 } from "../utilities/graph-utils";
 import {useGraphModelContext} from "../models/graph-model";
+import { useAppConfig } from "../../../hooks/use-stores";
 
 export const ScatterDots = function ScatterDots(props: PlotProps) {
   const {dotsRef, enableAnimation} = props,
@@ -37,6 +38,8 @@ export const ScatterDots = function ScatterDots(props: PlotProps) {
     target = useRef<any>(),
     selectedDataObjects = useRef<Record<string, { x: number, y: number }>>({}),
     plotNumRef = useRef(0);
+
+  const applicationConfig = useAppConfig();
 
   secondaryAttrIDsRef.current = dataConfiguration?.yAttributeIDs || [];
   pointRadiusRef.current = graphModel.getPointRadius();
@@ -187,10 +190,11 @@ export const ScatterDots = function ScatterDots(props: PlotProps) {
       dataset, dotsRef, pointRadius: pointRadiusRef.current,
       selectedPointRadius: selectedPointRadiusRef.current,
       selectedOnly, getScreenX, getScreenY, getLegendColor,
-      getPointColorAtIndex: graphModel.pointColorAtIndex, enableAnimation, pointColor, pointStrokeColor
+      getPointColorAtIndex: graphModel.pointColorAtIndex,
+      enableAnimation, pointColor, pointStrokeColor, applicationConfig
     });
   }, [dataConfiguration, dataset, dotsRef, layout, legendAttrID,
-    enableAnimation, graphModel, yScaleRef]);
+    enableAnimation, graphModel, yScaleRef, applicationConfig]);
 
   // const refreshPointPositionsSVG = useCallback((selectedOnly: boolean) => {
   //   const xAttrID = dataConfiguration?.attributeID('x') ?? '',

--- a/src/plugins/graph/utilities/graph-utils.ts
+++ b/src/plugins/graph/utilities/graph-utils.ts
@@ -460,7 +460,7 @@ export function setPointCoordinates(props: ISetPointCoordinates) {
             const linePoints = xSeries.map((x, i) => [x, ySeries[i]]) as Iterable<[number, number]>;
             // DRAFT implementation - need to find appropriate config to query/control
             const isClue = appConfig.appName === "CLUE";
-            isClue && drawDotLine(dotsRef.current, linePoints, pointColor);
+            isClue && drawPath(dotsRef.current, linePoints, pointColor);
       }
     };
 
@@ -476,7 +476,7 @@ export function setPointCoordinates(props: ISetPointCoordinates) {
     setPoints();
 }
 
-export function drawDotLine(el: DotsElt, points: Iterable<[number, number]>, color: string) {
+export function drawPath(el: DotsElt, points: Iterable<[number, number]>, color: string) {
   const curve = line().curve(curveLinear);
   const dotArea = select(el);
   const anyFoundPath = dotArea.selectAll("path");
@@ -487,6 +487,7 @@ export function drawDotLine(el: DotsElt, points: Iterable<[number, number]>, col
     .attr('stroke-width', 2)
     .attr('d', curve(points))
     .attr('fill', 'none');
+  // bring path group to the top/front within the svg
   const parentSvg = newPath.node()?.parentNode;
   parentSvg?.insertBefore(newPath.node() as Node, parentSvg.firstChild);
 }


### PR DESCRIPTION
This is an initial implementation of [PT#185647872](https://www.pivotaltracker.com/story/show/185647872):  **[SeeIt]** Connect Points in XY Plot by default when axes are numeric 

- collects points and draws a line between each point in the series
- moves the path to the uppermost dom spot within the svg
- manually throws away old path and redraws whenever graph re-renders

This is in draft with the following to-dos:
- [ ] get the correct architecture for determining if we are in clue (right now we check appConfig.appName, but that doesn't look like a common pattern)
- [ ] get the correct state for determining if axis is numeric - I am guessing in this case I would add it as a prop to `setPointCoordinates`, but want to be sure. 
