### PR TITLE
URL param to load a student document

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ To deploy a production release:
     - `ls -lhS *.js | awk '{print "|", $9, "|", $5, "|"}'`
     - `ls -lhS *.css | awk '{print "|", $9, "|", $5, "|"}'`
 1. Create `release-<version>` branch and commit changes, push to GitHub, create PR and merge
-1. Test the master build at: https://collaborative-learning.concord.org/index-master.html
-1. Push a version tag to GitHub and/or use https://github.com/concord-consortium/collaborative-learning/releases to create a new GitHub release
+1. Test the master build at: <https://collaborative-learning.concord.org/index-master.html>
+1. Push a version tag to GitHub and/or use <https://github.com/concord-consortium/collaborative-learning/releases> to create a new GitHub release
 1. Stage the release by running the [Release Staging Workflow](https://github.com/concord-consortium/collaborative-learning/actions/workflows/release-staging.yml) and entering the version tag you just pushed.
-1. Test the staged release at https://collaborative-learning.concord.org/index-staging.html
+1. Test the staged release at <https://collaborative-learning.concord.org/index-staging.html>
 1. Update production by running the [Release Workflow](https://github.com/concord-consortium/collaborative-learning/actions/workflows/release.yml) and entering the release version tag.
 
 ## Developing/deploying cloud functions
@@ -62,6 +62,7 @@ To deploy a production release:
 CLUE uses several Google cloud functions to implement certain features that would be difficult (or impossible) to implement entirely client-side. There are two folders of functions `functions-v1` and `functions-v2`. We are trying to incrementally migrate the v1 functions into the v2 folder.
 
 Each folder has its own readme:
+
 - [functions-v2](functions-v2/README.md)
 - [functions-v1](functions-v1/README.md)
 
@@ -124,16 +125,16 @@ To enable per component debugging set the "debug" localstorage key with one or m
 - `stores` this will set `window.stores` so you can monitor the stores global from the browser console.
 - `undo` this will print information about each action that is added to the undo stack.
 
-
 ## Testing
 
 CLUE has a fairly extensive set of jest (unit/integration) tests and cypress (integration/end-to-end) tests. To run them:
-```
-$ npm [run] test                # run all jest tests
-$ npm [run] test -- abc.test.ts # run a single jest test
-$ npm run test:coverage         # run all jest tests and report coverage
-$ npm run test:cypress          # run the cypress tests headless
-$ npm run test:cypress:open     # open the cypress app for running the cypress tests interactively
+
+```bash
+npm [run] test                # run all jest tests
+npm [run] test -- abc.test.ts # run a single jest test
+npm run test:coverage         # run all jest tests and report coverage
+npm run test:cypress          # run the cypress tests headless
+npm run test:cypress:open     # open the cypress app for running the cypress tests interactively
 ```
 
 The tests are run automatically on PRs and Codecov is configured to track coverage. Codecov will report on whether a given PR increases or decreases overall coverage to encourage good testing habits.
@@ -160,8 +161,10 @@ There are a number of URL parameters that can aid in testing:
 |`functions`     |`emulator\|<URL>`        |Target emulator-hosted firebase functions.|
 |`noPersistentUI`|none                     |Do not initialize persistent ui store.|
 |`researcher`    |`true`                   |When set to true the user authenticates as a researcher|
+|`studentDocument`|string                  |If set to the ID of a document, this will be displayed as the left-side content.|
 
 The `unit` parameter can be in 3 forms:
+
 - a valid URL starting with `https:` or `http:` will be treated as an absolute URL.
 - a string starting with `./` will be treated as a URL relative to the javascript files of CLUE.
 - Everything else is treated as a unit code, these codes are first looked up in a map to remap legacy codes. Then the URL of the unit is created by `${curriculumSiteUrl}/branch/${branchName}/${unitCode}/content.json`.
@@ -191,7 +194,8 @@ qaGroup - the group to automatically assign the fake user to after connecting to
 
 Additionally in `qa` mode the "root" in Firestore and the Realtime database is based on the Firebase user uid. This user is stored in session storage so each new tab will start a new root. In Cypress session storage is cleared between tests so each new test will have its own root.
 
-### To run Cypress integration tests:
+### To run Cypress integration tests
+
 - `npm run test:local`
 - `npm run test:dev`
 - `npm run test:branch` (requires change in environments.json to add the branch name)
@@ -201,7 +205,8 @@ Additionally in `qa` mode the "root" in Firestore and the Realtime database is b
 ### Additional notes about configuration
 
 You can also temporarily overwrite any configuration option using env variables with `CYPRESS_` prefix. E.g.:
-- `CYPRESS_baseUrl=https://collaborative-learning.concord.org/branch/fix-data-attributes npm run test:dev`
+
+`CYPRESS_baseUrl=https://collaborative-learning.concord.org/branch/fix-data-attributes npm run test:dev`
 
 ### Writing tests, workflow and patterns
 

--- a/cypress/e2e/functional/teacher_tests/teacher_student_work_spec.js
+++ b/cypress/e2e/functional/teacher_tests/teacher_student_work_spec.js
@@ -1,0 +1,52 @@
+import ClueCanvas from '../../../support/elements/common/cCanvas';
+import TextToolTile from '../../../support/elements/tile/TextToolTile';
+import ResourcesPanel from '../../../support/elements/common/ResourcesPanel';
+
+const studentQueryParams = `${Cypress.config("qaUnitStudent5")}`;
+const teacherQueryParams = `${Cypress.config("qaUnitTeacher6")}`;
+
+const clueCanvas = new ClueCanvas;
+const textToolTile = new TextToolTile;
+const resourcesPanel = new ResourcesPanel;
+
+function beforeTest(params) {
+  cy.visit(params);
+  cy.waitForLoad();
+  cy.openTopTab("problems");
+}
+
+const sampleText = "Text for studentDocument view test";
+
+// This URL parameter is usually used by researchers, but works for teachers as well
+context('Teacher can use studentDocument URL parameter', () => {
+  it('Allows teacher to link to student work', () => {
+    cy.log('Log in as student and put content into problem document');
+    beforeTest(studentQueryParams);
+    clueCanvas.addTile('text');
+    textToolTile.enterText(sampleText);
+    textToolTile.getTextTile().last().should('contain', sampleText);
+    // Click outside the text area to save the text
+    clueCanvas.getPlaceHolder().first().click();
+    // Store the ID of the document for later use
+    clueCanvas.getSingleWorkspaceDocumentContent().invoke('attr', 'data-document-key').then((documentId) => {
+      cy.log(`Document ID: ${documentId}`);
+      cy.wrap(documentId).as('documentId').should('not.be.undefined');
+    });
+    cy.wait(1000); // Give some time for the document to save
+
+    cy.log('Log in as teacher and view student work');
+    cy.get('@documentId').then((id) => {
+      expect(id).to.not.be.undefined;
+      cy.visit(teacherQueryParams + '&studentDocument=' + id);
+      cy.waitForLoad();
+
+      resourcesPanel.getPrimaryWorkspaceTab('student-work').should('have.class', 'selected');
+      resourcesPanel.getEditableDocumentContent()
+        .should('have.attr', 'data-document-key', id)
+        .should('have.class', 'read-only')
+        .should('contain', sampleText);
+    });
+
+  });
+
+});

--- a/docs/oauth2.md
+++ b/docs/oauth2.md
@@ -5,18 +5,19 @@ CLUE will use an OAuth2 flow to authenticate with the portal if an `authDomain` 
 This OAuth2 authentication will result in an `accessToken`. This `accessToken` can be used by CLUE to access other portal APIs the same way that the nonce `token` parameter is used by the current portal launches. However the portal's nonce `token` has some extra information in it in addition to the user authentication. So in order for the OAuth2 launch to work property a second parameter `resourceLinkId` needs to be included in the CLUE URL. This is an LTI name for the portal's offering id. This `resourceLinkId` is passed to the Portal JWT and Firebase JWT requests and it takes the place of the extra info that was original included in the portal's nonce `token`.
 
 This diagram describes how OAuth2 works:
-https://github.com/concord-consortium/portal-report/blob/master/docs/launch.md#launched-from-third-party-site-and-authenticate-user
+[portal-report launch diagram](https://github.com/concord-consortium/portal-report/blob/master/docs/launch.md#launched-from-third-party-site-and-authenticate-user)
+
 - Replace "Portal Report" with "CLUE".
 - Replace "Activity Player" with some other way a user can open a link. Planned cases are:
   - including links in the researcher log reports
   - updating the portal to use links like this to launch CLUE, this way the user can reload CLUE and be re-authenticated with the Portal and continue working where they left off.
 
-# Example URLS
+## Example URLS
 
-## Teacher Launch
+### Teacher Launch
 
 Original URL:
-https://collaborative-learning.concord.org/branch/master/?class=https%3A%2F%2Flearn.portal.staging.concord.org%2Fapi%2Fv1%2Fclasses%2F111&classOfferings=https%3A%2F%2Flearn.portal.staging.concord.org%2Fapi%2Fv1%2Fofferings%3Fclass_id%3D111&logging=true&offering=https%3A%2F%2Flearn.portal.staging.concord.org%2Fapi%2Fv1%2Fofferings%2F112&reportType=offering&token=a4ebf7f5aae51671a6b7081abfd1adb0&username=google-118170338932514291325
+<https://collaborative-learning.concord.org/branch/master/?class=https%3A%2F%2Flearn.portal.staging.concord.org%2Fapi%2Fv1%2Fclasses%2F111&classOfferings=https%3A%2F%2Flearn.portal.staging.concord.org%2Fapi%2Fv1%2Fofferings%3Fclass_id%3D111&logging=true&offering=https%3A%2F%2Flearn.portal.staging.concord.org%2Fapi%2Fv1%2Fofferings%2F112&reportType=offering&token=a4ebf7f5aae51671a6b7081abfd1adb0&username=google-118170338932514291325>
 
 Params broken out:
 - class=https%3A%2F%2Flearn.portal.staging.concord.org%2Fapi%2Fv1%2Fclasses%2F111
@@ -28,27 +29,29 @@ Params broken out:
 - username=google-118170338932514291325
 
 Localhost updated with OAuth2:
-http://localhost:8080/?class=https%3A%2F%2Flearn.portal.staging.concord.org%2Fapi%2Fv1%2Fclasses%2F111&classOfferings=https%3A%2F%2Flearn.portal.staging.concord.org%2Fapi%2Fv1%2Fofferings%3Fclass_id%3D111&logging=true&offering=https%3A%2F%2Flearn.portal.staging.concord.org%2Fapi%2Fv1%2Fofferings%2F112&reportType=offering&username=google-118170338932514291325&authDomain=https://learn.portal.staging.concord.org&resourceLinkId=112
+<http://localhost:8080/?class=https%3A%2F%2Flearn.portal.staging.concord.org%2Fapi%2Fv1%2Fclasses%2F111&classOfferings=https%3A%2F%2Flearn.portal.staging.concord.org%2Fapi%2Fv1%2Fofferings%3Fclass_id%3D111&logging=true&offering=https%3A%2F%2Flearn.portal.staging.concord.org%2Fapi%2Fv1%2Fofferings%2F112&reportType=offering&username=google-118170338932514291325&authDomain=https://learn.portal.staging.concord.org&resourceLinkId=112>
 
-## Student Launch
+### Student Launch
 
 Original URL:
-https://collaborative-learning.concord.org/branch/master/?unit=msa&problem=1.4&token=16c1c896e36d24eeb329508142bc6312&domain=https://learn.portal.staging.concord.org/&domain_uid=114
+<https://collaborative-learning.concord.org/branch/master/?unit=msa&problem=1.4&token=16c1c896e36d24eeb329508142bc6312&domain=https://learn.portal.staging.concord.org/&domain_uid=114>
 
 Localhost updated With OAuth2
-http://localhost:8080/?unit=msa&problem=1.4&domain=https://learn.portal.staging.concord.org/&domain_uid=114&authDomain=https://learn.portal.staging.concord.org&resourceLinkId=112
+<http://localhost:8080/?unit=msa&problem=1.4&domain=https://learn.portal.staging.concord.org/&domain_uid=114&authDomain=https://learn.portal.staging.concord.org&resourceLinkId=112>
 
-# Future Work
+## Future Work
+
 - update Portal with a new launch option for students and reports which includes the `authDomain` and `resourceLinkId` params.
 - add support for researcher access to CLUE student work. The portal already has a `target_user_id` param that is used for portal report researcher access to student data. There are special rules in the portal report firebase to allow this `target_user_id` claim to access the answers for students. CLUE doesn't have these rules, and the app will also fail because the user type in the JWT will not be student. See below for more details.
 - add support for researcher access to CLUE teacher dashboards. The researcher should only see students in the dashboard with permission forms. And most likely the student names should be replaced with ids so researchers can correlate the data with the log data without knowing the student name. The same `target_user_id` support in the portal can be used for this, but CLUE app code and the firebase rules will need to be updated to make it work.
 - when the URL includes a current user id, we should pass this to the portal during the OAuth2 flow. This way if a different user is signed into the portal, the portal can give them them the option to logout and login with the correct user. This can happen when testing different users, it can also happen when a computer is shared by multiple students. If the wrong user is logged in the current message is confusing: "Error: Unable to get classInfoUrl or offeringId"
 - add OAuth2 tests. We should be able to at least test that CLUE redirects to the authDomain and handles loading the parameters when it is loaded with the parameters after the user has logged in at the Portal.
 
-# Notes on parameter names
+## Notes on parameter names
+
 It is tempting to use the existing `domain` url parameter, but that would cause problems because CLUE wouldn't be able tell the difference between a nonce token Portal launch and OAuth2 Portal launch. But if we drop support for the nonce token Portal launch we might want to consolidate the two parameters. In the AP, portal-report, and researcher report SPAs the URL param is `auth-domain` instead of the `authDomain` used in CLUE. I switched to camel case in CLUE because that is our convention, and if CLUE projects are going to fund a new OAuth2 Portal launch type we might as well use that as an opportunity to switch preferred camel case style.
 
-# Handling Researcher Launches
+## Handling Researcher Launches
 
 See above for short notes on a researcher launch of student or teacher versions of CLUE.
 
@@ -59,14 +62,16 @@ Currently CLUE requests a Portal JWT and then it checks the user type in this JW
 If a researcher is launching CLUE they will likely not be a student or teacher in the class of the offering. So they will have a user type of "user" in the Portal JWT. Even when a `target_user_id` is passed along with the `resource_link_id` to the JWT API, and this target user is a student or teacher in the class, the portal will continue to set the user type to be "user".
 
 Here is where the `resource_link_id` and `target_user_id` are discussed when requesting portal JWTs:
-https://github.com/concord-consortium/rigse/blob/18df1de769a9098101eb10b2fa92846de23d7b6e/rails/app/controllers/api/v1/jwt_controller.rb#L89
+<https://github.com/concord-consortium/rigse/blob/18df1de769a9098101eb10b2fa92846de23d7b6e/rails/app/controllers/api/v1/jwt_controller.rb#L89>
 
 Currently in CLUE if the Portal JWT user type is not learner or teacher then CLUE will bail out. We probably want to change this to allow a type of "user".
 
 Then if the JWT is a learner:
+
 - CLUE gets the class_info_url and offering_id out of the JWT.
 
 Otherwise if the JWT user type is teacher (and user if we allow it above)
+
 - the classInfoUrl is taken from a class parameter in URL itself
 - the offeringId is taken from the offering parameter in the URL itself
 
@@ -78,10 +83,10 @@ To simplify these URLs we could update CLUE to get the offeringId from the resou
 
 In the case of a researcher the current user would not be found in the class. However we could use the target_user_id here and use that to find the target user in the class. Or perhaps we want the current user within CLUE to actually be the researcher. This could be useful so the researcher is not allowed to edit documents. Most document editing UI should be checking if the current user is the owner of the document before letting the current user edit the document.
 
-The JWT we would get as a researcher would not include the domain, just the uid. This happens because the domain is only added if the user is a learner or teacher: https://github.com/concord-consortium/rigse/blob/18df1de769a9098101eb10b2fa92846de23d7b6e/rails/app/controllers/api/v1/jwt_controller.rb#L147-L165
+The JWT we would get as a researcher would not include the domain, just the uid. This happens because the domain is only added if the user is a learner or teacher: <https://github.com/concord-consortium/rigse/blob/18df1de769a9098101eb10b2fa92846de23d7b6e/rails/app/controllers/api/v1/jwt_controller.rb#L147-L165>
 CLUE uses this domain for somethings. It seems reasonable for the Portal to always add this domain into the JWT. When we change this we'd need to check if there is javascript code in other repositories that is counting on this domain not being there in some cases. Repositories to check are: activity-player, portal-report, and researcher-report. There might also be firebase rules that are using this domain. If we want to avoid these potential problems, we could have CLUE OAuth launches use the authDomain instead. This should fix any issues in CLUE. However there might be code in the firebase rules that is using the domain to figure out the path in firebase, so in that case we'll still need to deal with adding the domain to JWT.
 
-# Tech Debt
+## Tech Debt
 
 - figure out a way to handle branches with the OAuth2 redirects, so we don't have to update the portal configuration each time we want to test a new branch.
 - simplify params used by a report launch of CLUE. With just the resourceLinkId and a domain it can discover all of the information it needs for the report. This makes the report launch more symmetric with the student launch. Especially if the offering api (or perhaps new resourceLinkId api) provided info about class (or context). The biggest problem with using a single id like that is that either we need a dynamic api where we can specify the shape of the result, or we have to make one request to get the offering info, wait for it, and then make a second request to get the class info. The next bullet can be used to simplify this.
@@ -98,24 +103,28 @@ This isn't really needed for this work. We have the offeringId provided by the r
 - update all of the places that currently pass a user object to getOfferingPath to pass the stores directly which would then implement this interface.
 - this way we can remove the class and offering info out of the user object which would then match the actual user concept in the portal.
 
-# Notes on affected code
+## Notes on affected code
 
 Old use of `urlParams.token`:
+
 - to figure out the app mode in index.tsx
 - to figure out if we are "previewing" in initializeApp (initialize-app.tsx). This approach might be broken if we drop the token from student launches.
 - bearerToken in authenticate (auth.ts)
 - token param in getPortalClassOfferings (portal-apis.ts)
 
 Use of `bearerToken` in auth.ts
+
 - figuring out if we're in preview mode from the portal, like in initialize-app.tsx
 - bailing out if it isn't set when the appMode is authed
 - getting the portal JWT with `getPortalJWTWithBearerToken`
 - getting the firebase JWT with `getFirebaseJWTWithBearerToken`
 
 Update of urlParams:
+
 - after initializeAuthorization has restored the url params from local storage we need to reprocess the url params. This is done by updating the urlParams object in place. This object is imported as a global into several files in CLUE, so updating it in place is the easiest way to handle the restored url params. See the urlParams tech debt above which would be an alternative way to handle this.
 
 Main CLUE entry points:
+
 - src/index.tsx (main CLUE app)
 - cms/src/admin.tsx (main authoring page)
 - src/cms/cms-editor.tsx (embedded CLUE for used in CMS authoring)
@@ -134,25 +143,25 @@ An important note is that there is an authenticatedUser that comes from the port
 
 `getPortalOfferings` - this uses the userType to decide if it should actually fetch the offerings of the current user. This is because we only show the list of offerings to teachers and don't let the students change their offering. With the new OAuth code we could allow the student to switch offerings at least in theory. However we would then lose some information in the portal that is recorded when the student launches a assignment from the portal. So we probably don't want to enable this yet.
 
-# Review of the ways CLUE can be launched
+## Review of the ways CLUE can be launched
 
 Note that preview launch is the same for students and teachers, the student preview launch is included just to make it clear that even though we try to hide this kind of launch, it is possible to do.
 
 - as a student on the assignment page:
-  https://collaborative-learning.concord.org/branch/master/?
+  <https://collaborative-learning.concord.org/branch/master/>?
   - unit=msa
   - problem=1.4
   - token=6c6ed7997286d70835a75f9b18a83f83
-  - domain=https://learn.portal.staging.concord.org/
+  - domain=<https://learn.portal.staging.concord.org/>
   - domain_uid=114
 - as a student that happens to find the preview page:
-  https://collaborative-learning.concord.org/branch/master/?
+  <https://collaborative-learning.concord.org/branch/master/>?
   - unit=msa
   - problem=1.4
   - domain=https%3A%2F%2Flearn.portal.staging.concord.org%2F
   - domain_uid=114
 - as a teacher opening "dashboard link" on the class page (an external report):
-  https://collaborative-learning.concord.org/branch/master/?
+  <https://collaborative-learning.concord.org/branch/master/>?
   - class=https%3A%2F%2Flearn.portal.staging.concord.org%2Fapi%2Fv1%2Fclasses%2F111
   - classOfferings=https%3A%2F%2Flearn.portal.staging.concord.org%2Fapi%2Fv1%2Fofferings%3Fclass_id%3D111
   - logging=true
@@ -161,13 +170,13 @@ Note that preview launch is the same for students and teachers, the student prev
   - token=a4ebf7f5aae51671a6b7081abfd1adb0
   - username=google-118170338932514291325
 - as a teacher previewing it from the class page or search results:
-  https://collaborative-learning.concord.org/branch/master/?
+  <https://collaborative-learning.concord.org/branch/master/>?
   - unit=msa
   - problem=1.4
   - domain=https%3A%2F%2Flearn.portal.staging.concord.org%2F
   - domain_uid=9
 - as a researcher trying to look at a specific answer. This is not currently supported by CLUE but the AP report supports it. If we add an OAuth2 launching option to the portal we should to take this case into account. And this type of launch is useful for reference when we add support to CLUE so a researcher can open a specific document.
-  https://portal-report.concord.org/branch/master/index.html?
+  <https://portal-report.concord.org/branch/master/index.html>?
   - auth-domain=https%3A%2F%2Flearn-report.portal.staging.concord.org
   - firebase-app=report-service-dev
   - sourceKey=authoring.lara.staging.concord.org
@@ -177,7 +186,7 @@ Note that preview launch is the same for students and teachers, the student prev
   - studentId=90
   - answersSourceKey=activity-player.concord.org
 
-# Ramifications for Page reloading
+## Ramifications for Page reloading
 
 1. Because the current portal student assignment launch does not include the offering id in the URL, we'll need to add it to the URL after launch so a reload can work properly. Or we need to update the portal launch to include this offering id. This id is now supported as the resourceLinkId. My preference is to update the portal launching, so CLUE doesn't have to rewrite the URL after launch.
 2. The teacher report launch includes 3 URLs. To make these URLs more concise it would be useful to simplify that to just the resourceLinkId and then CLUE can use that id to request the information from the portal so the 3 URLs aren't needed.

--- a/src/components/document/document-content.tsx
+++ b/src/components/document/document-content.tsx
@@ -150,6 +150,7 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
       <DocumentDndContext>
         <div className={documentClass}
           data-testid="document-content"
+          data-document-key={this.props.documentId}
           onScroll={this.handleScroll}
           onClick={this.handleClick}
           onDragOver={this.handleDragOver}

--- a/src/initialize-app.tsx
+++ b/src/initialize-app.tsx
@@ -70,7 +70,7 @@ export const initializeApp = (authoring: boolean): IStores => {
 
   const appConfig = AppConfigModel.create(appConfigSnapshot);
   const stores = createStores(
-    { appMode, appVersion, appConfig, user, showDemoCreator, demoName });
+    { appMode, appVersion, appConfig, user, showDemoCreator, demoName, documentToDisplay: urlParams.studentDocument });
 
   // Expose the stores if the debug flag is set or we are running in Cypress
   const aWindow = window as any;

--- a/src/models/stores/app-config-model.ts
+++ b/src/models/stores/app-config-model.ts
@@ -25,14 +25,24 @@ export const AppConfigModel = types
     toolbar: ToolbarModel.create(self.config?.toolbar || []),
     authorTools: ToolbarModel.create(self.config?.authorTools || []),
     settings: self.config?.settings,
+    requireSortWorkTab: false
   }))
   .actions(self => ({
     setConfigs(configs: Partial<UnitConfiguration>[]) {
       self.configMgr = new ConfigurationManager(self.config, configs);
       self.navTabs = NavTabsConfigModel.create(self.configMgr.navTabs);
+      if (self.requireSortWorkTab) {
+        self.navTabs.addSortWorkTab();
+      }
       self.disabledFeatures = self.configMgr.disabledFeatures;
       self.toolbar = ToolbarModel.create(self.configMgr.toolbar);
       self.settings = self.configMgr.settings;
+    },
+    setRequireSortWorkTab(requireSortWorkTab: boolean) {
+      self.requireSortWorkTab = requireSortWorkTab;
+      if (requireSortWorkTab) {
+        self.navTabs.addSortWorkTab();
+      }
     }
   }))
   .views(self => ({

--- a/src/models/stores/nav-tabs.ts
+++ b/src/models/stores/nav-tabs.ts
@@ -12,11 +12,22 @@ export const NavTabsConfigModel = types
   .views(self => ({
     getNavTabSpec(tabId: ENavTab) {
       return self.tabSpecs.find(tab => tabId === tab.tab);
+    },
+    hasSortWorkTab() {
+      return self.tabSpecs.some(tab => tab.tab === ENavTab.kSortWork);
     }
   }))
   .actions(self => ({
     toggleShowNavPanel() {
       self.showNavPanel = !self.showNavPanel;
+    },
+    addSortWorkTab() {
+      if (!self.hasSortWorkTab()) {
+        self.tabSpecs.push(NavTabModel.create({
+          tab: ENavTab.kSortWork,
+          label: "Sort Work"
+        }));
+      }
     }
   }));
 

--- a/src/models/stores/stores.ts
+++ b/src/models/stores/stores.ts
@@ -175,7 +175,7 @@ class Stores implements IStores{
         if (doc) {
           this.persistentUI.openResourceDocument(doc, this.user, this.sortedDocuments);
         } else {
-          console.log("Display document not found: ", params.documentToDisplay);
+          console.warn("Display document not found: ", params.documentToDisplay);
         }
       });
     }

--- a/src/models/stores/stores.ts
+++ b/src/models/stores/stores.ts
@@ -164,24 +164,18 @@ class Stores implements IStores{
     this.sortedDocuments = new SortedDocuments(this);
     this.sectionDocuments = new SectionDocuments(this);
 
-    // If there is a `studentDocument` URL parameter, then display it
+    // If there is a `studentDocument` URL parameter, then tell the UI to display it
     const docToDisplay = params?.documentToDisplay;
     if (docToDisplay) {
-      // We need to wait for the document to be loaded before we can display it.
-      // TODO: we don't know what type of document it is -- should we wait for all types?
-      const documentLoading = this.documents.requiredDocuments[ProblemDocument];
-      if (documentLoading) {
-        documentLoading.promise.then(() => {
-          const doc = this.documents.getDocument(docToDisplay);
-          if (doc) {
-            this.persistentUI.openResourceDocument(doc, undefined, this.sortedDocuments);
-          } else {
-            console.log("Display document not found: ", params.documentToDisplay);
-          }
-        });
-      } else {
-        console.log("No document loading promise found for ProblemDocument");
-      }
+      // We need to ensure that the document is loaded first.
+      const docPromise = this.sortedDocuments.fetchFullDocument(docToDisplay);
+      docPromise.then((doc) => {
+        if (doc) {
+          this.persistentUI.openResourceDocument(doc, undefined, this.sortedDocuments);
+        } else {
+          console.log("Display document not found: ", params.documentToDisplay);
+        }
+      });
     }
 
     this.unitLoadedPromise = when(() => this.unit !== defaultUnit);

--- a/src/models/stores/stores.ts
+++ b/src/models/stores/stores.ts
@@ -167,11 +167,13 @@ class Stores implements IStores{
     // If there is a `studentDocument` URL parameter, then tell the UI to display it
     const docToDisplay = params?.documentToDisplay;
     if (docToDisplay) {
-      // We need to ensure that the document is loaded first.
+      // Make sure there is a Sort Work tab to display the document in.
+      this.appConfig.setRequireSortWorkTab(true);
+      // Wait until the document is loaded, then open it.
       const docPromise = this.sortedDocuments.fetchFullDocument(docToDisplay);
       docPromise.then((doc) => {
         if (doc) {
-          this.persistentUI.openResourceDocument(doc, undefined, this.sortedDocuments);
+          this.persistentUI.openResourceDocument(doc, this.user, this.sortedDocuments);
         } else {
           console.log("Display document not found: ", params.documentToDisplay);
         }

--- a/src/utilities/url-params.ts
+++ b/src/utilities/url-params.ts
@@ -46,6 +46,8 @@ export interface QueryParams {
   reportType?: string;
   // set to string "true" to authenticate as a researcher
   researcher?: string;
+  // display a certain student document
+  studentDocument?: string;
 
   //
   // demo features


### PR DESCRIPTION
PT-188754089

Adds support for a `studentDocument` URL parameter for teacher/researcher users. This will load the referenced document into the resource area after startup.

Related changes:
- Fix some markdownlint warnings in doc files touched
- Add a `data-document-key` attribute to HTML for convenience in testing
- Adds a test of the URL parameter. We don't have a "researcher" setup for Cypress tests, and it didn't seem worth creating one just for this single test, so it's running as teacher for now.