### PR TITLE
run regression tests only with 'run regression'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,23 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       uuid: ${{ steps.uuid.outputs.value }}
+      pr_labels: ${{ steps.pr.outputs.labels }}
     steps:
       - name: Dump GitHub context
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "$GITHUB_CONTEXT"
+      - name: Get PR labels
+        id: pr
+        # the github.event.pull_request.labels does not seem to be available when a build
+        # is triggered by a push. So we use the `gh` CLI to get info about the PR for the
+        # current branch. If the same branch is part of multiple PR or the branch doesn't
+        # have a PR, I'm not sure what will happen yet.
+        run: echo "labels=$(gh pr view --json labels -q '.labels' || echo "[]")" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Print PR labels
+        run: echo "PR labels ${{ steps.pr.outputs.labels }}"
       - name: Generate unique ID 💎
         id: uuid
         # take the current commit + timestamp together
@@ -133,9 +145,8 @@ jobs:
             ["master"]
   regression:
     # only run the regression tests if the PR is labeled.
-    # the github.event.pull_request.labels does not seem to be availale when a build
-    # from a commit pushed before the PR was opened is rebuilt.
-    if: contains(github.event.pull_request.labels.*.name, 'run regression')
+    # I'm not sure if this approach will work for a json output
+    if: contains(needs.prepare.outputs.pr_labels.*.name, 'run regression')
     runs-on: ubuntu-latest
     timeout-minutes: 240
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Bail if not a push or run regression label
-        if: github.event_name == 'push' || (github.event.action == 'labeled' && github.event.label.name == 'run regression')
+        if: (!(github.event_name == 'push' || (github.event.action == 'labeled' && github.event.label.name == 'run regression')))
         # note we might want to use an ::error or ::notice message to improve this behavior
         # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message
         run: exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,10 @@ jobs:
     outputs:
       uuid: ${{ steps.uuid.outputs.value }}
       pr_labels: ${{ steps.pr.outputs.labels }}
+    permissions:
+      pull-requests: read
     steps:
+      - uses: actions/checkout@v2
       - name: Dump GitHub context
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,10 @@ jobs:
     outputs:
       uuid: ${{ steps.uuid.outputs.value }}
     steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
       - name: Generate unique ID 💎
         id: uuid
         # take the current commit + timestamp together
@@ -128,13 +132,14 @@ jobs:
           topBranches: |
             ["master"]
   regression:
+    # only run the regression tests if the PR is labeled.
+    # the github.event.pull_request.labels does not seem to be availale when a build
+    # from a commit pushed before the PR was opened is rebuilt.
     if: contains(github.event.pull_request.labels.*.name, 'run regression')
     runs-on: ubuntu-latest
     timeout-minutes: 240
     needs:
       - prepare
-      - build_test
-      - cypress
     container: cypress/browsers:node16.14.2-slim-chrome103-ff102
     strategy:
       # when one test fails, DO NOT cancel the other

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: Continuous Integration
 
 on: push
-
 jobs:
   build_test:
     name: Build and Run Jest Tests
@@ -129,8 +128,9 @@ jobs:
           topBranches: |
             ["master"]
   regression:
+    if: contains(github.event.pull_request.labels.*.name, 'run regression')
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 240
     needs:
       - prepare
       - build_test
@@ -144,7 +144,7 @@ jobs:
       fail-fast: false
       matrix:
         # run 5 copies of the current job in parallel
-        containers: [1, 2, 3, 4, 5]
+        containers: [1]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         run: echo "PR labels ${{ steps.pr.outputs.labels }}"
       - name: Get run_regression
         id: run_regression
-        run: echo "value=${{ contains(fromJSON(steps.pr.outputs.labels).*.name, 'run regression') }}"
+        run: echo "value=${{ contains(fromJSON(steps.pr.outputs.labels).*.name, 'run regression') }} >> $GITHUB_OUTPUT"
       - name: Generate unique ID 💎
         id: uuid
         # take the current commit + timestamp together

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
     types: [ labeled ]
 jobs:
   prepare:
+    # only conintue if a push or run regression label
+    if: github.event_name == 'push' || (github.event.action == 'labeled' && github.event.label.name == 'run regression')
     runs-on: ubuntu-latest
     outputs:
       uuid: ${{ steps.uuid.outputs.value }}
@@ -14,11 +16,6 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - name: Bail if not a push or run regression label
-        if: (!(github.event_name == 'push' || (github.event.action == 'labeled' && github.event.label.name == 'run regression')))
-        # note we might want to use an ::error or ::notice message to improve this behavior
-        # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message
-        run: exit 1
       - uses: actions/checkout@v4
       - name: Get PR labels
         id: pr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         run: echo "PR labels ${{ steps.pr.outputs.labels }}"
       - name: Get run_regression
         id: run_regression
-        run: echo "value=${{ contains(fromJSON(steps.pr.outputs.labels).*.name, 'run regression') }} >> $GITHUB_OUTPUT"
+        run: echo "value=${{ contains(fromJSON(steps.pr.outputs.labels).*.name, 'run regression') }}" >> $GITHUB_OUTPUT
       - name: Generate unique ID 💎
         id: uuid
         # take the current commit + timestamp together

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,15 @@ on:
     types: [ labeled ]
 jobs:
   prepare:
-    # only conintue if a push or run regression label
+    # only conintue if a push or PR labeled with 'run regression'
     if: github.event_name == 'push' || (github.event.action == 'labeled' && github.event.label.name == 'run regression')
     runs-on: ubuntu-latest
     outputs:
       uuid: ${{ steps.uuid.outputs.value }}
       pr_labels: ${{ steps.pr.outputs.labels }}
-      # if we are triggered by a pull_request labeled event, there is no branch, so the Get PR labels step will fail
+      # if we are triggered by a pull_request labeled event, there is no branch, so we fall back to checking the
+      # label in the github.event. Also steps.run_regression.outputs.value will be "false" in this case which
+      # being a string is actually considered true, so fromJSON is needed to turn `"false"` into `false`.
       run_regression: ${{ fromJSON(steps.run_regression.outputs.value) || github.event.label.name == 'run regression' }}
     permissions:
       pull-requests: read
@@ -25,8 +27,11 @@ jobs:
         # current branch.
         # - If the branch doesn't have a PR yet, then the `gh pr view` command fails with
         # the message: no pull requests found for branch "pr-label-test"
+        # - If the trigger is a labeled pull_request, a branch is not checked out, so the
+        # `gh pr view` command can't find the PR. This case is handled in the job output
+        # above.
         # - If the same branch is part of multiple PR, it isn't clear what will
-        # will happen, but that should be very unusual.
+        # happen, but that should be very unusual.
         run: echo "labels=$(gh pr view --json labels -q '.labels' || echo "[]")" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -44,12 +49,11 @@ jobs:
       - name: Print unique ID
         run: echo "generated id ${{ steps.uuid.outputs.value }}"
   build_test:
+    # We need 'prepare' so this job will be skipped if the trigger is a PR labeled with some other label
     needs: ['prepare']
     name: Build and Run Jest Tests
     runs-on: ubuntu-latest
     steps:
-      - name: Print run_regression
-        run: echo "run_regression ${{ needs.prepare.outputs.run_regression }}"
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v2
         with:
@@ -163,6 +167,8 @@ jobs:
     # only run the regression tests if the PR is labeled.
     if: fromJSON(needs.prepare.outputs.run_regression)
     runs-on: ubuntu-latest
+    # temporarily expand the timeout to 4hrs until cypress cloud is available again
+    # it was 1hr before.
     timeout-minutes: 240
     container: cypress/browsers:node16.14.2-slim-chrome103-ff102
     strategy:
@@ -172,7 +178,9 @@ jobs:
       # https://github.com/cypress-io/github-action/issues/48
       fail-fast: false
       matrix:
-        # run 5 copies of the current job in parallel
+        # temporarily use only 1 worker until cypress cloud is available again
+        # it was:
+        # container: [1, 2, 3, 4, 5]
         containers: [1]
     steps:
       - name: Checkout Repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
     name: Build and Run Jest Tests
     runs-on: ubuntu-latest
     steps:
+      - name: Print run_regression
+        run: echo "run_regression ${{ needs.prepare.outputs.run_regression }}"
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,8 @@ jobs:
     outputs:
       uuid: ${{ steps.uuid.outputs.value }}
       pr_labels: ${{ steps.pr.outputs.labels }}
-      run_regression: ${{ steps.run_regression.outputs.value }}
+      # if we are triggered by a pull_request labeled event, there is no branch, so the Get PR labels step will fail
+      run_regression: ${{ steps.run_regression.outputs.value || github.event.label.name == 'run regression' }}
     permissions:
       pull-requests: read
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,10 @@ jobs:
         # One thread is enoguh for now, since there is only one smoke test
         containers: [1]
     steps:
+      - name: Print PR labels
+        run: |
+          echo "PR labels ${{ needs.prepare.outputs.pr_labels }}"
+          echo "PR first_label ${{ fromJSON(needs.prepare.outputs.pr_labels)[0] }}"
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install CMS Dependencies
@@ -149,7 +153,7 @@ jobs:
   regression:
     # only run the regression tests if the PR is labeled.
     # I'm not sure if this approach will work for a json output
-    if: contains(needs.prepare.outputs.pr_labels.*.name, 'run regression')
+    if: contains(fromJSON(needs.prepare.outputs.pr_labels).*.name, 'run regression')
     runs-on: ubuntu-latest
     timeout-minutes: 240
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     name: Build and Run Jest Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v2
         with:
           node-version: '16'
@@ -32,14 +32,10 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - uses: actions/checkout@v2
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
+      - uses: actions/checkout@v4
       - name: Get PR labels
         id: pr
-        # the github.event.pull_request.labels does not seem to be available when a build
+        # the github.event.pull_request.labels is not available when a build
         # is triggered by a push. So we use the `gh` CLI to get info about the PR for the
         # current branch. If the same branch is part of multiple PR or the branch doesn't
         # have a PR, I'm not sure what will happen yet.
@@ -71,12 +67,8 @@ jobs:
         # One thread is enoguh for now, since there is only one smoke test
         containers: [1]
     steps:
-      - name: Print PR labels
-        run: |
-          echo "PR labels ${{ needs.prepare.outputs.pr_labels }}"
-          echo "PR first_label ${{ fromJSON(needs.prepare.outputs.pr_labels)[0] }}"
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install CMS Dependencies
         working-directory: ./cms
         run: npm ci
@@ -123,7 +115,7 @@ jobs:
       - cypress
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v2
         with:
           node-version: '16'
@@ -170,7 +162,7 @@ jobs:
         containers: [1]
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - uses: actions/setup-node@v2
         with:
           node-version: '16'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,52 @@
 name: Continuous Integration
 
-on: push
+on:
+  push:
+  pull_request:
+    types: [ labeled ]
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      uuid: ${{ steps.uuid.outputs.value }}
+      pr_labels: ${{ steps.pr.outputs.labels }}
+      run_regression: ${{ steps.run_regression.outputs.value }}
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Bail if not a push or run regression label
+        if: github.event_name == 'push' || (github.event.action == 'labeled' && github.event.label.name == 'run regression')
+        # note we might want to use an ::error or ::notice message to improve this behavior
+        # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message
+        run: exit 1
+      - uses: actions/checkout@v4
+      - name: Get PR labels
+        id: pr
+        # the github.event.pull_request.labels is not available when a build
+        # is triggered by a push. So we use the `gh` CLI to get info about the PR for the
+        # current branch.
+        # - If the branch doesn't have a PR yet, then the `gh pr view` command fails with
+        # the message: no pull requests found for branch "pr-label-test"
+        # - If the same branch is part of multiple PR, it isn't clear what will
+        # will happen, but that should be very unusual.
+        run: echo "labels=$(gh pr view --json labels -q '.labels' || echo "[]")" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Print PR labels
+        run: echo "PR labels ${{ steps.pr.outputs.labels }}"
+      - name: Get run_regression
+        id: run_regression
+        run: echo "value=${{ contains(fromJSON(steps.pr.outputs.labels).*.name, 'run regression') }}"
+      - name: Generate unique ID 💎
+        id: uuid
+        # take the current commit + timestamp together
+        # the typical value would be something like
+        # "sha-5d3fe...35d3-time-1620841214"
+        run: echo "value=sha-$GITHUB_SHA-time-$(date +"%s")" >> $GITHUB_OUTPUT
+      - name: Print unique ID
+        run: echo "generated id ${{ steps.uuid.outputs.value }}"
   build_test:
+    needs: ['prepare']
     name: Build and Run Jest Tests
     runs-on: ubuntu-latest
     steps:
@@ -24,34 +68,6 @@ jobs:
         with:
           flags: jest
           token: ${{ secrets.CODECOV_TOKEN }}
-  prepare:
-    runs-on: ubuntu-latest
-    outputs:
-      uuid: ${{ steps.uuid.outputs.value }}
-      pr_labels: ${{ steps.pr.outputs.labels }}
-    permissions:
-      pull-requests: read
-    steps:
-      - uses: actions/checkout@v4
-      - name: Get PR labels
-        id: pr
-        # the github.event.pull_request.labels is not available when a build
-        # is triggered by a push. So we use the `gh` CLI to get info about the PR for the
-        # current branch. If the same branch is part of multiple PR or the branch doesn't
-        # have a PR, I'm not sure what will happen yet.
-        run: echo "labels=$(gh pr view --json labels -q '.labels' || echo "[]")" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Print PR labels
-        run: echo "PR labels ${{ steps.pr.outputs.labels }}"
-      - name: Generate unique ID 💎
-        id: uuid
-        # take the current commit + timestamp together
-        # the typical value would be something like
-        # "sha-5d3fe...35d3-time-1620841214"
-        run: echo "value=sha-$GITHUB_SHA-time-$(date +"%s")" >> $GITHUB_OUTPUT
-      - name: Print unique ID
-        run: echo "generated id ${{ steps.uuid.outputs.value }}"
   cypress:
     needs: ['prepare']
     runs-on: ubuntu-latest
@@ -143,13 +159,11 @@ jobs:
           topBranches: |
             ["master"]
   regression:
+    needs: ['prepare']
     # only run the regression tests if the PR is labeled.
-    # I'm not sure if this approach will work for a json output
-    if: contains(fromJSON(needs.prepare.outputs.pr_labels).*.name, 'run regression')
+    if: fromJSON(needs.prepare.outputs.run_regression)
     runs-on: ubuntu-latest
     timeout-minutes: 240
-    needs:
-      - prepare
     container: cypress/browsers:node16.14.2-slim-chrome103-ff102
     strategy:
       # when one test fails, DO NOT cancel the other

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       uuid: ${{ steps.uuid.outputs.value }}
       pr_labels: ${{ steps.pr.outputs.labels }}
       # if we are triggered by a pull_request labeled event, there is no branch, so the Get PR labels step will fail
-      run_regression: ${{ steps.run_regression.outputs.value || github.event.label.name == 'run regression' }}
+      run_regression: ${{ fromJSON(steps.run_regression.outputs.value) || github.event.label.name == 'run regression' }}
     permissions:
       pull-requests: read
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,8 @@ jobs:
       # if we are triggered by a pull_request labeled event, there is no branch, so we fall back to checking the
       # label in the github.event. Also steps.run_regression.outputs.value will be "false" in this case which
       # being a string is actually considered true, so fromJSON is needed to turn `"false"` into `false`.
-      run_regression: ${{ fromJSON(steps.run_regression.outputs.value) || github.event.label.name == 'run regression' }}
+      # finally if we are on the 'master' branch then run the regression tests regardless of the PR label
+      run_regression: ${{ fromJSON(steps.run_regression.outputs.value) || github.event.label.name == 'run regression' || github.ref_name == 'master' }}
     permissions:
       pull-requests: read
     steps:


### PR DESCRIPTION
This adds support for a `run regression` label.

If the `run regression` label is added to a PR it will trigger a new build that includes the cypress regression tests.
Any further pushes to the PR's branch will also run the cypress regression tests, unless the `run regression` label is removed.

When a branch is pushed that doesn't have a PR yet, the regression tests will not run.
When a PR is created for the branch that doesn't have the `run regression` label the regression tests will not run.
When the PR is merged to master the regression tests should run. 

**Notes:** 
When any label is added to the PR it will now start a build. The first job of the build will only run if the label is `run regression`. 
When a label is added to the PR the list of checks will be updated to include ones with a suffix of `(pull request)`. So when you first add the label you will have twice as many checks on the PR as before. If a new commit is pushed these extra checks will disappear. 

**Tech Notes:**
- the prepare job is now a prerequisite for all other jobs, this way it can cancel the build if label other than `run regression` is added.
- the `gh pr view` command is used to get info about the PR associated with the currently checked out branch. See the comment in the code for nuances about this
- this would be simpler if there was a way to filter the `labeled` trigger to only apply to a specific label, but unfortunately that isn't possible.