### PR TITLE
fix shared model manager warning

### DIFF
--- a/src/models/tiles/tile-model.ts
+++ b/src/models/tiles/tile-model.ts
@@ -142,6 +142,12 @@ export const TileModel = types
       // which often occurs before the tile has been attached to the document, which means that references
       // can't be validated, etc.. Therefore, the tile model will call the content's afterAttachToDocument()
       // method when the tile model itself is attached.
+      // Note: The shared model manager is not guaranteed to be ready at this point. This is because it is
+      // is setup after the document is created from the snapshot, and this afterAttach can be called
+      // in between. It is recommended that you use a reaction to check for it to be reaction monitoring
+      // the shared model manager ready state. Also the shared model manager won't be ready until the tile
+      // is attached to the document, so you don't really need to use afterAttachToDocument in these cases
+      // you can instead just use afterAttach with a reaction.
       if ("afterAttachToDocument" in self.content && typeof self.content.afterAttachToDocument === "function") {
         self.content.afterAttachToDocument();
       }

--- a/src/plugins/graph/models/graph-model.ts
+++ b/src/plugins/graph/models/graph-model.ts
@@ -360,10 +360,16 @@ export const GraphModel = TileContentModel
         self.prevDataSetId = currDataSetId;
       }
     },
-    afterAttachToDocument() {
+    afterAttach() {
       addDisposer(self, reaction(
-        () => self.data,
-        data => {
+        () => {
+          const sharedModelManager = self.tileEnv?.sharedModelManager;
+          const sharedModelManagerReady = sharedModelManager?.isReady;
+          const data = sharedModelManagerReady ? self.data : undefined;
+          return { sharedModelManagerReady, data };
+        },
+        ({ sharedModelManagerReady, data }) => {
+          if (!sharedModelManagerReady) return;
           const sharedModelManager = getSharedModelManager(self);
           if (!self.metadata && data) {
             const caseMetadata = SharedCaseMetadata.create();


### PR DESCRIPTION
afterAttachToDocument is called
before the shared model manager is ready.
This then causes a warning when a shared model is accessed
by a tile using afterAttachToDocument.