### PR TITLE
Prevent any interaction with Sparrows when not in Sparrow mode.

### DIFF
--- a/src/components/annotations/annotation-arrow.scss
+++ b/src/components/annotations/annotation-arrow.scss
@@ -20,7 +20,7 @@
       pointer-events: none;
 
       .annotation-layer.show-handles & {
-        pointer-events: visible;
+        pointer-events: visibleStroke;
       }
     }
 

--- a/src/components/document/annotation-layer.tsx
+++ b/src/components/document/annotation-layer.tsx
@@ -51,10 +51,12 @@ export const AnnotationLayer = observer(function AnnotationLayer({
   const hotKeys = useMemoOne(() => new HotKeys(), []);
   const shape: ArrowShape = isArrowShape(ui.annotationMode) ? ui.annotationMode : ArrowShape.curved;
 
+  const editing = ui.annotationMode !== undefined;
+
   // Buttons are active unless a straight sparrow is being drawn from an object
   const showButtons = !(shape === ArrowShape.straight && sourceObjectId);
-  // Drag handles are active unless any sort of sparrow is being drawn
-  const showDragHandles = !(sourceObjectId || sourcePoint);
+  // Drag handles are active while editing, unless any sort of sparrow is being drawn
+  const showDragHandles = editing && !(sourceObjectId || sourcePoint);
 
   useEffect(() => {
     const deleteSelected = () => content?.deleteSelected();
@@ -383,7 +385,6 @@ export const AnnotationLayer = observer(function AnnotationLayer({
   };
 
   const rowIds = content?.rowOrder || [];
-  const editing = ui.annotationMode !== undefined;
   const hidden = !persistentUI.showAnnotations;
   const classes = classNames("annotation-layer",
     { editing, hidden, 'show-buttons': showButtons, 'show-handles': showDragHandles });


### PR DESCRIPTION
PT-188582563

Disable interaction with the sparrows when not in sparrow mode.

When you _are_ in sparrow mode, also tweak CSS so that curved sparrow does not consider mouseover event for the area inside its curve - just the actual stroke path.

These changes make it much easier to interact with the content that is underneath the sparrow.
