### PR TITLE
Rewrite URL with OAuth2 params

### DIFF
--- a/cypress/e2e/functional/portal_user_tests/teacher_report_spec.js
+++ b/cypress/e2e/functional/portal_user_tests/teacher_report_spec.js
@@ -1,0 +1,29 @@
+const portalUrl = "https://learn.portal.staging.concord.org";
+const offeringId1 = "221";
+const reportUrl1 = "https://learn.portal.staging.concord.org/portal/offerings/" + offeringId1 + "/external_report/11";
+const clueTeacher1 = {
+  username: "clueteachertest1",
+  password: "password"
+};
+
+describe('Teachers can launch the CLUE Report', () => {
+  it("rewrites the URL of the CLUE report so it can be reloaded", () => {
+    cy.login(portalUrl, clueTeacher1);
+    cy.launchReport(reportUrl1);
+    cy.waitForLoad();
+
+    // check the URL
+    cy.url()
+      .should("contain", `resourceLinkId=${offeringId1}`)
+      .should("contain", "authDomain=https%3A%2F%2Flearn.portal.staging.concord.org")
+      .should("not.contain", "token=");
+
+    cy.get(".header").should("contain", "Clue Teacher1");
+
+    // With the OAuth2 url params a reload should get us back to Clue Teacher1 without going to
+    // the portal first
+    cy.reload();
+
+    cy.get(".header").should("contain", "Clue Teacher1");
+  });
+});

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -14,7 +14,7 @@ import { Logger } from "../lib/logger";
 import { LogEventName } from "../lib/logger-types";
 import { uniqueId } from "../utilities/js-utils";
 import { getUnitCodeFromUnitParam } from "../utilities/url-utils";
-import { getBearerToken } from "../utilities/auth-utils";
+import { convertURLToOAuth2, getBearerToken } from "../utilities/auth-utils";
 
 export const PORTAL_JWT_URL_SUFFIX = "api/v1/jwt/portal";
 export const FIREBASE_JWT_URL_SUFFIX = "api/v1/jwt/firebase";
@@ -354,6 +354,12 @@ export const authenticate = async (appMode: AppMode, appConfig: AppConfigModelTy
 
   if (!classInfoUrl || !offeringId) {
     throw new Error("Unable to get classInfoUrl or offeringId");
+  }
+
+  // Re-Write the URL with OAuth2 parameters
+  const url = convertURLToOAuth2(window.location.href, basePortalUrl, offeringId);
+  if (url) {
+    window.history.replaceState(null, "CLUE", url.toString());
   }
 
   const classInfo = await getClassInfo({classInfoUrl, rawPortalJWT, portal, offeringId});

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -357,9 +357,9 @@ export const authenticate = async (appMode: AppMode, appConfig: AppConfigModelTy
   }
 
   // Re-Write the URL with OAuth2 parameters
-  const url = convertURLToOAuth2(window.location.href, basePortalUrl, offeringId);
-  if (url) {
-    window.history.replaceState(null, "CLUE", url.toString());
+  const oAuth2Url = convertURLToOAuth2(window.location.href, basePortalUrl, offeringId);
+  if (oAuth2Url) {
+    window.history.replaceState(null, "CLUE", oAuth2Url.toString());
   }
 
   const classInfo = await getClassInfo({classInfoUrl, rawPortalJWT, portal, offeringId});

--- a/src/utilities/auth-utils.test.ts
+++ b/src/utilities/auth-utils.test.ts
@@ -1,0 +1,26 @@
+import { convertURLToOAuth2 } from "./auth-utils";
+
+describe("auth-utils", () => {
+  describe("convertURLToOAuth2", () => {
+    it("handles a student url", () => {
+      const studentURL = "https://collaborative-learning.concord.org/branch/master/?unit=msa&problem=1.4&token=16c1c896e36d24eeb329508142bc6312&domain=https://learn.portal.staging.concord.org/&domain_uid=114";
+      const newURL = convertURLToOAuth2(studentURL, "https://example.com/", "123");
+      expect(newURL?.toString()).toBe("https://collaborative-learning.concord.org/branch/master/?unit=msa&problem=1.4&domain=https%3A%2F%2Flearn.portal.staging.concord.org%2F&domain_uid=114&authDomain=https%3A%2F%2Fexample.com&resourceLinkId=123");
+    });
+    it("handles a teacher url", () => {
+      const teacherURL = "https://collaborative-learning.concord.org/branch/master/?class=https%3A%2F%2Flearn.portal.staging.concord.org%2Fapi%2Fv1%2Fclasses%2F111&classOfferings=https%3A%2F%2Flearn.portal.staging.concord.org%2Fapi%2Fv1%2Fofferings%3Fclass_id%3D111&logging=true&offering=https%3A%2F%2Flearn.portal.staging.concord.org%2Fapi%2Fv1%2Fofferings%2F112&reportType=offering&token=a4ebf7f5aae51671a6b7081abfd1adb0&username=google-118170338932514291325";
+      const newURL = convertURLToOAuth2(teacherURL, "https://example.com/", "123");
+      expect(newURL?.toString()).toBe("https://collaborative-learning.concord.org/branch/master/?class=https%3A%2F%2Flearn.portal.staging.concord.org%2Fapi%2Fv1%2Fclasses%2F111&classOfferings=https%3A%2F%2Flearn.portal.staging.concord.org%2Fapi%2Fv1%2Fofferings%3Fclass_id%3D111&logging=true&offering=https%3A%2F%2Flearn.portal.staging.concord.org%2Fapi%2Fv1%2Fofferings%2F112&reportType=offering&username=google-118170338932514291325&authDomain=https%3A%2F%2Fexample.com&resourceLinkId=123");
+    });
+    it("handles a student url without a slash in the portal URL", () => {
+      const studentURL = "https://collaborative-learning.concord.org/branch/master/?unit=msa&problem=1.4&token=16c1c896e36d24eeb329508142bc6312&domain=https://learn.portal.staging.concord.org/&domain_uid=114";
+      const newURL = convertURLToOAuth2(studentURL, "https://example.com", "123");
+      expect(newURL?.toString()).toBe("https://collaborative-learning.concord.org/branch/master/?unit=msa&problem=1.4&domain=https%3A%2F%2Flearn.portal.staging.concord.org%2F&domain_uid=114&authDomain=https%3A%2F%2Fexample.com&resourceLinkId=123");
+    });
+    it("handles a student url that already has the OAuth2 parameters", () => {
+      const studentURL = "https://collaborative-learning.concord.org/branch/master/?unit=msa&problem=1.4&domain=https%3A%2F%2Flearn.portal.staging.concord.org%2F&domain_uid=114&authDomain=https%3A%2F%2Fexample.com&resourceLinkId=123";
+      const newURL = convertURLToOAuth2(studentURL, "https://example.com", "123");
+      expect(newURL?.toString()).toBeUndefined();
+    });
+  });
+});

--- a/src/utilities/auth-utils.ts
+++ b/src/utilities/auth-utils.ts
@@ -114,11 +114,13 @@ export const authorizeInPortal = (portalUrl: string, oauthClientName: string, st
 };
 
 /**
- *
+ * Convert a token-style launch URL to an OAuth2-friendly URL.
+ * The portal currently launches CLUE using a short-lived token. By converting it
+ * in this way we can allow reloadin the browser to work even after some time has passed.
  * @param urlString
  * @param basePortalUrl
  * @param offeringId
- * @returns a URL instance if it is converted and undefined if the url isn't be converted
+ * @returns a URL instance if the url is converted, or undefined if it isn't converted
  */
 export const convertURLToOAuth2 = (urlString: string, basePortalUrl: string, offeringId: string) => {
   const url = new URL(urlString);

--- a/src/utilities/auth-utils.ts
+++ b/src/utilities/auth-utils.ts
@@ -86,7 +86,7 @@ export const initializeAuthorization = () => {
 
   if (accessToken && state) {
     const savedParamString = sessionStorage.getItem(state);
-    window.history.pushState(null, "CLUE", savedParamString);
+    window.history.replaceState(null, "CLUE", savedParamString);
     reprocessUrlParams();
   }
   else {
@@ -111,4 +111,25 @@ export const authorizeInPortal = (portalUrl: string, oauthClientName: string, st
   });
   // Redirect
   window.location.assign(portalAuth.token.getUri());
+};
+
+/**
+ *
+ * @param urlString
+ * @param basePortalUrl
+ * @param offeringId
+ * @returns a URL instance if it is converted and undefined if the url isn't be converted
+ */
+export const convertURLToOAuth2 = (urlString: string, basePortalUrl: string, offeringId: string) => {
+  const url = new URL(urlString);
+  const searchParams = url.searchParams;
+  if (searchParams.get("token") && !searchParams.get("authDomain") && !searchParams.get("resourceLinkId")){
+    searchParams.delete("token");
+    searchParams.set("authDomain", basePortalUrl.replace(/\/$/,""));
+    searchParams.set("resourceLinkId", offeringId);
+    url.search = searchParams.toString();
+    return url;
+  } else {
+    return undefined;
+  }
 };


### PR DESCRIPTION
This way the student or teacher can reload the page even after the token has expired.
This also changes the OAuth2 code to use replaceState instead of pushState