### PR TITLE
fix rollbar errors from setPositions

### DIFF
--- a/src/plugins/graph/utilities/graph-utils.ts
+++ b/src/plugins/graph/utilities/graph-utils.ts
@@ -498,7 +498,10 @@ export function setPointCoordinates(props: ISetPointCoordinates) {
         .end()
         .then(() => {
           dotsRef.current?.setAttribute('x', '0');
-        });
+        })
+        // We were seeing rollbars errors from this. From the docs on `end()` it looks like it is
+        // legitimate to be rejected if the transition is canceled or interrupted.
+        .catch(rejectedObject => console.warn("setPositions was rejected", rejectedObject));
     }
   };
 


### PR DESCRIPTION
We were seeing rollbars errors from `setPositions`. From the docs about `end()`, it looks like it is legitimate for the resulting promise to be rejected if the transition is canceled or interrupted. My guess was that some animation was getting interrupted during loading because something in the graph state was changing. 

We were able to reproduce the error only by switching to the teacher from the rollbar error and running the teacher report for this particular assignment. The error did reproduce when running CLUE on localhost. We noticed that the number of errors generated locally would vary from reload to reload. From the error information we could tell that the errors were coming from multiple instances of the graph tile. And it seemed like they were coming from multiple documents within the teacher dashboard.