### PR TITLE
feat: add visibility property and values to metadata (PT-188001508)

### DIFF
--- a/scripts/ai/download-documents-with-info.ts
+++ b/scripts/ai/download-documents-with-info.ts
@@ -164,12 +164,42 @@ for (const key of Object.keys(classKeys)) {
       const offering = offeringId && offerings[offeringId];
       const problemDocPublication = offeringId && problemDocPublications[offeringId]?.[docId];
       const extraInfo = {} as any;
+
+      // Set the visibility of the document based on type or existing visibility value.
+      // The default values vary per document type.
+      switch (documentMetadata?.type) {
+        case "problem":
+        case "planning":
+          extraInfo.visibility = documentMetadata.visibility || "unknown";
+          break;
+        case "learningLog":
+        case "personal":
+          extraInfo.visibility = documentMetadata.visibility || "private";
+          break;
+        case "learningLogPublication":
+        case "personalPublication":
+        case "publication":
+          extraInfo.visibility = "public";
+          break;
+        default:
+          extraInfo.visibility = "unknown";
+          break;
+      }
+
       if (offering) {
         const offeringUser = offering.users?.[userId];
         const problemMetadata = offeringUser?.documents?.[docId];
         extraInfo.problemVisibility = problemMetadata?.visbility;
         const planningMetadata = offeringUser?.planning?.[docId];
         extraInfo.planningVisibility = planningMetadata?.visbility;
+        // If there is a problemMetadata or planningMetadata, then the visibility value
+        // previously set above should be overridden. Note that we use different default
+        // values here than above for problem and planning.
+        if (problemMetadata) {
+          extraInfo.visibility = problemMetadata.visibility || "private";
+        } else if (planningMetadata) {
+          extraInfo.visibility = planningMetadata.visibility || "private";
+        }
       }
 
       // It should really be published as one type or the other

--- a/scripts/ai/update-metadata.ts
+++ b/scripts/ai/update-metadata.ts
@@ -91,7 +91,8 @@ async function processFile(file: string) {
       documentType,
       offeringId,
       originDoc,
-      userId
+      userId,
+      visibility
     } = parsedContent;
 
     processedFiles++;
@@ -200,7 +201,8 @@ async function processFile(file: string) {
         tileTypes,
         title: documentTitle || null,
         type: documentType,
-        uid: userId
+        uid: userId,
+        visibility
       };
 
       // Use a prefix of `uid:[owner_uid]` for metadata documents that we create for more
@@ -223,6 +225,8 @@ async function processFile(file: string) {
         console.log(documentId, doc.id, "Updated metadata with", unitFields);
         doc.ref.update({ strategies, tileTypes } as any);
         console.log(documentId, doc.id, "Updated metadata with", { strategies, tileTypes });
+        doc.ref.update({ visibility } as any);
+        console.log(documentId, doc.id, "Updated metadata with", { visibility });
         metadataUpdated++;
       });
     }


### PR DESCRIPTION
[#188001508](https://www.pivotaltracker.com/story/show/188001508)

Documents downloaded using download-documents-with-info.ts will now get a visibility property set, and update-metadata.ts will add this property when updating metadata. This will allow us to get the information we need to identify documents as private in the new sort views.