### PR TITLE
Clue 14 default inserts

### DIFF
--- a/src/components/document/document-content.tsx
+++ b/src/components/document/document-content.tsx
@@ -238,8 +238,6 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
         typeClass={this.props.typeClass}
         scale={this.props.scale}
         readOnly={this.props.readOnly}
-        // FIXME: this is redundant now.
-        highlightPendingDropLocation={content.highlightPendingDropLocation}
       />
     );
   }

--- a/src/components/document/row-list.test.tsx
+++ b/src/components/document/row-list.test.tsx
@@ -179,7 +179,7 @@ describe("RowListComponent", () => {
                 context="test"
                 documentId="test-doc"
                 docId={documentContent.contentId}
-                highlightPendingDropLocation={0}
+                highlightPendingDropLocation={documentContent.defaultInsertRowId}
               />
             </RowRefsContext.Provider>
           </DropRowContext.Provider>

--- a/src/components/document/row-list.test.tsx
+++ b/src/components/document/row-list.test.tsx
@@ -136,9 +136,35 @@ describe("RowListComponent", () => {
       </Provider>
     );
 
-    // Check for drop feedback element with correct classes
-    const dropFeedback = container.querySelector(".drop-feedback.show.top");
-    expect(dropFeedback).toBeInTheDocument();
+    // Test top highlight
+    rerender(
+      <Provider stores={stores}>
+        <TileApiInterfaceContext.Provider value={mockTileApiInterface}>
+          <DropRowContext.Provider value={{
+            rowDropId: "row1",
+            rowDropLocation: "top",
+            rowInsertIndex: 0
+          }}>
+            <RowRefsContext.Provider value={{ addRowRef: () => {} }}>
+              <RowListComponent
+                rowListModel={documentContent}
+                documentContent={documentContent}
+                context="test"
+                documentId="test-doc"
+                docId={documentContent.contentId}
+              />
+            </RowRefsContext.Provider>
+          </DropRowContext.Provider>
+        </TileApiInterfaceContext.Provider>
+      </Provider>
+    );
+
+    // Verify top highlight is present and others are not
+    const topDropFeedback = container.querySelector(".drop-feedback.show.top");
+    expect(topDropFeedback).toBeInTheDocument();
+    expect(container.querySelector(".drop-feedback.show.bottom")).not.toBeInTheDocument();
+    expect(container.querySelector(".drop-feedback.show.left")).not.toBeInTheDocument();
+    expect(container.querySelector(".drop-feedback.show.right")).not.toBeInTheDocument();
 
     // Test bottom highlight
     rerender(
@@ -163,15 +189,22 @@ describe("RowListComponent", () => {
       </Provider>
     );
 
+    // Verify bottom highlight is present and others are not
     const bottomDropFeedback = container.querySelector(".drop-feedback.show.bottom");
     expect(bottomDropFeedback).toBeInTheDocument();
-  });
+    expect(container.querySelector(".drop-feedback.show.top")).not.toBeInTheDocument();
+    expect(container.querySelector(".drop-feedback.show.left")).not.toBeInTheDocument();
+    expect(container.querySelector(".drop-feedback.show.right")).not.toBeInTheDocument();
 
-  it("handles highlightPendingDropLocation", () => {
-    const { container } = render(
+    // Test left highlight
+    rerender(
       <Provider stores={stores}>
         <TileApiInterfaceContext.Provider value={mockTileApiInterface}>
-          <DropRowContext.Provider value={undefined}>
+          <DropRowContext.Provider value={{
+            rowDropId: "row1",
+            rowDropLocation: "left",
+            rowInsertIndex: 0
+          }}>
             <RowRefsContext.Provider value={{ addRowRef: () => {} }}>
               <RowListComponent
                 rowListModel={documentContent}
@@ -179,7 +212,6 @@ describe("RowListComponent", () => {
                 context="test"
                 documentId="test-doc"
                 docId={documentContent.contentId}
-                highlightPendingDropLocation={documentContent.defaultInsertRowId}
               />
             </RowRefsContext.Provider>
           </DropRowContext.Provider>
@@ -187,7 +219,42 @@ describe("RowListComponent", () => {
       </Provider>
     );
 
-    const dropFeedback = container.querySelector(".drop-feedback.show.top");
-    expect(dropFeedback).toBeInTheDocument();
+    // Verify left highlight is present and others are not
+    const leftDropFeedback = container.querySelector(".drop-feedback.show.left");
+    expect(leftDropFeedback).toBeInTheDocument();
+    expect(container.querySelector(".drop-feedback.show.top")).not.toBeInTheDocument();
+    expect(container.querySelector(".drop-feedback.show.bottom")).not.toBeInTheDocument();
+    expect(container.querySelector(".drop-feedback.show.right")).not.toBeInTheDocument();
+
+    // Test right highlight
+    rerender(
+      <Provider stores={stores}>
+        <TileApiInterfaceContext.Provider value={mockTileApiInterface}>
+          <DropRowContext.Provider value={{
+            rowDropId: "row1",
+            rowDropLocation: "right",
+            rowInsertIndex: 0
+          }}>
+            <RowRefsContext.Provider value={{ addRowRef: () => {} }}>
+              <RowListComponent
+                rowListModel={documentContent}
+                documentContent={documentContent}
+                context="test"
+                documentId="test-doc"
+                docId={documentContent.contentId}
+              />
+            </RowRefsContext.Provider>
+          </DropRowContext.Provider>
+        </TileApiInterfaceContext.Provider>
+      </Provider>
+    );
+
+    // Verify right highlight is present and others are not
+    const rightDropFeedback = container.querySelector(".drop-feedback.show.right");
+    expect(rightDropFeedback).toBeInTheDocument();
+    expect(container.querySelector(".drop-feedback.show.top")).not.toBeInTheDocument();
+    expect(container.querySelector(".drop-feedback.show.bottom")).not.toBeInTheDocument();
+    expect(container.querySelector(".drop-feedback.show.left")).not.toBeInTheDocument();
   });
 });
+

--- a/src/components/document/row-list.tsx
+++ b/src/components/document/row-list.tsx
@@ -15,12 +15,11 @@ interface IProps extends IBaseProps {
   typeClass?: string;
   scale?: number;
   readOnly?: boolean;
-  highlightPendingDropLocation?: string;
 }
 
 export const RowListComponent = observer((props: IProps) => {
   const { rowListModel, documentContent, context, documentId, docId, typeClass,
-    scale, readOnly, highlightPendingDropLocation } = props;
+    scale, readOnly } = props;
   const { rowMap, rowOrder } = rowListModel;
   const dropRowInfo = useContext(DropRowContext);
   const rowRefs = useContext(RowRefsContext);
@@ -29,15 +28,10 @@ export const RowListComponent = observer((props: IProps) => {
     <>
       {rowOrder.map((rowId, index) => {
         const row = rowMap.get(rowId);
-        let dropHighlight = dropRowInfo && (dropRowInfo.rowDropId === rowId) &&
+        const dropHighlight = dropRowInfo && (dropRowInfo.rowDropId === rowId) &&
                             dropRowInfo.rowDropLocation
                               ? dropRowInfo.rowDropLocation
                               : undefined;
-        if (!dropHighlight) { //  TODO do we need a "top" option?
-          if (rowId === highlightPendingDropLocation) {
-            dropHighlight = "bottom";
-          }
-        }
 
         return row
                 ? <TileRowComponent

--- a/src/components/document/row-list.tsx
+++ b/src/components/document/row-list.tsx
@@ -15,7 +15,7 @@ interface IProps extends IBaseProps {
   typeClass?: string;
   scale?: number;
   readOnly?: boolean;
-  highlightPendingDropLocation?: number;
+  highlightPendingDropLocation?: string;
 }
 
 export const RowListComponent = observer((props: IProps) => {
@@ -33,11 +33,8 @@ export const RowListComponent = observer((props: IProps) => {
                             dropRowInfo.rowDropLocation
                               ? dropRowInfo.rowDropLocation
                               : undefined;
-        if (!dropHighlight) {
-          if (index === highlightPendingDropLocation) {
-            dropHighlight = "top";
-          }
-          else if ((index === rowOrder.length - 1) && (index + 1 === highlightPendingDropLocation)) {
+        if (!dropHighlight) { //  TODO do we need a "top" option?
+          if (rowId === highlightPendingDropLocation) {
             dropHighlight = "bottom";
           }
         }

--- a/src/components/toolbar.tsx
+++ b/src/components/toolbar.tsx
@@ -2,7 +2,6 @@ import { inject, observer } from "mobx-react";
 import React from "react";
 import { BaseComponent, IBaseProps } from "./base";
 import { DocumentModelType } from "../models/document/document";
-import { orderTilePositions } from "../models/document/drag-tiles";
 import { IToolbarModel } from "../models/stores/problem-configuration";
 import { IToolbarButtonModel } from "../models/tiles/toolbar-button";
 import { getTileContentInfo, ITileContentInfo } from "../models/tiles/tile-content-info";
@@ -170,10 +169,11 @@ export class ToolbarComponent extends BaseComponent<IProps, IState> {
 
   private showDropRowHighlightAfterSelectedTiles = () => {
     const { document } = this.props;
+    if (!document?.content) return;
     const { ui: { selectedTileIds } } = this.stores;
-    const tilePositions = document?.content?.getTilePositions(Array.from(selectedTileIds)) || [];
-    const rowIndex = document?.content?.getRowAfterTiles(tilePositions);
-    document?.content?.showPendingInsertHighlight(true, rowIndex);
+    const tilePositions = document.content.getTilePositions(Array.from(selectedTileIds)) || [];
+    const rowId = document.content.getLastRowForTiles(tilePositions);
+    document.content.showPendingInsertHighlight(true, rowId);
   };
 
   private removeDropRowHighlight = () => {
@@ -266,7 +266,11 @@ export class ToolbarComponent extends BaseComponent<IProps, IState> {
     }
 
     const newTileOptions: IDocumentContentAddTileOptions = {
-            insertRowInfo: { rowInsertIndex: document?.content?.defaultInsertRow ?? 0 }
+            insertRowInfo: {
+              rowDropId: document?.content?.defaultInsertRowId,
+              rowInsertIndex: document?.content?.defaultInsertRowIndex || 0,
+              rowDropLocation: "bottom"
+            }
           };
     const rowTile = document?.addTile(tool.id, newTileOptions);
     if (document && rowTile && rowTile.tileId) {
@@ -303,8 +307,7 @@ export class ToolbarComponent extends BaseComponent<IProps, IState> {
 
     // Sort the selected tile ids in top->bottom, left->right order so they duplicate in the correct formation
     const tilePositions = document?.content?.getTilePositions(Array.from(selectedTileIds)) || [];
-    const sortedTileIds = orderTilePositions(tilePositions).map(info => info.tileId);
-    const dragTileItems = document?.content?.getDragTileItems(sortedTileIds) || [];
+    const dragTileItems = document?.content?.getDragTileItems(tilePositions.map(info => info.tileId)) || [];
 
     document?.content?.duplicateTiles(dragTileItems);
     ui.clearSelectedTiles();

--- a/src/lib/logger.test.ts
+++ b/src/lib/logger.test.ts
@@ -355,6 +355,7 @@ describe("authed logger", () => {
       const tileToCopy = sourceDocument.content!.firstTile!;
 
       const copyTileInfo: IDropTileItem = {
+        rowList: sourceDocument.content!,
         rowIndex: 0,
         tileIndex: 0,
         tileId: tileToCopy.id,

--- a/src/models/document/base-document-content.ts
+++ b/src/models/document/base-document-content.ts
@@ -49,7 +49,7 @@ export const BaseDocumentContentModel = RowList.named("BaseDocumentContent")
     return isImportDocument(snapshot) ? migrateSnapshot(snapshot) : snapshot;
   })
   .volatile(self => ({
-    highlightPendingDropLocation: -1,
+    highlightPendingDropLocation: undefined as string | undefined
   }))
   .views(self => {
     // used for drag/drop self-drop detection, for instance
@@ -70,11 +70,15 @@ export const BaseDocumentContentModel = RowList.named("BaseDocumentContent")
        * @returns An array of all tiles, in document order.
        */
       get allTiles(): ITileModel[] {
+        return self.rowOrder.flatMap(rowId => this.getAllTilesInRow(rowId));
+      },
+      /**
+       * Returns all tiles in the given row, including nested tiles from RowList containers.
+       * @returns An array of all tiles, in document order.
+       */
+      getAllTilesInRow(rowId: string) {
         const tiles: ITileModel[] = [];
-
-        // Get all tiles from the main document rows
-        self.rowOrder.forEach(rowId => {
-          const row = self.getRow(rowId);
+        const row = this.getRowRecursive(rowId);
           if (row) {
             row.tiles.forEach(tileLayout => {
               const tile = self.tileMap.get(tileLayout.tileId);
@@ -99,8 +103,6 @@ export const BaseDocumentContentModel = RowList.named("BaseDocumentContent")
               }
             });
           }
-        });
-
         return tiles;
       },
       getTilesInDocumentOrder(): string[] {
@@ -281,8 +283,9 @@ export const BaseDocumentContentModel = RowList.named("BaseDocumentContent")
       const tile = self.getTile(row.tiles[0].tileId);
       return getPlaceholderSectionId(tile);
     },
-    get defaultInsertRow() {
-      // next tile comes after the last visible row with content
+    /** Return the index of the row after which new content is inserted by default. */
+    get defaultInsertRowIndex() {
+      // by default new tiles are inserted after the last visible row with content
       for (let i = self.indexOfLastVisibleRow; i >= 0; --i) {
         const row = self.getRowByIndex(i);
         if (row && !row.isSectionHeader && !self.isPlaceholderRow(row)) {
@@ -299,6 +302,12 @@ export const BaseDocumentContentModel = RowList.named("BaseDocumentContent")
       // if all else fails, revert to last visible row
       return self.indexOfLastVisibleRow + 1;
     },
+    /** Return the ID of the row after which new content is inserted by default. */
+    get defaultInsertRowId() {
+      const insertIndex = this.defaultInsertRowIndex;
+      if (insertIndex <= 0) return;
+      return self.rowOrder[insertIndex-1];
+    },
     // Find the smallest RowList container that contains all the given tile ids.
     // Returns the whole document if no smaller container is found.
     getRowListContainingTileIds(tileIds: string[]): RowListType | undefined {
@@ -307,8 +316,19 @@ export const BaseDocumentContentModel = RowList.named("BaseDocumentContent")
       });
       return found ?? self;
     },
-    getRowAfterTiles(tiles: ITilePosition[]) {
-      return Math.max(...tiles.map(tile => tile.rowIndex)) + 1;
+    rowHasTileId(rowId: string, tileId: string) {
+      return self.getAllTilesInRow(rowId).some(tile => tile.id === tileId);
+    },
+    /**
+     * Given a sorted list of tile positions, return the last row of them.
+     * This will be a row in the smallest rowList that contains all the tiles.
+     * @param tiles
+     * @returns a rowId, or undefined if there are no tiles in the list.
+     */
+    getLastRowForTiles(tiles: ITilePosition[]): string | undefined {
+      const rowList = this.getRowListContainingTileIds(tiles.map(tile => tile.tileId));
+      const lastTileId = tiles[tiles.length - 1].tileId;
+      return rowList?.rowOrder.find(rowId => this.rowHasTileId(rowId, lastTileId));
     },
     // TODO: does this need to be recursive?
     getTilesInSection(sectionId: string) {
@@ -568,7 +588,7 @@ export const BaseDocumentContentModel = RowList.named("BaseDocumentContent")
       const rowList = o.rowList ?? self;
       if (o.rowIndex === undefined) {
         // by default, insert new tiles after last visible on screen
-        o.rowIndex = self.defaultInsertRow;
+        o.rowIndex = self.defaultInsertRowIndex;
       }
       const row = TileRowModel.create({});
       rowList.insertRow(row, o.rowIndex);
@@ -588,7 +608,7 @@ export const BaseDocumentContentModel = RowList.named("BaseDocumentContent")
       const rowList = o.rowList ?? self;
       if (o.rowIndex === undefined) {
         // by default, insert new tiles after last visible on screen.
-        o.rowIndex = self.defaultInsertRow;
+        o.rowIndex = self.defaultInsertRowIndex;
       }
       const row = o.rowId ? rowList.getRow(o.rowId) : rowList.getRowByIndex(o.rowIndex);
       if (row) {
@@ -610,8 +630,8 @@ export const BaseDocumentContentModel = RowList.named("BaseDocumentContent")
       self.addPlaceholderRowIfAppropriate(rowList, rowIndex);
       return row;
     },
-    showPendingInsertHighlight(show: boolean, insertRowIndex?: number) {
-      self.highlightPendingDropLocation = show ? insertRowIndex ?? self.defaultInsertRow : -1;
+    showPendingInsertHighlight(show: boolean, rowId?: string) {
+      self.highlightPendingDropLocation = show ? rowId ?? self.defaultInsertRowId : undefined;
     }
   }))
   .actions((self) => ({

--- a/src/models/document/document-content-tests/dc-general.test.ts
+++ b/src/models/document/document-content-tests/dc-general.test.ts
@@ -37,7 +37,7 @@ describe("DocumentContentModel", () => {
     expect(documentContent.firstTile).toBeUndefined();
     expect(documentContent.rowCount).toBe(0);
     expect(documentContent.indexOfLastVisibleRow).toBe(-1);
-    expect(documentContent.defaultInsertRow).toBe(0);
+    expect(documentContent.defaultInsertRowIndex).toBe(0);
     expect(parsedContentExport()).toEqual({ tiles: [] });
     expect(documentContent.getTilesInDocumentOrder()).toEqual([]);
   });
@@ -48,7 +48,7 @@ describe("DocumentContentModel", () => {
     expect(documentContent.tileMap.size).toBe(1);
     documentContent.addTile("geometry", { title: "Coordinate Grid 1" });
     expect(documentContent.tileMap.size).toBe(2);
-    expect(documentContent.defaultInsertRow).toBe(2);
+    expect(documentContent.defaultInsertRowIndex).toBe(2);
     const newRowTile = documentContent.addTile("table", { title: "Table 1" });
     const columnWidths = getColumnWidths(documentContent, newRowTile?.tileId);
     expect(documentContent.tileMap.size).toBe(3);
@@ -235,7 +235,7 @@ describe("DocumentContentModel -- sectioned documents --", () => {
       { Header: "A"},
       { Placeholder: "A" }
     ]);
-    expect(content1.defaultInsertRow).toBe(1);
+    expect(content1.defaultInsertRowIndex).toBe(1);
 
     const content2 = createDocumentContent(
       "[Header:A, Placeholder, Header:B, Placeholder]"
@@ -246,7 +246,7 @@ describe("DocumentContentModel -- sectioned documents --", () => {
       { Header: "B"},
       { Placeholder: "B" }
     ]);
-    expect(content2.defaultInsertRow).toBe(1);
+    expect(content2.defaultInsertRowIndex).toBe(1);
     expect(parsedExport(content2)).toEqual({ tiles: [] });
   });
 
@@ -262,7 +262,7 @@ describe("DocumentContentModel -- sectioned documents --", () => {
       { Header: "B"},
       { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] }}
     ]);
-    expect(content.defaultInsertRow).toBe(4);
+    expect(content.defaultInsertRowIndex).toBe(4);
   });
 
   it("will remove placeholder tiles when adding a new tile in an interior section", () => {
@@ -277,7 +277,7 @@ describe("DocumentContentModel -- sectioned documents --", () => {
       { Header: "B"},
       { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] }}
     ]);
-    expect(content.defaultInsertRow).toBe(4);
+    expect(content.defaultInsertRowIndex).toBe(4);
   });
 
   it("will restore placeholder tiles when deleting the last row in an interior section", () => {
@@ -293,7 +293,7 @@ describe("DocumentContentModel -- sectioned documents --", () => {
       { Header: "B"},
       { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] }}
     ]);
-    expect(content.defaultInsertRow).toBe(4);
+    expect(content.defaultInsertRowIndex).toBe(4);
   });
 
   it("will restore placeholder tiles when deleting the last row in the last section", () => {
@@ -309,7 +309,7 @@ describe("DocumentContentModel -- sectioned documents --", () => {
       { Header: "B"},
       { Placeholder: "B" }
     ]);
-    expect(content.defaultInsertRow).toBe(1);
+    expect(content.defaultInsertRowIndex).toBe(1);
   });
 
   it("will add/remove placeholder rows when moving entire rows (3 => 1)", () => {
@@ -329,7 +329,7 @@ describe("DocumentContentModel -- sectioned documents --", () => {
       { Header: "B"},
       { Placeholder: "B" }
     ]);
-    expect(content.defaultInsertRow).toBe(2);
+    expect(content.defaultInsertRowIndex).toBe(2);
   });
 
   it("will add/remove placeholder rows when moving entire rows (1 => 3)", () => {
@@ -344,7 +344,7 @@ describe("DocumentContentModel -- sectioned documents --", () => {
       { Header: "B"},
       { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } },
     ]);
-    expect(content.defaultInsertRow).toBe(4);
+    expect(content.defaultInsertRowIndex).toBe(4);
   });
 
   it("will add/remove placeholder rows when moving a tile back to a new row", () => {
@@ -361,7 +361,7 @@ describe("DocumentContentModel -- sectioned documents --", () => {
       { Header: "B"},
       { Placeholder: "B" }
     ]);
-    expect(content.defaultInsertRow).toBe(2);
+    expect(content.defaultInsertRowIndex).toBe(2);
   });
 
   it("will add/remove placeholder rows when moving a tile forward to a new row", () => {
@@ -378,7 +378,7 @@ describe("DocumentContentModel -- sectioned documents --", () => {
       { Header: "B"},
       { title: "Text 1", content: { type: "Text", format: "html", text: ["<p></p>"] } },
     ]);
-    expect(content.defaultInsertRow).toBe(4);
+    expect(content.defaultInsertRowIndex).toBe(4);
   });
 
   it("will add/remove placeholder rows when moving a tile back to an existing row", () => {
@@ -394,7 +394,7 @@ describe("DocumentContentModel -- sectioned documents --", () => {
       { Header: "B"},
       { Placeholder: "B" }
     ]);
-    expect(content.defaultInsertRow).toBe(2);
+    expect(content.defaultInsertRowIndex).toBe(2);
   });
 
   it("will add/remove placeholder rows when moving a tile forward to an existing row", () => {

--- a/src/models/document/document-content-tests/dc-question-tile-move-copy.test.ts
+++ b/src/models/document/document-content-tests/dc-question-tile-move-copy.test.ts
@@ -131,9 +131,11 @@ describe("Question tile operations", () => {
         rowDropId: "testid-6",
         rowDropLocation: "right"
       };
+      // Note, text-2 should be inserted before sketch-1, since it's earlier in the document order,
+      // despite the different order in the argument to getDocumentDragTileItems.
       documentContent.moveTiles(dragTiles, dropRowInfo);
       expect(documentContent.debugDescribeThis(documentContent.tileMap, ""))
-      .toEqual("testid-6: [Text: text-1] [Drawing: sketch-1] [Text: text-2]\n" +
+      .toEqual("testid-6: [Text: text-1] [Text: text-2] [Drawing: sketch-1]\n" +
         "testid-7: [Table: table-1] [Expression: expression-1]\n" +
         "testid-8: [Question: question-1]" +
         "\nContents of embedded row list:\n" +

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -130,7 +130,7 @@ export const DocumentContentModel = DocumentContentModelWithTileDragging.named("
     const builder = new StringBuilder();
     builder.pushLine("{");
 
-    const includedTileIds = rows.flatMap(row => row?.allTileIds ?? []);
+    const includedTileIds = rows.flatMap(row => row?.tileIds ?? []);
     const sharedModels = Object.values(self.getSharedModelsUsedByTiles(includedTileIds));
     const hasSharedModels = sharedModels.length > 0;
     const annotations = Object.values(self.getAnnotationsUsedByTiles(includedTileIds));
@@ -180,7 +180,7 @@ export const DocumentContentModel = DocumentContentModelWithTileDragging.named("
     updatedTiles.forEach(tile => {
       const {rowId, sectionId} = copySpec.tilePositions[tile.tileId];
       let targetRow = targetRowMap.get(rowId);
-      let insertedRowIndex = self.defaultInsertRow;
+      let insertedRowIndex = self.defaultInsertRowIndex;
       const insertingRow = !targetRow;
 
       if (sectionId) {
@@ -419,7 +419,7 @@ export const DocumentContentModel = DocumentContentModelWithTileDragging.named("
       return;
     }
     // New tiles go into a row after the last copied tile
-    const rowIndex = self.getRowAfterTiles(tiles);
+    const rowId = self.getLastRowForTiles(tiles) || rowList.rowOrder[rowList.rowOrder.length - 1];
 
     // Find shared models used by tiles being duplicated
     const sharedModelEntries = Object.values(self.getSharedModelsUsedByTiles(tileIds));
@@ -435,7 +435,7 @@ export const DocumentContentModel = DocumentContentModelWithTileDragging.named("
       snapshots,
       annotations,
       false, // duplicating within same document
-      { rowDropId: rowList.rowOrder[rowIndex-1], rowInsertIndex: rowIndex }
+      { rowDropId: rowId, rowInsertIndex: rowList.getRowIndex(rowId) + 1, rowDropLocation: "bottom" }
     );
   },
   /**

--- a/src/models/document/drag-tiles.test.ts
+++ b/src/models/document/drag-tiles.test.ts
@@ -6,6 +6,9 @@ import { IDocumentImportSnapshot } from "./document-content-import-types";
 import { SharedDataSetSnapshotType } from "../shared/shared-data-set";
 import { SharedModelDocumentManager } from "./shared-model-document-manager";
 import { ITileEnvironment } from "../tiles/tile-content";
+import { IDragTileItem } from "../tiles/tile-model";
+import { IDragTilesData } from "./document-content-types";
+
 registerTileTypes(["Text"]);
 
 // mock uniqueId so auto-generated IDs are consistent
@@ -25,6 +28,24 @@ function createDocumentContentModel(snapshot: IDocumentImportSnapshot) {
   const content = DocumentContentModel.create(snapshot as DocumentContentSnapshotType, environment);
   sharedModelManager.setDocument(content);
   return content;
+}
+
+// For simplicify of comparing to a snapshot, replace the complex rowList object
+// with a simpler object that just has the rowOrder.
+function cleanDragTileItems(items: IDragTileItem[]) {
+  return items.map((item: { rowList: { rowOrder: any; }; }) => {
+    return {
+      ...item,
+      rowList: { rowOrder: item.rowList.rowOrder }
+    };
+  });
+}
+
+function cleanDragTiles(tiles: IDragTilesData) {
+  return {
+    ...tiles,
+    tiles: cleanDragTileItems(tiles.tiles)
+  };
 }
 
 describe("tile dragging", () => {
@@ -116,8 +137,7 @@ describe("tile dragging", () => {
     });
     describe("when one tile is selected", () => {
       it("returns an array of one IDragTileItem object", () => {
-        const items = documentContent.getDragTileItems(["tile1"]);
-
+        const items = cleanDragTileItems(documentContent.getDragTileItems(["tile1"]));
         // Jest messes up the indentation when it writes out the snapshots with
         // --updateSnapshot (see https://jestjs.io/docs/snapshot-testing)
         // But having them inline seems more valuable than consistent indentation
@@ -127,6 +147,13 @@ Array [
   Object {
     "rowHeight": undefined,
     "rowIndex": 0,
+    "rowList": Object {
+      "rowOrder": Array [
+        "testid-3",
+        "testid-4",
+        "testid-5",
+      ],
+    },
     "tileContent": "{\\"id\\":\\"testid-1000\\",\\"title\\":\\"tile 1\\",\\"content\\":{\\"type\\":\\"Text\\",\\"text\\":\\"\\"}}",
     "tileId": "tile1",
     "tileIndex": 0,
@@ -139,7 +166,7 @@ Array [
     });
     describe("when two tiles are selected", () => {
       it("returns an array of both IDragTileItem objects", () => {
-        const items = documentContent.getDragTileItems(["tile1", "tile2"]);
+        const items = cleanDragTileItems(documentContent.getDragTileItems(["tile1", "tile2"]));
 
         /*eslint-disable max-len*/
         expect(items).toMatchInlineSnapshot(`
@@ -147,6 +174,13 @@ Array [
   Object {
     "rowHeight": undefined,
     "rowIndex": 0,
+    "rowList": Object {
+      "rowOrder": Array [
+        "testid-3",
+        "testid-4",
+        "testid-5",
+      ],
+    },
     "tileContent": "{\\"id\\":\\"testid-1000\\",\\"title\\":\\"tile 1\\",\\"content\\":{\\"type\\":\\"Text\\",\\"text\\":\\"\\"}}",
     "tileId": "tile1",
     "tileIndex": 0,
@@ -155,6 +189,13 @@ Array [
   Object {
     "rowHeight": undefined,
     "rowIndex": 1,
+    "rowList": Object {
+      "rowOrder": Array [
+        "testid-3",
+        "testid-4",
+        "testid-5",
+      ],
+    },
     "tileContent": "{\\"id\\":\\"testid-1001\\",\\"title\\":\\"tile 2\\",\\"content\\":{\\"type\\":\\"Text\\",\\"text\\":\\"\\"}}",
     "tileId": "tile2",
     "tileIndex": 0,
@@ -168,7 +209,7 @@ Array [
 
     describe("when a table using a shared dataset is selected", () => {
       it("returns the table IDragTileItem object", () => {
-        const items = documentContent.getDragTileItems(["tile3"]);
+        const items = cleanDragTileItems(documentContent.getDragTileItems(["tile3"]));
 
         // TODO: The exported table here includes importedDataSet property.
         // Since we are going to include the actual shared dataset too, the
@@ -180,6 +221,13 @@ Array [
   Object {
     "rowHeight": undefined,
     "rowIndex": 2,
+    "rowList": Object {
+      "rowOrder": Array [
+        "testid-3",
+        "testid-4",
+        "testid-5",
+      ],
+    },
     "tileContent": "{\\"id\\":\\"testid-1000\\",\\"content\\":{\\"type\\":\\"Table\\",\\"isImported\\":false,\\"importedDataSet\\":{\\"id\\":\\"testid-6\\",\\"attributes\\":[],\\"cases\\":[]},\\"columnWidths\\":{}}}",
     "tileId": "tile3",
     "tileIndex": 0,
@@ -195,7 +243,7 @@ Array [
   describe("getDragTiles", () => {
     describe("when one tile is selected", () => {
       it("returns that tile and an the other IDragTiles properties", () => {
-        const dragTiles = documentContent.getDragTiles(["tile1"]);
+        const dragTiles = cleanDragTiles(documentContent.getDragTiles(["tile1"]));
         /*eslint-disable max-len*/
         expect(dragTiles).toMatchInlineSnapshot(`
 Object {
@@ -206,6 +254,13 @@ Object {
     Object {
       "rowHeight": undefined,
       "rowIndex": 0,
+      "rowList": Object {
+        "rowOrder": Array [
+          "testid-3",
+          "testid-4",
+          "testid-5",
+        ],
+      },
       "tileContent": "{\\"id\\":\\"testid-1000\\",\\"title\\":\\"tile 1\\",\\"content\\":{\\"type\\":\\"Text\\",\\"text\\":\\"\\"}}",
       "tileId": "tile1",
       "tileIndex": 0,
@@ -220,7 +275,7 @@ Object {
     });
     describe("with two tiles selected", () => {
       it("returns both tiles in document order", () => {
-        const dragTiles = documentContent.getDragTiles(["tile2", "tile1"]);
+        const dragTiles = cleanDragTiles(documentContent.getDragTiles(["tile2", "tile1"]));
         /*eslint-disable max-len*/
         expect(dragTiles).toMatchInlineSnapshot(`
 Object {
@@ -231,6 +286,13 @@ Object {
     Object {
       "rowHeight": undefined,
       "rowIndex": 0,
+      "rowList": Object {
+        "rowOrder": Array [
+          "testid-3",
+          "testid-4",
+          "testid-5",
+        ],
+      },
       "tileContent": "{\\"id\\":\\"testid-1001\\",\\"title\\":\\"tile 1\\",\\"content\\":{\\"type\\":\\"Text\\",\\"text\\":\\"\\"}}",
       "tileId": "tile1",
       "tileIndex": 0,
@@ -239,6 +301,13 @@ Object {
     Object {
       "rowHeight": undefined,
       "rowIndex": 1,
+      "rowList": Object {
+        "rowOrder": Array [
+          "testid-3",
+          "testid-4",
+          "testid-5",
+        ],
+      },
       "tileContent": "{\\"id\\":\\"testid-1000\\",\\"title\\":\\"tile 2\\",\\"content\\":{\\"type\\":\\"Text\\",\\"text\\":\\"\\"}}",
       "tileId": "tile2",
       "tileIndex": 0,
@@ -253,7 +322,7 @@ Object {
     });
     describe("with a tile using a shared model", () => {
       it("returns the tile and the shared model", () => {
-        const dragTiles = documentContent.getDragTiles(["tile3"]);
+        const dragTiles = cleanDragTiles(documentContent.getDragTiles(["tile3"]));
 
         /*eslint-disable max-len*/
         expect(dragTiles).toMatchInlineSnapshot(`
@@ -274,6 +343,13 @@ Object {
     Object {
       "rowHeight": undefined,
       "rowIndex": 2,
+      "rowList": Object {
+        "rowOrder": Array [
+          "testid-3",
+          "testid-4",
+          "testid-5",
+        ],
+      },
       "tileContent": "{\\"id\\":\\"testid-1000\\",\\"content\\":{\\"type\\":\\"Table\\",\\"isImported\\":false,\\"importedDataSet\\":{\\"id\\":\\"testid-6\\",\\"attributes\\":[],\\"cases\\":[]},\\"columnWidths\\":{}}}",
       "tileId": "tile3",
       "tileIndex": 0,

--- a/src/models/document/row-list.ts
+++ b/src/models/document/row-list.ts
@@ -14,6 +14,7 @@ export const RowList = types
     rowOrder: types.array(types.string),
   })
   .volatile(self => ({
+    // IDs of top-level rows that are currently visible on the screen
     visibleRows: [] as string[],
   }))
   .views(self => ({
@@ -30,7 +31,7 @@ export const RowList = types
       return self.rowOrder.findIndex(_rowId => _rowId === rowId);
     },
     get indexOfLastVisibleRow() {
-      // returns last visible row or last row
+      // returns last visible row or last row FIXME
       if (!self.rowOrder.length) return -1;
       const lastVisibleRowId = self.visibleRows.length
                                 ? self.visibleRows[self.visibleRows.length - 1]
@@ -42,7 +43,7 @@ export const RowList = types
      * Does not include tile ids from nested RowList containers.
      */
     get tileIds() {
-      return self.rowOrder.flatMap(rowId => this.getRow(rowId)?.allTileIds ?? []);
+      return self.rowOrder.flatMap(rowId => this.getRow(rowId)?.tileIds ?? []);
     },
     rowHeightToExport(row: TileRowModelType, tileId: string, tileMap: Map<string, ITileModel>) {
       if (!row?.height) return;

--- a/src/models/document/tile-row.ts
+++ b/src/models/document/tile-row.ts
@@ -49,11 +49,9 @@ export const TileRowModel = types
     get isUserResizable() {
       return !self.isSectionHeader && self.tiles.some(tileRef => tileRef.isUserResizable);
     },
-    get allTileIds() {
-      return self.tiles.map(tile => tile.tileId);
-    },
+    /** Returns tileIds of tiles directly in this row */
     get tileIds() {
-      return this.allTileIds.join(", ");
+      return self.tiles.map(tile => tile.tileId);
     },
     acceptTileDrop(rowInfo: IDropRowInfo) {
       const rowDropLocation = rowInfo.rowDropLocation;

--- a/src/models/tiles/tile-model.ts
+++ b/src/models/tiles/tile-model.ts
@@ -9,11 +9,13 @@ import { uniqueId } from "../../utilities/js-utils";
 import { StringBuilder } from "../../utilities/string-builder";
 import { logTileDocumentEvent } from "./log/log-tile-document-event";
 import { LogEventName } from "../../lib/logger-types";
+import { RowListType } from "../document/row-list";
 
 // generally negotiated with app, e.g. single column width for table
 export const kDefaultMinWidth = 60;
 
 export interface ITilePosition {
+  rowList: RowListType;
   rowIndex: number;
   tileIndex: number;
   tileId: string;


### PR DESCRIPTION
Make the highlighting of "drop zones" work when the user hovers over toolbar buttons.

- Hovering over a tile button should highlight the location after the last visible top-level row of the document, and when clicked, the button should in fact insert the tile there.
- Hovering over the duplicate button should highlight a row just below the last of the selected tiles. ("last" means last in document order, not "most-recently selected"). Clicking the duplicate button will in fact put the copied tiles in this location, and they will match the selected tiles in order and layout.
  - If _all_ the selected tiles are inside a Question tile, this insert location will be inside the Question tile. 
  - If _any_ of the selected tiles are _not_ in the Question tile, then the insert location will not be in it; it will be after and outside it.

Attempts to drag a Question tile into a Question tile will be silently ignored. If a Question tile is selcted along with some other tiles, and dragged into a Question tile (including itself) the other tiles will be moved but the Question tile will not.