### PR TITLE
fix: Keep copy icon path fill [CLUE-4]

### DIFF
--- a/src/components/toolbar.scss
+++ b/src/components/toolbar.scss
@@ -27,7 +27,7 @@
     cursor: pointer;
 
     // the :not() here is for tools that shouldn't have their svg updated
-    &:not(.fourup) {
+    &:not(.fourup):not(.copytoworkspace):not(.copytodocument) {
       svg path {
         fill: $charcoal-dark-1;
         pointer-events: none;


### PR DESCRIPTION
This adds a css rule to not update the copy to workspace and copy to document icon svg path fills to gray and instead leave them blue as in the original svg.