### PR TITLE
Avoid row of buttons in toolbar wrapping

### DIFF
--- a/src/clue/clue.sass
+++ b/src/clue/clue.sass
@@ -64,6 +64,8 @@ body
       background-color: $sky-light-1
     #titlebar-title
       cursor: pointer
+      overflow: hidden
+      text-overflow: ellipsis
     .actions
       .action.icon, .action.icon-button
         background-color: inherit

--- a/src/components/document/document.scss
+++ b/src/components/document/document.scss
@@ -124,6 +124,8 @@
         border-radius: 5px;
         border: solid 1.5px $charcoal-light-1;
         box-sizing: border-box;
+        display: flex;
+        flex-wrap: nowrap;
         height: 26px;
 
         button {


### PR DESCRIPTION
Fixes PT-188092179.

When space is narrow, the second button wrapped under the first and was not displayed.