### PR TITLE
only complete attribute change if there is a draggedToValue defined

### DIFF
--- a/src/plugins/data-card/components/sort-area.tsx
+++ b/src/plugins/data-card/components/sort-area.tsx
@@ -38,7 +38,9 @@ export const DataCardSortArea: React.FC<IProps> = ({ model }) => {
         const draggingId = e.active?.data?.current?.caseId;
         const attrId = e.active?.data?.current?.sortedByAttrId;
         const draggedToValue = e.over?.data?.current?.stackValue;
-        content.setAttValue(draggingId, attrId, draggedToValue || "");
+        if (draggedToValue !== undefined) {
+          content.setAttValue(draggingId, attrId, draggedToValue);
+        }
         setSortDragActive(false);
       }
       document.body.style.cursor = "default";


### PR DESCRIPTION
This addresses the bug described in PT-187055825.  Dragging a Data Card off its current stack and on to "nothing" was causing the card to take on an empty string value for the current sort attribute.  This prevents that from happening. 