### PR TITLE
Allow user resizing of graph

### DIFF
--- a/src/components/document/canvas.scss
+++ b/src/components/document/canvas.scss
@@ -6,9 +6,12 @@
   display: flex;
   height: 100%;
   justify-content: center;
-  position: relative;
   text-align: center;
   width: 100%;
+  // position:relative + z-index causes canvas to be treated as a stacking context
+  // This means z-indexes within canvas don't interact with those outside; keeps overlays and portals on top
+  position: relative;
+  z-index: 0;
 
   .document {
     text-align: left;

--- a/src/plugins/graph/models/graph-model.ts
+++ b/src/plugins/graph/models/graph-model.ts
@@ -122,6 +122,9 @@ export const GraphModel = TileContentModel
     return newSnap;
   })
   .views(self => ({
+    get isUserResizable() {
+      return true;
+    },
     /**
      * Transitional way to get the layer 0 DataConfiguration.
      * This method will be removed when we are fully transitioned to layers.


### PR DESCRIPTION
Adds the manual resizing option to graphs as per PT-186813262 .

This caused a Cypress test to fail due to the resizing border of the tile having a higher z-index than a Chakra portal dialog. Addressed this by following  @kswenson 's suggestion to introduce a stacking context.
