### PR TITLE
Track end of document edit session

### DIFF
--- a/src/hooks/use-document-sync-to-firebase.ts
+++ b/src/hooks/use-document-sync-to-firebase.ts
@@ -67,7 +67,6 @@ export function useDocumentSyncToFirebase(
         // If an onDisconnect was set, remove it and set updated timestamp to now.
         if (disconnectHandler.current) {
           firebase.setLastEditedNow(user, key, uid, disconnectHandler.current);
-          console.log("Doc closed, setting last modified", key);
         }
       };
     }
@@ -205,7 +204,6 @@ export function useDocumentSyncToFirebase(
   const mutation = useMutation((snapshot: DocumentContentSnapshotType) => {
     if (!disconnectHandler.current) {
       disconnectHandler.current = firebase.setLastEditedOnDisconnect(user, key, uid);
-      console.log("Doc modified, tracking disconnect", key);
     }
 
     const tileMap = snapshot.tileMap || {};

--- a/src/hooks/use-document-sync-to-firebase.ts
+++ b/src/hooks/use-document-sync-to-firebase.ts
@@ -68,7 +68,7 @@ export function useDocumentSyncToFirebase(
         document.treeMonitor.enabled = true;
       }
       // Set up listener for online status
-      firebase.onlineStatusRef.off('value', handlePresenceChange);
+      firebase.onlineStatusRef.on('value', handlePresenceChange);
 
       return () => {
         // disable history tracking on this document

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -38,6 +38,10 @@ export class Firebase {
     return this.user !== null;
   }
 
+  public get onlineStatusRef() {
+    return firebase.database().ref(".info/connected");
+  }
+
   public ref(path = "") {
     if (!this.isConnected) {
       throw new Error("ref() requested before db connected!");

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -180,6 +180,32 @@ export class Firebase {
     return `${this.getUserPath(user, userId)}/documentMetadata${suffix}`;
   }
 
+  public getLastEditedMetadataPath(user: UserModelType, documentKey: string, userId?: string) {
+    return `${this.getUserDocumentMetadataPath(user, documentKey, userId)}/lastEditedAt`;
+  }
+
+  /**
+   * Set up a Firebase onDisconnect handler to update the lastEditedAt timestamp when the user disconnects.
+   */
+  public setLastEditedOnDisconnect(user: UserModelType, documentKey: string, userId?: string) {
+    const ref = this.ref(this.getLastEditedMetadataPath(user, documentKey, userId));
+    const onDisconnect = ref.onDisconnect();
+    onDisconnect.set(firebase.database.ServerValue.TIMESTAMP);
+    return onDisconnect;
+  }
+
+  /**
+   * Set the lastEditedAt timestamp to the current time, optionally cancelling an onDisconnect handler.
+   */
+  public setLastEditedNow(user: UserModelType, documentKey: string, userId: string|undefined,
+      onDisconnect?: firebase.database.OnDisconnect) {
+    if (onDisconnect) {
+      onDisconnect.cancel();
+    }
+    return this.ref(this.getLastEditedMetadataPath(user, documentKey, userId))
+      .set(firebase.database.ServerValue.TIMESTAMP);
+  }
+
   // Unpublished personal document/learning log metadata
   public getOtherDocumentPath(user: UserModelType, documentType: OtherDocumentType, documentKey?: string) {
     const dir = documentType === PersonalDocument ? "personalDocs" : "learningLogs";


### PR DESCRIPTION
PT-188320636

Adds a `lastEditedAt` metadata property for documents. After a document is modified by a user, this is set to the time when either:
* The document is unloaded from the editing workspace (eg, user opens a different document) or
* The user's database session ends (tab closed, browser closed, WiFi connection lost, etc)