### PR TITLE
Fix Cypress Tests

### DIFF
--- a/cypress/support/elements/common/SortedWork.js
+++ b/cypress/support/elements/common/SortedWork.js
@@ -67,7 +67,7 @@ class SortedWork {
     return cy.get("[data-test=list-item-all]");
   }
   openSortWorkSection(sectionLabel) {
-    return cy.get(".sort-work-view .sorted-sections .section-header-label").contains(sectionLabel).get(".section-header-right .section-header-arrow").click({multiple: true});
+    return cy.get(".sort-work-view .sorted-sections .section-header-label").contains(".section-header-label", sectionLabel).find(".section-header-arrow").click();
   }
   checkDocumentInGroup(groupName, doc) {
     this.getSortWorkGroup(groupName).find(".documents-list .list-item .footer .info").should("contain", doc);

--- a/cypress/support/elements/tile/DataflowToolTile.js
+++ b/cypress/support/elements/tile/DataflowToolTile.js
@@ -242,13 +242,13 @@ class DataflowToolTile {
   recordData(samplingRate, timer) {
     this.selectSamplingRate(samplingRate);
     this.getRecordButton().click();
-    this.getCountdownTimer().should("contain", "000:0" + timer.toString());
+    this.getCountdownTimer({timeout: (timer + 2) * 1000}).should("contain", "000:0" + timer.toString());
     this.getStopButton().click();
   }
   recordDataWithoutStop(samplingRate, timer) {
     this.selectSamplingRate(samplingRate);
     this.getRecordButton().click();
-    this.getCountdownTimer().should("contain", "000:0" + timer.toString());
+    this.getCountdownTimer({timeout: (timer + 2) * 1000}).should("contain", "000:0" + timer.toString());
   }
   clearRecordedData() {
     this.getRecordingClearButton().click();

--- a/src/models/stores/sorted-documents.ts
+++ b/src/models/stores/sorted-documents.ts
@@ -1,4 +1,4 @@
-import { makeAutoObservable } from "mobx";
+import { makeAutoObservable, runInAction } from "mobx";
 import { types, Instance, SnapshotIn, applySnapshot, typecheck, unprotect } from "mobx-state-tree";
 import { union } from "lodash";
 import firebase from "firebase";
@@ -310,7 +310,8 @@ export class SortedDocuments {
         problem: doc.problem,
         unit: doc.unit
       });
-      docsMap.put(metadata);
+      // MST's unprotect doesn't disable MobX's strict mode warnings
+      runInAction(() => docsMap.put(metadata));
     });
     return docsMap;
   }


### PR DESCRIPTION
The code for opening a specific section was opening all of the currently visible sections. The actual section that should be opened might not be visible yet.

There were extraneous MobX warnings showing up in the tests. These were fixed by wrapping the change in a runInAction.

When running locally the default timeout is now 5s which is was too short for the dataflow timer waiting.