### PR TITLE
186170880 Attribute Highlighting

### DIFF
--- a/cypress/e2e/clue/branch/student_tests/graph_table_integraton_test_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/graph_table_integraton_test_spec.js
@@ -29,7 +29,9 @@ context('Graph Table Integration', function () {
     beforeTest();
     clueCanvas.addTile('table');
     cy.get(".primary-workspace").within((workspace) => {
-      tableToolTile.getTableCell().eq(1).click().type(x[0] + '{enter}');
+      tableToolTile.getTableCell().eq(1).click();
+      tableToolTile.getTableCell().eq(1).click();
+      tableToolTile.getTableCell().eq(1).type(x[0] + '{enter}');
       tableToolTile.getTableCell().eq(2).click();
       tableToolTile.getTableCell().eq(2).type(y[0] + '{enter}');
       tableToolTile.getTableCell().eq(5).click();
@@ -179,7 +181,7 @@ context('Graph Table Integration', function () {
     tableToolTile.getTableCell().eq(3).should('contain', x[1]);
   });
 
-  it("Dragging to copy linked tiles", () => {
+  it.only("Dragging to copy linked tiles", () => {
     beforeTest();
 
     const dataTransfer = new DataTransfer;
@@ -187,7 +189,9 @@ context('Graph Table Integration', function () {
     // Set up and link table and geometry tile
     clueCanvas.addTile('table');
     cy.get(".primary-workspace").within((workspace) => {
-      tableToolTile.getTableCell().eq(1).click().type(x[0] + '{enter}');
+      tableToolTile.getTableCell().eq(1).click();
+      tableToolTile.getTableCell().eq(1).click();
+      tableToolTile.getTableCell().eq(1).type(x[0] + '{enter}');
       tableToolTile.getTableCell().eq(2).click();
       tableToolTile.getTableCell().eq(2).type(y[0] + '{enter}');
       tableToolTile.getTableCell().eq(5).click();
@@ -231,10 +235,13 @@ context('Graph Table Integration', function () {
 
     // Add a new point to the table
     cy.get(".primary-workspace").within((workspace) => {
-      tableToolTile.getTableCell().eq(9).click().click();
+      tableToolTile.getTableCell().eq(9).click();
       tableToolTile.getTableCell().eq(9).type(x[2] + '{enter}');
       tableToolTile.getTableCell().eq(10).click();
       tableToolTile.getTableCell().eq(10).type(y[2] + '{enter}');
+      // The first .type here stopped working, so we have to do it twice.
+      tableToolTile.getTableCell().eq(9).click();
+      tableToolTile.getTableCell().eq(9).type(x[2] + '{enter}');
       tableToolTile.getTableCell().eq(13).click();
     });
 

--- a/cypress/e2e/clue/branch/student_tests/graph_table_integraton_test_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/graph_table_integraton_test_spec.js
@@ -181,7 +181,7 @@ context('Graph Table Integration', function () {
     tableToolTile.getTableCell().eq(3).should('contain', x[1]);
   });
 
-  it.only("Dragging to copy linked tiles", () => {
+  it("Dragging to copy linked tiles", () => {
     beforeTest();
 
     const dataTransfer = new DataTransfer;

--- a/cypress/e2e/clue/branch/student_tests/shared_dataset_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/shared_dataset_spec.js
@@ -72,15 +72,36 @@ context('Shared Dataset', function () {
       tableTile.getTableCell().eq(5).click();
       datacardTile.getNavPanel().should("have.text", "Card 2 of 3");
 
+      cy.log("All Tiles Highlight Attributes Selected In Table");
+      tableTile.getTableRow().eq(1).should("have.class", "highlighted");
+      tableTile.getSelectedColumnHeaders().should("have.length", 0);
+      datacardTile.getAttrName().eq(0).should("not.have.class", "highlighted");
+      tableTile.getColumnHeader().eq(0).click();
+      tableTile.getSelectedColumnHeaders().should("have.length", 1);
+      datacardTile.getAttrName().eq(0).should("have.class", "highlighted");
+      // Selecting a column should deselect all rows
+      tableTile.getTableRow().eq(1).should("not.have.class", "highlighted");
+      // TODO: Synchronous attribute highlighting in xy plots
+
       cy.log("All Tiles Highlight Cases Selected In Datacard");
-      xyTile.getTile().click(); // Deselect all cases
       tableTile.getTableRow().eq(0).should("not.have.class", "highlighted");
+      // TODO: The xy plot is not set up for attribute selection so I'm commenting out these lines for now
       // TODO: It would be better to check which dot is highlighted, rather than counting how many are highlighted
-      xyTile.getHighlightedDot().should("not.exist");
+      // xyTile.getHighlightedDot().should("not.exist");
       datacardTile.getPreviousCardButton().click();
       datacardTile.getNavPanel().click("left");
       tableTile.getTableRow().eq(0).should("have.class", "highlighted");
-      xyTile.getHighlightedDot().should("have.length", 1);
+      // xyTile.getHighlightedDot().should("have.length", 1);
+      // Selecting a case should deselect all attributes
+      datacardTile.getAttrName().eq(0).should("not.have.class", "highlighted");
+
+      cy.log("All Tiles Highlight Attributes Selected In Datacard");
+      tableTile.getSelectedColumnHeaders().should("have.length", 0);
+      datacardTile.getAttrName().eq(0).click();
+      datacardTile.getAttrName().eq(0).should("have.class", "highlighted");
+      tableTile.getSelectedColumnHeaders().should("have.length", 1);
+      // Selecting an attribute should deselect all cases
+      datacardTile.getNavPanel().should("not.have.class", "highlighted");
 
       cy.log("All Tiles Highlight Cases Selected In XY Plot");
       xyTile.getTile().click(); // Deselect all cases
@@ -92,7 +113,7 @@ context('Shared Dataset', function () {
       datacardTile.getNavPanel().should("have.class", "highlighted");
       datacardTile.getAttrValueCell().eq(0).should("have.class", "highlighted");
 
-      cy.log("Datacard Sort View Highlights Correctly And Can Change Highlight");
+      cy.log("Datacard Sort View Highlights Cases Correctly And Can Change Case Highlight");
       tableTile.getTableRow().eq(0).should("have.class", "highlighted");
       tableTile.getTableRow().eq(1).should("not.have.class", "highlighted");
       datacardTile.getSortSelect().select("x");
@@ -103,6 +124,15 @@ context('Shared Dataset', function () {
       datacardTile.getSortCardHeading().eq(1).should("have.class", "highlighted");
       tableTile.getTableRow().eq(0).should("not.have.class", "highlighted");
       tableTile.getTableRow().eq(1).should("have.class", "highlighted");
+
+      cy.log("Datacard Sort View Highlights Attributes Correctly And Can Change Attribute Highlight");
+      datacardTile.getSortCardAttributes().eq(0).should("not.have.class", "highlighted");
+      tableTile.getSelectedColumnHeaders().should("have.length", 0);
+      datacardTile.getSortCardAttributes().eq(0).click();
+      datacardTile.getSortCardAttributes().eq(0).should("have.class", "highlighted");
+      datacardTile.getSortCardHeading().eq(1).should("not.have.class", "highlighted");
+      tableTile.getTableRow().eq(1).should("not.have.class", "highlighted");
+      tableTile.getSelectedColumnHeaders().should("have.length", 1);
     });
   });
 });

--- a/cypress/support/elements/clue/DataCardToolTile.js
+++ b/cypress/support/elements/clue/DataCardToolTile.js
@@ -68,12 +68,18 @@ class DataCardToolTile {
   getPreviousCardButton(tileIndex = 0, workspaceClass){
     return this.getTile(tileIndex, workspaceClass).find(`.card-nav.previous`);
   }
+  getSortCards(tileIndex = 0, workspaceClass) {
+    return this.getTile(tileIndex, workspaceClass).find(`.sortable.card`);
+  }
   getSortCardHeading(tileIndex = 0, workspaceClass){
     return this.getTile(tileIndex, workspaceClass).find(`.sortable .heading`);
   }
   getSortCardCollapseToggle(tileIndex = 0, workspaceClass){
     const selector = ".expand-toggle-area button.expand-toggle";
     return this.getTile(tileIndex, workspaceClass).find(`${selector}`);
+  }
+  getSortCardAttributes(card = 0, tileIndex = 0, workspaceClass){
+    return this.getSortCards(tileIndex, workspaceClass).eq(card).find(`.attribute`);
   }
   getSortCardData(tileIndex = 0, workspaceClass){
     const selector = ".sortable.expanded .attribute-value-row";

--- a/cypress/support/elements/clue/TableToolTile.js
+++ b/cypress/support/elements/clue/TableToolTile.js
@@ -1,9 +1,13 @@
+function wsclass(workspaceClass) {
+  return workspaceClass || ".primary-workspace";
+}
+
 class TableToolTile{
     getTableTile(workspaceClass) {
-        return cy.get(`${workspaceClass || ".primary-workspace"} .canvas-area .table-tool`);
+        return cy.get(`${wsclass(workspaceClass)} .canvas-area .table-tool`);
     }
     getTableTitle(workspaceClass){
-      return cy.get(`${workspaceClass || ".primary-workspace"} .canvas-area .table-title`);
+      return cy.get(`${wsclass(workspaceClass)} .canvas-area .table-title`);
     }
     getAddColumnButton(){
       return cy.get('.add-column-button');
@@ -12,13 +16,16 @@ class TableToolTile{
       return cy.get('.remove-column-button');
     }
     getIndexNumberToggle(workspaceClass){
-      return cy.get(`${workspaceClass || ".primary-workspace"} .show-hide-row-labels-button`);
+      return cy.get(`${wsclass(workspaceClass)} .show-hide-row-labels-button`);
     }
     getRemoveRowButton(){
         return cy.get('[data-test=remove-row-button]');
     }
     getColumnHeader(){
       return cy.get('.column-header-cell .editable-header-cell');
+    }
+    getSelectedColumnHeaders(workspaceClass) {
+      return cy.get(`${wsclass(workspaceClass)} .selected-column .column-header-cell`);
     }
     getWorkspaceColumnHeader(){
       return cy.get('.primary-workspace .column-header-cell .editable-header-cell');

--- a/src/components/tiles/table/table-tile.scss
+++ b/src/components/tiles/table/table-tile.scss
@@ -141,10 +141,10 @@ $controls-hover-background: #c0dfe7;
       .rdg-cell {
         border-top: $border-style;
         &.selected-column {
-          background-color: $highlight-blue-new;
+          background-color: $highlight-unlinked-header;
 
           &.linked {
-            background-color: $highlight-green;
+            background-color: $highlight-linked-header;
           }
         }
         &.rdg-cell-editing {
@@ -186,10 +186,10 @@ $controls-hover-background: #c0dfe7;
     .rdg-row {
       &.rdg-row-selected {
         .index-column {
-          background-color: $highlight-blue-new;
+          background-color: $highlight-unlinked-header;
 
           &.linked {
-            background-color: $highlight-green;
+            background-color: $highlight-linked-header;
           }
         }
         .has-expression {
@@ -203,27 +203,27 @@ $controls-hover-background: #c0dfe7;
       }
       &.highlighted {
         .rdg-cell {
-          background-color: $highlight-blue-light-new;
+          background-color: $highlight-unlinked-cell;
 
           &.controls-column {
             background-color: white;
           }
 
           &.index-column {
-            background-color: $highlight-blue-new;
+            background-color: $highlight-unlinked-header;
           }
         }
 
         &.linked {
           .rdg-cell {
-            background-color: $highlight-green-light;
+            background-color: $highlight-linked-cell;
 
             &.controls-column {
               background-color: white;
             }
 
             &.index-column {
-              background-color: $highlight-green;
+              background-color: $highlight-linked-header;
             }
           }
         }
@@ -295,10 +295,10 @@ $controls-hover-background: #c0dfe7;
         background-color: $charcoal-light-5;
       }
       &.selected-column {
-        background-color: $highlight-blue-light-new;
+        background-color: $highlight-unlinked-cell;
 
         &.linked {
-          background-color: $highlight-green-light;
+          background-color: $highlight-linked-cell;
         }
       }
       &.rdg-cell-resizable {

--- a/src/components/tiles/table/table-tile.scss
+++ b/src/components/tiles/table/table-tile.scss
@@ -143,8 +143,18 @@ $controls-hover-background: #c0dfe7;
         &.selected-column {
           background-color: $highlight-unlinked-header;
 
+          .rdg-text-editor {
+            background-color: white;
+            border: none;
+            box-shadow: inset 0 0 0 3px $highlight-unlinked-edit;
+          }
+
           &.linked {
             background-color: $highlight-linked-header;
+
+            .rdg-text-editor {
+              box-shadow: inset 0 0 0 3px $highlight-linked-edit;
+            }
           }
         }
         &.rdg-cell-editing {

--- a/src/components/tiles/table/table-tile.scss
+++ b/src/components/tiles/table/table-tile.scss
@@ -141,7 +141,11 @@ $controls-hover-background: #c0dfe7;
       .rdg-cell {
         border-top: $border-style;
         &.selected-column {
-          background-color: var(--header-selected-background-color);
+          background-color: $highlight-blue-new;
+
+          &.linked {
+            background-color: $highlight-green;
+          }
         }
         &.rdg-cell-editing {
           padding: 0;
@@ -183,7 +187,11 @@ $controls-hover-background: #c0dfe7;
       &.rdg-row-selected {
         background-color: var(--row-selected-background-color);
         .index-column {
-          background-color: var(--header-selected-background-color);
+          background-color: $highlight-blue-new;
+
+          &.linked {
+            background-color: $highlight-green;
+          }
         }
         .has-expression {
           background-color: var(--row-selected-background-color);
@@ -288,7 +296,11 @@ $controls-hover-background: #c0dfe7;
         background-color: $charcoal-light-5;
       }
       &.selected-column {
-        background-color: var(--row-selected-background-color);
+        background-color: $highlight-blue-light-new;
+
+        &.linked {
+          background-color: $highlight-green-light;
+        }
       }
       &.rdg-cell-resizable {
         padding: 0;

--- a/src/components/tiles/table/table-tile.scss
+++ b/src/components/tiles/table/table-tile.scss
@@ -185,7 +185,6 @@ $controls-hover-background: #c0dfe7;
     }
     .rdg-row {
       &.rdg-row-selected {
-        background-color: var(--row-selected-background-color);
         .index-column {
           background-color: $highlight-blue-new;
 

--- a/src/components/tiles/table/table-tile.tsx
+++ b/src/components/tiles/table/table-tile.tsx
@@ -23,10 +23,8 @@ import { useToolApi } from "./use-tile-api";
 import { useRowHeight } from "./use-row-height";
 import { useRowsFromDataSet } from "./use-rows-from-data-set";
 import { useCurrent } from "../../../hooks/use-current";
-import { lightenColor } from "../../../utilities/color-utils";
 import { verifyAlive } from "../../../utilities/mst-utils";
 import { gImageMap } from "../../../models/image-map";
-import { getColorMapEntry } from "../../../models/shared/shared-data-set-colors";
 import { TileToolbar } from "../../toolbar/tile-toolbar";
 import { TableToolbarContext } from "./table-toolbar-context";
 
@@ -78,6 +76,7 @@ const TableToolComponent: React.FC<ITileProps> = observer(function TableToolComp
   const {
     ref: gridRef, gridContext, inputRowId, selectedCell, getSelectedRows, ...gridProps
   } = useGridContext({ content, modelId: model.id, showRowLabels, triggerColumnChange, triggerRowChange });
+  const selectedCaseIds = getSelectedRows();
 
   // Maintains the cache of data values that map to image URLs.
   // For use in a synchronous context, returns undefined immediately if an image is not yet cached,
@@ -107,7 +106,7 @@ const TableToolComponent: React.FC<ITileProps> = observer(function TableToolComp
   // rowProps are expanded and passed to ReactDataGrid
   const { rows, ...rowProps } = useRowsFromDataSet({
     dataSet, isLinked, readOnly: !!readOnly, inputRowId: inputRowId.current,
-    rowChanges, context: gridContext});
+    rowChanges, context: gridContext, selectedCaseIds });
 
   // columns are required by ReactDataGrid and are used by other hooks as well
   const { columns, controlsColumn, columnEditingName, handleSetColumnEditingName } = useColumnsFromDataSet({
@@ -177,9 +176,6 @@ const TableToolComponent: React.FC<ITileProps> = observer(function TableToolComp
     gridRef, model, dataSet, triggerColumnChange, rows, rowChanges, triggerRowChange,
     readOnly: !!readOnly, changeHandlers, columns, onColumnResize, selectedCell, inputRowId, lookupImage });
 
-  const colorMapEntry = getColorMapEntry(model.id);
-  const linkColors = colorMapEntry?.colorSet;
-
   const containerRef = useRef<HTMLDivElement>(null);
   const handleBackgroundClick = (e: React.MouseEvent<HTMLDivElement>) => {
     // clear any selection on background click
@@ -194,11 +190,11 @@ const TableToolComponent: React.FC<ITileProps> = observer(function TableToolComp
   });
 
   useEffect(() => {
-    if (containerRef.current && linkColors) {
+    if (containerRef.current) {
       // override the CSS variables controlling selection color for linked tables
       const dataGrid = containerRef.current.getElementsByClassName("rdg")[0] as HTMLDivElement | undefined;
-      dataGrid?.style.setProperty("--header-selected-background-color", lightenColor(linkColors.stroke));
-      dataGrid?.style.setProperty("--row-selected-background-color", lightenColor(linkColors.fill));
+      dataGrid?.style.setProperty("--header-selected-background-color", "rgba(0,0,0,0)");
+      dataGrid?.style.setProperty("--row-selected-background-color", "rgba(0,0,0,0)");
     }
   });
 
@@ -245,7 +241,7 @@ const TableToolComponent: React.FC<ITileProps> = observer(function TableToolComp
           titleCellHeight={getTitleHeight()}
           onBeginEdit={onBeginTitleEdit}
           onEndEdit={onEndTitleEdit} />
-        <ReactDataGrid ref={gridRef} selectedRows={getSelectedRows()} rows={rows} rowHeight={rowHeight}
+        <ReactDataGrid ref={gridRef} selectedRows={selectedCaseIds} rows={rows} rowHeight={rowHeight}
           headerRowHeight={headerRowHeight()} columns={columns} {...gridProps} {...gridModelProps}
           {...dataGridProps} {...rowProps} />
       </div>

--- a/src/components/tiles/table/table-tile.tsx
+++ b/src/components/tiles/table/table-tile.tsx
@@ -111,7 +111,7 @@ const TableToolComponent: React.FC<ITileProps> = observer(function TableToolComp
 
   // columns are required by ReactDataGrid and are used by other hooks as well
   const { columns, controlsColumn, columnEditingName, handleSetColumnEditingName } = useColumnsFromDataSet({
-    gridContext, dataSet, metadata, readOnly: !!readOnly, columnChanges, headerHeight, rowHeight,
+    gridContext, dataSet, isLinked, metadata, readOnly: !!readOnly, columnChanges, headerHeight, rowHeight,
     ...rowLabelProps, measureColumnWidth, lookupImage});
 
   // The size of the title bar

--- a/src/components/tiles/table/use-column-extensions.ts
+++ b/src/components/tiles/table/use-column-extensions.ts
@@ -33,10 +33,10 @@ export const useColumnExtensions = ({
                     metadata.rawExpressions.get(column.key),
                     metadata.expressions.get(column.key) || "",
                     xName),
-      onBeginHeaderCellEdit: (() => {
-        gridContext.onClearSelection();
+      onBeginHeaderCellEdit: () => {
         !readOnly && setColumnEditingName(column);
-      }) as any,
+        return undefined;
+      },
       onHeaderCellEditKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => {
         switch (e.key) {
           case "Tab": {

--- a/src/components/tiles/table/use-columns-from-data-set.ts
+++ b/src/components/tiles/table/use-columns-from-data-set.ts
@@ -40,11 +40,12 @@ export const useColumnsFromDataSet = ({
       linked: isLinked,
       "selected-column": gridContext.isColumnSelected(attrId)
     };
+    dataSet.selectedAttributeIds; // eslint-disable-line no-unused-expressions
     return {
       cellClass: classNames({ "has-expression": metadata.hasExpression(attrId), ...selectedColumnClass }),
       headerCellClass: classNames({ "rdg-cell-editing": columnEditingName === attrId, ...selectedColumnClass })
     };
-  }, [columnEditingName, gridContext, isLinked, metadata]);
+  }, [columnEditingName, dataSet.selectedAttributeIds, gridContext, isLinked, metadata]);
 
   // controlsColumn is specified separate from the other columns because its headerRenderer and formatter
   // cannot be defined yet, so they must be attached in a later hook.

--- a/src/components/tiles/table/use-columns-from-data-set.ts
+++ b/src/components/tiles/table/use-columns-from-data-set.ts
@@ -13,6 +13,7 @@ import {
 interface IUseColumnsFromDataSet {
   gridContext: IGridContext;
   dataSet: IDataSet;
+  isLinked?: boolean;
   metadata: TableMetadataModelType;
   readOnly?: boolean;
   columnChanges: number;
@@ -24,8 +25,8 @@ interface IUseColumnsFromDataSet {
   lookupImage: (value: string) => string|undefined;
 }
 export const useColumnsFromDataSet = ({
-  gridContext, dataSet, metadata, readOnly, columnChanges, headerHeight, rowHeight, RowLabelHeader, RowLabelFormatter,
-  measureColumnWidth, lookupImage
+  gridContext, dataSet, isLinked, metadata, readOnly, columnChanges, headerHeight, rowHeight,
+  RowLabelHeader, RowLabelFormatter, measureColumnWidth, lookupImage
 }: IUseColumnsFromDataSet) => {
   const { attributes } = dataSet;
 
@@ -35,12 +36,15 @@ export const useColumnsFromDataSet = ({
   };
 
   const cellClasses = useCallback((attrId: string) => {
-    const selectedColumnClass = { "selected-column": gridContext.isColumnSelected(attrId) };
+    const selectedColumnClass = {
+      linked: isLinked,
+      "selected-column": gridContext.isColumnSelected(attrId)
+    };
     return {
       cellClass: classNames({ "has-expression": metadata.hasExpression(attrId), ...selectedColumnClass }),
       headerCellClass: classNames({ "rdg-cell-editing": columnEditingName === attrId, ...selectedColumnClass })
     };
-  }, [columnEditingName, gridContext, metadata]);
+  }, [columnEditingName, gridContext, isLinked, metadata]);
 
   // controlsColumn is specified separate from the other columns because its headerRenderer and formatter
   // cannot be defined yet, so they must be attached in a later hook.

--- a/src/components/tiles/table/use-grid-context.ts
+++ b/src/components/tiles/table/use-grid-context.ts
@@ -35,8 +35,8 @@ export const useGridContext = ({ content, modelId, showRowLabels, triggerColumnC
   const sharedSelection = useSharedSelectionStore();
   const getSelectedRows = useCallback(() => {
     // this is suitable for passing into ReactDataGrid
-    const { selection } = dataSet;
-    const dataSetSelection = Array.from(selection);
+    const { caseSelection } = dataSet;
+    const dataSetSelection = Array.from(caseSelection);
     const ssSelection = Array.from(sharedSelection.getSelected(modelId));
     ssSelection.forEach(s => {
       if (!dataSetSelection.includes(s)) dataSetSelection.push(s);
@@ -45,7 +45,7 @@ export const useGridContext = ({ content, modelId, showRowLabels, triggerColumnC
   }, [dataSet, modelId, sharedSelection]);
 
   const clearRowSelection = useCallback(() => {
-    dataSet.selectAll(false);
+    dataSet.selectAllCases(false);
     sharedSelection.clear(modelId);
   }, [dataSet, modelId, sharedSelection]);
   const clearColumnSelection = useCallback(() => setSelectedColumns(new Set([])), []);

--- a/src/components/tiles/table/use-grid-context.ts
+++ b/src/components/tiles/table/use-grid-context.ts
@@ -1,6 +1,5 @@
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { CellNavigationMode, DataGridHandle } from "react-data-grid";
-import { useCurrent } from "../../../hooks/use-current";
 import { useSharedSelectionStore } from "../../../hooks/use-stores";
 import { TableContentModelType } from "../../../models/tiles/table/table-content";
 import { uniqueId } from "../../../utilities/js-utils";
@@ -21,13 +20,8 @@ export const useGridContext = ({ content, modelId, showRowLabels, triggerColumnC
   // this tracks ReactDataGrid's notion of the selected cell
   const selectedCell = useRef<TPosition>({ rowIdx: -1, idx: -1 });
   const isSelectedCellInRow = useCallback((rowIdx: number) => selectedCell.current.rowIdx === rowIdx, []);
-  // local since ReactDataGrid doesn't have a notion of column selection
-  const [selectedColumns, setSelectedColumns] = useState(new Set<string>());
-  const selectedColumnsRef = useCurrent(selectedColumns);
-  // we use a Set to eventually support multiple selected columns, but
-  // currently the API constrains to a single selected column.
-  const isColumnSelected = useCallback((columnId: string) =>
-                            selectedColumnsRef.current.has(columnId), [selectedColumnsRef]);
+  const isColumnSelected = useCallback((columnId: string) => dataSet.isAttributeSelected(columnId),
+    [dataSet]);
   // TODO Remove the sharedSelection.
   // There should just be a single selection mechanism, and it should be the one in the dataSet.
   // However, sharedSelection is still in the code to maintain legacy shared highlighting between
@@ -48,7 +42,7 @@ export const useGridContext = ({ content, modelId, showRowLabels, triggerColumnC
     dataSet.selectAllCases(false);
     sharedSelection.clear(modelId);
   }, [dataSet, modelId, sharedSelection]);
-  const clearColumnSelection = useCallback(() => setSelectedColumns(new Set([])), []);
+  const clearColumnSelection = useCallback(() => dataSet.selectAllAttributes(false), [dataSet]);
   const clearCellSelection = useCallback(() => gridRef.current?.selectCell({ idx: -1, rowIdx: -1 }), []);
 
   // clears all selection by default; options can be used to preserve particular forms of selection
@@ -61,9 +55,9 @@ export const useGridContext = ({ content, modelId, showRowLabels, triggerColumnC
 
   const selectColumn = useCallback((columnId: string) => {
     clearSelection({ column: false });
-    setSelectedColumns(new Set([columnId]));
+    dataSet.setSelectedAttributes([columnId]);
     triggerColumnChange();
-  }, [clearSelection, triggerColumnChange]);
+  }, [clearSelection, dataSet, triggerColumnChange]);
 
   const selectRowById = useCallback((rowId: string, select: boolean) => {
     const actuallySelectRowById = () => {

--- a/src/components/tiles/table/use-rows-from-data-set.ts
+++ b/src/components/tiles/table/use-rows-from-data-set.ts
@@ -10,6 +10,7 @@ interface IUseRowsFromDataSet {
   inputRowId: string;
   rowChanges: number;
   context: IGridContext;
+  selectedCaseIds: Set<React.Key>;
 }
 
 const canonicalize = (dataSet: IDataSet, row: TRow) => {
@@ -26,14 +27,16 @@ const canonicalize = (dataSet: IDataSet, row: TRow) => {
 };
 
 export const useRowsFromDataSet = ({
-  dataSet, isLinked, readOnly, inputRowId, rowChanges, context
+  dataSet, isLinked, readOnly, inputRowId, rowChanges, context, selectedCaseIds
 }: IUseRowsFromDataSet) => {
   return useMemo(() => {
     const rowKeyGetter = (row: TRow) => row.__id__;
     const rowClass = (row: TRow) => {
       const rowId = row.__id__;
       return classNames({
-        highlighted: dataSet.isCaseSelected(rowId),
+        // TODO: When we remove sharedSelection, we should use dataSet.isCaseSelected instead
+        highlighted: Array.from(selectedCaseIds).includes(rowId),
+        // highlighted: dataSet.isCaseSelected(rowId),
         "input-row": rowId === inputRowId,
         linked: isLinked
       });
@@ -46,5 +49,5 @@ export const useRowsFromDataSet = ({
     !readOnly && rows.push(canonicalize(dataSet, { __id__: inputRowId, __context__: context }));
     rowChanges; // eslint-disable-line no-unused-expressions
     return { rows, rowKeyGetter, rowClass };
-  }, [context, dataSet, inputRowId, isLinked, readOnly, rowChanges]);
+  }, [context, dataSet, inputRowId, isLinked, readOnly, rowChanges, selectedCaseIds]);
 };

--- a/src/components/vars.sass
+++ b/src/components/vars.sass
@@ -328,12 +328,14 @@ $highlight-blue: #0081ff
 $highlight-blue-50: #80c0ff     // $highlight-blue @ 50% opacity
 $highlight-blue-25: #c0e0ff     // $highlight-blue @ 25% opacity
 $highlight-blue-50-35: #c3efff  // $highlight-blue-50 @ 35% opacity
-$highlight-green: #92ecc9
-$highlight-green-light: #cffae8
-$highlight-green-edit: #71f1a5
-$highlight-blue-new: #8bbff3
-$highlight-blue-light-new: #c4defc
-$highlight-blue-edit-new: #377ff7
+
+// Colors for synchronous highlighting of shared datasets
+$highlight-linked-header: #92ecc9
+$highlight-linked-cell: #cffae8
+$highlight-linked-edit: #71f1a5
+$highlight-unlinked-header: #8bbff3
+$highlight-unlinked-cell: #c4defc
+$highlight-unlinked-edit: #377ff7
 
 $document-select-green: #98ffd0
 $document-select-blue: #98ebff

--- a/src/components/vars.sass
+++ b/src/components/vars.sass
@@ -330,8 +330,10 @@ $highlight-blue-25: #c0e0ff     // $highlight-blue @ 25% opacity
 $highlight-blue-50-35: #c3efff  // $highlight-blue-50 @ 35% opacity
 $highlight-green: #92ecc9
 $highlight-green-light: #cffae8
+$highlight-green-edit: #71f1a5
 $highlight-blue-new: #8bbff3
 $highlight-blue-light-new: #c4defc
+$highlight-blue-edit-new: #377ff7
 
 $document-select-green: #98ffd0
 $document-select-blue: #98ebff

--- a/src/models/data/data-set.ts
+++ b/src/models/data/data-set.ts
@@ -637,8 +637,8 @@ export const DataSet = types.model("DataSet", {
       },
 
       selectAllAttributes(select = true) {
+        self.caseSelection.clear();
         if (select) {
-          clearAllSelections();
           self.attributes.forEach(attribute => self.attributeSelection.add(attribute.id));
         } else {
           self.attributeSelection.clear();
@@ -646,8 +646,8 @@ export const DataSet = types.model("DataSet", {
       },
 
       selectAllCases(select = true) {
+        self.attributeSelection.clear();
         if (select) {
-          clearAllSelections();
           self.cases.forEach(({__id__}) => self.caseSelection.add(__id__));
         }
         else {
@@ -656,9 +656,9 @@ export const DataSet = types.model("DataSet", {
       },
 
       selectAttributes(attributeIds: string[], select = true) {
+        if (select) self.caseSelection.clear();
         attributeIds.forEach(id => {
           if (select) {
-            self.caseSelection.clear();
             self.attributeSelection.add(id);
           } else {
             self.attributeSelection.delete(id);
@@ -667,6 +667,7 @@ export const DataSet = types.model("DataSet", {
       },
 
       selectCases(caseIds: string[], select = true) {
+        if (select) self.attributeSelection.clear();
         const ids: string[] = [];
         caseIds.forEach(id => {
           const pseudoCase = self.pseudoCaseMap[id];
@@ -678,7 +679,6 @@ export const DataSet = types.model("DataSet", {
         });
         ids.forEach(id => {
           if (select) {
-            self.attributeSelection.clear();
             self.caseSelection.add(id);
           }
           else {

--- a/src/models/data/data-set.ts
+++ b/src/models/data/data-set.ts
@@ -46,7 +46,7 @@ export const DataSet = types.model("DataSet", {
 })
 .volatile(self => ({
   // MobX-observable set of selected case IDs
-  selection: observable.set<string>(),
+  caseSelection: observable.set<string>(),
   // map from pseudo-case ID to the CaseGroup it represents
   pseudoCaseMap: {} as Record<string, CaseGroup>,
   transactionCount: 0
@@ -100,7 +100,7 @@ export const DataSet = types.model("DataSet", {
 })
 .views(self => ({
   get selectedCaseIds() {
-    return Array.from(self.selection);
+    return Array.from(self.caseSelection);
   }
 }))
 .extend(self => {
@@ -364,8 +364,8 @@ export const DataSet = types.model("DataSet", {
         // a pseudo-case is selected if all of its individual cases are selected
         const group = self.pseudoCaseMap[caseId];
         return group
-                ? group.childCaseIds.every(id => self.selection.has(id))
-                : self.selection.has(caseId);
+                ? group.childCaseIds.every(id => self.caseSelection.has(id))
+                : self.caseSelection.has(caseId);
       },
       get firstSelectedCaseId() {
         if (self.selectedCaseIds.length > 0) return self.selectedCaseIds[0];
@@ -374,7 +374,7 @@ export const DataSet = types.model("DataSet", {
         return self.selectedCaseIds.join(", ");
       },
       get isAnyCaseSelected() {
-        return self.selection.size > 0;
+        return self.caseSelection.size > 0;
       },
       get isInTransaction() {
         return self.transactionCount > 0;
@@ -620,12 +620,12 @@ export const DataSet = types.model("DataSet", {
         });
       },
 
-      selectAll(select = true) {
+      selectAllCases(select = true) {
         if (select) {
-          self.cases.forEach(({__id__}) => self.selection.add(__id__));
+          self.cases.forEach(({__id__}) => self.caseSelection.add(__id__));
         }
         else {
-          self.selection.clear();
+          self.caseSelection.clear();
         }
       },
 
@@ -641,10 +641,10 @@ export const DataSet = types.model("DataSet", {
         });
         ids.forEach(id => {
           if (select) {
-            self.selection.add(id);
+            self.caseSelection.add(id);
           }
           else {
-            self.selection.delete(id);
+            self.caseSelection.delete(id);
           }
         });
       },
@@ -659,7 +659,7 @@ export const DataSet = types.model("DataSet", {
             ids.push(id);
           }
         });
-        self.selection.replace(ids);
+        self.caseSelection.replace(ids);
       },
 
       addActionListener(key: string, listener: (action: ISerializedActionCall) => void) {

--- a/src/models/data/data-set.ts
+++ b/src/models/data/data-set.ts
@@ -238,6 +238,11 @@ export const DataSet = types.model("DataSet", {
     });
   }
 
+  function clearAllSelections() {
+    self.attributeSelection.clear();
+    self.caseSelection.clear();
+  }
+
   return {
     views: {
       attrFromID(id: string) {
@@ -633,6 +638,7 @@ export const DataSet = types.model("DataSet", {
 
       selectAllAttributes(select = true) {
         if (select) {
+          clearAllSelections();
           self.attributes.forEach(attribute => self.attributeSelection.add(attribute.id));
         } else {
           self.attributeSelection.clear();
@@ -641,6 +647,7 @@ export const DataSet = types.model("DataSet", {
 
       selectAllCases(select = true) {
         if (select) {
+          clearAllSelections();
           self.cases.forEach(({__id__}) => self.caseSelection.add(__id__));
         }
         else {
@@ -651,6 +658,7 @@ export const DataSet = types.model("DataSet", {
       selectAttributes(attributeIds: string[], select = true) {
         attributeIds.forEach(id => {
           if (select) {
+            self.caseSelection.clear();
             self.attributeSelection.add(id);
           } else {
             self.attributeSelection.delete(id);
@@ -670,6 +678,7 @@ export const DataSet = types.model("DataSet", {
         });
         ids.forEach(id => {
           if (select) {
+            self.attributeSelection.clear();
             self.caseSelection.add(id);
           }
           else {
@@ -679,10 +688,12 @@ export const DataSet = types.model("DataSet", {
       },
 
       setSelectedAttributes(attributeIds: string[]) {
+        clearAllSelections();
         self.attributeSelection.replace(attributeIds);
       },
 
       setSelectedCases(caseIds: string[]) {
+        clearAllSelections();
         const ids: string[] = [];
         caseIds.forEach(id => {
           const pseudoCase = self.pseudoCaseMap[id];

--- a/src/plugins/data-card/components/case-attribute.tsx
+++ b/src/plugins/data-card/components/case-attribute.tsx
@@ -48,6 +48,7 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
     setCurrEditFacet, setCurrEditAttrId, readOnly
   } = props;
   const content = model.content as DataCardContentModelType;
+  const dataSet = content.dataSet;
   const getLabel = () => content.dataSet.attrFromID(attrKey).name;
   const getValue = () => {
     const value = caseId && content.dataSet.getValue(caseId, attrKey) || "";
@@ -151,6 +152,7 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
     setCurrEditAttrId(attrKey);
     setCurrEditFacet("name");
     !editingLabel && setLabelCandidate(getLabel());
+    dataSet.setSelectedAttributes([attrKey]);
   };
 
   const handleValueClick = (event: React.MouseEvent<HTMLInputElement | HTMLDivElement>) => {
@@ -260,20 +262,40 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
   };
 
   const pairClassNames = `attribute-name-value-pair ${attrKey}`;
-  const valueInputClassNames = `value-input ${attrKey}`;
+
+  const attributeSelected = dataSet.isAttributeSelected(attrKey);
 
   const labelClassNames = classNames(
-    `name ${attrKey}`,
-    { "editing": editingLabel }
+    "name", attrKey,
+    {
+      editing: editingLabel,
+      highlighted: attributeSelected,
+      linked: isLinked
+    }
   );
 
-  const valueHighlighted = content.caseSelected;
+  const labelInputClassNames = classNames(
+    "input",
+    {
+      highlighted: attributeSelected,
+      linked: isLinked
+    }
+  );
+
+  const valueHighlighted = attributeSelected || content.caseSelected;
 
   const valueClassNames = classNames(
     "value", attrKey,
     {
       editing: editingValue,
       "has-image": gImageMap.isImageUrl(valueStr),
+      highlighted: valueHighlighted,
+      linked: isLinked
+    }
+  );
+  const valueInputClassNames = classNames(
+    "value-input", attrKey,
+    {
       highlighted: valueHighlighted,
       linked: isLinked
     }
@@ -325,7 +347,7 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
         { !readOnly && editingLabel
           ? <input
               type="text"
-              className="input"
+              className={labelInputClassNames}
               value={labelCandidate}
               onChange={handleChange}
               onKeyDown={handleKeyDown}

--- a/src/plugins/data-card/components/sort-area.scss
+++ b/src/plugins/data-card/components/sort-area.scss
@@ -73,10 +73,10 @@ $sort-view-width: ($sort-view-card-width * $cards-per-row ) + 3;
         text-align: center;
 
         &.highlighted {
-          background-color: $highlight-blue-new;
+          background-color: $highlight-unlinked-header;
 
           &.linked {
-            background-color: $highlight-green;
+            background-color: $highlight-linked-header;
           }
         }
 
@@ -111,10 +111,10 @@ $sort-view-width: ($sort-view-card-width * $cards-per-row ) + 3;
         border-radius: 0px 0px 5px 5px;
 
         &.highlighted {
-          background-color: $highlight-blue-new;
+          background-color: $highlight-unlinked-header;
 
           &.linked {
-            background-color: $highlight-green;
+            background-color: $highlight-linked-header;
           }
         }
       }
@@ -129,10 +129,10 @@ $sort-view-width: ($sort-view-card-width * $cards-per-row ) + 3;
           font-weight: bold;
 
           &.highlighted {
-            background-color: $highlight-blue-new;
+            background-color: $highlight-unlinked-header;
 
             &.linked {
-              background-color: $highlight-green;
+              background-color: $highlight-linked-header;
             }
           }
         }
@@ -141,10 +141,10 @@ $sort-view-width: ($sort-view-card-width * $cards-per-row ) + 3;
           padding: $card-space-factor;
 
           &.highlighted {
-            background-color: $highlight-blue-light-new;
+            background-color: $highlight-unlinked-cell;
 
             &.linked {
-              background-color: $highlight-green-light;
+              background-color: $highlight-linked-cell;
             }
           }
         }

--- a/src/plugins/data-card/components/sort-area.scss
+++ b/src/plugins/data-card/components/sort-area.scss
@@ -127,6 +127,14 @@ $sort-view-width: ($sort-view-card-width * $cards-per-row ) + 3;
           padding: $card-space-factor;
           background-color: $workspace-teal-light-4;
           font-weight: bold;
+
+          &.highlighted {
+            background-color: $highlight-blue-new;
+
+            &.linked {
+              background-color: $highlight-green;
+            }
+          }
         }
         .value {
           width: 100%;

--- a/src/plugins/data-card/components/sort-card-attribute.tsx
+++ b/src/plugins/data-card/components/sort-card-attribute.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import classNames from "classnames";
+import { observer } from "mobx-react-lite";
 import { ITileModel } from "../../../models/tiles/tile-model";
 import { DataCardContentModelType } from "../data-card-content";
 import { gImageMap } from "../../../models/image-map";
@@ -12,7 +13,7 @@ interface IProps {
   attr: IAttribute;
 }
 
-export const SortCardAttribute: React.FC<IProps> = ({ isLinked, model, caseId, attr }) => {
+export const SortCardAttribute: React.FC<IProps> = observer(({ isLinked, model, caseId, attr }) => {
   const content = model.content as DataCardContentModelType;
   const dataSet = content.dataSet;
   const value = dataSet.getStrValue(caseId, attr.id);
@@ -25,6 +26,10 @@ export const SortCardAttribute: React.FC<IProps> = ({ isLinked, model, caseId, a
   isImage && gImageMap.getImage(value).then((image)=>{
     setImageUrl(image.displayUrl || "");
   });
+
+  function handleAttributeClick() {
+    dataSet.setSelectedAttributes([attr.id]);
+  }
 
   const attributeClassNames = classNames(
     "attribute",
@@ -42,11 +47,13 @@ export const SortCardAttribute: React.FC<IProps> = ({ isLinked, model, caseId, a
   );
   return (
     <div className="attribute-value-row">
-      <div className={attributeClassNames}>{attr.name}</div>
+      <div className={attributeClassNames} onClick={handleAttributeClick}>
+        {attr.name}
+      </div>
       <div className={valueClassNames}>
         { !isImage && value }
         { isImage && <img src={imageUrl} className="image-value" /> }
       </div>
     </div>
   );
-};
+});

--- a/src/plugins/data-card/components/sort-card-attribute.tsx
+++ b/src/plugins/data-card/components/sort-card-attribute.tsx
@@ -14,20 +14,36 @@ interface IProps {
 
 export const SortCardAttribute: React.FC<IProps> = ({ isLinked, model, caseId, attr }) => {
   const content = model.content as DataCardContentModelType;
-  const value = content.dataSet.getStrValue(caseId, attr.id);
+  const dataSet = content.dataSet;
+  const value = dataSet.getStrValue(caseId, attr.id);
   const isImage = gImageMap.isImageUrl(value);
   const [imageUrl, setImageUrl] = useState("");
 
-  const caseHighlighted = content.dataSet.isCaseSelected(caseId);
+  const attributeHighlighted = dataSet.isAttributeSelected(attr.id);
+  const caseHighlighted = dataSet.isCaseSelected(caseId);
 
   isImage && gImageMap.getImage(value).then((image)=>{
     setImageUrl(image.displayUrl || "");
   });
 
+  const attributeClassNames = classNames(
+    "attribute",
+    {
+      highlighted: attributeHighlighted,
+      linked: isLinked
+    }
+  );
+  const valueClassNames = classNames(
+    "value",
+    {
+      highlighted: caseHighlighted || attributeHighlighted,
+      linked: isLinked
+    }
+  );
   return (
     <div className="attribute-value-row">
-      <div className="attribute">{attr.name}</div>
-      <div className={classNames("value", { highlighted: caseHighlighted, linked: isLinked })}>
+      <div className={attributeClassNames}>{attr.name}</div>
+      <div className={valueClassNames}>
         { !isImage && value }
         { isImage && <img src={imageUrl} className="image-value" /> }
       </div>

--- a/src/plugins/data-card/components/sort-card.tsx
+++ b/src/plugins/data-card/components/sort-card.tsx
@@ -73,12 +73,15 @@ export const SortCard: React.FC<IProps> = observer(
   return (
     <div
       className={cardClasses} id={caseId}
-      onClick={() => content.dataSet.setSelectedCases([caseId])}
       onDoubleClick={loadAsSingle}
       ref={setNodeRef}
       style={style}
     >
-      <div className={headingClasses} style={capStyle}>
+      <div
+        className={headingClasses}
+        onClick={() => content.dataSet.setSelectedCases([caseId])}
+        style={capStyle}
+      >
         <div className="expand-toggle-area">
           <button className="expand-toggle" onClick={toggleExpanded}>▶</button>
         </div>

--- a/src/plugins/data-card/data-card-tile.scss
+++ b/src/plugins/data-card/data-card-tile.scss
@@ -89,10 +89,10 @@ $default-button-border-color: #979797;
       justify-content: space-between;
 
       &.highlighted {
-        background-color: $highlight-blue-new;
+        background-color: $highlight-unlinked-header;
 
         &.linked {
-          background-color: $highlight-green;
+          background-color: $highlight-linked-header;
         }
       }
 
@@ -201,10 +201,10 @@ $default-button-border-color: #979797;
           box-sizing: border-box;
 
           &.highlighted {
-            background-color: $highlight-blue-new;
+            background-color: $highlight-unlinked-header;
 
             &.linked {
-              background-color: $highlight-green;
+              background-color: $highlight-linked-header;
             }
           }
 
@@ -225,10 +225,10 @@ $default-button-border-color: #979797;
             text-align: right;
 
             &.highlighted {
-              box-shadow: inset 0 0 0 3px $highlight-blue-edit-new;
+              box-shadow: inset 0 0 0 3px $highlight-unlinked-edit;
 
               &.linked {
-                box-shadow: inset 0 0 0 3px $highlight-green-edit;
+                box-shadow: inset 0 0 0 3px $highlight-linked-edit;
               }
             }
 
@@ -249,10 +249,10 @@ $default-button-border-color: #979797;
 
           input {
             &.highlighted {
-              background-color: $highlight-blue-light-new;
+              background-color: $highlight-unlinked-cell;
 
               &.linked {
-                background-color: $highlight-green-light;
+                background-color: $highlight-linked-cell;
               }
             }
 
@@ -260,11 +260,11 @@ $default-button-border-color: #979797;
               background-color: white;
 
               &.highlighted {
-                box-shadow: inset 0 0 0 3px $highlight-blue-edit-new;
+                box-shadow: inset 0 0 0 3px $highlight-unlinked-edit;
 
                 &.linked {
                   background-color: white;
-                  box-shadow: inset 0 0 0 3px $highlight-green-edit;
+                  box-shadow: inset 0 0 0 3px $highlight-linked-edit;
                 }
               }
             }
@@ -275,10 +275,10 @@ $default-button-border-color: #979797;
           padding: 0 4px;
 
           &.highlighted {
-            background-color: $highlight-blue-light-new;
+            background-color: $highlight-unlinked-cell;
 
             &.linked {
-              background-color: $highlight-green-light;
+              background-color: $highlight-linked-cell;
             }
           }
         }

--- a/src/plugins/data-card/data-card-tile.scss
+++ b/src/plugins/data-card/data-card-tile.scss
@@ -200,6 +200,14 @@ $default-button-border-color: #979797;
           color: $cell-text-color;
           box-sizing: border-box;
 
+          &.highlighted {
+            background-color: $highlight-blue-new;
+
+            &.linked {
+              background-color: $highlight-green;
+            }
+          }
+
           .cell-value {
             height: 100%;
             display: flex;
@@ -210,6 +218,22 @@ $default-button-border-color: #979797;
             padding:$cell-padding;
             &.default-label {
               font-style: italic;
+            }
+          }
+
+          input {
+            text-align: right;
+
+            &.highlighted {
+              box-shadow: inset 0 0 0 3px $highlight-blue-edit-new;
+
+              &.linked {
+                box-shadow: inset 0 0 0 3px $highlight-green-edit;
+              }
+            }
+
+            &:hover {
+              background:rgba(245, 245, 245);
             }
           }
         }
@@ -223,18 +247,25 @@ $default-button-border-color: #979797;
             padding:$cell-padding;
           }
 
-          &.highlighted {
-            background-color: $highlight-blue-light-new;
-
-            input {
+          input {
+            &.highlighted {
               background-color: $highlight-blue-light-new;
+
+              &.linked {
+                background-color: $highlight-green-light;
+              }
             }
 
-            &.linked {
-              background-color: $highlight-green-light;
+            &:focus {
+              background-color: white;
 
-              input {
-                background-color: $highlight-green-light;
+              &.highlighted {
+                box-shadow: inset 0 0 0 3px $highlight-blue-edit-new;
+
+                &.linked {
+                  background-color: white;
+                  box-shadow: inset 0 0 0 3px $highlight-green-edit;
+                }
               }
             }
           }
@@ -272,16 +303,8 @@ $default-button-border-color: #979797;
           outline: 0;
         }
 
-        .name input {
-          text-align: right;
-        }
-
         .editing input {
           padding: 2px 8px;
-        }
-
-        input:hover {
-          background:rgba(245, 245, 245);
         }
 
         .value.has-image {

--- a/src/plugins/graph/components/background.tsx
+++ b/src/plugins/graph/components/background.tsx
@@ -121,7 +121,7 @@ export const Background = forwardRef<SVGGElement, IProps>((props, ref) => {
         // clicking on the background deselects all cases
         .on('click', (event) => {
           if (!event.shiftKey) {
-            dataset.current?.selectAll(false);
+            dataset.current?.selectAllCases(false);
           }
         })
         .selectAll<SVGRectElement, number>('rect')

--- a/src/plugins/graph/models/data-configuration-model.test.ts
+++ b/src/plugins/graph/models/data-configuration-model.test.ts
@@ -185,7 +185,7 @@ describe("DataConfigurationModel", () => {
     expect(config.selection.length).toBe(0);
 
     config.setDataset(tree.data, tree.metadata);
-    tree.data.selectAll();
+    tree.data.selectAllCases();
     expect(config.selection.length).toBe(2);
 
     config.setAttribute("x", { attributeID: "xId" });

--- a/src/plugins/graph/models/data-configuration-model.ts
+++ b/src/plugins/graph/models/data-configuration-model.ts
@@ -271,9 +271,9 @@ export const DataConfigurationModel = types
      */
     get selection() {
       if (!self.dataset || !self.filteredCases || !self.filteredCases[0]) return [];
-      const selection = Array.from(self.dataset.selection),
+      const caseSelection = Array.from(self.dataset.caseSelection),
         allGraphCaseIds = self.graphCaseIDs;
-      return selection.filter((caseId: string) => allGraphCaseIds.has(caseId));
+      return caseSelection.filter((caseId: string) => allGraphCaseIds.has(caseId));
     }
   }))
   .views(self => (


### PR DESCRIPTION
PT Stories:
https://www.pivotaltracker.com/story/show/186170880
https://www.pivotaltracker.com/story/show/186170898

This PR adds the ability to synchronously highlight attributes between tables and datacard tiles.
- In tables, column selection is now handled in the dataSet.
  - Because of this, it's now possible to deselect columns when cases are selected in other tiles.

A lot of styling has been improved, especially in the datacard tile, where editing now follows the design spec.
- I wasn't able to get table header cell edit styling quite right. The colored outline is reduced at the bottom. I spent some time trying to fix this but gave up. I think it would make sense to split this into a separate bug story. We might want to just have a styling cleanup story after all these highlight stories are finished, honestly.

Highlighting between geometry tiles and tables is even more confusing now because it's no longer possible to differentiate the color between highlight types. This means it's possible to have a column and a row selected at the same time, for example.

A couple of the usual tests are failing, but nothing related to this PR.