### PR TITLE
feat: Add requests for researcher portal and Firebase JWTs [PT-188754102]

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ There are a number of URL parameters that can aid in testing:
 |`firestore`     |`emulator\|<URL>`        |Target emulator for firestore database calls.|
 |`functions`     |`emulator\|<URL>`        |Target emulator-hosted firebase functions.|
 |`noPersistentUI`|none                     |Do not initialize persistent ui store.|
+|`researcher`    |`true`                   |When set to true the user authenticates as a researcher|
 
 The `unit` parameter can be in 3 forms:
 - a valid URL starting with `https:` or `http:` will be treated as an absolute URL.

--- a/docs/unit-configuration.md
+++ b/docs/unit-configuration.md
@@ -64,7 +64,7 @@ These properties are configurable at the application (built into the code) or th
   // disables publishing documents of particular types or with particular properties
   disablePublish: Array<SnapshotIn<typeof DocumentSpecModel>> | boolean;
   // enable/disable showing the history-scrubbing controls for users in different roles
-  enableHistoryRoles: Array<"student" | "teacher">;
+  enableHistoryRoles: Array<"student" | "teacher" | "researcher">;
   // configures naming of copied documents
   copyPreferOriginTitle: boolean;
   // enable/disable dragging of tiles

--- a/shared/shared.ts
+++ b/shared/shared.ts
@@ -80,7 +80,7 @@ export interface IUserContext {
   demoName?: string;
   portal?: string;
   uid?: string;                 // user id of caller; validated for authenticated users when provided
-  type?: "student" | "teacher"; // user's role
+  type?: "student" | "teacher" | "researcher"; // user's role
   name?: string;
   network?: string;             // current network for teachers
   classHash: string;

--- a/src/clue/components/clue-app-header.tsx
+++ b/src/clue/components/clue-app-header.tsx
@@ -171,7 +171,7 @@ export const ClueAppHeaderComponent: React.FC<IProps> = observer(function ClueAp
     );
   };
 
-  if (user.isTeacher && appConfig.showClassSwitcher) {
+  if ((user.isTeacher || user.isResearcher) && appConfig.showClassSwitcher) {
     return renderTeacherHeader();
   }
 

--- a/src/clue/components/clue-app-header.tsx
+++ b/src/clue/components/clue-app-header.tsx
@@ -136,7 +136,7 @@ export const ClueAppHeaderComponent: React.FC<IProps> = observer(function ClueAp
       });
   };
 
-  const renderTeacherHeader = () => {
+  const renderNonStudentHeader = ({showProblemMenu}: {showProblemMenu: boolean}) => {
     return (
       <div className="app-header">
         <div className="left">
@@ -148,10 +148,14 @@ export const ClueAppHeaderComponent: React.FC<IProps> = observer(function ClueAp
               {investigation.title}
             </div>
           </div>
-          <div className="separator"/>
-          <div className="problem-dropdown" data-test="user-class">
-            <ProblemMenuContainer />
-          </div>
+          {showProblemMenu &&
+          <>
+            <div className="separator"/>
+            <div className="problem-dropdown" data-test="user-class">
+              <ProblemMenuContainer />
+            </div>
+          </>
+          }
         </div>
         <div className="middle">
           {renderPanelButtons()}
@@ -171,8 +175,12 @@ export const ClueAppHeaderComponent: React.FC<IProps> = observer(function ClueAp
     );
   };
 
-  if ((user.isTeacher || user.isResearcher) && appConfig.showClassSwitcher) {
-    return renderTeacherHeader();
+  if (user.isResearcher) {
+    return renderNonStudentHeader({showProblemMenu: false});
+  }
+
+  if (user.isTeacher && appConfig.showClassSwitcher) {
+    return renderNonStudentHeader({showProblemMenu: true});
   }
 
   return (

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -8,7 +8,7 @@ import { authenticate,
         getFirebaseJWTParams,
         generateDevAuthentication,
         createFakeOfferingIdFromProblem} from "./auth";
-import { IPortalClassInfo, IPortalClassUser, PortalStudentJWT, PortalTeacherJWT } from "./portal-types";
+import { IPortalClassInfo, IPortalClassUser, PortalResearcherJWT, PortalStudentJWT, PortalTeacherJWT } from "./portal-types";
 import nock from "nock";
 import { NUM_FAKE_STUDENTS, NUM_FAKE_TEACHERS } from "../components/demo/demo-creator";
 import { specAppConfig } from "../models/stores/spec-app-config";
@@ -23,6 +23,9 @@ const RAW_STUDENT_FIREBASE_JWT = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJhbGciO
 
 const RAW_TEACHER_PORTAL_JWT = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhbGciOiJIUzI1NiIsImlhdCI6MTUzODA1NTY2OSwiZXhwIjoxNTM4MDU5MjY5LCJ1aWQiOjIxNywiZG9tYWluIjoiaHR0cHM6Ly9sZWFybi5zdGFnaW5nLmNvbmNvcmQub3JnLyIsInVzZXJfdHlwZSI6InRlYWNoZXIiLCJ1c2VyX2lkIjoiaHR0cHM6Ly9sZWFybi5zdGFnaW5nLmNvbmNvcmQub3JnL3VzZXJzLzIxNyIsInRlYWNoZXJfaWQiOjg4fQ.lwFtD-UUXQOcOono0Q9fjBQFbOdP14rhZbJw9PN51vk";
 const RAW_TEACHER_FIREBASE_JWT = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJhbGciOiJSUzI1NiIsImlzcyI6ImZpcmViYXNlLWFkbWluc2RrLWF4a2JsQGNvbGxhYm9yYXRpdmUtbGVhcm5pbmctZWMyMTUuaWFtLmdzZXJ2aWNlYWNjb3VudC5jb20iLCJzdWIiOiJmaXJlYmFzZS1hZG1pbnNkay1heGtibEBjb2xsYWJvcmF0aXZlLWxlYXJuaW5nLWVjMjE1LmlhbS5nc2VydmljZWFjY291bnQuY29tIiwiYXVkIjoiaHR0cHM6Ly9pZGVudGl0eXRvb2xraXQuZ29vZ2xlYXBpcy5jb20vZ29vZ2xlLmlkZW50aXR5LmlkZW50aXR5dG9vbGtpdC52MS5JZGVudGl0eVRvb2xraXQiLCJpYXQiOjE1MzgwNTU2NzAsImV4cCI6MTUzODA1OTI3MCwidWlkIjoiMzU4MTYwYzk3M2Y0MmE0MzYxZjA5YzdlMjA2YjVmNGQiLCJkb21haW4iOiJodHRwczovL2xlYXJuLnN0YWdpbmcuY29uY29yZC5vcmcvIiwiZG9tYWluX3VpZCI6MjE3LCJjbGFpbXMiOnsidXNlcl90eXBlIjoidGVhY2hlciIsInVzZXJfaWQiOiJodHRwczovL2xlYXJuLnN0YWdpbmcuY29uY29yZC5vcmcvdXNlcnMvMjE3IiwiY2xhc3NfaGFzaCI6bnVsbH19.XQ_-MmbZUegnod789tKZgWt4r3QpecEoSASb572jDfQGEKupiWGcXn2MGeESuRsOFwD3eWbiQoC6B7F8cy6h0EiaXhIVFR_xrviqoXgayQsDQalrCVGjllLGak4vY7p-ZnLvSie6F9-KubPIfsF_0NdRSDTFOHbN3LGhpxGUYxc4GKandDgGTJwy5rgXLebU7ezzKyzE2YAYEGuVPge5Yf9PgXI__OsbiUD4tOK2dxSTytcL30maeYQ4x0CBWY96w8oOlusOHIsf96OkqKe272SXz2BgkhF6e1IHby_CIhl51FFxAqKr6P1sPlt8WnVpK7qwTDY8VSNCYNxNQMiaXw";
+
+const RAW_RESEARCHER_PORTAL_JWT = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhbGciOiJIUzI1NiIsImlhdCI6MTczNjM1MzA4MSwiZXhwIjoxNzM2MzU2NjgxLCJ1aWQiOjEsImRvbWFpbiI6Imh0dHBzOi8vbGVhcm4uc3RhZ2luZy5jb25jb3JkLm9yZy8iLCJ1c2VyX3R5cGUiOiJyZXNlYXJjaGVyIiwidXNlcl9pZCI6Imh0dHBzOi8vbGVhcm4uc3RhZ2luZy5jb25jb3JkLm9yZy91c2Vycy8xIiwiZmlyc3RfbmFtZSI6IlRlc3QiLCJsYXN0X25hbWUiOiJSZXNlYXJjaGVyIiwiYWRtaW4iOjEsInByb2plY3RfYWRtaW5zIjpbXX0.3fjKGohZ5RQPCHppLUuOwD_OGfDfrn0L1J3nBNOfV7I";
+const RAW_RESEARCHER_FIREBASE_JWT = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJhbGciOiJSUzI1NiIsImlzcyI6InJlcG9ydC1zZXJ2aWNlLWRldkBhcHBzcG90LmdzZXJ2aWNlYWNjb3VudC5jb20iLCJzdWIiOiJyZXBvcnQtc2VydmljZS1kZXZAYXBwc3BvdC5nc2VydmljZWFjY291bnQuY29tIiwiYXVkIjoiaHR0cHM6Ly9pZGVudGl0eXRvb2xraXQuZ29vZ2xlYXBpcy5jb20vZ29vZ2xlLmlkZW50aXR5LmlkZW50aXR5dG9vbGtpdC52MS5JZGVudGl0eVRvb2xraXQiLCJpYXQiOjE3MzYzNDcxODgsImV4cCI6MTczNjM1MDc4OCwidWlkIjoiNmM4NzgxYzU3YzZjM2RmNDQ2M2M0ZjQyNzQ2YWVmZjEiLCJjbGFpbXMiOnsicGxhdGZvcm1faWQiOiJodHRwczovLy0zMDAwLnByZXZpZXcuYXBwLmdpdGh1Yi5kZXYiLCJwbGF0Zm9ybV91c2VyX2lkIjo3LCJ1c2VyX2lkIjoiaHR0cHM6Ly8tMzAwMC5wcmV2aWV3LmFwcC5naXRodWIuZGV2L3VzZXJzLzciLCJ1c2VyX3R5cGUiOiJyZXNlYXJjaGVyIiwiY2xhc3NfaGFzaCI6ImE4OGQxMzZjODFmOWNmNTE1YWM0OWFhMzMwZDdlMDM1ZGNhNzQ0YzllNTliNjY2NSJ9fQ.HPlRnaWECdgXEIoafk71p6WYSux91_11kmg-nEBH2XA625jNrgUOxRoEKsZOwI0Mq1yhz2Sti297fHILzJAregt-1U_ZBTuhgqEZ04Xyp-jB3uPKiKtd5_59bLrunczyAke3ywXUaswIKgVYJl_D5L0WeySfz8g7y1SE1q3QIEw24RDlnLHRdJjjdLgBjBawupfy4m4uVzK1hHSAyZYpqjOH5rvq7t5odILNzv_9rBL9NP5qU5Be0vqVIKx8DryyMFYu-hroT0CKXOCW3ns4xuspTvWHmBe-p7-Jdr7MIyDU77tN7WOvjJhHj_5UvbCVPLU-3EIZ0nitkH2CnTAjSw";
 /* eslint-enable max-len */
 
 const STUDENT_PORTAL_JWT: PortalStudentJWT = {
@@ -49,11 +52,26 @@ const TEACHER_PORTAL_JWT: PortalTeacherJWT = {
   teacher_id: 88,
 };
 
+const RESEARCHER_PORTAL_JWT: PortalResearcherJWT = {
+  alg: "HS256",
+  iat: 1538055669,
+  exp: 1538059269,
+  uid: 1,
+  domain: "https://learn.staging.concord.org/",
+  user_type: "researcher",
+  user_id: "https://learn.staging.concord.org/users/1",
+  first_name: "Test",
+  last_name: "Researcher"
+};
+
 const GOOD_STUDENT_TOKEN = "goodStudentToken";
 const BAD_STUDENT_TOKEN = "badStudentToken";
 
 const GOOD_TEACHER_TOKEN = "goodTeacherToken";
 const BAD_TEACHER_TOKEN = "badTeacherToken";
+
+const GOOD_RESEARCHER_TOKEN = "goodReacherToken";
+const BAD_RESEARCHER_TOKEN = "badTeacherToken";
 
 const CLASS_HASH = "testHash";
 
@@ -90,6 +108,13 @@ const RAW_CORRECT_TEACHER: IPortalClassUser = {
   user_id: TEACHER_PORTAL_JWT.uid,
   first_name: "GoodFirst",
   last_name: "GoodLast",
+};
+
+const RAW_CORRECT_RESEARCHER: IPortalClassUser = {
+  id: RESEARCHER_PORTAL_JWT.user_id,
+  user_id: RESEARCHER_PORTAL_JWT.uid,
+  first_name: "Test",
+  last_name: "Researcher",
 };
 
 const RAW_CLASS_INFO: IPortalClassInfo = {
@@ -626,6 +651,152 @@ describe("teacher authentication", () => {
     .reply(400);
 
     urlParams.token = BAD_TEACHER_TOKEN;
+    authenticate("authed", appConfig, curriculumConfig, portal, urlParams)
+      .then(() => {
+        done.fail();
+      })
+      .catch(() => done());
+  });
+
+  it("fails with no token", (done) => {
+    urlParams.token = undefined;
+    authenticate("authed", appConfig, curriculumConfig, portal, urlParams)
+      .then(() => {
+        done.fail();
+      })
+      .catch(() => done());
+  });
+
+  it("fails with a bad report type", (done) => {
+    urlParams.reportType = "unknown";
+    authenticate("authed", appConfig, curriculumConfig, portal, urlParams)
+      .then(() => {
+        done.fail();
+      })
+      .catch(() => done());
+  });
+
+  it("fails with no class", (done) => {
+    urlParams.class = undefined;
+    authenticate("authed", appConfig, curriculumConfig, portal, urlParams)
+      .then(() => {
+        done.fail();
+      })
+      .catch(() => done());
+  });
+
+  it("fails with no offering", (done) => {
+    urlParams.offering = undefined;
+    authenticate("authed", appConfig, curriculumConfig, portal, urlParams)
+      .then(() => {
+        done.fail();
+      })
+      .catch(() => done());
+  });
+});
+
+describe("researcher authentication", () => {
+  let urlParams: QueryParams = {
+    token: GOOD_RESEARCHER_TOKEN,
+    reportType: "offering",
+    class: CLASS_INFO_URL,
+    offering: OFFERING_INFO_URL
+  };
+  const appConfig = specAppConfig();
+  const portal = new Portal(urlParams);
+
+  beforeEach(() => {
+    urlParams = {token: GOOD_RESEARCHER_TOKEN, reportType: "offering", class: CLASS_INFO_URL, offering: OFFERING_INFO_URL};
+
+    nock(BASE_PORTAL_HOST, {
+      reqheaders: {
+        Authorization: `Bearer/JWT ${RAW_RESEARCHER_PORTAL_JWT}`
+      }
+    })
+    .get(CLASS_INFO_PATH)
+    .reply(200, RAW_CLASS_INFO);
+
+    nock(BASE_PORTAL_HOST, {
+      reqheaders: {
+        Authorization: `Bearer/JWT ${RAW_RESEARCHER_PORTAL_JWT}`
+      }
+    })
+    .get(OFFERING_INFO_PATH)
+    .reply(200, PARTIAL_RAW_OFFERING_INFO);
+
+    nock("https://learn.staging.concord.org/")
+    .get(/\/offerings\/\?user_id=.*/)
+    .reply(200, []);
+
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  it("works in authed mode", (done) => {
+    nock(BASE_PORTAL_HOST, {
+      reqheaders: {
+        Authorization: `Bearer ${GOOD_RESEARCHER_TOKEN}`
+      }
+    })
+    .get(PORTAL_JWT_PATH)
+    .reply(200, {
+      token: RAW_RESEARCHER_PORTAL_JWT,
+    });
+
+    nock(BASE_PORTAL_HOST, {
+      reqheaders: {
+        Authorization: `Bearer ${GOOD_RESEARCHER_TOKEN}`
+      }
+    })
+    .get(FIREBASE_JWT_PATH + getFirebaseJWTParams(CLASS_HASH))
+    .reply(200, {
+      token: RAW_RESEARCHER_FIREBASE_JWT,
+    });
+
+    nock(BASE_PORTAL_HOST, {
+      reqheaders: {
+        Authorization: `Bearer ${GOOD_RESEARCHER_TOKEN}`
+      }
+    })
+    .get(CLASSES_MINE_PATH)
+    .reply(200, {classes: []});
+
+    authenticate("authed", appConfig, curriculumConfig, portal, urlParams).then(({authenticatedUser, problemId}) => {
+      expect(authenticatedUser.type).toEqual("researcher");
+      expect(authenticatedUser.id).toEqual(`${RESEARCHER_PORTAL_JWT.uid}`)
+      expect(authenticatedUser.portal).toEqual("learn.staging.concord.org")
+      expect(authenticatedUser.portalClassOfferings).toEqual([])
+      expect(authenticatedUser.firstName).toEqual(RAW_CORRECT_RESEARCHER.first_name)
+      expect(authenticatedUser.lastName).toEqual(RAW_CORRECT_RESEARCHER.last_name)
+      expect(authenticatedUser.fullName).toEqual(`${RAW_CORRECT_RESEARCHER.first_name} ${RAW_CORRECT_RESEARCHER.last_name}`)
+      expect(authenticatedUser.initials).toEqual("TR")
+
+      expect(problemId).toBe("3.2");
+      done();
+    })
+    .catch(done);
+  });
+
+  it("fails with a bad token", (done) => {
+    nock(BASE_PORTAL_HOST, {
+      reqheaders: {
+        Authorization: `Bearer ${BAD_RESEARCHER_TOKEN}`
+      }
+    })
+    .get(PORTAL_JWT_PATH)
+    .reply(400);
+
+    nock(BASE_PORTAL_HOST, {
+      reqheaders: {
+        Authorization: `Bearer ${BAD_RESEARCHER_TOKEN}`
+      }
+    })
+    .get(FIREBASE_JWT_PATH + getFirebaseJWTParams())
+    .reply(400);
+
+    urlParams.token = BAD_RESEARCHER_TOKEN;
     authenticate("authed", appConfig, curriculumConfig, portal, urlParams)
       .then(() => {
         done.fail();

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -8,7 +8,8 @@ import { authenticate,
         getFirebaseJWTParams,
         generateDevAuthentication,
         createFakeOfferingIdFromProblem} from "./auth";
-import { IPortalClassInfo, IPortalClassUser, PortalResearcherJWT, PortalStudentJWT, PortalTeacherJWT } from "./portal-types";
+import { IPortalClassInfo, IPortalClassUser, PortalResearcherJWT,
+         PortalStudentJWT, PortalTeacherJWT } from "./portal-types";
 import nock from "nock";
 import { NUM_FAKE_STUDENTS, NUM_FAKE_TEACHERS } from "../components/demo/demo-creator";
 import { specAppConfig } from "../models/stores/spec-app-config";
@@ -706,7 +707,8 @@ describe("researcher authentication", () => {
   const portal = new Portal(urlParams);
 
   beforeEach(() => {
-    urlParams = {token: GOOD_RESEARCHER_TOKEN, reportType: "offering", class: CLASS_INFO_URL, offering: OFFERING_INFO_URL};
+    urlParams = {token: GOOD_RESEARCHER_TOKEN, reportType: "offering",
+                 class: CLASS_INFO_URL, offering: OFFERING_INFO_URL};
 
     nock(BASE_PORTAL_HOST, {
       reqheaders: {
@@ -764,14 +766,15 @@ describe("researcher authentication", () => {
     .reply(200, {classes: []});
 
     authenticate("authed", appConfig, curriculumConfig, portal, urlParams).then(({authenticatedUser, problemId}) => {
+      const {first_name, last_name} = RAW_CORRECT_RESEARCHER;
       expect(authenticatedUser.type).toEqual("researcher");
-      expect(authenticatedUser.id).toEqual(`${RESEARCHER_PORTAL_JWT.uid}`)
-      expect(authenticatedUser.portal).toEqual("learn.staging.concord.org")
-      expect(authenticatedUser.portalClassOfferings).toEqual([])
-      expect(authenticatedUser.firstName).toEqual(RAW_CORRECT_RESEARCHER.first_name)
-      expect(authenticatedUser.lastName).toEqual(RAW_CORRECT_RESEARCHER.last_name)
-      expect(authenticatedUser.fullName).toEqual(`${RAW_CORRECT_RESEARCHER.first_name} ${RAW_CORRECT_RESEARCHER.last_name}`)
-      expect(authenticatedUser.initials).toEqual("TR")
+      expect(authenticatedUser.id).toEqual(`${RESEARCHER_PORTAL_JWT.uid}`);
+      expect(authenticatedUser.portal).toEqual("learn.staging.concord.org");
+      expect(authenticatedUser.portalClassOfferings).toEqual([]);
+      expect(authenticatedUser.firstName).toEqual(first_name);
+      expect(authenticatedUser.lastName).toEqual(last_name);
+      expect(authenticatedUser.fullName).toEqual(`${first_name} ${last_name}`);
+      expect(authenticatedUser.initials).toEqual("TR");
 
       expect(problemId).toBe("3.2");
       done();

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -237,6 +237,7 @@ export const authenticate = async (
   const [rawFirebaseJWT, firebaseJWT] = firebaseJWTResult;
   const { unitCode: newUnitCode, problemOrdinal: newProblemOrdinal } = problemIdResult;
 
+  let fullName: string;
   let authenticatedUser: StudentUser | TeacherUser | ResearcherUser | undefined = undefined;
   switch (user_type) {
     case "learner":
@@ -246,21 +247,19 @@ export const authenticate = async (
       authenticatedUser = classInfo.teachers.find(teacher => teacher.id === uidAsString);
       break;
     case "researcher":
-      const {first_name, last_name} = portalJWT;
-      const fullName = `${first_name} ${last_name}`
-      const researcherUser: ResearcherUser = {
+      fullName = `${portalJWT.first_name} ${portalJWT.last_name}`;
+      authenticatedUser = {
         type: "researcher",
         id: uidAsString,
         portal: portalHost,
-        firstName: first_name,
-        lastName: last_name,
+        firstName: portalJWT.first_name,
+        lastName: portalJWT.last_name,
         fullName,
         className: classInfo.name,
         initials: initials(fullName) as string,
         classHash: classInfo.classHash,
         offeringId: portalService.offeringId
       };
-      authenticatedUser = researcherUser;
       break;
     default:
       throw new Error(`Unsupported user type: ${user_type ?? "(unknown user type)"}`);

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,5 +1,6 @@
 import jwt_decode from "jwt-decode";
 import superagent from "superagent";
+import initials from "initials";
 import { AppMode } from "../models/stores/store-types";
 import { QueryParams, urlParams as pageUrlParams } from "../utilities/url-params";
 import { NUM_FAKE_STUDENTS, NUM_FAKE_TEACHERS } from "../components/demo/demo-creator";
@@ -14,7 +15,7 @@ import { LogEventName } from "../lib/logger-types";
 import { uniqueId } from "../utilities/js-utils";
 import { getUnitCodeFromUnitParam } from "../utilities/url-utils";
 import { ICurriculumConfig } from "../models/stores/curriculum-config";
-import { ClassInfo, Portal, StudentUser, TeacherUser } from "../models/stores/portal";
+import { ClassInfo, Portal, ResearcherUser, StudentUser, TeacherUser } from "../models/stores/portal";
 
 export const PORTAL_JWT_URL_SUFFIX = "api/v1/jwt/portal";
 export const FIREBASE_JWT_URL_SUFFIX = "api/v1/jwt/firebase";
@@ -54,8 +55,9 @@ export const DEV_CLASS_INFO: ClassInfo = {
   localTimestamp: Date.now()
 };
 
-export type AuthenticatedUser = StudentUser | TeacherUser;
+export type AuthenticatedUser = StudentUser | TeacherUser | ResearcherUser;
 export const isAuthenticatedTeacher = (u: AuthenticatedUser): u is TeacherUser => u.type === "teacher";
+export const isAuthenticatedResearcher = (u: AuthenticatedUser): u is ResearcherUser => u.type === "researcher";
 
 export interface AuthQueryParams {
   token?: string;
@@ -235,11 +237,37 @@ export const authenticate = async (
   const [rawFirebaseJWT, firebaseJWT] = firebaseJWTResult;
   const { unitCode: newUnitCode, problemOrdinal: newProblemOrdinal } = problemIdResult;
 
-  const authenticatedUser = user_type === "learner"
-                              ? classInfo.students.find(student => student.id === uidAsString)
-                              : classInfo.teachers.find(teacher => teacher.id === uidAsString);
+  let authenticatedUser: StudentUser | TeacherUser | ResearcherUser | undefined = undefined;
+  switch (user_type) {
+    case "learner":
+      authenticatedUser = classInfo.students.find(student => student.id === uidAsString);
+      break;
+    case "teacher":
+      authenticatedUser = classInfo.teachers.find(teacher => teacher.id === uidAsString);
+      break;
+    case "researcher":
+      const {first_name, last_name} = portalJWT;
+      const fullName = `${first_name} ${last_name}`
+      const researcherUser: ResearcherUser = {
+        type: "researcher",
+        id: uidAsString,
+        portal: portalHost,
+        firstName: first_name,
+        lastName: last_name,
+        fullName,
+        className: classInfo.name,
+        initials: initials(fullName) as string,
+        classHash: classInfo.classHash,
+        offeringId: portalService.offeringId
+      };
+      authenticatedUser = researcherUser;
+      break;
+    default:
+      throw new Error(`Unsupported user type: ${user_type ?? "(unknown user type)"}`);
+  }
+
   if (!authenticatedUser) {
-    throw new Error("Current user not found in class roster");
+    throw new Error("Current user not found in class roster or is not a researcher");
   }
 
   authenticatedUser.portalJWT = portalJWT;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -107,6 +107,9 @@ export const getFirebaseJWTParams = (classHash?: string) => {
   if (pageUrlParams.resourceLinkId) {
     params.resource_link_id = pageUrlParams.resourceLinkId;
   }
+  if (pageUrlParams.researcher) {
+    params.researcher = pageUrlParams.researcher;
+  }
 
   return `?${(new URLSearchParams(params)).toString()}`;
 };

--- a/src/lib/portal-types.ts
+++ b/src/lib/portal-types.ts
@@ -76,6 +76,8 @@ export interface PortalResearcherJWT extends BasePortalJWT {
   domain: string;
   user_type: "researcher";
   user_id: string;
+  first_name: string;
+  last_name: string;
 }
 
 export interface PortalUserJWT extends BasePortalJWT {

--- a/src/lib/portal-types.ts
+++ b/src/lib/portal-types.ts
@@ -47,7 +47,7 @@ export interface IPortalClassInfo {
   offerings: IPortalClassOffering[];
 }
 
-export type PortalJWT = PortalStudentJWT | PortalTeacherJWT | PortalUserJWT;
+export type PortalJWT = PortalStudentJWT | PortalTeacherJWT | PortalUserJWT | PortalResearcherJWT;
 
 export interface BasePortalJWT {
   alg: string;
@@ -70,6 +70,12 @@ export interface PortalTeacherJWT extends BasePortalJWT {
   user_type: "teacher";
   user_id: string;
   teacher_id: number;
+}
+
+export interface PortalResearcherJWT extends BasePortalJWT {
+  domain: string;
+  user_type: "researcher";
+  user_id: string;
 }
 
 export interface PortalUserJWT extends BasePortalJWT {

--- a/src/models/curriculum/unit.ts
+++ b/src/models/curriculum/unit.ts
@@ -14,8 +14,8 @@ import { UnitConfiguration } from "../stores/unit-configuration";
 
 const PlanningDocumentConfigModel = types
   .model("PlanningDocumentConfigModel", {
-    // boolean true to enable for all; "teacher" or "student" to enable for specific user roles
-    enable: types.union(types.boolean, types.enumeration("role", ["student", "teacher"])),
+    // boolean true to enable for all; "teacher" or "student" or "researcher" to enable for specific user roles
+    enable: types.union(types.boolean, types.enumeration("role", ["student", "teacher", "researcher"])),
     // whether to create a default planning document for each problem for each user
     default: true,
     // planning document section definitions
@@ -23,7 +23,7 @@ const PlanningDocumentConfigModel = types
     sections: types.array(SectionModel)
   })
   .views(self => ({
-    isEnabledForRole(role?: "student" | "teacher") {
+    isEnabledForRole(role?: "student" | "teacher" | "researcher") {
       return (self.enable === true) || (self.enable === role);
     }
   }));

--- a/src/models/stores/portal.ts
+++ b/src/models/stores/portal.ts
@@ -94,9 +94,15 @@ export class Portal {
 
   requestPortalJWT() {
     return new Promise<void>((resolve, reject) => {
-      const resourceLinkIdSuffix =
-        pageUrlParams.resourceLinkId ? `?resource_link_id=${ pageUrlParams.resourceLinkId }` : "";
-      const url = `${this.basePortalUrl}${PORTAL_JWT_URL_SUFFIX}${resourceLinkIdSuffix}`;
+      const params = new URLSearchParams();
+      if (pageUrlParams.resourceLinkId) {
+        params.append("resource_link_id", pageUrlParams.resourceLinkId);
+      }
+      if (pageUrlParams.researcher) {
+        params.append("researcher", pageUrlParams.researcher);
+      }
+      const queryString = params.size > 0 ? `?${params.toString()}` : "";
+      const url = `${this.basePortalUrl}${PORTAL_JWT_URL_SUFFIX}${queryString}`;
       superagent
         .get(url)
         .set("Authorization", `Bearer ${this.bearerToken}`)
@@ -129,11 +135,12 @@ export class Portal {
 
     await this.requestPortalJWT();
 
-    const {basePortalUrl, portalJWT,urlParams} = this;
+    const {basePortalUrl, portalJWT, urlParams} = this;
 
-    if (!((portalJWT.user_type === "learner") || (portalJWT.user_type === "teacher"))) {
-      throw new Error(`Only student and teacher logins are currently supported! ` +
-        `Unsupported type: ${portalJWT.user_type}`);
+    const supportedUserTypes = ["learner", "teacher", "researcher"];
+    if (!supportedUserTypes.includes(portalJWT.user_type)) {
+      throw new Error(`Only ${supportedUserTypes.join(" or ")} logins are currently supported! ` +
+        `Unsupported type: ${portalJWT.user_type ?? "(unknown user type)"}`);
     }
 
     this.portalHost = parseUrl(basePortalUrl).host;

--- a/src/models/stores/portal.ts
+++ b/src/models/stores/portal.ts
@@ -43,6 +43,10 @@ export interface TeacherUser extends User {
   networks?: string[];  // list of networks available to teacher
 }
 
+export interface ResearcherUser extends User {
+  type: "researcher";
+}
+
 export interface ClassInfo {
   name: string;
   classHash: string;

--- a/src/models/stores/unit-configuration.ts
+++ b/src/models/stores/unit-configuration.ts
@@ -64,7 +64,7 @@ export interface UnitConfiguration extends ProblemConfiguration {
   // disables publishing documents of particular types or with particular properties
   disablePublish: Array<SnapshotIn<typeof DocumentSpecModel>> | boolean;
   // enable/disable showing the history-scrubbing controls for users in different roles
-  enableHistoryRoles: Array<"student" | "teacher">;
+  enableHistoryRoles: Array<"student" | "teacher" | "researcher">;
   // configures naming of copied documents
   copyPreferOriginTitle: boolean;
   // enable/disable dragging of tiles

--- a/src/models/stores/user-types.ts
+++ b/src/models/stores/user-types.ts
@@ -1,6 +1,6 @@
 import { Instance, types } from "mobx-state-tree";
 
-export const UserTypeEnum = types.enumeration("type", ["student", "teacher"]);
+export const UserTypeEnum = types.enumeration("type", ["student", "teacher", "researcher"]);
 export type UserType = Instance<typeof UserTypeEnum>;
 
 export const DisplayUserTypeEnum = types.maybe(UserTypeEnum);

--- a/src/models/stores/user.ts
+++ b/src/models/stores/user.ts
@@ -139,6 +139,9 @@ export const UserModel = types
     get isTeacher() {
       return self.type === "teacher";
     },
+    get isResearcher() {
+      return self.type === "researcher";
+    },
     get isNetworkedTeacher() {
       return (self.type === "teacher") && !!self.network;
     },

--- a/src/utilities/url-params.ts
+++ b/src/utilities/url-params.ts
@@ -44,6 +44,8 @@ export interface QueryParams {
   offering?: string;
   // type of report
   reportType?: string;
+  // set to string "true" to authenticate as a researcher
+  researcher?: string;
 
   //
   // demo features


### PR DESCRIPTION
This adds a "researcher" url param to CLUE that, when present, is passed to the requests for the portal and Firebase JWTs.  When the researcher param is set to "true" the portal JWT will mint a JWT with the user_type set to "researcher" for any user.  When it is set to "true" for the Firebase JWT the user must be a researcher for the provided class_hash param.

The portal store was also updated to allow for researcher authentication.  However, once authenticated the user won't be able to currently read any data from Firestore.  There is a follow on PT story for updating the Firestore rules to allow researchers access to the data.