### PR TITLE
fix: Adding manual points causes axes to autoscale (PT-187934814)

### DIFF
--- a/cypress/e2e/functional/tile_tests/xy_plot_tool_spec.js
+++ b/cypress/e2e/functional/tile_tests/xy_plot_tool_spec.js
@@ -560,6 +560,8 @@ context('XYPlot Tool Tile', function () {
       clueCanvas.toolbarButtonIsNotSelected('graph', 'move-points');
       clueCanvas.toolbarButtonIsDisabled('graph', 'add-points');
       clueCanvas.toolbarButtonIsNotSelected('graph', 'add-points');
+      xyTile.getEditableAxisBox("left", "max").click().type("100{enter}");
+      xyTile.getEditableAxisBox("bottom", "max").click().type("100{enter}");
 
       // Create manual layer
       clueCanvas.clickToolbarButton('graph', 'add-points-by-hand');
@@ -571,6 +573,10 @@ context('XYPlot Tool Tile', function () {
       xyTile.getYAttributesLabel().should('have.length', 1).should('contain.text', 'Y Variable 1');
       xyTile.getLayerName().should('have.length', 1).should('contain.text', 'Added by hand');
       xyTile.getLayerNameInput().should('not.be.visible');
+
+      // Custom axis bounds should not have been changed
+      xyTile.getEditableAxisBox("left", "max").should('contain.text', '100');
+      xyTile.getEditableAxisBox("bottom", "max").should('contain.text', '100');
 
       // Rename manual layer
       xyTile.getLayerNameEditButton().click();

--- a/src/plugins/graph/models/graph-controller.ts
+++ b/src/plugins/graph/models/graph-controller.ts
@@ -153,9 +153,10 @@ export class GraphController {
         attrType = dataConfiguration.attributeType(attrRole) ?? 'empty',
         currAxisModel = graphModel.getAxis(place),
         currentType = currAxisModel?.type ?? 'empty',
-        [min, max] = graphModel.lockAxes && isNumericAxisModel(currAxisModel)
-                       ? [currAxisModel.min, currAxisModel.max]
-                       : kDefaultNumericAxisBounds;
+        graphHasEditableLayer = graphModel.layers.some(l => l.editable === true),
+        shouldNotResetBounds = (graphHasEditableLayer || graphModel.lockAxes) &&
+                               isNumericAxisModel(currAxisModel),
+        [min, max] = shouldNotResetBounds ? [currAxisModel.min, currAxisModel.max] : kDefaultNumericAxisBounds;
       switch (attrType) {
         case 'numeric': {
           if (!currAxisModel || !isNumericAxisModel(currAxisModel)) {
@@ -164,7 +165,7 @@ export class GraphController {
             dataConfiguration.setAttributeType(attrRole, 'numeric');
             layout.setAxisScaleType(place, 'linear');
           }
-          if (!graphModel.lockAxes) {
+          if (!graphModel.lockAxes && !graphHasEditableLayer) {
             setNiceDomain(graphModel.numericValuesForAttrRole(attrRole), graphModel.getAxis(place)!, false);
           }
         }

--- a/src/plugins/graph/models/graph-controller.ts
+++ b/src/plugins/graph/models/graph-controller.ts
@@ -153,8 +153,8 @@ export class GraphController {
         attrType = dataConfiguration.attributeType(attrRole) ?? 'empty',
         currAxisModel = graphModel.getAxis(place),
         currentType = currAxisModel?.type ?? 'empty',
-        graphHasEditableLayer = graphModel.layers.some(l => l.editable === true),
-        shouldNotResetBounds = (graphHasEditableLayer || graphModel.lockAxes) &&
+        currentLayer = graphModel.layers.find(l => l.config === dataConfiguration),
+        shouldNotResetBounds = (currentLayer?.editable || graphModel.lockAxes) &&
                                isNumericAxisModel(currAxisModel),
         [min, max] = shouldNotResetBounds ? [currAxisModel.min, currAxisModel.max] : kDefaultNumericAxisBounds;
       switch (attrType) {
@@ -165,7 +165,7 @@ export class GraphController {
             dataConfiguration.setAttributeType(attrRole, 'numeric');
             layout.setAxisScaleType(place, 'linear');
           }
-          if (!graphModel.lockAxes && !graphHasEditableLayer) {
+          if (!graphModel.lockAxes && !currentLayer?.editable) {
             setNiceDomain(graphModel.numericValuesForAttrRole(attrRole), graphModel.getAxis(place)!, false);
           }
         }

--- a/src/plugins/graph/models/graph-controller.ts
+++ b/src/plugins/graph/models/graph-controller.ts
@@ -153,7 +153,7 @@ export class GraphController {
         attrType = dataConfiguration.attributeType(attrRole) ?? 'empty',
         currAxisModel = graphModel.getAxis(place),
         currentType = currAxisModel?.type ?? 'empty',
-        currentLayer = graphModel.layers.find(l => l.config === dataConfiguration),
+        currentLayer = graphModel.layerForDataConfigurationId(dataConfiguration.id),
         shouldNotResetBounds = (currentLayer?.editable || graphModel.lockAxes) &&
                                isNumericAxisModel(currAxisModel),
         [min, max] = shouldNotResetBounds ? [currAxisModel.min, currAxisModel.max] : kDefaultNumericAxisBounds;


### PR DESCRIPTION
[187934814](https://www.pivotaltracker.com/story/show/187934814)

Adds an additional check when determining if the axis bounds should be automatically reset to the defaults when `setupAxis` is called in the graph controller's `handleAttributeAssignment` function. If the current layer is editable, the bounds are not changed.