### PR TITLE
Make history playback work for "X It!"

### DIFF
--- a/src/models/history/tree-manager.test.ts
+++ b/src/models/history/tree-manager.test.ts
@@ -226,6 +226,54 @@ const action4 = {
   undoable: true
 };
 
+const sharedModelChange = {
+    "action": "/content/sharedModelMap/sm1/sharedModel/setValue",
+    "created": expect.any(Number),
+    "id": expect.any(String),
+    "records": [
+      {
+        "action": "/content/sharedModelMap/sm1/sharedModel/setValue",
+        "inversePatches": [
+          {
+            "op": "replace",
+            "path": "/content/sharedModelMap/sm1/sharedModel/value",
+            "value": undefined,
+          },
+        ],
+        "patches": [
+          {
+            "op": "replace",
+            "path": "/content/sharedModelMap/sm1/sharedModel/value",
+            "value": "shared value",
+          },
+        ],
+        "tree": "test",
+      },
+      {
+        "action": "/handleSharedModelChanges",
+        "inversePatches": [
+          {
+            "op": "replace",
+            "path": "/content/tileMap/t1/content/text",
+          },
+        ],
+        "patches": [
+           {
+            "op": "replace",
+            "path": "/content/tileMap/t1/content/text",
+            "value": "shared value-tile",
+          },
+        ],
+        "tree": "test",
+      }
+    ],
+    "state": "complete",
+    "tree": "test",
+    "undoable": true,
+  };
+
+
+
 /**
  * Remove the Jest `expect.any(Number)` on created, and provide a real id.
  * @param entry
@@ -293,6 +341,17 @@ it("can replay the history entries", async () => {
 
   // The history should not change after it is replayed
   expect(getSnapshot(manager.document.history)).toEqual(history);
+});
+
+it("records tile model changes in response to shared model changes", async () => {
+  const {tileContent, manager, sharedModel} = setupDocument();
+  sharedModel.setValue("shared value");
+  await expectEntryToBeComplete(manager, 1);
+  expect(tileContent.text).toBe("shared value-tile");
+  expect(tileContent.updateCount).toBe(1);
+
+  const changeDocument = manager.document as Instance<typeof CDocument>;
+  expect(getSnapshot(changeDocument.history)).toEqual([sharedModelChange]);
 });
 
 // TODO: it would nicer to use a custom Jest matcher here so we can

--- a/src/models/history/tree-manager.ts
+++ b/src/models/history/tree-manager.ts
@@ -543,13 +543,17 @@ export const TreeManager = types
     const startingIndex = direction === 1 ? self.numHistoryEventsApplied : self.numHistoryEventsApplied - 1;
     const endingIndex = direction === 1 ? newHistoryPosition : newHistoryPosition - 1;
     for (let i=startingIndex; i !== endingIndex; i=i+direction) {
-      const entry = self.document.history.at(i);
-      for (const treeEntry of (entry?.records || [])) {
-        const patches = treePatches[treeEntry.tree];
+      const historyEntry = self.document.history.at(i);
+      let records = historyEntry ? [ ...historyEntry.records] : [];
+      if (direction === -1) {
+        records = records.reverse();
+      }
+      for (const entryRecord of records) {
+        const patches = treePatches[entryRecord.tree];
         if (newHistoryPosition > self.numHistoryEventsApplied) {
-          patches?.push(...treeEntry.getPatches(HistoryOperation.Redo));
+          patches?.push(...entryRecord.getPatches(HistoryOperation.Redo));
         } else {
-          patches?.push(...treeEntry.getPatches(HistoryOperation.Undo));
+          patches?.push(...entryRecord.getPatches(HistoryOperation.Undo));
         }
       }
     }

--- a/src/models/history/undo-store.test.ts
+++ b/src/models/history/undo-store.test.ts
@@ -610,21 +610,21 @@ const initialSharedModelUpdateEntry = {
   created: expect.any(Number),
   id: expect.any(String),
   records: [
-    { action: "/handleSharedModelChanges",
-      inversePatches: [
-        { op: "replace", path: "/content/tileMap/t1/content/text", value: undefined}
-      ],
-      patches: [
-        { op: "replace", path: "/content/tileMap/t1/content/text", value: "something-tile"}
-      ],
-      tree: "test"
-    },
     { action: "/content/sharedModelMap/sm1/sharedModel/setValue",
       inversePatches: [
         { op: "replace", path: "/content/sharedModelMap/sm1/sharedModel/value", value: undefined}
       ],
       patches: [
         { op: "replace", path: "/content/sharedModelMap/sm1/sharedModel/value", value: "something"}
+      ],
+      tree: "test"
+    },
+    { action: "/handleSharedModelChanges",
+      inversePatches: [
+        { op: "replace", path: "/content/tileMap/t1/content/text", value: undefined}
+      ],
+      patches: [
+        { op: "replace", path: "/content/tileMap/t1/content/text", value: "something-tile"}
       ],
       tree: "test"
     }
@@ -710,19 +710,19 @@ const redoSharedModelEntry = {
   records: [
     { action: "/applyPatchesFromManager",
       inversePatches: [
-        { op: "replace", path: "/content/tileMap/t1/content/text", value: undefined}
+        { op: "replace", path: "/content/sharedModelMap/sm1/sharedModel/value", value: undefined}
       ],
       patches: [
-        { op: "replace", path: "/content/tileMap/t1/content/text", value: "something-tile"}
+        { op: "replace", path: "/content/sharedModelMap/sm1/sharedModel/value", value: "something"}
       ],
       tree: "test"
     },
     { action: "/applyPatchesFromManager",
       inversePatches: [
-        { op: "replace", path: "/content/sharedModelMap/sm1/sharedModel/value", value: undefined}
+        { op: "replace", path: "/content/tileMap/t1/content/text", value: undefined}
       ],
       patches: [
-        { op: "replace", path: "/content/sharedModelMap/sm1/sharedModel/value", value: "something"}
+        { op: "replace", path: "/content/tileMap/t1/content/text", value: "something-tile"}
       ],
       tree: "test"
     }
@@ -822,24 +822,6 @@ it("can track the addition of a new shared model", async () => {
       id: expect.any(String),
       records: [
         {
-          tree: "test",
-          action: "/handleSharedModelChanges",
-          patches: [
-            {
-              op: "replace",
-              path: "/content/tileMap/t1/content/text",
-              value: "new model-tile"
-            }
-          ],
-          inversePatches: [
-            {
-              op: "replace",
-              path: "/content/tileMap/t1/content/text",
-              value: undefined
-            }
-          ]
-        },
-        {
           action: "/content/addSharedModel",
           inversePatches: [
             { op: "remove", path: `/content/sharedModelMap/${sharedModelId}` }
@@ -859,6 +841,24 @@ it("can track the addition of a new shared model", async () => {
             }
           ],
           tree: "test"
+        },
+        {
+          tree: "test",
+          action: "/handleSharedModelChanges",
+          patches: [
+            {
+              op: "replace",
+              path: "/content/tileMap/t1/content/text",
+              value: "new model-tile"
+            }
+          ],
+          inversePatches: [
+            {
+              op: "replace",
+              path: "/content/tileMap/t1/content/text",
+              value: undefined
+            }
+          ]
         }
       ],
       state: "complete",

--- a/src/plugins/data-card/components/case-attribute.tsx
+++ b/src/plugins/data-card/components/case-attribute.tsx
@@ -1,9 +1,11 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { observer } from "mobx-react";
+import { isAlive } from "mobx-state-tree";
 import escapeStringRegexp from "escape-string-regexp";
 import { useCombobox } from "downshift";
 import { uniq } from "lodash";
 import { VisuallyHidden } from "@chakra-ui/react";
+import classNames from "classnames";
 import { gImageMap } from "../../../models/image-map";
 import { ITileModel } from "../../../models/tiles/tile-model";
 import { DataCardContentModelType } from "../data-card-content";
@@ -25,7 +27,6 @@ import NumberTypeIcon from "../assets/id-type-number.svg";
 import ExpandDownIcon from "../assets/expand-more-icon.svg";
 
 import './single-card-data-area.scss';
-import classNames from "classnames";
 
 const typeIcons = {
   "date": <DateTypeIcon />,
@@ -57,13 +58,16 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
     model, caseId, attrKey, currEditAttrId, currEditFacet,
     setCurrEditFacet, setCurrEditAttrId, readOnly
   } = props;
+  if (!isAlive(model)) {
+    console.log("rendering unalive model", model);
+  }
   const content = model.content as DataCardContentModelType;
   const dataSet = content.dataSet;
   const cell = { attributeId: attrKey, caseId: caseId ?? "" };
   const isLinked = useIsLinked();
 
   const getName = useCallback(() => {
-    return content.dataSet.attrFromID(attrKey).name;
+    return content.dataSet.attrFromID(attrKey)?.name;
   }, [attrKey, content.dataSet]);
 
   const getValue = useCallback(() => {
@@ -92,7 +96,9 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
   }, [editingValue, valueCandidate.length]);
 
   useEffect(() => {
-    const nameLines = measureTextLines(getName(), kFieldWidthFactor);
+    const name = getName();
+    if (!name) return;
+    const nameLines = measureTextLines(name, kFieldWidthFactor);
     const nameCandidateLines = measureTextLines(nameCandidate, kFieldWidthFactor);
     const nameLinesNeeded = Math.max(nameLines, nameCandidateLines);
     const valueLines = measureTextLines(valueStr, kFieldWidthFactor);

--- a/src/plugins/data-card/components/data-card-toolbar-buttons.tsx
+++ b/src/plugins/data-card/components/data-card-toolbar-buttons.tsx
@@ -53,7 +53,7 @@ export const DeleteAttrButton = () => {
   const isEditingValue = !!context?.currEditAttrId && context?.currEditFacet === "value";
 
   const handleClick = () => {
-    const thisCaseId = content?.dataSet.caseIDFromIndex(content.caseIndex);
+    const thisCaseId = content?.dataSet.caseIDFromIndex(content.caseIndexNumber);
     if (thisCaseId && context){
       content?.setAttValue(thisCaseId, context.currEditAttrId, "");
     }

--- a/src/plugins/data-card/data-card-content.ts
+++ b/src/plugins/data-card/data-card-content.ts
@@ -135,7 +135,7 @@ export const DataCardContentModel = TileContentModel
   }))
   .views(self => ({
     get caseId() {
-      return self.caseIndex ? self.dataSet.caseIDFromIndex(self.caseIndex) : undefined;
+      return self.caseIndex !== undefined ? self.dataSet.caseIDFromIndex(self.caseIndex) : undefined;
     }
   }))
   .views(self => ({
@@ -260,13 +260,16 @@ export const DataCardContentModel = TileContentModel
     updateAfterSharedModelChanges(sharedModel?: SharedModelType) {
       const dataSet = self.dataSet;
       if (!dataSet) return;
-      // Select the card of the first selected case
-      const selectedCaseId = dataSet.firstSelectedCaseId
-        ? dataSet.firstSelectedCaseId : dataSet.firstSelectedCell?.caseId;
-      if (selectedCaseId && dataSet.caseIndexFromID(selectedCaseId) !== self.caseIndex) {
-        self.setCaseIndex(dataSet.caseIndexFromID(selectedCaseId));
-      } else if (self.caseIndex === undefined) {
-        self.setCaseIndex(0);
+      // At initialization, caseIndex will be undefined.
+      // Set it to the first selected case, or the first card if there's no selection.
+      if (self.caseIndex === undefined) {
+        const selectedCaseId = dataSet.firstSelectedCaseId !== undefined
+          ? dataSet.firstSelectedCaseId : dataSet.firstSelectedCell?.caseId;
+        if (selectedCaseId !== undefined) {
+          self.setCaseIndex(dataSet.caseIndexFromID(selectedCaseId));
+        } else {
+          self.setCaseIndex(0);
+        }
       } else if (self.caseIndex >= self.totalCases && self.totalCases > 0) {
         // Make sure case index is in range if number of cases has changed
         self.setCaseIndex(self.totalCases - 1);

--- a/src/plugins/data-card/data-card-tile.tsx
+++ b/src/plugins/data-card/data-card-tile.tsx
@@ -53,6 +53,10 @@ export const DataCardToolComponent: React.FC<ITileProps> = observer(function Dat
   const selectedCaseId = dataSet.firstSelectedCaseId !== undefined
     ? dataSet.firstSelectedCaseId : dataSet.firstSelectedCell?.caseId;
   useEffect(() => {
+    // caseIndex is undefined when the tile is first created.
+    // The initial setting of this field must be handled `updateAfterSharedModelChanges`,
+    // so that it is part of the same history entry as the tile creation. Setting it here would mean
+    // creating a second history entry that might be out of order.
     if (content.caseIndex === undefined) return;
     if (selectedCaseId !== undefined && dataSet.caseIndexFromID(selectedCaseId) !== content.caseIndex) {
       content.setCaseIndex(dataSet.caseIndexFromID(selectedCaseId));

--- a/src/plugins/data-card/data-card-tile.tsx
+++ b/src/plugins/data-card/data-card-tile.tsx
@@ -1,6 +1,7 @@
 import classNames from "classnames";
 import { observer } from "mobx-react";
-import React, { useEffect, useRef, useState } from "react";
+import { isAlive } from "mobx-state-tree";
+import React, { useRef, useState, useEffect } from "react";
 import { ITileProps } from "../../components/tiles/tile-component";
 import { useUIStore } from "../../hooks/use-stores";
 import { DataCardContentModelType } from "./data-card-content";
@@ -23,6 +24,11 @@ import "./data-card-tile.scss";
 export const DataCardToolComponent: React.FC<ITileProps> = observer(function DataCardToolComponent(props) {
   const { documentId, model, readOnly, documentContent, tileElt, onRegisterTileApi,
           scale, onUnregisterTileApi, height, onRequestRowHeight } = props;
+  // Doing this check lets mobx know that it shouldn't try to render a model that has been deleted
+  if (!isAlive(model)) {
+    console.log("rendering unalive model", model);
+  }
+
   const backgroundRef = useRef<HTMLDivElement | null>(null);
 
   const content = model.content as DataCardContentModelType;
@@ -41,12 +47,13 @@ export const DataCardToolComponent: React.FC<ITileProps> = observer(function Dat
   const displaySingle = !content.selectedSortAttributeId;
   const shouldShowAddField = !readOnly && isTileSelected && displaySingle;
   const attrIdsNames = content.existingAttributesWithNames();
-  const cardOf = `Card ${content.caseIndex + 1 } of `;
+  const cardOf = `Card ${content.caseIndexNumber + 1 } of `;
 
   // When a highlighted case or cell is set, show it
   const selectedCaseId = dataSet.firstSelectedCaseId ? dataSet.firstSelectedCaseId : dataSet.firstSelectedCell?.caseId;
   useEffect(() => {
-    if (selectedCaseId) {
+    if (content.caseIndex === undefined) return;
+    if (selectedCaseId && dataSet.caseIndexFromID(selectedCaseId) !== content.caseIndex) {
       content.setCaseIndex(dataSet.caseIndexFromID(selectedCaseId));
     }
   }, [content, dataSet, selectedCaseId]);
@@ -64,8 +71,8 @@ export const DataCardToolComponent: React.FC<ITileProps> = observer(function Dat
   });
 
   function nextCase() {
-    if (content.caseIndex < content.totalCases - 1) {
-      content.setCaseIndex(content.caseIndex + 1);
+    if (content.caseIndexNumber < content.totalCases - 1) {
+      content.setCaseIndex(content.caseIndexNumber + 1);
     }
   }
 
@@ -75,8 +82,8 @@ export const DataCardToolComponent: React.FC<ITileProps> = observer(function Dat
   };
 
   function previousCase() {
-    if (content.caseIndex > 0){
-      content.setCaseIndex(content.caseIndex - 1);
+    if (content.caseIndexNumber > 0){
+      content.setCaseIndex(content.caseIndexNumber - 1);
     }
   }
 
@@ -134,11 +141,11 @@ export const DataCardToolComponent: React.FC<ITileProps> = observer(function Dat
 
   const previousButtonClasses = classNames(
     "card-nav", "previous",
-    content.caseIndex > 0 ? "active" : "disabled",
+    content.caseIndexNumber > 0 ? "active" : "disabled",
   );
   const nextButtonClasses = classNames(
     "card-nav", "next",
-    content.caseIndex < content.totalCases - 1 ? "active" : "disabled",
+    content.caseIndexNumber < content.totalCases - 1 ? "active" : "disabled",
   );
   const addCardClasses = classNames("add-card", "teal-bg", { hidden: !shouldShowAddCase });
   const removeCardClasses = classNames("remove-card", { hidden: !shouldShowDeleteCase });
@@ -234,7 +241,7 @@ export const DataCardToolComponent: React.FC<ITileProps> = observer(function Dat
                 <div className="single-card-data-area">
                   { content.totalCases > 0 &&
                     <DataCardRows
-                      caseIndex={content.caseIndex}
+                      caseIndex={content.caseIndexNumber}
                       model={model}
                       totalCases={content.totalCases}
                       readOnly={readOnly}

--- a/src/plugins/data-card/data-card-tile.tsx
+++ b/src/plugins/data-card/data-card-tile.tsx
@@ -50,10 +50,11 @@ export const DataCardToolComponent: React.FC<ITileProps> = observer(function Dat
   const cardOf = `Card ${content.caseIndexNumber + 1 } of `;
 
   // When a highlighted case or cell is set, show it
-  const selectedCaseId = dataSet.firstSelectedCaseId ? dataSet.firstSelectedCaseId : dataSet.firstSelectedCell?.caseId;
+  const selectedCaseId = dataSet.firstSelectedCaseId !== undefined
+    ? dataSet.firstSelectedCaseId : dataSet.firstSelectedCell?.caseId;
   useEffect(() => {
     if (content.caseIndex === undefined) return;
-    if (selectedCaseId && dataSet.caseIndexFromID(selectedCaseId) !== content.caseIndex) {
+    if (selectedCaseId !== undefined && dataSet.caseIndexFromID(selectedCaseId) !== content.caseIndex) {
       content.setCaseIndex(dataSet.caseIndexFromID(selectedCaseId));
     }
   }, [content, dataSet, selectedCaseId]);

--- a/src/plugins/data-card/data-card-toolbar.tsx
+++ b/src/plugins/data-card/data-card-toolbar.tsx
@@ -37,7 +37,7 @@ export const DataCardToolbar: React.FC<IProps> = observer(function DataCardToolb
     onIsEnabled, setImageUrlToAdd,
     ...others }: IProps) {
   const content = model.content as DataCardContentModelType;
-  const { caseIndex, dataSet, totalCases } = content;
+  const { caseIndexNumber: caseIndex, dataSet, totalCases } = content;
   const currentCaseId = caseIndex >= 0 && caseIndex < totalCases ? dataSet.caseIDFromIndex(caseIndex) : undefined ;
   const enabled = onIsEnabled(); //"enabled" is the visibility of the toolbar at lower left
   const location = useFloatingToolbarLocation({


### PR DESCRIPTION
As noted in PT-188129121 , a bar graph created with the "Bar Graph It!" button from a table did not have its history recorded in a way that could play back without errors.  In fact this was failing for other tiles (data cards, graph) created with shared models pre-attached; changes made in response to the shared model were recorded in history _before_ the creation of the tile, and thus would fail on replay.

This PR is more careful about the order in which these events are recorded in history.  In addition, some deeper issues with the Data Card tile are addressed so that undo, redo, and history playback should now work for the "Data Card It!" case.
