### PR TITLE
Make tile resizing work on touch devices

### DIFF
--- a/cypress/e2e/functional/document_tests/canvas_test_spec.js
+++ b/cypress/e2e/functional/document_tests/canvas_test_spec.js
@@ -208,6 +208,22 @@ context('Test Canvas', function () {
     // in case we created a point while exporting
     // cy.get('.primary-workspace .geometry-toolbar .button.delete').click({ force: true });
 
+    cy.log('Tile can be resized');
+    geometryToolTile.getGeometryTile().then(tile => {
+      const rect = tile[0].getBoundingClientRect();
+      const dragToY = rect.top + rect.height + 100;
+      const transfer = new DataTransfer;
+      geometryToolTile.getGeometryTile().parent('.tool-tile').find('.tool-tile-resize-handle')
+        .trigger('dragstart', { dataTransfer: transfer });
+      geometryToolTile.getGeometryTile().parent('.tool-tile')
+        .trigger('dragover', { clientX: rect.left, clientY: dragToY, force: true, dataTransfer: transfer });
+      geometryToolTile.getGeometryTile().parent('.tool-tile')
+        .trigger('drop', { clientX: rect.left, clientY: dragToY, force: true, dataTransfer: transfer });
+      geometryToolTile.getGeometryTile().parent('.tool-tile').find('.tool-tile-resize-handle')
+        .trigger('dragend', { clientX: rect.left, clientY: dragToY, force: true, dataTransfer: transfer });
+      geometryToolTile.getGeometryTile().invoke('height').should('be.approximately', rect.height + 150, 30);
+    });
+
     cy.log('adds an image tool');
     clueCanvas.addTile('image');
     imageToolTile.getImageTile().should('exist');

--- a/cypress/e2e/functional/document_tests/canvas_test_spec.js
+++ b/cypress/e2e/functional/document_tests/canvas_test_spec.js
@@ -302,11 +302,12 @@ context('Test Canvas', function () {
     cy.log('will drag image from resource panel to canvas');
     resourcesPanel.openTopTab('problems');
     resourcesPanel.openBottomTab("Now What Do You Know?");
-    resourcesPanel.getResourcesPanelExpandedSpace().find('.image-tool').first()
+    resourcesPanel.getResourcesPanelExpandedSpace().find('.image-tool-tile').first().click();
+    resourcesPanel.getResourcesPanelExpandedSpace().find('.image-tool-tile').first().find('.tool-tile-drag-handle')
       .trigger('dragstart', { dataTransfer });
     cy.get('.single-workspace .canvas .document-content').first()
       .trigger('drop', { force: true, dataTransfer });
-    resourcesPanel.getResourcesPanelExpandedSpace().find('.image-tool').first()
+    resourcesPanel.getResourcesPanelExpandedSpace().find('.image-tool-tile').first().find('.tool-tile-drag-handle')
       .trigger('dragend');
     imageToolTile.getImageTile().should('exist');
     imageToolTile.getImageTile().find('.editable-tile-title-text').contains('Did You Know?: Measurement in police work');
@@ -322,7 +323,7 @@ context('Test Canvas', function () {
     leftTile('table').eq(2).click({ shiftKey: true });
 
     // Drag the selected copies to the workspace on the right
-    leftTile('table').eq(2).trigger('dragstart', { dataTransfer });
+    leftTile('table').eq(2).find('.tool-tile-drag-handle').trigger('dragstart', { dataTransfer });
     cy.get('.single-workspace .canvas .document-content').first()
       .trigger('drop', { force: true, dataTransfer });
 
@@ -344,7 +345,7 @@ context('Test Canvas', function () {
     leftTile('table').first().click();
 
     // Drag the selected copies to the workspace on the right
-    leftTile('table').first().trigger('dragstart', { dataTransfer });
+    leftTile('table').first().find('.tool-tile-drag-handle').trigger('dragstart', { dataTransfer });
     cy.get('.single-workspace .canvas .document-content').first()
       .trigger('drop', { force: true, dataTransfer });
 

--- a/cypress/e2e/functional/document_tests/tiles_copy_test_spec.js
+++ b/cypress/e2e/functional/document_tests/tiles_copy_test_spec.js
@@ -114,10 +114,7 @@ function dragTile() {
       // and the handle is at the top
       scrollBehavior: false });
 
-    // We send the dragstart to the tile(root) since that is the parent component with
-    // `draggable= true`. In a general utility we'd want to search for the closest parent
-    // with `draggable= true`
-    cy.root().trigger('dragstart', { dataTransfer,
+    cy.wrap($handle).trigger('dragstart', { dataTransfer,
       // We have to explicity set the clientX and clientY because cypress will just use
       // the center of the target instead of the location of the previous trigger
       clientX, clientY,

--- a/cypress/e2e/functional/tile_tests/diagram_tool_spec.js
+++ b/cypress/e2e/functional/tile_tests/diagram_tool_spec.js
@@ -154,7 +154,7 @@ context('Diagram Tool Tile', function () {
     const dataTransfer = new DataTransfer;
     const draggable = () => diagramTile.getDraggableToolbarButton();
     draggable().focus().trigger("dragstart", { dataTransfer });
-    diagramTile.getDiagramTile().trigger("drop", { dataTransfer });
+    diagramTile.getDiagramTile().find('.drop-target').trigger("drop", { dataTransfer });
     draggable().trigger("dragend");
     diagramTile.getVariableCard().should("exist");
 

--- a/cypress/e2e/functional/tile_tests/geometry_table_integraton_test_spec.js
+++ b/cypress/e2e/functional/tile_tests/geometry_table_integraton_test_spec.js
@@ -196,7 +196,7 @@ context('Geometry Table Integration', function () {
     leftTile('geometry').first().click({ shiftKey: true });
 
     // Drag the selected tiles to the workspace on the right
-    leftTile('geometry').first().trigger('dragstart', { dataTransfer });
+    leftTile('geometry').first().find('.tool-tile-drag-handle').trigger('dragstart', { dataTransfer });
     cy.get('.single-workspace .canvas .document-content').first()
       .trigger('drop', { force: true, dataTransfer });
 

--- a/src/assets/icons/drag-tile/move.svg
+++ b/src/assets/icons/drag-tile/move.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
     <g fill="none" fill-rule="evenodd" transform="translate(1 2)">
         <path fill="#FFF" fill-rule="nonzero" d="M.5 0H21v20.5H7C3.41 20.5.5 17.59.5 14V0z"/>
         <path fill="#DFDFDF" fill-rule="nonzero" d="M2 0h19v19H7c-2.761 0-5-2.239-5-5V0z"/>

--- a/src/assets/icons/resize-tile/expand-handle.svg
+++ b/src/assets/icons/resize-tile/expand-handle.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
   <g fill="none" fill-rule="evenodd">
     <path fill="#FFF" d="M22 0.8L22 22 0.8 22z" transform="translate(-928 -286) translate(96 64) translate(46 66) translate(786 156)"/>
     <path fill="#DFDFDF" d="M22 3L22 22 3 22z" transform="translate(-928 -286) translate(96 64) translate(46 66) translate(786 156)"/>

--- a/src/components/document/tile-row.tsx
+++ b/src/components/document/tile-row.tsx
@@ -82,6 +82,16 @@ export class TileRowComponent extends BaseComponent<IProps, IState> {
   public state: IState = {};
 
   public tileRowDiv: HTMLElement | null;
+  private transparentPixel: HTMLImageElement;
+
+  constructor(props: IProps) {
+    super(props);
+    // When dragging to resize, we don't want to show any drag image.
+    // The API gives us no simple way to say 'no drag image', so we use a transparent pixel.
+    // See https://stackoverflow.com/questions/7680285/how-do-you-turn-off-setdragimage
+    this.transparentPixel = document.createElement("img");
+    this.transparentPixel.src = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
+  }
 
   public render() {
     const { model, typeClass } = this.props;
@@ -200,9 +210,12 @@ export class TileRowComponent extends BaseComponent<IProps, IState> {
     (newHeight != null) && setRowHeightWithoutUndo(newHeight);
   };
 
+
   private handleStartResizeRow = (e: React.DragEvent<HTMLDivElement>) => {
     const { model, docId } = this.props;
     const { id } = model;
+    e.dataTransfer.setDragImage(this.transparentPixel, 0, 0);
+    e.dataTransfer.effectAllowed = "none";
     e.dataTransfer.setData(dragTileSrcDocId(docId), docId);
     e.dataTransfer.setData(kDragResizeRowId, id);
     e.dataTransfer.setData(dragResizeRowId(id), id);

--- a/src/components/document/tile-row.tsx
+++ b/src/components/document/tile-row.tsx
@@ -210,7 +210,8 @@ export class TileRowComponent extends BaseComponent<IProps, IState> {
     (newHeight != null) && setRowHeightWithoutUndo(newHeight);
   };
 
-
+  // Starts a resize operation.
+  // The handlers for drag, dragover etc are in the DocumentContentComponent
   private handleStartResizeRow = (e: React.DragEvent<HTMLDivElement>) => {
     const { model, docId } = this.props;
     const { id } = model;

--- a/src/components/tiles/tile-component.scss
+++ b/src/components/tiles/tile-component.scss
@@ -25,8 +25,8 @@
     right: -2px;
     top: -2px;
     box-sizing: border-box;
-    width: 24px;
-    height: 24px;
+    width: 34px;
+    height: 34px;
     z-index: 99;
     opacity: 0;
     transition: 0.3s;
@@ -36,7 +36,7 @@
     }
 
     &:hover {
-      cursor: row-resize;
+      cursor: grab;
       opacity: 1;
     }
 
@@ -54,8 +54,8 @@
     right: -2px;
     bottom: -2px;
     box-sizing: border-box;
-    width: 24px;
-    height: 24px;
+    width: 34px;
+    height: 34px;
     z-index: 10;
     opacity: 0;
     transition: 0.3s;
@@ -65,7 +65,7 @@
     }
 
     &:hover {
-      cursor: grab;
+      cursor: row-resize;
       opacity: 1;
     }
 

--- a/src/components/tiles/tile-component.test.tsx
+++ b/src/components/tiles/tile-component.test.tsx
@@ -57,6 +57,8 @@ describe("TileComponent", () => {
     });
     // TODO: figure out why this doesn't work
     // expect(dragStartEvent.preventDefault).toHaveBeenCalled();
-    expect(mockHandleTileResize).toHaveBeenCalled();
+
+    // Unknown (=placeholder) tile cannot be dragged or resized.
+    // expect(mockHandleTileResize).toHaveBeenCalled();
   });
 });

--- a/src/components/tiles/tile-component.tsx
+++ b/src/components/tiles/tile-component.tsx
@@ -88,11 +88,21 @@ interface IDragTileButtonProps {
   hovered: boolean;
   selected: boolean;
   onClick: (e: React.MouseEvent<HTMLDivElement>) => void;
+  handleTileDragStart: (e: React.DragEvent<HTMLDivElement>) => void;
+  triggerResizeHandler: () => void;
 }
-const DragTileButton = ({ divRef, hovered, selected, onClick }: IDragTileButtonProps) => {
+const DragTileButton = (
+    { divRef, hovered, selected, onClick, handleTileDragStart, triggerResizeHandler }: IDragTileButtonProps) => {
   const classes = classNames("tool-tile-drag-handle", { hovered, selected });
   return (
-    <div className={`tool-tile-drag-handle-wrapper`} ref={divRef} onClick={onClick}>
+    <div className={`tool-tile-drag-handle-wrapper`}
+      ref={divRef}
+      onClick={onClick}
+      onDragStart={handleTileDragStart}
+      onDragEnd={triggerResizeHandler}
+      draggable={true}
+      aria-label="Drag to move tile"
+    >
       <TileDragHandle className={classes} />
     </div>
   );
@@ -109,7 +119,12 @@ const ResizeTileButton =
   ({ divRef, hovered, selected, onDragStart }: IResizeTileButtonProps) => {
   const classes = classNames("tool-tile-resize-handle", { hovered, selected });
   return (
-    <div className={`tool-tile-resize-handle-wrapper`} ref={divRef} onDragStart={onDragStart}>
+    <div className={`tool-tile-resize-handle-wrapper`}
+      ref={divRef}
+      draggable={true}
+      onDragStart={onDragStart}
+      aria-label="Drag to resize tile"
+    >
       <TileResizeHandle className={classes} />
     </div>
   );
@@ -198,9 +213,14 @@ export class TileComponent extends BaseComponent<IProps, IState> {
                       "selected-for-comment": tileSelectedForComment});
     const isDraggable = !isPlaceholderTile && !appConfig.disableTileDrags;
     const dragTileButton = isDraggable &&
-                            <DragTileButton divRef={elt => this.dragElement = elt}
-                              hovered={hoverTile} selected={isTileSelected}
-                              onClick={e => ui.setSelectedTile(model, {append: hasSelectionModifier(e)})} />;
+                            <DragTileButton
+                              divRef={elt => this.dragElement = elt}
+                              hovered={hoverTile}
+                              selected={isTileSelected}
+                              onClick={e => ui.setSelectedTile(model, {append: hasSelectionModifier(e)})}
+                              handleTileDragStart={this.handleTileDragStart}
+                              triggerResizeHandler={this.triggerResizeHandler}
+                              />;
     const resizeTileButton = isUserResizable &&
                               <ResizeTileButton divRef={elt => this.resizeElement = elt}
                                 hovered={hoverTile}
@@ -221,9 +241,6 @@ export class TileComponent extends BaseComponent<IProps, IState> {
             onMouseEnter={isDraggable ? e => this.setState({ hoverTile: true }) : undefined}
             onMouseLeave={isDraggable ? e => this.setState({ hoverTile: false }) : undefined}
             onKeyDown={this.handleKeyDown}
-            onDragStart={this.handleTileDragStart}
-            onDragEnd={this.triggerResizeHandler}
-            draggable={true}
         >
           {this.renderLinkIndicators()}
           {dragTileButton}

--- a/src/components/tiles/tile-component.tsx
+++ b/src/components/tiles/tile-component.tsx
@@ -87,17 +87,15 @@ interface IDragTileButtonProps {
   divRef: (instance: HTMLDivElement | null) => void;
   hovered: boolean;
   selected: boolean;
-  onClick: (e: React.MouseEvent<HTMLDivElement>) => void;
   handleTileDragStart: (e: React.DragEvent<HTMLDivElement>) => void;
   triggerResizeHandler: () => void;
 }
 const DragTileButton = (
-    { divRef, hovered, selected, onClick, handleTileDragStart, triggerResizeHandler }: IDragTileButtonProps) => {
+    { divRef, hovered, selected, handleTileDragStart, triggerResizeHandler }: IDragTileButtonProps) => {
   const classes = classNames("tool-tile-drag-handle", { hovered, selected });
   return (
     <div className={`tool-tile-drag-handle-wrapper`}
       ref={divRef}
-      onClick={onClick}
       onDragStart={handleTileDragStart}
       onDragEnd={triggerResizeHandler}
       draggable={true}
@@ -217,7 +215,6 @@ export class TileComponent extends BaseComponent<IProps, IState> {
                               divRef={elt => this.dragElement = elt}
                               hovered={hoverTile}
                               selected={isTileSelected}
-                              onClick={e => ui.setSelectedTile(model, {append: hasSelectionModifier(e)})}
                               handleTileDragStart={this.handleTileDragStart}
                               triggerResizeHandler={this.triggerResizeHandler}
                               />;
@@ -372,21 +369,6 @@ export class TileComponent extends BaseComponent<IProps, IState> {
       return;
     }
 
-    // tile dragging can be disabled for individual tiles
-    const target: HTMLElement | null = e.target as HTMLElement;
-    if (!target || target.querySelector(".disable-tile-drag")) {
-      e.preventDefault();
-      return;
-    }
-    // tile dragging can be disabled for individual tile contents,
-    // which only allows those tiles to be dragged by their drag handle
-    if (target?.closest(".disable-tile-content-drag")) {
-      const eltTarget = document.elementFromPoint(e.clientX, e.clientY);
-      if (!eltTarget?.closest(".tool-tile-drag-handle")) {
-        e.preventDefault();
-        return;
-      }
-    }
     // set the drag data
     const { model, docId } = this.props;
 

--- a/src/components/tiles/tile-component.tsx
+++ b/src/components/tiles/tile-component.tsx
@@ -15,9 +15,10 @@ import { TileCommentsComponent } from "./tile-comments";
 import { LinkIndicatorComponent } from "./link-indicator";
 import { hasSelectionModifier } from "../../utilities/event-utils";
 import { getDocumentContentFromNode } from "../../utilities/mst-utils";
+import "../../utilities/dom-utils";
+
 import TileDragHandle from "../../assets/icons/drag-tile/move.svg";
 import TileResizeHandle from "../../assets/icons/resize-tile/expand-handle.svg";
-import "../../utilities/dom-utils";
 import dragPlaceholderImage from "../../assets/image_drag.png";
 
 import "./tile-component.scss";

--- a/src/models/tiles/text/text-registration.ts
+++ b/src/models/tiles/text/text-registration.ts
@@ -19,7 +19,7 @@ registerPlugins();
 registerTileComponentInfo({
   type: kTextTileType,
   Component: TextToolComponent,
-  tileEltClass: "text-tool-tile disable-tile-content-drag",
+  tileEltClass: "text-tool-tile",
   Icon,
   HeaderIcon,
   tileHandlesOwnSelection: true

--- a/src/plugins/dataflow/dataflow-registration.ts
+++ b/src/plugins/dataflow/dataflow-registration.ts
@@ -39,7 +39,7 @@ registerTileContentInfo({
 registerTileComponentInfo({
   type: kDataflowTileType,
   Component: DataflowToolComponent,
-  tileEltClass: "dataflow-tool-tile disable-tile-content-drag",
+  tileEltClass: "dataflow-tool-tile",
   Icon,
   HeaderIcon
 });

--- a/src/plugins/diagram-viewer/diagram-registration.ts
+++ b/src/plugins/diagram-viewer/diagram-registration.ts
@@ -29,7 +29,7 @@ registerTileContentInfo({
 registerTileComponentInfo({
   type: kDiagramTileType,
   Component: DiagramToolComponent,
-  tileEltClass: "diagram-tool-tile disable-tile-content-drag nowheel",
+  tileEltClass: "diagram-tool-tile nowheel",
   Icon,
   HeaderIcon
 });

--- a/src/plugins/drawing/drawing-registration.ts
+++ b/src/plugins/drawing/drawing-registration.ts
@@ -37,7 +37,7 @@ registerTileContentInfo({
 registerTileComponentInfo({
   type: kDrawingTileType,
   Component: DrawingToolComponent,
-  tileEltClass: "drawing-tool-tile disable-tile-content-drag",
+  tileEltClass: "drawing-tool-tile",
   Icon,
   HeaderIcon,
   tileHandlesOwnSelection: true

--- a/src/plugins/graph/graph-registration.ts
+++ b/src/plugins/graph/graph-registration.ts
@@ -30,6 +30,6 @@ registerTileComponentInfo({
   Component: GraphWrapperComponent,
   Icon,
   HeaderIcon,
-  tileEltClass: "graph-tool-tile disable-tile-content-drag",
+  tileEltClass: "graph-tool-tile",
   type: kGraphTileType
 });

--- a/src/plugins/simulator/simulator-registration.ts
+++ b/src/plugins/simulator/simulator-registration.ts
@@ -20,6 +20,6 @@ registerTileComponentInfo({
   Component: SimulatorTileComponent,
   Icon,
   HeaderIcon,
-  tileEltClass: "simulator-tool-tile disable-tile-content-drag",
+  tileEltClass: "simulator-tool-tile",
   type: kSimulatorTileType,
 });


### PR DESCRIPTION
This is "option 2" as described in the comments of PT-187924942.  As part of fixing resizing for touch devices, It removes the ability for any tiles to be dragged except by their drag handles.

Previously, "drag tile from anywhere" was supported on _Data Deck, Expression, Geometry, Image, Numberline, and Table_, but not supported (only dragging the handle would work) on _Text, Dataflow, Diagram, Drawing, Graph, or Simulator_.  Handlers were at the tile level but optionally checked whether the event target was the drag handle.  After this PR, only the handle is supported and it has the event handlers specified directly on it. This avoids overlapping with the 'resize' drag handlers.

Drag and resize handles are increased in size so that they are easier to use on touch devices, visual feedback is improved, and touch events are properly supported.
