### PR TITLE
"Add data" button includes diagrams

### DIFF
--- a/src/components/tiles/hooks/use-tile-model-context.ts
+++ b/src/components/tiles/hooks/use-tile-model-context.ts
@@ -1,8 +1,6 @@
-import { createContext, useCallback, useContext } from "react";
-import { ITileModel } from "../../../../models/tiles/tile-model";
-import { useUIStore } from "../../../../hooks/use-stores";
-
-export const TileModelContext = createContext<ITileModel | undefined>(undefined);
+import { useCallback, useContext } from "react";
+import { TileModelContext } from "../tile-api";
+import { useUIStore } from "../../../hooks/use-stores";
 
 export const useTileModelContext = () => {
   const tile = useContext(TileModelContext);

--- a/src/hooks/use-link-provider-tile-dialog.tsx
+++ b/src/hooks/use-link-provider-tile-dialog.tsx
@@ -3,7 +3,7 @@ import React, { useRef, useState } from "react";
 import LinkGraphIcon from "../clue/assets/icons/table/link-graph-icon.svg";
 import { useCustomModal } from "./use-custom-modal";
 import { isLinkedToTile } from "../models/shared/shared-data-utils";
-import { ITileLinkMetadata } from "../models/tiles/tile-link-types";
+import { ITileLinkMetadata, ITypedTileLinkMetadata } from "../models/tiles/tile-link-types";
 import { ITileModel } from "../models/tiles/tile-model";
 
 import "./link-tile-dialog.scss";
@@ -52,7 +52,7 @@ const Content: React.FC<IContentProps>
 };
 
 interface IProps {
-  linkableTiles: ITileLinkMetadata[];
+  linkableTiles: ITypedTileLinkMetadata[];
   model: ITileModel;
   onLinkTile: (tileInfo: ITileLinkMetadata) => void;
   onUnlinkTile: (tileInfo: ITileLinkMetadata) => void;
@@ -62,19 +62,21 @@ export const useLinkProviderTileDialog = ({
 }: IProps) => {
   const tileTitle = model.computedTitle;
   const [selectValue, setSelectValue] = useState("");
+  const selectedTileInfo = linkableTiles.find(tile => tile.id === selectValue);
+
   const handleClick = () => {
     const tileInfo = linkableTiles.find(tile => tile.id === selectValue);
     if (tileInfo) {
-      if (isLinkedToTile(model, tileInfo.id)) {
+      if (isLinkedToTile(model, tileInfo.id, tileInfo.type)) {
         onUnlinkTile?.(tileInfo);
       } else {
         onLinkTile?.(tileInfo);
       }
     }
   };
-  const unlinkedTiles = linkableTiles.filter(tileInfo => !isLinkedToTile(model, tileInfo.id));
+  const unlinkedTiles = linkableTiles.filter(tileInfo => !isLinkedToTile(model, tileInfo.id, tileInfo.type));
   const linkedTiles =
-    linkableTiles.filter(tileInfo => isLinkedToTile(model, tileInfo.id) && tileInfo.id !== model.id);
+    linkableTiles.filter(tileInfo => isLinkedToTile(model, tileInfo.id, tileInfo.type) && tileInfo.id !== model.id);
   const [showModal, hideModal] = useCustomModal({
     className: "link-tile",
     Icon: LinkGraphIcon,
@@ -83,7 +85,7 @@ export const useLinkProviderTileDialog = ({
     contentProps: { unlinkedTiles, linkedTiles, selectValue, tileTitle, setSelectValue },
     buttons: [
       { label: "Cancel" },
-      { label: !isLinkedToTile(model, selectValue) ? "Link" : "Unlink",
+      { label: !isLinkedToTile(model, selectValue, selectedTileInfo?.type) ? "Link" : "Unlink",
         isDefault: true,
         isDisabled: !selectValue,
         onClick: handleClick

--- a/src/hooks/use-linkable-tiles.ts
+++ b/src/hooks/use-linkable-tiles.ts
@@ -9,7 +9,7 @@ export const useLinkableTiles = ({ model }: IUseLinkableTilesProps) => {
   // See document-scope.md for notes about how linkable tiles
   // are accessed here.
   const documentContent = getDocumentContentFromNode(model);
-  const { providers, consumers } = documentContent?.getLinkableTiles() || kNoLinkableTiles;
+  const { providers, consumers, variableProviders } = documentContent?.getLinkableTiles() || kNoLinkableTiles;
 
   // add default title if there isn't a title
   const countsOfType = {} as Record<string, number>;
@@ -24,6 +24,7 @@ export const useLinkableTiles = ({ model }: IUseLinkableTilesProps) => {
 
   return {
     providers: providers.map(addDefaultTitle),
-    consumers: consumers.map(addDefaultTitle)
+    consumers: consumers.map(addDefaultTitle),
+    variableProviders: variableProviders.map(addDefaultTitle)
   };
 };

--- a/src/hooks/use-provider-tile-linking.tsx
+++ b/src/hooks/use-provider-tile-linking.tsx
@@ -15,6 +15,7 @@ interface IProps {
   actionHandlers?: any;
   model: ITileModel;
   readOnly?: boolean;
+  includeVariableProviders?: boolean;
   allowMultipleGraphDatasets?: boolean;
 }
 
@@ -28,17 +29,20 @@ interface IProps {
  * @param props.model - model representing the Tile that we are linking to.
  * @param props.actionHandlers - callback methods to handle linking and unlinking.
  *  Optional; default methods are provided.
- * @param props.readOnly - whether we are in a read-only context
+ * @param props.readOnly - whether we are in a read-only context (default false)
+ * @param props.includeVariableProviders - whether to allow linking to tiles that provide shared variables,
+ *  in addition to tiles that provide a shared dataset (default false)
  * @param props.allowMultipleGraphDatasets - whether the dialog should allow multiple connections to an XY Plot tile.
+ *  (default false)
  *
  * @returns a boolean indicating whether any providers are available, and a function to open the dialog.
  */
 export const useProviderTileLinking = ({
-  actionHandlers, model, readOnly, allowMultipleGraphDatasets
+  actionHandlers, model, readOnly, includeVariableProviders, allowMultipleGraphDatasets
 }: IProps) => {
   const {handleRequestTileLink, handleRequestTileUnlink} = actionHandlers || {};
   const { providers, variableProviders } = useLinkableTiles({ model });
-  const isLinkEnabled = (providers.length > 0 || variableProviders.length > 0);
+  const isLinkEnabled = (providers.length > 0 || (!!includeVariableProviders && variableProviders.length > 0));
 
   const linkTile = useCallback((tileInfo: ITileLinkMetadata) => {
     const providerTile = getTileContentById(model.content, tileInfo.id);
@@ -80,7 +84,7 @@ export const useProviderTileLinking = ({
   const onLinkTile = handleRequestTileLink || linkTile;
   const onUnlinkTile = handleRequestTileUnlink || unlinkTile;
 
-  const linkableTiles = providers.concat(variableProviders);
+  const linkableTiles = includeVariableProviders ? providers.concat(variableProviders) : providers;
 
   const [showLinkTileDialog] =
           useLinkProviderTileDialog({

--- a/src/models/document/base-document-content.ts
+++ b/src/models/document/base-document-content.ts
@@ -263,26 +263,31 @@ export const BaseDocumentContentModel = types
     getLinkableTiles(): ILinkableTiles {
       const providers: ITypedTileLinkMetadata[] = [];
       const consumers: ITypedTileLinkMetadata[] = [];
+      const variableProviders: ITypedTileLinkMetadata[] = [];
       self.rowOrder.forEach(rowId => {
         const row = self.getRow(rowId);
         each(row?.tiles, tileEntry => {
           const tileType = self.getTileType(tileEntry.tileId);
-          const titleBase = getTileContentInfo(tileType)?.titleBase || tileType;
           if (tileType) {
             const tile = self.getTile(tileEntry.tileId);
+            const contentInfo = getTileContentInfo(tileType);
+            const titleBase = contentInfo?.titleBase || tileType;
             const typedTileLinkMetadata: ITypedTileLinkMetadata = {
               id: tileEntry.tileId, type: tileType, title: tile?.title, titleBase
             };
-            if (getTileContentInfo(tileType)?.isDataProvider) {
+            if (contentInfo?.isDataProvider) {
               providers.push(typedTileLinkMetadata);
             }
-            if (getTileContentInfo(tileType)?.isDataConsumer) {
+            if (contentInfo?.isDataConsumer) {
               consumers.push(typedTileLinkMetadata);
+            }
+            if (contentInfo?.isVariableProvider) {
+              variableProviders.push(typedTileLinkMetadata);
             }
           }
         });
       });
-      return { providers, consumers };
+      return { providers, consumers, variableProviders };
     },
     exportTileAsJson(tileInfo: TileLayoutModelType, options?: IDocumentExportOptions) {
       const { includeTileIds, ...otherOptions } = options || {};

--- a/src/models/tiles/tile-content-info.ts
+++ b/src/models/tiles/tile-content-info.ts
@@ -43,6 +43,7 @@ export interface ITileContentInfo {
   exportNonDefaultHeight?: boolean;
   isDataConsumer?: boolean;
   isDataProvider?: boolean;
+  isVariableProvider?: boolean;
   consumesMultipleDataSets?: boolean;
   tileSnapshotPreProcessor?: TileModelSnapshotPreProcessor;
   contentSnapshotPostProcessor?: TileContentSnapshotPostProcessor;

--- a/src/models/tiles/tile-link-types.ts
+++ b/src/models/tiles/tile-link-types.ts
@@ -15,5 +15,6 @@ export interface ITypedTileLinkMetadata extends ITileLinkMetadata {
 export interface ILinkableTiles {
   providers: ITypedTileLinkMetadata[];
   consumers: ITypedTileLinkMetadata[];
+  variableProviders: ITypedTileLinkMetadata[];
 }
-export const kNoLinkableTiles: ILinkableTiles = { providers: [], consumers: [] };
+export const kNoLinkableTiles: ILinkableTiles = { providers: [], consumers: [], variableProviders: [] };

--- a/src/plugins/diagram-viewer/diagram-registration.ts
+++ b/src/plugins/diagram-viewer/diagram-registration.ts
@@ -15,7 +15,8 @@ registerTileContentInfo({
   //   typescript type for a MST "Class" which is less restrictive
   modelClass: DiagramMigrator as typeof DiagramContentModel,
   defaultContent: defaultDiagramContent,
-  defaultHeight: kDiagramDefaultHeight
+  defaultHeight: kDiagramDefaultHeight,
+  isVariableProvider: true
 });
 
 registerTileComponentInfo({

--- a/src/plugins/graph/adornments/adornments.tsx
+++ b/src/plugins/graph/adornments/adornments.tsx
@@ -8,7 +8,7 @@ import { Adornment } from "./adornment";
 import { getAdornmentContentInfo } from "./adornment-content-info";
 import { IAdornmentModel } from "./adornment-models";
 import { useInstanceIdContext } from "../imports/hooks/use-instance-id-context";
-import { useTileModelContext } from "../imports/hooks/use-tile-model-context";
+import { useTileModelContext } from "../../../components/tiles/hooks/use-tile-model-context";
 import { useDataConfigurationContext } from "../hooks/use-data-configuration-context";
 
 import "./adornments.scss";

--- a/src/plugins/graph/components/attribute-label.tsx
+++ b/src/plugins/graph/components/attribute-label.tsx
@@ -11,7 +11,7 @@ import {GraphPlace, isVertical} from "../imports/components/axis-graph-shared";
 import {graphPlaceToAttrRole, kGraphClassSelector} from "../graph-types";
 import {useGraphModelContext} from "../models/graph-model";
 import {useGraphLayoutContext} from "../models/graph-layout";
-import {useTileModelContext} from "../imports/hooks/use-tile-model-context";
+import {useTileModelContext} from "../../../components/tiles/hooks/use-tile-model-context";
 import {getStringBounds} from "../imports/components/axis/axis-utils";
 import {AxisOrLegendAttributeMenu} from "../imports/components/axis/components/axis-or-legend-attribute-menu";
 import { useGraphSettingsContext } from "../hooks/use-graph-settings-context";

--- a/src/plugins/graph/components/graph-toolbar-registration.tsx
+++ b/src/plugins/graph/components/graph-toolbar-registration.tsx
@@ -13,7 +13,8 @@ function LinkTileButton(name: string, title: string, allowMultiple: boolean) {
   const model = useContext(TileModelContext)!;
 
   const { isLinkEnabled, showLinkTileDialog }
-    = useProviderTileLinking({ model, allowMultipleGraphDatasets: allowMultiple });
+    = useProviderTileLinking({ model, allowMultipleGraphDatasets: allowMultiple,
+        includeVariableProviders: allowMultiple });
 
   const handleLinkTileButtonClick = (e: React.MouseEvent) => {
     isLinkEnabled && showLinkTileDialog();

--- a/src/plugins/graph/components/legend/multi-legend.tsx
+++ b/src/plugins/graph/components/legend/multi-legend.tsx
@@ -10,6 +10,7 @@ import { AddSeriesButton } from "./add-series-button";
 import { useInstanceIdContext } from "../../imports/hooks/use-instance-id-context";
 import { kGraphDefaultHeight } from "../../graph-types";
 import { ReadOnlyContext } from "../../../../components/document/read-only-context";
+import { VariableFunctionLegend } from "./variable-function-legend";
 
 export const kMultiLegendMenuHeight = 30;
 export const kMultiLegendPadding = 20;
@@ -91,6 +92,7 @@ export const MultiLegend = observer(function MultiLegend(props: IMultiLegendProp
 
   return (
     <div className="multi-legend" ref={ multiLegendRef }>
+      <VariableFunctionLegend/>
       {legendItemRows}
     </div>
   );

--- a/src/plugins/graph/components/legend/variable-function-legend.tsx
+++ b/src/plugins/graph/components/legend/variable-function-legend.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { getSharedModelManager } from "../../../../models/tiles/tile-environment";
+import { ITileModel } from "../../../../models/tiles/tile-model";
+import { SharedVariables } from "../../../shared-variables/shared-variables";
+import { useTileModelContext } from "../../../../components/tiles/hooks/use-tile-model-context";
+
+// FIXME: this function gets run a bazillion times - eg on every scroll -
+// but not when we need it to be run - after link/unlink operation.
+// Not spending time to optimize now since it's only temporary; presumably
+// the presence of the Adornment will actually be used to control showing this legend.
+function hasLinkedSharedVariables(tileModel: ITileModel) {
+  const smm = getSharedModelManager(tileModel);
+  if (smm?.isReady) {
+    const sharedVars = smm.findFirstSharedModelByType(SharedVariables, tileModel?.id);
+    if (sharedVars) return true;
+  }
+  return false;
+}
+
+/**
+ * XY Plot legend component that will control variables-based adornment.
+ * Just a stub for now.
+ */
+export function VariableFunctionLegend() {
+
+  const { tile } = useTileModelContext();
+  const hasSharedVariables = tile && hasLinkedSharedVariables(tile);
+
+  if (hasSharedVariables) {
+    return (<p>Shared variables are attached</p>);
+  } else {
+    return null;
+  }
+
+}


### PR DESCRIPTION
*Not to be merged into master. This is part of the long-running branch for XY Plot/Diagram integration*

PT-186345541

Allows XY Plot tiles to link to shared variables provided by a Diagram tile.  The only current effect of linking is that the message "Shared variables are attached" will be shown in the plot legend.

Implementation: 
* Adds new Tile metadata key `isVariableProvider` -- currently true only for the Diagram tile. This means it has a set of shared variables that may be interesting for linking to other tiles.
* Updates the "provider tile linking" dialog to include variable-provider tiles when requested-- currently only requested by the XY Plot tile, and only when using the 'Add data' button, not the 'Link data' button.

Code cleanup: this PR also removes `use-tile-model-context` from `plugins/graph/imports/hooks` -- which did not work since it defined its own `TileModelContext` that was never provided in CLUE -- and instead puts it in `components/tiles/hooks` referencing the context that `TileComponent` provides.

Testing notes:
* I don't know of any unit in which this can be tested right now. We will need to create a unit that both enables the Diagram tile and includes the "Add data" button on the XY Plot.
* The indicator in the legend doesn't show up right away; you have to scroll or make some other change. This is not worth fixing until a later stage of this work.

