### PR TITLE
Sparrows can connect to all graph traces

### DIFF
--- a/cypress/e2e/functional/tile_tests/arrow_annotation_spec.js
+++ b/cypress/e2e/functional/tile_tests/arrow_annotation_spec.js
@@ -1,5 +1,6 @@
 import ClueCanvas from '../../../support/elements/common/cCanvas';
 import ArrowAnnotation from '../../../support/elements/tile/ArrowAnnotation';
+import DiagramToolTile from '../../../support/elements/tile/DiagramToolTile';
 import DrawToolTile from '../../../support/elements/tile/DrawToolTile';
 import GeometryToolTile from '../../../support/elements/tile/GeometryToolTile';
 import NumberlineToolTile from '../../../support/elements/tile/NumberlineToolTile';
@@ -13,6 +14,7 @@ const tableToolTile = new TableToolTile;
 const geometryToolTile = new GeometryToolTile;
 const numberlineToolTile = new NumberlineToolTile;
 const xyTile = new XYPlotToolTile;
+const diagramToolTile = new DiagramToolTile;
 
 const queryParams = {
   unit1:"?appMode=qa&fakeClass=5&fakeUser=student:5&qaGroup=5&unit=example",
@@ -280,5 +282,39 @@ context('Arrow Annotations (Sparrows)', function () {
     aa.clickArrowToolbarButton();
     xyTile.selectYAttribute("y2");
     aa.getAnnotationArrows().should("not.exist");
+
+    cy.log("Annotation buttons appear for variable values");
+    const varName = "var1";
+
+    clueCanvas.addTile("diagram");
+    diagramToolTile.getDiagramTile().should("exist").click();
+    clueCanvas.clickToolbarButton("diagram", "new-variable");
+    diagramToolTile.getDiagramDialog().should("exist");
+    diagramToolTile.getDialogField("name").should("exist").type(varName);
+    diagramToolTile.getDialogField("value").should("exist").type("3");
+    diagramToolTile.getDialogOkButton().click();
+    diagramToolTile.getVariableCard().should("exist");
+
+    // Link to diagram instead of table
+    xyTile.getTile().click();
+    clueCanvas.clickToolbarButton('graph', 'link-tile');
+    xyTile.linkTable("Diagram 1");
+    aa.clickArrowToolbarButton();
+    aa.getAnnotationButtons().should("have.length", 9); // Just table cells
+    aa.clickArrowToolbarButton();
+
+    xyTile.selectXVariable(varName);
+    xyTile.selectYVariable(varName);
+    aa.clickArrowToolbarButton();
+    aa.getAnnotationButtons().should("have.length", 10);
+    aa.clickArrowToolbarButton();
+
+    cy.log("Can add an arrow to variable dots");
+    xyTile.getTile().click();
+    aa.clickArrowToolbarButton();
+    aa.getAnnotationArrows().should("not.exist");
+    aa.getAnnotationButtons().eq(0).click();
+    aa.getAnnotationButtons().eq(1).click();
+    aa.getAnnotationArrows().should("have.length", 1);
   });
 });

--- a/cypress/support/elements/tile/DiagramToolTile.js
+++ b/cypress/support/elements/tile/DiagramToolTile.js
@@ -45,6 +45,13 @@ class DiagramToolTile {
   getDiagramTileTitle(workspaceClass){
     return cy.get(`${workspaceClass || ".primary-workspace"} .editable-tile-title`);
   }
+
+  getDialogField(field) {
+    return cy.get(`#evd-${field}`);
+  }
+  getDialogOkButton() {
+    return cy.get(".modal-button").last();
+  }
 }
 
 export default DiagramToolTile;

--- a/src/plugins/graph/adornments/adornment-models.ts
+++ b/src/plugins/graph/adornments/adornment-models.ts
@@ -6,6 +6,7 @@ import {Instance, types} from "mobx-state-tree";
 import { IAxisModel } from "../imports/components/axis/models/axis-model";
 import {typedId} from "../../../utilities/js-utils";
 import {GraphAttrRole, Point} from "../graph-types";
+import { IClueObject } from "../../../models/annotations/clue-object";
 
 export const PointModel = types.model("Point", {
     x: types.optional(types.number, NaN),
@@ -67,6 +68,24 @@ export const AdornmentModel = types.model("AdornmentModel", {
      */
     numericValuesForAttrRole(role: GraphAttrRole) {
       return [] as number[];
+    },
+    /**
+     * Return a list of objects that can be used by the annotation layer.
+     * Normally an empty list, but can be overridden by subclasses.
+     * @param tileId The TileID is passed in since it is needed to create the IClueObject return values.
+     */
+    getAnnotatableObjects(tileId: string) {
+      return [] as IClueObject[];
+    },
+    /**
+     * Determine the position (in the graph's X/Y coordinate space) of the object with the given ID.
+     * May return undefined if the type is not one this adronment handles, or if no such object ID exists.
+     * @param type the annotatable object type
+     * @param objectId ID of an annotatable object
+     * @returns an {x, y} pair or undefined
+     */
+    getAnnotatableObjectPosition(type: string, objectId: string): Point|undefined {
+      return undefined;
     }
   }))
   .actions(self => ({

--- a/src/plugins/graph/components/graph-wrapper-component.tsx
+++ b/src/plugins/graph/components/graph-wrapper-component.tsx
@@ -46,6 +46,8 @@ export const GraphWrapperComponent: React.FC<ITileProps> = observer(function(pro
     if (caseId && xAttributeId && yAttributeId) {
       const layer = content.layerForAttributeId(xAttributeId);
       if (!layer) return;
+      const plotNum = layer.config.plotNumberForAttributeID(yAttributeId);
+      if (plotNum === undefined) return;
 
       // We don't use these values directly, but without referencing them the app
       // doesn't realize that changes in the axis scales require redrawing the annotations.
@@ -54,7 +56,6 @@ export const GraphWrapperComponent: React.FC<ITileProps> = observer(function(pro
       // eslint-disable-next-line unused-imports/no-unused-vars
       const domains = [isNumericAxisModel(xAxis) && xAxis.domain, isNumericAxisModel(yAxis) && yAxis.domain];
 
-      const plotNum = layer.config.plotNumberForAttributeID(yAttributeId);
       const x = getScreenX({ caseId, dataset: layer.config.dataset, layout, dataConfig: layer.config });
       const y = getScreenY({ caseId, dataset: layer.config.dataset, layout, dataConfig: layer.config, plotNum });
       if (!isFinite(x) || !isFinite(y)) return;

--- a/src/plugins/graph/components/graph-wrapper-component.tsx
+++ b/src/plugins/graph/components/graph-wrapper-component.tsx
@@ -49,8 +49,9 @@ export const GraphWrapperComponent: React.FC<ITileProps> = observer(function(pro
     if (caseId && xAttributeId && yAttributeId) {
       const layer = content.layerForAttributeId(xAttributeId);
       if (!layer) return;
+      const plotNum = layer.config.plotNumberForAttributeID(yAttributeId);
       const x = getScreenX({ caseId, dataset: layer.config.dataset, layout, dataConfig: layer.config });
-      const y = getScreenY({ caseId, dataset: layer.config.dataset, layout, dataConfig: layer.config });
+      const y = getScreenY({ caseId, dataset: layer.config.dataset, layout, dataConfig: layer.config, plotNum });
       if (!isFinite(x) || !isFinite(y)) return;
       return { x, y };
     }

--- a/src/plugins/graph/components/graph-wrapper-component.tsx
+++ b/src/plugins/graph/components/graph-wrapper-component.tsx
@@ -17,6 +17,8 @@ import { IGraphModel } from "../models/graph-model";
 import { decipherDotId } from "../utilities/graph-utils";
 import { GraphComponent } from "./graph-component";
 import { isNumericAxisModel } from "../imports/components/axis/models/axis-model";
+import { Point } from "../graph-types";
+import { ScaleLinear } from "d3";
 
 import "./graph-toolbar-registration";
 
@@ -34,11 +36,6 @@ export const GraphWrapperComponent: React.FC<ITileProps> = observer(function(pro
   const xAttrType = content.config.attributeType("x");
   const yAttrType = content.config.attributeType("y");
 
-  const xAxis = content.getAxis("bottom");
-  const xDomain = isNumericAxisModel(xAxis) && xAxis.domain;
-  const yAxis = content.getAxis("left");
-  const yDomain = isNumericAxisModel(yAxis) && yAxis.domain;
-
   // This is used for locating Sparrow endpoints.
   const getDotCenter = useCallback((dotId: string) => {
     // FIXME Currently, getScreenX and getScreenY only handle numeric axes, so just bail if they are a different type.
@@ -49,6 +46,14 @@ export const GraphWrapperComponent: React.FC<ITileProps> = observer(function(pro
     if (caseId && xAttributeId && yAttributeId) {
       const layer = content.layerForAttributeId(xAttributeId);
       if (!layer) return;
+
+      // We don't use these values directly, but without referencing them the app
+      // doesn't realize that changes in the axis scales require redrawing the annotations.
+      const xAxis = content.getAxis("bottom");
+      const yAxis = content.getAxis("left");
+      // eslint-disable-next-line unused-imports/no-unused-vars
+      const domains = [isNumericAxisModel(xAxis) && xAxis.domain, isNumericAxisModel(yAxis) && yAxis.domain];
+
       const plotNum = layer.config.plotNumberForAttributeID(yAttributeId);
       const x = getScreenX({ caseId, dataset: layer.config.dataset, layout, dataConfig: layer.config });
       const y = getScreenY({ caseId, dataset: layer.config.dataset, layout, dataConfig: layer.config, plotNum });
@@ -57,65 +62,87 @@ export const GraphWrapperComponent: React.FC<ITileProps> = observer(function(pro
     }
   }, [xAttrType, yAttrType, content, layout]);
 
+  const getPositionFromAdornment = useCallback((type: string, objectId: string) => {
+    // Ask each adornment in turn if it knows how to handle this object.
+    for (const adorn of content.adornments) {
+      const pos = adorn.getAnnotatableObjectPosition(type, objectId);
+      if (pos) return pos;
+    }
+  }, [content.adornments]);
+
+  const getScaledPosition = useCallback((pos: Point) => {
+    const xScale = layout.getAxisScale('bottom') as ScaleLinear<number, number>;
+    const yScale = layout.getAxisScale('left') as ScaleLinear<number, number>;
+    return { x: xScale(pos.x), y: yScale(pos.y) };
+  }, [layout]);
+
+  const boundingBoxForPoint = useCallback((pos: Point) => {
+    const halfSide = content.getPointRadius("hover-drag");
+    return {
+      top: pos.y - halfSide,
+      left: pos.x - halfSide + layout.getComputedBounds("left").width,
+      height: 2 * halfSide,
+      width: 2 * halfSide
+    };
+  }, [content, layout]);
+
   useEffect(() => {
     onRegisterTileApi?.({
       exportContentAsTileJson: (options?: ITileExportOptions) => {
         return content.exportJson(options);
       },
       getObjectBoundingBox: (objectId: string, objectType?: string) => {
+        let coords;
         if (objectType === "dot") {
-          const coords = getDotCenter(objectId);
-          if (!coords) return;
-          const { x, y } = coords;
-          const halfSide = content.getPointRadius("hover-drag");
-          const boundingBox = {
-            height: 2 * halfSide,
-            left: x - halfSide + layout.getComputedBounds("left").width,
-            top: y - halfSide,
-            width: 2 * halfSide
-          };
-          return boundingBox;
+          coords = getDotCenter(objectId);
+        } else {
+          // Maybe one of our adornments knows about this object
+          const pos = objectType && getPositionFromAdornment(objectType, objectId);
+          coords = pos && getScaledPosition(pos);
+        }
+        if (coords) {
+          return boundingBoxForPoint(coords);
         }
       },
       getObjectButtonSVG: ({ classes, handleClick, objectId, objectType }) => {
+        let coords;
         if (objectType === "dot") {
-          // Find the center point
-          const coords = getDotCenter(objectId);
-          if (!coords) return;
-          const { x, y } = coords;
-          const cx = x + layout.getComputedBounds("left").width;
-          const radius = content.getPointRadius("hover-drag");
-
-          // Return a circle at the center point
-          return (
-            <circle
-              className={classes}
-              cx={cx}
-              cy={y}
-              onClick={handleClick}
-              r={radius}
-            />
-          );
+          coords = getDotCenter(objectId);
+        } else if (objectType) {
+          const pos = getPositionFromAdornment(objectType, objectId);
+          coords = pos && getScaledPosition(pos);
         }
+        if (!coords) return;
+        const { x, y } = coords;
+        const cx = x + layout.getComputedBounds("left").width;
+        const radius = content.getPointRadius("hover-drag");
+
+        // Return a circle at the center point
+        return (
+          <circle
+            className={classes}
+            cx={cx}
+            cy={y}
+            onClick={handleClick}
+            r={radius}
+          />
+        );
       },
       getObjectDefaultOffsets: (objectId: string, objectType?: string) => {
         const offsets = OffsetModel.create({});
-        if (objectType === "dot") {
-          offsets.setDy(-kSmallAnnotationNodeRadius);
-        }
+        offsets.setDy(-kSmallAnnotationNodeRadius);
         return offsets;
       },
       getObjectNodeRadii: (objectId: string, objectType?: string) => {
-        if (objectType === "dot") {
-          return {
-            centerRadius: kSmallAnnotationNodeRadius / 2,
-            highlightRadius: kSmallAnnotationNodeRadius
-          };
-        }
+        return {
+          centerRadius: kSmallAnnotationNodeRadius / 2,
+          highlightRadius: kSmallAnnotationNodeRadius
+        };
       }
     });
     // xDomain and yDomain are included to force updating the sparrow locations when they change
-  }, [getDotCenter, content, layout, onRegisterTileApi, xDomain, yDomain]);
+  }, [getDotCenter, content, layout, onRegisterTileApi,
+      getPositionFromAdornment, boundingBoxForPoint, getScaledPosition]);
 
   useEffect(function cleanup() {
     return () => {

--- a/src/plugins/graph/models/data-configuration-model.ts
+++ b/src/plugins/graph/models/data-configuration-model.ts
@@ -91,6 +91,16 @@ export const DataConfigurationModel = types
       return this.yAttributeDescriptions.map((d: IAttributeDescriptionSnapshot) => d.attributeID);
     },
     /**
+     * Returns the sequential number of the given Y attribute ID.
+     * This includes the rightNumeric attribute if any.
+     * If the attribute ID is not found, returns undefined.
+     * @param id ID that should be one of the Y attributes.
+     */
+    plotNumberForAttributeID(id: string) {
+      const index = this.yAttributeIDs.indexOf(id);
+      return index >= 0 ? index : undefined;
+    },
+    /**
      * No attribute descriptions beyond the first for y are returned.
      * The rightNumeric attribute description is also not returned.
      */

--- a/src/plugins/graph/models/graph-layout.ts
+++ b/src/plugins/graph/models/graph-layout.ts
@@ -143,8 +143,18 @@ export class GraphLayout implements IAxisLayout {
    */
   @computed get computedBounds() {
     const {graphWidth, graphHeight} = this;
-    if (graphWidth<1 || graphHeight<0) {
-      // Layout functions can be called before tile size is known,
+    const
+      legendHeight = this.getDesiredExtent('legend'),
+      topAxisHeight = this.getDesiredExtent('top'),
+      leftAxisWidth = this.getDesiredExtent('left'),
+      bottomAxisHeight = this.getDesiredExtent('bottom'),
+      v2AxisWidth = this.getDesiredExtent('rightNumeric'),
+      rightAxisWidth = this.getDesiredExtent('rightCat'),
+      plotWidth = graphWidth - leftAxisWidth - v2AxisWidth - rightAxisWidth,
+      plotHeight = graphHeight - topAxisHeight - bottomAxisHeight - legendHeight;
+
+    if (plotWidth<1 || plotHeight<1) {
+      // Layout functions can be called before tile size is finalized,
       // leading to ugly errors if negative sizes are returned.
       const zeroSize = {left: 0, top: 0, width: 0, height: 0};
       return {
@@ -158,16 +168,8 @@ export class GraphLayout implements IAxisLayout {
         yPlus: zeroSize
       };
     }
-    const
-      legendHeight = this.getDesiredExtent('legend'),
-      topAxisHeight = this.getDesiredExtent('top'),
-      leftAxisWidth = this.getDesiredExtent('left'),
-      bottomAxisHeight = this.getDesiredExtent('bottom'),
-      v2AxisWidth = this.getDesiredExtent('rightNumeric'),
-      rightAxisWidth = this.getDesiredExtent('rightCat'),
-      plotWidth = graphWidth - leftAxisWidth - v2AxisWidth - rightAxisWidth,
-      plotHeight = graphHeight - topAxisHeight - bottomAxisHeight - legendHeight,
-      newBounds: Record<GraphPlace, Bounds> = {
+
+    const newBounds: Record<GraphPlace, Bounds> = {
         left: {left: 0, top: topAxisHeight, width: leftAxisWidth, height: plotHeight},
         top: {left: leftAxisWidth, top: 0, width: graphWidth - leftAxisWidth - rightAxisWidth, height: topAxisHeight},
         plot: {left: leftAxisWidth, top: topAxisHeight, width: plotWidth, height: plotHeight},

--- a/src/plugins/graph/models/graph-model.ts
+++ b/src/plugins/graph/models/graph-model.ts
@@ -285,16 +285,17 @@ export const GraphModel = TileContentModel
       const objects: IClueObject[] = [];
       for (const layer of self.layers) {
         if (layer.config.dataset) {
-        const xAttributeID = layer.config.attributeID("x");
-        const yAttributeID = layer.config.attributeID("y");
-        for (const c of layer.config.dataset.cases) {
-            if (xAttributeID && yAttributeID) {
-              const objectId = getDotId(c.__id__, xAttributeID, yAttributeID);
-              objects.push({
-                tileId,
-                objectId,
-                objectType: "dot"
-              });
+          const xAttributeID = layer.config.attributeID("x");
+          for (const yAttributeID of layer.config.yAttributeIDs) {
+            for (const c of layer.config.dataset.cases) {
+              if (xAttributeID && yAttributeID) {
+                const objectId = getDotId(c.__id__, xAttributeID, yAttributeID);
+                objects.push({
+                  tileId,
+                  objectId,
+                  objectType: "dot"
+                });
+              }
             }
           }
         }

--- a/src/plugins/graph/models/graph-model.ts
+++ b/src/plugins/graph/models/graph-model.ts
@@ -300,6 +300,10 @@ export const GraphModel = TileContentModel
           }
         }
       }
+      // Include any objects contributed by adornments
+      for (const adorn of self.adornments) {
+        objects.push(...adorn.getAnnotatableObjects(tileId));
+      }
       return objects;
     }
   }))

--- a/src/plugins/graph/models/graph-model.ts
+++ b/src/plugins/graph/models/graph-model.ts
@@ -215,7 +215,7 @@ export const GraphModel = TileContentModel
      */
     layerForAttributeId(id: string) {
       for (const layer of self.layers) {
-        if (layer.config.rolesForAttribute(id)) {
+        if (layer.config.rolesForAttribute(id).length) {
           return layer;
         }
       }
@@ -282,18 +282,23 @@ export const GraphModel = TileContentModel
     },
     get annotatableObjects() {
       const tileId = getTileIdFromContent(self) ?? "";
-      const xAttributeID = self.getAttributeID("x");
-      const yAttributeID = self.getAttributeID("y");
-      if (!self.layers[0].config.dataset) return []; // FIXME multi dataset
       const objects: IClueObject[] = [];
-      self.layers[0].config.dataset.cases.forEach(c => {
-        const objectId = getDotId(c.__id__, xAttributeID, yAttributeID);
-        objects.push({
-          tileId,
-          objectId,
-          objectType: "dot"
-        });
-      });
+      for (const layer of self.layers) {
+        if (layer.config.dataset) {
+        const xAttributeID = layer.config.attributeID("x");
+        const yAttributeID = layer.config.attributeID("y");
+        for (const c of layer.config.dataset.cases) {
+            if (xAttributeID && yAttributeID) {
+              const objectId = getDotId(c.__id__, xAttributeID, yAttributeID);
+              objects.push({
+                tileId,
+                objectId,
+                objectType: "dot"
+              });
+            }
+          }
+        }
+      }
       return objects;
     }
   }))


### PR DESCRIPTION
Per PT-186266962, allows all data and variable traces on the graph tile to participate in Sparrow annotation.

In addition, fixes a bug where changing the axis scale would not correctly adjust the sparrow endpoints.
- This was accomplished by adding `graph-wrapper-component` lines 52--57.  I'm not thrilled with this solution, let me know if you have a better suggestion.
