### PR TITLE
improve exported content loading

### DIFF
--- a/docs/document-types.md
+++ b/docs/document-types.md
@@ -12,7 +12,7 @@ All of the contents of the realtime database for a given class are stored at a p
 
 The content and generic metadata for all documents associated with the user's work in a given class is stored at `/{classPath}/users/{userId}/documents` and `/{classPath}/users/{userId}/documentMetadata`. Additional type-specific metadata is stored elsewhere to make it easier to find documents of specific types associated with specific problems, for instance.
 
-The document metadata at `/{classPath}/users/{userId}/documentMetadata` can be typed as:
+The document metadata at `/{classPath}/users/{userId}/documentMetadata` [is typed as](/src/lib/db-types.ts):
 ```typescript
 export type DBDocumentType = "section" |  // section documents are deprecated
                               "problem" | "planning" | "publication" |
@@ -31,6 +31,7 @@ export interface DBBaseDocumentMetadata {
   type: DBDocumentType;
   // previously in DBOtherDocument
   properties?: IDocumentProperties;
+  visibility?: "public" | "private";
 }
 
 export interface DBBaseProblemDocumentMetadata extends DBBaseDocumentMetadata {
@@ -39,7 +40,7 @@ export interface DBBaseProblemDocumentMetadata extends DBBaseDocumentMetadata {
 }
 ```
 
-Document contents at `/{classPath}/users/{userId}/documents` can be typed as:
+Document contents at `/{classPath}/users/{userId}/documents` [is typed as](/src/lib/db-types.ts):
 ```typescript
 export interface DBDocument {
   version: "1.0";

--- a/src/models/document/base-document-content.ts
+++ b/src/models/document/base-document-content.ts
@@ -1,4 +1,4 @@
-import { cloneDeep, each } from "lodash";
+import { each } from "lodash";
 import { types, getType, getEnv, SnapshotIn } from "mobx-state-tree";
 import { kPlaceholderTileDefaultHeight } from "../tiles/placeholder/placeholder-constants";
 import {
@@ -15,7 +15,7 @@ import {
   IDropRowInfo, TileRowModel, TileRowModelType, TileRowSnapshotType, TileLayoutModelType
 } from "../document/tile-row";
 import { migrateSnapshot } from "./document-content-import";
-import { isImportDocument, OriginalAuthoredTileModel } from "./document-content-import-types";
+import { isImportDocument } from "./document-content-import-types";
 import { logTileCopyEvent } from "../tiles/log/log-tile-copy-event";
 import { logTileDocumentEvent } from "../tiles/log/log-tile-document-event";
 import { getAppConfig } from "../tiles/tile-environment";
@@ -23,6 +23,7 @@ import { LogEventName } from "../../lib/logger-types";
 import { safeJsonParse, uniqueId } from "../../utilities/js-utils";
 import { defaultTitle, extractTitleBase, titleMatchesDefault } from "../../utilities/title-utils";
 import { SharedModel, SharedModelType } from "../shared/shared-model";
+import { getSharedModelInfoByType } from "../shared/shared-model-registry";
 import { kSectionHeaderHeight } from "./document-constants";
 import { IDocumentContentAddTileOptions, INewRowTile, INewTileOptions,
    ITileCountsPerSection, NewRowTileArray } from "./document-content-types";
@@ -53,8 +54,6 @@ export const BaseDocumentContentModel = types
   .volatile(self => ({
     visibleRows: [] as string[],
     highlightPendingDropLocation: -1,
-    importContextCurrentSection: "",
-    importContextTileCounts: {} as Record<string, number>
   }))
   .views(self => {
     // used for drag/drop self-drop detection, for instance
@@ -428,36 +427,6 @@ export const BaseDocumentContentModel = types
     },
   }))
   .actions(self => ({
-    setImportContext(section: string) {
-      self.importContextCurrentSection = section;
-      self.importContextTileCounts = {};
-    },
-    getNextTileId(tileType: string) {
-      if (!self.importContextTileCounts[tileType]) {
-        self.importContextTileCounts[tileType] = 1;
-      } else {
-        ++self.importContextTileCounts[tileType];
-      }
-      // FIXME: This doesn't generate unique ids.
-      // Many sections seem to be unnamed, so they never set the importContextCurrentSection.
-      // The result is tiles in different sections (including different investigations and problems)
-      // have the same id, and in turn share the same metadata.
-      const section = self.importContextCurrentSection || "document";
-      return `${section}_${tileType}_${self.importContextTileCounts[tileType]}`;
-    },
-    migrateContentTitles() {
-      // Find and fix any tiles that have a title incorrectly set on the tile, rather than on the content.
-      // We iterate through the tiles in reverse order, so that if there is more than one tile
-      // linked to the same shared title, the first tile's name is the one that ends up being used.
-      const tiles = self.getTilesInDocumentOrder().reverse();
-      for (const id of tiles) {
-        const tile = self.tileMap.get(id);
-        if (tile && tile.title && getTileContentInfo(tile.content.type)?.useContentTitle) {
-          tile.content.setContentTitle(tile.title);
-          tile.setTitle(undefined);
-        }
-      }
-    },
     insertRow(row: TileRowModelType, index?: number) {
       self.rowMap.put(row);
       if ((index != null) && (index < self.rowOrder.length)) {
@@ -488,9 +457,6 @@ export const BaseDocumentContentModel = types
     }
   }))
   .actions(self => ({
-    addSectionHeaderRow(sectionId: string) {
-      self.insertRow(TileRowModel.create({ isSectionHeader: true, sectionId }));
-    },
     addNewTileInNewRowAtIndex(tile: ITileModel, rowIndex: number) {
       const row = TileRowModel.create({});
       self.insertRow(row, rowIndex);
@@ -536,23 +502,25 @@ export const BaseDocumentContentModel = types
       for (let i = 1; i < self.rowCount; ++i) {
         self.addPlaceholderRowIfAppropriate(i);
       }
-    },
-    addImportedTileToRow(tile: OriginalAuthoredTileModel, row: TileRowModelType) {
 
-      const { layout, ...newTile } = cloneDeep(tile);
-      const tileHeight = layout?.height;
-
-      const id = newTile.id || self.getNextTileId(newTile.content.type);
-      const tileSnapshot = { id, ...newTile };
-
-      // Add the snapshot directly to the map instead of creating it
-      // independently. This way if the snapshot has references to
-      // shared model objects, those references will be valid.
-      const tileModel = self.tileMap.put(tileSnapshot);
-      row.insertTileInRow(tileModel!);
-
-      if (tileHeight) {
-        row.setRowHeight(Math.max((row.height || 0), tileHeight));
+      // Find and fix any tiles that have a title incorrectly set on the tile, rather than on the content.
+      // We iterate through the tiles in reverse order, so that if there is more than one tile
+      // linked to the same shared title, the first tile's name is the one that ends up being used.
+      // We have to do this without the sharedModelManagers's help because it won't be available
+      // immediately after creation.
+      const tiles = self.getTilesInDocumentOrder().reverse();
+      for (const id of tiles) {
+        const tile = self.tileMap.get(id);
+        if (tile && tile.title && getTileContentInfo(tile.content.type)?.useContentTitle) {
+          // Look for a SharedModel that can hold the title
+          for (const sm of Object.values(self.getSharedModelsUsedByTiles([id]))) {
+            if (getSharedModelInfoByType(sm.sharedModel.type)?.hasName) {
+              sm.sharedModel.setName(tile.title);
+              tile.setTitle(undefined);
+              break;
+            }
+          }
+        }
       }
     }
   }))

--- a/src/models/document/document-content-tests/dc-general.test.ts
+++ b/src/models/document/document-content-tests/dc-general.test.ts
@@ -5,7 +5,7 @@ import { createDefaultSectionedContent } from "../sectioned-content";
 import { SectionModel, SectionModelType } from "../../curriculum/section";
 import { TextContentModel } from "../../tiles/text/text-content";
 import { IDocumentExportOptions } from "../../tiles/tile-content-info";
-import { parsedExport, getColumnWidths } from "./dc-test-utils";
+import { parsedExport, getColumnWidths, getAllRows } from "./dc-test-utils";
 import placeholderImage from "../../assets/image_placeholder.png";
 
 jest.mock("../../../utilities/mst-utils", () => {
@@ -256,383 +256,376 @@ describe("DocumentContentModel", () => {
 
 });
 
+const sectionedContent = {
+    "[Header:A, Placeholder": [
+      { content: { isSectionHeader: true, sectionId: "A" } },
+      { content: { type: "Placeholder", sectionId: "A" }}
+    ],
+    "[Header:A, Placeholder, Header:B, Placeholder]": [
+      { content: { isSectionHeader: true, sectionId: "A" } },
+      { content: { type: "Placeholder", sectionId: "A" }},
+      { content: { isSectionHeader: true, sectionId: "B" } },
+      { content: { type: "Placeholder", sectionId: "B" }}
+    ],
+    "[Header:A, Placeholder, Header:B, Text]": [
+      { content: { isSectionHeader: true, sectionId: "A" } },
+      { content: { type: "Placeholder", sectionId: "A" }},
+      { content: { isSectionHeader: true, sectionId: "B" } },
+      { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } }
+    ],
+    "[Header:A, Text, Header:B, Text]": [
+      { content: { isSectionHeader: true, sectionId: "A" } },
+      { title: "Text 2", content: { type: "Text", format: "html", text: ["<p>foo</p>"] } },
+      { content: { isSectionHeader: true, sectionId: "B" } },
+      { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } }
+    ],
+    "[Header:A, Text, Header:B, Placeholder]": [
+      { content: { isSectionHeader: true, sectionId: "A" } },
+      { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } },
+      { content: { isSectionHeader: true, sectionId: "B" } },
+      { content: { type: "Placeholder", sectionId: "B" }}
+    ],
+    "[Header:A, [Geometry, Text], Header:B, Text]": [
+      { content: { isSectionHeader: true, sectionId: "A" } },
+      [
+        { title: "Shapes Graph 1", content: { type: "Geometry" } },
+        { content: { type: "Text", format: "html", text: ["<p></p>"] } }
+      ],
+      { content: { isSectionHeader: true, sectionId: "B" } },
+      { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } }
+    ],
+    "[Header:A, [Text, Geometry], Header:B, Text]": [
+      { content: { isSectionHeader: true, sectionId: "A" } },
+      [
+        { content: { type: "Text", format: "html", text: ["<p></p>"] } },
+        { title: "Shapes Graph 1", content: { type: "Geometry" } }
+      ],
+      { content: { isSectionHeader: true, sectionId: "B" } },
+      { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } }
+    ]
+} as const;
+
+function createDocumentContent(description: keyof typeof sectionedContent) {
+  return DocumentContentModel.create({tiles: sectionedContent[description]} as any);
+}
+
 describe("DocumentContentModel -- sectioned documents --", () => {
 
-  const content = DocumentContentModel.create({});
-
-  const parsedContentExport = () => parsedExport(content);
-
-  function isPlaceholderSection(sectionId: string) {
-    const rows = content.getRowsInSection(sectionId);
-    if (rows.length !== 1) return false;
-    if (!content.isPlaceholderRow(rows[0])) return false;
-    if (rows[0].tileCount !== 1) return false;
-    if (content.getTilesInSection(sectionId).length !== 0) return false;
-    return true;
-  }
-
-  function isContentSection(sectionId: string, tileCount = 1) {
-    const rows = content.getRowsInSection(sectionId);
-    if (rows.length !== 1) return false;
-    if (content.isPlaceholderRow(rows[0])) return false;
-    if (rows[0].tileCount !== tileCount) return false;
-    if (content.getTilesInSection(sectionId).length !== tileCount) return false;
-    return true;
-  }
-
-  // function logRows(label: string, c: DocumentContentModelType) {
-  //   console.log("***", label, "[begin] ***");
-  //   c.rowOrder.forEach((rowId, rowIndex) => {
-  //     const row = c.rowMap.get(rowId);
-  //     console.log(`Row ${rowIndex + 1}:`, "id:", row!.id, "isSectionHeader:",
-  //                 row!.isSectionHeader, "# tiles:", row!.tiles.length);
-  //     row && row.tiles.forEach((layout, tileIndex) => {
-  //       const tile = c.tileMap.get(layout.tileId);
-  //       console.log(`..Tile ${tileIndex + 1}:`, "type:", tile!.content.type);
-  //     });
-  //   });
-  //   console.log("***", label, "[end] ***");
-  // }
-
-  /*
-   * Note that contrary to unit-testing best practices, the separate `it()` blocks here
-   * are inter-dependent -- each subsequent test relies on the document content to be in
-   * the state that the previous test should have left it.
-   */
-
   it("can create sectioned documents", () => {
-    // []
-    content.addSectionHeaderRow("A");
-    // [Header:A]
-    content.addPlaceholderTile("A");
-    // [Header:A, Placeholder]
-    expect(content.rowCount).toBe(2);
-    expect(content.getRowByIndex(0)!.isSectionHeader).toBe(true);
-    expect(content.isPlaceholderRow(content.getRowByIndex(1)!)).toBe(true);
-    expect(isPlaceholderSection("A")).toBe(true);
-    expect(content.defaultInsertRow).toBe(1);
+    const content1 = createDocumentContent(
+      "[Header:A, Placeholder"
+    );
 
-    content.addSectionHeaderRow("B");
-    // [Header:A, Placeholder, Header:B]
-    content.addPlaceholderTile("B");
-    // [Header:A, Placeholder, Header:B, Placeholder]
-    expect(content.rowCount).toBe(4);
-    expect(content.getRowByIndex(2)!.isSectionHeader).toBe(true);
-    expect(content.isPlaceholderRow(content.getRowByIndex(3)!)).toBe(true);
-    expect(isPlaceholderSection("B")).toBe(true);
-    expect(content.defaultInsertRow).toBe(1);
-    expect(parsedContentExport()).toEqual({ tiles: [] });
+    expect(getAllRows(content1)).toEqual([
+      { Header: "A"},
+      { Placeholder: "A" }
+    ]);
+    expect(content1.defaultInsertRow).toBe(1);
+
+    const content2 = createDocumentContent(
+      "[Header:A, Placeholder, Header:B, Placeholder]"
+    );
+    expect(getAllRows(content2)).toEqual([
+      { Header: "A"},
+      { Placeholder: "A" },
+      { Header: "B"},
+      { Placeholder: "B" }
+    ]);
+    expect(content2.defaultInsertRow).toBe(1);
+    expect(parsedExport(content2)).toEqual({ tiles: [] });
   });
 
   it("will remove placeholder tiles when adding a new tile in the last section", () => {
-    // [Header:A, Placeholder, Header:B, Placeholder]
+    const content = createDocumentContent(
+      "[Header:A, Placeholder, Header:B, Placeholder]"
+    );
     content.addTile("text", { title: "Text 1" });
-    // [Header:A, Placeholder, Header:B, Text]
-    expect(content.rowCount).toBe(4);
-    expect(isPlaceholderSection("A")).toBe(true);
-    expect(isContentSection("B")).toBe(true);
+
+    expect(getAllRows(content)).toEqual([
+      { Header: "A"},
+      { Placeholder: "A" },
+      { Header: "B"},
+      { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] }}
+    ]);
     expect(content.defaultInsertRow).toBe(4);
-    expect(parsedContentExport()).toEqual({
-      tiles: [
-        { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } }
-      ]
-    });
   });
 
   it("will remove placeholder tiles when adding a new tile in an interior section", () => {
-    // [Header:A, Placeholder, Header:B, Text]
+    const content = createDocumentContent(
+      "[Header:A, Placeholder, Header:B, Text]"
+    );
     content.addTileContentInNewRow(TextContentModel.create({ text: "foo" }), { title: "Text 2", rowIndex: 1 });
-    // [Header:A, Text, Header:B, Text]
-    expect(content.rowCount).toBe(4);
-    expect(isContentSection("A")).toBe(true);
-    expect(isContentSection("B")).toBe(true);
+
+    expect(getAllRows(content)).toEqual([
+      { Header: "A"},
+      { title: "Text 2", content: { type: "Text", format: "html", text: ["<p>foo</p>"] } },
+      { Header: "B"},
+      { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] }}
+    ]);
     expect(content.defaultInsertRow).toBe(4);
-    expect(parsedContentExport()).toEqual({
-      tiles: [
-        { title: "Text 2", content: { type: "Text", format: "html", text: ["<p>foo</p>"] } },
-        { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } }
-      ]
-    });
   });
 
   it("will restore placeholder tiles when deleting the last row in an interior section", () => {
-    // [Header:A, Text, Header:B, Text]
+    const content = createDocumentContent(
+      "[Header:A, Text, Header:B, Text]"
+    );
     const rowId = content.rowOrder[1];
     content.deleteRowAddingPlaceholderRowIfAppropriate(rowId);
-    // [Header:A, Placeholder, Header:B, Text]
-    expect(content.rowCount).toBe(4);
-    expect(isPlaceholderSection("A")).toBe(true);
-    expect(isContentSection("B")).toBe(true);
+
+    expect(getAllRows(content)).toEqual([
+      { Header: "A"},
+      { Placeholder: "A" },
+      { Header: "B"},
+      { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] }}
+    ]);
     expect(content.defaultInsertRow).toBe(4);
-    expect(parsedContentExport()).toEqual({
-      tiles: [
-        { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } }
-      ]
-    });
   });
 
   it("will restore placeholder tiles when deleting the last row in the last section", () => {
-    // [Header:A, Placeholder, Header:B, Text]
+    const content = createDocumentContent(
+      "[Header:A, Placeholder, Header:B, Text]"
+    );
     const rowId = content.rowOrder[3];
     content.deleteRowAddingPlaceholderRowIfAppropriate(rowId);
-    // [Header:A, Placeholder, Header:B, Placeholder]
-    expect(content.rowCount).toBe(4);
-    expect(isPlaceholderSection("A")).toBe(true);
-    expect(isPlaceholderSection("B")).toBe(true);
+
+    expect(getAllRows(content)).toEqual([
+      { Header: "A"},
+      { Placeholder: "A" },
+      { Header: "B"},
+      { Placeholder: "B" }
+    ]);
     expect(content.defaultInsertRow).toBe(1);
-    expect(parsedContentExport()).toEqual({ tiles: [] });
   });
 
   it("will add/remove placeholder rows when moving entire rows (3 => 1)", () => {
-    // [Header:A, Placeholder, Header:B, Placeholder]
+    const content = createDocumentContent(
+      "[Header:A, Placeholder, Header:B, Placeholder]"
+    );
     content.addTile("text", { title: "Text 1" });
     // [Header:A, Placeholder, Header:B, Text]
     content.moveRowToIndex(3, 1);
     // [Header:A, Text, Header:B, Placeholder]
     // moving to row 0 when row 0 is a section header is a no-op
     content.moveRowToIndex(1, 0);
-    expect(content.rowCount).toBe(4);
-    expect(isContentSection("A")).toBe(true);
-    expect(isPlaceholderSection("B")).toBe(true);
+
+    expect(getAllRows(content)).toEqual([
+      { Header: "A"},
+      { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } },
+      { Header: "B"},
+      { Placeholder: "B" }
+    ]);
     expect(content.defaultInsertRow).toBe(2);
-    expect(parsedContentExport()).toEqual({
-      tiles: [
-        { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } }
-      ]
-    });
   });
 
   it("will add/remove placeholder rows when moving entire rows (1 => 3)", () => {
-    // [Header:A, Text, Header:B, Placeholder]
+    const content = createDocumentContent(
+      "[Header:A, Text, Header:B, Placeholder]"
+    );
     content.moveRowToIndex(1, 3);
-    // [Header:A, Placeholder, Header:B, Text]
-    expect(content.rowCount).toBe(4);
-    expect(isPlaceholderSection("A")).toBe(true);
-    expect(isContentSection("B")).toBe(true);
+
+    expect(getAllRows(content)).toEqual([
+      { Header: "A"},
+      { Placeholder: "A" },
+      { Header: "B"},
+      { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } },
+    ]);
     expect(content.defaultInsertRow).toBe(4);
-    expect(parsedContentExport()).toEqual({
-      tiles: [
-        { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } }
-      ]
-    });
   });
 
   it("will add/remove placeholder rows when moving a tile back to a new row", () => {
-    // [Header:A, Placeholder, Header:B, Text]
+    const content = createDocumentContent(
+      "[Header:A, Placeholder, Header:B, Text]"
+    );
     const tileId = content.getRowByIndex(3)!.tiles[0].tileId;
     content.moveTileToNewRow(tileId, 2);
-    // [Header:A, Text, Header:B, Placeholder]
-    expect(content.rowCount).toBe(4);
-    expect(isContentSection("A")).toBe(true);
-    expect(isPlaceholderSection("B")).toBe(true);
+
+    expect(getAllRows(content)).toEqual([
+      { Header: "A"},
+      { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } },
+      { Header: "B"},
+      { Placeholder: "B" }
+    ]);
     expect(content.defaultInsertRow).toBe(2);
-    expect(parsedContentExport()).toEqual({
-      tiles: [
-        { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } }
-      ]
-    });
   });
 
   it("will add/remove placeholder rows when moving a tile forward to a new row", () => {
-    // [Header:A, Text, Header:B, Placeholder]
+    const content = createDocumentContent(
+      "[Header:A, Text, Header:B, Placeholder]"
+    );
     const tileId = content.getRowByIndex(1)!.tiles[0].tileId;
     content.moveTileToNewRow(tileId, 4);
-    // [Header:A, Placeholder, Header:B, Text]
-    expect(content.rowCount).toBe(4);
-    expect(isPlaceholderSection("A")).toBe(true);
-    expect(isContentSection("B")).toBe(true);
+
+    expect(getAllRows(content)).toEqual([
+      { Header: "A"},
+      { Placeholder: "A" },
+      { Header: "B"},
+      { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } },
+    ]);
     expect(content.defaultInsertRow).toBe(4);
-    expect(parsedContentExport()).toEqual({
-      tiles: [
-        { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } }
-      ]
-    });
   });
 
   it("will add/remove placeholder rows when moving a tile back to an existing row", () => {
-    // [Header:A, Placeholder, Header:B, Text]
+    const content = createDocumentContent(
+      "[Header:A, Placeholder, Header:B, Text]"
+    );
     const tileId = content.getRowByIndex(3)!.tiles[0].tileId;
     content.moveTileToRow(tileId, 1);
-    // [Header:A, Text, Header:B, Placeholder]
-    expect(content.rowCount).toBe(4);
-    expect(isContentSection("A")).toBe(true);
-    expect(isPlaceholderSection("B")).toBe(true);
+
+    expect(getAllRows(content)).toEqual([
+      { Header: "A"},
+      { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } },
+      { Header: "B"},
+      { Placeholder: "B" }
+    ]);
     expect(content.defaultInsertRow).toBe(2);
-    expect(parsedContentExport()).toEqual({
-      tiles: [
-        { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } }
-      ]
-    });
   });
 
   it("will add/remove placeholder rows when moving a tile forward to an existing row", () => {
-    // [Header:A, Text, Header:B, Placeholder]
+    const content = createDocumentContent(
+      "[Header:A, Text, Header:B, Placeholder]"
+    );
     const tileId = content.getRowByIndex(1)!.tiles[0].tileId;
     content.moveTileToRow(tileId, 3, 0);
-    // [Header:A, Placeholder, Header:B, Text]
-    expect(content.rowCount).toBe(4);
-    expect(isPlaceholderSection("A")).toBe(true);
-    expect(isContentSection("B")).toBe(true);
-    expect(parsedContentExport()).toEqual({
-      tiles: [
-        { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } }
-      ]
-    });
+
+    expect(getAllRows(content)).toEqual([
+      { Header: "A"},
+      { Placeholder: "A" },
+      { Header: "B"},
+      { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } },
+    ]);
   });
 
   it("deleteTile() will add/remove placeholder rows", () => {
-    // [Header:A, Placeholder, Header:B, Text]
+    const content = createDocumentContent(
+      "[Header:A, Placeholder, Header:B, Text]"
+    );
     const tileId = content.getRowByIndex(3)!.tiles[0].tileId;
     content.deleteTile(tileId);
-    // [Header:A, Placeholder, Header:B, Placeholder]
-    expect(content.rowCount).toBe(4);
-    expect(isPlaceholderSection("A")).toBe(true);
-    expect(isPlaceholderSection("B")).toBe(true);
-    expect(parsedContentExport()).toEqual({ tiles: [] });
+
+    expect(getAllRows(content)).toEqual([
+      { Header: "A"},
+      { Placeholder: "A" },
+      { Header: "B"},
+      { Placeholder: "B" },
+    ]);
   });
 
   it("addTile() will add/remove placeholder rows", () => {
-    // [Header:A, Placeholder, Header:B, Placeholder]
+    const content = createDocumentContent(
+      "[Header:A, Placeholder, Header:B, Placeholder]"
+    );
     content.addTile("text", { title: "Text 1" });
-    // [Header:A, Placeholder, Header:B, Text]
-    expect(content.rowCount).toBe(4);
-    expect(isPlaceholderSection("A")).toBe(true);
-    expect(isContentSection("B")).toBe(true);
-    expect(parsedContentExport()).toEqual({
-      tiles: [
-        { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } }
-      ]
-    });
+
+    expect(getAllRows(content)).toEqual([
+      { Header: "A"},
+      { Placeholder: "A" },
+      { Header: "B"},
+      { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } },
+    ]);
   });
 
   it("moveTile() will add/remove placeholder rows", () => {
-    // [Header:A, Placeholder, Header:B, Text]
+    const content = createDocumentContent(
+      "[Header:A, Placeholder, Header:B, Text]"
+    );
     const tileId = content.getRowByIndex(3)!.tiles[0].tileId;
     content.moveTile(tileId, { rowDropIndex: 1, rowDropLocation: "right", rowInsertIndex: 1 });
-    // [Header:A, Text, Header:B, Placeholder]
-    expect(content.rowCount).toBe(4);
-    expect(isContentSection("A")).toBe(true);
-    expect(isPlaceholderSection("B")).toBe(true);
-    expect(parsedContentExport()).toEqual({
-      tiles: [
-        { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } }
-      ]
-    });
+    expect(getAllRows(content)).toEqual([
+      { Header: "A"},
+      { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } },
+      { Header: "B"},
+      { Placeholder: "B" }
+    ]);
 
     content.moveTile(tileId, { rowDropIndex: 3, rowDropLocation: "left", rowInsertIndex: 3 });
-    // [Header:A, Placeholder, Header:B, Text]
-    expect(content.rowCount).toBe(4);
-    expect(isPlaceholderSection("A")).toBe(true);
-    expect(isContentSection("B")).toBe(true);
-    expect(parsedContentExport()).toEqual({
-      tiles: [
-        { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } }
-      ]
-    });
+    expect(getAllRows(content)).toEqual([
+      { Header: "A"},
+      { Placeholder: "A" },
+      { Header: "B"},
+      { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } },
+    ]);
 
     content.moveTile(tileId, { rowInsertIndex: 1 });
-    // [Header:A, Text, Header:B, Placeholder]
-    expect(content.rowCount).toBe(4);
-    expect(isContentSection("A")).toBe(true);
-    expect(isPlaceholderSection("B")).toBe(true);
-    expect(parsedContentExport()).toEqual({
-      tiles: [
-        { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } }
-      ]
-    });
+    expect(getAllRows(content)).toEqual([
+      { Header: "A"},
+      { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } },
+      { Header: "B"},
+      { Placeholder: "B" }
+    ]);
 
     content.moveTile(tileId, { rowInsertIndex: 3 });
-    // [Header:A, Placeholder, Header:B, Text]
-    expect(content.rowCount).toBe(4);
-    expect(isPlaceholderSection("A")).toBe(true);
-    expect(isContentSection("B")).toBe(true);
-    expect(parsedContentExport()).toEqual({
-      tiles: [
-        { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } }
-      ]
-    });
+    expect(getAllRows(content)).toEqual([
+      { Header: "A"},
+      { Placeholder: "A" },
+      { Header: "B"},
+      { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } },
+    ]);
 
     content.addTile("geometry", { title: "Shapes Graph 1", addSidecarNotes: true,
       insertRowInfo: { rowInsertIndex: 2 } });
-    // [Header:A, [Geometry, Text], Header:B, Text]
-    expect(content.rowCount).toBe(4);
-    expect(isContentSection("A", 2)).toBe(true);
-    expect(isContentSection("B")).toBe(true);
-    expect(parsedContentExport()).toEqual({
-      tiles: [
-        [
-          { title: "Shapes Graph 1", content: { type: "Geometry", objects: [] } },
-          { content: { type: "Text", format: "html", text: ["<p></p>"] } }
-        ],
-        { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } }
-      ]
-    });
+    expect(getAllRows(content)).toEqual([
+      { Header: "A"},
+      [
+        { title: "Shapes Graph 1", content: { type: "Geometry", objects: [] } },
+        { content: { type: "Text", format: "html", text: ["<p></p>"] } }
+      ],
+      { Header: "B"},
+      { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } },
+    ]);
 
     const geometryId = content.getRowByIndex(1)!.tiles[0].tileId;
     content.moveTile(geometryId, { rowDropIndex: 3, rowDropLocation: "left", rowInsertIndex: 3 });
-    // [Header:A, Text, Header:B, [Geometry, Text]]
-    expect(content.rowCount).toBe(4);
-    expect(isContentSection("A")).toBe(true);
-    expect(isContentSection("B", 2)).toBe(true);
-    expect(parsedContentExport()).toEqual({
-      tiles: [
-        { content: { type: "Text", format: "html", text: ["<p></p>"] } },
-        [
-          { title: "Shapes Graph 1", content: { type: "Geometry", objects: [] } },
-          { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } }
-        ]
-      ]
-    });
+    expect(getAllRows(content)).toEqual([
+      { Header: "A"},
+      { content: { type: "Text", format: "html", text: ["<p></p>"] } },
+      { Header: "B"},
+      [
+        { title: "Shapes Graph 1", content: { type: "Geometry", objects: [] } },
+        { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } }
+      ],
+    ]);
 
     content.moveTile(geometryId, { rowDropIndex: 1, rowDropLocation: "left", rowInsertIndex: 1 });
-    // [Header:A, [Geometry, Text], Header:B, Text]
-    expect(content.rowCount).toBe(4);
-    expect(isContentSection("A", 2)).toBe(true);
-    expect(isContentSection("B")).toBe(true);
-    expect(parsedContentExport()).toEqual({
-      tiles: [
-        [
-          { title: "Shapes Graph 1", content: { type: "Geometry", objects: [] } },
-          { content: { type: "Text", format: "html", text: ["<p></p>"] } }
-        ],
-        { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } }
-      ]
-    });
+    expect(getAllRows(content)).toEqual([
+      { Header: "A"},
+      [
+        { title: "Shapes Graph 1", content: { type: "Geometry", objects: [] } },
+        { content: { type: "Text", format: "html", text: ["<p></p>"] } }
+      ],
+      { Header: "B"},
+      { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } },
+    ]);
   });
 
   it("moveTileToRow() will move tiles within a row", () => {
-    // [Header:A, [Geometry, Text], Header:B, Text]
+    const content = createDocumentContent(
+      "[Header:A, [Geometry, Text], Header:B, Text]"
+    );
     const tileId = content.getRowByIndex(1)!.tiles[1].tileId;
     content.moveTileToRow(tileId, 1, 0);
-    // [Header:A, [Text, Geometry], Header:B, Text]
-    expect(content.rowCount).toBe(4);
-    expect(isContentSection("A", 2)).toBe(true);
-    expect(isContentSection("B")).toBe(true);
-    expect(parsedContentExport()).toEqual({
-      tiles: [
-        [
-          { content: { type: "Text", format: "html", text: ["<p></p>"] } },
-          { title: "Shapes Graph 1", content: { type: "Geometry", objects: [] } }
-        ],
-        { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } }
-      ]
-    });
+    expect(getAllRows(content)).toEqual([
+      { Header: "A"},
+      [
+        { content: { type: "Text", format: "html", text: ["<p></p>"] } },
+        { title: "Shapes Graph 1", content: { type: "Geometry", objects: [] } },
+      ],
+      { Header: "B"},
+      { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } },
+    ]);
   });
 
   it("deleteTile() will remove individual tiles from rows", () => {
-    // [Header:A, [Text, Geometry], Header:B, Text]
+    const content = createDocumentContent(
+      "[Header:A, [Text, Geometry], Header:B, Text]"
+    );
     const tileId = content.getRowByIndex(1)!.tiles[0].tileId;
     content.deleteTile(tileId);
-    // [Header:A, Geometry, Header:B, Text]
-    expect(content.rowCount).toBe(4);
-    expect(isContentSection("A")).toBe(true);
-    expect(isContentSection("B")).toBe(true);
-    expect(parsedContentExport()).toEqual({
-      tiles: [
-        { title: "Shapes Graph 1", content: { type: "Geometry", objects: [] } },
-        { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } }
-      ]
-    });
+    expect(getAllRows(content)).toEqual([
+      { Header: "A"},
+      { title: "Shapes Graph 1", content: { type: "Geometry", objects: [] } },
+      { Header: "B"},
+      { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } },
+    ]);
   });
 });
 

--- a/src/models/document/document-content-tests/dc-shared-models.test.ts
+++ b/src/models/document/document-content-tests/dc-shared-models.test.ts
@@ -130,9 +130,9 @@ describe("DocumentContentModel -- shared Models --", () => {
 Object {
   "annotations": Object {},
   "rowMap": Object {
-    "testid-12": Object {
+    "testid-6": Object {
       "height": undefined,
-      "id": "testid-12",
+      "id": "testid-6",
       "isSectionHeader": false,
       "sectionId": undefined,
       "tiles": Array [
@@ -148,7 +148,7 @@ Object {
     },
   },
   "rowOrder": Array [
-    "testid-12",
+    "testid-6",
   ],
   "sharedModelMap": Object {
     "sharedDataSet1": Object {
@@ -255,7 +255,7 @@ Object {
         "importedDataSet": Object {
           "attributes": Array [],
           "cases": Array [],
-          "id": "testid-13",
+          "id": "testid-7",
           "name": undefined,
           "sourceID": undefined,
         },
@@ -293,25 +293,25 @@ Object {
 Object {
   "annotations": Object {},
   "rowMap": Object {
-    "testid-32": Object {
+    "testid-21": Object {
       "height": undefined,
-      "id": "testid-32",
+      "id": "testid-21",
       "isSectionHeader": false,
       "sectionId": undefined,
       "tiles": Array [
         Object {
-          "tileId": "testid-31",
+          "tileId": "testid-20",
           "widthPct": undefined,
         },
       ],
     },
   },
   "rowOrder": Array [
-    "testid-32",
+    "testid-21",
   ],
   "sharedModelMap": Object {
-    "testid-28": Object {
-      "provider": "testid-31",
+    "testid-17": Object {
+      "provider": "testid-20",
       "sharedModel": Object {
         "dataSet": Object {
           "attributes": Array [
@@ -323,7 +323,7 @@ Object {
                 "display": undefined,
               },
               "hidden": false,
-              "id": "testid-29",
+              "id": "testid-18",
               "name": "x",
               "precision": undefined,
               "sourceID": undefined,
@@ -343,7 +343,7 @@ Object {
                 "display": undefined,
               },
               "hidden": false,
-              "id": "testid-30",
+              "id": "testid-19",
               "name": "y",
               "precision": undefined,
               "sourceID": undefined,
@@ -367,27 +367,27 @@ Object {
               "__id__": "caseid-2",
             },
           ],
-          "id": "testid-27",
+          "id": "testid-16",
           "name": "Demo Dataset",
           "sourceID": undefined,
         },
-        "id": "testid-28",
-        "providerId": "testid-31",
+        "id": "testid-17",
+        "providerId": "testid-20",
         "type": "SharedDataSet",
       },
       "tiles": Array [
-        "testid-31",
+        "testid-20",
       ],
     },
   },
   "tileMap": Object {
-    "testid-31": Object {
+    "testid-20": Object {
       "content": Object {
         "columnWidths": Object {},
         "importedDataSet": Object {
           "attributes": Array [],
           "cases": Array [],
-          "id": "testid-21",
+          "id": "testid-12",
           "name": undefined,
           "sourceID": undefined,
         },
@@ -395,7 +395,7 @@ Object {
         "type": "Table",
       },
       "display": undefined,
-      "id": "testid-31",
+      "id": "testid-20",
       "title": undefined,
     },
   },
@@ -422,9 +422,9 @@ Object {
 Object {
   "annotations": Object {},
   "rowMap": Object {
-    "testid-44": Object {
+    "testid-28": Object {
       "height": undefined,
-      "id": "testid-44",
+      "id": "testid-28",
       "isSectionHeader": false,
       "sectionId": undefined,
       "tiles": Array [
@@ -433,18 +433,18 @@ Object {
           "widthPct": undefined,
         },
         Object {
-          "tileId": "testid-50",
+          "tileId": "testid-34",
           "widthPct": undefined,
         },
       ],
     },
   },
   "rowOrder": Array [
-    "testid-44",
+    "testid-28",
   ],
   "sharedModelMap": Object {
-    "testid-47": Object {
-      "provider": "testid-50",
+    "testid-31": Object {
+      "provider": "testid-34",
       "sharedModel": Object {
         "dataSet": Object {
           "attributes": Array [
@@ -456,7 +456,7 @@ Object {
                 "display": undefined,
               },
               "hidden": false,
-              "id": "testid-48",
+              "id": "testid-32",
               "name": "x",
               "precision": undefined,
               "sourceID": undefined,
@@ -476,7 +476,7 @@ Object {
                 "display": undefined,
               },
               "hidden": false,
-              "id": "testid-49",
+              "id": "testid-33",
               "name": "y",
               "precision": undefined,
               "sourceID": undefined,
@@ -500,27 +500,27 @@ Object {
               "__id__": "caseid-5",
             },
           ],
-          "id": "testid-46",
+          "id": "testid-30",
           "name": "Demo Dataset",
           "sourceID": undefined,
         },
-        "id": "testid-47",
-        "providerId": "testid-50",
+        "id": "testid-31",
+        "providerId": "testid-34",
         "type": "SharedDataSet",
       },
       "tiles": Array [
-        "testid-50",
+        "testid-34",
       ],
     },
   },
   "tileMap": Object {
-    "testid-50": Object {
+    "testid-34": Object {
       "content": Object {
         "columnWidths": Object {},
         "importedDataSet": Object {
           "attributes": Array [],
           "cases": Array [],
-          "id": "testid-38",
+          "id": "testid-24",
           "name": undefined,
           "sourceID": undefined,
         },
@@ -528,7 +528,7 @@ Object {
         "type": "Table",
       },
       "display": undefined,
-      "id": "testid-50",
+      "id": "testid-34",
       "title": undefined,
     },
     "textTool": Object {
@@ -562,29 +562,29 @@ Object {
 Object {
   "annotations": Object {},
   "rowMap": Object {
-    "testid-69": Object {
+    "testid-48": Object {
       "height": undefined,
-      "id": "testid-69",
+      "id": "testid-48",
       "isSectionHeader": false,
       "sectionId": undefined,
       "tiles": Array [
         Object {
-          "tileId": "testid-67",
+          "tileId": "testid-46",
           "widthPct": undefined,
         },
         Object {
-          "tileId": "testid-68",
+          "tileId": "testid-47",
           "widthPct": undefined,
         },
       ],
     },
   },
   "rowOrder": Array [
-    "testid-69",
+    "testid-48",
   ],
   "sharedModelMap": Object {
-    "testid-64": Object {
-      "provider": "testid-67",
+    "testid-43": Object {
+      "provider": "testid-46",
       "sharedModel": Object {
         "dataSet": Object {
           "attributes": Array [
@@ -596,7 +596,7 @@ Object {
                 "display": undefined,
               },
               "hidden": false,
-              "id": "testid-65",
+              "id": "testid-44",
               "name": "x",
               "precision": undefined,
               "sourceID": undefined,
@@ -616,7 +616,7 @@ Object {
                 "display": undefined,
               },
               "hidden": false,
-              "id": "testid-66",
+              "id": "testid-45",
               "name": "y",
               "precision": undefined,
               "sourceID": undefined,
@@ -640,28 +640,28 @@ Object {
               "__id__": "caseid-8",
             },
           ],
-          "id": "testid-63",
+          "id": "testid-42",
           "name": "Demo Dataset",
           "sourceID": undefined,
         },
-        "id": "testid-64",
-        "providerId": "testid-67",
+        "id": "testid-43",
+        "providerId": "testid-46",
         "type": "SharedDataSet",
       },
       "tiles": Array [
-        "testid-67",
-        "testid-68",
+        "testid-46",
+        "testid-47",
       ],
     },
   },
   "tileMap": Object {
-    "testid-67": Object {
+    "testid-46": Object {
       "content": Object {
         "columnWidths": Object {},
         "importedDataSet": Object {
           "attributes": Array [],
           "cases": Array [],
-          "id": "testid-56",
+          "id": "testid-37",
           "name": undefined,
           "sourceID": undefined,
         },
@@ -669,10 +669,10 @@ Object {
         "type": "Table",
       },
       "display": undefined,
-      "id": "testid-67",
+      "id": "testid-46",
       "title": undefined,
     },
-    "testid-68": Object {
+    "testid-47": Object {
       "content": Object {
         "bgImage": undefined,
         "board": Object {
@@ -695,7 +695,7 @@ Object {
         "type": "Geometry",
       },
       "display": undefined,
-      "id": "testid-68",
+      "id": "testid-47",
       "title": undefined,
     },
   },

--- a/src/models/document/document-content-with-annotations.ts
+++ b/src/models/document/document-content-with-annotations.ts
@@ -1,7 +1,7 @@
 import { types } from "mobx-state-tree";
 
 import { BaseDocumentContentModel } from "./base-document-content";
-import { ArrowAnnotation, IArrowAnnotation, IArrowAnnotationSnapshot } from "../annotations/arrow-annotation";
+import { ArrowAnnotation, IArrowAnnotation } from "../annotations/arrow-annotation";
 import { logSparrowCreate, logSparrowDelete } from "../tiles/log/log-sparrow-event";
 import { LogEventName } from "../../../src/lib/logger-types";
 
@@ -46,11 +46,6 @@ export const DocumentContentModelWithAnnotations = BaseDocumentContentModel
     deleteAnnotation(annotationId: string) {
       self.annotations.delete(annotationId);
       logSparrowDelete(LogEventName.SPARROW_DELETION, annotationId);
-    },
-    addAnnotationFromImport(id: string, annotation: IArrowAnnotationSnapshot){
-      if (self.annotations) {
-        self.annotations.set(id, annotation);
-      }
     },
     selectAnnotations(ids: string[]) {
       for (const annotation of self.annotations.values()) {

--- a/src/models/document/drag-tiles.test.ts
+++ b/src/models/document/drag-tiles.test.ts
@@ -180,7 +180,7 @@ Array [
   Object {
     "rowHeight": undefined,
     "rowIndex": 2,
-    "tileContent": "{\\"id\\":\\"testid-1000\\",\\"content\\":{\\"type\\":\\"Table\\",\\"isImported\\":false,\\"importedDataSet\\":{\\"id\\":\\"testid-9\\",\\"attributes\\":[],\\"cases\\":[]},\\"columnWidths\\":{}}}",
+    "tileContent": "{\\"id\\":\\"testid-1000\\",\\"content\\":{\\"type\\":\\"Table\\",\\"isImported\\":false,\\"importedDataSet\\":{\\"id\\":\\"testid-6\\",\\"attributes\\":[],\\"cases\\":[]},\\"columnWidths\\":{}}}",
     "tileId": "tile3",
     "tileIndex": 0,
     "tileType": "Table",
@@ -201,7 +201,7 @@ Array [
 Object {
   "annotations": Array [],
   "sharedModels": Array [],
-  "sourceDocId": "testid-10",
+  "sourceDocId": "testid-7",
   "tiles": Array [
     Object {
       "rowHeight": undefined,
@@ -226,7 +226,7 @@ Object {
 Object {
   "annotations": Array [],
   "sharedModels": Array [],
-  "sourceDocId": "testid-10",
+  "sourceDocId": "testid-7",
   "tiles": Array [
     Object {
       "rowHeight": undefined,
@@ -269,12 +269,12 @@ Object {
       ],
     },
   ],
-  "sourceDocId": "testid-10",
+  "sourceDocId": "testid-7",
   "tiles": Array [
     Object {
       "rowHeight": undefined,
       "rowIndex": 2,
-      "tileContent": "{\\"id\\":\\"testid-1000\\",\\"content\\":{\\"type\\":\\"Table\\",\\"isImported\\":false,\\"importedDataSet\\":{\\"id\\":\\"testid-9\\",\\"attributes\\":[],\\"cases\\":[]},\\"columnWidths\\":{}}}",
+      "tileContent": "{\\"id\\":\\"testid-1000\\",\\"content\\":{\\"type\\":\\"Table\\",\\"isImported\\":false,\\"importedDataSet\\":{\\"id\\":\\"testid-6\\",\\"attributes\\":[],\\"cases\\":[]},\\"columnWidths\\":{}}}",
       "tileId": "tile3",
       "tileIndex": 0,
       "tileType": "Table",

--- a/src/models/document/tile-row.ts
+++ b/src/models/document/tile-row.ts
@@ -27,6 +27,7 @@ export const TileLayoutModel = types
     }
   }));
 export type TileLayoutModelType = Instance<typeof TileLayoutModel>;
+export type TileLayoutSnapshotType = SnapshotIn<typeof TileLayoutModel>;
 
 export const TileRowModel = types
   .model("TileRow", {


### PR DESCRIPTION
- This changes the loading to manipulate the snapshot instead of a temporary MST document
- It also updates the general document loading to run `typecheck` if there is an error while
loading the document. This results in better error messages when the document is corrupt.
- It updates the dc-general.test.ts to check the structure of the document using a
representation of all of the rows of the document instead of a collection of methods.

A side effect of the loading change is that fewer ids are created, so the tests which compare
snapshots with ids had to be updated.