### PR TITLE
Refresh class roster plus refactor

### DIFF
--- a/cypress/e2e/functional/document_tests/group_chooser_spec.js
+++ b/cypress/e2e/functional/document_tests/group_chooser_spec.js
@@ -10,6 +10,13 @@ let student1 = '20',
   student4 = '23',
   student5 = '24',
   student6 = '25',
+  // Students with ids higher than 99 are not part of the fake class
+  // that is setup for QA, Dev, and Demo modes. For the CLUE window
+  // that is showing a high id student they are added to the class,
+  // but for other CLUE windows they will not be part of the class.
+  // So when viewed in other CLUE windows this student will
+  // be considered not in the class.
+  studentNotInClass = '150',
   fakeClass = '15',
   problem = '1.1',
   group1 = '20',
@@ -125,5 +132,48 @@ context('Test student join a group', function () {
     clueHeader.getGroupName().should('contain', 'Group ' + group1);
     header.getUserName().should('contain', 'Student ' + student1);
     clueHeader.getGroupMembers().should('contain', 'S' + student1).and('have.length', 1);
+
+    cy.log('will verify a student removed from the class is not visible');
+    // have student6 leave first group so special student can join
+    setup(student6, { alreadyInGroup: true });
+    cy.get('.app .group > .name').contains('Group ' + group1).click();
+    cy.get("#okButton").should('contain', 'Yes').click();
+
+    // have special student join group 1
+    setup(studentNotInClass);
+    cy.wait(500);
+    cy.get('.groups > .group-list > .group').contains(group1).click();
+    clueHeader.getGroupName().should('contain', 'Group ' + group1);
+    header.getUserName().should('contain', 'Student ' + studentNotInClass);
+    clueHeader.getGroupMembers()
+      .should('contain', 'S' + student1)
+      .and('contain', 'S' + student2)
+      .and('contain', 'S' + student4)
+      .and('contain', 'S' + studentNotInClass);
+
+    // Need to wait more than 1s so the student not in the class is considered removed
+    cy.wait(1500);
+    // switch back to student 1
+    setup(student1, { alreadyInGroup: true });
+    clueHeader.getGroupName().should('contain', 'Group ' + group1);
+    header.getUserName().should('contain', 'Student ' + student1);
+    // The studentNotInClass should not show up now
+    clueHeader.getGroupMembers()
+      .should('contain', 'S' + student1)
+      .and('contain', 'S' + student2)
+      .and('contain', 'S' + student4)
+      .and('not.contain', '**') // these are the initials of new students
+      .and('not.contain', 'S' + studentNotInClass);
+
+    cy.log('verify a 4th student can join a group with a removed student');
+    setup(student6);
+    cy.get('.groups > .group-list > .group').contains(group1).click();
+    clueHeader.getGroupName().should('contain', 'Group ' + group1);
+    header.getUserName().should('contain', 'Student ' + student6);
+    clueHeader.getGroupMembers()
+      .should('contain', 'S' + student1)
+      .and('contain', 'S' + student2)
+      .and('contain', 'S' + student4)
+      .and('contain', 'S' + student6);
   });
 });

--- a/src/clue/components/clue-app-header.tsx
+++ b/src/clue/components/clue-app-header.tsx
@@ -82,7 +82,7 @@ export const ClueAppHeaderComponent: React.FC<IProps> = observer(function ClueAp
   };
 
   const renderGroup = (group: GroupModelType) => {
-    const groupUsers = group.users.slice();
+    const groupUsers = group.activeUsers.slice();
     const userIndex = groupUsers.findIndex((groupUser) => groupUser.id === user.id);
     // Put the main user first to match 4-up colors
     if (userIndex > -1) {

--- a/src/clue/components/teacher/teacher-student-tab.tsx
+++ b/src/clue/components/teacher/teacher-student-tab.tsx
@@ -32,7 +32,7 @@ export class TeacherStudentTabComponent extends BaseComponent<IProps, IState> {
     const { groupId } = this.props;
     const group = groups.getGroupById(groupId);
     // TODO: if no group prop then get list of all users in class
-    const users = group ? group.users : [];
+    const users = group ? group.activeUsers : [];
     return (
       <div className="teacher-student-tab">
         {this.renderUsers(users)}

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -49,14 +49,14 @@ function resolveAppMode(
 }
 
 export const authAndConnect = async (stores: IStores) => {
-  const {appConfig, curriculumConfig, appMode, db, user, ui} = stores;
+  const {appConfig, appMode, curriculumConfig, db, portal, user, ui} = stores;
   let rawPortalJWT: string | undefined;
 
   showLoadingMessage("Connecting");
 
   try {
     const {appMode: newAppMode, authenticatedUser, classInfo, problemId, unitCode} =
-      await authenticate(appMode, appConfig, curriculumConfig, urlParams);
+      await authenticate(appMode, appConfig, curriculumConfig, portal, urlParams);
 
     // authentication can trigger appMode change (e.g. preview => demo)
     if (newAppMode && (newAppMode !== appMode)) {
@@ -180,7 +180,7 @@ export class AppComponent extends BaseComponent<IProps> {
 
     if (user.isStudent) {
       if (!user.currentGroupId) {
-        if (appConfig.autoAssignStudentsToIndividualGroups || this.stores.isPreviewing) {
+        if (appConfig.autoAssignStudentsToIndividualGroups || this.stores.portal.isPortalPreview) {
           // use userId as groupId
           db.joinGroup(user.id);
         }

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -64,9 +64,6 @@ export const authAndConnect = async (stores: IStores) => {
     }
     user.setAuthenticatedUser(authenticatedUser);
     rawPortalJWT = authenticatedUser.rawPortalJWT;
-    if (classInfo) {
-      stores.class.updateFromPortal(classInfo);
-    }
 
     // If the URL has a unit param or if the appMode is not "authed", then
     // `stores.loadUnitAndProblem` would have been called in initializeApp,
@@ -109,6 +106,12 @@ export const authAndConnect = async (stores: IStores) => {
     }
 
     await resolveAppMode(stores, authenticatedUser.rawFirebaseJWT);
+
+    if (classInfo) {
+      const timeOffset = await db.firebase.getServerTimeOffset();
+      classInfo.serverTimestamp = classInfo.localTimestamp + timeOffset;
+      stores.class.updateFromPortal(classInfo);
+    }
 
     const firestoreUser = user.isTeacher
               ? await db.firestore.getFirestoreUser(user.id)

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -48,89 +48,87 @@ function resolveAppMode(
   }
 }
 
-export const authAndConnect = (stores: IStores) => {
+export const authAndConnect = async (stores: IStores) => {
   const {appConfig, curriculumConfig, appMode, db, user, ui} = stores;
   let rawPortalJWT: string | undefined;
 
   showLoadingMessage("Connecting");
 
-  authenticate(appMode, appConfig, curriculumConfig, urlParams)
-    .then(({appMode: newAppMode, authenticatedUser, classInfo, problemId, unitCode}) => {
-      // authentication can trigger appMode change (e.g. preview => demo)
-      if (newAppMode && (newAppMode !== appMode)) {
-        stores.setAppMode(newAppMode);
-      }
-      user.setAuthenticatedUser(authenticatedUser);
-      rawPortalJWT = authenticatedUser.rawPortalJWT;
-      if (classInfo) {
-        stores.class.updateFromPortal(classInfo);
-      }
+  try {
+    const {appMode: newAppMode, authenticatedUser, classInfo, problemId, unitCode} =
+      await authenticate(appMode, appConfig, curriculumConfig, urlParams);
 
-      // If the URL has a unit param or if the appMode is not "authed", then
-      // `stores.loadUnitAndProblem` would have been called in initializeApp,
-      // and startedLoadingUnitAndProblem will be true.
+    // authentication can trigger appMode change (e.g. preview => demo)
+    if (newAppMode && (newAppMode !== appMode)) {
+      stores.setAppMode(newAppMode);
+    }
+    user.setAuthenticatedUser(authenticatedUser);
+    rawPortalJWT = authenticatedUser.rawPortalJWT;
+    if (classInfo) {
+      stores.class.updateFromPortal(classInfo);
+    }
+
+    // If the URL has a unit param or if the appMode is not "authed", then
+    // `stores.loadUnitAndProblem` would have been called in initializeApp,
+    // and startedLoadingUnitAndProblem will be true.
+    //
+    // In the case of a teacher launch from the portal, the window.location should
+    // not have a unit param. Instead the unit and problem is figured out by
+    // `authenticate` from the portal's resource information.
+    //
+    // Note: If the external report in the portal is misconfigured with a unit
+    // parameter, then window.location will have a unit param and the resource
+    // information will be incorrectly ignored here.
+    if (!stores.startedLoadingUnitAndProblem) {
+      // The unit and problem are required for portal resources so the behavior
+      // is more clear:
+      // - If the unit is optional for portal resources, then a student launch
+      // without a unit would not start loading the unit in initializeApp.
+      // - If the problem is optional, then the defaultProblemOrdinal might not
+      // exist in the specified unit.
+      // We don't enforce this requirement in initializeApp because during a
+      // teacher launch, we don't know the resource info.
       //
-      // In the case of a teacher launch from the portal, the window.location should
-      // not have a unit param. Instead the unit and problem is figured out by
-      // `authenticate` from the portal's resource information.
-      //
-      // Note: If the external report in the portal is misconfigured with a unit
-      // parameter, then window.location will have a unit param and the resource
-      // information will be incorrectly ignored here.
-      if (!stores.startedLoadingUnitAndProblem) {
-        // The unit and problem are required for portal resources so the behavior
-        // is more clear:
-        // - If the unit is optional for portal resources, then a student launch
-        // without a unit would not start loading the unit in initializeApp.
-        // - If the problem is optional, then the defaultProblemOrdinal might not
-        // exist in the specified unit.
-        // We don't enforce this requirement in initializeApp because during a
-        // teacher launch, we don't know the resource info.
-        //
-        // To test this you can make a CLUE resource in the portal that does not have
-        // a unit param. And then launch it
-        if (!unitCode || !problemId) {
-          // If we get here, CLUE will hang because unitLoadedPromise will never
-          // resolve so the listeners won't start and there will be no content
-          // for CLUE to render. The error message below indicates the most likely
-          // cause of this.
-          stores.ui.setError(
-            "This CLUE resource is incorrectly configured. The URL of the resource " +
-            "requires a unit and problem parameter. " +
-            "Contact the author of the resource to fix it. " +
-            `unitCode: ${unitCode}, problemId: ${problemId}`);
-        } else {
-          // loadUnitAndProblem is asynchronous.
-          // Code that requires the unit to be loaded should wait on `stores.unitLoadedPromise`
-          stores.loadUnitAndProblem(unitCode, problemId);
-        }
+      // To test this you can make a CLUE resource in the portal that does not have
+      // a unit param. And then launch it
+      if (!unitCode || !problemId) {
+        // If we get here, CLUE will hang because unitLoadedPromise will never
+        // resolve so the listeners won't start and there will be no content
+        // for CLUE to render. The error message below indicates the most likely
+        // cause of this.
+        stores.ui.setError(
+          "This CLUE resource is incorrectly configured. The URL of the resource " +
+          "requires a unit and problem parameter. " +
+          "Contact the author of the resource to fix it. " +
+          `unitCode: ${unitCode}, problemId: ${problemId}`);
+      } else {
+        // loadUnitAndProblem is asynchronous.
+        // Code that requires the unit to be loaded should wait on `stores.unitLoadedPromise`
+        stores.loadUnitAndProblem(unitCode, problemId);
       }
-      return resolveAppMode(stores, authenticatedUser.rawFirebaseJWT);
-    })
-    .then(() => {
-      return user.isTeacher
-              ? db.firestore.getFirestoreUser(user.id)
+    }
+
+    await resolveAppMode(stores, authenticatedUser.rawFirebaseJWT);
+
+    const firestoreUser = user.isTeacher
+              ? await db.firestore.getFirestoreUser(user.id)
               : undefined;
-    })
-    .then(firestoreUser => {
-      if (firestoreUser?.network) {
-        user.setNetworks(firestoreUser.network, firestoreUser.networks);
-      }
-      syncTeacherClassesAndOfferings(db.firestore, user, stores.class, rawPortalJWT);
-    })
-    .then(() => {
-      removeLoadingMessage("Connecting");
-    })
-    .catch((error) => {
-      let customMessage = undefined;
-      const errorMessage = error.toString();
-      if ((errorMessage.indexOf("Cannot find AccessGrant") !== -1) ||
-          (errorMessage.indexOf("AccessGrant has expired") !== -1)) {
-        customMessage = "Your authorization has expired. Please return to the Concord site to re-run the activity.";
-      }
+    if (firestoreUser?.network) {
+      user.setNetworks(firestoreUser.network, firestoreUser.networks);
+    }
+    syncTeacherClassesAndOfferings(db.firestore, user, stores.class, rawPortalJWT);
 
-      ui.setError(error, customMessage);
-    });
+    removeLoadingMessage("Connecting");
+  } catch(error) {
+    let customMessage = undefined;
+    const errorMessage = String(error);
+    if ((errorMessage.indexOf("Cannot find AccessGrant") !== -1) ||
+        (errorMessage.indexOf("AccessGrant has expired") !== -1)) {
+      customMessage = "Your authorization has expired. Please return to the Concord site to re-run the activity.";
+    }
+
+    ui.setError(error, customMessage);
+  }
 };
 
 @inject("stores")

--- a/src/components/four-up.test.tsx
+++ b/src/components/four-up.test.tsx
@@ -59,7 +59,7 @@ describe("Four Up Component", () => {
       ]
     });
     const groups = GroupsModel.create({
-      allGroups: [group]
+      groupsMap: {1: group}
     });
 
     const stores = specStores({ groups, documents });
@@ -101,7 +101,7 @@ describe("Four Up Component", () => {
       ],
     });
     const groups = GroupsModel.create({
-      allGroups: [group]
+      groupsMap: {1: group}
     });
 
     const stores = specStores({ user, groups, documents });

--- a/src/components/four-up.test.tsx
+++ b/src/components/four-up.test.tsx
@@ -105,8 +105,11 @@ describe("Four Up Component", () => {
     });
 
     const stores = specStores({ user, groups, documents });
+    // When the store is created the groups store is cloned so it can have the correct
+    // environment. Therefore we need to get the new groups store after specStores
+    const realGroup = stores.groups.allGroups[0];
 
-    const { container } = render(<FourUpComponent group={group} stores={stores}/>);
+    const { container } = render(<FourUpComponent group={realGroup} stores={stores}/>);
     // A canvas will be rendered unless an "unshared document" message is displayed.
     // User 2 has no document, so it will display an "unshared document" message.
     // User 1 has a shared document, User 3 is the main user, and there is no fourth user. All of those show canvases.

--- a/src/components/four-up.test.tsx
+++ b/src/components/four-up.test.tsx
@@ -8,6 +8,7 @@ import { ProblemDocument } from "../models/document/document-types";
 import { DocumentsModelType, DocumentsModel } from "../models/stores/documents";
 import { specStores } from "../models/stores/spec-stores";
 import { UserModel } from "../models/stores/user";
+import { ClassModel } from "../models/stores/class";
 
 configure({testIdAttribute: "data-test"});
 
@@ -52,8 +53,6 @@ describe("Four Up Component", () => {
       users: [
         GroupUserModel.create({
           id: "1",
-          name: "User 1",
-          initials: "U1",
           connectedTimestamp: 1
         })
       ]
@@ -75,26 +74,51 @@ describe("Four Up Component", () => {
       name: "User 3"
     });
 
+    const clazz = ClassModel.create({
+      name: "Test Class",
+      classHash: "test",
+      users: {
+        1: {
+          type: "student",
+          id: "1",
+          firstName: "User",
+          lastName: "1",
+          fullName: "User 1",
+          initials: "U1"
+        },
+        2: {
+          type: "student",
+          id: "2",
+          firstName: "User",
+          lastName: "2",
+          fullName: "User 2",
+          initials: "U2"
+        },
+        3: {
+          type: "student",
+          id: "3",
+          firstName: "User",
+          lastName: "3",
+          fullName: "User 3",
+          initials: "U3"
+        }
+      }
+    });
+
     const group = GroupModel.create({
       id: "1",
       users: [
         GroupUserModel.create({
           id: "1",
-          name: "User 1",
-          initials: "U1",
           connectedTimestamp: 1,
         }),
         GroupUserModel.create({
           id: "2",
-          name: "User 2",
-          initials: "U2",
           connectedTimestamp: 1,
           disconnectedTimestamp: 2,
         }),
         GroupUserModel.create({
           id: "3",
-          name: "User 3",
-          initials: "U3",
           connectedTimestamp: 3,
           disconnectedTimestamp: 2,
         }),
@@ -102,9 +126,9 @@ describe("Four Up Component", () => {
     });
     const groups = GroupsModel.create({
       groupsMap: {1: group}
-    });
+    },);
 
-    const stores = specStores({ user, groups, documents });
+    const stores = specStores({ user, groups, documents, class: clazz });
     // When the store is created the groups store is cloned so it can have the correct
     // environment. Therefore we need to get the new groups store after specStores
     const realGroup = stores.groups.allGroups[0];

--- a/src/components/four-up.tsx
+++ b/src/components/four-up.tsx
@@ -80,7 +80,7 @@ export function getFocusedGroupUser(group: GroupModelType| undefined, openDocId:
     mode: DocumentViewMode | undefined) {
   if (!openDocId || !group) return undefined;
 
-  return group?.users.find(obj => {
+  return group?.activeUsers.find(obj => {
     const userDoc = getUserDocument(obj, mode);
     return userDoc?.key === openDocId;
   });
@@ -144,7 +144,7 @@ export class FourUpComponent extends BaseComponent<IProps, IState> {
   private getFocusedGroupUser() {
     const {group} = this.props;
     const docKey = this.getFocusedUserDocKey();
-    return group.users.find(obj => docKey && this.getGroupUserDoc(obj)?.key === docKey);
+    return group.activeUsers.find(obj => docKey && this.getGroupUserDoc(obj)?.key === docKey);
   }
 
   private getGroupUserDoc(groupUser?: GroupUserModelType) {

--- a/src/components/group/group-chooser.tsx
+++ b/src/components/group/group-chooser.tsx
@@ -74,7 +74,7 @@ export class GroupChooserComponent extends BaseComponent<IProps, IState> {
   private renderChooseExistingGroup() {
     const {groups} = this.stores;
     const groupElements = groups.allGroups.map((group) => {
-      const users = group.users.map((user) => {
+      const users = group.activeUsers.map((user) => {
         const className = `user ${user.connected ? "connected" : "disconnected"}`;
         const title = `${user.name}: ${user.connected ? "connected" : "disconnected"}`;
         return <span key={user.id} className={className} title={title}>{user.initials}</span>;
@@ -121,7 +121,7 @@ export class GroupChooserComponent extends BaseComponent<IProps, IState> {
   private handleChooseExistingGroup = (group: GroupModelType) => {
     return (e: React.MouseEvent<HTMLElement>) => {
       e.preventDefault();
-      if (group.users.length >= 4) {
+      if (group.activeUsers.length >= 4) {
         this.setState({error: "Sorry, that group is full with four students"});
       }
       else {

--- a/src/initialize-app.tsx
+++ b/src/initialize-app.tsx
@@ -68,10 +68,9 @@ export const initializeApp = (authoring: boolean): IStores => {
   }
   const demoName = urlParams.demoName;
 
-  const isPreviewing = !!(urlParams.domain && urlParams.domain_uid && !bearerToken);
   const appConfig = AppConfigModel.create(appConfigSnapshot);
   const stores = createStores(
-    { appMode, appVersion, appConfig, user, showDemoCreator, demoName, isPreviewing });
+    { appMode, appVersion, appConfig, user, showDemoCreator, demoName });
 
   // Expose the stores if the debug flag is set or we are running in Cypress
   const aWindow = window as any;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -15,7 +15,7 @@ import { LogEventName } from "../lib/logger-types";
 import { uniqueId } from "../utilities/js-utils";
 import { getUnitCodeFromUnitParam } from "../utilities/url-utils";
 import { convertURLToOAuth2, getBearerToken } from "../utilities/auth-utils";
-import { ICurriculumConfig } from "src/models/stores/curriculum-config";
+import { ICurriculumConfig } from "../models/stores/curriculum-config";
 
 export const PORTAL_JWT_URL_SUFFIX = "api/v1/jwt/portal";
 export const FIREBASE_JWT_URL_SUFFIX = "api/v1/jwt/firebase";
@@ -51,7 +51,8 @@ export const DEV_CLASS_INFO: ClassInfo = {
   name: DEV_STUDENT.className,
   classHash: DEV_STUDENT.classHash,
   students: [DEV_STUDENT],
-  teachers: [DEV_TEACHER]
+  teachers: [DEV_TEACHER],
+  localTimestamp: Date.now()
 };
 
 export type AuthenticatedUser = StudentUser | TeacherUser;
@@ -90,6 +91,8 @@ export interface ClassInfo {
   classHash: string;
   students: StudentUser[];
   teachers: TeacherUser[];
+  localTimestamp: number;
+  serverTimestamp?: number;
 }
 
 export interface AuthQueryParams {
@@ -196,6 +199,7 @@ export const getClassInfo = (params: GetClassInfoParams) => {
         const rawClassInfo: IPortalClassInfo = res.body;
 
         const classInfo: ClassInfo = {
+          localTimestamp: Date.now(),
           name: rawClassInfo.name,
           classHash: rawClassInfo.class_hash,
           students: rawClassInfo.students.map((rawStudent) => {
@@ -536,6 +540,7 @@ export const createFakeAuthentication = (options: CreateFakeAuthenticationOption
     classHash: authenticatedUser.classHash,
     students: [],
     teachers: [],
+    localTimestamp: Date.now()
   };
   // Add the random student to the class first and then fill the class
   // FIXME: It looks like if the teacher id is not 1,2,3 then the teacher won't

--- a/src/lib/db-listeners/db-groups-listener.ts
+++ b/src/lib/db-listeners/db-groups-listener.ts
@@ -1,5 +1,6 @@
+import { destroy } from "mobx-state-tree";
 import firebase from "firebase/app";
-import { map } from "lodash";
+import { getGroupSnapshot, GroupModel, GroupUserModelType, GroupUserState } from "../../models/stores/groups";
 import { DB } from "../db";
 import { DBOfferingGroupMap } from "../db-types";
 import { BaseListener } from "./base-listener";
@@ -56,43 +57,80 @@ export class DBGroupsListener extends BaseListener {
   }
 
   private handleGroupsRef = (snapshot: firebase.database.DataSnapshot) => {
-    const {user} = this.db.stores;
+    const { user, class: clazz } = this.db.stores;
     const groups: DBOfferingGroupMap = snapshot.val() || {};
     const myGroupIds: string[] = [];
-    const overSubscribedUserUpdates: any = {};
+    const overSubscribedUserUpdates: Record<string, null> = {};
 
     this.debugLogSnapshot("#handleGroupsRef", snapshot);
 
+    const markGroupUserForRemoval = (groupId: string, userToRemove: GroupUserModelType) => {
+      const userPath = this.db.firebase.getFullPath(
+        this.db.firebase.getGroupUserPath(user, groupId, userToRemove.id)
+      );
+      overSubscribedUserUpdates[userPath] = null;
+    };
+
     // ensure that the current user is not in more than 1 group and groups are not oversubscribed
     Object.keys(groups).forEach((groupId) => {
-      const rawUsers = groups[groupId].users || {};
-      // rawUsers can get interpreted as an array instead of a map if user IDs are small (e.g. in demo mode)
-      // So, make sure to filter out empty array spaces and convert number IDs to strings for standardization
-      const groupUsers = map(rawUsers, (groupUser, uid) => ({uid: `${uid}`, user: groupUser}))
-        .filter(groupUser => !!groupUser.user);
-      if (groupUsers.find(groupUser => groupUser.uid === user.id)) {
+      // Create a temporary instance of the MST Group so the same parsing logic is used both here
+      // and by updateGroupsFromDb
+      const groupSnapshot = getGroupSnapshot(groupId, groups[groupId]);
+      const tempGroup = GroupModel.create(groupSnapshot, {class: clazz});
+
+      if (tempGroup.users.find(groupUser => groupUser.id === user.id)){
         myGroupIds.push(groupId);
       }
-      if (groupUsers.length > 4) {
+
+      let subscribedUsers = tempGroup.users.slice();
+      if (subscribedUsers.length > 4) {
+        // If a user is removed from the class kick them out. We only do this when the group
+        // is over subscribed. Perhaps the user was only removed temporarily. As long as another
+        // user doesn't try to steal their place in a group, if they are re-added to the class
+        // the user will still be in the same group.
+        const remainingUsers: GroupUserModelType[] = [];
+        subscribedUsers.forEach(groupUser => {
+          if (groupUser.state === GroupUserState.Removed) {
+            markGroupUserForRemoval(groupId, groupUser);
+          } else {
+            remainingUsers.push(groupUser);
+          }
+        });
+        subscribedUsers = remainingUsers;
+      }
+
+      // Are we are still over 4?
+      if (subscribedUsers.length > 4) {
         // sort the users by connected timestamp and find the newest users to kick out
-        groupUsers.sort((a, b) => a.user.connectedTimestamp - b.user.connectedTimestamp);
-        for (let i = 4; i < groupUsers.length; i++) {
-          const userToRemove = groupUsers[i];
-          const userPath = this.db.firebase.getFullPath(
-            this.db.firebase.getGroupUserPath(user, groupId, userToRemove.uid)
-          );
-          overSubscribedUserUpdates[userPath] = null;
+        subscribedUsers.sort((a, b) => a.connectedTimestamp - b.connectedTimestamp);
+        for (let i = 4; i < subscribedUsers.length; i++) {
+          markGroupUserForRemoval(groupId, subscribedUsers[i]);
         }
       }
+      destroy(tempGroup);
     });
 
     // if there is a problem with the groups fix the problem in the next timeslice
     const numUpdates = Object.keys(overSubscribedUserUpdates).length;
     if ((numUpdates > 0) || (myGroupIds.length > 1)) {
       setTimeout(() => {
+        // FIXME: Note multiple CLUE windows might be doing this update at the same time. The
+        // connectedTimestamp values should be same in both windows. But the removed users
+        // are based on each individual CLUE window, so that might result in different
+        // lists. For example a CLUE window that started before the user was removed
+        // from the class will *not* see them as removed. And a CLUE window that started
+        // after the user was removed from the class *will* see them as removed.
+        // If the group is oversubscribed the first window will delete the most recent
+        // user. The second window will delete the removed user. So now two different users will
+        // be removed from the group.
         if (numUpdates > 0) {
           firebase.database().ref().update(overSubscribedUserUpdates);
         }
+        // FIXME: How do we know that we haven't already been removed from this group by
+        // the overSubscribedUserUpdates?
+        // What if we decide to remove another user from this group and then we
+        // leave the group too. That means the first user was kicked out for no
+        // reason.
         if (myGroupIds.length > 1) {
           this.db.leaveGroup();
         }
@@ -112,6 +150,20 @@ export class DBGroupsListener extends BaseListener {
     groups.updateFromDB(dbGroups);
     if (!groups.needToRefreshClass) return;
 
+    // FIXME: if a user has launched CLUE and then the teacher removes them from the class, they can
+    // keep joining new groups which will make them look like a new user because their "connected" time
+    // will be newer than last class info request. Each time they change groups this will immediately
+    // trigger a re-request of the class info here. This will reset last class info request time to be
+    // newer than the "connected" time of the user. However we have an offset of 1 second before the user
+    // is considered removed. So if the class timestamp is less than 1 second newer than the "connected"
+    // time of the user, the user will continue to show up as new. Unless the groups in the DB are
+    // updated, this removed user will continue to show up as new.
+    //
+    // For portal launches we can address this by locking CLUE if the current user is no longer in
+    // the class. The user could circumvent this in the browser console, but it should be good enough
+    // to prevent data loss and deter most people.
+    // We currently only do these class refreshes here when the groups change. So if a new student
+    // starts CLUE or a student changes groups then this rouge user would effectively be kicked out.
     const classInfo = await portal.getClassInfo();
     if (!classInfo) return;
     const timeOffset = await this.db.firebase.getServerTimeOffset();

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -518,7 +518,7 @@ export class DB {
       this.createDocument({ type: ProblemPublication, content }).then(({document, metadata}) => {
         const publicationRef = this.firebase.ref(this.firebase.getProblemPublicationsPath(user)).push();
         const userGroup = groups.getGroupById(user.currentGroupId);
-        const groupUserConnections: DBGroupUserConnections | undefined = userGroup && userGroup.users
+        const groupUserConnections: DBGroupUserConnections | undefined = userGroup && userGroup.activeUsers
           .filter(groupUser => groupUser.id !== user.id)
           .reduce((allUsers: DBGroupUserConnections, groupUser) => {
             allUsers[groupUser.id] = groupUser.connected;

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -323,6 +323,18 @@ export class Firebase {
     this.groupOnDisconnect = null;
   }
 
+  /**
+   * Get an server time offset. This is useful to create an estimated server timestamp.
+   * See https://firebase.google.com/docs/database/web/offline-capabilities#clock-skew
+   *
+   * @returns
+   */
+  public async getServerTimeOffset() {
+    const offsetRef = firebase.database().ref(".info/serverTimeOffset");
+    const snap = await offsetRef.once("value");
+    return snap.val();
+  }
+
   //
   // Firebase Storage
   //

--- a/src/models/stores/base-stores-types.ts
+++ b/src/models/stores/base-stores-types.ts
@@ -21,7 +21,6 @@ import { ICurriculumConfig } from "./curriculum-config";
 
 export interface IBaseStores {
   appMode: AppMode;
-  isPreviewing?: boolean;
   appVersion: string;
   appConfig: AppConfigModelType;
   curriculumConfig: ICurriculumConfig;

--- a/src/models/stores/class.test.ts
+++ b/src/models/stores/class.test.ts
@@ -1,5 +1,5 @@
 import { ClassModel, ClassUserModel } from "./class";
-import { ClassInfo } from "../../lib/auth";
+import { ClassInfo } from "./portal";
 
 describe("Class model", () => {
 

--- a/src/models/stores/class.test.ts
+++ b/src/models/stores/class.test.ts
@@ -54,7 +54,8 @@ describe("Class model", () => {
           initials: "FS",
         }
       ],
-      teachers: []
+      teachers: [],
+      localTimestamp: Date.now()
     };
     clazz.updateFromPortal(classInfo);
 

--- a/src/models/stores/class.test.ts
+++ b/src/models/stores/class.test.ts
@@ -57,6 +57,8 @@ describe("Class model", () => {
       teachers: []
     };
     clazz.updateFromPortal(classInfo);
-    expect(clazz.users.size).toEqual(1);
+
+    // There is always a exemplar user added to the class
+    expect(clazz.users.size).toEqual(2);
   });
 });

--- a/src/models/stores/class.ts
+++ b/src/models/stores/class.ts
@@ -1,5 +1,5 @@
 import { applySnapshot, SnapshotIn, types } from "mobx-state-tree";
-import { ClassInfo } from "../../lib/auth";
+import { ClassInfo } from "./portal";
 import { kExemplarUserParams } from "./user-types";
 
 export const ClassUserModel = types

--- a/src/models/stores/class.ts
+++ b/src/models/stores/class.ts
@@ -26,6 +26,7 @@ export const ClassModel = types
     name: types.string,
     classHash: types.string,
     users: types.map(ClassUserModel),
+    timestamp: types.optional(types.number, () => Date.now()),
   })
   .actions((self) => {
     return {
@@ -44,6 +45,7 @@ export const ClassModel = types
         applySnapshot(self.users, usersSnapshot);
         self.name = classInfo.name;
         self.classHash = classInfo.classHash;
+        self.timestamp = classInfo.serverTimestamp || classInfo.localTimestamp;
       },
     };
   })

--- a/src/models/stores/create-exemplar-docs.ts
+++ b/src/models/stores/create-exemplar-docs.ts
@@ -2,8 +2,6 @@ import { ProblemModelType } from "../curriculum/problem";
 import { DocumentsModelType } from "./documents";
 import { DocumentModelSnapshotType, createDocumentModelWithEnv } from "../document/document";
 import { UserModelType } from "./user";
-import { ClassModelType, ClassUserModel } from "./class";
-import { kExemplarUserParams } from "./user-types";
 import { ICurriculumConfig } from "./curriculum-config";
 import { ExemplarDocument } from "../document/document-types";
 import { AppConfigModelType } from "./app-config-model";
@@ -16,7 +14,6 @@ interface ICreateExemplarDocsParams {
   investigation?: InvestigationModelType;
   problem: ProblemModelType;
   documents: DocumentsModelType;
-  classStore: ClassModelType;
   user: UserModelType;
   curriculumConfig: ICurriculumConfig;
   appConfig: AppConfigModelType;
@@ -38,13 +35,11 @@ export async function createAndLoadExemplarDocs({
   investigation,
   problem,
   documents,
-  classStore,
   curriculumConfig,
   appConfig
 }: ICreateExemplarDocsParams) {
   const { exemplars } = problem;
   const exemplarsData = await getExemplarsData(unitUrl, exemplars);
-  classStore.addUser(ClassUserModel.create(kExemplarUserParams));
   createExemplarDocs(unit, investigation, problem, documents, exemplarsData, curriculumConfig, appConfig);
 }
 

--- a/src/models/stores/document-group.test.ts
+++ b/src/models/stores/document-group.test.ts
@@ -133,11 +133,11 @@ const createMockGroups = () => {
   const group9Users = createMockGroupUsers(group9UsersData);
 
   const mockGroups = GroupsModel.create({
-    allGroups: [
-      GroupModel.create({ id: "3", users: group3Users }),
-      GroupModel.create({ id: "5", users: group5Users }),
-      GroupModel.create({ id: "9", users: group9Users }),
-    ]
+    groupsMap: {
+      3: GroupModel.create({ id: "3", users: group3Users }),
+      5: GroupModel.create({ id: "5", users: group5Users }),
+      9: GroupModel.create({ id: "9", users: group9Users }),
+    }
   });
   return mockGroups;
 };

--- a/src/models/stores/document-group.test.ts
+++ b/src/models/stores/document-group.test.ts
@@ -98,8 +98,6 @@ const createMockClassWithUsers = () => {
 
 type GroupUserData = {
   id: string;
-  name: string;
-  initials: string;
   connectedTimestamp: number;
   disconnectedTimestamp?: number;
 };
@@ -108,8 +106,6 @@ const createMockGroupUsers = (groupUsersData: GroupUserData[]) => {
   return groupUsersData.map(userData =>
     GroupUserModel.create({
       id: userData.id,
-      name: userData.name,
-      initials: userData.initials,
       connectedTimestamp: userData.connectedTimestamp,
       disconnectedTimestamp: userData.disconnectedTimestamp
     })
@@ -118,14 +114,14 @@ const createMockGroupUsers = (groupUsersData: GroupUserData[]) => {
 
 const createMockGroups = () => {
   const group3UsersData = [
-    { id: "2", name: "Scott Cytacki", initials: "SC", connectedTimestamp: 2 },
-    { id: "4", name: "Kirk Swenson", initials: "KS", connectedTimestamp: 4 },
+    { id: "2", connectedTimestamp: 2 },
+    { id: "4", connectedTimestamp: 4 },
   ];
   const group5UsersData = [
-    { id: "1", name: "Joe Bacal", initials: "JB", connectedTimestamp: 1 },
+    { id: "1", connectedTimestamp: 1 },
   ];
   const group9UsersData = [
-    { id: "3", name: "Dennis Cao", initials: "DC", connectedTimestamp: 3 },
+    { id: "3", connectedTimestamp: 3 },
   ];
 
   const group3Users = createMockGroupUsers(group3UsersData);

--- a/src/models/stores/groups.test.ts
+++ b/src/models/stores/groups.test.ts
@@ -141,6 +141,7 @@ describe("Groups model", () => {
     expect(groups.allGroups.length).toEqual(1);
     const group = groups.allGroups[0];
     expect(group.users.length).toEqual(3);
+    expect(group.activeUsers.length).toEqual(2);
     expect(group.users[0].id).toEqual("1");
     expect(group.users[0].name).toEqual("Test User");
     expect(group.users[0].initials).toEqual("TU");

--- a/src/models/stores/groups.test.ts
+++ b/src/models/stores/groups.test.ts
@@ -41,7 +41,7 @@ describe("Groups model", () => {
       ],
     });
     const groups = GroupsModel.create({
-      allGroups: [group]
+      groupsMap: {1: group}
     });
     expect(group.getUserById("1")).toBeDefined();
     expect(group.getUserById("2")).toBeDefined();

--- a/src/models/stores/groups.test.ts
+++ b/src/models/stores/groups.test.ts
@@ -84,7 +84,7 @@ describe("Groups model", () => {
             },
             connectedTimestamp: 1,
           },
-          2: {
+          2: { // Old user that doesn't exist in the class anymore
             version: "1.0",
             self: {
               classHash: "test",
@@ -99,7 +99,17 @@ describe("Groups model", () => {
             version: "1.0",
             connectedTimestamp: 1,
             disconnectedTimestamp: 2
-          } as any
+          } as any,
+          4: { // New user that doesn't exist in the class yet
+            version: "1.0",
+            connectedTimestamp: 2001,
+            self: {
+              classHash: "test",
+              offeringId: "1",
+              groupId: "1",
+              uid: "4",
+            },
+          }
         }
       }
     };
@@ -116,8 +126,9 @@ describe("Groups model", () => {
       classHash: "test",
       users: {
         1: user
-        // don't add student 2 so we can test missing students
-      }
+        // don't add student 2 and 4 so we can test missing students
+      },
+      timestamp: 2000, // Use a fixed timestamp so we can test the New verses Removed user behavior
     });
 
     const groups = GroupsModel.create({}, {class: clazz});
@@ -129,12 +140,15 @@ describe("Groups model", () => {
     groups.updateFromDB(dbGroupsWithUsers, clazz);
     expect(groups.allGroups.length).toEqual(1);
     const group = groups.allGroups[0];
-    expect(group.users.length).toEqual(2);
+    expect(group.users.length).toEqual(3);
     expect(group.users[0].id).toEqual("1");
     expect(group.users[0].name).toEqual("Test User");
     expect(group.users[0].initials).toEqual("TU");
     expect(group.users[1].id).toEqual("2");
     expect(group.users[1].name).toEqual("Unknown");
     expect(group.users[1].initials).toEqual("??");
+    expect(group.users[2].id).toEqual("4");
+    expect(group.users[2].name).toEqual("New User");
+    expect(group.users[2].initials).toEqual("**");
   });
 });

--- a/src/models/stores/groups.test.ts
+++ b/src/models/stores/groups.test.ts
@@ -133,11 +133,11 @@ describe("Groups model", () => {
 
     const groups = GroupsModel.create({}, {class: clazz});
 
-    groups.updateFromDB(dbGroupsWithoutUsers, clazz);
+    groups.updateFromDB(dbGroupsWithoutUsers);
     expect(groups.allGroups.length).toEqual(1);
     expect(groups.allGroups[0].users.length).toEqual(0);
 
-    groups.updateFromDB(dbGroupsWithUsers, clazz);
+    groups.updateFromDB(dbGroupsWithUsers);
     expect(groups.allGroups.length).toEqual(1);
     const group = groups.allGroups[0];
     expect(group.users.length).toEqual(3);

--- a/src/models/stores/groups.test.ts
+++ b/src/models/stores/groups.test.ts
@@ -20,21 +20,15 @@ describe("Groups model", () => {
       users: [
         GroupUserModel.create({
           id: "1",
-          name: "User 1",
-          initials: "U1",
           connectedTimestamp: 1,
         }),
         GroupUserModel.create({
           id: "2",
-          name: "User 2",
-          initials: "U2",
           connectedTimestamp: 1,
           disconnectedTimestamp: 2,
         }),
         GroupUserModel.create({
           id: "3",
-          name: "User 3",
-          initials: "U3",
           connectedTimestamp: 3,
           disconnectedTimestamp: 2,
         }),
@@ -61,7 +55,6 @@ describe("Groups model", () => {
   });
 
   it("updates from db", () => {
-    const groups = GroupsModel.create({});
     const dbGroupsWithoutUsers: DBOfferingGroupMap = {
       1: {
         version: "1.0",
@@ -127,13 +120,21 @@ describe("Groups model", () => {
       }
     });
 
+    const groups = GroupsModel.create({}, {class: clazz});
+
     groups.updateFromDB(dbGroupsWithoutUsers, clazz);
     expect(groups.allGroups.length).toEqual(1);
     expect(groups.allGroups[0].users.length).toEqual(0);
 
     groups.updateFromDB(dbGroupsWithUsers, clazz);
     expect(groups.allGroups.length).toEqual(1);
-    expect(groups.allGroups[0].users.length).toEqual(1);
-    expect(groups.allGroups[0].users[0].id).toEqual("1");
+    const group = groups.allGroups[0];
+    expect(group.users.length).toEqual(2);
+    expect(group.users[0].id).toEqual("1");
+    expect(group.users[0].name).toEqual("Test User");
+    expect(group.users[0].initials).toEqual("TU");
+    expect(group.users[1].id).toEqual("2");
+    expect(group.users[1].name).toEqual("Unknown");
+    expect(group.users[1].initials).toEqual("??");
   });
 });

--- a/src/models/stores/groups.ts
+++ b/src/models/stores/groups.ts
@@ -183,7 +183,7 @@ export const GroupsModel = types
     }
   }))
   .actions((self) => ({
-    updateFromDB(groups: DBOfferingGroupMap, clazz: ClassModelType) {
+    updateFromDB(groups: DBOfferingGroupMap) {
       const groupsMapSnapshot: SnapshotIn<typeof self.groupsMap> = {};
       Object.entries(groups).forEach(([groupId, group]) => {
         const groupUserSnapshots: SnapshotIn<typeof GroupUserModel>[] = [];

--- a/src/models/stores/portal.ts
+++ b/src/models/stores/portal.ts
@@ -1,0 +1,224 @@
+import jwt_decode from "jwt-decode";
+import superagent from "superagent";
+import { IPortalClassInfo, PortalFirebaseJWT, PortalJWT } from "../../lib/portal-types";
+import { getErrorMessage } from "../../utilities/super-agent-helpers";
+import { convertURLToOAuth2, getBearerToken } from "../../utilities/auth-utils";
+import { QueryParams, urlParams as pageUrlParams } from "../../utilities/url-params";
+import initials from "initials";
+import { IUserPortalOffering } from "./user";
+
+export const parseUrl = (url: string) => {
+  const parser = document.createElement("a");
+  parser.href = url;
+  return parser;
+};
+
+export const PORTAL_JWT_URL_SUFFIX = "api/v1/jwt/portal";
+
+interface User {
+  id: string;
+  portal: string;
+  firstName: string;
+  lastName: string;
+  fullName: string;
+  initials: string;
+  className: string;
+  classHash: string;
+  offeringId: string;
+  portalJWT?: PortalJWT;
+  rawPortalJWT?: string;
+  firebaseJWT?: PortalFirebaseJWT;
+  rawFirebaseJWT?: string;
+  portalClassOfferings?: IUserPortalOffering[];
+  demoClassHashes?: string[];
+}
+
+export interface StudentUser extends User {
+  type: "student";
+}
+
+export interface TeacherUser extends User {
+  type: "teacher";
+  network?: string;     // default network for teacher
+  networks?: string[];  // list of networks available to teacher
+}
+
+export interface ClassInfo {
+  name: string;
+  classHash: string;
+  students: StudentUser[];
+  teachers: TeacherUser[];
+  localTimestamp: number;
+  serverTimestamp?: number;
+}
+
+export class Portal {
+  rawPortalJWT: string;
+  portalJWT: PortalJWT;
+  urlParams: QueryParams;
+  bearerToken?: string;
+  basePortalUrl?: string;
+  portalHost: string;
+  classInfoUrl: string;
+  offeringId: string;
+  isPortalPreview = false;
+
+  constructor(urlParams?: QueryParams) {
+    this.urlParams = urlParams || pageUrlParams;
+    this.bearerToken = getBearerToken(this.urlParams);
+    this.isPortalPreview = !!this.urlParams.domain && !!this.urlParams.domain_uid && !this.bearerToken;
+  }
+
+  getBasePortalUrl() {
+    const {urlParams} = this;
+    if (urlParams.reportType) {
+      if (urlParams.reportType !== "offering") {
+        throw "Sorry, only external reports at the offering level are supported";
+      }
+      if (!urlParams.class) {
+        throw "Missing class parameter!";
+      }
+      if (!urlParams.offering) {
+        throw "Missing offering parameter!";
+      }
+      const {protocol, host} = parseUrl(urlParams.class);
+      return `${protocol}//${host}/`;
+    }
+    else if (urlParams.domain) {
+      return urlParams.domain;
+    }
+    else {
+      throw "Missing domain query parameter!";
+    }
+  }
+
+  requestPortalJWT() {
+    return new Promise<void>((resolve, reject) => {
+      const resourceLinkIdSuffix =
+        pageUrlParams.resourceLinkId ? `?resource_link_id=${ pageUrlParams.resourceLinkId }` : "";
+      const url = `${this.basePortalUrl}${PORTAL_JWT_URL_SUFFIX}${resourceLinkIdSuffix}`;
+      superagent
+        .get(url)
+        .set("Authorization", `Bearer ${this.bearerToken}`)
+        .end((err, res) => {
+          if (err) {
+            reject(getErrorMessage(err, res));
+          } else if (!res.body || !res.body.token) {
+            reject("No token found in JWT request response");
+          } else {
+            const rawJWT = res.body.token;
+            const portalJWT = jwt_decode(rawJWT);
+            if (portalJWT) {
+              this.portalJWT = portalJWT as PortalJWT;
+              this.rawPortalJWT = rawJWT;
+              resolve();
+            } else {
+              reject("Invalid portal token");
+            }
+          }
+        });
+    });
+  }
+
+  async initialize() {
+    if (!this.bearerToken) {
+      throw "No token provided for authentication (must launch from Portal)";
+    }
+
+    this.basePortalUrl = this.getBasePortalUrl();
+
+    await this.requestPortalJWT();
+
+    const {basePortalUrl, portalJWT,urlParams} = this;
+
+    if (!((portalJWT.user_type === "learner") || (portalJWT.user_type === "teacher"))) {
+      throw new Error(`Only student and teacher logins are currently supported! ` +
+        `Unsupported type: ${portalJWT.user_type}`);
+    }
+
+    this.portalHost = parseUrl(basePortalUrl).host;
+    if (portalJWT.user_type === "learner") {
+      this.classInfoUrl = portalJWT.class_info_url;
+      this.offeringId = `${portalJWT.offering_id}`;
+    }
+    else if (urlParams && urlParams.class && urlParams.offering) {
+      this.classInfoUrl = urlParams.class;
+      this.offeringId = urlParams.offering.split("/").pop() as string;
+    }
+
+    if (!this.classInfoUrl || !this.offeringId) {
+      throw new Error("Unable to get classInfoUrl or offeringId");
+    }
+
+    // Re-Write the URL with OAuth2 parameters
+    const oAuth2Url = convertURLToOAuth2(window.location.href, basePortalUrl, this.offeringId);
+    if (oAuth2Url) {
+      window.history.replaceState(null, "CLUE", oAuth2Url.toString());
+    }
+  }
+
+  /**
+   * This must be called after initialize()
+   *
+   * @returns the current class info from the portal
+   */
+  getClassInfo() {
+    const {classInfoUrl, rawPortalJWT, portalHost: portal, offeringId} = this;
+    return new Promise<ClassInfo>((resolve, reject) => {
+      superagent
+      .get(classInfoUrl)
+      .set("Authorization", `Bearer/JWT ${rawPortalJWT}`)
+      .end((err, res) => {
+        if (err) {
+          reject(getErrorMessage(err, res));
+        } else if (!res.body || !res.body.class_hash) {
+          reject("Invalid class info response");
+        } else {
+          const rawClassInfo: IPortalClassInfo = res.body;
+
+          const classInfo: ClassInfo = {
+            localTimestamp: Date.now(),
+            name: rawClassInfo.name,
+            classHash: rawClassInfo.class_hash,
+            students: rawClassInfo.students.map((rawStudent) => {
+              const fullName = `${rawStudent.first_name} ${rawStudent.last_name}`;
+              const id = rawStudent.id.split("/").pop() || "0";
+              const student: StudentUser = {
+                type: "student",
+                id,
+                portal,
+                firstName: rawStudent.first_name,
+                lastName: rawStudent.last_name,
+                fullName,
+                className: rawClassInfo.name,
+                initials: initials(fullName) as string,
+                classHash: rawClassInfo.class_hash,
+                offeringId,
+              };
+              return student;
+            }),
+            teachers: rawClassInfo.teachers.map((rawTeacher) => {
+              const fullName = `${rawTeacher.first_name} ${rawTeacher.last_name}`;
+              const id = rawTeacher.id.split("/").pop() || "0";
+              const teacher: TeacherUser = {
+                type: "teacher",
+                id,
+                portal,
+                firstName: rawTeacher.first_name,
+                lastName: rawTeacher.last_name,
+                fullName,
+                className: rawClassInfo.name,
+                initials: initials(fullName) as string,
+                classHash: rawClassInfo.class_hash,
+                offeringId,
+              };
+              return teacher;
+            }),
+          };
+
+          resolve(classInfo);
+        }
+      });
+    });
+  }
+}

--- a/src/models/stores/sorted-documents.test.ts
+++ b/src/models/stores/sorted-documents.test.ts
@@ -126,11 +126,11 @@ const createMockGroups = () => {
   const group9Users = createMockGroupUsers(group9UsersData);
 
   const mockGroups = GroupsModel.create({
-    allGroups: [
-      GroupModel.create({ id: "3", users: group3Users }),
-      GroupModel.create({ id: "5", users: group5Users }),
-      GroupModel.create({ id: "9", users: group9Users }),
-    ]
+    groupsMap: {
+      3: GroupModel.create({ id: "3", users: group3Users }),
+      5: GroupModel.create({ id: "5", users: group5Users }),
+      9: GroupModel.create({ id: "9", users: group9Users }),
+    }
   });
   return mockGroups;
 };

--- a/src/models/stores/sorted-documents.test.ts
+++ b/src/models/stores/sorted-documents.test.ts
@@ -91,8 +91,6 @@ const createMockClassWithUsers = () => {
 
 type GroupUserData = {
   id: string;
-  name: string;
-  initials: string;
   connectedTimestamp: number;
   disconnectedTimestamp?: number;
 };
@@ -101,8 +99,6 @@ const createMockGroupUsers = (groupUsersData: GroupUserData[]) => {
   return groupUsersData.map(userData =>
     GroupUserModel.create({
       id: userData.id,
-      name: userData.name,
-      initials: userData.initials,
       connectedTimestamp: userData.connectedTimestamp,
       disconnectedTimestamp: userData.disconnectedTimestamp
     })
@@ -111,14 +107,14 @@ const createMockGroupUsers = (groupUsersData: GroupUserData[]) => {
 
 const createMockGroups = () => {
   const group3UsersData = [
-    { id: "2", name: "Scott Cytacki", initials: "SC", connectedTimestamp: 2 },
-    { id: "4", name: "Kirk Swenson", initials: "KS", connectedTimestamp: 4 },
+    { id: "2", connectedTimestamp: 2 },
+    { id: "4", connectedTimestamp: 4 },
   ];
   const group5UsersData = [
-    { id: "1", name: "Joe Bacal", initials: "JB", connectedTimestamp: 1 },
+    { id: "1", connectedTimestamp: 1 },
   ];
   const group9UsersData = [
-    { id: "3", name: "Dennis Cao", initials: "DC", connectedTimestamp: 3 },
+    { id: "3", connectedTimestamp: 3 },
   ];
 
   const group3Users = createMockGroupUsers(group3UsersData);

--- a/src/models/stores/stores.ts
+++ b/src/models/stores/stores.ts
@@ -35,6 +35,7 @@ import curriculumConfigJson from "../../clue/curriculum-config.json";
 import { gImageMap } from "../image-map";
 import { ExemplarControllerModel, ExemplarControllerModelType } from "./exemplar-controller";
 import { SectionDocuments } from "./section-docs-store";
+import { Portal } from "./portal";
 
 export interface IStores extends IBaseStores {
   problemPath: string;
@@ -52,6 +53,7 @@ export interface IStores extends IBaseStores {
   sectionsLoadedPromise: Promise<void>;
   startedLoadingUnitAndProblem: boolean;
   exemplarController: ExemplarControllerModelType;
+  portal: Portal;
 }
 
 export interface ICreateStores extends Partial<IStores> {
@@ -67,7 +69,6 @@ export function createStores(params?: ICreateStores): IStores {
 
 class Stores implements IStores{
   appMode: AppMode;
-  isPreviewing?: boolean;
   appVersion: string;
   appConfig: AppConfigModelType;
   curriculumConfig: ICurriculumConfig;
@@ -97,6 +98,7 @@ class Stores implements IStores{
   sectionsLoadedPromise: Promise<void>;
   startedLoadingUnitAndProblem: boolean;
   exemplarController: ExemplarControllerModelType;
+  portal: Portal;
 
   constructor(params?: ICreateStores){
     // This will mark all properties as observable
@@ -107,7 +109,6 @@ class Stores implements IStores{
     // does seems to work without warnings.
     makeAutoObservable(this);
     this.appMode = params?.appMode || "dev";
-    this.isPreviewing = params?.isPreviewing || false;
     this.appVersion = params?.appVersion || "unknown";
     this.curriculumConfig = params?.curriculumConfig || CurriculumConfig.create(curriculumConfigJson, {urlParams});
     this.appConfig = params?.appConfig || AppConfigModel.create();
@@ -165,6 +166,7 @@ class Stores implements IStores{
     this.unitLoadedPromise = when(() => this.unit !== defaultUnit);
     this.sectionsLoadedPromise = when(() => this.problem.sections.length > 0);
     this.exemplarController = ExemplarControllerModel.create();
+    this.portal = new Portal();
   }
 
   get tabsToDisplay() {

--- a/src/models/stores/stores.ts
+++ b/src/models/stores/stores.ts
@@ -125,13 +125,14 @@ class Stores implements IStores{
 
     this.user = params?.user || UserModel.create({ id: "0" });
 
-    // Groups need us (stores) as the MST environment.
-    // So if we are passed a groups we need to clone it so we can set the environment.
-    // If any code passes in a groups they need to use the returned one instead of their
-    // original
+    // Groups need stores (this) as the MST environment.
+    // The environment of an MST object can't be changed once created. So if we are passed a
+    // groups object, we need to clone it so we can set the environment.
+    // Any code that passes in a groups object needs to use the returned one instead of their
+    // original.
     this.groups = params?.groups
       ? clone(params.groups, this)
-      : GroupsModel.create({ acceptUnknownStudents: params?.isPreviewing }, this);
+      : GroupsModel.create({}, this);
     this.class = params?.class || ClassModel.create({ name: "Null Class", classHash: "" });
     this.db = params?.db || new DB();
     this.documents = params?.documents || createDocumentsModelWithRequiredDocuments(requiredDocumentTypes);

--- a/src/models/stores/stores.ts
+++ b/src/models/stores/stores.ts
@@ -1,4 +1,4 @@
-import { addDisposer, getSnapshot } from "mobx-state-tree";
+import { addDisposer, clone, getSnapshot } from "mobx-state-tree";
 import { makeAutoObservable, runInAction, when } from "mobx";
 import { AppConfigModel, AppConfigModelType } from "./app-config-model";
 import { UnitModel, UnitModelType } from "../curriculum/unit";
@@ -124,6 +124,14 @@ class Stores implements IStores{
     this.problem = params?.problem || ProblemModel.create({ ordinal: 0, title: "Null Problem" });
 
     this.user = params?.user || UserModel.create({ id: "0" });
+
+    // Groups need us (stores) as the MST environment.
+    // So if we are passed a groups we need to clone it so we can set the environment.
+    // If any code passes in a groups they need to use the returned one instead of their
+    // original
+    this.groups = params?.groups
+      ? clone(params.groups, this)
+      : GroupsModel.create({ acceptUnknownStudents: params?.isPreviewing }, this);
     this.groups = params?.groups || GroupsModel.create({ acceptUnknownStudents: params?.isPreviewing });
     this.groups.setEnvironment(this);
     this.class = params?.class || ClassModel.create({ name: "Null Class", classHash: "" });

--- a/src/models/stores/stores.ts
+++ b/src/models/stores/stores.ts
@@ -275,7 +275,6 @@ class Stores implements IStores{
         problem,
         documents: this.documents,
         user: this.user,
-        classStore: this.class,
         curriculumConfig,
         appConfig
       }).then(() => {

--- a/src/models/stores/stores.ts
+++ b/src/models/stores/stores.ts
@@ -132,8 +132,6 @@ class Stores implements IStores{
     this.groups = params?.groups
       ? clone(params.groups, this)
       : GroupsModel.create({ acceptUnknownStudents: params?.isPreviewing }, this);
-    this.groups = params?.groups || GroupsModel.create({ acceptUnknownStudents: params?.isPreviewing });
-    this.groups.setEnvironment(this);
     this.class = params?.class || ClassModel.create({ name: "Null Class", classHash: "" });
     this.db = params?.db || new DB();
     this.documents = params?.documents || createDocumentsModelWithRequiredDocuments(requiredDocumentTypes);

--- a/src/models/stores/ui.ts
+++ b/src/models/stores/ui.ts
@@ -131,8 +131,8 @@ export const UIModel = types
       },
 
 
-      setError(error: string | Error, customMessage?: string) {
-        self.error = customMessage ?? error?.toString();
+      setError(error: unknown, customMessage?: string) {
+        self.error = customMessage ?? String(error);
         Logger.log(LogEventName.INTERNAL_ERROR_ENCOUNTERED, { message: self.error });
         if (error instanceof Error) {
           // In Chrome, passing an error instance to console.error() will print the


### PR DESCRIPTION
If a student is added to the class after CLUE has already launched, and then this new student runs CLUE and joins a group. The first student should see this new student.

To support this several changes were made:
- when the class store is updated from the portal data, it is done "in place" now with applySnapshot.
- the groups store was updated to use the MST environment system instead of handling this itself. Originally the MST system was avoided because we planning to drop MST for the Groups store. Now that we are syncing groups using MST is the best option.
- the groups store is now sync'd "in place" using applySnapshot
- the groups store now looks up the users in the class store instead of copying their initials and name. This way when a new student is in the groups and not the class store yet, we can just update the class store and the UI will update.
- We used to skip unknown group users in some configurations. These unkown users are group users with ids that are not in the class store.  Now we show them all of the time. They might be unknown because they are new or because they were removed from the class.
- switch authAndConnect to async/await to make it easier to read
- add a timestamp to the class store so we can tell when this data was fetched from the portal. This timestamp is compared with the group user creation time to tell if the user has been removed from the class. 
- add a portal service object. this provides a place store portal info like JWTs, and methods that use and update this info. 
- use the portal service to refresh the class info if necessary after updating the group info from Firebase.
- update the logic for deciding which students to boot from a group when it is oversubscribed. If there is a user that is removed from the class boot them first.

# Testing in demo mode:
It's possible to test some of this in demo mode. In demo a fake class is created for each tab that is running CLUE. This fake class is not shared with other tabs running in the same demo space and class. The fake class includes students with ids from 1 to 99. And it also includes the student that is in the URL. So if you launch CLUE with `fakeUser=student:900`, this student will be added to the class of this CLUE window but will not be added to the classes of any of the other CLUE windows. Additionally the fake class has a timestamp of `Date.now()`. These two "features" can be combined to simulate a new and removed user in the class.

## New User
1. open a tab with CLUE in demo mode with a `student:1` that is not in group. If this student is in a group already leave the group by clicking on the group button on the top right of CLUE. You should be seeing the group chooser.
2. open a second tab with CLUE in the same demo space and class with `student:900`. When this student:900 joins a group, the student:1 tab should see the group with a `**` in it. 

This is because student:900 doesn't exist in the fake class in the student:1 tab. And timestamp of the class in the student:1 tab is older than the "connected" group user timestamp for this `student:900`.

## Removed User
- open a tab with CLUE in demo mode with a `student:900`. Now join a group.
- wait at least 1 second
- open a second tab with CLUE in demo mode with a `student:1`. If student:1 is an group, leave the group. You should not see `student:900` or `**` in any groups. 

This is because `student:900` is not in the fake class of the `student:1` tab, and the group user connected timestamp for `student:900` is older than the timestamp of the fake class used by the `student:1` tab.

## Watch out when reloading tabs
If you reload the tabs used above, things will change. Each time the tab is reloaded the fakeClass timestamp is updated to the current time. And the group user connected timestamp for the current student is updated to the current time. So this will change the logic. 
 
# TODO: 
- [x] hide removed users in the UI
- [x] kick out removed users first from groups when resolving conflicts
- [x] add mechanism to test new and removed users in demo mode