### PR TITLE
Added Sort Work tab cypress tests for testing student groups

### DIFF
--- a/cypress/support/elements/common/ResourcesPanel.js
+++ b/cypress/support/elements/common/ResourcesPanel.js
@@ -43,6 +43,18 @@ class ResourcesPanel{
         return this.getCanvasItemTitle(tab, section).contains(title).parent().parent().siblings('.icon-holder').find('.icon-star');
     }
 
+    getDocumentCloseButton() {
+      return cy.get('.document-buttons .close-doc-button')
+    }
+
+    getDocumentEditButton() {
+      return cy.get('.document-buttons .edit-button')
+    }
+
+    getEditableDocumentContent() {
+      return cy.get('.resource-and-chat-panel .editable-document-content .document-content');
+    }
+
     closePrimaryWorkspaceTab(tab){
         cy.get('#primaryWorkspaceTab-'+tab+'.tab').click();
         cy.wait(2000);

--- a/cypress/support/elements/common/SortedWork.js
+++ b/cypress/support/elements/common/SortedWork.js
@@ -1,0 +1,25 @@
+class SortedWork {
+  getSortByMenu() {
+    return cy.get('.custom-select.sort-work-sort-menu');
+  }
+  getListItemByName() {
+    return cy.get('[data-test="list-item-name"]');
+  }
+  getListItemByGroup() {
+    return cy.get('[data-test="list-item-group"]')
+  }
+  getSortWorkItem() {
+    return cy.get(".sort-work-view .sorted-sections .list-item .footer .info");
+  }
+  checkDocumentInGroup(groupName, doc) {
+    cy.get(".sort-work-view .sorted-sections .section-header-label").contains(groupName).parent().parent().find(".list .list-item .footer .info").should("contain", doc);
+  }
+  checkDocumentNotInGroup(groupName, doc) {
+    cy.get(".sort-work-view .sorted-sections .section-header-label").contains(groupName).parent().parent().find(".list .list-item .footer .info").should("not.contain", doc);
+  }
+  checkGroupDoesNotExist(group) {
+    cy.get(".sort-work-view .sorted-sections .section-header-label").should("not.contain", group);
+  }
+}
+
+export default SortedWork;


### PR DESCRIPTION
This PR expands on the Sort Work tab tests that were previously written. There were a few TODOs (added as a comment in the spec) in the spec file that @dennisrcao had added when he initially wrote the tests. This PR addresses some of those TODOs (and removed the TODO comment pertaining to those). 
Specifically, this PR addresses the tests for the teacher Sort Work view updationss when students join and leave groups. It also checks student problem and personal documents in the sort work view, where they show up and when opened, whether or not they're editable.