### PR TITLE
fix scrollbar on the problem tabs

### DIFF
--- a/src/components/navigation/problem-panel.scss
+++ b/src/components/navigation/problem-panel.scss
@@ -2,10 +2,10 @@
 
 .problem-panel {
   height: 100%;
-  position: relative;
 
   .section {
-    margin-top: $document-margin;
+    position: relative;
+    height: 100%;
 
     .canvas {
       overflow: auto;

--- a/src/components/navigation/problem-tab-content.sass
+++ b/src/components/navigation/problem-tab-content.sass
@@ -91,11 +91,17 @@
           background-color: $learninglog-green-light-6
     .solutions-label
       margin: 0 7px 0 3px
-  .problem-panel
-    margin-top: $document-margin
-    overflow-y: auto
+  .problem-panels-container
     flex: 1
+    // This is so the flex layout doesn't use the content height as the min height
+    min-height: 0
+    // This padding is to deal with the how the tabs above are laid out.
+    // They stick out below their box.
+    padding-top: 2px
+
   &.chat-open
     border-right: 0
   &.teacher-guide
     border-color: $learninglog-green-dark-1
+  .problem-panel-tab-panel
+    height: 100%

--- a/src/components/navigation/problem-tab-content.tsx
+++ b/src/components/navigation/problem-tab-content.tsx
@@ -89,10 +89,11 @@ export const ProblemTabContent: React.FC<IProps>
         {isTeacher && showSolutionsSwitch &&
           <SolutionsButton onClick={handleToggleSolutions} isToggled={showTeacherContent} />}
       </div>
-      <div className="problem-panel">
+      <div className="problem-panels-container">
         {sections?.map((section) => {
           return (
-            <TabPanel key={`section-${section.type}`} data-focus-section={section.type}>
+            <TabPanel key={`section-${section.type}`} data-focus-section={section.type}
+                className={["react-tabs__tab-panel", "problem-panel-tab-panel"]}>
               <ProblemPanelComponent section={section} key={`section-${section.type}`} />
             </TabPanel>
           );


### PR DESCRIPTION
- multiple overflow-y:auto were taking effect because
2 divs had the class problem-panel
- the containment of the divs was not really being used to keep
the height 100% all of the way down
- the margin-top on the section was messing up the 100% height
calculation all the way up at the problem-panel-tab-panel

- [ ] Need to test problems without sub tabs, they might not have secion divs so then the position:relative might need to be moved up