### PR TITLE
186631894 sort work for students with isPrivate calc

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ To enable per component debugging set the "debug" localstorage key with one or m
 
 - `canvas` this will show the document key over the canvas, useful for looking up documents in Firebase
 - `cms` this will print info to the console as changes are made to authored content via the CMS
+- `docList` - this will print a table of information about a list of documents
 - `document` this will add the active document as `window.currentDocument`, you can use MST's hidden toJSON() like `currentDocument.toJSON()` to views its content.
 - `drop` console log the dataTransfer object from drop events on the document.
 - `history` this will: print some info to the console as the history system records changes, print the full history as JSON each time it is loaded from Firestore, and provide a `window.historyDocument` so you can inspect the document while navigating the history.
@@ -179,6 +180,7 @@ To enable per component debugging set the "debug" localstorage key with one or m
 - `sharedModels` console log messages about shared models, currently this is only used in the variables shared model
 - `stores` this will set `window.stores` so you can monitor the stores global from the browser console.
 - `undo` this will print information about each action that is added to the undo stack.
+
 
 ## Testing
 

--- a/src/components/document/doc-list-debug.scss
+++ b/src/components/document/doc-list-debug.scss
@@ -1,0 +1,20 @@
+.doc-list-debug {
+  font-family: monospace;
+  font-size: 10px;
+  border-collapse: collapse;
+  max-width: 800px;
+
+  th, td {
+    text-align: left;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  th {
+    border-bottom: 2px solid #ddd;
+  }
+
+  tr:nth-child(even) {
+    background-color: #f2f2f2;
+  }
+}

--- a/src/components/document/doc-list-debug.tsx
+++ b/src/components/document/doc-list-debug.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { DocumentModelType } from "../../models/document/document";
+
+import "./doc-list-debug.scss";
+
+interface IProps {
+  docs: DocumentModelType[];
+}
+
+export function DocListDebug(props: IProps) {
+  const { docs } = props;
+  return (
+    <table className="doc-list-debug">
+      <thead>
+        <tr>
+          <th>ct</th>
+          <th>key</th>
+          <th>type</th>
+          <th>viz</th>
+          <th>uid</th>
+          <th>gp</th>
+          <th>title</th>
+        </tr>
+      </thead>
+      <tbody>
+        {docs.map((doc, idx) => {
+          const ct = idx + 1;
+          return (
+            <tr key={idx}>
+              <td>{ct}</td>
+              <td>{doc.key}</td>
+              <td>{doc.type}</td>
+              <td>{doc.visibility ? doc.visibility : "undefined"}</td>
+              <td>{doc.uid}</td>
+              <td>{doc.groupId ?? " "}</td>
+              <td>{doc.title}</td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}

--- a/src/components/document/sort-work-view.scss
+++ b/src/components/document/sort-work-view.scss
@@ -141,4 +141,9 @@ $title-margin: 2px;
       }
     }
   }
+
+  .debug-header, .debug-row, .debug-line {
+    font-size: 10px;
+    margin: 0px;
+  }
 }

--- a/src/components/document/sort-work-view.scss
+++ b/src/components/document/sort-work-view.scss
@@ -141,9 +141,4 @@ $title-margin: 2px;
       }
     }
   }
-
-  .debug-header, .debug-row, .debug-line {
-    font-size: 10px;
-    margin: 0px;
-  }
 }

--- a/src/components/document/sort-work-view.tsx
+++ b/src/components/document/sort-work-view.tsx
@@ -6,7 +6,7 @@ import { ICustomDropdownItem } from "../../clue/components/custom-select";
 import { DecoratedDocumentThumbnailItem } from "../thumbnail/decorated-document-thumbnail-item";
 import { DocumentModelType, getDocumentContext } from "../../models/document/document";
 import { DocumentContextReact } from "./document-context";
-import { DEBUG_SORT_WORK } from "../../lib/debug";
+import { DEBUG_DOC_LIST } from "../../lib/debug";
 import { isSortableType } from "../../models/document/document-types";
 import { SortWorkDocumentArea } from "./sort-work-document-area";
 import { ENavTab } from "../../models/view/nav-tabs";
@@ -138,7 +138,7 @@ export const SortWorkView: React.FC = observer(function SortWorkView() {
                 );
               })
             }
-            {DEBUG_SORT_WORK && <DocListDebug docs={filteredDocsByType} />}
+            {DEBUG_DOC_LIST && <DocListDebug docs={filteredDocsByType} />}
           </div>
         </>
       }

--- a/src/components/document/sort-work-view.tsx
+++ b/src/components/document/sort-work-view.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { observer } from "mobx-react";
 import { SortWorkHeader } from "../navigation/sort-work-header";
-import { useStores, usePersistentUIStore, useAppConfig } from "../../hooks/use-stores";
+import { useStores, usePersistentUIStore } from "../../hooks/use-stores";
 import { ICustomDropdownItem } from "../../clue/components/custom-select";
 import { DecoratedDocumentThumbnailItem } from "../thumbnail/decorated-document-thumbnail-item";
 import { DocumentModelType, getDocumentContext } from "../../models/document/document";
@@ -100,14 +100,32 @@ export const SortWorkView: React.FC = observer(function SortWorkView() {
 
   //******************************* Handle Debug View ***************************************
   const renderDebugView = () => {
-    //returns a list lf all documents (unsorted)
     return filteredDocsByType.map((doc, idx) => {
       const ct = idx + 1;
       return (
-        <pre key={idx} style={{ margin: "0px", padding: "0px", fontSize: "10px" }}>
-          {ct < 10 && " "}{ct} | {doc.title?.slice(0, 20) || "                    "}
-          | {doc.key} | {doc.type} | {doc.uid}
-        </pre>
+        <React.Fragment key={idx}>
+          { idx === 0 &&
+            <pre className="debug-header">
+              &nbsp;
+              | key  {" ".repeat(17)}
+              | type {" ".repeat(7)}
+              | viz  {" ".repeat(5)}
+              | uid {" ".repeat(1)}
+              | gp {" ".repeat(0)}
+              | title {" ".repeat(4)}
+            </pre>
+          }
+          <hr className="debug-line" />
+          <pre className="debug-row">
+            {ct < 10 && " "}{ct}
+            | {doc.key}&nbsp;
+            | {doc.type}{" ".repeat(12 - doc.type.length)}
+            | {doc.visibility ? doc.visibility + " ".repeat(10 - doc.visibility.length) : "undefined "}
+            | {doc.uid}{" ".repeat(5 - doc.uid.length)}
+            | {doc.groupId ?? " "}&nbsp;
+            | {doc.title?.slice(0, 20)}
+          </pre>
+        </React.Fragment>
       );
     });
   };

--- a/src/components/document/sort-work-view.tsx
+++ b/src/components/document/sort-work-view.tsx
@@ -10,6 +10,7 @@ import { DEBUG_SORT_WORK } from "../../lib/debug";
 import { isSortableType } from "../../models/document/document-types";
 import { SortWorkDocumentArea } from "./sort-work-document-area";
 import { ENavTab } from "../../models/view/nav-tabs";
+import { DocListDebug } from "./doc-list-debug";
 
 import "../thumbnail/document-type-collection.sass";
 import "./sort-work-view.scss";
@@ -98,38 +99,6 @@ export const SortWorkView: React.FC = observer(function SortWorkView() {
   const openDocumentKey = tabState?.openDocuments.get(ENavTab.kSortWork) || "";
   const showSortWorkDocumentArea = !!openDocumentKey;
 
-  //******************************* Handle Debug View ***************************************
-  const renderDebugView = () => {
-    return filteredDocsByType.map((doc, idx) => {
-      const ct = idx + 1;
-      return (
-        <React.Fragment key={idx}>
-          { idx === 0 &&
-            <pre className="debug-header">
-              &nbsp;
-              | key  {" ".repeat(17)}
-              | type {" ".repeat(7)}
-              | viz  {" ".repeat(5)}
-              | uid {" ".repeat(1)}
-              | gp {" ".repeat(0)}
-              | title {" ".repeat(4)}
-            </pre>
-          }
-          <hr className="debug-line" />
-          <pre className="debug-row">
-            {ct < 10 && " "}{ct}
-            | {doc.key}&nbsp;
-            | {doc.type}{" ".repeat(12 - doc.type.length)}
-            | {doc.visibility ? doc.visibility + " ".repeat(10 - doc.visibility.length) : "undefined "}
-            | {doc.uid}{" ".repeat(5 - doc.uid.length)}
-            | {doc.groupId ?? " "}&nbsp;
-            | {doc.title?.slice(0, 20)}
-          </pre>
-        </React.Fragment>
-      );
-    });
-  };
-
   return (
     <div key="sort-work-view" className="sort-work-view">
       {
@@ -169,7 +138,7 @@ export const SortWorkView: React.FC = observer(function SortWorkView() {
                 );
               })
             }
-            {DEBUG_SORT_WORK && renderDebugView()}
+            {DEBUG_SORT_WORK && <DocListDebug docs={filteredDocsByType} />}
           </div>
         </>
       }

--- a/src/components/thumbnail/thumbnail-document-item.tsx
+++ b/src/components/thumbnail/thumbnail-document-item.tsx
@@ -5,7 +5,7 @@ import { DocumentModelType } from "../../models/document/document";
 import { DocumentCaption } from "./document-caption";
 import { ThumbnailPlaceHolderIcon } from "./thumbnail-placeholder-icon";
 import { ThumbnailPrivateIcon } from "./thumbnail-private-icon";
-import { useAppMode } from "../../hooks/use-stores";
+import { useAppMode, useStores } from "../../hooks/use-stores";
 import classNames from "classnames";
 
 interface IProps {
@@ -30,6 +30,7 @@ export const ThumbnailDocumentItem: React.FC<IProps> = observer((props: IProps) 
   } = props;
   const selectedClass = isSelected ? "selected" : "";
   const appMode = useAppMode();
+  const stores = useStores();
 
   const handleDocumentClick = (e: React.MouseEvent<HTMLDivElement>) => {
     onDocumentClick?.(document);
@@ -46,8 +47,8 @@ export const ThumbnailDocumentItem: React.FC<IProps> = observer((props: IProps) 
     onDocumentDeleteClick?.(document);
     e.stopPropagation();
   };
-  // TODO: add proper state of isPrivate based on document properties
-  const isPrivate = false; // document.visibility === "private" && document.isRemote;
+
+  const isPrivate = !document.isAccessibleToUser(stores.user);
   const privateClass = isPrivate ? "private" : "";
   const documentTitle = appMode !== "authed" && appMode !== "demo"
                           ? `Firebase UID: ${document.key}` : undefined;

--- a/src/lib/debug.ts
+++ b/src/lib/debug.ts
@@ -18,4 +18,4 @@ export const DEBUG_SAVE = debugContains("save");
 export const DEBUG_SHARED_MODELS = debugContains("sharedModels");
 export const DEBUG_STORES = debugContains("stores");
 export const DEBUG_UNDO = debugContains("undo");
-export const DEBUG_SORT_WORK = debugContains("sortWork");
+export const DEBUG_DOC_LIST = debugContains("docList");

--- a/src/models/document/document.ts
+++ b/src/models/document/document.ts
@@ -27,6 +27,7 @@ import { TreeManager } from "../history/tree-manager";
 import { ESupportType } from "../curriculum/support";
 import { IDocumentLogEvent, logDocumentEvent } from "./log-document-event";
 import { LogEventMethod, LogEventName } from "../../lib/logger-types";
+import { UserModelType } from "../stores/user";
 
 interface IMatchPropertiesOptions {
   isTeacherDocument?: boolean;
@@ -110,6 +111,20 @@ export const DocumentModel = Tree.named("Document")
       // code can work with the old functions.
       return { contextId: "ignored", uid, type, key, createdAt, title,
         originDoc, properties: properties.toJSON() } as IDocumentMetadata;
+    },
+    isAccessibleToUser(user: UserModelType) {
+      const ownDocument = self.uid === user.id;
+      const isShared = self.visibility === "public";
+      const isPub = (self.type === ProblemPublication)
+        || (self.type === LearningLogPublication)
+        || (self.type === PersonalPublication)
+        || (self.type === SupportPublication);
+
+      if (user.type === "teacher") return true;
+      if (user.type === "student") {
+        return ownDocument || isShared || isPub;
+      }
+      return false;
     },
     getProperty(key: string) {
       return self.properties.get(key);

--- a/src/models/document/document.ts
+++ b/src/models/document/document.ts
@@ -112,20 +112,6 @@ export const DocumentModel = Tree.named("Document")
       return { contextId: "ignored", uid, type, key, createdAt, title,
         originDoc, properties: properties.toJSON() } as IDocumentMetadata;
     },
-    isAccessibleToUser(user: UserModelType) {
-      const ownDocument = self.uid === user.id;
-      const isShared = self.visibility === "public";
-      const isPub = (self.type === ProblemPublication)
-        || (self.type === LearningLogPublication)
-        || (self.type === PersonalPublication)
-        || (self.type === SupportPublication);
-
-      if (user.type === "teacher") return true;
-      if (user.type === "student") {
-        return ownDocument || isShared || isPub;
-      }
-      return false;
-    },
     getProperty(key: string) {
       return self.properties.get(key);
     },
@@ -195,6 +181,13 @@ export const DocumentModel = Tree.named("Document")
     },
     getUniqueTitle(tileType: string, titleBase: string) {
       return self.content?.getUniqueTitle(tileType, titleBase);
+    },
+    isAccessibleToUser(user: UserModelType) {
+      const ownDocument = self.uid === user.id;
+      const isShared = self.visibility === "public";
+      if (user.type === "teacher") return true;
+      if (user.type === "student") return ownDocument || isShared || self.isPublished;
+      return false;
     }
   }))
   .views(self => ({


### PR DESCRIPTION
PT-186631894 _Draft_

For units with Sort Work tab enabled for students, this will apply the privacy "eyeball"  as needed according to user role, and the type and share setting of each document. 

It also moves the `sortWork` debug render function to its own component, changing the debug flag to the more general `DEBUG_DOC_LIST` and the key to `docList`

(It used to be `DEBUG_SORT_VIEW` and the key was `sortView`)

