### PR TITLE
Script to add missing metadata to docs

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,35 +1,40 @@
-# Local Setup
+# CLUE Offline Scripts
+
+## Local Setup
+
 For most scripts here you'll need Firebase credentials. You can get this by going to
-https://console.firebase.google.com/u/0/project/collaborative-learning-ec215/settings/serviceaccounts/adminsdk
+<https://console.firebase.google.com/u/0/project/collaborative-learning-ec215/settings/serviceaccounts/adminsdk>
 
 From that page if you click "Generate a new private key", it will download a json file. You should rename this file `serviceAccountKey.json` and move it to the the scripts folder.
 
 Most scripts can be run using `npx tsx <script filename>`
 
-# Running scripts that connect with the portal
+## Running scripts that connect with the portal
+
 You need to first get the portal admin api token.
 
 In 1Password you can find it in the Developer Admin vault under a "Learn Portal admin api user" entry.
 
 If the 1Password entry is out of date. You can also get it this way:
 You can follow these steps to get a console in the portal:
-https://docs.google.com/document/d/1dmAV4ojzwau2C-TANvoxw9jAnUN2F5FdOSSy6f42H84/edit#heading=h.l053izhapf0l
+<https://docs.google.com/document/d/1dmAV4ojzwau2C-TANvoxw9jAnUN2F5FdOSSy6f42H84/edit#heading=h.l053izhapf0l>
 Then look for the admin api user:
 `api_user = User.where(:login => "admin_api_user").first`
 `api_user.access_grants.first.access_token`
 
-This api user was probably created by this rake task: https://github.com/concord-consortium/rigse/blob/97a4bf3a2a911f88424b502361ae8dafd71d9823/rails/lib/tasks/api.rake#L18
+This api user was probably created by this rake task: <https://github.com/concord-consortium/rigse/blob/97a4bf3a2a911f88424b502361ae8dafd71d9823/rails/lib/tasks/api.rake#L18>
 
 This access token should be stored in a /scripts/.env file with:
-```
+
+```shell
 PORTAL_ACCESS_TOKEN=[token]
 ```
 
-# Running on Google Cloud Virtual Machine
+## Running on Google Cloud Virtual Machine
 
 It can be useful to offload the running of scripts to a virtual machine in Google Cloud. They will usually run faster there.
 
-1. Log in to Google Cloud at https://cloud.google.com/ and go to the Console.
+1. Log in to Google Cloud at <https://cloud.google.com/> and go to the Console.
 
 2. Click the Compute Engine option, then click "Create Instance".
 
@@ -57,7 +62,7 @@ It can be useful to offload the running of scripts to a virtual machine in Googl
 ## Possible Better Alternative
 
 It hasn't been tried, but it might be even better to use google cloud shell to run VSCode:
-- https://medium.com/google-cloud/how-to-run-visual-studio-code-in-google-cloud-shell-354d125d5748
+- <https://medium.com/google-cloud/how-to-run-visual-studio-code-in-google-cloud-shell-354d125d5748>
 
 The downside of doing that (I think) is any plugins you have in your local VSCode will have to be re-installed.
 It should also be possible to connect your local VSCode to the code-server described above. But I'm not sure if CloudShell will allow the external connection that your local VSCode will need.

--- a/scripts/find-documents-missing-metadata.ts
+++ b/scripts/find-documents-missing-metadata.ts
@@ -1,0 +1,152 @@
+#!/usr/bin/node
+
+// This script aims to fix certain documents that were created in Firestore with missing metadata.
+// The sympom is metadata documents that are missing their unit, investigation, and problem fields.
+// In at least some cases, there is another document with the same document key (but different network)
+// that has the correct metadata. This script will identify those documents and copy the metadata
+// to the document where it is missing.
+
+// Set dryRun to false below to actually make changes to the database.
+
+// to run this script type the following in the terminal
+// $ cd scripts
+// $ npx tsx find-documents-missing-metadata.ts
+
+import admin from "firebase-admin";
+import { getFirestoreBasePath, getScriptRootFilePath } from "./lib/script-utils.js";
+
+// The portal to get documents from. For example, "learn.concord.org".
+const portal = "learn.concord.org";
+// The demo name to use. Make falsy to not use a demo.
+// const demo = "CLUE";
+const demo = false;
+
+// Limit number of documents returned from query; or set to false to include all documents
+const documentLimit = 10;
+
+const dryRun = true;
+
+const should_match_fields = [ "context_id", "key", "title", "type" ];
+const fields_to_copy = [ "unit", "investigation", "problem" ];
+
+const databaseURL = "https://collaborative-learning-ec215.firebaseio.com";
+
+// Fetch the service account key JSON file contents
+const credential = admin.credential.cert(getScriptRootFilePath("serviceAccountKey.json"));
+// Initialize the app with a service account, granting admin privileges
+admin.initializeApp({
+  credential,
+  databaseURL
+});
+
+console.log(`*** Starting to Scan Documents ***`);
+
+const collectionUrl = getFirestoreBasePath(portal, demo);
+
+const documentCollection = admin.firestore().collection(collectionUrl);
+
+let documentQuery = documentCollection
+  // Omit document types that are not expected to be associated with a unit, investigation, and problem
+  .where("type", "not-in", ["personal", "personalPublication", "learningLog", "learningLogPublication"])
+  .where("unit", "==", null);
+
+if (documentLimit) {
+  documentQuery = documentQuery.limit(documentLimit);
+}
+
+const singles = new Set();
+const triplets = new Set();
+const pairs = new Set();
+const mismatchDocs = new Set();
+const fixableDocsByType = { "problem": 0, "problemPublication": 0, "planning": 0 };
+
+const promises = [];
+
+const documentSnapshots = await documentQuery.get();
+documentSnapshots.forEach(doc => {
+  const data = doc.data();
+  // console.log(`Document ${doc.ref.path}: ${data.type} unit: ${data.unit}`);
+  // Look for other documents with the same key
+  const key = data.key;
+  const keyQuery = documentCollection.where("key", "==", key);
+  const query = keyQuery.get().then(async snapshot => {
+    if (snapshot.size === 1) {
+      singles.add(key);
+    } else if (snapshot.size > 2) {
+      triplets.add(key);
+    } else if (snapshot.size === 2) {
+      if (!pairs.has(key)) {
+        pairs.add(key);
+        console.log(`Found ${snapshot.size} documents with key ${key}`);
+        console.log(`  ${snapshot.docs[0].ref.path} and ${snapshot.docs[1].ref.path}`);
+        let goodDoc, badDoc;
+        let badRef: admin.firestore.QueryDocumentSnapshot<admin.firestore.DocumentData>;
+        if (snapshot.docs[0].data().unit) {
+          goodDoc = snapshot.docs[0].data();
+          badDoc = snapshot.docs[1].data();
+          badRef = snapshot.docs[1];
+        } else if (snapshot.docs[1].data().unit) {
+          goodDoc = snapshot.docs[1].data();
+          badDoc = snapshot.docs[0].data();
+          badRef = snapshot.docs[0];
+        } else {
+          console.log(`   Neither document has metadata`);
+        }
+        if (goodDoc) {
+          // console.log("good doc", goodDoc);
+          // Make sure the main fields match in the two documents
+          let match = true;
+          should_match_fields.forEach(field => {
+            // Treat undefined and null as equivalent
+            const f1 = goodDoc[field] || null;
+            const f2 = badDoc[field] || null;
+            if (f1 !== f2) {
+              console.log(`      ${field} does not match: ${f1} != ${f2}`);
+              match = false;
+            }
+          });
+          // Make sure that the bad document has only nulls in all of the fields to copy
+          fields_to_copy.forEach(field => {
+            if (badDoc[field]) {
+              console.log(`      ${field} is not null: ${badDoc[field]}`);
+              match = false;
+            }
+          });
+          if (match) {
+            fixableDocsByType[goodDoc.type] += 1;
+            let logMsg = dryRun ? "    Would copy: " : "    Copy: ";
+            const updateDoc = { };
+            fields_to_copy.forEach(field => {
+              if (!dryRun) {
+                updateDoc[field] = goodDoc[field];
+              }
+              logMsg += ` ${field}: ${goodDoc[field]}  `;
+            });
+            if (dryRun) {
+              console.log(logMsg);
+            } else {
+              // Update the values in the bad document
+              await badRef.ref.set(updateDoc, { merge: true });
+              console.log(logMsg, "...done");
+            }
+          } else {
+            mismatchDocs.add(key);
+          }
+        }
+      }
+    }
+  });
+  promises.push(query);
+});
+
+await Promise.all(promises);
+console.log(`*** Finished Scanning Documents ***`);
+
+console.log(`Fixable documents:`);
+Object.entries(fixableDocsByType).forEach(([type, count]) => {
+  console.log(`  ${type}: ${count}`);
+});
+
+console.log(`Missing metadata but no other documents with the same key: ${singles.size}`);
+console.log(`Mismatched documents: ${mismatchDocs.size}`);
+console.log(`Triplets (or more): ${triplets.size}`);


### PR DESCRIPTION
PT-188784006

Script to address the symptom of this bug, which created (or perhaps still creates) documents without the unit, investigation, and problem fields. In at least some cases, there is another metadata doc with the same key, so we can copy these fields over.

Also fixes some lint warnings in the README.
