### PR TITLE
feat: Add check for unit parameter in standalone [CLUE-90]

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -136,6 +136,27 @@ export const authAndConnect = async (stores: IStores) => {
   }
 };
 
+const checkStandaloneUnitParam = ({ui}: IStores) => {
+  if (!ui.standalone || urlParams.unit) {
+    return true;
+  }
+
+  const error = new Error("Using CLUE in Standalone Mode requires a unit.");
+  ui.setError(error, undefined, () => {
+    return (
+      <div>
+        <p>
+          Using CLUE in Standalone Mode requires a unit. Please adjust your URL and try again.
+        </p>
+        <p>
+          Need assistance? Contact us at <a href="mailto:help@concord.org">help@concord.org</a>.
+        </p>
+      </div>
+    );
+  });
+  return false;
+};
+
 @inject("stores")
 @observer
 export class AppComponent extends BaseComponent<IProps> {
@@ -143,7 +164,9 @@ export class AppComponent extends BaseComponent<IProps> {
   constructor(props: IProps) {
     super(props);
 
-    authAndConnect(this.stores);
+    if (checkStandaloneUnitParam(this.stores)) {
+      authAndConnect(this.stores);
+    }
   }
 
   public componentWillUnmount() {
@@ -169,7 +192,7 @@ export class AppComponent extends BaseComponent<IProps> {
     }
 
     if (ui.error) {
-      return this.renderApp(this.renderError(ui.error));
+      return this.renderApp(this.renderError(ui.errorContent ?? ui.error));
     }
 
     // if we're in standalone mode and the user is not authenticated
@@ -217,14 +240,16 @@ export class AppComponent extends BaseComponent<IProps> {
     );
   }
 
-  private renderError(error: string) {
+  private renderError(error: string | React.FC<any>) {
+    const showButton = !this.stores.ui.errorContent;
+
     return (
       <div className="error">
         <ErrorAlert
           content={error}
           canCancel={false}
-          buttonLabel="Proceed"
-          onClick={this.handlePortalLoginRedirect}
+          buttonLabel={showButton ? "Proceed" : undefined}
+          onClick={showButton ? this.handlePortalLoginRedirect : undefined}
         />
       </div>
     );

--- a/src/components/utilities/error-alert.scss
+++ b/src/components/utilities/error-alert.scss
@@ -2,7 +2,6 @@
 
 .custom-modal.error-alert {
   width: 400px;
-  height: 160px;
   outline: none;
 
   .modal-icon svg {

--- a/src/components/utilities/use-error-alert.tsx
+++ b/src/components/utilities/use-error-alert.tsx
@@ -27,14 +27,14 @@ export const useErrorAlert = ({
 
   const [showAlert, hideAlert] = useCustomModal({
     className: `error-alert ${className || ""}`,
-    title: title || "",
+    title: title || "Uh oh!",
     Icon: ErrorSvg,
     Content,
     contentProps: {},
     canCancel,
-    buttons: [
+    buttons: onClick ? [
       { label: buttonLabel || "OK", isDefault: true, onClick }
-    ],
+    ] : [],
     onClose
   });
 

--- a/src/hooks/custom-modal.scss
+++ b/src/hooks/custom-modal.scss
@@ -3,7 +3,7 @@
 $modal-header-height: 34px;
 $modal-header-icon-width: 36px;
 $modal-header-border-radius: 6px;
-$modal-padding: 0 20px;
+$modal-padding: 20px;
 $modal-control-height: 30px;
 $modal-control-border: solid 1.5px $charcoal-light-1;
 $modal-control-border-radius: 5px;
@@ -86,12 +86,11 @@ $modal-footer-height: 45px;
 
   .modal-footer {
     width: 100%;
-    height: $modal-footer-height;
     flex: 0 0 auto;
     display: flex;
     justify-content: flex-end;
     align-items: flex-start;
-    padding: $modal-padding;
+    padding: 0 $modal-padding $modal-padding $modal-padding;
 
     .modal-button {
       cursor: pointer;

--- a/src/hooks/use-custom-modal.tsx
+++ b/src/hooks/use-custom-modal.tsx
@@ -102,18 +102,20 @@ export const useCustomModal = <IContentProps,>({
           { /* TODO Fix type cast */ }
           <Content as any {...(contentProps)}/>
         </div>
-        <div className="modal-footer">
-          {buttons.map((b, i) => {
-            const classes = classNames("modal-button", b.className, { default: b.isDefault, disabled: b.isDisabled });
-            const key = `${i}-${b.className}`;
-            const handleClick = () => invokeButton(b, handleClose);
-            return (
-              <button type="button" className={classes} key={key} onClick={handleClick}>
-                {b.label}
-              </button>
-            );
-          })}
-        </div>
+        {buttons.length > 0 &&
+          <div className="modal-footer">
+            {buttons.map((b, i) => {
+              const classes = classNames("modal-button", b.className, { default: b.isDefault, disabled: b.isDisabled });
+              const key = `${i}-${b.className}`;
+              const handleClick = () => invokeButton(b, handleClose);
+              return (
+                <button type="button" className={classes} key={key} onClick={handleClick}>
+                  {b.label}
+                </button>
+              );
+            })}
+          </div>
+        }
       </Modal>
     );
   }, dependencies);

--- a/src/models/stores/ui.ts
+++ b/src/models/stores/ui.ts
@@ -59,6 +59,7 @@ export const UIModel = types
   .volatile(self => ({
     defaultLeftNavExpanded: false,
     standalone: false,
+    errorContent: undefined as React.FC<any> | undefined,
   }))
   .views((self) => ({
     isSelectedTile(tile: ITileModel) {
@@ -158,8 +159,9 @@ export const UIModel = types
       },
 
 
-      setError(error: unknown, customMessage?: string) {
+      setError(error: unknown, customMessage?: string, content?: React.FC<any>) {
         self.error = customMessage ?? String(error);
+        self.errorContent = content;
         Logger.log(LogEventName.INTERNAL_ERROR_ENCOUNTERED, { message: self.error });
         if (error instanceof Error) {
           // In Chrome, passing an error instance to console.error() will print the
@@ -178,6 +180,7 @@ export const UIModel = types
       },
       clearError() {
         self.error = null;
+        self.errorContent = undefined;
       },
 
       setSelectedTile(tile?: ITileModel, options?: {append: boolean, dragging?: boolean}) {


### PR DESCRIPTION
This adds a check for the unit parameter in the standalone mode.

If the unit parameter is not present, an error alert will be displayed to the user using a custom model error content.

The ability to show custom modal error content was also added in this commit along with the following changes to modals:

- Removed the fixed height of the modal content
- Removed the bottom button area when no buttons are defined
- Updated the styling to allow for the bottom button area to be hidden
- Added a default error title of "Uh Oh!" to the error alert

Here is what the new unit check modal looks like:

![image](https://github.com/user-attachments/assets/13230688-4fae-4db6-9383-5abdaa48f2eb)

and here is what an existing modal with buttons looks like:

![image](https://github.com/user-attachments/assets/8c73b7d1-e871-49ac-9032-5a64286299f5)
