### PR TITLE
186472583 disable xy dnd

### DIFF
--- a/src/clue/app-config.json
+++ b/src/clue/app-config.json
@@ -246,6 +246,7 @@
         "defaultSeriesLegend": true,
         "connectPointsByDefault": true,
         "autoAssignAttributes": true,
+        "disableAttributeDnD": true,
         "tools": [
           "link-tile"
         ]

--- a/src/plugins/graph/components/attribute-label.tsx
+++ b/src/plugins/graph/components/attribute-label.tsx
@@ -14,7 +14,7 @@ import {useGraphLayoutContext} from "../models/graph-layout";
 import {useTileModelContext} from "../imports/hooks/use-tile-model-context";
 import {getStringBounds} from "../imports/components/axis/axis-utils";
 import {AxisOrLegendAttributeMenu} from "../imports/components/axis/components/axis-or-legend-attribute-menu";
-import {useSettingFromStores} from "../../../hooks/use-stores";
+import { useGraphSettingsContext } from "../hooks/use-graph-settings-context";
 
 import graphVars from "./graph.scss";
 
@@ -29,7 +29,7 @@ export const AttributeLabel = observer(
   function AttributeLabel({place, onTreatAttributeAs, onRemoveAttribute, onChangeAttribute}: IAttributeLabelProps) {
     const graphModel = useGraphModelContext(),
       dataConfiguration = useDataConfigurationContext(),
-      defaultAxisLabels = useSettingFromStores("defaultAxisLabels", "graph") as Record<string, string> | undefined,
+      { defaultSeriesLegend, defaultAxisLabels } = useGraphSettingsContext(),
       layout = useGraphLayoutContext(),
       {isTileSelected} = useTileModelContext(),
       dataset = dataConfiguration?.dataset,
@@ -161,7 +161,7 @@ export const AttributeLabel = observer(
     }, [place, dataConfiguration, refreshAxisTitle]);
 
     const readyForPortal = positioningParentElt && onChangeAttribute && onTreatAttributeAs && onRemoveAttribute;
-    const skipPortal = useSettingFromStores("defaultSeriesLegend", "graph") && place === "left";
+    const skipPortal = defaultSeriesLegend && place === "left";
 
     return (
       <>

--- a/src/plugins/graph/components/graph-axis.tsx
+++ b/src/plugins/graph/components/graph-axis.tsx
@@ -20,8 +20,8 @@ import {useDropHintString} from "../imports/hooks/use-drop-hint-string";
 import { isAddCasesAction, isSetCaseValuesAction } from "../../../models/data/data-set-actions";
 import { computeNiceNumericBounds } from "../utilities/graph-utils";
 import { isNumericAxisModel } from "../imports/components/axis/models/axis-model";
-import { useSettingFromStores } from "../../../hooks/use-stores";
 import { DroppableAxis } from "./droppable-axis";
+import { useGraphSettingsContext } from "../hooks/use-graph-settings-context";
 
 interface IProps {
   place: AxisPlace
@@ -42,7 +42,7 @@ export const GraphAxis = observer(function GraphAxis({
     layout = useGraphLayoutContext(),
     droppableId = `${instanceId}-${place}-axis-drop`,
     hintString = useDropHintString({role: axisPlaceToAttrRole[place]}),
-    emptyPlotIsNumeric = useSettingFromStores("emptyPlotIsNumeric", "graph") as boolean | undefined,
+    { disableAttributeDnD, emptyPlotIsNumeric } = useGraphSettingsContext(),
     axisShouldShowGridlines = emptyPlotIsNumeric || graphModel.axisShouldShowGridLines(place),
     parentEltRef = useRef<HTMLDivElement | null>(null),
     [wrapperElt, _setWrapperElt] = useState<SVGGElement | null>(null),
@@ -145,7 +145,7 @@ export const GraphAxis = observer(function GraphAxis({
         onRemoveAttribute={onRemoveAttribute}
         onTreatAttributeAs={onTreatAttributeAs}
       />
-      {onDropAttribute &&
+      {onDropAttribute && !disableAttributeDnD &&
          <DroppableAxis
             place={`${place}`}
             dropId={droppableId}

--- a/src/plugins/graph/components/graph-wrapper-component.tsx
+++ b/src/plugins/graph/components/graph-wrapper-component.tsx
@@ -7,8 +7,12 @@ import { BasicEditableTileTitle } from "../../../components/tiles/basic-editable
 import { ITileProps } from "../../../components/tiles/tile-component";
 import { OffsetModel } from "../../../models/annotations/clue-object";
 import { ITileExportOptions } from "../../../models/tiles/tile-content-info";
+import {
+  GraphSettingsContext, IGraphSettings, IGraphSettingsFromStores, kDefaultGraphSettings
+} from "../hooks/use-graph-settings-context";
 import { useInitGraphLayout } from "../hooks/use-init-graph-layout";
 import { getScreenX, getScreenY } from "../hooks/use-point-locations";
+import { useSettingFromStores } from "../../../hooks/use-stores";
 import { IGraphModel } from "../models/graph-model";
 import { decipherDotId } from "../utilities/graph-utils";
 import { GraphComponent } from "./graph-component";
@@ -22,6 +26,8 @@ export const GraphWrapperComponent: React.FC<ITileProps> = observer(function(pro
   const {
     model, readOnly, tileElt, onRegisterTileApi, onRequestRowHeight
   } = props;
+  const graphSettingsFromStores = useSettingFromStores("graph") as IGraphSettingsFromStores;
+  const graphSettings: IGraphSettings = { ...kDefaultGraphSettings, ...graphSettingsFromStores };
   const content = model.content as IGraphModel;
 
   const data = content.config.dataset; // TODO: this only considers layer 0
@@ -113,10 +119,12 @@ export const GraphWrapperComponent: React.FC<ITileProps> = observer(function(pro
   }, [layout]);
 
   return (
-    <div className={classNames("graph-wrapper", { "read-only": readOnly })}>
-      <TileToolbar tileType="graph" readOnly={!!readOnly} tileElement={tileElt}/>
-      <BasicEditableTileTitle readOnly={readOnly} />
-      <GraphComponent layout={layout} tile={model} onRequestRowHeight={onRequestRowHeight} />
-    </div>
+    <GraphSettingsContext.Provider value={graphSettings}>
+      <div className={classNames("graph-wrapper", { "read-only": readOnly })}>
+        <TileToolbar tileType="graph" readOnly={!!readOnly} tileElement={tileElt}/>
+        <BasicEditableTileTitle readOnly={readOnly} />
+        <GraphComponent layout={layout} tile={model} onRequestRowHeight={onRequestRowHeight} />
+      </div>
+    </GraphSettingsContext.Provider>
   );
 });

--- a/src/plugins/graph/components/legend/legend.tsx
+++ b/src/plugins/graph/components/legend/legend.tsx
@@ -15,6 +15,7 @@ import {AttributeType} from "../../../../models/data/attribute";
 import {IDataSet} from "../../../../models/data/data-set";
 import {GraphAttrRole} from "../../graph-types";
 import {GraphPlace} from "../../imports/components/axis-graph-shared";
+import { useGraphSettingsContext } from "../../hooks/use-graph-settings-context";
 
 interface ILegendProps {
   legendAttrID: string
@@ -36,7 +37,8 @@ export const Legend = function Legend({
     instanceId = useInstanceIdContext(),
     droppableId = `${instanceId}-legend-area-drop`,
     role = 'legend' as GraphAttrRole,
-    hintString = useDropHintString({role});
+    hintString = useDropHintString({role}),
+    { disableAttributeDnD } = useGraphSettingsContext();
 
   const handleIsActive = (active: Active) => {
     const {dataSet, attributeId: droppedAttrId} = getDragAttributeInfo(active) || {};
@@ -87,14 +89,16 @@ export const Legend = function Legend({
             : attrType === 'numeric' ? <NumericLegend legendAttrID={legendAttrID}/> : null
         }
       </svg>
-      <DroppableSvg
-        className="droppable-legend"
-        portal={graphElt}
-        target={legendRef.current}
-        dropId={droppableId}
-        onIsActive={handleIsActive}
-        hintString={hintString}
-      />
+      { !disableAttributeDnD &&
+        <DroppableSvg
+          className="droppable-legend"
+          portal={graphElt}
+          target={legendRef.current}
+          dropId={droppableId}
+          onIsActive={handleIsActive}
+          hintString={hintString}
+        />
+      }
     </>
 
   ) : null;

--- a/src/plugins/graph/hooks/use-graph-settings-context.ts
+++ b/src/plugins/graph/hooks/use-graph-settings-context.ts
@@ -1,24 +1,29 @@
 import { createContext, useContext } from "react";
+import { Optional } from "utility-types";
 
 export interface IGraphSettings {
-  disableAttributeDnD: boolean
-  scalePlotOnValueChange: boolean,
-  emptyPlotIsNumeric: boolean,
-  defaultSeriesLegend: boolean,
-  connectPointsByDefault: boolean,
-  autoAssignAttributes: boolean,
-  defaultAxisLabels: Record<string, string> | undefined
+  disableAttributeDnD: boolean;
+  scalePlotOnValueChange: boolean;
+  emptyPlotIsNumeric: boolean;
+  defaultSeriesLegend: boolean;
+  connectPointsByDefault: boolean;
+  autoAssignAttributes: boolean;
+  defaultAxisLabels: Record<string, string>;
 }
 
-export const GraphSettingsContext = createContext<IGraphSettings>({
+export type IGraphSettingsFromStores = Optional<IGraphSettings>;
+
+export const kDefaultGraphSettings: IGraphSettings = {
   disableAttributeDnD: true,
   scalePlotOnValueChange: true,
   emptyPlotIsNumeric: true,
   defaultSeriesLegend: true,
   connectPointsByDefault: true,
   autoAssignAttributes: true,
-  defaultAxisLabels: undefined
-});
+  defaultAxisLabels: {}
+};
+
+export const GraphSettingsContext = createContext<IGraphSettings>(kDefaultGraphSettings);
 
 export const useGraphSettingsContext = () => {
   return useContext(GraphSettingsContext);

--- a/src/plugins/graph/hooks/use-graph-settings-context.ts
+++ b/src/plugins/graph/hooks/use-graph-settings-context.ts
@@ -1,0 +1,25 @@
+import { createContext, useContext } from "react";
+
+export interface IGraphSettings {
+  disableAttributeDnD: boolean
+  scalePlotOnValueChange: boolean,
+  emptyPlotIsNumeric: boolean,
+  defaultSeriesLegend: boolean,
+  connectPointsByDefault: boolean,
+  autoAssignAttributes: boolean,
+  defaultAxisLabels: Record<string, string> | undefined
+}
+
+export const GraphSettingsContext = createContext<IGraphSettings>({
+  disableAttributeDnD: true,
+  scalePlotOnValueChange: true,
+  emptyPlotIsNumeric: true,
+  defaultSeriesLegend: true,
+  connectPointsByDefault: true,
+  autoAssignAttributes: true,
+  defaultAxisLabels: undefined
+});
+
+export const useGraphSettingsContext = () => {
+  return useContext(GraphSettingsContext);
+};

--- a/src/plugins/graph/imports/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/src/plugins/graph/imports/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -133,15 +133,13 @@ export const AxisOrLegendAttributeMenu = ({ place, attributeId, target, parent, 
           onCloseRef.current = onClose;
           return (
             <Portal containerRef={parentRef}>
-              { !disableAttributeDnD &&
-                <div ref={setDragNodeRef} style={overlayStyle} {...attributes} {...listeners}>
-                  { menuButtonAndPortal }
-                </div>
-              }
-              { disableAttributeDnD &&
-                <div style={overlayStyle}>
-                  {menuButtonAndPortal}
-                </div>
+              { disableAttributeDnD
+                  ? <div style={overlayStyle}>
+                      {menuButtonAndPortal}
+                    </div>
+                  : <div ref={setDragNodeRef} style={overlayStyle} {...attributes} {...listeners}>
+                      {menuButtonAndPortal}
+                    </div>
               }
             </Portal>
           );

--- a/src/plugins/graph/imports/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/src/plugins/graph/imports/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -12,6 +12,7 @@ import { useOverlayBounds } from "../../../hooks/use-overlay-bounds";
 import { AttributeType } from "../../../../../../models/data/attribute";
 import { IDataSet } from "../../../../../../models/data/data-set";
 import { isSetAttributeNameAction } from "../../../../../../models/data/data-set-actions";
+import { useGraphSettingsContext } from "../../../../hooks/use-graph-settings-context";
 
 interface IProps {
   place: GraphPlace
@@ -56,7 +57,7 @@ export const AxisOrLegendAttributeMenu = ({ place, attributeId, target, parent, 
   portalRef.current = portal;
   const menuListRef = useRef<HTMLDivElement>(null);
   const showRemoveOption = true; // Used to be a setting; for now we always want it available.
-
+  const { disableAttributeDnD }  = useGraphSettingsContext();
   const onCloseRef = useRef<() => void>();
   const overlayStyle: CSSProperties = {
     position: "absolute", ...useOverlayBounds({target, portal: parent})
@@ -84,6 +85,46 @@ export const AxisOrLegendAttributeMenu = ({ place, attributeId, target, parent, 
     });
   }, [attribute?.name, data?.attributes, dataConfig, labelText, setLabelText, attrId]);
 
+  const menuButtonAndPortal =
+    <>
+      <MenuButton style={buttonStyle}>{attribute?.name}</MenuButton>
+      <Portal containerRef={portalRef}>
+        <MenuList ref={menuListRef}>
+          { !data &&
+            <MenuItem className="inactive">
+              Link Data
+            </MenuItem>
+          }
+          { data?.attributes?.map((attr) => {
+            const isCurrent = attr.id === attrId;
+            const isPlottedX = dataConfig?.attributeID("x") === attr.id;
+            const isPlottedY = yAttributesPlotted?.includes(attr.id);
+            const showAttr = (!isCurrent && !isPlottedX && !isPlottedY);
+
+            return showAttr && (
+              <MenuItem onClick={() => onChangeAttribute(place, data, attr.id, attrId)} key={attr.id}>
+                {attr.name}
+              </MenuItem>
+            );
+          })}
+          { attribute &&
+            <>
+              <MenuDivider />
+              { showRemoveOption &&
+                <MenuItem onClick={() => onRemoveAttribute(place, attrId)}>
+                {removeAttrItemLabel}
+                </MenuItem>
+              }
+              <MenuItem onClick={() => onTreatAttributeAs(place, attribute?.id, treatAs)}>
+                {treatAs === "categorical" && t("DG.DataDisplayMenu.treatAsCategorical")}
+                {treatAs === "numeric" && t("DG.DataDisplayMenu.treatAsNumeric")}
+              </MenuItem>
+            </>
+          }
+        </MenuList>
+      </Portal>
+    </>;
+
   return (
     <div className={`axis-legend-attribute-menu ${place}`} >
       <Menu boundary="scrollParent">
@@ -92,44 +133,16 @@ export const AxisOrLegendAttributeMenu = ({ place, attributeId, target, parent, 
           onCloseRef.current = onClose;
           return (
             <Portal containerRef={parentRef}>
-              <div ref={setDragNodeRef} style={overlayStyle} {...attributes} {...listeners}>
-                <MenuButton style={buttonStyle}>{attribute?.name}</MenuButton>
-                <Portal containerRef={portalRef}>
-                  <MenuList ref={menuListRef}>
-                    { !data &&
-                      <MenuItem className="inactive">
-                        Link Data
-                      </MenuItem>
-                    }
-                    { data?.attributes?.map((attr) => {
-                      const isCurrent = attr.id === attrId;
-                      const isPlottedX = dataConfig?.attributeID("x") === attr.id;
-                      const isPlottedY = yAttributesPlotted?.includes(attr.id);
-                      const showAttr = (!isCurrent && !isPlottedX && !isPlottedY);
-
-                      return showAttr && (
-                        <MenuItem onClick={() => onChangeAttribute(place, data, attr.id, attrId)} key={attr.id}>
-                          {attr.name}
-                        </MenuItem>
-                      );
-                    })}
-                    { attribute &&
-                      <>
-                        <MenuDivider />
-                        { showRemoveOption &&
-                          <MenuItem onClick={() => onRemoveAttribute(place, attrId)}>
-                          {removeAttrItemLabel}
-                          </MenuItem>
-                        }
-                        <MenuItem onClick={() => onTreatAttributeAs(place, attribute?.id, treatAs)}>
-                          {treatAs === "categorical" && t("DG.DataDisplayMenu.treatAsCategorical")}
-                          {treatAs === "numeric" && t("DG.DataDisplayMenu.treatAsNumeric")}
-                        </MenuItem>
-                      </>
-                    }
-                  </MenuList>
-                </Portal>
-              </div>
+              { !disableAttributeDnD &&
+                <div ref={setDragNodeRef} style={overlayStyle} {...attributes} {...listeners}>
+                  { menuButtonAndPortal }
+                </div>
+              }
+              { disableAttributeDnD &&
+                <div style={overlayStyle}>
+                  {menuButtonAndPortal}
+                </div>
+              }
             </Portal>
           );
         }}


### PR DESCRIPTION
This disables the drag-and-drop functionality within the graph, as described in PT-186472583

- A new setting is created `"attributeDnD": false` (default)

In the default state:
- Droppable zones do not render
- The draggable attributes and listeners are not passed to the AxisOrAttributeMenu