### PR TITLE
handle non-existing firestore documents

### DIFF
--- a/src/hooks/document-comment-hooks.test.ts
+++ b/src/hooks/document-comment-hooks.test.ts
@@ -4,12 +4,9 @@ import {
   DocumentQueryType, useDocumentComments, usePostDocumentComment, useUnreadDocumentComments
 } from "./document-comment-hooks";
 
-const mockValidateCommentableDocument_v1 = jest.fn();
 const mockPostDocumentComment_v1 = jest.fn();
 const mockHttpsCallable = jest.fn((fn: string) => {
   switch(fn) {
-    case "validateCommentableDocument_v1":
-      return mockValidateCommentableDocument_v1;
     case "postDocumentComment_v1":
       return mockPostDocumentComment_v1;
   }
@@ -99,7 +96,6 @@ jest.mock("./firestore-hooks", () => ({
 describe("Document comment hooks", () => {
 
   function resetMocks() {
-    mockValidateCommentableDocument_v1.mockClear();
     mockPostDocumentComment_v1.mockClear();
     mockHttpsCallable.mockClear();
     mockUseMutation.mockClear();
@@ -123,8 +119,7 @@ describe("Document comment hooks", () => {
       const document = { uid: "user-id", type: "problem", key: "key" };
       // useDocumentComments() fills the commentsQueryKeyMap
       renderHook(() => useDocumentComments(document.key));
-      expect(mockHttpsCallable).toHaveBeenCalled();
-      expect(mockHttpsCallable.mock.calls[0][0]).toBe("validateCommentableDocument_v1");
+      expect(mockUseCollectionOrderedRealTimeQuery).toHaveBeenCalled();
       const { result: postCommentResult } = renderHook(() => usePostDocumentComment());
       expect(mockUseMutation).toHaveBeenCalled();
       expect(typeof postCommentResult.current.mutate).toBe("function");
@@ -133,7 +128,7 @@ describe("Document comment hooks", () => {
       expect(mockSetQueryData).toHaveBeenCalled();
       expect(mockSetQueryData.mock.calls[0][1]).toHaveLength(1);
       expect(mockHttpsCallable).toHaveBeenCalled();
-      expect(mockHttpsCallable.mock.calls[1][0]).toBe("postDocumentComment_v1");
+      expect(mockHttpsCallable.mock.calls[0][0]).toBe("postDocumentComment_v1");
       expect(mockPostDocumentComment_v1).toHaveBeenCalled();
     });
 

--- a/src/hooks/document-comment-hooks.ts
+++ b/src/hooks/document-comment-hooks.ts
@@ -1,8 +1,7 @@
 import firebase from "firebase/app";
 import { useCallback } from "react";
 import { useMutation, UseMutationOptions, useQuery, useQueryClient } from "react-query";
-import {
-  ICommentableDocumentParams, ICurriculumMetadata, IDocumentMetadata, IPostDocumentCommentParams,
+import { ICurriculumMetadata, IDocumentMetadata, IPostDocumentCommentParams,
   isCurriculumMetadata, isDocumentMetadata, isSectionPath
 } from "../../functions/src/shared";
 import { CommentDocument, CurriculumDocument, DocumentDocument } from "../lib/firestore-schema";
@@ -54,29 +53,16 @@ export const getCommentsQueryKeyFromMetadata = (metadata: IDocumentMetadata | IC
   return curriculumOrDocumentKey && commentsQueryKeyMap[curriculumOrDocumentKey];
 };
 
-/*
- * useValidateCommentableDocument
- *
- * Implemented via React Query's useMutation hook.
- */
-type IValidateDocumentClientParams = Omit<ICommentableDocumentParams, "context">;
-type ValidateDocumentUseMutationOptions =
-      UseMutationOptions<firebase.functions.HttpsCallableResult, unknown, IValidateDocumentClientParams>;
-
-export const useValidateCommentableDocument = (options?: ValidateDocumentUseMutationOptions) => {
-  const validateCommentableDocument = useFirebaseFunction<ICommentableDocumentParams>("validateCommentableDocument_v1");
-  const context = useUserContext();
-  const validateDocument = useCallback((clientParams: IValidateDocumentClientParams) => {
-    return validateCommentableDocument({ context, ...clientParams });
-  }, [context, validateCommentableDocument]);
-  return useMutation(validateDocument, options);
-};
-
 /**
  * useCommentableDocument
  *
  * Waits for the specified document to exist and returns it.
  * Implemented via React Query's useQuery hook.
+ *
+ * The document will be created by other parts of the code. Either when a comment is posted, or
+ * when the history is saved by the student:
+ * - functions/src/post-document-comment.ts -> createCommentableDocumentIfNecessary
+ * - src/models/history/tree-manager.ts -> prepareFirestoreHistoryInfo
  *
  * @param documentKeyOrSectionPath
  * @param userId optional param that overrides the current user and the network.


### PR DESCRIPTION
This removes the basically unused `useValidateCommentableDocument` hook. It was called, which did cause it to be warmed up. But the code in the onError was not being called so the document was not being created here.

This also removes an unused useDocumentHistory hook. The document history handling was moved into the model (tree-manager.ts) after this initial hook was added a while ago.

