### PR TITLE
local storage dev root id

### DIFF
--- a/src/clue/components/clue-app-header.tsx
+++ b/src/clue/components/clue-app-header.tsx
@@ -9,6 +9,7 @@ import { ToggleGroup } from "@concord-consortium/react-components";
 import { GroupModelType, GroupUserModelType } from "../../models/stores/groups";
 import { CustomSelect } from "./custom-select";
 import { useStores } from "../../hooks/use-stores";
+import { getDevId } from "../../lib/root-id";
 
 // cf. https://mattferderer.com/use-sass-variables-in-typescript-and-javascript
 import styles from "./toggle-buttons.scss";
@@ -29,6 +30,7 @@ export const ClueAppHeaderComponent: React.FC<IProps> = observer(function ClueAp
   const getUserTitle = () => {
     switch(appMode){
       case "dev":
+        return `Firebase Root: ${getDevId()}`;
       case "qa":
       case "test":
         return `Firebase UID: ${db.firebase.userId}`;

--- a/src/lib/firebase.test.ts
+++ b/src/lib/firebase.test.ts
@@ -1,5 +1,6 @@
 import { DB } from "./db";
 import { Firebase } from "./firebase";
+import { kClueDevIDKey } from "./root-id";
 
 const mockStores = {
   appMode: "authed",
@@ -21,6 +22,12 @@ describe("Firebase class", () => {
     it("should handle authed mode", () => {
       const firebase = new Firebase(mockDB);
       expect(firebase.getRootFolder()).toBe("/authed/portals/test-portal/");
+    });
+    it("should handle the dev appMode", () => {
+      window.localStorage.setItem(kClueDevIDKey, "random-id");
+      const stores = {...mockStores, appMode: "dev"};
+      const firestore = new Firebase({stores} as DB);
+      expect(firestore.getRootFolder()).toBe("/dev/random-id/portals/test-portal/");
     });
     describe("should handle the demo appMode", () => {
       it("handles basic demo name", () => {

--- a/src/lib/firestore.test.ts
+++ b/src/lib/firestore.test.ts
@@ -1,5 +1,6 @@
 import { DB } from "./db";
 import { Firestore } from "./firestore";
+import { kClueDevIDKey } from "./root-id";
 
 const mockStores = {
   appMode: "authed",
@@ -64,6 +65,12 @@ describe("Firestore class", () => {
     it("should handle the authed appMode", () => {
       const firestore = new Firestore(mockDB);
       expect(firestore.getRootFolder()).toBe("/authed/test-portal/");
+    });
+    it("should handle the dev appMode", () => {
+      window.localStorage.setItem(kClueDevIDKey, "random-id");
+      const stores = {...mockStores, appMode: "dev"};
+      const firestore = new Firestore({stores} as DB);
+      expect(firestore.getRootFolder()).toBe("/dev/random-id/");
     });
     describe("should handle the demo appMode", () => {
       it("handles basic demo name", () => {

--- a/src/lib/root-id.ts
+++ b/src/lib/root-id.ts
@@ -1,5 +1,18 @@
+import { nanoid } from "nanoid";
 import { IStores } from "../models/stores/stores";
 import { escapeKey } from "./fire-utils";
+
+export const kClueDevIDKey = "clue-dev-id";
+
+export function getDevId() {
+  let devId = window.localStorage.getItem(kClueDevIDKey);
+  if (!devId) {
+    const newDevId = nanoid();
+    window.localStorage.setItem(kClueDevIDKey, newDevId);
+    devId = newDevId;
+  }
+  return devId;
+}
 
 type IRootDocIdStores = Pick<IStores, "appMode" | "demo" | "user">;
 
@@ -22,7 +35,10 @@ export function getRootId(stores: IRootDocIdStores, firebaseUserId: string) {
       const escapedDemoName = demoName ? escapeKey(demoName) : demoName;
       return escapedDemoName || escapedPortal || "demo";
     }
-    // "dev", "qa", and "test"
+    case "dev": {
+      return getDevId();
+    }
+    // "test" and "qa"
     default: {
       return firebaseUserId;
     }


### PR DESCRIPTION
**Do not merge** 

This PR uses a random id in local storage for the root id when the appMode is dev. This restores a similar behavior to how appMode dev worked before the switch to use session storage for the firebase credentials.

To enable this:
- the security rules for the dev root were relax, so any user can write to any dev root. This was done in this PR: https://github.com/concord-consortium/collaborative-learning/pull/2403
- update user icon rollover so devs can find their root
- update getRootId utility to create or use the existing local storage id.
- update tests to verify the functionality

**However**:

This approach breaks the Firebase functions which create and read data in the Realtime database and Firestore. These functions compute the root based on a context and the firebase auth that is passed to them. Previously the dev root was firebase auth uid, so that is what these functions are using.  To support the new dev root approach, we'll need to send the random id from local storage to the functions. This complicates things because it is used by almost all the functions. We haven't migrated the old functions to the new functions-v2 folder, so it is harder to work on them.

The functions that would be broken in appMode dev are:
- getImageData: downloads images from firebase. I don't remember if this is used for all student images, or just ones outside of the current class
- publishSupport: publishing mulit-class supports
- validateCommentableDocument: this is the key one for the current work. It creates the metadata document in Firestore if it doesn't exist. So without it working the sort work tab doesn't have any metadata documents to show.
- postDocumentComment: save a teacher comment
- getNetworkDocument: retrieve a doc from a different class which is allowed because the user is in the same network
- getNetworkResources: get a list of documents from other classes the teacher has access too because of their network

All of these functions should not crash with this PR, they just are looking in or updating the wrong root in Firebase. So they save documents in the wrong place, or return no documents because the runtime is writing to a different place than the functions are looking.