### PR TITLE
186002744 avoid drawing nulls 4.6.x

### DIFF
--- a/src/plugins/drawing/objects/line.tsx
+++ b/src/plugins/drawing/objects/line.tsx
@@ -106,7 +106,14 @@ export const LineObject = StrokedObject.named("LineObject")
       }
       self.dragScaleX = self.dragScaleY = undefined;
     }
-  }));
+  }))
+  .preProcessSnapshot(sn => {
+    const snClone = { ...sn };
+    snClone.deltaPoints = snClone.deltaPoints?.filter((point) => {
+      return (isFinite(point.dx) && isFinite(point.dy));
+    });
+    return snClone;
+  });
 export interface LineObjectType extends Instance<typeof LineObject> {}
 export interface LineObjectSnapshot extends SnapshotIn<typeof LineObject> {}
 

--- a/src/plugins/drawing/objects/line.tsx
+++ b/src/plugins/drawing/objects/line.tsx
@@ -82,8 +82,8 @@ export const LineObject = StrokedObject.named("LineObject")
       const height = bbox.se.y - bbox.nw.y;
       const newWidth  = width -  deltas.left + deltas.right;
       const newHeight = height - deltas.top + deltas.bottom;
-      const widthFactor = newWidth/width;
-      const heightFactor = newHeight/height;
+      const widthFactor = width ? newWidth/width : 1;
+      const heightFactor = height ? newHeight/height : 1;
 
       // x,y get moved to a scaled position within the new bounds
       const newLeft = left+deltas.left;
@@ -110,7 +110,13 @@ export const LineObject = StrokedObject.named("LineObject")
   .preProcessSnapshot(sn => {
     const snClone = { ...sn };
     snClone.deltaPoints = snClone.deltaPoints?.filter((point) => {
-      return (isFinite(point.dx) && isFinite(point.dy));
+      if (typeof snClone.x !== 'number') {
+        snClone.x = 0;
+      }
+      if (typeof snClone.y !== 'number') {
+        snClone.y = 0;
+      }
+      return (typeof point.dx === 'number' && typeof point.dy === 'number');
     });
     return snClone;
   });

--- a/src/plugins/drawing/objects/line.tsx
+++ b/src/plugins/drawing/objects/line.tsx
@@ -109,13 +109,13 @@ export const LineObject = StrokedObject.named("LineObject")
   }))
   .preProcessSnapshot(sn => {
     const snClone = { ...sn };
+    if (typeof snClone.x !== 'number') {
+      snClone.x = 0;
+    }
+    if (typeof snClone.y !== 'number') {
+      snClone.y = 0;
+    }
     snClone.deltaPoints = snClone.deltaPoints?.filter((point) => {
-      if (typeof snClone.x !== 'number') {
-        snClone.x = 0;
-      }
-      if (typeof snClone.y !== 'number') {
-        snClone.y = 0;
-      }
       return (typeof point.dx === 'number' && typeof point.dy === 'number');
     });
     return snClone;


### PR DESCRIPTION
These are the same changes as PR #1929.
Fix a drawing tool bug ([PT-186002744](https://pivotaltracker.com/story/show/186002744)) that was leaving nulls in line drawings.

This PR targets the 4.6.x branch so that it can be more quickly deployed.
