### PR TITLE
Add URL param that links to point in document history

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ There are a number of URL parameters that can aid in testing:
 |`noPersistentUI`|none                     |Do not initialize persistent ui store.|
 |`researcher`    |`true`                   |When set to true the user authenticates as a researcher|
 |`studentDocument`|string                  |If set to the ID of a document, this will be displayed as the left-side content.|
+|`studentDocumentHistoryId`|string         |Open the history slider and move to the specified revision in the `studentDocument`.|
 
 The `unit` parameter can be in 3 forms:
 

--- a/cypress/e2e/functional/teacher_tests/teacher_student_work_spec.js
+++ b/cypress/e2e/functional/teacher_tests/teacher_student_work_spec.js
@@ -1,6 +1,7 @@
 import ClueCanvas from '../../../support/elements/common/cCanvas';
 import TextToolTile from '../../../support/elements/tile/TextToolTile';
 import ResourcesPanel from '../../../support/elements/common/ResourcesPanel';
+import { LogEventName } from "../../../../src/lib/logger-types";
 
 const studentQueryParams = `${Cypress.config("qaUnitStudent5")}`;
 const teacherQueryParams = `${Cypress.config("qaUnitTeacher6")}`;
@@ -12,10 +13,13 @@ const resourcesPanel = new ResourcesPanel;
 function beforeTest(params) {
   cy.visit(params);
   cy.waitForLoad();
-  cy.openTopTab("problems");
+  cy.window().then(win => {
+    cy.stub(win.ccLogger, "log").as("log");
+  });
 }
 
-const sampleText = "Text for studentDocument view test";
+const initialText = "Initial text for studentDocument view test";
+const additionalText = "Added after the history checkpoint";
 
 // This URL parameter is usually used by researchers, but works for teachers as well
 context('Teacher can use studentDocument URL parameter', () => {
@@ -23,30 +27,73 @@ context('Teacher can use studentDocument URL parameter', () => {
     cy.log('Log in as student and put content into problem document');
     beforeTest(studentQueryParams);
     clueCanvas.addTile('text');
-    textToolTile.enterText(sampleText);
-    textToolTile.getTextTile().last().should('contain', sampleText);
+
+    cy.get("@log")
+    .should("have.been.been.calledWith", LogEventName.CREATE_TILE, Cypress.sinon.match.object)
+    .its("lastCall.args.1")
+      .should("include", { objectType: "Text" })
+      .should("not.have.keys", "documentHistoryId");
+
+    textToolTile.enterText(initialText);
+    textToolTile.getTextTile().last().should('contain', initialText);
     // Click outside the text area to save the text
     clueCanvas.getPlaceHolder().first().click();
+
     // Store the ID of the document for later use
     clueCanvas.getSingleWorkspaceDocumentContent().invoke('attr', 'data-document-key').then((documentId) => {
       cy.log(`Document ID: ${documentId}`);
       cy.wrap(documentId).as('documentId').should('not.be.undefined');
     });
+
+    // We want the history entry after initial text has been added.
+    // That will be logged as part of the NEXT event.
+    textToolTile.enterText(' ');
+    clueCanvas.getPlaceHolder().first().click();
+
+    // Hold onto the document history ID at this point for later
+    cy.get("@log")
+    .should("have.been.calledWith", LogEventName.TEXT_TOOL_CHANGE, Cypress.sinon.match.object)
+    .its("lastCall.args.1")
+      .should("include.keys", "documentKey", "documentHistoryId")
+      .then((args) => {
+        cy.wrap(args.documentHistoryId).as('documentHistoryId').should('not.be.undefined');
+      });
+
+    // Make additional changes after that point in the history
+    textToolTile.enterText(additionalText);
+
     cy.wait(1000); // Give some time for the document to save
 
     cy.log('Log in as teacher and view student work');
-    cy.get('@documentId').then((id) => {
-      expect(id).to.not.be.undefined;
-      cy.visit(teacherQueryParams + '&studentDocument=' + id);
+    cy.get('@documentId').then((docId) => {
+      expect(docId).to.not.be.undefined;
+      cy.visit(teacherQueryParams + '&studentDocument=' + docId);
       cy.waitForLoad();
 
       resourcesPanel.getPrimaryWorkspaceTab('student-work').should('have.class', 'selected');
       resourcesPanel.getEditableDocumentContent()
-        .should('have.attr', 'data-document-key', id)
+        .should('have.attr', 'data-document-key', docId)
         .should('have.class', 'read-only')
-        .should('contain', sampleText);
+        .should('contain', initialText)
+        .should('contain', additionalText);
     });
 
+    cy.log('Log in as teacher with history ID');
+    cy.get('@documentId').then((docId) => {
+      cy.get('@documentHistoryId').then((docHistoryId) => {
+        expect(docId).to.not.be.undefined;
+        expect(docHistoryId).to.not.be.undefined;
+        cy.visit(teacherQueryParams + '&studentDocument=' + docId + "&studentDocumentHistoryId=" + docHistoryId);
+        cy.waitForLoad();
+
+        resourcesPanel.getPrimaryWorkspaceTab('student-work').should('have.class', 'selected');
+        resourcesPanel.getEditableDocumentContent()
+          .should('have.attr', 'data-document-key', docId)
+          .should('have.class', 'read-only')
+          .should('contain', initialText)
+          .should('not.contain', additionalText);
+      });
+    });
   });
 
 });

--- a/docs/firestore-schema.md
+++ b/docs/firestore-schema.md
@@ -75,6 +75,12 @@ Fields:
 
 ### Contents of `documents/{docId}`
 
+Holds metadata, history, and comments related to a user Document.
+(The actual current Document content is not stored here, it is in Firebase.)
+Note that there can be multiple Firestore records for a single Document,
+with different networks. These are needed to hold comments that can only
+be read by members of the network of their authors.
+
 Fields:
 
 - key: (string, the id of the document in firebase)

--- a/src/components/document/canvas.tsx
+++ b/src/components/document/canvas.tsx
@@ -88,6 +88,10 @@ export class CanvasComponent extends BaseComponent<IProps, IState> {
   }
 
   componentDidMount(): void {
+    this.checkForHistoryRequest();
+  }
+
+  private checkForHistoryRequest = () => {
     // If there is a request to show this document at a point in its history, show the history slider.
     if (this.props.showPlayback && this.props.document?.key) {
       const request = this.stores.sortedDocuments.getDocumentHistoryViewRequest(this.props.document?.key);
@@ -100,7 +104,7 @@ export class CanvasComponent extends BaseComponent<IProps, IState> {
         });
       }
     }
-  }
+  };
 
   private fallbackRender = ({ error, resetErrorBoundary }: FallbackProps) => {
     return (
@@ -142,6 +146,7 @@ export class CanvasComponent extends BaseComponent<IProps, IState> {
         return this.updateHistoryDocument(prevState, prevState.showPlaybackControls);
       });
     }
+    this.checkForHistoryRequest();
   }
 
   componentWillUnmount() {

--- a/src/components/document/canvas.tsx
+++ b/src/components/document/canvas.tsx
@@ -47,6 +47,7 @@ interface IState {
   documentScrollY: number;
   historyDocumentCopy?: DocumentModelType;
   showPlaybackControls: boolean;
+  requestedHistoryId: string | undefined;
 }
 
 @inject("stores")
@@ -80,9 +81,25 @@ export class CanvasComponent extends BaseComponent<IProps, IState> {
       documentScrollX: 0,
       documentScrollY: 0,
       showPlaybackControls: false,
+      requestedHistoryId: undefined,
     };
 
     this.canvasMethods = { cacheObjectBoundingBox: this.cacheObjectBoundingBox };
+  }
+
+  componentDidMount(): void {
+    // If there is a request to show this document at a point in its history, show the history slider.
+    if (this.props.showPlayback && this.props.document?.key) {
+      const request = this.stores.sortedDocuments.getDocumentHistoryViewRequest(this.props.document?.key);
+      if (request) {
+        this.setState((prevState, props) => {
+          return {
+            ...this.updateHistoryDocument(prevState, true),
+            requestedHistoryId: request
+          };
+        });
+      }
+    }
   }
 
   private fallbackRender = ({ error, resetErrorBoundary }: FallbackProps) => {
@@ -205,6 +222,7 @@ export class CanvasComponent extends BaseComponent<IProps, IState> {
               document={documentToShow}
               showPlaybackControls={showPlaybackControls}
               onTogglePlaybackControls={this.handleTogglePlaybackControlComponent}
+              requestedHistoryId={this.state.requestedHistoryId}
             />
           )}
         </>

--- a/src/components/playback/playback.tsx
+++ b/src/components/playback/playback.tsx
@@ -1,9 +1,9 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Instance } from "mobx-state-tree";
 import { observer } from "mobx-react";
 import classNames from "classnames";
 import { usePersistentUIStore } from "../../hooks/use-stores";
-import { HistoryStatus, TreeManager } from "../../models/history//tree-manager";
+import { HistoryStatus, TreeManager } from "../../models/history/tree-manager";
 import { DocumentModelType } from "../../models/document/document";
 import { PlaybackControlComponent } from "./playback-control";
 import PlaybackIcon from "../../clue/assets/icons/playback/playback-icon.svg";
@@ -14,12 +14,19 @@ interface IProps {
   document: DocumentModelType | undefined;
   showPlaybackControls: boolean | undefined;
   onTogglePlaybackControls: (() => void) | undefined;
+  requestedHistoryId: string | undefined;
 }
 
 export const PlaybackComponent: React.FC<IProps> = observer((props: IProps) => {
   const { document, showPlaybackControls, onTogglePlaybackControls  } = props;
   const { activeNavTab } = usePersistentUIStore();
   const treeManager = document?.treeManagerAPI as Instance<typeof TreeManager>;
+
+  useEffect(() => {
+    if (props.requestedHistoryId) {
+      treeManager.moveToHistoryEntryAfterLoad(props.requestedHistoryId);
+    }
+  }, [props.requestedHistoryId, treeManager]);
 
   const renderPlaybackToolbarButton = () => {
     const playbackToolbarButtonComponentStyle =

--- a/src/initialize-app.tsx
+++ b/src/initialize-app.tsx
@@ -70,7 +70,8 @@ export const initializeApp = (authoring: boolean): IStores => {
 
   const appConfig = AppConfigModel.create(appConfigSnapshot);
   const stores = createStores(
-    { appMode, appVersion, appConfig, user, showDemoCreator, demoName, documentToDisplay: urlParams.studentDocument });
+    { appMode, appVersion, appConfig, user, showDemoCreator, demoName,
+      documentToDisplay: urlParams.studentDocument, documentHistoryId: urlParams.studentDocumentHistoryId });
 
   // Expose the stores if the debug flag is set or we are running in Cypress
   const aWindow = window as any;

--- a/src/models/document/log-document-event.ts
+++ b/src/models/document/log-document-event.ts
@@ -39,11 +39,8 @@ function processDocumentEventParams(params: IDocumentLogEvent, { user, portal }:
   // before or after the actual change to the document, this may be the history
   // entry that was current before the change, or the one that was created by the change.
   // For the first change in a new document, it may be undefined.
-  const documentHistory = "treeManagerAPI" in document
-    ? (document.treeManagerAPI as TreeManagerType)?.document.history
-    : undefined;
-  const documentHistoryId = documentHistory && documentHistory.length > 0
-    ? documentHistory[documentHistory.length - 1].id
+  const documentHistoryId = "treeManagerAPI" in document
+    ? (document.treeManagerAPI as TreeManagerType)?.latestDocumentHistoryEntry?.id
     : undefined;
 
   const teacherNetworkInfo: ITeacherNetworkInfo | undefined = isRemote

--- a/src/models/history/tree-manager.ts
+++ b/src/models/history/tree-manager.ts
@@ -98,6 +98,11 @@ export const TreeManager = types
     return self.document.history.findIndex(entry => entry.id === historyEntryId);
   },
 
+  get latestDocumentHistoryEntry() {
+    const history = self.document.history;
+    return history ? history[history.length - 1] : undefined;
+  },
+
   findActiveHistoryEntry(historyEntryId: string) {
     return self.activeHistoryEntries.find(entry => entry.id === historyEntryId);
   },

--- a/src/models/stores/sorted-documents.ts
+++ b/src/models/stores/sorted-documents.ts
@@ -273,8 +273,10 @@ export class SortedDocuments {
 
     const disposeFilteredListener = filteredQuery.onSnapshot(snapshot => {
       const mstSnapshot = this.getMSTSnapshotFromFBSnapshot(snapshot);
-      applySnapshot(this.metadataDocsFiltered, mstSnapshot);
-      this.docsReceived = true;
+      runInAction(() => {
+        applySnapshot(this.metadataDocsFiltered, mstSnapshot);
+        this.docsReceived = true;
+      });
     });
 
     let disposeDocsWithoutUnitListener: () => void | undefined;

--- a/src/models/stores/sorted-documents.ts
+++ b/src/models/stores/sorted-documents.ts
@@ -1,4 +1,4 @@
-import { autorun, makeAutoObservable, runInAction } from "mobx";
+import { makeAutoObservable, runInAction, when } from "mobx";
 import { types, Instance, SnapshotIn, applySnapshot, typecheck, unprotect } from "mobx-state-tree";
 import { union } from "lodash";
 import firebase from "firebase";
@@ -80,6 +80,8 @@ export class SortedDocuments {
   metadataDocsFiltered = MetadataDocMapModel.create();
   metadataDocsWithoutUnit = MetadataDocMapModel.create();
   docsReceived = false;
+  // Maps from document ID to the history entry ID that the user requested to view.
+  documentHistoryViewRequests: Record<string,string> = {};
 
   constructor(stores: ISortedDocumentsStores) {
     makeAutoObservable(this);
@@ -115,6 +117,20 @@ export class SortedDocuments {
   }
   get user() {
     return this.stores.user;
+  }
+
+  setDocumentHistoryViewRequest(docKey: string, historyId: string) {
+    this.documentHistoryViewRequests[docKey] = historyId;
+    console.log("setDocumentHistoryViewRequest", docKey, historyId);
+  }
+  getDocumentHistoryViewRequest(docKey: string) {
+    // We only want to move to this history entry once,
+    // so we delete the request after it has been fulfilled.
+    const historyId = this.documentHistoryViewRequests[docKey];
+    if (historyId) {
+      delete this.documentHistoryViewRequests[docKey];
+    }
+    return historyId;
   }
 
   sortBy(sortType: PrimarySortType): DocumentGroup[] {
@@ -356,15 +372,8 @@ export class SortedDocuments {
 
   async fetchFullDocument(docKey: string) {
     if (!this.docsReceived) {
-      // Wait until the initial documents have been received before trying to open a document.
-      await new Promise<void>(resolve => {
-        const disposer = autorun(() => {
-          if (this.docsReceived) {
-            disposer();
-            resolve();
-          }
-        });
-      });
+      // Wait until the initial batch of documents has been received from Firestore.
+      await when(() => this.docsReceived);
     }
     const metadataDoc = this.firestoreMetadataDocs.find(doc => doc.key === docKey);
     if (!metadataDoc) {

--- a/src/models/stores/sorted-documents.ts
+++ b/src/models/stores/sorted-documents.ts
@@ -121,7 +121,6 @@ export class SortedDocuments {
 
   setDocumentHistoryViewRequest(docKey: string, historyId: string) {
     this.documentHistoryViewRequests[docKey] = historyId;
-    console.log("setDocumentHistoryViewRequest", docKey, historyId);
   }
   getDocumentHistoryViewRequest(docKey: string) {
     // We only want to move to this history entry once,

--- a/src/models/stores/stores.ts
+++ b/src/models/stores/stores.ts
@@ -43,6 +43,7 @@ export interface IStores extends IBaseStores {
   userContextProvider: UserContextProvider;
   tabsToDisplay: NavTabModelType[];
   documentToDisplay?: string;
+  documentHistoryId?: string;
   isShowingTeacherContent: boolean;
   studentWorkTabSelectedGroupId: string | undefined;
   setAppMode: (appMode: AppMode) => void;
@@ -169,6 +170,10 @@ class Stores implements IStores{
     if (docToDisplay) {
       // Make sure there is a Sort Work tab to display the document in.
       this.appConfig.setRequireSortWorkTab(true);
+      // Set request for viewing at the given history ID, if provided
+      if (params.documentHistoryId) {
+        this.sortedDocuments.setDocumentHistoryViewRequest(docToDisplay, params.documentHistoryId);
+      }
       // Wait until the document is loaded, then open it.
       const docPromise = this.sortedDocuments.fetchFullDocument(docToDisplay);
       docPromise.then((doc) => {

--- a/src/utilities/url-params.ts
+++ b/src/utilities/url-params.ts
@@ -46,8 +46,9 @@ export interface QueryParams {
   reportType?: string;
   // set to string "true" to authenticate as a researcher
   researcher?: string;
-  // display a certain student document
+  // display a certain student document, optionally at a point in its history
   studentDocument?: string;
+  studentDocumentHistoryId?: string
 
   //
   // demo features


### PR DESCRIPTION
PT-188754092

Adds a `studentDocumentHistoryId` URL param that works in concert with `studentDocument`.

Adds a test for this.

Cleans up a few things from the studentDocument PR.
