### PR TITLE
use MobX object instead of just observable.map

### DIFF
--- a/src/components/document/canvas.tsx
+++ b/src/components/document/canvas.tsx
@@ -1,4 +1,3 @@
-import { observable } from "mobx";
 import { inject, observer } from "mobx-react";
 import { getSnapshot, destroy } from "mobx-state-tree";
 import React from "react";
@@ -15,7 +14,7 @@ import { logHistoryEvent } from "../../models/history/log-history-event";
 import { TreeManagerType } from "../../models/history/tree-manager";
 import { PlaybackComponent } from "../playback/playback";
 import {
-  ITileApi, ITileApiInterface, TileApiInterfaceContext, EditableTileApiInterfaceRefContext, AddTilesContext
+  ITileApiInterface, TileApiInterfaceContext, EditableTileApiInterfaceRefContext, AddTilesContext, TileApiInterface
 } from "../tiles/tile-api";
 import { StringBuilder } from "../../utilities/string-builder";
 import { HotKeys } from "../../utilities/hot-keys";
@@ -47,7 +46,6 @@ interface IState {
 @inject("stores")
 @observer
 export class CanvasComponent extends BaseComponent<IProps, IState> {
-  private toolApiMap = observable.map<string, ITileApi>();
   private tileApiInterface: ITileApiInterface;
   private hotKeys: HotKeys = new HotKeys();
 
@@ -57,20 +55,7 @@ export class CanvasComponent extends BaseComponent<IProps, IState> {
   constructor(props: IProps) {
     super(props);
 
-    this.tileApiInterface = {
-      register: (id: string, tileApi: ITileApi) => {
-        this.toolApiMap.set(id, tileApi);
-      },
-      unregister: (id: string) => {
-        this.toolApiMap.delete(id);
-      },
-      getTileApi: (id: string) => {
-        return this.toolApiMap.get(id)!;
-      },
-      forEach: (callback: (api: ITileApi) => void) => {
-        this.toolApiMap.forEach(api => callback(api));
-      }
-    };
+    this.tileApiInterface = new TileApiInterface();
 
     this.hotKeys.register({
       "cmd-shift-s": this.handleCopyDocumentJson,

--- a/src/components/tiles/tile-api.tsx
+++ b/src/components/tiles/tile-api.tsx
@@ -4,6 +4,7 @@ import { IOffsetModel, ObjectBoundingBox } from "../../models/annotations/clue-o
 import { ITileExportOptions } from "../../models/tiles/tile-content-info";
 import { ITileModel } from "../../models/tiles/tile-model";
 import { SharedModelType } from "../../models/shared/shared-model";
+import { action, makeObservable, observable } from "mobx";
 
 export type TileResizeEntry = Optional<ResizeObserverEntry,
                                         "borderBoxSize" | "contentBoxSize" | "devicePixelContentBoxSize">;
@@ -40,9 +41,36 @@ export interface ITileApiInterface {
   forEach: (callback: (api: ITileApi) => void) => void;
 }
 
-export type ITileApiMap = Record<string, ITileApi>;
-
 export const TileApiInterfaceContext = createContext<ITileApiInterface | null>(null);
+
+/**
+ * An observable registry of tile API instances
+ */
+export class TileApiInterface implements ITileApiInterface {
+  private tileApiMap = observable.map<string, ITileApi>();
+
+  constructor() {
+    makeObservable(this);
+  }
+
+  @action
+  register(id: string, tileApi: ITileApi) {
+    this.tileApiMap.set(id, tileApi);
+  }
+
+  @action
+  unregister(id: string) {
+    this.tileApiMap.delete(id);
+  }
+
+  getTileApi(id: string) {
+    return this.tileApiMap.get(id)!;
+  }
+
+  forEach(callback: (api: ITileApi) => void) {
+    this.tileApiMap.forEach(api => callback(api));
+  }
+}
 
 // set by the canvas and used by the toolbar
 export type EditableTileApiInterfaceRef = React.MutableRefObject<ITileApiInterface | null>;


### PR DESCRIPTION
MobX was printing warnings in some cases when the map was modified
outside of an action.
The MobX object encapsulates this better and makes sure the map is only
modified inside of an action.

You need to be running CLUE locally with code previous to this.
Then open the standalone doc editor and add a table and a graph.