### PR TITLE
Create multiple ai comments

### DIFF
--- a/functions-v2/src/index.ts
+++ b/functions-v2/src/index.ts
@@ -1,7 +1,7 @@
 import * as admin from "firebase-admin";
 export {onUserDocWritten} from "./on-user-doc-written";
 export {atMidnight} from "./at-midnight";
-export {onAnalyzableDocWritten} from "./on-analyzable-doc-written";
+export {onAnalyzableTestDocWritten, onAnalyzableProdDocWritten} from "./on-analyzable-doc-written";
 export {onAnalysisDocumentPending} from "./on-analysis-document-pending";
 export {onAnalysisDocumentImaged} from "./on-analysis-document-imaged";
 

--- a/functions-v2/src/on-analysis-document-imaged.ts
+++ b/functions-v2/src/on-analysis-document-imaged.ts
@@ -67,34 +67,15 @@ export const onAnalysisDocumentImaged =
 
       const commentsPath = `demo/AI/documents/${docId}/comments`;
 
-      // Look for existing comment
-      const existing = await firestore.collection(commentsPath)
-        .where("uid", "==", commenterUid).get().then((snapshot) => {
-          if (snapshot.size > 0) {
-            return snapshot.docs[0];
-          } else {
-            return undefined;
-          }
-        });
-
-      if (existing) {
-        logger.info("Updating existing comment for", event.document);
-        await existing.ref.update({
-          tags,
-          content: message,
-          createdAt: admin.firestore.FieldValue.serverTimestamp(),
-        });
-      } else {
-        logger.info("Creating comment for", event.document);
-        // NOTE we are leaving the "network" and "tileId" fields empty in the comment doc.
-        await firestore.collection(commentsPath).add({
-          tags,
-          content: message,
-          createdAt: admin.firestore.FieldValue.serverTimestamp(),
-          name: commenterName,
-          uid: commenterUid,
-        });
-      }
+      logger.info("Creating comment for", event.document);
+      // NOTE we are leaving the "network" and "tileId" fields empty in the comment doc.
+      await firestore.collection(commentsPath).add({
+        tags,
+        content: message,
+        createdAt: admin.firestore.FieldValue.serverTimestamp(),
+        name: commenterName,
+        uid: commenterUid,
+      });
 
       // Add to "done" queue
       await firestore.collection(getAnalysisQueueFirestorePath("done")).add({

--- a/functions-v2/src/on-analysis-document-imaged.ts
+++ b/functions-v2/src/on-analysis-document-imaged.ts
@@ -36,7 +36,6 @@ export const onAnalysisDocumentImaged =
       secrets: [openaiApiKey],
     },
     async (event) => {
-      const {docId} = event.params;
       const firestore = admin.firestore();
       const queueDoc = event.data?.data();
 
@@ -65,7 +64,7 @@ export const onAnalysisDocumentImaged =
         ` Key Indicators: ${reply.parsed.keyIndicators.join(", ")}` : "";
       const message = reply.parsed.discussion + indicators;
 
-      const commentsPath = `demo/AI/documents/${docId}/comments`;
+      const commentsPath = queueDoc.commentsPath;
 
       logger.info("Creating comment for", event.document);
       // NOTE we are leaving the "network" and "tileId" fields empty in the comment doc.

--- a/functions-v2/src/on-analysis-document-pending.ts
+++ b/functions-v2/src/on-analysis-document-pending.ts
@@ -68,15 +68,7 @@ export const onAnalysisDocumentPending =
     }
 
     // Retrieve the document content
-
-    const metadataPathSegments = (queueDoc?.metadataPath as string).split("/");
-    // Metadata path will be something like "demo/AI/portals/demo/classes/democlass1/users/1/documentMetadata/testdoc1"
-    if (metadataPathSegments[metadataPathSegments.length - 2] !== "documentMetadata") {
-      await error(`Unexpected metadata path: ${queueDoc?.metadataPath}`, event);
-      return;
-    }
-    metadataPathSegments[metadataPathSegments.length - 2] = "documents";
-    const documentPath = metadataPathSegments.join("/");
+    const documentPath = (queueDoc?.documentPath as string);
     let content = undefined;
     try {
       await (getDatabase().ref(documentPath).once("value", (snapshot) => {

--- a/functions-v2/src/on-analyzable-doc-written.ts
+++ b/functions-v2/src/on-analyzable-doc-written.ts
@@ -1,4 +1,5 @@
-import {onValueWritten} from "firebase-functions/v2/database";
+import {DatabaseEvent, DataSnapshot, onValueWritten} from "firebase-functions/v2/database";
+import {Change} from "firebase-functions/v2";
 import * as logger from "firebase-functions/logger";
 import * as admin from "firebase-admin";
 import {getAnalysisQueueFirestorePath} from "./utils";
@@ -8,25 +9,60 @@ import {getAnalysisQueueFirestorePath} from "./utils";
 // 2. Create screenshots of those documents
 // 3. Send those screenshots to the AI service for processing, and create document comments with the results
 
-export const onAnalyzableDocWritten =
-  onValueWritten("{root}/classes/{classId}/users/{userId}/documentMetadata/{docId}/evaluation/{evaluator}",
-    async (event) => {
-      const timestamp = event.data.after.val();
-      // onValueWritten will trigger on create, update, or delete. Ignore deletes.
-      if (!timestamp) {
-        logger.info("evaluation was deleted", event.subject);
-        return;
-      }
-      const {root, classId, userId, docId, evaluator} = event.params;
-      const metadataPath = `${root}/classes/${classId}/users/${userId}/documentMetadata/${docId}`;
+// We watch for changes in the Firebase metadata, but will eventually need to write results out to comments
+// on the document.
 
-      const firestore = admin.firestore();
-      // This should be safe in the event of dupliclate calls; the second will just overwrite the first.
-      await firestore.doc(getAnalysisQueueFirestorePath("pending", docId)).set({
-        metadataPath,
-        docUpdated: timestamp,
-        evaluator,
-      });
-      logger.info(`Added document ${docId} to queue for ${evaluator}`);
-    }
-  );
+/* eslint-disable max-len */
+// Firebase metadata path                                                    --> corresponding Firestore document path
+// dev/devId/portals/localhost/classes/devclass/users/userId/documentMetadata/docId --> dev/devId/documents/docId
+// qa/qaId/portals/qa/classes/classId/users/userId/documentMetadata/docId           --> qa/qaId/documents/docId
+// demo/demoId/portals/demo/classes/classId/users/userId/documentMetadata/docId     --> demo/demoId/documents/docId
+// authed/portals/portalId/classes/classId/users/userId/documentMetadata/docId      --> authed/portalId/documents/docId
+
+// Note Firebase (unlike Firestore) does not support multi-segment wildcards so we can't just write {root}
+
+// This pattern handles dev, qa, and demo "realms"
+export const onAnalyzableTestDocWritten =
+  onValueWritten("{realm}/{realmId}/portals/{portalId}/classes/{classId}/users/{userId}/documentMetadata/{docId}/evaluation/{evaluator}",
+    (event) => {
+      const {realm, realmId, portalId} = event.params;
+      const firebaseRoot = `${realm}/${realmId}/portals/${portalId}`;
+      const firestoreRoot = `${realm}/${realmId}`;
+      return handleUpdate(event, firebaseRoot, firestoreRoot);
+    });
+
+// This pattern handles the authed "realm", which has one less level of hierarchy
+export const onAnalyzableProdDocWritten =
+  onValueWritten("authed/portals/{portalId}/classes/{classId}/users/{userId}/documentMetadata/{docId}/evaluation/{evaluator}",
+    (event) => {
+      const {portalId} = event.params;
+      const firebaseRoot = `authed/portals/${portalId}`;
+      const firestoreRoot = `authed/${portalId}`;
+      return handleUpdate(event, firebaseRoot, firestoreRoot);
+    });
+
+const handleUpdate = async (event: DatabaseEvent<Change<DataSnapshot>>, firebaseRoot: string, firestoreRoot: string) => {
+  const timestamp = event.data.after.val();
+  // onValueWritten will trigger on create, update, or delete. Ignore deletes.
+  if (!timestamp) {
+    logger.info("evaluation was deleted", event.subject);
+    return;
+  }
+
+  // Determine all the database paths that we are going to need
+  const {classId, userId, docId, evaluator} = event.params;
+  const metadataPath = `${firebaseRoot}/classes/${classId}/users/${userId}/documentMetadata/${docId}`;
+  const documentPath = `${firebaseRoot}/classes/${classId}/users/${userId}/documents/${docId}`;
+  const commentsPath = `${firestoreRoot}/documents/${docId}/comments`;
+
+  const firestore = admin.firestore();
+  // This should be safe in the event of dupliclate calls; the second will just overwrite the first.
+  await firestore.doc(getAnalysisQueueFirestorePath("pending", docId)).set({
+    metadataPath,
+    documentPath,
+    commentsPath,
+    docUpdated: timestamp,
+    evaluator,
+  });
+  logger.info(`Added document ${documentPath} to queue for ${evaluator}`);
+};

--- a/functions-v2/src/on-analyzable-doc-written.ts
+++ b/functions-v2/src/on-analyzable-doc-written.ts
@@ -8,12 +8,8 @@ import {getAnalysisQueueFirestorePath} from "./utils";
 // 2. Create screenshots of those documents
 // 3. Send those screenshots to the AI service for processing, and create document comments with the results
 
-// For now, restrict processing to a particular root for testing.
-// TODO later we will open this up to all documents, and {root} will be a parameter.
-const root = "demo/AI/portals/demo";
-
 export const onAnalyzableDocWritten =
-  onValueWritten(`${root}/classes/{classId}/users/{userId}/documentMetadata/{docId}/evaluation/{evaluator}`,
+  onValueWritten("{root}/classes/{classId}/users/{userId}/documentMetadata/{docId}/evaluation/{evaluator}",
     async (event) => {
       const timestamp = event.data.after.val();
       // onValueWritten will trigger on create, update, or delete. Ignore deletes.
@@ -21,7 +17,7 @@ export const onAnalyzableDocWritten =
         logger.info("evaluation was deleted", event.subject);
         return;
       }
-      const {classId, userId, docId, evaluator} = event.params;
+      const {root, classId, userId, docId, evaluator} = event.params;
       const metadataPath = `${root}/classes/${classId}/users/${userId}/documentMetadata/${docId}`;
 
       const firestore = admin.firestore();

--- a/functions-v2/src/utils.ts
+++ b/functions-v2/src/utils.ts
@@ -11,7 +11,3 @@ export function getAnalysisQueueFirestorePath(status: analysisQueueStatus, docId
     return `analysis/queue/${status}`;
   }
 }
-
-export function unitSupportsAnalysis(unit: string) {
-  return unit === "mods";
-}

--- a/functions-v2/test/on-analysis-document-imaged.test.ts
+++ b/functions-v2/test/on-analysis-document-imaged.test.ts
@@ -30,6 +30,8 @@ dotenv.config({
 
 const sampleDoc = {
   metadataPath: "demo/AI/portals/demo/classes/democlass1/users/1/documentMetadata/testdoc1",
+  documentPath: "demo/AI/portals/demo/classes/democlass1/users/1/documents/testdoc1",
+  commentsPath: "demo/AI/documents/testdoc1/comments",
   docUpdated: "1001",
   docImageUrl: "https://concord.org/wp-content/uploads/2024/05/capturing-moths-fig-2.png",
   evaluator: "categorize-design",
@@ -88,6 +90,8 @@ describe("functions", () => {
         snapshot.forEach((doc) => {
           expect(doc.data()).toEqual({
             metadataPath: "demo/AI/portals/demo/classes/democlass1/users/1/documentMetadata/testdoc1",
+            documentPath: "demo/AI/portals/demo/classes/democlass1/users/1/documents/testdoc1",
+            commentsPath: "demo/AI/documents/testdoc1/comments",
             documentId: "testdoc1",
             docUpdated: "1001",
             completedAt: expect.any(Object),
@@ -168,6 +172,8 @@ describe("functions", () => {
         snapshot.forEach((doc) => {
           expect(doc.data()).toEqual({
             metadataPath: "demo/AI/portals/demo/classes/democlass1/users/1/documentMetadata/testdoc1",
+            documentPath: "demo/AI/portals/demo/classes/democlass1/users/1/documents/testdoc1",
+            commentsPath: "demo/AI/documents/testdoc1/comments",
             documentId: "testdoc1",
             docUpdated: "1001",
             completedAt: expect.any(Object),
@@ -246,6 +252,8 @@ describe("functions", () => {
         snapshot.forEach((doc) => {
           expect(doc.data()).toEqual({
             metadataPath: "demo/AI/portals/demo/classes/democlass1/users/1/documentMetadata/testdoc1",
+            documentPath: "demo/AI/portals/demo/classes/democlass1/users/1/documents/testdoc1",
+            commentsPath: "demo/AI/documents/testdoc1/comments",
             documentId: "testdoc1",
             docUpdated: "1001",
             docImageUrl: "https://concord.org/wp-content/uploads/2024/05/capturing-moths-fig-2.png",

--- a/functions-v2/test/on-analysis-document-pending.test.ts
+++ b/functions-v2/test/on-analysis-document-pending.test.ts
@@ -54,6 +54,8 @@ describe("functions", () => {
       await wrapped({
         data: makeDocumentSnapshot({
           metadataPath: "demo/AI/portals/demo/classes/democlass1/users/1/documentMetadata/testdoc1",
+          documentPath: "demo/AI/portals/demo/classes/democlass1/users/1/documents/testdoc1",
+          commentsPath: "demo/AI/documents/testdoc1/comments",
           docUpdated: "1001",
           evaluator: "categorize-design",
         }, "analysis/queue/pending/testdoc1"),
@@ -76,6 +78,8 @@ describe("functions", () => {
       await imagedQueue.doc("testdoc1").get().then((result) => {
         expect(result.data()).toEqual({
           metadataPath: "demo/AI/portals/demo/classes/democlass1/users/1/documentMetadata/testdoc1",
+          documentPath: "demo/AI/portals/demo/classes/democlass1/users/1/documents/testdoc1",
+          commentsPath: "demo/AI/documents/testdoc1/comments",
           docUpdated: "1001",
           evaluator: "categorize-design",
           docImaged: expect.any(Object),
@@ -99,6 +103,8 @@ describe("functions", () => {
       await wrapped({
         data: makeDocumentSnapshot({
           metadataPath: "demo/AI/portals/demo/classes/democlass1/users/1/documentMetadata/testdoc1",
+          documentPath: "demo/AI/portals/demo/classes/democlass1/users/1/documents/testdoc1",
+          commentsPath: "demo/AI/documents/testdoc1/comments",
           docUpdated: "1001",
           evaluator: "does-not-exist",
         }, "analysis/queue/pending/testdoc1"),
@@ -133,6 +139,8 @@ describe("functions", () => {
         snapshot.forEach((doc) => {
           expect(doc.data()).toEqual({
             metadataPath: "demo/AI/portals/demo/classes/democlass1/users/1/documentMetadata/testdoc1",
+            documentPath: "demo/AI/portals/demo/classes/democlass1/users/1/documents/testdoc1",
+            commentsPath: "demo/AI/documents/testdoc1/comments",
             documentId: "testdoc1",
             docUpdated: "1001",
             evaluator: "does-not-exist",

--- a/functions-v2/test/on-analyzable-doc-written.test.ts
+++ b/functions-v2/test/on-analyzable-doc-written.test.ts
@@ -22,7 +22,7 @@ describe("functions", () => {
   });
 
   describe("onAnalyzableDocWritten", () => {
-    test("triggers on lastUpdateAt field creation", async () => {
+    test("triggers on evaluation field creation", async () => {
       const wrapped = fft.wrap(onAnalyzableDocWritten);
 
       const before = makeDataSnapshot(null,
@@ -34,6 +34,7 @@ describe("functions", () => {
       await wrapped({
         data: delta,
         params: {
+          root: "demo/AI/portals/demo",
           classId: "democlass1",
           userId: "1",
           docId: "testdoc1",

--- a/functions-v2/test/on-analyzable-doc-written.test.ts
+++ b/functions-v2/test/on-analyzable-doc-written.test.ts
@@ -1,14 +1,14 @@
 import {
   clearFirestoreData,
 } from "firebase-functions-test/lib/providers/firestore";
+import {makeChange} from "firebase-functions-test/lib/v1";
+import {makeDataSnapshot} from "firebase-functions-test/lib/providers/database";
 import * as logger from "firebase-functions/logger";
 import {getDatabase} from "firebase-admin/database";
 import * as admin from "firebase-admin";
 
 import {initialize, projectConfig} from "./initialize";
-import {onAnalyzableDocWritten} from "../src/on-analyzable-doc-written";
-import {makeChange} from "firebase-functions-test/lib/v1";
-import {makeDataSnapshot} from "firebase-functions-test/lib/providers/database";
+import {onAnalyzableProdDocWritten, onAnalyzableTestDocWritten} from "../src/on-analyzable-doc-written";
 
 jest.mock("firebase-functions/logger");
 
@@ -21,9 +21,9 @@ describe("functions", () => {
     await getDatabase().ref("demo").set(null);
   });
 
-  describe("onAnalyzableDocWritten", () => {
-    test("triggers on evaluation field creation", async () => {
-      const wrapped = fft.wrap(onAnalyzableDocWritten);
+  describe("on-analyzable-doc-written", () => {
+    test("triggers on demo document evaluation field creation", async () => {
+      const wrapped = fft.wrap(onAnalyzableTestDocWritten);
 
       const before = makeDataSnapshot(null,
         "demo/AI/portals/demo/classes/democlass1/users/1/documentMetadata/testdoc1/evaluation/categorize-design");
@@ -34,7 +34,9 @@ describe("functions", () => {
       await wrapped({
         data: delta,
         params: {
-          root: "demo/AI/portals/demo",
+          realm: "demo",
+          realmId: "AI",
+          portalId: "demo",
           classId: "democlass1",
           userId: "1",
           docId: "testdoc1",
@@ -42,13 +44,53 @@ describe("functions", () => {
         }});
 
       expect(logger.info)
-        .toHaveBeenCalledWith("Added document testdoc1 to queue for categorize-design");
+        // eslint-disable-next-line max-len
+        .toHaveBeenCalledWith("Added document demo/AI/portals/demo/classes/democlass1/users/1/documents/testdoc1 to queue for categorize-design");
 
       const pendingQueue = admin.firestore().collection("analysis/queue/pending");
       expect(await pendingQueue.count().get().then((result) => result.data().count)).toEqual(1);
       await pendingQueue.doc("testdoc1").get().then((result) => {
         expect(result.data()).toEqual({
           metadataPath: "demo/AI/portals/demo/classes/democlass1/users/1/documentMetadata/testdoc1",
+          documentPath: "demo/AI/portals/demo/classes/democlass1/users/1/documents/testdoc1",
+          commentsPath: "demo/AI/documents/testdoc1/comments",
+          docUpdated: "1001",
+          evaluator: "categorize-design",
+        });
+      });
+    });
+
+    test("triggers on authed document evaluation field creation", async () => {
+      const wrapped = fft.wrap(onAnalyzableProdDocWritten);
+
+      const before = makeDataSnapshot(null,
+        "authed/portals/learn/classes/democlass1/users/1/documentMetadata/testdoc1/evaluation/categorize-design");
+      const after = makeDataSnapshot("1001",
+        "authed/portals/learn/classes/democlass1/users/1/documentMetadata/testdoc1/evaluation/categorize-design");
+      const delta = makeChange(before, after);
+
+      await wrapped({
+        data: delta,
+        params: {
+          realm: "authed",
+          portalId: "learn",
+          classId: "democlass1",
+          userId: "1",
+          docId: "testdoc1",
+          evaluator: "categorize-design",
+        }});
+
+      expect(logger.info)
+        // eslint-disable-next-line max-len
+        .toHaveBeenCalledWith("Added document authed/portals/learn/classes/democlass1/users/1/documents/testdoc1 to queue for categorize-design");
+
+      const pendingQueue = admin.firestore().collection("analysis/queue/pending");
+      expect(await pendingQueue.count().get().then((result) => result.data().count)).toEqual(1);
+      await pendingQueue.doc("testdoc1").get().then((result) => {
+        expect(result.data()).toEqual({
+          metadataPath: "authed/portals/learn/classes/democlass1/users/1/documentMetadata/testdoc1",
+          documentPath: "authed/portals/learn/classes/democlass1/users/1/documents/testdoc1",
+          commentsPath: "authed/learn/documents/testdoc1/comments",
           docUpdated: "1001",
           evaluator: "categorize-design",
         });

--- a/src/public/demo/units/qa/content.json
+++ b/src/public/demo/units/qa/content.json
@@ -97,8 +97,7 @@
       "form": "What's it look like?",
       "function": "What's it do?"
     },
-    "tagPrompt": "Select QA Strategy",
-    "aiEvaluation": "categorize-design"
+    "tagPrompt": "Select QA Strategy"
   },
   "sections": {
     "introduction": {"initials": "IN", "title": "Introduction", "placeholder": "Work area for\nIntroduction section"},


### PR DESCRIPTION
Followup work on PT-188092997

* Allow creation of multiple comments by the AI evaluation. A new comment will be added each time the evaluator runs, as per request in Slack.
* Remove restriction to the `AI` demo space.