### PR TITLE
convert null to NaN in the graph Point model

### DIFF
--- a/src/models/mst.test.ts
+++ b/src/models/mst.test.ts
@@ -958,7 +958,7 @@ describe("mst", () => {
     let valueReturnedByPreProcess: any;
     const TestObject = types
       .model("TestObject", {
-        prop: types.optional(types.string, "default")
+        prop: types.string
       })
       .preProcessSnapshot(snapshot => {
         snapshotPassedToPreProcess = snapshot;
@@ -979,10 +979,46 @@ describe("mst", () => {
 
     valueReturnedByPreProcess = {};
     const container2 = TestContainer.create({});
+    expect(container2.child).toBeUndefined();
+
+    valueReturnedByPreProcess = {prop: "value"};
+    const container3 = TestContainer.create({});
+    expect(container3.child?.prop).toBe("value");
+  });
+
+  test("preProcessSnapshot with and optional prop can also return `{}` to respect `types.maybe`", () => {
+    let snapshotPassedToPreProcess = "Initial Value" as any;
+    let valueReturnedByPreProcess: any;
+    const TestObject = types
+      .model("TestObject", {
+        // This is different than the case above because this prop is optional
+        prop: types.optional(types.string, "default")
+      })
+      .preProcessSnapshot(snapshot => {
+        snapshotPassedToPreProcess = snapshot;
+        return valueReturnedByPreProcess;
+      });
+
+    const TestContainer = types.
+      model("TestContainer", {
+        child: types.maybe(TestObject)
+      });
+
+    valueReturnedByPreProcess = undefined;
+    const container1 = TestContainer.create({});
+    expect(snapshotPassedToPreProcess).toBeUndefined();
+    expect(container1.child).toBeUndefined();
+
+    // This is different than the case above returning `{}` results in
+    // an child object instead of undefined
+    valueReturnedByPreProcess = {};
+    const container2 = TestContainer.create({});
     expect(container2.child?.prop).toBe("default");
 
     valueReturnedByPreProcess = {prop: "value"};
     const container3 = TestContainer.create({});
     expect(container3.child?.prop).toBe("value");
   });
+
+
 });

--- a/src/models/mst.test.ts
+++ b/src/models/mst.test.ts
@@ -986,7 +986,7 @@ describe("mst", () => {
     expect(container3.child?.prop).toBe("value");
   });
 
-  test("preProcessSnapshot with and optional prop can also return `{}` to respect `types.maybe`", () => {
+  test("preProcessSnapshot with an optional prop can also return `{}` to respect `types.maybe`", () => {
     let snapshotPassedToPreProcess = "Initial Value" as any;
     let valueReturnedByPreProcess: any;
     const TestObject = types
@@ -1009,8 +1009,8 @@ describe("mst", () => {
     expect(snapshotPassedToPreProcess).toBeUndefined();
     expect(container1.child).toBeUndefined();
 
-    // This is different than the case above returning `{}` results in
-    // an child object instead of undefined
+    // This is different than the case above. Returning `{}` results in
+    // a child object instead of undefined.
     valueReturnedByPreProcess = {};
     const container2 = TestContainer.create({});
     expect(container2.child?.prop).toBe("default");

--- a/src/plugins/graph/adornments/adornment-models.test.ts
+++ b/src/plugins/graph/adornments/adornment-models.test.ts
@@ -26,6 +26,14 @@ describe("PointModel", () => {
     expect(point.x).toBe(2);
     expect(point.y).toBe(2);
   });
+  it("can be created without values and reloaded", () => {
+    const point = PointModel.create({});
+    const pointSnapshot = getSnapshot(point);
+    const pointString = JSON.stringify(pointSnapshot);
+    const reloadedPoint = PointModel.create(JSON.parse(pointString));
+    const reloadedPointSnapshot = getSnapshot(reloadedPoint);
+    expect(reloadedPointSnapshot).toEqual(pointSnapshot);
+  });
 });
 
 describe("AdornmentModel", () => {

--- a/src/plugins/graph/adornments/adornment-models.ts
+++ b/src/plugins/graph/adornments/adornment-models.ts
@@ -24,7 +24,24 @@ export const PointModel = types.model("Point", {
         self.y = aPt.y;
       }
     }
-  }));
+  }))
+  .preProcessSnapshot(snapshot => {
+    // Sometimes the snapshot is undefined. And in this case it is necessary
+    // to return undefined. This happens when the Point model is referenced
+    // by `prop: types.maybe(PointModel)`.
+    // However, the MST type system isn't happy with returning undefined,
+    // so we cast it to any to bypass the types.
+    if (snapshot == null) return undefined as any;
+
+    // When NaN is written out to JSON it will be converted to null,
+    // So we need to convert it back to NaN. It would be better to avoid using
+    // NaN in MST models, or use a primitive type other than the default
+    // `types.number` which can handle NaN correctly.
+    return {
+      x: snapshot.x == null ? NaN : snapshot.x,
+      y: snapshot.y == null ? NaN : snapshot.y
+    };
+  });
 export interface IPointModel extends Instance<typeof PointModel> {}
 export const kInfinitePoint = {x:NaN, y:NaN};
 


### PR DESCRIPTION
In the process of this change I also found that preProcessSnapshot has some nuance on how it works.
When `prop: types.maybe(Model)` is used, then it undefined is passed to preProcessSnapshot.
To respect the `types.maybe`, preProcessSnapshot has to return undefined.