### PR TITLE
feat: Create Firestore metadata document when users create new documents (PT-188066940)

### DIFF
--- a/functions/src/shared.ts
+++ b/functions/src/shared.ts
@@ -100,6 +100,12 @@ export function networkDocumentKey(uid: string, documentKey: string, network?: s
   return `${prefix}_${escapedKey}`;
 }
 
+export function getDocumentPath(userId: string, documentKey: string, network?: string) {
+  const networkDocKey = networkDocumentKey(userId, documentKey, network);
+  const documentPath = `documents/${networkDocKey}`;
+  return documentPath;
+}
+
 export interface IDocumentMetadata {
   uid: string;
   type: string;

--- a/src/lib/db-types.ts
+++ b/src/lib/db-types.ts
@@ -60,7 +60,10 @@ export interface DBBaseDocumentMetadata {
 
 export interface DBBaseProblemDocumentMetadata extends DBBaseDocumentMetadata {
   classHash: string;
+  investigation?: string;
   offeringId: string;
+  problem?: string;
+  unit?: string;
 }
 
 export interface DBSectionDocumentMetadataDEPRECATED extends DBBaseProblemDocumentMetadata {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -414,12 +414,14 @@ export class DB {
       const { classHash, self, version, ...cleanedMetadata } = metadata as DBDocumentMetadata & { classHash: string };
       const firestoreMetadata: IDocumentMetadata & { contextId: string } = {
         ...cleanedMetadata,
+        // The validateCommentableDocument firebase function currently deployed to production is out of date.
+        // It requires contextId to defined, but doesn't check its value.
         contextId: "ignored",
         key: documentKey,
         properties: {},
         uid: userContext.uid,
       };
-      if ("offeringId" in metadata) {
+      if ("offeringId" in metadata && metadata.offeringId != null) {
         const { investigation, problem, unit } = this.stores;
         const investigationOrdinal = String(investigation.ordinal);
         const problemOrdinal = String(problem.ordinal);

--- a/src/models/document/document.ts
+++ b/src/models/document/document.ts
@@ -111,7 +111,8 @@ export const DocumentModel = Tree.named("Document")
       // ignoring this contextId. So the contextId is added here so the client
       // code can work with the old functions.
       return { contextId: "ignored", uid, type, key, createdAt, title,
-        originDoc, properties: properties.toJSON() } as IDocumentMetadata;
+        originDoc, properties: properties.toJSON(), investigation: self.investigation,
+        problem: self.problem, unit: self.unit } as IDocumentMetadata;
     },
     getProperty(key: string) {
       return self.properties.get(key);

--- a/src/models/history/tree-manager.ts
+++ b/src/models/history/tree-manager.ts
@@ -9,8 +9,7 @@ import { TreePatchRecord, HistoryEntry, TreePatchRecordSnapshot,
   HistoryOperation } from "./history";
 import { DEBUG_HISTORY } from "../../lib/debug";
 import { getFirebaseFunction } from "../../hooks/use-firebase-function";
-import { ICommentableDocumentParams, IDocumentMetadata,
-  networkDocumentKey } from "../../../functions/src/shared";
+import { getDocumentPath, ICommentableDocumentParams, IDocumentMetadata } from "../../../functions/src/shared";
 import { Firestore } from "../../lib/firestore";
 import { UserModelType } from "../stores/user";
 import { UserContextProvider } from "../stores/user-context-provider";
@@ -643,10 +642,4 @@ async function prepareFirestoreHistoryInfo(
     // We use null here so this is a valid Firestore property value
     lastEntryId: lastHistoryEntry?.id || null
   };
-}
-
-function getDocumentPath(userId: string, documentKey: string, network?: string) {
-  const networkDocKey = networkDocumentKey(userId, documentKey, network);
-  const documentPath = `documents/${networkDocKey}`;
-  return documentPath;
 }


### PR DESCRIPTION
[#188066940](https://www.pivotaltracker.com/story/show/188066940)

Create a new Firestore metadata document for any new document when that document is created.

Metadata for certain document types (planning, problem, published problems, and published supports) will have investigation, problem, and unit information included.