### PR TITLE
Update name of toolbar button to fix test

### DIFF
--- a/cypress/e2e/functional/tile_tests/arrow_annotation_spec.js
+++ b/cypress/e2e/functional/tile_tests/arrow_annotation_spec.js
@@ -293,7 +293,7 @@ context('Arrow Annotations (Sparrows)', function () {
 
     // Link to diagram instead of table
     xyTile.getTile().click();
-    clueCanvas.clickToolbarButton('graph', 'link-tile');
+    clueCanvas.clickToolbarButton('graph', 'link-tile-multiple');
     xyTile.linkTable("Diagram 1");
     aa.clickArrowToolbarButton();
     aa.getAnnotationButtons().should("have.length", 9); // Just table cells

--- a/cypress/e2e/functional/tile_tests/arrow_annotation_spec.js
+++ b/cypress/e2e/functional/tile_tests/arrow_annotation_spec.js
@@ -291,18 +291,18 @@ context('Arrow Annotations (Sparrows)', function () {
     diagramToolTile.getDialogOkButton().click();
     diagramToolTile.getVariableCard().should("exist");
 
-    // Link to diagram instead of table
+    // Link to diagram as well as table
     xyTile.getTile().click();
     clueCanvas.clickToolbarButton('graph', 'link-tile-multiple');
     xyTile.linkTable("Diagram 1");
     aa.clickArrowToolbarButton();
-    aa.getAnnotationButtons().should("have.length", 9); // Just table cells
+    aa.getAnnotationButtons().should("have.length", 12);
     aa.clickArrowToolbarButton();
 
     xyTile.selectXVariable(varName);
     xyTile.selectYVariable(varName);
     aa.clickArrowToolbarButton();
-    aa.getAnnotationButtons().should("have.length", 10);
+    aa.getAnnotationButtons().should("have.length", 13);
     aa.clickArrowToolbarButton();
 
     cy.log("Can add an arrow to variable dots");


### PR DESCRIPTION
This change fixes a test failure noticed on master due to the test attempting to click a toolbar button (`link-tile`) that is not configured in the unit it's currently pointing to.

This changes it to use `link-tile-multiple`, and then updates some values in the test since that button operates differently and leaves the table connected.
