### PR TITLE
A demo of testing for a log event

### DIFF
--- a/cypress/e2e/functional/tile_tests/drawing_tool_spec.js
+++ b/cypress/e2e/functional/tile_tests/drawing_tool_spec.js
@@ -1,6 +1,7 @@
 import ClueCanvas from '../../../support/elements/common/cCanvas';
 import DrawToolTile from '../../../support/elements/tile/DrawToolTile';
 import ImageToolTile from '../../../support/elements/tile/ImageToolTile';
+import { LogEventName } from '../../../../src/lib/logger-types';
 
 let clueCanvas = new ClueCanvas,
   drawToolTile = new DrawToolTile;
@@ -33,7 +34,15 @@ context('Draw Tool Tile', function () {
   it("renders draw tool tile", () => {
     beforeTest();
 
+    cy.window().then(win => {
+      cy.stub(win.ccLogger, "log").as("log");
+    });
+    cy.get("@log").should('not.have.been.called');
     clueCanvas.addTile("drawing");
+    cy.get("@log")
+      .should("have.been.been.calledWith", LogEventName.CREATE_TILE, Cypress.sinon.match.object)
+      .its("firstCall.args.1").should("deep.include", { objectType: "Drawing" });
+
     drawToolTile.getDrawTile().should("exist");
     drawToolTile.getTileTitle().should("exist");
 

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -207,3 +207,9 @@ function sendToLoggingService(data: LogMessage, user: UserModelType) {
   request.setRequestHeader("Content-Type", "application/json; charset=UTF-8");
   request.send(JSON.stringify(data));
 }
+
+// Add the logger to the window in Cypress so we can stub it
+const aWindow = window as any;
+if (aWindow.Cypress) {
+  aWindow.ccLogger = Logger;
+}


### PR DESCRIPTION
This demonstrates how to drive the UI with Cypress and then verify that a log event is recorded.

I don't find the code very nice looking though. There are a lot of strings that will be easy to type wrong. So probably this should be moved into a helper function which can encapsulate all of the strings. 

However, it is probably good to merge this as is so it is available when someone wants to check log messages. And we can refactor it once we have a few more examples.