### PR TITLE
fix chrome 125 dragging

### DIFF
--- a/src/plugins/drawing/drawing-registration.ts
+++ b/src/plugins/drawing/drawing-registration.ts
@@ -29,7 +29,7 @@ registerTileContentInfo({
 registerTileComponentInfo({
   type: kDrawingTileType,
   Component: DrawingToolComponent,
-  tileEltClass: "drawing-tool-tile",
+  tileEltClass: "drawing-tool-tile disable-tile-content-drag",
   Icon,
   HeaderIcon,
   tileHandlesOwnSelection: true

--- a/src/plugins/simulator/simulator-registration.ts
+++ b/src/plugins/simulator/simulator-registration.ts
@@ -20,6 +20,6 @@ registerTileComponentInfo({
   Component: SimulatorTileComponent,
   Icon,
   HeaderIcon,
-  tileEltClass: "simulator-tool-tile",
+  tileEltClass: "simulator-tool-tile disable-tile-content-drag",
   type: kSimulatorTileType,
 });


### PR DESCRIPTION
This is fixed by disabling content drag for the whole tile. This means users have to grab the tile drag handle for these tiles instead.