### PR TITLE
feat: Add standalone app page [CLUE-72]

### DIFF
--- a/.github/workflows/manual-regression.yml
+++ b/.github/workflows/manual-regression.yml
@@ -58,6 +58,7 @@ on:
           - functional/tile_tests/table_tool_spec.js
           - functional/tile_tests/text_tool_spec.js
           - functional/tile_tests/xy_plot_tool_spec.js
+          - functional/standalone_tests/standalone_load_spec.js
           - smoke/single_student_canvas_test.js
 jobs:
   all-tests:

--- a/cypress/e2e/functional/standalone_tests/standalone_load_spec.js
+++ b/cypress/e2e/functional/standalone_tests/standalone_load_spec.js
@@ -1,0 +1,27 @@
+const url = "/standalone/";
+
+function beforeTest() {
+  cy.visit(url);
+}
+
+context('Standalone', () => {
+  it('verify standalone page loads', function () {
+    beforeTest();
+
+    cy.log("verify placeholder");
+    cy.get("[data-test=standalone-placeholder]").should("exist");
+
+    cy.log("verify only problems tab is visible");
+    cy.get(".tab-problems").should("exist");
+    const filteredTabs = ["my-work", "sort-work"];
+    for (const tab of filteredTabs) {
+      cy.get(`.tab-${tab}`).should("not.exist");
+    }
+
+    cy.log("verify problem panel toolbar is not visible");
+    cy.get(".problem-panel .toolbar").should("not.exist");
+
+    cy.log("verify user info is not visible");
+    cy.get(".app-header .user").should("not.exist");
+  });
+});

--- a/src/clue/components/clue-app-header.tsx
+++ b/src/clue/components/clue-app-header.tsx
@@ -184,22 +184,34 @@ export const ClueAppHeaderComponent: React.FC<IProps> = observer(function ClueAp
     return renderNonStudentHeader({showProblemMenu: true});
   }
 
+  // STANDALONE FIXME: once standalone auth is added there will probably be a UI flag for showing these
+  // ui elements
+  const showUserInfo = !(ui.standalone && user.waitingForStandaloneAuth);
+  const showProblemInfo = showUserInfo;
+  const showUnitInfo = unit.title !== "Null Unit";
+
   return (
       <div className="app-header">
         <div className="left">
-          <div className="unit">
-            <div className="title" data-test="unit-title">
-              {unit.title}
+          {showUnitInfo &&
+          <>
+            <div className="unit">
+              <div className="title" data-test="unit-title">
+                {unit.title}
+              </div>
+              <div className="investigation" data-test="investigation">
+                {investigation.title}
+              </div>
             </div>
-            <div className="investigation" data-test="investigation">
-              {investigation.title}
-            </div>
-          </div>
-          <div className="separator"/>
+            <div className="separator"/>
+          </>
+          }
+          {showProblemInfo &&
           <CustomSelect
             items={[{text: `${problem.title}${problem.subtitle ? `: ${problem.subtitle}`: ""}`}]}
             isDisabled={true}
           />
+          }
         </div>
         <div className="middle student">
           {renderPanelButtons()}
@@ -209,6 +221,7 @@ export const ClueAppHeaderComponent: React.FC<IProps> = observer(function ClueAp
           <NetworkStatus user={user}/>
           <div className="version">Version {appVersion}</div>
           {myGroup ? renderGroup(myGroup) : null}
+          {showUserInfo &&
           <div className="user" title={getUserTitle()}>
             <div className="user-contents">
               <div className="name" data-test="user-name">{user.name}</div>
@@ -218,6 +231,7 @@ export const ClueAppHeaderComponent: React.FC<IProps> = observer(function ClueAp
               <div className="profile-icon-inner"/>
             </div>
           </div>
+          }
         </div>
       </div>
     );

--- a/src/clue/components/clue-app-header.tsx
+++ b/src/clue/components/clue-app-header.tsx
@@ -188,6 +188,7 @@ export const ClueAppHeaderComponent: React.FC<IProps> = observer(function ClueAp
   // ui elements
   const showUserInfo = !(ui.standalone && user.waitingForStandaloneAuth);
   const showProblemInfo = showUserInfo;
+  const showAppMode = showUserInfo;
   const showUnitInfo = unit.title !== "Null Unit";
 
   return (
@@ -217,7 +218,7 @@ export const ClueAppHeaderComponent: React.FC<IProps> = observer(function ClueAp
           {renderPanelButtons()}
         </div>
         <div className="right">
-          <AppModeIndicator appMode={appMode}/>
+          {showAppMode && <AppModeIndicator appMode={appMode}/>}
           <NetworkStatus user={user}/>
           <div className="version">Version {appVersion}</div>
           {myGroup ? renderGroup(myGroup) : null}

--- a/src/clue/components/clue-app-header.tsx
+++ b/src/clue/components/clue-app-header.tsx
@@ -189,6 +189,7 @@ export const ClueAppHeaderComponent: React.FC<IProps> = observer(function ClueAp
   const showUserInfo = !(ui.standalone && user.waitingForStandaloneAuth);
   const showProblemInfo = showUserInfo;
   const showAppMode = showUserInfo;
+  const showGroupInfo = showUserInfo;
   const showUnitInfo = unit.title !== "Null Unit";
 
   return (
@@ -221,7 +222,7 @@ export const ClueAppHeaderComponent: React.FC<IProps> = observer(function ClueAp
           {showAppMode && <AppModeIndicator appMode={appMode}/>}
           <NetworkStatus user={user}/>
           <div className="version">Version {appVersion}</div>
-          {myGroup ? renderGroup(myGroup) : null}
+          {showGroupInfo && myGroup ? renderGroup(myGroup) : null}
           {showUserInfo &&
           <div className="user" title={getUserTitle()}>
             <div className="user-contents">

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -164,6 +164,10 @@ export class AppComponent extends BaseComponent<IProps> {
   public render() {
     const {appConfig, user, ui, db} = this.stores;
 
+    if (ui.standalone) {
+      return this.renderApp(<AppContentContainerComponent />);
+    }
+
     if (ui.showDemoCreator) {
       return this.renderApp(<DemoCreatorComponent />);
     }

--- a/src/components/navigation/problem-panel.scss
+++ b/src/components/navigation/problem-panel.scss
@@ -24,6 +24,11 @@
       top: 0px;
       border-top: $document-border-width solid white;
 
+      &.hide-toolbar {
+        left: 0;
+        width: 100%;
+      }
+
       .canvas {
         overflow: auto;
         height: 100%;

--- a/src/components/navigation/problem-panel.tsx
+++ b/src/components/navigation/problem-panel.tsx
@@ -5,6 +5,7 @@ import { CanvasComponent } from "../document/canvas";
 import { SectionModelType } from "../../models/curriculum/section";
 import { DocumentContentModelType } from "../../models/document/document-content";
 import { SectionToolbar } from "../document/section-toolbar";
+import clsx from "clsx";
 
 import "./problem-panel.scss";
 
@@ -36,11 +37,18 @@ export class ProblemPanelComponent extends BaseComponent<IProps> {
   }
 
   private renderContent(content: DocumentContentModelType) {
+    // STANDALONE FIXME: this will eventually probably be a ui boolean but for now we will do this here
+    const hideToolbar = this.stores.ui.standalone && this.stores.user.waitingForStandaloneAuth;
+
     return (
         <div key="problem-panel">
-          <SectionToolbar section={this.props.section!} toolbar={this.stores.appConfig.myResourcesToolbar({})} />
-          <div className="canvas-separator"/>
-          <div className="canvas-area">
+          {!hideToolbar &&
+          <>
+            <SectionToolbar section={this.props.section!} toolbar={this.stores.appConfig.myResourcesToolbar({})} />
+            <div className="canvas-separator"/>
+          </>
+          }
+          <div className={clsx("canvas-area", {"hide-toolbar": hideToolbar})}>
             <CanvasComponent
               content={content}
               context="left-nav"

--- a/src/components/navigation/problem-panel.tsx
+++ b/src/components/navigation/problem-panel.tsx
@@ -1,11 +1,11 @@
 import { inject, observer } from "mobx-react";
 import React from "react";
+import clsx from "clsx";
 import { BaseComponent, IBaseProps } from "../base";
 import { CanvasComponent } from "../document/canvas";
 import { SectionModelType } from "../../models/curriculum/section";
 import { DocumentContentModelType } from "../../models/document/document-content";
 import { SectionToolbar } from "../document/section-toolbar";
-import clsx from "clsx";
 
 import "./problem-panel.scss";
 

--- a/src/components/network-status.tsx
+++ b/src/components/network-status.tsx
@@ -10,7 +10,7 @@ interface IProps {
   user: UserModelType;
 }
 export const NetworkStatus = observer(({ user }: IProps) => {
-  const { isFirebaseConnected } = user;
+  const { isFirebaseConnected, waitingForStandaloneAuth } = user;
   const maxAlertDelay = 60;
   const alertDelaysSec = [1, 5, 10, 30, maxAlertDelay];
   const [alertDelay, setAlertDelay] = useState(alertDelaysSec[0]);
@@ -41,7 +41,7 @@ export const NetworkStatus = observer(({ user }: IProps) => {
     }
   }
 
-  if (!isFirebaseConnected && !isShowingAlert && !timer) {
+  if (!isFirebaseConnected && !waitingForStandaloneAuth && !isShowingAlert && !timer) {
     // first detection of a network issue; wait a bit to see if it's for real
     setTimer(window.setTimeout(() => {
       if (!user.isFirebaseConnected) {
@@ -60,6 +60,12 @@ export const NetworkStatus = observer(({ user }: IProps) => {
     setAlertDelay(alertDelaysSec[0]);
     checkFirebaseConnection(user);
   };
+
+  // don't show the status if we're waiting for standalone auth as we don't
+  // connect to Firebase until we have the user info
+  if (waitingForStandaloneAuth) {
+    return null;
+  }
 
   return (
     <div className="network-status" data-testid="network-status">

--- a/src/components/workspace/workspace.tsx
+++ b/src/components/workspace/workspace.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react";
-import React, { useCallback, useEffect, useRef } from "react";
+import React, { CSSProperties, useCallback, useEffect, useRef } from "react";
 import { IBaseProps } from "../base";
 import { useStores } from "../../hooks/use-stores";
 import { DocumentWorkspaceComponent } from "../document/document-workspace";
@@ -19,7 +19,8 @@ export const WorkspaceComponent: React.FC<IProps> = observer((props) => {
   const { appConfig: { navTabs: navTabSpecs },
           persistentUI: { navTabContentShown, workspaceShown },
           exemplarController,
-          user: { isResearcher }
+          user: { isResearcher },
+          ui: { standalone }
         } = stores;
   const hotKeys = useRef(new HotKeys());
 
@@ -47,6 +48,24 @@ export const WorkspaceComponent: React.FC<IProps> = observer((props) => {
   const showLeftPanel = isResearcher || navTabSpecs.showNavPanel;
   const showRightPanel = !isResearcher;
 
+  // this will be removed in a follow on story
+  const renderStandalonePlaceholder = () => {
+    const style: CSSProperties = {
+      display: "flex",
+      height: "100%",
+      alignContent: "flex-start",
+      justifyContent: "center",
+      alignItems: "center"
+    };
+    return (
+      <div style={style} data-test="standalone-placeholder">
+        <div>
+          TBD: Standalone
+        </div>
+      </div>
+    );
+  };
+
   return (
     <div
       className="workspace"
@@ -68,7 +87,7 @@ export const WorkspaceComponent: React.FC<IProps> = observer((props) => {
       }
       {showRightPanel &&
         <ResizablePanel collapsed={!workspaceShown}>
-          <DocumentWorkspaceComponent />
+          {standalone ? renderStandalonePlaceholder() : <DocumentWorkspaceComponent />}
         </ResizablePanel>
       }
     </div>

--- a/src/models/stores/stores.ts
+++ b/src/models/stores/stores.ts
@@ -194,12 +194,19 @@ class Stores implements IStores{
   get tabsToDisplay() {
     const { appConfig: { navTabs: navTabSpecs },
       teacherGuide,
-      user: { isTeacherOrResearcher }
+      user: { isTeacherOrResearcher, waitingForStandaloneAuth },
+      ui: { standalone },
     } = this;
 
-    return (isTeacherOrResearcher)
+    const removeNonCurriculumTabs = standalone && waitingForStandaloneAuth;
+
+    const tabs = (isTeacherOrResearcher)
       ? navTabSpecs.tabSpecs.filter(t => (t.tab !== "teacher-guide") || teacherGuide)
       : navTabSpecs.tabSpecs.filter(t => !t.teacherOnly);
+
+    return removeNonCurriculumTabs
+      ? tabs.filter(t => t.tab === "problems" || t.tab === "teacher-guide")
+      : tabs;
   }
 
   get problemPath() {

--- a/src/models/stores/ui.ts
+++ b/src/models/stores/ui.ts
@@ -57,7 +57,8 @@ export const UIModel = types
     dragId: types.maybe(types.string) // The id of the object being dragged. Used with dnd-kit dragging.
   })
   .volatile(self => ({
-    defaultLeftNavExpanded: false
+    defaultLeftNavExpanded: false,
+    standalone: false,
   }))
   .views((self) => ({
     isSelectedTile(tile: ITileModel) {
@@ -202,7 +203,11 @@ export const UIModel = types
 
       selectAllTiles,
 
-      getCopyToDocumentKey
+      getCopyToDocumentKey,
+
+      setStandalone(standalone: boolean) {
+        self.standalone = standalone;
+      }
     };
   })
   .actions(self => ({

--- a/src/models/stores/user.ts
+++ b/src/models/stores/user.ts
@@ -53,6 +53,7 @@ export const UserModel = types
     lastStickyNoteViewTimestamp: types.maybe(types.number)
   })
   .volatile(self => ({
+    // STANDALONE TODO: replace this boolean with a state machine enum
     waitingForStandaloneAuth: false,
     isFirebaseConnected: false,
     // number of firebase disconnects encountered during the current session

--- a/src/models/stores/user.ts
+++ b/src/models/stores/user.ts
@@ -53,6 +53,7 @@ export const UserModel = types
     lastStickyNoteViewTimestamp: types.maybe(types.number)
   })
   .volatile(self => ({
+    waitingForStandaloneAuth: false,
     isFirebaseConnected: false,
     // number of firebase disconnects encountered during the current session
     firebaseDisconnects: 0,
@@ -113,6 +114,9 @@ export const UserModel = types
       if (user.demoClassHashes?.length) {
         self.demoClassHashes.replace(user.demoClassHashes);
       }
+    },
+    setWaitingForStandaloneAuth(waiting: boolean) {
+      self.waitingForStandaloneAuth = waiting;
     },
     setIsFirebaseConnected(connected: boolean) {
       if (self.isFirebaseConnected && !connected) ++self.firebaseDisconnects;

--- a/src/standalone.tsx
+++ b/src/standalone.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import ReactDOM from "react-dom";
+
+import { AppProvider, initializeApp } from "./initialize-app";
+import { AppComponent } from "./components/app";
+import { removeLoadingMessage, showLoadingMessage } from "./utilities/loading-utils";
+
+removeLoadingMessage("Loading the application");
+showLoadingMessage("Initializing");
+
+const stores = initializeApp(false);
+stores.ui.setStandalone(true);
+stores.user.setWaitingForStandaloneAuth(true);
+
+ReactDOM.render(
+  <AppProvider stores={stores} modalAppElement="#app">
+    <AppComponent />
+  </AppProvider>,
+  document.getElementById("app")
+);
+
+removeLoadingMessage("Initializing");

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -62,7 +62,8 @@ module.exports = (env, argv) => {
     entry: {
       index: './src/index.tsx',
       iframe: './src/iframe/iframe.tsx',
-      'doc-editor': './src/doc-editor.tsx'
+      'doc-editor': './src/doc-editor.tsx',
+      standalone: './src/standalone.tsx',
     },
     mode: devMode ? 'development' : 'production',
     output: {
@@ -261,6 +262,10 @@ module.exports = (env, argv) => {
       ...configHtmlPlugins({
         chunks: ['doc-editor'],
         filename: 'editor/index.html',
+      }),
+      ...configHtmlPlugins({
+        chunks: ['standalone'],
+        filename: 'standalone/index.html',
       }),
       new HtmlWebpackPlugin({
         ...baseHtmlPluginConfig,


### PR DESCRIPTION
This adds a new top level page called "standalone".  For now standalone mode shows the curriculum on the left and a TBD panel on the right.

When the login UI is added in the next PR the "STANDALONE FIXME" comments will be addressed, probably with additional or modified model state.