### PR TITLE
No sidecar tile for geometry

### DIFF
--- a/cypress/e2e/functional/document_tests/canvas_test_spec.js
+++ b/cypress/e2e/functional/document_tests/canvas_test_spec.js
@@ -290,7 +290,6 @@ context('Test Canvas', function () {
     clueCanvas.deleteTile('draw');
     clueCanvas.deleteTile('table');
     clueCanvas.deleteTile('text');
-    clueCanvas.deleteTile('text');
     textToolTile.getTextTile().should('not.exist');
     geometryToolTile.getGeometryTile().should('not.exist');
     drawToolTile.getDrawTile().should('not.exist');

--- a/cypress/e2e/functional/document_tests/copy_doc_test_spec.js
+++ b/cypress/e2e/functional/document_tests/copy_doc_test_spec.js
@@ -53,8 +53,6 @@ context('Copy Document', () => {
 
     cy.log('Add geometry tile');
     clueCanvas.addTile('geometry');
-    cy.get('.spacer').click();
-    textTile.deleteTextTile();
     geometryTile.getGeometryTile().last().click();
     clueCanvas.clickToolbarButton('geometry', 'point');
     geometryTile.addPointToGraph(5, 5);

--- a/cypress/e2e/functional/document_tests/student_teacher_4up_readonly_spec.js
+++ b/cypress/e2e/functional/document_tests/student_teacher_4up_readonly_spec.js
@@ -81,7 +81,6 @@ function setupTest(studentIndex) {
   });
   clueCanvas.addTile('geometry');
   cy.get('.spacer').click();
-  textToolTile.deleteTextTile();
   geometryToolTile.getGeometryTile().last().click();
   clueCanvas.clickToolbarButton('geometry', 'point');
   geometryToolTile.addPointToGraph(5, 5);

--- a/cypress/e2e/functional/document_tests/tiles_copy_test_spec.js
+++ b/cypress/e2e/functional/document_tests/tiles_copy_test_spec.js
@@ -1,5 +1,4 @@
 import ClueCanvas from '../../../support/elements/common/cCanvas';
-import TextToolTile from '../../../support/elements/tile/TextToolTile';
 import Canvas from '../../../support/elements/common/Canvas';
 import TableToolTile from '../../../support/elements/tile/TableToolTile';
 import GeometryToolTile from '../../../support/elements/tile/GeometryToolTile';
@@ -15,7 +14,6 @@ const student5 = `${Cypress.config("qaUnitStudent5")}`;
 const student6 = `${Cypress.config("qaUnitStudent6")}`;
 
 let clueCanvas = new ClueCanvas,
-  textToolTile = new TextToolTile,
   tableToolTile = new TableToolTile,
   geometryToolTile = new GeometryToolTile,
   drawToolTile = new DrawToolTile,
@@ -139,7 +137,6 @@ context('Test copy tiles from one document to other document', function () {
     cy.log('Add graph tile');
     clueCanvas.addTile('geometry');
     cy.get('.spacer').click();
-    textToolTile.deleteTextTile();
     geometryToolTile.getGeometryTile().last().click();
     clueCanvas.clickToolbarButton('geometry', 'point');
     geometryToolTile.addPointToGraph(5, 5);

--- a/cypress/e2e/functional/tile_tests/geometry_table_integraton_test_spec.js
+++ b/cypress/e2e/functional/tile_tests/geometry_table_integraton_test_spec.js
@@ -3,14 +3,12 @@ import Canvas from '../../../support/elements/common/Canvas';
 import ClueCanvas from '../../../support/elements/common/cCanvas';
 import GeometryToolTile from '../../../support/elements/tile/GeometryToolTile';
 import TableToolTile from '../../../support/elements/tile/TableToolTile';
-import TextToolTile from '../../../support/elements/tile/TextToolTile';
 
 let resourcesPanel = new ResourcesPanel;
 const canvas = new Canvas;
 const clueCanvas = new ClueCanvas;
 const geometryToolTile = new GeometryToolTile;
 const tableToolTile = new TableToolTile;
-const textToolTile = new TextToolTile;
 
 const x = ['3', '7', '6', '0'];
 const y = ['2.5', '5', '1', '0'];
@@ -40,7 +38,6 @@ context('Geometry Table Integration', function () {
       tableToolTile.getTableCell().eq(17).click();
     });
     clueCanvas.addTile('geometry');
-    textToolTile.deleteTextTile();
 
     cy.log('verify correct geometry tile names appear in selection list');
     tableToolTile.getTableTile().click();
@@ -185,7 +182,6 @@ context('Geometry Table Integration', function () {
       tableToolTile.getTableCell().eq(9).click();
     });
     clueCanvas.addTile('geometry');
-    textToolTile.deleteTextTile();
     cy.linkTableToTile('Table Data 1', "Shapes Graph 1");
 
     // Open the document on the left, then create a new document on the right

--- a/cypress/e2e/functional/tile_tests/geometry_tool_spec.js
+++ b/cypress/e2e/functional/tile_tests/geometry_tool_spec.js
@@ -3,14 +3,12 @@ import ClueCanvas from '../../../support/elements/common/cCanvas';
 import PrimaryWorkspace from '../../../support/elements/common/PrimaryWorkspace';
 import ResourcePanel from '../../../support/elements/common/ResourcesPanel';
 import GeometryToolTile from '../../../support/elements/tile/GeometryToolTile';
-import TextToolTile from '../../../support/elements/tile/TextToolTile';
 
 const canvas = new Canvas;
 const clueCanvas = new ClueCanvas;
 const geometryToolTile = new GeometryToolTile;
 const primaryWorkspace = new PrimaryWorkspace;
 const resourcePanel = new ResourcePanel;
-const textToolTile = new TextToolTile;
 
 const problemDoc = 'QA 1.1 Solving a Mystery with Proportional Reasoning';
 const ptsDoc = 'Points';
@@ -37,7 +35,6 @@ context('Geometry Tool', function () {
     canvas.createNewExtraDocumentFromFileMenu(ptsDoc, "my-work");
     clueCanvas.addTile('geometry');
     cy.get('.spacer').click();
-    textToolTile.deleteTextTile();
     geometryToolTile.getGeometryTile().last().click();
     clueCanvas.clickToolbarButton('geometry', 'point');
     geometryToolTile.addPointToGraph(5, 5);
@@ -220,29 +217,23 @@ context('Geometry Tool', function () {
     // Creation - Undo/Redo
     clueCanvas.addTile('geometry');
     geometryToolTile.getGraph().should("exist");
-    textToolTile.getTextTile().should("exist");
     clueCanvas.getUndoTool().should("not.have.class", "disabled");
     clueCanvas.getRedoTool().should("have.class", "disabled");
     clueCanvas.getUndoTool().click();
     geometryToolTile.getGraph().should("not.exist");
-    textToolTile.getTextTile().should("not.exist");
     clueCanvas.getUndoTool().should("have.class", "disabled");
     clueCanvas.getRedoTool().should("not.have.class", "disabled");
     clueCanvas.getRedoTool().click();
     geometryToolTile.getGraph().should("exist");
-    textToolTile.getTextTile().should("exist");
     clueCanvas.getUndoTool().should("not.have.class", "disabled");
     clueCanvas.getRedoTool().should("have.class", "disabled");
     // Deletion - Undo/Redo
     clueCanvas.deleteTile('geometry');
     geometryToolTile.getGraph().should("not.exist");
-    textToolTile.getTextTile().should("exist");
     clueCanvas.getUndoTool().click();
     geometryToolTile.getGraph().should("exist");
-    textToolTile.getTextTile().should("exist");
     clueCanvas.getRedoTool().click();
     geometryToolTile.getGraph().should("not.exist");
-    textToolTile.getTextTile().should("exist");
     clueCanvas.getUndoTool().click();
 
     cy.log("edit tile title");
@@ -261,6 +252,5 @@ context('Geometry Tool', function () {
     cy.log("verify delete geometry");
     clueCanvas.deleteTile('geometry');
     geometryToolTile.getGraph().should("not.exist");
-    textToolTile.getTextTile().should("exist");
   });
 });

--- a/src/components/document/document-content.tsx
+++ b/src/components/document/document-content.tsx
@@ -419,10 +419,7 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
 
     const { toolId, title } = createTileInfo;
     const insertRowInfo = this.getDropRowInfo(e);
-    const isInsertingInExistingRow = insertRowInfo?.rowDropLocation &&
-                                      (["left", "right"].indexOf(insertRowInfo.rowDropLocation) >= 0);
-    const addSidecarNotes = (toolId.toLowerCase() === "geometry") && !isInsertingInExistingRow;
-    const rowTile = content.userAddTile(toolId, {title, addSidecarNotes, insertRowInfo});
+    const rowTile = content.userAddTile(toolId, {title, insertRowInfo});
 
     if (rowTile?.tileId) {
       ui.setSelectedTileId(rowTile.tileId);

--- a/src/components/toolbar.tsx
+++ b/src/components/toolbar.tsx
@@ -187,7 +187,6 @@ export class ToolbarComponent extends BaseComponent<IProps, IState> {
     }
 
     const newTileOptions: IDocumentContentAddTileOptions = {
-            addSidecarNotes: !!tileContentInfo?.addSidecarNotes,
             insertRowInfo: { rowInsertIndex: document.content?.defaultInsertRow ?? 0 }
           };
     const rowTile = document.addTile(tool.id, newTileOptions);

--- a/src/models/document/document-content-tests/dc-general.test.ts
+++ b/src/models/document/document-content-tests/dc-general.test.ts
@@ -46,23 +46,19 @@ describe("DocumentContentModel", () => {
     expect(documentContent.tileMap.size).toBe(0);
     documentContent.addTile("text", { title: "Text 1" });
     expect(documentContent.tileMap.size).toBe(1);
-    // adding geometry tool adds sidecar text tool
-    documentContent.addTile("geometry", { addSidecarNotes: true, title: "Shapes Graph 1" });
-    expect(documentContent.tileMap.size).toBe(3);
+    documentContent.addTile("geometry", { title: "Shapes Graph 1" });
+    expect(documentContent.tileMap.size).toBe(2);
     expect(documentContent.defaultInsertRow).toBe(2);
     const newRowTile = documentContent.addTile("table", { title: "Table 1" });
     const columnWidths = getColumnWidths(documentContent, newRowTile?.tileId);
-    expect(documentContent.tileMap.size).toBe(4);
+    expect(documentContent.tileMap.size).toBe(3);
     documentContent.addTile("drawing", { title: "Sketch 1" });
-    expect(documentContent.tileMap.size).toBe(5);
+    expect(documentContent.tileMap.size).toBe(4);
     expect(parsedContentExport()).toEqual({
       tiles: [
         { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } },
-        [
-          { title: "Shapes Graph 1", content: { type: "Geometry", objects: {},
+        { title: "Shapes Graph 1", content: { type: "Geometry", objects: {},
             linkedAttributeColors: {}, pointMetadata: {} } },
-          { content: { type: "Text", format: "html", text: ["<p></p>"] } }
-        ],
         { title: "Table 1", content: { type: "Table", columnWidths } },
         { title: "Sketch 1", content: { type: "Drawing", objects: [] } }
       ]
@@ -81,7 +77,6 @@ describe("DocumentContentModel", () => {
     // insert image between text tiles
     const imageTile1 = documentContent.addTile("image", {
       title: "Image 1",
-      addSidecarNotes: false,
       insertRowInfo: {
         rowInsertIndex: 1,
         rowDropIndex: 1,
@@ -103,7 +98,6 @@ describe("DocumentContentModel", () => {
     // insert image at bottom
     const imageTile2 = documentContent.addTile("image", {
       title: "Image 2",
-      addSidecarNotes: false,
       insertRowInfo: {
         rowInsertIndex: 3,
         rowDropIndex: 3,
@@ -137,7 +131,6 @@ describe("DocumentContentModel", () => {
 
     const imageTile1 = documentContent.addTile("image", {
       title: "Image 1",
-      addSidecarNotes: false,
       insertRowInfo: {
         rowInsertIndex: 1,
         rowDropIndex: 1,
@@ -166,97 +159,6 @@ describe("DocumentContentModel", () => {
       ]
     });
   });
-
-  it("allows the geometry tiles to be added with sidecar text as new row", () => {
-    documentContent.addTile("text", { title: "Text 1" });
-    const textTile2 = documentContent.addTile("text", { title: "Text 2" });
-
-    const graphTileInfo = documentContent.addTile("geometry", {
-      title: "Shapes Graph 1",
-      addSidecarNotes: true,
-      insertRowInfo: {
-        rowInsertIndex: 1,
-        rowDropIndex: 1,
-        rowDropLocation: "bottom"
-      }
-    });
-
-    const geometryRowId = documentContent.findRowContainingTile(graphTileInfo!.tileId);
-    const geometryRowIndex = documentContent.rowOrder.findIndex((id: string) => id === geometryRowId);
-
-    expect(geometryRowIndex).toBe(1);
-
-    // sidecar text tile should be on same row
-    expect(graphTileInfo!.additionalTileIds).toBeDefined();
-
-    const sidecarRowId = documentContent.findRowContainingTile(graphTileInfo!.tileId);
-    const sidecarRowIndex = documentContent.rowOrder.findIndex((id: string) => id === sidecarRowId);
-
-    expect(sidecarRowIndex).toBe(1);
-
-    // text tile should be on 2
-    const textTile2RowId = documentContent.findRowContainingTile(textTile2!.tileId);
-    const textTile2RowIndex1 = documentContent.rowOrder.findIndex((id: string) => id === textTile2RowId);
-
-    expect(textTile2RowIndex1).toBe(2);
-    expect(parsedContentExport()).toEqual({
-      tiles: [
-        { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } },
-        [
-          { title: "Shapes Graph 1",
-            content: { type: "Geometry", objects: {}, linkedAttributeColors: {}, pointMetadata: {} } },
-          { content: { type: "Text", format: "html", text: ["<p></p>"] } }
-        ],
-        { title: "Text 2", content: { type: "Text", format: "html", text: ["<p></p>"] } }
-      ]
-    });
-  });
-
-  it("allows the geometry tiles to be added with sidecar text at side of existing rows", () => {
-    documentContent.addTile("text", { title: "Text 1" });
-    const textTile2 = documentContent.addTile("text", { title: "Text 2" });
-
-    const graphTileInfo = documentContent.addTile("geometry", {
-      title: "Shapes Graph 1",
-      addSidecarNotes: true,
-      insertRowInfo: {
-        rowInsertIndex: 1,
-        rowDropIndex: 1,
-        rowDropLocation: "left"
-      }
-    });
-
-    const geometryRowId = documentContent.findRowContainingTile(graphTileInfo!.tileId);
-    const geometryRowIndex = documentContent.rowOrder.findIndex((id: string) => id === geometryRowId);
-
-    expect(geometryRowIndex).toBe(1);
-
-    // sidecar text tile should be on same row
-    expect(graphTileInfo!.additionalTileIds).toBeDefined();
-
-    const sidecarRowId = documentContent.findRowContainingTile(graphTileInfo!.tileId);
-    const sidecarRowIndex = documentContent.rowOrder.findIndex((id: string) => id === sidecarRowId);
-
-    expect(sidecarRowIndex).toBe(1);
-
-    // original text tile should be on 1 as well
-    const textTile2RowId = documentContent.findRowContainingTile(textTile2!.tileId);
-    const textTile2RowIndex1 = documentContent.rowOrder.findIndex((id: string) => id === textTile2RowId);
-
-    expect(textTile2RowIndex1).toBe(1);
-    expect(parsedContentExport()).toEqual({
-      tiles: [
-        { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } },
-        [
-          { title: "Shapes Graph 1",
-            content: { type: "Geometry", objects: {}, linkedAttributeColors: {}, pointMetadata: {} } },
-          { content: { type: "Text", format: "html", text: ["<p></p>"] } },
-          { title: "Text 2", content: { type: "Text", format: "html", text: ["<p></p>"] } }
-        ]
-      ]
-    });
-  });
-
 });
 
 const sectionedContent = {
@@ -564,15 +466,11 @@ describe("DocumentContentModel -- sectioned documents --", () => {
       { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } },
     ]);
 
-    content.addTile("geometry", { title: "Shapes Graph 1", addSidecarNotes: true,
-      insertRowInfo: { rowInsertIndex: 2 } });
+    content.addTile("geometry", { title: "Shapes Graph 1", insertRowInfo: { rowInsertIndex: 2 } });
     expect(getAllRows(content)).toEqual([
       { Header: "A"},
-      [
-        { title: "Shapes Graph 1",
+      { title: "Shapes Graph 1",
           content: { type: "Geometry", objects: {}, linkedAttributeColors: {}, pointMetadata: {} } },
-        { content: { type: "Text", format: "html", text: ["<p></p>"] } }
-      ],
       { Header: "B"},
       { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } },
     ]);
@@ -581,7 +479,7 @@ describe("DocumentContentModel -- sectioned documents --", () => {
     content.moveTile(geometryId, { rowDropIndex: 3, rowDropLocation: "left", rowInsertIndex: 3 });
     expect(getAllRows(content)).toEqual([
       { Header: "A"},
-      { content: { type: "Text", format: "html", text: ["<p></p>"] } },
+      { Placeholder: "A" },
       { Header: "B"},
       [
         { title: "Shapes Graph 1", content: { type: "Geometry", objects: {},
@@ -593,11 +491,8 @@ describe("DocumentContentModel -- sectioned documents --", () => {
     content.moveTile(geometryId, { rowDropIndex: 1, rowDropLocation: "left", rowInsertIndex: 1 });
     expect(getAllRows(content)).toEqual([
       { Header: "A"},
-      [
         { title: "Shapes Graph 1", content: { type: "Geometry", objects: {},
           linkedAttributeColors: {}, pointMetadata: {} } },
-        { content: { type: "Text", format: "html", text: ["<p></p>"] } }
-      ],
       { Header: "B"},
       { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } },
     ]);

--- a/src/models/document/document-content-types.ts
+++ b/src/models/document/document-content-types.ts
@@ -5,7 +5,6 @@ import { IDropRowInfo } from "./tile-row";
 
 export interface IDocumentAddTileOptions {
   title?: string;
-  addSidecarNotes?: boolean;
   url?: string;
 }
 
@@ -21,7 +20,6 @@ export interface INewTileOptions {
 export interface INewRowTile {
   rowId: string;
   tileId: string;
-  additionalTileIds?: string[];
 }
 export type NewRowTileArray = Array<INewRowTile | undefined>;
 

--- a/src/models/document/document.test.ts
+++ b/src/models/document/document.test.ts
@@ -180,9 +180,8 @@ describe("document model", () => {
     expect(document.content!.tileMap.size).toBe(0);
     document.addTile("text");
     expect(document.content!.tileMap.size).toBe(1);
-    // adding geometry tool adds sidecar text tool
-    document.addTile("geometry", {addSidecarNotes: true});
-    expect(document.content!.tileMap.size).toBe(3);
+    document.addTile("geometry");
+    expect(document.content!.tileMap.size).toBe(2);
   });
 
   it("allows tiles to be deleted", () => {

--- a/src/models/tiles/geometry/geometry-registration.ts
+++ b/src/models/tiles/geometry/geometry-registration.ts
@@ -22,7 +22,6 @@ registerTileContentInfo({
   displayName: "Shapes Graph",
   modelClass: GeometryContentModel,
   metadataClass: GeometryMetadataModel,
-  addSidecarNotes: true,
   defaultHeight: kGeometryDefaultHeight,
   exportNonDefaultHeight: true,
   isDataConsumer: true,

--- a/src/models/tiles/tile-content-info.ts
+++ b/src/models/tiles/tile-content-info.ts
@@ -53,7 +53,6 @@ export interface ITileContentInfo {
    */
   useContentTitle?: boolean;
   metadataClass?: typeof TileMetadataModel;
-  addSidecarNotes?: boolean;
   defaultHeight?: number;
   exportNonDefaultHeight?: boolean;
   isDataConsumer?: boolean;


### PR DESCRIPTION
PT-185538860

When a Geometry tile is created, it will no longer create a text tile.

Since we're not planning to bring this functionality back for any tile type, simplify the code by removing the concept of 'sidecar' tile creation entirely.
