### PR TITLE
handle node positions

### DIFF
--- a/cypress/e2e/functional/tile_tests/dataflow_tool_spec.js
+++ b/cypress/e2e/functional/tile_tests/dataflow_tool_spec.js
@@ -77,15 +77,15 @@ context('Dataflow Tool Tile', function () {
     dataflowToolTile.getNodeInput().should("not.exist");
     dataflowToolTile.getNodeOutput().should("exist");
 
-    // cy.log("verify zoom in & out");
-    // dataflowToolTile.getFlowtool().children().invoke("attr", "style").then(scale => {
-    //   dataflowToolTile.getZoomInButton().click();
-    //   dataflowToolTile.verifyZoomIn(scale);
-    // });
-    // dataflowToolTile.getFlowtool().children().invoke("attr", "style").then(scale => {
-    //   dataflowToolTile.getZoomOutButton().click();
-    //   dataflowToolTile.verifyZoomOut(scale);
-    // });
+    cy.log("verify zoom in & out");
+    dataflowToolTile.getFlowtool().children().invoke("attr", "style").then(scale => {
+      dataflowToolTile.getZoomInButton().click();
+      dataflowToolTile.verifyZoomIn(scale);
+    });
+    dataflowToolTile.getFlowtool().children().invoke("attr", "style").then(scale => {
+      dataflowToolTile.getZoomOutButton().click();
+      dataflowToolTile.verifyZoomOut(scale);
+    });
 
     cy.log("can delete number node");
     dataflowToolTile.getDeleteNodeButton(numberNode).click();
@@ -284,7 +284,7 @@ context('Dataflow Tool Tile', function () {
     dataflowToolTile.getDeleteNodeButton(logicNode).click();
     dataflowToolTile.getNode(logicNode).should("not.exist");
   });
-  it.only("Transform and Control Nodes", () => {
+  it("Transform and Control Nodes", () => {
     const transformNode = "transform";
     beforeTest();
     clueCanvas.addTile("dataflow");

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -357,13 +357,18 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
       connection.addPreset(ConnectionPresets.classic.setup());
 
       editor.use(area);
+      // Because these connection and render plugins are added before the notifyAboutExistingObjects,
+      // there is a flash as the nodes move into place. The plugins can't be added afterwards because
+      // they don't look at the existing nodes when they are added. We might have to modify Rete to
+      // remove this flash
       area.use(connection);
       area.use(render);
 
       AreaExtensions.simpleNodesOrder(area);
 
       // Notify after the area, connection, and render plugins have been configured
-      editor.notifyAboutExistingObjects();
+      await editor.notifyAboutExistingObjects();
+
 
       // Reprocess when connections are changed
       // And also count the serial nodes some of which only get counted if they are
@@ -376,14 +381,15 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
         return context;
       });
 
-      // area.nodeViews
-      // await area.translate(a.id, { x: 0, y: 0 });
-      // await area.translate(b.id, { x: 270, y: 0 });
-
-
       setTimeout(() => {
-        // wait until nodes rendered because they dont have predefined width and height
-        AreaExtensions.zoomAt(area, editor.getNodes());
+        // The zoomAt call was centering the origin of the dataflow canvas.
+        // This messes up the default node placement, and would likely mess up saved state.
+        // By removing this, we aren't going to be automatically making sure all of the nodes are visible
+        // AreaExtensions.zoomAt(area, editor.getNodes());
+
+        // In our Rete v1 implementation the origin always started at the top left of the component.
+        // When a user translated the canvas this translation was saved in the file, but
+        // it seems like it is just ignored when the program is loaded back in again.
 
         // This is needed to initialize things like the value control's sentence
         // It was having problems when called earlier

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -620,11 +620,18 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
   }
 
   private zoomIn = () => {
+    const { k } = this.programEditor.area.area.transform;
+    this.setZoom(Math.min(MAX_ZOOM, k + .05));
   };
 
   private zoomOut = () => {
+    const { k } = this.programEditor.area.area.transform;
+    this.setZoom(Math.max(MIN_ZOOM, k - .05));
   };
 
-  private setZoom = (zoom: number) => {
+  private setZoom = async (zoom: number) => {
+    await this.programEditor.area.area.zoom(zoom);
+    const { transform } = this.programEditor.area.area;
+    this.props.onZoomChange(transform.x, transform.y, transform.k);
   };
 }

--- a/src/plugins/dataflow/components/ui/dataflow-drop-zone.tsx
+++ b/src/plugins/dataflow/components/ui/dataflow-drop-zone.tsx
@@ -31,19 +31,18 @@ export const DataflowDropZone = observer((
       if (event.over?.id === droppableId && isNodeDraggableId(draggableId)) {
         const nodeType = getNodeType(draggableId);
         const pointerEvent = event.activatorEvent as PointerEvent;
+
         const clientX = pointerEvent.clientX + event.delta.x;
         const clientY = pointerEvent.clientY + event.delta.y;
-        // const { x, y, k } = programEditor.view.area.transform;
-        // const boundingBox = programEditor.view.area.container.getBoundingClientRect();
-        // const rawX = clientX - boundingBox.x;
-        // const rawY = clientY - boundingBox.y;
-        // const position: [number, number] = [
-        //   (rawX - x) / k,
-        //   (rawY - y) / k
-        // ];
+        const reteArea = programEditor.area.area;
+
+        // This was taken from Rete's Area.setPointerFrom
+        const { x, y } = reteArea.content.getPointerFrom({clientX, clientY} as MouseEvent);
+        const { k } = reteArea.transform;
+        const position: [number, number] = [ x / k, y / k ];
+
         if (nodeType) {
-          // addNode(nodeType, position);
-          addNode(nodeType);
+          addNode(nodeType, position);
         }
       }
     }

--- a/src/plugins/dataflow/model/dataflow-program-model.ts
+++ b/src/plugins/dataflow/model/dataflow-program-model.ts
@@ -42,6 +42,12 @@ export const DataflowNodeModel = types.
       TransformNodeModel,
     )
   })
+  .actions(self => ({
+    setPosition(position: {x: number, y: number}) {
+      self.x = position.x;
+      self.y = position.y;
+    }
+  }))
   .preProcessSnapshot((snapshot: any) => {
     // Turn position into x and y because MST has weird issues with arrays
     if (Array.isArray(snapshot.position)) {

--- a/src/plugins/dataflow/nodes/dataflow-node-plot.tsx
+++ b/src/plugins/dataflow/nodes/dataflow-node-plot.tsx
@@ -91,7 +91,6 @@ function lineData(model: IBaseNodeModel) {
   Object.keys(model.watchedValues).forEach((valueKey: string) => {
     const recentValues = model.recentValues?.get(valueKey);
     if (recentValues !== undefined) {
-      console.log("lineData", recentValues);
       const customOptions = model.watchedValues?.[valueKey] || {};
       const dataset: ChartDataSets = {
         backgroundColor: NodePlotColor,

--- a/src/plugins/dataflow/nodes/node-editor-mst.ts
+++ b/src/plugins/dataflow/nodes/node-editor-mst.ts
@@ -25,6 +25,7 @@ import { SensorNode } from "./sensor-node";
 import { TransformNode } from "./transform-node";
 import { TimerNode } from "./timer-node";
 import { ControlNode } from "./control-node";
+import { getNewNodePosition } from "./utilities/view-utilities";
 
 export class NodeEditorMST extends NodeEditor<Schemes> implements INodeServices {
   private reteNodesMap: Record<string, Schemes['Node']> = {};
@@ -49,6 +50,35 @@ export class NodeEditorMST extends NodeEditor<Schemes> implements INodeServices 
     AreaExtensions.selectableNodes(this.area, AreaExtensions.selector(), {
       accumulating: AreaExtensions.accumulateOnCtrl()
     });
+
+    this.area.addPipe((context) => {
+      if (context.type !== "nodedragged") return context;
+
+      const id = context.data.id;
+      const nodeView = this.area.nodeViews.get(id);
+
+      // This should not happen, but it is possible in theory
+      if (!nodeView) return context;
+
+      const nodeModel = mstProgram.nodes.get(id);
+
+      // This should also not happen but seems more likely
+      if (!nodeModel) {
+        console.warn("Cannot find MST node model for a dragged Rete node");
+        return context;
+      }
+
+      nodeModel.setPosition(nodeView.position);
+      return context;
+    });
+
+    // Useful for debugging:
+    // this.area.addPipe((context) => {
+    //   if (["pointermove", "render", "rendered"].includes(context.type)) return context;
+
+    //   console.warn("area event", context, this.area.area.transform);
+    //   return context;
+    // });
 
     // onPatch(mstProgram.nodes, (patch, reversePatch) => {
     //   console.log("nodes patch", patch);
@@ -92,9 +122,22 @@ export class NodeEditorMST extends NodeEditor<Schemes> implements INodeServices 
     });
   }
 
-  public notifyAboutExistingObjects() {
-    this.getNodes().forEach(node => this.emit({ type: 'nodecreated', data: node }));
-    this.getConnections().forEach(connection => this.emit({ type: 'connectioncreated', data: connection}));
+  public async notifyAboutExistingObjects() {
+    for (const node of this.getNodes()) {
+      // We need to wait for this before we add connections and translate the nodes
+      await this.emit({ type: 'nodecreated', data: node });
+    }
+    for (const connection of this.getConnections()) {
+      await this.emit({ type: 'connectioncreated', data: connection});
+    }
+
+    // FIXME: this causes a flash when the nodes move into position. I think the
+    // right fix is to delay the creation of the render plugin until all of the
+    // nodes have been positioned. But I'm not sure if the render plugin is
+    // smart enough to look at existing nodes or it just watches events.
+    for (const [id, nodeModel] of this.mstProgram.nodes) {
+      await this.area.translate(id, { x: nodeModel.x, y: nodeModel.y });
+    }
   }
 
   public process = () => {
@@ -197,13 +240,15 @@ export class NodeEditorMST extends NodeEditor<Schemes> implements INodeServices 
     return new constructor(id, model, this);
   }
 
-  public createAndAddNode(nodeType: string, position?: [number, number]) {
+  public async createAndAddNode(nodeType: string, position?: [number, number]) {
     const id = uniqueId();
+    const newPosition = position ?? getNewNodePosition(this);
+    console.log("createAndAddNode", nodeType, newPosition);
     this.mstProgram.addNodeSnapshot({
       id,
       name: nodeType,
-      x: position?.[0] || 0,
-      y: position?.[1] || 0,
+      x: newPosition[0],
+      y: newPosition[1],
       data: { type: nodeType }
     });
 
@@ -214,7 +259,9 @@ export class NodeEditorMST extends NodeEditor<Schemes> implements INodeServices 
     // is changed.
     // This is not waiting for the emit before calling the process.
     // we might need to add it
-    this.emit({ type: 'nodecreated', data: node });
+    await this.emit({ type: 'nodecreated', data: node });
+
+    this.area.translate(id, {x: newPosition[0], y: newPosition[1]});
 
     // run the process command so this newly added node can update any controls like the
     // value control.

--- a/src/plugins/dataflow/nodes/node-editor-mst.ts
+++ b/src/plugins/dataflow/nodes/node-editor-mst.ts
@@ -47,6 +47,9 @@ export class NodeEditorMST extends NodeEditor<Schemes> implements INodeServices 
 
     this.area = new AreaPlugin<Schemes, AreaExtra>(div);
 
+    // Disable the zoom handler which zooms on wheel and double click
+    this.area.area.setZoomHandler(null);
+
     AreaExtensions.selectableNodes(this.area, AreaExtensions.selector(), {
       accumulating: AreaExtensions.accumulateOnCtrl()
     });

--- a/src/plugins/dataflow/nodes/utilities/view-utilities.ts
+++ b/src/plugins/dataflow/nodes/utilities/view-utilities.ts
@@ -1,4 +1,24 @@
+import { NodeEditorMST } from "../node-editor-mst";
+
 export const kEmptyValueString = "__";
+
+export function getNewNodePosition(editor: NodeEditorMST) {
+  const kNodesPerColumn = 5;
+  const kNodesPerRow = 4;
+  const kColumnWidth = 200;
+  const kRowHeight = 90;
+  const kLeftMargin = 40;
+  const kTopMargin = 5;
+  const kColumnOffset = 15;
+
+  const numNodes = editor.getNodes().length;
+  const { k } = editor.area.area.transform;
+  const nodePos: [number, number] =
+    [kLeftMargin * (1 / k) + Math.floor((numNodes % (kNodesPerColumn * kNodesPerRow)) / kNodesPerColumn)
+      * kColumnWidth + Math.floor(numNodes / (kNodesPerColumn * kNodesPerRow)) * kColumnOffset,
+    kTopMargin + numNodes % kNodesPerColumn * kRowHeight];
+  return nodePos;
+}
 
 export function getNumDisplayStr(n: number){
   return isNaN(n) ? kEmptyValueString : Number(n).toFixed(3).replace(/\.?0+$/, "");


### PR DESCRIPTION
- when a node is dragged and dropped from the toolbar, create it in the drop location
- when a node item on the toolbar is clicked, add it to a unique position
- when a node is dragged update the position in its MST model
- when the tile is loaded translate the nodes into the position based on the MST model
- update the origin of the Rete canvas so it starts at 0,0 instead of the center of the diagram
- remove an extraneous console log