### PR TITLE
feat: Drawing tile panning controls (PT-187924987)

### DIFF
--- a/cypress/e2e/functional/tile_tests/drawing_tool_spec.js
+++ b/cypress/e2e/functional/tile_tests/drawing_tool_spec.js
@@ -1,13 +1,11 @@
 import ClueCanvas from '../../../support/elements/common/cCanvas';
 import DrawToolTile from '../../../support/elements/tile/DrawToolTile';
 import ImageToolTile from '../../../support/elements/tile/ImageToolTile';
-import TileNavigator from "../../../support/elements/tile/TileNavigator";
 import { LogEventName } from '../../../../src/lib/logger-types';
 
 const clueCanvas = new ClueCanvas;
 const drawToolTile = new DrawToolTile;
 const imageToolTile = new ImageToolTile;
-const tileNavigator = new TileNavigator;
 
 function beforeTest() {
   const queryParams = `${Cypress.config("qaUnitStudent5")}`;
@@ -86,15 +84,15 @@ context('Draw Tool Tile', function () {
     drawToolTile.getDrawTileShowSortPanel().get('li:last').should("contain.text", "Circle");
 
     cy.log("can zoom in, zoom out, and fit objects");
-    drawToolTile.getDrawTileObjectCanvas().should('have.attr', 'transform', 'scale(1)');
+    drawToolTile.getDrawTileObjectCanvas().should('have.attr', 'transform', 'translate(0, 0) scale(1)');
     clueCanvas.clickToolbarButton('drawing', 'zoom-in');
-    drawToolTile.getDrawTileObjectCanvas().should('have.attr', 'transform', 'scale(1.25)');
+    drawToolTile.getDrawTileObjectCanvas().should('have.attr', 'transform', 'translate(0, 0) scale(1.25)');
     cy.get("@log")
       .should("have.been.been.calledWith", LogEventName.DRAWING_TOOL_CHANGE, Cypress.sinon.match.object)
       .its("lastCall.args.1").should("deep.include", { operation: "setZoom", args: [1.25] });
 
     clueCanvas.clickToolbarButton('drawing', 'zoom-out');
-    drawToolTile.getDrawTileObjectCanvas().should('have.attr', 'transform', 'scale(1)');
+    drawToolTile.getDrawTileObjectCanvas().should('have.attr', 'transform', 'translate(0, 0) scale(1)');
     cy.get("@log")
       .should("have.been.been.calledWith", LogEventName.DRAWING_TOOL_CHANGE, Cypress.sinon.match.object)
       .its("lastCall.args.1").should("deep.include", { operation: "setZoom", args: [1] });
@@ -104,14 +102,14 @@ context('Draw Tool Tile', function () {
       clueCanvas.clickToolbarButton('drawing', 'zoom-out');
     }
     clueCanvas.toolbarButtonIsDisabled('drawing', 'zoom-out');
-    drawToolTile.getDrawTileObjectCanvas().should('have.attr', 'transform', 'scale(0.1)');
+    drawToolTile.getDrawTileObjectCanvas().should('have.attr', 'transform', 'translate(0, 0) scale(0.1)');
 
     // Should not zoom in past zoom level 2
     for (let z=0; z< 14; z++) {
       clueCanvas.clickToolbarButton('drawing', 'zoom-in');
     }
     clueCanvas.toolbarButtonIsDisabled('drawing', 'zoom-in');
-    drawToolTile.getDrawTileObjectCanvas().should('have.attr', 'transform', 'scale(2)');
+    drawToolTile.getDrawTileObjectCanvas().should('have.attr', 'transform', 'translate(0, 0) scale(2)');
 
     // Fit should return an appropriate zoom level for the objects drawn
     clueCanvas.clickToolbarButton('drawing', 'fit-all');
@@ -119,7 +117,7 @@ context('Draw Tool Tile', function () {
     clueCanvas.toolbarButtonIsEnabled('drawing', 'zoom-out');
     drawToolTile.getDrawTileObjectCanvas().then(canvas => {
       // Check that the canvas has a transform attribute like 'scale(x)' where x is approximatesly 1.12
-      const scale = parseFloat(canvas.attr('transform').replace(/scale\((\d+\.\d+)\)/, '$1'));
+      const scale = parseFloat(canvas.attr('transform').replace(/.*scale\((\d+\.\d+)\)/, '$1'));
       expect(scale).to.be.within(1.1, 1.2);
     });
 

--- a/cypress/e2e/functional/tile_tests/drawing_tool_spec.js
+++ b/cypress/e2e/functional/tile_tests/drawing_tool_spec.js
@@ -118,7 +118,7 @@ context('Draw Tool Tile', function () {
     drawToolTile.getDrawTileObjectCanvas().then(canvas => {
       // Check that the canvas has a transform attribute like 'scale(x)' where x is approximatesly 1.12
       const scale = parseFloat(canvas.attr('transform').replace(/.*scale\((\d+\.\d+)\)/, '$1'));
-      expect(scale).to.be.within(1.1, 1.2);
+      expect(scale).to.be.within(.82, .84);
     });
 
     cy.log("can delete objects and close panel");

--- a/cypress/e2e/functional/tile_tests/drawing_tool_spec.js
+++ b/cypress/e2e/functional/tile_tests/drawing_tool_spec.js
@@ -43,10 +43,12 @@ context('Draw Tool Tile', function () {
 
     drawToolTile.getDrawTile().should("exist");
     drawToolTile.getTileTitle().should("exist");
+    clueCanvas.toolbarButtonIsDisabled("drawing", "fit-all");
 
     cy.log("can open show/sort panel and select objects");
     drawToolTile.drawRectangle(100, 50, 150, 100);
     drawToolTile.drawEllipse(300, 50, 100, 100);
+    clueCanvas.toolbarButtonIsEnabled("drawing", "fit-all");
     // Unselect all
     drawToolTile.getDrawTile()
       .trigger("pointerdown", 50, 50)
@@ -86,30 +88,47 @@ context('Draw Tool Tile', function () {
     cy.log("can zoom in, zoom out, and fit objects");
     drawToolTile.getDrawTileObjectCanvas().should('have.attr', 'transform', 'translate(0, 0) scale(1)');
     clueCanvas.clickToolbarButton('drawing', 'zoom-in');
-    drawToolTile.getDrawTileObjectCanvas().should('have.attr', 'transform', 'translate(0, 0) scale(1.25)');
+    drawToolTile.getDrawTileObjectCanvas().then(canvas => {
+      const expectedTranslationValues = { x: -58, y: -8 };
+      const expectedScale = 1.1;
+      drawToolTile.verifyTransformValues(canvas.attr('transform'), expectedTranslationValues, expectedScale);
+    });
     cy.get("@log")
       .should("have.been.been.calledWith", LogEventName.DRAWING_TOOL_CHANGE, Cypress.sinon.match.object)
-      .its("lastCall.args.1").should("deep.include", { operation: "setZoom", args: [1.25] });
+      .its("lastCall.args.1").should("deep.include", { operation: "setZoom", args: [1.1, { x: 1170, y: 176 } ] });
 
     clueCanvas.clickToolbarButton('drawing', 'zoom-out');
-    drawToolTile.getDrawTileObjectCanvas().should('have.attr', 'transform', 'translate(0, 0) scale(1)');
+    drawToolTile.getDrawTileObjectCanvas().then(canvas => {
+      const expectedTranslationValues = { x: 0, y: 0 };
+      const expectedScale = 1;
+      const nearZeroTolerance = 1e-10;
+      drawToolTile.verifyTransformValues(canvas.attr('transform'), expectedTranslationValues, expectedScale, nearZeroTolerance);
+    });
     cy.get("@log")
       .should("have.been.been.calledWith", LogEventName.DRAWING_TOOL_CHANGE, Cypress.sinon.match.object)
-      .its("lastCall.args.1").should("deep.include", { operation: "setZoom", args: [1] });
+      .its("lastCall.args.1").should("deep.include", { operation: "setZoom", args: [1, { x: 1170, y: 176 }] });
 
     // Should not zoom out past zoom level .1
-    for (let z=0; z< 11; z++) {
+    for (let z=0; z< 9; z++) {
       clueCanvas.clickToolbarButton('drawing', 'zoom-out');
     }
     clueCanvas.toolbarButtonIsDisabled('drawing', 'zoom-out');
-    drawToolTile.getDrawTileObjectCanvas().should('have.attr', 'transform', 'translate(0, 0) scale(0.1)');
+    drawToolTile.getDrawTileObjectCanvas().then(canvas => {
+      const expectedTranslationValues = { x: 526, y: 79 };
+      const expectedScale = 0.1;
+      drawToolTile.verifyTransformValues(canvas.attr('transform'), expectedTranslationValues, expectedScale);
+    });
 
     // Should not zoom in past zoom level 2
-    for (let z=0; z< 14; z++) {
+    for (let z=0; z< 19; z++) {
       clueCanvas.clickToolbarButton('drawing', 'zoom-in');
     }
     clueCanvas.toolbarButtonIsDisabled('drawing', 'zoom-in');
-    drawToolTile.getDrawTileObjectCanvas().should('have.attr', 'transform', 'translate(0, 0) scale(2)');
+    drawToolTile.getDrawTileObjectCanvas().then(canvas => {
+      const expectedTranslationValues = { x: -585, y: -88 };
+      const expectedScale = 2;
+      drawToolTile.verifyTransformValues(canvas.attr('transform'), expectedTranslationValues, expectedScale);
+    });
 
     // Fit should return an appropriate zoom level for the objects drawn
     clueCanvas.clickToolbarButton('drawing', 'fit-all');
@@ -122,6 +141,9 @@ context('Draw Tool Tile', function () {
     });
 
     cy.log("can delete objects and close panel");
+    // Reset zoom to 100%
+    clueCanvas.clickToolbarButton('drawing', 'zoom-in');
+    clueCanvas.clickToolbarButton('drawing', 'zoom-in');
     // Delete objects
     drawToolTile.getDrawTileShowSortPanel().get('li:first').should("contain.text", "Rectangle").click();
     drawToolTile.getDrawToolDelete().should("not.have.class", "disabled").click();

--- a/cypress/e2e/functional/tile_tests/drawing_tool_spec.js
+++ b/cypress/e2e/functional/tile_tests/drawing_tool_spec.js
@@ -116,7 +116,7 @@ context('Draw Tool Tile', function () {
     clueCanvas.toolbarButtonIsEnabled('drawing', 'zoom-in');
     clueCanvas.toolbarButtonIsEnabled('drawing', 'zoom-out');
     drawToolTile.getDrawTileObjectCanvas().then(canvas => {
-      // Check that the canvas has a transform attribute like 'scale(x)' where x is approximatesly 1.12
+      // Check that the canvas has a transform attribute like 'scale(x)' where x is approximatesly .83
       const scale = parseFloat(canvas.attr('transform').replace(/.*scale\((\d+\.\d+)\)/, '$1'));
       expect(scale).to.be.within(.82, .84);
     });

--- a/cypress/e2e/functional/tile_tests/tile_navigator_spec.js
+++ b/cypress/e2e/functional/tile_tests/tile_navigator_spec.js
@@ -54,6 +54,31 @@ context("Tile Navigator", () => {
       .should("have.been.been.calledWith", LogEventName.DRAWING_TOOL_CHANGE, Cypress.sinon.match.object)
       .its("lastCall.args.1").should("deep.include", { operation: "showNavigator" });
   });
+  it("displays the current zoom level", () => {
+    beforeTest();
+
+    clueCanvas.addTile("drawing");
+    drawToolTile.drawEllipse(50, 55, 100, 50);
+    cy.get(".tile-navigator .zoom-level").should("have.text", "100%");
+
+    cy.log("Zoom in from 100% to the max zoom level, 200%");
+    for (let i = 1; i < 11; i++) {
+      clueCanvas.clickToolbarButton("drawing", "zoom-in");
+      cy.get(".tile-navigator .zoom-level").should("have.text", `${100 + i * 10}%`);
+    }
+
+    cy.log("Zoom out from 200% to the min zoom level, 10%");
+    for (let i = 1; i < 20; i++) {
+      clueCanvas.clickToolbarButton("drawing", "zoom-out");
+      cy.get(".tile-navigator .zoom-level").should("have.text", `${200 - i * 10}%`);
+    }
+
+    cy.log("Click the Fit All button then zoom out");
+    clueCanvas.clickToolbarButton("drawing", "fit-all");
+    cy.get(".tile-navigator .zoom-level").should("have.text", "166%");
+    clueCanvas.clickToolbarButton("drawing", "zoom-out");
+    cy.get(".tile-navigator .zoom-level").should("have.text", "160%");
+  });
   it("is at the bottom of the drawing tile by default but can be moved to the top", () => {
     beforeTest();
 
@@ -89,30 +114,22 @@ context("Tile Navigator", () => {
 
     cy.log("Draw an ellipse that partially extends beyond the viewport's right boundary");
     drawToolTile.drawEllipse(1200, 55, 100, 50);
+    clueCanvas.clickToolbarButton("drawing", "zoom-in");
+    clueCanvas.clickToolbarButton("drawing", "zoom-in");
     tileNavigator.getTileNavigatorPanningButtons().should("exist");
 
     cy.log("Click the right panning button twice to shift the drawing canvas 100 pixels to the left");
     tileNavigator.getTileNavigatorPanningButton("right").click().click();
     tileNavigator.getTileNavigatorPanningButtons().should("exist");
-    drawToolTile.getDrawTileObjectCanvas().should("have.attr", "transform", "translate(0, 0) scale(1)");
+    drawToolTile.getDrawTileObjectCanvas().should("have.attr", "transform", "translate(-131.1, -17.6) scale(1.2)");
 
     cy.log("Click the up panning button once to shift the drawing canvas 50 pixels down");
     tileNavigator.getTileNavigatorPanningButton("up").click();
-    drawToolTile.getDrawTileObjectCanvas().should("have.attr", "transform", "translate(0, 50) scale(1)");
+    drawToolTile.getDrawTileObjectCanvas().should("have.attr", "transform", "translate(-131.1, 32.4) scale(1.2)");
 
     cy.log("Click the down panning button once to shift the drawing canvas 50 pixels up");
     tileNavigator.getTileNavigatorPanningButton("down").click();
-    drawToolTile.getDrawTileObjectCanvas().should("have.attr", "transform", "translate(0, 0) scale(1)");
-
-    cy.log("Delete the ellipses");
-    drawToolTile.getEllipseDrawing().first().click();
-    clueCanvas.clickToolbarButton("drawing", "delete");
-    drawToolTile.getEllipseDrawing().first().click();
-    clueCanvas.clickToolbarButton("drawing", "delete");
-    tileNavigator.getTileNavigatorPanningButtons().should("not.exist");
-
-    cy.log("Draw an ellipse that partially extends beyond the viewport's top boundary");
-    drawToolTile.drawEllipse(100, 50, 50, 75);
+    drawToolTile.getDrawTileObjectCanvas().should("have.attr", "transform", "translate(-131.1, -17.6) scale(1.2)");
     tileNavigator.getTileNavigatorPanningButtons().should("exist");
 
     cy.log("Click the Fit All button to bring all content into view");

--- a/cypress/e2e/functional/tile_tests/tile_navigator_spec.js
+++ b/cypress/e2e/functional/tile_tests/tile_navigator_spec.js
@@ -87,7 +87,7 @@ context("Tile Navigator", () => {
     tileNavigator.getTileNavigatorPanningButtons().should("not.exist");
     drawToolTile.getDrawTileObjectCanvas().should("have.attr", "transform", "translate(100, 0) scale(1)");
 
-    cy.log("Draw a rectangle that partially extends beyond the viewport's right boundary");
+    cy.log("Draw an ellipse that partially extends beyond the viewport's right boundary");
     drawToolTile.drawEllipse(1200, 55, 100, 50);
     tileNavigator.getTileNavigatorPanningButtons().should("exist");
 

--- a/cypress/e2e/functional/tile_tests/tile_navigator_spec.js
+++ b/cypress/e2e/functional/tile_tests/tile_navigator_spec.js
@@ -121,15 +121,28 @@ context("Tile Navigator", () => {
     cy.log("Click the right panning button twice to shift the drawing canvas 100 pixels to the left");
     tileNavigator.getTileNavigatorPanningButton("right").click().click();
     tileNavigator.getTileNavigatorPanningButtons().should("exist");
-    drawToolTile.getDrawTileObjectCanvas().should("have.attr", "transform", "translate(-131.1, -17.6) scale(1.2)");
+    drawToolTile.getDrawTileObjectCanvas().then(canvas => {
+      const expectedTranslationValues = { x: -131, y: -17 };
+      const expectedScale = 1.2;
+      drawToolTile.verifyTransformValues(canvas.attr('transform'), expectedTranslationValues, expectedScale);
+    });
 
     cy.log("Click the up panning button once to shift the drawing canvas 50 pixels down");
     tileNavigator.getTileNavigatorPanningButton("up").click();
-    drawToolTile.getDrawTileObjectCanvas().should("have.attr", "transform", "translate(-131.1, 32.4) scale(1.2)");
+    drawToolTile.getDrawTileObjectCanvas().then(canvas => {
+      const expectedTranslationValues = { x: -131, y: 32 };
+      const expectedScale = 1.2;
+      drawToolTile.verifyTransformValues(canvas.attr('transform'), expectedTranslationValues, expectedScale);
+    });
 
     cy.log("Click the down panning button once to shift the drawing canvas 50 pixels up");
     tileNavigator.getTileNavigatorPanningButton("down").click();
-    drawToolTile.getDrawTileObjectCanvas().should("have.attr", "transform", "translate(-131.1, -17.6) scale(1.2)");
+    drawToolTile.getDrawTileObjectCanvas().then(canvas => {
+      const expectedTranslationValues = { x: -131, y: -17 };
+      const expectedScale = 1.2;
+      drawToolTile.verifyTransformValues(canvas.attr('transform'), expectedTranslationValues, expectedScale);
+    });
+
     tileNavigator.getTileNavigatorPanningButtons().should("exist");
 
     cy.log("Click the Fit All button to bring all content into view");

--- a/cypress/e2e/functional/tile_tests/tile_navigator_spec.js
+++ b/cypress/e2e/functional/tile_tests/tile_navigator_spec.js
@@ -70,4 +70,53 @@ context("Tile Navigator", () => {
     cy.wait(300);
     tileNavigator.getTileNavigatorContainer().should("not.have.class", "top");
   });
+  it("provides panning buttons when elements extend beyond the viewport boundaries", () => {
+    beforeTest();
+
+    clueCanvas.addTile("drawing");
+    tileNavigator.getTileNavigatorPanningButtons().should("not.exist");
+    drawToolTile.getDrawTileObjectCanvas().should("have.attr", "transform", "translate(0, 0) scale(1)");
+
+    cy.log("Draw an ellipse that partially extends beyond the viewport's left boundary");
+    drawToolTile.drawEllipse(50, 55, 100, 50);
+    tileNavigator.getTileNavigatorPanningButtons().should("exist");
+    tileNavigator.getTileNavigatorPanningButtons().find('button').should("have.length", 4);
+
+    cy.log("Click the left panning button twice to shift the drawing canvas 100 pixels to the right");
+    tileNavigator.getTileNavigatorPanningButton("left").click().click();
+    tileNavigator.getTileNavigatorPanningButtons().should("not.exist");
+    drawToolTile.getDrawTileObjectCanvas().should("have.attr", "transform", "translate(100, 0) scale(1)");
+
+    cy.log("Draw a rectangle that partially extends beyond the viewport's right boundary");
+    drawToolTile.drawEllipse(1200, 55, 100, 50);
+    tileNavigator.getTileNavigatorPanningButtons().should("exist");
+
+    cy.log("Click the right panning button twice to shift the drawing canvas 100 pixels to the left");
+    tileNavigator.getTileNavigatorPanningButton("right").click().click();
+    tileNavigator.getTileNavigatorPanningButtons().should("exist");
+    drawToolTile.getDrawTileObjectCanvas().should("have.attr", "transform", "translate(0, 0) scale(1)");
+
+    cy.log("Click the up panning button once to shift the drawing canvas 50 pixels down");
+    tileNavigator.getTileNavigatorPanningButton("up").click();
+    drawToolTile.getDrawTileObjectCanvas().should("have.attr", "transform", "translate(0, 50) scale(1)");
+
+    cy.log("Click the down panning button once to shift the drawing canvas 50 pixels up");
+    tileNavigator.getTileNavigatorPanningButton("down").click();
+    drawToolTile.getDrawTileObjectCanvas().should("have.attr", "transform", "translate(0, 0) scale(1)");
+
+    cy.log("Delete the ellipses");
+    drawToolTile.getEllipseDrawing().first().click();
+    clueCanvas.clickToolbarButton("drawing", "delete");
+    drawToolTile.getEllipseDrawing().first().click();
+    clueCanvas.clickToolbarButton("drawing", "delete");
+    tileNavigator.getTileNavigatorPanningButtons().should("not.exist");
+
+    cy.log("Draw an ellipse that partially extends beyond the viewport's top boundary");
+    drawToolTile.drawEllipse(100, 50, 50, 75);
+    tileNavigator.getTileNavigatorPanningButtons().should("exist");
+
+    cy.log("Click the Fit All button to bring all content into view");
+    clueCanvas.clickToolbarButton("drawing", "fit-all");
+    tileNavigator.getTileNavigatorPanningButtons().should("not.exist");
+  });
 });

--- a/cypress/support/elements/tile/DrawToolTile.js
+++ b/cypress/support/elements/tile/DrawToolTile.js
@@ -10,7 +10,7 @@ class DrawToolTile{
                .not('[data-testid=tile-navigator] [data-testid=drawing-tool]');
     }
     getDrawTileObjectCanvas(){
-      return this.getDrawTileComponent().find('.object-canvas');
+      return this.getDrawTileComponent().find('[data-testid=drawing-layer-object-canvas]');
     }
     getDrawTileShowSortPanel(){
       return cy.get('.primary-workspace .drawing-tool .object-list');

--- a/cypress/support/elements/tile/DrawToolTile.js
+++ b/cypress/support/elements/tile/DrawToolTile.js
@@ -148,6 +148,16 @@ class DrawToolTile{
       this.getTextDrawing().last().get('textarea').type(text + "{enter}");
     }
 
+    verifyTransformValues(transform, expectedTranslate, expectedScale, tolerance=1) {
+      const translate = transform.replace(/.*translate\(([^,]+), ([^)]+)\).*/, '$1,$2');
+      const translateX = parseFloat(translate.split(',')[0]);
+      const translateY = parseFloat(translate.split(',')[1]);
+      expect(translateX).to.be.closeTo(expectedTranslate.x, tolerance);
+      expect(translateY).to.be.closeTo(expectedTranslate.y, tolerance);
+      const scale = parseFloat(transform.replace(/.*scale\((\d+(\.\d+)?)\)/, '$1'));
+      expect(scale).to.equal(expectedScale);
+    }
+
 }
 
 export default DrawToolTile;

--- a/cypress/support/elements/tile/TileNavigator.js
+++ b/cypress/support/elements/tile/TileNavigator.js
@@ -11,6 +11,12 @@ class TileNavigator {
   getRectangleDrawing(){
     return cy.get('.primary-workspace [data-testid=tile-navigator-container] .drawing-layer svg rect.rectangle');
   }
+  getTileNavigatorPanningButtons(){
+    return cy.get('.primary-workspace [data-testid=navigator-panning-buttons]');
+  }
+  getTileNavigatorPanningButton(direction){
+    return cy.get(`.primary-workspace [data-testid=navigator-panning-button-${direction}]`);
+  }
 }
 
 export default TileNavigator;

--- a/src/components/tiles/tile-navigator.scss
+++ b/src/components/tiles/tile-navigator.scss
@@ -146,11 +146,15 @@
 
     button {
       all: unset;
+      align-items: center;
+      border: solid 1px transparent;
       border-radius: 50%;
       cursor: pointer;
-      height: 24px;
+      display: flex;
+      height: 28px;
+      justify-content: center;
       position: absolute;
-      width: 24px;
+      width: 28px;
 
       &:hover {
         background: $workspace-teal-light-4;
@@ -165,29 +169,29 @@
 
       &.up {
         left: 50%;
-        margin-left: -12px;
+        margin-left: -14px;
         top: 0;
         transform: rotate(180deg);
       }
       &.right {
-        margin-top: -12px;
+        margin-top: -14px;
         right: 0;
         top: 50%;
         transform: rotate(-90deg);
-        width: 24px;
+        width: 28px;
       }
       &.down {
         bottom: 0;
         left: 50%;
-        margin-left: -12px;
+        margin-left: -14px;
         transform: rotate(0deg);
       }
       &.left {
         left: 0;
-        margin-top: -12px;
+        margin-top: -14px;
         top: 50%;
         transform: rotate(90deg);
-        width: 24px;
+        width: 28px;
       }
 
       svg {

--- a/src/components/tiles/tile-navigator.scss
+++ b/src/components/tiles/tile-navigator.scss
@@ -22,6 +22,10 @@
     .tile-navigator {
       border-radius: 3px 3px 0 0;
     }
+
+    .navigator-panning-buttons {
+      top: 0;
+    }
   }
 
   &.animate {

--- a/src/components/tiles/tile-navigator.scss
+++ b/src/components/tiles/tile-navigator.scss
@@ -130,6 +130,68 @@
       }
     }
   }
+
+  .navigator-panning-buttons {
+    height: 78px;
+    left: 0;
+    margin: 0 2px;
+    position: absolute;
+    top: 15px;
+    width: calc(100% - 4px);
+    z-index: 5;
+
+    button {
+      all: unset;
+      border-radius: 50%;
+      cursor: pointer;
+      height: 24px;
+      position: absolute;
+      width: 24px;
+
+      &:hover {
+        background: $workspace-teal-light-4;
+        border: solid 1px $workspace-teal;
+        opacity: .5;
+      }
+      &:active {
+        background: $workspace-teal-light-4;
+        border: solid 1px $workspace-teal;
+        opacity: 1;
+      }
+
+      &.up {
+        left: 50%;
+        margin-left: -12px;
+        top: 0;
+        transform: rotate(180deg);
+      }
+      &.right {
+        margin-top: -12px;
+        right: 0;
+        top: 50%;
+        transform: rotate(-90deg);
+        width: 24px;
+      }
+      &.down {
+        bottom: 0;
+        left: 50%;
+        margin-left: -12px;
+        transform: rotate(0deg);
+      }
+      &.left {
+        left: 0;
+        margin-top: -12px;
+        top: 50%;
+        transform: rotate(90deg);
+        width: 24px;
+      }
+
+      svg {
+        height: 24px;
+        width: 24px;
+      }
+    }
+  }
 }
 
 @keyframes navigator-scroll-up {

--- a/src/components/tiles/tile-navigator.tsx
+++ b/src/components/tiles/tile-navigator.tsx
@@ -179,6 +179,7 @@ export const TileNavigator = observer(function TileNavigator(props: INavigatorPr
             className="navigator-panning-button up"
             data-testid="navigator-panning-button-up"
             onClick={() => handleNavButtonClick("up")}
+            aria-label="Pan up"
           >
             <NavigatorScrollIcon />
           </button>
@@ -186,6 +187,7 @@ export const TileNavigator = observer(function TileNavigator(props: INavigatorPr
             className="navigator-panning-button right"
             data-testid="navigator-panning-button-right"
             onClick={() => handleNavButtonClick("right")}
+            aria-label="Pan right"
           >
             <NavigatorScrollIcon />
           </button>
@@ -193,6 +195,7 @@ export const TileNavigator = observer(function TileNavigator(props: INavigatorPr
             className="navigator-panning-button down"
             data-testid="navigator-panning-button-down"
             onClick={() => handleNavButtonClick("down")}
+            aria-label="Pan down"
           >
             <NavigatorScrollIcon />
           </button>
@@ -200,6 +203,7 @@ export const TileNavigator = observer(function TileNavigator(props: INavigatorPr
             className="navigator-panning-button left"
             data-testid="navigator-panning-button-left"
             onClick={() => handleNavButtonClick("left")}
+            aria-label="Pan left"
           >
             <NavigatorScrollIcon />
           </button>

--- a/src/models/tiles/navigatable-tile-model.ts
+++ b/src/models/tiles/navigatable-tile-model.ts
@@ -21,6 +21,8 @@ export const NavigatableTileModel = TileContentModel
     type: types.optional(types.string, kUnknownTileType),
     isNavigatorVisible: types.optional(types.boolean, true),
     navigatorPosition: types.optional(types.string, "bottom"),
+    offsetX: types.optional(types.number, 0),
+    offsetY: types.optional(types.number, 0),
     zoom: types.optional(types.number, 1)
   })
   .views(() => ({
@@ -39,6 +41,10 @@ export const NavigatableTileModel = TileContentModel
     },
     setNavigatorPosition(position: NavigatorPosition) {
       self.navigatorPosition = position;
+    },
+    setOffset(x: number, y: number) {
+      self.offsetX = x;
+      self.offsetY = y;
     },
     setZoom(zoom: number) {
       self.zoom = zoom;

--- a/src/plugins/drawing/components/__snapshots__/drawing-layer-legacy.test.tsx.snap
+++ b/src/plugins/drawing/components/__snapshots__/drawing-layer-legacy.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`Drawing Layer Components Ellipse adds a ellipse 1`] = `
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(1)"
   >
     <ellipse
@@ -33,6 +34,7 @@ exports[`Drawing Layer Components Ellipse deletes a ellipse 1`] = `
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(1)"
   />
 </svg>
@@ -46,6 +48,7 @@ exports[`Drawing Layer Components Ellipse moves a ellipse 1`] = `
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(1)"
   >
     <ellipse
@@ -71,6 +74,7 @@ exports[`Drawing Layer Components Freehand Line adds a freehand line 1`] = `
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(1)"
   >
     <path
@@ -93,6 +97,7 @@ exports[`Drawing Layer Components Freehand Line deletes a freehand line 1`] = `
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(1)"
   />
 </svg>
@@ -106,6 +111,7 @@ exports[`Drawing Layer Components Freehand Line moves a freehand line 1`] = `
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(1)"
   >
     <path
@@ -128,6 +134,7 @@ exports[`Drawing Layer Components Image adds an image 1`] = `
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(1)"
   >
     <image
@@ -151,6 +158,7 @@ exports[`Drawing Layer Components Image deletes a image 1`] = `
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(1)"
   />
 </svg>
@@ -164,6 +172,7 @@ exports[`Drawing Layer Components Image moves a image 1`] = `
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(1)"
   >
     <image
@@ -187,6 +196,7 @@ exports[`Drawing Layer Components Rectangle adds a Rectangle 1`] = `
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(1)"
   >
     <rect
@@ -213,6 +223,7 @@ exports[`Drawing Layer Components Rectangle deletes a rectangle 1`] = `
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(1)"
   />
 </svg>
@@ -226,6 +237,7 @@ exports[`Drawing Layer Components Rectangle moves a rectangle 1`] = `
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(1)"
   >
     <rect
@@ -252,6 +264,7 @@ exports[`Drawing Layer Components Vector line adds a Vector line 1`] = `
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(1)"
   >
     <g
@@ -281,6 +294,7 @@ exports[`Drawing Layer Components Vector line deletes a vector line 1`] = `
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(1)"
   />
 </svg>
@@ -294,6 +308,7 @@ exports[`Drawing Layer Components Vector line moves a vector line 1`] = `
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(1)"
   >
     <g

--- a/src/plugins/drawing/components/__snapshots__/drawing-layer-legacy.test.tsx.snap
+++ b/src/plugins/drawing/components/__snapshots__/drawing-layer-legacy.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`Drawing Layer Components Ellipse adds a ellipse 1`] = `
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(1)"
+    transform="translate(0, 0) scale(1)"
   >
     <ellipse
       cx="10"
@@ -35,7 +35,7 @@ exports[`Drawing Layer Components Ellipse deletes a ellipse 1`] = `
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(1)"
+    transform="translate(0, 0) scale(1)"
   />
 </svg>
 `;
@@ -49,7 +49,7 @@ exports[`Drawing Layer Components Ellipse moves a ellipse 1`] = `
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(1)"
+    transform="translate(0, 0) scale(1)"
   >
     <ellipse
       cx="5"
@@ -75,7 +75,7 @@ exports[`Drawing Layer Components Freehand Line adds a freehand line 1`] = `
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(1)"
+    transform="translate(0, 0) scale(1)"
   >
     <path
       d="M 10 10 l 1 1 l 2 2"
@@ -98,7 +98,7 @@ exports[`Drawing Layer Components Freehand Line deletes a freehand line 1`] = `
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(1)"
+    transform="translate(0, 0) scale(1)"
   />
 </svg>
 `;
@@ -112,7 +112,7 @@ exports[`Drawing Layer Components Freehand Line moves a freehand line 1`] = `
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(1)"
+    transform="translate(0, 0) scale(1)"
   >
     <path
       d="M 5 5 l 1 1 l 2 2"
@@ -135,7 +135,7 @@ exports[`Drawing Layer Components Image adds an image 1`] = `
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(1)"
+    transform="translate(0, 0) scale(1)"
   >
     <image
       height="10"
@@ -159,7 +159,7 @@ exports[`Drawing Layer Components Image deletes a image 1`] = `
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(1)"
+    transform="translate(0, 0) scale(1)"
   />
 </svg>
 `;
@@ -173,7 +173,7 @@ exports[`Drawing Layer Components Image moves a image 1`] = `
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(1)"
+    transform="translate(0, 0) scale(1)"
   >
     <image
       height="10"
@@ -197,7 +197,7 @@ exports[`Drawing Layer Components Rectangle adds a Rectangle 1`] = `
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(1)"
+    transform="translate(0, 0) scale(1)"
   >
     <rect
       class="rectangle"
@@ -224,7 +224,7 @@ exports[`Drawing Layer Components Rectangle deletes a rectangle 1`] = `
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(1)"
+    transform="translate(0, 0) scale(1)"
   />
 </svg>
 `;
@@ -238,7 +238,7 @@ exports[`Drawing Layer Components Rectangle moves a rectangle 1`] = `
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(1)"
+    transform="translate(0, 0) scale(1)"
   >
     <rect
       class="rectangle"
@@ -265,7 +265,7 @@ exports[`Drawing Layer Components Vector line adds a Vector line 1`] = `
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(1)"
+    transform="translate(0, 0) scale(1)"
   >
     <g
       class="vector"
@@ -295,7 +295,7 @@ exports[`Drawing Layer Components Vector line deletes a vector line 1`] = `
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(1)"
+    transform="translate(0, 0) scale(1)"
   />
 </svg>
 `;
@@ -309,7 +309,7 @@ exports[`Drawing Layer Components Vector line moves a vector line 1`] = `
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(1)"
+    transform="translate(0, 0) scale(1)"
   >
     <g
       class="vector"

--- a/src/plugins/drawing/components/__snapshots__/drawing-layer.test.tsx.snap
+++ b/src/plugins/drawing/components/__snapshots__/drawing-layer.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`Drawing Layer Components Ellipse adds a ellipse 1`] = `
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(1)"
+    transform="translate(0, 0) scale(1)"
   >
     <ellipse
       cx="10"
@@ -35,7 +35,7 @@ exports[`Drawing Layer Components Ellipse deletes a ellipse 1`] = `
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(1)"
+    transform="translate(0, 0) scale(1)"
   />
 </svg>
 `;
@@ -49,7 +49,7 @@ exports[`Drawing Layer Components Ellipse moves a ellipse 1`] = `
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(1)"
+    transform="translate(0, 0) scale(1)"
   >
     <ellipse
       cx="5"
@@ -75,7 +75,7 @@ exports[`Drawing Layer Components Freehand Line adds a freehand line 1`] = `
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(1)"
+    transform="translate(0, 0) scale(1)"
   >
     <path
       d="M 10 10 l 1 1 l 2 2"
@@ -98,7 +98,7 @@ exports[`Drawing Layer Components Freehand Line deletes a freehand line 1`] = `
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(1)"
+    transform="translate(0, 0) scale(1)"
   />
 </svg>
 `;
@@ -112,7 +112,7 @@ exports[`Drawing Layer Components Freehand Line moves a freehand line 1`] = `
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(1)"
+    transform="translate(0, 0) scale(1)"
   >
     <path
       d="M 5 5 l 1 1 l 2 2"
@@ -135,7 +135,7 @@ exports[`Drawing Layer Components Group creates a group 1`] = `
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(1)"
+    transform="translate(0, 0) scale(1)"
   >
     <rect
       class="group"
@@ -248,7 +248,7 @@ exports[`Drawing Layer Components Group deletes a group 1`] = `
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(1)"
+    transform="translate(0, 0) scale(1)"
   />
 </svg>
 `;
@@ -262,7 +262,7 @@ exports[`Drawing Layer Components Group moves a group 1`] = `
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(1)"
+    transform="translate(0, 0) scale(1)"
   >
     <rect
       class="group"
@@ -375,7 +375,7 @@ exports[`Drawing Layer Components Image adds an image 1`] = `
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(1)"
+    transform="translate(0, 0) scale(1)"
   >
     <image
       height="10"
@@ -399,7 +399,7 @@ exports[`Drawing Layer Components Image deletes a image 1`] = `
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(1)"
+    transform="translate(0, 0) scale(1)"
   />
 </svg>
 `;
@@ -413,7 +413,7 @@ exports[`Drawing Layer Components Image moves a image 1`] = `
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(1)"
+    transform="translate(0, 0) scale(1)"
   >
     <image
       height="10"
@@ -437,7 +437,7 @@ exports[`Drawing Layer Components Rectangle adds a Rectangle 1`] = `
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(1)"
+    transform="translate(0, 0) scale(1)"
   >
     <rect
       class="rectangle"
@@ -464,7 +464,7 @@ exports[`Drawing Layer Components Rectangle deletes a rectangle 1`] = `
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(1)"
+    transform="translate(0, 0) scale(1)"
   />
 </svg>
 `;
@@ -478,7 +478,7 @@ exports[`Drawing Layer Components Rectangle moves a rectangle 1`] = `
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(1)"
+    transform="translate(0, 0) scale(1)"
   >
     <rect
       class="rectangle"
@@ -505,7 +505,7 @@ exports[`Drawing Layer Components Vector arrow adds a Vector arrow 1`] = `
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(1)"
+    transform="translate(0, 0) scale(1)"
   >
     <g
       class="vector"
@@ -549,7 +549,7 @@ exports[`Drawing Layer Components Vector arrow changes vector to double arrow 1`
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(1)"
+    transform="translate(0, 0) scale(1)"
   >
     <g
       class="vector"
@@ -593,7 +593,7 @@ exports[`Drawing Layer Components Vector arrow changes vector to single arrow 1`
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(1)"
+    transform="translate(0, 0) scale(1)"
   >
     <g
       class="vector"
@@ -630,7 +630,7 @@ exports[`Drawing Layer Components Vector arrow deletes a vector arrow 1`] = `
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(1)"
+    transform="translate(0, 0) scale(1)"
   />
 </svg>
 `;
@@ -644,7 +644,7 @@ exports[`Drawing Layer Components Vector arrow moves a vector arrow 1`] = `
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(1)"
+    transform="translate(0, 0) scale(1)"
   >
     <g
       class="vector"
@@ -688,7 +688,7 @@ exports[`Drawing Layer Components Vector line adds a Vector line 1`] = `
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(1)"
+    transform="translate(0, 0) scale(1)"
   >
     <g
       class="vector"
@@ -718,7 +718,7 @@ exports[`Drawing Layer Components Vector line deletes a vector line 1`] = `
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(1)"
+    transform="translate(0, 0) scale(1)"
   />
 </svg>
 `;
@@ -732,7 +732,7 @@ exports[`Drawing Layer Components Vector line moves a vector line 1`] = `
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(1)"
+    transform="translate(0, 0) scale(1)"
   >
     <g
       class="vector"
@@ -762,7 +762,7 @@ exports[`Drawing Layer Zoom zooms in 1`] = `
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(2)"
+    transform="translate(0, 0) scale(2)"
   >
     <rect
       class="rectangle"
@@ -789,7 +789,7 @@ exports[`Drawing Layer Zoom zooms out 1`] = `
   <g
     class="object-canvas"
     data-testid="drawing-layer-object-canvas"
-    transform="scale(0.5)"
+    transform="translate(0, 0) scale(0.5)"
   >
     <rect
       class="rectangle"

--- a/src/plugins/drawing/components/__snapshots__/drawing-layer.test.tsx.snap
+++ b/src/plugins/drawing/components/__snapshots__/drawing-layer.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`Drawing Layer Components Ellipse adds a ellipse 1`] = `
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(1)"
   >
     <ellipse
@@ -33,6 +34,7 @@ exports[`Drawing Layer Components Ellipse deletes a ellipse 1`] = `
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(1)"
   />
 </svg>
@@ -46,6 +48,7 @@ exports[`Drawing Layer Components Ellipse moves a ellipse 1`] = `
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(1)"
   >
     <ellipse
@@ -71,6 +74,7 @@ exports[`Drawing Layer Components Freehand Line adds a freehand line 1`] = `
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(1)"
   >
     <path
@@ -93,6 +97,7 @@ exports[`Drawing Layer Components Freehand Line deletes a freehand line 1`] = `
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(1)"
   />
 </svg>
@@ -106,6 +111,7 @@ exports[`Drawing Layer Components Freehand Line moves a freehand line 1`] = `
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(1)"
   >
     <path
@@ -128,6 +134,7 @@ exports[`Drawing Layer Components Group creates a group 1`] = `
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(1)"
   >
     <rect
@@ -240,6 +247,7 @@ exports[`Drawing Layer Components Group deletes a group 1`] = `
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(1)"
   />
 </svg>
@@ -253,6 +261,7 @@ exports[`Drawing Layer Components Group moves a group 1`] = `
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(1)"
   >
     <rect
@@ -365,6 +374,7 @@ exports[`Drawing Layer Components Image adds an image 1`] = `
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(1)"
   >
     <image
@@ -388,6 +398,7 @@ exports[`Drawing Layer Components Image deletes a image 1`] = `
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(1)"
   />
 </svg>
@@ -401,6 +412,7 @@ exports[`Drawing Layer Components Image moves a image 1`] = `
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(1)"
   >
     <image
@@ -424,6 +436,7 @@ exports[`Drawing Layer Components Rectangle adds a Rectangle 1`] = `
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(1)"
   >
     <rect
@@ -450,6 +463,7 @@ exports[`Drawing Layer Components Rectangle deletes a rectangle 1`] = `
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(1)"
   />
 </svg>
@@ -463,6 +477,7 @@ exports[`Drawing Layer Components Rectangle moves a rectangle 1`] = `
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(1)"
   >
     <rect
@@ -489,6 +504,7 @@ exports[`Drawing Layer Components Vector arrow adds a Vector arrow 1`] = `
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(1)"
   >
     <g
@@ -532,6 +548,7 @@ exports[`Drawing Layer Components Vector arrow changes vector to double arrow 1`
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(1)"
   >
     <g
@@ -575,6 +592,7 @@ exports[`Drawing Layer Components Vector arrow changes vector to single arrow 1`
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(1)"
   >
     <g
@@ -611,6 +629,7 @@ exports[`Drawing Layer Components Vector arrow deletes a vector arrow 1`] = `
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(1)"
   />
 </svg>
@@ -624,6 +643,7 @@ exports[`Drawing Layer Components Vector arrow moves a vector arrow 1`] = `
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(1)"
   >
     <g
@@ -667,6 +687,7 @@ exports[`Drawing Layer Components Vector line adds a Vector line 1`] = `
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(1)"
   >
     <g
@@ -696,6 +717,7 @@ exports[`Drawing Layer Components Vector line deletes a vector line 1`] = `
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(1)"
   />
 </svg>
@@ -709,6 +731,7 @@ exports[`Drawing Layer Components Vector line moves a vector line 1`] = `
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(1)"
   >
     <g
@@ -738,6 +761,7 @@ exports[`Drawing Layer Zoom zooms in 1`] = `
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(2)"
   >
     <rect
@@ -764,6 +788,7 @@ exports[`Drawing Layer Zoom zooms out 1`] = `
 >
   <g
     class="object-canvas"
+    data-testid="drawing-layer-object-canvas"
     transform="scale(0.5)"
   >
     <rect

--- a/src/plugins/drawing/components/drawing-layer.tsx
+++ b/src/plugins/drawing/components/drawing-layer.tsx
@@ -36,6 +36,7 @@ interface DrawingLayerViewProps {
   imageUrlToAdd?: string;
   setImageUrlToAdd?: (url: string) => void;
   svgHeight?: number;
+  svgOffset?: Point;
   svgWidth?: number;
 }
 
@@ -51,7 +52,7 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
     implements IDrawingLayer {
   static contextType = MobXProviderContext;
   public tools: DrawingToolMap;
-  private viewRef: React.RefObject<HTMLDivElement>;
+  public viewRef: React.RefObject<HTMLDivElement>;
   private svgRef: React.RefObject<any>|null;
   private setSvgRef: (element: any) => void;
   private _isMounted: boolean;
@@ -453,6 +454,14 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
 
     const zoom = this.getContent().zoom;
 
+    // If an offset value for the SVG is provided, the `object-canvas` group will be translated to place
+    // the drawing objects appropriately.
+    const objectCanvasOffset = this.props.svgOffset
+                             ? `translate(${this.props.svgOffset.x}, ${this.props.svgOffset.y})`
+                             : "";
+    let objectCanvasTransform = objectCanvasOffset ? `${objectCanvasOffset} ` : "";
+    objectCanvasTransform += `scale(${zoom})`;
+
     return (
       // We don't propagate pointer events to the tile, since the drawing layer
       // already handles selecting the tile when necessary and we don't want to
@@ -472,7 +481,7 @@ export class DrawingLayerView extends React.Component<DrawingLayerViewProps, Dra
           height={this.props.svgHeight ?? 1500}
           ref={this.setSvgRef}
         >
-          <g className="object-canvas" transform={`scale(${zoom})`}>
+          <g className="object-canvas" data-testid="drawing-layer-object-canvas" transform={objectCanvasTransform}>
             {this.renderObjects()}
             {!this.props.readOnly && this.renderSelectionBorders(this.getSelectedObjects(), true)}
             {highlightObject

--- a/src/plugins/drawing/components/drawing-tile.tsx
+++ b/src/plugins/drawing/components/drawing-tile.tsx
@@ -30,7 +30,6 @@ const DrawingToolComponent: React.FC<IDrawingTileProps> = observer(function Draw
   const { tileElt, model, readOnly, onRegisterTileApi, navigatorAllowed = true, overflowVisible,
           svgWidth, svgHeight } = props;
   const contentModel = model.content as DrawingContentModelType;
-  const svgOffset = {x: contentModel.offsetX, y: contentModel.offsetY};
   const contentRef = useCurrent(contentModel);
   const showNavigator = navigatorAllowed && contentRef.current.isNavigatorVisible;
   const [imageUrlToAdd, setImageUrlToAdd] = useState("");
@@ -158,33 +157,25 @@ const DrawingToolComponent: React.FC<IDrawingTileProps> = observer(function Draw
   };
 
   const handleNavigatorPan = (direction: NavigatorDirection) => {
-    const drawingContainer = drawingLayerViewRef.current?.viewRef.current;
-    const svgElement = drawingContainer?.firstChild as SVGSVGElement;
-    const drawingContainerWidth = tileElt?.getBoundingClientRect().width ?? 0;
-    const drawingContainerHeight = tileElt?.getBoundingClientRect().height ?? 0;
-    const svgElementWidth = svgElement?.getBoundingClientRect().width;
-    const svgElementHeight = svgElement?.getBoundingClientRect().height;
-    const currTranslateX = contentModel.offsetX;
-    const currTranslateY = contentModel.offsetY;
+    const currOffsetX = contentModel.offsetX;
+    const currOffsetY = contentModel.offsetY;
     const moveStep = 50;
-    // the maximum allowed distance to move the svg element in each direction
-    const maxTranslateX = Math.max(0, (svgElementWidth - drawingContainerWidth) / 2);
-    const maxTranslateY = Math.max(0, (svgElementHeight - drawingContainerHeight) / 2);
-    let newX = currTranslateX;
-    let newY = currTranslateY;
+    const { contentWidth, contentHeight } = contentModel.contentSize;
+    let newX = currOffsetX;
+    let newY = currOffsetY;
 
     switch (direction) {
       case "up":
-        newY = Math.max(currTranslateY + moveStep, -maxTranslateY);
+        newY = Math.min(currOffsetY + moveStep, contentHeight);
         break;
       case "down":
-        newY = Math.min(currTranslateY - moveStep, maxTranslateY);
+        newY = Math.max(currOffsetY - moveStep, -contentHeight);
         break;
       case "left":
-        newX = Math.max(currTranslateX + moveStep, -maxTranslateX);
+        newX = Math.min(currOffsetX + moveStep, contentWidth);
         break;
       case "right":
-        newX = Math.min(currTranslateX - moveStep, maxTranslateX);
+        newX = Math.max(currOffsetX - moveStep, -contentWidth);
         break;
     }
 
@@ -218,7 +209,6 @@ const DrawingToolComponent: React.FC<IDrawingTileProps> = observer(function Draw
             ref={drawingLayerViewRef}
             setImageUrlToAdd={setImageUrlToAdd}
             svgHeight={svgHeight}
-            svgOffset={svgOffset}
             svgWidth={svgWidth}
           />
         </div>

--- a/src/plugins/drawing/model/drawing-content.ts
+++ b/src/plugins/drawing/model/drawing-content.ts
@@ -18,6 +18,7 @@ import { tileContentAPIActions, tileContentAPIViews } from "../../../models/tile
 import { IClueTileObject } from "../../../models/annotations/clue-object";
 import { GroupObjectSnapshotForAdd, GroupObjectType, isGroupObject } from "../objects/group";
 import { NavigatableTileModel } from "../../../models/tiles/navigatable-tile-model";
+import { isEllipseObject } from "../objects/ellipse";
 
 export const DrawingToolMetadataModel = TileMetadataModel
   .named("DrawingToolMetadata");
@@ -110,6 +111,20 @@ export const DrawingContentModel = NavigatableTileModel
         if (bb.se.y > se.y) se.y = bb.se.y;
       });
       return {nw, se};
+    },
+    get lowestYCoordinate() {
+      return Math.min(...self.objects.map(o => {
+        if (isEllipseObject(o)) return Number(o.y) - Number(o.ry);
+        if ("y" in o) return Number(o.y);
+        return 0;
+      })) || 0;
+    },
+    get lowestXCoordinate() {
+      return Math.min(...self.objects.map(o => {
+        if (isEllipseObject(o)) return Number(o.x) - Number(o.rx);
+        if ("x" in o) return Number(o.x);
+        return 0;
+      })) || 0;
     },
     exportJson(options?: ITileExportOptions) {
       // Translate image urls if necessary

--- a/src/plugins/drawing/model/drawing-content.ts
+++ b/src/plugins/drawing/model/drawing-content.ts
@@ -18,7 +18,6 @@ import { tileContentAPIActions, tileContentAPIViews } from "../../../models/tile
 import { IClueTileObject } from "../../../models/annotations/clue-object";
 import { GroupObjectSnapshotForAdd, GroupObjectType, isGroupObject } from "../objects/group";
 import { NavigatableTileModel } from "../../../models/tiles/navigatable-tile-model";
-import { isEllipseObject } from "../objects/ellipse";
 
 export const DrawingToolMetadataModel = TileMetadataModel
   .named("DrawingToolMetadata");
@@ -111,20 +110,6 @@ export const DrawingContentModel = NavigatableTileModel
         if (bb.se.y > se.y) se.y = bb.se.y;
       });
       return {nw, se};
-    },
-    get lowestYCoordinate() {
-      return Math.min(...self.objects.map(o => {
-        if (isEllipseObject(o)) return Number(o.y) - Number(o.ry);
-        if ("y" in o) return Number(o.y);
-        return 0;
-      })) || 0;
-    },
-    get lowestXCoordinate() {
-      return Math.min(...self.objects.map(o => {
-        if (isEllipseObject(o)) return Number(o.x) - Number(o.rx);
-        if ("x" in o) return Number(o.x);
-        return 0;
-      })) || 0;
     },
     exportJson(options?: ITileExportOptions) {
       // Translate image urls if necessary

--- a/src/plugins/drawing/objects/ellipse.tsx
+++ b/src/plugins/drawing/objects/ellipse.tsx
@@ -58,7 +58,7 @@ export const EllipseObject = types.compose("EllipseObject", StrokedObject, Fille
 export interface EllipseObjectType extends Instance<typeof EllipseObject> {}
 export interface EllipseObjectSnapshot extends SnapshotIn<typeof EllipseObject> {}
 
-function isEllipseObject(model: DrawingObjectType): model is EllipseObjectType {
+export function isEllipseObject(model: DrawingObjectType): model is EllipseObjectType {
   return model.type === "ellipse";
 }
 

--- a/src/plugins/drawing/toolbar-buttons/zoom-buttons.tsx
+++ b/src/plugins/drawing/toolbar-buttons/zoom-buttons.tsx
@@ -64,23 +64,15 @@ export const FitAllButton = observer(function FitAllButton({ name }: IToolbarBut
     const canvasSize = drawingAreaContext?.getVisibleCanvasSize();
     if (canvasSize) {
       const bb = drawingModel.objectsBoundingBox;
-      // Calculate the full width and height of the drawing content bounding box.
       const contentWidth = bb.se.x - bb.nw.x;
       const contentHeight = bb.se.y - bb.nw.y;
-      // Find the optimal zoom level to fit the content inide the viewable area.
       const optimalZoom = Math.min((canvasSize.x - padding) / contentWidth, (canvasSize.y - padding) / contentHeight);
       const legalZoom = Math.max(minZoom, Math.min(maxZoom, optimalZoom));
-      drawingModel?.setZoom(legalZoom);
+      const requiredOffsetX = Math.abs(bb.nw.x * legalZoom);
+      const requiredOffsetY = Math.abs(bb.nw.y * legalZoom);
 
-      // Get the lowest x and y coordinates of all the objects and adjust the offset accordingly
-      // If the lowest coordinate is negative, adjust the offset. Otherwise, set it to 0.
-      const lowestYCoord = bb.nw.y;
-      const lowestXCoord = bb.nw.x;
-      const offsetX = drawingModel.offsetX;
-      const offsetY = drawingModel.offsetY;
-      const newOffsetX = lowestXCoord < 0 ? (offsetX - lowestXCoord) * legalZoom : 0;
-      const newOffsetY = lowestYCoord < 0 ? (offsetY - lowestYCoord) * legalZoom : 0;
-      drawingModel?.setOffset(newOffsetX, newOffsetY);
+      drawingModel?.setZoom(legalZoom);
+      drawingModel?.setOffset(requiredOffsetX, requiredOffsetY);
     }
   }
 

--- a/src/plugins/drawing/toolbar-buttons/zoom-buttons.tsx
+++ b/src/plugins/drawing/toolbar-buttons/zoom-buttons.tsx
@@ -10,7 +10,7 @@ import ZoomInIcon from "../../../clue/assets/icons/zoom-in-icon.svg";
 import ZoomOutIcon from "../../../clue/assets/icons/zoom-out-icon.svg";
 import FitViewIcon from "../../../clue/assets/icons/fit-view-icon.svg";
 
-const zoomFactor = 1.25;
+const zoomStep = 0.1;
 const minZoom = 0.1;
 const maxZoom = 2;
 
@@ -19,7 +19,8 @@ export const ZoomInButton = observer(function ZoomInButton({ name }: IToolbarBut
   const disabled = drawingModel?.zoom >= maxZoom;
 
   function handleClick() {
-    drawingModel?.setZoom(Math.min(maxZoom, drawingModel.zoom * zoomFactor));
+    const roundedZoom = Math.round((drawingModel.zoom + zoomStep) * 10) / 10;
+    drawingModel?.setZoom(Math.min(maxZoom, roundedZoom));
   }
 
   return (
@@ -39,7 +40,8 @@ export const ZoomOutButton = observer(function ZoomOutButton({ name }: IToolbarB
   const disabled = drawingModel?.zoom <= minZoom;
 
   function handleClick() {
-    drawingModel?.setZoom(Math.max(minZoom, drawingModel.zoom / zoomFactor));
+    const roundedZoom = Math.round((drawingModel.zoom - zoomStep) * 10) / 10;
+    drawingModel?.setZoom(Math.max(minZoom, roundedZoom));
   }
 
   return (

--- a/src/plugins/drawing/toolbar-buttons/zoom-buttons.tsx
+++ b/src/plugins/drawing/toolbar-buttons/zoom-buttons.tsx
@@ -73,8 +73,8 @@ export const FitAllButton = ({ name }: IToolbarButtonComponentProps) => {
 
       // Get the lowest x and y coordinates of all the objects and adjust the offset accordingly
       // If the lowest coordinate is negative, adjust the offset. Otherwise, set it to 0.
-      const lowestYCoord = drawingModel.lowestYCoordinate;
-      const lowestXCoord = drawingModel.lowestXCoordinate;
+      const lowestYCoord = bb.nw.y;
+      const lowestXCoord = bb.nw.x;
       const offsetX = drawingModel.offsetX;
       const offsetY = drawingModel.offsetY;
       const newOffsetX = lowestXCoord < 0 ? (offsetX - lowestXCoord) * legalZoom : 0;

--- a/src/plugins/drawing/toolbar-buttons/zoom-buttons.tsx
+++ b/src/plugins/drawing/toolbar-buttons/zoom-buttons.tsx
@@ -63,9 +63,23 @@ export const FitAllButton = ({ name }: IToolbarButtonComponentProps) => {
     const canvasSize = drawingAreaContext?.getVisibleCanvasSize();
     if (canvasSize) {
       const bb = drawingModel.objectsBoundingBox;
-      const optimalZoom = Math.min((canvasSize.x-padding) / bb.se.x, (canvasSize.y-padding) / bb.se.y);
+      // Calculate the full width and height of the drawing content bounding box.
+      const contentWidth = bb.se.x - bb.nw.x;
+      const contentHeight = bb.se.y - bb.nw.y;
+      // Find the optimal zoom level to fit the content inide the viewable area.
+      const optimalZoom = Math.min((canvasSize.x - padding) / contentWidth, (canvasSize.y - padding) / contentHeight);
       const legalZoom = Math.max(minZoom, Math.min(maxZoom, optimalZoom));
       drawingModel?.setZoom(legalZoom);
+
+      // Get the lowest x and y coordinates of all the objects and adjust the offset accordingly
+      // If the lowest coordinate is negative, adjust the offset. Otherwise, set it to 0.
+      const lowestYCoord = drawingModel.lowestYCoordinate;
+      const lowestXCoord = drawingModel.lowestXCoordinate;
+      const offsetX = drawingModel.offsetX;
+      const offsetY = drawingModel.offsetY;
+      const newOffsetX = lowestXCoord < 0 ? (offsetX - lowestXCoord) * legalZoom : 0;
+      const newOffsetY = lowestYCoord < 0 ? (offsetY - lowestYCoord) * legalZoom : 0;
+      drawingModel?.setOffset(newOffsetX, newOffsetY);
     }
   }
 

--- a/src/plugins/drawing/toolbar-buttons/zoom-buttons.tsx
+++ b/src/plugins/drawing/toolbar-buttons/zoom-buttons.tsx
@@ -54,10 +54,11 @@ export const ZoomOutButton = observer(function ZoomOutButton({ name }: IToolbarB
   );
 });
 
-export const FitAllButton = ({ name }: IToolbarButtonComponentProps) => {
+export const FitAllButton = observer(function FitAllButton({ name }: IToolbarButtonComponentProps) {
   const drawingModel = useContext(DrawingContentModelContext);
   const drawingAreaContext = useDrawingAreaContext();
   const padding = 10;
+  const disabled = !drawingModel.objects.length;
 
   function handleClick() {
     const canvasSize = drawingAreaContext?.getVisibleCanvasSize();
@@ -88,9 +89,9 @@ export const FitAllButton = ({ name }: IToolbarButtonComponentProps) => {
       name={name}
       title={"Fit all"}
       onClick={handleClick}
+      disabled={disabled}
     >
       <FitViewIcon/>
     </TileToolbarButton>
   );
-};
-
+});


### PR DESCRIPTION
[#187924987](https://www.pivotaltracker.com/story/show/187924987)

Adds up, down, left, and right panning buttons to the tile navigator. The buttons only appear when drawing content extends beyond the boundaries of the main tile's viewable content area. Clicking a button pans the tile navigator viewport's and main tile's content area's view in that direction. 