### PR TITLE
make Gripper 2.0 the default

### DIFF
--- a/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
@@ -390,7 +390,7 @@ context('Dataflow Tool Tile', function () {
       });
       it("verify live output types", () => {
         const dropdown = "liveOutputType";
-        const outputTypes = ["Gripper", "Gripper 2.0", "Humidifier", "Fan", "Heat Lamp"];
+        const outputTypes = ["Gripper 2.0", "Gripper", "Humidifier", "Fan", "Heat Lamp"];
         dataflowToolTile.getDropdown(nodeType, dropdown).click();
         dataflowToolTile.getDropdownOptions(nodeType, dropdown).should("have.length", 5);
         dataflowToolTile.getDropdownOptions(nodeType, dropdown).each(($tab, index, $typeList) => {

--- a/src/plugins/dataflow/model/utilities/node.ts
+++ b/src/plugins/dataflow/model/utilities/node.ts
@@ -349,17 +349,17 @@ export const NodeDemoOutputTypes = [
 
 export const NodeLiveOutputTypes = [
   {
+    name: "Gripper 2.0",
+    icon: GrabberIcon,
+    angleBase: 130,
+    sweep: 95
+  },
+  {
     name: "Grabber",
     icon: GrabberIcon,
     angleBase: 180,
     sweep: 60,
     displayName: "Gripper"
-  },
-  {
-    name: "Gripper 2.0",
-    icon: GrabberIcon,
-    angleBase: 130,
-    sweep: 95
   },
   {
     name: "Humidifier",


### PR DESCRIPTION
This makes the Gripper 2.0 the default first item in the menu for the live output node, as described in PT-186223127