### PR TITLE
create github deployment during release

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -11,4 +11,6 @@ jobs:
     with:
       version: ${{ inputs.version }}
       dest-file: index.html
+      environment: production
+      url: https://collaborative-learning.concord.org
     secrets: inherit

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -11,4 +11,6 @@ jobs:
     with:
       version: ${{ inputs.version }}
       dest-file: staging.html
+      environment: staging
+      url: https://collaborative-learning.concord.org/staging.html
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,14 @@ on:
         type: string
         description: The released file name for each index-top that is copied
         required: true
+      environment:
+        type: string
+        description: GitHub environment to send the deployment to
+        required: true
+      url:
+        type: string
+        description: URL to use for environment-url and log-url
+        required: true
 env:
   BUCKET: models-resources
   PREFIX: collaborative-learning
@@ -22,6 +30,14 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: us-east-1
     steps:
+      - uses: chrnorm/deployment-action@v2
+        name: Create GitHub deployment
+        id: deployment
+        with:
+          token: '${{ github.token }}'
+          environment-url: ${{ inputs.url }}
+          environment: ${{ inputs.environment }}
+          ref: ${{ inputs.version }}
       - run: >
           aws s3 cp
           s3://${{ env.BUCKET }}/${{ env.PREFIX }}/version/${{ inputs.version }}/${{ env.SRC_FILE }}
@@ -30,4 +46,21 @@ jobs:
           aws s3 cp
           s3://${{ env.BUCKET }}/${{ env.PREFIX }}/version/${{ inputs.version }}/editor/${{ env.SRC_FILE }}
           s3://${{ env.BUCKET }}/${{ env.PREFIX }}/editor/${{ inputs.dest-file }}
-
+      - name: Update deployment status (success)
+        if: success()
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ github.token }}'
+          environment-url: ${{ inputs.url }}
+          log-url: ${{ inputs.url }}
+          state: 'success'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+      - name: Update deployment status (failure)
+        if: failure()
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ github.token }}'
+          environment-url: ${{ inputs.url }}
+          log-url: ${{ inputs.url }}
+          state: 'failure'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}


### PR DESCRIPTION
We are already creating GitHub deployments when branches and versions are deployed by the s3-deploy-action.
Before this PR we were not creating GitHub deployments for staging and production releases.
The first release run with this code was `5.20.0`. It did create a deployment:
https://github.com/concord-consortium/collaborative-learning/deployments

The versions and branches deployments are created with a simple `environment` section in the workflow:
https://github.com/concord-consortium/collaborative-learning/blob/81632f12fe9ae69ee5cd85e3a68699e389d3ea42/.github/workflows/ci.yml#L135-L137

This environment section was not used for the release for two reasons:
1. As far as I know it would require checking out the tag that is being deployed. Our deployment process just copies some s3 files around it doesn't need any info from the repository itself other than the workflow file.
2. In order for Jira to have a nice link to the deployed code we need to specify the `log_url` in the deployment status. The environment section approach does not provide a way to do that.

This makes the configuration more complex. The https://github.com/chrnorm/deployment-action and https://github.com/chrnorm/deployment-status actions are used to create and update the deployment. These actions are recommended by Jira. 

It also seems to mean that the deployment is not connected with the workflow run that is doing the deployment. 
- Here is an example of a version workflow run. It includes the environment_url in the summary of the workflow run:
https://github.com/concord-consortium/collaborative-learning/actions/runs/13664554397
- Here is the workflow run for the production release of 5.20.0. It does not have a link to the deployment:
https://github.com/concord-consortium/collaborative-learning/actions/runs/13668263833

This deployment didn't show in Jira, but I suspect the next one will. 
See https://docs.google.com/document/d/16TynVQr-_umf99V9uQNhqQsv9wW8C4h5xltlmZmbVHg/edit?tab=t.0 for more information about deployments in Jira.