### PR TITLE
Offset positions when inserting variable chips in drawing (PT #183927775)

### DIFF
--- a/src/plugins/drawing/components/drawing-tile.tsx
+++ b/src/plugins/drawing/components/drawing-tile.tsx
@@ -69,9 +69,11 @@ const DrawingToolComponent: React.FC<IProps> = (props) => {
   const toolbarProps = useToolbarTileApi({ id: model.id, enabled: !readOnly, onRegisterTileApi, onUnregisterTileApi });
 
   const getVisibleCanvasSize = () => {
-    if (!drawingToolElement.current || !drawingToolElement.current.clientWidth || !drawingToolElement.current.clientHeight) return undefined;
+    if (!drawingToolElement.current 
+      || !drawingToolElement.current.clientWidth 
+      || !drawingToolElement.current.clientHeight) return undefined;
     return { x: drawingToolElement.current.clientWidth, y: drawingToolElement.current.clientHeight };
-  }
+  };
 
   return (
     <DrawingContentModelContext.Provider value={contentRef.current} >

--- a/src/plugins/drawing/components/drawing-tile.tsx
+++ b/src/plugins/drawing/components/drawing-tile.tsx
@@ -20,6 +20,7 @@ const DrawingToolComponent: React.FC<IProps> = (props) => {
   const contentRef = useCurrent(model.content as DrawingContentModelType);
   const [imageUrlToAdd, setImageUrlToAdd] = useState("");
   const hotKeys = useRef(new HotKeys());
+  const drawingToolElement = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!readOnly) {
@@ -67,6 +68,11 @@ const DrawingToolComponent: React.FC<IProps> = (props) => {
 
   const toolbarProps = useToolbarTileApi({ id: model.id, enabled: !readOnly, onRegisterTileApi, onUnregisterTileApi });
 
+  const getVisibleCanvasSize = () => {
+    if (!drawingToolElement.current || !drawingToolElement.current.clientWidth || !drawingToolElement.current.clientHeight) return undefined;
+    return { x: drawingToolElement.current.clientWidth, y: drawingToolElement.current.clientHeight };
+  }
+
   return (
     <DrawingContentModelContext.Provider value={contentRef.current} >
       <BasicEditableTileTitle
@@ -75,6 +81,7 @@ const DrawingToolComponent: React.FC<IProps> = (props) => {
         scale={scale}
       />
       <div
+        ref={drawingToolElement}
         className={classNames("drawing-tool", { "read-only": readOnly })}
         data-testid="drawing-tool"
         tabIndex={0}
@@ -86,6 +93,7 @@ const DrawingToolComponent: React.FC<IProps> = (props) => {
           tileElt={tileElt}
           scale={scale}
           setImageUrlToAdd={setImageUrlToAdd}
+          getVisibleCanvasSize={getVisibleCanvasSize}
           {...toolbarProps}
         />
         <DrawingLayerView

--- a/src/plugins/drawing/components/drawing-toolbar.tsx
+++ b/src/plugins/drawing/components/drawing-toolbar.tsx
@@ -89,7 +89,7 @@ export const ToolbarView: React.FC<IProps> = (
 
   const toolbarButtonProps: IToolbarButtonProps = {
     toolbarManager: drawingContent,
-    getVisibleCanvasSize: getVisibleCanvasSize,
+    getVisibleCanvasSize,
     togglePaletteState,
     clearPaletteState
   };

--- a/src/plugins/drawing/components/drawing-toolbar.tsx
+++ b/src/plugins/drawing/components/drawing-toolbar.tsx
@@ -17,10 +17,11 @@ import { ITileModel } from "../../../models/tiles/tile-model";
 import { useSettingFromStores } from "../../../hooks/use-stores";
 import { IPaletteState, IToolbarButtonProps, kClosedPalettesState, PaletteKey } from "../objects/drawing-object";
 import { getDrawingToolButtonComponent } from "./drawing-object-manager";
-import { VectorType } from "../model/drawing-basic-types";
+import { Point, VectorType } from "../model/drawing-basic-types";
 
 interface IProps extends IFloatingToolbarProps, IRegisterTileApiProps {
   model: ITileModel;
+  getVisibleCanvasSize: () => Point|undefined;
   setImageUrlToAdd: (url: string) => void;
 }
 
@@ -28,7 +29,7 @@ const defaultButtons = ["select", "line", "vector", "rectangle", "ellipse",
   "stamp", "stroke-color", "fill-color", "text", "image-upload", "duplicate", "delete"];
 
 export const ToolbarView: React.FC<IProps> = (
-              { documentContent, model, onIsEnabled, setImageUrlToAdd, ...others }: IProps) => {
+              { documentContent, model, onIsEnabled, setImageUrlToAdd, getVisibleCanvasSize, ...others }: IProps) => {
   const drawingContent = model.content as DrawingContentModelType;
   const toolbarButtonSetting = useSettingFromStores("tools", "drawing") as unknown as string[] | undefined;
   const toolbarButtons = toolbarButtonSetting || defaultButtons;
@@ -88,6 +89,7 @@ export const ToolbarView: React.FC<IProps> = (
 
   const toolbarButtonProps: IToolbarButtonProps = {
     toolbarManager: drawingContent,
+    getVisibleCanvasSize: getVisibleCanvasSize,
     togglePaletteState,
     clearPaletteState
   };

--- a/src/plugins/drawing/model/drawing-content.ts
+++ b/src/plugins/drawing/model/drawing-content.ts
@@ -2,7 +2,7 @@ import { types, Instance, SnapshotIn, getSnapshot, isStateTreeNode} from "mobx-s
 import { clone } from "lodash";
 import stringify from "json-stringify-pretty-compact";
 
-import { DefaultToolbarSettings, ToolbarSettings, VectorType, endShapesForVectorType } from "./drawing-basic-types";
+import { DefaultToolbarSettings, Point, ToolbarSettings, VectorType, endShapesForVectorType } from "./drawing-basic-types";
 import { kDrawingStateVersion, kDrawingTileType } from "./drawing-types";
 import { StampModel, StampModelType } from "./stamp";
 import { DrawingObjectMSTUnion } from "../components/drawing-object-manager";
@@ -87,9 +87,10 @@ export const DrawingContentModel = TileContentModel
       const { stroke, fill, strokeDashArray, strokeWidth, vectorType } = self;
       return { stroke, fill, strokeDashArray, strokeWidth, vectorType };
     },
-    objectsAtLocation(x: number, y: number) {
-      return self.objects.filter((obj) => {
-        return (obj.x === x && obj.y === y);
+    // Return the first object found that has its origin at the given point; or undefined if none.
+    objectAtLocation(pos: Point) {
+      return self.objects.find((obj) => {
+        return (obj.x === pos.x && obj.y === pos.y);
       });
     },
     exportJson(options?: ITileExportOptions) {

--- a/src/plugins/drawing/model/drawing-content.ts
+++ b/src/plugins/drawing/model/drawing-content.ts
@@ -2,7 +2,8 @@ import { types, Instance, SnapshotIn, getSnapshot, isStateTreeNode} from "mobx-s
 import { clone } from "lodash";
 import stringify from "json-stringify-pretty-compact";
 
-import { DefaultToolbarSettings, Point, ToolbarSettings, VectorType, endShapesForVectorType } from "./drawing-basic-types";
+import { DefaultToolbarSettings, Point, ToolbarSettings, VectorType, endShapesForVectorType } 
+  from "./drawing-basic-types";
 import { kDrawingStateVersion, kDrawingTileType } from "./drawing-types";
 import { StampModel, StampModelType } from "./stamp";
 import { DrawingObjectMSTUnion } from "../components/drawing-object-manager";

--- a/src/plugins/drawing/model/drawing-content.ts
+++ b/src/plugins/drawing/model/drawing-content.ts
@@ -87,6 +87,11 @@ export const DrawingContentModel = TileContentModel
       const { stroke, fill, strokeDashArray, strokeWidth, vectorType } = self;
       return { stroke, fill, strokeDashArray, strokeWidth, vectorType };
     },
+    objectsAtLocation(x: number, y: number) {
+      return self.objects.filter((obj) => {
+        return (obj.x === x && obj.y === y);
+      });
+    },
     exportJson(options?: ITileExportOptions) {
       // Translate image urls if necessary
       const {type, objects: originalObjects} = getSnapshot(self);

--- a/src/plugins/drawing/objects/drawing-object.ts
+++ b/src/plugins/drawing/objects/drawing-object.ts
@@ -197,6 +197,7 @@ export const kClosedPalettesState = { showStamps: false, showStroke: false, show
 
 export interface IToolbarButtonProps {
   toolbarManager: IToolbarManager;
+  getVisibleCanvasSize: () => Point|undefined;
   // TODO: the support for palettes is hard coded to specific tools
   togglePaletteState: (palette: PaletteKey, show?: boolean) => void;
   clearPaletteState: () => void;

--- a/src/plugins/shared-variables/drawing/drawing-utils.test.ts
+++ b/src/plugins/shared-variables/drawing/drawing-utils.test.ts
@@ -1,0 +1,39 @@
+import { RectangleObjectSnapshotForAdd } from "src/plugins/drawing/objects/rectangle";
+import { defaultDrawingContent } from "../../drawing/model/drawing-content";
+import { getValidInsertPosition } from "./drawing-utils";
+
+const mockGetVisibleCanvasSize = jest.fn(() => { return {x:200, y:100}} );
+
+const mockSettings = {
+    fill: "#666666",
+    stroke: "#888888",
+    strokeDashArray: "3,3",
+    strokeWidth: 5
+};
+
+const rect1: RectangleObjectSnapshotForAdd = {
+    id: "a",
+    type: "rectangle",
+    x: 10,
+    y: 10,
+    width: 10,
+    height: 10,
+    ...mockSettings
+};
+
+describe("getValidInsertPosition", () => {
+    it("Should return initial position", () => {
+        const content = defaultDrawingContent();
+        expect(getValidInsertPosition(content, mockGetVisibleCanvasSize)).toStrictEqual({ x: 10, y: 10});
+    });
+    it("Should increment position to avoid overlaps", () => {
+        const content = defaultDrawingContent();
+        content.addObject(rect1);
+        expect(getValidInsertPosition(content, mockGetVisibleCanvasSize)).toStrictEqual({ x: 35, y: 35});
+
+        content.addObject({...rect1, id: "b", x: 35, y: 35 });
+        content.addObject({...rect1, id: "c", x: 60, y: 60 });
+        content.addObject({...rect1, id: "d", x: 85, y: 85 });
+        expect(getValidInsertPosition(content, mockGetVisibleCanvasSize)).toStrictEqual({ x: 110, y: 10});
+    })
+});

--- a/src/plugins/shared-variables/drawing/drawing-utils.test.ts
+++ b/src/plugins/shared-variables/drawing/drawing-utils.test.ts
@@ -2,7 +2,7 @@ import { RectangleObjectSnapshotForAdd } from "src/plugins/drawing/objects/recta
 import { defaultDrawingContent } from "../../drawing/model/drawing-content";
 import { getValidInsertPosition } from "./drawing-utils";
 
-const mockGetVisibleCanvasSize = jest.fn(() => { return {x:200, y:100}} );
+const mockGetVisibleCanvasSize = jest.fn(() => { return {x:200, y:100};} );
 
 const mockSettings = {
     fill: "#666666",
@@ -35,5 +35,5 @@ describe("getValidInsertPosition", () => {
         content.addObject({...rect1, id: "c", x: 60, y: 60 });
         content.addObject({...rect1, id: "d", x: 85, y: 85 });
         expect(getValidInsertPosition(content, mockGetVisibleCanvasSize)).toStrictEqual({ x: 110, y: 10});
-    })
+    });
 });

--- a/src/plugins/shared-variables/drawing/drawing-utils.ts
+++ b/src/plugins/shared-variables/drawing/drawing-utils.ts
@@ -85,19 +85,19 @@ const INSERT_POSITION_MARGIN = 25;
 // Return a valid location to create a new object that is not right on top of an existing object.
 export function getValidInsertPosition(drawingContent: DrawingContentModelType, 
     getVisibleCanvasSize: () => Point | undefined) {
+  const canvasSize = getVisibleCanvasSize();
   const base_pos = {...INITIAL_INSERT_POSITION};
   let pos = {...base_pos};
   // Start at the initial position and try locations on a diagonal path.
   while (drawingContent.objectAtLocation(pos)) {
     pos.x += INSERT_POSITION_DELTA.x;
     pos.y += INSERT_POSITION_DELTA.y;
-    const size = getVisibleCanvasSize();
-    if (size) {
-      if (pos.x + INSERT_POSITION_MARGIN > size.x) {
+    if (canvasSize) {
+      if (pos.x + INSERT_POSITION_MARGIN > canvasSize.x) {
         // we've traversed the whole visible canvas and not found any available spot.  Give up.
         return INITIAL_INSERT_POSITION;
       }
-      if (pos.y + INSERT_POSITION_MARGIN > size.y) {
+      if (pos.y + INSERT_POSITION_MARGIN > canvasSize.y) {
         // Try a new diagonal starting from a new base position a little to the right.
         base_pos.x += INSERT_POSITION_BACKUP_DELTA.x;
         base_pos.y += INSERT_POSITION_BACKUP_DELTA.y;

--- a/src/plugins/shared-variables/drawing/drawing-utils.ts
+++ b/src/plugins/shared-variables/drawing/drawing-utils.ts
@@ -83,7 +83,8 @@ const INSERT_POSITION_BACKUP_DELTA = { x: 100, y: 0 };
 const INSERT_POSITION_MARGIN = 25;
 
 // Return a valid location to create a new object that is not right on top of an existing object.
-export function getValidInsertPosition(drawingContent: DrawingContentModelType, getVisibleCanvasSize: ()=>Point|undefined) {
+export function getValidInsertPosition(drawingContent: DrawingContentModelType, 
+    getVisibleCanvasSize: () => Point | undefined) {
   const base_pos = {...INITIAL_INSERT_POSITION};
   let pos = {...base_pos};
   // Start at the initial position and try locations on a diagonal path.
@@ -105,7 +106,7 @@ export function getValidInsertPosition(drawingContent: DrawingContentModelType, 
     }
   }
   return pos;
-  };
+  }
 
   export function addChipToContent(drawingContent: DrawingContentModelType, variableId: string, position: Point) {
   const variableChipSnapshot: VariableChipObjectSnapshotForAdd = {

--- a/src/plugins/shared-variables/drawing/drawing-utils.ts
+++ b/src/plugins/shared-variables/drawing/drawing-utils.ts
@@ -73,10 +73,6 @@ export function findVariable(drawingContent: DrawingContentModelType, variableId
   return variable;
 }
 
-export function locationIsAvailable(drawingContent: DrawingContentModelType, x: number, y: number) {
-  return (!drawingContent.objectsAtLocation(x, y).length);
-}
-
 export function addChipToContent(drawingContent: DrawingContentModelType, variableId: string, x?: number, y?: number) {
   const variableChipSnapshot: VariableChipObjectSnapshotForAdd = {
     type: "variable",

--- a/src/plugins/shared-variables/drawing/drawing-utils.ts
+++ b/src/plugins/shared-variables/drawing/drawing-utils.ts
@@ -73,6 +73,10 @@ export function findVariable(drawingContent: DrawingContentModelType, variableId
   return variable;
 }
 
+export function locationIsAvailable(drawingContent: DrawingContentModelType, x: number, y: number) {
+  return (!drawingContent.objectsAtLocation(x, y).length);
+}
+
 export function addChipToContent(drawingContent: DrawingContentModelType, variableId: string, x?: number, y?: number) {
   const variableChipSnapshot: VariableChipObjectSnapshotForAdd = {
     type: "variable",

--- a/src/plugins/shared-variables/drawing/variable-object.tsx
+++ b/src/plugins/shared-variables/drawing/variable-object.tsx
@@ -4,7 +4,7 @@ import { observer } from "mobx-react";
 import useResizeObserver from "use-resize-observer";
 import { VariableChip, VariableType } from "@concord-consortium/diagram-view";
 
-import { addChipToContent, findVariable, getOrFindSharedModel, locationIsAvailable } from "./drawing-utils";
+import { addChipToContent, findVariable, getOrFindSharedModel } from "./drawing-utils";
 import { useEditVariableDialog } from "../dialog/use-edit-variable-dialog";
 import { useInsertVariableDialog } from "../dialog/use-insert-variable-dialog";
 import { useNewVariableDialog } from "../dialog/use-new-variable-dialog";
@@ -123,24 +123,51 @@ export const drawingVariables = (drawingContent: DrawingContentModelType) => {
   return filteredVariables as VariableType[];
 };
 
+// Constants determining where we create objects that are inserted in default locations
+// rather than being placed by the user. The locations are staggered so that objects
+// don't get created right on top of each other.
+const INITIAL_INSERT_POSITION = { x: 10, y: 10 };
+const INSERT_POSITION_DELTA = { x: 25, y: 25 };
+const INSERT_POSITION_BACKUP_DELTA = { x: 100, y: 0 };
+const INSERT_POSITION_MARGIN = 25;
+
+// Return a valid location to create a new object that is not right on top of an existing object.
+const getValidInsertPosition = (drawingContent: DrawingContentModelType, getVisibleCanvasSize: ()=>Point|undefined) => {
+  let base_pos = {...INITIAL_INSERT_POSITION};
+  let pos = {...base_pos};
+  // Start at the initial position and try locations on a diagonal path.
+  while (drawingContent.objectAtLocation(pos)) {
+    pos.x += INSERT_POSITION_DELTA.x;
+    pos.y += INSERT_POSITION_DELTA.y;
+    const size = getVisibleCanvasSize();
+    if (size) {
+      if (pos.x + INSERT_POSITION_MARGIN > size.x) {
+        // we've traversed the whole visible canvas and not found any available spot.  Give up.
+        return INITIAL_INSERT_POSITION;
+      }
+      if (pos.y + INSERT_POSITION_MARGIN > size.y) {
+        // Try a new diagonal starting from a new base position a little to the right.
+        base_pos.x += INSERT_POSITION_BACKUP_DELTA.x;
+        base_pos.y += INSERT_POSITION_BACKUP_DELTA.y;
+        pos = {...base_pos};  
+      }
+    }
+  }
+  return pos;
+  }
+  
+
 interface IInsertVariableButton {
   toolbarManager: IToolbarManager;
+  getVisibleCanvasSize: () => Point|undefined;
 }
-export const InsertVariableButton = observer(({ toolbarManager }: IInsertVariableButton) => {
+export const InsertVariableButton = observer(({ toolbarManager, getVisibleCanvasSize }: IInsertVariableButton) => {
   const drawingContent = toolbarManager as DrawingContentModelType;
   const sharedModel = getOrFindSharedModel(drawingContent);
   const insertVariables = (variablesToInsert: VariableType[]) => {
-    let x = 25;
-    let y = 25;
-    const offset = 25;
     variablesToInsert.forEach(variable => {
-      while (!locationIsAvailable(drawingContent, x, y)) {
-        x += offset;
-        y += offset;
-      }
-      addChipToContent(drawingContent, variable.id, x, y);
-      x += offset;
-      y += offset;
+      const pos = getValidInsertPosition(drawingContent, getVisibleCanvasSize);
+      addChipToContent(drawingContent, variable.id, pos.x, pos.y);
     });
   };
   const { selfVariables, otherVariables, unusedVariables } = variableBuckets(drawingContent, sharedModel);

--- a/src/plugins/shared-variables/drawing/variable-object.tsx
+++ b/src/plugins/shared-variables/drawing/variable-object.tsx
@@ -182,13 +182,15 @@ export const InsertVariableButton = observer(({ toolbarManager, getVisibleCanvas
 
 interface INewVariableButtonProps {
   toolbarManager: IToolbarManager;
+  getVisibleCanvasSize: () => Point|undefined;
 }
-export const NewVariableButton = observer(({ toolbarManager }: INewVariableButtonProps) => {
+export const NewVariableButton = observer(({ toolbarManager, getVisibleCanvasSize }: INewVariableButtonProps) => {
   const drawingContent = useContext(DrawingContentModelContext);
   const sharedModel = getOrFindSharedModel(drawingContent) as SharedVariablesType;
   const addVariable = (variable: VariableType) => {
     const variableId = variable.id;
-    addChipToContent(drawingContent, variableId);
+    const pos = getValidInsertPosition(drawingContent, getVisibleCanvasSize);
+    addChipToContent(drawingContent, variableId, pos.x, pos.y);
   };
   const [showVariableDialog] = useNewVariableDialog({ addVariable, sharedModel });
 

--- a/src/plugins/shared-variables/drawing/variable-object.tsx
+++ b/src/plugins/shared-variables/drawing/variable-object.tsx
@@ -4,7 +4,7 @@ import { observer } from "mobx-react";
 import useResizeObserver from "use-resize-observer";
 import { VariableChip, VariableType } from "@concord-consortium/diagram-view";
 
-import { addChipToContent, findVariable, getOrFindSharedModel } from "./drawing-utils";
+import { addChipToContent, findVariable, getOrFindSharedModel, locationIsAvailable } from "./drawing-utils";
 import { useEditVariableDialog } from "../dialog/use-edit-variable-dialog";
 import { useInsertVariableDialog } from "../dialog/use-insert-variable-dialog";
 import { useNewVariableDialog } from "../dialog/use-new-variable-dialog";
@@ -130,10 +130,14 @@ export const InsertVariableButton = observer(({ toolbarManager }: IInsertVariabl
   const drawingContent = toolbarManager as DrawingContentModelType;
   const sharedModel = getOrFindSharedModel(drawingContent);
   const insertVariables = (variablesToInsert: VariableType[]) => {
-    let x = 250;
-    let y = 50;
+    let x = 25;
+    let y = 25;
     const offset = 25;
     variablesToInsert.forEach(variable => {
+      while (!locationIsAvailable(drawingContent, x, y)) {
+        x += offset;
+        y += offset;
+      }
       addChipToContent(drawingContent, variable.id, x, y);
       x += offset;
       y += offset;

--- a/src/plugins/shared-variables/drawing/variable-object.tsx
+++ b/src/plugins/shared-variables/drawing/variable-object.tsx
@@ -133,7 +133,7 @@ const INSERT_POSITION_MARGIN = 25;
 
 // Return a valid location to create a new object that is not right on top of an existing object.
 const getValidInsertPosition = (drawingContent: DrawingContentModelType, getVisibleCanvasSize: ()=>Point|undefined) => {
-  let base_pos = {...INITIAL_INSERT_POSITION};
+  const base_pos = {...INITIAL_INSERT_POSITION};
   let pos = {...base_pos};
   // Start at the initial position and try locations on a diagonal path.
   while (drawingContent.objectAtLocation(pos)) {
@@ -154,7 +154,7 @@ const getValidInsertPosition = (drawingContent: DrawingContentModelType, getVisi
     }
   }
   return pos;
-  }
+  };
   
 
 interface IInsertVariableButton {

--- a/src/plugins/shared-variables/drawing/variable-object.tsx
+++ b/src/plugins/shared-variables/drawing/variable-object.tsx
@@ -121,7 +121,7 @@ export const drawingVariables = (drawingContent: DrawingContentModelType) => {
   const variables = variableIds.map(id => findVariable(drawingContent, id));
   const filteredVariables = variables.filter(variable => variable !== undefined);
   return filteredVariables as VariableType[];
-};  
+};
 
 interface IInsertVariableButton {
   toolbarManager: IToolbarManager;


### PR DESCRIPTION
Adds an algorithm that finds a location that is not already occupied when inserting variables into a drawing.

Can be tested in units that include shared variables, such as m2s.  A diagram tile as well as a drawing tile is necessary in order to create variables and test this.

I would be interested in feedback on whether there is a more elegant way to get the drawing toolbar button access to know the actual size of the visible drawing area.  I did this by passing a `getVisibleCanvasSize` method down from the tile level to the toolbar and then the individual button.