### PR TITLE
delete sparrows

### DIFF
--- a/cypress/e2e/functional/document_tests/exemplar_test_spec.js
+++ b/cypress/e2e/functional/document_tests/exemplar_test_spec.js
@@ -40,19 +40,19 @@ context('Exemplar Documents', function () {
 
     cy.log("Create 3 drawing tiles with 3 events");
     clueCanvas.addTile("drawing");
-    drawToolTile.drawSmallRectangle(100, 50);
-    drawToolTile.drawSmallRectangle(200, 50);
-    drawToolTile.drawSmallRectangle(300, 50);
+    drawToolTile.drawRectangle(100, 50);
+    drawToolTile.drawRectangle(200, 50);
+    drawToolTile.drawRectangle(300, 50);
 
     clueCanvas.addTile("drawing");
-    drawToolTile.drawSmallRectangle(100, 50);
-    drawToolTile.drawSmallRectangle(200, 50);
-    drawToolTile.drawSmallRectangle(300, 50);
+    drawToolTile.drawRectangle(100, 50);
+    drawToolTile.drawRectangle(200, 50);
+    drawToolTile.drawRectangle(300, 50);
 
     clueCanvas.addTile("drawing");
-    drawToolTile.drawSmallRectangle(100, 50);
-    drawToolTile.drawSmallRectangle(200, 50);
-    drawToolTile.drawSmallRectangle(300, 50);
+    drawToolTile.drawRectangle(100, 50);
+    drawToolTile.drawRectangle(200, 50);
+    drawToolTile.drawRectangle(300, 50);
 
     cy.log("Create 3 text tiles and put 10 words in them");
     clueCanvas.addTile("text");
@@ -92,18 +92,18 @@ context('Exemplar Documents', function () {
 
     cy.log("Create 3 drawing tiles with 3 events and a label");
     clueCanvas.addTile("drawing");
-    drawToolTile.drawSmallRectangle(100, 50);
-    drawToolTile.drawSmallRectangle(200, 50);
+    drawToolTile.drawRectangle(100, 50);
+    drawToolTile.drawRectangle(200, 50);
     addText(300, 50, "one two three four five six seven eight nine ten");
 
     clueCanvas.addTile("drawing");
-    drawToolTile.drawSmallRectangle(100, 50);
-    drawToolTile.drawSmallRectangle(200, 50);
+    drawToolTile.drawRectangle(100, 50);
+    drawToolTile.drawRectangle(200, 50);
     addText(300, 50, "one two three four five six seven eight nine ten");
 
     clueCanvas.addTile("drawing");
-    drawToolTile.drawSmallRectangle(100, 50);
-    drawToolTile.drawSmallRectangle(200, 50);
+    drawToolTile.drawRectangle(100, 50);
+    drawToolTile.drawRectangle(200, 50);
 
     // Still private?
     sortWork.getSortWorkItemByTitle(exemplarName).parents('.list-item').should("have.class", "private");

--- a/cypress/e2e/functional/tile_tests/arrow_annotation_spec.js
+++ b/cypress/e2e/functional/tile_tests/arrow_annotation_spec.js
@@ -115,8 +115,11 @@ context('Arrow Annotations (Sparrows)', function () {
     aa.getAnnotationSparrowGroups().eq(0).should("not.have.class", "selected");
     aa.getAnnotationSparrowGroups().eq(1).should("not.have.class", "selected");
 
-    // Delete second arrow
-    aa.getAnnotationDeleteButtons().eq(1).click();
+    // Select & delete key to delete
+    aa.getAnnotationBackgroundArrowPaths().eq(1).click({ force: true });
+    aa.getAnnotationSparrowGroups().eq(1).should("have.class", "selected");
+    aa.getAnnotationLayer().type('{del}');
+    aa.getAnnotationArrows().should("have.length", 1);
 
     cy.log("Can only edit text in sparrow mode");
     aa.clickArrowToolbarButton();

--- a/cypress/e2e/functional/tile_tests/arrow_annotation_spec.js
+++ b/cypress/e2e/functional/tile_tests/arrow_annotation_spec.js
@@ -48,15 +48,11 @@ context('Arrow Annotations (Sparrows)', function () {
     drawToolTile.getTileTitle().should("exist");
 
     cy.log("Add two rectangles and an ellipse");
-    drawToolTile.drawSmallRectangle(50, 50);
+    drawToolTile.drawRectangle(50, 50);
     drawToolTile.getRectangleDrawing().should("exist").and("have.length", 1);
-    drawToolTile.getDrawToolEllipse().click();
-    drawToolTile.getDrawTile()
-      .trigger("mousedown", 250, 50)
-      .trigger("mousemove", 200, 100)
-      .trigger("mouseup", 200, 100);
+    drawToolTile.drawEllipse(200, 50);
     drawToolTile.getEllipseDrawing().should("exist").and("have.length", 1);
-    drawToolTile.drawSmallRectangle(400, 100);
+    drawToolTile.drawRectangle(400, 100);
     drawToolTile.getRectangleDrawing().should("exist").and("have.length", 2);
 
     cy.log("Annotation buttons only appear in sparrow mode");

--- a/cypress/support/elements/tile/DrawToolTile.js
+++ b/cypress/support/elements/tile/DrawToolTile.js
@@ -108,12 +108,20 @@ class DrawToolTile{
     getDrawTileTitle(workspaceClass){
       return cy.get(`${workspaceClass || ".primary-workspace"} .drawing-tool-tile .editable-tile-title`);
     }
-    drawSmallRectangle(x, y) {
+    drawRectangle(x, y, width=25, height=25) {
       this.getDrawToolRectangle().last().click();
       this.getDrawTile().last()
-      .trigger("mousedown", x, y)
-      .trigger("mousemove", x+25, y+25)
-      .trigger("mouseup", x+25, y+25);
+        .trigger("mousedown", x, y)
+        .trigger("mousemove", x+width, y+height)
+        .trigger("mouseup", x+width, y+height);
+    }
+
+    drawEllipse(x, y, width=25, height=25) {
+      this.getDrawToolEllipse().click();
+      this.getDrawTile().last()
+        .trigger("mousedown", x, y)
+        .trigger("mousemove", x+width, y+height)
+        .trigger("mouseup", x+width, y+height);
     }
 
 }

--- a/src/components/document/annotation-layer.tsx
+++ b/src/components/document/annotation-layer.tsx
@@ -13,6 +13,7 @@ import { ClueObjectModel, IClueObject, OffsetModel } from "../../models/annotati
 import { DocumentContentModelType } from "../../models/document/document-content";
 import { Point } from "../../utilities/math-utils";
 import { hasSelectionModifier } from "../../utilities/event-utils";
+import { HotKeys } from "../../utilities/hot-keys";
 
 import "./annotation-layer.scss";
 
@@ -41,9 +42,24 @@ export const AnnotationLayer = observer(function AnnotationLayer({
   const ui = useUIStore();
   const persistentUI = usePersistentUIStore();
   const tileApiInterface = useContext(TileApiInterfaceContext);
+  const hotKeys = useRef(new HotKeys());
+
+  useEffect(() => {
+    if (!readOnly) {
+      hotKeys.current.register({
+        "delete": () => content?.deleteSelected(),
+        "backspace": () => content?.deleteSelected()
+      });
+    }
+  }, [content, readOnly]);
+
+  function handleKeyDown(event: React.KeyboardEvent) {
+    hotKeys.current.dispatch(event);
+  }
 
   // Clicking to select annotations
   function handleArrowClick(arrowId: string, event: MouseEvent) {
+    if (readOnly) return;
     event.stopPropagation();
     const annotation = content?.annotations.get(arrowId);
     if (annotation) {
@@ -238,6 +254,8 @@ export const AnnotationLayer = observer(function AnnotationLayer({
       className={classes}
       onMouseMove={handleMouseMove}
       onClick={handleBackgroundClick}
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
       ref={element => {
         if (element) divRef.current = element;
       }}

--- a/src/models/document/document-content-with-annotations.ts
+++ b/src/models/document/document-content-with-annotations.ts
@@ -57,4 +57,14 @@ export const DocumentContentModelWithAnnotations = BaseDocumentContentModel
         annotation.setSelected(ids.includes(annotation.id));
       }
     }
+  }))
+  .actions(self => ({
+    deleteSelected() {
+      const keys = self.annotations.keys();
+      for (const annoId of keys) {
+        if (self.annotations.get(annoId)?.isSelected) {
+          self.deleteAnnotation(annoId);
+        }
+      }
+    }
   }));

--- a/src/utilities/hot-keys.ts
+++ b/src/utilities/hot-keys.ts
@@ -65,18 +65,28 @@ export class HotKeys {
 
   private hotKeyMap: IHotKeyMap = {};
 
+  private canonicalizeKeys(keys: string) {
+    const cmdKey = platformCmdKey();
+    return keys.toLowerCase()
+      .replace("cmd", cmdKey)
+      .replace("control", "ctrl")
+      .replace("option", "alt")
+      .replace("arrow", "");
+  }
+
   /*
    * [ctrl|meta|cmd]-[alt|option]-[shift]-[char]
    */
   public register(hotKeys: IHotKeyMap) {
-    const cmdKey = platformCmdKey();
     each(hotKeys, (handler, keys) => {
-      const _keys = keys.toLowerCase()
-                        .replace("cmd", cmdKey)
-                        .replace("control", "ctrl")
-                        .replace("option", "alt")
-                        .replace("arrow", "");
+      const _keys = this.canonicalizeKeys(keys);
       this.hotKeyMap[_keys] = handler;
+    });
+  }
+
+  public unregister(keys: string[]) {
+    each(keys, (key) => {
+      delete this.hotKeyMap[this.canonicalizeKeys(key)];
     });
   }
 


### PR DESCRIPTION
PT-187373174

This makes the Delete & Backspace keys delete any selected Sparrows. (If you are in Sparrow mode, have write access, and the annotation layer is focused, which it should normally be if you have been interacting with sparrows by selecting them).

Also makes a small correction to the previous PR -- you can no longer select sparrows by clicking on them in a read-only tile.

