### PR TITLE
Making history and teacher_dashboard tests independent and retry-able

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,7 @@ jobs:
             ["master"]
   regression:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs:
       - prepare
       - build_test
@@ -142,11 +143,14 @@ jobs:
       # https://github.com/cypress-io/github-action/issues/48
       fail-fast: false
       matrix:
-        # run 7 copies of the current job in parallel
-        containers: [1, 2, 3, 4, 5, 6, 7]
+        # run 5 copies of the current job in parallel
+        containers: [1, 2, 3, 4, 5]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
       - name: Install CMS Dependencies
         working-directory: ./cms
         run: npm ci

--- a/cypress/e2e/clue/branch/teacher_tests/history_playback_spec.js
+++ b/cypress/e2e/clue/branch/teacher_tests/history_playback_spec.js
@@ -3,36 +3,40 @@ import ClueCanvas from "../../../../support/elements/clue/cCanvas";
 import TableToolTile from "../../../../support/elements/clue/TableToolTile";
 import DrawToolTile from "../../../../support/elements/clue/DrawToolTile";
 
-let dashboard = new TeacherDashboard;
 let clueCanvas = new ClueCanvas;
 let tableToolTile = new TableToolTile;
 let drawToolTile = new DrawToolTile;
 
 const queryParams = "/?appMode=qa&fakeClass=5&fakeOffering=5&problem=2.1&fakeUser=teacher:7&unit=msa";
+const studentQueryParams = "/?appMode=demo&demoName=CLUE-Test&fakeClass=5&fakeOffering=5&problem=2.1&fakeUser=student:1";
+
+function moveSliderTo(percent) {
+  cy.get('.rc-slider-horizontal').then($slider => {
+    const width = $slider.width();
+    cy.wrap($slider).click(width * percent / 100, 0);
+  });
+}
+
+function beforeTest(params) {
+  cy.clearQAData('all');
+  cy.visit(params);
+  cy.waitForLoad();
+  clueCanvas.getInvestigationCanvasTitle().text().then((investigationTitle) => {
+    cy.openTopTab('my-work');
+    cy.openDocumentThumbnail('my-work', 'workspaces', investigationTitle);
+  });
+}
 
 context('History Playback', () => {
+  it('verify playback', function () {
+    beforeTest(queryParams);
 
-  before(() => {
-    cy.clearQAData('all');
-
-    cy.visit(queryParams);
-    cy.waitForLoad();
-    dashboard.switchView("Workspace & Resources");
-    cy.wait(2000);
-    clueCanvas.getInvestigationCanvasTitle().text().as('investigationTitle');
-  });
-  beforeEach(() => {
-    cy.fixture("teacher-dash-data-msa-test.json").as("clueData");
-  });
-
-  it('verify playback shows no history if there is no history', function() {
-    cy.openTopTab('my-work');
-    cy.openDocumentThumbnail('my-work','workspaces', this.investigationTitle);
+    cy.log('verify playback shows no history if there is no history');
     cy.get('[data-testid="playback-component-button"]').click();
     cy.get('.playback-controls').contains("This document has no history");
     cy.get('[data-testid="playback-component-button"]').click();
-  });
-  it('verify playback controls open with slider when there is history', () => {
+
+    cy.log('verify playback controls open with slider when there is history');
     clueCanvas.addTile('drawing');
     // give firestore some time to record this new history entry before we try
     // to find it.
@@ -43,195 +47,162 @@ context('History Playback', () => {
     cy.get('[data-testid="playback-component-button"]').click();
     cy.get('[data-testid="playback-slider"]').should('be.visible');
     cy.get('[data-testid="playback-time-info"]').should('be.visible');
-  });
-  it('verify play button is disabled when slider handle is at the right end', () => {
+
+    cy.log('verify play button is disabled when slider handle is at the right end');
     cy.wait(10);
     cy.get('[data-testid="playback-play-button"]').should('have.class', "disabled");
-  });
-  it('verify added tile is visible in the playback document', () => {
+
+    cy.log('verify added tile is visible in the playback document');
     cy.get('[data-test="subtab-workspaces"] .editable-document-content .canvas .document-content .drawing-tool-tile').should('be.visible');
-  });
-  it('verify play button is enabled when playback is rewound', () => {
+
+    cy.log('verify play button is enabled when playback is rewound');
     cy.get('.rc-slider-horizontal').click('left');
     cy.get('[data-testid="playback-play-button"]').should('not.have.class', 'disabled');
-  });
-  it('verify correct document state is shown in playback document when slider is moved', () => {
+
+    cy.log('verify correct document state is shown in playback document when slider is moved');
     cy.get('[data-test="subtab-workspaces"] .editable-document-content .canvas .document-content .drawing-tool-tile').should('not.exist');
-  });
-  it('verify primary document remains unchanged during playback', () => {
+
+    cy.log('verify primary document remains unchanged during playback');
     cy.get('.primary-workspace .editable-document-content .canvas .document-content .drawing-tool-tile').should('be.visible');
-  });
-  it('verify playback document does not have changes to primary document', () => {
+
+    cy.log('verify playback document does not have changes to primary document');
     drawToolTile.getDrawToolLine().click();
     drawToolTile.getDrawTile()
       .trigger('mousedown')
-      .trigger('mousemove', 50,0)
+      .trigger('mousemove', 50, 0)
       .trigger('mouseup');
     cy.get('.primary-workspace .editable-document-content .canvas .document-content .drawing-tool .drawing-layer line').should('be.visible');
     cy.get('[data-test="subtab-workspaces"] .editable-document-content .canvas .document-content .drawing-tool .drawing-layer line').should('not.exist');
-  });
-  it('verify playback document is updated when playback controls is closed and reopened', () => {
+
+    cy.log('verify playback document is updated when playback controls is closed and reopened');
     cy.get('[data-testid="playback-component-button"]').click(); //close playback controls
     cy.get('[data-testid="playback-component-button"]').click(); //open playback controls
     cy.get('[data-test="subtab-workspaces"] .editable-document-content .canvas .document-content .drawing-tool .drawing-layer line').should('be.visible');
-  });
-  it('verify playback of history', () => {
+
+    cy.log('verify playback of history');
     cy.get('.rc-slider-horizontal').click('left');
     cy.get('[data-test="subtab-workspaces"] .editable-document-content .canvas .document-content .drawing-tool .drawing-layer line').should('not.exist');
     cy.get('[data-testid="playback-play-button"]').click();
     cy.wait(2000);
     cy.get('[data-test="subtab-workspaces"] .editable-document-content .canvas .document-content .drawing-tool .drawing-layer line').should('be.visible');
   });
-  describe('Table Tile History Support', () => {
-    before(() => {
-      // Close playback controls
-      cy.get('[data-testid="playback-component-button"]').click(); //open playback controls
 
-      // create a table
-      clueCanvas.addTile('table');
-      //
-      // By default getTableTile looks in the right side (editable) workspace
-      tableToolTile.getTableTile().within(() => {
-        tableToolTile.typeInTableCell(1, '1');
-        tableToolTile.typeInTableCell(2, '2');
-      });
+  it("verify table tile history", () => {
+    beforeTest(queryParams);
+
+    cy.log('create table and add a row in it');
+    // create a table
+    clueCanvas.addTile('table');
+    // By default getTableTile looks in the right side (editable) workspace
+    tableToolTile.getTableTile().within(() => {
+      tableToolTile.typeInTableCell(1, '1');
+      tableToolTile.typeInTableCell(2, '2');
     });
 
-    it('verify table shows up in main doc on the left', () => {
-      tableToolTile.getTableTile('[data-test="subtab-workspaces"] .editable-document-content').should('exist');
-
-      tableToolTile.getTableTile('[data-test="subtab-workspaces"] .editable-document-content').within(() => {
-        tableToolTile.getTableCell().eq(1).should('contain', '1');
-        tableToolTile.getTableCell().eq(2).should('contain', '2');
-      });
+    cy.log('verify table shows up in main doc on the left');
+    tableToolTile.getTableTile('[data-test="subtab-workspaces"] .editable-document-content').should('exist');
+    tableToolTile.getTableTile('[data-test="subtab-workspaces"] .editable-document-content').within(() => {
+      tableToolTile.getTableCell().eq(1).should('contain', '1');
+      tableToolTile.getTableCell().eq(2).should('contain', '2');
     });
 
-    it('verify table shows up in history doc on the left', () => {
-      // Open playback controls
-      cy.get('[data-testid="playback-component-button"]').click(); //open playback controls
-
-      // wait for it to load
-      cy.get('.rc-slider-horizontal').should('exist');
-
-      tableToolTile.getTableTile('[data-test="subtab-workspaces"] .editable-document-content').should('exist');
-
-      tableToolTile.getTableTile('[data-test="subtab-workspaces"] .editable-document-content').within(() => {
-        tableToolTile.getTableCell().eq(1).should('contain', '1');
-        tableToolTile.getTableCell().eq(2).should('contain', '2');
-      });
+    cy.log('verify table shows up in history doc on the left');
+    // Open playback controls
+    cy.get('[data-testid="playback-component-button"]').click(); //open playback controls
+    // wait for it to load
+    cy.get('.rc-slider-horizontal').should('exist');
+    tableToolTile.getTableTile('[data-test="subtab-workspaces"] .editable-document-content').should('exist');
+    tableToolTile.getTableTile('[data-test="subtab-workspaces"] .editable-document-content').within(() => {
+      tableToolTile.getTableCell().eq(1).should('contain', '1');
+      tableToolTile.getTableCell().eq(2).should('contain', '2');
     });
 
-    function moveSliderTo(percent) {
-      cy.get('.rc-slider-horizontal').then($slider => {
-        const width = $slider.width();
-        cy.wrap($slider).click(width*percent/100, 0);
-      });
-    }
-
-    it('verify table is undone in the correctly', () => {
-      moveSliderTo(80);
-      tableToolTile.getTableTile('[data-test="subtab-workspaces"] .editable-document-content').within(() => {
-        tableToolTile.getTableCell().eq(1).should('contain', '1');
-        tableToolTile.getTableCell().eq(2).should('not.contain', '2');
-      });
-
-      moveSliderTo(60);
-      tableToolTile.getTableTile('[data-test="subtab-workspaces"] .editable-document-content').within(() => {
-        tableToolTile.getTableCell().should('not.exist');
-      });
-
-      moveSliderTo(40);
-      cy.get('[data-test="subtab-workspaces"] .editable-document-content .canvas .document-content .table-tool').should('not.exist');
+    cy.log('verify table is undone in the correctly');
+    moveSliderTo(80);
+    tableToolTile.getTableTile('[data-test="subtab-workspaces"] .editable-document-content').within(() => {
+      tableToolTile.getTableCell().eq(1).should('contain', '1');
+      tableToolTile.getTableCell().eq(2).should('not.contain', '2');
     });
-
-    it('verify table is redone in the correctly', () => {
-      moveSliderTo(60);
-      tableToolTile.getTableTile('[data-test="subtab-workspaces"] .editable-document-content').within(() => {
-        tableToolTile.getTableCell().should('not.exist');
-      });
-
-      moveSliderTo(80);
-      tableToolTile.getTableTile('[data-test="subtab-workspaces"] .editable-document-content').within(() => {
-        tableToolTile.getTableCell().eq(1).should('contain', '1');
-        tableToolTile.getTableCell().eq(2).should('not.contain', '2');
-      });
-
-      // This was 99 and sometimes Cypress said it was covered by the parent element
-      moveSliderTo(98);
-      tableToolTile.getTableTile('[data-test="subtab-workspaces"] .editable-document-content').within(() => {
-        tableToolTile.getTableCell().eq(1).should('contain', '1');
-        tableToolTile.getTableCell().eq(2).should('contain', '2');
-      });
+    moveSliderTo(40);
+    tableToolTile.getTableTile('[data-test="subtab-workspaces"] .editable-document-content').within(() => {
+      tableToolTile.getTableCell().should('not.exist');
     });
-    it('verify undo action in primary document and verify playback of history', () => {
-      clueCanvas.getUndoTool().click();
-      tableToolTile.getTableTile('[data-test="subtab-workspaces"] .editable-document-content').within(() => {
-        tableToolTile.getTableCell().eq(1).should('contain', '1');
-        tableToolTile.getTableCell().eq(2).should('contain', '2');
-      });
-      tableToolTile.getTableTile().within(() => {
-        tableToolTile.getTableCell().eq(1).should('contain', '1');
-        tableToolTile.getTableCell().eq(2).should('not.contain', '2');
-      });
-      cy.get('[data-testid="playback-play-button"]').click();
-      cy.wait(2000);
-      tableToolTile.getTableTile('[data-test="subtab-workspaces"] .editable-document-content').within(() => {
-        tableToolTile.getTableCell().eq(1).should('contain', '1');
-        tableToolTile.getTableCell().eq(2).should('not.contain', '2');
-      });
-      clueCanvas.getRedoTool().click();
-      tableToolTile.getTableTile().within(() => {
-        tableToolTile.getTableCell().eq(1).should('contain', '1');
-        tableToolTile.getTableCell().eq(2).should('contain', '2');
-      });
-      tableToolTile.getTableTile('[data-test="subtab-workspaces"] .editable-document-content').within(() => {
-        tableToolTile.getTableCell().eq(1).should('contain', '1');
-        tableToolTile.getTableCell().eq(2).should('not.contain', '2');
-      });
-      cy.get('[data-testid="playback-play-button"]').click();
-      cy.wait(2000);
-      tableToolTile.getTableTile('[data-test="subtab-workspaces"] .editable-document-content').within(() => {
-        tableToolTile.getTableCell().eq(1).should('contain', '1');
-        tableToolTile.getTableCell().eq(2).should('contain', '2');
-      });
+    moveSliderTo(10);
+    cy.get('[data-test="subtab-workspaces"] .editable-document-content .canvas .document-content .table-tool').should('not.exist');
+    
+    cy.log('verify table is redone in the correctly');
+    moveSliderTo(40);
+    tableToolTile.getTableTile('[data-test="subtab-workspaces"] .editable-document-content').within(() => {
+      tableToolTile.getTableCell().should('not.exist');
     });
-    it('verify playback icon in class work & learning logs & icon background color', () => {
-      cy.get('[data-testid="playback-component-button"]').click();
-      cy.get('.playback-toolbar-button.themed.my-work').should('have.css', 'background-color', 'rgb(183, 226, 236)');
-      clueCanvas.publishDoc("This Class");
-      cy.openSection('my-work', "learning-log");
-      cy.openDocumentWithTitle('my-work', 'learning-log','My First Learning Log');
-      cy.get('[data-testid="playback-component-button"]').should('be.visible');
-      cy.get('.playback-toolbar-button.themed.my-work').should('have.css', 'background-color', 'rgb(183, 226, 236)');
-      clueCanvas.publishDoc("This Class");
-      //removed palyback button in published documents
-      // cy.openTopTab('class-work');
-      // cy.openSection('class-work', "workspaces");
-      // cy.openDocumentThumbnail('class-work','workspaces','Network User');
-      // cy.get('[data-testid="playback-component-button"]').should('be.visible');
-      // cy.get('.playback-toolbar-button.themed.class-work').should('have.css', 'background-color', 'rgb(236, 201, 255)');
-      // cy.openSection('class-work', "learning-logs");
-      // cy.openDocumentThumbnail('class-work','learning-logs','Network User');
-      // cy.get('[data-testid="playback-component-button"]').should('be.visible');
-      // cy.get('.playback-toolbar-button.themed.class-work').should('have.css', 'background-color', 'rgb(236, 201, 255)');
+    moveSliderTo(80);
+    tableToolTile.getTableTile('[data-test="subtab-workspaces"] .editable-document-content').within(() => {
+      tableToolTile.getTableCell().eq(1).should('contain', '1');
+      tableToolTile.getTableCell().eq(2).should('not.contain', '2');
     });
-  });
-});
-
-context('History Playback for student', () => {
-
-  before(() => {
-    cy.clearQAData('all');
-
-    cy.visit('/?appMode=demo&demoName=CLUE-Test&fakeClass=5&fakeOffering=5&problem=2.1&fakeUser=student:1');
-    cy.waitForLoad();
+    // This was 99 and sometimes Cypress said it was covered by the parent element
+    moveSliderTo(98);
+    tableToolTile.getTableTile('[data-test="subtab-workspaces"] .editable-document-content').within(() => {
+      tableToolTile.getTableCell().eq(1).should('contain', '1');
+      tableToolTile.getTableCell().eq(2).should('contain', '2');
+    });
+    
+    cy.log('verify undo action in primary document and verify playback of history');
+    clueCanvas.getUndoTool().click();
+    tableToolTile.getTableTile('[data-test="subtab-workspaces"] .editable-document-content').within(() => {
+      tableToolTile.getTableCell().eq(1).should('contain', '1');
+      tableToolTile.getTableCell().eq(2).should('contain', '2');
+    });
+    tableToolTile.getTableTile().within(() => {
+      tableToolTile.getTableCell().eq(1).should('contain', '1');
+      tableToolTile.getTableCell().eq(2).should('not.contain', '2');
+    });
+    cy.get('[data-testid="playback-play-button"]').click();
     cy.wait(2000);
-    clueCanvas.getInvestigationCanvasTitle().text().as('investigationTitle');
+    tableToolTile.getTableTile('[data-test="subtab-workspaces"] .editable-document-content').within(() => {
+      tableToolTile.getTableCell().eq(1).should('contain', '1');
+      tableToolTile.getTableCell().eq(2).should('not.contain', '2');
+    });
+    clueCanvas.getRedoTool().click();
+    tableToolTile.getTableTile().within(() => {
+      tableToolTile.getTableCell().eq(1).should('contain', '1');
+      tableToolTile.getTableCell().eq(2).should('contain', '2');
+    });
+    tableToolTile.getTableTile('[data-test="subtab-workspaces"] .editable-document-content').within(() => {
+      tableToolTile.getTableCell().eq(1).should('contain', '1');
+      tableToolTile.getTableCell().eq(2).should('not.contain', '2');
+    });
+    cy.get('[data-testid="playback-play-button"]').click();
+    cy.wait(2000);
+    tableToolTile.getTableTile('[data-test="subtab-workspaces"] .editable-document-content').within(() => {
+      tableToolTile.getTableCell().eq(1).should('contain', '1');
+      tableToolTile.getTableCell().eq(2).should('contain', '2');
+    });
+    
+    cy.log('verify playback icon in class work & learning logs & icon background color');
+    cy.get('[data-testid="playback-component-button"]').click();
+    cy.get('.playback-toolbar-button.themed.my-work').should('have.css', 'background-color', 'rgb(183, 226, 236)');
+    clueCanvas.publishDoc("This Class");
+    cy.openSection('my-work', "learning-log");
+    cy.openDocumentWithTitle('my-work', 'learning-log', 'My First Learning Log');
+    cy.get('[data-testid="playback-component-button"]').should('be.visible');
+    cy.get('.playback-toolbar-button.themed.my-work').should('have.css', 'background-color', 'rgb(183, 226, 236)');
+    clueCanvas.publishDoc("This Class");
+    //removed palyback button in published documents
+    // cy.openTopTab('class-work');
+    // cy.openSection('class-work', "workspaces");
+    // cy.openDocumentThumbnail('class-work','workspaces','Network User');
+    // cy.get('[data-testid="playback-component-button"]').should('be.visible');
+    // cy.get('.playback-toolbar-button.themed.class-work').should('have.css', 'background-color', 'rgb(236, 201, 255)');
+    // cy.openSection('class-work', "learning-logs");
+    // cy.openDocumentThumbnail('class-work','learning-logs','Network User');
+    // cy.get('[data-testid="playback-component-button"]').should('be.visible');
+    // cy.get('.playback-toolbar-button.themed.class-work').should('have.css', 'background-color', 'rgb(236, 201, 255)');
   });
 
   it('verify playback icon not displayed for student', function() {
-    cy.openTopTab('my-work');
-    cy.openDocumentThumbnail('my-work','workspaces', this.investigationTitle);
+    beforeTest(studentQueryParams);
+    
     cy.get('[data-testid="playback-component-button"]').should("not.exist");
   });
 });

--- a/cypress/e2e/clue/full/teacher_tests/teacher_dashboard_six_pack_spec.js
+++ b/cypress/e2e/clue/full/teacher_tests/teacher_dashboard_six_pack_spec.js
@@ -1,0 +1,69 @@
+import TeacherDashboard from "../../../../support/elements/clue/TeacherDashboard";
+
+let dashboard = new TeacherDashboard();
+
+/**
+ * Notes:
+ *
+ * Teacher dashboard test needs static data from 'clueteachertest's class 'CLUE'
+ * Here is the ID for the class in firebase: a1f7b8f8b7b1ad1d2d6240c41bd2354d8575ee09ae8bd641
+ *
+ * Currently issues with problem switcher/class switcher. Maybe split these into two tests. Have this test
+ * log into portal with data that doesn't need to be static.
+ *
+ * -> This may also help with issue when verifying read-only student canvases which is currently looping through
+ *    all of the students in the dashboard's current view
+ */
+
+context("Teacher Space", () => {
+
+  const clueTeacher = {
+    username: "clueteachertest",
+    password: "password"
+  };
+
+  function beforeTest() {
+    cy.login("https://learn.concord.org", clueTeacher);
+    // insert offering number for your activity below
+    cy.launchReport('https://learn.concord.org/portal/offerings/40557/external_report/25');
+    cy.waitForLoad();
+
+    dashboard.switchView("Dashboard");
+    dashboard.switchWorkView('Published');
+    dashboard.clearAllStarsFromPublishedWork();
+    dashboard.switchWorkView('Current');
+    cy.fixture("teacher-dash-data.json").as("clueData");
+  }
+
+  context('Teacher Dashboard View', () => {
+    it('verify switching classes changes six pack content', () => {
+      beforeTest();
+      cy.get('@clueData').then((clueData) => {
+        const initClassIndex = 0;
+        const tempClassIndex = 1;
+        let initClass = clueData.classes[initClassIndex];
+        let tempClass = clueData.classes[tempClassIndex];
+        let className = tempClass.className;
+        let initClassName = initClass.className;
+
+        dashboard.switchView("Dashboard");
+        dashboard.getClassDropdown().should('contain', initClassName);
+        dashboard.getGroups().should('have.length', 6);
+        dashboard.getClassDropdown().click({ force: true }).then(() => {
+          dashboard.getClassList().contains(className).click({ force: true });
+          // cy.wait(1000)
+          cy.waitForLoad();
+          dashboard.switchView("Dashboard");
+        });
+        dashboard.getClassDropdown().should('contain', className);
+        dashboard.getGroups().should('have.length', 1);
+
+        //switch back to original problem for later test
+        dashboard.getClassDropdown().click({ force: true });
+        dashboard.getClassList().find('.list-item').contains(initClassName).click({ force: true });
+        // cy.wait(1000)
+        cy.waitForLoad();
+      });
+    });
+  });
+});

--- a/cypress/e2e/clue/full/teacher_tests/teacher_dashboard_spec.js
+++ b/cypress/e2e/clue/full/teacher_tests/teacher_dashboard_spec.js
@@ -1,7 +1,10 @@
 import TeacherDashboard from "../../../../support/elements/clue/TeacherDashboard";
 
 let dashboard = new TeacherDashboard();
-
+const clueTeacher = {
+  username: "clueteachertest",
+  password: "password"
+};
 /**
  * Notes:
  *
@@ -15,144 +18,96 @@ let dashboard = new TeacherDashboard();
  *    all of the students in the dashboard's current view
  */
 
-context("Teacher Space", () => {
 
-    const clueTeacher = {
-        username: "clueteachertest",
-        password: "password"
-    };
+function beforeTest() {
+  cy.login("https://learn.concord.org", clueTeacher);
+  // insert offering number for your activity below
+  cy.launchReport('https://learn.concord.org/portal/offerings/40557/external_report/25');
+  cy.waitForLoad();
 
-    before(() => {
-        cy.login("https://learn.concord.org", clueTeacher);
-        // insert offering number for your activity below
-        cy.launchReport('https://learn.concord.org/portal/offerings/40557/external_report/25');
+  dashboard.switchView("Dashboard");
+  dashboard.switchWorkView('Published');
+  dashboard.clearAllStarsFromPublishedWork();
+  dashboard.switchWorkView('Current');
+  cy.fixture("teacher-dash-data.json").as("clueData");
+}
+
+context('Teacher Dashboard View', () => {
+  it('verify header elements', () => {
+    beforeTest();
+    cy.get('@clueData').then((clueData) => {
+      let tempClass = clueData.classes[0];
+
+      // Check Investigation Name visibility
+      dashboard.getInvestigationTitle().should('be.visible').and('contain', clueData.investigationTitle);
+      // Check problem list  UI and visibility
+      dashboard.getProblemList().should('not.have.class', 'show');
+      dashboard.getProblemDropdown().should('be.visible').click({ force: true });
+      dashboard.getProblemList().should('exist').and('have.class', 'show');
+      dashboard.getProblemList().find('.list-item').should('have.length', tempClass.problemTotal);
+      dashboard.getProblemDropdown().click({ force: true });
+      dashboard.getProblemList().should('not.have.class', 'show');
+      // Check class list UI and visibility
+      dashboard.getClassList().should('not.have.class', 'show');
+      dashboard.getClassDropdown().should('contain', clueData.teacherName).and('contain', tempClass.className);
+      dashboard.getClassDropdown().should('be.visible').click({ force: true });
+      dashboard.getClassList().should('exist').and('have.class', 'show');
+      dashboard.getClassList().find('.list-item').should('have.length', clueData.classes.length);
+      dashboard.getClassDropdown().click({ force: true });
+      dashboard.getClassList().should('not.have.class', 'show');
+      // Check Teacher Username visibility and content
+      // header.getUserName().should('be.visible').and('contain', clueData.teacherName)
+    });
+  });
+  it('verifies six pack and group names', () => { //check this test again
+    beforeTest();
+    cy.get('@clueData').then((clueData) => {
+      let tempGroupIndex = 0;
+      let groups = clueData.classes[0].problems[0].groups;
+      let group = groups[tempGroupIndex];
+
+      // Check for group title
+      dashboard.getSixPackView().should('exist').and('be.visible');
+      dashboard.getGroupName().eq(group.groupIndex).should('contain', group.groupName);
+      // Check for group length (4Up Count)
+      dashboard.getSixPackView().then(() => {
+        dashboard.getFourUpViews().should('have.length', 6);
+      });
+    });
+  });
+  it('verify switching problems changes six pack content and problem title', () => {
+    beforeTest();
+    cy.get('@clueData').then((clueData) => {
+      let problems = clueData.classes[0].problems;
+      let initProblemIndex = 0;
+      let tempProblemIndex = 1;
+
+      dashboard.getProblemDropdown().text().should('not.contain', problems[tempProblemIndex].problemTitle);
+      dashboard.getGroups().should('have.length', 6);
+      dashboard.getProblemDropdown().click({ force: true }).then(() => {
+        dashboard.getProblemList().should('have.class', 'show');
+        dashboard.getProblemList().find('.list-item').contains(problems[tempProblemIndex].problemTitle).click({ force: true });
+        // cy.wait(1000);
         cy.waitForLoad();
+        tempProblemIndex += 1;
+      });
+      dashboard.getProblemDropdown().should('contain', problems[tempProblemIndex].problemTitle);
+      dashboard.getGroups().should('have.length', 0);
 
-        dashboard.switchView("Dashboard");
-        dashboard.switchWorkView('Published');
-        dashboard.clearAllStarsFromPublishedWork();
-        dashboard.switchWorkView('Current');
+      //switch back to original problem for later test
+      dashboard.getProblemDropdown().click({ force: true });
+      dashboard.getProblemList().find('.list-item').contains(problems[initProblemIndex].problemTitle).click({ force: true });
+      // cy.wait(1000);
+      cy.waitForLoad();
     });
+  });
+  it('verify selected class is shown in class dropdown', () => {
+    beforeTest();
+    cy.get('@clueData').then((clueData) => {
+      let initialClassIndex = 0;
+      let tempClass = clueData.classes[initialClassIndex];
 
-    beforeEach(() => {
-        cy.fixture("teacher-dash-data.json").as("clueData");
+      dashboard.getClassDropdown().should('contain', tempClass.className).and('be.visible');
     });
-
-    context('Teacher Dashboard View', () => {
-        describe('UI visibility', () => {
-            it('verify header elements', () => {
-                cy.get('@clueData').then((clueData) => {
-                    let tempClass = clueData.classes[0];
-
-                    // Check Investigation Name visibility
-                    dashboard.getInvestigationTitle().should('be.visible').and('contain', clueData.investigationTitle);
-                    // Check problem list  UI and visibility
-                    dashboard.getProblemList().should('not.have.class','show');
-                    dashboard.getProblemDropdown().should('be.visible').click({ force: true });
-                    dashboard.getProblemList().should('exist').and('have.class','show');
-                    dashboard.getProblemList().find('.list-item').should('have.length', tempClass.problemTotal);
-                    dashboard.getProblemDropdown().click({ force: true });
-                    dashboard.getProblemList().should('not.have.class','show');
-                    // Check class list UI and visibility
-                    dashboard.getClassList().should('not.have.class','show');
-                    dashboard.getClassDropdown().should('contain',clueData.teacherName).and('contain',tempClass.className);
-                    dashboard.getClassDropdown().should('be.visible').click({ force: true });
-                    dashboard.getClassList().should('exist').and('have.class', 'show');
-                    dashboard.getClassList().find('.list-item').should('have.length', clueData.classes.length);
-                    dashboard.getClassDropdown().click({ force: true });
-                    dashboard.getClassList().should('not.have.class','show');
-                    // Check Teacher Username visibility and content
-                    // header.getUserName().should('be.visible').and('contain', clueData.teacherName)
-                });
-            });
-            it('verifies six pack and group names', () => { //check this test again
-                cy.get('@clueData').then((clueData) => {
-                    let tempGroupIndex = 0;
-                    let groups = clueData.classes[0].problems[0].groups;
-                    let group = groups[tempGroupIndex];
-
-                    // Check for group title
-                    dashboard.getSixPackView().should('exist').and('be.visible');
-                    dashboard.getGroupName().eq(group.groupIndex).should('contain', group.groupName);
-                    // Check for group length (4Up Count)
-                    dashboard.getSixPackView().then(() => {
-                        dashboard.getFourUpViews().should('have.length', 6);
-                    });
-                });
-            });
-        });
-        describe('Header element functionality', () => {
-            it('verify switching problems changes six pack content and problem title', () => {
-                cy.get('@clueData').then((clueData) => {
-                    let problems = clueData.classes[0].problems;
-                    let initProblemIndex = 0;
-                    let tempProblemIndex = 1;
-
-                    dashboard.getProblemDropdown().text().should('not.contain', problems[tempProblemIndex].problemTitle);
-                    dashboard.getGroups().should('have.length',6);
-                    dashboard.getProblemDropdown().click({ force: true }).then(() => {
-                        dashboard.getProblemList().should('have.class','show');
-                        dashboard.getProblemList().find('.list-item').contains(problems[tempProblemIndex].problemTitle).click({ force: true });
-                        // cy.wait(1000);
-                        cy.waitForLoad();
-                        tempProblemIndex += 1;
-                    });
-                    dashboard.getProblemDropdown().should('contain', problems[tempProblemIndex].problemTitle);
-                    dashboard.getGroups().should('have.length',0);
-
-                    //switch back to original problem for later test
-                    dashboard.getProblemDropdown().click({force:true});
-                    dashboard.getProblemList().find('.list-item').contains(problems[initProblemIndex].problemTitle).click({ force: true });
-                    // cy.wait(1000);
-                    cy.waitForLoad();
-                });
-            });
-            it('verify selected class is shown in class dropdown', () => {
-                cy.get('@clueData').then((clueData) => {
-                    let initialClassIndex = 0;
-                    let tempClass = clueData.classes[initialClassIndex];
-
-                    dashboard.getClassDropdown().should('contain', tempClass.className).and('be.visible');
-                });
-            });
-            it('verify switching classes changes six pack content', () => {
-                cy.get('@clueData').then((clueData) => {
-                    const initClassIndex = 0;
-                    const tempClassIndex = 1;
-                    let initClass = clueData.classes[initClassIndex];
-                    let tempClass = clueData.classes[tempClassIndex];
-                    let className = tempClass.className;
-                    let initClassName = initClass.className;
-
-                    dashboard.switchView("Dashboard");
-                    dashboard.getClassDropdown().should('contain', initClassName);
-                    dashboard.getGroups().should('have.length',6);
-                    dashboard.getClassDropdown().click({ force: true }).then(() => {
-                        dashboard.getClassList().contains(className).click({ force: true });
-                        // cy.wait(1000)
-                        cy.waitForLoad();
-                        dashboard.switchView("Dashboard");
-                    });
-                    dashboard.getClassDropdown().should('contain', className);
-                    dashboard.getGroups().should('have.length', 1);
-
-                    //switch back to original problem for later test
-                    dashboard.getClassDropdown().click({force:true});
-                    dashboard.getClassList().find('.list-item').contains(initClassName).click({ force: true });
-                    // cy.wait(1000)
-                    cy.waitForLoad();
-                });
-            });
-        });
-        describe('6-pack view live updates', () => {
-            it('verify 4up views in 6 pack are updated as student makes changes', () => {
-                /**
-                 * Check for current existing element in student canvas
-                 * Visit student link
-                 * Do some work as student
-                 * Verify that there were changes/new elements
-                 */
-            });
-        });
-    });
+  });
 });


### PR DESCRIPTION
This PR address 3 things:
- Making history and teacher_dashboard tests independent and retry-able
- Changing number of cypress threads to 5 from 7
- Adding 60 minute timeout for regression tests