### PR TITLE
switch to using await

### DIFF
--- a/src/components/document/canvas.test.tsx
+++ b/src/components/document/canvas.test.tsx
@@ -4,7 +4,6 @@ import { Provider } from "mobx-react";
 import { ModalProvider } from "react-modal-hook";
 import { CanvasComponent } from "./canvas";
 import { createDocumentModel } from "../../models/document/document";
-import { DocumentContentModel } from "../../models/document/document-content";
 import { ProblemDocument } from "../../models/document/document-types";
 import { specStores } from "../../models/stores/spec-stores";
 import { createSingleTileContent } from "../../utilities/test-utils";
@@ -86,15 +85,23 @@ describe("Canvas Component", () => {
   });
 
   it("can render with content", () => {
-    const content = DocumentContentModel.create(createSingleTileContent({
+    const content = createSingleTileContent({
       type: "Text",
       text: "test"
-    }));
+    });
+    const document = createDocumentModel({
+      type: ProblemDocument,
+      uid: "1",
+      key: "test",
+      createdAt: 1,
+      content,
+      visibility: "public"
+    });
     const stores = specStores();
     render(
       <Provider stores={stores}>
         <ModalProvider>
-          <CanvasComponent context="test" content={content} readOnly={true} />
+          <CanvasComponent context="test" content={document.content} readOnly={true} />
         </ModalProvider>
       </Provider>
     );

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -226,164 +226,160 @@ export const getClassInfo = (params: GetClassInfoParams) => {
   });
 };
 
-export const authenticate = (appMode: AppMode, appConfig: AppConfigModelType, urlParams?: QueryParams) => {
-  interface IAuthenticateResponse {
-    appMode?: AppMode;
-    authenticatedUser: AuthenticatedUser;
-    classInfo?: ClassInfo;
-    problemId?: string;
-    unitCode?: string;
+interface IAuthenticateResponse {
+  appMode?: AppMode;
+  authenticatedUser: AuthenticatedUser;
+  classInfo?: ClassInfo;
+  problemId?: string;
+  unitCode?: string;
+}
+
+export const authenticate = async (appMode: AppMode, appConfig: AppConfigModelType, urlParams?: QueryParams):
+    Promise<IAuthenticateResponse> => {
+  urlParams = urlParams || pageUrlParams;
+  // TODO: we should be defaulting to appConfig.defaultUnit here rather than the empty string,
+  // but some cypress tests rely on the fact that in demo mode the offeringId is prefixed with
+  // the unit code, which results in an offeringId of `101` instead of `sas101`.
+  const unitCode = urlParams.unit || "";
+  // when launched as a report, the params will not contain the problemOrdinal
+  const problemOrdinal = urlParams.problem || appConfig.defaultProblemOrdinal;
+  const bearerToken = urlParams.token;
+  let basePortalUrl: string;
+
+  let {fakeClass, fakeUser} = urlParams;
+  // handle preview launch from portal
+  if (urlParams.domain && urlParams.domain_uid && !bearerToken) {
+    appMode = "demo";
+    fakeClass = `preview-${urlParams.domain_uid}`;
+    fakeUser = `student:${urlParams.domain_uid}`;
   }
-  return new Promise<IAuthenticateResponse>((resolve, reject) => {
-    urlParams = urlParams || pageUrlParams;
-    // TODO: we should be defaulting to appConfig.defaultUnit here rather than the empty string,
-    // but some cypress tests rely on the fact that in demo mode the offeringId is prefixed with
-    // the unit code, which results in an offeringId of `101` instead of `sas101`.
-    const unitCode = urlParams.unit || "";
-    // when launched as a report, the params will not contain the problemOrdinal
-    const problemOrdinal = urlParams.problem || appConfig.defaultProblemOrdinal;
-    const bearerToken = urlParams.token;
-    let basePortalUrl: string;
 
-    let {fakeClass, fakeUser} = urlParams;
-    // handle preview launch from portal
-    if (urlParams.domain && urlParams.domain_uid && !bearerToken) {
-      appMode = "demo";
-      fakeClass = `preview-${urlParams.domain_uid}`;
-      fakeUser = `student:${urlParams.domain_uid}`;
+  if ((appMode === "demo") || (appMode === "qa")) {
+    if (!fakeClass || !fakeUser) {
+      throw "Missing fakeClass or fakeUser parameter for demo!";
+    }
+    let [userType, userId] = fakeUser.split(":");
+
+    if (((userType !== "student") && (userType !== "teacher")) || !userId) {
+      throw "fakeUser must be in the form of student:<id> or teacher:<id>";
     }
 
-    if ((appMode === "demo") || (appMode === "qa")) {
-      if (!fakeClass || !fakeUser) {
-        return reject("Missing fakeClass or fakeUser parameter for demo!");
-      }
-      let [userType, userId] = fakeUser.split(":");
-
-      if (((userType !== "student") && (userType !== "teacher")) || !userId) {
-        return reject("fakeUser must be in the form of student:<id> or teacher:<id>");
-      }
-
-      if ((userId === "random")) {
-        const url = window.location.toString();
-        const title = document.title;
-        const randomStudentId = uniqueId();
-        fakeUser = `student:${randomStudentId}`;
-        userId = randomStudentId;
-        const newUrl = url.replace(/student:random/, fakeUser);
-        window.history.replaceState(title, title, newUrl);
-      }
-
-      // respect `network` url parameter in demo/qa modes
-      const networkProps = urlParams.network
-                            ? { network: urlParams.network, networks: [urlParams.network] }
-                            : undefined;
-      return resolve({
-              appMode,
-              ...createFakeAuthentication({
-                  appMode,
-                  classId: fakeClass,
-                  userType, userId,
-                  ...networkProps,
-                  unitCode,
-                  problemOrdinal
-                })
-            });
+    if ((userId === "random")) {
+      const url = window.location.toString();
+      const title = document.title;
+      const randomStudentId = uniqueId();
+      fakeUser = `student:${randomStudentId}`;
+      userId = randomStudentId;
+      const newUrl = url.replace(/student:random/, fakeUser);
+      window.history.replaceState(title, title, newUrl);
     }
 
-    if (appMode !== "authed") {
-      return resolve(generateDevAuthentication(unitCode || appConfig.defaultUnit, problemOrdinal));
-    }
-
-    if (!bearerToken) {
-      return reject("No token provided for authentication (must launch from Portal)");
-    }
-
-    if (urlParams.reportType) {
-      if (urlParams.reportType !== "offering") {
-        return reject("Sorry, only external reports at the offering level are supported");
-      }
-      if (!urlParams.class) {
-        return reject("Missing class parameter!");
-      }
-      if (!urlParams.offering) {
-        return reject("Missing offering parameter!");
-      }
-      const {protocol, host} = parseUrl(urlParams.class);
-      basePortalUrl = `${protocol}//${host}/`;
-    }
-    else if (urlParams.domain) {
-      basePortalUrl = urlParams.domain;
-    }
-    else {
-      return reject("Missing domain query parameter!");
-    }
-
-    return getPortalJWTWithBearerToken(basePortalUrl, "Bearer", bearerToken)
-      .then(([rawPortalJWT, portalJWT]) => {
-        if (!((portalJWT.user_type === "learner") || (portalJWT.user_type === "teacher"))) {
-          throw new Error("Only student and teacher logins are currently supported!");
-        }
-
-        const portal = parseUrl(basePortalUrl).host;
-        let classInfoUrl: string | undefined;
-        let offeringId: string | undefined;
-
-        if (portalJWT.user_type === "learner") {
-          classInfoUrl = portalJWT.class_info_url;
-          offeringId = `${portalJWT.offering_id}`;
-        }
-        else if (urlParams && urlParams.class && urlParams.offering) {
-          classInfoUrl = urlParams.class;
-          offeringId = urlParams.offering.split("/").pop() as string;
-        }
-
-        if (!classInfoUrl || !offeringId) {
-          throw new Error("Unable to get classInfoUrl or offeringId");
-        }
-
-        return getClassInfo({classInfoUrl, rawPortalJWT, portal, offeringId})
-          .then((classInfo) => {
-            const { user_type, uid, domain } = portalJWT;
-            const { classHash } = classInfo;
-            const uidAsString = `${portalJWT.uid}`;
-            const firebaseJWTPromise = getFirebaseJWTWithBearerToken(basePortalUrl, "Bearer", bearerToken, classHash);
-            const portalOfferingsPromise = getPortalOfferings(user_type, uid, domain, rawPortalJWT);
-            const problemIdPromise = getProblemIdForAuthenticatedUser(rawPortalJWT, appConfig, urlParams);
-            Promise
-              .all([firebaseJWTPromise, portalOfferingsPromise, problemIdPromise])
-              .then(([firebaseJWTResult, portalOfferingsResult, problemIdResult]) => {
-                const [rawFirebaseJWT, firebaseJWT] = firebaseJWTResult;
-                const { unitCode: newUnitCode, problemOrdinal: newProblemOrdinal } = problemIdResult;
-
-                const authenticatedUser = user_type === "learner"
-                                            ? classInfo.students.find(student => student.id === uidAsString)
-                                            : classInfo.teachers.find(teacher => teacher.id === uidAsString);
-                if (!authenticatedUser) {
-                  throw new Error("Current user not found in class roster");
-                }
-
-                authenticatedUser.portalJWT = portalJWT;
-                authenticatedUser.rawPortalJWT = rawPortalJWT;
-                authenticatedUser.firebaseJWT = firebaseJWT;
-                authenticatedUser.rawFirebaseJWT = rawFirebaseJWT;
-                authenticatedUser.id = uidAsString;
-                authenticatedUser.portal = portal;
-                authenticatedUser.portalClassOfferings =
-                  getPortalClassOfferings(portalOfferingsResult, appConfig, urlParams);
-
-                Logger.log(LogEventName.INTERNAL_AUTHENTICATED, {id: authenticatedUser.id, portal});
-                resolve({
-                  authenticatedUser,
-                  classInfo,
-                  unitCode: newUnitCode,
-                  problemId: newProblemOrdinal
-                });
-              });
+    // respect `network` url parameter in demo/qa modes
+    const networkProps = urlParams.network
+                          ? { network: urlParams.network, networks: [urlParams.network] }
+                          : undefined;
+    return {
+      appMode,
+      ...createFakeAuthentication({
+          appMode,
+          classId: fakeClass,
+          userType, userId,
+          ...networkProps,
+          unitCode,
+          problemOrdinal
         })
-        .catch(reject);
-    })
-    .catch(reject);
-  });
+    };
+  }
+
+  if (appMode !== "authed") {
+    return generateDevAuthentication(unitCode || appConfig.defaultUnit, problemOrdinal);
+  }
+
+  if (!bearerToken) {
+    throw "No token provided for authentication (must launch from Portal)";
+  }
+
+  if (urlParams.reportType) {
+    if (urlParams.reportType !== "offering") {
+      throw "Sorry, only external reports at the offering level are supported";
+    }
+    if (!urlParams.class) {
+      throw "Missing class parameter!";
+    }
+    if (!urlParams.offering) {
+      throw "Missing offering parameter!";
+    }
+    const {protocol, host} = parseUrl(urlParams.class);
+    basePortalUrl = `${protocol}//${host}/`;
+  }
+  else if (urlParams.domain) {
+    basePortalUrl = urlParams.domain;
+  }
+  else {
+    throw "Missing domain query parameter!";
+  }
+
+  const [rawPortalJWT, portalJWT] = await getPortalJWTWithBearerToken(basePortalUrl, "Bearer", bearerToken);
+
+  if (!((portalJWT.user_type === "learner") || (portalJWT.user_type === "teacher"))) {
+    throw new Error("Only student and teacher logins are currently supported!");
+  }
+
+  const portal = parseUrl(basePortalUrl).host;
+  let classInfoUrl: string | undefined;
+  let offeringId: string | undefined;
+
+  if (portalJWT.user_type === "learner") {
+    classInfoUrl = portalJWT.class_info_url;
+    offeringId = `${portalJWT.offering_id}`;
+  }
+  else if (urlParams && urlParams.class && urlParams.offering) {
+    classInfoUrl = urlParams.class;
+    offeringId = urlParams.offering.split("/").pop() as string;
+  }
+
+  if (!classInfoUrl || !offeringId) {
+    throw new Error("Unable to get classInfoUrl or offeringId");
+  }
+
+  const classInfo = await getClassInfo({classInfoUrl, rawPortalJWT, portal, offeringId});
+  const { user_type, uid, domain } = portalJWT;
+  const { classHash } = classInfo;
+  const uidAsString = `${portalJWT.uid}`;
+  const firebaseJWTPromise = getFirebaseJWTWithBearerToken(basePortalUrl, "Bearer", bearerToken, classHash);
+  const portalOfferingsPromise = getPortalOfferings(user_type, uid, domain, rawPortalJWT);
+  const problemIdPromise = getProblemIdForAuthenticatedUser(rawPortalJWT, appConfig, urlParams);
+
+  const [firebaseJWTResult, portalOfferingsResult, problemIdResult] =
+    await Promise.all([firebaseJWTPromise, portalOfferingsPromise, problemIdPromise]);
+
+  const [rawFirebaseJWT, firebaseJWT] = firebaseJWTResult;
+  const { unitCode: newUnitCode, problemOrdinal: newProblemOrdinal } = problemIdResult;
+
+  const authenticatedUser = user_type === "learner"
+                              ? classInfo.students.find(student => student.id === uidAsString)
+                              : classInfo.teachers.find(teacher => teacher.id === uidAsString);
+  if (!authenticatedUser) {
+    throw new Error("Current user not found in class roster");
+  }
+
+  authenticatedUser.portalJWT = portalJWT;
+  authenticatedUser.rawPortalJWT = rawPortalJWT;
+  authenticatedUser.firebaseJWT = firebaseJWT;
+  authenticatedUser.rawFirebaseJWT = rawFirebaseJWT;
+  authenticatedUser.id = uidAsString;
+  authenticatedUser.portal = portal;
+  authenticatedUser.portalClassOfferings =
+    getPortalClassOfferings(portalOfferingsResult, appConfig, urlParams);
+
+  Logger.log(LogEventName.INTERNAL_AUTHENTICATED, {id: authenticatedUser.id, portal});
+
+  return {
+    authenticatedUser,
+    classInfo,
+    unitCode: newUnitCode,
+    problemId: newProblemOrdinal
+  };
 };
 
 export const generateDevAuthentication = (unitCode: string, problemOrdinal: string) => {


### PR DESCRIPTION
Also fix an error thrown in the canvas test.
In some cases strings are thrown instead of Error objects. I think this makes the new code consistent with the old code. In that case it was rejecting the promise with a string. 

If you hide whitespace changes you can see the essence of the conversion to await.