### PR TITLE
186811130 enable sort work listeners

### DIFF
--- a/src/lib/db-listeners/db-student-personal-docs-listener.ts
+++ b/src/lib/db-listeners/db-student-personal-docs-listener.ts
@@ -2,6 +2,7 @@ import firebase from "firebase/app";
 import { DB } from "../db";
 import { OtherDocumentType, PersonalDocument } from "../../models/document/document-types";
 import { BaseListener } from "./base-listener";
+import { ENavTab } from "../../models/view/nav-tabs";
 
 export class DBStudentPersonalDocsListener extends BaseListener {
   private db: DB;
@@ -13,6 +14,10 @@ export class DBStudentPersonalDocsListener extends BaseListener {
   }
 
   public start() {
+    const tabNames = this.db.stores.tabsToDisplay.map(tab => tab.tab);
+    const usesSortWork = tabNames.includes(ENavTab.kSortWork);
+    if (!usesSortWork) return;
+    console.log("| starting DBStudentPersonalDocsListener because we have a sort work tab");
     const { user } = this.db.stores;
     return new Promise<void>((resolve, reject) => {
       const offeringUsersRef = this.db.firebase.ref(

--- a/src/lib/db-listeners/db-student-personal-docs-listener.ts
+++ b/src/lib/db-listeners/db-student-personal-docs-listener.ts
@@ -16,8 +16,7 @@ export class DBStudentPersonalDocsListener extends BaseListener {
   public start() {
     const tabNames = this.db.stores.tabsToDisplay.map(tab => tab.tab);
     const usesSortWork = tabNames.includes(ENavTab.kSortWork);
-    if (!usesSortWork) return;
-    console.log("| starting DBStudentPersonalDocsListener because we have a sort work tab");
+    if (!usesSortWork) return Promise.resolve();
     const { user } = this.db.stores;
     return new Promise<void>((resolve, reject) => {
       const offeringUsersRef = this.db.firebase.ref(


### PR DESCRIPTION
This makes it so we only start listening to offering users' personal doc changes if a sort-work tab is specified for the unit we are in, as described in PT-186811130