### PR TITLE
Add log calls to undo & redo (PT #185847005)

### DIFF
--- a/src/models/document/document.test.ts
+++ b/src/models/document/document.test.ts
@@ -178,6 +178,16 @@ describe("document model", () => {
     expect(document.content!.tileMap.size).toBe(0);
   });
 
+  it("allows undo and redo", () => {
+    const result = document.addTile("text");
+    console.log('result', result);
+    expect(document.content!.tileMap.size).toBe(1);
+    document.undoLastAction();
+    expect(document.content!.tileMap.size).toBe(0);
+    document.redoLastAction();
+    expect(document.content!.tileMap.size).toBe(1);
+  });
+
   it("allows the visibility to be toggled", () => {
     document.toggleVisibility();
     expect(document.visibility).toBe("private");

--- a/src/models/document/document.test.ts
+++ b/src/models/document/document.test.ts
@@ -1,8 +1,11 @@
-import { getSnapshot } from "mobx-state-tree";
+import { getSnapshot, Instance } from "mobx-state-tree";
 import { createDocumentModel, DocumentModelType } from "./document";
 import { PersonalDocument, ProblemDocument } from "./document-types";
 import { createSingleTileContent } from "../../utilities/test-utils";
 import { TextContentModelType } from "../tiles/text/text-content";
+import { expectEntryToBeComplete } from "../history/undo-store-test-utils";
+import { TreeManager } from "../history/tree-manager";
+import { LogEventName } from "../../lib/logger-types";
 
 // This is needed so MST can deserialize snapshots referring to tools
 import { registerTileTypes } from "../../register-tile-types";
@@ -11,7 +14,11 @@ registerTileTypes(["Geometry", "Text"]);
 // mock Logger calls
 const mockLogTileDocumentEvent = jest.fn();
 jest.mock("../tiles/log/log-tile-document-event", () => ({
-  logTileDocumentEvent: (...args: any[]) => mockLogTileDocumentEvent()
+  logTileDocumentEvent: (...args: any[]) => mockLogTileDocumentEvent(...args)
+}));
+const mockLogDocumentEvent = jest.fn();
+jest.mock("./log-document-event", () => ({
+  logDocumentEvent: (...args: any[]) => mockLogDocumentEvent(...args)
 }));
 
 const mockUserContext = { appMode: "authed", classHash: "class-1" };
@@ -178,14 +185,33 @@ describe("document model", () => {
     expect(document.content!.tileMap.size).toBe(0);
   });
 
-  it("allows undo and redo", () => {
+  it("allows undo and redo", async () => {
+    document.treeMonitor!.enabled = true;
+    const manager = document.treeManagerAPI as Instance<typeof TreeManager>;
+
     const result = document.addTile("text");
-    console.log('result', result);
+    await expectEntryToBeComplete(manager, 1);
     expect(document.content!.tileMap.size).toBe(1);
+
     document.undoLastAction();
+    await expectEntryToBeComplete(manager, 2);
     expect(document.content!.tileMap.size).toBe(0);
+
     document.redoLastAction();
+    await expectEntryToBeComplete(manager, 3);
     expect(document.content!.tileMap.size).toBe(1);
+
+    expect(mockLogDocumentEvent).toHaveBeenCalledTimes(2);
+    expect(mockLogDocumentEvent).toHaveBeenNthCalledWith(1,
+      LogEventName.TILE_UNDO,
+      expect.objectContaining({ targetAction: "/addTile" }),
+      'undo'
+    );
+    expect(mockLogDocumentEvent).toHaveBeenNthCalledWith(2,
+      LogEventName.TILE_REDO,
+      expect.objectContaining({ targetAction: "/addTile" }),
+      'redo'
+    );
   });
 
   it("allows the visibility to be toggled", () => {

--- a/src/models/document/document.test.ts
+++ b/src/models/document/document.test.ts
@@ -189,7 +189,7 @@ describe("document model", () => {
     document.treeMonitor!.enabled = true;
     const manager = document.treeManagerAPI as Instance<typeof TreeManager>;
 
-    const result = document.addTile("text");
+    document.addTile("text");
     await expectEntryToBeComplete(manager, 1);
     expect(document.content!.tileMap.size).toBe(1);
 

--- a/src/models/document/document.ts
+++ b/src/models/document/document.ts
@@ -324,16 +324,24 @@ export const DocumentModel = Tree.named("Document")
     undoLastAction() {
       const undoManager = self.treeManagerAPI?.undoManager;
       if (undoManager?.canUndo) {
-        undoManager.undo();
-        const logParams: IDocumentLogEvent = {document: self as DocumentModelType};
+        const {id, action} = undoManager.undo();
+        const logParams: IDocumentLogEvent = {
+          document: self as DocumentModelType,
+          targetAction: action,
+          targetEventId: id
+        };
         logDocumentEvent(LogEventName.TILE_UNDO, logParams, LogEventMethod.UNDO);
       }
     },
     redoLastAction() {
       const undoManager = self.treeManagerAPI?.undoManager;
       if (undoManager?.canRedo) {
-        undoManager.redo();
-        const logParams: IDocumentLogEvent = {document: self as DocumentModelType};
+        const {id, action} = undoManager.redo();
+        const logParams: IDocumentLogEvent = {
+          document: self as DocumentModelType,
+          targetAction: action,
+          targetEventId: id
+        };
         logDocumentEvent(LogEventName.TILE_REDO, logParams, LogEventMethod.REDO);
       }
     },

--- a/src/models/document/document.ts
+++ b/src/models/document/document.ts
@@ -25,6 +25,8 @@ import { ISharedModelDocumentManager, SharedModelDocumentManager } from "./share
 import { ITileEnvironment } from "../tiles/tile-content";
 import { TreeManager } from "../history/tree-manager";
 import { ESupportType } from "../curriculum/support";
+import { IDocumentLogEvent, logDocumentEvent } from "./log-document-event";
+import { LogEventMethod, LogEventName } from "../../lib/logger-types";
 
 interface IMatchPropertiesOptions {
   isTeacherDocument?: boolean;
@@ -323,12 +325,16 @@ export const DocumentModel = Tree.named("Document")
       const undoManager = self.treeManagerAPI?.undoManager;
       if (undoManager?.canUndo) {
         undoManager.undo();
+        const logParams: IDocumentLogEvent = {document: self as DocumentModelType};
+        logDocumentEvent(LogEventName.TILE_UNDO, logParams, LogEventMethod.UNDO);
       }
     },
     redoLastAction() {
       const undoManager = self.treeManagerAPI?.undoManager;
       if (undoManager?.canRedo) {
         undoManager.redo();
+        const logParams: IDocumentLogEvent = {document: self as DocumentModelType};
+        logDocumentEvent(LogEventName.TILE_REDO, logParams, LogEventMethod.REDO);
       }
     },
   }));

--- a/src/models/history/undo-store-test-utils.ts
+++ b/src/models/history/undo-store-test-utils.ts
@@ -1,0 +1,28 @@
+import { Instance } from "@concord-consortium/mobx-state-tree";
+import { when } from "mobx";
+import { TreeManager, CDocument } from "./tree-manager";
+
+// TODO: it would nicer to use a custom Jest matcher here so we can
+// provide a better error message when it fails
+export async function expectEntryToBeComplete(manager: Instance<typeof TreeManager>, length: number) {
+  const changeDocument = manager.document as Instance<typeof CDocument>;
+  let timedOut = false;
+  try {
+    await when(
+      () => changeDocument.history.length >= length && changeDocument.history.at(length-1)?.state === "complete",
+      {timeout: 100});
+  } catch (e) {
+    timedOut = true;
+  }
+  expect({
+    historyLength: changeDocument.history.length,
+    lastEntryState: changeDocument.history.at(-1)?.state,
+    activeExchanges: changeDocument.history.at(-1)?.activeExchanges.toJSON(),
+    timedOut
+  }).toEqual({
+    historyLength: length,
+    lastEntryState: "complete",
+    activeExchanges: [],
+    timedOut: false
+  });
+}

--- a/src/models/history/undo-store.test.ts
+++ b/src/models/history/undo-store.test.ts
@@ -14,7 +14,7 @@ import { when } from "mobx";
 import { CDocument, TreeManager } from "./tree-manager";
 import { HistoryEntrySnapshot } from "./history";
 import { withoutUndo } from "./without-undo";
-
+import { expectEntryToBeComplete } from "./undo-store-test-utils";
 // way to get a writable reference to libDebug
 const libDebug = require("../../lib/debug");
 
@@ -895,27 +895,3 @@ async function expectUpdateToBeCalledTimes(testTile: TestTileType, times: number
   return expect(updateCalledTimes).resolves.toBeUndefined();
 }
 
-// TODO: it would nicer to use a custom Jest matcher here so we can
-// provide a better error message when it fails
-async function expectEntryToBeComplete(manager: Instance<typeof TreeManager>, length: number) {
-  const changeDocument = manager.document as Instance<typeof CDocument>;
-  let timedOut = false;
-  try {
-    await when(
-      () => changeDocument.history.length >= length && changeDocument.history.at(length-1)?.state === "complete",
-      {timeout: 100});
-  } catch (e) {
-    timedOut = true;
-  }
-  expect({
-    historyLength: changeDocument.history.length,
-    lastEntryState: changeDocument.history.at(-1)?.state,
-    activeExchanges: changeDocument.history.at(-1)?.activeExchanges.toJSON(),
-    timedOut
-  }).toEqual({
-    historyLength: length,
-    lastEntryState: "complete",
-    activeExchanges: [],
-    timedOut: false
-  });
-}

--- a/src/models/history/undo-store.ts
+++ b/src/models/history/undo-store.ts
@@ -9,8 +9,14 @@ export interface IUndoManager {
   redoLevels : number;
   canUndo : boolean;
   canRedo : boolean;
-  undo() : void;
-  redo() : void;
+  undo() : IUndoInformation;
+  redo() : IUndoInformation;
+}
+
+// Information that is returned by undo and redo calls
+export interface IUndoInformation {
+  id: string|undefined,
+  action: string|undefined
 }
 
 export const UndoStore = types
@@ -165,6 +171,10 @@ export const UndoStore = types
       applyPatchesToTrees(entryToUndo, HistoryOperation.Undo);
 
       self.undoIdx--;
+      return {
+        id: entryToUndo.id,
+        action: entryToUndo.action
+      };
     },
     redo() {
       if (!self.canRedo) {
@@ -181,6 +191,10 @@ export const UndoStore = types
       applyPatchesToTrees(entryToRedo, HistoryOperation.Redo);
 
       self.undoIdx++;
+      return {
+        id: entryToRedo.id,
+        action: entryToRedo.action
+      };
     },
   };
 });


### PR DESCRIPTION
Adding logging of undo and redo operations.

Ideally one would log what operation was undone or redone. However, I don't see any simple way to do that, since at best all we have access to would be the tree diffs.  Unless I'm missing something?  If it's not possible, I do think just logging that an undo happened is better than nothing.

I tried to add a test, to which I was going to add testing that the log messages actually get sent, but for some reason undo does not seem to be available in the test environment.  Again, I am probably missing some simple thing.

So I need a little help here. This task goes pretty deep into the internals that I don't yet understand.