### PR TITLE
fix-ai-tag-crashing

### DIFF
--- a/functions/src/post-document-comment.ts
+++ b/functions/src/post-document-comment.ts
@@ -7,7 +7,7 @@ import { validateUserContext } from "./user-context";
 import { createCommentableDocumentIfNecessary } from "./validate-commentable-document";
 
 // update this when deploying updates to this function
-const version = "1.1.4";
+const version = "1.1.5";
 
 export async function postDocumentComment(
                         params?: IPostDocumentCommentUnionParams,

--- a/src/components/chat/chat-thread.tsx
+++ b/src/components/chat/chat-thread.tsx
@@ -18,7 +18,7 @@ interface IProps {
   user?: UserModelType;
   activeNavTab?: string;
   chatThreads?: ChatCommentThread[];
-  onPostComment?: (comment: string) => void;
+  onPostComment?: (comment: string, tags: string[]) => void;
   onDeleteComment?: (commentId: string, commentContent: string) => void;
   focusDocument?: string;
   focusTileId?: string;

--- a/src/components/chat/comment-card.tsx
+++ b/src/components/chat/comment-card.tsx
@@ -61,16 +61,10 @@ export const CommentCard: React.FC<IProps> = ({ activeNavTab, user, postedCommen
   const { appConfig } = useStores();
   const { showCommentTag, commentTags, tagPrompt } = appConfig;
 
-  console.log("postedComments:", postedComments);
-  console.log("typeof", typeof (postedComments));
-  console.log("isArray", Array.isArray(postedComments));
-
-
   return (
     <div className="comment-card selected" data-testid="comment-card">
       <div className="comment-card-content selected" data-testid="comment-card-content">
         {postedComments?.map((comment, idx) => {
-            console.log("mapping");
             const userInitialBackgroundColor = ["#f79999", "#ffc18a", "#99d099", "#ff9", "#b2b2ff", "#efa6ef"];
             const commenterInitial = comment.name.charAt(0);
             const userInitialBackgroundColorIndex = parseInt(comment.uid, 10) % 6;
@@ -87,6 +81,7 @@ export const CommentCard: React.FC<IProps> = ({ activeNavTab, user, postedCommen
             const isTagPrompt = (comment.tags && comment.tags[0] === "") || (comment.tags === undefined);
 
             return (
+
               <div key={idx} className="comment-thread" data-testid="comment-thread">
                 <div className="comment-text-header">
                   <div className="user-icon" style={backgroundStyle}>

--- a/src/components/chat/comment-card.tsx
+++ b/src/components/chat/comment-card.tsx
@@ -96,11 +96,10 @@ export const CommentCard: React.FC<IProps> = ({ activeNavTab, user, postedCommen
                   }
                 </div>
                 {
-                  appConfig.showCommentTag &&  !isTagPrompt &&
+                  showCommentTag &&  !isTagPrompt &&
                   <div className="comment-dropdown-tag">
                     {
-                      comment.tags &&
-                      comment.tags.map((tag) => {
+                      comment.tags?.map((tag) => {
                         return commentTags && (commentTags[tag]);
                       }).join(", ")
                     }

--- a/src/components/chat/comment-card.tsx
+++ b/src/components/chat/comment-card.tsx
@@ -93,7 +93,7 @@ export const CommentCard: React.FC<IProps> = ({ activeNavTab, user, postedCommen
                 {
                   appConfig.showCommentTag && comment.tags &&
                   <div className="comment-dropdown-tag">
-                    { comment.tags.join(", ") }
+                    { Object.values(comment.tags).join() || comment.tags[0] }
                   </div>
                 }
                 <div key={idx} className="comment-text" data-testid="comment">

--- a/src/components/chat/comment-card.tsx
+++ b/src/components/chat/comment-card.tsx
@@ -78,7 +78,7 @@ export const CommentCard: React.FC<IProps> = ({ activeNavTab, user, postedCommen
 
             //if tagPrompt was posted to Firestore - for ex: SAS unit (where tagPrompt = "Select Student Strategy")
             //our comment.tags should be [""]
-            const isTagPrompt = (comment.tags && comment.tags[0] === "");
+            const isTagPrompt = (comment.tags && comment.tags[0] === "") || (comment.tags === undefined);
 
             return (
               <div key={idx} className="comment-thread" data-testid="comment-thread">
@@ -96,7 +96,7 @@ export const CommentCard: React.FC<IProps> = ({ activeNavTab, user, postedCommen
                   }
                 </div>
                 {
-                  showCommentTag &&  !isTagPrompt &&
+                  showCommentTag && !isTagPrompt &&
                   <div className="comment-dropdown-tag">
                     {
                       comment.tags?.map((tag) => {

--- a/src/components/chat/comment-card.tsx
+++ b/src/components/chat/comment-card.tsx
@@ -16,7 +16,7 @@ interface IProps {
   user?: UserModelType;
   activeNavTab?: string;
   postedComments?: WithId<CommentDocument>[];
-  onPostComment?: (comment: string, tag: string) => void;
+  onPostComment?: (comment: string, tags: string[]) => void;
   onDeleteComment?: (commentId: string, commentContent: string) => void;
   focusDocument?: string;
   focusTileId?: string;
@@ -59,6 +59,7 @@ export const CommentCard: React.FC<IProps> = ({ activeNavTab, user, postedCommen
 
   //appConfig holds showCommentTag, commentTags, tagPrompt fetched from "clue-curriculum" repository
   const { appConfig } = useStores();
+  const { showCommentTag, commentTags, tagPrompt } = appConfig;
 
   return (
     <div className="comment-card selected" data-testid="comment-card">
@@ -74,6 +75,10 @@ export const CommentCard: React.FC<IProps> = ({ activeNavTab, user, postedCommen
             const backgroundStyle = shouldShowUserIcon
                                       ? {backgroundColor: "white"}
                                       : {backgroundColor: userInitialBackgroundColor[userInitialBackgroundColorIndex]};
+
+            //if tagPrompt was posted to Firestore - for ex: SAS unit (where tagPrompt = "Select Student Strategy")
+            //our comment.tags should be [""]
+            const isTagPrompt = (comment.tags && comment.tags[0] === "");
 
             return (
               <div key={idx} className="comment-thread" data-testid="comment-thread">
@@ -91,9 +96,14 @@ export const CommentCard: React.FC<IProps> = ({ activeNavTab, user, postedCommen
                   }
                 </div>
                 {
-                  appConfig.showCommentTag && comment.tags &&
+                  appConfig.showCommentTag &&  !isTagPrompt &&
                   <div className="comment-dropdown-tag">
-                    { Object.values(comment.tags).join() || comment.tags[0] }
+                    {
+                      comment.tags &&
+                      comment.tags.map((tag) => {
+                        return commentTags && (commentTags[tag]);
+                      }).join(", ")
+                    }
                   </div>
                 }
                 <div key={idx} className="comment-text" data-testid="comment">
@@ -107,9 +117,9 @@ export const CommentCard: React.FC<IProps> = ({ activeNavTab, user, postedCommen
           activeNavTab={activeNavTab}
           onPostComment={onPostComment}
           numPostedComments={postedComments?.length || 0}
-          showCommentTag={appConfig.showCommentTag}
-          commentTags={appConfig.commentTags}
-          tagPrompt={appConfig.tagPrompt}
+          showCommentTag={showCommentTag || false}
+          commentTags={commentTags}
+          tagPrompt={tagPrompt}
         />
       </div>
     </div>

--- a/src/components/chat/comment-card.tsx
+++ b/src/components/chat/comment-card.tsx
@@ -61,10 +61,16 @@ export const CommentCard: React.FC<IProps> = ({ activeNavTab, user, postedCommen
   const { appConfig } = useStores();
   const { showCommentTag, commentTags, tagPrompt } = appConfig;
 
+  console.log("postedComments:", postedComments);
+  console.log("typeof", typeof (postedComments));
+  console.log("isArray", Array.isArray(postedComments));
+
+
   return (
     <div className="comment-card selected" data-testid="comment-card">
       <div className="comment-card-content selected" data-testid="comment-card-content">
         {postedComments?.map((comment, idx) => {
+            console.log("mapping");
             const userInitialBackgroundColor = ["#f79999", "#ffc18a", "#99d099", "#ff9", "#b2b2ff", "#efa6ef"];
             const commenterInitial = comment.name.charAt(0);
             const userInitialBackgroundColorIndex = parseInt(comment.uid, 10) % 6;

--- a/src/components/chat/comment-textbox.tsx
+++ b/src/components/chat/comment-textbox.tsx
@@ -147,7 +147,7 @@ export const CommentTextBox: React.FC<IProps> = (props) => {
             Object.keys(commentTags).map(key => {
               const value = commentTags[key];
               return (
-                <option key={key} value={key}> {value} </option>
+                <option key={key} value={value}> {value} </option>
               );
             })
           }

--- a/src/components/chat/comment-textbox.tsx
+++ b/src/components/chat/comment-textbox.tsx
@@ -71,7 +71,8 @@ export const CommentTextBox: React.FC<IProps> = (props) => {
   const handlePostComment = () => {
     // do not send post if text area is empty, only has spaces or new lines
     const [trimmedText, isEmpty] = trimContent(commentText);
-    if (!isEmpty || showCommentTag) {
+    if (!isEmpty || (showCommentTag && allTags[0] !== "" )){
+      //do not post to Firestore if select tag is tagPrompt
       onPostComment?.(trimmedText, allTags);
       setCommentTextAreaHeight(minTextAreaHeight);
       setCommentAdded(false);

--- a/src/components/chat/comment-textbox.tsx
+++ b/src/components/chat/comment-textbox.tsx
@@ -76,6 +76,7 @@ export const CommentTextBox: React.FC<IProps> = (props) => {
       setCommentTextAreaHeight(minTextAreaHeight);
       setCommentAdded(false);
       setCommentText("");
+      setAllTags((oldArray) => [""]); //select will go back to top choice (tagPrompt)
     }
   };
 
@@ -138,6 +139,7 @@ export const CommentTextBox: React.FC<IProps> = (props) => {
           onChange={(e) => {
             handleSelectDropDown(e.target.value);
           }}
+          value={allTags[0]}
         >
           {
             tagPrompt &&

--- a/src/components/chat/comment-textbox.tsx
+++ b/src/components/chat/comment-textbox.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import React, { useEffect, useRef, useState } from "react";
+import React, { Dispatch, SetStateAction, useEffect, useRef, useState } from "react";
 import { useUIStore } from "../../hooks/use-stores";
 import SendIcon from "../../assets/send-icon.svg";
 import "../themes.scss";
@@ -7,12 +7,11 @@ import "../themes.scss";
 interface IProps {
   activeNavTab?: string;
   numPostedComments: number;
-  onPostComment?: (comment: string, tag: string) => void;
+  onPostComment?: (comment: string, tags: string[]) => void;
   showCommentTag?: boolean;
   commentTags?: Record<string, string>;
   tagPrompt?: string;
 }
-
 
 export const CommentTextBox: React.FC<IProps> = (props) => {
   const { activeNavTab, numPostedComments, onPostComment, showCommentTag, commentTags, tagPrompt } = props;
@@ -22,7 +21,8 @@ export const CommentTextBox: React.FC<IProps> = (props) => {
   const selectElt = useRef<HTMLSelectElement>(null);
   const [commentAdded, setCommentAdded] = useState(false);
   const [commentText, setCommentText] = useState("");
-  const [tagText, setTagText] = useState("");
+   //all the AI tags pertaining to one comment - length is 1 for now
+  const [allTags, setAllTags] = useState([""]);
   const textareaStyle = {height: commentTextAreaHeight};
 
   const commentEmptyNoTags =  (!commentAdded && !showCommentTag);
@@ -72,7 +72,7 @@ export const CommentTextBox: React.FC<IProps> = (props) => {
     // do not send post if text area is empty, only has spaces or new lines
     const [trimmedText, isEmpty] = trimContent(commentText);
     if (!isEmpty || showCommentTag) {
-      onPostComment?.(trimmedText, tagText);
+      onPostComment?.(trimmedText, allTags);
       setCommentTextAreaHeight(minTextAreaHeight);
       setCommentAdded(false);
       setCommentText("");
@@ -111,10 +111,10 @@ export const CommentTextBox: React.FC<IProps> = (props) => {
 
   const handleSelectDropDown = (val: string) => {
     if (tagPrompt && val !== tagPrompt){ //do not save comments with default tag
-      setTagText(val);
+      setAllTags((oldArray) => [val]);
     }
     else {
-      setTagText("");
+      setAllTags((oldArray) => [""]);
     }
   };
 
@@ -147,7 +147,7 @@ export const CommentTextBox: React.FC<IProps> = (props) => {
             Object.keys(commentTags).map(key => {
               const value = commentTags[key];
               return (
-                <option key={key} value={value}> {value} </option>
+                <option key={key} value={key}> {value} </option>
               );
             })
           }

--- a/src/components/chat/comment-textbox.tsx
+++ b/src/components/chat/comment-textbox.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import React, { Dispatch, SetStateAction, useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useUIStore } from "../../hooks/use-stores";
 import SendIcon from "../../assets/send-icon.svg";
 import "../themes.scss";

--- a/src/plugins/dataflow/nodes/dataflow-node.tsx
+++ b/src/plugins/dataflow/nodes/dataflow-node.tsx
@@ -25,6 +25,7 @@ export class DataflowNode extends Node {
     const showPlot = plotButton?.props.showgraph ?? node.data.plot ?? false;
     const nodeType = NodeTypes.find( (n: NodeType) => n.name === node.name);
     const displayName = nodeType ? nodeType.displayName : node.name;
+    console.log("one change for pr");
 
     const dynamicClasses = classNames({
       "gate-active": node.data.gateActive,

--- a/src/plugins/dataflow/nodes/dataflow-node.tsx
+++ b/src/plugins/dataflow/nodes/dataflow-node.tsx
@@ -25,7 +25,6 @@ export class DataflowNode extends Node {
     const showPlot = plotButton?.props.showgraph ?? node.data.plot ?? false;
     const nodeType = NodeTypes.find( (n: NodeType) => n.name === node.name);
     const displayName = nodeType ? nodeType.displayName : node.name;
-    console.log("one change for pr");
 
     const dynamicClasses = classNames({
       "gate-active": node.data.gateActive,


### PR DESCRIPTION
Deployed link - 
https://collaborative-learning.concord.org/branch/fix-aitag-crashing/?appMode=demo&demoName=CLUE&fakeClass=1&fakeUser=teacher:2&problem=2.2&unit=https://collaborative-learning.concord.org/branch/master/curriculum/stretching-and-shrinking/stretching-and-shrinking.json
 ______ ______ ______ ______ ______ ______ ______ ______ ______ ______ ______ ______ ______ ______ ______ ______

- Fixed issue where opening comments panel would crash CLUE 
(see below)
<img width="629" alt="image" src="https://github.com/concord-consortium/collaborative-learning/assets/521934/0ceca972-bc72-4703-a1e6-b8c83d72a768">
  This was because in Firestore, `tags` was not being written as an array but rather a string. 
  
 - Added capability to have multiple tags for a comment in the database schema (although our UI currently doesn't support it) 
 
 - Fixed bug reported where when you select a non `tagPrompt` option (in our example "Select Student Strategy") , hit post, then the textbox dropdown should return back to tagPrompt ("Select Student Strategy") 
 
 
 
 ______ ______ ______ ______ ______ ______ ______ ______ ______ ______ ______ ______ ______ ______ ______ ______

~~*Note that we still can't post empty comments that have a non tagPrompt tag (i.e. lets say we select Part-to-Part and have an empty comment field and hit post), this is (I'm assuming) 
because the new version of` post-document-comment.ts ` has not been deployed.~~ 

FIXED - we should now be able to post empty comments
 Edit : At 2:38PM (PST) - I talked with Aden @433eros and he has deployed the previous PR's  `post-document-comment.ts ` . And I tested it and it works to post an empty comment field given a non prompt tag (such as Part-to-Part + empty field). 
I've just updated the version # to reflect that. 

 ______ ______ ______ ______ ______ ______ ______ ______ ______ ______ ______ ______ ______ ______ ______ ______

FIXED: ~~Functional bug reported~~ 
<img width="638" alt="image" src="https://github.com/concord-consortium/collaborative-learning/assets/521934/1b7d044a-4a19-4a14-9038-343355ddb05a">
