### PR TITLE
process in read only mode too

### DIFF
--- a/src/lib/debug.ts
+++ b/src/lib/debug.ts
@@ -30,6 +30,7 @@ export function debugLog(enabled: boolean, message: any, ...params: any[]) {
 export const DEBUG_BOOKMARKS = debugContains("bookmarks");
 export const DEBUG_CANVAS = debugContains("canvas");
 export const DEBUG_CMS = debugContains("cms");
+export const DEBUG_DATAFLOW = debugContains("dataflow");
 export const DEBUG_DOC_LIST = debugContains("docList");
 export const DEBUG_DOCUMENT = debugContains("document");
 export const DEBUG_DROP = debugContains("drop");

--- a/src/models/tiles/tile-model.ts
+++ b/src/models/tiles/tile-model.ts
@@ -76,6 +76,7 @@ export const TileModel = types
      * can provide a title. The empty string is considered an "unset" title.
      */
     get computedTitle() {
+      // FIXME: this causes an MST error when the dataflow tile is deleted now
       return self.title || self.content.contentTitle || "";
     },
     // generally negotiated with tile, e.g. single column width for table

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -205,7 +205,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
       const contentCopy = DataflowContentModel.create(contentSnapshot);
       this.playbackReteManager = new ReteManager(
         contentCopy.program, this.tileId, this.playbackToolDiv, contentCopy, this.stores,
-        this.props.runnable, this.props.readOnly, true
+        this.props.runnable, true, true
       );
 
       // When we first show the playbackToolDiv after finishing recording it would show

--- a/src/plugins/dataflow/nodes/controls/dropdown-list-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/dropdown-list-control.tsx
@@ -85,9 +85,6 @@ export class DropdownListControl<
 
   public setValue(val: string) {
     this.setter(val);
-
-    // trigger a reprocess so our new value propagates through the nodes
-    this.node.process();
   }
 
   public getValue() {

--- a/src/plugins/dataflow/nodes/controls/input-value-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/input-value-control.tsx
@@ -3,17 +3,13 @@ import "./value-control.sass";
 import React from "react";
 import { observer } from "mobx-react";
 import { computed, makeObservable } from "mobx";
-import { IBaseNode, IBaseNodeModel } from "../base-node";
-import { MinigraphOptions, defaultMinigraphOptions } from "../dataflow-node-plot";
+import { IBaseNode } from "../base-node";
+import { MinigraphOptions, defaultMinigraphOptions } from "../dataflow-node-plot-types";
 import { PlotButtonControl, PlotButtonControlComponent } from "./plot-button-control";
 
 import "./input-value-control.scss";
 
-export class InputValueControl<
-  ModelType extends Record<Key, number>,
-  NodeType extends { model: ModelType } & IBaseNode,
-  Key extends keyof NodeType['model'] & string
->
+export class InputValueControl
   extends ClassicPreset.Control
   implements IInputValueControl
 {
@@ -27,8 +23,8 @@ export class InputValueControl<
   // watchedValue property.
 
   constructor(
-    public node: NodeType,
-    public modelKey: Key,
+    public node: IBaseNode,
+    public inputName: string,
     public label = "",
     public tooltip = "Something", // FIXME: need better default
     public getDisplayMessage: () => string
@@ -43,12 +39,12 @@ export class InputValueControl<
 
   @computed
   public get connected() {
-    return this.node.isConnected(this.modelKey);
+    return this.node.isConnected(this.inputName);
   }
 
   @computed
   public get legendDotStyle() {
-    const graphStyle = this.model.watchedValues[this.modelKey];
+    const graphStyle = this.model.watchedValues[this.inputName];
     return graphStyle ?? defaultMinigraphOptions;
   }
 
@@ -60,9 +56,7 @@ export class InputValueControl<
 
 export interface IInputValueControl {
   id: string;
-  node: IBaseNode;
-  model: IBaseNodeModel;
-  modelKey: string;
+  inputName: string;
   label: string;
   tooltip: string;
   getDisplayMessage(): string;

--- a/src/plugins/dataflow/nodes/controls/num-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/num-control.tsx
@@ -54,9 +54,6 @@ export class NumberControl<
 
     this.setter(val);
 
-    // trigger a reprocess so our new value propagates through the nodes
-    this.node.process();
-
     this.node.logControlEvent("numberinputmanualentry", "nodenumber", this.modelKey, val);
   }
 

--- a/src/plugins/dataflow/nodes/controls/num-units-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/num-units-control.tsx
@@ -62,9 +62,6 @@ export class NumberUnitsControl <
     }
 
     this.setter(val);
-
-    // trigger a reprocess so our new value propagates through the nodes
-    this.node.process();
   }
 
   public getValue() {
@@ -72,10 +69,9 @@ export class NumberUnitsControl <
   }
 
   /**
-   * This will not convert the value. In order to support a user changing the units
-   * of a value, the caller needs to convert value at the same time they change the
-   * units. Because the units do not change the underlying value, there should be no
-   * need to reprocess the node when just the units change.
+   * This will not convert the value. That should be done by the caller.
+   * Because the underlying value doesn't change here we don't need to reprocess
+   * the node.
    *
    * @param val
    */

--- a/src/plugins/dataflow/nodes/dataflow-node-plot-types.ts
+++ b/src/plugins/dataflow/nodes/dataflow-node-plot-types.ts
@@ -1,0 +1,11 @@
+import { NodePlotColor } from "../model/utilities/node";
+
+export interface MinigraphOptions {
+  backgroundColor?: string;
+  borderColor?: string;
+}
+
+export const defaultMinigraphOptions: MinigraphOptions = {
+  backgroundColor: NodePlotColor,
+  borderColor: NodePlotColor
+};

--- a/src/plugins/dataflow/nodes/dataflow-node-plot.tsx
+++ b/src/plugins/dataflow/nodes/dataflow-node-plot.tsx
@@ -13,16 +13,6 @@ interface INodePlotProps {
   model: IBaseNodeModel;
 }
 
-export interface MinigraphOptions {
-  backgroundColor?: string;
-  borderColor?: string;
-}
-
-export const defaultMinigraphOptions: MinigraphOptions = {
-  backgroundColor: NodePlotColor,
-  borderColor: NodePlotColor
-};
-
 let stepY = 5;
 
 // CHECKME: dsMax defaults to -Infinity this might cause a problem
@@ -122,7 +112,7 @@ function lineData(model: IBaseNodeModel) {
   stepY = (maxY(model) - minY(model)) / 2;
 
   const chartData: ChartData = {
-    labels: new Array(kMaxNodeValues).fill(undefined).map((val,idx) => idx),
+    labels: new Array(kMaxNodeValues+1).fill(undefined).map((val,idx) => idx),
     datasets: chartDataSets
   };
 

--- a/src/plugins/dataflow/nodes/logic-node.ts
+++ b/src/plugins/dataflow/nodes/logic-node.ts
@@ -1,10 +1,10 @@
 import { ClassicPreset } from "rete";
-import { Instance, types } from "mobx-state-tree";
+import { Instance } from "mobx-state-tree";
 import { numSocket } from "./num-socket";
 import { ValueControl } from "./controls/value-control";
 import { getNumDisplayStr } from "./utilities/view-utilities";
 import { NodeOperationTypes } from "../model/utilities/node";
-import { BaseNode, BaseNodeModel, StringifiedNumber } from "./base-node";
+import { BaseNode, BaseNodeModel } from "./base-node";
 import { DropdownListControl, IDropdownListControl } from "./controls/dropdown-list-control";
 import { PlotButtonControl } from "./controls/plot-button-control";
 import { typeField } from "../../../utilities/mst-utils";
@@ -14,16 +14,15 @@ export const LogicNodeModel = BaseNodeModel.named("LogicNodeModel")
 .props({
   type: typeField("Logic"),
   logicOperator: "Greater Than",
-
-  // TODO: we'll have to deal with migrating this somehow, we might
-  // need to run the process function once for imported dataflow tiles
-  // so these inputs get saved
-  num1: types.maybe(StringifiedNumber),
-  num2: types.maybe(StringifiedNumber),
 })
-.actions(self => ({
+.volatile(self => ({
+  num1: NaN,
+  num2: NaN,
+})).actions(self => ({
   setLogicOperator(val: string) {
     self.logicOperator = val;
+    // When the logic operator changes we need to update all of the downstream nodes
+    self.process();
   },
   setNum1(val: number) {
     self.num1 = val;
@@ -82,10 +81,6 @@ export class LogicNode extends BaseNode<
     const result = this.model.nodeValue;
     const resultStr = getNumDisplayStr(result);
 
-    if (this.services.playback) {
-      return ` ⇒ ${resultStr}`;
-    }
-
     const { num1, num2 } = this.model;
 
     const nodeOperationTypes = NodeOperationTypes.find(op => op.name === this.model.logicOperator);
@@ -116,15 +111,12 @@ export class LogicNode extends BaseNode<
       }
     }
 
-    // TODO: we should try to wrap these data functions in an action so all of their
-    // changes are grouped together.
-
     // The input numbers are saved so readOnly views can display the sentence
     this.model.setNum1(n1);
     this.model.setNum2(n2);
 
     // This nodeValue is used to record the recent values of the node
-    this.model.setNodeValue(result);
+    this.saveNodeValue(result);
 
     return { value: result };
   }

--- a/src/plugins/dataflow/nodes/number-node.ts
+++ b/src/plugins/dataflow/nodes/number-node.ts
@@ -27,6 +27,7 @@ export const NumberNodeModel = BaseNodeModel.named("NumberNodeModel")
 .actions(self => ({
   setValue(val: number) {
     self.value = val;
+    self.process();
   }
 }));
 export interface INumberNodeModel extends Instance<typeof NumberNodeModel> {}
@@ -56,8 +57,10 @@ export class NumberNode extends BaseNode<
   }
 
   data(): { value: number } {
-    // Save the updated value so it can be recorded in recent values on each tick
-    this.model.setNodeValue(this.model.value);
+    if (this.services.inTick) {
+      // Save the updated value so it can be recorded in recent values on each tick
+      this.saveNodeValue(this.model.value);
+    }
     return { value: this.model.value };
   }
 }

--- a/src/plugins/dataflow/nodes/rete-manager.tsx
+++ b/src/plugins/dataflow/nodes/rete-manager.tsx
@@ -3,7 +3,7 @@ import { structures } from "rete-structures";
 import { ConnectionPlugin, Presets as ConnectionPresets } from "rete-connection-plugin";
 import { Presets, ReactPlugin } from "rete-react-plugin";
 import { AreaExtensions, AreaPlugin } from "rete-area-plugin";
-import { onSnapshot } from "mobx-state-tree";
+import { onPatch, onSnapshot } from "mobx-state-tree";
 
 import { IStores } from "../../../models/stores/stores";
 import { DataflowContentModelType } from "../model/dataflow-content";
@@ -37,15 +37,18 @@ import { InputValueControl, InputValueControlComponent } from "./controls/input-
 import { DataflowEngine } from "./engine/dataflow-engine";
 import { ValueWithUnitsControl, ValueWithUnitsControlComponent } from "./controls/value-with-units-control";
 import { DataflowProgramChange } from "../dataflow-logger";
+import { runInAction } from "mobx";
 
 const MAX_ZOOM = 2;
 const MIN_ZOOM = .1;
 
-export class ReteManager {
+export class ReteManager implements INodeServices {
   public editor: NodeEditorMST;
   public engine = new DataflowEngine<Schemes>();
   public area: AreaPlugin<Schemes, AreaExtra>;
   private snapshotDisposer: () => void | undefined;
+  public inTick = false;
+  public disposed = false;
 
   constructor(
     private mstProgram: DataflowProgramModelType,
@@ -59,6 +62,7 @@ export class ReteManager {
   ){
     this.editor = new NodeEditorMST(mstProgram, this.createReteNodeFromNodeModel);
     this.area = new AreaPlugin<Schemes, AreaExtra>(div);
+    this.updateMainProcessor();
 
     this.setup();
   }
@@ -197,6 +201,8 @@ export class ReteManager {
     // Notify after the area, connection, and render plugins have been configured
     await this.notifyAboutExistingObjects();
 
+    // Need to do an initial process after all of the nodes are create so their inputs are correct
+    this.processAfterProgramChange();
 
     if (!this.readOnly) {
       editor.addPipe(context => {
@@ -207,12 +213,12 @@ export class ReteManager {
           const targetNode = editor.getNode(target);
           const change: DataflowProgramChange = {
             targetType: 'connection',
-            nodeTypes: [sourceNode.label, targetNode.label],
-            nodeIds: [sourceNode.id, targetNode.id],
-            connectionOutputNodeId: sourceNode.id,
-            connectionOutputNodeType: sourceNode.label,
-            connectionInputNodeId: targetNode.id,
-            connectionInputNodeType: targetNode.label
+            nodeTypes: [sourceNode?.label, targetNode?.label],
+            nodeIds: [source, target],
+            connectionOutputNodeId: source,
+            connectionOutputNodeType: sourceNode?.label,
+            connectionInputNodeId: target,
+            connectionInputNodeType: targetNode?.label
           };
           this.logTileChangeEvent({operation: context.type, change});
         }
@@ -229,20 +235,27 @@ export class ReteManager {
 
         return context;
       });
+
+      // Reprocess when connections are changed
+      // And also count the serial nodes some of which only get counted if they are
+      // connected
+      editor.addPipe((context) => {
+        if (["noderemoved", "connectioncreated", "connectionremoved"].includes(context.type)) {
+          // FIXME: Any changes to the state caused by these events should be combined
+          // into the history entry with the actual node removal, connection creation or removal
+          // In the meantime we wrap this in an action so it only creates one more history entry
+          this.processAfterProgramChange();
+          this.countSerialDataNodes();
+        }
+        return context;
+      });
     }
 
-    // Reprocess when connections are changed
-    // And also count the serial nodes some of which only get counted if they are
-    // connected
-    editor.addPipe((context) => {
-      if (["noderemoved", "connectioncreated", "connectionremoved"].includes(context.type)) {
-        this.process();
-        this.countSerialDataNodes();
-      }
-      return context;
-    });
-
     this.setupOnSnapshot();
+  }
+
+  private processAfterProgramChange() {
+    this.mstProgram.processAfterProgramChange(this.process);
   }
 
   public async notifyAboutExistingObjects() {
@@ -264,9 +277,49 @@ export class ReteManager {
     }
   }
 
+  private updateMainProcessor() {
+    const { mstProgram, readOnly, disposed } = this;
+    if (disposed) {
+      console.warn("Trying to process after being disposed");
+      return;
+    }
+    const { processor } = mstProgram;
+    if (processor === this) {
+      // We already are the processor
+      return;
+    }
+
+    if (
+        // There is no processor, so we are best option
+        !processor ||
+
+        // The processor is disposed, so we are better
+        processor.disposed ||
+
+        // We are not readonly but the processor is, so we are better
+        !readOnly && processor.readOnly
+    ) {
+      mstProgram.setProcessor(this);
+    }
+  }
+
   public process = () => {
-    // Don't do any processing when we are read-only
-    if (this.readOnly) return;
+    this.updateMainProcessor();
+
+    // Only do the process if we are main processor for this MST Program
+    if (this.mstProgram.processor !== this) return;
+
+    let readOnPatchDisposer;
+    if (this.readOnly) {
+      console.log("readOnly process called");
+      readOnPatchDisposer = onPatch(this.mstContent, (patch) => {
+        // It is likely that Dataflow will kind of crash when this happens
+        // So you'll need to fix the problem, and possibly disable readOnly processing
+        // to get the original diagram to load if you need to modify it before fixing
+        // this.
+        console.warn("readOnly process modified the tile", patch);
+      });
+    }
 
     const { editor } = this;
 
@@ -282,6 +335,8 @@ export class ReteManager {
     // will only be called once.
     const leafNodes = graph.leaves().nodes();
     leafNodes.forEach(n => this.engine.fetch(n.id));
+
+    readOnPatchDisposer?.();
   };
 
   public logTileChangeEvent = (
@@ -370,7 +425,11 @@ export class ReteManager {
     const id = uniqueId();
     const { editor } = this;
     const newPosition = position ?? this.getNewNodePosition();
-    console.log("createAndAddNode", nodeType, newPosition);
+    // FIXME: because this is not a single synchronous MST transaction
+    // the nodeValue of the added node is updated by the process call
+    // down below. This means that any readOnly views will try to initialize
+    // the nodeValue. That isn't a problem it is just confusing. The bigger
+    // problem is that this results in two history events so undo is broken.
     this.mstProgram.addNodeSnapshot({
       id,
       name: nodeType,
@@ -387,6 +446,8 @@ export class ReteManager {
     // This is not waiting for the emit before calling the process.
     // we might need to add it
     await editor.emit({ type: 'nodecreated', data: node });
+
+    this.processAfterProgramChange();
 
     this.area.translate(id, {x: newPosition[0], y: newPosition[1]});
   }
@@ -463,30 +524,18 @@ export class ReteManager {
     // This is wrapped in an MST action so all of the changes are batched together
     // We are using our own custom Rete Dataflow Engine which runs synchronously
     // so all calls to the nodes `data` and `onTick` methods are grouped together.
-    this.mstProgram.tickAndProcess(() => this._tickAndProcessNodes());
-  }
+    this.mstProgram.tickAndProcess(() => {
+      this.inTick = true;
+      this.process();
+      this.inTick = false;
 
-  private _tickAndProcessNodes() {
-    let processNeeded = false;
-
-    // This has to be hacked until we figure out the way to specify the Rete Schemes
-    // so its node type is our node specific node types
-    const nodes = this.editor.getNodes() as unknown as IBaseNode[];
-    nodes.forEach(node => {
-      // If tick returns true then it means something was updated
-      // and we need to reprocess the diagram
-      if(node.onTick()) {
-        processNeeded = true;
-      }
-      // Perhaps move this to the model since it should just be working on
-      // stuff in the model
-      node.model.updateRecentValues();
+      // This has to be hacked until we figure out the way to specify the Rete Schemes
+      // so its node type is our node specific node types
+      const nodes = this.editor.getNodes() as unknown as IBaseNode[];
+      nodes.forEach(node => {
+        node.model.updateRecentValues();
+      });
     });
-    if (processNeeded) {
-        // if we've updated values on 1 or more nodes (such as a generator),
-        // reprocess all nodes so current values are up to date
-        this.process();
-    }
   }
 
   public dispose() {
@@ -505,17 +554,19 @@ export class ReteManager {
       area.removeConnectionView(id);
     });
 
-    const nodes = editor.getNodes();
-    nodes.forEach(node => (node as IBaseNode).dispose());
+    // We aren't using editor.getNodes() because the editor might have been deleted
+    // So all we really want to do is clean up any of the rete nodes that might have
+    // timers running
+    Object.values(editor.reteNodesMap).forEach(node => (node as IBaseNode).dispose());
+
+    this.disposed = true;
   }
 
   public setupOnSnapshot() {
     // TODO: handle undo/redo events too
     if (!this.readOnly) return;
 
-    this.snapshotDisposer = onSnapshot(this.mstProgram, snapshot => {
-        this.updateProgramEditor(snapshot);
-    });
+    this.snapshotDisposer = onSnapshot(this.mstProgram, this.updateProgramEditor);
   }
 
   private updateProgramEditor = async (snapshot: DataflowProgramSnapshotOut) => {
@@ -528,6 +579,10 @@ export class ReteManager {
     // Process connections that were deleted
     for (const [id] of area.connectionViews) {
       if (!snapshot.connections[id]) {
+        // FIXME: this causes problems because the rete-area-plugin keeps a
+        // reference to the connection object in its connectionViews. And then
+        // it tries to access the id of this connection object. But MST complains
+        // because the connection object has already been removed from the tree
         await editor.emit({ type: 'connectionremoved', data: { id } as any });
       }
     }
@@ -564,6 +619,17 @@ export class ReteManager {
         area.translate(id, {x: snapshotNode.x, y: snapshotNode.y});
       }
     }
+
+    // Let the nodes update their volatile state so their components can show
+    // the input values without us storing them in state.
+    // We run this in an action because even in readOnly mode some node data
+    // functions update MobX or MobX State tree properties.
+    // We don't use processAfterProgramChange because it shouldn't be modifying
+    // and MST state, so MST should complain if a node's data method messes with
+    // the node model directly. If the data method uses an action this won't be
+    // reported. We also don't care about recording this in history because this
+    // is a readOnly doc.
+    runInAction(this.process);
   };
 
   public zoomIn = () => {

--- a/src/plugins/dataflow/nodes/service-types.ts
+++ b/src/plugins/dataflow/nodes/service-types.ts
@@ -13,6 +13,12 @@ export interface INodeServices {
   getOutputVariables(): VariableType[];
   getChannels(): NodeChannelInfo[];
   stores: IStores;
+  /**
+   * This will be true if dataflow is executing a sampling tick. It should be used by
+   * node `data` methods to read data from sensors or variables, write data to
+   * hardware or variables, generating data based on time.
+   */
+  inTick: boolean;
   runnable?: boolean;
   readOnly?: boolean;
   playback?: boolean;

--- a/src/plugins/dataflow/nodes/timer-node.ts
+++ b/src/plugins/dataflow/nodes/timer-node.ts
@@ -82,24 +82,20 @@ export class TimerNode extends BaseNode<
   };
 
   data(): { value: number } {
-    return { value: this.currentValue };
-  }
+    if (this.services.inTick) {
+      const timeOn = Number(this.model.timeOn);
+      const timeOff = Number(this.model.timeOff);
+      // FIXME: this won't handle 0s correctly
+      if (timeOn && timeOff) {
+        const time = Date.now();
 
-  onTick() {
-    const timeOn = Number(this.model.timeOn);
-    const timeOff = Number(this.model.timeOff);
-    // FIXME: this won't handle 0s correctly
-    if (timeOn && timeOff) {
-      const time = Date.now();
-
-      // time on/off is given in s, but we convert to ms so we can use a simple mod function
-      const timeOnMS = timeOn * 1000;
-      const timeOffMS = timeOff * 1000;
-      const value = time % (timeOnMS + timeOffMS) < timeOnMS ? 1 : 0;
-      this.model.setNodeValue(value);
-      return true;
+        // time on/off is given in s, but we convert to ms so we can use a simple mod function
+        const timeOnMS = timeOn * 1000;
+        const timeOffMS = timeOff * 1000;
+        const value = time % (timeOnMS + timeOffMS) < timeOnMS ? 1 : 0;
+        this.saveNodeValue(value);
+      }
     }
-
-    return false;
+    return { value: this.currentValue };
   }
 }

--- a/src/plugins/dataflow/nodes/transform-node.ts
+++ b/src/plugins/dataflow/nodes/transform-node.ts
@@ -1,10 +1,10 @@
 import { ClassicPreset } from "rete";
-import { Instance, types } from "mobx-state-tree";
+import { Instance } from "mobx-state-tree";
 import { numSocket } from "./num-socket";
 import { ValueControl } from "./controls/value-control";
 import { getNumDisplayStr } from "./utilities/view-utilities";
 import { NodeOperationTypes } from "../model/utilities/node";
-import { BaseNode, BaseNodeModel, StringifiedNumber } from "./base-node";
+import { BaseNode, BaseNodeModel } from "./base-node";
 import { DropdownListControl, IDropdownListControl } from "./controls/dropdown-list-control";
 import { PlotButtonControl } from "./controls/plot-button-control";
 import { typeField } from "../../../utilities/mst-utils";
@@ -14,15 +14,16 @@ export const TransformNodeModel = BaseNodeModel.named("TransformNodeModel")
 .props({
   type: typeField("Transform"),
   transformOperator: "Absolute Value",
-
-  // TODO: we'll have to deal with migrating this somehow, we might
-  // need to run the process function once for imported dataflow tiles
-  // so these inputs get saved
-  num1: types.maybe(StringifiedNumber),
 })
+.volatile(self => ({
+  num1: NaN,
+}))
 .actions(self => ({
   setTransformOperator(val: string) {
     self.transformOperator = val;
+    // When the transformOperator changes we want to update all of the
+    // downstream nodes
+    self.process();
   },
   setNum1(val: number) {
     self.num1 = val;
@@ -76,10 +77,6 @@ export class TransformNode extends BaseNode<
     const result = this.model.nodeValue;
     const resultStr = getNumDisplayStr(result);
 
-    if (this.services.playback) {
-      return ` → ${resultStr}`;
-    }
-
     const { num1 } = this.model;
     const nodeOperationTypes = NodeOperationTypes.find(op => op.name === this.model.transformOperator);
     if (nodeOperationTypes) {
@@ -97,9 +94,12 @@ export class TransformNode extends BaseNode<
 
     const nodeOperationTypes = NodeOperationTypes.find(op => op.name === this.model.transformOperator);
 
-    // FIXME: The "ramp" transform runs on each `data` call, not each `tick`.
+    // FIXME: The "ramp" transform runs on every `data` call, not just the `ticks`.
     // This is consistent with the previous implementation, but it means that it
-    // doesn't work properly in all cases
+    // doesn't work properly when the diagram is reprocessed not for a tick.
+    // For example a number node is changed. This could be fixed by including
+    // the time elapsed since the prevValue. Or we could change it to only change
+    // the ramp value during a tick.
     if (nodeOperationTypes) {
       if (isNaN(n1)) {
         result = NaN;
@@ -114,27 +114,12 @@ export class TransformNode extends BaseNode<
       }
     }
 
-    // TODO: we should try to wrap these data functions in an action so all of their
-    // changes are grouped together.
-
     // The input numbers are saved so readOnly views can display the sentence
     this.model.setNum1(n1);
 
     // This nodeValue is used to record the recent values of the node
-    this.model.setNodeValue(result);
+    this.saveNodeValue(result);
 
     return { value: result };
-  }
-
-  onTick() {
-    if (this.model.transformOperator === "Ramp") {
-      // If we are "ramping", we need to reprocess on every tick so the values can update
-      // Probably we should go further and move the ramp logic into onTick.
-      // If the program sampling rate is really slow and the user changes connections or
-      // values in another node that causes a reprocess that will cause the ramped value
-      // to change outside of the tick
-      return true;
-    }
-    return false;
   }
 }


### PR DESCRIPTION
- replace the onTick method on nodes with an inTick flag in services. This way nodes have access to the most recent input values during their tick code. This is because the data code is called in the order of input nodes to output nodes while the onTick was called in the insertion order of the nodes. Additional output nodes needed to make sure their data method was called first before the tick code, and previously this was not the case.
- now process is called on every tick so it isn't necessary for nodes to indicate if a tick should be trigger a reprocess
- add dataflow debug option which includes warnings when state might be changed incorrectly
- have the playback always run in readOnly mode, this way the code in node data functions should not update any state in the snapshot copy
- add a main dataflow processor to the MST program. This way just a single processor will be running for any instance of the MST program. Even if this program is displayed in multiple places. The main processor is updated if it is disposed or if a non readOnly tile is added.
- add a createAndAddNode action to wrap the process call that is made when a new node is added to the program, this way the process call recorded in one history event, and MobX doesn't complain about modifying state outside of an action
- add a process action to node models, this way when certain node model properties are changed, the node model can trigger a process inside of these set methods. So now a single history event is created when a user changes a pull down or a number field.
- add a saveNodeValue function to the base node (not model). data functions should use saveNodeValue instead of calling setNodeValue directly. This is so the call can be ignored in readOnly mode
- separate out the dataflow node plot types to avoid a circular dependency
- bug fix: show the last point on the plot when there are 17 recent values
- bug fix: logging of deleted nodes that were connected would sometimes fail.
- bug fix: when the manager is disposed when a tile is deleted, or the document is closed, it needs to dispose each of the nodes. If this disposal happens because of applying a snapshot from a remote document, the nodes will no longer exist in the MST tree. This was causing an MST error. The fix is to work with the node objects from the editor's cache instead of MST models.
- control node:
  - move the control node timerRunning into state so a readOnly view of the node can correctly show the "waiting" string.
  - call process when the control operator changes since this can change the output value of the node.
  - only use the special playback sentence when the waitDuration is not 0. When the duration isn't 0, we can correctly show the on or off status in the sentence.
  - only start the time when we are in a live view of the node
- demo output node:
  - move tilt into volatile, it is computed from the inputs to the node during its data method.
  - update the watchedValues in the data method so it only happens in one place if there are multiple views of the same program
- liveOutputNode: only save the output status if we are not readOnly
- logicNode:
  - move input saving to volatile now that process is called on readOnly tiles
  - remove special playback handling now that process is called during playback
- mathNode:
  - move input saving to volatile now that process is called on readOnly tiles
  - remove special playback handling now that process is called during playback
- number node:
  - call process when the number changes
  - only save the nodeValue on tick to be consistent with the other input nodes
- timer node:
  - move inputs to volatile,
  - call process when necessary
  - remove playback handling
- remove automatic process from dropdown list control, num control, and num units control
- simplify the input value control so it could be used for any input not just ones with model properties.