### PR TITLE
186507040 Multiple Variable Plots

### DIFF
--- a/cypress/e2e/functional/tile_tests/xy_plot_tool_spec.js
+++ b/cypress/e2e/functional/tile_tests/xy_plot_tool_spec.js
@@ -256,7 +256,7 @@ context('XYPlot Tool Tile', function () {
       beforeTest(queryParamsPlotVariables);
 
       cy.log("Add Diagram Tile with a Variable");
-      const name1 = "a";
+      const name1 = "variable_name";
       const value1 = "2";
       clueCanvas.addTile("diagram");
       diagramTile.getDiagramTile().click();
@@ -276,9 +276,29 @@ context('XYPlot Tool Tile', function () {
       // xyTile.selectYVariable was failing because it was catching the button from the x "dropdown" instead
       xyTile.getYVariableDropdown().click();
       xyTile.getPortalButton().eq(1).click({ force: true });
-
       xyTile.getYVariableDropdown().should("contain.text", name1);
-      xyTile.getPlottedVariablesPath().should("exist");
+
+      xyTile.getPlottedVariablesPath().should("have.length", 1);
+
+      cy.log("Plot multiple traces");
+      xyTile.getAddVariablesButton().should("exist").click();
+
+      // Select the x variable for the 2nd trace
+      xyTile.getXVariableDropdown(1).click();
+      xyTile.getPortalButton().eq(2).click({ force: true });
+      xyTile.getXVariableDropdown(1).should("contain.text", name1);
+
+      // Select the y variable for the 2nd trace
+      xyTile.getYVariableDropdown(1).click();
+      xyTile.getPortalButton().eq(3).click({ force: true });
+      xyTile.getYVariableDropdown().should("contain.text", name1);
+
+      xyTile.getPlottedVariablesPath().should("have.length", 2);
+
+      cy.log("Remove a variable trace");
+      xyTile.getRemoveVariablesButton(1).click();
+      xyTile.getPlottedVariablesPath().should("have.length", 1);
+      xyTile.getRemoveVariablesButtons().should("not.exist");
     });
   });
 });

--- a/cypress/support/elements/tile/XYPlotToolTile.js
+++ b/cypress/support/elements/tile/XYPlotToolTile.js
@@ -53,22 +53,36 @@ class XYPlotToolTile {
   getMultiLegend(workspaceClass) {
     return cy.get(`${wsClass(workspaceClass)} .graph-tool-tile .multi-legend`);
   }
+  getPlottedVariablesLegend(workspaceClass) {
+    return this.getMultiLegend(workspaceClass).find(".plotted-variables-legend");
+  }
   getVariableDropdowns(workspaceClass) {
-    return this.getMultiLegend(workspaceClass).find(".variable-function-legend-button");
+    return this.getPlottedVariablesLegend(workspaceClass).find(".variable-function-legend-button");
   }
-  getXVariableDropdown(workspaceClass) {
-    return this.getVariableDropdowns(workspaceClass).eq(0);
+  getXVariableDropdown(traceNumber = 0, workspaceClass) {
+    return this.getVariableDropdowns(workspaceClass).eq(traceNumber * 2);
   }
-  selectXVariable(variableName, workspaceClass) {
-    this.getXVariableDropdown().click();
+  // This function only works for the first menu, including y variables :\
+  selectXVariable(variableName, traceNumber = 0, workspaceClass) {
+    this.getXVariableDropdown(traceNumber).click();
     this.clickPortalButton(variableName, workspaceClass);
   }
-  getYVariableDropdown(workspaceClass) {
-    return this.getVariableDropdowns(workspaceClass).eq(1);
+  getYVariableDropdown(traceNumber = 0, workspaceClass) {
+    return this.getVariableDropdowns(workspaceClass).eq(traceNumber * 2 + 1);
   }
-  selectYVariable(variableName, workspaceClass) {
-    this.getYVariableDropdown().click();
+  // This function only works for the first menu, including x variables :\
+  selectYVariable(variableName, traceNumber = 0, workspaceClass) {
+    this.getYVariableDropdown(traceNumber).click();
     this.clickPortalButton(variableName, workspaceClass);
+  }
+  getRemoveVariablesButtons(workspaceClass) {
+    return this.getPlottedVariablesLegend(workspaceClass).find("button.remove-button");
+  }
+  getRemoveVariablesButton(traceNumber = 0, workspaceClass) {
+    return this.getRemoveVariablesButtons().eq(traceNumber);
+  }
+  getAddVariablesButton(workspaceClass) {
+    return this.getPlottedVariablesLegend(workspaceClass).find("button.add-series-button");
   }
   getEditableAxisBox(axis, minOrMax) {
     return this.getTile().find(`[data-testid=editable-border-box-${axis}-${minOrMax}]`);

--- a/src/plugins/graph/adornments/plotted-function/plotted-variables/plotted-variables-adornment-component.tsx
+++ b/src/plugins/graph/adornments/plotted-function/plotted-variables/plotted-variables-adornment-component.tsx
@@ -40,8 +40,6 @@ export const PlottedVariablesAdornmentComponent = observer(function PlottedVaria
   const xCellCount = xCats.length * xSubAxesCount;
   const yCellCount = yCats.length * ySubAxesCount;
   const classFromKey = model.classNameFromKey(cellKey);
-  // const instanceKey = model.instanceKey(cellKey);
-  const path = useRef("");
   const plottedFunctionRef = useRef<SVGGElement>(null);
   const sharedVariables = graphModel.sharedVariables;
 
@@ -51,19 +49,20 @@ export const PlottedVariablesAdornmentComponent = observer(function PlottedVaria
     const tPixelMin = xScale(xMin);
     const tPixelMax = xScale(xMax);
     const kPixelGap = 1;
-    const instanceKey = Array.from(model.plottedVariables.keys())[0];
-    const tPoints = model.computePoints({
-      instanceKey, min: tPixelMin, max: tPixelMax, xCellCount, yCellCount, gap: kPixelGap, xScale, yScale
-    });
-    if (tPoints.length === 0) return;
-    path.current = `M${tPoints[0].x},${tPoints[0].y},${curveBasis(tPoints)}`;
+    for (const instanceKey of model.plottedVariables.keys()) {
+      const tPoints = model.computePoints({
+        instanceKey, min: tPixelMin, max: tPixelMax, xCellCount, yCellCount, gap: kPixelGap, xScale, yScale
+      });
+      if (tPoints.length > 0) {
+        const path = `M${tPoints[0].x},${tPoints[0].y},${curveBasis(tPoints)}`;
 
-    const selection = select(plottedFunctionRef.current);
-    selection.append("path")
-      .attr("class", `plotted-function plotted-function-${classFromKey}`)
-      .attr("data-testid", `plotted-function-path${classFromKey ? `-${classFromKey}` : ""}`)
-      .attr("d", path.current);
-
+        const selection = select(plottedFunctionRef.current);
+        selection.append("path")
+          .attr("class", `plotted-function plotted-function-${classFromKey}`)
+          .attr("data-testid", `plotted-function-path${classFromKey ? `-${classFromKey}` : ""}`)
+          .attr("d", path);
+      }
+    }
   }, [classFromKey, model, xCellCount, xScale, yCellCount, yScale]);
 
   // Add the lines and their associated covers and labels

--- a/src/plugins/graph/components/legend/multi-legend.scss
+++ b/src/plugins/graph/components/legend/multi-legend.scss
@@ -30,28 +30,25 @@
     .legend-title {
       flex: 1 0 auto;
     }
+  }
 
-    .legend-icon {
-      flex-grow: 0 0 auto;
-      vertical-align: baseline;
+  .legend-icon {
+    flex-grow: 0 0 auto;
+    vertical-align: baseline;
 
-      .remove-button {
-        margin: 0;
-        height: 27px;
-        width: 27px;
-        padding: 2px;
-        border: none;
-        border-radius: 50%;
-        background: inherit;
-        cursor: pointer;
+    .remove-button {
+      margin: 0;
+      height: 27px;
+      width: 27px;
+      padding: 2px;
+      border: none;
+      border-radius: 50%;
+      background: inherit;
+      cursor: pointer;
 
-        &:hover {
-          background-color: $workspace-teal-light-6;
-        }
-
-
+      &:hover {
+        background-color: $workspace-teal-light-6;
       }
-
     }
   }
 

--- a/src/plugins/graph/components/legend/multi-legend.scss
+++ b/src/plugins/graph/components/legend/multi-legend.scss
@@ -64,30 +64,6 @@
       width: 50%;
       padding: 0 10%;
     }
-
-    .add-series-button {
-      height: $menu-height;
-      width: $min-menu-width;
-      border: none;
-      padding: 0;
-      background-color: inherit;
-      text-align: left;
-      font-family: Lato;
-      font-size: 14pt;
-      font-style: italic;
-      color: #707070;
-
-      &:hover {
-        background-color: $workspace-teal-light-4;
-      }
-
-      svg {
-        width: 22px;
-        height: 22px;
-        margin-right: 8px;
-        vertical-align: bottom;
-      }
-    }
   }
 
   .variable-row {
@@ -95,6 +71,31 @@
     flex-direction: row;
     margin-left: 20px;
     padding: $vertical-gap 0;
+  }
+
+  .add-series-button {
+    cursor: pointer;
+    height: $menu-height;
+    width: $min-menu-width;
+    border: none;
+    padding: 0;
+    background-color: inherit;
+    text-align: left;
+    font-family: Lato;
+    font-size: 14pt;
+    font-style: italic;
+    color: #707070;
+
+    &:hover {
+      background-color: $workspace-teal-light-4;
+    }
+
+    svg {
+      width: 22px;
+      height: 22px;
+      margin-right: 8px;
+      vertical-align: bottom;
+    }
   }
 }
 

--- a/src/plugins/graph/components/legend/variable-function-legend.tsx
+++ b/src/plugins/graph/components/legend/variable-function-legend.tsx
@@ -7,6 +7,7 @@ import {
 import { VariableSelection } from "./variable-selection";
 
 import AddSeriesIcon from "../../imports/assets/add-series-icon.svg";
+import RemoveDataIcon from "../../assets/remove-data-icon.svg";
 import XAxisIcon from "../../assets/x-axis-icon.svg";
 import YAxisIcon from "../../assets/y-axis-icon.svg";
 
@@ -51,6 +52,17 @@ export const VariableFunctionLegend = observer(function(
                     selectedVariable={plottedVariablesInstance.yVariable}
                     variables={sharedVars.variables}
                   />
+                  {plottedVariablesAdornment.plottedVariables.size > 1 &&
+                    <div className="legend-icon">
+                      <button
+                        className="remove-button"
+                        onClick={() => plottedVariablesAdornment.removePlottedVariables(instanceKey)}
+                        title="Remove variable plot"
+                      >
+                        <RemoveDataIcon />
+                      </button>
+                    </div>
+                  }
                 </div>
               );
             }

--- a/src/plugins/graph/components/legend/variable-function-legend.tsx
+++ b/src/plugins/graph/components/legend/variable-function-legend.tsx
@@ -26,7 +26,7 @@ export const VariableFunctionLegend = observer(function(
   const sharedVars = plottedVariablesAdornment.sharedVariables;
   if (sharedVars) {
     return (
-      <>
+      <div className="plotted-variables-legend">
         <div className="legend-title-row">
           <div className="legend-title">
             Variables from: <strong>{sharedVars.label}</strong>
@@ -77,7 +77,7 @@ export const VariableFunctionLegend = observer(function(
             Add variables
           </button>
         </div>
-      </>
+      </div>
     );
   } else {
     return null;

--- a/src/plugins/graph/components/legend/variable-function-legend.tsx
+++ b/src/plugins/graph/components/legend/variable-function-legend.tsx
@@ -6,6 +6,7 @@ import {
 } from "../../adornments/plotted-function/plotted-variables/plotted-variables-adornment-model";
 import { VariableSelection } from "./variable-selection";
 
+import AddSeriesIcon from "../../imports/assets/add-series-icon.svg";
 import XAxisIcon from "../../assets/x-axis-icon.svg";
 import YAxisIcon from "../../assets/y-axis-icon.svg";
 
@@ -55,6 +56,15 @@ export const VariableFunctionLegend = observer(function(
             }
           })
         }
+        <div className="variable-row">
+          <button
+            className="add-series-button"
+            onClick={() => plottedVariablesAdornment.addPlottedVariables()}
+          >
+            <AddSeriesIcon/>
+            Add variables
+          </button>
+        </div>
       </>
     );
   } else {

--- a/src/plugins/graph/components/legend/variable-function-legend.tsx
+++ b/src/plugins/graph/components/legend/variable-function-legend.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { useContext } from "react";
 import { observer } from "mobx-react";
 
+import { ReadOnlyContext } from "../../../../components/document/read-only-context";
 import {
   IPlottedVariablesAdornmentModel
 } from "../../adornments/plotted-function/plotted-variables/plotted-variables-adornment-model";
@@ -21,6 +22,7 @@ interface IVariableFunctionLegendProps {
 export const VariableFunctionLegend = observer(function(
   { plottedVariablesAdornment }: IVariableFunctionLegendProps
 ) {
+  const readOnly = useContext(ReadOnlyContext);
   if (!plottedVariablesAdornment || plottedVariablesAdornment.plottedVariables.size <= 0) return null;
 
   const sharedVars = plottedVariablesAdornment.sharedVariables;
@@ -48,7 +50,7 @@ export const VariableFunctionLegend = observer(function(
                   <VariableSelection
                     alternateButtonLabel="Select a variable for Y"
                     icon={<YAxisIcon />}
-                    onSelect={(variableId) => plottedVariablesInstance.setYVariableId(variableId)}
+                    onSelect={variableId => plottedVariablesInstance.setYVariableId(variableId)}
                     selectedVariable={plottedVariablesInstance.yVariable}
                     variables={sharedVars.variables}
                   />
@@ -68,15 +70,17 @@ export const VariableFunctionLegend = observer(function(
             }
           })
         }
-        <div className="variable-row">
-          <button
-            className="add-series-button"
-            onClick={() => plottedVariablesAdornment.addPlottedVariables()}
-          >
-            <AddSeriesIcon/>
-            Add variables
-          </button>
-        </div>
+        { !readOnly &&
+          <div className="variable-row">
+            <button
+              className="add-series-button"
+              onClick={() => plottedVariablesAdornment.addPlottedVariables()}
+            >
+              <AddSeriesIcon/>
+              Add variables
+            </button>
+          </div>
+        }
       </div>
     );
   } else {

--- a/src/plugins/graph/components/legend/variable-selection.tsx
+++ b/src/plugins/graph/components/legend/variable-selection.tsx
@@ -1,9 +1,10 @@
 import classNames from "classnames";
 import { observer } from "mobx-react-lite";
-import React, { ReactElement, useRef, useState } from "react";
+import React, { ReactElement, useContext, useRef, useState } from "react";
 import { Menu, MenuItem, MenuList, MenuButton, Portal } from "@chakra-ui/react";
 import { VariableType } from "@concord-consortium/diagram-view";
 
+import { ReadOnlyContext } from "../../../../components/document/read-only-context";
 import DropdownCaretIcon from "../../assets/dropdown-caret.svg";
 
 import "./variable-selection.scss";
@@ -24,6 +25,7 @@ interface IVariableSelectionProps {
 export const VariableSelection = observer(function VariableSelection({
   alternateButtonLabel, icon, onSelect, selectedVariable, variables
 }: IVariableSelectionProps) {
+  const readOnly = useContext(ReadOnlyContext);
   const [buttonContainer, setButtonContainer] = useState<HTMLDivElement | null>(null);
   const portalParentElt = buttonContainer?.closest('.document-content') as HTMLDivElement ?? null;
   const portalRef = useRef(portalParentElt);
@@ -38,7 +40,7 @@ export const VariableSelection = observer(function VariableSelection({
         {({ isOpen }) => (
           <>
             <div ref={(e) => setButtonContainer(e)} className={labelClassNames}>
-              <MenuButton className="variable-function-legend-button">
+              <MenuButton className="variable-function-legend-button" disabled={readOnly}>
                 <div className="button-content">
                   <div>{buttonLabel}</div>
                   <div className={classNames("caret", { open: isOpen })}>


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/186507040

This PR allows the user to plot multiple variable traces in a graph tile.
- Adds an "Add variables" button to the variables part of the graph legend, which adds another trace to the graph. There is no limit to the number of traces that can be graphed, including repeats.
- When there are at least two traces, an X button appears in the legend for each trace, which deletes that trace. No button appears when there is only one trace to ensure that each linked graph has at least one trace.

Implementation details:
- The new buttons reuse css used elsewhere in the graph legend, which required moving the css around a bit.
- The calculation for the height of the legend is improved a bit with this work, but it's still not great. I think it would make sense to clean it up further when setting up the plugin system (https://www.pivotaltracker.com/story/show/186345543).