### PR TITLE
bring demo temperature data back in as an option on temp sensor

### DIFF
--- a/cypress/e2e/functional/tile_tests/dataflow_tool_spec.js
+++ b/cypress/e2e/functional/tile_tests/dataflow_tool_spec.js
@@ -544,7 +544,7 @@ context('Dataflow Tool Tile', function () {
     cy.log("verify sensor select");
     const sensorSelectdropdown = "sensor-select";
     const sensorSelect = [
-      "Humidity Demo Data", "CO2 Demo Data", "O2 Demo Data", "Light Demo Data", "Particulates Demo Data",
+      "Temperature Demo Data", "Humidity Demo Data", "CO2 Demo Data", "O2 Demo Data", "Light Demo Data", "Particulates Demo Data",
       "⚠️ Connect Arduino for live EMG",
       "⚠️ Connect Arduino for live Pressure",
       "⚠️ Connect Arduino for live Temperature",
@@ -559,7 +559,7 @@ context('Dataflow Tool Tile', function () {
     ];
     dataflowToolTile.getCreateNodeButton(sensorNode).click();
     dataflowToolTile.getDropdown(sensorNode, sensorSelectdropdown).click();
-    dataflowToolTile.getSensorDropdownOptions(sensorNode).should("have.length", 16);
+    dataflowToolTile.getSensorDropdownOptions(sensorNode).should("have.length", 17);
     dataflowToolTile.getSensorDropdownOptions(sensorNode).each(($tab, index, $typeList) => {
       expect($tab.text()).to.contain(sensorSelect[index]);
     });

--- a/cypress/e2e/functional/tile_tests/simulator_tile_spec.js
+++ b/cypress/e2e/functional/tile_tests/simulator_tile_spec.js
@@ -1,6 +1,6 @@
-import ClueCanvas from '../../../support/elements/common/cCanvas';
+import ClueCanvas from "../../../support/elements/common/cCanvas";
 import DataflowTile from "../../../support/elements/tile/DataflowToolTile";
-import SimulatorTile from '../../../support/elements/tile/SimulatorTile';
+import SimulatorTile from "../../../support/elements/tile/SimulatorTile";
 
 let clueCanvas = new ClueCanvas;
 const dataflowTile = new DataflowTile;
@@ -124,7 +124,7 @@ context('Simulator Tile', function () {
 
   it("Simulator Tile with Terrarium Simulation", () => {
     beforeTest(queryParams2);
-    
+
     cy.log("links to dataflow tile");
     // Copy a simulator tile over from curriculum
     simulatorTile.getSimulatorTile().should("not.exist");
@@ -146,7 +146,7 @@ context('Simulator Tile', function () {
     dataflowTile.getDropdown(sensor, "sensor-type").click();
     dataflowTile.getSensorDropdownOptions(sensor).eq(0).find(".label").click(); // Temperature
     dataflowTile.getDropdown(sensor, "sensor-select").click();
-    dataflowTile.getSensorDropdownOptions(sensor).should("have.length", 6);
+    dataflowTile.getSensorDropdownOptions(sensor).should("have.length", 7);
     dataflowTile.getDropdown(sensor, "sensor-type").click();
     dataflowTile.getSensorDropdownOptions(sensor).eq(1).find(".label").click(); // Humidity
     dataflowTile.getDropdown(sensor, "sensor-select").click();

--- a/src/plugins/dataflow/model/utilities/virtual-channel.ts
+++ b/src/plugins/dataflow/model/utilities/virtual-channel.ts
@@ -1,15 +1,13 @@
 import { NodeChannelInfo } from "./channel";
-// import { demoStreams } from "../../../shared-assets/data/dataflow/demo-data";
+import { demoStreams } from "../../../shared-assets/data/dataflow/demo-data";
 
-// Virtual channels have just been commented out rather than fully removed in case we want to add them back
-// in at least some contexts in the future.
-// const virtualTempChannel: NodeChannelInfo = {
-//   hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "Temperature", channelId: "00001-VIR",
-//   missing: false, type: "temperature", units: "°C", value: 0, virtual: true, timeFactor: 1000,
-//   virtualValueMethod: (t: number) => {
-//     const vals = demoStreams.fastBoil;
-//     return vals[t % vals.length];
-//   } };
+const virtualTempChannel: NodeChannelInfo = {
+  hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "Temperature", channelId: "00001-VIR",
+  missing: false, type: "temperature", units: "°C", value: 0, virtual: true, timeFactor: 1000,
+  virtualValueMethod: (t: number) => {
+    const vals = demoStreams.fastBoil;
+    return vals[t % vals.length];
+  } };
 const virtualHumidChannel: NodeChannelInfo = {
   hubId: "00000-VIRTUAL-HUB", hubName: "Virtual Sensor", name: "Humidity", channelId: "00002-VIR",
   missing: false, type: "humidity", units: "%", value: 0, virtual: true, timeFactor: 1000,
@@ -47,6 +45,6 @@ const virtualPartChannel: NodeChannelInfo = {
   } };
 
 export const virtualSensorChannels: NodeChannelInfo[] = [
-  virtualHumidChannel, virtualCO2Channel, virtualO2Channel,
+  virtualTempChannel, virtualHumidChannel, virtualCO2Channel, virtualO2Channel,
   virtualLightChannel, virtualPartChannel
 ];


### PR DESCRIPTION
PT-186872441

This brings the hard coded `fastBoil` temp series back into the Sensor block as an option.  This data was created originally for this purpose, and was then taken out of the temperature sensor directly, (and eventually used instead in the Sim tile).  Now it is available in both places. 

- [x] adjust cypress tests
- [x] double-check sim tile use of the data doesn't conflict