### PR TITLE
build with the new deploy-path action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,6 @@ jobs:
       name: ${{ github.ref_type == 'branch' && 'branches' || 'versions' }}
       url: https://collaborative-learning.concord.org/${{ steps.s3-deploy.outputs.deployPath }}/?demo
     steps:
-      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           name: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install CMS Dependencies
         working-directory: ./cms
         run: npm ci
-      - uses: concord-consortium/s3-deploy-action/deploy-path@add-deploy-path-action
+      - uses: concord-consortium/s3-deploy-action/deploy-path@v1
         id: s3-deploy-path
       - name: Lint
         run: npm run lint:build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,29 +126,14 @@ jobs:
       url: https://collaborative-learning.concord.org/${{ steps.s3-deploy.outputs.deployPath }}/?demo
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v2
+      - uses: actions/download-artifact@v4
         with:
-          node-version: '16'
-          cache: 'npm'
-          cache-dependency-path: |
-            package-lock.json
-            cms/package-lock.json
-      - name: Install Dependencies
-        run: npm ci
-        env:
-          # skip installing cypress since it isn't needed for just building
-          # This decreases the deploy time quite a bit
-          CYPRESS_INSTALL_BINARY: 0
-      - name: Install CMS Dependencies
-        working-directory: ./cms
-        run: npm ci
-        env:
-          # skip installing cypress since it isn't needed for just building
-          # This decreases the deploy time quite a bit
-          CYPRESS_INSTALL_BINARY: 0
+          name: build
+          path: dist
       - uses: concord-consortium/s3-deploy-action@v1
         id: s3-deploy
         with:
+          build: echo no build
           bucket: models-resources
           prefix: collaborative-learning
           awsAccessKeyId: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,16 @@ jobs:
         run: npm ci
       - uses: concord-consortium/s3-deploy-action/deploy-path@add-deploy-path-action
         id: s3-deploy-path
-      - name: Build
-        run: npm run build
+      - name: Lint
+        run: npm run lint:build
+      - name: Clean
+        run: npm run clean
+      - name: Build Main App
+        run: npm run build:webpack
+        env:
+          DEPLOY_PATH: ${{ steps.s3-deploy-path.outputs.deployPath }}
+      - name: Build CMS
+        run: npm run build:cms
         env:
           DEPLOY_PATH: ${{ steps.s3-deploy-path.outputs.deployPath }}
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,10 @@ jobs:
         run: npm run build
         env:
           DEPLOY_PATH: ${{ steps.s3-deploy-path.outputs.deployPath }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: build
+          path: dist/
   jest:
     name: Run Jest Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,12 @@ jobs:
       - name: Install CMS Dependencies
         working-directory: ./cms
         run: npm ci
+      - uses: concord-consortium/s3-deploy-action/deploy-path@add-deploy-path-action
+        id: s3-deploy-path
       - name: Build
         run: npm run build
+        env:
+          DEPLOY_PATH: ${{ steps.s3-deploy-path.outputs.deployPath }}
   jest:
     name: Run Jest Tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
This uses the new `concord-consortium/s3-deploy-action/deploy-path@v1` action which was added here:
https://github.com/concord-consortium/s3-deploy-action/pull/403
Readme doc on it is here: https://github.com/concord-consortium/s3-deploy-action?tab=readme-ov-file#deploy-path-only-action

The basic changes are:
- the build job now figures out the deployPath first
- the build job then passes this deployPath as the DEPLOY_PATH environment variable when running the webpack builds. 
- after the build is completed the whole `dist/` folder is uploaded as an "artifact"
- the s3-deploy job now downloads this artifact.
- the s3-deploy job no longer needs to install any dependencies or build anything.
- by default the s3-deploy-action will try to run `npm run build` so this is overridden with no op command of `echo no build`.
 
Additionally the build job is split into multiple steps. This makes it easier to see how long the lint, clean, main app build, and cms app build take to run.  With this data we could consider running the main app build and cms app build in two parallel jobs. However both of these jobs would need to run `npm ci` which almost dwarfs any benefit.  There are ways we could improve our caching so `npm ci` would run much faster but that is a new story.

## Future Direction
Also it would be nice to use this build artifact for the Cypress tests. There are two sets of Cypress tests to consider:
- the `cypress` job in `ci.yml
- the `regression` job in `ci-regression.yml`

### ci.yml
The `cypress` job in this `ci.yml` workflow would be easy to do this with. However it means the `cypress` job would have to wait for the build to finish before it starts. So the net result might actually be a slower build.

### ci-regression.yml
The `regession` job in `ci-regression.yml` would get more benefit because it is typically kicked off when the `run-regression` label is added to the PR. So the build would have already been complete at this point. Additionally because it uses 5 workers that means they are each running `npm ci` and `npm build`. This wastes a lot of our GitHub build minutes. The install also eats up a lot of network bandwidth in GitHub. I suspect there is throttling that happens when actions use too much bandwidth.  

However using the build artifact is tricky in this case. These are two different workflows and artifacts are not automatically available between them. It is necessary to know the run id for a workflow to download an artifact from another workflow's run. It is possible to figure out the latest run id for a particular workflow using commandline tools, but there is also a dependency relationship. We need to wait for the build of the current commit to be finished before trying to download the artifact from its run. 

After having looking at this, I think the best approach is to try to move the `ci-regression.yml` workflow back into the `ci.yml`. And then update the `regression-label.yml` workflow so it re-runs just this new regression job in `ci.yml` when the label is added. It seems like this is possible using the command line tools. It isn't possible using the GitHub UI. It might also have the side effect of simplifying the checks that are shown on the PR. Currently these checks are confusing with the two different workflows.