### PR TITLE
fix: issues with filtering points on multiple-y plots

### DIFF
--- a/src/plugins/graph/components/graph.tsx
+++ b/src/plugins/graph/components/graph.tsx
@@ -21,7 +21,10 @@ import {setNiceDomain, startAnimation} from "../utilities/graph-utils";
 import {IAxisModel} from "../imports/components/axis/models/axis-model";
 import {GraphPlace} from "../imports/components/axis-graph-shared";
 import {useGraphLayoutContext} from "../models/graph-layout";
-import {isSetAttributeIDAction, useGraphModelContext} from "../models/graph-model";
+import {
+  isAttributeAssignmentAction, isRemoveYAttributeAction, isReplaceYAttributeAction, isSetAttributeIDAction,
+  useGraphModelContext
+} from "../models/graph-model";
 import {useInstanceIdContext} from "../imports/hooks/use-instance-id-context";
 import {MarqueeState} from "../models/marquee-state";
 import {Legend} from "./legend/legend";
@@ -72,7 +75,7 @@ export const Graph = observer(
     const computedPlace = place === 'plot' && graphModel.config.noAttributesAssigned ? 'bottom' : place;
     const attrRole = graphPlaceToAttrRole[computedPlace];
     if (attrRole === 'y' && oldAttrId) {
-      graphModel.config.replaceYAttribute(oldAttrId, attrId);
+      graphModel.replaceYAttribute(oldAttrId, attrId);
       const yAxisModel = graphModel.getAxis('left') as IAxisModel;
       setNiceDomain(graphModel.config.numericValuesForYAxis, yAxisModel);
     } else {
@@ -86,7 +89,7 @@ export const Graph = observer(
    */
   const handleRemoveAttribute = (place: GraphPlace, idOfAttributeToRemove: string) => {
     if (place === 'left' && graphModel.config?.yAttributeDescriptions.length > 1) {
-      graphModel.config?.removeYAttributeWithID(idOfAttributeToRemove);
+      graphModel.removeYAttributeID(idOfAttributeToRemove);
       const yAxisModel = graphModel.getAxis('left') as IAxisModel;
       setNiceDomain(graphModel.config.numericValuesForYAxis, yAxisModel);
     } else {
@@ -97,11 +100,26 @@ export const Graph = observer(
   // respond to assignment of new attribute ID
   useEffect(function handleNewAttributeID() {
     const disposer = graphModel && onAnyAction(graphModel, action => {
-      if (isSetAttributeIDAction(action)) {
-        const [role, dataSetId, attrID] = action.args,
-          graphPlace = attrRoleToGraphPlace[role];
+      if (isAttributeAssignmentAction(action)) {
+        let graphPlace: GraphPlace = "yPlus";
+        let dataSetId = dataset?.id ?? "";
+        let attrId = "";
+        if (isSetAttributeIDAction(action)) {
+          const [role, _dataSetId, _attrId] = action.args;
+          graphPlace = attrRoleToGraphPlace[role] as GraphPlace;
+          dataSetId = _dataSetId;
+          attrId = _attrId;
+        }
+        else if (isRemoveYAttributeAction(action)) {
+          graphPlace = "yPlus";
+        }
+        else if (isReplaceYAttributeAction(action)) {
+          const [ , newAttrId] = action.args;
+          graphPlace = "yPlus";
+          attrId = newAttrId;
+        }
         startAnimation(enableAnimation);
-        graphPlace && graphController?.handleAttributeAssignment(graphPlace, dataSetId, attrID);
+        graphPlace && graphController?.handleAttributeAssignment(graphPlace, dataSetId, attrId);
       }
     });
     return () => disposer?.();

--- a/src/plugins/graph/components/graph.tsx
+++ b/src/plugins/graph/components/graph.tsx
@@ -75,7 +75,7 @@ export const Graph = observer(
     const computedPlace = place === 'plot' && graphModel.config.noAttributesAssigned ? 'bottom' : place;
     const attrRole = graphPlaceToAttrRole[computedPlace];
     if (attrRole === 'y' && oldAttrId) {
-      graphModel.replaceYAttribute(oldAttrId, attrId);
+      graphModel.replaceYAttributeID(oldAttrId, attrId);
       const yAxisModel = graphModel.getAxis('left') as IAxisModel;
       setNiceDomain(graphModel.config.numericValuesForYAxis, yAxisModel);
     } else {

--- a/src/plugins/graph/models/data-configuration-model.ts
+++ b/src/plugins/graph/models/data-configuration-model.ts
@@ -659,7 +659,7 @@ export const DataConfigurationModel = types
        * the old position to prevent duplication.
        */
       if (self._yAttributeDescriptions.find(d=>d.attributeID===oldAttrId)) {
-        this.removeYAttributeWithID(newAttrId);
+        this.removeYAttribute(newAttrId);
         const index = self._yAttributeDescriptions.findIndex(d=>d.attributeID===oldAttrId);
         self._yAttributeDescriptions[index].attributeID = newAttrId;
         if (index === 0 && self._yAttributeDescriptions.length === 1) {
@@ -682,7 +682,7 @@ export const DataConfigurationModel = types
         existingFilteredCases?.invalidateCases();
       }
     },
-    removeYAttributeWithID(id: string) {
+    removeYAttribute(id: string) {
       const index = self._yAttributeDescriptions.findIndex((aDesc) => aDesc.attributeID === id);
       if (index >= 0) {
         self._yAttributeDescriptions.splice(index, 1);

--- a/src/plugins/graph/models/graph-model.ts
+++ b/src/plugins/graph/models/graph-model.ts
@@ -228,6 +228,12 @@ export const GraphModel = TileContentModel
       }
       self.updateAdornments(true);
     },
+    removeYAttributeID(attrID: string) {
+      self.config.removeYAttribute(attrID);
+    },
+    replaceYAttribute(oldAttrId: string, newAttrId: string) {
+      self.config.replaceYAttribute(oldAttrId, newAttrId);
+    },
     setPlotType(type: PlotType) {
       self.plotType = type;
     },
@@ -413,9 +419,29 @@ export interface SetAttributeIDAction extends ISerializedActionCall {
   name: "setAttributeID"
   args: [GraphAttrRole, string, string]
 }
-
 export function isSetAttributeIDAction(action: ISerializedActionCall): action is SetAttributeIDAction {
   return action.name === "setAttributeID";
+}
+
+export interface RemoveYAttributeAction extends ISerializedActionCall {
+  name: "removeYAttributeID",
+  args: [string]
+}
+export function isRemoveYAttributeAction(action: ISerializedActionCall): action is RemoveYAttributeAction {
+  return action.name === "removeYAttributeID";
+}
+
+export interface ReplaceYAttributeAction extends ISerializedActionCall {
+  name: "replaceYAttribute",
+  args: [string, string]
+}
+export function isReplaceYAttributeAction(action: ISerializedActionCall): action is ReplaceYAttributeAction {
+  return action.name === "replaceYAttribute";
+}
+
+export type AttributeAssignmentAction = SetAttributeIDAction | RemoveYAttributeAction | ReplaceYAttributeAction;
+export function isAttributeAssignmentAction(action: ISerializedActionCall): action is AttributeAssignmentAction {
+  return ["setAttributeID", "removeYAttributeID", "replaceYAttribute"].includes(action.name);
 }
 
 export interface SetGraphVisualPropsAction extends ISerializedActionCall {

--- a/src/plugins/graph/models/graph-model.ts
+++ b/src/plugins/graph/models/graph-model.ts
@@ -231,7 +231,7 @@ export const GraphModel = TileContentModel
     removeYAttributeID(attrID: string) {
       self.config.removeYAttribute(attrID);
     },
-    replaceYAttribute(oldAttrId: string, newAttrId: string) {
+    replaceYAttributeID(oldAttrId: string, newAttrId: string) {
       self.config.replaceYAttribute(oldAttrId, newAttrId);
     },
     setPlotType(type: PlotType) {
@@ -432,16 +432,16 @@ export function isRemoveYAttributeAction(action: ISerializedActionCall): action 
 }
 
 export interface ReplaceYAttributeAction extends ISerializedActionCall {
-  name: "replaceYAttribute",
+  name: "replaceYAttributeID",
   args: [string, string]
 }
 export function isReplaceYAttributeAction(action: ISerializedActionCall): action is ReplaceYAttributeAction {
-  return action.name === "replaceYAttribute";
+  return action.name === "replaceYAttributeID";
 }
 
 export type AttributeAssignmentAction = SetAttributeIDAction | RemoveYAttributeAction | ReplaceYAttributeAction;
 export function isAttributeAssignmentAction(action: ISerializedActionCall): action is AttributeAssignmentAction {
-  return ["setAttributeID", "removeYAttributeID", "replaceYAttribute"].includes(action.name);
+  return ["setAttributeID", "removeYAttributeID", "replaceYAttributeID"].includes(action.name);
 }
 
 export interface SetGraphVisualPropsAction extends ISerializedActionCall {


### PR DESCRIPTION
In PR #1983 I stated that the first question to ask in the case of point filtering issues in the graph code is:

>1. Is `matchCirclesToData()` being called in the relevant path?
  a. if so, there may be a bug in `matchCirclesToData()` itself
  b. if not, why not?

In the case of these multiple Y filtering bugs, `matchCirclesToData()` was not being called. The reason is that one of the main ways `matchCirclesToData()` is called is that `GraphModel.setAttributeID()` triggers a reaction in the `Graph` component which calls `GraphController.handleAttributeAssignment()`, which calls `matchCirclesToData()` (among other plot configuration). PR #1966 added several methods to the `DataConfigurationModel` for updating the attribute configuration, but they don't trigger the above cycle. With this PR, `removeYAttributeID()` and `replaceYAttribute()` actions are added to the `GraphModel`, and these methods are called when the user makes changes. The reaction in the `Graph` component is extended to listen to these additional actions.

@bgoldowsky I leave it to you to shepherd this PR through the process.