### PR TITLE
185520282-clean-up-draw-action-names

### DIFF
--- a/src/plugins/drawing/components/drawing-layer.tsx
+++ b/src/plugins/drawing/components/drawing-layer.tsx
@@ -243,7 +243,7 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
       window.removeEventListener("mouseup", handleMouseUp);
       if (moved) {
         objectsToInteract.map((object, index) => {
-          object.adoptDragPosition();
+          object.repositionObject();
         });
       } else {
         this.handleObjectClick(e2, obj);

--- a/src/plugins/drawing/components/drawing-layer.tsx
+++ b/src/plugins/drawing/components/drawing-layer.tsx
@@ -383,7 +383,7 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
       window.removeEventListener("mousemove", handleResizeMove);
       window.removeEventListener("mouseup", handleResizecomplete);
       handle.classList.remove('active');
-      object.adoptDragBounds();
+      object.resizeObject();
     };
 
     window.addEventListener("mousemove", handleResizeMove);

--- a/src/plugins/drawing/model/drawing-content.test.ts
+++ b/src/plugins/drawing/model/drawing-content.test.ts
@@ -286,7 +286,7 @@ describe("DrawingContentModel", () => {
 
     // drag bottom right bigger
     obj.setDragBounds({ top: 0, right: 10, bottom: 10, left: 0 });
-    obj.adoptDragBounds();
+    obj.resizeObject();
     expect(obj).toHaveProperty('x', 0);
     expect(obj).toHaveProperty('y', 0);
     expect(obj).toHaveProperty('width', 20);
@@ -294,7 +294,7 @@ describe("DrawingContentModel", () => {
 
     // drag top left smaller
     obj.setDragBounds({ top: 10, right: 0, bottom: 0, left: 10 });
-    obj.adoptDragBounds();
+    obj.resizeObject();
     expect(obj).toHaveProperty('x', 10);
     expect(obj).toHaveProperty('y', 10);
     expect(obj).toHaveProperty('width', 10);
@@ -322,7 +322,7 @@ describe("DrawingContentModel", () => {
     });
     expect(mockLogTileChangeEvent).toHaveBeenNthCalledWith(2,
       LogEventName.DRAWING_TOOL_CHANGE, {
-      operation: "adoptDragBounds",
+      operation: "resizeObject",
       "change": {
         "args": [ ],
         "path": "/objects/0",
@@ -331,7 +331,7 @@ describe("DrawingContentModel", () => {
     });
     expect(mockLogTileChangeEvent).toHaveBeenNthCalledWith(3,
       LogEventName.DRAWING_TOOL_CHANGE, {
-      operation: "adoptDragBounds",
+      operation: "resizeObject",
       "change": {
         "args": [ ],
         "path": "/objects/0",
@@ -356,7 +356,7 @@ describe("DrawingContentModel", () => {
 
     // drag bottom right bigger
     obj.setDragBounds({ top: 0, right: 10, bottom: 10, left: 0 });
-    obj.adoptDragBounds();
+    obj.resizeObject();
     expect(obj).toHaveProperty('x', 5);
     expect(obj).toHaveProperty('y', 5);
     expect(obj).toHaveProperty('rx', 15);
@@ -364,7 +364,7 @@ describe("DrawingContentModel", () => {
 
     // drag top left smaller
     obj.setDragBounds({ top: 10, right: 0, bottom: 0, left: 10 });
-    obj.adoptDragBounds();
+    obj.resizeObject();
     expect(obj).toHaveProperty('x', 10);
     expect(obj).toHaveProperty('y', 10);
     expect(obj).toHaveProperty('rx', 10);
@@ -381,7 +381,7 @@ describe("DrawingContentModel", () => {
 
     // drag bottom right bigger
     obj.setDragBounds({ top: 0, right: 10, bottom: 10, left: 0 });
-    obj.adoptDragBounds();
+    obj.resizeObject();
     expect(obj).toHaveProperty('x', 0);
     expect(obj).toHaveProperty('y', 0);
     expect(obj).toHaveProperty('width', 20);
@@ -389,7 +389,7 @@ describe("DrawingContentModel", () => {
 
     // drag top left smaller
     obj.setDragBounds({ top: 10, right: 0, bottom: 0, left: 10 });
-    obj.adoptDragBounds();
+    obj.resizeObject();
     expect(obj).toHaveProperty('x', 10);
     expect(obj).toHaveProperty('y', 10);
     expect(obj).toHaveProperty('width', 10);
@@ -407,7 +407,7 @@ describe("DrawingContentModel", () => {
 
     // drag bottom right bigger
     obj.setDragBounds({ top: 0, right: 10, bottom: 10, left: 0 });
-    obj.adoptDragBounds();
+    obj.resizeObject();
     expect(obj).toHaveProperty('x', 0);
     expect(obj).toHaveProperty('y', 0);
     expect(obj).toHaveProperty('dx', 20);
@@ -415,7 +415,7 @@ describe("DrawingContentModel", () => {
 
     // drag top left smaller
     obj.setDragBounds({ top: 10, right: 0, bottom: 0, left: 10 });
-    obj.adoptDragBounds();
+    obj.resizeObject();
     expect(obj).toHaveProperty('x', 10);
     expect(obj).toHaveProperty('y', 10);
     expect(obj).toHaveProperty('dx', 10);
@@ -434,14 +434,14 @@ describe("DrawingContentModel", () => {
 
     // drag bottom right bigger
     obj.setDragBounds({ top: 0, right: 10, bottom: 10, left: 0 });
-    obj.adoptDragBounds();
+    obj.resizeObject();
     expect(obj).toHaveProperty('x', 0);
     expect(obj).toHaveProperty('y', 0);
     expect(obj).toHaveProperty('deltaPoints', [{dx: 20, dy: 20}]);
 
     // drag top left smaller
     obj.setDragBounds({ top: 10, right: 0, bottom: 0, left: 10 });
-    obj.adoptDragBounds();
+    obj.resizeObject();
     expect(obj).toHaveProperty('x', 10);
     expect(obj).toHaveProperty('y', 10);
     expect(obj).toHaveProperty('deltaPoints', [{dx: 10, dy: 10}]);

--- a/src/plugins/drawing/objects/drawing-object.ts
+++ b/src/plugins/drawing/objects/drawing-object.ts
@@ -97,9 +97,9 @@ export const DrawingObject = types.model("DrawingObject", {
     // Implementated in subclasses since this will affect object types differently.
     console.error("setDragBounds is unimplemented for this type");
   },
-  adoptDragBounds() {
+  resizeObject() {
     // Move any volatile resizing into the persisted object model.
-    console.error("adoptDragBounds is unimplemented for this type");
+    console.error("resizeObject is unimplemented for this type");
   }
 }));
 export interface DrawingObjectType extends Instance<typeof DrawingObject> {}

--- a/src/plugins/drawing/objects/drawing-object.ts
+++ b/src/plugins/drawing/objects/drawing-object.ts
@@ -85,7 +85,7 @@ export const DrawingObject = types.model("DrawingObject", {
     self.dragX = x;
     self.dragY = y;
   },
-  adoptDragPosition() {
+  repositionObject() {
     self.x = self.dragX ?? self.x;
     self.y = self.dragY ?? self.y;
     self.dragX = self.dragY = undefined;

--- a/src/plugins/drawing/objects/ellipse.tsx
+++ b/src/plugins/drawing/objects/ellipse.tsx
@@ -42,7 +42,7 @@ export const EllipseObject = types.compose("EllipseObject", StrokedObject, Fille
       self.dragRy = self.ry + deltas.bottom/2 - deltas.top/2;
     },
     resizeObject() {
-      self.adoptDragPosition();
+      self.repositionObject();
       self.rx = self.dragRx ?? self.rx;
       self.ry = self.dragRy ?? self.ry;
       self.dragRx = self.dragRy = undefined;

--- a/src/plugins/drawing/objects/ellipse.tsx
+++ b/src/plugins/drawing/objects/ellipse.tsx
@@ -41,7 +41,7 @@ export const EllipseObject = types.compose("EllipseObject", StrokedObject, Fille
       self.dragRx  = self.rx  + deltas.right/2 - deltas.left/2;
       self.dragRy = self.ry + deltas.bottom/2 - deltas.top/2;
     },
-    adoptDragBounds() {
+    resizeObject() {
       self.adoptDragPosition();
       self.rx = self.dragRx ?? self.rx;
       self.ry = self.dragRy ?? self.ry;

--- a/src/plugins/drawing/objects/image.tsx
+++ b/src/plugins/drawing/objects/image.tsx
@@ -68,7 +68,7 @@ export const ImageObject = DrawingObject.named("ImageObject")
       self.dragHeight = self.height + deltas.bottom - deltas.top;
     },
     resizeObject() {
-      self.adoptDragPosition();
+      self.repositionObject();
       self.width = self.dragWidth ?? self.width;
       self.height = self.dragHeight ?? self.height;
       self.dragWidth = self.dragHeight = undefined;

--- a/src/plugins/drawing/objects/image.tsx
+++ b/src/plugins/drawing/objects/image.tsx
@@ -67,7 +67,7 @@ export const ImageObject = DrawingObject.named("ImageObject")
       self.dragWidth  = self.width  + deltas.right - deltas.left;
       self.dragHeight = self.height + deltas.bottom - deltas.top;
     },
-    adoptDragBounds() {
+    resizeObject() {
       self.adoptDragPosition();
       self.width = self.dragWidth ?? self.width;
       self.height = self.dragHeight ?? self.height;

--- a/src/plugins/drawing/objects/line.tsx
+++ b/src/plugins/drawing/objects/line.tsx
@@ -85,7 +85,7 @@ export const LineObject = StrokedObject.named("LineObject")
       self.dragScaleY = heightFactor;
     },
     resizeObject() {
-      self.adoptDragPosition();
+      self.repositionObject();
 
       // The delta points get permanently scaled by the x & y scale factors
       const scaleX = self.dragScaleX ?? 1;

--- a/src/plugins/drawing/objects/line.tsx
+++ b/src/plugins/drawing/objects/line.tsx
@@ -84,7 +84,7 @@ export const LineObject = StrokedObject.named("LineObject")
       self.dragScaleX = widthFactor;
       self.dragScaleY = heightFactor;
     },
-    adoptDragBounds() {
+    resizeObject() {
       self.adoptDragPosition();
 
       // The delta points get permanently scaled by the x & y scale factors

--- a/src/plugins/drawing/objects/rectangle.tsx
+++ b/src/plugins/drawing/objects/rectangle.tsx
@@ -69,7 +69,7 @@ export const RectangleObject = types.compose("RectangleObject", StrokedObject, F
       self.dragWidth  = self.width  + deltas.right - deltas.left;
       self.dragHeight = self.height + deltas.bottom - deltas.top;
     },
-    adoptDragBounds() {
+    resizeObject() {
       self.adoptDragPosition();
       self.width = self.dragWidth ?? self.width;
       self.height = self.dragHeight ?? self.height;

--- a/src/plugins/drawing/objects/rectangle.tsx
+++ b/src/plugins/drawing/objects/rectangle.tsx
@@ -70,7 +70,7 @@ export const RectangleObject = types.compose("RectangleObject", StrokedObject, F
       self.dragHeight = self.height + deltas.bottom - deltas.top;
     },
     resizeObject() {
-      self.adoptDragPosition();
+      self.repositionObject();
       self.width = self.dragWidth ?? self.width;
       self.height = self.dragHeight ?? self.height;
       self.dragWidth = self.dragHeight = undefined;

--- a/src/plugins/drawing/objects/vector.tsx
+++ b/src/plugins/drawing/objects/vector.tsx
@@ -61,7 +61,7 @@ export const VectorObject = StrokedObject.named("VectorObject")
       }
     },
     resizeObject() {
-      self.adoptDragPosition();
+      self.repositionObject();
       self.dx = self.dragDx ?? self.dx;
       self.dy = self.dragDy ?? self.dy;
       self.dragDx = self.dragDy = undefined;

--- a/src/plugins/drawing/objects/vector.tsx
+++ b/src/plugins/drawing/objects/vector.tsx
@@ -60,7 +60,7 @@ export const VectorObject = StrokedObject.named("VectorObject")
         self.dragDy = self.dy - deltas.bottom + deltas.top;
       }
     },
-    adoptDragBounds() {
+    resizeObject() {
       self.adoptDragPosition();
       self.dx = self.dragDx ?? self.dx;
       self.dy = self.dragDy ?? self.dy;


### PR DESCRIPTION
Since action names in the draw tile are used directly as the "operation" field of log entries, they have to be understandable out of context.  This PR changes the names of two new actions to be more clear:

adoptDragBounds --> resizeObject
adoptDragPosition --> repositionObject
