### PR TITLE
WIP: Refactor image system

### DIFF
--- a/src/components/tiles/image/image-component.tsx
+++ b/src/components/tiles/image/image-component.tsx
@@ -1,21 +1,13 @@
 import { observer } from "mobx-react";
 import React from "react";
-import { IDocumentContext } from "../../../models/document/document-types";
-import { ImageContentModelType } from "../../../models/tiles/image/image-content";
-import { useImageContentUrl } from "./use-image-content-url";
 
 interface IProps {
-  content: ImageContentModelType;
   style: React.CSSProperties;
   onMouseDown: (e: React.MouseEvent<HTMLDivElement>) => void;
-  onUrlChange: (url: string, filename?: string, context?: IDocumentContext) => void;
 }
 
 const _ImageComponent =
-  React.forwardRef<HTMLDivElement, IProps>(({ content, style, onMouseDown, onUrlChange }, forwardedRef) => {
-
-    // calls onUrlChange when image url changes in content
-    useImageContentUrl(content, onUrlChange);
+  React.forwardRef<HTMLDivElement, IProps>(({ style, onMouseDown }, forwardedRef) => {
 
     return (
       <div className="image-frame">

--- a/src/components/tiles/image/image-tile.test.tsx
+++ b/src/components/tiles/image/image-tile.test.tsx
@@ -1,26 +1,157 @@
+// mock the measureText function
+const mockMeasureText = jest.fn((text: string, fontSize: number) => {
+  // assume every character is half the width of the font's height
+  const width = text.length * fontSize / 2;
+  return { width };
+});
+
+// mock the 2D canvas context
+class MockCanvas2DContext {
+  font: string;
+
+  get fontSize() {
+    const match = /(\d+)/.exec(this.font || "");
+    const sizeStr = match?.[1];
+    return sizeStr ? +sizeStr : 16;
+  }
+
+  measureText(text: string) {
+    return mockMeasureText(text, this.fontSize);
+  }
+}
+
+// mock document.createElement to return a "canvas" element that returns our mock 2D context
+const origCreateElement = document.createElement;
+const createElementSpy = jest.spyOn(document, "createElement")
+    .mockImplementation((tagName: string, options?: any) => {
+  // console.log("mockCreateElement", "tag:", tagName);
+  return tagName === "canvas"
+          ? { getContext: () => new MockCanvas2DContext() } as any as HTMLCanvasElement
+          : origCreateElement.call(document, tagName, options);
+});
+
+
 import React from "react";
+import { Provider } from "mobx-react";
 import { render } from "@testing-library/react";
-import { ImageComponent } from "./image-component";
 import { ImageContentModel } from "../../../models/tiles/image/image-content";
+import { TileModel } from "../../../models/tiles/tile-model";
+import { specStores } from "../../../models/stores/spec-stores";
+import { EntryStatus, gImageMap } from "../../../models/image-map";
+import { ITileApi } from "../tile-api";
+import ImageToolComponent from "./image-tile";
+
+import "../../../models/tiles/image/image-registration";
+import { runInAction } from "mobx";
 
 describe("Image Component", () => {
-  const handleMouseDown = jest.fn();
-  const handleUrlChange = jest.fn();
+  const mockImageUrl = "my/image/url";
+  const updatedUrl = "new-image-url";
 
-  it("calls onUrlChange when content changes", () => {
-    const imageContent = ImageContentModel.create();
-    const imageStyle = {background: "url(${imageContent.url})", width: 10, height: 10};
-    render(
-      <ImageComponent
-        ref={null}
-        content={imageContent}
-        style={imageStyle}
-        onMouseDown={handleMouseDown}
-        onUrlChange={handleUrlChange}
-      />
-    );
-     expect(handleUrlChange).toHaveBeenCalledTimes(0);
-     imageContent.setUrl("newImage.jpg");
-     expect(handleUrlChange).toHaveBeenCalledTimes(1);
+  const content = ImageContentModel.create({url: mockImageUrl});
+  const model = TileModel.create({content});
+
+  const stores = specStores();
+
+  const defaultProps = {
+    tileElt: null,
+    context: "",
+    docId: "",
+    documentContent: null,
+    isUserResizable: true,
+    onResizeRow: (e: React.DragEvent<HTMLDivElement>): void => {
+      throw new Error("Function not implemented.");
+    },
+    onSetCanAcceptDrop: (tileId?: string): void => {
+      throw new Error("Function not implemented.");
+    },
+    onRequestUniqueTitle: (tileId: string): string | undefined => {
+      throw new Error("Function not implemented.");
+    },
+    onRequestRowHeight: (tileId: string, height?: number, deltaHeight?: number): void => {
+      throw new Error("Function not implemented.");
+    },
+    onRegisterTileApi: (tileApi: ITileApi, facet?: string): void => {
+      // throw new Error("Function not implemented.");
+    },
+    onUnregisterTileApi: (facet?: string): void => {
+      // throw new Error("Function not implemented.");
+    }
+  };
+
+  beforeEach(() => {
+    // This short circuits the download of the image content
+    gImageMap._addOrUpdateEntry(mockImageUrl, {
+      contentUrl: mockImageUrl,
+      displayUrl: mockImageUrl,
+      status: EntryStatus.Ready
+    });
+
+    // This short circuits the download of the image content
+    gImageMap._addOrUpdateEntry(updatedUrl, {
+      contentUrl: updatedUrl,
+      displayUrl: updatedUrl,
+      status: EntryStatus.Ready
+    });
+
+    // Make sure our content has the right url
+    content.setUrl(mockImageUrl);
   });
+
+  afterAll(() => {
+    createElementSpy.mockRestore();
+
+    // We do this in afterAll because there are delayed promises in
+    // image-tile.tsx in `storeNewImageUrl` and `updateImage`.  At least one of these
+    // is running after afterEach but before afterAll. So if we remove the entries
+    // in afterEach these promises trigger warnings about missing handlers for this
+    // bogus images.
+    // This should be simplified when the image map entry lookup is moved to the model
+    runInAction(() => {
+      gImageMap.images.delete(mockImageUrl);
+      gImageMap.images.delete(updatedUrl);
+    });
+  });
+
+  it("renders successfully", () => {
+    const { getByTestId } =
+      render(
+        <Provider stores={stores}>
+          <ImageToolComponent {...defaultProps} {...{model}} />
+        </Provider>
+      );
+    expect(getByTestId("image-tile")).toBeInTheDocument();
+  });
+
+  it("renders the displayUrl as the background image", () => {
+    const { getByTestId } =
+      render(
+        <Provider stores={stores}>
+          <ImageToolComponent {...defaultProps} {...{model}} />
+        </Provider>
+      );
+    const tile = getByTestId("image-tile");
+    // FIXME: if you log the renders of the ImageToolComponent you will see that the background
+    // image is flip flopping between `test-file-stub` and `my/image/url`
+    // This is due to the complexities of the autorun in componentDidMount, the setState in updateImage,
+    // and the promise.then in updateImage.
+    // This complexity should be reduced if image map entry was moved into the ImageContentModel
+    expect(tile.querySelector(".image-tool-image")).toHaveStyle(`background-image: url(${mockImageUrl})`);
+  });
+
+  it("updates the background image when the contentUrl changes", () => {
+    const { getByTestId } =
+      render(
+        <Provider stores={stores}>
+          <ImageToolComponent {...defaultProps} {...{model}} />
+        </Provider>
+      );
+    const tile = getByTestId("image-tile");
+    expect(tile.querySelector(".image-tool-image")).toHaveStyle(`background-image: url(${mockImageUrl})`);
+
+
+    content.setUrl(updatedUrl);
+    expect(tile.querySelector(".image-tool-image")).toHaveStyle(`background-image: url(${updatedUrl})`);
+  });
+
 });

--- a/src/components/tiles/image/image-tile.tsx
+++ b/src/components/tiles/image/image-tile.tsx
@@ -10,9 +10,8 @@ import { ImageComponent } from "./image-component";
 import { ITileApi, TileResizeEntry } from "../tile-api";
 import { ITileProps } from "../tile-component";
 import { BasicEditableTileTitle } from "../../../components/tiles/basic-editable-tile-title";
-import { IDocumentContext } from "../../../models/document/document-types";
 import { debouncedSelectTile } from "../../../models/stores/ui";
-import { gImageMap, ImageMapEntry } from "../../../models/image-map";
+import { EntryStatus, gImageMap, ImageMapEntry } from "../../../models/image-map";
 import { ImageContentModelType } from "../../../models/tiles/image/image-content";
 import { ITileExportOptions } from "../../../models/tiles/tile-content-info";
 import { hasSelectionModifier } from "../../../utilities/event-utils";
@@ -20,17 +19,14 @@ import { ImageDragDrop } from "../../utilities/image-drag-drop";
 import { isPlaceholderImage } from "../../../utilities/image-utils";
 import placeholderImage from "../../../assets/image_placeholder.png";
 import { HotKeys } from "../../../utilities/hot-keys";
-import { getClipboardContent, pasteClipboardImage } from "../../../utilities/clipboard-utils";
+import { getClipboardContent, pasteClipboardImage2 } from "../../../utilities/clipboard-utils";
 
 import "./image-tile.sass";
+import { autorun, IReactionDisposer } from "mobx";
 
 type IProps = ITileProps;
 
 interface IState {
-  isLoading?: boolean;
-  imageContentUrl?: string;
-  imageFilename?: string;
-  documentContext?: IDocumentContext;
   imageEntry?: ImageMapEntry;
   imageEltWidth?: number;
   imageEltHeight?: number;
@@ -45,42 +41,42 @@ let nextImageToolId = 0;
 @inject("stores")
 @observer
 export default class ImageToolComponent extends BaseComponent<IProps, IState> {
-  public state: IState = { isLoading: true,
-                           imageContentUrl: this.getContent().url,
+  public state: IState = {
                            isEditingTitle: false
                          };
   // give each component instance a unique id
   private imageToolId = ++nextImageToolId;
-  private _isMounted = false;
   private toolbarToolApi: ITileApi | undefined;
   private resizeObserver: ResizeObserver;
   private imageElt: HTMLDivElement | null;
-  private updateImage = (url: string, filename?: string) => {
+  private contentObserverDisposer: IReactionDisposer | null;
 
-    gImageMap.getImage(url, { filename })
-      .then(image => {
-        if (!this._isMounted) return;
-        // update react state
-        this.setState({
-          isLoading: false,
-          imageContentUrl: undefined,
-          imageFilename: undefined,
-          imageEntry: image
-        });
-        // update mst content if conversion occurred
-        if (image.contentUrl && (url !== image.contentUrl)) {
-          this.getContent().updateImageUrl(url, image.contentUrl);
-        }
-      })
-      .catch(() => {
-        this.setState({
-          isLoading: false,
-          imageContentUrl: undefined,
-          imageFilename: undefined,
-          imageEntry: undefined
-        });
-      });
+  private updateImage = (url: string, filename?: string) => {
+    const promise = gImageMap.getImage(url, { filename });
+    const entry = gImageMap.getCachedImage(url);
+    this.setState({ imageEntry: entry });
+    promise.then(image => {
+      // update mst content if conversion occurred
+      // FIXME: this might result in an extra action in the undo history.
+      // This would be handled better by moving this updateImage into the model
+      // as a flow action. This way the final URL change should be grouped in
+      // the history event of which ever action caused the url to change in the
+      // first place. The trick with that approach is how to handle the state
+      // update. If the imageEntry was put in the model's volatile then the code
+      // here could use that property instead of state.
+      // Perhaps the imageEntry could be a view on the model. This way it would
+      // only be loaded when the render requests it.
+      // The trick with that is how to handle the upload file code path.
+      // In that case we probably need to move the addFile action into the
+      // image model. That way it could update an entry stored in volatile or
+      // could store the temporary url which is then used by the view to get the
+      // the current entry.
+      if (image.contentUrl && (url !== image.contentUrl)) {
+        this.getContent().updateImageUrl(url, image.contentUrl);
+      }
+    });
   };
+
   private imageDragDrop: ImageDragDrop;
   private hotKeys = new HotKeys();
 
@@ -93,10 +89,15 @@ export default class ImageToolComponent extends BaseComponent<IProps, IState> {
   }
 
   public componentDidMount() {
-    this._isMounted = true;
-    if (this.state.imageContentUrl) {
-      this.updateImageUrl(this.state.imageContentUrl, this.state.imageFilename);
-    }
+    // We do this as an autorun here instead of relying on render observation
+    // This is because we don't want trigger a new image request on each render
+    // If the image request was moved into the model, then this would be simplified
+    this.contentObserverDisposer = autorun(() => {
+      const { url, filename } = this.getContent();
+      if (url) {
+        this.updateImage(url, filename);
+      }
+    });
 
     this.resizeObserver = new ResizeObserver(entries => {
       for (const entry of entries) {
@@ -126,12 +127,13 @@ export default class ImageToolComponent extends BaseComponent<IProps, IState> {
   public componentWillUnmount() {
     this.resizeObserver.disconnect();
     this.handleResizeDebounced.cancel();
-    this._isMounted = false;
+    this.contentObserverDisposer?.();
   }
+
   public componentDidUpdate(prevProps: IProps, prevState: IState) {
-    if (this.state.imageContentUrl) {
-      this.updateImageUrl(this.state.imageContentUrl, this.state.imageFilename);
-    }
+    // If the url changes, the autorun registered in componentDidMount
+    // will take care of fetching the new image and updating the imageEntry
+
     // if we have a new image, or the image height has changed, request an explicit height
     const desiredHeight = this.getDesiredHeight();
     if (desiredHeight && (desiredHeight !== this.state.requestedHeight)) {
@@ -142,11 +144,21 @@ export default class ImageToolComponent extends BaseComponent<IProps, IState> {
 
   public render() {
     const { documentContent, tileElt, readOnly, scale } = this.props;
-    const { isLoading, imageEntry } = this.state;
+    const { imageEntry } = this.state;
     const showEmptyImagePrompt = !this.getContent().hasValidImage;
 
+    const isLoading =
+      imageEntry?.status === EntryStatus.PendingStorage || imageEntry?.status === EntryStatus.PendingDimensions;
+
+    // TODO: I don't know what this comment means:
     // Include states for selected and editing separately to clean up UI a little
-    const imageToUseForDisplay = imageEntry?.displayUrl || (isLoading ? "" : placeholderImage as string);
+
+    // TODO: check the change in behavior here. Previously if the imageEntry had a displayUrl
+    // that would be shown. This would be the case even if the image was loading.
+    // This might have had the effect that an old image would continue to be shown with a
+    // a spinner on top, when the image was replaced. Now this isn't possible becasue the
+    // imageEntry is updated immediately when the image is replaced.
+    const imageToUseForDisplay = isLoading ? "" : imageEntry?.displayUrl || placeholderImage as string;
     // Set image display properties for the div, since this won't resize automatically when the image changes
     const imageDisplayStyle: React.CSSProperties = {
       backgroundImage: "url(" + imageToUseForDisplay + ")"
@@ -156,9 +168,10 @@ export default class ImageToolComponent extends BaseComponent<IProps, IState> {
       imageDisplayStyle.height = `${defaultImagePlaceholderSize.height}px`;
     }
 
-    return (
+        return (
       <>
         <div className={classNames("image-tool", readOnly ? "read-only" : "editable")}
+          data-testid="image-tile"
           data-image-tool-id={this.imageToolId}
           onMouseDown={this.handleMouseDown}
           onDragOver={this.handleDragOver}
@@ -179,10 +192,8 @@ export default class ImageToolComponent extends BaseComponent<IProps, IState> {
           <BasicEditableTileTitle readOnly={readOnly} />
           <ImageComponent
             ref={elt => this.imageElt = elt}
-            content={this.getContent()}
             style={imageDisplayStyle}
             onMouseDown={this.handleMouseDown}
-            onUrlChange={this.handleUrlChange}
           />
         </div>
         <EmptyImagePrompt show={showEmptyImagePrompt} />
@@ -190,29 +201,32 @@ export default class ImageToolComponent extends BaseComponent<IProps, IState> {
     );
   }
 
-  private handlePaste = () => {
-    this.setState({ isLoading: true }, async () => {
-      const osClipboardContents = await getClipboardContent();
-      if (osClipboardContents) {
-        pasteClipboardImage(osClipboardContents, ({ image }) => this.handleNewImage(image));
-      }
-    });
+  private handlePaste = async () => {
+    // FIXME: With this new approach there will be a brief period of time when
+    // displayed image is not updated. This will happen while waiting for the clipboard
+    // content.
+    const osClipboardContents = await getClipboardContent();
+    if (osClipboardContents) {
+      const result = pasteClipboardImage2(osClipboardContents);
+      if (!result) return;
+      result.promise.then(image => this.handleNewImage(image));
+      this.setState({ imageEntry: result.entry });
+    }
   };
 
   private handleUploadImageFile = (file: File) => {
-    this.setState({ isLoading: true }, () => {
-      gImageMap.addFileImage(file)
-        .then(image => this.handleNewImage(image));
-    });
+    // This also returns the image map entry which should be put in the state instead
+    // of isLoading
+    // eslint-disable-next-line unused-imports/no-unused-vars
+    const { promise, entry } = gImageMap.addFileImage2(file);
+    promise.then(image => this.handleNewImage(image));
+    this.setState({ imageEntry: entry });
   };
 
   private handleNewImage = (image: ImageMapEntry) => {
-    if (this._isMounted) {
-      const content = this.getContent();
-      this.setState({ isLoading: false, imageEntry: image });
-      if (image.contentUrl && (image.contentUrl !== content.url)) {
-        content.setUrl(image.contentUrl, image.filename);
-      }
+    const content = this.getContent();
+    if (image.contentUrl && (image.contentUrl !== content.url)) {
+      content.setUrl(image.contentUrl, image.filename);
     }
   };
 
@@ -229,6 +243,11 @@ export default class ImageToolComponent extends BaseComponent<IProps, IState> {
     this.setState({ imageEltWidth: Math.ceil(width), imageEltHeight: Math.ceil(height) });
   }, 100);
 
+  // TODO: test that this is still working. It is called from componentDidUpdate
+  // this should happen when the state, props, or the an observed property has changed
+  // With the new approach we are observing the status of the imageEntry so that means
+  // we should re-render when the dimensions change. And that should trigger
+  // componentDidUpdate
   private getDesiredHeight() {
     const kMarginsAndBorders = 26;
     const { imageEntry, imageEltWidth } = this.state;
@@ -243,22 +262,6 @@ export default class ImageToolComponent extends BaseComponent<IProps, IState> {
   private getContent() {
     return this.props.model.content as ImageContentModelType;
   }
-
-  private updateImageUrl(url: string, filename?: string) {
-    if (!this.state.isLoading) {
-      this.setState({ isLoading: true });
-    }
-    this.updateImage(url, filename);
-  }
-
-  private handleUrlChange = (url: string, filename?: string, context?: IDocumentContext) => {
-    this.setState({
-      isLoading: true,
-      imageContentUrl: url,
-      imageFilename: filename,
-      documentContext: context
-    });
-  };
 
   private handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
     debouncedSelectTile(this.stores.ui, this.props.model, hasSelectionModifier(e));

--- a/src/models/image-map.test.ts
+++ b/src/models/image-map.test.ts
@@ -9,7 +9,8 @@ import { externalUrlImagesHandler, localAssetsImagesHandler,
   IImageHandler, ImageMapEntry, ImageMap,
   EntryStatus, IImageHandlerStoreOptions,
   IImageHandlerStoreResult,
-  ImageMapEntrySnapshot} from "./image-map";
+  ImageMapEntrySnapshot,
+  blobUrlImagesHandler} from "./image-map";
 
 let sImageMap: ImageMap;
 
@@ -35,7 +36,7 @@ describe("ImageMap", () => {
           localAssetsImagesHandler, externalUrlImagesHandler, externalUrlImagesHandler,
           firebaseStorageImagesHandler, firebaseStorageImagesHandler,
           firebaseRealTimeDBImagesHandler, firebaseRealTimeDBImagesHandler, firebaseRealTimeDBImagesHandler,
-          externalUrlImagesHandler, undefined, undefined ];
+          externalUrlImagesHandler, undefined, blobUrlImagesHandler ];
 
   beforeEach(() => {
     jest.restoreAllMocks();

--- a/src/models/image-map.ts
+++ b/src/models/image-map.ts
@@ -11,6 +11,7 @@ import placeholderImage from "../assets/image_placeholder.png";
 import { getAssetUrl } from "../utilities/asset-utils";
 
 export const kExternalUrlHandlerName = "externalUrl";
+export const kBlobUrlHandlerName = "blobUrl";
 export const kLocalAssetsHandlerName = "localAssets";
 export const kFirebaseStorageHandlerName = "firebaseStorage";
 export const kFirebaseRealTimeDBHandlerName = "firebaseRealTimeDB";
@@ -115,6 +116,7 @@ export class ImageMap {
     this.registerHandler(firebaseStorageImagesHandler);
     this.registerHandler(localAssetsImagesHandler);
     this.registerHandler(externalUrlImagesHandler);
+    this.registerHandler(blobUrlImagesHandler);
   }
 
   isImageUrl(url: string) {
@@ -421,6 +423,15 @@ export class ImageMap {
     this.getImage(url, options);
     return this.getCachedImage(url);
   }
+
+  @action
+  addFileImage2(file: File): {promise: Promise<ImageMapEntry>, entry?: ImageMapEntry} {
+    const url = URL.createObjectURL(file);
+    const promise = this.getImage(url, {filename: file.name});
+    const entry = this.getCachedImage(url);
+    promise.then((result) => URL.revokeObjectURL(url));
+    return {promise, entry};
+  }
 }
 
 /*
@@ -481,12 +492,68 @@ export const externalUrlImagesHandler: IImageHandler = {
   imageMap: {}
 };
 
+// The contentUrl is not set here.
+// This means any content that is referencing an image that cannot be downloaded
+// will not be updated. Modifying content like this seems kind of dangerous because
+// this could be a temporary network error.
+// By not setting the contentUrl, it also means that the default placeholder image
+// entry will not be modified by syncContentUrl. That is a good thing.
+const kErrorStorageResult: IImageHandlerStoreResult = {
+  displayUrl: placeholderImage, success: false
+};
+
+/**
+ * This can be used to upload Files
+ * You should get a url for the file with
+ * const url = URL.createObjectURL(file)
+ * After the image is ready the object url should be revoked
+ * URLrevokeObjectURL(url)
+ */
+export const blobUrlImagesHandler: IImageHandler = {
+  name: kBlobUrlHandlerName,
+  priority: 2,
+
+  match(url: string) {
+    return url ? /^blob:/.test(url) : false;
+  },
+
+  async store(url: string, options?: IImageHandlerStoreOptions): Promise<IImageHandlerStoreResult> {
+    const { db, filename } = options || {};
+
+    // Only upload if we have a place to put the image
+    if (db?.stores.user.id) {
+      try {
+        const simpleImage = await storeImage(db, url, filename);
+        // At this point it means we've successfully stored the image
+        // so we could revoke the blob/object url at this point.
+        // However it seems better for the caller that passed blob/object url
+        // to revoke it.
+        const { normalized } = parseFauxFirebaseRTDBUrl(simpleImage.imageUrl);
+        const entry: IImageHandlerStoreResult = {
+          filename,
+          contentUrl: normalized,
+          displayUrl: simpleImage.imageData,
+          success: true
+        };
+        return entry;
+      } catch (error) {
+        return kErrorStorageResult;
+      }
+    } else {
+      // If there is no db or user, we don't want the user to think they successfully uploaded the image
+      // so we run an error
+      return kErrorStorageResult;
+    }
+  },
+  imageMap: {}
+};
+
 /*
  * localAssetsImagesHandler
  */
 export const localAssetsImagesHandler: IImageHandler = {
   name: kLocalAssetsHandlerName,
-  priority: 2,
+  priority: 3,
 
   match(url: string) {
            // don't match values with a protocol or port specified
@@ -529,19 +596,9 @@ export const localAssetsImagesHandler: IImageHandler = {
  */
 const kFirebaseStorageUrlPrefix = "https://firebasestorage.googleapis.com";
 
-// The contentUrl is not set here.
-// This means any content that is referencing an image that cannot be downloaded
-// will not be updated. Modifying content like this seems kind of dangerous because
-// this could be a temporary network error.
-// By not setting the contentUrl, it also means that the default placeholder image
-// entry will not be modified by syncContentUrl. That is a good thing.
-const kErrorStorageResult: IImageHandlerStoreResult = {
-  displayUrl: placeholderImage, success: false
-};
-
 export const firebaseStorageImagesHandler: IImageHandler = {
   name: kFirebaseStorageHandlerName,
-  priority: 3,
+  priority: 4,
 
   match(url: string) {
     return url.startsWith(kFirebaseStorageUrlPrefix) ||

--- a/src/utilities/clipboard-utils.ts
+++ b/src/utilities/clipboard-utils.ts
@@ -30,6 +30,25 @@ export const pasteClipboardImage = async (imageData: IClipboardContents, onCompl
   }
 };
 
+export const pasteClipboardImage2 = (imageData: IClipboardContents) => {
+  if (imageData.image) {
+    return gImageMap.addFileImage2(imageData.image);
+  } else if (imageData.text) {
+    const url = imageData.text.match(/curriculum\/([^/]+\/images\/.*)/);
+    if (!url) {
+      console.error(`ERROR: invalid image URL: ${imageData.text}`);
+      return;
+    }
+    const fileUrl = url[1];
+    const filename = fileUrl.split("/").pop();
+    const promise = gImageMap.getImage(fileUrl, {filename});
+    const entry = gImageMap.getCachedImage(fileUrl);
+    return { promise, entry };
+  } else {
+    console.error(`ERROR: unknown clipboard content type(s): ${imageData.types}`);
+  }
+};
+
 export const getClipboardContent = async (clipboardData?: DataTransfer) => {
   const clipboardContent: IClipboardContents = {
     image: null,


### PR DESCRIPTION
This is probably not worth merging until it is updated to move the image map entry management into the image tile model. 

- make uploading files work the same way as external url uploading
- provide ImageMapEntry objects synchronously when uploading,
so these entries can be observed.
- simplify image-tile so it uses these observable image map entries.
The isLoading state is no longer needed because the entry provides it.
- a new clipboard util function is needed so it can provide the entry
almost right away.
- withoutUndo is updated to have an ignoreInChildActions option
because this refactor caused tile height changes to happen within the
setUrl action.