### PR TITLE
186569351 Make Graph Dropdowns Render Over Tile Toolbar

### DIFF
--- a/src/plugins/graph/components/attribute-label.tsx
+++ b/src/plugins/graph/components/attribute-label.tsx
@@ -8,7 +8,7 @@ import {AttributeType} from "../../../models/data/attribute";
 import {IDataSet} from "../../../models/data/data-set";
 import {isSetAttributeNameAction} from "../../../models/data/data-set-actions";
 import {GraphPlace, isVertical} from "../imports/components/axis-graph-shared";
-import {graphPlaceToAttrRole, kGraphClassSelector} from "../graph-types";
+import {graphPlaceToAttrRole, kGraphClassSelector, kGraphPortalClass} from "../graph-types";
 import { useGraphModelContext } from "../hooks/use-graph-model-context";
 import {useGraphLayoutContext} from "../models/graph-layout";
 import {useTileModelContext} from "../../../components/tiles/hooks/use-tile-model-context";
@@ -37,7 +37,7 @@ export const AttributeLabel = observer(
       hideClickHereCue = useClickHereCue &&
         !dataConfiguration?.placeAlwaysShowsClickHereCue(place) && !isTileSelected(),
       [labelElt, setLabelElt] = useState<SVGGElement | null>(null),
-      portalParentElt = labelElt?.closest('.document-content') as HTMLDivElement ?? null,
+      portalParentElt = labelElt?.closest(kGraphPortalClass) as HTMLDivElement ?? null,
       positioningParentElt = labelElt?.closest(kGraphClassSelector) as HTMLDivElement ?? null;
 
     const getAttributeIDs = useCallback(() => {

--- a/src/plugins/graph/components/legend/variable-selection.tsx
+++ b/src/plugins/graph/components/legend/variable-selection.tsx
@@ -3,6 +3,7 @@ import { observer } from "mobx-react-lite";
 import React, { ReactElement, useRef, useState } from "react";
 import { Menu, MenuItem, MenuList, MenuButton, Portal } from "@chakra-ui/react";
 import { VariableType } from "@concord-consortium/diagram-view";
+import { kGraphPortalClass } from "../../graph-types";
 
 import DropdownCaretIcon from "../../assets/dropdown-caret.svg";
 
@@ -25,7 +26,7 @@ export const VariableSelection = observer(function VariableSelection({
   alternateButtonLabel, icon, onSelect, selectedVariable, variables
 }: IVariableSelectionProps) {
   const [buttonContainer, setButtonContainer] = useState<HTMLDivElement | null>(null);
-  const portalParentElt = buttonContainer?.closest('.document-content') as HTMLDivElement ?? null;
+  const portalParentElt = buttonContainer?.closest(kGraphPortalClass) as HTMLDivElement ?? null;
   const portalRef = useRef(portalParentElt);
   portalRef.current = portalParentElt;
 

--- a/src/plugins/graph/components/simple-attribute-label.tsx
+++ b/src/plugins/graph/components/simple-attribute-label.tsx
@@ -6,7 +6,7 @@ import {AxisOrLegendAttributeMenu} from "../imports/components/axis/components/a
 import { useDataConfigurationContext } from "../hooks/use-data-configuration-context";
 import { useGraphModelContext } from "../hooks/use-graph-model-context";
 import { IDataSet } from "../../../models/data/data-set";
-import { kGraphClassSelector } from "../graph-types";
+import { kGraphClassSelector, kGraphPortalClass } from "../graph-types";
 
 import "../components/legend/multi-legend.scss";
 
@@ -24,7 +24,7 @@ export const SimpleAttributeLabel = observer(
     const { place, index, attrId, onTreatAttributeAs, onRemoveAttribute, onChangeAttribute } = props;
     // Must be State, not Ref, so that the menu gets re-rendered when this becomes non-null
     const [simpleLabelElement, setSimpleLabelElement] = useState<HTMLSpanElement|null>(null);
-    const documentElt = simpleLabelElement?.closest('.document-content') as HTMLDivElement ?? null;
+    const canvasAreaElt = simpleLabelElement?.closest(kGraphPortalClass) as HTMLDivElement ?? null;
     const graphElement = simpleLabelElement?.closest(kGraphClassSelector) as HTMLDivElement ?? null;
     const graphModel = useGraphModelContext();
     const dataConfiguration = useDataConfigurationContext();
@@ -38,7 +38,7 @@ export const SimpleAttributeLabel = observer(
             pointColor={pointColor || undefined}
             target={null}
             parent={graphElement}
-            portal={documentElt}
+            portal={canvasAreaElt}
             place={place}
             attributeId={attrId}
             highlighted={dataset?.isAttributeSelected(attrId)}

--- a/src/plugins/graph/graph-types.ts
+++ b/src/plugins/graph/graph-types.ts
@@ -97,3 +97,5 @@ export const kGraphAdornmentsClassSelector = `.${kGraphAdornmentsClass}`;
 
 // TODO: determine this via configuration, e.g. appConfig, since apps may prefer different defaults
 export const kDefaultNumericAxisBounds = [-10, 11] as const;
+
+export const kGraphPortalClass = ".canvas-area";


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/186569351

This PR fixes an issue identified while testing the above PT story. Previously, the chakra portals used for dropdowns in the graph tile would render below the tile's toolbar. Now these portals render above the toolbar.