### PR TITLE
updated document scripts

### DIFF
--- a/scripts/ai/collect-mods-documents.ts
+++ b/scripts/ai/collect-mods-documents.ts
@@ -1,0 +1,65 @@
+import { mkdir, copyFile, readFile, writeFile } from "fs/promises";
+import fsPath from "path";
+import stringify from "json-stringify-pretty-compact";
+
+import { processFiles } from "../lib/process-files.js";
+
+// This file was generated from a spreadsheet that included the
+// offeringId, classHash, and classId
+// A similar file can be created using the offering-json-to-csv.ts
+// script.
+const modsOfferingsFiles = "mods-offerings.csv";
+const modsOfferings = await readFile(modsOfferingsFiles, "utf8");
+const offeringRows = modsOfferings.split('\n');
+// remove the header
+offeringRows.splice(0,1);
+const offeringObjects = offeringRows.map(offering => {
+  const [offeringId, classHash, classId] = offering.split('\t');
+  return { offeringId, classHash, classId};
+});
+
+const classHashes = offeringObjects.map(offering => offering.classHash);
+const classHashSet = new Set(classHashes);
+
+const datasetFolder = "/Users/scytacki/Development/ai/dataset1720819925834/";
+const targetFolder = "/Users/scytacki/Development/ai/dataset1720819925834-mods/";
+
+// Create the target directories
+await mkdir(targetFolder);
+await mkdir(fsPath.join(targetFolder, "documentInfos"));
+await mkdir(fsPath.join(targetFolder, "documents"));
+
+async function processFile(file: string, path: string) {
+  const content = await readFile(path, "utf8");
+  const parsedContent = JSON.parse(content);
+
+  if (!classHashSet.has(parsedContent.classId)) return;
+
+  if (!parsedContent.documentContent) return;
+
+  const { tileMap } = parsedContent.documentContent;
+  if (!tileMap) return;
+
+  let emptyDocument = true;
+  const tiles = Object.values<any>(tileMap);
+  for (const tile of tiles) {
+    if (tile.content.type !== "Placeholder") {
+      emptyDocument = false;
+      break;
+    }
+  }
+  if (emptyDocument) return;
+
+  await copyFile(path, fsPath.join(targetFolder, "documentInfos", file));
+
+  const documentFile = file.replace("documentInfo-", "document-");
+  await writeFile(fsPath.join(targetFolder, "documents", documentFile), stringify(parsedContent.documentContent));
+}
+
+const stats = await processFiles({
+  sourcePath: datasetFolder,
+  processFile,
+  fileNamePrefix: "documentInfo"
+});
+
+console.log(stats);

--- a/scripts/ai/count-docs.ts
+++ b/scripts/ai/count-docs.ts
@@ -12,90 +12,44 @@
 // Set aiService to be whichever service you're interested in. This will determine the format of the output file.
 // $ cd scripts/ai
 // $ npx tsx count-docs.ts
-
-import fs from "fs";
-
+import { readFile } from "fs/promises";
 import { datasetPath } from "./script-constants.js";
 import { prettyDuration } from "../lib/script-utils.js";
+import { processFiles } from "../lib/process-files.js";
 
-const sourceDirectory = "dataset1706677550897";
-
-// The number of files to process in parallel
-const fileBatchSize = 8;
+const sourceDirectory = "dataset1721072285516";
 
 const sourcePath = `${datasetPath}${sourceDirectory}`;
 
 console.log(`*** Starting Document Count ***`);
 
-const startTime = Date.now();
-let checkedFiles = 0;
-let processedFiles = 0;
 const typeCounts: Record<string, number> = {};
 let titles = 0;
 
 // Processes a file, counting the relevant tiles in it if it's a document
-async function processFile(file: string) {
-  const path = `${sourcePath}/${file}`;
-  if (file.startsWith("documentInfo")) {
-    // For files named like documentXXX.txt, read the file
-    const content = fs.readFileSync(path, "utf8");
-    const parsedContent = JSON.parse(content);
-    const { documentContent, ...documentIds } = parsedContent;
+async function processFile(file: string, path: string) {
+  const content = await readFile(path, "utf8");
+  const parsedContent = JSON.parse(content);
 
-    if (!Object.keys(typeCounts).includes(documentIds.documentType)) {
-      typeCounts[documentIds.documentType] = 0;
-    }
-    typeCounts[documentIds.documentType]++;
+  const { documentContent, ...documentIds } = parsedContent;
 
-    if (documentIds.documentTitle) titles++;
-
-    processedFiles++;
+  if (!Object.keys(typeCounts).includes(documentIds.documentType)) {
+    typeCounts[documentIds.documentType] = 0;
   }
+  typeCounts[documentIds.documentType]++;
+
+  if (documentIds.documentTitle) titles++;
 }
 
-let fileBatch: string[] = [];
-// Process a batch of files
-async function processBatch() {
-  await Promise.all(fileBatch.map(async f => processFile(f)));
-  fileBatch = [];
+const stats = await processFiles({
+  sourcePath,
+  processFile,
+  fileNamePrefix: "documentInfo"
+});
 
-  const currentDuration = Date.now() - startTime;
-  console.log(`*** Time to count tiles in ${processedFiles} documents`, prettyDuration(currentDuration));
-}
-
-// Process every file in the source directory
-fs.readdir(sourcePath, async (_error, files) => {
-  for (const file of files) {
-    checkedFiles++;
-    fileBatch.push(file);
-
-    // We're finished if we've made it through all of the files
-    const finished = checkedFiles >= files.length;
-    if (fileBatch.length >= fileBatchSize || finished) {
-      await processBatch();
-
-      if (finished) {
-        // Write to an output file when all of the files have been processed
-        // const fileName = `${annotationTypes.join("-")}.json`;
-        // const filePath = `${sourcePath}/${fileName}`;
-        // console.log(`**** Writing annotation info to ${filePath} ****`);
-        // fs.writeFileSync(filePath, stringify(documentInfo, { maxLength: 100 }));
-        // console.log(`**** Annotation info saved to ${filePath} ****`);
-        // const outputFileProps = { documentInfo, fileName, sourceDirectory, azureMetadata };
-        // const outputFunctions = { azure: outputAzureFile, vertexAI: outputVertexAIFile };
-        // outputFunctions[aiService](outputFileProps);
-
-        const endTime = Date.now();
-        const finalDuration = endTime - startTime;
-        console.log(`***** Finished in ${prettyDuration(finalDuration)} *****`);
-        console.log(`*** Found ${titles} documents with titles ***`);
-        console.log(`*** Document types ***`);
-        Object.keys(typeCounts).forEach(type => {
-          console.log(`${type}: ${typeCounts[type]}`);
-        });
-
-        process.exit(0);
-      }
-    }
-  }
+console.log(`***** Finished in ${prettyDuration(stats.duration)} *****`);
+console.log(`*** Found ${titles} documents with titles ***`);
+console.log(`*** Document types ***`);
+Object.keys(typeCounts).forEach(type => {
+  console.log(`${type}: ${typeCounts[type]}`);
 });

--- a/scripts/ai/offering-json-to-csv.ts
+++ b/scripts/ai/offering-json-to-csv.ts
@@ -1,0 +1,48 @@
+import fs from "fs";
+
+const offeringInfoFile = `/Users/scytacki/Development/ai/dataset1720819925834/offering-info.json`;
+const offeringInfo = JSON.parse(fs.readFileSync(offeringInfoFile, "utf8"));
+
+// eslint-disable-next-line prefer-regex-literals
+const clueBranchRegExp = new RegExp("^https://[^/]*(/[^?]*)");
+function getClueBranch(activityUrl: string) {
+  return clueBranchRegExp.exec(activityUrl)?.[1];
+}
+
+// eslint-disable-next-line prefer-regex-literals
+const unitParamRegExp = new RegExp("unit=([^&]*)");
+function getUnitParam(activityUrl: string) {
+  return unitParamRegExp.exec(activityUrl)?.[1];
+}
+
+// eslint-disable-next-line prefer-regex-literals
+const unitBranchRegExp = new RegExp("/branch/[^/]*");
+function getUnitBranch(unitParam: string | undefined) {
+  if (unitParam?.startsWith("https://")) {
+    return unitBranchRegExp.exec(unitParam)?.[0];
+  } else {
+    return "";
+  }
+}
+
+// eslint-disable-next-line prefer-regex-literals
+const unitCodeRegExp = new RegExp("/([^/]*)/content.json");
+function getUnitCode(unitParam: string | undefined) {
+  if (unitParam?.startsWith("https://")) {
+    return unitCodeRegExp.exec(unitParam)?.[1];
+  } else {
+    return unitParam;
+  }
+}
+
+console.log("offering_id, activity_url, class_id, clazz_hash, clue_branch, unit_param, unit_branch, unit_code");
+Object.entries(offeringInfo).forEach(([offering_id, offering]) => {
+  const {activity_url, clazz_id, clazz_hash} = offering as any;
+  const clueBranch = getClueBranch(activity_url);
+  const unitParam = getUnitParam(activity_url);
+  const unitBranch = getUnitBranch(unitParam);
+  const unitCode = getUnitCode(unitParam);
+  console.log(
+    `${offering_id}, ${activity_url}, ${clazz_id}, ${clazz_hash}, ` +
+    `${clueBranch}, ${unitParam}, ${unitBranch}, ${unitCode}`);
+});

--- a/scripts/ai/screenshot-by-class.ts
+++ b/scripts/ai/screenshot-by-class.ts
@@ -1,0 +1,86 @@
+import fsPath from "path";
+import { readFile, mkdir } from "fs/promises";
+
+import { prettyDuration } from "../lib/script-utils.js";
+import { makeCLUEScreenshot } from "../lib/screenshot.js";
+import { IProcessFilesStats, processFiles } from "../lib/process-files.js";
+
+// This script saves images of all the documents in a folder and updates its tags.csv with new folder and file names.
+// It's intended to be used on the output of count-document-tiles.ts.
+
+// to run this script:
+// cf. https://stackoverflow.com/a/66626333/16328462
+// Start a local CLUE server
+// Then type the following in the terminal
+// $ cd scripts/ai
+// $ npx tsx screenshot-by-class.ts
+
+
+const rootPath = "/Users/scytacki/Development/ai/dataset1720819925834-mods/";
+const documentPath = fsPath.join(rootPath, "documentInfos");
+
+// Fun the following command in the folder with the documents
+// npx http-server --cors
+const publicPath = `http://localhost:8081`;
+
+let totalSnapshots = 0;
+const targetDir = `screenshots`;
+const targetPath = fsPath.join(rootPath, targetDir);
+
+const failedFiles: string[] = [];
+
+console.log(`***** Starting document screenshots *****`);
+
+async function imageFileName(docInfoFileName: string, docInfoPath: string) {
+  // Load the docInfo in order to figure out the class, user, and documentType
+  const content = await readFile(docInfoPath, "utf8");
+  const parsedContent = JSON.parse(content);
+  const { classId, userId, documentType, documentId } = parsedContent;
+
+  const imageDir = fsPath.join(targetPath, classId, userId);
+  await mkdir(imageDir, {recursive: true});
+
+  const fileName = [userId, documentType, documentId].join("-");
+  return fsPath.join(imageDir, `${fileName}.png`);
+}
+
+// makeSnapshot loads document content at path in a CLUE standalone document editor, takes a snapshot of it,
+// then saves it in the output directory as fileName
+const urlRoot = `http://localhost:8080/editor/?appMode=dev&unit=example&document=`;
+
+// Processes a file, usually making a screenshot but updating tags.csv when that file is encountered
+async function processFile(docInfoFile: string, path: string) {
+  const docFileName = docInfoFile.replace("documentInfo-", "document-");
+  const docEditorPath = `${publicPath}/${docFileName}`;
+  const screenshotFileName = await imageFileName(docInfoFile, path);
+  try {
+    await makeCLUEScreenshot({
+      url: `${urlRoot}${docEditorPath}`,
+      outputFile: screenshotFileName
+    });
+    totalSnapshots++;
+  } catch (error) {
+    failedFiles.push(docEditorPath);
+  }
+}
+
+function batchComplete(stats: IProcessFilesStats) {
+  const currentDuration = Date.now() - stats.startTime;
+  console.log(`*** Time to process ${totalSnapshots} snapshots`, prettyDuration(currentDuration));
+}
+
+// Process every file in the source directory
+const resultStats = await processFiles({
+  sourcePath: documentPath,
+  processFile,
+  batchComplete,
+  fileNamePrefix: "documentInfo-",
+  // Uncomment to limit the number of files processed
+  // fileLimit: 100
+});
+
+console.log(`***** Finished in ${prettyDuration(resultStats.duration)}`);
+if (failedFiles.length > 0) {
+  console.log(`Failed to get snapshots for the following files:`);
+  console.log(failedFiles);
+}

--- a/scripts/lib/process-files.ts
+++ b/scripts/lib/process-files.ts
@@ -1,0 +1,73 @@
+import { readdir } from "fs/promises";
+
+const fileBatchSize = 8;
+
+export interface IProcessFilesStats {
+  startTime: number,
+  endTime?: number,
+  duration?: number,
+  fileCount: number,
+  processedFiles: number,
+}
+
+interface IOptions {
+  sourcePath: string,
+  processFile: (fileName: string, path: string) => Promise<void>,
+  batchComplete?: (stats: IProcessFilesStats) => void,
+  fileNamePrefix?: string,
+  fileLimit?: number,
+}
+
+export async function processFiles({
+  sourcePath,
+  processFile,
+  batchComplete,
+  fileNamePrefix,
+  fileLimit,
+}: IOptions) {
+  const stats: IProcessFilesStats = {
+    startTime: Date.now(),
+    fileCount: 0,
+    processedFiles: 0,
+  };
+  let fileBatch: string[] = [];
+
+  const files = await readdir(sourcePath);
+
+  async function processBatch() {
+    await Promise.all(fileBatch.map(async file => {
+      // If we've hit the file limit don't continue
+      if (fileLimit && stats.processedFiles >= fileLimit) return;
+
+      const path = `${sourcePath}/${file}`;
+      await processFile(file, path);
+      stats.processedFiles++;
+
+
+    }));
+    fileBatch = [];
+    batchComplete?.(stats);
+  }
+
+  for (const file of files) {
+    // If we've hit the file limit don't continue
+    if (fileLimit && stats.processedFiles >= fileLimit) break;
+
+    // Skip files that don't match the prefix
+    if (fileNamePrefix && !file.startsWith(fileNamePrefix)) return;
+
+    fileBatch.push(file);
+
+    if (fileBatch.length >= fileBatchSize) {
+      await processBatch();
+    }
+  }
+  // Process any remaining files
+  await processBatch();
+
+  stats.endTime = Date.now();
+  stats.duration = stats.endTime - stats.startTime;
+  stats.fileCount = files.length;
+
+  return stats;
+}

--- a/scripts/lib/screenshot.ts
+++ b/scripts/lib/screenshot.ts
@@ -1,0 +1,55 @@
+import puppeteer from "puppeteer";
+import { writeFile } from "fs/promises";
+
+interface IOptions {
+  url: string,
+  outputFile: string,
+
+  // The width of the browser window. The height is determined dynamically.
+  // Default: 1920 /2
+  windowWidth?: number
+}
+
+export async function makeCLUEScreenshot({
+  url,
+  outputFile,
+  windowWidth
+}: IOptions) {
+  console.log(`*   Processing screenshot`, url);
+
+
+  // View the document in the document editor
+  const browser = await puppeteer.launch({ headless: true });
+  const page = await browser.newPage();
+  try {
+    await page.goto(url, {
+      timeout: 60000, // 30 seconds
+      waitUntil: 'networkidle0'
+    });
+  } catch (error) {
+    await page.close();
+    await browser.close();
+    throw new Error(`Failed to load file ${url}`, {cause: error});
+  }
+
+  await page.evaluate(() => {
+    (window as any).docEditorSettings.setShowLocalReadOnly(false);
+    (window as any).docEditorSettings.setShowRemoteReadOnly(false);
+  });
+
+  // Approximate the height of the document by adding up the heights of the rows and make the viewport that tall
+  let pageHeight = 30;
+  const rowElements = await page.$$(".tile-row");
+  for (const rowElement of rowElements) {
+    const boundingBox = await rowElement.boundingBox();
+    pageHeight += boundingBox?.height ?? 0;
+  }
+  const width = windowWidth || 1920 / 2;
+  await page.setViewport({ width, height: Math.round(pageHeight) });
+
+  // Take a screenshot and save it to a file
+  const buffer = await page.screenshot({ fullPage: true, type: 'png' });
+  await page.close();
+  await browser.close();
+  await writeFile(outputFile, buffer);
+}


### PR DESCRIPTION
Multiple changes in this commit:
- new process-files library function which can replace duplicate code in several scripts which process a directory of files in batches
- extract clue document screenshot function so it can be used by multiple scripts
- script to process the url of offerings and pull out the unit info from the url
- script to generate screenshots and organize them by class, user, and document type
- script to find classes that have assigned mods units, and collect all documents associated with those classes.
- refactor of the count-docs and document-screenshots.ts to use the process-files library