### PR TITLE
Avoid toolbar overflow and extra buttons

### DIFF
--- a/cypress/support/elements/clue/cCanvas.js
+++ b/cypress/support/elements/clue/cCanvas.js
@@ -396,7 +396,7 @@ class ClueCanvas {
      */
     clickToolbarButton(tileType, buttonName) {
       cy.document().within(() => {
-        cy.get(`.tile-toolbar.${tileType}-toolbar .toolbar-button.${buttonName}`)
+        cy.get(`[data-test=canvas] .tile-toolbar.${tileType}-toolbar .toolbar-button.${buttonName}`)
           .should('have.length', 1)
           .should('not.be.disabled')
           .click();

--- a/src/components/toolbar/tile-toolbar.tsx
+++ b/src/components/toolbar/tile-toolbar.tsx
@@ -33,12 +33,11 @@ export function isValidButtonDescription(obj: JSONValue): obj is IButtonDescript
 export const TileToolbar = observer(
   function TileToolbar({ tileType, readOnly, tileElement }: ToolbarWrapperProps) {
 
-
     const model = useContext(TileModelContext);
     const id = model?.id;
 
     // Get styles to position the toolbar
-    const { toolbarRefs, toolbarStyles, toolbarPlacement } = useTileToolbarPositioning(tileElement);
+    const { toolbarRefs, toolbarStyles, toolbarPlacement, rootElement, hide } = useTileToolbarPositioning(tileElement);
 
     // Determine the buttons to be shown.
     const ui = useUIStore();
@@ -86,11 +85,11 @@ export const TileToolbar = observer(
     });
 
     return (
-      <FloatingPortal>
+      <FloatingPortal root={rootElement}>
         <div
           ref={toolbarRefs.setFloating}
           data-testid="tile-toolbar"
-          style={toolbarStyles}
+          style={{visibility: hide ? 'hidden' : 'visible', ...toolbarStyles}}
           className={classNames("tile-toolbar",
             `${tileType}-toolbar`,
             toolbarPlacement,

--- a/src/components/toolbar/use-tile-toolbar-positioning.tsx
+++ b/src/components/toolbar/use-tile-toolbar-positioning.tsx
@@ -1,23 +1,29 @@
-import { useFloating, autoUpdate, offset, flip, shift } from "@floating-ui/react";
+import { useFloating, autoUpdate, offset, flip, shift, hide } from "@floating-ui/react";
 
 import "./toolbar.scss";
 
 export function useTileToolbarPositioning(tileElement: HTMLElement|null) {
 
-  const canvas = tileElement?.closest('.canvas') || 'clippingAncestors';
+  const canvasElement = tileElement?.closest('.canvas') as HTMLElement|| undefined;
+  const boundary = canvasElement || 'clippingAncestors';
 
-  const { refs, placement, floatingStyles } = useFloating({
+  const { refs, placement, floatingStyles, middlewareData } = useFloating({
     open: true,
     placement: "bottom-start",
     whileElementsMounted: autoUpdate,
-    // Offset accounts for margin width. Shift and flip keep toolbar in the viewport.
+    // "offset" middleware accounts for margin width.
+    // "shift" and "flip" keep toolbar in the viewport.
+    // "hide" tells us not to display the toolbar if the active element has scrolled out of view.
     middleware: [offset({ mainAxis: -2}),
-      flip({mainAxis: true, crossAxis: true, fallbackStrategy: 'initialPlacement', boundary: canvas}),
-      shift({crossAxis: true})],
+      flip({mainAxis: true, crossAxis: true, fallbackStrategy: 'initialPlacement', boundary}),
+      shift({crossAxis: true}),
+      hide()
+    ],
     elements: {
       reference: tileElement
     }
   });
 
-  return { toolbarRefs: refs, toolbarStyles: floatingStyles, toolbarPlacement: placement };
+  return { toolbarRefs: refs, toolbarStyles: floatingStyles, toolbarPlacement: placement, rootElement: canvasElement,
+    hide: middlewareData.hide?.referenceHidden };
 }

--- a/src/models/stores/configuration-manager.test.ts
+++ b/src/models/stores/configuration-manager.test.ts
@@ -67,6 +67,38 @@ describe("ConfigurationManager", () => {
     settings: {}
   } as UnitConfiguration;
 
+  const baseSettings: Partial<UnitConfiguration> = {
+    settings: {
+      table: {
+        numFormat: ".2~f",
+        tools: [
+          "set-expression",
+          "link-tile",
+          ["data-set-view", "DataCard"],
+         ]
+        }
+    }
+  };
+
+  const unitSettings: Partial<UnitConfiguration> = {
+    settings: {
+      table: {
+        tools: [
+          "delete"
+         ]
+      }
+    }
+  };
+
+  const mergedSettings = {
+    table: {
+      numFormat: ".2~f",
+      tools: [
+        "delete"
+        ]
+      }
+  };
+
   const keys = Object.keys(defaults) as Array<keyof typeof defaults>;
 
   it("can be constructed with just defaults and return those defaults", () => {
@@ -88,4 +120,10 @@ describe("ConfigurationManager", () => {
       }
     });
   });
+
+  it("merges settings", () => {
+    const config = new ConfigurationManager(defaults, [baseSettings, unitSettings]);
+    expect(config.settings).toEqual(mergedSettings);
+  });
+
 });

--- a/src/models/stores/configuration-manager.ts
+++ b/src/models/stores/configuration-manager.ts
@@ -1,4 +1,4 @@
-import { merge } from "lodash";
+import { assign, assignWith } from "lodash";
 import { UnitConfiguration } from "./unit-configuration";
 
 type UC = UnitConfiguration;
@@ -177,8 +177,12 @@ export class ConfigurationManager implements UnitConfiguration {
 
   get settings(): UC["settings"]  {
     // settings are merged rather than simply returning the closest non-empty value
+    // merge is just two levels deep: eg merges items under settings.table, but not elements of settings.table.tools
     const reverseSettings = [...this.configs].reverse().map(config => config.settings);
-    return merge({}, this.defaults.settings, ...reverseSettings);
+    return assignWith({}, this.defaults.settings, ...reverseSettings,
+      (objValue: any, srcValue: any) => {
+        return assign({}, objValue, srcValue);
+      });
   }
 }
 


### PR DESCRIPTION
Followup work for PT-186143201.

Fix settings merge so that keys inside settings.table from base app config and unit, lesson configs will still be merged, lists of toolbar buttons will not attempt to be merged (only the more specific config that is defined will be used).

Moved toolbars floating elements to be inside the document "canvas", and add "hide" middleware that makes sure the toolbar is hidden when the tile it is attached to is scrolled out of view.