### PR TITLE
optimize Dataflow tick

### DIFF
--- a/src/plugins/dataflow/model/dataflow-program-model.ts
+++ b/src/plugins/dataflow/model/dataflow-program-model.ts
@@ -76,6 +76,12 @@ export const DataflowProgramModel = types.
         node.data.orderedDisplayName = displayNameBase + " " + idx;
         idx++;
       });
+    },
+    // This action is used to wrap the changes in a single MST transaction
+    // This could be generic, but a specific name is used so the recorded event has
+    // a useful name.
+    tickAndProcess(runner: () => void) {
+      runner();
     }
   }))
   .actions(self => ({

--- a/src/plugins/dataflow/nodes/engine/dataflow-engine.ts
+++ b/src/plugins/dataflow/nodes/engine/dataflow-engine.ts
@@ -1,0 +1,118 @@
+import { GetSchemes, NodeEditor, NodeId, Root, Scope } from 'rete';
+
+import { Dataflow, ClassicScheme } from './dataflow';
+import { Cache } from './utils/cache';
+
+export type DataflowNode = { data(inputs: Record<string, any>): Promise<Record<string, any>> | Record<string, any> }
+export type DataflowEngineScheme = GetSchemes<
+  ClassicScheme['Node'] & DataflowNode,
+  ClassicScheme['Connection']
+>
+
+type Configure<Schemes extends DataflowEngineScheme> = (node: Schemes['Node']) => ({
+  inputs: () => string[]
+  outputs: () => string[]
+})
+
+/**
+ * DataflowEngine is a plugin that integrates Dataflow with NodeEditor making it easy to use.
+ * Additionally, it provides a cache for the data of each node in order to avoid recurring calculations.
+ * @priority 10
+ * @listens nodecreated
+ * @listens noderemoved
+ */
+export class DataflowEngine<Schemes extends DataflowEngineScheme> extends Scope<never, [Root<Schemes>]> {
+  editor!: NodeEditor<Schemes>;
+  dataflow?: Dataflow<Schemes>;
+  cache = new Cache<NodeId, Record<string, any>>();
+
+  constructor(private configure?: Configure<Schemes>) {
+    super('dataflow-engine');
+
+    this.addPipe(context => {
+      if (context.type === 'nodecreated') {
+        this.add(context.data);
+      }
+      if (context.type === 'noderemoved') {
+        this.remove(context.data);
+      }
+      return context;
+    });
+  }
+
+  setParent(scope: Scope<Root<Schemes>>): void {
+    super.setParent(scope);
+
+    this.editor = this.parentScope<NodeEditor<Schemes>>(NodeEditor);
+    this.dataflow = new Dataflow(this.editor);
+  }
+
+  private getDataflow() {
+    if (!this.dataflow) throw new Error(`DataflowEngine isn't attached to NodeEditor`);
+    return this.dataflow;
+  }
+
+  private add(node: Schemes['Node']) {
+    const options = this.configure
+      ? this.configure(node)
+      : { inputs: () => Object.keys(node.inputs), outputs: () => Object.keys(node.outputs) };
+
+    this.getDataflow().add(node, {
+      inputs: options.inputs,
+      outputs: options.outputs,
+      data: (fetchInputs) => {
+        const cache = this.cache.get(node.id);
+
+        if (cache) return cache;
+
+        const inputs = fetchInputs();
+        const result = node.data(inputs);
+
+        this.cache.add(node.id, result);
+
+        return result;
+      }
+    });
+  }
+
+  private remove(node: Schemes['Node']) {
+    this.getDataflow().remove(node.id);
+  }
+
+  /**
+   * Resets the cache of the node and all its predecessors.
+   * @param nodeId Node id to reset. If not specified, all nodes will be reset.
+   */
+  public reset(nodeId?: NodeId) {
+    if (nodeId) {
+      const setup = this.getDataflow().setups.get(nodeId);
+
+      if (!setup) throw 'setup';
+
+      const outputKeys = setup.outputs();
+
+      this.cache.delete(nodeId);
+      this.editor.getConnections()
+        .filter(c => c.source === nodeId && outputKeys.includes(c.sourceOutput))
+        .forEach(c => this.reset(c.target));
+    } else {
+      this.cache.clear();
+    }
+  }
+
+  /**
+   * Fetches input data for the node by fetching data for all its predecessors recursively.
+   * @param nodeId Node id to fetch input data for
+   */
+  public fetchInputs(nodeId: NodeId) {
+    return this.getDataflow().fetchInputs(nodeId);
+  }
+
+  /**
+   * Fetches output data of the node
+   * @param nodeId Node id to fetch data from
+   */
+  public fetch(nodeId: NodeId) {
+    return this.getDataflow().fetch(nodeId);
+  }
+}

--- a/src/plugins/dataflow/nodes/engine/dataflow.ts
+++ b/src/plugins/dataflow/nodes/engine/dataflow.ts
@@ -1,0 +1,117 @@
+import { NodeEditor, NodeId, ClassicPreset as Classic, GetSchemes } from 'rete';
+
+export type ClassicScheme = GetSchemes<Classic.Node, Classic.Connection<Classic.Node, Classic.Node>>
+
+/**
+ * DataflowNodeSetup is a set of functions that define how to process a node.
+ */
+export type DataflowNodeSetup<
+  T extends ClassicScheme['Node'],
+  I extends { [key in keyof T['inputs']]: any },
+  O extends { [key in keyof T['outputs']]: any }
+> = {
+  inputs: () => (keyof I)[]
+  outputs: () => (keyof O)[]
+  // The typing here is weird. The data function of the setup returns a
+  // map of outputs, but here it indicates it just returns 0
+  data(fetchInputs: () => { [key in keyof I]: I[key][] }): O
+}
+
+/**
+ * Dataflow is a class that allows to process nodes in a graph using Dataflow approach.
+ * @priority 8
+ */
+export class Dataflow<Schemes extends ClassicScheme> {
+  setups = new Map<NodeId, DataflowNodeSetup<any, any, any>>();
+
+  /**
+   * @param editor NodeEditor instance
+   */
+  constructor(private editor: NodeEditor<Schemes>) { }
+
+  /**
+   * Adds the node to the dataflow.
+   * @param node Node instance
+   * @param setup Set of functions that define how to process the node
+   */
+  public add<T extends Schemes['Node']>(node: T, setup: DataflowNodeSetup<T, any, any>) {
+    const affected = this.setups.get(node.id);
+
+    if (affected) {
+      throw new Error('already processed');
+    }
+    this.setups.set(node.id, setup);
+  }
+
+  /**
+   * Removes the node from the dataflow.
+   * @param nodeId Node id
+   */
+  public remove(nodeId: NodeId) {
+    this.setups.delete(nodeId);
+  }
+
+  /**
+   * Fetches inputs of the node.
+   * Unlike `fetch` method, this method doesn't call `data` function of the specified node
+   * (but does call `data` for predecessor nodes recursively).
+   * @param nodeId Node id
+   * @returns Object with inputs
+   */
+  public fetchInputs(nodeId: NodeId) {
+    const result = this.setups.get(nodeId);
+
+    if (!result) throw new Error('node is not initialized');
+
+    const inputKeys = result.inputs();
+
+    const cons = this.editor.getConnections().filter(c => {
+      return c.target === nodeId && inputKeys.includes(c.targetInput);
+    });
+
+    const inputs: Record<string, any> = {};
+    const consWithSourceData = cons.map(c => {
+      return {
+        c,
+        sourceData: this.fetch(c.source)
+      };
+    });
+
+    for (const { c, sourceData } of consWithSourceData) {
+      // TODO: this "previous" variable is why the inputs are passed as arrays
+      // to the node data methods.
+      // This is to support multiple connections to the same input socket.
+      // We don't currently support this.
+      const previous = inputs[c.targetInput] ? inputs[c.targetInput] : [];
+
+      inputs[c.targetInput] = [...previous, sourceData[c.sourceOutput]];
+    }
+
+    return inputs;
+  }
+
+  /**
+   * Fetches outputs of the node.
+   * This method recursively calls `data` function of the predecessor nodes until receives
+   * all of the required inputs and calls `data` function of the specified node.
+   * @param nodeId Node id
+   * @returns Object with outputs
+   */
+  public fetch(nodeId: NodeId): Record<string, any> {
+    const result = this.setups.get(nodeId);
+
+    if (!result) throw new Error('node is not initialized');
+
+    const outputKeys = result.outputs();
+    const data = result.data(() => this.fetchInputs(nodeId));
+
+    const returningKeys = Object.keys(data) as (string | number | symbol)[];
+
+    if (!outputKeys.every(key => returningKeys.includes(key))) {
+      throw new Error(`dataflow node "${nodeId}" doesn't return all of required properties. ` +
+        `Expected "${outputKeys.join('", "')}". Got "${returningKeys.join('", "')}"`);
+    }
+
+    return data;
+  }
+}

--- a/src/plugins/dataflow/nodes/engine/readme.md
+++ b/src/plugins/dataflow/nodes/engine/readme.md
@@ -1,0 +1,31 @@
+This is a re-write of the Rete Dataflow engine.
+
+The Rete Dataflow engine uses asynchronous calls to each node's data method. This conflicts with MobX and MobX React's transaction mechanism to optimize re-renders.
+
+Our engine here strips out all of the async code so the full update can be wrapped in a single MobX transaction. At some point this might cause problems if there are too many nodes and they take too long to process. Currently this synchronous approach is more efficient.
+
+You can compare these files to the ones in https://github.com/retejs/engine.
+
+The original files were licensed with:
+
+MIT License
+
+Copyright (c) 2023 "Ni55aN" Vitaliy Stoliarov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/plugins/dataflow/nodes/engine/utils/cache.ts
+++ b/src/plugins/dataflow/nodes/engine/utils/cache.ts
@@ -1,0 +1,32 @@
+export class Cache<Key, T> {
+  cache = new Map<Key, T>();
+
+  constructor(private onDelete?: (item?: T) => void) {}
+
+  get(key: Key) {
+    return this.cache.get(key);
+  }
+
+  add(key: Key, data: T) {
+    if (this.cache.has(key)) throw new Error('cache already exists');
+
+    this.cache.set(key, data);
+  }
+
+  patch(key: Key, data: T) {
+    this.cache.set(key, data);
+  }
+
+  delete(key: Key) {
+    const item = this.cache.get(key);
+
+    this.cache.delete(key);
+    this.onDelete && this.onDelete(item);
+  }
+
+  clear() {
+    Array.from(this.cache.keys()).forEach(item => {
+      this.delete(item);
+    });
+  }
+}

--- a/src/plugins/dataflow/nodes/node-editor-mst.ts
+++ b/src/plugins/dataflow/nodes/node-editor-mst.ts
@@ -10,7 +10,6 @@ export class NodeEditorMST extends NodeEditor<Schemes> {
 
   constructor(
     private mstProgram: DataflowProgramModelType,
-    private process: () => void,
     private createReteNodeFromNodeModel: (id: string, model: IBaseNodeModel) => IBaseNode | undefined
   ) {
     super();
@@ -130,10 +129,6 @@ export class NodeEditorMST extends NodeEditor<Schemes> {
 
     // Temporarily emit like normal so we can get things back to working.
     await this.emit({ type: 'nodecreated', data: node });
-
-    // run the process command so this newly added node can update any controls like the
-    // value control.
-    this.process();
 
     return true;
   }


### PR DESCRIPTION
This combines all of the changes made during the onTick and data methods of each node into a single MST action.

It was necessary to fork our own version of the rete dataflow engine which runs synchronously to make this work properly.

The multiple changes per tick caused several negative effects:
- multiple history events were created each tick. The history code gets slower the more history events there are, so this caused a slow down.
- multiple react renders were triggered one for each MST change was completed.  This caused a lot of overhead for each change.
- more storage was needed since there is a wrapper around each of the history events
- the snapshot changes triggered network updates to store the document content.