### PR TITLE
Group and ungroup keyboard shortcuts (PT-185994631)

### DIFF
--- a/src/plugins/drawing/components/drawing-tile.tsx
+++ b/src/plugins/drawing/components/drawing-tile.tsx
@@ -51,6 +51,7 @@ const DrawingToolComponent: React.FC<IProps> = (props) => {
         "cmd-v": handlePaste, //allows user to paste image with cmd+v
         "delete": handleDelete, // I'm not sure if this will handle "Del" IE 9 and Edge
         "backspace": handleDelete,
+        "cmd-g": handleGroup
       });
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
@@ -67,6 +68,11 @@ const DrawingToolComponent: React.FC<IProps> = (props) => {
   const handleDelete = () => {
     contentRef.current.deleteObjects([...contentRef.current.selection]);
   };
+
+  const handleGroup = () => {
+    const content = contentRef.current;
+    content.createGroup(content.selection);
+  }
 
   const toolbarProps = useToolbarTileApi({ id: model.id, enabled: !readOnly, onRegisterTileApi, onUnregisterTileApi });
 

--- a/src/plugins/drawing/components/drawing-tile.tsx
+++ b/src/plugins/drawing/components/drawing-tile.tsx
@@ -51,7 +51,8 @@ const DrawingToolComponent: React.FC<IProps> = (props) => {
         "cmd-v": handlePaste, //allows user to paste image with cmd+v
         "delete": handleDelete, // I'm not sure if this will handle "Del" IE 9 and Edge
         "backspace": handleDelete,
-        "cmd-g": handleGroup
+        "cmd-g": handleGroup,
+        "cmd-shift-g": handleUngroup
       });
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
@@ -72,7 +73,14 @@ const DrawingToolComponent: React.FC<IProps> = (props) => {
   const handleGroup = () => {
     const content = contentRef.current;
     content.createGroup(content.selection);
-  }
+    return true; // true return means 'prevent default action'
+  };
+
+  const handleUngroup = () => {
+    const content = contentRef.current;
+    content.ungroupGroups(content.selection);
+    return true; // true return means 'prevent default action'
+  };
 
   const toolbarProps = useToolbarTileApi({ id: model.id, enabled: !readOnly, onRegisterTileApi, onUnregisterTileApi });
 

--- a/src/plugins/drawing/components/drawing-tile.tsx
+++ b/src/plugins/drawing/components/drawing-tile.tsx
@@ -72,13 +72,17 @@ const DrawingToolComponent: React.FC<IProps> = (props) => {
 
   const handleGroup = () => {
     const content = contentRef.current;
-    content.createGroup(content.selection);
+    if (content.selection.length > 1) {
+      content.createGroup(content.selection);
+    }
     return true; // true return means 'prevent default action'
   };
 
   const handleUngroup = () => {
     const content = contentRef.current;
-    content.ungroupGroups(content.selection);
+    if (content.selection.length > 0) {
+      content.ungroupGroups(content.selection);
+    }
     return true; // true return means 'prevent default action'
   };
 

--- a/src/plugins/drawing/objects/group.tsx
+++ b/src/plugins/drawing/objects/group.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { observer } from "mobx-react";
-import { Instance, SnapshotIn, getMembers, types } from "mobx-state-tree";
+import { Instance, SnapshotIn, getMembers, isAlive, types } from "mobx-state-tree";
 import { DrawingObject, DrawingObjectType, IDrawingComponentProps, 
   StrokedObjectType, 
   isFilledObject, 
@@ -32,7 +32,7 @@ export const GroupObject = DrawingObject.named("GroupObject")
   })
   .views(self => ({
     get boundingBox() {
-      if (!self.objects.length) return { nw: { x: 0, y: 0 }, se: { x: 0, y: 0 } };
+      if (!isAlive(self) || !self.objects.length) return { nw: { x: 0, y: 0 }, se: { x: 0, y: 0 } };
       return self.objects.reduce((cur, obj) => {
         if (obj) {
           const objBB = obj.boundingBox;

--- a/src/utilities/hot-keys.ts
+++ b/src/utilities/hot-keys.ts
@@ -104,8 +104,12 @@ export class HotKeys {
     if (handler) {
       const result = handler(e, keys);
       if (result) {
+        console.log('running hot key handler: ', e);
+        e.nativeEvent.preventDefault();
         e.preventDefault();
         e.stopPropagation();
+      } else {
+        console.log('no hot key handler: ' , keys);
       }
       return true;
     }

--- a/src/utilities/hot-keys.ts
+++ b/src/utilities/hot-keys.ts
@@ -104,12 +104,8 @@ export class HotKeys {
     if (handler) {
       const result = handler(e, keys);
       if (result) {
-        console.log('running hot key handler: ', e);
-        e.nativeEvent.preventDefault();
         e.preventDefault();
         e.stopPropagation();
-      } else {
-        console.log('no hot key handler: ' , keys);
       }
       return true;
     }


### PR DESCRIPTION
Adds keyboard shortcuts for 'group' and 'ungroup' operations in the drawing tile.

Added a liveness check in the group getBoundingBox call, since it apparently gets called via some observer after it has been detached and throws an error into the console.
