### PR TITLE
Graph scaling fix

### DIFF
--- a/src/plugins/graph/adornments/connecting-lines/connecting-lines.tsx
+++ b/src/plugins/graph/adornments/connecting-lines/connecting-lines.tsx
@@ -1,68 +1,7 @@
-import { useEffect } from "react";
-import { line, curveLinear, select } from "d3";
 import { IConnectingLinesModel } from "./connecting-lines-model";
-import { DotsElt } from "../../d3-types";
 import { IDotsRef } from "../../graph-types";
-import { isNumericAxisModel } from "../../imports/components/axis/models/axis-model";
-import { useGraphModelContext } from "../../hooks/use-graph-model-context";
-import { lightenColor } from "../../../../utilities/color-utils";
-import { mstAutorun } from "../../../../utilities/mst-autorun";
-import { IGraphModel } from "../../models/graph-model";
-import { GraphLayout, useGraphLayoutContext } from "../../models/graph-layout";
 
-function cleanUpPaths(el: DotsElt){
-  const dotArea = select(el);
-  const anyFoundPath = dotArea.selectAll("path");
-  if (anyFoundPath) anyFoundPath.remove();
-}
-
-function drawPath(el: DotsElt, points: Iterable<[number, number]>, color: string) {
-  const curve = line().curve(curveLinear);
-  const dotArea = select(el);
-  const newPath = dotArea.append("path");
-  newPath
-    .attr('stroke', color)
-    .attr('stroke-width', 2)
-    .attr('d', curve(points))
-    .attr('fill', 'none');
-  // bring path group to the top/front within the svg
-  const parentSvg = newPath.node()?.parentNode;
-  parentSvg?.insertBefore(newPath.node() as Node, parentSvg.firstChild);
-}
-
-export const getPointLocations = (graphModel: IGraphModel, layout: GraphLayout) => {
-  const result: Record<string, Iterable<[number, number]>> = {};
-  // Outer loop over layer
-  for (const layer of graphModel.layers) {
-    const dataConfig = layer.config;
-    if (dataConfig.attributeType("x") !== "numeric") continue; // Never connect categorical points
-    const dataset = dataConfig.dataset;
-    if (dataConfig && dataset && layout) {
-      const caseIds = dataset.cases.map(c => c.__id__) ?? [];
-      const xAttrID = dataConfig.xAttributeID;
-      // Loop over plotNum (which series in the layer)
-      for (let plotNum = 0; plotNum < dataConfig.yAttributeDescriptions.length; ++plotNum) {
-        const yAttrID = dataConfig.yAttributeID(plotNum);
-        if (dataConfig.attributeTypeForID(yAttrID) !== "numeric") continue; // categorical
-        const series: [number, number][] = [];
-        // Inner loop over cases in that series
-        caseIds.forEach((caseId) => {
-          const xValue = dataset.getNumeric(caseId, xAttrID);
-          const yValue = dataset.getNumeric(caseId, yAttrID);
-          if (xValue!==undefined && yValue!==undefined) {
-            const xLoc = layout.getAxisMultiScale("bottom").getScreenCoordinate({ cell: 0, data: xValue });
-            const yLoc = layout.getAxisMultiScale("left").getScreenCoordinate({ cell: 0, data: yValue });
-            if (isFinite(xLoc) && isFinite(yLoc)) {
-              series.push([xLoc, yLoc]);
-            }
-          }
-        });
-        result[yAttrID] = series;
-      }
-    }
-  }
-  return result;
-};
+// Leaving this here for the moment since legacy models still include the adornment.
 
 interface IConnectLines {
   model: IConnectingLinesModel
@@ -71,32 +10,5 @@ interface IConnectLines {
 }
 
 export const ConnectingLines = function ConnectingLines({dotsRef}: IConnectLines) {
-  const graphModel = useGraphModelContext();
-  const layout = useGraphLayoutContext();
-
-  useEffect(() => {
-
-    mstAutorun(() => {
-      const foundLinePoints = getPointLocations(graphModel, layout);
-      // access the axis domains so that a render will be triggered when they change
-      const xAxis = graphModel.getAxis("bottom");
-      const xDomain = isNumericAxisModel(xAxis) ? xAxis.domain : undefined;
-      const yAxis = graphModel.getAxis("left");
-      const yDomain = isNumericAxisModel(yAxis) ? yAxis.domain : undefined;
-      const domains = { xDomain, yDomain }; // eslint-disable-line unused-imports/no-unused-vars
-
-      cleanUpPaths(dotsRef.current);
-      //first clean up paths then render each line
-      Object.keys(foundLinePoints).forEach(attributeId => {
-        const singleLinePoints = foundLinePoints[attributeId];
-        const color = graphModel.getColorForId(attributeId);
-        const adjustedColor = lightenColor(color, 0.5);
-        drawPath(dotsRef.current as DotsElt, singleLinePoints, adjustedColor);
-      });
-    },
-    { name: "ConnectingLines" },
-    graphModel);
-  }, [dotsRef, graphModel, layout]);
-
   return null;
 };

--- a/src/plugins/graph/components/casedots.tsx
+++ b/src/plugins/graph/components/casedots.tsx
@@ -102,7 +102,8 @@ export const CaseDots = function CaseDots(props: PlotProps) {
     setPointCoordinates({
       dataConfiguration, pointRadius, selectedPointRadius, dotsRef, selectedOnly,
       getColorForId: graphModel.getColorForId,
-      pointColor, pointStrokeColor, getScreenX, getScreenY, getLegendColor, enableAnimation
+      pointColor, pointStrokeColor, getScreenX, getScreenY, getLegendColor, enableAnimation,
+      enableConnectors: false
     });
   }, [dataConfiguration, graphModel, layout, dotsRef, enableAnimation]);
 

--- a/src/plugins/graph/components/chartdots.tsx
+++ b/src/plugins/graph/components/chartdots.tsx
@@ -212,7 +212,8 @@ export const ChartDots = function ChartDots(props: PlotProps) {
       dataConfiguration, pointRadius, selectedPointRadius: graphModel.getPointRadius('select'),
       getColorForId: graphModel.getColorForId,
       dotsRef, selectedOnly, pointColor, pointStrokeColor,
-      getScreenX, getScreenY, getLegendColor, enableAnimation
+      getScreenX, getScreenY, getLegendColor, enableAnimation,
+      enableConnectors: false
     });
   }, [dataConfiguration, primaryAxisPlace, primaryAttrRole, secondaryAttrRole, graphModel, dotsRef,
     extraPrimaryAttrRole, extraSecondaryAttrRole, pointColor,

--- a/src/plugins/graph/components/dotplotdots.tsx
+++ b/src/plugins/graph/components/dotplotdots.tsx
@@ -262,7 +262,8 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
         getColorForId: graphModel.getColorForId,
         selectedPointRadius: graphModel.getPointRadius('select'),
         dotsRef, selectedOnly, pointColor, pointStrokeColor,
-        getScreenX, getScreenY, getLegendColor, enableAnimation
+        getScreenX, getScreenY, getLegendColor, enableAnimation,
+        enableConnectors: false
       });
     },
     [graphModel, dataConfiguration, layout, primaryAttrRole, secondaryAttrRole, dataset, dotsRef,

--- a/src/plugins/graph/components/scatterdots.tsx
+++ b/src/plugins/graph/components/scatterdots.tsx
@@ -14,18 +14,20 @@ import {
   setPointSelection
 } from "../utilities/graph-utils";
 import { useGraphLayerContext } from "../hooks/use-graph-layer-context";
+import { useGraphSettingsContext } from "../hooks/use-graph-settings-context";
 
 export const ScatterDots = function ScatterDots(props: PlotProps) {
   const {dotsRef, enableAnimation} = props,
     graphModel = useGraphModelContext(),
     layer = useGraphLayerContext(),
     dataConfiguration = useDataConfigurationContext(),
+    layout = useGraphLayoutContext(),
+    { connectPointsByDefault } = useGraphSettingsContext(),
     dataset = dataConfiguration?.dataset,
     secondaryAttrIDsRef = useRef<string[]>([]),
     pointRadiusRef = useRef(0),
     selectedPointRadiusRef = useRef(0),
     dragPointRadiusRef = useRef(0),
-    layout = useGraphLayoutContext(),
     legendAttrID = dataConfiguration?.attributeID('legend') as string,
     yScaleRef = useRef<ScaleNumericBaseType>(),
     target = useRef<any>(),
@@ -146,11 +148,12 @@ export const ScatterDots = function ScatterDots(props: PlotProps) {
       dataConfiguration, dotsRef, pointRadius: pointRadiusRef.current,
       selectedPointRadius: selectedPointRadiusRef.current,
       selectedOnly, getScreenX, getScreenY, getLegendColor,
-      getColorForId: graphModel.getColorForId, enableAnimation, pointColor, pointStrokeColor
+      getColorForId: graphModel.getColorForId, enableAnimation, pointColor, pointStrokeColor,
+      enableConnectors: connectPointsByDefault
     });
     refreshDragHandlers();
   }, [dataConfiguration, dataset, dotsRef, layout, legendAttrID,
-    enableAnimation, graphModel, yScaleRef, refreshDragHandlers]);
+    enableAnimation, graphModel, yScaleRef, refreshDragHandlers, connectPointsByDefault]);
 
   // const refreshPointPositionsSVG = useCallback((selectedOnly: boolean) => {
   //   const xAttrID = dataConfiguration?.attributeID('x') ?? '',

--- a/src/plugins/graph/models/graph-controller.ts
+++ b/src/plugins/graph/models/graph-controller.ts
@@ -103,18 +103,19 @@ export class GraphController {
   handleAttributeAssignment(dataConfiguration: IDataConfigurationModel, graphPlace: GraphPlace, attrID: string) {
     const {graphModel, layout} = this,
       appConfig = getAppConfig(graphModel),
-      emptyPlotIsNumeric = appConfig?.getSetting("emptyPlotIsNumeric", "graph");
+      emptyPlotIsNumeric = appConfig?.getSetting("emptyPlotIsNumeric", "graph"),
+      isPrimaryLayer = graphModel?.layers[0].config === dataConfiguration;
     if (!(graphModel && layout)) {
       return;
     }
     if (['plot', 'legend'].includes(graphPlace)) {
       // Since there is no axis associated with the legend and the plotType will not change, we bail
       return;
-    } else if (graphPlace === 'yPlus') {
-      // The yPlus attribute utilizes the left numeric axis for plotting but doesn't change anything else
-      const yAxisModel = graphModel.getAxis('left');
+    } else if (!isPrimaryLayer || graphPlace === 'yPlus') {
+      // The first trace of the primary (0th) layer controls the plot type.
+      // Other data traces just rescale without altering anything else.
       if (!graphModel.lockAxes) {
-        yAxisModel && setNiceDomain(graphModel.numericValuesForYAxis, yAxisModel);
+        this.autoscaleAllAxes();
       }
       this.callMatchCirclesToData();
       return;

--- a/src/plugins/graph/models/graph-controller.ts
+++ b/src/plugins/graph/models/graph-controller.ts
@@ -161,7 +161,9 @@ export class GraphController {
             graphModel.setAxis(place, newAxisModel);
             dataConfiguration.setAttributeType(attrRole, 'numeric');
             layout.setAxisScaleType(place, 'linear');
-            setNiceDomain(graphModel.numericValuesForAttrRole(attrRole), newAxisModel);
+          }
+          if (!graphModel.lockAxes) {
+            setNiceDomain(graphModel.numericValuesForAttrRole(attrRole), graphModel.getAxis(place)!, false);
           }
         }
           break;

--- a/src/plugins/graph/models/graph-model.ts
+++ b/src/plugins/graph/models/graph-model.ts
@@ -24,7 +24,6 @@ import {
   clueGraphColors, defaultBackgroundColor, defaultPointColor, defaultStrokeColor
 } from "../../../utilities/color-utils";
 import { AdornmentModelUnion } from "../adornments/adornment-types";
-import { ConnectingLinesModel } from "../adornments/connecting-lines/connecting-lines-model";
 import { isSharedCaseMetadata, SharedCaseMetadata } from "../../../models/shared/shared-case-metadata";
 import { getDotId } from "../utilities/graph-utils";
 import { GraphLayerModel, IGraphLayerModel } from "./graph-layer-model";
@@ -811,11 +810,6 @@ export function createGraphModel(snap?: IGraphModelSnapshot, appConfig?: AppConf
     yAttributeLabel: axisLabels && axisLabels.left,
     ...snap
   });
-  const connectByDefault = appConfig?.getSetting("connectPointsByDefault", "graph");
-  if (connectByDefault) {
-    const cLines = ConnectingLinesModel.create();
-    createdGraphModel.addAdornment(cLines);
-  }
 
   return createdGraphModel;
 }


### PR DESCRIPTION
PT-187406957

Calls scaling when attributes are changed on any axis, including when new datasets are added.
When a dataset is added in a new layer, however, avoids resetting the graph type.  Newly-added manual points layer was registering as 'empty', and thus resetting the axes to defaults.

To fix some related bugs, and generally simplify the code, this PR also replaces the implementation of the connecting lines between points.  Previously this was an 'adornment', drawn over the top of the graph in a completely separate code path. With this update, the lines from the previous point is drawn as part of each point. Rather than being deleted and redrawn on every change, they are also animated as part of the animation that moves the points.