### PR TITLE
refactor firebase root id computation

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -426,10 +426,9 @@ service cloud.firestore {
       allow read, write: if isAuthed();
     }
 
-    match /dev/{userId}/{restOfPath=**} {
-      allow read: if isAuthed();
-      // users can only write to their own folders
-      allow write: if matchFirebaseUserId(userId);
+    // Developers get a random unique key that their data is stored under
+    match /dev/{devId}/{restOfPath=**} {
+      allow read, write: if isAuthed();
     }
 
     match /qa/{userId}/{restOfPath=**} {

--- a/firestore.rules
+++ b/firestore.rules
@@ -426,7 +426,8 @@ service cloud.firestore {
       allow read, write: if isAuthed();
     }
 
-    // Developers get a random unique key that their data is stored under
+    // In the future, developers might use a random unique key instead of
+    // the firebase user id. So this rule is relaxed inorder to allow that.
     match /dev/{devId}/{restOfPath=**} {
       allow read, write: if isAuthed();
     }

--- a/firestore.rules
+++ b/firestore.rules
@@ -427,7 +427,7 @@ service cloud.firestore {
     }
 
     // In the future, developers might use a random unique key instead of
-    // the firebase user id. So this rule is relaxed inorder to allow that.
+    // the firebase user id. So this rule is relaxed in order to allow that.
     match /dev/{devId}/{restOfPath=**} {
       allow read, write: if isAuthed();
     }

--- a/src/clue/components/clue-app-header.tsx
+++ b/src/clue/components/clue-app-header.tsx
@@ -9,6 +9,7 @@ import { ToggleGroup } from "@concord-consortium/react-components";
 import { GroupModelType, GroupUserModelType } from "../../models/stores/groups";
 import { CustomSelect } from "./custom-select";
 import { useStores } from "../../hooks/use-stores";
+import { getDevId } from "../../lib/root-id";
 
 // cf. https://mattferderer.com/use-sass-variables-in-typescript-and-javascript
 import styles from "./toggle-buttons.scss";
@@ -26,8 +27,17 @@ export const ClueAppHeaderComponent: React.FC<IProps> = observer(function ClueAp
   const { showGroup } = props;
   const { appConfig, appMode, appVersion, db, user, problem, groups, investigation, ui, unit } = useStores();
   const myGroup = showGroup ? groups.getGroupById(user.currentGroupId) : undefined;
-  const userTitle = appMode !== "authed" && appMode !== "demo"
-                      ? `Firebase UID: ${db.firebase.userId}` : undefined;
+  const getUserTitle = () => {
+    switch(appMode){
+      case "dev":
+        return `Firebase Root: ${getDevId()}`;
+      case "qa":
+      case "test":
+        return `Firebase UID: ${db.firebase.userId}`;
+      default:
+        return undefined;
+    }
+  };
 
   const renderPanelButtons = () => {
     const { panels, onPanelChange, current} = props;
@@ -150,7 +160,7 @@ export const ClueAppHeaderComponent: React.FC<IProps> = observer(function ClueAp
         </div>
         <div className="right">
           <div className="version">Version {appVersion}</div>
-          <div className="user teacher" title={userTitle}>
+          <div className="user teacher" title={getUserTitle()}>
             <div className="class" data-test="user-class">
               <ClassMenuContainer />
             </div>
@@ -191,7 +201,7 @@ export const ClueAppHeaderComponent: React.FC<IProps> = observer(function ClueAp
           <NetworkStatus user={user}/>
           <div className="version">Version {appVersion}</div>
           {myGroup ? renderGroup(myGroup) : null}
-          <div className="user" title={userTitle}>
+          <div className="user" title={getUserTitle()}>
             <div className="user-contents">
               <div className="name" data-test="user-name">{user.name}</div>
               <div className="class" data-test="user-class">{user.className}</div>

--- a/src/clue/components/clue-app-header.tsx
+++ b/src/clue/components/clue-app-header.tsx
@@ -9,7 +9,6 @@ import { ToggleGroup } from "@concord-consortium/react-components";
 import { GroupModelType, GroupUserModelType } from "../../models/stores/groups";
 import { CustomSelect } from "./custom-select";
 import { useStores } from "../../hooks/use-stores";
-import { getDevId } from "../../lib/root-id";
 
 // cf. https://mattferderer.com/use-sass-variables-in-typescript-and-javascript
 import styles from "./toggle-buttons.scss";
@@ -30,7 +29,6 @@ export const ClueAppHeaderComponent: React.FC<IProps> = observer(function ClueAp
   const getUserTitle = () => {
     switch(appMode){
       case "dev":
-        return `Firebase Root: ${getDevId()}`;
       case "qa":
       case "test":
         return `Firebase UID: ${db.firebase.userId}`;

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -40,6 +40,7 @@ import { urlParams } from "../utilities/url-params";
 import { firebaseConfig } from "./firebase-config";
 import { UserModelType } from "../models/stores/user";
 import { logExemplarDocumentEvent } from "../models/document/log-exemplar-document-event";
+import { AppMode } from "../models/stores/store-types";
 import { DEBUG_FIRESTORE } from "./debug";
 
 export type IDBConnectOptions = IDBAuthConnectOptions | IDBNonAuthConnectOptions;
@@ -55,7 +56,7 @@ export interface IDBAuthConnectOptions extends IDBBaseConnectOptions {
   rawFirebaseJWT: string;
 }
 export interface IDBNonAuthConnectOptions extends IDBBaseConnectOptions {
-  appMode: "dev" | "test" | "demo" | "qa";
+  appMode: Exclude<AppMode, "authed">;
 }
 export interface UserGroupMap {
   [key: string]: {

--- a/src/lib/firebase.test.ts
+++ b/src/lib/firebase.test.ts
@@ -1,0 +1,54 @@
+import { DB } from "./db";
+import { Firebase } from "./firebase";
+import { kClueDevIDKey } from "./root-id";
+
+const mockStores = {
+  appMode: "authed",
+  demo: { name: "demo" },
+  user: { portal: "test-portal" }
+};
+const mockDB = {
+  stores: mockStores
+} as DB;
+
+describe("Firebase class", () => {
+  describe("initialization", () => {
+    it("should create a valid Firebase object", () => {
+      const firebase = new Firebase(mockDB);
+      expect(firebase).toBeDefined();
+    });
+  });
+  describe("getRootFolder", () => {
+    it("should handle authed mode", () => {
+      const firebase = new Firebase(mockDB);
+      expect(firebase.getRootFolder()).toBe("/authed/test-portal/portals/test-portal/");
+    });
+    it("should handle the dev appMode", () => {
+      window.localStorage.setItem(kClueDevIDKey, "random-id");
+      const stores = {...mockStores, appMode: "dev"};
+      const firestore = new Firebase({stores} as DB);
+      expect(firestore.getRootFolder()).toBe("/dev/random-id/portals/test-portal/");
+    });
+    describe("should handle the demo appMode", () => {
+      it("handles basic demo name", () => {
+        const stores = {...mockStores,
+          appMode: "demo", demo: { name: "test-demo" }};
+        const firestore = new Firebase({stores} as DB);
+        expect(firestore.getRootFolder()).toBe("/demo/test-demo/portals/test-portal/");
+      });
+      it("handles empty demo name", () => {
+        const stores = {...mockStores,
+          appMode: "demo", demo: { name: "" }};
+        const firestore = new Firebase({stores} as DB);
+        expect(firestore.getRootFolder()).toBe("/demo/test-portal/portals/test-portal/");
+      });
+      it("handles empty demo name and empty portal", () => {
+        const stores = {...mockStores,
+          appMode: "demo", demo: { name: "" }, user: { portal: ""}};
+        const firestore = new Firebase({stores} as DB);
+        // FIXME
+        expect(firestore.getRootFolder()).toBe("/demo/demo/portals//");
+      });
+    });
+  });
+});

--- a/src/lib/firebase.test.ts
+++ b/src/lib/firebase.test.ts
@@ -1,6 +1,5 @@
 import { DB } from "./db";
 import { Firebase } from "./firebase";
-import { kClueDevIDKey } from "./root-id";
 
 const mockStores = {
   appMode: "authed",
@@ -23,31 +22,24 @@ describe("Firebase class", () => {
       const firebase = new Firebase(mockDB);
       expect(firebase.getRootFolder()).toBe("/authed/portals/test-portal/");
     });
-    it("should handle the dev appMode", () => {
-      window.localStorage.setItem(kClueDevIDKey, "random-id");
-      const stores = {...mockStores, appMode: "dev"};
-      const firestore = new Firebase({stores} as DB);
-      expect(firestore.getRootFolder()).toBe("/dev/random-id/portals/test-portal/");
-    });
     describe("should handle the demo appMode", () => {
       it("handles basic demo name", () => {
         const stores = {...mockStores,
           appMode: "demo", demo: { name: "test-demo" }};
-        const firestore = new Firebase({stores} as DB);
-        expect(firestore.getRootFolder()).toBe("/demo/test-demo/portals/test-portal/");
+        const firebase = new Firebase({stores} as DB);
+        expect(firebase.getRootFolder()).toBe("/demo/test-demo/portals/test-portal/");
       });
       it("handles empty demo name", () => {
         const stores = {...mockStores,
           appMode: "demo", demo: { name: "" }};
-        const firestore = new Firebase({stores} as DB);
-        expect(firestore.getRootFolder()).toBe("/demo/test-portal/portals/test-portal/");
+        const firebase = new Firebase({stores} as DB);
+        expect(firebase.getRootFolder()).toBe("/demo/test-portal/portals/test-portal/");
       });
       it("handles empty demo name and empty portal", () => {
         const stores = {...mockStores,
           appMode: "demo", demo: { name: "" }, user: { portal: ""}};
-        const firestore = new Firebase({stores} as DB);
-        // FIXME
-        expect(firestore.getRootFolder()).toBe("/demo/demo/portals//");
+        const firebase = new Firebase({stores} as DB);
+        expect(firebase.getRootFolder()).toBe("/demo/demo/portals//");
       });
     });
   });

--- a/src/lib/firebase.test.ts
+++ b/src/lib/firebase.test.ts
@@ -21,7 +21,7 @@ describe("Firebase class", () => {
   describe("getRootFolder", () => {
     it("should handle authed mode", () => {
       const firebase = new Firebase(mockDB);
-      expect(firebase.getRootFolder()).toBe("/authed/test-portal/portals/test-portal/");
+      expect(firebase.getRootFolder()).toBe("/authed/portals/test-portal/");
     });
     it("should handle the dev appMode", () => {
       window.localStorage.setItem(kClueDevIDKey, "random-id");

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -73,7 +73,9 @@ export class Firebase {
       parts.push(FIREBASE_ROOT_OVERRIDE);
     } else {
       parts.push(`${appMode}`);
-      parts.push(getRootId(this.db.stores, this.userId));
+      if (appMode !== "authed") {
+        parts.push(getRootId(this.db.stores, this.userId));
+      }
     }
     parts.push("portals");
     parts.push(escapeKey(user.portal));

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -8,6 +8,7 @@ import { DB } from "./db";
 import { escapeKey } from "./fire-utils";
 import { urlParams } from "../utilities/url-params";
 import { DocumentModelType } from "src/models/document/document";
+import { getRootId } from "./root-id";
 
 // Set this during database testing in combination with the urlParam testMigration=true to
 // override the top-level Firebase key regardless of mode. For example, setting this to "authed-copy"
@@ -65,22 +66,14 @@ export class Firebase {
     // dev: /dev/<firebaseUserId>/portals/localhost <as portalDomain>
     // qa: /qa/<firebaseUserId>/portals/qa <as portalDomain>
     // test: /test/<firebaseUserId>/portals/<arbitraryString as portalDomain>
-    const { appMode, demo: { name: demoName }, user } = this.db.stores;
+    const { appMode, user } = this.db.stores;
 
     const parts = [];
     if (urlParams.testMigration === "true" && FIREBASE_ROOT_OVERRIDE) {
       parts.push(FIREBASE_ROOT_OVERRIDE);
     } else {
       parts.push(`${appMode}`);
-      if ((appMode === "dev") || (appMode === "test") || (appMode === "qa")) {
-        parts.push(this.userId);
-      }
-      else if (appMode === "demo") {
-        const slug = demoName && demoName.length > 0 ? escapeKey(demoName) : "";
-        if (slug.length > 0) {
-          parts.push(slug);
-        }
-      }
+      parts.push(getRootId(this.db.stores, this.userId));
     }
     parts.push("portals");
     parts.push(escapeKey(user.portal));

--- a/src/lib/firestore.test.ts
+++ b/src/lib/firestore.test.ts
@@ -1,5 +1,6 @@
 import { DB } from "./db";
 import { Firestore } from "./firestore";
+import { kClueDevIDKey } from "./root-id";
 
 const mockStores = {
   appMode: "authed",
@@ -56,7 +57,40 @@ describe("Firestore class", () => {
     it("should create a valid Firestore object", () => {
       const firestore = new Firestore(mockDB);
       expect(firestore).toBeDefined();
+    });
+  });
+
+  describe("getRootFolder", () => {
+    beforeEach(() => resetMocks());
+    it("should handle the authed appMode", () => {
+      const firestore = new Firestore(mockDB);
       expect(firestore.getRootFolder()).toBe("/authed/test-portal/");
+    });
+    it("should handle the dev appMode", () => {
+      window.localStorage.setItem(kClueDevIDKey, "random-id");
+      const stores = {...mockStores, appMode: "dev"};
+      const firestore = new Firestore({stores} as DB);
+      expect(firestore.getRootFolder()).toBe("/dev/random-id/");
+    });
+    describe("should handle the demo appMode", () => {
+      it("handles basic demo name", () => {
+        const stores = {...mockStores,
+          appMode: "demo", demo: { name: "test-demo" }};
+        const firestore = new Firestore({stores} as DB);
+        expect(firestore.getRootFolder()).toBe("/demo/test-demo/");
+      });
+      it("handles empty demo name", () => {
+        const stores = {...mockStores,
+          appMode: "demo", demo: { name: "" }};
+        const firestore = new Firestore({stores} as DB);
+        expect(firestore.getRootFolder()).toBe("/demo/test-portal/");
+      });
+      it("handles empty demo name and empty portal", () => {
+        const stores = {...mockStores,
+          appMode: "demo", demo: { name: "" }, user: { portal: ""}};
+        const firestore = new Firestore({stores} as DB);
+        expect(firestore.getRootFolder()).toBe("/demo/demo/");
+      });
     });
   });
 

--- a/src/lib/firestore.test.ts
+++ b/src/lib/firestore.test.ts
@@ -1,6 +1,5 @@
 import { DB } from "./db";
 import { Firestore } from "./firestore";
-import { kClueDevIDKey } from "./root-id";
 
 const mockStores = {
   appMode: "authed",
@@ -65,12 +64,6 @@ describe("Firestore class", () => {
     it("should handle the authed appMode", () => {
       const firestore = new Firestore(mockDB);
       expect(firestore.getRootFolder()).toBe("/authed/test-portal/");
-    });
-    it("should handle the dev appMode", () => {
-      window.localStorage.setItem(kClueDevIDKey, "random-id");
-      const stores = {...mockStores, appMode: "dev"};
-      const firestore = new Firestore({stores} as DB);
-      expect(firestore.getRootFolder()).toBe("/dev/random-id/");
     });
     describe("should handle the demo appMode", () => {
       it("handles basic demo name", () => {

--- a/src/lib/firestore.ts
+++ b/src/lib/firestore.ts
@@ -1,6 +1,7 @@
 import firebase from "firebase/app";
 import "firebase/firestore";
 import { DB } from "./db";
+import { getRootId } from "./root-id";
 import { escapeKey } from "./fire-utils";
 import { UserDocument } from "./firestore-schema";
 
@@ -40,25 +41,8 @@ export class Firestore {
   //
 
   public getRootFolder() {
-    const { appMode, demo: { name: demoName }, user: { portal } } = this.db.stores;
-    let rootDocId: string;
-    const escapedPortal = portal ? escapeKey(portal) : portal;
-
-    // `authed/${escapedPortalDomain}`
-    if (appMode === "authed") {
-      rootDocId = escapedPortal;
-    }
-    // `demo/${escapedDemoName}`
-    else if ((appMode === "demo") && (demoName?.length > 0)) {
-      const escapedDemoName = demoName ? escapeKey(demoName) : demoName;
-      rootDocId = escapedDemoName || escapedPortal || "demo";
-    }
-    // `${appMode}/${userId}`
-    else {  // (appMode === "dev") || (appMode === "test") || (appMode === "qa")
-      rootDocId = this.userId;
-    }
-
-    return `/${appMode}/${rootDocId}/`;
+    const { appMode } = this.db.stores;
+    return `/${appMode}/${getRootId(this.db.stores, this.userId)}/`;
   }
 
   public getFullPath(path = "") {

--- a/src/lib/root-id.ts
+++ b/src/lib/root-id.ts
@@ -1,18 +1,5 @@
-import { nanoid } from "nanoid";
 import { IStores } from "../models/stores/stores";
 import { escapeKey } from "./fire-utils";
-
-export const kClueDevIDKey = "clue-dev-id";
-
-export function getDevId() {
-  let devId = window.localStorage.getItem(kClueDevIDKey);
-  if (!devId) {
-    const newDevId = nanoid();
-    window.localStorage.setItem(kClueDevIDKey, newDevId);
-    devId = newDevId;
-  }
-  return devId;
-}
 
 type IRootDocIdStores = Pick<IStores, "appMode" | "demo" | "user">;
 
@@ -35,10 +22,7 @@ export function getRootId(stores: IRootDocIdStores, firebaseUserId: string) {
       const escapedDemoName = demoName ? escapeKey(demoName) : demoName;
       return escapedDemoName || escapedPortal || "demo";
     }
-    case "dev": {
-      return getDevId();
-    }
-    // "test" and "qa"
+    // "dev", "qa", and "test"
     default: {
       return firebaseUserId;
     }

--- a/src/lib/root-id.ts
+++ b/src/lib/root-id.ts
@@ -1,0 +1,46 @@
+import { nanoid } from "nanoid";
+import { IStores } from "../models/stores/stores";
+import { escapeKey } from "./fire-utils";
+
+export const kClueDevIDKey = "clue-dev-id";
+
+export function getDevId() {
+  let devId = window.localStorage.getItem(kClueDevIDKey);
+  if (!devId) {
+    const newDevId = nanoid();
+    window.localStorage.setItem(kClueDevIDKey, newDevId);
+    devId = newDevId;
+  }
+  return devId;
+}
+
+type IRootDocIdStores = Pick<IStores, "appMode" | "demo" | "user">;
+
+export function getRootId(stores: IRootDocIdStores, firebaseUserId: string) {
+  const { appMode, demo: { name: demoName }, user: { portal } } = stores;
+  const escapedPortal = portal ? escapeKey(portal) : portal;
+
+  switch (appMode) {
+    case "authed": {
+      return escapedPortal;
+    }
+    case "demo": {
+      // Legacy Note: Previously if the demoName was "", the root id in the realtime database
+      // and Firestore would be different. The paths would end up being:
+      // database: /demo/portals/demo/ (root id is skipped)
+      // firestore: /demo/{firebaseUserId}/
+      // Now the root id will be the default "demo" in this case so the paths will be:
+      // database: /demo/demo/portals/demo/
+      // firestore: /demo/demo/
+      const escapedDemoName = demoName ? escapeKey(demoName) : demoName;
+      return escapedDemoName || escapedPortal || "demo";
+    }
+    case "dev": {
+      return getDevId();
+    }
+    // "test" and "qa"
+    default: {
+      return firebaseUserId;
+    }
+  }
+}

--- a/src/models/stores/user-context-provider.ts
+++ b/src/models/stores/user-context-provider.ts
@@ -11,6 +11,10 @@ export class UserContextProvider {
     this.stores = stores;
   }
 
+  /**
+   * This user context is sent to the Firebase functions so they know the context of the
+   * request.
+   */
   get userContext() {
     const appMode = this.stores.appMode;
     const { name: demoName } = this.stores.demo;


### PR DESCRIPTION
This PR started as a change to use a random id in local storage for the root id when the appMode is dev. However that approach couldn't be finished because the Firebase functions needed to be updated. That incomplete work was split out into its own PR: https://github.com/concord-consortium/collaborative-learning/pull/2407

What remains in this PR is:
- a refactoring of the code to get the root id which is used in both Firestore and the Realtime database.
- relaxing the Firestore rules so we can implement the random id behavior in the future. The Realtime database have been relaxed like this since the beginning. 

**Historical Options**
When this PR included the local random id, the following options were considered for dealing with the problem of the broken functions.  See https://github.com/concord-consortium/collaborative-learning/pull/2407 for more info.

There is not enough time to fix the functions, so we have to look at other options.

1. Don't apply this PR, or apply a stripped down version of it that has the refactoring without the functional change. In this case appMode dev will function the same as appMode qa. A new firebase user will be created by each tab that is opened and will get its new root. A developer can't build up a collection of documents and users in Firebase. At least appMode dev won't be broken in weird ways.
2. Apply it anyway. appMode dev will appear broken because of the functions problem. However developers can still use it to test many parts of CLUE, and build a collection of documents. And we can incrementally fix the functions as we go forward.
3. Revert the whole change to the session authentication storage. This leaves us back without a good way of handling the firestore metadata documents created during tests. So it seems one of the first 2 options is better than this. 