### PR TITLE
187091498 dataflow wait 2

### DIFF
--- a/src/plugins/dataflow/model/dataflow-program-model.ts
+++ b/src/plugins/dataflow/model/dataflow-program-model.ts
@@ -80,6 +80,7 @@ const DataflowNodeDataModel = types.
 
     // Control
     controlOperator: types.maybe(types.string),
+    waitDuration: types.maybe(types.number),
 
     // Demo Output
     outputType: types.maybe(types.string),

--- a/src/plugins/dataflow/model/utilities/node.ts
+++ b/src/plugins/dataflow/model/utilities/node.ts
@@ -288,6 +288,24 @@ export const HoldFunctionOptions = [
     displayName: "Hold 0",
     type: "control",
     icon: HoldZeroArrowIcon
+  },
+  {
+    name: "Hold Current Wait",
+    displayName: "Hold this, wait",
+    type: "control",
+    icon: HoldCurrentArrowIcon
+  },
+  {
+    name: "Hold Prior Wait",
+    displayName: "Hold previous, wait",
+    type: "control",
+    icon: HoldPreviousArrowIcon
+  },
+  {
+    name: "Output Zero Wait",
+    displayName: "Hold 0, wait",
+    type: "control",
+    icon: HoldZeroArrowIcon
   }
 ];
 

--- a/src/plugins/dataflow/nodes/controls/num-control.sass
+++ b/src/plugins/dataflow/nodes/controls/num-control.sass
@@ -12,7 +12,7 @@
 
   .number-input
     border-radius: 3px
-    &.units
+    &.units.multiple
       border-top-right-radius: 0
       border-bottom-right-radius: 0
 
@@ -48,3 +48,10 @@
     margin: 0
     box-sizing: border-box
     box-shadow: none
+
+.number-container.units.one
+  width: 97%
+
+  .single-unit
+    text-align: center
+    padding-left: 5px

--- a/src/plugins/dataflow/nodes/controls/num-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/num-control.tsx
@@ -1,6 +1,7 @@
 // FIXME: ESLint is unhappy with these control components
 /* eslint-disable react-hooks/rules-of-hooks */
 import React, { useRef } from "react";
+import classNames from "classnames";
 import Rete, { NodeEditor, Node, Control } from "rete";
 import { useStopEventPropagation } from "./custom-hooks";
 import { NodePeriodUnits } from "../../model/utilities/node";
@@ -59,13 +60,45 @@ export class NumControl extends Rete.Control {
                                    tooltip: string}) => {
       const inputRef = useRef<HTMLInputElement>(null);
       useStopEventPropagation(inputRef, "pointerdown");
+
+      const unitsClasses = classNames({
+        "units one": compProps.units && compProps.units.length === 1,
+        "units multiple": compProps.units && compProps.units.length > 1
+      });
+
+      const renderUnits = () => {
+        if (!compProps.units || compProps.units.length === 0) {
+          return null;
+        }
+
+        if (compProps.units.length === 1) {
+          return (
+            <div className="single-unit">
+              {compProps.units[0]}
+            </div>
+          );
+        }
+
+        return (
+          <div className="type-options-back">
+            <div className="type-options">
+              <select onChange={handleSelectChange} value={compProps.currentUnits}>
+                {compProps.units.map((unit, index) => (
+                  <option key={index} value={unit}>{unit}</option>
+                ))}
+              </select>
+            </div>
+          </div>
+        );
+      };
+
       return (
-        <div className="number-container" title={compProps.tooltip}>
+        <div className={`number-container ${unitsClasses}`} title={compProps.tooltip}>
           { label
             ? <label className="number-label">{compProps.label}</label>
             : null
           }
-          <input className={`number-input ${compProps.units && compProps.units.length ? "units" : ""}`}
+          <input className={`number-input ${unitsClasses}`}
             ref={inputRef}
             type={"text"}
             value={compProps.inputValue}
@@ -73,21 +106,7 @@ export class NumControl extends Rete.Control {
             onChange={handleChange(compProps.onChange)}
             onBlur={handleBlur(compProps.onBlur)}
           />
-          { compProps.units?.length
-            ? <div className="type-options-back">
-                <div className="type-options">
-                  <select onChange={handleSelectChange}
-                    value={compProps.currentUnits}
-                  >
-                    { compProps.units.map((unit, index) => (
-                        <option key={index} value={unit}>{unit}</option>
-                      ))
-                    }
-                  </select>
-                </div>
-              </div>
-            : null
-          }
+          {renderUnits()}
         </div>
       );
     };

--- a/src/plugins/dataflow/nodes/dataflow-node.tsx
+++ b/src/plugins/dataflow/nodes/dataflow-node.tsx
@@ -25,6 +25,8 @@ export class DataflowNode extends Node {
 
     const dynamicClasses = classNames({
       "gate-active": node.data.gateActive,
+      "wait-option-selected": node.data.hasWait,
+      "wait-active": node.data.waitActive,
       "has-flow-in": hasFlowIn(node),
       "uses-relays": outputsToAnyRelay(node),
       "uses-gripper": outputsToAnyGripper(node),

--- a/src/plugins/dataflow/nodes/factories/control-rete-node-factory.tsx
+++ b/src/plugins/dataflow/nodes/factories/control-rete-node-factory.tsx
@@ -6,7 +6,7 @@ import { DropdownListControl } from "../controls/dropdown-list-control";
 import { NumControl } from "../controls/num-control";
 import { HoldFunctionOptions } from "../../model/utilities/node";
 import { PlotButtonControl } from "../controls/plot-button-control";
-import { getNumDisplayStr } from "../utilities/view-utilities";
+import { determineGateActive, getHoldNodeResultString } from "../utilities/view-utilities";
 
 export class ControlReteNodeFactory extends DataflowReteNodeFactory {
   constructor(numSocket: Socket) {
@@ -14,7 +14,25 @@ export class ControlReteNodeFactory extends DataflowReteNodeFactory {
   }
 
   private heldValue: number | null = null;
-  private timerRunning: boolean = false;
+  private waitTimerOn: boolean = false;
+
+  /**
+   *  incoming ON  -> exsiting OFF : start timer  (this is a new on signal)
+   *  incoming ON  -> existing ON  : do nothing   (gate already on)
+   *  incoming OFF -> existing OFF : do nothing   (gate is already off)
+   *  incoming OFF -> existing ON  : do nothing   (ignore gate open while timer is running)
+   */
+  private handleTimer(incomingSwitchVal: number, isCurrentOnSignal: boolean, duration: number){
+    if (this.waitTimerOn) return null;
+    if (isCurrentOnSignal) return null;
+    if (incomingSwitchVal === 0) return null;
+
+    this.waitTimerOn = true;
+    setTimeout(() => {
+      console.log("| timer done");
+      this.waitTimerOn = false;
+    }, duration);
+  }
 
   public builder(node: Node) {
     super.defaultBuilder(node);
@@ -33,7 +51,7 @@ export class ControlReteNodeFactory extends DataflowReteNodeFactory {
         .addInput(valueInput)
         .addInput(binaryInput)
         .addControl(new DropdownListControl(this.editor, "controlOperator", node, dropdownOptions, true))
-        .addControl(new NumControl(this.editor, "wait_ms", node, true, "wait", 10, 1, ["ms"], "wait"))
+        .addControl(new NumControl(this.editor, "waitDuration", node, true, "wait", 2000, 1, ["ms"], "wait"))
         .addControl(new PlotButtonControl(this.editor, "plot", node))
         .addControl(new ValueControl(this.editor, "nodeValue", node))
         .addOutput(out) as any;
@@ -42,21 +60,21 @@ export class ControlReteNodeFactory extends DataflowReteNodeFactory {
 
   public worker(node: NodeData, inputs: any, outputs: any) {
     const funcName = node.data.controlOperator as string;
-    const hasWait = funcName.includes("Wait");
     const recents: number[] | undefined = (node.data.recentValues as any)?.nodeValue;
     const lastRecentValue = recents?.[recents.length - 1];
     const priorValue = lastRecentValue == null ? null : lastRecentValue;
-    const waitTimeDuration = node.data.wait_ms;
+    const isWaitFunc = funcName.includes("Wait");
     const n1 :number = inputs.num1.length ? inputs.num1[0] : node.data.num1;
     const n2 :number = inputs.num2 ? (inputs.num2.length ? inputs.num2[0] : node.data.num2) : 0;
 
     let result = 0;
     let cResult = 0;
 
+    isWaitFunc && this.handleTimer(inputs.num1[0], node.data.gateActive as boolean, node.data.waitDuration as number);
+
     // for setting classes on node
-    node.data.gateActive = n1 === 1;
-    node.data.hasWait = hasWait;
-    node.data.waitActive = hasWait && this.timerRunning;
+    node.data.hasWait = isWaitFunc;
+    node.data.gateActive = determineGateActive(n1, isWaitFunc, this.waitTimerOn);
 
     // requires value in n2 (except for case of Output Zero)
     if (isNaN(n2)) {
@@ -67,13 +85,13 @@ export class ControlReteNodeFactory extends DataflowReteNodeFactory {
 
     // For each function, evaluate given inputs and node state
     // TODO - check and see if this gets serialized, and if so, how to handle legacy funcNames on load
-    if (funcName === "Hold 0" || funcName === "Output Zero"){
+    if (funcName === "Hold 0" || funcName.includes("Output Zero")){
       this.heldValue = null;
       result = node.data.gateActive ? 0 : n2;
       cResult = 0;
     }
 
-    else if (funcName === "Hold Current"){
+    else if (funcName.includes("Hold Current")){
       if (node.data.gateActive){
         // Already a number here? Maintain. Otherwise set the new held value;
         this.heldValue = typeof this.heldValue === "number" ? this.heldValue : n2;
@@ -87,7 +105,7 @@ export class ControlReteNodeFactory extends DataflowReteNodeFactory {
       }
     }
 
-    else if (funcName === "Hold Prior"){
+    else if (funcName.includes("Hold Prior")){
       if (node.data.gateActive){
         // Already a number here? Maintain. Otherwise set the new held value;
         this.heldValue = typeof this.heldValue === "number" ? this.heldValue : priorValue;
@@ -101,12 +119,7 @@ export class ControlReteNodeFactory extends DataflowReteNodeFactory {
       }
     }
 
-    // prepare string to display on node
-    const resultString = getNumDisplayStr(result);
-    const cResultString = getNumDisplayStr(cResult);
-    const onString = `on → ${cResultString}`;
-    const offString = `off → ${resultString}`;
-    const resultSentence = node.data.gateActive ? onString : offString;
+    const resultSentence = getHoldNodeResultString(node.data, result, cResult) || "";
 
     // operate rete
     if (this.editor) {

--- a/src/plugins/dataflow/nodes/node-states.scss
+++ b/src/plugins/dataflow/nodes/node-states.scss
@@ -34,7 +34,7 @@
     transform: rotate(0deg);
   }
 
-  div[title="wait_ms"] {
+  div[title="waitDuration"] {
     display: none;
   }
 }
@@ -66,7 +66,7 @@
 }
 
 .node.control.wait-option-selected {
-  div[title="wait_ms"] {
+  div[title="waitDuration"] {
     display: block;
   }
 }

--- a/src/plugins/dataflow/nodes/node-states.scss
+++ b/src/plugins/dataflow/nodes/node-states.scss
@@ -79,6 +79,7 @@
 
 // temporary for dev
 .wait-active {
-  border:5px dotted red !important;
+  // make all colors faded and increase opacity
+  filter: opacity(0.5);
 }
 

--- a/src/plugins/dataflow/nodes/node-states.scss
+++ b/src/plugins/dataflow/nodes/node-states.scss
@@ -33,6 +33,10 @@
     transition: all .2s ease-in-out;
     transform: rotate(0deg);
   }
+
+  div[title="wait_ms"] {
+    display: none;
+  }
 }
 
 .node.control.gate-active .binary .socket {
@@ -55,8 +59,26 @@
   }
 }
 
+.node.control.has-flow-in.wait-option-selected .inputs {
+  .number2 .socket::before {
+    top: 93px;
+  }
+}
+
+.node.control.wait-option-selected {
+  div[title="wait_ms"] {
+    display: block;
+  }
+}
+
 .node.control.has-flow-in.gate-active .inputs {
   .number2 .socket::before {
     animation: none;
   }
 }
+
+// temporary for dev
+.wait-active {
+  border:5px dotted red !important;
+}
+

--- a/src/plugins/dataflow/nodes/utilities/view-utilities.ts
+++ b/src/plugins/dataflow/nodes/utilities/view-utilities.ts
@@ -75,3 +75,20 @@ export function getInsertionOrder(editor: NodeEditor, id: number) {
   return index + 1;
 }
 
+export function getHoldNodeResultString(nodeData: any, result: number, calcResult: number){
+  const resultString = getNumDisplayStr(result);
+  const cResultString = getNumDisplayStr(calcResult);
+  const waitString = `waiting → ${cResultString}`;
+  const onString = `on → ${cResultString}`;
+  const offString = `off → ${resultString}`;
+
+  if (nodeData.gateActive) return nodeData.hasWait ? waitString : onString;
+  else return offString;
+}
+
+export function determineGateActive(switchVal: number, isWaitFunc: boolean, timerOn: boolean){
+  if (!isWaitFunc) return switchVal === 1;
+  if (isWaitFunc && timerOn) return true;
+  return false;
+}
+


### PR DESCRIPTION
PT-187091498

This adds a set of "wait" functions to the existing "hold" node, as specified in PT-187091498

- adds waitDuration to control node model
- adds a wait duration input to control node
- hide and show input based on function choice
- if node function is set to one of "wait" family and node gets a an on signal, it will turn on the timer (if the on signal is arriving at a node with an inactive gate)
- timer is set to the duration in the input
- until timer expires, the gate will remain active, no matter what value arrives at switch