### PR TITLE
Cypress updates

### DIFF
--- a/.github/workflows/ci-regression.yml
+++ b/.github/workflows/ci-regression.yml
@@ -45,7 +45,10 @@ jobs:
     # If we run out cypress test runs then we temporarily expand the timeout to 4hrs until cypress cloud is available
     # again
     # timeout-minutes: 240
-    container: cypress/browsers:node-20.11.0-chrome-121.0.6167.184-1-ff-123.0-edge-121.0.2277.128-1
+    container:
+      image: cypress/browsers:node-20.11.0-chrome-121.0.6167.184-1-ff-123.0-edge-121.0.2277.128-1
+      # This is needed so the commit info can be recorded by cypress
+      options: --user 1001
     strategy:
       # when one test fails, DO NOT cancel the other
       # containers, because this will kill Cypress processes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,10 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
   cypress:
     runs-on: ubuntu-latest
-    container: cypress/browsers:node-20.11.0-chrome-121.0.6167.184-1-ff-123.0-edge-121.0.2277.128-1
+    container:
+      image: cypress/browsers:node-20.11.0-chrome-121.0.6167.184-1-ff-123.0-edge-121.0.2277.128-1
+      # This is needed so the commit info can be recorded by cypress
+      options: --user 1001
     strategy:
       # when one test fails, DO NOT cancel the other
       # containers, because this will kill Cypress processes

--- a/.github/workflows/manual-regression.yml
+++ b/.github/workflows/manual-regression.yml
@@ -62,7 +62,10 @@ on:
 jobs:
   all-tests:
     runs-on: ubuntu-latest
-    container: cypress/browsers:node-20.11.0-chrome-121.0.6167.184-1-ff-123.0-edge-121.0.2277.128-1
+    container:
+      image: cypress/browsers:node-20.11.0-chrome-121.0.6167.184-1-ff-123.0-edge-121.0.2277.128-1
+      # This is needed so the commit info can be recorded by cypress
+      options: --user 1001
     if: ${{ github.event.inputs.test == 'all' }}
     strategy:
       # when one test fails, DO NOT cancel the other

--- a/.github/workflows/regression-daily.yml
+++ b/.github/workflows/regression-daily.yml
@@ -6,7 +6,10 @@ on:
 jobs:
   all-tests:
     runs-on: ubuntu-latest
-    container: cypress/browsers:node-20.11.0-chrome-121.0.6167.184-1-ff-123.0-edge-121.0.2277.128-1
+    container:
+      image: cypress/browsers:node-20.11.0-chrome-121.0.6167.184-1-ff-123.0-edge-121.0.2277.128-1
+      # This is needed so the commit info can be recorded by cypress
+      options: --user 1001
     strategy:
       # when one test fails, DO NOT cancel the other
       # containers, because this will kill Cypress processes

--- a/cypress/e2e/functional/teacher_tests/teacher_sort_work_view_spec.js
+++ b/cypress/e2e/functional/teacher_tests/teacher_sort_work_view_spec.js
@@ -66,6 +66,9 @@ describe('SortWorkView Tests', () => {
 
 
   it("should open Sort Work tab and test sorting by group", () => {
+    // Clear data before the test so it can be retried and will start with a clean slate
+    cy.clearQAData('all');
+
     const students = ["student:1", "student:2", "student:3", "student:4"];
     const studentProblemDocs = [
       `Student 1: ${title}`,

--- a/cypress/support/elements/common/cHeader.js
+++ b/cypress/support/elements/common/cHeader.js
@@ -10,11 +10,14 @@ class ClueHeader{
     getGroupMembers(){
         return cy.get('[data-test=group-members]');
     }
-    
+
     leaveGroup(){
         this.getGroupName().click();
         dialog.getDialogTitle().should('contain', 'Leave Group');
         dialog.getDialogOKButton().click();
+
+        // Wait a little bit to make sure this group change makes it to the database
+        cy.wait(500);
     }
 
     cancelLeaveGroup(){

--- a/dependencies-notes.md
+++ b/dependencies-notes.md
@@ -12,9 +12,6 @@ Notes on dependencies, particularly reasons for not updating to their latest ver
 |@types/react-dom            |17.0.17        |18.0.6        |React 18                                                                     |
 |@types/react-tabs           |2.3.4          |5.0.5         |Versions 3 and 4 were never published(?); Version 5 requires React 18        |
 |@types/slate-react          |0.22.9         |0.50.1        |Requires slate-editor library update to latest slate                         |
-|cypress                     |9.7.0          |10.6.0        |Cypress 10 requires non-trivial migration.                                   |
-|cypress-commands            |2.0.1          |3.0.0         |Cypress 10                                                                   |
-|cypress-terminal-report     |3.5.2          |4.1.2         |Cypress 10                                                                   |
 
 ## Runtime Dependencies
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -124,7 +124,7 @@
         "cross-env": "^7.0.3",
         "css-loader": "^6.7.1",
         "cypress": "^13.5.0",
-        "cypress-commands": "2.0.1",
+        "cypress-commands": "3.0.0",
         "cypress-file-upload": "^5.0.8",
         "cypress-terminal-report": "^4.1.2",
         "enquirer": "^2.3.6",
@@ -9642,9 +9642,10 @@
       }
     },
     "node_modules/cypress-commands": {
-      "version": "2.0.1",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cypress-commands/-/cypress-commands-3.0.0.tgz",
+      "integrity": "sha512-f0m6tmsT596AnMH2Wa5h3wClsYkCEEAHp7BnFEGtxB+Pl0aiko9z6qAvY1FL3/X+jXEiGVgGmKnXEPeTnUzKdw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "path-browserify": "^1.0.1"
       }
@@ -29595,7 +29596,9 @@
       }
     },
     "cypress-commands": {
-      "version": "2.0.1",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cypress-commands/-/cypress-commands-3.0.0.tgz",
+      "integrity": "sha512-f0m6tmsT596AnMH2Wa5h3wClsYkCEEAHp7BnFEGtxB+Pl0aiko9z6qAvY1FL3/X+jXEiGVgGmKnXEPeTnUzKdw==",
       "dev": true,
       "requires": {
         "path-browserify": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "cross-env": "^7.0.3",
     "css-loader": "^6.7.1",
     "cypress": "^13.5.0",
-    "cypress-commands": "2.0.1",
+    "cypress-commands": "3.0.0",
     "cypress-file-upload": "^5.0.8",
     "cypress-terminal-report": "^4.1.2",
     "enquirer": "^2.3.6",


### PR DESCRIPTION
This has two changes:

1. This is to fix this failure that has happened a few times now:
https://github.com/concord-consortium/collaborative-learning/actions/runs/9720002467/job/26830753417
The fix is to make the test retry-able by clearing the data at the beginning of the test, and also add a short delay to give more time for firebase to store the change of the group. 

2. add the user arg to all of the other containers used in the cypress github jobs. This arg was added to one a little while ago, but I forgot to add it to all of them.
