### PR TITLE
handle special numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "postinstall": "patch-package",
     "serve": "npx serve -c ../serve.json -l 8080 dist",
     "start": "webpack-dev-server --hot",
-    "start:secure": "webpack-dev-server --https --hot --cert ~/.localhost-ssl/localhost.pem --key ~/.localhost-ssl/localhost.key",
+    "start:secure": "webpack-dev-server --server-type https --hot --server-options-cert ~/.localhost-ssl/localhost.pem --server-options-key ~/.localhost-ssl/localhost.key",
     "stats": "webpack --profile --json --mode production > stats.json",
     "test": "jest",
     "test:all": "npm-run-all build test start",

--- a/src/models/json-number.test.ts
+++ b/src/models/json-number.test.ts
@@ -1,0 +1,70 @@
+import { SnapshotIn, types, getSnapshot } from "mobx-state-tree";
+import { JsonNumber } from "./json-number";
+
+const TestObject = types.model("TestObject", {
+  numProp: JsonNumber
+})
+.actions(self => ({
+  setNumProp(value: string | number) {
+    // This is a weird feature of MST where a value can be set as either a
+    // snapshot or the actual value
+    self.numProp = value as number;
+  }
+}));
+interface TestObjectSnapshot extends SnapshotIn<typeof TestObject> {}
+
+function roundTripObject(initialSnapshot: TestObjectSnapshot) {
+  const line = TestObject.create(initialSnapshot);
+  const savedSnapshot = getSnapshot(line);
+  const savedJson = JSON.stringify(savedSnapshot);
+  const loadedSnapshot = JSON.parse(savedJson);
+  return TestObject.create(loadedSnapshot);
+}
+
+describe("JsonNumber", () => {
+  it("serializes NaN", () => {
+    const obj1 = roundTripObject({numProp: NaN});
+    expect(obj1.numProp).toBe(NaN);
+
+    const obj2 = roundTripObject({numProp: "NaN"});
+    expect(obj2.numProp).toBe(NaN);
+  });
+  it("serializes Infinity", () => {
+    const obj1 = roundTripObject({numProp: Infinity});
+    expect(obj1.numProp).toBe(Infinity);
+
+    const obj2 = roundTripObject({numProp: "Infinity"});
+    expect(obj2.numProp).toBe(Infinity);
+  });
+  it("serializes -Infinity", () => {
+    const obj1 = roundTripObject({numProp: -Infinity});
+    expect(obj1.numProp).toBe(-Infinity);
+
+    const obj2 = roundTripObject({numProp: "-Infinity"});
+    expect(obj2.numProp).toBe(-Infinity);
+  });
+  it("serializes finite numbers as numbers", () => {
+    const obj = TestObject.create({numProp: 5});
+    const snapshot = getSnapshot(obj);
+    expect(snapshot.numProp).not.toBe("5");
+    expect(snapshot.numProp).toBe(5);
+  });
+  it("loads string numbers", () => {
+    // This isn't required but is nice in case a string number ends up in
+    // the JSON
+    const obj = roundTripObject({numProp: "5" as unknown as number});
+    expect(obj.numProp).toBe(5);
+  });
+  it("loads null values", () => {
+    // This isn't required but it is nice that old documents will not completely crash if loaded
+    // with a null value
+    const obj = roundTripObject({numProp: null as unknown as number});
+    expect(obj.numProp).toBe(NaN);
+  });
+  it("converts value on assignment", () => {
+    const obj = TestObject.create({numProp: 1});
+    expect(obj.numProp).toBe(1);
+    obj.setNumProp("NaN");
+    expect(obj.numProp).toBe(NaN);
+  });
+});

--- a/src/models/json-number.ts
+++ b/src/models/json-number.ts
@@ -1,0 +1,44 @@
+import { types } from "mobx-state-tree";
+
+type SpecialNumbers = "NaN" | "Infinity" | "-Infinity";
+
+/**
+ * This custom MST type handles NaN, Infinity, and -Infinity better than the built in
+ * `type.number`
+ * When NaN, Infinity, or -Infinity are stored in a `types.number` field,
+ * JSON.stringify(getSnapshot(obj)) will turn these values into `null`.
+ * This custom type turns those values into strings so they can be stored JSON.
+ *
+ * The typescript typing will only allow you to pass a number or "NaN", "Infinity", or "-Infinity"
+ * as a value in a snapshot. However at runtime stringified numbers will be handled too.
+ * Additionally if the value is null at runtime this will be turned in NaN.
+ */
+export const JsonNumber = types.custom<SpecialNumbers | number, number>({
+  name: "StringifiedNumber",
+  fromSnapshot(snapshot: SpecialNumbers | number, env?: any): number {
+    // Handle legacy values. In some cases a user might want to customize
+    // how null is handled. By default `Number(null)` returns 0
+    // If you want null to be invalid, change getValidationMessage
+    if (snapshot === null) {
+      return NaN;
+    }
+    return Number(snapshot);
+  },
+  toSnapshot(value: number): SpecialNumbers | number {
+    if (!isFinite(value)) {
+      return value.toString() as SpecialNumbers;
+    }
+    return value;
+  },
+  isTargetType(value: string | number): boolean {
+    return typeof value === "number";
+  },
+  getValidationMessage(snapshot: number | string): string {
+    const parsed = Number(snapshot);
+    if (isNaN(parsed) && snapshot !== "NaN") {
+      return `'${snapshot}' can't be parsed as a number`;
+    } else {
+      return "";
+    }
+  }
+});

--- a/src/plugins/graph/adornments/movable-line/movable-line-model.test.ts
+++ b/src/plugins/graph/adornments/movable-line/movable-line-model.test.ts
@@ -125,6 +125,12 @@ describe("MovableLineInstance", () => {
     const line = roundTripLine({intercept: 1, slope: "5" as unknown as number});
     expect(line.slope).toBe(5);
   });
+  it("can handle null slopes", () => {
+    // This isn't ideal but it is nice that old documents will not completely crash if loaded
+    // with a null slope
+    const line = roundTripLine({intercept: 1, slope: null as unknown as number});
+    expect(line.slope).toBe(NaN);
+  });
 });
 
 describe("MovableLineModel", () => {

--- a/src/plugins/graph/adornments/movable-line/movable-line-model.ts
+++ b/src/plugins/graph/adornments/movable-line/movable-line-model.ts
@@ -8,6 +8,7 @@ import { kMovableLineType } from "./movable-line-types";
 import { IGraphModel } from "../../models/graph-model";
 import { IClueTileObject } from "../../../../models/annotations/clue-object";
 import { uniqueId } from "../../../../utilities/js-utils";
+import { JsonNumber } from "../../../../models/json-number";
 
 export function getAnnotationId(lineKey: string, type: "handle"|"equation", position?: "lower"|"upper") {
   if (position) {
@@ -16,39 +17,6 @@ export function getAnnotationId(lineKey: string, type: "handle"|"equation", posi
     return `movable_line_${type}:${lineKey}`;
   }
 }
-
-// This custom type handles NaN, Infinity, and -Infinity
-// When NaN, Infinity, or -Infinity are stored in a `types.number` field,
-// JSON.stringify(getSnapshot(obj)) will turn then into `null`.
-// This custom type turns those values into strings so they can be stored
-// in JSON.
-// Note: even though typescript will only allow the following strings in
-// snapshots, the code will correctly import a stringified number too.
-type SpecialNumbers = "NaN" | "Infinity" | "-Infinity"
-
-export const JsonNumber = types.custom<SpecialNumbers | number, number>({
-  name: "StringifiedNumber",
-  fromSnapshot(snapshot: SpecialNumbers | number, env?: any): number {
-    return Number(snapshot);
-  },
-  toSnapshot(value: number): SpecialNumbers | number {
-    if (!isFinite(value)) {
-      return value.toString() as SpecialNumbers;
-    }
-    return value;
-  },
-  isTargetType(value: string | number): boolean {
-    return typeof value === "number";
-  },
-  getValidationMessage(snapshot: number | string): string {
-    const parsed = Number(snapshot);
-    if (isNaN(parsed) && snapshot !== "NaN") {
-      return `'${snapshot}' can't be parsed as a number`;
-    } else {
-      return "";
-    }
-  }
-});
 
 export const MovableLineInstance = types.model("MovableLineInstance", {
   equationCoords: types.maybe(PointModel),


### PR DESCRIPTION
This adds a JsonNumber type which serializes NaN, Infinity, and -Infinity as strings.
This makes the javascript number type safe to serialize with MST.

It fixes a bug where vertical lines with Infinity slope were not round tripping.