### PR TITLE
fix image being identified as date

### DIFF
--- a/src/models/data/attribute.test.ts
+++ b/src/models/data/attribute.test.ts
@@ -118,6 +118,8 @@ describe("DataSet Attributes", () => {
     ["2/23", "1", "2"],
     ["ccimg://fbrtdb.concord.org/devclass/-NcP-LmubeWUdANUM_vO", "1"],
     ["ccimg://fbrtdb.concord.org/devclass/-NcP-LmubeWUdANUM_vO", "1", "a"],
+    // This was being categorized as both a date and an image. It no longer is.
+    ["ccimg://fbrtdb.concord.org/democlass1/-NdC3tVdE70ngANCam6q"],
     // Maybe this should result in numeric but count of numbers is less than
     // half of the non empty values, so the result is "categorical"
     ["1", "2", "a", "2/23", "ccimg://fbrtdb.concord.org/img.png"]
@@ -144,6 +146,7 @@ describe("DataSet Attributes", () => {
 ["2/23","1","2"] => "categorical"
 ["ccimg://fbrtdb.concord.org/devclass/-NcP-LmubeWUdANUM_vO","1"] => "categorical"
 ["ccimg://fbrtdb.concord.org/devclass/-NcP-LmubeWUdANUM_vO","1","a"] => "categorical"
+["ccimg://fbrtdb.concord.org/democlass1/-NdC3tVdE70ngANCam6q"] => "categorical"
 ["1","2","a","2/23","ccimg://fbrtdb.concord.org/img.png"] => "categorical"
 `);
   });
@@ -170,6 +173,7 @@ describe("DataSet Attributes", () => {
 ["2/23","1","2"] => [["numeric",2],["date",1]]
 ["ccimg://fbrtdb.concord.org/devclass/-NcP-LmubeWUdANUM_vO","1"] => [["image",1],["numeric",1]]
 ["ccimg://fbrtdb.concord.org/devclass/-NcP-LmubeWUdANUM_vO","1","a"] => [["image",1],["numeric",1]]
+["ccimg://fbrtdb.concord.org/democlass1/-NdC3tVdE70ngANCam6q"] => [["image",1]]
 ["1","2","a","2/23","ccimg://fbrtdb.concord.org/img.png"] => [["numeric",2],["date",1],["image",1]]
 `);
   });
@@ -196,6 +200,7 @@ describe("DataSet Attributes", () => {
 ["2/23","1","2"] => "numeric"
 ["ccimg://fbrtdb.concord.org/devclass/-NcP-LmubeWUdANUM_vO","1"] => "image"
 ["ccimg://fbrtdb.concord.org/devclass/-NcP-LmubeWUdANUM_vO","1","a"] => "categorical"
+["ccimg://fbrtdb.concord.org/democlass1/-NdC3tVdE70ngANCam6q"] => "image"
 ["1","2","a","2/23","ccimg://fbrtdb.concord.org/img.png"] => "categorical"
 `);
   });

--- a/src/models/data/data-types.test.ts
+++ b/src/models/data/data-types.test.ts
@@ -1,4 +1,5 @@
-import { isDate, isImageUrl, isNumeric } from "./data-types";
+import { dateFrom, isDate, isImageUrl, isNumeric } from "./data-types";
+import dayjs from "dayjs";
 
 expect.addSnapshotSerializer({
   serialize(val, config, indentation, depth, refs, printer) {
@@ -13,37 +14,120 @@ expect.addSnapshotSerializer({
 });
 
 // run `npm run test -- -u data-types.test` to update the snapshots in this file
+describe("dayjs", () => {
+  const valuesToTest: string[] = [
+    "2/23",
+    "some string with a date 2/23",
+    "extra chars between 2/nb23"
+  ];
+  test("non strict, no format", () => {
+    const testCases = valuesToTest.map(value => {
+      return [value, dayjs(value).isValid()];
+    });
+    expect({ testCases }).toMatchInlineSnapshot(`
+"2/23" => true
+"some string with a date 2/23" => true
+"extra chars between 2/nb23" => false
+`);
+  });
+  test("non strict, format", () => {
+    // Note: data-types.ts extends dayjs so we don't have to do that here
+    const testCases = valuesToTest.map(value => {
+      return [value, dayjs(value, "M/D").isValid()];
+    });
+    expect({ testCases }).toMatchInlineSnapshot(`
+"2/23" => true
+"some string with a date 2/23" => true
+"extra chars between 2/nb23" => true
+`);
+  });
+  test("strict, format", () => {
+    // Note: data-types.ts extends dayjs so we don't have to do that here
+    const testCases = valuesToTest.map(value => {
+      return [value, dayjs(value, "M/D", true).isValid()];
+    });
+    expect({ testCases }).toMatchInlineSnapshot(`
+"2/23" => true
+"some string with a date 2/23" => false
+"extra chars between 2/nb23" => false
+`);
+  });
+});
+
 
 describe("data-types", () => {
   test("isDate", () => {
     const valuesToTest: string[] = [
       "2/3",
+      "2/3/76",
+      "2/3/1976",
+      "2/03",
+      "2/03/76",
+      "2/03/1976",
+      "02/3",
+      "02/3/76",
+      "02/3/1976",
+      "02/03",
+      "02/03/76",
+      "02/03/1976",
+      "Feb 3",
+      "Feb 3, 76",
+      "Feb 3, 1976",
+      "Feb 03",
+      "Feb 03, 76",
+      "Feb 03, 1976",
+      "February 3",
+      "February 3, 76",
+      "February 3, 1976",
+      "February 03",
+      "February 03, 76",
+      "February 03, 1976",
       "2 / 3",
-      "02/23/1976",
-      "02/23/76",
-      "23/02/1976",
-      "02/31/1976",
-      "02/32/1976",
+      "Feb3,1976",
       "02-23-1976",
-      "02/23",
+      // invalid dates
+      "02/30/1976",
+      "23/02/1976",
       "23/02",
-      "123"
+      "123",
+      "ccimg://fbrtdb.concord.org/democlass1/-NdC3tVdE70ngANCam6q"
     ];
     const testCases = valuesToTest.map(value => {
       return [value, isDate(value)];
     });
     expect({ testCases }).toMatchInlineSnapshot(`
 "2/3" => true
+"2/3/76" => true
+"2/3/1976" => true
+"2/03" => true
+"2/03/76" => true
+"2/03/1976" => true
+"02/3" => true
+"02/3/76" => true
+"02/3/1976" => true
+"02/03" => true
+"02/03/76" => true
+"02/03/1976" => true
+"Feb 3" => true
+"Feb 3, 76" => true
+"Feb 3, 1976" => true
+"Feb 03" => true
+"Feb 03, 76" => true
+"Feb 03, 1976" => true
+"February 3" => true
+"February 3, 76" => true
+"February 3, 1976" => true
+"February 03" => true
+"February 03, 76" => true
+"February 03, 1976" => true
 "2 / 3" => true
-"02/23/1976" => true
-"02/23/76" => true
-"23/02/1976" => true
-"02/31/1976" => true
-"02/32/1976" => true
+"Feb3,1976" => true
 "02-23-1976" => true
-"02/23" => true
-"23/02" => true
+"02/30/1976" => false
+"23/02/1976" => false
+"23/02" => false
 "123" => false
+"ccimg://fbrtdb.concord.org/democlass1/-NdC3tVdE70ngANCam6q" => false
 `);
   });
 

--- a/src/models/data/data-types.test.ts
+++ b/src/models/data/data-types.test.ts
@@ -1,4 +1,4 @@
-import { dateFrom, isDate, isImageUrl, isNumeric } from "./data-types";
+import { isDate, isImageUrl, isNumeric } from "./data-types";
 import dayjs from "dayjs";
 
 expect.addSnapshotSerializer({

--- a/src/models/data/data-types.ts
+++ b/src/models/data/data-types.ts
@@ -3,11 +3,51 @@ import dayjs from "dayjs";
 import customParseFormat from "dayjs/plugin/customParseFormat";
 
 dayjs.extend(customParseFormat);
+// TODO: This is really locale specific, we need a better way to handle
+// locale date identification. It isn't clear if dayjs supports this.
+// In particular some locales put the day first instead of the month.
+// We can just let dayjs check all of its known formats but then it
+// will match any string with a date anywhere in it. There are is
+// a locale format plugin which is close but is probably still too
+// strict.
+// See data-types.test.ts to see examples
 const dayjsFormats = [
-  "MM/DD/YYYY",
-  "MM/DD/YY",
+  "M/D",
+  "M/D/YY",
+  "M/D/YYYY",
+  "M/DD",
+  "M/DD/YY",
+  "M/DD/YYYY",
+  "MM/D",
+  "MM/D/YY",
+  "MM/D/YYYY",
   "MM/DD",
-  "M/D"
+  "MM/DD/YY",
+  "MM/DD/YYYY",
+  "M-D",
+  "M-D-YY",
+  "M-D-YYYY",
+  "M-DD",
+  "M-DD-YY",
+  "M-DD-YYYY",
+  "MM-D",
+  "MM-D-YY",
+  "MM-D-YYYY",
+  "MM-DD",
+  "MM-DD-YY",
+  "MM-DD-YYYY",
+  "MMMD",
+  "MMMD,YY",
+  "MMMD,YYYY",
+  "MMMDD",
+  "MMMDD,YY",
+  "MMMDD,YYYY",
+  "MMMMD",
+  "MMMMD,YY",
+  "MMMMD,YYYY",
+  "MMMMDD",
+  "MMMMDD,YY",
+  "MMMMDD,YYYY"
 ];
 
 export const ValueType = types.union(types.number, types.string, types.undefined);
@@ -36,7 +76,18 @@ export function isDate(val: IValueType) {
     return false;
   }
 
-  return dayjs(val, dayjsFormats).isValid();
+  // We need to use strict matching so extra characters in the string aren't
+  // completely ignored. However this also means that spaces are not allowed
+  // For now we just strip the spaces. This might cause problems with some
+  // formats.
+
+  const stripped = val.replace(/ /g, "");
+
+  return dayjs(stripped, dayjsFormats, true).isValid();
+}
+
+export function dateFrom(val: string) {
+  return dayjs(val, dayjsFormats, true);
 }
 
 export function isImageUrl(val: IValueType) {

--- a/src/models/data/data-types.ts
+++ b/src/models/data/data-types.ts
@@ -7,7 +7,7 @@ dayjs.extend(customParseFormat);
 // locale date identification. It isn't clear if dayjs supports this.
 // In particular some locales put the day first instead of the month.
 // We can just let dayjs check all of its known formats but then it
-// will match any string with a date anywhere in it. There are is
+// will match any string with a date anywhere in it. There is
 // a locale format plugin which is close but is probably still too
 // strict.
 // See data-types.test.ts to see examples


### PR DESCRIPTION
this now uses strict date parsing, which means invalid
dates will also not be considered dates. For example
if the day or month is too large.
It also means the separator character is strict only `/` and `-` are supported.

I'm about to submit another PR that updates this slightly. That PR will remove all of the single `/` date formats since those are going to be identified as fractions in this next PR.