### PR TITLE
Fix Diagram behavior with unused inputs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@chakra-ui/react": "^1.8.9",
         "@concord-consortium/compute-engine": "^0.12.3-cc.2",
-        "@concord-consortium/diagram-view": "^0.0.53",
+        "@concord-consortium/diagram-view": "1.0.0-beta.1",
         "@concord-consortium/mobx-state-tree": "^5.1.8-cc.2",
         "@concord-consortium/react-components": "^0.7.1",
         "@concord-consortium/react-modal-hook": "^3.0.0-cc.1",
@@ -50,7 +50,7 @@
         "patch-package": "^6.4.7",
         "promise-assist": "^2.0.1",
         "query-string": "7.1.1",
-        "rc-slider": "^10.0.1",
+        "rc-slider": "^10.5.0",
         "react": "^17.0.2",
         "react-chartjs-2": "^2.11.2",
         "react-data-grid": "7.0.0-canary.46",
@@ -2695,12 +2695,18 @@
       }
     },
     "node_modules/@concord-consortium/diagram-view": {
-      "version": "0.0.53",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.53.tgz",
-      "integrity": "sha512-jK2yfs5/cqT0Xan9552eX31HKx7CMZNTIyNpgE/h1DXYszoWQxPtzIlib20+YnqrYslJekMLSv2I2naN/ASt0Q==",
+      "version": "1.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-1.0.0-beta.1.tgz",
+      "integrity": "sha512-WDM7YBvrAOubtsoImd2DZ3H4ufkHMnavTqM35EaFLzvek0MDqt9qMZrtPGpFgMy00ONhWUHXC8LSpj5xcPpUoQ==",
+      "hasInstallScript": true,
       "dependencies": {
+        "classnames": "^2.3.2",
         "iframe-phone": "^1.3.1",
         "mathjs": "^10.4.1",
+        "patch-package": "^6.5.1",
+        "pluralize": "^8.0.0",
+        "react-color": "^2.19.3",
+        "react-textarea-autosize": "^8.3.4",
         "reactflow": "^11.7.2"
       },
       "peerDependencies": {
@@ -2708,6 +2714,7 @@
         "mobx": "^6.4.2",
         "mobx-react-lite": "^3.3.0",
         "nanoid": "^3.3.1",
+        "rc-slider": "^10.2.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "tslib": "^2.3.1"
@@ -4290,6 +4297,14 @@
       "version": "1.2.1",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@icons/material": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
+      "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==",
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -8032,7 +8047,6 @@
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 4.0.0"
@@ -12620,7 +12634,6 @@
     },
     "node_modules/fs-extra": {
       "version": "9.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "at-least-node": "^1.0.0",
@@ -16660,7 +16673,6 @@
     },
     "node_modules/jsonfile": {
       "version": "6.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -17022,6 +17034,11 @@
       "version": "4.17.21",
       "license": "MIT"
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "license": "MIT"
@@ -17341,6 +17358,11 @@
         "@babel/runtime": "^7.12.5",
         "remove-accents": "0.4.2"
       }
+    },
+    "node_modules/material-colors": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
+      "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "node_modules/mathjs": {
       "version": "10.6.4",
@@ -18395,33 +18417,81 @@
       }
     },
     "node_modules/patch-package": {
-      "version": "6.4.7",
-      "license": "MIT",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.5.1.tgz",
+      "integrity": "sha512-I/4Zsalfhc6bphmJTlrLoOcAF87jcxko4q0qsv4bGcurbr8IskEOtdnt9iCmsQVGL1B+iUhSQqweyTLJfCF9rA==",
       "dependencies": {
         "@yarnpkg/lockfile": "^1.1.0",
-        "chalk": "^2.4.2",
+        "chalk": "^4.1.2",
         "cross-spawn": "^6.0.5",
         "find-yarn-workspace-root": "^2.0.0",
-        "fs-extra": "^7.0.1",
+        "fs-extra": "^9.0.0",
         "is-ci": "^2.0.0",
         "klaw-sync": "^6.0.0",
-        "minimist": "^1.2.0",
+        "minimist": "^1.2.6",
         "open": "^7.4.2",
         "rimraf": "^2.6.3",
         "semver": "^5.6.0",
         "slash": "^2.0.0",
-        "tmp": "^0.0.33"
+        "tmp": "^0.0.33",
+        "yaml": "^1.10.2"
       },
       "bin": {
         "patch-package": "index.js"
       },
       "engines": {
+        "node": ">=10",
         "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/patch-package/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/patch-package/node_modules/ci-info": {
       "version": "2.0.0",
       "license": "MIT"
+    },
+    "node_modules/patch-package/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/patch-package/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/patch-package/node_modules/cross-spawn": {
       "version": "6.0.5",
@@ -18437,16 +18507,12 @@
         "node": ">=4.8"
       }
     },
-    "node_modules/patch-package/node_modules/fs-extra": {
-      "version": "7.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
+    "node_modules/patch-package/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "engines": {
-        "node": ">=6 <7 || >=8"
+        "node": ">=8"
       }
     },
     "node_modules/patch-package/node_modules/is-ci": {
@@ -18457,13 +18523,6 @@
       },
       "bin": {
         "is-ci": "bin.js"
-      }
-    },
-    "node_modules/patch-package/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/patch-package/node_modules/open": {
@@ -18521,6 +18580,17 @@
         "node": ">=6"
       }
     },
+    "node_modules/patch-package/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/patch-package/node_modules/tmp": {
       "version": "0.0.33",
       "license": "MIT",
@@ -18529,13 +18599,6 @@
       },
       "engines": {
         "node": ">=0.6.0"
-      }
-    },
-    "node_modules/patch-package/node_modules/universalify": {
-      "version": "0.1.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
       }
     },
     "node_modules/patch-package/node_modules/which": {
@@ -18649,6 +18712,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/popmotion": {
@@ -19201,13 +19272,13 @@
       "dev": true
     },
     "node_modules/rc-slider": {
-      "version": "10.0.1",
-      "license": "MIT",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-10.5.0.tgz",
+      "integrity": "sha512-xiYght50cvoODZYI43v3Ylsqiw14+D7ELsgzR40boDZaya1HFa1Etnv9MDkQE8X/UrXAffwv2AcNAhslgYuDTw==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.5",
-        "rc-util": "^5.18.1",
-        "shallowequal": "^1.1.0"
+        "rc-util": "^5.27.0"
       },
       "engines": {
         "node": ">=8.x"
@@ -19218,17 +19289,22 @@
       }
     },
     "node_modules/rc-util": {
-      "version": "5.22.5",
-      "license": "MIT",
+      "version": "5.38.1",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.38.1.tgz",
+      "integrity": "sha512-e4ZMs7q9XqwTuhIK7zBIVFltUtMSjphuPPQXHoHlzRzNdOwUxDejo0Zls5HYaJfRKNURcsS/ceKVULlhjBrxng==",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
-        "react-is": "^16.12.0",
-        "shallowequal": "^1.1.0"
+        "react-is": "^18.2.0"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
         "react-dom": ">=16.9.0"
       }
+    },
+    "node_modules/rc-util/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/react": {
       "version": "17.0.2",
@@ -19262,6 +19338,23 @@
       },
       "peerDependencies": {
         "react": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-color": {
+      "version": "2.19.3",
+      "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.19.3.tgz",
+      "integrity": "sha512-LEeGE/ZzNLIsFWa1TMe8y5VYqr7bibneWmvJwm1pCn/eNmrabWDh659JSPn9BuaMpEfU83WTOJfnCcjDZwNQTA==",
+      "dependencies": {
+        "@icons/material": "^0.2.4",
+        "lodash": "^4.17.15",
+        "lodash-es": "^4.17.15",
+        "material-colors": "^1.2.1",
+        "prop-types": "^15.5.10",
+        "reactcss": "^1.2.0",
+        "tinycolor2": "^1.4.1"
+      },
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-data-grid": {
@@ -19489,6 +19582,22 @@
         "react": "^16.3.0 || ^17.0.0-0"
       }
     },
+    "node_modules/react-textarea-autosize": {
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.3.tgz",
+      "integrity": "sha512-XT1024o2pqCuZSuBt9FwHlaDeNtVrtCXu0Rnz88t1jUGheCLa3PhjE1GH8Ctm2axEtvdCl5SUHYschyQ0L5QHQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "use-composed-ref": "^1.3.0",
+        "use-latest": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-tippy": {
       "version": "1.4.0",
       "license": "MIT",
@@ -19508,6 +19617,14 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/reactcss": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
+      "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
+      "dependencies": {
+        "lodash": "^4.0.1"
       }
     },
     "node_modules/reactflow": {
@@ -21403,6 +21520,11 @@
       "version": "1.0.3",
       "license": "MIT"
     },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="
+    },
     "node_modules/tmp": {
       "version": "0.2.1",
       "dev": true,
@@ -21934,7 +22056,6 @@
     },
     "node_modules/universalify": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
@@ -22044,9 +22165,33 @@
         }
       }
     },
+    "node_modules/use-composed-ref": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
+      "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/use-isomorphic-layout-effect": {
       "version": "1.1.2",
       "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-latest": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.2.1.tgz",
+      "integrity": "sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==",
+      "dependencies": {
+        "use-isomorphic-layout-effect": "^1.1.1"
+      },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       },
@@ -24577,12 +24722,17 @@
       }
     },
     "@concord-consortium/diagram-view": {
-      "version": "0.0.53",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-0.0.53.tgz",
-      "integrity": "sha512-jK2yfs5/cqT0Xan9552eX31HKx7CMZNTIyNpgE/h1DXYszoWQxPtzIlib20+YnqrYslJekMLSv2I2naN/ASt0Q==",
+      "version": "1.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-1.0.0-beta.1.tgz",
+      "integrity": "sha512-WDM7YBvrAOubtsoImd2DZ3H4ufkHMnavTqM35EaFLzvek0MDqt9qMZrtPGpFgMy00ONhWUHXC8LSpj5xcPpUoQ==",
       "requires": {
+        "classnames": "^2.3.2",
         "iframe-phone": "^1.3.1",
         "mathjs": "^10.4.1",
+        "patch-package": "^6.5.1",
+        "pluralize": "^8.0.0",
+        "react-color": "^2.19.3",
+        "react-textarea-autosize": "^8.3.4",
         "reactflow": "^11.7.2"
       }
     },
@@ -25711,6 +25861,12 @@
     "@humanwhocodes/object-schema": {
       "version": "1.2.1",
       "dev": true
+    },
+    "@icons/material": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
+      "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==",
+      "requires": {}
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -28220,8 +28376,7 @@
       "version": "0.4.0"
     },
     "at-least-node": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "autoprefixer": {
       "version": "10.4.8",
@@ -31237,7 +31392,6 @@
     },
     "fs-extra": {
       "version": "9.1.0",
-      "dev": true,
       "requires": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
@@ -33824,7 +33978,6 @@
     },
     "jsonfile": {
       "version": "6.1.0",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
@@ -34069,6 +34222,11 @@
     "lodash": {
       "version": "4.17.21"
     },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+    },
     "lodash.camelcase": {
       "version": "4.3.0"
     },
@@ -34294,6 +34452,11 @@
         "@babel/runtime": "^7.12.5",
         "remove-accents": "0.4.2"
       }
+    },
+    "material-colors": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
+      "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mathjs": {
       "version": "10.6.4",
@@ -34935,25 +35098,58 @@
       }
     },
     "patch-package": {
-      "version": "6.4.7",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.5.1.tgz",
+      "integrity": "sha512-I/4Zsalfhc6bphmJTlrLoOcAF87jcxko4q0qsv4bGcurbr8IskEOtdnt9iCmsQVGL1B+iUhSQqweyTLJfCF9rA==",
       "requires": {
         "@yarnpkg/lockfile": "^1.1.0",
-        "chalk": "^2.4.2",
+        "chalk": "^4.1.2",
         "cross-spawn": "^6.0.5",
         "find-yarn-workspace-root": "^2.0.0",
-        "fs-extra": "^7.0.1",
+        "fs-extra": "^9.0.0",
         "is-ci": "^2.0.0",
         "klaw-sync": "^6.0.0",
-        "minimist": "^1.2.0",
+        "minimist": "^1.2.6",
         "open": "^7.4.2",
         "rimraf": "^2.6.3",
         "semver": "^5.6.0",
         "slash": "^2.0.0",
-        "tmp": "^0.0.33"
+        "tmp": "^0.0.33",
+        "yaml": "^1.10.2"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
         "ci-info": {
           "version": "2.0.0"
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "cross-spawn": {
           "version": "6.0.5",
@@ -34965,24 +35161,15 @@
             "which": "^1.2.9"
           }
         },
-        "fs-extra": {
-          "version": "7.0.1",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "is-ci": {
           "version": "2.0.0",
           "requires": {
             "ci-info": "^2.0.0"
-          }
-        },
-        "jsonfile": {
-          "version": "4.0.0",
-          "requires": {
-            "graceful-fs": "^4.1.6"
           }
         },
         "open": {
@@ -35013,14 +35200,19 @@
         "slash": {
           "version": "2.0.0"
         },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
         "tmp": {
           "version": "0.0.33",
           "requires": {
             "os-tmpdir": "~1.0.2"
           }
-        },
-        "universalify": {
-          "version": "0.1.2"
         },
         "which": {
           "version": "1.3.1",
@@ -35086,6 +35278,11 @@
       "requires": {
         "find-up": "^4.0.0"
       }
+    },
+    "pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="
     },
     "popmotion": {
       "version": "11.0.3",
@@ -35440,20 +35637,29 @@
       "dev": true
     },
     "rc-slider": {
-      "version": "10.0.1",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-10.5.0.tgz",
+      "integrity": "sha512-xiYght50cvoODZYI43v3Ylsqiw14+D7ELsgzR40boDZaya1HFa1Etnv9MDkQE8X/UrXAffwv2AcNAhslgYuDTw==",
       "requires": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.5",
-        "rc-util": "^5.18.1",
-        "shallowequal": "^1.1.0"
+        "rc-util": "^5.27.0"
       }
     },
     "rc-util": {
-      "version": "5.22.5",
+      "version": "5.38.1",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.38.1.tgz",
+      "integrity": "sha512-e4ZMs7q9XqwTuhIK7zBIVFltUtMSjphuPPQXHoHlzRzNdOwUxDejo0Zls5HYaJfRKNURcsS/ceKVULlhjBrxng==",
       "requires": {
         "@babel/runtime": "^7.18.3",
-        "react-is": "^16.12.0",
-        "shallowequal": "^1.1.0"
+        "react-is": "^18.2.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "18.2.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+        }
       }
     },
     "react": {
@@ -35474,6 +35680,20 @@
       "version": "1.2.6",
       "requires": {
         "@babel/runtime": "^7.12.13"
+      }
+    },
+    "react-color": {
+      "version": "2.19.3",
+      "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.19.3.tgz",
+      "integrity": "sha512-LEeGE/ZzNLIsFWa1TMe8y5VYqr7bibneWmvJwm1pCn/eNmrabWDh659JSPn9BuaMpEfU83WTOJfnCcjDZwNQTA==",
+      "requires": {
+        "@icons/material": "^0.2.4",
+        "lodash": "^4.17.15",
+        "lodash-es": "^4.17.15",
+        "material-colors": "^1.2.1",
+        "prop-types": "^15.5.10",
+        "reactcss": "^1.2.0",
+        "tinycolor2": "^1.4.1"
       }
     },
     "react-data-grid": {
@@ -35604,6 +35824,16 @@
         "prop-types": "^15.5.0"
       }
     },
+    "react-textarea-autosize": {
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.3.tgz",
+      "integrity": "sha512-XT1024o2pqCuZSuBt9FwHlaDeNtVrtCXu0Rnz88t1jUGheCLa3PhjE1GH8Ctm2axEtvdCl5SUHYschyQ0L5QHQ==",
+      "requires": {
+        "@babel/runtime": "^7.20.13",
+        "use-composed-ref": "^1.3.0",
+        "use-latest": "^1.2.1"
+      }
+    },
     "react-tippy": {
       "version": "1.4.0",
       "requires": {
@@ -35617,6 +35847,14 @@
         "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
+      }
+    },
+    "reactcss": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
+      "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
+      "requires": {
+        "lodash": "^4.0.1"
       }
     },
     "reactflow": {
@@ -36884,6 +37122,11 @@
     "tiny-warning": {
       "version": "1.0.3"
     },
+    "tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="
+    },
     "tmp": {
       "version": "0.2.1",
       "dev": true,
@@ -37199,8 +37442,7 @@
       "dev": true
     },
     "universalify": {
-      "version": "2.0.0",
-      "dev": true
+      "version": "2.0.0"
     },
     "unload": {
       "version": "2.2.0",
@@ -37265,9 +37507,23 @@
         "tslib": "^2.0.0"
       }
     },
+    "use-composed-ref": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
+      "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==",
+      "requires": {}
+    },
     "use-isomorphic-layout-effect": {
       "version": "1.1.2",
       "requires": {}
+    },
+    "use-latest": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.2.1.tgz",
+      "integrity": "sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==",
+      "requires": {
+        "use-isomorphic-layout-effect": "^1.1.1"
+      }
     },
     "use-memo-one": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -211,7 +211,7 @@
   "dependencies": {
     "@chakra-ui/react": "^1.8.9",
     "@concord-consortium/compute-engine": "^0.12.3-cc.2",
-    "@concord-consortium/diagram-view": "^0.0.53",
+    "@concord-consortium/diagram-view": "1.0.0-beta.1",
     "@concord-consortium/mobx-state-tree": "^5.1.8-cc.2",
     "@concord-consortium/react-components": "^0.7.1",
     "@concord-consortium/react-modal-hook": "^3.0.0-cc.1",
@@ -249,7 +249,7 @@
     "patch-package": "^6.4.7",
     "promise-assist": "^2.0.1",
     "query-string": "7.1.1",
-    "rc-slider": "^10.0.1",
+    "rc-slider": "^10.5.0",
     "react": "^17.0.2",
     "react-chartjs-2": "^2.11.2",
     "react-data-grid": "7.0.0-canary.46",

--- a/src/plugins/diagram-viewer/diagram-tile.tsx
+++ b/src/plugins/diagram-viewer/diagram-tile.tsx
@@ -16,7 +16,7 @@ import { DiagramHelperContext } from "./use-diagram-helper-context";
 import { TileToolbar } from "../../components/toolbar/tile-toolbar";
 
 import InsertVariableCardIcon from "./src/assets/insert-variable-card-icon.svg";
-import "@concord-consortium/diagram-view/dist/index.css";
+
 import "./diagram-tile.scss";
 
 /**


### PR DESCRIPTION
Addresses PT-186817666, so that variables without values can be connected to other variables without preventing their calculations from running.

This updates the diagram-view to version `1.0.0-beta.1`, which involves a new building/bundling process, so the Diagram tile should be tested for any regressions.
