### PR TITLE
use a registration pattern for table toolbar

### DIFF
--- a/cypress/e2e/clue/branch/student_tests/simulator_tile_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/simulator_tile_spec.js
@@ -139,7 +139,7 @@ context('Simulator Tile with Terrarium Simulation', function() {
     dataflowTile.getDropdown(sensor, "sensor-type").click();
     dataflowTile.getSensorDropdownOptions(sensor).eq(0).find(".label").click(); // Temperature
     dataflowTile.getDropdown(sensor, "sensor-select").click();
-    dataflowTile.getSensorDropdownOptions(sensor).should("have.length", 6);
+    dataflowTile.getSensorDropdownOptions(sensor).should("have.length", 7);
     dataflowTile.getDropdown(sensor, "sensor-type").click();
     dataflowTile.getSensorDropdownOptions(sensor).eq(1).find(".label").click(); // Humidity
     dataflowTile.getDropdown(sensor, "sensor-select").click();

--- a/docs/document-scope.md
+++ b/docs/document-scope.md
@@ -22,7 +22,9 @@ This is really simple to use. The calling code has full access to all of the pro
 ### Downsides
 This can make the code harder to test. A MST tree has to be created to test the model that is using it. If types are used to find the parent, a tree with those types has to be made, which can require lots of extra intermediate nodes.
 
-The approach of `getDocumentContentFromNode` means we can't use type "inheritance" to provide stripped down models which provide the necessary features. It would be possible to provide a mock model which has the name of DocumentContent to work around this, but that seems fragile.
+The approach of `getDocumentContentFromNode` means we can't use type "inheritance" to provide stripped down models which provide the necessary features. It would be possible to provide a mock model which has the name of `"DocumentContent"`` to work around this, but that seems fragile.
+
+There is also issue of children having explicit knowledge of their parents which can cause import cycles. In most cases CLUE doesn't have this import cycle because the document doesn't have explicit knowledge of its tiles. The tiles register themselves with the system.
 
 ## MST Environment
 Models have access to the MST environment of their root node. In CLUE this environment includes:

--- a/docs/document-scope.md
+++ b/docs/document-scope.md
@@ -2,8 +2,72 @@
 
 CLUE tiles often need to access stuff at the document level to get their job done.
 
-Sometimes the code needing access is in the view layer (components and hooks) and sometimes it is in the model layer. The view layer has access to the models, but not vice versa, so anything described below about the model layer can be used by the views.
+Sometimes the code needing access is in the view layer (components and hooks) and sometimes it is in the model layer. The view layer has access to the models, but not vice versa, so anything described below about the model layer could be used by the views.
 
-Because the view can use the model layer mechanisms code that is based on them can be used in more places.
+Because the view can use the model layer mechanisms, code that is based on the model layer mechanisms can be used in more places.
 
-More details to come soon hopefully including a complete list of all of the ways the code accesses the document scope.
+# Model layer
+
+## Traversing the tree
+Models can go up the MST tree to find the document or other parent and then use its views or actions or services.
+
+### Cases
+- `getDocumentContentFromNode` this looks explicitly at the string type of each parent node instead of using the MST "class" itself.
+- `getDocumentIdentifier` looks at the two kinds of parents of DocumentContent to construct an identifier.
+- `getTileModel` looks at the parent of of a tile content model to get the tile model
+
+### Benefits
+This is really simple to use. The calling code has full access to all of the properties, views, and actions of the parent. So new interface don't need to be created or modified, the calling code can just get what it needs.
+
+### Downsides
+This can make the code harder to test. A MST tree has to be created to test the model that is using it. If types are used to find the parent, a tree with those types has to be made, which can require lots of extra intermediate nodes.
+
+The approach of `getDocumentContentFromNode` means we can't use type "inheritance" to provide stripped down models which provide the necessary features. It would be possible to provide a mock model which has the name of DocumentContent to work around this, but that seems fragile.
+
+## MST Environment
+Models have access to the MST environment of their root node. In CLUE this environment includes:
+- `sharedModelManager`
+- `appConfig`
+
+I'll call these "services".
+
+The environment object of a MST tree has to be provided when the root of the tree is created and this object instance can't be changed. This object is not observable. And according to the docs the top level properties of this object should not be modified. I think this is because MST does try to merge environments when a node with an environment is added to another tree. However nested environments are not supported like React supports nested context's.
+
+### Cases
+- `getSharedModelManager`
+- `getAppConfig`
+
+### Benefits
+Any MST tree can have an environment that provides the necessary services.
+
+### Downsides
+The construction of this environment is kind of awkward because it often requires a circular reference. In many cases the services need access to the tree itself. So the tree refers to the service and the service refers to the tree.
+
+So the environment service has to be created, then the root node created with the environment service, and finally the root node needs to set back on the environment service. See `createDocumentModel` for an example of this.
+
+The top level properties of the environment object are not supposed to be modified after it is created, based on this "shallowly immutable" note here: https://mobx-state-tree.js.org/concepts/dependency-injection
+However we are doing this when the appConfig is added to the environment object in `Documents#add`
+
+# View layer
+
+## React Context
+
+### Cases
+- `AddTilesContext` provided by the Canvas component. `DataSetViewButton` uses this add new tiles to the document.
+- `TileApiInterfaceContext` provided by the Canvas component. This is used internally for the tileApi mechanism described below
+- `DocumentContextReact` provided by `EditableDocumentContent`, `CollapsibleDocumentsSection`, and `DocumentCollectionByType`. This provides basic info about the document (type, key, title, originDoc) and methods for setting and getting properties on the document. This is accessed by `useImageContentUrl`, but it does not seem to actually be using it. It is also accessed by `DataflowProgram` but again doesn't seem to be used.
+- `EditableTileApiInterfaceRefContext` provided by the `EditableDocumentContent`. It is a simple React ref object so basically just an object with `current`. The `Canvas` sets this `current` to be the same `tileApiInterface` that is available via the `TileApiInterfaceContext`. I'm not sure why this is. Its existence is checked by the `Toolbar`'s `getUniqueTitle`. I'm not sure what this existence check is for. Its `deleteSelection` function is used by the `Toolbar`'s `handleDelete`.
+
+These next contexts are not at the document level but it seemed good to include them for completeness:
+- `TileModelContext` this is provided by the `TileComponent`. Its value is the `TileModel` instance of the tile.
+- `AppConfigContext` this is provided by `AppProvider`. Despite its name it does not provide the global appConfig. It just provides the `appIcons` global.
+
+## Common Tile Properties
+This is described in `tiles.md`.
+
+All tile content components are passed a standard set of properties. These are typed by `ITileProps` in `tile-component.tsx`. Many of these properties provide document level info. Others are functions the tile content component can call to get information, or modify the document.
+
+## Tile Component API
+This is described in `tiles.md`.
+
+Two of the properties passed into the tile content component are `onRegisterTileApi` and `onUnregisterTileApi`. These are used by the component to provide the CLUE framework with a way to interact with the tile.  So really this is the inverse of the focus of this documentation, but it seems good to include for completeness.

--- a/docs/document-scope.md
+++ b/docs/document-scope.md
@@ -1,0 +1,9 @@
+# Access document scope
+
+CLUE tiles often need to access stuff at the document level to get their job done.
+
+Sometimes the code needing access is in the view layer (components and hooks) and sometimes it is in the model layer. The view layer has access to the models, but not vice versa, so anything described below about the model layer can be used by the views.
+
+Because the view can use the model layer mechanisms code that is based on them can be used in more places.
+
+More details to come soon hopefully including a complete list of all of the ways the code accesses the document scope.

--- a/src/components/document/document-content.tsx
+++ b/src/components/document/document-content.tsx
@@ -261,6 +261,11 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
     return tile?.computedTitle;
   }
 
+  // TODO: this should be moved into DocumentContent now that
+  // the document component is not needed to get the title of a tile.
+  // Code currently uses this through onRequestTilesOfType, all of that code
+  // is inside of a tile so it can use the TileModelContext to get the tileModel
+  // then use getDocumentContentFromNode(model) to get the content.
   private handleRequestTilesOfType = (tileType: string) => {
     const { content } = this.props;
     const tileApiInterface = this.context;
@@ -269,13 +274,13 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
     return tilesOfType.map(id => ({ id, title: this.getTileTitle(id) }));
   };
 
+  // TODO: remove this.
+  // Code currently uses this through onRequestLinkableTiles
+  // Instead it can use the TileModelContext to get the tileModel
+  // then use getDocumentContentFromNode(model) to get the content.
   private handleRequestLinkableTiles = () => {
     const { content } = this.props;
-    const { providers, consumers } = content?.getLinkableTiles() || kNoLinkableTiles;
-    return {
-      providers: providers.map(tileInfo => ({ title: this.getTileTitle(tileInfo.id), ...tileInfo })),
-      consumers: consumers.map(tileInfo => ({ title: this.getTileTitle(tileInfo.id), ...tileInfo }))
-    };
+    return content?.getLinkableTiles() || kNoLinkableTiles;
   };
 
   private handleRequestUniqueTitle = (tileId: string) => {

--- a/src/components/document/document-content.tsx
+++ b/src/components/document/document-content.tsx
@@ -11,7 +11,6 @@ import { TileRowComponent, kDragResizeRowId, extractDragResizeRowId, extractDrag
 import { DocumentContentModelType } from "../../models/document/document-content";
 import { IDragToolCreateInfo, IDragTilesData } from "../../models/document/document-content-types";
 import { getTileContentInfo } from "../../models/tiles/tile-content-info";
-import { kNoLinkableTiles } from "../../models/tiles/tile-link-types";
 import { getDocumentIdentifier } from "../../models/document/document-utils";
 import { IDropRowInfo } from "../../models/document/tile-row";
 import { logDataTransfer } from "../../models/document/drag-tiles";
@@ -235,8 +234,6 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
                                   documentContent={this.domElement}
                                   rowIndex={index} height={rowHeight} tileMap={tileMap}
                                   dropHighlight={dropHighlight}
-                                  onRequestTilesOfType={this.handleRequestTilesOfType}
-                                  onRequestLinkableTiles={this.handleRequestLinkableTiles}
                                   onRequestUniqueTitle={this.handleRequestUniqueTitle}
                                   ref={(elt) => this.rowRefs.push(elt)} {...others} />
               : null;
@@ -260,28 +257,6 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
     const tile = this.props.content?.getTile(id);
     return tile?.computedTitle;
   }
-
-  // TODO: this should be moved into DocumentContent now that
-  // the document component is not needed to get the title of a tile.
-  // Code currently uses this through onRequestTilesOfType, all of that code
-  // is inside of a tile so it can use the TileModelContext to get the tileModel
-  // then use getDocumentContentFromNode(model) to get the content.
-  private handleRequestTilesOfType = (tileType: string) => {
-    const { content } = this.props;
-    const tileApiInterface = this.context;
-    if (!content || !tileType || !tileApiInterface) return [];
-    const tilesOfType = content.getTilesOfType(tileType);
-    return tilesOfType.map(id => ({ id, title: this.getTileTitle(id) }));
-  };
-
-  // TODO: remove this.
-  // Code currently uses this through onRequestLinkableTiles
-  // Instead it can use the TileModelContext to get the tileModel
-  // then use getDocumentContentFromNode(model) to get the content.
-  private handleRequestLinkableTiles = () => {
-    const { content } = this.props;
-    return content?.getLinkableTiles() || kNoLinkableTiles;
-  };
 
   private handleRequestUniqueTitle = (tileId: string) => {
     const { content } = this.props;

--- a/src/components/document/tile-row.tsx
+++ b/src/components/document/tile-row.tsx
@@ -4,7 +4,6 @@ import { observer, inject } from "mobx-react";
 import { BaseComponent } from "../base";
 import { TileLayoutModelType, TileRowModelType } from "../../models/document/tile-row";
 import { getTileContentInfo } from "../../models/tiles/tile-content-info";
-import { ILinkableTiles } from "../../models/tiles/tile-link-types";
 import { ITileModel } from "../../models/tiles/tile-model";
 import { SectionHeader } from "../tiles/section-header";
 import { TileApiInterfaceContext } from "../tiles/tile-api";
@@ -68,8 +67,6 @@ interface IProps {
   tileMap: any;
   readOnly?: boolean;
   dropHighlight?: string;
-  onRequestTilesOfType: (tileType: string) => Array<{ id: string, title?: string }>;
-  onRequestLinkableTiles?: () => ILinkableTiles;
   onRequestUniqueTitle: (tileId: string) => string | undefined;
 }
 

--- a/src/components/shared/data-set-view-button.tsx
+++ b/src/components/shared/data-set-view-button.tsx
@@ -9,12 +9,19 @@ import ViewBadgeIcon from "../../assets/icons/view/view-badge.svg";
 import "./data-set-view-button.scss";
 
 interface IProps {
-  newTileType: string;
+  args: string[];
 }
 
-export const DataSetViewButton: React.FC<IProps> = ({newTileType}) => {
+export const DataSetViewButton: React.FC<IProps> = ({args}) => {
   const addTilesContext = useContext(AddTilesContext);
   const tile = useContext(TileModelContext);
+
+  if (args.length !== 2 || args[0] !== "data-set-view") {
+    console.error("Unknown args", args);
+    return null;
+  }
+
+  const newTileType = args[1];
 
   // TODO: if the document or tile are undefined then disable the button
 

--- a/src/components/tiles/basic-editable-tile-title.tsx
+++ b/src/components/tiles/basic-editable-tile-title.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { ToolTitleArea } from "./tile-title-area";
+import { TileTitleArea } from "./tile-title-area";
 import { EditableTileTitle } from "./editable-tile-title";
 import { measureText } from "./hooks/use-measure-text";
 import { defaultTileTitleFont } from "../constants";
@@ -11,12 +11,12 @@ interface IBasicEditableTileTitleProps {
 }
 export function BasicEditableTileTitle({ readOnly, titleKey }: IBasicEditableTileTitleProps) {
   return (
-    <ToolTitleArea>
+    <TileTitleArea>
       <EditableTileTitle
         key={titleKey}
         readOnly={readOnly}
         measureText={(text) => measureText(text, defaultTileTitleFont)}
       />
-    </ToolTitleArea>
+    </TileTitleArea>
   );
 }

--- a/src/components/tiles/geometry/geometry-content.tsx
+++ b/src/components/tiles/geometry/geometry-content.tsx
@@ -56,7 +56,7 @@ import ErrorAlert from "../../utilities/error-alert";
 import { halfPi, normalizeAngle, Point } from "../../../utilities/math-utils";
 import SingleStringDialog from "../../utilities/single-string-dialog";
 import { getClipboardContent, pasteClipboardImage } from "../../../utilities/clipboard-utils";
-import { ToolTitleArea } from "../tile-title-area";
+import { TileTitleArea } from "../tile-title-area";
 
 import "./geometry-tile.sass";
 
@@ -594,10 +594,10 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
 
   private renderTitleArea() {
     return (
-      <ToolTitleArea>
+      <TileTitleArea>
         {this.renderTitle()}
         {this.renderTileLinkButton()}
-      </ToolTitleArea>
+      </TileTitleArea>
     );
   }
 

--- a/src/components/tiles/geometry/geometry-tile.tsx
+++ b/src/components/tiles/geometry/geometry-tile.tsx
@@ -16,8 +16,7 @@ import "./geometry-tile.sass";
 const _GeometryToolComponent: React.FC<IGeometryProps> = ({
   model, readOnly, ...others
 }) => {
-  const { documentContent, tileElt, scale, onRequestLinkableTiles, onRequestTilesOfType,
-    onRegisterTileApi, onUnregisterTileApi } = others;
+  const { documentContent, tileElt, scale, onRegisterTileApi, onUnregisterTileApi } = others;
   const modelRef = useCurrent(model);
   const domElement = useRef<HTMLDivElement>(null);
   const content = model.content as GeometryContentModelType;
@@ -49,9 +48,7 @@ const _GeometryToolComponent: React.FC<IGeometryProps> = ({
   );
   const enabled = !readOnly && !!board && !!actionHandlers;
   const toolbarProps = useToolbarTileApi({ id: model.id, enabled, onRegisterTileApi, onUnregisterTileApi });
-  const { isLinkEnabled, showLinkTileDialog } = useProviderTileLinking({
-    model, readOnly, onRequestTilesOfType, onRequestLinkableTiles
-  });
+  const { isLinkEnabled, showLinkTileDialog } = useProviderTileLinking({ model, readOnly });
   // We must listen for pointer events because we want to get the events before
   // JSXGraph, which appears to listen to pointer events on browsers that support them.
   // We must listen for mouse events because some browsers (notably Safari) don't

--- a/src/components/tiles/table/table-tile.tsx
+++ b/src/components/tiles/table/table-tile.tsx
@@ -29,7 +29,7 @@ import { lightenColor } from "../../../utilities/color-utils";
 import { verifyAlive } from "../../../utilities/mst-utils";
 import { gImageMap } from "../../../models/image-map";
 import { getColorMapEntry } from "../../../models/shared/shared-data-set-colors";
-import { ToolbarContext } from "./table-toolbar-buttons";
+import { TableToolbarContext } from "./table-toolbar-context";
 
 import "./table-tile.scss";
 
@@ -222,14 +222,14 @@ const TableToolComponent: React.FC<ITileProps> = observer(function TableToolComp
   const toolbarProps = useToolbarTileApi({ id: model.id, enabled: !readOnly, onRegisterTileApi, onUnregisterTileApi });
   return (
     <div className="table-tool">
-      <ToolbarContext.Provider value={toolbarContext} >
+      <TableToolbarContext.Provider value={toolbarContext} >
         <TableToolbar
           documentContent={documentContent}
           tileElt={tileElt}
           {...toolbarProps}
           scale={scale}
         />
-      </ToolbarContext.Provider>
+      </TableToolbarContext.Provider>
       <div className="table-grid-container" ref={containerRef} onClick={handleBackgroundClick}>
         <EditableTableTitle
           model={model}

--- a/src/components/tiles/table/table-tile.tsx
+++ b/src/components/tiles/table/table-tile.tsx
@@ -15,7 +15,6 @@ import { useContentChangeHandlers } from "./use-content-change-handlers";
 import { useControlsColumn } from "./use-controls-column";
 import { useDataSet } from "./use-data-set";
 import { useExpressionsDialog } from "./use-expressions-dialog";
-import { useConsumerTileLinking } from "../../../hooks/use-consumer-tile-linking";
 import { useGridContext } from "./use-grid-context";
 import { useMeasureColumnWidth } from "./use-measure-column-width";
 import { useModelDataSet } from "./use-model-data-set";
@@ -29,14 +28,15 @@ import { useToolbarTileApi } from "../hooks/use-toolbar-tile-api";
 import { lightenColor } from "../../../utilities/color-utils";
 import { verifyAlive } from "../../../utilities/mst-utils";
 import { gImageMap } from "../../../models/image-map";
+import { getColorMapEntry } from "../../../models/shared/shared-data-set-colors";
+import { ToolbarContext } from "./table-toolbar-buttons";
 
 import "./table-tile.scss";
 
 // observes row selection from shared selection store
 const TableToolComponent: React.FC<ITileProps> = observer(function TableToolComponent({
   documentContent, tileElt, model, readOnly, height, scale,
-  onRequestRowHeight, onRequestTilesOfType, onRequestLinkableTiles, onRequestUniqueTitle,
-  onRegisterTileApi, onUnregisterTileApi
+  onRequestRowHeight, onRequestUniqueTitle, onRegisterTileApi, onUnregisterTileApi
 }) {
   // Gather data from the model
   const modelRef = useCurrent(model);
@@ -165,14 +165,12 @@ const TableToolComponent: React.FC<ITileProps> = observer(function TableToolComp
   // deleteSelected is a function that clears the value of the currently selected cell
   // dataGridProps contains callbacks to pass to ReactDataGrid
   // hasLinkableRows is used to determine if the table can meaningfully be linked to a geometry tile
-  const { deleteSelected, hasLinkableRows, ...dataGridProps } = useDataSet({
+  const { deleteSelected, ...dataGridProps } = useDataSet({
     gridRef, model, dataSet, triggerColumnChange, rows, rowChanges, triggerRowChange,
     readOnly: !!readOnly, changeHandlers, columns, onColumnResize, selectedCell, inputRowId, lookupImage });
 
-  // Variables for handling linking to geometry tiles
-  const { isLinkEnabled, linkColors, showLinkTileDialog } =
-    useConsumerTileLinking({ model, hasLinkableRows,
-                          onRequestTilesOfType, onRequestLinkableTiles });
+  const colorMapEntry = getColorMapEntry(model.id);
+  const linkColors = colorMapEntry?.colorSet;
 
   const containerRef = useRef<HTMLDivElement>(null);
   const handleBackgroundClick = (e: React.MouseEvent<HTMLDivElement>) => {
@@ -211,19 +209,27 @@ const TableToolComponent: React.FC<ITileProps> = observer(function TableToolComp
     return () => disposer();
   });
 
+  // Currently this is recreated on each render, so the ToolbarContext is changed
+  // on each render. deleteSelected is changed on each render, so a useMemo
+  // here would not help the situation. I think an object that is managing
+  // the internal state of the component would be a better way to factor
+  // all of the use* calls above.
+  const toolbarContext = {
+    showExpressionsDialog,
+    deleteSelected,
+  };
+
   const toolbarProps = useToolbarTileApi({ id: model.id, enabled: !readOnly, onRegisterTileApi, onUnregisterTileApi });
   return (
     <div className="table-tool">
-      <TableToolbar
-        documentContent={documentContent}
-        tileElt={tileElt}
-        {...toolbarProps}
-        deleteSelected={deleteSelected}
-        onSetExpression={showExpressionsDialog}
-        scale={scale}
-        isLinkEnabled={isLinkEnabled}
-        showLinkDialog={showLinkTileDialog}
-      />
+      <ToolbarContext.Provider value={toolbarContext} >
+        <TableToolbar
+          documentContent={documentContent}
+          tileElt={tileElt}
+          {...toolbarProps}
+          scale={scale}
+        />
+      </ToolbarContext.Provider>
       <div className="table-grid-container" ref={containerRef} onClick={handleBackgroundClick}>
         <EditableTableTitle
           model={model}

--- a/src/components/tiles/table/table-toolbar-buttons.tsx
+++ b/src/components/tiles/table/table-toolbar-buttons.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext } from "react";
+import React, { useContext } from "react";
 import { Tooltip, TooltipProps } from "react-tippy";
 import classNames from "classnames";
 
@@ -9,15 +9,10 @@ import { useTooltipOptions } from "../../../hooks/use-tooltip-options";
 import { useConsumerTileLinking } from "../../../hooks/use-consumer-tile-linking";
 import { getTileDataSet } from "../../../models/shared/shared-data-utils";
 import { TileModelContext } from "../tile-api";
+import { TableToolbarContext } from "./table-toolbar-context";
 
 import "./table-toolbar.scss";
 
-export interface IToolbarContext {
-  showExpressionsDialog: () => void;
-  deleteSelected: () => void;
-}
-
-export const ToolbarContext = createContext<IToolbarContext | null>(null);
 interface ITableButtonProps {
   className?: string;
   icon: any;
@@ -37,7 +32,7 @@ const TableButton = ({ className, icon, onClick, tooltipOptions}: ITableButtonPr
 };
 
 export const DeleteSelectedButton = () => {
-  const toolbarContext = useContext(ToolbarContext);
+  const toolbarContext = useContext(TableToolbarContext);
 
   return (
     <TableButton
@@ -50,7 +45,7 @@ export const DeleteSelectedButton = () => {
 };
 
 export const SetExpressionButton = () => {
-  const toolbarContext = useContext(ToolbarContext);
+  const toolbarContext = useContext(TableToolbarContext);
 
   return (
     <TableButton

--- a/src/components/tiles/table/table-toolbar-context.ts
+++ b/src/components/tiles/table/table-toolbar-context.ts
@@ -1,0 +1,8 @@
+import { createContext } from "react";
+
+export interface ITableToolbarContext {
+  showExpressionsDialog: () => void;
+  deleteSelected: () => void;
+}
+
+export const TableToolbarContext = createContext<ITableToolbarContext | null>(null);

--- a/src/components/tiles/table/table-toolbar.tsx
+++ b/src/components/tiles/table/table-toolbar.tsx
@@ -13,15 +13,20 @@ type IButtonSetting = string | [string, string];
 
 const defaultButtons = ["set-expression", "link-tile", "delete"];
 
-interface IProps extends IFloatingToolbarProps {
-  isLinkEnabled: boolean;
-  deleteSelected: () => void;
-  onSetExpression: () => void;
-  showLinkDialog?: () => void;
+const simpleButtons: Record<string, React.ComponentType | undefined> = {
+  "set-expression": SetExpressionButton,
+  "delete": DeleteSelectedButton,
+  "link-tile": LinkTileButton,
+};
+interface IParameterButtonProps {
+  args: string[];
 }
-export const TableToolbar: React.FC<IProps> = observer(({
-  documentContent, isLinkEnabled, deleteSelected, onIsEnabled,
-  onSetExpression, showLinkDialog, ...others
+const parameterButtons: Record<string, React.ComponentType<IParameterButtonProps> | undefined> = {
+  "data-set-view": DataSetViewButton,
+};
+
+export const TableToolbar: React.FC<IFloatingToolbarProps> = observer(({
+  documentContent, onIsEnabled, ...others
 }) => {
   const enabled = onIsEnabled();
   const location = useFloatingToolbarLocation({
@@ -37,26 +42,14 @@ export const TableToolbar: React.FC<IProps> = observer(({
 
   const getToolbarButton = (toolName: IButtonSetting) => {
     if (typeof toolName === "string") {
-      switch (toolName) {
-        case "set-expression":
-          return <SetExpressionButton key={toolName} onClick={onSetExpression} />;
-        case "delete":
-          return <DeleteSelectedButton key={toolName} onClick={deleteSelected} />;
-        case "link-tile":
-          return <LinkTileButton
-                  key={toolName}
-                  isEnabled={isLinkEnabled}
-                  onClick={showLinkDialog}
-                />;
-      }
+      const Button = simpleButtons[toolName];
+      return Button && <Button key={toolName} />;
     } else {
       // If `toolName` is an array, the first item is the tool name.
       // The remaining items are parameters to the pass to the tool
       const realToolName = toolName[0];
-      if (realToolName === "data-set-view") {
-        const tileType = toolName[1];
-        return <DataSetViewButton key={`${toolName[0]}_${toolName[1]}`} newTileType={tileType} />;
-      }
+      const Button = parameterButtons[realToolName];
+      return Button && <Button key={toolName.join("_")} args={toolName} />;
     }
   };
 

--- a/src/components/tiles/table/use-data-set.ts
+++ b/src/components/tiles/table/use-data-set.ts
@@ -78,8 +78,6 @@ export const useDataSet = ({
     }
   };
 
-  const hasLinkableRows = dataSet.attributes.length > 1;
-
   const getUpdatedRowAndColumn = (_rows?: TRow[], _columns?: TColumn[]) => {
     const rs = _rows ?? rows;
     const cs = _columns ?? columns;
@@ -134,6 +132,6 @@ export const useDataSet = ({
     triggerColumnChange();
     return returnVal;
   }, [onColumnResize, triggerColumnChange]);
-  
-  return { hasLinkableRows, onColumnResize: handleColumnResize, onRowsChange, deleteSelected, onSelectedCellChange};
+
+  return { onColumnResize: handleColumnResize, onRowsChange, deleteSelected, onSelectedCellChange};
 };

--- a/src/components/tiles/text/spec-text-tile.tsx
+++ b/src/components/tiles/text/spec-text-tile.tsx
@@ -35,9 +35,6 @@ export function specTextTile(options: ISpecTextTileOptions) {
     onSetCanAcceptDrop: (tileId) => {
       throw new Error("Function not implemented.");
     },
-    onRequestTilesOfType: (tileType) => {
-      throw new Error("Function not implemented.");
-    },
     onRequestUniqueTitle: (tileId) => {
       throw new Error("Function not implemented.");
     },

--- a/src/components/tiles/tile-component.test.tsx
+++ b/src/components/tiles/tile-component.test.tsx
@@ -29,8 +29,6 @@ describe("TileComponent", () => {
 
     const onResizeRow = jest.fn();
     const onSetCanAcceptDrop = jest.fn();
-    const onRequestTilesOfType = jest.fn();
-    const onRequestLinkableTiles = jest.fn();
     const onRequestUniqueTitle = jest.fn();
     const onRequestRowHeight = jest.fn();
 
@@ -45,8 +43,6 @@ describe("TileComponent", () => {
             model={toolTileModel}
             onResizeRow={onResizeRow}
             onSetCanAcceptDrop={onSetCanAcceptDrop}
-            onRequestTilesOfType={onRequestTilesOfType}
-            onRequestLinkableTiles={onRequestLinkableTiles}
             onRequestUniqueTitle={onRequestUniqueTitle}
             onRequestRowHeight={onRequestRowHeight}
             />

--- a/src/components/tiles/tile-component.tsx
+++ b/src/components/tiles/tile-component.tsx
@@ -6,7 +6,6 @@ import { isAlive } from "mobx-state-tree";
 import ResizeObserver from "resize-observer-polyfill";
 import { transformCurriculumImageUrl } from "../../models/tiles/image/image-import-export";
 import { getTileComponentInfo } from "../../models/tiles/tile-component-info";
-import { ILinkableTiles } from "../../models/tiles/tile-link-types";
 import { ITileModel } from "../../models/tiles/tile-model";
 import { BaseComponent } from "../base";
 import PlaceholderTileComponent from "./placeholder/placeholder-tile";
@@ -68,8 +67,6 @@ interface ITileBaseProps {
   readOnly?: boolean;
   onResizeRow: (e: React.DragEvent<HTMLDivElement>) => void;
   onSetCanAcceptDrop: (tileId?: string) => void;
-  onRequestTilesOfType: (tileType: string) => Array<{ id: string, title?: string }>;
-  onRequestLinkableTiles?: () => ILinkableTiles;
   // TODO: this isn't really necessary to be in component API anymore, it is
   // implemented in the model layer.
   onRequestUniqueTitle: (tileId: string) => string | undefined;

--- a/src/components/tiles/tile-title-area.tsx
+++ b/src/components/tiles/tile-title-area.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-export const ToolTitleArea: React.FC = ({ children }) => {
+export const TileTitleArea: React.FC = ({ children }) => {
   return (
     <div className="title-area-wrapper" key="title-area">
       <div className="title-area">

--- a/src/hooks/use-consumer-tile-linking.ts
+++ b/src/hooks/use-consumer-tile-linking.ts
@@ -18,7 +18,7 @@ interface IProps {
   readOnly?: boolean;
 
   // These callbacks are used by components to override the default link
-  // and unlink behavior. If they are set, the caller is
+  // and unlink behavior. If they are set, the caller
   // is responsible for actually linking the tile.
   onLinkTile?: (tileInfo: ITileLinkMetadata) => void;
   onUnlinkTile?: (tileInfo: ITileLinkMetadata) => void;

--- a/src/hooks/use-consumer-tile-linking.ts
+++ b/src/hooks/use-consumer-tile-linking.ts
@@ -1,12 +1,12 @@
 import { useCallback } from "react";
 
-import { ITileLinkMetadata, ITypedTileLinkMetadata, kNoLinkableTiles
-} from "../models/tiles/tile-link-types";
+import { ITileLinkMetadata} from "../models/tiles/tile-link-types";
 import { ITileModel } from "../models/tiles/tile-model";
 import { useLinkConsumerTileDialog } from "./use-link-consumer-tile-dialog";
-import { getDocumentContentFromNode, getTileContentById } from "../utilities/mst-utils";
+import { getTileContentById } from "../utilities/mst-utils";
 import { SharedDataSet } from "../models/shared/shared-data-set";
 import { getTileContentInfo } from "../models/tiles/tile-content-info";
+import { useLinkableTiles } from "./use-linkable-tiles";
 
 interface IProps {
   // TODO: This should be replaced with a generic disabled
@@ -88,26 +88,4 @@ export const useConsumerTileLinking = ({
   return { isLinkEnabled, showLinkTileDialog };
 };
 
-interface IUseLinkableTilesProps {
-  model: ITileModel;
-}
-const useLinkableTiles = ({ model }: IUseLinkableTilesProps) => {
-  const documentContent = getDocumentContentFromNode(model);
-  const { providers, consumers } = documentContent?.getLinkableTiles() || kNoLinkableTiles;
 
-  // add default title if there isn't a title
-  const countsOfType = {} as Record<string, number>;
-  function addDefaultTitle({ id, type, title, titleBase }: ITypedTileLinkMetadata) {
-    if (!countsOfType[type]) {
-      countsOfType[type] = 1;
-    } else {
-      countsOfType[type]++;
-    }
-    return { id, type, title: title || `${titleBase || type} ${countsOfType[type]}`};
-  }
-
-  return {
-    providers: providers.map(addDefaultTitle),
-    consumers: consumers.map(addDefaultTitle)
-  };
-};

--- a/src/hooks/use-linkable-tiles.ts
+++ b/src/hooks/use-linkable-tiles.ts
@@ -1,0 +1,29 @@
+import { ITypedTileLinkMetadata, kNoLinkableTiles } from "../models/tiles/tile-link-types";
+import { ITileModel } from "../models/tiles/tile-model";
+import { getDocumentContentFromNode } from "../utilities/mst-utils";
+
+interface IUseLinkableTilesProps {
+  model: ITileModel;
+}
+export const useLinkableTiles = ({ model }: IUseLinkableTilesProps) => {
+  // See document-scope.md for notes about how linkable tiles
+  // are accessed here.
+  const documentContent = getDocumentContentFromNode(model);
+  const { providers, consumers } = documentContent?.getLinkableTiles() || kNoLinkableTiles;
+
+  // add default title if there isn't a title
+  const countsOfType = {} as Record<string, number>;
+  function addDefaultTitle({ id, type, title, titleBase }: ITypedTileLinkMetadata) {
+    if (!countsOfType[type]) {
+      countsOfType[type] = 1;
+    } else {
+      countsOfType[type]++;
+    }
+    return { id, type, title: title || `${titleBase || type} ${countsOfType[type]}` };
+  }
+
+  return {
+    providers: providers.map(addDefaultTitle),
+    consumers: consumers.map(addDefaultTitle)
+  };
+};

--- a/src/hooks/use-provider-tile-linking.tsx
+++ b/src/hooks/use-provider-tile-linking.tsx
@@ -1,25 +1,23 @@
 import { useCallback } from "react";
 
-import {
-  ILinkableTiles, ITileLinkMetadata, ITypedTileLinkMetadata, kNoLinkableTiles
+import { ITileLinkMetadata
 } from "../models/tiles/tile-link-types";
 import { ITileModel } from "../models/tiles/tile-model";
 import { useLinkProviderTileDialog } from "./use-link-provider-tile-dialog";
 import { getTileContentById } from "../utilities/mst-utils";
 import { SharedDataSet } from "../models/shared/shared-data-set";
+import { useLinkableTiles } from "./use-linkable-tiles";
 
 interface IProps {
   actionHandlers?: any;
   model: ITileModel;
   readOnly?: boolean;
-  onRequestTilesOfType: (tileType: string) => ITileLinkMetadata[];
-  onRequestLinkableTiles?: () => ILinkableTiles;
 }
 export const useProviderTileLinking = ({
-  actionHandlers, model, readOnly, onRequestTilesOfType, onRequestLinkableTiles
+  actionHandlers, model, readOnly
 }: IProps) => {
   const {handleRequestTileLink, handleRequestTileUnlink} = actionHandlers || {};
-  const { providers: linkableTiles } = useLinkableTiles({ model, onRequestTilesOfType, onRequestLinkableTiles });
+  const { providers: linkableTiles } = useLinkableTiles({ model });
   const isLinkEnabled = (linkableTiles.length > 0);
 
   const linkTile = useCallback((tileInfo: ITileLinkMetadata) => {
@@ -55,29 +53,4 @@ export const useProviderTileLinking = ({
           });
 
   return { isLinkEnabled, showLinkTileDialog };
-};
-
-interface IUseLinkableTilesProps {
-  model: ITileModel;
-  onRequestTilesOfType: (tileType: string) => ITileLinkMetadata[];
-  onRequestLinkableTiles?: () => ILinkableTiles;
-}
-const useLinkableTiles = ({ model, onRequestTilesOfType, onRequestLinkableTiles }: IUseLinkableTilesProps) => {
-  const { providers, consumers } = onRequestLinkableTiles?.() || kNoLinkableTiles;
-
-  // add default title if there isn't a title
-  const countsOfType = {} as Record<string, number>;
-  function addDefaultTitle({ id, type, title, titleBase }: ITypedTileLinkMetadata) {
-    if (!countsOfType[type]) {
-      countsOfType[type] = 1;
-    } else {
-      countsOfType[type]++;
-    }
-    return { id, type, title: title || `${titleBase || type} ${countsOfType[type]}`};
-  }
-
-  return {
-    providers: providers.map(addDefaultTitle),
-    consumers: consumers.map(addDefaultTitle)
-  };
 };

--- a/src/hooks/use-provider-tile-linking.tsx
+++ b/src/hooks/use-provider-tile-linking.tsx
@@ -1,7 +1,6 @@
 import { useCallback } from "react";
 
-import { ITileLinkMetadata
-} from "../models/tiles/tile-link-types";
+import { ITileLinkMetadata } from "../models/tiles/tile-link-types";
 import { ITileModel } from "../models/tiles/tile-model";
 import { useLinkProviderTileDialog } from "./use-link-provider-tile-dialog";
 import { getTileContentById } from "../utilities/mst-utils";

--- a/src/models/document/base-document-content.ts
+++ b/src/models/document/base-document-content.ts
@@ -269,11 +269,15 @@ export const BaseDocumentContentModel = types
           const tileType = self.getTileType(tileEntry.tileId);
           const titleBase = getTileContentInfo(tileType)?.titleBase || tileType;
           if (tileType) {
+            const tile = self.getTile(tileEntry.tileId);
+            const typedTileLinkMetadata: ITypedTileLinkMetadata = {
+              id: tileEntry.tileId, type: tileType, title: tile?.title, titleBase
+            };
             if (getTileContentInfo(tileType)?.isDataProvider) {
-              providers.push({ id: tileEntry.tileId, type: tileType, titleBase });
+              providers.push(typedTileLinkMetadata);
             }
             if (getTileContentInfo(tileType)?.isDataConsumer) {
-              consumers.push({ id: tileEntry.tileId, type: tileType, titleBase });
+              consumers.push(typedTileLinkMetadata);
             }
           }
         });

--- a/src/plugins/data-card/data-card-tile.test.tsx
+++ b/src/plugins/data-card/data-card-tile.test.tsx
@@ -39,9 +39,6 @@ describe("DataCardToolComponent", () => {
     onSetCanAcceptDrop: (tileId?: string): void => {
       throw new Error("Function not implemented.");
     },
-    onRequestTilesOfType: (tileType: string): { id: string; title?: string | undefined; }[] => {
-      throw new Error("Function not implemented.");
-    },
     onRequestUniqueTitle: (tileId: string): string | undefined => {
       return "Data Card Collection 1";
     },

--- a/src/plugins/data-card/data-card-tile.tsx
+++ b/src/plugins/data-card/data-card-tile.tsx
@@ -23,8 +23,8 @@ import "./data-card-tile.scss";
 
 export const DataCardToolComponent: React.FC<ITileProps> = observer(function DataCardToolComponent(props) {
   const { documentId, model, readOnly, documentContent, tileElt, onSetCanAcceptDrop, onRegisterTileApi,
-            scale, onRequestUniqueTitle, onUnregisterTileApi, onRequestTilesOfType,
-            height, onRequestRowHeight, onRequestLinkableTiles } = props;
+            scale, onRequestUniqueTitle, onUnregisterTileApi,
+            height, onRequestRowHeight } = props;
 
   const content = model.content as DataCardContentModelType;
   const ui = useUIStore();
@@ -236,10 +236,7 @@ export const DataCardToolComponent: React.FC<ITileProps> = observer(function Dat
   };
 
   const hasLinkableRows = content.dataSet.attributes.length > 1;
-  const { isLinkEnabled, showLinkTileDialog } = useConsumerTileLinking({
-    model, hasLinkableRows, onRequestTilesOfType, onRequestLinkableTiles
-  });
-
+  const { isLinkEnabled, showLinkTileDialog } = useConsumerTileLinking({ model, hasLinkableRows });
 
   return (
     <div className={toolClasses}>

--- a/src/plugins/dataflow/components/dataflow-tile.tsx
+++ b/src/plugins/dataflow/components/dataflow-tile.tsx
@@ -15,6 +15,7 @@ import { TileTitleArea } from "../../../components/tiles/tile-title-area";
 import { DataflowLinkTableButton } from "./ui/dataflow-program-link-table-button";
 import { ProgramMode, UpdateMode } from "./types/dataflow-tile-types";
 import { ITileLinkMetadata } from "../../../models/tiles/tile-link-types";
+import { getDocumentContentFromNode } from "../../../utilities/mst-utils";
 
 import "./dataflow-tile.scss";
 
@@ -144,9 +145,10 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IDatafl
   }
 
   private renderTableLinkButton() {
-    const { model, documentId, onRequestLinkableTiles } = this.props;
-    // TODO: replace with documentContent.getLinkableTiles()
-    const isLinkButtonEnabled = onRequestLinkableTiles && onRequestLinkableTiles().consumers.length > 0;
+    const { model, documentId } = this.props;
+    const documentContent = getDocumentContentFromNode(model);
+    const linkableTiles = documentContent?.getLinkableTiles();
+    const isLinkButtonEnabled = linkableTiles && linkableTiles.consumers.length > 0;
     const actionHandlers = {
                              handleRequestTableLink: this.handleRequestTableLink,
                              handleRequestTableUnlink: this.handleRequestTableUnlink

--- a/src/plugins/dataflow/components/dataflow-tile.tsx
+++ b/src/plugins/dataflow/components/dataflow-tile.tsx
@@ -11,7 +11,7 @@ import { EditableTileTitle } from "../../../components/tiles/editable-tile-title
 import { DataflowContentModelType } from "../model/dataflow-content";
 import { measureText } from "../../../components/tiles/hooks/use-measure-text";
 import { defaultTileTitleFont } from "../../../components/constants";
-import { ToolTitleArea } from "../../../components/tiles/tile-title-area";
+import { TileTitleArea } from "../../../components/tiles/tile-title-area";
 import { DataflowLinkTableButton } from "./ui/dataflow-program-link-table-button";
 import { ProgramMode, UpdateMode } from "./types/dataflow-tile-types";
 import { ITileLinkMetadata } from "../../../models/tiles/tile-link-types";
@@ -56,10 +56,10 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IDatafl
 
     return (
       <>
-        <ToolTitleArea>
+        <TileTitleArea>
           {this.renderTitle()}
           {this.renderTableLinkButton()}
-        </ToolTitleArea>
+        </TileTitleArea>
         <div className={classes}>
           <SizeMe monitorHeight={true}>
             {({ size }: SizeMeProps) => {
@@ -144,7 +144,8 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IDatafl
   }
 
   private renderTableLinkButton() {
-    const { model, documentId, onRequestTilesOfType, onRequestLinkableTiles } = this.props;
+    const { model, documentId, onRequestLinkableTiles } = this.props;
+    // TODO: replace with documentContent.getLinkableTiles()
     const isLinkButtonEnabled = onRequestLinkableTiles && onRequestLinkableTiles().consumers.length > 0;
     const actionHandlers = {
                              handleRequestTableLink: this.handleRequestTableLink,
@@ -158,8 +159,6 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IDatafl
         //use in useTableLinking
         documentId={documentId}
         model={model}
-        onRequestTilesOfType={onRequestTilesOfType}
-        onRequestLinkableTiles={onRequestLinkableTiles}
         actionHandlers={actionHandlers}
       />
     );

--- a/src/plugins/dataflow/components/ui/dataflow-program-link-table-button.tsx
+++ b/src/plugins/dataflow/components/ui/dataflow-program-link-table-button.tsx
@@ -4,7 +4,6 @@ import LinkTableIcon from "../../assets/icons/link-table-icon.svg"; //we may nee
 import { useFeatureFlag } from "../../../../hooks/use-stores";
 import { useConsumerTileLinking } from "../../../../hooks/use-consumer-tile-linking";
 import { ITileModel } from "../../../../models/tiles/tile-model";
-import { ILinkableTiles, ITileLinkMetadata } from "../../../../models/tiles/tile-link-types";
 import { IDataFlowActionHandlers } from "../dataflow-shared";
 
 import "./dataflow-program-link-table-button.scss";
@@ -16,21 +15,16 @@ interface IProps {
   isLinkButtonEnabled?: boolean;
   documentId?: string;
   model: ITileModel;
-  onRequestTilesOfType: (tileType: string) => ITileLinkMetadata[];
-  onRequestLinkableTiles?: () => ILinkableTiles;
   actionHandlers: IDataFlowActionHandlers;
 }
 
 export const DataflowLinkTableButton: React.FC<IProps> = (props: IProps) => {
-  const { isLinkButtonEnabled,
-          documentId,  model, onRequestTilesOfType, onRequestLinkableTiles, actionHandlers } = props;
+  const { isLinkButtonEnabled, documentId,  model, actionHandlers } = props;
   const classes = classNames("link-table-button", { disabled: !isLinkButtonEnabled });
 
   const { showLinkTileDialog } = useConsumerTileLinking({
                                     hasLinkableRows: true,
                                     model,
-                                    onRequestTilesOfType,
-                                    onRequestLinkableTiles,
                                     onLinkTile: actionHandlers.handleRequestTableLink,
                                     onUnlinkTile: actionHandlers.handleRequestTableUnlink
                                   });

--- a/src/plugins/drawing/components/drawing-tile.test.tsx
+++ b/src/plugins/drawing/components/drawing-tile.test.tsx
@@ -101,9 +101,6 @@ describe("DrawingToolComponent", () => {
     onSetCanAcceptDrop: (tileId?: string): void => {
       throw new Error("Function not implemented.");
     },
-    onRequestTilesOfType: (tileType: string): { id: string; title?: string | undefined; }[] => {
-      throw new Error("Function not implemented.");
-    },
     onRequestUniqueTitle: (tileId: string): string | undefined => {
       throw new Error("Function not implemented.");
     },

--- a/src/plugins/expression/expression-tile.test.tsx
+++ b/src/plugins/expression/expression-tile.test.tsx
@@ -37,9 +37,6 @@ describe("ExpressionToolComponent", () => {
     onSetCanAcceptDrop: (tileId?: string): void => {
       throw new Error("Function not implemented.");
     },
-    onRequestTilesOfType: (tileType: string): { id: string; title?: string | undefined; }[] => {
-      throw new Error("Function not implemented.");
-    },
     onRequestUniqueTitle: (tileId: string): string | undefined => {
       return tileId;
     },

--- a/src/plugins/graph/components/graph-toolbar.tsx
+++ b/src/plugins/graph/components/graph-toolbar.tsx
@@ -6,7 +6,6 @@ import {
   IFloatingToolbarProps, useFloatingToolbarLocation
   } from "../../../components/tiles/hooks/use-floating-toolbar-location";
 import { IGraphModel } from "../models/graph-model";
-import { ITileLinkMetadata } from "../../../models/tiles/tile-link-types";
 import { ITileModel } from "../../../models/tiles/tile-model";
 import LinkTableIcon from "../../../clue/assets/icons/geometry/link-table-icon.svg";
 
@@ -18,12 +17,11 @@ interface IProps extends IFloatingToolbarProps {
   isLinkEnabled: boolean;
   model: ITileModel;
   onLinkTableButtonClick: () => void;
-  onRequestTilesOfType: (tileType: string) => ITileLinkMetadata[];
 }
 
 export const GraphToolbar: React.FC<IProps> = observer(({
   documentContent, documentId, isLinkEnabled, tileElt, content, model,
-  onIsEnabled, onLinkTableButtonClick, onRequestTilesOfType, ...others
+  onIsEnabled, onLinkTableButtonClick, ...others
 }) => {
   const enabled = onIsEnabled();
   const location = useFloatingToolbarLocation({

--- a/src/plugins/graph/components/graph-wrapper-component.tsx
+++ b/src/plugins/graph/components/graph-wrapper-component.tsx
@@ -22,14 +22,14 @@ import "./graph-wrapper-component.scss";
 export const GraphWrapperComponent: React.FC<ITileProps> = observer(function(props) {
   const {
     documentContent, documentId, model, readOnly, scale, tileElt,
-    onRegisterTileApi, onUnregisterTileApi, onRequestTilesOfType, onRequestLinkableTiles
+    onRegisterTileApi, onUnregisterTileApi
   } = props;
   const enabled = !readOnly;
   const content = model.content as IGraphModel;
   const toolbarProps = useToolbarTileApi({ id: model.id, enabled, onRegisterTileApi, onUnregisterTileApi });
 
   const { isLinkEnabled, showLinkTileDialog } = useProviderTileLinking({
-    model, readOnly, onRequestTilesOfType, onRequestLinkableTiles
+    model, readOnly
   });
 
   const { data } = useDataSet(content?.data);
@@ -129,7 +129,6 @@ export const GraphWrapperComponent: React.FC<ITileProps> = observer(function(pro
         content={content} {...toolbarProps}
         isLinkEnabled={isLinkEnabled}
         onLinkTableButtonClick={showLinkTileDialog}
-        onRequestTilesOfType={onRequestTilesOfType}
       />
       <BasicEditableTileTitle readOnly={readOnly} />
       <GraphComponent data={data} layout={layout} tile={model} />

--- a/src/plugins/starter/starter-tile.test.tsx
+++ b/src/plugins/starter/starter-tile.test.tsx
@@ -26,9 +26,6 @@ describe("StarterToolComponent", () => {
     onSetCanAcceptDrop: (tileId?: string): void => {
       throw new Error("Function not implemented.");
     },
-    onRequestTilesOfType: (tileType: string): { id: string; title?: string | undefined; }[] => {
-      throw new Error("Function not implemented.");
-    },
     onRequestUniqueTitle: (tileId: string): string | undefined => {
       throw new Error("Function not implemented.");
     },

--- a/tiles.md
+++ b/tiles.md
@@ -80,7 +80,6 @@ interface ITileBaseProps {
   readOnly?: boolean;
   onResizeRow: (e: React.DragEvent<HTMLDivElement>) => void;
   onSetCanAcceptDrop: (tileId?: string) => void;
-  onRequestTilesOfType: (tileType: string) => Array<{ id: string, title?: string }>;
   onRequestUniqueTitle: (tileId: string) => string | undefined;
   onRequestRowHeight: (tileId: string, height?: number, deltaHeight?: number) => void;
 }


### PR DESCRIPTION
- removes onRequestTilesOfType and onRequestLinkableTiles.
- renames ToolTitleArea to TileTitleArea

`onRequestTilesOfType` was actually not being used anywhere.
`onRequestLinkableTiles` is replaced by getting the DocumentContent from the TileModel and then calling getLinkableTiles on the DocumentContent. This approach isn't ideal, it is an alternative to the React context approach taken by the `DataSetViewButton`.  

I like keeping the code model based so it is usable in both the model and view layers. But using the full DocumentContent means the code can't be tested or used in a MST tree without a DocumentContent.

After reviewing our existing patterns. I think the best option for this would be to add a new service in the MST environment which provides the getLinkableTiles method. Once setup this would just be a 2 line change to the code in this PR. Because it is a minor change and there is other work waiting on this PR, I think it is best to just leave this PR as is.

Another thing missing are tests of the DataSetViewButton that was added recently. Again since other work is waiting on this one, I think it is best to continue to punt those. I'm still waiting to see what the test coverage looks like after running the regression tests though. If it is really bad then I'll try to add more tests.

I've noticed that I'm not able to get the XYPlot to link to the table when using the standalone doc-editor (doc-editor.html). This is the case when running on this branch locally, or on deployed master, or on [deployed v4.7.0](https://collaborative-learning.concord.org/version/v4.7.0/doc-editor.html?unit=brain) . I'm testing using the brain unit. This kind of linking works when running in the full CLUE.

This kind of linking also works with the Geometry tile instead of the XYPlot in the doc-editor. So there is something broken with XYPlot in the standalone editor. Because this is also happening on master and version 4.7.0, it isn't caused by this PR. I'm not planning to fix it here. 