### PR TITLE
Fix bug in copying multi-dataset Coordinate Grid tiles.

### DIFF
--- a/src/components/tiles/geometry/geometry-content.tsx
+++ b/src/components/tiles/geometry/geometry-content.tsx
@@ -842,7 +842,7 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
       const content = this.getContent();
       const data = content.getLinkedPointsData();
       const remainingIds = getAllLinkedPoints(board);
-      for (const [link, points] of data.entries()) {
+      for (const points of data.values()) {
         // Loop through points, adding new ones and updating any that need to be moved.
         for (let i=0; i<points.coords.length; i++) {
           const id = points.properties[i].id;
@@ -855,7 +855,8 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
               name: labelProperties.name,
               clientLabelOption: labelProperties.labelOption
             };
-            const pt = createLinkedPoint(board, points.coords[i], allProps, { tileIds: [link] });
+            const tileIds = allProps.linkedTableId ? { tileIds: [allProps.linkedTableId] } : undefined;
+            const pt = createLinkedPoint(board, points.coords[i], allProps, tileIds);
             this.handleCreatePoint(pt);
             pointsChanged = true;
           } else {

--- a/src/models/tiles/geometry/geometry-content.ts
+++ b/src/models/tiles/geometry/geometry-content.ts
@@ -210,21 +210,22 @@ export const GeometryContentModel = GeometryBaseContentModel
     },
     /**
      * Compile a map of data for all points that are part of linked datasets.
-     * The returned Map has the providing tile's ID as the key, and an object
+     * The returned Map has the sharedDataSet's ID as the key, and an object
      * containing two parallel lists as its value:
      *
      * - coords: list of coordinate pairs
-     * - properties: list of point property objects (id and color)
+     * - properties: list of point property objects (id, color, linkedTableId)
      *
      * TODO: should we also look at the selections in the DataSet
      *
      * @returns the Map
      */
     getLinkedPointsData() {
-      const data: Map<string,{coords:JXGCoordPair[],properties:{id:string, colorScheme:number}[]}> = new Map();
+      const data: Map<string,
+        { coords:JXGCoordPair[], properties: { id:string, colorScheme:number, linkedTableId?:string }[] }> = new Map();
       self.linkedDataSets.forEach(link => {
         const coords: JXGCoordPair[] = [];
-        const properties: Array<{ id: string, colorScheme: number }> = [];
+        const properties: Array<{ id: string, colorScheme: number, linkedTableId?: string }> = [];
         for (let ci = 0; ci < link.dataSet.cases.length; ++ci) {
           const x = link.dataSet.attributes[0]?.numValue(ci);
           for (let ai = 1; ai < link.dataSet.attributes.length; ++ai) {
@@ -234,11 +235,15 @@ export const GeometryContentModel = GeometryBaseContentModel
             const y = attr.numValue(ci);
             if (isFinite(x) && isFinite(y)) {
               coords.push([x, y]);
-              properties.push({ id, colorScheme });
+              if (link.providerId) {
+                properties.push({ id, colorScheme, linkedTableId: link.providerId });
+              } else {
+                properties.push({ id, colorScheme });
+              }
             }
           }
         }
-        data.set(link.providerId, { coords, properties });
+        data.set(link.id, { coords, properties });
       });
       return data;
     }


### PR DESCRIPTION
Fixes bug where after copying a Geometry tile, not all linked datasets were being displayed.

Changes the return value of getLinkedPointsData, which was previously a hash indexed by the `providerId` of each linked SharedDataSet.  After a tile copy operation, the newly-created SharedDataSet copies have no providerId any more, so this was being indexed by `undefined`.

Change this to using the SharedDataSet id as the hash key, and include the providerId in each point's properties.
