### PR TITLE
adjust cy tests - we no longer have simulated data streams in the menu

### DIFF
--- a/cypress/e2e/clue/branch/student_tests/simulator_tile_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/simulator_tile_spec.js
@@ -72,8 +72,8 @@ context('Simulator Tile with Brainwaves Gripper Simulation', function () {
       // Sensor options are correct after adding the simulation to the document
       clueCanvas.addTile("simulator");
       dataflowTile.getDropdown(sensor, "sensor-select").click();
-      dataflowTile.getSensorDropdownOptions(sensor).should("have.length", 3);
-      dataflowTile.getSensorDropdownOptions(sensor).eq(1).click();
+      dataflowTile.getSensorDropdownOptions(sensor).should("have.length", 2);
+      dataflowTile.getSensorDropdownOptions(sensor).eq(0).click();
       dataflowTile.getNodeValueContainer(sensor).invoke('text').then(parseFloat).should("be.below", 41).should("be.above", 35);
       simulatorTile.getEMGSlider().click("right");
       cy.wait(50);


### PR DESCRIPTION
This adjusts the sim tile cypress test to match the expected behavior of the sim tile.  Since we no longer have an option of hard-coded data stream without a sim tile, we have one less menu item. 