### PR TITLE
show annotation controls in doc editors

### DIFF
--- a/src/cms/document-editor.tsx
+++ b/src/cms/document-editor.tsx
@@ -7,6 +7,7 @@ import { AppProvider, initializeApp } from "../initialize-app";
 import { createDocumentModelWithEnv, DocumentModelType } from "../models/document/document";
 import { DEBUG_CMS } from "../lib/debug";
 import { EditableDocumentContent } from "../components/document/editable-document-content";
+import { DocumentAnnotationToolbar } from "../components/document/document-annotation-toolbar";
 
 import "../../cms/src/custom-control.scss";
 
@@ -97,15 +98,24 @@ export class DocumentEditor extends React.Component<IProps, IState>  {
     if (document) {
       return (
         <AppProvider stores={stores} modalAppElement="#app">
-          <EditableDocumentContent
-            className="iframe-control"
-            contained={true}
-            mode="1-up"
-            isPrimary={true}
-            readOnly={false}
-            document={document}
-            toolbar={stores.appConfig.authorToolbar}
-          />
+          <div className="document">
+            { stores.appConfig.showAnnotationControls &&
+              <div className="titlebar">
+                <div className="actions left">
+                   <DocumentAnnotationToolbar/>
+                </div>
+              </div>
+            }
+            <EditableDocumentContent
+              className="iframe-control"
+              contained={!stores.appConfig.showAnnotationControls}
+              mode="1-up"
+              isPrimary={true}
+              readOnly={false}
+              document={document}
+              toolbar={stores.appConfig.authorToolbar}
+            />
+          </div>
         </AppProvider>
       );
     } else {

--- a/src/components/doc-editor-app.tsx
+++ b/src/components/doc-editor-app.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import stringify from "json-stringify-pretty-compact";
 import { getSnapshot } from "mobx-state-tree";
 
@@ -21,7 +21,7 @@ export const DocEditorApp = () => {
   const [sectionSnapshot, setSectionSnapshot] = useState<any>();
   const [fileName, setFileName] = useState<string>("");
 
-  function loadDocument(text: string) {
+  const loadDocument = useCallback((text: string) => {
     const _parsedText = JSON.parse(text);
     let documentContentSnapshot;
     if (_parsedText.content ) {
@@ -34,7 +34,7 @@ export const DocEditorApp = () => {
       ...defaultDocumentModelParts,
       content: documentContentSnapshot
     }));
-  }
+  }, [appConfig]);
 
   // Handle opening both section documents with a content field
   // and basic documents which are just the content itself
@@ -103,7 +103,7 @@ export const DocEditorApp = () => {
       // This error is printed in the console as an "Uncaught (in promise)..."
       throw Error(`Request rejected with exception ${error}`);
     });
-  }, []);
+  }, [loadDocument]);
 
   // This is wrapped in a div.primary-workspace so it can be used with cypress
   // tests that are looking for stuff in a div like this

--- a/src/components/doc-editor-app.tsx
+++ b/src/components/doc-editor-app.tsx
@@ -8,6 +8,9 @@ import { createDocumentModelWithEnv } from "../models/document/document";
 import { DocumentContentSnapshotType } from "../models/document/document-content";
 import { urlParams } from "../utilities/url-params";
 import { useAppConfig } from "../hooks/use-stores";
+import { DocumentAnnotationToolbar } from "./document/document-annotation-toolbar";
+
+import "./document/document.scss";
 
 export const DocEditorApp = () => {
   const appConfig = useAppConfig();
@@ -106,17 +109,24 @@ export const DocEditorApp = () => {
   // tests that are looking for stuff in a div like this
   return (
     <div className="primary-workspace">
-      <button onClick={handleOpen}>open</button>
-      <button onClick={handleSave}>save</button>
-      <span>{fileName}</span>
-      <EditableDocumentContent
-        contained={false}
-        mode="1-up"
-        isPrimary={true}
-        readOnly={false}
-        document={document}
-        toolbar={appConfig.authorToolbar}
-      />
+      <div className="document">
+        <div className="titlebar">
+          <div className="actions left">
+            <button onClick={handleOpen}>open</button>
+            <button onClick={handleSave}>save</button>
+            <span>{fileName}</span>
+            <DocumentAnnotationToolbar/>
+          </div>
+        </div>
+        <EditableDocumentContent
+            contained={false}
+            mode="1-up"
+            isPrimary={true}
+            readOnly={false}
+            document={document}
+            toolbar={appConfig.authorToolbar}
+          />
+      </div>
     </div>
   );
 };

--- a/src/components/document/document-annotation-toolbar.tsx
+++ b/src/components/document/document-annotation-toolbar.tsx
@@ -15,12 +15,7 @@ export const DocumentAnnotationToolbar = observer(function DocumentAnnotationToo
   const { ui, persistentUI } = stores;
   const sparrowActive = ui.annotationMode === kSparrowAnnotationMode;
 
-  // Toolbar is enabled by any setting of 'annotation' in the config other than 'none'
-  // in the future there will be more options supported.
-  let showToolbar = stores.appConfig.annotations && stores.appConfig.annotations !== 'none';
-  // we also enable it, for back-compatibility, if the toolbar has a 'hide-annotations' button specified
-  if (stores.appConfig.toolbar.find(item => item.id === 'hide-annotations')) showToolbar  = true;
-  if (!showToolbar) return null;
+  if (!stores.appConfig.showAnnotationControls) return null;
 
   function handleSparrow() {
     if (sparrowActive) {

--- a/src/models/stores/app-config-model.ts
+++ b/src/models/stores/app-config-model.ts
@@ -108,6 +108,17 @@ export const AppConfigModel = types
     getDocumentLabel(docType: string, num?: number, lowerCase?: boolean) {
       const docLabel = self.documentLabels[docType];
       return docLabel ? DocumentLabelModel.create(docLabel).getLabel(num, lowerCase) : "";
+    },
+    get showAnnotationControls() {
+      return (
+
+        // Controls are enabled by any setting of 'annotation' in the config other than 'none'
+        // in the future there will be more options supported.
+        self.annotations && self.annotations !== 'none' ||
+
+        // we also enable it, for back-compatibility, if the toolbar has a 'hide-annotations' button specified
+        !!self.toolbar.find(item => item.id === 'hide-annotations')
+      );
     }
   }));
 export interface AppConfigModelType extends Instance<typeof AppConfigModel> {}

--- a/src/models/stores/app-config-model.ts
+++ b/src/models/stores/app-config-model.ts
@@ -114,7 +114,7 @@ export const AppConfigModel = types
 
         // Controls are enabled by any setting of 'annotation' in the config other than 'none'
         // in the future there will be more options supported.
-        self.annotations && self.annotations !== 'none' ||
+        (self.annotations && self.annotations !== 'none') ||
 
         // we also enable it, for back-compatibility, if the toolbar has a 'hide-annotations' button specified
         !!self.toolbar.find(item => item.id === 'hide-annotations')


### PR DESCRIPTION
- the controls will only be shown if they are enabled in the unit.
- the doc editor's dom elements were updated so the existing css for the annotation controls would apply
- the logic for determining if the controls should be shown was moved so it could be shared.