### PR TITLE
Allow drawing with touch events

### DIFF
--- a/cypress/e2e/functional/document_tests/copy_doc_test_spec.js
+++ b/cypress/e2e/functional/document_tests/copy_doc_test_spec.js
@@ -63,11 +63,7 @@ context('Copy Document', () => {
 
     cy.log('Add drawing tile');
     clueCanvas.addTile("drawing");
-    drawTile.getDrawToolRectangle().click();
-    drawTile.getDrawTile()
-      .trigger("mousedown", 250, 50)
-      .trigger("mousemove", 100, 150)
-      .trigger("mouseup", 100, 50);
+    drawTile.drawRectangle(250, 50, -150, 100);
     drawTile.getRectangleDrawing().should("exist").and("have.length", 1);
 
     cy.log("Add expression tile");

--- a/cypress/e2e/functional/document_tests/exemplar_test_spec.js
+++ b/cypress/e2e/functional/document_tests/exemplar_test_spec.js
@@ -23,17 +23,6 @@ function beforeTest(params) {
   cy.waitForLoad();
 }
 
-function addText(x, y, text) {
-  drawToolTile.getDrawToolText().last().click();
-  drawToolTile.getDrawTile().last()
-    .trigger("mousedown", x, y)
-    .trigger("mouseup", x, y);
-  drawToolTile.getDrawTile().last()
-    .trigger("mousedown", x, y)
-    .trigger("mouseup", x, y);
-  drawToolTile.getTextDrawing().get('textarea').type(text + "{enter}");
-}
-
 context('Exemplar Documents', function () {
   it('Unit with default config does not reveal exemplars or generate sticky notes', function () {
     beforeTest(queryParams2);
@@ -46,17 +35,17 @@ context('Exemplar Documents', function () {
     clueCanvas.addTile("drawing");
     drawToolTile.drawRectangle(100, 50);
     drawToolTile.drawRectangle(200, 50);
-    addText(300, 50, "one two three four five six seven eight nine ten");
+    drawToolTile.addText(300, 50, "one two three four five six seven eight nine ten");
 
     clueCanvas.addTile("drawing");
     drawToolTile.drawRectangle(100, 50);
     drawToolTile.drawRectangle(200, 50);
-    addText(300, 50, "one two three four five six seven eight nine ten");
+    drawToolTile.addText(300, 50, "one two three four five six seven eight nine ten");
 
     clueCanvas.addTile("drawing");
     drawToolTile.drawRectangle(100, 50);
     drawToolTile.drawRectangle(200, 50);
-    addText(300, 50, "one two three four five six seven eight nine ten");
+    drawToolTile.addText(300, 50, "one two three four five six seven eight nine ten");
 
     // No change, no sticky note
     sortWork.getSortWorkItemByTitle(exemplarName).parents('.list-item').should("not.have.class", "private");
@@ -119,7 +108,7 @@ context('Exemplar Documents', function () {
     clueCanvas.addTile("drawing");
     drawToolTile.drawRectangle(100, 50);
     drawToolTile.drawRectangle(200, 50);
-    addText(300, 50, "one two three four five");
+    drawToolTile.addText(300, 50, "one two three four five");
 
     clueCanvas.addTile("drawing");
     drawToolTile.drawRectangle(100, 50);
@@ -127,7 +116,7 @@ context('Exemplar Documents', function () {
 
     // Still private?
     sortWork.getSortWorkItemByTitle(exemplarName).parents('.list-item').should("have.class", "private");
-    addText(300, 50, "one two three four five");
+    drawToolTile.addText(300, 50, "one two three four five");
     // Now the exemplar should be revealed
     sortWork.getSortWorkItemByTitle(exemplarInfo).parents('.list-item').should("not.have.class", "private");
     clueCanvas.getStickyNotePopup().should("exist").should("be.visible")

--- a/cypress/e2e/functional/document_tests/student_teacher_4up_readonly_spec.js
+++ b/cypress/e2e/functional/document_tests/student_teacher_4up_readonly_spec.js
@@ -89,11 +89,7 @@ function setupTest(studentIndex) {
   geometryToolTile.getGraphPoint().should('have.length', 3);
   geometryToolTile.getPhantomGraphPoint().should('exist');
   clueCanvas.addTile("drawing");
-  drawToolTile.getDrawToolRectangle().click();
-  drawToolTile.getDrawTile()
-    .trigger("mousedown", 250, 50)
-    .trigger("mousemove", 100, 150)
-    .trigger("mouseup", 100, 50);
+  drawToolTile.drawRectangle(100, 100);
   drawToolTile.getRectangleDrawing().should("exist").and("have.length", 1);
   clueCanvas.addTile("expression");
   exp.getMathField().should("have.value", "a=\\pi r^2");

--- a/cypress/e2e/functional/document_tests/tiles_copy_test_spec.js
+++ b/cypress/e2e/functional/document_tests/tiles_copy_test_spec.js
@@ -154,11 +154,7 @@ context('Test copy tiles from one document to other document', function () {
 
     cy.log('Add drawing tile');
     clueCanvas.addTile("drawing");
-    drawToolTile.getDrawToolRectangle().click();
-    drawToolTile.getDrawTile()
-      .trigger("mousedown", 250, 50)
-      .trigger("mousemove", 100, 150)
-      .trigger("mouseup", 100, 50);
+    drawToolTile.drawRectangle(250, 50, -150, 100);
     drawToolTile.getRectangleDrawing().should("exist").and("have.length", 1);
 
     cy.log("Add expression tile");

--- a/cypress/e2e/functional/teacher_tests/history_playback_spec.js
+++ b/cypress/e2e/functional/teacher_tests/history_playback_spec.js
@@ -65,11 +65,7 @@ context('History Playback', () => {
     cy.get('.primary-workspace .editable-document-content .canvas .document-content .drawing-tool-tile').should('be.visible');
 
     cy.log('verify playback document does not have changes to primary document');
-    drawToolTile.getDrawToolVector().click();
-    drawToolTile.getDrawTile()
-      .trigger('mousedown')
-      .trigger('mousemove', 50, 0)
-      .trigger('mouseup');
+    drawToolTile.drawVector(50, 50, 50, 0);
     cy.get('.primary-workspace .editable-document-content .canvas .document-content .drawing-tool .drawing-layer line').should('be.visible');
     cy.get('[data-test="subtab-workspaces"] .editable-document-content .canvas .document-content .drawing-tool .drawing-layer line').should('not.exist');
 

--- a/cypress/e2e/functional/tile_tests/arrow_annotation_spec.js
+++ b/cypress/e2e/functional/tile_tests/arrow_annotation_spec.js
@@ -176,9 +176,9 @@ context('Arrow Annotations (Sparrows)', function () {
     clueCanvas.addTile("drawing");
     drawToolTile.getDrawToolVector().eq(0).click();
     drawToolTile.getDrawTile().eq(1)
-      .trigger("mousedown", 150, 50)
-      .trigger("mousemove", 100, 150)
-      .trigger("mouseup", 100, 50);
+      .trigger("pointerdown", 150, 50)
+      .trigger("pointermove", 100, 150)
+      .trigger("pointerup", 100, 50);
     aa.clickArrowToolbarButton();
     aa.getAnnotationButtons().should("have.length", 4);
     aa.getAnnotationButtons().first().click({ force: true });

--- a/cypress/e2e/functional/tile_tests/drawing_tool_spec.js
+++ b/cypress/e2e/functional/tile_tests/drawing_tool_spec.js
@@ -47,20 +47,12 @@ context('Draw Tool Tile', function () {
     drawToolTile.getTileTitle().should("exist");
 
     cy.log("can open show/sort panel and select objects");
-    drawToolTile.getDrawToolRectangle().click();
-    drawToolTile.getDrawTile()
-      .trigger("mousedown", 100, 50)
-      .trigger("mousemove", 250, 150)
-      .trigger("mouseup", 250, 150);
-    drawToolTile.getDrawToolEllipse().click();
-    drawToolTile.getDrawTile()
-      .trigger("mousedown", 300, 50)
-      .trigger("mousemove", 400, 150)
-      .trigger("mouseup", 400, 150);
+    drawToolTile.drawRectangle(100, 50, 150, 100);
+    drawToolTile.drawEllipse(300, 50, 100, 100);
     // Unselect all
     drawToolTile.getDrawTile()
-      .trigger("mousedown", 50, 50)
-      .trigger("mouseup", 50, 50);
+      .trigger("pointerdown", 50, 50)
+      .trigger("pointerup", 50, 50);
     drawToolTile.getSelectionBox().should("not.exist");
 
     // Open panel
@@ -108,10 +100,10 @@ context('Draw Tool Tile', function () {
     cy.log("verify draw a line");
     drawToolTile.getDrawToolFreehand().click();
     drawToolTile.getDrawTile()
-      .trigger("mousedown", 350, 50)
-      .trigger("mousemove", 350, 100)
-      .trigger("mousemove", 450, 100)
-      .trigger("mouseup", 450, 100);
+      .trigger("pointerdown", 350, 50)
+      .trigger("pointermove", 350, 100)
+      .trigger("pointermove", 450, 100)
+      .trigger("pointerup", 450, 100);
     drawToolTile.getFreehandDrawing().should("exist").and("have.length", 1);
     // Freehand tool should still be active
     drawToolTile.getDrawToolFreehand().should("have.class", "selected");
@@ -127,15 +119,15 @@ context('Draw Tool Tile', function () {
     // First make sure we don't select it even if we are inside of its
     // bounding box
     drawToolTile.getDrawTile()
-      .trigger("mousedown", 370, 50)
-      .trigger("mousemove", 450, 80)
-      .trigger("mouseup", 450, 80);
+      .trigger("pointerdown", 370, 50)
+      .trigger("pointermove", 450, 80)
+      .trigger("pointerup", 450, 80);
     drawToolTile.getDrawToolDelete().should("have.class", "disabled");
 
     drawToolTile.getDrawTile()
-      .trigger("mousedown", 340, 90)
-      .trigger("mousemove", 360, 110)
-      .trigger("mouseup", 360, 110);
+      .trigger("pointerdown", 340, 90)
+      .trigger("pointermove", 360, 110)
+      .trigger("pointerup", 360, 110);
     drawToolTile.getDrawToolDelete().should("not.have.class", "disabled");
 
     cy.log("verify change outline color");
@@ -150,8 +142,8 @@ context('Draw Tool Tile', function () {
     // is not on the path
     // drawToolTile.getDrawToolSelect().click();
     // drawToolTile.getDrawTile()
-    //   .trigger("mousedown", 350, 100)
-    //   .trigger("mouseup", 350, 100);
+    //   .trigger("pointerdown", 350, 100)
+    //   .trigger("pointerup", 350, 100);
     drawToolTile.getSelectionBox().should("exist");
     drawToolTile.getDrawToolDelete().should("not.have.class", "disabled").click();
     drawToolTile.getFreehandDrawing().should("not.exist");
@@ -163,11 +155,7 @@ context('Draw Tool Tile', function () {
     drawToolTile.getDrawTileTitle().first().type(newName + '{enter}');
     drawToolTile.getTileTitle().should("contain", newName);
 
-    drawToolTile.getDrawToolRectangle().click();
-    drawToolTile.getDrawTile()
-      .trigger("mousedown", 250, 50)
-      .trigger("mousemove", 100, 150)
-      .trigger("mouseup", 100, 50);
+    drawToolTile.drawRectangle(250, 50, -150, 100);
 
     cy.log("verify Draw tile restore upon page reload");
     cy.wait(2000);
@@ -182,11 +170,7 @@ context('Draw Tool Tile', function () {
     clueCanvas.addTile("drawing");
 
     cy.log("verify draw vector");
-    drawToolTile.getDrawToolVector().click();
-    drawToolTile.getDrawTile()
-      .trigger("mousedown", 250, 50)
-      .trigger("mousemove", 100, 50)
-      .trigger("mouseup", 100, 50);
+    drawToolTile.drawVector(250, 50, -150, 0);
     drawToolTile.getVectorDrawing().should("exist").and("have.length", 1);
     // Select tool should be selected after object created
     drawToolTile.getDrawToolSelect().should("have.class", "selected");
@@ -225,9 +209,9 @@ context('Draw Tool Tile', function () {
     // re-select the object using a selection rectangle.
     drawToolTile.getDrawToolSelect().click();
     drawToolTile.getDrawTile()
-      .trigger("mousedown", 90, 40)
-      .trigger("mousemove", 260, 60)
-      .trigger("mouseup", 260, 60);
+      .trigger("pointerdown", 90, 40)
+      .trigger("pointermove", 260, 60)
+      .trigger("pointerup", 260, 60);
     drawToolTile.getDrawToolDelete().click();
     drawToolTile.getVectorDrawing().should("not.exist");
   });
@@ -236,11 +220,7 @@ context('Draw Tool Tile', function () {
     clueCanvas.addTile("drawing");
 
     cy.log("verify draw rectangle");
-    drawToolTile.getDrawToolRectangle().click();
-    drawToolTile.getDrawTile()
-      .trigger("mousedown", 250, 50)
-      .trigger("mousemove", 100, 150)
-      .trigger("mouseup", 100, 50);
+    drawToolTile.drawRectangle(250, 50, -150, 100);
     drawToolTile.getRectangleDrawing().should("exist").and("have.length", 1);
     // Select tool should be selected after object created
     drawToolTile.getDrawToolSelect().should("have.class", "selected");
@@ -269,17 +249,17 @@ context('Draw Tool Tile', function () {
     cy.log("verify moving pre-selected object");
     drawToolTile.getDrawToolSelect().click();
     drawToolTile.getDrawTile()
-      .trigger("mousedown", 100, 100)
-      .trigger("mousemove", 200, 100)
-      .trigger("mouseup", 200, 100);
+      .trigger("pointerdown", 100, 100)
+      .trigger("pointermove", 200, 100)
+      .trigger("pointerup", 200, 100);
     // For some reason the move isn't very accurate in cypress so often the final location off
     drawToolTile.getRectangleDrawing().first().should("have.attr", "x").then(parseInt).and("within", 160, 220);
 
     cy.log("verify hovering objects");
     drawToolTile.getDrawTile()
       // Un-select the rectangle
-      .trigger("mousedown", 500, 100)
-      .trigger("mouseup", 500, 100);
+      .trigger("pointerdown", 500, 100)
+      .trigger("pointerup", 500, 100);
 
     drawToolTile.getRectangleDrawing().first()
       // Get the rectangle to be hovered. In the code we are listening to
@@ -296,19 +276,15 @@ context('Draw Tool Tile', function () {
     drawToolTile.getHighlightBox().should("not.exist");
 
     cy.log("verify moving not selected object");
-    drawToolTile.getDrawToolRectangle().click();
-    drawToolTile.getDrawTile()
-      .trigger("mousedown", 250, 50)
-      .trigger("mousemove", 100, 150)
-      .trigger("mouseup", 100, 150);
+    drawToolTile.drawRectangle(250, 50, -150, 100);
     drawToolTile.getRectangleDrawing().should("exist").and("have.length", 1);
     drawToolTile.getSelectionBox().should("exist");
 
     // Unselect the rectangle just drawn
     drawToolTile.getDrawTile()
       // Un-select the rectangle
-      .trigger("mousedown", 500, 100)
-      .trigger("mouseup", 500, 100);
+      .trigger("pointerdown", 500, 100)
+      .trigger("pointerup", 500, 100);
     drawToolTile.getSelectionBox().should("not.exist");
 
     // Get the rectangle to be hovered, see above for more info.
@@ -317,9 +293,9 @@ context('Draw Tool Tile', function () {
     drawToolTile.getHighlightBox().should("exist").should("have.attr", "stroke").and("eq", "#bbdd00");
 
     drawToolTile.getDrawTile()
-      .trigger("mousedown", 100, 135)
-      .trigger("mousemove", 200, 135)
-      .trigger("mouseup", 200, 135);
+      .trigger("pointerdown", 100, 135)
+      .trigger("pointermove", 200, 135)
+      .trigger("pointerup", 200, 135);
 
     drawToolTile.getRectangleDrawing().first().should("have.attr", "x").then(parseInt).and("within", 150, 250);
 
@@ -333,9 +309,9 @@ context('Draw Tool Tile', function () {
     // starting from top edge
     drawToolTile.getDrawToolRectangle().click();
     drawToolTile.getDrawTile()
-      .trigger("mousedown", 100, 50, { altKey: true })
-      .trigger("mousemove", 100, 70, { altKey: true })
-      .trigger("mouseup", 100, 70);
+      .trigger("pointerdown", 100, 50, { altKey: true })
+      .trigger("pointermove", 100, 70, { altKey: true })
+      .trigger("pointerup", 100, 70);
 
     drawToolTile.getRectangleDrawing().should("exist").and("have.length", 1);
     drawToolTile.getRectangleDrawing().last().should("have.attr", "width").and("eq", "20");
@@ -344,9 +320,9 @@ context('Draw Tool Tile', function () {
     // starting from the left edge
     drawToolTile.getDrawToolRectangle().click();
     drawToolTile.getDrawTile()
-      .trigger("mousedown", 200, 50, { altKey: true })
-      .trigger("mousemove", 230, 50, { altKey: true })
-      .trigger("mouseup", 230, 50);
+      .trigger("pointerdown", 200, 50, { altKey: true })
+      .trigger("pointermove", 230, 50, { altKey: true })
+      .trigger("pointerup", 230, 50);
     drawToolTile.getRectangleDrawing().should("exist").and("have.length", 2);
     drawToolTile.getRectangleDrawing().last().should("have.attr", "width").and("eq", "30");
     drawToolTile.getRectangleDrawing().last().should("have.attr", "height").and("eq", "30");
@@ -354,9 +330,9 @@ context('Draw Tool Tile', function () {
     // draw a square starting at the bottom edge
     drawToolTile.getDrawToolRectangle().click();
     drawToolTile.getDrawTile()
-      .trigger("mousedown", 300, 90, { altKey: true })
-      .trigger("mousemove", 300, 50, { altKey: true })
-      .trigger("mouseup", 300, 50);
+      .trigger("pointerdown", 300, 90, { altKey: true })
+      .trigger("pointermove", 300, 50, { altKey: true })
+      .trigger("pointerup", 300, 50);
     drawToolTile.getRectangleDrawing().should("exist").and("have.length", 3);
     drawToolTile.getRectangleDrawing().last().should("have.attr", "width").and("eq", "40");
     drawToolTile.getRectangleDrawing().last().should("have.attr", "height").and("eq", "40");
@@ -364,9 +340,9 @@ context('Draw Tool Tile', function () {
     // draw a square starting at the right edge
     drawToolTile.getDrawToolRectangle().click();
     drawToolTile.getDrawTile()
-      .trigger("mousedown", 450, 50, { altKey: true })
-      .trigger("mousemove", 400, 50, { altKey: true })
-      .trigger("mouseup", 400, 50);
+      .trigger("pointerdown", 450, 50, { altKey: true })
+      .trigger("pointermove", 400, 50, { altKey: true })
+      .trigger("pointerup", 400, 50);
     drawToolTile.getRectangleDrawing().should("exist").and("have.length", 4);
     drawToolTile.getRectangleDrawing().last().should("have.attr", "width").and("eq", "50");
     drawToolTile.getRectangleDrawing().last().should("have.attr", "height").and("eq", "50");
@@ -374,9 +350,9 @@ context('Draw Tool Tile', function () {
     // Diagonal from top right to bottom left with the width 60 and height 50
     drawToolTile.getDrawToolRectangle().click();
     drawToolTile.getDrawTile()
-      .trigger("mousedown", 560, 50, { altKey: true })
-      .trigger("mousemove", 500, 100, { altKey: true })
-      .trigger("mouseup", 500, 100);
+      .trigger("pointerdown", 560, 50, { altKey: true })
+      .trigger("pointermove", 500, 100, { altKey: true })
+      .trigger("pointerup", 500, 100);
     drawToolTile.getRectangleDrawing().should("exist").and("have.length", 5);
     drawToolTile.getRectangleDrawing().last().should("have.attr", "width").and("eq", "60");
     drawToolTile.getRectangleDrawing().last().should("have.attr", "height").and("eq", "60");
@@ -384,9 +360,9 @@ context('Draw Tool Tile', function () {
     // Diagonal from bottom right to top left with the width 50 and the height 70
     drawToolTile.getDrawToolRectangle().click();
     drawToolTile.getDrawTile()
-      .trigger("mousedown", 650, 120, { altKey: true })
-      .trigger("mousemove", 600, 50, { altKey: true })
-      .trigger("mouseup", 600, 50);
+      .trigger("pointerdown", 650, 120, { altKey: true })
+      .trigger("pointermove", 600, 50, { altKey: true })
+      .trigger("pointerup", 600, 50);
     drawToolTile.getRectangleDrawing().should("exist").and("have.length", 6);
     drawToolTile.getRectangleDrawing().last().should("have.attr", "width").and("eq", "70");
     drawToolTile.getRectangleDrawing().last().should("have.attr", "height").and("eq", "70");
@@ -418,11 +394,7 @@ context('Draw Tool Tile', function () {
     clueCanvas.addTile("drawing");
 
     cy.log("verify draw ellipse");
-    drawToolTile.getDrawToolEllipse().click();
-    drawToolTile.getDrawTile()
-      .trigger("mousedown", 250, 50)
-      .trigger("mousemove", 100, 150)
-      .trigger("mouseup", 100, 150);
+    drawToolTile.drawEllipse(250, 50, -150, 100);
     drawToolTile.getEllipseDrawing().should("exist").and("have.length", 1);
     // Select tool should be selected after object created
     drawToolTile.getDrawToolSelect().should("have.class", "selected");
@@ -436,9 +408,9 @@ context('Draw Tool Tile', function () {
     cy.log("verify draw circle");
     drawToolTile.getDrawToolEllipse().click();
     drawToolTile.getDrawTile()
-      .trigger("mousedown", 450, 50, { altKey: true })
-      .trigger("mousemove", 450, 150, { altKey: true })
-      .trigger("mouseup", 450, 150);
+      .trigger("pointerdown", 450, 50, { altKey: true })
+      .trigger("pointermove", 450, 150, { altKey: true })
+      .trigger("pointerup", 450, 150);
     drawToolTile.getEllipseDrawing().should("exist").and("have.length", 2);
     drawToolTile.getEllipseDrawing().last().should("have.attr", "rx").and("eq", "100");
     drawToolTile.getEllipseDrawing().last().should("have.attr", "ry").and("eq", "100");
@@ -460,8 +432,8 @@ context('Draw Tool Tile', function () {
     cy.log("verify draw stamp");
     drawToolTile.getDrawToolStamp().click();
     drawToolTile.getDrawTile()
-      .trigger("mousedown", 250, 50)
-      .trigger("mouseup");
+      .trigger("pointerdown", 250, 50)
+      .trigger("pointerup");
     drawToolTile.getImageDrawing().should("exist").and("have.length", 1);
     // Stamp tool should still be active
     drawToolTile.getDrawToolStamp().should("have.class", "selected");
@@ -477,15 +449,15 @@ context('Draw Tool Tile', function () {
     drawToolTile.getDrawToolStampExpand().click();
     cy.get(".toolbar-palette.stamps .palette-buttons .stamp-button").eq(1).click();
     drawToolTile.getDrawTile()
-      .trigger("mousedown", 250, 100)
-      .trigger("mouseup");
+      .trigger("pointerdown", 250, 100)
+      .trigger("pointerup");
     drawToolTile.getImageDrawing().should("exist").and("have.length", 2);
     drawToolTile.getImageDrawing().eq(1).should("have.attr", "href").and("contain", "equals.png");
     drawToolTile.getDrawToolStampExpand().click();
     cy.get(".toolbar-palette.stamps .palette-buttons .stamp-button").eq(2).click();
     drawToolTile.getDrawTile()
-      .trigger("mousedown", 250, 150)
-      .trigger("mouseup");
+      .trigger("pointerdown", 250, 150)
+      .trigger("pointerup");
     drawToolTile.getImageDrawing().should("exist").and("have.length", 3);
     drawToolTile.getImageDrawing().eq(2).should("have.attr", "href").and("contain", "lparen.png");
 
@@ -507,8 +479,8 @@ context('Draw Tool Tile', function () {
     cy.log("adds text object");
     drawToolTile.getDrawToolText().click();
     drawToolTile.getDrawTile()
-      .trigger("mousedown", 100, 100)
-      .trigger("mouseup", 100, 100);
+      .trigger("pointerdown", 100, 100)
+      .trigger("pointerup", 100, 100);
     drawToolTile.getTextDrawing().should("exist").and("have.length", 1);
     // Select tool should be selected after object created
     drawToolTile.getDrawToolSelect().should("have.class", "selected");
@@ -522,16 +494,16 @@ context('Draw Tool Tile', function () {
     cy.log("edits text content of object");
     // Click inside drawing box to enter edit mode
     drawToolTile.getDrawTile()
-      .trigger("mousedown", 150, 150)
-      .trigger("mouseup", 150, 150);
+      .trigger("pointerdown", 150, 150)
+      .trigger("pointerup", 150, 150);
     drawToolTile.getTextDrawing().get('textarea').type("The five boxing wizards jump quickly.{enter}");
     drawToolTile.getTextDrawing().get('text tspan').should("exist").and("have.length", 7);
 
     cy.log("deletes text object");
     drawToolTile.getDrawToolSelect().click();
     drawToolTile.getDrawTile()
-      .trigger("mousedown", 150, 150)
-      .trigger("mouseup", 150, 150);
+      .trigger("pointerdown", 150, 150)
+      .trigger("pointerup", 150, 150);
     drawToolTile.getSelectionBox().should("exist");
     drawToolTile.getDrawToolDelete().should("not.have.class", "disabled").click();
     drawToolTile.getTextDrawing().should("not.exist");
@@ -543,26 +515,26 @@ context('Draw Tool Tile', function () {
     cy.log("can group and ungroup");
     drawToolTile.getDrawToolRectangle().click();
     drawToolTile.getDrawTile()
-      .trigger("mousedown", 250, 50)
-      .trigger("mousemove", 100, 150)
-      .trigger("mouseup", 100, 150);
+      .trigger("pointerdown", 250, 50)
+      .trigger("pointermove", 100, 150)
+      .trigger("pointerup", 100, 150);
     drawToolTile.getDrawToolEllipse().click();
     drawToolTile.getDrawTile()
-      .trigger("mousedown", 50, 100)
-      .trigger("mousemove", 100, 150)
-      .trigger("mouseup", 100, 150);
+      .trigger("pointerdown", 50, 100)
+      .trigger("pointermove", 100, 150)
+      .trigger("pointerup", 100, 150);
     drawToolTile.getDrawToolFreehand().click();
     drawToolTile.getDrawTile()
-      .trigger("mousedown", 150, 50)
-      .trigger("mousemove", 200, 150)
-      .trigger("mouseup", 200, 150);
+      .trigger("pointerdown", 150, 50)
+      .trigger("pointermove", 200, 150)
+      .trigger("pointerup", 200, 150);
 
     // Select all 3
     drawToolTile.getDrawToolSelect().click();
     drawToolTile.getDrawTile()
-      .trigger("mousedown", 40, 40)
-      .trigger("mousemove", 250, 150)
-      .trigger("mouseup", 250, 150);
+      .trigger("pointerdown", 40, 40)
+      .trigger("pointermove", 250, 150)
+      .trigger("pointerup", 250, 150);
     cy.wait(1000);
     drawToolTile.getSelectionBox().should("have.length", 3);
 

--- a/cypress/e2e/functional/tile_tests/drawing_tool_spec.js
+++ b/cypress/e2e/functional/tile_tests/drawing_tool_spec.js
@@ -214,7 +214,38 @@ context('Draw Tool Tile', function () {
       .trigger("pointerup", 260, 60);
     drawToolTile.getDrawToolDelete().click();
     drawToolTile.getVectorDrawing().should("not.exist");
+
+    cy.log("draws vector constrained to horizontal or vertical");
+    drawToolTile.getDrawToolVector().click();
+    drawToolTile.getDrawTile()
+      .trigger("pointerdown", 100, 100, { shiftKey: true })
+      .trigger("pointermove", 200, 110, { shiftKey: true }) // Y value is different, but should be constrained to horizontal
+      .trigger("pointerup",   200, 110, { shiftKey: true });
+    drawToolTile.getVectorDrawing().should("exist").and("have.length", 1);
+    drawToolTile.getVectorDrawing().get('line').invoke('attr', 'y1')
+      .then(y1 => {
+        drawToolTile.getVectorDrawing().get('line').invoke('attr', 'y2')
+        .should('eq', y1);
+      });
+    drawToolTile.getDrawToolDelete().click();
+    drawToolTile.getVectorDrawing().should("not.exist");
+
+    // Same for vertical vector
+    drawToolTile.getDrawToolVector().click();
+    drawToolTile.getDrawTile()
+      .trigger("pointerdown", 100, 25, { shiftKey: true })
+      .trigger("pointermove", 110, 125, { shiftKey: true }) // X value is different, but should be constrained to vertical
+      .trigger("pointerup",   110, 125, { shiftKey: true });
+    drawToolTile.getVectorDrawing().should("exist").and("have.length", 1);
+    drawToolTile.getVectorDrawing().get('line').invoke('attr', 'x1')
+      .then(x1 => {
+        drawToolTile.getVectorDrawing().get('line').invoke('attr', 'x2')
+        .should('eq', x1);
+      });
+    drawToolTile.getDrawToolDelete().click();
+    drawToolTile.getVectorDrawing().should("not.exist");
   });
+
   it("Rectangle", { scrollBehavior: false }, () => {
     beforeTest();
     clueCanvas.addTile("drawing");

--- a/cypress/support/elements/tile/DrawToolTile.js
+++ b/cypress/support/elements/tile/DrawToolTile.js
@@ -111,17 +111,36 @@ class DrawToolTile{
     drawRectangle(x, y, width=25, height=25) {
       this.getDrawToolRectangle().last().click();
       this.getDrawTile().last()
-        .trigger("mousedown", x, y)
-        .trigger("mousemove", x+width, y+height)
-        .trigger("mouseup", x+width, y+height);
+        .trigger("pointerdown", x, y)
+        .trigger("pointermove", x+width, y+height)
+        .trigger("pointerup", x+width, y+height);
     }
 
     drawEllipse(x, y, width=25, height=25) {
       this.getDrawToolEllipse().click();
       this.getDrawTile().last()
-        .trigger("mousedown", x, y)
-        .trigger("mousemove", x+width, y+height)
-        .trigger("mouseup", x+width, y+height);
+        .trigger("pointerdown", x, y)
+        .trigger("pointermove", x+width, y+height)
+        .trigger("pointerup", x+width, y+height);
+    }
+
+    drawVector(x, y, width=25, height=25) {
+      this.getDrawToolVector().click();
+      this.getDrawTile().last()
+        .trigger("pointerdown", x, y)
+        .trigger("pointermove", x+width, y+height)
+        .trigger("pointerup", x+width, y+height);
+    }
+
+    addText(x, y, text) {
+      this.getDrawToolText().click();
+      this.getDrawTile().last()
+        .trigger("pointerdown", x, y)
+        .trigger("pointerup", x, y);
+      this.getDrawTile().last()
+        .trigger("pointerdown", x, y)
+        .trigger("pointerup", x, y);
+      this.getTextDrawing().last().get('textarea').type(text + "{enter}");
     }
 
 }

--- a/src/plugins/drawing/components/drawing-layer.tsx
+++ b/src/plugins/drawing/components/drawing-layer.tsx
@@ -79,9 +79,12 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
   }
 
   public componentDidMount() {
-    // Prevent scrolling on touch devices
-    // For iPad, listeners must be registered as non-passive in order to prevent scrolling
-    // Check touches.length to allow scrolling with 2 fingers
+    // Prevent drag events from scrolling the window on touch devices,
+    // since drag gestures are needed for various sketching functions.
+    // For iPad, listeners must be registered as non-passive in order to prevent scrolling, see
+    // https://stackoverflow.com/questions/49500339/prevent-scrolling-when-touching-the-screen-in-ios
+    // We check touches.length and only intercept events when there is a single touch.
+    // This should allow for pinch-to-zoom and scrolling with 2 fingers to still work.
     this.viewRef.current?.addEventListener("touchstart", (e) => {
       if (e.touches.length === 1) e.preventDefault(); }, { passive: false });
     this.viewRef.current?.addEventListener("touchmove", (e) => {

--- a/src/plugins/drawing/components/drawing-layer.tsx
+++ b/src/plugins/drawing/components/drawing-layer.tsx
@@ -388,6 +388,7 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
       e2.preventDefault();
       window.removeEventListener("pointermove", handleResizeMove);
       window.removeEventListener("pointerup", handleResizecomplete);
+      handleResizeMove.flush(); // complete any movement pending in the debounce
       handle.classList.remove('active');
       object.resizeObject();
     };

--- a/src/plugins/drawing/components/drawing-layer.tsx
+++ b/src/plugins/drawing/components/drawing-layer.tsx
@@ -140,13 +140,13 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
     return drawingContent.currentStamp;
   }
 
-  public handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+  public handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
     if (!this.props.readOnly) {
-      this.getCurrentTool()?.handleMouseDown(e);
+      this.getCurrentTool()?.handlePointerDown(e);
     }
   };
 
-  public handleObjectClick = (e: MouseEvent|React.MouseEvent<any>, obj: DrawingObjectType) => {
+  public handleObjectClick = (e: PointerEvent|React.PointerEvent<any>, obj: DrawingObjectType) => {
     if (!this.props.readOnly) {
       this.getCurrentTool()?.handleObjectClick(e, obj);
     }
@@ -159,7 +159,7 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
   };
 
   // Handles click/drag of selected/hovered objects
-  public handleSelectedObjectMouseDown = (e: React.MouseEvent<any>, obj: DrawingObjectType) => {
+  public handleSelectedObjectPointerDown = (e: React.PointerEvent<any>, obj: DrawingObjectType) => {
     // Only the select tool does anything special when an object is clicked.
     // Other tools just let the click pass through to the canvas layer.
     if (this.props.readOnly || !this.getContent().isSelectedButton('select')) return;
@@ -200,7 +200,7 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
     e.stopPropagation();
     this.selectTile(false);
 
-    const handleMouseMove = (e2: MouseEvent) => {
+    const handlePointerMove = (e2: PointerEvent) => {
       e2.preventDefault();
       e2.stopPropagation();
 
@@ -226,11 +226,11 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
         needToAddHoverToSelection = false;
       }
     };
-    const handleMouseUp = (e2: MouseEvent) => {
+    const handlePointerUp = (e2: PointerEvent) => {
       e2.preventDefault();
       e2.stopPropagation();
-      window.removeEventListener("mousemove", handleMouseMove);
-      window.removeEventListener("mouseup", handleMouseUp);
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerup", handlePointerUp);
       if (moved) {
         objectsToMove.map((object, index) => {
           object.repositionObject();
@@ -240,8 +240,8 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
       }
     };
 
-    window.addEventListener("mousemove", handleMouseMove);
-    window.addEventListener("mouseup", handleMouseUp);
+    window.addEventListener("pointermove", handlePointerMove);
+    window.addEventListener("pointerup", handlePointerUp);
   };
 
   public startSelectionBox(p: Point) {
@@ -276,10 +276,10 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
   private conditionallyRenderObject(object: DrawingObjectType, selected: boolean, inGroup: boolean) {
     if (!object) return null;
     if (!selected && !object.visible) return null;
-    // Objects that are members of a group do not individually respond to mouse events.
+    // Objects that are members of a group do not individually respond to pointer events.
     const hoverAction = inGroup ? undefined : this.handleObjectHover;
-    const mouseDownAction = inGroup ? undefined : this.handleSelectedObjectMouseDown;
-    return renderDrawingObject(object, this.props.readOnly, hoverAction, mouseDownAction);
+    const pointerDownAction = inGroup ? undefined : this.handleSelectedObjectPointerDown;
+    return renderDrawingObject(object, this.props.readOnly, hoverAction, pointerDownAction);
   }
 
   public renderObjects() {
@@ -342,11 +342,11 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
                 x={x-resizeBoxOffset} y={y-resizeBoxOffset}
                 width={SELECTION_BOX_RESIZE_HANDLE_SIZE} height={SELECTION_BOX_RESIZE_HANDLE_SIZE}
                 stroke={color} strokeWidth="1" fill="#FFF" fillOpacity="1"
-                onMouseDown={(e) => this.handleResizeStart(e, object)}
+                onPointerDown={(e) => this.handleResizeStart(e, object)}
           />;
   }
 
-  private handleResizeStart(e: React.MouseEvent<SVGRectElement, MouseEvent>, object: DrawingObjectType) {
+  private handleResizeStart(e: React.PointerEvent<SVGRectElement>, object: DrawingObjectType) {
     e.stopPropagation();
     e.preventDefault();
     const handle = e.currentTarget;
@@ -359,10 +359,10 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
     const origWidth = origBoundingBox.se.x - origBoundingBox.nw.x;
     const origHeight = origBoundingBox.se.y - origBoundingBox.nw.y;
 
-    const handleResizeMove = debounce((e2: MouseEvent) => {
+    const handleResizeMove = debounce((e2: PointerEvent) => {
       e2.stopPropagation();
       e2.preventDefault();
-      // Check if mouse is within the drawtool canvas; if not do nothing.
+      // Check if pointer is within the drawtool canvas; if not do nothing.
       if (!((this.svgRef as unknown) as Element).matches(':hover')) {
         return;
       }
@@ -383,17 +383,17 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
 
     }, 10);
 
-    const handleResizecomplete = (e2: MouseEvent) => {
+    const handleResizecomplete = (e2: PointerEvent) => {
       e2.stopPropagation();
       e2.preventDefault();
-      window.removeEventListener("mousemove", handleResizeMove);
-      window.removeEventListener("mouseup", handleResizecomplete);
+      window.removeEventListener("pointermove", handleResizeMove);
+      window.removeEventListener("pointerup", handleResizecomplete);
       handle.classList.remove('active');
       object.resizeObject();
     };
 
-    window.addEventListener("mousemove", handleResizeMove);
-    window.addEventListener("mouseup", handleResizecomplete);
+    window.addEventListener("pointermove", handleResizeMove);
+    window.addEventListener("pointerup", handleResizecomplete);
   }
 
 
@@ -403,7 +403,7 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
     this.setState({currentDrawingObject: object});
   }
 
-  public getWorkspacePoint = (e: MouseEvent|React.MouseEvent<any>): Point|null => {
+  public getWorkspacePoint = (e: PointerEvent|React.PointerEvent<any>): Point|null => {
     if (this.svgRef) {
       const scale = this.props.scale || 1;
       const rect = ((this.svgRef as unknown) as Element).getBoundingClientRect();
@@ -428,9 +428,14 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
     }
 
     return (
+      // We don't propagate pointer events to the tile, since the drawing layer
+      // already handles selecting the tile when necessary and we don't want to
+      // deselect it when shift-click is used to select multiple drawing objects.
       <div className="drawing-layer"
           data-testid="drawing-layer"
-          onMouseDown={this.handleMouseDown}
+          onMouseDown={(e) => { e.stopPropagation(); }}
+          onTouchStart={(e) => { e.stopPropagation(); }}
+          onPointerDown={this.handlePointerDown}
           onDragOver={this.handleDragOver}
           onDragLeave={this.handleDragLeave}
           onDrop={this.handleDrop} >

--- a/src/plugins/drawing/components/drawing-layer.tsx
+++ b/src/plugins/drawing/components/drawing-layer.tsx
@@ -49,6 +49,7 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
     implements IDrawingLayer {
   static contextType = MobXProviderContext;
   public tools: DrawingToolMap;
+  private viewRef: React.RefObject<HTMLDivElement>;
   private svgRef: React.RefObject<any>|null;
   private setSvgRef: (element: any) => void;
   private _isMounted: boolean;
@@ -70,6 +71,7 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
       }
     });
 
+    this.viewRef = React.createRef();
     this.svgRef = null;
     this.setSvgRef = (element) => {
       this.svgRef = element;
@@ -77,6 +79,13 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
   }
 
   public componentDidMount() {
+    // Prevent scrolling on touch devices
+    // For iPad, listeners must be registered as non-passive in order to prevent scrolling
+    // Check touches.length to allow scrolling with 2 fingers
+    this.viewRef.current?.addEventListener("touchstart", (e) => {
+      if (e.touches.length === 1) e.preventDefault(); }, { passive: false });
+    this.viewRef.current?.addEventListener("touchmove", (e) => {
+      if (e.touches.length === 1) e.preventDefault(); }, { passive: false });
     this._isMounted = true;
   }
 
@@ -432,10 +441,10 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
       // We don't propagate pointer events to the tile, since the drawing layer
       // already handles selecting the tile when necessary and we don't want to
       // deselect it when shift-click is used to select multiple drawing objects.
-      <div className="drawing-layer"
+      <div ref={this.viewRef}
+          className="drawing-layer"
           data-testid="drawing-layer"
           onMouseDown={(e) => { e.stopPropagation(); }}
-          onTouchStart={(e) => { e.stopPropagation(); }}
           onPointerDown={this.handlePointerDown}
           onDragOver={this.handleDragOver}
           onDragLeave={this.handleDragLeave}

--- a/src/plugins/drawing/components/selection-drawing-tool.tsx
+++ b/src/plugins/drawing/components/selection-drawing-tool.tsx
@@ -7,7 +7,7 @@ export class SelectionDrawingTool extends DrawingTool {
     super(drawingLayer);
   }
 
-  public handleMouseDown(e: React.MouseEvent<HTMLDivElement>) {
+  public handlePointerDown(e: React.PointerEvent<HTMLDivElement>) {
     const drawingLayerView = this.drawingLayer;
     const addToSelectedObjects = e.ctrlKey || e.metaKey || e.shiftKey;
     const start = this.drawingLayer.getWorkspacePoint(e);
@@ -19,7 +19,7 @@ export class SelectionDrawingTool extends DrawingTool {
 
     drawingLayerView.startSelectionBox(start);
 
-    const handleMouseMove = (e2: MouseEvent) => {
+    const handlePointerMove = (e2: PointerEvent) => {
       e2.preventDefault();
       if (!moved) {
         // User started to drag. Make sure tile is selected.
@@ -31,11 +31,11 @@ export class SelectionDrawingTool extends DrawingTool {
       drawingLayerView.updateSelectionBox(p);
     };
 
-    const handleMouseUp = (e2: MouseEvent) => {
+    const handlePointerUp = (e2: PointerEvent) => {
       e2.preventDefault();
       drawingLayerView.endSelectionBox(addToSelectedObjects);
-      window.removeEventListener("mousemove", handleMouseMove);
-      window.removeEventListener("mouseup", handleMouseUp);
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerup", handlePointerUp);
 
       if (!moved) {
         // User just clicked on the canvas w/no drag. They may be trying to select or deselect the tile.
@@ -43,11 +43,11 @@ export class SelectionDrawingTool extends DrawingTool {
       }
     };
 
-    window.addEventListener("mousemove", handleMouseMove);
-    window.addEventListener("mouseup", handleMouseUp);
+    window.addEventListener("pointermove", handlePointerMove);
+    window.addEventListener("pointerup", handlePointerUp);
   }
 
-  public handleObjectClick(e: React.MouseEvent<HTMLDivElement>, obj: DrawingObjectType) {
+  public handleObjectClick(e: React.PointerEvent<HTMLDivElement>, obj: DrawingObjectType) {
     const selectedObjects = this.drawingLayer.getSelectedObjects();
     const index = selectedObjects.indexOf(obj);
     if (index === -1) {

--- a/src/plugins/drawing/objects/drawing-object.tsx
+++ b/src/plugins/drawing/objects/drawing-object.tsx
@@ -193,7 +193,7 @@ export type HandleObjectHover =
   (e: MouseEvent|React.MouseEvent<any>, obj: DrawingObjectType, hovering: boolean) => void;
 
 export type HandleObjectDrag =
-(e: React.MouseEvent<any>, obj: DrawingObjectType) => void;
+(e: React.PointerEvent<any>, obj: DrawingObjectType) => void;
 
 export interface IDrawingComponentProps {
   model: DrawingObjectType;
@@ -206,7 +206,7 @@ export type DrawingComponentType = React.ComponentType<IDrawingComponentProps>;
 
 export interface IDrawingLayer {
   selectTile: (append: boolean) => void;
-  getWorkspacePoint: (e:MouseEvent|React.MouseEvent) => Point|null;
+  getWorkspacePoint: (e:PointerEvent|React.PointerEvent) => Point|null;
   setCurrentDrawingObject: (object: DrawingObjectType|null) => void;
   addNewDrawingObject:
     (object: DrawingObjectSnapshotForAdd,
@@ -227,11 +227,11 @@ export abstract class DrawingTool {
     this.drawingLayer = drawingLayer;
   }
 
-  public handleMouseDown(e: React.MouseEvent<HTMLDivElement>): void {
+  public handlePointerDown(e: React.PointerEvent<HTMLDivElement>): void {
     // handled in subclass
   }
 
-  public handleObjectClick(e: MouseEvent|React.MouseEvent<any>, obj: DrawingObjectType): void   {
+  public handleObjectClick(e: PointerEvent|React.PointerEvent<any>, obj: DrawingObjectType): void   {
     // handled in subclass
   }
 }

--- a/src/plugins/drawing/objects/ellipse.tsx
+++ b/src/plugins/drawing/objects/ellipse.tsx
@@ -81,7 +81,7 @@ export const EllipseComponent = observer(function EllipseComponent({model, handl
     strokeDasharray={computeStrokeDashArray(strokeDashArray, strokeWidth)}
     onMouseEnter={(e) => handleHover ? handleHover(e, model, true) : null}
     onMouseLeave={(e) => handleHover ? handleHover(e, model, false) : null}
-    onMouseDown={(e)=> handleDrag?.(e, model)}
+    onPointerDown={(e)=> handleDrag?.(e, model)}
     pointerEvents={handleHover ? "visible" : "none"}
   />;
 });
@@ -92,7 +92,7 @@ export class EllipseDrawingTool extends DrawingTool {
     super(drawingLayer);
   }
 
-  public handleMouseDown(e: React.MouseEvent<HTMLDivElement>) {
+  public handlePointerDown(e: React.PointerEvent<HTMLDivElement>) {
     // Select the drawing tile, but don't propagate event to do normal Cmd-click procesing.
     this.drawingLayer.selectTile(false);
     e.stopPropagation();
@@ -108,7 +108,7 @@ export class EllipseDrawingTool extends DrawingTool {
       stroke, fill, strokeWidth, strokeDashArray
     });
 
-    const handleMouseMove = (e2: MouseEvent) => {
+    const handlePointerMove = (e2: PointerEvent) => {
       e2.preventDefault();
       const end = this.drawingLayer.getWorkspacePoint(e2);
       if (!end) return;
@@ -116,18 +116,18 @@ export class EllipseDrawingTool extends DrawingTool {
       ellipse.resize(start, end, makeCircle);
       this.drawingLayer.setCurrentDrawingObject(ellipse);
     };
-    const handleMouseUp = (e2: MouseEvent) => {
+    const handlePointerUp = (e2: PointerEvent) => {
       e2.preventDefault();
       if ((ellipse.rx > 0) && (ellipse.ry > 0)) {
         this.drawingLayer.addNewDrawingObject(getSnapshot(ellipse));
       }
       this.drawingLayer.setCurrentDrawingObject(null);
-      window.removeEventListener("mousemove", handleMouseMove);
-      window.removeEventListener("mouseup", handleMouseUp);
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerup", handlePointerUp);
     };
 
     this.drawingLayer.setCurrentDrawingObject(ellipse);
-    window.addEventListener("mousemove", handleMouseMove);
-    window.addEventListener("mouseup", handleMouseUp);
+    window.addEventListener("pointermove", handlePointerMove);
+    window.addEventListener("pointerup", handlePointerUp);
   }
 }

--- a/src/plugins/drawing/objects/group.tsx
+++ b/src/plugins/drawing/objects/group.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 import { observer } from "mobx-react";
 import { Instance, SnapshotIn, getMembers, isAlive, types } from "mobx-state-tree";
-import { DrawingObject, DrawingObjectType, IDrawingComponentProps, 
-  StrokedObjectType, 
-  isFilledObject, 
-  isStrokedObject, 
-  typeField, 
+import { DrawingObject, DrawingObjectType, IDrawingComponentProps,
+  StrokedObjectType,
+  isFilledObject,
+  isStrokedObject,
+  typeField,
   ObjectTypeIconViewBox} from "./drawing-object";
 import { BoundingBoxSides, VectorEndShape } from "../model/drawing-basic-types";
 import { DrawingObjectMSTUnion } from "../components/drawing-object-manager";
@@ -15,7 +15,7 @@ import GroupObjectsIcon from "../assets/group-objects-icon.svg";
 // An "extent" represents the position of each side of a member object's bounding box,
 // as a fraction of the group's overall bounding box.
 // The members' extents are stored when the group is created and never changed.
-// This avoids objects getting distorted by rounding error if the group is 
+// This avoids objects getting distorted by rounding error if the group is
 // resized to, say, 1 pixel and then expanded again.
 const Extents = types.model("Extents")
 .props({
@@ -64,15 +64,15 @@ export const GroupObject = DrawingObject.named("GroupObject")
     },
     setStrokeDashArray(strokeDashArray: string) {
       self.objects.forEach((member) => {
-        if (getMembers(member).actions.includes("setStrokeDashArray")) { 
-          (member as StrokedObjectType).setStrokeDashArray(strokeDashArray); 
+        if (getMembers(member).actions.includes("setStrokeDashArray")) {
+          (member as StrokedObjectType).setStrokeDashArray(strokeDashArray);
         }
       });
     },
     setStrokeWidth(strokeWidth: number) {
       self.objects.forEach((member) => {
-        if (getMembers(member).actions.includes("setStrokeWidth")) { 
-          (member as StrokedObjectType).setStrokeWidth(strokeWidth); 
+        if (getMembers(member).actions.includes("setStrokeWidth")) {
+          (member as StrokedObjectType).setStrokeWidth(strokeWidth);
         }
       });
     },
@@ -104,7 +104,7 @@ export const GroupObject = DrawingObject.named("GroupObject")
       });
     },
     setDragBounds(deltas: BoundingBoxSides) {
-      // Each contained object gets adjusted in proportion to its 
+      // Each contained object gets adjusted in proportion to its
       // size relative to the whole group's size.
       self.objects.forEach((obj) => {
         // How much to adjust each side of the object.
@@ -153,7 +153,7 @@ export const GroupComponent = observer(function GroupComponent(
     fill="none"
     onMouseEnter={(e) => handleHover ? handleHover(e, model, true) : null}
     onMouseLeave={(e) => handleHover ? handleHover(e, model, false) : null}
-    onMouseDown={(e)=> handleDrag?.(e, model)}
+    onPointerDown={(e)=> handleDrag?.(e, model)}
     pointerEvents={"visible"}
    />;
 });

--- a/src/plugins/drawing/objects/image.tsx
+++ b/src/plugins/drawing/objects/image.tsx
@@ -103,7 +103,7 @@ export const ImageComponent: React.FC<IDrawingComponentProps> = observer(functio
     preserveAspectRatio="none"
     onMouseEnter={(e) => handleHover ? handleHover(e, model, true) : null}
     onMouseLeave={(e) => handleHover ? handleHover(e, model, false) : null}
-    onMouseDown={(e)=> handleDrag?.(e, model)}
+    onPointerDown={(e)=> handleDrag?.(e, model)}
     pointerEvents={handleHover ? "visible" : "none"}
   />;
 
@@ -115,7 +115,7 @@ export class StampDrawingTool extends DrawingTool {
     super(drawingLayer);
   }
 
-  public handleMouseDown(e: React.MouseEvent<HTMLDivElement>) {
+  public handlePointerDown(e: React.PointerEvent<HTMLDivElement>) {
     // Select the drawing tile, but don't propagate event to do normal Cmd-click procesing.
     this.drawingLayer.selectTile(false);
     e.stopPropagation();

--- a/src/plugins/drawing/objects/line.tsx
+++ b/src/plugins/drawing/objects/line.tsx
@@ -141,7 +141,7 @@ export const LineComponent = observer(function LineComponent({model, handleHover
     strokeDasharray={computeStrokeDashArray(strokeDashArray, strokeWidth)}
     onMouseEnter={(e) => handleHover ? handleHover(e, model, true) : null}
     onMouseLeave={(e) => handleHover ? handleHover(e, model, false) : null}
-    onMouseDown={(e)=> handleDrag?.(e, model)}
+    onPointerDown={(e)=> handleDrag?.(e, model)}
     pointerEvents={handleHover ? "visible" : "none"}
   />;
 });
@@ -153,7 +153,7 @@ export class LineDrawingTool extends DrawingTool {
     this.drawingLayer = drawingLayer;
   }
 
-  public handleMouseDown(e: React.MouseEvent<HTMLDivElement>) {
+  public handlePointerDown(e: React.PointerEvent<HTMLDivElement>) {
     // Select the drawing tile, but don't propagate event to do normal Cmd-click procesing.
     this.drawingLayer.selectTile(false);
     e.stopPropagation();
@@ -165,7 +165,7 @@ export class LineDrawingTool extends DrawingTool {
       deltaPoints: [], stroke, strokeWidth, strokeDashArray});
 
     let lastPoint = start;
-    const addPoint = (e2: MouseEvent|React.MouseEvent<HTMLDivElement>) => {
+    const addPoint = (e2: PointerEvent|React.PointerEvent<HTMLDivElement>) => {
       const p = this.drawingLayer.getWorkspacePoint(e2);
       if (p && (p.x >= 0) && (p.y >= 0)) {
         line.addPoint({dx: p.x - lastPoint.x, dy: p.y - lastPoint.y});
@@ -174,24 +174,24 @@ export class LineDrawingTool extends DrawingTool {
       }
     };
 
-    const handleMouseMove = (e2: MouseEvent) => {
+    const handlePointerMove = (e2: PointerEvent) => {
       e2.preventDefault();
       addPoint(e2);
     };
-    const handleMouseUp = (e2: MouseEvent) => {
+    const handlePointerUp = (e2: PointerEvent) => {
       e2.preventDefault();
       if (line.deltaPoints.length > 0) {
         addPoint(e2);
         this.drawingLayer.addNewDrawingObject(getSnapshot(line), { keepToolActive: true });
       }
       this.drawingLayer.setCurrentDrawingObject(null);
-      window.removeEventListener("mousemove", handleMouseMove);
-      window.removeEventListener("mouseup", handleMouseUp);
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerup", handlePointerUp);
     };
 
     this.drawingLayer.setCurrentDrawingObject(line);
-    window.addEventListener("mousemove", handleMouseMove);
-    window.addEventListener("mouseup", handleMouseUp);
+    window.addEventListener("pointermove", handlePointerMove);
+    window.addEventListener("pointerup", handlePointerUp);
   }
 }
 

--- a/src/plugins/drawing/objects/rectangle.tsx
+++ b/src/plugins/drawing/objects/rectangle.tsx
@@ -107,7 +107,7 @@ export const RectangleComponent = observer(function RectangleComponent({model, h
     strokeDasharray={computeStrokeDashArray(strokeDashArray, strokeWidth)}
     onMouseEnter={(e) => handleHover ? handleHover(e, model, true) : null}
     onMouseLeave={(e) => handleHover ? handleHover(e, model, false) : null}
-    onMouseDown={(e)=> handleDrag?.(e, model)}
+    onPointerDown={(e)=> handleDrag?.(e, model)}
     pointerEvents={handleHover ? "visible" : "none"}
   />;
 
@@ -119,7 +119,7 @@ export class RectangleDrawingTool extends DrawingTool {
     super(drawingLayer);
   }
 
-  public handleMouseDown(e: React.MouseEvent<HTMLDivElement>) {
+  public handlePointerDown(e: React.PointerEvent<HTMLDivElement>) {
     // Select the drawing tile, but don't propagate event to do normal Cmd-click procesing.
     this.drawingLayer.selectTile(false);
     e.stopPropagation();
@@ -135,7 +135,7 @@ export class RectangleDrawingTool extends DrawingTool {
       stroke, fill, strokeWidth, strokeDashArray
     });
 
-    const handleMouseMove = (e2: MouseEvent) => {
+    const handlePointerMove = (e2: PointerEvent) => {
       e2.preventDefault();
       const end = this.drawingLayer.getWorkspacePoint(e2);
       if (!end) return;
@@ -143,19 +143,19 @@ export class RectangleDrawingTool extends DrawingTool {
       rectangle.resize(start, end, makeSquare);
       this.drawingLayer.setCurrentDrawingObject(rectangle);
     };
-    const handleMouseUp = (e2: MouseEvent) => {
+    const handlePointerUp = (e2: PointerEvent) => {
       e2.preventDefault();
       if ((rectangle.width > 0) && (rectangle.height > 0)) {
         this.drawingLayer.addNewDrawingObject(getSnapshot(rectangle));
       }
       this.drawingLayer.setCurrentDrawingObject(null);
-      window.removeEventListener("mousemove", handleMouseMove);
-      window.removeEventListener("mouseup", handleMouseUp);
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerup", handlePointerUp);
     };
 
     this.drawingLayer.setCurrentDrawingObject(rectangle);
-    window.addEventListener("mousemove", handleMouseMove);
-    window.addEventListener("mouseup", handleMouseUp);
+    window.addEventListener("pointermove", handlePointerMove);
+    window.addEventListener("pointerup", handlePointerUp);
   }
 }
 

--- a/src/plugins/drawing/objects/text.tsx
+++ b/src/plugins/drawing/objects/text.tsx
@@ -112,7 +112,7 @@ export const TextComponent = observer(
             defaultValue={text}
             onBlur={(e) => handleClose(true)}
             onKeyDown={handleTextAreaKeyDown}
-            onMouseDown={handleTextAreaMouseDown}>
+            onPointerDown={handleTextAreaPointerDown}>
           </textarea>
         </foreignObject>);
     } else {
@@ -126,7 +126,7 @@ export const TextComponent = observer(
     }
   };
 
-  const handleTextAreaMouseDown = (e: React.MouseEvent<HTMLTextAreaElement>) => {
+  const handleTextAreaPointerDown = (e: React.PointerEvent<HTMLTextAreaElement>) => {
     e.stopPropagation();
   };
 
@@ -159,7 +159,7 @@ export const TextComponent = observer(
           className="text"
           onMouseEnter={(e) => handleHover?.(e, model, true)}
           onMouseLeave={(e) => handleHover?.(e, model, false)}
-          onMouseDown={(e)=> handleDrag?.(e, model)}
+          onPointerDown={(e)=> handleDrag?.(e, model)}
           pointerEvents={handleHover ? "visible" : "none"}
          >
           <rect x={x} y={y}
@@ -180,7 +180,7 @@ export class TextDrawingTool extends DrawingTool {
     super(drawingLayer);
   }
 
-  public handleMouseDown(e: React.MouseEvent<HTMLDivElement>) {
+  public handlePointerDown(e: React.PointerEvent<HTMLDivElement>) {
     // Select the drawing tile, but don't propagate event to do normal Cmd-click procesing.
     this.drawingLayer.selectTile(false);
     e.stopPropagation();

--- a/src/plugins/drawing/objects/vector.tsx
+++ b/src/plugins/drawing/objects/vector.tsx
@@ -111,7 +111,7 @@ export const VectorComponent = observer(function VectorComponent({model, handleH
       strokeDasharray={computeStrokeDashArray(strokeDashArray, strokeWidth)}
       onMouseEnter={(e) => handleHover ? handleHover(e, model, true) : null}
       onMouseLeave={(e) => handleHover ? handleHover(e, model, false) : null}
-      onMouseDown={(e) => handleDrag?.(e, model)}
+      onPointerDown={(e) => handleDrag?.(e, model)}
       pointerEvents={handleHover ? "visible" : "none"}
     >
       {line}{head}{tail}
@@ -140,7 +140,7 @@ export class VectorDrawingTool extends DrawingTool {
     super(drawingLayer);
   }
 
-  public handleMouseDown(e: React.MouseEvent<HTMLDivElement>) {
+  public handlePointerDown(e: React.PointerEvent<HTMLDivElement>) {
     // Select the drawing tile, but don't propagate event to do normal Cmd-click procesing.
     this.drawingLayer.selectTile(false);
     e.stopPropagation();
@@ -156,7 +156,7 @@ export class VectorDrawingTool extends DrawingTool {
       dy: 0,
       headShape, tailShape, stroke, strokeWidth, strokeDashArray});
 
-    const handleMouseMove = (e2: MouseEvent) => {
+    const handlePointerMove = (e2: PointerEvent) => {
       e2.preventDefault();
       const end = this.drawingLayer.getWorkspacePoint(e2);
       if (!end) return;
@@ -172,19 +172,19 @@ export class VectorDrawingTool extends DrawingTool {
       vector.setDeltas(dx, dy);
       this.drawingLayer.setCurrentDrawingObject(vector);
     };
-    const handleMouseUp = (e2: MouseEvent) => {
+    const handlePointerUp = (e2: PointerEvent) => {
       e2.preventDefault();
       if ((vector.dx !== 0) || (vector.dy !== 0)) {
         this.drawingLayer.addNewDrawingObject(getSnapshot(vector));
       }
       this.drawingLayer.setCurrentDrawingObject(null);
-      window.removeEventListener("mousemove", handleMouseMove);
-      window.removeEventListener("mouseup", handleMouseUp);
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerup", handlePointerUp);
     };
 
     this.drawingLayer.setCurrentDrawingObject(vector);
-    window.addEventListener("mousemove", handleMouseMove);
-    window.addEventListener("mouseup", handleMouseUp);
+    window.addEventListener("pointermove", handlePointerMove);
+    window.addEventListener("pointerup", handlePointerUp);
   }
 }
 

--- a/src/plugins/shared-variables/drawing/variable-object.tsx
+++ b/src/plugins/shared-variables/drawing/variable-object.tsx
@@ -92,7 +92,7 @@ export const VariableChipComponent: React.FC<IDrawingComponentProps> = observer(
         height={height}
         onMouseEnter={(e) => handleHover ? handleHover(e, model, true) : null }
         onMouseLeave={(e) => handleHover ? handleHover(e, model, false) : null }
-        onMouseDown={(e)=> handleDrag?.(e, model)}
+        onPointerDown={(e)=> handleDrag?.(e, model)}
         pointerEvents={handleHover ? "visible" : "none"}
       >
         <span ref={variableChipRef} className="drawing-variable-container">


### PR DESCRIPTION
This PR is mostly a big search-and-replace that uses `PointerEvent`s rather than `MouseEvent`s to draw, thus allowing drawing on touch devices like the iPad and touchscreen Chromebooks.

Some mild refactoring in Cypress tests so that the events used are not in so many different places.

One slight complication is the need to separately `stopPropagation` on `touchStart` and `mouseDown` in order to prevent the `TileComponent` from interpreting these as tile selection.  It listens for both of these rather than Pointer events, and if propagation is not stopped, as you use shift-click to select multiple drawing objects, the tile keeps switching between selected and deselected.