### PR TITLE
update live output node to not update state on tick

### DIFF
--- a/docs/dataflow.md
+++ b/docs/dataflow.md
@@ -1,5 +1,85 @@
-Development Guidelines
+# Program Views
 
-- Node `data` methods should not modify MST state. These functions will be called even on readonly views of the DataFlow tile. This can be used to update volatile or computed information that is based on a node's inputs and outputs.  This rule is violated by many of the nodes when they call setNodeValue in the `data` method. It is likely that these will need to be moved to the `onTick` method in order to support readonly views.
-- The `process` function should not modify MST state. Same as above
-- The `onTick` function can modify MST state, it should only be called when the tile is writable.
+There are several ways the program can be displayed:
+- a live editable view
+- a read only view when looking at the document on the left of CLUE
+- a read only view in a thumbnail of the document
+- a read only view when the program has been recorded
+
+When testing or updating the code of programs there are 4 cases to handle:
+- **single live view**: there is just one view of the program and it is editable.
+- **live plus readOnly views**: there is a live view of the program and there are other readOnly views in the same application displaying the program.
+- **only readOnly views**: there is one or more readOnly views and no live view.
+- **recorded program**: the program has been recorded and the user can play it back.
+
+## Single Live View
+This is the easiest and probably where you'll start your development. You can use the /doc-editor.html to work on this case.
+
+## Live plus ReadOnly Views
+This will happen when you have the same document open on the left and right side of CLUE at the same time. In some cases it is possible for a thumbnail of the document to also be active (sometimes visible sometimes not) at the same time.
+
+## Only ReadOnly Views
+This can happen when a user closes the live document on the right of CLUE and is just looking at it on the left. However that case doesn't usually cause problems. The harder case is when a second user is looking at document that is being edited by another user. The best way to test this is to use the CLUE `demo` mode to open a student browser tab and teacher browser tab for a class and then edit the document as a student and view the document as the teacher.
+
+## Recorded Program
+After the program has been recorded, a copy of the program is created and is displayed using a readOnly view of this copy. This readOnly view is updated when the user plays back the recording. The mechanism of this playback is not the same as the mechanism for showing a readOnly document to another user.
+
+# Dataflow processing
+
+Nodes can support data flowing through them using the `data` method. This method gets the input values from its input sockets, and needs to return the output values from its output sockets. The input values are arrays since in theory each input socket could have multiple connection to it. We do not support multiple connections to an input socket, so the arrays will always have 0 or 1 values.
+
+The program has a `process` method which calls the `data` method on all of the nodes. The order the node's `data` methods are called is based on program connections. Nodes which are inputs to other nodes have their `data` method called first. We don't currently support loops. Additionally during a single `process` the `data` method is only called once on a node. The value of this single `data` method is cached and used as the input for any nodes connected to it.
+
+The program is "processed":
+- when the program "ticks". This happens at the period of the selected sampling rate
+- when the program is first loaded
+- when a node calls `process` because the node changed one of its values which will affect downstream nodes
+- when the state of a readOnly program is changed underneath it
+
+In an application with multiple views of the same program only one of these views is the "main processor". If there is a live view of the program this view will be the "main processor". When there is no live view of the program one of the readOnly views will be the "main processor". It is this processor which calls the `data` function on the nodes.
+
+## Tick Support
+
+Several nodes need to do different things during the tick that they don't do during other `data` calls. This is done by checking the `services.inTick` boolean in their `data` method.
+
+- Input nodes: use the tick to "inject" a new value into the diagram. These are Sensor/Input node, Number node, Generator node, Timer node.
+- Output nodes: use the tick to "send" a new value to their output. Currently just Live Output uses this.
+
+Additionally each `watchedValue` of the node is recorded on each tick. These recorded values are used by the plots beneath each node.
+
+In a readOnly program, there is no tick. The `data` function will only be called when the program is changed underneath it. This is why the "only readOnly views" case described above should be tested.
+
+# Location of Node State
+
+Nodes can store stuff in several places:
+- **node model properties**: these values will get saved in the document, sent to any readOnly views of the tile, and will reload
+- **node model volatile**: these values will not be saved in the document, and not sent to a readOnly view that is in a different CLUE tab. They will be shared with readOnly views that are in the same CLUE tab. In otherwords they aren't shared with remote views of the program.
+- **tick entries**: *coming soon* these values will be saved in the document, and are related to a specific tick. They are shared between all of the views both local and remote.
+- **node instance properties**: these are not saved in the document, and not shared between any of the views.
+- **control instance properties**: these are not saved in the document, and not shared between any of the views.
+- **control component React places**: the controls have React components so they can use React state or React references to store state.
+
+In order to support the different program view cases described above, some conventions should be followed.
+
+## Node Model Properties
+This should be where settings the user can change on the node are stored. Such as the value of a drop down menu, or a numeric input. The `data` method should never update these properties. If it does it will cause problems with the undo system.
+
+## Node Model Volatile
+This is where nodes should put state that can be "recomputed" by a readOnly view's `data` function. By storing this state in volatile we will not bloat the state of the document and eliminate the chance of conflicts caused by undo. These properties are usually used by controls to display information about their controls.
+
+## Tick Entries (coming soon)
+This is where nodes should put their main `nodeValue` and any state that can not be "recomputed" by a readOnly view.
+
+## Node Instance Properties
+These are usually used when a node needs to work with a control after it has been created.
+
+# Recording and Playback Support
+
+A key part of recording and playback is that the diagram is locked during the recording. So the user cannot change numeric inputs or drop down menus of the nodes. And after recording the program remained locked until the user clears it. This way the user can playback the recording and the only information need for a near perfect playback are a single value from each nodes. These values are stored in a dataset so they can be used by other tiles in CLUE.
+
+A recorded program is played back by making a copy of the `DataflowProgramModel` MST object and creating a `playbackReteManager` with this model. This `playbackReteManager` is bound to a second div in the DataflowProgram component.
+
+Then on each "tick" the DataflowProgram updates each node's value from the data in the dataset. The dataset does not include the inputs of each node. The `process` is run after these values are updated.
+
+In most cases this provides enough information for the node displays (sentences or displayValues) to show the same value the user saw when the program was running for real. The one current exception is the control node (Hold block) which can't tell if its "wait" timer was running during the playback tick. So in this case the control node shows a slightly different display.
+

--- a/src/plugins/dataflow/model/utilities/node.ts
+++ b/src/plugins/dataflow/model/utilities/node.ts
@@ -456,13 +456,19 @@ export const NodeGeneratorTypes = [
 ];
 
 export const baseLiveOutputOptions = {
-   liveGripperOption: {
+  liveGripperOption: {
     active: true,
     icon: GrabberIcon,
     id: "bb-gripper",
     name: "Physical Gripper"
   },
-  warningOption: {
+  noDeviceLiveGripperOption: {
+    active: true,
+    id: "no-device-bb-gripper",
+    name: "Physical Gripper",
+    displayName: "⚠️ connect device",
+  },
+  genericWarningOption: {
     active: true,
     id: "no-outputs-found",
     name: "⚠️ connect device",

--- a/src/plugins/dataflow/nodes/control-node.ts
+++ b/src/plugins/dataflow/nodes/control-node.ts
@@ -99,7 +99,8 @@ export class ControlNode extends BaseNode<
       const { name, displayName, icon } = nodeOp;
       return { name, displayName, icon };
     });
-    const dropdownControl = new DropdownListControl(this, "controlOperator", dropdownOptions);
+    const dropdownControl =
+      new DropdownListControl(this, "controlOperator", model.setControlOperator, dropdownOptions);
     this.addControl("controlOperator", dropdownControl);
 
     const valueControl = new NumberControl(this, "waitDuration", "wait", null, "", "secs");

--- a/src/plugins/dataflow/nodes/controls/dropdown-list-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/dropdown-list-control.tsx
@@ -35,7 +35,6 @@ const optionLabelClass = (str?: string) => {
 export class DropdownListControl<
   ModelType extends
     Record<Key, string> &
-    Record<`set${Capitalize<Key>}`, (val: string) => void> &
     IBaseNodeModel,
   NodeType extends { model: ModelType } & IBaseNode,
   Key extends keyof NodeType['model'] & string
@@ -43,8 +42,6 @@ export class DropdownListControl<
   extends ClassicPreset.Control
   implements IDropdownListControl
 {
-  setter: (val: string) => void;
-
   @observable
   disabledFunction?: DisabledChecker;
 
@@ -58,7 +55,7 @@ export class DropdownListControl<
   constructor(
     public node: NodeType,
     public modelKey: Key,
-
+    public setter: (val: string) => void,
     optionArray: ListOption[],
     public tooltip = "Select Type", // This is not currently passed
     public placeholder = "Select an option",
@@ -69,12 +66,6 @@ export class DropdownListControl<
     super();
     this.optionArray = optionArray;
     this.optionsFunc = optionsFunc;
-
-    const setterProp = "set" + modelKey.charAt(0).toUpperCase() + modelKey.slice(1) as `set${Capitalize<Key>}`;
-
-    // The typing above using `set${Capitalize<Key>}` almost works, but it fails here
-    // I'm pretty sure there is a way to make it work without having to use the "as any" here
-    this.setter = this.model[setterProp] as any;
 
     makeObservable(this);
   }
@@ -170,11 +161,11 @@ export class DropdownListControl<
   }
 
   // This is used by the live output node
+  @action
   public setActiveOption(id: string, state: boolean) {
     if (this.optionArray){
       const option = this.optionArray.find(o => o.id === id);
       if(option){
-        // TODO: this is not currently triggering any updates itself
         option.active = state;
       }
     }
@@ -200,6 +191,7 @@ export interface IDropdownListControl {
   getValue(): string;
   setValue(val: string): void;
   disabledFunction?: DisabledChecker;
+  setActiveOption(id: string, state: boolean): void;
   logEvent(operation: string): void;
   selectNode(): void;
   getSelectionId(): string | undefined;

--- a/src/plugins/dataflow/nodes/demo-output-node.ts
+++ b/src/plugins/dataflow/nodes/demo-output-node.ts
@@ -64,7 +64,6 @@ export class DemoOutputNode extends BaseNode<
   },
   IDemoOutputNodeModel
 > {
-  demoOutputControl: DemoOutputControl;
   disposeTiltMonitor?: () => void;
 
   constructor(
@@ -79,7 +78,7 @@ export class DemoOutputNode extends BaseNode<
 
     // Copy the types so typescript doesn't complain that they are readonly
     const outputTypes = [...NodeDemoOutputTypes];
-    const dropdownControl = new DropdownListControl(this, "outputType", outputTypes);
+    const dropdownControl = new DropdownListControl(this, "outputType", model.setOutputType, outputTypes);
     this.addControl("outputType", dropdownControl);
 
     const demoOutputControl = new DemoOutputControl(model);

--- a/src/plugins/dataflow/nodes/generator-node.ts
+++ b/src/plugins/dataflow/nodes/generator-node.ts
@@ -61,7 +61,7 @@ export class GeneratorNode extends BaseNode<
     const dropdownOptions = NodeGeneratorTypes.map((nodeOp) => {
       return { name: nodeOp.name, icon: nodeOp.icon };
     });
-    const dropdownControl = new DropdownListControl(this, "generatorType", dropdownOptions);
+    const dropdownControl = new DropdownListControl(this, "generatorType", model.setGeneratorType, dropdownOptions);
     this.addControl("generatorType", dropdownControl);
 
     const ampControl = new NumberControl(this, "amplitude", "amplitude",

--- a/src/plugins/dataflow/nodes/live-output-node.ts
+++ b/src/plugins/dataflow/nodes/live-output-node.ts
@@ -132,7 +132,7 @@ export class LiveOutputNode extends BaseNode<
     } else {
       this.hubSelectControl = new DropdownListControl(this, "hubSelect", model.setHubSelect, []);
 
-      if (!model.hubSelect) {
+      if (!model.liveOutputType) {
         // Set the default value. This also updates the hubSelect depending on the connected device and
         // and simulation.
         // FIXME: this might cause problems with undo support since it is changing the state on node

--- a/src/plugins/dataflow/nodes/live-output-node.ts
+++ b/src/plugins/dataflow/nodes/live-output-node.ts
@@ -10,29 +10,78 @@ import { NodeLiveOutputTypes, NodeMicroBitHubs, baseLiveOutputOptions,
   kGripperOutputTypes, kMicroBitHubRelaysIndexed } from "../model/utilities/node";
 import { InputValueControl } from "./controls/input-value-control";
 import { SerialDevice } from "../../../models/stores/serial";
-import { VariableType } from "@concord-consortium/diagram-view";
 import { simulatedHub, simulatedHubName } from "../model/utilities/simulated-output";
+import { VariableType } from "@concord-consortium/diagram-view";
+import { runInAction } from "mobx";
 
 // TODO: the list of sensors is populated on the tick, so if the tick is slow, the
 // list of sensors will not update very well
 export const LiveOutputNodeModel = BaseNodeModel.named("LiveOutputNodeModel")
 .props({
   type: typeField("Live Output"),
-  liveOutputType: "Gripper 2.0",
-  // The default in the old DF was "connect device", choosing this does not bring up
-  // the dialog, but it doesn't in the old one either. Hmm.
+  liveOutputType: "",
   hubSelect: "",
   // We record this in state so readOnly views of this node can mirror the status
   // without needing to track all of the channel state
   outputStatus: ""
 })
-.actions(self => ({
-  setLiveOutputType(outputType: string) {
-    self.liveOutputType = outputType;
-    // There is nothing downstream from us so we don't need to reprocess
+.views(self => ({
+  get isGripperType() {
+    return kGripperOutputTypes.includes(self.liveOutputType);
   },
+  get isRelayType() {
+    return kMicroBitHubRelaysIndexed.includes(self.liveOutputType);
+  },
+}))
+.actions(self => ({
   setHubSelect(hub: string) {
     self.hubSelect = hub;
+    // There is nothing downstream from us so we don't need to reprocess
+  },
+}))
+.actions(self => ({
+  setLiveOutputType(outputType: string, deviceFamily: string | undefined,
+      getSharedVar: () => VariableType | undefined )
+  {
+    if (outputType === self.liveOutputType) return;
+
+    self.liveOutputType = outputType;
+
+    // Get the shared variable after setting our new outputType since
+    // the variable depends on the outputType
+    const sharedVar = getSharedVar();
+    console.log("setLiveOutputType.sharedVariable", sharedVar?.getAllOfType("live-output"));
+    if (self.isGripperType) {
+      if (deviceFamily === "arduino") {
+        // If we have a connected arduino we should have a gripper, prefer that
+        self.setHubSelect(baseLiveOutputOptions.liveGripperOption.name);
+      } else if (sharedVar) {
+        self.setHubSelect(simulatedHubName(sharedVar));
+      } else {
+        // Without a valid device, or variable, default to the device
+        // The options list will be updated so this device option will prompt the user to
+        // connect a device
+        self.setHubSelect(baseLiveOutputOptions.liveGripperOption.name);
+      }
+    }
+
+    // When a relay type is selected this is used with the microbit where hubs need to be
+    // selected. We can't just automatically choose a particular hub.
+    if (self.isRelayType) {
+      if (deviceFamily === "microbit") {
+        // Prompt the user to select an option if there is a microbit connected
+        self.setHubSelect("");
+      } else if (sharedVar) {
+        self.setHubSelect(simulatedHubName(sharedVar));
+      } else {
+        // Without a valid device, or variable, default to a warning suggesting they
+        // connect a device
+        self.setHubSelect(baseLiveOutputOptions.genericWarningOption.name);
+      }
+    }
+
+    // TODO: what do we do with the new servo type?
+
     // There is nothing downstream from us so we don't need to reprocess
   },
   setOutputStatus(status: string) {
@@ -64,7 +113,8 @@ export class LiveOutputNode extends BaseNode<
     const nodeValueInput = new ClassicPreset.Input(numSocket, "NodeValue");
     this.addInput("nodeValue", nodeValueInput);
 
-    const liveOutputControl = new DropdownListControl(this, "liveOutputType", NodeLiveOutputTypes);
+    const liveOutputControl =
+      new DropdownListControl(this, "liveOutputType", this.setLiveOutputTypeWrapper, NodeLiveOutputTypes);
     this.addControl("liveOutputType", liveOutputControl);
 
     if (this.readOnly) {
@@ -76,11 +126,21 @@ export class LiveOutputNode extends BaseNode<
       // TODO: this could be improved by serializing more info about the current hubSelect option
       // like the displayName, active, and missing properties. This way the readOnly view could
       // display these as well.
-      this.hubSelectControl = new DropdownListControl(this, "hubSelect", [], undefined, undefined,
+      this.hubSelectControl = new DropdownListControl(this, "hubSelect", model.setHubSelect, [], undefined, undefined,
         this.getReadOnlyHubSelectOptions
       );
     } else {
-      this.hubSelectControl = new DropdownListControl(this, "hubSelect", NodeMicroBitHubs);
+      this.hubSelectControl = new DropdownListControl(this, "hubSelect", model.setHubSelect, []);
+
+      if (!model.hubSelect) {
+        // Set the default value. This also updates the hubSelect depending on the connected device and
+        // and simulation.
+        // FIXME: this might cause problems with undo support since it is changing the state on node
+        // initialization, we'll have to make sure this happens within the node creation action
+        this.setLiveOutputTypeWrapper("Gripper 2.0");
+      }
+      // Update the options now that we have a type
+      this.setHubSelectOptions();
     }
     this.addControl("hubSelect", this.hubSelectControl);
 
@@ -88,6 +148,12 @@ export class LiveOutputNode extends BaseNode<
       this.getDisplayMessageWithStatus);
     nodeValueInput.addControl(inputValueControl);
   }
+
+  setLiveOutputTypeWrapper = (val: string) => {
+    this.model.setLiveOutputType(val, this.deviceFamily, this.getPotentialOutputVariable);
+    // Update the options now that our type might have changed
+    this.setHubSelectOptions();
+  };
 
   getReadOnlyHubSelectOptions = () => {
     if (this.model.hubSelect) {
@@ -97,9 +163,18 @@ export class LiveOutputNode extends BaseNode<
     }
   };
 
-  findOutputVariable() {
+  getPotentialOutputVariable = () => {
     const type = this.model.liveOutputType;
     return this.services.getOutputVariables().find(variable => variable.getAllOfType("live-output").includes(type));
+  };
+
+  private getSelectedOutputVariable() {
+    const outputVariable = this.getPotentialOutputVariable();
+    if (outputVariable && this.model.hubSelect === simulatedHubName(outputVariable)) {
+      return outputVariable;
+    } else {
+      return undefined;
+    }
   }
 
   public requiresSerial() {
@@ -107,7 +182,7 @@ export class LiveOutputNode extends BaseNode<
     // after a connection to another node is made.
     // This allows user to drag a block out and work on program before
     // the message prompting them to connect.
-    return !this.findOutputVariable() && this.isConnected("nodeValue");
+    return !this.getSelectedOutputVariable() && this.isConnected("nodeValue");
   }
 
   private sendDataToSerialDevice(serialDevice: SerialDevice) {
@@ -132,68 +207,49 @@ export class LiveOutputNode extends BaseNode<
     }
   }
 
-  private sendDataToSimulatedOutput(outputVariables?: VariableType[]) {
-    const outputVariable = this.findOutputVariable();
-    if (outputVariable && this.model.hubSelect === simulatedHubName(outputVariable)) {
+  private sendDataToSimulatedOutput() {
+    const outputVariable = this.getSelectedOutputVariable();
+    if (outputVariable) {
       const val = this.model.nodeValue;
       // NOTE: this is where we historically saw NaN values with origins in the Sensor node
       if (val != null && isFinite(val)) outputVariable.setValue(val);
     }
   }
 
-  outputsToAnyRelay() {
-    return kMicroBitHubRelaysIndexed.includes(this.model.liveOutputType);
-  }
-
-  outputsToAnyGripper() {
-    return kGripperOutputTypes.includes(this.model.liveOutputType);
-  }
-
-  getLiveOptions(deviceFamily: string, sharedVar?: VariableType ) {
+  setHubSelectOptions() {
     const options: ListOption[] = [];
+    const deviceFamily = this.deviceFamily;
+    const sharedVar = this.getPotentialOutputVariable();
     const simOption = sharedVar && simulatedHub(sharedVar);
-    const anyOutputFound = simOption || deviceFamily === "arduino" || deviceFamily === "microbit";
-    const { liveGripperOption, warningOption } = baseLiveOutputOptions;
+    const { liveGripperOption, noDeviceLiveGripperOption, genericWarningOption } = baseLiveOutputOptions;
+    const { isGripperType, isRelayType, hubSelect } = this.model;
 
-    if (sharedVar && simOption) {
+    if (simOption) {
       options.push(simOption);
     }
 
-    if (this.outputsToAnyRelay() && deviceFamily === "microbit") {
-      options.push(...NodeMicroBitHubs);
-    }
-
-    if (this.outputsToAnyGripper() && deviceFamily === "arduino") {
-      options.push(liveGripperOption);
-    }
-
-    if (this.outputsToAnyGripper() && deviceFamily !== "arduino") {
-      if (!options.includes(warningOption)) {
-        options.push(warningOption);
+    if (isRelayType) {
+      if (deviceFamily === "microbit") {
+        options.push(...NodeMicroBitHubs);
+      } else {
+        options.push(genericWarningOption);
       }
     }
 
-    if (!anyOutputFound && !options.includes(warningOption)) options.push(warningOption);
+    if (isGripperType) {
+      if (deviceFamily === "arduino") {
+        options.push(liveGripperOption);
+      } else {
+        options.push(noDeviceLiveGripperOption);
+      }
+    }
 
-    return options;
-  }
-
-  setLiveOutputOpts(deviceFamily: string, sharedVar?: VariableType) {
-    // This is only called in a tick so it won't be called on a readOnly diagram
-    const options = this.getLiveOptions(deviceFamily, sharedVar);
+    if (!options.find(option => option.name === hubSelect)) {
+      // In certain cases, if we don't have an option for the current selection
+      // we might need to add one.
+    }
 
     this.hubSelectControl.setOptions(options);
-
-    const selectionId = this.hubSelectControl.getSelectionId();
-
-    // FIXME: this is modifying state in a tick which can also be modified by a user
-    // directly. This will cause a conflict when restoring the node from an undo.
-    if (!selectionId) this.model.setHubSelect(options[0].name);
-
-    // if user successfully connects arduino with warning selected, switch to physical gripper
-    if (selectionId === "no-outputs-found" && deviceFamily === "arduino") {
-      this.model.setHubSelect(baseLiveOutputOptions.liveGripperOption.name);
-    }
   }
 
   private getSelectedRelayIndex(){
@@ -205,7 +261,11 @@ export class LiveOutputNode extends BaseNode<
     const hubsChannels = this.services.getChannels();
     if (!hubsChannels) return;
     const hubSelectOptions = hubSelect.options;
-    hubsChannels
+
+    // Run this in an action so the UI only updates once when the status
+    // of the options is changed
+    runInAction(() => {
+      hubsChannels
       .filter(c => c.deviceFamily === "microbit")
       .forEach(c => {
         // Incase there is a channel without a microbitId, skip it
@@ -214,10 +274,11 @@ export class LiveOutputNode extends BaseNode<
         if (!targetHub) return;
 
         // The options are observable objects so changing the active status
-        // should trigger the list to re-render. However this is being changed
-        // outside of a transaction, so MobX might complain about it.
+        // should trigger the list to re-render.
+        hubSelect.setActiveOption(c.microbitId, c.missing);
         targetHub.active = c.missing;
       });
+    });
   }
 
   private getHubRelaysChannel(){
@@ -272,6 +333,10 @@ export class LiveOutputNode extends BaseNode<
     }
   }
 
+  get deviceFamily() {
+    return this.services.stores.serialDevice.deviceFamily;
+  }
+
   data({nodeValue}: {nodeValue?: number[]}) {
     // if there is not a valid input, use 0
     const value = nodeValue && nodeValue[0] != null && !isNaN(nodeValue[0]) ? nodeValue[0] : 0;
@@ -302,14 +367,11 @@ export class LiveOutputNode extends BaseNode<
 
     if (this.services.inTick) {
       const { stores, runnable } = this.services;
-      const outputVariables = this.services.getOutputVariables();
-      const outputVar = this.findOutputVariable();
-      const foundDeviceFamily = stores.serialDevice.deviceFamily ?? "unknown device";
       if (runnable) {
         this.sendDataToSerialDevice(stores.serialDevice);
-        this.sendDataToSimulatedOutput(outputVariables);
+        this.sendDataToSimulatedOutput();
       }
-      this.setLiveOutputOpts(foundDeviceFamily, outputVar);
+      this.setHubSelectOptions();
 
       // We won't be in a tick in a read only view. However users aren't allowed
       // to look at the options so there isn't a reason to update the status

--- a/src/plugins/dataflow/nodes/logic-node.ts
+++ b/src/plugins/dataflow/nodes/logic-node.ts
@@ -68,7 +68,7 @@ export class LogicNode extends BaseNode<
     }).map((nodeOp) => {
       return { name: nodeOp.name, icon: nodeOp.icon };
     });
-    const dropdownControl = new DropdownListControl(this, "logicOperator", dropdownOptions);
+    const dropdownControl = new DropdownListControl(this, "logicOperator", model.setLogicOperator, dropdownOptions);
     this.addControl("logicOperator", dropdownControl);
 
     this.valueControl = new ValueControl("Logic", this.getSentence);

--- a/src/plugins/dataflow/nodes/math-node.ts
+++ b/src/plugins/dataflow/nodes/math-node.ts
@@ -69,7 +69,7 @@ export class MathNode extends BaseNode<
     }).map((nodeOp) => {
       return { name: nodeOp.name, icon: nodeOp.icon };
     });
-    const dropdownControl = new DropdownListControl(this, "mathOperator", dropdownOptions);
+    const dropdownControl = new DropdownListControl(this, "mathOperator", model.setMathOperator, dropdownOptions);
     this.addControl("mathOperator", dropdownControl);
 
     this.valueControl = new ValueControl("Math", this.getSentence);

--- a/src/plugins/dataflow/nodes/sensor-node.ts
+++ b/src/plugins/dataflow/nodes/sensor-node.ts
@@ -70,14 +70,15 @@ export class SensorNode extends BaseNode<
       displayName: sensorType.name,
       icon: sensorType.icon
     }));
-    const sensorTypeControl = new DropdownListControl(this, "sensorType", sensorTypeOptions,
+    const sensorTypeControl =
+      new DropdownListControl(this, "sensorType", model.setSensorType, sensorTypeOptions,
       "Select Sensor Type",  "Select a sensor type");
     this.addControl("sensorType", sensorTypeControl);
 
     // A function is passed for the options, this way the dropdown component can
     // observe this function and re-render when its dependencies change
-    this.sensorControl = new DropdownListControl(this, "sensor", [],
-      "Select Sensor", kSensorSelectMessage, () => this.getSensorOptions());
+    this.sensorControl = new DropdownListControl(this, "sensor", model.setSensor, [],
+      "Select Sensor", kSensorSelectMessage, this.getSensorOptions);
     this.addControl("sensor", this.sensorControl);
 
     const valueControl = new ValueWithUnitsControl("Sensor", this.getDisplayValue,
@@ -149,7 +150,7 @@ export class SensorNode extends BaseNode<
     }));
   }
 
-  getSensorOptions() {
+  getSensorOptions = () => {
     const options = this.convertChannelsToOptions();
 
     // If the current sensor no longer exists in the channels, then add a fake
@@ -182,7 +183,7 @@ export class SensorNode extends BaseNode<
     }
 
     return options;
-  }
+  };
 
   data(): { value: number} {
     if (this.services.inTick) {

--- a/src/plugins/dataflow/nodes/transform-node.ts
+++ b/src/plugins/dataflow/nodes/transform-node.ts
@@ -64,7 +64,8 @@ export class TransformNode extends BaseNode<
     }).map((nodeOp) => {
       return { name: nodeOp.name, icon: nodeOp.icon };
     });
-    const dropdownControl = new DropdownListControl(this, "transformOperator", dropdownOptions);
+    const dropdownControl =
+      new DropdownListControl(this, "transformOperator", model.setTransformOperator, dropdownOptions);
     this.addControl("transformOperator", dropdownControl);
 
     this.valueControl = new ValueControl("Transform", this.getSentence);


### PR DESCRIPTION
- switch to passing the setter to the DropdownListControl instead of having it figure it out automatically
- the live output now:
  - updates its hubSelect value when the user changes the liveOutputType
  - uses the deviceFamily and sharedVariable when updating the hubSelect
  - updates the hub select options when the liveOutputType is changed
  - the requiresSerial check now takes into account the hubSelect value
  - the "Physical Gripper" value of the hubSelect has both a device and noDevice view. This way the hubSelect value doesn't have to be changed when an arduino is connected or disconnected, instead just the view changes.