### PR TITLE
fix: tiles don't retain their vertical size (PT-188449969)

### DIFF
--- a/src/components/document/tile-row.tsx
+++ b/src/components/document/tile-row.tsx
@@ -216,7 +216,6 @@ export class TileRowComponent extends BaseComponent<IProps, IState> {
     const { model, docId } = this.props;
     const { id } = model;
     e.dataTransfer.setDragImage(this.transparentPixel, 0, 0);
-    e.dataTransfer.effectAllowed = "none";
     e.dataTransfer.setData(dragTileSrcDocId(docId), docId);
     e.dataTransfer.setData(kDragResizeRowId, id);
     e.dataTransfer.setData(dragResizeRowId(id), id);


### PR DESCRIPTION
[#188449969](https://www.pivotaltracker.com/story/show/188449969)

Removes `e.dataTransfer.effectAllowed = "none"` from `handleStartResizeRow` which was preventing `handleDrop` from being called. Setting `effectAllowed` means the [item may not be dropped](https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/effectAllowed#none). Removing the line results in a tile resize being maintained when a document is reloaded, and doesn't appear to break anything.