### PR TITLE
Added cypress tests for edit box in xy-plot axes

### DIFF
--- a/cypress/e2e/functional/tile_tests/xy_plot_tool_spec.js
+++ b/cypress/e2e/functional/tile_tests/xy_plot_tool_spec.js
@@ -84,6 +84,18 @@ context('XYPlot Tool Tile', function () {
       cy.log("verify graph dot is updated");
       xyTile.getGraphDot().should('have.length', 2);
 
+      cy.log("verify edit box for horizontal and vertical axes");
+      xyTile.getEditableAxisBox("bottom", "min").click().type('-10{enter}');
+      xyTile.getEditableAxisBox("bottom", "min").should('contain', '-10');
+      xyTile.getEditableAxisBox("bottom", "max").click().type('50.02345{enter}');
+      xyTile.getEditableAxisBox("bottom", "max").should('contain', '50.02345');
+      xyTile.getEditableAxisBox("left", "min").click().type('-10.55{enter}');
+      xyTile.getEditableAxisBox("left", "min").should('contain', '-10.55');
+      xyTile.getEditableAxisBox("left", "max").click().type('50{enter}');
+      xyTile.getEditableAxisBox("left", "max").should('contain', '50');
+      xyTile.getEditableAxisBox("left", "max").click().type('abc{enter}');
+      xyTile.getEditableAxisBox("left", "max").should('contain', '50');
+
       cy.log("restore points to canvas");
       primaryWorkspace.openResourceTab();
       resourcePanel.openPrimaryWorkspaceTab("my-work");

--- a/cypress/support/elements/tile/XYPlotToolTile.js
+++ b/cypress/support/elements/tile/XYPlotToolTile.js
@@ -38,5 +38,8 @@ class XYPlotToolTile {
     this.getYAttributesLabel(workspaceClass).first().click({ force: true });
     cy.get(`.chakra-portal button`).contains(attribute).click({ force: true });
   }
+  getEditableAxisBox(axis, minOrMax) {
+    return this.getTile().find(`[data-testid=editable-border-box-${axis}-${minOrMax}]`);
+  }
 }
 export default XYPlotToolTile;

--- a/src/plugins/graph/components/editable-graph-value.tsx
+++ b/src/plugins/graph/components/editable-graph-value.tsx
@@ -104,7 +104,8 @@ export const EditableGraphValue: React.FC<IEditableValueProps> = observer(functi
   };
 
   return (
-    <div style={borderBoxStyles} className={"editable-border-box"} onClick={handleClick}>
+    <div style={borderBoxStyles} className={"editable-border-box"} onClick={handleClick}
+      data-testid={`editable-border-box-${axis}-${minOrMax}`}>
       { isEditing ?
         <input
           className="input-textbox"


### PR DESCRIPTION
This PR includes:
1. Adding `data-testid` for editable-box so that these elements can be accessed from the cypress tests in a straight-forward way.
2. Included tests to check for integer, decimal and string values in the edit boxes.