### PR TITLE
switch image map from MST to MobX

### DIFF
--- a/src/components/tiles/geometry/geometry-content.tsx
+++ b/src/components/tiles/geometry/geometry-content.tsx
@@ -40,7 +40,7 @@ import {
 } from "../../../models/tiles/geometry/jxg-vertex-angle";
 import { getAllLinkedPoints, injectGetTableLinkColorsFunction } from "../../../models/tiles/geometry/jxg-table-link";
 import { extractDragTileType, kDragTileContent, kDragTileId, dragTileSrcDocId } from "../tile-component";
-import { ImageMapEntryType, gImageMap } from "../../../models/image-map";
+import { gImageMap, ImageMapEntry } from "../../../models/image-map";
 import { linkedPointId } from "../../../models/tiles/table-link-types";
 import { ITileExportOptions } from "../../../models/tiles/tile-content-info";
 import { getParentWithTypeName } from "../../../utilities/mst-utils";
@@ -85,7 +85,7 @@ interface IState extends Mutable<SizeMeProps> {
   isEditingTitle?: boolean;
   imageContentUrl?: string;
   imageFilename?: string;
-  imageEntry?: ImageMapEntryType;
+  imageEntry?: ImageMapEntry;
   disableRotate: boolean;
   redoStack: string[][];
   selectedComment?: JXG.Text;
@@ -1015,7 +1015,7 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
     return this.handleDelete();
   };
 
-  private handleNewImage = (image: ImageMapEntryType) => {
+  private handleNewImage = (image: ImageMapEntry) => {
     if (this._isMounted) {
       const content = this.getContent();
       this.setState({ isLoading: false, imageEntry: image });
@@ -1180,7 +1180,7 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
     });
   };
 
-  private setBackgroundImage(image: ImageMapEntryType) {
+  private setBackgroundImage(image: ImageMapEntry) {
     const { board } = this.state;
     const contentUrl = image.contentUrl;
     if (!board || !this._isMounted || !contentUrl) return;

--- a/src/components/tiles/image/image-tile.tsx
+++ b/src/components/tiles/image/image-tile.tsx
@@ -12,7 +12,7 @@ import { ITileProps } from "../tile-component";
 import { BasicEditableTileTitle } from "../../../components/tiles/basic-editable-tile-title";
 import { IDocumentContext } from "../../../models/document/document-types";
 import { debouncedSelectTile } from "../../../models/stores/ui";
-import { gImageMap, ImageMapEntryType } from "../../../models/image-map";
+import { gImageMap, ImageMapEntry } from "../../../models/image-map";
 import { ImageContentModelType } from "../../../models/tiles/image/image-content";
 import { ITileExportOptions } from "../../../models/tiles/tile-content-info";
 import { hasSelectionModifier } from "../../../utilities/event-utils";
@@ -31,7 +31,7 @@ interface IState {
   imageContentUrl?: string;
   imageFilename?: string;
   documentContext?: IDocumentContext;
-  imageEntry?: ImageMapEntryType;
+  imageEntry?: ImageMapEntry;
   imageEltWidth?: number;
   imageEltHeight?: number;
   requestedHeight?: number;
@@ -206,7 +206,7 @@ export default class ImageToolComponent extends BaseComponent<IProps, IState> {
     });
   };
 
-  private handleNewImage = (image: ImageMapEntryType) => {
+  private handleNewImage = (image: ImageMapEntry) => {
     if (this._isMounted) {
       const content = this.getContent();
       this.setState({ isLoading: false, imageEntry: image });

--- a/src/models/image-map.test.ts
+++ b/src/models/image-map.test.ts
@@ -1,24 +1,17 @@
-import { autorun, runInAction, when } from "mobx";
-import { applySnapshot, destroy, getSnapshot, protect, unprotect } from "mobx-state-tree";
+import { autorun, flowResult, runInAction, when } from "mobx";
 import { externalUrlImagesHandler, localAssetsImagesHandler,
         firebaseRealTimeDBImagesHandler, firebaseStorageImagesHandler,
-        IImageHandler, ImageMapEntry, ImageMapModel, ImageMapModelType, 
-        EntryStatus, IImageHandlerStoreOptions, 
-        IImageHandlerStoreResult, ImageMapEntryType, ImageMapEntrySnapshot} from "./image-map";
+        IImageHandler, ImageMapEntry, ImageMap,
+        EntryStatus, IImageHandlerStoreOptions,
+        IImageHandlerStoreResult,
+        ImageMapEntrySnapshot,
+        createImageMapEntry} from "./image-map";
 import { parseFirebaseImageUrl } from "../../functions/src/shared-utils";
 import { DB } from "../lib/db";
 import * as ImageUtils from "../utilities/image-utils";
 import placeholderImage from "../assets/image_placeholder.png";
 
-let sImageMap: ImageMapModelType;
-
-function unsafeUpdate(func: () => void) {
-  runInAction(() => {
-    unprotect(sImageMap);
-    func();
-    protect(sImageMap);
-  });
-}
+let sImageMap: ImageMap;
 
 describe("ImageMap", () => {
   const kCurriculumUnitBaseUrl = "https://example.com/clue-curriculum/branch/main/sas";
@@ -49,12 +42,11 @@ describe("ImageMap", () => {
     jest.spyOn(ImageUtils, "getImageDimensions")
         .mockImplementation(() =>
           Promise.resolve({ src: placeholderImage, width: 200, height: 150 }));
-    if (sImageMap) { destroy(sImageMap); }
-    sImageMap = ImageMapModel.create();
+    sImageMap = new ImageMap();
     sImageMap.setUnitUrl(kCurriculumUnitUrl);
     sImageMap.setUnitCodeMap({"stretching-and-shrinking": "sas"});
   });
-          
+
   function createMockDB(overrides?: Record<string, any>) {
     return {
       stores: { user: { id: "user", classHash: "classHash" }},
@@ -335,7 +327,7 @@ describe("ImageMap", () => {
                 expect(consoleSpy).toBeCalledTimes(1);
               });
     });
-  
+
     it("can retrieve placeholder image from cache", () => {
       expect(sImageMap.hasImage(placeholderImage));
       expect(sImageMap.getCachedImage(placeholderImage)).toEqual({
@@ -352,55 +344,55 @@ describe("ImageMap", () => {
                 expect(image.height).toBe(150);
               });
     });
-    
+
     it("can handle duplicate renders when image map is slow to compute the dimensions", async () => {
       // Expose the image dimensions resolve function so we can call it when we want to
       let imageDimensionResolve: (entrySnapshot: ImageUtils.IImageDimensions) => void;
-      const imageDimensionPromise = 
-        new Promise<ImageUtils.IImageDimensions>((resolve) => imageDimensionResolve = resolve);    
+      const imageDimensionPromise =
+        new Promise<ImageUtils.IImageDimensions>((resolve) => imageDimensionResolve = resolve);
       const dimSpy = jest.spyOn(ImageUtils, "getImageDimensions")
                           .mockImplementation(() => imageDimensionPromise);
-      
+
       expect.assertions(10);
-  
+
       // After this first call we should expect that the getImage promise will not be
       // resolved until we call imageDimensionResolve
       const firstGetImagePromise = sImageMap.getImage(kLocalImageUrl);
       const secondGetImagePromise = sImageMap.getImage(kLocalImageUrl);
-  
+
       let firstGetImagePromiseResolved = false;
       let secondGetImagePromiseResolved = false;
       firstGetImagePromise.then(() => firstGetImagePromiseResolved = true);
       secondGetImagePromise.then(() => secondGetImagePromiseResolved = true);
-  
+
       // Wait for there to be a cached entry for this url using MobX's wait
       // This will happen after the image is stored, but before the dimensions
       // are requested
       await when(() => !!sImageMap.getCachedImage(kLocalImageUrl));
-      
+
       const imageEntry = sImageMap.getCachedImage(kLocalImageUrl);
       expect(imageEntry?.status).toBe(EntryStatus.PendingDimensions);
-  
+
       expect(dimSpy).toHaveBeenCalled();
       // We wait for 20ms just to give the javascript engine time to resolve
-      // the promises. 
+      // the promises.
       // Just because the entry was created doesn't mean that the javascript
-      // engine had enough time to run the promises (if it was going to 
-      // do so).  It depends if the observer for the `when` is run before 
+      // engine had enough time to run the promises (if it was going to
+      // do so).  It depends if the observer for the `when` is run before
       // the `then` attached to the promises above.
       await new Promise((resolve) => setTimeout(resolve, 20));
       expect(firstGetImagePromiseResolved).toBe(false);
       expect(secondGetImagePromiseResolved).toBe(false);
-  
+
       imageDimensionResolve!({ src: placeholderImage, width: 200, height: 150 });
-  
+
       const image = await firstGetImagePromise;
       expect(image.contentUrl).toBe(kLocalImageUrl);
       expect(image.displayUrl).toBe(`${kLocalImageUrl}`);
       expect(image.width).toBe(200);
       expect(image.height).toBe(150);
       expect(image.status).toBe(EntryStatus.Ready);
-  
+
       const image2 = await secondGetImagePromise;
       expect(image2).toBe(image);
     });
@@ -417,7 +409,7 @@ describe("ImageMap", () => {
     it("handles when a previous getImage failed due to a getImageDimensions error", async () => {
       expect.assertions(3);
 
-      // We reset the mocks because when the ImageMap is created it will request the 
+      // We reset the mocks because when the ImageMap is created it will request the
       // dimensions of the placeholder image
       jest.resetAllMocks();
       jest.spyOn(ImageUtils, "getImageDimensions").mockImplementation(() =>
@@ -427,7 +419,7 @@ describe("ImageMap", () => {
       const returnedEntry = await sImageMap.getImage(kLocalImageUrl);
       expect(returnedEntry?.status).toBe(EntryStatus.Error);
 
-      // A second call should try again and succeed   
+      // A second call should try again and succeed
       jest.spyOn(ImageUtils, "getImageDimensions").mockImplementation(() =>
         Promise.resolve({ src: placeholderImage, width: 200, height: 150 })
       );
@@ -440,7 +432,7 @@ describe("ImageMap", () => {
     it("handles when a previous getImage that converts the url failed due to a getImageDimensions error", async () => {
       expect.assertions(6);
 
-      // We reset the mocks because when the ImageMap is created it will request the 
+      // We reset the mocks because when the ImageMap is created it will request the
       // dimensions of the placeholder image
       jest.resetAllMocks();
       jest.spyOn(ImageUtils, "getImageDimensions").mockImplementation(() =>
@@ -450,8 +442,8 @@ describe("ImageMap", () => {
       const mockHandler: any = {
         async store(url: string, options?: IImageHandlerStoreOptions): Promise<IImageHandlerStoreResult> {
           return {
-            contentUrl: "convertedUrl", 
-            displayUrl: "convertedUrl", 
+            contentUrl: "convertedUrl",
+            displayUrl: "convertedUrl",
             success: true};
         }
       };
@@ -459,8 +451,8 @@ describe("ImageMap", () => {
 
       const returnedEntry = await sImageMap.getImage(kLocalImageUrl);
       const expectedEntry = {
-        contentUrl: "convertedUrl", 
-        displayUrl: "convertedUrl", 
+        contentUrl: "convertedUrl",
+        displayUrl: "convertedUrl",
         status: EntryStatus.Error,
         retries: 0
       };
@@ -468,21 +460,21 @@ describe("ImageMap", () => {
       expect(sImageMap.getCachedImage(kLocalImageUrl)).toEqual(expectedEntry);
       expect(sImageMap.getCachedImage("convertedUrl")).toEqual(expectedEntry);
 
-      // A second call should try again and succeed   
+      // A second call should try again and succeed
       jest.spyOn(ImageUtils, "getImageDimensions").mockImplementation(() =>
         Promise.resolve({ src: placeholderImage, width: 200, height: 150 })
       );
       const getImagePromise2 = sImageMap.getImage(kLocalImageUrl);
-      
-      // TODO: it'd be good to check the intermediate state to see that the 
+
+      // TODO: it'd be good to check the intermediate state to see that the
       // main entry has a `PendingStorage` status. And then when addImage is called
       // the main entry and the copied entry have a `PendingDimensions` state
       // Doing this would require setting up a delayed getDimensions like above
 
       const returnedEntry2 = await getImagePromise2;
       const expectedEntry2 = {
-        contentUrl: "convertedUrl", 
-        displayUrl: "convertedUrl", 
+        contentUrl: "convertedUrl",
+        displayUrl: "convertedUrl",
         width: 200,
         height: 150,
         status: EntryStatus.Ready,
@@ -498,9 +490,10 @@ describe("ImageMap", () => {
       // Directly add an initial entry
       const initialEntry = {
         displayUrl: "bogus",
+        retries: 0,
         status: EntryStatus.PendingStorage
       };
-      unsafeUpdate(() => sImageMap.images.set(kLocalImageUrl, initialEntry));
+      sImageMap._addOrUpdateEntry(kLocalImageUrl, initialEntry);
 
       const consoleSpy = jest.spyOn(global.console, "warn").mockImplementation();
       const getImagePromise = sImageMap.getImage(kLocalImageUrl);
@@ -526,7 +519,7 @@ describe("ImageMap", () => {
       const mockHandler: any = {
         async store(url: string, options?: IImageHandlerStoreOptions): Promise<IImageHandlerStoreResult> {
           return {
-            displayUrl: placeholderImage, 
+            displayUrl: placeholderImage,
             success: false};
         }
       };
@@ -535,8 +528,8 @@ describe("ImageMap", () => {
 
       let countOfGetImage = 0;
       let countOfAutorun = 0;
-      let imageEntry: ImageMapEntryType | undefined;
-      let displayUrl: string | undefined; 
+      let imageEntry: ImageMapEntry | undefined;
+      let displayUrl: string | undefined;
       let lastStatus: EntryStatus | undefined;
       const disposer = autorun(() => {
         // This is a pattern that an observing component could use to display an
@@ -550,10 +543,10 @@ describe("ImageMap", () => {
           imageEntry = sImageMap.getCachedImage(mockUrl);
         }
         // This displayURL is what the the observing component would use to
-        // render the image.  
+        // render the image.
         displayUrl = imageEntry?.displayUrl;
-        
-        // **This line is important.** 
+
+        // **This line is important.**
         // Without this line, there will be no looping. This line tells MobX the
         // autorun should be re-run whenever the status changes. The status is
         // being checked above, but only if imageEntry already exists. So the
@@ -567,7 +560,7 @@ describe("ImageMap", () => {
           // to the image entry, this is why the limit is 15 instead of something lower
           disposer();
         }
-      });  
+      });
 
       return new Promise(resolve => setTimeout(resolve, 500))
       .then(() => {
@@ -591,13 +584,15 @@ describe("ImageMap", () => {
 
   describe("getImageEntry", () => {
     it("returns undefined when no URL is passed to it", () => {
+      const consoleSpy = jest.spyOn(global.console, "warn").mockImplementation();
       expect(sImageMap.getImageEntry("")).toBeUndefined();
+      expect(consoleSpy).toBeCalled();
     });
     it("limits the number times it retries entries that have failed", () => {
       const mockHandler: any = {
         async store(url: string, options?: IImageHandlerStoreOptions): Promise<IImageHandlerStoreResult> {
           return {
-            displayUrl: placeholderImage, 
+            displayUrl: placeholderImage,
             success: false};
         }
       };
@@ -605,8 +600,8 @@ describe("ImageMap", () => {
       const mockUrl = "fake-url-for-retry-test";
 
       let countOfAutorun = 0;
-      let imageEntry: ImageMapEntryType | undefined;
-      let displayUrl: string | undefined; 
+      let imageEntry: ImageMapEntry | undefined;
+      let displayUrl: string | undefined;
       let lastStatus: EntryStatus | undefined;
       const imageEntries: (ImageMapEntrySnapshot | null)[] = [];
       const disposer = autorun(() => {
@@ -617,15 +612,15 @@ describe("ImageMap", () => {
 
         // The imageEntry is saved before and after the call to illustrate what is
         // changing on each time through the autorun loop
-        imageEntries.push(imageEntry ? getSnapshot(imageEntry) : null);
+        imageEntries.push(imageEntry ? imageEntry.toJSON() : null);
         imageEntry = sImageMap.getImageEntry(mockUrl);
-        imageEntries.push(imageEntry ? getSnapshot(imageEntry) : null);
+        imageEntries.push(imageEntry ? imageEntry.toJSON() : null);
 
         // This displayURL is what the the observing component would use to
-        // render the image.  
+        // render the image.
         displayUrl = imageEntry?.displayUrl;
-        
-        // **This line is important.** 
+
+        // **This line is important.**
         // Without this line, there will be no looping. This line tells MobX the
         // autorun should be re-run whenever the status changes. The status is
         // being checked above, but only if imageEntry already exists. So the
@@ -639,7 +634,7 @@ describe("ImageMap", () => {
           // to the image entry, this is why the limit is 15 instead of something lower
           disposer();
         }
-      });  
+      });
 
       return new Promise(resolve => setTimeout(resolve, 500))
       .then(() => {
@@ -678,13 +673,14 @@ describe("ImageMap", () => {
   });
 
   it("can update an image entry with syncContentUrl", () => {
-    const kLocalImageUrl2 = kLocalImageUrl + "2";    
-    const imageEntry2 = ImageMapEntry.create({
+    const kLocalImageUrl2 = kLocalImageUrl + "2";
+    const imageEntry2 = createImageMapEntry({
                           contentUrl: kLocalImageUrl2,
                           displayUrl: kLocalImageUrl2,
-                          status: EntryStatus.Ready
+                          status: EntryStatus.Ready,
+                          retries: 0
                         });
-    
+
     // It should add a new entry at the contentUrl
     // It doesn't create or modify the entry at the original url
     sImageMap._syncContentUrl(kLocalImageUrl, imageEntry2);
@@ -692,17 +688,18 @@ describe("ImageMap", () => {
     const altEntry = sImageMap.getCachedImage(kLocalImageUrl2);
     expect(altEntry).toEqual(imageEntry2);
     // We never added an entry for the original url so it remains undefined
-    expect(sImageMap.getCachedImage(kLocalImageUrl)).toBeUndefined();                   
+    expect(sImageMap.getCachedImage(kLocalImageUrl)).toBeUndefined();
 
     // syncs should update existing entries in place if they are in an error
     // status
-    unsafeUpdate(() => altEntry!.status = EntryStatus.Error);
-    const imageEntry2mod = ImageMapEntry.create({
+    runInAction(() => altEntry!.status = EntryStatus.Error);
+    const imageEntry2mod = createImageMapEntry({
       contentUrl: kLocalImageUrl2,
       displayUrl: kLocalImageUrl2,
       width: 20,
       height: 20,
-      status: EntryStatus.Ready
+      status: EntryStatus.Ready,
+      retries: 0
     });
     sImageMap._syncContentUrl(kLocalImageUrl, imageEntry2mod);
     expect(altEntry).toEqual(imageEntry2mod);
@@ -725,34 +722,35 @@ describe("ImageMap", () => {
   describe("_addImage", () => {
     it("can update an image entry", () => {
       const kLocalImageUrl2 = kLocalImageUrl + "2";
-  
+
       // Directly add an initial entry
       const initialEntry = {
         contentUrl: kLocalImageUrl,
         displayUrl: kLocalImageUrl,
         width: 20,
         height: 20,
-        status: EntryStatus.Ready
+        status: EntryStatus.Ready,
+        retries: 0
       };
-      unsafeUpdate(() => sImageMap.images.set(kLocalImageUrl, initialEntry));
-  
+      sImageMap._addOrUpdateEntry(kLocalImageUrl, initialEntry);
+
       // It synchronously updates the entry and changes the status to `PendingDimensions`.
       const changedStoreResult = {
         contentUrl: kLocalImageUrl2,
         displayUrl: kLocalImageUrl2,
         success: true
       };
-      const addImagePromise = sImageMap._addImage(kLocalImageUrl, changedStoreResult);
-  
+      const addImagePromise = flowResult(sImageMap._addImage(kLocalImageUrl, changedStoreResult));
+
       expect(sImageMap.getCachedImage(kLocalImageUrl)).toEqual({
         contentUrl: kLocalImageUrl2,
         displayUrl: kLocalImageUrl2,
         status: EntryStatus.PendingDimensions,
         retries: 0
       });
-  
+
       // Then asynchronously after the getImageDimensions call returns,
-      // the status will be set to Ready, and the width and height will be set 
+      // the status will be set to Ready, and the width and height will be set
       // to the values returned by getImageDimensions
       return addImagePromise.then(() => {
         expect(sImageMap.getCachedImage(kLocalImageUrl)).toEqual({
@@ -765,11 +763,11 @@ describe("ImageMap", () => {
         });
       });
     });
-  
+
     it("handles entries with the error status", async () => {
       expect.assertions(7);
 
-      // We reset the mocks because when the ImageMap is created it will request the 
+      // We reset the mocks because when the ImageMap is created it will request the
       // dimensions of the placeholder image
       jest.resetAllMocks();
       const dimSpy = jest.spyOn(ImageUtils, "getImageDimensions");
@@ -786,21 +784,22 @@ describe("ImageMap", () => {
         status: EntryStatus.Error,
         retries: 0
       };
-      
+
       // It synchronously adds the entry to the map
       const entryInMap = sImageMap.getCachedImage(kLocalImageUrl);
       expect(entryInMap).toEqual(expectedEntry);
-      
+
       const entryReturned = await addImagePromise;
       // It returns the entry, without computing the dimensions
       expect(entryReturned).toEqual(expectedEntry);
       expect(dimSpy).not.toBeCalled();
 
       function resetEntryInMap(status: EntryStatus) {
-        applySnapshot(entryInMap!, {
+        Object.assign(entryInMap!, {
           status,
           contentUrl: "bogus",
-          displayUrl: "radical"
+          displayUrl: "radical",
+          retries: 0
         });
       }
 
@@ -822,44 +821,21 @@ describe("ImageMap", () => {
       expect(entryInMap).toEqual(expectedEntry);
     });
 
-    it("handles when there is no displayUrl set", async () => {
-      expect.assertions(6);
-      const consoleSpy = jest.spyOn(global.console, "error").mockImplementation();
-      const returnedEntry = await sImageMap._addImage(kLocalImageUrl, {
-        contentUrl: kLocalImageUrl,
-        success: false
-      });
-      expect(returnedEntry.status).toBe(EntryStatus.Error);
-      expect(sImageMap.getCachedImage(kLocalImageUrl)).toBe(returnedEntry);
-      expect(consoleSpy).toBeCalledTimes(1);
-  
-      // Even error entries are expected to have an displayUrl
-      jest.resetAllMocks();
-      const otherUrl = "fake-url";
-      const returnedEntry2 = await sImageMap._addImage(otherUrl, {
-        contentUrl: otherUrl,
-        success: false
-      });
-      expect(returnedEntry2.status).toBe(EntryStatus.Error);
-      expect(sImageMap.getCachedImage(otherUrl)).toBe(returnedEntry2);
-      expect(consoleSpy).toBeCalledTimes(1);
-    });
-    
     it("handles an error in getDimensions", async () => {
       expect.assertions(3);
 
-      // We reset the mocks because when the ImageMap is created it will request the 
+      // We reset the mocks because when the ImageMap is created it will request the
       // dimensions of the placeholder image
       jest.resetAllMocks();
       const dimSpy = jest.spyOn(ImageUtils, "getImageDimensions").mockImplementation(() =>
         Promise.reject(new Error("mock error"))
       );
 
-      const returnedEntry = await sImageMap._addImage(kLocalImageUrl, {
+      const returnedEntry = await flowResult(sImageMap._addImage(kLocalImageUrl, {
         displayUrl: kLocalImageUrl,
         contentUrl: kLocalImageUrl,
         success: true
-      });
+      }));
       expect(returnedEntry.status).toBe(EntryStatus.Error);
       expect(sImageMap.getCachedImage(kLocalImageUrl)).toBe(returnedEntry);
       expect(dimSpy).toBeCalled();

--- a/src/models/image-map.test.ts
+++ b/src/models/image-map.test.ts
@@ -1,15 +1,15 @@
 import { autorun, flowResult, runInAction, when } from "mobx";
-import { externalUrlImagesHandler, localAssetsImagesHandler,
-        firebaseRealTimeDBImagesHandler, firebaseStorageImagesHandler,
-        IImageHandler, ImageMapEntry, ImageMap,
-        EntryStatus, IImageHandlerStoreOptions,
-        IImageHandlerStoreResult,
-        ImageMapEntrySnapshot,
-        createImageMapEntry} from "./image-map";
+
 import { parseFirebaseImageUrl } from "../../functions/src/shared-utils";
 import { DB } from "../lib/db";
 import * as ImageUtils from "../utilities/image-utils";
 import placeholderImage from "../assets/image_placeholder.png";
+import { externalUrlImagesHandler, localAssetsImagesHandler,
+  firebaseRealTimeDBImagesHandler, firebaseStorageImagesHandler,
+  IImageHandler, ImageMapEntry, ImageMap,
+  EntryStatus, IImageHandlerStoreOptions,
+  IImageHandlerStoreResult,
+  ImageMapEntrySnapshot} from "./image-map";
 
 let sImageMap: ImageMap;
 
@@ -674,11 +674,10 @@ describe("ImageMap", () => {
 
   it("can update an image entry with syncContentUrl", () => {
     const kLocalImageUrl2 = kLocalImageUrl + "2";
-    const imageEntry2 = createImageMapEntry({
+    const imageEntry2 = ImageMapEntry.create({
                           contentUrl: kLocalImageUrl2,
                           displayUrl: kLocalImageUrl2,
                           status: EntryStatus.Ready,
-                          retries: 0
                         });
 
     // It should add a new entry at the contentUrl
@@ -693,13 +692,12 @@ describe("ImageMap", () => {
     // syncs should update existing entries in place if they are in an error
     // status
     runInAction(() => altEntry!.status = EntryStatus.Error);
-    const imageEntry2mod = createImageMapEntry({
+    const imageEntry2mod = ImageMapEntry.create({
       contentUrl: kLocalImageUrl2,
       displayUrl: kLocalImageUrl2,
       width: 20,
       height: 20,
       status: EntryStatus.Ready,
-      retries: 0
     });
     sImageMap._syncContentUrl(kLocalImageUrl, imageEntry2mod);
     expect(altEntry).toEqual(imageEntry2mod);

--- a/src/models/image-map.ts
+++ b/src/models/image-map.ts
@@ -186,7 +186,7 @@ export class ImageMap {
       return;
     }
 
-    const entrySnapshot = serializeEntry(entry);
+    const entrySnapshot = entry.toJSON();
     const existingEntry = this.images.get(entry.contentUrl);
     if (!existingEntry || existingEntry.status === EntryStatus.Error) {
       if (entry.status === EntryStatus.Ready) {

--- a/src/plugins/drawing/components/drawing-layer-legacy.test.tsx
+++ b/src/plugins/drawing/components/drawing-layer-legacy.test.tsx
@@ -10,7 +10,7 @@ import { RectangleObjectSnapshot } from "../objects/rectangle";
 import { EllipseObjectSnapshot } from "../objects/ellipse";
 import { ImageObjectSnapshot } from "../objects/image";
 import { DrawingMigrator } from "../model/drawing-migrator";
-import { EntryStatus, gImageMap, ImageMapEntry } from "../../../models/image-map";
+import { createImageMapEntry, EntryStatus, gImageMap } from "../../../models/image-map";
 
 // The drawing tile needs to be registered so the TileModel.create
 // knows it is a supported tile type
@@ -188,10 +188,11 @@ describe("Drawing Layer Components", () => {
       // an async error will happen when the image map fails to fetch the fake
       // URL. The following mocking short circuits the async behavior and just
       // returns a constant image map entry for every lookup.
-      const imageMapEntry = ImageMapEntry.create({
+      const imageMapEntry = createImageMapEntry({
         contentUrl: mockImageUrl,
         displayUrl: mockImageUrl,
-        status: EntryStatus.Ready
+        status: EntryStatus.Ready,
+        retries: 0
       });
       jest.spyOn(gImageMap, "getImageEntry").mockImplementation(() => imageMapEntry);
     });

--- a/src/plugins/drawing/components/drawing-layer-legacy.test.tsx
+++ b/src/plugins/drawing/components/drawing-layer-legacy.test.tsx
@@ -10,7 +10,7 @@ import { RectangleObjectSnapshot } from "../objects/rectangle";
 import { EllipseObjectSnapshot } from "../objects/ellipse";
 import { ImageObjectSnapshot } from "../objects/image";
 import { DrawingMigrator } from "../model/drawing-migrator";
-import { createImageMapEntry, EntryStatus, gImageMap } from "../../../models/image-map";
+import { EntryStatus, gImageMap, ImageMapEntry } from "../../../models/image-map";
 
 // The drawing tile needs to be registered so the TileModel.create
 // knows it is a supported tile type
@@ -188,11 +188,10 @@ describe("Drawing Layer Components", () => {
       // an async error will happen when the image map fails to fetch the fake
       // URL. The following mocking short circuits the async behavior and just
       // returns a constant image map entry for every lookup.
-      const imageMapEntry = createImageMapEntry({
+      const imageMapEntry = ImageMapEntry.create({
         contentUrl: mockImageUrl,
         displayUrl: mockImageUrl,
-        status: EntryStatus.Ready,
-        retries: 0
+        status: EntryStatus.Ready
       });
       jest.spyOn(gImageMap, "getImageEntry").mockImplementation(() => imageMapEntry);
     });

--- a/src/utilities/clipboard-utils.test.ts
+++ b/src/utilities/clipboard-utils.test.ts
@@ -1,4 +1,4 @@
-import { EntryStatus, gImageMap } from "../models/image-map";
+import { createImageMapEntry, EntryStatus, gImageMap } from "../models/image-map";
 import { getClipboardContent, pasteClipboardImage } from "./clipboard-utils";
 
 const mockBlob = {
@@ -60,7 +60,7 @@ describe("pasteClipboardImage", () => {
     type: "image/png",
     webkitRelativePath: ""
   };
-  const mockImageResponse = {
+  const mockImageResponse = createImageMapEntry({
     contentUrl: "test/test.png",
     displayUrl: "https://example.com/test/test.png",
     filename: "test.png",
@@ -68,7 +68,7 @@ describe("pasteClipboardImage", () => {
     retries: 0,
     status: EntryStatus.Ready,
     width: 100
-  };
+  });
 
   afterEach(() => {
     jest.resetAllMocks();

--- a/src/utilities/clipboard-utils.test.ts
+++ b/src/utilities/clipboard-utils.test.ts
@@ -1,4 +1,4 @@
-import { createImageMapEntry, EntryStatus, gImageMap } from "../models/image-map";
+import { EntryStatus, gImageMap, ImageMapEntry } from "../models/image-map";
 import { getClipboardContent, pasteClipboardImage } from "./clipboard-utils";
 
 const mockBlob = {
@@ -60,7 +60,7 @@ describe("pasteClipboardImage", () => {
     type: "image/png",
     webkitRelativePath: ""
   };
-  const mockImageResponse = createImageMapEntry({
+  const mockImageResponse = ImageMapEntry.create({
     contentUrl: "test/test.png",
     displayUrl: "https://example.com/test/test.png",
     filename: "test.png",

--- a/src/utilities/clipboard-utils.ts
+++ b/src/utilities/clipboard-utils.ts
@@ -1,7 +1,7 @@
-import { gImageMap, ImageMapEntryType } from "../models/image-map";
+import { gImageMap, ImageMapEntry } from "../models/image-map";
 
 interface IOnCompleteParams {
-  image: ImageMapEntryType;
+  image: ImageMapEntry;
 }
 interface IClipboardContents {
   image: File | null;

--- a/src/utilities/image-utils.ts
+++ b/src/utilities/image-utils.ts
@@ -17,7 +17,7 @@ export interface IImageDimensions {
 export interface ISimpleImage {
   imageKey?: string;
   imageUrl: string;
-  imageData?: string;
+  imageData: string;
 }
 
 const ccImageId = "ccimg://";
@@ -34,7 +34,8 @@ export function isPlaceholderImage(url?: string) {
 
 function kUploadImage(db: DB, image: ImageModelType): Promise<ISimpleImage> {
   const img: ISimpleImage = {
-    imageUrl: placeholderImage
+    imageUrl: placeholderImage,
+    imageData: placeholderImage
   };
 
   return new Promise((resolve, reject) =>


### PR DESCRIPTION
Switch the image map to a MobX class instead of an MST model.

This change is a for few reasons:
- it will make it safer to use the image map within our tile models. There is a known issue with MST where action tracking fails when an action from one tree runs an action in another tree which then triggers an action back in the first tree. This issue doesn't happen when MobX objects are used.
- it hopefully makes the code a little easier to read without all `action` and `view` sections.
- it also makes it possible to mark members as private. Unfortunately this can't be used much since the tests need access to these members. 

When looking at image-map.ts it is useful to hide whitespace changes.  There are still lots of changes, but they match up better.

The image map has a mix of flow and async actions. In MobX the use of flow makes the implementation code a little nicer (in theory) but doesn't have any other benefits. In MST flows actually group the recorded actions together so they are more important to use. In MobX when you use a flow you have to use `flowResult` with typescript in order for the result. Because of this it was better to use async actions since they are easier for users of the ImageMap to deal with.

Also MobX's `makeAutoObservable` didn't seem to correctly identify the various actions. So there were errors about modifying state outside of an action. To fix this, I switched to `makeObservable` with explicit annotation.

MST's snapshots were used a lot with the ImageMapEntry models. So I added `toJSON`, `update`, and `create` methods to support a similar behavior.

In the `IImageHandlerStoreResult` the `displayUrl` is now required. This eliminates the need for some edge case code. 

The original motivation for all of this started with a plan to update the ImageUploadButton so it could be used in multiple places. This currently uses callbacks that run in the components to track the uploading the file. The components track this via React state. This tracking is error prone, and duplicates the existing status field in the ImageMapEntries. So instead of tracking the loading status in react state. The component could keep track of an ImageMapEntry that is created when the file starts uploading. But keeping that entry in the component state still requires handling callbacks and edge cases which should disappear if the image map entry was managed by the tile model itself. And this is why it is useful to make the image map a MobX class so that it can be safely used in these tile models.  Implementing all of those changes at once was becoming a large PR so this part of the MobX class is split out.  And as described above, I think the change has other benefits too.

PT-186143035