### PR TITLE
Consolidate smaller cypress tests into larger ones to reduce test results

### DIFF
--- a/.github/workflows/manual-regression.yml
+++ b/.github/workflows/manual-regression.yml
@@ -21,6 +21,7 @@ on:
           - branch/student_tests/arrow_annotation_spec.js
           - branch/student_tests/canvas_test_spec.js
           - branch/student_tests/data_card_tool_spec.js
+          - branch/student_tests/datacard_merge_spec.js
           - branch/student_tests/dataflow_table_integration_test_spec.js
           - branch/student_tests/dataflow_tool_spec.js
           - branch/student_tests/diagram_tool_spec.js
@@ -29,6 +30,7 @@ on:
           - branch/student_tests/expression_tool_spec.js
           - branch/student_tests/graph_table_integraton_test_spec.js
           - branch/student_tests/graph_tool_spec.js
+          - branch/student_tests/group_test_readonly_spec.js
           - branch/student_tests/group_test_spec.js
           - branch/student_tests/image_tool_spec.js
           - branch/student_tests/nav_panel_test_spec.js
@@ -49,6 +51,7 @@ on:
           - branch/teacher_tests/teacher_six_pack_spec.js
           - branch/teacher_tests/teacher_support_note.js
           - branch/teacher_tests/teacher_support_spec.js
+          - branch/teacher_tests/teacher_tagged_comments_spec.js
           - branch/teacher_tests/teacher_workspace_spec.js
           - full/student_tests/group_chooser_spec.js
           - full/teacher_tests/teacher_chat_spec.js

--- a/.github/workflows/regression-daily.yml
+++ b/.github/workflows/regression-daily.yml
@@ -2,7 +2,7 @@ name: Regression Tests
 
 on:
   schedule:
-    - cron: "35 13 * * *"
+    - cron: "0 0 * * *"
 jobs:
   all-tests:
     runs-on: ubuntu-latest

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
     // You may want to clean this up later by importing these.
 
     numTestsKeptInMemory: 20,
+    experimentalRunAllSpecs: true,
     setupNodeEvents(on, config) {
       const fetchConfigurationByFile = file => {
         const pathOfConfigurationFile = `config/cypress.${file}.json`;

--- a/cypress/e2e/clue/branch/student_tests/canvas_test_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/canvas_test_spec.js
@@ -24,433 +24,388 @@ let copyTitle = 'Personal Workspace Copy';
 // let renameTitle = "Renamed Title title";
 let renameTitlePencil = "Renamed Title pencil";
 
+const queryParams1 = `${Cypress.config("queryParams")}`
+const queryParams2 = "?appMode=qa&fakeClass=5&fakeUser=student:5&fakeOffering=5&problem=3.3&qaGroup=5&unit=example-no-group-share";
+const queryParams3 = "?appMode=demo&demoName=BrokenDocs&fakeClass=1&fakeUser=student:1&unit=sas&problem=0.1";
+
+const title = "SAS 2.1 Drawing Wumps";
+
+function beforeTest(params) {
+  cy.clearQAData('all');
+  cy.visit(params);
+  cy.waitForLoad();
+}
+
 context('Test Canvas', function () {
   //TODO: Tests to add to canvas:
   // 1. reorder
   // 3. drag image from resourcesPanel to canvas
   // 5. drag a tool from tool bar to canvas
-  before(function () {
-    const queryParams = `${Cypress.config("queryParams")}`;
-    cy.clearQAData('all');
 
-    cy.visit(queryParams);
-    cy.waitForLoad();
-    clueCanvas.getInvestigationCanvasTitle().text().as('title');
-  });
+  it('test canvas tools', function () {
+    beforeTest(queryParams1);
+    cy.log('verify investigation header UI');
+    canvas.getEditTitleIcon().should('not.exist');
+    canvas.getPublishIcon().should('be.visible');
+    clueCanvas.getShareButton().should('be.visible');
+    clueCanvas.getFourUpViewToggle().should('be.visible');
+    clueCanvas.openFourUpView();
+    clueCanvas.getShareButton().should('be.visible');//should have share in 4 up
+    clueCanvas.openOneUpViewFromFourUp();
 
-  context('test canvas tools', function () {
-    describe('test header elements', function () {
-      it('verify investigation header UI', () => { // element functionality are tested in common
-        canvas.getEditTitleIcon().should('not.exist');
-        canvas.getPublishIcon().should('be.visible');
-        clueCanvas.getShareButton().should('be.visible');
-        clueCanvas.getFourUpViewToggle().should('be.visible');
-        clueCanvas.openFourUpView();
-        clueCanvas.getShareButton().should('be.visible');//should have share in 4 up
-        clueCanvas.openOneUpViewFromFourUp();
-      });
-      it('verify personal workspace header UI', () => { //other header elements are tested in common
-        canvas.createNewExtraDocumentFromFileMenu(studentWorkspace, "my-work");
-        canvas.getEditTitleIcon().should('be.visible');
-        canvas.getPersonalPublishIcon().should('be.visible');
-        clueCanvas.getShareButton().should('not.exist');
-        clueCanvas.getFourUpViewToggle().should('not.exist');
-      });
-    });
-    describe('Test personal workspace canvas', function () {
-      it('verify personal workspace does not have section headers', function () {
-        clueCanvas.getRowSectionHeader().should('not.exist');
-      });
-      it('verify tool tiles', function () { //to be used for save and restore test
-        clueCanvas.addTile('geometry');
-        clueCanvas.addTile('table');
-        clueCanvas.addTile('text');
-        textToolTile.enterText('this is ' + studentWorkspace);
-        textToolTile.getTextTile().should('be.visible').and('contain', studentWorkspace);
-      });
-      it('verify copy of personal workspace', function () {
-        canvas.copyDocument(copyTitle);
-        canvas.getPersonalDocTitle().should('contain', copyTitle);
-        graphToolTile.getGraphTile().should('be.visible');
-        tableToolTile.getTableTile().should('be.visible');
-        textToolTile.getTextTile().should('be.visible').and('contain', studentWorkspace);
-      });
-      it('verify rename of workspace title with edit icon', function () {
-        canvas.editTitlewithPencil(renameTitlePencil);
-        canvas.getPersonalDocTitle().should("contain", renameTitlePencil);
-      });
-      it('verify title change in document thumbnail in nav panel', function () {
-        // cy.get(".resources-expander.my-work").click();
-        cy.openTopTab("my-work");
-        cy.openSection("my-work", "workspaces");
-        resourcesPanel.getCanvasItemTitle('my-work', 'workspaces').should('contain', renameTitlePencil);
-      });
-      it('verify publish document', function () {
-        canvas.publishCanvas("personal");
-        resourcesPanel.openTopTab('class-work');
-        cy.openSection('class-work', "workspaces");
-        resourcesPanel.getCanvasItemTitle('class-work', 'workspaces').should('contain', renameTitlePencil);
-      });
-    });
+    cy.log('verify personal workspace header UI');
+    canvas.createNewExtraDocumentFromFileMenu(studentWorkspace, "my-work");
+    canvas.getEditTitleIcon().should('be.visible');
+    canvas.getPersonalPublishIcon().should('be.visible');
+    clueCanvas.getShareButton().should('not.exist');
+    clueCanvas.getFourUpViewToggle().should('not.exist');
 
-    describe('Test section headers', function () {
-      let headers = ['IN', 'IC', 'WI', 'NW'];
-      let headerTitles = ["Introduction", "Initial Challenge", "What If...?", "Now What Do You Know?"];
-      before(function () {
-        resourcesPanel.openTopTab("my-work");
-        cy.openDocumentWithTitle('my-work', 'workspaces', this.title);
-      });
-      it('verify initial canvas load has sections', function () {
-        headers.forEach(function (header) {
-          clueCanvas.getSectionHeader(header).should('exist');
-        });
-      });
-      it('verifies section header has initials and titles', function () {
-        let i = 0;
-        for (i = 0; i < headers.length; i++) {
-          clueCanvas.getSectionHeader(headers[i]).find('.initials').should('contain', headers[i]);
-          clueCanvas.getSectionHeader(headers[i]).find('.title').should('contain', headerTitles[i]);
-        }
-      });
-      it('verifies section headers are not deletable', function () {
-        clueCanvas.getRowSectionHeader().each(function ($header) {
-          cy.wrap($header).click({ force: true });
-          clueCanvas.getDeleteTool().should('have.class', 'disabled').click();
-          expect($header).to.exist;
-        });
-      });
-      it('verifies a placeholder tile for every section header', function () {
-        let numHeaders = 0;
-        clueCanvas.getRowSectionHeader().each(function () {
-          numHeaders++;
-        }).then(() => {
-          clueCanvas.getPlaceHolder().should('have.length', numHeaders);
-        });
-      });
-      it('verifies work area placeholder is not deletable', function () {
-        let numHolders = 0;
-        clueCanvas.getPlaceHolder().each(function () {
-          numHolders++;
-        }).then(() => {
-          clueCanvas.getPlaceHolder().first().should('exist');
-          clueCanvas.getPlaceHolder().first().click({ force: true });
-          clueCanvas.getDeleteTool().click();
-          clueCanvas.getPlaceHolder().should('have.length', numHolders);
-        });
-      });
-      it('verifies work area placeholder is not draggable', function () {
-        //TODO: not sure how to test this yet
-      });
-      it('verifies publish of investigation', function () {
-        canvas.publishCanvas("investigation");
-        resourcesPanel.openTopTab('class-work');
-        cy.openSection('class-work', "workspaces");
-        resourcesPanel.getCanvasItemTitle('class-work', 'workspaces').should('contain', "Student 5: "+this.title);
-      });
-      it('verifies copy of investigation', function () {
-        let investigationTitle = 'Investigation Copy';
-        canvas.copyDocument(investigationTitle);
-        canvas.getPersonalDocTitle().should('contain', investigationTitle);
-        resourcesPanel.openTopTab("my-work");
-        cy.openSection('my-work', "workspaces");
-        resourcesPanel.getCanvasItemTitle('my-work', 'workspaces').should('contain', investigationTitle);
-      });
-    });
-    describe('Test 4up view', function () {
-      before(function () {
-        cy.openDocumentWithTitle('my-work','workspaces', this.title);
-      });
-      it('verifies views button changes when clicked and shows the correct corresponding workspace view', function () {
-        //1-up view has 4-up button visible and 1-up canvas
-        clueCanvas.getFourUpViewToggle().should('be.visible');
-        canvas.getSingleCanvas().should('be.visible');
-        clueCanvas.getFourUpView().should('not.exist');
-        clueCanvas.openFourUpView();
-        //4-up view is visible and 1-up button is visible
-        clueCanvas.getFourToOneUpViewToggle().should('be.visible');
-        clueCanvas.getNorthEastCanvas().should('be.visible');
-        clueCanvas.getNorthWestCanvas().should('be.visible');
-        clueCanvas.getSouthEastCanvas().should('be.visible');
-        clueCanvas.getSouthEastCanvas().should('be.visible');
+    cy.log('Test personal workspace canvas');
+    cy.log('verify personal workspace does not have section headers');
+    clueCanvas.getRowSectionHeader().should('not.exist');
 
-        //can get back to 1 up view from 4 up
-        clueCanvas.openOneUpViewFromFourUp();
-        canvas.getSingleCanvas().should('be.visible');
-        clueCanvas.getFourUpViewToggle().should('be.visible');
-        clueCanvas.getFourUpView().should('not.exist');
-      });
+    cy.log('verify tool tiles');
+    clueCanvas.addTile('geometry');
+    clueCanvas.addTile('table');
+    clueCanvas.addTile('text');
+    textToolTile.enterText('this is ' + studentWorkspace);
+    textToolTile.getTextTile().should('be.visible').and('contain', studentWorkspace);
 
-      it('verify share button', function () {
-        clueCanvas.getShareButton().should('be.visible');
-        clueCanvas.getShareButton().should('have.class', 'private');
-        clueCanvas.shareCanvas();
-        clueCanvas.getShareButton().should('be.visible');
-        clueCanvas.getShareButton().should('have.class', 'public');
-        clueCanvas.unshareCanvas();
-        clueCanvas.getShareButton().should('be.visible');
-        clueCanvas.getShareButton().should('have.class', 'private');
-      });
+    cy.log('verify copy of personal workspace');
+    canvas.copyDocument(copyTitle);
+    canvas.getPersonalDocTitle().should('contain', copyTitle);
+    graphToolTile.getGraphTile().should('be.visible');
+    tableToolTile.getTableTile().should('be.visible');
+    textToolTile.getTextTile().should('be.visible').and('contain', studentWorkspace);
+
+    cy.log('verify rename of workspace title with edit icon');
+    canvas.editTitlewithPencil(renameTitlePencil);
+    canvas.getPersonalDocTitle().should("contain", renameTitlePencil);
+
+    cy.log('verify title change in document thumbnail in nav panel');
+    // cy.get(".resources-expander.my-work").click();
+    cy.openTopTab("my-work");
+    cy.openSection("my-work", "workspaces");
+    resourcesPanel.getCanvasItemTitle('my-work', 'workspaces').should('contain', renameTitlePencil);
+
+    cy.log('verify publish document');
+    canvas.publishCanvas("personal");
+    resourcesPanel.openTopTab('class-work');
+    cy.openSection('class-work', "workspaces");
+    resourcesPanel.getCanvasItemTitle('class-work', 'workspaces').should('contain', renameTitlePencil);
+
+    let headers = ['IN', 'IC', 'WI', 'NW'];
+    let headerTitles = ["Introduction", "Initial Challenge", "What If...?", "Now What Do You Know?"];
+
+    cy.log("Test section headers");
+    resourcesPanel.openTopTab("my-work");
+    cy.openDocumentWithTitle('my-work', 'workspaces', title);
+
+    cy.log('verify initial canvas load has sections');
+    headers.forEach(function (header) {
+      clueCanvas.getSectionHeader(header).should('exist');
     });
 
-    describe('Test 4-up view', function () {
-      it('will drag the center point and verify that canvases resize', function () {
-        clueCanvas.openFourUpView();
-        cy.get('.four-up .center')
-          .trigger('dragstart')
-          .trigger('mousemove', 100, 250, { force: true })
-          .trigger('drop');
-        clueCanvas.openOneUpViewFromFourUp(); //clean up
-      });
+    cy.log('verifies section header has initials and titles');
+    let i = 0;
+    for (i = 0; i < headers.length; i++) {
+      clueCanvas.getSectionHeader(headers[i]).find('.initials').should('contain', headers[i]);
+      clueCanvas.getSectionHeader(headers[i]).find('.title').should('contain', headerTitles[i]);
+    }
+
+    cy.log('verifies section headers are not deletable');
+    clueCanvas.getRowSectionHeader().each(function ($header) {
+      cy.wrap($header).click({ force: true });
+      clueCanvas.getDeleteTool().should('have.class', 'disabled').click();
+      expect($header).to.exist;
     });
 
-    describe('Test the tool palette', function () {//This should test the tools in the tool shelf
-      // Tool palettes for Graph, Image, Draw,and Table are tested in respective tool spec test
-      //Selection tool is tested as a functionality of graph tool tiles
-
-      it('adds text tool', function () {
-        clueCanvas.addTile('text');
-        textToolTile.getTextTile().should('exist');
-        textToolTile.enterText('This is the Investigation ' + this.title);
-        clueCanvas.exportTileAndDocument('text-tool-tile');
-      });
-      it('adds a graph tool', function () {
-        clueCanvas.addTile('geometry');
-        graphToolTile.getGraphTile().should('exist');
-        clueCanvas.exportTileAndDocument('geometry-tool-tile');
-        // in case we created a point while exporting
-        cy.get('.primary-workspace .geometry-toolbar .button.delete').click({ force: true});
-      });
-      it('adds an image tool', function () {
-        clueCanvas.addTile('image');
-        imageToolTile.getImageTile().should('exist');
-        clueCanvas.exportTileAndDocument('image-tool-tile');
-      });
-      it('adds a draw tool', function () {
-        clueCanvas.addTile('drawing');
-        drawToolTile.getDrawTile().should('exist');
-        clueCanvas.exportTileAndDocument('drawing-tool-tile');
-      });
-      it('adds a table tool', function () {
-        clueCanvas.addTile('table');
-        tableToolTile.getTableTile().should('exist');
-        clueCanvas.exportTileAndDocument('table-tool-tile');
-      });
-      it('verifies scrolling', function () {
-        graphToolTile.getGraphTile().scrollIntoView();
-        textToolTile.getTextTile().first().scrollIntoView();
-      });
-      // TODO:4-up view canvas selector does not work in cypress even though it works in Chrome. it currently selects the entire canvas and not the scaled one
-      // it('verifies scrolling in 4up view', function(){
-      //      canvas.openFourUpView();
-      //      canvas.scrollToBottom(canvas.getNorthWestCanvas());
-      //     // cy.get('.single-workspace > .document> .canvas-area > .four-up > .canvas-container.north-west >.canvas-scaler >.canvas').scrollTo('bottom');
-      //     canvas.getGraphTile().last().should('be.visible');
-      //     canvas.getSouthWestCanvas().should('be.visible');
-      //     canvas.openOneUpViewFromFourUp(); //clean up
-      //
-      // });
+    cy.log('verifies a placeholder tile for every section header');
+    let numHeaders = 0;
+    clueCanvas.getRowSectionHeader().each(function () {
+      numHeaders++;
+    }).then(() => {
+      clueCanvas.getPlaceHolder().should('have.length', numHeaders);
     });
 
-    describe('save and restore of tool tiles', function () {
-      describe('verify that tool tiles is saved from various locations', function () {
-        it('will restore from My Work/Workspaces tab', function () {
-          //Open personal workspace
-          resourcesPanel.openTopTab("my-work");
-          cy.openDocumentWithTitle('my-work','workspaces', studentWorkspace);
-          canvas.getPersonalDocTitle().should('contain', studentWorkspace);
-          graphToolTile.getGraphTile().should('be.visible');
-          tableToolTile.getTableTile().should('be.visible');
-          textToolTile.getTextTile().should('be.visible').and('contain', studentWorkspace);
-        });
-        it('will restore from My Work/Investigation tab', function () {
-          //Open Investigation
-          resourcesPanel.openTopTab("my-work");
-          cy.openDocumentWithTitle('my-work','workspaces', this.title);
-          clueCanvas.getInvestigationCanvasTitle().should('contain', this.title);
-          textToolTile.getTextTile().should('be.visible').and('contain', this.title);
-          graphToolTile.getGraphTile().should('exist');
-          drawToolTile.getDrawTile().should('exist');
-          imageToolTile.getImageTile().should('exist');
-          tableToolTile.getTableTile().should('exist');
-        });
-      });
-
-      describe('verify that if user leaves a canvas in four-up view, restore is also in four up view', function () {
-        before(() => {
-          clueCanvas.openFourUpView();//for later test on restore of 4up view
-          clueCanvas.getNorthWestCanvas().should('be.visible');
-        });
-        it('verify restore in 4 up view from Extra Workspace', function () {
-          //Open Personal Workspace
-          resourcesPanel.openTopTab("my-work");
-          cy.openDocumentWithTitle('my-work','workspaces', studentWorkspace);
-          canvas.getPersonalDocTitle().should('contain', studentWorkspace);
-        });
-        it('verify restore in 4 up view from Investigation', function () {
-          //Open Investigation should be in 4up view
-          resourcesPanel.openTopTab("my-work");
-          cy.openDocumentWithTitle('my-work','workspaces', this.title);
-          clueCanvas.getInvestigationCanvasTitle().should('contain', this.title);
-          clueCanvas.getNorthWestCanvas().should('be.visible');
-        });
-        after(() => { //restore to 1up view
-          clueCanvas.openOneUpViewFromFourUp();
-        });
-      });
-    });
-  });
-
-  context('Drag and drop clue canvas tiles', () => {
-    it('Drags and drops a tile', () => {
-      // TO DO
-      //clueCanvas.moveTile(movingTile, targetTile, direction)
-    });
-  });
-
-  context('delete elements from canvas', function () {
-    before(() => {
-      //star a document to verify delete
-      cy.openSection("my-work", "workspaces");
-      cy.get('.list.workspaces [data-test=workspaces-list-items] .footer').contains(renameTitlePencil).parents().siblings('.icon-holder').find('.icon-star').click();
-      cy.openDocumentWithTitle('my-work', 'workspaces', 'SAS 2.1 Drawing Wumps');
-    });
-    it('will delete elements from canvas', function () {
-      // Delete elements in the canvas
-      clueCanvas.deleteTile('graph');
-      clueCanvas.deleteTile('image');
-      clueCanvas.deleteTile('draw');
-      clueCanvas.deleteTile('table');
-      clueCanvas.deleteTile('text');
-      clueCanvas.deleteTile('text');
-      textToolTile.getTextTile().should('not.exist');
-      graphToolTile.getGraphTile().should('not.exist');
-      drawToolTile.getDrawTile().should('not.exist');
-      imageToolTile.getImageTile().should('not.exist');
-      tableToolTile.getTableTile().should('not.exist');
-    });
-  });
-
-  context('Dragging elements from different locations to canvas', function () {
-    describe('Drag element from left nav', function () {
-      const dataTransfer = new DataTransfer;
-      it('will drag image from resource panel to canvas', () => {
-        resourcesPanel.openTopTab('problems');
-        resourcesPanel.openBottomTab("Now What Do You Know?");
-        resourcesPanel.getResourcesPanelExpandedSpace().find('.image-tool').first()
-          .trigger('dragstart', { dataTransfer });
-        cy.get('.single-workspace .canvas .document-content').first()
-          .trigger('drop', { force: true, dataTransfer });
-        resourcesPanel.getResourcesPanelExpandedSpace().find('.image-tool').first()
-          .trigger('dragend');
-        imageToolTile.getImageTile().should('exist');
-        imageToolTile.getImageTile().find('.editable-tile-title-text').contains('Did You Know?: Images in computer graphics');
-        clueCanvas.deleteTile('image');
-      });
-      it('will maintain positioning when copying multiple tiles', () => {
-        resourcesPanel.openBottomTab("Initial Challenge");
-        const leftTile = type => cy.get(`.nav-tab-panel .problem-panel .${type}-tool-tile`);
-
-        // Select three table tiles on the left
-        leftTile('table').first().click({ shiftKey: true });
-        leftTile('table').eq(1).click({ shiftKey: true });
-        leftTile('table').eq(2).click({ shiftKey: true });
-
-        // Drag the selected copies to the workspace on the right
-        leftTile('table').eq(2).trigger('dragstart', { dataTransfer });
-        cy.get('.single-workspace .canvas .document-content').first()
-          .trigger('drop', { force: true, dataTransfer });
-
-        // Make sure the tiles were copied in the correct order
-        tableToolTile.getTableTile().first().find('.editable-header-cell').contains('Mug Wump');
-        tableToolTile.getTableTile().eq(1).find('.editable-header-cell').contains('Mug Wump Part 2');
-        tableToolTile.getTableTile().eq(2).find('.editable-header-cell').contains('Mug Wump Part 3');
-
-        // Clean up
-        clueCanvas.deleteTile('table');
-        clueCanvas.deleteTile('table');
-        clueCanvas.deleteTile('table');
-      });
-      it('will copy a single table tile from resources to canvas', () => {
-        resourcesPanel.openBottomTab("Initial Challenge");
-        const leftTile = type => cy.get(`.nav-tab-panel .problem-panel .${type}-tool-tile`);
-
-        // Select one table tile on the left
-        leftTile('table').first().click();
-
-        // Drag the selected copies to the workspace on the right
-        leftTile('table').first().trigger('dragstart', { dataTransfer });
-        cy.get('.single-workspace .canvas .document-content').first()
-          .trigger('drop', { force: true, dataTransfer });
-
-        // Make sure the tiles were copied in the correct order
-        tableToolTile.getTableTile().first().find('.editable-header-cell').contains('Mug Wump');
-
-        // Clean up
-        clueCanvas.deleteTile('table');
-      });
+    cy.log('verifies work area placeholder is not deletable');
+    let numHolders = 0;
+    clueCanvas.getPlaceHolder().each(function () {
+      numHolders++;
+    }).then(() => {
+      clueCanvas.getPlaceHolder().first().should('exist');
+      clueCanvas.getPlaceHolder().first().click({ force: true });
+      clueCanvas.getDeleteTool().click();
+      clueCanvas.getPlaceHolder().should('have.length', numHolders);
     });
 
-  });
+    cy.log('verifies publish of investigation');
+    canvas.publishCanvas("investigation");
+    resourcesPanel.openTopTab('class-work');
+    cy.openSection('class-work', "workspaces");
+    resourcesPanel.getCanvasItemTitle('class-work', 'workspaces').should('contain', "Student 5: " + title);
 
-  context('delete workspaces', function () {
-    it('verify delete of copy of investigation', function () {
-      resourcesPanel.openTopTab("my-work");
-      cy.openDocumentWithTitle('my-work','workspaces', 'Investigation Copy');
-      canvas.deleteDocument();
-      resourcesPanel.openTopTab("my-work");
-      cy.openSection("my-work", "workspaces");
-      resourcesPanel.getCanvasItemTitle("my-work","workspaces").contains('Investigation Copy').should('not.exist');
-    });
-    it('verify original investigation canvas still exist after copy delete', function () {
-      resourcesPanel.getCanvasItemTitle("my-work","workspaces").contains('Drawing Wumps').should('be.visible');
-    });
-    it('verify that original personal workspace is not deleted when copy is deleted', function () {
-      resourcesPanel.openTopTab("my-work");
-      cy.openDocumentWithTitle('my-work', 'workspaces', renameTitlePencil);
-      canvas.deleteDocument();
-      resourcesPanel.openTopTab("my-work");
-      cy.openSection("my-work", "workspaces");
-      resourcesPanel.getCanvasItemTitle("my-work","workspaces").contains(renameTitlePencil).should('not.exist');
+    cy.log('verifies copy of investigation');
+    let investigationTitle = 'Investigation Copy';
+    canvas.copyDocument(investigationTitle);
+    canvas.getPersonalDocTitle().should('contain', investigationTitle);
+    resourcesPanel.openTopTab("my-work");
+    cy.openSection('my-work', "workspaces");
+    resourcesPanel.getCanvasItemTitle('my-work', 'workspaces').should('contain', investigationTitle);
+  
+    cy.log('test 4up view');
+    cy.openDocumentWithTitle('my-work', 'workspaces', title);
 
-    });
-    it('verify delete of personal workspace', function () {
-      resourcesPanel.openTopTab("my-work");
-      cy.openDocumentWithTitle('my-work', 'workspaces', studentWorkspace);
-      canvas.deleteDocument();
-      resourcesPanel.openTopTab("my-work");
-      cy.openSection("my-work", "workspaces");
-      resourcesPanel.getCanvasItemTitle("my-work","workspaces").contains(studentWorkspace).should('not.exist');
-    });
-    it('verify starred document is no longer in the Starred section after delete', function () {
-      cy.openSection('my-work', 'starred');
-      cy.getCanvasItemTitle('my-work', 'starred').should('not.exist');
-    });
-  });
-});
+    cy.log('verifies views button changes when clicked and shows the correct corresponding workspace view');
+    //1-up view has 4-up button visible and 1-up canvas
+    clueCanvas.getFourUpViewToggle().should('be.visible');
+    canvas.getSingleCanvas().should('be.visible');
+    clueCanvas.getFourUpView().should('not.exist');
+    clueCanvas.openFourUpView();
+    //4-up view is visible and 1-up button is visible
+    clueCanvas.getFourToOneUpViewToggle().should('be.visible');
+    clueCanvas.getNorthEastCanvas().should('be.visible');
+    clueCanvas.getNorthWestCanvas().should('be.visible');
+    clueCanvas.getSouthEastCanvas().should('be.visible');
+    clueCanvas.getSouthEastCanvas().should('be.visible');
 
-describe("Canvas unit config test", function () {
-  before(function () {
-    cy.visit("??appMode=qa&fakeClass=5&fakeUser=student:5&fakeOffering=5&problem=3.3&qaGroup=5&unit=example-no-group-share");
-    cy.waitForLoad();
-  });
+    //can get back to 1 up view from 4 up
+    clueCanvas.openOneUpViewFromFourUp();
+    canvas.getSingleCanvas().should('be.visible');
+    clueCanvas.getFourUpViewToggle().should('be.visible');
+    clueCanvas.getFourUpView().should('not.exist');
 
-  it("verify group section in header is not visible when unit is configured to auto assign students to groups", function () {
+    cy.log('verify share button');
+    clueCanvas.getShareButton().should('be.visible');
+    clueCanvas.getShareButton().should('have.class', 'private');
+    clueCanvas.shareCanvas();
+    clueCanvas.getShareButton().should('be.visible');
+    clueCanvas.getShareButton().should('have.class', 'public');
+    clueCanvas.unshareCanvas();
+    clueCanvas.getShareButton().should('be.visible');
+    clueCanvas.getShareButton().should('have.class', 'private');
+
+    cy.log('will drag the center point and verify that canvases resize');
+    clueCanvas.openFourUpView();
+    cy.get('.four-up .center')
+      .trigger('dragstart')
+      .trigger('mousemove', 100, 250, { force: true })
+      .trigger('drop');
+    clueCanvas.openOneUpViewFromFourUp(); //clean up
+  
+    cy.log('test the tool palette');
+    //This should test the tools in the tool shelf
+    // Tool palettes for Graph, Image, Draw,and Table are tested in respective tool spec test
+    //Selection tool is tested as a functionality of graph tool tiles
+
+    cy.log('adds text tool');
+    clueCanvas.addTile('text');
+    textToolTile.getTextTile().should('exist');
+    textToolTile.enterText('This is the Investigation ' + title);
+    clueCanvas.exportTileAndDocument('text-tool-tile');
+
+    cy.log('adds a graph tool');
+    clueCanvas.addTile('geometry');
+    graphToolTile.getGraphTile().should('exist');
+    // clueCanvas.exportTileAndDocument('geometry-tool-tile');
+    // in case we created a point while exporting
+    cy.get('.primary-workspace .geometry-toolbar .button.delete').click({ force: true });
+
+    cy.log('adds an image tool');
+    clueCanvas.addTile('image');
+    imageToolTile.getImageTile().should('exist');
+    // clueCanvas.exportTileAndDocument('image-tool-tile');
+
+    cy.log('adds a draw tool');
+    clueCanvas.addTile('drawing');
+    drawToolTile.getDrawTile().should('exist');
+    // clueCanvas.exportTileAndDocument('drawing-tool-tile');
+
+    cy.log('adds a table tool');
+    clueCanvas.addTile('table');
+    tableToolTile.getTableTile().should('exist');
+    // clueCanvas.exportTileAndDocument('table-tool-tile');
+
+    cy.log('verifies scrolling');
+    graphToolTile.getGraphTile().scrollIntoView();
+    textToolTile.getTextTile().first().scrollIntoView();
+
+    // TODO:4-up view canvas selector does not work in cypress even though it works in Chrome. it currently selects the entire canvas and not the scaled one
+    // cy.log('verifies scrolling in 4up view');
+    // canvas.openFourUpView();
+    // canvas.scrollToBottom(canvas.getNorthWestCanvas());
+    // cy.get('.single-workspace > .document> .canvas-area > .four-up > .canvas-container.north-west >.canvas-scaler >.canvas').scrollTo('bottom');
+    // canvas.getGraphTile().last().should('be.visible');
+    // canvas.getSouthWestCanvas().should('be.visible');
+    // canvas.openOneUpViewFromFourUp(); //clean up
+
+    cy.log('save and restore of tool tiles');
+
+    cy.log('will restore from My Work/Workspaces tab');
+    //Open personal workspace
+    resourcesPanel.openTopTab("my-work");
+    cy.openDocumentWithTitle('my-work', 'workspaces', studentWorkspace);
+    canvas.getPersonalDocTitle().should('contain', studentWorkspace);
+    graphToolTile.getGraphTile().should('be.visible');
+    tableToolTile.getTableTile().should('be.visible');
+    textToolTile.getTextTile().should('be.visible').and('contain', studentWorkspace);
+
+    cy.log('will restore from My Work/Investigation tab');
+    //Open Investigation
+    resourcesPanel.openTopTab("my-work");
+    cy.openDocumentWithTitle('my-work', 'workspaces', title);
+    clueCanvas.getInvestigationCanvasTitle().should('contain', title);
+    textToolTile.getTextTile().should('be.visible').and('contain', title);
+    graphToolTile.getGraphTile().should('exist');
+    drawToolTile.getDrawTile().should('exist');
+    imageToolTile.getImageTile().should('exist');
+    tableToolTile.getTableTile().should('exist');
+
+    cy.log('verify that if user leaves a canvas in four-up view, restore is also in four up view');
+    clueCanvas.openFourUpView();//for later test on restore of 4up view
+    clueCanvas.getNorthWestCanvas().should('be.visible');
+
+    cy.log('verify restore in 4 up view from Extra Workspace');
+    //Open Personal Workspace
+    resourcesPanel.openTopTab("my-work");
+    cy.openDocumentWithTitle('my-work', 'workspaces', studentWorkspace);
+    canvas.getPersonalDocTitle().should('contain', studentWorkspace);
+
+    cy.log('verify restore in 4 up view from Investigation');
+    //Open Investigation should be in 4up view
+    resourcesPanel.openTopTab("my-work");
+    cy.openDocumentWithTitle('my-work', 'workspaces', title);
+    clueCanvas.getInvestigationCanvasTitle().should('contain', title);
+    clueCanvas.getNorthWestCanvas().should('be.visible');
+
+    clueCanvas.openOneUpViewFromFourUp();
+  
+    cy.log('delete elements from canvas');
+    //star a document to verify delete
+    cy.openSection("my-work", "workspaces");
+    cy.get('.list.workspaces [data-test=workspaces-list-items] .footer').contains(renameTitlePencil).parents().siblings('.icon-holder').find('.icon-star').click();
+    cy.openDocumentWithTitle('my-work', 'workspaces', 'SAS 2.1 Drawing Wumps');
+
+    cy.log('will delete elements from canvas');
+    // Delete elements in the canvas
+    clueCanvas.deleteTile('graph');
+    clueCanvas.deleteTile('image');
+    clueCanvas.deleteTile('draw');
+    clueCanvas.deleteTile('table');
+    clueCanvas.deleteTile('text');
+    clueCanvas.deleteTile('text');
+    textToolTile.getTextTile().should('not.exist');
+    graphToolTile.getGraphTile().should('not.exist');
+    drawToolTile.getDrawTile().should('not.exist');
+    imageToolTile.getImageTile().should('not.exist');
+    tableToolTile.getTableTile().should('not.exist');
+
+    cy.log('Dragging elements from different locations to canvas');
+    cy.log('Drag element from left nav');
+    const dataTransfer = new DataTransfer;
+    cy.log('will drag image from resource panel to canvas')
+    resourcesPanel.openTopTab('problems');
+    resourcesPanel.openBottomTab("Now What Do You Know?");
+    resourcesPanel.getResourcesPanelExpandedSpace().find('.image-tool').first()
+      .trigger('dragstart', { dataTransfer });
+    cy.get('.single-workspace .canvas .document-content').first()
+      .trigger('drop', { force: true, dataTransfer });
+    resourcesPanel.getResourcesPanelExpandedSpace().find('.image-tool').first()
+      .trigger('dragend');
+    imageToolTile.getImageTile().should('exist');
+    imageToolTile.getImageTile().find('.editable-tile-title-text').contains('Did You Know?: Images in computer graphics');
+    clueCanvas.deleteTile('image');
+
+    cy.log('will maintain positioning when copying multiple tiles');
+    resourcesPanel.openBottomTab("Initial Challenge");
+    const leftTile = type => cy.get(`.nav-tab-panel .problem-panel .${type}-tool-tile`);
+
+    // Select three table tiles on the left
+    leftTile('table').first().click({ shiftKey: true });
+    leftTile('table').eq(1).click({ shiftKey: true });
+    leftTile('table').eq(2).click({ shiftKey: true });
+
+    // Drag the selected copies to the workspace on the right
+    leftTile('table').eq(2).trigger('dragstart', { dataTransfer });
+    cy.get('.single-workspace .canvas .document-content').first()
+      .trigger('drop', { force: true, dataTransfer });
+
+    // Make sure the tiles were copied in the correct order
+    tableToolTile.getTableTile().first().find('.editable-header-cell').contains('Mug Wump');
+    tableToolTile.getTableTile().eq(1).find('.editable-header-cell').contains('Mug Wump Part 2');
+    tableToolTile.getTableTile().eq(2).find('.editable-header-cell').contains('Mug Wump Part 3');
+
+    // Clean up
+    clueCanvas.deleteTile('table');
+    clueCanvas.deleteTile('table');
+    clueCanvas.deleteTile('table');
+
+    cy.log('will copy a single table tile from resources to canvas');
+    resourcesPanel.openBottomTab("Initial Challenge");
+    // const leftTile = type => cy.get(`.nav-tab-panel .problem-panel .${type}-tool-tile`);
+
+    // Select one table tile on the left
+    leftTile('table').first().click();
+
+    // Drag the selected copies to the workspace on the right
+    leftTile('table').first().trigger('dragstart', { dataTransfer });
+    cy.get('.single-workspace .canvas .document-content').first()
+      .trigger('drop', { force: true, dataTransfer });
+
+    // Make sure the tiles were copied in the correct order
+    tableToolTile.getTableTile().first().find('.editable-header-cell').contains('Mug Wump');
+
+    // Clean up
+    clueCanvas.deleteTile('table');
+  
+    cy.log('delete workspaces');
+
+    cy.log('verify delete of copy of investigation');
+    resourcesPanel.openTopTab("my-work");
+    cy.openDocumentWithTitle('my-work', 'workspaces', 'Investigation Copy');
+    canvas.deleteDocument();
+    resourcesPanel.openTopTab("my-work");
+    cy.openSection("my-work", "workspaces");
+    resourcesPanel.getCanvasItemTitle("my-work", "workspaces").contains('Investigation Copy').should('not.exist');
+
+    cy.log('verify original investigation canvas still exist after copy delete');
+    resourcesPanel.getCanvasItemTitle("my-work", "workspaces").contains('Drawing Wumps').should('be.visible');
+
+    cy.log('verify that original personal workspace is not deleted when copy is deleted');
+    resourcesPanel.openTopTab("my-work");
+    cy.openDocumentWithTitle('my-work', 'workspaces', renameTitlePencil);
+    canvas.deleteDocument();
+    resourcesPanel.openTopTab("my-work");
+    cy.openSection("my-work", "workspaces");
+    resourcesPanel.getCanvasItemTitle("my-work", "workspaces").contains(renameTitlePencil).should('not.exist');
+
+    cy.log('verify delete of personal workspace');
+    resourcesPanel.openTopTab("my-work");
+    cy.openDocumentWithTitle('my-work', 'workspaces', studentWorkspace);
+    canvas.deleteDocument();
+    resourcesPanel.openTopTab("my-work");
+    cy.openSection("my-work", "workspaces");
+    resourcesPanel.getCanvasItemTitle("my-work", "workspaces").contains(studentWorkspace).should('not.exist');
+
+    cy.log('verify starred document is no longer in the Starred section after delete');
+    cy.openSection('my-work', 'starred');
+    cy.getCanvasItemTitle('my-work', 'starred').should('not.exist');
+
+    cy.log("Canvas unit config test");
+    beforeTest(queryParams2);
+
+    cy.log("verify group section in header is not visible when unit is configured to auto assign students to groups");
     cy.get(".app-header .right .group").should("not.exist");
-  });
-  it("verify publish button is not visible when publish is disabled", function () {
+
+    cy.log("verify publish button is not visible when publish is disabled");
     cy.get(".icon-button.icon-publish").should("not.exist");
-  });
-});
 
-// This is using an intentionally broken document.
-// Info about this document can be found here: src/test-fixtures/broken-doc-content.md
-describe("Canvas document error test", function () {
-  before(function () {
-    cy.visit("?appMode=demo&demoName=BrokenDocs&fakeClass=1&fakeUser=student:1&unit=sas&problem=0.1");
-    cy.waitForLoad();
-  });
+    // This is using an intentionally broken document.
+    // Info about this document can be found here: src/test-fixtures/broken-doc-content.md
+    cy.log("Canvas document error test");
+    beforeTest(queryParams3);
 
-  it("verify an error message is shown", function () {
+    cy.log("verify an error message is shown");
     cy.get('[data-test="document-title"]').should("contain", "0.1 Intro to CLUE");
     cy.get(".document-error").should("exist");
   });

--- a/cypress/e2e/clue/branch/student_tests/data_card_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/data_card_tool_spec.js
@@ -6,121 +6,123 @@ let clueCanvas = new ClueCanvas;
 let dc = new DataCardToolTile;
 let xyplot = new XYPlotToolTile;
 
-context('Data Card Tool Tile', function () {
-  before(function () {
-    const queryParams = "?appMode=qa&fakeClass=5&fakeUser=student:5&qaGroup=5&unit=moth";
-    cy.clearQAData('all');
-    cy.visit(queryParams);
-    cy.waitForLoad();
-  });
-  describe("Data Card Tool", () => {
-    it("renders Data Card tool tile", () => {
-      clueCanvas.addTile("datacard");
-      dc.getTile().should("exist");
-    });
-    it("has a default title", () => {
-      dc.getTile().contains("Data Card Collection");
-    });
-    it("can create a new attribute", () => {
-      dc.getAttrName().dblclick().type("Attr1 Name{enter}");
-      dc.getAttrName().contains("Attr1 Name");
-    });
-    it("can add a value to an attribute", () => {
-      dc.getAttrValue().click().type("ocean{enter}");
-      dc.getTile().click();
-      dc.getAttrValueInput().invoke('val').should('eq', "ocean");
-    });
-    it("can toggle between single and sort views", () => {
-      dc.getSingleCardView().should('exist');
-      dc.getSortSelect().select("Attr1 Name");
-      dc.getSortView().should('exist');
-      dc.getSortSelect().select("None");
-      dc.getSingleCardView().should('exist');
-    });
-    it("has attribute names that stay in sync on sort menu and card", () => {
-      dc.getAttrName().dblclick().type("habitat{enter}");
-      dc.getAttrName().contains("habitat");
-      dc.getSortSelect().select("habitat");
-      dc.getSortView().should('exist');
-      dc.getSortSelect().select("None");
-      dc.getSingleCardView().should('exist');
-    });
-    it("can add new cards", () =>{
+function beforeTest() {
+  const queryParams = "?appMode=qa&fakeClass=5&fakeUser=student:5&qaGroup=5&unit=moth";
+  cy.clearQAData('all');
+  cy.visit(queryParams);
+  cy.waitForLoad();
+}
+
+context('Data Card Tool Tile', () => {
+  it("Data Card Tool", () => {
+    beforeTest();
+
+    cy.log("renders Data Card tool tile");
+    clueCanvas.addTile("datacard");
+    dc.getTile().should("exist");
+
+    cy.log("has a default title");
+    dc.getTile().contains("Data Card Collection");
+
+    cy.log("can create a new attribute");
+    dc.getAttrName().dblclick().type("Attr1 Name{enter}");
+    dc.getAttrName().contains("Attr1 Name");
+
+    cy.log("can add a value to an attribute");
+    dc.getAttrValue().click().type("ocean{enter}");
+    dc.getTile().click();
+    dc.getAttrValueInput().invoke('val').should('eq', "ocean");
+
+    cy.log("can toggle between single and sort views");
+    dc.getSingleCardView().should('exist');
+    dc.getSortSelect().select("Attr1 Name");
+    dc.getSortView().should('exist');
+    dc.getSortSelect().select("None");
+    dc.getSingleCardView().should('exist');
+
+    cy.log("has attribute names that stay in sync on sort menu and card");
+    dc.getAttrName().dblclick().type("habitat{enter}");
+    dc.getAttrName().contains("habitat");
+    dc.getSortSelect().select("habitat");
+    dc.getSortView().should('exist');
+    dc.getSortSelect().select("None");
+    dc.getSingleCardView().should('exist');
+
+    cy.log("can add new cards");
       dc.getSortSelect().select("None");
       dc.getAddCardButton().click();
       dc.getCardNofTotalListing().contains("Card 2 of 2");
       dc.getAddCardButton().click();
       dc.getCardNofTotalListing().contains("Card 3 of 3");
-    });
-    it("can advance from card to card in both directions", () =>{
-      dc.getPreviousCardButton().click();
-      dc.getCardNofTotalListing().contains("Card 2 of 3");
-      dc.getNextCardButton().click();
-      dc.getCardNofTotalListing().contains("Card 3 of 3");
-    });
-    it("can delete a card", () => {
-      dc.getDeleteCardButton().click();
-      cy.wait(100);
-      dc.getDeleteCardButton().click();
-      cy.wait(100);
-      dc.getCardNofTotalListing().contains("Card 1 of 1");
-    });
-    it("can expand and collapse a card in sort view", () =>{
-      dc.getSortSelect().select("habitat");
-      dc.getSortView().should('exist');
-      dc.getSortCardCollapseToggle().click();
-      dc.getSortCardData().should('not.exist');
-      dc.getSortCardCollapseToggle().click();
-      dc.getSortCardData().should('exist');
-    });
-    it("can add a second attribute and give it a value", () => {
-      dc.getSortSelect().select("None");
-      dc.getAddAttributeButton().click();
-      dc.getAttrName().eq(1).dblclick().type("animal{enter}");
-      dc.getAttrName().eq(1).contains("animal");
-      dc.getAttrValue().eq(1).click().type("whale{enter}");
-      dc.getAttrValueInput().eq(1).invoke('val').should('eq', 'whale');
-    });
-    it("should resize when attributes are added", () => {
-      dc.getAddAttributeButton().click();
-      dc.getAddAttributeButton().click();
-      dc.getAddAttributeButton().click();
-      dc.getAddAttributeButton().click();
-      dc.getAttrName().eq(5).contains("Label 4");
-      dc.getAttrName().eq(5).should('be.visible');
-    });
-    it("shows type-ahead options using existing values for current attribute only", () => {
-      dc.getAddCardButton().click();
-      dc.getAttrValue().eq(0).click().type("desert{enter}");
-      dc.getAttrValueInput().eq(0).invoke('val').should('eq', 'desert');
-      dc.getAttrValue().eq(1).click().type("camel{enter}");
-      dc.getAttrValueInput().eq(1).invoke('val').should('eq', 'camel');
-      dc.getAttrValue().eq(0).click().type("{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}");
-      dc.getDownshiftOptions().should('have.length', 2);
-      dc.getDownshiftOptions().eq(0).contains("desert");
-      dc.getDownshiftOptions().eq(1).contains("ocean");
-      dc.getAttrValueInput().eq(0).click().type("d");
-      dc.getDownshiftOptions().should('have.length', 1);
-      dc.getDownshiftOptions().eq(0).contains("desert");
-    });
-    it("can create a graph from the data", () => {
-      dc.getLinkGraphButton().should('not.be.disabled').click();
-      dc.getLinkGraphModalCreateNewButton().click();
-      xyplot.getTile().should("exist").contains("Data Card Collection 1");
-      xyplot.getXYPlotTitle().should("contain", "Data Card Collection 1");
-      xyplot.getXAxisLabel().should("contain", "habitat");
-    });
-    it("can link and unlink data from a graph", () => {
-      // Unlink
-      dc.getLinkGraphButton().should('not.be.disabled').click();
-      dc.getLinkGraphModalTileMenu().select('Data Card Collection 1');
-      dc.getLinkGraphModalLinkButton().should("contain", "Unlink").click();
-      xyplot.getXAxisLabel().should("not.contain", "habitat");
-      // Re-link
-      dc.getLinkGraphButton().should('not.be.disabled').click();
-      dc.getLinkGraphModalTileMenu().select('Data Card Collection 1');
-      dc.getLinkGraphModalLinkButton().should("contain", "Link").click();
-      xyplot.getXAxisLabel().should("contain", "habitat");
-    });
-  });
-});
+
+      cy.log("can advance from card to card in both directions");
+        dc.getPreviousCardButton().click();
+        dc.getCardNofTotalListing().contains("Card 2 of 3");
+        dc.getNextCardButton().click();
+        dc.getCardNofTotalListing().contains("Card 3 of 3");
+
+        cy.log("can delete a card");
+        dc.getDeleteCardButton().click();
+        cy.wait(100);
+        dc.getDeleteCardButton().click();
+        cy.wait(100);
+        dc.getCardNofTotalListing().contains("Card 1 of 1");
+
+        cy.log("can expand and collapse a card in sort view");
+          dc.getSortSelect().select("habitat");
+          dc.getSortView().should('exist');
+          dc.getSortCardCollapseToggle().click();
+          dc.getSortCardData().should('not.exist');
+          dc.getSortCardCollapseToggle().click();
+          dc.getSortCardData().should('exist');
+
+          cy.log("can add a second attribute and give it a value");
+          dc.getSortSelect().select("None");
+          dc.getAddAttributeButton().click();
+          dc.getAttrName().eq(1).dblclick().type("animal{enter}");
+          dc.getAttrName().eq(1).contains("animal");
+          dc.getAttrValue().eq(1).click().type("whale{enter}");
+          dc.getAttrValueInput().eq(1).invoke('val').should('eq', 'whale');
+
+          cy.log("should resize when attributes are added");
+          dc.getAddAttributeButton().click();
+          dc.getAddAttributeButton().click();
+          dc.getAddAttributeButton().click();
+          dc.getAddAttributeButton().click();
+          dc.getAttrName().eq(5).contains("Label 4");
+          dc.getAttrName().eq(5).should('be.visible');
+
+          cy.log("shows type-ahead options using existing values for current attribute only");
+          dc.getAddCardButton().click();
+          dc.getAttrValue().eq(0).click().type("desert{enter}");
+          dc.getAttrValueInput().eq(0).invoke('val').should('eq', 'desert');
+          dc.getAttrValue().eq(1).click().type("camel{enter}");
+          dc.getAttrValueInput().eq(1).invoke('val').should('eq', 'camel');
+          dc.getAttrValue().eq(0).click().type("{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}");
+          dc.getDownshiftOptions().should('have.length', 2);
+          dc.getDownshiftOptions().eq(0).contains("desert");
+          dc.getDownshiftOptions().eq(1).contains("ocean");
+          dc.getAttrValueInput().eq(0).click().type("d");
+          dc.getDownshiftOptions().should('have.length', 1);
+          dc.getDownshiftOptions().eq(0).contains("desert");
+
+          cy.log("can create a graph from the data");
+          dc.getLinkGraphButton().should('not.be.disabled').click();
+          dc.getLinkGraphModalCreateNewButton().click();
+          xyplot.getTile().should("exist").contains("Data Card Collection 1");
+          xyplot.getXYPlotTitle().should("contain", "Data Card Collection 1");
+          xyplot.getXAxisLabel().should("contain", "habitat");
+
+          cy.log("can link and unlink data from a graph");
+          // Unlink
+          dc.getLinkGraphButton().should('not.be.disabled').click();
+          dc.getLinkGraphModalTileMenu().select('Data Card Collection 1');
+          dc.getLinkGraphModalLinkButton().should("contain", "Unlink").click();
+          xyplot.getXAxisLabel().should("not.contain", "habitat");
+          // Re-link
+          dc.getLinkGraphButton().should('not.be.disabled').click();
+          dc.getLinkGraphModalTileMenu().select('Data Card Collection 1');
+          dc.getLinkGraphModalLinkButton().should("contain", "Link").click();
+          xyplot.getXAxisLabel().should("contain", "habitat");
+        });
+      });

--- a/cypress/e2e/clue/branch/student_tests/datacard_merge_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/datacard_merge_spec.js
@@ -25,7 +25,7 @@ function openMyWork() {
 }
 
 context('Merge Data Card Tool Tile', function () {
-  it("can merge in data using the merge button", () => {
+  it("Merge Data Card Tool Tile", () => {
     beforeTest();
     clueCanvas.addTile("datacard");
     dc.getTile(0).should("exist");
@@ -54,8 +54,8 @@ context('Merge Data Card Tool Tile', function () {
     dc.getAttrName(1).eq(1).should("have.text", "animal");
     dc.getNextCardButton(1).click();
     dc.getAttrValue(1).eq(1).invoke("attr", "value").should("contain", "cat");
-  });
-  it("merges two empty Data Card tool tiles", () => {
+  
+    cy.log("merges two empty Data Card tool tiles");
     beforeTest();
     clueCanvas.addTile("datacard");
     dc.getTile(0).should("exist");
@@ -84,8 +84,8 @@ context('Merge Data Card Tool Tile', function () {
     dc.getAttrName(1).should("have.text", "Label 1");
     dc.getPreviousCardButton(1).click();
     dc.getCardNofTotalListing(1).should("have.text", "Card 1 of 2");
-  });
-  it("merges filled-in into empty Data Card tool tile", () => {
+  
+    cy.log("merges filled-in into empty Data Card tool tile");
     beforeTest();
     clueCanvas.addTile("datacard");
     dc.getTile(0).should("exist");
@@ -126,8 +126,8 @@ context('Merge Data Card Tool Tile', function () {
     dc.getAttrValue(1).eq(1).invoke("attr", "value").should("contain", "Attr1 Value");
     dc.getPreviousCardButton(1).click();
     dc.getCardNofTotalListing(1).should("have.text", "Card 1 of 2");
-  });
-  it("merges empty into filled-in Data Card tool tile", () => {
+  
+    cy.log("merges empty into filled-in Data Card tool tile");
     beforeTest();
     clueCanvas.addTile("datacard");
     dc.getTile(0).should("exist");
@@ -168,8 +168,8 @@ context('Merge Data Card Tool Tile', function () {
     dc.getAttrValue(1).eq(1).invoke("attr", "value").should("be.empty");
     dc.getPreviousCardButton(1).click();
     dc.getCardNofTotalListing(1).should("have.text", "Card 1 of 2");
-  });
-  it("merges two filled-in Data Card tool tiles", () => {
+  
+    cy.log("merges two filled-in Data Card tool tiles");
     beforeTest();
     clueCanvas.addTile("datacard");
     dc.getTile(0).should("exist");
@@ -214,8 +214,8 @@ context('Merge Data Card Tool Tile', function () {
     dc.getAttrValue(1).eq(1).invoke("attr", "value").should("contain", "Attr1 Value");
     dc.getPreviousCardButton(1).click();
     dc.getCardNofTotalListing(1).should("have.text", "Card 1 of 2");
-  });
-  it("merges datacards with same attribute labels", () => {
+  
+    cy.log("merges datacards with same attribute labels");
     beforeTest();
     clueCanvas.addTile("datacard");
     dc.getTile(0).should("exist");

--- a/cypress/e2e/clue/branch/student_tests/dataflow_table_integration_test_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/dataflow_table_integration_test_spec.js
@@ -7,15 +7,15 @@ let dataflowToolTile = new DataflowToolTile;
 let tableTile = new TableToolTile;
 const tableTitle = "Table 1";
 const programTitle = "Program 1";
-const programNodes = [{ name: "timer", title: "Timer (on/off)", attribute: "Timer 1"},
-                      { name: "demo-output", title: "Demo Output", attribute: "Demo Output 2"}];
-const linkedTableAttributes = [ "Time (sec)", programNodes[0].attribute, programNodes[1].attribute ];
+const programNodes = [{ name: "timer", title: "Timer (on/off)", attribute: "Timer 1" },
+{ name: "demo-output", title: "Demo Output", attribute: "Demo Output 2" }];
+const linkedTableAttributes = ["Time (sec)", programNodes[0].attribute, programNodes[1].attribute];
 const defaultTableAttributes = ["x", "y"];
 const timer1 = 5;
 const timer2 = 3;
 
 
-function setupInitialLoading() {
+function beforeTest() {
   const queryParams = "?appMode=qa&fakeClass=5&fakeUser=student:5&qaGroup=5&unit=dfe&mouseSensor";
   cy.clearQAData('all');
   cy.visit(queryParams);
@@ -25,87 +25,98 @@ function setupInitialLoading() {
 
 // FIXME: this test seems to be causing cypress timeouts.
 context.skip('Dataflow Tool Tile', function () {
-  describe("Link table with Recorded Data", () => {
-    beforeEach("create a small program, select sampling rate and record data", () => {
-      setupInitialLoading();
-      clueCanvas.addTile("dataflow");
-      dataflowToolTile.createProgram(programNodes);
-      dataflowToolTile.checkInitialStateButtons();
-      dataflowToolTile.recordData("1000", timer1);
-      clueCanvas.addTile("table");
-      cy.linkTableToDataflow(programTitle, tableTitle);
-    });
-    it("verify link table from dataflow with recorded data", () => {
-      dataflowToolTile.checkLinkedTableRecordedData(tableTile, tableTitle, linkedTableAttributes, timer1);
+  it("Link table with Recorded Data", () => {
+    beforeTest();
 
-      dataflowToolTile.clearRecordedData();
-      dataflowToolTile.checkEmptyLinkedTable(tableTile, tableTitle, defaultTableAttributes);
+    cy.log("create a small program, select sampling rate and record data");
+    clueCanvas.addTile("dataflow");
+    dataflowToolTile.createProgram(programNodes);
+    dataflowToolTile.checkInitialStateButtons();
+    dataflowToolTile.recordData("1000", timer1);
+    clueCanvas.addTile("table");
+    cy.linkTableToDataflow(programTitle, tableTitle);
 
-      dataflowToolTile.recordData("1000", timer2);
-      dataflowToolTile.checkLinkedTableRecordedData(tableTile, tableTitle, linkedTableAttributes, timer2);
+    cy.log("verify link table from dataflow with recorded data");
+    dataflowToolTile.checkLinkedTableRecordedData(tableTile, tableTitle, linkedTableAttributes, timer1);
 
-      cy.unlinkTableToDataflow("Program 1", "Table 1");
-      dataflowToolTile.checkEmptyLinkedTable(tableTile, tableTitle, defaultTableAttributes);
+    dataflowToolTile.clearRecordedData();
+    dataflowToolTile.checkEmptyLinkedTable(tableTile, tableTitle, defaultTableAttributes);
 
-      cy.linkTableToDataflow(programTitle, tableTitle);
-      dataflowToolTile.checkLinkedTableRecordedData(tableTile, tableTitle, linkedTableAttributes, timer2);
+    dataflowToolTile.recordData("1000", timer2);
+    dataflowToolTile.checkLinkedTableRecordedData(tableTile, tableTitle, linkedTableAttributes, timer2);
 
-      dataflowToolTile.clearRecordedData();
-      dataflowToolTile.checkEmptyLinkedTable(tableTile, tableTitle, defaultTableAttributes);
-    });
-    it("verify the effect of page reload cause on various button states and linked table state", () => {
-      // record data
-      dataflowToolTile.clearRecordedData();
-      dataflowToolTile.recordDataWithoutStop("1000", timer2);
+    cy.unlinkTableToDataflow("Program 1", "Table 1");
+    dataflowToolTile.checkEmptyLinkedTable(tableTile, tableTitle, defaultTableAttributes);
 
-      // reload while recording
-      cy.reload();
+    cy.linkTableToDataflow(programTitle, tableTitle);
+    dataflowToolTile.checkLinkedTableRecordedData(tableTile, tableTitle, linkedTableAttributes, timer2);
 
-      // check buttons after reload
-      dataflowToolTile.checkRecordedStateButtons();
-      dataflowToolTile.checkLinkedTableRecordedData(tableTile, tableTitle, linkedTableAttributes, timer2);
+    dataflowToolTile.clearRecordedData();
+    dataflowToolTile.checkEmptyLinkedTable(tableTile, tableTitle, defaultTableAttributes);
 
-      // play recorded data
-      dataflowToolTile.clickPlayButton();
+  });
+  it("verify the effect of page reload cause on various button states and linked table state", () => {
+    beforeTest();
 
-      // reload while playing
-      cy.reload();
+    cy.log("create a small program, select sampling rate and record data");
+    clueCanvas.addTile("dataflow");
+    dataflowToolTile.createProgram(programNodes);
+    dataflowToolTile.checkInitialStateButtons();
+    dataflowToolTile.recordData("1000", timer1);
+    clueCanvas.addTile("table");
+    cy.linkTableToDataflow(programTitle, tableTitle);
 
-      // check buttons after reload
-      dataflowToolTile.checkRecordedStateButtons();
-      dataflowToolTile.checkLinkedTableRecordedData(tableTile, tableTitle, linkedTableAttributes, timer2);
+    // record data
+    dataflowToolTile.clearRecordedData();
+    dataflowToolTile.recordDataWithoutStop("1000", timer2);
 
-      // pause recorded data
-      dataflowToolTile.clickPlayButton();
-      cy.wait(1000);
-      dataflowToolTile.clickPauseButton();
+    // reload while recording
+    cy.reload();
 
-      // reload while in pause
-      cy.reload();
+    // check buttons after reload
+    dataflowToolTile.checkRecordedStateButtons();
+    dataflowToolTile.checkLinkedTableRecordedData(tableTile, tableTitle, linkedTableAttributes, timer2);
 
-      // check buttons after reload
-      dataflowToolTile.checkRecordedStateButtons();
-      dataflowToolTile.checkLinkedTableRecordedData(tableTile, tableTitle, linkedTableAttributes, timer2);
+    // play recorded data
+    dataflowToolTile.clickPlayButton();
 
-      // click clear
-      dataflowToolTile.getRecordingClearButton().click();
+    // reload while playing
+    cy.reload();
 
-      // reload before confirming clear
-      cy.reload();
+    // check buttons after reload
+    dataflowToolTile.checkRecordedStateButtons();
+    dataflowToolTile.checkLinkedTableRecordedData(tableTile, tableTitle, linkedTableAttributes, timer2);
 
-      // check buttons after reload
-      dataflowToolTile.checkRecordedStateButtons();
-      dataflowToolTile.checkLinkedTableRecordedData(tableTile, tableTitle, linkedTableAttributes, timer2);
+    // pause recorded data
+    dataflowToolTile.clickPlayButton();
+    cy.wait(1000);
+    dataflowToolTile.clickPauseButton();
 
-      // record data
-      dataflowToolTile.clearRecordedData();
+    // reload while in pause
+    cy.reload();
 
-      // reload after confirming clear
-      // cy.reload();
+    // check buttons after reload
+    dataflowToolTile.checkRecordedStateButtons();
+    dataflowToolTile.checkLinkedTableRecordedData(tableTile, tableTitle, linkedTableAttributes, timer2);
 
-      // check buttons after reload
-      dataflowToolTile.checkInitialStateButtons();
-      dataflowToolTile.checkEmptyLinkedTable(tableTile, tableTitle, defaultTableAttributes);
-    });
+    // click clear
+    dataflowToolTile.getRecordingClearButton().click();
+
+    // reload before confirming clear
+    cy.reload();
+
+    // check buttons after reload
+    dataflowToolTile.checkRecordedStateButtons();
+    dataflowToolTile.checkLinkedTableRecordedData(tableTile, tableTitle, linkedTableAttributes, timer2);
+
+    // record data
+    dataflowToolTile.clearRecordedData();
+
+    // reload after confirming clear
+    // cy.reload();
+
+    // check buttons after reload
+    dataflowToolTile.checkInitialStateButtons();
+    dataflowToolTile.checkEmptyLinkedTable(tableTile, tableTitle, defaultTableAttributes);
   });
 });

--- a/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/dataflow_tool_spec.js
@@ -5,623 +5,624 @@ let clueCanvas = new ClueCanvas;
 let dataflowToolTile = new DataflowToolTile;
 let dragXDestination = 300;
 
+function beforeTest() {
+  const url = "./doc-editor.html?appMode=qa&unit=./curriculum/example-curriculum/example-curriculum.json&mouseSensor";
+  cy.visit(url);
+}
 context('Dataflow Tool Tile', function () {
-  before(function () {
-    const url = "./doc-editor.html?appMode=qa&unit=./curriculum/example-curriculum/example-curriculum.json&mouseSensor";
-    cy.visit(url);
+  it("Dataflow Tool and Number Node", () => {
+    beforeTest();
+
+    cy.log("renders dataflow tool tile");
+    clueCanvas.addTile("dataflow");
+    dataflowToolTile.getDataflowTile().should("exist");
+    dataflowToolTile.getTileTitle().should("exist");
+
+    cy.log("edit tile title");
+    const newName = "Dataflow Tile";
+    dataflowToolTile.getTileTitle().should("contain", "Program 1");
+    dataflowToolTile.getDataflowTileTitle().click();
+    dataflowToolTile.getDataflowTileTitle().type(newName + '{enter}');
+    dataflowToolTile.getTileTitle().should("contain", newName);
+
+    cy.log("makes link button active when table is present");
+    dataflowToolTile.getLinkTileButton().should("exist");
+    dataflowToolTile.getLinkTileButton().should("have.class", "disabled");
+    clueCanvas.addTile("table");
+    dataflowToolTile.getLinkTileButton().should("not.have.class", "disabled");
+    clueCanvas.deleteTile("table");
+
+    cy.log("Number Node");
+    const numberNode = "number";
+    cy.log("can create number node");
+
+    dataflowToolTile.getCreateNodeButton(numberNode).click();
+    dataflowToolTile.getNode(numberNode).should("exist");
+    dataflowToolTile.getNodeTitle().should("contain", "Number");
+
+    cy.log("can toggle minigraph");
+    dataflowToolTile.getShowGraphButton(numberNode).click();
+    dataflowToolTile.getMinigraph(numberNode).should("exist");
+    dataflowToolTile.getShowGraphButton(numberNode).click();
+    dataflowToolTile.getMinigraph(numberNode).should("not.exist");
+
+    cy.log("can change the number");
+    dataflowToolTile.getNumberField().type("3{enter}");
+    dataflowToolTile.getNumberField().should("have.value", "3");
+
+    //TODO: write a test that can check min and max (should be 0 and 3)
+    // could be in class .chartjs-size-monitor
+
+    cy.log("can click zoom in positive button");
+    dataflowToolTile.getShowGraphButton(numberNode).click(); //open minigraph
+    dataflowToolTile.getShowZoomInButton(numberNode).click();
+
+    cy.log("can click zoom out negative button");
+    dataflowToolTile.getShowZoomOutButton(numberNode).click();
+    dataflowToolTile.getShowGraphButton(numberNode).click(); //close minigraph
+
+    cy.log("verify node inputs outputs");
+    dataflowToolTile.getNodeInput().should("not.exist");
+    dataflowToolTile.getNodeOutput().should("exist");
+
+    cy.log("verify zoom in & out");
+    dataflowToolTile.getZoomInButton().click();
+    dataflowToolTile.getFlowtool().children().should("have.attr", "style").and("contain", "scale(1.05)");
+    dataflowToolTile.getZoomOutButton().click();
+    dataflowToolTile.getFlowtool().children().should("have.attr", "style").and("contain", "scale(1)");
+
+    cy.log("can delete number node");
+    dataflowToolTile.getDeleteNodeButton(numberNode).click();
+    dataflowToolTile.getNode(numberNode).should("not.exist");
+
+    cy.log('can create node by dragging button onto tile');
+    const draggable = () => cy.get(".program-toolbar [aria-roledescription='draggable'] button").eq(1);
+    dataflowToolTile.getNode(numberNode).should("not.exist");
+    draggable().trigger("mousedown", { force: true })
+      .wait(100)
+      .trigger("mousemove", {
+        force: true,
+        clientX: 500,
+        clientY: 200
+      })
+      .wait(100)
+      .trigger("mouseup", { force: true })
+      .wait(100);
+    // const dataTransfer = new DataTransfer;
+    // draggable().focus().trigger('dragstart', { dataTransfer });
+    // dataflowToolTile.getDataflowTile().trigger('drop', { dataTransfer });
+    // draggable().trigger('dragend');
+    dataflowToolTile.getNode(numberNode).should("exist");
+    dataflowToolTile.getDeleteNodeButton(numberNode).click();
+    dataflowToolTile.getNode(numberNode).should("not.exist");
+
+    cy.log("Manage Decimals");
+    cy.log('can create a number node and change it to a decimal');
+    // create a number node
+    dataflowToolTile.getCreateNodeButton("number").click();
+    dataflowToolTile.getNode("number").should("exist");
+    dataflowToolTile.getNodeTitle().should("contain", "Number");
+    dataflowToolTile.getNumberField().type("1.8309{enter}");
+
+    cy.log('values should be rounded to three decimals for display');
+    // create transform node and drag to the right
+    dataflowToolTile.getCreateNodeButton("transform").click();
+    dataflowToolTile.getNode("transform").should("exist");
+    dataflowToolTile.getNodeTitle().should("contain", "Transform");
+    dataflowToolTile.getNode("transform").click(50, 10)
+      .trigger("pointerdown", 50, 10)
+      .trigger("pointermove", dragXDestination, 10, { force: true })
+      .trigger("pointerup", dragXDestination, 10, { force: true });
+    cy.wait(2000);
+    // connect the number node to the transform node
+    dataflowToolTile.getNodeOutput().eq(0).click();
+    dataflowToolTile.getNodeInput().eq(0).click();
+    // verify the transform node has the correct value
+    dataflowToolTile.getNode("transform").should("contain", "1.831");
+    dataflowToolTile.getDeleteNodeButton("number").click();
+    dataflowToolTile.getDeleteNodeButton("transform").click();
+    dataflowToolTile.getNode("number").should("not.exist");
+    dataflowToolTile.getNode("transform").should("not.exist");
   });
-  describe("Dataflow Tool", () => {
-    it("renders dataflow tool tile", () => {
-      clueCanvas.addTile("dataflow");
-      dataflowToolTile.getDataflowTile().should("exist");
-      dataflowToolTile.getTileTitle().should("exist");
-    });
-    it("edit tile title", () => {
-      const newName = "Dataflow Tile";
-      dataflowToolTile.getTileTitle().should("contain", "Program 1");
-      dataflowToolTile.getDataflowTileTitle().click();
-      dataflowToolTile.getDataflowTileTitle().type(newName + '{enter}');
-      dataflowToolTile.getTileTitle().should("contain", newName);
-    });
-    it("makes link button active when table is present", () => {
-      dataflowToolTile.getLinkTileButton().should("exist");
-      dataflowToolTile.getLinkTileButton().should("have.class", "disabled");
-      clueCanvas.addTile("table");
-      dataflowToolTile.getLinkTileButton().should("not.have.class", "disabled");
-      clueCanvas.deleteTile("table");
-    });
-    describe("Number Node", () => {
-      const nodeType = "number";
-      it("can create number node", () => {
-        dataflowToolTile.getCreateNodeButton(nodeType).click();
-        dataflowToolTile.getNode(nodeType).should("exist");
-        dataflowToolTile.getNodeTitle().should("contain", "Number");
-      });
-      it("can toggle minigraph", () => {
-        dataflowToolTile.getShowGraphButton(nodeType).click();
-        dataflowToolTile.getMinigraph(nodeType).should("exist");
-        dataflowToolTile.getShowGraphButton(nodeType).click();
-        dataflowToolTile.getMinigraph(nodeType).should("not.exist");
-      });
-      it("can change the number", () => {
-        dataflowToolTile.getNumberField().type("3{enter}");
-        dataflowToolTile.getNumberField().should("have.value", "3");
-      });
+  it("Generator and Timer Nodes", () => {
+    const generatorNode = "generator";
+    beforeTest();
+    clueCanvas.addTile("dataflow");
 
-      //TODO: write a test that can check min and max (should be 0 and 3)
-      // could be in class .chartjs-size-monitor
+    cy.log("can create generator node");
+    dataflowToolTile.getCreateNodeButton(generatorNode).click();
+    dataflowToolTile.getNode(generatorNode).should("exist");
+    dataflowToolTile.getNodeTitle().should("contain", "Generator");
 
-      it("can click zoom in positive button", () => {
-        dataflowToolTile.getShowGraphButton(nodeType).click(); //open minigraph
-        dataflowToolTile.getShowZoomInButton(nodeType).click();
-      });
-      it("can click zoom out negative button", () => {
-        dataflowToolTile.getShowZoomOutButton(nodeType).click();
-        dataflowToolTile.getShowGraphButton(nodeType).click(); //close minigraph
-      });
-      it("verify node inputs outputs", () => {
-        dataflowToolTile.getNodeInput().should("not.exist");
-        dataflowToolTile.getNodeOutput().should("exist");
-      });
-      it("verify zoom in & out", () => {
-        dataflowToolTile.getZoomInButton().click();
-        dataflowToolTile.getFlowtool().children().should("have.attr", "style").and("contain", "scale(1.05)");
-        dataflowToolTile.getZoomOutButton().click();
-        dataflowToolTile.getFlowtool().children().should("have.attr", "style").and("contain", "scale(1)");
-      });
-      it("can delete number node", () => {
-        dataflowToolTile.getDeleteNodeButton(nodeType).click();
-        dataflowToolTile.getNode(nodeType).should("not.exist");
-      });
+    cy.log("can toggle minigraph");
+    dataflowToolTile.getShowGraphButton(generatorNode).click();
+    dataflowToolTile.getMinigraph(generatorNode).should("exist");
+    dataflowToolTile.getShowGraphButton(generatorNode).click();
+    dataflowToolTile.getMinigraph(generatorNode).should("not.exist");
+
+    cy.log("can change the number");
+    dataflowToolTile.getAmplitudeField().clear();
+    dataflowToolTile.getAmplitudeField().type("3{enter}");
+    dataflowToolTile.getAmplitudeField().find('input').should("have.value", "3");
+
+    cy.log("verify generator types");
+    const dropdown2 = "generatorType";
+    const generatorTypes = ["Sine", "Square", "Triangle"];
+    dataflowToolTile.getDropdown(generatorNode, dropdown2).click();
+    dataflowToolTile.getDropdownOptions(generatorNode, dropdown2).should("have.length", 3);
+    dataflowToolTile.getDropdownOptions(generatorNode, dropdown2).each(($tab, index, $typeList) => {
+      expect($tab.text()).to.contain(generatorTypes[index]);
     });
-    describe("Drag to Add Node", () => {
-      const nodeType = "number";
-      // TODO Why isn't this test working?
-      it('can create node by dragging button onto tile', () => {
-        const draggable = () => cy.get(".program-toolbar [aria-roledescription='draggable'] button").eq(1);
-        dataflowToolTile.getNode(nodeType).should("not.exist");
-        draggable().trigger("mousedown", { force: true })
-          .wait(100)
-          .trigger("mousemove", {
-            force: true,
-            clientX: 500,
-            clientY: 200
-          })
-          .wait(100)
-          .trigger("mouseup", { force: true })
-          .wait(100);
-        // const dataTransfer = new DataTransfer;
-        // draggable().focus().trigger('dragstart', { dataTransfer });
-        // dataflowToolTile.getDataflowTile().trigger('drop', { dataTransfer });
-        // draggable().trigger('dragend');
-        dataflowToolTile.getNode(nodeType).should("exist");
-        dataflowToolTile.getDeleteNodeButton(nodeType).click();
-        dataflowToolTile.getNode(nodeType).should("not.exist");
-      });
+    dataflowToolTile.getDropdownOptions(generatorNode, dropdown2).last().click();
+    dataflowToolTile.getDropdownOptions(generatorNode, dropdown2).should("have.length", 0);
+    dataflowToolTile.getDropdown(generatorNode, dropdown2).contains("Triangle").should("exist");
+
+    cy.log("verify node inputs outputs");
+    dataflowToolTile.getNodeInput().should("not.exist");
+    dataflowToolTile.getNodeOutput().should("exist");
+
+    cy.log("can delete generator node");
+    dataflowToolTile.getDeleteNodeButton(generatorNode).click();
+    dataflowToolTile.getNode(generatorNode).should("not.exist");
+
+    cy.log("Timer Node");
+    const timerNode = "timer";
+    beforeTest();
+    clueCanvas.addTile("dataflow");
+
+    cy.log("can create timer node");
+    dataflowToolTile.getCreateNodeButton(timerNode).click();
+    dataflowToolTile.getNode(timerNode).should("exist");
+    dataflowToolTile.getNodeTitle().should("contain", "Timer (on/off)");
+
+    cy.log("timer node labels");
+    dataflowToolTile.getLabel("On").should('contain', "time on");
+    dataflowToolTile.getLabel("Off").should('contain', "time off");
+
+    cy.log("can toggle minigraph");
+    dataflowToolTile.getShowGraphButton(timerNode).click();
+    dataflowToolTile.getMinigraph(timerNode).should("exist");
+    dataflowToolTile.getShowGraphButton(timerNode).click();
+    dataflowToolTile.getMinigraph(timerNode).should("not.exist");
+
+    cy.log("verify node inputs outputs");
+    dataflowToolTile.getNodeInput().should("not.exist");
+    dataflowToolTile.getNodeOutput().should("exist");
+
+    cy.log("can delete timer node");
+    dataflowToolTile.getDeleteNodeButton(timerNode).click();
+    dataflowToolTile.getNode(timerNode).should("not.exist");
+  });
+
+  it("Math and Logic Nodes", () => {
+    const mathNode = "math";
+    beforeTest();
+    clueCanvas.addTile("dataflow");
+
+    cy.log("can create math node");
+    dataflowToolTile.getCreateNodeButton(mathNode).click();
+    dataflowToolTile.getNode(mathNode).should("exist");
+    dataflowToolTile.getNodeTitle().should("contain", "Math");
+
+    cy.log("can toggle minigraph");
+    dataflowToolTile.getShowGraphButton(mathNode).click();
+    dataflowToolTile.getMinigraph(mathNode).should("exist");
+    dataflowToolTile.getShowGraphButton(mathNode).click();
+    dataflowToolTile.getMinigraph(mathNode).should("not.exist");
+
+    cy.log("verify math operator types");
+    const mathOperator = "mathOperator";
+    const mathOperatorTypes = ["Add", "Subtract", "Multiply", "Divide"];
+    dataflowToolTile.getDropdown(mathNode, mathOperator).click();
+    dataflowToolTile.getDropdownOptions(mathNode, mathOperator).should("have.length", 4);
+    dataflowToolTile.getDropdownOptions(mathNode, mathOperator).each(($tab, index, $typeList) => {
+      expect($tab.text()).to.contain(mathOperatorTypes[index]);
     });
-    describe("Manage Decimals", () => {
-      it('can create a number node and change it to a decimal', () => {
-        // create a number node
-        dataflowToolTile.getCreateNodeButton("number").click();
-        dataflowToolTile.getNode("number").should("exist");
-        dataflowToolTile.getNodeTitle().should("contain", "Number");
-        dataflowToolTile.getNumberField().type("1.8309{enter}");
-      });
-      it('values should be rounded to three decimals for display', () => {
-        // create transform node and drag to the right
-        dataflowToolTile.getCreateNodeButton("transform").click();
-        dataflowToolTile.getNode("transform").should("exist");
-        dataflowToolTile.getNodeTitle().should("contain", "Transform");
-        dataflowToolTile.getNode("transform").click(50, 10)
-          .trigger("pointerdown", 50, 10 )
-          .trigger("pointermove", dragXDestination, 10, { force: true } )
-          .trigger("pointerup", dragXDestination, 10, { force: true } );
-          cy.wait(2000);
-        // connect the number node to the transform node
-        dataflowToolTile.getNodeOutput().eq(0).click();
-        dataflowToolTile.getNodeInput().eq(0).click();
-        // verify the transform node has the correct value
-        dataflowToolTile.getNode("transform").should("contain", "1.831");
-        dataflowToolTile.getDeleteNodeButton("number").click();
-        dataflowToolTile.getDeleteNodeButton("transform").click();
-        dataflowToolTile.getNode("number").should("not.exist");
-        dataflowToolTile.getNode("transform").should("not.exist");
-      });
+    dataflowToolTile.getDropdownOptions(mathNode, mathOperator).last().click();
+    dataflowToolTile.getDropdownOptions(mathNode, mathOperator).should("have.length", 0);
+    dataflowToolTile.getDropdown(mathNode, mathOperator).contains("Divide").should("exist");
+
+    cy.log("verify node inputs outputs");
+    dataflowToolTile.getNodeInput().should("exist");
+    dataflowToolTile.getNodeInput().should('have.length', 2);
+    dataflowToolTile.getNodeOutput().should("exist");
+
+    cy.log("can delete math node");
+    dataflowToolTile.getDeleteNodeButton(mathNode).click();
+    dataflowToolTile.getNode(mathNode).should("not.exist");
+
+    cy.log("Logic Node");
+    const logicNode = "logic";
+    beforeTest();
+    clueCanvas.addTile("dataflow");
+
+    cy.log("can create logic node");
+    dataflowToolTile.getCreateNodeButton(logicNode).click();
+    dataflowToolTile.getNode(logicNode).should("exist");
+    dataflowToolTile.getNodeTitle().should("contain", "Logic");
+
+    cy.log("can toggle minigraph");
+    dataflowToolTile.getShowGraphButton(logicNode).click();
+    dataflowToolTile.getMinigraph(logicNode).should("exist");
+    dataflowToolTile.getShowGraphButton(logicNode).click();
+    dataflowToolTile.getMinigraph(logicNode).should("not.exist");
+
+    cy.log("verify logic operator types");
+    const logicOperator = "logicOperator";
+    const logicOperatorTypes = ["Greater Than", "Less Than", "Greater Than Or Equal To", "Less Than Or Equal To", "Equal", "Not Equal", "And", "Or", "Nand", "Xor"];
+    dataflowToolTile.getDropdown(logicNode, logicOperator).click();
+    dataflowToolTile.getDropdownOptions(logicNode, logicOperator).should("have.length", 10);
+    dataflowToolTile.getDropdownOptions(logicNode, logicOperator).each(($tab, index, $typeList) => {
+      expect($tab.text()).to.contain(logicOperatorTypes[index]);
     });
-    describe("Generator Node", () => {
-      const nodeType = "generator";
-      it("can create generator node", () => {
-        dataflowToolTile.getCreateNodeButton(nodeType).click();
-        dataflowToolTile.getNode(nodeType).should("exist");
-        dataflowToolTile.getNodeTitle().should("contain", "Generator");
-      });
-      it("can toggle minigraph", () => {
-        dataflowToolTile.getShowGraphButton(nodeType).click();
-        dataflowToolTile.getMinigraph(nodeType).should("exist");
-        dataflowToolTile.getShowGraphButton(nodeType).click();
-        dataflowToolTile.getMinigraph(nodeType).should("not.exist");
-      });
-      it("can change the number", () => {
-        dataflowToolTile.getAmplitudeField().clear();
-        dataflowToolTile.getAmplitudeField().type("3{enter}");
-        dataflowToolTile.getAmplitudeField().find('input').should("have.value", "3");
-      });
-      it("verify generator types", () => {
-        const dropdown = "generatorType";
-        const generatorTypes = ["Sine", "Square", "Triangle"];
-        dataflowToolTile.getDropdown(nodeType, dropdown).click();
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).should("have.length", 3);
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).each(($tab, index, $typeList) => {
-          expect($tab.text()).to.contain(generatorTypes[index]);
-        });
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).last().click();
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).should("have.length", 0);
-        dataflowToolTile.getDropdown(nodeType, dropdown).contains("Triangle").should("exist");
-      });
-      it("verify node inputs outputs", () => {
-        dataflowToolTile.getNodeInput().should("not.exist");
-        dataflowToolTile.getNodeOutput().should("exist");
-      });
-      it("can delete generator node", () => {
-        dataflowToolTile.getDeleteNodeButton(nodeType).click();
-        dataflowToolTile.getNode(nodeType).should("not.exist");
-      });
+    dataflowToolTile.getDropdownOptions(logicNode, logicOperator).last().click();
+    dataflowToolTile.getDropdownOptions(logicNode, logicOperator).should("have.length", 0);
+    dataflowToolTile.getDropdown(logicNode, logicOperator).contains("Xor").should("exist");
+
+    cy.log("verify node inputs outputs");
+    dataflowToolTile.getNodeInput().should("exist");
+    dataflowToolTile.getNodeInput().should('have.length', 2);
+    dataflowToolTile.getNodeOutput().should("exist");
+
+    cy.log("can delete logic node");
+    dataflowToolTile.getDeleteNodeButton(logicNode).click();
+    dataflowToolTile.getNode(logicNode).should("not.exist");
+  });
+  it("Transform and Control Nodes", () => {
+    const transformNode = "transform";
+    beforeTest();
+    clueCanvas.addTile("dataflow");
+
+    cy.log("can create transform node");
+    dataflowToolTile.getCreateNodeButton(transformNode).click();
+    dataflowToolTile.getNode(transformNode).should("exist");
+    dataflowToolTile.getNodeTitle().should("contain", "Transform");
+
+    cy.log("can toggle minigraph");
+    dataflowToolTile.getShowGraphButton(transformNode).click();
+    dataflowToolTile.getMinigraph(transformNode).should("exist");
+    dataflowToolTile.getShowGraphButton(transformNode).click();
+    dataflowToolTile.getMinigraph(transformNode).should("not.exist");
+
+    cy.log("verify logic operator types");
+    const transformOperator = "transformOperator";
+    const transformOperatorTypes = ["Absolute Value", "Negation", "Not", "Round", "Floor", "Ceil"];
+    dataflowToolTile.getDropdown(transformNode, transformOperator).click();
+    dataflowToolTile.getDropdownOptions(transformNode, transformOperator).should("have.length", 6);
+    dataflowToolTile.getDropdownOptions(transformNode, transformOperator).each(($tab, index, $typeList) => {
+      expect($tab.text()).to.contain(transformOperatorTypes[index]);
     });
-    describe("Timer Node", () => {
-      const nodeType = "timer";
-      it("can create timer node", () => {
-        dataflowToolTile.getCreateNodeButton(nodeType).click();
-        dataflowToolTile.getNode(nodeType).should("exist");
-        dataflowToolTile.getNodeTitle().should("contain", "Timer (on/off)");
-      });
-      it("timer node labels", () => {
-        dataflowToolTile.getLabel("On").should('contain', "time on");
-        dataflowToolTile.getLabel("Off").should('contain', "time off");
-      });
-      it("can toggle minigraph", () => {
-        dataflowToolTile.getShowGraphButton(nodeType).click();
-        dataflowToolTile.getMinigraph(nodeType).should("exist");
-        dataflowToolTile.getShowGraphButton(nodeType).click();
-        dataflowToolTile.getMinigraph(nodeType).should("not.exist");
-      });
-      it("verify node inputs outputs", () => {
-        dataflowToolTile.getNodeInput().should("not.exist");
-        dataflowToolTile.getNodeOutput().should("exist");
-      });
-      it("can delete timer node", () => {
-        dataflowToolTile.getDeleteNodeButton(nodeType).click();
-        dataflowToolTile.getNode(nodeType).should("not.exist");
-      });
+    dataflowToolTile.getDropdownOptions(transformNode, transformOperator).last().click();
+    dataflowToolTile.getDropdownOptions(transformNode, transformOperator).should("have.length", 0);
+    dataflowToolTile.getDropdown(transformNode, transformOperator).contains("Ceil").should("exist");
+
+    cy.log("verify node inputs outputs");
+    dataflowToolTile.getNodeInput().should("exist");
+    dataflowToolTile.getNodeInput().should('have.length', 1);
+    dataflowToolTile.getNodeOutput().should("exist");
+
+    cy.log("can delete transform node");
+    dataflowToolTile.getDeleteNodeButton(transformNode).click();
+    dataflowToolTile.getNode(transformNode).should("not.exist");
+
+    cy.log("Control Node");
+    const controlNode = "control";
+
+    cy.log("can create control node");
+    dataflowToolTile.getCreateNodeButton(controlNode).click();
+    dataflowToolTile.getNode(controlNode).should("exist");
+    dataflowToolTile.getNodeTitle().should("contain", "Hold");
+
+    cy.log("can toggle minigraph");
+    dataflowToolTile.getShowGraphButton(controlNode).click();
+    dataflowToolTile.getMinigraph(controlNode).should("exist");
+    dataflowToolTile.getShowGraphButton(controlNode).click();
+    dataflowToolTile.getMinigraph(controlNode).should("not.exist");
+
+    cy.log("verify control operator types");
+    const controlOperator = "controlOperator";
+    const controlOperatorTypes = ["Hold this", "Hold previous", "Hold 0"];
+    dataflowToolTile.getDropdown(controlNode, controlOperator).click();
+    dataflowToolTile.getDropdownOptions(controlNode, controlOperator).should("have.length", 3);
+    dataflowToolTile.getDropdownOptions(controlNode, controlOperator).each(($tab, index, $typeList) => {
+      expect($tab.text()).to.contain(controlOperatorTypes[index]);
     });
-    describe("Math Node", () => {
-      const nodeType = "math";
-      it("can create math node", () => {
-        dataflowToolTile.getCreateNodeButton(nodeType).click();
-        dataflowToolTile.getNode(nodeType).should("exist");
-        dataflowToolTile.getNodeTitle().should("contain", "Math");
-      });
-      it("can toggle minigraph", () => {
-        dataflowToolTile.getShowGraphButton(nodeType).click();
-        dataflowToolTile.getMinigraph(nodeType).should("exist");
-        dataflowToolTile.getShowGraphButton(nodeType).click();
-        dataflowToolTile.getMinigraph(nodeType).should("not.exist");
-      });
-      it("verify math operator types", () => {
-        const dropdown = "mathOperator";
-        const operatorTypes = ["Add", "Subtract", "Multiply", "Divide"];
-        dataflowToolTile.getDropdown(nodeType, dropdown).click();
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).should("have.length", 4);
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).each(($tab, index, $typeList) => {
-          expect($tab.text()).to.contain(operatorTypes[index]);
-        });
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).last().click();
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).should("have.length", 0);
-        dataflowToolTile.getDropdown(nodeType, dropdown).contains("Divide").should("exist");
-      });
-      it("verify node inputs outputs", () => {
-        dataflowToolTile.getNodeInput().should("exist");
-        dataflowToolTile.getNodeInput().should('have.length', 2);
-        dataflowToolTile.getNodeOutput().should("exist");
-      });
-      it("can delete math node", () => {
-        dataflowToolTile.getDeleteNodeButton(nodeType).click();
-        dataflowToolTile.getNode(nodeType).should("not.exist");
-      });
+    dataflowToolTile.getDropdownOptions(controlNode, controlOperator).last().click();
+    dataflowToolTile.getDropdownOptions(controlNode, controlOperator).should("have.length", 0);
+    dataflowToolTile.getDropdown(controlNode, controlOperator).contains("Hold 0").should("exist");
+
+    cy.log("verify node inputs outputs");
+    dataflowToolTile.getNodeInput().should("exist");
+    dataflowToolTile.getNodeInput().should('have.length', 2);
+    dataflowToolTile.getNodeOutput().should("exist");
+
+    cy.log("can delete control node");
+    dataflowToolTile.getDeleteNodeButton(controlNode).click();
+    dataflowToolTile.getNode(controlNode).should("not.exist");
+  });
+  it("Demo Output and Live Output Nodes", () => {
+    const demoOutputNode = "demo-output";
+    beforeTest();
+    clueCanvas.addTile("dataflow");
+
+    cy.log("can create demo output node");
+    dataflowToolTile.getCreateNodeButton(demoOutputNode).click();
+    dataflowToolTile.getNode(demoOutputNode).should("exist");
+    dataflowToolTile.getNodeTitle().should("contain", "Demo Output");
+
+    cy.log("can change output type");
+    const demoOutputType = "outputType";
+    const demoOutputTypes = ["Light Bulb", "Gripper", "Advanced Gripper", "Fan", "Humidifier"];
+    dataflowToolTile.getDropdown(demoOutputNode, demoOutputType).click();
+    dataflowToolTile.getDropdownOptions(demoOutputNode, demoOutputType).should("have.length", 5);
+    dataflowToolTile.getDropdownOptions(demoOutputNode, demoOutputType).each(($tab, index, $typeList) => {
+      expect($tab.text()).to.contain(demoOutputTypes[index]);
     });
-    describe("Logic Node", () => {
-      const nodeType = "logic";
-      it("can create logic node", () => {
-        dataflowToolTile.getCreateNodeButton(nodeType).click();
-        dataflowToolTile.getNode(nodeType).should("exist");
-        dataflowToolTile.getNodeTitle().should("contain", "Logic");
-      });
-      it("can toggle minigraph", () => {
-        dataflowToolTile.getShowGraphButton(nodeType).click();
-        dataflowToolTile.getMinigraph(nodeType).should("exist");
-        dataflowToolTile.getShowGraphButton(nodeType).click();
-        dataflowToolTile.getMinigraph(nodeType).should("not.exist");
-      });
-      it("verify logic operator types", () => {
-        const dropdown = "logicOperator";
-        const operatorTypes = ["Greater Than", "Less Than", "Greater Than Or Equal To", "Less Than Or Equal To", "Equal", "Not Equal", "And", "Or", "Nand", "Xor"];
-        dataflowToolTile.getDropdown(nodeType, dropdown).click();
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).should("have.length", 10);
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).each(($tab, index, $typeList) => {
-          expect($tab.text()).to.contain(operatorTypes[index]);
-        });
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).last().click();
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).should("have.length", 0);
-        dataflowToolTile.getDropdown(nodeType, dropdown).contains("Xor").should("exist");
-      });
-      it("verify node inputs outputs", () => {
-        dataflowToolTile.getNodeInput().should("exist");
-        dataflowToolTile.getNodeInput().should('have.length', 2);
-        dataflowToolTile.getNodeOutput().should("exist");
-      });
-      it("can delete logic node", () => {
-        dataflowToolTile.getDeleteNodeButton(nodeType).click();
-        dataflowToolTile.getNode(nodeType).should("not.exist");
-      });
+    dataflowToolTile.getDropdownOptions(demoOutputNode, demoOutputType).last().click();
+    dataflowToolTile.getDropdownOptions(demoOutputNode, demoOutputType).should("have.length", 0);
+    dataflowToolTile.getDropdown(demoOutputNode, demoOutputType).contains("Humidifier").should("exist");
+
+    cy.log("verify demo output images, node inputs outputs & toggle minigraph");
+    //verify advanced grabber
+    dataflowToolTile.getDropdown(demoOutputNode, demoOutputType).click();
+    dataflowToolTile.getDropdownOptions(demoOutputNode, demoOutputType).eq(2).click();
+    dataflowToolTile.getAdvancedGrabberImages();
+    dataflowToolTile.getNodeInput().should("exist");
+    dataflowToolTile.getNodeInput().should('have.length', 2);
+    dataflowToolTile.getNodeOutput().should("not.exist");
+
+    dataflowToolTile.getShowGraphButton(demoOutputNode).should('have.length', 2);
+    dataflowToolTile.getShowGraphButton(demoOutputNode).eq(0).click();
+    dataflowToolTile.getMinigraph(demoOutputNode).should("exist");
+    dataflowToolTile.getShowGraphButton(demoOutputNode).eq(0).click();
+    dataflowToolTile.getMinigraph(demoOutputNode).should("not.exist");
+    dataflowToolTile.getShowGraphButton(demoOutputNode).eq(1).click();
+    dataflowToolTile.getMinigraph(demoOutputNode).should("exist");
+    dataflowToolTile.getShowGraphButton(demoOutputNode).eq(1).click();
+    dataflowToolTile.getMinigraph(demoOutputNode).should("not.exist");
+
+    dataflowToolTile.getOutputNodeValueText().should("contain", "0% closed");
+    dataflowToolTile.getOutputTiltValueText().should("contain", "tilt: center");
+
+    // verify grabber
+    dataflowToolTile.getDropdown(demoOutputNode, demoOutputType).click();
+    dataflowToolTile.getDropdownOptions(demoOutputNode, demoOutputType).eq(1).click();
+    dataflowToolTile.getGrabberImage();
+    dataflowToolTile.getNodeInput().should("exist");
+    dataflowToolTile.getNodeInput().should('have.length', 1);
+    dataflowToolTile.getNodeOutput().should("not.exist");
+
+    dataflowToolTile.getShowGraphButton(demoOutputNode).click();
+    dataflowToolTile.getMinigraph(demoOutputNode).should("exist");
+    dataflowToolTile.getShowGraphButton(demoOutputNode).click();
+    dataflowToolTile.getMinigraph(demoOutputNode).should("not.exist");
+
+    dataflowToolTile.getOutputNodeValueText().should("contain", "0% closed");
+
+    // verify light bulb
+    dataflowToolTile.getDropdown(demoOutputNode, demoOutputType).click();
+    dataflowToolTile.getDropdownOptions(demoOutputNode, demoOutputType).first().click();
+    dataflowToolTile.getLightBulbImage();
+    dataflowToolTile.getNodeInput().should("exist");
+    dataflowToolTile.getNodeInput().should('have.length', 1);
+    dataflowToolTile.getNodeOutput().should("not.exist");
+
+    dataflowToolTile.getShowGraphButton(demoOutputNode).click();
+    dataflowToolTile.getMinigraph(demoOutputNode).should("exist");
+    dataflowToolTile.getShowGraphButton(demoOutputNode).click();
+    dataflowToolTile.getMinigraph(demoOutputNode).should("not.exist");
+    dataflowToolTile.getOutputNodeValueText().should("contain", "off");
+
+    cy.log("can delete demo output node");
+    dataflowToolTile.getDeleteNodeButton(demoOutputNode).click();
+    dataflowToolTile.getNode(demoOutputNode).should("not.exist");
+
+    cy.log("Live Output Node");
+    const liveOutputNode = "live-output";
+    cy.log("can create live output node");
+    dataflowToolTile.getCreateNodeButton(liveOutputNode).click();
+    dataflowToolTile.getNode(liveOutputNode).should("exist");
+    dataflowToolTile.getNodeTitle().should("contain", "Live Output");
+
+    cy.log("can toggle minigraph");
+    dataflowToolTile.getShowGraphButton(liveOutputNode).click();
+    dataflowToolTile.getMinigraph(liveOutputNode).should("exist");
+    dataflowToolTile.getShowGraphButton(liveOutputNode).click();
+    dataflowToolTile.getMinigraph(liveOutputNode).should("not.exist");
+
+    cy.log("verify live output types");
+    const liveOutputType = "liveOutputType";
+    const liveOutputTypes = ["Gripper 2.0", "Gripper", "Humidifier", "Fan", "Heat Lamp"];
+    dataflowToolTile.getDropdown(liveOutputNode, liveOutputType).click();
+    dataflowToolTile.getDropdownOptions(liveOutputNode, liveOutputType).should("have.length", 5);
+    dataflowToolTile.getDropdownOptions(liveOutputNode, liveOutputType).each(($tab, index, $typeList) => {
+      expect($tab.text()).to.contain(liveOutputTypes[index]);
     });
-    describe("Transform Node", () => {
-      const nodeType = "transform";
-      it("can create transform node", () => {
-        dataflowToolTile.getCreateNodeButton(nodeType).click();
-        dataflowToolTile.getNode(nodeType).should("exist");
-        dataflowToolTile.getNodeTitle().should("contain", "Transform");
-      });
-      it("can toggle minigraph", () => {
-        dataflowToolTile.getShowGraphButton(nodeType).click();
-        dataflowToolTile.getMinigraph(nodeType).should("exist");
-        dataflowToolTile.getShowGraphButton(nodeType).click();
-        dataflowToolTile.getMinigraph(nodeType).should("not.exist");
-      });
-      it("verify logic operator types", () => {
-        const dropdown = "transformOperator";
-        const operatorTypes = ["Absolute Value", "Negation", "Not", "Round", "Floor", "Ceil"];
-        dataflowToolTile.getDropdown(nodeType, dropdown).click();
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).should("have.length", 6);
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).each(($tab, index, $typeList) => {
-          expect($tab.text()).to.contain(operatorTypes[index]);
-        });
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).last().click();
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).should("have.length", 0);
-        dataflowToolTile.getDropdown(nodeType, dropdown).contains("Ceil").should("exist");
-      });
-      it("verify node inputs outputs", () => {
-        dataflowToolTile.getNodeInput().should("exist");
-        dataflowToolTile.getNodeInput().should('have.length', 1);
-        dataflowToolTile.getNodeOutput().should("exist");
-      });
-      it("can delete transform node", () => {
-        dataflowToolTile.getDeleteNodeButton(nodeType).click();
-        dataflowToolTile.getNode(nodeType).should("not.exist");
-      });
+    dataflowToolTile.getDropdownOptions(liveOutputNode, liveOutputType).last().click();
+    dataflowToolTile.getDropdownOptions(liveOutputNode, liveOutputType).should("have.length", 0);
+    dataflowToolTile.getDropdown(liveOutputNode, liveOutputType).contains("Heat Lamp").should("exist");
+    dataflowToolTile.getOutputNodeValueText().should("contain", "off");
+
+    cy.log("verify live binary outputs indicate hub not present if not connected");
+    dataflowToolTile.getDropdown(liveOutputNode, liveOutputType).click();
+    dataflowToolTile.getDropdownOptions(liveOutputNode, liveOutputType).eq(3).click();
+    dataflowToolTile.getDropdown(liveOutputNode, liveOutputType).contains("Fan").should("exist");
+    dataflowToolTile.getOutputNodeValueText().should("contain", "(no hub)");
+
+    cy.log("can be dragged to the right and set back to light bulb");
+    dataflowToolTile.getNode(liveOutputNode).click(50, 10)
+      .trigger("pointerdown", 50, 10)
+      .trigger("pointermove", dragXDestination, 10, { force: true })
+      .trigger("pointerup", dragXDestination, 10, { force: true });
+    dataflowToolTile.getDropdown(liveOutputNode, liveOutputType).click();
+    dataflowToolTile.getDropdownOptions(liveOutputNode, liveOutputType).eq(0).click();
+
+    cy.log("can connect and trigger modal connection warning");
+    // vars for controlling click and drag to connect nodes
+    const startX = 306;
+    const startY = 182;
+    const deltaX = 70;  //  60 with fixed styles
+    const deltaY = -22; // -10 with fixed styles
+    dataflowToolTile.getCreateNodeButton("number").click();
+    dataflowToolTile.getNode("number").should("exist");
+    dataflowToolTile.getNumberField().type("1{enter}");
+    dataflowToolTile.getNumberNodeOutput().should("exist");
+    dataflowToolTile.getDataflowTile().click(startX, startY)
+      .trigger("pointerdown", startX, startY, { force: true })
+      .trigger("pointermove", startX + deltaX, startY + deltaY, { force: true })
+      .trigger("pointerup", startX + deltaX, startY + deltaY, { force: true });
+    dataflowToolTile.getModalOkButton().click();
+
+    cy.log("should show needs connection message when fan is selected and there are no outputs");
+    dataflowToolTile.getDropdown(liveOutputNode, liveOutputType).click();
+    dataflowToolTile.getDropdownOptions(liveOutputNode, liveOutputType).eq(3).click();
+    dataflowToolTile.getDropdown(liveOutputNode, liveOutputType).contains("Fan").should("exist");
+    dataflowToolTile.getDropdown(liveOutputNode, "hubSelect").should("contain", "connect device");
+
+    cy.log("can recieve a value from a connected block, and display correct on or off string");
+    dataflowToolTile.getNode("number").should("exist");
+    dataflowToolTile.getOutputNodeValueText().should("contain", "on");
+    dataflowToolTile.getNumberField().type("{backspace}0{enter}");
+    dataflowToolTile.getNumberNodeOutput().should("exist");
+    dataflowToolTile.getOutputNodeValueText().should("contain", "off");
+    dataflowToolTile.getDeleteNodeButton("number").click();
+
+    cy.log("verify node inputs outputs");
+    dataflowToolTile.getNodeInput().should("exist");
+    dataflowToolTile.getNodeInput().should('have.length', 1);
+    dataflowToolTile.getNodeOutput().should("not.exist");
+
+    cy.log("can delete live output node");
+    dataflowToolTile.getDeleteNodeButton(liveOutputNode).click();
+    dataflowToolTile.getNode(liveOutputNode).should("not.exist");
+  });
+  it("Sensor Node and Record Data", () => {
+    const sensorNode = "sensor";
+    beforeTest();
+    clueCanvas.addTile("dataflow");
+
+    cy.log("can create sensor node");
+    dataflowToolTile.getCreateNodeButton(sensorNode).click();
+    dataflowToolTile.getNode(sensorNode).should("exist");
+    dataflowToolTile.getNodeTitle().should("contain", "Sensor");
+
+    cy.log("can toggle minigraph");
+    dataflowToolTile.getShowGraphButton(sensorNode).click();
+    dataflowToolTile.getMinigraph(sensorNode).should("exist");
+    dataflowToolTile.getShowGraphButton(sensorNode).click();
+    dataflowToolTile.getMinigraph(sensorNode).should("not.exist");
+
+    cy.log("verify sensor types");
+    const dropdown10 = "sensor-type";
+    const sensorTypes = ["Temperature", "Humidity", "CO₂", "O₂", "Light", "Soil Moisture", "Particulates", "EMG", "Surface Pressure"];
+    dataflowToolTile.getDropdown(sensorNode, dropdown10).click();
+    dataflowToolTile.getSensorDropdownOptions(sensorNode).should("have.length", 9);
+    dataflowToolTile.getSensorDropdownOptions(sensorNode).each(($tab, index, $typeList) => {
+      expect($tab.text()).to.contain(sensorTypes[index]);
     });
-    describe("Demo Output Node", () => {
-      const nodeType = "demo-output";
-      it("can create demo output node", () => {
-        dataflowToolTile.getCreateNodeButton(nodeType).click();
-        dataflowToolTile.getNode(nodeType).should("exist");
-        dataflowToolTile.getNodeTitle().should("contain", "Demo Output");
-      });
-      it("can change output type", () => {
-        const dropdown = "outputType";
-        const outputTypes = ["Light Bulb", "Gripper", "Advanced Gripper", "Fan", "Humidifier"];
-        dataflowToolTile.getDropdown(nodeType, dropdown).click();
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).should("have.length", 5);
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).each(($tab, index, $typeList) => {
-          expect($tab.text()).to.contain(outputTypes[index]);
-        });
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).last().click();
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).should("have.length", 0);
-        dataflowToolTile.getDropdown(nodeType, dropdown).contains("Humidifier").should("exist");
-      });
-      it("verify demo output images, node inputs outputs & toggle minigraph", () => {
-        const dropdown = "outputType";
-        //verify advanced grabber
-        dataflowToolTile.getDropdown(nodeType, dropdown).click();
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).eq(2).click();
-        dataflowToolTile.getAdvancedGrabberImages();
-        dataflowToolTile.getNodeInput().should("exist");
-        dataflowToolTile.getNodeInput().should('have.length', 2);
-        dataflowToolTile.getNodeOutput().should("not.exist");
 
-        dataflowToolTile.getShowGraphButton(nodeType).should('have.length', 2);
-        dataflowToolTile.getShowGraphButton(nodeType).eq(0).click();
-        dataflowToolTile.getMinigraph(nodeType).should("exist");
-        dataflowToolTile.getShowGraphButton(nodeType).eq(0).click();
-        dataflowToolTile.getMinigraph(nodeType).should("not.exist");
-        dataflowToolTile.getShowGraphButton(nodeType).eq(1).click();
-        dataflowToolTile.getMinigraph(nodeType).should("exist");
-        dataflowToolTile.getShowGraphButton(nodeType).eq(1).click();
-        dataflowToolTile.getMinigraph(nodeType).should("not.exist");
+    cy.log("verify clear button");
+    dataflowToolTile.getClearButton().click();
+    dataflowToolTile.getNode(sensorNode).should("not.exist");
 
-        dataflowToolTile.getOutputNodeValueText().should("contain", "0% closed");
-        dataflowToolTile.getOutputTiltValueText().should("contain", "tilt: center");
-
-        // verify grabber
-        dataflowToolTile.getDropdown(nodeType, dropdown).click();
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).eq(1).click();
-        dataflowToolTile.getGrabberImage();
-        dataflowToolTile.getNodeInput().should("exist");
-        dataflowToolTile.getNodeInput().should('have.length', 1);
-        dataflowToolTile.getNodeOutput().should("not.exist");
-
-        dataflowToolTile.getShowGraphButton(nodeType).click();
-        dataflowToolTile.getMinigraph(nodeType).should("exist");
-        dataflowToolTile.getShowGraphButton(nodeType).click();
-        dataflowToolTile.getMinigraph(nodeType).should("not.exist");
-
-        dataflowToolTile.getOutputNodeValueText().should("contain", "0% closed");
-
-        // verify light bulb
-        dataflowToolTile.getDropdown(nodeType, dropdown).click();
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).first().click();
-        dataflowToolTile.getLightBulbImage();
-        dataflowToolTile.getNodeInput().should("exist");
-        dataflowToolTile.getNodeInput().should('have.length', 1);
-        dataflowToolTile.getNodeOutput().should("not.exist");
-
-        dataflowToolTile.getShowGraphButton(nodeType).click();
-        dataflowToolTile.getMinigraph(nodeType).should("exist");
-        dataflowToolTile.getShowGraphButton(nodeType).click();
-        dataflowToolTile.getMinigraph(nodeType).should("not.exist");
-
-        dataflowToolTile.getOutputNodeValueText().should("contain", "off");
-      });
-      it("can delete demo output node", () => {
-        dataflowToolTile.getDeleteNodeButton(nodeType).click();
-        dataflowToolTile.getNode(nodeType).should("not.exist");
-      });
+    cy.log("verify sensor select");
+    const sensorSelectdropdown = "sensor-select";
+    const sensorSelect = [
+      "Humidity Demo Data", "CO2 Demo Data", "O2 Demo Data", "Light Demo Data", "Particulates Demo Data",
+      "⚠️ Connect Arduino for live EMG",
+      "⚠️ Connect Arduino for live Pressure",
+      "⚠️ Connect Arduino for live Temperature",
+      "⚠️ Connect micro:bit for live Temperature A",
+      "⚠️ Connect micro:bit for live Humidity A",
+      "⚠️ Connect micro:bit for live Temperature B",
+      "⚠️ Connect micro:bit for live Humidity B",
+      "⚠️ Connect micro:bit for live Temperature C",
+      "⚠️ Connect micro:bit for live Humidity C",
+      "⚠️ Connect micro:bit for live Temperature D",
+      "⚠️ Connect micro:bit for live Humidity D",
+    ];
+    dataflowToolTile.getCreateNodeButton(sensorNode).click();
+    dataflowToolTile.getDropdown(sensorNode, sensorSelectdropdown).click();
+    dataflowToolTile.getSensorDropdownOptions(sensorNode).should("have.length", 16);
+    dataflowToolTile.getSensorDropdownOptions(sensorNode).each(($tab, index, $typeList) => {
+      expect($tab.text()).to.contain(sensorSelect[index]);
     });
-    describe("Live Output Node", () => {
-      const nodeType = "live-output";
-      it("can create live output node", () => {
-        dataflowToolTile.getCreateNodeButton(nodeType).click();
-        dataflowToolTile.getNode(nodeType).should("exist");
-        dataflowToolTile.getNodeTitle().should("contain", "Live Output");
-      });
-      it("can toggle minigraph", () => {
-        dataflowToolTile.getShowGraphButton(nodeType).click();
-        dataflowToolTile.getMinigraph(nodeType).should("exist");
-        dataflowToolTile.getShowGraphButton(nodeType).click();
-        dataflowToolTile.getMinigraph(nodeType).should("not.exist");
-      });
-      it("verify live output types", () => {
-        const dropdown = "liveOutputType";
-        const outputTypes = ["Gripper 2.0", "Gripper", "Humidifier", "Fan", "Heat Lamp"];
-        dataflowToolTile.getDropdown(nodeType, dropdown).click();
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).should("have.length", 5);
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).each(($tab, index, $typeList) => {
-          expect($tab.text()).to.contain(outputTypes[index]);
-        });
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).last().click();
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).should("have.length", 0);
-        dataflowToolTile.getDropdown(nodeType, dropdown).contains("Heat Lamp").should("exist");
-        dataflowToolTile.getOutputNodeValueText().should("contain", "off");
-      });
-      it("verify live binary outputs indicate hub not present if not connected", () => {
-        const dropdown = "liveOutputType";
-        dataflowToolTile.getDropdown(nodeType, dropdown).click();
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).eq(3).click();
-        dataflowToolTile.getDropdown(nodeType, dropdown).contains("Fan").should("exist");
-        dataflowToolTile.getOutputNodeValueText().should("contain", "(no hub)");
-      });
-      it("can be dragged to the right and set back to light bulb", () => {
-        const dropdown = "liveOutputType";
-        dataflowToolTile.getNode(nodeType).click(50, 10)
-          .trigger("pointerdown", 50, 10 )
-          .trigger("pointermove", dragXDestination, 10, { force: true } )
-          .trigger("pointerup", dragXDestination, 10, { force: true } );
-          dataflowToolTile.getDropdown(nodeType, dropdown).click();
-          dataflowToolTile.getDropdownOptions(nodeType, dropdown).eq(0).click();
-      });
-      it("can connect and trigger modal connection warning", () => {
-        // vars for controlling click and drag to connect nodes
-        const startX = 306;
-        const startY = 182;
-        const deltaX = 70;  //  60 with fixed styles
-        const deltaY = -22; // -10 with fixed styles
-        dataflowToolTile.getCreateNodeButton("number").click();
-        dataflowToolTile.getNode("number").should("exist");
-        dataflowToolTile.getNumberField().type("1{enter}");
-        dataflowToolTile.getNumberNodeOutput().should("exist");
-        dataflowToolTile.getDataflowTile().click(startX, startY)
-          .trigger("pointerdown", startX, startY, {force: true})
-          .trigger("pointermove", startX + deltaX, startY + deltaY, {force: true})
-          .trigger("pointerup", startX + deltaX, startY + deltaY, {force: true});
-        dataflowToolTile.getModalOkButton().click();
-      });
-      it("should show needs connection message when fan is selected and there are no outputs", () => {
-        const dropdown = "liveOutputType";
-        dataflowToolTile.getDropdown(nodeType, dropdown).click();
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).eq(3).click();
-        dataflowToolTile.getDropdown(nodeType, dropdown).contains("Fan").should("exist");
-        dataflowToolTile.getDropdown(nodeType, "hubSelect").should("contain", "connect device");
-      });
-      it("can recieve a value from a connected block, and display correct on or off string", () => {
-        dataflowToolTile.getNode("number").should("exist");
-        dataflowToolTile.getOutputNodeValueText().should("contain", "on");
-        dataflowToolTile.getNumberField().type("{backspace}0{enter}");
-        dataflowToolTile.getNumberNodeOutput().should("exist");
-        dataflowToolTile.getOutputNodeValueText().should("contain", "off");
-        dataflowToolTile.getDeleteNodeButton("number").click();
-      });
-      it("verify node inputs outputs", () => {
-        dataflowToolTile.getNodeInput().should("exist");
-        dataflowToolTile.getNodeInput().should('have.length', 1);
-        dataflowToolTile.getNodeOutput().should("not.exist");
-      });
-      it("can delete live output node", () => {
-        dataflowToolTile.getDeleteNodeButton(nodeType).click();
-        dataflowToolTile.getNode(nodeType).should("not.exist");
-      });
-    });
-    describe("Control Node", () => {
-      const nodeType = "control";
-      it("can create control node", () => {
-        dataflowToolTile.getCreateNodeButton(nodeType).click();
-        dataflowToolTile.getNode(nodeType).should("exist");
-        dataflowToolTile.getNodeTitle().should("contain", "Hold");
-      });
-      it("can toggle minigraph", () => {
-        dataflowToolTile.getShowGraphButton(nodeType).click();
-        dataflowToolTile.getMinigraph(nodeType).should("exist");
-        dataflowToolTile.getShowGraphButton(nodeType).click();
-        dataflowToolTile.getMinigraph(nodeType).should("not.exist");
-      });
-      it("verify control operator types", () => {
-        const dropdown = "controlOperator";
-        const operatorTypes = ["Hold this", "Hold previous", "Hold 0"];
-        dataflowToolTile.getDropdown(nodeType, dropdown).click();
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).should("have.length", 3);
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).each(($tab, index, $typeList) => {
-          expect($tab.text()).to.contain(operatorTypes[index]);
-        });
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).last().click();
-        dataflowToolTile.getDropdownOptions(nodeType, dropdown).should("have.length", 0);
-        dataflowToolTile.getDropdown(nodeType, dropdown).contains("Hold 0").should("exist");
-      });
-      it("verify node inputs outputs", () => {
-        dataflowToolTile.getNodeInput().should("exist");
-        dataflowToolTile.getNodeInput().should('have.length', 2);
-        dataflowToolTile.getNodeOutput().should("exist");
-      });
-      it("can delete control node", () => {
-        dataflowToolTile.getDeleteNodeButton(nodeType).click();
-        dataflowToolTile.getNode(nodeType).should("not.exist");
-      });
-    });
-    describe("Sensor Node", () => {
-      const nodeType = "sensor";
-      it("can create sensor node", () => {
-        dataflowToolTile.getCreateNodeButton(nodeType).click();
-        dataflowToolTile.getNode(nodeType).should("exist");
-        dataflowToolTile.getNodeTitle().should("contain", "Sensor");
-      });
-      it("can toggle minigraph", () => {
-        dataflowToolTile.getShowGraphButton(nodeType).click();
-        dataflowToolTile.getMinigraph(nodeType).should("exist");
-        dataflowToolTile.getShowGraphButton(nodeType).click();
-        dataflowToolTile.getMinigraph(nodeType).should("not.exist");
-      });
-      it("verify sensor types", () => {
-        const dropdown = "sensor-type";
-        const sensorTypes = ["Temperature", "Humidity", "CO₂", "O₂", "Light", "Soil Moisture", "Particulates", "EMG", "Surface Pressure"];
-        dataflowToolTile.getDropdown(nodeType, dropdown).click();
-        dataflowToolTile.getSensorDropdownOptions(nodeType).should("have.length", 9);
-        dataflowToolTile.getSensorDropdownOptions(nodeType).each(($tab, index, $typeList) => {
-          expect($tab.text()).to.contain(sensorTypes[index]);
-        });
-      });
-      it("verify clear button", () => {
-        dataflowToolTile.getClearButton().click();
-        dataflowToolTile.getNode(nodeType).should("not.exist");
-      });
-      it("verify sensor select", () => {
-        const dropdown = "sensor-select";
-        const sensorSelect = [
-          "Humidity Demo Data", "CO2 Demo Data", "O2 Demo Data", "Light Demo Data", "Particulates Demo Data",
-         "⚠️ Connect Arduino for live EMG",
-         "⚠️ Connect Arduino for live Pressure",
-         "⚠️ Connect Arduino for live Temperature",
-         "⚠️ Connect micro:bit for live Temperature A",
-         "⚠️ Connect micro:bit for live Humidity A",
-         "⚠️ Connect micro:bit for live Temperature B",
-         "⚠️ Connect micro:bit for live Humidity B",
-         "⚠️ Connect micro:bit for live Temperature C",
-         "⚠️ Connect micro:bit for live Humidity C",
-         "⚠️ Connect micro:bit for live Temperature D",
-         "⚠️ Connect micro:bit for live Humidity D",
-        ];
-        dataflowToolTile.getCreateNodeButton(nodeType).click();
-        dataflowToolTile.getDropdown(nodeType, dropdown).click();
-        dataflowToolTile.getSensorDropdownOptions(nodeType).should("have.length", 16);
-        dataflowToolTile.getSensorDropdownOptions(nodeType).each(($tab, index, $typeList) => {
-          expect($tab.text()).to.contain(sensorSelect[index]);
-        });
-        dataflowToolTile.getClearButton().click();
-        dataflowToolTile.getNode(nodeType).should("not.exist");
-      });
-      it("verify node inputs outputs", () => {
-        dataflowToolTile.getCreateNodeButton(nodeType).click();
-        dataflowToolTile.getNodeInput().should("not.exist");
-        dataflowToolTile.getNodeOutput().should("exist");
-      });
-      it("can delete sensor node", () => {
-        dataflowToolTile.getDeleteNodeButton(nodeType).click();
-        dataflowToolTile.getNode(nodeType).should("not.exist");
-      });
-    });
-    describe("Record Data", () => {
-      it("can create a small program", () => {
-        const nodes = [ "timer", "demo-output" ];
-        dataflowToolTile.getCreateNodeButton(nodes[0]).click();
-        dataflowToolTile.getNode(nodes[0]).should("exist");
-        dataflowToolTile.getNodeTitle().should("contain", "Timer (on/off)");
-        dataflowToolTile.getCreateNodeButton(nodes[1]).click();
-        dataflowToolTile.getNode(nodes[1]).should("exist");
-        dataflowToolTile.getNodeTitle().should("contain", "Demo Output");
-        dataflowToolTile.getNodeOutput().eq(0).click();
-        dataflowToolTile.getNodeInput().eq(0).click();
-        dataflowToolTile.getShowGraphButton("demo-output").click();
-        dataflowToolTile.getMinigraph("demo-output").should("exist");
-      });
-      it("verify sampling rate", () => {
-        const rate = "500";
-        dataflowToolTile.getSamplingRateLabel().should("have.text", "Sampling Rate");
-        dataflowToolTile.selectSamplingRate(rate);
-      });
-      it("verify recording and stop recording", () => {
-        dataflowToolTile.verifyRecordButtonText();
-        dataflowToolTile.verifyRecordButtonIcon();
-        dataflowToolTile.getRecordButton().click();
+    dataflowToolTile.getClearButton().click();
+    dataflowToolTile.getNode(sensorNode).should("not.exist");
 
-        dataflowToolTile.verifyPlayButtonText();
-        dataflowToolTile.verifyPlayButtonIcon();
-        dataflowToolTile.getPlayButton().should("be.disabled");
-        dataflowToolTile.verifyStopButtonText();
-        dataflowToolTile.verifyStopButtonIcon();
+    cy.log("verify node inputs outputs");
+    dataflowToolTile.getCreateNodeButton(sensorNode).click();
+    dataflowToolTile.getNodeInput().should("not.exist");
+    dataflowToolTile.getNodeOutput().should("exist");
 
-        dataflowToolTile.getTimeSlider().should("be.visible");
-        dataflowToolTile.getCountdownTimer().should("contain", "/");
-        cy.wait(5000);
+    cy.log("can delete sensor node");
+    dataflowToolTile.getDeleteNodeButton(sensorNode).click();
+    dataflowToolTile.getNode(sensorNode).should("not.exist");
 
-        dataflowToolTile.getStopButton().click();
-      });
-      it("verify play and pause recording", () => {
-        dataflowToolTile.getPlayButton().should("be.enabled");
-        dataflowToolTile.verifyRecordingClearButtonText();
-        dataflowToolTile.verifyRecordingClearButtonIcon();
-        dataflowToolTile.getPlayButton().click();
+    cy.log("Record Data");
+    cy.log("can create a small program");
+    const nodes = ["timer", "demo-output"];
+    dataflowToolTile.getCreateNodeButton(nodes[0]).click();
+    dataflowToolTile.getNode(nodes[0]).should("exist");
+    dataflowToolTile.getNodeTitle().should("contain", "Timer (on/off)");
+    dataflowToolTile.getCreateNodeButton(nodes[1]).click();
+    dataflowToolTile.getNode(nodes[1]).should("exist");
+    dataflowToolTile.getNodeTitle().should("contain", "Demo Output");
+    dataflowToolTile.getNodeOutput().eq(0).click();
+    dataflowToolTile.getNodeInput().eq(0).click();
+    dataflowToolTile.getShowGraphButton("demo-output").click();
+    dataflowToolTile.getMinigraph("demo-output").should("exist");
 
-        dataflowToolTile.verifyPauseButtonText();
-        dataflowToolTile.verifyPauseButtonIcon();
-        dataflowToolTile.getPauseButton().should("be.enabled");
-        dataflowToolTile.getPauseButton().click();
+    cy.log("verify sampling rate");
+    const rate = "500";
+    dataflowToolTile.getSamplingRateLabel().should("have.text", "Sampling Rate");
+    dataflowToolTile.selectSamplingRate(rate);
 
-        dataflowToolTile.getPlayButton().should("be.enabled");
-        dataflowToolTile.getPlayButton().click();
-        cy.wait(5000);
-      });
-      it("verify clear recording", () => {
-        dataflowToolTile.verifyRecordingClearButtonText();
-        dataflowToolTile.verifyRecordingClearButtonIcon();
-        dataflowToolTile.getRecordingClearButton().click();
-        dataflowToolTile.getClearDataWarningTitle().should("have.text", "Clear Data");
-        dataflowToolTile.getClearDataWarningContent().should(
-          "contain",
-          "Remove the program's recorded data and any linked displays of this data? This action is not undoable.");
-        dataflowToolTile.getClearDataWarningCancel().click();
-        dataflowToolTile.verifyRecordingClearButtonText();
-        dataflowToolTile.verifyRecordingClearButtonIcon();
-        dataflowToolTile.getRecordingClearButton().click();
-        dataflowToolTile.getClearDataWarningClear().click();
-        dataflowToolTile.getSamplingRateLabel().should("have.text", "Sampling Rate");
-        dataflowToolTile.verifyRecordButtonText();
-        dataflowToolTile.verifyRecordButtonIcon();
-      });
-    });
+    cy.log("verify recording and stop recording");
+    dataflowToolTile.verifyRecordButtonText();
+    dataflowToolTile.verifyRecordButtonIcon();
+    dataflowToolTile.getRecordButton().click();
+    dataflowToolTile.verifyPlayButtonText();
+    dataflowToolTile.verifyPlayButtonIcon();
+    dataflowToolTile.getPlayButton().should("be.disabled");
+    dataflowToolTile.verifyStopButtonText();
+    dataflowToolTile.verifyStopButtonIcon();
+    dataflowToolTile.getTimeSlider().should("be.visible");
+    dataflowToolTile.getCountdownTimer().should("contain", "/");
+    cy.wait(5000);
+
+    dataflowToolTile.getStopButton().click();
+
+    cy.log("verify play and pause recording");
+    dataflowToolTile.getPlayButton().should("be.enabled");
+    dataflowToolTile.verifyRecordingClearButtonText();
+    dataflowToolTile.verifyRecordingClearButtonIcon();
+    dataflowToolTile.getPlayButton().click();
+
+    dataflowToolTile.verifyPauseButtonText();
+    dataflowToolTile.verifyPauseButtonIcon();
+    dataflowToolTile.getPauseButton().should("be.enabled");
+    dataflowToolTile.getPauseButton().click();
+
+    dataflowToolTile.getPlayButton().should("be.enabled");
+    dataflowToolTile.getPlayButton().click();
+    cy.wait(5000);
+
+    cy.log("verify clear recording");
+    dataflowToolTile.verifyRecordingClearButtonText();
+    dataflowToolTile.verifyRecordingClearButtonIcon();
+    dataflowToolTile.getRecordingClearButton().click();
+    dataflowToolTile.getClearDataWarningTitle().should("have.text", "Clear Data");
+    dataflowToolTile.getClearDataWarningContent().should(
+      "contain",
+      "Remove the program's recorded data and any linked displays of this data? This action is not undoable.");
+    dataflowToolTile.getClearDataWarningCancel().click();
+    dataflowToolTile.verifyRecordingClearButtonText();
+    dataflowToolTile.verifyRecordingClearButtonIcon();
+    dataflowToolTile.getRecordingClearButton().click();
+    dataflowToolTile.getClearDataWarningClear().click();
+    dataflowToolTile.getSamplingRateLabel().should("have.text", "Sampling Rate");
+    dataflowToolTile.verifyRecordButtonText();
+    dataflowToolTile.verifyRecordButtonIcon();
   });
 });

--- a/cypress/e2e/clue/branch/student_tests/diagram_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/diagram_tool_spec.js
@@ -6,11 +6,19 @@ import TextToolTile from '../../../../support/elements/clue/TextToolTile';
 let clueCanvas = new ClueCanvas,
   diagramTile = new DiagramToolTile,
   drawTile = new DrawToolTile;
-  const textTile = new TextToolTile;
+const textTile = new TextToolTile;
 
 const cmdKey = Cypress.platform === "darwin" ? "cmd" : "ctrl";
 const undoKeystroke = `{${cmdKey}}z`;
 const redoKeystroke = `{${cmdKey}}{shift}z`;
+
+function beforeTest() {
+  const queryParams = "?appMode=qa&fakeClass=5&fakeUser=student:5&qaGroup=5&unit=m2s";
+  cy.clearQAData('all');
+  cy.visit(queryParams);
+  cy.waitForLoad();
+  cy.showOnlyDocumentWorkspace();
+}
 
 context('Diagram Tool Tile', function () {
   const dialogField = (field) => cy.get(`#evd-${field}`);
@@ -22,322 +30,318 @@ context('Diagram Tool Tile', function () {
   const hideNavigatorButton = () => diagramTile.getDiagramToolbarButton("button-hide-navigator", undefined, true);
   const diagramDeleteButton = () => diagramTile.getDiagramToolbarButton("button-delete", undefined, true);
   const dialogOkButton = () => cy.get(".modal-button").last();
-  beforeEach(function () {
-    const queryParams = "?appMode=qa&fakeClass=5&fakeUser=student:5&qaGroup=5&unit=m2s";
-    cy.clearQAData('all');
+  
+  it("Shared Variable Tiles (Diagram, Drawing)", () => {
 
-    cy.visit(queryParams);
-    cy.waitForLoad();
-    cy.showOnlyDocumentWorkspace();
+    beforeTest();
+    clueCanvas.addTile("diagram");
+
+    // Tile, toolbar, and buttons render
+    diagramTile.getDiagramTile().should("exist").click();
+    diagramTile.getDiagramToolbar().should("exist");
+    diagramNewVariableButton().should("exist");
+    diagramInsertVariableButton().should("exist").should("be.disabled"); // Insert variable button is disabled when no variables have been created
+    diagramEditVariableButton().should("exist").should("be.disabled");
+    diagramTile.getDiagramToolbarButton("button-zoom-in").should("be.enabled");
+    diagramTile.getDiagramToolbarButton("button-zoom-out").should("be.enabled");
+    diagramTile.getDiagramToolbarButton("button-fit-view").should("be.enabled");
+    lockLayoutButton().should("exist");
+    hideNavigatorButton().should("exist");
+    diagramDeleteButton().should("exist").should("be.disabled");
+
+    // Title
+    const newName = "Test Diagram";
+    diagramTile.getTileTitleText().should("contain", "Diagram 1");
+    diagramTile.getTileTitleContainer().click();
+    diagramTile.getTileTitleContainer().type(newName + '{enter}');
+    diagramTile.getTileTitleText().should("contain", newName);
+
+    // Navigator can be hidden and shown
+    const navigator = () => diagramTile.getDiagramTile().find(".react-flow__minimap");
+    navigator().should("exist");
+    hideNavigatorButton().click();
+    navigator().should("not.exist");
+    hideNavigatorButton().click();
+    navigator().should("exist");
+
+    // New variable dialog works
+    diagramTile.getVariableCard().should("not.exist");
+    diagramNewVariableButton().click();
+    diagramTile.getDiagramDialog().should("exist");
+    const name = "name1";
+    dialogField("name").should("exist").type(name);
+    dialogOkButton().click();
+    diagramTile.getVariableCard().should("exist");
+    diagramTile.getVariableCardField("name").should("have.value", name);
+
+    // Insert variable button is disabled when all variables are in the diagram
+    diagramInsertVariableButton().should("be.disabled");
+
+    // Lock layout button prevents nodes from being selected
+    lockLayoutButton().click();
+    diagramDeleteButton().should("be.disabled");
+    diagramTile.getVariableCard().should("have.css", "pointer-events", "none");
+    lockLayoutButton().click();
+    diagramTile.getVariableCard().click();
+    diagramDeleteButton().should("be.enabled");
+
+    // Edit variable dialog works
+    const vName = "name3";
+    const vValue = "999.999";
+    const vUnit = "C";
+    diagramEditVariableButton().should("be.enabled").click();
+    dialogField("name").clear();
+    dialogField("name").type(vName);
+    dialogField("value").clear();
+    dialogField("value").type(vValue);
+    dialogField("units").clear();
+    dialogField("units").type(vUnit);
+    dialogOkButton().click();
+    diagramTile.getVariableCardField("name").should("have.value", vName);
+    diagramTile.getVariableCardField("value").should("have.value", vValue);
+    diagramTile.getVariableCardField("unit").should("have.value", vUnit);
+
+    // Edit directly in variable card
+    const eName = "name4";
+    const eValue = "888.888";
+    const eUnit = "M";
+    diagramTile.getVariableCardField("name").clear();
+    diagramTile.getVariableCardField("name").type(eName);
+    diagramTile.getVariableCardField("value").clear();
+    diagramTile.getVariableCardField("value").type(eValue);
+    diagramTile.getVariableCardField("unit").clear();
+    diagramTile.getVariableCardField("unit").type(eUnit);
+    diagramTile.getVariableCardField("name").should("have.value", eName);
+    diagramTile.getVariableCardField("value").should("have.value", eValue);
+    diagramTile.getVariableCardField("unit").should("have.value", eUnit);
+
+    // Add notes in variable card
+    diagramTile.getVariableCardNotesField().should("not.exist");
+    diagramTile.getVariableCardDescriptionToggle().click();
+    diagramTile.getVariableCardNotesField().should("exist");
+    diagramTile.getVariableCardNotesField().clear();
+    diagramTile.getVariableCardNotesField().type("test notes");
+    diagramTile.getVariableCardNotesField().should("have.value", "test notes");
+
+    // Edit variable card color
+    diagramTile.getColorEditorDialog().should("not.exist");
+    diagramTile.getVariableCardColorEditButton().click();
+    diagramTile.getColorEditorDialog().should("exist");
+    diagramTile.getColorPicker().last().click();
+    diagramTile.getVariableCard().children().should("have.class", "red");
+    diagramTile.getVariableCardColorEditButton().click();
+    diagramTile.getColorPicker().eq(3).click();
+    diagramTile.getVariableCard().children().should("have.class", "green");
+
+    // Fit view
+    diagramTile.getDiagramToolbarButton("button-fit-view").click();
+    diagramTile.getVariableCard().parent().parent().should("have.attr", "style").and("contain", "scale(2)");
+
+    // Delete button works
+    diagramDeleteButton().should("be.enabled").click();
+    diagramTile.getVariableCard().should("not.exist");
+
+    // Insert variable dialog shows unused variables
+    diagramInsertVariableButton().should("be.enabled").click();
+    diagramTile.getDiagramDialog().should("contain.text", "Unused variables:");
+    diagramTile.getDiagramDialogCloseButton().click();
+
+    // Can drag new variable button to create a new variable card
+    const dataTransfer = new DataTransfer;
+    const draggable = () => diagramTile.getDiagramToolbar(undefined, true).find("div[role=button]").first();
+    draggable().focus().trigger("dragstart", { dataTransfer });
+    diagramTile.getDiagramTile().trigger("drop", { dataTransfer });
+    draggable().trigger("dragend");
+    diagramTile.getVariableCard().should("exist");
+
+    // Can undo previous step by pressing control+z or command+z on the keyboard
+    cy.get("body").type(undoKeystroke);
+    diagramTile.getVariableCard().should("not.exist");
+
+    // Can redo previous step by pressing control+shift+z or command+shift+z on the keyboard
+    cy.get("body").type(redoKeystroke);
+    diagramTile.getVariableCard().should("exist");
+  
+    cy.log("Make sure only one diagram tile is allowed");
+    clueCanvas.addTile("diagram");
+    clueCanvas.verifyToolDisabled("diagram");
+    clueCanvas.deleteTile("diagram");
+    clueCanvas.verifyToolEnabled("diagram");
+    clueCanvas.addTile("diagram");
+    diagramTile.getDiagramTile().should("exist");
   });
-  describe("Shared Variable Tiles (Diagram, Drawing)", () => {
-    it("Diagram tile, toolbar, and dialogs", () => {
-      clueCanvas.addTile("diagram");
 
-      // Tile, toolbar, and buttons render
-      diagramTile.getDiagramTile().should("exist").click();
-      diagramTile.getDiagramToolbar().should("exist");
-      diagramNewVariableButton().should("exist");
-      diagramInsertVariableButton().should("exist").should("be.disabled"); // Insert variable button is disabled when no variables have been created
-      diagramEditVariableButton().should("exist").should("be.disabled");
-      diagramTile.getDiagramToolbarButton("button-zoom-in").should("be.enabled");
-      diagramTile.getDiagramToolbarButton("button-zoom-out").should("be.enabled");
-      diagramTile.getDiagramToolbarButton("button-fit-view").should("be.enabled");
-      lockLayoutButton().should("exist");
-      hideNavigatorButton().should("exist");
-      diagramDeleteButton().should("exist").should("be.disabled");
+  it("Drawing tile, text tile, toolbar, dialogs, and interactions between tiles", () => {
+    beforeTest();
 
-      // Title
-      const newName = "Test Diagram";
-      diagramTile.getTileTitleText().should("contain", "Diagram 1");
-      diagramTile.getTileTitleContainer().click();
-      diagramTile.getTileTitleContainer().type(newName + '{enter}');
-      diagramTile.getTileTitleText().should("contain", newName);
+    clueCanvas.addTile("diagram");
+    clueCanvas.addTile("drawing");
+    clueCanvas.addTile("text");
 
-      // Navigator can be hidden and shown
-      const navigator = () => diagramTile.getDiagramTile().find(".react-flow__minimap");
-      navigator().should("exist");
-      hideNavigatorButton().click();
-      navigator().should("not.exist");
-      hideNavigatorButton().click();
-      navigator().should("exist");
+    // Draw tile and toolbar buttons render
+    drawTile.getDrawTile().should("exist");
+    drawTile.getDrawToolNewVariable().should("exist").should("be.enabled");
+    drawTile.getDrawToolEditVariable().should("exist").should("be.disabled");
+    drawTile.getDrawToolInsertVariable().should("exist").should("be.disabled");
 
-      // New variable dialog works
-      diagramTile.getVariableCard().should("not.exist");
-      diagramNewVariableButton().click();
-      diagramTile.getDiagramDialog().should("exist");
-      const name = "name1";
-      dialogField("name").should("exist").type(name);
-      dialogOkButton().click();
-      diagramTile.getVariableCard().should("exist");
-      diagramTile.getVariableCardField("name").should("have.value", name);
+    // Text tile and editor render
+    textTile.getTextTile().should("exist");
+    textTile.getTextEditor().should("exist");
 
-      // Insert variable button is disabled when all variables are in the diagram
-      diagramInsertVariableButton().should("be.disabled");
+    // New variable dialog works
+    const vName = "variable-name";
+    const vNameProcessed = "variablename";
+    const vValue = "1.2";
+    const vUnit = "meter";
+    drawTile.getDrawTile().click();
+    drawTile.getDrawToolNewVariable().click();
+    cy.get(".custom-modal").should("exist");
+    dialogField("name").type(vName);
+    dialogField("value").type(vValue);
+    dialogField("units").type(vUnit);
+    drawTile.getVariableChip().should("not.exist");
+    dialogOkButton().click();
+    drawTile.getVariableChip().should("exist");
+    drawTile.getVariableChip().should("contain", vNameProcessed);
+    drawTile.getVariableChip().should("contain", vValue);
+    drawTile.getVariableChip().should("contain", vUnit);
 
-      // Lock layout button prevents nodes from being selected
-      lockLayoutButton().click();
-      diagramDeleteButton().should("be.disabled");
-      diagramTile.getVariableCard().should("have.css", "pointer-events", "none");
-      lockLayoutButton().click();
-      diagramTile.getVariableCard().click();
-      diagramDeleteButton().should("be.enabled");
+    // Diagram tile can insert variable created by another tile
+    const dialogChip = () => diagramTile.getDiagramDialog().find(".variable-chip");
+    diagramTile.getDiagramTile().click();
+    diagramTile.getVariableCard().should("not.exist");
+    diagramInsertVariableButton().should("be.enabled").click();
+    diagramTile.getDiagramDialog().should("contain.text", "other tiles:");
+    dialogChip().click();
+    dialogOkButton().click();
+    diagramTile.getVariableCard().should("exist");
+    diagramInsertVariableButton().should("be.disabled");
 
-      // Edit variable dialog works
-      const vName = "name3";
-      const vValue = "999.999";
-      const vUnit = "C";
-      diagramEditVariableButton().should("be.enabled").click();
-      dialogField("name").clear();
-      dialogField("name").type(vName);
-      dialogField("value").clear();
-      dialogField("value").type(vValue);
-      dialogField("units").clear();
-      dialogField("units").type(vUnit);
-      dialogOkButton().click();
-      diagramTile.getVariableCardField("name").should("have.value", vName);
-      diagramTile.getVariableCardField("value").should("have.value", vValue);
-      diagramTile.getVariableCardField("unit").should("have.value", vUnit);
+    // Draw tile edit variable dialog works
+    const newName = "vn2";
+    const newValue = "47";
+    const newUnit = "util";
+    drawTile.getDrawTile().click();
+    drawTile.getVariableChip().click();
+    drawTile.getDrawToolEditVariable().should("not.be.disabled").click();
+    dialogField("name").clear();
+    dialogField("name").type(newName);
+    dialogField("value").clear();
+    dialogField("value").type(newValue);
+    dialogField("units").clear();
+    dialogField("units").type(newUnit);
+    dialogOkButton().click();
+    drawTile.getVariableChip().should("contain", newName);
+    drawTile.getVariableChip().should("contain", newValue);
+    drawTile.getVariableChip().should("contain", newUnit);
 
-      // Edit directly in variable card
-      const eName = "name4";
-      const eValue = "888.888";
-      const eUnit = "M";
-      diagramTile.getVariableCardField("name").clear();
-      diagramTile.getVariableCardField("name").type(eName);
-      diagramTile.getVariableCardField("value").clear();
-      diagramTile.getVariableCardField("value").type(eValue);
-      diagramTile.getVariableCardField("unit").clear();
-      diagramTile.getVariableCardField("unit").type(eUnit);
-      diagramTile.getVariableCardField("name").should("have.value", eName);
-      diagramTile.getVariableCardField("value").should("have.value", eValue);
-      diagramTile.getVariableCardField("unit").should("have.value", eUnit);
+    // Editing variable in drawing tile also changes it in dialog tile
+    diagramTile.getVariableCardField("name").should("have.value", newName);
+    diagramTile.getVariableCardField("value").should("have.value", newValue);
+    diagramTile.getVariableCardField("unit").should("have.value", newUnit);
 
-      // Add notes in variable card
-      diagramTile.getVariableCardNotesField().should("not.exist");
-      diagramTile.getVariableCardDescriptionToggle().click();
-      diagramTile.getVariableCardNotesField().should("exist");
-      diagramTile.getVariableCardNotesField().clear();
-      diagramTile.getVariableCardNotesField().type("test notes");
-      diagramTile.getVariableCardNotesField().should("have.value", "test notes");
+    // Editing variable in diagram tile also changes it in drawing tile
+    const eName = "vn3";
+    const eValue = "2.5";
+    const eUnit = "meter";
+    diagramTile.getVariableCardField("name").clear();
+    diagramTile.getVariableCardField("name").type(eName);
+    diagramTile.getVariableCardField("value").clear();
+    diagramTile.getVariableCardField("value").type(eValue);
+    diagramTile.getVariableCardField("unit").clear();
+    diagramTile.getVariableCardField("unit").type(eUnit);
+    diagramTile.getVariableCardField("name").should("have.value", eName);
+    diagramTile.getVariableCardField("value").should("have.value", eValue);
+    diagramTile.getVariableCardField("unit").should("have.value", eUnit);
 
-      // Edit variable card color
-      diagramTile.getColorEditorDialog().should("not.exist");
-      diagramTile.getVariableCardColorEditButton().click();
-      diagramTile.getColorEditorDialog().should("exist");
-      diagramTile.getColorPicker().last().click();
-      diagramTile.getVariableCard().children().should("have.class", "red");
-      diagramTile.getVariableCardColorEditButton().click();
-      diagramTile.getColorPicker().eq(3).click();
-      diagramTile.getVariableCard().children().should("have.class", "green");
+    drawTile.getDrawTile().click();
+    drawTile.getVariableChip().should("contain", eName);
+    drawTile.getVariableChip().should("contain", eValue);
+    drawTile.getVariableChip().should("contain", eUnit);
 
-      // Fit view
-      diagramTile.getDiagramToolbarButton("button-fit-view").click();
-      diagramTile.getVariableCard().parent().parent().should("have.attr", "style").and("contain", "scale(2)");
+    // Draw tile insert variable dialog works
+    const listChip = otherClass => cy.get(`.variable-chip-list .variable-chip${otherClass || ""}`);
+    drawTile.getDrawTile().click();
+    drawTile.getVariableChip().click();
+    drawTile.getDrawToolDelete().click();
+    drawTile.getVariableChip().should("not.exist");
+    drawTile.getDrawToolInsertVariable().click();
+    listChip().click();
+    listChip(".selected").should("exist");
+    listChip().click();
+    listChip(".selected").should("not.exist");
+    listChip().click();
+    dialogOkButton().click();
+    drawTile.getVariableChip().should("exist");
+    drawTile.getVariableChip().click();
+    drawTile.getDrawToolDelete().click();
 
-      // Delete button works
-      diagramDeleteButton().should("be.enabled").click();
-      diagramTile.getVariableCard().should("not.exist");
+    // Undoing previous step in diagram tile by pressing control+z or command+z on
+    // the keyboard does not undo the most recent step in a different tile
+    diagramTile.getDiagramTile().click();
+    diagramTile.getVariableCardField("name").should("have.value", eName);
+    diagramTile.getVariableCardField("name").clear();
+    textTile.getTextTile().click();
+    textTile.enterText("Hello");
+    cy.get("body").type(undoKeystroke);
+    diagramTile.getVariableCardField("name").should("have.value", "");
+    textTile.getTextTile().should("contain", "Hell");
+  });
 
-      // Insert variable dialog shows unused variables
-      diagramInsertVariableButton().should("be.enabled").click();
-      diagramTile.getDiagramDialog().should("contain.text", "Unused variables:");
-      diagramTile.getDiagramDialogCloseButton().click();
+  it("Undo Redo Actions", () => {
+    beforeTest();
 
-      // Can drag new variable button to create a new variable card
-      const dataTransfer = new DataTransfer;
-      const draggable = () => diagramTile.getDiagramToolbar(undefined, true).find("div[role=button]").first();
-      draggable().focus().trigger("dragstart", { dataTransfer });
-      diagramTile.getDiagramTile().trigger("drop", { dataTransfer });
-      draggable().trigger("dragend");
-      diagramTile.getVariableCard().should("exist");
+    // Creation - Undo/Redo
+    clueCanvas.addTile('diagram');
+    diagramTile.getDiagramTile().should("exist");
+    clueCanvas.getUndoTool().should("not.have.class", "disabled");
+    clueCanvas.getRedoTool().should("have.class", "disabled");
+    clueCanvas.getUndoTool().click();
+    diagramTile.getDiagramTile().should("not.exist");
+    clueCanvas.getUndoTool().should("have.class", "disabled");
+    clueCanvas.getRedoTool().should("not.have.class", "disabled");
+    clueCanvas.getRedoTool().click();
+    diagramTile.getDiagramTile().should("exist");
+    clueCanvas.getUndoTool().should("not.have.class", "disabled");
+    clueCanvas.getRedoTool().should("have.class", "disabled");
 
-      // Can undo previous step by pressing control+z or command+z on the keyboard
-      cy.get("body").type(undoKeystroke);
-      diagramTile.getVariableCard().should("not.exist");
+    diagramNewVariableButton().click();
+    diagramTile.getDiagramDialog().should("exist");
+    const name = "name1";
+    dialogField("name").should("exist").type(name);
+    dialogOkButton().click();
+    diagramTile.getVariableCard().should("exist");
 
-      // Can redo previous step by pressing control+shift+z or command+shift+z on the keyboard
-      cy.get("body").type(redoKeystroke);
-      diagramTile.getVariableCard().should("exist");
-    });
+    //undo redo
+    clueCanvas.getUndoTool().click();
+    diagramTile.getVariableCard().should("not.exist");
+    clueCanvas.getRedoTool().click();
+    diagramTile.getVariableCard().should("exist");
 
-    it("Make sure only one diagram tile is allowed", () => {
-      clueCanvas.addTile("diagram");
-      clueCanvas.verifyToolDisabled("diagram");
-      clueCanvas.deleteTile("diagram");
-      clueCanvas.verifyToolEnabled("diagram");
-      clueCanvas.addTile("diagram");
-      diagramTile.getDiagramTile().should("exist");
-    });
+    // undo redo on text tile after inserting a variable card
+    const dialogChip = () => diagramTile.getDiagramDialog().find(".variable-chip");
+    clueCanvas.addTile("text");
+    textTile.getTextTile().click();
+    textTile.getTextToolInsertVariable().click();
+    diagramTile.getDiagramDialog().should("contain.text", "other tiles:");
+    dialogChip().click();
+    dialogOkButton().click();
+    textTile.getVariableChip().should("exist");
+    clueCanvas.getUndoTool().click();
+    textTile.getVariableChip().should("not.exist");
+    clueCanvas.getRedoTool().click();
+    textTile.getVariableChip().should("exist");
+    clueCanvas.getUndoTool().click();
 
-    it("Drawing tile, text tile, toolbar, dialogs, and interactions between tiles", () => {
-      clueCanvas.addTile("diagram");
-      clueCanvas.addTile("drawing");
-      clueCanvas.addTile("text");
-
-      // Draw tile and toolbar buttons render
-      drawTile.getDrawTile().should("exist");
-      drawTile.getDrawToolNewVariable().should("exist").should("be.enabled");
-      drawTile.getDrawToolEditVariable().should("exist").should("be.disabled");
-      drawTile.getDrawToolInsertVariable().should("exist").should("be.disabled");
-
-      // Text tile and editor render
-      textTile.getTextTile().should("exist");
-      textTile.getTextEditor().should("exist");
-
-      // New variable dialog works
-      const vName = "variable-name";
-      const vNameProcessed = "variablename";
-      const vValue = "1.2";
-      const vUnit = "meter";
-      drawTile.getDrawTile().click();
-      drawTile.getDrawToolNewVariable().click();
-      cy.get(".custom-modal").should("exist");
-      dialogField("name").type(vName);
-      dialogField("value").type(vValue);
-      dialogField("units").type(vUnit);
-      drawTile.getVariableChip().should("not.exist");
-      dialogOkButton().click();
-      drawTile.getVariableChip().should("exist");
-      drawTile.getVariableChip().should("contain", vNameProcessed);
-      drawTile.getVariableChip().should("contain", vValue);
-      drawTile.getVariableChip().should("contain", vUnit);
-
-      // Diagram tile can insert variable created by another tile
-      const dialogChip = () => diagramTile.getDiagramDialog().find(".variable-chip");
-      diagramTile.getDiagramTile().click();
-      diagramTile.getVariableCard().should("not.exist");
-      diagramInsertVariableButton().should("be.enabled").click();
-      diagramTile.getDiagramDialog().should("contain.text", "other tiles:");
-      dialogChip().click();
-      dialogOkButton().click();
-      diagramTile.getVariableCard().should("exist");
-      diagramInsertVariableButton().should("be.disabled");
-
-      // Draw tile edit variable dialog works
-      const newName = "vn2";
-      const newValue = "47";
-      const newUnit = "util";
-      drawTile.getDrawTile().click();
-      drawTile.getVariableChip().click();
-      drawTile.getDrawToolEditVariable().should("not.be.disabled").click();
-      dialogField("name").clear();
-      dialogField("name").type(newName);
-      dialogField("value").clear();
-      dialogField("value").type(newValue);
-      dialogField("units").clear();
-      dialogField("units").type(newUnit);
-      dialogOkButton().click();
-      drawTile.getVariableChip().should("contain", newName);
-      drawTile.getVariableChip().should("contain", newValue);
-      drawTile.getVariableChip().should("contain", newUnit);
-
-      // Editing variable in drawing tile also changes it in dialog tile
-      diagramTile.getVariableCardField("name").should("have.value", newName);
-      diagramTile.getVariableCardField("value").should("have.value", newValue);
-      diagramTile.getVariableCardField("unit").should("have.value", newUnit);
-
-      // Editing variable in diagram tile also changes it in drawing tile
-      const eName = "vn3";
-      const eValue = "2.5";
-      const eUnit = "meter";
-      diagramTile.getVariableCardField("name").clear();
-      diagramTile.getVariableCardField("name").type(eName);
-      diagramTile.getVariableCardField("value").clear();
-      diagramTile.getVariableCardField("value").type(eValue);
-      diagramTile.getVariableCardField("unit").clear();
-      diagramTile.getVariableCardField("unit").type(eUnit);
-      diagramTile.getVariableCardField("name").should("have.value", eName);
-      diagramTile.getVariableCardField("value").should("have.value", eValue);
-      diagramTile.getVariableCardField("unit").should("have.value", eUnit);
-
-      drawTile.getDrawTile().click();
-      drawTile.getVariableChip().should("contain", eName);
-      drawTile.getVariableChip().should("contain", eValue);
-      drawTile.getVariableChip().should("contain", eUnit);
-
-      // Draw tile insert variable dialog works
-      const listChip = otherClass => cy.get(`.variable-chip-list .variable-chip${otherClass || ""}`);
-      drawTile.getDrawTile().click();
-      drawTile.getVariableChip().click();
-      drawTile.getDrawToolDelete().click();
-      drawTile.getVariableChip().should("not.exist");
-      drawTile.getDrawToolInsertVariable().click();
-      listChip().click();
-      listChip(".selected").should("exist");
-      listChip().click();
-      listChip(".selected").should("not.exist");
-      listChip().click();
-      dialogOkButton().click();
-      drawTile.getVariableChip().should("exist");
-      drawTile.getVariableChip().click();
-      drawTile.getDrawToolDelete().click();
-
-      // Undoing previous step in diagram tile by pressing control+z or command+z on
-      // the keyboard does not undo the most recent step in a different tile
-      diagramTile.getDiagramTile().click();
-      diagramTile.getVariableCardField("name").should("have.value", eName);
-      diagramTile.getVariableCardField("name").clear();
-      textTile.getTextTile().click();
-      textTile.enterText("Hello");
-      cy.get("body").type(undoKeystroke);
-      diagramTile.getVariableCardField("name").should("have.value", "");
-      textTile.getTextTile().should("contain", "Hell");
-    });
-
-    it("Undo Redo Actions", () => {
-      // Creation - Undo/Redo
-      clueCanvas.addTile('diagram');
-      diagramTile.getDiagramTile().should("exist");
-      clueCanvas.getUndoTool().should("not.have.class", "disabled");
-      clueCanvas.getRedoTool().should("have.class", "disabled");
-      clueCanvas.getUndoTool().click();
-      diagramTile.getDiagramTile().should("not.exist");
-      clueCanvas.getUndoTool().should("have.class", "disabled");
-      clueCanvas.getRedoTool().should("not.have.class", "disabled");
-      clueCanvas.getRedoTool().click();
-      diagramTile.getDiagramTile().should("exist");
-      clueCanvas.getUndoTool().should("not.have.class", "disabled");
-      clueCanvas.getRedoTool().should("have.class", "disabled");
-
-      diagramNewVariableButton().click();
-      diagramTile.getDiagramDialog().should("exist");
-      const name = "name1";
-      dialogField("name").should("exist").type(name);
-      dialogOkButton().click();
-      diagramTile.getVariableCard().should("exist");
-
-      //undo redo
-      clueCanvas.getUndoTool().click();
-      diagramTile.getVariableCard().should("not.exist");
-      clueCanvas.getRedoTool().click();
-      diagramTile.getVariableCard().should("exist");
-
-      // undo redo on text tile after inserting a variable card
-      const dialogChip = () => diagramTile.getDiagramDialog().find(".variable-chip");
-      clueCanvas.addTile("text");
-      textTile.getTextTile().click();
-      textTile.getTextToolInsertVariable().click();
-      diagramTile.getDiagramDialog().should("contain.text", "other tiles:");
-      dialogChip().click();
-      dialogOkButton().click();
-      textTile.getVariableChip().should("exist");
-      clueCanvas.getUndoTool().click();
-      textTile.getVariableChip().should("not.exist");
-      clueCanvas.getRedoTool().click();
-      textTile.getVariableChip().should("exist");
-      clueCanvas.getUndoTool().click();
-
-      //undo redo on text tile after adding a new variable
-      textTile.getTextTile().click();
-      textTile.getTextToolNewVariable().click();
-      dialogField("name").should("exist").type("name2");
-      dialogOkButton().click();
-      textTile.getVariableChip().should("exist");
-      clueCanvas.getUndoTool().click();
-      textTile.getVariableChip().should("not.exist");
-      clueCanvas.getRedoTool().click();
-      textTile.getVariableChip().should("exist");
-    });
+    //undo redo on text tile after adding a new variable
+    textTile.getTextTile().click();
+    textTile.getTextToolNewVariable().click();
+    dialogField("name").should("exist").type("name2");
+    dialogOkButton().click();
+    textTile.getVariableChip().should("exist");
+    clueCanvas.getUndoTool().click();
+    textTile.getVariableChip().should("not.exist");
+    clueCanvas.getRedoTool().click();
+    textTile.getVariableChip().should("exist");
   });
 });

--- a/cypress/e2e/clue/branch/student_tests/drawing_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/drawing_tool_spec.js
@@ -6,6 +6,15 @@ let clueCanvas = new ClueCanvas,
   drawToolTile = new DrawToolTile;
 const imageToolTile = new ImageToolTile;
 
+function beforeTest() {
+  const queryParams = "?appMode=qa&fakeClass=5&fakeUser=student:5&qaGroup=5&unit=msa";
+  cy.clearQAData('all');
+
+  cy.visit(queryParams);
+  cy.waitForLoad();
+  cy.showOnlyDocumentWorkspace();
+}
+
 // NOTE: For some reason cypress+chrome thinks that the SVG elements are in a
 // scrollable container. Because of this when cypress does an action on a SVG
 // element like click or trigger, by default it tries to scroll this element to
@@ -21,618 +30,609 @@ const imageToolTile = new ImageToolTile;
 //   so cypress+chrome simply cannot scroll the container.
 
 context('Draw Tool Tile', function () {
-  before(function () {
-    const queryParams = "?appMode=qa&fakeClass=5&fakeUser=student:5&qaGroup=5&unit=msa";
-    cy.clearQAData('all');
+  it("renders draw tool tile", () => {
+    beforeTest();
 
-    cy.visit(queryParams);
-    cy.waitForLoad();
-    cy.showOnlyDocumentWorkspace();
+    clueCanvas.addTile("drawing");
+    drawToolTile.getDrawTile().should("exist");
+    drawToolTile.getTileTitle().should("exist");
+
+    cy.log("can open show/sort panel and select objects");
+    drawToolTile.getDrawToolRectangle().click();
+    drawToolTile.getDrawTile()
+      .trigger("mousedown", 100, 50)
+      .trigger("mousemove", 250, 150)
+      .trigger("mouseup", 250, 150);
+    drawToolTile.getDrawToolEllipse().click();
+    drawToolTile.getDrawTile()
+      .trigger("mousedown", 300, 50)
+      .trigger("mousemove", 400, 150)
+      .trigger("mouseup", 400, 150);
+    // Unselect all
+    drawToolTile.getDrawTile()
+      .trigger("mousedown", 50, 50)
+      .trigger("mouseup", 50, 50);
+    drawToolTile.getSelectionBox().should("not.exist");
+
+    // Open panel
+    drawToolTile.getDrawTileShowSortPanelOpenButton().click({ scrollBehavior: false });
+    drawToolTile.getDrawTileShowSortPanel().should("have.class", "open").and("contain.text", "Rectangle").and("contain.text", "Circle");
+    // Click to select
+    drawToolTile.getDrawTileShowSortPanel().get('li:first').should("contain.text", "Circle").click({ scrollBehavior: false });
+    drawToolTile.getSelectionBox().should("exist");
+
+    cy.log("can hide and show objects");
+    drawToolTile.getEllipseDrawing().should("exist");
+    // Click 'hide' button - unselects ellipse and makes it invisible
+    drawToolTile.getDrawTileShowSortPanel().get('li:first button.visibility-icon').click();
+    drawToolTile.getEllipseDrawing().should("not.exist");
+    drawToolTile.getSelectionBox().should("not.exist");
+    // Now select it - should show as a faint 'ghost'
+    drawToolTile.getDrawTileShowSortPanel().get('li:first').click();
+    drawToolTile.getSelectionBox().should("exist");
+    drawToolTile.getGhostGroup().should("exist").get('ellipse').should("exist");
+    // Make visible again
+    drawToolTile.getDrawTileShowSortPanel().get('li:first button.visibility-icon').click();
+    drawToolTile.getEllipseDrawing().should("exist");
+    drawToolTile.getGhostGroup().should("not.exist");
+
+    cy.log("can re-order objects");
+    // Test via keyboard since dragging is harder
+    drawToolTile.getDrawTileShowSortPanel().get('li:first').should("contain.text", "Circle");
+    drawToolTile.getDrawTileShowSortPanel().get('li:last').should("contain.text", "Rectangle");
+    drawToolTile.getDrawTileShowSortPanel().get('li:first svg.move-icon').focus().type(' {downArrow}{enter}');
+    drawToolTile.getDrawTileShowSortPanel().get('li:first').should("contain.text", "Rectangle");
+    drawToolTile.getDrawTileShowSortPanel().get('li:last').should("contain.text", "Circle");
+
+    cy.log("can delete objects and close panel");
+    // Delete objects
+    drawToolTile.getDrawTileShowSortPanel().get('li:first').should("contain.text", "Rectangle").click();
+    drawToolTile.getDrawToolDelete().should("not.have.class", "disabled").click();
+    drawToolTile.getDrawTileShowSortPanel().get('li').should("have.length", 1);
+    drawToolTile.getDrawTileShowSortPanel().get('li:first').should("contain.text", "Circle").click();
+    drawToolTile.getDrawToolDelete().should("not.have.class", "disabled").click();
+    drawToolTile.getDrawTileShowSortPanel().get('li').should("not.exist");
+    // Close panel
+    drawToolTile.getDrawTileShowSortPanelCloseButton().click();
+    drawToolTile.getDrawTileShowSortPanel().should("have.class", "closed");
+
+    cy.log("verify draw a line");
+    drawToolTile.getDrawToolFreehand().click();
+    drawToolTile.getDrawTile()
+      .trigger("mousedown", 350, 50)
+      .trigger("mousemove", 350, 100)
+      .trigger("mousemove", 450, 100)
+      .trigger("mouseup", 450, 100);
+    drawToolTile.getFreehandDrawing().should("exist").and("have.length", 1);
+    // Freehand tool should still be active
+    drawToolTile.getDrawToolFreehand().should("have.class", "selected");
+
+    cy.log("shows up in show/sort panel");
+    drawToolTile.getDrawTileShowSortPanelOpenButton().click();
+    drawToolTile.getDrawTileShowSortPanel().should("have.class", "open")
+      .get("li").should("have.length", 1).and("contain.text", "Freehand");
+    drawToolTile.getDrawTileShowSortPanelCloseButton().click();
+
+    cy.log("selects freehand drawing");
+    drawToolTile.getDrawToolSelect().click();
+    // First make sure we don't select it even if we are inside of its
+    // bounding box
+    drawToolTile.getDrawTile()
+      .trigger("mousedown", 370, 50)
+      .trigger("mousemove", 450, 80)
+      .trigger("mouseup", 450, 80);
+    drawToolTile.getDrawToolDelete().should("have.class", "disabled");
+
+    drawToolTile.getDrawTile()
+      .trigger("mousedown", 340, 90)
+      .trigger("mousemove", 360, 110)
+      .trigger("mouseup", 360, 110);
+    drawToolTile.getDrawToolDelete().should("not.have.class", "disabled");
+
+    cy.log("verify change outline color");
+    drawToolTile.getDrawToolStrokeColor().click();
+    cy.get(".toolbar-palette.stroke-color .palette-buttons").should("be.visible");
+    cy.get(".toolbar-palette.stroke-color .palette-buttons .color-swatch").eq(1).click();
+    drawToolTile.getFreehandDrawing().first().should("have.attr", "stroke").and("eq", "#eb0000");
+
+    cy.log("deletes freehand drawing");
+    // Without the previous test this is how to select it, using the simple click
+    // approach doesn't seem to work well with paths, the location that cypress clicks
+    // is not on the path
+    // drawToolTile.getDrawToolSelect().click();
+    // drawToolTile.getDrawTile()
+    //   .trigger("mousedown", 350, 100)
+    //   .trigger("mouseup", 350, 100);
+    drawToolTile.getSelectionBox().should("exist");
+    drawToolTile.getDrawToolDelete().should("not.have.class", "disabled").click();
+    drawToolTile.getFreehandDrawing().should("not.exist");
   });
-  describe("Draw Tool", () => {
-    it("renders draw tool tile", () => {
-      clueCanvas.addTile("drawing");
-      drawToolTile.getDrawTile().should("exist");
-      drawToolTile.getTileTitle().should("exist");
-    });
-    describe("Show/sort", { scrollBehavior: false }, () => {
-      it("can open show/sort panel and select objects", () => {
-        drawToolTile.getDrawToolRectangle().click();
-        drawToolTile.getDrawTile()
-          .trigger("mousedown", 100,  50)
-          .trigger("mousemove", 250, 150)
-          .trigger("mouseup",   250, 150);
-        drawToolTile.getDrawToolEllipse().click();
-        drawToolTile.getDrawTile()
-          .trigger("mousedown", 300,  50)
-          .trigger("mousemove", 400, 150)
-          .trigger("mouseup",   400, 150);
-        // Unselect all
-        drawToolTile.getDrawTile()
-          .trigger("mousedown", 50, 50)
-          .trigger("mouseup", 50, 50);
-        drawToolTile.getSelectionBox().should("not.exist");
+  it("Vector", { scrollBehavior: false }, () => {
+    beforeTest();
+    clueCanvas.addTile("drawing");
 
-        // Open panel
-        drawToolTile.getDrawTileShowSortPanelOpenButton().click({scrollBehavior: false});
-        drawToolTile.getDrawTileShowSortPanel().should("have.class", "open").and("contain.text", "Rectangle").and("contain.text", "Circle");
-        // Click to select
-        drawToolTile.getDrawTileShowSortPanel().get('li:first').should("contain.text", "Circle").click({scrollBehavior: false});
-        drawToolTile.getSelectionBox().should("exist");
-      });
-      it("can hide and show objects", () => {
-        drawToolTile.getEllipseDrawing().should("exist");
-        // Click 'hide' button - unselects ellipse and makes it invisible
-        drawToolTile.getDrawTileShowSortPanel().get('li:first button.visibility-icon').click();
-        drawToolTile.getEllipseDrawing().should("not.exist");
-        drawToolTile.getSelectionBox().should("not.exist");
-        // Now select it - should show as a faint 'ghost'
-        drawToolTile.getDrawTileShowSortPanel().get('li:first').click();
-        drawToolTile.getSelectionBox().should("exist");
-        drawToolTile.getGhostGroup().should("exist").get('ellipse').should("exist");
-        // Make visible again
-        drawToolTile.getDrawTileShowSortPanel().get('li:first button.visibility-icon').click();
-        drawToolTile.getEllipseDrawing().should("exist");
-        drawToolTile.getGhostGroup().should("not.exist");
-      });
-      it("can re-order objects", () => {
-        // Test via keyboard since dragging is harder
-        drawToolTile.getDrawTileShowSortPanel().get('li:first').should("contain.text", "Circle");
-        drawToolTile.getDrawTileShowSortPanel().get('li:last').should("contain.text", "Rectangle");
-        drawToolTile.getDrawTileShowSortPanel().get('li:first svg.move-icon').focus().type(' {downArrow}{enter}');
-        drawToolTile.getDrawTileShowSortPanel().get('li:first').should("contain.text", "Rectangle");
-        drawToolTile.getDrawTileShowSortPanel().get('li:last').should("contain.text", "Circle");
-      });
-      it("can delete objects and close panel", () => {
-        // Delete objects
-        drawToolTile.getDrawTileShowSortPanel().get('li:first').should("contain.text", "Rectangle").click();
-        drawToolTile.getDrawToolDelete().should("not.have.class", "disabled").click();
-        drawToolTile.getDrawTileShowSortPanel().get('li').should("have.length", 1);
-        drawToolTile.getDrawTileShowSortPanel().get('li:first').should("contain.text", "Circle").click();
-        drawToolTile.getDrawToolDelete().should("not.have.class", "disabled").click();
-        drawToolTile.getDrawTileShowSortPanel().get('li').should("not.exist");
-        // Close panel
-        drawToolTile.getDrawTileShowSortPanelCloseButton().click();
-        drawToolTile.getDrawTileShowSortPanel().should("have.class", "closed");
-      });
-    });
-    describe("Freehand", {scrollBehavior: false}, () => {
-      it("verify draw a line", () => {
-        drawToolTile.getDrawToolFreehand().click();
-        drawToolTile.getDrawTile()
-          .trigger("mousedown", 350, 50)
-          .trigger("mousemove", 350, 100)
-          .trigger("mousemove", 450, 100)
-          .trigger("mouseup",   450, 100);
-        drawToolTile.getFreehandDrawing().should("exist").and("have.length", 1);
-        // Freehand tool should still be active
-        drawToolTile.getDrawToolFreehand().should("have.class", "selected");
-      });
-      it("shows up in show/sort panel", () => {
-        drawToolTile.getDrawTileShowSortPanelOpenButton().click();
-        drawToolTile.getDrawTileShowSortPanel().should("have.class", "open")
-          .get("li").should("have.length", 1).and("contain.text", "Freehand");
-        drawToolTile.getDrawTileShowSortPanelCloseButton().click();
-      });
-      it("selects freehand drawing", () => {
-        drawToolTile.getDrawToolSelect().click();
-        // First make sure we don't select it even if we are inside of its
-        // bounding box
-        drawToolTile.getDrawTile()
-          .trigger("mousedown", 370, 50)
-          .trigger("mousemove", 450, 80)
-          .trigger("mouseup",   450, 80);
-        drawToolTile.getDrawToolDelete().should("have.class", "disabled");
+    cy.log("verify draw vector");
+    drawToolTile.getDrawToolVector().click();
+    drawToolTile.getDrawTile()
+      .trigger("mousedown", 250, 50)
+      .trigger("mousemove", 100, 50)
+      .trigger("mouseup", 100, 50);
+    drawToolTile.getVectorDrawing().should("exist").and("have.length", 1);
+    // Select tool should be selected after object created
+    drawToolTile.getDrawToolSelect().should("have.class", "selected");
 
-        drawToolTile.getDrawTile()
-          .trigger("mousedown", 340, 90)
-          .trigger("mousemove", 360, 110)
-          .trigger("mouseup",   360, 110);
-        drawToolTile.getDrawToolDelete().should("not.have.class", "disabled");
-      });
-      it("verify change outline color", () => {
-        drawToolTile.getDrawToolStrokeColor().click();
-        cy.get(".toolbar-palette.stroke-color .palette-buttons").should("be.visible");
-        cy.get(".toolbar-palette.stroke-color .palette-buttons .color-swatch").eq(1).click();
-        drawToolTile.getFreehandDrawing().first().should("have.attr", "stroke").and("eq", "#eb0000");
-      });
-      it("deletes freehand drawing", () => {
-        // Without the previous test this is how to select it, using the simple click
-        // approach doesn't seem to work well with paths, the location that cypress clicks
-        // is not on the path
-        // drawToolTile.getDrawToolSelect().click();
-        // drawToolTile.getDrawTile()
-        //   .trigger("mousedown", 350, 100)
-        //   .trigger("mouseup", 350, 100);
-        drawToolTile.getSelectionBox().should("exist");
-        drawToolTile.getDrawToolDelete().should("not.have.class", "disabled").click();
-        drawToolTile.getFreehandDrawing().should("not.exist");
-      });
-    });
-    describe("Vector", {scrollBehavior: false}, () => {
-      it("verify draw vector", () => {
-        drawToolTile.getDrawToolVector().click();
-        drawToolTile.getDrawTile()
-          .trigger("mousedown", 250, 50)
-          .trigger("mousemove", 100, 50)
-          .trigger("mouseup",   100, 50);
-        drawToolTile.getVectorDrawing().should("exist").and("have.length", 1);
-        // Select tool should be selected after object created
-        drawToolTile.getDrawToolSelect().should("have.class", "selected");
-      });
-      it("shows up in show/sort panel", () => {
-        drawToolTile.getDrawTileShowSortPanelOpenButton().click();
-        drawToolTile.getDrawTileShowSortPanel().should("have.class", "open")
-          .get("li").should("have.length", 1).and("contain.text", "Line");
-        drawToolTile.getDrawTileShowSortPanelCloseButton().click();
-      });
-      it("verify after creation, object is selected", () => {
-        drawToolTile.getDrawToolSelect().should("have.class", "selected");
-        drawToolTile.getDrawToolVector().should("not.have.class", "selected");
-        drawToolTile.getSelectionBox().should("exist");
-        drawToolTile.getDrawToolDelete().should("not.have.class", "disabled");
-      });
-      it("verify change outline color", () => {
-        drawToolTile.getDrawToolStrokeColor().click();
-        cy.get(".toolbar-palette.stroke-color .palette-buttons").should("be.visible");
-        cy.get(".toolbar-palette.stroke-color .palette-buttons .color-swatch").eq(2).click();
-        drawToolTile.getVectorDrawing().first().should("have.attr", "stroke").and("eq", "#008a00");
-        drawToolTile.getDrawToolStrokeColor().click();
-        cy.get(".toolbar-palette.stroke-color .palette-buttons").should("be.visible");
-        cy.get(".toolbar-palette.stroke-color .palette-buttons .color-swatch").first().click();
-      });
-      it("change line to arrow", () => {
-        drawToolTile.getVectorDrawing().children().its("length").should("eq", 1); // Only a line, no arrowheads yet.
-        drawToolTile.getDrawToolVectorSubmenu().click();
-        cy.get(".toolbar-palette.vectors .drawing-tool-buttons").should("be.visible");
-        cy.get(".toolbar-palette.vectors .drawing-tool-buttons div:nth-child(3) button").click();
-        drawToolTile.getVectorDrawing().children().its("length").should("eq", 3); // Now three items in group...
-        drawToolTile.getVectorDrawing().find("polygon").its("length").should("eq", 2); // including two arrowheads.
-        // selecting from this submenu activates the vector tool, which de-selects the object.
-        });
-      it("deletes vector drawing", () => {
-        // re-select the object using a selection rectangle.
-        drawToolTile.getDrawToolSelect().click();
-        drawToolTile.getDrawTile()
-          .trigger("mousedown", 90, 40)
-          .trigger("mousemove", 260, 60)
-          .trigger("mouseup",   260, 60);
-        drawToolTile.getDrawToolDelete().click();
-        drawToolTile.getVectorDrawing().should("not.exist");
-      });
-    });
-    describe("Rectangle", {scrollBehavior: false}, () => {
-      it("verify draw rectangle", () => {
-        drawToolTile.getDrawToolRectangle().click();
-        drawToolTile.getDrawTile()
-          .trigger("mousedown", 250,  50)
-          .trigger("mousemove", 100, 150)
-          .trigger("mouseup",   100,  50);
-        drawToolTile.getRectangleDrawing().should("exist").and("have.length", 1);
-        // Select tool should be selected after object created
-        drawToolTile.getDrawToolSelect().should("have.class", "selected");
-      });
-      it("shows up in show/sort panel", () => {
-        drawToolTile.getDrawTileShowSortPanelOpenButton().click();
-        drawToolTile.getDrawTileShowSortPanel().should("have.class", "open")
-          .get("li").should("have.length", 1).and("contain.text", "Rectangle");
-        drawToolTile.getDrawTileShowSortPanelCloseButton().click();
-      });
-      it("verify change outline color", () => {
-        drawToolTile.getRectangleDrawing().first().should("have.attr", "stroke").and("eq", "#000000");
-        drawToolTile.getDrawToolStrokeColor().click();
-        cy.get(".toolbar-palette.stroke-color .palette-buttons").should("be.visible");
-        cy.get(".toolbar-palette.stroke-color .palette-buttons .color-swatch").last().click();
-        drawToolTile.getRectangleDrawing().first().should("have.attr", "stroke").and("eq", "#d100d1");
-      });
-      it("verify change fill color", () => {
-        drawToolTile.getRectangleDrawing().first().should("not.have.attr", "fill-color");
-        // The rectangle is already selected, so we don't need to select it again
-        drawToolTile.getDrawToolFillColor().click();
-        cy.get(".toolbar-palette.fill-color .palette-buttons").should("be.visible");
-        cy.get(".toolbar-palette.fill-color .palette-buttons .color-swatch").last().click();
-        drawToolTile.getRectangleDrawing().first().should("have.attr", "fill").and("eq", "#d100d1");
-      });
-      it("verify moving pre-selected object", () => {
-        drawToolTile.getDrawToolSelect().click();
-        drawToolTile.getDrawTile()
-          .trigger("mousedown", 100, 100)
-          .trigger("mousemove", 200, 100)
-          .trigger("mouseup", 200, 100);
-        // For some reason the move isn't very accurate in cypress so often the final location off
-        drawToolTile.getRectangleDrawing().first().should("have.attr", "x").then(parseInt).and("within", 160, 220);
-      });
-      it("verify hovering objects", () => {
-        drawToolTile.getDrawTile()
-          // Un-select the rectangle
-          .trigger("mousedown", 500, 100)
-          .trigger("mouseup", 500, 100);
+    cy.log("shows up in show/sort panel");
+    drawToolTile.getDrawTileShowSortPanelOpenButton().click();
+    drawToolTile.getDrawTileShowSortPanel().should("have.class", "open")
+      .get("li").should("have.length", 1).and("contain.text", "Line");
+    drawToolTile.getDrawTileShowSortPanelCloseButton().click();
 
-        drawToolTile.getRectangleDrawing().first()
-          // Get the rectangle to be hovered. In the code we are listening to
-          // `onMouseEnter` but in Cypress triggering a "mouseenter" event
-          // doesn't work. Triggering a "mouseover" does work for some reason.
-          .trigger("mouseover");
+    cy.log("verify after creation, object is selected");
+    drawToolTile.getDrawToolSelect().should("have.class", "selected");
+    drawToolTile.getDrawToolVector().should("not.have.class", "selected");
+    drawToolTile.getSelectionBox().should("exist");
+    drawToolTile.getDrawToolDelete().should("not.have.class", "disabled");
 
-        // The hover box is rendered as a selection-box with a different color
-        drawToolTile.getHighlightBox().should("exist").should("have.attr", "stroke").and("eq", "#bbdd00");
+    cy.log("verify change outline color");
+    drawToolTile.getDrawToolStrokeColor().click();
+    cy.get(".toolbar-palette.stroke-color .palette-buttons").should("be.visible");
+    cy.get(".toolbar-palette.stroke-color .palette-buttons .color-swatch").eq(2).click();
+    drawToolTile.getVectorDrawing().first().should("have.attr", "stroke").and("eq", "#008a00");
+    drawToolTile.getDrawToolStrokeColor().click();
+    cy.get(".toolbar-palette.stroke-color .palette-buttons").should("be.visible");
+    cy.get(".toolbar-palette.stroke-color .palette-buttons .color-swatch").first().click();
 
-        // The best way I found to remove the hover was to delete the rectangle
-        drawToolTile.getRectangleDrawing().first().click({force: true});
-        drawToolTile.getDrawToolDelete().click();
-        drawToolTile.getHighlightBox().should("not.exist");
+    cy.log("change line to arrow");
+    drawToolTile.getVectorDrawing().children().its("length").should("eq", 1); // Only a line, no arrowheads yet.
+    drawToolTile.getDrawToolVectorSubmenu().click();
+    cy.get(".toolbar-palette.vectors .drawing-tool-buttons").should("be.visible");
+    cy.get(".toolbar-palette.vectors .drawing-tool-buttons div:nth-child(3) button").click();
+    drawToolTile.getVectorDrawing().children().its("length").should("eq", 3); // Now three items in group...
+    drawToolTile.getVectorDrawing().find("polygon").its("length").should("eq", 2); // including two arrowheads.
+    // selecting from this submenu activates the vector tool, which de-selects the object.
 
-      });
-      it("verify moving not selected object", () => {
-        drawToolTile.getDrawToolRectangle().click();
-        drawToolTile.getDrawTile()
-          .trigger("mousedown", 250,  50)
-          .trigger("mousemove", 100, 150)
-          .trigger("mouseup",   100, 150);
-        drawToolTile.getRectangleDrawing().should("exist").and("have.length", 1);
-        drawToolTile.getSelectionBox().should("exist");
-
-        // Unselect the rectangle just drawn
-        drawToolTile.getDrawTile()
-          // Un-select the rectangle
-          .trigger("mousedown", 500, 100)
-          .trigger("mouseup", 500, 100);
-        drawToolTile.getSelectionBox().should("not.exist");
-
-        // Get the rectangle to be hovered, see above for more info.
-        drawToolTile.getRectangleDrawing()
-          .trigger("mouseover");
-        drawToolTile.getHighlightBox().should("exist").should("have.attr", "stroke").and("eq", "#bbdd00");
-
-        drawToolTile.getDrawTile()
-          .trigger("mousedown", 100, 135)
-          .trigger("mousemove", 200, 135)
-          .trigger("mouseup", 200, 135);
-
-        drawToolTile.getRectangleDrawing().first().should("have.attr", "x").then(parseInt).and("within", 150, 250);
-
-        // The best way I found to remove the hover was to delete the rectangle
-        drawToolTile.getDrawToolDelete().click();
-        drawToolTile.getRectangleDrawing().should("not.exist");
-        drawToolTile.getSelectionBox().should("not.exist");
-        drawToolTile.getHighlightBox().should("not.exist");
-      });
-      it("verify draw squares", () => {
-        // starting from top edge
-        drawToolTile.getDrawToolRectangle().click();
-        drawToolTile.getDrawTile()
-          .trigger("mousedown", 100, 50, {altKey: true})
-          .trigger("mousemove", 100, 70, {altKey: true})
-          .trigger("mouseup",   100, 70);
-
-        drawToolTile.getRectangleDrawing().should("exist").and("have.length", 1);
-        drawToolTile.getRectangleDrawing().last().should("have.attr", "width").and("eq", "20");
-        drawToolTile.getRectangleDrawing().last().should("have.attr", "height").and("eq", "20");
-
-        // starting from the left edge
-        drawToolTile.getDrawToolRectangle().click();
-        drawToolTile.getDrawTile()
-          .trigger("mousedown", 200, 50, {altKey: true})
-          .trigger("mousemove", 230, 50, {altKey: true})
-          .trigger("mouseup",   230, 50);
-        drawToolTile.getRectangleDrawing().should("exist").and("have.length", 2);
-        drawToolTile.getRectangleDrawing().last().should("have.attr", "width").and("eq", "30");
-        drawToolTile.getRectangleDrawing().last().should("have.attr", "height").and("eq", "30");
-
-        // draw a square starting at the bottom edge
-        drawToolTile.getDrawToolRectangle().click();
-        drawToolTile.getDrawTile()
-          .trigger("mousedown", 300, 90, {altKey: true})
-          .trigger("mousemove", 300, 50, {altKey: true})
-          .trigger("mouseup",   300, 50);
-        drawToolTile.getRectangleDrawing().should("exist").and("have.length", 3);
-        drawToolTile.getRectangleDrawing().last().should("have.attr", "width").and("eq", "40");
-        drawToolTile.getRectangleDrawing().last().should("have.attr", "height").and("eq", "40");
-
-        // draw a square starting at the right edge
-        drawToolTile.getDrawToolRectangle().click();
-        drawToolTile.getDrawTile()
-          .trigger("mousedown", 450, 50, {altKey: true})
-          .trigger("mousemove", 400, 50, {altKey: true})
-          .trigger("mouseup",   400, 50);
-        drawToolTile.getRectangleDrawing().should("exist").and("have.length", 4);
-        drawToolTile.getRectangleDrawing().last().should("have.attr", "width").and("eq", "50");
-        drawToolTile.getRectangleDrawing().last().should("have.attr", "height").and("eq", "50");
-
-        // Diagonal from top right to bottom left with the width 60 and height 50
-        drawToolTile.getDrawToolRectangle().click();
-        drawToolTile.getDrawTile()
-          .trigger("mousedown", 560, 50,  {altKey: true})
-          .trigger("mousemove", 500, 100, {altKey: true})
-          .trigger("mouseup",   500, 100);
-        drawToolTile.getRectangleDrawing().should("exist").and("have.length", 5);
-        drawToolTile.getRectangleDrawing().last().should("have.attr", "width").and("eq", "60");
-        drawToolTile.getRectangleDrawing().last().should("have.attr", "height").and("eq", "60");
-
-        // Diagonal from bottom right to top left with the width 50 and the height 70
-        drawToolTile.getDrawToolRectangle().click();
-        drawToolTile.getDrawTile()
-          .trigger("mousedown", 650, 120, {altKey: true})
-          .trigger("mousemove", 600, 50,  {altKey: true})
-          .trigger("mouseup",   600, 50);
-        drawToolTile.getRectangleDrawing().should("exist").and("have.length", 6);
-        drawToolTile.getRectangleDrawing().last().should("have.attr", "width").and("eq", "70");
-        drawToolTile.getRectangleDrawing().last().should("have.attr", "height").and("eq", "70");
-
-      });
-      it("deletes rectangle drawings", () => {
-        drawToolTile.getDrawTile().click();
-        // delete the first 4 with the toolbar button
-        for (let i=0; i<4; i++) {
-          drawToolTile.getDrawToolSelect().click();
-          drawToolTile.getRectangleDrawing().first().click({force:true});
-          drawToolTile.getDrawToolDelete().click();
-        }
-        // Delete with backspace key
-        drawToolTile.getDrawToolSelect().click();
-        drawToolTile.getRectangleDrawing().first().click({force:true});
-        drawToolTile.getDrawTileComponent().type("{backspace}");
-
-        // Delete with delete key
-        drawToolTile.getDrawToolSelect().click();
-        drawToolTile.getRectangleDrawing().first().click({force:true});
-        drawToolTile.getDrawTileComponent().type("{del}");
-
-        drawToolTile.getRectangleDrawing().should("not.exist");
-      });
-    });
-    describe("Ellipse", {scrollBehavior: false}, () => {
-      it("verify draw ellipse", () => {
-        drawToolTile.getDrawToolEllipse().click();
-        drawToolTile.getDrawTile()
-          .trigger("mousedown", 250,  50)
-          .trigger("mousemove", 100, 150)
-          .trigger("mouseup",   100, 150);
-        drawToolTile.getEllipseDrawing().should("exist").and("have.length", 1);
-        // Select tool should be selected after object created
-        drawToolTile.getDrawToolSelect().should("have.class", "selected");
-      });
-      it("shows up in show/sort panel", () => {
-        drawToolTile.getDrawTileShowSortPanelOpenButton().click();
-        drawToolTile.getDrawTileShowSortPanel().should("have.class", "open")
-          .get("li").should("have.length", 1).and("contain.text", "Ellipse");
-        drawToolTile.getDrawTileShowSortPanelCloseButton().click();
-      });
-      it("verify draw circle", () => {
-        drawToolTile.getDrawToolEllipse().click();
-        drawToolTile.getDrawTile()
-          .trigger("mousedown", 450,  50, {altKey: true})
-          .trigger("mousemove", 450, 150, {altKey: true})
-          .trigger("mouseup",   450, 150);
-        drawToolTile.getEllipseDrawing().should("exist").and("have.length", 2);
-        drawToolTile.getEllipseDrawing().last().should("have.attr", "rx").and("eq", "100");
-        drawToolTile.getEllipseDrawing().last().should("have.attr", "ry").and("eq", "100");
-      });
-      it("deletes ellipse drawing", () => {
-        drawToolTile.getDrawTile().click();
-        drawToolTile.getDrawToolSelect().click();
-        drawToolTile.getEllipseDrawing().first().click({force:true});
-        drawToolTile.getDrawToolDelete().click();
-        drawToolTile.getEllipseDrawing().first().click({force:true});
-        drawToolTile.getDrawToolDelete().click();
-        drawToolTile.getEllipseDrawing().should("not.exist");
-      });
-    });
-    describe("Stamp", {scrollBehavior: false}, () => {
-      it("verify draw stamp", () => {
-        drawToolTile.getDrawToolStamp().click();
-        drawToolTile.getDrawTile()
-          .trigger("mousedown", 250, 50)
-          .trigger("mouseup");
-        drawToolTile.getImageDrawing().should("exist").and("have.length", 1);
-        // Stamp tool should still be active
-        drawToolTile.getDrawToolStamp().should("have.class", "selected");
-      });
-      it("shows up in show/sort panel", () => {
-        drawToolTile.getDrawTileShowSortPanelOpenButton().click();
-        drawToolTile.getDrawTileShowSortPanel().should("have.class", "open")
-          .get("li").should("have.length", 1).and("contain.text", "Image");
-        drawToolTile.getDrawTileShowSortPanelCloseButton().click();
-      });
-      it("verify stamp images", () => {
-        drawToolTile.getImageDrawing().eq(0).should("have.attr", "href").and("contain", "coin.png");
-        drawToolTile.getDrawToolStampExpand().click();
-        cy.get(".toolbar-palette.stamps .palette-buttons .stamp-button").eq(1).click();
-        drawToolTile.getDrawTile()
-          .trigger("mousedown", 250, 100)
-          .trigger("mouseup");
-        drawToolTile.getImageDrawing().should("exist").and("have.length", 2);
-        drawToolTile.getImageDrawing().eq(1).should("have.attr", "href").and("contain", "pouch.png");
-        drawToolTile.getDrawToolStampExpand().click();
-        cy.get(".toolbar-palette.stamps .palette-buttons .stamp-button").eq(2).click();
-        drawToolTile.getDrawTile()
-          .trigger("mousedown", 250, 150)
-          .trigger("mouseup");
-        drawToolTile.getImageDrawing().should("exist").and("have.length", 3);
-        drawToolTile.getImageDrawing().eq(2).should("have.attr", "href").and("contain", "plus.png");
-      });
-      it("deletes stamp drawing", () => {
-        drawToolTile.getDrawToolSelect().click();
-        // drawToolTile.getImageDrawing().click({force:true, scrollBehavior: false});
-        drawToolTile.getImageDrawing().eq(0).click({force:true});
-        drawToolTile.getDrawToolDelete().click();
-        drawToolTile.getImageDrawing().eq(1).click({force:true});
-        drawToolTile.getDrawToolDelete().click();
-        drawToolTile.getImageDrawing().click({force:true});
-        drawToolTile.getDrawToolDelete().click();
-        drawToolTile.getImageDrawing().should("not.exist");
-      });
-    });
-    describe("Text", {scrollBehavior: false}, () => {
-      it("adds text object", () => {
-        drawToolTile.getDrawToolText().click();
-        drawToolTile.getDrawTile()
-          .trigger("mousedown", 100,  100)
-          .trigger("mouseup", 100, 100);
-        drawToolTile.getTextDrawing().should("exist").and("have.length", 1);
-        // Select tool should be selected after object created
-        drawToolTile.getDrawToolSelect().should("have.class", "selected");
-      });
-      it("shows up in show/sort panel", () => {
-        drawToolTile.getDrawTileShowSortPanelOpenButton().click();
-        drawToolTile.getDrawTileShowSortPanel().should("have.class", "open")
-          .get("li").should("have.length", 1).and("contain.text", "Text");
-        drawToolTile.getDrawTileShowSortPanelCloseButton().click();
-      });
-      it("edits text content of object", () => {
-        // Click inside drawing box to enter edit mode
-        drawToolTile.getDrawTile()
-          .trigger("mousedown", 150,  150)
-          .trigger("mouseup", 150, 150);
-          drawToolTile.getTextDrawing().get('textarea').type("The five boxing wizards jump quickly.{enter}");
-          drawToolTile.getTextDrawing().get('text tspan').should("exist").and("have.length", 6);
-      });
-      it("deletes text object", () => {
-        drawToolTile.getDrawToolSelect().click();
-        drawToolTile.getDrawTile()
-          .trigger("mousedown", 150,  150)
-          .trigger("mouseup", 150, 150);
-        drawToolTile.getSelectionBox().should("exist");
-        drawToolTile.getDrawToolDelete().should("not.have.class", "disabled").click();
-        drawToolTile.getTextDrawing().should("not.exist");
-      });
-    });
-    describe("Group", {scrollBehavior: false}, () => {
-      it("can group and ungroup", () => {
-        drawToolTile.getDrawToolRectangle().click();
-        drawToolTile.getDrawTile()
-          .trigger("mousedown", 250, 50)
-          .trigger("mousemove", 100, 150)
-          .trigger("mouseup",   100, 150);
-        drawToolTile.getDrawToolEllipse().click();
-        drawToolTile.getDrawTile()
-          .trigger("mousedown", 50,  100)
-          .trigger("mousemove", 100, 150)
-          .trigger("mouseup",   100, 150);
-        drawToolTile.getDrawToolFreehand().click();
-        drawToolTile.getDrawTile()
-          .trigger("mousedown", 150, 50)
-          .trigger("mousemove", 200, 150)
-          .trigger("mouseup",   200, 150);
-
-        // Select all 3
-        drawToolTile.getDrawToolSelect().click();
-        drawToolTile.getDrawTile()
-          .trigger("mousedown", 40,  40)
-          .trigger("mousemove", 250, 150)
-          .trigger("mouseup",   250, 150);
-          cy.wait(1000);
-          drawToolTile.getSelectionBox().should("have.length", 3);
-
-        drawToolTile.getDrawToolUngroup().should("have.class", "disabled");
-        drawToolTile.getDrawToolGroup().should("not.have.class", "disabled").click();
-        drawToolTile.getSelectionBox().should("have.length", 1);
-        drawToolTile.getDrawToolGroup().should("have.class", "disabled");
-        drawToolTile.getDrawToolUngroup().should("not.have.class", "disabled").click();
-        drawToolTile.getSelectionBox().should("have.length", 3);
-      });
-    describe("Image", {scrollBehavior: false}, () => {
-      it("drags images from image tiles", () => {
-        const imageFilePath='image.png';
-        clueCanvas.addTile('image');
-        cy.uploadFile(imageToolTile.imageChooseFileButton(), imageFilePath, 'image/png');
-        cy.wait(2000);
-        // Doesn't seem like the image is actually loading into the image tile.
-        // Once that's fixed, we should drag that image into the drawing tile.
-      });
-      it("uploads images", () => {
-        const imageFilePath='image.png';
-        cy.uploadFile(drawToolTile.getDrawToolUploadImage(), imageFilePath, 'image/png');
-        cy.wait(2000);
-        // Uploading images doesn't seem to be working at the moment.
-        // drawToolTile.getImageDrawing().should("exist").and("have.length", 1);
-      });
-      // TODO: Figure out how to get the clipboard paste check below to work when the tests
-      // are run using Chrome. It will pass when using Electron, but not Chrome. In Chrome
-      // the attempt to write to the clipboard results in an error: "Must be handling a user
-      // gesture to use custom clipboard." See https://github.com/cypress-io/cypress/issues/2752
-      // for more background. Apparently, the basic problem is that Cypress "currently uses
-      // programmatic browser APIs which Chrome doesn't consider as genuine user interaction."
-      it.skip('will accept a valid image URL pasted from the clipboard', function(){
-        // For the drawing tool, this path needs to correspond to an actual file in the curriculum repository.
-        const imageFilePath = "curriculum/sas/images/survey.png";
-        Cypress.automation("remote:debugger:protocol", {
-          command: "Browser.grantPermissions",
-          params: {
-            permissions: ["clipboardReadWrite", "clipboardSanitizedWrite"],
-            origin: window.location.origin,
-          },
-        }).then(cy.window().then((win) => {
-          win.navigator.clipboard.write([new win.ClipboardItem({
-              "text/plain": new Blob([imageFilePath], { type: "text/plain" }),
-          })]);
-        }));
-        const isMac = navigator.platform.indexOf("Mac") === 0;
-        const cmdKey = isMac ? "meta" : "ctrl";
-        drawToolTile.getDrawTileComponent().last().type(`{${cmdKey}+v}`);
-        drawToolTile.getImageDrawing().last().should("exist").invoke("attr", "href").should("contain", "sas/images/survey.png");
-      });
-    });
-    });
+    cy.log("deletes vector drawing");
+    // re-select the object using a selection rectangle.
+    drawToolTile.getDrawToolSelect().click();
+    drawToolTile.getDrawTile()
+      .trigger("mousedown", 90, 40)
+      .trigger("mousemove", 260, 60)
+      .trigger("mouseup", 260, 60);
+    drawToolTile.getDrawToolDelete().click();
+    drawToolTile.getVectorDrawing().should("not.exist");
   });
-});
+  it("Rectangle", { scrollBehavior: false }, () => {
+    beforeTest();
+    clueCanvas.addTile("drawing");
+
+    cy.log("verify draw rectangle");
+    drawToolTile.getDrawToolRectangle().click();
+    drawToolTile.getDrawTile()
+      .trigger("mousedown", 250, 50)
+      .trigger("mousemove", 100, 150)
+      .trigger("mouseup", 100, 50);
+    drawToolTile.getRectangleDrawing().should("exist").and("have.length", 1);
+    // Select tool should be selected after object created
+    drawToolTile.getDrawToolSelect().should("have.class", "selected");
+
+    cy.log("shows up in show/sort panel");
+    drawToolTile.getDrawTileShowSortPanelOpenButton().click();
+    drawToolTile.getDrawTileShowSortPanel().should("have.class", "open")
+      .get("li").should("have.length", 1).and("contain.text", "Rectangle");
+    drawToolTile.getDrawTileShowSortPanelCloseButton().click();
+
+    cy.log("verify change outline color");
+    drawToolTile.getRectangleDrawing().first().should("have.attr", "stroke").and("eq", "#000000");
+    drawToolTile.getDrawToolStrokeColor().click();
+    cy.get(".toolbar-palette.stroke-color .palette-buttons").should("be.visible");
+    cy.get(".toolbar-palette.stroke-color .palette-buttons .color-swatch").last().click();
+    drawToolTile.getRectangleDrawing().first().should("have.attr", "stroke").and("eq", "#d100d1");
+
+    cy.log("verify change fill color");
+    drawToolTile.getRectangleDrawing().first().should("not.have.attr", "fill-color");
+    // The rectangle is already selected, so we don't need to select it again
+    drawToolTile.getDrawToolFillColor().click();
+    cy.get(".toolbar-palette.fill-color .palette-buttons").should("be.visible");
+    cy.get(".toolbar-palette.fill-color .palette-buttons .color-swatch").last().click();
+    drawToolTile.getRectangleDrawing().first().should("have.attr", "fill").and("eq", "#d100d1");
+
+    cy.log("verify moving pre-selected object");
+    drawToolTile.getDrawToolSelect().click();
+    drawToolTile.getDrawTile()
+      .trigger("mousedown", 100, 100)
+      .trigger("mousemove", 200, 100)
+      .trigger("mouseup", 200, 100);
+    // For some reason the move isn't very accurate in cypress so often the final location off
+    drawToolTile.getRectangleDrawing().first().should("have.attr", "x").then(parseInt).and("within", 160, 220);
+
+    cy.log("verify hovering objects");
+    drawToolTile.getDrawTile()
+      // Un-select the rectangle
+      .trigger("mousedown", 500, 100)
+      .trigger("mouseup", 500, 100);
+
+    drawToolTile.getRectangleDrawing().first()
+      // Get the rectangle to be hovered. In the code we are listening to
+      // `onMouseEnter` but in Cypress triggering a "mouseenter" event
+      // doesn't work. Triggering a "mouseover" does work for some reason.
+      .trigger("mouseover");
+
+    // The hover box is rendered as a selection-box with a different color
+    drawToolTile.getHighlightBox().should("exist").should("have.attr", "stroke").and("eq", "#bbdd00");
+
+    // The best way I found to remove the hover was to delete the rectangle
+    drawToolTile.getRectangleDrawing().first().click({ force: true });
+    drawToolTile.getDrawToolDelete().click();
+    drawToolTile.getHighlightBox().should("not.exist");
+
+    cy.log("verify moving not selected object");
+    drawToolTile.getDrawToolRectangle().click();
+    drawToolTile.getDrawTile()
+      .trigger("mousedown", 250, 50)
+      .trigger("mousemove", 100, 150)
+      .trigger("mouseup", 100, 150);
+    drawToolTile.getRectangleDrawing().should("exist").and("have.length", 1);
+    drawToolTile.getSelectionBox().should("exist");
+
+    // Unselect the rectangle just drawn
+    drawToolTile.getDrawTile()
+      // Un-select the rectangle
+      .trigger("mousedown", 500, 100)
+      .trigger("mouseup", 500, 100);
+    drawToolTile.getSelectionBox().should("not.exist");
+
+    // Get the rectangle to be hovered, see above for more info.
+    drawToolTile.getRectangleDrawing()
+      .trigger("mouseover");
+    drawToolTile.getHighlightBox().should("exist").should("have.attr", "stroke").and("eq", "#bbdd00");
+
+    drawToolTile.getDrawTile()
+      .trigger("mousedown", 100, 135)
+      .trigger("mousemove", 200, 135)
+      .trigger("mouseup", 200, 135);
+
+    drawToolTile.getRectangleDrawing().first().should("have.attr", "x").then(parseInt).and("within", 150, 250);
+
+    // The best way I found to remove the hover was to delete the rectangle
+    drawToolTile.getDrawToolDelete().click();
+    drawToolTile.getRectangleDrawing().should("not.exist");
+    drawToolTile.getSelectionBox().should("not.exist");
+    drawToolTile.getHighlightBox().should("not.exist");
+
+    cy.log("verify draw squares");
+    // starting from top edge
+    drawToolTile.getDrawToolRectangle().click();
+    drawToolTile.getDrawTile()
+      .trigger("mousedown", 100, 50, { altKey: true })
+      .trigger("mousemove", 100, 70, { altKey: true })
+      .trigger("mouseup", 100, 70);
+
+    drawToolTile.getRectangleDrawing().should("exist").and("have.length", 1);
+    drawToolTile.getRectangleDrawing().last().should("have.attr", "width").and("eq", "20");
+    drawToolTile.getRectangleDrawing().last().should("have.attr", "height").and("eq", "20");
+
+    // starting from the left edge
+    drawToolTile.getDrawToolRectangle().click();
+    drawToolTile.getDrawTile()
+      .trigger("mousedown", 200, 50, { altKey: true })
+      .trigger("mousemove", 230, 50, { altKey: true })
+      .trigger("mouseup", 230, 50);
+    drawToolTile.getRectangleDrawing().should("exist").and("have.length", 2);
+    drawToolTile.getRectangleDrawing().last().should("have.attr", "width").and("eq", "30");
+    drawToolTile.getRectangleDrawing().last().should("have.attr", "height").and("eq", "30");
+
+    // draw a square starting at the bottom edge
+    drawToolTile.getDrawToolRectangle().click();
+    drawToolTile.getDrawTile()
+      .trigger("mousedown", 300, 90, { altKey: true })
+      .trigger("mousemove", 300, 50, { altKey: true })
+      .trigger("mouseup", 300, 50);
+    drawToolTile.getRectangleDrawing().should("exist").and("have.length", 3);
+    drawToolTile.getRectangleDrawing().last().should("have.attr", "width").and("eq", "40");
+    drawToolTile.getRectangleDrawing().last().should("have.attr", "height").and("eq", "40");
+
+    // draw a square starting at the right edge
+    drawToolTile.getDrawToolRectangle().click();
+    drawToolTile.getDrawTile()
+      .trigger("mousedown", 450, 50, { altKey: true })
+      .trigger("mousemove", 400, 50, { altKey: true })
+      .trigger("mouseup", 400, 50);
+    drawToolTile.getRectangleDrawing().should("exist").and("have.length", 4);
+    drawToolTile.getRectangleDrawing().last().should("have.attr", "width").and("eq", "50");
+    drawToolTile.getRectangleDrawing().last().should("have.attr", "height").and("eq", "50");
+
+    // Diagonal from top right to bottom left with the width 60 and height 50
+    drawToolTile.getDrawToolRectangle().click();
+    drawToolTile.getDrawTile()
+      .trigger("mousedown", 560, 50, { altKey: true })
+      .trigger("mousemove", 500, 100, { altKey: true })
+      .trigger("mouseup", 500, 100);
+    drawToolTile.getRectangleDrawing().should("exist").and("have.length", 5);
+    drawToolTile.getRectangleDrawing().last().should("have.attr", "width").and("eq", "60");
+    drawToolTile.getRectangleDrawing().last().should("have.attr", "height").and("eq", "60");
+
+    // Diagonal from bottom right to top left with the width 50 and the height 70
+    drawToolTile.getDrawToolRectangle().click();
+    drawToolTile.getDrawTile()
+      .trigger("mousedown", 650, 120, { altKey: true })
+      .trigger("mousemove", 600, 50, { altKey: true })
+      .trigger("mouseup", 600, 50);
+    drawToolTile.getRectangleDrawing().should("exist").and("have.length", 6);
+    drawToolTile.getRectangleDrawing().last().should("have.attr", "width").and("eq", "70");
+    drawToolTile.getRectangleDrawing().last().should("have.attr", "height").and("eq", "70");
 
 
+    cy.log("deletes rectangle drawings");
+    drawToolTile.getDrawTile().click();
+    // delete the first 4 with the toolbar button
+    for (let i = 0; i < 4; i++) {
+      drawToolTile.getDrawToolSelect().click();
+      drawToolTile.getRectangleDrawing().first().click({ force: true });
+      drawToolTile.getDrawToolDelete().click();
+    }
+    // Delete with backspace key
+    drawToolTile.getDrawToolSelect().click();
+    drawToolTile.getRectangleDrawing().first().click({ force: true });
+    drawToolTile.getDrawTileComponent().type("{backspace}");
 
-context('Draw Tool Tile Undo Redo', function () {
-  before(function () {
-    const queryParams = "?appMode=qa&fakeClass=5&fakeUser=student:5&qaGroup=5&unit=msa";
-    cy.clearQAData('all');
+    // Delete with delete key
+    drawToolTile.getDrawToolSelect().click();
+    drawToolTile.getRectangleDrawing().first().click({ force: true });
+    drawToolTile.getDrawTileComponent().type("{del}");
 
-    cy.visit(queryParams);
-    cy.waitForLoad();
-    cy.showOnlyDocumentWorkspace();
+    drawToolTile.getRectangleDrawing().should("not.exist");
+
   });
-  describe("Drawing tile title edit, undo redo and delete tile", () => {
-    it('will undo redo drawing tile creation/deletion', function () {
-      // Creation - Undo/Redo
-      clueCanvas.addTile('drawing');
-      drawToolTile.getDrawTile().should("exist");
-      clueCanvas.getUndoTool().should("not.have.class", "disabled");
-      clueCanvas.getRedoTool().should("have.class", "disabled");
-      clueCanvas.getUndoTool().click();
-      drawToolTile.getDrawTile().should("not.exist");
-      clueCanvas.getUndoTool().should("have.class", "disabled");
-      clueCanvas.getRedoTool().should("not.have.class", "disabled");
-      clueCanvas.getRedoTool().click();
-      drawToolTile.getDrawTile().should("exist");
-      clueCanvas.getUndoTool().should("not.have.class", "disabled");
-      clueCanvas.getRedoTool().should("have.class", "disabled");
+  it("Ellipse", { scrollBehavior: false }, () => {
+    beforeTest();
+    clueCanvas.addTile("drawing");
 
-      // Deletion - Undo/Redo
-      clueCanvas.deleteTile('draw');
-      drawToolTile.getDrawTile().should('not.exist');
-      clueCanvas.getUndoTool().click();
-      drawToolTile.getDrawTile().should("exist");
-      clueCanvas.getRedoTool().click();
-      drawToolTile.getDrawTile().should('not.exist');
-    });
-    it("edit tile title", () => {
-      const newName = "Drawing Tile";
-      clueCanvas.addTile("drawing");
-      drawToolTile.getDrawTile().should("exist");
-      drawToolTile.getTileTitle().should("exist");
-      drawToolTile.getTileTitle().first().should("contain", "Drawing 1");
-      drawToolTile.getDrawTileTitle().first().click();
-      drawToolTile.getDrawTileTitle().first().type(newName + '{enter}');
-      drawToolTile.getTileTitle().should("contain", newName);
+    cy.log("verify draw ellipse");
+    drawToolTile.getDrawToolEllipse().click();
+    drawToolTile.getDrawTile()
+      .trigger("mousedown", 250, 50)
+      .trigger("mousemove", 100, 150)
+      .trigger("mouseup", 100, 150);
+    drawToolTile.getEllipseDrawing().should("exist").and("have.length", 1);
+    // Select tool should be selected after object created
+    drawToolTile.getDrawToolSelect().should("have.class", "selected");
+
+    cy.log("shows up in show/sort panel");
+    drawToolTile.getDrawTileShowSortPanelOpenButton().click();
+    drawToolTile.getDrawTileShowSortPanel().should("have.class", "open")
+      .get("li").should("have.length", 1).and("contain.text", "Ellipse");
+    drawToolTile.getDrawTileShowSortPanelCloseButton().click();
+
+    cy.log("verify draw circle");
+    drawToolTile.getDrawToolEllipse().click();
+    drawToolTile.getDrawTile()
+      .trigger("mousedown", 450, 50, { altKey: true })
+      .trigger("mousemove", 450, 150, { altKey: true })
+      .trigger("mouseup", 450, 150);
+    drawToolTile.getEllipseDrawing().should("exist").and("have.length", 2);
+    drawToolTile.getEllipseDrawing().last().should("have.attr", "rx").and("eq", "100");
+    drawToolTile.getEllipseDrawing().last().should("have.attr", "ry").and("eq", "100");
+
+    cy.log("deletes ellipse drawing");
+    drawToolTile.getDrawTile().click();
+    drawToolTile.getDrawToolSelect().click();
+    drawToolTile.getEllipseDrawing().first().click({ force: true });
+    drawToolTile.getDrawToolDelete().click();
+    drawToolTile.getEllipseDrawing().first().click({ force: true });
+    drawToolTile.getDrawToolDelete().click();
+    drawToolTile.getEllipseDrawing().should("not.exist");
+
   });
-  it("undo redo actions", () => {
-      clueCanvas.getUndoTool().click();
-      drawToolTile.getTileTitle().first().should("contain", "Drawing 1");
-      clueCanvas.getUndoTool().click();
-      drawToolTile.getDrawTile().should("not.exist");
-      clueCanvas.getRedoTool().click().click();
-      drawToolTile.getTileTitle().should("contain", "Drawing Tile");
+  it("Stamp", { scrollBehavior: false }, () => {
+    beforeTest();
+    clueCanvas.addTile("drawing");
+
+    cy.log("verify draw stamp");
+    drawToolTile.getDrawToolStamp().click();
+    drawToolTile.getDrawTile()
+      .trigger("mousedown", 250, 50)
+      .trigger("mouseup");
+    drawToolTile.getImageDrawing().should("exist").and("have.length", 1);
+    // Stamp tool should still be active
+    drawToolTile.getDrawToolStamp().should("have.class", "selected");
+
+    cy.log("shows up in show/sort panel");
+    drawToolTile.getDrawTileShowSortPanelOpenButton().click();
+    drawToolTile.getDrawTileShowSortPanel().should("have.class", "open")
+      .get("li").should("have.length", 1).and("contain.text", "Image");
+    drawToolTile.getDrawTileShowSortPanelCloseButton().click();
+
+    cy.log("verify stamp images");
+    drawToolTile.getImageDrawing().eq(0).should("have.attr", "href").and("contain", "coin.png");
+    drawToolTile.getDrawToolStampExpand().click();
+    cy.get(".toolbar-palette.stamps .palette-buttons .stamp-button").eq(1).click();
+    drawToolTile.getDrawTile()
+      .trigger("mousedown", 250, 100)
+      .trigger("mouseup");
+    drawToolTile.getImageDrawing().should("exist").and("have.length", 2);
+    drawToolTile.getImageDrawing().eq(1).should("have.attr", "href").and("contain", "pouch.png");
+    drawToolTile.getDrawToolStampExpand().click();
+    cy.get(".toolbar-palette.stamps .palette-buttons .stamp-button").eq(2).click();
+    drawToolTile.getDrawTile()
+      .trigger("mousedown", 250, 150)
+      .trigger("mouseup");
+    drawToolTile.getImageDrawing().should("exist").and("have.length", 3);
+    drawToolTile.getImageDrawing().eq(2).should("have.attr", "href").and("contain", "plus.png");
+
+    cy.log("deletes stamp drawing");
+    drawToolTile.getDrawToolSelect().click();
+    // drawToolTile.getImageDrawing().click({force:true, scrollBehavior: false});
+    drawToolTile.getImageDrawing().eq(0).click({ force: true });
+    drawToolTile.getDrawToolDelete().click();
+    drawToolTile.getImageDrawing().eq(1).click({ force: true });
+    drawToolTile.getDrawToolDelete().click();
+    drawToolTile.getImageDrawing().click({ force: true });
+    drawToolTile.getDrawToolDelete().click();
+    drawToolTile.getImageDrawing().should("not.exist");
   });
-  it('verify delete tile', function () {
-      clueCanvas.deleteTile('draw');
-      drawToolTile.getDrawTile().should("not.exist");
+  it("Text", { scrollBehavior: false }, () => {
+    beforeTest();
+    clueCanvas.addTile("drawing");
+
+    cy.log("adds text object");
+    drawToolTile.getDrawToolText().click();
+    drawToolTile.getDrawTile()
+      .trigger("mousedown", 100, 100)
+      .trigger("mouseup", 100, 100);
+    drawToolTile.getTextDrawing().should("exist").and("have.length", 1);
+    // Select tool should be selected after object created
+    drawToolTile.getDrawToolSelect().should("have.class", "selected");
+
+    cy.log("shows up in show/sort panel");
+    drawToolTile.getDrawTileShowSortPanelOpenButton().click();
+    drawToolTile.getDrawTileShowSortPanel().should("have.class", "open")
+      .get("li").should("have.length", 1).and("contain.text", "Text");
+    drawToolTile.getDrawTileShowSortPanelCloseButton().click();
+
+    cy.log("edits text content of object");
+    // Click inside drawing box to enter edit mode
+    drawToolTile.getDrawTile()
+      .trigger("mousedown", 150, 150)
+      .trigger("mouseup", 150, 150);
+    drawToolTile.getTextDrawing().get('textarea').type("The five boxing wizards jump quickly.{enter}");
+    drawToolTile.getTextDrawing().get('text tspan').should("exist").and("have.length", 7);
+
+    cy.log("deletes text object");
+    drawToolTile.getDrawToolSelect().click();
+    drawToolTile.getDrawTile()
+      .trigger("mousedown", 150, 150)
+      .trigger("mouseup", 150, 150);
+    drawToolTile.getSelectionBox().should("exist");
+    drawToolTile.getDrawToolDelete().should("not.have.class", "disabled").click();
+    drawToolTile.getTextDrawing().should("not.exist");
   });
+  it("Group", { scrollBehavior: false }, () => {
+    beforeTest();
+    clueCanvas.addTile("drawing");
+
+    cy.log("can group and ungroup");
+    drawToolTile.getDrawToolRectangle().click();
+    drawToolTile.getDrawTile()
+      .trigger("mousedown", 250, 50)
+      .trigger("mousemove", 100, 150)
+      .trigger("mouseup", 100, 150);
+    drawToolTile.getDrawToolEllipse().click();
+    drawToolTile.getDrawTile()
+      .trigger("mousedown", 50, 100)
+      .trigger("mousemove", 100, 150)
+      .trigger("mouseup", 100, 150);
+    drawToolTile.getDrawToolFreehand().click();
+    drawToolTile.getDrawTile()
+      .trigger("mousedown", 150, 50)
+      .trigger("mousemove", 200, 150)
+      .trigger("mouseup", 200, 150);
+
+    // Select all 3
+    drawToolTile.getDrawToolSelect().click();
+    drawToolTile.getDrawTile()
+      .trigger("mousedown", 40, 40)
+      .trigger("mousemove", 250, 150)
+      .trigger("mouseup", 250, 150);
+    cy.wait(1000);
+    drawToolTile.getSelectionBox().should("have.length", 3);
+
+    drawToolTile.getDrawToolUngroup().should("have.class", "disabled");
+    drawToolTile.getDrawToolGroup().should("not.have.class", "disabled").click();
+    drawToolTile.getSelectionBox().should("have.length", 1);
+    drawToolTile.getDrawToolGroup().should("have.class", "disabled");
+    drawToolTile.getDrawToolUngroup().should("not.have.class", "disabled").click();
+    drawToolTile.getSelectionBox().should("have.length", 3);
+  });
+  it("Image", { scrollBehavior: false }, () => {
+    beforeTest();
+    clueCanvas.addTile("drawing");
+
+    cy.log("drags images from image tiles");
+    const imageFilePath1 = 'image.png';
+    clueCanvas.addTile('image');
+    cy.uploadFile(imageToolTile.imageChooseFileButton(), imageFilePath1, 'image/png');
+    cy.wait(2000);
+    // Doesn't seem like the image is actually loading into the image tile.
+    // Once that's fixed, we should drag that image into the drawing tile.
+
+    cy.log("uploads images");
+    const imageFilePath2 = 'image.png';
+    cy.uploadFile(drawToolTile.getDrawToolUploadImage(), imageFilePath2, 'image/png');
+    cy.wait(2000);
+    // Uploading images doesn't seem to be working at the moment.
+    // drawToolTile.getImageDrawing().should("exist").and("have.length", 1);
+
+    // TODO: Figure out how to get the clipboard paste check below to work when the tests
+    // are run using Chrome. It will pass when using Electron, but not Chrome. In Chrome
+    // the attempt to write to the clipboard results in an error: "Must be handling a user
+    // gesture to use custom clipboard." See https://github.com/cypress-io/cypress/issues/2752
+    // for more background. Apparently, the basic problem is that Cypress "currently uses
+    // programmatic browser APIs which Chrome doesn't consider as genuine user interaction."
+    // it.skip('will accept a valid image URL pasted from the clipboard', function () {
+    //   // For the drawing tool, this path needs to correspond to an actual file in the curriculum repository.
+    //   const imageFilePath = "curriculum/sas/images/survey.png";
+    //   Cypress.automation("remote:debugger:protocol", {
+    //     command: "Browser.grantPermissions",
+    //     params: {
+    //       permissions: ["clipboardReadWrite", "clipboardSanitizedWrite"],
+    //       origin: window.location.origin,
+    //     },
+    //   }).then(cy.window().then((win) => {
+    //     win.navigator.clipboard.write([new win.ClipboardItem({
+    //       "text/plain": new Blob([imageFilePath], { type: "text/plain" }),
+    //     })]);
+    //   }));
+    //   const isMac = navigator.platform.indexOf("Mac") === 0;
+    //   const cmdKey = isMac ? "meta" : "ctrl";
+    //   drawToolTile.getDrawTileComponent().last().type(`{${cmdKey}+v}`);
+    //   drawToolTile.getImageDrawing().last().should("exist").invoke("attr", "href").should("contain", "sas/images/survey.png");
+    // });
+  });
+  it('Draw Tool Tile Undo Redo', function () {
+    beforeTest();
+    cy.log('will undo redo drawing tile creation/deletion');
+    // Creation - Undo/Redo
+    clueCanvas.addTile('drawing');
+    drawToolTile.getDrawTile().should("exist");
+    clueCanvas.getUndoTool().should("not.have.class", "disabled");
+    clueCanvas.getRedoTool().should("have.class", "disabled");
+    clueCanvas.getUndoTool().click();
+    drawToolTile.getDrawTile().should("not.exist");
+    clueCanvas.getUndoTool().should("have.class", "disabled");
+    clueCanvas.getRedoTool().should("not.have.class", "disabled");
+    clueCanvas.getRedoTool().click();
+    drawToolTile.getDrawTile().should("exist");
+    clueCanvas.getUndoTool().should("not.have.class", "disabled");
+    clueCanvas.getRedoTool().should("have.class", "disabled");
+
+    // Deletion - Undo/Redo
+    clueCanvas.deleteTile('draw');
+    drawToolTile.getDrawTile().should('not.exist');
+    clueCanvas.getUndoTool().click();
+    drawToolTile.getDrawTile().should("exist");
+    clueCanvas.getRedoTool().click();
+    drawToolTile.getDrawTile().should('not.exist');
+
+    cy.log("edit tile title");
+    const newName = "Drawing Tile";
+    clueCanvas.addTile("drawing");
+    drawToolTile.getDrawTile().should("exist");
+    drawToolTile.getTileTitle().should("exist");
+    drawToolTile.getTileTitle().first().should("contain", "Drawing 1");
+    drawToolTile.getDrawTileTitle().first().click();
+    drawToolTile.getDrawTileTitle().first().type(newName + '{enter}');
+    drawToolTile.getTileTitle().should("contain", newName);
+
+    cy.log("undo redo actions");
+    clueCanvas.getUndoTool().click();
+    drawToolTile.getTileTitle().first().should("contain", "Drawing 1");
+    clueCanvas.getUndoTool().click();
+    drawToolTile.getDrawTile().should("not.exist");
+    clueCanvas.getRedoTool().click().click();
+    drawToolTile.getTileTitle().should("contain", "Drawing Tile");
+
+    cy.log('verify delete tile');
+    clueCanvas.deleteTile('draw');
+    drawToolTile.getDrawTile().should("not.exist");
   });
 });

--- a/cypress/e2e/clue/branch/student_tests/duplicate_tile_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/duplicate_tile_spec.js
@@ -10,71 +10,67 @@ let clueCanvas = new ClueCanvas,
   tableToolTile = new TableToolTile,
   dataCardToolTile = new DataCardToolTile;
 
+function beforeTest() {
+  const queryParams = "?appMode=qa&fakeClass=5&fakeUser=student:5&qaGroup=5&unit=example";
+  cy.clearQAData('all');
+
+  cy.visit(queryParams);
+  cy.waitForLoad();
+}
+
 context('Duplicate Tiles', function () {
-  const toolButton = toolType => cy.get(`.tool.${toolType}`);
-  const duplicateTool = () => toolButton("duplicate");
 
-  before(function () {
-    const queryParams = "?appMode=qa&fakeClass=5&fakeUser=student:5&qaGroup=5&unit=example";
-    cy.clearQAData('all');
+  it("Duplicate tool", () => {
+    beforeTest();
 
-    cy.visit(queryParams);
-    cy.waitForLoad();
-  });
+    const toolButton = toolType => cy.get(`.tool.${toolType}`);
+    const duplicateTool = () => toolButton("duplicate");
+    
+    cy.log("duplicate tool is enabled properly");
+    duplicateTool().should("have.class", "disabled");
+    clueCanvas.addTile("image");
+    duplicateTool().should("have.class", "enabled");
 
-  describe("Duplicate tool", () => {
-    it("duplicate tool is enabled properly", () => {
-      duplicateTool().should("have.class", "disabled");
-      clueCanvas.addTile("image");
-      duplicateTool().should("have.class", "enabled");
-    });
+    cy.log("copies one tile and increments default titles");
+    imageToolTile.getImageTile().should("have.length", 1);
+    duplicateTool().click();
+    imageToolTile.getImageTile().should("have.length", 2);
+    imageToolTile.getImageTileTitle().last().should("contain.text", "Image 2");
 
-    it("copies one tile and increments default titles", () => {
-      imageToolTile.getImageTile().should("have.length", 1);
-      duplicateTool().click();
-      imageToolTile.getImageTile().should("have.length", 2);
-      imageToolTile.getImageTileTitle().last().should("contain.text", "Image 2");
-    });
+    cy.log("copies multiple tiles, and only selected tiles");
+    const customDrawingTitle = "Custom Drawing";
+    clueCanvas.addTile("drawing");
+    drawToolTile.getDrawTileTitle().type(customDrawingTitle);
+    imageToolTile.getImageTile().first().click();
+    drawToolTile.getDrawTile().click({ shiftKey: true });
+    duplicateTool().click();
+    imageToolTile.getImageTile().should("have.length", 3);
+    drawToolTile.getDrawTileTitle().last().should("contain.text", customDrawingTitle);
 
-    it("copies multiple tiles, and only selected tiles", () => {
-      const customDrawingTitle = "Custom Drawing";
-      clueCanvas.addTile("drawing");
-      drawToolTile.getDrawTileTitle().type(customDrawingTitle);
-      imageToolTile.getImageTile().first().click();
-      drawToolTile.getDrawTile().click({ shiftKey: true });
-      duplicateTool().click();
-      imageToolTile.getImageTile().should("have.length", 3);
-      drawToolTile.getDrawTileTitle().last().should("contain.text", customDrawingTitle);
-    });
+    cy.log("adds tiles immediately after selected tiles");
+    imageToolTile.getImageTile().first().click();
+    duplicateTool().click();
+    imageToolTile.getImageTileTitle().eq(1).should("contain.text", "Image 4");
 
-    it("adds tiles immediately after selected tiles", () => {
-      imageToolTile.getImageTile().first().click();
-      duplicateTool().click();
-      imageToolTile.getImageTileTitle().eq(1).should("contain.text", "Image 4");
-    });
-  });
+    cy.log("Duplicate tool with shared models");
+    cy.log("duplicates tables");
+    clueCanvas.addTile("table");
+    tableToolTile.getTableTile().click();
+    duplicateTool().click();
+    tableToolTile.getTableTile().should("have.length", 2);
+    tableToolTile.getTableTitle().last().should("contain.text", "Table 2");
+    tableToolTile.typeInTableCell(1, "x");
+    tableToolTile.getTableCell().eq(1).should("contain.text", "x");
+    tableToolTile.getTableCell().eq(5).should("not.contain.text", "x");
 
-  describe("Duplicate tool with shared models", () => {
-    it("duplicates tables", () => {
-      clueCanvas.addTile("table");
-      tableToolTile.getTableTile().click();
-      duplicateTool().click();
-      tableToolTile.getTableTile().should("have.length", 2);
-      tableToolTile.getTableTitle().last().should("contain.text", "Table 2");
-      tableToolTile.typeInTableCell(1, "x");
-      tableToolTile.getTableCell().eq(1).should("contain.text", "x");
-      tableToolTile.getTableCell().eq(5).should("not.contain.text", "x");
-    });
-
-    it("duplicates datacards", () => {
-      clueCanvas.addTile("datacard");
-      dataCardToolTile.getSortSelect().select("Label 1");
-      dataCardToolTile.getTile().click();
-      duplicateTool().click();
-      dataCardToolTile.getTiles().should("have.length", 2);
-      dataCardToolTile.getSortSelect(1).should("contain.text", "Label 1");
-      dataCardToolTile.getSortSelect(1).select("None");
-      dataCardToolTile.getSortSelect(0).should("contain.text", "Label 1");
-    });
+    cy.log("duplicates datacards");
+    clueCanvas.addTile("datacard");
+    dataCardToolTile.getSortSelect().select("Label 1");
+    dataCardToolTile.getTile().click();
+    duplicateTool().click();
+    dataCardToolTile.getTiles().should("have.length", 2);
+    dataCardToolTile.getSortSelect(1).should("contain.text", "Label 1");
+    dataCardToolTile.getSortSelect(1).select("None");
+    dataCardToolTile.getSortSelect(0).should("contain.text", "Label 1");
   });
 });

--- a/cypress/e2e/clue/branch/student_tests/expression_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/expression_tool_spec.js
@@ -4,116 +4,118 @@ import ExpressionToolTile from '../../../../support/elements/clue/ExpressionTool
 let clueCanvas = new ClueCanvas;
 let exp = new ExpressionToolTile;
 
+function beforeTest() {
+  const queryParams = "?appMode=qa&fakeClass=5&fakeUser=student:5&qaGroup=5&unit=example";
+  cy.clearQAData('all');
+  cy.visit(queryParams);
+  cy.waitForLoad();
+  //TODO - implement within a curriculum unit
+  //cy.collapseResourceTabs();
+}
+
 context('Expression Tool Tile', function () {
-  before(function () {
-    const queryParams = "?appMode=qa&fakeClass=5&fakeUser=student:5&qaGroup=5&unit=example";
-    cy.clearQAData('all');
-    cy.visit(queryParams);
-    cy.waitForLoad();
-    //TODO - implement within a curriculum unit
-    //cy.collapseResourceTabs();
-  });
-  describe("Expression Tool", () => {
-    it("renders expression tool tile", () => {
-      clueCanvas.addTile("expression");
-      exp.getExpressionTile().should("exist");
+  it("Expression Tool", () => {
+    beforeTest();
+    
+    cy.log("renders expression tool tile");
+    clueCanvas.addTile("expression");
+    exp.getExpressionTile().should("exist");
+
+    cy.log("should have the correct default title");
+    exp.getTileTitle().should("exist");
+    exp.getTileTitle().should("contain", "(Eq. 1)");
+
+    cy.log("should contain a default value as latex string");
+    exp.getMathArea().should("exist");
+    exp.getMathField().should("have.value", "a=\\pi r^2");
+    exp.getMathFieldLatex().should("eq", "a=\\pi r^2");
+
+    cy.log("should render latex string as math characters");
+    exp.getMathFieldMath().should("exist");
+    exp.getMathFieldMath().should("contain", "π");
+
+    cy.log("should have an editable title");
+    exp.getTileTitle().click();
+    exp.getTitleInput().should("exist");
+    exp.getTitleInput().should("have.value", "Eq. 1");
+    exp.getTitleInput().dblclick();
+    exp.getTitleInput().type("new title{enter}");
+    exp.getTileTitle().should("contain", "(new title)");
+
+    cy.log("should accept basic keyboard input");
+    // Can now perform keyboard input
+    // but thus far cannot get sequences like {del} to work in test
+    exp.getMathField().eq(0).click({ force: true });
+    exp.getMathField().eq(0).type("hi", { force: true });
+    exp.getMathField().eq(0).should("have.value", "hia=\\pi r^2");
+    cy.wait(2000);
+
+    cy.log("expression can be changed and re-renders");
+    //  The below tests a change, but does not follow a genuine user path
+    //   see: https://github.com/arnog/mathlive/issues/830
+    exp.getMathField().invoke("val", "a=\\theta r^3");
+    exp.getMathFieldMath().should("contain", "θ");
+
+    cy.log("can create a mixed fraction with the button");
+    exp.clearValue();
+    exp.getMathField().eq(0).click({ force: true });
+    exp.getMixedFractionButton().eq(0).click();
+    exp.getMathField().eq(0).should("have.value", "\\placeholder{}\\frac{\\placeholder{}}{\\placeholder{}}");
+
+    cy.log("can add an empty division expression when division button clicked in empty expression");
+    exp.clearValue();
+    exp.getMathField().eq(0).click({ force: true });
+    exp.getDivisionButton().eq(0).click();
+    exp.getMathField().eq(0).should("have.value", "\\placeholder{}\\div\\placeholder{}");
+
+    cy.log("can add a division sign and a placeholder when division button clicked following existing value");
+    exp.clearValue();
+    exp.getMathField().eq(0).click({ force: true });
+    exp.getMathField().eq(0).invoke("val", "123");
+    exp.getDivisionButton().eq(0).click();
+    exp.getMathField().eq(0).should("have.value", "123\\div\\placeholder{}");
+
+    cy.log("should name new expressions with an incrementing id");
+    clueCanvas.addTile("expression");
+    cy.contains("(Eq. 1)").should("exist");
+    clueCanvas.addTile("expression");
+    cy.contains("(Eq. 2)").should("exist");
+
+    cy.log("should become the active tile when equation is clicked");
+    exp.getMathField().eq(1).click({ force: true });
+    exp.getExpressionTile().eq(1).should("have.class", "selected");
+    exp.getExpressionTile().eq(0).should("not.have.class", "selected");
+
+    cy.log("should have a toggleable toolbar");
+    exp.getExpressionToolbar().eq(1).should("be.visible");
+    exp.getExpressionToolbar().eq(0).should("not.be.visible");
+    exp.getMathField().eq(0).click({ force: true });
+    exp.getExpressionToolbar().eq(0).should("be.visible");
+    exp.getExpressionToolbar().eq(1).should("not.be.visible");
+
+    cy.log("delete expression button deletes the whole expression");
+    exp.getMathField().eq(0).click({ force: true });
+    exp.getDeleteExpressionButton().eq(0).click();
+    exp.getMathFieldMath().eq(0).should("not.contain.text");
+    exp.getMathField().should("not.have.value", "a=\\pi r^2");
+
+    cy.log("adds placeholder to negative sign");
+    exp.getDeleteExpressionButton().eq(0).click();
+    exp.getMathField().eq(0).click({ force: true });
+    exp.getMathField().eq(0).type("-", { force: true });
+    exp.getMathField().eq(0).should("have.value", "-\\placeholder{}");
+
+    cy.log("adds placeholders to multiplication symbol");
+    exp.getDeleteExpressionButton().eq(0).click();
+    // Normally typing "*" will add a \cdot to the latex value. This happens because
+    // of some special handling in the mathField. Apparently when cypress types
+    // characters this handling doesn't happen. So instead we use MathLives
+    // executeCommand to insert the \cdot directly
+    exp.getMathField().then($mf => {
+      const mf = $mf[0];
+      mf.executeCommand(["insert", "\\cdot"]);
     });
-    it("should have the correct default title", () => {
-      exp.getTileTitle().should("exist");
-      exp.getTileTitle().should("contain", "(Eq. 1)");
-    });
-    it("should contain a default value as latex string", () => {
-      exp.getMathArea().should("exist");
-      exp.getMathField().should("have.value", "a=\\pi r^2");
-      exp.getMathFieldLatex().should("eq", "a=\\pi r^2");
-    });
-    it("should render latex string as math characters", () => {
-      exp.getMathFieldMath().should("exist");
-      exp.getMathFieldMath().should("contain", "π");
-    });
-    it("should have an editable title", () => {
-      exp.getTileTitle().click();
-      exp.getTitleInput().should("exist");
-      exp.getTitleInput().should("have.value", "Eq. 1");
-      exp.getTitleInput().dblclick();
-      exp.getTitleInput().type("new title{enter}");
-      exp.getTileTitle().should("contain", "(new title)");
-    });
-    it("should accept basic keyboard input", () => {
-      // Can now perform keyboard input
-      // but thus far cannot get sequences like {del} to work in test
-      exp.getMathField().eq(0).click({force: true});
-      exp.getMathField().eq(0).type("hi", {force: true});
-      exp.getMathField().eq(0).should("have.value", "hia=\\pi r^2");
-      cy.wait(2000);
-    });
-    it("expression can be changed and re-renders", () => {
-      //  The below tests a change, but does not follow a genuine user path
-      //   see: https://github.com/arnog/mathlive/issues/830
-      exp.getMathField().invoke("val", "a=\\theta r^3");
-      exp.getMathFieldMath().should("contain", "θ");
-    });
-    it("can create a mixed fraction with the button", () => {
-      exp.clearValue();
-      exp.getMathField().eq(0).click({force: true});
-      exp.getMixedFractionButton().eq(0).click();
-      exp.getMathField().eq(0).should("have.value", "\\placeholder{}\\frac{\\placeholder{}}{\\placeholder{}}");
-    });
-    it("can add an empty division expression when division button clicked in empty expression", () => {
-      exp.clearValue();
-      exp.getMathField().eq(0).click({force: true});
-      exp.getDivisionButton().eq(0).click();
-      exp.getMathField().eq(0).should("have.value", "\\placeholder{}\\div\\placeholder{}");
-    });
-    it("can add a division sign and a placeholder when division button clicked following existing value", () => {
-      exp.clearValue();
-      exp.getMathField().eq(0).click({force: true});
-      exp.getMathField().eq(0).invoke("val", "123");
-      exp.getDivisionButton().eq(0).click();
-      exp.getMathField().eq(0).should("have.value", "123\\div\\placeholder{}");
-    });
-    it("should name new expressions with an incrementing id", () => {
-      clueCanvas.addTile("expression");
-      cy.contains("(Eq. 1)").should("exist");
-      clueCanvas.addTile("expression");
-      cy.contains("(Eq. 2)").should("exist");
-    });
-    it("should become the active tile when equation is clicked", () => {
-      exp.getMathField().eq(1).click({force: true});
-      exp.getExpressionTile().eq(1).should("have.class", "selected");
-      exp.getExpressionTile().eq(0).should("not.have.class", "selected");
-    });
-    it("should have a toggleable toolbar", () => {
-      exp.getExpressionToolbar().eq(1).should("be.visible");
-      exp.getExpressionToolbar().eq(0).should("not.be.visible");
-      exp.getMathField().eq(0).click({force: true});
-      exp.getExpressionToolbar().eq(0).should("be.visible");
-      exp.getExpressionToolbar().eq(1).should("not.be.visible");
-    });
-    it("delete expression button deletes the whole expression", () => {
-      exp.getMathField().eq(0).click({force: true});
-      exp.getDeleteExpressionButton().eq(0).click();
-      exp.getMathFieldMath().eq(0).should("not.contain.text");
-      exp.getMathField().should("not.have.value", "a=\\pi r^2");
-    });
-    it("adds placeholder to negative sign", () => {
-      exp.getDeleteExpressionButton().eq(0).click();
-      exp.getMathField().eq(0).click({force: true});
-      exp.getMathField().eq(0).type("-", {force: true});
-      exp.getMathField().eq(0).should("have.value", "-\\placeholder{}");
-    });
-    it("adds placeholders to multiplication symbol", () => {
-      exp.getDeleteExpressionButton().eq(0).click();
-      // Normally typing "*" will add a \cdot to the latex value. This happens because
-      // of some special handling in the mathField. Apparently when cypress types
-      // characters this handling doesn't happen. So instead we use MathLives
-      // executeCommand to insert the \cdot directly
-      exp.getMathField().then($mf => {
-        const mf = $mf[0];
-        mf.executeCommand(["insert", "\\cdot"]);
-      });
-      exp.getMathField().eq(0).should("have.value", "\\placeholder{}\\cdot\\placeholder{}");
-      cy.wait(2000);
-    });
+    exp.getMathField().eq(0).should("have.value", "\\placeholder{}\\cdot\\placeholder{}");
+    cy.wait(2000);
   });
 });

--- a/cypress/e2e/clue/branch/student_tests/graph_table_integraton_test_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/graph_table_integraton_test_spec.js
@@ -15,283 +15,230 @@ const textToolTile = new TextToolTile;
 const x = ['3', '7', '6', '0'];
 const y = ['2.5', '5', '1', '0'];
 
+function beforeTest() {
+  const queryParams = "?appMode=qa&fakeClass=5&fakeUser=student:5&problem=2.3&qaGroup=5"; //using different problem bec. 2.1 disables graph table integration
+  cy.clearQAData('all');
+
+  cy.visit(queryParams);
+  cy.waitForLoad();
+  clueCanvas.getInvestigationCanvasTitle().text().as('investigationTitle');
+}
+
 context('Graph Table Integration', function () {
-  before(function () {
-    const queryParams = "?appMode=qa&fakeClass=5&fakeUser=student:5&problem=2.3&qaGroup=5"; //using different problem bec. 2.1 disables graph table integration
-    cy.clearQAData('all');
+  it('Tests for graph and table integration', function () {
+    beforeTest();
+    clueCanvas.addTile('table');
+    cy.get(".primary-workspace").within((workspace) => {
+      tableToolTile.getTableCell().eq(1).click().type(x[0] + '{enter}');
+      tableToolTile.getTableCell().eq(2).click();
+      tableToolTile.getTableCell().eq(2).type(y[0] + '{enter}');
+      tableToolTile.getTableCell().eq(5).click();
+      tableToolTile.getTableCell().eq(5).type(x[1] + '{enter}');
+      tableToolTile.getTableCell().eq(6).click();
+      cy.wait(500);
+      tableToolTile.getTableCell().eq(6).type(y[1] + '{enter}');
+      tableToolTile.getTableCell().eq(9).click();
+      tableToolTile.getTableCell().eq(9).type(x[2] + '{enter}');
+      tableToolTile.getTableCell().eq(10).click();
+      tableToolTile.getTableCell().eq(10).type(y[2] + '{enter}');
+      tableToolTile.getTableCell().eq(13).click();
+      tableToolTile.getTableCell().eq(13).type(x[3] + '{enter}');
+      tableToolTile.getTableCell().eq(14).click();
+      tableToolTile.getTableCell().eq(14).type(y[3] + '{enter}');
+      tableToolTile.getTableCell().eq(17).click();
+    });
+    clueCanvas.addTile('geometry');
+    textToolTile.deleteTextTile();
 
-    cy.visit(queryParams);
-    cy.waitForLoad();
-    cy.collapseResourceTabs();
+    cy.log('verify correct graph names appear in selection list');
+    tableToolTile.getTableTile().click();
+    cy.get('.primary-workspace .link-tile-button').click();
+    cy.wait(2000);
+    // cy.get('[data-test=link-tile-select]').select('Second One');
+    cy.get('[data-test=link-tile-select]').select('Graph 1');
 
-    clueCanvas.getInvestigationCanvasTitle().text().as('investigationTitle');
+    cy.get('.ReactModalPortal button').contains('Cancel').click();
+
+    cy.log("connect and disconnect table and graph after coordinates have been added");
+    cy.log('verify link icon appears when table and graph are connected');
+    cy.get(clueCanvas.linkIconEl()).should('not.exist');
+    cy.linkTableToGraph('Table 1', "Graph 1");
+    tableToolTile.getTableTile().scrollIntoView();
+    graphToolTile.getGraphTile().siblings(clueCanvas.linkIconEl()).should('exist');
+    // verifies that values exported from .scss file were successfully imported
+    graphToolTile.getGraphTile().siblings(clueCanvas.linkIconEl()).children('svg').attribute('data-indicator-width').should('exist');
+    graphToolTile.getGraph().should('have.class', 'is-linked');
+
+    cy.log('verify points added has label in table and graph');
+    tableToolTile.getIndexNumberToggle().should('exist').click({ force: true });
+    tableToolTile.getTableIndexColumnCell().first().should('contain', '1');
+    graphToolTile.getGraphPointLabel().contains('A').should('exist');
+    graphToolTile.getGraphPointLabel().contains('B').should('exist');
+    graphToolTile.getGraphPointLabel().contains('C').should('exist');
+    graphToolTile.getGraphPointLabel().contains('D').should('exist');
+
+    cy.log('verify table can be linked to two graphs');
+    clueCanvas.addTile('geometry');
+    cy.linkTableToGraph('Table 1', "Graph 2");
+    graphToolTile.getGraphTile().siblings(clueCanvas.linkIconEl()).should('have.length', 2);
+
+    cy.log('verify unlink of graph and table');
+    cy.unlinkTableToGraph('Table 1', "Graph 2");
+    graphToolTile.getGraphTile().siblings(clueCanvas.linkIconEl()).should('have.length', 1);
+    graphToolTile.getGraph().last().should('not.have.class', 'is-linked');
+
+    cy.log('verify point no longer has p1 in table and graph');
+    graphToolTile.getGraphPointLabel().contains('A').should('have.length', 1);
+
+    clueCanvas.deleteTile('graph');
   });
 
-  context('Tests for graph and table integration', function () {
-    before(function () {
-      clueCanvas.addTile('table');
-      cy.get(".primary-workspace").within((workspace) => {
-        tableToolTile.getTableCell().eq(1).click().type(x[0] +'{enter}');
-        tableToolTile.getTableCell().eq(2).click();
-        tableToolTile.getTableCell().eq(2).type(y[0] +'{enter}');
-        tableToolTile.getTableCell().eq(5).click();
-        tableToolTile.getTableCell().eq(5).type(x[1] + '{enter}');
-        tableToolTile.getTableCell().eq(6).click();
-        cy.wait(500);
-        tableToolTile.getTableCell().eq(6).type(y[1] + '{enter}');
-        tableToolTile.getTableCell().eq(9).click();
-        tableToolTile.getTableCell().eq(9).type(x[2] + '{enter}');
-        tableToolTile.getTableCell().eq(10).click();
-        tableToolTile.getTableCell().eq(10).type(y[2] + '{enter}');
-        tableToolTile.getTableCell().eq(13).click();
-        tableToolTile.getTableCell().eq(13).type(x[3] + '{enter}');
-        tableToolTile.getTableCell().eq(14).click();
-        tableToolTile.getTableCell().eq(14).type(y[3] + '{enter}');
-        tableToolTile.getTableCell().eq(17).click();
-      });
-      clueCanvas.addTile('geometry');
-      textToolTile.deleteTextTile();
-    });
-    describe('Link graph dialog', () => {
-      it('verify correct graph names appear in selection list', function () {
-        tableToolTile.getTableTile().click();
-        cy.get('.primary-workspace .link-tile-button').click();
-        cy.wait(2000);
-        // cy.get('[data-test=link-tile-select]').select('Second One');
-        cy.get('[data-test=link-tile-select]').select('Graph 1');
-      });
-      after(function () {
-        cy.get('.ReactModalPortal button').contains('Cancel').click();
-      });
-    });
-    describe("connect and disconnect table and graph after coordinates have been added", function () {
-      it('verify link icon appears when table and graph are connected', function () {
-        cy.get(clueCanvas.linkIconEl()).should('not.exist');
-        cy.linkTableToGraph('Table 1', "Graph 1");
-        tableToolTile.getTableTile().scrollIntoView();
-        graphToolTile.getGraphTile().siblings(clueCanvas.linkIconEl()).should('exist');
-        // verifies that values exported from .scss file were successfully imported
-        graphToolTile.getGraphTile().siblings(clueCanvas.linkIconEl()).children('svg').attribute('data-indicator-width').should('exist');
-        graphToolTile.getGraph().should('have.class', 'is-linked');
-      });
-      it('verify points added has label in table and graph', function () {
-        tableToolTile.getIndexNumberToggle().should('exist').click({force: true});
-        tableToolTile.getTableIndexColumnCell().first().should('contain', '1');
-        graphToolTile.getGraphPointLabel().contains('A').should('exist');
-        graphToolTile.getGraphPointLabel().contains('B').should('exist');
-        graphToolTile.getGraphPointLabel().contains('C').should('exist');
-        graphToolTile.getGraphPointLabel().contains('D').should('exist');
-      });
-      it('verify table can be linked to two graphs', function () {
-        clueCanvas.addTile('geometry');
-        cy.linkTableToGraph('Table 1', "Graph 2");
-        graphToolTile.getGraphTile().siblings(clueCanvas.linkIconEl()).should('have.length', 2);
-      });
-      it('verify unlink of graph and table', function () {
-        cy.unlinkTableToGraph('Table 1', "Graph 2");
-        graphToolTile.getGraphTile().siblings(clueCanvas.linkIconEl()).should('have.length', 1);
-        graphToolTile.getGraph().last().should('not.have.class', 'is-linked');
-      });
-      it('verify point no longer has p1 in table and graph', function () {
-        graphToolTile.getGraphPointLabel().contains('A').should('have.length', 1);
-      });
-      after(function () {
-        clueCanvas.deleteTile('graph');
-      });
-    });
-    describe.skip('test creating a polygon', function () {
-      it('will create a polygon', function () {
-        graphToolTile.getGraphPoint().last().click({ force: true }).dblclick({ force: true });
-        graphToolTile.getGraphPolygon().should('exist');
-      });
-      it('will add angle to a table point', function () {
-        tableToolTile.getTableIndexColumnCell().contains('3').click({ force: true });
-        graphToolTile.getGraphPoint().first().click({ force: true }).dblclick({ force: true });
-        graphToolTile.showAngle();
-        graphToolTile.getAngleAdornment().should('exist');
+  it.skip('test creating a polygon', function () {
+    beforeTest();
+    clueCanvas.addTile('table');
+    clueCanvas.addTile('geometry');
+    cy.log('will create a polygon')
+    graphToolTile.getGraphPoint().last().click({ force: true }).dblclick({ force: true });
+    graphToolTile.getGraphPolygon().should('exist');
 
-      });
-      it('will move a point by changing coordinates on the table', function () {
-        let new_y = '8';
-        tableToolTile.getTableTile().click();
-        cy.get(".primary-workspace").within((workspace) => {
-          tableToolTile.getTableCell().eq(10).click();
-          tableToolTile.getTableCell().eq(10).type(new_y + '{enter}');
-        });
-        graphToolTile.getGraphPointCoordinates(2).should('contain', '(6, ' + new_y + ')');
-      });
-      it('will delete a point in the table', function () {
-        let point = 0; //the 4th point in the graph
-        tableToolTile.getTableTile().click();
-        tableToolTile.removeRow(point);
+    cy.log('will add angle to a table point');
+    tableToolTile.getTableIndexColumnCell().contains('3').click({ force: true });
+    graphToolTile.getGraphPoint().first().click({ force: true }).dblclick({ force: true });
+    graphToolTile.showAngle();
+    graphToolTile.getAngleAdornment().should('exist');
 
-        //verifies p1 no longer exist in table and graph
-        tableToolTile.getTableRow().should('have.length', 4);
-        tableToolTile.getTableIndexColumnCell().eq(2).should('contain', '3');
-        tableToolTile.getTableIndexColumnCell().eq(3).should('not.contain', 'p4');
-        graphToolTile.getGraphPointLabel().contains('p4').should('not.exist');
-        graphToolTile.getGraphPointID(point)
-          .then((id) => {
-            id = '#'.concat(id);
-            cy.get(id).then(($el) => {
-              expect($el).to.not.be.visible;
-            });
-          });
-        //verifies angle adornment no longer exists
-        // graphToolTile.getAngleAdornment().should('not.exist'); TODO
-      });
+    cy.log('will move a point by changing coordinates on the table');
+    let new_y = '8';
+    tableToolTile.getTableTile().click();
+    cy.get(".primary-workspace").within((workspace) => {
+      tableToolTile.getTableCell().eq(10).click();
+      tableToolTile.getTableCell().eq(10).type(new_y + '{enter}');
     });
-    describe.skip('text axes changes', function () {
-      it('will change the name of the x-axis in the table', function () {
-        tableToolTile.getTableTile().click();
-        cy.get(".primary-workspace").within((workspace) => {
-          tableToolTile.renameColumn('x', 'mars');
-        });
-        graphToolTile.getGraphAxisLabelId('x')
-          .then((id) => {
-            id = '#'.concat(id);
-            cy.get(id).then(($el) => {
-              expect($el.text()).to.contain('mars');
-            });
-          });
-      });
-      it('will change the name of the y-axis in the table', function () {
-        tableToolTile.getTableTile().click();
-        cy.get(".primary-workspace").within((workspace) => {
-          tableToolTile.renameColumn('y', 'venus');
-        });
-        graphToolTile.getGraphAxisLabelId('y')
-          .then((id) => {
-            id = '#'.concat(id);
-            cy.get(id).then(($el) => {
-              expect($el.text()).to.contain('venus');
-            });
-          });
-      });
-    });
-    describe.skip('normal graph interactions', function () {
-      it('will add a polygon directly onto the graph', function () {
-        graphToolTile.getGraphTile().click();
-        graphToolTile.addPointToGraph(10, 10); //not sure why this isn't appearing
-        graphToolTile.addPointToGraph(10, 10);
-        graphToolTile.addPointToGraph(15, 10);
-        graphToolTile.addPointToGraph(10, 5);
-        graphToolTile.getGraphPoint().last().click({ force: true }).click({ force: true });
-      });
-      it('will add an angle to a point created from a table', function () {
-        graphToolTile.getGraphPolygon().last().click({force: true});
-        graphToolTile.showAngle();
-        graphToolTile.getAngleAdornment().should('exist');
-      });
-    });
-    describe.skip('test non-numeric entries in table', function () {
-      it('will enter non-numeric number in the table', function () {
-        tableToolTile.getTableCellWithColIndex(2, 6).scrollIntoView();
-        tableToolTile.getTableCellWithColIndex(2, 6).click({force: true}).type(9);
-        tableToolTile.getTableCell().eq(3).should('contain', x[1]);
+    graphToolTile.getGraphPointCoordinates(2).should('contain', '(6, ' + new_y + ')');
+
+    cy.log('will delete a point in the table');
+    let point = 0; //the 4th point in the graph
+    tableToolTile.getTableTile().click();
+    tableToolTile.removeRow(point);
+
+    //verifies p1 no longer exist in table and graph
+    tableToolTile.getTableRow().should('have.length', 4);
+    tableToolTile.getTableIndexColumnCell().eq(2).should('contain', '3');
+    tableToolTile.getTableIndexColumnCell().eq(3).should('not.contain', 'p4');
+    graphToolTile.getGraphPointLabel().contains('p4').should('not.exist');
+    graphToolTile.getGraphPointID(point).then((id) => {
+      id = '#'.concat(id);
+      cy.get(id).then(($el) => {
+        expect($el).to.not.be.visible;
       });
     });
 
-  });
-  context('Save and restore keeps the connection between table and graph', function () {
-    before(function () {
-      let title = '2.3 Mouthing Off and Nosing Around';
-      canvas.createNewExtraDocumentFromFileMenu("empty",'my-work');
-      cy.wait(2000);
-      cy.openResourceTabs();
-      cy.openTopTab('my-work');
-      cy.openDocumentWithTitle('my-work', 'workspaces', title);
-      cy.collapseResourceTabs();
+    cy.log('will change the name of the x-axis in the table');
+    tableToolTile.getTableTile().click();
+    cy.get(".primary-workspace").within((workspace) => {
+      tableToolTile.renameColumn('x', 'mars');
     });
-    it('verify connection of table and graph on restored canvas', function () {
-      graphToolTile.getGraphPointLabel().contains('A').should('exist');
+    graphToolTile.getGraphAxisLabelId('x').then((id) => {
+      id = '#'.concat(id);
+      cy.get(id).then(($el) => {
+        expect($el.text()).to.contain('mars');
+      });
     });
-  });
-  context.skip('Delete connected table', function () {
-    it('will delete connected table', function () {
-      clueCanvas.deleteTile('table');
-      graphToolTile.getGraphPointLabel().contains('p1').should('not.exist');
-    });
-    it('will verify graph is still functional after connected table is deleted', function () {
-      graphToolTile.getGraphTile().click();
-      graphToolTile.addPointToGraph(2, 6);
-      graphToolTile.getGraphPoint().should('exist').and('have.length', 3);
-    });
-  });
-});
 
-context("Dragging to copy linked tiles", () => {
-  before(function () {
-    const queryParams = "?appMode=qa&fakeClass=5&fakeUser=student:5&problem=2.3&qaGroup=5"; //using different problem bec. 2.1 disables graph table integration
-    cy.clearQAData('all');
+    cy.log('will change the name of the y-axis in the table');
+    tableToolTile.getTableTile().click();
+    cy.get(".primary-workspace").within((workspace) => {
+      tableToolTile.renameColumn('y', 'venus');
+    });
+    graphToolTile.getGraphAxisLabelId('y').then((id) => {
+      id = '#'.concat(id);
+      cy.get(id).then(($el) => {
+        expect($el.text()).to.contain('venus');
+      });
+    });
 
-    cy.visit(queryParams);
-    cy.waitForLoad();
-    // cy.collapseResourceTabs();
+    cy.log('normal graph interactions');
+    cy.log('will add a polygon directly onto the graph');
+    graphToolTile.getGraphTile().click();
+    graphToolTile.addPointToGraph(10, 10); //not sure why this isn't appearing
+    graphToolTile.addPointToGraph(10, 10);
+    graphToolTile.addPointToGraph(15, 10);
+    graphToolTile.addPointToGraph(10, 5);
+    graphToolTile.getGraphPoint().last().click({ force: true }).click({ force: true });
 
-    clueCanvas.getInvestigationCanvasTitle().text().as('investigationTitle');
+    cy.log('will add an angle to a point created from a table');
+    graphToolTile.getGraphPolygon().last().click({ force: true });
+    graphToolTile.showAngle();
+    graphToolTile.getAngleAdornment().should('exist');
+
+
+    cy.log('test non-numeric entries in table');
+    cy.log('will enter non-numeric number in the table');
+    tableToolTile.getTableCellWithColIndex(2, 6).scrollIntoView();
+    tableToolTile.getTableCellWithColIndex(2, 6).click({ force: true }).type(9);
+    tableToolTile.getTableCell().eq(3).should('contain', x[1]);
   });
 
-  describe("Can drag to copy linked tiles from the left panel", () => {
+  it("Dragging to copy linked tiles", () => {
+    beforeTest();
+    
     const dataTransfer = new DataTransfer;
-    it("drag a linked table and geometry tile", () => {
-      // Set up and link table and geometry tile
-      clueCanvas.addTile('table');
-      cy.get(".primary-workspace").within((workspace) => {
-        tableToolTile.getTableCell().eq(1).click().type(x[0] +'{enter}');
-        tableToolTile.getTableCell().eq(2).click();
-        tableToolTile.getTableCell().eq(2).type(y[0] +'{enter}');
-        tableToolTile.getTableCell().eq(5).click();
-        tableToolTile.getTableCell().eq(5).type(x[1] + '{enter}');
-        tableToolTile.getTableCell().eq(6).click();
-        cy.wait(500);
-        tableToolTile.getTableCell().eq(6).type(y[1] + '{enter}');
-        tableToolTile.getTableCell().eq(9).click();
-      });
-      clueCanvas.addTile('geometry');
-      textToolTile.deleteTextTile();
-      cy.linkTableToGraph('Table 1', "Graph 1");
-
-      // Open the document on the left, then create a new document on the right
-      resourcesPanel.openPrimaryWorkspaceTab("my-work");
-      cy.get(".tab-panel-documents-section .list-item").first().click();
-      canvas.createNewExtraDocumentFromFileMenuWithoutTabs("Test Document", "my-work");
-      cy.wait(100);
-
-      // Select the table and geometry tiles on the left
-      const leftTile = type => cy.get(`.nav-tab-panel .documents-panel .${type}-tool-tile`);
-      leftTile('table').first().click();
-      leftTile('geometry').first().click({ shiftKey: true });
-
-      // Drag the selected tiles to the workspace on the right
-      leftTile('geometry').first().trigger('dragstart', { dataTransfer });
-      cy.get('.single-workspace .canvas .document-content').first()
-        .trigger('drop', { force: true, dataTransfer });
-
-      // The copied geometry tile should have two points from its linked shared dataset
-      graphToolTile.getGraphPoint().should("exist").and("have.length", 2);
-
-      // Drag just the geometry tile from the left to the right
-      leftTile('table').first().click({ shiftKey: true });
-      leftTile('geometry').first().trigger('dragstart', { dataTransfer });
-      cy.get('.single-workspace .canvas .document-content').first()
-        .trigger('drop', { force: true, dataTransfer });
-
-      // We should now have a total of four points, two in each table
-      graphToolTile.getGraphPoint().should("exist").and("have.length", 4);
-
-      // Add a new point to the table
-      cy.get(".primary-workspace").within((workspace) => {
-        tableToolTile.getTableCell().eq(9).click();
-        tableToolTile.getTableCell().eq(9).type(x[2] + '{enter}');
-        tableToolTile.getTableCell().eq(10).click();
-        tableToolTile.getTableCell().eq(10).type(y[2] + '{enter}');
-        tableToolTile.getTableCell().eq(13).click();
-      });
-
-      // The new point should only appear in the first copied geometry tile, so we now have a total of five
-      graphToolTile.getGraphPoint().should("exist").and("have.length", 5);
+    cy.log("drag a linked table and geometry tile");
+    // Set up and link table and geometry tile
+    clueCanvas.addTile('table');
+    cy.get(".primary-workspace").within((workspace) => {
+      tableToolTile.getTableCell().eq(1).click().type(x[0] + '{enter}');
+      tableToolTile.getTableCell().eq(2).click();
+      tableToolTile.getTableCell().eq(2).type(y[0] + '{enter}');
+      tableToolTile.getTableCell().eq(5).click();
+      tableToolTile.getTableCell().eq(5).type(x[1] + '{enter}');
+      tableToolTile.getTableCell().eq(6).click();
+      cy.wait(500);
+      tableToolTile.getTableCell().eq(6).type(y[1] + '{enter}');
+      tableToolTile.getTableCell().eq(9).click();
     });
-  });
+    clueCanvas.addTile('geometry');
+    textToolTile.deleteTextTile();
+    cy.linkTableToGraph('Table 1', "Graph 1");
 
+    // Open the document on the left, then create a new document on the right
+    resourcesPanel.openPrimaryWorkspaceTab("my-work");
+    cy.get(".tab-panel-documents-section .list-item").first().click();
+    canvas.createNewExtraDocumentFromFileMenuWithoutTabs("Test Document", "my-work");
+    cy.wait(100);
+
+    // Select the table and geometry tiles on the left
+    const leftTile = type => cy.get(`.nav-tab-panel .documents-panel .${type}-tool-tile`);
+    leftTile('table').first().click();
+    leftTile('geometry').first().click({ shiftKey: true });
+
+    // Drag the selected tiles to the workspace on the right
+    leftTile('geometry').first().trigger('dragstart', { dataTransfer });
+    cy.get('.single-workspace .canvas .document-content').first()
+      .trigger('drop', { force: true, dataTransfer });
+
+    // The copied geometry tile should have two points from its linked shared dataset
+    graphToolTile.getGraphPoint().should("exist").and("have.length", 2);
+
+    // Drag just the geometry tile from the left to the right
+    leftTile('table').first().click({ shiftKey: true });
+    leftTile('geometry').first().trigger('dragstart', { dataTransfer });
+    cy.get('.single-workspace .canvas .document-content').first()
+      .trigger('drop', { force: true, dataTransfer });
+
+    // We should now have a total of four points, two in each table
+    graphToolTile.getGraphPoint().should("exist").and("have.length", 4);
+
+    // Add a new point to the table
+    cy.get(".primary-workspace").within((workspace) => {
+      tableToolTile.getTableCell().eq(9).click();
+      tableToolTile.getTableCell().eq(9).type(x[2] + '{enter}');
+      tableToolTile.getTableCell().eq(10).click();
+      tableToolTile.getTableCell().eq(10).type(y[2] + '{enter}');
+      tableToolTile.getTableCell().eq(13).click();
+    });
+
+    // The new point should only appear in the first copied geometry tile, so we now have a total of five
+    graphToolTile.getGraphPoint().should("exist").and("have.length", 5);
+  });
 });

--- a/cypress/e2e/clue/branch/student_tests/graph_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/graph_tool_spec.js
@@ -15,16 +15,18 @@ const textToolTile = new TextToolTile;
 const problemDoc = '2.1 Drawing Wumps';
 const ptsDoc = 'Points';
 
-context('Graph Tool', function () {
-  beforeEach(function () {
-    const queryParams = `${Cypress.config("queryParams")}`;
-    cy.clearQAData('all');
-    cy.visit(queryParams);
-    cy.waitForLoad();
-    cy.collapseResourceTabs();
-  });
+function beforeTest() {
+  const queryParams = `${Cypress.config("queryParams")}`;
+  cy.clearQAData('all');
+  cy.visit(queryParams);
+  cy.waitForLoad();
+  cy.collapseResourceTabs();
+}
 
+context('Graph Tool', function () {
   it('will test adding points to a graph', function () {
+    beforeTest();
+
     cy.log("add a point to the origin");
     clueCanvas.addTile('geometry');
     graphToolTile.addPointToGraph(0, 0);
@@ -81,6 +83,8 @@ context('Graph Tool', function () {
   });
 
   it('will test Graph tile undo redo', () => {
+    beforeTest();
+
     cy.log("undo redo graph tile creation/deletion");
     // Creation - Undo/Redo
     clueCanvas.addTile('geometry');

--- a/cypress/e2e/clue/branch/student_tests/group_test_readonly_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/group_test_readonly_spec.js
@@ -1,0 +1,51 @@
+import ClueCanvas from '../../../../support/elements/clue/cCanvas';
+import TextToolTile from '../../../../support/elements/clue/TextToolTile';
+import TeacherDashboard from "../../../../support/elements/clue/TeacherDashboard";
+
+const clueCanvas = new ClueCanvas;
+const textToolTile = new TextToolTile;
+let dashboard = new TeacherDashboard();
+let students = [15, 16, 17, 18];
+
+const baseUrl = `${Cypress.config("baseUrl")}`;
+
+function getUrl(studentIndex) {
+  return baseUrl + '?appMode=qa&qaGroup=10&fakeClass=10&problem=2.3&fakeUser=student:' + students[studentIndex]
+}
+
+function setupTest(studentIndex) {
+  const url = getUrl(studentIndex);
+  cy.visit(url);
+  cy.waitForLoad();
+  clueCanvas.shareCanvas();//all students will share their canvas
+  cy.wait(10000);
+  clueCanvas.addTile('text');
+  textToolTile.enterText('This is to test the 4-up view of S' + students[studentIndex]);
+  textToolTile.getTextTile().last().should('contain', '4-up').and('contain', 'S' + students[studentIndex]);
+}
+
+context('Test group functionalities', function () {
+  it('4-up view read-only', function () {
+    
+    cy.log('students to check each others tiles in 4-up view read-only');
+    cy.clearQAData('all');
+
+    setupTest(0);
+    setupTest(1);
+    setupTest(2);
+    setupTest(3);
+
+    clueCanvas.openFourUpView();
+    clueCanvas.getSingleWorkspace().find('.member').eq(0).click();
+    clueCanvas.getSingleWorkspace().find('.text-tool').should('not.have.class', 'read-only');
+    dashboard.getZoomedStudentID().click();
+    clueCanvas.getSingleWorkspace().find('.member').eq(1).click();
+    clueCanvas.getSingleWorkspace().find('.text-tool').should('have.class', 'read-only');
+    dashboard.getZoomedStudentID().click();
+    clueCanvas.getSingleWorkspace().find('.member').eq(2).click();
+    clueCanvas.getSingleWorkspace().find('.text-tool').should('have.class', 'read-only');
+    dashboard.getZoomedStudentID().click();
+    clueCanvas.getSingleWorkspace().find('.member').eq(3).click();
+    clueCanvas.getSingleWorkspace().find('.text-tool').should('have.class', 'read-only');
+  });
+});

--- a/cypress/e2e/clue/branch/student_tests/group_test_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/group_test_spec.js
@@ -1,257 +1,145 @@
 import ClueCanvas from '../../../../support/elements/clue/cCanvas';
 import TextToolTile from '../../../../support/elements/clue/TextToolTile';
-import TeacherDashboard from "../../../../support/elements/clue/TeacherDashboard";
 import Canvas from '../../../../support/elements/common/Canvas';
 import ResourcesPanel from '../../../../support/elements/clue/ResourcesPanel';
 import ClueHeader from '../../../../support/elements/clue/cHeader';
 
 const clueCanvas = new ClueCanvas;
 const textToolTile = new TextToolTile;
-let dashboard = new TeacherDashboard();
 let canvas = new Canvas;
 let resourcesPanel = new ResourcesPanel;
 let header = new ClueHeader;
+let qaClass = 10,
+  qaGroup = 10,
+  problem = 2.3,
+  students = [15, 16, 17, 18, 19];
 
 const baseUrl = `${Cypress.config("baseUrl")}`;
-context('Test group functionalities', function(){
-    before(()=>{
-        cy.clearQAData('all');
-    });
 
-    let qaClass = 10,
-        qaGroup = 10,
-        problem = 3.3,
-        studentArr=[15,16,17,18];
-    context('test the views', function(){
-        describe('set-up for 4-up view tests', function(){
-            it('will set up groups', function(){
-                cy.setupGroup(studentArr, qaGroup);
-            });
-            it('will add content to each student canvas', function(){
-                let i=0;
-                for (i=0; i<studentArr.length; i++){
-                    cy.visit(baseUrl+'?appMode=qa&qaGroup='+qaGroup+'&fakeClass='+qaClass+'&fakeUser=student:'+studentArr[i]+'&problem='+problem);
-                    // cy.log(baseUrl+'?appMode=qa&qaGroup='+qaGroup+'&fakeClass='+qaClass+'&fakeUser=student:'+studentArr[i]+'&problem='+problem);
-                    cy.waitForLoad();
-                    cy.wait(5000);
-                    clueCanvas.addTile('text');
-                    textToolTile.enterText('This is to test the 4-up view of S'+studentArr[i]);
-                    textToolTile.getTextTile().last().should('contain', '4-up').and('contain','S'+studentArr[i]);
-                    clueCanvas.addTile('geometry');
-                    clueCanvas.addTile('table');
-                    clueCanvas.addTile('drawing');
-                    clueCanvas.addTile('image');
-                    cy.wait(500);
-                    clueCanvas.shareCanvas();//all students will share their canvas
-                    cy.wait(1000);
-                }
-            });
-            it('verify 4-up view comes up correctly with students', function(){
-                clueCanvas.openFourUpView();
-                clueCanvas.getFourToOneUpViewToggle().should('be.visible');
-                clueCanvas.getNorthEastCanvas().should('be.visible').and('contain','S'+studentArr[0]);
-                clueCanvas.getSouthEastCanvas().should('be.visible').and('contain','S'+studentArr[1]);
-                clueCanvas.getSouthWestCanvas().should('be.visible').and('contain','S'+studentArr[2]);
-                clueCanvas.getNorthWestCanvas().should('be.visible').and('contain','S'+studentArr[3]);
-            });
-        });
-        // describe('test the 4-up view', function(){
-        //     // TODO: CSS element visibility error, {force: true}
-        //     it.skip("will move horizontal splitter vertically and verify canvas size change", function () {
-        //         cy.get('.canvas-area > .four-up > .horizontal.splitter').trigger('mousedown', {force: true});
-        //         cy.wait(1000);
-        //         cy.get('.canvas-area > .four-up > .horizontal.splitter').trigger('mousemove', {pageX:243, pageY: 175, force: true});
-        //         cy.wait(1000);
-        //         cy.get('.canvas-area > .four-up > .horizontal.splitter').trigger('mouseup', {force: true});
-        //         // cy.get('.canvas-area > .four-up > .horizontal.splitter').trigger('mousedown',{which:1}, {force:true}).trigger('mousemove',{pageX:243, pageY: 175}, {force:true}).trigger('mouseup',{force:true});
-        //         cy.get('.canvas-area .canvas-container.north-west').should('have.css','height').and('less.than', 243);
-        //         cy.get('.canvas-area .canvas-container.south-east').should('have.css','height').and('greater.than', 243);
-        //     });
-        //     // TODO: Write this test
-        //     it.skip('will move vertical splitter horizantally and verify canvas size change', function(){
-        //         cy.log('need to write this test');
-        //     });
-        //     // TODO: drag and drop of center point to change 4up view canvas sizes
-        //     it.skip('will move the center handle horizontally and vertically and verify canvas size change', function (){
-        //         clueCanvas.getCenterSeparator()
-        //             .trigger('dragstart',{force:true})
-        //             .trigger('drag',243, 175, {force:true})
-        //             .trigger('dragend',{force:true});
-        //     });
-        //     it('will verify editing own canvas is still possible in 4-up view', function(){
-        //         clueCanvas.addTile('text');
-        //         textToolTile.getTextTile().first().type('Hello World!');
-        //         textToolTile.getTextTile().first().should('contain', 'Hello World');
-        //         clueCanvas.addTile('geometry');
-        //         // cy.get('.canvas-container.north-west > .canvas-scaler > .canvas > .document-content > .tile-row> .tool-tile > .geometry-size-me > .geometry-tool').last().click();
-        //         // cy.get('.canvas-container.north-west > .canvas-scaler > .canvas > .document-content > .tile-row> .tool-tile > .geometry-size-me  > .geometry-tool > .JXGtext').last().should('contain', 'A' );
-        //         // cy.get('.canvas-container.north-west > .canvas-scaler > .canvas > .document-content > .tile-row> .tool-tile > .geometry-size-me > .geometry-tool').last().click(140,70, {force:true});
-        //         // cy.get('.canvas-container.north-west > .canvas-scaler > .canvas > .document-content > .tile-row> .tool-tile > .geometry-size-me > .geometry-tool > .JXGtext').last().should('contain', 'B' );
-        //     });
-        //     // TODO: Never found elements
-        //     it('will verify editing is not allowed in other group members\' canvas', function(){
-        //         cy.get('.canvas-container.north-east > .canvas-scaler > .canvas > .document-content > .tile-row >.tool-tile > .text-tool').last().should('not.contain', 'Hello World');
-        //         cy.get('.canvas-container.south-west > .canvas-scaler > .canvas > .document-content > .tile-row >.tool-tile > .text-tool').last().should('not.contain', 'Hello World');
-        //         cy.get('.canvas-container.south-east > .canvas-scaler > .canvas > .document-content > .tile-row >.tool-tile > .text-tool').last().should('not.contain', 'Hello World');
-        //     });
-        //     it.skip('will try to delete elements from other canvases in 4 up view', function(){
-        //         //TODO
-        //         cy.log('need to write this test');
-        //     });
-        //
-        //     //TODO: have to figure out drag and drop
-        //     it.skip('will copy text from one canvas to own canvas', function(){
-        //         cy.log('need to write this test');
-        //     });
-        //     after(()=>{
-        //         clueCanvas.unshareCanvas();
-        //         clueCanvas.openOneUpViewFromFourUp(); //clean up
-        //     });
-        // });
+function getUrl(studentIndex) {
+  return baseUrl + '?appMode=qa&qaGroup=10&fakeClass=10&problem=2.3&fakeUser=student:' + students[studentIndex];
+}
 
-        // TODO: Need to write tests
-        describe('test sharing and unsharing canvases', function(){
-            it('verify share icon toggles correctly',()=>{
-                clueCanvas.getShareButton().should('have.class', 'public');
-                clueCanvas.shareCanvas();
-                clueCanvas.getShareButton().should('have.class', 'private');
-                clueCanvas.unshareCanvas();
-                clueCanvas.getShareButton().should('have.class', 'public');
-            });
-            it('will verify canvas is visible in groupmates 4-up view', function(){ //canvas is shared during set up
-                cy.log('need to write this test');
-                cy.visit(baseUrl+'?appMode=qa&qaGroup='+qaGroup+'&fakeClass='+qaClass+'&fakeUser=student:18&problem=2.3');
-                cy.waitForLoad();
-                cy.wait(5000);
-                clueCanvas.openFourUpView();
-                clueCanvas.getFourToOneUpViewToggle().should('be.visible');
-                cy.get('.canvas-area .four-up .canvas-container.north-west').should('be.visible').and('not.contain','not shared their workspace');
-                clueCanvas.getNorthEastCanvas().should('be.visible').and('not.contain','not shared their workspace');
-                clueCanvas.getSouthEastCanvas().should('be.visible').and('not.contain','not shared their workspace');
-                clueCanvas.getSouthWestCanvas().should('be.visible').and('not.contain','not shared their workspace');
-            });
-            it('will unshare canvas and verify canvas is not visible in groupmates 4-up view', function(){
-                cy.log('need to write this test');
-                clueCanvas.shareCanvas();
-                cy.visit(baseUrl+'?appMode=qa&qaGroup='+qaGroup+'&fakeClass='+qaClass+'&fakeUser=student:15&problem=2.3');
-                cy.waitForLoad();
-                cy.wait(5000);
-                clueCanvas.openFourUpView();
-                clueCanvas.getFourToOneUpViewToggle().should('be.visible');
-                clueCanvas.getSouthWestCanvas().should('be.visible').and('contain','Student 18 has not shared their workspace.');
-            });
-            it('restore a 4-up canvas where a groupmate has shared a canvas while it was not open', function(){
-                let copyTitle = 'Workspace Copy Document';
-                canvas.copyDocument(copyTitle);
-                canvas.getPersonalDocTitle().should('contain', copyTitle);
-                cy.openTopTab("my-work");
-                cy.openSection("my-work", "workspaces");
-                resourcesPanel.getCanvasItemTitle('my-work', 'workspaces').should('contain', copyTitle);
-                cy.openDocumentWithTitle('my-work', 'workspaces', copyTitle);
-                cy.visit(baseUrl+'?appMode=qa&qaGroup='+qaGroup+'&fakeClass='+qaClass+'&fakeUser=student:18&problem=2.3');
-                cy.waitForLoad();
-                cy.wait(5000);
-                clueCanvas.openFourUpView();
-                clueCanvas.getFourToOneUpViewToggle().should('be.visible');
-                clueCanvas.getNorthEastCanvas().should('contain', 'S15');
-                clueCanvas.getNorthEastCanvas().should('be.visible').and('not.contain','not shared their workspace');        
-                clueCanvas.shareCanvas();
-                cy.visit(baseUrl+'?appMode=qa&qaGroup='+qaGroup+'&fakeClass='+qaClass+'&fakeUser=student:15&problem=2.3');
-                cy.waitForLoad();
-                cy.wait(5000);
-                clueCanvas.openFourUpView();
-                clueCanvas.getFourToOneUpViewToggle().should('be.visible');
-                clueCanvas.getSouthWestCanvas().should('contain', 'S18');
-                clueCanvas.getSouthWestCanvas().should('be.visible').and('not.contain','not shared their workspace');
-            });
-            it('restore a 4-up canvas where a groupmate has unshared a canvas while it was not open', function(){
-                cy.log('need to write this test');
-                let copyTitle = 'Workspace Copy Document';
-                cy.openTopTab("my-work");
-                cy.openSection("my-work", "workspaces");
-                resourcesPanel.getCanvasItemTitle('my-work', 'workspaces').should('contain', copyTitle);
-                cy.openDocumentWithTitle('my-work', 'workspaces', copyTitle);
-                cy.visit(baseUrl+'?appMode=qa&qaGroup='+qaGroup+'&fakeClass='+qaClass+'&fakeUser=student:18&problem=2.3');
-                cy.waitForLoad();
-                cy.wait(5000);
-                clueCanvas.openFourUpView();
-                clueCanvas.getFourToOneUpViewToggle().should('be.visible');
-                clueCanvas.getNorthEastCanvas().should('contain', 'S15');
-                clueCanvas.getNorthEastCanvas().should('be.visible').and('not.contain','not shared their workspace');        
-                clueCanvas.shareCanvas();
-                cy.visit(baseUrl+'?appMode=qa&qaGroup='+qaGroup+'&fakeClass='+qaClass+'&fakeUser=student:15&problem=2.3');
-                cy.waitForLoad();
-                cy.wait(5000);
-                clueCanvas.openFourUpView();
-                clueCanvas.getFourToOneUpViewToggle().should('be.visible');
-                clueCanvas.getSouthWestCanvas().should('contain', 'S18');
-                clueCanvas.getSouthWestCanvas().should('be.visible').and('contain','Student 18 has not shared their workspace.');
-                header.leaveGroup();
+function setupTest(studentIndex) {
+  const url = getUrl(studentIndex);
+  cy.visit(url);
+  cy.waitForLoad();
+  header.getGroupName().should('contain', 'Group ' + qaGroup);
+  header.getGroupMembers().find('div.member').should('contain', 'S' + students[studentIndex]);
+  clueCanvas.shareCanvas();
+  cy.wait(5000)
+  clueCanvas.addTile('text');
+  textToolTile.enterText('This is to test the 4-up view of S' + students[studentIndex]);
+  textToolTile.getTextTile().last().should('contain', '4-up').and('contain', 'S' + students[studentIndex]);
+  clueCanvas.addTile('geometry');
+  clueCanvas.addTile('table');
+  clueCanvas.addTile('drawing');
+  clueCanvas.addTile('image');
+}
 
-            });
-            it('will open a new 4-up canvas with shared canvas from other students updated', function(){
-                cy.log('need to write this test');
-                cy.visit(baseUrl+'?appMode=qa&qaGroup='+qaGroup+'&fakeClass='+qaClass+'&fakeUser=student:18&problem=2.3');
-                cy.waitForLoad();
-                cy.wait(5000);
-                clueCanvas.shareCanvas();
-                //add new student to the group
-                cy.visit(baseUrl+'?appMode=qa&qaGroup='+qaGroup+'&fakeClass='+qaClass+'&fakeUser=student:19&problem=2.3');
-                cy.waitForLoad();
-                cy.wait(5000);
-                clueCanvas.openFourUpView();
-                clueCanvas.getFourToOneUpViewToggle().should('be.visible');
-                clueCanvas.getSouthWestCanvas().should('contain', 'S18');
-                clueCanvas.getSouthWestCanvas().should('be.visible').and('not.contain','not shared their workspace');
-            });
-        });
+function verifyGroup() {
+  // Verify Group num and the correct 4 students are listed, now that all 4 are loaded
+  header.getGroupName().should('contain', 'Group ' + qaGroup);
+  header.getGroupMembers().find('div.member').should('contain', 'S' + students[0]);
+  header.getGroupMembers().find('div.member').should('contain', 'S' + students[1]);
+  header.getGroupMembers().find('div.member').should('contain', 'S' + students[2]);
+  header.getGroupMembers().find('div.member').should('contain', 'S' + students[3]);
+}
 
-        describe('4-up view read-only', function(){
-            it('students to check each others tiles in 4-up view read-only', function(){
-                let i=0;
-                for (i=0; i<studentArr.length; i++){
-                    cy.visit(baseUrl+'?appMode=qa&qaGroup='+qaGroup+'&fakeClass='+qaClass+'&fakeUser=student:'+studentArr[i]+'&problem='+problem);
-                    cy.waitForLoad();
-                    cy.wait(5000);
-                    clueCanvas.addTile('text');
-                    textToolTile.enterText('This is to test the 4-up view of S'+studentArr[i]);
-                    textToolTile.getTextTile().last().should('contain', '4-up').and('contain','S'+studentArr[i]);
-                    cy.wait(500);
-                    clueCanvas.shareCanvas();//all students will share their canvas
-                    cy.wait(1000);
-                }
-                clueCanvas.openFourUpView();
-                clueCanvas.getSingleWorkspace().find('.member').eq(0).click();
-                clueCanvas.getSingleWorkspace().find('.text-tool').should('not.have.class', 'read-only');
-                dashboard.getZoomedStudentID().click();
-                clueCanvas.getSingleWorkspace().find('.member').eq(1).click();
-                clueCanvas.getSingleWorkspace().find('.text-tool').should('have.class', 'read-only');
-                dashboard.getZoomedStudentID().click();
-                clueCanvas.getSingleWorkspace().find('.member').eq(2).click();
-                clueCanvas.getSingleWorkspace().find('.text-tool').should('have.class', 'read-only');
-                dashboard.getZoomedStudentID().click();
-                clueCanvas.getSingleWorkspace().find('.member').eq(3).click();
-                clueCanvas.getSingleWorkspace().find('.text-tool').should('have.class', 'read-only');
+context('Test group functionalities', function () {
+  it('4-up view tests', function () {
 
-            });
-        });
+    cy.log('will set up groups');
+    cy.clearQAData('all');
+    setupTest(0);
+    setupTest(1);
+    setupTest(2);
+    setupTest(3);
+    verifyGroup();
 
-        // describe.skip('test copy and paste from another canvas to another canvas', function(){
-        //     it('verify that student can copy text field from another student canvas into own', function(){
-        //         cy.log('need to write this test');
-        //     });
-        //     it('verify that student can copy graph field from another student canvas into own', function(){
-        //         cy.log('need to write this test');
-        //     });
-        //     it('verify that student cannot copy text field from own canvas into another student canvas', function(){
-        //         cy.log('need to write this test');
-        //     });
-        //     it('verify that student cannot copy graph field from own canvas into another student', function(){
-        //         cy.log('need to write this test');
-        //     });
-        //     it('verify student cannot copy text and graph field from another student to another student', function(){
-        //         cy.log('need to write this test');
-        //     });
-        // });
-    });
+    cy.log('verify 4-up view comes up correctly with students');
+    clueCanvas.openFourUpView();
+    clueCanvas.getFourToOneUpViewToggle().should('be.visible');
+    clueCanvas.getNorthEastCanvas().should('be.visible').and('contain', 'S' + students[0]);
+    clueCanvas.getSouthEastCanvas().should('be.visible').and('contain', 'S' + students[1]);
+    clueCanvas.getSouthWestCanvas().should('be.visible').and('contain', 'S' + students[2]);
+    clueCanvas.getNorthWestCanvas().should('be.visible').and('contain', 'S' + students[3]);
+
+    cy.log('verify share icon toggles correctly');
+    clueCanvas.getShareButton().should('have.class', 'public');
+    clueCanvas.unshareCanvas();
+    clueCanvas.getShareButton().should('have.class', 'private');
+    clueCanvas.shareCanvas();
+    clueCanvas.getShareButton().should('have.class', 'public');
+
+    cy.log('will verify canvas is visible in groupmates 4-up view');
+    clueCanvas.getFourToOneUpViewToggle().should('be.visible');
+    cy.get('.canvas-area .four-up .canvas-container.north-west').should('be.visible').and('not.contain', 'not shared their workspace');
+    clueCanvas.getNorthEastCanvas().should('be.visible').and('not.contain', 'not shared their workspace');
+    clueCanvas.getSouthEastCanvas().should('be.visible').and('not.contain', 'not shared their workspace');
+    clueCanvas.getSouthWestCanvas().should('be.visible').and('not.contain', 'not shared their workspace');
+
+    cy.log('will unshare canvas and verify canvas is not visible in groupmates 4-up view');
+    clueCanvas.unshareCanvas();
+    cy.visit(getUrl(0));
+    cy.waitForLoad();
+    clueCanvas.openFourUpView();
+    clueCanvas.getFourToOneUpViewToggle().should('be.visible');
+    clueCanvas.getSouthWestCanvas().should('be.visible').and('contain', 'Student 18 has not shared their workspace.');
+
+    cy.log('restore a 4-up canvas where a groupmate has shared a canvas while it was not open');
+    let copyTitle1 = 'Workspace Copy Document';
+    canvas.copyDocument(copyTitle1);
+    canvas.getPersonalDocTitle().should('contain', copyTitle1);
+    cy.openTopTab("my-work");
+    cy.openSection("my-work", "workspaces");
+    resourcesPanel.getCanvasItemTitle('my-work', 'workspaces').should('contain', copyTitle1);
+    cy.openDocumentWithTitle('my-work', 'workspaces', copyTitle1);
+    cy.visit(getUrl(3));
+    cy.waitForLoad();
+    clueCanvas.openFourUpView();
+    clueCanvas.getFourToOneUpViewToggle().should('be.visible');
+    clueCanvas.getNorthEastCanvas().should('contain', 'S15');
+    clueCanvas.getNorthEastCanvas().should('be.visible').and('not.contain', 'not shared their workspace');
+    clueCanvas.shareCanvas();
+    cy.visit(getUrl(0));
+    cy.waitForLoad();
+    clueCanvas.openFourUpView();
+    clueCanvas.getFourToOneUpViewToggle().should('be.visible');
+    clueCanvas.getSouthWestCanvas().should('contain', 'S18');
+    clueCanvas.getSouthWestCanvas().should('be.visible').and('not.contain', 'not shared their workspace');
+
+    cy.log('restore a 4-up canvas where a groupmate has unshared a canvas while it was not open');
+    let copyTitle2 = 'Workspace Copy Document';
+    cy.openTopTab("my-work");
+    cy.openSection("my-work", "workspaces");
+    resourcesPanel.getCanvasItemTitle('my-work', 'workspaces').should('contain', copyTitle2);
+    cy.openDocumentWithTitle('my-work', 'workspaces', copyTitle2);
+    cy.visit(getUrl(3));
+    cy.waitForLoad();
+    clueCanvas.openFourUpView();
+    clueCanvas.getFourToOneUpViewToggle().should('be.visible');
+    clueCanvas.getNorthEastCanvas().should('contain', 'S15');
+    clueCanvas.getNorthEastCanvas().should('be.visible').and('not.contain', 'not shared their workspace');
+    clueCanvas.shareCanvas();
+    cy.visit(getUrl(0));
+    cy.waitForLoad();
+    clueCanvas.openFourUpView();
+    clueCanvas.getFourToOneUpViewToggle().should('be.visible');
+    clueCanvas.getSouthWestCanvas().should('contain', 'S18');
+    clueCanvas.getSouthWestCanvas().should('be.visible').and('contain', 'Student 18 has not shared their workspace.');
+    header.leaveGroup();
+
+    cy.log('will open a new 4-up canvas with shared canvas from other students updated');
+    cy.visit(getUrl(3));
+    cy.waitForLoad();
+    clueCanvas.shareCanvas();
+    //add new student to the group
+    cy.visit(getUrl(4));
+    cy.waitForLoad();
+    clueCanvas.openFourUpView();
+    clueCanvas.getFourToOneUpViewToggle().should('be.visible');
+    clueCanvas.getSouthWestCanvas().should('contain', 'S18');
+    clueCanvas.getSouthWestCanvas().should('be.visible').and('not.contain', 'not shared their workspace');
+  });
 });

--- a/cypress/e2e/clue/branch/student_tests/image_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/image_tool_spec.js
@@ -13,168 +13,99 @@ const resourcesPanel = new ResourcesPanel;
 
 let userCanvas = 'Uploaded Images';
 
-context('Test image functionalities', function(){
-    before(function(){
-        const queryParams = `${Cypress.config("queryParams")}`;
-        cy.clearQAData('all');
-        cy.visit(queryParams);
-        cy.waitForLoad();
-        cy.showOnlyDocumentWorkspace();
-    });
+function beforeTest() {
+  const queryParams = `${Cypress.config("queryParams")}`;
+  cy.clearQAData('all');
+  cy.visit(queryParams);
+  cy.waitForLoad();
+  cy.showOnlyDocumentWorkspace();
+}
 
-    describe('upload image from user computer',()=>{
-        before(()=>{ //create a new doc so that save and restore can be tested
-            canvas.createNewExtraDocumentFromFileMenu(userCanvas, "my-work");
-            cy.wait(2000);
-        });
-        it('will upload png file from user computer', function(){
-            const imageFilePath='image.png';
-            clueCanvas.addTile('image');
-            imageToolTile.getImageToolTile().should("exist");
-            // imageToolTile.getImageToolControl().last().click();
-            cy.uploadFile(imageToolTile.imageChooseFileButton(), imageFilePath, 'image/png');
-            cy.wait(2000);
-        });
+context('Image Tile', function () {
+  it('Test image functionalities', function () {
+    beforeTest();
 
-        it('will upload jpg file from user computer', function(){
-            const imageFilePath='case_image.jpg';
-            clueCanvas.addTile('image');
-            // imageToolTile.getImageToolControl().last().click();
-            cy.uploadFile(imageToolTile.imageChooseFileButton(), imageFilePath, 'image/jpg');
-            cy.wait(2000);
-        });
+    cy.log('upload image from user computer');
+    canvas.createNewExtraDocumentFromFileMenu(userCanvas, "my-work");
+    cy.wait(2000);
 
-        it('will upload gif file from user computer', function(){
-            const imageFilePath='model_image.gif';
-            clueCanvas.addTile('image');
-            // imageToolTile.getImageToolControl().last().click();
-            cy.uploadFile(imageToolTile.imageChooseFileButton(), imageFilePath, 'image/gif');
-            cy.wait(2000);
-        });
-        // TODO: Figure out how to get the clipboard paste check below to work when the tests
-        // are run using Chrome. It will pass when using Electron, but not Chrome. In Chrome
-        // the attempt to write to the clipboard results in an error: "Must be handling a user
-        // gesture to use custom clipboard." See https://github.com/cypress-io/cypress/issues/2752
-        // for more background. Apparently, the basic problem is that Cypress "currently uses
-        // programmatic browser APIs which Chrome doesn't consider as genuine user interaction."
-        it.skip('will accept a valid image URL pasted from the clipboard', function(){
-            const imageFilePath = "curriculum/test/images/image.png";
-            Cypress.automation("remote:debugger:protocol", {
-                command: "Browser.grantPermissions",
-                params: {
-                  permissions: ["clipboardReadWrite", "clipboardSanitizedWrite"],
-                  origin: window.location.origin,
-                },
-              }).then(cy.window().then((win) => {
-                win.navigator.clipboard.write([new win.ClipboardItem({
-                    "text/plain": new Blob([imageFilePath], { type: "text/plain" }),
-                })]);
-            }));
-            const isMac = navigator.platform.indexOf("Mac") === 0;
-            const cmdKey = isMac ? "meta" : "ctrl";
-            imageToolTile.getImageToolTile().last().type(`{${cmdKey}+v}`);
-            imageToolTile.getImageToolImage().last().should("have.css", "background-image").and("contain", "test/images/image.png");
-        });
-    });
-    describe.skip('restore of images', function(){
-        before(()=>{ //reopen the first canvas
-            resourcesPanel.openPrimaryWorkspaceTab('my-work');
-            cy.openSection('my-work','workspaces');
-            cy.openDocumentWithTitle('my-work','workspaces', '2.1 Drawing Wumps');
-            cy.wait(5000);
-            // resourcePanel.closePrimaryWorkspaceTabs();
-        });
-        it('verify restore of all images that were added by URL', function(){
-            // TODO: Need to figure out how to check that correct images were reloaded. For now just checking for 3 image tools are reloaded
-            // const imageFileURL = ['https://codap.concord.org/~eireland/image.png', 'https://codap.concord.org/~eireland/case_image.jpg','https://codap.concord.org/~eireland/model_image.gif'];
-            // imageToolTile.getImageToolImage().each(($images, index, $list)=>{
-                // expect($list).to.have.length(3);
-                // expect($images).to.have.css('background-image').and.contains(imageFileURL[index]);
-                // expect($images).to.have.css('background-image').and.contains('url("data:image/png;base64');
-            // });
-            imageToolTile.getImageToolImage().should('have.length', 3);
-        });
-        it('verify restore of all  images that were added by upload', function(){
-            resourcesPanel.openPrimaryWorkspaceTab('my-work');
-            cy.openSection('my-work','workspaces');
-            cy.openDocumentWithTitle('my-work','workspaces', userCanvas);
-            cy.wait(3000);
-            // TODO: Need to figure out how to check that correct images were reloaded. For now just checking for 3 image tools are reloaded
-            // const imageFilePath=['image.png','case_image.jpg',/*'model_image.gif'*/];
+    cy.log('will upload png file from user computer')
+    const imageFilePath1 = 'image.png';
+    clueCanvas.addTile('image');
+    imageToolTile.getImageToolTile().should("exist");
+    // imageToolTile.getImageToolControl().last().click();
+    cy.uploadFile(imageToolTile.imageChooseFileButton(), imageFilePath1, 'image/png');
+    cy.wait(2000);
 
-            // imageToolTile.getImageToolImage().each(($images, index, $list)=>{
-            //     expect($list).to.have.length(imageFilePath.length);
-            //     expect($images).to.have.css('background-image').and.contains('url("data:image');
-            // });
-            imageToolTile.getImageToolImage().should('have.length', 3);
-        });
-    });
+    cy.log('will upload jpg file from user computer');
+    const imageFilePath2 = 'case_image.jpg';
+    clueCanvas.addTile('image');
+    // imageToolTile.getImageToolControl().last().click();
+    cy.uploadFile(imageToolTile.imageChooseFileButton(), imageFilePath2, 'image/jpg');
+    cy.wait(2000);
 
-});
+    cy.log('will upload gif file from user computer');
+    const imageFilePath3 = 'model_image.gif';
+    clueCanvas.addTile('image');
+    // imageToolTile.getImageToolControl().last().click();
+    cy.uploadFile(imageToolTile.imageChooseFileButton(), imageFilePath3, 'image/gif');
+    cy.wait(2000);
+  });
 
-context('Test undo redo functionalities', function(){
-    before(function(){
-        const queryParams = `${Cypress.config("queryParams")}`;
-        cy.clearQAData('all');
-        cy.visit(queryParams);
-        cy.waitForLoad();
-        cy.showOnlyDocumentWorkspace();
-    });
+  it('Image tile title edit, undo redo and delete tile', () => {
+    beforeTest();
 
-    describe('Image tile title edit, undo redo and delete tile',()=>{
-        it('will undo redo image tile creation/deletion', function () {
-            // Creation - Undo/Redo
-            clueCanvas.addTile('image');
-            imageToolTile.getImageToolTile().should("exist");
-            clueCanvas.getUndoTool().should("not.have.class", "disabled");
-            clueCanvas.getRedoTool().should("have.class", "disabled");
-            clueCanvas.getUndoTool().click();
-            imageToolTile.getImageToolTile().should("not.exist");
-            clueCanvas.getUndoTool().should("have.class", "disabled");
-            clueCanvas.getRedoTool().should("not.have.class", "disabled");
-            clueCanvas.getRedoTool().click();
-            imageToolTile.getImageToolTile().should("exist");
-            clueCanvas.getUndoTool().should("not.have.class", "disabled");
-            clueCanvas.getRedoTool().should("have.class", "disabled");
+    cy.log('will undo redo image tile creation/deletion');
+    // Creation - Undo/Redo
+    clueCanvas.addTile('image');
+    imageToolTile.getImageToolTile().should("exist");
+    clueCanvas.getUndoTool().should("not.have.class", "disabled");
+    clueCanvas.getRedoTool().should("have.class", "disabled");
+    clueCanvas.getUndoTool().click();
+    imageToolTile.getImageToolTile().should("not.exist");
+    clueCanvas.getUndoTool().should("have.class", "disabled");
+    clueCanvas.getRedoTool().should("not.have.class", "disabled");
+    clueCanvas.getRedoTool().click();
+    imageToolTile.getImageToolTile().should("exist");
+    clueCanvas.getUndoTool().should("not.have.class", "disabled");
+    clueCanvas.getRedoTool().should("have.class", "disabled");
 
-            // Deletion - Undo/Redo
-            clueCanvas.deleteTile('image');
-            imageToolTile.getImageToolTile().should('not.exist');
-            clueCanvas.getUndoTool().click();
-            imageToolTile.getImageToolTile().should("exist");
-            clueCanvas.getRedoTool().click();
-            imageToolTile.getImageToolTile().should('not.exist');
-        });
-        it("edit tile title", () => {
-            const newName = "Image Tile";
-            clueCanvas.addTile('image');
-            imageToolTile.getTileTitle().first().should("contain", "Image 1");
-            imageToolTile.getImageTileTitle().first().click();
-            imageToolTile.getImageTileTitle().first().type(newName + '{enter}');
-            imageToolTile.getTileTitle().should("contain", newName);
-        });
-        it("undo redo actions", () => {
-            clueCanvas.getUndoTool().click();
-            imageToolTile.getTileTitle().first().should("contain", "Image 1");
-            clueCanvas.getRedoTool().click();
-            imageToolTile.getTileTitle().should("contain", "Image Tile");
-        });
-        it('will undo redo image tile using keyboard', function () {
-            clueCanvas.addTile('image');
-            imageToolTile.getTileTitle().first().click();
-            imageToolTile.getTileTitle().first().type('{cmd+z}');
-            imageToolTile.getTileTitle().should("not.contain", "Image 1");
-            imageToolTile.getTileTitle().first().type('{cmd+shift+z}');
-            imageToolTile.getTileTitle().should("contain", "Image 1");
-        });
-        it('verify delete image', function () {
-            imageToolTile.getImageToolTile().first().click();
-            clueCanvas.deleteTile('image');
-            imageToolTile.getImageToolTile().first().click();
-            clueCanvas.deleteTile('image');
-            imageToolTile.getImageToolTile().should("not.exist");
-        });
-    });
+    // Deletion - Undo/Redo
+    clueCanvas.deleteTile('image');
+    imageToolTile.getImageToolTile().should('not.exist');
+    clueCanvas.getUndoTool().click();
+    imageToolTile.getImageToolTile().should("exist");
+    clueCanvas.getRedoTool().click();
+    imageToolTile.getImageToolTile().should('not.exist');
 
+    cy.log("edit tile title");
+    const newName = "Image Tile";
+    clueCanvas.addTile('image');
+    imageToolTile.getTileTitle().first().should("contain", "Image 1");
+    imageToolTile.getImageTileTitle().first().click();
+    imageToolTile.getImageTileTitle().first().type(newName + '{enter}');
+    imageToolTile.getTileTitle().should("contain", newName);
+
+    cy.log("undo redo actions");
+    clueCanvas.getUndoTool().click();
+    imageToolTile.getTileTitle().first().should("contain", "Image 1");
+    clueCanvas.getRedoTool().click();
+    imageToolTile.getTileTitle().should("contain", "Image Tile");
+
+    cy.log('will undo redo image tile using keyboard');
+    clueCanvas.addTile('image');
+    imageToolTile.getTileTitle().first().click();
+    imageToolTile.getTileTitle().first().type('{cmd+z}');
+    imageToolTile.getTileTitle().should("not.contain", "Image 1");
+    imageToolTile.getTileTitle().first().type('{cmd+shift+z}');
+    imageToolTile.getTileTitle().should("contain", "Image 1");
+
+    cy.log('verify delete image');
+    imageToolTile.getImageToolTile().first().click();
+    clueCanvas.deleteTile('image');
+    imageToolTile.getImageToolTile().first().click();
+    clueCanvas.deleteTile('image');
+    imageToolTile.getImageToolTile().should("not.exist");
+  });
 });
 

--- a/cypress/e2e/clue/branch/student_tests/nav_panel_test_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/nav_panel_test_spec.js
@@ -11,243 +11,202 @@ const clueCanvas = new ClueCanvas;
 const problemSubTabTitles = ['Introduction', 'Initial Challenge', 'What If', 'Now What'];
 const dialog = new Dialog;
 
-context('Nav Panel', function () {
-  before(()=>{
-    cy.clearQAData('all');
-  });
+const queryParams1 = `${Cypress.config("queryParams")}`;
+const queryParams2 = "?appMode=qa&fakeClass=10&fakeUser=student:11&fakeOffering=10&qaGroup=10&unit=example";
+const queryParams3 = "?appMode=qa&fakeClass=10&fakeUser=student:11&fakeOffering=10&qaGroup=10&unit=example-show-nav-panel";
+const queryParams4 = "?appMode=qa&fakeClass=10&fakeUser=student:11&fakeOffering=10&qaGroup=10&unit=example-no-section-problem-tab";
+const queryParams5 = "?appMode=qa&fakeClass=10&fakeUser=student:11&fakeOffering=10&qaGroup=10&&unit=example-config-subtabs";
 
-  describe('Test nav panel tabs', function () {
+function beforeTest(params) {
+  cy.clearQAData('all');
+  cy.visit(params);
+  cy.waitForLoad();
+}
+
+context('Nav Panel', function () {
+  it('Test nav panel tabs', function () {
+    beforeTest(queryParams1);
     let copyDocumentTitle = 'copy Investigation';
 
-    before(function () {
-      const queryParams = `${Cypress.config("queryParams")}`;
-      cy.clearQAData('all');
+    clueCanvas.getInvestigationCanvasTitle().then(($canvasTitle) => {
+      let title = $canvasTitle.text().trim();
 
-      cy.visit(queryParams);
-      cy.waitForLoad();
-      clueCanvas.getInvestigationCanvasTitle().text().as('title');
-    });
-    describe("Investigation Tab tests", function () {
-      describe("Problem tabs", function () {
-        it('verify tab names are visible', () => {
-          // cy.get(".resources-expander.my-work").click();
-          cy.openTopTab("problems");
-          cy.get(".problem-tabs .tab-list .prob-tab").each(($tab, index, $tabList) => {
-            expect($tab.text()).to.contain(problemSubTabTitles[index]);
-          });
-        });
-        it('saves current subtab when the resources panel is collapsed and expand', () => {
-          cy.openTopTab("problems");
-          const section = "Initial Challenge";
-          cy.openProblemSection(section);
-          cy.get('.prob-tab').contains(section).should('have.class', 'selected');
-          cy.collapseResourceTabs();
-          cy.openResourceTabs();
-          cy.get('.prob-tab').contains(section).should('have.class', 'selected');
-        });
-      });
-    });
-    describe('My Work tab tests', function () {
-      describe('Investigation section', function () {
-        it('verify that a problem workspace thumbnail is visible in the My Work/Workspaces nav panel', function () {
-          cy.openTopTab('my-work');
-          cy.openSection('my-work', 'workspaces');
-          resourcesPanel.getCanvasItemTitle('my-work','workspaces').contains(this.title).should('exist');
-          // cy.closeTabs();
-        });
-        it('verify publish Investigation', function () {
-          canvas.publishCanvas("investigation");
-          cy.openTopTab('class-work');
-          resourcesPanel.getCanvasItemTitle('class-work','workspaces').should('contain', this.title);
-        });
-        it('verify make a copy of a canvas', function () {
-          canvas.copyDocument(copyDocumentTitle);
-          canvas.getPersonalDocTitle().find('span').text().should('contain', copyDocumentTitle);
-        });
-        it('verify copied investigation appears in the workspaces section', function () {
-          cy.openTopTab("my-work");
-          resourcesPanel.getCanvasItemTitle('my-work','workspaces').contains(copyDocumentTitle).should('be.visible');
-        });
-        it('verify publish of personal workspace', function () {
-          canvas.publishCanvas("personal");
-          cy.openTopTab('class-work');
-          cy.openSection('class-work', 'workspaces');
-          resourcesPanel.getCanvasItemTitle('class-work','workspaces').should('contain', copyDocumentTitle);
-        });
-        it('verify delete document reverts nav-tab panel to show thumbnails', function () {
-          const deleteDocument = "Delete me";
-          canvas.copyDocument(deleteDocument);
-          cy.openTopTab('my-work');
-          cy.wait(1000);
-          resourcesPanel.getCanvasItemTitle('my-work','workspaces').should('contain', deleteDocument);
-          cy.openDocumentWithTitle('my-work', 'workspaces', copyDocumentTitle);
-          cy.openDocumentWithTitle('my-work', 'workspaces', deleteDocument);
-          canvas.deleteDocument();
-          resourcesPanel.getCanvasItemTitle('my-work','workspaces').should('not.contain', deleteDocument);
-        });
-      });
-      describe('Workspaces section', function () {
-        it('verify open the correct canvas selected from Investigations section', function () {
-          cy.openTopTab("my-work");
-          cy.openDocumentWithTitle('my-work', 'workspaces', this.title);
-          clueCanvas.getInvestigationCanvasTitle().should('contain', this.title);
-        });
-        it('verify open the correct canvas selected from Extra Workspace section', function () {
-          cy.openTopTab("my-work");
-          cy.openDocumentWithTitle('my-work', 'workspaces', copyDocumentTitle);
-          canvas.getPersonalDocTitle().should('contain', copyDocumentTitle);
-        });
-        after(()=>{
-          cy.collapseResourceTabs();
-        });
-      });
-      describe('Starred section', function () {
-        before(() => {
-          cy.get(".resources-expander.my-work").click();
-          cy.openTopTab('my-work');
-          cy.openSection("my-work", "workspaces");
-          resourcesPanel.starCanvasItem('my-work', 'workspaces', copyDocumentTitle);
-        });
-        it('verify starred document star is highlighted', function () {
-          resourcesPanel.getCanvasStarIcon('my-work', 'workspaces', copyDocumentTitle).should('have.class', 'starred');
-        });
-        it('verify starred document appears in the Starred section', function () {
-          cy.openSection('my-work', 'starred');
-          resourcesPanel.getCanvasItemTitle('my-work','starred').contains(copyDocumentTitle).should('exist');
-        });
-        it('remains open after the resources panel is collapsed and expand', () => {
-          cy.collapseResourceTabs();
-          cy.openResourceTabs();
-          cy.get('.doc-tab.my-work.starred').should('have.class', 'selected');
-        });
-      });
-      describe('Learning Log Section', function () {
-        it('verify investigation canvas is not listed in Learning Log ', function () { //still need to verify the titles match the titles from opened canvases
-          cy.openTopTab('my-work');
-          cy.openSection('my-work', 'learning-log');
-          resourcesPanel.getCanvasItemTitle('my-work','learning-log').contains(this.title).should('not.exist');
-          resourcesPanel.getCanvasItemTitle('my-work','learning-log').should('have.length', 1);
-        });
-        it('verify user starter learning log canvas exists', function () {
-          resourcesPanel.getCanvasItemTitle('my-work','learning-log').contains("My First Learning Log").should('be.visible');
-        });
-        it('verify open of learning log canvas into main workspace', function () {
-          cy.openDocumentWithTitle('my-work', 'learning-log', "My First Learning Log");
-          cy.get("[data-test=learning-log-title]").should('contain', "My First Learning Log");
-        });
-        it('verify Learning Log copy appears in Learning Log section', function () {
-          canvas.copyDocument("Learning Log Copy");
-          cy.openSection("my-work","learning-log");
-          cy.wait(2500);
-          resourcesPanel.getCanvasItemTitle('my-work','learning-log').contains("Learning Log Copy").should("be.visible");
-        });
-        it('verify publish learning log', function () {
-          canvas.publishCanvas("personal");
-          cy.openTopTab("class-work");
-          cy.openSection("class-work", "learning-logs");
-          resourcesPanel.getCanvasItemTitle("class-work","learning-logs", "Learning Log Copy");
-        });
-      });
-      after(function () {
-        cy.collapseResourceTabs(); // clean up
-      });
-    });
-
-    describe('Class Work tab tests', function () { //uses publish documents from earlier tests
-      before(() => {
-        cy.get(".resources-expander.class-work").click();
-        cy.openTopTab('class-work');
-      });
-      describe('Open correct canvas from correct section', function () {
-        it('verify open published canvas from Workspace list', function () { //this assumes there are published work
-          cy.openSection("class-work", "workspaces");
-          cy.openDocumentThumbnail('class-work','workspaces', copyDocumentTitle);
-        });
-        it('will verify that published canvas does not have Edit button', function () {
-          resourcesPanel.getActiveTabEditButton().should("not.exist");
-        });
-        it('verify open published canvas from Investigations list', function () { //this assumes there are published work
-          cy.openSection("class-work", "workspaces");
-          cy.openDocumentThumbnail('class-work','workspaces', this.title);
-        });
-        it('will verify that published canvas does not have Edit button', function () {
-          resourcesPanel.getActiveTabEditButton().should("not.exist");
-        });
-        it('verify delete document from Workspace list', function () { //this assumes there are published work
-          cy.openSection("class-work", "workspaces");
-          cy.deleteDocumentThumbnail("class-work", 'workspaces', copyDocumentTitle);
-          dialog.getDialogTitle().should('exist').contains('Confirm Delete');
-          dialog.getDialogOKButton().click();
-          resourcesPanel.getCanvasItemTitle('class-work','workspaces').should('not.contain', copyDocumentTitle);
-        });
-      });
-    });
-    describe.skip('Supports Tab', function () {
-      describe('Test supports area', function () {
-        it('verify support tabs', function () {
-          cy.openTopTab("supports");
-          // cy.get(".support-badge").should("be.visible");
-          cy.get(".doc-tab.supports").should("have.length", 2);
-          cy.get(".doc-tab.supports.teacher-supports").click();
-          // clicking on a teacher support should update the unread supports badge
-          // cy.get("[data-test=teacher-supports-list-items]").last().click();
-          // cy.get(".support-badge").should("not.exist");
-        });
-      });
-    });
-  });
-
-  describe('Nav panel tab configs', function () {
-    const baseQueryParam = "?appMode=qa&fakeClass=10&fakeUser=student:11&fakeOffering=10&qaGroup=10";
-    it('Single Top tab with visible resource tab panel', function () {
-      cy.visit(`${baseQueryParam}&unit=example`);
-      cy.waitForLoad();
-      cy.get(".resources-expander.my-work").should('not.exist');
-      canvas.openFileMenu();
-      cy.get ("[data-test=list-item-icon-open-workspace]").click();
-      cy.get(".tab-header-row").should("not.be.visible");
-    });
-    it('Single Top tab with visible resource tab panel', function () {
-      cy.visit(`${baseQueryParam}&unit=example-show-nav-panel`);
-      cy.waitForLoad();
-      // cy.get(".resources-expander.my-work").click();
-      cy.get(".top-tab").should("have.length", 1);
-      cy.get(".document-tabs.my-work .tab-header-row").should("not.be.visible");
-      canvas.openFileMenu();
-      cy.get ("[data-test=list-item-icon-open-workspace]").click();
-      cy.get(".tab-header-row").should("not.be.visible");
-    });
-    it('Problem Tabs with no sub tabs', function () {
-      cy.visit(`${baseQueryParam}&unit=example-no-section-problem-tab`);
-      cy.waitForLoad();
-      // cy.get(".resources-expander.my-work").click();
-      cy.openTopTab("problems");
-      cy.get(".problem-tabs .tab-header-row").should("not.be.visible");
-    });
-    it('Customized tabs', function () {
-      const exampleProblemSubTabTitles = ["First Section", "Second Section", "Third Section"];
-      const exampleMyWorkSubTabTitles = ["Workspaces", "Starred"];
-      const exampleClassWorkSubTabTitles = ["Workspaces", "Supplemental Work", "Starred"];
-
-      cy.visit(`${baseQueryParam}&unit=example-config-subtabs`);
-      cy.waitForLoad();
+      cy.log('verify tab names are visible');
       // cy.get(".resources-expander.my-work").click();
       cy.openTopTab("problems");
       cy.get(".problem-tabs .tab-list .prob-tab").each(($tab, index, $tabList) => {
-        expect($tabList).to.have.lengthOf(exampleProblemSubTabTitles.length);
-        expect($tab.text()).to.contain(exampleProblemSubTabTitles[index]);
+        expect($tab.text()).to.contain(problemSubTabTitles[index]);
       });
+
+      cy.log('saves current subtab when the resources panel is collapsed and expand');
+      cy.openTopTab("problems");
+      const section = "Initial Challenge";
+      cy.openProblemSection(section);
+      cy.get('.prob-tab').contains(section).should('have.class', 'selected');
+      cy.collapseResourceTabs();
+      cy.openResourceTabs();
+      cy.get('.prob-tab').contains(section).should('have.class', 'selected');
+
+      cy.log('verify that a problem workspace thumbnail is visible in the My Work/Workspaces nav panel');
+      cy.openTopTab('my-work');
+      cy.openSection('my-work', 'workspaces');
+      resourcesPanel.getCanvasItemTitle('my-work', 'workspaces').contains(title).should('exist');
+
+      cy.log('verify publish Investigation');
+      canvas.publishCanvas("investigation");
+      cy.openTopTab('class-work');
+      resourcesPanel.getCanvasItemTitle('class-work', 'workspaces').should('contain', title);
+
+      cy.log('verify make a copy of a canvas');
+      canvas.copyDocument(copyDocumentTitle);
+      canvas.getPersonalDocTitle().find('span').text().should('contain', copyDocumentTitle);
+
+      cy.log('verify copied investigation appears in the workspaces section');
       cy.openTopTab("my-work");
-      cy.get(".document-tabs .tab-list .doc-tab.my-work").each(($tab, index, $tabList) => {
-        expect($tabList).to.have.lengthOf(exampleMyWorkSubTabTitles.length);
-        expect($tab.text()).to.contain(exampleMyWorkSubTabTitles[index]);
-      });
+      resourcesPanel.getCanvasItemTitle('my-work', 'workspaces').contains(copyDocumentTitle).should('be.visible');
+
+      cy.log('verify publish of personal workspace');
+      canvas.publishCanvas("personal");
+      cy.openTopTab('class-work');
+      cy.openSection('class-work', 'workspaces');
+      resourcesPanel.getCanvasItemTitle('class-work', 'workspaces').should('contain', copyDocumentTitle);
+
+      cy.log('verify delete document reverts nav-tab panel to show thumbnails');
+      const deleteDocument = "Delete me";
+      canvas.copyDocument(deleteDocument);
+
+      cy.log('verify Workspaces Section');
+      cy.openTopTab('my-work');
+      cy.wait(1000);
+      resourcesPanel.getCanvasItemTitle('my-work', 'workspaces').should('contain', deleteDocument);
+      cy.openDocumentWithTitle('my-work', 'workspaces', copyDocumentTitle);
+      cy.openDocumentWithTitle('my-work', 'workspaces', deleteDocument);
+      canvas.deleteDocument();
+      resourcesPanel.getCanvasItemTitle('my-work', 'workspaces').should('not.contain', deleteDocument);
+
+      cy.log('verify open the correct canvas selected from Investigations section');
+      cy.openTopTab("my-work");
+      cy.openDocumentWithTitle('my-work', 'workspaces', title);
+      clueCanvas.getInvestigationCanvasTitle().should('contain', title);
+
+      cy.log('verify open the correct canvas selected from Extra Workspace section');
+      cy.openTopTab("my-work");
+      cy.openDocumentWithTitle('my-work', 'workspaces', copyDocumentTitle);
+      canvas.getPersonalDocTitle().should('contain', copyDocumentTitle);
+
+      cy.log('verify Starred Section');
+      cy.openTopTab('my-work');
+      cy.openSection("my-work", "workspaces");
+      resourcesPanel.starCanvasItem('my-work', 'workspaces', copyDocumentTitle);
+
+      cy.log('verify starred document star is highlighted');
+      resourcesPanel.getCanvasStarIcon('my-work', 'workspaces', copyDocumentTitle).should('have.class', 'starred');
+
+      cy.log('verify starred document appears in the Starred section');
+      cy.openSection('my-work', 'starred');
+      resourcesPanel.getCanvasItemTitle('my-work', 'starred').contains(copyDocumentTitle).should('exist');
+
+      cy.log('remains open after the resources panel is collapsed and expand');
+      cy.collapseResourceTabs();
+      cy.openResourceTabs();
+      cy.get('.doc-tab.my-work.starred').should('have.class', 'selected');
+
+      cy.log('verify Learning Log Section');
+      cy.openTopTab('my-work');
+      cy.openSection('my-work', 'learning-log');
+
+      cy.log('verify investigation canvas is not listed in Learning Log ');
+      resourcesPanel.getCanvasItemTitle('my-work', 'learning-log').contains(title).should('not.exist');
+      resourcesPanel.getCanvasItemTitle('my-work', 'learning-log').should('have.length', 1);
+
+      cy.log('verify user starter learning log canvas exists');
+      resourcesPanel.getCanvasItemTitle('my-work', 'learning-log').contains("My First Learning Log").should('be.visible');
+
+      cy.log('verify open of learning log canvas into main workspace');
+      cy.openDocumentWithTitle('my-work', 'learning-log', "My First Learning Log");
+      cy.get("[data-test=learning-log-title]").should('contain', "My First Learning Log");
+
+      cy.log('verify Learning Log copy appears in Learning Log section');
+      canvas.copyDocument("Learning Log Copy");
+      cy.openSection("my-work", "learning-log");
+      cy.wait(2500);
+      resourcesPanel.getCanvasItemTitle('my-work', 'learning-log').contains("Learning Log Copy").should("be.visible");
+
+      cy.log('verify publish learning log');
+      canvas.publishCanvas("personal");
       cy.openTopTab("class-work");
-      cy.get(".document-tabs .tab-list .doc-tab.class-work").each(($tab, index, $tabList) => {
-        expect($tabList).to.have.lengthOf(exampleClassWorkSubTabTitles.length);
-        expect($tab.text()).to.contain(exampleClassWorkSubTabTitles[index]);
-      });
+      cy.openSection("class-work", "learning-logs");
+      resourcesPanel.getCanvasItemTitle("class-work", "learning-logs", "Learning Log Copy");
+
+
+      cy.log('Class Work tab tests');
+      cy.openTopTab('class-work');
+
+      cy.log('verify open published canvas from Workspace list');
+      cy.openSection("class-work", "workspaces");
+      cy.openDocumentThumbnail('class-work', 'workspaces', copyDocumentTitle);
+
+      cy.log('will verify that published canvas does not have Edit button');
+      resourcesPanel.getActiveTabEditButton().should("not.exist");
+
+      cy.log('verify open published canvas from Investigations list');
+      cy.openSection("class-work", "workspaces");
+      cy.openDocumentThumbnail('class-work', 'workspaces', title);
+
+      cy.log('will verify that published canvas does not have Edit button');
+      resourcesPanel.getActiveTabEditButton().should("not.exist");
+
+      cy.log('verify delete document from Workspace list');
+      cy.openSection("class-work", "workspaces");
+      cy.deleteDocumentThumbnail("class-work", 'workspaces', copyDocumentTitle);
+      dialog.getDialogTitle().should('exist').contains('Confirm Delete');
+      dialog.getDialogOKButton().click();
+      resourcesPanel.getCanvasItemTitle('class-work', 'workspaces').should('not.contain', copyDocumentTitle);
     });
   });
 
+  it('Nav panel tab configs', function () {
+    beforeTest(queryParams2);
+
+    cy.log('Single Top tab with visible resource tab panel');
+    cy.get(".resources-expander.my-work").should('not.exist');
+    canvas.openFileMenu();
+    cy.get("[data-test=list-item-icon-open-workspace]").click();
+    cy.get(".tab-header-row").should("not.be.visible");
+
+    cy.log('Single Top tab with visible resource tab panel');
+    beforeTest(queryParams3);
+    cy.get(".top-tab").should("have.length", 1);
+    cy.get(".document-tabs.my-work .tab-header-row").should("not.be.visible");
+    canvas.openFileMenu();
+    cy.get("[data-test=list-item-icon-open-workspace]").click();
+    cy.get(".tab-header-row").should("not.be.visible");
+
+    cy.log('Problem Tabs with no sub tabs');
+    beforeTest(queryParams4);
+    cy.openTopTab("problems");
+    cy.get(".problem-tabs .tab-header-row").should("not.be.visible");
+
+    cy.log('Customized tabs');
+    const exampleProblemSubTabTitles = ["First Section", "Second Section", "Third Section"];
+    const exampleMyWorkSubTabTitles = ["Workspaces", "Starred"];
+    const exampleClassWorkSubTabTitles = ["Workspaces", "Supplemental Work", "Starred"];
+
+    beforeTest(queryParams5);
+    cy.openTopTab("problems");
+    cy.get(".problem-tabs .tab-list .prob-tab").each(($tab, index, $tabList) => {
+      expect($tabList).to.have.lengthOf(exampleProblemSubTabTitles.length);
+      expect($tab.text()).to.contain(exampleProblemSubTabTitles[index]);
+    });
+    cy.openTopTab("my-work");
+    cy.get(".document-tabs .tab-list .doc-tab.my-work").each(($tab, index, $tabList) => {
+      expect($tabList).to.have.lengthOf(exampleMyWorkSubTabTitles.length);
+      expect($tab.text()).to.contain(exampleMyWorkSubTabTitles[index]);
+    });
+    cy.openTopTab("class-work");
+    cy.get(".document-tabs .tab-list .doc-tab.class-work").each(($tab, index, $tabList) => {
+      expect($tabList).to.have.lengthOf(exampleClassWorkSubTabTitles.length);
+      expect($tab.text()).to.contain(exampleClassWorkSubTabTitles[index]);
+    });
+  });
 });

--- a/cypress/e2e/clue/branch/student_tests/numberline_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/numberline_tool_spec.js
@@ -4,59 +4,47 @@ import NumberlineToolTile from '../../../../support/elements/clue/NumberlineTool
 let clueCanvas = new ClueCanvas;
 let numberlineToolTile = new NumberlineToolTile;
 
+function beforeTest() {
+  const queryParams = "?appMode=qa&fakeClass=5&fakeUser=student:5&qaGroup=5&unit=example";
+  cy.clearQAData('all');
+  cy.visit(queryParams);
+  cy.waitForLoad();
+}
+
 context('Numberline Tile', function () {
-  before(function () {
-    const queryParams = "?appMode=qa&fakeClass=5&fakeUser=student:5&qaGroup=5&unit=example";
-    cy.clearQAData('all');
-    cy.visit(queryParams);
-    cy.waitForLoad();
-    // cy.closeResourceTabs(); //maybe enable this when we have a unit besides example that has a nav tab panel
-  });
-  describe("Numberline Tile", () => {
-    it("renders numberline tile", () => {
-      numberlineToolTile.getNumberlineTile().should("not.exist");
-      clueCanvas.addTile("numberline");
-      numberlineToolTile.getNumberlineTile().should("exist");
-      numberlineToolTile.getNumberlineTileTitle().should("exist");
-    });
-    it("edit tile title", () => {
-      const newName = "Numberline test";
-      numberlineToolTile.getNumberlineTileTitleText().should("contain", "Numberline");
-      numberlineToolTile.getNumberlineTileTitle().click();
-      numberlineToolTile.getNumberlineTileTitle().type(newName + '{enter}');
-      numberlineToolTile.getNumberlineTileTitleText().should("contain", newName);
-    });
-    it('will test adding points to a numberline', () => {
-      numberlineToolTile.addPointOnNumberlineTick(-4.0);
-      numberlineToolTile.addPointOnNumberlineTick(2.0);
-      numberlineToolTile.getPointsOnGraph().should('have.length', 2);
-    });
-    it('will change min and max value of numberline and recalculate ticks', () => {
-      numberlineToolTile.setMaxValue(10);
-      numberlineToolTile.getAllNumberlineTicks().should('contain', 8.5);
-      numberlineToolTile.setMinValue(-10);
-      numberlineToolTile.getAllNumberlineTicks().should('contain', 6.0);
-    });
+  it("Numberline Tile", () => {
+    beforeTest();
+    cy.log("renders numberline tile");
+    numberlineToolTile.getNumberlineTile().should("not.exist");
+    clueCanvas.addTile("numberline");
+    numberlineToolTile.getNumberlineTile().should("exist");
+    numberlineToolTile.getNumberlineTileTitle().should("exist");
 
-    it("will delete all points", () =>{
-      cy.log("delete all points in the numberline");
-      numberlineToolTile.deleteAllPointsOnNumberline();
-      numberlineToolTile.getPointsOnGraph().should('have.length', 0);
-    });
-    it("deletes numberline tile", ()=>{
-      clueCanvas.deleteTile('numberline');
-      numberlineToolTile.getNumberlineTile().should("not.exist");
-    });
+    cy.log("edit tile title");
+    const newName = "Numberline test";
+    numberlineToolTile.getNumberlineTileTitleText().should("contain", "Numberline");
+    numberlineToolTile.getNumberlineTileTitle().click();
+    numberlineToolTile.getNumberlineTileTitle().type(newName + '{enter}');
+    numberlineToolTile.getNumberlineTileTitleText().should("contain", newName);
 
-    //TODO: finish drag test : currently it creates a third point 50 pixels
-    //to the right of -4 which disapears after hovering
-    // it("will drag a point", () => {
-    //   numberlineToolTile.cy.get(".defaultPointInnerCircle").first() //attach to -4
-    //   .trigger('dragstart')
-    //   .trigger('mousemove', 50, 0, { force: true })
-    //   .trigger('drop', {force: true});
-    //   numberlineToolTile.getPointsOnGraph().should('have.length', 2);
-    // });
+    cy.log('will test adding points to a numberline');
+    numberlineToolTile.addPointOnNumberlineTick(-4.0);
+    numberlineToolTile.addPointOnNumberlineTick(2.0);
+    numberlineToolTile.getPointsOnGraph().should('have.length', 2);
 
+    cy.log('will change min and max value of numberline and recalculate ticks');
+    numberlineToolTile.setMaxValue(10);
+    numberlineToolTile.getAllNumberlineTicks().should('contain', 8.5);
+    numberlineToolTile.setMinValue(-10);
+    numberlineToolTile.getAllNumberlineTicks().should('contain', 6.0);
+
+    cy.log("will delete all points");
+    cy.log("delete all points in the numberline");
+    numberlineToolTile.deleteAllPointsOnNumberline();
+    numberlineToolTile.getPointsOnGraph().should('have.length', 0);
+
+    cy.log("deletes numberline tile");
+    clueCanvas.deleteTile('numberline');
+    numberlineToolTile.getNumberlineTile().should("not.exist");
   });
 });

--- a/cypress/e2e/clue/branch/student_tests/shared_variables_test_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/shared_variables_test_spec.js
@@ -7,206 +7,114 @@ const canvas = new Canvas;
 const clueCanvas = new ClueCanvas;
 const textToolTile = new TextToolTile;
 const diagramToolTile = new DiagramToolTile;
+const queryParam = "?appMode=qa&fakeClass=5&fakeUser=student:5&qaGroup=5&unit=example-variables";
+
+function beforeTest() {
+  cy.clearQAData('all');
+  cy.visit(queryParam);
+  cy.waitForLoad();
+}
 
 context('Shared Variables', function () {
-  const queryParam = "?appMode=qa&fakeClass=5&fakeUser=student:5&qaGroup=5&unit=example-variables";
-  // What is the difference between fakeOffering and demoOffering
+  it('Text Tile', function () {
+    beforeTest();
 
-  let title;
-  before(()=>{
-    cy.clearQAData('all');
-    cy.visit(queryParam);
-    cy.waitForLoad();
-    // cy.collapseResourceTabs();
     cy.get('.primary-workspace [data-test=personal-doc-title]')
-    .then(($canvasTitle)=>{
-        title = $canvasTitle.text().trim();
-        cy.log('title is: '+title);
-    });
+      .then(($canvasTitle) => {
+        let title = $canvasTitle.text().trim();
+
+        const addCard = (last) => {
+          diagramToolTile.getDiagramToolbarButton("button-insert-variable").click();
+          if (last) {
+            cy.get(".custom-modal .variable-chip").last().click();
+          } else {
+            cy.get(".custom-modal .variable-chip").first().click();
+          }
+          cy.get(".custom-modal .modal-button").last().click();
+        };
+
+        const addLastCard = () => addCard(true);
+
+        const dialogField = (field) => cy.get(`#evd-${field}`);
+        const dialogOkButton = () => cy.get(".modal-button").last();
+        const textTileVName1 = "varA";
+        const textTileVValue1 = "7";
+        const textTileVUnit1 = "seconds";
+        const textTileVName2 = "varB";
+        const textTileVValue2 = "1.234";
+
+        cy.log('can add a variable chip to the text tool with appropriate spacing');
+        clueCanvas.addTile('text');
+        clueCanvas.addTile('diagram');
+
+        textToolTile.enterText('Hello World!');
+        textToolTile.getTextTile().last().should('contain', 'Hello World!');
+        textToolTile.getTextTile().last().should('not.contain', ' Hello World!');
+        textToolTile.enterText("{moveToStart}");
+        textToolTile.clickToolbarTool("New Variable");
+        cy.get(".custom-modal").should("exist");
+        dialogField("name").type(textTileVName1);
+        dialogField("value").type(textTileVValue1);
+        dialogField("units").type(textTileVUnit1);
+        textToolTile.getVariableChip().should("not.exist");
+        dialogOkButton().click();
+        textToolTile.getVariableChip().should("exist");
+        textToolTile.getVariableChip().should("contain", textTileVName1);
+        textToolTile.getVariableChip().should("contain", textTileVValue1);
+        textToolTile.getVariableChip().should("contain", textTileVUnit1);
+        textToolTile.getTextTile().last().should('contain', ' Hello World!');
+        // Make sure the diagram tile now has a card with variable name.
+        addLastCard();
+        cy.get('.primary-workspace .canvas-area .diagram-tool [data-testid="quantity-node"]')
+          .findByDisplayValue(textTileVName1)
+          .should('exist');
+
+        cy.log('can add a duplicate variable chip to the text tool');
+        textToolTile.enterText('Second Chip:');
+        textToolTile.getTextTile().last().should('contain', 'Second Chip:');
+        textToolTile.getTextTile().last().should('not.contain', 'Second Chip: ');
+        textToolTile.clickToolbarTool("Insert Variable");
+        cy.get(".custom-modal").should("exist");
+        cy.get(".variable-chip-list .variable-chip").click();
+        dialogOkButton().click();
+        textToolTile.getTextTile().last().should('contain', 'Second Chip: ');
+        // Make sure the text tile now has 2 chips with the same name.
+        textToolTile.getTextTile().last().find(`.variable-chip:contains("${textTileVName1}")`).should('have.length', 2);
+
+        cy.log('can edit a variable name');
+        textToolTile.getTextTile().last().find('.variable-name').first().click();
+        textToolTile.clickToolbarTool("Edit Variable");
+        cy.get(".custom-modal").should("exist");
+        dialogField("name").clear().type(textTileVName2);
+        dialogOkButton().click();
+        // Make sure the text tile now has 2 chips with the new variable name.
+        textToolTile.getTextTile().last().find(`.variable-chip:contains("${textTileVName2}")`).should('have.length', 2);
+        // Make sure the diagram tile now has a card with the new variable name.
+        cy.get('.primary-workspace .canvas-area .diagram-tool [data-testid="quantity-node"]')
+          .findByDisplayValue(textTileVName2)
+          .should('exist');
+
+        cy.log('can change the value of a variable');
+        textToolTile.getTextTile().last().find('.variable-chip').first().click();
+        textToolTile.clickToolbarTool("Edit Variable");
+        cy.get(".custom-modal").should("exist");
+        dialogField("value").clear().type(textTileVValue2);
+        dialogOkButton().click();
+        // Make sure the text tile now has 2 chips with the new variable value.
+        textToolTile.getTextTile().last().find(`.variable-chip:contains("${textTileVName2}=${textTileVValue2}")`).should('have.length', 2);
+
+        cy.log('verifies restore of variable chip content');
+        canvas.createNewExtraDocumentFromFileMenuWithoutTabs('text tool test', 'my-work');
+        cy.wait(2000);
+        textToolTile.getTextTile().should('not.exist');
+        //re-open investigation
+        canvas.openDocumentWithTitleWithoutTabs(title);
+        // Make sure the text tile still has 2 chips with Var B.
+        textToolTile.getTextTile().last().find(`.variable-chip:contains("${textTileVName2}=${textTileVValue2}")`).should('have.length', 2);
+        // Make sure the diagram tile still has a card with Var B.
+        cy.get('.primary-workspace .canvas-area .diagram-tool [data-testid="quantity-node"]')
+          .findByDisplayValue(textTileVName2)
+          .should('exist');
+      });
   });
-
-  const addCard = (last) => {
-    diagramToolTile.getDiagramToolbarButton("button-insert-variable").click();
-    if (last) {
-      cy.get(".custom-modal .variable-chip").last().click();
-    } else {
-      cy.get(".custom-modal .variable-chip").first().click();
-    }
-    cy.get(".custom-modal .modal-button").last().click();
-  };
-
-  const addLastCard = () => addCard(true);
-
-  describe("Text tile", () => {
-    const dialogField = (field) => cy.get(`#evd-${field}`);
-    const dialogOkButton = () => cy.get(".modal-button").last();
-    const textTileVName1 = "varA";
-    const textTileVValue1 = "7";
-    const textTileVUnit1 = "seconds";
-    const textTileVName2 = "varB";
-    const textTileVValue2 = "1.234";
-
-    it('can add a variable chip to the text tool with appropriate spacing', function() {
-      clueCanvas.addTile('text');
-      clueCanvas.addTile('diagram');
-
-      textToolTile.enterText('Hello World!');
-      textToolTile.getTextTile().last().should('contain', 'Hello World!');
-      textToolTile.getTextTile().last().should('not.contain', ' Hello World!');
-      textToolTile.enterText("{moveToStart}");
-      textToolTile.clickToolbarTool("New Variable");
-      cy.get(".custom-modal").should("exist");
-      dialogField("name").type(textTileVName1);
-      dialogField("value").type(textTileVValue1);
-      dialogField("units").type(textTileVUnit1);
-      textToolTile.getVariableChip().should("not.exist");
-      dialogOkButton().click();
-      textToolTile.getVariableChip().should("exist");
-      textToolTile.getVariableChip().should("contain", textTileVName1);
-      textToolTile.getVariableChip().should("contain", textTileVValue1);
-      textToolTile.getVariableChip().should("contain", textTileVUnit1);
-      textToolTile.getTextTile().last().should('contain', ' Hello World!');
-      // Make sure the diagram tile now has a card with variable name.
-      addLastCard();
-      cy.get('.primary-workspace .canvas-area .diagram-tool [data-testid="quantity-node"]')
-        .findByDisplayValue(textTileVName1)
-        .should('exist');
-    });
-
-    it('can add a duplicate variable chip to the text tool', function() {
-      textToolTile.enterText('Second Chip:');
-      textToolTile.getTextTile().last().should('contain', 'Second Chip:');
-      textToolTile.getTextTile().last().should('not.contain', 'Second Chip: ');
-      textToolTile.clickToolbarTool("Insert Variable");
-      cy.get(".custom-modal").should("exist");
-      cy.get(".variable-chip-list .variable-chip").click();
-      dialogOkButton().click();
-      textToolTile.getTextTile().last().should('contain', 'Second Chip: ');
-      // Make sure the text tile now has 2 chips with the same name.
-      textToolTile.getTextTile().last().find(`.variable-chip:contains("${textTileVName1}")`).should('have.length', 2);
-    });
-
-    // FIXME: The method for highlighting text using shift+leftarrow that was being used here
-    // doesn't seem to work. It was possibly broken by the Slate upgrade, but it also doesn't
-    // seem like Cypress supports selecting text like that.
-    // it('can pre populate the notes field based on the selected text', function() {
-    //   textToolTile.getTextEditor().last().click().type(' 0 time for this{shift}{leftarrow}{leftarrow}{leftarrow}{leftarrow}');
-    //   textToolTile.clickToolbarTool("New Variable");
-    //   dialogField("name").type("new");
-    //   dialogField("value").type("1");
-    //   dialogField("units").type("hour");
-    //   cy.pause();
-    //   dialogField("notes").should("have.value", "this");
-    //   dialogOkButton().click();
-    // });
-
-    it('can edit a variable name', function() {
-      textToolTile.getTextTile().last().find('.variable-name').first().click();
-      textToolTile.clickToolbarTool("Edit Variable");
-      cy.get(".custom-modal").should("exist");
-      dialogField("name").clear().type(textTileVName2);
-      dialogOkButton().click();
-      // Make sure the text tile now has 2 chips with the new variable name.
-      textToolTile.getTextTile().last().find(`.variable-chip:contains("${textTileVName2}")`).should('have.length', 2);
-      // Make sure the diagram tile now has a card with the new variable name.
-      cy.get('.primary-workspace .canvas-area .diagram-tool [data-testid="quantity-node"]')
-        .findByDisplayValue(textTileVName2)
-        .should('exist');
-    });
-    it('can change the value of a variable', function() {
-      textToolTile.getTextTile().last().find('.variable-chip').first().click();
-      textToolTile.clickToolbarTool("Edit Variable");
-      cy.get(".custom-modal").should("exist");
-      dialogField("value").clear().type(textTileVValue2);
-      dialogOkButton().click();
-      // Make sure the text tile now has 2 chips with the new variable value.
-      textToolTile.getTextTile().last().find(`.variable-chip:contains("${textTileVName2}=${textTileVValue2}")`).should('have.length', 2);
-    });
-
-    it('verifies restore of variable chip content',()=>{
-      canvas.createNewExtraDocumentFromFileMenuWithoutTabs('text tool test','my-work');
-      cy.wait(2000);
-      textToolTile.getTextTile().should('not.exist');
-      //re-open investigation
-      canvas.openDocumentWithTitleWithoutTabs(title);
-      // Make sure the text tile still has 2 chips with Var B.
-      textToolTile.getTextTile().last().find(`.variable-chip:contains("${textTileVName2}=${textTileVValue2}")`).should('have.length', 2);
-      // Make sure the diagram tile still has a card with Var B.
-      cy.get('.primary-workspace .canvas-area .diagram-tool [data-testid="quantity-node"]')
-        .findByDisplayValue(textTileVName2)
-        .should('exist');
-    });
-  });
-
-  // FIXME: these are broken from slate upgrade.
-  describe("Drawing tile", () => {
-    it('dummy test', function () {
-      expect(true).to.equal(true);
-    });
-  });
-
-    // const diagramTile = () => cy.get(".diagram-tool");
-    // const drawTile = () => drawToolTile.getDrawTile().last();
-    // const listChip = () => cy.get(`.variable-chip-list .variable-chip`);
-    
-  //   it("verify Insert Variable dialog opens on variable button click in drawing tile", () => {
-  //     clueCanvas.addTile('drawing');
-  //     drawToolTile.getDrawToolInsertVariable().click();
-  //     cy.get(".modal-header").should("contain", "Insert Variables");
-  //     cy.get(".ReactModalPortal").within(() => {
-  //       // cy.findByRole("combobox").type("VarC{enter}");
-  //       listChip().last().click();
-  //       cy.get(".custom-modal .modal-button").last().click();
-  //     });
-  //   });
-  //   it("verify variables appears in draw tool", () => {
-  //     drawTile().find('.drawing-variable:contains("VarC")').should('have.length', 1);
-  //   });
-  //   it("verify changes in diagram view propagates to draw tool", () => {
-  //     // Delete the existing variable card so it won't overlap with the new card
-  //     diagramTile().find(".node").click();
-  //     diagramToolTile.getDiagramToolbarButton("button-delete", undefined, true).click();
-
-  //     addCard();
-  //     diagramTile().find(".variable-info.name[value=VarC]");
-  //     diagramTile().find(".variable-info.name[value=VarC]").type('Var D').blur();
-  //     // Look for "VarCVarD" because spaces are not allowed in variable names
-  //     drawTile().find('.drawing-variable:contains("VarCVarD")').should('exist');
-  //   });
-  //   it("verify edit variable dialog works", () => {
-  //     const editVariableButton = () => drawToolTile.getDrawToolEditVariable();
-  //     const customModal = () => cy.get(".custom-modal");
-  //     drawToolTile.getDrawTile().last().click();
-  //     editVariableButton().should("exist");
-  //     editVariableButton().should("be.disabled");
-  //     drawTile().find('.drawing-variable:contains("VarC")').click();
-  //     editVariableButton().should("be.enabled");
-  //     customModal().should("not.exist");
-  //     editVariableButton().click();
-  //     customModal().should("exist");
-  //     cy.get("#evd-units").type("util");
-  //     customModal().find(".modal-button").last().click();
-  //     customModal().should("not.exist");
-  //     diagramTile().find(".variable-info.unit").should("exist");
-  //     diagramTile().find(".variable-info.unit").should("have.value", "util");
-  //   });
-  //   it('deletes variable chip in draw tool', () => {
-  //     drawTile().click();
-  //     drawToolTile.getDrawToolSelect().click();
-  //     drawTile().find('.drawing-variable:contains("VarC")').click();
-  //     drawToolTile.getDrawToolDelete().click();
-  //     drawTile().find('.drawing-variable:contains("VarCVarD")').should('not.exist');
-  //   });
-  //   it("verify create new variable", () => {
-  //     drawToolTile.getDrawToolNewVariable().click();
-  //     cy.get(".modal-header").should("contain", "New Variable");
-  //     cy.get(".ReactModalPortal").within(() => {
-  //       cy.get("#evd-name").type("VarE");
-  //       cy.get("#evd-value").type("5.432");
-  //       cy.findByRole("button", {name: "OK"}).click();
-  //     });
-  //     drawTile().find('.drawing-variable:contains("VarE")').should('have.length', 1);
-  //     drawTile().find('.drawing-variable:contains("5.432")').should('have.length', 1);
-
-  //   });
-   });
+});

--- a/cypress/e2e/clue/branch/student_tests/simulator_tile_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/simulator_tile_spec.js
@@ -6,108 +6,103 @@ let clueCanvas = new ClueCanvas;
 const dataflowTile = new DataflowTile;
 let simulatorTile = new SimulatorTile;
 
-context('Simulator Tile with Brainwaves Gripper Simulation', function () {
-  beforeEach(function () {
-    const queryParams = "?appMode=qa&fakeClass=5&fakeUser=student:5&qaGroup=5&mouseSensor&unit=brain";
-    cy.clearQAData('all');
-    cy.visit(queryParams);
-    cy.waitForLoad();
-    cy.collapseResourceTabs();
-  });
-  describe("Simulator Tile", () => {
-    it("renders simulator tile", () => {
-      simulatorTile.getSimulatorTile().should("not.exist");
-      clueCanvas.addTile("simulator");
-      simulatorTile.getSimulatorTile().should("exist");
-      simulatorTile.getTileTitle().should("exist");
-      simulatorTile.getSimulatorTile().should("contain.text", "EMG Sensor");
-      simulatorTile.getSimulatorTile().should("contain.text", "Surface Pressure Sensor");
-      simulatorTile.getSimulatorTile().should("contain.text", "Gripper Output");
-      // Icons are being rendered
-      simulatorTile.getSimulatorTile().find(".leading-box.variable-icon").should("have.length", 4);
+const queryParams1 = "?appMode=qa&fakeClass=5&fakeUser=student:5&qaGroup=5&mouseSensor&unit=brain";
+const queryParams2 = "?appMode=qa&fakeClass=5&fakeUser=student:5&qaGroup=5&mouseSensor&unit=seeit";
 
-      cy.get(".arm-image").should("exist");
-      cy.get(".arduino-image").should("exist");
-      cy.get(".gripper-image").should("exist");
+function beforeTest(params) {
+  cy.clearQAData('all');
+  cy.visit(params);
+  cy.waitForLoad();
+}
 
-      cy.log("Can switch to temperature variant.");
-      cy.get(".temperature-part").should("not.exist");
-      simulatorTile.getSelectionButtons().should("have.length", 2).eq(1).click();
-      cy.get(".gripper-image").should("not.exist");
-      cy.get(".temperature-part").should("exist");
-    });
-    it("edit tile title", () => {
-      const newName = "Test Simulation";
-      clueCanvas.addTile("simulator");
-      simulatorTile.getTileTitle().should("contain", "Simulation 1");
-      simulatorTile.getSimulatorTileTitle().click();
-      simulatorTile.getSimulatorTileTitle().type(newName + '{enter}');
-      simulatorTile.getTileTitle().should("contain", newName);
-    });
-    it("links to dataflow tile", () => {
-      clueCanvas.addTile("dataflow");
-      dataflowTile.selectSamplingRate("50ms");
+context('Simulator Tile', function () {
+  it("Simulator Tile with Brainwaves Gripper Simulation", () => {
+    beforeTest(queryParams1);
 
-      // Simulation options are not present in the sensor before the simulation has been added to the document
-      const sensor = "sensor";
-      dataflowTile.getCreateNodeButton(sensor).click();
-      dataflowTile.getDropdown(sensor, "sensor-type").click();
-      dataflowTile.getSensorDropdownOptions(sensor).eq(7).find(".label").click(); // EMG
-      dataflowTile.getDropdown(sensor, "sensor-select").click();
-      dataflowTile.getSensorDropdownOptions(sensor).should("have.length", 1);
-      // Click the background to not select any option
-      cy.get(".primary-workspace .flow-tool").click();
-      dataflowTile.getNodeValueContainer(sensor).invoke('text').then(parseFloat).should("equal", 0);
+    cy.log("renders simulator tile");
+    simulatorTile.getSimulatorTile().should("not.exist");
+    clueCanvas.addTile("simulator");
+    simulatorTile.getSimulatorTile().should("exist");
+    simulatorTile.getTileTitle().should("exist");
+    simulatorTile.getSimulatorTile().should("contain.text", "EMG Sensor");
+    simulatorTile.getSimulatorTile().should("contain.text", "Surface Pressure Sensor");
+    simulatorTile.getSimulatorTile().should("contain.text", "Gripper Output");
+    // Icons are being rendered
+    simulatorTile.getSimulatorTile().find(".leading-box.variable-icon").should("have.length", 4);
 
-      // Simulation options are not present in the live output before the simulation has been added to the document
-      const lo = "live-output";
-      dataflowTile.getCreateNodeButton(lo).click();
-      dataflowTile.getDropdown(lo, "liveOutputType").click();
-      dataflowTile.getDropdownOptions(lo, "liveOutputType").eq(1).click(); // Gripper
-      dataflowTile.getDropdown(lo, "hubSelect").click();
-      dataflowTile.getDropdownOptions(lo, "hubSelect").should("have.length", 1);
-      // Click the background to not select any option
-      cy.get(".primary-workspace .flow-tool").click();
+    cy.get(".arm-image").should("exist");
+    cy.get(".arduino-image").should("exist");
+    cy.get(".gripper-image").should("exist");
 
-      // Sensor options are correct after adding the simulation to the document
-      clueCanvas.addTile("simulator");
-      dataflowTile.getDropdown(sensor, "sensor-select").click();
-      dataflowTile.getSensorDropdownOptions(sensor).should("have.length", 2);
-      dataflowTile.getSensorDropdownOptions(sensor).eq(0).click();
-      dataflowTile.getNodeValueContainer(sensor).invoke('text').then(parseFloat).should("be.below", 41).should("be.above", 35);
-      simulatorTile.getEMGSlider().click("right");
-      cy.wait(50);
-      dataflowTile.getNodeValueContainer(sensor).invoke('text').then(parseFloat).should("be.below", 441).should("be.above", 390);
+    cy.log("Can switch to temperature variant.");
+    cy.get(".temperature-part").should("not.exist");
+    simulatorTile.getSelectionButtons().should("have.length", 2).eq(1).click();
+    cy.get(".gripper-image").should("not.exist");
+    cy.get(".temperature-part").should("exist");
 
-      // Live output options are correct after adding the simulation to the document
-      dataflowTile.getDropdown(lo, "hubSelect").click();
-      dataflowTile.getDropdownOptions(lo, "hubSelect").should("have.length", 2);
-      dataflowTile.getDropdownOptions(lo, "hubSelect").eq(0).click({force: true});
+    cy.log("edit tile title");
+    const newName = "Test Simulation";
+    clueCanvas.addTile("simulator");
+    simulatorTile.getTileTitle().should("contain", "Simulation 1");
+    simulatorTile.getSimulatorTileTitle().click();
+    simulatorTile.getSimulatorTileTitle().type(newName + '{enter}');
+    simulatorTile.getTileTitle().should("contain", newName);
 
-      // Simulator tile's output variable updates when dataflow sets it
-      dataflowTile.getCreateNodeButton("number").click();
-      dataflowTile.getNumberField().type("1{enter}");
-      const output = () => dataflowTile.getNode("number").find(".socket.output");
-      const input = () => dataflowTile.getNode(lo).find(".socket.input");
-      output().click();
-      input().click({ force: true });
-      dataflowTile.getOutputNodeValueText().should("contain", "100% closed");
-      simulatorTile.getSimulatorTile().should("contain.text", "Gripper Output100");
+    cy.log("links to dataflow tile");
+    clueCanvas.addTile("dataflow");
+    dataflowTile.selectSamplingRate("50ms");
 
-      // Pressure variable updates when the gripper changes
-      simulatorTile.getSimulatorTile().should("contain.text", "Surface Pressure Sensor300");
-    });
-  });
-});
+    // Simulation options are not present in the sensor before the simulation has been added to the document
+    const sensor = "sensor";
+    dataflowTile.getCreateNodeButton(sensor).click();
+    dataflowTile.getDropdown(sensor, "sensor-type").click();
+    dataflowTile.getSensorDropdownOptions(sensor).find(".label").contains("EMG").click(); // EMG
+    dataflowTile.getDropdown(sensor, "sensor-select").click();
+    dataflowTile.getSensorDropdownOptions(sensor).should("have.length", 2);
+    // Click the background to not select any option
+    cy.get(".primary-workspace .flow-tool").click();
+    dataflowTile.getNodeValueContainer(sensor).invoke('text').then(parseFloat).should("equal", 0);
 
-context('Simulator Tile with Brain Simulation', function() {
-  beforeEach(function () {
-    const queryParams = "?appMode=qa&fakeClass=5&fakeUser=student:5&qaGroup=5&mouseSensor&unit=brain";
-    cy.clearQAData('all');
-    cy.visit(queryParams);
-    cy.waitForLoad();
-  });
-  it("Make sure only one simulator tile is allowed", () => {
+    // Simulation options are not present in the live output before the simulation has been added to the document
+    const lo = "live-output";
+    dataflowTile.getCreateNodeButton(lo).click();
+    dataflowTile.getDropdown(lo, "liveOutputType").click();
+    dataflowTile.getDropdownOptions(lo, "liveOutputType").eq(1).click(); // Gripper
+    dataflowTile.getDropdown(lo, "hubSelect").click();
+    dataflowTile.getDropdownOptions(lo, "hubSelect").should("have.length", 2);
+    // Click the background to not select any option
+    cy.get(".primary-workspace .flow-tool").click();
+
+    // Sensor options are correct after adding the simulation to the document
+    clueCanvas.addTile("simulator");
+    dataflowTile.getDropdown(sensor, "sensor-select").click();
+    dataflowTile.getSensorDropdownOptions(sensor).should("have.length", 2);
+    dataflowTile.getSensorDropdownOptions(sensor).eq(0).click();
+    dataflowTile.getNodeValueContainer(sensor).invoke('text').then(parseFloat).should("be.below", 41).should("be.above", 35);
+    simulatorTile.getEMGSlider().click("right");
+    cy.wait(50);
+    dataflowTile.getNodeValueContainer(sensor).invoke('text').then(parseFloat).should("be.below", 441).should("be.above", 390);
+
+    // Live output options are correct after adding the simulation to the document
+    dataflowTile.getDropdown(lo, "hubSelect").click();
+    dataflowTile.getDropdownOptions(lo, "hubSelect").should("have.length", 2);
+    dataflowTile.getDropdownOptions(lo, "hubSelect").eq(0).click({ force: true });
+
+    // Simulator tile's output variable updates when dataflow sets it
+    dataflowTile.getCreateNodeButton("number").click();
+    dataflowTile.getNumberField().type("1{enter}");
+    const output = () => dataflowTile.getNode("number").find(".socket.output");
+    const input = () => dataflowTile.getNode(lo).find(".socket.input");
+    output().click();
+    input().click({ force: true });
+    dataflowTile.getOutputNodeValueText().should("contain", "100% closed");
+    simulatorTile.getSimulatorTile().should("contain.text", "Gripper Output100");
+
+    // Pressure variable updates when the gripper changes
+    simulatorTile.getSimulatorTile().should("contain.text", "Surface Pressure Sensor300");
+    clueCanvas.deleteTile("simulator");
+
+    cy.log("Make sure only one simulator tile is allowed");
     clueCanvas.addTile("simulator");
     clueCanvas.verifyToolDisabled("simulator");
     clueCanvas.deleteTile("simulator");
@@ -115,16 +110,11 @@ context('Simulator Tile with Brain Simulation', function() {
     clueCanvas.addTile("simulator");
     simulatorTile.getSimulatorTile().should("exist");
   });
-});
 
-context('Simulator Tile with Terrarium Simulation', function() {
-  beforeEach(function () {
-    const queryParams = "?appMode=qa&fakeClass=5&fakeUser=student:5&qaGroup=5&mouseSensor&unit=seeit";
-    cy.clearQAData('all');
-    cy.visit(queryParams);
-    cy.waitForLoad();
-  });
-  it("links to dataflow tile", () => {
+  it("Simulator Tile with Terrarium Simulation", () => {
+    beforeTest(queryParams2);
+    
+    cy.log("links to dataflow tile")
     // Copy a simulator tile over from curriculum
     simulatorTile.getSimulatorTile().should("not.exist");
     const dataTransfer = new DataTransfer;

--- a/cypress/e2e/clue/branch/student_tests/student_test_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/student_test_spec.js
@@ -6,40 +6,40 @@ const header = new Header;
 const clueHeader = new ClueHeader;
 
 let student = '5',
-    classroom = '5',
-    group = '5';
+  classroom = '5',
+  group = '5';
 
-describe('Check header area for correctness', function(){
-    before(function(){
-        const queryParams = `${Cypress.config("queryParams")}`;
+function beforeTest() {
+  const queryParams = `${Cypress.config("queryParams")}`;
+  cy.clearQAData('all');
+  cy.visit(queryParams);
+  cy.waitForLoad();
+}
 
-        cy.clearQAData('all');
-        cy.visit(queryParams);
-        cy.waitForLoad();
-    });
+context('Check header area for correctness', function () {
+  it('verify header area', function () {
+    beforeTest();
 
-    it('will verify if class name is correct', function(){
-        header.getClassName().should('contain','Class '+classroom);
-    });
-    it('will verify if group name is present', function(){
-        clueHeader.getGroupName().should('contain','Group '+ group);
-    });
-    it('will verify group members is correct', function(){
-        clueHeader.getGroupMembers().should('contain','S'+student);
-    });
-    it('will verify student name is correct', function(){
-        header.getUserName().should('contain','Student '+student);
-    });
-    it('will verify student network status', function(){
-        header.getNetworkStatus().should('contain','Online');
-    });
-    it('will verify teacher options are not displayed', function(){
-        header.getDashboardWorkspaceToggleButtons().should("not.exist");
-        cy.get('.top-tab.tab-teacher-guide').should("not.exist");
-        cy.get('.top-tab.tab-student-work').should("not.exist");
-        cy.get('[data-test="solutions-button"]').should("not.exist");
-        // cy.get('.chat-panel-toggle').should("not.exist"); // this is nolonger true and chat-panel-toggle is being made available to students
-    });
+    cy.log('will verify if class name is correct');
+    header.getClassName().should('contain', 'Class ' + classroom);
 
+    cy.log('will verify if group name is present');
+    clueHeader.getGroupName().should('contain', 'Group ' + group);
+
+    cy.log('will verify group members is correct');
+    clueHeader.getGroupMembers().should('contain', 'S' + student);
+
+    cy.log('will verify student name is correct');
+    header.getUserName().should('contain', 'Student ' + student);
+
+    cy.log('will verify student network status');
+    header.getNetworkStatus().should('contain', 'Online');
+
+    cy.log('will verify teacher options are not displayed');
+    header.getDashboardWorkspaceToggleButtons().should("not.exist");
+    cy.get('.top-tab.tab-teacher-guide').should("not.exist");
+    cy.get('.top-tab.tab-student-work').should("not.exist");
+    cy.get('[data-test="solutions-button"]').should("not.exist");
+  });
 });
 

--- a/cypress/e2e/clue/branch/student_tests/table_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/table_tool_spec.js
@@ -18,292 +18,273 @@ let headerY2 = 'y';
 
 let copyTitle = 'Table Tile Workspace Copy';
 
+function beforeTest() {
+  cy.clearQAData('all');
+  cy.visit(queryParams);
+  cy.waitForLoad();
+  cy.showOnlyDocumentWorkspace();
+}
+
 context('Table Tool Tile', function () {
-  before(function () {
-    cy.clearQAData('all');
-    cy.visit(queryParams);
-    cy.waitForLoad();
-    cy.showOnlyDocumentWorkspace();
-  });
+  it('Test table functions', function () {
+    beforeTest();
 
-  describe('Test table functions', function () {
-    it('will add a table to canvas', function () {
-      clueCanvas.addTile('table');
-      tableToolTile.getTableTile().should('be.visible');
-    });
-    it('verify table title can be edited', function () {
-      const title = "table test";
-      tableToolTile.getTableTitle().click().type(title + '{enter}');
-      tableToolTile.getTableTitle().should('contain', title);
-    });
-    it('will verify there are only two columns x & y', function () {
-      cy.get(".primary-workspace").within((workspace) => {
-        tableToolTile.getColumnHeaderText().then(($headers) => {
-          expect(($headers.length)).to.be.eq(2);
-        });
-        tableToolTile.getColumnHeaderText().each((header, index, $header_list) => {
-          let headerText = ['x', 'y'];
-          cy.wrap(header).should('contain', headerText[index]);
-        });
-      });
-    });
-    it('will change column x name', function () {
-      cy.get(".primary-workspace").within((workspace) => {
-        tableToolTile.renameColumn('x', headerX);
-        tableToolTile.getColumnHeaderText().then((text) => {
-          expect(text[0]).to.be.eq(headerX);
-        });
-      });
-    });
-    it('will change column y name', function () {
-      cy.get(".primary-workspace").within((workspace) => {
-        tableToolTile.renameColumn('y', headerY);
-        tableToolTile.getColumnHeaderText().then((text) => {
-          expect(text[1]).to.be.eq(headerY);
-        });
-      });
-    });
-    it('will add a column', function () {
-      tableToolTile.getAddColumnButton().click();
-      cy.get('.primary-workspace').within(function () {
-        tableToolTile.getColumnHeader().should('have.length', 3);
-      });
-    });
-    it('verify first column cannot be deleted', function () {
-      cy.get('.primary-workspace').within(function () {
-        tableToolTile.getColumnHeader().eq(0).click();
-        tableToolTile.getRemoveColumnButton().should('not.be.visible');
-      });
-    });
-    it('will remove a column', function () {
-      cy.get('.primary-workspace').within(function () {
-        tableToolTile.getColumnHeader().contains(headerY).click();
-        tableToolTile.getRemoveColumnButton().eq(0).should('be.visible').click();
-      });
-      cy.get('.modal-title').should('be.visible').and('contain', 'Remove Column');
-      cy.get('.modal-content').should('contain', 'Remove column').and('contain', headerY);
-      cy.get('.modal-button').contains('Remove Column').click();
-      cy.get('.primary-workspace').within(function () {
-        tableToolTile.getColumnHeader().should('have.length', 2);
-        tableToolTile.getColumnHeaderText().then((text) => {
-          expect(text[0]).to.be.eq(headerX);
-          expect(text[1]).to.be.eq(headerY2);
-        });
-      });
-    });
-  });
+    cy.log('will add a table to canvas');
+    clueCanvas.addTile('table');
+    tableToolTile.getTableTile().should('be.visible');
 
-  describe('edit table entries', function () {
-    // TODO: Found 1, expected 3
-    it('will add content to table', function () {
-      cy.get(".primary-workspace").within((workspace) => {
-        tableToolTile.typeInTableCell(1, '3');
-        tableToolTile.getTableCell().eq(1).should('contain', '3');
-        tableToolTile.typeInTableCell(2, '2.5');
-        tableToolTile.getTableCell().eq(2).should('contain', '2.5');
-        tableToolTile.typeInTableCell(1, '5');
-        tableToolTile.getTableCell().eq(1).should('contain', '5');
-        tableToolTile.getTableRow().should('have.length', 2);
+    cy.log('verify table title can be edited');
+    const title = "table test";
+    tableToolTile.getTableTitle().click().type(title + '{enter}');
+    tableToolTile.getTableTitle().should('contain', title);
+
+    cy.log('will verify there are only two columns x & y');
+    cy.get(".primary-workspace").within((workspace) => {
+      tableToolTile.getColumnHeaderText().then(($headers) => {
+        expect(($headers.length)).to.be.eq(2);
+      });
+      tableToolTile.getColumnHeaderText().each((header, index, $header_list) => {
+        let headerText = ['x', 'y'];
+        cy.wrap(header).should('contain', headerText[index]);
       });
     });
-    it('delete button works', function () {
-      cy.get(".primary-workspace").within((workspace) => {
-        tableToolTile.getTableCell().eq(1).should('contain', '5');
-        tableToolTile.getTableToolbarButton('delete').click();
-        tableToolTile.getTableCell().eq(1).should('contain', '');
+
+    cy.log('will change column x name');
+    cy.get(".primary-workspace").within((workspace) => {
+      tableToolTile.renameColumn('x', headerX);
+      tableToolTile.getColumnHeaderText().then((text) => {
+        expect(text[0]).to.be.eq(headerX);
       });
     });
-    it('will toggle index numbers', function () {
-      tableToolTile.getIndexNumberToggle().click();
-      cy.get(".primary-workspace").within(() => {
-        cy.get(".index-cell-contents").eq(0).should('contain', 1);
-        cy.get(".index-cell-contents").eq(1).should('contain', "");
+
+    cy.log('will change column y name');
+    cy.get(".primary-workspace").within((workspace) => {
+      tableToolTile.renameColumn('y', headerY);
+      tableToolTile.getColumnHeaderText().then((text) => {
+        expect(text[1]).to.be.eq(headerY);
       });
     });
-    it('will remove a row', function () {
-      tableToolTile.removeRow("0");
-      tableToolTile.getTableRow().should('have.length', 1);
-      cy.get(".index-cell-contents").eq(0).should('contain', "");
+
+    cy.log('will add a column');
+    tableToolTile.getAddColumnButton().click();
+    cy.get('.primary-workspace').within(function () {
+      tableToolTile.getColumnHeader().should('have.length', 3);
     });
-  });
-  describe("formulas", function () {
+
+    cy.log('verify first column cannot be deleted');
+    cy.get('.primary-workspace').within(function () {
+      tableToolTile.getColumnHeader().eq(0).click();
+      tableToolTile.getRemoveColumnButton().should('not.be.visible');
+    });
+
+    cy.log('will remove a column');
+    cy.get('.primary-workspace').within(function () {
+      tableToolTile.getColumnHeader().contains(headerY).click();
+      tableToolTile.getRemoveColumnButton().eq(0).should('be.visible').click();
+    });
+    cy.get('.modal-title').should('be.visible').and('contain', 'Remove Column');
+    cy.get('.modal-content').should('contain', 'Remove column').and('contain', headerY);
+    cy.get('.modal-button').contains('Remove Column').click();
+    cy.get('.primary-workspace').within(function () {
+      tableToolTile.getColumnHeader().should('have.length', 2);
+      tableToolTile.getColumnHeaderText().then((text) => {
+        expect(text[0]).to.be.eq(headerX);
+        expect(text[1]).to.be.eq(headerY2);
+      });
+    });
+  // });
+
+  // it('edit table entries and formulas', function () {
+  //   beforeTest();
     let formula = `3*${headerX}+2`;
-    it('will verify formula modal', function () {
-      cy.get(".primary-workspace").within((workspace) => {
-        tableToolTile.getTableToolbarButton('set-expression').click();
-      });
-      cy.get('.modal-title').should('contain', "Set Expression");
-      cy.get('.modal-content .prompt select').should('not.exist');
-      cy.get('.modal-content .prompt').should('contain', "y");
+
+    cy.log('will add content to table');
+    cy.get(".primary-workspace").within((workspace) => {
+      tableToolTile.typeInTableCell(1, '3');
+      tableToolTile.getTableCell().eq(1).should('contain', '3');
+      tableToolTile.typeInTableCell(2, '2.5');
+      tableToolTile.getTableCell().eq(2).should('contain', '2.5');
+      tableToolTile.typeInTableCell(1, '5');
+      tableToolTile.getTableCell().eq(1).should('contain', '5');
+      tableToolTile.getTableRow().should('have.length', 2);
     });
-    it('will enter a formula', function () {
-      cy.get('#expression-input').click().type(formula + '{enter}');
-      cy.get('.ReactModalPortal').should('not.exist');
+
+    cy.log('delete button works');
+    cy.get(".primary-workspace").within((workspace) => {
+      tableToolTile.getTableCell().eq(1).should('contain', '5');
+      tableToolTile.getTableToolbarButton('delete').click();
+      tableToolTile.getTableCell().eq(1).should('contain', '');
     });
-    it('verify formula appears under correct column header', function () {
+
+    cy.log('will toggle index numbers');
+    tableToolTile.getIndexNumberToggle().click();
+    cy.get(".primary-workspace").within(() => {
+      cy.get(".index-cell-contents").eq(0).should('contain', 1);
+      cy.get(".index-cell-contents").eq(1).should('contain', "");
+    });
+
+    cy.log('will remove a row');
+    tableToolTile.removeRow("0");
+    tableToolTile.getTableRow().should('have.length', 1);
+    cy.get(".index-cell-contents").eq(0).should('contain', "");
+
+    cy.log('will verify formula modal');
+    cy.get(".primary-workspace").within((workspace) => {
+      tableToolTile.getTableToolbarButton('set-expression').click();
+    });
+    cy.get('.modal-title').should('contain', "Set Expression");
+    cy.get('.modal-content .prompt select').should('not.exist');
+    cy.get('.modal-content .prompt').should('contain', "y");
+
+    cy.log('will enter a formula');
+    cy.get('#expression-input').click().type(formula + '{enter}');
+    cy.get('.ReactModalPortal').should('not.exist');
+
+    cy.log('verify formula appears under correct column header');
+    cy.get('.editable-header-cell')
+      .contains('.header-name', 'y')
+      .parent()
+      .siblings('.expression-cell.has-expression')
+      .should('contain', formula);
+
+    cy.log('verify selection of y axis when there is more than one');
+    cy.get(".primary-workspace").within((workspace) => {
+      tableToolTile.getAddColumnButton().click();
+      tableToolTile.renameColumn('y', headerY); //makes it easier to find the correct column header
+      tableToolTile.getTableToolbarButton('set-expression').click();
+    });
+    cy.get('.modal-title').should('contain', "Set Expression");
+    cy.get('.modal-content .prompt select').should('exist');
+    cy.get('.modal-content .prompt select').select(headerY);
+    cy.get('.expression label').should('contain', headerY);
+
+    cy.log('verify clear button functionality');
+    cy.get('.modal-button').contains('Clear').click();
+    cy.get('#expression-input').should('not.contain', formula);
+
+    cy.log('verify cancel does not enter in a formula');
+    cy.get('#expression-input').click().type(formula);
+    cy.get('.modal-button').contains('Cancel').click();
+    cy.get('.editable-header-cell')
+      .contains(headerY) // y2 also contains "y" so this no longer works
+      .first()
+      .siblings('.expression-cell.has-expression')
+      .should('not.exist');
+
+    cy.log('verify selection of y2 axis and will enter a formula');
+    cy.get(".primary-workspace").within((workspace) => {
+      tableToolTile.getTableToolbarButton('set-expression').click();
+    });
+    cy.get('.modal-title').should('contain', "Set Expression");
+    cy.get('.modal-content .prompt select').should('exist');
+    cy.get('.modal-content .prompt select').select('y2');
+    cy.get('.modal-content .prompt').should('contain', 'y2');
+    cy.get('#expression-input').click().type(`${headerX}+2{enter}`);
+
+    cy.log('verify value calculated based on formula correctly');
+    cy.get(".primary-workspace").within((workspace) => {
+      tableToolTile.typeInTableCell(1, '3');
+      tableToolTile.getTableCell().eq(1).should('contain', '3');
+      tableToolTile.getTableCell().eq(2).should('contain', '11');
+      tableToolTile.getTableCell().eq(3).should('contain', '5');
+      tableToolTile.typeInTableCell(1, '5');
+      tableToolTile.getTableCell().eq(2).should('contain', '17');
+      tableToolTile.getTableCell().eq(3).should('contain', '7');
+      tableToolTile.typeInTableCell(6, 'a');
+      tableToolTile.getTableCell().eq(7).should('contain', 'NaN');
+      tableToolTile.getTableCell().eq(8).should('contain', 'NaN');
+    });
+
+    cy.log('verifies restore of table field content in copy document');
+    const tableTitle = "table test";
+    //copy investigation
+    canvas.copyDocument(copyTitle);
+    cy.wait(1000);
+    canvas.getPersonalDocTitle().should('contain', copyTitle);
+    tableToolTile.getTableTitle().should('contain', tableTitle);
+    tableToolTile.getTableCell().eq(1).should('contain', '5');
+    tableToolTile.getTableCell().eq(2).should('contain', '17');
+    tableToolTile.getTableCell().eq(3).should('contain', '7');
+
+    cy.get(".primary-workspace").within((workspace) => {
       cy.get('.editable-header-cell')
-        .contains('.header-name', 'y')
+        .contains('.header-name', 'mars')
         .parent()
         .siblings('.expression-cell.has-expression')
         .should('contain', formula);
     });
-    it('verify selection of y axis when there is more than one',function(){
-      cy.get(".primary-workspace").within((workspace) => {
-        tableToolTile.getAddColumnButton().click();
-        tableToolTile.renameColumn('y', headerY); //makes it easier to find the correct column header
-        tableToolTile.getTableToolbarButton('set-expression').click();
-      });
-      cy.get('.modal-title').should('contain', "Set Expression");
-      cy.get('.modal-content .prompt select').should('exist');
-      cy.get('.modal-content .prompt select').select(headerY);
-      cy.get('.expression label').should('contain', headerY);
-    });
-    it('verify clear button functionality', function(){
-      cy.get('.modal-button').contains('Clear').click();
-      cy.get('#expression-input').should('not.contain', formula);
-    });
-    it('verify cancel does not enter in a formula', function(){
-      cy.get('#expression-input').click().type(formula );
-      cy.get('.modal-button').contains('Cancel').click();
-      cy.get('.editable-header-cell')
-        .contains(headerY) // y2 also contains "y" so this no longer works
-        .first()
-        .siblings('.expression-cell.has-expression')
-        .should('not.exist');
-    });
-    it('verify selection of y2 axis and will enter a formula',function(){
-      cy.get(".primary-workspace").within((workspace) => {
-        tableToolTile.getTableToolbarButton('set-expression').click();
-      });
-      cy.get('.modal-title').should('contain', "Set Expression");
-      cy.get('.modal-content .prompt select').should('exist');
-      cy.get('.modal-content .prompt select').select('y2');
-      cy.get('.modal-content .prompt').should('contain', 'y2');
-      cy.get('#expression-input').click().type(`${headerX}+2{enter}`);
-    });
-    it('verify value calculated based on formula correctly', function () {
-      cy.get(".primary-workspace").within((workspace) => {
-        tableToolTile.typeInTableCell(1, '3');
-        tableToolTile.getTableCell().eq(1).should('contain', '3');
-        tableToolTile.getTableCell().eq(2).should('contain', '11');
-        tableToolTile.getTableCell().eq(3).should('contain', '5');
-        tableToolTile.typeInTableCell(1, '5');
-        tableToolTile.getTableCell().eq(2).should('contain', '17');
-        tableToolTile.getTableCell().eq(3).should('contain', '7');
-        tableToolTile.typeInTableCell(6, 'a');
-        tableToolTile.getTableCell().eq(7).should('contain', 'NaN');
-        tableToolTile.getTableCell().eq(8).should('contain', 'NaN');
-        });
-    });
-    it('verifies restore of table field content in copy document',()=>{
-        const title = "table test";
-        //copy investigation
-        canvas.copyDocument(copyTitle);
-        cy.wait(1000);
-        canvas.getPersonalDocTitle().should('contain', copyTitle);
-        tableToolTile.getTableTitle().should('contain', title);
-        tableToolTile.getTableCell().eq(1).should('contain', '5');
-        tableToolTile.getTableCell().eq(2).should('contain', '17');
-        tableToolTile.getTableCell().eq(3).should('contain', '7');
 
-        cy.get(".primary-workspace").within((workspace) => {
-          cy.get('.editable-header-cell')
-          .contains('.header-name', 'mars')
-          .parent()
-          .siblings('.expression-cell.has-expression')
-          .should('contain', formula);
-        });
+    canvas.deleteDocument();
 
-        canvas.deleteDocument();
-    });
-  });
-  describe('delete table', function () {
-    it('verify delete table', function () {
-      tableToolTile.getTableTile().click();
-      clueCanvas.deleteTile('table');
-    });
-  });
-});
-
-context('Table Tool Tile Undo Redo', function () {
-  before(function () {
-    cy.clearQAData('all');
-    cy.visit(queryParams);
-    cy.waitForLoad();
-    cy.showOnlyDocumentWorkspace();
+    cy.log('verify delete table');
+    tableToolTile.getTableTile().click();
+    clueCanvas.deleteTile('table');
   });
 
-  describe('Test undo redo actions', function () {
-    it('will undo redo table tile creation/deletion', function () {
-      // Creation - Undo/Redo
-      clueCanvas.addTile('table');
-      tableToolTile.getTableTile().should('be.visible');
-      clueCanvas.getUndoTool().should("not.have.class", "disabled");
-      clueCanvas.getRedoTool().should("have.class", "disabled");
-      clueCanvas.getUndoTool().click();
-      tableToolTile.getTableTile().should("not.exist");
-      clueCanvas.getUndoTool().should("have.class", "disabled");
-      clueCanvas.getRedoTool().should("not.have.class", "disabled");
-      clueCanvas.getRedoTool().click();
-      tableToolTile.getTableTile().should("exist");
-      clueCanvas.getUndoTool().should("not.have.class", "disabled");
-      clueCanvas.getRedoTool().should("have.class", "disabled");
+  it('Table Tool Tile Undo Redo', function () {
+    beforeTest();
 
-      // Deletion - Undo/Redo
-      clueCanvas.deleteTile('table');
-      tableToolTile.getTableTile().should('not.exist');
-      clueCanvas.getUndoTool().click();
-      tableToolTile.getTableTile().should("exist");
-      clueCanvas.getRedoTool().click();
-      tableToolTile.getTableTile().should('not.exist');
-    });
-    it('will undo redo table field content', function () {
-      clueCanvas.addTile('table');
-      tableToolTile.getAddColumnButton().click();
-      tableToolTile.getAddColumnButton().click();
-      cy.get('.primary-workspace').within(function () {
-        tableToolTile.getColumnHeader().should('have.length', 4);
-      });
-      clueCanvas.getUndoTool().click().click();
-      cy.get('.primary-workspace').within(function () {
-        tableToolTile.getColumnHeader().should('have.length', 2);
-      });
-      clueCanvas.getRedoTool().click();
-      cy.get('.primary-workspace').within(function () {
-        tableToolTile.getColumnHeader().should('have.length', 3);
-      });
-    });
-  });
+    cy.log('will undo redo table tile creation/deletion');
+    // Creation - Undo/Redo
+    clueCanvas.addTile('table');
+    tableToolTile.getTableTile().should('be.visible');
+    clueCanvas.getUndoTool().should("not.have.class", "disabled");
+    clueCanvas.getRedoTool().should("have.class", "disabled");
+    clueCanvas.getUndoTool().click();
+    tableToolTile.getTableTile().should("not.exist");
+    clueCanvas.getUndoTool().should("have.class", "disabled");
+    clueCanvas.getRedoTool().should("not.have.class", "disabled");
+    clueCanvas.getRedoTool().click();
+    tableToolTile.getTableTile().should("exist");
+    clueCanvas.getUndoTool().should("not.have.class", "disabled");
+    clueCanvas.getRedoTool().should("have.class", "disabled");
 
-});
+    // Deletion - Undo/Redo
+    clueCanvas.deleteTile('table');
+    tableToolTile.getTableTile().should('not.exist');
+    clueCanvas.getUndoTool().click();
+    tableToolTile.getTableTile().should("exist");
+    clueCanvas.getRedoTool().click();
+    tableToolTile.getTableTile().should('not.exist');
 
-context('Table Tile View Data As Graph Button', function() {
-  before(function () {
-    cy.clearQAData('all');
-    cy.visit(queryParams);
-    cy.waitForLoad();
-    cy.showOnlyDocumentWorkspace();
-  });
-  describe('Test View Data as Graph Button', function() {
-    it('will link to an XY Plot using the "View Data as Graph" button', function () {
-      clueCanvas.addTile('table');
-      tableToolTile.typeInTableCell(1, '5');
-      tableToolTile.typeInTableCell(2, '2.5');
-      tableToolTile.typeInTableCell(5, '4');
-      tableToolTile.typeInTableCell(6, '7');
-      tableToolTile.getTableToolbarButton("link-graph-button").should('not.be.disabled').click();
-      tableToolTile.getLinkGraphModalCreateNewButton().click();
-      xyplot.getTile().should("exist").contains("Table 1");
+    cy.log('will undo redo table field content');
+    clueCanvas.addTile('table');
+    tableToolTile.getAddColumnButton().click();
+    tableToolTile.getAddColumnButton().click();
+    cy.get('.primary-workspace').within(function () {
+      tableToolTile.getColumnHeader().should('have.length', 4);
     });
-    it('can unlink and link data from a table using the "Link Table" button', () => {
-      // Unlink
-      tableToolTile.getTableToolbarButton("link-tile-button").click();
-      tableToolTile.getLinkGraphModalTileMenu().select('Table 1');
-      tableToolTile.getLinkGraphModalLinkButton().should("contain", "Unlink").click();
-      // Re-link
-      tableToolTile.getTableToolbarButton("link-tile-button").click();
-      tableToolTile.getLinkGraphModalTileMenu().select('Table 1');
-      tableToolTile.getLinkGraphModalLinkButton().should("contain", "Link").click();
+    clueCanvas.getUndoTool().click().click();
+    cy.get('.primary-workspace').within(function () {
+      tableToolTile.getColumnHeader().should('have.length', 2);
     });
+    clueCanvas.getRedoTool().click();
+    cy.get('.primary-workspace').within(function () {
+      tableToolTile.getColumnHeader().should('have.length', 3);
+    });
+
+    cy.log('verify delete table');
+    tableToolTile.getTableTile().click();
+    clueCanvas.deleteTile('table');
+
+    cy.log('will link to an XY Plot using the "View Data as Graph" button');
+    clueCanvas.addTile('table');
+    tableToolTile.typeInTableCell(1, '5');
+    tableToolTile.typeInTableCell(2, '2.5');
+    tableToolTile.typeInTableCell(5, '4');
+    tableToolTile.typeInTableCell(6, '7');
+    tableToolTile.getTableToolbarButton("link-graph-button").should('not.be.disabled').click();
+    tableToolTile.getLinkGraphModalCreateNewButton().click();
+    xyplot.getTile().should("exist").contains("Table 1");
+
+    cy.log('can unlink and link data from a table using the "Link Table" button');
+    // Unlink
+    tableToolTile.getTableToolbarButton("link-tile-button").click();
+    tableToolTile.getLinkGraphModalTileMenu().select('Table 1');
+    tableToolTile.getLinkGraphModalLinkButton().should("contain", "Unlink").click();
+    // Re-link
+    tableToolTile.getTableToolbarButton("link-tile-button").click();
+    tableToolTile.getLinkGraphModalTileMenu().select('Table 1');
+    tableToolTile.getLinkGraphModalLinkButton().should("contain", "Link").click();
   });
 });

--- a/cypress/e2e/clue/branch/student_tests/text_tool_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/text_tool_spec.js
@@ -5,229 +5,203 @@ import TextToolTile from '../../../../support/elements/clue/TextToolTile';
 const canvas = new Canvas;
 const clueCanvas = new ClueCanvas;
 const textToolTile = new TextToolTile;
-
+let title = "SAS 2.1 Drawing Wumps";
 let copyTitle = 'Text Tile Workspace Copy';
 
+function beforeTest() {
+  const queryParams = `${Cypress.config("queryParams")}`;
+  cy.clearQAData('all');
+  cy.visit(queryParams);
+  cy.waitForLoad();
+}
 
-context('Text tool tile functionalities', function(){
-    before(function(){
-        const queryParams = `${Cypress.config("queryParams")}`;
+context('Text tool tile functionalities', function () {
+  it('add, select, delete and edit text', function () {
+    beforeTest();
+    
+    cy.log('adds text tool and types Hello World');
+    clueCanvas.addTile('text');
+    textToolTile.enterText('Hello World');
+    textToolTile.getTextTile().last().should('contain', 'Hello World');
 
-        cy.clearQAData('all');
-        cy.visit(queryParams);
-        cy.waitForLoad();
-    });
+    cy.log('clicks the same text field and allows user to edit text');
+    textToolTile.getTextTile().last().focus();
+    textToolTile.enterText('! Adding more text to see if it gets added. ');
+    textToolTile.getTextEditor().last().should('contain', '! Adding more text to see if it gets added. ');
+    textToolTile.enterText('Adding more text to delete');
+    textToolTile.getTextEditor().last().should('contain', 'Adding more text to delete');
+    textToolTile.deleteText('{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}...');
+    textToolTile.getTextTile().last().should('not.contain', 'delete');
 
-    let title;
-    before(()=>{
-        clueCanvas.getInvestigationCanvasTitle()
-            .then(($canvasTitle)=>{
-                title = $canvasTitle.text().trim();
-                cy.log('title is: '+title);
-            });
-    });
-    it('adds text tool and types Hello World', function(){
-        clueCanvas.addTile('text');
-        textToolTile.enterText('Hello World');
-        textToolTile.getTextTile().last().should('contain', 'Hello World');
-    });
-    it('clicks the same text field and allows user to edit text', function(){
-        textToolTile.getTextTile().last().focus();
-        textToolTile.enterText('! Adding more text to see if it gets added. ');
-        textToolTile.getTextEditor().last().should('contain','! Adding more text to see if it gets added. ');
-        textToolTile.enterText('Adding more text to delete');
-        textToolTile.getTextEditor().last().should('contain','Adding more text to delete');
-        textToolTile.deleteText('{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}...');
-        textToolTile.getTextTile().last().should('not.contain', 'delete');
-    });
     // FIXME: For some reason that only seems present in these tests, we have to add seemingly
     // superfluous spaces and line breaks before applying each text format. If we don't, the
     // elements we're checking for either don't get added, or get added in a somewhat meaningless
     // way (e.g., `<em></em> This should be italic`). This issue doesn't exist in the browser.
-    it('has a toolbar that can be used', function(){
-        textToolTile.clickToolbarTool("Bold");
-        textToolTile.enterText('{end} {enter}');
-        textToolTile.enterText('{end}This should be bold.');
-        textToolTile.getTextEditor().last().should('have.descendants', 'strong');
-        textToolTile.clickToolbarTool("Bold");
+    cy.log('has a toolbar that can be used');
+    textToolTile.clickToolbarTool("Bold");
+    textToolTile.enterText('{end} {enter}');
+    textToolTile.enterText('{end}This should be bold.');
+    textToolTile.getTextEditor().last().should('have.descendants', 'strong');
+    textToolTile.clickToolbarTool("Bold");
 
-        textToolTile.clickToolbarTool("Italic");
-        textToolTile.enterText('{end} {enter}');
-        textToolTile.enterText('{end} {enter}This should be italic.');
-        textToolTile.getTextEditor().last().should('have.descendants', 'em');
-        textToolTile.clickToolbarTool("Italic");
+    textToolTile.clickToolbarTool("Italic");
+    textToolTile.enterText('{end} {enter}');
+    textToolTile.enterText('{end} {enter}This should be italic.');
+    textToolTile.getTextEditor().last().should('have.descendants', 'em');
+    textToolTile.clickToolbarTool("Italic");
 
-        textToolTile.clickToolbarTool("Underline");
-        textToolTile.enterText('{end} {enter}');
-        textToolTile.enterText('{end} {enter}This should be underlined.');
-        textToolTile.getTextEditor().last().should('have.descendants', 'u');
-        textToolTile.clickToolbarTool("Underline");
+    textToolTile.clickToolbarTool("Underline");
+    textToolTile.enterText('{end} {enter}');
+    textToolTile.enterText('{end} {enter}This should be underlined.');
+    textToolTile.getTextEditor().last().should('have.descendants', 'u');
+    textToolTile.clickToolbarTool("Underline");
 
-        textToolTile.clickToolbarTool("Subscript");
-        textToolTile.enterText('{end} {enter}');
-        textToolTile.enterText('{end} {enter}This should be subscript.');
-        textToolTile.getTextEditor().last().should('have.descendants', 'sub');
-        textToolTile.clickToolbarTool("Subscript");
+    textToolTile.clickToolbarTool("Subscript");
+    textToolTile.enterText('{end} {enter}');
+    textToolTile.enterText('{end} {enter}This should be subscript.');
+    textToolTile.getTextEditor().last().should('have.descendants', 'sub');
+    textToolTile.clickToolbarTool("Subscript");
 
-        textToolTile.clickToolbarTool("Superscript");
-        textToolTile.enterText('{end} {enter}');
-        textToolTile.enterText('{end} {enter}This should be superscript.');
-        textToolTile.getTextEditor().last().should('have.descendants', 'sup');
-        textToolTile.clickToolbarTool("Superscript");
+    textToolTile.clickToolbarTool("Superscript");
+    textToolTile.enterText('{end} {enter}');
+    textToolTile.enterText('{end} {enter}This should be superscript.');
+    textToolTile.getTextEditor().last().should('have.descendants', 'sup');
+    textToolTile.clickToolbarTool("Superscript");
 
-        textToolTile.enterText('{end} {enter}');
-        textToolTile.enterText('{end} {enter}This should be in a numbered list');
-        textToolTile.clickToolbarTool("Numbered List");
-        textToolTile.getTextEditor().last().should('have.descendants', 'ol');
+    textToolTile.enterText('{end} {enter}');
+    textToolTile.enterText('{end} {enter}This should be in a numbered list');
+    textToolTile.clickToolbarTool("Numbered List");
+    textToolTile.getTextEditor().last().should('have.descendants', 'ol');
 
-        textToolTile.enterText('{end} {enter}');
-        textToolTile.enterText('{end} {enter}This should be in a bulleted list');
-        textToolTile.clickToolbarTool("Bulleted List");
-        textToolTile.getTextEditor().last().should('have.descendants', 'ul');
-    });
-    it('verifies restore of text field content',()=>{
-        canvas.createNewExtraDocumentFromFileMenu('text tool test','my-work');
-        cy.wait(2000);
-        textToolTile.getTextTile().should('not.exist');
-        //re-open investigation
-        canvas.openDocumentWithTitle('workspaces',title);
-        textToolTile.getTextTile().last().should('exist').and('contain', 'Hello World');
-        textToolTile.getTextEditor().last().should('have.descendants', 'strong');
-        textToolTile.getTextEditor().last().should('have.descendants', 'em');
-        textToolTile.getTextEditor().last().should('have.descendants', 'u');
-        textToolTile.getTextEditor().last().should('have.descendants', 'sub');
-        textToolTile.getTextEditor().last().should('have.descendants', 'sup');
-        textToolTile.getTextEditor().last().should('have.descendants', 'ol');
-        textToolTile.getTextEditor().last().should('have.descendants', 'ul');
-    });
-    it('verifies restore of text field content in copy document',()=>{
-        //copy investigation
-        canvas.copyDocument(copyTitle);
-        canvas.getPersonalDocTitle().should('contain', copyTitle);
-        textToolTile.getTextTile().last().should('exist').and('contain', 'Hello World');
-        textToolTile.getTextEditor().last().should('have.descendants', 'strong');
-        textToolTile.getTextEditor().last().should('have.descendants', 'em');
-        textToolTile.getTextEditor().last().should('have.descendants', 'u');
-        textToolTile.getTextEditor().last().should('have.descendants', 'sub');
-        textToolTile.getTextEditor().last().should('have.descendants', 'sup');
-        textToolTile.getTextEditor().last().should('have.descendants', 'ol');
-        textToolTile.getTextEditor().last().should('have.descendants', 'ul');
-        canvas.deleteDocument();
-    });
-    it('delete text tile',()=>{
-        clueCanvas.deleteTile('text');
-        textToolTile.getTextTile().should('not.exist');
-    });
-});
-context('Text Tool Tile selection', function () {
-    before(function () {
-        const queryParams = `${Cypress.config("queryParams")}`;
-          cy.clearQAData('all');
-      
-          cy.visit(queryParams);
-          cy.waitForLoad();
-          cy.collapseResourceTabs();
-        });
-      
-    describe('Test undo redo actions', function () {
-    it('selecting the text and verify the tool bar buttons', function(){
-        clueCanvas.addTile('text');
-        textToolTile.enterText('Hello World');
-        textToolTile.getTextTile().last().should('contain', 'Hello World');
-        textToolTile.getTextEditor().type('{selectall}');
+    textToolTile.enterText('{end} {enter}');
+    textToolTile.enterText('{end} {enter}This should be in a bulleted list');
+    textToolTile.clickToolbarTool("Bulleted List");
+    textToolTile.getTextEditor().last().should('have.descendants', 'ul');
 
-        //Bold
-        textToolTile.clickToolbarTool("Bold");
-        textToolTile.getTextEditor().last().should('have.descendants', 'strong');
-        textToolTile.clickToolbarTool("Bold");
-        textToolTile.getTextEditor().last().should('not.have.descendants', 'strong');
+    cy.log('verifies restore of text field content');
+    canvas.createNewExtraDocumentFromFileMenu('text tool test', 'my-work');
+    cy.wait(2000);
+    textToolTile.getTextTile().should('not.exist');
+    //re-open investigation
+    canvas.openDocumentWithTitle('workspaces', title);
+    textToolTile.getTextTile().last().should('exist').and('contain', 'Hello World');
+    textToolTile.getTextEditor().last().should('have.descendants', 'strong');
+    textToolTile.getTextEditor().last().should('have.descendants', 'em');
+    textToolTile.getTextEditor().last().should('have.descendants', 'u');
+    textToolTile.getTextEditor().last().should('have.descendants', 'sub');
+    textToolTile.getTextEditor().last().should('have.descendants', 'sup');
+    textToolTile.getTextEditor().last().should('have.descendants', 'ol');
+    textToolTile.getTextEditor().last().should('have.descendants', 'ul');
 
-        //Italic
-        textToolTile.clickToolbarTool("Italic");
-        textToolTile.getTextEditor().last().should('have.descendants', 'em');
-        textToolTile.clickToolbarTool("Italic");
-        textToolTile.getTextEditor().last().should('not.have.descendants', 'em');
+    cy.log('verifies restore of text field content in copy document');
+    //copy investigation
+    canvas.copyDocument(copyTitle);
+    canvas.getPersonalDocTitle().should('contain', copyTitle);
+    textToolTile.getTextTile().last().should('exist').and('contain', 'Hello World');
+    textToolTile.getTextEditor().last().should('have.descendants', 'strong');
+    textToolTile.getTextEditor().last().should('have.descendants', 'em');
+    textToolTile.getTextEditor().last().should('have.descendants', 'u');
+    textToolTile.getTextEditor().last().should('have.descendants', 'sub');
+    textToolTile.getTextEditor().last().should('have.descendants', 'sup');
+    textToolTile.getTextEditor().last().should('have.descendants', 'ol');
+    textToolTile.getTextEditor().last().should('have.descendants', 'ul');
+    canvas.deleteDocument();
 
-        //Underline
-        textToolTile.clickToolbarTool("Underline");
-        textToolTile.getTextEditor().last().should('have.descendants', 'u');
-        textToolTile.clickToolbarTool("Underline");
-        textToolTile.getTextEditor().last().should('not.have.descendants', 'u');
-
-        //Subscript
-        textToolTile.clickToolbarTool("Subscript");
-        textToolTile.getTextEditor().last().should('have.descendants', 'sub');
-        textToolTile.clickToolbarTool("Subscript");
-        textToolTile.getTextEditor().last().should('not.have.descendants', 'sub');
-
-        //Superscript
-        textToolTile.clickToolbarTool("Superscript");
-        textToolTile.getTextEditor().last().should('have.descendants', 'sup');
-        textToolTile.clickToolbarTool("Superscript");
-        textToolTile.getTextEditor().last().should('not.have.descendants', 'sup');
-
-        //Numbered List
-        textToolTile.clickToolbarTool("Numbered List");
-        textToolTile.getTextEditor().last().should('have.descendants', 'ol');
-        textToolTile.clickToolbarTool("Numbered List");
-        textToolTile.getTextEditor().last().should('not.have.descendants', 'ol');
-
-        //Bulleted List
-        textToolTile.clickToolbarTool("Bulleted List");
-        textToolTile.getTextEditor().last().should('have.descendants', 'ul');
-        textToolTile.clickToolbarTool("Bulleted List");
-        textToolTile.getTextEditor().last().should('not.have.descendants', 'ul');
-    });
+    cy.log('delete text tile');
+    clueCanvas.deleteTile('text');
+    textToolTile.getTextTile().should('not.exist');
   });
-});
 
-context('Text Tool Tile Undo Redo', function () {
-    before(function () {
-      const queryParams = `${Cypress.config("queryParams")}`;
-      cy.clearQAData('all');
-  
-      cy.visit(queryParams);
-      cy.waitForLoad();
-      cy.collapseResourceTabs();
-    });
-  
-    describe('Test undo redo actions', function () {
-      it('will undo redo state', function () {
-        clueCanvas.getUndoTool().should("have.class", "disabled");
-        clueCanvas.getRedoTool().should("have.class", "disabled");
-      });  
-      it('will undo redo text tile creation/deletion', function () {
-        // Creation - Undo/Redo
-        clueCanvas.addTile('text');
-        textToolTile.getTextTile().should("exist");
-        clueCanvas.getUndoTool().should("not.have.class", "disabled");
-        clueCanvas.getRedoTool().should("have.class", "disabled");
-        clueCanvas.getUndoTool().click();
-        textToolTile.getTextTile().should("not.exist");
-        clueCanvas.getUndoTool().should("have.class", "disabled");
-        clueCanvas.getRedoTool().should("not.have.class", "disabled");
-        clueCanvas.getRedoTool().click();
-        textToolTile.getTextTile().should("exist");
-        clueCanvas.getUndoTool().should("not.have.class", "disabled");
-        clueCanvas.getRedoTool().should("have.class", "disabled");
+  it('Text Tool Tile selection', function () {
+    beforeTest();
 
-        // Deletion - Undo/Redo
-        clueCanvas.deleteTile('text');
-        textToolTile.getTextTile().should('not.exist');
-        clueCanvas.getUndoTool().click();
-        textToolTile.getTextTile().should("exist");
-        clueCanvas.getRedoTool().click();
-        textToolTile.getTextTile().should('not.exist');
-      });       
-      it('will undo redo text field content', function () {
-        clueCanvas.addTile('text');
-        textToolTile.enterText('Hello World');
-        textToolTile.getTextTile().last().should('contain', 'Hello World');
-        clueCanvas.getUndoTool().click().click();
-        textToolTile.getTextTile().should('have.text', 'Hello Wor');
-        textToolTile.getTextTile().should('not.contain', 'World');
-        clueCanvas.getRedoTool().click();
-        textToolTile.getTextTile().should('have.text', 'Hello Worl');
-      });
-    });
+    cy.log('selecting the text and verify the tool bar buttons');
+    clueCanvas.addTile('text');
+    textToolTile.enterText('Hello World');
+    textToolTile.getTextTile().last().should('contain', 'Hello World');
+    textToolTile.getTextEditor().type('{selectall}');
+
+    //Bold
+    textToolTile.clickToolbarTool("Bold");
+    textToolTile.getTextEditor().last().should('have.descendants', 'strong');
+    textToolTile.clickToolbarTool("Bold");
+    textToolTile.getTextEditor().last().should('not.have.descendants', 'strong');
+
+    //Italic
+    textToolTile.clickToolbarTool("Italic");
+    textToolTile.getTextEditor().last().should('have.descendants', 'em');
+    textToolTile.clickToolbarTool("Italic");
+    textToolTile.getTextEditor().last().should('not.have.descendants', 'em');
+
+    //Underline
+    textToolTile.clickToolbarTool("Underline");
+    textToolTile.getTextEditor().last().should('have.descendants', 'u');
+    textToolTile.clickToolbarTool("Underline");
+    textToolTile.getTextEditor().last().should('not.have.descendants', 'u');
+
+    //Subscript
+    textToolTile.clickToolbarTool("Subscript");
+    textToolTile.getTextEditor().last().should('have.descendants', 'sub');
+    textToolTile.clickToolbarTool("Subscript");
+    textToolTile.getTextEditor().last().should('not.have.descendants', 'sub');
+
+    //Superscript
+    textToolTile.clickToolbarTool("Superscript");
+    textToolTile.getTextEditor().last().should('have.descendants', 'sup');
+    textToolTile.clickToolbarTool("Superscript");
+    textToolTile.getTextEditor().last().should('not.have.descendants', 'sup');
+
+    //Numbered List
+    textToolTile.clickToolbarTool("Numbered List");
+    textToolTile.getTextEditor().last().should('have.descendants', 'ol');
+    textToolTile.clickToolbarTool("Numbered List");
+    textToolTile.getTextEditor().last().should('not.have.descendants', 'ol');
+
+    //Bulleted List
+    textToolTile.clickToolbarTool("Bulleted List");
+    textToolTile.getTextEditor().last().should('have.descendants', 'ul');
+    textToolTile.clickToolbarTool("Bulleted List");
+    textToolTile.getTextEditor().last().should('not.have.descendants', 'ul');
+  });
+  
+  it('Text Tool Undo/Redo', function () {
+    beforeTest();
+
+    cy.log('will undo redo state');
+    clueCanvas.getUndoTool().should("have.class", "disabled");
+    clueCanvas.getRedoTool().should("have.class", "disabled");
+
+    cy.log('will undo redo text tile creation/deletion');
+    // Creation - Undo/Redo
+    clueCanvas.addTile('text');
+    textToolTile.getTextTile().should("exist");
+    clueCanvas.getUndoTool().should("not.have.class", "disabled");
+    clueCanvas.getRedoTool().should("have.class", "disabled");
+    clueCanvas.getUndoTool().click();
+    textToolTile.getTextTile().should("not.exist");
+    clueCanvas.getUndoTool().should("have.class", "disabled");
+    clueCanvas.getRedoTool().should("not.have.class", "disabled");
+    clueCanvas.getRedoTool().click();
+    textToolTile.getTextTile().should("exist");
+    clueCanvas.getUndoTool().should("not.have.class", "disabled");
+    clueCanvas.getRedoTool().should("have.class", "disabled");
+
+    // Deletion - Undo/Redo
+    clueCanvas.deleteTile('text');
+    textToolTile.getTextTile().should('not.exist');
+    clueCanvas.getUndoTool().click();
+    textToolTile.getTextTile().should("exist");
+    clueCanvas.getRedoTool().click();
+    textToolTile.getTextTile().should('not.exist');
+
+    cy.log('will undo redo text field content');
+    clueCanvas.addTile('text');
+    textToolTile.enterText('Hello World');
+    textToolTile.getTextTile().last().should('contain', 'Hello World');
+    clueCanvas.getUndoTool().click().click();
+    textToolTile.getTextTile().should('have.text', 'Hello Wor');
+    textToolTile.getTextTile().should('not.contain', 'World');
+    clueCanvas.getRedoTool().click();
+    textToolTile.getTextTile().should('have.text', 'Hello Worl');
+  });
 });

--- a/cypress/e2e/clue/branch/student_tests/workspace_test_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/workspace_test_spec.js
@@ -3,86 +3,86 @@ import TextToolTile from '../../../../support/elements/clue/TextToolTile';
 
 const queryParams = `${Cypress.config("queryParams")}`;
 let clueCanvas = new ClueCanvas,
-    textToolTile = new TextToolTile;
+  textToolTile = new TextToolTile;
+
+function beforeTest() {
+  cy.clearQAData('all');
+  cy.visit(queryParams);
+  cy.waitForLoad();
+}
 
 context('Test the overall workspace', function () {
-  before(function () {
-    cy.clearQAData('all');
+  it('Desktop functionalities', function () {
+    beforeTest();
 
-    cy.visit(queryParams);
-    cy.waitForLoad();
+    cy.log('will verify that clicking on collapsed resource tab opens the nav area');
+    // cy.get(".resources-expander.my-work").click();
+    cy.openTopTab("my-work");
+    cy.get('[data-test=my-work-section-investigations-documents]').should('be.visible');
+
+    cy.log('will verify clicking on subtab opens panel to subtab section');
+    const section = "learning-log";
+    cy.openSection('my-work', section);
+    cy.get('[data-test=subtab-learning-log]').should('be.visible');
+    cy.get('.list.' + section + ' [data-test=' + section + '-list-items] .footer').should('contain', "My First Learning Log");
+
+    cy.log('verify click on document thumbnail opens document in nav panel');
+    cy.openDocumentWithTitle('my-work', 'learning-log', 'My First Learning Log');
+    cy.get('.editable-document-content [data-test=canvas]').should('be.visible');
+    cy.get('.edit-button.learning-log').should('be.visible');
+
+    cy.log('verify click on Edit button opens document in main workspace');
+    cy.get('.edit-button.learning-log').click();
+    cy.get('.primary-workspace [data-test=learning-log-title]').should('contain', "Learning Log: My First Learning Log");
+
+    cy.log('verify close of nav tabs');
+    cy.collapseResourceTabs();
+    cy.get('.nav-tab-panel').should('not.be.visible');
+    cy.get('.primary-workspace').should('be.visible');
+    cy.get('.workspace-expander').should('not.be.visible');
+    cy.get('.resources-expander').should('be.visible');
+
+    cy.log('verify collapse workspace');
+    cy.get('.resources-expander').click();
+    cy.collapseWorkspace();
+    cy.get('.primary-workspace').should('not.be.visible');
+    cy.get('.workspace-expander').should('be.visible');
+    cy.get('.resources-expander').should('not.be.visible');
+    cy.get('.nav-tab-panel').should('be.visible');
+
+    cy.log('verify collapsed workspace tab opens on click');
+    cy.get('.workspace-expander').click();
+    cy.get('.primary-workspace').should('be.visible');
+    cy.get('.nav-tab-panel').should('be.visible');
+
   });
+  // TODO: Changes in new document add feature.
+  // FIXME: The test is failing looking for the selected class
+  it('will verify canvases do not persist between problems', function () {
+    let problem1 = '1',
+      problem2 = '2.1';
+    let tab1 = 'Introduction';
 
-  describe('Desktop functionalities', function () {
-    it('will verify that clicking on collapsed resource tab opens the nav area', function () {
-      // cy.get(".resources-expander.my-work").click();
-      cy.openTopTab("my-work");
-      cy.get('[data-test=my-work-section-investigations-documents]').should('be.visible');
-    });
-    it('will verify clicking on subtab opens panel to subtab section', function () {
-      const section = "learning-log";
-      cy.openSection('my-work', section);
-      cy.get('[data-test=subtab-learning-log]').should('be.visible');
-      cy.get('.list.'+section+' [data-test='+section+'-list-items] .footer').should('contain', "My First Learning Log");
-    });
-    it('verify click on document thumbnail opens document in nav panel', function () {
-      cy.openDocumentWithTitle('my-work', 'learning-log','My First Learning Log');
-      cy.get('.editable-document-content [data-test=canvas]').should('be.visible');
-      cy.get('.edit-button.learning-log').should('be.visible');
-    });
-    it('verify click on Edit button opens document in main workspace', function () {
-      cy.get('.edit-button.learning-log').click();
-      cy.get('.primary-workspace [data-test=learning-log-title]').should('contain', "Learning Log: My First Learning Log");
-    });
-    it('verify close of nav tabs', function () {
-      cy.collapseResourceTabs();
-      cy.get('.nav-tab-panel').should('not.be.visible');
-      cy.get('.primary-workspace').should('be.visible');
-      cy.get('.workspace-expander').should('not.be.visible');
-      cy.get('.resources-expander').should('be.visible');
-    });
-    it('verify collapse workspace', function () {
-      cy.get('.resources-expander').click();
-      cy.collapseWorkspace();
-      cy.get('.primary-workspace').should('not.be.visible');
-      cy.get('.workspace-expander').should('be.visible');
-      cy.get('.resources-expander').should('not.be.visible');
-      cy.get('.nav-tab-panel').should('be.visible');
-    });
-    it('verify collapsed workspace tab opens on click', function () {
-      cy.get('.workspace-expander').click();
-      cy.get('.primary-workspace').should('be.visible');
-      cy.get('.nav-tab-panel').should('be.visible');
-    });
-    // TODO: Changes in new document add feature.
-    // FIXME: The test is failing looking for the selected class
-    it('will verify canvases do not persist between problems', function () {
-      let problem1 = '1',
-        problem2 = '2.1';
-      let tab1 = 'Introduction';
+    cy.visit('?appMode=qa&fakeClass=5&fakeUser=student:1&qaGroup=1&problem=' + problem1);
+    cy.waitForLoad();
 
-      cy.visit('?appMode=qa&fakeClass=5&fakeUser=student:1&qaGroup=1&problem=' + problem1);
-      cy.waitForLoad();
+    clueCanvas.addTile('text');
+    textToolTile.enterText('This is the ' + tab1 + ' in Problem ' + problem1 + '{enter}');
+    textToolTile.getTextTile().last().should('contain', 'Problem ' + problem1);
+    // the save to firebase is debounced, so we need to wait for it to complete
+    cy.wait(3000);
 
-      clueCanvas.addTile('text');
-      textToolTile.enterText('This is the ' + tab1 + ' in Problem ' + problem1 + '{enter}');
-      textToolTile.getTextTile().last().should('contain', 'Problem ' + problem1);
-      // the save to firebase is debounced, so we need to wait for it to complete
-      cy.wait(3000);
+    cy.visit('?appMode=qa&fakeClass=5&fakeUser=student:1&qaGroup=1&problem=' + problem2);
+    cy.waitForLoad();
+    // cy.wait(1000);
+    textToolTile.getTextTile().should('not.exist');
 
-      cy.visit('?appMode=qa&fakeClass=5&fakeUser=student:1&qaGroup=1&problem=' + problem2);
-      cy.waitForLoad();
-      // cy.wait(1000);
-      textToolTile.getTextTile().should('not.exist');
-
-      //Shows student as disconnected and will not load the introduction canvas
-      cy.visit('?appMode=qa&fakeClass=5&fakeUser=student:1&qaGroup=1&problem=' + problem1);
-      cy.waitForLoad();
-      // cy.wait(2000);
-      textToolTile.getTextTile().click();
-      textToolTile.getTextTile().last().should('contain', 'Problem ' + problem1);
-      clueCanvas.deleteTile('text');//clean up
-    });
-
+    //Shows student as disconnected and will not load the introduction canvas
+    cy.visit('?appMode=qa&fakeClass=5&fakeUser=student:1&qaGroup=1&problem=' + problem1);
+    cy.waitForLoad();
+    // cy.wait(2000);
+    textToolTile.getTextTile().click();
+    textToolTile.getTextTile().last().should('contain', 'Problem ' + problem1);
+    clueCanvas.deleteTile('text');//clean up
   });
 });

--- a/cypress/e2e/clue/branch/teacher_tests/teacher_chat_spec.js
+++ b/cypress/e2e/clue/branch/teacher_tests/teacher_chat_spec.js
@@ -1,8 +1,6 @@
-import TeacherDashboard from "../../../../support/elements/clue/TeacherDashboard";
 import ClueCanvas from "../../../../support/elements/clue/cCanvas";
 import ChatPanel from "../../../../support/elements/clue/ChatPanel";
 
-let dashboard = new TeacherDashboard();
 let clueCanvas = new ClueCanvas;
 let chatPanel = new ChatPanel;
 
@@ -19,198 +17,182 @@ function beforeTest(params) {
   cy.clearQAData('all');
   cy.visit(params);
   cy.waitForLoad();
-  dashboard.switchView("Workspace & Resources");
-  cy.wait(2000);
-  clueCanvas.getInvestigationCanvasTitle().text().as('investigationTitle');
-}
-
-function loadNetworkTest(params) {
-  cy.visit(params);
-  cy.waitForLoad();
-  dashboard.switchView("Workspace & Resources");
-  cy.wait(2000);
   cy.openTopTab("problems");
   chatPanel.getChatPanelToggle().should('exist');
 }
 
 context('Chat Panel', () => {
-  beforeEach(() => {
-    cy.fixture("teacher-dash-data-msa-test.json").as("clueData");
-  });
+  it('verify chat panel', () => {
+    cy.log('verify chat panel is accessible if teacher is in network (via url params)');
+    beforeTest(queryParams.teacher7NetworkQueryParams);
 
-  describe('Chat panel for networked teacher', () => {
-    it('verify chat panel', () => {
-      cy.log('verify chat panel is accessible if teacher is in network (via url params)');
-      beforeTest(queryParams.teacherQueryParams);
-      loadNetworkTest(queryParams.teacher7NetworkQueryParams);
-    
-      cy.log('verify chat panel opens');
-      chatPanel.getChatPanelToggle().click();
-      chatPanel.getChatPanel().should('exist');
-      chatPanel.getNotificationToggle().should('exist');
-      chatPanel.getChatCloseButton().should('exist').click();
-      chatPanel.getChatPanelToggle().should('exist');
-      chatPanel.getChatPanel().should('not.exist');
-    
-      cy.log('verify new comment card exits, card icon exists and Post button is disabled');
-      chatPanel.getChatPanelToggle().click();
-      cy.wait(2000);
-      chatPanel.getCommentCard().should('exist');
-    
-      cy.log('verify the comment card and the document are highlighted');
-      chatPanel.verifyProblemCommentClass();
-      chatPanel.getProblemDocumentContent().should('be.visible').should('have.css', 'background-color').and('eq', selectedChatBackground);
-      chatPanel.getSelectedCommentThreadHeader().should('have.css', 'background-color').and('eq', expandedChatBackground);
-    
-      cy.log('verify the comment card and tile are highlighted and have tile icon');
-      cy.clickProblemResourceTile('introduction');
-      cy.wait(2000);
-      chatPanel.getSelectedCommentThreadHeader().should('exist').should('have.css', 'background-color').and('eq', expandedChatBackground);
-      chatPanel.getCommentTileTypeIcon().should('exist');
-      chatPanel.getToolTile().should('be.visible').should('have.css', 'background-color').and('eq', selectedChatBackground);
-    
-      cy.log('verify user can cancel a comment');
-      cy.openProblemSection("Introduction");
-      const documentComment = "This comment is for the document.";
-      cy.wait(2000);
-      chatPanel.typeInCommentArea(documentComment);
-      chatPanel.getCommentCancelButton().scrollIntoView();
-      chatPanel.verifyCommentAreaContains(documentComment);
-      chatPanel.getCommentCancelButton().scrollIntoView().click();
-      chatPanel.verifyCommentAreaDoesNotContain(documentComment);
-    
-      cy.log('verify user can post a comment');
-      const documentComment1 = "An alert should show this document comment.";
-      chatPanel.addCommentAndVerify(documentComment1);
-    
-      cy.log('verify teacher name and initial appear on comment correctly');
-      chatPanel.getUsernameFromCommentHeader().should('contain', "Teacher 7");
-    
-      cy.log('verify workspace tab document is highlighted');
-      clueCanvas.getInvestigationCanvasTitle().text().then((title)=>{
-        cy.openTopTab('my-work');
-        cy.openSection('my-work', 'workspaces');
-        cy.openDocumentThumbnail('my-work','workspaces', title);
-        chatPanel.verifyDocumentCommentClass();
-      });
-    
-      cy.log("verify escape key empties textarea");
-      chatPanel.typeInCommentArea("this should be erased. {esc}");
-      chatPanel.verifyCommentAreaContains("");
-      chatPanel.verifyCommentThreadDoesNotExist();
-    
-      cy.log('verify user can use shift+enter to go to the next line and not post');
-      chatPanel.typeInCommentArea("this is the first line. {shift}{enter}");
-      chatPanel.verifyCommentThreadDoesNotExist();
-      chatPanel.typeInCommentArea("this is the second line.");
-      chatPanel.clickPostCommentButton();
-      chatPanel.verifyCommentThreadLength(1);
-      chatPanel.verifyCommentThreadContains("this is the first line.\nthis is the second line.");
-    
-      cy.log('verify user can use enter to send post');
-      chatPanel.typeInCommentArea("Send this comment after enter.");
-      chatPanel.useEnterToPostComment();
-      chatPanel.verifyCommentThreadLength(2);
-      chatPanel.verifyCommentThreadContains("Send this comment after enter.");
-    
-      cy.log('verify user can delete a post');
-      const msgToDelete = "Send this comment after enter.";
-      chatPanel.getDeleteMessageButton(msgToDelete).click({force:true});
-      chatPanel.getDeleteConfirmModalButton().contains("Delete").click();
-      cy.wait(2000);
-      chatPanel.verifyCommentThreadLength(1);
-      chatPanel.verifyCommentThreadDoesNotContain(msgToDelete);
-    
-      cy.log("verify commenting on document only shows document comment");
-      cy.openTopTab("problems");
-      chatPanel.verifyProblemCommentClass();
-      chatPanel.addCommentAndVerify("This is a document comment");
-      cy.clickProblemResourceTile('introduction');
-      chatPanel.addCommentAndVerify("This is a tile comment for the first tile");
-      cy.clickProblemResourceTile('introduction', 2);
-      chatPanel.addCommentAndVerify("This is the 3rd tile comment.");
-    
-      cy.log("verify commenting on tile only shows tile comment");
-      chatPanel.showAndVerifyTileCommentClass(3);
-      chatPanel.verifyCommentThreadDoesNotContain("This is a document comment");
-      chatPanel.verifyCommentThreadDoesNotContain("This is a tile comment for the first tile");
-      chatPanel.verifyCommentThreadContains("This is the 3rd tile comment.");
-      cy.clickProblemResourceTile('introduction');
-      chatPanel.showAndVerifyTileCommentClass();
-      chatPanel.verifyCommentThreadDoesNotContain("This is a document comment");
-      chatPanel.verifyCommentThreadContains("This is a tile comment for the first tile");
-      chatPanel.verifyCommentThreadDoesNotContain("This is the 3rd tile comment.");
-    
-      cy.log("verify clicking problem section tab shows document comment");
-      cy.openProblemSection("Introduction");
-      chatPanel.verifyProblemCommentClass();
-      chatPanel.verifyTileCommentDoesNotHaveClass();
-      chatPanel.verifyCommentThreadContains("This is a document comment");
-    
-      cy.log("verify document is selected when switching between tabs");
-      cy.openTopTab("problems");
-      // Open Introduction tab and show tile comment
-      cy.openProblemSection("Introduction");
-      chatPanel.verifyProblemCommentClass();
-      cy.clickProblemResourceTile('introduction');
-      chatPanel.showAndVerifyTileCommentClass();
-      // Open Initial Challenge tab and show tile comment
-      cy.openProblemSection("Initial Challenge");
-      chatPanel.verifyProblemCommentClass();
-      cy.clickProblemResourceTile('initialChallenge');
-      chatPanel.showAndVerifyTileCommentClass();
-      // Return to Introduction tab and make sure document comment and not tile comment is shown
-      cy.openProblemSection("Introduction");
-      chatPanel.verifyProblemCommentClass();
-      chatPanel.verifyTileCommentDoesNotHaveClass();
-      
-      cy.log("verify chat is available on Problem section - Introduction tab");
-      cy.openTopTab("problems");
-      cy.openProblemSection("Introduction");
-      cy.wait(2000);
-      // document comment
-      chatPanel.addCommentAndVerify("This is document comment for problems-section introduction-subsection");
-      // click first tile
-      cy.clickProblemResourceTile('introduction');
-      // tile comment
-      chatPanel.addCommentAndVerify("This is tile comment for problems-section introduction-subsection");
-   
-      cy.log("verify chat is available on Problem section - Initial Challenge tab");
-      cy.openTopTab("problems");
-      cy.openProblemSection("Initial Challenge");
-      cy.wait(2000);
-      // document comment
-      chatPanel.addCommentAndVerify("This is document comment for problems-section initial-challenge-subsection");
-      // click first tile
-      cy.clickProblemResourceTile('initialChallenge');
-      cy.wait(2000);
-      // tile comment
-      chatPanel.addCommentAndVerify("This is tile comment for problems-section initial-challenge-subsection");
-    
-      cy.log("verify chat is available on Problem section - What If... tab");
-      cy.openTopTab("problems");
-      cy.openProblemSection("What If...?");
-      cy.wait(2000);
-      // document comment
-      chatPanel.addCommentAndVerify("This is document comment for problems-section what-if-subsection");
-      // click first tile
-      cy.clickProblemResourceTile('whatIf');
-      cy.wait(2000);
-      // tile comment
-      chatPanel.addCommentAndVerify("This is tile comment for problems-section what-if-subsection");
-    
-      cy.log("verify chat is available on Problem section - Now What Do You Know? tab");
-      cy.openTopTab("problems");
-      cy.openProblemSection("Now What Do You Know?");
-      cy.wait(2000);
-      // document comment
-      chatPanel.addCommentAndVerify("This is document comment for problems-section now-what-subsection");
-      // click first tile
-      cy.clickProblemResourceTile('nowWhatDoYouKnow');
-      cy.wait(2000);
-      // tile comment
-      chatPanel.addCommentAndVerify("This is tile comment for problems-section now-what-subsection");
-    
+    cy.log('verify chat panel opens');
+    chatPanel.getChatPanelToggle().click();
+    chatPanel.getChatPanel().should('exist');
+    chatPanel.getNotificationToggle().should('exist');
+    chatPanel.getChatCloseButton().should('exist').click();
+    chatPanel.getChatPanelToggle().should('exist');
+    chatPanel.getChatPanel().should('not.exist');
+
+    cy.log('verify new comment card exits, card icon exists and Post button is disabled');
+    chatPanel.getChatPanelToggle().click();
+    cy.wait(2000);
+    chatPanel.getCommentCard().should('exist');
+
+    cy.log('verify the comment card and the document are highlighted');
+    chatPanel.verifyProblemCommentClass();
+    chatPanel.getProblemDocumentContent().should('be.visible').should('have.css', 'background-color').and('eq', selectedChatBackground);
+    chatPanel.getSelectedCommentThreadHeader().should('have.css', 'background-color').and('eq', expandedChatBackground);
+
+    cy.log('verify the comment card and tile are highlighted and have tile icon');
+    cy.clickProblemResourceTile('introduction');
+    cy.wait(2000);
+    chatPanel.getSelectedCommentThreadHeader().should('exist').should('have.css', 'background-color').and('eq', expandedChatBackground);
+    chatPanel.getCommentTileTypeIcon().should('exist');
+    chatPanel.getToolTile().should('be.visible').should('have.css', 'background-color').and('eq', selectedChatBackground);
+
+    cy.log('verify user can cancel a comment');
+    cy.openProblemSection("Introduction");
+    const documentComment = "This comment is for the document.";
+    cy.wait(2000);
+    chatPanel.typeInCommentArea(documentComment);
+    chatPanel.getCommentCancelButton().scrollIntoView();
+    chatPanel.verifyCommentAreaContains(documentComment);
+    chatPanel.getCommentCancelButton().scrollIntoView().click();
+    chatPanel.verifyCommentAreaDoesNotContain(documentComment);
+
+    cy.log('verify user can post a comment');
+    const documentComment1 = "An alert should show this document comment.";
+    chatPanel.addCommentAndVerify(documentComment1);
+
+    cy.log('verify teacher name and initial appear on comment correctly');
+    chatPanel.getUsernameFromCommentHeader().should('contain', "Teacher 7");
+
+    cy.log('verify workspace tab document is highlighted');
+    clueCanvas.getInvestigationCanvasTitle().text().then((title) => {
+      cy.openTopTab('my-work');
+      cy.openSection('my-work', 'workspaces');
+      cy.openDocumentThumbnail('my-work', 'workspaces', title);
+      chatPanel.verifyDocumentCommentClass();
+    });
+
+    cy.log("verify escape key empties textarea");
+    chatPanel.typeInCommentArea("this should be erased. {esc}");
+    chatPanel.verifyCommentAreaContains("");
+    chatPanel.verifyCommentThreadDoesNotExist();
+
+    cy.log('verify user can use shift+enter to go to the next line and not post');
+    chatPanel.typeInCommentArea("this is the first line. {shift}{enter}");
+    chatPanel.verifyCommentThreadDoesNotExist();
+    chatPanel.typeInCommentArea("this is the second line.");
+    chatPanel.clickPostCommentButton();
+    chatPanel.verifyCommentThreadLength(1);
+    chatPanel.verifyCommentThreadContains("this is the first line.\nthis is the second line.");
+
+    cy.log('verify user can use enter to send post');
+    chatPanel.typeInCommentArea("Send this comment after enter.");
+    chatPanel.useEnterToPostComment();
+    chatPanel.verifyCommentThreadLength(2);
+    chatPanel.verifyCommentThreadContains("Send this comment after enter.");
+
+    cy.log('verify user can delete a post');
+    const msgToDelete = "Send this comment after enter.";
+    chatPanel.getDeleteMessageButton(msgToDelete).click({ force: true });
+    chatPanel.getDeleteConfirmModalButton().contains("Delete").click();
+    cy.wait(2000);
+    chatPanel.verifyCommentThreadLength(1);
+    chatPanel.verifyCommentThreadDoesNotContain(msgToDelete);
+
+    cy.log("verify commenting on document only shows document comment");
+    cy.openTopTab("problems");
+    chatPanel.verifyProblemCommentClass();
+    chatPanel.addCommentAndVerify("This is a document comment");
+    cy.clickProblemResourceTile('introduction');
+    chatPanel.addCommentAndVerify("This is a tile comment for the first tile");
+    cy.clickProblemResourceTile('introduction', 2);
+    chatPanel.addCommentAndVerify("This is the 3rd tile comment.");
+
+    cy.log("verify commenting on tile only shows tile comment");
+    chatPanel.showAndVerifyTileCommentClass(3);
+    chatPanel.verifyCommentThreadDoesNotContain("This is a document comment");
+    chatPanel.verifyCommentThreadDoesNotContain("This is a tile comment for the first tile");
+    chatPanel.verifyCommentThreadContains("This is the 3rd tile comment.");
+    cy.clickProblemResourceTile('introduction');
+    chatPanel.showAndVerifyTileCommentClass();
+    chatPanel.verifyCommentThreadDoesNotContain("This is a document comment");
+    chatPanel.verifyCommentThreadContains("This is a tile comment for the first tile");
+    chatPanel.verifyCommentThreadDoesNotContain("This is the 3rd tile comment.");
+
+    cy.log("verify clicking problem section tab shows document comment");
+    cy.openProblemSection("Introduction");
+    chatPanel.verifyProblemCommentClass();
+    chatPanel.verifyTileCommentDoesNotHaveClass();
+    chatPanel.verifyCommentThreadContains("This is a document comment");
+
+    cy.log("verify document is selected when switching between tabs");
+    cy.openTopTab("problems");
+    // Open Introduction tab and show tile comment
+    cy.openProblemSection("Introduction");
+    chatPanel.verifyProblemCommentClass();
+    cy.clickProblemResourceTile('introduction');
+    chatPanel.showAndVerifyTileCommentClass();
+    // Open Initial Challenge tab and show tile comment
+    cy.openProblemSection("Initial Challenge");
+    chatPanel.verifyProblemCommentClass();
+    cy.clickProblemResourceTile('initialChallenge');
+    chatPanel.showAndVerifyTileCommentClass();
+    // Return to Introduction tab and make sure document comment and not tile comment is shown
+    cy.openProblemSection("Introduction");
+    chatPanel.verifyProblemCommentClass();
+    chatPanel.verifyTileCommentDoesNotHaveClass();
+
+    cy.log("verify chat is available on Problem section - Introduction tab");
+    cy.openTopTab("problems");
+    cy.openProblemSection("Introduction");
+    cy.wait(2000);
+    // document comment
+    chatPanel.addCommentAndVerify("This is document comment for problems-section introduction-subsection");
+    // click first tile
+    cy.clickProblemResourceTile('introduction');
+    // tile comment
+    chatPanel.addCommentAndVerify("This is tile comment for problems-section introduction-subsection");
+
+    cy.log("verify chat is available on Problem section - Initial Challenge tab");
+    cy.openTopTab("problems");
+    cy.openProblemSection("Initial Challenge");
+    cy.wait(2000);
+    // document comment
+    chatPanel.addCommentAndVerify("This is document comment for problems-section initial-challenge-subsection");
+    // click first tile
+    cy.clickProblemResourceTile('initialChallenge');
+    cy.wait(2000);
+    // tile comment
+    chatPanel.addCommentAndVerify("This is tile comment for problems-section initial-challenge-subsection");
+
+    cy.log("verify chat is available on Problem section - What If... tab");
+    cy.openTopTab("problems");
+    cy.openProblemSection("What If...?");
+    cy.wait(2000);
+    // document comment
+    chatPanel.addCommentAndVerify("This is document comment for problems-section what-if-subsection");
+    // click first tile
+    cy.clickProblemResourceTile('whatIf');
+    cy.wait(2000);
+    // tile comment
+    chatPanel.addCommentAndVerify("This is tile comment for problems-section what-if-subsection");
+
+    cy.log("verify chat is available on Problem section - Now What Do You Know? tab");
+    cy.openTopTab("problems");
+    cy.openProblemSection("Now What Do You Know?");
+    cy.wait(2000);
+    // document comment
+    chatPanel.addCommentAndVerify("This is document comment for problems-section now-what-subsection");
+    // click first tile
+    cy.clickProblemResourceTile('nowWhatDoYouKnow');
+    cy.wait(2000);
+    // tile comment
+    chatPanel.addCommentAndVerify("This is tile comment for problems-section now-what-subsection");
+
     // it.skip("verify chat is available on Teacher Guide section - Unit Plan tab", () => {
     //   cy.openTopTab("teacher-guide");
     //   cy.openProblemSection('Unit Plan');
@@ -223,199 +205,58 @@ context('Chat Panel', () => {
     //   // tile comment
     //   chatPanel.addCommentAndVerify("This is tile comment for teacher-guide-section unit-plan-subsection");
     // });
-      cy.log("verify chat is available on Teacher Guide section - Launch tab");
-      cy.openTopTab("teacher-guide");
-      cy.openProblemSection('Launch');
-      cy.wait(2000);
-      // document comment
-      chatPanel.addCommentAndVerify("This is document comment for teacher-guide-section launch-subsection");
-      // click first tile
-      cy.clickProblemResourceTile('launch');
-      cy.wait(2000);
-      // tile comment
-      chatPanel.addCommentAndVerify("This is tile comment for teacher-guide-section launch-subsection");
-    
-      cy.log("verify chat is available on Teacher Guide section - Explore tab");
-      cy.openTopTab("teacher-guide");
-      cy.openProblemSection('Explore');
-      cy.wait(2000);
-      // document comment
-      chatPanel.addCommentAndVerify("This is document comment for teacher-guide-section explore-subsection");
-      // click first tile
-      cy.clickProblemResourceTile('explore');
-      cy.wait(2000);
-      // tile comment
-      chatPanel.addCommentAndVerify("This is tile comment for teacher-guide-section explore-subsection");
-    
-      cy.log("verify chat is available on Teacher Guide section - Summarize tab");
-      cy.openTopTab("teacher-guide");
-      cy.openProblemSection('Summarize');
-      cy.wait(2000);
-      // document comment
-      chatPanel.addCommentAndVerify("This is document comment for teacher-guide-section summarize-subsection");
-      // click first tile
-      cy.clickProblemResourceTile('summarize');
-      cy.wait(2000);
-      // tile comment
-      chatPanel.addCommentAndVerify("This is tile comment for teacher-guide-section summarize-subsection");
-    
-      cy.log("verify chat is available on My Work section - Workspaces tab");
-      clueCanvas.getInvestigationCanvasTitle().text().then((title)=>{
-        cy.openTopTab('my-work');
-        cy.openSection('my-work', 'workspaces');
-        cy.openDocumentThumbnail('my-work','workspaces', title);
-        cy.wait(2000);
-        // document comment
-        chatPanel.addCommentAndVerify("This is document comment for teacher-my-work workspaces-subsection");
-      });
-    
-      cy.log("verify chat is available on My Work section - Learning Log tab");
+    cy.log("verify chat is available on Teacher Guide section - Launch tab");
+    cy.openTopTab("teacher-guide");
+    cy.openProblemSection('Launch');
+    cy.wait(2000);
+    // document comment
+    chatPanel.addCommentAndVerify("This is document comment for teacher-guide-section launch-subsection");
+    // click first tile
+    cy.clickProblemResourceTile('launch');
+    cy.wait(2000);
+    // tile comment
+    chatPanel.addCommentAndVerify("This is tile comment for teacher-guide-section launch-subsection");
+
+    cy.log("verify chat is available on Teacher Guide section - Explore tab");
+    cy.openTopTab("teacher-guide");
+    cy.openProblemSection('Explore');
+    cy.wait(2000);
+    // document comment
+    chatPanel.addCommentAndVerify("This is document comment for teacher-guide-section explore-subsection");
+    // click first tile
+    cy.clickProblemResourceTile('explore');
+    cy.wait(2000);
+    // tile comment
+    chatPanel.addCommentAndVerify("This is tile comment for teacher-guide-section explore-subsection");
+
+    cy.log("verify chat is available on Teacher Guide section - Summarize tab");
+    cy.openTopTab("teacher-guide");
+    cy.openProblemSection('Summarize');
+    cy.wait(2000);
+    // document comment
+    chatPanel.addCommentAndVerify("This is document comment for teacher-guide-section summarize-subsection");
+    // click first tile
+    cy.clickProblemResourceTile('summarize');
+    cy.wait(2000);
+    // tile comment
+    chatPanel.addCommentAndVerify("This is tile comment for teacher-guide-section summarize-subsection");
+
+    cy.log("verify chat is available on My Work section - Workspaces tab");
+    clueCanvas.getInvestigationCanvasTitle().text().then((title) => {
       cy.openTopTab('my-work');
-      cy.openSection('my-work', 'learning-log');
-      cy.openDocumentWithIndex('my-work', 'learning-log', 0);
+      cy.openSection('my-work', 'workspaces');
+      cy.openDocumentThumbnail('my-work', 'workspaces', title);
       cy.wait(2000);
       // document comment
-      chatPanel.addCommentAndVerify("This is document comment for teacher-my-work learning-log-subsection");
+      chatPanel.addCommentAndVerify("This is document comment for teacher-my-work workspaces-subsection");
     });
 
-    it("Teachers can communicate back and forth in chat panel", () => {
-      cy.log("verify teacher7 can post document and tile comments");
-      beforeTest(queryParams.teacherQueryParams);
-      loadNetworkTest(queryParams.teacher7NetworkQueryParams);
-      // Teacher 7 document comment
-      cy.openTopTab("problems");
-      cy.openProblemSection("Introduction");
-      chatPanel.getChatPanelToggle().click();
-      chatPanel.verifyProblemCommentClass();
-      cy.wait(2000);
-      chatPanel.addCommentAndVerify("This is a teacher7 document comment");
-      // Teacher 7 tile comment
-      cy.clickProblemResourceTile('introduction');
-      cy.wait(2000);
-      chatPanel.addCommentAndVerify("This is a teacher7 tile comment");
-    
-      cy.log("verify teacher8 can open clue chat in the same network");
-      // Open clue chat for Teacher 8
-      loadNetworkTest(queryParams.teacher8NetworkQueryParams);
-      chatPanel.getChatPanelToggle().click();
-    
-      cy.log("verify teacher8 can view teacher7's comments and add more comments");
-      // Teacher 8 document comment
-      chatPanel.verifyProblemCommentClass();
-      chatPanel.verifyCommentThreadContains("This is a teacher7 document comment");
-      chatPanel.addCommentAndVerify("This is a teacher8 document comment");
-      // Teacher 8 tile comment
-      cy.clickProblemResourceTile('introduction');
-      cy.wait(2000);
-      chatPanel.verifyCommentThreadContains("This is a teacher7 tile comment");
-      chatPanel.addCommentAndVerify("This is a teacher8 tile comment");
-    
-      cy.log("verify reopening teacher7's clue chat in the same network");
-      // Open clue chat for Teacher 7
-      loadNetworkTest(queryParams.teacher7NetworkQueryParams);
-      chatPanel.getChatPanelToggle().click();
-    
-      cy.log("verify teacher7 can view teacher8's comments");
-      // Teacher 7 document comment
-      chatPanel.verifyProblemCommentClass();
-      chatPanel.verifyCommentThreadContains("This is a teacher8 document comment");
-      // Teacher 7 tile comment
-      cy.clickProblemResourceTile('introduction');
-      cy.wait(2000);
-      chatPanel.verifyCommentThreadContains("This is a teacher8 tile comment");
-    });
- });
-});
-
-context('Chat Panel Comment Tags', () => {
-  beforeEach(() => {
-    cy.fixture("teacher-dash-data-msa-test.json").as("clueData");
+    cy.log("verify chat is available on My Work section - Learning Log tab");
+    cy.openTopTab('my-work');
+    cy.openSection('my-work', 'learning-log');
+    cy.openDocumentWithIndex('my-work', 'learning-log', 0);
+    cy.wait(2000);
+    // document comment
+    chatPanel.addCommentAndVerify("This is document comment for teacher-my-work learning-log-subsection");
   });
-
-  describe('Chat panel comment tags for networked teacher', () => {
-    it('verify chat panel comment tags', () => {
-      const tags = [
-       "Select Student Strategy",
-       "Part-to-Part",
-       "Part-to-Whole",
-       "Unit Rate",
-       "Guess and Check",
-       "None"
-      ];
-      const tagComment = [
-       "This is Part-to-Part tag comment" + Math.random(),
-       "This is Part-to-Whole tag comment" + Math.random(),
-       "This is Unit Rate tag comment" + Math.random(),
-       "This is Guess and Check tag comment" + Math.random(),
-       "This is None tag comment" + Math.random(),
-      ];
-      cy.log('verify chat panel comment tags are accessible if teacher is in network (via url params)');
-      beforeTest(queryParams.teacherQueryParams);
-      loadNetworkTest(queryParams.teacher7NetworkQueryParams);
-    
-      cy.log('verify comment tag dropdown');
-      chatPanel.getChatPanelToggle().click();
-      chatPanel.getChatPanel().should('exist');
-      chatPanel.getCommentTextDropDown().should('exist');
-    
-      cy.log('verify comment tag dropdown options');
-      chatPanel.getCommentTextDropDown()
-      .should("contain", tags[0])
-      .should("contain", tags[1])
-      .should("contain", tags[2])
-      .should("contain", tags[3])
-      .should("contain", tags[4])
-      .should("contain", tags[5]);
-
-      cy.log('verify user post only comment tags on document comment');
-      cy.openTopTab("problems");
-      chatPanel.verifyProblemCommentClass();
-      chatPanel.addCommentTagAndVerify(tags[1]);
-      chatPanel.deleteCommentTagThread(tags[1]);
-
-      cy.log('verify user post only comment tags on tile comment');
-      cy.clickProblemResourceTile('introduction');
-      chatPanel.showAndVerifyTileCommentClass(0);
-      chatPanel.addCommentTagAndVerify(tags[2]);
-      chatPanel.deleteCommentTagThread(tags[2]);
-
-      cy.log('verify user post both comment tags and plain text on document comment');
-      cy.openTopTab("problems");
-      cy.openProblemSection("Introduction");
-      chatPanel.verifyProblemCommentClass();
-      chatPanel.addCommentTagTextAndVerify(tags[3], tagComment[2]);
-      chatPanel.deleteCommentTagThread(tags[3]);
-
-      cy.log('verify user post both comment tags and plain text on tile comment');
-      cy.openTopTab("problems");
-      cy.clickProblemResourceTile('introduction');
-      chatPanel.showAndVerifyTileCommentClass(0);
-      chatPanel.addCommentTagTextAndVerify(tags[5], tagComment[4]);
-      chatPanel.deleteCommentTagThread(tags[5]);
-
-      cy.log('verify user post only plain text and comment tag not displayed on document comment');
-      const docComment = "Only plain text and no comment tag document comment";
-      cy.openTopTab("problems");
-      cy.openProblemSection("Introduction");
-      chatPanel.verifyProblemCommentClass();
-      chatPanel.addCommentAndVerify(docComment);
-      chatPanel.verifyCommentTagNotDisplayed(docComment);
-      chatPanel.getDeleteMessageButton(docComment).click({force:true});
-      chatPanel.getDeleteConfirmModalButton().contains("Delete").click();
-      cy.wait(2000);
-      chatPanel.verifyCommentThreadDoesNotContain(docComment);
-
-      cy.log('verify user post only plain text and comment tag not displayed on tile comment');
-      const tileComment = "Only plain text and no comment tag tile comment";
-      cy.openTopTab("problems");
-      cy.clickProblemResourceTile('introduction');
-      chatPanel.showAndVerifyTileCommentClass(0);
-      chatPanel.addCommentAndVerify(tileComment);
-      chatPanel.verifyCommentTagNotDisplayed(tileComment);
-      chatPanel.getDeleteMessageButton(tileComment).click({force:true});
-      chatPanel.getDeleteConfirmModalButton().contains("Delete").click();
-      cy.wait(2000);
-      chatPanel.verifyCommentThreadDoesNotContain(tileComment);   
-    });
- });
 });

--- a/cypress/e2e/clue/branch/teacher_tests/teacher_dashboard_4_quadrants_spec.js
+++ b/cypress/e2e/clue/branch/teacher_tests/teacher_dashboard_4_quadrants_spec.js
@@ -14,118 +14,114 @@ function beforeTest(params) {
   dashboard.clearAllStarsFromPublishedWork();
   dashboard.switchWorkView('Current');
   dashboard.getProblemDropdown().text().as('problemTitle');
+  cy.fixture("teacher-dash-data-CLUE-test.json").as("clueData");
 }
 
 context('Teacher Dashboard View 4 Quadrants', () => {
+  describe('4 quadrants functionality', () => {
+    it('verify 4 quadrants functionality', () => {
+      beforeTest(queryParams);
+      cy.log('verifies students are in correct groups');
+      cy.get('@clueData').then((clueData) => {
+        let groups = clueData.classes[0].problems[0].groups;
+        let groupIndex = 0;
 
-    beforeEach(() => {
-      cy.fixture("teacher-dash-data-CLUE-test.json").as("clueData");
-    });
+        let groupName = groups[groupIndex].groupName;
 
-    describe('4 quadrants functionality', () => {
-      it('verify 4 quadrants functionality', () => {
-        beforeTest(queryParams);   
-        cy.log('verifies students are in correct groups');
-        cy.get('@clueData').then((clueData) => {
-          let groups = clueData.classes[0].problems[0].groups;
-          let groupIndex = 0;
-
-          let groupName = groups[groupIndex].groupName;
-
-          dashboard.getGroupName().eq(groupIndex).should('contain', 'Group ' + groupName);
-          dashboard.getGroups().eq(groupIndex).within(() => {
-            cy.get('.member').should('contain', "S1")
+        dashboard.getGroupName().eq(groupIndex).should('contain', 'Group ' + groupName);
+        dashboard.getGroups().eq(groupIndex).within(() => {
+          cy.get('.member').should('contain', "S1")
             .should('contain', "S2")
             .should('contain', "S3")
             .should('contain', "S4");
-          });
         });
-        cy.log('verify each canvas in a 4 up view is read only');
-        cy.get('@clueData').then((clueData) => {
-          let tempGroupIndex = 0;
-          let tempGroup = clueData.classes[0].problems[0].groups[tempGroupIndex];
-          dashboard.verifyWorkForGroupReadOnly(tempGroup);
-          cy.wait(1000);
-        });
+      });
+      cy.log('verify each canvas in a 4 up view is read only');
+      cy.get('@clueData').then((clueData) => {
+        let tempGroupIndex = 0;
+        let tempGroup = clueData.classes[0].problems[0].groups[tempGroupIndex];
+        dashboard.verifyWorkForGroupReadOnly(tempGroup);
+        cy.wait(1000);
+      });
 
       // FIXME: this test was crashing my local cypress.
-        cy.log('verify toggling the 4 quardrants in a 4 up view');
+      cy.log('verify toggling the 4 quardrants in a 4 up view');
 
-        //North West Quardrants
-        dashboard.getGroups().eq(0).within(() => {
-          dashboard.getStudentID(0).should('contain', "S1").click();
-        });
-        dashboard.getZoomedStudentID().should('contain', "Student 1");
-        dashboard.getGroups().eq(0).within(() => {
-          cy.get('.canvas-container').should("have.length", 1);
-        });
-        dashboard.getPlaybackToolBar().should("exist");
-        dashboard.getGroups().eq(0).within(() => {
-          dashboard.getStudentCanvas(".north-east").should("not.exist");
-          dashboard.getStudentCanvas(".south-east").should("not.exist");
-          dashboard.getStudentCanvas(".south-west").should("not.exist");
-        });
-        dashboard.getZoomedStudentID().click();
-        dashboard.getGroups().eq(0).within(() => {
-          cy.get('.canvas-container').should("have.length", 4);
-        });
+      //North West Quardrants
+      dashboard.getGroups().eq(0).within(() => {
+        dashboard.getStudentID(0).should('contain', "S1").click();
+      });
+      dashboard.getZoomedStudentID().should('contain', "Student 1");
+      dashboard.getGroups().eq(0).within(() => {
+        cy.get('.canvas-container').should("have.length", 1);
+      });
+      dashboard.getPlaybackToolBar().should("exist");
+      dashboard.getGroups().eq(0).within(() => {
+        dashboard.getStudentCanvas(".north-east").should("not.exist");
+        dashboard.getStudentCanvas(".south-east").should("not.exist");
+        dashboard.getStudentCanvas(".south-west").should("not.exist");
+      });
+      dashboard.getZoomedStudentID().click();
+      dashboard.getGroups().eq(0).within(() => {
+        cy.get('.canvas-container').should("have.length", 4);
+      });
 
-        //North East Quardrants
-        dashboard.getGroups().eq(0).within(() => {
-          dashboard.getStudentID(1).should('contain', "S2").click();
-        });
-        dashboard.getZoomedStudentID().should('contain', "Student 2");
-        dashboard.getGroups().eq(0).within(() => {
-          cy.get('.canvas-container').should("have.length", 1);
-        });
-        dashboard.getPlaybackToolBar().should("exist");
-        dashboard.getGroups().eq(0).within(() => {
-          dashboard.getStudentCanvas(".north-west").should("not.exist");
-          dashboard.getStudentCanvas(".south-east").should("not.exist");
-          dashboard.getStudentCanvas(".south-west").should("not.exist");
-        });
-        dashboard.getZoomedStudentID().click();
-        dashboard.getGroups().eq(0).within(() => {
-          cy.get('.canvas-container').should("have.length", 4);
-        });
+      //North East Quardrants
+      dashboard.getGroups().eq(0).within(() => {
+        dashboard.getStudentID(1).should('contain', "S2").click();
+      });
+      dashboard.getZoomedStudentID().should('contain', "Student 2");
+      dashboard.getGroups().eq(0).within(() => {
+        cy.get('.canvas-container').should("have.length", 1);
+      });
+      dashboard.getPlaybackToolBar().should("exist");
+      dashboard.getGroups().eq(0).within(() => {
+        dashboard.getStudentCanvas(".north-west").should("not.exist");
+        dashboard.getStudentCanvas(".south-east").should("not.exist");
+        dashboard.getStudentCanvas(".south-west").should("not.exist");
+      });
+      dashboard.getZoomedStudentID().click();
+      dashboard.getGroups().eq(0).within(() => {
+        cy.get('.canvas-container').should("have.length", 4);
+      });
 
-        //South East Quardrants
-        dashboard.getGroups().eq(0).within(() => {
-          dashboard.getStudentID(2).should('contain', "S3").click();
-        });
-        dashboard.getZoomedStudentID().should('contain', "Student 3");
-        dashboard.getGroups().eq(0).within(() => {
-          cy.get('.canvas-container').should("have.length", 1);
-        });
-        dashboard.getPlaybackToolBar().should("exist");
-        dashboard.getGroups().eq(0).within(() => {
-          dashboard.getStudentCanvas(".north-west").should("not.exist");
-          dashboard.getStudentCanvas(".north-east").should("not.exist");
-          dashboard.getStudentCanvas(".south-west").should("not.exist");
-        });
-        dashboard.getZoomedStudentID().click();
-        dashboard.getGroups().eq(0).within(() => {
-          cy.get('.canvas-container').should("have.length", 4);
-        });
+      //South East Quardrants
+      dashboard.getGroups().eq(0).within(() => {
+        dashboard.getStudentID(2).should('contain', "S3").click();
+      });
+      dashboard.getZoomedStudentID().should('contain', "Student 3");
+      dashboard.getGroups().eq(0).within(() => {
+        cy.get('.canvas-container').should("have.length", 1);
+      });
+      dashboard.getPlaybackToolBar().should("exist");
+      dashboard.getGroups().eq(0).within(() => {
+        dashboard.getStudentCanvas(".north-west").should("not.exist");
+        dashboard.getStudentCanvas(".north-east").should("not.exist");
+        dashboard.getStudentCanvas(".south-west").should("not.exist");
+      });
+      dashboard.getZoomedStudentID().click();
+      dashboard.getGroups().eq(0).within(() => {
+        cy.get('.canvas-container').should("have.length", 4);
+      });
 
-        //South West Quardrants
-        dashboard.getGroups().eq(0).within(() => {
-          dashboard.getStudentID(3).should('contain', "S4").click();
-        });
-        dashboard.getZoomedStudentID().should('contain', "Student 4");
-        dashboard.getGroups().eq(0).within(() => {
-          cy.get('.canvas-container').should("have.length", 1);
-        });
-        dashboard.getPlaybackToolBar().should("exist");
-        dashboard.getGroups().eq(0).within(() => {
-          dashboard.getStudentCanvas(".north-west").should("not.exist");
-          dashboard.getStudentCanvas(".north-east").should("not.exist");
-          dashboard.getStudentCanvas(".south-east").should("not.exist");
-        });
-        dashboard.getZoomedStudentID().click();
-        dashboard.getGroups().eq(0).within(() => {
-          cy.get('.canvas-container').should("have.length", 4);
-        });
+      //South West Quardrants
+      dashboard.getGroups().eq(0).within(() => {
+        dashboard.getStudentID(3).should('contain', "S4").click();
+      });
+      dashboard.getZoomedStudentID().should('contain', "Student 4");
+      dashboard.getGroups().eq(0).within(() => {
+        cy.get('.canvas-container').should("have.length", 1);
+      });
+      dashboard.getPlaybackToolBar().should("exist");
+      dashboard.getGroups().eq(0).within(() => {
+        dashboard.getStudentCanvas(".north-west").should("not.exist");
+        dashboard.getStudentCanvas(".north-east").should("not.exist");
+        dashboard.getStudentCanvas(".south-east").should("not.exist");
+      });
+      dashboard.getZoomedStudentID().click();
+      dashboard.getGroups().eq(0).within(() => {
+        cy.get('.canvas-container').should("have.length", 4);
       });
     });
   });
+});

--- a/cypress/e2e/clue/branch/teacher_tests/teacher_network_spec.js
+++ b/cypress/e2e/clue/branch/teacher_tests/teacher_network_spec.js
@@ -9,32 +9,28 @@ let teacherNetwork = new TeacherNetwork;
 const queryParams = "/?appMode=qa&fakeClass=5&fakeOffering=5&problem=2.1&fakeUser=teacher:7&unit=msa";
 
 function beforeTest(params) {
-    cy.clearQAData('all');
+  cy.clearQAData('all');
 
-    cy.visit(queryParams);
-    cy.waitForLoad();
-    dashboard.switchView("Workspace & Resources");
-    cy.wait(2000);
-    clueCanvas.getInvestigationCanvasTitle().text().as('investigationTitle');
+  cy.visit(queryParams);
+  cy.waitForLoad();
+  dashboard.switchView("Workspace & Resources");
+  cy.wait(2000);
+  clueCanvas.getInvestigationCanvasTitle().text().as('investigationTitle');
+  cy.fixture("teacher-dash-data-msa-test.json").as("clueData");
 }
 
 function loadNetworkTest() {
-    cy.visit("/?appMode=qa&fakeClass=5&fakeOffering=5&problem=2.1&fakeUser=teacher:7&unit=msa&network=foo");
-    cy.waitForLoad();
-    dashboard.switchView("Workspace & Resources");
-    cy.wait(2000);
+  cy.visit("/?appMode=qa&fakeClass=5&fakeOffering=5&problem=2.1&fakeUser=teacher:7&unit=msa&network=foo");
+  cy.waitForLoad();
+  dashboard.switchView("Workspace & Resources");
+  cy.wait(2000);
 }
 
 describe('Networked dividers for networked teacher', () => {
-  
-  beforeEach(() => {
-    cy.fixture("teacher-dash-data-msa-test.json").as("clueData");
-  });
-
   it('verify network dividers for teacher in network (via url params)', () => {
     beforeTest(queryParams);
     loadNetworkTest();
-  
+
     cy.log('verify network dividers in \'My Work\' tab for teacher in network');
     cy.openTopTab("my-work");
     cy.openSection('my-work', 'workspaces');

--- a/cypress/e2e/clue/branch/teacher_tests/teacher_tagged_comments_spec.js
+++ b/cypress/e2e/clue/branch/teacher_tests/teacher_tagged_comments_spec.js
@@ -1,0 +1,160 @@
+import ChatPanel from "../../../../support/elements/clue/ChatPanel";
+
+let chatPanel = new ChatPanel;
+
+const queryParams = {
+  teacherQueryParams: "/?appMode=qa&fakeClass=5&fakeOffering=5&problem=2.1&fakeUser=teacher:7&unit=msa",
+  teacher7NetworkQueryParams: "/?appMode=qa&fakeClass=5&fakeOffering=5&problem=2.1&fakeUser=teacher:7&unit=msa&network=foo",
+  teacher8NetworkQueryParams: "/?appMode=qa&fakeClass=5&fakeOffering=5&problem=2.1&fakeUser=teacher:8&unit=msa&network=foo"
+};
+
+function beforeTest(params) {
+  cy.clearQAData('all');
+  cy.visit(params);
+  cy.waitForLoad();
+  cy.openTopTab("problems");
+  chatPanel.getChatPanelToggle().should('exist');
+}
+
+context('Chat Panel', () => {
+  it("Teachers can communicate back and forth in chat panel", () => {
+    cy.log("verify teacher7 can post document and tile comments");
+    beforeTest(queryParams.teacher7NetworkQueryParams);
+    // Teacher 7 document comment
+    cy.openTopTab("problems");
+    cy.openProblemSection("Introduction");
+    chatPanel.getChatPanelToggle().click();
+    chatPanel.verifyProblemCommentClass();
+    cy.wait(2000);
+    chatPanel.addCommentAndVerify("This is a teacher7 document comment");
+    // Teacher 7 tile comment
+    cy.clickProblemResourceTile('introduction');
+    cy.wait(2000);
+    chatPanel.addCommentAndVerify("This is a teacher7 tile comment");
+
+    cy.log("verify teacher8 can open clue chat in the same network");
+    // Open clue chat for Teacher 8
+    beforeTest(queryParams.teacher8NetworkQueryParams);
+    chatPanel.getChatPanelToggle().click();
+
+    cy.log("verify teacher8 can view teacher7's comments and add more comments");
+    // Teacher 8 document comment
+    chatPanel.verifyProblemCommentClass();
+    chatPanel.verifyCommentThreadContains("This is a teacher7 document comment");
+    chatPanel.addCommentAndVerify("This is a teacher8 document comment");
+    // Teacher 8 tile comment
+    cy.clickProblemResourceTile('introduction');
+    cy.wait(2000);
+    chatPanel.verifyCommentThreadContains("This is a teacher7 tile comment");
+    chatPanel.addCommentAndVerify("This is a teacher8 tile comment");
+
+    cy.log("verify reopening teacher7's clue chat in the same network");
+    // Open clue chat for Teacher 7
+    beforeTest(queryParams.teacher7NetworkQueryParams);
+    chatPanel.getChatPanelToggle().click();
+
+    cy.log("verify teacher7 can view teacher8's comments");
+    // Teacher 7 document comment
+    chatPanel.verifyProblemCommentClass();
+    chatPanel.verifyCommentThreadContains("This is a teacher8 document comment");
+    // Teacher 7 tile comment
+    cy.clickProblemResourceTile('introduction');
+    cy.wait(2000);
+    chatPanel.verifyCommentThreadContains("This is a teacher8 tile comment");
+  });
+});
+
+context('Chat Panel Comment Tags', () => {
+  it('verify chat panel comment tags', () => {
+    const tags = [
+      "Select Student Strategy",
+      "Part-to-Part",
+      "Part-to-Whole",
+      "Unit Rate",
+      "Ratios of Same Variable",
+      "Common Part or Whole",
+      "Building Up",
+      "Other - Proportional",
+      "Other - Nonproportional"
+    ];
+    const tagComment = [
+      "This is Part-to-Part tag comment" + Math.random(),
+      "This is Part-to-Whole tag comment" + Math.random(),
+      "This is Unit Rate tag comment" + Math.random(),
+      "This is Ratios of Same Variable tag comment" + Math.random(),
+      "This is Common Part or Whole tag comment" + Math.random(),
+      "This is Building Up tag comment" + Math.random(),
+      "This is Other - Proportional tag comment" + Math.random(),
+      "This is Other - Nonproportional tag comment" + Math.random()
+    ];
+    cy.log('verify chat panel comment tags are accessible if teacher is in network (via url params)');
+    beforeTest(queryParams.teacher7NetworkQueryParams);
+
+    cy.log('verify comment tag dropdown');
+    chatPanel.getChatPanelToggle().click();
+    chatPanel.getChatPanel().should('exist');
+    chatPanel.getCommentTextDropDown().should('exist');
+
+    cy.log('verify comment tag dropdown options');
+    chatPanel.getCommentTextDropDown()
+      .should("contain", tags[0])
+      .should("contain", tags[1])
+      .should("contain", tags[2])
+      .should("contain", tags[3])
+      .should("contain", tags[4])
+      .should("contain", tags[5])
+      .should("contain", tags[6])
+      .should("contain", tags[7])
+      .should("contain", tags[8]);
+
+    cy.log('verify user post only comment tags on document comment');
+    cy.openTopTab("problems");
+    chatPanel.verifyProblemCommentClass();
+    chatPanel.addCommentTagAndVerify(tags[1]);
+    chatPanel.deleteCommentTagThread(tags[1]);
+
+    cy.log('verify user post only comment tags on tile comment');
+    cy.clickProblemResourceTile('introduction');
+    chatPanel.showAndVerifyTileCommentClass(0);
+    chatPanel.addCommentTagAndVerify(tags[2]);
+    chatPanel.deleteCommentTagThread(tags[2]);
+
+    cy.log('verify user post both comment tags and plain text on document comment');
+    cy.openTopTab("problems");
+    cy.openProblemSection("Introduction");
+    chatPanel.verifyProblemCommentClass();
+    chatPanel.addCommentTagTextAndVerify(tags[3], tagComment[2]);
+    chatPanel.deleteCommentTagThread(tags[3]);
+
+    cy.log('verify user post both comment tags and plain text on tile comment');
+    cy.openTopTab("problems");
+    cy.clickProblemResourceTile('introduction');
+    chatPanel.showAndVerifyTileCommentClass(0);
+    chatPanel.addCommentTagTextAndVerify(tags[5], tagComment[4]);
+    chatPanel.deleteCommentTagThread(tags[5]);
+
+    cy.log('verify user post only plain text and comment tag not displayed on document comment');
+    const docComment = "Only plain text and no comment tag document comment";
+    cy.openTopTab("problems");
+    cy.openProblemSection("Introduction");
+    chatPanel.verifyProblemCommentClass();
+    chatPanel.addCommentAndVerify(docComment);
+    chatPanel.verifyCommentTagNotDisplayed(docComment);
+    chatPanel.getDeleteMessageButton(docComment).click({ force: true });
+    chatPanel.getDeleteConfirmModalButton().contains("Delete").click();
+    cy.wait(2000);
+    chatPanel.verifyCommentThreadDoesNotContain(docComment);
+
+    cy.log('verify user post only plain text and comment tag not displayed on tile comment');
+    const tileComment = "Only plain text and no comment tag tile comment";
+    cy.openTopTab("problems");
+    cy.clickProblemResourceTile('introduction');
+    chatPanel.showAndVerifyTileCommentClass(0);
+    chatPanel.addCommentAndVerify(tileComment);
+    chatPanel.verifyCommentTagNotDisplayed(tileComment);
+    chatPanel.getDeleteMessageButton(tileComment).click({ force: true });
+    chatPanel.getDeleteConfirmModalButton().contains("Delete").click();
+    cy.wait(2000);
+    chatPanel.verifyCommentThreadDoesNotContain(tileComment);
+  });
+});

--- a/cypress/e2e/clue/full/student_tests/group_chooser_spec.js
+++ b/cypress/e2e/clue/full/student_tests/group_chooser_spec.js
@@ -4,133 +4,132 @@ import ClueHeader from '../../../../support/elements/clue/cHeader';
 const header = new Header;
 const clueHeader = new ClueHeader;
 
-describe('Test student join a group', function(){
-    let student1 = '20',
-        student2 = '21',
-        student3 = '22',
-        student4 = '23',
-        student5='24',
-        student6='25',
-        fakeClass = '15',
-        problem = '2.2',
-        group1='20',
-        group2='21';
+let student1 = '20',
+  student2 = '21',
+  student3 = '22',
+  student4 = '23',
+  student5 = '24',
+  student6 = '25',
+  fakeClass = '15',
+  problem = '2.2',
+  group1 = '20',
+  group2 = '21';
 
-    before(() => {
-        cy.clearQAData('all');
-    });
+const defaultSetupOptions = {
+  alreadyInGroup: false,
+  problem
+};
 
-    const defaultSetupOptions = {
-        alreadyInGroup: false,
-        problem
-    };
+function beforeTest() {
+  cy.clearQAData('all');
+}
 
-    function setup(student, opts={} ){
-        const options = {...defaultSetupOptions, ...opts};
-        cy.visit('?appMode=qa&fakeClass='+fakeClass+'&fakeUser=student:'+student+'&problem='+options.problem);
-        if (options.alreadyInGroup) {
-          // This is looking for the version div in the header
-          cy.waitForLoad();
-        } else {
-          // If the student is not in a group already the header will not show up
-          // instead only a group chooser dialog is shown. The timeout of 60s is the same
-          // used by waitForLoad and gives the app extra time to load
-          cy.get('.join-title', {timeout: 60000});
-        }
-    }
+function setup(student, opts = {}) {
+  const options = { ...defaultSetupOptions, ...opts };
+  cy.visit('?appMode=qa&fakeClass=' + fakeClass + '&fakeUser=student:' + student + '&problem=' + options.problem);
+  if (options.alreadyInGroup) {
+    // This is looking for the version div in the header
+    cy.waitForLoad();
+  } else {
+    // If the student is not in a group already the header will not show up
+    // instead only a group chooser dialog is shown. The timeout of 60s is the same
+    // used by waitForLoad and gives the app extra time to load
+    cy.get('.join-title', { timeout: 60000 });
+  }
+}
 
-    it('Student 1 will join and will verify Join Group Dialog comes up with welcome message to correct student', function(){
-        setup(student1);
-        cy.get('.app > .join > .join-title').should('contain','Join Group');
-        cy.get('.app > .join > .join-content > .welcome').should('contain','Student ' + student1);
-    });
+context('Test student join a group', function () {
+  it('Test student join a group', function () {
+    beforeTest();
 
-    it('will create a group', function(){
-        //select a group 20 from the dropdown
-        cy.get('select').select('Group ' + group1);
-        cy.get('[value="Create Group"]').click();
-        // cy.wait(1000);
-    });
-    it('will verify student is an specified group', function(){
-        clueHeader.getGroupName().should('contain','Group '+group1);
-        header.getUserName().should('contain','Student '+student1);
-        clueHeader.getGroupMembers().should('contain','S'+student1);
+    cy.log('Student 1 will join and will verify Join Group Dialog comes up with welcome message to correct student');
+    setup(student1);
+    cy.get('.app > .join > .join-title').should('contain', 'Join Group');
+    cy.get('.app > .join > .join-content > .welcome').should('contain', 'Student ' + student1);
 
-    });
-    it('will verify created group is no longer available as a choice in Join Group dialog dropdown', function(){
-        setup(student2);
-        cy.get('.app > .join > .join-title').should('contain','Join Group');
-        cy.get('.app > .join > .join-content > .welcome').should('contain','Student ' +  student2);
-        cy.get('select > option').should('not.contain','Group '+group1);
-    });
-    it('will have another student joining an existing group', function(){
-            //Student2 will join the same group
-        cy.get('.groups > .group-list > .group').contains(group1).click();
-    });
-    it('will verify second student is in existing group', function(){
-        clueHeader.getGroupName().should('contain','Group '+group1);
-        header.getUserName().should('contain','Student '+student2);
-        clueHeader.getGroupMembers().should('contain','S'+student1).and('contain','S'+student2);
-    });
+    cy.log('will create a group');
+    //select a group 20 from the dropdown
+    cy.get('select').select('Group ' + group1);
+    cy.get('[value="Create Group"]').click();
+    // cy.wait(1000);
 
-    it('will will verify that both students are listed in the group in the Join Group group list and will create a new group when a student selects a different group and verify workspace header is correct', function(){
-        setup(student3);
-        cy.get('.groups > .group-list > .group').first().should('contain','Group '+group1).and('contain','S'+student1).and('contain','S'+student2);
-        cy.get('select').select('Group ' + group2);
-        cy.get('[value="Create Group"]').click();
-        clueHeader.getGroupName().should('contain','Group '+group2);
-        header.getUserName().should('contain','Student '+student3);
-        clueHeader.getGroupMembers().should('contain','S'+student3);
-        clueHeader.getGroupMembers().should('not.contain','S'+student2).and('not.contain','S'+student1);
-    });
-    it('will verify no additional students can join group',function(){
-        setup(student4);
-        cy.get('.groups > .group-list > .group').contains(group1).click();
-        clueHeader.getGroupName().should('contain','Group '+group1);
-        header.getUserName().should('contain','Student '+student4);
-        clueHeader.getGroupMembers().should('contain','S'+student1).and('contain','S'+student2).and('contain','S'+student4);
-        setup(student5);
-        cy.get('.groups > .group-list > .group').contains(group1).click();
-        clueHeader.getGroupName().should('contain','Group '+group1);
-        header.getUserName().should('contain','Student '+student5);
-        clueHeader.getGroupMembers().should('contain','S'+student1).and('contain','S'+student2).and('contain','S'+student4).and('contain','S'+student5);
-        setup(student6);
-        cy.get('.groups > .group-list > .group').contains(group1).click();
-        cy.get('.join > .join-content > .error').should('be.visible').and('contain','Sorry, that group is full');
-    });
-    it('will verify cancel of leave group dialog',function(){
-        //have student leave first group and join second group
-        setup(student5, {alreadyInGroup: true});
-        cy.get('.app .group > .name').contains('Group '+group1).click();
-        cy.get('#cancelButton').should('contain','No').click();
-        clueHeader.getGroupName().should('contain','Group '+group1);
-        header.getUserName().should('contain','Student '+student5);
-        clueHeader.getGroupMembers().should('contain','S'+student1).and('contain','S'+student2).and('contain','S'+student4).and('contain','S'+student5);
+    cy.log('will verify student is an specified group');
+    clueHeader.getGroupName().should('contain', 'Group ' + group1);
+    header.getUserName().should('contain', 'Student ' + student1);
+    clueHeader.getGroupMembers().should('contain', 'S' + student1);
 
-    });
-    it('will verify a student can switch groups',function(){
-        //have student leave first group and join second group
-        setup(student5, {alreadyInGroup: true});
-        cy.get('.app .group > .name').contains('Group '+group1).click();
-        cy.get("#okButton").should('contain','Yes').click();
-        cy.get('.groups > .group-list > .group').contains('Group '+group2).click();
-        clueHeader.getGroupName().should('contain','Group '+group2);
-        header.getUserName().should('contain','Student '+student5);
-        clueHeader.getGroupMembers().should('contain','S'+student3).and('contain','S'+student5);
-    });
-    it('will verify new student can join group when one leaves it', function(){
-        //have new student join the first group
-        setup(student6);
-        cy.wait(500);
-        cy.get('.groups > .group-list > .group').contains(group1).click();
-        clueHeader.getGroupName().should('contain','Group '+group1);
-        header.getUserName().should('contain','Student '+student6);
-        clueHeader.getGroupMembers().should('contain','S'+student1).and('contain','S'+student2).and('contain','S'+student4).and('contain','S'+student6);
-    });
-    it('Student will automatically join last group number in new problem', function(){
-        setup(student1, {alreadyInGroup: true, problem: '2.3'});
-        clueHeader.getGroupName().should('contain','Group '+group1);
-        header.getUserName().should('contain','Student '+student1);
-        clueHeader.getGroupMembers().should('contain','S'+student1).and('have.length', 1);
-    });
+    cy.log('will verify created group is no longer available as a choice in Join Group dialog dropdown');
+    setup(student2);
+    cy.get('.app > .join > .join-title').should('contain', 'Join Group');
+    cy.get('.app > .join > .join-content > .welcome').should('contain', 'Student ' + student2);
+    cy.get('select > option').should('not.contain', 'Group ' + group1);
+
+    cy.log('will have another student joining an existing group');
+    //Student2 will join the same group
+    cy.get('.groups > .group-list > .group').contains(group1).click();
+
+    cy.log('will verify second student is in existing group');
+    clueHeader.getGroupName().should('contain', 'Group ' + group1);
+    header.getUserName().should('contain', 'Student ' + student2);
+    clueHeader.getGroupMembers().should('contain', 'S' + student1).and('contain', 'S' + student2);
+
+    cy.log('will verify that both students are listed in the group in the Join Group group list');
+    setup(student3);
+    cy.get('.groups > .group-list > .group').first().should('contain', 'Group ' + group1).and('contain', 'S' + student1).and('contain', 'S' + student2);
+    cy.get('select').select('Group ' + group2);
+    cy.get('[value="Create Group"]').click();
+    clueHeader.getGroupName().should('contain', 'Group ' + group2);
+    header.getUserName().should('contain', 'Student ' + student3);
+    clueHeader.getGroupMembers().should('contain', 'S' + student3);
+    clueHeader.getGroupMembers().should('not.contain', 'S' + student2).and('not.contain', 'S' + student1);
+
+    cy.log('will verify no additional students can join group');
+    setup(student4);
+    cy.get('.groups > .group-list > .group').contains(group1).click();
+    clueHeader.getGroupName().should('contain', 'Group ' + group1);
+    header.getUserName().should('contain', 'Student ' + student4);
+    clueHeader.getGroupMembers().should('contain', 'S' + student1).and('contain', 'S' + student2).and('contain', 'S' + student4);
+    setup(student5);
+    cy.get('.groups > .group-list > .group').contains(group1).click();
+    clueHeader.getGroupName().should('contain', 'Group ' + group1);
+    header.getUserName().should('contain', 'Student ' + student5);
+    clueHeader.getGroupMembers().should('contain', 'S' + student1).and('contain', 'S' + student2).and('contain', 'S' + student4).and('contain', 'S' + student5);
+    setup(student6);
+    cy.get('.groups > .group-list > .group').contains(group1).click();
+    cy.get('.join > .join-content > .error').should('be.visible').and('contain', 'Sorry, that group is full');
+
+    cy.log('will verify cancel of leave group dialog');
+    //have student leave first group and join second group
+    setup(student5, { alreadyInGroup: true });
+    cy.get('.app .group > .name').contains('Group ' + group1).click();
+    cy.get('#cancelButton').should('contain', 'No').click();
+    clueHeader.getGroupName().should('contain', 'Group ' + group1);
+    header.getUserName().should('contain', 'Student ' + student5);
+    clueHeader.getGroupMembers().should('contain', 'S' + student1).and('contain', 'S' + student2).and('contain', 'S' + student4).and('contain', 'S' + student5);
+
+    cy.log('will verify a student can switch groups');
+    //have student leave first group and join second group
+    setup(student5, { alreadyInGroup: true });
+    cy.get('.app .group > .name').contains('Group ' + group1).click();
+    cy.get("#okButton").should('contain', 'Yes').click();
+    cy.get('.groups > .group-list > .group').contains('Group ' + group2).click();
+    clueHeader.getGroupName().should('contain', 'Group ' + group2);
+    header.getUserName().should('contain', 'Student ' + student5);
+    clueHeader.getGroupMembers().should('contain', 'S' + student3).and('contain', 'S' + student5);
+
+    cy.log('will verify new student can join group when one leaves it');
+    //have new student join the first group
+    setup(student6);
+    cy.wait(500);
+    cy.get('.groups > .group-list > .group').contains(group1).click();
+    clueHeader.getGroupName().should('contain', 'Group ' + group1);
+    header.getUserName().should('contain', 'Student ' + student6);
+    clueHeader.getGroupMembers().should('contain', 'S' + student1).and('contain', 'S' + student2).and('contain', 'S' + student4).and('contain', 'S' + student6);
+
+    cy.log('Student will automatically join last group number in new problem');
+    setup(student1, { alreadyInGroup: true, problem: '2.3' });
+    clueHeader.getGroupName().should('contain', 'Group ' + group1);
+    header.getUserName().should('contain', 'Student ' + student1);
+    clueHeader.getGroupMembers().should('contain', 'S' + student1).and('have.length', 1);
+  });
 });

--- a/cypress/e2e/clue/full/teacher_tests/teacher_workspace_spec.js
+++ b/cypress/e2e/clue/full/teacher_tests/teacher_workspace_spec.js
@@ -111,28 +111,27 @@ context.skip("Teacher Workspace", () => {
         let problems = clueData.classes[0].problems;
         let initProblemIndex = 0;
 
-      clueCanvas.publishTeacherDocToMultipleClasses();
-      cy.openResourceTabs();
-      cy.openTopTab("class-work");
-      cy.getCanvasItemTitle('workspaces').contains(problems[initProblemIndex].problemTitle).should('exist');
-      dashboard.getClassDropdown().click({ force: true });
-      dashboard.getClassList().find('.list-item').contains(class2).click({ force: true });
-      cy.waitForLoad();
-      dashboard.switchView('Workspace & Resources');
-      // cy.openResourceTabs();
-      cy.openTopTab("class-work");
-      cy.getCanvasItemTitle('workspaces').contains(problems[initProblemIndex].problemTitle).should('exist');
+        clueCanvas.publishTeacherDocToMultipleClasses();
+        cy.openResourceTabs();
+        cy.openTopTab("class-work");
+        cy.getCanvasItemTitle('workspaces').contains(problems[initProblemIndex].problemTitle).should('exist');
+        dashboard.getClassDropdown().click({ force: true });
+        dashboard.getClassList().find('.list-item').contains(class2).click({ force: true });
+        cy.waitForLoad();
+        dashboard.switchView('Workspace & Resources');
+        // cy.openResourceTabs();
+        cy.openTopTab("class-work");
+        cy.getCanvasItemTitle('workspaces').contains(problems[initProblemIndex].problemTitle).should('exist');
+
+        beforeTest();
+        //switch back to original problem for later test
+        dashboard.getClassDropdown().click({ force: true });
+        dashboard.getClassList().find('.list-item').contains(class1).click({ force: true });
+        cy.waitForLoad();
+        dashboard.switchView('Workspace & Resources');
+        drawToolTile.getDrawTile().should('exist');
+        clueCanvas.deleteTile('draw');
       });
     });
-  });
-  after(function () {
-    beforeTest();
-    //switch back to original problem for later test
-    dashboard.getClassDropdown().click({ force: true });
-    dashboard.getClassList().find('.list-item').contains(class1).click({ force: true });
-    cy.waitForLoad();
-    dashboard.switchView('Workspace & Resources');
-    drawToolTile.getDrawTile().should('exist');
-    clueCanvas.deleteTile('draw');
   });
 });

--- a/cypress/e2e/clue/smoke/single_student_canvas_test.js
+++ b/cypress/e2e/clue/smoke/single_student_canvas_test.js
@@ -14,168 +14,157 @@ let drawToolTile = new DrawToolTile;
 let textToolTile = new TextToolTile;
 let tableToolTile = new TableToolTile;
 
-context('single student functional test',()=>{
-    before(function(){
-            const queryParams = `${Cypress.config("queryParams")}`;
-            cy.clearQAData('all');
-            cy.visit(queryParams);
-            cy.waitForLoad();
-            // cy.wait(4000);
-        clueCanvas.getInvestigationCanvasTitle().text().as('title');
-    });
-    describe('Nav tabs open and close',()=>{
-      it('will verify that clicking on any tab opens the nav area', function () {
-        // cy.get(".resources-expander.my-work").click();
-        cy.openTopTab("my-work");
-        cy.openSection('my-work', "workspaces");
-        cy.get('[data-test=my-work-section-investigations-documents]').should('be.visible');
-      });
-      it('will verify clicking on subtab opens panel to subtab section', function () {
-        const section = "learning-log";
-        cy.openSection('my-work', section);
-        cy.get('[data-test=subtab-learning-log]').should('be.visible');
-        cy.get('.list.'+section+' [data-test='+section+'-list-items] .footer').should('contain', "My First Learning Log");
-      });
-      it('verify click on document thumbnail opens document in nav panel', function () {
-        cy.openDocumentWithTitle('my-work', 'learning-log','My First Learning Log');
-        cy.get('.editable-document-content [data-test=canvas]').should('be.visible');
-        cy.get('.edit-button.learning-log').should('be.visible');
-      });
-      it('verify click on Edit button opens document in main workspace', function () {
-        cy.get('.edit-button.learning-log').click();
-        cy.get('.primary-workspace [data-test=learning-log-title]').should('contain', "Learning Log: My First Learning Log");
-      });
-      it('verify close of nav tabs', function () {
-        cy.collapseResourceTabs();
-        cy.get('.nav-tab-panel').should('not.be.visible');
-      });
+const title = "SAS 2.1 Drawing Wumps";
+
+function beforeTest() {
+  const queryParams = `${Cypress.config("queryParams")}`;
+  cy.clearQAData('all');
+  cy.visit(queryParams);
+  cy.waitForLoad();
+}
+context('single student functional test', () => {
+  it('Nav tabs open and close', () => {
+    beforeTest();
+    cy.log('will verify that clicking on any tab opens the nav area');
+    // cy.get(".resources-expander.my-work").click();
+    cy.openTopTab("my-work");
+    cy.openSection('my-work', "workspaces");
+    cy.get('[data-test=my-work-section-investigations-documents]').should('be.visible');
+
+    cy.log('will verify clicking on subtab opens panel to subtab section');
+    const section = "learning-log";
+    cy.openSection('my-work', section);
+    cy.get('[data-test=subtab-learning-log]').should('be.visible');
+    cy.get('.list.' + section + ' [data-test=' + section + '-list-items] .footer').should('contain', "My First Learning Log");
+
+    cy.log('verify click on document thumbnail opens document in nav panel');
+    cy.openDocumentWithTitle('my-work', 'learning-log', 'My First Learning Log');
+    cy.get('.editable-document-content [data-test=canvas]').should('be.visible');
+    cy.get('.edit-button.learning-log').should('be.visible');
+
+    cy.log('verify click on Edit button opens document in main workspace');
+    cy.get('.edit-button.learning-log').click();
+    cy.get('.primary-workspace [data-test=learning-log-title]').should('contain', "Learning Log: My First Learning Log");
+
+    cy.log('verify close of nav tabs');
+    cy.collapseResourceTabs();
+    cy.get('.nav-tab-panel').should('not.be.visible');
+
+    cy.log('test header elements');
+    cy.openResourceTabs();
+    cy.openTopTab('my-work');
+    cy.openDocumentWithTitle("my-work", "workspaces", title);
+
+    cy.log('verifies views button changes when clicked and shows the correct corresponding workspace view');
+    //1-up view has 4-up button visible and 1-up canvas
+    clueCanvas.getFourUpViewToggle().should('be.visible');
+    canvas.getSingleCanvas().should('be.visible');
+    clueCanvas.getFourUpView().should('not.exist');
+    clueCanvas.openFourUpView();
+    //4-up view is visible and 1-up button is visible
+    clueCanvas.getFourToOneUpViewToggle().should('be.visible');
+    clueCanvas.getNorthEastCanvas().should('be.visible');
+    clueCanvas.getNorthWestCanvas().should('be.visible');
+    clueCanvas.getSouthEastCanvas().should('be.visible');
+    clueCanvas.getSouthEastCanvas().should('be.visible');
+    // canvas.getSingleCanvas().should('not.be.visible');
+
+    //can get back to 1 up view from 4 up
+    clueCanvas.openOneUpViewFromFourUp();
+    canvas.getSingleCanvas().should('be.visible');
+    clueCanvas.getFourUpViewToggle().should('be.visible');
+    clueCanvas.getFourUpView().should('not.exist');
+
+    cy.log('verify share button');
+    clueCanvas.getShareButton().should('be.visible');
+    clueCanvas.getShareButton().should('have.class', 'private');
+    clueCanvas.shareCanvas();
+    clueCanvas.getShareButton().should('be.visible');
+    clueCanvas.getShareButton().should('have.class', 'public');
+    clueCanvas.unshareCanvas();
+    clueCanvas.getShareButton().should('be.visible');
+    clueCanvas.getShareButton().should('have.class', 'private');
+
+    cy.log('verify publish button');
+    canvas.publishCanvas("investigation");
+    canvas.getPublishIcon().should('exist');
+  
+    cy.log('test the tool palette');
+    //This should test the tools in the tool shelf
+    // Tool palettes for Graph, Image, Draw,and Table are tested in respective tool spec test
+    //Selection tool is tested as a functionality of graph tool tiles
+
+    cy.log('adds text tool');
+    clueCanvas.addTile('text');
+    textToolTile.getTextTile().should('exist');
+    textToolTile.enterText('This is a smoke test');
+
+    cy.log('adds a graph tool');
+    clueCanvas.addTile('geometry');
+    graphToolTile.getGraphTile().should('exist');
+    graphToolTile.addPointToGraph(0, 0);
+
+    cy.log('adds an image tool');
+    clueCanvas.addTile('image');
+    imageToolTile.getImageTile().should('exist');
+
+    cy.log('adds a draw tool');
+    clueCanvas.addTile('drawing');
+    drawToolTile.getDrawTile().should('exist');
+
+    cy.log('adds a table tool');
+    clueCanvas.addTile('table');
+    tableToolTile.getTableTile().should('exist');
+
+    cy.log('save and restore of canvas');
+    // let canvas1='Document 1';
+    let canvas2 = 'Document 2';
+
+    // canvas.copyDocument(canvas1);
+    canvas.createNewExtraDocumentFromFileMenu(canvas2, "my-work");
+    canvas.getPersonalDocTitle().should('contain', canvas2);
+    textToolTile.getTextTile().should('not.exist');
+
+    cy.log('will restore from My Work tab');
+    // //open the my work tab, click a different canvas, verify canvas is shown, open the my work tab, click the introduction canvas, verify intro canvas is showing
+    cy.openTopTab('my-work');
+    cy.openSection('my-work', 'workspaces');
+    cy.openDocumentWithTitle('my-work', 'workspaces', title);
+    textToolTile.getTextTile().should('exist');
+    graphToolTile.getGraphTile().first().should('exist');
+    drawToolTile.getDrawTile().should('exist');
+    imageToolTile.getImageTile().should('exist');
+    tableToolTile.getTableTile().should('exist');
+
+    cy.log('verify published canvas thumbnail');
+    cy.openTopTab('class-work');
+    cy.openSection('class-work', 'workspaces');
+    cy.getCanvasItemTitle('workspaces').should('have.length', 1);
+
+    cy.log('verify publish canvas thumbnail appears in Class Work Published List');
+    canvas.publishCanvas("investigation");
+    cy.openTopTab('class-work');
+    cy.openSection('class-work', 'workspaces');
+    cy.getCanvasItemTitle('workspaces').should('have.length', 2);
+    cy.getCanvasItemTitle('workspaces').first().should('contain', 'v2');
+
+    cy.log('verify student name appears under thumbnail');
+    cy.get('[data-test=user-name]').then(($el) => {
+      const user = $el.text();
+      cy.getCanvasItemTitle('workspaces').first().find('.info div').should('contain', user);
     });
 
-    describe('test header elements', function(){
-      before(function(){
-        cy.openResourceTabs();
-        cy.openTopTab('my-work');
-        cy.openDocumentWithTitle("my-work", "workspaces", this.title);
-      });
-        it('verifies views button changes when clicked and shows the correct corresponding workspace view', function(){
-            //1-up view has 4-up button visible and 1-up canvas
-            clueCanvas.getFourUpViewToggle().should('be.visible');
-            canvas.getSingleCanvas().should('be.visible');
-            clueCanvas.getFourUpView().should('not.exist');
-            clueCanvas.openFourUpView();
-            //4-up view is visible and 1-up button is visible
-            clueCanvas.getFourToOneUpViewToggle().should('be.visible');
-            clueCanvas.getNorthEastCanvas().should('be.visible');
-            clueCanvas.getNorthWestCanvas().should('be.visible');
-            clueCanvas.getSouthEastCanvas().should('be.visible');
-            clueCanvas.getSouthEastCanvas().should('be.visible');
-            // canvas.getSingleCanvas().should('not.be.visible');
-
-            //can get back to 1 up view from 4 up
-            clueCanvas.openOneUpViewFromFourUp();
-            canvas.getSingleCanvas().should('be.visible');
-            clueCanvas.getFourUpViewToggle().should('be.visible');
-            clueCanvas.getFourUpView().should('not.exist');
-        });
-
-        it('verify share button', function(){
-            clueCanvas.getShareButton().should('be.visible');
-            clueCanvas.getShareButton().should('have.class','private');
-            clueCanvas.shareCanvas();
-            clueCanvas.getShareButton().should('be.visible');
-            clueCanvas.getShareButton().should('have.class','public');
-            clueCanvas.unshareCanvas();
-            clueCanvas.getShareButton().should('be.visible');
-            clueCanvas.getShareButton().should('have.class','private');
-        });
-        it('verify publish button', function(){
-            canvas.publishCanvas("investigation");
-            canvas.getPublishIcon().should('exist');
-        });
+    cy.log('verify restore of published canvas');
+    cy.openTopTab("class-work");
+    cy.openSection("class-work", "workspaces");
+    cy.get('[data-test=user-name]').then(($el) => {
+      const user = $el.text();
+      cy.getCanvasItemTitle('workspaces', user).first().click();
     });
-    context('test the tool palette', function(){//This should test the tools in the tool shelf
-        // Tool palettes for Graph, Image, Draw,and Table are tested in respective tool spec test
-        //Selection tool is tested as a functionality of graph tool tiles
-
-        it('adds text tool', function(){
-            clueCanvas.addTile('text');
-            textToolTile.getTextTile().should('exist');
-            textToolTile.enterText('This is a smoke test');
-        });
-        it('adds a graph tool', function(){
-            clueCanvas.addTile('geometry');
-            graphToolTile.getGraphTile().should('exist');
-            graphToolTile.addPointToGraph(0,0);
-        });
-        it('adds an image tool', function(){
-            clueCanvas.addTile('image');
-            imageToolTile.getImageTile().should('exist');
-        });
-        it('adds a draw tool', function(){
-            clueCanvas.addTile('drawing');
-            drawToolTile.getDrawTile().should('exist');
-        });
-        it('adds a table tool', function(){
-            clueCanvas.addTile('table');
-            tableToolTile.getTableTile().should('exist');
-        });
-    });
-    context('save and restore of canvas', function(){
-        // let canvas1='Document 1';
-        let canvas2='Document 2';
-        before(function(){ //Open a different document to see if original document is restored
-            // canvas.copyDocument(canvas1);
-            canvas.createNewExtraDocumentFromFileMenu(canvas2, "my-work");
-            canvas.getPersonalDocTitle().should('contain', canvas2);
-            textToolTile.getTextTile().should('not.exist');
-        });
-        describe('verify that canvas is saved from various locations', function(){
-            it('will restore from My Work tab', function() {
-                // //open the my work tab, click a different canvas, verify canvas is shown, open the my work tab, click the introduction canvas, verify intro canvas is showing
-
-                cy.openTopTab('my-work');
-                cy.openSection('my-work', 'workspaces');
-                cy.openDocumentWithTitle('my-work', 'workspaces', this.title );
-                textToolTile.getTextTile().should('exist');
-                graphToolTile.getGraphTile().first().should('exist');
-                drawToolTile.getDrawTile().should('exist');
-                imageToolTile.getImageTile().should('exist');
-                tableToolTile.getTableTile().should('exist');
-            });
-        });
-        // TODO: Class Work changed with new feature changes.
-        describe('publish canvas', ()=>{
-            it('verify published canvas thumbnail', () => {
-              cy.openTopTab('class-work');
-              cy.openSection('class-work','workspaces');
-              cy.getCanvasItemTitle('workspaces').should('have.length',1);
-            });
-            it('verify publish canvas thumbnail appears in Class Work Published List',()=>{
-                canvas.publishCanvas("investigation");
-                cy.openTopTab('class-work');
-                cy.openSection('class-work','workspaces');
-                cy.getCanvasItemTitle('workspaces').should('have.length',2);
-                cy.getCanvasItemTitle('workspaces').first().should('contain', 'v2');
-            });
-            it('verify student name appears under thumbnail',()=>{
-                cy.get('[data-test=user-name]').then(($el)=>{
-                    const user = $el.text();
-                    cy.getCanvasItemTitle('workspaces').first().find('.info div').should('contain',user);
-                });
-            } );
-            it('verify restore of published canvas', ()=>{
-              cy.openTopTab("class-work");
-              cy.openSection("class-work", "workspaces");
-                cy.get('[data-test=user-name]').then(($el)=>{
-                    const user = $el.text();
-                    cy.getCanvasItemTitle('workspaces', user).first().click();
-                });
-                cy.get(".document-tabs.class-work .documents-panel .canvas-area").find('.text-tool').should('exist').and('contain','This is a smoke test');
-                cy.get(".document-tabs.class-work .documents-panel .canvas-area").find('.geometry-content').should('exist');
-                cy.get(".document-tabs.class-work .documents-panel .canvas-area").find('.drawing-tool').should('exist');
-                cy.get(".document-tabs.class-work .documents-panel .canvas-area").find('.image-tool').should('exist');
-                cy.get(".document-tabs.class-work .documents-panel .canvas-area").find('.table-tool-tile').should('exist');
-            });
-        });
-    });
+    cy.get(".document-tabs.class-work .documents-panel .canvas-area").find('.text-tool').should('exist').and('contain', 'This is a smoke test');
+    cy.get(".document-tabs.class-work .documents-panel .canvas-area").find('.geometry-content').should('exist');
+    cy.get(".document-tabs.class-work .documents-panel .canvas-area").find('.drawing-tool').should('exist');
+    cy.get(".document-tabs.class-work .documents-panel .canvas-area").find('.image-tool').should('exist');
+    cy.get(".document-tabs.class-work .documents-panel .canvas-area").find('.table-tool-tile').should('exist');
+  });
 });

--- a/cypress/e2e/common/header_test_spec.js
+++ b/cypress/e2e/common/header_test_spec.js
@@ -2,32 +2,32 @@ import Header from '../../support/elements/common/Header';
 
 const header = new Header;
 
-context('Test header elements',()=>{
-  before(function(){
-    const baseUrl = `${Cypress.config("baseUrl")}`;
-    const queryParams = `${Cypress.config("queryParams")}`;
-    cy.clearQAData('all');
-    cy.visit(baseUrl+queryParams);
-    cy.waitForLoad();
-  });
+function beforeTest() {
+  const baseUrl = `${Cypress.config("baseUrl")}`;
+  const queryParams = `${Cypress.config("queryParams")}`;
+  cy.clearQAData('all');
+  cy.visit(baseUrl + queryParams);
+  cy.waitForLoad();
+}
 
-  describe('Test header UI',()=>{
-    it('verify correct information is in header elements',()=>{
-      cy.location('search').then((queryParam)=>{
-        const params = (queryParam.split('&'));
-        let headerInfoObj = {};
-        params.forEach((param)=>{
-          let query = (param.split("="));
-          headerInfoObj[query[0]] = query[1];
-        });
-        header.getVersionNumber().should('exist');
-        header.getClassName().should('exist').and('contain', headerInfoObj.fakeClass);
-        header.getUnitTitle().should('exist').and('contain', "Stretching and Shrinking");
-        header.getInvestigationTitle().should('exist').and('contain', 'The Mug Wump Family');
-        header.getProblemTitle().should('exist').and('contain', headerInfoObj.problem);
-        header.getUserName().should('exist').and('contain', ((headerInfoObj.fakeUser).split(":"))[1]);
-        header.getGroupNumber().should('exist').and('contain', headerInfoObj.qaGroup);
+context('Test header elements', () => {
+  it('verify correct information is in header elements', () => {
+    beforeTest();
+
+    cy.location('search').then((queryParam) => {
+      const params = (queryParam.split('&'));
+      let headerInfoObj = {};
+      params.forEach((param) => {
+        let query = (param.split("="));
+        headerInfoObj[query[0]] = query[1];
       });
+      header.getVersionNumber().should('exist');
+      header.getClassName().should('exist').and('contain', headerInfoObj.fakeClass);
+      header.getUnitTitle().should('exist').and('contain', "Stretching and Shrinking");
+      header.getInvestigationTitle().should('exist').and('contain', 'The Mug Wump Family');
+      header.getProblemTitle().should('exist').and('contain', headerInfoObj.problem);
+      header.getUserName().should('exist').and('contain', ((headerInfoObj.fakeUser).split(":"))[1]);
+      header.getGroupNumber().should('exist').and('contain', headerInfoObj.qaGroup);
     });
   });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -24,40 +24,13 @@
 // -- This is will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 import '@testing-library/cypress/add-commands';
-import ClueHeader from './elements/clue/cHeader';
 import PrimaryWorkspace from './elements/common/PrimaryWorkspace';
 import Canvas from './elements/common/Canvas';
 import TeacherDashboard from "./elements/clue/TeacherDashboard";
 import 'cypress-file-upload';
 import 'cypress-commands';
 import ResourcesPanel from "./elements/clue/ResourcesPanel";
-import ClueCanvas from './elements/clue/cCanvas';
 import {platformCmdKey} from '../../src/utilities/hot-keys';
-
-const clueCanvas = new ClueCanvas;
-
-Cypress.Commands.add("setupGroup", (students, group) => {
-    let qaClass = 10,
-        problem = 2.3;
-
-    let header = new ClueHeader;
-    let i=0, j=0;
-
-    for (i=0;i<students.length;i++) {
-        cy.visit('?appMode=qa&qaGroup='+group+'&fakeClass='+qaClass+'&fakeUser=student:'+students[i]+'&problem='+problem);
-        // These checks are here to make sure the workspace has loaded enough to create
-        // the student
-        cy.waitForLoad();
-        header.getGroupName().should('contain','Group '+group);
-        header.getGroupMembers().find('div.member').should('contain','S'+students[i]);
-        clueCanvas.shareCanvas();
-    }
-    // Verify Group num and the correct 4 students are listed, now that all 4 are loaded
-    header.getGroupName().should('contain','Group '+group);
-    for (j=0; j<students.length; j++) {
-        header.getGroupMembers().find('div.member').should('contain','S'+students[j]);
-    }
-});
 
 Cypress.Commands.add("uploadFile",(selector, filename, type="")=>{
     // cy.fixture(filename).as("image");

--- a/cypress/support/elements/clue/cCanvas.js
+++ b/cypress/support/elements/clue/cCanvas.js
@@ -119,11 +119,11 @@ class ClueCanvas {
     }
 
     shareCanvas() {
-        this.getShareButton().click();
+        this.getShareButton().click({force:true});
     }
 
     unshareCanvas() {
-        this.getShareButton().click();
+        this.getShareButton().click({force:true});
     }
 
     getToolPalette() {


### PR DESCRIPTION
Following are the changes made in this PR:
- Reduced number of tests and consolidated tests into larger ones. This was already for some tests in the past. But there were others for which this wasn't done.
- All of the cypress tests in CLUE should now be independent. This makes it possible for upgrading to Cypress 13 so we can leverage the test replay functionality that this upgrade offers.
- Fixed a few failing tests mainly group_test_spec.js which was timing out/crashing for various reasons. I split it into two sepaarate spec files (to take advantage of parallelization) and removed a lot of unnecessary clue `visit` calls that were slowing the test down and had no purpose except to have a common `before` method.
- I also split the teacher_chat_spec.js into two spec files since it was flaky and too long. It is probably still a little flaky and I can add a future story to make improvements on it and lessen the time.
- Added three of the newer spec files into the manual_regression.yml so we can run them individually on custom branches if/when we want.
- Changed the schedule of regression-daily.yml so they run in the midnight and we have the results available first thing in the morning.

The overall test results count is down to `87` (excluding the `10` skipped tests) from `395` (plus `25` skipped) tests. This should, hopefully, alleviate the issues with us running out of test results in the dashboard and add room to write more tests.
But we'll need to also be careful about the way we write tests. Many of us are in the habit of writing smaller dependent tests and continuing that this will only bring back the problems that this PR tries to resolve.