### PR TITLE
unify more the titles displayed for documents

### DIFF
--- a/shared/shared.ts
+++ b/shared/shared.ts
@@ -106,20 +106,23 @@ export function getDocumentPath(userId: string, documentKey: string, network?: s
   return documentPath;
 }
 
-export interface IDocumentMetadata {
+export interface IDocumentMetadataBase {
   uid: string;
   type: string;
   key: string;
+  title?: string|null;
+  visibility?: string;
+  investigation?: string|null;
+  problem?: string|null;
+  unit?: string|null;
+}
+
+export interface IDocumentMetadata extends IDocumentMetadataBase {
   createdAt?: number;
-  title?: string;
-  originDoc?: string;
+  originDoc?: string|null;
   properties?: Record<string, string>;
   tools?: string[];
   strategies?: string[];
-  investigation?: string;
-  problem?: string;
-  unit?: string|null;
-  visibility?: string;
 }
 export function isDocumentMetadata(o: any): o is IDocumentMetadata {
   return !!o.uid && !!o.type && !!o.key;

--- a/src/components/document/document-group.tsx
+++ b/src/components/document/document-group.tsx
@@ -1,9 +1,8 @@
 import React, { useEffect, useRef, useState } from "react";
 import { observer } from "mobx-react-lite";
-import { DocumentModelType } from "../../models/document/document";
 import { SimpleDocumentItem } from "../thumbnail/simple-document-item";
-import { IDocumentMetadata } from "../../../shared/shared";
 import { DocumentGroup } from "../../models/stores/document-group";
+import { IDocumentMetadataModel } from "../../models/stores/sorted-documents";
 
 import ScrollArrowIcon from "../../assets/workspace-instance-scroll.svg";
 
@@ -12,7 +11,7 @@ import "./document-group.scss";
 interface IProps {
   documentGroup: DocumentGroup;
   secondarySort: string;
-  onSelectDocument: (document: DocumentModelType | IDocumentMetadata) => void;
+  onSelectDocument: (document: IDocumentMetadataModel) => void;
 }
 
 export const DocumentGroupComponent = observer(function DocumentGroupComponent(props: IProps) {
@@ -119,13 +118,11 @@ export const DocumentGroupComponent = observer(function DocumentGroupComponent(p
       }
       {visibleCount < docCount && renderScrollButton("left", leftArrowDisabled)}
       <div ref={docListContainerRef} className="doc-group-list simple" data-testid="doc-group-list">
-        {documentGroup.documents?.map((doc: any) => {
+        {documentGroup.documents?.map((doc) => {
           return (
             <SimpleDocumentItem
               key={doc.key}
               document={doc}
-              investigationOrdinal={doc.investigation}
-              problemOrdinal={doc.problem}
               onSelectDocument={onSelectDocument}
             />
           );

--- a/src/components/document/document.tsx
+++ b/src/components/document/document.tsx
@@ -11,6 +11,7 @@ import { logDocumentEvent, logDocumentViewEvent } from "../../models/document/lo
 import { IToolbarModel } from "../../models/stores/problem-configuration";
 import { SupportType, TeacherSupportModelType, AudienceEnum } from "../../models/stores/supports";
 import { WorkspaceModelType } from "../../models/stores/workspace";
+import { getDocumentTitleWithTimestamp } from "../../models/document/document-utils";
 import { ENavTab } from "../../models/view/nav-tabs";
 import { IconButton } from "../utilities/icon-button";
 import ToggleControl from "../utilities/toggle-control";
@@ -384,7 +385,9 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
               { !hideButtons && <EditButton onClick={this.handleDocumentRename} /> }
             </div>
           : <div className="title" data-test="personal-doc-title">
-              <TitleInfo docTitle={`${document.getDisplayTitle(appConfig)}`} onClick={this.handleDocumentRename} />
+              <TitleInfo
+                docTitle={`${getDocumentTitleWithTimestamp(document, appConfig)}`}
+                onClick={this.handleDocumentRename} />
               { !hideButtons && <EditButton onClick={this.handleDocumentRename} /> }
             </div>
         }

--- a/src/components/document/sort-work-document-area.tsx
+++ b/src/components/document/sort-work-document-area.tsx
@@ -1,8 +1,7 @@
 import React, { useState } from "react";
 import classNames from "classnames";
 import { observer } from "mobx-react";
-import { useAppConfig, useProblemStore,
-  usePersistentUIStore, useUserStore, useClassStore, useUIStore, useStores } from "../../hooks/use-stores";
+import { useStores } from "../../hooks/use-stores";
 import { DocumentModelType } from "../../models/document/document";
 import { EditableDocumentContent } from "./editable-document-content";
 import { getDocumentDisplayTitle } from "../../models/document/document-utils";
@@ -24,13 +23,8 @@ interface IProps {
 
 export const SortWorkDocumentArea: React.FC<IProps> = observer(function SortWorkDocumentArea(props: IProps) {
   const { openDocumentsGroup } = props;
-  const store = useStores();
-  const ui = useUIStore();
-  const persistentUI = usePersistentUIStore();
-  const user = useUserStore();
-  const classStore = useClassStore();
-  const problemStore = useProblemStore();
-  const appConfigStore = useAppConfig();
+  const {appConfig, class: classStore, documents, networkDocuments,
+    persistentUI, sortedDocuments, ui, unit, user} = useStores();
   const tabState = persistentUI.tabs.get(ENavTab.kSortWork);
   const openDocumentKey = tabState?.openSubTab && tabState?.openDocuments.get(tabState.openSubTab);
   const showScroller = persistentUI.showDocumentScroller;
@@ -43,24 +37,24 @@ export const SortWorkDocumentArea: React.FC<IProps> = observer(function SortWork
   }
 
   const getOpenDocument = () => {
-    const openDoc = store.documents.getDocument(openDocumentKey) ||
-                      store.networkDocuments.getDocument(openDocumentKey);
+    const openDoc = documents.getDocument(openDocumentKey) ||
+                      networkDocuments.getDocument(openDocumentKey);
     if (openDoc) {
       return openDoc;
     }
 
     // Calling `fetchFullDocument` will update the `documents` store with the full document,
     // triggering a re-render of this component since it's an observer.
-    store.sortedDocuments.fetchFullDocument(openDocumentKey);
+    sortedDocuments.fetchFullDocument(openDocumentKey);
   };
 
   const openDocument = getOpenDocument();
-  const isVisible = openDocument?.isAccessibleToUser(user, store.documents);
-  const showPlayback = user.type && appConfigStore.enableHistoryRoles.includes(user.type);
+  const isVisible = openDocument?.isAccessibleToUser(user, documents);
+  const showPlayback = user.type && appConfig.enableHistoryRoles.includes(user.type);
   const showExemplarShare = user.type === "teacher" && openDocument && isExemplarType(openDocument.type);
   const getDisplayTitle = (document: DocumentModelType) => {
     const documentOwner = classStore.users.get(document.uid);
-    const documentTitle = getDocumentDisplayTitle(document, appConfigStore, problemStore, store.unit.code);
+    const documentTitle = getDocumentDisplayTitle(unit, document, appConfig);
     return {owner: documentOwner ? documentOwner.fullName : "", title: documentTitle};
   };
   const displayTitle = openDocument && getDisplayTitle(openDocument);

--- a/src/components/document/sorted-section.tsx
+++ b/src/components/document/sorted-section.tsx
@@ -5,7 +5,6 @@ import classNames from "classnames";
 import { DocumentModelType } from "../../models/document/document";
 import { useStores } from "../../hooks/use-stores";
 import { DocFilterType, SecondarySortType } from "../../models/stores/ui-types";
-import { IDocumentMetadata } from "../../../shared/shared";
 import { DocumentGroup } from "../../models/stores/document-group";
 import { DocumentGroupComponent } from "./document-group";
 import { logDocumentViewEvent } from "../../models/document/log-document-event";
@@ -53,7 +52,7 @@ export const SortedSection: React.FC<IProps> = observer(function SortedSection(p
                                : { primaryLabel: documentGroup.label, primaryType: documentGroup.sortType,
                                    secondaryLabel: label, secondaryType: sortType };
 
-    return async (document: DocumentModelType | IDocumentMetadata) => {
+    return async (document: DocumentModelType | IDocumentMetadataModel) => {
       const openSubTab = JSON.stringify(openSubTabMetadata);
       persistentUI.openSubTabDocument(ENavTab.kSortWork, openSubTab, document.key);
       logDocumentViewEvent(document);

--- a/src/components/navigation/document-view.tsx
+++ b/src/components/navigation/document-view.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import { observer } from "mobx-react";
 import { useQueryClient } from "react-query";
 import classNames from "classnames";
-import { useAppConfig, useLocalDocuments, useProblemStore, useStores,
-  usePersistentUIStore, useUserStore, useClassStore, useUIStore } from "../../hooks/use-stores";
+import { useAppConfig, useLocalDocuments, useStores,
+  usePersistentUIStore } from "../../hooks/use-stores";
 import { useUserContext } from "../../hooks/use-user-context";
 import { ISubTabSpec, NavTabModelType, kBookmarksTabTitle } from "../../models/view/nav-tabs";
 import { DocumentType } from "../../models/document/document-types";
@@ -202,18 +202,14 @@ interface IDocumentAreaProps {
 }
 
 const DocumentArea = ({openDocument, subTab, tab, sectionClass, isSecondaryDocument,
-    hasSecondaryDocument, hideLeftFlipper, hideRightFlipper, onChangeDocument}: IDocumentAreaProps) => {
-  const ui = useUIStore();
-  const persistentUI = usePersistentUIStore();
-  const user = useUserStore();
-  const appConfig = useAppConfig();
-  const classStore = useClassStore();
-  const problemStore = useProblemStore();
+    hasSecondaryDocument, hideLeftFlipper, hideRightFlipper, onChangeDocument}: IDocumentAreaProps
+) => {
+  const {appConfig, class: classStore, persistentUI, ui, unit, user} = useStores();
   const showPlayback = user.type && !openDocument?.isPublished
                           ? appConfig.enableHistoryRoles.includes(user.type) : false;
   const getDisplayTitle = (document: DocumentModelType) => {
     const documentOwner = classStore.users.get(document.uid);
-    const documentTitle = getDocumentDisplayTitle(document, appConfig, problemStore);
+    const documentTitle = getDocumentDisplayTitle(unit, document, appConfig);
     return {owner: documentOwner ? documentOwner.fullName : "", title: documentTitle};
   };
   const displayTitle = getDisplayTitle(openDocument);

--- a/src/components/thumbnail/simple-document-item.tsx
+++ b/src/components/thumbnail/simple-document-item.tsx
@@ -1,30 +1,24 @@
 import { observer } from "mobx-react";
 import React from "react";
-import { IDocumentMetadata } from "../../../shared/shared";
+import { IDocumentMetadataModel } from "../../models/stores/sorted-documents";
 import { useStores } from "../../hooks/use-stores";
-import { isDocumentAccessibleToUser } from "../../models/document/document-utils";
+import { getDocumentDisplayTitle, isDocumentAccessibleToUser } from "../../models/document/document-utils";
 
 import "./simple-document-item.scss";
 
 interface IProps {
-  document: IDocumentMetadata;
-  investigationOrdinal: string;
-  problemOrdinal: string;
-  onSelectDocument: (document: IDocumentMetadata) => void;
+  document: IDocumentMetadataModel;
+  onSelectDocument: (document: IDocumentMetadataModel) => void;
 }
 
 export const SimpleDocumentItem = observer(function SimpleDocumentItem(
-  { document, investigationOrdinal, onSelectDocument, problemOrdinal }: IProps
+  { document, onSelectDocument }: IProps
 ) {
-  const { documents, class: classStore, unit, user } = useStores();
+  const { appConfig, documents, class: classStore, unit, user } = useStores();
   const { uid } = document;
   const userName = classStore.getUserById(uid)?.displayName;
-  // TODO: Make it so we don't have to convert investigationOrdinal and problemOrdinal to numbers here? We do so
-  // because the values originate as strings. Changing their types to numbers in the model would make this unnecessary,
-  // but doing that causes errors elsewhere when trying to load documents that aren't associated with a problem.
-  const investigation = unit.getInvestigation(Number(investigationOrdinal));
-  const problem = investigation?.getProblem(Number(problemOrdinal));
-  const title = document.title ? `${userName}: ${document.title}` : `${userName}: ${problem?.title ?? "unknown title"}`;
+  const title = getDocumentDisplayTitle(unit, document, appConfig);
+  const titleWithUser = `${userName}: ${title}`;
   const isPrivate = !isDocumentAccessibleToUser(document, user, documents);
 
   const handleClick = () => {
@@ -35,7 +29,7 @@ export const SimpleDocumentItem = observer(function SimpleDocumentItem(
     <div
       className={isPrivate ? "simple-document-item private" : "simple-document-item"}
       data-test="simple-document-item"
-      title={title}
+      title={titleWithUser}
       onClick={!isPrivate ? handleClick : undefined}
     >
     </div>

--- a/src/hooks/use-document-caption.tsx
+++ b/src/hooks/use-document-caption.tsx
@@ -1,14 +1,11 @@
 import { useFirestoreTeacher } from "./firestore-hooks";
-import { useAppConfig, useClassStore, useProblemStore, useUserStore } from "./use-stores";
 import { DocumentModelType } from "../models/document/document";
 import { ExemplarDocument, isPublishedType, isUnpublishedType } from "../models/document/document-types";
 import { getDocumentDisplayTitle } from "../models/document/document-utils";
+import { useStores } from "./use-stores";
 
 export function useDocumentCaption(document: DocumentModelType, isStudentWorkspaceDoc?: boolean) {
-  const appConfig = useAppConfig();
-  const problem = useProblemStore();
-  const classStore = useClassStore();
-  const user = useUserStore();
+  const {appConfig, class: classStore, unit, user} = useStores();
   const { type, uid } = document;
   const pubVersion = document.pubVersion;
   const teacher = useFirestoreTeacher(uid, user.network || "");
@@ -29,6 +26,6 @@ export function useDocumentCaption(document: DocumentModelType, isStudentWorkspa
                       : isPublishedType(type) && pubVersion
                           ? ` v${pubVersion}`
                           : "";
-  const title = getDocumentDisplayTitle(document, appConfig, problem);
+  const title = getDocumentDisplayTitle(unit, document, appConfig);
   return `${namePrefix}${title}${dateSuffix}`;
 }

--- a/src/models/document/document-types.ts
+++ b/src/models/document/document-types.ts
@@ -25,6 +25,9 @@ export function isPersonalType(type: string) {
 export function isLearningLogType(type: string) {
   return [LearningLogDocument, LearningLogPublication].indexOf(type) >= 0;
 }
+export function isSupportType(type: string) {
+  return type === SupportPublication;
+}
 export function isExemplarType(type: string) {
   return type === ExemplarDocument;
 }

--- a/src/models/document/document-utils.test.ts
+++ b/src/models/document/document-utils.test.ts
@@ -92,7 +92,7 @@ describe("document utils", () => {
         });
         const appConfig = AppConfigModel.create({config: unitConfigDefaults});
         const title = getDocumentDisplayTitle(unit, metadata, appConfig);
-        expect(title).toBe("Test Title (23FEB76-00:00:00)");
+        expect(title).toMatch(/Test Title \(23FEB76-..:..:..\)/);
       });
     });
 

--- a/src/models/document/document-utils.test.ts
+++ b/src/models/document/document-utils.test.ts
@@ -1,0 +1,179 @@
+import { UnitModel } from "../curriculum/unit";
+import { AppConfigModel } from "../stores/app-config-model";
+import { DocumentMetadataModel } from "../stores/sorted-documents";
+import { PersonalDocument, ProblemDocument, SupportPublication } from "./document-types";
+import { getDocumentDisplayTitle } from "./document-utils";
+import { unitConfigDefaults } from "../../test-fixtures/sample-unit-configurations";
+
+describe("document utils", () => {
+  describe("getDocumentDisplayTitle", () => {
+    describe("support documents", () => {
+      test("without caption", () => {
+        const metadata = DocumentMetadataModel.create({
+          type: SupportPublication,
+          uid: "123",
+          key: "123",
+        });
+        const unit = UnitModel.create({
+          code: "test",
+          title: "test"
+        });
+        const appConfig = AppConfigModel.create();
+        const title = getDocumentDisplayTitle(unit, metadata, appConfig);
+        expect(title).toBe("Support");
+      });
+      test("with caption", () => {
+        const metadata = DocumentMetadataModel.create({
+          type: SupportPublication,
+          uid: "123",
+          key: "123",
+          properties: {
+            caption: "Test Title"
+          }
+        });
+        const unit = UnitModel.create({
+          code: "test",
+          title: "test"
+        });
+        const appConfig = AppConfigModel.create();
+        const title = getDocumentDisplayTitle(unit, metadata, appConfig);
+        expect(title).toBe("Test Title");
+      });
+    });
+
+    describe("personal documents", () => {
+      test("without title", () => {
+        const metadata = DocumentMetadataModel.create({
+          type: PersonalDocument,
+          uid: "123",
+          key: "123",
+        });
+        const unit = UnitModel.create({
+          code: "test",
+          title: "test"
+        });
+        const appConfig = AppConfigModel.create({config: unitConfigDefaults});
+        const title = getDocumentDisplayTitle(unit, metadata, appConfig);
+        expect(title).toBe(null);
+      });
+
+      test("with a title", () => {
+        const metadata = DocumentMetadataModel.create({
+          type: PersonalDocument,
+          uid: "123",
+          key: "123",
+          title: "Test Title"
+        });
+        const unit = UnitModel.create({
+          code: "test",
+          title: "test"
+        });
+        const appConfig = AppConfigModel.create({config: unitConfigDefaults});
+        const title = getDocumentDisplayTitle(unit, metadata, appConfig);
+        expect(title).toBe("Test Title");
+      });
+
+      // NOTE: the default appConfig does not configure a timestamp property
+      // and none of the production units set this property.
+      // So really this timestamp feature is dead code in production
+      test("with a title and configured timestamp property", () => {
+        const metadata = DocumentMetadataModel.create({
+          type: PersonalDocument,
+          uid: "123",
+          key: "123",
+          title: "Test Title",
+          properties: {
+           timeStamp: "193899600000"
+          }
+        });
+        const unit = UnitModel.create({
+          code: "test",
+          title: "test"
+        });
+        const appConfig = AppConfigModel.create({config: unitConfigDefaults});
+        const title = getDocumentDisplayTitle(unit, metadata, appConfig);
+        expect(title).toBe("Test Title (23FEB76-00:00:00)");
+      });
+    });
+
+    describe("problem documents", () => {
+      test("without a unit", () => {
+        const metadata = DocumentMetadataModel.create({
+          type: ProblemDocument,
+          uid: "123",
+          key: "123",
+        });
+        const unit = UnitModel.create({
+          code: "test",
+          title: "test"
+        });
+        const appConfig = AppConfigModel.create({config: unitConfigDefaults});
+        const title = getDocumentDisplayTitle(unit, metadata, appConfig);
+        expect(title).toBe("Problem doc without unit");
+      });
+      test("from another unit", () => {
+        const metadata = DocumentMetadataModel.create({
+          type: ProblemDocument,
+          uid: "123",
+          key: "123",
+          unit: "other",
+          investigation: "1",
+          problem: "1"
+        });
+        const unit = UnitModel.create({
+          code: "test",
+          title: "test"
+        });
+        const appConfig = AppConfigModel.create({config: unitConfigDefaults});
+        const title = getDocumentDisplayTitle(unit, metadata, appConfig);
+        expect(title).toBe("Problem doc from other-1.1");
+      });
+      test("from the same unit but for a problem that doesn't exist", () => {
+        const metadata = DocumentMetadataModel.create({
+          type: ProblemDocument,
+          uid: "123",
+          key: "123",
+          unit: "test",
+          investigation: "1",
+          problem: "1"
+        });
+        const unit = UnitModel.create({
+          code: "test",
+          title: "test"
+        });
+        const appConfig = AppConfigModel.create({config: unitConfigDefaults});
+        const title = getDocumentDisplayTitle(unit, metadata, appConfig);
+        expect(title).toBe("Problem doc from test-1.1");
+      });
+      test("from the same unit", () => {
+        const metadata = DocumentMetadataModel.create({
+          type: ProblemDocument,
+          uid: "123",
+          key: "123",
+          unit: "test",
+          investigation: "1",
+          problem: "1"
+        });
+        const unit = UnitModel.create({
+          code: "test",
+          title: "Test Unit",
+          investigations: [
+            {
+              ordinal: 1,
+              title: "Test Investigation",
+              problems: [
+                {
+                  ordinal: 1,
+                  title: "Test Problem"
+                }
+              ]
+            }
+          ]
+        });
+        const appConfig = AppConfigModel.create({config: unitConfigDefaults});
+        const title = getDocumentDisplayTitle(unit, metadata, appConfig);
+        expect(title).toBe("Test Problem");
+      });
+    });
+  });
+});

--- a/src/models/document/document-utils.ts
+++ b/src/models/document/document-utils.ts
@@ -20,7 +20,7 @@ function getProblemFromDoc(unit: UnitModelType, document: DocumentModelType | ID
   return problem;
 }
 
-function getDocumentTileFromProblem(currentUnit: UnitModelType, document: DocumentModelType | IDocumentMetadataModel) {
+function getDocumentTitleFromProblem(currentUnit: UnitModelType, document: DocumentModelType | IDocumentMetadataModel) {
   const {type, unit, investigation, problem} = document;
   const problemModel = getProblemFromDoc(currentUnit, document);
   if (problemModel) {
@@ -61,7 +61,7 @@ export function getDocumentDisplayTitle(
   if (isSupportType(type)) {
     return document.getProperty("caption") || "Support";
   } else if (isProblemType(type) || isPlanningType(type)) {
-    return getDocumentTileFromProblem(unit, document);
+    return getDocumentTitleFromProblem(unit, document);
   } else {
     return getDocumentTitleWithTimestamp(document, appConfig);
   }

--- a/src/models/document/document.ts
+++ b/src/models/document/document.ts
@@ -15,7 +15,6 @@ import {
 } from "../../../shared/shared";
 import { getFirebaseFunction } from "../../hooks/use-firebase-function";
 import { IDocumentProperties } from "../../lib/db-types";
-import { getLocalTimeStamp } from "../../utilities/time";
 import { safeJsonParse } from "../../utilities/js-utils";
 import { Tree } from "../history/tree";
 import { TreeMonitor } from "../history/tree-monitor";
@@ -130,17 +129,6 @@ export const DocumentModel = Tree.named("Document")
         docStr += self.getProperty(prop) ? `:${prop}` : `:!${prop}`;
       });
       return appConfig.getDocumentLabel(docStr, count, lowerCase);
-    },
-    getDisplayTitle(appConfig: AppConfigModelType) {
-      const timeStampPropName = appConfig.docTimeStampPropertyName || undefined;
-      const timeStampProp = timeStampPropName && self.getProperty(timeStampPropName);
-      const timeStamp = timeStampProp
-                          ? parseFloat(timeStampProp)
-                          : undefined;
-      const timeStampStr = timeStamp ? getLocalTimeStamp(timeStamp) : undefined;
-      return timeStampStr
-              ? `${self.title} (${timeStampStr})`
-              : self.title;
     },
     getDisplayId(appConfig: AppConfigModelType) {
       const { docDisplayIdPropertyName } = appConfig;

--- a/src/models/document/log-document-event.ts
+++ b/src/models/document/log-document-event.ts
@@ -1,6 +1,7 @@
 import { IDocumentMetadata } from "../../../shared/shared";
 import { Logger } from "../../lib/logger";
 import { LogEventMethod, LogEventName } from "../../lib/logger-types";
+import { IDocumentMetadataModel } from "../stores/sorted-documents";
 import { UserModelType } from "../stores/user";
 import { DocumentModelType } from "./document";
 import { ExemplarDocument } from "./document-types";
@@ -11,7 +12,7 @@ interface ITeacherNetworkInfo {
 }
 
 export interface IDocumentLogEvent extends Record<string, any> {
-  document: DocumentModelType | IDocumentMetadata;
+  document: DocumentModelType | IDocumentMetadata | IDocumentMetadataModel;
 }
 
 export function isDocumentLogEvent(params: Record<string, any>): params is IDocumentLogEvent {
@@ -59,7 +60,7 @@ export function logDocumentEvent(event: LogEventName, _params: IDocumentLogEvent
  * Convenience function to log the appropriate type of VIEW_SHOW_*_DOCUMENT event for the document.
  * @param document
  */
-export function logDocumentViewEvent(document: DocumentModelType | IDocumentMetadata) {
+export function logDocumentViewEvent(document: DocumentModelType | IDocumentMetadata | IDocumentMetadataModel) {
   const isRemote = "isRemote" in document ? document.isRemote : undefined;
   const event =
     document.type === ExemplarDocument

--- a/src/models/stores/sorted-documents.ts
+++ b/src/models/stores/sorted-documents.ts
@@ -64,7 +64,13 @@ export const DocumentMetadataModel = types.model("DocumentMetadata", {
   problem: types.maybeNull(types.string),
   unit: types.maybeNull(types.string),
   visibility: types.maybe(types.string)
-});
+})
+.views((self) => ({
+  getProperty(key: string) {
+    return self.properties.get(key);
+  },
+}));
+
 export interface IDocumentMetadataModel extends Instance<typeof DocumentMetadataModel> {}
 
 export const MetadataDocMapModel = types.map(DocumentMetadataModel);


### PR DESCRIPTION
Specifically this unifies the way the simple document items (the boxes in the sorted documents view), and the thumbnail captions are computed. It also improves the titling when the unit or problem is not known or found for the current document.

Additionally it takes care of an issue with the creation of the metadata documents. Before we started using them for the sort work view they were created by the history system so the history entries could be stored underneath the metadata document. When we added the sort work view we started creating these metadata documents immediately when any document was created.  The new spot that created these documents makes sure to set the unit, investigation, and problem when necessary. The original spot in the history system was not doing this. So if the history system created the metadata document first it would created without the unit, investigation, and problem. 

This PR fixes that problem by removing the history system's metadata creation code and replacing it with some code that will wait 5 seconds for the metadata document to be created.

PT-188328447