### PR TITLE
fix: Update tile select/deselect pattern [CLUE-66]

### DIFF
--- a/cypress/e2e/functional/document_tests/tiles_copy_test_spec.js
+++ b/cypress/e2e/functional/document_tests/tiles_copy_test_spec.js
@@ -65,7 +65,10 @@ function testPrimaryWorkspace1() {
   cy.get('.primary-workspace .rdg-row .rdg-cell').eq(1).should('contain', '3');
   cy.get('.primary-workspace .rdg-row .rdg-cell').eq(2).should('contain', '2.5');
   // Make sure the geometry tile were copied correctly
-  cy.get('.primary-workspace .geometry-content.editable ellipse[display="inline"]').should('have.length', 3);
+  // This could be 3 or more depending if a geometry tile was already selected before dragging as the drag
+  // select behavior changed to include the previously selected tiles in the drag if the user selects tile(s)
+  // and then clicks directly on the drag handle on another tile to drag.
+  cy.get('.primary-workspace .geometry-content.editable ellipse[display="inline"]').should('have.length.gte', 3);
   // Make sure the drawing tile were copied correctly
   drawToolTile.getRectangleDrawing().should("exist").and("have.length", 1);
   // Make sure the expression tile were copied correctly

--- a/src/components/tiles/geometry/geometry-tile.tsx
+++ b/src/components/tiles/geometry/geometry-tile.tsx
@@ -86,7 +86,8 @@ const GeometryToolComponent: React.FC<IGeometryProps> = observer(function _Geome
 
   const ui = useUIStore();
   const [handlePointerDown, handlePointerUp] = useTileSelectionPointerEvents(
-    useCallback(() => ui.isSelectedTile(modelRef.current), [modelRef, ui]),
+    useCallback(() => modelRef.current.id, [modelRef]),
+    useCallback(() => ui.selectedTileIds, [ui]),
     useCallback((append: boolean) => ui.setSelectedTile(modelRef.current, { append }), [modelRef, ui]),
     domElement
   );

--- a/src/components/tiles/geometry/use-tile-selection-pointer-events.ts
+++ b/src/components/tiles/geometry/use-tile-selection-pointer-events.ts
@@ -2,7 +2,8 @@ import React, { useCallback, useRef } from "react";
 import { hasSelectionModifier } from "../../../utilities/event-utils";
 
 export const useTileSelectionPointerEvents = (
-              isTileSelected: () => boolean,
+              getTileId: () => string,
+              getSelectedTileIds: () => string[],
               setSelectedTile: (append: boolean) => void,
               focusableElement: React.RefObject<HTMLDivElement>) => {
   const didLastMouseDownSelectTile = useRef(false);
@@ -20,15 +21,19 @@ export const useTileSelectionPointerEvents = (
       focusableElement.current.focus();
     }
 
-    // first click selects the tile
-    if (!isTileSelected()) {
+    // first click or subsequent clicks when the tile is one of many selected
+    // tiles selects the tile and prevents the click from taking effect
+    const selectedTileIds = getSelectedTileIds();
+    const isTileSelected = selectedTileIds.includes(getTileId());
+    const otherTilesSelected = selectedTileIds.length > 1;
+    if (!isTileSelected || otherTilesSelected) {
       setSelectedTile(hasSelectionModifier(e));
       didLastMouseDownSelectTile.current = true;
       // prevent the click from taking effect, e.g. creating a point
       e.preventDefault();
       e.stopPropagation();
     }
-  }, [focusableElement, isTileSelected, setSelectedTile]);
+  }, [focusableElement, getSelectedTileIds, getTileId, setSelectedTile]);
 
   const handlePointerUp = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
     if (didLastMouseDownSelectTile.current) {

--- a/src/components/tiles/tile-component.tsx
+++ b/src/components/tiles/tile-component.tsx
@@ -386,7 +386,7 @@ export class TileComponent extends BaseComponent<IProps, IState> {
     const { ui } = this.stores;
 
     // dragging a tile selects it first
-    ui.setSelectedTile(model, { append: hasSelectionModifier(e) });
+    ui.setSelectedTile(model, { append: hasSelectionModifier(e), dragging: true });
 
     const documentContent = getDocumentContentFromNode(model);
     if (!documentContent) {

--- a/src/components/toolbar.tsx
+++ b/src/components/toolbar.tsx
@@ -15,6 +15,7 @@ import { SectionModelType } from "../models/curriculum/section";
 import { logHistoryEvent } from "../models/history/log-history-event";
 import { LogEventName } from "../lib/logger-types";
 import { IToolbarEventProps, logToolbarEvent } from "../models/tiles/log/log-toolbar-event";
+import { IDropTileItem } from "src/models/tiles/tile-model";
 
 import "./toolbar.scss";
 
@@ -425,9 +426,10 @@ export class ToolbarComponent extends BaseComponent<IProps, IState> {
     if (content && primaryDocument?.content && (document?.key !== primaryDocument.key)) {
       const sectionId = document ? undefined : section?.type;
       const copySpec = content.getCopySpec(ui.selectedTileIds, sectionId);
-      primaryDocument.content.applyCopySpec(copySpec);
+      const copiedTiles = primaryDocument.content.applyCopySpec(copySpec);
 
       this.logDocumentOrSectionEvent(LogEventName.TOOLBAR_COPY_TO_WORKSPACE, {}, primaryDocument);
+      this.selectCopiedTiles(copiedTiles);
     }
   };
 
@@ -443,11 +445,18 @@ export class ToolbarComponent extends BaseComponent<IProps, IState> {
           if (copyToDocument?.content) {
             const sectionId = document ? undefined : section?.type;
             const copySpec = content.getCopySpec(ui.selectedTileIds, sectionId);
-            copyToDocument.content.applyCopySpec(copySpec);
+            const copiedTiles = copyToDocument.content.applyCopySpec(copySpec);
 
             this.logDocumentOrSectionEvent(LogEventName.TOOLBAR_COPY_TO_DOCUMENT, {}, copyToDocument);
+            this.selectCopiedTiles(copiedTiles);
           }
         });
     }
+  };
+
+  private selectCopiedTiles = (copiedTiles: IDropTileItem[]) => {
+    const { ui } = this.stores;
+    const copiedTileIds = copiedTiles.map(tile => tile.newTileId);
+    ui.selectAllTiles(copiedTileIds);
   };
 }

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -411,6 +411,8 @@ export const DocumentContentModel = DocumentContentModelWithTileDragging.named("
         self.addArrow(ArrowAnnotation.create(newAnnotationSnapshot));
       }
     });
+
+    return updatedTiles;
   }
 }))
 .actions(self => ({
@@ -525,7 +527,7 @@ export const DocumentContentModel = DocumentContentModelWithTileDragging.named("
     };
   },
   applyCopySpec(copySpec: ICopySpec) {
-    self.copyTiles(
+    return self.copyTiles(
       copySpec.tiles, copySpec.sharedModelEntries, copySpec.annotations, undefined, copySpec
     );
   },

--- a/src/models/stores/ui.ts
+++ b/src/models/stores/ui.ts
@@ -115,7 +115,7 @@ export const UIModel = types
       dialogResolver = undefined;
     };
 
-    const setOrAppendTileIdToSelection = (tileId?: string, options?: {append: boolean}) => {
+    const setOrAppendTileIdToSelection = (tileId?: string, options?: {append: boolean, dragging?: boolean}) => {
       if (tileId) {
         const tileIdIndex = self.selectedTileIds.indexOf(tileId);
         const isCurrentlySelected = tileIdIndex >= 0;
@@ -128,7 +128,12 @@ export const UIModel = types
           else {
             self.selectedTileIds.push(tileId);
           }
-        } else if (!isCurrentlySelected) {
+        } else if (options?.dragging) {
+          // dragging a tile adds it to the selection
+          if (!isCurrentlySelected) {
+            self.selectedTileIds.push(tileId);
+          }
+        } else if (!options?.dragging) {
           self.selectedTileIds.replace([tileId]);
         }
         // clicking on an already-selected tile doesn't change selection
@@ -174,10 +179,10 @@ export const UIModel = types
         self.error = null;
       },
 
-      setSelectedTile(tile?: ITileModel, options?: {append: boolean}) {
+      setSelectedTile(tile?: ITileModel, options?: {append: boolean, dragging?: boolean}) {
         setOrAppendTileIdToSelection(tile && tile.id, options);
       },
-      setSelectedTileId(tileId: string, options?: {append: boolean}) {
+      setSelectedTileId(tileId: string, options?: {append: boolean, dragging?: boolean}) {
         setOrAppendTileIdToSelection(tileId, options);
       },
       removeTileIdFromSelection(tileId: string) {


### PR DESCRIPTION
- select the copied tiles when copying to workspace or other document
- when all tiles are selected (or when more than one tile is selected), clicking on a single selected tile will deselect all the other tiles but keep the one tile selected