### PR TITLE
make image url match more strict

### DIFF
--- a/src/models/image-map.test.ts
+++ b/src/models/image-map.test.ts
@@ -310,8 +310,10 @@ describe("ImageMap", () => {
       }));
     });
     it("returns false for an invalid image URL or path", () => {
-      const invalidImageUrl = "hi";
-      expect(sImageMap.isImageUrl(invalidImageUrl)).toBe(false);
+      expect(sImageMap.isImageUrl("hi")).toBe(false);
+      expect(sImageMap.isImageUrl("4/5 + 3.4")).toBe(false);
+      expect(sImageMap.isImageUrl("4/5 + 3.456")).toBe(false);
+      expect(sImageMap.isImageUrl("4/5+3.456")).toBe(false);
     });
   });
 

--- a/src/models/image-map.ts
+++ b/src/models/image-map.ts
@@ -493,10 +493,12 @@ export const localAssetsImagesHandler: IImageHandler = {
     return !/:/.test(url) &&
            // or legacy firebase storage references
            !/^\/.+\/portals\/.+$/.test(url) &&
+           // spaces are not allowed
+           !/ /.test(url) &&
            // make sure there's at least one slash
            /\//.test(url) &&
            // make sure value ends with a file extension
-           /\.[a-z0-9]+$/i.test(url);
+           /\.[a-z]{3,}$/i.test(url);
   },
 
   async store(url: string, options?: IImageHandlerStoreOptions): Promise<IImageHandlerStoreResult> {


### PR DESCRIPTION
PT-187179232

This approach is still fragile. It would be better to only allow localAssets in specific cases. And then we could require the image urls have a protocol which will make the pattern even less likely to be falsely identified.

Also there are two different tests for image urls. One is in the image map. The other is in data-types.ts. The test in data-types.ts is much more strict, but it likely prevent cases where an image is dragged from another page into CLUE.