### PR TITLE
fix: Ensure correct svg path fill for primary tools [CLUE-42]

### DIFF
--- a/src/components/document/editable-document-content.scss
+++ b/src/components/document/editable-document-content.scss
@@ -55,7 +55,7 @@
 
       svg {
         path {
-          fill: $workspace-teal-dark-1;
+          fill: $workspace-teal-dark-1 !important;
         }
       }
 
@@ -79,7 +79,7 @@
 
         svg {
           path {
-            fill: $learninglog-green-dark-1;
+            fill: $learninglog-green-dark-1 !important;
           }
         }
 

--- a/src/components/document/sort-work-view.scss
+++ b/src/components/document/sort-work-view.scss
@@ -237,7 +237,7 @@ $title-margin: 0;
 
           svg {
             path {
-              fill: $classwork-purple-dark-1;
+              fill: $classwork-purple-dark-1 !important;
             }
           }
 


### PR DESCRIPTION
This ensures the primary toolbar tool svg path colors stay the same.