### PR TITLE
only set the subTab if one isn't already set

### DIFF
--- a/cypress/e2e/clue/branch/student_tests/nav_panel_test_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/nav_panel_test_spec.js
@@ -36,6 +36,15 @@ context('Nav Panel', function () {
             expect($tab.text()).to.contain(problemSubTabTitles[index]);
           });
         });
+        it('saves current subtab when the resources panel is collapsed and expand', () => {
+          cy.openTopTab("problems");
+          const section = "Initial Challenge";
+          cy.openProblemSection(section);
+          cy.get('.prob-tab').contains(section).should('have.class', 'selected');
+          cy.collapseResourceTabs();
+          cy.openResourceTabs();
+          cy.get('.prob-tab').contains(section).should('have.class', 'selected');
+        });
       });
     });
     describe('My Work tab tests', function () {
@@ -105,6 +114,11 @@ context('Nav Panel', function () {
         it('verify starred document appears in the Starred section', function () {
           cy.openSection('my-work', 'starred');
           resourcesPanel.getCanvasItemTitle('my-work','starred').contains(copyDocumentTitle).should('exist');
+        });
+        it('remains open after the resources panel is collapsed and expand', () => {
+          cy.collapseResourceTabs();
+          cy.openResourceTabs();
+          cy.get('.doc-tab.my-work.starred').should('have.class', 'selected');
         });
       });
       describe('Learning Log Section', function () {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -215,7 +215,7 @@ Cypress.Commands.add("getDocumentToolTile", (tileIndex = 0) => {
   cy.get('.documents-panel .editable-document-content .tile-row tool-tile').eq(tileIndex).click();
 });
 Cypress.Commands.add('collapseResourceTabs', () => {
-  cy.get('.divider-container').trigger('mouseover').then(() => {
+  cy.get('.drag-thumbnail').trigger('mouseover').then(() => {
     cy.get('.divider-container .expand-handle.left.shown').should("exist");
     cy.get('.divider-container .expand-handle.left.shown').click();
     cy.get('.primary-workspace .toolbar', {timeout: 120000});

--- a/src/components/navigation/problem-tab-content.tsx
+++ b/src/components/navigation/problem-tab-content.tsx
@@ -40,7 +40,8 @@ export const ProblemTabContent: React.FC<IProps>
   const tabId = context || ENavTab.kProblems;
 
   useEffect(() => {
-    if (hasSubTabs) {
+    // Set the default subTab if a subtab isn't already set
+    if (hasSubTabs && !ui.tabs.get(tabId)?.openSubTab) {
       ui.setOpenSubTab(tabId, sections[0].type);
     }
   }, [hasSubTabs, sections, tabId, ui]);

--- a/src/components/navigation/section-document-or-browser.tsx
+++ b/src/components/navigation/section-document-or-browser.tsx
@@ -38,9 +38,10 @@ export const SectionDocumentOrBrowser: React.FC<IProps> = observer(function Sect
   const selectedSubTab = subTabs[subTabIndex];
 
   useEffect(() => {
-    // Set the initial open tab. If the tabSpec changes somehow then the open
-    // sub tab will get reset
-    ui.setOpenSubTab(tabSpec.tab, subTabs[0].label);
+    // Set the default open subTab if a subTab isn't already set.
+    if (!ui.tabs.get(tabSpec.tab)?.openSubTab) {
+      ui.setOpenSubTab(tabSpec.tab, subTabs[0].label);
+    }
   }, [subTabs, tabSpec.tab, ui]);
 
   // This is called even if the tab is already open


### PR DESCRIPTION
The left side components get recreated each time the resources panel is collapsed and expanded. 
So without this code change, the open subTab was getting reset each time the resource panel was collapsed and expanded.
https://www.pivotaltracker.com/story/show/185800396

Also one of the Cypress functions for collapsing the resource panel was updated. It was flakey before. Below are some notes from a slack conversation about it https://concord-consortium.slack.com/archives/CCHKYUW3S/p1691763253308029

Fix for collapseResourceTabs() is to use cy.get('.drag-thumbnail').trigger('mouseover'). The drag-thumbnail is the 3 vertical dots. It is ontop of everything and it's mouse handler does not have a delay.

There were a few issues with using `.divider-container`:
- one is that the center point is on top of the drag-thumbnail so I think this was confusing cypress
- two is that the mouse handlers are actually on .divider which is a child of .divider-container so I’d bet in some cases the events sent by Cypress were not being propagated to the child.

There are other commands which use cy.get('.divider').click({force:true});. That seems to work too. The force is necessary because actually drag-thumbnail is sitting on top of the center point so without the force Cypress will complain.  The downside of the ‘click’ is that it actually toggles the divider. So if it is already open then clicking it will close it.

I’m not totally sure but I’d guess that cy.get('.drag-thumbnail').trigger('mouseover') is the best of these options. It will fail if the divider is open, and it seems to be just as fast as the click approach.  