### PR TITLE
live update sorted documents

### DIFF
--- a/cypress/e2e/functional/teacher_tests/teacher_sort_work_view_spec.js
+++ b/cypress/e2e/functional/teacher_tests/teacher_sort_work_view_spec.js
@@ -209,6 +209,7 @@ describe('SortWorkView Tests', () => {
     cy.visit(queryParams2);
     cy.waitForLoad();
     cy.openTopTab('sort-work');
+    cy.get('.section-header-label').should("contain", "Group 5");
     cy.get('.section-header-arrow').click({multiple: true}); // Open the sections
     cy.wait(1000);
     studentProblemDocs.forEach(doc => {
@@ -307,11 +308,6 @@ describe('SortWorkView Tests', () => {
     cy.log("check that exemplar document is displayed in new tag");
     chatPanel.getChatCloseButton().click();
     cy.openTopTab('sort-work');
-    // at the moment this is required to refresh the sort
-    sortWork.getShowForMenu().click();
-    sortWork.getShowForInvestigationOption().click();
-    sortWork.getShowForMenu().click();
-    sortWork.getShowForProblemOption().click();
 
     cy.get('.section-header-arrow').click({multiple: true}); // Open the sections
     sortWork.checkDocumentInGroup("Diverging Designs", exemplarDocs[0]);

--- a/src/components/document/doc-list-debug.tsx
+++ b/src/components/document/doc-list-debug.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-import { IDocumentMetadata } from "../../../shared/shared";
+import { IDocumentMetadataModel } from "../../models/stores/sorted-documents";
 
 import "./doc-list-debug.scss";
 
 interface IProps {
-  docs: IDocumentMetadata[];
+  docs: IDocumentMetadataModel[];
 }
 
 export function DocListDebug(props: IProps) {

--- a/src/components/document/document-group.tsx
+++ b/src/components/document/document-group.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { observer } from "mobx-react-lite";
-import { DocumentModelType, getDocumentContext } from "../../models/document/document";
+import { DocumentModelType } from "../../models/document/document";
 import { SimpleDocumentItem } from "../thumbnail/simple-document-item";
-import { DocumentContextReact } from "./document-context";
 import { IDocumentMetadata } from "../../../shared/shared";
 import { DocumentGroup } from "../../models/stores/document-group";
 
@@ -121,16 +120,14 @@ export const DocumentGroupComponent = observer(function DocumentGroupComponent(p
       {visibleCount < docCount && renderScrollButton("left", leftArrowDisabled)}
       <div ref={docListContainerRef} className="doc-group-list simple" data-testid="doc-group-list">
         {documentGroup.documents?.map((doc: any) => {
-          const documentContext = getDocumentContext(doc);
           return (
-            <DocumentContextReact.Provider key={doc.key} value={documentContext}>
-              <SimpleDocumentItem
-                document={doc}
-                investigationOrdinal={doc.investigation}
-                problemOrdinal={doc.problem}
-                onSelectDocument={onSelectDocument}
-              />
-            </DocumentContextReact.Provider>
+            <SimpleDocumentItem
+              key={doc.key}
+              document={doc}
+              investigationOrdinal={doc.investigation}
+              problemOrdinal={doc.problem}
+              onSelectDocument={onSelectDocument}
+            />
           );
         })}
       </div>

--- a/src/components/document/sort-work-view.tsx
+++ b/src/components/document/sort-work-view.tsx
@@ -76,7 +76,7 @@ export const SortWorkView: React.FC = observer(function SortWorkView() {
   const showSortWorkDocumentArea = !!openDocumentKey;
 
   useEffect(()=>{
-    sortedDocuments.updateMetaDataDocs(docFilter, unit.code, investigation.ordinal, problem.ordinal);
+    return sortedDocuments.watchFirestoreMetaDataDocs(docFilter, unit.code, investigation.ordinal, problem.ordinal);
   }, [docFilter, unit.code, investigation.ordinal, problem.ordinal, sortedDocuments]);
 
   return (

--- a/src/components/document/sorted-section.tsx
+++ b/src/components/document/sorted-section.tsx
@@ -11,6 +11,7 @@ import { DocumentGroupComponent } from "./document-group";
 import { logDocumentViewEvent } from "../../models/document/log-document-event";
 import { DecoratedDocumentThumbnailItem } from "../thumbnail/decorated-document-thumbnail-item";
 import { ENavTab } from "../../models/view/nav-tabs";
+import { IDocumentMetadataModel } from "../../models/stores/sorted-documents";
 
 import ArrowIcon from "../../assets/icons/arrow/arrow.svg";
 
@@ -49,7 +50,7 @@ export const SortedSection: React.FC<IProps> = observer(function SortedSection(p
     setShowDocuments(!showDocuments);
   };
 
-  const renderUngroupedDocument = (doc: IDocumentMetadata) => {
+  const renderUngroupedDocument = (doc: IDocumentMetadataModel) => {
     const fullDocument = getDocument(doc.key);
     if (!fullDocument) return <div key={doc.key} className="loading-spinner"/>;
 

--- a/src/components/thumbnail/simple-document-item.tsx
+++ b/src/components/thumbnail/simple-document-item.tsx
@@ -1,3 +1,4 @@
+import { observer } from "mobx-react";
 import React from "react";
 import { IDocumentMetadata } from "../../../shared/shared";
 import { useStores } from "../../hooks/use-stores";
@@ -12,7 +13,9 @@ interface IProps {
   onSelectDocument: (document: IDocumentMetadata) => void;
 }
 
-export const SimpleDocumentItem = ({ document, investigationOrdinal, onSelectDocument, problemOrdinal }: IProps) => {
+export const SimpleDocumentItem = observer(function SimpleDocumentItem(
+  { document, investigationOrdinal, onSelectDocument, problemOrdinal }: IProps
+) {
   const { documents, class: classStore, unit, user } = useStores();
   const { uid } = document;
   const userName = classStore.getUserById(uid)?.displayName;
@@ -37,4 +40,4 @@ export const SimpleDocumentItem = ({ document, investigationOrdinal, onSelectDoc
     >
     </div>
   );
-};
+});

--- a/src/models/stores/document-group.test.ts
+++ b/src/models/stores/document-group.test.ts
@@ -1,15 +1,15 @@
-import { IObservableArray, observable } from "mobx";
+import { observable } from "mobx";
 import { createDocumentModel, DocumentModelSnapshotType, DocumentModelType } from "../document/document";
 import { DocumentContentSnapshotType } from "../document/document-content";
 import { ProblemDocument } from '../document/document-types';
 import { ClassModel, ClassModelType, ClassUserModel } from "./class";
 import { GroupModel, GroupsModel, GroupsModelType, GroupUserModel } from "./groups";
 import { DeepPartial } from "utility-types";
-import { IDocumentMetadata } from "../../../shared/shared";
-import { ISortedDocumentsStores, SortedDocuments } from "./sorted-documents";
+import { ISortedDocumentsStores, MetadataDocMapModel, SortedDocuments } from "./sorted-documents";
 import { DB } from "../../lib/db";
 import { mock } from "ts-jest-mocker";
 import { Bookmark, Bookmarks } from "./bookmarks";
+import { SnapshotIn } from "mobx-state-tree";
 
 
 //****************************************** Documents Mock ***************************************
@@ -34,8 +34,8 @@ const mockDocumentsData: DocumentModelSnapshotType[] = [
   }
 ];
 
-const mockMetadataDocuments: IObservableArray<IDocumentMetadata> = observable.array([
-  {
+const mockMetadataDocuments: SnapshotIn<typeof MetadataDocMapModel> = {
+  "Student 1 Problem Doc Group 5": {
     uid: "1", //Joe
     type: ProblemDocument,
     key:"Student 1 Problem Doc Group 5",
@@ -43,23 +43,23 @@ const mockMetadataDocuments: IObservableArray<IDocumentMetadata> = observable.ar
     tools: [],
     strategies: ["foo", "bar"],
   },
-  {
+  "Student 2 Problem Doc Group 3": {
     uid: "2", //Scott
     type: ProblemDocument, key:"Student 2 Problem Doc Group 3", createdAt: 2,
     tools: ["Text"]
   },
-  {
+  "Student 3 Problem Doc Group 9": {
     uid: "3", //Dennis
     type: ProblemDocument, key:"Student 3 Problem Doc Group 9", createdAt: 3,
     tools: ["Drawing"]
   },
-  {
+  "Student 4 Problem Doc Group 3": {
     uid: "4", //Kirk
     type: ProblemDocument, key:"Student 4 Problem Doc Group 3", createdAt: 4,
     tools: [],
     strategies: ["bar"]
   }
-]);
+};
 
 const createMockDocuments = () => {
   return mockDocumentsData.map(createDocumentModel);
@@ -170,7 +170,7 @@ describe('DocumentGroup Model', () => {
     const mockStores: DeepPartial<ISortedDocumentsStores> = {
       //DeepPartial allows us to not need to mock the "dB" and "appConfig" stores
       //as well not needing to type the stores below
-      documents: { all: mockDocuments },
+      documents: { all: mockDocuments, exemplarDocuments: [] },
       groups: mockGroups,
       class: mockClass,
       appConfig: { commentTags: {"foo": "foo", "bar": "bar"} },
@@ -178,7 +178,7 @@ describe('DocumentGroup Model', () => {
     };
 
     sortedDocuments = new SortedDocuments(mockStores as ISortedDocumentsStores);
-    sortedDocuments.firestoreMetadataDocs = mockMetadataDocuments;
+    sortedDocuments.metadataDocsFiltered = MetadataDocMapModel.create(mockMetadataDocuments);
   });
 
   describe("byBookMarked Function", () => {

--- a/src/models/stores/document-group.test.ts
+++ b/src/models/stores/document-group.test.ts
@@ -1,15 +1,16 @@
 import { observable } from "mobx";
+import { mock } from "ts-jest-mocker";
+import { DeepPartial } from "utility-types";
+import { SnapshotIn } from "mobx-state-tree";
+
 import { createDocumentModel, DocumentModelSnapshotType, DocumentModelType } from "../document/document";
 import { DocumentContentSnapshotType } from "../document/document-content";
 import { ProblemDocument } from '../document/document-types';
 import { ClassModel, ClassModelType, ClassUserModel } from "./class";
 import { GroupModel, GroupsModel, GroupsModelType, GroupUserModel } from "./groups";
-import { DeepPartial } from "utility-types";
 import { ISortedDocumentsStores, MetadataDocMapModel, SortedDocuments } from "./sorted-documents";
 import { DB } from "../../lib/db";
-import { mock } from "ts-jest-mocker";
 import { Bookmark, Bookmarks } from "./bookmarks";
-import { SnapshotIn } from "mobx-state-tree";
 
 
 //****************************************** Documents Mock ***************************************

--- a/src/models/stores/document-group.ts
+++ b/src/models/stores/document-group.ts
@@ -1,6 +1,5 @@
 import { FC, SVGProps } from "react";
-import { IDocumentMetadata } from "../../../shared/shared";
-import { ISortedDocumentsStores, TagWithDocs } from "./sorted-documents";
+import { IDocumentMetadataModel, ISortedDocumentsStores, TagWithDocs } from "./sorted-documents";
 import { makeAutoObservable } from "mobx";
 import {
   createDocMapByBookmarks,
@@ -20,7 +19,7 @@ import SparrowHeaderIcon from "../../assets/icons/sort-by-tools/sparrow-id.svg";
 interface IDocumentGroup {
   icon?:FC<SVGProps<SVGSVGElement>>;
   label: string;
-  documents: IDocumentMetadata[];
+  documents: IDocumentMetadataModel[];
   stores: ISortedDocumentsStores;
 }
 
@@ -44,7 +43,7 @@ interface IDocumentGroup {
 export class DocumentGroup {
   stores: ISortedDocumentsStores;
   label: string;
-  documents: IDocumentMetadata[];
+  documents: IDocumentMetadataModel[];
   icon?: FC<SVGProps<SVGSVGElement>>;
 
   constructor(props: IDocumentGroup) {
@@ -56,7 +55,10 @@ export class DocumentGroup {
     this.icon = icon;
   }
 
-  buildDocumentCollection(sortedSectionLabels: string[], docMap: Map<string, IDocumentMetadata[]>): DocumentGroup[] {
+  buildDocumentCollection(
+    sortedSectionLabels: string[],
+    docMap: Map<string, IDocumentMetadataModel[]>
+  ): DocumentGroup[] {
     return sortedSectionLabels.map(label => {
       return new DocumentGroup({
         label,
@@ -104,7 +106,7 @@ export class DocumentGroup {
       const tagWithDocs = tagKeyAndValObj[1] as TagWithDocs;
       const label = tagWithDocs.tagValue;
       const docKeys = tagWithDocs.docKeysFoundWithTag;
-      const documents = this.documents.filter((doc: IDocumentMetadata) => docKeys.includes(doc.key));
+      const documents = this.documents.filter(doc => docKeys.includes(doc.key));
       sortedDocsArr.push(new DocumentGroup({
         label,
         documents,

--- a/src/models/stores/sorted-documents.test.ts
+++ b/src/models/stores/sorted-documents.test.ts
@@ -1,15 +1,14 @@
-import { IObservableArray, observable } from "mobx";
 import { DocumentModelType, createDocumentModel, DocumentModelSnapshotType } from "../document/document";
 import { GroupModel, GroupsModel, GroupsModelType, GroupUserModel } from './groups';
 import { ClassModel, ClassModelType, ClassUserModel } from './class';
 import { ProblemDocument } from '../document/document-types';
-import { ISortedDocumentsStores, SortedDocuments } from "./sorted-documents";
+import { ISortedDocumentsStores, MetadataDocMapModel, SortedDocuments } from "./sorted-documents";
 import { DeepPartial } from "utility-types";
 import { DocumentContentSnapshotType } from "../document/document-content";
-import { IDocumentMetadata } from "../../../shared/shared";
 
 import "../tiles/text/text-registration";
 import "../../plugins/drawing/drawing-registration";
+import { SnapshotIn } from "mobx-state-tree";
 
 //****************************************** Documents Mock ***************************************
 
@@ -33,28 +32,28 @@ const mockDocumentsData: DocumentModelSnapshotType[] = [
   }
 ];
 
-const mockMetadataDocuments: IObservableArray<IDocumentMetadata> = observable.array([
-  {
+const mockMetadataDocuments: SnapshotIn<typeof MetadataDocMapModel> = {
+  "Student 1 Problem Doc Group 5": {
     uid: "1", //Joe
     type: ProblemDocument, key:"Student 1 Problem Doc Group 5", createdAt: 1,
     tools: []
   },
-  {
+  "Student 2 Problem Doc Group 3": {
     uid: "2", //Scott
     type: ProblemDocument, key:"Student 2 Problem Doc Group 3", createdAt: 2,
     tools: ["Text"]
   },
-  {
+  "Student 3 Problem Doc Group 9": {
     uid: "3", //Dennis
     type: ProblemDocument, key:"Student 3 Problem Doc Group 9", createdAt: 3,
     tools: ["Drawing"]
   },
-  {
+  "Student 4 Problem Doc Group 3": {
     uid: "4", //Kirk
     type: ProblemDocument, key:"Student 4 Problem Doc Group 3", createdAt: 4,
     tools: []
   }
-]);
+};
 
 const createMockDocuments = () => {
   return mockDocumentsData.map(createDocumentModel);
@@ -153,13 +152,13 @@ describe('Sorted Documents Model', () => {
     const mockStores: DeepPartial<ISortedDocumentsStores> = {
       //DeepPartial allows us to not need to mock the "dB" and "appConfig" stores
       //as well not needing to type the stores below
-      documents: { all: mockDocuments },
+      documents: { all: mockDocuments, exemplarDocuments: [] },
       groups: mockGroups,
       class: mockClass,
     };
 
     sortedDocuments = new SortedDocuments(mockStores as ISortedDocumentsStores);
-    sortedDocuments.firestoreMetadataDocs = mockMetadataDocuments;
+    sortedDocuments.metadataDocsFiltered = MetadataDocMapModel.create(mockMetadataDocuments);
   });
 
 

--- a/src/models/stores/sorted-documents.ts
+++ b/src/models/stores/sorted-documents.ts
@@ -340,23 +340,26 @@ export class SortedDocuments {
     const metadataDoc = this.firestoreMetadataDocs.find(doc => doc.key === docKey);
     if (!metadataDoc) return;
 
-    const unit = metadataDoc?.unit ?? undefined;
     const visibility = metadataDoc?.visibility === "public" || metadataDoc?.visibility === "private"
                          ? metadataDoc?.visibility as "public" | "private"
                          : undefined;
     const props = {
-      documentKey: metadataDoc?.key,
-      type: metadataDoc?.type as any,
-      title: metadataDoc?.title || undefined,
-      properties: metadataDoc?.properties.toJSON(),
-      userId: metadataDoc?.uid,
+      documentKey: metadataDoc.key,
+      type: metadataDoc.type as any,
+      properties: metadataDoc.properties.toJSON(),
+      userId: metadataDoc.uid,
       groupId: undefined,
       visibility,
       originDoc: undefined,
       pubVersion: undefined,
-      problem: metadataDoc?.problem || undefined,
-      investigation: metadataDoc?.investigation || undefined,
-      unit,
+
+      // The following props are sometimes null in Firestore on the metadata docs.
+      // For consistency we make them undefined which is what openDocument
+      // expects.
+      title: metadataDoc.title ?? undefined,
+      problem: metadataDoc.problem ?? undefined,
+      investigation: metadataDoc.investigation ?? undefined,
+      unit: metadataDoc.unit ?? undefined,
     };
 
     return  this.db.openDocument(props);

--- a/src/models/stores/sorted-documents.ts
+++ b/src/models/stores/sorted-documents.ts
@@ -201,10 +201,18 @@ export class SortedDocuments {
       typecheck(DocumentMetadataModel, data);
       const exemplarMetadata = this.exemplarMetadataDocs.get(data.key);
       if (exemplarMetadata) {
+        // If this metadata doc in Firestore is an exemplar in the same unit then the exemplar
+        // metadata will be found. This will happen when a teacher comments on a exemplar.
+        // So in this case we need to merge the strategies from the exemplar with the strategies from
+        // the teacher's comments.
         const authoredStrategies = exemplarMetadata.strategies || [];
         const userStrategies = data.strategies || [];
         data.strategies = union(authoredStrategies, userStrategies);
-        data.tools = exemplarMetadata.tools;
+        // We also update the tools incase the author has changed the exemplar content after
+        // the teacher commented on the document.
+        // We need a copy of the tools so the same array isn't attached to two MST trees at
+        // the same time.
+        data.tools = [...exemplarMetadata.tools];
       }
     });
     return mstSnapshot;

--- a/src/models/stores/sorted-documents.ts
+++ b/src/models/stores/sorted-documents.ts
@@ -259,6 +259,10 @@ export class SortedDocuments {
 
   get exemplarMetadataDocs() {
     const docsMap = MetadataDocMapModel.create();
+    // We are just using this map for consistency with the other maps
+    // We don't need the benefits of MST's actions
+    unprotect(docsMap);
+
     // OPTIMIZE: this isn't efficient. Every time a new document is added to stores.documents
     // this exemplarDocuments will be recomputed even though its value will not have changed.
     // So then all of these exemplar docs will get recreated.

--- a/src/models/stores/sorted-documents.ts
+++ b/src/models/stores/sorted-documents.ts
@@ -238,7 +238,6 @@ export class SortedDocuments {
     }
 
     const disposeFilteredListener = filteredQuery.onSnapshot(snapshot => {
-      console.log("filteredQuery.onSnapshot", snapshot.size);
       const mstSnapshot = this.getMSTSnapshotFromFBSnapshot(snapshot);
       applySnapshot(this.metadataDocsFiltered, mstSnapshot);
     });
@@ -252,8 +251,7 @@ export class SortedDocuments {
         applySnapshot(this.metadataDocsWithoutUnit, mstSnapshot);
       });
     } else {
-      // If the filter is "All" then the metaDocsWithUnit will include everything.
-      // This is mixing MST and MobX
+      // If the filter is "All" then the metaDocsFiltered will include everything.
       this.metadataDocsWithoutUnit.clear();
     }
 

--- a/src/utilities/sort-document-utils.ts
+++ b/src/utilities/sort-document-utils.ts
@@ -4,6 +4,7 @@ import { Bookmarks } from "src/models/stores/bookmarks";
 import { getTileComponentInfo } from "../models/tiles/tile-component-info";
 
 import SparrowHeaderIcon from "../assets/icons/sort-by-tools/sparrow-id.svg";
+import { IDocumentMetadataModel } from "src/models/stores/sorted-documents";
 
 export type DocumentCollection = {
   label: string;
@@ -17,8 +18,8 @@ type TagWithDocs = {
   docKeysFoundWithTag: string[];
 };
 
-export const createDocMapByGroups = (documents: IDocumentMetadata[], groupForUser: (userId: string) => any) => {
-  const documentMap: Map<string, IDocumentMetadata[]> = new Map();
+export const createDocMapByGroups = (documents: IDocumentMetadataModel[], groupForUser: (userId: string) => any) => {
+  const documentMap: Map<string, IDocumentMetadataModel[]> = new Map();
   documents.forEach((doc) => {
     const userId = doc.uid;
     const group = groupForUser(userId);
@@ -40,8 +41,8 @@ export const sortGroupSectionLabels = (docMapKeys: string[]) => {
   });
 };
 
-export const createDocMapByNames = (documents: IDocumentMetadata[], getUserById: (uid: string) => any) => {
-  const documentMap: Map<string, IDocumentMetadata[]> = new Map();
+export const createDocMapByNames = (documents: IDocumentMetadataModel[], getUserById: (uid: string) => any) => {
+  const documentMap: Map<string, IDocumentMetadataModel[]> = new Map();
   documents.forEach((doc) => {
     const user = getUserById(doc.uid);
     const sectionLabel = user && `${user.lastName}, ${user.firstName}`;
@@ -72,7 +73,7 @@ export const sortNameSectionLabels = (docMapKeys: string[]) => {
 };
 
 export const getTagsWithDocs = (
-  documents: IDocumentMetadata[],
+  documents: IDocumentMetadataModel[],
   commentTags: Record<string, string>|undefined,
 ) => {
   const tagsWithDocs: Record<string, TagWithDocs> = {};
@@ -116,9 +117,9 @@ export const getTagsWithDocs = (
   return tagsWithDocs;
 };
 
-export const createTileTypeToDocumentsMap = (documents: IDocumentMetadata[]) => {
+export const createTileTypeToDocumentsMap = (documents: IDocumentMetadataModel[]) => {
   const toolToDocumentsMap = new Map<string, Record<string, any>>();
-  const addDocByType = (docToAdd: IDocumentMetadata, type: string) => {
+  const addDocByType = (docToAdd: IDocumentMetadataModel, type: string) => {
     if (!toolToDocumentsMap.get(type)) {
       let icon: FC<SVGProps<SVGSVGElement>> | undefined;
       if (type === "Sparrow") {
@@ -154,8 +155,8 @@ export const createTileTypeToDocumentsMap = (documents: IDocumentMetadata[]) => 
   return toolToDocumentsMap;
 };
 
-export const createDocMapByBookmarks = (documents: IDocumentMetadata[], bookmarks: Bookmarks) => {
-  const documentMap: Map<string, IDocumentMetadata[]> = new Map();
+export const createDocMapByBookmarks = (documents: IDocumentMetadataModel[], bookmarks: Bookmarks) => {
+  const documentMap: Map<string, IDocumentMetadataModel[]> = new Map();
   documents.forEach((doc) => {
     const sectionLabel = bookmarks.isDocumentBookmarked(doc.key) ? "Bookmarked" : "Not Bookmarked";
     if (!documentMap.has(sectionLabel)) {


### PR DESCRIPTION
- remove unnecessary DocumentContext around SimpleDocumentItem
- switch usage of IDocumentMetadata to IDocumentMetadataModel (the MST model)
- add disposer for the metadata docs watcher
- make SimpleDocumentItem an observing component so it updates when the visibility changes.
- update tests to work with the new metadataDocsFiltered property
- update sorted-documents to have two MST models for the filtered and withoutUnit metadata docs. These models are kept in sync with the Firestore query results.
- update the queries to use Firebase `onSnapshot` listeners instead of just calling `get`
- have the `onSnapshot` listeners merge the exemplar docs and then apply the new query results to the MST models
- turn firestoreMetadataDocs into a view that combines all of the documents together.