### PR TITLE
add spaces after `{` and before `}`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,9 +35,10 @@ module.exports = {
       "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/no-non-null-assertion": "off",  // 27 as of 2020-09-13
       "@typescript-eslint/no-require-imports": "error",
-      "@typescript-eslint/no-shadow": ["error", { builtinGlobals: false, hoist: "all", allow: ["resolve", "reject"] }],
+      "@typescript-eslint/no-shadow": ["error", {builtinGlobals: false, hoist: "all", allow: ["resolve", "reject"]}],
       "@typescript-eslint/no-unused-vars": ["warn",
-        { args: "none", ignoreRestSiblings: true, "destructuredArrayIgnorePattern": "^_" }],
+        {args: "none", ignoreRestSiblings: true, "destructuredArrayIgnorePattern": "^_"}],
+      "@typescript-eslint/object-curly-spacing": ["warn", "always"],
       "@typescript-eslint/prefer-optional-chain": "off",  // 300 as of 2020-09-13
       "comma-spacing": "warn",
       curly: ["error", "multi-line", "consistent"],
@@ -45,7 +46,7 @@ module.exports = {
       "eol-last": "warn",
       eqeqeq: ["error", "smart"],
       "eslint-comments/no-unused-disable": "off",   // enabled in .eslintrc.build.js
-      "max-len": ["warn", { code: 120, ignoreUrls: true }],
+      "max-len": ["warn", {code: 120, ignoreUrls: true}],
       "no-bitwise": "error",
       "no-debugger": "off", // enabled in .eslintrc.build.js
       "no-duplicate-imports": "error",
@@ -53,7 +54,7 @@ module.exports = {
       "no-shadow": "off", // superseded by @typescript-eslint/no-shadow
       "no-tabs": "error",
       "no-unneeded-ternary": "error",
-      "no-unused-expressions": ["error", { allowShortCircuit: true }],
+      "no-unused-expressions": ["error", {allowShortCircuit: true}],
       "no-unused-vars": "off",  // superseded by @typescript-eslint/no-unused-vars
       "no-useless-call": "error",
       "no-useless-concat": "error",
@@ -73,7 +74,7 @@ module.exports = {
       "react/jsx-no-useless-fragment": "error",
       "react/no-access-state-in-setstate": "error",
       "react/no-danger": "error",
-      "react/no-unsafe": ["off", { checkAliases: true }], // 1 as of 2020-09-13
+      "react/no-unsafe": ["off", {checkAliases: true}], // 1 as of 2020-09-13
       "react/no-unused-state": "error",
       "react/prop-types": "off",
       semi: ["error", "always"]

--- a/cypress/e2e/clue/branch/student_tests/canvas_test_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/canvas_test_spec.js
@@ -218,7 +218,7 @@ context('Test Canvas', function () {
         graphToolTile.getGraphTile().should('exist');
         clueCanvas.exportTileAndDocument('geometry-tool-tile');
         // in case we created a point while exporting
-        cy.get('.primary-workspace .geometry-toolbar .button.delete').click({ force: true});
+        cy.get('.primary-workspace .geometry-toolbar .button.delete').click({ force: true });
       });
       it('adds an image tool', function () {
         clueCanvas.addTile('image');

--- a/cypress/e2e/clue/branch/student_tests/dataflow_table_integration_test_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/dataflow_table_integration_test_spec.js
@@ -7,8 +7,8 @@ let dataflowToolTile = new DataflowToolTile;
 let tableTile = new TableToolTile;
 const tableTitle = "Table 1";
 const programTitle = "Program 1";
-const programNodes = [{ name: "timer", title: "Timer (on/off)", attribute: "Timer 1"},
-                      { name: "demo-output", title: "Demo Output", attribute: "Demo Output 2"}];
+const programNodes = [{ name: "timer", title: "Timer (on/off)", attribute: "Timer 1" },
+                      { name: "demo-output", title: "Demo Output", attribute: "Demo Output 2" }];
 const linkedTableAttributes = [ "Time (sec)", programNodes[0].attribute, programNodes[1].attribute ];
 const defaultTableAttributes = ["x", "y"];
 const timer1 = 5;

--- a/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
@@ -432,9 +432,9 @@ context('Dataflow Tool Tile', function () {
         dataflowToolTile.getNumberField().type("1{enter}");
         dataflowToolTile.getNumberNodeOutput().should("exist");
         dataflowToolTile.getDataflowTile().click(startX, startY)
-          .trigger("pointerdown", startX, startY, {force: true})
-          .trigger("pointermove", startX + deltaX, startY + deltaY, {force: true})
-          .trigger("pointerup", startX + deltaX, startY + deltaY, {force: true});
+          .trigger("pointerdown", startX, startY, { force: true })
+          .trigger("pointermove", startX + deltaX, startY + deltaY, { force: true })
+          .trigger("pointerup", startX + deltaX, startY + deltaY, { force: true });
         dataflowToolTile.getModalOkButton().click();
       });
       it("should show needs connection message when fan is selected and there are no outputs", () => {

--- a/cypress/e2e/clue/branch/student_tests/drawing_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/drawing_tool_spec.js
@@ -37,12 +37,12 @@ context('Draw Tool Tile', function () {
     });
     describe("Show/sort", () => {
       it("can open show/sort panel and select objects", () => {
-        drawToolTile.getDrawToolRectangle().click({scrollBehavior: false});
+        drawToolTile.getDrawToolRectangle().click({ scrollBehavior: false });
         drawToolTile.getDrawTile()
           .trigger("mousedown", 100,  50)
           .trigger("mousemove", 250, 150)
           .trigger("mouseup",   250, 150);
-        drawToolTile.getDrawToolEllipse().click({scrollBehavior: false});
+        drawToolTile.getDrawToolEllipse().click({ scrollBehavior: false });
         drawToolTile.getDrawTile()
           .trigger("mousedown", 300,  50)
           .trigger("mousemove", 400, 150)
@@ -54,24 +54,24 @@ context('Draw Tool Tile', function () {
         drawToolTile.getSelectionBox().should("not.exist");
 
         // Open panel
-        drawToolTile.getDrawTileShowSortPanelOpenButton().click({scrollBehavior: false});
+        drawToolTile.getDrawTileShowSortPanelOpenButton().click({ scrollBehavior: false });
         drawToolTile.getDrawTileShowSortPanel().should("have.class", "open").and("contain.text", "Rectangle").and("contain.text", "Circle");
         // Click to select
-        drawToolTile.getDrawTileShowSortPanel().get('li:first').should("contain.text", "Circle").click({scrollBehavior: false});
+        drawToolTile.getDrawTileShowSortPanel().get('li:first').should("contain.text", "Circle").click({ scrollBehavior: false });
         drawToolTile.getSelectionBox().should("exist");
       });
       it("can hide and show objects", () => {
         drawToolTile.getEllipseDrawing().should("exist");
         // Click 'hide' button - unselects ellipse and makes it invisible
-        drawToolTile.getDrawTileShowSortPanel().get('li:first button.visibility-icon').click({scrollBehavior: false});
+        drawToolTile.getDrawTileShowSortPanel().get('li:first button.visibility-icon').click({ scrollBehavior: false });
         drawToolTile.getEllipseDrawing().should("not.exist");
         drawToolTile.getSelectionBox().should("not.exist");
         // Now select it - should show as a faint 'ghost'
-        drawToolTile.getDrawTileShowSortPanel().get('li:first').click({scrollBehavior: false});
+        drawToolTile.getDrawTileShowSortPanel().get('li:first').click({ scrollBehavior: false });
         drawToolTile.getSelectionBox().should("exist");
         drawToolTile.getGhostGroup().should("exist").get('ellipse').should("exist");
         // Make visible again
-        drawToolTile.getDrawTileShowSortPanel().get('li:first button.visibility-icon').click({scrollBehavior: false});
+        drawToolTile.getDrawTileShowSortPanel().get('li:first button.visibility-icon').click({ scrollBehavior: false });
         drawToolTile.getEllipseDrawing().should("exist");
         drawToolTile.getGhostGroup().should("not.exist");        
       });
@@ -85,20 +85,20 @@ context('Draw Tool Tile', function () {
       });
       it("can delete objects and close panel", () => {
         // Delete objects
-        drawToolTile.getDrawTileShowSortPanel().get('li:first').should("contain.text", "Rectangle").click({scrollBehavior: false});
-        drawToolTile.getDrawToolDelete().should("not.have.class", "disabled").click({scrollBehavior: false});
+        drawToolTile.getDrawTileShowSortPanel().get('li:first').should("contain.text", "Rectangle").click({ scrollBehavior: false });
+        drawToolTile.getDrawToolDelete().should("not.have.class", "disabled").click({ scrollBehavior: false });
         drawToolTile.getDrawTileShowSortPanel().get('li').should("have.length", 1);
-        drawToolTile.getDrawTileShowSortPanel().get('li:first').should("contain.text", "Circle").click({scrollBehavior: false});
-        drawToolTile.getDrawToolDelete().should("not.have.class", "disabled").click({scrollBehavior: false});
+        drawToolTile.getDrawTileShowSortPanel().get('li:first').should("contain.text", "Circle").click({ scrollBehavior: false });
+        drawToolTile.getDrawToolDelete().should("not.have.class", "disabled").click({ scrollBehavior: false });
         drawToolTile.getDrawTileShowSortPanel().get('li').should("not.exist");
         // Close panel
-        drawToolTile.getDrawTileShowSortPanelCloseButton().click({scrollBehavior: false});
+        drawToolTile.getDrawTileShowSortPanelCloseButton().click({ scrollBehavior: false });
         drawToolTile.getDrawTileShowSortPanel().should("have.class", "closed");
       });
     });
     describe("Freehand", () => {
       it("verify draw a line", () => {
-        drawToolTile.getDrawToolFreehand().click({scrollBehavior: false});
+        drawToolTile.getDrawToolFreehand().click({ scrollBehavior: false });
         drawToolTile.getDrawTile()
           .trigger("mousedown", 350, 50)
           .trigger("mousemove", 350, 100)
@@ -107,13 +107,13 @@ context('Draw Tool Tile', function () {
         drawToolTile.getFreehandDrawing().should("exist").and("have.length", 1);
       });
       it("shows up in show/sort panel", () => {
-        drawToolTile.getDrawTileShowSortPanelOpenButton().click({scrollBehavior: false});
+        drawToolTile.getDrawTileShowSortPanelOpenButton().click({ scrollBehavior: false });
         drawToolTile.getDrawTileShowSortPanel().should("have.class", "open")
           .get("li").should("have.length", 1).and("contain.text", "Freehand");
-        drawToolTile.getDrawTileShowSortPanelCloseButton().click({scrollBehavior: false});
+        drawToolTile.getDrawTileShowSortPanelCloseButton().click({ scrollBehavior: false });
       });
       it("selects freehand drawing", () => {
-        drawToolTile.getDrawToolSelect().click({scrollBehavior: false});
+        drawToolTile.getDrawToolSelect().click({ scrollBehavior: false });
         // First make sure we don't select it even if we are inside of its
         // bounding box
         drawToolTile.getDrawTile()
@@ -129,9 +129,9 @@ context('Draw Tool Tile', function () {
         drawToolTile.getDrawToolDelete().should("not.have.class", "disabled");
       });
       it("verify change outline color", () => {
-        drawToolTile.getDrawToolStrokeColor().click({scrollBehavior: false});
+        drawToolTile.getDrawToolStrokeColor().click({ scrollBehavior: false });
         cy.get(".toolbar-palette.stroke-color .palette-buttons").should("be.visible");
-        cy.get(".toolbar-palette.stroke-color .palette-buttons .color-swatch").eq(1).click({scrollBehavior: false});
+        cy.get(".toolbar-palette.stroke-color .palette-buttons .color-swatch").eq(1).click({ scrollBehavior: false });
         drawToolTile.getFreehandDrawing().first().should("have.attr", "stroke").and("eq", "#eb0000");
       });
       it("deletes freehand drawing", () => {
@@ -143,13 +143,13 @@ context('Draw Tool Tile', function () {
         //   .trigger("mousedown", 350, 100)
         //   .trigger("mouseup", 350, 100);
         drawToolTile.getSelectionBox().should("exist");
-        drawToolTile.getDrawToolDelete().should("not.have.class", "disabled").click({scrollBehavior: false});
+        drawToolTile.getDrawToolDelete().should("not.have.class", "disabled").click({ scrollBehavior: false });
         drawToolTile.getFreehandDrawing().should("not.exist");
       });
     });
     describe("Vector", () => {
       it("verify draw vector", () => {
-        drawToolTile.getDrawToolVector().click({scrollBehavior: false});
+        drawToolTile.getDrawToolVector().click({ scrollBehavior: false });
         drawToolTile.getDrawTile()
           .trigger("mousedown", 250, 50)
           .trigger("mousemove", 100, 50)
@@ -157,10 +157,10 @@ context('Draw Tool Tile', function () {
         drawToolTile.getVectorDrawing().should("exist").and("have.length", 1);
       });
       it("shows up in show/sort panel", () => {
-        drawToolTile.getDrawTileShowSortPanelOpenButton().click({scrollBehavior: false});
+        drawToolTile.getDrawTileShowSortPanelOpenButton().click({ scrollBehavior: false });
         drawToolTile.getDrawTileShowSortPanel().should("have.class", "open")
           .get("li").should("have.length", 1).and("contain.text", "Line");
-        drawToolTile.getDrawTileShowSortPanelCloseButton().click({scrollBehavior: false});
+        drawToolTile.getDrawTileShowSortPanelCloseButton().click({ scrollBehavior: false });
       });
       it("verify after creation, object is selected", () => {
         drawToolTile.getDrawToolSelect().should("have.class", "selected");
@@ -169,31 +169,31 @@ context('Draw Tool Tile', function () {
         drawToolTile.getDrawToolDelete().should("not.have.class", "disabled");
       });
       it("verify change outline color", () => {
-        drawToolTile.getDrawToolStrokeColor().click({scrollBehavior: false});
+        drawToolTile.getDrawToolStrokeColor().click({ scrollBehavior: false });
         cy.get(".toolbar-palette.stroke-color .palette-buttons").should("be.visible");
-        cy.get(".toolbar-palette.stroke-color .palette-buttons .color-swatch").eq(2).click({scrollBehavior: false});
+        cy.get(".toolbar-palette.stroke-color .palette-buttons .color-swatch").eq(2).click({ scrollBehavior: false });
         drawToolTile.getVectorDrawing().first().should("have.attr", "stroke").and("eq", "#008a00");
-        drawToolTile.getDrawToolStrokeColor().click({scrollBehavior: false});
+        drawToolTile.getDrawToolStrokeColor().click({ scrollBehavior: false });
         cy.get(".toolbar-palette.stroke-color .palette-buttons").should("be.visible");
-        cy.get(".toolbar-palette.stroke-color .palette-buttons .color-swatch").first().click({scrollBehavior: false});
+        cy.get(".toolbar-palette.stroke-color .palette-buttons .color-swatch").first().click({ scrollBehavior: false });
       });
       it("change line to arrow", () => {
         drawToolTile.getVectorDrawing().children().its("length").should("eq", 1); // Only a line, no arrowheads yet.
-        drawToolTile.getDrawToolVectorSubmenu().click({scrollBehavior: false});
+        drawToolTile.getDrawToolVectorSubmenu().click({ scrollBehavior: false });
         cy.get(".toolbar-palette.vectors .drawing-tool-buttons").should("be.visible");
-        cy.get(".toolbar-palette.vectors .drawing-tool-buttons div:nth-child(3) button").click({scrollBehavior: false});
+        cy.get(".toolbar-palette.vectors .drawing-tool-buttons div:nth-child(3) button").click({ scrollBehavior: false });
         drawToolTile.getVectorDrawing().children().its("length").should("eq", 3); // Now three items in group...
         drawToolTile.getVectorDrawing().find("polygon").its("length").should("eq", 2); // including two arrowheads.
         // selecting from this submenu activates the vector tool, which de-selects the object.
         });
       it("deletes vector drawing", () => {
         // re-select the object using a selection rectangle.
-        drawToolTile.getDrawToolSelect().click({scrollBehavior: false});
+        drawToolTile.getDrawToolSelect().click({ scrollBehavior: false });
         drawToolTile.getDrawTile()
           .trigger("mousedown", 90, 40)
           .trigger("mousemove", 260, 60)
           .trigger("mouseup",   260, 60);
-        drawToolTile.getDrawToolDelete().click({scrollBehavior: false});
+        drawToolTile.getDrawToolDelete().click({ scrollBehavior: false });
         drawToolTile.getVectorDrawing().should("not.exist");
       });
     });
@@ -207,10 +207,10 @@ context('Draw Tool Tile', function () {
         drawToolTile.getRectangleDrawing().should("exist").and("have.length", 1);
       });
       it("shows up in show/sort panel", () => {
-        drawToolTile.getDrawTileShowSortPanelOpenButton().click({scrollBehavior: false});
+        drawToolTile.getDrawTileShowSortPanelOpenButton().click({ scrollBehavior: false });
         drawToolTile.getDrawTileShowSortPanel().should("have.class", "open")
           .get("li").should("have.length", 1).and("contain.text", "Rectangle");
-        drawToolTile.getDrawTileShowSortPanelCloseButton().click({scrollBehavior: false});
+        drawToolTile.getDrawTileShowSortPanelCloseButton().click({ scrollBehavior: false });
       });
       it("verify change outline color", () => {
         drawToolTile.getRectangleDrawing().first().should("have.attr", "stroke").and("eq", "#000000");
@@ -246,13 +246,13 @@ context('Draw Tool Tile', function () {
           // Get the rectangle to be hovered. In the code we are listening to
           // `onMouseEnter` but in Cypress triggering a "mouseenter" event
           // doesn't work. Triggering a "mouseover" does work for some reason.
-          .trigger("mouseover", {scrollBehavior: false});
+          .trigger("mouseover", { scrollBehavior: false });
 
         // The hover box is rendered as a selection-box with a different color
         drawToolTile.getHighlightBox().should("exist").should("have.attr", "stroke").and("eq", "#bbdd00");
 
         // The best way I found to remove the hover was to delete the rectangle
-        drawToolTile.getRectangleDrawing().first().click({force: true, scrollBehavior: false});
+        drawToolTile.getRectangleDrawing().first().click({ force: true, scrollBehavior: false });
         drawToolTile.getDrawToolDelete().click();
         drawToolTile.getHighlightBox().should("not.exist");
 
@@ -275,7 +275,7 @@ context('Draw Tool Tile', function () {
 
         // Get the rectangle to be hovered, see above for more info.
         drawToolTile.getRectangleDrawing()
-          .trigger("mouseover", {scrollBehavior: false});
+          .trigger("mouseover", { scrollBehavior: false });
         drawToolTile.getHighlightBox().should("exist").should("have.attr", "stroke").and("eq", "#bbdd00");
 
         drawToolTile.getDrawTile()
@@ -295,8 +295,8 @@ context('Draw Tool Tile', function () {
         // starting from top edge
         drawToolTile.getDrawToolRectangle().click();
         drawToolTile.getDrawTile()
-          .trigger("mousedown", 100, 50, {altKey: true})
-          .trigger("mousemove", 100, 70, {altKey: true})
+          .trigger("mousedown", 100, 50, { altKey: true })
+          .trigger("mousemove", 100, 70, { altKey: true })
           .trigger("mouseup",   100, 70);
 
         drawToolTile.getRectangleDrawing().should("exist").and("have.length", 1);
@@ -306,8 +306,8 @@ context('Draw Tool Tile', function () {
         // starting from the left edge
         drawToolTile.getDrawToolRectangle().click();
         drawToolTile.getDrawTile()
-          .trigger("mousedown", 200, 50, {altKey: true})
-          .trigger("mousemove", 230, 50, {altKey: true})
+          .trigger("mousedown", 200, 50, { altKey: true })
+          .trigger("mousemove", 230, 50, { altKey: true })
           .trigger("mouseup",   230, 50);
         drawToolTile.getRectangleDrawing().should("exist").and("have.length", 2);
         drawToolTile.getRectangleDrawing().last().should("have.attr", "width").and("eq", "30");
@@ -316,8 +316,8 @@ context('Draw Tool Tile', function () {
         // draw a square starting at the bottom edge
         drawToolTile.getDrawToolRectangle().click();
         drawToolTile.getDrawTile()
-          .trigger("mousedown", 300, 90, {altKey: true})
-          .trigger("mousemove", 300, 50, {altKey: true})
+          .trigger("mousedown", 300, 90, { altKey: true })
+          .trigger("mousemove", 300, 50, { altKey: true })
           .trigger("mouseup",   300, 50);
         drawToolTile.getRectangleDrawing().should("exist").and("have.length", 3);
         drawToolTile.getRectangleDrawing().last().should("have.attr", "width").and("eq", "40");
@@ -326,8 +326,8 @@ context('Draw Tool Tile', function () {
         // draw a square starting at the right edge
         drawToolTile.getDrawToolRectangle().click();
         drawToolTile.getDrawTile()
-          .trigger("mousedown", 450, 50, {altKey: true})
-          .trigger("mousemove", 400, 50, {altKey: true})
+          .trigger("mousedown", 450, 50, { altKey: true })
+          .trigger("mousemove", 400, 50, { altKey: true })
           .trigger("mouseup",   400, 50);
         drawToolTile.getRectangleDrawing().should("exist").and("have.length", 4);
         drawToolTile.getRectangleDrawing().last().should("have.attr", "width").and("eq", "50");
@@ -336,8 +336,8 @@ context('Draw Tool Tile', function () {
         // Diagonal from top right to bottom left with the width 60 and height 50
         drawToolTile.getDrawToolRectangle().click();
         drawToolTile.getDrawTile()
-          .trigger("mousedown", 560, 50,  {altKey: true})
-          .trigger("mousemove", 500, 100, {altKey: true})
+          .trigger("mousedown", 560, 50,  { altKey: true })
+          .trigger("mousemove", 500, 100, { altKey: true })
           .trigger("mouseup",   500, 100);
         drawToolTile.getRectangleDrawing().should("exist").and("have.length", 5);
         drawToolTile.getRectangleDrawing().last().should("have.attr", "width").and("eq", "60");
@@ -346,8 +346,8 @@ context('Draw Tool Tile', function () {
         // Diagonal from bottom right to top left with the width 50 and the height 70
         drawToolTile.getDrawToolRectangle().click();
         drawToolTile.getDrawTile()
-          .trigger("mousedown", 650, 120, {altKey: true})
-          .trigger("mousemove", 600, 50,  {altKey: true})
+          .trigger("mousedown", 650, 120, { altKey: true })
+          .trigger("mousemove", 600, 50,  { altKey: true })
           .trigger("mouseup",   600, 50);
         drawToolTile.getRectangleDrawing().should("exist").and("have.length", 6);
         drawToolTile.getRectangleDrawing().last().should("have.attr", "width").and("eq", "70");
@@ -359,17 +359,17 @@ context('Draw Tool Tile', function () {
         // delete the first 4 with the toolbar button
         for (let i=0; i<4; i++) {
           drawToolTile.getDrawToolSelect().click();
-          drawToolTile.getRectangleDrawing().first().click({force:true, scrollBehavior: false});
+          drawToolTile.getRectangleDrawing().first().click({ force:true, scrollBehavior: false });
           drawToolTile.getDrawToolDelete().click();
         }
         // Delete with backspace key
         drawToolTile.getDrawToolSelect().click();
-        drawToolTile.getRectangleDrawing().first().click({force:true, scrollBehavior: false});
+        drawToolTile.getRectangleDrawing().first().click({ force:true, scrollBehavior: false });
         drawToolTile.getDrawTileComponent().type("{backspace}");
 
         // Delete with delete key
         drawToolTile.getDrawToolSelect().click();
-        drawToolTile.getRectangleDrawing().first().click({force:true, scrollBehavior: false});
+        drawToolTile.getRectangleDrawing().first().click({ force:true, scrollBehavior: false });
         drawToolTile.getDrawTileComponent().type("{del}");
 
         drawToolTile.getRectangleDrawing().should("not.exist");
@@ -385,16 +385,16 @@ context('Draw Tool Tile', function () {
         drawToolTile.getEllipseDrawing().should("exist").and("have.length", 1);
       });
       it("shows up in show/sort panel", () => {
-        drawToolTile.getDrawTileShowSortPanelOpenButton().click({scrollBehavior: false});
+        drawToolTile.getDrawTileShowSortPanelOpenButton().click({ scrollBehavior: false });
         drawToolTile.getDrawTileShowSortPanel().should("have.class", "open")
           .get("li").should("have.length", 1).and("contain.text", "Ellipse");
-        drawToolTile.getDrawTileShowSortPanelCloseButton().click({scrollBehavior: false});
+        drawToolTile.getDrawTileShowSortPanelCloseButton().click({ scrollBehavior: false });
       });
       it("verify draw circle", () => {
         drawToolTile.getDrawToolEllipse().click();
         drawToolTile.getDrawTile()
-          .trigger("mousedown", 450,  50, {altKey: true})
-          .trigger("mousemove", 450, 150, {altKey: true})
+          .trigger("mousedown", 450,  50, { altKey: true })
+          .trigger("mousemove", 450, 150, { altKey: true })
           .trigger("mouseup",   450, 150);
         drawToolTile.getEllipseDrawing().should("exist").and("have.length", 2);
         drawToolTile.getEllipseDrawing().last().should("have.attr", "rx").and("eq", "100");
@@ -403,9 +403,9 @@ context('Draw Tool Tile', function () {
       it("deletes ellipse drawing", () => {
         drawToolTile.getDrawTile().click();
         drawToolTile.getDrawToolSelect().click();
-        drawToolTile.getEllipseDrawing().first().click({force:true, scrollBehavior: false});
+        drawToolTile.getEllipseDrawing().first().click({ force:true, scrollBehavior: false });
         drawToolTile.getDrawToolDelete().click();
-        drawToolTile.getEllipseDrawing().first().click({force:true, scrollBehavior: false});
+        drawToolTile.getEllipseDrawing().first().click({ force:true, scrollBehavior: false });
         drawToolTile.getDrawToolDelete().click();
         drawToolTile.getEllipseDrawing().should("not.exist");
       });
@@ -419,10 +419,10 @@ context('Draw Tool Tile', function () {
         drawToolTile.getImageDrawing().should("exist").and("have.length", 1);
       });
       it("shows up in show/sort panel", () => {
-        drawToolTile.getDrawTileShowSortPanelOpenButton().click({scrollBehavior: false});
+        drawToolTile.getDrawTileShowSortPanelOpenButton().click({ scrollBehavior: false });
         drawToolTile.getDrawTileShowSortPanel().should("have.class", "open")
           .get("li").should("have.length", 1).and("contain.text", "Image");
-        drawToolTile.getDrawTileShowSortPanelCloseButton().click({scrollBehavior: false});
+        drawToolTile.getDrawTileShowSortPanelCloseButton().click({ scrollBehavior: false });
       });
       it("verify stamp images", () => {
         drawToolTile.getImageDrawing().eq(0).should("have.attr", "href").and("contain", "coin.png");
@@ -444,55 +444,55 @@ context('Draw Tool Tile', function () {
       it("deletes stamp drawing", () => {
         drawToolTile.getDrawToolSelect().click();
         // drawToolTile.getImageDrawing().click({force:true, scrollBehavior: false});
-        drawToolTile.getImageDrawing().eq(0).click({force:true, scrollBehavior: false});
+        drawToolTile.getImageDrawing().eq(0).click({ force:true, scrollBehavior: false });
         drawToolTile.getDrawToolDelete().click();
-        drawToolTile.getImageDrawing().eq(1).click({force:true, scrollBehavior: false});
+        drawToolTile.getImageDrawing().eq(1).click({ force:true, scrollBehavior: false });
         drawToolTile.getDrawToolDelete().click();
-        drawToolTile.getImageDrawing().click({force:true, scrollBehavior: false});
+        drawToolTile.getImageDrawing().click({ force:true, scrollBehavior: false });
         drawToolTile.getDrawToolDelete().click();
         drawToolTile.getImageDrawing().should("not.exist");
       });
     });
     describe("Text", () => {
       it("adds text object", () => {
-        drawToolTile.getDrawToolText().click({scrollBehavior: false});
+        drawToolTile.getDrawToolText().click({ scrollBehavior: false });
         drawToolTile.getDrawTile()
           .trigger("mousedown", 100,  100)
           .trigger("mouseup", 100, 100);
           drawToolTile.getTextDrawing().should("exist").and("have.length", 1);
       });
       it("shows up in show/sort panel", () => {
-        drawToolTile.getDrawTileShowSortPanelOpenButton().click({scrollBehavior: false});
+        drawToolTile.getDrawTileShowSortPanelOpenButton().click({ scrollBehavior: false });
         drawToolTile.getDrawTileShowSortPanel().should("have.class", "open")
           .get("li").should("have.length", 1).and("contain.text", "Text");
-        drawToolTile.getDrawTileShowSortPanelCloseButton().click({scrollBehavior: false});
+        drawToolTile.getDrawTileShowSortPanelCloseButton().click({ scrollBehavior: false });
       });
       it("edits text content of object", () => {
         // Click inside drawing box to enter edit mode
         drawToolTile.getDrawTile()
           .trigger("mousedown", 150,  150)
           .trigger("mouseup", 150, 150);
-          drawToolTile.getTextDrawing().get('textarea').type("The five boxing wizards jump quickly.{enter}", {scrollBehavior: false});
+          drawToolTile.getTextDrawing().get('textarea').type("The five boxing wizards jump quickly.{enter}", { scrollBehavior: false });
           drawToolTile.getTextDrawing().get('text tspan').should("exist").and("have.length", 6);
       });
       it("deletes text object", () => {
-        drawToolTile.getDrawToolSelect().click({scrollBehavior: false});
+        drawToolTile.getDrawToolSelect().click({ scrollBehavior: false });
         drawToolTile.getDrawTile()
           .trigger("mousedown", 150,  150)
           .trigger("mouseup", 150, 150);
         drawToolTile.getSelectionBox().should("exist");
-        drawToolTile.getDrawToolDelete().should("not.have.class", "disabled").click({scrollBehavior: false});
+        drawToolTile.getDrawToolDelete().should("not.have.class", "disabled").click({ scrollBehavior: false });
         drawToolTile.getTextDrawing().should("not.exist");
       });
     });
     describe("Group", () => {
       it("can group and ungroup", () => {
-        drawToolTile.getDrawToolRectangle().click({scrollBehavior: false});
+        drawToolTile.getDrawToolRectangle().click({ scrollBehavior: false });
         drawToolTile.getDrawTile()
           .trigger("mousedown", 250, 50)
           .trigger("mousemove", 100, 150)
           .trigger("mouseup",   100, 150);
-        drawToolTile.getDrawToolEllipse().click({scrollBehavior: false});
+        drawToolTile.getDrawToolEllipse().click({ scrollBehavior: false });
         drawToolTile.getDrawTile()
           .trigger("mousedown", 50,  100)
           .trigger("mousemove", 100, 150)

--- a/cypress/e2e/clue/branch/student_tests/expression_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/expression_tool_spec.js
@@ -42,8 +42,8 @@ context('Expression Tool Tile', function () {
     it("should accept basic keyboard input", () => {
       // Can now perform keyboard input
       // but thus far cannot get sequences like {del} to work in test
-      exp.getMathField().eq(0).click({force: true});
-      exp.getMathField().eq(0).type("hi", {force: true});
+      exp.getMathField().eq(0).click({ force: true });
+      exp.getMathField().eq(0).type("hi", { force: true });
       exp.getMathField().eq(0).should("have.value", "hia=\\pi r^2");
       cy.wait(2000);
     });
@@ -55,19 +55,19 @@ context('Expression Tool Tile', function () {
     });
     it("can create a mixed fraction with the button", () => {
       exp.clearValue();
-      exp.getMathField().eq(0).click({force: true});
+      exp.getMathField().eq(0).click({ force: true });
       exp.getMixedFractionButton().eq(0).click();
       exp.getMathField().eq(0).should("have.value", "\\placeholder{}\\frac{\\placeholder{}}{\\placeholder{}}");
     });
     it("can add an empty division expression when division button clicked in empty expression", () => {
       exp.clearValue();
-      exp.getMathField().eq(0).click({force: true});
+      exp.getMathField().eq(0).click({ force: true });
       exp.getDivisionButton().eq(0).click();
       exp.getMathField().eq(0).should("have.value", "\\placeholder{}\\div\\placeholder{}");
     });
     it("can add a division sign and a placeholder when division button clicked following existing value", () => {
       exp.clearValue();
-      exp.getMathField().eq(0).click({force: true});
+      exp.getMathField().eq(0).click({ force: true });
       exp.getMathField().eq(0).invoke("val", "123");
       exp.getDivisionButton().eq(0).click();
       exp.getMathField().eq(0).should("have.value", "123\\div\\placeholder{}");
@@ -79,27 +79,27 @@ context('Expression Tool Tile', function () {
       cy.contains("(Eq. 2)").should("exist");
     });
     it("should become the active tile when equation is clicked", () => {
-      exp.getMathField().eq(1).click({force: true});
+      exp.getMathField().eq(1).click({ force: true });
       exp.getExpressionTile().eq(1).should("have.class", "selected");
       exp.getExpressionTile().eq(0).should("not.have.class", "selected");
     });
     it("should have a toggleable toolbar", () => {
       exp.getExpressionToolbar().eq(1).should("be.visible");
       exp.getExpressionToolbar().eq(0).should("not.be.visible");
-      exp.getMathField().eq(0).click({force: true});
+      exp.getMathField().eq(0).click({ force: true });
       exp.getExpressionToolbar().eq(0).should("be.visible");
       exp.getExpressionToolbar().eq(1).should("not.be.visible");
     });
     it("delete expression button deletes the whole expression", () => {
-      exp.getMathField().eq(0).click({force: true});
+      exp.getMathField().eq(0).click({ force: true });
       exp.getDeleteExpressionButton().eq(0).click();
       exp.getMathFieldMath().eq(0).should("not.contain.text");
       exp.getMathField().should("not.have.value", "a=\\pi r^2");
     });
     it("adds placeholder to negative sign", () => {
       exp.getDeleteExpressionButton().eq(0).click();
-      exp.getMathField().eq(0).click({force: true});
-      exp.getMathField().eq(0).type("-", {force: true});
+      exp.getMathField().eq(0).click({ force: true });
+      exp.getMathField().eq(0).type("-", { force: true });
       exp.getMathField().eq(0).should("have.value", "-\\placeholder{}");
     });
     it("adds placeholders to multiplication symbol", () => {

--- a/cypress/e2e/clue/branch/student_tests/graph_table_integraton_test_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/graph_table_integraton_test_spec.js
@@ -75,7 +75,7 @@ context('Graph Table Integration', function () {
         graphToolTile.getGraph().should('have.class', 'is-linked');
       });
       it('verify points added has label in table and graph', function () {
-        tableToolTile.getIndexNumberToggle().should('exist').click({force: true});
+        tableToolTile.getIndexNumberToggle().should('exist').click({ force: true });
         tableToolTile.getTableIndexColumnCell().first().should('contain', '1');
         graphToolTile.getGraphPointLabel().contains('A').should('exist');
         graphToolTile.getGraphPointLabel().contains('B').should('exist');
@@ -179,7 +179,7 @@ context('Graph Table Integration', function () {
         graphToolTile.getGraphPoint().last().click({ force: true }).click({ force: true });
       });
       it('will add an angle to a point created from a table', function () {
-        graphToolTile.getGraphPolygon().last().click({force: true});
+        graphToolTile.getGraphPolygon().last().click({ force: true });
         graphToolTile.showAngle();
         graphToolTile.getAngleAdornment().should('exist');
       });
@@ -187,7 +187,7 @@ context('Graph Table Integration', function () {
     describe.skip('test non-numeric entries in table', function () {
       it('will enter non-numeric number in the table', function () {
         tableToolTile.getTableCellWithColIndex(2, 6).scrollIntoView();
-        tableToolTile.getTableCellWithColIndex(2, 6).click({force: true}).type(9);
+        tableToolTile.getTableCellWithColIndex(2, 6).click({ force: true }).type(9);
         tableToolTile.getTableCell().eq(3).should('contain', x[1]);
       });
     });

--- a/cypress/e2e/clue/branch/student_tests/simulator_tile_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/simulator_tile_spec.js
@@ -76,7 +76,7 @@ context('Simulator Tile with Brainwaves Gripper Simulation', function () {
       // Live output options are correct after adding the simulation to the document
       dataflowTile.getDropdown(lo, "hubSelect").click();
       dataflowTile.getDropdownOptions(lo, "hubSelect").should("have.length", 2);
-      dataflowTile.getDropdownOptions(lo, "hubSelect").eq(0).click({force: true});
+      dataflowTile.getDropdownOptions(lo, "hubSelect").eq(0).click({ force: true });
 
       // Simulator tile's output variable updates when dataflow sets it
       dataflowTile.getCreateNodeButton("number").click();

--- a/cypress/e2e/clue/branch/teacher_tests/teacher_support_note.js
+++ b/cypress/e2e/clue/branch/teacher_tests/teacher_support_note.js
@@ -39,8 +39,8 @@ context.skip('Support messages in student view', () => {
 
     cy.log('verify group support note appears in student view');
     loadStudentSession(queryParams.student10QueryParams);
-    cy.get('#icon-sticky-note').should('exist').click({force:true});
-    cy.get('#icon-sticky-note').click({force:true}).then(()=> {
+    cy.get('#icon-sticky-note').should('exist').click({ force:true });
+    cy.get('#icon-sticky-note').click({ force:true }).then(()=> {
       cy.get('.sticky-note-popup').should('exist');
       cy.get('.sticky-note-popup-item-content').should('contain', textToGroup);
     });
@@ -58,8 +58,8 @@ context.skip('Support messages in student view', () => {
 
     cy.log('verify student support note appears in student view');
     loadStudentSession(queryParams.student1QueryParams);
-    cy.get('#icon-sticky-note').should('exist').click({force:true});
-    cy.get('#icon-sticky-note').click({force:true}).then(()=> {
+    cy.get('#icon-sticky-note').should('exist').click({ force:true });
+    cy.get('#icon-sticky-note').click({ force:true }).then(()=> {
       cy.get('.sticky-note-popup').should('exist');
       cy.get('.sticky-note-popup-item-content').should('contain', textToStudent);
     });

--- a/cypress/e2e/clue/branch/teacher_tests/teacher_workspace_spec.js
+++ b/cypress/e2e/clue/branch/teacher_tests/teacher_workspace_spec.js
@@ -105,7 +105,7 @@ context('Teacher Workspace', () => {
       //So we close the Resources panel, and re-open to force it to rerender
       cy.collapseResourceTabs();
       cy.openResourceTabs();
-      cy.get('.top-tab.tab-teacher-guide').should('exist').click({force:true});
+      cy.get('.top-tab.tab-teacher-guide').should('exist').click({ force:true });
       cy.get('.prob-tab.teacher-guide').should('exist').and('have.length', 4).each(function (subTab, index, subTabList) {
         const teacherGuideSubTabs = ["Launch", "Explore", "Summarize", "Unit Plan"];
         cy.wrap(subTab).text().should('contain', teacherGuideSubTabs[index]);
@@ -122,7 +122,7 @@ context('Teacher Workspace', () => {
       cy.wait(2000);
       cy.get('@clueData').then((clueData) => {
         const groups = clueData.classes[0].problems[0].groups;
-        cy.get('.top-tab.tab-student-work').should('exist').click({force:true});
+        cy.get('.top-tab.tab-student-work').should('exist').click({ force:true });
         cy.get('.student-group-view').should('be.visible');
         cy.get('.student-group .group-number').should('be.visible').and('have.length', groups.length);
         cy.get('.student-group .group-number').eq(0).should('have.class', 'active');

--- a/cypress/e2e/clue/full/student_tests/group_chooser_spec.js
+++ b/cypress/e2e/clue/full/student_tests/group_chooser_spec.js
@@ -26,7 +26,7 @@ describe('Test student join a group', function(){
     };
 
     function setup(student, opts={} ){
-        const options = {...defaultSetupOptions, ...opts};
+        const options = { ...defaultSetupOptions, ...opts };
         cy.visit('?appMode=qa&fakeClass='+fakeClass+'&fakeUser=student:'+student+'&problem='+options.problem);
         if (options.alreadyInGroup) {
           // This is looking for the version div in the header
@@ -35,7 +35,7 @@ describe('Test student join a group', function(){
           // If the student is not in a group already the header will not show up
           // instead only a group chooser dialog is shown. The timeout of 60s is the same
           // used by waitForLoad and gives the app extra time to load
-          cy.get('.join-title', {timeout: 60000});
+          cy.get('.join-title', { timeout: 60000 });
         }
     }
 
@@ -100,7 +100,7 @@ describe('Test student join a group', function(){
     });
     it('will verify cancel of leave group dialog', function(){
         //have student leave first group and join second group
-        setup(student5, {alreadyInGroup: true});
+        setup(student5, { alreadyInGroup: true });
         cy.get('.app .group > .name').contains('Group '+group1).click();
         cy.get('#cancelButton').should('contain', 'No').click();
         clueHeader.getGroupName().should('contain', 'Group '+group1);
@@ -110,7 +110,7 @@ describe('Test student join a group', function(){
     });
     it('will verify a student can switch groups', function(){
         //have student leave first group and join second group
-        setup(student5, {alreadyInGroup: true});
+        setup(student5, { alreadyInGroup: true });
         cy.get('.app .group > .name').contains('Group '+group1).click();
         cy.get("#okButton").should('contain', 'Yes').click();
         cy.get('.groups > .group-list > .group').contains('Group '+group2).click();
@@ -128,7 +128,7 @@ describe('Test student join a group', function(){
         clueHeader.getGroupMembers().should('contain', 'S'+student1).and('contain', 'S'+student2).and('contain', 'S'+student4).and('contain', 'S'+student6);
     });
     it('Student will automatically join last group number in new problem', function(){
-        setup(student1, {alreadyInGroup: true, problem: '2.3'});
+        setup(student1, { alreadyInGroup: true, problem: '2.3' });
         clueHeader.getGroupName().should('contain', 'Group '+group1);
         header.getUserName().should('contain', 'Student '+student1);
         clueHeader.getGroupMembers().should('contain', 'S'+student1).and('have.length', 1);

--- a/cypress/e2e/clue/full/teacher_tests/teacher_dashboard_spec.js
+++ b/cypress/e2e/clue/full/teacher_tests/teacher_dashboard_spec.js
@@ -35,7 +35,7 @@ function beforeTest() {
 // This test creates a lot of dom elements because it it showing 6 4-up views. So it is showing
 // 23 documents at once. This seems to give cypress problems, setting numTestsKeptInMemory to 0
 // improves things.
-context('Teacher Dashboard View', {numTestsKeptInMemory: 0}, () => {
+context('Teacher Dashboard View', { numTestsKeptInMemory: 0 }, () => {
   it('verify header elements', () => {
     beforeTest();
     cy.get('@clueData').then((clueData) => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -32,7 +32,7 @@ import 'cypress-file-upload';
 import 'cypress-commands';
 import ResourcesPanel from "./elements/clue/ResourcesPanel";
 import ClueCanvas from './elements/clue/cCanvas';
-import {platformCmdKey} from '../../src/utilities/hot-keys';
+import { platformCmdKey } from '../../src/utilities/hot-keys';
 
 const clueCanvas = new ClueCanvas;
 
@@ -91,7 +91,7 @@ Cypress.Commands.add("clearQAData", (data)=>{ //clears data from Firebase (curre
         //   or a weakset, but undefined given
         // The log shows the assertion passing and then shows it failing right after
         // using contains fixes this problem.
-        cy.contains('span', 'QA Cleared: OK', {timeout: 60000});
+        cy.contains('span', 'QA Cleared: OK', { timeout: 60000 });
     }
 });
 
@@ -108,7 +108,7 @@ Cypress.Commands.add("login", (baseUrl, testTeacher) => {
       the login will fail in a strange way. It returns success, but doesn't set a valid
       cookie.
     */
-    cy.clearCookies({domain: null});
+    cy.clearCookies({ domain: null });
 
     cy.request({
         url: `${baseUrl}/api/v1/users/sign_in`,
@@ -144,7 +144,7 @@ Cypress.Commands.add("launchReport", (reportUrl) => {
     });
 });
 Cypress.Commands.add("waitForLoad", () => {
-  cy.get('.version', {timeout: 60000});
+  cy.get('.version', { timeout: 60000 });
 });
 Cypress.Commands.add("deleteWorkspaces", (baseUrl, queryParams)=>{
     let primaryWorkspace = new PrimaryWorkspace;
@@ -178,10 +178,10 @@ Cypress.Commands.add("openTopTab", (tab) => {
   cy.get('.top-tab.tab-'+tab).click();
 } );
 Cypress.Commands.add("openProblemSection", (section) => {//doc-tab my-work workspaces problem-documents selected
-  cy.get('.prob-tab').contains(section).click({force:true});
+  cy.get('.prob-tab').contains(section).click({ force:true });
 });
 Cypress.Commands.add("openSection", (tab, section) => {//doc-tab my-work workspaces problem-documents selected
-  cy.get('.doc-tab.'+tab+'.'+section).click({force:true});
+  cy.get('.doc-tab.'+tab+'.'+section).click({ force:true });
 });
 
 // TODO: this is duplicated in ResourcesPanel.js, however in that case the tab
@@ -191,16 +191,16 @@ Cypress.Commands.add("getCanvasItemTitle", (section) => {
   cy.get('.list.'+section+' [data-test='+section+'-list-items] .footer');
 });
 Cypress.Commands.add("openDocumentThumbnail", (navTab, section, title) => { //opens thumbnail into the nav panel
-  cy.get('.document-tabs.'+navTab+' .list.'+section+' [data-test='+section+'-list-items] .footer').contains(title).parent().parent().siblings('.scaled-list-item-container').click({force:true});
+  cy.get('.document-tabs.'+navTab+' .list.'+section+' [data-test='+section+'-list-items] .footer').contains(title).parent().parent().siblings('.scaled-list-item-container').click({ force:true });
 });
 Cypress.Commands.add("openDocumentWithTitle", (tab, section, title) => {
   cy.openSection(tab, section);
-  cy.get('.document-tabs.'+tab+' .list.'+section+' [data-test='+section+'-list-items] .footer').contains(title).parent().parent().siblings('.scaled-list-item-container').click({force:true});
+  cy.get('.document-tabs.'+tab+' .list.'+section+' [data-test='+section+'-list-items] .footer').contains(title).parent().parent().siblings('.scaled-list-item-container').click({ force:true });
   cy.get('.document-tabs.'+tab+' [data-test=subtab-'+section+'] .edit-button').click();
 });
 Cypress.Commands.add("openDocumentWithIndex", (tab, section, docIndex) => {
   cy.openSection(tab, section);
-  cy.get('.list.'+section+' [data-test='+section+'-list-items] .footer').eq(docIndex).siblings('.scaled-list-item-container').click({force:true});
+  cy.get('.list.'+section+' [data-test='+section+'-list-items] .footer').eq(docIndex).siblings('.scaled-list-item-container').click({ force:true });
   cy.get('.edit-button').click();
 });
 Cypress.Commands.add("clickProblemResourceTile", (subsection, tileIndex = 0) => {
@@ -218,7 +218,7 @@ Cypress.Commands.add("getDocumentToolTile", (tileIndex = 0) => {
 Cypress.Commands.add('collapseResourceTabs', () => {
   cy.get('.drag-thumbnail').trigger('mouseover').then(() => {
     cy.get('.divider-container .workspace-expander').click();
-    cy.get('.primary-workspace .toolbar', {timeout: 120000});
+    cy.get('.primary-workspace .toolbar', { timeout: 120000 });
   });
 });
 Cypress.Commands.add('closeResourceTabs', () => {
@@ -229,7 +229,7 @@ Cypress.Commands.add('showOnlyDocumentWorkspace', () => {
   cy.get(".workspace").then($workspace => {
     // only toggle the full screen of the document workspace if it is necessary
     if($workspace.find(".divider-container").length > 0) {
-      cy.get('.primary-workspace .canvas').type(`{${cmdKey}+shift+f}`, {force: true});
+      cy.get('.primary-workspace .canvas').type(`{${cmdKey}+shift+f}`, { force: true });
     }
   });
 });
@@ -277,5 +277,5 @@ Cypress.Commands.add('unlinkTableToDataflow', (program, table) => {
   });
 });
 Cypress.Commands.add("deleteDocumentThumbnail", (tab, section, title) => {
-  cy.get('.'+tab+' .list.'+section+' [data-test='+section+'-list-items] .footer .icon-delete-document').eq(1).click({force:true});
+  cy.get('.'+tab+' .list.'+section+' [data-test='+section+'-list-items] .footer .icon-delete-document').eq(1).click({ force:true });
 });

--- a/cypress/support/elements/clue/ArrowAnnotation.js
+++ b/cypress/support/elements/clue/ArrowAnnotation.js
@@ -7,7 +7,7 @@ class ArrowAnnotation {
     cy.get(`${wsClass(workspaceClass)} .tool.sparrow`).click({ force: true });
   }
   clickHideAnnotationsButton(workspaceClass) {
-    cy.get(`${wsClass(workspaceClass)} .tool.hide-annotations`).click({force: true});
+    cy.get(`${wsClass(workspaceClass)} .tool.hide-annotations`).click({ force: true });
   }
   getAnnotationLayer(workspaceClass) {
     return cy.get(`${wsClass(workspaceClass)} .annotation-layer`);

--- a/cypress/support/elements/clue/ChatPanel.js
+++ b/cypress/support/elements/clue/ChatPanel.js
@@ -63,12 +63,12 @@ class ChatPanel{
     }
     typeInCommentArea(commentText) {
       // If the comment list is long, the text box is off screen so force.
-      cy.get("[data-testid=comment-textarea]").scrollIntoView().type(commentText, {force: true});
+      cy.get("[data-testid=comment-textarea]").scrollIntoView().type(commentText, { force: true });
       cy.wait(2000);
     }
     clickPostCommentButton() {
       // If the comment list is long, the button is off screen so force.
-      cy.get("[data-testid=comment-post-button]").scrollIntoView().click({force: true});
+      cy.get("[data-testid=comment-post-button]").scrollIntoView().click({ force: true });
       cy.wait(5000);
     }
     useEnterToPostComment() {

--- a/cypress/support/elements/clue/DataflowToolTile.js
+++ b/cypress/support/elements/clue/DataflowToolTile.js
@@ -212,8 +212,8 @@ class DataflowToolTile {
       this.getNode(node.name).should("exist");
       this.getNodeTitle().should("contain", node.title);
     });
-    this.getNodeOutput().eq(0).click({force: true});
-    this.getNodeInput().eq(0).click({force: true});
+    this.getNodeOutput().eq(0).click({ force: true });
+    this.getNodeInput().eq(0).click({ force: true });
   }
   recordData(samplingRate, timer) {
     this.selectSamplingRate(samplingRate);

--- a/cypress/support/elements/clue/GraphToolTile.js
+++ b/cypress/support/elements/clue/GraphToolTile.js
@@ -86,7 +86,7 @@ class GraphToolTile{
         let transX=this.transformFromCoordinate('x', x),
             transY=this.transformFromCoordinate('y', y);
 
-        this.getGraph().last().click(transX, transY, {force:true});
+        this.getGraph().last().click(transX, transY, { force:true });
     }
     getGraphPointID(point){
          return cy.get('.geometry-content.editable ellipse').eq(point)
@@ -102,7 +102,7 @@ class GraphToolTile{
         let transX=this.transformFromCoordinate('x', x),
             transY=this.transformFromCoordinate('y', y);
 
-        this.getGraph().last().click(transX, transY, {force:true});
+        this.getGraph().last().click(transX, transY, { force:true });
     }
     getRotateTool(){
         return cy.get('.single-workspace .rotate-polygon-icon.enabled');
@@ -111,7 +111,7 @@ class GraphToolTile{
         return cy.get('.geometry-menu-button');
     }
     showAngle(){
-        cy.get('.single-workspace.primary-workspace .geometry-toolbar .button.angle-label').click({force: true});
+        cy.get('.single-workspace.primary-workspace .geometry-toolbar .button.angle-label').click({ force: true });
     }
     hideAngle(){
         cy.get('.single-workspace.primary-workspace .geometry-toolbar .button.angle-label.enabled').click();

--- a/cypress/support/elements/clue/TeacherDashboard.js
+++ b/cypress/support/elements/clue/TeacherDashboard.js
@@ -155,7 +155,7 @@ class TeacherDashboard {
             }
         }
         // subtract 4 because there are 4 published docs that are not in view
-        this.getStarPublishIcon().should('have.length', totalPublished-4).click({force:true, multiple:true});
+        this.getStarPublishIcon().should('have.length', totalPublished-4).click({ force:true, multiple:true });
     }
     clearAllStarsFromPublishedWork() {
         cy.get('.icon-star').each(star => {

--- a/cypress/support/elements/common/Canvas.js
+++ b/cypress/support/elements/common/Canvas.js
@@ -131,9 +131,9 @@ class Canvas {
 
   publishCanvas(type) {
     if (type==="investigation" ) {
-      this.getPublishIcon().click({force:true});
+      this.getPublishIcon().click({ force:true });
     } else {
-      this.getPersonalPublishIcon().click({force:true});
+      this.getPersonalPublishIcon().click({ force:true });
     }
     dialog.getModalTitle().should('exist').contains('Publish ');
     dialog.getModalButton().contains("OK").click();

--- a/cypress/support/elements/common/PrimaryWorkspace.js
+++ b/cypress/support/elements/common/PrimaryWorkspace.js
@@ -62,16 +62,16 @@ class PrimaryWorkspace{
 
     deleteSupport(index) {
         if (index === "all") {
-            return cy.get('svg.icon-delete-document').click({multiple:true, force:true});
+            return cy.get('svg.icon-delete-document').click({ multiple:true, force:true });
         } else {
-            return cy.get('svg.icon-delete-document').eq(index-1).click({force:true});
+            return cy.get('svg.icon-delete-document').eq(index-1).click({ force:true });
         }
     }
     confirmDeleteDialog() {
         return cy.get('.dialog-container').within(() => {
             cy.get('.dialog-title').contains('Confirm Delete');
             cy.get('.dialog-text').contains('Do you want to delete this?');
-            cy.get('button#okButton').contains('Yes').click({force:true});
+            cy.get('button#okButton').contains('Yes').click({ force:true });
         });
     }
 }

--- a/src/clue/components/clue-app-content.tsx
+++ b/src/clue/components/clue-app-content.tsx
@@ -22,7 +22,7 @@ export class ClueAppContentComponent extends BaseComponent<IProps> {
   }
 
   public render() {
-    const { appConfig: {autoAssignStudentsToIndividualGroups}, user, ui } = this.stores;
+    const { appConfig: { autoAssignStudentsToIndividualGroups }, user, ui } = this.stores;
 
     const panels: IPanelGroupSpec = [{
                     panelId: EPanelId.workspace,

--- a/src/clue/components/clue-app-header.tsx
+++ b/src/clue/components/clue-app-header.tsx
@@ -30,7 +30,7 @@ export const ClueAppHeaderComponent: React.FC<IProps> = observer(function ClueAp
                       ? `Firebase UID: ${db.firebase.userId}` : undefined;
 
   const renderPanelButtons = () => {
-    const { panels, onPanelChange, current} = props;
+    const { panels, onPanelChange, current } = props;
     if (!panels || (panels.length < 2)) return;
 
     const panelButtons = panels
@@ -180,7 +180,7 @@ export const ClueAppHeaderComponent: React.FC<IProps> = observer(function ClueAp
           </div>
           <div className="separator"/>
           <CustomSelect
-            items={[{text: `${problem.title}${problem.subtitle ? `: ${problem.subtitle}`: ""}`}]}
+            items={[{ text: `${problem.title}${problem.subtitle ? `: ${problem.subtitle}`: ""}` }]}
             isDisabled={true}
           />
         </div>

--- a/src/clue/components/progress-widget-item.tsx
+++ b/src/clue/components/progress-widget-item.tsx
@@ -13,7 +13,7 @@ interface IState {}
 export class ProgressWidgetItem extends React.Component<IProps, IState> {
 
   public render() {
-    const {item, selected} = this.props;
+    const { item, selected } = this.props;
     const circleClassName = `section-circle${selected ? " selected" : ""}`;
     return(
       <div className="progress-widget-item" key={item.label} onClick={this.handleClicked}>

--- a/src/clue/components/progress-widget.tsx
+++ b/src/clue/components/progress-widget.tsx
@@ -51,7 +51,7 @@ export class ProgressWidget extends BaseComponent<IProps, IState> {
     const sectionInitials = sections.map(section => section.initials);
 
     // get the tile section counts per user
-    const countsPerUser: {[key: string]: ITileCountsPerSection} = {};
+    const countsPerUser: { [key: string]: ITileCountsPerSection } = {};
     groups.allGroups.forEach(group => {
       documents.getProblemDocumentsForGroup(group.id).forEach(document => {
         // In the normal course of events there should only ever be one problem document per user,

--- a/src/clue/components/teacher/teacher-class-info-button.tsx
+++ b/src/clue/components/teacher/teacher-class-info-button.tsx
@@ -32,7 +32,7 @@ export class ClassInfoButton extends BaseComponent <IProps> {
   }
 
   private handleExportClick = async () => {
-    const {db, user} = this.stores; // access the database
+    const { db, user } = this.stores; // access the database
     const latestGroupsArray: string[] = []; // store the group ids
 
     const offeringsPath = db.firebase.getOfferingsPath(db.stores.user);
@@ -116,7 +116,7 @@ export class ClassInfoButton extends BaseComponent <IProps> {
   };
 
   private exportCSV = (csv: string, fileName: string) => {
-    const csvBlob = new Blob([csv], {type: "text/csv;charset=utf-8;"});
+    const csvBlob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
     // if (navigator.msSaveBlob) {
     //   navigator.msSaveBlob(csvBlob, fileName);
     // }

--- a/src/clue/components/teacher/teacher-dashboard.tsx
+++ b/src/clue/components/teacher/teacher-dashboard.tsx
@@ -18,7 +18,7 @@ interface TabInfo {
 }
 
 const tabs: TabInfo[] = [
-  {type: "Groups", id: "groups"},
+  { type: "Groups", id: "groups" },
   // TODO: add back tab when support stories (#160073804 && 160073880) are worked on
   // {type: "Supports", id: "supports"}
 ];
@@ -32,7 +32,7 @@ export class TeacherDashboardComponent extends BaseComponent<IProps, IState> {
   };
 
   public render() {
-    const {activeTab} = this.state;
+    const { activeTab } = this.state;
 
     return (
       <div className="teacher-dashboard">

--- a/src/clue/components/teacher/teacher-group-six-pack-fourup.tsx
+++ b/src/clue/components/teacher/teacher-group-six-pack-fourup.tsx
@@ -84,7 +84,7 @@ interface IGroupHeaderProps {
 }
 
 const TeacherGroupHeader: React.FC<IGroupHeaderProps> = observer(function TeacherGroupHeader(
-    {group, navTabName, documentViewMode}){
+    { group, navTabName, documentViewMode }){
   const { ui, db, groups }  = useStores();
 
   const openDocId = ui.tabs.get(navTabName)?.openDocuments.get(group.id);
@@ -95,7 +95,7 @@ const TeacherGroupHeader: React.FC<IGroupHeaderProps> = observer(function Teache
     if (focusedGroupUser) {
       ui.prompt(`Enter your message for ${focusedGroupUser.name}`, "", `Message ${focusedGroupUser.name}`, 5)
       .then((message) => {
-        const audience = AudienceModel.create({type: AudienceEnum.user, identifier: focusedGroupUser.id});
+        const audience = AudienceModel.create({ type: AudienceEnum.user, identifier: focusedGroupUser.id });
         db.createSupport(createStickyNote(message), "", audience);
         Logger.log(LogEventName.CREATE_STICKY_NOTE, {
           type: "user",
@@ -107,7 +107,7 @@ const TeacherGroupHeader: React.FC<IGroupHeaderProps> = observer(function Teache
     else {
       ui.prompt(`Enter your message for Group ${group.id}`, "", "Message Group", 5)
       .then((message) => {
-        const audience = AudienceModel.create({type: AudienceEnum.group, identifier: group.id});
+        const audience = AudienceModel.create({ type: AudienceEnum.group, identifier: group.id });
         db.createSupport(createStickyNote(message), "", audience);
         Logger.log(LogEventName.CREATE_STICKY_NOTE, {
           type: "group",

--- a/src/clue/components/teacher/teacher-group-tab.tsx
+++ b/src/clue/components/teacher/teacher-group-tab.tsx
@@ -31,7 +31,7 @@ export class  TeacherGroupTabComponent extends BaseComponent<IProps, IState> {
   }
 
   public render() {
-    const {page, documentViewMode, selectedSectionId} = this.state;
+    const { page, documentViewMode, selectedSectionId } = this.state;
     return (
       <div className="teacher-group-tab">
         <TeacherGroupSixPack
@@ -55,17 +55,17 @@ export class  TeacherGroupTabComponent extends BaseComponent<IProps, IState> {
     );
   }
 
-  private setPage = (nextPage: number) => this.setState({page: nextPage});
+  private setPage = (nextPage: number) => this.setState({ page: nextPage });
 
   private get numPages(){
     return Math.ceil(this.stores.groups.allGroups.length / GROUPS_PER_PAGE);
   }
 
   private setDocumentViewMode = (documentViewMode: DocumentViewMode) => {
-    this.setState({documentViewMode});
+    this.setState({ documentViewMode });
   };
 
   private setSelectedSectionId = (selectedSectionId: string) => {
-    this.setState({selectedSectionId});
+    this.setState({ selectedSectionId });
   };
 }

--- a/src/clue/components/teacher/teacher-student-tab.tsx
+++ b/src/clue/components/teacher/teacher-student-tab.tsx
@@ -22,7 +22,7 @@ export class TeacherStudentTabComponent extends BaseComponent<IProps, IState> {
 
   public UNSAFE_componentWillReceiveProps(nextProps: IProps) {
     if (nextProps.groupId !== this.props.groupId) {
-      this.setState({selectedUserId: undefined});
+      this.setState({ selectedUserId: undefined });
     }
   }
 
@@ -82,7 +82,7 @@ export class TeacherStudentTabComponent extends BaseComponent<IProps, IState> {
         </div>
         <div className="content">
           <TeacherSupports
-            audience={UserAudienceModel.create({identifier: user.id})}
+            audience={UserAudienceModel.create({ identifier: user.id })}
             supports={supports.userSupports.filter(support => {
               return !support.deleted && support.audience.identifier === user.id;
             })}
@@ -94,7 +94,7 @@ export class TeacherStudentTabComponent extends BaseComponent<IProps, IState> {
 
   private handleChooseUser = (user: GroupUserModelType) => {
     return (e: React.MouseEvent<HTMLElement>) => {
-      this.setState({selectedUserId: user.id});
+      this.setState({ selectedUserId: user.id });
     };
   };
 }

--- a/src/components/annotations/arrow-annotation.tsx
+++ b/src/components/annotations/arrow-annotation.tsx
@@ -58,7 +58,7 @@ interface IArrowAnnotationProps {
   documentRight: number;
   documentTop: number;
   getBoundingBox: (object: IClueObject) =>
-    { height: number, left: number, top: number, width: number} | null | undefined;
+    { height: number, left: number, top: number, width: number } | null | undefined;
   key?: string;
   readOnly?: boolean;
 }
@@ -259,7 +259,7 @@ export const ArrowAnnotationComponent = observer(
                   onChange={handleChange}
                   onKeyDown={handleKeyDown}
                   ref={inputRef}
-                  style={{ width: `calc(${tempText.length}ch + 2ch)`}}
+                  style={{ width: `calc(${tempText.length}ch + 2ch)` }}
                   type="text"
                   value={tempText}
                 />

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -24,7 +24,7 @@ interface IState {
 }
 
 function initRollbar(stores: IStores, problemId: string) {
-  const {user, unit, appVersion} = stores;
+  const { user, unit, appVersion } = stores;
   if (typeof (window as any).Rollbar !== "undefined") {
     const _Rollbar = (window as any).Rollbar;
     if (_Rollbar.configure) {
@@ -37,7 +37,7 @@ function initRollbar(stores: IStores, problemId: string) {
               role: user.type,
               unit: unit.title,
               version: appVersion
-            }};
+            } };
       _Rollbar.configure(config);
     }
   }
@@ -47,20 +47,20 @@ function resolveAppMode(
   stores: IStores,
   rawFirebaseJWT: string | undefined,
   onQAClear?: (result: boolean, err?: string) => void) {
-  const { appMode, db, ui} = stores;
+  const { appMode, db, ui } = stores;
   if (appMode === "authed")  {
     if (rawFirebaseJWT) {
-      return db.connect({appMode, stores, rawFirebaseJWT}).catch(error => ui.setError(error));
+      return db.connect({ appMode, stores, rawFirebaseJWT }).catch(error => ui.setError(error));
     }
     else {
       ui.setError("No firebase token available to connect to db!");
     }
   }
   else {
-    return db.connect({appMode, stores})
+    return db.connect({ appMode, stores })
       .then(() => {
         if (appMode === "qa") {
-          const {qaClear, qaGroup} = urlParams;
+          const { qaClear, qaGroup } = urlParams;
           if (qaClear) {
             const cleared = (err?: string) => {
               if (onQAClear) {
@@ -81,11 +81,11 @@ function resolveAppMode(
 }
 
 export const authAndConnect = (stores: IStores, onQAClear?: (result: boolean, err?: string) => void) => {
-  const {appConfig, appMode, db, user, ui} = stores;
+  const { appConfig, appMode, db, user, ui } = stores;
   let rawPortalJWT: string | undefined;
 
   authenticate(appMode, appConfig, urlParams)
-    .then(async ({appMode: newAppMode, authenticatedUser, classInfo, problemId, unitCode}) => {
+    .then(async ({ appMode: newAppMode, authenticatedUser, classInfo, problemId, unitCode }) => {
       // authentication can trigger appMode change (e.g. preview => demo)
       if (newAppMode && (newAppMode !== appMode)) {
         stores.setAppMode(newAppMode);
@@ -140,7 +140,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
     super(props);
 
     authAndConnect(this.stores, (qaCleared, qaClearError) => {
-      this.setState({qaCleared, qaClearError});
+      this.setState({ qaCleared, qaClearError });
     });
   }
 
@@ -160,7 +160,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
   // time.
 
   public render() {
-    const {appConfig, user, ui, db} = this.stores;
+    const { appConfig, user, ui, db } = this.stores;
 
     if (ui.showDemoCreator) {
       return this.renderApp(<DemoCreatorComponent />);
@@ -175,7 +175,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
     }
 
     if (urlParams.qaClear) {
-      const {qaCleared, qaClearError} = this.state;
+      const { qaCleared, qaClearError } = this.state;
       return this.renderApp(
         <span className="qa-clear">
           {qaCleared ? `QA Cleared: ${qaClearError || "OK"}` : "QA Clearing..."}

--- a/src/components/chat/chat-panel-header.tsx
+++ b/src/components/chat/chat-panel-header.tsx
@@ -14,8 +14,8 @@ interface IProps {
   chatPanelTitle: string;
 }
 
-export const ChatPanelHeader: React.FC<IProps> = observer(({activeNavTab, newCommentCount, onCloseChatPanel,
-  handleDocView, chatPanelTitle}) => {
+export const ChatPanelHeader: React.FC<IProps> = observer(({ activeNavTab, newCommentCount, onCloseChatPanel,
+  handleDocView, chatPanelTitle }) => {
   const renderNotification = () => {
     return (
       <div className="notification-toggle">

--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -1,9 +1,9 @@
-import React, { useCallback, useEffect, useState} from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { ILogComment, logCommentEvent } from "../../models/tiles/log/log-comment-event";
 import { UserModelType } from "../../models/stores/user";
 import { ChatPanelHeader } from "./chat-panel-header";
 import { ChatThread } from "./chat-thread";
-import { makeChatThreads} from "./chat-comment-thread";
+import { makeChatThreads } from "./chat-comment-thread";
 import {
   useCommentsCollectionPath, useDocumentComments, usePostDocumentComment, useUnreadDocumentComments
 } from "../../hooks/document-comment-hooks";

--- a/src/components/chat/chat-thread-toggle.tsx
+++ b/src/components/chat/chat-thread-toggle.tsx
@@ -9,7 +9,7 @@ interface IProps {
   activeNavTab?: string;
 }
 
-export const ChatThreadToggle: React.FC<IProps> = ({ isThreadExpanded, activeNavTab}) => {
+export const ChatThreadToggle: React.FC<IProps> = ({ isThreadExpanded, activeNavTab }) => {
   return (
     <div className={classNames(`chat-thread-toggle ${activeNavTab}`, {
           expanded: isThreadExpanded

--- a/src/components/chat/chat-thread.test.tsx
+++ b/src/components/chat/chat-thread.test.tsx
@@ -52,7 +52,7 @@ describe("CommentThread", () => {
   it("Render threads. No User owned comments", () => {
     const chatThreads =
       [makeFakeCommentThread("Thread 1", "abcd", "u1"), makeFakeCommentThread("Thread 2", "jkl", "u2")];
-    const testUser = {id: "uuuuuu", "name": "test user"} as UserModelType;
+    const testUser = { id: "uuuuuu", "name": "test user" } as UserModelType;
     render((
       <ModalProvider>
         <ChatThread chatThreads={chatThreads}
@@ -72,7 +72,7 @@ describe("CommentThread", () => {
   it("Focused Thread has correct styling and shows correct comments and metadata", () => {
     const chatThreads =
       [makeFakeCommentThread("Thread 1", "abcd", "u3"), makeFakeCommentThread("Thread 2", "jkl", "u4")];
-    const testUser = {id: "u4", "name": "test user"} as UserModelType;
+    const testUser = { id: "u4", "name": "test user" } as UserModelType;
     render((
       <ModalProvider>
         <ChatThread

--- a/src/components/chat/chat-thread.tsx
+++ b/src/components/chat/chat-thread.tsx
@@ -1,14 +1,14 @@
-import React, {useEffect, useState} from "react";
+import React, { useEffect, useState } from "react";
 import classNames from "classnames";
 import { ILogComment, logCommentEvent } from "../../models/tiles/log/log-comment-event";
 import { UserModelType } from "../../models/stores/user";
 import { getTileComponentInfo } from "../../models/tiles/tile-component-info";
 import { WithId } from "../../hooks/firestore-hooks";
 import { useUIStore } from "../../hooks/use-stores";
-import { CommentDocument} from "../../lib/firestore-schema";
+import { CommentDocument } from "../../lib/firestore-schema";
 import { CommentCard } from "./comment-card";
 import UserIcon from "../../assets/icons/clue-dashboard/teacher-student.svg";
-import {ChatCommentThread} from "./chat-comment-thread";
+import { ChatCommentThread } from "./chat-comment-thread";
 import { TileIconComponent } from "./tile-icon-component";
 import { ChatThreadToggle } from "./chat-thread-toggle";
 
@@ -26,7 +26,7 @@ interface IProps {
 }
 
 export const ChatThread: React.FC<IProps> = ({ activeNavTab, user, chatThreads,
-  onPostComment, onDeleteComment, focusDocument, focusTileId, isDocumentView}) => {
+  onPostComment, onDeleteComment, focusDocument, focusTileId, isDocumentView }) => {
 
   useEffect(() => {
     setExpandedThread(focusTileId || 'document');

--- a/src/components/chat/comment-card.tsx
+++ b/src/components/chat/comment-card.tsx
@@ -73,8 +73,8 @@ export const CommentCard: React.FC<IProps> = ({ activeNavTab, user, postedCommen
             // can't delete comment until we have a valid server-generated id
             const shouldShowDeleteIcon = isOwnComment && !comment.id.startsWith("pending-");
             const backgroundStyle = shouldShowUserIcon
-                                      ? {backgroundColor: "white"}
-                                      : {backgroundColor: userInitialBackgroundColor[userInitialBackgroundColorIndex]};
+              ? { backgroundColor: "white" }
+              : { backgroundColor: userInitialBackgroundColor[userInitialBackgroundColorIndex] };
 
             //if tagPrompt was posted to Firestore - for ex: SAS unit (where tagPrompt = "Select Student Strategy")
             //our comment.tags should be [""]

--- a/src/components/chat/comment-textbox.tsx
+++ b/src/components/chat/comment-textbox.tsx
@@ -23,7 +23,7 @@ export const CommentTextBox: React.FC<IProps> = (props) => {
   const [commentText, setCommentText] = useState("");
    //all the AI tags pertaining to one comment - length is 1 for now
   const [allTags, setAllTags] = useState([""]);
-  const textareaStyle = {height: commentTextAreaHeight};
+  const textareaStyle = { height: commentTextAreaHeight };
 
   const commentEmptyNoTags =  (!commentAdded && !showCommentTag);
   const postButtonClass = classNames("comment-footer-button", "themed-negative", activeNavTab,
@@ -123,7 +123,7 @@ export const CommentTextBox: React.FC<IProps> = (props) => {
   return (
     <div className="comment-textbox">
       <textarea
-        className={classNames({"shift-down" : showCommentTag})}
+        className={classNames({ "shift-down" : showCommentTag })}
         ref={textareaRef}
         style={textareaStyle}
         placeholder={placeholderText}

--- a/src/components/chat/commented-documents.tsx
+++ b/src/components/chat/commented-documents.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 
 import { useFirestore } from "../../hooks/firestore-hooks";
-import { useStores, useUIStore, useUserStore} from "../../hooks/use-stores";
+import { useStores, useUIStore, useUserStore } from "../../hooks/use-stores";
 import { useDocumentCaption } from "../../hooks/use-document-caption";
 import { CurriculumDocument, DocumentDocument } from "../../lib/firestore-schema";
 import { getSectionTitle } from "../../models/curriculum/section";
@@ -28,7 +28,7 @@ interface PromisedDocumentDocument extends DocumentDocument {
   title?: string
 }
 
-export const CommentedDocuments: React.FC<IProps> = ({user, handleDocView}) => {
+export const CommentedDocuments: React.FC<IProps> = ({ user, handleDocView }) => {
   const [db] = useFirestore();
   const ui = useUIStore();
   const store = useStores();
@@ -74,7 +74,7 @@ export const CommentedDocuments: React.FC<IProps> = ({user, handleDocView}) => {
           if (qs.empty === false) {
             const firstCharPosition = doc.id.split("_", 4).join("_").length + 1; //first char after 4th _
             const sectionType =  doc.id.substring(firstCharPosition, doc.id.length);
-            doc = {...doc, title: getSectionTitle(sectionType), numComments: qs.size};
+            doc = { ...doc, title: getSectionTitle(sectionType), numComments: qs.size };
             commentedDocs.push(doc as PromisedCurriculumDocument);
           }
         }));
@@ -119,7 +119,7 @@ export const CommentedDocuments: React.FC<IProps> = ({user, handleDocView}) => {
         const docCommentsRef = mDocsRef.doc(doc.id).collection("comments");
         promiseArr.push(docCommentsRef.get().then((qs)=>{
           if (qs.empty === false){
-            doc = {...doc, numComments: qs.size};
+            doc = { ...doc, numComments: qs.size };
             commentedDocs.push(doc as PromisedDocumentDocument);
           }
         }));
@@ -138,7 +138,7 @@ export const CommentedDocuments: React.FC<IProps> = ({user, handleDocView}) => {
       {
         docsCommentedOn &&
         (docsCommentedOn).map((doc: PromisedCurriculumDocument, index:number) => { //Problem + Teacher Guide documents
-          const {navTab} = getTabsOfCurriculumDoc(doc.path);
+          const { navTab } = getTabsOfCurriculumDoc(doc.path);
           return (
             <div
               className={`document-box ${navTab}`}

--- a/src/components/chat/tile-icon-component.tsx
+++ b/src/components/chat/tile-icon-component.tsx
@@ -8,7 +8,7 @@ interface IProps {
   tileId?: string;
 }
 
-export const TileIconComponent: React.FC<IProps> = ({documentKey, tileId}) => {
+export const TileIconComponent: React.FC<IProps> = ({ documentKey, tileId }) => {
   const tileType = useTypeOfTileInDocumentOrCurriculum(documentKey, tileId);
   const Icon = tileType && getTileComponentInfo(tileType)?.Icon;
   return Icon ? <Icon/> : <DocumentIcon/>;

--- a/src/components/class-menu-container.tsx
+++ b/src/components/class-menu-container.tsx
@@ -26,7 +26,7 @@ export class ClassMenuContainer extends BaseComponent <IProps> {
   }
 
   private getPortalClasses() {
-    const {user} = this.stores;
+    const { user } = this.stores;
     const classNames = uniq(user.portalClassOfferings.map(o => o.className));
     const currentProblemPath = this.stores.problemPath;
     const links: IDropdownItem[] = [];
@@ -47,7 +47,7 @@ export class ClassMenuContainer extends BaseComponent <IProps> {
       const handleClick = (name: string, url: string) => {
         const log = {
           event: LogEventName.DASHBOARD_SWITCH_CLASS,
-          parameters: {className, link: url}
+          parameters: { className, link: url }
         };
         Logger.log(log.event, log.parameters, LogEventMethod.DO);
         window.location.replace(url);

--- a/src/components/demo/demo-creator.tsx
+++ b/src/components/demo/demo-creator.tsx
@@ -56,7 +56,7 @@ export class DemoCreatorComponent extends BaseComponent<IProps> {
                         .replace("%investigationTitle%", investigation.title)
                         .replace("%problemTitle%", problem.fullTitle);
         const ordinal = `${investigation.ordinal}.${problem.ordinal}`;
-        this.problemOptions.push({investigation, problem, ordinal, title});
+        this.problemOptions.push({ investigation, problem, ordinal, title });
         if (!demo.problemOrdinal) {
           demo.setProblemOrdinal(ordinal);
         }

--- a/src/components/doc-editor-app.tsx
+++ b/src/components/doc-editor-app.tsx
@@ -75,7 +75,7 @@ export const DocEditorApp = ({ appConfig }: IDocEditorAppProps) => {
       // TODO: we probably want to keep track if we loaded an exported or raw file
       // and then save it the same way
       const contentJson = getSnapshot(document.content);
-      contents = stringify(contentJson, {maxLength: 100});
+      contents = stringify(contentJson, { maxLength: 100 });
     }
 
     const writable = await (_fileHandle as any).createWritable();
@@ -86,7 +86,7 @@ export const DocEditorApp = ({ appConfig }: IDocEditorAppProps) => {
   }
 
   useEffect(() => {
-    const {document: documentURL} = urlParams;
+    const { document: documentURL } = urlParams;
     if (!documentURL) {
       return;
     }

--- a/src/components/document/annotation-layer.tsx
+++ b/src/components/document/annotation-layer.tsx
@@ -48,7 +48,7 @@ export const AnnotationLayer = observer(function AnnotationLayer({
   }, [ui.annotationMode]);
 
   // Force rerenders when the layer's size changes
-  useResizeObserver({ref: divRef, box: "border-box"});
+  useResizeObserver({ ref: divRef, box: "border-box" });
 
   function getRowElement(rowId?: string) {
     if (rowId === undefined) return undefined;

--- a/src/components/document/canvas.tsx
+++ b/src/components/document/canvas.tsx
@@ -125,8 +125,8 @@ export class CanvasComponent extends BaseComponent<IProps, IState> {
   }
 
   private renderContent() {
-    const {content, document, showPlayback, viaTeacherDashboard, ...others} = this.props;
-    const {showPlaybackControls} = this.state;
+    const { content, document, showPlayback, viaTeacherDashboard, ...others } = this.props;
+    const { showPlaybackControls } = this.state;
     const documentToShow = this.getDocumentToShow();
     const documentContent = content || documentToShow?.content; // we only pass in content if it is a problem panel
     const typeClass = document?.type === "planning" ? "planning-doc" : "";
@@ -144,7 +144,7 @@ export class CanvasComponent extends BaseComponent<IProps, IState> {
             content={documentContent}
             documentId={documentToShow?.key}
             onScroll={(x: number, y: number) => this.setState({ documentScrollX: x, documentScrollY: y })}
-            {...{typeClass, viaTeacherDashboard, ...others}}
+            {...{ typeClass, viaTeacherDashboard, ...others }}
           />
           {showPlayback && (
             <PlaybackComponent
@@ -166,7 +166,7 @@ export class CanvasComponent extends BaseComponent<IProps, IState> {
     if (document && DEBUG_CANVAS) {
       return (
         <div className="canvas-debug">
-          <span style={{fontSize: "1.5em"}}>{document.key}</span>
+          <span style={{ fontSize: "1.5em" }}>{document.key}</span>
         </div>
       );
     }
@@ -177,7 +177,7 @@ export class CanvasComponent extends BaseComponent<IProps, IState> {
     if (overlayMessage) {
       return (
         <div className="canvas-overlay-message">
-          <span style={{fontSize: "1.5em"}}>{overlayMessage}</span>
+          <span style={{ fontSize: "1.5em" }}>{overlayMessage}</span>
         </div>
       );
     }
@@ -213,7 +213,7 @@ export class CanvasComponent extends BaseComponent<IProps, IState> {
       return;
     }
     const json = getSnapshot(documentContent);
-    const jsonString =  stringify(json, {maxLength: 100});
+    const jsonString =  stringify(json, { maxLength: 100 });
     navigator.clipboard.writeText(jsonString);
   };
 
@@ -278,7 +278,7 @@ export class CanvasComponent extends BaseComponent<IProps, IState> {
       if (prevState.historyDocumentCopy) {
         destroy(prevState.historyDocumentCopy);
       }
-      logHistoryEvent({documentId: this.props.document?.key || '',
+      logHistoryEvent({ documentId: this.props.document?.key || '',
         action: showPlaybackControls ? "showControls": "hideControls" });
       return {
         showPlaybackControls,
@@ -303,7 +303,7 @@ export class CanvasComponent extends BaseComponent<IProps, IState> {
   };
 
   private getDocumentToShow = () => {
-    const {showPlaybackControls, historyDocumentCopy: documentToShow} = this.state;
+    const { showPlaybackControls, historyDocumentCopy: documentToShow } = this.state;
     if (showPlaybackControls && documentToShow) {
       return documentToShow;
     } else {

--- a/src/components/document/document-content.tsx
+++ b/src/components/document/document-content.tsx
@@ -120,7 +120,7 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
       }
 
       // scroll to selected section if it changed
-      const {selectedSectionId} = this.props;
+      const { selectedSectionId } = this.props;
       if (selectedSectionId && (selectedSectionId !== prevProps.selectedSectionId)) {
         this.scrollToSection(selectedSectionId);
       }
@@ -129,7 +129,7 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
       requestAnimationFrame(() => {
         if (this.props.content !== prevProps.content) {
           if (!this.scrollToSection(this.props.selectedSectionId)) {
-            domElement.scrollTo({top: 0});
+            domElement.scrollTo({ top: 0 });
           }
         }
       });
@@ -144,7 +144,7 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
                                           && ui.focusDocument;
     const documentClass = classNames(
       "document-content",
-      {"document-content-smooth-scroll" : viaTeacherDashboard, "comment-select" : documentSelectedForComment},
+      { "document-content-smooth-scroll" : viaTeacherDashboard, "comment-select" : documentSelectedForComment },
       this.props.readOnly ? "read-only" : "read-write"
     );
 
@@ -244,7 +244,8 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
   }
 
   private renderSpacer = () => {
-    const spacerClass = classNames({"spacer" : !this.props.readOnly, "playback-spacer": this.props.showPlaybackSpacer});
+    const spacerClass = classNames({ "spacer" : !this.props.readOnly,
+      "playback-spacer": this.props.showPlaybackSpacer });
     return <div className={spacerClass} onClick={this.handleClick} />;
   };
 
@@ -447,7 +448,7 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
     const isInsertingInExistingRow = insertRowInfo?.rowDropLocation &&
                                       (["left", "right"].indexOf(insertRowInfo.rowDropLocation) >= 0);
     const addSidecarNotes = (toolId.toLowerCase() === "geometry") && !isInsertingInExistingRow;
-    const rowTile = content.userAddTile(toolId, {title, addSidecarNotes, insertRowInfo});
+    const rowTile = content.userAddTile(toolId, { title, addSidecarNotes, insertRowInfo });
 
     if (rowTile?.tileId) {
       ui.setSelectedTileId(rowTile.tileId);
@@ -504,7 +505,7 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
 
     const sectionElementTop = this.findSectionElementTop(this.domElement, sectionId);
     if (sectionElementTop !== undefined) {
-      this.domElement.scrollTo({top: sectionElementTop});
+      this.domElement.scrollTo({ top: sectionElementTop });
       return true;
     }
     return false;

--- a/src/components/document/document-error.tsx
+++ b/src/components/document/document-error.tsx
@@ -24,7 +24,7 @@ export const DocumentError: React.FC<IProps> = ({ document }) => {
       {document.invalidContent &&
         <>
           <h2>Document Content</h2>
-          <pre>{stringify(document.invalidContent, {maxLength: 150})}</pre>
+          <pre>{stringify(document.invalidContent, { maxLength: 150 })}</pre>
         </>
       }
     </div>

--- a/src/components/document/document-workspace.tsx
+++ b/src/components/document/document-workspace.tsx
@@ -175,10 +175,10 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps> {
 
   private handleDropSide = (side: WorkspaceSide) => {
     return (e: React.DragEvent<HTMLDivElement>) => {
-      const {ui, documents} = this.stores;
+      const { ui, documents } = this.stores;
       const documentKey = e.dataTransfer && e.dataTransfer.getData(DocumentDragKey);
       if (documentKey) {
-        const {problemWorkspace} = ui;
+        const { problemWorkspace } = ui;
         const document = documents.getDocument(documentKey);
         if (document) {
           if ((side === "primary") && !document.isPublished) {
@@ -202,7 +202,7 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps> {
   };
 
   private handleImageDrop = (e: React.DragEvent<HTMLDivElement>, rowId?: string) => {
-    const {ui} = this.stores;
+    const { ui } = this.stores;
     this.imageDragDrop.drop(e)
       .then((url) => {
         const primaryDocument = this.getPrimaryDocument(ui.problemWorkspace.primaryDocumentKey);
@@ -258,7 +258,7 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps> {
   private handleNewDocumentOpen = async (type: OtherDocumentType, title: string) => {
     const { db, ui: { problemWorkspace } } = this.stores;
     const content = this.defaultOtherDocumentContent(type);
-    const newDocument = await db.createOtherDocument(type, {title, content});
+    const newDocument = await db.createOtherDocument(type, { title, content });
     if (newDocument) {
       problemWorkspace.setPrimaryDocument(newDocument);
     }

--- a/src/components/document/document.tsx
+++ b/src/components/document/document.tsx
@@ -216,7 +216,7 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
   }
 
   private renderProblemTitleBar(type: string, hideButtons?: boolean) {
-    const {problem, appMode, clipboard, user: { isTeacher }} = this.stores;
+    const { problem, appMode, clipboard, user: { isTeacher } } = this.stores;
     const problemTitle = problem.title;
     const { document, workspace } = this.props;
     const isShared = document.visibility === "public";
@@ -269,7 +269,7 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
 
   private getStickyNoteData() {
     if (!this.isPrimary()) {
-      return {stickyNotes: [], hasNotes: false, showNotes: false};
+      return { stickyNotes: [], hasNotes: false, showNotes: false };
     }
     const { user, supports } = this.stores;
     const { stickyNotesVisible } = this.state;
@@ -283,11 +283,11 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
     const hasNotes = stickyNotes.length > 0;
     const hasNewStickyNotes = supports.hasNewStickyNotes(user.lastStickyNoteViewTimestamp);
     const showNotes = hasNotes && (stickyNotesVisible || hasNewStickyNotes);
-    return {stickyNotes, hasNotes, showNotes};
+    return { stickyNotes, hasNotes, showNotes };
   }
 
   private renderStickyNotes() {
-    const {hasNotes, showNotes} = this.getStickyNoteData();
+    const { hasNotes, showNotes } = this.getStickyNoteData();
     if (!hasNotes) {
       return;
     }
@@ -301,7 +301,7 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
 
   private renderStickyNotesPopup() {
     const { user } = this.stores;
-    const { stickyNotes, showNotes} = this.getStickyNoteData();
+    const { stickyNotes, showNotes } = this.getStickyNoteData();
     if (!showNotes || !this.stickyNoteIcon || !this.documentContainer) {
       return;
     }
@@ -312,7 +312,7 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
     const top = 55;
     const left = (iconRect.left - documentRect.left) - (maxWidth / 2);
     return (
-      <div className="sticky-note-popup" style={{top, left, maxWidth}}>
+      <div className="sticky-note-popup" style={{ top, left, maxWidth }}>
         <div className="sticky-note-popup-titlebar">
           <div className="sticky-note-popup-titlebar-title" >{title}</div>
           <div className="sticky-note-popup-titlebar-close-icon" onClick={this.handleViewStickyNoteClose} />
@@ -342,7 +342,7 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
   }
 
   private renderMode() {
-    const {workspace} = this.props;
+    const { workspace } = this.props;
     const mode = workspace.mode === "1-up" ? "up1" : "up4";
     const modeTitle = workspace.mode === "1-up" ? "Join Group View" : "Return to Student View";
     return (
@@ -375,7 +375,7 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
               <PublishButton document={document} />}
           </div>
         }
-        {hasDisplayId && <div className="display-id" style={{opacity: 0}}>{displayId}</div>}
+        {hasDisplayId && <div className="display-id" style={{ opacity: 0 }}>{displayId}</div>}
         {
           document.type === LearningLogDocument || document.type === LearningLogPublication
           ? <div className="title" data-test="learning-log-title">
@@ -424,17 +424,17 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
   };
 
   private handleShowTwoUp = () => {
-    this.props.workspace.toggleComparisonVisible({override: true});
+    this.props.workspace.toggleComparisonVisible({ override: true });
   };
   private handleHideTwoUp = () => {
-    this.props.workspace.toggleComparisonVisible({override: false});
+    this.props.workspace.toggleComparisonVisible({ override: false });
   };
 
   private handleDownloadTileJson = () => {
     const { clipboard } = this.stores;
     const tileJson = clipboard.getJsonTileContent();
     if (tileJson) {
-      const blobJson = new Blob([tileJson], {type: "text/plain;charset=utf-8"});
+      const blobJson = new Blob([tileJson], { type: "text/plain;charset=utf-8" });
       FileSaver.saveAs(blobJson, "tile-content.json");
     }
     clipboard.clear();
@@ -488,7 +488,7 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
   }
 
   private setStickyNotesVisible = (stickyNotesVisible: boolean) => {
-    this.setState({stickyNotesVisible});
+    this.setState({ stickyNotesVisible });
     this.stores.db.setLastStickyNoteViewTimestamp();
   };
 

--- a/src/components/document/editable-document-content.tsx
+++ b/src/components/document/editable-document-content.tsx
@@ -44,7 +44,7 @@ interface IOneUpCanvasProps {
   readOnly: boolean;
 }
 const OneUpCanvas: React.FC<IOneUpCanvasProps> = props => {
-  const {document, ...others} = props;
+  const { document, ...others } = props;
 
 
   return (
@@ -81,7 +81,7 @@ const DocumentCanvas: React.FC<IDocumentCanvasProps> = props => {
     <div className="canvas-area">
       {isFourUp
         ? <EditableFourUpCanvas userId={document.uid} />
-        : <OneUpCanvas {...{document, readOnly, showPlayback}} />}
+        : <OneUpCanvas {...{ document, readOnly, showPlayback }} />}
     </div>
   );
 };
@@ -111,7 +111,7 @@ export function EditableDocumentContent({
   const documentSelectedForComment = isChatEnabled && ui.showChatPanel && ui.selectedTileIds.length === 0 && !isPrimary;
   const editableDocContentClass = classNames("editable-document-content", showToolbarClass,
     contained ? "contained-editable-document-content" : "full-screen-editable-document-content",
-    {"comment-select" : documentSelectedForComment, "full-height": fullHeight}, className);
+    { "comment-select" : documentSelectedForComment, "full-height": fullHeight }, className);
 
   useDocumentSyncToFirebase(user, firebase, document, readOnly);
   return (
@@ -123,7 +123,7 @@ export function EditableDocumentContent({
           {isShowingToolbar && <div className="canvas-separator"/>}
           <DocumentCanvas
             readOnly={isReadOnly}
-            {...{mode, isPrimary, document, showPlayback}}
+            {...{ mode, isPrimary, document, showPlayback }}
           />
         </div>
       </EditableTileApiInterfaceRefContext.Provider>

--- a/src/components/document/group-virtual-document.tsx
+++ b/src/components/document/group-virtual-document.tsx
@@ -69,8 +69,8 @@ export class GroupVirtualDocumentComponent extends BaseComponent<IProps, IState>
 
   private handleGroupClicked(groupID: string) {
     const { ui } = this.stores;
-    Logger.log(LogEventName.VIEW_GROUP, {group: groupID, via: "group-document-titlebar"});
-    ui.problemWorkspace.setComparisonDocument(new GroupVirtualDocument({id: groupID}));
+    Logger.log(LogEventName.VIEW_GROUP, { group: groupID, via: "group-document-titlebar" });
+    ui.problemWorkspace.setComparisonDocument(new GroupVirtualDocument({ id: groupID }));
   }
 
   private render4UpCanvas() {

--- a/src/components/document/student-group-view.tsx
+++ b/src/components/document/student-group-view.tsx
@@ -12,7 +12,7 @@ import "./student-group-view.scss";
 
 export const StudentGroupView:React.FC = observer(function StudentGroupView(){
   const stores = useStores();
-  const {groups, ui } = stores;
+  const { groups, ui } = stores;
 
   useEffect(() => stores.initializeStudentWorkTab(), [stores]);
 
@@ -23,7 +23,7 @@ export const StudentGroupView:React.FC = observer(function StudentGroupView(){
   const isChatPanelShown = ui.showChatPanel;
   const documentSelectedForComment = ui.showChatPanel && ui.selectedTileIds.length === 0 && ui.focusDocument;
   const studentGroupViewClasses = classNames( "editable-document-content", "document", "student-group-view",
-    {"chat-open": isChatPanelShown}, {"comment-select" : documentSelectedForComment});
+    { "chat-open": isChatPanelShown }, { "comment-select" : documentSelectedForComment });
 
   return (
     <div key="student-group-view" className={studentGroupViewClasses}>
@@ -46,8 +46,8 @@ interface IGroupComponentProps {
   groupUser?: GroupUserModelType;
 }
 
-const GroupViewTitlebar: React.FC<IGroupComponentProps> = observer(function GroupViewTitlebar({group, groupUser}) {
-  const {groups, ui} = useStores();
+const GroupViewTitlebar: React.FC<IGroupComponentProps> = observer(function GroupViewTitlebar({ group, groupUser }) {
+  const { groups, ui } = useStores();
   const focusedGroupUser = groupUser;
 
   const handleFocusedUserChange = (selectedUser: GroupUserModelType) => {
@@ -58,7 +58,7 @@ const GroupViewTitlebar: React.FC<IGroupComponentProps> = observer(function Grou
   const handleSelectGroup = (id: string) => {
     ui.setOpenSubTab("student-work", id);
     ui.closeSubTabDocument("student-work", id);
-    Logger.log(LogEventName.VIEW_GROUP, {group: id, via: "group-document-titlebar"});
+    Logger.log(LogEventName.VIEW_GROUP, { group: id, via: "group-document-titlebar" });
   };
 
   return (
@@ -71,7 +71,7 @@ const GroupViewTitlebar: React.FC<IGroupComponentProps> = observer(function Grou
             />
             { group.sortedUsers.map((u, index) => {
                 const className = classNames("member-button", "in-student-group-view", getQuadrant(index),
-                                              {focused: u.id === focusedGroupUser.id}
+                                              { focused: u.id === focusedGroupUser.id }
                                               );
               return (
                 <button key={u.name} className={className} title={u.name}
@@ -110,7 +110,7 @@ const GroupButton: React.FC<IGroupButtonProps> = (props) => {
   );
 };
 
-const GroupTitlebar: React.FC<IGroupComponentProps> = observer(function GroupTitlebar({group, groupUser}) {
+const GroupTitlebar: React.FC<IGroupComponentProps> = observer(function GroupTitlebar({ group, groupUser }) {
   const problem = useProblemStore();
   const document= groupUser?.problemDocument;
   const userDocTitle = document?.title || "Document";

--- a/src/components/four-up.test.tsx
+++ b/src/components/four-up.test.tsx
@@ -9,7 +9,7 @@ import { DocumentsModelType, DocumentsModel } from "../models/stores/documents";
 import { specStores } from "../models/stores/spec-stores";
 import { UserModel } from "../models/stores/user";
 
-configure({testIdAttribute: "data-test"});
+configure({ testIdAttribute: "data-test" });
 
 const mockGetQueryState = jest.fn();
 jest.mock("react-query", () => ({

--- a/src/components/four-up.tsx
+++ b/src/components/four-up.tsx
@@ -135,36 +135,36 @@ export class FourUpComponent extends BaseComponent<IProps, IState> {
   }
 
   private getFocusedUserDocKey() {
-    const {ui} = this.stores;
-    const {group} = this.props;
+    const { ui } = this.stores;
+    const { group } = this.props;
     return ui.tabs.get(this.getNavTabName())?.openDocuments.get(group.id);
   }
 
   private getFocusedGroupUser() {
-    const {group} = this.props;
+    const { group } = this.props;
     const docKey = this.getFocusedUserDocKey();
     return group.users.find(obj => docKey && this.getGroupUserDoc(obj)?.key === docKey);
   }
 
   private getGroupUserDoc(groupUser?: GroupUserModelType) {
-    const {documentViewMode} = this.props;
+    const { documentViewMode } = this.props;
     return getUserDocument(groupUser, documentViewMode);
   }
 
   public render() {
-    const {documentViewMode, viaStudentGroupView,
+    const { documentViewMode, viaStudentGroupView,
         group, isGhostUser, ...others } = this.props;
 
-    const {width, height} = this.grid;
+    const { width, height } = this.grid;
     const nwCell = this.grid.cells[CellPositions.NorthWest];
     const neCell = this.grid.cells[CellPositions.NorthEast];
     const seCell = this.grid.cells[CellPositions.SouthEast];
     const swCell = this.grid.cells[CellPositions.SouthWest];
-    const toggledStyle = {top: 0, left: 0, width, height};
+    const toggledStyle = { top: 0, left: 0, width, height };
 
     const scaleStyle = (cell: FourUpGridCellModelType) => {
       const transform = `scale(${focusedGroupUser ? 1 : cell.scale})`;
-      return {width, height, transform, transformOrigin: "0 0"};
+      return { width, height, transform, transformOrigin: "0 0" };
     };
 
     // We are using this as a lookup table, so its possible the index being looked
@@ -174,10 +174,10 @@ export class FourUpComponent extends BaseComponent<IProps, IState> {
     const focusedGroupUser = this.getFocusedGroupUser();
 
     const indexToStyle = [
-      focusedGroupUser ? toggledStyle : {top: 0, left: 0, width: nwCell.width, height: nwCell.height},
-      focusedGroupUser ? toggledStyle : {top: 0, left: neCell.left, right: 0, height: neCell.height},
-      focusedGroupUser ? toggledStyle : {top: seCell.top, left: seCell.left, right: 0, bottom: 0},
-      focusedGroupUser ? toggledStyle : {top: swCell.top, left: 0, width: swCell.width, bottom: 0}
+      focusedGroupUser ? toggledStyle : { top: 0, left: 0, width: nwCell.width, height: nwCell.height },
+      focusedGroupUser ? toggledStyle : { top: 0, left: neCell.left, right: 0, height: neCell.height },
+      focusedGroupUser ? toggledStyle : { top: seCell.top, left: seCell.left, right: 0, bottom: 0 },
+      focusedGroupUser ? toggledStyle : { top: swCell.top, left: 0, width: swCell.width, bottom: 0 }
     ];
 
     const isFocused = (groupUser?: GroupUserModelType) => focusedGroupUser && focusedGroupUser === groupUser;
@@ -233,8 +233,8 @@ export class FourUpComponent extends BaseComponent<IProps, IState> {
       const userFocused = isFocused(groupUser);
       if (groupUser) {
         const { name: fullName, initials } = groupUser;
-        const className = classNames("member", {"member-centered": userFocused && !viaStudentGroupView},
-                                     {"in-student-group-view": userFocused && viaStudentGroupView});
+        const className = classNames("member", { "member-centered": userFocused && !viaStudentGroupView },
+                                     { "in-student-group-view": userFocused && viaStudentGroupView });
 
         const name = userFocused ? fullName : initials;
         return (
@@ -305,12 +305,12 @@ export class FourUpComponent extends BaseComponent<IProps, IState> {
       <>
         <div
           className="horizontal splitter" data-test="4up-horizontal-splitter"
-          style={{top: this.grid.hSplitter, height: this.grid.splitterSize}}
+          style={{ top: this.grid.hSplitter, height: this.grid.splitterSize }}
           onMouseDown={this.handleHSplitter}
         />
         <div
           className="vertical splitter" data-test="4up-vertical-splitter"
-          style={{left: this.grid.vSplitter, width: this.grid.splitterSize}}
+          style={{ left: this.grid.vSplitter, width: this.grid.splitterSize }}
           onMouseDown={this.handleVSplitter}
         />
         <div
@@ -343,7 +343,7 @@ export class FourUpComponent extends BaseComponent<IProps, IState> {
   };
 
   private handleResizeDebounced = debounce((entry: ResizeObserverEntry) => {
-    const {width, height} = entry.contentRect;
+    const { width, height } = entry.contentRect;
     if (width > 0 && height > 0) {
       this.grid.update({
         height: height - BORDER_SIZE,
@@ -411,7 +411,7 @@ export class FourUpComponent extends BaseComponent<IProps, IState> {
     const document = this.getGroupUserDoc(groupUser);
 
     if (groupUser && document) {
-      const logInfo = {groupId: group.id, studentId: groupUser.id};
+      const logInfo = { groupId: group.id, studentId: groupUser.id };
       if (focusedUser){
         ui.closeSubTabDocument(this.getNavTabName(), group.id);
         Logger.log(LogEventName.DASHBOARD_DESELECT_STUDENT, logInfo);

--- a/src/components/group/group-chooser.tsx
+++ b/src/components/group/group-chooser.tsx
@@ -29,7 +29,7 @@ export class GroupChooserComponent extends BaseComponent<IProps, IState> {
   }
 
   public render() {
-    const {user, groups} = this.stores;
+    const { user, groups } = this.stores;
     return (
       <div className="join">
         <div className="join-title">Join Group</div>
@@ -44,7 +44,7 @@ export class GroupChooserComponent extends BaseComponent<IProps, IState> {
   }
 
   private renderChooseNewGroup() {
-    const {allGroups} = this.stores.groups;
+    const { allGroups } = this.stores.groups;
     const groupIds = allGroups.map((group) => group.id);
     const items: JSX.Element[] = [];
     const haveExistingGroups = groupIds.length > 0;
@@ -65,7 +65,7 @@ export class GroupChooserComponent extends BaseComponent<IProps, IState> {
   }
 
   private renderChooseExistingGroup() {
-    const {groups} = this.stores;
+    const { groups } = this.stores;
     const groupElements = groups.allGroups.map((group) => {
       const users = group.users.map((user) => {
         const className = `user ${user.connected ? "connected" : "disconnected"}`;
@@ -97,7 +97,7 @@ export class GroupChooserComponent extends BaseComponent<IProps, IState> {
   }
 
   private renderError() {
-    const {error} = this.state;
+    const { error } = this.state;
     if (error) {
       return (
         <div className="error">{error}</div>
@@ -107,15 +107,15 @@ export class GroupChooserComponent extends BaseComponent<IProps, IState> {
 
   private selectGroup = (groupId: string) => {
     this.stores.db.joinGroup(groupId)
-      .then(() => { if (this._isMounted) this.setState({error: undefined}); })
-      .catch((err) => { if (this._isMounted) this.setState({error: err.toString()}); });
+      .then(() => { if (this._isMounted) this.setState({ error: undefined }); })
+      .catch((err) => { if (this._isMounted) this.setState({ error: err.toString() }); });
   };
 
   private handleChooseExistingGroup = (group: GroupModelType) => {
     return (e: React.MouseEvent<HTMLElement>) => {
       e.preventDefault();
       if (group.users.length >= 4) {
-        this.setState({error: "Sorry, that group is full with four students"});
+        this.setState({ error: "Sorry, that group is full with four students" });
       }
       else {
         this.selectGroup(group.id);

--- a/src/components/mobx-react-mst.test.tsx
+++ b/src/components/mobx-react-mst.test.tsx
@@ -53,14 +53,14 @@ function initialize() {
   }));
 
   const ItemComponent = observer(function ItemComponent(
-    {item}: {item: Instance<typeof Item>}
+    { item }: { item: Instance<typeof Item> }
   ) {
     log.push(`ItemComponent rendering ${item.name}`);
     return <div>{item.nameWithDescription}</div>;
   });
 
   const ListComponent = observer(function ListComponent(
-    {list}: {list: Instance<typeof List>}
+    { list }: { list: Instance<typeof List> }
   ) {
     log.push("ListComponent rendering");
     return (
@@ -102,9 +102,9 @@ const initialLog = [
 
 describe("behavior of mobx-react with mst objects", () => {
   it("updates a list when items are destroyed", () => {
-    const {List, ListComponent, log, clearLog } = initialize();
+    const { List, ListComponent, log, clearLog } = initialize();
     const list = List.create({
-      items: [ {name: "one"}, {name: "two"}]
+      items: [ { name: "one" }, { name: "two" }]
     });
 
     render(<ListComponent list={list}/>);
@@ -127,9 +127,9 @@ describe("behavior of mobx-react with mst objects", () => {
   });
 
   it("updates a list and prints warning with removeFirstDescriptionAndItem", () => {
-    const {List, ListComponent, log, clearLog } = initialize();
+    const { List, ListComponent, log, clearLog } = initialize();
     const list = List.create({
-      items: [ {name: "one"}, {name: "two"}]
+      items: [ { name: "one" }, { name: "two" }]
     });
 
     render(<ListComponent list={list}/>);
@@ -156,13 +156,13 @@ describe("behavior of mobx-react with mst objects", () => {
   });
 
   it("updates a list and doesn't print warning with removeFirstDescriptionAndItem and isAlive short circuit", () => {
-    const {List, Item, log, clearLog } = initialize();
+    const { List, Item, log, clearLog } = initialize();
     const testList = List.create({
-      items: [ {name: "one"}, {name: "two"}]
+      items: [ { name: "one" }, { name: "two" }]
     });
 
     const ItemComponent = observer(function ItemComponent(
-      {item}: {item: Instance<typeof Item>}
+      { item }: { item: Instance<typeof Item> }
     ) {
       log.push(`ItemComponent rendering ${item.name}`);
       // Note: we aren't bailing out here. Just checking if
@@ -176,7 +176,7 @@ describe("behavior of mobx-react with mst objects", () => {
     });
 
     const ListComponent = observer(function ListComponent(
-      {list}: {list: Instance<typeof List>}
+      { list }: { list: Instance<typeof List> }
     ) {
       log.push("ListComponent rendering");
       return (
@@ -210,9 +210,9 @@ describe("behavior of mobx-react with mst objects", () => {
   });
 
   it("updates a list and doesn't print warning with removeFirstDescriptionAndItemSoon", () => {
-    const {List, ListComponent, log, clearLog } = initialize();
+    const { List, ListComponent, log, clearLog } = initialize();
     const testList = List.create({
-      items: [ {name: "one"}, {name: "two"}]
+      items: [ { name: "one" }, { name: "two" }]
     });
 
     render(<ListComponent list={testList}/>);

--- a/src/components/navigation/document-browser-scroller.tsx
+++ b/src/components/navigation/document-browser-scroller.tsx
@@ -17,8 +17,8 @@ interface DocumentBrowserScrollerProps {
   onSelectDocument: (document: DocumentModelType) => void;
 }
 
-export const DocumentBrowserScroller =
-    ({subTab, tabSpec, openDocumentKey, openSecondaryDocumentKey, onSelectDocument}: DocumentBrowserScrollerProps) => {
+export const DocumentBrowserScroller = ({ subTab, tabSpec, openDocumentKey, openSecondaryDocumentKey,
+    onSelectDocument }: DocumentBrowserScrollerProps) => {
   const [scrollerCollapsed, setScrollerCollapsed] = useState(false);
   const [collectionElement, setCollectionElement] = useState<HTMLDivElement>();
   const documentScrollerRef = useRef<HTMLDivElement>(null);
@@ -30,7 +30,7 @@ export const DocumentBrowserScroller =
 
   useEffect(() => {
     if(scrollToLocation !== undefined) {
-      collectionElement?.scrollTo({left: scrollToLocation, behavior: "smooth"});
+      collectionElement?.scrollTo({ left: scrollToLocation, behavior: "smooth" });
     }
   }, [collectionElement, scrollToLocation]);
 
@@ -60,7 +60,7 @@ export const DocumentBrowserScroller =
 
   return (
     <>
-      <div className={classNames("document-scroller", tabSpec.tab, {"collapsed": scrollerCollapsed})}
+      <div className={classNames("document-scroller", tabSpec.tab, { "collapsed": scrollerCollapsed })}
           ref={documentScrollerRef}>
         <DocumentCollectionList
             setCollectionElement={setCollectionElement}
@@ -81,7 +81,7 @@ export const DocumentBrowserScroller =
         }
       </div>
       <div className={classNames("collapse-scroller-button", "themed", tabSpec.tab,
-                {"collapsed": scrollerCollapsed})} onClick={handleCollapseScroller}>
+                { "collapsed": scrollerCollapsed })} onClick={handleCollapseScroller}>
         <CollapseScrollerIcon className={`scroller-icon ${tabSpec.tab}`}/>
       </div>
     </>
@@ -94,7 +94,7 @@ interface IScrollEndControlProps {
   onScroll: (side: string) => void
 }
 
-const ScrollEndControl = ({side, tab, onScroll}: IScrollEndControlProps) => {
+const ScrollEndControl = ({ side, tab, onScroll }: IScrollEndControlProps) => {
   return (
     <div className={classNames("scroller-controls", side)}>
       <ScrollButton side={side} theme={tab} onClick={() => onScroll(side)} />
@@ -109,7 +109,7 @@ interface IScrollButtonProps {
   theme: string;
 }
 
-export const ScrollButton = ({className, onClick, side, theme}: IScrollButtonProps) => {
+export const ScrollButton = ({ className, onClick, side, theme }: IScrollButtonProps) => {
   return (
     <div className={classNames("scroll-arrow-button", "themed", theme, side, className)}
           onClick={onClick}>

--- a/src/components/navigation/document-view.tsx
+++ b/src/components/navigation/document-view.tsx
@@ -20,7 +20,7 @@ interface IProps {
   subTab: ISubTabSpec;
 }
 //TODO: Need to refactor this if we want to deploy to all tabs
-export const DocumentView = observer(function DocumentView({tabSpec, subTab}: IProps) {
+export const DocumentView = observer(function DocumentView({ tabSpec, subTab }: IProps) {
   const ui = useUIStore();
   const store = useStores();
   const appConfigStore = useAppConfig();
@@ -202,8 +202,8 @@ interface IDocumentAreaProps {
   onChangeDocument?: (shift: number, secondary?: boolean) => void;
 }
 
-const DocumentArea = ({openDocument, subTab, tab, sectionClass, isSecondaryDocument,
-    hasSecondaryDocument, hideLeftFlipper, hideRightFlipper, onChangeDocument}: IDocumentAreaProps) => {
+const DocumentArea = ({ openDocument, subTab, tab, sectionClass, isSecondaryDocument,
+    hasSecondaryDocument, hideLeftFlipper, hideRightFlipper, onChangeDocument }: IDocumentAreaProps) => {
   const ui = useUIStore();
   const user = useUserStore();
   const appConfig = useAppConfig();
@@ -214,7 +214,7 @@ const DocumentArea = ({openDocument, subTab, tab, sectionClass, isSecondaryDocum
   const getDisplayTitle = (document: DocumentModelType) => {
     const documentOwner = classStore.users.get(document.uid);
     const documentTitle = getDocumentDisplayTitle(document, appConfig, problemStore);
-    return {owner: documentOwner ? documentOwner.fullName : "", title: documentTitle};
+    return { owner: documentOwner ? documentOwner.fullName : "", title: documentTitle };
   };
   const displayTitle = getDisplayTitle(openDocument);
 
@@ -228,7 +228,7 @@ const DocumentArea = ({openDocument, subTab, tab, sectionClass, isSecondaryDocum
   // knew the state of playback controls. It no longer knows that state, so now
   // the edit button is shown all of the time.
   // PT Story: https://www.pivotaltracker.com/story/show/183416176
-  const editButton = (type: string, sClass: {secondary: boolean | undefined; primary: boolean | undefined} | string,
+  const editButton = (type: string, sClass: { secondary: boolean | undefined; primary: boolean | undefined } | string,
                       document: DocumentModelType) => {
     return (
       (type === "my-work") || (type === "learningLog")
@@ -250,7 +250,7 @@ const DocumentArea = ({openDocument, subTab, tab, sectionClass, isSecondaryDocum
         <div className="document-title">
           {(displayTitle.owner && tab === "class-work")
               && <span className="document-owner">{displayTitle.owner}: </span>}
-          <span className={classNames("document-title", {"class-work": tab === "class-work"})}>
+          <span className={classNames("document-title", { "class-work": tab === "class-work" })}>
             {displayTitle.title}
           </span>
         </div>

--- a/src/components/navigation/nav-tab-panel.tsx
+++ b/src/components/navigation/nav-tab-panel.tsx
@@ -123,7 +123,7 @@ export class NavTabPanel extends BaseComponent<IProps> {
   };
 
   private renderProblem = () => {
-    const { user: { isTeacher }, problem: { sections }} = this.stores;
+    const { user: { isTeacher }, problem: { sections } } = this.stores;
     return (
       <ProblemTabContent
         sections={sections}

--- a/src/components/navigation/problem-panel.tsx
+++ b/src/components/navigation/problem-panel.tsx
@@ -26,7 +26,7 @@ export class ProblemPanelComponent extends BaseComponent<IProps> {
   }
 
   private renderSection(section: SectionModelType) {
-    const {content} = section;
+    const { content } = section;
     return (
       <div className="section">
         {content ? this.renderContent(content) : null}

--- a/src/components/navigation/problem-tab-content.tsx
+++ b/src/components/navigation/problem-tab-content.tsx
@@ -72,8 +72,8 @@ export const ProblemTabContent: React.FC<IProps>
           onSelect={handleTabSelected}
           data-focus-document={problemPath}
     >
-      <div className={classNames("tab-header-row", {"no-sub-tabs": !hasSubTabs})}>
-        <TabList className={classNames("tab-list", {"chat-open" : ui.showChatPanel})}>
+      <div className={classNames("tab-header-row", { "no-sub-tabs": !hasSubTabs })}>
+        <TabList className={classNames("tab-list", { "chat-open" : ui.showChatPanel })}>
           {sections?.map((section, index) => {
             const sectionTitle = getSectionTitle(section.type);
             return (

--- a/src/components/navigation/section-document-or-browser.tsx
+++ b/src/components/navigation/section-document-or-browser.tsx
@@ -124,7 +124,7 @@ export const SectionDocumentOrBrowser: React.FC<IProps> = observer(function Sect
   return (
     <SubTabsPanel
       tabSpec={tabSpec}
-      tabsExtraClassNames={{"chat-open": isChatOpen}}
+      tabsExtraClassNames={{ "chat-open": isChatOpen }}
       onSelect={handleTabSelect}
       selectedIndex={subTabIndex}
       renderSubTabPanel={subTab => renderDocumentView(subTab) || renderDocumentBrowserView(subTab)}

--- a/src/components/navigation/sub-tabs-panel.tsx
+++ b/src/components/navigation/sub-tabs-panel.tsx
@@ -33,7 +33,7 @@ export const SubTabsPanel: React.FC<IProps> = observer(function SubTabsPanel(
         onSelect={onSelect}
         selectedIndex={selectedIndex}
       >
-        <div className={classNames("tab-header-row", {"no-sub-tabs": !hasSubTabs})}>
+        <div className={classNames("tab-header-row", { "no-sub-tabs": !hasSubTabs })}>
           <TabList className={classNames("tab-list", navTabClass)}>
             {subTabs.map((subTab) => {
               const sectionTitle = subTab.label.toLowerCase().replace(' ', '-');
@@ -47,7 +47,7 @@ export const SubTabsPanel: React.FC<IProps> = observer(function SubTabsPanel(
             })}
           </TabList>
         </div>
-        <div className={classNames("documents-panel", {"no-sub-tabs": !hasSubTabs})}>
+        <div className={classNames("documents-panel", { "no-sub-tabs": !hasSubTabs })}>
           {subTabs.map((subTab, index) => {
             const sectionTitle = subTab.label.toLowerCase().replace(' ', '-');
             return (

--- a/src/components/playback/marker-toolbar.tsx
+++ b/src/components/playback/marker-toolbar.tsx
@@ -21,15 +21,15 @@ interface IProps {
 // TODO: Need to handle delete marker. Currently, we don't track which marker was selected, so we don't delete any
 // TODO: need to handle comment marker.
 // TODO: need to add editable marker labels.
-export const PlaybackMarkerToolbar: React.FC<IProps> = ({markerSelected, addMarkerSelected, onAddMarkerSelected}) => {
+export const PlaybackMarkerToolbar: React.FC<IProps> = ({ markerSelected, addMarkerSelected, onAddMarkerSelected }) => {
   const { activeNavTab } = useUIStore();
 
   const AddMarkerButton: React.FC = () => {
     const handleAddMarker = () => {
       onAddMarkerSelected(!addMarkerSelected);
     };
-    const markerButtonClass = classNames("add-marker-button", activeNavTab, {"disabled" : markerSelected},
-                                         {"selected": addMarkerSelected});
+    const markerButtonClass = classNames("add-marker-button", activeNavTab, { "disabled" : markerSelected },
+                                         { "selected": addMarkerSelected });
     return (
       <div className={markerButtonClass}
         onClick={handleAddMarker}>

--- a/src/components/playback/playback-control.tsx
+++ b/src/components/playback/playback-control.tsx
@@ -41,7 +41,7 @@ export const PlaybackControlComponent: React.FC<IProps> = observer((props: IProp
   // by the history stuff, but it is being used to trigger document saves to Firebase
   // I think.  In some sense this is like a hash of the document content.
 
-  const {numHistoryEventsApplied, currentHistoryEntry} = treeManager;
+  const { numHistoryEventsApplied, currentHistoryEntry } = treeManager;
   // numHistoryEventsApplied can be 0 or undefined, the event is undefined in both cases
   const sliderValue = numHistoryEventsApplied ?? 0;
   const eventCreatedTime = currentHistoryEntry?.created;
@@ -76,7 +76,7 @@ export const PlaybackControlComponent: React.FC<IProps> = observer((props: IProp
     if (markers.length >= 9) {
       alert("You already have 9 markers. Please delete some markers to add more.");
     } else {
-      setMarkers([...markers, {id: markers.length+1, location: value}]);
+      setMarkers([...markers, { id: markers.length+1, location: value }]);
     }
   };
 
@@ -102,8 +102,8 @@ export const PlaybackControlComponent: React.FC<IProps> = observer((props: IProp
   };
 
   const renderTimeInfo = () => {
-    const monthMap: Record<number, string> = {0: "Jan", 1: "Feb", 2: "Mar", 3: "Apr", 4: "May", 5: "Jun",
-                      6: "Jul", 7: "Aug", 8: "Sep", 9: "Oct", 10: "Nov", 11: "Dec"};
+    const monthMap: Record<number, string> = { 0: "Jan", 1: "Feb", 2: "Mar", 3: "Apr", 4: "May", 5: "Jun",
+                      6: "Jul", 7: "Aug", 8: "Sep", 9: "Oct", 10: "Nov", 11: "Dec" };
     const date = eventCreatedTime;
     const month = date?.getMonth();
     const monthStr = month && monthMap[month];
@@ -132,8 +132,8 @@ export const PlaybackControlComponent: React.FC<IProps> = observer((props: IProp
   };
 
   const renderPlayPauseButton = () => {
-    const playButtonStyle = classNames("play-button", "themed", activeNavTab, {"disabled" : playbackDisabled});
-    const pauseButtonStyle = classNames("pause-button", "themed", activeNavTab, {"playing" : sliderPlaying});
+    const playButtonStyle = classNames("play-button", "themed", activeNavTab, { "disabled" : playbackDisabled });
+    const pauseButtonStyle = classNames("pause-button", "themed", activeNavTab, { "playing" : sliderPlaying });
     if (sliderPlaying) {
       return <PauseButton className={pauseButtonStyle} onClick={()=>handlePlayPauseToggle()}
                 data-testid="playback-pause-button" />;
@@ -144,7 +144,7 @@ export const PlaybackControlComponent: React.FC<IProps> = observer((props: IProp
   };
 
   const renderSliderContainer = () => {
-    const markerContainerClass = classNames("marker-container", activeNavTab, {"selected": markerSelected});
+    const markerContainerClass = classNames("marker-container", activeNavTab, { "selected": markerSelected });
     const markerClass = classNames("marker", activeNavTab);
 
     const getMarkerLocation = (location: number) => {
@@ -171,7 +171,7 @@ export const PlaybackControlComponent: React.FC<IProps> = observer((props: IProp
         </div>
         { markers.map(marker => {
           const markerLocation = getMarkerLocation(marker.location);
-          const markerStyle = {left: `${markerLocation}%`};
+          const markerStyle = { left: `${markerLocation}%` };
           return (
             <div key={`marker-${marker.id}`} className={markerContainerClass} style={markerStyle}
                 onClick={handleMarkerSelected}>
@@ -185,7 +185,7 @@ export const PlaybackControlComponent: React.FC<IProps> = observer((props: IProp
     );
   };
 
-  const playbackControlsClass = classNames("playback-controls", activeNavTab, {"disabled" : false});
+  const playbackControlsClass = classNames("playback-controls", activeNavTab, { "disabled" : false });
   const sliderComponentClass = classNames(`slider-component ${activeNavTab}`);
 
   return (

--- a/src/components/playback/playback.tsx
+++ b/src/components/playback/playback.tsx
@@ -23,11 +23,11 @@ export const PlaybackComponent: React.FC<IProps> = observer((props: IProps) => {
 
   const renderPlaybackToolbarButton = () => {
     const playbackToolbarButtonComponentStyle =
-      classNames("playback-toolbar-button-component", {"disabled" : false},
-                  {"show-control": showPlaybackControls});
+      classNames("playback-toolbar-button-component", { "disabled" : false },
+                  { "show-control": showPlaybackControls });
     const playbackToolbarButtonStyle =
       classNames("playback-toolbar-button", "themed", activeNavTab,
-                {"show-control": showPlaybackControls});
+                { "show-control": showPlaybackControls });
     return (
       <div className={playbackToolbarButtonComponentStyle} onClick={onTogglePlaybackControls}
           data-testid="playback-component-button">
@@ -38,8 +38,8 @@ export const PlaybackComponent: React.FC<IProps> = observer((props: IProps) => {
 
   const disablePlayback = false;
   const playbackComponentClass = classNames("playback-component", activeNavTab,
-                                            {"show-control" : showPlaybackControls,
-                                              "disabled" : disablePlayback});
+                                            { "show-control" : showPlaybackControls,
+                                              "disabled" : disablePlayback });
 
   let playbackControls = null;
   if (showPlaybackControls) {

--- a/src/components/problem-menu-container.tsx
+++ b/src/components/problem-menu-container.tsx
@@ -20,7 +20,7 @@ export const ProblemMenuContainer: React.FC<IProps> = observer(function ProblemM
   };
 
   const handleMenuItemClick = (item: IDropdownItem, problemName: string) => {
-    const {link, text} = item;
+    const { link, text } = item;
     if (link) {
       window.location.replace(link);
     } else {
@@ -28,7 +28,7 @@ export const ProblemMenuContainer: React.FC<IProps> = observer(function ProblemM
     }
     const logItem = {
       event: LogEventName.DASHBOARD_SWITCH_CLASS,
-      parameters: {text, link}
+      parameters: { text, link }
     };
     Logger.log(logItem.event, logItem.parameters, LogEventMethod.DO);
   };

--- a/src/components/tab.tsx
+++ b/src/components/tab.tsx
@@ -25,8 +25,8 @@ export class TabComponent extends React.Component<IProps, IState> {
   }
 
   public render() {
-    const {id, active, title} = this.props;
-    const {hovering} = this.state;
+    const { id, active, title } = this.props;
+    const { hovering } = this.state;
     const className = `tab${active ? " active" : ""}${hovering ? " hovering" : ""}`;
     return (
       <div
@@ -53,10 +53,10 @@ export class TabComponent extends React.Component<IProps, IState> {
   // manual hover state is maintained so that we can set a class to override
   // a child element's style - the :hover pseudo class won't work in this case
   private handleMouseOver = (e: React.MouseEvent<HTMLDivElement>) => {
-    this.setState({hovering: true});
+    this.setState({ hovering: true });
   };
 
   private handleMouseOut = (e: React.MouseEvent<HTMLDivElement>) => {
-    this.setState({hovering: false});
+    this.setState({ hovering: false });
   };
 }

--- a/src/components/thumbnail/collapsible-document-section.tsx
+++ b/src/components/thumbnail/collapsible-document-section.tsx
@@ -29,8 +29,8 @@ interface IProps {
 }
 
 export const CollapsibleDocumentsSection: React.FC<IProps> = observer(
-  ({userName, classNameStr, scale, selectedDocument, onSelectDocument, subTab,
-    networkResource, userId, classHash}) => {
+  ({ userName, classNameStr, scale, selectedDocument, onSelectDocument, subTab,
+    networkResource, userId, classHash }) => {
   const [isOpen, setIsOpen] = useState(false);
   const user = useUserStore();
   const handleSectionToggle = () => {
@@ -108,7 +108,7 @@ export const CollapsibleDocumentsSection: React.FC<IProps> = observer(
                 </DocumentContextReact.Provider>
               );
             })
-            : <div style={{padding: "5px 10px"}}>No Documents Found</div>
+            : <div style={{ padding: "5px 10px" }}>No Documents Found</div>
           }
         </div>
       }

--- a/src/components/thumbnail/document-collection-list.tsx
+++ b/src/components/thumbnail/document-collection-list.tsx
@@ -26,7 +26,7 @@ export const kNavItemScale = 0.11;
 
 export const DocumentCollectionList: React.FC<IProps> = observer(function DocumentCollectionList(
     { setCollectionElement, subTab, tabSpec, horizontal, collapsed, selectedDocument, selectedSecondaryDocument,
-        onSelectNewDocument, onSelectDocument}) {
+        onSelectNewDocument, onSelectDocument }) {
   const ui = useUIStore();
   const appConfigStore = useAppConfig();
   const user = useUserStore();
@@ -53,7 +53,7 @@ export const DocumentCollectionList: React.FC<IProps> = observer(function Docume
   };
 
   return (
-    <div className={classNames("doc-collection-list", {horizontal, collapsed})}
+    <div className={classNames("doc-collection-list", { horizontal, collapsed })}
         ref={element => element && setCollectionElement?.(element)}>
       {
         subTab.sections.map((section: any, index: any) => {

--- a/src/components/thumbnail/documents-type-collection.tsx
+++ b/src/components/thumbnail/documents-type-collection.tsx
@@ -107,10 +107,10 @@ export const DocumentCollectionByType: React.FC<IProps> = observer(({
     onSelectNewDocument?.(section.documentTypes[0]);
   }
   const tabPanelDocumentSectionClass = classNames("tab-panel-documents-section", tabName,
-                                                  {"top-panel": isTopPanel, horizontal});
+                                                  { "top-panel": isTopPanel, horizontal });
   const bottomPanel = isBottomPanel && !isSinglePanel && sectionDocs.length > 0;
-  const listClass = classNames("list", tabName, {"top-panel": isTopPanel, horizontal,
-                                "bottom-panel": bottomPanel});
+  const listClass = classNames("list", tabName, { "top-panel": isTopPanel, horizontal,
+                                "bottom-panel": bottomPanel });
   return (
     <div className={tabPanelDocumentSectionClass}
           key={`${tab}-${section.type}`}

--- a/src/components/thumbnail/thumbnail-document-item.tsx
+++ b/src/components/thumbnail/thumbnail-document-item.tsx
@@ -53,7 +53,7 @@ export const ThumbnailDocumentItem: React.FC<IProps> = observer((props: IProps) 
                           ? `Firebase UID: ${document.key}` : undefined;
 
   return (
-    <div className={classNames("list-item", selectedClass, privateClass, {"secondary": isSecondarySelected})}
+    <div className={classNames("list-item", selectedClass, privateClass, { "secondary": isSecondarySelected })}
       data-test={dataTestName} key={document.key} data-document-key={document.key}
       title={documentTitle} onClick={isPrivate ? undefined : handleDocumentClick}>
       <div className="scaled-list-item-container" onDragStart={handleDocumentDragStart}

--- a/src/components/tiles/basic-editable-tile-title.tsx
+++ b/src/components/tiles/basic-editable-tile-title.tsx
@@ -24,7 +24,7 @@ export function BasicEditableTileTitle({ model, readOnly, scale, titleKey }: IBa
     <ToolTitleArea>
       <EditableTileTitle
         key={titleKey}
-        size={{width:null, height:null}}
+        size={{ width:null, height:null }}
         scale={scale}
         getTitle={getTitle}
         readOnly={readOnly}

--- a/src/components/tiles/custom-editable-tile-title.tsx
+++ b/src/components/tiles/custom-editable-tile-title.tsx
@@ -69,7 +69,7 @@ export const CustomEditableTileTitle: React.FC<IProps> = observer((props) => {
   };
 
   const elementClasses = classNames(
-    "title-text-element", {editing: isEditingTitle}
+    "title-text-element", { editing: isEditingTitle }
   );
 
   const titleString = content.type === "Expression"

--- a/src/components/tiles/geometry/geometry-content.tsx
+++ b/src/components/tiles/geometry/geometry-content.tsx
@@ -898,7 +898,7 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
           const comment = elems?.find(isComment);
           if (comment) {
             this.handleCreateText(comment);
-            this.setState({selectedComment: comment});
+            this.setState({ selectedComment: comment });
           }
         });
       } else if (activeComment) {
@@ -933,7 +933,7 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
     const { board } = this.state;
     const content = this.getContent();
     const ids = [line.point1.id, line.point2.id];
-    const props = [{position: point1}, {position: point2}];
+    const props = [{ position: point1 }, { position: point2 }];
     this.applyChange(() => content.updateObjects(board, ids, props));
     this.setState({ selectedLine: undefined });
   };
@@ -1801,7 +1801,7 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
       if (isComment(text)) {
         const coords = copyCoords(text.coords);
         if (this.isDoubleClick(this.lastPointDown, { evt, coords }) && !readOnly) {
-          this.setState({selectedComment: text});
+          this.setState({ selectedComment: text });
           this.lastPointDown = undefined;
         } else {
           this.lastPointDown = { evt, coords };
@@ -1837,7 +1837,7 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
         if (evt.timeStamp - this.lastBoardDown.evt.timeStamp < clickTimeThreshold) {
           const parentLine = values(text.ancestors)[0];
           if (isLine(parentLine) && !readOnly) {
-            this.setState({selectedLine: parentLine});
+            this.setState({ selectedLine: parentLine });
           }
         }
       }

--- a/src/components/tiles/geometry/use-label-segment-dialog.tsx
+++ b/src/components/tiles/geometry/use-label-segment-dialog.tsx
@@ -11,7 +11,7 @@ interface LabelRadioButtonProps {
   checkedLabel: string;
   setLabelOption: React.Dispatch<React.SetStateAction<string>>;
 }
-const LabelRadioButton: React.FC<LabelRadioButtonProps> = ({display, label, checkedLabel, setLabelOption}) => {
+const LabelRadioButton: React.FC<LabelRadioButtonProps> = ({ display, label, checkedLabel, setLabelOption }) => {
   return (
     <div className="radio-button-container">
       <input

--- a/src/components/tiles/geometry/use-movable-line-dialog.tsx
+++ b/src/components/tiles/geometry/use-movable-line-dialog.tsx
@@ -12,7 +12,7 @@ interface LineOptionProps {
   defaultValue: string;
   setValue: React.Dispatch<React.SetStateAction<string>>;
 }
-const LineOption: React.FC<LineOptionProps> = ({display, id, defaultValue, setValue}) => {
+const LineOption: React.FC<LineOptionProps> = ({ display, id, defaultValue, setValue }) => {
   return (
     <div className="movable-line-option">
       <label className="dialog-label" htmlFor={id}>{display}</label>

--- a/src/components/tiles/image/image-tile.test.tsx
+++ b/src/components/tiles/image/image-tile.test.tsx
@@ -9,7 +9,7 @@ describe("Image Component", () => {
 
   it("calls onUrlChange when content changes", () => {
     const imageContent = ImageContentModel.create();
-    const imageStyle = {background: "url(${imageContent.url})", width: 10, height: 10};
+    const imageStyle = { background: "url(${imageContent.url})", width: 10, height: 10 };
     render(
       <ImageComponent
         ref={null}

--- a/src/components/tiles/image/image-tile.tsx
+++ b/src/components/tiles/image/image-tile.tsx
@@ -231,7 +231,7 @@ export default class ImageToolComponent extends BaseComponent<IProps, IState> {
   };
 
   private handleResizeDebounced = debounce((entry: ResizeObserverEntry) => {
-    const {width, height} = entry.contentRect;
+    const { width, height } = entry.contentRect;
     this.setState({ imageEltWidth: Math.ceil(width), imageEltHeight: Math.ceil(height) });
   }, 100);
 
@@ -271,7 +271,7 @@ export default class ImageToolComponent extends BaseComponent<IProps, IState> {
 
   private renderTitle() {
     const { readOnly, scale } = this.props;
-    const size = {width: this.state.imageEltWidth || null, height: this.state.imageEltHeight || null};
+    const size = { width: this.state.imageEltWidth || null, height: this.state.imageEltHeight || null };
     return (
       <EditableTileTitle key="geometry-title" size={size} scale={scale} getTitle={() => this.getTitle()}
                               readOnly={readOnly} measureText={(text) => measureText(text, defaultTileTitleFont)}

--- a/src/components/tiles/table/cell-formatter.tsx
+++ b/src/components/tiles/table/cell-formatter.tsx
@@ -23,7 +23,7 @@ export const formatValue = (
       const url = lookupImage(value);
       if (url) {
         return (
-          <div className="image-cell" style={{ height, width: cellWidth}}>
+          <div className="image-cell" style={{ height, width: cellWidth }}>
             <img src={url}></img>
           </div>
         );

--- a/src/components/tiles/table/table-tile.tsx
+++ b/src/components/tiles/table/table-tile.tsx
@@ -99,12 +99,12 @@ const TableToolComponent: React.FC<ITileProps> = observer(function TableToolComp
   // rowProps are expanded and passed to ReactDataGrid
   const { rows, ...rowProps } = useRowsFromDataSet({
     dataSet, readOnly: !!readOnly, inputRowId: inputRowId.current,
-    rowChanges, context: gridContext});
+    rowChanges, context: gridContext });
 
   // columns are required by ReactDataGrid and are used by other hooks as well
   const { columns, controlsColumn, columnEditingName, handleSetColumnEditingName } = useColumnsFromDataSet({
     gridContext, dataSet, metadata, readOnly: !!readOnly, columnChanges, headerHeight, rowHeight,
-    ...rowLabelProps, measureColumnWidth, lookupImage});
+    ...rowLabelProps, measureColumnWidth, lookupImage });
 
   // The size of the title bar
   const { titleCellWidth, getTitleHeight } =

--- a/src/components/tiles/table/table-toolbar-buttons.tsx
+++ b/src/components/tiles/table/table-toolbar-buttons.tsx
@@ -15,7 +15,7 @@ interface ITableButtonProps {
   onClick: (e: React.MouseEvent) => void;
   tooltipOptions: TooltipProps;
 }
-const TableButton = ({ className, icon, onClick, tooltipOptions}: ITableButtonProps) => {
+const TableButton = ({ className, icon, onClick, tooltipOptions }: ITableButtonProps) => {
   const to = useTooltipOptions(tooltipOptions);
   const classes = classNames("toolbar-button", className);
   return (

--- a/src/components/tiles/table/use-data-set.ts
+++ b/src/components/tiles/table/use-data-set.ts
@@ -135,5 +135,5 @@ export const useDataSet = ({
     return returnVal;
   }, [onColumnResize, triggerColumnChange]);
   
-  return { hasLinkableRows, onColumnResize: handleColumnResize, onRowsChange, deleteSelected, onSelectedCellChange};
+  return { hasLinkableRows, onColumnResize: handleColumnResize, onRowsChange, deleteSelected, onSelectedCellChange };
 };

--- a/src/components/tiles/text/slate-renderers.tsx
+++ b/src/components/tiles/text/slate-renderers.tsx
@@ -31,17 +31,17 @@ export function renderSlateBlock(blockName: string, attributes: any, children: a
     case "paragraph":
       return (<p {...attributes}>{children}</p>);
     case "heading1":
-      return (<h1 {...{attributes}}>{children}</h1>);
+      return (<h1 {...{ attributes }}>{children}</h1>);
     case "heading2":
-      return (<h2 {...{attributes}}>{children}</h2>);
+      return (<h2 {...{ attributes }}>{children}</h2>);
     case "heading3":
-      return (<h3 {...{attributes}}>{children}</h3>);
+      return (<h3 {...{ attributes }}>{children}</h3>);
     case "heading4":
-      return (<h4 {...{attributes}}>{children}</h4>);
+      return (<h4 {...{ attributes }}>{children}</h4>);
     case "heading5":
-      return (<h5 {...{attributes}}>{children}</h5>);
+      return (<h5 {...{ attributes }}>{children}</h5>);
     case "heading6":
-      return (<h6 {...{attributes}}>{children}</h6>);
+      return (<h6 {...{ attributes }}>{children}</h6>);
     case "code":
       return (<code {...attributes}>{children}</code>);
     case "ordered-list":
@@ -50,7 +50,7 @@ export function renderSlateBlock(blockName: string, attributes: any, children: a
     case "todo-list":
       return (<ul {...attributes}>{children}</ul>);
     case "list-item":
-      return (<li {...{attributes}}>{children}</li>);
+      return (<li {...{ attributes }}>{children}</li>);
     case "horizontal-rule":
       return (<hr />);
 

--- a/src/components/tiles/text/spec-text-tile.tsx
+++ b/src/components/tiles/text/spec-text-tile.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import {render, screen} from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 
 import { defaultTextContent } from "../../../models/tiles/text/text-content";
 import { ITileModel, TileModel } from "../../../models/tiles/tile-model";
@@ -14,7 +14,7 @@ export interface ISpecTextTileOptions {
 }
 
 export function specTextTile(options: ISpecTextTileOptions) {
-  const model = options.tileModel || TileModel.create({content: defaultTextContent()});
+  const model = options.tileModel || TileModel.create({ content: defaultTextContent() });
 
   const stores = specStores();
 

--- a/src/components/tiles/text/text-tile.test.tsx
+++ b/src/components/tiles/text/text-tile.test.tsx
@@ -1,4 +1,4 @@
-import {screen} from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { defaultTextContent } from "../../../models/tiles/text/text-content";
 import { TileModel } from "../../../models/tiles/tile-model";
 import { specTextTile } from "./spec-text-tile";
@@ -17,9 +17,9 @@ describe("TextToolComponent", () => {
 
   it("sets the editor on the content after rendering", () => {
     const content = defaultTextContent();
-    const tileModel = TileModel.create({content});
+    const tileModel = TileModel.create({ content });
     expect(content.editor).toBeUndefined();
-    specTextTile({tileModel});
+    specTextTile({ tileModel });
     expect(content.editor).toBeDefined();
   });
 

--- a/src/components/tiles/text/text-tile.tsx
+++ b/src/components/tiles/text/text-tile.tsx
@@ -274,7 +274,7 @@ export default class TextToolComponent extends BaseComponent<ITileProps, IState>
     // If the text has changed since the editor was focused, log the new text.
     const text = this.getContent().text;
     if (text !== this.textOnFocus) {
-      const change = {args:[{ text }]};
+      const change = { args:[{ text }] };
       logTileChangeEvent(LogEventName.TEXT_TOOL_CHANGE, { operation: 'update', change, tileId: this.props.model.id });
     }
     this.setState({ revision: this.state.revision + 1 }); // Force a rerender

--- a/src/components/tiles/text/toolbar/text-toolbar.tsx
+++ b/src/components/tiles/text/toolbar/text-toolbar.tsx
@@ -100,7 +100,7 @@ export const TextToolbarComponent: React.FC<IProps> = (props: IProps) => {
       // only add this plugin button def if there isn't one there already
       // buttonDefs is a global so every toolbar component will share this
       if (!buttonDefs.has(iconName)) {
-        buttonDefs.set(iconName, {pluginName: plugin.pluginName, ButtonComponent: pluginButtonDefComponent});
+        buttonDefs.set(iconName, { pluginName: plugin.pluginName, ButtonComponent: pluginButtonDefComponent });
       }
     }
   });

--- a/src/components/tiles/tile-component.tsx
+++ b/src/components/tiles/tile-component.tsx
@@ -198,12 +198,12 @@ export class TileComponent extends BaseComponent<IProps, IState> {
                       hovered: this.state.hoverTile,
                       selected: isTileSelected,
                       annotatable: ui.annotationMode !== undefined && model.content.annotatableObjects.length > 0,
-                      "selected-for-comment": tileSelectedForComment});
+                      "selected-for-comment": tileSelectedForComment });
     const isDraggable = !isPlaceholderTile && !appConfig.disableTileDrags;
     const dragTileButton = isDraggable &&
                             <DragTileButton divRef={elt => this.dragElement = elt}
                               hovered={hoverTile} selected={isTileSelected}
-                              onClick={e => ui.setSelectedTile(model, {append: hasSelectionModifier(e)})} />;
+                              onClick={e => ui.setSelectedTile(model, { append: hasSelectionModifier(e) })} />;
     const resizeTileButton = isUserResizable &&
                               <ResizeTileButton divRef={elt => this.resizeElement = elt}
                                 hovered={hoverTile}
@@ -318,7 +318,7 @@ export class TileComponent extends BaseComponent<IProps, IState> {
 
     // Select the tile if the tool doesn't handle the selection itself
     if (!getTileComponentInfo(model.content.type)?.tileHandlesOwnSelection) {
-      ui.setSelectedTile(model, {append: hasSelectionModifier(e)});
+      ui.setSelectedTile(model, { append: hasSelectionModifier(e) });
     }
   };
 

--- a/src/components/utilities/dialog.tsx
+++ b/src/components/utilities/dialog.tsx
@@ -34,12 +34,12 @@ export class DialogComponent extends BaseComponent<IProps, IState> {
 
   public UNSAFE_componentWillReceiveProps(nextProps: IProps) {
     if (nextProps.dialog !== this.props.dialog) {
-      this.setState({promptValue: nextProps.dialog && nextProps.dialog.defaultValue});
+      this.setState({ promptValue: nextProps.dialog && nextProps.dialog.defaultValue });
     }
   }
 
   public render() {
-    const {dialog} = this.stores.ui;
+    const { dialog } = this.stores.ui;
     if (dialog) {
       let title = dialog.title;
       let contents: JSX.Element;
@@ -139,7 +139,7 @@ export class DialogComponent extends BaseComponent<IProps, IState> {
 
   private handlePromptValueChanged = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     if (this.input) {
-      this.setState({promptValue: this.input.value});
+      this.setState({ promptValue: this.input.value });
     }
   };
 
@@ -155,7 +155,7 @@ export class DialogComponent extends BaseComponent<IProps, IState> {
   }
 
   private handlePromptDialogOk = (e?: React.MouseEvent<HTMLButtonElement>) => {
-    const {promptValue} = this;
+    const { promptValue } = this;
     if (promptValue.length > 0) {
       this.stores.ui.resolveDialog(promptValue);
     }

--- a/src/components/utilities/use-single-string-dialog.tsx
+++ b/src/components/utilities/use-single-string-dialog.tsx
@@ -46,7 +46,7 @@ export const useSingleStringDialog = ({
     buttons: [
       { label: "Cancel" },
       { label: "OK", isDefault: true,
-        onClick: () => onAccept(inputRef.current?.value || valueRef.current || "", context)}
+        onClick: () => onAccept(inputRef.current?.value || valueRef.current || "", context) }
     ],
     onClose
   });

--- a/src/components/workspace/resizable-panel.tsx
+++ b/src/components/workspace/resizable-panel.tsx
@@ -16,9 +16,9 @@ interface IProps {
 // documents shown on the left sided just by collapsing it.
 // There is now a hotkey cmd-shit-f which makes the right side take
 // the full width and does not render the left side at all.
-export const ResizablePanel: React.FC <IProps> = ({collapsed, children}) => {
+export const ResizablePanel: React.FC <IProps> = ({ collapsed, children }) => {
   return (
-    <div className={classNames("resizable-panel", {collapsed})} >
+    <div className={classNames("resizable-panel", { collapsed })} >
       {children}
     </div>
   );

--- a/src/components/workspace/resize-panel-divider.tsx
+++ b/src/components/workspace/resize-panel-divider.tsx
@@ -76,7 +76,7 @@ export const ResizePanelDivider: React.FC <IProps> = observer(function ResizePan
     // TODO: rename the class names so the top level one is resize-panel-divider since
     // that is the name of the component
     return (
-      <div className={classNames("divider-container", positionClass, {"show-expanders": reallyShowExpanders})}
+      <div className={classNames("divider-container", positionClass, { "show-expanders": reallyShowExpanders })}
           onMouseEnter={handleDividerEnter} onMouseLeave={handleDividerLeave} onClick={()=>handleDividerClick()}>
         <WorkspaceExpander onExpandWorkspace={handleExpandWorkspace} workspaceType={problemWorkspace.type} />
         <div className="resize-panel-divider" >

--- a/src/hooks/firestore-hooks.test.ts
+++ b/src/hooks/firestore-hooks.test.ts
@@ -81,7 +81,7 @@ describe("Firestore hooks", () => {
       const kNetwork = "network";
       const kRealTeacher = { uid: kId, name: kRealName, type: "teacher", network: kNetwork, networks: [kNetwork] };
       const kDefaultTeacher = { ...kRealTeacher, name: kDefaultName };
-      mockGet.mockImplementation(() => Promise.resolve({ data: () => kRealTeacher}));
+      mockGet.mockImplementation(() => Promise.resolve({ data: () => kRealTeacher }));
       const { result, rerender } = renderHook(() => useFirestoreTeacher(kId, kNetwork));
       expect(mockGet).toHaveBeenCalledTimes(1);
       // initial response is the default response

--- a/src/hooks/use-consumer-tile-linking.ts
+++ b/src/hooks/use-consumer-tile-linking.ts
@@ -116,7 +116,7 @@ const useLinkableTiles = ({ model, onRequestTilesOfType, onRequestLinkableTiles 
     } else {
       countsOfType[type]++;
     }
-    return { id, type, title: title || `${titleBase || type} ${countsOfType[type]}`};
+    return { id, type, title: title || `${titleBase || type} ${countsOfType[type]}` };
   }
 
   return {

--- a/src/hooks/use-custom-modal.tsx
+++ b/src/hooks/use-custom-modal.tsx
@@ -66,7 +66,7 @@ export const useCustomModal = <IContentProps, >({
     return () => contentElt?.removeEventListener("keydown", handleKeyDown, true);
   }, [blurModal, buttons, contentElt]);
 
-  const handleAfterOpen = ({overlayEl, contentEl}: { overlayEl: Element, contentEl: HTMLDivElement }) => {
+  const handleAfterOpen = ({ overlayEl, contentEl }: { overlayEl: Element, contentEl: HTMLDivElement }) => {
     setContentElt(contentEl);
 
     const element = focusElement && contentEl.querySelector(focusElement) as HTMLElement || contentEl;

--- a/src/hooks/use-force-update.ts
+++ b/src/hooks/use-force-update.ts
@@ -1,4 +1,4 @@
-import {useCallback, useState} from "react";
+import { useCallback, useState } from "react";
 
 /*
  * For those rare times you really need to force a component to re-render.

--- a/src/hooks/use-provider-tile-linking.tsx
+++ b/src/hooks/use-provider-tile-linking.tsx
@@ -22,7 +22,7 @@ interface IProps {
 export const useProviderTileLinking = ({
   actionHandlers, documentId, model, readOnly, onRequestTilesOfType, onRequestLinkableTiles
 }: IProps) => {
-  const {handleRequestTileLink, handleRequestTileUnlink} = actionHandlers || {};
+  const { handleRequestTileLink, handleRequestTileUnlink } = actionHandlers || {};
   const modelId = model.id;
   const { providers: linkableTiles } = useLinkableTiles({ model, onRequestTilesOfType, onRequestLinkableTiles });
   const isLinkEnabled = (linkableTiles.length > 0);
@@ -88,7 +88,7 @@ const useLinkableTiles = ({ model, onRequestTilesOfType, onRequestLinkableTiles 
     } else {
       countsOfType[type]++;
     }
-    return { id, type, title: title || `${titleBase || type} ${countsOfType[type]}`};
+    return { id, type, title: title || `${titleBase || type} ${countsOfType[type]}` };
   }
 
   return {

--- a/src/hooks/use-stores.ts
+++ b/src/hooks/use-stores.ts
@@ -7,7 +7,7 @@ import {
 import { ProblemModelType } from "../models/curriculum/problem";
 import { AppConfigModelType } from "../models/stores/app-config-model";
 import { DocumentsModelType } from "../models/stores/documents";
-import { DocumentContentModelType} from "../models/document/document-content";
+import { DocumentContentModelType } from "../models/document/document-content";
 
 import { GroupsModelType } from "../models/stores/groups";
 import { SelectionStoreModelType } from "../models/stores/selection";

--- a/src/hooks/use-tile-data-merging.ts
+++ b/src/hooks/use-tile-data-merging.ts
@@ -11,7 +11,7 @@ interface IProps {
   model: ITileModel;
 }
 
-export const useTileDataMerging = ({model}: IProps) => {
+export const useTileDataMerging = ({ model }: IProps) => {
   const mergableTiles = useMemo(() => getMergableDataSets(model), [model]);
   const mergeTileFunc = useCallback((selectedTile: ITileLinkMetadata) => {
     const sourceSnap = getSnapshot(selectedTile.dataSet as IDataSet);

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -7,7 +7,7 @@ import { authenticate,
         getAppMode,
         createFakeUser,
         getFirebaseJWTParams,
-        generateDevAuthentication} from "./auth";
+        generateDevAuthentication } from "./auth";
 import { IPortalClassInfo, IPortalClassUser, PortalStudentJWT, PortalTeacherJWT } from "./portal-types";
 import nock from "nock";
 import { NUM_FAKE_STUDENTS, NUM_FAKE_TEACHERS } from "../components/demo/demo-creator";
@@ -190,7 +190,7 @@ describe("demo mode", () => {
   });
 
   it("should authenticate demo students", (done) => {
-    authenticate("demo", appConfig, urlParams).then(({authenticatedUser}) => {
+    authenticate("demo", appConfig, urlParams).then(({ authenticatedUser }) => {
       const demoUser = createFakeUser({
         appMode: "demo",
         classId: "1",
@@ -206,7 +206,7 @@ describe("demo mode", () => {
   it("should handle preview launch from portal", (done) => {
     urlParams.domain = "preview";
     urlParams.domain_uid = "2222";
-    authenticate("demo", appConfig, urlParams).then(({authenticatedUser}) => {
+    authenticate("demo", appConfig, urlParams).then(({ authenticatedUser }) => {
       expect(authenticatedUser.className).toBe("Demo Class preview-2222");
       expect(authenticatedUser.type).toBe("student");
       expect(authenticatedUser.id).toBe("2222");
@@ -262,7 +262,7 @@ describe("student authentication", () => {
   });
 
   it("works in dev mode", (done) => {
-    authenticate("dev", appConfig).then(({authenticatedUser}) => {
+    authenticate("dev", appConfig).then(({ authenticatedUser }) => {
       expect(authenticatedUser).toEqual(DEV_STUDENT);
       done();
     });
@@ -289,8 +289,8 @@ describe("student authentication", () => {
       token: RAW_STUDENT_FIREBASE_JWT,
     });
 
-    authenticate("authed", appConfig, {token: GOOD_STUDENT_TOKEN, domain: BASE_PORTAL_URL})
-    .then(({authenticatedUser}) => {
+    authenticate("authed", appConfig, { token: GOOD_STUDENT_TOKEN, domain: BASE_PORTAL_URL })
+    .then(({ authenticatedUser }) => {
       expect(authenticatedUser).toEqual({
         type: "student",
         id: `${STUDENT_PORTAL_JWT.uid}`,
@@ -361,7 +361,7 @@ describe("student authentication", () => {
     .get(FIREBASE_JWT_PATH + FIREBASE_JWT_QUERY)
     .reply(400);
 
-    authenticate("authed", appConfig, {token: BAD_STUDENT_TOKEN, domain: BASE_PORTAL_URL})
+    authenticate("authed", appConfig, { token: BAD_STUDENT_TOKEN, domain: BASE_PORTAL_URL })
       .then(() => {
         done.fail();
       })
@@ -369,7 +369,7 @@ describe("student authentication", () => {
   });
 
   it("fails with no token", (done) => {
-    authenticate("authed", appConfig, {token: undefined, domain: BASE_PORTAL_URL})
+    authenticate("authed", appConfig, { token: undefined, domain: BASE_PORTAL_URL })
       .then(() => {
         done.fail();
       })
@@ -377,7 +377,7 @@ describe("student authentication", () => {
   });
 
   it("fails with no domain", (done) => {
-    authenticate("authed", appConfig, {token: BAD_STUDENT_TOKEN, domain: undefined})
+    authenticate("authed", appConfig, { token: BAD_STUDENT_TOKEN, domain: undefined })
       .then(() => {
         done.fail();
       })
@@ -454,7 +454,8 @@ describe("teacher authentication", () => {
   const appConfig = specAppConfig();
 
   beforeEach(() => {
-    urlParams = {token: GOOD_TEACHER_TOKEN, reportType: "offering", class: CLASS_INFO_URL, offering: OFFERING_INFO_URL};
+    urlParams = { token: GOOD_TEACHER_TOKEN, reportType: "offering", class: CLASS_INFO_URL,
+      offering: OFFERING_INFO_URL };
 
     nock(BASE_PORTAL_HOST, {
       reqheaders: {
@@ -509,9 +510,9 @@ describe("teacher authentication", () => {
       }
     })
     .get(CLASSES_MINE_PATH)
-    .reply(200, {classes: []});
+    .reply(200, { classes: [] });
 
-    authenticate("authed", appConfig, urlParams).then(({authenticatedUser, problemId}) => {
+    authenticate("authed", appConfig, urlParams).then(({ authenticatedUser, problemId }) => {
       expect(authenticatedUser).toEqual({
         type: "teacher",
         id: `${TEACHER_PORTAL_JWT.uid}`,

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -147,7 +147,7 @@ export const getFirebaseJWTWithBearerToken = (basePortalUrl: string, type: strin
           reject("No Firebase token found in Firebase JWT request response");
         }
         else {
-          const {token} = res.body;
+          const { token } = res.body;
           const firebaseJWT = jwt_decode(token);
           if (firebaseJWT) {
             resolve([token, firebaseJWT as PortalFirebaseJWT]);
@@ -168,7 +168,7 @@ export interface GetClassInfoParams {
 }
 
 export const getClassInfo = (params: GetClassInfoParams) => {
-  const {classInfoUrl, rawPortalJWT, portal, offeringId} = params;
+  const { classInfoUrl, rawPortalJWT, portal, offeringId } = params;
   return new Promise<ClassInfo>((resolve, reject) => {
     superagent
     .get(classInfoUrl)
@@ -245,7 +245,7 @@ export const authenticate = (appMode: AppMode, appConfig: AppConfigModelType, ur
     const bearerToken = urlParams.token;
     let basePortalUrl: string;
 
-    let {fakeClass, fakeUser} = urlParams;
+    let { fakeClass, fakeUser } = urlParams;
     // handle preview launch from portal
     if (urlParams.domain && urlParams.domain_uid && !bearerToken) {
       appMode = "demo";
@@ -308,7 +308,7 @@ export const authenticate = (appMode: AppMode, appConfig: AppConfigModelType, ur
       if (!urlParams.offering) {
         return reject("Missing offering parameter!");
       }
-      const {protocol, host} = parseUrl(urlParams.class);
+      const { protocol, host } = parseUrl(urlParams.class);
       basePortalUrl = `${protocol}//${host}/`;
     }
     else if (urlParams.domain) {
@@ -341,7 +341,7 @@ export const authenticate = (appMode: AppMode, appConfig: AppConfigModelType, ur
           throw new Error("Unable to get classInfoUrl or offeringId");
         }
 
-        return getClassInfo({classInfoUrl, rawPortalJWT, portal, offeringId})
+        return getClassInfo({ classInfoUrl, rawPortalJWT, portal, offeringId })
           .then((classInfo) => {
             const { user_type, uid, domain } = portalJWT;
             const { classHash } = classInfo;
@@ -371,7 +371,7 @@ export const authenticate = (appMode: AppMode, appConfig: AppConfigModelType, ur
                 authenticatedUser.portalClassOfferings =
                   getPortalClassOfferings(portalOfferingsResult, appConfig, urlParams);
 
-                Logger.log(LogEventName.INTERNAL_AUTHENTICATED, {id: authenticatedUser.id, portal});
+                Logger.log(LogEventName.INTERNAL_AUTHENTICATED, { id: authenticatedUser.id, portal });
                 resolve({
                   authenticatedUser,
                   classInfo,
@@ -412,7 +412,7 @@ export const generateDevAuthentication = (unitCode: string, problemOrdinal: stri
     }
   }
 
-  return {authenticatedUser, classInfo: DEV_CLASS_INFO};
+  return { authenticatedUser, classInfo: DEV_CLASS_INFO };
 };
 
 const createOfferingIdFromProblem = (unitCode: string, problemOrdinal: string) => {
@@ -459,7 +459,7 @@ const getFakeTeacherClassHashes = (appMode: AppMode, classId: string) => {
 };
 
 export const createFakeUser = (options: CreateFakeUserOptions) => {
-  const {appMode, classId, userType, userId, network, offeringId} = options;
+  const { appMode, classId, userType, userId, network, offeringId } = options;
   const className = `${appMode === "demo" ? "Demo" : "QA"} Class ${classId}`;
   if (userType === "student") {
     const student: StudentUser = {
@@ -506,12 +506,12 @@ export interface CreateFakeAuthenticationOptions {
 }
 
 export const createFakeAuthentication = (options: CreateFakeAuthenticationOptions) => {
-  const {appMode, classId, userType, userId, network: _network, unitCode, problemOrdinal} = options;
+  const { appMode, classId, userType, userId, network: _network, unitCode, problemOrdinal } = options;
   const network = userType === "teacher"
                     ? _network || (parseInt(userId, 10) > 1 ? "demo-network" : undefined) || undefined
                     : undefined;
   const offeringId = createOfferingIdFromProblem(unitCode, problemOrdinal);
-  const authenticatedUser = createFakeUser({appMode, classId, userType, network, userId, offeringId});
+  const authenticatedUser = createFakeUser({ appMode, classId, userType, network, userId, offeringId });
   const classInfo: ClassInfo = {
     name: authenticatedUser.className,
     classHash: authenticatedUser.classHash,
@@ -555,5 +555,5 @@ export const createFakeAuthentication = (options: CreateFakeAuthenticationOption
       }) as TeacherUser
     );
   }
-  return {authenticatedUser, classInfo};
+  return { authenticatedUser, classInfo };
 };

--- a/src/lib/db-listeners/base-listener.ts
+++ b/src/lib/db-listeners/base-listener.ts
@@ -1,5 +1,5 @@
 import firebase from "firebase/app";
-import {DEBUG_LISTENERS} from "../../lib/debug";
+import { DEBUG_LISTENERS } from "../../lib/debug";
 
 export class BaseListener {
   protected listener: string;

--- a/src/lib/db-listeners/db-comments-listener.ts
+++ b/src/lib/db-listeners/db-comments-listener.ts
@@ -40,7 +40,7 @@ export class DBCommentsListener extends BaseListener {
       const docModel = snapshot.ref.key && documents.getDocument(snapshot.ref.key);
       if (docModel) {
         forEach(dbDocComments, (tileComments, tileId) => {
-          const tileCommentsModel = TileCommentsModel.create({tileId});
+          const tileCommentsModel = TileCommentsModel.create({ tileId });
           forEach(tileComments, (tileComment, commentKey) => {
             if (!tileComment.deleted) {
               const { uid, content, selectionInfo } = tileComment;

--- a/src/lib/db-listeners/db-docs-content-listener.ts
+++ b/src/lib/db-listeners/db-docs-content-listener.ts
@@ -53,7 +53,7 @@ export class DBDocumentsContentListener extends BaseListener {
 
   public start() {
     this.disposer = autorun(() => {
-      const {documents, groups, user} = this.db.stores;
+      const { documents, groups, user } = this.db.stores;
 
       const documentsToMonitor: DocumentModelType[] = [];
 

--- a/src/lib/db-listeners/db-groups-listener.ts
+++ b/src/lib/db-listeners/db-groups-listener.ts
@@ -15,7 +15,7 @@ export class DBGroupsListener extends BaseListener {
 
   public start() {
     return new Promise<void>((resolve, reject) => {
-      const {user, groups} = this.db.stores;
+      const { user, groups } = this.db.stores;
       const groupsRef = this.groupsRef = this.db.firebase.ref(this.db.firebase.getGroupsPath(user));
 
       // use once() so we are ensured that groups are set before we resolve
@@ -56,7 +56,7 @@ export class DBGroupsListener extends BaseListener {
   }
 
   private handleGroupsRef = (snapshot: firebase.database.DataSnapshot) => {
-    const {user} = this.db.stores;
+    const { user } = this.db.stores;
     const groups: DBOfferingGroupMap = snapshot.val() || {};
     const myGroupIds: string[] = [];
     const overSubscribedUserUpdates: any = {};
@@ -68,7 +68,7 @@ export class DBGroupsListener extends BaseListener {
       const rawUsers = groups[groupId].users || {};
       // rawUsers can get interpreted as an array instead of a map if user IDs are small (e.g. in demo mode)
       // So, make sure to filter out empty array spaces and convert number IDs to strings for standardization
-      const groupUsers = map(rawUsers, (groupUser, uid) => ({uid: `${uid}`, user: groupUser}))
+      const groupUsers = map(rawUsers, (groupUser, uid) => ({ uid: `${uid}`, user: groupUser }))
         .filter(groupUser => !!groupUser.user);
       if (groupUsers.find(groupUser => groupUser.uid === user.id)) {
         myGroupIds.push(groupId);

--- a/src/lib/db-listeners/db-other-docs-listener.ts
+++ b/src/lib/db-listeners/db-other-docs-listener.ts
@@ -66,7 +66,7 @@ export class DBOtherDocumentsListener extends BaseListener {
   }
 
   private handleDocumentAdded = (snapshot: firebase.database.DataSnapshot) => {
-    const {documents, user} = this.db.stores;
+    const { documents, user } = this.db.stores;
     const dbDoc: DBOtherDocument|null = snapshot.val();
     this.debugLogSnapshot("#handleDocumentAdded", snapshot);
     if (dbDoc) {
@@ -90,7 +90,7 @@ export class DBOtherDocumentsListener extends BaseListener {
   };
 
   private handleDocumentChanged = (snapshot: firebase.database.DataSnapshot) => {
-    const {documents} = this.db.stores;
+    const { documents } = this.db.stores;
     const dbDoc: DBOtherDocument|null = snapshot.val();
     this.debugLogSnapshot("#handleDocumentChanged", snapshot);
     if (dbDoc) {
@@ -102,7 +102,7 @@ export class DBOtherDocumentsListener extends BaseListener {
   };
 
   private handleDocumentRemoved = (snapshot: firebase.database.DataSnapshot) => {
-    const {documents} = this.db.stores;
+    const { documents } = this.db.stores;
     const dbDoc: DBOtherDocument|null = snapshot.val();
     this.debugLogSnapshot("#handleDocumentRemoved", snapshot);
     if (dbDoc) {

--- a/src/lib/db-listeners/db-supports-listener.ts
+++ b/src/lib/db-listeners/db-supports-listener.ts
@@ -54,7 +54,7 @@ export class DBSupportsListener extends BaseListener {
   }
 
   private handleSupportsUpdate = (eventType: string) => (snapshot: firebase.database.DataSnapshot) => {
-    const {supports} = this.db.stores;
+    const { supports } = this.db.stores;
     const dbSupports = snapshot.val();
     this.debugLogSnapshot("#handleSupportsUpdate", snapshot);
     // The top-level key will be the audience for with an updated support
@@ -80,8 +80,8 @@ export class DBSupportsListener extends BaseListener {
             const dbSupport: DBSupport = dbSupports[audienceId][key];
             const uid = dbSupport.uid;
             const audience = audienceType === AudienceEnum.group
-              ? GroupAudienceModel.create({identifier: audienceId})
-              : UserAudienceModel.create({identifier: audienceId});
+              ? GroupAudienceModel.create({ identifier: audienceId })
+              : UserAudienceModel.create({ identifier: audienceId });
             const supportModel = this.createSupportModel(uid, "all", dbSupport, audience);
             supportModel && teacherSupports.push(supportModel);
           });
@@ -99,7 +99,7 @@ export class DBSupportsListener extends BaseListener {
             const teacherSupport = support as TeacherSupportModelType;
             if (teacherSupport.uid === user.id) {
               // teachers sync their support document properties to Firebase to track isDeleted
-              const {audience, sectionTarget, key} = teacherSupport;
+              const { audience, sectionTarget, key } = teacherSupport;
               const path = this.db.firebase.getSupportsPath(user, audience, sectionTarget, key);
               this.db.listeners.syncSupportDocumentProperties(document, "firebase", path);
             }

--- a/src/lib/db-listeners/index.test.ts
+++ b/src/lib/db-listeners/index.test.ts
@@ -10,12 +10,12 @@ describe("DBListeners", () => {
     appConfig: specAppConfig(),
     appMode: "test",
     documents: DocumentsModel.create(),
-    user: UserModel.create({id: "1", portal: "example.com"})
+    user: UserModel.create({ id: "1", portal: "example.com" })
   });
   const db = new DB();
 
   beforeEach(async () => {
-    await db.connect({appMode: "test", stores, dontStartListeners: true});
+    await db.connect({ appMode: "test", stores, dontStartListeners: true });
   });
 
   afterEach(() => {

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -53,7 +53,7 @@ describe("db", () => {
     stores = specStores({
       appMode: "test",
       documents: DocumentsModel.create(),
-      user: UserModel.create({id: "1", portal: "example.com"})
+      user: UserModel.create({ id: "1", portal: "example.com" })
     });
     db = new DB();
     mockDatabase.mockReset();
@@ -69,7 +69,7 @@ describe("db", () => {
     expect.assertions(5);
     expect(db.firebase.isConnected).toBe(false);
     expect(db.isAuthStateSubscribed()).toBe(false);
-    await db.connect({appMode: "test", stores, dontStartListeners: true});
+    await db.connect({ appMode: "test", stores, dontStartListeners: true });
     expect(db.firebase.isConnected).toBe(true);
     expect(db.isAuthStateSubscribed()).toBe(true);
     db.disconnect();
@@ -87,7 +87,7 @@ describe("db", () => {
     expect.assertions(8);
     expect(db.firebase.isConnected).toBe(false);
     expect(db.isAuthStateSubscribed()).toBe(false);
-    await db.connect({appMode: "test", stores, dontStartListeners: true});
+    await db.connect({ appMode: "test", stores, dontStartListeners: true });
     expect(mockUseDatabaseEmulator).toHaveBeenCalled();
     expect(mockUseFirestoreEmulator).toHaveBeenCalled();
     expect(mockUseFunctionsEmulator).toHaveBeenCalled();
@@ -102,7 +102,7 @@ describe("db", () => {
 
   it("resolves paths in test mode", async () => {
     expect.assertions(2);
-    await db.connect({appMode: "test", stores, dontStartListeners: true});
+    await db.connect({ appMode: "test", stores, dontStartListeners: true });
     expect(db.firebase.getRootFolder()).toMatch(/^\/test\/([^/])+\/portals\/example_com\/$/);
     expect(db.firebase.getFullPath("foo")).toMatch(/^\/test\/([^/])+\/portals\/example_com\/foo$/);
   });
@@ -110,14 +110,14 @@ describe("db", () => {
   it("resolves paths in dev mode", async () => {
     expect.assertions(2);
     stores.setAppMode("dev");
-    await db.connect({appMode: "dev", stores, dontStartListeners: true});
+    await db.connect({ appMode: "dev", stores, dontStartListeners: true });
     expect(db.firebase.getRootFolder()).toMatch(/^\/dev\/([^/])+\/portals\/example_com\/$/);
     expect(db.firebase.getFullPath("foo")).toMatch(/^\/dev\/([^/])+\/portals\/example_com\/foo$/);
   });
 
   it("can get a reference to the database", async () => {
     expect.assertions(1);
-    await db.connect({appMode: "test", stores, dontStartListeners: true});
+    await db.connect({ appMode: "test", stores, dontStartListeners: true });
     const testString = "this is a test";
 
     mockDatabase.mockImplementation(() => ({
@@ -135,9 +135,9 @@ describe("db", () => {
 
   it("can parse document text content", async () => {
     expect.assertions(4);
-    await db.connect({appMode: "test", stores, dontStartListeners: true});
+    await db.connect({ appMode: "test", stores, dontStartListeners: true });
     const storedJsonString = JSON.stringify(createSingleTileContent({ type: "Text", text: "Testing" }));
-    const docContentSnapshot = db.parseDocumentContent({content: storedJsonString} as DBDocument);
+    const docContentSnapshot = db.parseDocumentContent({ content: storedJsonString } as DBDocument);
     const docContent = DocumentContentModel.create(docContentSnapshot);
 
     if (docContent == null) {
@@ -171,14 +171,14 @@ describe("db", () => {
                 stores.documents.resolveRequiredDocumentPromise(newDocument);
                 return docPromise;
               }
-            })};
+            }) };
           }
         })
       })
     }));
     stores.documents = createDocumentsModelWithRequiredDocuments([ProblemDocument, PlanningDocument]);
     stores.documents.resolveRequiredDocumentPromisesWithNull();
-    await db.connect({appMode: "test", stores, dontStartListeners: true});
+    await db.connect({ appMode: "test", stores, dontStartListeners: true });
     expect((await db.guaranteeOpenDefaultDocument(ProblemDocument))?.type).toBe(ProblemDocument);
     expect(await stores.documents.requiredDocuments[ProblemDocument].promise).toEqual(newDocument);
     expect(await stores.documents.requiredDocuments[PlanningDocument].promise).toBeNull();
@@ -201,14 +201,14 @@ describe("db", () => {
                 stores.documents.resolveRequiredDocumentPromise(newDocument);
                 return docPromise;
               }
-            })};
+            }) };
           }
         })
       })
     }));
     stores.documents = createDocumentsModelWithRequiredDocuments([ProblemDocument, PlanningDocument]);
     stores.documents.resolveRequiredDocumentPromisesWithNull();
-    await db.connect({appMode: "test", stores, dontStartListeners: true});
+    await db.connect({ appMode: "test", stores, dontStartListeners: true });
     expect((await db.guaranteePlanningDocument())?.type).toBe(PlanningDocument);
     expect(await stores.documents.requiredDocuments[PlanningDocument].promise).toEqual(newDocument);
     expect(await stores.documents.requiredDocuments[ProblemDocument].promise).toBeNull();
@@ -218,12 +218,12 @@ describe("db", () => {
     const personalDocument = createDocumentModel({ uid: "1", type: PersonalDocument, key: "doc-1" });
     stores.documents = createDocumentsModelWithRequiredDocuments([PersonalDocument]);
     stores.documents.resolveRequiredDocumentPromise(personalDocument);
-    await db.connect({appMode: "test", stores, dontStartListeners: true});
+    await db.connect({ appMode: "test", stores, dontStartListeners: true });
     expect(await db.guaranteeOpenDefaultDocument(PersonalDocument)).toBe(personalDocument);
   });
 
   it("logs errors when asked to open default documents without required document promises", async () => {
-    await db.connect({appMode: "test", stores, dontStartListeners: true});
+    await db.connect({ appMode: "test", stores, dontStartListeners: true });
 
     await jestSpyConsole("error", async spy => {
       await db.guaranteeOpenDefaultDocument(ProblemDocument);

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -184,7 +184,7 @@ export class DB {
   }
 
   public joinGroup(groupId: string) {
-    const {user} = this.stores;
+    const { user } = this.stores;
     const groupRef = this.firebase.ref(this.firebase.getGroupPath(user, groupId));
     let userRef: firebase.database.Reference;
 
@@ -231,7 +231,7 @@ export class DB {
   }
 
   public leaveGroup() {
-    const {user} = this.stores;
+    const { user } = this.stores;
     const groupsRef = this.firebase.ref(this.firebase.getGroupsPath(user));
 
     this.firebase.cancelGroupDisconnect();
@@ -265,7 +265,7 @@ export class DB {
 
   public async guaranteeOpenDefaultDocument(documentType: typeof ProblemDocument | typeof PersonalDocument,
                                             defaultContent?: DocumentContentModelType) {
-    const {documents} = this.stores;
+    const { documents } = this.stores;
 
     // problem document
     if (documentType === ProblemDocument) {
@@ -297,7 +297,7 @@ export class DB {
   }
 
   public async guaranteePlanningDocument(sections?: SectionModelType[]) {
-    const {appConfig, documents} = this.stores;
+    const { appConfig, documents } = this.stores;
 
     const requiredPlanningDocument = documents.requiredDocuments[PlanningDocument];
     if (requiredPlanningDocument) {
@@ -313,7 +313,7 @@ export class DB {
   }
 
   public async guaranteeLearningLog(initialTitle?: string, defaultContent?: DocumentContentModelType) {
-    const {documents} = this.stores;
+    const { documents } = this.stores;
 
     const requiredLearningLogDocument = documents.requiredDocuments[LearningLogDocument];
     if (requiredLearningLogDocument) {
@@ -328,7 +328,7 @@ export class DB {
 
   public createProblemOrPlanningDocument(type: ProblemOrPlanningDocumentType, content?: DocumentContentModelType) {
     return new Promise<DocumentModelType | null>((resolve, reject) => {
-      const {user, documents} = this.stores;
+      const { user, documents } = this.stores;
       const offeringUserRef = this.firebase.ref(this.firebase.getOfferingUserPath(user));
 
       return offeringUserRef.once("value")
@@ -349,7 +349,7 @@ export class DB {
         .then(() => {
           // create the new document
           return this.createDocument({ type, content: JSON.stringify(content) })
-            .then(({document, metadata}) => {
+            .then(({ document, metadata }) => {
                 const newDocument: DBOfferingUserProblemDocument = {
                   version: "1.0",
                   self: {
@@ -380,16 +380,16 @@ export class DB {
 
   public createDocument(params: { type: DBDocumentType, content?: string }) {
     const { type, content } = params;
-    const {user} = this.stores;
-    return new Promise<{document: DBDocument, metadata: DBDocumentMetadata}>((resolve, reject) => {
+    const { user } = this.stores;
+    return new Promise<{ document: DBDocument, metadata: DBDocumentMetadata }>((resolve, reject) => {
       const documentRef = this.firebase.ref(this.firebase.getUserDocumentPath(user)).push();
       const documentKey = documentRef.key!;
       const metadataRef = this.firebase.ref(this.firebase.getUserDocumentMetadataPath(user, documentKey));
       const version = "1.0";
       const createdAt = firebase.database.ServerValue.TIMESTAMP as number;
-      const {classHash, offeringId} = user;
-      const self = {uid: user.id, documentKey, classHash};
-      const document: DBDocument = {version, self, type};
+      const { classHash, offeringId } = user;
+      const self = { uid: user.id, documentKey, classHash };
+      const document: DBDocument = { version, self, type };
       if (content) {
         document.content = content;
       }
@@ -401,20 +401,20 @@ export class DB {
         case LearningLogDocument:
         case PersonalPublication:
         case LearningLogPublication:
-          metadata = {version, self, createdAt, type};
+          metadata = { version, self, createdAt, type };
           break;
         case PlanningDocument:
         case ProblemDocument:
         case ProblemPublication:
         case SupportPublication:
-          metadata = {version, self, createdAt, type, classHash, offeringId};
+          metadata = { version, self, createdAt, type, classHash, offeringId };
           break;
       }
 
       return documentRef.set(document)
         .then(() => metadataRef.set(metadata))
         .then(() => {
-          resolve({document, metadata});
+          resolve({ document, metadata });
         })
         .catch(reject);
     });
@@ -425,7 +425,7 @@ export class DB {
   }
 
   public publishProblemDocument(documentModel: DocumentModelType) {
-    const {user, groups} = this.stores;
+    const { user, groups } = this.stores;
     // JSON content with modified unique ids which will break the history
     const content = documentModel.content?.publish();
     if (!content) {
@@ -433,8 +433,8 @@ export class DB {
     }
     let pubCount = documentModel.getNumericProperty("pubCount");
     documentModel.setNumericProperty("pubCount", ++pubCount);
-    return new Promise<{document: DBDocument, metadata: DBPublicationDocumentMetadata}>((resolve, reject) => {
-      this.createDocument({ type: ProblemPublication, content }).then(({document, metadata}) => {
+    return new Promise<{ document: DBDocument, metadata: DBPublicationDocumentMetadata }>((resolve, reject) => {
+      this.createDocument({ type: ProblemPublication, content }).then(({ document, metadata }) => {
         const publicationRef = this.firebase.ref(this.firebase.getProblemPublicationsPath(user)).push();
         const userGroup = groups.getGroupById(user.currentGroupId);
         const groupUserConnections: DBGroupUserConnections | undefined = userGroup && userGroup.users
@@ -459,7 +459,7 @@ export class DB {
         publicationRef.set(publication)
           .then(() => {
             logDocumentEvent(LogEventName.PUBLISH_DOCUMENT, { document: documentModel });
-            resolve({document, metadata: metadata as DBPublicationDocumentMetadata});
+            resolve({ document, metadata: metadata as DBPublicationDocumentMetadata });
           })
           .catch(reject);
       });
@@ -467,7 +467,7 @@ export class DB {
   }
 
   public publishOtherDocument(documentModel: DocumentModelType) {
-    const {user} = this.stores;
+    const { user } = this.stores;
     const content = documentModel.content?.publish();
     if (!content) {
       throw new Error("Could not publish the specified document because its content is not available.");
@@ -475,8 +475,8 @@ export class DB {
     const publicationType = documentModel.type + "Publication" as DBDocumentType;
     let pubCount = documentModel.getNumericProperty("pubCount");
     documentModel.setNumericProperty("pubCount", ++pubCount);
-    return new Promise<{document: DBDocument, metadata: DBPublicationDocumentMetadata}>((resolve, reject) => {
-      this.createDocument({ type: publicationType, content }).then(({document, metadata}) => {
+    return new Promise<{ document: DBDocument, metadata: DBPublicationDocumentMetadata }>((resolve, reject) => {
+      this.createDocument({ type: publicationType, content }).then(({ document, metadata }) => {
         const publicationPath = publicationType === "personalPublication"
                                 ? this.firebase.getPersonalPublicationsPath(user)
                                 : this.firebase.getLearningLogPublicationsPath(user);
@@ -496,7 +496,7 @@ export class DB {
         publicationRef.set(publication)
           .then(() => {
             logDocumentEvent(LogEventName.PUBLISH_DOCUMENT, { document: documentModel });
-            resolve({document, metadata: metadata as DBPublicationDocumentMetadata});
+            resolve({ document, metadata: metadata as DBPublicationDocumentMetadata });
           })
           .catch(reject);
       });
@@ -530,9 +530,9 @@ export class DB {
 
   public openDocument(options: OpenDocumentOptions) {
     const { documents } = this.stores;
-    const {documentKey, type, title, properties, userId, groupId, visibility, originDoc, pubVersion} = options;
+    const { documentKey, type, title, properties, userId, groupId, visibility, originDoc, pubVersion } = options;
     return new Promise<DocumentModelType>((resolve, reject) => {
-      const {user} = this.stores;
+      const { user } = this.stores;
       const documentPath = this.firebase.getUserDocumentPath(user, documentKey, userId);
       const metadataPath = this.firebase.getUserDocumentMetadataPath(user, documentKey, userId);
       const documentRef = this.firebase.ref(documentPath);
@@ -598,7 +598,7 @@ export class DB {
   // personal documents and learning logs
   public createOtherDocument(documentType: OtherDocumentType, params: ICreateOtherDocumentParams = {}) {
     const { title, properties, content } = params;
-    const {appConfig, documents, user} = this.stores;
+    const { appConfig, documents, user } = this.stores;
     const baseTitle = documentType === PersonalDocument
                         ? appConfig.defaultDocumentTitle
                         : appConfig.defaultLearningLogTitle;
@@ -606,8 +606,8 @@ export class DB {
 
     return new Promise<DocumentModelType | null>((resolve, reject) => {
       return this.createDocument({ type: documentType, content: JSON.stringify(content) })
-        .then(({document, metadata}) => {
-          const {documentKey} = document.self;
+        .then(({ document, metadata }) => {
+          const { documentKey } = document.self;
           const newDocument: DBOtherDocument = {
             version: "1.0",
             self: {
@@ -686,7 +686,7 @@ export class DB {
 
   public clear(level: DBClearLevel) {
     return new Promise<void>((resolve, reject) => {
-      const {user} = this.stores;
+      const { user } = this.stores;
       const clearPath = (path?: string) => {
         this.firebase.ref(path).remove().then(resolve).catch(reject);
       };
@@ -716,7 +716,7 @@ export class DB {
   public createDocumentModelFromProblemMetadata(
           type: ProblemOrPlanningDocumentType, userId: string,
           metadata: DBOfferingUserProblemDocument) {
-    const {documentKey} = metadata;
+    const { documentKey } = metadata;
     const group = this.stores.groups.groupForUser(userId);
     return this.openDocument({
       type,
@@ -734,23 +734,23 @@ export class DB {
 
   // handles personal documents and learning logs
   public createDocumentModelFromOtherDocument(dbDocument: DBOtherDocument, type: OtherDocumentType) {
-    const {title, properties, self: {uid, documentKey}} = dbDocument;
+    const { title, properties, self: { uid, documentKey } } = dbDocument;
     const group = this.stores.groups.groupForUser(uid);
     const groupId = group && group.id;
-    return this.openDocument({type, userId: uid, documentKey, groupId, title, properties});
+    return this.openDocument({ type, userId: uid, documentKey, groupId, title, properties });
   }
 
   // handles published personal documents and published learning logs
   public createDocumentModelFromOtherPublication(publication: DBOtherPublication, type: OtherPublicationType) {
-    const {title, properties, uid, originDoc, self: {documentKey}, pubVersion} = publication;
+    const { title, properties, uid, originDoc, self: { documentKey }, pubVersion } = publication;
 
     const group = this.stores.groups.groupForUser(uid);
     const groupId = group && group.id;
-    return this.openDocument({type, userId: uid, documentKey, groupId, title, properties, originDoc, pubVersion});
+    return this.openDocument({ type, userId: uid, documentKey, groupId, title, properties, originDoc, pubVersion });
   }
 
   public createDocumentFromPublication(publication: DBPublication) {
-    const {groupId, groupUserConnections, userId, documentKey, pubVersion} = publication;
+    const { groupId, groupUserConnections, userId, documentKey, pubVersion } = publication;
     // groupUserConnections returns as an array and must be converted back to a map
     const groupUserConnectionsMap = Object.keys(groupUserConnections || [])
       .reduce((allUsers, groupUserId) => {

--- a/src/lib/firestore.test.ts
+++ b/src/lib/firestore.test.ts
@@ -66,7 +66,7 @@ describe("Firestore class", () => {
       const firestore = new Firestore(mockDB);
       expect(firestore.userId).toBe("no-user-id");
       expect(firestore.isConnected).toBe(false);
-      firestore.setFirebaseUser({ uid: "user-1"} as any);
+      firestore.setFirebaseUser({ uid: "user-1" } as any);
       expect(firestore.userId).toBe("user-1");
       expect(firestore.isConnected).toBe(true);
     });

--- a/src/lib/logger.debug.test.ts
+++ b/src/lib/logger.debug.test.ts
@@ -25,7 +25,7 @@ describe("dev/qa/test logger with DEBUG_LOGGER true", () => {
     stores = createStores({
       appMode: "test",
       appConfig: specAppConfig({ config: { appName: "TestLogger" } }),
-      user: UserModel.create({id: "0", type: "teacher", portal: "test"})
+      user: UserModel.create({ id: "0", type: "teacher", portal: "test" })
     });
 
     // intercept and suppress console logs

--- a/src/lib/logger.test.ts
+++ b/src/lib/logger.test.ts
@@ -40,8 +40,8 @@ describe("uninitialized logger", () => {
     mockXhr.setup();
     stores = createStores({
       appMode: "authed",
-      appConfig: specAppConfig({ config: { appName: "TestLogger"} }),
-      user: UserModel.create({id: "0", portal: "test"})
+      appConfig: specAppConfig({ config: { appName: "TestLogger" } }),
+      user: UserModel.create({ id: "0", portal: "test" })
     });
   });
 
@@ -80,7 +80,7 @@ describe("dev/qa/test logger with DEBUG_LOGGER false", () => {
     mockXhr.setup();
     stores = createStores({
       appMode: "test",
-      appConfig: specAppConfig({ config: { appName: "TestLogger"} }),
+      appConfig: specAppConfig({ config: { appName: "TestLogger" } }),
       ui: UIModel.create({
         activeNavTab: ENavTab.kStudentWork,
         problemWorkspace: {
@@ -92,7 +92,7 @@ describe("dev/qa/test logger with DEBUG_LOGGER false", () => {
           mode: "1-up"
         },
       }),
-      user: UserModel.create({id: "0", type: "teacher", portal: "test"})
+      user: UserModel.create({ id: "0", type: "teacher", portal: "test" })
     });
 
     Logger.initializeLogger(stores, { investigation: investigation.title, problem: problem?.title });
@@ -129,7 +129,7 @@ describe("demo logger with DEBUG_LOGGER false", () => {
     mockXhr.setup();
     stores = createStores({
       appMode: "demo",
-      appConfig: specAppConfig({ config: { appName: "TestLogger"} }),
+      appConfig: specAppConfig({ config: { appName: "TestLogger" } }),
       ui: UIModel.create({
         activeNavTab: ENavTab.kStudentWork,
         problemWorkspace: {
@@ -141,7 +141,7 @@ describe("demo logger with DEBUG_LOGGER false", () => {
           mode: "1-up"
         },
       }),
-      user: UserModel.create({id: "0", type: "teacher", portal: "test"})
+      user: UserModel.create({ id: "0", type: "teacher", portal: "test" })
     });
 
     Logger.initializeLogger(stores, { investigation: investigation.title, problem: problem?.title });
@@ -185,7 +185,7 @@ describe("authed logger", () => {
 
     stores = createStores({
       appMode: "authed",
-      appConfig: specAppConfig({ config: { appName: "TestLogger"} }),
+      appConfig: specAppConfig({ config: { appName: "TestLogger" } }),
       user: UserModel.create({
         id: "0", type: "student", portal: "test",
         loggingRemoteEndpoint: "foo"
@@ -240,7 +240,7 @@ describe("authed logger", () => {
         expect(request.time).toEqual(expect.anything());
         expect(request.event).toBe("CREATE_TILE");
         expect(request.method).toBe("do");
-        expect(request.parameters).toEqual({foo: "bar"});
+        expect(request.parameters).toEqual({ foo: "bar" });
 
         done();
         return res.status(201);

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -99,7 +99,7 @@ export class Logger {
 
   private createLogMessage(
     event: string,
-    parameters?: {section?: string},
+    parameters?: { section?: string },
     method: LogEventMethod = LogEventMethod.DO
   ): LogMessage {
     const {
@@ -108,7 +108,7 @@ export class Logger {
       ui: { activeNavTab, navTabContentShown, problemWorkspace, teacherPanelKey },
       user: { activityUrl, classHash, id, isStudent, isTeacher, portal, type, currentGroupId,
               loggingRemoteEndpoint, firebaseDisconnects, loggingDisconnects, networkStatusAlerts
-    }} = this.stores;
+    } } = this.stores;
     // only log disconnect counts if there have been any disconnections
     const totalDisconnects = firebaseDisconnects + loggingDisconnects + networkStatusAlerts;
     const disconnects = totalDisconnects

--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -18,12 +18,12 @@ export const setPageTitle = (stores: IStores, argProblem?: ProblemModelType) => 
 };
 
 export const updateProblem = (stores: IStores, problemId: string) => {
-  const {unit} = stores;
-  const {investigation, problem} = unit.getProblem(problemId);
+  const { unit } = stores;
+  const { investigation, problem } = unit.getProblem(problemId);
   if (investigation && problem) {
     Logger.updateAppContext({ investigation: investigation.title, problem: problem.title });
     setPageTitle(stores, problem);
-    stores.supports.createFromUnit({unit, investigation, problem, documents: stores.documents});
+    stores.supports.createFromUnit({ unit, investigation, problem, documents: stores.documents });
     stores.problem = problem;
   }
 };

--- a/src/models/curriculum/log-curriculum-event.test.ts
+++ b/src/models/curriculum/log-curriculum-event.test.ts
@@ -33,7 +33,7 @@ describe("logCurriculumEvent", () => {
 
     stores = createStores({
       appMode: "authed",
-      appConfig: specAppConfig({ config: { appName: "TestLogger"} }),
+      appConfig: specAppConfig({ config: { appName: "TestLogger" } }),
       user: UserModel.create({
         id: "0", type: "student", portal: "test",
         loggingRemoteEndpoint: "foo"

--- a/src/models/curriculum/problem.test.ts
+++ b/src/models/curriculum/problem.test.ts
@@ -193,7 +193,7 @@ describe("problem model", () => {
       ordinal: 1,
       title: "Test",
       disabled: ["roo"],
-      settings: { roo: "baz"},
+      settings: { roo: "baz" },
       config: {
         disabledFeatures: ["foo"],
         settings: { foo: "bar" }

--- a/src/models/curriculum/unit.test.ts
+++ b/src/models/curriculum/unit.test.ts
@@ -46,8 +46,8 @@ describe("UnitModel", () => {
   });
 
   it("getProblem() should work as expected", () => {
-    expect(unit.getProblem("")).toEqual({investigation: undefined, problem: undefined});
-    expect(unit.getProblem("0")).toEqual({investigation: undefined, problem: undefined});
+    expect(unit.getProblem("")).toEqual({ investigation: undefined, problem: undefined });
+    expect(unit.getProblem("0")).toEqual({ investigation: undefined, problem: undefined });
     const result1 = unit.getProblem("1");
     expect(result1.problem && result1.problem.title).toBe(problemTitle);
     expect(result1.investigation && result1.investigation.title).toBe(investigation1Title);

--- a/src/models/data/attribute.test.ts
+++ b/src/models/data/attribute.test.ts
@@ -128,7 +128,7 @@ describe("DataSet Attributes", () => {
 
   test("type", () => {
     const testCases = valuesToTest.map(values => {
-      return [values, Attribute.create({name: "foo", values}).type];
+      return [values, Attribute.create({ name: "foo", values }).type];
     });
     expect({ testCases }).toMatchInlineSnapshot(`
 [0,1,2] => "numeric"
@@ -155,7 +155,7 @@ describe("DataSet Attributes", () => {
 
   test("typeCounts", () => {
     const testCases = valuesToTest.map(values => {
-      return [values, Attribute.create({name: "foo", values}).typeCounts];
+      return [values, Attribute.create({ name: "foo", values }).typeCounts];
     });
     // This can be updated with `npm run test -- -u attribute.test`
     expect({ testCases }).toMatchInlineSnapshot(`
@@ -183,7 +183,7 @@ describe("DataSet Attributes", () => {
 
   test("mostCommonType", () => {
     const testCases = valuesToTest.map(values => {
-      return [values, Attribute.create({name: "foo", values}).mostCommonType];
+      return [values, Attribute.create({ name: "foo", values }).mostCommonType];
     });
     // This can be updated with `npm run test -- -u attribute.test`
     expect({ testCases }).toMatchInlineSnapshot(`

--- a/src/models/data/attribute.ts
+++ b/src/models/data/attribute.ts
@@ -1,4 +1,4 @@
-import {Instance, SnapshotIn, types} from "mobx-state-tree";
+import { Instance, SnapshotIn, types } from "mobx-state-tree";
 import { Formula } from "./formula";
 import { typedId } from "../../utilities/js-utils";
 import { IValueType, ValueType, isDate, isImageUrl, isNumeric, toNumeric } from "./data-types";
@@ -143,7 +143,7 @@ export const Attribute = types.model("Attribute", {
   // TODO: we really need to keep track of empty values, or we need to count
   // categorical (everything not empty) but empty could be categorical
   get mostCommonType(): undefined | AttributeType {
-    const {typeCounts} = self;
+    const { typeCounts } = self;
     if (typeCounts.size === 0) {
       if (self.values.length > 0) {
         // typeCounts does not include categorical

--- a/src/models/data/data-broker.test.ts
+++ b/src/models/data/data-broker.test.ts
@@ -9,7 +9,7 @@ describe("DataBroker", () => {
 
   beforeEach(() => {
     broker = new DataBroker();
-    dsEmpty = DataSet.create({ name: "empty"});
+    dsEmpty = DataSet.create({ name: "empty" });
     dsCases = DataSet.create({ name: "cases" });
     dsCases.addAttributeWithID({ name: "a" });
     dsCases.addCasesWithIDs([{ a: 1, __id__: "c1" }, { a: 2, __id__: "c2" }, { a: 3, __id__: "c3" }]);

--- a/src/models/data/data-set.ts
+++ b/src/models/data/data-set.ts
@@ -608,7 +608,7 @@ export const DataSet = types.model("DataSet", {
 
       selectAll(select = true) {
         if (select) {
-          self.cases.forEach(({__id__}) => self.selection.add(__id__));
+          self.cases.forEach(({ __id__ }) => self.selection.add(__id__));
         }
         else {
           self.selection.clear();
@@ -720,7 +720,7 @@ export function addCanonicalCasesToDataSet(dataset: IDataSet, cases: ICaseCreati
 }
 
 export function getDataSetBounds(dataSet: IDataSet) {
-  const result: Array<{ min: number, max: number}> = [];
+  const result: Array<{ min: number, max: number }> = [];
   dataSet.attributes.forEach(( attr, attrIndex) => {
     let min = Infinity;
     let max = -Infinity;

--- a/src/models/data/expression-utils.ts
+++ b/src/models/data/expression-utils.ts
@@ -42,7 +42,7 @@ export const validateDisplayExpression = (displayExpression: string, xName: stri
       return `Unrecognized variable "${unknownVar}" in expression.`;
     }
     // Attempt an evaluation to check for errors e.g. invalid function names
-    parsed.evaluate({[kSerializedXKey]: 1});
+    parsed.evaluate({ [kSerializedXKey]: 1 });
   } catch {
     return "Could not understand expression. Make sure you supply all operands " +
     "and use a multiplication sign where necessary, e.g. 3 * x + 4 instead of 3x + 4.";

--- a/src/models/data/filtered-cases.test.ts
+++ b/src/models/data/filtered-cases.test.ts
@@ -118,7 +118,7 @@ describe("DerivedDataSet", () => {
     expect(filtered.caseIds.length).toBe(2);
     expect(filtered.caseIds).toEqual(["c1", "c3"]);
 
-    data.setCaseValues([{ __id__: "c1", x: undefined}]);
+    data.setCaseValues([{ __id__: "c1", x: undefined }]);
     expect(filtered.caseIds.length).toBe(1);
     expect(filtered.caseIds).toEqual(["c3"]);
     expect(trigger).toHaveBeenCalledTimes(4);

--- a/src/models/document/base-document-content.ts
+++ b/src/models/document/base-document-content.ts
@@ -278,7 +278,7 @@ export const BaseDocumentContentModel = types
     },
     exportTileAsJson(tileInfo: TileLayoutModelType, options?: IDocumentExportOptions) {
       const { includeTileIds, ...otherOptions } = options || {};
-      const tileOptions = { includeId: includeTileIds, ...otherOptions};
+      const tileOptions = { includeId: includeTileIds, ...otherOptions };
       const tile = self.getTile(tileInfo.tileId);
       const json = tile?.exportJson(tileOptions);
       if (json) {
@@ -405,7 +405,7 @@ export const BaseDocumentContentModel = types
       const afterRow = (rowIndex < self.rowCount) && self.getRowByIndex(rowIndex);
       if ((beforeRow && beforeRow.isSectionHeader) && (!afterRow || afterRow.isSectionHeader)) {
         const beforeSectionId = beforeRow.sectionId;
-        const content = PlaceholderContentModel.create({sectionId: beforeSectionId});
+        const content = PlaceholderContentModel.create({ sectionId: beforeSectionId });
         const tile = TileModel.create({ content });
         self.addNewTileInNewRowAtIndex(tile, rowIndex);
       }
@@ -788,7 +788,7 @@ export const BaseDocumentContentModel = types
     moveTiles(tiles: IDragTileItem[], rowInfo: IDropRowInfo) {
       if (tiles.length > 0) {
         // organize tiles by row
-        const tileRows: {[index: number]: IDragTileItem[]} = {};
+        const tileRows: { [index: number]: IDragTileItem[] } = {};
         tiles.forEach(tile => {
           tileRows[tile.rowIndex] = tileRows[tile.rowIndex] || [];
           tileRows[tile.rowIndex].push(tile);
@@ -835,7 +835,7 @@ export const BaseDocumentContentModel = types
       let sharedModelEntry = self.sharedModelMap.get(sharedModel.id);
 
       if (!sharedModelEntry) {
-        sharedModelEntry = SharedModelEntry.create({sharedModel});
+        sharedModelEntry = SharedModelEntry.create({ sharedModel });
         self.sharedModelMap.set(sharedModel.id, sharedModelEntry);
       }
 

--- a/src/models/document/document-content-tests/dc-shared-models.test.ts
+++ b/src/models/document/document-content-tests/dc-shared-models.test.ts
@@ -102,9 +102,9 @@ describe("DocumentContentModel -- shared Models --", () => {
                 }
               ],
               cases: [
-                {__id__: "HR3at2-RqvnRaT9z" },
-                {__id__: "O3SmGUb4iRPw29HU" },
-                {__id__: "76WRbhQpTu2Wqy1c" }
+                { __id__: "HR3at2-RqvnRaT9z" },
+                { __id__: "O3SmGUb4iRPw29HU" },
+                { __id__: "76WRbhQpTu2Wqy1c" }
               ]
             }
           }
@@ -279,7 +279,7 @@ Object {
   describe("single tile copies", () => {
     it("can copy a tile into another empty document", () => {
       const dragTileInfo = documentContent.getDragTiles(["tableTool"]);
-      const targetDocument = createDocumentContentModel({tiles: []});
+      const targetDocument = createDocumentContentModel({ tiles: [] });
       const dropRowInfo: IDropRowInfo = {
         rowInsertIndex: 0
       };
@@ -405,7 +405,7 @@ Object {
       // The import doc needs to have a tile in the row for the first
       // row to be created
       const targetDocument = createDocumentContentModel({
-        tiles: [{ "id": "textTool", "content": {"type": "Text" }}]
+        tiles: [{ "id": "textTool", "content": { "type": "Text" } }]
       });
       const dropRowInfo: IDropRowInfo = {
         rowInsertIndex: 0,
@@ -548,7 +548,7 @@ Object {
   describe("multiple tile copies", () => {
     it("can copy two tiles into another document", () => {
       const dragTileInfo = documentContent.getDragTiles(["tableTool", "graphTool"]);
-      const targetDocument = createDocumentContentModel({tiles: []});
+      const targetDocument = createDocumentContentModel({ tiles: [] });
       const dropRowInfo: IDropRowInfo = {
         rowInsertIndex: 0
       };

--- a/src/models/document/document-content-tests/dc-tile-move-copy.test.ts
+++ b/src/models/document/document-content-tests/dc-tile-move-copy.test.ts
@@ -120,7 +120,7 @@ describe("DocumentContentModel -- move/copy tiles --", () => {
         { content: { type: "Text", format: "html", text: ["<p>Some text</p>"] } },
         // explicit row height exported since it differs from drawing tool default
         { content: { type: "Drawing", objects: [] }, layout: { height: 320 } }
-      ]},
+      ] },
       "initialChallenge": { tiles: [
         [
           {
@@ -137,7 +137,7 @@ describe("DocumentContentModel -- move/copy tiles --", () => {
           // explicit row height exported since it differs from drawing tool default
           { content: { type: "Drawing", objects: [] }, layout: { height: 320 } }
         ]
-      ]},
+      ] },
       "whatIf": { tiles: [] },
       "nowWhatDoYouKnow": { tiles: [] }
     });
@@ -233,7 +233,8 @@ describe("DocumentContentModel -- move/copy tiles --", () => {
 
     it("can copy a tile to an existing row, removing placeholder tiles", () => {
       // copy drawingTool1 to whatIfRow1
-      const dragTiles = getDocumentDragTileItems(["drawingTool1"]).map(tile => ({...tile, newTileId: mockUniqueId()}));
+      const dragTiles = getDocumentDragTileItems(["drawingTool1"])
+        .map(tile => ({ ...tile, newTileId: mockUniqueId() }));
       const whatIfRowIndex = documentContent.getRowIndex("whatIfRow1");
       const dropRowInfo: IDropRowInfo = {
         rowInsertIndex: whatIfRowIndex,
@@ -439,7 +440,8 @@ describe("DocumentContentModel -- move/copy tiles --", () => {
   describe("single tile copies", () => {
     it("can copy a tile before another row", () => {
       // copy drawingTile1 to new row before introductionRow1
-      const dragTiles = getDocumentDragTileItems(["drawingTool1"]).map(tile => ({...tile, newTileId: mockUniqueId()}));
+      const dragTiles = getDocumentDragTileItems(["drawingTool1"])
+        .map(tile => ({ ...tile, newTileId: mockUniqueId() }));
       const rowInsertIndex = documentContent.getRowIndex("introductionRow1");
       documentContent.copyTilesIntoNewRows(dragTiles, rowInsertIndex);
       expect(getRowLayout()).toEqual({
@@ -459,7 +461,8 @@ describe("DocumentContentModel -- move/copy tiles --", () => {
 
     it("can copy a tile after another row", () => {
       // copy drawingTile1 to new row after introductionRow1
-      const dragTiles = getDocumentDragTileItems(["drawingTool1"]).map(tile => ({...tile, newTileId: mockUniqueId()}));
+      const dragTiles = getDocumentDragTileItems(["drawingTool1"])
+        .map(tile => ({ ...tile, newTileId: mockUniqueId() }));
       const rowInsertIndex = documentContent.getRowIndex("introductionRow1") + 1;
       documentContent.copyTilesIntoNewRows(dragTiles, rowInsertIndex);
       expect(getRowLayout()).toEqual({

--- a/src/models/document/document.test.ts
+++ b/src/models/document/document.test.ts
@@ -173,7 +173,7 @@ describe("document model", () => {
     document.addTile("text");
     expect(document.content!.tileMap.size).toBe(1);
     // adding geometry tool adds sidecar text tool
-    document.addTile("geometry", {addSidecarNotes: true});
+    document.addTile("geometry", { addSidecarNotes: true });
     expect(document.content!.tileMap.size).toBe(3);
   });
 

--- a/src/models/document/document.ts
+++ b/src/models/document/document.ts
@@ -311,7 +311,7 @@ export const DocumentModel = Tree.named("Document")
   .actions(self => ({
     afterCreate() {
       // TODO: it would be nice to unify this with the code in createDocumentModel
-      const manager = TreeManager.create({document: {}, undoStore: {}});
+      const manager = TreeManager.create({ document: {}, undoStore: {} });
       self.treeManagerAPI = manager;
       self.treeMonitor = new TreeMonitor(self, manager, false);
       manager.setMainDocument(self);
@@ -324,7 +324,7 @@ export const DocumentModel = Tree.named("Document")
     undoLastAction() {
       const undoManager = self.treeManagerAPI?.undoManager;
       if (undoManager?.canUndo) {
-        const {id, action} = undoManager.undo();
+        const { id, action } = undoManager.undo();
         const logParams: IDocumentLogEvent = {
           document: self as DocumentModelType,
           targetAction: action,
@@ -336,7 +336,7 @@ export const DocumentModel = Tree.named("Document")
     redoLastAction() {
       const undoManager = self.treeManagerAPI?.undoManager;
       if (undoManager?.canRedo) {
-        const {id, action} = undoManager.redo();
+        const { id, action } = undoManager.redo();
         const logParams: IDocumentLogEvent = {
           document: self as DocumentModelType,
           targetAction: action,
@@ -395,18 +395,18 @@ export const createDocumentModel = (snapshot?: DocumentModelSnapshotType) => {
     }
 
     if (!snapshot.content) {
-      console.error("Document with empty content failed to be created", {docKey: snapshot.key});
+      console.error("Document with empty content failed to be created", { docKey: snapshot.key });
       throw e;
     }
 
     // Putting the error in an object like this prevents Chrome from expanding the
     // error and taking up a bunch of console lines.
-    console.error("Failed to load document", {docKey: snapshot.key, error: e});
+    console.error("Failed to load document", { docKey: snapshot.key, error: e });
 
     // Create a document without the content, so this can be returned and passed
     // through the rest of the CLUE system. The Canvas component checks the contentStatus
     // and renders a DocumentError component if the status is Error
-    const {content, ...snapshotWithoutContent} = snapshot;
+    const { content, ...snapshotWithoutContent } = snapshot;
     const documentWithoutContent = DocumentModel.create(snapshotWithoutContent, fullEnvironment);
     documentWithoutContent.setContentError(content, (e as Error)?.message);
     return documentWithoutContent;

--- a/src/models/document/drag-tiles.test.ts
+++ b/src/models/document/drag-tiles.test.ts
@@ -62,7 +62,7 @@ describe("tile dragging", () => {
           }
         ],
         "cases": [
-          {"__id__": "case-1"}
+          { "__id__": "case-1" }
         ]
       }
     };

--- a/src/models/document/log-document-event.test.ts
+++ b/src/models/document/log-document-event.test.ts
@@ -34,7 +34,7 @@ describe("logDocumentEvent", () => {
 
     stores = createStores({
       appMode: "authed",
-      appConfig: specAppConfig({ config: { appName: "TestLogger"} }),
+      appConfig: specAppConfig({ config: { appName: "TestLogger" } }),
       user: UserModel.create({
         id: "0", type: "student", portal: "test",
         loggingRemoteEndpoint: "foo"

--- a/src/models/document/sectioned-content.ts
+++ b/src/models/document/sectioned-content.ts
@@ -11,12 +11,12 @@ export function createDefaultSectionedContent({ sections, content }: ISectionedC
   // for blank sectioned documents, default content is a section header row and a placeholder
   // tile for each section that is present in the template (the passed sections)
   sections?.forEach(section => {
-    tiles.push({ content: { isSectionHeader: true, sectionId: section.type }});
+    tiles.push({ content: { isSectionHeader: true, sectionId: section.type } });
     if (content?.[section.type]) {
       tiles.push(...(content[section.type].tiles || []));
     }
     else {
-      tiles.push({ content: { type: "Placeholder", sectionId: section.type }});
+      tiles.push({ content: { type: "Placeholder", sectionId: section.type } });
     }
   });
   // cast required because we're using the import format

--- a/src/models/document/shared-model-document-manager.test.ts
+++ b/src/models/document/shared-model-document-manager.test.ts
@@ -56,7 +56,7 @@ registerSharedModelInfo({
 
 const TestSharedModel2 = SharedModel
   .named("TestSharedModel2")
-  .props({type: "TestSharedModel2"});
+  .props({ type: "TestSharedModel2" });
 
 registerSharedModelInfo({
   type: "TestSharedModel2",
@@ -66,7 +66,7 @@ registerSharedModelInfo({
 // Snapshot processor type
 const _TestSharedModel3 = SharedModel
   .named("TestSharedModel3")
-  .props({type: "TestSharedModel3"});
+  .props({ type: "TestSharedModel3" });
 const TestSharedModel3 = types.snapshotProcessor(_TestSharedModel3, {
   preProcessor(snapshot: any) {
     // Remove any extra properties
@@ -172,11 +172,11 @@ describe("SharedModelDocumentManager", () => {
     // Enable the tree monitor so changes to the shared model trigger the update.
     docModel.treeMonitor!.enabled = true;
 
-    return {doc, docModel};
+    return { doc, docModel };
   }
 
   it("calls tileContent#updateAfterSharedModelChanges when the shared model changes", async () => {
-    const {doc, docModel} = setupDocument();
+    const { doc, docModel } = setupDocument();
     const tile = doc.tileMap.get("t1");
     assertIsDefined(tile);
     const tileContent = tile.content as TestTileType;
@@ -194,7 +194,7 @@ describe("SharedModelDocumentManager", () => {
   });
 
   it("calls tileContent#updateAfterSharedModelChanges only for shared model changes", async () => {
-    const {doc, docModel} = setupDocument();
+    const { doc, docModel } = setupDocument();
 
     const tile = doc.tileMap.get("t1");
     assertIsDefined(tile);
@@ -234,7 +234,7 @@ describe("SharedModelDocumentManager", () => {
   });
 
   it("starts monitoring shared models added after the document", async () => {
-    const {doc, docModel} = setupDocument({
+    const { doc, docModel } = setupDocument({
       tileMap: {
         "t1": {
           id: "t1",
@@ -267,7 +267,7 @@ describe("SharedModelDocumentManager", () => {
   });
 
   it("updates tiles added after the document", async () => {
-    const {doc, docModel} = setupDocument({
+    const { doc, docModel } = setupDocument({
       sharedModelMap: {
         "sm1": {
           sharedModel: {
@@ -775,7 +775,7 @@ describe("SharedModelDocumentManager", () => {
   });
 
   it("handles a tile being deleted that references a shared model", async () => {
-    const {doc, docModel} = setupDocument({
+    const { doc, docModel } = setupDocument({
       sharedModelMap: {
         "sm1": {
           sharedModel: {
@@ -830,7 +830,7 @@ describe("SharedModelDocumentManager", () => {
   });
 
   it("handles a loading a shared model entry with a broken reference", async () => {
-    const {doc, docModel} = setupDocument({
+    const { doc, docModel } = setupDocument({
       sharedModelMap: {
         "sm1": {
           sharedModel: {
@@ -890,7 +890,7 @@ describe("SharedModelDocumentManager", () => {
 
 // Just to get this done we could just make a helper function for this
 async function expectUpdateToBeCalledTimes(testTile: TestTileType, times: number) {
-  const updateCalledTimes = when(() => testTile.updateCount === times, {timeout: 100});
+  const updateCalledTimes = when(() => testTile.updateCount === times, { timeout: 100 });
   return expect(updateCalledTimes).resolves.toBeUndefined();
 }
 

--- a/src/models/history/history-firestore.ts
+++ b/src/models/history/history-firestore.ts
@@ -3,7 +3,7 @@ import { DEBUG_HISTORY } from "../../lib/debug";
 import { Firestore } from "../../lib/firestore";
 import { HistoryEntrySnapshot } from "./history";
 
-export type LastHistoryEntry = undefined | { index: number, id: string};
+export type LastHistoryEntry = undefined | { index: number, id: string };
 
 export async function getLastHistoryEntry(firestore: Firestore, documentPath: string): Promise<LastHistoryEntry> {
   const lastEntryQuery = await firestore.collection(`${documentPath}/history`)
@@ -56,7 +56,7 @@ export function loadHistory(firestore: Firestore, historyPath: string,
     querySnapshot => {
       if (DEBUG_HISTORY) {
         // eslint-disable-next-line no-console
-        console.log("Loaded History:", querySnapshot.docs.map(doc => ({id: doc.id, ...doc.data()})));
+        console.log("Loaded History:", querySnapshot.docs.map(doc => ({ id: doc.id, ...doc.data() })));
       }
       const history = querySnapshot.docs.map(doc => {
         const { entry } = doc.data();

--- a/src/models/history/history.ts
+++ b/src/models/history/history.ts
@@ -37,7 +37,7 @@ export const HistoryEntry = types.model("HistoryEntry", {
   // for debugging an activeExchange that hasn't been ended. 
   // The {name: "activeExchanges"} is a feature of MobX that can also 
   // help with debugging.
-  activeExchanges: observable.map<string, string>({}, {name: "activeExchanges"})
+  activeExchanges: observable.map<string, string>({}, { name: "activeExchanges" })
 }));
 export interface HistoryEntrySnapshot extends SnapshotIn<typeof HistoryEntry> {}
 export interface HistoryEntryType extends Instance<typeof HistoryEntry> {}

--- a/src/models/history/log-history-event.test.ts
+++ b/src/models/history/log-history-event.test.ts
@@ -34,7 +34,7 @@ describe("authed logger", () => {
 
     stores = createStores({
       appMode: "authed",
-      appConfig: specAppConfig({ config: { appName: "TestLogger"} }),
+      appConfig: specAppConfig({ config: { appName: "TestLogger" } }),
       user: UserModel.create({
         id: "0", type: "student", portal: "test",
         loggingRemoteEndpoint: "foo"

--- a/src/models/history/tree-manager-history.test.ts
+++ b/src/models/history/tree-manager-history.test.ts
@@ -63,7 +63,7 @@ function setupDocument(initialContent? : DocumentContentSnapshotType) {
   const manager = docModel.treeManagerAPI as Instance<typeof TreeManager>;
   const undoStore = manager.undoStore;
 
-  return {docContent, tileContent, manager, undoStore};
+  return { docContent, tileContent, manager, undoStore };
 }
 
 describe("history loading", () => {
@@ -81,11 +81,11 @@ describe("history loading", () => {
   describe("setNumHistoryEntriesAppliedFromFirestore", () => {
     it("updates numHistoryEntriesAppliedFromFirestore based on returned entry", async () => {
       const { manager } = setupDocument();
-      getLastHistoryEntry.mockResolvedValue({index: 0, id: "1234"});
+      getLastHistoryEntry.mockResolvedValue({ index: 0, id: "1234" });
       await manager.setNumHistoryEntriesAppliedFromFirestore({} as Firestore, "");
       expect(manager.numHistoryEventsApplied).toBe(1);
 
-      getLastHistoryEntry.mockResolvedValue({index: 10, id: "12345"});
+      getLastHistoryEntry.mockResolvedValue({ index: 10, id: "12345" });
       await manager.setNumHistoryEntriesAppliedFromFirestore({} as Firestore, "");
       expect(manager.numHistoryEventsApplied).toBe(11);
     });
@@ -127,7 +127,7 @@ describe("history loading", () => {
       const { manager } = setupDocument();
       // this makes loadHistory be a no op.
       loadHistory.mockReturnValue(() => undefined);
-      manager.mirrorHistoryFromFirestore({id: "1234"} as UserModelType, {} as Firestore);
+      manager.mirrorHistoryFromFirestore({ id: "1234" } as UserModelType, {} as Firestore);
       expect(manager.document.history).toHaveLength(0);
     });
 
@@ -142,7 +142,7 @@ describe("history loading", () => {
         ]);
         return () => undefined;
       });
-      manager.mirrorHistoryFromFirestore({id: "1234"} as UserModelType, {} as Firestore);
+      manager.mirrorHistoryFromFirestore({ id: "1234" } as UserModelType, {} as Firestore);
       expect(manager.document.history).toHaveLength(2);
     });
 
@@ -184,7 +184,7 @@ describe("history loading", () => {
           historyLoaded(entries, loadingError);
           return () => undefined;
         });
-        manager.mirrorHistoryFromFirestore({id: "1234"} as UserModelType, {} as Firestore);
+        manager.mirrorHistoryFromFirestore({ id: "1234" } as UserModelType, {} as Firestore);
 
         await called.promise;
         // If we actually delayed the historyLoaded callback above we should be able to
@@ -205,14 +205,14 @@ describe("history loading", () => {
           entries: [
             { id: "a1" },
             { id: "a2" }
-          ]});
+          ] });
 
         // The history length is greater than the numHistoryEventsApplied
         expect(manager.historyStatus).toBe(HistoryStatus.HISTORY_LOADED);
       });
 
       it("is NO_HISTORY when there are no events and the firestore length is 0", async () => {
-        const { manager } = await mirrorMockHistory({entries: []});
+        const { manager } = await mirrorMockHistory({ entries: [] });
 
         expect(manager.historyStatus).toBe(HistoryStatus.NO_HISTORY);
       });
@@ -223,7 +223,7 @@ describe("history loading", () => {
             { id: "a1" },
             { id: "a2" }
           ],
-          lastHistoryEntry: {index: 1, id: "1234"}
+          lastHistoryEntry: { index: 1, id: "1234" }
         });
 
         // The history length is 1 plus the index of last history entry
@@ -234,8 +234,8 @@ describe("history loading", () => {
       it("is ERROR when loadHistory returns an error", async () => {
         const { manager } = await mirrorMockHistory({
           entries:[],
-          loadingError: { message: "fake error"} as firebase.firestore.FirestoreError,
-          lastHistoryEntry: {index: 1, id: "1234"}
+          loadingError: { message: "fake error" } as firebase.firestore.FirestoreError,
+          lastHistoryEntry: { index: 1, id: "1234" }
         });
 
         expect(manager.historyStatus).toBe(HistoryStatus.HISTORY_ERROR);
@@ -252,7 +252,7 @@ describe("history loading", () => {
             { id: "a1" },
             { id: "a2" }
           ],
-          lastHistoryEntry: {index: 2, id: "1234"}
+          lastHistoryEntry: { index: 2, id: "1234" }
         });
 
         // The history length is 1 plus the index of last history entry

--- a/src/models/history/tree-manager.test.ts
+++ b/src/models/history/tree-manager.test.ts
@@ -122,7 +122,7 @@ function setupDocument(initialContent? : DocumentContentSnapshotType) {
   const manager = docModel.treeManagerAPI as Instance<typeof TreeManager>;
   const undoStore = manager.undoStore;
 
-  return {docContent, sharedModel, tileContent, manager, undoStore};
+  return { docContent, sharedModel, tileContent, manager, undoStore };
 }
 
 const updateFlag = {
@@ -132,10 +132,10 @@ const updateFlag = {
   records: [
     { action: "/content/tileMap/t1/content/setFlag",
       inversePatches: [
-        { op: "replace", path: "/content/tileMap/t1/content/flag", value: undefined}
+        { op: "replace", path: "/content/tileMap/t1/content/flag", value: undefined }
       ],
       patches: [
-        { op: "replace", path: "/content/tileMap/t1/content/flag", value: true}
+        { op: "replace", path: "/content/tileMap/t1/content/flag", value: true }
       ],
       tree: "test"
     },
@@ -152,10 +152,10 @@ const action1 =   {
   records: [
     { action: "/content/tileMap/t1/content/setActionText",
       inversePatches: [
-        { op: "replace", path: "/content/tileMap/t1/content/actionText", value: undefined}
+        { op: "replace", path: "/content/tileMap/t1/content/actionText", value: undefined }
       ],
       patches: [
-        { op: "replace", path: "/content/tileMap/t1/content/actionText", value: "action 1"}
+        { op: "replace", path: "/content/tileMap/t1/content/actionText", value: "action 1" }
       ],
       tree: "test"
     },
@@ -172,10 +172,10 @@ const action2 =   {
   records: [
     { action: "/content/tileMap/t1/content/setActionText",
       inversePatches: [
-        { op: "replace", path: "/content/tileMap/t1/content/actionText", value: "action 1"}
+        { op: "replace", path: "/content/tileMap/t1/content/actionText", value: "action 1" }
       ],
       patches: [
-        { op: "replace", path: "/content/tileMap/t1/content/actionText", value: "action 2"}
+        { op: "replace", path: "/content/tileMap/t1/content/actionText", value: "action 2" }
       ],
       tree: "test"
     },
@@ -192,10 +192,10 @@ const action3 = {
   records: [
     { action: "/content/tileMap/t1/content/setActionText",
       inversePatches: [
-        { op: "replace", path: "/content/tileMap/t1/content/actionText", value: "action 2"}
+        { op: "replace", path: "/content/tileMap/t1/content/actionText", value: "action 2" }
       ],
       patches: [
-        { op: "replace", path: "/content/tileMap/t1/content/actionText", value: "action 3"}
+        { op: "replace", path: "/content/tileMap/t1/content/actionText", value: "action 3" }
       ],
       tree: "test"
     },
@@ -212,10 +212,10 @@ const action4 = {
   records: [
     { action: "/content/tileMap/t1/content/setActionText",
       inversePatches: [
-        { op: "replace", path: "/content/tileMap/t1/content/actionText", value: "action 3"}
+        { op: "replace", path: "/content/tileMap/t1/content/actionText", value: "action 3" }
       ],
       patches: [
-        { op: "replace", path: "/content/tileMap/t1/content/actionText", value: "action 4"}
+        { op: "replace", path: "/content/tileMap/t1/content/actionText", value: "action 4" }
       ],
       tree: "test"
     },
@@ -254,7 +254,7 @@ jest.mock("firebase/app", () => ({
 }));
 
 it("records multiple history entries", async () => {
-  const {tileContent, manager} = setupDocument();
+  const { tileContent, manager } = setupDocument();
   tileContent.setFlag(true);
   tileContent.setActionText("action 1");
   tileContent.setActionText("action 2");
@@ -269,7 +269,7 @@ it("records multiple history entries", async () => {
 });
 
 it("can replay the history entries", async () => {
-  const {tileContent, manager} = setupDocument();
+  const { tileContent, manager } = setupDocument();
   const history = [
     makeRealHistoryEntry(updateFlag),
     makeRealHistoryEntry(action1),
@@ -278,7 +278,7 @@ it("can replay the history entries", async () => {
     makeRealHistoryEntry(action4),
   ];
 
-  manager.setChangeDocument(CDocument.create({history}));
+  manager.setChangeDocument(CDocument.create({ history }));
   await manager.replayHistoryToTrees();
 
   expect(tileContent.flag).toBe(true);
@@ -302,7 +302,7 @@ async function expectEntryToBeComplete(manager: Instance<typeof TreeManager>, le
   try {
     await when(
       () => changeDocument.history.length >= length && changeDocument.history.at(-1)?.state === "complete",
-      {timeout: 100});
+      { timeout: 100 });
   } catch (e) {
     timedOut = true;
   }

--- a/src/models/history/tree-manager.ts
+++ b/src/models/history/tree-manager.ts
@@ -105,7 +105,7 @@ export const TreeManager = types
     }
 
     const historyLength = self.document.history.length;
-    const {numHistoryEventsApplied} = self;
+    const { numHistoryEventsApplied } = self;
     if (numHistoryEventsApplied === undefined) {
       // We are waiting for the query to figure out the last history entry.
       return HistoryStatus.FINDING_HISTORY_LENGTH;
@@ -138,7 +138,7 @@ export const TreeManager = types
         return "History is loaded";
       case HistoryStatus.HISTORY_LOADING: {
         const historyLength = self.document.history.length;
-        const {numHistoryEventsApplied} = self;
+        const { numHistoryEventsApplied } = self;
         return `Loading history (${historyLength}/${numHistoryEventsApplied})`;
       }
       default:
@@ -159,7 +159,7 @@ export const TreeManager = types
 
   return {
     completeHistoryEntry(entry: Instance<typeof HistoryEntry>) {
-      const {firestore} = self;
+      const { firestore } = self;
       entry.state = "complete";
 
       // Remove the entry from the activeHistoryEntries
@@ -205,7 +205,7 @@ export const TreeManager = types
       }
 
       // Create the document in firestore if necessary
-      getFirestoreHistoryInfo().then(({documentPath, lastEntryIndex, lastEntryId}) => {
+      getFirestoreHistoryInfo().then(({ documentPath, lastEntryIndex, lastEntryId }) => {
         // add a new document for this history entry
         const historyEntryPath = firestore.getFullPath(`${documentPath}/history`);
 
@@ -237,7 +237,7 @@ export const TreeManager = types
     self.loadingError = error;
   },
 
-  setPropsForFirestoreSaving({userContextProvider, firestore}: IFirestoreSavingProps) {
+  setPropsForFirestoreSaving({ userContextProvider, firestore }: IFirestoreSavingProps) {
     self.userContextProvider = userContextProvider;
     self.firestore = firestore;
   },
@@ -260,12 +260,12 @@ export const TreeManager = types
     // Find if there is already an entry with this historyEntryId
     const entry = self.findActiveHistoryEntry(historyEntryId);
     if (!entry) {
-      throw new Error(`History Entry doesn't exist ${ json({historyEntryId})} `);
+      throw new Error(`History Entry doesn't exist ${ json({ historyEntryId })} `);
     }
 
     // Make sure this entry wasn't marked complete before
     if (entry.state === "complete") {
-      throw new Error(`The entry was already marked complete ${ json({historyEntryId, exchangeId})}`);
+      throw new Error(`The entry was already marked complete ${ json({ historyEntryId, exchangeId })}`);
     }
 
     // start a new open exchange with this exchangeId
@@ -281,7 +281,7 @@ export const TreeManager = types
   endExchange(entry: Instance<typeof HistoryEntry>, exchangeId: string) {
     const openExchangeValue = entry.activeExchanges.get(exchangeId);
     if (!openExchangeValue) {
-      throw new Error(`There is no active exchange matching ${ json({historyEntryId: entry.id, exchangeId}) }`);
+      throw new Error(`There is no active exchange matching ${ json({ historyEntryId: entry.id, exchangeId }) }`);
     }
 
     entry.activeExchanges.delete(exchangeId);
@@ -296,7 +296,7 @@ export const TreeManager = types
   createHistoryEntry(historyEntryId: string, exchangeId: string, name: string,
     treeId: string, undoable: boolean) {
     if (self.findHistoryEntry(historyEntryId) || self.findActiveHistoryEntry(historyEntryId)) {
-      throw new Error(`The entry already exists ${ json({historyEntryId})}`);
+      throw new Error(`The entry already exists ${ json({ historyEntryId })}`);
     }
     const entry = HistoryEntry.create({
       id: historyEntryId,
@@ -361,7 +361,7 @@ export const TreeManager = types
         if (error) {
           self.setLoadingError(error);
         } else {
-          const cDocument = CDocument.create({history});
+          const cDocument = CDocument.create({ history });
           self.setChangeDocument(cDocument);
         }
       }
@@ -426,12 +426,12 @@ export const TreeManager = types
     // Find if there is already an entry with this historyEntryId
     const entry = self.findActiveHistoryEntry(historyEntryId);
     if (!entry) {
-      throw new Error(`There isn't an active entry for ${ json({historyEntryId, exchangeId})}`);
+      throw new Error(`There isn't an active entry for ${ json({ historyEntryId, exchangeId })}`);
     }
 
     // Make sure this entry wasn't marked complete before
     if (entry.state === "complete") {
-      throw new Error(`The entry was already marked complete ${ json({historyEntryId, exchangeId})}`);
+      throw new Error(`The entry was already marked complete ${ json({ historyEntryId, exchangeId })}`);
     }
 
     // The tree patch record will be sent even if there are no patches.
@@ -444,7 +444,7 @@ export const TreeManager = types
       // eslint-disable-next-line no-console
       console.log("addTreePatchRecord",
         { action: record.action, historyEntryId, exchangeId,
-          exchangeName: entry.activeExchanges.get(exchangeId)});
+          exchangeName: entry.activeExchanges.get(exchangeId) });
     }
 
     self.endExchange(entry, exchangeId);
@@ -604,8 +604,9 @@ interface IPrepareFirestoreHistoryInfoArgs {
   firestore?: Firestore;
 }
 
-async function prepareFirestoreHistoryInfo(
-    {userContextProvider, mainDocument, firestore}: IPrepareFirestoreHistoryInfoArgs): Promise<IFirestoreHistoryInfo> {
+async function prepareFirestoreHistoryInfo({
+  userContextProvider, mainDocument, firestore
+}: IPrepareFirestoreHistoryInfoArgs): Promise<IFirestoreHistoryInfo> {
   // TODO: Wait for userContext to be valid.
   // The userContext initially starts out with a user id of 0 and doesn't have a portal and other
   // properties defined. After the user is authenticated the userContext will have valid fields.
@@ -630,7 +631,7 @@ async function prepareFirestoreHistoryInfo(
 
 
     // FIXME-HISTORY: rename this function to validateFirestoreDocumentMetadata_v1
-    await validateCommentableDocument({context: userContext, document: mainDocument.metadata});
+    await validateCommentableDocument({ context: userContext, document: mainDocument.metadata });
   }
 
   const lastHistoryEntry = await getLastHistoryEntry(firestore, documentPath);

--- a/src/models/history/tree.ts
+++ b/src/models/history/tree.ts
@@ -20,8 +20,8 @@ export const Tree = types.model("Tree", {
   }
 }))
 .actions(self => ({
-  updateTreeAfterSharedModelChanges(options?: {sharedModel: SharedModelType,
-      initialSharedModelMap: SharedModelMapSnapshotOutType}) {
+  updateTreeAfterSharedModelChanges(options?: { sharedModel: SharedModelType,
+      initialSharedModelMap: SharedModelMapSnapshotOutType }) {
     // If there is no sharedModel param, run the update function on all tiles which
     // have shared model references.
     // If there is a sharedModel param, only run the update function on tiles which
@@ -113,7 +113,7 @@ export const Tree = types.model("Tree", {
       // exchangeId parameters automatically. And then when it sends any
       // changes captured during the update, it should include these ids
       if (isAlive(self)) {
-        self.updateTreeAfterSharedModelChanges({sharedModel, initialSharedModelMap});
+        self.updateTreeAfterSharedModelChanges({ sharedModel, initialSharedModelMap });
       }
     };
 
@@ -215,7 +215,7 @@ export const Tree = types.model("Tree", {
       if (DEBUG_HISTORY) {
         // eslint-disable-next-line no-console
         console.log(`observed changes in sharedModel: ${model.id} of tree: ${self.treeId}`,
-          {historyEntryId, action: call});
+          { historyEntryId, action: call });
       }
 
       if (!self.treeManagerAPI) {

--- a/src/models/history/undo-store-test-utils.ts
+++ b/src/models/history/undo-store-test-utils.ts
@@ -10,7 +10,7 @@ export async function expectEntryToBeComplete(manager: Instance<typeof TreeManag
   try {
     await when(
       () => changeDocument.history.length >= length && changeDocument.history.at(length-1)?.state === "complete",
-      {timeout: 100});
+      { timeout: 100 });
   } catch (e) {
     timedOut = true;
   }

--- a/src/models/history/undo-store.test.ts
+++ b/src/models/history/undo-store.test.ts
@@ -176,7 +176,7 @@ function setupDocument(initialContent? : DocumentContentSnapshotType) {
   const manager = docModel.treeManagerAPI as Instance<typeof TreeManager>;
   const undoStore = manager.undoStore;
 
-  return {docModel, docContent, sharedModel, tileContent, manager, undoStore};
+  return { docModel, docContent, sharedModel, tileContent, manager, undoStore };
 }
 
 const setFlagTrueEntry = {
@@ -186,10 +186,10 @@ const setFlagTrueEntry = {
   records: [
     { action: "/content/tileMap/t1/content/setFlag",
       inversePatches: [
-        { op: "replace", path: "/content/tileMap/t1/content/flag", value: undefined}
+        { op: "replace", path: "/content/tileMap/t1/content/flag", value: undefined }
       ],
       patches: [
-        { op: "replace", path: "/content/tileMap/t1/content/flag", value: true}
+        { op: "replace", path: "/content/tileMap/t1/content/flag", value: true }
       ],
       tree: "test"
     },
@@ -200,7 +200,7 @@ const setFlagTrueEntry = {
 };
 
 it("records a tile change as one history event with one TreeRecordEntry", async () => {
-  const {tileContent, manager} = setupDocument();
+  const { tileContent, manager } = setupDocument();
   // This should record a history entry with this change and any changes to tiles
   // triggered by this change
   tileContent.setFlag(true);
@@ -220,10 +220,10 @@ const undoEntry = {
   records: [
     { action: "/applyPatchesFromManager",
       inversePatches: [
-        { op: "replace", path: "/content/tileMap/t1/content/flag", value: true}
+        { op: "replace", path: "/content/tileMap/t1/content/flag", value: true }
       ],
       patches: [
-        { op: "replace", path: "/content/tileMap/t1/content/flag", value: undefined}
+        { op: "replace", path: "/content/tileMap/t1/content/flag", value: undefined }
       ],
       tree: "test"
     },
@@ -234,7 +234,7 @@ const undoEntry = {
 };
 
 it("can undo a tile change", async () => {
-  const {tileContent, manager, undoStore} = setupDocument();
+  const { tileContent, manager, undoStore } = setupDocument();
   // This should record a history entry with this change and any changes to tiles
   // triggered by this change
   tileContent.setFlag(true);
@@ -261,10 +261,10 @@ const redoEntry = {
   records: [
     { action: "/applyPatchesFromManager",
       inversePatches: [
-        { op: "replace", path: "/content/tileMap/t1/content/flag", value: undefined}
+        { op: "replace", path: "/content/tileMap/t1/content/flag", value: undefined }
       ],
       patches: [
-        { op: "replace", path: "/content/tileMap/t1/content/flag", value: true}
+        { op: "replace", path: "/content/tileMap/t1/content/flag", value: true }
       ],
       tree: "test"
     },
@@ -275,7 +275,7 @@ const redoEntry = {
 };
 
 it("can redo a tile change", async () => {
-  const {tileContent, manager, undoStore} = setupDocument();
+  const { tileContent, manager, undoStore } = setupDocument();
   // This should record a history entry with this change and any changes to tiles
   // triggered by this change
   tileContent.setFlag(true);
@@ -303,7 +303,7 @@ it("can redo a tile change", async () => {
 
 
 it("records a async tile change as one history event with one TreeRecordEntry", async () => {
-  const {tileContent, manager} = setupDocument();
+  const { tileContent, manager } = setupDocument();
   // This should record a history entry with this change and any changes to tiles
   // triggered by this change
   await tileContent.updateCounterAsync();
@@ -319,12 +319,12 @@ it("records a async tile change as one history event with one TreeRecordEntry", 
       records: [
         { action: "/content/tileMap/t1/content/updateCounterAsync",
           inversePatches: [
-            { op: "replace", path: "/content/tileMap/t1/content/counter", value: 0},
-            { op: "replace", path: "/content/tileMap/t1/content/counter", value: 1}
+            { op: "replace", path: "/content/tileMap/t1/content/counter", value: 0 },
+            { op: "replace", path: "/content/tileMap/t1/content/counter", value: 1 }
           ],
           patches: [
-            { op: "replace", path: "/content/tileMap/t1/content/counter", value: 1},
-            { op: "replace", path: "/content/tileMap/t1/content/counter", value: 2}
+            { op: "replace", path: "/content/tileMap/t1/content/counter", value: 1 },
+            { op: "replace", path: "/content/tileMap/t1/content/counter", value: 2 }
           ],
           tree: "test"
         },
@@ -337,7 +337,7 @@ it("records a async tile change as one history event with one TreeRecordEntry", 
 });
 
 it("records an async tile change and an interleaved history event with 2 entries", async () => {
-  const {tileContent, manager} = setupDocument();
+  const { tileContent, manager } = setupDocument();
   // This should record a history entry with this change and any changes to tiles
   // triggered by this change
   const updateCounterPromise = tileContent.updateCounterAsync();
@@ -358,12 +358,12 @@ it("records an async tile change and an interleaved history event with 2 entries
       records: [
         { action: "/content/tileMap/t1/content/updateCounterAsync",
           inversePatches: [
-            { op: "replace", path: "/content/tileMap/t1/content/counter", value: 0},
-            { op: "replace", path: "/content/tileMap/t1/content/counter", value: 1}
+            { op: "replace", path: "/content/tileMap/t1/content/counter", value: 0 },
+            { op: "replace", path: "/content/tileMap/t1/content/counter", value: 1 }
           ],
           patches: [
-            { op: "replace", path: "/content/tileMap/t1/content/counter", value: 1},
-            { op: "replace", path: "/content/tileMap/t1/content/counter", value: 2}
+            { op: "replace", path: "/content/tileMap/t1/content/counter", value: 1 },
+            { op: "replace", path: "/content/tileMap/t1/content/counter", value: 2 }
           ],
           tree: "test"
         },
@@ -376,7 +376,7 @@ it("records an async tile change and an interleaved history event with 2 entries
 });
 
 it("can skip adding an action to the undo list", async () => {
-  const {tileContent, manager, undoStore} = setupDocument();
+  const { tileContent, manager, undoStore } = setupDocument();
   // This should record a history entry with this change and any changes to tiles
   // triggered by this change
   tileContent.setFlagWithoutUndo(true);
@@ -404,7 +404,7 @@ it("can skip adding an action to the undo list", async () => {
 });
 
 it("can handle withoutUndo even when tree isn't monitored", async () => {
-  const {tileContent, manager, undoStore, docModel} = setupDocument();
+  const { tileContent, manager, undoStore, docModel } = setupDocument();
 
   // disable the monitor
   docModel.treeMonitor!.enabled = false;
@@ -426,7 +426,7 @@ it("can handle withoutUndo even when tree isn't monitored", async () => {
 });
 
 it("does not warn about withoutUndo when tree isn't monitored and DEBUG_UNDO is on", async () => {
-  const {tileContent, docModel} = setupDocument();
+  const { tileContent, docModel } = setupDocument();
 
   // disable the monitor
   docModel.treeMonitor!.enabled = false;
@@ -475,7 +475,7 @@ it("will print a warning and still add the action to the undo list if any child 
     }
   };
 
-  const {tileContent, manager, undoStore} = setupDocument(documentWithTileChild);
+  const { tileContent, manager, undoStore } = setupDocument(documentWithTileChild);
 
   jestSpyConsole("warn", spy => {
     tileContent.setChildValue("new child value");
@@ -502,11 +502,11 @@ it("will print a warning and still add the action to the undo list if any child 
         { action: "/content/tileMap/t1/content/setChildValue",
           inversePatches: [
             { op: "replace", path: "/content/tileMap/t1/content/child/value",
-              value: "initial child value"}
+              value: "initial child value" }
           ],
           patches: [
             { op: "replace", path: "/content/tileMap/t1/content/child/value",
-              value: "new child value"}
+              value: "new child value" }
           ],
           tree: "test"
         },
@@ -521,7 +521,7 @@ it("will print a warning and still add the action to the undo list if any child 
 
 
 it("records undoable actions that happen in the middle async actions which are not undoable", async () => {
-  const {tileContent, manager, undoStore} = setupDocument();
+  const { tileContent, manager, undoStore } = setupDocument();
 
   const updateCounterPromise = tileContent.updateCounterWithoutUndoAsync();
 
@@ -549,12 +549,12 @@ it("records undoable actions that happen in the middle async actions which are n
       records: [
         { action: "/content/tileMap/t1/content/updateCounterWithoutUndoAsync",
           inversePatches: [
-            { op: "replace", path: "/content/tileMap/t1/content/counter", value: 0},
-            { op: "replace", path: "/content/tileMap/t1/content/counter", value: 1}
+            { op: "replace", path: "/content/tileMap/t1/content/counter", value: 0 },
+            { op: "replace", path: "/content/tileMap/t1/content/counter", value: 1 }
           ],
           patches: [
-            { op: "replace", path: "/content/tileMap/t1/content/counter", value: 1},
-            { op: "replace", path: "/content/tileMap/t1/content/counter", value: 2}
+            { op: "replace", path: "/content/tileMap/t1/content/counter", value: 1 },
+            { op: "replace", path: "/content/tileMap/t1/content/counter", value: 2 }
           ],
           tree: "test"
         },
@@ -584,7 +584,7 @@ it("can replay the history entries", async () => {
     // document state. We should create a history entry that setups up this initial
     // document state so we can test creating a document's content complete from
     // scratch.
-    const {tileContent, manager} = setupDocument();
+    const { tileContent, manager } = setupDocument();
 
     // Add the history entries used in the tests above so we can replay them all at
     // the same time.
@@ -593,7 +593,7 @@ it("can replay the history entries", async () => {
       makeRealHistoryEntry(undoEntry),
       makeRealHistoryEntry(redoEntry)
     ];
-    manager.setChangeDocument(CDocument.create({history}));
+    manager.setChangeDocument(CDocument.create({ history }));
     await manager.replayHistoryToTrees();
 
     expect(tileContent.flag).toBe(true);
@@ -611,19 +611,19 @@ const initialSharedModelUpdateEntry = {
   records: [
     { action: "/handleSharedModelChanges",
       inversePatches: [
-        { op: "replace", path: "/content/tileMap/t1/content/text", value: undefined}
+        { op: "replace", path: "/content/tileMap/t1/content/text", value: undefined }
       ],
       patches: [
-        { op: "replace", path: "/content/tileMap/t1/content/text", value: "something-tile"}
+        { op: "replace", path: "/content/tileMap/t1/content/text", value: "something-tile" }
       ],
       tree: "test"
     },
     { action: "/content/sharedModelMap/sm1/sharedModel/setValue",
       inversePatches: [
-        { op: "replace", path: "/content/sharedModelMap/sm1/sharedModel/value", value: undefined}
+        { op: "replace", path: "/content/sharedModelMap/sm1/sharedModel/value", value: undefined }
       ],
       patches: [
-        { op: "replace", path: "/content/sharedModelMap/sm1/sharedModel/value", value: "something"}
+        { op: "replace", path: "/content/sharedModelMap/sm1/sharedModel/value", value: "something" }
       ],
       tree: "test"
     }
@@ -634,7 +634,7 @@ const initialSharedModelUpdateEntry = {
 };
 
 it("records a shared model change as one history event with two TreeRecordEntries", async () => {
-  const {sharedModel, manager} = setupDocument();
+  const { sharedModel, manager } = setupDocument();
   // This should record a history entry with this change and any changes to tiles
   // triggered by this change
   sharedModel.setValue("something");
@@ -654,19 +654,19 @@ const undoSharedModelEntry = {
   records: [
     { action: "/applyPatchesFromManager",
       inversePatches: [
-        { op: "replace", path: "/content/tileMap/t1/content/text", value: "something-tile"}
+        { op: "replace", path: "/content/tileMap/t1/content/text", value: "something-tile" }
       ],
       patches: [
-        { op: "replace", path: "/content/tileMap/t1/content/text", value: undefined}
+        { op: "replace", path: "/content/tileMap/t1/content/text", value: undefined }
       ],
       tree: "test"
     },
     { action: "/applyPatchesFromManager",
       inversePatches: [
-        { op: "replace", path: "/content/sharedModelMap/sm1/sharedModel/value", value: "something"}
+        { op: "replace", path: "/content/sharedModelMap/sm1/sharedModel/value", value: "something" }
       ],
       patches: [
-        { op: "replace", path: "/content/sharedModelMap/sm1/sharedModel/value", value: undefined}
+        { op: "replace", path: "/content/sharedModelMap/sm1/sharedModel/value", value: undefined }
       ],
       tree: "test"
     }
@@ -677,7 +677,7 @@ const undoSharedModelEntry = {
 };
 
 it("can undo a shared model change", async () => {
-  const {sharedModel, tileContent, manager, undoStore} = setupDocument();
+  const { sharedModel, tileContent, manager, undoStore } = setupDocument();
   // This should record a history entry with this change and any changes to tiles
   // triggered by this change
   sharedModel.setValue("something");
@@ -709,19 +709,19 @@ const redoSharedModelEntry = {
   records: [
     { action: "/applyPatchesFromManager",
       inversePatches: [
-        { op: "replace", path: "/content/tileMap/t1/content/text", value: undefined}
+        { op: "replace", path: "/content/tileMap/t1/content/text", value: undefined }
       ],
       patches: [
-        { op: "replace", path: "/content/tileMap/t1/content/text", value: "something-tile"}
+        { op: "replace", path: "/content/tileMap/t1/content/text", value: "something-tile" }
       ],
       tree: "test"
     },
     { action: "/applyPatchesFromManager",
       inversePatches: [
-        { op: "replace", path: "/content/sharedModelMap/sm1/sharedModel/value", value: undefined}
+        { op: "replace", path: "/content/sharedModelMap/sm1/sharedModel/value", value: undefined }
       ],
       patches: [
-        { op: "replace", path: "/content/sharedModelMap/sm1/sharedModel/value", value: "something"}
+        { op: "replace", path: "/content/sharedModelMap/sm1/sharedModel/value", value: "something" }
       ],
       tree: "test"
     }
@@ -732,7 +732,7 @@ const redoSharedModelEntry = {
 };
 
 it("can redo a shared model change", async () => {
-  const {sharedModel, tileContent, manager, undoStore} = setupDocument();
+  const { sharedModel, tileContent, manager, undoStore } = setupDocument();
   // This should record a history entry with this change and any changes to tiles
   // triggered by this change
   sharedModel.setValue("something");
@@ -770,7 +770,7 @@ it("can replay history entries that include shared model changes", async () => {
   // document state. We should create a history entry that setups up this initial
   // document state so we can test creating a document's content complete from
   // scratch.
-  const {tileContent, sharedModel, manager} = setupDocument();
+  const { tileContent, sharedModel, manager } = setupDocument();
 
   // Add the history entries used in the tests above so we can replay them all at
   // the same time.
@@ -780,7 +780,7 @@ it("can replay history entries that include shared model changes", async () => {
     makeRealHistoryEntry(redoSharedModelEntry)
   ];
 
-  manager.setChangeDocument(CDocument.create({history}));
+  manager.setChangeDocument(CDocument.create({ history }));
   await manager.replayHistoryToTrees();
 
   expect(sharedModel.value).toBe("something");
@@ -795,7 +795,7 @@ it("can replay history entries that include shared model changes", async () => {
 // However we don't have a good solution for that yet.
 it("can track the addition of a new shared model", async () => {
   // Start with just a tile and no shared model
-  const {tileContent, manager} = setupDocument({
+  const { tileContent, manager } = setupDocument({
     tileMap: {
       "t1": {
         id: "t1",
@@ -807,7 +807,7 @@ it("can track the addition of a new shared model", async () => {
   });
 
   const sharedModelManager = tileContent.tileEnv?.sharedModelManager;
-  const newSharedModel = TestSharedModel.create({value: "new model"});
+  const newSharedModel = TestSharedModel.create({ value: "new model" });
   const sharedModelId = newSharedModel.id;
   sharedModelManager?.addTileSharedModel(tileContent, newSharedModel);
 
@@ -872,7 +872,7 @@ it("can track the addition of a new shared model", async () => {
         {
           action: `/content/sharedModelMap/${sharedModelId}/addTile`,
           inversePatches: [
-            { op: "remove", path: `/content/sharedModelMap/${sharedModelId}/tiles/0`}
+            { op: "remove", path: `/content/sharedModelMap/${sharedModelId}/tiles/0` }
           ],
           patches: [
             {
@@ -891,7 +891,7 @@ it("can track the addition of a new shared model", async () => {
 });
 
 async function expectUpdateToBeCalledTimes(testTile: TestTileType, times: number) {
-  const updateCalledTimes = when(() => testTile.updateCount === times, {timeout: 100});
+  const updateCalledTimes = when(() => testTile.updateCount === times, { timeout: 100 });
   return expect(updateCalledTimes).resolves.toBeUndefined();
 }
 

--- a/src/models/history/without-undo.ts
+++ b/src/models/history/without-undo.ts
@@ -36,7 +36,7 @@ export function withoutUndo() {
     //     DocumentModel so there is no middleware.
     if (DEBUG_UNDO) {
       try {
-        const {context} = actionCall;
+        const { context } = actionCall;
         const root = getRoot(context);
         // Use duck typing to figure out if the root is a tree
         // and its tree monitor is enabled

--- a/src/models/image-map.test.ts
+++ b/src/models/image-map.test.ts
@@ -2,9 +2,9 @@ import { autorun, runInAction, when } from "mobx";
 import { applySnapshot, destroy, getSnapshot, protect, unprotect } from "mobx-state-tree";
 import { externalUrlImagesHandler, localAssetsImagesHandler,
         firebaseRealTimeDBImagesHandler, firebaseStorageImagesHandler,
-        IImageHandler, ImageMapEntry, ImageMapModel, ImageMapModelType, 
-        EntryStatus, IImageHandlerStoreOptions, 
-        IImageHandlerStoreResult, ImageMapEntryType, ImageMapEntrySnapshot} from "./image-map";
+        IImageHandler, ImageMapEntry, ImageMapModel, ImageMapModelType,
+        EntryStatus, IImageHandlerStoreOptions,
+        IImageHandlerStoreResult, ImageMapEntryType, ImageMapEntrySnapshot } from "./image-map";
 import { parseFirebaseImageUrl } from "../../functions/src/shared-utils";
 import { DB } from "../lib/db";
 import * as ImageUtils from "../utilities/image-utils";
@@ -52,12 +52,12 @@ describe("ImageMap", () => {
     if (sImageMap) { destroy(sImageMap); }
     sImageMap = ImageMapModel.create();
     sImageMap.setUnitUrl(kCurriculumUnitUrl);
-    sImageMap.setUnitCodeMap({"stretching-and-shrinking": "sas"});
+    sImageMap.setUnitCodeMap({ "stretching-and-shrinking": "sas" });
   });
-          
+
   function createMockDB(overrides?: Record<string, any>) {
     return {
-      stores: { user: { id: "user", classHash: "classHash" }},
+      stores: { user: { id: "user", classHash: "classHash" } },
       firebase: { getPublicUrlFromStore: (path?: string, url?: string) => Promise.resolve(kFBStorageUrl) },
       getCloudImageBlob: jest.fn(() => Promise.resolve(kBlobUrl)),
       getImageBlob: jest.fn(() => Promise.resolve(kBlobUrl)),
@@ -115,7 +115,7 @@ describe("ImageMap", () => {
     {
       const storeSpy = jest.spyOn(ImageUtils, "storeImage")
                             .mockImplementation(() =>
-                              Promise.resolve({ imageUrl: kCCImgFBRTDBUrl, imageData: kBlobUrl}));
+                              Promise.resolve({ imageUrl: kCCImgFBRTDBUrl, imageData: kBlobUrl }));
       p1 = externalUrlImagesHandler.store(kHttpsImageUrl, { db: createMockDB() })
         .then(storeResult => {
           expect(storeSpy).toHaveBeenCalled();
@@ -145,8 +145,8 @@ describe("ImageMap", () => {
       const kHttpsImage2 = kHttpsImageUrl + "2";
       const storeSpy = jest.spyOn(ImageUtils, "storeImage")
                             .mockImplementation(() =>
-                              Promise.resolve({ imageUrl: placeholderImage, imageData: placeholderImage}));
-      p1 = externalUrlImagesHandler.store(kHttpsImage2, {db: createMockDB() })
+                              Promise.resolve({ imageUrl: placeholderImage, imageData: placeholderImage }));
+      p1 = externalUrlImagesHandler.store(kHttpsImage2, { db: createMockDB() })
         .then(storeResult => {
           expect(storeSpy).toHaveBeenCalled();
           expect(storeResult.contentUrl).toBe(kHttpsImage2);
@@ -157,8 +157,8 @@ describe("ImageMap", () => {
       const kHttpsImage3 = kHttpsImageUrl + "3";
       const storeSpy = jest.spyOn(ImageUtils, "storeImage")
                             .mockImplementation(() =>
-                              Promise.resolve({ imageUrl: placeholderImage, imageData: placeholderImage}));
-      p2 = externalUrlImagesHandler.store(kHttpsImage3, { db: createMockDB({ stores: { user: { id: "" }} }) })
+                              Promise.resolve({ imageUrl: placeholderImage, imageData: placeholderImage }));
+      p2 = externalUrlImagesHandler.store(kHttpsImage3, { db: createMockDB({ stores: { user: { id: "" } } }) })
         .then(storeResult => {
           expect(storeSpy).toHaveBeenCalled();
           expect(storeResult.contentUrl).toBe(kHttpsImage3);
@@ -171,8 +171,9 @@ describe("ImageMap", () => {
   it("test firebaseStorageImagesHandler on firebase storage URL", () => {
     expectToMatch(firebaseStorageImagesHandler, [kFBStorageUrl, kFBStorageRef]);
 
-    const storeSpy = jest.spyOn(ImageUtils, "storeCorsImage")
-                          .mockImplementation(() => Promise.resolve({ imageUrl: kCCImgFBRTDBUrl, imageData: kBlobUrl}));
+    const storeSpy = jest
+      .spyOn(ImageUtils, "storeCorsImage")
+      .mockImplementation(() => Promise.resolve({ imageUrl: kCCImgFBRTDBUrl, imageData: kBlobUrl }));
     return firebaseStorageImagesHandler.store(kFBStorageUrl, { db: createMockDB() })
       .then(storeResult => {
         expect(storeSpy).toHaveBeenCalled();
@@ -183,8 +184,9 @@ describe("ImageMap", () => {
   });
 
   it("test firebaseStorageImagesHandler on firebase storage reference", () => {
-    const storeSpy = jest.spyOn(ImageUtils, "storeCorsImage")
-                          .mockImplementation(() => Promise.resolve({ imageUrl: kCCImgFBRTDBUrl, imageData: kBlobUrl}));
+    const storeSpy = jest
+      .spyOn(ImageUtils, "storeCorsImage")
+      .mockImplementation(() => Promise.resolve({ imageUrl: kCCImgFBRTDBUrl, imageData: kBlobUrl }));
     return firebaseStorageImagesHandler.store(kFBStorageRef, { db: createMockDB() })
       .then(storeResult => {
         expect(storeSpy).toHaveBeenCalled();
@@ -335,7 +337,7 @@ describe("ImageMap", () => {
                 expect(consoleSpy).toBeCalledTimes(1);
               });
     });
-  
+
     it("can retrieve placeholder image from cache", () => {
       expect(sImageMap.hasImage(placeholderImage));
       expect(sImageMap.getCachedImage(placeholderImage)).toEqual({
@@ -352,55 +354,55 @@ describe("ImageMap", () => {
                 expect(image.height).toBe(150);
               });
     });
-    
+
     it("can handle duplicate renders when image map is slow to compute the dimensions", async () => {
       // Expose the image dimensions resolve function so we can call it when we want to
       let imageDimensionResolve: (entrySnapshot: ImageUtils.IImageDimensions) => void;
-      const imageDimensionPromise = 
-        new Promise<ImageUtils.IImageDimensions>((resolve) => imageDimensionResolve = resolve);    
+      const imageDimensionPromise =
+        new Promise<ImageUtils.IImageDimensions>((resolve) => imageDimensionResolve = resolve);
       const dimSpy = jest.spyOn(ImageUtils, "getImageDimensions")
                           .mockImplementation(() => imageDimensionPromise);
-      
+
       expect.assertions(10);
-  
+
       // After this first call we should expect that the getImage promise will not be
       // resolved until we call imageDimensionResolve
       const firstGetImagePromise = sImageMap.getImage(kLocalImageUrl);
       const secondGetImagePromise = sImageMap.getImage(kLocalImageUrl);
-  
+
       let firstGetImagePromiseResolved = false;
       let secondGetImagePromiseResolved = false;
       firstGetImagePromise.then(() => firstGetImagePromiseResolved = true);
       secondGetImagePromise.then(() => secondGetImagePromiseResolved = true);
-  
+
       // Wait for there to be a cached entry for this url using MobX's wait
       // This will happen after the image is stored, but before the dimensions
       // are requested
       await when(() => !!sImageMap.getCachedImage(kLocalImageUrl));
-      
+
       const imageEntry = sImageMap.getCachedImage(kLocalImageUrl);
       expect(imageEntry?.status).toBe(EntryStatus.PendingDimensions);
-  
+
       expect(dimSpy).toHaveBeenCalled();
       // We wait for 20ms just to give the javascript engine time to resolve
-      // the promises. 
+      // the promises.
       // Just because the entry was created doesn't mean that the javascript
-      // engine had enough time to run the promises (if it was going to 
-      // do so).  It depends if the observer for the `when` is run before 
+      // engine had enough time to run the promises (if it was going to
+      // do so).  It depends if the observer for the `when` is run before
       // the `then` attached to the promises above.
       await new Promise((resolve) => setTimeout(resolve, 20));
       expect(firstGetImagePromiseResolved).toBe(false);
       expect(secondGetImagePromiseResolved).toBe(false);
-  
+
       imageDimensionResolve!({ src: placeholderImage, width: 200, height: 150 });
-  
+
       const image = await firstGetImagePromise;
       expect(image.contentUrl).toBe(kLocalImageUrl);
       expect(image.displayUrl).toBe(`${kLocalImageUrl}`);
       expect(image.width).toBe(200);
       expect(image.height).toBe(150);
       expect(image.status).toBe(EntryStatus.Ready);
-  
+
       const image2 = await secondGetImagePromise;
       expect(image2).toBe(image);
     });
@@ -417,7 +419,7 @@ describe("ImageMap", () => {
     it("handles when a previous getImage failed due to a getImageDimensions error", async () => {
       expect.assertions(3);
 
-      // We reset the mocks because when the ImageMap is created it will request the 
+      // We reset the mocks because when the ImageMap is created it will request the
       // dimensions of the placeholder image
       jest.resetAllMocks();
       jest.spyOn(ImageUtils, "getImageDimensions").mockImplementation(() =>
@@ -427,7 +429,7 @@ describe("ImageMap", () => {
       const returnedEntry = await sImageMap.getImage(kLocalImageUrl);
       expect(returnedEntry?.status).toBe(EntryStatus.Error);
 
-      // A second call should try again and succeed   
+      // A second call should try again and succeed
       jest.spyOn(ImageUtils, "getImageDimensions").mockImplementation(() =>
         Promise.resolve({ src: placeholderImage, width: 200, height: 150 })
       );
@@ -440,7 +442,7 @@ describe("ImageMap", () => {
     it("handles when a previous getImage that converts the url failed due to a getImageDimensions error", async () => {
       expect.assertions(6);
 
-      // We reset the mocks because when the ImageMap is created it will request the 
+      // We reset the mocks because when the ImageMap is created it will request the
       // dimensions of the placeholder image
       jest.resetAllMocks();
       jest.spyOn(ImageUtils, "getImageDimensions").mockImplementation(() =>
@@ -450,17 +452,17 @@ describe("ImageMap", () => {
       const mockHandler: any = {
         async store(url: string, options?: IImageHandlerStoreOptions): Promise<IImageHandlerStoreResult> {
           return {
-            contentUrl: "convertedUrl", 
-            displayUrl: "convertedUrl", 
-            success: true};
+            contentUrl: "convertedUrl",
+            displayUrl: "convertedUrl",
+            success: true };
         }
       };
       jest.spyOn(sImageMap, "getHandler").mockImplementation((url: string) => mockHandler);
 
       const returnedEntry = await sImageMap.getImage(kLocalImageUrl);
       const expectedEntry = {
-        contentUrl: "convertedUrl", 
-        displayUrl: "convertedUrl", 
+        contentUrl: "convertedUrl",
+        displayUrl: "convertedUrl",
         status: EntryStatus.Error,
         retries: 0
       };
@@ -468,21 +470,21 @@ describe("ImageMap", () => {
       expect(sImageMap.getCachedImage(kLocalImageUrl)).toEqual(expectedEntry);
       expect(sImageMap.getCachedImage("convertedUrl")).toEqual(expectedEntry);
 
-      // A second call should try again and succeed   
+      // A second call should try again and succeed
       jest.spyOn(ImageUtils, "getImageDimensions").mockImplementation(() =>
         Promise.resolve({ src: placeholderImage, width: 200, height: 150 })
       );
       const getImagePromise2 = sImageMap.getImage(kLocalImageUrl);
-      
-      // TODO: it'd be good to check the intermediate state to see that the 
+
+      // TODO: it'd be good to check the intermediate state to see that the
       // main entry has a `PendingStorage` status. And then when addImage is called
       // the main entry and the copied entry have a `PendingDimensions` state
       // Doing this would require setting up a delayed getDimensions like above
 
       const returnedEntry2 = await getImagePromise2;
       const expectedEntry2 = {
-        contentUrl: "convertedUrl", 
-        displayUrl: "convertedUrl", 
+        contentUrl: "convertedUrl",
+        displayUrl: "convertedUrl",
         width: 200,
         height: 150,
         status: EntryStatus.Ready,
@@ -526,8 +528,8 @@ describe("ImageMap", () => {
       const mockHandler: any = {
         async store(url: string, options?: IImageHandlerStoreOptions): Promise<IImageHandlerStoreResult> {
           return {
-            displayUrl: placeholderImage, 
-            success: false};
+            displayUrl: placeholderImage,
+            success: false };
         }
       };
       jest.spyOn(sImageMap, "getHandler").mockImplementation((url: string) => mockHandler);
@@ -536,7 +538,7 @@ describe("ImageMap", () => {
       let countOfGetImage = 0;
       let countOfAutorun = 0;
       let imageEntry: ImageMapEntryType | undefined;
-      let displayUrl: string | undefined; 
+      let displayUrl: string | undefined;
       let lastStatus: EntryStatus | undefined;
       const disposer = autorun(() => {
         // This is a pattern that an observing component could use to display an
@@ -550,10 +552,10 @@ describe("ImageMap", () => {
           imageEntry = sImageMap.getCachedImage(mockUrl);
         }
         // This displayURL is what the the observing component would use to
-        // render the image.  
+        // render the image.
         displayUrl = imageEntry?.displayUrl;
-        
-        // **This line is important.** 
+
+        // **This line is important.**
         // Without this line, there will be no looping. This line tells MobX the
         // autorun should be re-run whenever the status changes. The status is
         // being checked above, but only if imageEntry already exists. So the
@@ -567,7 +569,7 @@ describe("ImageMap", () => {
           // to the image entry, this is why the limit is 15 instead of something lower
           disposer();
         }
-      });  
+      });
 
       return new Promise(resolve => setTimeout(resolve, 500))
       .then(() => {
@@ -597,8 +599,8 @@ describe("ImageMap", () => {
       const mockHandler: any = {
         async store(url: string, options?: IImageHandlerStoreOptions): Promise<IImageHandlerStoreResult> {
           return {
-            displayUrl: placeholderImage, 
-            success: false};
+            displayUrl: placeholderImage,
+            success: false };
         }
       };
       jest.spyOn(sImageMap, "getHandler").mockImplementation((url: string) => mockHandler);
@@ -606,7 +608,7 @@ describe("ImageMap", () => {
 
       let countOfAutorun = 0;
       let imageEntry: ImageMapEntryType | undefined;
-      let displayUrl: string | undefined; 
+      let displayUrl: string | undefined;
       let lastStatus: EntryStatus | undefined;
       const imageEntries: (ImageMapEntrySnapshot | null)[] = [];
       const disposer = autorun(() => {
@@ -622,10 +624,10 @@ describe("ImageMap", () => {
         imageEntries.push(imageEntry ? getSnapshot(imageEntry) : null);
 
         // This displayURL is what the the observing component would use to
-        // render the image.  
+        // render the image.
         displayUrl = imageEntry?.displayUrl;
-        
-        // **This line is important.** 
+
+        // **This line is important.**
         // Without this line, there will be no looping. This line tells MobX the
         // autorun should be re-run whenever the status changes. The status is
         // being checked above, but only if imageEntry already exists. So the
@@ -639,7 +641,7 @@ describe("ImageMap", () => {
           // to the image entry, this is why the limit is 15 instead of something lower
           disposer();
         }
-      });  
+      });
 
       return new Promise(resolve => setTimeout(resolve, 500))
       .then(() => {
@@ -678,13 +680,13 @@ describe("ImageMap", () => {
   });
 
   it("can update an image entry with syncContentUrl", () => {
-    const kLocalImageUrl2 = kLocalImageUrl + "2";    
+    const kLocalImageUrl2 = kLocalImageUrl + "2";
     const imageEntry2 = ImageMapEntry.create({
                           contentUrl: kLocalImageUrl2,
                           displayUrl: kLocalImageUrl2,
                           status: EntryStatus.Ready
                         });
-    
+
     // It should add a new entry at the contentUrl
     // It doesn't create or modify the entry at the original url
     sImageMap._syncContentUrl(kLocalImageUrl, imageEntry2);
@@ -692,7 +694,7 @@ describe("ImageMap", () => {
     const altEntry = sImageMap.getCachedImage(kLocalImageUrl2);
     expect(altEntry).toEqual(imageEntry2);
     // We never added an entry for the original url so it remains undefined
-    expect(sImageMap.getCachedImage(kLocalImageUrl)).toBeUndefined();                   
+    expect(sImageMap.getCachedImage(kLocalImageUrl)).toBeUndefined();
 
     // syncs should update existing entries in place if they are in an error
     // status
@@ -711,7 +713,7 @@ describe("ImageMap", () => {
   it("can add a file image", () => {
     const storeSpy = jest.spyOn(ImageUtils, "storeFileImage")
                           .mockImplementation(() =>
-                            Promise.resolve({ imageUrl: kCCImgFBRTDBUrl, imageData: kBlobUrl}));
+                            Promise.resolve({ imageUrl: kCCImgFBRTDBUrl, imageData: kBlobUrl }));
     const file: any = { name: "foo" };
     return sImageMap.addFileImage(file)
             .then(image => {
@@ -725,7 +727,7 @@ describe("ImageMap", () => {
   describe("_addImage", () => {
     it("can update an image entry", () => {
       const kLocalImageUrl2 = kLocalImageUrl + "2";
-  
+
       // Directly add an initial entry
       const initialEntry = {
         contentUrl: kLocalImageUrl,
@@ -735,7 +737,7 @@ describe("ImageMap", () => {
         status: EntryStatus.Ready
       };
       unsafeUpdate(() => sImageMap.images.set(kLocalImageUrl, initialEntry));
-  
+
       // It synchronously updates the entry and changes the status to `PendingDimensions`.
       const changedStoreResult = {
         contentUrl: kLocalImageUrl2,
@@ -743,16 +745,16 @@ describe("ImageMap", () => {
         success: true
       };
       const addImagePromise = sImageMap._addImage(kLocalImageUrl, changedStoreResult);
-  
+
       expect(sImageMap.getCachedImage(kLocalImageUrl)).toEqual({
         contentUrl: kLocalImageUrl2,
         displayUrl: kLocalImageUrl2,
         status: EntryStatus.PendingDimensions,
         retries: 0
       });
-  
+
       // Then asynchronously after the getImageDimensions call returns,
-      // the status will be set to Ready, and the width and height will be set 
+      // the status will be set to Ready, and the width and height will be set
       // to the values returned by getImageDimensions
       return addImagePromise.then(() => {
         expect(sImageMap.getCachedImage(kLocalImageUrl)).toEqual({
@@ -765,11 +767,11 @@ describe("ImageMap", () => {
         });
       });
     });
-  
+
     it("handles entries with the error status", async () => {
       expect.assertions(7);
 
-      // We reset the mocks because when the ImageMap is created it will request the 
+      // We reset the mocks because when the ImageMap is created it will request the
       // dimensions of the placeholder image
       jest.resetAllMocks();
       const dimSpy = jest.spyOn(ImageUtils, "getImageDimensions");
@@ -786,11 +788,11 @@ describe("ImageMap", () => {
         status: EntryStatus.Error,
         retries: 0
       };
-      
+
       // It synchronously adds the entry to the map
       const entryInMap = sImageMap.getCachedImage(kLocalImageUrl);
       expect(entryInMap).toEqual(expectedEntry);
-      
+
       const entryReturned = await addImagePromise;
       // It returns the entry, without computing the dimensions
       expect(entryReturned).toEqual(expectedEntry);
@@ -832,7 +834,7 @@ describe("ImageMap", () => {
       expect(returnedEntry.status).toBe(EntryStatus.Error);
       expect(sImageMap.getCachedImage(kLocalImageUrl)).toBe(returnedEntry);
       expect(consoleSpy).toBeCalledTimes(1);
-  
+
       // Even error entries are expected to have an displayUrl
       jest.resetAllMocks();
       const otherUrl = "fake-url";
@@ -844,11 +846,11 @@ describe("ImageMap", () => {
       expect(sImageMap.getCachedImage(otherUrl)).toBe(returnedEntry2);
       expect(consoleSpy).toBeCalledTimes(1);
     });
-    
+
     it("handles an error in getDimensions", async () => {
       expect.assertions(3);
 
-      // We reset the mocks because when the ImageMap is created it will request the 
+      // We reset the mocks because when the ImageMap is created it will request the
       // dimensions of the placeholder image
       jest.resetAllMocks();
       const dimSpy = jest.spyOn(ImageUtils, "getImageDimensions").mockImplementation(() =>

--- a/src/models/image-map.ts
+++ b/src/models/image-map.ts
@@ -198,7 +198,7 @@ export const ImageMapModel = types
       if (existingEntry) {
         retries = existingEntry.retries;
       }
-      const { success: successfulStore, ...otherProps} = storeResult;
+      const { success: successfulStore, ...otherProps } = storeResult;
       const snapshot: ImageMapEntrySnapshot = {
         ...otherProps,
         status: successfulStore ? EntryStatus.PendingDimensions : EntryStatus.Error,
@@ -349,8 +349,8 @@ export const ImageMapModel = types
         retries = imageEntry.retries + 1;
       }
 
-      self.images.set(url, {status: EntryStatus.PendingStorage, displayUrl: placeholderImage,
-        retries});
+      self.images.set(url, { status: EntryStatus.PendingStorage, displayUrl: placeholderImage,
+        retries });
 
       const storingPromise = self._storeAndAddImage(url, handler, options);
 

--- a/src/models/mst.test.ts
+++ b/src/models/mst.test.ts
@@ -2,14 +2,14 @@ import { action, autorun, makeObservable, observable } from "mobx";
 import { addDisposer, applySnapshot, getType, isAlive, types, getRoot,
   isStateTreeNode, SnapshotOut, Instance, getParent, destroy, hasParent,
   getSnapshot, addMiddleware, getEnv,
-  createActionTrackingMiddleware2, resolvePath} from "mobx-state-tree";
+  createActionTrackingMiddleware2, resolvePath } from "mobx-state-tree";
 
 describe("mst", () => {
   it("snapshotProcessor unexpectedly modifies the base type", () => {
     const Todo1 = types.model({ text: types.maybe(types.string) });
     const Todo2 = types.snapshotProcessor(Todo1, {
       preProcessor(sn) {
-        return {text: "todo2 text"};
+        return { text: "todo2 text" };
       }
     });
     const todo1a = Todo1.create();
@@ -30,7 +30,7 @@ describe("mst", () => {
     const Todo1 = types.model({ text: types.maybe(types.string) });
     const Todo2 = types.snapshotProcessor(Todo1, {
       preProcessor(sn) {
-        return {text: "todo2 text"};
+        return { text: "todo2 text" };
       }
     });
     const todo2 =Todo2.create();
@@ -55,7 +55,7 @@ describe("mst", () => {
     });
     expect(lateCalled).toBe(false);
 
-    TypeUsingLate.create({withLate: {prop: "val"}});
+    TypeUsingLate.create({ withLate: { prop: "val" } });
     expect(lateCalled).toBe(true);
   });
 
@@ -116,7 +116,7 @@ describe("mst", () => {
     });
     expect(lateCalled).toBe(false);
 
-    TypeWithLate.create({prop: {"hi": "hello"}});
+    TypeWithLate.create({ prop: { "hi": "hello" } });
     expect(lateCalled).toBe(true);
   });
 
@@ -135,10 +135,10 @@ describe("mst", () => {
     });
     expect(lateCalled).toBe(false);
 
-    TypeUsingLate.create({withLateMap: {}});
+    TypeUsingLate.create({ withLateMap: {} });
     expect(lateCalled).toBe(false);
 
-    TypeUsingLate.create({withLateMap: {"key": {prop: "value"}}});
+    TypeUsingLate.create({ withLateMap: { "key": { prop: "value" } } });
     expect(lateCalled).toBe(true);
   });
 
@@ -148,9 +148,9 @@ describe("mst", () => {
       text2: types.maybe(types.string)
     });
 
-    const todo = Todo1.create({text1: "1", text2:"2"});
+    const todo = Todo1.create({ text1: "1", text2:"2" });
     expect(todo.text1).toBe("1");
-    applySnapshot(todo, {text2: "changed"});
+    applySnapshot(todo, { text2: "changed" });
     expect(todo.text1).toBeUndefined();
   });
 
@@ -167,16 +167,16 @@ describe("mst", () => {
       }
     }));
 
-    const todo = Todo.create({values: {"first": {name: "1"}}});
+    const todo = Todo.create({ values: { "first": { name: "1" } } });
     const firstValue = todo.values.get("first");
     expect(firstValue!.name).toBe("1");
 
-    todo.setValue("first", {name: "changed"});
+    todo.setValue("first", { name: "changed" });
     const updatedValue = todo.values.get("first");
     expect(updatedValue).toBe(firstValue);
     expect(firstValue!.name).toBe("changed");
 
-    todo.setValue("first", TodoValue.create({name: "created"}));
+    todo.setValue("first", TodoValue.create({ name: "created" }));
     const createdValue = todo.values.get("first");
     expect(createdValue).not.toBe(firstValue);
     expect(isAlive(firstValue)).toBe(false);
@@ -207,7 +207,7 @@ describe("mst", () => {
       }
     }));
 
-    const todo = Todo.create({name: "hello"});
+    const todo = Todo.create({ name: "hello" });
     expect(autorunCount).toBe(1);
 
     const todoList = TodoList.create();
@@ -248,7 +248,7 @@ describe("mst", () => {
       }
     }));
 
-    const todo = Todo.create({name: "hello"});
+    const todo = Todo.create({ name: "hello" });
     expect(autorunCount).toBe(1);
 
     const todoList = TodoList.create();
@@ -289,17 +289,17 @@ describe("mst", () => {
 
     // We are not passing an environment here so MST creates an
     // empty object as the environment.
-    const todo = Todo.create({name: "hello"});
+    const todo = Todo.create({ name: "hello" });
     expect(autorunCount).toBe(1);
     expect(doSomething).toBeCalledTimes(1);
     expect(getEnv(todo)).toEqual({});
 
     // Now we pass an environment with someValue
-    const todoList = TodoList.create({}, {someValue: 1});
+    const todoList = TodoList.create({}, { someValue: 1 });
     todoList.addTodo(todo);
 
     // The environment of the todo has now changed
-    expect(getEnv(todo)).toEqual({someValue: 1});
+    expect(getEnv(todo)).toEqual({ someValue: 1 });
 
     return new Promise(resolve => {
       setTimeout(resolve, 50);
@@ -346,7 +346,7 @@ describe("mst", () => {
     const env = observable({}) as any;
     const todoList = TodoList.create({
       todos: [
-        {name: "hello"}
+        { name: "hello" }
       ]
     }, env);
     const todo = todoList.todos.at(0);
@@ -359,7 +359,7 @@ describe("mst", () => {
       env.someValue = 1;
     });
 
-    expect(getEnv(todo)).toEqual({someValue: 1});
+    expect(getEnv(todo)).toEqual({ someValue: 1 });
 
     return new Promise(resolve => {
       setTimeout(resolve, 50);
@@ -381,8 +381,8 @@ describe("mst", () => {
     }));
     interface TodoSnapshot extends SnapshotOut<typeof Todo> {}
 
-    const todo1 = Todo.create({name: "hello"});
-    const todo2 = Todo.create({name: "bye"});
+    const todo1 = Todo.create({ name: "hello" });
+    const todo2 = Todo.create({ name: "bye" });
     applySnapshot(todo1, todo2);
     expect(todo1.name).toBe("bye");
 
@@ -416,8 +416,8 @@ describe("mst", () => {
       todos: types.array(Todo)
     });
 
-    const todo = Todo.create({name: "todo1"});
-    const todoList = TodoList.create({todos: [todo]});
+    const todo = Todo.create({ name: "todo1" });
+    const todoList = TodoList.create({ todos: [todo] });
     expect(todoList.todos.at(0)).toBe(todo);
   });
 
@@ -497,10 +497,10 @@ describe("mst", () => {
           call.env = { id: topLevelCallId };
           topLevelCallId++;
         }
-        started.push({action: call.name, topLevelId: call.env.id});
+        started.push({ action: call.name, topLevelId: call.env.id });
       },
       onFinish(call) {
-        finished.push({action: call.name, topLevelId: call.env.id});
+        finished.push({ action: call.name, topLevelId: call.env.id });
       }
     });
     const disposer = addMiddleware(todoList, middleware, true);
@@ -513,17 +513,17 @@ describe("mst", () => {
 
     // This is what we generally want: 3 calls all with the same topLevelId
     const singleTopLevelOnStartedCalls: ICallRecord[] = [
-      {action: "updateAllTodos", topLevelId: 0},
-      {action: "setName", topLevelId: 0},
-      {action: "setName", topLevelId: 0}
+      { action: "updateAllTodos", topLevelId: 0 },
+      { action: "setName", topLevelId: 0 },
+      { action: "setName", topLevelId: 0 }
     ];
 
     // This is what we generally don't want: 3 calls all with different
     // topLevelIds
     const multipleTopLevelOnStartedCalls: ICallRecord[] = [
-      {action: "updateAllTodos", topLevelId: 0},
-      {action: "setName", topLevelId: 1},
-      {action: "setName", topLevelId: 2}
+      { action: "updateAllTodos", topLevelId: 0 },
+      { action: "setName", topLevelId: 1 },
+      { action: "setName", topLevelId: 2 }
     ];
 
     // Case 0: Run an action in the Main Tree that does not pass through a

--- a/src/models/shared/shared-model.test.ts
+++ b/src/models/shared/shared-model.test.ts
@@ -9,7 +9,7 @@ describe("Shared Models", () => {
       });
 
       const container = Container.create({
-        model: { id: "1", type: "foo", extra: "stuff"}
+        model: { id: "1", type: "foo", extra: "stuff" }
       } as any);
 
       expect(container.model).toBeDefined();
@@ -22,7 +22,7 @@ describe("Shared Models", () => {
       });
 
       const container = Container.create({
-        model: { id: "1", type: "foo", extra: "stuff"}
+        model: { id: "1", type: "foo", extra: "stuff" }
       } as any);
 
       expect(container.model.type).toBe("unknownSharedModel");

--- a/src/models/stores/app-config-model.ts
+++ b/src/models/stores/app-config-model.ts
@@ -55,7 +55,7 @@ export const AppConfigModel = types
       const teacherGuideUrl = unitUrl.replace(/content\.json$/, "teacher-guide/content.json");
       gImageMap.setUnitUrl(unitUrl);
       gImageMap.setUnitCodeMap(getSnapshot(self.unitCodeMap));
-      return {"content": unitUrl, "guide": teacherGuideUrl};
+      return { "content": unitUrl, "guide": teacherGuideUrl };
     }
   }))
   .views(self => ({

--- a/src/models/stores/documents.test.ts
+++ b/src/models/stores/documents.test.ts
@@ -137,7 +137,7 @@ describe("documents model", () => {
       clazz = ClassModel.create({
         name: "test",
         classHash: "testHash",
-        users: {1: student1, 2: student2, 3: student3}
+        users: { 1: student1, 2: student2, 3: student3 }
       });
     });
 

--- a/src/models/stores/documents.ts
+++ b/src/models/stores/documents.ts
@@ -194,7 +194,7 @@ export const DocumentsModel = types
         const tileEnv = getTileEnvironment(document);
         if (tileEnv) tileEnv.appConfig = self.appConfig;
 
-        const {firestore, userContextProvider} = self;
+        const { firestore, userContextProvider } = self;
 
         if (!firestore || !userContextProvider) {
           // TODO: There is a chance that we'll lose history if the documents

--- a/src/models/stores/groups.ts
+++ b/src/models/stores/groups.ts
@@ -29,7 +29,7 @@ export const GroupUserModel = types
   }))
   .views((self) => ({
     get connected() {
-      const {connectedTimestamp, disconnectedTimestamp} = self;
+      const { connectedTimestamp, disconnectedTimestamp } = self;
       return !disconnectedTimestamp || (connectedTimestamp > disconnectedTimestamp);
     },
     get problemDocument() {
@@ -108,7 +108,7 @@ export const GroupsModel = types
         const users: GroupUserModelType[] = [];
         Object.keys(groupUsers).forEach((groupUserId) => {
           const groupUser = groupUsers[groupUserId];
-          const {connectedTimestamp, disconnectedTimestamp} = groupUser;
+          const { connectedTimestamp, disconnectedTimestamp } = groupUser;
           // self may be undefined if the database was deleted while a tab remains open
           // causing the disconnectedAt timestamp to be set at the groupUser level
           if (groupUser.self) {
@@ -129,7 +129,7 @@ export const GroupsModel = types
             }
           }
         });
-        const groupModel = GroupModel.create({id: groupId, users});
+        const groupModel = GroupModel.create({ id: groupId, users });
         groupModel.setEnvironment(self.environment);
         return groupModel;
       });

--- a/src/models/stores/stores.ts
+++ b/src/models/stores/stores.ts
@@ -105,9 +105,9 @@ class Stores implements IStores{
     this.db = params?.db || new DB();
     this.documents = params?.documents || createDocumentsModelWithRequiredDocuments(requiredDocumentTypes);
     this.networkDocuments = params?.networkDocuments || DocumentsModel.create({});
-    this.unit = params?.unit || UnitModel.create({code: "NULL", title: "Null Unit"});
+    this.unit = params?.unit || UnitModel.create({ code: "NULL", title: "Null Unit" });
     const demoName = params?.demoName || this.appConfig.appName;
-    this.demo = params?.demo || DemoModel.create({name: demoName, class: {id: "0", name: "Null Class"}});
+    this.demo = params?.demo || DemoModel.create({ name: demoName, class: { id: "0", name: "Null Class" } });
     this.showDemoCreator = params?.showDemoCreator || false;
     this.supports = params?.supports || SupportsModel.create({});
     this.clipboard = ClipboardModel.create();
@@ -211,7 +211,7 @@ class Stores implements IStores{
     runInAction(() => {
       // read the unit content with full contents now that we have tools
       this.unit = UnitModel.create(unitJson);
-      const {investigation, problem} = this.unit.getProblem(_problemOrdinal);
+      const { investigation, problem } = this.unit.getProblem(_problemOrdinal);
 
       // TODO: make this dynamic like the way the components work. The components
       // access these values from the stores when they need them. This way the values

--- a/src/models/stores/supports.test.ts
+++ b/src/models/stores/supports.test.ts
@@ -23,39 +23,39 @@ describe("supports model", () => {
   it("uses override values", () => {
     const supports = SupportsModel.create({
       curricularSupports: [
-        {support: {type: ESupportType.text, content: "support #1"}, type: SupportTarget.unit, visible: true},
-        {support: {type: ESupportType.text, content: "support #2"}, type: SupportTarget.investigation},
-        {support: {type: ESupportType.text, content: "support #3"}, type: SupportTarget.problem, visible: true},
-        {support: {type: ESupportType.text, content: "support #4"}, type: SupportTarget.section},
+        { support: { type: ESupportType.text, content: "support #1" }, type: SupportTarget.unit, visible: true },
+        { support: { type: ESupportType.text, content: "support #2" }, type: SupportTarget.investigation },
+        { support: { type: ESupportType.text, content: "support #3" }, type: SupportTarget.problem, visible: true },
+        { support: { type: ESupportType.text, content: "support #4" }, type: SupportTarget.section },
       ],
       classSupports: [
-        {uid: "1", key: "1", support: {type: ESupportType.text, content: "support #5"}, type: SupportTarget.problem,
-          audience: ClassAudienceModel.create(), authoredTime: 42}
+        { uid: "1", key: "1", support: { type: ESupportType.text, content: "support #5" }, type: SupportTarget.problem,
+          audience: ClassAudienceModel.create(), authoredTime: 42 }
       ]
     });
     expect(omitUndefined(getSnapshot(supports))).toEqual({
       curricularSupports: [
         {
           supportType: "curricular",
-          support: {type: ESupportType.text, content: "support #1"},
+          support: { type: ESupportType.text, content: "support #1" },
           type: "unit",
           visible: true,
         },
         {
           supportType: "curricular",
-          support: {type: ESupportType.text, content: "support #2"},
+          support: { type: ESupportType.text, content: "support #2" },
           type: "investigation",
           visible: false,
         },
         {
           supportType: "curricular",
-          support: {type: ESupportType.text, content: "support #3"},
+          support: { type: ESupportType.text, content: "support #3" },
           type: "problem",
           visible: true,
         },
         {
           supportType: "curricular",
-          support: {type: ESupportType.text, content: "support #4"},
+          support: { type: ESupportType.text, content: "support #4" },
           type: "section",
           visible: false,
         },
@@ -65,7 +65,7 @@ describe("supports model", () => {
           uid: "1",
           key: "1",
           supportType: "teacher",
-          support: {type: ESupportType.text, content: "support #5"},
+          support: { type: ESupportType.text, content: "support #5" },
           type: "problem",
           audience: {
             type: "class"
@@ -96,21 +96,21 @@ describe("supports model", () => {
         {
           type: "introduction",
           supports: [
-            {type: ESupportType.text, content: "Investigation 1, Problem 1, section: introduction, support #1"},
-            {type: ESupportType.text, content: "Investigation 1, Problem 1, section: introduction, support #2"}
+            { type: ESupportType.text, content: "Investigation 1, Problem 1, section: introduction, support #1" },
+            { type: ESupportType.text, content: "Investigation 1, Problem 1, section: introduction, support #2" }
           ]
         },
         {
           type: "initialChallenge",
           supports: [
-            {type: ESupportType.text, content: "Investigation 1, Problem 1, section: initial challenge, support #1"},
-            {type: ESupportType.text, content: "Investigation 1, Problem 1, section: initial challenge, support #2"}
+            { type: ESupportType.text, content: "Investigation 1, Problem 1, section: initial challenge, support #1" },
+            { type: ESupportType.text, content: "Investigation 1, Problem 1, section: initial challenge, support #2" }
           ]
         }
       ],
       supports: [
-        {type: ESupportType.text, content: "Investigation 1, Problem 1, support #1"},
-        {type: ESupportType.text, content: "Investigation 1, Problem 1, support #2"}
+        { type: ESupportType.text, content: "Investigation 1, Problem 1, support #1" },
+        { type: ESupportType.text, content: "Investigation 1, Problem 1, support #2" }
       ]
     };
     const investigation1 = {
@@ -125,29 +125,29 @@ describe("supports model", () => {
             {
               type: "introduction",
               supports: [
-                {type: ESupportType.text, content: "Investigation 1, Problem 2, section: introduction, support #1"},
-                {type: ESupportType.text, content: "Investigation 1, Problem 2, section: introduction, support #2"}
+                { type: ESupportType.text, content: "Investigation 1, Problem 2, section: introduction, support #1" },
+                { type: ESupportType.text, content: "Investigation 1, Problem 2, section: introduction, support #2" }
               ]
             },
             {
               type: "initialChallenge",
               supports: [
-                {type: ESupportType.text,
-                  content: "Investigation 1, Problem 2, section: initial challenge, support #1"},
-                {type: ESupportType.text,
-                  content: "Investigation 1, Problem 2, section: initial challenge, support #2"}
+                { type: ESupportType.text,
+                  content: "Investigation 1, Problem 2, section: initial challenge, support #1" },
+                { type: ESupportType.text,
+                  content: "Investigation 1, Problem 2, section: initial challenge, support #2" }
               ]
             }
           ],
           supports: [
-            {type: ESupportType.text, content: "Investigation 1, Problem 1, support #1"},
-            {type: ESupportType.text, content: "Investigation 1, Problem 1, support #2"}
+            { type: ESupportType.text, content: "Investigation 1, Problem 1, support #1" },
+            { type: ESupportType.text, content: "Investigation 1, Problem 1, support #2" }
           ]
         }
       ],
       supports: [
-        {type: ESupportType.text, content: "Investigation 1, support #1"},
-        {type: ESupportType.text, content: "Investigation 1, support #2"}
+        { type: ESupportType.text, content: "Investigation 1, support #1" },
+        { type: ESupportType.text, content: "Investigation 1, support #2" }
       ]
     };
     const investigation2 = {
@@ -161,23 +161,23 @@ describe("supports model", () => {
             {
               type: "introduction",
               supports: [
-                {type: ESupportType.text, content: "Investigation 2, Problem 1, section: introduction, support #1"},
-                {type: ESupportType.text, content: "Investigation 2, Problem 1, section: introduction, support #2"}
+                { type: ESupportType.text, content: "Investigation 2, Problem 1, section: introduction, support #1" },
+                { type: ESupportType.text, content: "Investigation 2, Problem 1, section: introduction, support #2" }
               ]
             },
             {
               type: "initialChallenge",
               supports: [
-                {type: ESupportType.text,
-                  content: "Investigation 2, Problem 1, section: initial challenge, support #1"},
-                {type: ESupportType.text,
-                  content: "Investigation 2, Problem 1, section: initial challenge, support #2"}
+                { type: ESupportType.text,
+                  content: "Investigation 2, Problem 1, section: initial challenge, support #1" },
+                { type: ESupportType.text,
+                  content: "Investigation 2, Problem 1, section: initial challenge, support #2" }
               ]
             }
           ],
           supports: [
-            {type: ESupportType.text, content: "Investigation 2, Problem 1, support #1"},
-            {type: ESupportType.text, content: "Investigation 2, Problem 1, support #2"}
+            { type: ESupportType.text, content: "Investigation 2, Problem 1, support #1" },
+            { type: ESupportType.text, content: "Investigation 2, Problem 1, support #2" }
           ]
         },
         {
@@ -187,29 +187,29 @@ describe("supports model", () => {
             {
               type: "introduction",
               supports: [
-                {type: ESupportType.text, content: "Investigation 2, Problem 2, section: introduction, support #1"},
-                {type: ESupportType.text, content: "Investigation 2, Problem 2, section: introduction, support #2"}
+                { type: ESupportType.text, content: "Investigation 2, Problem 2, section: introduction, support #1" },
+                { type: ESupportType.text, content: "Investigation 2, Problem 2, section: introduction, support #2" }
               ]
             },
             {
               type: "initialChallenge",
               supports: [
-                {type: ESupportType.text,
-                  content: "Investigation 2, Problem 2, section: initial challenge, support #1"},
-                {type: ESupportType.text,
-                  content: "Investigation 2, Problem 2, section: initial challenge, support #2"}
+                { type: ESupportType.text,
+                  content: "Investigation 2, Problem 2, section: initial challenge, support #1" },
+                { type: ESupportType.text,
+                  content: "Investigation 2, Problem 2, section: initial challenge, support #2" }
               ]
             }
           ],
           supports: [
-            {type: ESupportType.text, content: "Investigation 2, Problem 2, support #1"},
-            {type: ESupportType.text, content: "Investigation 2, Problem 2, support #2"}
+            { type: ESupportType.text, content: "Investigation 2, Problem 2, support #1" },
+            { type: ESupportType.text, content: "Investigation 2, Problem 2, support #2" }
           ]
         }
       ],
       supports: [
-        {type: ESupportType.text, content: "Investigation 2, support #1"},
-        {type: ESupportType.text, content: "Investigation 2, support #2"}
+        { type: ESupportType.text, content: "Investigation 2, support #1" },
+        { type: ESupportType.text, content: "Investigation 2, support #2" }
       ]
     };
 
@@ -218,12 +218,12 @@ describe("supports model", () => {
         title: "Unit 1",
         investigations: [investigation1, investigation2],
         supports: [
-          {type: ESupportType.text, content: "Unit 1, support #1"},
-          {type: ESupportType.text, content: "Unit 1, support #2"}
+          { type: ESupportType.text, content: "Unit 1, support #1" },
+          { type: ESupportType.text, content: "Unit 1, support #2" }
         ]
       }),
       investigation: InvestigationModel.create(cloneDeep(investigation1)),
-      problem: ProblemModel.create(cloneDeep(problem1))});
+      problem: ProblemModel.create(cloneDeep(problem1)) });
 
     expect(supports.getSupportsForUserProblem(
                       { sectionId: "introduction", groupId: "groupId", userId: "userId" }))
@@ -286,16 +286,16 @@ describe("supports model", () => {
   });
 
   it("Gets supports by audience and section type", () => {
-    const classSupportAll = {uid: "1", key: "1", support: createTextSupport(""), type: SupportTarget.problem,
-      audience: ClassAudienceModel.create(), authoredTime: 42};
-    const classSupportIntro = {uid: "1", key: "2", support: createTextSupport(""),
+    const classSupportAll = { uid: "1", key: "1", support: createTextSupport(""), type: SupportTarget.problem,
+      audience: ClassAudienceModel.create(), authoredTime: 42 };
+    const classSupportIntro = { uid: "1", key: "2", support: createTextSupport(""),
       type: SupportTarget.section, sectionId: "introduction",
-      audience: ClassAudienceModel.create(), authoredTime: 43};
-    const groupSupport = {uid: "1", key: "3", support: createTextSupport(""), type: SupportTarget.problem,
-      audience: GroupAudienceModel.create({identifier: "group1"}), authoredTime: 44};
-    const userSupport = {uid: "1", key: "4", support: createTextSupport(""),
+      audience: ClassAudienceModel.create(), authoredTime: 43 };
+    const groupSupport = { uid: "1", key: "3", support: createTextSupport(""), type: SupportTarget.problem,
+      audience: GroupAudienceModel.create({ identifier: "group1" }), authoredTime: 44 };
+    const userSupport = { uid: "1", key: "4", support: createTextSupport(""),
       type: SupportTarget.section, sectionId: "didYouKnow",
-      audience: UserAudienceModel.create({identifier: "user1"}), authoredTime: 45};
+      audience: UserAudienceModel.create({ identifier: "user1" }), authoredTime: 45 };
 
     const supports = SupportsModel.create({
       classSupports: [

--- a/src/models/stores/supports.ts
+++ b/src/models/stores/supports.ts
@@ -23,9 +23,9 @@ export enum AudienceEnum {
 }
 
 export const audienceInfo = {
-  [AudienceEnum.class]: { display: "Class"},
-  [AudienceEnum.group]: { display: "Group"},
-  [AudienceEnum.user]: { display: "User"},
+  [AudienceEnum.class]: { display: "Class" },
+  [AudienceEnum.group]: { display: "Group" },
+  [AudienceEnum.user]: { display: "User" },
 };
 
 export enum SupportType {
@@ -387,7 +387,7 @@ export function addSupportDocumentsToStore(params: ICreateFromUnitParams) {
         // we skip it for firestore supports (using the fromDB parameter), which means
         // that we won't include any properties other than the ones configured above.
         // For now this seems fine since no other properties are relevant to supports.
-        properties = {...properties, ...await getSupportDocumentProperties(support, db)};
+        properties = { ...properties, ...await getSupportDocumentProperties(support, db) };
       }
     }
 
@@ -421,7 +421,7 @@ export function addSupportDocumentsToStore(params: ICreateFromUnitParams) {
 }
 
 export async function getSupportDocumentProperties(support: TeacherSupportModelType, db: DB) {
-  const {audience, sectionTarget, key, support: { type }} = support;
+  const { audience, sectionTarget, key, support: { type } } = support;
 
   if (type === ESupportType.multiclass) {
     const snapshot = await db.firestore.getDocument(db.firestore.getMulticlassSupportDocumentPath(key));

--- a/src/models/stores/ui.test.ts
+++ b/src/models/stores/ui.test.ts
@@ -66,7 +66,7 @@ describe("ui model", () => {
 
   it("allows selected tile to be set", () => {
     expect(ui.selectedTileIds).toStrictEqual([]);
-    const content = TextContentModel.create({text: "test"});
+    const content = TextContentModel.create({ text: "test" });
     const tile = TileModel.create({
       id: "1",
       content

--- a/src/models/stores/ui.ts
+++ b/src/models/stores/ui.ts
@@ -151,7 +151,7 @@ export const UIModel = types
       dialogResolver = undefined;
     };
 
-    const setOrAppendTileIdToSelection = (tileId?: string, options?: {append: boolean}) => {
+    const setOrAppendTileIdToSelection = (tileId?: string, options?: { append: boolean }) => {
       if (tileId) {
         const tileIdIndex = self.selectedTileIds.indexOf(tileId);
         const isCurrentlySelected = tileIdIndex >= 0;
@@ -176,7 +176,7 @@ export const UIModel = types
     const getTabState = (tab: string) => {
       let tabState = self.tabs.get(tab);
       if (!tabState) {
-        tabState = UITabModel.create({id: tab});
+        tabState = UITabModel.create({ id: tab });
         self.tabs.put(tabState);
       }
       return tabState;
@@ -214,10 +214,10 @@ export const UIModel = types
       setActiveNavTab(tab: string) {
         self.activeNavTab = tab;
       },
-      setSelectedTile(tile?: ITileModel, options?: {append: boolean}) {
+      setSelectedTile(tile?: ITileModel, options?: { append: boolean }) {
         setOrAppendTileIdToSelection(tile && tile.id, options);
       },
-      setSelectedTileId(tileId: string, options?: {append: boolean}) {
+      setSelectedTileId(tileId: string, options?: { append: boolean }) {
         setOrAppendTileIdToSelection(tileId, options);
       },
       removeTileIdFromSelection(tileId: string) {
@@ -237,7 +237,7 @@ export const UIModel = types
         else if (document.isPublished) {
           if (self.problemWorkspace.primaryDocumentKey) {
             self.problemWorkspace.setComparisonDocument(document);
-            self.problemWorkspace.toggleComparisonVisible({override: true});
+            self.problemWorkspace.toggleComparisonVisible({ override: true });
           }
           else {
             alert("Please select a primary document first.", "Select Primary Document");
@@ -350,7 +350,7 @@ export const UIModel = types
     },
 
     openCurriculumDocument(docPath: string) {
-      const {navTab, subTab} = getTabsOfCurriculumDoc(docPath);
+      const { navTab, subTab } = getTabsOfCurriculumDoc(docPath);
       if (!subTab) {
         console.warn("Can't find subTab in curriculum documentPath", docPath);
         return;
@@ -373,7 +373,7 @@ export const debouncedSelectTile = debounce(selectTile, 50);
 
 // Maybe this should return the navTab and subTab
 export function getTabsOfCurriculumDoc(docPath: string) {
-  const {facet, section} = getCurriculumMetadata(docPath) || {};
+  const { facet, section } = getCurriculumMetadata(docPath) || {};
   return {
     navTab: facet === "guide" ? ENavTab.kTeacherGuide : ENavTab.kProblems,
     subTab: section

--- a/src/models/stores/user.test.ts
+++ b/src/models/stores/user.test.ts
@@ -34,7 +34,7 @@ describe("UserPortalOffering", () => {
 describe("user model", () => {
 
   it("sets default values", () => {
-    const user = UserModel.create({type: "student"});
+    const user = UserModel.create({ type: "student" });
     expect(user.authenticated).toBe(false);
     expect(user.type).toBe("student");
     expect(user.name).toBe("Anonymous User");
@@ -241,7 +241,7 @@ describe("user model", () => {
   });
 
   it("can set connected status", () => {
-    const user = UserModel.create({type: "student"});
+    const user = UserModel.create({ type: "student" });
     expect(user.isFirebaseConnected).toBe(false);
     expect(user.isLoggingConnected).toBe(false);
     user.setIsFirebaseConnected(true);
@@ -251,7 +251,7 @@ describe("user model", () => {
   });
 
   it("can set view timestamps", () => {
-    const user = UserModel.create({type: "student"});
+    const user = UserModel.create({ type: "student" });
     expect(user.lastSupportViewTimestamp).toBeUndefined();
     expect(user.lastStickyNoteViewTimestamp).toBeUndefined();
     const timestamp = new Date().getTime();

--- a/src/models/stores/workspace.test.ts
+++ b/src/models/stores/workspace.test.ts
@@ -81,9 +81,9 @@ describe("workspaces model", () => {
     expect(workspace.comparisonVisible).toBe(true);
     workspace.toggleComparisonVisible();
     expect(workspace.comparisonVisible).toBe(false);
-    workspace.toggleComparisonVisible({override: true});
+    workspace.toggleComparisonVisible({ override: true });
     expect(workspace.comparisonVisible).toBe(true);
-    workspace.toggleComparisonVisible({override: false});
+    workspace.toggleComparisonVisible({ override: false });
     expect(workspace.comparisonVisible).toBe(false);
   });
 

--- a/src/models/stores/workspace.ts
+++ b/src/models/stores/workspace.ts
@@ -61,8 +61,8 @@ export const WorkspaceModel = types
         }
       },
 
-      toggleComparisonVisible({override, muteLog = false, hidePrimary = false}:
-          {override?: boolean; muteLog?: boolean, hidePrimary?: boolean} = {}) {
+      toggleComparisonVisible({ override, muteLog = false, hidePrimary = false }:
+          { override?: boolean; muteLog?: boolean, hidePrimary?: boolean } = {}) {
         const visible = typeof override !== "undefined" ? override : !self.comparisonVisible;
         self.comparisonVisible = visible;
         self.hidePrimaryForCompare = hidePrimary;

--- a/src/models/tiles/geometry/geometry-content.test.ts
+++ b/src/models/tiles/geometry/geometry-content.test.ts
@@ -789,7 +789,7 @@ describe("GeometryContent", () => {
     const [comment] = content.addComment(board, p0.id, "p0 comment") || [];
     expect(content.copySelection(board)).toEqualWithUniqueIds([
       PointModel.create({ id: p0.id, x: 0, y: 0 }),
-      CommentModel.create({ id: comment.id, anchors: [p0.id], text: "p0 comment"})
+      CommentModel.create({ id: comment.id, anchors: [p0.id], text: "p0 comment" })
     ]);
     content.removeObjects(board, [comment.id]);
 
@@ -845,7 +845,7 @@ describe("GeometryContent", () => {
     const [comment] = content.addComment(board, p0.id, "p0 comment") || [];
     expect(content.copySelection(board)).toEqualWithUniqueIds([
       PointModel.create({ id: p0.id, x: 0, y: 0 }),
-      CommentModel.create({ id: comment.id, anchors: [p0.id], text: "p0 comment"})
+      CommentModel.create({ id: comment.id, anchors: [p0.id], text: "p0 comment" })
     ]);
     content.removeObjects(board, [comment.id]);
 

--- a/src/models/tiles/geometry/geometry-content.ts
+++ b/src/models/tiles/geometry/geometry-content.ts
@@ -276,7 +276,7 @@ export const GeometryContentModel = GeometryBaseContentModel
       return board.objectsList.filter(obj => self.isSelected(obj.id));
     },
     exportJson(options?: ITileExportOptions) {
-      const changes = convertModelToChanges(self, { addBuffers: false, includeUnits: false});
+      const changes = convertModelToChanges(self, { addBuffers: false, includeUnits: false });
       const jsonChanges = changes.map(change => JSON.stringify(change));
       return exportGeometryJson(jsonChanges, options);
     }
@@ -400,7 +400,7 @@ export const GeometryContentModel = GeometryBaseContentModel
     // actions
     function initializeBoard(domElementID: string, onCreate?: onCreateCallback): JXG.Board | undefined {
       let board: JXG.Board | undefined;
-      const changes = convertModelToChanges(self, { addBuffers: true, includeUnits: true});
+      const changes = convertModelToChanges(self, { addBuffers: true, includeUnits: true });
       applyChanges(domElementID, changes, getDispatcherContext())
         .filter(result => result != null)
         .forEach(changeResult => {
@@ -590,7 +590,7 @@ export const GeometryContentModel = GeometryBaseContentModel
         operation: "create",
         target: "movableLine",
         parents,
-        properties: {id, ...props}
+        properties: { id, ...props }
       };
       const elems = applyAndLogChange(board, change);
       return elems ? elems as JXG.GeometryElement[] : undefined;
@@ -604,7 +604,7 @@ export const GeometryContentModel = GeometryBaseContentModel
       const change: JXGChange = {
         operation: "create",
         target: "comment",
-        properties: {id, anchor: anchorId, ...textProp }
+        properties: { id, anchor: anchorId, ...textProp }
       };
       const elems = applyAndLogChange(board, change);
       return elems ? elems as JXG.GeometryElement[] : undefined;
@@ -935,7 +935,7 @@ export const GeometryContentModel = GeometryBaseContentModel
     function applyAndLogChange(board: JXG.Board | undefined, _change: JXGChange) {
       const result = board && syncChange(board, _change);
 
-      let loggedChange = {..._change};
+      let loggedChange = { ..._change };
       if (!Array.isArray(_change.properties)) {
         // flatten change.properties
         delete loggedChange.properties;
@@ -1126,7 +1126,7 @@ export const GeometryContentModel = GeometryBaseContentModel
         });
         self.replaceLinks(remainingLinks);
       },
-      {name: "sharedModelSetup", fireImmediately: true}));
+      { name: "sharedModelSetup", fireImmediately: true }));
     },
     updateAfterSharedModelChanges(sharedModel?: SharedModelType) {
       self.forceSharedModelUpdate();

--- a/src/models/tiles/geometry/geometry-import.test.ts
+++ b/src/models/tiles/geometry/geometry-import.test.ts
@@ -130,7 +130,7 @@ describe("Geometry import", () => {
       objects: [
         { type: "point", parents: [0, 0] },
         { type: "point", parents: [2, 2], properties: { id: "p1" } },
-        { type: "point", parents: [5, 5], properties: { foo: "bar" }}
+        { type: "point", parents: [5, 5], properties: { foo: "bar" } }
       ]
     };
     jestSpyConsole("warn", spy => {

--- a/src/models/tiles/geometry/geometry-migrate.test.ts
+++ b/src/models/tiles/geometry/geometry-migrate.test.ts
@@ -539,7 +539,7 @@ describe("Geometry migration", () => {
         target: "board",
         properties: { axis: true, boundingBox: [-2, 15, 22, -1], unitX: 20, unitY: 20 }
       },
-      { operation: "create", target: "tableLink", properties: { ids: ["lp1", "lp2", "lp3"] }},
+      { operation: "create", target: "tableLink", properties: { ids: ["lp1", "lp2", "lp3"] } },
       { operation: "create", target: "polygon", parents: ["lp1", "lp2", "lp3"], properties: { id: "p1" } },
     ];
     expect(convertChangesToJson(changes)).toEqual({
@@ -554,7 +554,7 @@ describe("Geometry migration", () => {
 
     expect(convertChangesToModelSnapshot(changes)).toEqual({
       ...kDefaultModelProps, objects: {
-        p1: { type: "polygon", id: "p1", points: ["lp1", "lp2", "lp3"]},
+        p1: { type: "polygon", id: "p1", points: ["lp1", "lp2", "lp3"] },
       }
     });
   });
@@ -647,8 +647,8 @@ describe("Geometry migration", () => {
         v1: { type: "point", id: "v1", x: 0, y: 0 },
         v2: { type: "point", id: "v2", x: 5, y: 0 },
         v3: { type: "point", id: "v3", x: 0, y: 5 },
-        p1: { type: "polygon", id: "p1", points: ["v1", "v2", "v3"]},
-        p2: { type: "polygon", id: "p2", points: ["v1", "v2", "v3"]}
+        p1: { type: "polygon", id: "p1", points: ["v1", "v2", "v3"] },
+        p2: { type: "polygon", id: "p2", points: ["v1", "v2", "v3"] }
       }
     });
   });
@@ -685,7 +685,7 @@ describe("Geometry migration", () => {
         v1: { type: "point", id: "v1", x: 0, y: 0 },
         v2: { type: "point", id: "v2", x: 5, y: 0 },
         v3: { type: "point", id: "v3", x: 0, y: 5 },
-        p2: { type: "polygon", id: "p2", points: ["v1", "v2", "v3"]}
+        p2: { type: "polygon", id: "p2", points: ["v1", "v2", "v3"] }
       }
     });
   });
@@ -722,7 +722,7 @@ describe("Geometry migration", () => {
         v1: { type: "point", id: "v1", x: 0, y: 0 },
         v2: { type: "point", id: "v2", x: 5, y: 0 },
         v3: { type: "point", id: "v3", x: 0, y: 5 },
-        p1: { type: "polygon", id: "p1", points: ["v1", "v2", "v3"]}
+        p1: { type: "polygon", id: "p1", points: ["v1", "v2", "v3"] }
       }
     });
   });
@@ -807,7 +807,7 @@ describe("Geometry migration", () => {
         v2: { type: "point", id: "v2", x: 6, y: 6 },
         v3: { type: "point", id: "v3", x: 6, y: 0 },
         v4: { type: "point", id: "v4", x: 0, y: 0 },
-        p1: { type: "polygon", id: "p1", points: ["v1", "v2", "v3", "v4"]},
+        p1: { type: "polygon", id: "p1", points: ["v1", "v2", "v3", "v4"] },
         c1: { type: "comment", id: "c1", anchors: ["p1"] }
       }
     });
@@ -848,7 +848,7 @@ describe("Geometry migration", () => {
         v2: { type: "point", id: "v2", x: 6, y: 6 },
         v3: { type: "point", id: "v3", x: 6, y: 0 },
         v4: { type: "point", id: "v4", x: 0, y: 0 },
-        p1: { type: "polygon", id: "p1", points: ["v1", "v2", "v3", "v4"]},
+        p1: { type: "polygon", id: "p1", points: ["v1", "v2", "v3", "v4"] },
         c1: { type: "comment", id: "c1", anchors: ["p1"], x: 3, y: 3 }
       }
     });
@@ -890,7 +890,7 @@ describe("Geometry migration", () => {
         v2: { type: "point", id: "v2", x: 6, y: 6 },
         v3: { type: "point", id: "v3", x: 6, y: 0 },
         v4: { type: "point", id: "v4", x: 0, y: 0 },
-        p1: { type: "polygon", id: "p1", points: ["v1", "v2", "v3", "v4"]},
+        p1: { type: "polygon", id: "p1", points: ["v1", "v2", "v3", "v4"] },
         c1: { type: "comment", id: "c1", anchors: ["p1"], x: 2, y: 2 }
       }
     });
@@ -928,7 +928,7 @@ describe("Geometry migration", () => {
         v1: { type: "point", id: "v1", x: 0, y: 0 },
         v2: { type: "point", id: "v2", x: 5, y: 0 },
         v3: { type: "point", id: "v3", x: 0, y: 5 },
-        p1: { type: "polygon", id: "p1", points: ["v1", "v2", "v3"]},
+        p1: { type: "polygon", id: "p1", points: ["v1", "v2", "v3"] },
         a1: { type: "vertexAngle", id: "a1", points: ["v1", "v2", "v3"] }
       }
     });

--- a/src/models/tiles/geometry/geometry-migrate.ts
+++ b/src/models/tiles/geometry/geometry-migrate.ts
@@ -330,7 +330,7 @@ export const exportGeometry = (changes: string[], options?: ITileExportOptions) 
     let inParents = _changes[0].parents as JXGCoordPair | undefined;
     let props: any = {};
     _changes.forEach(change => {
-      props = {...props, ...change.properties };
+      props = { ...props, ...change.properties };
     });
     const { position, ...others } = props;
     if (others.id !== id) others.id = id;
@@ -364,7 +364,7 @@ export const exportGeometry = (changes: string[], options?: ITileExportOptions) 
     const transformedUrl = options?.transformImageUrl?.(url, inFilename) || url;
     let props: any = {};
     _changes.forEach(change => {
-      props = {...props, ...change.properties };
+      props = { ...props, ...change.properties };
     });
     const { filename, position, ...others } = props;
     if (others.id !== id) others.id = id;
@@ -394,10 +394,10 @@ export const exportGeometry = (changes: string[], options?: ITileExportOptions) 
         const ptIndex = Array.isArray(change.targetID)
                           ? change.targetID.indexOf(id)
                           : change.properties.findIndex(p => p.id === id);
-        (ptIndex >= 0) && (props = {...props, ...change.properties[ptIndex] });
+        (ptIndex >= 0) && (props = { ...props, ...change.properties[ptIndex] });
       }
       else {
-        props = {...props, ...change.properties };
+        props = { ...props, ...change.properties };
       }
     });
     const { position, ...others } = props;
@@ -488,7 +488,7 @@ export const exportGeometry = (changes: string[], options?: ITileExportOptions) 
         labelMap.set(key, { points: parents as string[], option: labelOption });
       }
       else {
-        props = {...props, ...properties };
+        props = { ...props, ...properties };
       }
     });
     if (props.id !== id) props.id = id;
@@ -516,7 +516,7 @@ export const exportGeometry = (changes: string[], options?: ITileExportOptions) 
     const _changes = objectInfoMap[id].changes;
     let props: any = {};
     _changes.forEach(change => {
-      props = {...props, ...change.properties };
+      props = { ...props, ...change.properties };
     });
     if (props.id !== id) props.id = id;
 
@@ -549,7 +549,7 @@ export const exportGeometry = (changes: string[], options?: ITileExportOptions) 
     const _changes = objectInfoMap[id].changes;
     let props: any = {};
     _changes.forEach(change => {
-      props = {...props, ...change.properties };
+      props = { ...props, ...change.properties };
     });
     if (props.id !== id) props.id = id;
     const pointIds = getMovableLinePointIds(id);

--- a/src/models/tiles/geometry/jxg-board.ts
+++ b/src/models/tiles/geometry/jxg-board.ts
@@ -255,7 +255,7 @@ function addAxes(board: JXG.Board, params: IAddAxesParams) {
   const xAxis = board.create("axis", [ [0, 0], [1, 0] ], {
     name: xName || "x",
     withLabel: true,
-    label: {fontSize: 13, anchorX: "right", position: "rt", offset: [0, 15]},
+    label: { fontSize: 13, anchorX: "right", position: "rt", offset: [0, 15] },
     ...toObj("clientName", xName),
     ...toObj("clientAnnotation", xAnnotation)
   });
@@ -271,7 +271,7 @@ function addAxes(board: JXG.Board, params: IAddAxesParams) {
   const yAxis = board.create("axis", [ [0, 0], [0, 1] ], {
     name: yName || "y",
     withLabel: true,
-    label: {fontSize: 13, position: "rt", offset: [15, 0]},
+    label: { fontSize: 13, position: "rt", offset: [15, 0] },
     ...toObj("clientName", yName),
     ...toObj("clientAnnotation", yAnnotation)
   });

--- a/src/models/tiles/geometry/jxg-comment.ts
+++ b/src/models/tiles/geometry/jxg-comment.ts
@@ -97,7 +97,7 @@ export const commentChangeAgent: JXGChangeAgent = {
       const line = _board.create(
         "line",
         [anchorPoint, commentPoint],
-        { ...lineProps, id: `${id}-labelLine`});
+        { ...lineProps, id: `${id}-labelLine` });
       return [comment, commentPoint, anchorPoint, line];
     }
   },

--- a/src/models/tiles/geometry/jxg-movable-line.ts
+++ b/src/models/tiles/geometry/jxg-movable-line.ts
@@ -94,9 +94,9 @@ export const movableLineChangeAgent: JXGChangeAgent = {
   create: (board, change, context) => {
     const { id, pt1, pt2, line, ...shared }: any = change.properties || {};
     const lineId = id || uniqueId();
-    const props = syncClientColors({...sharedProps, ...shared });
-    const lineProps = {...props, ...lineSpecificProps, ...line };
-    const pointProps = {...props, ...pointSpecificProps};
+    const props = syncClientColors({ ...sharedProps, ...shared });
+    const lineProps = { ...props, ...lineSpecificProps, ...line };
+    const pointProps = { ...props, ...pointSpecificProps };
     const pointIds = getMovableLinePointIds(lineId);
 
     if (change.parents && change.parents.length === 2) {

--- a/src/models/tiles/geometry/jxg-object.ts
+++ b/src/models/tiles/geometry/jxg-object.ts
@@ -72,10 +72,10 @@ export const objectChangeAgent: JXGChangeAgent = {
           validateTransformations(obj);
           if (isPositionGraphable(position)) {
             obj.setPosition(JXG.COORDS_BY_USER, position as JXGCoordPair);
-            obj.setAttribute({visible: true});
+            obj.setAttribute({ visible: true });
           } else {
             obj.setPosition(JXG.COORDS_BY_USER, getGraphablePosition(position));
-            obj.setAttribute({visible: false});
+            obj.setAttribute({ visible: false });
           }
         }
 

--- a/src/models/tiles/geometry/jxg-point.ts
+++ b/src/models/tiles/geometry/jxg-point.ts
@@ -58,7 +58,7 @@ export function createPoint(board: JXG.Board, parents: JXGUnsafeCoordPair, chang
     props.snapSizeY = kSnapUnit;
   }
   const isGraphable = isPositionGraphable(parents);
-  const point = board.create("point", getGraphablePosition(parents), {...props, visible: isGraphable});
+  const point = board.create("point", getGraphablePosition(parents), { ...props, visible: isGraphable });
   return point;
 }
 

--- a/src/models/tiles/geometry/jxg-polygon.ts
+++ b/src/models/tiles/geometry/jxg-polygon.ts
@@ -205,7 +205,7 @@ export const polygonChangeAgent: JXGChangeAgent = {
     if (poly) {
       const segments = getPolygonEdges(poly);
       segments.forEach(seg => {
-        seg.setAttribute({strokeColor: "#0000FF"});
+        seg.setAttribute({ strokeColor: "#0000FF" });
         seg._set("clientStrokeColor", "#0000FF");
         seg._set("clientSelectedStrokeColor", "#0000FF");
       });

--- a/src/models/tiles/image/image-content.ts
+++ b/src/models/tiles/image/image-content.ts
@@ -11,7 +11,7 @@ export const kImageTileType = "Image";
 
 // This is only used directly by tests
 export function defaultImageContent(options?: IDefaultContentOptions) {
-  return ImageContentModel.create({url: options?.url || placeholderImage});
+  return ImageContentModel.create({ url: options?.url || placeholderImage });
 }
 
 export const ImageContentModel = TileContentModel

--- a/src/models/tiles/image/image-import-export.ts
+++ b/src/models/tiles/image/image-import-export.ts
@@ -19,7 +19,7 @@ export const convertLegacyImageTile = (snapshot: ILegacyImageTileImport) => {
     changeUrl = changeObj.url;
     changeFilename = changeObj.filename;
   }
-  return ({url: changeUrl, fileName: changeFilename, ...others});
+  return ({ url: changeUrl, fileName: changeFilename, ...others });
 
 };
 

--- a/src/models/tiles/log/log-comment-event.test.ts
+++ b/src/models/tiles/log/log-comment-event.test.ts
@@ -39,7 +39,7 @@ describe("authed logger", () => {
 
     stores = createStores({
       appMode: "authed",
-      appConfig: specAppConfig({ config: { appName: "TestLogger"} }),
+      appConfig: specAppConfig({ config: { appName: "TestLogger" } }),
       user: UserModel.create({
         id: "0", type: "student", portal: "test",
         loggingRemoteEndpoint: "foo"

--- a/src/models/tiles/table/table-content.test.ts
+++ b/src/models/tiles/table/table-content.test.ts
@@ -74,8 +74,8 @@ const makeSharedModelManager = (): ISharedModelManager => {
 const setupContainer = (content: TableContentModelType) => {
   const sharedModelManager = makeSharedModelManager();
   TestTileContentModelContainer.create(
-    {child: castToSnapshot(content)},
-    {sharedModelManager}
+    { child: castToSnapshot(content) },
+    { sharedModelManager }
   );
 };
 
@@ -380,7 +380,7 @@ describe("TableContent", () => {
 
     table.addCanonicalCases([{ __id__: "row4", xCol: "x4", yCol: "y4" }]);
     expect(table.dataSet.cases.length).toBe(3);
-    expect(getCaseNoId(table.dataSet, 2)).toEqual({ x: "x4", y: "y4"});
+    expect(getCaseNoId(table.dataSet, 2)).toEqual({ x: "x4", y: "y4" });
   });
 
   it("can apply changes with expressions to a DataSet", () => {

--- a/src/models/tiles/table/table-content.ts
+++ b/src/models/tiles/table/table-content.ts
@@ -122,7 +122,7 @@ export const TableMetadataModel = TileMetadataModel
             } else {
               let expressionVal: number;
               try {
-                expressionVal = parsedExpression.evaluate({[kSerializedXKey]: xVal});
+                expressionVal = parsedExpression.evaluate({ [kSerializedXKey]: xVal });
               }
               catch(e) {
                 expressionVal = NaN;
@@ -286,7 +286,7 @@ export const TableContentModel = TileContentModel
         return { sharedModelManager, sharedDataSet, tileSharedModels };
       },
       // reaction/effect
-      ({sharedModelManager, sharedDataSet, tileSharedModels}) => {
+      ({ sharedModelManager, sharedDataSet, tileSharedModels }) => {
         if (!sharedModelManager?.isReady) {
           // We aren't added to a document yet so we can't do anything yet
           return;
@@ -319,7 +319,7 @@ export const TableContentModel = TileContentModel
         const dataSets = sharedModelManager.getSharedModelsByType(kSharedDataSetType) as SharedDataSetType[];
         updateSharedDataSetColors(dataSets);
       },
-      {name: "sharedModelSetup", fireImmediately: true}));
+      { name: "sharedModelSetup", fireImmediately: true }));
     },
     updateAfterSharedModelChanges(sharedModel?: SharedModelType) {
       // console.warn("updateAfterSharedModelChanges hasn't been implemented for table content.");

--- a/src/models/tiles/text/text-plugin-info.test.ts
+++ b/src/models/tiles/text/text-plugin-info.test.ts
@@ -1,13 +1,13 @@
 import { getAllTextPluginInfos, getTextPluginIds, getTextPluginInfo,
   createTextPluginInstances, registerTextPluginInfo } from "./text-plugin-info";
 
-const testTextPluginInstance = {from: "testTextPluginInfo"} as any;
+const testTextPluginInstance = { from: "testTextPluginInfo" } as any;
 const testTextPluginInfo = {
   pluginName: "test",
   createSlatePlugin: jest.fn(() => testTextPluginInstance),
   buttonDefs: {}
 };
-const testTextPluginWithUpdateInstance = {from: "testTextPluginInfoWithUpdate"}  as any;
+const testTextPluginWithUpdateInstance = { from: "testTextPluginInfoWithUpdate" }  as any;
 const testTextPluginInfoWithUpdate = {
   pluginName: "testWithUpdate",
   createSlatePlugin: jest.fn(() => testTextPluginWithUpdateInstance),
@@ -26,7 +26,7 @@ describe("TextPluginInfo", () => {
   });
 
   test("getTextPluginInstances", () => {
-    const textContent: any = {foo: "bar"};
+    const textContent: any = { foo: "bar" };
     const pluginInstances = createTextPluginInstances(textContent);
     expect(testTextPluginInfo.createSlatePlugin).toBeCalledWith(textContent);
     expect(testTextPluginInfoWithUpdate.createSlatePlugin).toBeCalledWith(textContent);

--- a/src/models/tiles/text/text-plugin-info.ts
+++ b/src/models/tiles/text/text-plugin-info.ts
@@ -1,4 +1,4 @@
-import { Editor} from "@concord-consortium/slate-editor";
+import { Editor } from "@concord-consortium/slate-editor";
 import { SharedModelType } from "../../shared/shared-model";
 import { TextContentModelType } from "./text-content";
 

--- a/src/models/tiles/tile-model-hooks.ts
+++ b/src/models/tiles/tile-model-hooks.ts
@@ -56,5 +56,5 @@ export function tileModelHooks(clientHooks: Partial<ITileModelHooks>) {
     },
     ...clientHooks
   };
-  return {...hooks};
+  return { ...hooks };
 }

--- a/src/models/view/four-up-grid.test.ts
+++ b/src/models/view/four-up-grid.test.ts
@@ -116,7 +116,7 @@ describe("four-up grid model", () => {
       splitterSize: 3,
       width: 200,
     });
-    grid.update({initSplitters: true});
+    grid.update({ initSplitters: true });
     expect(grid.hSplitter).toBe(48.5);
     expect(grid.vSplitter).toBe(98.5);
   });
@@ -127,7 +127,7 @@ describe("four-up grid model", () => {
       splitterSize: 3,
       width: 200,
     });
-    grid.update({initSplitters: true});
+    grid.update({ initSplitters: true });
     grid.update({
       height: 200,
       resizeSplitters: true,
@@ -143,7 +143,7 @@ describe("four-up grid model", () => {
       splitterSize: 3,
       width: 200,
     });
-    grid.update({initSplitters: true});
+    grid.update({ initSplitters: true });
     grid.update({
       hSplitter: 25,
       vSplitter: 75,
@@ -158,9 +158,9 @@ describe("four-up grid model", () => {
       splitterSize: 3,
       width: 200,
     });
-    grid.cells[CellPositions.NorthWest].update({right: 10});
+    grid.cells[CellPositions.NorthWest].update({ right: 10 });
     grid.cells[CellPositions.NorthEast].update({});
-    grid.cells[CellPositions.SouthEast].update({bottom: 0});
-    grid.cells[CellPositions.SouthWest].update({right: 10, bottom: 0});
+    grid.cells[CellPositions.SouthEast].update({ bottom: 0 });
+    grid.cells[CellPositions.SouthWest].update({ right: 10, bottom: 0 });
   });
 });

--- a/src/models/view/four-up-grid.ts
+++ b/src/models/view/four-up-grid.ts
@@ -84,10 +84,10 @@ export const FourUpGridModel = types
       const eastLeft = self.vSplitter + self.splitterSize;
       const eastWidth = Math.max(0, self.width - eastLeft);
       const southHeight = Math.max(0, self.height - southTop);
-      const nwPos = {top: 0,        left: 0,        width: self.vSplitter, height: self.hSplitter};
-      const nePos = {top: 0,        left: eastLeft, width: eastWidth,      height: self.hSplitter};
-      const sePos = {top: southTop, left: eastLeft, width: eastWidth,      height: southHeight};
-      const swPos = {top: southTop, left: 0,        width: self.vSplitter, height: southHeight};
+      const nwPos = { top: 0,        left: 0,        width: self.vSplitter, height: self.hSplitter };
+      const nePos = { top: 0,        left: eastLeft, width: eastWidth,      height: self.hSplitter };
+      const sePos = { top: southTop, left: eastLeft, width: eastWidth,      height: southHeight };
+      const swPos = { top: southTop, left: 0,        width: self.vSplitter, height: southHeight };
       return {
         [CellPositions.NorthWest]: getCellScaling(nwPos),
         [CellPositions.NorthEast]: getCellScaling(nePos),
@@ -135,8 +135,8 @@ export const FourUpGridModel = types
     };
 
     // set the splitters
-    const {height, width, splitterSize} = self;
-    let {hSplitter, vSplitter} = self;
+    const { height, width, splitterSize } = self;
+    let { hSplitter, vSplitter } = self;
     if (hSplitter === 0) {
       hSplitter = splitInMiddle(height);
     }

--- a/src/plugins/data-card/components/case-attribute.tsx
+++ b/src/plugins/data-card/components/case-attribute.tsx
@@ -88,7 +88,7 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
   } = useCombobox({
     items: inputItems,
     initialInputValue: valueCandidate,
-    onInputValueChange: ({inputValue}) => {
+    onInputValueChange: ({ inputValue }) => {
       const safeValue = inputValue || "";
       setValueCandidate(safeValue);
       const allAttrValues = content.dataSet.attrFromID(attrKey)?.values as string[] || [];
@@ -228,7 +228,7 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
   const DeleteAttributeAlertContent = () => {
     return (
       <p>
-        Are you sure you want to remove the <em style={{ fontWeight: "bold"}}>{ getLabel() }</em>&nbsp;
+        Are you sure you want to remove the <em style={{ fontWeight: "bold" }}>{ getLabel() }</em>&nbsp;
         attribute from the Data Card? If you remove it from this card it will delete the data in the field,
         and it will also be removed from all the Cards in this collection.
       </p>
@@ -269,7 +269,7 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
   const valueClassNames = classNames(
     `value ${attrKey}`,
     { "editing": editingValue },
-    {"has-image": gImageMap.isImageUrl(valueStr)}
+    { "has-image": gImageMap.isImageUrl(valueStr) }
   );
 
   const typeIconClassNames = classNames(
@@ -329,7 +329,7 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
       </div>
 
       <div className={valueClassNames} onClick={handleValueClick}>
-          <div style={{display: (!readOnly && !valueIsImage()) ? 'block' : 'none'}} className="downshift-dropdown">
+          <div style={{ display: (!readOnly && !valueIsImage()) ? 'block' : 'none' }} className="downshift-dropdown">
             <VisuallyHidden>
               <label {...getLabelProps()} className="">
                 Value for {labelCandidate}
@@ -347,9 +347,10 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
             <ul {...getMenuProps()} className={ isOpen ? "open" : "closed"}>
               {isOpen &&
                 inputItems.map((item, index) => (
-                  <li className="dropdown-item" style={highlightedIndex === index ? {backgroundColor: '#bde4ff'} : {} }
+                  <li className="dropdown-item"
+                    style={highlightedIndex === index ? { backgroundColor: '#bde4ff' } : {} }
                     key={`${item}${index}`}
-                    {...getItemProps({item, index})}
+                    {...getItemProps({ item, index })}
                   >
                     {item}
                   </li>

--- a/src/plugins/data-card/components/data-card-toolbar-buttons.tsx
+++ b/src/plugins/data-card/components/data-card-toolbar-buttons.tsx
@@ -14,7 +14,7 @@ interface IToolbarButtonProps {
   tooltipOptions: TooltipProps;
   onClick: (e: React.MouseEvent) => void;
 }
-const ToolbarButton = ({ className, icon, onClick, tooltipOptions}: IToolbarButtonProps) => {
+const ToolbarButton = ({ className, icon, onClick, tooltipOptions }: IToolbarButtonProps) => {
   const to = useTooltipOptions(tooltipOptions);
   const classes = classNames("toolbar-button", className);
   return (

--- a/src/plugins/data-card/components/sort-card.tsx
+++ b/src/plugins/data-card/components/sort-card.tsx
@@ -44,7 +44,7 @@ export const SortCard: React.FC<IProps> = ({ model, caseId, indexInStack, totalI
     { collapsed: !expanded }, { expanded }
   );
 
-  const {attributes, listeners, setNodeRef, transform} = useDraggable({
+  const { attributes, listeners, setNodeRef, transform } = useDraggable({
     id: `draggable-sort-card-${caseId}`,
     data: { caseId, sortedByAttrId: content.selectedSortAttributeId, sortDrag: true }
   });

--- a/src/plugins/data-card/components/sort-stack.tsx
+++ b/src/plugins/data-card/components/sort-stack.tsx
@@ -36,8 +36,8 @@ export const SortStack: React.FC<IProps> = ({ model, stackValue, inAttributeId, 
 
   const dropZoneClasses = classNames(
    "stack-drop-zone",
-   {"show-droppable": draggingActive },
-   { "is-over" : isOver}
+   { "show-droppable": draggingActive },
+   { "is-over" : isOver }
   );
 
   return (

--- a/src/plugins/data-card/data-card-content.ts
+++ b/src/plugins/data-card/data-card-content.ts
@@ -151,7 +151,7 @@ export const DataCardContentModel = TileContentModel
         return { sharedModelManager, sharedDataSet, tileSharedModels };
       },
       // reaction/effect
-      ({sharedModelManager, sharedDataSet, tileSharedModels}) => {
+      ({ sharedModelManager, sharedDataSet, tileSharedModels }) => {
         if (!sharedModelManager?.isReady) {
           // We aren't added to a document yet so we can't do anything yet
           return;
@@ -180,7 +180,7 @@ export const DataCardContentModel = TileContentModel
         const dataSets = sharedModelManager.getSharedModelsByType(kSharedDataSetType) as SharedDataSetType[];
         updateSharedDataSetColors(dataSets);
       },
-      {name: "sharedModelSetup", fireImmediately: true}));
+      { name: "sharedModelSetup", fireImmediately: true }));
     },
     updateAfterSharedModelChanges(sharedModel?: SharedModelType) {
       if (self.caseIndex >= self.totalCases) {
@@ -205,7 +205,7 @@ export const DataCardContentModel = TileContentModel
       ]);
     },
     addNewCaseFromAttrKeys(atts: string[], beforeId?: string ){
-      const obj = atts.reduce((o, key) => Object.assign(o, {[key]: ""}), {});
+      const obj = atts.reduce((o, key) => Object.assign(o, { [key]: "" }), {});
       if (beforeId){
         addCanonicalCasesToDataSet(self.dataSet, [obj], beforeId);
       } else {

--- a/src/plugins/data-card/data-card-tile.test.tsx
+++ b/src/plugins/data-card/data-card-tile.test.tsx
@@ -24,7 +24,7 @@ jest.mock("../../models/tiles/log/log-tile-document-event", () => ({
 
 describe("DataCardToolComponent", () => {
   const content = defaultDataCardContent();
-  const model = TileModel.create({content});
+  const model = TileModel.create({ content });
 
   const defaultProps = {
     tileElt: null,
@@ -57,10 +57,10 @@ describe("DataCardToolComponent", () => {
   };
 
   it("renders successfully", () => {
-    const {getByText} =
+    const { getByText } =
       render(
         <ModalProvider>
-          <DataCardToolComponent  {...defaultProps} {...{model}}></DataCardToolComponent>
+          <DataCardToolComponent  {...defaultProps} {...{ model }}></DataCardToolComponent>
         </ModalProvider>
       );
       expect(getByText("Data Card Collection 1")).toBeInTheDocument();

--- a/src/plugins/data-card/data-card-tile.tsx
+++ b/src/plugins/data-card/data-card-tile.tsx
@@ -106,8 +106,8 @@ export const DataCardToolComponent: React.FC<ITileProps> = observer((props) => {
 
   const highlightContainerClasses = classNames(
     "data-card-container",
-    {"highlight": highlightDataCard},
-    {"no-highlight": !highlightDataCard}
+    { "highlight": highlightDataCard },
+    { "no-highlight": !highlightDataCard }
   );
 
   const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {

--- a/src/plugins/data-card/data-card-toolbar.tsx
+++ b/src/plugins/data-card/data-card-toolbar.tsx
@@ -48,7 +48,7 @@ export const DataCardToolbar: React.FC<IProps> = observer(({
        ...others
   });
 
-  const { isMergeEnabled, showMergeTileDialog } = useTileDataMerging({model});
+  const { isMergeEnabled, showMergeTileDialog } = useTileDataMerging({ model });
 
   const isEditingValue = !!currEditAttrId && currEditFacet === "value";
   const valueActionsEnabled = enabled && isEditingValue;

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -131,7 +131,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
 
   public render() {
     const { readOnly, documentProperties, tileContent, programDataRate, onProgramDataRateChange,
-            isPlaying, playBackIndex, handleChangeIsPlaying, handleChangeOfProgramMode, programMode} = this.props;
+            isPlaying, playBackIndex, handleChangeIsPlaying, handleChangeOfProgramMode, programMode } = this.props;
 
     const editorClassForDisplayState = "full";
     const editorClass = `editor ${editorClassForDisplayState}`;
@@ -298,7 +298,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
       // Work around for cleaning up React components created
       // by the react-render-plugin. The other part of this is
       // in `destroyEditor`.
-      this.programEditor.on("rendercontrol", ({el, control}) => {
+      this.programEditor.on("rendercontrol", ({ el, control }) => {
         const extControl = control as any;
         if (!extControl.render || extControl.render === "react") {
           this.reactElements.push(el);
@@ -519,12 +519,12 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
   private keepNodesInView = () => {
     const margin = 5;
     let { k } = this.programEditor.view.area.transform;
-    const { container: { clientWidth, clientHeight }, area: { transform }} = this.programEditor.view;
+    const { container: { clientWidth, clientHeight }, area: { transform } } = this.programEditor.view;
 
     // If we're at zero scale but have any window to fill,
     // give a little scale so we can tell the program's proportions with a valid rect
     if (k === 0 && clientWidth > 0 && clientHeight > 0) {
-      this.programEditor.view.area.transform = {k: .01, x: transform.x, y: transform.y};
+      this.programEditor.view.area.transform = { k: .01, x: transform.x, y: transform.y };
       this.programEditor.view.area.update();
       k = this.programEditor.view.area.transform.k;
     }
@@ -540,13 +540,13 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
       const tooBig = newZoom < k && rect.right > 0 && newZoom > 0;
 
       if (tooSmall) {
-        this.programEditor.view.area.transform = {k: .9, x: transform.x, y: transform.y};
+        this.programEditor.view.area.transform = { k: .9, x: transform.x, y: transform.y };
         this.programEditor.view.area.update();
         return;
       }
 
       if (tooBig) {
-        this.programEditor.view.area.transform = {k: newZoom, x: transform.x, y: transform.y};
+        this.programEditor.view.area.transform = { k: newZoom, x: transform.x, y: transform.y };
         this.programEditor.view.area.update();
       }
     }
@@ -636,7 +636,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
 
     const dataSet = tileModel.dataSet;
     const now = Date.now();
-    this.setState({lastIntervalDuration: now - this.lastIntervalTime});
+    this.setState({ lastIntervalDuration: now - this.lastIntervalTime });
     this.lastIntervalTime = now;
 
     switch (programMode){
@@ -731,7 +731,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
 
   private setZoom = (zoom: number) => {
     const currentTransform = this.programEditor.view.area.transform;
-    this.programEditor.view.area.transform = {k: zoom, x: currentTransform.x, y: currentTransform.y};
+    this.programEditor.view.area.transform = { k: zoom, x: currentTransform.x, y: currentTransform.y };
     this.programEditor.view.area.update();
     const { transform } = this.programEditor.view.area;
     this.props.onZoomChange(transform.x, transform.y, transform.k);

--- a/src/plugins/dataflow/components/dataflow-tile.tsx
+++ b/src/plugins/dataflow/components/dataflow-tile.tsx
@@ -126,19 +126,19 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IDatafl
   }
 
   private handleBeginEditTitle = () => {
-    this.setState({isEditingTitle: true});
+    this.setState({ isEditingTitle: true });
   };
 
   private handleTitleChange = (title?: string) => {
     if (title){
       this.props.model.setTitle(title);
       dataflowLogEvent("changeprogramtitle", { programTitleValue: this.getTitle() }, this.props.model.id);
-      this.setState({isEditingTitle: false});
+      this.setState({ isEditingTitle: false });
     }
   };
 
   private renderTitle() {
-    const size = {width: null, height: null};
+    const size = { width: null, height: null };
     const { readOnly, scale } = this.props;
     return (
       <EditableTileTitle
@@ -207,11 +207,11 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IDatafl
     switch (programMode){
       case ProgramMode.Ready:
         tileContent.prepareRecording();
-        this.setState({isPlaying: false}); //reset isPlaying
-        this.setState({isRecording: true});
+        this.setState({ isPlaying: false }); //reset isPlaying
+        this.setState({ isRecording: true });
         break;
       case ProgramMode.Recording:
-        this.setState({isRecording: false});
+        this.setState({ isRecording: false });
         break;
       case ProgramMode.Done:
         tileContent.resetRecording();
@@ -235,7 +235,7 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IDatafl
   };
 
   private handleChangeIsPlaying = () => {
-    this.setState({isPlaying: !this.state.isPlaying});
+    this.setState({ isPlaying: !this.state.isPlaying });
   };
 
   private updatePlayBackIndex = (update: string) => {
@@ -244,13 +244,13 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IDatafl
       const tileContent = this.getContent();
       const recordedCases = tileContent.dataSet.cases.length;
       if (newPlayBackIndex >= recordedCases) {
-        this.setState({isPlaying: false});
+        this.setState({ isPlaying: false });
       } else {
-        this.setState({playBackIndex: newPlayBackIndex});
+        this.setState({ playBackIndex: newPlayBackIndex });
       }
     }
     if (update === UpdateMode.Reset){
-      this.setState({playBackIndex: 0});
+      this.setState({ playBackIndex: 0 });
     }
   };
 
@@ -258,13 +258,13 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IDatafl
     if (update === UpdateMode.Increment){
       const newRecordIndex = this.state.recordIndex + 1;
       if (newRecordIndex >= this.getContent().maxRecordableCases) {
-        this.setState({isRecording: false});
+        this.setState({ isRecording: false });
       } else {
-        this.setState({recordIndex: newRecordIndex});
+        this.setState({ recordIndex: newRecordIndex });
       }
     }
     if (update === UpdateMode.Reset){
-      this.setState({recordIndex: 0});
+      this.setState({ recordIndex: 0 });
     }
   };
   private getContent() {

--- a/src/plugins/dataflow/components/ui/dataflow-program-topbar.tsx
+++ b/src/plugins/dataflow/components/ui/dataflow-program-topbar.tsx
@@ -34,7 +34,7 @@ interface TopbarProps {
 export const DataflowProgramTopbar = (props: TopbarProps) => {
   const { onSerialRefreshDevices, readOnly, serialDevice, programDataRates, dataRate, onRateSelectClick,
           handleChangeOfProgramMode, programMode, playBackIndex, isPlaying,
-          handleChangeIsPlaying, tileContent} = props;
+          handleChangeIsPlaying, tileContent } = props;
 
   return (
     <div className="program-editor-topbar">
@@ -150,7 +150,7 @@ interface IPlaybackProps {
 }
 
 const PlaybackButton = (props: IPlaybackProps) => {
-  const {programMode, isPlaying, handleChangeIsPlaying} = props;
+  const { programMode, isPlaying, handleChangeIsPlaying } = props;
   return (
     <div className="playback-btn-container">
       <button

--- a/src/plugins/dataflow/components/ui/dataflow-serial-connect-button.tsx
+++ b/src/plugins/dataflow/components/ui/dataflow-serial-connect-button.tsx
@@ -21,8 +21,8 @@ export const DataflowSerialConnectButton = (props: SerialConnectProps) => {
   const lastMsg = localStorage.getItem("last-connect-message");
   const classes = classNames(
     "icon-serial",
-    { "physical-connection": lastMsg === "connect"},
-    { "no-physical-connection": lastMsg === "disconnect" && knownBoard},
+    { "physical-connection": lastMsg === "connect" },
+    { "no-physical-connection": lastMsg === "disconnect" && knownBoard },
     serialDevice.serialNodesCount > 0 ? "nodes-in-need" : "no-serial-needed",
     serialDevice.hasPort() ? "has-port" : "no-port"
   );

--- a/src/plugins/dataflow/model/dataflow-content.ts
+++ b/src/plugins/dataflow/model/dataflow-content.ts
@@ -1,6 +1,6 @@
 import { types, Instance, applySnapshot, getSnapshot, addDisposer } from "mobx-state-tree";
 import { reaction } from "mobx";
-import { cloneDeep} from "lodash";
+import { cloneDeep } from "lodash";
 import stringify from "json-stringify-pretty-compact";
 
 import { DataflowProgramModel } from "./dataflow-program-model";
@@ -198,7 +198,7 @@ export const DataflowContentModel = TileContentModel
 
         return { sharedModelManager, sharedDataSet, sharedVariables, tileSharedModels };
       },
-      ({sharedModelManager, sharedDataSet, sharedVariables, tileSharedModels}) => {
+      ({ sharedModelManager, sharedDataSet, sharedVariables, tileSharedModels }) => {
         if (!sharedModelManager?.isReady) {
           return;
         }
@@ -221,7 +221,7 @@ export const DataflowContentModel = TileContentModel
         const dataSets = sharedModelManager.getSharedModelsByType(kSharedDataSetType) as SharedDataSetType[];
         updateSharedDataSetColors(dataSets);
       },
-      {name: "sharedModelSetup", fireImmediately: true}));
+      { name: "sharedModelSetup", fireImmediately: true }));
     },
     setProgram(program: any) {
       if (program) {
@@ -283,7 +283,7 @@ export const DataflowContentModel = TileContentModel
       });
     },
     clearCases() {
-      const ids = self.dataSet.cases.map(({__id__}) => ( __id__));
+      const ids = self.dataSet.cases.map(({ __id__ }) => ( __id__));
       self.dataSet.removeCases(ids);
     },
   }))

--- a/src/plugins/dataflow/model/utilities/create-default-data-set.ts
+++ b/src/plugins/dataflow/model/utilities/create-default-data-set.ts
@@ -1,7 +1,7 @@
-import {addAttributeToDataSet, DataSet } from "../../../../models/data/data-set";
+import { addAttributeToDataSet, DataSet } from "../../../../models/data/data-set";
 
 export function createDefaultDataSet(title: string | undefined){
-  const dataSet = DataSet.create({name: title});
+  const dataSet = DataSet.create({ name: title });
   addAttributeToDataSet(dataSet, { name: "x" });
   addAttributeToDataSet(dataSet, { name: "y" });
   return dataSet;

--- a/src/plugins/dataflow/nodes/controls/demo-output-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/demo-output-control.tsx
@@ -23,7 +23,7 @@ export class DemoOutputControl extends Rete.Control {
     this.key = key;
     this.node = node;
 
-    this.component = (compProps: {value: number, percentClosed: number, percentTilt: number, type: string}) => {
+    this.component = (compProps: { value: number, percentClosed: number, percentTilt: number, type: string }) => {
       const controlClassName = classNames({
         "lightbulb-control": compProps.type === "Light Bulb" || compProps.type === "Heat Lamp",
         "advanced-grabber-control": compProps.type === "Advanced Grabber",

--- a/src/plugins/dataflow/nodes/controls/dropdown-list-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/dropdown-list-control.tsx
@@ -144,13 +144,13 @@ export class DropdownListControl extends Rete.Control {
       readonly,
       value: initial,
       onItemClick: (v: any) => {
-        this.emitter.trigger("selectnode", {node: this.getNode()});
+        this.emitter.trigger("selectnode", { node: this.getNode() });
         this.props.showList = !this.props.showList;
         (this as any).update();
         dataflowLogEvent("nodedropdownclick", this as Control, this.getNode().meta.inTileWithId as string);
       },
       onListClick: (v: any) => () => {
-        this.emitter.trigger("selectnode", {node: this.getNode()});
+        this.emitter.trigger("selectnode", { node: this.getNode() });
         this.props.showList = !this.props.showList;
         this.setValue(v);
         this.emitter.trigger("process");

--- a/src/plugins/dataflow/nodes/controls/humidifier-animation.tsx
+++ b/src/plugins/dataflow/nodes/controls/humidifier-animation.tsx
@@ -22,7 +22,7 @@ function nodeHasAnimation(nodeId: number) {
   return humidAnimations.has(nodeId);
 }
 
-export const HumidiferAnimation: React.FC<IProps> = ({nodeValue, nodeId, editor}) => {
+export const HumidiferAnimation: React.FC<IProps> = ({ nodeValue, nodeId, editor }) => {
   const priorValue = useRef<number | undefined>();
 
   editor.on("noderemoved", (node: any) => {

--- a/src/plugins/dataflow/nodes/controls/num-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/num-control.tsx
@@ -56,7 +56,7 @@ export class NumControl extends Rete.Control {
                                    label: string;
                                    currentUnits: string;
                                    units: string[] | null,
-                                   tooltip: string}) => {
+                                   tooltip: string }) => {
       const inputRef = useRef<HTMLInputElement>(null);
       useStopEventPropagation(inputRef, "pointerdown");
       return (

--- a/src/plugins/dataflow/nodes/controls/plot-button-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/plot-button-control.tsx
@@ -9,7 +9,7 @@ const handleChange = (onChange: any) => {
   return (e: any) => { onChange(e.target.value); };
 };
 
-export const PlotButtonControlComponent = (compProps: {showgraph: any; onGraphButtonClick: any; }) => (
+export const PlotButtonControlComponent = (compProps: { showgraph: any; onGraphButtonClick: any; }) => (
   <div className="node-graph-container"
        title={compProps.showgraph ? "Hide Block Value Graph" : "Show Block Value Graph"}>
     <div

--- a/src/plugins/dataflow/nodes/controls/text-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/text-control.tsx
@@ -21,7 +21,7 @@ export class TextControl extends Rete.Control {
     const handleChange = (onChange: any) => {
       return (e: any) => { onChange(e.target.value); };
     };
-    this.component = (compProps: { value: any; onChange: any; label: any, color: string, tooltip: string}) => {
+    this.component = (compProps: { value: any; onChange: any; label: any, color: string, tooltip: string }) => {
       const inputRef = useRef<HTMLInputElement>(null);
       useStopEventPropagation(inputRef, "pointerdown");
       return (
@@ -38,7 +38,7 @@ export class TextControl extends Rete.Control {
             onChange={handleChange(compProps.onChange)}
           />
           {
-          compProps.color && <div className="color-dot" style={{backgroundColor: compProps.color}}/>
+          compProps.color && <div className="color-dot" style={{ backgroundColor: compProps.color }}/>
           }
         </div>
       );

--- a/src/plugins/dataflow/nodes/factories/control-rete-node-factory.tsx
+++ b/src/plugins/dataflow/nodes/factories/control-rete-node-factory.tsx
@@ -108,7 +108,7 @@ export class ControlReteNodeFactory extends DataflowReteNodeFactory {
         const nodeValue = _node.controls.get("nodeValue") as ValueControl;
         nodeValue?.setValue(result);
         nodeValue?.setSentence(resultSentence);
-        this.editor.view.updateConnections( {node: _node} );
+        this.editor.view.updateConnections( { node: _node } );
       }
     }
     outputs.num = result;

--- a/src/plugins/dataflow/nodes/factories/dataflow-rete-node-factory.tsx
+++ b/src/plugins/dataflow/nodes/factories/dataflow-rete-node-factory.tsx
@@ -24,7 +24,7 @@ export abstract class DataflowReteNodeFactory extends Rete.Component {
     // data.watchedValues determines which values the node cares about tracking
     // The key is the id of the control
     // The value is options related to the value, currently just for the minigraph
-    node.data.watchedValues = {"nodeValue": defaultMinigraphOptions};
+    node.data.watchedValues = { "nodeValue": defaultMinigraphOptions };
 
     return node;
   }

--- a/src/plugins/dataflow/nodes/factories/demo-output-rete-node-factory.tsx
+++ b/src/plugins/dataflow/nodes/factories/demo-output-rete-node-factory.tsx
@@ -87,7 +87,7 @@ export class DemoOutputReteNodeFactory extends DataflowReteNodeFactory {
         _node.data.outputType = outputType;
         demoOutput?.setOutputType(outputType);
 
-        this.editor.view.updateConnections( {node: _node} );
+        this.editor.view.updateConnections( { node: _node } );
 
         _node.update();
       }

--- a/src/plugins/dataflow/nodes/factories/live-output-rete-node-factory.tsx
+++ b/src/plugins/dataflow/nodes/factories/live-output-rete-node-factory.tsx
@@ -64,7 +64,7 @@ export class LiveOutputReteNodeFactory extends DataflowReteNodeFactory {
         nodeValue?.setConnected(inputs.nodeValue.length);
 
         _node.data.outputType = outputType;
-        this.editor.view.updateConnections( {node: _node} );
+        this.editor.view.updateConnections( { node: _node } );
         _node.update();
       }
     }

--- a/src/plugins/dataflow/nodes/factories/logic-rete-node-factory.tsx
+++ b/src/plugins/dataflow/nodes/factories/logic-rete-node-factory.tsx
@@ -64,7 +64,7 @@ export class LogicReteNodeFactory extends DataflowReteNodeFactory {
         const nodeValue = _node.controls.get("nodeValue") as ValueControl;
         nodeValue && nodeValue.setValue(result);
         nodeValue && nodeValue.setSentence(resultSentence);
-        this.editor.view.updateConnections( {node: _node} );
+        this.editor.view.updateConnections( { node: _node } );
       }
     }
 

--- a/src/plugins/dataflow/nodes/factories/math-rete-node-factory.tsx
+++ b/src/plugins/dataflow/nodes/factories/math-rete-node-factory.tsx
@@ -64,7 +64,7 @@ export class MathReteNodeFactory extends DataflowReteNodeFactory {
         const nodeValue = _node.controls.get("nodeValue") as ValueControl;
         nodeValue && nodeValue.setValue(result);
         nodeValue && nodeValue.setSentence(resultSentence);
-        this.editor.view.updateConnections( {node: _node} );
+        this.editor.view.updateConnections( { node: _node } );
       }
     }
 

--- a/src/plugins/dataflow/nodes/factories/timer-rete-node-factory.tsx
+++ b/src/plugins/dataflow/nodes/factories/timer-rete-node-factory.tsx
@@ -33,7 +33,7 @@ export class TimerReteNodeFactory extends DataflowReteNodeFactory {
       if (_node) {
         const nodeValue = _node.controls.get("nodeValue") as ValueControl;
         nodeValue && nodeValue.setSentence(+result === 0 ? "off" : "on");
-        this.editor.view.updateConnections( {node: _node} );
+        this.editor.view.updateConnections( { node: _node } );
       }
     }
   }

--- a/src/plugins/dataflow/nodes/factories/transform-rete-node-factory.tsx
+++ b/src/plugins/dataflow/nodes/factories/transform-rete-node-factory.tsx
@@ -59,7 +59,7 @@ export class TransformReteNodeFactory extends DataflowReteNodeFactory {
         const nodeValue = _node.controls.get("nodeValue") as ValueControl;
         nodeValue && nodeValue.setValue(result);
         nodeValue && nodeValue.setSentence(resultSentence);
-        this.editor.view.updateConnections( {node: _node} );
+        this.editor.view.updateConnections( { node: _node } );
       }
     }
 

--- a/src/plugins/dataflow/nodes/utilities/update-utilities.ts
+++ b/src/plugins/dataflow/nodes/utilities/update-utilities.ts
@@ -109,7 +109,7 @@ export function updateNodeRecentValues(n: Node) {
         recentValues[valueKey] = [recentValue];
       }
     } else {
-      n.data.recentValues = {[valueKey]: [recentValue]};
+      n.data.recentValues = { [valueKey]: [recentValue] };
     }
 
     if (n.data.watchedValues) {

--- a/src/plugins/diagram-viewer/diagram-content.test.ts
+++ b/src/plugins/diagram-viewer/diagram-content.test.ts
@@ -53,8 +53,8 @@ const makeSharedModelManager = (variables?: SharedVariablesType): ISharedModelMa
 const setupContainer = (content: DiagramContentModelType, variables?: SharedVariablesType) => {
   const sharedModelManager = makeSharedModelManager(variables);
   TestContainer.create(
-    {content: castToSnapshot(content), variables: castToSnapshot(variables)},
-    {sharedModelManager}
+    { content: castToSnapshot(content), variables: castToSnapshot(variables) },
+    { sharedModelManager }
   );
 
   // Need to monitor the variables just like sharedModelDocumentManager does
@@ -67,7 +67,7 @@ const setupContainer = (content: DiagramContentModelType, variables?: SharedVari
   // So far it hasn't been necessary to wait for the MobX reaction to run inside of
   // DocumentContent#afterAttach. It seems to run immediately in the line above, so
   // we can write expectations on this content without waiting.
-  return {content, sharedModelManager};
+  return { content, sharedModelManager };
 };
 
 describe("DiagramContent", () => {
@@ -78,7 +78,7 @@ describe("DiagramContent", () => {
 
   it("can export content", () => {
     const content = createDiagramContent();
-    const expected = JSON.stringify({nodes: {}});
+    const expected = JSON.stringify({ nodes: {} });
     expect(content.exportJson()).toEqual(expected);
   });
 
@@ -106,7 +106,7 @@ describe("DiagramContent", () => {
     expect(content.root.nodes.size).toBe(0);
     expect(content.sharedModel?.variables.length).toBe(0);
 
-    content.root.createNode({x: 1, y: 1});
+    content.root.createNode({ x: 1, y: 1 });
     expect(content.root.nodes.size).toBe(1);
     const newNode = Array.from(content.root.nodes.values())[0];
     assertIsDefined(newNode);
@@ -187,8 +187,8 @@ describe("DiagramContent", () => {
     const sharedModelManager = makeSharedModelManager();
     const addTileSharedModelSpy = jest.spyOn(sharedModelManager, "addTileSharedModel");
     TestContainer.create(
-      {content: castToSnapshot(content)},
-      {sharedModelManager}
+      { content: castToSnapshot(content) },
+      { sharedModelManager }
     );
 
     expect(addTileSharedModelSpy).toHaveBeenCalled();

--- a/src/plugins/diagram-viewer/diagram-content.ts
+++ b/src/plugins/diagram-viewer/diagram-content.ts
@@ -42,7 +42,7 @@ export const DiagramContentModel = TileContentModel
       // In the future this can look at all of the existing nodes and find an empty spot.
       // For now just return 100, 100
       // TODO: this should be moved into DQRoot
-      return {x: 100, y: 100};
+      return { x: 100, y: 100 };
     },
     get variables() {
       return self.root?.variables || [];
@@ -61,10 +61,10 @@ export const DiagramContentModel = TileContentModel
         const tileSharedModels = sharedModelManager?.isReady ?
           sharedModelManager?.getTileSharedModels(self) : undefined;
 
-        const values = {sharedModelManager, containerSharedModel, tileSharedModels};
+        const values = { sharedModelManager, containerSharedModel, tileSharedModels };
         return values;
       },
-      ({sharedModelManager, containerSharedModel, tileSharedModels}) => {
+      ({ sharedModelManager, containerSharedModel, tileSharedModels }) => {
         if (!sharedModelManager?.isReady) {
           // We aren't added to a document yet so we can't do anything yet
           return;
@@ -100,7 +100,7 @@ export const DiagramContentModel = TileContentModel
         // a document from storage.
         self.root.setVariablesAPI(containerSharedModel);
       },
-      {name: "sharedModelSetup", fireImmediately: true}));
+      { name: "sharedModelSetup", fireImmediately: true }));
     }
   }))
   .actions(self => ({

--- a/src/plugins/diagram-viewer/diagram-migrator.test.ts
+++ b/src/plugins/diagram-viewer/diagram-migrator.test.ts
@@ -54,7 +54,7 @@ describe("DiagramMigrator", () => {
 
   it("blanks out any kind of state without a version", () => {
     jestSpyConsole("warn", mockConsole => {
-      const migrated = DiagramMigrator.create({foo: "bar"});
+      const migrated = DiagramMigrator.create({ foo: "bar" });
       expect(mockConsole).toHaveBeenCalled();
       expect(migrated.root?.nodes.size).toBe(0);
     });

--- a/src/plugins/diagram-viewer/diagram-tile.tsx
+++ b/src/plugins/diagram-viewer/diagram-tile.tsx
@@ -74,7 +74,7 @@ export const DiagramToolComponent: React.FC<ITileProps> = observer((
 
     const offset = 25;
     variablesToInsert.forEach(variable => {
-      content.root.insertNode(variable, {x, y});
+      content.root.insertNode(variable, { x, y });
       x += offset;
       y += offset;
       content.root.setSelectedNode(content.root.getNodeFromVariableId(variable.id));
@@ -114,7 +114,7 @@ export const DiagramToolComponent: React.FC<ITileProps> = observer((
         const pointerEvent = event.activatorEvent as PointerEvent;
         const clientX = pointerEvent.clientX + event.delta.x;
         const clientY = pointerEvent.clientY + event.delta.y;
-        const position = diagramHelper?.convertClientToDiagramPosition({x: clientX, y: clientY});
+        const position = diagramHelper?.convertClientToDiagramPosition({ x: clientX, y: clientY });
         const { x, y } = position;
 
         const variable = Variable.create({});

--- a/src/plugins/diagram-viewer/diagram-toolbar.tsx
+++ b/src/plugins/diagram-viewer/diagram-toolbar.tsx
@@ -104,7 +104,7 @@ interface IEditVariableButton {
 const EditVariableButton = ({ handleClick, selectedVariable }: IEditVariableButton) => {
   return (
     <SvgToolbarButton SvgIcon={VariableEditorIcon} buttonClass="button-edit-variable" disabled={!selectedVariable}
-      title="Edit Variable" onClick={handleClick} style={{fill: "#000000", strokeWidth: 0.1}} />
+      title="Edit Variable" onClick={handleClick} style={{ fill: "#000000", strokeWidth: 0.1 }} />
   );
 };
 

--- a/src/plugins/drawing/components/drawing-layer-legacy.test.tsx
+++ b/src/plugins/drawing/components/drawing-layer-legacy.test.tsx
@@ -20,7 +20,7 @@ let content, drawingLayerProps, drawingLayer;
 
 const getDrawingObject = (objectContent: DrawingContentModelType) => {
   drawingLayerProps = {
-    model: TileModel.create({content: objectContent}),
+    model: TileModel.create({ content: objectContent }),
     onSetCanAcceptDrop: (tileId?: string) => {
       throw new Error("Function not implemented.");
     }
@@ -43,25 +43,25 @@ describe("Drawing Layer Components", () => {
     };
 
     it("adds a freehand line", () => {
-      content = DrawingMigrator.create({changes:[
-        JSON.stringify({action: "create", data: lineData})
-      ]});
+      content = DrawingMigrator.create({ changes:[
+        JSON.stringify({ action: "create", data: lineData })
+      ] });
       expect(getDrawingObject(content)).toMatchSnapshot();
     });
     it("moves a freehand line", () => {
-      const moves: DrawingToolMove = [{ id: "123", destination: {x: 5, y: 5} }];
-      content = DrawingMigrator.create({changes:[
-        JSON.stringify({action: "create", data: lineData}),
-        JSON.stringify({action: "move", data: moves})
-      ]});
+      const moves: DrawingToolMove = [{ id: "123", destination: { x: 5, y: 5 } }];
+      content = DrawingMigrator.create({ changes:[
+        JSON.stringify({ action: "create", data: lineData }),
+        JSON.stringify({ action: "move", data: moves })
+      ] });
       expect(getDrawingObject(content)).toMatchSnapshot();
     });
     it("deletes a freehand line", () => {
       const deleteObject: DrawingToolDeletion = [ "123" ];
-      content = DrawingMigrator.create({changes:[
-        JSON.stringify({action: "create", data: lineData}),
-        JSON.stringify({action: "delete", data: deleteObject})
-      ]});
+      content = DrawingMigrator.create({ changes:[
+        JSON.stringify({ action: "create", data: lineData }),
+        JSON.stringify({ action: "delete", data: deleteObject })
+      ] });
       expect(getDrawingObject(content)).toMatchSnapshot();
     });
   });
@@ -77,25 +77,25 @@ describe("Drawing Layer Components", () => {
       strokeWidth: 1
     };
     it("adds a Vector line", () => {
-      content = DrawingMigrator.create({changes:[
-        JSON.stringify({action: "create", data: vectorData})
-      ]});
+      content = DrawingMigrator.create({ changes:[
+        JSON.stringify({ action: "create", data: vectorData })
+      ] });
       expect(getDrawingObject(content)).toMatchSnapshot();
     });
     it("moves a vector line", () => {
-      const moves: DrawingToolMove = [{ id: "234", destination: {x: 5, y: 5} }];
-      content = DrawingMigrator.create({changes:[
-        JSON.stringify({action: "create", data: vectorData}),
-        JSON.stringify({action: "move", data: moves})
-      ]});
+      const moves: DrawingToolMove = [{ id: "234", destination: { x: 5, y: 5 } }];
+      content = DrawingMigrator.create({ changes:[
+        JSON.stringify({ action: "create", data: vectorData }),
+        JSON.stringify({ action: "move", data: moves })
+      ] });
       expect(getDrawingObject(content)).toMatchSnapshot();
     });
     it("deletes a vector line", () => {
       const deleteObject: DrawingToolDeletion = [ "234" ];
-      content = DrawingMigrator.create({changes:[
-        JSON.stringify({action: "create", data: vectorData}),
-        JSON.stringify({action: "delete", data: deleteObject})
-      ]});
+      content = DrawingMigrator.create({ changes:[
+        JSON.stringify({ action: "create", data: vectorData }),
+        JSON.stringify({ action: "delete", data: deleteObject })
+      ] });
       expect(getDrawingObject(content)).toMatchSnapshot();
     });
   });
@@ -112,25 +112,25 @@ describe("Drawing Layer Components", () => {
       strokeWidth: 1
     };
     it("adds a Rectangle", () => {
-      content = DrawingMigrator.create({changes:[
-        JSON.stringify({action: "create", data: rectData})
-      ]});
+      content = DrawingMigrator.create({ changes:[
+        JSON.stringify({ action: "create", data: rectData })
+      ] });
       expect(getDrawingObject(content)).toMatchSnapshot();
     });
     it("moves a rectangle", () => {
-      const moves: DrawingToolMove = [{ id: "345", destination: {x: 5, y: 5} }];
-      content = DrawingMigrator.create({changes:[
-        JSON.stringify({action: "create", data: rectData}),
-        JSON.stringify({action: "move", data: moves})
-      ]});
+      const moves: DrawingToolMove = [{ id: "345", destination: { x: 5, y: 5 } }];
+      content = DrawingMigrator.create({ changes:[
+        JSON.stringify({ action: "create", data: rectData }),
+        JSON.stringify({ action: "move", data: moves })
+      ] });
       expect(getDrawingObject(content)).toMatchSnapshot();
     });
     it("deletes a rectangle", () => {
       const deleteObject: DrawingToolDeletion = [ "345" ];
-      content = DrawingMigrator.create({changes:[
-        JSON.stringify({action: "create", data: rectData}),
-        JSON.stringify({action: "delete", data: deleteObject})
-      ]});
+      content = DrawingMigrator.create({ changes:[
+        JSON.stringify({ action: "create", data: rectData }),
+        JSON.stringify({ action: "delete", data: deleteObject })
+      ] });
       expect(getDrawingObject(content)).toMatchSnapshot();
     });
   });
@@ -147,25 +147,25 @@ describe("Drawing Layer Components", () => {
       strokeWidth: 1
     };
     it("adds a ellipse", () => {
-      content = DrawingMigrator.create({changes:[
-        JSON.stringify({action: "create", data: ellipseData})
-      ]});
+      content = DrawingMigrator.create({ changes:[
+        JSON.stringify({ action: "create", data: ellipseData })
+      ] });
       expect(getDrawingObject(content)).toMatchSnapshot();
     });
     it("moves a ellipse", () => {
-      const moves: DrawingToolMove = [{ id: "456", destination: {x: 5, y: 5} }];
-      content = DrawingMigrator.create({changes:[
-        JSON.stringify({action: "create", data: ellipseData}),
-        JSON.stringify({action: "move", data: moves})
-      ]});
+      const moves: DrawingToolMove = [{ id: "456", destination: { x: 5, y: 5 } }];
+      content = DrawingMigrator.create({ changes:[
+        JSON.stringify({ action: "create", data: ellipseData }),
+        JSON.stringify({ action: "move", data: moves })
+      ] });
       expect(getDrawingObject(content)).toMatchSnapshot();
     });
     it("deletes a ellipse", () => {
       const deleteObject: DrawingToolDeletion = [ "456" ];
-      content = DrawingMigrator.create({changes:[
-        JSON.stringify({action: "create", data: ellipseData}),
-        JSON.stringify({action: "delete", data: deleteObject})
-      ]});
+      content = DrawingMigrator.create({ changes:[
+        JSON.stringify({ action: "create", data: ellipseData }),
+        JSON.stringify({ action: "delete", data: deleteObject })
+      ] });
       expect(getDrawingObject(content)).toMatchSnapshot();
     });
   });
@@ -196,25 +196,25 @@ describe("Drawing Layer Components", () => {
       jest.spyOn(gImageMap, "getImageEntry").mockImplementation(() => imageMapEntry);
     });
     it("adds an image", () => {
-      content = DrawingMigrator.create({changes:[
-        JSON.stringify({action: "create", data: imageData})
-      ]});
+      content = DrawingMigrator.create({ changes:[
+        JSON.stringify({ action: "create", data: imageData })
+      ] });
       expect(getDrawingObject(content)).toMatchSnapshot();
     });
     it("moves a image", () => {
-      const moves: DrawingToolMove = [{ id: "567", destination: {x: 5, y: 5} }];
-      content = DrawingMigrator.create({changes:[
-        JSON.stringify({action: "create", data: imageData}),
-        JSON.stringify({action: "move", data: moves})
-      ]});
+      const moves: DrawingToolMove = [{ id: "567", destination: { x: 5, y: 5 } }];
+      content = DrawingMigrator.create({ changes:[
+        JSON.stringify({ action: "create", data: imageData }),
+        JSON.stringify({ action: "move", data: moves })
+      ] });
       expect(getDrawingObject(content)).toMatchSnapshot();
     });
     it("deletes a image", () => {
       const deleteObject: DrawingToolDeletion = [ "567" ];
-      content = DrawingMigrator.create({changes:[
-        JSON.stringify({action: "create", data: imageData}),
-        JSON.stringify({action: "delete", data: deleteObject})
-      ]});
+      content = DrawingMigrator.create({ changes:[
+        JSON.stringify({ action: "create", data: imageData }),
+        JSON.stringify({ action: "delete", data: deleteObject })
+      ] });
       expect(getDrawingObject(content)).toMatchSnapshot();
     });
   });

--- a/src/plugins/drawing/components/drawing-layer.test.tsx
+++ b/src/plugins/drawing/components/drawing-layer.test.tsx
@@ -20,7 +20,7 @@ const kLocalImageUrl = "assets/logo_tw.png";
 
 const getDrawingObject = (objectContent: DrawingContentModelType) => {
   drawingLayerProps = {
-    model: TileModel.create({content: objectContent}),
+    model: TileModel.create({ content: objectContent }),
     onSetCanAcceptDrop: (tileId?: string) => {
       throw new Error("Function not implemented.");
     }

--- a/src/plugins/drawing/components/drawing-layer.tsx
+++ b/src/plugins/drawing/components/drawing-layer.tsx
@@ -10,7 +10,7 @@ import { gImageMap } from "../../../models/image-map";
 import { SelectionBox } from "./selection-box";
 import { DrawingObjectSnapshotForAdd, DrawingObjectType, DrawingTool,
   HandleObjectHover,
-  IDrawingLayer} from "../objects/drawing-object";
+  IDrawingLayer } from "../objects/drawing-object";
 import { Point, ToolbarSettings } from "../model/drawing-basic-types";
 import { getDrawingToolInfos, renderDrawingObject } from "./drawing-object-manager";
 import { ImageObject } from "../objects/image";
@@ -131,7 +131,7 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
 
   public handleObjectHover: HandleObjectHover = (e, obj, hovering) => {
     if (!this.props.readOnly && this.getCurrentTool() === this.tools.select) {
-      this.setState({hoverObject: hovering ? obj : null});
+      this.setState({ hoverObject: hovering ? obj : null });
     }
   };
 
@@ -142,7 +142,7 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
     if (this.props.readOnly || !this.getContent().isSelectedButton('select')) return;
 
     let moved = false;
-    const {hoverObject } = this.state;
+    const { hoverObject } = this.state;
     const selectedObjects = this.getSelectedObjects();
     let objectsToSelect: DrawingObjectType[];
     let objectsToMove: DrawingObjectType[];
@@ -219,19 +219,19 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
   };
 
   public startSelectionBox(p: Point) {
-    this.setState({selectionBox: new SelectionBox(p)});
+    this.setState({ selectionBox: new SelectionBox(p) });
   }
 
   public updateSelectionBox(p: Point) {
-    const {selectionBox} = this.state;
+    const { selectionBox } = this.state;
     if (selectionBox) {
       selectionBox.update(p);
-      this.setState({selectionBox});
+      this.setState({ selectionBox });
     }
   }
 
   public endSelectionBox(addToSelectedObjects: boolean) {
-    const {selectionBox} = this.state;
+    const { selectionBox } = this.state;
     if (selectionBox) {
       selectionBox.close();
       const selectedIds: string[] = addToSelectedObjects ? [...this.getContent().selection] : [];
@@ -243,7 +243,7 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
         }
       });
       this.getContent().setSelectedIds(selectedIds);
-      this.setState({selectionBox: null});
+      this.setState({ selectionBox: null });
     }
   }
 
@@ -272,7 +272,7 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
 
   public renderSelectionBorders(selectedObjects: DrawingObjectType[], enableActions: boolean) {
     return selectedObjects.map((object, index) => {
-      let {nw: {x: nwX, y: nwY}, se: {x: seX, y: seY}} = object.boundingBox;
+      let { nw: { x: nwX, y: nwY }, se: { x: seX, y: seY } } = object.boundingBox;
       nwX -= SELECTION_BOX_PADDING;
       nwY -= SELECTION_BOX_PADDING;
       seX += SELECTION_BOX_PADDING;
@@ -374,7 +374,7 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
   //we want to populate our objectsBeingDragged state array
 
   public setCurrentDrawingObject(object: DrawingObjectType | null) {
-    this.setState({currentDrawingObject: object});
+    this.setState({ currentDrawingObject: object });
   }
 
   public getWorkspacePoint = (e: MouseEvent|React.MouseEvent<any>): Point|null => {
@@ -503,7 +503,7 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
   }
 
   private forEachObject(callback: (object: DrawingObjectType, key?: string) => void) {
-    const {objects} = this.getContent();
+    const { objects } = this.getContent();
     objects.forEach((object) => {
       if (object) {
         callback(object, object.id);

--- a/src/plugins/drawing/components/drawing-object-manager.tsx
+++ b/src/plugins/drawing/components/drawing-object-manager.tsx
@@ -7,7 +7,7 @@ import { EllipseComponent, EllipseDrawingTool, EllipseObject, EllipseToolbarButt
 import { ImageComponent, ImageObject, StampDrawingTool, StampToolbarButton } from "../objects/image";
 import { LineComponent, LineDrawingTool, LineObject, LineToolbarButton } from "../objects/line";
 import { RectangleComponent, RectangleDrawingTool, RectangleObject,
-  RectangleToolbarButton} from "../objects/rectangle";
+  RectangleToolbarButton } from "../objects/rectangle";
 import { VectorComponent, VectorDrawingTool, VectorObject, VectorToolbarButton } from "../objects/vector";
 import { DeleteButton, DuplicateButton, SelectToolbarButton } from "./drawing-toolbar-buttons";
 import { SelectionDrawingTool } from "./selection-drawing-tool";

--- a/src/plugins/drawing/components/drawing-tile.test.tsx
+++ b/src/plugins/drawing/components/drawing-tile.test.tsx
@@ -83,7 +83,7 @@ describe("DrawingToolComponent", () => {
   const stores = specStores();
 
   const content = createDrawingContent();
-  const model = TileModel.create({content});
+  const model = TileModel.create({ content });
   model.setTitle('A Title for Testing');
   render(<div className="document-content" data-testid="document-content"/>);
   const documentContent = screen.getByTestId("document-content");
@@ -126,7 +126,7 @@ describe("DrawingToolComponent", () => {
     render(
       <ModalProvider>
         <Provider stores={stores}>
-          <DrawingToolComponent {...defaultProps} {...{model}} />
+          <DrawingToolComponent {...defaultProps} {...{ model }} />
         </Provider>
       </ModalProvider>
     );
@@ -140,7 +140,7 @@ describe("DrawingToolComponent", () => {
     render(
       <ModalProvider>
         <Provider stores={stores}>
-          <DrawingToolComponent {...defaultProps} {...{model}} />
+          <DrawingToolComponent {...defaultProps} {...{ model }} />
         </Provider>
       </ModalProvider>
     );
@@ -160,7 +160,7 @@ describe("DrawingToolComponent", () => {
     render(
       <ModalProvider>
         <Provider stores={stores}>
-          <DrawingToolComponent {...defaultProps} {...{model}} />
+          <DrawingToolComponent {...defaultProps} {...{ model }} />
         </Provider>
       </ModalProvider>
     );
@@ -175,7 +175,7 @@ describe("DrawingToolComponent", () => {
     render(
       <ModalProvider>
         <Provider stores={stores}>
-          <DrawingToolComponent {...defaultProps} {...{model}} />
+          <DrawingToolComponent {...defaultProps} {...{ model }} />
         </Provider>
       </ModalProvider>
     );

--- a/src/plugins/drawing/components/drawing-toolbar-buttons.tsx
+++ b/src/plugins/drawing/components/drawing-toolbar-buttons.tsx
@@ -97,7 +97,7 @@ export const SvgToolModeButton: React.FC<ISvgToolModeButtonProps> = observer(fun
     selected={selected} settings={_settings} {...others} />;
 });
 
-export const SelectToolbarButton: React.FC<IToolbarButtonProps> = ({toolbarManager}) => {
+export const SelectToolbarButton: React.FC<IToolbarButtonProps> = ({ toolbarManager }) => {
   return <SvgToolModeButton modalButton="select" title="Select"
     toolbarManager={toolbarManager} SvgIcon={SelectToolIcon} settings={{}}/>;
 };

--- a/src/plugins/drawing/components/drawing-toolbar.tsx
+++ b/src/plugins/drawing/components/drawing-toolbar.tsx
@@ -1,7 +1,7 @@
 import classNames from "classnames";
 import React, { useCallback, useState } from "react";
 import ReactDOM from "react-dom";
-import { FillColorButton, StrokeColorButton} from "./drawing-toolbar-buttons";
+import { FillColorButton, StrokeColorButton } from "./drawing-toolbar-buttons";
 import { StampsPalette } from "./stamps-palette";
 import { StrokeColorPalette } from "./stroke-color-palette";
 import { FillColorPalette } from "./fill-color-palette";
@@ -124,7 +124,7 @@ export const ToolbarView: React.FC<IProps> = (
         return <ImageUploadButton
           key="upload-image"
           onUploadImageFile={file => uploadImage(file)}
-          tooltipOffset={{x: 0, y: 0}}
+          tooltipOffset={{ x: 0, y: 0 }}
           extraClasses="drawing-tool-button"
         />;
     }

--- a/src/plugins/drawing/components/object-list-view.tsx
+++ b/src/plugins/drawing/components/object-list-view.tsx
@@ -8,7 +8,7 @@ import {
   verticalListSortingStrategy,
   sortableKeyboardCoordinates
 } from '@dnd-kit/sortable';
-import {CSS} from '@dnd-kit/utilities';
+import { CSS } from '@dnd-kit/utilities';
 import { restrictToParentElement, restrictToVerticalAxis } from "@dnd-kit/modifiers";
 import { DrawingContentModelType } from "../model/drawing-content";
 import { DrawingObjectType } from "../objects/drawing-object";
@@ -25,7 +25,7 @@ interface IObjectListViewProps {
   setHoverObject: (value: string|null) => void
 }
 
-export const ObjectListView = observer(function ObjectListView({model, setHoverObject}: IObjectListViewProps) {
+export const ObjectListView = observer(function ObjectListView({ model, setHoverObject }: IObjectListViewProps) {
 
   const [open, setOpen] = useState(false);
   const sensors = useSensors(
@@ -48,7 +48,7 @@ export const ObjectListView = observer(function ObjectListView({model, setHoverO
   }
 
   function handleDragEnd(event: DragEndEvent) {
-    const {active, over} = event;
+    const { active, over } = event;
     if (over && active.id !== over.id) {
       const content = getContent();
       content.changeZOrder(active.id as string, over.id as string);
@@ -110,7 +110,7 @@ interface IObjectLineProps {
   setHoverObject: (id: string|null) => void
 }
 
-const ObjectLine = observer(function ObjectLine({object, content, selection, setHoverObject}: IObjectLineProps) {
+const ObjectLine = observer(function ObjectLine({ object, content, selection, setHoverObject }: IObjectLineProps) {
 
   const {
     attributes,
@@ -120,7 +120,7 @@ const ObjectLine = observer(function ObjectLine({object, content, selection, set
     transition,
     active,
     isDragging
-  } = useSortable({id: object.id});
+  } = useSortable({ id: object.id });
 
   function handleHoverIn() {
     if (active) return; // avoid flashes of highlight while dragging

--- a/src/plugins/drawing/components/selection-box.tsx
+++ b/src/plugins/drawing/components/selection-box.tsx
@@ -16,7 +16,7 @@ export class SelectionBox {
   }
 
   public render() {
-    const {nw, se} = this;
+    const { nw, se } = this;
     return <rect
       x={nw.x}
       y={nw.y}
@@ -30,12 +30,12 @@ export class SelectionBox {
   }
 
   public contains(p: Point): boolean {
-    const {nw, se} = this;
+    const { nw, se } = this;
     return (p.x >= nw.x) && (p.y >= nw.y) && (p.x <= se.x) && (p.y <= se.y);
   }
 
   public overlaps(nw2: Point, se2: Point) {
-    const {nw, se} = this;
+    const { nw, se } = this;
     return  ((nw.x < se2.x) && (se.x > nw2.x) && (nw.y < se2.y) && (se.y > nw2.y));
   }
 
@@ -53,7 +53,7 @@ export class SelectionBox {
     const minY = Math.min(this.start.y, this.end.y);
     const maxX = Math.max(this.start.x, this.end.x);
     const maxY = Math.max(this.start.y, this.end.y);
-    this.nw = {x: minX, y: minY};
-    this.se = {x: maxX, y: maxY};
+    this.nw = { x: minX, y: minY };
+    this.se = { x: maxX, y: maxY };
   }
 }

--- a/src/plugins/drawing/components/wrapped-svg-text.tsx
+++ b/src/plugins/drawing/components/wrapped-svg-text.tsx
@@ -15,7 +15,7 @@ interface ISvgTextProps {
 // Creates an SVG <text> element of the given dimentions, 
 // with the requested text broken up into lines that fit within the given width
 // Very long words will not be broken, and may extend past the width bound.
-export const WrappedSvgText = function({text, x, y, width, height, style}: ISvgTextProps) {
+export const WrappedSvgText = function({ text, x, y, width, height, style }: ISvgTextProps) {
     const [completedLines, setCompletedLines] = useState<string[]>([]);
     const [lineHeight, setLineHeight] = useState<number>(0);
     const textRef = useRef<SVGTextElement>(null);

--- a/src/plugins/drawing/model/drawing-change-playback.test.ts
+++ b/src/plugins/drawing/model/drawing-change-playback.test.ts
@@ -58,7 +58,7 @@ describe("playbackChanges", () => {
       { action: "create", data: v1Data },
       { action: "create", data: v2Data },
       { action: "move", data: [{ id: "v1", destination: { x: 5, y: 5 } }] },
-      { action: "update", data: { ids: ["v2"], update: { prop: "strokeWidth", newValue: 2 } }}
+      { action: "update", data: { ids: ["v2"], update: { prop: "strokeWidth", newValue: 2 } } }
     ];
     const v1DataMoved = { ...v1Data, x: 5, y: 5 };
     const v2DataUpdated = { ...v2Data, strokeWidth: 2 };
@@ -68,9 +68,9 @@ describe("playbackChanges", () => {
     const changesWithDeletion: DrawingToolChange[] = [
       { action: "create", data: v1Data },
       { action: "create", data: v2Data },
-      { action: "delete", data: ["v1"]},
+      { action: "delete", data: ["v1"] },
       // TODO: verify with previous loading code
-      { action: "delete", data: ["v3"]}   // handles invalid ids
+      { action: "delete", data: ["v3"] }   // handles invalid ids
     ];
     expect(playbackObjectChanges(changesWithDeletion)).toEqual({ type: "Drawing", objects: [v2Data] });
   });
@@ -103,7 +103,7 @@ describe("playbackChanges", () => {
       { action: "create", data: l1Data },
       { action: "create", data: l2Data },
       { action: "move", data: [{ id: "l1", destination: { x: 5, y: 5 } }] },
-      { action: "update", data: { ids: ["l2"], update: { prop: "strokeWidth", newValue: 2 } }}
+      { action: "update", data: { ids: ["l2"], update: { prop: "strokeWidth", newValue: 2 } } }
     ];
     const l1DataMoved = { ...l1Data, x: 5, y: 5 };
     const l2DataUpdated = { ...l2Data, strokeWidth: 2 };
@@ -113,8 +113,8 @@ describe("playbackChanges", () => {
     const changesWithDeletion: DrawingToolChange[] = [
       { action: "create", data: l1Data },
       { action: "create", data: l2Data },
-      { action: "delete", data: ["l1"]},
-      { action: "delete", data: ["l3"]}   // handles invalid ids
+      { action: "delete", data: ["l1"] },
+      { action: "delete", data: ["l3"] }   // handles invalid ids
     ];
     expect(playbackObjectChanges(changesWithDeletion)).toEqual({ type: "Drawing", objects: [l2Data] });
   });
@@ -151,7 +151,7 @@ describe("playbackChanges", () => {
       { action: "create", data: r2Data },
       { action: "create", data: r3Data },
       { action: "move", data: [{ id: "r1", destination: { x: 5, y: 5 } }, { id: "r2", destination: { x: 5, y: 5 } }] },
-      { action: "update", data: { ids: ["r2", "r3"], update: { prop: "strokeWidth", newValue: 2 } }}
+      { action: "update", data: { ids: ["r2", "r3"], update: { prop: "strokeWidth", newValue: 2 } } }
     ];
     const r1DataMoved = { ...r1Data, x: 5, y: 5 };
     const r2DataMovedAndUpdated = { ...r2Data, x: 5, y: 5, strokeWidth: 2 };
@@ -163,7 +163,7 @@ describe("playbackChanges", () => {
       { action: "create", data: r1Data },
       { action: "create", data: r2Data },
       { action: "create", data: r3Data },
-      { action: "delete", data: ["r2", "r3", "r4"]}
+      { action: "delete", data: ["r2", "r3", "r4"] }
     ];
     expect(playbackObjectChanges(changesWithDeletion)).toEqual({ type: "Drawing", objects: [r1Data] });
   });
@@ -200,7 +200,7 @@ describe("playbackChanges", () => {
       { action: "create", data: e2Data },
       { action: "create", data: e3Data },
       { action: "move", data: [{ id: "e1", destination: { x: 5, y: 5 } }, { id: "e2", destination: { x: 5, y: 5 } }] },
-      { action: "update", data: { ids: ["e2", "e3"], update: { prop: "strokeWidth", newValue: 2 } }}
+      { action: "update", data: { ids: ["e2", "e3"], update: { prop: "strokeWidth", newValue: 2 } } }
     ];
     const e1DataMoved = { ...e1Data, x: 5, y: 5 };
     const e2DataMovedAndUpdated = { ...e2Data, x: 5, y: 5, strokeWidth: 2 };
@@ -212,7 +212,7 @@ describe("playbackChanges", () => {
       { action: "create", data: e1Data },
       { action: "create", data: e2Data },
       { action: "create", data: e3Data },
-      { action: "delete", data: ["e2", "e3", "e4"]}
+      { action: "delete", data: ["e2", "e3", "e4"] }
     ];
     expect(playbackObjectChanges(changesWithDeletion)).toEqual({ type: "Drawing", objects: [e1Data] });
   });
@@ -262,7 +262,7 @@ describe("playbackChanges", () => {
       { action: "create", data: i1Data },
       { action: "create", data: i2Data },
       { action: "create", data: i3Data },
-      { action: "delete", data: ["i2", "i4"]}
+      { action: "delete", data: ["i2", "i4"] }
     ];
     expect(playbackObjectChanges(changesWithDeletion)).toEqual({ type: "Drawing", objects: [i1Data, i3Data] });
   });

--- a/src/plugins/drawing/model/drawing-change-playback.ts
+++ b/src/plugins/drawing/model/drawing-change-playback.ts
@@ -63,7 +63,7 @@ export const playbackChanges = (changes: string[]) => {
           });
           break;
         case "update": {
-          const { ids, update: { prop, newValue }} = change.data;
+          const { ids, update: { prop, newValue } } = change.data;
           ids.forEach(_id => {
             if (_id === id) {
               applyPropertyChange(object, prop, newValue);

--- a/src/plugins/drawing/model/drawing-content.test.ts
+++ b/src/plugins/drawing/model/drawing-content.test.ts
@@ -92,7 +92,7 @@ describe("DrawingContentModel", () => {
   });
 
   it("imports the drawing tool import format", () => {
-    const { fill, stroke, strokeDashArray, strokeWidth} = mockSettings;
+    const { fill, stroke, strokeDashArray, strokeWidth } = mockSettings;
     const model = createDrawingContentWithMetadata({
       type: "Drawing", objects: [
         { type: "rectangle", x: 10, y: 10, width: 100, height: 100,
@@ -116,7 +116,7 @@ describe("DrawingContentModel", () => {
   });
 
   it("can manage the toolbar settings", () => {
-    const { fill, stroke, strokeDashArray, strokeWidth} = mockSettings;
+    const { fill, stroke, strokeDashArray, strokeWidth } = mockSettings;
     const model = createDrawingContentWithMetadata();
     const defaultSettings = {
       stroke: DefaultToolbarSettings.stroke,
@@ -137,10 +137,10 @@ describe("DrawingContentModel", () => {
 
   it("can add objects", () => {
     const model = createDrawingContentWithMetadata();
-    const rectSnapshot1: RectangleObjectSnapshotForAdd = {...baseRectangleSnapshot, id:"a", x:0, y:0};
+    const rectSnapshot1: RectangleObjectSnapshotForAdd = { ...baseRectangleSnapshot, id:"a", x:0, y:0 };
     model.addObject(rectSnapshot1);
 
-    const rectSnapshot2: RectangleObjectSnapshotForAdd = {...baseRectangleSnapshot, id:"b", x:20, y:20};
+    const rectSnapshot2: RectangleObjectSnapshotForAdd = { ...baseRectangleSnapshot, id:"b", x:20, y:20 };
     model.addObject(rectSnapshot2);
 
     const imageSnapshot: ImageObjectSnapshotForAdd = {
@@ -161,10 +161,10 @@ describe("DrawingContentModel", () => {
 
   it("can reorder objects", () => {
     const model = createDrawingContentWithMetadata();
-    model.addObject({...baseRectangleSnapshot, id:"a", x:0, y:0});
-    model.addObject({...baseRectangleSnapshot, id:"b", x:10, y:10});
-    model.addObject({...baseRectangleSnapshot, id:"c", x:20, y:20});
-    model.addObject({...baseRectangleSnapshot, id:"d", x:30, y:30});
+    model.addObject({ ...baseRectangleSnapshot, id:"a", x:0, y:0 });
+    model.addObject({ ...baseRectangleSnapshot, id:"b", x:10, y:10 });
+    model.addObject({ ...baseRectangleSnapshot, id:"c", x:20, y:20 });
+    model.addObject({ ...baseRectangleSnapshot, id:"d", x:30, y:30 });
     expect(model.objects.map((obj) => obj.id)).toStrictEqual(["a", "b", "c", "d"]);
 
     model.changeZOrder("a", "c");
@@ -179,10 +179,10 @@ describe("DrawingContentModel", () => {
 
     mockLogTileChangeEvent.mockReset();
 
-    const rectSnapshot1: RectangleObjectSnapshotForAdd = {...baseRectangleSnapshot, id:"a", x:0, y:0};
+    const rectSnapshot1: RectangleObjectSnapshotForAdd = { ...baseRectangleSnapshot, id:"a", x:0, y:0 };
     model.addObject(rectSnapshot1);
 
-    const rectSnapshot2: RectangleObjectSnapshotForAdd = {...baseRectangleSnapshot, id:"b", x:20, y:20};
+    const rectSnapshot2: RectangleObjectSnapshotForAdd = { ...baseRectangleSnapshot, id:"b", x:20, y:20 };
     model.addObject(rectSnapshot2);
 
     // delete does nothing if nothing is selected
@@ -240,13 +240,13 @@ describe("DrawingContentModel", () => {
       });
     expect(mockLogTileChangeEvent).toHaveBeenNthCalledWith(3,
       LogEventName.DRAWING_TOOL_CHANGE,
-      { operation: "deleteObjects", change: { args: [ [] ], path: ""}, tileId: "drawing-1" });
+      { operation: "deleteObjects", change: { args: [ [] ], path: "" }, tileId: "drawing-1" });
     expect(mockLogTileChangeEvent).toHaveBeenNthCalledWith(4,
       LogEventName.DRAWING_TOOL_CHANGE,
-      { operation: "setSelectedIds", change: { args: [ ["a", "b"] ], path: ""}, tileId: "drawing-1" });
+      { operation: "setSelectedIds", change: { args: [ ["a", "b"] ], path: "" }, tileId: "drawing-1" });
     expect(mockLogTileChangeEvent).toHaveBeenNthCalledWith(5,
       LogEventName.DRAWING_TOOL_CHANGE,
-      { operation: "deleteObjects", change: { args: [ ["a", "b"] ], path: ""}, tileId: "drawing-1" });
+      { operation: "deleteObjects", change: { args: [ ["a", "b"] ], path: "" }, tileId: "drawing-1" });
     expect(mockLogTileChangeEvent).toHaveBeenCalledTimes(5);
   });
 
@@ -254,10 +254,10 @@ describe("DrawingContentModel", () => {
     const model = createDrawingContentWithMetadata();
     expect(model.currentStamp).toBeNull();
 
-    const rectSnapshot1: RectangleObjectSnapshotForAdd = {...baseRectangleSnapshot, id:"a", x:0, y:0};
+    const rectSnapshot1: RectangleObjectSnapshotForAdd = { ...baseRectangleSnapshot, id:"a", x:0, y:0 };
     model.addObject(rectSnapshot1);
 
-    const rectSnapshot2: RectangleObjectSnapshotForAdd = {...baseRectangleSnapshot, id:"b", x:10, y:10};
+    const rectSnapshot2: RectangleObjectSnapshotForAdd = { ...baseRectangleSnapshot, id:"b", x:10, y:10 };
     model.addObject(rectSnapshot2);
 
     mockLogTileChangeEvent.mockReset();
@@ -295,22 +295,22 @@ describe("DrawingContentModel", () => {
   it("can move objects", () => {
     const model = createDrawingContentWithMetadata();
 
-    const rectSnapshot1: RectangleObjectSnapshotForAdd = {...baseRectangleSnapshot, id:"a", x:0, y:0};
+    const rectSnapshot1: RectangleObjectSnapshotForAdd = { ...baseRectangleSnapshot, id:"a", x:0, y:0 };
     model.addObject(rectSnapshot1);
 
-    const rectSnapshot2: RectangleObjectSnapshotForAdd = {...baseRectangleSnapshot, id:"b", x:10, y:10};
+    const rectSnapshot2: RectangleObjectSnapshotForAdd = { ...baseRectangleSnapshot, id:"b", x:10, y:10 };
     model.addObject(rectSnapshot2);
 
     mockLogTileChangeEvent.mockReset();
     model.moveObjects([
-      {id: "a", destination: {x: 20, y: 20}},
-      {id: "b", destination: {x: 30, y: 30}}
+      { id: "a", destination: { x: 20, y: 20 } },
+      { id: "b", destination: { x: 30, y: 30 } }
     ]);
     expect(mockLogTileChangeEvent).toHaveBeenNthCalledWith(1,
       LogEventName.DRAWING_TOOL_CHANGE, {
         operation: "moveObjects",
         change: {
-          args: [[{id: "a", destination: {x: 20, y: 20}}, {id: "b", destination: {x: 30, y: 30}}]],
+          args: [[{ id: "a", destination: { x: 20, y: 20 } }, { id: "b", destination: { x: 30, y: 30 } }]],
           path: ""
         },
         tileId: "drawing-1"
@@ -322,7 +322,7 @@ describe("DrawingContentModel", () => {
     mockLogTileChangeEvent.mockClear();
     const model = createDrawingContentWithMetadata();
 
-    const rectSnapshot1: RectangleObjectSnapshotForAdd = {...baseRectangleSnapshot, id:"a"};
+    const rectSnapshot1: RectangleObjectSnapshotForAdd = { ...baseRectangleSnapshot, id:"a" };
     model.addObject(rectSnapshot1);
 
     const obj = model.objectMap.a as RectangleObjectType;
@@ -496,7 +496,7 @@ describe("DrawingContentModel", () => {
       x: 0, y: 0, 
       ...mockSettings
     });
-    obj.addPoint(DeltaPoint.create({dx: 10, dy: 10})); // FIXME this point is not actually getting added.
+    obj.addPoint(DeltaPoint.create({ dx: 10, dy: 10 })); // FIXME this point is not actually getting added.
     createDrawingContentWithMetadata({
       objects: [obj]
     });
@@ -506,21 +506,21 @@ describe("DrawingContentModel", () => {
     obj.resizeObject();
     expect(obj).toHaveProperty('x', 0);
     expect(obj).toHaveProperty('y', 0);
-    expect(obj).toHaveProperty('deltaPoints', [{dx: 20, dy: 20}]);
+    expect(obj).toHaveProperty('deltaPoints', [{ dx: 20, dy: 20 }]);
 
     // drag top left smaller
     obj.setDragBounds({ top: 10, right: 0, bottom: 0, left: 10 });
     obj.resizeObject();
     expect(obj).toHaveProperty('x', 10);
     expect(obj).toHaveProperty('y', 10);
-    expect(obj).toHaveProperty('deltaPoints', [{dx: 10, dy: 10}]);
+    expect(obj).toHaveProperty('deltaPoints', [{ dx: 10, dy: 10 }]);
   });
 
   it("can copy rectangle", () => {
     mockLogTileChangeEvent.mockClear();
     const model = createDrawingContentWithMetadata();
 
-    const rectSnapshot1: RectangleObjectSnapshotForAdd = {...baseRectangleSnapshot, id:"a"};
+    const rectSnapshot1: RectangleObjectSnapshotForAdd = { ...baseRectangleSnapshot, id:"a" };
     model.addObject(rectSnapshot1);
 
     model.duplicateObjects(["a"]);
@@ -572,7 +572,7 @@ describe("DrawingContentModel", () => {
   it("can copy multiple objects", () => {
     mockLogTileChangeEvent.mockClear();
 
-    const rectSnapshot: RectangleObjectSnapshotForAdd = {...baseRectangleSnapshot, id:"a"};
+    const rectSnapshot: RectangleObjectSnapshotForAdd = { ...baseRectangleSnapshot, id:"a" };
 
     const ellipse = EllipseObject.create({
       id: "b",
@@ -686,7 +686,7 @@ describe("DrawingContentModel", () => {
 
     expect(model.objects).toHaveLength(1);
     expect(group.objects).toHaveLength(2);
-    expect(group.boundingBox).toStrictEqual({ nw: { x: 0, y: 0}, se: { x: 100, y: 100}});
+    expect(group.boundingBox).toStrictEqual({ nw: { x: 0, y: 0 }, se: { x: 100, y: 100 } });
     expect(group.objectExtents.get('r2')).toStrictEqual({ top: 0.5, right: 1, bottom: 1, left: .1 });
 
     model.ungroupGroups([groupId]);
@@ -770,7 +770,7 @@ describe("DrawingContentModel", () => {
     // Make a group with one of every type of object.
     const line = LineObject.create({
       x: 0, y: 0, 
-      deltaPoints: [{dx: 10, dy: 10}],
+      deltaPoints: [{ dx: 10, dy: 10 }],
       ...mockSettings
     });
     const vector = VectorObject.create({
@@ -789,7 +789,7 @@ describe("DrawingContentModel", () => {
       y: 35,
       rx: 5,
       ry: 5,
-    ...mockSettings});
+    ...mockSettings });
     const image = ImageObject.create({
       url: "my/image/url", x: 40, y: 40, width: 10, height: 10
     });
@@ -807,19 +807,19 @@ describe("DrawingContentModel", () => {
     expect(model.objects).toHaveLength(1);
 
     const group = model.objects[0] as GroupObjectType;
-    expect(group.boundingBox).toStrictEqual({ nw: {x: 0, y: 0}, se: {x: 60, y: 60}});
-    expect(ellipse.boundingBox).toStrictEqual({ nw: {x: 30, y: 30}, se: {x: 40, y: 40}});
+    expect(group.boundingBox).toStrictEqual({ nw: { x: 0, y: 0 }, se: { x: 60, y: 60 } });
+    expect(ellipse.boundingBox).toStrictEqual({ nw: { x: 30, y: 30 }, se: { x: 40, y: 40 } });
 
-    group.setDragBounds({ top: 0, right: 60, bottom: 60, left: 0});
+    group.setDragBounds({ top: 0, right: 60, bottom: 60, left: 0 });
     group.resizeObject();
-    expect(group.boundingBox).toStrictEqual({ nw: {x: 0, y: 0}, se: {x: 120, y: 120}});
+    expect(group.boundingBox).toStrictEqual({ nw: { x: 0, y: 0 }, se: { x: 120, y: 120 } });
 
-    expect(line.boundingBox).toStrictEqual({ nw: {x: 0, y: 0}, se: {x: 20, y: 20}});
-    expect(vector.boundingBox).toStrictEqual({ nw: {x: 20, y: 20}, se: {x: 40, y: 40}});
-    expect(rect.boundingBox).toStrictEqual({ nw: {x: 40, y: 40}, se: {x: 60, y: 60}});
-    expect(ellipse.boundingBox).toStrictEqual({ nw: {x: 60, y: 60}, se: {x: 80, y: 80}});
-    expect(image.boundingBox).toStrictEqual({ nw: {x: 80, y: 80}, se: {x: 100, y: 100}});
-    expect(text.boundingBox).toStrictEqual({ nw: {x: 100, y: 100}, se: {x: 120, y: 120}});
+    expect(line.boundingBox).toStrictEqual({ nw: { x: 0, y: 0 }, se: { x: 20, y: 20 } });
+    expect(vector.boundingBox).toStrictEqual({ nw: { x: 20, y: 20 }, se: { x: 40, y: 40 } });
+    expect(rect.boundingBox).toStrictEqual({ nw: { x: 40, y: 40 }, se: { x: 60, y: 60 } });
+    expect(ellipse.boundingBox).toStrictEqual({ nw: { x: 60, y: 60 }, se: { x: 80, y: 80 } });
+    expect(image.boundingBox).toStrictEqual({ nw: { x: 80, y: 80 }, se: { x: 100, y: 100 } });
+    expect(text.boundingBox).toStrictEqual({ nw: { x: 100, y: 100 }, se: { x: 120, y: 120 } });
 
     group.setStroke('#abcdef');
     group.setStrokeDashArray('1 2');

--- a/src/plugins/drawing/model/drawing-content.ts
+++ b/src/plugins/drawing/model/drawing-content.ts
@@ -1,4 +1,4 @@
-import { types, Instance, SnapshotIn, getSnapshot, isStateTreeNode, detach, destroy} from "mobx-state-tree";
+import { types, Instance, SnapshotIn, getSnapshot, isStateTreeNode, detach, destroy } from "mobx-state-tree";
 import { clone } from "lodash";
 import stringify from "json-stringify-pretty-compact";
 
@@ -25,7 +25,7 @@ export type DrawingToolMetadataModelType = Instance<typeof DrawingToolMetadataMo
 
 export interface DrawingObjectMove {
   id: string,
-  destination: {x: number, y: number}
+  destination: { x: number, y: number }
 }
 
 export const DrawingContentModel = TileContentModel
@@ -101,7 +101,7 @@ export const DrawingContentModel = TileContentModel
     },
     exportJson(options?: ITileExportOptions) {
       // Translate image urls if necessary
-      const {type, objects: originalObjects} = getSnapshot(self);
+      const { type, objects: originalObjects } = getSnapshot(self);
       const objects = originalObjects.map(object => {
         if (isImageObjectSnapshot(object) && options?.transformImageUrl) {
           if (object.filename) {
@@ -117,7 +117,7 @@ export const DrawingContentModel = TileContentModel
       // json-stringify-pretty-compact is used, so the exported content is more
       // compact. It results in something close to what we used to get when the
       // export was created using a string builder.
-      return stringify({type, objects}, {maxLength: 200});
+      return stringify({ type, objects }, { maxLength: 200 });
     }
   }))
   .views(self => ({
@@ -131,7 +131,7 @@ export const DrawingContentModel = TileContentModel
     },
     onTileAction(call) {
       const tileId = self.metadata?.id ?? "";
-      const {name: operation, ...change} = call;
+      const { name: operation, ...change } = call;
       // Ignore actions that don't need to be logged
       if (["setDisabledFeatures", "setDragPosition", "setDragBounds", "setSelectedButton"].includes(operation)) return;
 
@@ -326,7 +326,7 @@ export const DrawingContentModel = TileContentModel
                   x: 0,
                   y: 0,
                   objects: getSnapshot(object.objects).map((s) => {
-                    const {id, ...params} = s;
+                    const { id, ...params } = s;
                     params.x += 10;
                     params.y += 10;
                     return params;
@@ -334,7 +334,7 @@ export const DrawingContentModel = TileContentModel
                 };
                 newObject = self.addObject(newGroup);
               } else {
-                const {id, ...newParams} = snap; // remove existing ID
+                const { id, ...newParams } = snap; // remove existing ID
                 newParams.x = snap.x + 10;     // offset by 10 pixels so it is not hidden
                 newParams.y = snap.y + 10;
                 newObject = self.addObject(newParams);

--- a/src/plugins/drawing/model/drawing-export.test.ts
+++ b/src/plugins/drawing/model/drawing-export.test.ts
@@ -28,7 +28,7 @@ describe("exportDrawingTileSpec", () => {
   });
 
   it("should export empty drawings", () => {
-    const drawing = createDrawingContent({ objects: []});
+    const drawing = createDrawingContent({ objects: [] });
     expect(exportDrawing2(drawing)).toEqual({ type: "Drawing", objects: [] });
   });
 
@@ -47,12 +47,12 @@ describe("exportDrawingTileSpec", () => {
     const v2Data: VectorObjectSnapshot = { ...vectorData, id: "v2" };
     const drawing = createDrawingContent({ objects: [
       v1Data, v2Data
-    ]});
+    ] });
     expect(exportDrawing2(drawing)).toEqual({ type: "Drawing", objects: [v1Data, v2Data] });
 
     const drawing2 = createDrawingContent({ objects: [
       v1Data, v2Data
-    ]});
+    ] });
     drawing2.objects[0].setPosition(5, 5);
     (drawing2.objects[1] as VectorObjectType).setStrokeWidth(2);
     const v1DataMoved = { ...v1Data, x: 5, y: 5 };
@@ -61,7 +61,7 @@ describe("exportDrawingTileSpec", () => {
 
     const drawing3 = createDrawingContent({ objects: [
       v1Data, v2Data
-    ]});
+    ] });
     drawing3.deleteObjects([drawing3.objects[0].id]);
     expect(exportDrawing2(drawing3)).toEqual({ type: "Drawing", objects: [v2Data] });
   });
@@ -81,12 +81,12 @@ describe("exportDrawingTileSpec", () => {
     const l2Data: LineObjectSnapshot = { ...lineData, id: "l2" };
     const drawing = createDrawingContent({ objects: [
       l1Data, l2Data
-    ]});
+    ] });
     expect(exportDrawing2(drawing)).toEqual({ type: "Drawing", objects: [l1Data, l2Data] });
 
     const drawing2 = createDrawingContent({ objects: [
       l1Data, l2Data
-    ]});
+    ] });
     drawing2.objects[0].setPosition(5, 5);
     (drawing2.objects[1] as LineObjectType).setStrokeWidth(2);
     const l1DataMoved = { ...l1Data, x: 5, y: 5 };
@@ -95,7 +95,7 @@ describe("exportDrawingTileSpec", () => {
 
     const drawing3 = createDrawingContent({ objects: [
       l1Data, l2Data
-    ]});
+    ] });
     drawing3.deleteObjects([drawing3.objects[0].id]);
     expect(exportDrawing2(drawing3)).toEqual({ type: "Drawing", objects: [l2Data] });
   });
@@ -117,12 +117,12 @@ describe("exportDrawingTileSpec", () => {
     const r3Data: RectangleObjectSnapshot = { ...rectData, id: "r3" };
     const drawing = createDrawingContent({ objects: [
       r1Data, r2Data, r3Data
-    ]});
+    ] });
     expect(exportDrawing2(drawing)).toEqual({ type: "Drawing", objects: [r1Data, r2Data, r3Data] });
 
     const drawing2 = createDrawingContent({ objects: [
       r1Data, r2Data, r3Data
-    ]});
+    ] });
     drawing2.objects[0].setPosition(5, 5);
     drawing2.objects[1].setPosition(5, 5);
     (drawing2.objects[1] as RectangleObjectType).setStrokeWidth(2);
@@ -135,7 +135,7 @@ describe("exportDrawingTileSpec", () => {
 
     const drawing3 = createDrawingContent({ objects: [
       r1Data, r2Data, r3Data
-    ]});
+    ] });
     drawing3.deleteObjects([drawing3.objects[1].id, drawing3.objects[2].id]);
     expect(exportDrawing2(drawing3)).toEqual({ type: "Drawing", objects: [r1Data] });
   });
@@ -156,12 +156,12 @@ describe("exportDrawingTileSpec", () => {
     const e3Data: EllipseObjectSnapshot = { ...ellipseData, id: "e3" };
     const drawing = createDrawingContent({ objects: [
       e1Data, e2Data, e3Data
-    ]});
+    ] });
     expect(exportDrawing2(drawing)).toEqual({ type: "Drawing", objects: [e1Data, e2Data, e3Data] });
 
     const drawing2 = createDrawingContent({ objects: [
       e1Data, e2Data, e3Data
-    ]});
+    ] });
     drawing2.objects[0].setPosition(5, 5);
     drawing2.objects[1].setPosition(5, 5);
     (drawing2.objects[1] as EllipseObjectType).setStrokeWidth(2);
@@ -175,7 +175,7 @@ describe("exportDrawingTileSpec", () => {
 
     const drawing3 = createDrawingContent({ objects: [
       e1Data, e2Data, e3Data
-    ]});
+    ] });
     drawing3.deleteObjects([drawing3.objects[1].id, drawing3.objects[2].id]);
     expect(exportDrawing2(drawing3)).toEqual({ type: "Drawing", objects: [e1Data] });
   });
@@ -193,12 +193,12 @@ describe("exportDrawingTileSpec", () => {
     const i3Data: ImageObjectSnapshot = { ...imageData, id: "i3" };
     const drawing = createDrawingContent({ objects: [
       i1Data, i2Data, i3Data
-    ]});
+    ] });
     expect(exportDrawing2(drawing)).toEqual({ type: "Drawing", objects: [i1Data, i2Data, i3Data] });
 
     const drawing2 = createDrawingContent({ objects: [
       i1Data, i2Data, i3Data
-    ]});
+    ] });
     drawing2.objects[0].setPosition(5, 5);
     drawing2.objects[1].setPosition(5, 5);
     const i1DataMoved = { ...i1Data, x: 5, y: 5 };
@@ -208,7 +208,7 @@ describe("exportDrawingTileSpec", () => {
 
     const drawing3 = createDrawingContent({ objects: [
       i1Data, i2Data, i3Data
-    ]});
+    ] });
     drawing3.deleteObjects([drawing3.objects[1].id]);
     expect(exportDrawing2(drawing3)).toEqual({ type: "Drawing", objects: [i1Data, i3Data] });
   });
@@ -240,7 +240,7 @@ describe("exportDrawingTileSpec", () => {
     const i3Data: ImageObjectSnapshot = { ...imageData, id: "i3" };
     const drawing = createDrawingContent({ objects: [
       i1Data, i2Data, i3Data
-    ]});
+    ] });
 
     const i1OutData = { ...exportImageData, id: "i1" };
     const i2OutData = { ...exportImageData, id: "i2" };
@@ -250,7 +250,7 @@ describe("exportDrawingTileSpec", () => {
 
     const drawing2 = createDrawingContent({ objects: [
       i1Data, i2Data, i3Data
-    ]});
+    ] });
     drawing2.objects[0].setPosition(5, 5);
     drawing2.objects[1].setPosition(5, 5);
     const i1DataMoved = { ...i1OutData, x: 5, y: 5 };
@@ -260,7 +260,7 @@ describe("exportDrawingTileSpec", () => {
 
     const drawing3 = createDrawingContent({ objects: [
       i1Data, i2Data, i3Data
-    ]});
+    ] });
     drawing3.deleteObjects([drawing3.objects[1].id]);
     expect(exportDrawingWithTransform(drawing3))
             .toEqual({ type: "Drawing", objects: [i1OutData, i3OutData] });

--- a/src/plugins/drawing/model/drawing-types.ts
+++ b/src/plugins/drawing/model/drawing-types.ts
@@ -9,7 +9,7 @@ export const kDrawingStateVersion = "1.0.0";
 export const kDrawingDefaultHeight = 180;
 
 // These types are used by legacy import code in drawing-change-playback.ts
-export type DrawingToolMove = Array<{id: string, destination: Point}>;
+export type DrawingToolMove = Array<{ id: string, destination: Point }>;
 export interface DrawingToolUpdate {
   ids: string[];
   update: {

--- a/src/plugins/drawing/objects/drawing-object.tsx
+++ b/src/plugins/drawing/objects/drawing-object.tsx
@@ -86,7 +86,7 @@ export const DrawingObject = types.model("DrawingObject", {
 }))
 .views(self => ({
   inSelection(selectionBox: SelectionBox) {
-    const {nw, se} = self.boundingBox;
+    const { nw, se } = self.boundingBox;
     return selectionBox.overlaps(nw, se);
   },
   get supportsResize() {

--- a/src/plugins/drawing/objects/ellipse.tsx
+++ b/src/plugins/drawing/objects/ellipse.tsx
@@ -19,12 +19,12 @@ export const EllipseObject = types.compose("EllipseObject", StrokedObject, Fille
   }))
   .views(self => ({
     get boundingBox() {
-      const {x, y} = self.position;
+      const { x, y } = self.position;
       const rx = self.dragRx ?? self.rx;
       const ry = self.dragRy ?? self.ry;
-      const nw: Point = {x: x - rx, y: y - ry};
-      const se: Point = {x: x + rx, y: y + ry};
-      return {nw, se};
+      const nw: Point = { x: x - rx, y: y - ry };
+      const se: Point = { x: x + rx, y: y + ry };
+      return { nw, se };
     },
     get label() {
       return (self.rx === self.ry) ? "Circle" : "Ellipse";
@@ -63,11 +63,11 @@ function isEllipseObject(model: DrawingObjectType): model is EllipseObjectType {
   return model.type === "ellipse";
 }
 
-export const EllipseComponent = observer(function EllipseComponent({model, handleHover,
-  handleDrag} : IDrawingComponentProps) {
+export const EllipseComponent = observer(function EllipseComponent({ model, handleHover,
+  handleDrag } : IDrawingComponentProps) {
   if (!isEllipseObject(model)) return null;
   const { id, stroke, strokeWidth, strokeDashArray, fill } = model;
-  const {x, y} = model.position;
+  const { x, y } = model.position;
   const rx = model.dragRx ?? model.rx;
   const ry = model.dragRy ?? model.ry;
   return <ellipse
@@ -96,7 +96,7 @@ export class EllipseDrawingTool extends DrawingTool {
   public handleMouseDown(e: React.MouseEvent<HTMLDivElement>) {
     const start = this.drawingLayer.getWorkspacePoint(e);
     if (!start) return;
-    const {stroke, fill, strokeWidth, strokeDashArray} = this.drawingLayer.toolbarSettings();
+    const { stroke, fill, strokeWidth, strokeDashArray } = this.drawingLayer.toolbarSettings();
     const ellipse = EllipseObject.create({
       x: start.x,
       y: start.y,
@@ -129,7 +129,7 @@ export class EllipseDrawingTool extends DrawingTool {
   }
 }
 
-export function EllipseToolbarButton({toolbarManager}: IToolbarButtonProps) {
+export function EllipseToolbarButton({ toolbarManager }: IToolbarButtonProps) {
   return <SvgToolModeButton modalButton="ellipse" title="Ellipse"
       toolbarManager={toolbarManager} SvgIcon={EllipseToolIcon} />;
 }

--- a/src/plugins/drawing/objects/group.tsx
+++ b/src/plugins/drawing/objects/group.tsx
@@ -6,7 +6,7 @@ import { DrawingObject, DrawingObjectType, IDrawingComponentProps,
   isFilledObject, 
   isStrokedObject, 
   typeField, 
-  ObjectTypeIconViewBox} from "./drawing-object";
+  ObjectTypeIconViewBox } from "./drawing-object";
 import { BoundingBoxSides, VectorEndShape } from "../model/drawing-basic-types";
 import { DrawingObjectMSTUnion } from "../components/drawing-object-manager";
 import { isVectorObject } from "./vector";
@@ -137,10 +137,10 @@ export function isGroupObject(model: DrawingObjectType): model is GroupObjectTyp
 }
 
 export const GroupComponent = observer(function GroupComponent(
-    {model, handleHover, handleDrag} : IDrawingComponentProps) {
+    { model, handleHover, handleDrag } : IDrawingComponentProps) {
   if (!isGroupObject(model)) return null;
   const group = model as GroupObjectType;
-  const {id, boundingBox: bb} = group;
+  const { id, boundingBox: bb } = group;
   // Renders as a rectangle that is invisible, but reacts to mouse events
   return <rect
     key={id}

--- a/src/plugins/drawing/objects/image.tsx
+++ b/src/plugins/drawing/objects/image.tsx
@@ -35,12 +35,12 @@ export const ImageObject = DrawingObject.named("ImageObject")
   }))
   .views(self => ({
     get boundingBox() {
-      const {x, y} = self.position;
+      const { x, y } = self.position;
       const width = self.dragWidth ?? self.width;
       const height = self.dragHeight ?? self.height;
-      const nw: Point = {x, y};
-      const se: Point = {x: x + width, y: y + height};
-      return {nw, se};
+      const nw: Point = { x, y };
+      const se: Point = { x: x + width, y: y + height };
+      return { nw, se };
     },
     get label() {
       return "Image";
@@ -49,7 +49,7 @@ export const ImageObject = DrawingObject.named("ImageObject")
       return (<ImageToolIcon viewBox={ObjectTypeIconViewBox}/>);
     },
     get displayUrl() {
-      const entry = gImageMap.getImageEntry(self.url, {filename: self.filename});
+      const entry = gImageMap.getImageEntry(self.url, { filename: self.filename });
       // TODO we could return a spinner image if the entry is storing or computing dimensions
       return entry?.displayUrl || (placeholderImage as string);
     },
@@ -89,8 +89,8 @@ export function isImageObjectSnapshot(object: DrawingObjectSnapshot): object is 
   return object.type === "image";
 }
 
-export const ImageComponent: React.FC<IDrawingComponentProps> = observer(function ImageComponent({model, handleHover,
-  handleDrag}){
+export const ImageComponent: React.FC<IDrawingComponentProps> = observer(function ImageComponent({ model, handleHover,
+  handleDrag }){
   if (model.type !== "image") return null;
   const image = model as ImageObjectType;
   const { id, displayUrl } = image;

--- a/src/plugins/drawing/objects/line.tsx
+++ b/src/plugins/drawing/objects/line.tsx
@@ -16,10 +16,10 @@ function* pointIterator(line: LineObjectType): Generator<Point, string, unknown>
   const scaleX = line.dragScaleX ?? 1;
   const scaleY = line.dragScaleY ?? 1;
   yield { x: currentX, y: currentY };
-  for (const {dx, dy} of points) {
+  for (const { dx, dy } of points) {
     currentX += dx * scaleX;
     currentY += dy * scaleY;
-    yield {x: currentX, y: currentY};
+    yield { x: currentX, y: currentY };
   }
   // Due to some conflict between TS and ESLint it is necessary to return
   // a value here. As far as I can tell this value is not used.
@@ -47,16 +47,16 @@ export const LineObject = StrokedObject.named("LineObject")
     },
 
     get boundingBox() {
-      const {x, y} = self.position;
-      const nw: Point = {x, y};
-      const se: Point = {x, y};
+      const { x, y } = self.position;
+      const nw: Point = { x, y };
+      const se: Point = { x, y };
       for (const point of pointIterator(self as LineObjectType)){
         nw.x = Math.min(nw.x, point.x);
         nw.y = Math.min(nw.y, point.y);
         se.x = Math.max(se.x, point.x);
         se.y = Math.max(se.y, point.y);
       }
-      return {nw, se};
+      return { nw, se };
     },
 
     get label() {
@@ -124,7 +124,7 @@ export const LineObject = StrokedObject.named("LineObject")
 export interface LineObjectType extends Instance<typeof LineObject> {}
 export interface LineObjectSnapshot extends SnapshotIn<typeof LineObject> {}
 
-export const LineComponent = observer(function LineComponent({model, handleHover, handleDrag}
+export const LineComponent = observer(function LineComponent({ model, handleHover, handleDrag }
   : IDrawingComponentProps) {
   if (model.type !== "line") return null;
   const line = model as LineObjectType;
@@ -157,15 +157,15 @@ export class LineDrawingTool extends DrawingTool {
   public handleMouseDown(e: React.MouseEvent<HTMLDivElement>) {
     const start = this.drawingLayer.getWorkspacePoint(e);
     if (!start) return;
-    const {stroke, strokeWidth, strokeDashArray} = this.drawingLayer.toolbarSettings();
-    const line = LineObject.create({x: start.x, y: start.y,
-      deltaPoints: [], stroke, strokeWidth, strokeDashArray});
+    const { stroke, strokeWidth, strokeDashArray } = this.drawingLayer.toolbarSettings();
+    const line = LineObject.create({ x: start.x, y: start.y,
+      deltaPoints: [], stroke, strokeWidth, strokeDashArray });
 
     let lastPoint = start;
     const addPoint = (e2: MouseEvent|React.MouseEvent<HTMLDivElement>) => {
       const p = this.drawingLayer.getWorkspacePoint(e2);
       if (p && (p.x >= 0) && (p.y >= 0)) {
-        line.addPoint({dx: p.x - lastPoint.x, dy: p.y - lastPoint.y});
+        line.addPoint({ dx: p.x - lastPoint.x, dy: p.y - lastPoint.y });
         lastPoint = p;
         this.drawingLayer.setCurrentDrawingObject(line);
       }
@@ -192,7 +192,7 @@ export class LineDrawingTool extends DrawingTool {
   }
 }
 
-export function LineToolbarButton({toolbarManager}: IToolbarButtonProps) {
+export function LineToolbarButton({ toolbarManager }: IToolbarButtonProps) {
   return <SvgToolModeButton modalButton="line" 
     title="Freehand" toolbarManager={toolbarManager} SvgIcon={FreehandToolIcon} />;
 }

--- a/src/plugins/drawing/objects/rectangle.tsx
+++ b/src/plugins/drawing/objects/rectangle.tsx
@@ -30,9 +30,9 @@ export const RectangleObject = types.compose("RectangleObject", StrokedObject, F
     get boundingBox() {
       const { x, y } = self.position;
       const { width, height } = self.currentDims;
-      const nw: Point = {x, y};
-      const se: Point = {x: x + width, y: y + height};
-      return {nw, se};
+      const nw: Point = { x, y };
+      const se: Point = { x: x + width, y: y + height };
+      return { nw, se };
     },
     get label() {
       return self.width===self.height ? "Square" : "Rectangle";
@@ -50,8 +50,8 @@ export const RectangleObject = types.compose("RectangleObject", StrokedObject, F
       self.width = Math.max(start.x, end.x) - self.x;
       self.height = Math.max(start.y, end.y) - self.y;
       if (makeSquare) {
-        let {x, y} = self;
-        const {width, height} = self;
+        let { x, y } = self;
+        const { width, height } = self;
         const squareSize = Math.max(width, height);
 
         if (x === start.x) {
@@ -88,8 +88,8 @@ export interface RectangleObjectType extends Instance<typeof RectangleObject> {}
 export interface RectangleObjectSnapshot extends SnapshotIn<typeof RectangleObject> {}
 export interface RectangleObjectSnapshotForAdd extends SnapshotIn<typeof RectangleObject> {type: string}
 
-export const RectangleComponent = observer(function RectangleComponent({model, handleHover,
-  handleDrag} : IDrawingComponentProps) {
+export const RectangleComponent = observer(function RectangleComponent({ model, handleHover,
+  handleDrag } : IDrawingComponentProps) {
   if (model.type !== "rectangle") return null;
   const rect = model as RectangleObjectType;
   const { id, stroke, strokeWidth, strokeDashArray, fill } = rect;
@@ -123,7 +123,7 @@ export class RectangleDrawingTool extends DrawingTool {
   public handleMouseDown(e: React.MouseEvent<HTMLDivElement>) {
     const start = this.drawingLayer.getWorkspacePoint(e);
     if (!start) return;
-    const {stroke, fill, strokeWidth, strokeDashArray} = this.drawingLayer.toolbarSettings();
+    const { stroke, fill, strokeWidth, strokeDashArray } = this.drawingLayer.toolbarSettings();
     const rectangle = RectangleObject.create({
       x: start.x,
       y: start.y,
@@ -156,7 +156,7 @@ export class RectangleDrawingTool extends DrawingTool {
   }
 }
 
-export function RectangleToolbarButton({toolbarManager}: IToolbarButtonProps) {
+export function RectangleToolbarButton({ toolbarManager }: IToolbarButtonProps) {
   return <SvgToolModeButton modalButton="rectangle" title="Rectangle"
     toolbarManager={toolbarManager} SvgIcon={RectToolIcon}  />;
 }

--- a/src/plugins/drawing/objects/text.tsx
+++ b/src/plugins/drawing/objects/text.tsx
@@ -34,9 +34,9 @@ export const TextObject = EditableObject.named("TextObject")
     get boundingBox() {
       const { x, y } = self.position;
       const { width, height } = self.currentDims;
-      const nw: Point = {x, y};
-      const se: Point = {x: x + width, y: y + height};
-      return {nw, se};
+      const nw: Point = { x, y };
+      const se: Point = { x: x + width, y: y + height };
+      return { nw, se };
     },
     get label() {
       return "Text";
@@ -83,7 +83,7 @@ export function isTextObject(model: DrawingObjectType): model is TextObjectType 
 }
 
 export const TextComponent = observer(
-    function TextComponent({model, readOnly, handleHover, handleDrag} : IDrawingComponentProps) {
+    function TextComponent({ model, readOnly, handleHover, handleDrag } : IDrawingComponentProps) {
   const textEditor = useRef<HTMLTextAreaElement>(null);
   if (!isTextObject(model)) return null;
   const textobj = model as TextObjectType;
@@ -97,7 +97,7 @@ export const TextComponent = observer(
     editing: boolean,
     clip: string
   }
-  const Content = function({editing, clip}: IContentProps) {
+  const Content = function({ editing, clip }: IContentProps) {
 
     useEffect(() => {
       // Focus text area when it opens, to avoid need for user to click it again.
@@ -122,7 +122,7 @@ export const TextComponent = observer(
       return(<g clipPath={'url(#'+clip+')'}>
               <WrappedSvgText text={text} 
                   x={x+margin} y={y+margin} width={width-2*margin} height={height-2*margin} 
-                  style={{fill: stroke}} />
+                  style={{ fill: stroke }} />
              </g>);
     }
   };
@@ -198,7 +198,7 @@ export class TextDrawingTool extends DrawingTool {
   }
 }
 
-export function TextToolbarButton({toolbarManager}: IToolbarButtonProps) {
+export function TextToolbarButton({ toolbarManager }: IToolbarButtonProps) {
   const buttonSettings: ToolbarSettings = {
     stroke: toolbarManager.toolbarSettings.stroke,
     fill: toolbarManager.toolbarSettings.stroke,

--- a/src/plugins/drawing/objects/vector.tsx
+++ b/src/plugins/drawing/objects/vector.tsx
@@ -26,9 +26,9 @@ export const VectorObject = StrokedObject.named("VectorObject")
       const { x, y } = self.position;
       const dx = self.dragDx ?? self.dx;
       const dy = self.dragDy ?? self.dy;
-      const nw: Point = {x: Math.min(x, x + dx), y: Math.min(y, y + dy)};
-      const se: Point = {x: Math.max(x, x + dx), y: Math.max(y, y + dy)};
-      return {nw, se};
+      const nw: Point = { x: Math.min(x, x + dx), y: Math.min(y, y + dy) };
+      const se: Point = { x: Math.max(x, x + dx), y: Math.max(y, y + dy) };
+      return { nw, se };
     },
     get label() {
       return  (self.headShape || self.tailShape) ? "Arrow" : "Line";
@@ -81,8 +81,8 @@ export interface VectorObjectSnapshot extends SnapshotIn<typeof VectorObject> {}
 export function isVectorObject(model: DrawingObjectType): model is VectorObjectType {
   return model.type === "vector";
 }
-export const VectorComponent = observer(function VectorComponent({model, handleHover,
-  handleDrag} : IDrawingComponentProps) {
+export const VectorComponent = observer(function VectorComponent({ model, handleHover,
+  handleDrag } : IDrawingComponentProps) {
   if (!isVectorObject(model)) return null;
   const vector = model as VectorObjectType;
   const { id, headShape, tailShape, stroke, strokeWidth, strokeDashArray } = vector;
@@ -142,14 +142,14 @@ export class VectorDrawingTool extends DrawingTool {
   public handleMouseDown(e: React.MouseEvent<HTMLDivElement>) {
     const start = this.drawingLayer.getWorkspacePoint(e);
     if (!start) return;
-    const {stroke, strokeWidth, strokeDashArray, vectorType} = this.drawingLayer.toolbarSettings();
+    const { stroke, strokeWidth, strokeDashArray, vectorType } = this.drawingLayer.toolbarSettings();
     const [headShape, tailShape] = endShapesForVectorType(vectorType);
     const vector = VectorObject.create({
       x: start.x,
       y: start.y,
       dx: 0,
       dy: 0,
-      headShape, tailShape, stroke, strokeWidth, strokeDashArray});
+      headShape, tailShape, stroke, strokeWidth, strokeDashArray });
 
     const handleMouseMove = (e2: MouseEvent) => {
       e2.preventDefault();

--- a/src/plugins/expression/expression-buttons.tsx
+++ b/src/plugins/expression/expression-buttons.tsx
@@ -24,7 +24,7 @@ interface AddMathTextButtonProps {
 export const AddMathTextButton = (props: AddMathTextButtonProps) => {
   const { mf, buttonName, enabled } = props;
   const button = expressionButtonsList.find((btn) => btn.name === buttonName);
-  const tooltipOptions = useTooltipOptions({distance: 5, offset: 5});
+  const tooltipOptions = useTooltipOptions({ distance: 5, offset: 5 });
   const tooltipText = "Add  " + button?.title + "  to expression";
 
   const buttonClasses = classNames(

--- a/src/plugins/expression/expression-content.ts
+++ b/src/plugins/expression/expression-content.ts
@@ -4,7 +4,7 @@ import { kExpressionTileType } from "./expression-types";
 import { IDefaultContentOptions, ITileExportOptions } from "../../models/tiles/tile-content-info";
 
 export function defaultExpressionContent(props?: IDefaultContentOptions): ExpressionContentModelType {
-  return ExpressionContentModel.create({latexStr: `a=\\pi r^2`});
+  return ExpressionContentModel.create({ latexStr: `a=\\pi r^2` });
 }
 
 export const ExpressionContentModel = TileContentModel

--- a/src/plugins/expression/expression-tile-utils.ts
+++ b/src/plugins/expression/expression-tile-utils.ts
@@ -30,5 +30,5 @@ export function getCommand(mf: MathfieldElement, buttonName: string) {
   if (selectStatus === "cursor") insertMode = "insertAfter";
   if (selectStatus === "some") insertMode = "replaceSelection";
 
-  return ["insert", insertString, {insertionMode: insertMode}];
+  return ["insert", insertString, { insertionMode: insertMode }];
 }

--- a/src/plugins/expression/expression-tile.test.tsx
+++ b/src/plugins/expression/expression-tile.test.tsx
@@ -24,7 +24,7 @@ jest.mock("mathlive", () => jest.fn());
 
 describe("ExpressionToolComponent", () => {
   const content = defaultExpressionContent();
-  const model = TileModel.create({content});
+  const model = TileModel.create({ content });
   const defaultProps = {
     tileElt: null,
     context: "",
@@ -56,12 +56,12 @@ describe("ExpressionToolComponent", () => {
   };
 
   it("renders a math field web component", () => {
-    render(<ExpressionToolComponent  {...defaultProps} {...{model}}></ExpressionToolComponent>);
+    render(<ExpressionToolComponent  {...defaultProps} {...{ model }}></ExpressionToolComponent>);
     expect(document.querySelector("math-field")).toBeInTheDocument();
   });
 
   it("loads default LaTeX string in the math-field value", () => {
-    render(<ExpressionToolComponent  {...defaultProps} {...{model}}></ExpressionToolComponent>);
+    render(<ExpressionToolComponent  {...defaultProps} {...{ model }}></ExpressionToolComponent>);
     expect(document.querySelector("math-field")).toHaveAttribute("value", "a=\\pi r^2");
   });
 

--- a/src/plugins/expression/expression-tile.tsx
+++ b/src/plugins/expression/expression-tile.tsx
@@ -79,7 +79,7 @@ export const ExpressionToolComponent: React.FC<ITileProps> = observer((props) =>
     // model has changed beneath UI - update mathfield, yet restore cursor position
     const disposer = onSnapshot((content as any), () => {
       if (mf.current?.getValue() === content.latexStr) return;
-      mf.current?.setValue(content.latexStr, {silenceNotifications: true});
+      mf.current?.setValue(content.latexStr, { silenceNotifications: true });
       if (!readOnly && mf.current) mf.current.position = trackedCursorPos.current - 1;
     });
     return () => disposer();

--- a/src/plugins/expression/expression-toolbar.tsx
+++ b/src/plugins/expression/expression-toolbar.tsx
@@ -6,7 +6,7 @@ import {
   IFloatingToolbarProps, useFloatingToolbarLocation
 } from "../../components/tiles/hooks/use-floating-toolbar-location";
 import { ExpressionContentModelType } from "./expression-content";
-import { expressionButtonsList} from "./expression-types";
+import { expressionButtonsList } from "./expression-types";
 import { ITileModel } from "../../models/tiles/tile-model";
 import { DeleteExpressionButton, AddMathTextButton } from "./expression-buttons";
 import { MathfieldElement } from "mathlive";

--- a/src/plugins/graph/adornments/adornment-models.test.ts
+++ b/src/plugins/graph/adornments/adornment-models.test.ts
@@ -7,20 +7,20 @@ import { MovableValueModel, isMovableValue } from "./movable-value/movable-value
 
 describe("PointModel", () => {
   it("is valid if x and y are finite", () => {
-    const point = PointModel.create({x: 1, y: 1});
+    const point = PointModel.create({ x: 1, y: 1 });
     expect(point.isValid()).toBe(true);
   });
   it("is invalid if x is not finite", () => {
-    const point = PointModel.create({x: NaN, y: 1});
+    const point = PointModel.create({ x: NaN, y: 1 });
     expect(point.isValid()).toBe(false);
   });
   it("is invalid if y is not finite", () => {
-    const point = PointModel.create({x: 1, y: NaN});
+    const point = PointModel.create({ x: 1, y: NaN });
     expect(point.isValid()).toBe(false);
   });
   it("can have its x and y values changed", () => {
-    const point = PointModel.create({x: 1, y: 1});
-    point.set({x: 2, y: 2});
+    const point = PointModel.create({ x: 1, y: 1 });
+    point.set({ x: 2, y: 2 });
     expect(point.x).toBe(2);
     expect(point.y).toBe(2);
   });
@@ -31,11 +31,11 @@ describe("AdornmentModel", () => {
     expect(() => AdornmentModel.create()).toThrow("type must be overridden");
   });
   it("has an ID that begins with 'ADRN'", () => {
-    const adornment = AdornmentModel.create({type: "Movable Line"});
+    const adornment = AdornmentModel.create({ type: "Movable Line" });
     expect(adornment.id).toMatch(/^ADRN/);
   });
   it("is visible by default and can have its visibility property changed", () => {
-    const adornment = AdornmentModel.create({type: "Movable Line"});
+    const adornment = AdornmentModel.create({ type: "Movable Line" });
     expect(adornment.isVisible).toBe(true);
     adornment.setVisibility(false);
     expect(adornment.isVisible).toBe(false);
@@ -51,23 +51,23 @@ describe("AdornmentModel", () => {
       rightAttrId: "jkl012",
       rightCats: ["new", "used"]
     };
-    const adornment = AdornmentModel.create({type: "Movable Line"});
+    const adornment = AdornmentModel.create({ type: "Movable Line" });
     const subPlotKey = adornment.setSubPlotKey(options, 0);
-    expect(subPlotKey).toEqual({abc123: "pizza", def456: "red", ghi789: "small", jkl012: "new"});
+    expect(subPlotKey).toEqual({ abc123: "pizza", def456: "red", ghi789: "small", jkl012: "new" });
   });
   it("will create an instance key value from given category values", () => {
-    const adornment = AdornmentModel.create({type: "Movable Line"});
+    const adornment = AdornmentModel.create({ type: "Movable Line" });
     const xCategories = ["pizza", "pasta", "salad"];
     const yCategories = ["red", "green", "blue"];
-    const subPlotKey = {abc123: xCategories[0], def456: yCategories[0]};
+    const subPlotKey = { abc123: xCategories[0], def456: yCategories[0] };
     expect(adornment.instanceKey({})).toEqual("{}");
     expect(adornment.instanceKey(subPlotKey)).toEqual("{\"abc123\":\"pizza\",\"def456\":\"red\"}");
   });
   it("will create a class name from a given subplot key", () => {
-    const adornment = AdornmentModel.create({type: "Movable Line"});
+    const adornment = AdornmentModel.create({ type: "Movable Line" });
     const xCategories = ["pizza", "pasta", "salad"];
     const yCategories = ["red", "green", "blue"];
-    const subPlotKey = {abc123: xCategories[0], def456: yCategories[0]};
+    const subPlotKey = { abc123: xCategories[0], def456: yCategories[0] };
     expect(adornment.classNameFromKey(subPlotKey)).toEqual("abc123-pizza-def456-red");
   });
 });

--- a/src/plugins/graph/adornments/adornment-models.ts
+++ b/src/plugins/graph/adornments/adornment-models.ts
@@ -2,10 +2,10 @@
   Adornment models are strictly MST. They keep track of the user modifications of the defaults.
  */
 
-import {Instance, types} from "mobx-state-tree";
+import { Instance, types } from "mobx-state-tree";
 import { IAxisModel } from "../imports/components/axis/models/axis-model";
-import {typedId} from "../../../utilities/js-utils";
-import {Point} from "../graph-types";
+import { typedId } from "../../../utilities/js-utils";
+import { Point } from "../graph-types";
 
 export const PointModel = types.model("Point", {
     x: types.optional(types.number, NaN),
@@ -25,7 +25,7 @@ export const PointModel = types.model("Point", {
     }
   }));
 export interface IPointModel extends Instance<typeof PointModel> {}
-export const kInfinitePoint = {x:NaN, y:NaN};
+export const kInfinitePoint = { x:NaN, y:NaN };
 
 export interface IUpdateCategoriesOptions {
   xAxis?: IAxisModel

--- a/src/plugins/graph/adornments/adornment.tsx
+++ b/src/plugins/graph/adornments/adornment.tsx
@@ -19,7 +19,7 @@ interface IProps {
 }
 
 export const Adornment = observer(function Adornment(
-  {adornment, subPlotKey, topCats, rightCats, dotsRef}: IProps
+  { adornment, subPlotKey, topCats, rightCats, dotsRef }: IProps
 ) {
   const graphModel = useGraphModelContext(),
     layout = useGraphLayoutContext(),
@@ -61,7 +61,7 @@ export const Adornment = observer(function Adornment(
     <div
       id={adornmentKey}
       className={adornmentWrapperClass}
-      style={{animationDuration: `${transitionDuration}ms`}}
+      style={{ animationDuration: `${transitionDuration}ms` }}
       data-testid={'adornment-wrapper'}
     >
       <Component

--- a/src/plugins/graph/adornments/connecting-lines/connecting-lines.tsx
+++ b/src/plugins/graph/adornments/connecting-lines/connecting-lines.tsx
@@ -30,7 +30,7 @@ function drawPath(el: DotsElt, points: Iterable<[number, number]>, color: string
   parentSvg?.insertBefore(newPath.node() as Node, parentSvg.firstChild);
 }
 
-export const ConnectingLines = observer(function ConnectingLines({dotsRef}: IProps) {
+export const ConnectingLines = observer(function ConnectingLines({ dotsRef }: IProps) {
   const dataConfiguration = useDataConfigurationContext();
   const { _pointColors } = useGraphModelContext();
   const plotsCt = dataConfiguration?.numberOfPlots || 1;

--- a/src/plugins/graph/adornments/count/count.tsx
+++ b/src/plugins/graph/adornments/count/count.tsx
@@ -10,7 +10,7 @@ interface IProps {
   subPlotKey: Record<string, string>
 }
 
-export const Count = observer(function Count({model, subPlotKey}: IProps) {
+export const Count = observer(function Count({ model, subPlotKey }: IProps) {
   const dataConfig = useDataConfigurationContext();
   const casesInPlot = dataConfig?.subPlotCases(subPlotKey)?.length ?? 0;
   const classFromKey = model.classNameFromKey(subPlotKey);

--- a/src/plugins/graph/adornments/movable-line/movable-line-model.test.ts
+++ b/src/plugins/graph/adornments/movable-line/movable-line-model.test.ts
@@ -2,23 +2,23 @@ import { MovableLineModel, MovableLineInstance } from "./movable-line-model";
 
 describe("MovableLineInstance", () => {
   it("is created with intercept and slope properties", () => {
-    const lineParams = MovableLineInstance.create({intercept: 1, slope: 1});
+    const lineParams = MovableLineInstance.create({ intercept: 1, slope: 1 });
     expect(lineParams.intercept).toEqual(1);
     expect(lineParams.slope).toEqual(1);
   });
   it("can have pivot1 and pivot2 properties set", () => {
-    const lineParams = MovableLineInstance.create({intercept: 1, slope: 1});
-    lineParams.setPivot1({x: 1, y: 1});
-    lineParams.setPivot2({x: 2, y: 2});
+    const lineParams = MovableLineInstance.create({ intercept: 1, slope: 1 });
+    lineParams.setPivot1({ x: 1, y: 1 });
+    lineParams.setPivot2({ x: 2, y: 2 });
     expect(lineParams.pivot1.x).toEqual(1);
     expect(lineParams.pivot1.y).toEqual(1);
     expect(lineParams.pivot2.x).toEqual(2);
     expect(lineParams.pivot2.y).toEqual(2);
   });
   it("can have equationCoords property set", () => {
-    const lineParams = MovableLineInstance.create({intercept: 1, slope: 1});
+    const lineParams = MovableLineInstance.create({ intercept: 1, slope: 1 });
     expect(lineParams.equationCoords).toBeUndefined();
-    lineParams.setEquationCoords({x: 50, y: 50});
+    lineParams.setEquationCoords({ x: 50, y: 50 });
     expect(lineParams.equationCoords?.x).toEqual(50);
     expect(lineParams.equationCoords?.y).toEqual(50);
   });
@@ -34,8 +34,8 @@ describe("MovableLineModel", () => {
     const line1 = {
       intercept: 1,
       slope: 1,
-      pivot1: {x: 2, y: 2},
-      pivot2: {x: 3, y: 3}
+      pivot1: { x: 2, y: 2 },
+      pivot2: { x: 3, y: 3 }
     };
     const movableLine = MovableLineModel.create();
     movableLine.setLine(line1);
@@ -46,14 +46,14 @@ describe("MovableLineModel", () => {
     const line1 = {
       intercept: 1,
       slope: 1,
-      pivot1: {x: 2, y: 2},
-      pivot2: {x: 3, y: 3}
+      pivot1: { x: 2, y: 2 },
+      pivot2: { x: 3, y: 3 }
     };
     const line2 = {
       intercept: 2,
       slope: 2,
-      pivot1: {x: 3, y: 3},
-      pivot2: {x: 4, y: 4}
+      pivot1: { x: 3, y: 3 },
+      pivot2: { x: 4, y: 4 }
     };
     const movableLine = MovableLineModel.create();
     movableLine.setLine(line1, "line1key");

--- a/src/plugins/graph/adornments/movable-line/movable-line-model.ts
+++ b/src/plugins/graph/adornments/movable-line/movable-line-model.ts
@@ -35,7 +35,7 @@ export const MovableLineModel = AdornmentModel
 })
 .actions(self => ({
   setLine(
-    aLine: {intercept: number, slope: number, pivot1?: Point, pivot2?: Point, equationCoords?: Point}, key=''
+    aLine: { intercept: number, slope: number, pivot1?: Point, pivot2?: Point, equationCoords?: Point }, key=''
   ) {
     self.lines.set(key, aLine);
     const line = self.lines.get(key);

--- a/src/plugins/graph/adornments/movable-line/movable-line.tsx
+++ b/src/plugins/graph/adornments/movable-line/movable-line.tsx
@@ -1,14 +1,14 @@
-import React, {useCallback, useEffect, useRef, useState} from "react";
-import {autorun} from "mobx";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { autorun } from "mobx";
 import { observer } from "mobx-react-lite";
-import {drag, select} from "d3";
-import {useAxisLayoutContext} from "../../imports/components/axis/models/axis-layout-context";
-import {ScaleNumericBaseType} from "../../imports/components/axis/axis-types";
-import {INumericAxisModel} from "../../imports/components/axis/models/axis-model";
-import {computeSlopeAndIntercept, equationString, IAxisIntercepts,
-        lineToAxisIntercepts} from "../../utilities/graph-utils";
-import {useDataConfigurationContext} from "../../hooks/use-data-configuration-context";
-import {useInstanceIdContext} from "../../imports/hooks/use-instance-id-context";
+import { drag, select } from "d3";
+import { useAxisLayoutContext } from "../../imports/components/axis/models/axis-layout-context";
+import { ScaleNumericBaseType } from "../../imports/components/axis/axis-types";
+import { INumericAxisModel } from "../../imports/components/axis/models/axis-model";
+import { computeSlopeAndIntercept, equationString, IAxisIntercepts,
+        lineToAxisIntercepts } from "../../utilities/graph-utils";
+import { useDataConfigurationContext } from "../../hooks/use-data-configuration-context";
+import { useInstanceIdContext } from "../../imports/hooks/use-instance-id-context";
 import { IMovableLineModel } from "./movable-line-model";
 
 import "./movable-line.scss";
@@ -31,7 +31,7 @@ interface IProps {
 }
 
 export const MovableLine = observer(function MovableLine(props: IProps) {
-  const {containerId, model, plotHeight, plotWidth, subPlotKey={}, xAxis, yAxis} = props,
+  const { containerId, model, plotHeight, plotWidth, subPlotKey={}, xAxis, yAxis } = props,
     dataConfig = useDataConfigurationContext(),
     layout = useAxisLayoutContext(),
     instanceId = useInstanceIdContext(),
@@ -45,7 +45,7 @@ export const MovableLine = observer(function MovableLine(props: IProps) {
     kHandleSize = 12,
     instanceKey = model.instanceKey(subPlotKey),
     classFromKey = model.classNameFromKey(subPlotKey),
-    {equationContainerClass, equationContainerSelector} = equationContainer(model, subPlotKey, containerId),
+    { equationContainerClass, equationContainerSelector } = equationContainer(model, subPlotKey, containerId),
     lineRef = useRef() as React.RefObject<SVGSVGElement>,
     [lineObject, setLineObject] = useState<{ [index: string]: any }>({
       line: null, lower: null, middle: null, upper: null, equation: null
@@ -75,8 +75,8 @@ export const MovableLine = observer(function MovableLine(props: IProps) {
         if (!lineObject.line || !lineModel) return;
 
         const { slope, intercept } = lineModel,
-          {domain: xDomain} = xAxis,
-          {domain: yDomain} = yAxis;
+          { domain: xDomain } = xAxis,
+          { domain: yDomain } = yAxis;
         pointsOnAxes.current = lineToAxisIntercepts(slope, intercept, xDomain, yDomain);
 
         function fixEndPoints(iLine: any, index: number) {
@@ -100,7 +100,7 @@ export const MovableLine = observer(function MovableLine(props: IProps) {
           const
             screenX = xScale((pointsOnAxes.current.pt1.x + pointsOnAxes.current.pt2.x) / 2) / xSubAxesCount,
             screenY = yScale((pointsOnAxes.current.pt1.y + pointsOnAxes.current.pt2.y) / 2) / ySubAxesCount,
-            attrNames = {x: xAttrName, y: yAttrName},
+            attrNames = { x: xAttrName, y: yAttrName },
             string = equationString(slope, intercept, attrNames),
             equation = select(equationContainerSelector).select('p');
 
@@ -138,10 +138,10 @@ export const MovableLine = observer(function MovableLine(props: IProps) {
             y: pixelPtsOnAxes.pt1.y + (5 / 8) * (pixelPtsOnAxes.pt2.y - pixelPtsOnAxes.pt1.y)
           },
           endPointsArray = [
-            {pt1: pixelPtsOnAxes.pt1, pt2: pixelPtsOnAxes.pt2},
-            {pt1: pixelPtsOnAxes.pt1, pt2: breakPt1},
-            {pt1: breakPt1, pt2: breakPt2},
-            {pt1: breakPt2, pt2: pixelPtsOnAxes.pt2}
+            { pt1: pixelPtsOnAxes.pt1, pt2: pixelPtsOnAxes.pt2 },
+            { pt1: pixelPtsOnAxes.pt1, pt2: breakPt1 },
+            { pt1: breakPt1, pt2: breakPt2 },
+            { pt1: breakPt2, pt2: pixelPtsOnAxes.pt2 }
           ];
         fixEndPoints(lineObject.line, 0);
         fixEndPoints(lineObject.lower, 1);
@@ -175,12 +175,12 @@ export const MovableLine = observer(function MovableLine(props: IProps) {
           tWorldY > yScaleCopy.domain()[1]
       ) {
         const { intercept, slope: initSlope } = computeSlopeAndIntercept(xAxis, yAxis);
-        model.setLine({slope: initSlope, intercept}, instanceKey);
+        model.setLine({ slope: initSlope, intercept }, instanceKey);
         return;
       }
 
       const newIntercept = isFinite(slope) ? tWorldY - slope * tWorldX : tWorldX;
-      model.setLine({slope, intercept: newIntercept, equationCoords}, instanceKey);
+      model.setLine({ slope, intercept: newIntercept, equationCoords }, instanceKey);
     }, [instanceKey, model, xAxis, xScaleCopy, yAxis, yScaleCopy]),
 
     continueRotation = useCallback((
@@ -258,7 +258,7 @@ export const MovableLine = observer(function MovableLine(props: IProps) {
           x = left / plotWidth,
           y = top / plotHeight;
 
-        lineModel?.setEquationCoords({x, y});
+        lineModel?.setEquationCoords({ x, y });
         equation.style('left', `${left}px`)
           .style('top', `${top}px`);
       }
@@ -344,7 +344,7 @@ export const MovableLine = observer(function MovableLine(props: IProps) {
   return (
     <svg
       className={`line-${model.classNameFromKey(subPlotKey)}`}
-      style={{height: `${plotHeight}px`, width: `${plotWidth}px`}}
+      style={{ height: `${plotHeight}px`, width: `${plotWidth}px` }}
       x={0}
       y={0}
     >

--- a/src/plugins/graph/adornments/movable-point/movable-point.tsx
+++ b/src/plugins/graph/adornments/movable-point/movable-point.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import {drag, select, Selection} from "d3";
-import {tip as d3tip} from "d3-v6-tip";
+import { drag, select, Selection } from "d3";
+import { tip as d3tip } from "d3-v6-tip";
 import { autorun } from "mobx";
 import { observer } from "mobx-react-lite";
 import { INumericAxisModel } from "../../imports/components/axis/models/axis-model";
@@ -33,7 +33,7 @@ interface IProps {
 }
 
 export const MovablePoint = observer(function MovablePoint(props: IProps) {
-  const {model, plotHeight, plotWidth, subPlotKey = {}, xAxis, yAxis} = props,
+  const { model, plotHeight, plotWidth, subPlotKey = {}, xAxis, yAxis } = props,
     dataConfig = useDataConfigurationContext(),
     layout = useAxisLayoutContext(),
     xScale = layout.getAxisScale("bottom") as ScaleNumericBaseType,
@@ -96,7 +96,7 @@ export const MovablePoint = observer(function MovablePoint(props: IProps) {
       .classed('dragging', true);
     dataTip.show(string, event.target);
     movePoint(xPoint, yPoint);
-    model.setPoint({x: xValue, y: yValue}, instanceKey);
+    model.setPoint({ x: xValue, y: yValue }, instanceKey);
   }, [classFromKey, instanceKey, model, movePoint, plotHeight, plotWidth, xAttrName,
       xScale, xSubAxesCount, yAttrName, yScale, ySubAxesCount]);
 
@@ -159,7 +159,7 @@ export const MovablePoint = observer(function MovablePoint(props: IProps) {
   return (
     <svg
       className={`point-${classFromKey}`}
-      style={{height: `${plotHeight}px`, width: `${plotWidth}px`}}
+      style={{ height: `${plotHeight}px`, width: `${plotWidth}px` }}
       x={0}
       y={0}
     >

--- a/src/plugins/graph/adornments/movable-value/movable-value-model.test.ts
+++ b/src/plugins/graph/adornments/movable-value/movable-value-model.test.ts
@@ -2,11 +2,11 @@ import { MovableValueModel } from "./movable-value-model";
 
 describe("MovableValueModel", () => {
   it("can be created with a value", () => {
-    const movableValue = MovableValueModel.create({value: 1});
+    const movableValue = MovableValueModel.create({ value: 1 });
     expect(movableValue.value).toEqual(1);
   });
   it("can have its value changed", () => {
-    const movableValue = MovableValueModel.create({value: 1});
+    const movableValue = MovableValueModel.create({ value: 1 });
     movableValue.setValue(2);
     expect(movableValue.value).toEqual(2);
   });

--- a/src/plugins/graph/adornments/movable-value/movable-value.tsx
+++ b/src/plugins/graph/adornments/movable-value/movable-value.tsx
@@ -1,11 +1,11 @@
-import React, {useCallback, useEffect, useRef, useState} from "react";
-import {drag, select} from "d3";
-import {autorun, reaction} from "mobx";
-import {useAxisLayoutContext} from "../../imports/components/axis/models/axis-layout-context";
-import {INumericAxisModel} from "../../imports/components/axis/models/axis-model";
-import {ScaleNumericBaseType} from "../../imports/components/axis/axis-types";
-import {kGraphClassSelector} from "../../graph-types";
-import {valueLabelString} from "../../utilities/graph-utils";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { drag, select } from "d3";
+import { autorun, reaction } from "mobx";
+import { useAxisLayoutContext } from "../../imports/components/axis/models/axis-layout-context";
+import { INumericAxisModel } from "../../imports/components/axis/models/axis-model";
+import { ScaleNumericBaseType } from "../../imports/components/axis/axis-types";
+import { kGraphClassSelector } from "../../graph-types";
+import { valueLabelString } from "../../utilities/graph-utils";
 import { IMovableValueModel } from "./movable-value-model";
 
 import "./movable-value.scss";
@@ -16,7 +16,7 @@ interface IProps {
   transform: string
 }
 
-export function MovableValue ({model, axis, transform}: IProps) {
+export function MovableValue ({ model, axis, transform }: IProps) {
   const layout = useAxisLayoutContext(),
     xScale = layout.getAxisScale("bottom") as ScaleNumericBaseType,
     yScale = layout.getAxisScale("left"),

--- a/src/plugins/graph/components/attribute-label.tsx
+++ b/src/plugins/graph/components/attribute-label.tsx
@@ -1,21 +1,21 @@
-import React, {useCallback, useEffect, useState} from "react";
-import {createPortal} from "react-dom";
-import {reaction} from "mobx";
-import {observer} from "mobx-react-lite";
-import {select} from "d3";
+import React, { useCallback, useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { reaction } from "mobx";
+import { observer } from "mobx-react-lite";
+import { select } from "d3";
 import t from "../imports/utilities/translation/translate";
-import {useDataConfigurationContext} from "../hooks/use-data-configuration-context";
-import {AttributeType} from "../../../models/data/attribute";
-import {IDataSet} from "../../../models/data/data-set";
-import {isSetAttributeNameAction} from "../../../models/data/data-set-actions";
-import {GraphPlace, isVertical} from "../imports/components/axis-graph-shared";
-import {graphPlaceToAttrRole} from "../graph-types";
-import {useGraphModelContext} from "../models/graph-model";
-import {useGraphLayoutContext} from "../models/graph-layout";
-import {useTileModelContext} from "../imports/hooks/use-tile-model-context";
-import {getStringBounds} from "../imports/components/axis/axis-utils";
-import {AxisOrLegendAttributeMenu} from "../imports/components/axis/components/axis-or-legend-attribute-menu";
-import {useSettingFromStores} from "../../../hooks/use-stores";
+import { useDataConfigurationContext } from "../hooks/use-data-configuration-context";
+import { AttributeType } from "../../../models/data/attribute";
+import { IDataSet } from "../../../models/data/data-set";
+import { isSetAttributeNameAction } from "../../../models/data/data-set-actions";
+import { GraphPlace, isVertical } from "../imports/components/axis-graph-shared";
+import { graphPlaceToAttrRole } from "../graph-types";
+import { useGraphModelContext } from "../models/graph-model";
+import { useGraphLayoutContext } from "../models/graph-layout";
+import { useTileModelContext } from "../imports/hooks/use-tile-model-context";
+import { getStringBounds } from "../imports/components/axis/axis-utils";
+import { AxisOrLegendAttributeMenu } from "../imports/components/axis/components/axis-or-legend-attribute-menu";
+import { useSettingFromStores } from "../../../hooks/use-stores";
 
 import graphVars from "./graph.scss";
 
@@ -27,12 +27,12 @@ interface IAttributeLabelProps {
 }
 
 export const AttributeLabel = observer(
-  function AttributeLabel({place, onTreatAttributeAs, onRemoveAttribute, onChangeAttribute}: IAttributeLabelProps) {
+  function AttributeLabel({ place, onTreatAttributeAs, onRemoveAttribute, onChangeAttribute }: IAttributeLabelProps) {
     const graphModel = useGraphModelContext(),
       dataConfiguration = useDataConfigurationContext(),
       defaultAxisLabels = useSettingFromStores("defaultAxisLabels", "graph") as Record<string, string> | undefined,
       layout = useGraphLayoutContext(),
-      {isTileSelected} = useTileModelContext(),
+      { isTileSelected } = useTileModelContext(),
       dataset = dataConfiguration?.dataset,
       useClickHereCue = dataConfiguration?.placeCanShowClickHereCue(place) ?? false,
       hideClickHereCue = useClickHereCue &&

--- a/src/plugins/graph/components/background.tsx
+++ b/src/plugins/graph/components/background.tsx
@@ -1,17 +1,17 @@
-import {autorun} from "mobx";
-import React, {forwardRef, MutableRefObject, useCallback, useEffect, useMemo, useRef} from "react";
-import {drag, select, color, range} from "d3";
+import { autorun } from "mobx";
+import React, { forwardRef, MutableRefObject, useCallback, useEffect, useMemo, useRef } from "react";
+import { drag, select, color, range } from "d3";
 import RTreeLib from 'rtree';
 type RTree = ReturnType<typeof RTreeLib>;
-import {CaseData} from "../d3-types";
-import {InternalizedData, rTreeRect} from "../graph-types";
-import {useGraphLayoutContext} from "../models/graph-layout";
-import {rectangleSubtract, rectNormalize} from "../utilities/graph-utils";
-import {useCurrent} from "../../../hooks/use-current";
-import {useDataSetContext} from "../imports/hooks/use-data-set-context";
-import {MarqueeState} from "../models/marquee-state";
-import {useGraphModelContext} from "../models/graph-model";
-import {useInstanceIdContext} from "../imports/hooks/use-instance-id-context";
+import { CaseData } from "../d3-types";
+import { InternalizedData, rTreeRect } from "../graph-types";
+import { useGraphLayoutContext } from "../models/graph-layout";
+import { rectangleSubtract, rectNormalize } from "../utilities/graph-utils";
+import { useCurrent } from "../../../hooks/use-current";
+import { useDataSetContext } from "../imports/hooks/use-data-set-context";
+import { MarqueeState } from "../models/marquee-state";
+import { useGraphModelContext } from "../models/graph-model";
+import { useInstanceIdContext } from "../imports/hooks/use-instance-id-context";
 
 interface IProps {
   marqueeState: MarqueeState
@@ -43,7 +43,7 @@ const prepareTree = (areaSelector: string, circleSelector: string): RTree => {
   };
 
 export const Background = forwardRef<SVGGElement, IProps>((props, ref) => {
-  const {marqueeState} = props,
+  const { marqueeState } = props,
     instanceId = useInstanceIdContext() || 'background',
     dataset = useCurrent(useDataSetContext()),
     layout = useGraphLayoutContext(),
@@ -57,7 +57,7 @@ export const Background = forwardRef<SVGGElement, IProps>((props, ref) => {
     previousMarqueeRect = useRef<rTreeRect>();
 
   const onDragStart = useCallback((event: { x: number; y: number; sourceEvent: { shiftKey: boolean } }) => {
-      const {computedBounds} = layout,
+      const { computedBounds } = layout,
         plotBounds = computedBounds.plot;
       selectionTree.current = prepareTree(`.${instanceId}`, 'circle');
       startX.current = event.x - plotBounds.left;
@@ -67,13 +67,13 @@ export const Background = forwardRef<SVGGElement, IProps>((props, ref) => {
       if (!event.sourceEvent.shiftKey) {
         dataset.current?.setSelectedCases([]);
       }
-      marqueeState.setMarqueeRect({x: startX.current, y: startY.current, width: 0, height: 0});
+      marqueeState.setMarqueeRect({ x: startX.current, y: startY.current, width: 0, height: 0 });
     }, [dataset, instanceId, layout, marqueeState]),
 
     onDrag = useCallback((event: { dx: number; dy: number }) => {
       if (event.dx !== 0 || event.dy !== 0) {
         previousMarqueeRect.current = rectNormalize(
-          {x: startX.current, y: startY.current, w: width.current, h: height.current});
+          { x: startX.current, y: startY.current, w: width.current, h: height.current });
         width.current = width.current + event.dx;
         height.current = height.current + event.dy;
         const marqueeRect = marqueeState.marqueeRect;
@@ -95,7 +95,7 @@ export const Background = forwardRef<SVGGElement, IProps>((props, ref) => {
     }, [dataset, marqueeState]),
 
     onDragEnd = useCallback(() => {
-      marqueeState.setMarqueeRect({x: 0, y: 0, width: 0, height: 0});
+      marqueeState.setMarqueeRect({ x: 0, y: 0, width: 0, height: 0 });
       selectionTree.current = null;
     }, [marqueeState]),
     dragBehavior = useMemo(() => drag<SVGRectElement, number>()

--- a/src/plugins/graph/components/casedots.tsx
+++ b/src/plugins/graph/components/casedots.tsx
@@ -1,16 +1,16 @@
-import {randomUniform, select} from "d3";
-import React, {useCallback, useEffect, useRef, useState} from "react";
-import {CaseData} from "../d3-types";
-import {IDotsRef} from "../graph-types";
-import {ICase} from "../../../models/data/data-set-types";
-import {isAddCasesAction} from "../../../models/data/data-set-actions";
-import {useDragHandlers, usePlotResponders} from "../hooks/use-plot";
-import {useDataConfigurationContext} from "../hooks/use-data-configuration-context";
-import {useDataSetContext} from "../imports/hooks/use-data-set-context";
-import {useGraphLayoutContext} from "../models/graph-layout";
-import {handleClickOnDot, setPointCoordinates, setPointSelection} from "../utilities/graph-utils";
-import {useGraphModelContext} from "../models/graph-model";
-import {onAnyAction} from "../../../utilities/mst-utils";
+import { randomUniform, select } from "d3";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { CaseData } from "../d3-types";
+import { IDotsRef } from "../graph-types";
+import { ICase } from "../../../models/data/data-set-types";
+import { isAddCasesAction } from "../../../models/data/data-set-actions";
+import { useDragHandlers, usePlotResponders } from "../hooks/use-plot";
+import { useDataConfigurationContext } from "../hooks/use-data-configuration-context";
+import { useDataSetContext } from "../imports/hooks/use-data-set-context";
+import { useGraphLayoutContext } from "../models/graph-layout";
+import { handleClickOnDot, setPointCoordinates, setPointSelection } from "../utilities/graph-utils";
+import { useGraphModelContext } from "../models/graph-model";
+import { onAnyAction } from "../../../utilities/mst-utils";
 
 export const CaseDots = function CaseDots(props: {
   dotsRef: IDotsRef
@@ -27,7 +27,7 @@ export const CaseDots = function CaseDots(props: {
     randomPointsRef = useRef<Record<string, { x: number, y: number }>>({}),
     dragPointRadius = graphModel.getPointRadius('hover-drag'),
     [dragID, setDragID] = useState(''),
-    currPos = useRef({x: 0, y: 0}),
+    currPos = useRef({ x: 0, y: 0 }),
     target = useRef<any>();
 
   const onDragStart = useCallback((event: MouseEvent) => {
@@ -38,14 +38,14 @@ export const CaseDots = function CaseDots(props: {
         target.current.transition()
           .attr('r', dragPointRadius);
         setDragID(aCaseData.caseID);
-        currPos.current = {x: event.clientX, y: event.clientY};
+        currPos.current = { x: event.clientX, y: event.clientY };
         handleClickOnDot(event, aCaseData.caseID, dataset);
       }
     }, [dragPointRadius, dataset, enableAnimation]),
 
     onDrag = useCallback((event: MouseEvent) => {
       if (dotsRef.current && dragID !== '') {
-        const newPos = {x: event.clientX, y: event.clientY},
+        const newPos = { x: event.clientX, y: event.clientY },
           dx = newPos.x - currPos.current.x,
           dy = newPos.y - currPos.current.y;
         currPos.current = newPos;
@@ -73,10 +73,10 @@ export const CaseDots = function CaseDots(props: {
       }
     }, [dragID, graphModel]);
 
-  useDragHandlers(window, {start: onDragStart, drag: onDrag, end: onDragEnd});
+  useDragHandlers(window, { start: onDragStart, drag: onDrag, end: onDragEnd });
 
   const refreshPointSelection = useCallback(() => {
-    const {pointColor, pointStrokeColor} = graphModel,
+    const { pointColor, pointStrokeColor } = graphModel,
       selectedPointRadius = graphModel.getPointRadius('select');
     dataConfiguration && setPointSelection({
       dotsRef, dataConfiguration, pointRadius: graphModel.getPointRadius(), selectedPointRadius,
@@ -89,7 +89,7 @@ export const CaseDots = function CaseDots(props: {
     const
       pointRadius = graphModel.getPointRadius(),
       selectedPointRadius = graphModel.getPointRadius('select'),
-      {pointColor, pointStrokeColor} = graphModel,
+      { pointColor, pointStrokeColor } = graphModel,
       xLength = layout.getAxisMultiScale('bottom')?.length ?? 0,
       yLength = layout.getAxisMultiScale('left')?.length ?? 0,
       getScreenX = (anID: string) => {
@@ -108,12 +108,12 @@ export const CaseDots = function CaseDots(props: {
   }, [dataset, dataConfiguration, graphModel, layout, dotsRef, enableAnimation]);
 
   useEffect(function initDistribution() {
-    const {cases} = dataset || {};
+    const { cases } = dataset || {};
     const uniform = randomUniform();
 
     const initCases = (_cases?: typeof cases | ICase[]) => {
-      _cases?.forEach(({__id__}) => {
-        randomPointsRef.current[__id__] = {x: uniform(), y: uniform()};
+      _cases?.forEach(({ __id__ }) => {
+        randomPointsRef.current[__id__] = { x: uniform(), y: uniform() };
       });
     };
 
@@ -127,7 +127,7 @@ export const CaseDots = function CaseDots(props: {
     return () => disposer?.();
   }, [dataset]);
 
-  usePlotResponders({dotsRef, refreshPointPositions, refreshPointSelection, enableAnimation});
+  usePlotResponders({ dotsRef, refreshPointPositions, refreshPointSelection, enableAnimation });
 
   return (
     <>

--- a/src/plugins/graph/components/chartdots.tsx
+++ b/src/plugins/graph/components/chartdots.tsx
@@ -1,20 +1,20 @@
-import {ScaleBand} from "d3";
-import React, {useCallback} from "react";
-import {CaseData, selectDots} from "../d3-types";
-import {attrRoleToAxisPlace, PlotProps} from "../graph-types";
-import {usePlotResponders} from "../hooks/use-plot";
-import {useDataConfigurationContext} from "../hooks/use-data-configuration-context";
-import {useDataSetContext} from "../imports/hooks/use-data-set-context";
-import {useGraphLayoutContext} from "../models/graph-layout";
-import {setPointCoordinates, setPointSelection} from "../utilities/graph-utils";
-import {useGraphModelContext} from "../models/graph-model";
+import { ScaleBand } from "d3";
+import React, { useCallback } from "react";
+import { CaseData, selectDots } from "../d3-types";
+import { attrRoleToAxisPlace, PlotProps } from "../graph-types";
+import { usePlotResponders } from "../hooks/use-plot";
+import { useDataConfigurationContext } from "../hooks/use-data-configuration-context";
+import { useDataSetContext } from "../imports/hooks/use-data-set-context";
+import { useGraphLayoutContext } from "../models/graph-layout";
+import { setPointCoordinates, setPointSelection } from "../utilities/graph-utils";
+import { useGraphModelContext } from "../models/graph-model";
 
 type BinMap = Record<string, Record<string, Record<string, Record<string, number>>>>;
 
 export const ChartDots = function ChartDots(props: PlotProps) {
-  const {dotsRef, enableAnimation} = props,
+  const { dotsRef, enableAnimation } = props,
     graphModel = useGraphModelContext(),
-    {pointColor, pointStrokeColor} = graphModel,
+    { pointColor, pointStrokeColor } = graphModel,
     dataConfiguration = useDataConfigurationContext(),
     dataset = useDataSetContext(),
     layout = useGraphLayoutContext(),
@@ -131,7 +131,7 @@ export const ChartDots = function ChartDots(props: PlotProps) {
               extraSecCatsArray.forEach((exSecCat, l) => {
                 if (!catMap[primeCat][secCat][exPrimeCat][exSecCat]) {
                   catMap[primeCat][secCat][exPrimeCat][exSecCat] =
-                    {cell: {p: i, s: j, ep: k, es: l}, numSoFar: 0};
+                    { cell: { p: i, s: j, ep: k, es: l }, numSoFar: 0 };
                 }
               });
             });
@@ -149,7 +149,7 @@ export const ChartDots = function ChartDots(props: PlotProps) {
           actualPointsPerColumn = Math.ceil(maxInCell / numPointsInRow),
           overlap = -Math.max(0, ((actualPointsPerColumn + 1) * pointDiameter - primaryHeight) /
             actualPointsPerColumn);
-        return {numPointsInRow, overlap};
+        return { numPointsInRow, overlap };
       },
       cellParams = computeCellParams(),
 
@@ -173,7 +173,7 @@ export const ChartDots = function ChartDots(props: PlotProps) {
               numInCell = mapEntry.numSoFar++,
               row = Math.floor(numInCell / cellParams.numPointsInRow),
               column = numInCell % cellParams.numPointsInRow;
-            indices[anID] = {cell: mapEntry.cell, row, column};
+            indices[anID] = { cell: mapEntry.cell, row, column };
           }
         });
         return indices;
@@ -184,8 +184,8 @@ export const ChartDots = function ChartDots(props: PlotProps) {
       pointRadius = graphModel.getPointRadius(),
       getPrimaryScreenCoord = (anID: string) => {
         if (cellIndices[anID]) {
-          const {column} = cellIndices[anID],
-            {p, ep} = cellIndices[anID].cell;
+          const { column } = cellIndices[anID],
+            { p, ep } = cellIndices[anID].cell;
           return baseCoord + signForOffset * ((p + 0.5) * primaryCellWidth + ep * extraPrimCellWidth) +
             (column + 0.5) * pointDiameter - cellParams.numPointsInRow * pointDiameter / 2;
         } else {
@@ -194,8 +194,8 @@ export const ChartDots = function ChartDots(props: PlotProps) {
       },
       getSecondaryScreenCoord = (anID: string) => {
         if (cellIndices[anID] && secOrdinalScale) {
-          const {row} = cellIndices[anID],
-            {s, es} = cellIndices[anID].cell;
+          const { row } = cellIndices[anID],
+            { s, es } = cellIndices[anID].cell;
           return secOrdinalScale.range()[0] -
             signForOffset * (s * primaryHeight + es * extraSecCellWidth +
               (row + 0.5) * pointDiameter + row * cellParams.overlap);
@@ -215,7 +215,7 @@ export const ChartDots = function ChartDots(props: PlotProps) {
     extraPrimaryAttrRole, extraSecondaryAttrRole, pointColor,
     enableAnimation, primaryIsBottom, layout, pointStrokeColor, computeMaxOverAllCells, dataset]);
 
-  usePlotResponders({dotsRef, refreshPointPositions, refreshPointSelection, enableAnimation});
+  usePlotResponders({ dotsRef, refreshPointPositions, refreshPointSelection, enableAnimation });
 
   return (
     <>

--- a/src/plugins/graph/components/dotplotdots.tsx
+++ b/src/plugins/graph/components/dotplotdots.tsx
@@ -1,23 +1,23 @@
-import {max, range, ScaleBand, ScaleLinear, select} from "d3";
-import {observer} from "mobx-react-lite";
-import React, {useCallback, useRef, useState} from "react";
-import {CaseData} from "../d3-types";
-import {PlotProps} from "../graph-types";
-import {useDragHandlers, usePlotResponders} from "../hooks/use-plot";
-import {useDataConfigurationContext} from "../hooks/use-data-configuration-context";
-import {useDataSetContext} from "../imports/hooks/use-data-set-context";
-import {useGraphLayoutContext} from "../models/graph-layout";
-import {ICase} from "../../../models/data/data-set-types";
+import { max, range, ScaleBand, ScaleLinear, select } from "d3";
+import { observer } from "mobx-react-lite";
+import React, { useCallback, useRef, useState } from "react";
+import { CaseData } from "../d3-types";
+import { PlotProps } from "../graph-types";
+import { useDragHandlers, usePlotResponders } from "../hooks/use-plot";
+import { useDataConfigurationContext } from "../hooks/use-data-configuration-context";
+import { useDataSetContext } from "../imports/hooks/use-data-set-context";
+import { useGraphLayoutContext } from "../models/graph-layout";
+import { ICase } from "../../../models/data/data-set-types";
 import {
   handleClickOnDot,
   setPointCoordinates,
   setPointSelection,
   startAnimation
 } from "../utilities/graph-utils";
-import {useGraphModelContext} from "../models/graph-model";
+import { useGraphModelContext } from "../models/graph-model";
 
 export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
-  const {dotsRef, enableAnimation} = props,
+  const { dotsRef, enableAnimation } = props,
     graphModel = useGraphModelContext(),
     dataConfiguration = useDataConfigurationContext(),
     dataset = useDataSetContext(),
@@ -25,7 +25,7 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
     primaryAttrRole = dataConfiguration?.primaryRole ?? 'x',
     primaryIsBottom = primaryAttrRole === 'x',
     secondaryAttrRole = primaryAttrRole === 'x' ? 'y' : 'x',
-    {pointColor, pointStrokeColor} = graphModel,
+    { pointColor, pointStrokeColor } = graphModel,
     // Used for tracking drag events
     [dragID, setDragID] = useState(''),
     currPos = useRef(0),
@@ -51,7 +51,7 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
 
         handleClickOnDot(event, tItsID, dataset);
         // Record the current values, so we can change them during the drag and restore them when done
-        const {selection} = dataConfiguration || {},
+        const { selection } = dataConfiguration || {},
           primaryAttrID = dataConfiguration?.attributeID(dataConfiguration?.primaryRole ?? 'x') ?? '';
         selection?.forEach(anID => {
           const itsValue = dataset?.getNumeric(anID, primaryAttrID) || undefined;
@@ -75,11 +75,11 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
           const delta = Number(primaryAxisScale.invert(deltaPixels)) -
               Number(primaryAxisScale.invert(0)),
             caseValues: ICase[] = [],
-            {selection} = dataConfiguration || {};
+            { selection } = dataConfiguration || {};
           selection?.forEach(anID => {
             const currValue = Number(dataset?.getNumeric(anID, primaryAttrID));
             if (isFinite(currValue)) {
-              caseValues.push({__id__: anID, [primaryAttrID]: currValue + delta});
+              caseValues.push({ __id__: anID, [primaryAttrID]: currValue + delta });
             }
           });
           caseValues.length && dataset?.setCaseValues(caseValues, [primaryAttrID]);
@@ -100,7 +100,7 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
 
         if (didDrag.current) {
           const caseValues: ICase[] = [],
-            {selection} = dataConfiguration || {};
+            { selection } = dataConfiguration || {};
           selection?.forEach(anID => {
             caseValues.push({
               __id__: anID,
@@ -114,7 +114,7 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
       }
     }, [graphModel, dataConfiguration, primaryAttrRole, dataset, dragID, enableAnimation]);
 
-  useDragHandlers(window, {start: onDragStart, drag: onDrag, end: onDragEnd});
+  useDragHandlers(window, { start: onDragStart, drag: onDrag, end: onDragEnd });
 
   const refreshPointSelection = useCallback(() => {
     dataConfiguration && setPointSelection({
@@ -209,7 +209,7 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
 
       const computeSecondaryCoord =
         (caseInfo: { secondaryCat: string, extraSecondaryCat: string, indexInBin: number }) => {
-          const {secondaryCat, extraSecondaryCat, indexInBin} = caseInfo;
+          const { secondaryCat, extraSecondaryCat, indexInBin } = caseInfo;
           let catCoord = (!!secondaryCat && secondaryCat !== '__main__' ? secondaryAxisScale(secondaryCat) ?? 0 : 0) /
             numExtraSecondaryBands;
           let extraCoord = !!extraSecondaryCat && extraSecondaryCat !== '__main__'
@@ -246,7 +246,7 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
             indexInBin = binMap[anID].indexInBin,
             onePixelOffset = primaryIsBottom ? -1 : 1; // Separate circles from axis line by 1 pixel
           return binMap[anID]
-            ? computeSecondaryCoord({secondaryCat, extraSecondaryCat, indexInBin}) + onePixelOffset
+            ? computeSecondaryCoord({ secondaryCat, extraSecondaryCat, indexInBin }) + onePixelOffset
             : null;
         },
         getScreenX = primaryIsBottom ? getPrimaryScreenCoord : getSecondaryScreenCoord,
@@ -264,7 +264,7 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
     [graphModel, dataConfiguration, layout, primaryAttrRole, secondaryAttrRole, dataset, dotsRef,
       enableAnimation, primaryIsBottom, pointColor, pointStrokeColor]);
 
-  usePlotResponders({dotsRef, refreshPointPositions, refreshPointSelection, enableAnimation});
+  usePlotResponders({ dotsRef, refreshPointPositions, refreshPointSelection, enableAnimation });
 
   return (
     <>

--- a/src/plugins/graph/components/drop-hint.tsx
+++ b/src/plugins/graph/components/drop-hint.tsx
@@ -1,5 +1,5 @@
-import {useDndMonitor} from "@dnd-kit/core";
-import React, {useRef, useState} from "react";
+import { useDndMonitor } from "@dnd-kit/core";
+import React, { useRef, useState } from "react";
 
 import "./drop-hint.scss";
 

--- a/src/plugins/graph/components/droppable-add-attribute.tsx
+++ b/src/plugins/graph/components/droppable-add-attribute.tsx
@@ -1,14 +1,14 @@
 import React from "react";
-import {clsx} from "clsx";
-import {Active, useDroppable} from "@dnd-kit/core";
-import {useDropHintString} from "../imports/hooks/use-drop-hint-string";
-import {getDragAttributeInfo, useDropHandler} from "../imports/hooks/use-drag-drop";
-import {DropHint} from "./drop-hint";
-import {graphPlaceToAttrRole, PlotType} from "../graph-types";
-import {GraphPlace} from "../imports/components/axis-graph-shared";
-import {useDataConfigurationContext} from "../hooks/use-data-configuration-context";
-import {useInstanceIdContext} from "../imports/hooks/use-instance-id-context";
-import {IDataSet} from "../../../models/data/data-set";
+import { clsx } from "clsx";
+import { Active, useDroppable } from "@dnd-kit/core";
+import { useDropHintString } from "../imports/hooks/use-drop-hint-string";
+import { getDragAttributeInfo, useDropHandler } from "../imports/hooks/use-drag-drop";
+import { DropHint } from "./drop-hint";
+import { graphPlaceToAttrRole, PlotType } from "../graph-types";
+import { GraphPlace } from "../imports/components/axis-graph-shared";
+import { useDataConfigurationContext } from "../hooks/use-data-configuration-context";
+import { useInstanceIdContext } from "../imports/hooks/use-instance-id-context";
+import { IDataSet } from "../../../models/data/data-set";
 
 interface IAddAttributeProps {
   place: GraphPlace
@@ -16,14 +16,14 @@ interface IAddAttributeProps {
   onDrop: (dataSet: IDataSet, attributeId: string) => void
 }
 
-export const DroppableAddAttribute = ({place, onDrop}: IAddAttributeProps) => {
+export const DroppableAddAttribute = ({ place, onDrop }: IAddAttributeProps) => {
   const graphID = useInstanceIdContext(),
     dataConfiguration = useDataConfigurationContext(),
     isDropAllowed = dataConfiguration?.graphPlaceCanAcceptAttributeIDDrop,
     droppableId = `${graphID}-add-attribute-${place}-drop`,
     role = graphPlaceToAttrRole[place],
-    {active, isOver, setNodeRef} = useDroppable({id: droppableId}),
-    hintString = useDropHintString({role});
+    { active, isOver, setNodeRef } = useDroppable({ id: droppableId }),
+    hintString = useDropHintString({ role });
 
   const handleIsActive = (iActive: Active) => {
     const { dataSet, attributeId: droppedAttrId } = getDragAttributeInfo(iActive) || {};
@@ -41,7 +41,7 @@ export const DroppableAddAttribute = ({place, onDrop}: IAddAttributeProps) => {
 
   const isActive = active && handleIsActive(active),
     placeKey = ['rightNumeric', 'rightCat'].includes(place) ? 'right' : place; // both use same css
-  const className = clsx(`add-attribute-drop-${placeKey}`, {over: isActive && isOver, active: isActive});
+  const className = clsx(`add-attribute-drop-${placeKey}`, { over: isActive && isOver, active: isActive });
   return isActive ? (
     <div ref={setNodeRef} id={droppableId}
          className={className}>

--- a/src/plugins/graph/components/droppable-axis.tsx
+++ b/src/plugins/graph/components/droppable-axis.tsx
@@ -2,10 +2,10 @@ import { Active, useDroppable } from "@dnd-kit/core";
 import { observer } from "mobx-react-lite";
 import React, { CSSProperties } from "react";
 import { createPortal } from "react-dom";
-import {clsx} from "clsx";
+import { clsx } from "clsx";
 import { DropHint } from "./drop-hint";
 import { AxisPlace } from "../imports/components/axis/axis-types";
-import {useGraphLayoutContext} from "../models/graph-layout";
+import { useGraphLayoutContext } from "../models/graph-layout";
 
 interface IProps {
   place: AxisPlace

--- a/src/plugins/graph/components/droppable-plot.tsx
+++ b/src/plugins/graph/components/droppable-plot.tsx
@@ -1,12 +1,12 @@
-import {Active} from "@dnd-kit/core";
-import React, {memo} from "react";
-import {getDragAttributeInfo, useDropHandler} from "../imports/hooks/use-drag-drop";
-import {useDropHintString} from "../imports/hooks/use-drop-hint-string";
-import {useInstanceIdContext} from "../imports/hooks/use-instance-id-context";
-import {DroppableSvg} from "./droppable-svg";
-import {useDataConfigurationContext} from "../hooks/use-data-configuration-context";
-import {GraphPlace} from "../imports/components/axis-graph-shared";
-import {IDataSet} from "../../../models/data/data-set";
+import { Active } from "@dnd-kit/core";
+import React, { memo } from "react";
+import { getDragAttributeInfo, useDropHandler } from "../imports/hooks/use-drag-drop";
+import { useDropHintString } from "../imports/hooks/use-drop-hint-string";
+import { useInstanceIdContext } from "../imports/hooks/use-instance-id-context";
+import { DroppableSvg } from "./droppable-svg";
+import { useDataConfigurationContext } from "../hooks/use-data-configuration-context";
+import { GraphPlace } from "../imports/components/axis-graph-shared";
+import { IDataSet } from "../../../models/data/data-set";
 
 interface IProps {
   graphElt: HTMLDivElement | null
@@ -14,13 +14,13 @@ interface IProps {
   onDropAttribute: (place: GraphPlace, dataSet: IDataSet, attrId: string) => void
 }
 
-const _DroppablePlot = ({graphElt, plotElt, onDropAttribute}: IProps) => {
+const _DroppablePlot = ({ graphElt, plotElt, onDropAttribute }: IProps) => {
   const instanceId = useInstanceIdContext();
   const dataConfig = useDataConfigurationContext();
   const isDropAllowed = dataConfig?.graphPlaceCanAcceptAttributeIDDrop ?? (() => true);
   const droppableId = `${instanceId}-plot-area-drop`;
   const role = dataConfig?.noAttributesAssigned ? 'x' : 'legend';
-  const hintString = useDropHintString({role});
+  const hintString = useDropHintString({ role });
 
   const handleIsActive = (active: Active) => {
     const { dataSet, attributeId: droppedAttrId } = getDragAttributeInfo(active) || {};

--- a/src/plugins/graph/components/graph-axis.tsx
+++ b/src/plugins/graph/components/graph-axis.tsx
@@ -1,22 +1,22 @@
-import React, {MutableRefObject, useCallback, useEffect, useRef, useState} from "react";
-import {autorun} from "mobx";
-import {observer} from "mobx-react-lite";
-import {isAlive} from "mobx-state-tree";
-import {select} from "d3";
-import {Active} from "@dnd-kit/core";
-import {useInstanceIdContext} from "../imports/hooks/use-instance-id-context";
-import {AttributeType} from "../../../models/data/attribute";
+import React, { MutableRefObject, useCallback, useEffect, useRef, useState } from "react";
+import { autorun } from "mobx";
+import { observer } from "mobx-react-lite";
+import { isAlive } from "mobx-state-tree";
+import { select } from "d3";
+import { Active } from "@dnd-kit/core";
+import { useInstanceIdContext } from "../imports/hooks/use-instance-id-context";
+import { AttributeType } from "../../../models/data/attribute";
 import { IDataSet } from "../../../models/data/data-set";
-import {useGraphModelContext} from "../models/graph-model";
-import {useDataConfigurationContext} from "../hooks/use-data-configuration-context";
-import {useGraphLayoutContext} from "../models/graph-layout";
-import {getDragAttributeInfo, useDropHandler} from "../imports/hooks/use-drag-drop";
-import {AxisPlace} from "../imports/components/axis/axis-types";
-import {Axis} from "../imports/components/axis/components/axis";
-import {axisPlaceToAttrRole, kGraphClassSelector} from "../graph-types";
-import {GraphPlace} from "../imports/components/axis-graph-shared";
-import {AttributeLabel} from "./attribute-label";
-import {useDropHintString} from "../imports/hooks/use-drop-hint-string";
+import { useGraphModelContext } from "../models/graph-model";
+import { useDataConfigurationContext } from "../hooks/use-data-configuration-context";
+import { useGraphLayoutContext } from "../models/graph-layout";
+import { getDragAttributeInfo, useDropHandler } from "../imports/hooks/use-drag-drop";
+import { AxisPlace } from "../imports/components/axis/axis-types";
+import { Axis } from "../imports/components/axis/components/axis";
+import { axisPlaceToAttrRole, kGraphClassSelector } from "../graph-types";
+import { GraphPlace } from "../imports/components/axis-graph-shared";
+import { AttributeLabel } from "./attribute-label";
+import { useDropHintString } from "../imports/hooks/use-drop-hint-string";
 import { isAddCasesAction, isSetCaseValuesAction } from "../../../models/data/data-set-actions";
 import { computeNiceNumericBounds } from "../utilities/graph-utils";
 import { isNumericAxisModel } from "../imports/components/axis/models/axis-model";
@@ -41,7 +41,7 @@ export const GraphAxis = observer(function GraphAxis({
     instanceId = useInstanceIdContext(),
     layout = useGraphLayoutContext(),
     droppableId = `${instanceId}-${place}-axis-drop`,
-    hintString = useDropHintString({role: axisPlaceToAttrRole[place]}),
+    hintString = useDropHintString({ role: axisPlaceToAttrRole[place] }),
     emptyPlotIsNumeric = useSettingFromStores("emptyPlotIsNumeric", "graph") as boolean | undefined,
     axisShouldShowGridlines = emptyPlotIsNumeric || graphModel.axisShouldShowGridLines(place),
     parentEltRef = useRef<HTMLDivElement | null>(null),
@@ -51,7 +51,7 @@ export const GraphAxis = observer(function GraphAxis({
       _setWrapperElt(elt);
     }, []);
   const handleIsActive = (active: Active) => {
-    const {dataSet, attributeId: droppedAttrId} = getDragAttributeInfo(active) || {};
+    const { dataSet, attributeId: droppedAttrId } = getDragAttributeInfo(active) || {};
     if (isDropAllowed) {
       return isDropAllowed(place, dataSet, droppedAttrId);
     } else {
@@ -59,7 +59,7 @@ export const GraphAxis = observer(function GraphAxis({
     }
   };
   useDropHandler(droppableId, active => {
-    const {dataSet, attributeId: droppedAttrId} = getDragAttributeInfo(active) || {};
+    const { dataSet, attributeId: droppedAttrId } = getDragAttributeInfo(active) || {};
     dataSet && droppedAttrId && isDropAllowed(place, dataSet, droppedAttrId) &&
     onDropAttribute?.(place, dataSet, droppedAttrId);
   });

--- a/src/plugins/graph/components/graph-component-title-bar.tsx
+++ b/src/plugins/graph/components/graph-component-title-bar.tsx
@@ -5,7 +5,7 @@ import { observer } from "mobx-react-lite";
 import { ITileTitleBarProps } from "../imports/components/tiles/tile-base-props";
 
 export const GraphComponentTitleBar = observer(function GraphComponentTitleBar(props: ITileTitleBarProps) {
-  const {tile, ...others} = props;
+  const { tile, ...others } = props;
   const data = isGraphModel(tile?.content) ? tile?.content.data : undefined;
   const getTitle = () => tile?.title || data?.name;
 

--- a/src/plugins/graph/components/graph-component.test.tsx
+++ b/src/plugins/graph/components/graph-component.test.tsx
@@ -24,7 +24,7 @@ describe.skip("Graph", () => {
 
   it("renders graph point for each case", () => {
     const data = DataSet.create();
-    data.addAttributeWithID({ name: "xVariable"});
+    data.addAttributeWithID({ name: "xVariable" });
     data.addAttributeWithID({ name: "yVariable" });
     data.addCasesWithIDs([{ xVariable: 1, yVariable: 2, __id__: "c1" }, { xVariable: 3, yVariable: 4, __id__: "c2" }]);
     broker.addDataSet(data);

--- a/src/plugins/graph/components/graph-component.tsx
+++ b/src/plugins/graph/components/graph-component.tsx
@@ -1,23 +1,23 @@
-import {useDndContext, useDroppable} from '@dnd-kit/core';
-import {observer} from "mobx-react-lite";
-import React, {useEffect, useMemo, useRef} from "react";
-import {useResizeDetector} from "react-resize-detector";
-import {ITileBaseProps} from '../imports/components/tiles/tile-base-props';
-import {useDataSet} from '../imports/hooks/use-data-set';
-import {DataSetContext} from '../imports/hooks/use-data-set-context';
-import {useGraphController} from "../hooks/use-graph-controller";
-import {useInitGraphLayout} from '../hooks/use-init-graph-layout';
-import {InstanceIdContext, useNextInstanceId} from "../imports/hooks/use-instance-id-context";
-import {AxisLayoutContext} from "../imports/components/axis/models/axis-layout-context";
-import {GraphController} from "../models/graph-controller";
-import {GraphLayoutContext} from "../models/graph-layout";
-import {GraphModelContext, isGraphModel} from "../models/graph-model";
-import {Graph} from "./graph";
-import {DotsElt} from '../d3-types';
-import {AttributeDragOverlay} from "../imports/components/drag-drop/attribute-drag-overlay";
+import { useDndContext, useDroppable } from '@dnd-kit/core';
+import { observer } from "mobx-react-lite";
+import React, { useEffect, useMemo, useRef } from "react";
+import { useResizeDetector } from "react-resize-detector";
+import { ITileBaseProps } from '../imports/components/tiles/tile-base-props';
+import { useDataSet } from '../imports/hooks/use-data-set';
+import { DataSetContext } from '../imports/hooks/use-data-set-context';
+import { useGraphController } from "../hooks/use-graph-controller";
+import { useInitGraphLayout } from '../hooks/use-init-graph-layout';
+import { InstanceIdContext, useNextInstanceId } from "../imports/hooks/use-instance-id-context";
+import { AxisLayoutContext } from "../imports/components/axis/models/axis-layout-context";
+import { GraphController } from "../models/graph-controller";
+import { GraphLayoutContext } from "../models/graph-layout";
+import { GraphModelContext, isGraphModel } from "../models/graph-model";
+import { Graph } from "./graph";
+import { DotsElt } from '../d3-types';
+import { AttributeDragOverlay } from "../imports/components/drag-drop/attribute-drag-overlay";
 import "../register-adornment-types";
 
-export const GraphComponent = observer(function GraphComponent({tile}: ITileBaseProps) {
+export const GraphComponent = observer(function GraphComponent({ tile }: ITileBaseProps) {
   const graphModel = isGraphModel(tile?.content) ? tile?.content : undefined;
 
   const instanceId = useNextInstanceId("graph");
@@ -25,16 +25,16 @@ export const GraphComponent = observer(function GraphComponent({tile}: ITileBase
   const layout = useInitGraphLayout(graphModel);
   // Removed debouncing, but we can bring it back if we find we need it
   const graphRef = useRef<HTMLDivElement | null>(null);
-  const {width, height} = useResizeDetector<HTMLDivElement>({ targetRef: graphRef });
+  const { width, height } = useResizeDetector<HTMLDivElement>({ targetRef: graphRef });
   const enableAnimation = useRef(true);
   const autoAdjustAxes = useRef(true);
   const dotsRef = useRef<DotsElt>(null);
   const graphController = useMemo(
-    () => new GraphController({layout, enableAnimation, instanceId, autoAdjustAxes}),
+    () => new GraphController({ layout, enableAnimation, instanceId, autoAdjustAxes }),
     [layout, instanceId]
   );
 
-  useGraphController({graphController, graphModel, dotsRef});
+  useGraphController({ graphController, graphModel, dotsRef });
 
   useEffect(() => {
     (width != null) && (height != null) && layout.setParentExtent(width, height);
@@ -48,7 +48,7 @@ export const GraphComponent = observer(function GraphComponent({tile}: ITileBase
 
   // used to determine when a dragged attribute is over the graph component
   const dropId = `${instanceId}-component-drop-overlay`;
-  const {setNodeRef} = useDroppable({id: dropId});
+  const { setNodeRef } = useDroppable({ id: dropId });
   setNodeRef(graphRef.current ?? null);
 
   const { active } = useDndContext();

--- a/src/plugins/graph/components/graph.tsx
+++ b/src/plugins/graph/components/graph.tsx
@@ -1,35 +1,35 @@
-import {observer} from "mobx-react-lite";
-import {appConfig} from "../../../initialize-app";
-import React, {MutableRefObject, useEffect, useMemo, useRef} from "react";
-import {select} from "d3";
-import {GraphController} from "../models/graph-controller";
-import {DroppableAddAttribute} from "./droppable-add-attribute";
-import {Background} from "./background";
-import {DroppablePlot} from "./droppable-plot";
-import {AxisPlace, AxisPlaces} from "../imports/components/axis/axis-types";
-import {GraphAxis} from "./graph-axis";
-import {attrRoleToGraphPlace, graphPlaceToAttrRole, IDotsRef, kGraphClass} from "../graph-types";
-import {ScatterDots} from "./scatterdots";
-import {DotPlotDots} from "./dotplotdots";
-import {CaseDots} from "./casedots";
-import {ChartDots} from "./chartdots";
-import {Marquee} from "./marquee";
-import {DataConfigurationContext} from "../hooks/use-data-configuration-context";
-import {useDataSetContext} from "../imports/hooks/use-data-set-context";
-import {useGraphModel} from "../hooks/use-graph-model";
-import {setNiceDomain, startAnimation} from "../utilities/graph-utils";
-import {IAxisModel} from "../imports/components/axis/models/axis-model";
-import {GraphPlace} from "../imports/components/axis-graph-shared";
-import {useGraphLayoutContext} from "../models/graph-layout";
-import {isSetAttributeIDAction, useGraphModelContext} from "../models/graph-model";
-import {useInstanceIdContext} from "../imports/hooks/use-instance-id-context";
-import {MarqueeState} from "../models/marquee-state";
-import {Legend} from "./legend/legend";
-import {MultiLegend} from "./legend/multi-legend";
-import {AttributeType} from "../../../models/data/attribute";
-import {IDataSet} from "../../../models/data/data-set";
-import {useDataTips} from "../hooks/use-data-tips";
-import {onAnyAction} from "../../../utilities/mst-utils";
+import { observer } from "mobx-react-lite";
+import { appConfig } from "../../../initialize-app";
+import React, { MutableRefObject, useEffect, useMemo, useRef } from "react";
+import { select } from "d3";
+import { GraphController } from "../models/graph-controller";
+import { DroppableAddAttribute } from "./droppable-add-attribute";
+import { Background } from "./background";
+import { DroppablePlot } from "./droppable-plot";
+import { AxisPlace, AxisPlaces } from "../imports/components/axis/axis-types";
+import { GraphAxis } from "./graph-axis";
+import { attrRoleToGraphPlace, graphPlaceToAttrRole, IDotsRef, kGraphClass } from "../graph-types";
+import { ScatterDots } from "./scatterdots";
+import { DotPlotDots } from "./dotplotdots";
+import { CaseDots } from "./casedots";
+import { ChartDots } from "./chartdots";
+import { Marquee } from "./marquee";
+import { DataConfigurationContext } from "../hooks/use-data-configuration-context";
+import { useDataSetContext } from "../imports/hooks/use-data-set-context";
+import { useGraphModel } from "../hooks/use-graph-model";
+import { setNiceDomain, startAnimation } from "../utilities/graph-utils";
+import { IAxisModel } from "../imports/components/axis/models/axis-model";
+import { GraphPlace } from "../imports/components/axis-graph-shared";
+import { useGraphLayoutContext } from "../models/graph-layout";
+import { isSetAttributeIDAction, useGraphModelContext } from "../models/graph-model";
+import { useInstanceIdContext } from "../imports/hooks/use-instance-id-context";
+import { MarqueeState } from "../models/marquee-state";
+import { Legend } from "./legend/legend";
+import { MultiLegend } from "./legend/multi-legend";
+import { AttributeType } from "../../../models/data/attribute";
+import { IDataSet } from "../../../models/data/data-set";
+import { useDataTips } from "../hooks/use-data-tips";
+import { onAnyAction } from "../../../utilities/mst-utils";
 import { Adornments } from "../adornments/adornments";
 
 import "./graph.scss";
@@ -41,10 +41,10 @@ interface IProps {
   dotsRef: IDotsRef
 }
 
-export const Graph = observer(function Graph({graphController, graphRef, dotsRef}: IProps) {
+export const Graph = observer(function Graph({ graphController, graphRef, dotsRef }: IProps) {
   const graphModel = useGraphModelContext(),
-    {autoAdjustAxes, enableAnimation} = graphController,
-    {plotType} = graphModel,
+    { autoAdjustAxes, enableAnimation } = graphController,
+    { plotType } = graphModel,
     instanceId = useInstanceIdContext(),
     marqueeState = useMemo<MarqueeState>(() => new MarqueeState(), []),
     dataset = useDataSetContext(),
@@ -118,7 +118,7 @@ export const Graph = observer(function Graph({graphController, graphRef, dotsRef
     }
   };
 
-  useDataTips({dotsRef, dataset, graphModel, enableAnimation});
+  useDataTips({ dotsRef, dataset, graphModel, enableAnimation });
 
   const renderPlotComponent = () => {
     const props = {
@@ -171,7 +171,7 @@ export const Graph = observer(function Graph({graphController, graphRef, dotsRef
     return droppables;
   };
 
-  useGraphModel({dotsRef, graphModel, enableAnimation, instanceId});
+  useGraphModel({ dotsRef, graphModel, enableAnimation, instanceId });
 
   return (
     <DataConfigurationContext.Provider value={graphModel.config}>

--- a/src/plugins/graph/components/legend/categorical-legend.tsx
+++ b/src/plugins/graph/components/legend/categorical-legend.tsx
@@ -1,16 +1,16 @@
-import {observer} from "mobx-react-lite";
-import {reaction} from "mobx";
-import {drag, range, select} from "d3";
-import React, {useCallback, useEffect, useMemo, useRef} from "react";
-import {isSelectionAction} from "../../../../models/data/data-set-actions";
-import {useDataConfigurationContext} from "../../hooks/use-data-configuration-context";
-import {useGraphLayoutContext} from "../../models/graph-layout";
-import {missingColor} from "../../../../utilities/color-utils";
-import {onAnyAction} from "../../../../utilities/mst-utils";
-import {measureText} from "../../../../components/tiles/hooks/use-measure-text";
-import {kGraphFont, transitionDuration} from "../../graph-types";
-import {getStringBounds} from "../../imports/components/axis/axis-utils";
-import {axisGap} from "../../imports/components/axis/axis-types";
+import { observer } from "mobx-react-lite";
+import { reaction } from "mobx";
+import { drag, range, select } from "d3";
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
+import { isSelectionAction } from "../../../../models/data/data-set-actions";
+import { useDataConfigurationContext } from "../../hooks/use-data-configuration-context";
+import { useGraphLayoutContext } from "../../models/graph-layout";
+import { missingColor } from "../../../../utilities/color-utils";
+import { onAnyAction } from "../../../../utilities/mst-utils";
+import { measureText } from "../../../../components/tiles/hooks/use-measure-text";
+import { kGraphFont, transitionDuration } from "../../graph-types";
+import { getStringBounds } from "../../imports/components/axis/axis-utils";
+import { axisGap } from "../../imports/components/axis/axis-types";
 
 import './legend.scss';
 import graphVars from "../graph.scss";
@@ -55,7 +55,7 @@ interface LayoutData {
 const labelHeight = getStringBounds('Wy', graphVars.graphLabelFont).height;
 
 const coordinatesToCatIndex = (lod: LayoutData, numCategories: number, localPoint: { x: number, y: number }) => {
-    const {x, y} = localPoint,
+    const { x, y } = localPoint,
       col = Math.floor(x / lod.columnWidth),
       row = Math.floor(y / (keySize + padding)),
       catIndex = row * lod.numColumns + col;
@@ -69,7 +69,7 @@ const coordinatesToCatIndex = (lod: LayoutData, numCategories: number, localPoin
   };
 
 export const CategoricalLegend = observer(function CategoricalLegend(
-  {transform}: ICategoricalLegendProps) {
+  { transform }: ICategoricalLegendProps) {
   const transformRef = useRef(transform),
     dataConfiguration = useDataConfigurationContext(),
     dataset = dataConfiguration?.dataset,
@@ -86,8 +86,8 @@ export const CategoricalLegend = observer(function CategoricalLegend(
     ),
     dragInfo = useRef<DragInfo>({
       indexOfCategory: -1,
-      initialOffset: {x: 0, y: 0},
-      currentDragPosition: {x: 0, y: 0}
+      initialOffset: { x: 0, y: 0 },
+      currentDragPosition: { x: 0, y: 0 }
     }),
     duration = useRef(0);
 
@@ -201,7 +201,7 @@ export const CategoricalLegend = observer(function CategoricalLegend(
         catIndex = coordinatesToCatIndex(lod, numCategories, localPt),
         keyLocation = catLocation(lod, categoryData.current, catIndex);
       dI.indexOfCategory = catIndex;
-      dI.initialOffset = {x: localPt.x - keyLocation.x, y: localPt.y - keyLocation.y};
+      dI.initialOffset = { x: localPt.x - keyLocation.x, y: localPt.y - keyLocation.y };
       dI.currentDragPosition = localPt;
       duration.current = 0;
     }, [layout]),
@@ -294,7 +294,7 @@ export const CategoricalLegend = observer(function CategoricalLegend(
   useEffect(function respondToLayoutChange() {
     const disposer = reaction(
       () => {
-        const {graphHeight, graphWidth} = layout,
+        const { graphHeight, graphWidth } = layout,
           legendAttrID = dataConfiguration?.attributeID('legend');
         return [graphHeight, graphWidth, legendAttrID];
       },
@@ -303,7 +303,7 @@ export const CategoricalLegend = observer(function CategoricalLegend(
         // todo: Figure out whether this is cause extra calls to setupKeys and refreshKeys
         setupKeys();
         refreshKeys();
-      }, {fireImmediately: true}
+      }, { fireImmediately: true }
     );
     return () => disposer();
   }, [layout, refreshKeys, computeDesiredExtent, dataConfiguration, setupKeys]);

--- a/src/plugins/graph/components/legend/choropleth-legend/choropleth-legend.ts
+++ b/src/plugins/graph/components/legend/choropleth-legend/choropleth-legend.ts
@@ -15,8 +15,8 @@ import {
   // range,
   select, range, min, max, ScaleQuantile, NumberValue
 } from "d3";
-import {kChoroplethHeight} from "../../../graph-types";
-import {neededSigDigitsArrayForQuantiles} from "../../../utilities/math-utils";
+import { kChoroplethHeight } from "../../../graph-types";
+import { neededSigDigitsArrayForQuantiles } from "../../../utilities/math-utils";
 
 export type ChoroplethLegendProps = {
   tickSize?: number,

--- a/src/plugins/graph/components/legend/legend.tsx
+++ b/src/plugins/graph/components/legend/legend.tsx
@@ -1,20 +1,20 @@
-import {autorun} from "mobx";
-import React, {useEffect, useRef} from "react";
-import {select} from "d3";
-import {Active} from "@dnd-kit/core";
-import {useDataConfigurationContext} from "../../hooks/use-data-configuration-context";
-import {useGraphLayoutContext} from "../../models/graph-layout";
-import {AttributeLabel} from "../attribute-label";
-import {CategoricalLegend} from "./categorical-legend";
-import {NumericLegend} from "./numeric-legend";
-import {DroppableSvg} from "../droppable-svg";
-import {useInstanceIdContext} from "../../imports/hooks/use-instance-id-context";
-import {getDragAttributeInfo, useDropHandler} from "../../imports/hooks/use-drag-drop";
-import {useDropHintString} from "../../imports/hooks/use-drop-hint-string";
-import {AttributeType} from "../../../../models/data/attribute";
-import {IDataSet} from "../../../../models/data/data-set";
-import {GraphAttrRole} from "../../graph-types";
-import {GraphPlace} from "../../imports/components/axis-graph-shared";
+import { autorun } from "mobx";
+import React, { useEffect, useRef } from "react";
+import { select } from "d3";
+import { Active } from "@dnd-kit/core";
+import { useDataConfigurationContext } from "../../hooks/use-data-configuration-context";
+import { useGraphLayoutContext } from "../../models/graph-layout";
+import { AttributeLabel } from "../attribute-label";
+import { CategoricalLegend } from "./categorical-legend";
+import { NumericLegend } from "./numeric-legend";
+import { DroppableSvg } from "../droppable-svg";
+import { useInstanceIdContext } from "../../imports/hooks/use-instance-id-context";
+import { getDragAttributeInfo, useDropHandler } from "../../imports/hooks/use-drag-drop";
+import { useDropHintString } from "../../imports/hooks/use-drop-hint-string";
+import { AttributeType } from "../../../../models/data/attribute";
+import { IDataSet } from "../../../../models/data/data-set";
+import { GraphAttrRole } from "../../graph-types";
+import { GraphPlace } from "../../imports/components/axis-graph-shared";
 
 interface ILegendProps {
   legendAttrID: string
@@ -36,10 +36,10 @@ export const Legend = function Legend({
     instanceId = useInstanceIdContext(),
     droppableId = `${instanceId}-legend-area-drop`,
     role = 'legend' as GraphAttrRole,
-    hintString = useDropHintString({role});
+    hintString = useDropHintString({ role });
 
   const handleIsActive = (active: Active) => {
-    const {dataSet, attributeId: droppedAttrId} = getDragAttributeInfo(active) || {};
+    const { dataSet, attributeId: droppedAttrId } = getDragAttributeInfo(active) || {};
     if (isDropAllowed) {
       return isDropAllowed('legend', dataSet, droppedAttrId);
     } else {
@@ -48,7 +48,7 @@ export const Legend = function Legend({
   };
 
   useDropHandler(droppableId, active => {
-    const {dataSet, attributeId: dragAttributeID} = getDragAttributeInfo(active) || {};
+    const { dataSet, attributeId: dragAttributeID } = getDragAttributeInfo(active) || {};
     dataSet && dragAttributeID && isDropAllowed('legend', dataSet, dragAttributeID) &&
     onDropAttribute('legend', dataSet, dragAttributeID);
   });

--- a/src/plugins/graph/components/legend/multi-legend.tsx
+++ b/src/plugins/graph/components/legend/multi-legend.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from "react";
-import {AttributeType} from "../../../../models/data/attribute";
+import { AttributeType } from "../../../../models/data/attribute";
 import { GraphPlace } from "../../imports/components/axis-graph-shared";
 import { SimpleAttributeLabel } from "../simple-attribute-label";
 import { kMultiLegendHeight, useGraphLayoutContext } from "../../models/graph-layout";
@@ -13,7 +13,7 @@ interface IMultiLegendProps {
 }
 
 export const MultiLegend = function MultiLegend(props: IMultiLegendProps) {
-  const {onChangeAttribute, onRemoveAttribute, onTreatAttributeAs} = props;
+  const { onChangeAttribute, onRemoveAttribute, onTreatAttributeAs } = props;
   const layout = useGraphLayoutContext();
   const legendBounds = layout.computedBounds.legend;
   const transform = `translate(${legendBounds.left}, ${legendBounds.top})`;

--- a/src/plugins/graph/components/legend/numeric-legend.tsx
+++ b/src/plugins/graph/components/legend/numeric-legend.tsx
@@ -1,14 +1,14 @@
-import React, {memo, useCallback, useEffect, useRef, useState} from "react";
-import {reaction} from "mobx";
-import {ScaleQuantile, scaleQuantile, schemeBlues} from "d3";
-import {useDataConfigurationContext} from "../../hooks/use-data-configuration-context";
-import {isSelectionAction} from "../../../../models/data/data-set-actions";
-import {useGraphLayoutContext} from "../../models/graph-layout";
-import {choroplethLegend} from "./choropleth-legend/choropleth-legend";
-import {useDataSetContext} from "../../imports/hooks/use-data-set-context";
-import {kChoroplethHeight} from "../../graph-types";
-import {axisGap} from "../../imports/components/axis/axis-types";
-import {getStringBounds} from "../../imports/components/axis/axis-utils";
+import React, { memo, useCallback, useEffect, useRef, useState } from "react";
+import { reaction } from "mobx";
+import { ScaleQuantile, scaleQuantile, schemeBlues } from "d3";
+import { useDataConfigurationContext } from "../../hooks/use-data-configuration-context";
+import { isSelectionAction } from "../../../../models/data/data-set-actions";
+import { useGraphLayoutContext } from "../../models/graph-layout";
+import { choroplethLegend } from "./choropleth-legend/choropleth-legend";
+import { useDataSetContext } from "../../imports/hooks/use-data-set-context";
+import { kChoroplethHeight } from "../../graph-types";
+import { axisGap } from "../../imports/components/axis/axis-types";
+import { getStringBounds } from "../../imports/components/axis/axis-utils";
 
 import graphVars from "../graph.scss";
 
@@ -17,7 +17,7 @@ interface INumericLegendProps {
   legendAttrID: string
 }
 
-export const NumericLegend = memo(function NumericLegend({legendAttrID}: INumericLegendProps) {
+export const NumericLegend = memo(function NumericLegend({ legendAttrID }: INumericLegendProps) {
   const dataConfiguration = useDataConfigurationContext(),
     layout = useGraphLayoutContext(),
     dataset = useDataSetContext(),
@@ -64,13 +64,13 @@ export const NumericLegend = memo(function NumericLegend({legendAttrID}: INumeri
   useEffect(function respondToLayoutChange() {
     const disposer = reaction(
       () => {
-        const {graphHeight, graphWidth} = layout,
+        const { graphHeight, graphWidth } = layout,
           legendID = dataConfiguration?.attributeID('legend');
         return [graphHeight, graphWidth, legendID];
       },
       () => {
         refreshScale();
-      }, {fireImmediately: true}
+      }, { fireImmediately: true }
     );
     return () => disposer();
   }, [layout, dataConfiguration, refreshScale]);

--- a/src/plugins/graph/components/marquee.tsx
+++ b/src/plugins/graph/components/marquee.tsx
@@ -1,10 +1,10 @@
-import React, {useEffect, useRef} from "react";
-import {observer} from "mobx-react-lite";
-import {select} from "d3";
-import {MarqueeState} from "../models/marquee-state";
+import React, { useEffect, useRef } from "react";
+import { observer } from "mobx-react-lite";
+import { select } from "d3";
+import { MarqueeState } from "../models/marquee-state";
 import "./marquee.scss";
 
-export const Marquee = observer(function Marquee(props:{marqueeState: MarqueeState}) {
+export const Marquee = observer(function Marquee(props:{ marqueeState: MarqueeState }) {
   const marqueeRef = useRef<SVGSVGElement>(null),
     marqueeRect = props.marqueeState.marqueeRect;
 

--- a/src/plugins/graph/components/scatterdots.tsx
+++ b/src/plugins/graph/components/scatterdots.tsx
@@ -1,14 +1,14 @@
-import {ScaleBand, ScaleLinear, select} from "d3";
-import React, {useCallback, useRef, useState} from "react";
-import {ScaleNumericBaseType} from "../imports/components/axis/axis-types";
-import {CaseData} from "../d3-types";
-import {PlotProps} from "../graph-types";
-import {useDragHandlers, usePlotResponders} from "../hooks/use-plot";
-import {useDataConfigurationContext} from "../hooks/use-data-configuration-context";
-import {useDataSetContext} from "../imports/hooks/use-data-set-context";
+import { ScaleBand, ScaleLinear, select } from "d3";
+import React, { useCallback, useRef, useState } from "react";
+import { ScaleNumericBaseType } from "../imports/components/axis/axis-types";
+import { CaseData } from "../d3-types";
+import { PlotProps } from "../graph-types";
+import { useDragHandlers, usePlotResponders } from "../hooks/use-plot";
+import { useDataConfigurationContext } from "../hooks/use-data-configuration-context";
+import { useDataSetContext } from "../imports/hooks/use-data-set-context";
 // import {useInstanceIdContext} from "../hooks/use-instance-id-context";
-import {useGraphLayoutContext} from "../models/graph-layout";
-import {ICase} from "../../../models/data/data-set-types";
+import { useGraphLayoutContext } from "../models/graph-layout";
+import { ICase } from "../../../models/data/data-set-types";
 import {
   // getScreenCoord,
   handleClickOnDot,
@@ -16,10 +16,10 @@ import {
   setPointSelection,
   startAnimation
 } from "../utilities/graph-utils";
-import {useGraphModelContext} from "../models/graph-model";
+import { useGraphModelContext } from "../models/graph-model";
 
 export const ScatterDots = function ScatterDots(props: PlotProps) {
-  const {dotsRef, enableAnimation} = props,
+  const { dotsRef, enableAnimation } = props,
     graphModel = useGraphModelContext(),
     // instanceId = useInstanceIdContext(),
     dataConfiguration = useDataConfigurationContext(),
@@ -32,7 +32,7 @@ export const ScatterDots = function ScatterDots(props: PlotProps) {
     legendAttrID = dataConfiguration?.attributeID('legend') as string,
     yScaleRef = useRef<ScaleNumericBaseType>(),
     [dragID, setDragID] = useState(''),
-    currPos = useRef({x: 0, y: 0}),
+    currPos = useRef({ x: 0, y: 0 }),
     didDrag = useRef(false),
     target = useRef<any>(),
     selectedDataObjects = useRef<Record<string, { x: number, y: number }>>({}),
@@ -61,11 +61,11 @@ export const ScatterDots = function ScatterDots(props: PlotProps) {
           .transition()
           .attr('r', dragPointRadiusRef.current);
         setDragID(tItsID);
-        currPos.current = {x: event.clientX, y: event.clientY};
+        currPos.current = { x: event.clientX, y: event.clientY };
 
         handleClickOnDot(event, tItsID, dataset);
         // Record the current values, so we can change them during the drag and restore them when done
-        const {selection} = dataConfiguration || {},
+        const { selection } = dataConfiguration || {},
           xAttrID = dataConfiguration?.attributeID('x') ?? '';
         selection?.forEach(anID => {
           selectedDataObjects.current[anID] = {
@@ -80,7 +80,7 @@ export const ScatterDots = function ScatterDots(props: PlotProps) {
       const xAxisScale = layout.getAxisScale('bottom') as ScaleLinear<number, number>,
         xAttrID = dataConfiguration?.attributeID('x') ?? '';
       if (dragID !== '') {
-        const newPos = {x: event.clientX, y: event.clientY},
+        const newPos = { x: event.clientX, y: event.clientY },
           dx = newPos.x - currPos.current.x,
           dy = newPos.y - currPos.current.y;
         currPos.current = newPos;
@@ -89,7 +89,7 @@ export const ScatterDots = function ScatterDots(props: PlotProps) {
           const deltaX = Number(xAxisScale.invert(dx)) - Number(xAxisScale.invert(0)),
             deltaY = Number(yScaleRef.current?.invert(dy)) - Number(yScaleRef.current?.invert(0)),
             caseValues: ICase[] = [],
-            {selection} = dataConfiguration || {};
+            { selection } = dataConfiguration || {};
           selection?.forEach(anID => {
             const currX = Number(dataset?.getNumeric(anID, xAttrID)),
               currY = Number(dataset?.getNumeric(anID, secondaryAttrIDsRef.current[plotNumRef.current]));
@@ -121,7 +121,7 @@ export const ScatterDots = function ScatterDots(props: PlotProps) {
 
         if (didDrag.current) {
           const caseValues: ICase[] = [],
-            {selection} = dataConfiguration || {},
+            { selection } = dataConfiguration || {},
             xAttrID = dataConfiguration?.attributeID('x') ?? '';
           selection?.forEach(anID => {
             caseValues.push({
@@ -138,10 +138,10 @@ export const ScatterDots = function ScatterDots(props: PlotProps) {
       }
     }, [dataConfiguration, dataset, dragID, enableAnimation,]);
 
-  useDragHandlers(window, {start: onDragStart, drag: onDrag, end: onDragEnd});
+  useDragHandlers(window, { start: onDragStart, drag: onDrag, end: onDragEnd });
 
   const refreshPointSelection = useCallback(() => {
-    const {pointColor, pointStrokeColor} = graphModel;
+    const { pointColor, pointStrokeColor } = graphModel;
     dataConfiguration && setPointSelection(
       {
         dotsRef, dataConfiguration, pointRadius: pointRadiusRef.current,
@@ -174,7 +174,7 @@ export const ScatterDots = function ScatterDots(props: PlotProps) {
     };
 
     const yAttrIDs = dataConfiguration?.yAttributeIDs || [],
-      {pointColor, pointStrokeColor} = graphModel,
+      { pointColor, pointStrokeColor } = graphModel,
       hasY2Attribute = dataConfiguration?.hasY2Attribute,
       v2Scale = layout.getAxisScale("rightNumeric") as ScaleNumericBaseType,
       numExtraPrimaryBands = dataConfiguration?.numRepetitionsForPlace('bottom') ?? 1,

--- a/src/plugins/graph/components/simple-attribute-label.tsx
+++ b/src/plugins/graph/components/simple-attribute-label.tsx
@@ -1,9 +1,9 @@
-import React, {useRef} from "react";
-import {createPortal} from "react-dom";
-import {observer} from "mobx-react-lite";
-import {GraphPlace } from "../imports/components/axis-graph-shared";
-import {AttributeType} from "../../../models/data/attribute";
-import {AxisOrLegendAttributeMenu} from "../imports/components/axis/components/axis-or-legend-attribute-menu";
+import React, { useRef } from "react";
+import { createPortal } from "react-dom";
+import { observer } from "mobx-react-lite";
+import { GraphPlace } from "../imports/components/axis-graph-shared";
+import { AttributeType } from "../../../models/data/attribute";
+import { AxisOrLegendAttributeMenu } from "../imports/components/axis/components/axis-or-legend-attribute-menu";
 import { graphPlaceToAttrRole, kGraphClassSelector } from "../graph-types";
 import { useDataConfigurationContext } from "../hooks/use-data-configuration-context";
 import { useGraphModelContext } from "../models/graph-model";
@@ -21,7 +21,7 @@ interface ISimpleAttributeLabelProps {
 
 export const SimpleAttributeLabel = observer(
   function SimpleAttributeLabel(props: ISimpleAttributeLabelProps) {
-    const {place, onTreatAttributeAs, onRemoveAttribute, onChangeAttribute} = props;
+    const { place, onTreatAttributeAs, onRemoveAttribute, onChangeAttribute } = props;
     const simpleLabelRef = useRef<HTMLDivElement>(null);
     const parentElt = simpleLabelRef.current?.closest(kGraphClassSelector) as HTMLDivElement ?? null;
     const dataConfiguration = useDataConfigurationContext();

--- a/src/plugins/graph/graph-types.ts
+++ b/src/plugins/graph/graph-types.ts
@@ -1,7 +1,7 @@
 import React from "react";
 import { AxisPlace } from "./imports/components/axis/axis-types";
-import {GraphPlace} from "./imports/components/axis-graph-shared";
-import {DotsElt} from "./d3-types";
+import { GraphPlace } from "./imports/components/axis-graph-shared";
+import { DotsElt } from "./d3-types";
 
 export const kGraphTileType = "Graph";
 export const kGraphTileClass = "graph";
@@ -60,7 +60,7 @@ export interface InternalizedData {
 
 export type Point = { x: number, y: number };
 export type CPLine = { slope: number, intercept: number, pivot1?: Point, pivot2?: Point };
-export const kNullPoint = {x: -999, y: -999};
+export const kNullPoint = { x: -999, y: -999 };
 
 export interface Rect {
   x: number, y: number, width: number, height: number

--- a/src/plugins/graph/hooks/use-data-tips.ts
+++ b/src/plugins/graph/hooks/use-data-tips.ts
@@ -1,11 +1,11 @@
-import {select} from "d3";
-import React, {useEffect} from "react";
-import {tip as d3tip} from "d3-v6-tip";
-import {IGraphModel} from "../models/graph-model";
-import {IDotsRef, transitionDuration} from "../graph-types";
-import {IDataSet} from "../../../models/data/data-set";
-import {getPointTipText} from "../utilities/graph-utils";
-import {RoleAttrIDPair} from "../models/data-configuration-model";
+import { select } from "d3";
+import React, { useEffect } from "react";
+import { tip as d3tip } from "d3-v6-tip";
+import { IGraphModel } from "../models/graph-model";
+import { IDotsRef, transitionDuration } from "../graph-types";
+import { IDataSet } from "../../../models/data/data-set";
+import { getPointTipText } from "../utilities/graph-utils";
+import { RoleAttrIDPair } from "../models/data-configuration-model";
 import { CaseData } from "../d3-types";
 
 const dataTip = d3tip().attr('class', 'graph-d3-tip')/*.attr('opacity', 0.8)*/
@@ -20,7 +20,7 @@ interface IUseDataTips {
   graphModel: IGraphModel,
   enableAnimation: React.MutableRefObject<boolean>
 }
-export const useDataTips = ({dotsRef, dataset, graphModel, enableAnimation}:IUseDataTips) => {
+export const useDataTips = ({ dotsRef, dataset, graphModel, enableAnimation }:IUseDataTips) => {
   const hoverPointRadius = graphModel.getPointRadius('hover-drag'),
     pointRadius = graphModel.getPointRadius(),
     selectedPointRadius = graphModel.getPointRadius('select'),

--- a/src/plugins/graph/hooks/use-graph-controller.ts
+++ b/src/plugins/graph/hooks/use-graph-controller.ts
@@ -1,7 +1,7 @@
-import {useEffect} from "react";
-import {IDotsRef} from "../graph-types";
-import {GraphController} from "../models/graph-controller";
-import {IGraphModel} from "../models/graph-model";
+import { useEffect } from "react";
+import { IDotsRef } from "../graph-types";
+import { GraphController } from "../models/graph-controller";
+import { IGraphModel } from "../models/graph-model";
 
 export interface IUseGraphControllerProps {
   graphController: GraphController,
@@ -9,8 +9,8 @@ export interface IUseGraphControllerProps {
   dotsRef: IDotsRef
 }
 
-export const useGraphController = ({graphController, graphModel, dotsRef}: IUseGraphControllerProps) => {
+export const useGraphController = ({ graphController, graphModel, dotsRef }: IUseGraphControllerProps) => {
   useEffect(() => {
-    graphModel && graphController.setProperties({graphModel, dotsRef});
+    graphModel && graphController.setProperties({ graphModel, dotsRef });
   }, [graphController, graphModel, dotsRef]);
 };

--- a/src/plugins/graph/hooks/use-graph-model.ts
+++ b/src/plugins/graph/hooks/use-graph-model.ts
@@ -1,11 +1,11 @@
-import {MutableRefObject, useCallback, useEffect} from "react";
-import {isAddCasesAction, isRemoveCasesAction} from "../../../models/data/data-set-actions";
-import {IGraphModel, isGraphVisualPropsAction} from "../models/graph-model";
-import {useDataSetContext} from "../imports/hooks/use-data-set-context";
-import {INumericAxisModel} from "../imports/components/axis/models/axis-model";
-import {IDotsRef} from "../graph-types";
-import {matchCirclesToData, setNiceDomain, startAnimation} from "../utilities/graph-utils";
-import {onAnyAction} from "../../../utilities/mst-utils";
+import { MutableRefObject, useCallback, useEffect } from "react";
+import { isAddCasesAction, isRemoveCasesAction } from "../../../models/data/data-set-actions";
+import { IGraphModel, isGraphVisualPropsAction } from "../models/graph-model";
+import { useDataSetContext } from "../imports/hooks/use-data-set-context";
+import { INumericAxisModel } from "../imports/components/axis/models/axis-model";
+import { IDotsRef } from "../graph-types";
+import { matchCirclesToData, setNiceDomain, startAnimation } from "../utilities/graph-utils";
+import { onAnyAction } from "../../../utilities/mst-utils";
 
 interface IProps {
   graphModel: IGraphModel
@@ -15,7 +15,7 @@ interface IProps {
 }
 
 export function useGraphModel(props: IProps) {
-  const {graphModel, enableAnimation, dotsRef, instanceId} = props,
+  const { graphModel, enableAnimation, dotsRef, instanceId } = props,
     dataConfig = graphModel.config,
     yAttrID = graphModel.getAttributeID('y'),
     dataset = useDataSetContext();

--- a/src/plugins/graph/hooks/use-movables.ts
+++ b/src/plugins/graph/hooks/use-movables.ts
@@ -1,8 +1,8 @@
-import {useCallback, useEffect} from "react";
-import {ScaleNumericBaseType} from "../imports/components/axis/axis-types";
-import {useGraphLayoutContext} from "../models/graph-layout";
-import {useGraphModelContext} from "../models/graph-model";
-import {onAnyAction} from "../../../utilities/mst-utils";
+import { useCallback, useEffect } from "react";
+import { ScaleNumericBaseType } from "../imports/components/axis/axis-types";
+import { useGraphLayoutContext } from "../models/graph-layout";
+import { useGraphModelContext } from "../models/graph-model";
+import { onAnyAction } from "../../../utilities/mst-utils";
 import { IMovableLineModel } from "../adornments/movable-line/movable-line-model";
 import { IMovableValueModel } from "../adornments/movable-value/movable-value-model";
 
@@ -12,7 +12,7 @@ interface IProps {
 }
 
 export function useMovables(props: IProps) {
-  const { movableValueModel, movableLineModel} = props,
+  const { movableValueModel, movableLineModel } = props,
     graphModel = useGraphModelContext(),
     layout = useGraphLayoutContext(),
     xScale = layout.getAxisScale('bottom') as ScaleNumericBaseType,
@@ -21,8 +21,8 @@ export function useMovables(props: IProps) {
   const updateMovables = useCallback(() => {
     const xDomainDelta = xScale.domain()[1] - xScale.domain()[0],
       yDomainDelta = yScale.domain()[1] - yScale.domain()[0];
-    movableLineModel.setLine({intercept: yScale.domain()[0] + yDomainDelta / 3, slope: yDomainDelta / xDomainDelta,
-      pivot1:undefined, pivot2:undefined});
+    movableLineModel.setLine({ intercept: yScale.domain()[0] + yDomainDelta / 3, slope: yDomainDelta / xDomainDelta,
+      pivot1:undefined, pivot2:undefined });
     movableValueModel.setValue(xScale.domain()[0] + xDomainDelta / 3);
   }, [xScale, yScale, movableLineModel, movableValueModel]);
 

--- a/src/plugins/graph/hooks/use-plot.ts
+++ b/src/plugins/graph/hooks/use-plot.ts
@@ -1,14 +1,14 @@
-import React, {useCallback, useEffect, useRef} from "react";
-import {autorun, reaction} from "mobx";
-import {isSelectionAction, isSetCaseValuesAction} from "../../../models/data/data-set-actions";
-import {IDotsRef, GraphAttrRoles} from "../graph-types";
-import {INumericAxisModel} from "../imports/components/axis/models/axis-model";
-import {useGraphLayoutContext} from "../models/graph-layout";
-import {useGraphModelContext} from "../models/graph-model";
-import {matchCirclesToData, startAnimation} from "../utilities/graph-utils";
-import {useCurrent} from "../../../hooks/use-current";
-import {useInstanceIdContext} from "../imports/hooks/use-instance-id-context";
-import {onAnyAction} from "../../../utilities/mst-utils";
+import React, { useCallback, useEffect, useRef } from "react";
+import { autorun, reaction } from "mobx";
+import { isSelectionAction, isSetCaseValuesAction } from "../../../models/data/data-set-actions";
+import { IDotsRef, GraphAttrRoles } from "../graph-types";
+import { INumericAxisModel } from "../imports/components/axis/models/axis-model";
+import { useGraphLayoutContext } from "../models/graph-layout";
+import { useGraphModelContext } from "../models/graph-model";
+import { matchCirclesToData, startAnimation } from "../utilities/graph-utils";
+import { useCurrent } from "../../../hooks/use-current";
+import { useInstanceIdContext } from "../imports/hooks/use-instance-id-context";
+import { onAnyAction } from "../../../utilities/mst-utils";
 
 interface IDragHandlers {
   start: (event: MouseEvent) => void
@@ -16,7 +16,7 @@ interface IDragHandlers {
   end: (event: MouseEvent) => void
 }
 
-export const useDragHandlers = (target: any, {start, drag, end}: IDragHandlers) => {
+export const useDragHandlers = (target: any, { start, drag, end }: IDragHandlers) => {
   useEffect(() => {
     if (target) {
       target.addEventListener('mousedown', start);
@@ -40,7 +40,7 @@ export interface IPlotResponderProps {
 }
 
 export const usePlotResponders = (props: IPlotResponderProps) => {
-  const {enableAnimation, refreshPointPositions, refreshPointSelection, dotsRef} = props,
+  const { enableAnimation, refreshPointPositions, refreshPointSelection, dotsRef } = props,
     graphModel = useGraphModelContext(),
     layout = useGraphLayoutContext(),
     dataConfiguration = graphModel.config,
@@ -91,7 +91,7 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
       },
       () => {
         callRefreshPointPositions(false);
-      }, {fireImmediately: true}
+      }, { fireImmediately: true }
     );
     return () => disposer();
   }, [callRefreshPointPositions, graphModel]);

--- a/src/plugins/graph/hooks/use-point-locations.ts
+++ b/src/plugins/graph/hooks/use-point-locations.ts
@@ -15,7 +15,7 @@ interface GetScreenXYParams {
 }
 
 // These functions are modelled after the getScreenX and getScreenY functions in scatterdots.tsx
-export const getScreenX = ({ caseId, dataset, layout, dataConfig}: GetScreenXYParams) => {
+export const getScreenX = ({ caseId, dataset, layout, dataConfig }: GetScreenXYParams) => {
   const xAttrID = dataConfig?.attributeID('x') ?? '';
   const xValue = dataset?.getNumeric(caseId, xAttrID) ?? NaN;
   const xScale = layout.getAxisScale('bottom') as ScaleLinear<number, number>;
@@ -53,8 +53,8 @@ export const usePointLocations = () => {
 
   caseIds?.forEach((caseId) => {
     if (dataConfig && dataset && layout) {
-      xSeries.push(getScreenX({caseId, dataset, layout, dataConfig}));
-      ySeries.push(getScreenY({caseId, dataset, layout, dataConfig}));
+      xSeries.push(getScreenX({ caseId, dataset, layout, dataConfig }));
+      ySeries.push(getScreenY({ caseId, dataset, layout, dataConfig }));
     }
   });
 

--- a/src/plugins/graph/imports/components/axis-graph-shared.ts
+++ b/src/plugins/graph/imports/components/axis-graph-shared.ts
@@ -1,4 +1,4 @@
-import {AxisPlaces} from "./axis/axis-types";
+import { AxisPlaces } from "./axis/axis-types";
 
 export const GraphPlaces = [...AxisPlaces, "yPlus", "plot", "legend"] as const;
 export type GraphPlace = typeof GraphPlaces[number];

--- a/src/plugins/graph/imports/components/axis/axis-types.ts
+++ b/src/plugins/graph/imports/components/axis/axis-types.ts
@@ -1,5 +1,5 @@
-import {axisBottom, axisLeft, axisRight, axisTop,
-  ScaleBand, ScaleContinuousNumeric, ScaleOrdinal, select, Selection} from "d3";
+import { axisBottom, axisLeft, axisRight, axisTop,
+  ScaleBand, ScaleContinuousNumeric, ScaleOrdinal, select, Selection } from "d3";
 
 export const axisGap = 5;
 

--- a/src/plugins/graph/imports/components/axis/axis-utils.ts
+++ b/src/plugins/graph/imports/components/axis/axis-utils.ts
@@ -1,9 +1,9 @@
-import {ScaleLinear} from "d3";
-import {MutableRefObject} from "react";
-import {AxisPlace} from "./axis-types";
-import {measureText, measureTextExtent} from "../../../../../components/tiles/hooks/use-measure-text";
-import {kAxisGap, kAxisTickLength, kGraphFont} from "../../../graph-types";
-import {ICategorySet} from "../../../../../models/data/category-set";
+import { ScaleLinear } from "d3";
+import { MutableRefObject } from "react";
+import { AxisPlace } from "./axis-types";
+import { measureText, measureTextExtent } from "../../../../../components/tiles/hooks/use-measure-text";
+import { kAxisGap, kAxisTickLength, kGraphFont } from "../../../graph-types";
+import { ICategorySet } from "../../../../../models/data/category-set";
 
 export const getStringBounds = (s = 'Wy', font = kGraphFont) => {
   return measureTextExtent(s, font);
@@ -20,7 +20,7 @@ export const collisionExists = (props: ICollisionProps) => {
    * This can occur when labels are centered on the tick, or when they are left-aligned.
    * The former requires computation of two adjacent label widths.
    */
-  const {bandWidth, categories, centerCategoryLabels} = props,
+  const { bandWidth, categories, centerCategoryLabels } = props,
     narrowedBandwidth = bandWidth - 5,
     labelWidths = categories.map(category => getStringBounds(category).width);
   return centerCategoryLabels ? labelWidths.some((width, i) => {
@@ -44,22 +44,22 @@ export const getCategoricalLabelPlacement = (
   const labelPlacementMap: Partial<Record<AxisPlace, CenterCollisionPlacementMap>> = {
     left: {
       center: {
-        collision: {textAnchor: 'end'},
-        fit: {rotation, textAnchor: 'middle'}
+        collision: { textAnchor: 'end' },
+        fit: { rotation, textAnchor: 'middle' }
       },
       justify: {
-        collision: {textAnchor: 'end'},
-        fit: {rotation, textAnchor: 'start'}
+        collision: { textAnchor: 'end' },
+        fit: { rotation, textAnchor: 'start' }
       }
     },
     rightCat: {
       center: {
-        collision: {textAnchor: 'start'},
-        fit: {rotation, textAnchor: 'middle'}
+        collision: { textAnchor: 'start' },
+        fit: { rotation, textAnchor: 'middle' }
       },
       justify: {
-        collision: {textAnchor: 'end'},
-        fit: {rotation, textAnchor: 'start'}
+        collision: { textAnchor: 'end' },
+        fit: { rotation, textAnchor: 'start' }
       }
     },
     bottom: {
@@ -67,11 +67,11 @@ export const getCategoricalLabelPlacement = (
         collision: {
           rotation, textAnchor: 'end'
         },
-        fit: {textAnchor: 'middle'}
+        fit: { textAnchor: 'middle' }
       },
       justify: {
-        collision: {rotation, textAnchor: 'end'},
-        fit: {textAnchor: 'start'}
+        collision: { rotation, textAnchor: 'end' },
+        fit: { textAnchor: 'start' }
       }
     },
     top: {
@@ -80,11 +80,11 @@ export const getCategoricalLabelPlacement = (
           rotation,
           textAnchor: 'start'
         },
-        fit: {textAnchor: 'middle'}
+        fit: { textAnchor: 'middle' }
       },
       justify: {
-        collision: {rotation, textAnchor: 'end'},
-        fit: {textAnchor: 'start'}
+        collision: { rotation, textAnchor: 'end' },
+        fit: { textAnchor: 'start' }
       }
     }
   };
@@ -92,7 +92,7 @@ export const getCategoricalLabelPlacement = (
   const centerOrJustify = centerCategoryLabels ? "center" : "justify";
   const collisionOrFit = collision ? "collision" : "fit";
   const labelPlacement = labelPlacementMap[axisPlace]?.[centerOrJustify][collisionOrFit];
-  return {rotation: '', textAnchor: 'none', ...labelPlacement};
+  return { rotation: '', textAnchor: 'none', ...labelPlacement };
 };
 
 export interface DragInfo {
@@ -131,10 +131,10 @@ interface ICoordFunctions {
 }
 
 export const getCoordFunctions = (props: IGetCoordFunctionsProps): ICoordFunctions => {
-  const {numCategories, centerCategoryLabels, collision,
+  const { numCategories, centerCategoryLabels, collision,
     axisIsVertical,
     rangeMin, rangeMax, subAxisLength,
-    isRightCat, isTop, dragInfo} = props,
+    isRightCat, isTop, dragInfo } = props,
     bandWidth = subAxisLength / numCategories,
     labelTextHeight = getStringBounds('12px sans-serif').height,
     indexOffset = centerCategoryLabels ? 0.5 : 0/*(axisIsVertical ? 1 : 0)*/,

--- a/src/plugins/graph/imports/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/src/plugins/graph/imports/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -1,7 +1,7 @@
 import { Menu, MenuItem, MenuList, MenuButton, MenuDivider } from "@chakra-ui/react";
 import React, { CSSProperties, useRef, memo, useEffect, useState } from "react";
 import t from "../../../utilities/translation/translate";
-import {GraphPlace} from "../../axis-graph-shared";
+import { GraphPlace } from "../../axis-graph-shared";
 import { graphPlaceToAttrRole } from "../../../../graph-types";
 import { useDataConfigurationContext } from "../../../../hooks/use-data-configuration-context";
 import { useDataSetContext } from "../../../hooks/use-data-set-context";
@@ -42,14 +42,14 @@ const _AxisOrLegendAttributeMenu = ({ place, target, portal, onOpenClose,
   const instanceId = useInstanceIdContext();
   const attribute = attrId ? data?.attrFromID(attrId) : null;
   const [labelText, setLabelText] = useState(attribute?.name);
-  const removeAttrItemLabel = t(removeAttrItemLabelKeys[role], {vars: [attribute?.name]});
+  const removeAttrItemLabel = t(removeAttrItemLabelKeys[role], { vars: [attribute?.name] });
   const treatAs = dataConfig?.attributeType(role) === "numeric" ? "categorical" : "numeric";
   const menuRef = useRef<HTMLDivElement>(null);
   const showRemoveOption = useSettingFromStores("defaultSeriesLegend", "graph") !== true;
 
   const onCloseRef = useRef<() => void>();
   const overlayStyle: CSSProperties = {
-    position: "absolute", ...useOverlayBounds({target, portal})
+    position: "absolute", ...useOverlayBounds({ target, portal })
   };
   const buttonStyle: CSSProperties = {
     position: "absolute", inset: 0, padding: 0, color: "transparent"
@@ -60,7 +60,7 @@ const _AxisOrLegendAttributeMenu = ({ place, target, portal, onOpenClose,
   };
   const { attributes, listeners, setNodeRef: setDragNodeRef } = useDraggableAttribute(draggableOptions);
 
-  useOutsidePointerDown({ref: menuRef, handler: () => onCloseRef.current?.()});
+  useOutsidePointerDown({ ref: menuRef, handler: () => onCloseRef.current?.() });
 
   useEffect(() => {
     dataConfig?.onAction(action => {

--- a/src/plugins/graph/imports/components/axis/components/axis.tsx
+++ b/src/plugins/graph/imports/components/axis/components/axis.tsx
@@ -1,9 +1,9 @@
-import React, {MutableRefObject, useState} from "react";
-import {range} from "d3";
-import {useAxis} from "../hooks/use-axis";
-import {useAxisLayoutContext} from "../models/axis-layout-context";
-import {IAxisModel} from "../models/axis-model";
-import {SubAxis} from "./sub-axis";
+import React, { MutableRefObject, useState } from "react";
+import { range } from "d3";
+import { useAxis } from "../hooks/use-axis";
+import { useAxisLayoutContext } from "../models/axis-layout-context";
+import { IAxisModel } from "../models/axis-model";
+import { SubAxis } from "./sub-axis";
 
 import "./axis.scss";
 

--- a/src/plugins/graph/imports/components/axis/components/numeric-axis-drag-rects.tsx
+++ b/src/plugins/graph/imports/components/axis/components/numeric-axis-drag-rects.tsx
@@ -1,13 +1,13 @@
-import {observer} from "mobx-react-lite";
-import React, {useEffect, useRef} from "react";
-import {reaction} from "mobx";
-import {drag, ScaleContinuousNumeric, select} from "d3";
+import { observer } from "mobx-react-lite";
+import React, { useEffect, useRef } from "react";
+import { reaction } from "mobx";
+import { drag, ScaleContinuousNumeric, select } from "d3";
 import t from "../../../utilities/translation/translate";
-import {RectIndices, selectDragRects} from "../axis-types";
-import {useAxisLayoutContext} from "../models/axis-layout-context";
-import {INumericAxisModel} from "../models/axis-model";
-import {isVertical} from "../../axis-graph-shared";
-import {MultiScale} from "../models/multi-scale";
+import { RectIndices, selectDragRects } from "../axis-types";
+import { useAxisLayoutContext } from "../models/axis-layout-context";
+import { INumericAxisModel } from "../models/axis-model";
+import { isVertical } from "../../axis-graph-shared";
+import { MultiScale } from "../models/multi-scale";
 
 import "./axis.scss";
 
@@ -25,7 +25,7 @@ const axisDragHints = [t("DG.CellLinearAxisView.lowerPanelTooltip"),
   t("DG.CellLinearAxisView.upperPanelTooltip")];
 
 export const NumericAxisDragRects = observer(
-  function NumericAxisDragRects({axisModel, axisWrapperElt, numSubAxes = 1, subAxisIndex = 0}: IProps) {
+  function NumericAxisDragRects({ axisModel, axisWrapperElt, numSubAxes = 1, subAxisIndex = 0 }: IProps) {
     const rectRef = useRef() as React.RefObject<SVGGElement>,
       place = axisModel.place,
       layout = useAxisLayoutContext();
@@ -178,7 +178,7 @@ export const NumericAxisDragRects = observer(
               );
             selectDragRects(rectRef.current)?.raise();
           }
-        }, {fireImmediately: true}
+        }, { fireImmediately: true }
       );
       return () => disposer();
     }, [axisModel, layout, axisWrapperElt, place, numSubAxes, subAxisIndex]);

--- a/src/plugins/graph/imports/components/axis/components/sub-axis.tsx
+++ b/src/plugins/graph/imports/components/axis/components/sub-axis.tsx
@@ -1,7 +1,7 @@
-import React, {memo, MutableRefObject, useRef, useState} from "react";
-import {useSubAxis} from "../hooks/use-sub-axis";
-import {IAxisModel, INumericAxisModel} from "../models/axis-model";
-import {NumericAxisDragRects} from "./numeric-axis-drag-rects";
+import React, { memo, MutableRefObject, useRef, useState } from "react";
+import { useSubAxis } from "../hooks/use-sub-axis";
+import { IAxisModel, INumericAxisModel } from "../models/axis-model";
+import { NumericAxisDragRects } from "./numeric-axis-drag-rects";
 
 import "./axis.scss";
 

--- a/src/plugins/graph/imports/components/axis/hooks/use-axis.ts
+++ b/src/plugins/graph/imports/components/axis/hooks/use-axis.ts
@@ -1,13 +1,13 @@
-import {ScaleBand, ScaleLinear, scaleLinear, scaleOrdinal} from "d3";
-import {autorun, reaction} from "mobx";
-import {MutableRefObject, useCallback, useEffect, useRef} from "react";
-import {axisGap} from "../axis-types";
-import {useAxisLayoutContext} from "../models/axis-layout-context";
-import {IAxisModel, isNumericAxisModel} from "../models/axis-model";
-import {graphPlaceToAttrRole} from "../../../../graph-types";
-import {maxWidthOfStringsD3} from "../../../../utilities/graph-utils";
-import {useDataConfigurationContext} from "../../../../hooks/use-data-configuration-context";
-import {collisionExists, getStringBounds} from "../axis-utils";
+import { ScaleBand, ScaleLinear, scaleLinear, scaleOrdinal } from "d3";
+import { autorun, reaction } from "mobx";
+import { MutableRefObject, useCallback, useEffect, useRef } from "react";
+import { axisGap } from "../axis-types";
+import { useAxisLayoutContext } from "../models/axis-layout-context";
+import { IAxisModel, isNumericAxisModel } from "../models/axis-model";
+import { graphPlaceToAttrRole } from "../../../../graph-types";
+import { maxWidthOfStringsD3 } from "../../../../utilities/graph-utils";
+import { useDataConfigurationContext } from "../../../../hooks/use-data-configuration-context";
+import { collisionExists, getStringBounds } from "../axis-utils";
 import graphVars from "../../../../components/graph.scss";
 
 export interface IUseAxis {
@@ -62,7 +62,7 @@ export const useAxis = ({
       numbersHeight = getStringBounds('0').height,
       repetitions = multiScale?.repetitions ?? 1,
       bandWidth = ((ordinalScale?.bandwidth?.()) ?? 0) / repetitions,
-      collision = collisionExists({bandWidth, categories, centerCategoryLabels}),
+      collision = collisionExists({ bandWidth, categories, centerCategoryLabels }),
       maxLabelExtent = maxWidthOfStringsD3(dataConfiguration?.categoryArrayForAttrRole(attrRole) ?? []),
       d3Scale = multiScale?.scale ?? (type === 'numeric' ? scaleLinear() : scaleOrdinal());
     let desiredExtent = axisTitleHeight + 2 * axisGap;
@@ -90,10 +90,10 @@ export const useAxis = ({
     if (axisModel) {
       const disposer = reaction(
         () => {
-          const {place: aPlace, scale: scaleType} = axisModel;
-          return {place: aPlace, scaleType};
+          const { place: aPlace, scale: scaleType } = axisModel;
+          return { place: aPlace, scaleType };
         },
-        ({place: aPlace, scaleType}) => {
+        ({ place: aPlace, scaleType }) => {
           layout.getAxisMultiScale(aPlace)?.setScaleType(scaleType);
         }
       );

--- a/src/plugins/graph/imports/components/axis/hooks/use-sub-axis.ts
+++ b/src/plugins/graph/imports/components/axis/hooks/use-sub-axis.ts
@@ -1,13 +1,13 @@
-import {BaseType, drag, format, ScaleLinear, select, Selection} from "d3";
-import {autorun, reaction} from "mobx";
-import {isAlive} from "mobx-state-tree";
-import {MutableRefObject, useCallback, useEffect, useMemo, useRef} from "react";
-import {AxisBounds, axisPlaceToAxisFn, AxisScaleType, otherPlace} from "../axis-types";
-import {useAxisLayoutContext} from "../models/axis-layout-context";
-import {IAxisModel, isCategoricalAxisModel, isNumericAxisModel} from "../models/axis-model";
-import {isVertical} from "../../axis-graph-shared";
-import {between} from "../../../../utilities/math-utils";
-import {kAxisTickLength, transitionDuration} from "../../../../graph-types";
+import { BaseType, drag, format, ScaleLinear, select, Selection } from "d3";
+import { autorun, reaction } from "mobx";
+import { isAlive } from "mobx-state-tree";
+import { MutableRefObject, useCallback, useEffect, useMemo, useRef } from "react";
+import { AxisBounds, axisPlaceToAxisFn, AxisScaleType, otherPlace } from "../axis-types";
+import { useAxisLayoutContext } from "../models/axis-layout-context";
+import { IAxisModel, isCategoricalAxisModel, isNumericAxisModel } from "../models/axis-model";
+import { isVertical } from "../../axis-graph-shared";
+import { between } from "../../../../utilities/math-utils";
+import { kAxisTickLength, transitionDuration } from "../../../../graph-types";
 import {
   DragInfo, collisionExists, computeBestNumberOfTicks, getCategoricalLabelPlacement,
   getCoordFunctions, IGetCoordFunctionsProps
@@ -128,8 +128,8 @@ export const useSubAxis = ({
             categories = Array.from(categorySet?.values ?? []),
             numCategories = categories.length,
             bandWidth = subAxisLength / numCategories,
-            collision = collisionExists({bandWidth, categories, centerCategoryLabels}),
-            {rotation, textAnchor} = getCategoricalLabelPlacement(place, centerCategoryLabels,
+            collision = collisionExists({ bandWidth, categories, centerCategoryLabels }),
+            { rotation, textAnchor } = getCategoricalLabelPlacement(place, centerCategoryLabels,
               collision),
             duration = (enableAnimation.current && !swapInProgress.current &&
               dragInfo.current.indexOfCategory === -1) ? transitionDuration : 0;
@@ -278,7 +278,7 @@ export const useSubAxis = ({
         categorySet = multiScale?.categorySet,
         categories = Array.from(categorySet?.values ?? []),
         categoryData: CatObject[] = categories.map((cat, index) =>
-          ({cat, index: isVertical(place) ? categories.length - index - 1 : index}));
+          ({ cat, index: isVertical(place) ? categories.length - index - 1 : index }));
 
       subAxisSelectionRef.current = select(subAxisElt);
       const sAS = subAxisSelectionRef.current;
@@ -319,10 +319,10 @@ export const useSubAxis = ({
   useEffect(() => {
     const disposer = reaction(
       () => {
-        const {place: aPlace, scale: scaleType} = axisModel;
-        return {place: aPlace, scaleType};
+        const { place: aPlace, scale: scaleType } = axisModel;
+        return { place: aPlace, scaleType };
       },
-      ({place: aPlace, scaleType}) => {
+      ({ place: aPlace, scaleType }) => {
         layout.getAxisMultiScale(aPlace)?.setScaleType(scaleType);
         renderSubAxis();
       }
@@ -347,7 +347,7 @@ export const useSubAxis = ({
     if (isNumeric) {
       const disposer = autorun(() => {
         if (isAlive(axisModel) && axisModel.domain) {
-          const {domain} = axisModel;
+          const { domain } = axisModel;
           layout.getAxisMultiScale(axisModel.place)?.setNumericDomain(domain);
           renderSubAxis();
         }

--- a/src/plugins/graph/imports/components/axis/models/axis-layout-context.ts
+++ b/src/plugins/graph/imports/components/axis/models/axis-layout-context.ts
@@ -1,6 +1,6 @@
 import { createContext, useContext } from "react";
 import { AxisBounds, AxisPlace, AxisScaleType, IScaleType } from "../axis-types";
-import {MultiScale} from "./multi-scale";
+import { MultiScale } from "./multi-scale";
 
 export interface IAxisLayout {
   setParentExtent: (width: number, height: number) => void

--- a/src/plugins/graph/imports/components/axis/models/axis-model.test.ts
+++ b/src/plugins/graph/imports/components/axis/models/axis-model.test.ts
@@ -1,5 +1,5 @@
-import {AxisModel, AxisModelUnion, IAxisModelUnion, isNumericAxisModel, NumericAxisModel} from "./axis-model";
-import {getSnapshot, types} from "mobx-state-tree";
+import { AxisModel, AxisModelUnion, IAxisModelUnion, isNumericAxisModel, NumericAxisModel } from "./axis-model";
+import { getSnapshot, types } from "mobx-state-tree";
 
 describe("AxisModel", () => {
   it("should error if AxisModel is instantiated directly", () => {

--- a/src/plugins/graph/imports/components/axis/models/axis-model.ts
+++ b/src/plugins/graph/imports/components/axis/models/axis-model.ts
@@ -1,6 +1,6 @@
-import {Instance, isAlive, SnapshotIn, types} from "mobx-state-tree";
+import { Instance, isAlive, SnapshotIn, types } from "mobx-state-tree";
 import { kDefaultNumericAxisBounds } from "../../../../graph-types";
-import {AxisOrientation, AxisPlaces, IScaleType, ScaleTypes} from "../axis-types";
+import { AxisOrientation, AxisPlaces, IScaleType, ScaleTypes } from "../axis-types";
 
 export const AxisModel = types.model("AxisModel", {
   type: types.optional(types.string, () => {

--- a/src/plugins/graph/imports/components/axis/models/multi-scale.ts
+++ b/src/plugins/graph/imports/components/axis/models/multi-scale.ts
@@ -1,9 +1,9 @@
-import {action, computed, IReactionDisposer, makeObservable, observable, reaction} from "mobx";
+import { action, computed, IReactionDisposer, makeObservable, observable, reaction } from "mobx";
 import {
   format, NumberValue, ScaleBand, scaleBand, scaleLinear, scaleLog, ScaleOrdinal, scaleOrdinal
 } from "d3";
-import {AxisScaleType, IScaleType, ScaleNumericBaseType} from "../axis-types";
-import {ICategorySet} from "../../../../../../models/data/category-set";
+import { AxisScaleType, IScaleType, ScaleNumericBaseType } from "../axis-types";
+import { ICategorySet } from "../../../../../../models/data/category-set";
 
 interface IDataCoordinate {
   cell: number
@@ -51,7 +51,7 @@ export class MultiScale {
   scale: AxisScaleType;  // d3 scale whose range is the entire axis length.
   disposers: IReactionDisposer[] = [];
 
-  constructor({scaleType, orientation}: IMultiScaleProps) {
+  constructor({ scaleType, orientation }: IMultiScaleProps) {
     this.scaleType = scaleType;
     this.orientation = orientation;
     this.scale = scaleTypeToD3Scale(scaleType);
@@ -156,9 +156,9 @@ export class MultiScale {
     const numericScale = this.numericScale;
     if (numericScale) {
       const cell = this.cellLength && screenCoordinate ? Math.floor(this.cellLength / screenCoordinate) : 0;
-      return {cell, data: numericScale.invert(screenCoordinate)};
+      return { cell, data: numericScale.invert(screenCoordinate) };
     }
-    return {cell: 0, data: NaN};
+    return { cell: 0, data: NaN };
   }
 
   /** To display values for a numeric axis we use just the number of significant figures required to distinguish

--- a/src/plugins/graph/imports/components/component-title-bar.tsx
+++ b/src/plugins/graph/imports/components/component-title-bar.tsx
@@ -20,10 +20,10 @@ export const ComponentTitleBar = observer(function ComponentTitleBar(
   const tileId = tile?.id || "";
   const tileType = tile?.content.type;
   const draggableId = `${tileType}-${tileId}`;
-  const draggableOptions = {id: draggableId, disabled: isEditing};
-  const {attributes, listeners, setActivatorNodeRef} = useDraggable(draggableOptions);
+  const draggableOptions = { id: draggableId, disabled: isEditing };
+  const { attributes, listeners, setActivatorNodeRef } = useDraggable(draggableOptions);
   const { isTileSelected } = useTileModelContext();
-  const classes = clsx("component-title-bar", `${tileType}-title-bar`, {focusTile: isTileSelected()});
+  const classes = clsx("component-title-bar", `${tileType}-title-bar`, { focusTile: isTileSelected() });
 
   const handleChangeTitle = (nextValue?: string) => {
     if (tile != null && nextValue) {

--- a/src/plugins/graph/imports/hooks/use-drag-drop.ts
+++ b/src/plugins/graph/imports/hooks/use-drag-drop.ts
@@ -68,7 +68,7 @@ export const useDropHandler = (dropId: string, onDrop: (active: Active) => void)
   useDndMonitor({ onDragEnd: ({ active, over }) => {
     // only call onDrop for the handler that registered it
     (over?.id === dropId) && onDrop(active);
-  }});
+  } });
 };
 
 // Tile Dragging
@@ -102,7 +102,7 @@ export const useTileDragStartHandler = (dragId: string, onStartDrag: (active: Ac
   useDndMonitor({ onDragStart: ({ active }) => {
     // only call onDragStart for the handler that registered it
     (active.id === dragId) && onStartDrag(active);
-  }});
+  } });
 };
 
 export const useContainerDroppable = (
@@ -118,10 +118,10 @@ export const useTileDropHandler = (dropId: string, onDrop: (event: DragEndEvent)
   useDndMonitor({ onDragEnd: (event: DragEndEvent) => {
     // only call onDrop for the handler that registered it
     (event.over?.id === dropId) && onDrop(event);
-  }});
+  } });
 };
 
-export const containerSnapToGridModifier: Modifier = ({transform, active}) => {
+export const containerSnapToGridModifier: Modifier = ({ transform, active }) => {
   // in pixels
   const gridSize = active && isDragTileData(active.data) ? 5 : 1;
   return {

--- a/src/plugins/graph/imports/hooks/use-drop-hint-string.test.ts
+++ b/src/plugins/graph/imports/hooks/use-drop-hint-string.test.ts
@@ -1,6 +1,6 @@
 import { AttributeType } from "../../../../models/data/attribute";
-import {determineBaseString} from "./use-drop-hint-string";
-import {GraphAttrRole} from "../../graph-types";
+import { determineBaseString } from "./use-drop-hint-string";
+import { GraphAttrRole } from "../../graph-types";
 
 interface Scenario {
   role: GraphAttrRole

--- a/src/plugins/graph/imports/hooks/use-drop-hint-string.ts
+++ b/src/plugins/graph/imports/hooks/use-drop-hint-string.ts
@@ -1,10 +1,10 @@
-import {useDndContext} from "@dnd-kit/core";
+import { useDndContext } from "@dnd-kit/core";
 import { AttributeType } from "../../../../models/data/attribute";
-import {useDataSetContext} from "./use-data-set-context";
-import {getDragAttributeInfo} from "./use-drag-drop";
-import {useDataConfigurationContext} from "../../../graph/hooks/use-data-configuration-context";
-import {attrRoleToGraphPlace, GraphAttrRole} from "../../../graph/graph-types";
-import {GraphPlace} from "../components/axis-graph-shared";
+import { useDataSetContext } from "./use-data-set-context";
+import { getDragAttributeInfo } from "./use-drag-drop";
+import { useDataConfigurationContext } from "../../../graph/hooks/use-data-configuration-context";
+import { attrRoleToGraphPlace, GraphAttrRole } from "../../../graph/graph-types";
+import { GraphPlace } from "../components/axis-graph-shared";
 import t from "../utilities/translation/translate";
 
 export interface IUseDropHintStringProps {
@@ -79,7 +79,7 @@ export function determineBaseString(role: GraphAttrRole, dropType?: AttributeTyp
   return stringKey ? `DG.GraphView.${stringKey}` : undefined;
 }
 
-export const useDropHintString = ({role} : IUseDropHintStringProps) => {
+export const useDropHintString = ({ role } : IUseDropHintStringProps) => {
   const dataSet = useDataSetContext(),
     dataConfig = useDataConfigurationContext(),
     { active } = useDndContext(),

--- a/src/plugins/graph/models/data-configuration-model.test.ts
+++ b/src/plugins/graph/models/data-configuration-model.test.ts
@@ -1,8 +1,8 @@
 import { reaction } from "mobx";
-import {getSnapshot, Instance, types} from "mobx-state-tree";
+import { getSnapshot, Instance, types } from "mobx-state-tree";
 import { DataSet } from "../../../models/data/data-set";
 import { DataConfigurationModel } from "./data-configuration-model";
-import {SharedCaseMetadata} from "../../../models/shared/shared-case-metadata";
+import { SharedCaseMetadata } from "../../../models/shared/shared-case-metadata";
 
 const TreeModel = types.model("Tree", {
   data: DataSet,
@@ -54,12 +54,12 @@ describe("DataConfigurationModel", () => {
     expect(config.places).toEqual(["caption"]);
     expect(config.attributes).toEqual(["nId"]);
     expect(config.uniqueAttributes).toEqual(["nId"]);
-    expect(config.tipAttributes).toEqual([{attributeID: "nId", role: "caption"}]);
-    expect(config.uniqueTipAttributes).toEqual([{attributeID: "nId", role: "caption"}]);
+    expect(config.tipAttributes).toEqual([{ attributeID: "nId", role: "caption" }]);
+    expect(config.uniqueTipAttributes).toEqual([{ attributeID: "nId", role: "caption" }]);
     expect(config.caseDataArray).toEqual([
-      {plotNum: 0, caseID: "c1"},
-      {plotNum: 0, caseID: "c2"},
-      {plotNum: 0, caseID: "c3"}
+      { plotNum: 0, caseID: "c1" },
+      { plotNum: 0, caseID: "c2" },
+      { plotNum: 0, caseID: "c3" }
     ]);
   });
 
@@ -76,12 +76,12 @@ describe("DataConfigurationModel", () => {
     expect(config.places).toEqual(["x", "caption"]);
     expect(config.attributes).toEqual(["nId", "nId"]);
     expect(config.uniqueAttributes).toEqual(["nId"]);
-    expect(config.tipAttributes).toEqual([{attributeID: "nId", role: "x"},
-      {attributeID: "nId", role: "caption"}]);
-    expect(config.uniqueTipAttributes).toEqual([{attributeID: "nId", role: "caption"}]);
+    expect(config.tipAttributes).toEqual([{ attributeID: "nId", role: "x" },
+      { attributeID: "nId", role: "caption" }]);
+    expect(config.uniqueTipAttributes).toEqual([{ attributeID: "nId", role: "caption" }]);
     expect(config.caseDataArray).toEqual([
-      {plotNum: 0, caseID: "c1"},
-      {plotNum: 0, caseID: "c3"}
+      { plotNum: 0, caseID: "c1" },
+      { plotNum: 0, caseID: "c3" }
     ]);
   });
 
@@ -98,13 +98,13 @@ describe("DataConfigurationModel", () => {
     expect(config.places).toEqual(["x", "caption"]);
     expect(config.attributes).toEqual(["xId", "nId"]);
     expect(config.uniqueAttributes).toEqual(["xId", "nId"]);
-    expect(config.tipAttributes).toEqual([{attributeID: "xId", role: "x"},
-      {attributeID: "nId", role: "caption"}]);
-    expect(config.uniqueTipAttributes).toEqual([{attributeID: "xId", role: "x"},
-      {attributeID: "nId", role: "caption"}]);
+    expect(config.tipAttributes).toEqual([{ attributeID: "xId", role: "x" },
+      { attributeID: "nId", role: "caption" }]);
+    expect(config.uniqueTipAttributes).toEqual([{ attributeID: "xId", role: "x" },
+      { attributeID: "nId", role: "caption" }]);
     expect(config.caseDataArray).toEqual([
-      {plotNum: 0, caseID: "c1"},
-      {plotNum: 0, caseID: "c2"}
+      { plotNum: 0, caseID: "c1" },
+      { plotNum: 0, caseID: "c2" }
     ]);
   });
 
@@ -125,11 +125,11 @@ describe("DataConfigurationModel", () => {
     expect(config.places).toEqual(["x", "caption", "y"]);
     expect(config.attributes).toEqual(["xId", "nId", "yId"]);
     expect(config.uniqueAttributes).toEqual(["xId", "nId", "yId"]);
-    expect(config.tipAttributes).toEqual([{attributeID: "xId", role: "x"},
-      {attributeID: "yId", role: "y"}, {attributeID: "nId", role: "caption"}]);
-    expect(config.uniqueTipAttributes).toEqual([{attributeID: "xId", role: "x"},
-      {attributeID: "yId", role: "y"}, {attributeID: "nId", role: "caption"}]);
-    expect(config.caseDataArray).toEqual([{plotNum: 0, caseID: "c1"}]);
+    expect(config.tipAttributes).toEqual([{ attributeID: "xId", role: "x" },
+      { attributeID: "yId", role: "y" }, { attributeID: "nId", role: "caption" }]);
+    expect(config.uniqueTipAttributes).toEqual([{ attributeID: "xId", role: "x" },
+      { attributeID: "yId", role: "y" }, { attributeID: "nId", role: "caption" }]);
+    expect(config.caseDataArray).toEqual([{ plotNum: 0, caseID: "c1" }]);
 
     // behaves as expected after removing x axis attribute (yId on y-axis)
     config.setAttribute("x");
@@ -143,21 +143,21 @@ describe("DataConfigurationModel", () => {
     expect(config.places).toEqual(["caption", "y"]);
     expect(config.attributes).toEqual(["nId", "yId"]);
     expect(config.uniqueAttributes).toEqual(["nId", "yId"]);
-    expect(config.tipAttributes).toEqual([{attributeID: "yId", role: "y"},
-      {attributeID: "nId", role: "caption"}]);
-    expect(config.uniqueTipAttributes).toEqual([{attributeID: "yId", role: "y"},
-      {attributeID: "nId", role: "caption"}]);
+    expect(config.tipAttributes).toEqual([{ attributeID: "yId", role: "y" },
+      { attributeID: "nId", role: "caption" }]);
+    expect(config.uniqueTipAttributes).toEqual([{ attributeID: "yId", role: "y" },
+      { attributeID: "nId", role: "caption" }]);
     expect(config.caseDataArray).toEqual([
-      {plotNum: 0, caseID: "c1"},
-      {plotNum: 0, caseID: "c3"}
+      { plotNum: 0, caseID: "c1" },
+      { plotNum: 0, caseID: "c3" }
     ]);
 
     // updates cases when values change
     tree.data.setCanonicalCaseValues([{ __id__: "c2", "yId": 2 }]);
     expect(config.caseDataArray).toEqual([
-      {plotNum: 0, caseID: "c1"},
-      {plotNum: 0, caseID: "c2"},
-      {plotNum: 0, caseID: "c3"}
+      { plotNum: 0, caseID: "c1" },
+      { plotNum: 0, caseID: "c2" },
+      { plotNum: 0, caseID: "c3" }
     ]);
 
     // triggers observers when values change
@@ -167,15 +167,15 @@ describe("DataConfigurationModel", () => {
     tree.data.setCanonicalCaseValues([{ __id__: "c2", "yId": "" }]);
     expect(trigger).toHaveBeenCalledTimes(2); // TODO: should be 1
     expect(config.caseDataArray).toEqual([
-      {plotNum: 0, caseID: "c1"},
-      {plotNum: 0, caseID: "c3"}
+      { plotNum: 0, caseID: "c1" },
+      { plotNum: 0, caseID: "c3" }
     ]);
     tree.data.setCanonicalCaseValues([{ __id__: "c2", "yId": "2" }]);
     expect(trigger).toHaveBeenCalledTimes(4); // TODO: should be 2
     expect(config.caseDataArray).toEqual([
-      {plotNum: 0, caseID: "c1"},
-      {plotNum: 0, caseID: "c2"},
-      {plotNum: 0, caseID: "c3"}
+      { plotNum: 0, caseID: "c1" },
+      { plotNum: 0, caseID: "c2" },
+      { plotNum: 0, caseID: "c3" }
     ]);
   });
 
@@ -264,9 +264,9 @@ describe("DataConfigurationModel", () => {
     const config = DataConfigurationModel.create();
     config.setDataset(tree.data, tree.metadata);
     expect(config.subPlotCases({})).toEqual([
-      {"__id__": "c1", "nId": "n1", "xId": 1, "yId": 1},
-      {"__id__": "c2", "xId": 2},
-      {"__id__": "c3", "nId": "n3", "yId": 3}
+      { "__id__": "c1", "nId": "n1", "xId": 1, "yId": 1 },
+      { "__id__": "c2", "xId": 2 },
+      { "__id__": "c3", "nId": "n3", "yId": 3 }
     ]);
   });
 

--- a/src/plugins/graph/models/data-configuration-model.ts
+++ b/src/plugins/graph/models/data-configuration-model.ts
@@ -1,18 +1,18 @@
-import {scaleQuantile, ScaleQuantile, schemeBlues} from "d3";
-import {getSnapshot, Instance, ISerializedActionCall, SnapshotIn, types} from "mobx-state-tree";
-import {AttributeType, attributeTypes} from "../../../models/data/attribute";
-import {ICase} from "../../../models/data/data-set-types";
-import {IDataSet} from "../../../models/data/data-set";
-import {getCategorySet, ISharedCaseMetadata} from "../../../models/shared/shared-case-metadata";
-import {isSetCaseValuesAction} from "../../../models/data/data-set-actions";
-import {FilteredCases, IFilteredChangedCases} from "../../../models/data/filtered-cases";
-import {typedId, uniqueId} from "../../../utilities/js-utils";
-import {missingColor} from "../../../utilities/color-utils";
-import {onAnyAction} from "../../../utilities/mst-utils";
-import {CaseData} from "../d3-types";
-import {GraphAttrRole, graphPlaceToAttrRole, PrimaryAttrRoles, TipAttrRoles} from "../graph-types";
-import {AxisPlace} from "../imports/components/axis/axis-types";
-import {GraphPlace} from "../imports/components/axis-graph-shared";
+import { scaleQuantile, ScaleQuantile, schemeBlues } from "d3";
+import { getSnapshot, Instance, ISerializedActionCall, SnapshotIn, types } from "mobx-state-tree";
+import { AttributeType, attributeTypes } from "../../../models/data/attribute";
+import { ICase } from "../../../models/data/data-set-types";
+import { IDataSet } from "../../../models/data/data-set";
+import { getCategorySet, ISharedCaseMetadata } from "../../../models/shared/shared-case-metadata";
+import { isSetCaseValuesAction } from "../../../models/data/data-set-actions";
+import { FilteredCases, IFilteredChangedCases } from "../../../models/data/filtered-cases";
+import { typedId, uniqueId } from "../../../utilities/js-utils";
+import { missingColor } from "../../../utilities/color-utils";
+import { onAnyAction } from "../../../utilities/mst-utils";
+import { CaseData } from "../d3-types";
+import { GraphAttrRole, graphPlaceToAttrRole, PrimaryAttrRoles, TipAttrRoles } from "../graph-types";
+import { AxisPlace } from "../imports/components/axis/axis-types";
+import { GraphPlace } from "../imports/components/axis-graph-shared";
 
 export const AttributeDescription = types
   .model('AttributeDescription', {
@@ -90,7 +90,7 @@ export const DataConfigurationModel = types
      * The rightNumeric attribute description is also not returned.
      */
     get attributeDescriptions() {
-      const descriptions = {...getSnapshot(self._attributeDescriptions)};
+      const descriptions = { ...getSnapshot(self._attributeDescriptions) };
       delete descriptions.rightNumeric;
       if (self._yAttributeDescriptions.length > 0) {
         descriptions.y = self._yAttributeDescriptions[0];
@@ -207,14 +207,14 @@ export const DataConfigurationModel = types
     filterCase(data: IDataSet, caseID: string, caseArrayNumber?: number) {
       const hasY2 = !!self._attributeDescriptions.get('rightNumeric'),
         numY = self._yAttributeDescriptions.length,
-        descriptions = {...self.attributeDescriptions};
+        descriptions = { ...self.attributeDescriptions };
       if (hasY2 && caseArrayNumber === self._yAttributeDescriptions.length) {
         descriptions.y = self._attributeDescriptions.get('rightNumeric') ?? descriptions.y;
       } else if (caseArrayNumber != null && caseArrayNumber < numY) {
         descriptions.y = self._yAttributeDescriptions[caseArrayNumber];
       }
       delete descriptions.rightNumeric;
-      return Object.entries(descriptions).every(([role, {attributeID}]) => {
+      return Object.entries(descriptions).every(([role, { attributeID }]) => {
         // can still plot the case without a caption or a legend
         if (["caption", "legend"].includes(role)) return true;
         switch (self.attributeType(role as GraphAttrRole)) {
@@ -237,7 +237,7 @@ export const DataConfigurationModel = types
     get tipAttributes(): RoleAttrIDPair[] {
       return TipAttrRoles
         .map(role => {
-          return {role, attributeID: self.attributeID(role) || ''};
+          return { role, attributeID: self.attributeID(role) || '' };
         })
         .filter(pair => !!pair.attributeID);
     },
@@ -343,7 +343,7 @@ export const DataConfigurationModel = types
     getUnsortedCaseDataArray(caseArrayNumber: number): CaseData[] {
       return self.filteredCases
         ? (self.filteredCases[caseArrayNumber]?.caseIds || []).map(id => {
-          return {plotNum: caseArrayNumber, caseID: id};
+          return { plotNum: caseArrayNumber, caseID: id };
         })
         : [];
     },
@@ -364,7 +364,7 @@ export const DataConfigurationModel = types
       const joinedCaseData: CaseData[] = [];
       self.filteredCases?.forEach((aFilteredCases, index) => {
           aFilteredCases.caseIds.forEach(
-            (id) => joinedCaseData.push({plotNum: index, caseID: id}));
+            (id) => joinedCaseData.push({ plotNum: index, caseID: id }));
         }
       );
       return joinedCaseData;
@@ -543,15 +543,15 @@ export const DataConfigurationModel = types
       // a single call to setCaseValues can result in up to three calls to the handlers
       if (cases.added.length) {
         const newCases = self.dataset?.getCases(cases.added);
-        self.handlers.forEach(handler => handler({name: "addCases", args: [newCases]}));
+        self.handlers.forEach(handler => handler({ name: "addCases", args: [newCases] }));
       }
       if (cases.removed.length) {
-        self.handlers.forEach(handler => handler({name: "removeCases", args: [cases.removed]}));
+        self.handlers.forEach(handler => handler({ name: "removeCases", args: [cases.removed] }));
       }
       if (cases.changed.length) {
         const idSet = new Set(cases.changed);
         const changedCases = affectedCases.filter(aCase => idSet.has(aCase.__id__));
-        self.handlers.forEach(handler => handler({name: "setCaseValues", args: [changedCases]}));
+        self.handlers.forEach(handler => handler({ name: "setCaseValues", args: [changedCases] }));
       }
       // Changes to case values require that existing cached categorySets be wiped.
       // But if we know the ids of the attributes involved, we can determine whether
@@ -622,7 +622,7 @@ export const DataConfigurationModel = types
         const otherRole = role === 'x' ? 'y' : 'x',
           otherDesc = self.attributeDescriptionForRole(otherRole);
         if (otherDesc?.attributeID === desc?.attributeID) {
-          const currentDesc = self.attributeDescriptionForRole(role) ?? {attributeID: '', type: 'categorical'};
+          const currentDesc = self.attributeDescriptionForRole(role) ?? { attributeID: '', type: 'categorical' };
           self._setAttributeDescription(otherRole, currentDesc);
         }
       }

--- a/src/plugins/graph/models/graph-controller.ts
+++ b/src/plugins/graph/models/graph-controller.ts
@@ -1,23 +1,23 @@
 import React from "react";
-import {IGraphModel} from "./graph-model";
-import {GraphLayout} from "./graph-layout";
-import {getDataSetFromId} from "../../../models/shared/shared-data-utils";
-import {AxisPlace, AxisPlaces} from "../imports/components/axis/axis-types";
+import { IGraphModel } from "./graph-model";
+import { GraphLayout } from "./graph-layout";
+import { getDataSetFromId } from "../../../models/shared/shared-data-utils";
+import { AxisPlace, AxisPlaces } from "../imports/components/axis/axis-types";
 import {
   CategoricalAxisModel, EmptyAxisModel, isCategoricalAxisModel, isEmptyAxisModel, isNumericAxisModel, NumericAxisModel
 } from "../imports/components/axis/models/axis-model";
 import {
   axisPlaceToAttrRole, graphPlaceToAttrRole, IDotsRef, kDefaultNumericAxisBounds, PlotType
 } from "../graph-types";
-import {GraphPlace} from "../imports/components/axis-graph-shared";
-import {matchCirclesToData, setNiceDomain} from "../utilities/graph-utils";
+import { GraphPlace } from "../imports/components/axis-graph-shared";
+import { matchCirclesToData, setNiceDomain } from "../utilities/graph-utils";
 import { getAppConfig } from "../../../models/tiles/tile-environment";
 
 // keys are [primaryAxisType][secondaryAxisType]
 const plotChoices: Record<string, Record<string, PlotType>> = {
-  empty: {empty: 'casePlot', numeric: 'dotPlot', categorical: 'dotChart'},
-  numeric: {empty: 'dotPlot', numeric: 'scatterPlot', categorical: 'dotPlot'},
-  categorical: {empty: 'dotChart', numeric: 'dotPlot', categorical: 'dotChart'}
+  empty: { empty: 'casePlot', numeric: 'dotPlot', categorical: 'dotChart' },
+  numeric: { empty: 'dotPlot', numeric: 'scatterPlot', categorical: 'dotPlot' },
+  categorical: { empty: 'dotChart', numeric: 'dotPlot', categorical: 'dotChart' }
 };
 
 interface IGraphControllerConstructorProps {
@@ -40,7 +40,7 @@ export class GraphController {
   instanceId: string;
   autoAdjustAxes: React.MutableRefObject<boolean>;
 
-  constructor({layout, enableAnimation, instanceId, autoAdjustAxes}: IGraphControllerConstructorProps) {
+  constructor({ layout, enableAnimation, instanceId, autoAdjustAxes }: IGraphControllerConstructorProps) {
     this.layout = layout;
     this.instanceId = instanceId;
     this.enableAnimation = enableAnimation;
@@ -57,7 +57,7 @@ export class GraphController {
   }
 
   callMatchCirclesToData() {
-    const {graphModel, dotsRef, enableAnimation, instanceId} = this;
+    const { graphModel, dotsRef, enableAnimation, instanceId } = this;
     if (graphModel && dotsRef?.current) {
       const { config: dataConfiguration, pointColor, pointStrokeColor } = graphModel,
         pointRadius = graphModel.getPointRadius();
@@ -69,7 +69,7 @@ export class GraphController {
   }
 
   initializeGraph() {
-    const {graphModel, dotsRef, layout} = this,
+    const { graphModel, dotsRef, layout } = this,
       dataConfig = graphModel?.config;
     if (dataConfig && layout && dotsRef?.current) {
       AxisPlaces.forEach((axisPlace: AxisPlace) => {
@@ -94,7 +94,7 @@ export class GraphController {
   }
 
   handleAttributeAssignment(graphPlace: GraphPlace, dataSetID: string, attrID: string) {
-    const {graphModel, layout} = this,
+    const { graphModel, layout } = this,
       dataset = getDataSetFromId(graphModel, dataSetID),
       dataConfig = graphModel?.config,
       appConfig = getAppConfig(graphModel),
@@ -133,7 +133,7 @@ export class GraphController {
         graphModel.setPlotType(plotChoices[primaryType][otherAttributeType]);
       }
       if (dataConfig.attributeID(graphAttributeRole) !== attrID) {
-        dataConfig.setAttribute(graphAttributeRole, {attributeID: attrID});
+        dataConfig.setAttribute(graphAttributeRole, { attributeID: attrID });
       }
     };
 
@@ -148,7 +148,7 @@ export class GraphController {
       switch (attrType) {
         case 'numeric': {
           if (!currAxisModel || !isNumericAxisModel(currAxisModel)) {
-            const newAxisModel = NumericAxisModel.create({place, min, max});
+            const newAxisModel = NumericAxisModel.create({ place, min, max });
             graphModel.setAxis(place, newAxisModel);
             layout.setAxisScaleType(place, 'linear');
             setNiceDomain(attr?.numValues || [], newAxisModel);
@@ -159,7 +159,7 @@ export class GraphController {
           break;
         case 'categorical': {
           if (currentType !== 'categorical') {
-            const newAxisModel = CategoricalAxisModel.create({place});
+            const newAxisModel = CategoricalAxisModel.create({ place });
             graphModel.setAxis(place, newAxisModel);
             layout.setAxisScaleType(place, 'band');
           }
@@ -174,8 +174,8 @@ export class GraphController {
             }
             else {
               const newAxisModel = emptyPlotIsNumeric
-                                     ? NumericAxisModel.create({place, min, max})
-                                     : EmptyAxisModel.create({place});
+                                     ? NumericAxisModel.create({ place, min, max })
+                                     : EmptyAxisModel.create({ place });
               graphModel.setAxis(place, newAxisModel);
             }
           }

--- a/src/plugins/graph/models/graph-layout.ts
+++ b/src/plugins/graph/models/graph-layout.ts
@@ -1,10 +1,10 @@
-import {action, computed, makeObservable, observable} from "mobx";
-import {createContext, useContext} from "react";
-import {appConfig} from "../../../initialize-app";
-import {AxisPlace, AxisPlaces, AxisBounds, IScaleType} from "../imports/components/axis/axis-types";
-import {GraphPlace, isVertical} from "../imports/components/axis-graph-shared";
-import {IAxisLayout} from "../imports/components/axis/models/axis-layout-context";
-import {MultiScale} from "../imports/components/axis/models/multi-scale";
+import { action, computed, makeObservable, observable } from "mobx";
+import { createContext, useContext } from "react";
+import { appConfig } from "../../../initialize-app";
+import { AxisPlace, AxisPlaces, AxisBounds, IScaleType } from "../imports/components/axis/axis-types";
+import { GraphPlace, isVertical } from "../imports/components/axis-graph-shared";
+import { IAxisLayout } from "../imports/components/axis/models/axis-layout-context";
+import { MultiScale } from "../imports/components/axis/models/multi-scale";
 
 export const kDefaultGraphWidth = 480;
 export const kDefaultGraphHeight = 300;
@@ -30,8 +30,8 @@ export class GraphLayout implements IAxisLayout {
 
   constructor() {
     AxisPlaces.forEach(place => this.axisScales.set(place,
-      new MultiScale({scaleType: "ordinal",
-        orientation: isVertical(place) ? "vertical" : "horizontal"})));
+      new MultiScale({ scaleType: "ordinal",
+        orientation: isVertical(place) ? "vertical" : "horizontal" })));
     makeObservable(this);
   }
 
@@ -90,7 +90,7 @@ export class GraphLayout implements IAxisLayout {
 
   getAxisMultiScale(place: AxisPlace) {
     return this.axisScales.get(place) ??
-      new MultiScale({scaleType: "ordinal", orientation: "horizontal"});
+      new MultiScale({ scaleType: "ordinal", orientation: "horizontal" });
   }
 
   @computed get categorySetArrays() {
@@ -131,7 +131,7 @@ export class GraphLayout implements IAxisLayout {
    * Todo: Eventually there will be additional room set aside at the top for formulas
    */
   @computed get computedBounds() {
-    const {desiredExtents, graphWidth, graphHeight} = this,
+    const { desiredExtents, graphWidth, graphHeight } = this,
       usesMultiLegend = appConfig.getSetting("defaultSeriesLegend", "graph"),
       legendHeight = usesMultiLegend ? kMultiLegendHeight : desiredExtents.get('legend') ?? 0,
       topAxisHeight = desiredExtents.get('top') ?? 0,
@@ -142,14 +142,14 @@ export class GraphLayout implements IAxisLayout {
       plotWidth = graphWidth - leftAxisWidth - v2AxisWidth - rightAxisWidth,
       plotHeight = graphHeight - topAxisHeight - bottomAxisHeight - legendHeight,
       newBounds: Record<GraphPlace, Bounds> = {
-        left: {left: 0, top: topAxisHeight, width: leftAxisWidth, height: plotHeight},
-        top: {left: leftAxisWidth, top: 0, width: graphWidth - leftAxisWidth - rightAxisWidth, height: topAxisHeight},
-        plot: {left: leftAxisWidth, top: topAxisHeight, width: plotWidth, height: plotHeight},
-        bottom: {left: leftAxisWidth, top: topAxisHeight + plotHeight, width: plotWidth, height: bottomAxisHeight},
-        legend: {left: 6, top: graphHeight - legendHeight, width: graphWidth - 6, height: legendHeight},
-        rightNumeric: {left: leftAxisWidth + plotWidth, top: topAxisHeight, width: v2AxisWidth, height: plotHeight},
-        rightCat: {left: leftAxisWidth + plotWidth, top: topAxisHeight, width: rightAxisWidth, height: plotHeight},
-        yPlus: {left: 0, top: topAxisHeight, width: leftAxisWidth, height: plotHeight} // This value is not used
+        left: { left: 0, top: topAxisHeight, width: leftAxisWidth, height: plotHeight },
+        top: { left: leftAxisWidth, top: 0, width: graphWidth - leftAxisWidth - rightAxisWidth, height: topAxisHeight },
+        plot: { left: leftAxisWidth, top: topAxisHeight, width: plotWidth, height: plotHeight },
+        bottom: { left: leftAxisWidth, top: topAxisHeight + plotHeight, width: plotWidth, height: bottomAxisHeight },
+        legend: { left: 6, top: graphHeight - legendHeight, width: graphWidth - 6, height: legendHeight },
+        rightNumeric: { left: leftAxisWidth + plotWidth, top: topAxisHeight, width: v2AxisWidth, height: plotHeight },
+        rightCat: { left: leftAxisWidth + plotWidth, top: topAxisHeight, width: rightAxisWidth, height: plotHeight },
+        yPlus: { left: 0, top: topAxisHeight, width: leftAxisWidth, height: plotHeight } // This value is not used
       };
     return newBounds;
   }

--- a/src/plugins/graph/models/graph-model.test.ts
+++ b/src/plugins/graph/models/graph-model.test.ts
@@ -25,7 +25,7 @@ describe('GraphModel', () => {
   it('should show and hide adornments', () => {
     const graphModel = GraphModel.create();
     expect(graphModel.adornments.length).toBe(0);
-    const testAdornment = MovablePointModel.create({id: 'test', type: 'Movable Point', isVisible: true});
+    const testAdornment = MovablePointModel.create({ id: 'test', type: 'Movable Point', isVisible: true });
     graphModel.showAdornment(testAdornment, 'Movable Point');
     expect(graphModel.adornments.length).toBe(1);
     expect(graphModel.adornments[0]).toBe(testAdornment);

--- a/src/plugins/graph/models/graph-model.ts
+++ b/src/plugins/graph/models/graph-model.ts
@@ -1,9 +1,9 @@
 import stringify from "json-stringify-pretty-compact";
-import {reaction} from "mobx";
-import {addDisposer, getSnapshot, Instance, ISerializedActionCall, SnapshotIn, types} from "mobx-state-tree";
-import {createContext, useContext} from "react";
+import { reaction } from "mobx";
+import { addDisposer, getSnapshot, Instance, ISerializedActionCall, SnapshotIn, types } from "mobx-state-tree";
+import { createContext, useContext } from "react";
 import { IAdornmentModel, IUpdateCategoriesOptions } from "../adornments/adornment-models";
-import {AxisPlace} from "../imports/components/axis/axis-types";
+import { AxisPlace } from "../imports/components/axis/axis-types";
 import {
   AxisModelUnion, EmptyAxisModel, IAxisModelUnion, NumericAxisModel
 } from "../imports/components/axis/models/axis-model";
@@ -11,14 +11,14 @@ import {
   GraphAttrRole, hoverRadiusFactor, kDefaultNumericAxisBounds, kGraphTileType, PlotType, PlotTypes,
   pointRadiusLogBase, pointRadiusMax, pointRadiusMin, pointRadiusSelectionAddend
 } from "../graph-types";
-import {DataConfigurationModel} from "./data-configuration-model";
+import { DataConfigurationModel } from "./data-configuration-model";
 import { SharedModelType } from "../../../models/shared/shared-model";
 import {
   getDataSetFromId, getTileCaseMetadata, getTileDataSet, isTileLinkedToDataSet, linkTileToDataSet
 } from "../../../models/shared/shared-data-utils";
 import { AppConfigModelType } from "../../../models/stores/app-config-model";
-import {ITileContentModel, TileContentModel} from "../../../models/tiles/tile-content";
-import {ITileExportOptions} from "../../../models/tiles/tile-content-info";
+import { ITileContentModel, TileContentModel } from "../../../models/tiles/tile-content";
+import { ITileExportOptions } from "../../../models/tiles/tile-content-info";
 import { getAppConfig, getSharedModelManager } from "../../../models/tiles/tile-environment";
 import {
   defaultBackgroundColor, defaultPointColor, defaultStrokeColor, kellyColors
@@ -121,7 +121,7 @@ export const GraphModel = TileContentModel
       // json-stringify-pretty-compact is used, so the exported content is more
       // compact. It results in something close to what we used to get when the
       // export was created using a string builder.
-      return stringify(snapshot, {maxLength: 200});
+      return stringify(snapshot, { maxLength: 200 });
     }
   }))
   .views(self => ({
@@ -193,9 +193,9 @@ export const GraphModel = TileContentModel
         self.config.setDataset(newDataSet, getTileCaseMetadata(self));
       }
       if (role === 'yPlus') {
-        self.config.addYAttribute({attributeID: id});
+        self.config.addYAttribute({ attributeID: id });
       } else {
-        self.config.setAttribute(role, {attributeID: id});
+        self.config.setAttribute(role, { attributeID: id });
       }
       self.updateAdornments(true);
     },
@@ -357,11 +357,11 @@ export function createGraphModel(snap?: IGraphModelSnapshot, appConfig?: AppConf
   const [min, max] = kDefaultNumericAxisBounds;
   const emptyPlotIsNumeric = appConfig?.getSetting("emptyPlotIsNumeric", "graph");
   const bottomAxisModel = emptyPlotIsNumeric
-                            ? NumericAxisModel.create({place: "bottom", min, max})
-                            : EmptyAxisModel.create({place: "bottom"});
+                            ? NumericAxisModel.create({ place: "bottom", min, max })
+                            : EmptyAxisModel.create({ place: "bottom" });
   const leftAxisModel = emptyPlotIsNumeric
-                          ? NumericAxisModel.create({place: "left", min, max})
-                          : EmptyAxisModel.create({place: "left"});
+                          ? NumericAxisModel.create({ place: "left", min, max })
+                          : EmptyAxisModel.create({ place: "left" });
   const createdGraphModel = GraphModel.create({
     axes: {
       bottom: bottomAxisModel,
@@ -373,7 +373,7 @@ export function createGraphModel(snap?: IGraphModelSnapshot, appConfig?: AppConf
   // const connectLinesByDefault = appConfig?.getSetting("defaultConnectedLines", "graph");
   const connectByDefault = appConfig?.getSetting("defaultSeriesLegend", "graph");
   if (connectByDefault) {
-    const cLines = ConnectingLinesModel.create({type: kConnectingLinesType, isVisible: true});
+    const cLines = ConnectingLinesModel.create({ type: kConnectingLinesType, isVisible: true });
     createdGraphModel.showAdornment(cLines, kConnectingLinesType);
   }
   return createdGraphModel;

--- a/src/plugins/graph/models/marquee-state.ts
+++ b/src/plugins/graph/models/marquee-state.ts
@@ -1,5 +1,5 @@
-import {action, makeObservable, observable} from "mobx";
-import {Rect} from "../graph-types";
+import { action, makeObservable, observable } from "mobx";
+import { Rect } from "../graph-types";
 
 export class MarqueeState {
 
@@ -7,7 +7,7 @@ export class MarqueeState {
     makeObservable(this);
   }
 
-  @observable marqueeRect: Rect = {x: 0, y: 0, height: 0, width: 0};
+  @observable marqueeRect: Rect = { x: 0, y: 0, height: 0, width: 0 };
 
   @action setMarqueeRect(rect: Rect) {
     this.marqueeRect = rect;

--- a/src/plugins/graph/models/plot-model.ts
+++ b/src/plugins/graph/models/plot-model.ts
@@ -1,5 +1,5 @@
-import {Instance, types} from "mobx-state-tree";
-import {typedId} from "../../../utilities/js-utils";
+import { Instance, types } from "mobx-state-tree";
+import { typedId } from "../../../utilities/js-utils";
 
 export const PlotModel = types
   .model('PlotModel', {

--- a/src/plugins/graph/utilities/graph-utils.test.ts
+++ b/src/plugins/graph/utilities/graph-utils.test.ts
@@ -1,16 +1,16 @@
-import {scaleLinear} from "d3";
-import {equationString, getScreenCoord, lineToAxisIntercepts, ptInRect, valueLabelString} from "./graph-utils";
-import {DataSet} from "../../../models/data/data-set";
+import { scaleLinear } from "d3";
+import { equationString, getScreenCoord, lineToAxisIntercepts, ptInRect, valueLabelString } from "./graph-utils";
+import { DataSet } from "../../../models/data/data-set";
 
 describe("equationString", () => {
   it("should return a valid equation for a given slope and intercept", () => {
-    expect(equationString(1, 0, {x: "Lifespan", y: "Speed"})).toBe('<em>Speed</em> = 1 <em>Lifespan</em> + 0');
+    expect(equationString(1, 0, { x: "Lifespan", y: "Speed" })).toBe('<em>Speed</em> = 1 <em>Lifespan</em> + 0');
   });
   it("should return an equation containing only the y attribute when the slope is 0", () => {
-    expect(equationString(0, 1, {x: "Lifespan", y: "Speed"})).toBe('<em>Speed</em> = 1');
+    expect(equationString(0, 1, { x: "Lifespan", y: "Speed" })).toBe('<em>Speed</em> = 1');
   });
   it("should return an equation containing only the x attribute when the slope is Infinity", () => {
-    expect(equationString(Infinity, 1, {x: "Lifespan", y: "Speed"})).toBe('<em>Lifespan</em> = 1');
+    expect(equationString(Infinity, 1, { x: "Lifespan", y: "Speed" })).toBe('<em>Lifespan</em> = 1');
   });
 });
 
@@ -22,48 +22,48 @@ describe("valueLabelString", () => {
 
 describe("ptInRect", () => {
   it("{x: 0, y: 0} should be in {x:-1, y: -1, width: 2, height: 2}", () => {
-    expect(ptInRect({x: 0, y: 0}, {x: -1, y: -1, width: 2, height: 2})).toBe(true);
+    expect(ptInRect({ x: 0, y: 0 }, { x: -1, y: -1, width: 2, height: 2 })).toBe(true);
   });
 
   it("{x: 0, y: 0} should be in {x:0, y: 0, width: 0, height: 0}", () => {
-    expect(ptInRect({x: 0, y: 0}, {x: 0, y: 0, width: 0, height: 0})).toBe(true);
+    expect(ptInRect({ x: 0, y: 0 }, { x: 0, y: 0, width: 0, height: 0 })).toBe(true);
   });
 
   it("{x: 1, y: 1} should not be in {x:0, y: 0, width: 1, height: 0.999}", () => {
-    expect(ptInRect({x: 1, y: 1}, {x: 0, y: 0, width: 1, height: 0.999})).toBe(false);
+    expect(ptInRect({ x: 1, y: 1 }, { x: 0, y: 0, width: 1, height: 0.999 })).toBe(false);
   });
 });
 
 describe("lineToAxisIntercepts", () => {
   it("Line with slope 1 and intercept 0 should intercept (0,0),(1,1)", () => {
     expect(lineToAxisIntercepts(1, 0, [0, 1], [0, 1]))
-      .toEqual({pt1: {x: 0, y: 0}, pt2: {x: 1, y: 1}});
+      .toEqual({ pt1: { x: 0, y: 0 }, pt2: { x: 1, y: 1 } });
   });
 
   it("Line with slope ∞ and intercept 0.5 should be parallel to y-axis going through x=0.5", () => {
     expect(lineToAxisIntercepts(1 / 0, 0.5, [0, 1], [0, 1]))
-      .toEqual({pt1: {x: 0.5, y: 0}, pt2: {x: 0.5, y: 1}});
+      .toEqual({ pt1: { x: 0.5, y: 0 }, pt2: { x: 0.5, y: 1 } });
   });
 
   it("Line with slope -1 and intercept 1 should intercept (0,1),(1,0)", () => {
     expect(lineToAxisIntercepts(-1, 1, [0, 1], [0, 1]))
-      .toEqual({pt1: {x: 0, y: 1}, pt2: {x: 1, y: 0}});
+      .toEqual({ pt1: { x: 0, y: 1 }, pt2: { x: 1, y: 0 } });
   });
 
   it("Line with slope -1 and intercept 0 should hit the lower-left corner of (0,1),(1,0)", () => {
     expect(lineToAxisIntercepts(-1, 0, [0, 1], [0, 1]))
-      .toEqual({pt1: {x: 0, y: 0}, pt2: {x: -0, y: 0}});
+      .toEqual({ pt1: { x: 0, y: 0 }, pt2: { x: -0, y: 0 } });
   });
 
   it("Line with slope 1 and intercept -1 should hit the lower-right corner of (0,1),(1,0)", () => {
     expect(lineToAxisIntercepts(1, -1, [0, 1], [0, 1]))
-      .toEqual({pt1: {x: 1, y: 0}, pt2: {x: 1, y: 0}});
+      .toEqual({ pt1: { x: 1, y: 0 }, pt2: { x: 1, y: 0 } });
   });
 
   it("Line with slope 1 and intercept -2 should not intersect (0,1),(1,0)", () => {
     const xDomain = [0, 1],
       yDomain = [0, 1],
-      rect = {x: 0, y: 1, width: 1, height: 1},
+      rect = { x: 0, y: 1, width: 1, height: 1 },
       result = lineToAxisIntercepts(1, -2, xDomain, yDomain);
     expect(ptInRect(result.pt1, rect) || ptInRect(result.pt2, rect))
       .toBe(false);
@@ -73,9 +73,9 @@ describe("lineToAxisIntercepts", () => {
 
 describe("getScreenCoord", () => {
   it("The screen coord with domain [0, 100] and range [20,200] should be ???", () => {
-    const dataset = DataSet.create({name: "data"});
-    dataset.addAttributeWithID({name: "a"});
-    dataset.addCasesWithIDs([{a: 3, __id__: "c1"}]);
+    const dataset = DataSet.create({ name: "data" });
+    dataset.addAttributeWithID({ name: "a" });
+    dataset.addCasesWithIDs([{ a: 3, __id__: "c1" }]);
     const attrID = dataset.attributes[0].id,
       caseID = dataset.cases[0].__id__,
       scale = scaleLinear([0, 100], [20, 200]),

--- a/src/plugins/graph/utilities/graph-utils.ts
+++ b/src/plugins/graph/utilities/graph-utils.ts
@@ -1,12 +1,12 @@
-import {extent, format, select, timeout} from "d3";
+import { extent, format, select, timeout } from "d3";
 import React from "react";
-import {isInteger} from "lodash";
-import {CaseData, DotsElt, selectCircles, selectDots} from "../d3-types";
-import {IDotsRef, kGraphFont, Point, Rect, rTreeRect, transitionDuration} from "../graph-types";
-import {between} from "./math-utils";
-import {IAxisModel, isNumericAxisModel} from "../imports/components/axis/models/axis-model";
-import {ScaleNumericBaseType} from "../imports/components/axis/axis-types";
-import {IDataSet} from "../../../models/data/data-set";
+import { isInteger } from "lodash";
+import { CaseData, DotsElt, selectCircles, selectDots } from "../d3-types";
+import { IDotsRef, kGraphFont, Point, Rect, rTreeRect, transitionDuration } from "../graph-types";
+import { between } from "./math-utils";
+import { IAxisModel, isNumericAxisModel } from "../imports/components/axis/models/axis-model";
+import { ScaleNumericBaseType } from "../imports/components/axis/axis-types";
+import { IDataSet } from "../../../models/data/data-set";
 import {
   defaultSelectedColor,
   defaultSelectedStroke,
@@ -15,8 +15,8 @@ import {
   defaultStrokeOpacity,
   defaultStrokeWidth
 } from "../../../utilities/color-utils";
-import {IDataConfigurationModel} from "../models/data-configuration-model";
-import {measureText} from "../../../components/tiles/hooks/use-measure-text";
+import { IDataConfigurationModel } from "../models/data-configuration-model";
+import { measureText } from "../../../components/tiles/hooks/use-measure-text";
 
 /**
  * Utility routines having to do with graph entities
@@ -69,7 +69,7 @@ export function computeNiceNumericBounds(min: number, max: number): { min: numbe
 
   const kAddend = 5,  // amount to extend scale
     kFactor = 2.5,
-    bounds = {min, max};
+    bounds = { min, max };
   if (min === max && min === 0) {
     bounds.min = -10;
     bounds.max = 10;
@@ -98,7 +98,7 @@ export function computeNiceNumericBounds(min: number, max: number): { min: numbe
 export function setNiceDomain(values: number[], axisModel: IAxisModel) {
   if (isNumericAxisModel(axisModel)) {
     const [minValue, maxValue] = extent(values, d => d) as [number, number];
-    const {min: niceMin, max: niceMax} = computeNiceNumericBounds(minValue, maxValue);
+    const { min: niceMin, max: niceMax } = computeNiceNumericBounds(minValue, maxValue);
     axisModel.setDomain(niceMin, niceMax);
   }
 }
@@ -143,8 +143,8 @@ export interface IMatchCirclesProps {
 
 export function matchCirclesToData(props: IMatchCirclesProps) {
 
-  const {dataConfiguration, enableAnimation, instanceId,
-      dotsElement, pointRadius, pointColor, pointStrokeColor} = props,
+  const { dataConfiguration, enableAnimation, instanceId,
+      dotsElement, pointRadius, pointColor, pointStrokeColor } = props,
     allCaseData = dataConfiguration.joinedCaseDataArrays,
     caseDataKeyFunc = (d: CaseData) => `${d.plotNum}-${d.caseID}`,
     circles = selectCircles(dotsElement);
@@ -250,12 +250,12 @@ export function lineToAxisIntercepts(iSlope: number, iIntercept: number,
     tY2 = tmp;
   }
   return {
-    pt1: {x: tX1, y: tY1},
-    pt2: {x: tX2, y: tY2}
+    pt1: { x: tX1, y: tY1 },
+    pt2: { x: tX2, y: tY2 }
   };
 }
 
-export function equationString(slope: number, intercept: number, attrNames: {x: string, y: string}) {
+export function equationString(slope: number, intercept: number, attrNames: { x: string, y: string }) {
   const float = format('.4~r');
   if (isFinite(slope) && slope !== 0) {
     return `<em>${attrNames.y}</em> = ${float(slope)} <em>${attrNames.x}</em> + ${float(intercept)}`;
@@ -290,7 +290,7 @@ export function rectangleIntersect(iA: rTreeRect, iB: rTreeRect) {
     bottom = Math.min(iA.y + iA.h, iB.y + iB.h);
 
   if (right - left <= 0 || bottom - top <= 0) return null;
-  return {x: left, y: top, w: right - left, h: bottom - top};
+  return { x: left, y: top, w: right - left, h: bottom - top };
 }
 
 /**
@@ -307,8 +307,8 @@ export function rectangleSubtract(iA: rTreeRect, iB: rTreeRect) {
     rectangleALR;
 
   if (intersectRect) {
-    intersectLR = {x: intersectRect.x + intersectRect.w, y: intersectRect.y + intersectRect.h};
-    rectangleALR = {x: iA.x + iA.w, y: iA.y + iA.h};
+    intersectLR = { x: intersectRect.x + intersectRect.w, y: intersectRect.y + intersectRect.h };
+    rectangleALR = { x: iA.x + iA.w, y: iA.y + iA.h };
     if (iA.x < intersectRect.x) {
       result.push({
         x: iA.x, y: iA.y, w: intersectRect.x - iA.x, h: iA.h
@@ -363,8 +363,8 @@ export interface ISetPointSelection {
 
 export function setPointSelection(props: ISetPointSelection) {
   const
-    {dotsRef, dataConfiguration, pointRadius, selectedPointRadius,
-      pointColor, pointStrokeColor, getPointColorAtIndex} = props,
+    { dotsRef, dataConfiguration, pointRadius, selectedPointRadius,
+      pointColor, pointStrokeColor, getPointColorAtIndex } = props,
     dataset = dataConfiguration.dataset,
     dots = selectCircles(dotsRef.current),
     legendID = dataConfiguration.attributeID('legend');
@@ -478,5 +478,5 @@ export function computeSlopeAndIntercept(xAxis?: IAxisModel, yAxis?: IAxisModel)
     slope = (yUpper - yLower) / (adjustedXUpper - xLower),
     intercept = yLower - slope * xLower;
 
-  return {slope, intercept};
+  return { slope, intercept };
 }

--- a/src/plugins/graph/utilities/math-utils.ts
+++ b/src/plugins/graph/utilities/math-utils.ts
@@ -1,4 +1,4 @@
-import {format} from "d3";
+import { format } from "d3";
 
 export function between(num: number, min: number, max: number) {
   return min < max ? (min <= num && num <= max) : (max <= num && num <= min);

--- a/src/plugins/numberline/components/numberline-tile.tsx
+++ b/src/plugins/numberline/components/numberline-tile.tsx
@@ -329,7 +329,7 @@ export const NumberlineTile: React.FC<ITileProps> = observer(function Numberline
         className="numberline-tool"
         ref={documentScrollerRef}
         data-testid="numberline-tool"
-        style={{"height": `${kNumberLineContainerHeight}`}}
+        style={{ "height": `${kNumberLineContainerHeight}` }}
       >
         <div className="numberline-tool-container" >
           <i className="arrow left" style={{ left: xShiftNum + kArrowheadOffset, top: kArrowheadTop }}/>

--- a/src/plugins/numberline/components/numberline-toolbar-buttons.tsx
+++ b/src/plugins/numberline/components/numberline-toolbar-buttons.tsx
@@ -16,7 +16,7 @@ interface INumberlineButtonProps{
   tooltipOptions?: TooltipProps
 }
 
-const NumberlineButton = ({ className, icon, onClick, tooltipOptions}: INumberlineButtonProps) => {
+const NumberlineButton = ({ className, icon, onClick, tooltipOptions }: INumberlineButtonProps) => {
   const to = useTooltipOptions(tooltipOptions);
   const classes = classNames("toolbar-button", className);
   return (
@@ -37,7 +37,7 @@ export const PlacePointButton = ({ onClick }: ISetNumberlineHandler) => (
     className="place-point"
     icon={<PlacePointIcon/>}
     onClick={onClick}
-    tooltipOptions={{ title: "Place Point"}}
+    tooltipOptions={{ title: "Place Point" }}
   />
 );
 
@@ -46,7 +46,7 @@ export const ClearPointsButton = ({ onClick }: ISetNumberlineHandler) => (
     className="clear-points"
     icon={<ClearPointsIcon/>}
     onClick={onClick}
-    tooltipOptions={{ title: "Clear Points"}}
+    tooltipOptions={{ title: "Clear Points" }}
   />
 );
 
@@ -55,6 +55,6 @@ export const DeletePointButton = ({ onClick }: ISetNumberlineHandler) => (
     className="delete-points"
     icon={<DeletePointsIcon/>}
     onClick={onClick}
-    tooltipOptions={{ title: "Delete Point(s)"}}
+    tooltipOptions={{ title: "Delete Point(s)" }}
   />
 );

--- a/src/plugins/numberline/models/numberline-content.ts
+++ b/src/plugins/numberline/models/numberline-content.ts
@@ -82,7 +82,7 @@ export const NumberlineContentModel = TileContentModel
     },
     exportJson(options?: ITileExportOptions) {
       const snapshot = getSnapshot(self);
-      return stringify(snapshot, {maxLength: 200});
+      return stringify(snapshot, { maxLength: 200 });
     }
   }))
   .actions(self =>({

--- a/src/plugins/shared-variables/dialog/use-insert-variable-dialog.tsx
+++ b/src/plugins/shared-variables/dialog/use-insert-variable-dialog.tsx
@@ -29,7 +29,7 @@ const InsertVariableContent =
           Variables already used by this tile:
           <div className="variable-chip-list-container">
             <VariableChipList
-              className={classNames({disabled: disallowSelf})}
+              className={classNames({ disabled: disallowSelf })}
               onClick={disallowSelf ? undefined : onClick}
               nameOnly={true}
               selectedVariables={selectedVariables}

--- a/src/plugins/shared-variables/dialog/use-new-variable-dialog.tsx
+++ b/src/plugins/shared-variables/dialog/use-new-variable-dialog.tsx
@@ -17,7 +17,7 @@ interface IUseNewVariableDialog {
 export const useNewVariableDialog = ({
   addVariable, sharedModel, descriptionPrefill, noUndo = false, onClose
 }: IUseNewVariableDialog) => {
-  const [newVariable, setNewVariable] = useState(Variable.create({description: descriptionPrefill || undefined}));
+  const [newVariable, setNewVariable] = useState(Variable.create({ description: descriptionPrefill || undefined }));
 
   const handleClick = () => {
     sharedModel?.addAndInsertVariable(
@@ -25,7 +25,7 @@ export const useNewVariableDialog = ({
       (variable: VariableType) => addVariable(variable),
       noUndo
     );
-    setNewVariable(Variable.create({description: descriptionPrefill || undefined}));
+    setNewVariable(Variable.create({ description: descriptionPrefill || undefined }));
   };
 
   const [show, hideModal] = useCustomModal({

--- a/src/plugins/shared-variables/drawing/drawing-utils.test.ts
+++ b/src/plugins/shared-variables/drawing/drawing-utils.test.ts
@@ -2,7 +2,7 @@ import { RectangleObjectSnapshotForAdd } from "src/plugins/drawing/objects/recta
 import { defaultDrawingContent } from "../../drawing/model/drawing-content";
 import { getValidInsertPosition } from "./drawing-utils";
 
-const mockGetVisibleCanvasSize = jest.fn(() => { return {x:200, y:100};} );
+const mockGetVisibleCanvasSize = jest.fn(() => { return { x:200, y:100 };} );
 
 const mockSettings = {
     fill: "#666666",
@@ -24,16 +24,16 @@ const rect1: RectangleObjectSnapshotForAdd = {
 describe("getValidInsertPosition", () => {
     it("Should return initial position", () => {
         const content = defaultDrawingContent();
-        expect(getValidInsertPosition(content, mockGetVisibleCanvasSize)).toStrictEqual({ x: 10, y: 10});
+        expect(getValidInsertPosition(content, mockGetVisibleCanvasSize)).toStrictEqual({ x: 10, y: 10 });
     });
     it("Should increment position to avoid overlaps", () => {
         const content = defaultDrawingContent();
         content.addObject(rect1);
-        expect(getValidInsertPosition(content, mockGetVisibleCanvasSize)).toStrictEqual({ x: 35, y: 35});
+        expect(getValidInsertPosition(content, mockGetVisibleCanvasSize)).toStrictEqual({ x: 35, y: 35 });
 
-        content.addObject({...rect1, id: "b", x: 35, y: 35 });
-        content.addObject({...rect1, id: "c", x: 60, y: 60 });
-        content.addObject({...rect1, id: "d", x: 85, y: 85 });
-        expect(getValidInsertPosition(content, mockGetVisibleCanvasSize)).toStrictEqual({ x: 110, y: 10});
+        content.addObject({ ...rect1, id: "b", x: 35, y: 35 });
+        content.addObject({ ...rect1, id: "c", x: 60, y: 60 });
+        content.addObject({ ...rect1, id: "d", x: 85, y: 85 });
+        expect(getValidInsertPosition(content, mockGetVisibleCanvasSize)).toStrictEqual({ x: 110, y: 10 });
     });
 });

--- a/src/plugins/shared-variables/drawing/drawing-utils.ts
+++ b/src/plugins/shared-variables/drawing/drawing-utils.ts
@@ -86,8 +86,8 @@ const INSERT_POSITION_MARGIN = 25;
 export function getValidInsertPosition(drawingContent: DrawingContentModelType, 
     getVisibleCanvasSize: () => Point | undefined) {
   const canvasSize = getVisibleCanvasSize();
-  const base_pos = {...INITIAL_INSERT_POSITION};
-  let pos = {...base_pos};
+  const base_pos = { ...INITIAL_INSERT_POSITION };
+  let pos = { ...base_pos };
   // Start at the initial position and try locations on a diagonal path.
   while (drawingContent.objectAtLocation(pos)) {
     pos.x += INSERT_POSITION_DELTA.x;
@@ -101,7 +101,7 @@ export function getValidInsertPosition(drawingContent: DrawingContentModelType,
         // Try a new diagonal starting from a new base position a little to the right.
         base_pos.x += INSERT_POSITION_BACKUP_DELTA.x;
         base_pos.y += INSERT_POSITION_BACKUP_DELTA.y;
-        pos = {...base_pos};  
+        pos = { ...base_pos };  
       }
     }
   }

--- a/src/plugins/shared-variables/drawing/variable-object.tsx
+++ b/src/plugins/shared-variables/drawing/variable-object.tsx
@@ -40,11 +40,11 @@ export const VariableChipObject = DrawingObject.named("VariableObject")
   }))
   .views(self => ({
     get boundingBox() {
-      const {width, height} = self;
-      const {x, y} = self.position;
-      const nw: Point = {x, y};
-      const se: Point = {x: x + width, y: y + height};
-      return {nw, se};
+      const { width, height } = self;
+      const { x, y } = self.position;
+      const nw: Point = { x, y };
+      const se: Point = { x: x + width, y: y + height };
+      return { nw, se };
     },
     get label() {
       return "Variable";
@@ -61,15 +61,15 @@ export interface VariableChipObjectSnapshot extends SnapshotIn<typeof VariableCh
 export interface VariableChipObjectSnapshotForAdd extends SnapshotIn<typeof VariableChipObject> {type: string}
 
 export const VariableChipComponent: React.FC<IDrawingComponentProps> = observer(
-  function VariableChipComponent({model, handleHover, handleDrag}){
+  function VariableChipComponent({ model, handleHover, handleDrag }){
     const drawingContent = useContext(DrawingContentModelContext);
     const variableChipRef = useRef(null);
-    useResizeObserver({ref: variableChipRef, box: "border-box",
+    useResizeObserver({ ref: variableChipRef, box: "border-box",
       // Volatile model props are used to track with the size. This way
       // the bounding box view will be updated when the size changes.
       // This is necessary so a selection box around the variable gets
       // re-rendered when the size changes.
-      onResize({width: chipWidth, height: chipHeight}){
+      onResize({ width: chipWidth, height: chipHeight }){
         if (!chipWidth || !chipHeight) {
           return;
         }

--- a/src/plugins/shared-variables/shared-variables-registration.ts
+++ b/src/plugins/shared-variables/shared-variables-registration.ts
@@ -2,7 +2,7 @@ import { registerSharedModelInfo } from "../../models/shared/shared-model-regist
 import { registerTextPluginInfo } from "../../models/tiles/text/text-plugin-info";
 import { kSharedVariablesID, SharedVariables } from "./shared-variables";
 import { NewVariableTextButton, InsertVariableTextButton, EditVariableTextButton,
-  kNewVariableButtonName, kInsertVariableButtonName, kEditVariableButtonName} from "./slate/text-tile-buttons";
+  kNewVariableButtonName, kInsertVariableButtonName, kEditVariableButtonName } from "./slate/text-tile-buttons";
 import { kVariableTextPluginName, VariablesPlugin } from "./slate/variables-plugin";
 import { registerDrawingObjectInfo, registerDrawingToolInfo } from "../drawing/components/drawing-object-manager";
 import { EditVariableButton, InsertVariableButton, NewVariableButton, VariableChipComponent, VariableChipObject }

--- a/src/plugins/shared-variables/slate/text-tile-buttons.tsx
+++ b/src/plugins/shared-variables/slate/text-tile-buttons.tsx
@@ -35,22 +35,22 @@ export function insertTextVariable(variable: VariableType, editor?: Editor) {
   const range = editor.selection || [0, 0];
   const beforeInsertPoint = Editor.before(editor, range, { unit: "character" });
   const charBefore = editor.selection && beforeInsertPoint &&
-                       Editor.string(editor, {anchor: editor.selection.anchor, focus: beforeInsertPoint });
+                       Editor.string(editor, { anchor: editor.selection.anchor, focus: beforeInsertPoint });
   if (charBefore && charBefore !== " ") {
-    newNodes.push({text: " "});
+    newNodes.push({ text: " " });
   }
 
   // Add the variable chip.
   const reference = variable.id;
-  const varElt: VariableElement = { type: kVariableFormat, reference, children: [{text: "" }]};
+  const varElt: VariableElement = { type: kVariableFormat, reference, children: [{ text: "" }] };
   newNodes.push(varElt);
 
   // If insertion point is followed by a character that's not a space or punctuation, add a space.
   const afterInsertPoint = Editor.after(editor, range, { unit: "character" });
   const charAfter = editor.selection && afterInsertPoint &&
-                      Editor.string(editor, {anchor: editor.selection.anchor, focus: afterInsertPoint });
+                      Editor.string(editor, { anchor: editor.selection.anchor, focus: afterInsertPoint });
   if (charAfter && !(/^[.,;:!? ]/.test(charAfter))) {
-    newNodes.push({text: " "});
+    newNodes.push({ text: " " });
   }
 
   Transforms.insertNodes(editor, newNodes);
@@ -76,7 +76,7 @@ export function findSelectedVariable(selectedElements: any, variables: VariableT
   selectedElements?.forEach((selectedItem: any) => {
     const baseElement = (selectedItem as any)[0];
     if (isVariableElement(baseElement)) {
-      const {reference} = baseElement;
+      const { reference } = baseElement;
       selected = variables.find(v => v.id === reference);
     }
   });
@@ -107,7 +107,7 @@ function handleClose(editor: Editor) {
 }
 
 export const NewVariableTextButton = observer(function NewVariableTextButton(
-    {pluginInstance}: IButtonDefProps) {
+    { pluginInstance }: IButtonDefProps) {
 
   const editor = useSlate();
   const variablesPlugin = castToVariablesPlugin(pluginInstance);
@@ -138,7 +138,7 @@ export const NewVariableTextButton = observer(function NewVariableTextButton(
 });
 
 export const InsertVariableTextButton = observer(function InsertVariableTextButton(
-    {pluginInstance}: IButtonDefProps) {
+    { pluginInstance }: IButtonDefProps) {
   const editor = useSlate();
   const variablesPlugin = castToVariablesPlugin(pluginInstance);
 
@@ -169,7 +169,7 @@ export const InsertVariableTextButton = observer(function InsertVariableTextButt
 });
 
 export const EditVariableTextButton = observer(function EditVariableTextButton(
-    {pluginInstance}: IButtonDefProps) {
+    { pluginInstance }: IButtonDefProps) {
     const editor = useSlate();
     const variablesPlugin = castToVariablesPlugin(pluginInstance);
 

--- a/src/plugins/shared-variables/slate/variables-plugin.test.tsx
+++ b/src/plugins/shared-variables/slate/variables-plugin.test.tsx
@@ -1,5 +1,5 @@
 import { IAnyType, types, castToSnapshot } from "mobx-state-tree";
-import {screen} from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { specTextTile } from "../../../components/tiles/text/spec-text-tile";
 import { ISharedModelManager } from "../../../models/shared/shared-model-manager";
 import { TextContentModel, TextContentModelType } from "../../../models/tiles/text/text-content";
@@ -70,14 +70,14 @@ const makeSharedModelManager = (variables?: SharedVariablesType): ISharedModelMa
 const setupContainer = (content: TextContentModelType, variables?: SharedVariablesType) => {
   const sharedModelManager = makeSharedModelManager(variables);
   TestTextContentModelContainer.create(
-    {child: castToSnapshot(content), variables: castToSnapshot(variables)},
-    {sharedModelManager}
+    { child: castToSnapshot(content), variables: castToSnapshot(variables) },
+    { sharedModelManager }
   );
 
   // So far it hasn't been necessary to wait for the MobX reaction to run inside of
   // DocumentContent#afterAttach. It seems to run immediately in the line above, so
   // we can write expectations on this content without waiting.
-  return {content, sharedModelManager};
+  return { content, sharedModelManager };
 };
 
 describe("VariablesPlugin", () => {
@@ -145,7 +145,7 @@ describe("VariablesPlugin", () => {
       const variables = SharedVariables.create();
 
       // setup the environment with a shared model
-      const {sharedModelManager} = setupContainer(textContent, variables);
+      const { sharedModelManager } = setupContainer(textContent, variables);
 
       // override getTileSharedModels so it always returns undefined
       sharedModelManager.getTileSharedModels = jest.fn();
@@ -164,7 +164,7 @@ describe("VariablesPlugin", () => {
   describe("used in TextToolComponent", () => {
 
     it("renders successfully and creates the VariablesPlugin", () => {
-      const {plugins, textTile} = specTextTile({});
+      const { plugins, textTile } = specTextTile({});
       expect(screen.getByTestId("text-tool-wrapper")).toBeInTheDocument();
       expect(screen.getByTestId("ccrte-editor")).toBeInTheDocument();
       const plugin = plugins?.[kVariableTextPluginName];
@@ -174,7 +174,7 @@ describe("VariablesPlugin", () => {
     });
 
     it("finds no chips with empty content and no configured shared model", () => {
-      const {plugins} = specTextTile({});
+      const { plugins } = specTextTile({});
       const plugin = plugins?.[kVariableTextPluginName] as VariablesPlugin;
       expect(plugin.chipVariables).toHaveLength(0);
     });
@@ -185,16 +185,16 @@ describe("VariablesPlugin", () => {
 
       // setup the environment with a shared model
       const sharedModelManager = makeSharedModelManager(variables);
-      const tileModel = TileModel.create({content});
+      const tileModel = TileModel.create({ content });
 
       // Create an MST tree with both the TileModel and the shared variables
       // and the sharedModelManager in the MST tree environment
       TestTileModelContainer.create(
-        {child: castToSnapshot(tileModel), variables: castToSnapshot(variables)},
-        {sharedModelManager}
+        { child: castToSnapshot(tileModel), variables: castToSnapshot(variables) },
+        { sharedModelManager }
       );
 
-      const {plugins} = specTextTile({tileModel});
+      const { plugins } = specTextTile({ tileModel });
 
       const plugin = plugins?.[kVariableTextPluginName] as VariablesPlugin;
       const editor = content.editor;

--- a/src/plugins/shared-variables/slate/variables-plugin.tsx
+++ b/src/plugins/shared-variables/slate/variables-plugin.tsx
@@ -106,10 +106,10 @@ export class VariablesPlugin implements ITextPlugin {
   }
 
   get chipVariables() {
-    const {editor} = this.textContent;
+    const { editor } = this.textContent;
     const variableIds: string[] = [];
     if (editor) {
-      for (const [node] of Editor.nodes(editor, {at: [], mode: 'all'})) {
+      for (const [node] of Editor.nodes(editor, { at: [], mode: 'all' })) {
         if (Editor.isInline(editor, node) && isVariableElement(node)) {
           variableIds.push(node.reference);
         }
@@ -143,7 +143,7 @@ export const VariableComponent = observer(function({ attributes, children, eleme
 
   if (!isVariableElement(element)) return null;
 
-  const {reference} = element;
+  const { reference } = element;
 
   const classes = classNames(kSlateVoidClass, kVariableClass);
   const selectedClass = isHighlighted && !isSerializing ? "slate-selected" : undefined;

--- a/src/plugins/simulator/model/simulator-content.ts
+++ b/src/plugins/simulator/model/simulator-content.ts
@@ -77,10 +77,10 @@ export const SimulatorContentModel = TileContentModel
         const tileSharedModels = sharedModelManager?.isReady ?
           sharedModelManager?.getTileSharedModels(self) : undefined;
 
-        const values = {sharedModelManager, containerSharedModel, tileSharedModels};
+        const values = { sharedModelManager, containerSharedModel, tileSharedModels };
         return values;
       },
-      ({sharedModelManager, containerSharedModel, tileSharedModels}) => {
+      ({ sharedModelManager, containerSharedModel, tileSharedModels }) => {
         if (!sharedModelManager?.isReady) {
           // We aren't added to a document yet so we can't do anything yet
           return;
@@ -106,7 +106,7 @@ export const SimulatorContentModel = TileContentModel
           }
         });
       },
-      {name: "sharedModelSetup", fireImmediately: true}));
+      { name: "sharedModelSetup", fireImmediately: true }));
     },
     updateAfterSharedModelChanges() {
       // nothing to do here

--- a/src/plugins/starter/starter-content.ts
+++ b/src/plugins/starter/starter-content.ts
@@ -3,7 +3,7 @@ import { TileContentModel } from "../../models/tiles/tile-content";
 import { kStarterTileType } from "./starter-types";
 
 export function defaultStarterContent(): StarterContentModelType {
-  return StarterContentModel.create({text: "Hello World"});
+  return StarterContentModel.create({ text: "Hello World" });
 }
 
 

--- a/src/plugins/starter/starter-tile.test.tsx
+++ b/src/plugins/starter/starter-tile.test.tsx
@@ -12,7 +12,7 @@ import "./starter-registration";
 
 describe("StarterToolComponent", () => {
   const content = defaultStarterContent();
-  const model = TileModel.create({content});
+  const model = TileModel.create({ content });
 
   const defaultProps = {
     tileElt: null,
@@ -44,14 +44,14 @@ describe("StarterToolComponent", () => {
   };
 
   it("renders successfully", () => {
-    const {getByText} =
-      render(<StarterToolComponent  {...defaultProps} {...{model}}></StarterToolComponent>);
+    const { getByText } =
+      render(<StarterToolComponent  {...defaultProps} {...{ model }}></StarterToolComponent>);
     expect(getByText("Hello World")).toBeInTheDocument();
   });
 
   it("updates the text when the model changes", async () => {
-    const {getByText, findByText} =
-      render(<StarterToolComponent  {...defaultProps} {...{model}}></StarterToolComponent>);
+    const { getByText, findByText } =
+      render(<StarterToolComponent  {...defaultProps} {...{ model }}></StarterToolComponent>);
     expect(getByText("Hello World")).toBeInTheDocument();
 
     content.setText("New Text");
@@ -60,8 +60,8 @@ describe("StarterToolComponent", () => {
   });
 
   it("updates the model when the user types", () => {
-    const {getByRole, getByText} =
-      render(<StarterToolComponent  {...defaultProps} {...{model}}></StarterToolComponent>);
+    const { getByRole, getByText } =
+      render(<StarterToolComponent  {...defaultProps} {...{ model }}></StarterToolComponent>);
     expect(getByText("New Text")).toBeInTheDocument();
 
     const textBox = getByRole("textbox");

--- a/src/utilities/clipboard-utils.test.ts
+++ b/src/utilities/clipboard-utils.test.ts
@@ -81,7 +81,7 @@ describe("pasteClipboardImage", () => {
   });
 
   it ("does not call addFileImage or getImage when the clipboard does not contain an image or text item", () => {
-    pasteClipboardImage({image: null, text: null, types: ["text/html"]}, onComplete);
+    pasteClipboardImage({ image: null, text: null, types: ["text/html"] }, onComplete);
     expect(gImageMap.addFileImage).not.toHaveBeenCalled();
     expect(gImageMap.getImage).not.toHaveBeenCalled();
     expect(mockConsoleError).toHaveBeenCalledWith("ERROR: unknown clipboard content type(s): text/html");

--- a/src/utilities/clipboard-utils.ts
+++ b/src/utilities/clipboard-utils.ts
@@ -23,7 +23,7 @@ export const pasteClipboardImage = async (imageData: IClipboardContents, onCompl
     }
     const fileUrl = url[1];
     const filename = fileUrl.split("/").pop();
-    const imageEntry = await gImageMap.getImage(fileUrl, {filename});
+    const imageEntry = await gImageMap.getImage(fileUrl, { filename });
     onComplete({ image: imageEntry });
   } else {
     console.error(`ERROR: unknown clipboard content type(s): ${imageData.types}`);

--- a/src/utilities/mst-utils.test.ts
+++ b/src/utilities/mst-utils.test.ts
@@ -6,7 +6,7 @@ import { types, unprotect } from "mobx-state-tree";
 // I'd note that the MST jest tests themselves have this same problem and they 
 // have not disabled the warning. An example test is here:
 //   https://github.com/mobxjs/mobx-state-tree/blob/master/packages/mobx-state-tree/__tests__/core/node.test.ts#L35
-import {configure} from "mobx"; configure({ enforceActions: "never" });
+import { configure } from "mobx"; configure({ enforceActions: "never" });
 
 describe("getParentWithTypeName", () => {
 


### PR DESCRIPTION
This includes an eslint rule to enforce this, with the automatic eslint
fixing in VSCode it should get automatically fixed.

I personally don't care about this styling, but in order to get better
automatic import ordering it is necessary.