### PR TITLE
187080552 teacher name prefix

### DIFF
--- a/src/hooks/use-document-caption.tsx
+++ b/src/hooks/use-document-caption.tsx
@@ -1,7 +1,7 @@
 import { useFirestoreTeacher } from "./firestore-hooks";
 import { useAppConfig, useClassStore, useProblemStore, useUserStore } from "./use-stores";
 import { DocumentModelType } from "../models/document/document";
-import { isPublishedType, isUnpublishedType, SupportPublication } from "../models/document/document-types";
+import { isPublishedType, isUnpublishedType } from "../models/document/document-types";
 import { getDocumentDisplayTitle } from "../models/document/document-utils";
 
 export function useDocumentCaption(document: DocumentModelType, isStudentWorkspaceDoc?: boolean) {
@@ -12,13 +12,13 @@ export function useDocumentCaption(document: DocumentModelType, isStudentWorkspa
   const { type, uid } = document;
   const pubVersion = document.pubVersion;
   const teacher = useFirestoreTeacher(uid, user.network || "");
-  if (type === SupportPublication) {
-    const caption = document.getProperty("caption") || "Support";
-    return pubVersion ? `${caption} v${pubVersion}` : `${caption}`;
-  }
   const userName = classStore.getUserById(uid)?.displayName || teacher?.name ||
-                    (document.isRemote ? teacher?.name : "") || "Unknown User";
+  (document.isRemote ? teacher?.name : "") || "Unknown User";
 
+  // if (type === SupportPublication) {
+  //   const caption = document.getProperty("caption") || "Support";
+  //   return pubVersion ? `${caption} v${pubVersion}` : `${caption}`;
+  // }
 
   const hasNamePrefix =  document.isRemote || isPublishedType(type) || isUnpublishedType(type) || isStudentWorkspaceDoc;
   const namePrefix = hasNamePrefix ? `${userName}: ` : "";

--- a/src/hooks/use-document-caption.tsx
+++ b/src/hooks/use-document-caption.tsx
@@ -12,8 +12,10 @@ export function useDocumentCaption(document: DocumentModelType, isStudentWorkspa
   const { type, uid } = document;
   const pubVersion = document.pubVersion;
   const teacher = useFirestoreTeacher(uid, user.network || "");
-  const userName = classStore.getUserById(uid)?.displayName || teacher?.name ||
-                  (document.isRemote ? teacher?.name : "") || "Unknown User";
+  const userName = classStore.getUserById(uid)?.displayName
+    || teacher?.name
+    || (document.isRemote ? teacher?.name : "")
+    || "Unknown User";
 
   const hasNamePrefix =  document.isRemote || isPublishedType(type) || isUnpublishedType(type) || isStudentWorkspaceDoc;
   const namePrefix = hasNamePrefix ? `${userName}: ` : "";

--- a/src/hooks/use-document-caption.tsx
+++ b/src/hooks/use-document-caption.tsx
@@ -12,8 +12,8 @@ export function useDocumentCaption(document: DocumentModelType, isStudentWorkspa
   const { type, uid } = document;
   const pubVersion = document.pubVersion;
   const teacher = useFirestoreTeacher(uid, user.network || "");
-  const userName = classStore.getUserById(uid)?.displayName || teacher?.name ||
-                  (document.isRemote ? teacher?.name : "") || "Unknown User";
+  const userName = classStore.getUserById(uid)?.displayName
+    || teacher?.name || (document.isRemote ? teacher?.name : "") || "Unknown User";
 
   const hasNamePrefix =  document.isRemote || isPublishedType(type) || isUnpublishedType(type) || isStudentWorkspaceDoc;
   const namePrefix = hasNamePrefix ? `${userName}: ` : "";
@@ -23,6 +23,5 @@ export function useDocumentCaption(document: DocumentModelType, isStudentWorkspa
                           ? ` v${pubVersion}`
                           : "";
   const title = getDocumentDisplayTitle(document, appConfig, problem);
-
   return `${namePrefix}${title}${dateSuffix}`;
 }

--- a/src/hooks/use-document-caption.tsx
+++ b/src/hooks/use-document-caption.tsx
@@ -12,8 +12,8 @@ export function useDocumentCaption(document: DocumentModelType, isStudentWorkspa
   const { type, uid } = document;
   const pubVersion = document.pubVersion;
   const teacher = useFirestoreTeacher(uid, user.network || "");
-  const userName = classStore.getUserById(uid)?.displayName
-    || teacher?.name || (document.isRemote ? teacher?.name : "") || "Unknown User";
+  const userName = classStore.getUserById(uid)?.displayName || teacher?.name ||
+                  (document.isRemote ? teacher?.name : "") || "Unknown User";
 
   const hasNamePrefix =  document.isRemote || isPublishedType(type) || isUnpublishedType(type) || isStudentWorkspaceDoc;
   const namePrefix = hasNamePrefix ? `${userName}: ` : "";

--- a/src/hooks/use-document-caption.tsx
+++ b/src/hooks/use-document-caption.tsx
@@ -13,12 +13,7 @@ export function useDocumentCaption(document: DocumentModelType, isStudentWorkspa
   const pubVersion = document.pubVersion;
   const teacher = useFirestoreTeacher(uid, user.network || "");
   const userName = classStore.getUserById(uid)?.displayName || teacher?.name ||
-  (document.isRemote ? teacher?.name : "") || "Unknown User";
-
-  // if (type === SupportPublication) {
-  //   const caption = document.getProperty("caption") || "Support";
-  //   return pubVersion ? `${caption} v${pubVersion}` : `${caption}`;
-  // }
+                  (document.isRemote ? teacher?.name : "") || "Unknown User";
 
   const hasNamePrefix =  document.isRemote || isPublishedType(type) || isUnpublishedType(type) || isStudentWorkspaceDoc;
   const namePrefix = hasNamePrefix ? `${userName}: ` : "";
@@ -28,5 +23,6 @@ export function useDocumentCaption(document: DocumentModelType, isStudentWorkspa
                           ? ` v${pubVersion}`
                           : "";
   const title = getDocumentDisplayTitle(document, appConfig, problem);
+
   return `${namePrefix}${title}${dateSuffix}`;
 }


### PR DESCRIPTION
PT-187080552

- adds the display of the teacher name to the title under thumbnails in my work for teacher support publications published to all classes.  
- this is achieved by removing the special casing for rendering the "caption" when the document is a `SupportPublication` (the type created when publishing to all classes)