### PR TITLE
Handle tile render errors

### DIFF
--- a/cypress/e2e/functional/tile_tests/tile_error_spec.js
+++ b/cypress/e2e/functional/tile_tests/tile_error_spec.js
@@ -1,0 +1,7 @@
+context('Tile Errors', function () {
+  it("Shows Errors without crashing CLUE", () => {
+    cy.log("shows error message for tiles with render errors");
+    cy.visit("./doc-editor.html?unit=./curriculum/example-curriculum/error-unit.json&document=curriculum/example-curriculum/error-document.json");
+    cy.get(".document-error").should("contain.text", "Error rendering the document");
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "react-data-grid": "7.0.0-canary.46",
         "react-dom": "^17.0.2",
         "react-dom-factories": "^1.0.2",
+        "react-error-boundary": "^4.0.11",
         "react-modal": "^3.15.1",
         "react-query": "^3.39.2",
         "react-resize-detector": "^8.0.4",
@@ -5971,6 +5972,22 @@
         "react-test-renderer": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/react-hooks/node_modules/react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/@testing-library/user-event": {
@@ -19157,15 +19174,11 @@
       "license": "MIT"
     },
     "node_modules/react-error-boundary": {
-      "version": "3.1.3",
-      "dev": true,
-      "license": "MIT",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.0.11.tgz",
+      "integrity": "sha512-U13ul67aP5DOSPNSCWQ/eO0AQEYzEFkVljULQIjMV0KlffTAhxuDoBKdO0pb/JZ8mDhMKFZ9NZi0BmLGUiNphw==",
       "dependencies": {
         "@babel/runtime": "^7.12.5"
-      },
-      "engines": {
-        "node": ">=10",
-        "npm": ">=6"
       },
       "peerDependencies": {
         "react": ">=16.13.1"
@@ -26633,6 +26646,17 @@
       "requires": {
         "@babel/runtime": "^7.12.5",
         "react-error-boundary": "^3.1.0"
+      },
+      "dependencies": {
+        "react-error-boundary": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+          "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.12.5"
+          }
+        }
       }
     },
     "@testing-library/user-event": {
@@ -35230,8 +35254,9 @@
       "version": "1.0.2"
     },
     "react-error-boundary": {
-      "version": "3.1.3",
-      "dev": true,
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.0.11.tgz",
+      "integrity": "sha512-U13ul67aP5DOSPNSCWQ/eO0AQEYzEFkVljULQIjMV0KlffTAhxuDoBKdO0pb/JZ8mDhMKFZ9NZi0BmLGUiNphw==",
       "requires": {
         "@babel/runtime": "^7.12.5"
       }

--- a/package.json
+++ b/package.json
@@ -254,6 +254,7 @@
     "react-data-grid": "7.0.0-canary.46",
     "react-dom": "^17.0.2",
     "react-dom-factories": "^1.0.2",
+    "react-error-boundary": "^4.0.11",
     "react-modal": "^3.15.1",
     "react-query": "^3.39.2",
     "react-resize-detector": "^8.0.4",

--- a/src/components/document/document-error.tsx
+++ b/src/components/document/document-error.tsx
@@ -13,7 +13,12 @@ interface IProps {
 export const DocumentError: React.FC<IProps> = ({ action, document, errorMessage, content }) => {
   const {user, db: {firebase} } = useStores();
 
-  const path = document && firebase?.getFullDocumentPath(document, user);
+  let path;
+  try {
+    path = document && firebase?.getFullDocumentPath(document, user);
+  } catch(e) {
+    path = "unable to get the document path";
+  }
   return (
     <div className="document-error" data-testid="document-error">
       <h1>Error {action} the document</h1>

--- a/src/components/document/document-error.tsx
+++ b/src/components/document/document-error.tsx
@@ -1,30 +1,42 @@
 import stringify from "json-stringify-pretty-compact";
 import React from "react";
-import { ContentStatus, DocumentModelType } from "../../models/document/document";
+import { useStores } from "../../hooks/use-stores";
+import { DocumentModelType } from "../../models/document/document";
 import "./document-error.scss";
 
 interface IProps {
+  action: "loading" | "rendering";
   document?: DocumentModelType;
+  errorMessage?: string;
+  content?: object;
 }
-export const DocumentError: React.FC<IProps> = ({ document }) => {
-  if (document?.contentStatus !== ContentStatus.Error) {
-    return null;
-  }
+export const DocumentError: React.FC<IProps> = ({ action, document, errorMessage, content }) => {
+  const {user, db: {firebase} } = useStores();
+
+  const path = document && firebase?.getFullDocumentPath(document, user);
   return (
     <div className="document-error" data-testid="document-error">
-      <h1>Error loading the document</h1>
-      <ul>
-        <li>Key: &quot;{document.key}&quot;</li>
-        <li>User ID (uid): {document.uid}</li>
-        <li>Context ID (remoteContext): {document.remoteContext}</li>
-        <li>Type: &quot;{document.type}&quot;</li>
-      </ul>
-      <h2>Error Message</h2>
-      <pre>{document.contentErrorMessage}</pre>
-      {document.invalidContent &&
+      <h1>Error {action} the document</h1>
+      {document ?
+        <ul>
+          <li>Key: &quot;{document.key}&quot;</li>
+          <li>User ID (uid): {document.uid}</li>
+          <li>Remote Context: {document.remoteContext}</li>
+          <li>Type: &quot;{document.type}&quot;</li>
+          { path && <li>Path: {path}</li> }
+        </ul> :
+        <div>Unknown document</div>
+      }
+      {errorMessage &&
+        <>
+          <h2>Error Message</h2>
+          <pre>{errorMessage}</pre>
+        </>
+      }
+      {content &&
         <>
           <h2>Document Content</h2>
-          <pre>{stringify(document.invalidContent, {maxLength: 150})}</pre>
+          <pre>{stringify(content, {maxLength: 150})}</pre>
         </>
       }
     </div>

--- a/src/lib/db-listeners/db-other-docs-listener.ts
+++ b/src/lib/db-listeners/db-other-docs-listener.ts
@@ -85,6 +85,8 @@ export class DBOtherDocumentsListener extends BaseListener {
     const dbDoc: DBOtherPublication|null = snapshot.val();
     this.debugLogSnapshot("#handlePublicationAdded", snapshot);
     if (dbDoc) {
+      // TODO: handle rejections of this promise, see the note in
+      // the catch of db.ts#openDocument
       this.db.createDocumentModelFromOtherPublication(dbDoc, this.publicationType);
     }
   };

--- a/src/lib/db-listeners/db-problem-documents-listener.ts
+++ b/src/lib/db-listeners/db-problem-documents-listener.ts
@@ -89,6 +89,8 @@ export class DBProblemDocumentsListener extends BaseListener {
       if (existingDoc) {
         this.db.updateDocumentFromProblemDocument(existingDoc, document);
       } else {
+        // TODO: handle rejections of this promise, see the note in
+        // the catch of db.ts#openDocument
         this.db.createDocumentModelFromProblemMetadata(ProblemDocument, document.self.uid, document)
           .then((docModel) => {
             if (isOwnDocument) {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -588,19 +588,18 @@ export class DB {
           resolve(document);
         })
         .catch((msg) => {
-          // TODO: rather than rejecting the promise here it seems it would be better to resolve with a
-          // document that has a contentStatus of Error. Or perhaps add new status field that is independent
-          // contentStatus since the errors here are not content errors they are either metadata or other
-          // problems.
-          // The callers of openDocument do not handle rejected promises. So currently this results in
-          // console errors: "Uncaught (in promise) ...". There are many callers and it seems the best thing
-          // is to show the user message where the document would have been shown. Returning an error
-          // document should take care of this so we don't need to update all of these places. We might just
-          // need to update the DocumentError component.
-          // However we still need to trace through these place to make sure this invalid document isn't
-          // being saved somewhere. For example if a network error happens while opening a document, we
-          // wouldn't want to try to save this error document back to firebase blowing away the legitimate
-          // document.
+          // TODO: this rejected promise is not handled by the callers of openDocument. Most of those
+          // callers trace back to firebase listeners. The listener is triggered by some existing or new
+          // entry representing a document. The listener then tries to create a document from the
+          // information. If an error happens this document is likely not added to the documents list.
+          // The document will likely not ever be seen by the user.
+          // The best thing to do here seems to be to add error handling in these listeners so they can
+          // print out a useful error message. Ideally the message should include the paths in firebase
+          // that were accessed, and what data was missing or invalid. Getting all of this information
+          // will probably require additional logging a lower level.
+          // After this is changed, the updated error reporting should be tested to make sure it
+          // continues show a stack trace pointing at the original error site.
+          // For example just calling console.error(msg) here will hide the original stack trace.
           reject(msg);
         });
     });
@@ -952,4 +951,8 @@ export class DB {
     this.firebase.getLastStickyNoteViewTimestampRef().set(Date.now());
   }
 
+}
+
+export function getRefFullPath(ref: firebase.database.Reference) {
+  return ref.toString().substring(ref.root.toString().length-1);
 }

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -7,6 +7,7 @@ import { UserModelType } from "../models/stores/user";
 import { DB } from "./db";
 import { escapeKey } from "./fire-utils";
 import { urlParams } from "../utilities/url-params";
+import { DocumentModelType } from "src/models/document/document";
 
 // Set this during database testing in combination with the urlParam testMigration=true to
 // override the top-level Firebase key regardless of mode. For example, setting this to "authed-copy"
@@ -121,6 +122,18 @@ export class Firebase {
   public getUserDocumentPath(user: UserModelType, documentKey?: string, userId?: string) {
     const suffix = documentKey ? `/${documentKey}` : "";
     return `${this.getUserPath(user, userId)}/documents${suffix}`;
+  }
+
+  public getDocumentPath(document: DocumentModelType, user: UserModelType) {
+    if (document.isRemote) {
+      return `classes/${document.remoteContext}/users/${document.uid}/documents/${document.key}`;
+    } else {
+      return this.getUserDocumentPath(user, document.key, document.uid);
+    }
+  }
+
+  public getFullDocumentPath(document: DocumentModelType, user: UserModelType) {
+    return this.getFullPath(this.getDocumentPath(document, user));
   }
 
   // convenience function which returns all of the relevant paths for a given document

--- a/src/plugins/error-test/README.md
+++ b/src/plugins/error-test/README.md
@@ -1,0 +1,1 @@
+This tile will intentionally cause errors so we can test the error handling in CLUE.

--- a/src/plugins/error-test/error-test-content.ts
+++ b/src/plugins/error-test/error-test-content.ts
@@ -1,0 +1,22 @@
+import { types, Instance } from "mobx-state-tree";
+import { TileContentModel } from "../../models/tiles/tile-content";
+import { kErrorTestTileType } from "./error-test-types";
+
+export function defaultErrorTestContent(): ErrorTestContentModelType {
+  return ErrorTestContentModel.create({});
+}
+
+
+export const ErrorTestContentModel = TileContentModel
+  .named("ErrorTestTool")
+  .props({
+    type: types.optional(types.literal(kErrorTestTileType), kErrorTestTileType),
+    throwRenderError: true,
+  })
+  .views(self => ({
+    get isUserResizable() {
+      return true;
+    }
+  }));
+
+export interface ErrorTestContentModelType extends Instance<typeof ErrorTestContentModel> {}

--- a/src/plugins/error-test/error-test-icon.svg
+++ b/src/plugins/error-test/error-test-icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="36" height="34" viewBox="0 0 36 34">
+    <text text-anchor="middle" x="50%" y="25">Er</text>
+</svg>

--- a/src/plugins/error-test/error-test-registration.ts
+++ b/src/plugins/error-test/error-test-registration.ts
@@ -1,0 +1,20 @@
+import { registerTileComponentInfo } from "../../models/tiles/tile-component-info";
+import { registerTileContentInfo } from "../../models/tiles/tile-content-info";
+import { kErrorTestDefaultHeight, kErrorTestTileType } from "./error-test-types";
+import ErrorTestToolIcon from "./error-test-icon.svg";
+import { ErrorTestToolComponent } from "./error-test-tile";
+import { defaultErrorTestContent, ErrorTestContentModel } from "./error-test-content";
+
+registerTileContentInfo({
+  type: kErrorTestTileType,
+  modelClass: ErrorTestContentModel,
+  defaultContent: defaultErrorTestContent,
+  defaultHeight: kErrorTestDefaultHeight
+});
+
+registerTileComponentInfo({
+  type: kErrorTestTileType,
+  Component: ErrorTestToolComponent,
+  tileEltClass: "error-test-tool-tile",
+  Icon: ErrorTestToolIcon
+});

--- a/src/plugins/error-test/error-test-tile.scss
+++ b/src/plugins/error-test/error-test-tile.scss
@@ -1,0 +1,12 @@
+@import "../../components/vars.sass";
+
+.error-test-tool {
+  width: 100%;
+  height: 100%;
+  text-align: left;
+  overflow: auto;
+
+  &.editable {
+    border: 1px solid #cccccc;
+  }
+}

--- a/src/plugins/error-test/error-test-tile.tsx
+++ b/src/plugins/error-test/error-test-tile.tsx
@@ -1,0 +1,20 @@
+import { observer } from "mobx-react";
+import React from "react";
+import { ITileProps } from "../../components/tiles/tile-component";
+import { ErrorTestContentModelType } from "./error-test-content";
+import "./error-test-tile.scss";
+
+export const ErrorTestToolComponent: React.FC<ITileProps> = observer((props) => {
+  const content = props.model.content as ErrorTestContentModelType;
+
+  if (content.throwRenderError) {
+    throw new Error("Test error created by the Error Test tile");
+  }
+
+  return (
+    <div className="error-test-tool">
+      Error Test Component
+    </div>
+  );
+});
+ErrorTestToolComponent.displayName = "ErrorTestToolComponent";

--- a/src/plugins/error-test/error-test-types.ts
+++ b/src/plugins/error-test/error-test-types.ts
@@ -1,0 +1,3 @@
+export const kErrorTestTileType = "ErrorTest";
+
+export const kErrorTestDefaultHeight = 320;

--- a/src/public/curriculum/example-curriculum/error-document.json
+++ b/src/public/curriculum/example-curriculum/error-document.json
@@ -1,0 +1,25 @@
+{
+  "rowMap": {
+    "row1": {"id": "row1", "isSectionHeader": false, "tiles": [{"tileId": "tile1"}]},
+    "OfYbICNpRaOMedfu": {
+      "id": "OfYbICNpRaOMedfu",
+      "height": 320,
+      "isSectionHeader": false,
+      "tiles": [{"tileId": "wVdeVNVICWwijmJU"}]
+    }
+  },
+  "rowOrder": ["row1", "OfYbICNpRaOMedfu"],
+  "tileMap": {
+    "tile1": {
+      "id": "tile1",
+      "content": {"type": "Text", "text": "Welcome to the standalone document editor"}
+    },
+    "wVdeVNVICWwijmJU": {
+      "id": "wVdeVNVICWwijmJU",
+      "title": "ErrorTest 1",
+      "content": {"type": "ErrorTest", "throwRenderError": true}
+    }
+  },
+  "sharedModelMap": {},
+  "annotations": {}
+}

--- a/src/public/curriculum/example-curriculum/error-unit.json
+++ b/src/public/curriculum/example-curriculum/error-unit.json
@@ -1,0 +1,36 @@
+{
+  "code": "error-test",
+  "abbrevTitle": "ERT",
+  "title": "Error Test",
+  "subtitle": "Test errors in tiles",
+  "config": {
+    "autoAssignStudentsToIndividualGroups": true,
+    "placeholderText": "Enter notes here",
+    "toolbar": [
+      {
+        "id": "ErrorTest",
+        "title": "ErrorTest",
+        "isTileTool": true
+      },
+      {
+        "id": "Text",
+        "title": "Text",
+        "isTileTool": true
+      },
+      {
+        "id": "delete",
+        "title": "Delete",
+        "iconId": "icon-delete-tool",
+        "isTileTool": false
+      }
+    ]
+  },
+  "sections": {
+    "content": {
+      "initials": "",
+      "title": "Content",
+      "placeholder": ""
+    }
+  },
+  "investigations": []
+}

--- a/src/register-tile-types.ts
+++ b/src/register-tile-types.ts
@@ -17,6 +17,7 @@ const gTileRegistration: Record<string, () => void> = {
     import(/* webpackChunkName: "SharedVariables" */"./plugins/shared-variables/shared-variables-registration")
   ]),
   "Drawing": () => import(/* webpackChunkName: "Drawing" */"./plugins/drawing/drawing-registration"),
+  "ErrorTest": () => import(/* webpackChunkName: "Drawing" */"./plugins/error-test/error-test-registration"),
   "Expression": () => import(/* webpackChunkName: "Expression" */"./plugins/expression/expression-registration"),
   "Geometry": () => Promise.all([
     import(/* webpackChunkName: "Geometry" */"./models/tiles/geometry/geometry-registration"),

--- a/src/register-tile-types.ts
+++ b/src/register-tile-types.ts
@@ -17,7 +17,7 @@ const gTileRegistration: Record<string, () => void> = {
     import(/* webpackChunkName: "SharedVariables" */"./plugins/shared-variables/shared-variables-registration")
   ]),
   "Drawing": () => import(/* webpackChunkName: "Drawing" */"./plugins/drawing/drawing-registration"),
-  "ErrorTest": () => import(/* webpackChunkName: "Drawing" */"./plugins/error-test/error-test-registration"),
+  "ErrorTest": () => import(/* webpackChunkName: "Error" */"./plugins/error-test/error-test-registration"),
   "Expression": () => import(/* webpackChunkName: "Expression" */"./plugins/expression/expression-registration"),
   "Geometry": () => Promise.all([
     import(/* webpackChunkName: "Geometry" */"./models/tiles/geometry/geometry-registration"),


### PR DESCRIPTION
We were getting CLUE crashes when tiles had rendering errors. Since these errors can happen in the thumbnails, without error handling it is hard to find them. 

A React error boundary is used to catch these errors at the document level. We could add an additional error boundary at the tile level so then the document could still be rendered and just the specific tile would show the error. However the whole document approach seems better to start.

Also a new ErrorTest tile is added to make it easier to demo and test this error handling.

You can see the error page with this with this link:
https://collaborative-learning.concord.org/branch/improve-error-handling/doc-editor.html?unit=./curriculum/example-curriculum/error-unit.json&document=curriculum/example-curriculum/error-document.json