### PR TITLE
Image logging cleanup

### DIFF
--- a/src/plugins/drawing/components/drawing-layer.test.tsx
+++ b/src/plugins/drawing/components/drawing-layer.test.tsx
@@ -49,7 +49,8 @@ describe("Drawing Layer Components", () => {
       expect(getDrawingObject(content)).toMatchSnapshot();
     });
     it("moves a freehand line", () => {
-      line.setPosition(5, 5);
+      line.setDragPosition(5, 5);
+      line.repositionObject();
       expect(getDrawingObject(content)).toMatchSnapshot();
     });
     it("deletes a freehand line", () => {
@@ -75,7 +76,8 @@ describe("Drawing Layer Components", () => {
       expect(getDrawingObject(content)).toMatchSnapshot();
     });
     it("moves a vector line", () => {
-      vector.setPosition(5,5);
+      vector.setDragPosition(5,5);
+      vector.repositionObject();
       expect(getDrawingObject(content)).toMatchSnapshot();
     });
     it("deletes a vector line", () => {
@@ -103,7 +105,8 @@ describe("Drawing Layer Components", () => {
       expect(getDrawingObject(content)).toMatchSnapshot();
     });
     it("moves a vector arrow", () => {
-      vector.setPosition(5,5);
+      vector.setDragPosition(5,5);
+      vector.repositionObject();
       expect(getDrawingObject(content)).toMatchSnapshot();
     });
     it("changes vector to single arrow", () => {
@@ -138,7 +141,8 @@ describe("Drawing Layer Components", () => {
       expect(getDrawingObject(content)).toMatchSnapshot();
     });
     it("moves a rectangle", () => {
-      rect.setPosition(5,5);
+      rect.setDragPosition(5,5);
+      rect.repositionObject();
       expect(getDrawingObject(content)).toMatchSnapshot();
     });
     it("deletes a rectangle", () => {
@@ -165,7 +169,8 @@ describe("Drawing Layer Components", () => {
       expect(getDrawingObject(content)).toMatchSnapshot();
     });
     it("moves a ellipse", () => {
-      ellipse.setPosition(5,5);
+      ellipse.setDragPosition(5,5);
+      ellipse.repositionObject();
       expect(getDrawingObject(content)).toMatchSnapshot();
     });
     it("deletes a ellipse", () => {
@@ -252,7 +257,8 @@ describe("Drawing Layer Components", () => {
       expect(getDrawingObject(content)).toMatchSnapshot();
     });
     it("moves a image", () => {
-      image.setPosition(5,5);
+      image.setDragPosition(5,5);
+      image.repositionObject();
       expect(getDrawingObject(content)).toMatchSnapshot();
     });
     it("deletes a image", () => {

--- a/src/plugins/drawing/model/drawing-content.test.ts
+++ b/src/plugins/drawing/model/drawing-content.test.ts
@@ -242,11 +242,8 @@ describe("DrawingContentModel", () => {
       { operation: "deleteObjects", change: { args: [ [] ], path: ""}, tileId: "drawing-1" });
     expect(mockLogTileChangeEvent).toHaveBeenNthCalledWith(4,
       LogEventName.DRAWING_TOOL_CHANGE,
-      { operation: "setSelectedIds", change: { args: [ ["a", "b"] ], path: ""}, tileId: "drawing-1" });
-    expect(mockLogTileChangeEvent).toHaveBeenNthCalledWith(5,
-      LogEventName.DRAWING_TOOL_CHANGE,
       { operation: "deleteObjects", change: { args: [ ["a", "b"] ], path: ""}, tileId: "drawing-1" });
-    expect(mockLogTileChangeEvent).toHaveBeenCalledTimes(5);
+    expect(mockLogTileChangeEvent).toHaveBeenCalledTimes(4);
   });
 
   it("can update the properties of a set of selected drawing objects", () => {
@@ -278,44 +275,38 @@ describe("DrawingContentModel", () => {
 
     expect(mockLogTileChangeEvent).toHaveBeenNthCalledWith(1,
       LogEventName.DRAWING_TOOL_CHANGE,
-      { operation: "setSelectedIds", change: { args: [["a", "b"]], path: "" }, tileId: "drawing-1" });
+      { operation: "setStroke", change: { args: ["#000000", ["a", "b"]], path: "" }, tileId: "drawing-1" });
     expect(mockLogTileChangeEvent).toHaveBeenNthCalledWith(2,
       LogEventName.DRAWING_TOOL_CHANGE,
-      { operation: "setStroke", change: { args: ["#000000", ["a", "b"]], path: "" }, tileId: "drawing-1" });
+      { operation: "setStrokeWidth", change: { args: [2, ["a", "b"]], path: "" }, tileId: "drawing-1" });
     expect(mockLogTileChangeEvent).toHaveBeenNthCalledWith(3,
       LogEventName.DRAWING_TOOL_CHANGE,
-      { operation: "setStrokeWidth", change: { args: [2, ["a", "b"]], path: "" }, tileId: "drawing-1" });
-    expect(mockLogTileChangeEvent).toHaveBeenNthCalledWith(4,
-      LogEventName.DRAWING_TOOL_CHANGE,
       { operation: "setStrokeDashArray", change: { args: ["3,3", ["a", "b"]], path: "" }, tileId: "drawing-1" });
-    expect(mockLogTileChangeEvent).toHaveBeenCalledTimes(4);
-    });
+    expect(mockLogTileChangeEvent).toHaveBeenCalledTimes(3);
+  });
 
   it("can move objects", () => {
     const model = createDrawingContentWithMetadata();
 
     const rectSnapshot1: RectangleObjectSnapshotForAdd = {...baseRectangleSnapshot, id:"a", x:0, y:0};
-    model.addObject(rectSnapshot1);
-
-    const rectSnapshot2: RectangleObjectSnapshotForAdd = {...baseRectangleSnapshot, id:"b", x:10, y:10};
-    model.addObject(rectSnapshot2);
+    const rect1 = model.addObject(rectSnapshot1);
 
     mockLogTileChangeEvent.mockReset();
-    model.moveObjects([
-      {id: "a", destination: {x: 20, y: 20}},
-      {id: "b", destination: {x: 30, y: 30}}
-    ]);
+    rect1.setDragPosition(20, 20);
+    rect1.repositionObject();
     expect(mockLogTileChangeEvent).toHaveBeenNthCalledWith(1,
       LogEventName.DRAWING_TOOL_CHANGE, {
-        operation: "moveObjects",
+        operation: "repositionObject",
         change: {
-          args: [[{id: "a", destination: {x: 20, y: 20}}, {id: "b", destination: {x: 30, y: 30}}]],
-          path: ""
+          args: [],
+          path: "/objects/0"
         },
         tileId: "drawing-1"
       });
     expect(mockLogTileChangeEvent).toHaveBeenCalledTimes(1);
-    });
+    expect(rect1.x).toBe(20);
+    expect(rect1.y).toBe(20);
+});
 
   it("can resize rectangle", () => {
     mockLogTileChangeEvent.mockClear();
@@ -623,29 +614,6 @@ describe("DrawingContentModel", () => {
     model.setSelectedStamp(1);
 
     expect(model.currentStamp!.url).toBe("b.png");
-  });
-
-  it("can update image urls", () => {
-    const originalUrl = "my/image/url";
-    const image = ImageObject.create({
-      url: originalUrl, x: 0, y: 0, width: 10, height: 10
-    });
-    const model = createDrawingContentWithMetadata({
-      objects: [image]
-    });
-
-    model.updateImageUrl("", "");
-    expect(image.url).toEqual(originalUrl);
-
-    // Updates to a empty string are ignored
-    model.updateImageUrl("my/image/url", "");
-    expect(image.url).toEqual(originalUrl);
-
-    model.updateImageUrl("", "my/image/newUrl");
-    expect(image.url).toEqual(originalUrl);
-
-    model.updateImageUrl("my/image/url", "my/image/newUrl");
-    expect(image.url).toBe("my/image/newUrl");
   });
 
   test("addObject throws when an instance is passed to it", () => {

--- a/src/plugins/drawing/model/drawing-content.ts
+++ b/src/plugins/drawing/model/drawing-content.ts
@@ -9,7 +9,7 @@ import { StampModel, StampModelType } from "./stamp";
 import { DrawingObjectMSTUnion } from "../components/drawing-object-manager";
 import { DrawingObjectSnapshotForAdd, DrawingObjectType,
   ObjectMap, ToolbarModalButton } from "../objects/drawing-object";
-import { ImageObjectType, isImageObjectSnapshot } from "../objects/image";
+import { isImageObjectSnapshot } from "../objects/image";
 import { LogEventName } from "../../../lib/logger-types";
 import { logTileChangeEvent } from "../../../models/tiles/log/log-tile-change-event";
 import { ITileExportOptions, IDefaultContentOptions } from "../../../models/tiles/tile-content-info";
@@ -179,8 +179,9 @@ export const DrawingContentModel = NavigatableTileModel
       const tileId = self.metadata?.id ?? "";
       const {name: operation, ...change} = call;
       // Ignore actions that don't need to be logged
-      const ignoredActions = ["setDisabledFeatures", "setDragPosition", "setDragBounds",
-        "setSelectedButton", "afterAttach"];
+      const ignoredActions = ["afterAttach", "afterCreate", "reset",
+        "setDisabledFeatures", "setDragPosition", "setDragBounds",
+        "setSelectedButton", "setSelectedIds", "setOpenPalette", "setEditing"];
       if (ignoredActions.includes(operation)) return;
 
       logTileChangeEvent(LogEventName.DRAWING_TOOL_CHANGE, { operation, change, tileId });
@@ -394,25 +395,6 @@ export const DrawingContentModel = NavigatableTileModel
             }
           });
           self.setSelectedIds(newIds);
-        },
-
-        moveObjects(moves: DrawingObjectMove[]) {
-          moves.forEach(move => {
-            const object = self.objectMap[move.id];
-            object?.setPosition(move.destination.x, move.destination.y);
-          });
-        },
-
-        updateImageUrl(oldUrl: string, newUrl: string) {
-          if (!oldUrl || !newUrl || (oldUrl === newUrl)) return;
-          // Modify all images with this url
-          self.objects.forEach(object => {
-            if (object.type !== "image") return;
-            const image = object as ImageObjectType;
-            if (image.url === oldUrl) {
-              image.setUrl(newUrl);
-            }
-          });
         },
 
         createGroup(objectIds: string[]) {


### PR DESCRIPTION
PT-185893761

- Removes logging for a couple of model actions that do not represent user actions (reset, afterCreate) or are just precursors to actions (setEditing, setOpenPalette).
- Removes methods only called by tests: `moveObjects`, `updateImageUrl`
- Updates tests to use `setDragPosition` / `repositionObject` which is how the UI does it, rather than calling `setPosition` directly,.

I did not attempt to create a `dontLog` annotation; wasn't quite sure how & there was already a list of actions not to log in the code so I just added to that.
