### PR TITLE
feat: Filter All retains Shared State (PT-188001508)

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -35,6 +35,7 @@ export default defineConfig({
   qaMothPlotUnitStudent5: "/?appMode=qa&fakeClass=5&fakeUser=student:5&qaGroup=5&problem=1.1&unit=./demo/units/qa-moth-plot/content.json",
   qaNoSectionProblemTabUnitStudent5: "/?appMode=qa&fakeClass=5&fakeUser=student:5&qaGroup=5&problem=1.1&unit=./demo/units/qa-no-section-problem-tab/content.json",
   clueTestqaUnitStudent5: "/?appMode=demo&demoName=CLUE-Test&fakeClass=5&fakeUser=student:5&problem=1.1&unit=./demo/units/qa/content.json&noPersistentUI",
+  clueTestNoUnitStudent5: "/?appMode=demo&demoName=CLUE-Test&fakeClass=5&fakeUser=student:5&problem=1.1&noPersistentUI",
   clueTestqaUnitTeacher6: "/?appMode=demo&demoName=CLUE-Test&fakeClass=5&fakeUser=teacher:6&problem=1.1&unit=./demo/units/qa/content.json&noPersistentUI",
   clueTestqaConfigSubtabsUnitTeacher6: "/?appMode=demo&demoName=CLUE-Test&fakeClass=5&fakeUser=teacher:6&problem=1.1&unit=qa-config-subtabs&noPersistentUI",
   e2e: {

--- a/cypress/e2e/functional/document_tests/student_test_spec.js
+++ b/cypress/e2e/functional/document_tests/student_test_spec.js
@@ -1,16 +1,17 @@
 import Header from '../../../support/elements/common/Header';
 import ClueHeader from '../../../support/elements/common/cHeader';
+import SortedWork from "../../../support/elements/common/SortedWork";
 
 
 const header = new Header;
 const clueHeader = new ClueHeader;
+const sortWork = new SortedWork;
 
 let student = '5',
   classroom = '5',
   group = '5';
 
-function beforeTest() {
-  const queryParams = `${Cypress.config("qaUnitStudent5")}`;
+function beforeTest(queryParams) {
   cy.clearQAData('all');
   cy.visit(queryParams);
   cy.waitForLoad();
@@ -18,7 +19,7 @@ function beforeTest() {
 
 context('Check header area for correctness', function () {
   it('verify header area', function () {
-    beforeTest();
+    beforeTest(`${Cypress.config("qaUnitStudent5")}`);
 
     cy.log('will verify if class name is correct');
     header.getClassName().should('contain', 'Class ' + classroom);
@@ -43,3 +44,25 @@ context('Check header area for correctness', function () {
   });
 });
 
+context("check public/private document access", function() {
+  it("marks private documents as private and only shows public documents as accessible", function() {
+    const queryParams = (`${Cypress.config("clueTestNoUnitStudent5")}`);
+    beforeTest(queryParams);
+
+    cy.openTopTab("sort-work");
+    cy.get(".section-header-arrow").click({multiple: true}); // Open all sections
+    cy.log("will verify if private documents are marked as private and are not accessible");
+    sortWork.checkGroupDocumentVisibility("No Group", true, true);
+    cy.log("will verify if user's own documents are not marked as private and are accessible");
+    sortWork.checkGroupDocumentVisibility("Group 2", false, true);
+
+    // Check the above for a view that contains compact document items
+    sortWork.getShowForMenu().click();
+    sortWork.getShowForInvestigationOption().click();
+    cy.get(".section-header-arrow").click({multiple: true}); // Open all sections
+    cy.log("will verify if private documents are marked as private and are not accessible in the compact view");
+    sortWork.checkGroupDocumentVisibility("No Group", true);
+    cy.log("will verify if user's own documents are not marked as private and are accessible in the compact view");
+    sortWork.checkGroupDocumentVisibility("Group 2", false);
+  });
+});

--- a/cypress/support/elements/common/SortedWork.js
+++ b/cypress/support/elements/common/SortedWork.js
@@ -81,6 +81,26 @@ class SortedWork {
   checkSimpleDocumentInSubgroup(groupName, subgroupName, doc) {
     this.getSortWorkSubgroup(groupName, subgroupName).find('[data-test="simple-document-item"]').should("have.attr", "title", doc);
   }
+  checkGroupDocumentVisibility(groupName, isPrivate, isThumbnailView = false) {
+    const docSelector = isThumbnailView
+      ? '[data-test="sort-work-list-items"]'
+      : '[data-testid="doc-group-list"] [data-test="simple-document-item"]';
+
+    // Assign the documents list to a variable to simplify the code
+    cy.get(".section-header-left").contains(groupName).parent().parent()
+      .siblings('[data-testid="section-document-list"]')
+      .within(() => {
+        cy.get(docSelector).as("groupDocs");
+      });
+
+    cy.get("@groupDocs").should(`${isPrivate ? "" : "not."}have.class`, "private");
+    cy.get("@groupDocs").first().click();
+    cy.get(".focus-document").should(`${isPrivate ? "not." : ""}exist`);
+
+    if (!isPrivate) {
+      cy.get(".close-doc-button").click();
+    }
+  }
   checkGroupIsEmpty(groupName){
     cy.get(".sort-work-view .sorted-sections .section-header-label")
       .contains(groupName).parent().parent().parent().find(".list").should('be.empty');

--- a/functions/src/shared.ts
+++ b/functions/src/shared.ts
@@ -113,6 +113,7 @@ export interface IDocumentMetadata {
   investigation?: string;
   problem?: string;
   unit?: string;
+  visibility?: string;
 }
 export function isDocumentMetadata(o: any): o is IDocumentMetadata {
   return !!o.uid && !!o.type && !!o.key;

--- a/src/components/thumbnail/simple-document-item.scss
+++ b/src/components/thumbnail/simple-document-item.scss
@@ -2,7 +2,7 @@
 
 .simple-document-item {
   background: $classwork-purple-light-7;
-  border: solid 1px #707070;
+  border: solid 1px $charcoal;
   border-radius: 1px;
   cursor: pointer;
   display: flex;
@@ -17,5 +17,18 @@
   }
   &:active {
     background: $classwork-purple-light-2;
+  }
+
+  &.private {
+    background: $charcoal-light-7;
+    border: dotted 1px $charcoal;
+    cursor: not-allowed;
+
+    &:hover {
+      background: $charcoal-light-4;
+    }
+    &:active {
+      background: $color3;
+    }
   }
 }

--- a/src/components/thumbnail/simple-document-item.tsx
+++ b/src/components/thumbnail/simple-document-item.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { IDocumentMetadata } from "../../../functions/src/shared";
 import { useStores } from "../../hooks/use-stores";
+import { isDocumentAccessibleToUser } from "../../models/document/document-utils";
 
 import "./simple-document-item.scss";
 
@@ -12,7 +13,7 @@ interface IProps {
 }
 
 export const SimpleDocumentItem = ({ document, investigationOrdinal, onSelectDocument, problemOrdinal }: IProps) => {
-  const { class: classStore, unit } = useStores();
+  const { documents, class: classStore, unit, user } = useStores();
   const { uid } = document;
   const userName = classStore.getUserById(uid)?.displayName;
   const investigations = unit.investigations;
@@ -22,8 +23,7 @@ export const SimpleDocumentItem = ({ document, investigationOrdinal, onSelectDoc
   const investigation = investigations[Number(investigationOrdinal)];
   const problem = investigation?.problems[Number(problemOrdinal) - 1];
   const title = document.title ? `${userName}: ${document.title}` : `${userName}: ${problem?.title ?? "unknown title"}`;
-  // TODO: Account for and use isPrivate in the view. isAccessibleToUser won't currently work here.
-  // const isPrivate = !document.isAccessibleToUser(user, documents);
+  const isPrivate = !isDocumentAccessibleToUser(document, user, documents);
 
   const handleClick = () => {
     onSelectDocument(document);
@@ -31,10 +31,10 @@ export const SimpleDocumentItem = ({ document, investigationOrdinal, onSelectDoc
 
   return (
     <div
-      className="simple-document-item"
+      className={isPrivate ? "simple-document-item private" : "simple-document-item"}
       data-test="simple-document-item"
       title={title}
-      onClick={handleClick}
+      onClick={!isPrivate ? handleClick : undefined}
     >
     </div>
   );

--- a/src/models/document/document-utils.ts
+++ b/src/models/document/document-utils.ts
@@ -7,8 +7,7 @@ import { AppConfigModelType } from "../stores/app-config-model";
 import { UserModelType } from "../stores/user";
 import { DocumentModelType, IExemplarVisibilityProvider } from "./document";
 import { DocumentContentModelType } from "./document-content";
-import { isExemplarType, isPlanningType, isProblemType, LearningLogPublication, PersonalPublication,
-         ProblemPublication, SupportPublication } from "./document-types";
+import { isExemplarType, isPlanningType, isProblemType, isPublishedType } from "./document-types";
 
 export function getDocumentDisplayTitle(
   document: DocumentModelType, appConfig: AppConfigModelType, problem?: ProblemModelType,
@@ -48,21 +47,15 @@ export function getDocumentIdentifier(document?: DocumentContentModelType) {
   }
 }
 
-export const isDocumentPublished = (doc: IDocumentMetadata) => {
-  return (doc.type === ProblemPublication)
-          || (doc.type === LearningLogPublication)
-          || (doc.type === PersonalPublication)
-          || (doc.type === SupportPublication);
-};
-
 export const isDocumentAccessibleToUser = (
   doc: IDocumentMetadata, user: UserModelType, documentStore: IExemplarVisibilityProvider
 ) => {
   const ownDocument = doc.uid === user.id;
   const isShared = doc.visibility === "public";
+  const isPublished = isPublishedType(doc.type);
   if (user.type === "teacher") return true;
   if (user.type === "student") {
-    return ownDocument || isShared || isDocumentPublished(doc)
+    return ownDocument || isShared || isPublished
            || (isExemplarType(doc.type) && documentStore.isExemplarVisible(doc.key));
   }
   return false;

--- a/src/models/document/document-utils.ts
+++ b/src/models/document/document-utils.ts
@@ -1,11 +1,14 @@
 import { getParent } from "mobx-state-tree";
+import { IDocumentMetadata } from "../../../functions/src/shared";
 import { ProblemModelType } from "../curriculum/problem";
 import { SectionModelType } from "../curriculum/section";
 import { getSectionPath } from "../curriculum/unit";
 import { AppConfigModelType } from "../stores/app-config-model";
-import { DocumentModelType } from "./document";
+import { UserModelType } from "../stores/user";
+import { DocumentModelType, IExemplarVisibilityProvider } from "./document";
 import { DocumentContentModelType } from "./document-content";
-import { isPlanningType, isProblemType } from "./document-types";
+import { isExemplarType, isPlanningType, isProblemType, LearningLogPublication, PersonalPublication,
+         ProblemPublication, SupportPublication } from "./document-types";
 
 export function getDocumentDisplayTitle(
   document: DocumentModelType, appConfig: AppConfigModelType, problem?: ProblemModelType,
@@ -44,3 +47,23 @@ export function getDocumentIdentifier(document?: DocumentContentModelType) {
     return getSectionPath(section);
   }
 }
+
+export const isDocumentPublished = (doc: IDocumentMetadata) => {
+  return (doc.type === ProblemPublication)
+          || (doc.type === LearningLogPublication)
+          || (doc.type === PersonalPublication)
+          || (doc.type === SupportPublication);
+};
+
+export const isDocumentAccessibleToUser = (
+  doc: IDocumentMetadata, user: UserModelType, documentStore: IExemplarVisibilityProvider
+) => {
+  const ownDocument = doc.uid === user.id;
+  const isShared = doc.visibility === "public";
+  if (user.type === "teacher") return true;
+  if (user.type === "student") {
+    return ownDocument || isShared || isDocumentPublished(doc)
+           || (isExemplarType(doc.type) && documentStore.isExemplarVisible(doc.key));
+  }
+  return false;
+};

--- a/src/models/document/document.test.ts
+++ b/src/models/document/document.test.ts
@@ -275,7 +275,8 @@ describe("document model", () => {
       uid: "1",
       key: "test",
       createdAt: 1,
-      properties: {}
+      properties: {},
+      visibility: "public"
     });
   });
 

--- a/src/models/document/document.ts
+++ b/src/models/document/document.ts
@@ -3,7 +3,7 @@ import { forEach } from "lodash";
 import { QueryClient, UseQueryResult } from "react-query";
 import { DocumentContentModel, DocumentContentSnapshotType } from "./document-content";
 import { IDocumentAddTileOptions } from "./document-content-types";
-import { DocumentTypeEnum, IDocumentContext, ISetProperties,
+import { DocumentTypeEnum, IDocumentContext, ISetProperties, isPublishedType,
   LearningLogDocument, LearningLogPublication, PersonalDocument, PersonalPublication,
   PlanningDocument, ProblemDocument, ProblemPublication, SupportPublication
 } from "./document-types";
@@ -26,7 +26,7 @@ import { ESupportType } from "../curriculum/support";
 import { IDocumentLogEvent, logDocumentEvent } from "./log-document-event";
 import { LogEventMethod, LogEventName } from "../../lib/logger-types";
 import { UserModelType } from "../stores/user";
-import { isDocumentAccessibleToUser, isDocumentPublished } from "./document-utils";
+import { isDocumentAccessibleToUser } from "./document-utils";
 
 export enum ContentStatus {
   Valid,
@@ -86,6 +86,9 @@ export const DocumentModel = Tree.named("Document")
     get isSupport() {
       return self.type === SupportPublication;
     },
+    get isPublished() {
+      return isPublishedType(self.type);
+    },
     get isRemote() {
       return !!self.remoteContext;
     },
@@ -119,9 +122,6 @@ export const DocumentModel = Tree.named("Document")
     },
   }))
   .views(self => ({
-    get isPublished() {
-      return isDocumentPublished(self.metadata);
-    },
     getLabel(appConfig: AppConfigModelType, count: number, lowerCase?: boolean) {
       const props = appConfig.documentLabelProperties || [];
       let docStr = self.type as string;

--- a/src/models/document/document.ts
+++ b/src/models/document/document.ts
@@ -4,7 +4,6 @@ import { QueryClient, UseQueryResult } from "react-query";
 import { DocumentContentModel, DocumentContentSnapshotType } from "./document-content";
 import { IDocumentAddTileOptions } from "./document-content-types";
 import { DocumentTypeEnum, IDocumentContext, ISetProperties,
-  isExemplarType,
   LearningLogDocument, LearningLogPublication, PersonalDocument, PersonalPublication,
   PlanningDocument, ProblemDocument, ProblemPublication, SupportPublication
 } from "./document-types";
@@ -27,13 +26,14 @@ import { ESupportType } from "../curriculum/support";
 import { IDocumentLogEvent, logDocumentEvent } from "./log-document-event";
 import { LogEventMethod, LogEventName } from "../../lib/logger-types";
 import { UserModelType } from "../stores/user";
+import { isDocumentAccessibleToUser, isDocumentPublished } from "./document-utils";
 
 export enum ContentStatus {
   Valid,
   Error
 }
 
-type IExemplarVisibilityProvider = {
+export type IExemplarVisibilityProvider = {
   isExemplarVisible: (id: string) => boolean;
 };
 
@@ -86,12 +86,6 @@ export const DocumentModel = Tree.named("Document")
     get isSupport() {
       return self.type === SupportPublication;
     },
-    get isPublished() {
-      return (self.type === ProblemPublication)
-              || (self.type === LearningLogPublication)
-              || (self.type === PersonalPublication)
-              || (self.type === SupportPublication);
-    },
     get isRemote() {
       return !!self.remoteContext;
     },
@@ -104,14 +98,14 @@ export const DocumentModel = Tree.named("Document")
       return !!self.content;
     },
     get metadata(): IDocumentMetadata {
-      const { uid, type, key, createdAt, title, originDoc, properties } = self;
+      const { uid, type, key, createdAt, title, originDoc, properties, visibility } = self;
       // FIXME: the contextId was added here temporarily. This metadata is sent
       // up to the Firestore functions. The new functions do not require the
       // contextId. However the old functions do. The old functions were just
       // ignoring this contextId. So the contextId is added here so the client
       // code can work with the old functions.
       return { contextId: "ignored", uid, type, key, createdAt, title,
-        originDoc, properties: properties.toJSON() } as IDocumentMetadata;
+        originDoc, properties: properties.toJSON(), visibility } as IDocumentMetadata;
     },
     getProperty(key: string) {
       return self.properties.get(key);
@@ -125,6 +119,9 @@ export const DocumentModel = Tree.named("Document")
     },
   }))
   .views(self => ({
+    get isPublished() {
+      return isDocumentPublished(self.metadata);
+    },
     getLabel(appConfig: AppConfigModelType, count: number, lowerCase?: boolean) {
       const props = appConfig.documentLabelProperties || [];
       let docStr = self.type as string;
@@ -160,14 +157,7 @@ export const DocumentModel = Tree.named("Document")
       return self.content?.getUniqueTitleForType(tileType);
     },
     isAccessibleToUser(user: UserModelType, documentStore: IExemplarVisibilityProvider) {
-      const ownDocument = self.uid === user.id;
-      const isShared = self.visibility === "public";
-      if (user.type === "teacher") return true;
-      if (user.type === "student") {
-        return ownDocument || isShared || self.isPublished
-               || (isExemplarType(self.type) && documentStore.isExemplarVisible(self.key));
-      }
-      return false;
+      return isDocumentAccessibleToUser(self.metadata, user, documentStore);
     }
   }))
   .actions((self) => ({


### PR DESCRIPTION
[#188001508](https://www.pivotaltracker.com/story/show/188001508)

Use metadata documents' new `visibility` property to render private documents differently than public documents in the sort work UI.