### PR TITLE
prevent MST from validating ids in sections

### DIFF
--- a/src/models/curriculum/section.ts
+++ b/src/models/curriculum/section.ts
@@ -1,4 +1,4 @@
-import { IAnyStateTreeNode, types } from "mobx-state-tree";
+import { IAnyStateTreeNode, Instance, SnapshotIn, types } from "mobx-state-tree";
 import { parseSectionPath } from "../../../functions/src/shared";
 import { DocumentContentModel } from "../document/document-content";
 import { IAuthoredTileContent } from "../document/document-content-import-types";
@@ -113,7 +113,8 @@ export const SectionModel = types
       self.realParent = parent;
     }
   }));
-export type SectionModelType = typeof SectionModel.Type;
+export interface SectionModelType extends Instance<typeof SectionModel> {}
+export interface SectionModelSnapshot extends SnapshotIn<typeof SectionModel> {}
 
 export function findSectionIndex(sections: SectionModelType[], fullPath: string | undefined){
   if (fullPath !==undefined) {

--- a/src/models/mst.test.ts
+++ b/src/models/mst.test.ts
@@ -816,4 +816,17 @@ describe("mst", () => {
 
 
   });
+
+  test("frozen props can be anything", () => {
+    const TestObject = types
+      .model("TestObject", {
+        prop: types.frozen<any>()
+      });
+
+    expect(TestObject.create({prop: 1}).prop).toBe(1);
+    const simpleObj = {"hi": "bye"};
+    expect(TestObject.create({prop: simpleObj}).prop).toEqual(simpleObj);
+    const complexObj = {"hi": {"more": ["stuff", "in"], "here": 1}};
+    expect(TestObject.create({prop: complexObj}).prop).toEqual(complexObj);
+  });
 });


### PR DESCRIPTION
Before this change if a unit had content with duplicate ids across sections, the content would
crash CLUE. With this change the ids only need to be unique within the section itself.

This can be tested with an old version of the seeit unit. You can use this unit by passing this argument to CLUE:
`unit=https://models-resources.concord.org/clue-curriculum/version/seeit-duplicate-ids/seeit/content.json`

So this should work:
https://collaborative-learning.concord.org/branch/section-scoped-ids/?appMode=dev&unit=https://models-resources.concord.org/clue-curriculum/version/seeit-duplicate-ids/seeit/content.json
And this should fail:
https://collaborative-learning.concord.org/version/v4.7.0/?appMode=dev&unit=https://models-resources.concord.org/clue-curriculum/version/seeit-duplicate-ids/seeit/content.json

