### PR TITLE
Add variable-value readout point to graph

### DIFF
--- a/cypress/e2e/functional/tile_tests/xy_plot_tool_spec.js
+++ b/cypress/e2e/functional/tile_tests/xy_plot_tool_spec.js
@@ -303,7 +303,7 @@ context('XYPlot Tool Tile', function () {
       clueCanvas.clickToolbarButton("diagram", "variables-link");
       cy.get('select').select("New Graph");
       dialogOkButton().click();
-      xyTile.getPlottedVariablesPath().should("not.exist");
+      xyTile.getPlottedVariablesGroup().should("not.exist");
       xyTile.getEditableAxisBox('bottom', 'min').invoke('text').then(parseFloat).should("be.within", -11, -9);
       xyTile.getEditableAxisBox('bottom', 'max').invoke('text').then(parseFloat).should("be.within", 9, 11);
 
@@ -313,7 +313,9 @@ context('XYPlot Tool Tile', function () {
       xyTile.selectYVariable(name1);
       xyTile.getYVariableDropdown().should("contain.text", name1);
 
-      xyTile.getPlottedVariablesPath().should("have.length", 1);
+      xyTile.getPlottedVariablesGroup().should("have.length", 1);
+      xyTile.getPlottedVariablesPoint().should("have.length", 1);
+      xyTile.getPlottedVariablesLabel().should("have.length", 1).should("have.text", "2, 2");
       // Variable value is 2 so should autoscale to [0, 4]
       xyTile.getEditableAxisBox('bottom', 'min').invoke('text').then(parseFloat).should("be.within", -1, 1);
       xyTile.getEditableAxisBox('bottom', 'max').invoke('text').then(parseFloat).should("be.within", 3, 5);
@@ -329,7 +331,9 @@ context('XYPlot Tool Tile', function () {
       xyTile.selectYVariable(name2, 1);
       xyTile.getYVariableDropdown(1).should("contain.text", name2);
 
-      xyTile.getPlottedVariablesPath().should("have.length", 2);
+      xyTile.getPlottedVariablesGroup().should("have.length", 2);
+      xyTile.getPlottedVariablesPoint().should("have.length", 2);
+      xyTile.getPlottedVariablesLabel().should("have.length", 2).eq(1).should("have.text", "3, 3");
 
       // Fit button should adjust bounds to narrowly include (2,2) and (3,3)
       clueCanvas.clickToolbarButton('graph', 'fit-all');
@@ -338,7 +342,7 @@ context('XYPlot Tool Tile', function () {
 
       cy.log("Remove a variable trace");
       xyTile.getRemoveVariablesButton(1).click();
-      xyTile.getPlottedVariablesPath().should("have.length", 1);
+      xyTile.getPlottedVariablesGroup().should("have.length", 1);
       // Only the unlink remove button should remain
       xyTile.getRemoveVariablesButtons().should("have.length", 1);
     });

--- a/cypress/support/elements/tile/XYPlotToolTile.js
+++ b/cypress/support/elements/tile/XYPlotToolTile.js
@@ -47,8 +47,14 @@ class XYPlotToolTile {
   getAdornments(adornmentType, workspaceClass) {
     return cy.get(`${wsClass(workspaceClass)} .graph-tool-tile .graph-adornments-grid${adornmentType ? " ." + adornmentType : ""}`);
   }
-  getPlottedVariablesPath(workspaceClass) {
-    return this.getAdornments("plotted-function", workspaceClass).find("path");
+  getPlottedVariablesGroup(workspaceClass) {
+    return this.getAdornments("plotted-function", workspaceClass).find("g.plotted-variable");
+  }
+  getPlottedVariablesPoint(workspaceClass) {
+    return this.getPlottedVariablesGroup(workspaceClass).find("circle.plotted-variable-value");
+  }
+  getPlottedVariablesLabel(workspaceClass) {
+    return this.getPlottedVariablesGroup(workspaceClass).find("text.plotted-variable-label");
   }
   getMultiLegend(workspaceClass) {
     return cy.get(`${wsClass(workspaceClass)} .graph-tool-tile .multi-legend`);

--- a/src/plugins/graph/adornments/plotted-function/plotted-function-adornment-component.scss
+++ b/src/plugins/graph/adornments/plotted-function/plotted-function-adornment-component.scss
@@ -9,5 +9,4 @@ svg[class^="plotted-function-"] {
 
 .plotted-function {
   fill: transparent;
-  stroke-width: 1px;
 }

--- a/src/plugins/graph/adornments/plotted-function/plotted-function-adornment-component.scss
+++ b/src/plugins/graph/adornments/plotted-function/plotted-function-adornment-component.scss
@@ -9,4 +9,5 @@ svg[class^="plotted-function-"] {
 
 .plotted-function {
   fill: transparent;
+  stroke-width: 1px;
 }

--- a/src/plugins/shared-variables/graph/plotted-variables-adornment/plotted-variables-adornment-component.tsx
+++ b/src/plugins/shared-variables/graph/plotted-variables-adornment/plotted-variables-adornment-component.tsx
@@ -16,6 +16,7 @@ import { SharedVariables } from "../../shared-variables";
 import { IPlottedVariablesAdornmentModel } from "./plotted-variables-adornment-model";
 
 import "../../../graph/adornments/plotted-function/plotted-function-adornment-component.scss";
+import "./plotted-variables.scss";
 
 interface IProps {
   containerId?: string
@@ -65,10 +66,20 @@ export const PlottedVariablesAdornmentComponent = observer(function PlottedVaria
         const path = `M${tPoints[0].x},${tPoints[0].y},${curveBasis(tPoints)}`;
 
         const selection = select(plottedFunctionRef.current);
+        // Path for hover state, visible on hover
+        selection.append("path")
+          .attr("class", `plotted-function-highlight plotted-function-${classFromKey}`)
+          .attr("data-testid", `plotted-function-highlight-path${classFromKey ? `-${classFromKey}` : ""}`)
+          .attr("d", path)
+          .attr("pointer-events", "all")
+          .on('mouseover', function(d, i) { this.classList.add('selected'); })
+          .on('mouseout', function(d, i) { this.classList.remove('selected'); });
+        // Path for main line
         selection.append("path")
           .attr("class", `plotted-function plotted-function-${classFromKey}`)
           .attr("data-testid", `plotted-function-path${classFromKey ? `-${classFromKey}` : ""}`)
           .attr("stroke", graphModel.getColorForId(instanceKey))
+          .attr("stroke-width", "3")
           .attr("d", path);
       }
     }
@@ -102,11 +113,14 @@ export const PlottedVariablesAdornmentComponent = observer(function PlottedVaria
       .join(
         enter => {
           return enter.append('circle')
-            .attr('r', '5')
-            .attr('class', 'variable-valuex')
-            .attr("fill", (data) => graphModel.getColorForId(data.key))
+            .attr('r', graphModel.getPointRadius())
+            .attr('stroke-width', '2')
+            .attr("stroke", (data) => graphModel.getColorForId(data.key))
+            .attr("fill", "#fff")
             .attr('cx', (data) => model.pointPosition(data.x, xScale, xCellCount))
-            .attr('cy', (data) => model.pointPosition(data.y, yScale, yCellCount));
+            .attr('cy', (data) => model.pointPosition(data.y, yScale, yCellCount))
+            .on('mouseover', function(d, i) { console.log('mouseover'); this.classList.add('selected'); });
+
         },
         update => {
           return update

--- a/src/plugins/shared-variables/graph/plotted-variables-adornment/plotted-variables-adornment-component.tsx
+++ b/src/plugins/shared-variables/graph/plotted-variables-adornment/plotted-variables-adornment-component.tsx
@@ -68,7 +68,7 @@ export const PlottedVariablesAdornmentComponent = observer(function PlottedVaria
 
         const selection = select(plottedFunctionRef.current);
         const traceGroup = selection.append("g")
-          .attr("class", `plotted-variable plotted-function-${classFromKey}`)
+          .attr("class", 'plotted-variable')
           .on('mouseover', function(d, i) { this.classList.add('selected'); })
           .on('mouseout', function(d, i) { this.classList.remove('selected'); });
 
@@ -78,10 +78,8 @@ export const PlottedVariablesAdornmentComponent = observer(function PlottedVaria
           .attr('d', path);
         // Path for main line
         traceGroup.append('path')
-          .attr('class', `plotted-function plotted-function-${classFromKey}`)
-          .attr('data-testid', `plotted-function-path${classFromKey ? `-${classFromKey}` : ''}`)
+          .attr('class', `plotted-variable-path`)
           .attr('stroke', graphModel.getColorForId(instanceKey))
-          .attr('stroke-width', '3')
           .attr('d', path);
         if (values) {
           const x = model.pointPosition(values.x, xScale, xCellCount),
@@ -93,7 +91,7 @@ export const PlottedVariablesAdornmentComponent = observer(function PlottedVaria
             label = `${labelFormat(values.x)}, ${labelFormat(values.y)}`;
           // Highlight for value marker
           traceGroup.append('circle')
-            .attr('class', 'plotted-variable-highlight plotted-variable-highlight-point')
+            .attr('class', 'plotted-variable-highlight plotted-variable-highlight-value')
             .attr('r', graphModel.getPointRadius() + 2.5)
             .attr('stroke-width', '5')
             .attr('cx', x)
@@ -102,7 +100,6 @@ export const PlottedVariablesAdornmentComponent = observer(function PlottedVaria
           traceGroup.append('circle')
             .attr('class', 'plotted-variable-value')
             .attr('r', graphModel.getPointRadius())
-            .attr('stroke-width', '2')
             .attr('stroke', (data) => graphModel.getColorForId(instanceKey))
             .attr('fill', '#fff')
             .attr('cx', x)
@@ -110,14 +107,14 @@ export const PlottedVariablesAdornmentComponent = observer(function PlottedVaria
           // Value label background
           const labelRectHeight = textHeight + 2 * padding;
           const labelRect = traceGroup.append('rect')
-            .attr('class', 'plotted-variable-label')
+            .attr('class', 'plotted-variable-highlight plotted-variable-labelbox')
             .attr('y', y - offsetFromPoint - labelRectHeight)
             .attr('rx', labelRectHeight / 2)
             .attr('ry', labelRectHeight / 2)
             .attr('height', labelRectHeight);
           // Value label
           const valueLabel = traceGroup.append('text')
-            .attr('class', 'plotted-variable-label')
+            .attr('class', 'plotted-variable-highlight plotted-variable-label')
             .attr('text-anchor', 'middle')
             .attr('x', x)
             .attr('y', y - offsetFromPoint - padding - 2) // up 2px to account for borders
@@ -130,7 +127,7 @@ export const PlottedVariablesAdornmentComponent = observer(function PlottedVaria
         }
       }
     }
-  }, [classFromKey, graphModel, model, xCellCount, xScale, yCellCount, yScale]);
+  }, [graphModel, model, xCellCount, xScale, yCellCount, yScale]);
 
   // Add the lines and their associated covers and labels
   const refreshValues = useCallback(() => {

--- a/src/plugins/shared-variables/graph/plotted-variables-adornment/plotted-variables-adornment-component.tsx
+++ b/src/plugins/shared-variables/graph/plotted-variables-adornment/plotted-variables-adornment-component.tsx
@@ -87,13 +87,14 @@ export const PlottedVariablesAdornmentComponent = observer(function PlottedVaria
             textHeight = 12,
             padding = 4,
             offsetFromPoint = 14,
+            highlightStrokeWidth = 5,
             labelFormat = format('.3~r'),
             label = `${labelFormat(values.x)}, ${labelFormat(values.y)}`;
           // Highlight for value marker
           traceGroup.append('circle')
             .attr('class', 'plotted-variable-highlight plotted-variable-highlight-value')
-            .attr('r', graphModel.getPointRadius() + 2.5)
-            .attr('stroke-width', '5')
+            .attr('r', graphModel.getPointRadius() + highlightStrokeWidth/2)
+            .attr('stroke-width', highlightStrokeWidth)
             .attr('cx', x)
             .attr('cy', y);
           // Value marker circle

--- a/src/plugins/shared-variables/graph/plotted-variables-adornment/plotted-variables-adornment-component.tsx
+++ b/src/plugins/shared-variables/graph/plotted-variables-adornment/plotted-variables-adornment-component.tsx
@@ -165,7 +165,6 @@ export const PlottedVariablesAdornmentComponent = observer(function PlottedVaria
         plottedVariables.xVariable; // eslint-disable-line no-unused-expressions
       });
       refreshValues();
-      // refreshCurrentValues();
     }, { name: "PlottedVariablesAdornmentComponent.refreshAxisChange" }, model);
   }, [dataConfig, model, plotWidth, plotHeight, sharedVariables, xAxis, yAxis, refreshValues]);
 

--- a/src/plugins/shared-variables/graph/plotted-variables-adornment/plotted-variables.scss
+++ b/src/plugins/shared-variables/graph/plotted-variables-adornment/plotted-variables.scss
@@ -1,9 +1,39 @@
-path.plotted-function-highlight {
-  stroke: none;
-  stroke-width: 13;
+g.plotted-variable {
+  pointer-events: stroke;
+
+  .plotted-variable-highlight {
+    stroke: none;
+
+    &.plotted-variable-highlight-path {
+      stroke-width: 13;
+    }
+  }
+
+  .plotted-variable-label {
+    opacity: 0;
+  }
 
   &.selected {
-    stroke: rgba(20, 244, 158, 0.5);
-  }
-}
 
+    .plotted-variable-highlight {
+      stroke: rgba(20, 244, 158, 0.5);
+    }
+
+    .plotted-variable-label {
+      opacity: 1;
+    }
+
+  }
+
+  rect.plotted-variable-label {
+    fill: #14f49e;
+    stroke: #949494;  // --text-gray
+    stroke-width: 1.5;
+  }
+
+  text.plotted-variable-label {
+      fill: #3f3f3f;
+      font-size: 12px;
+  }
+
+}

--- a/src/plugins/shared-variables/graph/plotted-variables-adornment/plotted-variables.scss
+++ b/src/plugins/shared-variables/graph/plotted-variables-adornment/plotted-variables.scss
@@ -1,0 +1,9 @@
+path.plotted-function-highlight {
+  stroke: none;
+  stroke-width: 13;
+
+  &.selected {
+    stroke: rgba(20, 244, 158, 0.5);
+  }
+}
+

--- a/src/plugins/shared-variables/graph/plotted-variables-adornment/plotted-variables.scss
+++ b/src/plugins/shared-variables/graph/plotted-variables-adornment/plotted-variables.scss
@@ -1,37 +1,41 @@
 g.plotted-variable {
   pointer-events: stroke;
 
+  // All 'highlight' elements are invisible unless g.plotted-variable has 'selected' class.
   .plotted-variable-highlight {
-    stroke: none;
-
-    &.plotted-variable-highlight-path {
-      stroke-width: 13;
-    }
-  }
-
-  .plotted-variable-label {
     opacity: 0;
   }
 
   &.selected {
-
     .plotted-variable-highlight {
-      stroke: rgba(20, 244, 158, 0.5);
-    }
-
-    .plotted-variable-label {
       opacity: 1;
     }
-
   }
 
-  rect.plotted-variable-label {
+  .plotted-variable-path {
+    stroke-width: 3;
+  }
+
+  .plotted-variable-highlight-path {
+    stroke: rgba(20, 244, 158, 0.5);
+    stroke-width: 13;
+  }
+
+  .plotted-variable-value {
+    stroke-width: 3;
+  }
+
+  .plotted-variable-highlight-value {
+    stroke: rgba(20, 244, 158, 0.5);
+  }
+
+  .plotted-variable-labelbox {
     fill: #14f49e;
     stroke: #949494;  // --text-gray
     stroke-width: 1.5;
   }
 
-  text.plotted-variable-label {
+  .plotted-variable-label {
       fill: #3f3f3f;
       font-size: 12px;
   }


### PR DESCRIPTION
Implements PT-186610304.

A point is drawn on the trace of each variable pair added to a graph, showing the current value of those variables (if the variables both have a value). 

On mouseover, the trace and the point are highlighted, and a label showing the current values (rounded off) is shown.
