### PR TITLE
create playbackReteManager on load too

### DIFF
--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -178,9 +178,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
   }
 
   public componentDidMount() {
-    if (!this.reteManager && this.toolDiv) {
-      this.initProgram();
-    }
+    this.initReteManagersIfNeeded();
   }
 
   public componentWillUnmount() {
@@ -192,15 +190,19 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
   }
 
   public componentDidUpdate(prevProps: IProps) {
-    if (!this.reteManager && this.toolDiv) {
-      this.initProgram();
-    }
+    this.initReteManagersIfNeeded();
 
     if (this.props.programDataRate !== prevProps.programDataRate) {
       this.setDataRate(this.props.programDataRate);
     }
+  }
 
-    if (this.playbackToolDiv && !this.playbackReteManager) {
+  private initReteManagersIfNeeded() {
+    if (!this.reteManager && this.toolDiv) {
+      this.initProgram();
+    }
+
+    if (!this.playbackReteManager && this.playbackToolDiv) {
       const contentSnapshot = getSnapshot(this.props.tileContent);
       const contentCopy = DataflowContentModel.create(contentSnapshot);
       this.playbackReteManager = new ReteManager(
@@ -211,7 +213,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
       // When we first show the playbackToolDiv after finishing recording it would show
       // the last nodeValues and recent values if we don't do anything.
       // However the playback slider and the time display will be showing the start of the
-      // recording.
+      // recording (00:00)
       // The code below resets the shown nodeValues and recentValues to match the slider
       // position
       const dataSet = this.props.tileContent.dataSet;

--- a/src/plugins/dataflow/nodes/rete-manager.tsx
+++ b/src/plugins/dataflow/nodes/rete-manager.tsx
@@ -334,7 +334,6 @@ export class ReteManager implements INodeServices {
 
     let readOnPatchDisposer;
     if (this.readOnly) {
-      console.log("readOnly process called");
       readOnPatchDisposer = onPatch(this.mstContent, (patch) => {
         // It is likely that Dataflow will kind of crash when this happens
         // So you'll need to fix the problem, and possibly disable readOnly processing


### PR DESCRIPTION
- This make sure the playbackReteManager is created even if the program component is never updated.
- Also deletes extra console.log