### PR TITLE
handle curriculum mode better

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ There is an alternative entry point for CLUE available at `/doc-editor.html`. Th
 
 The `document` parameter is useful if you want to work on something that requires a document in a specific state. You can just reload the page and get back to this state. You can use this locally by creating an initial document in doc-editor.html, and save the file to `src/public/[filename]`. Now you can load the document back with the parameter `document=[filename]`. This works because the document parameter will load URLs relative to the current page in the browser. This approach can also be used in Cypress tests. It would mean the test could just load in a document to test instead of having to setup the document first.
 
+The Standalone Document Editor also supports a `readOnly` url param. If you specify this param the document you open will be opened in readOnly mode. This is useful for testing or debugging issues with tiles that have different displays when in readOnly model.
+
 ### QA
 
 Along with `dev`, `test`, `authed` and `demo` modes the app has a `qa` mode.  QA mode uses the same parameters as demo mode with two additional parameters:

--- a/src/components/doc-editor-app.tsx
+++ b/src/components/doc-editor-app.tsx
@@ -18,6 +18,8 @@ export const DocEditorApp = () => {
   const [sectionSnapshot, setSectionSnapshot] = useState<any>();
   const [fileName, setFileName] = useState<string>("");
 
+  const {document: documentURL, readOnly } = urlParams;
+
   function loadDocument(text: string) {
     const _parsedText = JSON.parse(text);
     let documentContentSnapshot;
@@ -82,7 +84,6 @@ export const DocEditorApp = () => {
   }
 
   useEffect(() => {
-    const {document: documentURL} = urlParams;
     if (!documentURL) {
       return;
     }
@@ -113,7 +114,7 @@ export const DocEditorApp = () => {
         contained={false}
         mode="1-up"
         isPrimary={true}
-        readOnly={false}
+        readOnly={readOnly}
         document={document}
         toolbar={appConfig.authorToolbar}
       />

--- a/src/models/mst.test.ts
+++ b/src/models/mst.test.ts
@@ -40,6 +40,36 @@ describe("mst", () => {
     expect(getType(todo2) === Todo1).toBe(true);
   });
 
+  it("preProcessSnapshot is called twice, and is not called extra times for model extensions", () => {
+    let preProcessCount = 0;
+    const Base = types.model("Base", {
+      text1: types.maybe(types.string)
+    })
+    .preProcessSnapshot(snapshot => {
+      preProcessCount++;
+      return snapshot;
+    });
+
+    const Extension1 = Base.named("Extension1").props({
+      text2: types.maybe(types.string)}
+    );
+
+    const Extension2 = Extension1.named("Extension2").props({
+      text3: types.maybe(types.string)
+    });
+
+    Base.create({});
+    expect(preProcessCount).toBe(2);
+
+    preProcessCount = 0;
+    Extension1.create({});
+    expect(preProcessCount).toBe(2);
+
+    preProcessCount = 0;
+    Extension2.create({});
+    expect(preProcessCount).toBe(2);
+  });
+
   it("loads late types when another type referencing is instantiated", () => {
     let lateCalled = false;
     const TypeWithLate = types.model("TypeWithLate", {

--- a/src/models/stores/stores.ts
+++ b/src/models/stores/stores.ts
@@ -323,7 +323,9 @@ class Stores implements IStores{
           // Not sure if this should be "guide" or "teacher-guide", either ought to work
           unitGuide?.setFacet("teacher-guide");
           const teacherGuide = unitGuide?.getProblem(problemOrdinal || appConfig.defaultProblemOrdinal)?.problem;
-          unitUrls?.guide && teacherGuide.loadSections(unitUrls.guide);
+          // There might not be a teacher guide for this specific problem
+          if (!unitUrls?.guide || !teacherGuide) return;
+          teacherGuide.loadSections(unitUrls.guide);
           this.setTeacherGuide(teacherGuide);
         }
       }

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -40,7 +40,6 @@ interface IProps extends SizeMeProps {
   program?: DataflowProgramModelType;
   programDataRate: number;
   readOnly?: boolean;
-  runnable?: boolean;
   tileHeight?: number;
   tileContent: DataflowContentModelType;
 }
@@ -210,7 +209,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
       const contentCopy = DataflowContentModel.create(contentSnapshot);
       this.playbackReteManager = new ReteManager(
         contentCopy.program, this.tileId, this.playbackToolDiv, contentCopy, this.stores,
-        this.props.runnable, true, true
+        true, true
       );
 
       // When we first show the playbackToolDiv after finishing recording it would show
@@ -253,7 +252,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
     if (!this.toolDiv || !this.props.program) return;
 
     const reteManager = new ReteManager(this.props.program, this.tileId,
-      this.toolDiv, this.props.tileContent, this.stores, this.props.runnable, this.props.readOnly, false);
+      this.toolDiv, this.props.tileContent, this.stores, this.props.readOnly, false);
 
     this.reteManager = reteManager;
   };
@@ -331,7 +330,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
   }
 
   private tick = () => {
-    const { runnable, tileContent: tileModel } = this.props;
+    const { readOnly, tileContent: tileModel } = this.props;
     const { playBackIndex, isPlaying, recordIndex } = this.state;
     const programMode = this.determineProgramMode();
     const { reteManager } = this;
@@ -351,7 +350,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
       case ProgramMode.Recording:
         this.updateChannels();
         reteManager.tickAndProcessNodes();
-        if (runnable) {
+        if (!readOnly) {
           recordCase(this.props.tileContent, recordIndex);
         }
         this.incrementRecordIndex();

--- a/src/plugins/dataflow/components/dataflow-tile.tsx
+++ b/src/plugins/dataflow/components/dataflow-tile.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { SizeMe, SizeMeProps } from "react-sizeme";
 import { observer, inject } from "mobx-react";
 
-import { isCurriculumDocument } from "../../../models/document/document-types";
 import { DataflowProgram } from "./dataflow-program";
 import { BaseComponent } from "../../../components/base";
 import { ITileModel } from "../../../models/tiles/tile-model";
@@ -53,7 +52,6 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IDatafl
     const classes = `dataflow-tool disable-tile-content-drag ${editableClass}`;
     const { program, programDataRate, programZoom } = this.getContent();
     const tileContent = this.getContent();
-    const runnable = this.getRunnable();
 
     return (
       <>
@@ -70,7 +68,6 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IDatafl
                   program={program}
                   programDataRate={programDataRate}
                   readOnly={readOnly}
-                  runnable={runnable}
                   size={size}
                   tileHeight={height}
                   tileContent={tileContent}
@@ -120,11 +117,6 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IDatafl
       />
     );
   }
-
-  private getRunnable = () => {
-    const isCurriculum = isCurriculumDocument(this.props.documentId);
-    return !this.props.readOnly || isCurriculum;
-  };
 
   private getContent() {
     return this.props.model.content as DataflowContentModelType;

--- a/src/plugins/dataflow/model/dataflow-program-model.ts
+++ b/src/plugins/dataflow/model/dataflow-program-model.ts
@@ -55,6 +55,7 @@ export const DataflowNodeModel = types.
     }
   }))
   .preProcessSnapshot((snapshot: any) => {
+    // TODO: is this needed anymore?
     // Turn position into x and y because MST has weird issues with arrays
     if (Array.isArray(snapshot.position)) {
       const { position: [x, y], ...rest } = snapshot;

--- a/src/plugins/dataflow/nodes/live-output-node.ts
+++ b/src/plugins/dataflow/nodes/live-output-node.ts
@@ -433,8 +433,8 @@ export class LiveOutputNode extends BaseNode<
     }
 
     if (this.services.inTick) {
-      const { stores, runnable } = this.services;
-      if (runnable) {
+      const { stores, readOnly } = this.services;
+      if (!readOnly) {
         this.sendDataToSerialDevice(stores.serialDevice);
         this.sendDataToSimulatedOutput();
       }

--- a/src/plugins/dataflow/nodes/rete-manager.tsx
+++ b/src/plugins/dataflow/nodes/rete-manager.tsx
@@ -60,7 +60,6 @@ export class ReteManager implements INodeServices {
     div: HTMLElement,
     public mstContent: DataflowContentModelType,
     public stores: IStores,
-    public runnable: boolean | undefined,
     public readOnly: boolean | undefined,
     public playback: boolean | undefined
   ){

--- a/src/plugins/dataflow/nodes/service-types.ts
+++ b/src/plugins/dataflow/nodes/service-types.ts
@@ -22,7 +22,6 @@ export interface INodeServices {
    * hardware or variables, generating data based on time.
    */
   inTick: boolean;
-  runnable?: boolean;
   readOnly?: boolean;
   playback?: boolean;
 }

--- a/src/utilities/url-params.test.ts
+++ b/src/utilities/url-params.test.ts
@@ -1,3 +1,4 @@
+import { parse } from "query-string";
 import { processUrlParams } from "./url-params";
 
 describe("urlParams", () => {
@@ -25,7 +26,7 @@ describe("urlParams", () => {
     mockWindowLocation(originalLocation);
   });
 
-  it("appMode must be valid", () => {
+  test("appMode must be valid", () => {
     expect(processQueryParams().appMode).toBeUndefined();
     expect(processQueryParams("appMode").appMode).toBeUndefined();
     expect(processQueryParams("appMode=bogus").appMode).toBeUndefined();
@@ -33,10 +34,20 @@ describe("urlParams", () => {
     expect(processQueryParams("appMode=authed").appMode).toBe("authed");
   });
 
-  it("demo param accepts but does not require value", () => {
+  test("boolean params are true without a value", () => {
     expect(processQueryParams().demo).toBe(false);
     expect(processQueryParams("demo").demo).toBe(true);
     expect(processQueryParams("demo=true").demo).toBe(true);
     expect(processQueryParams("demo=yes").demo).toBe(true);
+    expect(processQueryParams("demo=false").demo).toBe(false);
+  });
+});
+
+describe("query-string parse", () => {
+  it("returns null for a param without a value", () => {
+    const result = parse("?foo&bar=1");
+    expect(result.foo).toBeDefined();
+    expect(result.foo).toBe(null);
+    expect(result.bar).toBe("1");
   });
 });


### PR DESCRIPTION
- remove `runnable` flag that was used for curriculum mode, now they behave the same as a readOnly document
- add `readOnly` param to doc-editor for testing
- update url params to handle booleans more generically
- a false value for a url param is now treated as false
- fix a error thrown when a problem doesn't have a teacher guide