### PR TITLE
withoutUndo with opt out

### DIFF
--- a/src/models/document/tile-row.ts
+++ b/src/models/document/tile-row.ts
@@ -124,7 +124,7 @@ export const TileRowModel = types
   }))
   .actions(self => ({
     setRowHeightWithoutUndo(height?: number) {
-      withoutUndo();
+      withoutUndo({ unlessChildAction: true });
       self.setRowHeight(height);
     }
   }));

--- a/src/models/history/without-undo.ts
+++ b/src/models/history/without-undo.ts
@@ -2,7 +2,22 @@ import { getRoot, getRunningActionContext } from "mobx-state-tree";
 import { DEBUG_UNDO } from "../../lib/debug";
 import { runningCalls } from "./tree-types";
 
-export function withoutUndo(options?: { unlessChildAction?: boolean }) {
+  /**
+   * When added to the body of a MST action, this will prevent any changes
+   * made by the action from being recorded in the CLUE undo stack. The changes
+   * will still be recorded in the CLUE document history.
+   *
+   * If this action was called from another MST action it is considered a child
+   * action. Child action changes are always recorded, so by default a warning
+   * is printed when withoutUndo is called from a child action.
+   *
+   * There is is an option so you can record the child action changes, but not
+   * record the changes when the action is the initial action:
+   *
+   *   `withoutUndo({ unlessChildAction: true })`
+   *
+   */
+  export function withoutUndo(options?: { unlessChildAction?: boolean }) {
   const actionCall = getRunningActionContext();
   if (!actionCall) {
     throw new Error("withoutUndo called outside of an MST action");

--- a/src/models/history/without-undo.ts
+++ b/src/models/history/without-undo.ts
@@ -2,28 +2,39 @@ import { getRoot, getRunningActionContext } from "mobx-state-tree";
 import { DEBUG_UNDO } from "../../lib/debug";
 import { runningCalls } from "./tree-types";
 
-export function withoutUndo() {
+export function withoutUndo(options?: { unlessChildAction?: boolean }) {
   const actionCall = getRunningActionContext();
   if (!actionCall) {
     throw new Error("withoutUndo called outside of an MST action");
   }
 
   if (actionCall.parentActionEvent) {
+    if (options?.unlessChildAction) {
+      // The caller has explicity said it is OK to ignore the withoutUndo
+      // when we are in a child action.
+      return;
+    }
     // It is a little weird to print all this, but it seems like a good way to leave
     // this part unimplemented.
     console.warn([
-      "withoutUndo() called by a child action. If calling a child action " +
-      "with withoutUndo is something you need to do, update this code to support it. " +
-      "There are several options for supporting it:",
-      "   1. Ignore the call",
-      "   2. Apply the withoutUndo to the parent action",
-      "   3. Apply the withoutUndo just to the child action",
-      "Notes:",
-      "   - option 1 will be hard to debug, so if you do this, you should add a debug " +
-      "option to print out a message when it is ignored",
-      "   - option 3 will require changing the undo stack so it can record different " +
-      "entries from the history stack. It will also require changing the recordPatches " +
-      "function to somehow track this child action information."
+      "withoutUndo() was called by a child action. If calling a child action " +
+      "with withoutUndo is something you need to do, you have a few options." +
+      "- If you want to ignore the withoutUndo when in a child action:" +
+      "  withoutUndo({ unlessChildAction: true })" +
+      "  Note: this may cause issues if other code is always assuming this action" +
+      "  will never be included in the undo history" +
+      "- If you want to do something else you'll need to update this code." +
+      "  Here are a couple options you might want:" +
+      "    1. Apply the withoutUndo to the parent action",
+      "    2. Apply the withoutUndo just to the child action",
+      "  Notes:",
+      "   - option 1 might have unintended consequences. Actions can become child actions" +
+      "     in strange ways. For example a model action can trigger a re-render of a component." +
+      "     If the component has a componentDidUpdate which calls another action, this second" +
+      "     action will be considered a child action of the initial model action." +
+      "   - option 2 will require changing the undo stack so it can record different " +
+      "     entries from the history stack. It will also require changing the recordPatches " +
+      "     function to somehow track this child action information."
     ].join('\n'));
     return;
   }


### PR DESCRIPTION
This fixes warnings that happened when the resizing of a row was being triggered by parent action.

In these cases it seems to make sense to just go ahead and record the resizing. The reason we didn't record it before because it could happen on document load and would result in a weird undo history.

The change really should just remove a warning that is printed in some cases. The adding of undo history events should behave exactly the same as when the warning was there.