### PR TITLE
186472564 XY Plots Always have Both Axes

### DIFF
--- a/cypress/e2e/functional/tile_tests/xy_plot_tool_spec.js
+++ b/cypress/e2e/functional/tile_tests/xy_plot_tool_spec.js
@@ -280,6 +280,22 @@ context('XYPlot Tool Tile', function () {
       xyTile.getAddSeriesButton().click();
       xyTile.getXAttributesLabel().should('have.length', 1);
       xyTile.getYAttributesLabel().should('have.length', 2);
+
+      cy.log("verify that x attribute cannot be removed and y variables appear in x axis dropdown");
+      xyTile.getXAttributesLabel().click();
+      xyTile.getPortalButton().contains("Remove").should("not.exist");
+      xyTile.getPortalButton().contains("y").should("exist");
+      xyTile.getPortalButton().contains("y2").should("exist");
+
+      cy.log("verify that y attribute can be removed when there is more than one and y variables do not appear in the y axis dropdown");
+      xyTile.getYAttributesLabel().first().click();
+      xyTile.getPortalButton().contains("x").should("exist");
+      xyTile.getPortalButton().contains("y2").should("not.exist");
+      xyTile.getPortalButton().contains("Remove").should("exist").click();
+
+      cy.log("verify that y attribute cannot be removed when there's only one");
+      xyTile.getYAttributesLabel().should("have.length", 1).click();
+      xyTile.getPortalButton().contains("Remove").should("not.exist");
     });
 
     it("Test linking two datasets", () => {

--- a/src/plugins/graph/components/legend/layer-legend.tsx
+++ b/src/plugins/graph/components/legend/layer-legend.tsx
@@ -86,6 +86,7 @@ const SingleLayerLegend = observer(function SingleLayerLegend(props: ILegendPart
         </div>
         <SimpleAttributeLabel
           attrId={description.attributeID}
+          hideRemoveOption={yAttributes.length <= 1}
           key={description.attributeID}
           onChangeAttribute={onChangeAttribute}
           onRemoveAttribute={onRemoveAttribute}
@@ -157,6 +158,7 @@ const SingleLayerLegend = observer(function SingleLayerLegend(props: ILegendPart
                   <XAxisIcon />
                 </div>
                 <SimpleAttributeLabel
+                  hideRemoveOption={true}
                   place="bottom"
                   attrId={xAttrId}
                   onChangeAttribute={onChangeAttribute}

--- a/src/plugins/graph/components/simple-attribute-label.tsx
+++ b/src/plugins/graph/components/simple-attribute-label.tsx
@@ -12,6 +12,7 @@ import "../components/legend/multi-legend.scss";
 
 interface ISimpleAttributeLabelProps {
   attrId: string;
+  hideRemoveOption?: boolean;
   includePoint?: boolean;
   onChangeAttribute?: (place: GraphPlace, dataSet: IDataSet, attrId: string, oldAttrId?: string) => void;
   onRemoveAttribute?: (place: GraphPlace, attrId: string) => void;
@@ -20,8 +21,9 @@ interface ISimpleAttributeLabelProps {
 }
 
 export const SimpleAttributeLabel = observer(
-  function SimpleAttributeLabel(props: ISimpleAttributeLabelProps) {
-    const { attrId, includePoint, onTreatAttributeAs, onRemoveAttribute, onChangeAttribute, place } = props;
+  function SimpleAttributeLabel({
+    attrId, hideRemoveOption, includePoint, onTreatAttributeAs, onRemoveAttribute, onChangeAttribute, place
+  }: ISimpleAttributeLabelProps) {
     // Must be State, not Ref, so that the menu gets re-rendered when this becomes non-null
     const [simpleLabelElement, setSimpleLabelElement] = useState<HTMLSpanElement|null>(null);
     const canvasAreaElt = simpleLabelElement?.closest(kGraphPortalClass) as HTMLDivElement ?? null;
@@ -35,6 +37,7 @@ export const SimpleAttributeLabel = observer(
       return  (
         <span ref={e => setSimpleLabelElement(e)}>
           <AxisOrLegendAttributeMenu
+            hideRemoveOption={hideRemoveOption}
             pointColor={pointColor || undefined}
             target={null}
             parent={graphElement}

--- a/src/plugins/graph/imports/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/src/plugins/graph/imports/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -3,7 +3,7 @@ import React, { CSSProperties, useEffect, useRef, useState } from "react";
 import classNames from "classnames";
 
 import t from "../../../utilities/translation/translate";
-import {GraphPlace} from "../../axis-graph-shared";
+import {GraphPlace, isVertical} from "../../axis-graph-shared";
 import { graphPlaceToAttrRole } from "../../../../graph-types";
 import { useDataConfigurationContext } from "../../../../hooks/use-data-configuration-context";
 import { IUseDraggableAttribute, useDraggableAttribute } from "../../../hooks/use-drag-drop";
@@ -136,9 +136,8 @@ export const AxisOrLegendAttributeMenu = ({
           }
           { data?.attributes?.map((attr) => {
             const isCurrent = attr.id === attrId;
-            const isPlottedX = dataConfig?.attributeID("x") === attr.id;
-            const isPlottedY = yAttributesPlotted?.includes(attr.id);
-            const showAttr = (!isCurrent && !isPlottedX && !isPlottedY);
+            const isPlottedY = isVertical(place) && yAttributesPlotted?.includes(attr.id);
+            const showAttr = (!isCurrent && !isPlottedY);
 
             return showAttr && (
               <MenuItem onClick={() => onChangeAttribute(place, data, attr.id, attrId)} key={attr.id}>

--- a/src/plugins/graph/imports/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/src/plugins/graph/imports/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -19,6 +19,7 @@ import { useReadOnlyContext } from "../../../../../../components/document/read-o
 import DropdownCaretIcon from "../../../../assets/dropdown-caret.svg";
 
 interface IProps {
+  hideRemoveOption?: boolean;
   place: GraphPlace;
   attributeId?: string;
   // element to be mirrored. If null, a styled button will be created.
@@ -45,8 +46,8 @@ const removeAttrItemLabelKeys: Record<string, string> = {
 };
 
 export const AxisOrLegendAttributeMenu = ({
-  place, attributeId, target, parent, portal, onChangeAttribute, onRemoveAttribute, onTreatAttributeAs,
-  highlighted, pointColor
+  hideRemoveOption, place, attributeId, target, parent, portal, onChangeAttribute, onRemoveAttribute,
+  onTreatAttributeAs, highlighted, pointColor
 }: IProps) => {
   const dataConfig = useDataConfigurationContext();
   const data = dataConfig?.dataset;
@@ -64,7 +65,7 @@ export const AxisOrLegendAttributeMenu = ({
   const portalRef = useRef(portal);
   portalRef.current = portal;
   const menuListRef = useRef<HTMLDivElement>(null);
-  const showRemoveOption = true; // Used to be a setting; for now we always want it available.
+  // const showRemoveOption = true; // Used to be a setting; for now we always want it available.
   const { disableAttributeDnD }  = useGraphSettingsContext();
   const onCloseRef = useRef<() => void>();
   const overlayBounds = useOverlayBounds({ target, portal: parent });
@@ -148,7 +149,7 @@ export const AxisOrLegendAttributeMenu = ({
           { attribute &&
             <>
               <MenuDivider />
-              { showRemoveOption &&
+              { !hideRemoveOption &&
                 <MenuItem onClick={() => onRemoveAttribute(place, attrId)}>
                 {removeAttrItemLabel}
                 </MenuItem>

--- a/src/plugins/graph/imports/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/src/plugins/graph/imports/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -65,7 +65,6 @@ export const AxisOrLegendAttributeMenu = ({
   const portalRef = useRef(portal);
   portalRef.current = portal;
   const menuListRef = useRef<HTMLDivElement>(null);
-  // const showRemoveOption = true; // Used to be a setting; for now we always want it available.
   const { disableAttributeDnD }  = useGraphSettingsContext();
   const onCloseRef = useRef<() => void>();
   const overlayBounds = useOverlayBounds({ target, portal: parent });
@@ -137,7 +136,7 @@ export const AxisOrLegendAttributeMenu = ({
           { data?.attributes?.map((attr) => {
             const isCurrent = attr.id === attrId;
             const isPlottedY = isVertical(place) && yAttributesPlotted?.includes(attr.id);
-            const showAttr = (!isCurrent && !isPlottedY);
+            const showAttr = !isCurrent && !isPlottedY;
 
             return showAttr && (
               <MenuItem onClick={() => onChangeAttribute(place, data, attr.id, attrId)} key={attr.id}>


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/186472564

This story prevents the user from removing the attribute from the x axis or only y axis of an xy plot tile (y attributes can be removed until there's only one left). It's also now possible to assign the same attribute to the x and y axes, which will make it easier for the user to switch axes.

Please note that this story only applies to the CLUE style legend. This story does not impact units that use the old CODAP style axis labels (like `moth`).