### PR TITLE
Only render EditableGraphValue if the axis is numeric

### DIFF
--- a/src/plugins/graph/components/graph.tsx
+++ b/src/plugins/graph/components/graph.tsx
@@ -293,25 +293,26 @@ export const Graph = observer(
               const axisModel = graphModel?.getAxis(axis);
               const minVal = isNumericAxisModel(axisModel) ? axisModel.min : kDefaultNumericAxisBounds[0];
               const maxVal = isNumericAxisModel(axisModel) ? axisModel.max : kDefaultNumericAxisBounds[1];
-              return (
-                <div key={`${axis}-min-max`}>
-                  <EditableGraphValue
-                    value={minVal}
-                    minOrMax={"min"}
-                    axis={axis}
-                    onValueChange={(newValue) => handleMinMaxChange("min", axis, newValue)}
-                    readOnly={readOnly}
-                  />
-                  <EditableGraphValue
-                    value={maxVal}
-                    minOrMax={"max"}
-                    axis={axis}
-                    onValueChange={(newValue) => handleMinMaxChange("max", axis, newValue)}
-                    readOnly={readOnly}
-                  />
-                </div>
-              );
-
+              if (isNumericAxisModel(axisModel)){
+                return (
+                  <div key={`${axis}-min-max`}>
+                    <EditableGraphValue
+                      value={minVal}
+                      minOrMax={"min"}
+                      axis={axis}
+                      onValueChange={(newValue) => handleMinMaxChange("min", axis, newValue)}
+                      readOnly={readOnly}
+                    />
+                    <EditableGraphValue
+                      value={maxVal}
+                      minOrMax={"max"}
+                      axis={axis}
+                      onValueChange={(newValue) => handleMinMaxChange("max", axis, newValue)}
+                      readOnly={readOnly}
+                    />
+                  </div>
+                );
+              }
             })
           }
         </div>


### PR DESCRIPTION
This makes it so the axis scale controls are only visible on numeric axes.  