### PR TITLE
autoassign fix

### DIFF
--- a/cypress/e2e/functional/tile_tests/xy_plot_tool_spec.js
+++ b/cypress/e2e/functional/tile_tests/xy_plot_tool_spec.js
@@ -258,7 +258,7 @@ context('XYPlot Tool Tile', function () {
 
       cy.log("Link First Table");
       xyTile.getTile().click();
-      clueCanvas.clickToolbarButton('graph', 'link-tile');
+      clueCanvas.clickToolbarButton('graph', 'link-tile-multiple');
       xyTile.linkTable("Table 1");
       xyTile.getXAttributesLabel().should('have.length', 1);
       xyTile.getYAttributesLabel().should('have.length', 1);

--- a/src/plugins/graph/models/graph-controller.ts
+++ b/src/plugins/graph/models/graph-controller.ts
@@ -140,9 +140,6 @@ export class GraphController {
         graphModel.setPrimaryRole(primaryRole);
         graphModel.setPlotType(plotChoices[primaryType][otherAttributeType]);
       }
-      if (attrID && dataConfiguration.attributeID(graphAttributeRole) !== attrID) {
-          dataConfiguration.setAttributeForRole(graphAttributeRole, {attributeID: attrID});
-      }
     };
 
     const setupAxis = (place: AxisPlace) => {


### PR DESCRIPTION
Fixes PT-186740258.

Testing notes:

- This bug is hard to replicate.  It seemed to happen most often in a brand new session - any cached or already-rendered content would avoid it.  With a brand new session, follow the replication instructions in the bug report.  It may take many tries before the bug can be observed.

Implementation notes:

- in the `GraphController`, there is a `handleAttributeAssignment` method that is called when attributes are assigned to a place on the graph, and also for all `autoAssignedAttributes` at graph initialization time.  This method previously had code that checked whether the attribute was in fact assigned to the given place, and if not, assigned it. This code did not account for the possibility of multiple Y attributes and would set the given attribute as the only Y attribute if it was not already.  
  - When the document was opened on the left side, `initializeGraph` is called, and auto-assigned attributes are passed to this function. This had the effect of replacing all the Y attributes with the single auto-assigned one.
  - *However* - by inspection we determined that the `handleAttributeAssignment` is only ever called after the attribute was just set. So there is no need for it to check and re-do the assignment. This PR deletes that code to fix the bug.
- one failing Cypress test also fixed