### PR TITLE
fix: Add missing researcher and target_user_id params to portal requests [PT-188754125]

### DIFF
--- a/docs/oauth2.md
+++ b/docs/oauth2.md
@@ -58,7 +58,7 @@ To enable researcher launches two additional parameters are sent to the portal w
 
 The `researcher=true` parameter causes the portal to skip the usual learner/teacher checks and instead checks if the user has access to the `target_user_id` user id as either an admin, project admin or researcher.  If the user does have access a JWT is generated with the `user_type` claim set to `researcher`.  CLUE then then uses the `researcher` user_type to alter the UI.
 
-Further requests to the portal for the class and offering information also pass the `researcher=true` parameter if it is set in the CLUE query params.  This overrides the portals anonymization check to alway anonymize the student info.  This is important as the user launching CLUE may have higher privileges like admin or project admin access to the user which normally would cause the student info to not be anonymized.
+Further requests to the portal for the class and offering information also pass the `researcher=true` parameter if it is set in the CLUE query params.  This overrides the portals anonymization check to always anonymize the student info.  This is important as the user launching CLUE may have higher privileges like admin or project admin access to the user which normally would cause the student info to not be anonymized.
 
 ## Tech Debt
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -16,6 +16,7 @@ import { uniqueId } from "../utilities/js-utils";
 import { getUnitCodeFromUnitParam } from "../utilities/url-utils";
 import { ICurriculumConfig } from "../models/stores/curriculum-config";
 import { ClassInfo, Portal, ResearcherUser, StudentUser, TeacherUser } from "../models/stores/portal";
+import { maybeAddResearcherParam } from "../utilities/researcher-param";
 
 export const PORTAL_JWT_URL_SUFFIX = "api/v1/jwt/portal";
 export const FIREBASE_JWT_URL_SUFFIX = "api/v1/jwt/firebase";
@@ -79,7 +80,7 @@ export const getPortalJWTWithBearerToken = (basePortalUrl: string, type: string,
       pageUrlParams.resourceLinkId ? `?resource_link_id=${ pageUrlParams.resourceLinkId }` : "";
     const url = `${basePortalUrl}${PORTAL_JWT_URL_SUFFIX}${resourceLinkIdSuffix}`;
     superagent
-      .get(url)
+      .get(maybeAddResearcherParam(url))
       .set("Authorization", `${type} ${rawToken}`)
       .end((err, res) => {
         if (err) {
@@ -109,8 +110,8 @@ export const getFirebaseJWTParams = (classHash?: string) => {
   if (pageUrlParams.resourceLinkId) {
     params.resource_link_id = pageUrlParams.resourceLinkId;
   }
-  if (pageUrlParams.researcher) {
-    params.researcher = pageUrlParams.researcher;
+  if (pageUrlParams.targetUserId) {
+    params.target_user_id = pageUrlParams.targetUserId;
   }
 
   return `?${(new URLSearchParams(params)).toString()}`;
@@ -121,7 +122,7 @@ export const getFirebaseJWTWithBearerToken = (basePortalUrl: string, type: strin
   return new Promise<[string, PortalFirebaseJWT]>((resolve, reject) => {
     const url = `${basePortalUrl}${FIREBASE_JWT_URL_SUFFIX}${getFirebaseJWTParams(classHash)}`;
     superagent
-      .get(url)
+      .get(maybeAddResearcherParam(url))
       .set("Authorization", `${type} ${rawToken}`)
       .end((err, res) => {
         if (err) {

--- a/src/lib/portal-api.ts
+++ b/src/lib/portal-api.ts
@@ -8,6 +8,7 @@ import { IUserPortalOffering, UserPortalOffering } from "../models/stores/user";
 import { IPortalOffering } from "./portal-types";
 import { getAuthParams } from "../utilities/auth-utils";
 import { ICurriculumConfig, getProblemOrdinal } from "../models/stores/curriculum-config";
+import { maybeAddResearcherParam } from "../utilities/researcher-param";
 
 const isClueAssignment = (offering: IPortalOffering) => {
   const clueActivityUrlRegex = /collaborative-learning/;
@@ -109,7 +110,7 @@ export const getProblemIdForAuthenticatedUser =
   return new Promise<IUnitAndProblem>((resolve, reject) => {
     if (urlParams && urlParams.offering) {
       superagent
-      .get(urlParams.offering)
+      .get(maybeAddResearcherParam(urlParams.offering))
       .set("Authorization", `Bearer/JWT ${rawPortalJWT}`)
       .end((err, res) => {
         if (err) {

--- a/src/models/stores/portal.ts
+++ b/src/models/stores/portal.ts
@@ -6,6 +6,7 @@ import { convertURLToOAuth2, getBearerToken } from "../../utilities/auth-utils";
 import { QueryParams, urlParams as pageUrlParams } from "../../utilities/url-params";
 import initials from "initials";
 import { IUserPortalOffering } from "./user";
+import { maybeAddResearcherParam } from "../../utilities/researcher-param";
 
 export const parseUrl = (url: string) => {
   const parser = document.createElement("a");
@@ -102,13 +103,13 @@ export class Portal {
       if (pageUrlParams.resourceLinkId) {
         params.append("resource_link_id", pageUrlParams.resourceLinkId);
       }
-      if (pageUrlParams.researcher) {
-        params.append("researcher", pageUrlParams.researcher);
+      if (pageUrlParams.targetUserId) {
+        params.append("target_user_id", pageUrlParams.targetUserId);
       }
       const queryString = params.size > 0 ? `?${params.toString()}` : "";
       const url = `${this.basePortalUrl}${PORTAL_JWT_URL_SUFFIX}${queryString}`;
       superagent
-        .get(url)
+        .get(maybeAddResearcherParam(url))
         .set("Authorization", `Bearer ${this.bearerToken}`)
         .end((err, res) => {
           if (err) {
@@ -177,7 +178,7 @@ export class Portal {
     const {classInfoUrl, rawPortalJWT, portalHost: portal, offeringId} = this;
     return new Promise<ClassInfo>((resolve, reject) => {
       superagent
-      .get(classInfoUrl)
+      .get(maybeAddResearcherParam(classInfoUrl))
       .set("Authorization", `Bearer/JWT ${rawPortalJWT}`)
       .end((err, res) => {
         if (err) {

--- a/src/utilities/researcher-param.ts
+++ b/src/utilities/researcher-param.ts
@@ -1,0 +1,15 @@
+import { urlParams } from "./url-params";
+
+export const isResearcher = () => urlParams.researcher === "true";
+
+export const maybeAddResearcherParam = (url: string): string => {
+  if (isResearcher()) {
+    const parsedUrl = new URL(url);
+    const queryParams = new URLSearchParams(parsedUrl.search);
+    queryParams.set("researcher", "true");
+    parsedUrl.search = queryParams.toString();
+    return parsedUrl.toString();
+  } else {
+    return url;
+  }
+};

--- a/src/utilities/url-params.ts
+++ b/src/utilities/url-params.ts
@@ -50,6 +50,9 @@ export interface QueryParams {
   studentDocument?: string;
   studentDocumentHistoryId?: string
 
+  // set to user id to target a specific user when logging in as a researcher
+  targetUserId?: string;
+
   //
   // demo features
   //


### PR DESCRIPTION
A utility function called maybeAddResearcherParam was added to add the researcher=true query param to portal api urls if it is set in the CLUE query parameters.  This ensures the portal anonymizes the student info even if the user has higher privileges than a researcher.

The target_user_id is also passed to the portal JWT and Firebase JWT calles if the targetUserId parameter is set in the CLUE query parameters.  This is needed for researchers to check if they have access to the user's information.