### PR TITLE
fix importing tiles with shared model refs

### DIFF
--- a/src/models/document/document-content-tests/dc-shared-models.test.ts
+++ b/src/models/document/document-content-tests/dc-shared-models.test.ts
@@ -130,9 +130,9 @@ describe("DocumentContentModel -- shared Models --", () => {
 Object {
   "annotations": Object {},
   "rowMap": Object {
-    "testid-13": Object {
+    "testid-12": Object {
       "height": undefined,
-      "id": "testid-13",
+      "id": "testid-12",
       "isSectionHeader": false,
       "sectionId": undefined,
       "tiles": Array [
@@ -148,7 +148,7 @@ Object {
     },
   },
   "rowOrder": Array [
-    "testid-13",
+    "testid-12",
   ],
   "sharedModelMap": Object {
     "sharedDataSet1": Object {
@@ -255,7 +255,7 @@ Object {
         "importedDataSet": Object {
           "attributes": Array [],
           "cases": Array [],
-          "id": "testid-12",
+          "id": "testid-13",
           "name": undefined,
           "sourceID": undefined,
         },
@@ -387,7 +387,7 @@ Object {
         "importedDataSet": Object {
           "attributes": Array [],
           "cases": Array [],
-          "id": "testid-20",
+          "id": "testid-21",
           "name": undefined,
           "sourceID": undefined,
         },
@@ -520,7 +520,7 @@ Object {
         "importedDataSet": Object {
           "attributes": Array [],
           "cases": Array [],
-          "id": "testid-37",
+          "id": "testid-38",
           "name": undefined,
           "sourceID": undefined,
         },
@@ -661,7 +661,7 @@ Object {
         "importedDataSet": Object {
           "attributes": Array [],
           "cases": Array [],
-          "id": "testid-55",
+          "id": "testid-56",
           "name": undefined,
           "sourceID": undefined,
         },

--- a/src/models/document/drag-tiles.test.ts
+++ b/src/models/document/drag-tiles.test.ts
@@ -180,7 +180,7 @@ Array [
   Object {
     "rowHeight": undefined,
     "rowIndex": 2,
-    "tileContent": "{\\"id\\":\\"testid-1000\\",\\"title\\":\\"tile 3\\",\\"content\\":{\\"type\\":\\"Table\\",\\"isImported\\":false,\\"importedDataSet\\":{\\"id\\":\\"testid-8\\",\\"attributes\\":[],\\"cases\\":[]},\\"columnWidths\\":{}}}",
+    "tileContent": "{\\"id\\":\\"testid-1000\\",\\"title\\":\\"tile 3\\",\\"content\\":{\\"type\\":\\"Table\\",\\"isImported\\":false,\\"importedDataSet\\":{\\"id\\":\\"testid-9\\",\\"attributes\\":[],\\"cases\\":[]},\\"columnWidths\\":{}}}",
     "tileId": "tile3",
     "tileIndex": 0,
     "tileType": "Table",
@@ -274,7 +274,7 @@ Object {
     Object {
       "rowHeight": undefined,
       "rowIndex": 2,
-      "tileContent": "{\\"id\\":\\"testid-1000\\",\\"title\\":\\"tile 3\\",\\"content\\":{\\"type\\":\\"Table\\",\\"isImported\\":false,\\"importedDataSet\\":{\\"id\\":\\"testid-8\\",\\"attributes\\":[],\\"cases\\":[]},\\"columnWidths\\":{}}}",
+      "tileContent": "{\\"id\\":\\"testid-1000\\",\\"title\\":\\"tile 3\\",\\"content\\":{\\"type\\":\\"Table\\",\\"isImported\\":false,\\"importedDataSet\\":{\\"id\\":\\"testid-9\\",\\"attributes\\":[],\\"cases\\":[]},\\"columnWidths\\":{}}}",
       "tileId": "tile3",
       "tileIndex": 0,
       "tileType": "Table",

--- a/src/plugins/diagram-viewer/diagram-content.test.ts
+++ b/src/plugins/diagram-viewer/diagram-content.test.ts
@@ -81,8 +81,8 @@ describe("DiagramContent", () => {
 
   it("can export content", () => {
     const content = createDiagramContent();
-    const expected = JSON.stringify({nodes: {}});
-    expect(content.exportJson()).toEqual(expected);
+    const expected = {type: "Diagram", version: "0.0.3", root: {nodes: {}}};
+    expect(JSON.parse(content.exportJson())).toEqual(expected);
   });
 
   it("is always user resizable", () => {

--- a/src/plugins/diagram-viewer/diagram-content.ts
+++ b/src/plugins/diagram-viewer/diagram-content.ts
@@ -1,6 +1,7 @@
 import { getSnapshot, types, Instance, destroy, SnapshotIn,
   isValidReference, addDisposer, getType } from "mobx-state-tree";
 import { reaction } from "mobx";
+import stringify from "json-stringify-pretty-compact";
 import { DQRoot } from "@concord-consortium/diagram-view";
 import { ITileExportOptions, IDefaultContentOptions } from "../../models/tiles/tile-content-info";
 import { TileContentModel } from "../../models/tiles/tile-content";
@@ -17,8 +18,8 @@ export const DiagramContentModel = TileContentModel
   })
   .views(self => ({
     exportJson(options?: ITileExportOptions) {
-      // crude, but enough to get us started
-      return JSON.stringify(getSnapshot(self.root));
+      const snapshot = getSnapshot(self);
+      return stringify(snapshot, {maxLength: 120});
     }
   }))
   .views(self => ({


### PR DESCRIPTION
There were 2 issues with old approach:
1. the shared models were added to the document after the tiles
2. the tiles were created independently from the document

The core problem with both issues is that references in the tiles to shared model objects could not be resolved.  The solution for `#1` was to first add the content of the shared models to the doc, then the tiles, and then the tile references.  The solution for `#2` required refactoring the import code so the tiles would be created within the content by passing the snapshot of the tile to `tileMap.put`.

The refactored import code replaces some deeply nested calls to `add*` methods in BaseDocumentContent. These `add*` methods could not be removed because they are still be used in other places. This does mean there is some duplication with those `add*` methods, but I think the new approach is easier to reason about. It also unifies some parts that were duplicated before. I did the refactoring by "exploding" all of the nested calls and then refactored the result to remove duplication and unnecessary code.

A couple of tests had to be adjusted because the sequence of unique id creation
has changed slightly.