### PR TITLE
print the urls of the files that fail to load

### DIFF
--- a/src/models/curriculum/unit.ts
+++ b/src/models/curriculum/unit.ts
@@ -154,9 +154,13 @@ function getUnitSpec(unitId: string | undefined, appConfig: AppConfigModelType) 
 
 const getExternalProblemSectionData =
   async (invIdx: number, probIdx: number, sectIdx: number, dataUrl: string, sectionPath?: string) => {
-    const sectionData = await fetch(dataUrl).then(res => res.json());
-    sectionData.sectionPath = sectionPath;
-    return { invIdx, probIdx, sectIdx, sectionData };
+    try {
+      const sectionData = await fetch(dataUrl).then(res => res.json());
+      sectionData.sectionPath = sectionPath;
+      return { invIdx, probIdx, sectIdx, sectionData };
+    } catch (error) {
+      throw new Error(`Failed to load problem-section ${dataUrl} cause:\n ${error}`);
+    }
 };
 
 const populateProblemSections = async (content: Record<string, any>, unitUrl: string) => {
@@ -214,7 +218,7 @@ export function getUnitJson(unitId: string | undefined, appConfig: AppConfigMode
              }
            })
            .catch(error => {
-             throw Error(`Request rejected with exception ${error}`);
+             throw Error(`Failed to load unit ${unitUrl} cause:\n ${error}`);
            });
 }
 


### PR DESCRIPTION
There is better `cause` support in the JS standard but Chrome
still doesn't support it:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
https://bugs.chromium.org/p/chromium/issues/detail?id=1211260

This was used to help track down a recent syntax error in the moth unit.
I don't have a simple way to test it. One approach is to check out the clue-curriculum repo. Then add an syntax error to one of the problem files, and then load that unit.