### PR TITLE
move disabled tile content dragging to tile element

### DIFF
--- a/src/plugins/dataflow/components/dataflow-tile.tsx
+++ b/src/plugins/dataflow/components/dataflow-tile.tsx
@@ -48,7 +48,7 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IDatafl
   public render() {
     const { readOnly, height, model, onRegisterTileApi, tileElt } = this.props;
     const editableClass = readOnly ? "read-only" : "editable";
-    const classes = `dataflow-tool disable-tile-content-drag ${editableClass}`;
+    const classes = `dataflow-tool ${editableClass}`;
     const { program, programDataRate } = this.getContent();
     const tileContent = this.getContent();
 

--- a/src/plugins/dataflow/dataflow-registration.ts
+++ b/src/plugins/dataflow/dataflow-registration.ts
@@ -39,7 +39,7 @@ registerTileContentInfo({
 registerTileComponentInfo({
   type: kDataflowTileType,
   Component: DataflowToolComponent,
-  tileEltClass: "dataflow-tool-tile",
+  tileEltClass: "dataflow-tool-tile disable-tile-content-drag",
   Icon,
   HeaderIcon
 });


### PR DESCRIPTION
This fixes an issue that was happening with the latest version of Chrome.
When a block within a Dataflow tile was dragged it would move a couple of pixels and then the whole Dataflow tile would start to be dragged.

CLUE has a mechanism for saying that drag events should be ignored unless they are on the specific drag handle of the tile. Dataflow was trying to use this mechanism, however it was not working. The main issue only showed up in the latest Chrome, however it was possible to see that drag events which should have been ignored were causing tile dragging in older versions of Chrome.

The mechanism CLUE uses for tiles to say only their drag handle should be draggable, is by adding the `disable-tile-content-drag` class to an element. The tile dragging code listens for drag events on the tile element and for each event looks to see if any of the parents of the drag event target have this class. If they do, the event is ignored.

The problem was that a browser dragStart event is only sent to the first parent element that has `draggable=true`.  And the `target` of this event is this draggable parent element not the child element under the mouse..  Because Dataflow doesn't use the html drag API, none of its elements have `draggable=true`.  So the first parent element was the tile element itself. And this tile element did not have the `disable-tile-content-drag` class. The special class was added to a child element of the tile element. The solution is to add the `disable-tile-content-drag` class to the tile element. This is the same approach used by the Diagram tile.

Why the core issue started happening in the latest Chrome is not perfectly clear. I think the issue was caused by this change: https://developer.chrome.com/release-notes/125#interoperable_mousemove_default_action  My guess is that the block are handling `mousemove` and calling `preventDefaults`. This used to prevent a dragStart from being bubbled up to the first draggable parent. But with the change in Chrome 125, preventing the default on the mousemove doesn't also stop the dragStart.