### PR TITLE
186386406 Graph Cell Highlighting

### DIFF
--- a/cypress/e2e/functional/teacher_tests/teacher_scrolling_spec.js
+++ b/cypress/e2e/functional/teacher_tests/teacher_scrolling_spec.js
@@ -28,7 +28,7 @@ function beforeTest(params) {
 }
 
 context('Vertical Scrolling', () => {
-  describe('Vertical scrolling in various places', () => {   
+  describe('Vertical scrolling in various places', () => {
     it('verify scrolling in Resources under problem, teacher guide and problem, personal documents', () => {
       cy.log('verify vertical scrolling under problem subtabs');
       beforeTest(queryParams.sas1_1);
@@ -78,24 +78,24 @@ context('Vertical Scrolling', () => {
       cy.log("verify My Work - starred");
       cy.openSection("my-work", "starred");
       cy.wait(10000);
-      
+
       cy.log("verify my work - starred single flipper view scrolling");
       scrolling.verifyScrollingMyWorkStarred();
       cy.log("verify my work - starred double flipper view scrolling");
       scrolling.verifyScrollingMyWorkStarredDoubleFlipperView();
       cy.log("verify my work - starred thumbnail view scrolling");
       scrolling.verifyScrollingMyWorkThumbnailView();
-    
+
       cy.log("verify scrolling in student workspaces");
       cy.openTopTab("student-work");
       cy.wait(10000);
-      
+
       cy.log('verify scrolling for individual student workspace 4-up view');
       scrolling.verifyScrollingStudentWorkspaces4upView();
       cy.log('verify scrolling for individual student workspace');
       cy.get('.four-up .north-east .member').should('contain', "S3").click();
       scrolling.verifyScrollingStudentWorkspacesExpandedView();
-   
+
       cy.log("verify scrolling in class work - workspaces");
       cy.openTopTab("class-work");
       cy.wait(2000);
@@ -122,9 +122,9 @@ context('Vertical Scrolling', () => {
       cy.wait(20000);
       dashboard.switchView("Dashboard");
       dashboard.getWorkToggle("Current").should('have.class', 'selected').and('be.visible');
-      cy.log('verify scrolling under current work')
+      cy.log('verify scrolling under current work');
       scrolling.verifyDashboard();
-      
+
       cy.log('verify scrolling under published work');
       dashboard.getWorkToggle("Published").should('not.have.class', 'selected').and('be.visible').click({ force: true });
       cy.wait(10000);
@@ -141,13 +141,13 @@ context('Vertical Scrolling', () => {
         dashboard.getStudentCanvas(".north-east").find("[data-testid='document-content'] .tile-row").last().scrollIntoView();
         dashboard.getStudentCanvas(".north-east").find("[data-testid='document-content'] .tile-row").last().should("be.visible");
       });
-      
+
       cy.log('verify scrolling for individual student workspace');
       dashboard.getWorkToggle("Current").should('have.class', 'selected').and('be.visible');
       cy.wait(2000);
       dashboard.getGroups().eq(0).within(() => {
         dashboard.getStudentID(0).should('contain', "S1").click();
-      });  
+      });
       dashboard.getGroups().eq(0).within(() => {
         dashboard.getStudentCanvas(".north-west").find('#section_NW').should("not.be.visible");
         dashboard.getStudentCanvas(".north-west").find('#section_NW').scrollIntoView();
@@ -155,4 +155,4 @@ context('Vertical Scrolling', () => {
       });
     });
   });
-})
+});

--- a/cypress/e2e/functional/tile_tests/shared_dataset_spec.js
+++ b/cypress/e2e/functional/tile_tests/shared_dataset_spec.js
@@ -85,13 +85,12 @@ context('Shared Dataset', function () {
 
       cy.log("All Tiles Highlight Cases Selected In Datacard");
       tableTile.getTableRow().eq(0).should("not.have.class", "highlighted");
-      // TODO: The xy plot is not set up for attribute selection so I'm commenting out these lines for now
       // TODO: It would be better to check which dot is highlighted, rather than counting how many are highlighted
-      // xyTile.getHighlightedDot().should("not.exist");
+      xyTile.getHighlightedDot().should("have.length", 3);
       datacardTile.getPreviousCardButton().click();
       datacardTile.getNavPanel().click("left");
       tableTile.getTableRow().eq(0).should("have.class", "highlighted");
-      // xyTile.getHighlightedDot().should("have.length", 1);
+      xyTile.getHighlightedDot().should("have.length", 1);
       // Selecting a case should deselect all attributes
       datacardTile.getAttrName().eq(0).should("not.have.class", "highlighted");
 
@@ -110,6 +109,16 @@ context('Shared Dataset', function () {
       xyTile.getGraphDot().eq(0).click();
       tableTile.getTableCellContent(2).should("have.class", "highlighted");
       datacardTile.getAttrValueCell().eq(1).should("have.class", "highlighted");
+
+      cy.log("All Tiles Highlight Attributes Selected In XY Plot");
+      xyTile.getTile().click(); // Deselect all cases
+      tableTile.getSelectedColumnHeaders().should("have.length", 0);
+      datacardTile.getAttrName().eq(2).should("not.have.class", "highlighted");
+      xyTile.getHighlightedDot().should("not.exist");
+      xyTile.selectYAttribute("y2");
+      tableTile.getSelectedColumnHeaders().should("have.length", 1);
+      datacardTile.getAttrName().eq(2).should("have.class", "highlighted");
+      xyTile.getHighlightedDot().should("have.length", 3);
 
       cy.log("Datacard Sort View Highlights Cases Correctly And Can Change Case Highlight");
       tableTile.getTableRow().eq(1).should("not.have.class", "highlighted");

--- a/cypress/e2e/functional/tile_tests/shared_dataset_spec.js
+++ b/cypress/e2e/functional/tile_tests/shared_dataset_spec.js
@@ -103,26 +103,20 @@ context('Shared Dataset', function () {
       // Selecting an attribute should deselect all cases
       datacardTile.getNavPanel().should("not.have.class", "highlighted");
 
-      cy.log("All Tiles Highlight Cases Selected In XY Plot");
+      cy.log("All Tiles Highlight Cells Selected In XY Plot");
       xyTile.getTile().click(); // Deselect all cases
-      tableTile.getTableRow().eq(0).should("not.have.class", "highlighted");
-      datacardTile.getNavPanel().should("not.have.class", "highlighted");
-      datacardTile.getAttrValueCell().eq(0).should("not.have.class", "highlighted");
+      tableTile.getTableCellContent(2).should("not.have.class", "highlighted");
+      datacardTile.getAttrValueCell().eq(1).should("not.have.class", "highlighted");
       xyTile.getGraphDot().eq(0).click();
-      tableTile.getTableRow().eq(0).should("have.class", "highlighted");
-      datacardTile.getNavPanel().should("have.class", "highlighted");
-      datacardTile.getAttrValueCell().eq(0).should("have.class", "highlighted");
+      tableTile.getTableCellContent(2).should("have.class", "highlighted");
+      datacardTile.getAttrValueCell().eq(1).should("have.class", "highlighted");
 
       cy.log("Datacard Sort View Highlights Cases Correctly And Can Change Case Highlight");
-      tableTile.getTableRow().eq(0).should("have.class", "highlighted");
       tableTile.getTableRow().eq(1).should("not.have.class", "highlighted");
       datacardTile.getSortSelect().select("x");
-      datacardTile.getSortCardHeading().eq(0).should("have.class", "highlighted");
       datacardTile.getSortCardHeading().eq(1).should("not.have.class", "highlighted");
       datacardTile.getSortCardHeading().eq(1).click();
-      datacardTile.getSortCardHeading().eq(0).should("not.have.class", "highlighted");
       datacardTile.getSortCardHeading().eq(1).should("have.class", "highlighted");
-      tableTile.getTableRow().eq(0).should("not.have.class", "highlighted");
       tableTile.getTableRow().eq(1).should("have.class", "highlighted");
 
       cy.log("Datacard Sort View Highlights Attributes Correctly And Can Change Attribute Highlight");

--- a/src/components/tiles/table/table-tile.tsx
+++ b/src/components/tiles/table/table-tile.tsx
@@ -54,10 +54,8 @@ const TableToolComponent: React.FC<ITileProps> = observer(function TableToolComp
   // Forces the table to rerender when its dataset's selection changes
   useEffect(() => {
     triggerRowChange();
-    dataSet.selectedAttributeIdString; // eslint-disable-line no-unused-expressions
-    dataSet.selectedCaseIdString; // eslint-disable-line no-unused-expressions
-    dataSet.selectedCellIdString; // eslint-disable-line no-unused-expressions
-  }, [dataSet.selectedAttributeIdString, dataSet.selectedCaseIdString, dataSet.selectedCellIdString, triggerRowChange]);
+    dataSet.selectionIdString; // eslint-disable-line no-unused-expressions
+  }, [dataSet.selectionIdString, triggerRowChange]);
 
   // Set up user specified columns and function to measure a column
   const { measureColumnWidth, resizeColumn, resizeColumnWidth } = useMeasureColumnWidth({ content });

--- a/src/models/data/data-types.ts
+++ b/src/models/data/data-types.ts
@@ -54,7 +54,9 @@ export interface ICell {
   caseId: string;
 }
 export function getCellId(cell: ICell) {
-  return JSON.stringify(cell);
+  // Create a new one to ensure that the members are in a consistent order
+  const orderedCell = { attributeId: cell.attributeId, caseId: cell.caseId };
+  return JSON.stringify(orderedCell);
 }
 export function getCellFromId(cellId: string) {
   const cell = JSON.parse(cellId);

--- a/src/plugins/graph/components/casedots.tsx
+++ b/src/plugins/graph/components/casedots.tsx
@@ -39,9 +39,9 @@ export const CaseDots = function CaseDots(props: {
           .attr('r', dragPointRadius);
         setDragID(aCaseData.caseID);
         currPos.current = {x: event.clientX, y: event.clientY};
-        handleClickOnDot(event, aCaseData.caseID, dataset);
+        handleClickOnDot(event, aCaseData, dataConfiguration);
       }
-    }, [dragPointRadius, dataset, enableAnimation]),
+    }, [dragPointRadius, dataConfiguration, enableAnimation]),
 
     onDrag = useCallback((event: MouseEvent) => {
       if (dotsRef.current && dragID !== '') {

--- a/src/plugins/graph/components/dotplotdots.tsx
+++ b/src/plugins/graph/components/dotplotdots.tsx
@@ -49,7 +49,7 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
         setDragID(() => tItsID);
         currPos.current = primaryIsBottom ? event.clientX : event.clientY;
 
-        handleClickOnDot(event, tItsID, dataset);
+        handleClickOnDot(event, aCaseData, dataConfiguration);
         // Record the current values, so we can change them during the drag and restore them when done
         const { caseSelection } = dataConfiguration || {},
           primaryAttrID = dataConfiguration?.attributeID(dataConfiguration?.primaryRole ?? 'x') ?? '';

--- a/src/plugins/graph/components/scatterdots.tsx
+++ b/src/plugins/graph/components/scatterdots.tsx
@@ -62,7 +62,7 @@ export const ScatterDots = function ScatterDots(props: PlotProps) {
         setDragID(tItsID);
         currPos.current = {x: event.clientX, y: event.clientY};
 
-        handleClickOnDot(event, tItsID, dataset);
+        handleClickOnDot(event, aCaseData, dataConfiguration);
         // Record the current values, so we can change them during the drag and restore them when done
         const { caseSelection } = dataConfiguration || {},
           xAttrID = dataConfiguration?.attributeID('x') ?? '';

--- a/src/plugins/graph/utilities/graph-utils.ts
+++ b/src/plugins/graph/utilities/graph-utils.ts
@@ -183,9 +183,13 @@ export function matchCirclesToData(props: IMatchCirclesProps) {
 function isCircleSelected(aCaseData: CaseData, dataConfiguration?: IDataConfigurationModel) {
   const dataset = dataConfiguration?.dataset;
   if (!dataset) return false;
+  const xAttributeId = dataConfiguration.xAttributeID;
+  const yAttributeId = dataConfiguration.yAttributeID(aCaseData.plotNum);
   return dataset.isCaseSelected(aCaseData.caseID)
-    || dataset.isAttributeSelected(dataConfiguration.xAttributeID)
-    || dataset.isAttributeSelected(dataConfiguration.yAttributeID(aCaseData.plotNum));
+    || dataset.isAttributeSelected(xAttributeId)
+    || dataset.isAttributeSelected(yAttributeId)
+    || dataset.isCellSelected({ attributeId: xAttributeId, caseId: aCaseData.caseID })
+    || dataset.isCellSelected({ attributeId: yAttributeId, caseId: aCaseData.caseID });
 }
 
 function applySelectedClassToCircles(selection: DotSelection, dataConfiguration?: IDataConfigurationModel){

--- a/src/plugins/graph/utilities/graph-utils.ts
+++ b/src/plugins/graph/utilities/graph-utils.ts
@@ -121,17 +121,21 @@ export function getPointTipText(caseID: string, attributeIDs: string[], dataset?
   return Array.from(new Set(attrArray)).filter(anEntry => anEntry !== '').join('<br>');
 }
 
-export function handleClickOnDot(event: MouseEvent, caseID: string, dataset?: IDataSet) {
+export function handleClickOnDot(event: MouseEvent, caseData: CaseData, dataConfiguration?: IDataConfigurationModel) {
+  if (!dataConfiguration) return;
+  const dataset = dataConfiguration.dataset;
+  const yAttributeId = dataConfiguration.yAttributeID(caseData.plotNum);
+  const yCell = { attributeId: yAttributeId, caseId: caseData.caseID };
   const extendSelection = event.shiftKey,
-    caseIsSelected = dataset?.isCaseSelected(caseID);
-  if (!caseIsSelected) {
-    if (extendSelection) { // case is not selected and Shift key is down => add case to selection
-      dataset?.selectCases([caseID]);
-    } else { // case is not selected and Shift key is up => only this case should be selected
-      dataset?.setSelectedCases([caseID]);
+    cellIsSelected = dataset?.isCellSelected(yCell);
+  if (!cellIsSelected) {
+    if (extendSelection) { // y cell is not selected and Shift key is down => add y cell to selection
+      dataset?.selectCells([yCell]);
+    } else { // y cell is not selected and Shift key is up => only this y cell should be selected
+      dataset?.setSelectedCells([yCell]);
     }
-  } else if (extendSelection) { // case is selected and Shift key is down => deselect case
-    dataset?.selectCases([caseID], false);
+  } else if (extendSelection) { // y cell is selected and Shift key is down => deselect cell
+    dataset?.selectCells([yCell], false);
   }
 }
 
@@ -174,7 +178,7 @@ export function matchCirclesToData(props: IMatchCirclesProps) {
     event.stopPropagation();
     const target = select(event.target as SVGSVGElement);
     if (target.node()?.nodeName === 'circle') {
-      handleClickOnDot(event, (target.datum() as CaseData).caseID, dataConfiguration.dataset);
+      handleClickOnDot(event, target.datum() as CaseData, dataConfiguration);
     }
   });
   dataConfiguration.setPointsNeedUpdating(false);


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/186386406

This PR adds cell highlighting in the graph tile.
- Cells highlighted in tables and values highlighted in datadecks will now cause the corresponding dots to highlight in linked xy plot tiles.
  - Note that selecting an x axis cell will select all dots in the case, because all dots share that cell as their x values.
- Clicking a dot in an xy plot will now highlight that dot's y cell rather than the entire case.
  - The exception to this rule is for units with the `dataset.cellsSelectCases` option set (currently only true for the `moth` unit). In this case, clicking a dot will still select the entire case.