### PR TITLE
185855379 Increase Allowed Zoom Out and Prevent Panning while Dragging Nodes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@chakra-ui/react": "^1.8.9",
         "@concord-consortium/compute-engine": "^0.12.3-cc.2",
-        "@concord-consortium/diagram-view": "^0.0.52",
+        "@concord-consortium/diagram-view": "^0.0.53",
         "@concord-consortium/mobx-state-tree": "^5.1.8-cc.2",
         "@concord-consortium/react-components": "^0.7.1",
         "@concord-consortium/react-modal-hook": "^3.0.0-cc.1",
@@ -2695,9 +2695,9 @@
       }
     },
     "node_modules/@concord-consortium/diagram-view": {
-      "version": "0.0.52",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.52.tgz",
-      "integrity": "sha512-zDnL3i68X0fI0BQoXCPpY+pe0Beuy9xoTyjnDMVIu6/MIRO1VXnD/xmDwfa1IpxDDLwtjeOIs4Yon+zdy0OrFw==",
+      "version": "0.0.53",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.53.tgz",
+      "integrity": "sha512-jK2yfs5/cqT0Xan9552eX31HKx7CMZNTIyNpgE/h1DXYszoWQxPtzIlib20+YnqrYslJekMLSv2I2naN/ASt0Q==",
       "dependencies": {
         "iframe-phone": "^1.3.1",
         "mathjs": "^10.4.1",
@@ -24561,9 +24561,9 @@
       }
     },
     "@concord-consortium/diagram-view": {
-      "version": "0.0.52",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.52.tgz",
-      "integrity": "sha512-zDnL3i68X0fI0BQoXCPpY+pe0Beuy9xoTyjnDMVIu6/MIRO1VXnD/xmDwfa1IpxDDLwtjeOIs4Yon+zdy0OrFw==",
+      "version": "0.0.53",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.53.tgz",
+      "integrity": "sha512-jK2yfs5/cqT0Xan9552eX31HKx7CMZNTIyNpgE/h1DXYszoWQxPtzIlib20+YnqrYslJekMLSv2I2naN/ASt0Q==",
       "requires": {
         "iframe-phone": "^1.3.1",
         "mathjs": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -211,7 +211,7 @@
   "dependencies": {
     "@chakra-ui/react": "^1.8.9",
     "@concord-consortium/compute-engine": "^0.12.3-cc.2",
-    "@concord-consortium/diagram-view": "^0.0.52",
+    "@concord-consortium/diagram-view": "^0.0.53",
     "@concord-consortium/mobx-state-tree": "^5.1.8-cc.2",
     "@concord-consortium/react-components": "^0.7.1",
     "@concord-consortium/react-modal-hook": "^3.0.0-cc.1",

--- a/src/plugins/diagram-viewer/diagram-types.ts
+++ b/src/plugins/diagram-viewer/diagram-types.ts
@@ -4,7 +4,7 @@ export const kDiagramTileType = "Diagram";
 // Currently it is just the version of the diagram-view library.
 // TODO: include a version in the diagram-view library so we can reference that
 // instead
-export const kQPVersion = "0.0.52";
+export const kQPVersion = "0.0.53";
 
 // This is a version stored in the state of the tile
 // Currently any state with a different version will be ignored.


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/185855379

This PR updates the version of diagram-view used by CLUE. The updated version of diagram-view allows the user to zoom out more and also prevents the tile from panning when dragging nodes, which should prevent most cases where nodes are separated very far from each other.