### PR TITLE
186208247-revert-id-change

### DIFF
--- a/src/models/document/base-document-content.ts
+++ b/src/models/document/base-document-content.ts
@@ -20,7 +20,7 @@ import { logTileCopyEvent } from "../tiles/log/log-tile-copy-event";
 import { logTileDocumentEvent } from "../tiles/log/log-tile-document-event";
 import { getAppConfig } from "../tiles/tile-environment";
 import { LogEventName } from "../../lib/logger-types";
-import { safeJsonParse, typedId, uniqueId } from "../../utilities/js-utils";
+import { safeJsonParse, uniqueId } from "../../utilities/js-utils";
 import { defaultTitle, titleMatchesDefault } from "../../utilities/title-utils";
 import { SharedModel, SharedModelType } from "../shared/shared-model";
 import { kSectionHeaderHeight } from "./document-constants";
@@ -345,13 +345,17 @@ export const BaseDocumentContentModel = types
       self.importContextTileCounts = {};
     },
     getNextTileId(tileType: string) {
-      // It'd be nice to use a prefix here that indicated the type of the tile
-      // However this means we'd need a unique 4 char id for each tile
-      // The first 4 chars of most tiles are unique but DataFlow and DataCard
-      // are an exception. So to do that right we'd need this unique string
-      // to be registered by each tile type. That doesn't seem worth it for
-      // these kinds of ids.
-      return typedId("TILE");
+      if (!self.importContextTileCounts[tileType]) {
+        self.importContextTileCounts[tileType] = 1;
+      } else {
+        ++self.importContextTileCounts[tileType];
+      }
+      // FIXME: This doesn't generate unique ids.
+      // Many sections seem to be unnamed, so they never set the importContextCurrentSection.
+      // The result is tiles in different sections (including different investigations and problems)
+      // have the same id, and in turn share the same metadata.
+      const section = self.importContextCurrentSection || "document";
+      return `${section}_${tileType}_${self.importContextTileCounts[tileType]}`;
     },
     insertRow(row: TileRowModelType, index?: number) {
       self.rowMap.put(row);

--- a/src/models/document/document-content-tests/dc-general.test.ts
+++ b/src/models/document/document-content-tests/dc-general.test.ts
@@ -659,6 +659,7 @@ describe("DocumentContentModel", () => {
     const row = content.getRowByIndex(1);
     expect(row!.tileCount).toBe(1);
     const tileId = row!.getTileIdAtIndex(0);
+    expect(tileId).toBe("Foo_Text_1");
     const tile = tileId ? content.tileMap.get(tileId) : undefined;
     const tileContent = tile!.content;
     expect(tileContent.type).toBe("Text");


### PR DESCRIPTION
The id change broke comments on curriculum tiles.

With this id change, if a tile doesn't have an id then one was randomly assigned when it is loaded. There are several curriculum files that do not have ids on all of their tiles, so each time one of these was loaded the tile would get a different id. When a comment is made on a tile it is associated with this id. So comments on these id-less tiles would not match any tile when viewed on a new instance of CLUE.

With this reversion PR, the tile ids will again be set deterministically based on their type and index in the section. This means that comments will continue to match up with the tile in the curriculum. However this approach is fragile, if a new tile is inserted into the curriculum the indexes of tiles after it will change so their ids will change and then the comments will get messed up.  Additionally when the content is loaded the ids currently need to be unique across the whole unit not just the section so this can result in id conflicts.

Even with these downsides reverting seems like the right thing to do for now, and then we can look for better solutions later.

I can think of a few solutions, but each has up and downsides.

### Assign ids to all of the content
This way ids will not change at runtime.  New tiles added by authors using the authoring system already have unique ids.

Authors could still add tiles manually by editing the json and they might forget to add an id. To resolve this, we could add a check in GitHub based deployment of the content to make sure it has ids before it is deployed.

#### Downsides
Old comments on curriculum would be broken unless we also migrate these comments within Firestore.
The logs of making these comments would be broken unless we migrate the logs.
Doing these migrations won't be perfect since the actual tile ids might have changed when the curriculum was modified.  To be super safe we'd have to compare the date the tile was created with the content at this date. 

### Prevent id conflicts while loading the content
The id conflict that caused this problem to start with could be avoided by changing the runtime. I didn't realize this before. The conflict happened because we load the whole unit into one MST tree. When we actually use the sections of the unit they are in separate trees. So if we avoid loading the whole unit the id conflict wouldn't happen.

As long as authors only edit content in the authoring system, this might not break existing comments. This is because when the authoring system loads the content the deterministic id will be assigned. When they save the content these deterministic ids will be saved into the content. Even if they re-order the tiles the ids will remain how they were initially loaded so any comments will still point at the correct tile. If they add a new tile it will be given a random id.

We could migrate the authored content to explicitly assign these deterministic ids. This migration could identify cases of id conflicts which could still happen if content has been copied from one sections to another in the past. If we do this then we could add an id check in GitHub before the content is deployed. This would prevent any manual edits from breaking things.

#### Downsides
If we don't migrate the authored content and add the id check. We could still get id conflicts when authors manually edit the JSON.

### Only assign random ids at authoring time
We could just assign random ids in the authoring system. This way the deterministic ids would still be used at runtime for any tile that doesn't have an explicit id. So as long as the authored content doesn't change the comments should continue to match up.

#### Downsides
When an author edits a section that doesn't have explicit ids, random ids will be assigned to all tiles when it is saved. Now any comments that have been made on the old version of this section will no longer match up.