### PR TITLE
add sparrows to dataflow tile

### DIFF
--- a/cypress/e2e/functional/tile_tests/arrow_annotation_spec.js
+++ b/cypress/e2e/functional/tile_tests/arrow_annotation_spec.js
@@ -406,7 +406,9 @@ context('Arrow Annotations (Sparrows)', function () {
     dataflowTile.getCreateNodeButton("demo-output").click();
 
     aa.clickArrowToolbarButton();
-    aa.getAnnotationButtons().should("have.length", 28+3);
+    // The 3 nodes create annotation buttons in the dataflow tile and mini nodes
+    // in the simulation tile
+    aa.getAnnotationButtons().should("have.length", 28+2*3);
     aa.getAnnotationButtons().eq(0).click();
     aa.getAnnotationButtons().eq(2).click();
     aa.getAnnotationArrows().should("have.length", 2);

--- a/cypress/e2e/functional/tile_tests/arrow_annotation_spec.js
+++ b/cypress/e2e/functional/tile_tests/arrow_annotation_spec.js
@@ -412,4 +412,55 @@ context('Arrow Annotations (Sparrows)', function () {
     aa.getAnnotationArrows().should("have.length", 2);
 
   });
+
+  it("Can add annotations to the dataflow tile", () => {
+    const url = "./doc-editor.html?appMode=qa&unit=./demo/units/qa-config-subtabs/content.json&mouseSensor";
+    cy.visit(url);
+
+    clueCanvas.addTile("dataflow");
+    dataflowTile.getDataflowTile().should("exist");
+
+    // Create input, processing, and output nodes
+    dataflowTile.getCreateNodeButton("number").click();
+    dataflowTile.getCreateNodeButton("number").click();
+    dataflowTile.getCreateNodeButton("math").click();
+    dataflowTile.getCreateNodeButton("demo-output").click();
+
+    cy.log("There should be an annotation button for each node");
+    aa.getAnnotationButtons().should("not.exist");
+    aa.clickArrowToolbarButton();
+    aa.getAnnotationButtons().should("have.length", 4);
+
+    aa.getAnnotationButtons().eq(0).click();
+    aa.getAnnotationButtons().eq(2).click();
+    aa.getAnnotationArrows().should("have.length", 1);
+    aa.clickArrowToolbarButton();
+
+    cy.log("The annotation arrow should continue showing when recording");
+    dataflowTile.getRecordButton().click();
+    // This ought to wait until the first tick happens which will update the timer
+    dataflowTile.getCountdownTimer({timeout: 3000}).should("contain", "00:01");
+    aa.getAnnotationArrows().should("have.length", 1);
+    dataflowTile.getStopButton().click();
+
+    cy.log("The annotation arrow should continue showing when stopped");
+    dataflowTile.getPlayButton().should("be.enabled");
+    // Briefly wait to make sure the recorded program blocks are now showing
+    cy.wait(100);
+    aa.getAnnotationArrows().should("have.length", 1);
+
+    cy.log("New annotations can be made on a recorded program");
+    aa.clickArrowToolbarButton();
+    aa.getAnnotationButtons().should("have.length", 4);
+    aa.getAnnotationButtons().eq(1).click();
+    aa.getAnnotationButtons().eq(3).click();
+    aa.getAnnotationArrows().should("have.length", 2);
+    aa.clickArrowToolbarButton();
+
+    cy.log("Annotations continue showing after clearing the recording");
+    dataflowTile.getRecordingClearButton().click();
+    dataflowTile.getClearDataWarningClear().click();
+    dataflowTile.getSamplingRateLabel().should("have.text", "Sampling Rate");
+    aa.getAnnotationArrows().should("have.length", 2);
+  });
 });

--- a/cypress/support/elements/tile/DataflowToolTile.js
+++ b/cypress/support/elements/tile/DataflowToolTile.js
@@ -183,8 +183,8 @@ class DataflowToolTile {
   getTimeSlider() {
     return cy.get(".primary-workspace .program-editor-topbar .rc-slider.rc-slider-horizontal");
   }
-  getCountdownTimer() {
-    return cy.get(".primary-workspace .program-editor-topbar .countdown-timer");
+  getCountdownTimer(options={}) {
+    return cy.get(".primary-workspace .program-editor-topbar .countdown-timer", options);
   }
   verifyStopButtonText() {
     cy.get(".primary-workspace .record-data-txt").should("have.text", "Stop");

--- a/src/components/doc-editor-app.tsx
+++ b/src/components/doc-editor-app.tsx
@@ -104,7 +104,7 @@ export const DocEditorApp = () => {
       // This error is printed in the console as an "Uncaught (in promise)..."
       throw Error(`Request rejected with exception ${error}`);
     });
-  }, [loadDocument]);
+  }, [documentURL, loadDocument]);
 
   // This is wrapped in a div.primary-workspace so it can be used with cypress
   // tests that are looking for stuff in a div like this

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -344,10 +344,6 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
     return ( programMode === ProgramMode.Recording || programMode === ProgramMode.Done);
   }
 
-  private keepNodesInView = () => {
-    const margin = 5;
-  };
-
   private addNode = (nodeType: string, position?: [number, number]) => {
     this.reteManager?.createAndAddNode(nodeType, position);
   };

--- a/src/plugins/dataflow/components/dataflow-tile.tsx
+++ b/src/plugins/dataflow/components/dataflow-tile.tsx
@@ -5,7 +5,6 @@ import { observer, inject } from "mobx-react";
 import { DataflowProgram } from "./dataflow-program";
 import { BaseComponent } from "../../../components/base";
 import { ITileModel } from "../../../models/tiles/tile-model";
-import { ITileExportOptions } from "../../../models/tiles/tile-content-info";
 import { ITileProps } from "../../../components/tiles/tile-component";
 import { EditableTileTitle } from "../../../components/tiles/editable-tile-title";
 import { DataflowContentModelType } from "../model/dataflow-content";
@@ -47,10 +46,10 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IDatafl
     };
   }
   public render() {
-    const { readOnly, height, model } = this.props;
+    const { readOnly, height, model, onRegisterTileApi, tileElt } = this.props;
     const editableClass = readOnly ? "read-only" : "editable";
     const classes = `dataflow-tool disable-tile-content-drag ${editableClass}`;
-    const { program, programDataRate, programZoom } = this.getContent();
+    const { program, programDataRate } = this.getContent();
     const tileContent = this.getContent();
 
     return (
@@ -71,6 +70,8 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IDatafl
                   size={size}
                   tileHeight={height}
                   tileContent={tileContent}
+                  tileElt={tileElt}
+                  onRegisterTileApi={onRegisterTileApi}
                 />
               );
             }}
@@ -79,14 +80,6 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IDatafl
         </div>
       </>
     );
-  }
-
-  public componentDidMount() {
-    this.props.onRegisterTileApi({
-      exportContentAsTileJson: (options?: ITileExportOptions) => {
-        return this.getContent().exportJson(options);
-      }
-    });
   }
 
   private getDocument() {

--- a/src/plugins/dataflow/model/dataflow-content-test-constants.ts
+++ b/src/plugins/dataflow/model/dataflow-content-test-constants.ts
@@ -1,6 +1,6 @@
 
 export const newDataRate = 10;
-export const newZoom = { dx: 1, dy: 1, scale: 10 };
+export const newZoom = { x: 1, y: 1, k: 10 };
 
 // program has four nodes: Generator, Timer, Number, Demo Output
 export const exampleProgram = `{

--- a/src/plugins/dataflow/model/dataflow-content.test.ts
+++ b/src/plugins/dataflow/model/dataflow-content.test.ts
@@ -23,11 +23,11 @@ describe("DataflowContentModel", () => {
   it("should handle basic changes", () => {
     const dcm = defaultDataflowContent();
     dcm.setProgramDataRate(newDataRate);
-    dcm.setProgramZoom(newZoom.dx, newZoom.dy, newZoom.scale);
+    dcm.setProgramZoom(newZoom);
     expect(dcm.programDataRate).toBe(newDataRate);
-    expect(dcm.programZoom.dx).toBe(newZoom.dx);
-    expect(dcm.programZoom.dy).toBe(newZoom.dy);
-    expect(dcm.programZoom.scale).toBe(newZoom.scale);
+    expect(dcm.programZoom.dx).toBe(newZoom.x);
+    expect(dcm.programZoom.dy).toBe(newZoom.y);
+    expect(dcm.programZoom.scale).toBe(newZoom.k);
   });
 
   it("should be to load a program", () => {

--- a/src/plugins/dataflow/model/dataflow-program-model.ts
+++ b/src/plugins/dataflow/model/dataflow-program-model.ts
@@ -69,10 +69,19 @@ export const DataflowNodeModel = types.
       TransformNodeModel,
     ) as typeof BaseNodeModel
   })
+  .volatile(self => ({
+    // These are stored so annotations can update as the node moves around
+    liveX: NaN,
+    liveY: NaN,
+  }))
   .actions(self => ({
     setPosition(position: {x: number, y: number}) {
-      self.x = position.x;
-      self.y = position.y;
+      self.x = self.liveX = position.x;
+      self.y = self.liveY = position.y;
+    },
+    setLivePosition(position: {x: number, y: number}) {
+      self.liveX = position.x;
+      self.liveY = position.y;
     }
   }))
   .preProcessSnapshot((snapshot: any) => {

--- a/src/plugins/dataflow/model/dataflow-program-model.ts
+++ b/src/plugins/dataflow/model/dataflow-program-model.ts
@@ -205,8 +205,13 @@ export const DataflowProgramModel = types.
         self.nodes.forEach((_node) => {
           const node = _node.data as IBaseNodeModel;
           const attrId = getAttributeIdForNode(dataSet, nodeIndex);
-          const nodeValue = dataSet.getValue(caseId, attrId) as number;
-          node.setNodeValue(nodeValue);
+
+          // The user might have messed with the table, so the attribute might not exist
+          if (attrId) {
+            const nodeValue = dataSet.getValue(caseId, attrId) as number;
+            node.setNodeValue(nodeValue);
+          }
+
           nodeIndex++;
         });
       }

--- a/src/plugins/dataflow/model/utilities/recording-utilities.ts
+++ b/src/plugins/dataflow/model/utilities/recording-utilities.ts
@@ -4,7 +4,13 @@ import { ICaseCreation } from "../../../../models/data/data-set-types";
 
 // this function adds one to index to skip time attribute
 export function getAttributeIdForNode(dataSet: IDataSet, nodeIndex: number) {
-  return dataSet.attributes[nodeIndex + 1].id;
+  // The table might have been modified by the user so the attributes might
+  // not exist or match up. We do not currently check if the attributes match
+  // up, but we handle when the index is out of bounds or if the attribute
+  // has become undefined somehow.
+  const attrIndex = nodeIndex + 1;
+  if (attrIndex >= dataSet.attributes.length) return undefined;
+  return dataSet.attributes[attrIndex]?.id;
 }
 
 export function recordCase(content: DataflowContentModelType, recordIndex: number) {
@@ -22,6 +28,13 @@ export function recordCase(content: DataflowContentModelType, recordIndex: numbe
   let idx = 0;
   program.nodes.forEach((node) => {
     const key = getAttributeIdForNode(dataSet, idx);
+
+    // The user might have deleted an attribute while the data is recording.
+    // In this case we'll continue recording and not crash. The data will
+    // go in the wrong columns if the user deleted an attribute other than the
+    // last one.
+    if (!key) return;
+
     const { nodeValue } =  node.data;
     // TODO: This approach will show NaN as "NaN" in the table.
     // That is what was happening before.

--- a/src/plugins/dataflow/nodes/rete-manager.tsx
+++ b/src/plugins/dataflow/nodes/rete-manager.tsx
@@ -75,6 +75,7 @@ export class ReteManager implements INodeServices {
   private snapshotDisposer: () => void | undefined;
   public inTick = false;
   public disposed = false;
+  public setupComplete: Promise<void>;
   private previousChannelIds = "";
 
   constructor(
@@ -90,7 +91,7 @@ export class ReteManager implements INodeServices {
     this.area = new AreaPlugin<Schemes, AreaExtra>(div);
     this.updateMainProcessor();
 
-    this.setup();
+    this.setupComplete = this.setup();
   }
 
   async setup() {

--- a/src/plugins/dataflow/nodes/rete-manager.tsx
+++ b/src/plugins/dataflow/nodes/rete-manager.tsx
@@ -106,23 +106,38 @@ export class ReteManager implements INodeServices {
     });
 
     area.addPipe((context) => {
-      if (context.type !== "nodedragged") return context;
+      const event = context.type;
+      if (event === "nodedragged" || event === "nodetranslated") {
 
-      const id = context.data.id;
-      const nodeView = area.nodeViews.get(id);
+        const id = context.data.id;
+        const nodeView = area.nodeViews.get(id);
 
-      // This should not happen, but it is possible in theory
-      if (!nodeView) return context;
+        // This should not happen, but it is possible in theory
+        if (!nodeView) return context;
 
-      const nodeModel = mstProgram.nodes.get(id);
+        const nodeModel = mstProgram.nodes.get(id);
 
-      // This should also not happen but seems more likely
-      if (!nodeModel) {
-        console.warn("Cannot find MST node model for a dragged Rete node");
-        return context;
+        // This should also not happen but seems more likely
+        if (!nodeModel) {
+          console.warn("Cannot find MST node model for a dragged Rete node");
+          return context;
+        }
+
+        if (event === "nodedragged") {
+          // We are done dragging the node, so save the position for real
+          nodeModel.setPosition(nodeView.position);
+        } else {
+          // We are currently translating the node, only save it in volatile
+          nodeModel.setLivePosition(nodeView.position);
+        }
       }
-
-      nodeModel.setPosition(nodeView.position);
+      if (event === "translate" || event === "translated") {
+        if (event === "translate" ) {
+          this.mstContent.setLiveProgramZoom(area.area.transform);
+        } else {
+          this.mstContent.setProgramZoom(area.area.transform);
+        }
+      }
       return context;
     });
 
@@ -752,6 +767,6 @@ export class ReteManager implements INodeServices {
   private async setZoom(zoom: number) {
     await this.area.area.zoom(zoom);
     const { transform } = this.area.area;
-    this.mstContent.setProgramZoom(transform.x, transform.y, transform.k);
+    this.mstContent.setProgramZoom(transform);
   }
 }


### PR DESCRIPTION
This also fixes the translation of the dataflow canvas. Previously the translation of the canvas was not saved in state unless the user also zoomed the program canvas. With this change the translation is now saved even if the user doesn't zoom the program canvas.

PT-186813616
PT-187581801