### PR TITLE
handle readOnly sensor names

### DIFF
--- a/src/models/stores/serial.ts
+++ b/src/models/stores/serial.ts
@@ -121,12 +121,12 @@ export class SerialDevice {
           if (isFinite(Number(reading))){
             targetChannel.value = Number(reading);
           }
-          targetChannel.lastMessageRecievedAt = Date.now();
+          targetChannel.lastMessageReceivedAt = Date.now();
         }
         if (["r"].includes(element)){
           // handle message about relays state
           targetChannel.relaysState = reading.split('').map(s => Number(s));
-          targetChannel.lastMessageRecievedAt = Date.now();
+          targetChannel.lastMessageReceivedAt = Date.now();
         }
       }
     } while (match);

--- a/src/plugins/dataflow/model/utilities/channel.ts
+++ b/src/plugins/dataflow/model/utilities/channel.ts
@@ -20,7 +20,7 @@ export interface NodeChannelInfo {
   outputTargetActuator?: string;
   timeFactor?: number;
   deviceFamily?: string | undefined;
-  lastMessageRecievedAt?: number | null;
+  lastMessageReceivedAt?: number | null;
   relaysState?: number[];
   microbitId?: string;
 }

--- a/src/plugins/dataflow/model/utilities/simulated-channel.ts
+++ b/src/plugins/dataflow/model/utilities/simulated-channel.ts
@@ -36,3 +36,15 @@ export function simulatedChannel(variable: VariableType): NodeChannelInfo {
     simulatedVariable: variable
   };
 }
+
+export function niceNameFromSimulationChannelId(channelId: string) {
+  if (channelId.startsWith(kSimulatedChannelPrefix)) {
+    let niceName = channelId.substring(kSimulatedChannelPrefix.length);
+    // Some variable names end with _key
+    if (channelId.endsWith("_key")) {
+      niceName = niceName.substring(0, niceName.length - 4);
+    }
+    return niceName;
+  }
+  return channelId;
+}

--- a/src/plugins/dataflow/nodes/rete-manager.tsx
+++ b/src/plugins/dataflow/nodes/rete-manager.tsx
@@ -42,6 +42,9 @@ import { DataflowProgramChange } from "../dataflow-logger";
 import { runInAction } from "mobx";
 import { getSharedNodes } from "./utilities/shared-program-data-utilities";
 import { ProgramDataRates } from "../model/utilities/node";
+import { simulatedChannel } from "../model/utilities/simulated-channel";
+import { virtualSensorChannels } from "../model/utilities/virtual-channel";
+import { serialSensorChannels } from "../model/utilities/channel";
 
 const MAX_ZOOM = 2;
 const MIN_ZOOM = .1;
@@ -53,6 +56,7 @@ export class ReteManager implements INodeServices {
   private snapshotDisposer: () => void | undefined;
   public inTick = false;
   public disposed = false;
+  private previousChannelIds = "";
 
   constructor(
     private mstProgram: DataflowProgramModelType,
@@ -539,11 +543,47 @@ export class ReteManager implements INodeServices {
     }
   }
 
+  private get simulatedChannels() {
+    return this.mstContent
+      ? this.mstContent.inputVariables?.map(variable => simulatedChannel(variable)) ?? []
+      : [];
+  }
+
+  public updateChannels() {
+    const channels = [...virtualSensorChannels, ...this.simulatedChannels, ...serialSensorChannels];
+
+    // The only channels that might be added or removed from this array change are the simulatedChannels
+    const channelIds = channels.map(c => c.channelId).join(",");
+    if (channelIds !== this.previousChannelIds) {
+      this.previousChannelIds = channelIds;
+      this.mstContent.setChannels(channels);
+
+      this.countSerialDataNodes();
+    }
+
+    // NOTE: these channels are observable, so changes to their missing or connected
+    // status should trigger updates.
+    this.mstContent.channels.filter(c => c.usesSerial).forEach((channel) => {
+      const { serialDevice } = this.stores;
+      if (serialDevice.hasPort()){
+        channel.serialConnected = true;
+        const deviceMismatch = serialDevice.deviceFamily !== channel.deviceFamily;
+        const timeSinceActive = channel.usesSerial && channel.lastMessageReceivedAt
+          ? Date.now() - channel.lastMessageReceivedAt: 0;
+        channel.missing = deviceMismatch || timeSinceActive > 7000;
+      } else {
+        channel.serialConnected = false;
+        channel.missing = true;
+      }
+    });
+  }
+
   public tickAndProcessNodes() {
     // This is wrapped in an MST action so all of the changes are batched together
     // We are using our own custom Rete Dataflow Engine which runs synchronously
     // so all calls to the nodes `data` and `onTick` methods are grouped together.
     this.mstProgram.tickAndProcess(() => {
+      this.updateChannels();
       this.inTick = true;
       this.process();
       this.inTick = false;


### PR DESCRIPTION
- add new sensorDisplayName prop to sensor nodes so readOnly views can show the correct option in the sensor dropdown menu
- add code to compute a nice looking name when we don't have a displayName
- only show the extra sensor option as missing if we are not readOnly
- move updateChannels to rete manager
- add back missing code which updates channel status on each tick
- fix a spelling mistake of lastMessageRecievedAt