### PR TITLE
add deployment url

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,9 @@ jobs:
       - jest
       - cypress
     runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.ref_type == 'branch' && 'branches' || 'versions' }}
+      url: https://collaborative-learning.concord.org/${{ steps.s3-deploy.outputs.deployPath }}/?demo
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v2
@@ -136,6 +139,7 @@ jobs:
           # This decreases the deploy time quite a bit
           CYPRESS_INSTALL_BINARY: 0
       - uses: concord-consortium/s3-deploy-action@v1
+        id: s3-deploy
         with:
           bucket: models-resources
           prefix: collaborative-learning


### PR DESCRIPTION
This change tells GitHub the branch was deployed, and it adds a new deployment section to the PR. If you click the "Show environments" link you'll find a "View deployment" button which will open the CLUE demo page for the PR's branch. 

More info can be found in this PR:
https://github.com/concord-consortium/starter-projects/pull/72