### PR TITLE
Dialog wording changes

### DIFF
--- a/cypress/e2e/functional/tile_tests/data_card_tool_spec.js
+++ b/cypress/e2e/functional/tile_tests/data_card_tool_spec.js
@@ -131,7 +131,7 @@ context('Data Card Tool Tile', () => {
     // Unlink
     dc.getLinkGraphButton().should('not.be.disabled').click();
     dc.getLinkGraphModalTileMenu().select('Data Card Collection 1');
-    dc.getLinkGraphModalLinkButton().should("contain", "Unlink").click();
+    dc.getLinkGraphModalLinkButton().should("contain", "Clear It!").click();
     xyplot.getXAxisLabel().should("not.contain", "habitat");
     // Re-link
     dc.getLinkGraphButton().should('not.be.disabled').click();
@@ -157,7 +157,7 @@ context('Data Card Tool Tile', () => {
     dc.getAttrValueInput().eq(0).invoke('val').should('eq', "river");
     dc.getAttrValueInput().eq(1).invoke('val').should('eq', "rhinocerotter");
 
-    cy.log("verify Datacard tile title restore upon page reload")
+    cy.log("verify Datacard tile title restore upon page reload");
     const newName = "Data Card Title";
     dc.getTile().find('.title-text-element').first().dblclick();
     dc.getTile().find('.title-text-element').first().type(newName + '{enter}');

--- a/cypress/e2e/functional/tile_tests/table_tool_spec.js
+++ b/cypress/e2e/functional/tile_tests/table_tool_spec.js
@@ -285,7 +285,7 @@ context('Table Tool Tile', function () {
     // Unlink
     clueCanvas.clickToolbarButton('table', 'link-tile');
     tableToolTile.getLinkGraphModalTileMenu().select('Table 1');
-    tableToolTile.getLinkGraphModalLinkButton().should("contain", "Unlink").click();
+    tableToolTile.getLinkGraphModalLinkButton().should("contain", "Clear It!").click();
     // Re-link
     clueCanvas.clickToolbarButton('table', 'link-tile');
     tableToolTile.getLinkGraphModalTileMenu().select('Table 1');

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -235,7 +235,7 @@ Cypress.Commands.add('unlinkTableToTile', (table, tile) => {
   cy.get(".table-toolbar .toolbar-button.link-tile").click();
   cy.get('.ReactModalPortal').within(() => {
     cy.get('[data-test=link-tile-select]').select(tile);
-    cy.get('button').contains('Unlink').click();
+    cy.get('button').contains('Clear It!').click();
   });
 });
 Cypress.Commands.add('linkTableToDataflow', (program, table) => {
@@ -253,7 +253,7 @@ Cypress.Commands.add('unlinkTableToDataflow', (program, table) => {
   });
   cy.get('.ReactModalPortal').within(() => {
     cy.get('[data-test=link-tile-select]').select(table);
-    cy.get('button').contains('Unlink').click();
+    cy.get('button').contains('Clear It!').click();
   });
 });
 Cypress.Commands.add("deleteDocumentThumbnail", (tab, section,title) => {

--- a/cypress/support/elements/tile/XYPlotToolTile.js
+++ b/cypress/support/elements/tile/XYPlotToolTile.js
@@ -17,7 +17,7 @@ class XYPlotToolTile {
   }
   linkTable(table) {
       cy.get('select').select(table);
-      cy.get('.modal-button').contains("Link").click();
+      cy.get('.modal-button').contains("Graph It!").click();
   }
   getGraphDot(workspaceClass) {
     return cy.get(`${wsClass(workspaceClass)} .canvas-area .graph-dot`);

--- a/src/hooks/use-link-consumer-tile-dialog.tsx
+++ b/src/hooks/use-link-consumer-tile-dialog.tsx
@@ -115,7 +115,7 @@ export const useLinkConsumerTileDialog =
     .filter(tileInfo => modelToShare && isLinkedToTile(modelToShare, tileInfo.id) && tileInfo.id !== model.id);
 
   const primaryButtonText = modelToShare && isLinkedToTile(modelToShare, selectValue)
-    ? 'Unlink'
+    ? 'Clear It!'
     : tileType ? `${tileType} It!` : 'Link';
 
   // Builds an appopriate icon for the dialog.

--- a/src/hooks/use-link-provider-tile-dialog.tsx
+++ b/src/hooks/use-link-provider-tile-dialog.tsx
@@ -25,7 +25,7 @@ const Content: React.FC<IContentProps>
   return (
       <>
         <div className="prompt">
-          Select a data or variables source to link or unlink:
+          Select a data or variables source to graph or clear:
         </div>
         <select ref={selectElt} value={selectValue} data-test="link-tile-select"
                                 onChange={e => {
@@ -96,7 +96,7 @@ export const useLinkProviderTileDialog = ({
       selectValue, tileTitle, setSelectValue },
     buttons: [
       { label: "Cancel" },
-      { label: selectedModel && linkedSharedModels.includes(selectedModel) ? "Unlink" : "Link",
+      { label: selectedModel && linkedSharedModels.includes(selectedModel) ? "Clear It!" : "Graph It!",
         isDefault: true,
         isDisabled: !selectValue,
         onClick: handleClick


### PR DESCRIPTION
As requested in the latest designs and in PT-186566168, revises the wording in the dialog of the graph's "Add data" button, and in all of the linking buttons changes the "Unlink" button to "Clear It!".

 