### PR TITLE
Added wait to fix failure

### DIFF
--- a/cypress/e2e/cleanup/remove_teacher_comment_spec.js
+++ b/cypress/e2e/cleanup/remove_teacher_comment_spec.js
@@ -53,6 +53,7 @@ function beforePortalTest(url, clueTeacher, reportUrl) {
   cy.login(url, clueTeacher);
   cy.launchReport(reportUrl);
   cy.waitForLoad();
+  cy.wait(10000);
   chatPanel.openChatPanel();
 }
 


### PR DESCRIPTION
Added wait to fix remove teacher comment failure in portal report.
This wait is required because of https://www.pivotaltracker.com/story/show/186702606. With the recent save and restore documents work, there is an intermediate screen that appears before the past state is restored which also causes the chat panel to not show up for the first second or two and then to show up. 
So, the code found the chat panel element length at that time and it was > 0 but after that chat panel was displayed in open mode by default. At that time, the chat panel element would not be available to click so the test was failing.
Error message in Cypress: “We initially found matching element(s), but while waiting for them to become actionable, they disappeared from the page.”
Adding this wait gives cypress time to get to the correct state before the condition for checking whether the chat panel is open or not is evaluated before trying to open it.