### PR TITLE
186419478 Fix Sparrow Document Limits

### DIFF
--- a/cypress/e2e/clue/branch/student_tests/graph_table_integraton_test_spec.js
+++ b/cypress/e2e/clue/branch/student_tests/graph_table_integraton_test_spec.js
@@ -231,7 +231,7 @@ context('Graph Table Integration', function () {
 
     // Add a new point to the table
     cy.get(".primary-workspace").within((workspace) => {
-      tableToolTile.getTableCell().eq(9).click();
+      tableToolTile.getTableCell().eq(9).click().click();
       tableToolTile.getTableCell().eq(9).type(x[2] + '{enter}');
       tableToolTile.getTableCell().eq(10).click();
       tableToolTile.getTableCell().eq(10).type(y[2] + '{enter}');

--- a/src/components/document/annotation-layer.tsx
+++ b/src/components/document/annotation-layer.tsx
@@ -60,8 +60,14 @@ export const AnnotationLayer = observer(function AnnotationLayer({
   }
 
   const documentWidth = canvasElement?.offsetWidth ?? 0;
-  // TODO Would it be better to use canvasElement?.offsetHeight here?
-  const documentHeight = content?.height ?? 0;
+  let documentHeight = 0;
+  const rows = canvasElement?.getElementsByClassName("tile-row");
+  if (rows) {
+    Array.from(rows).forEach(row => {
+      const boundingBox = row.getBoundingClientRect();
+      documentHeight += boundingBox.height;
+    });
+  }
   const documentLeft = 0;
   const documentRight = documentWidth;
   const documentBottom = documentHeight - (documentScrollY ?? 0);


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/186419478

This PR fixes a bug where the document size limiting placement of sparrow parts (especially the text field) was inaccurate, causing the sparrows to acquire really awkward shapes. The underlying problem was that the annotation layer was determining document height by summing `TileRowModel.height`, but this number was not always accurate. In particular, rows with text tiles were often incorrect.

The solution was to look at the DOM elements of the rows and use their bounding boxes to determine height.

I don't think these changes should impact any cypress tests. The tests that are failing are timing out, so it's tough to tell what's going on, but before they were timing out it was just the usual suspects that were failing.

I'm casting a wide net in requesting reviews on this one, but I think I should only need one.