### PR TITLE
187042217-exemplar-multiple-teachers-should-show

### DIFF
--- a/src/models/stores/sorted-documents.ts
+++ b/src/models/stores/sorted-documents.ts
@@ -106,7 +106,7 @@ export class SortedDocuments {
     const documentMap = new Map();
     this.filteredDocsByType.forEach((doc) => {
       const user = this.class.getUserById(doc.uid);
-      const sectionLabel = (user && user.type === "student") ? `${user.lastName}, ${user.firstName}` : "Teacher";
+      const sectionLabel = user && `${user.lastName}, ${user.firstName}`;
       if (!documentMap.has(sectionLabel)) {
         documentMap.set(sectionLabel, {
           sectionLabel,


### PR DESCRIPTION
Fulfills this ticket

[**[Exemplar]** Multiple Teachers should show with different names in name sort](https://www.pivotaltracker.com/n/projects/2441242/stories/187042217)

________________________________________________________________________
Deployed Link
https://collaborative-learning.concord.org/branch/exemplar-multiple-teachers-should-show-2/?appMode=demo&demoName=CLUE&fakeClass=1&fakeUser=teacher:1&unit=example-config-subtabs&problem=1.1