### PR TITLE
fix issue with graphs and the authoring system

### DIFF
--- a/cms/src/preview-link-control.tsx
+++ b/cms/src/preview-link-control.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import { CmsWidgetControlProps } from "netlify-cms-core";
 
-import { appConfig } from "../../src/initialize-app";
 import { getGuideJson, getUnitJson } from "../../src/models/curriculum/unit";
 import { DocumentModelType } from "../../src/models/document/document";
 import { stripPTNumberFromBranch } from "../../src/utilities/branch-utils";
 import { urlParams } from "../../src/utilities/url-params";
+import { AppConfigModel } from "../../src/models/stores/app-config-model";
+import { appConfigSnapshot } from "../../src/app-config";
 import { defaultCurriculumBranch } from "./cms-constants";
 
 import "./custom-control.scss";
@@ -47,6 +48,8 @@ export class PreviewLinkControl extends React.Component<CmsWidgetControlProps, I
       warning = `Could not determine unit. Using default ${defaultUnit}.`;
     }
     this.unit = urlParams.unit ?? this.pathParts?.[1] ?? defaultUnit;
+
+    const appConfig = AppConfigModel.create(appConfigSnapshot);
 
     // Finish setting up the preview link after reading the unit json
     this.isTeacherGuide = this.pathParts?.[2] === "teacher-guide";

--- a/src/cms/document-editor.tsx
+++ b/src/cms/document-editor.tsx
@@ -3,9 +3,9 @@ import { IDisposer, onSnapshot } from "mobx-state-tree";
 import { Map } from "immutable";
 
 import { defaultDocumentModelParts } from "../components/doc-editor-app-defaults";
-import { appConfig, AppProvider, initializeApp } from "../initialize-app";
+import { AppProvider, initializeApp } from "../initialize-app";
 import { IStores } from "../models/stores/stores";
-import { createDocumentModel, DocumentModelType } from "../models/document/document";
+import { createDocumentModelWithEnv, DocumentModelType } from "../models/document/document";
 import { DEBUG_CMS } from "../lib/debug";
 import { EditableDocumentContent } from "../components/document/editable-document-content";
 
@@ -33,10 +33,11 @@ export class DocumentEditor extends React.Component<IProps, IState>  {
 
     initializeAppPromise.then((stores) => {
       const { initialValue } = this.props;
+      const { appConfig } = stores;
       // Wait to construct the document until the main CLUE stuff is
       // initialized. I'm not sure if this is necessary but it seems
       // like the safest way to do things
-      const document = createDocumentModel({
+      const document = createDocumentModelWithEnv(appConfig, {
         ...defaultDocumentModelParts,
         content: initialValue
       });
@@ -102,7 +103,7 @@ export class DocumentEditor extends React.Component<IProps, IState>  {
             isPrimary={true}
             readOnly={false}
             document={document}
-            toolbar={appConfig.authorToolbar}
+            toolbar={stores.appConfig.authorToolbar}
           />
         </AppProvider>
       );

--- a/src/components/doc-editor-app.tsx
+++ b/src/components/doc-editor-app.tsx
@@ -4,18 +4,15 @@ import { getSnapshot } from "mobx-state-tree";
 
 import { defaultDocumentModel, defaultDocumentModelParts } from "./doc-editor-app-defaults";
 import { EditableDocumentContent } from "./document/editable-document-content";
-import { createDocumentModel } from "../models/document/document";
-import { AppConfigModelType } from "../models/stores/app-config-model";
+import { createDocumentModelWithEnv } from "../models/document/document";
 import { DocumentContentSnapshotType } from "../models/document/document-content";
 import { urlParams } from "../utilities/url-params";
+import { useAppConfig } from "../hooks/use-stores";
 
-export interface IDocEditorAppProps {
-  appConfig: AppConfigModelType;
-}
-
-export const DocEditorApp = ({ appConfig }: IDocEditorAppProps) => {
+export const DocEditorApp = () => {
+  const appConfig = useAppConfig();
   const [document, setDocument] = useState(() => {
-    return createDocumentModel(defaultDocumentModel);
+    return createDocumentModelWithEnv(appConfig, defaultDocumentModel);
   });
   const [fileHandle, setFileHandle] = useState<FileSystemHandle|undefined>();
   const [sectionSnapshot, setSectionSnapshot] = useState<any>();
@@ -30,7 +27,7 @@ export const DocEditorApp = ({ appConfig }: IDocEditorAppProps) => {
     } else {
       documentContentSnapshot = _parsedText;
     }
-    setDocument(createDocumentModel({
+    setDocument(createDocumentModelWithEnv(appConfig, {
       ...defaultDocumentModelParts,
       content: documentContentSnapshot
     }));

--- a/src/components/document/canvas.tsx
+++ b/src/components/document/canvas.tsx
@@ -7,7 +7,7 @@ import { AnnotationLayer } from "./annotation-layer";
 import { DocumentLoadingSpinner } from "./document-loading-spinner";
 import { BaseComponent } from "../base";
 import { DocumentContentComponent } from "./document-content";
-import { createDocumentModel, ContentStatus, DocumentModelType } from "../../models/document/document";
+import { ContentStatus, DocumentModelType, createDocumentModelWithEnv } from "../../models/document/document";
 import { DocumentContentModelType } from "../../models/document/document-content";
 import { transformCurriculumImageUrl } from "../../models/tiles/image/image-import-export";
 import { logHistoryEvent } from "../../models/history/log-history-event";
@@ -297,7 +297,7 @@ export class CanvasComponent extends BaseComponent<IProps, IState> {
 
   private createHistoryDocumentCopy = () => {
     if (this.props.document) {
-      const docCopy = createDocumentModel(getSnapshot(this.props.document));
+      const docCopy = createDocumentModelWithEnv(this.stores.appConfig, getSnapshot(this.props.document));
       // Make a variable available with the current history document
       if (DEBUG_DOCUMENT) {
         (window as any).currentHistoryDocument = docCopy;

--- a/src/doc-editor.tsx
+++ b/src/doc-editor.tsx
@@ -4,14 +4,14 @@ import { DocEditorApp } from "./components/doc-editor-app";
 import { DialogComponent } from "./components/utilities/dialog";
 import { urlParams } from "./utilities/url-params";
 
-import { appConfig, AppProvider, initializeApp } from "./initialize-app";
+import { AppProvider, initializeApp } from "./initialize-app";
 
 (window as any).DISABLE_FIREBASE_SYNC = true;
 
 initializeApp(urlParams.appMode || "dev", true).then((stores) => {
   ReactDOM.render(
     <AppProvider stores={stores} modalAppElement="#app">
-      <DocEditorApp appConfig={appConfig}/>
+      <DocEditorApp/>
       <DialogComponent/>
     </AppProvider>,
     document.getElementById("app")

--- a/src/initialize-app.tsx
+++ b/src/initialize-app.tsx
@@ -25,8 +25,6 @@ import "./index.scss";
 // set to true to enable MST liveliness checking
 const kEnableLivelinessChecking = false;
 
-export const appConfig = AppConfigModel.create(appConfigSnapshot);
-
 /**
  * This function is used by the 3 different entry points supported
  * by CLUE:
@@ -51,6 +49,7 @@ export const initializeApp = async (appMode: AppMode, authoring?: boolean): Prom
   const demoName = urlParams.demoName;
 
   const isPreviewing = !!(urlParams.domain && urlParams.domain_uid && !getBearerToken(urlParams));
+  const appConfig = AppConfigModel.create(appConfigSnapshot);
   const stores = createStores({ appMode, appVersion, appConfig, user, showDemoCreator, demoName, isPreviewing });
 
   if (DEBUG_STORES) {

--- a/src/models/document/document.ts
+++ b/src/models/document/document.ts
@@ -9,7 +9,7 @@ import { DocumentTypeEnum, IDocumentContext, ISetProperties,
 } from "./document-types";
 import { AppConfigModelType } from "../stores/app-config-model";
 import { TileCommentsModel, TileCommentsModelType } from "../tiles/tile-comments";
-import { getSharedModelManager } from "../tiles/tile-environment";
+import { getSharedModelManager, getTileEnvironment } from "../tiles/tile-environment";
 import {
   IDocumentMetadata, IGetNetworkDocumentParams, IGetNetworkDocumentResponse, IUserContext
 } from "../../../functions/src/shared";
@@ -358,4 +358,12 @@ export const createDocumentModel = (snapshot?: DocumentModelSnapshotType) => {
     documentWithoutContent.setContentError(content, (e as Error)?.message);
     return documentWithoutContent;
   }
+};
+
+export const createDocumentModelWithEnv = (appConfig: AppConfigModelType, docSnapshot: DocumentModelSnapshotType) => {
+  const newDocument = createDocumentModel(docSnapshot);
+  const tileEnv = getTileEnvironment(newDocument);
+  if (!tileEnv) throw new Error("missing tile environment");
+  tileEnv.appConfig = appConfig;
+  return newDocument;
 };


### PR DESCRIPTION
The authoring system documents were being loaded without a tile environment
This also cleans up some usage of the appConfig.
The appConfig was being used a global in some cases instead of being pulled from the stores.