### PR TITLE
186487775 Graph Colors

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -41,7 +41,7 @@
   ],
 
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true,
+    "source.fixAll.eslint": "explicit"
   },
 
 }

--- a/src/plugins/graph/adornments/connecting-lines/connecting-lines.tsx
+++ b/src/plugins/graph/adornments/connecting-lines/connecting-lines.tsx
@@ -47,8 +47,9 @@ export const ConnectingLines = observer(function ConnectingLines({dotsRef}: ICon
   // installed by a useEffect() (which should also improve the render lag currently present).
   cleanUpPaths(dotsRef.current);
   //first clean up paths then render each line
-  foundLinePoints.forEach((singleLinePoints, idx) => {
-    const color = graphModel.pointColorAtIndex(idx);
+  Object.keys(foundLinePoints).forEach(attributeId => {
+    const singleLinePoints = foundLinePoints[attributeId];
+    const color = graphModel.getColorForId(attributeId);
     const adjustedColor = lightenColor(color, 0.5);
     drawPath(dotsRef.current as DotsElt, singleLinePoints, adjustedColor);
   });

--- a/src/plugins/graph/components/casedots.tsx
+++ b/src/plugins/graph/components/casedots.tsx
@@ -101,6 +101,7 @@ export const CaseDots = function CaseDots(props: PlotProps) {
 
     setPointCoordinates({
       dataConfiguration, pointRadius, selectedPointRadius, dotsRef, selectedOnly,
+      getColorForId: graphModel.getColorForId,
       pointColor, pointStrokeColor, getScreenX, getScreenY, getLegendColor, enableAnimation
     });
   }, [dataConfiguration, graphModel, layout, dotsRef, enableAnimation]);

--- a/src/plugins/graph/components/chartdots.tsx
+++ b/src/plugins/graph/components/chartdots.tsx
@@ -210,6 +210,7 @@ export const ChartDots = function ChartDots(props: PlotProps) {
 
     setPointCoordinates({
       dataConfiguration, pointRadius, selectedPointRadius: graphModel.getPointRadius('select'),
+      getColorForId: graphModel.getColorForId,
       dotsRef, selectedOnly, pointColor, pointStrokeColor,
       getScreenX, getScreenY, getLegendColor, enableAnimation
     });

--- a/src/plugins/graph/components/dotplotdots.tsx
+++ b/src/plugins/graph/components/dotplotdots.tsx
@@ -259,6 +259,7 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
 
       setPointCoordinates({
         dataConfiguration, pointRadius: graphModel.getPointRadius(),
+        getColorForId: graphModel.getColorForId,
         selectedPointRadius: graphModel.getPointRadius('select'),
         dotsRef, selectedOnly, pointColor, pointStrokeColor,
         getScreenX, getScreenY, getLegendColor, enableAnimation

--- a/src/plugins/graph/components/legend/layer-legend.tsx
+++ b/src/plugins/graph/components/legend/layer-legend.tsx
@@ -52,12 +52,13 @@ export const LayerLegend = observer(function LayerLegend(props: ILayerLegendProp
 
     legendItems = yAttributes.map((description, index) =>
       <SimpleAttributeLabel
-        key={description.attributeID}
-        place={'left'}
         attrId={description.attributeID}
+        includePoint={true}
+        key={description.attributeID}
         onChangeAttribute={onChangeAttribute}
         onRemoveAttribute={onRemoveAttribute}
         onTreatAttributeAs={onTreatAttributeAs}
+        place={'left'}
       />);
     if (!readOnly) {
       legendItems.push(<AddSeriesButton />);

--- a/src/plugins/graph/components/legend/layer-legend.tsx
+++ b/src/plugins/graph/components/legend/layer-legend.tsx
@@ -54,7 +54,6 @@ export const LayerLegend = observer(function LayerLegend(props: ILayerLegendProp
       <SimpleAttributeLabel
         key={description.attributeID}
         place={'left'}
-        index={index}
         attrId={description.attributeID}
         onChangeAttribute={onChangeAttribute}
         onRemoveAttribute={onRemoveAttribute}

--- a/src/plugins/graph/components/scatterdots.tsx
+++ b/src/plugins/graph/components/scatterdots.tsx
@@ -143,7 +143,7 @@ export const ScatterDots = function ScatterDots(props: PlotProps) {
       {
         dotsRef, dataConfiguration, pointRadius: pointRadiusRef.current,
         selectedPointRadius: selectedPointRadiusRef.current,
-        pointColor, pointStrokeColor, getPointColorAtIndex: graphModel.pointColorAtIndex
+        pointColor, pointStrokeColor
       });
   }, [dataConfiguration, dotsRef, graphModel]);
 
@@ -184,7 +184,7 @@ export const ScatterDots = function ScatterDots(props: PlotProps) {
       dataConfiguration, dotsRef, pointRadius: pointRadiusRef.current,
       selectedPointRadius: selectedPointRadiusRef.current,
       selectedOnly, getScreenX, getScreenY, getLegendColor,
-      getPointColorAtIndex: graphModel.pointColorAtIndex, enableAnimation, pointColor, pointStrokeColor
+      getColorForId: graphModel.getColorForId, enableAnimation, pointColor, pointStrokeColor
     });
   }, [dataConfiguration, dataset, dotsRef, layout, legendAttrID,
     enableAnimation, graphModel, yScaleRef]);

--- a/src/plugins/graph/components/simple-attribute-label.tsx
+++ b/src/plugins/graph/components/simple-attribute-label.tsx
@@ -15,7 +15,6 @@ import "../components/legend/multi-legend.scss";
 
 interface ISimpleAttributeLabelProps {
   place: GraphPlace;
-  index?: number;
   attrId: string;
   onChangeAttribute?: (place: GraphPlace, dataSet: IDataSet, attrId: string, oldAttrId?: string) => void;
   onRemoveAttribute?: (place: GraphPlace, attrId: string) => void;
@@ -24,7 +23,7 @@ interface ISimpleAttributeLabelProps {
 
 export const SimpleAttributeLabel = observer(
   function SimpleAttributeLabel(props: ISimpleAttributeLabelProps) {
-    const { place, index, attrId, onTreatAttributeAs, onRemoveAttribute, onChangeAttribute } = props;
+    const { place, attrId, onTreatAttributeAs, onRemoveAttribute, onChangeAttribute } = props;
     // Must be State, not Ref, so that the menu gets re-rendered when this becomes non-null
     const [simpleLabelElement, setSimpleLabelElement] = useState<HTMLDivElement|null>(null);
     const documentElt = simpleLabelElement?.closest('.document-content') as HTMLDivElement ?? null;
@@ -34,7 +33,7 @@ export const SimpleAttributeLabel = observer(
     const dataset = dataConfiguration?.dataset;
     const attr = attrId ? dataset?.attrFromID(attrId) : undefined;
     const attrName = attr?.name ?? "";
-    const pointColor = index !== undefined && graphModel.pointColorAtIndex(index);
+    const pointColor = graphModel.getColorForId(attrId);
 
     const readOnly = useContext(ReadOnlyContext);
 

--- a/src/plugins/graph/components/simple-attribute-label.tsx
+++ b/src/plugins/graph/components/simple-attribute-label.tsx
@@ -11,16 +11,17 @@ import { kGraphClassSelector } from "../graph-types";
 import "../components/legend/multi-legend.scss";
 
 interface ISimpleAttributeLabelProps {
-  place: GraphPlace;
   attrId: string;
+  includePoint?: boolean;
   onChangeAttribute?: (place: GraphPlace, dataSet: IDataSet, attrId: string, oldAttrId?: string) => void;
   onRemoveAttribute?: (place: GraphPlace, attrId: string) => void;
   onTreatAttributeAs?: (place: GraphPlace, attrId: string, treatAs: AttributeType) => void;
+  place: GraphPlace;
 }
 
 export const SimpleAttributeLabel = observer(
   function SimpleAttributeLabel(props: ISimpleAttributeLabelProps) {
-    const { place, attrId, onTreatAttributeAs, onRemoveAttribute, onChangeAttribute } = props;
+    const { attrId, includePoint, onTreatAttributeAs, onRemoveAttribute, onChangeAttribute, place } = props;
     // Must be State, not Ref, so that the menu gets re-rendered when this becomes non-null
     const [simpleLabelElement, setSimpleLabelElement] = useState<HTMLSpanElement|null>(null);
     const documentElt = simpleLabelElement?.closest('.document-content') as HTMLDivElement ?? null;
@@ -28,7 +29,7 @@ export const SimpleAttributeLabel = observer(
     const graphModel = useGraphModelContext();
     const dataConfiguration = useDataConfigurationContext();
     const dataset = dataConfiguration?.dataset;
-    const pointColor = graphModel.getColorForId(attrId);
+    const pointColor = includePoint && graphModel.getColorForId(attrId);
 
     if (onChangeAttribute && onTreatAttributeAs && onRemoveAttribute && attrId) {
       return  (

--- a/src/plugins/graph/hooks/use-point-locations.ts
+++ b/src/plugins/graph/hooks/use-point-locations.ts
@@ -44,7 +44,7 @@ export const getScreenY = ({ caseId, dataset, layout, dataConfig, plotNum = 0 }:
 export const usePointLocations = () => {
   const layout = useGraphLayoutContext();
   const graphModel = useGraphModelContext();
-  const result: Iterable<[number, number]>[] = [];
+  const result: Record<string, Iterable<[number, number]>> = {};
   // Outer loop over layer
   for (const layer of graphModel.layers) {
     const dataConfig = layer.config;
@@ -64,7 +64,8 @@ export const usePointLocations = () => {
             }
           }
         });
-        result.push(series);
+        const attributeId = dataConfig.yAttributeID(plotNum);
+        result[attributeId] = series;
       }
     }
   }

--- a/src/plugins/graph/models/graph-model.ts
+++ b/src/plugins/graph/models/graph-model.ts
@@ -332,6 +332,8 @@ export const GraphModel = TileContentModel
     getColorForId(id: string) {
       let colorIndex = self._idColors.get(id);
       if (colorIndex === undefined) {
+        // This function gets called automatically in response to plots being added to a graph.
+        // withoutUndo prevents a second action being added to the undo stack when this happens.
         withoutUndo();
         colorIndex = self.nextColor;
         self._idColors.set(id, colorIndex);

--- a/src/plugins/graph/models/graph-model.ts
+++ b/src/plugins/graph/models/graph-model.ts
@@ -334,6 +334,9 @@ export const GraphModel = TileContentModel
       }
       return clueGraphColors[colorIndex % clueGraphColors.length];
     },
+    removeColorForId(id: string) {
+      self._idColors.delete(id);
+    },
     setAxis(place: AxisPlace, axis: IAxisModelUnion) {
       self.axes.set(place, axis);
     },

--- a/src/plugins/graph/models/graph-model.ts
+++ b/src/plugins/graph/models/graph-model.ts
@@ -20,7 +20,7 @@ import {ITileContentModel, TileContentModel} from "../../../models/tiles/tile-co
 import {ITileExportOptions} from "../../../models/tiles/tile-content-info";
 import { getSharedModelManager } from "../../../models/tiles/tile-environment";
 import {
-  defaultBackgroundColor, defaultPointColor, defaultStrokeColor, kellyColors
+  clueGraphColors, defaultBackgroundColor, defaultPointColor, defaultStrokeColor
 } from "../../../utilities/color-utils";
 import { AdornmentModelUnion } from "../adornments/adornment-types";
 import { ConnectingLinesModel } from "../adornments/connecting-lines/connecting-lines-model";
@@ -123,7 +123,7 @@ export const GraphModel = TileContentModel
       if (plotIndex < self._pointColors.length) {
         return self._pointColors[plotIndex];
       } else {
-        return kellyColors[plotIndex % kellyColors.length];
+        return clueGraphColors[plotIndex % clueGraphColors.length];
       }
     },
     get pointColor() {

--- a/src/plugins/graph/models/graph-model.ts
+++ b/src/plugins/graph/models/graph-model.ts
@@ -33,6 +33,7 @@ import { DataConfigurationModel, RoleAttrIDPair } from "./data-configuration-mod
 import { PlottedFunctionAdornmentModel } from "../adornments/plotted-function/plotted-function-adornment-model";
 import { SharedVariables, SharedVariablesType } from "../../shared-variables/shared-variables";
 import { kPlottedFunctionType } from "../adornments/plotted-function/plotted-function-adornment-types";
+import { withoutUndo } from "../../../models/history/without-undo";
 
 export interface GraphProperties {
   axes: Record<string, IAxisModelUnion>
@@ -61,6 +62,8 @@ export const GraphModel = TileContentModel
     plotType: types.optional(types.enumeration([...PlotTypes]), "casePlot"),
     layers: types.array(GraphLayerModel /*, () => GraphLayerModel.create() */),
     // Visual properties
+    // A map from IDs (which can refer to anything) to indexes to an array of colors
+    _idColors: types.map(types.number),
     _pointColors: types.optional(types.array(types.string), [defaultPointColor]),
     _pointStrokeColor: defaultStrokeColor,
     pointStrokeSameAsFill: false,
@@ -107,6 +110,24 @@ export const GraphModel = TileContentModel
         }));
       }
       return all;
+    },
+    get nextColor() {
+      const colorCounts: Record<number, number> = {};
+      self._idColors.forEach(index => {
+        if (!colorCounts[index]) colorCounts[index] = 0;
+        colorCounts[index]++;
+      });
+      const usedColorIndices = Object.keys(colorCounts).map(index => Number(index));
+      if (usedColorIndices.length < clueGraphColors.length) {
+        // If there are unused colors, return the index of the first one
+        return Object.keys(clueGraphColors).map(index => Number(index))
+          .filter(index => !usedColorIndices.includes(index))[0];
+      } else {
+        // Otherwise, use the next minimally used color's index
+        const counts = usedColorIndices.map(index => colorCounts[index]);
+        const minCount = Math.min(...counts);
+        return usedColorIndices.find(index => colorCounts[index] === minCount) ?? 0;
+      }
     }
   }))
   .views(self => ({
@@ -302,6 +323,17 @@ export const GraphModel = TileContentModel
     },
   }))
   .actions(self => ({
+    // Returns an objet's color, given its id.
+    // This is an action because if the id doesn't have a specified color, this will assign one to it.
+    getColorForId(id: string) {
+      let colorIndex = self._idColors.get(id);
+      if (colorIndex === undefined) {
+        withoutUndo();
+        colorIndex = self.nextColor;
+        self._idColors.set(id, colorIndex);
+      }
+      return clueGraphColors[colorIndex % clueGraphColors.length];
+    },
     setAxis(place: AxisPlace, axis: IAxisModelUnion) {
       self.axes.set(place, axis);
     },

--- a/src/plugins/graph/utilities/graph-utils.ts
+++ b/src/plugins/graph/utilities/graph-utils.ts
@@ -428,8 +428,7 @@ export interface ISetPointSelection {
   pointRadius: number,
   selectedPointRadius: number,
   pointColor: string,
-  pointStrokeColor: string,
-  getPointColorAtIndex?: (index: number) => string
+  pointStrokeColor: string
 }
 
 export function setPointSelection(props: ISetPointSelection) {
@@ -449,7 +448,7 @@ export interface ISetPointCoordinates {
   selectedPointRadius: number
   pointColor: string
   pointStrokeColor: string
-  getPointColorAtIndex?: (index: number) => string
+  getColorForId?: (id: string) => string
   getScreenX: ((anID: string) => number | null)
   getScreenY: ((anID: string, plotNum?:number) => number | null)
   getLegendColor?: ((anID: string) => string)
@@ -458,7 +457,7 @@ export interface ISetPointCoordinates {
 
 export function setPointCoordinates(props: ISetPointCoordinates) {
   const {
-    dataConfiguration, dotsRef, pointColor, pointRadius, getPointColorAtIndex,
+    dataConfiguration, dotsRef, pointColor, pointRadius, getColorForId,
     getScreenX, getScreenY, getLegendColor, enableAnimation, selectedPointRadius
   } = props;
   const duration = enableAnimation.current ? transitionDuration : 0;
@@ -468,8 +467,8 @@ export function setPointCoordinates(props: ISetPointCoordinates) {
     const legendColor = getLegendColor ? getLegendColor(id) : '';
     if (legendColor !== '') {
       return legendColor;
-    } else if (getPointColorAtIndex && aCaseData.plotNum) {
-      return getPointColorAtIndex(aCaseData.plotNum);
+    } else if (getColorForId) {
+      return getColorForId(dataConfiguration.yAttributeID(aCaseData.plotNum));
     } else {
       return pointColor;
     }

--- a/src/utilities/color-utils.ts
+++ b/src/utilities/color-utils.ts
@@ -25,6 +25,18 @@ export const isLightColorRequiringContrastOffset = (color?: string) => {
   return (luminance != null) && (luminance >= kLightLuminanceThreshold);
 };
 
+export const kGraphDataBlue = "#0069ff";
+export const kGraphDataOrange = "#ff9617";
+export const kGraphDataGreen = "#19a90f";
+export const kGraphDataRed = "#e00";
+export const kGraphDataYellow = "#cbd114";
+export const kGraphDataPurple = "#d51eff";
+export const kGraphDataIndigo = "#6b00d2";
+export const clueGraphColors = [
+  kGraphDataBlue, kGraphDataOrange, kGraphDataGreen, kGraphDataRed,
+  kGraphDataYellow, kGraphDataPurple, kGraphDataIndigo
+];
+
 /*
   The following list of 20 colors are maximally visually distinct from each other.
   See http://eleanormaclure.files.wordpress.com/2011/03/colour-coding.pdf


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/186487775

This PR updates how colors are handled in the graph tile.
- Colors from the design spec are now used rather than kelly colors.
- Within a graph, colors are assigned to attributes rather than the index of a plot. This means that an attribute's color won't change if you remove a plot above it, for example.

Implementation notes:
- I basically followed @bgoldowsky's suggested strategy for this work. The `GraphModel` manages colors via ids (which can be any type of ids, so will work for variable as well as data plots).
  - However, the colors are not consistent between graphs.
  - Right now, deleting a plot will not remove it from the list of colors, so the color will not be reused until going through all other colors, and if you bring the same attribute back it should retain its old color.
  - If all colors have already been used, the next minimally used color will be picked.
- A color is internally represented by its index in the list of colors, rather than the color's hex value or a keyword. This means it will be possible to change the list of colors without performing a migration.