### PR TITLE
fix: Issue with combining  data card stacks via drag and drop (PT-187848992)

### DIFF
--- a/cypress/e2e/functional/tile_tests/datacard_merge_spec.js
+++ b/cypress/e2e/functional/tile_tests/datacard_merge_spec.js
@@ -1,26 +1,14 @@
 import ClueCanvas from '../../../support/elements/common/cCanvas';
-import Canvas from '../../../support/elements/common/Canvas';
 import DataCardToolTile from '../../../support/elements/tile/DataCardToolTile';
 
 let clueCanvas = new ClueCanvas;
 let dc = new DataCardToolTile;
-let canvas = new Canvas;
-let studentWorkspace = 'SAS 1.1 Solving a Mystery with Proportional Reasoning';
-const dataTransfer = new DataTransfer;
 
 function beforeTest() {
   const queryParams = `${Cypress.config("qaUnitStudent5")}`;
   cy.clearQAData('all');
   cy.visit(queryParams);
   cy.waitForLoad();
-}
-
-function openMyWork() {
-  cy.wait(2000);
-  clueCanvas.getInvestigationCanvasTitle().text().then((investigationTitle) => {
-    cy.openTopTab('my-work');
-    cy.openDocumentThumbnail('my-work', 'workspaces', investigationTitle);
-  });
 }
 
 context('Merge Data Card Tool Tile', function () {
@@ -64,12 +52,9 @@ context('Merge Data Card Tool Tile', function () {
     dc.getTile(1).should("exist");
     dc.getTileTitle(1).should("have.text", "Card Deck Data 2");
 
-    dc.getTile(0).find(".data-card-tool")
-      .trigger('dragstart', { dataTransfer }).then(() => {
-        dc.getTile(1).find(".data-card-tool .data-card-header-row")
-          .trigger('drop', { dataTransfer, force: true })
-          .trigger('dragend', { dataTransfer, force: true });
-      });
+    dc.getMergeDataButton(1).click();
+    dc.getMergeDataModalSelect().select("Card Deck Data 1");
+    dc.getMergeDataModalAddDataButton().click();
 
     dc.getAttrs(0).should("have.length", 1);
     dc.getCardNofTotalListing(0).should("have.text", "Card 1 of 1");
@@ -98,12 +83,9 @@ context('Merge Data Card Tool Tile', function () {
     dc.getTile(1).should("exist");
     dc.getTileTitle(1).should("have.text", "Card Deck Data 2");
 
-    dc.getTile(0).find(".data-card-tool")
-      .trigger('dragstart', { dataTransfer }).then(() => {
-        dc.getTile(1).find(".data-card-tool .data-card-header-row")
-          .trigger('drop', { dataTransfer, force: true })
-          .trigger('dragend', { dataTransfer, force: true });
-      });
+    dc.getMergeDataButton(1).click();
+    dc.getMergeDataModalSelect().select("Card Deck Data 1");
+    dc.getMergeDataModalAddDataButton().click();
 
     dc.getAttrs(0).should("have.length", 1);
     dc.getCardNofTotalListing(0).should("have.text", "Card 1 of 1");
@@ -140,12 +122,9 @@ context('Merge Data Card Tool Tile', function () {
     dc.getAttrName(1).contains("Attr1 Name");
     dc.getAttrValue(1).click().type("Attr1 Value{enter}");
 
-    dc.getTile(0).find(".data-card-tool")
-      .trigger('dragstart', { dataTransfer }).then(() => {
-        dc.getTile(1).find(".data-card-tool .data-card-header-row")
-          .trigger('drop', { dataTransfer, force: true })
-          .trigger('dragend', { dataTransfer, force: true });
-      });
+    dc.getMergeDataButton(1).click();
+    dc.getMergeDataModalSelect().select("Card Deck Data 1");
+    dc.getMergeDataModalAddDataButton().click();
 
     dc.getAttrs(0).should("have.length", 1);
     dc.getCardNofTotalListing(0).should("have.text", "Card 1 of 1");
@@ -186,12 +165,9 @@ context('Merge Data Card Tool Tile', function () {
     dc.getAttrName(1).contains("Attr2 Name");
     dc.getAttrValue(1).click().type("Attr2 Value{enter}");
 
-    dc.getTile(0).find(".data-card-tool")
-      .trigger('dragstart', { dataTransfer }).then(() => {
-        dc.getTile(1).find(".data-card-tool .data-card-header-row")
-          .trigger('drop', { dataTransfer, force: true })
-          .trigger('dragend', { dataTransfer, force: true });
-      });
+    dc.getMergeDataButton(1).click();
+    dc.getMergeDataModalSelect().select("Card Deck Data 1");
+    dc.getMergeDataModalAddDataButton().click();
 
     dc.getAttrs(0).should("have.length", 1);
     dc.getCardNofTotalListing(0).should("have.text", "Card 1 of 1");
@@ -232,12 +208,9 @@ context('Merge Data Card Tool Tile', function () {
     dc.getAttrName(1).contains("Attr1 Name");
     dc.getAttrValue(1).click().type("Attr2 Value{enter}");
 
-    dc.getTile(0).find(".data-card-tool")
-      .trigger('dragstart', { dataTransfer }).then(() => {
-        dc.getTile(1).find(".data-card-tool .data-card-header-row")
-          .trigger('drop', { dataTransfer, force: true })
-          .trigger('dragend', { dataTransfer, force: true });
-      });
+    dc.getMergeDataButton(1).click();
+    dc.getMergeDataModalSelect().select("Card Deck Data 1");
+    dc.getMergeDataModalAddDataButton().click();
 
     dc.getAttrs(1).should("have.length", 1);
     dc.getCardNofTotalListing(1).should("have.text", "Card 1 of 2");
@@ -275,12 +248,9 @@ context('Merge Data Card Tool Tile', function () {
     dc.getSortSelect(1).select("Attr2 Name");
     dc.getSortView(1).should('exist');
 
-    dc.getTile(0).find(".data-card-tool")
-      .trigger('dragstart', { dataTransfer }).then(() => {
-        dc.getTile(1).find(".data-card-tool .data-card-header-row")
-          .trigger('drop', { dataTransfer, force: true })
-          .trigger('dragend', { dataTransfer, force: true });
-      });
+    dc.getMergeDataButton(1).click();
+    dc.getMergeDataModalSelect().select("Card Deck Data 1");
+    dc.getMergeDataModalAddDataButton().click();
 
     dc.getSortSelect(1).select("None");
     dc.getSingleCardView(1).should('exist');
@@ -300,53 +270,5 @@ context('Merge Data Card Tool Tile', function () {
     dc.getAttrValue(1).eq(1).invoke("val").should("contain", "Attr1 Value");
     dc.getPreviousCardButton(1).click();
     dc.getCardNofTotalListing(1).should("have.text", "Card 1 of 2");
-  });
-
-  it("merge Data card tool tile across documents", () => {
-    beforeTest();
-    openMyWork();
-    clueCanvas.addTile("datacard");
-    dc.getTile(0).should("exist");
-    dc.getTileTitle(0).should("have.text", "Card Deck Data 1");
-
-    dc.getAttrName(0).dblclick().type("Attr1 Name{enter}");
-    dc.getAttrName(0).contains("Attr1 Name");
-    dc.getAttrValue(0).click().type("Attr1 Value{enter}");
-
-    cy.log("opens document in main doc on the left");
-    canvas.createNewExtraDocumentFromFileMenu(studentWorkspace, "my-work");
-
-    cy.log("creates a Data Card tool tile in new personal workspace");
-    clueCanvas.addTile("datacard");
-    dc.getTile(0).should("exist");
-    dc.getTileTitle(0).should("have.text", "Card Deck Data 1");
-
-    dc.getAttrName(0).dblclick().type("Attr2 Name{enter}");
-    dc.getAttrName(0).contains("Attr2 Name");
-    dc.getAttrValue(0).click().type("Attr2 Value{enter}");
-
-    cy.log("merge Data card tool tile from left to right");
-    dc.getTile(0, "[data-test=\"subtab-workspaces\"] .editable-document-content").find(".data-card-tool")
-      .trigger('dragstart', { dataTransfer }).then(() => {
-        dc.getTile(0).find(".data-card-tool .data-card-header-row")
-          .trigger('drop', { dataTransfer, force: true })
-          .trigger('dragend', { dataTransfer, force: true });
-      });
-
-    dc.getAttrs(0).should("have.length", 2);
-    dc.getCardNofTotalListing(0).should("have.text", "Card 1 of 2");
-    dc.getAttrName(0).eq(0).should("have.text", "Attr2 Name");
-    dc.getAttrValue(0).eq(0).invoke("val").should("contain", "Attr2 Value");
-    dc.getAttrName(0).eq(1).should("have.text", "Attr1 Name");
-    dc.getAttrValue(0).eq(1).invoke("val").should("be.empty");
-    dc.getNextCardButton(0).click();
-    dc.getCardNofTotalListing(0).should("have.text", "Card 2 of 2");
-    dc.getAttrs(0).should("have.length", 2);
-    dc.getAttrName(0).eq(0).should("have.text", "Attr2 Name");
-    dc.getAttrValue(0).eq(0).invoke("val").should("be.empty");
-    dc.getAttrName(0).eq(1).should("have.text", "Attr1 Name");
-    dc.getAttrValue(0).eq(1).invoke("val").should("contain", "Attr1 Value");
-    dc.getPreviousCardButton(0).click();
-    dc.getCardNofTotalListing(0).should("have.text", "Card 1 of 2");
   });
 });


### PR DESCRIPTION
[#187848992](https://www.pivotaltracker.com/story/show/187848992)

We determined that simply dropping the drag-to-merge data cards feature was the solution for this. These changes:

- Remove all code related to dragging and dropping data cards into one another
- Update the data card tests to use the "Add Data from..." button instead of dragging to merge data cards. Note that the ability to drag-to-merge a data card from another document will be lost, so I removed the test related to that. (Students will still be able to drag a data card into their document from another document, and then merge it with other data cards by using the "Add Data from..." button.)