### PR TITLE
fix: History is showing "0" for January dates [PT-188788349]

### DIFF
--- a/src/components/playback/playback-control.tsx
+++ b/src/components/playback/playback-control.tsx
@@ -106,7 +106,7 @@ export const PlaybackControlComponent: React.FC<IProps> = observer((props: IProp
                       6: "Jul", 7: "Aug", 8: "Sep", 9: "Oct", 10: "Nov", 11: "Dec"};
     const date = eventCreatedTime;
     const month = date?.getMonth();
-    const monthStr = month && monthMap[month];
+    const monthStr = month !== undefined ? monthMap[month] : "";
     const dateDay = date?.getDate();
     const year = date?.getFullYear();
     let hours = date?.getHours();


### PR DESCRIPTION
This fixes a bug in the playback control that showed "0" instead of "Jan" when the edit date was in January.