### PR TITLE
Coordinate grid navigator panel

### DIFF
--- a/cypress/e2e/functional/document_tests/canvas_test_spec.js
+++ b/cypress/e2e/functional/document_tests/canvas_test_spec.js
@@ -213,14 +213,14 @@ context('Test Canvas', function () {
       const dragToY = rect.top + rect.height + 100;
       const transfer = new DataTransfer;
       geometryToolTile.getGeometryTile().parent('.tool-tile').find('.tool-tile-resize-handle')
-        .trigger('dragstart', { dataTransfer: transfer });
+        .trigger('dragstart', { dataTransfer: transfer, force: true }); // The navigator covers a small corner of the resize handle, need to force for Cypress
       geometryToolTile.getGeometryTile().parent('.tool-tile')
         .trigger('dragover', { clientX: rect.left, clientY: dragToY, force: true, dataTransfer: transfer });
       geometryToolTile.getGeometryTile().parent('.tool-tile')
         .trigger('drop', { clientX: rect.left, clientY: dragToY, force: true, dataTransfer: transfer });
       geometryToolTile.getGeometryTile().parent('.tool-tile').find('.tool-tile-resize-handle')
         .trigger('dragend', { clientX: rect.left, clientY: dragToY, force: true, dataTransfer: transfer });
-      geometryToolTile.getGeometryTile().invoke('height').should('be.approximately', rect.height + 150, 30);
+      geometryToolTile.getGeometryTile().invoke('height').should('be.approximately', rect.height + 100, 30);
     });
 
     cy.log('adds an image tool');

--- a/cypress/e2e/functional/tile_tests/geometry_table_integraton_test_spec.js
+++ b/cypress/e2e/functional/tile_tests/geometry_table_integraton_test_spec.js
@@ -60,7 +60,7 @@ context('Geometry Table Integration', function () {
     tableToolTile.getIndexNumberToggle().should('exist').click({ force: true });
     tableToolTile.getTableIndexColumnCell().first().should('contain', '1');
     geometryToolTile.getGeometryTile().click();
-    geometryToolTile.getGraphPointLabel().should('have.length', 2); // just x and y labels
+    geometryToolTile.getGraphPointLabel().should('have.length', 1); // just y label (x hidden by navigator)
     geometryToolTile.getGraphPointLabel().contains('A').should('not.exist');
 
     cy.log('verify points added to table are added to geometry');

--- a/cypress/e2e/functional/tile_tests/geometry_tool_spec.js
+++ b/cypress/e2e/functional/tile_tests/geometry_tool_spec.js
@@ -342,13 +342,13 @@ context('Geometry Tool', function () {
     let origPointLabel2 = 5.0;
 
     // Verify that the first point label is close to 10.0
-    geometryToolTile.getGraphPointLabel().eq(2).invoke('text').then((text) => {
+    geometryToolTile.getGraphPointLabel().eq(1).invoke('text').then((text) => {
       const value = parseFloat(text);
       expect(value).to.be.closeTo(origPointLabel1, 0.1); // Allow tolerance for value close to 10.0
     });
 
     // Verify that the second point label is close to 5.0
-    geometryToolTile.getGraphPointLabel().eq(3).invoke('text').then((text) => {
+    geometryToolTile.getGraphPointLabel().eq(2).invoke('text').then((text) => {
       const value = parseFloat(text);
       expect(value).to.be.closeTo(origPointLabel2, 0.1); // Allow tolerance for value close to 5.0
     });
@@ -381,13 +381,13 @@ context('Geometry Tool', function () {
     });
 
     // Verify that the first line segment has changed to a value close to 10.4
-    geometryToolTile.getGraphPointLabel().eq(2).invoke('text').then((text) => {
+    geometryToolTile.getGraphPointLabel().eq(1).invoke('text').then((text) => {
       const lineSegment1 = parseFloat(text);
       expect(lineSegment1).to.be.closeTo(updatedValue1, 0.1); // Tolerance for value close to 10.4
     });
 
     // Verify that the second line segment has changed to a value close to 4.6
-    geometryToolTile.getGraphPointLabel().eq(3).invoke('text').then((text) => {
+    geometryToolTile.getGraphPointLabel().eq(2).invoke('text').then((text) => {
       const lineSegment2 = parseFloat(text);
       expect(lineSegment2).to.be.closeTo(updatedValue2, 0.1); // Tolerance for value close to 4.6
     });
@@ -413,13 +413,13 @@ context('Geometry Tool', function () {
     });
 
     // Verify that the first line segment has returned to a value close to 10.0
-    geometryToolTile.getGraphPointLabel().eq(2).invoke('text').then((text) => {
+    geometryToolTile.getGraphPointLabel().eq(1).invoke('text').then((text) => {
       const lineSegment1 = parseFloat(text);
       expect(lineSegment1).to.be.closeTo(origPointLabel1, 0.1); // Tolerance for value close to 10.0
     });
 
     // Verify that the second line segment has returned to a value close to 5.0
-    geometryToolTile.getGraphPointLabel().eq(3).invoke('text').then((text) => {
+    geometryToolTile.getGraphPointLabel().eq(2).invoke('text').then((text) => {
       const lineSegment2 = parseFloat(text);
       expect(lineSegment2).to.be.closeTo(origPointLabel2, 0.1); // Tolerance for value close to 5.0
     });

--- a/cypress/e2e/functional/tile_tests/tile_navigator_spec.js
+++ b/cypress/e2e/functional/tile_tests/tile_navigator_spec.js
@@ -2,9 +2,11 @@ import ClueCanvas from "../../../support/elements/common/cCanvas";
 import TileNavigator from "../../../support/elements/tile/TileNavigator";
 import DrawToolTile from "../../../support/elements/tile/DrawToolTile";
 import { LogEventName } from "../../../../src/lib/logger-types";
+import GeometryToolTile from "../../../support/elements/tile/GeometryToolTile";
 
 let clueCanvas = new ClueCanvas,
     drawToolTile = new DrawToolTile,
+    geometryTile = new GeometryToolTile,
     tileNavigator = new TileNavigator;
 
 function beforeTest() {
@@ -15,7 +17,7 @@ function beforeTest() {
 }
 
 context("Tile Navigator", () => {
-  it("renders with a draw tool tile by default", () => {
+  it("renders with draw and geometry tiles", () => {
     beforeTest();
 
     clueCanvas.addTile("drawing");
@@ -29,7 +31,24 @@ context("Tile Navigator", () => {
     cy.log("Draw a rectangle");
     drawToolTile.drawRectangle(100, 50, 20, 20);
     tileNavigator.getRectangleDrawing().should("exist").and("have.length", 1);
+
+    clueCanvas.deleteTile("draw");
+    tileNavigator.getTileNavigator().should("not.exist");
+
+    clueCanvas.addTile("geometry");
+    tileNavigator.getTileNavigator().should("exist");
+    clueCanvas.toolbarButtonIsEnabled("geometry", "navigator");
+    clueCanvas.getToolbarButtonToolTip("geometry", "navigator").should("exist");
+    clueCanvas.getToolbarButtonToolTipText("geometry", "navigator").should("eq", "Hide Navigator");
+
+    geometryTile.getGraphPoint().should("not.exist");
+    tileNavigator.getGeometryPoint().should("not.exist");
+    clueCanvas.clickToolbarButton("geometry", "point");
+    geometryTile.clickGraphPosition(20, 20);
+    geometryTile.getGraphPoint().should("exist").and("have.length", 1);
+    tileNavigator.getGeometryPoint().should("exist").and("have.length", 1);
   });
+
   it("can be hidden and shown", () => {
     beforeTest();
 
@@ -37,22 +56,26 @@ context("Tile Navigator", () => {
       cy.stub(win.ccLogger, "log").as("log");
     });
 
-    clueCanvas.addTile("drawing");
-    cy.log("Hide tile navigator");
-    clueCanvas.clickToolbarButton("drawing", "navigator");
-    clueCanvas.getToolbarButtonToolTipText("drawing", "navigator").should("eq", "Show Navigator");
-    tileNavigator.getTileNavigator().should("not.exist");
-    cy.get("@log")
-      .should("have.been.been.calledWith", LogEventName.DRAWING_TOOL_CHANGE, Cypress.sinon.match.object)
-      .its("lastCall.args.1").should("deep.include", { operation: "hideNavigator" });
+    for(let tileType of ["drawing", "geometry"]) {
+      clueCanvas.addTile(tileType);
+      cy.log(`Testing ${tileType} navigator`);
+      const logEventName = tileType === "drawing" ? LogEventName.DRAWING_TOOL_CHANGE : LogEventName.GEOMETRY_TOOL_CHANGE;
 
-    cy.log("Show tile navigator");
-    clueCanvas.clickToolbarButton("drawing", "navigator");
-    clueCanvas.getToolbarButtonToolTipText("drawing", "navigator").should("eq", "Hide Navigator");
-    tileNavigator.getTileNavigator().should("exist");
-    cy.get("@log")
-      .should("have.been.been.calledWith", LogEventName.DRAWING_TOOL_CHANGE, Cypress.sinon.match.object)
-      .its("lastCall.args.1").should("deep.include", { operation: "showNavigator" });
+      clueCanvas.clickToolbarButton(tileType, "navigator");
+      clueCanvas.getToolbarButtonToolTipText(tileType, "navigator").should("eq", "Show Navigator");
+      tileNavigator.getTileNavigator().should("not.exist");
+      cy.get("@log")
+        .should("have.been.been.calledWith", logEventName, Cypress.sinon.match.object)
+        .its("lastCall.args.1").should("deep.include", { operation: "hideNavigator" });
+
+      clueCanvas.clickToolbarButton(tileType, "navigator");
+      clueCanvas.getToolbarButtonToolTipText(tileType, "navigator").should("eq", "Hide Navigator");
+      tileNavigator.getTileNavigator().should("exist");
+      cy.get("@log")
+        .should("have.been.been.calledWith", logEventName, Cypress.sinon.match.object)
+        .its("lastCall.args.1").should("deep.include", { operation: "showNavigator" });
+      clueCanvas.deleteTile(tileType);
+    }
   });
   it("displays the current zoom level", () => {
     beforeTest();
@@ -78,45 +101,62 @@ context("Tile Navigator", () => {
     cy.get(".tile-navigator .zoom-level").should("have.text", "166%");
     clueCanvas.clickToolbarButton("drawing", "zoom-out");
     cy.get(".tile-navigator .zoom-level").should("have.text", "160%");
+    clueCanvas.deleteTile("drawing");
+
+    clueCanvas.addTile("geometry");
+    cy.get(".tile-navigator .zoom-level").should("have.text", "100%");
+    clueCanvas.clickToolbarButton("geometry", "zoom-in");
+    cy.get(".tile-navigator .zoom-level").should("have.text", "125%");
+    clueCanvas.clickToolbarButton("geometry", "zoom-in");
+    cy.get(".tile-navigator .zoom-level").should("have.text", "156%");
+    clueCanvas.clickToolbarButton("geometry", "zoom-out");
+    cy.get(".tile-navigator .zoom-level").should("have.text", "125%");
+    clueCanvas.clickToolbarButton("geometry", "zoom-out");
+    cy.get(".tile-navigator .zoom-level").should("have.text", "100%");
+    clueCanvas.clickToolbarButton("geometry", "zoom-out");
+    cy.get(".tile-navigator .zoom-level").should("have.text", "80%");
+    clueCanvas.deleteTile("geometry");
   });
+
   it("is at the bottom of the drawing tile by default but can be moved to the top", () => {
     beforeTest();
 
-    clueCanvas.addTile("drawing");
-    tileNavigator.getTileNavigator().should("exist").and("not.have.class", "top");
+    for(let tileType of ["drawing", "geometry"]) {
+      clueCanvas.addTile(tileType);
+      tileNavigator.getTileNavigator().should("exist").and("not.have.class", "top");
 
-    cy.log("Move tile navigator to the top of the drawing tile in a quick animation");
-    tileNavigator.getTileNavigatorPlacementButton().click();
-    cy.wait(300);
-    tileNavigator.getTileNavigatorContainer().should("have.class", "top");
+      cy.log("Move tile navigator to the top of the drawing tile in a quick animation");
+      tileNavigator.getTileNavigatorPlacementButton().click();
+      cy.wait(300);
+      tileNavigator.getTileNavigatorContainer().should("have.class", "top");
 
-    cy.log("Move tile navigator to the bottom of the drawing tile in a quick animation");
-    tileNavigator.getTileNavigatorPlacementButton().click();
-    cy.wait(300);
-    tileNavigator.getTileNavigatorContainer().should("not.have.class", "top");
+      cy.log("Move tile navigator to the bottom of the drawing tile in a quick animation");
+      tileNavigator.getTileNavigatorPlacementButton().click();
+      cy.wait(300);
+      tileNavigator.getTileNavigatorContainer().should("not.have.class", "top");
+      clueCanvas.deleteTile(tileType);
+    }
   });
-  it("provides panning buttons when elements extend beyond the viewport boundaries", () => {
+
+  it("provides panning buttons", () => {
     beforeTest();
 
     clueCanvas.addTile("drawing");
-    tileNavigator.getTileNavigatorPanningButtons().should("not.exist");
+    tileNavigator.getTileNavigatorPanningButtons().should("exist");
+    tileNavigator.getTileNavigatorPanningButtons().find('button').should("have.length", 4);
     drawToolTile.getDrawTileObjectCanvas().should("have.attr", "transform", "translate(0, 0) scale(1)");
 
     cy.log("Draw an ellipse that partially extends beyond the viewport's left boundary");
     drawToolTile.drawEllipse(50, 55, 100, 50);
-    tileNavigator.getTileNavigatorPanningButtons().should("exist");
-    tileNavigator.getTileNavigatorPanningButtons().find('button').should("have.length", 4);
 
     cy.log("Click the left panning button twice to shift the drawing canvas 100 pixels to the right");
     tileNavigator.getTileNavigatorPanningButton("left").click().click();
-    tileNavigator.getTileNavigatorPanningButtons().should("not.exist");
     drawToolTile.getDrawTileObjectCanvas().should("have.attr", "transform", "translate(100, 0) scale(1)");
 
     cy.log("Draw an ellipse that partially extends beyond the viewport's right boundary");
     drawToolTile.drawEllipse(1200, 55, 100, 50);
     clueCanvas.clickToolbarButton("drawing", "zoom-in");
     clueCanvas.clickToolbarButton("drawing", "zoom-in");
-    tileNavigator.getTileNavigatorPanningButtons().should("exist");
 
     cy.log("Click the right panning button twice to shift the drawing canvas 100 pixels to the left");
     tileNavigator.getTileNavigatorPanningButton("right").click().click();
@@ -143,10 +183,24 @@ context("Tile Navigator", () => {
       drawToolTile.verifyTransformValues(canvas.attr('transform'), expectedTranslationValues, expectedScale);
     });
 
-    tileNavigator.getTileNavigatorPanningButtons().should("exist");
-
     cy.log("Click the Fit All button to bring all content into view");
     clueCanvas.clickToolbarButton("drawing", "fit-all");
-    tileNavigator.getTileNavigatorPanningButtons().should("not.exist");
+    drawToolTile.getDrawTileObjectCanvas().then(canvas => {
+      const expectedTranslationValues = { x: 90, y: 33 };
+      const expectedScale = 1.04;
+      drawToolTile.verifyTransformValues(canvas.attr('transform'), expectedTranslationValues, expectedScale);
+    });
+
+    clueCanvas.deleteTile("drawing");
+
+    cy.log("Test panning buttons in Geometry tile");
+    clueCanvas.addTile("geometry");
+    geometryTile.getGraphAxisTickLabels().should("exist");
+    geometryTile.getGraphAxisTickLabels().eq(0).should("have.text", "0");
+    // Pan right to move the "0" off the left side.
+    tileNavigator.getTileNavigatorPanningButton("right").click().click();
+    geometryTile.getGraphAxisTickLabels().eq(0).should("have.text", "5");
+    tileNavigator.getTileNavigatorPanningButton("left").click().click();
+    geometryTile.getGraphAxisTickLabels().eq(0).should("have.text", "0");
   });
 });

--- a/cypress/e2e/functional/tile_tests/tile_navigator_spec.js
+++ b/cypress/e2e/functional/tile_tests/tile_navigator_spec.js
@@ -77,6 +77,7 @@ context("Tile Navigator", () => {
       clueCanvas.deleteTile(tileType);
     }
   });
+
   it("displays the current zoom level", () => {
     beforeTest();
 
@@ -118,7 +119,7 @@ context("Tile Navigator", () => {
     clueCanvas.deleteTile("geometry");
   });
 
-  it("is at the bottom of the drawing tile by default but can be moved to the top", () => {
+  it("is at the bottom of the tile by default but can be moved to the top", () => {
     beforeTest();
 
     for(let tileType of ["drawing", "geometry"]) {

--- a/cypress/e2e/functional/tile_tests/tile_navigator_spec.js
+++ b/cypress/e2e/functional/tile_tests/tile_navigator_spec.js
@@ -186,7 +186,7 @@ context("Tile Navigator", () => {
     cy.log("Click the Fit All button to bring all content into view");
     clueCanvas.clickToolbarButton("drawing", "fit-all");
     drawToolTile.getDrawTileObjectCanvas().then(canvas => {
-      const expectedTranslationValues = { x: 90, y: 33 };
+      const expectedTranslationValues = { x: 89, y: 33 };
       const expectedScale = 1.04;
       drawToolTile.verifyTransformValues(canvas.attr('transform'), expectedTranslationValues, expectedScale);
     });

--- a/cypress/support/elements/common/cCanvas.js
+++ b/cypress/support/elements/common/cCanvas.js
@@ -270,6 +270,7 @@ class ClueCanvas {
                 tileElement = imageToolTile.getImageTile().last().click({ force: true }).parent();
                 break;
             case 'draw':
+            case 'drawing':
                 // For some reason the getDrawTile returns the tool tile component
                 tileElement = drawToolTile.getDrawTile().last().click({ force: true });
                 break;

--- a/cypress/support/elements/tile/DrawToolTile.js
+++ b/cypress/support/elements/tile/DrawToolTile.js
@@ -148,14 +148,14 @@ class DrawToolTile{
       this.getTextDrawing().last().get('textarea').type(text + "{enter}");
     }
 
-    verifyTransformValues(transform, expectedTranslate, expectedScale, tolerance=1) {
+    verifyTransformValues(transform, expectedTranslate, expectedScale, tolerance=1, scaleTolerance=0.01) {
       const translate = transform.replace(/.*translate\(([^,]+), ([^)]+)\).*/, '$1,$2');
       const translateX = parseFloat(translate.split(',')[0]);
       const translateY = parseFloat(translate.split(',')[1]);
       expect(translateX).to.be.closeTo(expectedTranslate.x, tolerance);
       expect(translateY).to.be.closeTo(expectedTranslate.y, tolerance);
       const scale = parseFloat(transform.replace(/.*scale\((\d+(\.\d+)?)\)/, '$1'));
-      expect(scale).to.equal(expectedScale);
+      expect(scale).to.be.closeTo(expectedScale, scaleTolerance);
     }
 
 }

--- a/cypress/support/elements/tile/GeometryToolTile.js
+++ b/cypress/support/elements/tile/GeometryToolTile.js
@@ -25,21 +25,21 @@ class GeometryToolTile {
         return coord === 0 ? 0 : coord; // convert -0 to 0
     }
     getGeometryTile(workspaceClass){
-        return cy.get(`${workspaceClass || ".primary-workspace"} .canvas-area .geometry-tool`);
+        return cy.get(`${workspaceClass || ".primary-workspace"} .canvas-area [data-testid=geometry-tool]`);
     }
     getGraph(workspaceClass){
-        return cy.get(`${workspaceClass || ".primary-workspace"} .canvas-area .geometry-content`);
+        return cy.get(`${workspaceClass || ".primary-workspace"} .canvas-area [data-testid=geometry-tool] .geometry-content.show-tile`);
     }
     // getGraphPoint(workspaceClass){
     //     return cy.get(`${workspaceClass || ".primary-workspace"} .canvas-area .geometry-content svg g`);
     // }
 
     getGraphPointEclipse(workspaceClass){
-        return cy.get(`${workspaceClass || ".primary-workspace"} .canvas-area .geometry-content svg g ellipse`);
+        return cy.get(`${workspaceClass || ".primary-workspace"} .canvas-area .geometry-content.show-tile svg g ellipse`);
     }
 
     getGraphTitle(workspaceClass){
-      return cy.get(`${workspaceClass || ".primary-workspace"} .canvas-area .geometry-tool .editable-tile-title-text`);
+      return cy.get(`${workspaceClass || ".primary-workspace"} .canvas-area [data-testid=geometry-tool] .editable-tile-title-text`);
     }
 
     getGraphTileTitle(workspaceClass){
@@ -55,15 +55,15 @@ class GeometryToolTile {
     }
     getGraphAxisLabel(axis){
         if (axis==='x') {
-            return cy.get('.canvas-area .geometry-content .JXGtext').contains('x');
+            return cy.get('.canvas-area .geometry-content.show-tile .JXGtext').contains('x');
         }
         if(axis==='y') {
-            return cy.get('.canvas-area .geometry-content .JXGtext').contains('y');
+            return cy.get('.canvas-area .geometry-content.show-tile .JXGtext').contains('y');
         }
     }
     // Returns all tick labels on both axes. The X-axis ones are first in the list.
     getGraphAxisTickLabels(axis) {
-      return cy.get('.canvas-area .geometry-content .tick-label');
+      return cy.get('.canvas-area .geometry-content.show-tile .tick-label');
     }
 
     getGraphPointCoordinates(index){ //This is the point coordinate text
@@ -77,17 +77,17 @@ class GeometryToolTile {
                 return '"(' + this.transformToCoordinate('x',x) + ', ' + this.transformToCoordinate('y',y) + ')"';
             });
     }
-    getGraphPointLabel(){ // This selects the letter labels for points as well as the x,y labels on the axes
-        return cy.get('.geometry-content.editable .JXGtext:visible');
+    getGraphPointLabel(workspaceClass){ // This selects the letter labels for points as well as the x,y labels on the axes
+      return this.getGeometryTile(workspaceClass).find('.geometry-content.show-tile .JXGtext:visible');
     }
-    getGraphPoint(){
-        return cy.get('.geometry-content.editable ellipse[display="inline"][fill-opacity="1"]');
+    getGraphPoint(workspaceClass){
+        return this.getGeometryTile(workspaceClass).find('.geometry-content.show-tile ellipse[display="inline"][fill-opacity="1"]');
     }
-    getPhantomGraphPoint(){
-        return cy.get('.geometry-content.editable ellipse[fill-opacity="0.5"]');
+    getPhantomGraphPoint(workspaceClass){
+      return this.getGeometryTile(workspaceClass).find('.geometry-content.show-tile ellipse[fill-opacity="0.5"]');
     }
-    getSelectedGraphPoint() {
-        return cy.get('.geometry-content.editable ellipse[fill-opacity="1"][stroke-opacity="0.25"]');
+    getSelectedGraphPoint(workspaceClass){
+      return this.getGeometryTile(workspaceClass).find('.geometry-content.show-tile ellipse[fill-opacity="1"][stroke-opacity="0.25"]');
     }
     hoverGraphPoint(x,y){
         let transX=this.transformFromCoordinate('x', x),
@@ -162,13 +162,13 @@ class GeometryToolTile {
         cy.get('.single-workspace.primary-workspace .geometry-toolbar .button.angle-label.enabled').click();
     }
     getAngleAdornment(){
-        return cy.get('.single-workspace .geometry-content g polygon').siblings('path');
+        return cy.get('.single-workspace .geometry-content.show-tile g polygon').siblings('path');
     }
     copyGraphElement(){
         cy.get('.single-workspace.primary-workspace .geometry-toolbar .button.duplicate.enabled').click();
     }
     addMovableLine(){
-        cy.get('.single-workspace .geometry-tool .button.movable-line.enabled').click();
+        cy.get('.single-workspace [data-testid=geometry-tool] .button.movable-line.enabled').click();
     }
     addComment(){
         cy.get('.single-workspace.primary-workspace .geometry-toolbar .button.comment.enabled').click();

--- a/cypress/support/elements/tile/TileNavigator.js
+++ b/cypress/support/elements/tile/TileNavigator.js
@@ -8,15 +8,23 @@ class TileNavigator {
   getTileNavigatorPlacementButton() {
     return cy.get('.primary-workspace [data-testid=tile-navigator-placement-button]');
   }
-  getRectangleDrawing(){
-    return cy.get('.primary-workspace [data-testid=tile-navigator-container] .drawing-layer svg rect.rectangle');
-  }
   getTileNavigatorPanningButtons(){
     return cy.get('.primary-workspace [data-testid=navigator-panning-buttons]');
   }
   getTileNavigatorPanningButton(direction){
     return cy.get(`.primary-workspace [data-testid=navigator-panning-button-${direction}]`);
   }
+
+  // Rectangle showing inside the drawing tile's navigator
+  getRectangleDrawing(){
+    return cy.get('.primary-workspace [data-testid=tile-navigator-container] .drawing-layer svg rect.rectangle');
+  }
+
+  // Geometry point showing inside the geometry tile's navigator
+  getGeometryPoint(){
+    return cy.get('.primary-workspace [data-testid=tile-navigator-container] ellipse[display="inline"][fill-opacity="1"]');
+  }
+
 }
 
 export default TileNavigator;

--- a/src/clue/app-config.json
+++ b/src/clue/app-config.json
@@ -316,6 +316,7 @@
           "zoom-in",
           "zoom-out",
           "fit-all",
+          "navigator",
           "|",
           "delete"
         ]

--- a/src/components/tiles/geometry/geometry-content-wrapper.tsx
+++ b/src/components/tiles/geometry/geometry-content-wrapper.tsx
@@ -3,20 +3,27 @@ import React from "react";
 import { SizeMe, SizeMeProps } from "react-sizeme";
 import { defaultTileTitleFont } from "../../constants";
 import { useMeasureText } from "../hooks/use-measure-text";
+import { useTileNavigatorContext } from "../hooks/use-tile-navigator-context";
 import { GeometryContentComponent, IGeometryContentProps } from "./geometry-content";
 
-interface IProps extends IGeometryContentProps{
+interface IProps extends IGeometryContentProps {
   readOnly?: boolean;
+  showAllContent: boolean;
 }
 export const GeometryContentWrapper: React.FC<IProps> = (props) => {
+  // Pass this context as a prop to the GeometryContentComponent
+  // Since it is a class component and can't read two contexts
+  const tileNavigatorContext = useTileNavigatorContext();
   const measureLabelText = useMeasureText(defaultTileTitleFont);
+
   return (
     <div className={classNames("geometry-wrapper", { "read-only": props.readOnly })}>
       <SizeMe monitorHeight={true}>
         {({ size }: SizeMeProps) => {
           return (
             <div className="geometry-size-me">
-              <GeometryContentComponent size={size} {...props} measureText={measureLabelText} />
+              <GeometryContentComponent size={size} {...props}
+                measureText={measureLabelText} tileNavigatorContext={tileNavigatorContext} />
             </div>
           );
         }}

--- a/src/components/tiles/geometry/geometry-content.tsx
+++ b/src/components/tiles/geometry/geometry-content.tsx
@@ -5,6 +5,7 @@ import { inject, observer } from "mobx-react";
 import { getSnapshot, onSnapshot } from "mobx-state-tree";
 import objectHash from "object-hash";
 import { SizeMeProps } from "react-sizeme";
+import classNames from "classnames";
 
 import { pointBoundingBoxSize, pointButtonRadius, segmentButtonWidth, zoomFactor } from "./geometry-constants";
 import { BaseComponent } from "../../base";
@@ -547,9 +548,11 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
   };
 
   public render() {
-    const editableClass = this.props.readOnly ? "read-only" : "editable";
-    const isLinkedClass = this.getContent().isLinked ? "is-linked" : "";
-    const classes = `geometry-content ${editableClass} ${isLinkedClass}`;
+    const classes = classNames("geometry-content",
+      this.props.readOnly ? "read-only" : "editable",
+      this.props.showAllContent ? "show-all" : "show-tile",
+      { "is-linked": this.getContent().isLinked }
+    );
     return (
       <>
         {this.renderCommentEditor()}
@@ -699,6 +702,7 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
   };
 
   private renderTitleArea() {
+    if (this.props.showAllContent) return null;
     return (
       <TileTitleArea>
         {this.renderTitle()}

--- a/src/components/tiles/geometry/geometry-tile.tsx
+++ b/src/components/tiles/geometry/geometry-tile.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useRef, useState } from "react";
+import { observer } from "mobx-react";
 import { GeometryContentWrapper } from "./geometry-content-wrapper";
 import { IGeometryProps, IActionHandlers } from "./geometry-shared";
 import { GeometryContentModelType } from "../../../models/tiles/geometry/geometry-content";
@@ -10,23 +11,29 @@ import { HotKeys } from "../../../utilities/hot-keys";
 import { TileToolbar } from "../../toolbar/tile-toolbar";
 import { IGeometryTileContext, GeometryTileContext } from "./geometry-tile-context";
 import { GeometryTileMode } from "./geometry-types";
+import { TileNavigator } from "../tile-navigator";
+import { NavigatorDirection } from "../../../models/tiles/navigatable-tile-model";
 
 import "./geometry-toolbar-registration";
 
 import "./geometry-tile.scss";
 
-const _GeometryToolComponent: React.FC<IGeometryProps> = ({
-  model, readOnly, ...others
-}) => {
+const _GeometryToolComponent: React.FC<IGeometryProps> = observer(function _GeometryToolComponent(props) {
+  const { model, readOnly, navigatorAllowed = true, ...others } = props;
   const { tileElt } = others;
   const modelRef = useCurrent(model);
   const domElement = useRef<HTMLDivElement>(null);
   const content = model.content as GeometryContentModelType;
+  const showNavigator = navigatorAllowed && content.isNavigatorVisible;
   const [board, setBoard] = useState<JXG.Board>();
   const [actionHandlers, setActionHandlers] = useState<IActionHandlers>();
   const [mode, setMode] = useState<GeometryTileMode>("select");
   const hotKeys = useRef(new HotKeys());
   const forceUpdate = useForceUpdate();
+
+  const handleNavigatorPan = (direction: NavigatorDirection) => {
+    console.log("Navigator pan", direction);
+  };
 
   const handleSetHandlers = (handlers: IActionHandlers) => {
     hotKeys.current.register({
@@ -75,9 +82,16 @@ const _GeometryToolComponent: React.FC<IGeometryProps> = ({
           onContentChange={forceUpdate} />
         <TileToolbar tileType="geometry" readOnly={!!readOnly} tileElement={tileElt} />
       </div>
+      {!readOnly && showNavigator &&
+        <TileNavigator
+          onNavigatorPan={handleNavigatorPan}
+          tileProps={props}
+          renderTile={(tileProps) => <GeometryToolComponent {...tileProps} />}
+        />
+      }
     </GeometryTileContext.Provider>
   );
-};
+});
 
 const GeometryToolComponent = React.memo(_GeometryToolComponent);
 export default GeometryToolComponent;

--- a/src/components/tiles/geometry/geometry-tile.tsx
+++ b/src/components/tiles/geometry/geometry-tile.tsx
@@ -32,7 +32,22 @@ const _GeometryToolComponent: React.FC<IGeometryProps> = observer(function _Geom
   const forceUpdate = useForceUpdate();
 
   const handleNavigatorPan = (direction: NavigatorDirection) => {
-    console.log("Navigator pan", direction);
+    if (!content.board) return;
+    const panStep = 50; // number of pixels to move in whichever direction
+    switch (direction) {
+      case "left":
+        content.board.xAxis.panByPixels(-panStep);
+        break;
+      case "right":
+        content.board.xAxis.panByPixels(panStep);
+        break;
+      case "up":
+        content.board.yAxis.panByPixels(panStep);
+        break;
+      case "down":
+        content.board.yAxis.panByPixels(-panStep);
+        break;
+    }
   };
 
   const handleSetHandlers = (handlers: IActionHandlers) => {

--- a/src/components/tiles/geometry/geometry-tile.tsx
+++ b/src/components/tiles/geometry/geometry-tile.tsx
@@ -97,7 +97,8 @@ const GeometryToolComponent: React.FC<IGeometryProps> = observer(function _Geome
   // support pointer events.
   return (
     <GeometryTileContext.Provider value={context}>
-      <div className="geometry-tool" ref={domElement} tabIndex={0}
+      <div className="geometry-tool" data-testid="geometry-tool"
+        ref={domElement} tabIndex={0}
         onPointerDownCapture={handlePointerDown}
         onPointerUpCapture={handlePointerUp}
         onMouseDownCapture={handlePointerDown}

--- a/src/components/tiles/geometry/geometry-toolbar-registration.tsx
+++ b/src/components/tiles/geometry/geometry-toolbar-registration.tsx
@@ -279,9 +279,10 @@ function ZoomOutButton({name}: IToolbarButtonComponentProps) {
   );
 }
 
-function FitAllButton({name}: IToolbarButtonComponentProps) {
+const FitAllButton = observer(function FitAllButton({name}: IToolbarButtonComponentProps) {
   const readOnly = useReadOnlyContext();
-  const { handlers } = useGeometryTileContext();
+  const { content, handlers } = useGeometryTileContext();
+  const disabled = !content || content.objects.size === 0;
 
   function handleClick() {
     if (readOnly) return;
@@ -293,11 +294,12 @@ function FitAllButton({name}: IToolbarButtonComponentProps) {
       name={name}
       title="Fit all"
       onClick={handleClick}
-      >
+      disabled={disabled}
+    >
       <FitAllSvg/>
     </TileToolbarButton>
   );
-}
+});
 
 registerTileToolbarButtons("geometry",
   [

--- a/src/components/tiles/geometry/geometry-toolbar-registration.tsx
+++ b/src/components/tiles/geometry/geometry-toolbar-registration.tsx
@@ -12,6 +12,7 @@ import { ColorPalette } from "./color-palette";
 import { clueDataColorInfo } from "../../../utilities/color-utils";
 import { GeometryContentModelType } from "src/models/tiles/geometry/geometry-content";
 import { NavigatorButton } from "../../toolbar/navigator-button";
+import { logGeometryEvent } from "../../../models/tiles/geometry/geometry-utils";
 
 import AddImageSvg from "../../../clue/assets/icons/geometry/add-image-icon.svg";
 import CommentSvg from "../../../assets/icons/comment/comment.svg";
@@ -301,6 +302,15 @@ const FitAllButton = observer(function FitAllButton({name}: IToolbarButtonCompon
   );
 });
 
+const GeometryNavigatorButton = ({name}: IToolbarButtonComponentProps) => {
+  const { content } = useGeometryTileContext();
+  const logChange = (visible: boolean) => {
+    if (!content) return;
+    logGeometryEvent(content, visible ? "showNavigator" : "hideNavigator", "board");
+  };
+  return (<NavigatorButton name={name} onChange={logChange} />);
+};
+
 registerTileToolbarButtons("geometry",
   [
     { name: "select",
@@ -364,7 +374,7 @@ registerTileToolbarButtons("geometry",
     },
     {
       name: "navigator",
-      component: NavigatorButton
+      component: GeometryNavigatorButton
     },
   ]
 );

--- a/src/components/tiles/geometry/geometry-toolbar-registration.tsx
+++ b/src/components/tiles/geometry/geometry-toolbar-registration.tsx
@@ -11,6 +11,7 @@ import { GeometryTileMode } from "./geometry-types";
 import { ColorPalette } from "./color-palette";
 import { clueDataColorInfo } from "../../../utilities/color-utils";
 import { GeometryContentModelType } from "src/models/tiles/geometry/geometry-content";
+import { NavigatorButton } from "../../toolbar/navigator-button";
 
 import AddImageSvg from "../../../clue/assets/icons/geometry/add-image-icon.svg";
 import CommentSvg from "../../../assets/icons/comment/comment.svg";
@@ -358,6 +359,10 @@ registerTileToolbarButtons("geometry",
     {
       name: "fit-all",
       component: FitAllButton
-    }
+    },
+    {
+      name: "navigator",
+      component: NavigatorButton
+    },
   ]
 );

--- a/src/components/tiles/hooks/use-tile-navigator-context.ts
+++ b/src/components/tiles/hooks/use-tile-navigator-context.ts
@@ -1,0 +1,20 @@
+import { createContext, useContext } from "react";
+import { BoundingBox } from "../../../models/tiles/navigatable-tile-model";
+
+// This context allows a the parent tile to be informed of the region
+// of x,y space that is in view in a child tile. This is used by the
+// TileNavigator to show what is in view in the tile.
+
+export interface ITileNavigatorContext {
+  reportVisibleBoundingBox: (boundingBox: BoundingBox) => void;
+}
+
+export const TileNavigatorContext = createContext<ITileNavigatorContext | null>(null);
+
+export const useTileNavigatorContext = () => {
+  const context = useContext(TileNavigatorContext);
+  if (!context) {
+    throw new Error("useTileNavigatorContext must be used within a TileNavigatorContext.Provider");
+  }
+  return context;
+};

--- a/src/components/tiles/tile-navigator.scss
+++ b/src/components/tiles/tile-navigator.scss
@@ -9,6 +9,7 @@
   right: 10px;
   transition: .2s position;
   width: 100px;
+  z-index: 10;
 
   &.top {
     padding-bottom: 15px;

--- a/src/components/tiles/tile-navigator.scss
+++ b/src/components/tiles/tile-navigator.scss
@@ -43,19 +43,19 @@
     overflow: hidden;
 
     .tile-navigator-content-area {
-      background: #fff;
       height: 79px;
-      margin: 0 5px;
       overflow: hidden;
       position: relative;
       width: 100%;
 
       .tile-navigator-tile-content {
-        left: 50%;
-        overflow: visible;
+        background: #fff;
         pointer-events: none;
         position: absolute;
-        top: 50%;
+        top: 7.5px;
+        left: 5px;
+        height: calc(100% - 15px);
+        width: calc(100% - 10px);
         transform-origin: top left;
         z-index: 1;
 
@@ -65,12 +65,12 @@
       }
       .tile-navigator-overlay {
         background: $charcoal-light-4;
-        height: 100%;
-        left: 0;
-        opacity: .65;
         position: absolute;
-        top: 0;
-        width: 100%;
+        top: 7.5px;
+        left: 5px;
+        height: calc(100% - 15px);
+        width: calc(100% - 10px);
+        opacity: .40;
         z-index: 2;
       }
       .tile-navigator-viewport {

--- a/src/components/tiles/tile-navigator.tsx
+++ b/src/components/tiles/tile-navigator.tsx
@@ -48,16 +48,6 @@ export const TileNavigator = observer(function TileNavigator(props: INavigatorPr
   const placementButtonRef = useRef<HTMLButtonElement>(null);
   const [isAnimating, setIsAnimating] = useState(false);
 
-  // Adjust the props for the scaled down version of the tile.
-  const renderTileProps = {
-    ...tileProps,
-    navigatorAllowed: false,
-    readOnly: true,
-    overflowVisible: true,
-    svgWidth: canvasSize.width,
-    svgHeight: canvasSize.height,
-  };
-
   // Determine the width and height of the navigator viewport based on a scale factor
   // calculated from the parent tile's dimensions and navigator's dimensions.
   const scaleX = navigatorSize.width / tileWidth;
@@ -67,6 +57,18 @@ export const TileNavigator = observer(function TileNavigator(props: INavigatorPr
   const scaleFactor = zoom > 1 ? baseScaleFactor / zoom : baseScaleFactor;
   const viewportWidth = tileWidth * scaleFactor;
   const viewportHeight = tileHeight * scaleFactor;
+
+  // Adjust the props for the scaled down version of the tile.
+  const renderTileProps = {
+    ...tileProps,
+    navigatorAllowed: false,
+    showAllContent: true,
+    readOnly: true,
+    overflowVisible: true,
+    svgWidth: canvasSize.width,
+    svgHeight: canvasSize.height,
+    scale: scaleFactor,
+  };
 
   // Define a clip path for the overlay that allows content within the viewport's bounds
   // to show through without being covered by the semi-transparent overlay.

--- a/src/components/toolbar/navigator-button.tsx
+++ b/src/components/toolbar/navigator-button.tsx
@@ -9,11 +9,18 @@ import { isNavigatableTileModel } from "../../models/tiles/navigatable-tile-mode
 import HideNavigatorIcon from "../../assets/icons/hide-navigator-icon.svg";
 import ShowNavigatorIcon from "../../assets/icons/show-navigator-icon.svg";
 
+interface INavigatorButtonProps extends IToolbarButtonComponentProps {
+  onChange?: (visible: boolean) => void;
+}
+
+
 /**
  * The NavigatorButton component provides toolbar button for adding or removing the Tile Navigator
  * to/from tiles that support it.
+ * An "onChange" callback can be provided to take additional actions (eg, log an event) beyond just
+ * setting the visibility of the navigator.
  */
-export const NavigatorButton = observer(function NavigatorButton({ name }: IToolbarButtonComponentProps) {
+export const NavigatorButton = observer(function NavigatorButton({ name, onChange }: INavigatorButtonProps) {
   const tileContentModel = useContext(TileModelContext)?.content;
   if (!isNavigatableTileModel(tileContentModel)) return null;
 
@@ -21,6 +28,9 @@ export const NavigatorButton = observer(function NavigatorButton({ name }: ITool
   const ButtonIcon = tileContentModel?.isNavigatorVisible ? <HideNavigatorIcon/> : <ShowNavigatorIcon/>;
 
   const handleClick = () => {
+    if (onChange) {
+      onChange(!tileContentModel.isNavigatorVisible);
+    }
     if (tileContentModel.isNavigatorVisible) {
       tileContentModel.hideNavigator();
     } else {

--- a/src/models/document/document-content-tests/dc-general.test.ts
+++ b/src/models/document/document-content-tests/dc-general.test.ts
@@ -57,8 +57,18 @@ describe("DocumentContentModel", () => {
     expect(parsedContentExport()).toEqual({
       tiles: [
         { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } },
-        { title: "Coordinate Grid 1", content: { type: "Geometry", objects: {},
-            linkedAttributeColors: {}, pointMetadata: {} } },
+        { title: "Coordinate Grid 1",
+          content: {
+            type: "Geometry",
+            objects: {},
+            linkedAttributeColors: {},
+            pointMetadata: {},
+            offsetX: 0,
+            offsetY: 0,
+            isNavigatorVisible: true,
+            navigatorPosition: "bottom",
+            zoom: 1
+          } },
         { title: "Table 1", content: { type: "Table", columnWidths } },
         { title: "Sketch 1", content: { type: "Drawing", objects: [] } }
       ]
@@ -470,7 +480,17 @@ describe("DocumentContentModel -- sectioned documents --", () => {
     expect(getAllRows(content)).toEqual([
       { Header: "A"},
       { title: "Coordinate Grid 1",
-          content: { type: "Geometry", objects: {}, linkedAttributeColors: {}, pointMetadata: {} } },
+          content: {
+            type: "Geometry",
+            objects: {},
+            linkedAttributeColors: {},
+            pointMetadata: {},
+            isNavigatorVisible: true,
+            navigatorPosition: "bottom",
+            zoom: 1,
+            offsetX: 0,
+            offsetY: 0
+           } },
       { Header: "B"},
       { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } },
     ]);
@@ -482,8 +502,17 @@ describe("DocumentContentModel -- sectioned documents --", () => {
       { Placeholder: "A" },
       { Header: "B"},
       [
-        { title: "Coordinate Grid 1", content: { type: "Geometry", objects: {},
-          linkedAttributeColors: {}, pointMetadata: {} } },
+        { title: "Coordinate Grid 1", content: {
+          type: "Geometry",
+          objects: {},
+          linkedAttributeColors: {},
+          pointMetadata: {},
+          isNavigatorVisible: true,
+          navigatorPosition: "bottom",
+          zoom: 1,
+          offsetX: 0,
+          offsetY: 0
+        } },
         { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } }
       ],
     ]);
@@ -491,8 +520,17 @@ describe("DocumentContentModel -- sectioned documents --", () => {
     content.moveTile(geometryId, { rowDropIndex: 1, rowDropLocation: "left", rowInsertIndex: 1 });
     expect(getAllRows(content)).toEqual([
       { Header: "A"},
-        { title: "Coordinate Grid 1", content: { type: "Geometry", objects: {},
-          linkedAttributeColors: {}, pointMetadata: {} } },
+        { title: "Coordinate Grid 1", content: {
+          type: "Geometry",
+          objects: {},
+          linkedAttributeColors: {},
+          pointMetadata: {},
+          isNavigatorVisible: true,
+          navigatorPosition: "bottom",
+          zoom: 1,
+          offsetX: 0,
+          offsetY: 0
+         } },
       { Header: "B"},
       { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } },
     ]);
@@ -508,8 +546,17 @@ describe("DocumentContentModel -- sectioned documents --", () => {
       { Header: "A"},
       [
         { content: { type: "Text", format: "html", text: ["<p></p>"] } },
-        { title: "Coordinate Grid 1", content: { type: "Geometry", objects: {},
-          linkedAttributeColors: {}, pointMetadata: {} } },
+        { title: "Coordinate Grid 1", content: {
+          type: "Geometry",
+          objects: {},
+          linkedAttributeColors: {},
+          pointMetadata: {},
+          isNavigatorVisible: true,
+          navigatorPosition: "bottom",
+          zoom: 1,
+          offsetX: 0,
+          offsetY: 0
+        } },
       ],
       { Header: "B"},
       { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } },
@@ -524,8 +571,17 @@ describe("DocumentContentModel -- sectioned documents --", () => {
     content.deleteTile(tileId);
     expect(getAllRows(content)).toEqual([
       { Header: "A"},
-      { title: "Coordinate Grid 1", content: { type: "Geometry", objects: {},
-        linkedAttributeColors: {}, pointMetadata: {} } },
+      { title: "Coordinate Grid 1", content: {
+        type: "Geometry",
+        objects: {},
+        linkedAttributeColors: {},
+        pointMetadata: {},
+        isNavigatorVisible: true,
+        navigatorPosition: "bottom",
+        zoom: 1,
+        offsetX: 0,
+        offsetY: 0
+      } },
       { Header: "B"},
       { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } },
     ]);

--- a/src/models/document/document-content-tests/dc-shared-models.test.ts
+++ b/src/models/document/document-content-tests/dc-shared-models.test.ts
@@ -68,7 +68,17 @@ describe("DocumentContentModel -- shared Models --", () => {
       tiles: [
         [
           { content: { type: "Table", columnWidths } },
-          { content: { type: "Geometry", objects: {}, linkedAttributeColors: {}, pointMetadata: {} } }
+          { content: {
+            type: "Geometry",
+            objects: {},
+            linkedAttributeColors: {},
+            pointMetadata: {},
+            isNavigatorVisible: true,
+            navigatorPosition: "bottom",
+            zoom: 1,
+            offsetX: 0,
+            offsetY: 0
+          } }
         ]
       ],
       sharedModels: [
@@ -242,10 +252,15 @@ Object {
             "unit": 18.3,
           },
         },
+        "isNavigatorVisible": true,
         "linkedAttributeColors": Object {},
+        "navigatorPosition": "bottom",
         "objects": Object {},
+        "offsetX": 0,
+        "offsetY": 0,
         "pointMetadata": Object {},
         "type": "Geometry",
+        "zoom": 1,
       },
       "display": undefined,
       "id": "graphTool",
@@ -693,10 +708,15 @@ Object {
             "unit": 18.3,
           },
         },
+        "isNavigatorVisible": true,
         "linkedAttributeColors": Object {},
+        "navigatorPosition": "bottom",
         "objects": Object {},
+        "offsetX": 0,
+        "offsetY": 0,
         "pointMetadata": Object {},
         "type": "Geometry",
+        "zoom": 1,
       },
       "display": undefined,
       "id": "testid-47",

--- a/src/models/document/document-content-tests/dc-tile-move-copy.test.ts
+++ b/src/models/document/document-content-tests/dc-tile-move-copy.test.ts
@@ -106,7 +106,17 @@ describe("DocumentContentModel -- move/copy tiles --", () => {
           { content: { type: "Image", url: "image/url" } }
         ],
         [
-          { content: { type: "Geometry", objects: {}, linkedAttributeColors: {}, pointMetadata: {} } },
+          { content: {
+            type: "Geometry",
+            objects: {},
+            linkedAttributeColors: {},
+            pointMetadata: {},
+            isNavigatorVisible: true,
+            navigatorPosition: "bottom",
+            zoom: 1,
+            offsetX: 0,
+            offsetY: 0
+        } },
           { content: { type: "Text", format: "html", text: ["<p>More text</p>"] } },
           // explicit row height exported since it differs from drawing tool default
           { content: { type: "Drawing", objects: [] }, layout: { height: 320 } }
@@ -133,7 +143,17 @@ describe("DocumentContentModel -- move/copy tiles --", () => {
           { content: { type: "Image", url: "image/url" } }
         ],
         [
-          { content: { type: "Geometry", objects: {}, linkedAttributeColors: {}, pointMetadata: {} } },
+          { content: {
+            type: "Geometry",
+            objects: {},
+            linkedAttributeColors: {},
+            pointMetadata: {},
+            isNavigatorVisible: true,
+            navigatorPosition: "bottom",
+            zoom: 1,
+            offsetX: 0,
+            offsetY: 0
+        } },
           { content: { type: "Text", format: "html", text: ["<p>More text</p>"] } },
           // explicit row height exported since it differs from drawing tool default
           { content: { type: "Drawing", objects: [] }, layout: { height: 320 } }

--- a/src/models/tiles/geometry/geometry-content.test.ts
+++ b/src/models/tiles/geometry/geometry-content.test.ts
@@ -189,7 +189,18 @@ describe("GeometryContent", () => {
   it("can create with default properties", () => {
     const content = GeometryContentModel.create();
     expect(getSnapshot(content)).toEqual(
-      { type: kGeometryTileType, board: defaultBoard(), objects: {}, linkedAttributeColors: {}, pointMetadata: {} });
+      {
+        type: kGeometryTileType,
+        board: defaultBoard(),
+        objects: {},
+        linkedAttributeColors: {},
+        pointMetadata: {},
+        isNavigatorVisible: true,
+        navigatorPosition: "bottom",
+        zoom: 1,
+        offsetX: 0,
+        offsetY: 0
+    });
 
     destroy(content);
   });
@@ -213,7 +224,12 @@ describe("GeometryContent", () => {
       },
       objects: {},
       linkedAttributeColors: {},
-      pointMetadata: {}
+      pointMetadata: {},
+      isNavigatorVisible: true,
+      navigatorPosition: "bottom",
+      zoom: 1,
+      offsetX: 0,
+      offsetY: 0
     });
 
     destroy(content);
@@ -1237,6 +1253,11 @@ describe("GeometryContent", () => {
     expect(exportAndSimplifyIds(content)).toMatchInlineSnapshot(`
 "{
   \\"type\\": \\"Geometry\\",
+  \\"isNavigatorVisible\\": true,
+  \\"navigatorPosition\\": \\"bottom\\",
+  \\"offsetX\\": 0,
+  \\"offsetY\\": 0,
+  \\"zoom\\": 1,
   \\"board\\": {\\"xAxis\\": {\\"name\\": \\"x\\", \\"label\\": \\"x\\", \\"min\\": -2, \\"unit\\": 18.3, \\"range\\": 26.229508196721312}, \\"yAxis\\": {\\"name\\": \\"y\\", \\"label\\": \\"y\\", \\"min\\": -1, \\"unit\\": 18.3, \\"range\\": 17.486338797814206}},
   \\"objects\\": {
     \\"p1\\": {\\"type\\": \\"point\\", \\"id\\": \\"p1\\", \\"x\\": 1, \\"y\\": 1, \\"colorScheme\\": 0, \\"labelOption\\": \\"none\\"},
@@ -1257,6 +1278,11 @@ describe("GeometryContent", () => {
 toMatchInlineSnapshot(`
 "{
   \\"type\\": \\"Geometry\\",
+  \\"isNavigatorVisible\\": true,
+  \\"navigatorPosition\\": \\"bottom\\",
+  \\"offsetX\\": 0,
+  \\"offsetY\\": 0,
+  \\"zoom\\": 1,
   \\"board\\": {\\"xAxis\\": {\\"name\\": \\"x\\", \\"label\\": \\"x\\", \\"min\\": -2, \\"unit\\": 18.3, \\"range\\": 26.229508196721312}, \\"yAxis\\": {\\"name\\": \\"y\\", \\"label\\": \\"y\\", \\"min\\": -1, \\"unit\\": 18.3, \\"range\\": 17.486338797814206}},
   \\"objects\\": {
     \\"testid\\": {\\"type\\": \\"point\\", \\"id\\": \\"testid\\", \\"x\\": 0, \\"y\\": 0, \\"snapToGrid\\": true, \\"colorScheme\\": 0, \\"labelOption\\": \\"none\\"},
@@ -1288,6 +1314,11 @@ toMatchInlineSnapshot(`
 toMatchInlineSnapshot(`
 "{
   \\"type\\": \\"Geometry\\",
+  \\"isNavigatorVisible\\": true,
+  \\"navigatorPosition\\": \\"bottom\\",
+  \\"offsetX\\": 0,
+  \\"offsetY\\": 0,
+  \\"zoom\\": 1,
   \\"board\\": {\\"xAxis\\": {\\"name\\": \\"x\\", \\"label\\": \\"x\\", \\"min\\": -2, \\"unit\\": 18.3, \\"range\\": 26.229508196721312}, \\"yAxis\\": {\\"name\\": \\"y\\", \\"label\\": \\"y\\", \\"min\\": -1, \\"unit\\": 18.3, \\"range\\": 17.486338797814206}},
   \\"objects\\": {
     \\"ml\\": {
@@ -1314,6 +1345,11 @@ toMatchInlineSnapshot(`
     expect(exportAndSimplifyIds(content)).toMatchInlineSnapshot(`
 "{
   \\"type\\": \\"Geometry\\",
+  \\"isNavigatorVisible\\": true,
+  \\"navigatorPosition\\": \\"bottom\\",
+  \\"offsetX\\": 0,
+  \\"offsetY\\": 0,
+  \\"zoom\\": 1,
   \\"board\\": {\\"xAxis\\": {\\"name\\": \\"x\\", \\"label\\": \\"x\\", \\"min\\": -2, \\"unit\\": 18.3, \\"range\\": 26.229508196721312}, \\"yAxis\\": {\\"name\\": \\"y\\", \\"label\\": \\"y\\", \\"min\\": -1, \\"unit\\": 18.3, \\"range\\": 17.486338797814206}},
   \\"bgImage\\": {\\"type\\": \\"image\\", \\"id\\": \\"img\\", \\"x\\": 0, \\"y\\": 0, \\"url\\": \\"test-file-stub\\", \\"width\\": 5, \\"height\\": 5},
   \\"objects\\": {},

--- a/src/models/tiles/geometry/geometry-content.test.ts
+++ b/src/models/tiles/geometry/geometry-content.test.ts
@@ -135,7 +135,7 @@ describe("GeometryContent", () => {
     function onCreate(elt: JXG.GeometryElement) {
       // handle a point
     }
-    const board = content.initializeBoard(divId, onCreate, (b) => {}) as JXG.Board;
+    const board = content.initializeBoard(divId, false, onCreate, (b) => {}) as JXG.Board;
     content.resizeBoard(board, 200, 200);
     content.updateScale(board, 0.5);
     return board;
@@ -269,7 +269,7 @@ describe("GeometryContent", () => {
       yMax: 3
     };
 
-    content.rescaleBoard(board, params);
+    content.rescaleBoard(board, params, true);
     expect(content.board?.xAxis.name).toBe("xName");
     expect(content.board?.xAxis.label).toBe("xAnnotation");
     expect(content.board?.xAxis.min).toBe(-1);

--- a/src/models/tiles/geometry/geometry-content.ts
+++ b/src/models/tiles/geometry/geometry-content.ts
@@ -532,7 +532,6 @@ export const GeometryContentModel = GeometryBaseContentModel
         const initialBB: BoundingBox = initialProperties.boundingBox;
         const [xMin, yMax, xMax, yMin] = initialBB;
 
-        console.log("Resize to show all content", extents, initialBB);
         const params: IAxesParams = {
           xMin: Math.min(xMin, extents.xMin),
           xMax: Math.max(xMax, extents.xMax),
@@ -567,7 +566,6 @@ export const GeometryContentModel = GeometryBaseContentModel
         xMax * widthMultiplier + xMaxBufferRange,
         yMin * heightMultiplier - yBufferRange
       ];
-      console.log("Resizing board", scaledWidth, scaledHeight, newBoundingBox);
       board.resizeContainer(scaledWidth, scaledHeight, false, true);
       board.setBoundingBox(newBoundingBox, false);
       board.update();
@@ -628,7 +626,6 @@ export const GeometryContentModel = GeometryBaseContentModel
           && curY.unit === yAxisProperties.unit && curY.range === yAxisProperties.range) {
         return undefined;
       }
-      console.log("Rescaling board", xAxisProperties, yAxisProperties);
       if (self.board && writeToModel) {
         self.zoom = calcUnit/kGeometryDefaultPixelsPerUnit;
         applySnapshot(self.board.xAxis, xAxisProperties);

--- a/src/models/tiles/geometry/geometry-content.ts
+++ b/src/models/tiles/geometry/geometry-content.ts
@@ -556,6 +556,7 @@ export const GeometryContentModel = GeometryBaseContentModel
       const oldUnit = (xAxis.unit + yAxis.unit) / 2;
       const newUnit = oldUnit * factor;
       xAxis.unit = yAxis.unit = newUnit;
+      self.zoom = newUnit/kGeometryDefaultPixelsPerUnit;
     }
 
     function rescaleBoard(board: JXG.Board, params: IAxesParams) {
@@ -601,6 +602,7 @@ export const GeometryContentModel = GeometryBaseContentModel
           && curY.unit === yAxisProperties.unit && curY.range === yAxisProperties.range) {
         return undefined;
       }
+      self.zoom = calcUnit/kGeometryDefaultPixelsPerUnit;
       if (self.board) {
         applySnapshot(self.board.xAxis, xAxisProperties);
         applySnapshot(self.board.yAxis, yAxisProperties);

--- a/src/models/tiles/geometry/geometry-import.ts
+++ b/src/models/tiles/geometry/geometry-import.ts
@@ -181,11 +181,12 @@ function getBoardBounds(axisMin?: JXGCoordPair, protoRange?: JXGCoordPair) {
 export interface IGeometryBoardChangeOptions {
   addBuffers?: boolean;
   includeUnits?: boolean;
+  showAllContent?: boolean;
 }
 export function defaultGeometryBoardChange(
   xAxis: AxisModelType, yAxis: AxisModelType, overrides?: JXGProperties, options?: IGeometryBoardChangeOptions
 ) {
-  const { addBuffers, includeUnits } = options ?? {};
+  const { addBuffers, includeUnits, showAllContent } = options ?? {};
   const axisMin: JXGCoordPair = [xAxis.min, yAxis.min];
   const axisRange: JXGCoordPair = [xAxis.range ?? kGeometryDefaultWidth / xAxis.unit,
                                    yAxis.range ?? kGeometryDefaultHeight / yAxis.unit];
@@ -202,6 +203,7 @@ export function defaultGeometryBoardChange(
     target: "board",
     properties: {
       boundingBox,
+      showAllContent,
       ...units,
       ...overrides
     }

--- a/src/models/tiles/geometry/geometry-migrate.ts
+++ b/src/models/tiles/geometry/geometry-migrate.ts
@@ -38,8 +38,9 @@ export const getGeometryBoardChange = (
   const { xAxis, yAxis } = model.board || BoardModel.create(kDefaultBoardModelOutputProps);
   const { name: xName, label: xAnnotation } = xAxis;
   const { name: yName, label: yAnnotation } = yAxis;
+  const overrides = { xName, yName, xAnnotation, yAnnotation };
   return (
-    defaultGeometryBoardChange(xAxis, yAxis, { xName, yName, xAnnotation, yAnnotation }, boardOptions )
+    defaultGeometryBoardChange(xAxis, yAxis, overrides, boardOptions )
   );
 };
 

--- a/src/models/tiles/geometry/geometry-model.ts
+++ b/src/models/tiles/geometry/geometry-model.ts
@@ -7,7 +7,7 @@ import { ELabelOption, JXGPositionProperty } from "./jxg-changes";
 import { kGeometryDefaultPixelsPerUnit } from "./jxg-types";
 import { findLeastUsedNumber } from "../../../utilities/math-utils";
 import { clueDataColorInfo } from "../../../utilities/color-utils";
-import { BoundingBox, NavigatableTileModel } from "../navigatable-tile-model";
+import { NavigatableTileModel } from "../navigatable-tile-model";
 
 export interface IDependsUponResult {
   depends: boolean;
@@ -455,17 +455,6 @@ export const GeometryBaseContentModel = NavigatableTileModel
     return { ...rest };
   })
   .views(self => ({
-    get objectsBoundingBox(): BoundingBox | undefined {
-      // TODO implement this to return the bounding box of all objects
-      // Compare to `getBoardObjectsExtents` in geometry-content.tsx which does the same thing
-      // but it uses the JXG board to get the bounding box of each object - which is not so obvious for circles
-      // Maybe the tile navigator could be changed to make this call to the component rather than to the model?
-      return undefined;
-    },
-    contentFitsViewport(tileWidth: number, tileHeight: number, unavailableSpace=0) {
-      // TODO implement this to check if the content fits the viewport
-      return false;
-    },
     getColorSchemeForAttributeId(id: string) {
       return self.linkedAttributeColors.get(id);
     },

--- a/src/models/tiles/geometry/geometry-model.ts
+++ b/src/models/tiles/geometry/geometry-model.ts
@@ -3,11 +3,11 @@ import { applySnapshot, getSnapshot, Instance, SnapshotIn, types } from "mobx-st
 import { kDefaultBoardModelInputProps, kGeometryTileType } from "./geometry-types";
 import { uniqueId } from "../../../utilities/js-utils";
 import { typeField } from "../../../utilities/mst-utils";
-import { TileContentModel } from "../tile-content";
 import { ELabelOption, JXGPositionProperty } from "./jxg-changes";
 import { kGeometryDefaultPixelsPerUnit } from "./jxg-types";
 import { findLeastUsedNumber } from "../../../utilities/math-utils";
 import { clueDataColorInfo } from "../../../utilities/color-utils";
+import { NavigatableTileModel } from "../navigatable-tile-model";
 
 export interface IDependsUponResult {
   depends: boolean;
@@ -414,7 +414,7 @@ export type GeometryObjectModelUnion = CircleModelType | CommentModelType | Imag
                                        PointModelType | PolygonModelType | VertexAngleModelType;
 
 // Define the shape of the geometry content without the views/actions, etc. to avoid circular references
-export const GeometryBaseContentModel = TileContentModel
+export const GeometryBaseContentModel = NavigatableTileModel
   .named("GeometryBaseContent")
   .props({
     type: types.optional(types.literal(kGeometryTileType), kGeometryTileType),

--- a/src/models/tiles/geometry/geometry-model.ts
+++ b/src/models/tiles/geometry/geometry-model.ts
@@ -7,7 +7,7 @@ import { ELabelOption, JXGPositionProperty } from "./jxg-changes";
 import { kGeometryDefaultPixelsPerUnit } from "./jxg-types";
 import { findLeastUsedNumber } from "../../../utilities/math-utils";
 import { clueDataColorInfo } from "../../../utilities/color-utils";
-import { NavigatableTileModel } from "../navigatable-tile-model";
+import { BoundingBox, NavigatableTileModel } from "../navigatable-tile-model";
 
 export interface IDependsUponResult {
   depends: boolean;
@@ -45,6 +45,9 @@ export const AxisModel = types.model("AxisModel", {
   },
   setRange(range: number) {
     self.range = range;
+  },
+  panByPixels(pixels: number) {
+    self.min += pixels / self.unit;
   }
 }));
 export interface AxisModelType extends Instance<typeof AxisModel> {}
@@ -452,6 +455,17 @@ export const GeometryBaseContentModel = NavigatableTileModel
     return { ...rest };
   })
   .views(self => ({
+    get objectsBoundingBox(): BoundingBox | undefined {
+      // TODO implement this to return the bounding box of all objects
+      // Compare to `getBoardObjectsExtents` in geometry-content.tsx which does the same thing
+      // but it uses the JXG board to get the bounding box of each object - which is not so obvious for circles
+      // Maybe the tile navigator could be changed to make this call to the component rather than to the model?
+      return undefined;
+    },
+    contentFitsViewport(tileWidth: number, tileHeight: number, unavailableSpace=0) {
+      // TODO implement this to check if the content fits the viewport
+      return false;
+    },
     getColorSchemeForAttributeId(id: string) {
       return self.linkedAttributeColors.get(id);
     },

--- a/src/models/tiles/geometry/geometry-utils.ts
+++ b/src/models/tiles/geometry/geometry-utils.ts
@@ -1,5 +1,6 @@
 import { values } from "lodash";
 import { Instance, SnapshotOut } from "mobx-state-tree";
+import { GeometryElement } from "jsxgraph";
 import { getAssociatedPolygon } from "./jxg-polygon";
 import { isCircle, isGeometryElement, isPoint, isPolygon } from "./jxg-types";
 import { JXGObjectType } from "./jxg-changes";
@@ -14,7 +15,6 @@ import { SharedModelEntrySnapshotType } from "../../document/shared-model-entry"
 import { replaceJsonStringsWithUpdatedIds, UpdatedSharedDataSetIds } from "../../shared/shared-data-set";
 import { IClueObjectSnapshot } from "../../annotations/clue-object";
 import { linkedPointId, splitLinkedPointId } from "../table-link-types";
-import { GeometryElement } from "jsxgraph";
 
 export function copyCoords(coords: JXG.Coords) {
   const usrCoords = coords.usrCoords;

--- a/src/models/tiles/geometry/geometry-utils.ts
+++ b/src/models/tiles/geometry/geometry-utils.ts
@@ -15,6 +15,7 @@ import { SharedModelEntrySnapshotType } from "../../document/shared-model-entry"
 import { replaceJsonStringsWithUpdatedIds, UpdatedSharedDataSetIds } from "../../shared/shared-data-set";
 import { IClueObjectSnapshot } from "../../annotations/clue-object";
 import { linkedPointId, splitLinkedPointId } from "../table-link-types";
+import { BoundingBox } from "../navigatable-tile-model";
 
 export function copyCoords(coords: JXG.Coords) {
   const usrCoords = coords.usrCoords;
@@ -87,6 +88,24 @@ export function getBoardObjectsExtents(board: JXG.Board) {
     }
   });
   return { xMax, yMax, xMin, yMin };
+}
+
+/**
+ * Convert a JSXGraph-style BoundingBox to a CLUE-style BoundingBox.
+ */
+export function formatAsBoundingBox(coordinates: [number, number, number, number]): BoundingBox {
+  const [x1, y1, x2, y2] = coordinates;
+  return { nw: { x: x1, y: y1 }, se: { x: x2, y: y2 } };
+}
+
+/**
+ * Return a bounding box that includes the areas of both input bounding boxes.
+ */
+export function combineBoundingBoxes(b1: BoundingBox, b2: BoundingBox|undefined): BoundingBox {
+  return {
+    nw: { x: Math.min(b1.nw.x, b2?.nw.x ?? b1.nw.x), y: Math.min(b1.nw.y, b2?.nw.y ?? b1.nw.y) },
+    se: { x: Math.max(b1.se.x, b2?.se.x ?? b1.se.x), y: Math.max(b1.se.y, b2?.se.y ?? b1.se.y) }
+  };
 }
 
 /**

--- a/src/models/tiles/geometry/geometry-utils.ts
+++ b/src/models/tiles/geometry/geometry-utils.ts
@@ -14,6 +14,7 @@ import { SharedModelEntrySnapshotType } from "../../document/shared-model-entry"
 import { replaceJsonStringsWithUpdatedIds, UpdatedSharedDataSetIds } from "../../shared/shared-data-set";
 import { IClueObjectSnapshot } from "../../annotations/clue-object";
 import { linkedPointId, splitLinkedPointId } from "../table-link-types";
+import { GeometryElement } from "jsxgraph";
 
 export function copyCoords(coords: JXG.Coords) {
   const usrCoords = coords.usrCoords;
@@ -67,6 +68,25 @@ export function getPolygon(board: JXG.Board, id: string): JXG.Polygon|undefined 
 export function getCircle(board: JXG.Board, id: string): JXG.Circle|undefined {
   const obj = board.objects[id];
   return isCircle(obj) ? obj : undefined;
+}
+
+export function getBoardObjectsExtents(board: JXG.Board) {
+  let xMax = 1;
+  let yMax = 1;
+  let xMin = -1;
+  let yMin = -1;
+
+  forEachBoardObject(board, (obj: GeometryElement) => {
+    // Don't need to consider polygons since the extent of their points will be enough.
+    if (isPoint(obj) || isCircle(obj)) {
+      const [left, top, right, bottom] = obj.bounds();
+      if (left < xMin) xMin = left - 1;
+      if (right > xMax) xMax = right + 1;
+      if (top > yMax) yMax = top + 1;
+      if (bottom < yMin) yMin = bottom - 1;
+    }
+  });
+  return { xMax, yMax, xMin, yMin };
 }
 
 /**

--- a/src/models/tiles/geometry/jxg-board.ts
+++ b/src/models/tiles/geometry/jxg-board.ts
@@ -287,12 +287,16 @@ function addAxes(board: JXG.Board, params: IAddAxesParams) {
 export const boardChangeAgent: JXGChangeAgent = {
   create: (boardOrDomId: JXG.Board|string, change: JXGChange) => {
     const props = change.properties as JXGProperties;
+    console.log("create board with props", props);
     const board = isBoard(boardOrDomId)
                     ? boardOrDomId
                     : createBoard(boardOrDomId, props);
     // If we created the board from a DOM element ID, then we need to add the axes.
     // If we are undoing an action, then the board already exists but its axes have
     // been removed, so we have to add the axes in that case as well.
+    if (props.showAllContent) {
+      props.boundingBox = [0, 100, 100, 0]; // xMin, yMax, xMax, yMin
+    }
     const boundingBox = scaleBoundingBoxToElement(board.containerObj.id, props);
     const scale = getCanvasScale(board ? board.container : boardOrDomId as string);
     const [xName, yName] = getAxisLabelsFromProps(props);

--- a/src/models/tiles/geometry/jxg-board.ts
+++ b/src/models/tiles/geometry/jxg-board.ts
@@ -196,6 +196,10 @@ function getAxisUnitsFromProps(props?: JXGProperties, scale = 1) {
 }
 
 function createBoard(domElementId: string, properties?: JXGProperties) {
+  if (document.getElementById(domElementId) == null) {
+    console.log("Cannot create board; element not found:", domElementId);
+    return;
+  }
   // cf. https://www.intmath.com/cg3/jsxgraph-axes-ticks-grids.php
   const defaults: Partial<BoardAttributes> = {
     axis: false,
@@ -287,16 +291,13 @@ function addAxes(board: JXG.Board, params: IAddAxesParams) {
 export const boardChangeAgent: JXGChangeAgent = {
   create: (boardOrDomId: JXG.Board|string, change: JXGChange) => {
     const props = change.properties as JXGProperties;
-    console.log("create board with props", props);
     const board = isBoard(boardOrDomId)
                     ? boardOrDomId
                     : createBoard(boardOrDomId, props);
+    if (!board) return;
     // If we created the board from a DOM element ID, then we need to add the axes.
     // If we are undoing an action, then the board already exists but its axes have
     // been removed, so we have to add the axes in that case as well.
-    if (props.showAllContent) {
-      props.boundingBox = [0, 100, 100, 0]; // xMin, yMax, xMax, yMin
-    }
     const boundingBox = scaleBoundingBoxToElement(board.containerObj.id, props);
     const scale = getCanvasScale(board ? board.container : boardOrDomId as string);
     const [xName, yName] = getAxisLabelsFromProps(props);

--- a/src/models/tiles/geometry/jxg-board.ts
+++ b/src/models/tiles/geometry/jxg-board.ts
@@ -8,7 +8,8 @@ import {
 import { goodTickValue } from "../../../utilities/graph-utils";
 import { filterBoardObjects, findBoardObject, forEachBoardObject, getBoardObject } from "./geometry-utils";
 
-const kScalerClasses = ["canvas-scaler", "scaled-list-item"];
+// Only elements with one of these classes will be checked for CSS scaling transforms
+const kScalerClasses = ["canvas-scaler", "scaled-list-item", "tile-navigator-tile-content"];
 
 export function suspendBoardUpdates(board: JXG.Board) {
   if (board.suspendCount) {

--- a/src/models/tiles/geometry/jxg-board.ts
+++ b/src/models/tiles/geometry/jxg-board.ts
@@ -197,7 +197,6 @@ function getAxisUnitsFromProps(props?: JXGProperties, scale = 1) {
 
 function createBoard(domElementId: string, properties?: JXGProperties) {
   if (document.getElementById(domElementId) == null) {
-    console.log("Cannot create board; element not found:", domElementId);
     return;
   }
   // cf. https://www.intmath.com/cg3/jsxgraph-axes-ticks-grids.php

--- a/src/models/tiles/navigatable-tile-model.ts
+++ b/src/models/tiles/navigatable-tile-model.ts
@@ -23,25 +23,6 @@ export const NavigatableTileModel = TileContentModel
     offsetY: types.optional(types.number, 0),
     zoom: types.optional(types.number, 1)
   })
-  .views(() => ({
-    get objectsBoundingBox(): BoundingBox | undefined {
-      // derived models should override
-      console.warn("Derived models should override objectsBoundingBox.");
-      return undefined;
-    }
-  }))
-  .views(self => ({
-    contentSize(): { width: number, height: number } {
-      // derived models should override
-      console.warn("Derived models should override contentSize.");
-      return { width: 0, height: 0 };
-    },
-    contentFitsViewport(tileWidth: number, tileHeight: number, unavailableSpace=0): boolean {
-      // derived models should override
-      console.warn("Derived models should override contentFitsViewport.");
-      return false;
-    }
-  }))
   .views(self => ({
     calculateOffset(canvasSize: {x: number, y: number}, targetZoom: number): Point {
       // Calculate offset required to keep the content centered in the viewport.

--- a/src/models/tiles/navigatable-tile-model.ts
+++ b/src/models/tiles/navigatable-tile-model.ts
@@ -11,8 +11,6 @@ export interface Point { x: number; y: number; }
 export interface BoundingBox {
   nw: Point;
   se: Point;
-  start?: Point;
-  end?: Point;
 }
 
 export const NavigatableTileModel = TileContentModel

--- a/src/plugins/drawing/components/__snapshots__/drawing-layer-legacy.test.tsx.snap
+++ b/src/plugins/drawing/components/__snapshots__/drawing-layer-legacy.test.tsx.snap
@@ -2,8 +2,6 @@
 
 exports[`Drawing Layer Components Ellipse adds a ellipse 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g
@@ -28,8 +26,6 @@ exports[`Drawing Layer Components Ellipse adds a ellipse 1`] = `
 
 exports[`Drawing Layer Components Ellipse deletes a ellipse 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g
@@ -42,8 +38,6 @@ exports[`Drawing Layer Components Ellipse deletes a ellipse 1`] = `
 
 exports[`Drawing Layer Components Ellipse moves a ellipse 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g
@@ -68,8 +62,6 @@ exports[`Drawing Layer Components Ellipse moves a ellipse 1`] = `
 
 exports[`Drawing Layer Components Freehand Line adds a freehand line 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g
@@ -91,8 +83,6 @@ exports[`Drawing Layer Components Freehand Line adds a freehand line 1`] = `
 
 exports[`Drawing Layer Components Freehand Line deletes a freehand line 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g
@@ -105,8 +95,6 @@ exports[`Drawing Layer Components Freehand Line deletes a freehand line 1`] = `
 
 exports[`Drawing Layer Components Freehand Line moves a freehand line 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g
@@ -128,8 +116,6 @@ exports[`Drawing Layer Components Freehand Line moves a freehand line 1`] = `
 
 exports[`Drawing Layer Components Image adds an image 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g
@@ -152,8 +138,6 @@ exports[`Drawing Layer Components Image adds an image 1`] = `
 
 exports[`Drawing Layer Components Image deletes a image 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g
@@ -166,8 +150,6 @@ exports[`Drawing Layer Components Image deletes a image 1`] = `
 
 exports[`Drawing Layer Components Image moves a image 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g
@@ -190,8 +172,6 @@ exports[`Drawing Layer Components Image moves a image 1`] = `
 
 exports[`Drawing Layer Components Rectangle adds a Rectangle 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g
@@ -217,8 +197,6 @@ exports[`Drawing Layer Components Rectangle adds a Rectangle 1`] = `
 
 exports[`Drawing Layer Components Rectangle deletes a rectangle 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g
@@ -231,8 +209,6 @@ exports[`Drawing Layer Components Rectangle deletes a rectangle 1`] = `
 
 exports[`Drawing Layer Components Rectangle moves a rectangle 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g
@@ -258,8 +234,6 @@ exports[`Drawing Layer Components Rectangle moves a rectangle 1`] = `
 
 exports[`Drawing Layer Components Vector line adds a Vector line 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g
@@ -288,8 +262,6 @@ exports[`Drawing Layer Components Vector line adds a Vector line 1`] = `
 
 exports[`Drawing Layer Components Vector line deletes a vector line 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g
@@ -302,8 +274,6 @@ exports[`Drawing Layer Components Vector line deletes a vector line 1`] = `
 
 exports[`Drawing Layer Components Vector line moves a vector line 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g

--- a/src/plugins/drawing/components/__snapshots__/drawing-layer.test.tsx.snap
+++ b/src/plugins/drawing/components/__snapshots__/drawing-layer.test.tsx.snap
@@ -2,8 +2,6 @@
 
 exports[`Drawing Layer Components Ellipse adds a ellipse 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g
@@ -28,8 +26,6 @@ exports[`Drawing Layer Components Ellipse adds a ellipse 1`] = `
 
 exports[`Drawing Layer Components Ellipse deletes a ellipse 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g
@@ -42,8 +38,6 @@ exports[`Drawing Layer Components Ellipse deletes a ellipse 1`] = `
 
 exports[`Drawing Layer Components Ellipse moves a ellipse 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g
@@ -68,8 +62,6 @@ exports[`Drawing Layer Components Ellipse moves a ellipse 1`] = `
 
 exports[`Drawing Layer Components Freehand Line adds a freehand line 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g
@@ -91,8 +83,6 @@ exports[`Drawing Layer Components Freehand Line adds a freehand line 1`] = `
 
 exports[`Drawing Layer Components Freehand Line deletes a freehand line 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g
@@ -105,8 +95,6 @@ exports[`Drawing Layer Components Freehand Line deletes a freehand line 1`] = `
 
 exports[`Drawing Layer Components Freehand Line moves a freehand line 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g
@@ -128,8 +116,6 @@ exports[`Drawing Layer Components Freehand Line moves a freehand line 1`] = `
 
 exports[`Drawing Layer Components Group creates a group 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g
@@ -241,8 +227,6 @@ exports[`Drawing Layer Components Group creates a group 1`] = `
 
 exports[`Drawing Layer Components Group deletes a group 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g
@@ -255,8 +239,6 @@ exports[`Drawing Layer Components Group deletes a group 1`] = `
 
 exports[`Drawing Layer Components Group moves a group 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g
@@ -368,8 +350,6 @@ exports[`Drawing Layer Components Group moves a group 1`] = `
 
 exports[`Drawing Layer Components Image adds an image 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g
@@ -392,8 +372,6 @@ exports[`Drawing Layer Components Image adds an image 1`] = `
 
 exports[`Drawing Layer Components Image deletes a image 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g
@@ -406,8 +384,6 @@ exports[`Drawing Layer Components Image deletes a image 1`] = `
 
 exports[`Drawing Layer Components Image moves a image 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g
@@ -430,8 +406,6 @@ exports[`Drawing Layer Components Image moves a image 1`] = `
 
 exports[`Drawing Layer Components Rectangle adds a Rectangle 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g
@@ -457,8 +431,6 @@ exports[`Drawing Layer Components Rectangle adds a Rectangle 1`] = `
 
 exports[`Drawing Layer Components Rectangle deletes a rectangle 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g
@@ -471,8 +443,6 @@ exports[`Drawing Layer Components Rectangle deletes a rectangle 1`] = `
 
 exports[`Drawing Layer Components Rectangle moves a rectangle 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g
@@ -498,8 +468,6 @@ exports[`Drawing Layer Components Rectangle moves a rectangle 1`] = `
 
 exports[`Drawing Layer Components Vector arrow adds a Vector arrow 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g
@@ -542,8 +510,6 @@ exports[`Drawing Layer Components Vector arrow adds a Vector arrow 1`] = `
 
 exports[`Drawing Layer Components Vector arrow changes vector to double arrow 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g
@@ -586,8 +552,6 @@ exports[`Drawing Layer Components Vector arrow changes vector to double arrow 1`
 
 exports[`Drawing Layer Components Vector arrow changes vector to single arrow 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g
@@ -623,8 +587,6 @@ exports[`Drawing Layer Components Vector arrow changes vector to single arrow 1`
 
 exports[`Drawing Layer Components Vector arrow deletes a vector arrow 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g
@@ -637,8 +599,6 @@ exports[`Drawing Layer Components Vector arrow deletes a vector arrow 1`] = `
 
 exports[`Drawing Layer Components Vector arrow moves a vector arrow 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g
@@ -681,8 +641,6 @@ exports[`Drawing Layer Components Vector arrow moves a vector arrow 1`] = `
 
 exports[`Drawing Layer Components Vector line adds a Vector line 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g
@@ -711,8 +669,6 @@ exports[`Drawing Layer Components Vector line adds a Vector line 1`] = `
 
 exports[`Drawing Layer Components Vector line deletes a vector line 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g
@@ -725,8 +681,6 @@ exports[`Drawing Layer Components Vector line deletes a vector line 1`] = `
 
 exports[`Drawing Layer Components Vector line moves a vector line 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g
@@ -755,8 +709,6 @@ exports[`Drawing Layer Components Vector line moves a vector line 1`] = `
 
 exports[`Drawing Layer Zoom zooms in 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g
@@ -782,8 +734,6 @@ exports[`Drawing Layer Zoom zooms in 1`] = `
 
 exports[`Drawing Layer Zoom zooms out 1`] = `
 <svg
-  height="1500"
-  width="1500"
   xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <g

--- a/src/plugins/drawing/components/drawing-layer-legacy.test.tsx
+++ b/src/plugins/drawing/components/drawing-layer-legacy.test.tsx
@@ -11,6 +11,7 @@ import { EllipseObjectSnapshot } from "../objects/ellipse";
 import { ImageObjectSnapshot } from "../objects/image";
 import { DrawingMigrator } from "../model/drawing-migrator";
 import { EntryStatus, gImageMap, ImageMapEntry } from "../../../models/image-map";
+import { TileNavigatorContext } from "../../../components/tiles/hooks/use-tile-navigator-context";
 
 // The drawing tile needs to be registered so the TileModel.create
 // knows it is a supported tile type
@@ -25,7 +26,11 @@ const getDrawingObject = (objectContent: DrawingContentModelType) => {
       throw new Error("Function not implemented.");
     }
   };
-  render(<DrawingLayerView {...drawingLayerProps} />);
+  render(
+    <TileNavigatorContext.Provider value={{ reportVisibleBoundingBox: () => {}}}>
+      <DrawingLayerView {...drawingLayerProps} />
+    </TileNavigatorContext.Provider>
+);
   drawingLayer = screen.getByTestId("drawing-layer");
   return drawingLayer.firstChild;
 };

--- a/src/plugins/drawing/components/drawing-layer.test.tsx
+++ b/src/plugins/drawing/components/drawing-layer.test.tsx
@@ -9,6 +9,7 @@ import { VectorEndShape, VectorType, endShapesForVectorType } from "../model/dra
 import { RectangleObject, RectangleObjectSnapshotForAdd, RectangleObjectType } from "../objects/rectangle";
 import { EllipseObject, EllipseObjectType } from "../objects/ellipse";
 import { ImageObject, ImageObjectType } from "../objects/image";
+import { TileNavigatorContext } from "../../../components/tiles/hooks/use-tile-navigator-context";
 
 // The drawing tile needs to be registered so the TileModel.create
 // knows it is a supported tile type
@@ -25,7 +26,11 @@ const getDrawingObject = (objectContent: DrawingContentModelType) => {
       throw new Error("Function not implemented.");
     }
   };
-  render(<DrawingLayerView {...drawingLayerProps} />);
+  render(
+    <TileNavigatorContext.Provider value={{ reportVisibleBoundingBox: () => {}}}>
+      <DrawingLayerView {...drawingLayerProps} />
+    </TileNavigatorContext.Provider>
+  );
   drawingLayer = screen.getByTestId("drawing-layer");
   return drawingLayer.firstChild;
 };

--- a/src/plugins/drawing/components/drawing-tile.scss
+++ b/src/plugins/drawing/components/drawing-tile.scss
@@ -9,7 +9,9 @@
   }
 
   .drawing-container {
+    width: 100%;
     display: flex;
+    justify-content: flex-start;
 
     .object-list {
       border: solid 1.5px $charcoal-light-1;
@@ -152,7 +154,11 @@
     }
 
     .drawing-layer {
+      flex-grow: 1;
+
       svg {
+        width: 100%;
+        height: 100%;
         overflow: visible;
 
         .ghost {

--- a/src/plugins/drawing/components/drawing-tile.tsx
+++ b/src/plugins/drawing/components/drawing-tile.tsx
@@ -215,7 +215,7 @@ const DrawingToolComponent: React.FC<IDrawingTileProps> = observer(function Draw
       </div>
       {!readOnly && showNavigator &&
         <TileNavigator
-          objectListPanelWidth={getObjectListPanelWidth()}
+          unavailableWidth={getObjectListPanelWidth()}
           onNavigatorPan={handleNavigatorPan}
           tileProps={props}
           renderTile={(tileProps) => <DrawingToolComponent {...tileProps} />}

--- a/src/plugins/drawing/model/drawing-content.ts
+++ b/src/plugins/drawing/model/drawing-content.ts
@@ -141,26 +141,6 @@ export const DrawingContentModel = NavigatableTileModel
   .views(self => ({
     getSelectedObjects():DrawingObjectType[] {
       return self.selection.map((id) => self.objectMap[id]).filter((x)=>!!x) as DrawingObjectType[];
-    },
-    get contentSize(): { contentWidth: number, contentHeight: number } {
-      const contentBoundingBox = self.objectsBoundingBox;
-      const leftExtent = (contentBoundingBox.nw.x * self.zoom);
-      const rightExtent = (contentBoundingBox.se.x * self.zoom);
-      const topExtent = (contentBoundingBox.nw.y * self.zoom);
-      const bottomExtent = (contentBoundingBox.se.y * self.zoom);
-      const contentWidth = rightExtent - leftExtent;
-      const contentHeight = bottomExtent - topExtent;
-
-      return { contentWidth, contentHeight };
-    },
-    contentFitsViewport(tileWidth: number, tileHeight: number, unavailableSpace=0): boolean {
-      const bb = self.objectsBoundingBox;
-      const heightContained = bb.se.y * self.zoom + self.offsetY <= tileHeight &&
-                              bb.nw.y * self.zoom + self.offsetY >= 0;
-      const widthContained = bb.se.x * self.zoom + self.offsetX <= tileWidth + unavailableSpace &&
-                             bb.nw.x * self.zoom + self.offsetX >= 0;
-
-      return heightContained && widthContained;
     }
   }))
   .views(self => tileContentAPIViews({


### PR DESCRIPTION
Adds navigator panel to the coordinate grid (PT-188291407) including the panning controls (PT-188157831).

Per discussion in https://www.pivotaltracker.com/story/show/188291407, allows panning always, rather than only when content exceeds the visible area of the tile. This change is also made in the drawing tile.

This PR includes some significant refactoring of the Tile Navigator and its implementation within the Drawing tile as well as application to the Geometry tile. Previously the drawing tile navigator always followed the aspect ratio of the tile itself. Now it will use all of the area availabe in the (squarish) navigator panel. Within this area, content is shown as large as possible while keeping both the full content and the full extent of the main tile visible.  Restrictions on how far you can pan have been removed. This should lead to more predictable behavior and fixes some of the edge cases noted previously.

The overlay clip-path is now calculated by getting, and comparing the bounding boxes of what content is shown in the main tile, and in the navigator.  The rendered component has to report the bounding box it is displaying by calling a method displayed by `TileNavigatorContext`.  For the main tile bounding box, the value is then passed in to the navigator component, so that the navigator has access to both and can draw the appropriate clip-path.  It also uses this information to make sure that area is fully displayed inside the navigator (even if there are no objects in that region).
