### PR TITLE
Do re-autoassignment of graph X & Y when needed

### DIFF
--- a/src/plugins/graph/models/graph-model.ts
+++ b/src/plugins/graph/models/graph-model.ts
@@ -341,6 +341,16 @@ export const GraphModel = TileContentModel
         return;
       }
 
+      // This handles auto-assignment in case dataset has changed in significant ways (eg, columns and recreated)
+      if (isSharedDataSet(sharedModel)) {
+        const dataSetId = sharedModel.dataSet?.id;
+        if (dataSetId) {
+          const changedLayer = self.layers.find((layer) => {
+            return layer.config.dataset?.id === dataSetId; });
+          changedLayer?.configureLinkedLayer();
+        }
+      }
+
       // Would be nice if there was a simple way to tell if anything relevant has changed.
       // This is a little heavy-handed but does the job.
       const sharedDatasetIds = sharedDataSets.map(m => isSharedDataSet(m) ? m.dataSet.id : undefined);


### PR DESCRIPTION
Fix for PT-186506561

Run the auto-assign method `configureLinkedLayer` after all dataset changes. This will catch cases where attributes are removed and re-created, and automatically assign the first two attributes after such events.

This restores the previous behavior from before multi-dataset changes, which was removed in error since it is important for tracking incoming data from Dataflow tile.
