### PR TITLE
on teacher launch, don't load default unit

### DIFF
--- a/docs/launch-sequence.md
+++ b/docs/launch-sequence.md
@@ -26,8 +26,8 @@ flowchart TB
   component("Create app component")
   cs --> component
 
-  callLoadUnitProblem1{{call loadUnitProblem}}
-  cs -- if != auth or unit param --> callLoadUnitProblem1
+  callLoadUnitProblem1{{"call loadUnitProblem"}}
+  cs --"if != auth or unit param"--> callLoadUnitProblem1
 
   component --> authAndConnect
   component --> renderApp
@@ -77,10 +77,10 @@ flowchart TB
   subgraph authAndConnect [AuthAndConnect]
     direction TB
 
-    callAuthenticate{{call authenticate}}
+    callAuthenticate{{"call authenticate"}}
 
-    callLoadUnitProblem2{{call loadUnitProblem}}
-    callAuthenticate -- if not started loading --> callLoadUnitProblem2
+    callLoadUnitProblem2{{"call loadUnitProblem"}}
+    callAuthenticate --"if not started loading"--> callLoadUnitProblem2
     callLoadUnitProblem2 ~~~ ram
 
     subgraph ram [Resolve app mode]
@@ -125,8 +125,6 @@ flowchart TB
     unitLoadedPromise --> listeners
   end
   %% LE.end: Connecting
-
-
 
   %% LE.start: Joining group
   renderGroupChooser(Render group chooser)

--- a/src/cms/document-editor.tsx
+++ b/src/cms/document-editor.tsx
@@ -4,7 +4,6 @@ import { Map } from "immutable";
 
 import { defaultDocumentModelParts } from "../components/doc-editor-app-defaults";
 import { AppProvider, initializeApp } from "../initialize-app";
-import { IStores } from "../models/stores/stores";
 import { createDocumentModelWithEnv, DocumentModelType } from "../models/document/document";
 import { DEBUG_CMS } from "../lib/debug";
 import { EditableDocumentContent } from "../components/document/editable-document-content";
@@ -20,10 +19,9 @@ interface IProps {
 
 interface IState {
   document?: DocumentModelType;
-  stores?: IStores;
 }
 
-const initializeAppPromise = initializeApp("dev", true);
+const stores = initializeApp("dev", true);
 
 export class DocumentEditor extends React.Component<IProps, IState>  {
   disposer: IDisposer;
@@ -32,62 +30,59 @@ export class DocumentEditor extends React.Component<IProps, IState>  {
     this.state = {};
 
     // Need wait for the unit to be loaded to safely render the components
-    initializeAppPromise.then((stores) => stores.problemLoadedPromise
-      .then(() => {
-        const { initialValue } = this.props;
-        const { appConfig } = stores;
-        // Wait to construct the document until the main CLUE stuff is
-        // initialized. I'm not sure if this is necessary but it seems
-        // like the safest way to do things
-        const document = createDocumentModelWithEnv(appConfig, {
-          ...defaultDocumentModelParts,
-          content: initialValue
-        });
+    stores.unitLoadedPromise.then(() => {
+      const { initialValue } = this.props;
+      const { appConfig } = stores;
+      // Wait to construct the document until the main CLUE stuff is
+      // initialized. I'm not sure if this is necessary but it seems
+      // like the safest way to do things
+      const document = createDocumentModelWithEnv(appConfig, {
+        ...defaultDocumentModelParts,
+        content: initialValue
+      });
 
-        // Save the initial state, this is compared with the exported state
-        // on each snapshot. See the comment below for more details
-        let lastState = JSON.stringify(initialValue);
+      // Save the initial state, this is compared with the exported state
+      // on each snapshot. See the comment below for more details
+      let lastState = JSON.stringify(initialValue);
 
-        // Update the widget's value whenever a change is made to the document's content
-        this.disposer = onSnapshot(document, snapshot => {
-          const json = document.content?.exportAsJson({ includeTileIds: true });
-          if (json) {
-            const parsedJson = JSON.parse(json);
-            const stringifiedJson = JSON.stringify(parsedJson);
-            // Only update when actual changes have been made.
-            // CLUE sometimes changes the document state but those changes are not
-            // part of the exported JSON. One example is when the row height is adjusted
-            // this is saved into the document but not exported and the value of this
-            // row height could change based on the window width.
-            // So we start with the initial JSON and then only call the CMS onChange
-            // when the exported value changes from the last exported value.
-            //
-            // Note: when loading manually authored content there will often be an
-            // immediate change which is not visible. An example of that is when an author
-            // has divided the text of a text tile into multiple strings. This is exported
-            // as a single string.
-            if (stringifiedJson !== lastState) {
-              lastState = stringifiedJson;
-              // Looking at the CMS code it seems safer to pass an immutable object here
-              // not a plain JS object. The plain JS object does get saved correctly,
-              // but it also gets returned in the value property so it means sometimes the value
-              // is a immutable object and sometimes it is a plain JS object.
-              const immutableValue = Map(parsedJson);
-              this.props.handleUpdateContent(immutableValue);
-              if (DEBUG_CMS) {
-                // eslint-disable-next-line no-console
-                console.log("DEBUG: CMS ClueControl onChange called with new content value: ", parsedJson);
-              }
+      // Update the widget's value whenever a change is made to the document's content
+      this.disposer = onSnapshot(document, snapshot => {
+        const json = document.content?.exportAsJson({ includeTileIds: true });
+        if (json) {
+          const parsedJson = JSON.parse(json);
+          const stringifiedJson = JSON.stringify(parsedJson);
+          // Only update when actual changes have been made.
+          // CLUE sometimes changes the document state but those changes are not
+          // part of the exported JSON. One example is when the row height is adjusted
+          // this is saved into the document but not exported and the value of this
+          // row height could change based on the window width.
+          // So we start with the initial JSON and then only call the CMS onChange
+          // when the exported value changes from the last exported value.
+          //
+          // Note: when loading manually authored content there will often be an
+          // immediate change which is not visible. An example of that is when an author
+          // has divided the text of a text tile into multiple strings. This is exported
+          // as a single string.
+          if (stringifiedJson !== lastState) {
+            lastState = stringifiedJson;
+            // Looking at the CMS code it seems safer to pass an immutable object here
+            // not a plain JS object. The plain JS object does get saved correctly,
+            // but it also gets returned in the value property so it means sometimes the value
+            // is a immutable object and sometimes it is a plain JS object.
+            const immutableValue = Map(parsedJson);
+            this.props.handleUpdateContent(immutableValue);
+            if (DEBUG_CMS) {
+              // eslint-disable-next-line no-console
+              console.log("DEBUG: CMS ClueControl onChange called with new content value: ", parsedJson);
             }
           }
-        });
+        }
+      });
 
-        this.setState({
-          document,
-          stores
-        });
-      })
-    );
+      this.setState({
+        document
+      });
+    });
   }
 
   componentWillUnmount() {
@@ -95,8 +90,8 @@ export class DocumentEditor extends React.Component<IProps, IState>  {
   }
 
   render() {
-    const { document, stores } = this.state;
-    if (document && stores) {
+    const { document } = this.state;
+    if (document) {
       return (
         <AppProvider stores={stores} modalAppElement="#app">
           <EditableDocumentContent

--- a/src/cms/document-editor.tsx
+++ b/src/cms/document-editor.tsx
@@ -32,7 +32,7 @@ export class DocumentEditor extends React.Component<IProps, IState>  {
     this.state = {};
 
     // Need wait for the unit to be loaded to safely render the components
-    initializeAppPromise.then((stores) => stores.unitLoadedPromise
+    initializeAppPromise.then((stores) => stores.problemLoadedPromise
       .then(() => {
         const { initialValue } = this.props;
         const { appConfig } = stores;

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -193,11 +193,10 @@ export class AppComponent extends BaseComponent<IProps, IState> {
       return this.renderApp(this.renderError(ui.error));
     }
 
-    // The slowest part is the !db.listeners.isListening
-    // That can't happen until the curriculum is loaded
-    // This could be optimized by rendering a shell of the app that has
-    // "loading" scattered around. For example the problem menu could say loading
-    // just waiting for the user authentication
+    // `db.listeners.isListening` is often the slowest requirement to be true.
+    // This requirement could be dropped, but several components would
+    // have to be checked to make sure they render something reasonable
+    // in this case.
     if (!user.authenticated || !db.listeners.isListening) {
       return this.renderApp(this.renderLoading());
     }

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -85,7 +85,7 @@ export const authAndConnect = (stores: IStores, onQAClear?: (result: boolean, er
         // In that case the unit isn't known until after CLUE has got the offering information
         // from the portal.
         // loadUnitAndProblem is asynchronous.
-        // Code that requires the unit and problem to be loaded should wait on `stores.problemLoadedPromise`
+        // Code that requires the unit to be loaded should wait on `stores.unitLoadedPromise`
         stores.loadUnitAndProblem(unitCode, problemId);
       }
       return resolveAppMode(stores, authenticatedUser.rawFirebaseJWT, onQAClear);

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -79,31 +79,30 @@ export const authAndConnect = (stores: IStores, onQAClear?: (result: boolean, er
         stores.class.updateFromPortal(classInfo);
       }
 
-      // If the URL has a unit param, then stores.loadUnitAndProblem would have
-      // been called in initializeApp, and startedLoadingUnitAndProblem will be
-      // true.
-      // In the case of a teacher launch from the portal the URL should not have
-      // a unit param. Instead we figure out the unit and problem from the
-      // portal's offering information.
-      // Note: If the external report in the portal is misconfigured and includes
-      // a unit parameter, then the offering information will be ignored.
+      // If the URL has a unit param or if the appMode is not "authed", then
+      // `stores.loadUnitAndProblem` would have been called in initializeApp,
+      // and startedLoadingUnitAndProblem will be true.
+      //
+      // In the case of a teacher launch from the portal, the window.location should
+      // not have a unit param. Instead the unit and problem is figured out by
+      // `authenticate` from the portal's resource information.
+      //
+      // Note: If the external report in the portal is misconfigured with a unit
+      // parameter, then window.location will have a unit param and the resource
+      // information will be incorrectly ignored here.
       if (!stores.startedLoadingUnitAndProblem) {
-        // TODO: It'd be better if we automatically computed the problemId as the first
-        // problem of the unit. This way even without a problemId we wouldn't
-        // error out here. This same logic could be used for both the problemId here and
-        // the problemId passed at the beginning.  If we move the logic into
-        // loadUnitAndProblem then we can just have problemId be undefined in that
-        // case. However there are several places where `defaultProblemOrdinal` is used.
-        // To make the code consistently handle URLs without a problem param we need to
-        // update all of those places too.
+        // The unit and problem are required for portal resources so the behavior
+        // is more clear:
+        // - If the unit is optional for portal resources, then a student launch
+        // without a unit would not start loading the unit in initializeApp.
+        // - If the problem is optional, then the defaultProblemOrdinal might not
+        // exist in the specified unit.
+        // We don't enforce this requirement in initializeApp because during a
+        // teacher launch, we don't know the resource info.
+        //
+        // To test this you can make a CLUE resource in the portal that does not have
+        // a unit param. And then launch it
         if (!unitCode || !problemId) {
-          // To test this you can make a CLUE resource in the portal that does not have
-          // a unit param. And then launch it
-
-          // TODO: we should have a way to test this without actually launching from
-          // the portal. This currently isn't easy to do without adding a lot of
-          // complexity to the code.
-
           // If we get here, CLUE will hang because unitLoadedPromise will never
           // resolve so the listeners won't start and there will be no content
           // for CLUE to render. The error message below indicates the most likely

--- a/src/doc-editor.tsx
+++ b/src/doc-editor.tsx
@@ -8,16 +8,15 @@ import { AppProvider, initializeApp } from "./initialize-app";
 
 (window as any).DISABLE_FIREBASE_SYNC = true;
 
-initializeApp(urlParams.appMode || "dev", true)
-  // Need wait for the unit to be loaded to safely render the components
-  .then((stores) => stores.problemLoadedPromise
-    .then(() => {
-      ReactDOM.render(
-        <AppProvider stores={stores} modalAppElement="#app">
-          <DocEditorApp/>
-          <DialogComponent/>
-        </AppProvider>,
-        document.getElementById("app")
-      );
-    })
+const stores = initializeApp(urlParams.appMode || "dev", true);
+
+// Need wait for the unit to be loaded to safely render the components
+stores.unitLoadedPromise.then(() => {
+  ReactDOM.render(
+    <AppProvider stores={stores} modalAppElement="#app">
+      <DocEditorApp/>
+      <DialogComponent/>
+    </AppProvider>,
+    document.getElementById("app")
   );
+});

--- a/src/doc-editor.tsx
+++ b/src/doc-editor.tsx
@@ -10,7 +10,7 @@ import { AppProvider, initializeApp } from "./initialize-app";
 
 initializeApp(urlParams.appMode || "dev", true)
   // Need wait for the unit to be loaded to safely render the components
-  .then((stores) => stores.unitLoadedPromise
+  .then((stores) => stores.problemLoadedPromise
     .then(() => {
       ReactDOM.render(
         <AppProvider stores={stores} modalAppElement="#app">

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,16 +23,15 @@ if (!redirectingToAuthDomain) {
       document.getElementById("app")
     );
   } else {
-    initializeApp(appMode).then((stores) => {
-      stores.ui.setShowDemoCreator(!!stores.showDemoCreator);
+    const stores = initializeApp(appMode);
+    stores.ui.setShowDemoCreator(!!stores.showDemoCreator);
 
-      ReactDOM.render(
-        <AppProvider stores={stores} modalAppElement="#app">
-          <AppComponent />
-        </AppProvider>,
-        document.getElementById("app")
-      );
-      removeLoadingMessage("Initializing");
-    });
+    ReactDOM.render(
+      <AppProvider stores={stores} modalAppElement="#app">
+        <AppComponent />
+      </AppProvider>,
+      document.getElementById("app")
+    );
+    removeLoadingMessage("Initializing");
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,7 +6,6 @@ import { AppComponent } from "./components/app";
 import { getAppMode } from "./lib/auth";
 import { urlParams } from "./utilities/url-params";
 import { QAClear } from "./components/qa-clear";
-import { setPageTitle } from "./lib/misc";
 import { getBearerToken, initializeAuthorization } from "./utilities/auth-utils";
 import { removeLoadingMessage, showLoadingMessage } from "./utilities/loading-utils";
 
@@ -25,7 +24,6 @@ if (!redirectingToAuthDomain) {
     );
   } else {
     initializeApp(appMode).then((stores) => {
-      stores.unitLoadedPromise.then(() => setPageTitle(stores));
       stores.ui.setShowDemoCreator(!!stores.showDemoCreator);
 
       ReactDOM.render(

--- a/src/initialize-app.tsx
+++ b/src/initialize-app.tsx
@@ -54,17 +54,17 @@ export const initializeApp = (appMode: AppMode, authoring?: boolean): IStores =>
   }
 
 
-  // Only load the unit here if we are not authed, or we are authed and have a unit param.
-  // If we are authed with a unit param we can go ahead and start the process of loading
-  // unit. If we are authed without a unit param, the unit will be figured out later
+  // Only load the unit here if we are not authed, or we are authed and have a unit and problem param.
+  // If we are authed with a unit and problem param we can go ahead and start the process of loading
+  // the unit. If we are authed without a unit and problem params, the unit will be figured out later
   // from the information returned by the portal.
   //
-  // TODO: A better approach than this would be to never use a default unit
-  // Then this check would just look at the unit param. This approach isn't implemented
+  // TODO: A better approach would be to never use a default unit or problems.
+  // Then this check could ignore the appMode. This approach isn't implemented
   // because it is still convenient for developers and demo'ers to use simple URLs.
-  // Those cases can be handled by having the code automatically add the default
-  // unit to the URL before this point.
-  if (appMode !== "authed" || urlParams.unit) {
+  // Those cases can be handled by having the code automatically add the defaults
+  // to the URL before this point.
+  if (appMode !== "authed" || (urlParams.unit && urlParams.problem)) {
     const unitId = urlParams.unit || appConfigSnapshot.defaultUnit;
     const problemOrdinal = urlParams.problem || appConfigSnapshot.config.defaultProblemOrdinal;
 

--- a/src/initialize-app.tsx
+++ b/src/initialize-app.tsx
@@ -37,7 +37,7 @@ const kEnableLivelinessChecking = false;
  * @param appMode
  * @returns
  */
-export const initializeApp = async (appMode: AppMode, authoring?: boolean): Promise<IStores> => {
+export const initializeApp = (appMode: AppMode, authoring?: boolean): IStores => {
   const appVersion = PackageJson.version;
 
   const user = UserModel.create();
@@ -67,10 +67,10 @@ export const initializeApp = async (appMode: AppMode, authoring?: boolean): Prom
     const unitId = urlParams.unit || appConfigSnapshot.defaultUnit;
     const problemOrdinal = urlParams.problem || appConfigSnapshot.config.defaultProblemOrdinal;
 
-    // Start setUnitAndProblem asynchronously. The bulk of the initialization code can continue
+    // Run loadUnitAndProblem asynchronously. The bulk of the initialization code can continue
     // while that unit information is loaded, including getting the persistentUI loaded as
     // soon as possible so we only render what we need.
-    // Code that requires the unit and problem to be loaded should wait on `stores.problemLoadedPromise`
+    // Code that requires the unit and problem to be loaded should wait on `stores.unitLoadedPromise`
     // This promise will resolve when the problem has been loaded.
     stores.loadUnitAndProblem(unitId, problemOrdinal);
   }

--- a/src/initialize-app.tsx
+++ b/src/initialize-app.tsx
@@ -54,16 +54,17 @@ export const initializeApp = (appMode: AppMode, authoring?: boolean): IStores =>
   }
 
 
-  // Only load the unit here if we have a unit param or we are not launched from the portal.
-  // If we are launched from the portal and we don't have a unit param, then the unit
-  // will be figured out later on.
-
-  // FIXME: since we are now only using the default unit if we are not launched from the portal.
-  // It is possible there are some portal links for students that don't include a unit
-  // so this change would break these resources.
+  // Only load the unit here if we are not authed, or we are authed and have a unit param.
+  // If we are authed with a unit param we can go ahead and start the process of loading
+  // unit. If we are authed without a unit param, the unit will be figured out later
+  // from the information returned by the portal.
+  //
   // TODO: A better approach than this would be to never use a default unit
-  // Then this check would just look at the unit param.
-  if (urlParams.unit || appMode !== "authed") {
+  // Then this check would just look at the unit param. This approach isn't implemented
+  // because it is still convenient for developers and demo'ers to use simple URLs.
+  // Those cases can be handled by having the code automatically add the default
+  // unit to the URL before this point.
+  if (appMode !== "authed" || urlParams.unit) {
     const unitId = urlParams.unit || appConfigSnapshot.defaultUnit;
     const problemOrdinal = urlParams.problem || appConfigSnapshot.config.defaultProblemOrdinal;
 

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -6,7 +6,8 @@ import { authenticate,
         getAppMode,
         createFakeUser,
         getFirebaseJWTParams,
-        generateDevAuthentication} from "./auth";
+        generateDevAuthentication,
+        createFakeOfferingIdFromProblem} from "./auth";
 import { IPortalClassInfo, IPortalClassUser, PortalStudentJWT, PortalTeacherJWT } from "./portal-types";
 import nock from "nock";
 import { NUM_FAKE_STUDENTS, NUM_FAKE_TEACHERS } from "../components/demo/demo-creator";
@@ -389,8 +390,7 @@ describe("student authentication", () => {
       classId: "1",
       userType: "student",
       userId: "2",
-      unitCode: "",
-      problemOrdinal: "3.1"
+      offeringId: "301",
     });
     expect(demoInfo.authenticatedUser).toEqual({
       type: "student",
@@ -416,8 +416,7 @@ describe("student authentication", () => {
       userType: "teacher",
       userId: "2",
       network: "demo-network",
-      unitCode: "",
-      problemOrdinal: "3.1"
+      offeringId: "301",
     });
     expect(demoInfo.authenticatedUser).toEqual({
       type: "teacher",
@@ -440,6 +439,37 @@ describe("student authentication", () => {
     expect(demoTeachers.length).toEqual(NUM_FAKE_TEACHERS);
     expect(demoTeachers[0].network).toBeUndefined();
     expect(demoTeachers[1].network).toBe("demo-network");
+  });
+
+});
+
+describe("fake offering ids", () => {
+  test("normal unitCode and problemOrdinal", () => {
+    expect(createFakeOfferingIdFromProblem("sas", "3.1")).toBe("sas301");
+  });
+
+  test("empty unitCode and normal problemId", () => {
+    expect(createFakeOfferingIdFromProblem("", "3.1")).toBe("301");
+  });
+
+  test("empty unitCode and partial problemId", () => {
+    expect(createFakeOfferingIdFromProblem("", "3")).toBe("300");
+  });
+
+  test("empty unitCode and decimal problemId", () => {
+    expect(createFakeOfferingIdFromProblem("", "0.3")).toBe("3");
+  });
+
+  test("normal url unitCode and normal problemId", () => {
+    const url = "https://example.com/my_unit/content.json";
+    expect(createFakeOfferingIdFromProblem(url, "3.3")).toBe("my_unit303");
+  });
+
+  // FIXME: this will likely cause a problem when this is used as a key
+  // in firebase
+  test("local url unitCode and normal problemId", () => {
+    const url = "https://localhost:8080/my_unit.json";
+    expect(createFakeOfferingIdFromProblem(url, "3.3")).toBe("localhost:8080303");
   });
 });
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -153,7 +153,7 @@ export class DB {
           this.firebase.setFirebaseUser(firebaseUser);
           this.firestore.setFirebaseUser(firebaseUser);
           if (!options.dontStartListeners) {
-            const { persistentUI, user, db, problemLoadedPromise } = this.stores;
+            const { persistentUI, user, db, unitLoadedPromise } = this.stores;
             // Start fetching the persistent UI. We want this to happen as early as possible.
             persistentUI.initializePersistentUISync(user, db);
 
@@ -161,7 +161,7 @@ export class DB {
             // Before they can be started  we need to wait for the unit to be loaded,
             // since it includes the list of tile types being registered.
             // We need those types to be registered so the listeners can safely create documents.
-            problemLoadedPromise.then(() => {
+            unitLoadedPromise.then(() => {
               this.listeners.start().then(resolve).catch(reject);
             });
           }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -153,7 +153,7 @@ export class DB {
           this.firebase.setFirebaseUser(firebaseUser);
           this.firestore.setFirebaseUser(firebaseUser);
           if (!options.dontStartListeners) {
-            const { persistentUI, user, db, unitLoadedPromise} = this.stores;
+            const { persistentUI, user, db, problemLoadedPromise } = this.stores;
             // Start fetching the persistent UI. We want this to happen as early as possible.
             persistentUI.initializePersistentUISync(user, db);
 
@@ -161,7 +161,7 @@ export class DB {
             // Before they can be started  we need to wait for the unit to be loaded,
             // since it includes the list of tile types being registered.
             // We need those types to be registered so the listeners can safely create documents.
-            unitLoadedPromise.then(() => {
+            problemLoadedPromise.then(() => {
               this.listeners.start().then(resolve).catch(reject);
             });
           }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -153,7 +153,7 @@ export class DB {
           this.firebase.setFirebaseUser(firebaseUser);
           this.firestore.setFirebaseUser(firebaseUser);
           if (!options.dontStartListeners) {
-            const { persistentUI, user, db, unitLoadedPromise } = this.stores;
+            const { persistentUI, user, db, unitLoadedPromise} = this.stores;
             // Start fetching the persistent UI. We want this to happen as early as possible.
             persistentUI.initializePersistentUISync(user, db);
 

--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -1,13 +1,11 @@
-import { ProblemModelType } from "../models/curriculum/problem";
 import { IStores } from "../models/stores/stores";
 import { Logger } from "./logger";
 
-export const setPageTitle = (stores: IStores, argProblem?: ProblemModelType) => {
-  const { appConfig, showDemoCreator, unit, problem: storeProblem } = stores;
+function setPageTitle(stores: IStores) {
+  const { appConfig, showDemoCreator, unit, problem } = stores;
   const pageTitleTemplate = appConfig && appConfig.pageTitle;
   let pageTitle;
   if (pageTitleTemplate) {
-    const problem = argProblem || storeProblem;
     pageTitle = pageTitleTemplate
                   .replace("%unitTitle%", unit && unit.fullTitle || "")
                   .replace("%problemTitle%", problem && problem.fullTitle || "");
@@ -15,14 +13,32 @@ export const setPageTitle = (stores: IStores, argProblem?: ProblemModelType) => 
   document.title = showDemoCreator
                     ? `CLUE: Demo Creator`
                     : (pageTitle || document.title);
-};
+}
 
-export const updateProblem = (stores: IStores, problemId: string) => {
-  const {unit} = stores;
-  const {investigation, problem} = unit.getProblem(problemId);
-  if (investigation && problem) {
-    Logger.updateAppContext({ investigation: investigation.title, problem: problem.title });
-    setPageTitle(stores, problem);
-    stores.problem = problem;
+function initRollbar(stores: IStores, problemId: string) {
+  const {user, unit, appVersion} = stores;
+  if (typeof (window as any).Rollbar !== "undefined") {
+    const _Rollbar = (window as any).Rollbar;
+    if (_Rollbar.configure) {
+      const config = { payload: {
+              class: user.classHash,
+              offering: user.offeringId,
+              person: { id: user.id },
+              problemId: problemId || "",
+              problem: stores.problem.title,
+              role: user.type,
+              unit: unit.title,
+              version: appVersion
+            }};
+      _Rollbar.configure(config);
+    }
   }
-};
+}
+
+export function problemLoaded(stores: IStores, problemId: string) {
+  setPageTitle(stores);
+  initRollbar(stores, problemId);
+
+  // The logger will only be enabled if the appMode is "authed", or DEBUG_LOGGER is true
+  Logger.initializeLogger(stores, { investigation: stores.investigation.title, problem: stores.problem.title });
+}

--- a/src/lib/portal-api.ts
+++ b/src/lib/portal-api.ts
@@ -89,8 +89,8 @@ export const getPortalOfferings = (
 };
 
 interface IUnitAndProblem {
-  unitCode: string;
-  problemOrdinal: string;
+  unitCode?: string;
+  problemOrdinal?: string;
 }
 export const getProblemIdForAuthenticatedUser =
               (rawPortalJWT: string, appConfig: AppConfigModelType, urlParams?: QueryParams) => {
@@ -105,16 +105,16 @@ export const getProblemIdForAuthenticatedUser =
         } else {
           const activityUrl = ((res.body || {}).activity_url) || "";
           resolve({
-            unitCode: getUnitCode(activityUrl, appConfig) || appConfig.defaultUnit,
-            problemOrdinal: getProblemOrdinal(activityUrl) || appConfig.defaultProblemOrdinal
+            unitCode: getUnitCode(activityUrl, appConfig),
+            problemOrdinal: getProblemOrdinal(activityUrl)
           });
         }
       });
     }
     else {
       resolve({
-        unitCode: urlParams && urlParams.unit || appConfig.defaultUnit,
-        problemOrdinal: urlParams && urlParams.problem || appConfig.defaultProblemOrdinal
+        unitCode: urlParams && urlParams.unit,
+        problemOrdinal: urlParams && urlParams.problem
       });
     }
   });

--- a/src/models/curriculum/unit.test.ts
+++ b/src/models/curriculum/unit.test.ts
@@ -1,6 +1,5 @@
 import { destroy, getSnapshot } from "mobx-state-tree";
-import { UnitModel, isDifferentUnitAndProblem } from "./unit";
-import { IStores } from "../stores/stores";
+import { UnitModel } from "./unit";
 
 describe("UnitModel", () => {
 
@@ -57,20 +56,6 @@ describe("UnitModel", () => {
     const result21 = unit.getProblem("2.1");
     expect(result21.problem && result21.problem.title).toBe(problemTitle);
     expect(result21.investigation && result21.investigation.title).toBe(investigation2Title);
-  });
-
-  it("isDifferentUnitAndProblem() should work as expected", () => {
-    const stores: IStores = {
-            unit,
-            investigation: unit.getInvestigation(1),
-            problem: unit.getInvestigation(1)!.getProblem(1)
-          } as IStores;
-    expect(isDifferentUnitAndProblem(stores, "u1", undefined)).toBe(false);
-    expect(isDifferentUnitAndProblem(stores, undefined, "1.1")).toBe(false);
-    expect(isDifferentUnitAndProblem(stores, "u1", "1.1")).toBe(false);
-    expect(isDifferentUnitAndProblem(stores, "u1", "1.2")).toBe(true);
-    expect(isDifferentUnitAndProblem(stores, "u2", "1.1")).toBe(true);
-    expect(isDifferentUnitAndProblem(stores, "u2", "2.2")).toBe(true);
   });
 
   it("can import legacy snapshots", () => {

--- a/src/models/curriculum/unit.ts
+++ b/src/models/curriculum/unit.ts
@@ -14,7 +14,6 @@ import { StampModel } from "../../plugins/drawing/model/stamp";
 import { AppConfigModelType } from "../stores/app-config-model";
 import { NavTabsConfigModel } from "../stores/nav-tabs";
 import { SettingsMstType } from "../stores/settings";
-import { IBaseStores } from "../stores/base-stores-types";
 import { UnitConfiguration } from "../stores/unit-configuration";
 
 const PlanningDocumentConfigModel = types
@@ -256,13 +255,6 @@ export function createUnitWithoutContent(unitJson: any) {
     resumeSupportContentParsing();
     resumeSectionContentParsing();
   }
-}
-
-export function isDifferentUnitAndProblem(stores: IBaseStores, unitId?: string | undefined, problemOrdinal?: string) {
-  if (!unitId || !problemOrdinal) return false;
-  const { unit, investigation, problem } = stores;
-  const combinedOrdinal = `${investigation.ordinal}.${problem.ordinal}`;
-  return (unit.code !== unitId) || (combinedOrdinal !== problemOrdinal);
 }
 
 export function getSectionPath(section: SectionModelType) {

--- a/src/models/stores/stores.ts
+++ b/src/models/stores/stores.ts
@@ -40,6 +40,7 @@ export interface IStores extends IBaseStores {
   loadUnitAndProblem: (unitId: string | undefined, problemOrdinal?: string) => Promise<void>;
   sortedDocuments: SortedDocuments;
   unitLoadedPromise: Promise<void>;
+  startedLoadingUnitAndProblem: boolean;
 }
 
 export interface ICreateStores extends Partial<IStores> {
@@ -80,6 +81,7 @@ class Stores implements IStores{
   userContextProvider: UserContextProvider;
   sortedDocuments: SortedDocuments;
   unitLoadedPromise: Promise<void>;
+  startedLoadingUnitAndProblem: boolean;
 
   constructor(params?: ICreateStores){
     // This will mark all properties as observable
@@ -207,6 +209,7 @@ class Stores implements IStores{
   // be some weird interactions with action tracking if we mix them.
   async loadUnitAndProblem(unitId: string | undefined, problemOrdinal?: string) {
     const { appConfig, persistentUI } = this;
+    this.startedLoadingUnitAndProblem = true;
     showLoadingMessage("Loading curriculum content");
     let unitJson = await getUnitJson(unitId, appConfig);
     if (unitJson.status === 404) {

--- a/src/models/stores/stores.ts
+++ b/src/models/stores/stores.ts
@@ -96,10 +96,11 @@ class Stores implements IStores{
     this.appVersion = params?.appVersion || "unknown";
     this.appConfig = params?.appConfig || AppConfigModel.create();
 
-    // To keep the code simple, we create a null unit, investigation, and problem if they aren't provided.
+    // To keep the code simple, we create a null unit, investigation, and problem if
+    // they aren't provided.
     // Code that needs the real unit should wait on the `unitLoadedPromise`.
-    // CHECKME: do we ever pass the unit?
-    // If we do, then the unitLoadedPromise will resolve immediately
+    // If the unit is passed in, then the unitLoadedPromise will resolve immediately,
+    // this only happens in tests.
     const defaultUnit = UnitModel.create({code: "NULL", title: "Null Unit"});
     this.unit = params?.unit || defaultUnit;
     this.investigation = params?.investigation ||
@@ -137,10 +138,6 @@ class Stores implements IStores{
     this.bookmarks = new Bookmarks({db: this.db});
     this.sortedDocuments = new SortedDocuments(this);
 
-    // It would be cleaner if we could just leave the problem undefined
-    // until it was loaded for real. However there are lots of components that expect the
-    // problem to be defined. By using a default problem these components can render with
-    // the default problem and then update when it is set for real.
     this.unitLoadedPromise = when(() => this.unit !== defaultUnit);
   }
 

--- a/src/models/stores/ui.ts
+++ b/src/models/stores/ui.ts
@@ -131,10 +131,23 @@ export const UIModel = types
       },
 
 
-      setError(error: string) {
-        self.error = error ? error.toString() : error;
+      setError(error: string | Error, customMessage?: string) {
+        self.error = customMessage ?? error?.toString();
         Logger.log(LogEventName.INTERNAL_ERROR_ENCOUNTERED, { message: self.error });
-        console.error(self.error);
+        if (error instanceof Error) {
+          // In Chrome, passing an error instance to console.error() will print the
+          // message and the stack. This is useful to find the original error. It
+          // does not show async chaining like Chrome does when it shows the stack
+          // trace directly from an uncaught error or the trace of the console.error
+          // itself. Even without the extra detail, this trace is useful for debugging.
+          if (customMessage) {
+            console.error(customMessage, error);
+          } else {
+            console.error(error);
+          }
+        } else {
+          console.error(self.error);
+        }
       },
       clearError() {
         self.error = null;


### PR DESCRIPTION
This includes several changes:

- make sure that loadUnitAndProblem is only called once. This replaces the logic that was checking if the portal offering had a different unit than the initial unit.
- make initializeApp synchronous. It no longer needed to be async, with this change some code could be simplified
- move the code that needed the problem to be loaded into `loadUnitAndProblem`. Including initializing the logger, configuring rollbar, and setting the page tile. Now that `loadUnitAndProblem` is only called once, moving this code simplified things.
- improve error handling by showing stack of original error
- require a unit and problem to be set on CLUE URLs in the portal
- add tests for the fake offering ids, this identified a case which might cause problems. I didn't want grow the scope of this PR, so I didn't fix it.
- extract fake offering id function from `createFakeAuthentication` so it is more clear what is happening, and so createFakeAuthentication can be used differently in the future.

I use the Rails console to search for CLUE URLs that didn't have a unit and/or problem. I've updated all of them so this change should not cause any problems when deployed to production.

The PT story has instructions on how to test this within its branch:
https://www.pivotaltracker.com/story/show/187064481/comments/240291939