### PR TITLE
co-teachers can view documents, history, comments

### DIFF
--- a/firebase-test/src/setup-rules-tests.ts
+++ b/firebase-test/src/setup-rules-tests.ts
@@ -14,18 +14,28 @@ export const studentAuth = { uid: studentId, platform_user_id: studentIdNumeric,
 export const student2IdNumeric = 2;
 export const student2Id = `${student2IdNumeric}`;
 export const student2Auth = { uid: student2Id, platform_user_id: student2IdNumeric, user_type: "student", class_hash: otherClass };
+
 export const teacherIdNumeric = 11;
 export const teacherId = `${teacherIdNumeric}`;
 export const teacherName = "Jane Teacher";
 export const teacherAuth = { uid: teacherId, platform_user_id: teacherIdNumeric, user_type: "teacher", class_hash: thisClass };
+
 export const teacher2IdNumeric = 12;
 export const teacher2Id = `${teacher2IdNumeric}`;
 export const teacher2Name = "John Teacher";
 export const teacher2Auth = { uid: teacher2Id, platform_user_id: teacher2IdNumeric, user_type: "teacher", class_hash: otherClass };
+
 export const teacher3IdNumeric = 13;
 export const teacher3Id = `${teacher3IdNumeric}`;
 export const teacher3Name = "Jade Teacher";
 export const teacher3Auth = { uid: teacher3Id, platform_user_id: teacher3IdNumeric, user_type: "teacher", class_hash: lastClass };
+
+// Co-teacher of teacher's class
+export const teacher4IdNumeric = 14;
+export const teacher4Id = `${teacher4IdNumeric}`;
+export const teacher4Name = "Joe Teacher";
+export const teacher4Auth = { uid: teacher4Id, platform_user_id: teacher4IdNumeric, user_type: "teacher", class_hash: thisClass };
+
 export const offeringIdNumeric = 2000;
 export const offeringId = `${offeringIdNumeric}`;
 export const noNetwork = null;

--- a/firestore.rules
+++ b/firestore.rules
@@ -153,6 +153,11 @@ service cloud.firestore {
         return resource.data.network in getTeacherNetworks();
       }
 
+      // user's class_hash must be the requested document's context_id
+      function resourceInUserClass() {
+        return request.auth.token.class_hash == resource.data.context_id;
+      }
+
       match /users/{userId} {
         // teachers can read their own user documents or other teachers in the same network
         allow read: if isAuthedTeacher() &&
@@ -294,14 +299,11 @@ service cloud.firestore {
         // teachers can only delete their own documents
         allow delete: if isAuthedTeacher() && userIsResourceUser();
         // teachers can read their own documents or other documents in their network
-        allow read: if  (isAuthed() && (resource == null || userOwnsDocument())) || (isAuthedTeacher() && (userInResourceTeachers() || resourceInTeacherNetworks()));
+        allow read: if (isAuthed() && (resource == null || userOwnsDocument())) ||
+          (isAuthedTeacher() && (userInResourceTeachers() || resourceInTeacherNetworks() || resourceInUserClass()))
 
         function getDocumentData() {
           return get(/databases/$(database)/documents/authed/$(portal)/documents/$(docId)).data;
-        }
-        // return the list of teachers associated with the specified document
-        function getDocumentTeachers() {
-          return getDocumentData().teachers;
         }
 
         // return owner of the parent document
@@ -314,20 +316,32 @@ service cloud.firestore {
           return getDocumentData().network;
         }
 
-        // check whether the current teacher is one of the teachers associated with the document
-        function teacherInDocumentTeachers() {
-          return isAuthedTeacher() && (string(request.auth.token.platform_user_id) in getDocumentTeachers());
-        }
-
-        // check whether the document's network corresponds to one of the teacher's networks
-        function documentInTeacherNetworks() {
-          let docNetwork = getDocumentNetwork();
-          return exists(docNetwork) && (docNetwork in getTeacherNetworks());
+        // Note: some of this logic seems redundant with the functions used above:
+        // userInResourceTeachers, resourceInTeacherNetworks, resourceInUserClass.
+        // However there is a important difference.
+        // This function works with the doc that is the parent of the comments or history. While those other
+        // functions work with the actual resource/document being requested.
+        // So `userInResourceTeachers` would fail if used on a comment request because it would be
+        // looking for teachers in the comment document itself. And the logic in this function would
+        // probably be inefficient for a top level document request becuase it would do an additional lookup
+        // to retrieve the data from the document, when the system already had access the document in
+        // `resource.data`.
+        function userCanAccessDocument() {
+          let docData = getDocumentData();
+          let docNetwork = docData.network;
+          return (
+            // check whether the current user is one of the teachers associated with the document
+            string(request.auth.token.platform_user_id) in docData.teachers ||
+            // check whether the document's network corresponds to one of the users's networks
+            exists(docNetwork) && (docNetwork in getTeacherNetworks()) ||
+            // check if document is in user's class
+            request.auth.token.class_hash == docData.context_id
+          );
         }
 
         // check whether the teacher can access the document
         function teacherCanAccessDocument() {
-          return teacherInDocumentTeachers() || documentInTeacherNetworks();
+          return isAuthedTeacher() && userCanAccessDocument();
         }
 
         function isValidCommentCreateRequest() {
@@ -346,30 +360,30 @@ service cloud.firestore {
         function isValidCommentUpdateRequest() {
           return userIsRequestUser() && preservesReadOnlyCommentFields();
         }
-        
+
         function userOwnsDocument() {
           return getDocumentOwner() == string(request.auth.token.platform_user_id);
         }
         match /comments/{commentId} {
           // portal-authenticated teachers with access to the document can create valid comments
-          allow create: if isAuthedTeacher() && teacherCanAccessDocument() && isValidCommentCreateRequest();
+          allow create: if teacherCanAccessDocument() && isValidCommentCreateRequest();
           // teachers can only update their own comments and only if they're valid
-          allow update: if isAuthedTeacher() && teacherCanAccessDocument() && isValidCommentUpdateRequest();
+          allow update: if teacherCanAccessDocument() && isValidCommentUpdateRequest();
           // teachers can only delete their own comments
-          allow delete: if isAuthedTeacher() && teacherCanAccessDocument() && userIsResourceUser();
+          allow delete: if teacherCanAccessDocument() && userIsResourceUser();
           // only teachers that "own" the document can read the comments (for now)
-          allow read: if isAuthedTeacher() && teacherCanAccessDocument();
+          allow read: if teacherCanAccessDocument();
         }
-        
+
         // For writing individual history entries
         match /history/{entryId} {
           allow create: if isAuthed() && userOwnsDocument();
-          allow read: if (isAuthed() && userOwnsDocument()) || (isAuthedTeacher() && teacherCanAccessDocument());
+          allow read: if (isAuthed() && userOwnsDocument()) || teacherCanAccessDocument();
           allow delete: if false;
           allow update: if false;
         }
       }
-      
+
       match /mcsupports/{docId} {
         // portal-authenticated teachers can create valid supports
         allow create: if isAuthedTeacher() && isValidSupportCreateRequest();

--- a/firestore.rules
+++ b/firestore.rules
@@ -318,7 +318,7 @@ service cloud.firestore {
 
         // Note: some of this logic seems redundant with the functions used above:
         // userInResourceTeachers, resourceInTeacherNetworks, resourceInUserClass.
-        // However there is a important difference.
+        // However there is an important difference.
         // This function works with the doc that is the parent of the comments or history. While those other
         // functions work with the actual resource/document being requested.
         // So `userInResourceTeachers` would fail if used on a comment request because it would be


### PR DESCRIPTION
This uses the class_hash in the current user's token and compares it with the context_id in the document. 
The list of teachers in the documents is not updated when a co-teacher is added to the class, so this approach seems better. 

It would be better if the use of the list of teachers on a document was removed from these rules to keep them more simple. However there might be a use case which requires that. I can't think of one. Since it isn't currently possible to test these rules on QA before deploying them, it seems best to stay conservative and continue supporting both.