### PR TITLE
Identify data set types, add new image type

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
     // We've imported your old cypress plugins here.
     // You may want to clean this up later by importing these.
 
-    numTestsKeptInMemory: 0,
+    numTestsKeptInMemory: 2,
     setupNodeEvents(on, config) {
       const fetchConfigurationByFile = file => {
         const pathOfConfigurationFile = `config/cypress.${file}.json`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "d3": "^7.8.4",
         "d3-format": "^3.1.0",
         "d3-v6-tip": "^1.0.9",
+        "dayjs": "^1.11.9",
         "escape-string-regexp": "^5.0.0",
         "expr-eval": "^2.0.2",
         "file-saver": "^2.0.5",
@@ -2865,6 +2866,12 @@
       "version": "1.1.4",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@cypress/code-coverage/node_modules/dayjs": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
+      "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig==",
+      "dev": true
     },
     "node_modules/@cypress/code-coverage/node_modules/debug": {
       "version": "4.3.4",
@@ -9509,9 +9516,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.10.7",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.11.9",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.9.tgz",
+      "integrity": "sha512-QvzAURSbQ0pKdIye2txOzNaHmxtUBXerpY0FJsFXUMKbIZeFm5ht1LS/jFsrncjnmtv8HsG0W2g6c0zUjZWmpA=="
     },
     "node_modules/debug": {
       "version": "3.2.6",
@@ -23168,6 +23175,12 @@
           "version": "1.1.4",
           "dev": true
         },
+        "dayjs": {
+          "version": "1.10.7",
+          "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
+          "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig==",
+          "dev": true
+        },
         "debug": {
           "version": "4.3.4",
           "dev": true,
@@ -27601,8 +27614,9 @@
       }
     },
     "dayjs": {
-      "version": "1.10.7",
-      "dev": true
+      "version": "1.11.9",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.9.tgz",
+      "integrity": "sha512-QvzAURSbQ0pKdIye2txOzNaHmxtUBXerpY0FJsFXUMKbIZeFm5ht1LS/jFsrncjnmtv8HsG0W2g6c0zUjZWmpA=="
     },
     "debug": {
       "version": "3.2.6",

--- a/package.json
+++ b/package.json
@@ -222,6 +222,7 @@
     "d3": "^7.8.4",
     "d3-format": "^3.1.0",
     "d3-v6-tip": "^1.0.9",
+    "dayjs": "^1.11.9",
     "escape-string-regexp": "^5.0.0",
     "expr-eval": "^2.0.2",
     "file-saver": "^2.0.5",

--- a/src/models/data/attribute.test.ts
+++ b/src/models/data/attribute.test.ts
@@ -117,7 +117,10 @@ describe("DataSet Attributes", () => {
     ["2/23", "2/24"],
     ["2/23", "1", "2"],
     ["ccimg://fbrtdb.concord.org/devclass/-NcP-LmubeWUdANUM_vO", "1"],
-    ["ccimg://fbrtdb.concord.org/devclass/-NcP-LmubeWUdANUM_vO", "1", "a"]
+    ["ccimg://fbrtdb.concord.org/devclass/-NcP-LmubeWUdANUM_vO", "1", "a"],
+    // Maybe this should result in numeric but count of numbers is less than
+    // half of the non empty values, so the result is "categorical"
+    ["1", "2", "a", "2/23", "ccimg://fbrtdb.concord.org/img.png"]
   ];
 
   test("type", () => {
@@ -141,6 +144,7 @@ describe("DataSet Attributes", () => {
 ["2/23","1","2"] => "categorical"
 ["ccimg://fbrtdb.concord.org/devclass/-NcP-LmubeWUdANUM_vO","1"] => "categorical"
 ["ccimg://fbrtdb.concord.org/devclass/-NcP-LmubeWUdANUM_vO","1","a"] => "categorical"
+["1","2","a","2/23","ccimg://fbrtdb.concord.org/img.png"] => "categorical"
 `);
   });
 
@@ -166,6 +170,7 @@ describe("DataSet Attributes", () => {
 ["2/23","1","2"] => [["numeric",2],["date",1]]
 ["ccimg://fbrtdb.concord.org/devclass/-NcP-LmubeWUdANUM_vO","1"] => [["image",1],["numeric",1]]
 ["ccimg://fbrtdb.concord.org/devclass/-NcP-LmubeWUdANUM_vO","1","a"] => [["image",1],["numeric",1]]
+["1","2","a","2/23","ccimg://fbrtdb.concord.org/img.png"] => [["numeric",2],["date",1],["image",1]]
 `);
   });
 
@@ -191,6 +196,7 @@ describe("DataSet Attributes", () => {
 ["2/23","1","2"] => "numeric"
 ["ccimg://fbrtdb.concord.org/devclass/-NcP-LmubeWUdANUM_vO","1"] => "image"
 ["ccimg://fbrtdb.concord.org/devclass/-NcP-LmubeWUdANUM_vO","1","a"] => "categorical"
+["1","2","a","2/23","ccimg://fbrtdb.concord.org/img.png"] => "categorical"
 `);
   });
 });

--- a/src/models/data/attribute.test.ts
+++ b/src/models/data/attribute.test.ts
@@ -1,76 +1,198 @@
-import { Attribute } from "./attribute";
+import { Attribute, IAttributeSnapshot } from "./attribute";
 import { clone } from "lodash";
 
-test("Attribute functionality", () => {
-  const attribute = Attribute.create({ name: "foo" } as any);
-  expect(attribute.id).toBeDefined();
-  expect(attribute.name).toBe("foo");
-  expect(attribute.length).toBe(0);
+// run `npm run test -- -u attribute.test` to update the snapshots in this file
 
-  const copy = clone(attribute);
-  expect(copy.id).toBe(attribute.id);
-  expect(copy.name).toBe(attribute.name);
+function replacer(key: string, value: any) {
+  if(value instanceof Map) {
+    return [...value];
+  } else {
+    return value;
+  }
+}
 
-  attribute.setName("bar");
-  expect(attribute.name).toBe("bar");
-
-  attribute.setUnits("m");
-  expect(attribute.units).toBe("m");
-
-  attribute.addValue(1);
-  expect(attribute.length).toBe(1);
-  expect(attribute.value(0)).toBe(1);
-
-  attribute.addValues([2, 3]);
-  expect(attribute.length).toBe(3);
-  expect(attribute.value(1)).toBe(2);
-  expect(attribute.value(2)).toBe(3);
-
-  attribute.addValue(0, 0);
-  expect(attribute.length).toBe(4);
-  expect(attribute.value(0)).toBe(0);
-  expect(attribute.value(3)).toBe(3);
-
-  attribute.addValues([-2, -1], 0);
-  expect(attribute.length).toBe(6);
-  expect(attribute.value(0)).toBe(-2);
-  expect(attribute.value(5)).toBe(3);
-
-  attribute.setValue(2, 3);
-  expect(attribute.value(2)).toBe(3);
-  attribute.setValue(10, 10);
-
-  attribute.setValues([0, 1], [1, 2]);
-  expect(attribute.value(0)).toBe(1);
-  expect(attribute.value(1)).toBe(2);
-  attribute.setValues([10, 11], [10, 11]);
-
-  attribute.setValues([0, 1], [0]);
-  expect(attribute.value(0)).toBe(0);
-  expect(attribute.value(1)).toBe(2);
-
-  attribute.removeValues(2);
-  expect(attribute.length).toBe(5);
-  expect(attribute.value(2)).toBe(1);
-
-  attribute.removeValues(0, 2);
-  expect(attribute.length).toBe(3);
-  expect(attribute.value(0)).toBe(1);
-  attribute.removeValues(0, 0);
-  expect(attribute.length).toBe(3);
-  expect(attribute.value(0)).toBe(1);
-
-  const bar = Attribute.create({ name: "bar", values: [0, 1, 2] } as any);
-  expect(bar.name).toBe("bar");
-  expect(bar.length).toBe(3);
-
-  const bazSnap = bar.derive("baz");
-  expect(bazSnap.id).toBe(bar.id);
-  expect(bazSnap.name).toBe("baz");
-  expect(bazSnap.values && bazSnap.values.length).toBe(0);
-
-  const barSnap = bar.derive();
-  expect(barSnap.id).toBe(bar.id);
-  expect(barSnap.name).toBe(bar.name);
-  expect(barSnap.values && barSnap.values.length).toBe(0);
+// This should only apply to this test file, so it shouldn't mess up other tests
+// To be extra sure it requires the `testCases` key.
+expect.addSnapshotSerializer({
+  serialize(val, config, indentation, depth, refs, printer) {
+    return val.testCases.map(([inputValue, result]: [any, any]) =>
+      `${JSON.stringify(inputValue)} => ${JSON.stringify(result, replacer)}`)
+    .join("\n");
+  },
+  // Look for a value that has a testCases key with a value of an array
+  test(val: any): boolean {
+    return val?.testCases?.length > 0;
+  }
 });
+
+describe("DataSet Attributes", () => {
+  test("Basic attribute functionality", () => {
+    const attribute = Attribute.create({ name: "foo" } as any);
+    expect(attribute.id).toBeDefined();
+    expect(attribute.name).toBe("foo");
+    expect(attribute.length).toBe(0);
+
+    const copy = clone(attribute);
+    expect(copy.id).toBe(attribute.id);
+    expect(copy.name).toBe(attribute.name);
+
+    attribute.setName("bar");
+    expect(attribute.name).toBe("bar");
+
+    attribute.setUnits("m");
+    expect(attribute.units).toBe("m");
+
+    attribute.addValue(1);
+    expect(attribute.length).toBe(1);
+    expect(attribute.value(0)).toBe(1);
+
+    attribute.addValues([2, 3]);
+    expect(attribute.length).toBe(3);
+    expect(attribute.value(1)).toBe(2);
+    expect(attribute.value(2)).toBe(3);
+
+    attribute.addValue(0, 0);
+    expect(attribute.length).toBe(4);
+    expect(attribute.value(0)).toBe(0);
+    expect(attribute.value(3)).toBe(3);
+
+    attribute.addValues([-2, -1], 0);
+    expect(attribute.length).toBe(6);
+    expect(attribute.value(0)).toBe(-2);
+    expect(attribute.value(5)).toBe(3);
+
+    attribute.setValue(2, 3);
+    expect(attribute.value(2)).toBe(3);
+    attribute.setValue(10, 10);
+
+    attribute.setValues([0, 1], [1, 2]);
+    expect(attribute.value(0)).toBe(1);
+    expect(attribute.value(1)).toBe(2);
+    attribute.setValues([10, 11], [10, 11]);
+
+    attribute.setValues([0, 1], [0]);
+    expect(attribute.value(0)).toBe(0);
+    expect(attribute.value(1)).toBe(2);
+
+    attribute.removeValues(2);
+    expect(attribute.length).toBe(5);
+    expect(attribute.value(2)).toBe(1);
+
+    attribute.removeValues(0, 2);
+    expect(attribute.length).toBe(3);
+    expect(attribute.value(0)).toBe(1);
+    attribute.removeValues(0, 0);
+    expect(attribute.length).toBe(3);
+    expect(attribute.value(0)).toBe(1);
+  });
+  test("derive", () => {
+    const bar = Attribute.create({ name: "bar", values: [0, 1, 2] } as any);
+    expect(bar.name).toBe("bar");
+    expect(bar.length).toBe(3);
+
+    const bazSnap = bar.derive("baz");
+    expect(bazSnap.id).toBe(bar.id);
+    expect(bazSnap.name).toBe("baz");
+    expect(bazSnap.values && bazSnap.values.length).toBe(0);
+
+    const barSnap = bar.derive();
+    expect(barSnap.id).toBe(bar.id);
+    expect(barSnap.name).toBe(bar.name);
+    expect(barSnap.values && barSnap.values.length).toBe(0);
+  });
+
+  const valuesToTest: IAttributeSnapshot['values'][] = [
+    [0, 1, 2],
+    ["0", "1", "2"],
+    [1, "2", "3"],
+    ["a", "b", "c"],
+    ["a", "1", "2"],
+    ["", "1", "2"],
+    [undefined, "1", "2"],
+    ["", "a", "b"],
+    [undefined, "a", "b"],
+    ["1", "a", "a"],
+    ["", "1", "a"],
+    ["", "", "", "1", "a"],
+    ["2/23", "2/24"],
+    ["2/23", "1", "2"],
+    ["ccimg://fbrtdb.concord.org/devclass/-NcP-LmubeWUdANUM_vO", "1"],
+    ["ccimg://fbrtdb.concord.org/devclass/-NcP-LmubeWUdANUM_vO", "1", "a"]
+  ];
+
+  test("type", () => {
+    const testCases = valuesToTest.map(values => {
+      return [values, Attribute.create({name: "foo", values}).type];
+    });
+    expect({ testCases }).toMatchInlineSnapshot(`
+[0,1,2] => "numeric"
+["0","1","2"] => "numeric"
+[1,"2","3"] => "numeric"
+["a","b","c"] => "categorical"
+["a","1","2"] => "categorical"
+["","1","2"] => "numeric"
+[null,"1","2"] => "numeric"
+["","a","b"] => "categorical"
+[null,"a","b"] => "categorical"
+["1","a","a"] => "categorical"
+["","1","a"] => "categorical"
+["","","","1","a"] => "categorical"
+["2/23","2/24"] => "categorical"
+["2/23","1","2"] => "categorical"
+["ccimg://fbrtdb.concord.org/devclass/-NcP-LmubeWUdANUM_vO","1"] => "categorical"
+["ccimg://fbrtdb.concord.org/devclass/-NcP-LmubeWUdANUM_vO","1","a"] => "categorical"
+`);
+  });
+
+  test("typeCounts", () => {
+    const testCases = valuesToTest.map(values => {
+      return [values, Attribute.create({name: "foo", values}).typeCounts];
+    });
+    // This can be updated with `npm run test -- -u attribute.test`
+    expect({ testCases }).toMatchInlineSnapshot(`
+[0,1,2] => [["numeric",3]]
+["0","1","2"] => [["numeric",3]]
+[1,"2","3"] => [["numeric",3]]
+["a","b","c"] => []
+["a","1","2"] => [["numeric",2]]
+["","1","2"] => [["numeric",2]]
+[null,"1","2"] => [["numeric",2]]
+["","a","b"] => []
+[null,"a","b"] => []
+["1","a","a"] => [["numeric",1]]
+["","1","a"] => [["numeric",1]]
+["","","","1","a"] => [["numeric",1]]
+["2/23","2/24"] => [["date",2]]
+["2/23","1","2"] => [["numeric",2],["date",1]]
+["ccimg://fbrtdb.concord.org/devclass/-NcP-LmubeWUdANUM_vO","1"] => [["image",1],["numeric",1]]
+["ccimg://fbrtdb.concord.org/devclass/-NcP-LmubeWUdANUM_vO","1","a"] => [["image",1],["numeric",1]]
+`);
+  });
+
+  test("mostCommonType", () => {
+    const testCases = valuesToTest.map(values => {
+      return [values, Attribute.create({name: "foo", values}).mostCommonType];
+    });
+    // This can be updated with `npm run test -- -u attribute.test`
+    expect({ testCases }).toMatchInlineSnapshot(`
+[0,1,2] => "numeric"
+["0","1","2"] => "numeric"
+[1,"2","3"] => "numeric"
+["a","b","c"] => "categorical"
+["a","1","2"] => "numeric"
+["","1","2"] => "numeric"
+[null,"1","2"] => "numeric"
+["","a","b"] => "categorical"
+[null,"a","b"] => "categorical"
+["1","a","a"] => "categorical"
+["","1","a"] => "numeric"
+["","","","1","a"] => "numeric"
+["2/23","2/24"] => "date"
+["2/23","1","2"] => "numeric"
+["ccimg://fbrtdb.concord.org/devclass/-NcP-LmubeWUdANUM_vO","1"] => "image"
+["ccimg://fbrtdb.concord.org/devclass/-NcP-LmubeWUdANUM_vO","1","a"] => "categorical"
+`);
+  });
+});
+
+

--- a/src/models/data/data-set-types.ts
+++ b/src/models/data/data-set-types.ts
@@ -1,6 +1,6 @@
 import { Instance, types } from "mobx-state-tree";
 import { uniqueSortableId } from "../../utilities/js-utils";
-import { IValueType } from "./attribute";
+import { IValueType } from "./data-types";
 
 export const uniqueCaseId = () => `CASE${uniqueSortableId()}`;
 

--- a/src/models/data/data-set.ts
+++ b/src/models/data/data-set.ts
@@ -1,10 +1,11 @@
 import { cloneDeep, findIndex } from "lodash";
+import { observable } from "mobx";
 import { applyAction, getEnv, Instance, ISerializedActionCall,
           onAction, types, getSnapshot, SnapshotOut } from "mobx-state-tree";
-import { Attribute, IAttribute, IAttributeSnapshot, IValueType } from "./attribute";
+import { Attribute, IAttribute, IAttributeSnapshot } from "./attribute";
 import { uniqueId, uniqueSortableId } from "../../utilities/js-utils";
 import { CaseGroup } from "./data-set-types";
-import { observable } from "mobx";
+import { IValueType } from "./data-types";
 
 export const newCaseId = uniqueSortableId;
 

--- a/src/models/data/data-types.test.ts
+++ b/src/models/data/data-types.test.ts
@@ -69,7 +69,7 @@ describe("data-types", () => {
 
   test("isNumeric", () => {
     const valuesToTest: string[] = [
-      "", // <-- this seems like a bug
+      "",
       "123",
       "1E10",
       "1e10",
@@ -80,6 +80,7 @@ describe("data-types", () => {
       "0xFF",
       "0o10",
       "0b10",
+      "2,000" // <-- this should be a number but is not
     ];
     const testCases = valuesToTest.map(value => {
       return [value, isNumeric(value)];
@@ -96,6 +97,7 @@ describe("data-types", () => {
 "0xFF" => true
 "0o10" => true
 "0b10" => true
+"2,000" => false
 `);
   });
 });

--- a/src/models/data/data-types.test.ts
+++ b/src/models/data/data-types.test.ts
@@ -1,0 +1,101 @@
+import { isDate, isImageUrl, isNumeric } from "./data-types";
+
+expect.addSnapshotSerializer({
+  serialize(val, config, indentation, depth, refs, printer) {
+    return val.testCases.map(([inputValue, result]: [any, any]) =>
+      `${JSON.stringify(inputValue)} => ${JSON.stringify(result)}`)
+    .join("\n");
+  },
+  // Look for a value that has a testCases key with a value of an array
+  test(val: any): boolean {
+    return val?.testCases?.length > 0;
+  }
+});
+
+// run `npm run test -- -u data-types.test` to update the snapshots in this file
+
+describe("data-types", () => {
+  test("isDate", () => {
+    const valuesToTest: string[] = [
+      "2/3",
+      "2 / 3",
+      "02/23/1976",
+      "02/23/76",
+      "23/02/1976",
+      "02/31/1976",
+      "02/32/1976",
+      "02-23-1976",
+      "02/23",
+      "23/02",
+      "123"
+    ];
+    const testCases = valuesToTest.map(value => {
+      return [value, isDate(value)];
+    });
+    expect({ testCases }).toMatchInlineSnapshot(`
+"2/3" => true
+"2 / 3" => true
+"02/23/1976" => true
+"02/23/76" => true
+"23/02/1976" => true
+"02/31/1976" => true
+"02/32/1976" => true
+"02-23-1976" => true
+"02/23" => true
+"23/02" => true
+"123" => false
+`);
+  });
+
+  test("isImageUrl", () => {
+    const valuesToTest: string[] = [
+      "https://something.concord.org/hello.png",
+      "ccimg://fbrtdb.concord.org/hello.png",
+      "ccimg://fbrtdb.concord.org/anything.txt",
+      "ccimg://not-a-cc.domain.com/hello.png",
+      "random.string.com/"
+    ];
+    const testCases = valuesToTest.map(value => {
+      return [value, isImageUrl(value)];
+    });
+    expect({ testCases }).toMatchInlineSnapshot(`
+"https://something.concord.org/hello.png" => false
+"ccimg://fbrtdb.concord.org/hello.png" => true
+"ccimg://fbrtdb.concord.org/anything.txt" => true
+"ccimg://not-a-cc.domain.com/hello.png" => false
+"random.string.com/" => false
+`);
+  });
+
+  test("isNumeric", () => {
+    const valuesToTest: string[] = [
+      "", // <-- this seems like a bug
+      "123",
+      "1E10",
+      "1e10",
+      "1 E10",
+      "1E 10",
+      "1 E 10",
+      "-1.0",
+      "0xFF",
+      "0o10",
+      "0b10",
+    ];
+    const testCases = valuesToTest.map(value => {
+      return [value, isNumeric(value)];
+    });
+    expect({ testCases }).toMatchInlineSnapshot(`
+"" => false
+"123" => true
+"1E10" => true
+"1e10" => true
+"1 E10" => false
+"1E 10" => false
+"1 E 10" => false
+"-1.0" => true
+"0xFF" => true
+"0o10" => true
+"0b10" => true
+`);
+  });
+});

--- a/src/models/data/data-types.ts
+++ b/src/models/data/data-types.ts
@@ -1,0 +1,43 @@
+import { types } from "mobx-state-tree";
+import dayjs from "dayjs";
+import customParseFormat from "dayjs/plugin/customParseFormat";
+
+dayjs.extend(customParseFormat);
+const dayjsFormats = [
+  "MM/DD/YYYY",
+  "MM/DD/YY",
+  "MM/DD",
+  "M/D"
+];
+
+export const ValueType = types.union(types.number, types.string, types.undefined);
+export type IValueType = number | string | undefined;
+
+export function isNumeric(val: IValueType) {
+  return val !== "" && !isNaN(Number(val));
+}
+
+export function isDate(val: IValueType) {
+  // Technically a plain number can be timestamp but for this purpose we only
+  // care about non numeric string dates
+  if (typeof val !== "string" || isNumeric(val)) {
+    return false;
+  }
+
+  return dayjs(val, dayjsFormats).isValid();
+}
+
+export function isImageUrl(val: IValueType) {
+  if (typeof val !== "string") {
+    return false;
+  }
+
+  // We might need to support more advanced image detection in the future
+  // For now we just look for strings matching the URL for an user uploaded
+  // image. Like:
+  // ccimg://fbrtdb.concord.org/devclass/-NcP-LmubeWUdANUM_vO
+  // The ImageMap has a isImageUrl function but it will pickup pretty
+  // much any http URL. And I'd guess we don't want to add a dependency
+  // on the imageMap to this shared code.
+  return val.startsWith("ccimg://fbrtdb.concord.org");
+}

--- a/src/plugins/data-card/components/case-attribute.tsx
+++ b/src/plugins/data-card/components/case-attribute.tsx
@@ -12,6 +12,18 @@ import { getClipboardContent } from "../../../utilities/clipboard-utils";
 
 import '../data-card-tile.scss';
 
+const typeIcons = {
+  "date": "📅",
+  "categorical": "txt",
+  "numeric": "#",
+  "image": "📷",
+  "boundary": "?",
+  "color": "?",
+  "checkbox": "?",
+  "qualitative": "?",
+  "": "?"
+};
+
 interface IProps {
   model: ITileModel;
   caseId?: string;
@@ -213,6 +225,10 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
     {"has-image": gImageMap.isImageUrl(valueStr)}
   );
 
+  const typeIconClassNames = classNames(
+    `type-icon ${attrKey}`
+  );
+
   const deleteAttrButtonClassNames = classNames(
     `delete-attribute ${attrKey}`,
     { "show": currEditAttrId === attrKey }
@@ -222,6 +238,8 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
     "cell-value",
     { "default-label": looksLikeDefaultLabel(getLabel()) }
   );
+
+  const typeIcon = typeIcons[content.dataSet.attrFromID(attrKey).mostCommonType || ""];
 
   return (
     <div className={pairClassNames}>
@@ -265,6 +283,7 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
           <img src={imageUrl} className="image-value" />
         }
       </div>
+      <div className={typeIconClassNames} >{typeIcon}</div>
 
       { !readOnly &&
         <RemoveIconButton className={deleteAttrButtonClassNames} onClick={handleDeleteAttribute} />

--- a/src/plugins/data-card/data-card-tile.scss
+++ b/src/plugins/data-card/data-card-tile.scss
@@ -2,7 +2,6 @@
 
 $single-view-card-width: 359px;
 $name-width: 34%;
-$value-width: 66%;
 $data-row-min-height: 24px;
 $charcoal-light-border: rgb(206, 206, 206);
 $cell-padding: 0px 8px;
@@ -59,21 +58,21 @@ $default-button-border-color: #979797;
       font-style: italic;
       border-bottom-width: 0px;
 
-    .title-text-element {
-      .title-input-editing {
-        width: 100%;
+      .title-text-element {
+        .title-input-editing {
+          width: 100%;
+          height: 100%;
+          font-style: normal;
+          font-weight: 300;
+          text-align: center;
+          outline:1px solid $highlight-blue;
+        }
+      }
+      .title-text-element.editing {
+        width:100%;
         height: 100%;
-        font-style: normal;
-        font-weight: 300;
-        text-align: center;
-        outline:1px solid $highlight-blue;
       }
     }
-    .title-text-element.editing {
-      width:100%;
-      height: 100%;
-    }
-  }
 
 
 
@@ -210,12 +209,16 @@ $default-button-border-color: #979797;
         }
 
         .value {
-          width: $value-width;
+          flex: 1;
           font-weight: normal;
           color:$cell-text-color;
           .cell-value {
             padding:$cell-padding;
           }
+        }
+
+        .type-icon {
+          margin: 0 4px;
         }
 
         .delete-attribute {


### PR DESCRIPTION
This also increases the tests of the attribute model.
It introduces the `dayjs` dependency to help with date parsing.

To visualize the types it adds a type icon to the data card tile.