### PR TITLE
feat: bar graph color picker (PT-188212464)

### DIFF
--- a/cypress/e2e/functional/tile_tests/bar_graph_tile_spec.js
+++ b/cypress/e2e/functional/tile_tests/bar_graph_tile_spec.js
@@ -1,5 +1,6 @@
 import ClueCanvas from '../../../support/elements/common/cCanvas';
 import Canvas from '../../../support/elements/common/Canvas';
+import { clueDataColors } from '../../../support/utils/data-display';
 import BarGraphTile from '../../../support/elements/tile/BarGraphTile';
 import TableToolTile
  from '../../../support/elements/tile/TableToolTile';
@@ -495,20 +496,6 @@ context('Bar Graph Tile', function () {
 
     const workspace = workspaces[0];
     const tileIndex = 0;
-    const barColors = [
-      '#0069ff', // blue
-      '#ff9617', // orange
-      '#19a90f', // green
-      '#ee0000', // red
-      '#cbd114', // yellow
-      '#d51eff', // purple
-      '#6b00d2', // indigo
-      '#ffffff', // white
-      '#f1d9ae', // peach
-      '#a5a5a5', // gray
-      '#915e3b', // brown
-      '#000000'  // black
-    ];
 
     clueCanvas.addTile('bargraph');
 
@@ -526,46 +513,46 @@ context('Bar Graph Tile', function () {
     cy.get('.modal-button').contains("Graph It!").click();
 
     cy.log('Check color change when there is no secondary attribute');
-    barGraph.getBar().should('have.length', 2).should('have.attr', 'fill', 'black');
+    barGraph.getBar().should('have.length', 2).should('have.attr', 'fill', clueDataColors[0]);
     barGraph.getBarColorMenu().should('not.be.visible');
     barGraph.getBarColorButton().should('have.length', 1).click();
     barGraph.getBarColorMenu(workspace, tileIndex, 0).should('be.visible');
     barGraph.getBarColorMenuButtons(workspace, tileIndex, 0).should('have.length', 12);
     barGraph.getBarColorMenuButtons(workspace, tileIndex, 0).eq(0).click({force: true});
     barGraph.getBarColorMenu(workspace, tileIndex, 0).should('not.be.visible');
-    barGraph.getBar().eq(0).should('have.attr', 'fill', barColors[0]);
-    barGraph.getBar().eq(1).should('have.attr', 'fill', barColors[0]);
+    barGraph.getBar().eq(0).should('have.attr', 'fill', clueDataColors[0]);
+    barGraph.getBar().eq(1).should('have.attr', 'fill', clueDataColors[0]);
 
     cy.log('Check color change when there is a secondary attribute');
     barGraph.getSortByMenuButton(workspace).click();
     barGraph.getChakraMenuItem().eq(1).click();
     barGraph.getBar().should("have.length", 3);
     barGraph.getBarColorButton().should('have.length', 3);
-    barGraph.getBar().eq(0).should('have.attr', 'fill', barColors[0]);
-    barGraph.getBar().eq(1).should('have.attr', 'fill', barColors[1]);
-    barGraph.getBar().eq(2).should('have.attr', 'fill', barColors[2]);
+    barGraph.getBar().eq(0).should('have.attr', 'fill', clueDataColors[0]);
+    barGraph.getBar().eq(1).should('have.attr', 'fill', clueDataColors[1]);
+    barGraph.getBar().eq(2).should('have.attr', 'fill', clueDataColors[2]);
     barGraph.getBarColorButton().eq(0).click();
     barGraph.getBarColorMenu(workspace, tileIndex, 0).should('be.visible');
     barGraph.getBarColorMenuButtons(workspace, tileIndex, 0).eq(1).click({force: true});
-    barGraph.getBar().eq(0).should('have.attr', 'fill', barColors[1]);
+    barGraph.getBar().eq(0).should('have.attr', 'fill', clueDataColors[1]);
     barGraph.getBarColorButton().eq(1).click();
     barGraph.getBarColorMenu(workspace, tileIndex, 1).should('be.visible');
     barGraph.getBarColorMenuButtons(workspace, tileIndex, 1).eq(2).click({force: true});
-    barGraph.getBar().eq(1).should('have.attr', 'fill', barColors[2]);
+    barGraph.getBar().eq(1).should('have.attr', 'fill', clueDataColors[2]);
     barGraph.getBarColorButton().eq(2).click();
     barGraph.getBarColorMenu(workspace, tileIndex, 2).should('be.visible');
     barGraph.getBarColorMenuButtons(workspace, tileIndex, 2).eq(3).click({force: true});
-    barGraph.getBar().eq(2).should('have.attr', 'fill', barColors[3]);
+    barGraph.getBar().eq(2).should('have.attr', 'fill', clueDataColors[3]);
 
     cy.log('Check undo/redo of color changes.');
     clueCanvas.getUndoTool().click();
-    barGraph.getBar().eq(2).should('have.attr', 'fill', barColors[2]);
+    barGraph.getBar().eq(2).should('have.attr', 'fill', clueDataColors[2]);
     clueCanvas.getUndoTool().click();
-    barGraph.getBar().eq(1).should('have.attr', 'fill', barColors[1]);
+    barGraph.getBar().eq(1).should('have.attr', 'fill', clueDataColors[1]);
     clueCanvas.getRedoTool().click();
-    barGraph.getBar().eq(1).should('have.attr', 'fill', barColors[2]);
+    barGraph.getBar().eq(1).should('have.attr', 'fill', clueDataColors[2]);
     clueCanvas.getRedoTool().click();
-    barGraph.getBar().eq(2).should('have.attr', 'fill', barColors[3]);
+    barGraph.getBar().eq(2).should('have.attr', 'fill', clueDataColors[3]);
 
     cy.log('Check adding new value to secondary attribute.');
     const newTableRowValues = ['XX', 'YYYY', 'ZZZZ'];
@@ -577,10 +564,10 @@ context('Bar Graph Tile', function () {
     barGraph.getChakraMenuItem().eq(2).click();
     barGraph.getBar().should("have.length", 4);
     barGraph.getBarColorButton().should('have.length', 4);
-    barGraph.getBar().eq(0).should('have.attr', 'fill', barColors[0]);
-    barGraph.getBar().eq(1).should('have.attr', 'fill', barColors[1]);
-    barGraph.getBar().eq(2).should('have.attr', 'fill', barColors[2]);
-    barGraph.getBar().eq(3).should('have.attr', 'fill', barColors[3]);
+    barGraph.getBar().eq(0).should('have.attr', 'fill', clueDataColors[0]);
+    barGraph.getBar().eq(1).should('have.attr', 'fill', clueDataColors[1]);
+    barGraph.getBar().eq(2).should('have.attr', 'fill', clueDataColors[2]);
+    barGraph.getBar().eq(3).should('have.attr', 'fill', clueDataColors[3]);
 
   });
 });

--- a/cypress/e2e/functional/tile_tests/bar_graph_tile_spec.js
+++ b/cypress/e2e/functional/tile_tests/bar_graph_tile_spec.js
@@ -490,4 +490,87 @@ context('Bar Graph Tile', function () {
     }
   });
 
+  it('Setting bar colors', function () {
+    beforeTest();
+
+    const workspace = workspaces[0];
+    const tileIndex = 0;
+    const barColors = [
+      '#0069ff', // blue
+      '#ff9617', // orange
+      '#19a90f', // green
+      '#ee0000', // red
+      '#cbd114', // yellow
+      '#d51eff', // purple
+      '#6b00d2', // indigo
+      '#ffffff', // white
+      '#f1d9ae', // peach
+      '#a5a5a5', // gray
+      '#915e3b', // brown
+      '#000000'  // black
+    ];
+
+    clueCanvas.addTile('bargraph');
+
+    // Table dataset for testing:
+    clueCanvas.addTile('table');
+    tableTile.fillTable(tableTile.getTableTile(), [
+      ['X', 'Y', 'Z'],
+      ['X', 'YY', 'Z'],
+      ['XX', 'YYY', 'Z'],
+    ]);
+
+    barGraph.getTile().click();
+    clueCanvas.clickToolbarButton('bargraph', 'link-tile');
+    cy.get('select').select('Table Data 1');
+    cy.get('.modal-button').contains("Graph It!").click();
+
+    cy.log('Check color change when there is no secondary attribute');
+    barGraph.getBar().should('have.length', 2).should('have.attr', 'fill', 'black');
+    barGraph.getBarColorMenu().should('not.be.visible');
+    barGraph.getBarColorButton().should('have.length', 1).click();
+    barGraph.getBarColorMenu(workspace, tileIndex, 0).should('be.visible');
+    barGraph.getBarColorMenuButtons(workspace, tileIndex, 0).should('have.length', 12);
+    barGraph.getBarColorMenuButtons(workspace, tileIndex, 0).eq(0).click({force: true});
+    barGraph.getBarColorMenu(workspace, tileIndex, 0).should('not.be.visible');
+    barGraph.getBar().eq(0).should('have.attr', 'fill', barColors[0]);
+    barGraph.getBar().eq(1).should('have.attr', 'fill', barColors[0]);
+
+    cy.log('Check color change when there is a secondary attribute');
+    barGraph.getSortByMenuButton(workspace).click();
+    barGraph.getChakraMenuItem().eq(1).click();
+    barGraph.getBar().should("have.length", 3);
+    barGraph.getBarColorButton().should('have.length', 3);
+    barGraph.getBar().eq(0).should('have.attr', 'fill', barColors[0]);
+    barGraph.getBar().eq(1).should('have.attr', 'fill', barColors[1]);
+    barGraph.getBar().eq(2).should('have.attr', 'fill', barColors[2]);
+    barGraph.getBarColorButton().eq(0).click();
+    barGraph.getBarColorMenu(workspace, tileIndex, 0).should('be.visible');
+    barGraph.getBarColorMenuButtons(workspace, tileIndex, 0).eq(1).click({force: true});
+    barGraph.getBar().eq(0).should('have.attr', 'fill', barColors[1]);
+    barGraph.getBarColorButton().eq(1).click();
+    barGraph.getBarColorMenu(workspace, tileIndex, 1).should('be.visible');
+    barGraph.getBarColorMenuButtons(workspace, tileIndex, 1).eq(2).click({force: true});
+    barGraph.getBar().eq(1).should('have.attr', 'fill', barColors[2]);
+    barGraph.getBarColorButton().eq(2).click();
+    barGraph.getBarColorMenu(workspace, tileIndex, 2).should('be.visible');
+    barGraph.getBarColorMenuButtons(workspace, tileIndex, 2).eq(3).click({force: true});
+    barGraph.getBar().eq(2).should('have.attr', 'fill', barColors[3]);
+
+    cy.log('Check undo/redo of color changes.');
+    clueCanvas.getUndoTool().click();
+    barGraph.getBar().eq(2).should('have.attr', 'fill', barColors[2]);
+    clueCanvas.getUndoTool().click();
+    barGraph.getBar().eq(1).should('have.attr', 'fill', barColors[1]);
+    clueCanvas.getRedoTool().click();
+    barGraph.getBar().eq(1).should('have.attr', 'fill', barColors[2]);
+    clueCanvas.getRedoTool().click();
+    barGraph.getBar().eq(2).should('have.attr', 'fill', barColors[3]);
+
+    cy.log('Check adding new value to secondary attribute.');
+    const newTableRowValues = ['XX', 'YYYY', 'Z'];
+    tableTile.addRowToTable(tableTile.getTableTile(), 3, newTableRowValues);
+    barGraph.getBarColorButton().should('have.length', 4);
+
+  });
 });

--- a/cypress/e2e/functional/tile_tests/bar_graph_tile_spec.js
+++ b/cypress/e2e/functional/tile_tests/bar_graph_tile_spec.js
@@ -516,8 +516,8 @@ context('Bar Graph Tile', function () {
     clueCanvas.addTile('table');
     tableTile.fillTable(tableTile.getTableTile(), [
       ['X', 'Y', 'Z'],
-      ['X', 'YY', 'Z'],
-      ['XX', 'YYY', 'Z'],
+      ['X', 'YY', 'ZZ'],
+      ['XX', 'YYY', 'ZZZ'],
     ]);
 
     barGraph.getTile().click();
@@ -568,9 +568,19 @@ context('Bar Graph Tile', function () {
     barGraph.getBar().eq(2).should('have.attr', 'fill', barColors[3]);
 
     cy.log('Check adding new value to secondary attribute.');
-    const newTableRowValues = ['XX', 'YYYY', 'Z'];
+    const newTableRowValues = ['XX', 'YYYY', 'ZZZZ'];
     tableTile.addRowToTable(tableTile.getTableTile(), 3, newTableRowValues);
     barGraph.getBarColorButton().should('have.length', 4);
+
+    cy.log("Check secondary attribute switch results in default color sequence for bars.");
+    barGraph.getSortByMenuButton().click();
+    barGraph.getChakraMenuItem().eq(2).click();
+    barGraph.getBar().should("have.length", 4);
+    barGraph.getBarColorButton().should('have.length', 4);
+    barGraph.getBar().eq(0).should('have.attr', 'fill', barColors[0]);
+    barGraph.getBar().eq(1).should('have.attr', 'fill', barColors[1]);
+    barGraph.getBar().eq(2).should('have.attr', 'fill', barColors[2]);
+    barGraph.getBar().eq(3).should('have.attr', 'fill', barColors[3]);
 
   });
 });

--- a/cypress/e2e/functional/tile_tests/xy_plot_tool_spec.js
+++ b/cypress/e2e/functional/tile_tests/xy_plot_tool_spec.js
@@ -5,6 +5,7 @@ import DiagramToolTile from '../../../support/elements/tile/DiagramToolTile';
 import XYPlotToolTile from '../../../support/elements/tile/XYPlotToolTile';
 import TableToolTile from '../../../support/elements/tile/TableToolTile';
 import DataCardToolTile from '../../../support/elements/tile/DataCardToolTile';
+import { clueDataColors, hexToRgb } from '../../../support/utils/data-display';
 
 let clueCanvas = new ClueCanvas;
 let xyTile = new XYPlotToolTile;
@@ -192,6 +193,12 @@ context('XYPlot Tool Tile', function () {
       cy.openDocumentWithTitle('my-work', 'workspaces', problemDoc);
       xyTile.getGraphDot().should('have.length', 3);
       xyTile.getXYPlotTitle().should('contain', title);
+
+      // TODO: More thorough color checks.
+      cy.log("check colors of dots");
+      xyTile.getGraphDot().eq(0).find('.inner-circle').should('have.attr', 'style').and('contain', hexToRgb(clueDataColors[0]));
+      xyTile.selectYAttribute("y2");
+      xyTile.getGraphDot().eq(0).find('.inner-circle').should('have.attr', 'style').and('contain', hexToRgb(clueDataColors[1]));
 
        //XY Plot tile restore upon page reload
        cy.wait(2000);

--- a/cypress/support/elements/tile/BarGraphTile.js
+++ b/cypress/support/elements/tile/BarGraphTile.js
@@ -80,5 +80,17 @@ class BarGraphTile {
     return this.getLegendArea(workspaceClass, tileIndex).find(`.secondary-values .secondary-value-name`);
   }
 
+  getBarColorButton(workspaceClass, tileIndex = 0) {
+    return this.getLegendArea(workspaceClass, tileIndex).find(`[data-testid="color-menu-button"]`);
+  }
+
+  getBarColorMenu(workspaceClass, tileIndex = 0, menuIndex = 0) {
+    return this.getLegendArea(workspaceClass, tileIndex).find(`[data-testid="color-menu-list"]`).eq(menuIndex);
+  }
+
+  getBarColorMenuButtons(workspaceClass, tileIndex = 0, menuIndex = 0) {
+    return this.getBarColorMenu(workspaceClass, tileIndex, menuIndex).find(`[data-testid="color-menu-list-item"]`);
+  }
+
 }
 export default BarGraphTile;

--- a/cypress/support/elements/tile/TableToolTile.js
+++ b/cypress/support/elements/tile/TableToolTile.js
@@ -114,6 +114,14 @@ class TableToolTile{
       });
     }
 
+    addRowToTable($tile, rowIndex, data) {
+      $tile.within(() => {
+        for (let j=0; j<data.length; j++) {
+          this.typeInTableCellXY(rowIndex, j, data[j]);
+        }
+      });
+    }
+
     getLinkGraphButton(){
       return cy.get('.link-tile-button');
     }

--- a/cypress/support/utils/data-display.js
+++ b/cypress/support/utils/data-display.js
@@ -1,0 +1,41 @@
+export const clueDataColors = [
+  '#0069ff', // blue
+  '#ff9617', // orange
+  '#19a90f', // green
+  '#ee0000', // red
+  '#cbd114', // yellow
+  '#d51eff', // purple
+  '#6b00d2', // indigo
+  '#ffffff', // white
+  '#f1d9ae', // peach
+  '#a5a5a5', // gray
+  '#915e3b', // brown
+  '#000000'  // black
+];
+
+export const hexToRgb = (hex) => {
+  hex = hex.replace(/^#/, "");
+  let r, g, b, a;
+
+  if (hex.length === 3 || hex.length === 4) {
+    // shorthand hex format (#RGB or #RGBA)
+    r = parseInt(hex[0] + hex[0], 16);
+    g = parseInt(hex[1] + hex[1], 16);
+    b = parseInt(hex[2] + hex[2], 16);
+    a = hex.length === 4 ? parseInt(hex[3] + hex[3], 16) / 255 : 1;
+  } else if (hex.length === 6 || hex.length === 8) {
+    // standard hex format (#RRGGBB or #RRGGBBAA)
+    r = parseInt(hex.substring(0, 2), 16);
+    g = parseInt(hex.substring(2, 4), 16);
+    b = parseInt(hex.substring(4, 6), 16);
+    a = hex.length === 8 ? parseInt(hex.substring(6, 8), 16) / 255 : 1;
+  } else {
+    throw new Error("Invalid hex color.");
+  }
+
+  if (a === 1) {
+    return `rgb(${r}, ${g}, ${b})`;
+  } else {
+    return `rgba(${r}, ${g}, ${b}, ${a.toFixed(2)})`;
+  }
+};

--- a/src/clue/data-colors.scss
+++ b/src/clue/data-colors.scss
@@ -8,6 +8,10 @@ $data-red:    #ee0000;
 $data-yellow: #cbd114;
 $data-purple: #d51eff;
 $data-indigo: #6b00d2;
+$data-white: #ffffff;
+$data-peach: #f1d9ae;
+$data-gray: #a5a5a5;
+$data-brown: #915e3b;
 $data-black : #000000;
 
 :export {
@@ -18,5 +22,9 @@ $data-black : #000000;
   dataYellow: $data-yellow;
   dataPurple: $data-purple;
   dataIndigo: $data-indigo;
+  dataWhite:  $data-white;
+  dataPeach:  $data-peach;
+  dataGray:   $data-gray;
+  dataBrown:  $data-brown;
   dataBlack:  $data-black;
 }

--- a/src/clue/data-colors.scss.d.ts
+++ b/src/clue/data-colors.scss.d.ts
@@ -10,6 +10,10 @@ export interface IClueDataColors {
   dataYellow: string;
   dataPurple: string;
   dataIndigo: string;
+  dataWhite: string;
+  dataPeach: string;
+  dataGray: string;
+  dataBrown: string;
   dataBlack: string;
 }
 

--- a/src/plugins/bar-graph/bar-graph-content.test.ts
+++ b/src/plugins/bar-graph/bar-graph-content.test.ts
@@ -11,16 +11,6 @@ const mockCases: ICaseCreation[] = [
   { species: "owl", location: "forest" }
 ];
 
-jest.mock("../../utilities/color-utils", () => ({
-  ...jest.requireActual("../../utilities/color-utils"),
-  clueDataColorInfo: [
-    { color: "red", name: "red" },
-    { color: "blue", name: "blue" },
-    { color: "green", name: "green" },
-    { color: "yellow", name: "yellow" },
-    { color: "purple", name: "purple" },
-  ]
-}));
 
 function sharedEmptyDataSet() {
   const emptyDataSet = DataSet.create();
@@ -68,7 +58,7 @@ describe("Bar Graph Content", () => {
 Object {
   "dataSetId": undefined,
   "primaryAttribute": undefined,
-  "primaryAttributeColor": "black",
+  "primaryAttributeColor": 0,
   "secondaryAttribute": undefined,
   "secondaryAttributeColorMap": Object {},
   "type": "BarGraph",
@@ -300,18 +290,18 @@ Object {
   it("sets the primary attribute color", () => {
     const content = TestingBarGraphContentModel.create({ });
     content.setPrimaryAttribute("att-l");
-    content.setPrimaryAttributeColor("cerulean");
-    expect(content.primaryAttributeColor).toBe("cerulean");
+    content.setPrimaryAttributeColor(1);
+    expect(content.primaryAttributeColor).toBe(1);
   });
 
   it("sets a secondary attribute key's color", () => {
     const content = TestingBarGraphContentModel.create({ });
     content.setPrimaryAttribute("att-l");
     content.setSecondaryAttribute("att-s");
-    content.setSecondaryAttributeKeyColor("key1", "obsidian");
-    content.setSecondaryAttributeKeyColor("key2", "veridian");
-    expect(content.colorForSecondaryKey("key1")).toBe("obsidian");
-    expect(content.colorForSecondaryKey("key2")).toBe("veridian");
+    content.setSecondaryAttributeKeyColor("key1", 2);
+    content.setSecondaryAttributeKeyColor("key2", 3);
+    expect(content.colorForSecondaryKey("key1")).toBe(2);
+    expect(content.colorForSecondaryKey("key2")).toBe(3);
   });
 
   it("can export content", () => {
@@ -319,7 +309,7 @@ Object {
     const expected = {
       type: "BarGraph",
       yAxisLabel: "",
-      primaryAttributeColor: "black",
+      primaryAttributeColor: 0,
       secondaryAttributeColorMap: {},
       dataSetId: undefined,
       primaryAttribute: undefined,

--- a/src/plugins/bar-graph/bar-graph-content.test.ts
+++ b/src/plugins/bar-graph/bar-graph-content.test.ts
@@ -11,6 +11,17 @@ const mockCases: ICaseCreation[] = [
   { species: "owl", location: "forest" }
 ];
 
+jest.mock("../../utilities/color-utils", () => ({
+  ...jest.requireActual("../../utilities/color-utils"),
+  clueDataColorInfo: [
+    { color: "red", name: "red" },
+    { color: "blue", name: "blue" },
+    { color: "green", name: "green" },
+    { color: "yellow", name: "yellow" },
+    { color: "purple", name: "purple" },
+  ]
+}));
+
 function sharedEmptyDataSet() {
   const emptyDataSet = DataSet.create();
   addAttributeToDataSet(emptyDataSet, { id: "att-s", name: "species" });
@@ -288,16 +299,19 @@ Object {
 
   it("sets the primary attribute color", () => {
     const content = TestingBarGraphContentModel.create({ });
+    content.setPrimaryAttribute("att-l");
     content.setPrimaryAttributeColor("cerulean");
     expect(content.primaryAttributeColor).toBe("cerulean");
   });
 
   it("sets a secondary attribute key's color", () => {
     const content = TestingBarGraphContentModel.create({ });
+    content.setPrimaryAttribute("att-l");
+    content.setSecondaryAttribute("att-s");
     content.setSecondaryAttributeKeyColor("key1", "obsidian");
     content.setSecondaryAttributeKeyColor("key2", "veridian");
-    expect(content.secondaryAttributeColorMap.get("key1")).toBe("obsidian");
-    expect(content.secondaryAttributeColorMap.get("key2")).toBe("veridian");
+    expect(content.colorForSecondaryKey("key1")).toBe("obsidian");
+    expect(content.colorForSecondaryKey("key2")).toBe("veridian");
   });
 
   it("can export content", () => {

--- a/src/plugins/bar-graph/bar-graph-content.test.ts
+++ b/src/plugins/bar-graph/bar-graph-content.test.ts
@@ -300,4 +300,18 @@ Object {
     expect(content.secondaryAttributeColorMap.get("key2")).toBe("veridian");
   });
 
+  it("can export content", () => {
+    const content = TestingBarGraphContentModel.create({ });
+    const expected = {
+      type: "BarGraph",
+      yAxisLabel: "",
+      primaryAttributeColor: "black",
+      secondaryAttributeColorMap: {},
+      dataSetId: undefined,
+      primaryAttribute: undefined,
+      secondaryAttribute: undefined
+    };
+    expect(JSON.parse(content.exportJson())).toEqual(expected);
+  });
+
 });

--- a/src/plugins/bar-graph/bar-graph-content.test.ts
+++ b/src/plugins/bar-graph/bar-graph-content.test.ts
@@ -57,7 +57,9 @@ describe("Bar Graph Content", () => {
 Object {
   "dataSetId": undefined,
   "primaryAttribute": undefined,
+  "primaryAttributeColor": "black",
   "secondaryAttribute": undefined,
+  "secondaryAttributeColorMap": Object {},
   "type": "BarGraph",
   "yAxisLabel": "Counts",
 }
@@ -282,6 +284,20 @@ Object {
 
     content.setSecondaryAttribute("att-s");
     expect(content.maxDataValue).toBe(2);
+  });
+
+  it("sets the primary attribute color", () => {
+    const content = TestingBarGraphContentModel.create({ });
+    content.setPrimaryAttributeColor("cerulean");
+    expect(content.primaryAttributeColor).toBe("cerulean");
+  });
+
+  it("sets a secondary attribute key's color", () => {
+    const content = TestingBarGraphContentModel.create({ });
+    content.setSecondaryAttributeKeyColor("key1", "obsidian");
+    content.setSecondaryAttributeKeyColor("key2", "veridian");
+    expect(content.secondaryAttributeColorMap.get("key1")).toBe("obsidian");
+    expect(content.secondaryAttributeColorMap.get("key2")).toBe("veridian");
   });
 
 });

--- a/src/plugins/bar-graph/bar-graph-content.ts
+++ b/src/plugins/bar-graph/bar-graph-content.ts
@@ -1,5 +1,6 @@
-import { types, Instance } from "mobx-state-tree";
+import { getSnapshot, types, Instance } from "mobx-state-tree";
 import { isObject } from "lodash";
+import stringify from "json-stringify-pretty-compact";
 import { ITileContentModel, TileContentModel } from "../../models/tiles/tile-content";
 import { kBarGraphTileType, kBarGraphContentType, BarInfo } from "./bar-graph-types";
 import { getSharedModelManager } from "../../models/tiles/tile-environment";
@@ -7,6 +8,7 @@ import { SharedDataSet, SharedDataSetType } from "../../models/shared/shared-dat
 import { clueDataColorInfo } from "../../utilities/color-utils";
 import { keyForValue } from "./bar-graph-utils";
 import { SharedModelType } from "../../models/shared/shared-model";
+import { ITileExportOptions } from "../../models/tiles/tile-content-info";
 
 export function defaultBarGraphContent(): BarGraphContentModelType {
   return BarGraphContentModel.create({yAxisLabel: "Counts"});
@@ -27,6 +29,10 @@ export const BarGraphContentModel = TileContentModel
     secondaryAttributeColorMap: types.optional(types.map(types.string), {}),
   })
   .views(self => ({
+    exportJson(options?: ITileExportOptions) {
+      const snapshot = getSnapshot(self);
+      return stringify(snapshot, {maxLength: 200});
+    },
     get sharedModel() {
       const sharedModelManager = self.tileEnv?.sharedModelManager;
       const firstSharedModel = sharedModelManager?.getTileSharedModelsByType(self, SharedDataSet)?.[0];

--- a/src/plugins/bar-graph/bar-graph.scss
+++ b/src/plugins/bar-graph/bar-graph.scss
@@ -1,5 +1,8 @@
 @import "../../components/vars.sass";
 
+$color-button-hover: rgba(20, 244, 158, .25); // 25% #14f49e
+$color-button-active: rgba(20, 244, 158, .5); // 50% #14f49e
+
 .bar-graph-content {
   width: 100%;
   height: 100%;
@@ -32,7 +35,7 @@
   div.bar-graph-legend {
     height: 100%;
     width: 186px;
-    border-left: 1.5px solid #0592af;
+    border-left: 1.5px solid $workspace-teal;
     padding: 0 10px 0 5px;
     overflow: auto;
     text-align: left;
@@ -75,20 +78,74 @@
       margin: 5px 0 5px 5px;
       align-items: center;
 
-      .color-button {
-        width: 26px;
+      button, button.chakra-menu__menu-button {
+        background: transparent;
+        border: none;
+        border-radius: 0;
         height: 26px;
         margin: 0 7px 0 0;
+        width: 26px;
+
+        &> span { min-width: 26px; }
+      }
+
+      .color-button {
+        cursor: pointer;
+        width: 26px;
+        height: 26px;
+        margin: 0;
         padding: 5px;
         background-color: $workspace-teal-light-8;
         border-radius: 5px;
-        border: solid 1.5px #949494;
+        border: solid 1.5px $charcoal-light-1;
+        pointer-events: auto;
+
+        &:hover {
+          background: $color-button-hover;
+        }
+        &:active, &:focus {
+          background: $color-button-active;
+        }
 
         .color-swatch {
           border: 1px solid black;
+          outline: 2px solid white;
           width: 100%;
           height: 100%;
           margin: 0;
+        }
+      }
+
+      .color-menu-list {
+        .color-menu-list-item {
+          background: white;
+          height: 24px;
+          margin: 0;
+          padding: 0;
+          width: 24px;
+
+          .color-button {
+            background: white;
+            border: none;
+            border-radius: 0;
+            height: 24px;
+            margin: 0;
+            padding: 0;
+            width: 24px;
+
+            .color-swatch {
+              height: 12px;
+              margin: 6px;
+              width: 12px;
+            }
+
+            &:hover {
+              background: $color-button-hover;
+            }
+            &:active, &:focus {
+              background: $color-button-active;
+            }
+          }
         }
       }
 
@@ -105,7 +162,7 @@
     div.bar-graph-legend {
       width: 100%;
       height: auto;
-      border-top: 1.5px solid #0592af;
+      border-top: 1.5px solid $workspace-teal;
       border-left: none;
       padding: 8px 0 0 0;
 
@@ -132,6 +189,12 @@
         display: flex;
         flex-wrap: wrap;
         margin-left: 8px;
+
+        .secondary-value {
+          button.chakra-menu__menu-button {
+            margin-right: 14px;
+          }
+        }
 
         .color-button {
           margin: 0 7px 0 7px;
@@ -168,6 +231,5 @@
     }
 
   }
-
 }
 

--- a/src/plugins/bar-graph/chart-area.tsx
+++ b/src/plugins/bar-graph/chart-area.tsx
@@ -6,6 +6,7 @@ import { Group } from "@visx/group";
 import { scaleBand, scaleLinear } from "@visx/scale";
 import { Bar, BarGroup } from "@visx/shape";
 import { PositionScale } from "@visx/shape/lib/types";
+import { getSnapshot } from "@concord-consortium/mobx-state-tree";
 import { useBarGraphModelContext } from "./bar-graph-content-context";
 import { CategoryPulldown } from "./category-pulldown";
 import EditableAxisLabel from "./editable-axis-label";
@@ -49,7 +50,10 @@ export const ChartArea = observer(function BarGraphChart({ width, height }: IPro
 
   function barColor(key: string) {
     if (!model) return "black";
-    return model.getColorForSecondaryKey(key);
+
+    return model.secondaryAttribute
+      ? model.getColorForSecondaryKey(key)
+      : model.primaryAttributeColor;
   }
 
   // Count cases and make the data array
@@ -125,10 +129,16 @@ export const ChartArea = observer(function BarGraphChart({ width, height }: IPro
   }
 
   function groupedBars() {
+    // generate a unique value from the color map to force a re-render when the map changes
+    const colorMapKey = model?.secondaryAttributeColorMap?.size
+      ? JSON.stringify(getSnapshot(model.secondaryAttributeColorMap))
+      : "no-color-map";
+
     return (
       <BarGroup
         data={data}
         color={barColor}
+        key={colorMapKey}
         keys={secondaryKeys}
         height={yMax}
         x0={(d) => d[primary] as string}

--- a/src/plugins/bar-graph/chart-area.tsx
+++ b/src/plugins/bar-graph/chart-area.tsx
@@ -12,6 +12,7 @@ import { CategoryPulldown } from "./category-pulldown";
 import EditableAxisLabel from "./editable-axis-label";
 import { displayValue, logBarGraphEvent, roundTo5 } from "./bar-graph-utils";
 import { BarInfo } from "./bar-graph-types";
+import { clueDataColorInfo } from "../../utilities/color-utils";
 
 const margin = {
   top: 7,
@@ -49,11 +50,11 @@ export const ChartArea = observer(function BarGraphChart({ width, height }: IPro
   }
 
   function barColor(key: string) {
-    if (!model) return "black";
+    if (!model) return "blue";
 
     return model.secondaryAttribute
-      ? model.colorForSecondaryKey(key)
-      : model.primaryAttributeColor;
+      ? clueDataColorInfo[model.colorForSecondaryKey(key)].color
+      : clueDataColorInfo[model.primaryAttributeColor].color;
   }
 
   // Count cases and make the data array

--- a/src/plugins/bar-graph/chart-area.tsx
+++ b/src/plugins/bar-graph/chart-area.tsx
@@ -52,7 +52,7 @@ export const ChartArea = observer(function BarGraphChart({ width, height }: IPro
     if (!model) return "black";
 
     return model.secondaryAttribute
-      ? model.getColorForSecondaryKey(key)
+      ? model.colorForSecondaryKey(key)
       : model.primaryAttributeColor;
   }
 

--- a/src/plugins/bar-graph/chart-area.tsx
+++ b/src/plugins/bar-graph/chart-area.tsx
@@ -50,7 +50,7 @@ export const ChartArea = observer(function BarGraphChart({ width, height }: IPro
   }
 
   function barColor(key: string) {
-    if (!model) return "blue";
+    if (!model) return clueDataColorInfo[0].color;
 
     return model.secondaryAttribute
       ? clueDataColorInfo[model.colorForSecondaryKey(key)].color

--- a/src/plugins/bar-graph/legend-secondary-row.tsx
+++ b/src/plugins/bar-graph/legend-secondary-row.tsx
@@ -17,14 +17,14 @@ export const LegendSecondaryRow = observer(function LegendSecondaryRow ({attrVal
   const missingData = isMissingData(attrValue);
   const display = displayValue(attrValue);
   const backgroundColor = model.secondaryAttribute
-    ? model.colorForSecondaryKey(attrValue)
-    : model.primaryAttributeColor;
+    ? clueDataColorInfo[model.colorForSecondaryKey(attrValue)].color
+    : clueDataColorInfo[model.primaryAttributeColor].color;
 
-  const handleColorSelect = (color: string) => {
+  const handleColorSelect = (colorIndex: number) => {
     if (model.secondaryAttribute) {
-      model.setSecondaryAttributeKeyColor(attrValue, color);
+      model.setSecondaryAttributeKeyColor(attrValue, colorIndex);
     } else {
-      model.setPrimaryAttributeColor(color);
+      model.setPrimaryAttributeColor(colorIndex);
     }
   };
 
@@ -48,12 +48,12 @@ export const LegendSecondaryRow = observer(function LegendSecondaryRow ({attrVal
           gridTemplateColumns="repeat(2, 1fr)"
           zIndex={1}
         >
-          {Object.entries(clueDataColorInfo).map(([key, value]) => (
+          {Object.entries(clueDataColorInfo).map(([key, value], index) => (
             <MenuItem
               className="color-menu-list-item"
               data-testid="color-menu-list-item"
               key={key}
-              onClick={() => handleColorSelect(value.color)}
+              onClick={() => handleColorSelect(index)}
             >
               <div className="color-button">
                 <div className="color-swatch" style={{ backgroundColor: value.color }} />

--- a/src/plugins/bar-graph/legend-secondary-row.tsx
+++ b/src/plugins/bar-graph/legend-secondary-row.tsx
@@ -17,7 +17,7 @@ export const LegendSecondaryRow = observer(function LegendSecondaryRow ({attrVal
   const missingData = isMissingData(attrValue);
   const display = displayValue(attrValue);
   const backgroundColor = model.secondaryAttribute
-    ? model.getColorForSecondaryKey(attrValue)
+    ? model.colorForSecondaryKey(attrValue)
     : model.primaryAttributeColor;
 
   const handleColorSelect = (color: string) => {

--- a/src/plugins/bar-graph/legend-secondary-row.tsx
+++ b/src/plugins/bar-graph/legend-secondary-row.tsx
@@ -1,29 +1,71 @@
 import React from 'react';
 import classNames from 'classnames';
+import { observer } from 'mobx-react';
+import { Button, Menu, MenuButton, MenuItem, MenuList } from '@chakra-ui/react';
 import { useBarGraphModelContext } from './bar-graph-content-context';
 import { displayValue, isMissingData } from './bar-graph-utils';
+import { clueDataColorInfo } from '../../utilities/color-utils';
 
 interface IProps {
   attrValue: string;
 }
 
-export function LegendSecondaryRow({attrValue}: IProps) {
+export const LegendSecondaryRow = observer(function LegendSecondaryRow ({attrValue}: IProps) {
   const model = useBarGraphModelContext();
   if (!model) return null;
 
   const missingData = isMissingData(attrValue);
   const display = displayValue(attrValue);
+  const backgroundColor = model.secondaryAttribute
+    ? model.getColorForSecondaryKey(attrValue)
+    : model.primaryAttributeColor;
+
+  const handleColorSelect = (color: string) => {
+    if (model.secondaryAttribute) {
+      model.setSecondaryAttributeKeyColor(attrValue, color);
+    } else {
+      model.setPrimaryAttributeColor(color);
+    }
+  };
 
   return (
     <div key={attrValue} className="secondary-value">
-      <div className="color-button">
-        <div className="color-swatch" style={{ backgroundColor: model.getColorForSecondaryKey(attrValue) }} />
-      </div>
+      <Menu placement="auto">
+        <MenuButton as={Button} unstyle="true" data-testid="color-menu-button">
+          <div className="color-button">
+            <div className="color-swatch" style={{ backgroundColor }} />
+          </div>
+        </MenuButton>
+        <MenuList
+          bg="white"
+          border="none"
+          borderRadius="5px"
+          boxShadow="0 0 5px 0 rgba(0, 0, 0, 0.35)"
+          className="color-menu-list"
+          data-testid="color-menu-list"
+          display="grid"
+          gap={0}
+          gridTemplateColumns="repeat(2, 1fr)"
+        >
+          {Object.entries(clueDataColorInfo).map(([key, value]) => (
+            <MenuItem
+              className="color-menu-list-item"
+              data-testid="color-menu-list-item"
+              key={key}
+              onClick={() => handleColorSelect(value.color)}
+            >
+              <div className="color-button">
+                <div className="color-swatch" style={{ backgroundColor: value.color }} />
+              </div>
+            </MenuItem>
+          ))}
+        </MenuList>
+      </Menu>
       <div className={classNames("secondary-value-name", { missing: missingData })}>
         {display}
       </div>
     </div>
   );
-}
+});
 
 export default LegendSecondaryRow;

--- a/src/plugins/bar-graph/legend-secondary-row.tsx
+++ b/src/plugins/bar-graph/legend-secondary-row.tsx
@@ -46,6 +46,7 @@ export const LegendSecondaryRow = observer(function LegendSecondaryRow ({attrVal
           display="grid"
           gap={0}
           gridTemplateColumns="repeat(2, 1fr)"
+          zIndex={1}
         >
           {Object.entries(clueDataColorInfo).map(([key, value]) => (
             <MenuItem

--- a/src/utilities/color-utils.ts
+++ b/src/utilities/color-utils.ts
@@ -38,7 +38,12 @@ export const clueDataColorInfo: ClueColor[] = [
   { color: clueDataColors.dataRed, name: "red" },
   { color: clueDataColors.dataYellow, name: "yellow" },
   { color: clueDataColors.dataPurple, name: "purple" },
-  { color: clueDataColors.dataIndigo, name: "indigo" }
+  { color: clueDataColors.dataIndigo, name: "indigo" },
+  { color: clueDataColors.dataWhite, name: "white" },
+  { color: clueDataColors.dataPeach, name: "peach" },
+  { color: clueDataColors.dataGray, name: "gray" },
+  { color: clueDataColors.dataBrown, name: "brown" },
+  { color: clueDataColors.dataBlack, name: "black" }
 ];
 
 /*


### PR DESCRIPTION
[#188212464](https://www.pivotaltracker.com/story/show/188212464)

Adds a color picker option to the Bar Graph component's color legend. Clicking a legend color brings up a color palette from which the user can change the associated bars' color.

The menu placement differs from the spec in that it's automatically placed so it isn't cropped by the container, which would happen if the menu was always placed below its associated button. Also, offline discussion determined that it's desirable to allow a color to be used more than once. However, when automatically adding new colors, we should try to avoid duplication.

Also adds an `exportJson` view to `BarGraphContentModel` for export/authoring.