### PR TITLE
185539001 Sparrow Default Offsets

### DIFF
--- a/src/components/document/annotation-layer.tsx
+++ b/src/components/document/annotation-layer.tsx
@@ -45,8 +45,6 @@ export const AnnotationLayer = observer(function AnnotationLayer({
     }
   };
 
-  const rowIds = content?.rowOrder || [];
-
   function getObjectBoundingBox(
     rowId: string, tileId: string, objectId: string, objectType?: string
   ) {
@@ -88,6 +86,20 @@ export const AnnotationLayer = observer(function AnnotationLayer({
   const sourceBoundingBox = sourceTileId && sourceObjectId
     ? getObjectBoundingBoxUnknownRow(sourceTileId, sourceObjectId, sourceObjectType)
     : undefined;
+  function defaultOffset(tileId?: string, objectId?: string, objectType?: string) {
+    return (tileId && objectId
+      ? tileApiInterface?.getTileApi(tileId)?.getObjectDefaultOffsets?.(objectId, objectType)
+      : undefined)
+      ?? OffsetModel.create({});
+  }
+  const sourceOffset = defaultOffset(sourceTileId, sourceObjectId, sourceObjectType);
+
+  const previewArrowSourceX = sourceBoundingBox && sourceOffset
+    ? sourceBoundingBox.left + sourceBoundingBox.width / 2 + sourceOffset.dx
+    : undefined;
+  const previewArrowSourceY = sourceBoundingBox && sourceOffset
+    ? sourceBoundingBox.top + sourceBoundingBox.height / 2 + sourceOffset.dy
+    : undefined;
 
   const handleAnnotationButtonClick = (tileId: string, objectId: string, objectType?: string) => {
     if (!sourceBoundingBox) {
@@ -106,6 +118,7 @@ export const AnnotationLayer = observer(function AnnotationLayer({
         ClueObjectModel.create({ tileId: sourceTileId, objectId: sourceObjectId, objectType: sourceObjectType });
       const targetObject = ClueObjectModel.create({ tileId, objectId, objectType });
       const targetBoundingBox = getObjectBoundingBoxUnknownRow(tileId, objectId, objectType);
+      const targetOffset = defaultOffset(tileId, objectId, objectType);
       let textOffset;
       if (targetBoundingBox) {
         const sourceX = sourceBoundingBox.left + sourceBoundingBox.width / 2;
@@ -115,7 +128,7 @@ export const AnnotationLayer = observer(function AnnotationLayer({
         const { peakDx, peakDy } = getDeafultPeak(sourceX, sourceY, targetX, targetY);
         textOffset = OffsetModel.create({ dx: peakDx, dy: peakDy });
       }
-      const newArrow = ArrowAnnotation.create({ sourceObject, targetObject, textOffset });
+      const newArrow = ArrowAnnotation.create({ sourceObject, sourceOffset, targetObject, targetOffset, textOffset });
       newArrow.setIsNew(true);
       content?.addArrow(newArrow);
       setSourceTileId("");
@@ -128,6 +141,7 @@ export const AnnotationLayer = observer(function AnnotationLayer({
     return getObjectBoundingBoxUnknownRow(object.tileId, object.objectId, object.objectType);
   };
 
+  const rowIds = content?.rowOrder || [];
   const editing = ui.annotationMode !== undefined;
   const hidden = !ui.showAnnotations;
   const classes = classNames("annotation-layer", { editing, hidden });
@@ -184,8 +198,8 @@ export const AnnotationLayer = observer(function AnnotationLayer({
           );
         })}
         <PreviewArrow
-          sourceX={sourceBoundingBox ? sourceBoundingBox.left + sourceBoundingBox.width / 2 : undefined}
-          sourceY={sourceBoundingBox ? sourceBoundingBox.top + sourceBoundingBox.height / 2 : undefined}
+          sourceX={previewArrowSourceX}
+          sourceY={previewArrowSourceY}
           targetX={mouseX}
           targetY={mouseY}
         />

--- a/src/components/tiles/table/use-tile-api.ts
+++ b/src/components/tiles/table/use-tile-api.ts
@@ -11,6 +11,7 @@ import { TableContentModelType } from "../../../models/tiles/table/table-content
 import { exportTableContentAsJson } from "../../../models/tiles/table/table-export";
 import { getLinkedTableIndex } from "../../../models/tiles/table-links";
 import { decipherCellId } from "../../../models/tiles/table/table-utils";
+import { OffsetModel } from "../../../models/annotations/clue-object";
 
 // Offsets for annotation bounding boxes
 const kCellTopOffset = -2.5;
@@ -84,6 +85,16 @@ export const useToolApi = ({
       return boundingBox;
     }
   }, [dataSet, getColumnLeft, getRowTop, measureColumnWidth, rowHeight, rows]);
+  const getObjectDefaultOffsets = useCallback((objectId: string, objectType?: string) => {
+    const offsets = OffsetModel.create({});
+    if (objectType === "cell") {
+      const boundingBox = getObjectBoundingBox(objectId, objectType);
+      if (boundingBox) {
+        offsets.setDy(boundingBox.height * -.5 + 2);
+      }
+    }
+    return offsets;
+  }, [getObjectBoundingBox]);
 
   const tileApi: ITileApi = useMemo(() => ({
     // TODO: we should be able to remove getTitle from the tool api. All other
@@ -103,8 +114,9 @@ export const useToolApi = ({
               ? getLinkedTableIndex(contentRef.current.metadata.id)
               : -1;
     },
-    getObjectBoundingBox
-  }), [exportContentAsTileJson, getContentHeight, contentRef, getObjectBoundingBox]);
+    getObjectBoundingBox,
+    getObjectDefaultOffsets
+  }), [exportContentAsTileJson, getContentHeight, contentRef, getObjectBoundingBox, getObjectDefaultOffsets]);
 
   useEffect(() => {
     onRegisterTileApi(tileApi);

--- a/src/components/tiles/tile-api.tsx
+++ b/src/components/tiles/tile-api.tsx
@@ -1,6 +1,6 @@
 import { createContext } from "react";
 import { Optional } from "utility-types";
-import { ObjectBoundingBox } from "../../models/annotations/clue-object";
+import { IOffsetModel, ObjectBoundingBox } from "../../models/annotations/clue-object";
 import { ITileExportOptions } from "../../models/tiles/tile-content-info";
 
 export type TileResizeEntry = Optional<ResizeObserverEntry,
@@ -19,6 +19,7 @@ export interface ITileApi {
   handleDocumentScroll?: (x: number, y: number) => void;
   handleTileResize?: (entry: TileResizeEntry) => void;
   getObjectBoundingBox?: (objectId: string, objectType?: string) => ObjectBoundingBox | undefined;
+  getObjectDefaultOffsets?: (objectId: string, objectType?: string) => IOffsetModel;
 }
 
 export interface ITileApiInterface {

--- a/src/models/annotations/clue-object.ts
+++ b/src/models/annotations/clue-object.ts
@@ -27,6 +27,7 @@ export const OffsetModel = types
     self.dy = dy;
   }
 }));
+export interface IOffsetModel extends Instance<typeof OffsetModel> {}
 
 export interface ObjectBoundingBox {
   left: number;


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/185539001

This PR addresses feedback related to the positioning of sparrows for table cells.
- It's now possible to specify default offsets for different target objects.
- Default offsets for table cells have been changed to the top center of the cell.