### PR TITLE
Align icons in drawing tile Show/sort panel

### DIFF
--- a/src/plugins/drawing/components/drawing-tile.scss
+++ b/src/plugins/drawing/components/drawing-tile.scss
@@ -85,8 +85,8 @@
             align-items: baseline;
             list-style: none;
             margin: 1px 0;
+            border: none;
             padding: 0 5px;
-            display: flex;
 
             &:hover {
               background-color: $workspace-teal-light-6;
@@ -99,7 +99,8 @@
             &.dragging {
               box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.25);
               border: solid 1px #979797;
-              padding: 2px 4px;
+              margin: 0 0;
+              padding: 0 4px;
             }
 
             &.invisible {

--- a/src/plugins/drawing/components/drawing-tile.scss
+++ b/src/plugins/drawing/components/drawing-tile.scss
@@ -41,7 +41,7 @@
             color: #707070;
             margin: 10px 0 0 10px;
             transform-origin: 0 50%;
-            transform: rotate(90deg);  
+            transform: rotate(90deg);
           }
         }
 
@@ -74,7 +74,7 @@
 
       .body {
         overflow-y: scroll;
-        
+
         ul {
           margin: 0;
           padding: 0;
@@ -82,8 +82,10 @@
 
           li {
             display: flex;
+            align-items: baseline;
             list-style: none;
-            padding: 3px 5px;
+            margin: 1px 0;
+            padding: 0 5px;
             display: flex;
 
             &:hover {
@@ -223,7 +225,7 @@
       position: relative;
       // These are button elements so we have to disable default button styles
       // of border, padding, and display
-      border: 0;    
+      border: 0;
       padding: 0;
       display: block;
       user-select: none;
@@ -392,7 +394,7 @@
     &.one-row {
       height: 40px;
     }
-    
+
     &.vectors {
       left: 70px;
       height: 38px;


### PR DESCRIPTION
This is a (partial) fix for PT-186082444.  It just updates the CSS.

There are still 1-2 pixel differences between exactly where the different icons align vertically.  To fix this detail we would need to make a matching set of icon images for this context -- the current ones are scavenged from other places that used similar icons.  Not sure if it is worth doing that extra work.
