### PR TITLE
chore: remove existing tag-handling code (PT-188476611)

### DIFF
--- a/cypress/e2e/functional/teacher_tests/teacher_sort_work_view_spec.js
+++ b/cypress/e2e/functional/teacher_tests/teacher_sort_work_view_spec.js
@@ -340,11 +340,7 @@ describe('SortWorkView Tests', () => {
     cy.get('.section-header-arrow').click({multiple: true}); // Open the sections
     sortWork.checkDocumentInGroup("Unit Rate", exemplarDocs[0]);
 
-    // FIXME: We haven't implemented support for deleting comments
-    // what should be true:
-    // sortWork.checkGroupIsEmpty("Diverging Designs");
-    // what currently happens
-    sortWork.checkDocumentInGroup("Diverging Designs", exemplarDocs[0]);
+    sortWork.checkGroupIsEmpty("Diverging Designs");
 
     cy.log("run CLUE as a student:1 and join group 6");
     visitQaSubtabsUnit({student: 1, group: 6});

--- a/src/hooks/document-comment-hooks.ts
+++ b/src/hooks/document-comment-hooks.ts
@@ -109,7 +109,6 @@ type PostDocumentCommentUseMutationOptions =
 
 export const usePostDocumentComment = (options?: PostDocumentCommentUseMutationOptions) => {
   const queryClient = useQueryClient();
-  const [firestore] = useFirestore();
   const postDocumentComment = useFirebaseFunction<IPostDocumentCommentParams>("postDocumentComment_v1");
   const context = useUserContext();
   const postComment = useCallback((clientParams: IPostDocumentCommentClientParams) => {
@@ -121,39 +120,6 @@ export const usePostDocumentComment = (options?: PostDocumentCommentUseMutationO
     onMutate: async newCommentParams => {
       const { document, comment } = newCommentParams;
       const queryKey = getCommentsQueryKeyFromMetadata(document);
-
-      // update metadata document with the new tags
-      const tags = comment.tags || [];
-      const documentKey = isDocumentMetadata(document) ? document.key : undefined;
-      if (documentKey && tags.length > 0) {
-        // Just the document key is not enough for Firestore to know that we have permission
-        // to access the document. Providing a context_id gives the rules enough info to make
-        // sure we have access to the returned docs. The `context.classHash` used here is
-        // the current class that CLUE has been run in. However, a teacher might be commenting
-        // on a document from a different class. In that case the code below will not find
-        // the documents that need to have their strategies updated.
-        // Instead we should be using the context_id of the document that we are commenting on.
-        // CLUE tries to track the context_id when it loads a remote document. That
-        // information should be stored in the DocumentModel#remoteContext field. We don't
-        // have access to the DocumentModel here though, just document.metadata.
-        // FIXME: provide access to remoteContext here so we can update strategies on remote
-        // documents. Alternatively move this into a firebase function instead of doing this
-        // in the client.
-        // FIXME: in the case of exemplar documents, the metadata document won't exist
-        // until this mutation happens. That probably means metadataQuery.get() below
-        // will run before the document has been created so it will return an empty array of
-        // docs. This is another reason the firebase function approach to keep the strategies
-        // updated is a better way to go
-        const metadataQuery = firestore.collection("documents")
-          .where("key", "==", documentKey)
-          .where("context_id", "==", context.classHash);
-        metadataQuery.get().then(querySnapshot => {
-          querySnapshot.docs.forEach(doc => {
-            const docRef = doc.ref;
-            docRef.update({ strategies: firebase.firestore.FieldValue.arrayUnion(...tags) });
-          });
-        });
-      }
 
       // snapshot the current state of the comments in case we need to roll back on error
       const rollbackComments = queryKey && queryClient.getQueryData<CommentWithId[]>(queryKey);


### PR DESCRIPTION
[#188476611](https://www.pivotaltracker.com/story/show/188476611)

The functionality provided by the removed code is now handled by a [new Cloud Function](https://github.com/concord-consortium/collaborative-learning/pull/2433). Also included is a small modification to the teacher sort work view tests in light of deleted comments now being supported.