### PR TITLE
autoscale adjustments

### DIFF
--- a/cypress/e2e/functional/tile_tests/xy_plot_tool_spec.js
+++ b/cypress/e2e/functional/tile_tests/xy_plot_tool_spec.js
@@ -312,7 +312,7 @@ context('XYPlot Tool Tile', function () {
       cy.get('select').select("New Graph");
       dialogOkButton().click();
       xyTile.getPlottedVariablesGroup().should("not.exist");
-      xyTile.getEditableAxisBox('bottom', 'min').invoke('text').then(parseFloat).should("be.within", -11, -9);
+      xyTile.getEditableAxisBox('bottom', 'min').invoke('text').then(parseFloat).should("be.within", -1, 0);
       xyTile.getEditableAxisBox('bottom', 'max').invoke('text').then(parseFloat).should("be.within", 9, 11);
 
       xyTile.selectXVariable(name1);
@@ -355,10 +355,10 @@ context('XYPlot Tool Tile', function () {
       xyTile.getPlottedVariablesPoint().should("have.length", 2);
       xyTile.getPlottedVariablesLabel().should("have.length", 2).eq(1).should("have.text", "3, 2");
 
-      // Fit button should adjust bounds to narrowly include (2,2) and (3,3)
+      // Fit button should adjust bounds to center points (2,2) and (3,3) - so, 0 to 6 on each axis
       clueCanvas.clickToolbarButton('graph', 'fit-all');
-      xyTile.getEditableAxisBox('bottom', 'min').invoke('text').then(parseFloat).should("be.within", 1.5, 2);
-      xyTile.getEditableAxisBox('bottom', 'max').invoke('text').then(parseFloat).should("be.within", 3, 4);
+      xyTile.getEditableAxisBox('bottom', 'min').invoke('text').then(parseFloat).should("be.within", -1, 0);
+      xyTile.getEditableAxisBox('bottom', 'max').invoke('text').then(parseFloat).should("be.within", 6, 8);
 
       // Drag point to change value
       diagramTile.getVariableCardField("value").eq(1).should("have.value", "3");

--- a/src/plugins/graph/graph-types.ts
+++ b/src/plugins/graph/graph-types.ts
@@ -105,6 +105,6 @@ export const kGraphAdornmentsClass = "graph-adornments-grid";
 export const kGraphAdornmentsClassSelector = `.${kGraphAdornmentsClass}`;
 
 // TODO: determine this via configuration, e.g. appConfig, since apps may prefer different defaults
-export const kDefaultNumericAxisBounds = [-10, 11] as const;
+export const kDefaultNumericAxisBounds = [0, 10] as const;
 
 export const kGraphPortalClass = ".canvas-area";

--- a/src/plugins/graph/models/graph-model.ts
+++ b/src/plugins/graph/models/graph-model.ts
@@ -173,7 +173,7 @@ export const GraphModel = TileContentModel
       return self.layers.reduce((prev, layer) => prev+layer.config.caseDataArray.length, 0);
     },
     /**
-     * Return list of all values for attributes of the given role across all layers.
+     * Return list of all values to be plotted on the given role across all layers and adornments.
      */
     numericValuesForAttrRole(role: GraphAttrRole): number[] {
       let allValues: number[] = [];

--- a/src/plugins/shared-variables/graph/plotted-variables-adornment/plotted-variables-adornment-model.ts
+++ b/src/plugins/shared-variables/graph/plotted-variables-adornment/plotted-variables-adornment-model.ts
@@ -128,7 +128,10 @@ export const PlottedVariablesAdornmentModel = PlottedFunctionAdornmentModel
     numericValuesForAttrRole(role: GraphAttrRole) {
       const values = self.variableValues;
       if (role in values) {
-        return values[role as 'x'|'y'];
+        // We don't return the actual variable values, but rather 0 and 2 times each value.
+        // This is because of how autoscale is defined for variables - not just the current-value point
+        // has to fit in the graph, but a range of values around it so the function line can be seen.
+        return [0, ...values[role as 'x'|'y'].map(x => 2*x)];
       } else {
         return [] as number[];
       }


### PR DESCRIPTION
Adjust autoscaling rules as per PT-186819809.

* x variable default range changed to 0 to 10 (when there are no data points or variables)
* 'Fit all' button behavior adjusted to match autoscaling behavior - clicking 'Fit' should not change how the graph is scaled if the graph has already been auto-scaled.  The new behavior always shows the range `[0 - 2*value]` for all variable values