### PR TITLE
add value and plot to sensor

### DIFF
--- a/cypress/e2e/functional/tile_tests/dataflow_tool_spec.js
+++ b/cypress/e2e/functional/tile_tests/dataflow_tool_spec.js
@@ -517,11 +517,11 @@ context('Dataflow Tool Tile', function () {
     dataflowToolTile.getNode(sensorNode).should("exist");
     dataflowToolTile.getNodeTitle().should("contain", "Sensor");
 
-    // cy.log("can toggle minigraph");
-    // dataflowToolTile.getShowGraphButton(sensorNode).click();
-    // dataflowToolTile.getMinigraph(sensorNode).should("exist");
-    // dataflowToolTile.getShowGraphButton(sensorNode).click();
-    // dataflowToolTile.getMinigraph(sensorNode).should("not.exist");
+    cy.log("can toggle minigraph");
+    dataflowToolTile.getShowGraphButton(sensorNode).click();
+    dataflowToolTile.getMinigraph(sensorNode).should("exist");
+    dataflowToolTile.getShowGraphButton(sensorNode).click();
+    dataflowToolTile.getMinigraph(sensorNode).should("not.exist");
 
     cy.log("verify sensor types");
     const dropdown10 = "sensorType";
@@ -613,16 +613,16 @@ context('Dataflow Tool Tile', function () {
     dataflowToolTile.getPlayButton().should("be.enabled");
     dataflowToolTile.verifyRecordingClearButtonText();
     dataflowToolTile.verifyRecordingClearButtonIcon();
-    // dataflowToolTile.getPlayButton().click();
+    dataflowToolTile.getPlayButton().click();
 
-    // dataflowToolTile.verifyPauseButtonText();
-    // dataflowToolTile.verifyPauseButtonIcon();
-    // dataflowToolTile.getPauseButton().should("be.enabled");
-    // dataflowToolTile.getPauseButton().click();
+    dataflowToolTile.verifyPauseButtonText();
+    dataflowToolTile.verifyPauseButtonIcon();
+    dataflowToolTile.getPauseButton().should("be.enabled");
+    dataflowToolTile.getPauseButton().click();
 
-    // dataflowToolTile.getPlayButton().should("be.enabled");
-    // dataflowToolTile.getPlayButton().click();
-    // cy.wait(5000);
+    dataflowToolTile.getPlayButton().should("be.enabled");
+    dataflowToolTile.getPlayButton().click();
+    cy.wait(5000);
 
     cy.log("verify clear recording");
     dataflowToolTile.verifyRecordingClearButtonText();

--- a/cypress/e2e/functional/tile_tests/simulator_tile_spec.js
+++ b/cypress/e2e/functional/tile_tests/simulator_tile_spec.js
@@ -40,14 +40,10 @@ context('Simulator Tile', function () {
     simulatorTile.getSelectionButtons().should("have.length", 2).eq(1).click();
     cy.get(".gripper-image").should("not.exist");
     cy.get(".temperature-part").should("exist");
+  });
 
-    cy.log("edit tile title");
-    const newName = "Test Simulation";
-    clueCanvas.addTile("simulator");
-    simulatorTile.getTileTitle().should("contain", "Simulation 1");
-    simulatorTile.getSimulatorTileTitle().click();
-    simulatorTile.getSimulatorTileTitle().type(newName + '{enter}');
-    simulatorTile.getTileTitle().should("contain", newName);
+  it("Simulator Tile with Dataflow", () => {
+    beforeTest(queryParams1 + "&mouseSensor");
 
     cy.log("links to dataflow tile");
     clueCanvas.addTile("dataflow");
@@ -59,13 +55,11 @@ context('Simulator Tile', function () {
     dataflowTile.getDropdown(sensor, "sensorType").click();
     dataflowTile.getSensorDropdownOptions(sensor).find(".label").contains("EMG").click(); // EMG
     dataflowTile.getDropdown(sensor, "sensor").click();
-    dataflowTile.getSensorDropdownOptions(sensor).should("have.length", 2);
+    dataflowTile.getSensorDropdownOptions(sensor).should("have.length", 1);
     // Click the background to not select any option
     cy.get(".primary-workspace .flow-tool").click();
 
-    // FIXME: this was disabled because the sensor block didn't have a value display
-    // dataflowTile.getNodeValueContainer(sensor).invoke('text').then(parseFloat).should("equal", 0);
-    dataflowTile.getNodeValueContainer(sensor).should("not.exist");
+    dataflowTile.getNodeValueContainer(sensor).invoke('text').should("equal", "__");
 
     // Simulation options are not present in the live output before the simulation has been added to the document
     const lo = "live-output";
@@ -73,15 +67,15 @@ context('Simulator Tile', function () {
     dataflowTile.getDropdown(lo, "liveOutputType").click();
     dataflowTile.getDropdownOptions(lo, "liveOutputType").eq(1).click(); // Gripper
     dataflowTile.getDropdown(lo, "hubSelect").click();
-    dataflowTile.getDropdownOptions(lo, "hubSelect").should("have.length", 2);
+    dataflowTile.getDropdownOptions(lo, "hubSelect").should("have.length", 1);
     // Click the background to not select any option
     cy.get(".primary-workspace .flow-tool").click();
 
     // Need to move it out of the way
     dataflowTile.getNode("live-output").click(50, 10)
       .trigger("pointerdown", 50, 10)
-      .trigger("pointermove", 300, 10, { force: true })
-      .trigger("pointerup", 300, 10, { force: true });
+      .trigger("pointermove", 300, 100, { force: true })
+      .trigger("pointerup", 300, 100, { force: true });
 
 
     // Sensor options are correct after adding the simulation to the document
@@ -90,17 +84,13 @@ context('Simulator Tile', function () {
     dataflowTile.getSensorDropdownOptions(sensor).should("have.length", 2);
     dataflowTile.getSensorDropdownOptions(sensor).eq(0).click();
 
-    // FIXME: this was disabled because the sensor block didn't have a value display
-    // dataflowTile.getNodeValueContainer(sensor).invoke('text').then(parseFloat).should("be.below", 41).should("be.above", 35);
-    dataflowTile.getNodeValueContainer(sensor).should("not.exist");
+    dataflowTile.getNodeValueContainer(sensor).invoke('text').then(parseFloat).should("be.below", 41).should("be.above", 35);
 
     simulatorTile.getEMGSlider().click("right");
 
     cy.wait(50);
 
-    // FIXME: this was disabled because the sensor block didn't have a value display
-    // dataflowTile.getNodeValueContainer(sensor).invoke('text').then(parseFloat).should("be.below", 441).should("be.above", 390);
-    dataflowTile.getNodeValueContainer(sensor).should("not.exist");
+    dataflowTile.getNodeValueContainer(sensor).invoke('text').then(parseFloat).should("be.below", 441).should("be.above", 390);
 
     // Live output options are correct after adding the simulation to the document
     dataflowTile.getDropdown(lo, "hubSelect").click();
@@ -112,13 +102,22 @@ context('Simulator Tile', function () {
     dataflowTile.getNumberField().type("1{enter}");
     const output = () => dataflowTile.getNode("number").find(".output-socket");
     const input = () => dataflowTile.getNode(lo).find(".input-socket");
-    output().click();
-    input().click({ force: true });
+    output().trigger("pointerdown");
+    input().trigger("pointermove", {force: true});
+    input().trigger("pointerup", {force: true});
     dataflowTile.getOutputNodeValueText().should("contain", "100% closed");
     simulatorTile.getSimulatorTile().should("contain.text", "Gripper Output100");
 
     // Pressure variable updates when the gripper changes
     simulatorTile.getSimulatorTile().should("contain.text", "Surface Pressure Sensor300");
+
+    cy.log("edit tile title");
+    const newName = "Test Simulation";
+    clueCanvas.addTile("simulator");
+    simulatorTile.getTileTitle().should("contain", "Simulation 1");
+    simulatorTile.getSimulatorTileTitle().click();
+    simulatorTile.getSimulatorTileTitle().type(newName + '{enter}');
+    simulatorTile.getTileTitle().should("contain", newName);
 
     //Simulator tile restore upon page reload
     cy.wait(2000);

--- a/src/plugins/dataflow/nodes/base-node.ts
+++ b/src/plugins/dataflow/nodes/base-node.ts
@@ -141,7 +141,18 @@ export const BaseNodeModel = types.model("BaseNodeModel",
   setTickMax(max: number) { self.tickMax = max; },
   setTickMin(min: number) { self.tickMin = min; },
   setDsMax(max: number) { self.dsMax = max; },
-  setDsMin(min: number) { self.dsMin = min; }
+  setDsMin(min: number) { self.dsMin = min; },
+}))
+.actions(self => ({
+  resetGraph () {
+    self.dsMax = -Infinity;
+    self.dsMin = Infinity;
+
+    self.tickMax = undefined;
+    self.tickMin = undefined;
+
+    self.clearRecentValues();
+  }
 }));
 export interface IBaseNodeModel extends Instance<typeof BaseNodeModel> {}
 

--- a/src/plugins/dataflow/nodes/controls/value-with-units-control.sass
+++ b/src/plugins/dataflow/nodes/controls/value-with-units-control.sass
@@ -1,0 +1,19 @@
+@import ../../components/dataflow-vars
+
+.value-with-units
+  display: flex
+
+  .value-container
+    width: 63px
+    font-size: 18px
+
+  .units-container
+    width: 44px
+    height: 24px
+    line-height: 24px
+    font-size: 18px
+    background-color: $sensor-blue-outline
+    border-radius: 0 13px 13px 0
+    border-left: 1px solid white
+    &.small
+      font-size: 12px

--- a/src/plugins/dataflow/nodes/controls/value-with-units-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/value-with-units-control.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { observer } from "mobx-react";
+import { ClassicPreset } from "rete";
+
+import "./value-with-units-control.sass";
+
+export class ValueWithUnitsControl extends ClassicPreset.Control
+{
+  constructor(
+    public nodeName: string,
+    public getDisplayValue: () => string,
+    public getUnits: () => string,
+  ){
+    super();
+  }
+}
+
+export const ValueWithUnitsControlComponent: React.FC<{ data: ValueWithUnitsControl; }> =
+  observer(function ValueWithUnitsControlComponent(props)
+{
+  const control = props.data;
+  const displayValue = control.getDisplayValue();
+  const units = control.getUnits();
+
+  return (
+    <div className="value-with-units" title={"Node Value"}>
+      <div className="value-container">
+        {displayValue}
+      </div>
+      <div className={`units-container ${units.length > 4 ? "small" : ""}`}>
+        {units}
+      </div>
+    </div>
+  );
+});

--- a/src/plugins/dataflow/nodes/generator-node.ts
+++ b/src/plugins/dataflow/nodes/generator-node.ts
@@ -47,8 +47,6 @@ export class GeneratorNode extends BaseNode<
   },
   IGeneratorNodeModel
 > {
-  valueControl: ValueControl;
-
   constructor(
     id: string | undefined,
     model: IGeneratorNodeModel,
@@ -73,8 +71,8 @@ export class GeneratorNode extends BaseNode<
       "Set Period");
     this.addControl("period", periodControl);
 
-    this.valueControl = new ValueControl("Generator", this.getSentence);
-    this.addControl("value", this.valueControl);
+    const valueControl = new ValueControl("Generator", this.getSentence);
+    this.addControl("value", valueControl);
 
     this.addControl("plotButton", new PlotButtonControl(this));
   }

--- a/src/plugins/dataflow/nodes/rete-manager.tsx
+++ b/src/plugins/dataflow/nodes/rete-manager.tsx
@@ -35,6 +35,7 @@ import { DropdownListControl, DropdownListControlComponent } from "./controls/dr
 import { DemoOutputControl, DemoOutputControlComponent } from "./controls/demo-output-control";
 import { PlotButtonControl, PlotButtonControlComponent } from "./controls/plot-button-control";
 import { InputValueControl, InputValueControlComponent } from "./controls/input-value-control";
+import { ValueWithUnitsControl, ValueWithUnitsControlComponent } from "./controls/value-with-units-control";
 
 const MAX_ZOOM = 2;
 const MIN_ZOOM = .1;
@@ -153,6 +154,9 @@ export class ReteManager {
         control(data) {
           if (data.payload instanceof ValueControl) {
             return ValueControlComponent;
+          }
+          if (data.payload instanceof ValueWithUnitsControl) {
+            return ValueWithUnitsControlComponent;
           }
           if (data.payload instanceof NumberUnitsControl) {
             return NumberUnitsControlComponent;

--- a/src/plugins/dataflow/nodes/rete-scheme.ts
+++ b/src/plugins/dataflow/nodes/rete-scheme.ts
@@ -8,6 +8,7 @@ import { PlotButtonControl } from "./controls/plot-button-control";
 import { INumberUnitsControl } from "./controls/num-units-control";
 import { DemoOutputControl } from "./controls/demo-output-control";
 import { IInputValueControl } from "./controls/input-value-control";
+import { ValueWithUnitsControl } from "./controls/value-with-units-control";
 
 // Crazy Rete typing...
 class NodeWithControls extends ClassicPreset.Node<
@@ -18,6 +19,7 @@ class NodeWithControls extends ClassicPreset.Node<
       | INumberControl
       | INumberUnitsControl
       | ValueControl
+      | ValueWithUnitsControl
       | IDropdownListControl
       | IInputValueControl
       | DemoOutputControl


### PR DESCRIPTION
PT-187382896

Changes:
- add ValueWithUnitsControl
- use ValueWithUnitsControl in sensor node
- reset the graph when the sensor or sensorType changes
- lookup the decimal places and units from the NodeSensorType instance
- re-enable the cypress tests that are looking at the sensor value
- remove valueControl instance variable from generator node
