### PR TITLE
readOnly Data flow support

### DIFF
--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import ReactDOM from "react-dom";
 import "regenerator-runtime/runtime";
 import { inject, observer } from "mobx-react";
 import { IDisposer, onSnapshot } from "mobx-state-tree";
@@ -412,10 +411,19 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
   }
 
   private destroyEditor() {
-    this.reactElements.forEach(el => {
-      ReactDOM.unmountComponentAtNode(el);
+    const {area} = this.programEditor;
+    // This should unmount the React components.
+    // As far as I can tell Rete doesn't have cleaup or destroy function to unmount
+    // all of the nodes and connections that it creates React roots for. The loops
+    // below do this.  If a node or connection is removed, then all of its
+    // sub parts (controls and sockets) are also unmounted.
+    area.nodeViews.forEach((view, id) => {
+      area.removeNodeView(id);
     });
-    this.reactElements = [];
+    area.connectionViews.forEach((view, id) => {
+      area.removeConnectionView(id);
+    });
+
     this.reactNodeElements.clear();
     this.programEditor.disposeNodes();
   }

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -577,8 +577,6 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
   };
 
   private tick = () => {
-    console.log("DataFlow.tick");
-
     const { runnable, tileContent: tileModel, playBackIndex, programMode,
             isPlaying,  updateRecordIndex, updatePlayBackIndex } = this.props;
 

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -417,6 +417,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
     });
     this.reactElements = [];
     this.reactNodeElements.clear();
+    this.programEditor.disposeNodes();
   }
 
   private updateProgramEditor = async (snapshot: DataflowProgramSnapshotOut) => {
@@ -436,6 +437,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
       // Process nodes that were deleted
       for (const [id] of this.programEditor.area.nodeViews) {
         if (!snapshot.nodes[id]) {
+          (this.programEditor.reteNodesMap[id] as IBaseNode)?.dispose();
           await this.programEditor.emit({ type: 'noderemoved', data: { id } as any });
         }
       }

--- a/src/plugins/dataflow/nodes/base-node.ts
+++ b/src/plugins/dataflow/nodes/base-node.ts
@@ -140,6 +140,7 @@ export type NodeClass = new (id: string | undefined, model: any, services: INode
 export type IBaseNode = Schemes['Node'] & {
   model: IBaseNodeModel;
   onTick(): boolean;
+  dispose(): void;
   process(): void;
   select(): void;
   isConnected(inputKey: string): boolean;
@@ -189,6 +190,12 @@ export class BaseNode<
    * @returns whether the nodes need to reprocessed
    */
   onTick() { return false; }
+
+  /**
+   * If a node has created reactions or other things that need to be cleaned up,
+   * do so here.
+   */
+  dispose() {}
 
   process() {
     this.services.process();

--- a/src/plugins/dataflow/nodes/base-node.ts
+++ b/src/plugins/dataflow/nodes/base-node.ts
@@ -153,6 +153,7 @@ export type IBaseNode = Schemes['Node'] & {
   logNodeEvent(
     operation: string
   ): void;
+  readOnly?: boolean;
 }
 
 export class BaseNode<
@@ -191,6 +192,10 @@ export class BaseNode<
 
   process() {
     this.services.process();
+  }
+
+  get readOnly() {
+    return this.services.readOnly;
   }
 
   /**

--- a/src/plugins/dataflow/nodes/controls/demo-outputs/humidifier-animation.tsx
+++ b/src/plugins/dataflow/nodes/controls/demo-outputs/humidifier-animation.tsx
@@ -27,6 +27,7 @@ export const HumidifierAnimation: React.FC<IProps> = ({nodeValue}) => {
     intervalRef.current = _interval;
   }
 
+  // Remove the animation when the component is disposed
   useEffect(() => {
     return removeAnimation;
   }, []);

--- a/src/plugins/dataflow/nodes/controls/dropdown-list-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/dropdown-list-control.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, SVGProps, useCallback, useRef, useState } from "react";
-import { computed, makeObservable, observable } from "mobx";
+import { action, computed, makeObservable, observable } from "mobx";
 import { observer } from "mobx-react";
 import { ClassicPreset } from "rete";
 import classNames from "classnames";
@@ -162,6 +162,7 @@ export class DropdownListControl<
     return this.optionArray;
   }
 
+  @action
   public setOptions(options: ListOption[]) {
     if (this.optionsFunc) {
       console.warn("This dropdown list is using an options function instead of array");

--- a/src/plugins/dataflow/nodes/controls/input-value-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/input-value-control.tsx
@@ -2,7 +2,7 @@ import { ClassicPreset } from "rete";
 import "./value-control.sass";
 import React from "react";
 import { observer } from "mobx-react";
-import { action, computed, makeObservable, observable } from "mobx";
+import { computed, makeObservable } from "mobx";
 import { IBaseNode, IBaseNodeModel } from "../base-node";
 import { MinigraphOptions, defaultMinigraphOptions } from "../dataflow-node-plot";
 import { PlotButtonControl, PlotButtonControlComponent } from "./plot-button-control";
@@ -15,6 +15,7 @@ export class InputValueControl<
   Key extends keyof NodeType['model'] & string
 >
   extends ClassicPreset.Control
+  implements IInputValueControl
 {
   // In Dataflow v1 setting the value also updated the node data with putData
   // for the given key of the ValueControl. This approach overlapped with the
@@ -24,14 +25,13 @@ export class InputValueControl<
   // So in Dataflow v2 we are just getting rid of the value property and
   // each node will need to explicity save its calculated data in a
   // watchedValue property.
-  @observable _displayMessage = "Undefined";
 
   constructor(
     public node: NodeType,
     public modelKey: Key,
     public label = "",
     public tooltip = "Something", // FIXME: need better default
-    public getDisplayMessage?: () => string
+    public getDisplayMessage: () => string
   ){
     super();
     makeObservable(this);
@@ -39,18 +39,6 @@ export class InputValueControl<
 
   public get model() {
     return this.node.model;
-  }
-
-  @action
-  public setDisplayMessage(message: string) {
-    this._displayMessage = message;
-  }
-
-  get displayMessage() {
-    if (this.getDisplayMessage) {
-      return this.getDisplayMessage();
-    }
-    return this._displayMessage;
   }
 
   @computed
@@ -77,8 +65,7 @@ export interface IInputValueControl {
   modelKey: string;
   label: string;
   tooltip: string;
-  displayMessage: string;
-  setDisplayMessage(message: string): void;
+  getDisplayMessage(): string;
   connected: boolean;
   legendDotStyle: MinigraphOptions;
   plotButtonControl: PlotButtonControl;
@@ -102,7 +89,7 @@ export const InputValueControlComponent: React.FC<{ data: IInputValueControl; }>
         </div>
       </div>
       <div className="display-text">
-        { control.label + control.displayMessage }
+        { control.label + control.getDisplayMessage() }
       </div>
     </div>
   );

--- a/src/plugins/dataflow/nodes/controls/input-value-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/input-value-control.tsx
@@ -24,13 +24,14 @@ export class InputValueControl<
   // So in Dataflow v2 we are just getting rid of the value property and
   // each node will need to explicity save its calculated data in a
   // watchedValue property.
-  @observable displayMessage = "Undefined";
+  @observable _displayMessage = "Undefined";
 
   constructor(
     public node: NodeType,
     public modelKey: Key,
     public label = "",
-    public tooltip = "Something" // FIXME: need better default
+    public tooltip = "Something", // FIXME: need better default
+    public getDisplayMessage?: () => string
   ){
     super();
     makeObservable(this);
@@ -42,7 +43,14 @@ export class InputValueControl<
 
   @action
   public setDisplayMessage(message: string) {
-    this.displayMessage = message;
+    this._displayMessage = message;
+  }
+
+  get displayMessage() {
+    if (this.getDisplayMessage) {
+      return this.getDisplayMessage();
+    }
+    return this._displayMessage;
   }
 
   @computed

--- a/src/plugins/dataflow/nodes/controls/num-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/num-control.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useRef, useState } from "react";
 import { ClassicPreset } from "rete";
+import { observer } from "mobx-react";
 import { useStopEventPropagation } from "./custom-hooks";
 import { IBaseNode } from "../base-node";
 
@@ -67,13 +68,16 @@ export class NumberControl<
 // means we can't configure Rete's type system with this control
 export interface INumberControl {
   id: string;
+  node: IBaseNode;
   setValue(val: number): void;
   getValue(): number;
   label: string;
   tooltip: string;
 }
 
-export const NumberControlComponent: React.FC<{ data: INumberControl }> = (props) => {
+export const NumberControlComponent: React.FC<{ data: INumberControl }> = observer(
+  function NumberControlComponent(props)
+{
   const control = props.data;
 
   // FIXME: the type of inputValue is flipping between a number and a string
@@ -102,6 +106,11 @@ export const NumberControlComponent: React.FC<{ data: INumberControl }> = (props
     }
   }, []);
 
+  // FIXME: in readOnly mode there is a lot of stuff in this component that is
+  // extraneous. A layer is put on top of dataflow that prevents interactions
+  // with the nodes. It would be better to make this more clear somehow.
+  const possiblyReadOnlyInputValue = control.node.readOnly ? control.getValue() : inputValue;
+
   const inputRef = useRef<HTMLInputElement>(null);
   useStopEventPropagation(inputRef, "pointerdown");
   useStopEventPropagation(inputRef, "dblclick");
@@ -114,11 +123,11 @@ export const NumberControlComponent: React.FC<{ data: INumberControl }> = (props
       <input className={`number-input`}
         ref={inputRef}
         type={"text"}
-        value={inputValue}
+        value={possiblyReadOnlyInputValue}
         onKeyPress={handleKeyPress}
         onChange={handleChange}
         onBlur={handleBlur}
       />
     </div>
   );
-};
+});

--- a/src/plugins/dataflow/nodes/controls/num-units-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/num-units-control.tsx
@@ -111,6 +111,7 @@ export class NumberUnitsControl <
 // means we can't configure Rete's type system with this control
 export interface INumberUnitsControl {
   id: string;
+  node: IBaseNode;
   units: string[];
   setValue(val: number): void;
   getValue(): number;
@@ -165,6 +166,11 @@ export const NumberUnitsControlComponent: React.FC<{ data: INumberUnitsControl; 
     control.logEvent("unitdropdownselection");
   }, [control]);
 
+  // FIXME: in readOnly mode there is a lot of stuff in this component that is
+  // extraneous. A layer is put on top of dataflow that prevents interactions
+  // with the nodes. It would be better to make this more clear somehow.
+  const possiblyReadOnlyInputValue = control.node.readOnly ? control.getValue() : inputValue;
+
   const inputRef = useRef<HTMLInputElement>(null);
   useStopEventPropagation(inputRef, "pointerdown");
   useStopEventPropagation(inputRef, "dblclick");
@@ -183,7 +189,7 @@ export const NumberUnitsControlComponent: React.FC<{ data: INumberUnitsControl; 
       <input className={`number-input units ${unitsCountClass}`}
         ref={inputRef}
         type={"text"}
-        value={inputValue}
+        value={possiblyReadOnlyInputValue}
         onKeyPress={handleKeyPress}
         onChange={handleChange}
         onBlur={handleBlur}

--- a/src/plugins/dataflow/nodes/controls/value-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/value-control.tsx
@@ -15,18 +15,27 @@ export class ValueControl extends ClassicPreset.Control
   // So in Dataflow v2 we are just getting rid of the value property and
   // each node will need to explicity save its calculated data in a
   // watchedValue property.
-  @observable sentence = "";
+  @observable _sentence = "";
 
   constructor(
-    public nodeName: string
+    public nodeName: string,
+    private getSentenceFunc?: () => string
   ){
     super();
+    // TODO we can remove this when we've switched everything to using the function
     makeObservable(this);
   }
 
   @action
   public setSentence(sentence: string) {
-    this.sentence = sentence;
+    this._sentence = sentence;
+  }
+
+  get sentence() {
+    if (this.getSentenceFunc) {
+      return this.getSentenceFunc();
+    }
+    return this._sentence;
   }
 }
 

--- a/src/plugins/dataflow/nodes/controls/value-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/value-control.tsx
@@ -3,39 +3,14 @@ import "./value-control.sass";
 import classNames from "classnames";
 import React from "react";
 import { observer } from "mobx-react";
-import { action, makeObservable, observable } from "mobx";
 
 export class ValueControl extends ClassicPreset.Control
 {
-  // In Dataflow v1 setting the value also updated the node data with putData
-  // for the given key of the ValueControl. This approach overlapped with the
-  // updating of the node data via the watchedValues feature.
-  // The actual value was not used by the value control because in all cases
-  // the setSentence was called too.
-  // So in Dataflow v2 we are just getting rid of the value property and
-  // each node will need to explicity save its calculated data in a
-  // watchedValue property.
-  @observable _sentence = "";
-
   constructor(
     public nodeName: string,
-    private getSentenceFunc?: () => string
+    public getSentence: () => string
   ){
     super();
-    // TODO we can remove this when we've switched everything to using the function
-    makeObservable(this);
-  }
-
-  @action
-  public setSentence(sentence: string) {
-    this._sentence = sentence;
-  }
-
-  get sentence() {
-    if (this.getSentenceFunc) {
-      return this.getSentenceFunc();
-    }
-    return this._sentence;
   }
 }
 
@@ -43,8 +18,9 @@ export const ValueControlComponent: React.FC<{ data: ValueControl; }> =
   observer(function ValueControlComponent(props)
 {
   const control = props.data;
+  const sentence = control.getSentence();
 
-  const sentLen = control.sentence.length;
+  const sentLen = sentence.length;
   const fontSizeClasses = {
     "smallest": sentLen >= 15,
     "small": sentLen > 13 && sentLen < 15,
@@ -56,7 +32,7 @@ export const ValueControlComponent: React.FC<{ data: ValueControl; }> =
 
   return (
     <div className={valueClasses} title={"Node Value"}>
-      {control.sentence}
+      {sentence}
     </div>
   );
 

--- a/src/plugins/dataflow/nodes/counter-node.ts
+++ b/src/plugins/dataflow/nodes/counter-node.ts
@@ -9,6 +9,14 @@ import { INodeServices } from "./service-types";
 export const CounterNodeModel = BaseNodeModel.named("CounterNodeModel")
 .props(({
   type: typeField("Counter")
+}))
+.volatile(self => ({
+  count: 0
+}))
+.actions(self => ({
+  incrementCount() {
+    self.count++;
+  }
 }));
 export interface ICounterNodeModel extends Instance<typeof CounterNodeModel> {}
 
@@ -25,7 +33,6 @@ export class CounterNode extends BaseNode<
   ICounterNodeModel
 > {
   valueControl: ValueControl;
-  counter = 0;
 
   constructor(
     id: string | undefined,
@@ -36,16 +43,16 @@ export class CounterNode extends BaseNode<
 
     this.addOutput("value", new ClassicPreset.Output(numSocket, "Number"));
 
-    this.valueControl = new ValueControl("Math");
+    this.valueControl = new ValueControl("Math", this.getSentence);
     this.addControl("value", this.valueControl);
   }
 
+  getSentence = () => {
+    return `${this.model.count}`;
+  };
+
   data() {
-    console.log("Counter node data called");
-    const result = this.counter++;
-    this.valueControl.setSentence(`${result}`);
-
-
-    return { value: result};
+    this.model.incrementCount();
+    return { value: this.model.count};
   }
 }

--- a/src/plugins/dataflow/nodes/demo-output-node.ts
+++ b/src/plugins/dataflow/nodes/demo-output-node.ts
@@ -1,5 +1,5 @@
 import { ClassicPreset } from "rete";
-import { Instance } from "mobx-state-tree";
+import { Instance, isAlive } from "mobx-state-tree";
 import { numSocket } from "./num-socket";
 import { NodeDemoOutputTypes, NodePlotRed, kBinaryOutputTypes } from "../model/utilities/node";
 import { BaseNode, BaseNodeModel, NoOutputs } from "./base-node";
@@ -121,11 +121,15 @@ export class DemoOutputNode extends BaseNode<
   }
 
   getTiltDisplayMessage = () => {
+    if (!isAlive(this.model)) return "";
+
     const { tilt } = this.model;
     return tilt === 1 ? "up" : tilt === -1 ? "down" : "center";
   };
 
   getNodeValueDisplayMessage = () => {
+    if (!isAlive(this.model)) return "";
+
     const nodeValue = this.model.nodeValue ?? 0;
     if (kBinaryOutputTypes.includes(this.model.outputType)) {
       return nodeValue === 0 ? "off" : "on";

--- a/src/plugins/dataflow/nodes/generator-node.ts
+++ b/src/plugins/dataflow/nodes/generator-node.ts
@@ -73,19 +73,25 @@ export class GeneratorNode extends BaseNode<
       "Set Period");
     this.addControl("period", periodControl);
 
-    this.valueControl = new ValueControl("Generator");
+    this.valueControl = new ValueControl("Generator", this.getSentence);
     this.addControl("value", this.valueControl);
 
     this.addControl("plotButton", new PlotButtonControl(this));
   }
 
-  data(): { value: number } {
+  get currentValue() {
     // This follows the v1 generator block approach and shows and outputs 0 when
     // it hasn't been 'ticked' yet. This can happen if the sampling rate
     // is 1min and the block is just added to the diagram
-    const value = this.model.nodeValue ?? 0;
-    this.valueControl.setSentence(`${value}`);
-    return { value };
+    return this.model.nodeValue ?? 0;
+  }
+
+  getSentence = () => {
+    return `${this.currentValue}`;
+  };
+
+  data(): { value: number } {
+    return { value: this.currentValue };
   }
 
   onTick() {

--- a/src/plugins/dataflow/nodes/live-output-node.ts
+++ b/src/plugins/dataflow/nodes/live-output-node.ts
@@ -8,7 +8,7 @@ import { numSocket } from "./num-socket";
 import { NodeLiveOutputTypes, NodeMicroBitHubs, baseLiveOutputOptions,
   kBinaryOutputTypes,
   kGripperOutputTypes, kMicroBitHubRelaysIndexed } from "../model/utilities/node";
-import { IInputValueControl, InputValueControl } from "./controls/input-value-control";
+import { InputValueControl } from "./controls/input-value-control";
 import { SerialDevice } from "../../../models/stores/serial";
 import { VariableType } from "@concord-consortium/diagram-view";
 import { simulatedHub, simulatedHubName } from "../model/utilities/simulated-output";
@@ -21,7 +21,10 @@ export const LiveOutputNodeModel = BaseNodeModel.named("LiveOutputNodeModel")
   liveOutputType: "Gripper 2.0",
   // The default in the old DF was "connect device", choosing this does not bring up
   // the dialog, but it doesn't in the old one either. Hmm.
-  hubSelect: ""
+  hubSelect: "",
+  // We record this in state so readOnly views of this node can mirror the status
+  // without needing to track all of the channel state
+  outputStatus: ""
 })
 .actions(self => ({
   setLiveOutputType(outputType: string) {
@@ -29,6 +32,9 @@ export const LiveOutputNodeModel = BaseNodeModel.named("LiveOutputNodeModel")
   },
   setHubSelect(hub: string) {
     self.hubSelect = hub;
+  },
+  setOutputStatus(status: string) {
+    self.outputStatus = status;
   }
 }));
 export interface ILiveOutputNodeModel extends Instance<typeof LiveOutputNodeModel> {}
@@ -44,7 +50,6 @@ export class LiveOutputNode extends BaseNode<
   },
   ILiveOutputNodeModel
 > {
-  inputValueControl: IInputValueControl;
   hubSelectControl: IDropdownListControl;
 
   constructor(
@@ -63,8 +68,9 @@ export class LiveOutputNode extends BaseNode<
     this.hubSelectControl = new DropdownListControl(this, "hubSelect", NodeMicroBitHubs);
     this.addControl("hubSelect", this.hubSelectControl);
 
-    this.inputValueControl = new InputValueControl(this, "nodeValue", "", "Display for nodeValue");
-    nodeValueInput.addControl(this.inputValueControl);
+    const inputValueControl = new InputValueControl(this, "nodeValue", "", "Display for nodeValue",
+      this.getDisplayMessageWithStatus);
+    nodeValueInput.addControl(inputValueControl);
   }
 
   findOutputVariable() {
@@ -122,7 +128,7 @@ export class LiveOutputNode extends BaseNode<
   getLiveOptions(deviceFamily: string, sharedVar?: VariableType ) {
     const options: ListOption[] = [];
     const simOption = sharedVar && simulatedHub(sharedVar);
-    const anyOuputFound = simOption || deviceFamily === "arduino" || deviceFamily === "microbit";
+    const anyOutputFound = simOption || deviceFamily === "arduino" || deviceFamily === "microbit";
     const { liveGripperOption, warningOption } = baseLiveOutputOptions;
 
     if (sharedVar && simOption) {
@@ -143,7 +149,7 @@ export class LiveOutputNode extends BaseNode<
       }
     }
 
-    if (!anyOuputFound && !options.includes(warningOption)) options.push(warningOption);
+    if (!anyOutputFound && !options.includes(warningOption)) options.push(warningOption);
 
     return options;
   }
@@ -196,10 +202,18 @@ export class LiveOutputNode extends BaseNode<
 
   private getRelayMessageReceived() {
     const hubRelaysChannel = this.getHubRelaysChannel();
-    if (!hubRelaysChannel || !hubRelaysChannel.relaysState) return "(no hub)";
+    if (!hubRelaysChannel || !hubRelaysChannel.relaysState) return "no hub";
     const rIndex = this.getSelectedRelayIndex();
     const reportedValue = hubRelaysChannel.relaysState[rIndex];
-    return reportedValue === this.model.nodeValue ? "(received)" : "(sent)";
+    // TODO: this approach of knowing whether a message was received isn't
+    // accurate. If we are sending the same value that was received before it will
+    // immediately be labeled as "received". To really indicate if a message was
+    // received we'd need an id system so the relay would return the id of message
+    // that it received. However this might not be very useful if there are multiple
+    // programs both trying to update the same relay. So instead showing a status
+    // like: "Y secs ago, relay reported X" might be better. But even that isn't
+    // great.
+    return reportedValue === this.model.nodeValue ? "received" : "sent";
   }
 
   onTick() {
@@ -222,6 +236,28 @@ export class LiveOutputNode extends BaseNode<
     return true;
   }
 
+  getDisplayMessage = () => {
+    // TODO: if the nodeValue is not defined we might want display something
+    // different than just showing it as 0
+    const value = this.model.nodeValue ?? 0;
+    const { liveOutputType } = this.model;
+    if (kBinaryOutputTypes.includes(liveOutputType)) {
+      return value === 0 ? "off" : "on";
+    } else if (kGripperOutputTypes.includes(liveOutputType)){
+      const roundedDisplayValue = Math.round((value / 10) * 10);
+      return `${roundedDisplayValue}% closed`;
+    }
+
+    // We shouldn't hit this case but if we do then just pass the value through
+    return `${value}`;
+  };
+
+  getDisplayMessageWithStatus = () => {
+    const { outputStatus } = this.model;
+    const displayMessage = this.getDisplayMessage();
+    return displayMessage + (outputStatus ? ` (${outputStatus})` : "");
+  };
+
   data({nodeValue}: {nodeValue?: number[]}) {
     // if there is not a valid input, use 0
     const value = nodeValue && nodeValue[0] != null && !isNaN(nodeValue[0]) ? nodeValue[0] : 0;
@@ -232,23 +268,22 @@ export class LiveOutputNode extends BaseNode<
       // convert all non-zero to 1
       const newValue = +(value !== 0);
       this.model.setNodeValue(newValue);
-      const offOnString = newValue === 0 ? "off" : "on";
-      const displayMessage = kMicroBitHubRelaysIndexed.includes(outputType)
-        ? `${offOnString} ${this.getRelayMessageReceived()}`
-        : offOnString;
-      this.inputValueControl.setDisplayMessage(displayMessage);
+      if (kMicroBitHubRelaysIndexed.includes(outputType)) {
+        this.model.setOutputStatus(this.getRelayMessageReceived());
+      } else {
+        this.model.setOutputStatus("");
+      }
     } else if (kGripperOutputTypes.includes(outputType)){
       // NOTE: this looks similar to the Demo Output Node, but in this case we
       // are setting the nodeValue to 0-100. In the Demo Output Node it is set to
       // 0-1
       const newValue = getPercentageAsInt(value);
       this.model.setNodeValue(newValue);
-      const roundedDisplayValue = Math.round((newValue / 10) * 10);
-      this.inputValueControl.setDisplayMessage(`${roundedDisplayValue}% closed`);
+      this.model.setOutputStatus("");
     } else {
       // We shouldn't hit this case but if we do then just pass the value through
       this.model.setNodeValue(value);
-      this.inputValueControl.setDisplayMessage(`${value}`);
+      this.model.setOutputStatus("");
     }
 
     return {};

--- a/src/plugins/dataflow/nodes/live-output-node.ts
+++ b/src/plugins/dataflow/nodes/live-output-node.ts
@@ -65,13 +65,35 @@ export class LiveOutputNode extends BaseNode<
     const liveOutputControl = new DropdownListControl(this, "liveOutputType", NodeLiveOutputTypes);
     this.addControl("liveOutputType", liveOutputControl);
 
-    this.hubSelectControl = new DropdownListControl(this, "hubSelect", NodeMicroBitHubs);
+    if (this.readOnly) {
+      // In readOnly mode we will not be updating the list of options, so if the value of hubSelect
+      // is one of these dynamically added options, it will not be found in the readOnly view.
+      // This will result in the readOnly view just showing "Select an option".
+      // To work around this we use a special set of readOnly options which always contains the name
+      // of the current option.
+      // TODO: this could be improved by serializing more info about the current hubSelect option
+      // like the displayName, active, and missing properties. This way the readOnly view could
+      // display these as well.
+      this.hubSelectControl = new DropdownListControl(this, "hubSelect", [], undefined, undefined,
+        this.getReadOnlyHubSelectOptions
+      );
+    } else {
+      this.hubSelectControl = new DropdownListControl(this, "hubSelect", NodeMicroBitHubs);
+    }
     this.addControl("hubSelect", this.hubSelectControl);
 
     const inputValueControl = new InputValueControl(this, "nodeValue", "", "Display for nodeValue",
       this.getDisplayMessageWithStatus);
     nodeValueInput.addControl(inputValueControl);
   }
+
+  getReadOnlyHubSelectOptions = () => {
+    if (this.model.hubSelect) {
+      return [ { name: this.model.hubSelect }];
+    } else {
+      return NodeMicroBitHubs;
+    }
+  };
 
   findOutputVariable() {
     const type = this.model.liveOutputType;

--- a/src/plugins/dataflow/nodes/logic-node.ts
+++ b/src/plugins/dataflow/nodes/logic-node.ts
@@ -1,10 +1,10 @@
 import { ClassicPreset } from "rete";
-import { Instance } from "mobx-state-tree";
+import { Instance, types } from "mobx-state-tree";
 import { numSocket } from "./num-socket";
 import { ValueControl } from "./controls/value-control";
 import { getNumDisplayStr } from "./utilities/view-utilities";
 import { NodeOperationTypes } from "../model/utilities/node";
-import { BaseNode, BaseNodeModel } from "./base-node";
+import { BaseNode, BaseNodeModel, StringifiedNumber } from "./base-node";
 import { DropdownListControl, IDropdownListControl } from "./controls/dropdown-list-control";
 import { PlotButtonControl } from "./controls/plot-button-control";
 import { typeField } from "../../../utilities/mst-utils";
@@ -13,11 +13,23 @@ import { INodeServices } from "./service-types";
 export const LogicNodeModel = BaseNodeModel.named("LogicNodeModel")
 .props({
   type: typeField("Logic"),
-  logicOperator: "Greater Than"
+  logicOperator: "Greater Than",
+
+  // TODO: we'll have to deal with migrating this somehow, we might
+  // need to run the process function once for imported dataflow tiles
+  // so these inputs get saved
+  num1: types.maybe(StringifiedNumber),
+  num2: types.maybe(StringifiedNumber),
 })
 .actions(self => ({
   setLogicOperator(val: string) {
     self.logicOperator = val;
+  },
+  setNum1(val: number) {
+    self.num1 = val;
+  },
+  setNum2(val: number) {
+    self.num2 = val;
   }
 }));
 export interface ILogicNodeModel extends Instance<typeof LogicNodeModel> {}
@@ -60,13 +72,16 @@ export class LogicNode extends BaseNode<
     const dropdownControl = new DropdownListControl(this, "logicOperator", dropdownOptions);
     this.addControl("logicOperator", dropdownControl);
 
-    this.valueControl = new ValueControl("Logic");
+    this.valueControl = new ValueControl("Logic", this.getSentence);
     this.addControl("value", this.valueControl);
 
     this.addControl("plotButton", new PlotButtonControl(this));
   }
 
-  getSentence(num1: number, num2: number, result: number) {
+  getSentence = () => {
+    const result = this.model.nodeValue;
+    const { num1, num2 } = this.model;
+
     const nodeOperationTypes = NodeOperationTypes.find(op => op.name === this.model.logicOperator);
     if (nodeOperationTypes) {
       const n1Str = getNumDisplayStr(num1);
@@ -76,24 +91,13 @@ export class LogicNode extends BaseNode<
     } else {
       return "";
     }
-  }
+  };
 
   data({num1, num2}: {num1?: number[], num2?: number[]}) {
     let result = 0;
-    let resultSentence = "";
 
     const n1 = num1 ? num1[0] : NaN;
     const n2 = num2 ? num2[0] : NaN;
-
-
-    // In v1 the inputs can be arrays not just single values this was probably
-    // used to handle some kind of smoothing transform. The only block which might
-    // use these previous values currently is the hold block which has a "previous value"
-    // option. However it seems like that could be implemented by internally recording
-    // the value.
-    // The other place the previous values are shown is in the plot block.
-    // The plot block could record these values internally also, so it seems like we
-    // can keep it simple and just pass single values.
 
     const nodeOperationTypes = NodeOperationTypes.find(op => op.name === this.model.logicOperator);
 
@@ -105,13 +109,17 @@ export class LogicNode extends BaseNode<
         // Actual math errors like divide-by-zero should output 0.
         result = nodeOperationTypes.method(n1, n2);
       }
-
-      resultSentence = this.getSentence(n1, n2, result);
     }
+
+    // TODO: we should try to wrap these data functions in an action so all of their
+    // changes are grouped together.
+
+    // The input numbers are saved so readOnly views can display the sentence
+    this.model.setNum1(n1);
+    this.model.setNum2(n2);
 
     // This nodeValue is used to record the recent values of the node
     this.model.setNodeValue(result);
-    this.valueControl.setSentence(resultSentence);
 
     return { value: result };
   }

--- a/src/plugins/dataflow/nodes/node-editor-mst.ts
+++ b/src/plugins/dataflow/nodes/node-editor-mst.ts
@@ -39,7 +39,8 @@ export class NodeEditorMST extends NodeEditor<Schemes> implements INodeServices 
     private div: HTMLElement,
     private mstContent: DataflowContentModelType,
     public stores: IStores,
-    public runnable: boolean | undefined
+    public runnable: boolean | undefined,
+    public readOnly: boolean | undefined,
   ) {
     super();
 
@@ -144,10 +145,13 @@ export class NodeEditorMST extends NodeEditor<Schemes> implements INodeServices 
   }
 
   public process = () => {
-    console.warn("NodeEditorMST.process");
-    this.engine.reset();
+    console.log("NodeEditorMST.process");
 
-    console.log("NodeEditorMST.process getNodes", this.getNodes());
+    // Don't do any processing when we are read-only
+    if (this.readOnly) return;
+
+
+    this.engine.reset();
 
     // It seems like structures should correctly handle our setup, but from what
     // I can tell it is reading the empty private nodes and connections from
@@ -159,7 +163,6 @@ export class NodeEditorMST extends NodeEditor<Schemes> implements INodeServices 
     // will only be called once.
     // debugger;
     const leafNodes = graph.leaves().nodes();
-    console.log("NodeEditorMST.process leafNodes", leafNodes);
     leafNodes.forEach(n => this.engine.fetch(n.id));
   };
 

--- a/src/plugins/dataflow/nodes/node-editor-mst.ts
+++ b/src/plugins/dataflow/nodes/node-editor-mst.ts
@@ -11,7 +11,7 @@ import { MathNode } from "./math-node";
 import { CounterNode } from "./counter-node";
 import { LogicNode } from "./logic-node";
 import { GeneratorNode } from "./generator-node";
-import { IBaseNodeModel, NodeClass } from "./base-node";
+import { IBaseNode, IBaseNodeModel, NodeClass } from "./base-node";
 import { uniqueId } from "../../../utilities/js-utils";
 import { INodeServices } from "./service-types";
 import { LogEventName } from "../../../lib/logger-types";
@@ -28,7 +28,7 @@ import { ControlNode } from "./control-node";
 import { getNewNodePosition } from "./utilities/view-utilities";
 
 export class NodeEditorMST extends NodeEditor<Schemes> implements INodeServices {
-  private reteNodesMap: Record<string, Schemes['Node']> = {};
+  public reteNodesMap: Record<string, Schemes['Node']> = {};
 
   public engine = new DataflowEngine<Schemes>();
   public area: AreaPlugin<Schemes, AreaExtra>;
@@ -274,6 +274,11 @@ export class NodeEditorMST extends NodeEditor<Schemes> implements INodeServices 
     this.process();
   }
 
+  disposeNodes() {
+    const nodes = this.getNodes();
+    nodes.forEach(node => (node as IBaseNode).dispose());
+  }
+
   //
   // Methods implementing the Rete `Editor` interface
   //
@@ -288,6 +293,7 @@ export class NodeEditorMST extends NodeEditor<Schemes> implements INodeServices 
     if (!mstNode) {
       const _reteNode = this.reteNodesMap[id];
       if (_reteNode) {
+        (_reteNode as IBaseNode).dispose();
         delete this.reteNodesMap[id];
       }
       // We have to hack this to make the types happy, this is a bug
@@ -441,6 +447,7 @@ export class NodeEditorMST extends NodeEditor<Schemes> implements INodeServices 
 
     if (!await this.emit({ type: 'noderemove', data: node })) return false;
 
+    (node as IBaseNode).dispose();
     this.mstProgram.removeNode(id);
 
     // Temporary use this approach to get things working

--- a/src/plugins/dataflow/nodes/service-types.ts
+++ b/src/plugins/dataflow/nodes/service-types.ts
@@ -14,4 +14,5 @@ export interface INodeServices {
   getChannels(): NodeChannelInfo[];
   stores: IStores;
   runnable?: boolean;
+  readOnly?: boolean;
 }

--- a/src/plugins/dataflow/nodes/timer-node.ts
+++ b/src/plugins/dataflow/nodes/timer-node.ts
@@ -64,19 +64,25 @@ export class TimerNode extends BaseNode<
       "Set Time Off");
     this.addControl("timeOff", timeOffControl);
 
-    this.valueControl = new ValueControl("Timer");
+    this.valueControl = new ValueControl("Timer", this.getSentence);
     this.addControl("value", this.valueControl);
 
     this.addControl("plotButton", new PlotButtonControl(this));
   }
 
-  data(): { value: number } {
+  get currentValue() {
     // This follows the v1 generator block approach and shows and outputs 0 when
     // it hasn't been 'ticked' yet. This can happen if the sampling rate
     // is 1min and the block is just added to the diagram
-    const value = this.model.nodeValue ?? 0;
-    this.valueControl.setSentence(+value === 0 ? "off" : "on");
-    return { value };
+    return this.model.nodeValue ?? 0;
+  }
+
+  getSentence = () => {
+    return +this.currentValue === 0 ? "off" : "on";
+  };
+
+  data(): { value: number } {
+    return { value: this.currentValue };
   }
 
   onTick() {

--- a/src/plugins/dataflow/nodes/transform-node.ts
+++ b/src/plugins/dataflow/nodes/transform-node.ts
@@ -1,10 +1,10 @@
 import { ClassicPreset } from "rete";
-import { Instance } from "mobx-state-tree";
+import { Instance, types } from "mobx-state-tree";
 import { numSocket } from "./num-socket";
 import { ValueControl } from "./controls/value-control";
 import { getNumDisplayStr } from "./utilities/view-utilities";
 import { NodeOperationTypes } from "../model/utilities/node";
-import { BaseNode, BaseNodeModel } from "./base-node";
+import { BaseNode, BaseNodeModel, StringifiedNumber } from "./base-node";
 import { DropdownListControl, IDropdownListControl } from "./controls/dropdown-list-control";
 import { PlotButtonControl } from "./controls/plot-button-control";
 import { typeField } from "../../../utilities/mst-utils";
@@ -13,11 +13,19 @@ import { INodeServices } from "./service-types";
 export const TransformNodeModel = BaseNodeModel.named("TransformNodeModel")
 .props({
   type: typeField("Transform"),
-  transformOperator: "Absolute Value"
+  transformOperator: "Absolute Value",
+
+  // TODO: we'll have to deal with migrating this somehow, we might
+  // need to run the process function once for imported dataflow tiles
+  // so these inputs get saved
+  num1: types.maybe(StringifiedNumber),
 })
 .actions(self => ({
   setTransformOperator(val: string) {
     self.transformOperator = val;
+  },
+  setNum1(val: number) {
+    self.num1 = val;
   }
 }));
 export interface ITransformNodeModel extends Instance<typeof TransformNodeModel> {}
@@ -58,13 +66,16 @@ export class TransformNode extends BaseNode<
     const dropdownControl = new DropdownListControl(this, "transformOperator", dropdownOptions);
     this.addControl("transformOperator", dropdownControl);
 
-    this.valueControl = new ValueControl("Math");
+    this.valueControl = new ValueControl("Transform", this.getSentence);
     this.addControl("value", this.valueControl);
 
     this.addControl("plotButton", new PlotButtonControl(this));
   }
 
-  getSentence(num1: number, result: number) {
+  getSentence = () => {
+    const result = this.model.nodeValue;
+    const { num1 } = this.model;
+
     const nodeOperationTypes = NodeOperationTypes.find(op => op.name === this.model.transformOperator);
     if (nodeOperationTypes) {
       const n1Str = getNumDisplayStr(num1);
@@ -73,22 +84,12 @@ export class TransformNode extends BaseNode<
     } else {
       return "";
     }
-  }
+  };
 
   data({num1}: {num1?: number[]}) {
     let result = 0;
-    let resultSentence = "";
 
     const n1 = num1 ? num1[0] : NaN;
-
-    // In v1 the inputs can be arrays not just single values this was probably
-    // used to handle some kind of smoothing transform. The only block which might
-    // use these previous values currently is the hold block which has a "previous value"
-    // option. However it seems like that could be implemented by internally recording
-    // the value.
-    // The other place the previous values are shown is in the plot block.
-    // The plot block could record these values internally also, so it seems like we
-    // can keep it simple and just pass single values.
 
     const nodeOperationTypes = NodeOperationTypes.find(op => op.name === this.model.transformOperator);
 
@@ -107,14 +108,29 @@ export class TransformNode extends BaseNode<
         // prevValue might be null, and nodeOperationTypes doesn't handle that
         result = nodeOperationTypes.method(n1, 0, prevValue ?? undefined);
       }
-
-      resultSentence = this.getSentence(n1, result);
     }
+
+    // TODO: we should try to wrap these data functions in an action so all of their
+    // changes are grouped together.
+
+    // The input numbers are saved so readOnly views can display the sentence
+    this.model.setNum1(n1);
 
     // This nodeValue is used to record the recent values of the node
     this.model.setNodeValue(result);
-    this.valueControl.setSentence(resultSentence);
 
     return { value: result };
+  }
+
+  onTick() {
+    if (this.model.transformOperator === "Ramp") {
+      // If we are "ramping", we need to reprocess on every tick so the values can update
+      // Probably we should go further and move the ramp logic into onTick.
+      // If the program sampling rate is really slow and the user changes connections or
+      // values in another node that causes a reprocess that will cause the ramped value
+      // to change outside of the tick
+      return true;
+    }
+    return false;
   }
 }

--- a/src/plugins/dataflow/nodes/utilities/view-utilities.ts
+++ b/src/plugins/dataflow/nodes/utilities/view-utilities.ts
@@ -20,6 +20,6 @@ export function getNewNodePosition(editor: NodeEditorMST) {
   return nodePos;
 }
 
-export function getNumDisplayStr(n: number){
-  return isNaN(n) ? kEmptyValueString : Number(n).toFixed(3).replace(/\.?0+$/, "");
+export function getNumDisplayStr(n: number | undefined ){
+  return (n === undefined || isNaN(n)) ? kEmptyValueString : Number(n).toFixed(3).replace(/\.?0+$/, "");
 }


### PR DESCRIPTION
Making readOnly mode work required several changes

###  Disabling `tick` and `process`
`tick` and `process` were stopped from running in readOnly mode, this way only the editable tile should be updating the state of the tile model. This is a change from Rete v1. In that old approach we were ticking and processing the nodes even in readOnly mode.

With `process` it means all nodes and controls needed to be updated so the controls can display the right thing even without the node's `data` method being called. The approach is to save more information in the Node's MST model and update the controls and control components so they can observe this state and update appropriately.  For simple nodes like the Math and Logic nodes, this means they needed to store their two input values into their MST model. This way the readOnly view could generate the "sentence" describing the current state of the node.

### Snapshot Syncing
As before in Rete v1, in readOnly mode snapshots of the program are monitored with onSnapshot. However in the new Rete v2 design, we do not just destroy the whole program and recreate it. Instead we compare the nodes, connections, and node positions from the the incoming snapshot with what Rete currently knows about. When there is a difference, we update Rete by emitting the appropriate event or calling a Rete function.

### Unmounting React Components
When a document is closed all of the components rendering that document are unmounted. When the component is unmounted this gives MobX React a chance to dispose its observers. It gives the component a chance to dispose any timers its started. 

In both Rete v1 and Rete v2, Rete creates new "React roots" for every node, control, and socket. Because of this when the DataFlow tile is unmounted, these separate roots are not automatically unmounted.  This means that all of the observers and timers continue to run for this closed document. When DataFlow is viewed on the left side it is much more common to open and close documents and thumbnails of documents.

In Rete v1, this was at least partially addressed by monitoring the "render*" events emitted to Rete, and keeping track of the dom elements the controls and nodes were rendered to. Then when DataFlow was disposed we tried unmount React from all of these elements.

In Rete v2 this approach didn't work. Additionally in Rete v2 it has built in support for unmounting controls and sockets associated with a node that is removed from the program. So in Rete v2, we just go through all of the "nodeViews" and "connectionViews" in Rete and remove them. This causes Rete to unmount the nodes, controls, sockets, and connections components.

A specific way to verify this is with the humidifier animation. This component runs a timer to show an animation. If it isn't unmounted this animation continues to run. If you add log statements to the animation loop, it is possible to see that there is now only 1 animation running for each node that is currently visible (whether in a thumbnail or full document). We might want to optimize this further so thumbnails don't run the animation at all. 

### Dynamic drop down options
In the live output node, the `hubSelect` field is a dropdown to choose which hub or a simulated sensor to connect to. This list of options dynamically changes based on the device connected, and properties of these options can also change to indicate of a hub has gone offline. Because these dynamic changes are triggered by the `tick` and they rely on information from the connected serial port, these dynamic options are available in a readOnly view. If the readOnly view was on a different computer it wouldn't have access to the Serial port to know the status. 

The `name` of the selected option is saved in the MST state, so the readOnly view knows this, but since the control's options are not updated, the readOnly control doesn't find this `name` in its list of options.

The solution for now is to have a separate set of options in readOnly mode which always includes the currently selected option name. It doesn't include the extra info for this option like `active`, `missing`, `icon`, and `displayName`. So it won't look exactly the same, but this approach seemed good enough for now.