### PR TITLE
Logging additions to enable linking to historical documents

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -160,6 +160,7 @@ export const authenticate = async (
   const unitCode = urlParams.unit || "";
   // when launched as a report, the params will not contain the problemOrdinal
   const problemOrdinal = urlParams.problem || appConfig.defaultProblemOrdinal;
+  const offeringId = urlParams.resourceLinkId || undefined;
 
   let {fakeClass, fakeUser} = urlParams;
   // handle preview launch from portal
@@ -223,7 +224,7 @@ export const authenticate = async (
   const { classHash } = classInfo;
   const uidAsString = `${portalJWT.uid}`;
   const firebaseJWTPromise = getFirebaseJWTWithBearerToken(basePortalUrl, "Bearer", bearerToken, classHash);
-  const portalOfferingsPromise = getPortalOfferings(user_type, uid, domain, rawPortalJWT);
+  const portalOfferingsPromise = getPortalOfferings(user_type, uid, domain, rawPortalJWT, offeringId);
   const problemIdPromise = getProblemIdForAuthenticatedUser(rawPortalJWT, curriculumConfig, urlParams);
 
   const [firebaseJWTResult, portalOfferingsResult, problemIdResult] =

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -26,6 +26,8 @@ export interface LogMessage {
   session: string;
   username: string;
 
+  parameters: any;
+
   // the rest of the properties are packaged into `extras` by the log-ingester
   role: string;
   classHash: string;
@@ -43,7 +45,7 @@ export interface LogMessage {
   tzOffset: string;
   method: string;
   disconnects?: string;
-  parameters: any;
+  offeringId: string;
 }
 
 // List of log messages that were generated before a Logger is initialized;
@@ -144,7 +146,9 @@ export class Logger {
       persistentUI: { activeNavTab, navTabContentShown, problemWorkspace, teacherPanelKey },
       user: { activityUrl, classHash, id, isStudent, isTeacher, portal, type, currentGroupId,
               loggingRemoteEndpoint, firebaseDisconnects, loggingDisconnects, networkStatusAlerts
-    }} = this.stores;
+      },
+      portal: { offeringId },
+  } = this.stores;
     // only log disconnect counts if there have been any disconnections
     const totalDisconnects = firebaseDisconnects + loggingDisconnects + networkStatusAlerts;
     const disconnects = totalDisconnects
@@ -154,6 +158,7 @@ export class Logger {
     const logMessage: LogMessage = {
       application: appName,
       activity: activityUrl,
+      offeringId,
       username: `${id}@${portal}`,
       role: type || "unknown",
       classHash,

--- a/src/lib/portal-api.test.ts
+++ b/src/lib/portal-api.test.ts
@@ -16,13 +16,16 @@ describe("Portal Offerings", () => {
       .get(/\/api\/v1\/offerings\/\?user_id=22/)
       .reply(200, TeacherOfferings);
     nock(/superfake/)
+      .get(/\/api\/v1\/offerings\/1190/)
+      .reply(200, TeacherOfferings[0]);
+    nock(/superfake/)
       .get(/\/api\/v1\/classes\/mine/)
       .reply(200, TeacherMineClasses);
   });
 
   afterEach(() => nock.cleanAll());
 
-  describe("getPortalOfferings", () => {
+  describe("getPortalOfferings for teacher", () => {
     let fetchedOfferings: IPortalOffering[];
 
     beforeEach(async () => {
@@ -35,6 +38,20 @@ describe("Portal Offerings", () => {
 
     it("offerings should have class hashes", () => {
       expect(fetchedOfferings.every(o => o.clazz_hash));
+    });
+  });
+
+  describe("getPortalOfferings for learner or other", () => {
+    it("should return a single offering for learner", async () => {
+      const offerings = await getPortalOfferings("learner", userID, domain, fakeJWT, "1190");
+      expect(offerings.length).toEqual(1);
+      expect(offerings[0].id).toEqual(1190);
+      expect(offerings[0].activity_url).toEqual("https://collaborative-learning.concord.org/branch/master/?unit=sas&problem=1.2");
+    });
+
+
+    it("should not return anything for researcher", async () => {
+      expect(await getPortalOfferings("researcher", userID, domain, fakeJWT)).toEqual([]);
     });
   });
 

--- a/src/lib/portal-api.ts
+++ b/src/lib/portal-api.ts
@@ -30,10 +30,9 @@ export const getPortalOfferings = (
   userType: string,
   userId: number,
   domain: string,
-  rawPortalJWT: any) => {
-
+  rawPortalJWT: any,
+  offeringId?: string) => {
   return new Promise<IPortalOffering[]> ((resolve, reject) => {
-    // TODO: For now isolate this to the teachers view
     if (userType === "teacher") {
       superagent
       .get(`${domain}api/v1/offerings/?user_id=${userId}`)
@@ -79,6 +78,19 @@ export const getPortalOfferings = (
             // class hashes are already present so no further work required
             resolve(clueOfferings);
           }
+        }
+      });
+    }
+    else if (userType === "learner" && offeringId) {
+      // For learner, just look up the single current offering
+      superagent
+      .get(`${domain}api/v1/offerings/${offeringId}`)
+      .set("Authorization", `Bearer/JWT ${rawPortalJWT}`)
+      .end((err, res) => {
+        if (err) {
+          reject(getErrorMessage(err, res));
+        } else {
+          resolve([res.body]);
         }
       });
     }

--- a/src/models/document/log-document-event.ts
+++ b/src/models/document/log-document-event.ts
@@ -1,6 +1,7 @@
 import { IDocumentMetadata } from "../../../shared/shared";
 import { Logger } from "../../lib/logger";
 import { LogEventMethod, LogEventName } from "../../lib/logger-types";
+import { TreeManagerType } from "../history/tree-manager";
 import { IDocumentMetadataModel } from "../stores/sorted-documents";
 import { UserModelType } from "../stores/user";
 import { DocumentModelType } from "./document";
@@ -23,7 +24,7 @@ interface IContext extends Record<string, any> {
   user: UserModelType;
 }
 
-function processDocumentEventParams(params: IDocumentLogEvent, { user }: IContext) {
+function processDocumentEventParams(params: IDocumentLogEvent, { user, portal }: IContext) {
   const { document, ...others } = params;
   const isRemote = "isRemote" in document ? document.isRemote : undefined;
   const remoteContext = "remoteContext" in document ? document.remoteContext : undefined;
@@ -32,6 +33,18 @@ function processDocumentEventParams(params: IDocumentLogEvent, { user }: IContex
                                : {};
   const documentVisibility = "visibility" in document ? document.visibility : undefined;
   const documentChanges = "changeCount" in document ? document.changeCount : undefined;
+
+  // Log the ID of the last history entry for the document.
+  // Note that depending whether the call to write a log event is made
+  // before or after the actual change to the document, this may be the history
+  // entry that was current before the change, or the one that was created by the change.
+  // For the first change in a new document, it may be undefined.
+  const documentHistory = "treeManagerAPI" in document
+    ? (document.treeManagerAPI as TreeManagerType)?.document.history
+    : undefined;
+  const documentHistoryId = documentHistory && documentHistory.length > 0
+    ? documentHistory[documentHistory.length - 1].id
+    : undefined;
 
   const teacherNetworkInfo: ITeacherNetworkInfo | undefined = isRemote
       ? { networkClassHash: remoteContext,
@@ -46,6 +59,7 @@ function processDocumentEventParams(params: IDocumentLogEvent, { user }: IContex
     documentProperties,
     documentVisibility,
     documentChanges,
+    documentHistoryId,
     ...others,
     ...teacherNetworkInfo
   };

--- a/src/models/tiles/geometry/geometry-utils.ts
+++ b/src/models/tiles/geometry/geometry-utils.ts
@@ -169,10 +169,15 @@ function isPreferredClickableObject(current: JXG.GeometryElement | undefined, pr
   return (isFiniteNumber(proposed.visProp.layer) && proposed.visProp.layer >= current.visProp.layer);
 }
 
-// Note: Our layering logic is different from JSXGraph's. When clicks occur on overlapping objects,
-// we may select one object, but JSXGraph may drag another. For now this is preferable to adopting
-// the JSXGraph layering model in which all points are above all segments which are above all
-// polygons. Fixing the drag behavior would require internal changes to JSXGraph.
+// TODO: this may no longer be necessary, since JSXGraph now supports customizing the layering of objects.
+// There is a global seting for what layers different types of objects go into, and also a "layer" property
+// on all geometry objects, and JSXGraph's click and drag handlers should respect these.
+//
+// Here is the original comment for this function, which I believe is outdated as of 2024:
+//   Note: Our layering logic is different from JSXGraph's. When clicks occur on overlapping objects,
+//   we may select one object, but JSXGraph may drag another. For now this is preferable to adopting
+//   the JSXGraph layering model in which all points are above all segments which are above all
+//   polygons. Fixing the drag behavior would require internal changes to JSXGraph.
 export function getClickableObjectUnderMouse(board: JXG.Board, evt: any, draggable: boolean, scale?: number):
     JXG.GeometryElement|undefined {
   const coords = getEventCoords(board, evt, scale);


### PR DESCRIPTION
This adds three elements to the information that is logged with events.
- A new `documentHistoryId` entry is added inside the `parameters` of document-related events. 
- When launched from the portal, the `offeringId` is included with _all_ events. It should get added to `extras` by the log ingester.
- When launched from the portal, the `activity` URL should now be included for students; it was already being sent for teachers. This is one of the top-level elements in the log schema.

I included one TODO comment that is unrealated to this change, but was in my local copy & I didn't want it to get lost. 