### PR TITLE
fix: graph axis menus after resizing earlier rows

### DIFF
--- a/src/plugins/data-card/components/case-attribute.tsx
+++ b/src/plugins/data-card/components/case-attribute.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { observer } from "mobx-react";
 import classNames from "classnames";
 import { useCombobox } from "downshift";
@@ -61,7 +61,7 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
   const editingLabel = currEditFacet === "name" && currEditAttrId === attrKey;
   const editingValue = currEditFacet === "value" && currEditAttrId === attrKey;
 
-  const validCompletions = (aValues: string[], prefixString: string) => {
+  const validCompletions = useCallback((aValues: string[], prefixString: string) => {
     const prefixStringLC = prefixString.toLowerCase();
     const values = uniq(aValues).sort();
     if (editingValue && valueCandidate.length > 0){
@@ -74,7 +74,7 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
         return value && typeof(value)==='string' && !isImageUrl(value);
       }) as string[];
     }
-  };
+  }, [editingValue, valueCandidate.length]);
 
   const {
     isOpen,
@@ -101,7 +101,7 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
     const attrValues = content.dataSet.attrFromID(attrKey)?.values || [];
     const completions = validCompletions(attrValues as string[], valueCandidate);
     setInputItems(completions);
-  }, [content.dataSet, attrKey, valueCandidate]);
+  }, [content.dataSet, attrKey, valueCandidate, validCompletions]);
 
   // reset contents of input when attribute value changes without direct user input
   // (when it is deleted by toolbar or the underlying case has changed )
@@ -219,8 +219,8 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
     }
   };
 
-  function deleteAttribute(){
-    if(attrKey){
+  function deleteAttribute() {
+    if (attrKey){
       content.dataSet.removeAttribute(attrKey);
     }
   }

--- a/src/plugins/graph/components/simple-attribute-label.tsx
+++ b/src/plugins/graph/components/simple-attribute-label.tsx
@@ -1,5 +1,4 @@
 import React, { useContext, useState} from "react";
-import {createPortal} from "react-dom";
 import {observer} from "mobx-react-lite";
 import {GraphPlace } from "../imports/components/axis-graph-shared";
 import {AttributeType} from "../../../models/data/attribute";
@@ -28,6 +27,7 @@ export const SimpleAttributeLabel = observer(
     const { place, index, attrId, onTreatAttributeAs, onRemoveAttribute, onChangeAttribute } = props;
     // Must be State, not Ref, so that the menu gets re-rendered when this becomes non-null
     const [simpleLabelElement, setSimpleLabelElement] = useState<HTMLDivElement|null>(null);
+    const documentElt = simpleLabelElement?.closest('.document-content') as HTMLDivElement ?? null;
     const graphElement = simpleLabelElement?.closest(kGraphClassSelector) as HTMLDivElement ?? null;
     const dataConfiguration = useDataConfigurationContext();
     const dataset = dataConfiguration?.dataset;
@@ -58,16 +58,17 @@ export const SimpleAttributeLabel = observer(
         </div>
         {!readOnly && simpleLabelElement && graphElement && onChangeAttribute
             && onTreatAttributeAs && onRemoveAttribute && attrId &&
-          createPortal(<AxisOrLegendAttributeMenu
+          <AxisOrLegendAttributeMenu
             target={simpleLabelElement}
-            portal={graphElement}
+            parent={graphElement}
+            portal={documentElt}
             place={place}
             attributeId={attrId}
             onChangeAttribute={onChangeAttribute}
             onRemoveAttribute={onRemoveAttribute}
             onTreatAttributeAs={onTreatAttributeAs}
             onOpenClose={handleOpenClose}
-          />, graphElement)
+          />
         }
       </>
     );

--- a/src/plugins/graph/imports/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/src/plugins/graph/imports/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -102,11 +102,10 @@ export const AxisOrLegendAttributeMenu = ({ place, attributeId, target, parent, 
                       </MenuItem>
                     }
                     { data?.attributes?.map((attr, idx) => {
-                      //only show y attr that is not self, not the x axis, and not an already plotted Y
-                      const isCurrent = attr.id === attributeId;
-                      const isXAxis = (idx === 0);
-                      const isAPlottedYAttribute = yAttributesPlotted?.includes(attr.id);
-                      const showAttr = (!isCurrent && !isXAxis && !isAPlottedYAttribute);
+                      const isCurrent = attr.id === attrId;
+                      const isPlottedX = dataConfig?.attributeID("x") === attr.id;
+                      const isPlottedY = yAttributesPlotted?.includes(attr.id);
+                      const showAttr = (!isCurrent && !isPlottedX && !isPlottedY);
 
                       return showAttr && (
                         <MenuItem onClick={() => onChangeAttribute(place, data, attr.id, attrId)} key={attr.id}>

--- a/src/plugins/graph/imports/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/src/plugins/graph/imports/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -101,7 +101,7 @@ export const AxisOrLegendAttributeMenu = ({ place, attributeId, target, parent, 
                         Link Data
                       </MenuItem>
                     }
-                    { data?.attributes?.map((attr, idx) => {
+                    { data?.attributes?.map((attr) => {
                       const isCurrent = attr.id === attrId;
                       const isPlottedX = dataConfig?.attributeID("x") === attr.id;
                       const isPlottedY = yAttributesPlotted?.includes(attr.id);

--- a/src/plugins/graph/imports/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/src/plugins/graph/imports/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -54,7 +54,7 @@ export const AxisOrLegendAttributeMenu = ({ place, attributeId, target, parent, 
   parentRef.current = parent;
   const portalRef = useRef(portal);
   portalRef.current = portal;
-  const menuRef = useRef<HTMLDivElement>(null);
+  const menuListRef = useRef<HTMLDivElement>(null);
   const showRemoveOption = true; // Used to be a setting; for now we always want it available.
 
   const onCloseRef = useRef<() => void>();
@@ -70,7 +70,7 @@ export const AxisOrLegendAttributeMenu = ({ place, attributeId, target, parent, 
   };
   const { attributes, listeners, setNodeRef: setDragNodeRef } = useDraggableAttribute(draggableOptions);
 
-  useOutsidePointerDown({ref: menuRef, handler: () => onCloseRef.current?.()});
+  useOutsidePointerDown({ref: menuListRef, handler: () => onCloseRef.current?.()});
 
   useEffect(() => {
     dataConfig?.onAction(action => {
@@ -85,7 +85,7 @@ export const AxisOrLegendAttributeMenu = ({ place, attributeId, target, parent, 
   }, [attribute?.name, data?.attributes, dataConfig, labelText, setLabelText, attrId]);
 
   return (
-    <div className={`axis-legend-attribute-menu ${place}`} ref={menuRef}>
+    <div className={`axis-legend-attribute-menu ${place}`} >
       <Menu boundary="scrollParent">
         {({ onClose, isOpen }) => {
           onOpenClose && onOpenClose(isOpen);
@@ -95,7 +95,7 @@ export const AxisOrLegendAttributeMenu = ({ place, attributeId, target, parent, 
               <div ref={setDragNodeRef} style={overlayStyle} {...attributes} {...listeners}>
                 <MenuButton style={buttonStyle}>{attribute?.name}</MenuButton>
                 <Portal containerRef={portalRef}>
-                  <MenuList>
+                  <MenuList ref={menuListRef}>
                     { !data &&
                       <MenuItem className="inactive">
                         Link Data


### PR DESCRIPTION
Fixes: first issue of [[#186234669]](https://www.pivotaltracker.com/story/show/186234669)

The bug was caused by previous rows (above the row with the graph) resizing. The bug occurred because the button used to trigger the menu was being rendered relative to the document rather than to the tile. This, in turn, was because the component was being portaled to the document so that the displayed menu wouldn't be clipped by the tile. The fix is to separately portal the button that triggers the menu (relative to the tile) and the displayed menu itself (relative to the document).