### PR TITLE
185815546 do not distort attribute-less table's title cell

### DIFF
--- a/src/components/tiles/table/editable-table-title.tsx
+++ b/src/components/tiles/table/editable-table-title.tsx
@@ -23,6 +23,7 @@ export const EditableTableTitle: React.FC<IProps> = observer(function EditableTa
   getLinkIndex, onBeginEdit, onEndEdit, onLinkGeometryClick
 }) {
 
+  console.log("| EditableTableTitle: titleCellWidth: ", titleCellWidth, " titleCellHeight: ", titleCellHeight);
   verifyAlive(content, "EditableTableTile");
 
   // content.title and observer() allow this component to re-render
@@ -59,7 +60,7 @@ export const EditableTableTitle: React.FC<IProps> = observer(function EditableTa
                             { "table-title-editing": isEditing, "table-title-default": isDefaultTitle });
   const style = { width: titleCellWidth, height: titleCellHeight };
   return (
-    <div className={classes} style={style} onClick={handleClick}>
+    <div className={classes} style={style} onClick={handleClick}>ME
       {isEditing
         ? <HeaderCellInput style={style} value={editingTitle || ""}
             onKeyDown={handleKeyDown} onChange={setEditingTitle} onClose={handleClose} />

--- a/src/components/tiles/table/editable-table-title.tsx
+++ b/src/components/tiles/table/editable-table-title.tsx
@@ -59,10 +59,7 @@ export const EditableTableTitle: React.FC<IProps> = observer(function EditableTa
   const isDefaultTitle = title && /Table\s+(\d+)\s*$/.test(title);
   const classes = classNames("editable-header-cell", className,
                             { "table-title-editing": isEditing, "table-title-default": isDefaultTitle });
-
-  const hCalc = titleCellHeight > (kHeaderRowHeight * 3) ? kHeaderRowHeight : titleCellHeight;
-  const wCalc = titleCellWidth < kDefaultColumnWidth ? kDefaultColumnWidth : titleCellWidth;
-  const style = { width: wCalc, height: hCalc, };
+  const style = { width: titleCellWidth, height: titleCellHeight };
 
   return (
     <div className={classes} style={style} onClick={handleClick}>

--- a/src/components/tiles/table/editable-table-title.tsx
+++ b/src/components/tiles/table/editable-table-title.tsx
@@ -4,6 +4,7 @@ import React, { useState } from "react";
 import { TableContentModelType } from "../../../models/tiles/table/table-content";
 import { verifyAlive } from "../../../utilities/mst-utils";
 import { HeaderCellInput } from "./header-cell-input";
+import { kDefaultColumnWidth, kHeaderRowHeight } from "./table-types";
 
 interface IProps {
   content: TableContentModelType;
@@ -23,7 +24,6 @@ export const EditableTableTitle: React.FC<IProps> = observer(function EditableTa
   getLinkIndex, onBeginEdit, onEndEdit, onLinkGeometryClick
 }) {
 
-  console.log("| EditableTableTitle: titleCellWidth: ", titleCellWidth, " titleCellHeight: ", titleCellHeight);
   verifyAlive(content, "EditableTableTile");
 
   // content.title and observer() allow this component to re-render
@@ -55,12 +55,17 @@ export const EditableTableTitle: React.FC<IProps> = observer(function EditableTa
     onEndEdit?.(accept && trimTitle ? trimTitle : undefined);
     setIsEditing(false);
   };
+
   const isDefaultTitle = title && /Table\s+(\d+)\s*$/.test(title);
   const classes = classNames("editable-header-cell", className,
                             { "table-title-editing": isEditing, "table-title-default": isDefaultTitle });
-  const style = { width: titleCellWidth, height: titleCellHeight };
+
+  const hCalc = titleCellHeight > (kHeaderRowHeight * 3) ? kHeaderRowHeight : titleCellHeight;
+  const wCalc = titleCellWidth < kDefaultColumnWidth ? kDefaultColumnWidth : titleCellWidth;
+  const style = { width: wCalc, height: hCalc, };
+
   return (
-    <div className={classes} style={style} onClick={handleClick}>ME
+    <div className={classes} style={style} onClick={handleClick}>
       {isEditing
         ? <HeaderCellInput style={style} value={editingTitle || ""}
             onKeyDown={handleKeyDown} onChange={setEditingTitle} onClose={handleClose} />

--- a/src/components/tiles/table/editable-table-title.tsx
+++ b/src/components/tiles/table/editable-table-title.tsx
@@ -4,7 +4,6 @@ import React, { useState } from "react";
 import { TableContentModelType } from "../../../models/tiles/table/table-content";
 import { verifyAlive } from "../../../utilities/mst-utils";
 import { HeaderCellInput } from "./header-cell-input";
-import { kDefaultColumnWidth, kHeaderRowHeight } from "./table-types";
 
 interface IProps {
   content: TableContentModelType;

--- a/src/components/tiles/table/use-title-size.ts
+++ b/src/components/tiles/table/use-title-size.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from "react";
-import { isDataColumn, kCellLineHeight, kControlsColumnWidth, kDefaultColumnWidth, kTitlePadding,
+import { isDataColumn, kCellLineHeight, kControlsColumnWidth, kDefaultColumnWidth, kHeaderRowHeight, kTitlePadding,
   TColumn } from "./table-types";
 import { measureTextLines } from "../hooks/use-measure-text";
 import { IDataSet } from "../../../models/data/data-set";
@@ -29,13 +29,16 @@ export const useTitleSize = ({ readOnly, columns, dataSet, measureColumnWidth, r
                       1 - (readOnly ? 0 : kControlsColumnWidth));
     };
     rowChanges; // eslint-disable-line no-unused-expressions
-    return getTitleCellWidthFromColumns();
+    const widthFromColumns = getTitleCellWidthFromColumns();
+    return widthFromColumns < kDefaultColumnWidth ? kDefaultColumnWidth : widthFromColumns;
   }, [readOnly, columns, dataSet, measureColumnWidth, rowChanges]);
 
   const getTitleHeight = useCallback(() => {
     const font = `700 ${defaultFont}`;
+    // TODO - table does not currently render multi-line titles, but leaving this calc in place
     const lines = measureTextLines(dataSet.name || 'Table 8', titleCellWidth - 2 * kTitlePadding, font);
-    return lines * kCellLineHeight + 2 * kTitlePadding;
+    const calculatedHeight = lines * kCellLineHeight + 2 * kTitlePadding;
+    return calculatedHeight > (kHeaderRowHeight + 2 * kTitlePadding) ? kHeaderRowHeight : calculatedHeight;
   }, [dataSet, titleCellWidth]);
 
   return { titleCellWidth, getTitleHeight };


### PR DESCRIPTION
As described in [PT#185815546](https://www.pivotaltracker.com/story/show/185815546) this prevents the table from looking distorted if it has been linked to a DataCard deck, and then has all of its attributes removed.  

Note - the table title at the moment, does not adjust it's height for additional lines.  This PR does not address that issue