### PR TITLE
fixing thrown errors fixed the closing problem

### DIFF
--- a/src/components/tiles/geometry/geometry-content.tsx
+++ b/src/components/tiles/geometry/geometry-content.tsx
@@ -746,7 +746,11 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
 
   private destroyBoard() {
     const { board } = this.state;
-    board && JXG.JSXGraph.freeBoard(board);
+    try {
+      board && JXG.JSXGraph.freeBoard(board);
+    } catch (e) {
+      console.warn("Can't free the JSX Board", {cause: e});
+    }
   }
 
   private async initializeContent() {

--- a/src/components/tiles/tile-component.tsx
+++ b/src/components/tiles/tile-component.tsx
@@ -253,7 +253,7 @@ export class TileComponent extends BaseComponent<IProps, IState> {
     const tileId = this.props.model.id;
     return Component != null
             ? <Component
-                key={tileId} tileElt={this.domElement} {...this.props}
+                key={`tile-component-${tileId}`} tileElt={this.domElement} {...this.props}
                 onRegisterTileApi={this.handleRegisterTileApi}
                 onUnregisterTileApi={this.handleUnregisterTileApi} />
             : null;
@@ -264,9 +264,11 @@ export class TileComponent extends BaseComponent<IProps, IState> {
     const tileApiInterface = this.context;
     const tileApi = tileApiInterface?.getTileApi(model.id);
     const clientTileLinks = tileApi?.getLinkedTiles?.();
-    return clientTileLinks
-            ? clientTileLinks.map((id, index) => {
-                return <LinkIndicatorComponent key={id} id={id} index={index} />;
+    // There are cases where the link ids are empty strings, so we skip those
+    const filteredLinks = clientTileLinks?.filter(id => !!id);
+    return filteredLinks
+            ? filteredLinks.map((id, index) => {
+                return <LinkIndicatorComponent key={`linked-tile-${id}`} id={id} index={index} />;
               })
             : null; // tables don't use the original link indicator any more
   }


### PR DESCRIPTION
- some linked tiles had empty string ids, so this caused react to complain about duplicate keys
- the geometry board couldn't be destroyed, the uncaught exception prevented React from re-rendering the sort work tab

PT-188339926