### PR TITLE
185903129-limit-resource-panel-width

### DIFF
--- a/src/components/navigation/nav-tab-panel.sass
+++ b/src/components/navigation/nav-tab-panel.sass
@@ -1,9 +1,6 @@
 @import ../vars
 
 .resource-and-chat-panel
-  display: flex
-  flex-direction: row
-  justify-content: flex-start
   position: relative
   // Split the remaing width in .workspace with the primary workspace
   flex: 1
@@ -17,6 +14,7 @@
     // Split width between the tabs and the chat panel
     display: flex
     width: 100%
+    height: 100%
     .top-row
       display: flex
       align-items: center

--- a/src/components/navigation/nav-tab-panel.sass
+++ b/src/components/navigation/nav-tab-panel.sass
@@ -7,11 +7,14 @@
   position: relative
   // Split the remaing width in .workspace with the primary workspace
   flex: 1
+  // Allow the width to be less than what is required by the content inside
+  min-width: 0
   transition-duration: .5s
   background-color: white
   border-radius: 0 6px 0 0
 
   .nav-tab-panel
+    // Split width between the tabs and the chat panel
     display: flex
     width: 100%
     .top-row
@@ -102,6 +105,8 @@
       // stretch the tabs out horizontally in their container to take all space not used
       // by the chat panel
       flex: 1
+      // Allow the element to get smaller than what its content requires
+      min-width: 0
       display: flex
       flex-direction: column
 

--- a/src/components/workspace/resize-panel-divider.scss
+++ b/src/components/workspace/resize-panel-divider.scss
@@ -2,19 +2,18 @@
 
 .divider-container {
   z-index: 1;
-  display: flex;
-  flex-direction: row;
   position: relative;
   margin-right: 2px;
   margin-left: 2px;
   transition-duration: .5s;
 
   .resize-panel-divider {
+    height: 100%;
+    padding-top: 4px;
     display: flex;
     align-items: center;
     flex-direction: column;
     justify-content: center;
-    margin-top: 4px;
 
     &.divider-min {
       align-items: flex-start;
@@ -41,6 +40,7 @@
     }
   }
   .expand-handles-container {
+    height: 100%;
     display: flex;
     flex-direction: row;
     position: relative;


### PR DESCRIPTION
Add some min-width properties so wide content doesn't cause the left side to take extra width.

Also remove some flex containers which were just being used to set the height of a single child.