### PR TITLE
fix: Remove tile expand icon when tile rendered on left side [CLUE-68]

### DIFF
--- a/cypress/e2e/functional/document_tests/nav_panel_test_spec.js
+++ b/cypress/e2e/functional/document_tests/nav_panel_test_spec.js
@@ -25,6 +25,20 @@ function beforeTest(params) {
 //https://www.pivotaltracker.com/n/projects/2441242/stories/186891632
 
 context('Nav Panel', function () {
+  it('Nav tiles', function () {
+    beforeTest(queryParams1);
+
+    cy.log('Tiles in nav panel should not show resize handle');
+    cy.openTopTab("problems");
+    for (const section of problemSubTabTitles) {
+      cy.openProblemSection(section);
+      cy.get('.problem-panel .tool-tile').each(($tile) => {
+        cy.wrap($tile).click();
+        cy.wrap($tile).find('.resize-handle').should('not.exist');
+      });
+    }
+  });
+
   it('Test nav panel tabs', function () {
     beforeTest(queryParams1);
     let copyDocumentTitle = 'copy Investigation';

--- a/src/components/document/tile-row.tsx
+++ b/src/components/document/tile-row.tsx
@@ -151,7 +151,7 @@ export class TileRowComponent extends BaseComponent<IProps, IState> {
   }
 
   private renderTiles(tiles: TileLayoutModelType[], rowHeight?: number) {
-    const { model, tileMap, ...others } = this.props;
+    const { model, tileMap, readOnly, ...others } = this.props;
 
     return tiles.map((tileRef, index) => {
       const tileModel = this.getTile(tileRef.tileId);
@@ -162,10 +162,11 @@ export class TileRowComponent extends BaseComponent<IProps, IState> {
                   model={tileModel}
                   widthPct={tileWidthPct}
                   height={rowHeight}
-                  isUserResizable={model.isUserResizable}
+                  isUserResizable={!readOnly && model.isUserResizable}
                   onResizeRow={this.handleStartResizeRow}
                   onSetCanAcceptDrop={this.handleSetCanAcceptDrop}
                   onRequestRowHeight={this.handleRequestRowHeight}
+                  readOnly={readOnly}
                   {...others}
                 />
               : null;


### PR DESCRIPTION
This fix hides the resizing icon when the tile is in a readonly document.