### PR TITLE
Add a "Debug Jest test" launch config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,6 +6,14 @@
       "type": "chrome",
       "url": "http://localhost:8080",
       "webRoot": "${workspaceFolder}"
+    },
+    {
+      "name": "Debug test",
+      "request": "launch",
+      "type": "node",
+      "console": "integratedTerminal",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": ["${fileBasenameNoExtension}"]
     }
   ]
 }


### PR DESCRIPTION
This adds a configuration so that in the VSCode "Run and Debug" view, you can easily choose to launch the debugger on the Jest test that is in the editor window.

To do so, while the test  file is displayed in the editor, go to `View - Run`, set the pulldown menu at the top to `Debug test`, and click the 'Start debugger' button next to the pulldown menu.

If the editor is displaying a regular source file, it will try to find a similarly-named .test file.
