### PR TITLE
Add ways to exit annotation mode

### DIFF
--- a/cypress/e2e/functional/tile_tests/arrow_annotation_spec.js
+++ b/cypress/e2e/functional/tile_tests/arrow_annotation_spec.js
@@ -46,7 +46,7 @@ function beforeTest(params) {
 }
 
 context('Arrow Annotations (Sparrows)', function () {
-  it("can add arrows to draw tiles", () => {
+  it.only("can add arrows to draw tiles", () => {
     beforeTest(queryParams);
     clueCanvas.addTile("drawing");
     drawToolTile.getDrawTile().should("exist");
@@ -68,6 +68,24 @@ context('Arrow Annotations (Sparrows)', function () {
 
     cy.log("Pressing a tile button exits sparrow mode");
     clueCanvas.addTile("drawing");
+    aa.getAnnotationLayer().should("not.have.class", "editing");
+    aa.clickArrowToolbarButton();
+
+    cy.log("Pressing select button exits sparrow mode");
+    aa.getAnnotationLayer().should("have.class", "editing");
+    clueCanvas.getSelectTool().click();
+    aa.getAnnotationLayer().should("not.have.class", "editing");
+    aa.clickArrowToolbarButton();
+
+    cy.log("Double-clicking background exits sparrow mode");
+    aa.getAnnotationLayer().should("have.class", "editing");
+    aa.getAnnotationLayer().dblclick();
+    aa.getAnnotationLayer().should("not.have.class", "editing");
+    aa.clickArrowToolbarButton();
+
+    cy.log("ESC key exits sparrow mode");
+    aa.getAnnotationLayer().should("have.class", "editing");
+    aa.getAnnotationLayer().type("{esc}");
     aa.getAnnotationLayer().should("not.have.class", "editing");
     aa.clickArrowToolbarButton();
 

--- a/cypress/e2e/functional/tile_tests/arrow_annotation_spec.js
+++ b/cypress/e2e/functional/tile_tests/arrow_annotation_spec.js
@@ -46,7 +46,7 @@ function beforeTest(params) {
 }
 
 context('Arrow Annotations (Sparrows)', function () {
-  it.only("can add arrows to draw tiles", () => {
+  it("can add arrows to draw tiles", () => {
     beforeTest(queryParams);
     clueCanvas.addTile("drawing");
     drawToolTile.getDrawTile().should("exist");
@@ -86,6 +86,10 @@ context('Arrow Annotations (Sparrows)', function () {
     cy.log("ESC key exits sparrow mode");
     aa.getAnnotationLayer().should("have.class", "editing");
     aa.getAnnotationLayer().type("{esc}");
+    aa.getAnnotationLayer().should("not.have.class", "editing");
+    aa.clickArrowToolbarButton();
+    aa.getAnnotationLayer().should("have.class", "editing");
+    aa.getArrowToolbarButton().type("{esc}");
     aa.getAnnotationLayer().should("not.have.class", "editing");
     aa.clickArrowToolbarButton();
 

--- a/cypress/support/elements/tile/ArrowAnnotation.js
+++ b/cypress/support/elements/tile/ArrowAnnotation.js
@@ -3,8 +3,11 @@ function wsClass(wsc) {
 }
 
 class ArrowAnnotation {
+  getArrowToolbarButton(workspaceClass) {
+    return cy.get(`${wsClass(workspaceClass)} [data-testid="curved-sparrow-button"]`);
+  }
   clickArrowToolbarButton(workspaceClass) {
-    cy.get(`${wsClass(workspaceClass)} [data-testid="curved-sparrow-button"]`).click({ force: true });
+    this.getArrowToolbarButton().click({ force: true });
   }
   clickHideAnnotationsButton(workspaceClass) {
     cy.get(`${wsClass(workspaceClass)} [data-testid="hide-annotations-button"]`).click({force: true});

--- a/src/components/document/annotation-layer.tsx
+++ b/src/components/document/annotation-layer.tsx
@@ -123,19 +123,10 @@ export const AnnotationLayer = observer(function AnnotationLayer({
 
   const handleBackgroundClick: MouseEventHandler<HTMLDivElement> = event => {
     content?.selectAnnotations([]);
-    // FIXME: this doesn't work because the event target is the annotation-svg, not the background,
-    // not on the tiles that are behind it.
-    const target = event.target;
-    if (target instanceof HTMLElement) {
-      const tile = target.closest('.tool-tile');
-      if (tile && tile.classList.contains('placeholder-tile')) {
-        ui.setAnnotationMode();
-      }
-    }
   };
 
   const handleBackgroundDoubleClick: MouseEventHandler<HTMLDivElement> = event => {
-    // Make sure it's really a click on the annotation-svg background, not bubbled up from a button
+    // Make sure it's a click on the annotation-svg background, not bubbled up from a button
     if ((event.target as HTMLElement).classList.contains("annotation-svg")) {
       ui.setAnnotationMode();
     }

--- a/src/components/toolbar.tsx
+++ b/src/components/toolbar.tsx
@@ -201,7 +201,7 @@ export class ToolbarComponent extends BaseComponent<IProps, IState> {
   }
 
   private handleSelect() {
-    // nothing to do
+    this.stores.ui.setAnnotationMode();
   }
 
   private handleUndo() {

--- a/src/public/demo/units/qa-config-subtabs/content.json
+++ b/src/public/demo/units/qa-config-subtabs/content.json
@@ -253,6 +253,7 @@
     },
     "annotations": "all",
     "toolbar": [
+      {"id": "select", "title": "Select", "iconId": "icon-select-tool", "isTileTool": false, "isDefault": true},
       {"id": "Text", "title": "Text", "isTileTool": true},
       {"id": "Table", "title": "Table", "isTileTool": true},
       {"id": "DataCard", "title": "Data Card", "isTileTool": true},


### PR DESCRIPTION
Exit annotation mode when user clicks the 'select' toolbar button (in addition to other toolbar buttons which already did so); uses the ESC key; or double-clicks anywhere that is not an active annotation button.
