### PR TITLE
Copying question tiles

### DIFF
--- a/src/components/document/document-content.tsx
+++ b/src/components/document/document-content.tsx
@@ -18,6 +18,7 @@ import { safeJsonParse } from "../../utilities/js-utils";
 import { RowListComponent } from "./row-list";
 import { DropRowContext } from "./drop-row-context";
 import { RowRefsContext } from "./row-refs-context";
+import { LockedContainerContext } from "./locked-container-context";
 
 import "./document-content.sass";
 
@@ -168,21 +169,23 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
     return (
       <DocumentDndContext>
         <DropRowContext.Provider value={dropRow}>
-          <RowRefsContext.Provider value={{ addRowRef: this.addRowRef }}>
-            <div className={documentClass}
-              data-testid="document-content"
-              data-document-key={this.props.documentId}
-              onScroll={this.handleScroll}
-              onClick={this.handleClick}
-              onDragOver={this.handleDragOver}
+          <LockedContainerContext.Provider value={false}>
+            <RowRefsContext.Provider value={{ addRowRef: this.addRowRef }}>
+              <div className={documentClass}
+                data-testid="document-content"
+                data-document-key={this.props.documentId}
+                onScroll={this.handleScroll}
+                onClick={this.handleClick}
+                onDragOver={this.handleDragOver}
               onDragLeave={this.handleDragLeave}
               onDrop={this.handleDrop}
               ref={(elt) => this.domElement = elt}
-            >
-              {this.renderRows()}
-              {this.renderSpacer()}
-            </div>
-          </RowRefsContext.Provider>
+              >
+                {this.renderRows()}
+                {this.renderSpacer()}
+              </div>
+            </RowRefsContext.Provider>
+          </LockedContainerContext.Provider>
         </DropRowContext.Provider>
       </DocumentDndContext>
     );
@@ -430,8 +433,9 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
 
   private handleMoveTilesDrop = (e: React.DragEvent<HTMLDivElement>, dragTilesData: IDragTilesData) => {
     const dropRowInfo = this.getDropRowInfo(e);
-    if (!dropRowInfo) return;
-    this.props.content?.userMoveTiles(dragTilesData.tiles, dropRowInfo);
+    const content = this.props.content;
+    if (!dropRowInfo || !content) return;
+    content.userMoveTiles(content.removeEmbeddedTilesFromDragTiles(dragTilesData.tiles), dropRowInfo);
   };
 
   private handleCopyTilesDrop = (e: React.DragEvent<HTMLDivElement>, dragTiles: IDragTilesData) => {

--- a/src/components/document/locked-container-context.tsx
+++ b/src/components/document/locked-container-context.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+/**
+ * Context to let children know if they are inside a locked container.
+ */
+export const LockedContainerContext = React.createContext<boolean>(false);
+
+export const useLockedContainerContext = () => {
+  return React.useContext(LockedContainerContext);
+};

--- a/src/components/tiles/question/question-tile.tsx
+++ b/src/components/tiles/question/question-tile.tsx
@@ -9,6 +9,7 @@ import QuestionBadge from "../../../assets/icons/question-badge.svg";
 import { useCurrent } from "../../../hooks/use-current";
 import { useUIStore } from "../../../hooks/use-stores";
 import { useTileSelectionPointerEvents } from "../geometry/use-tile-selection-pointer-events";
+import { LockedContainerContext } from "../../document/locked-container-context";
 
 import "./question-tile.scss";
 
@@ -27,32 +28,34 @@ export const QuestionTileComponent: React.FC<ITileProps> = observer(function Que
   );
 
   return (
-    <div className="question-tile-content"
+    <LockedContainerContext.Provider value={content.locked}>
+      <div className="question-tile-content"
           data-testid="question-tile"
           ref={domElement}
           onMouseDown={handlePointerDown}
           onMouseUp={handlePointerUp}
       >
-      <div className="question-badge">
-        <QuestionBadge />
+        <div className="question-badge">
+          <QuestionBadge />
+        </div>
+        <div className="question-tile-spacer" />
+        {content.locked ? (
+          <ReadOnlyTileTitle />
+        ) : (
+          <BasicEditableTileTitle />
+        )}
+        <div className="question-tile-rows focusable">
+          <RowListComponent
+            rowListModel={content}
+            documentContent={props.documentContent}
+            context={props.context}
+            documentId={props.documentId}
+            docId={props.docId}
+            scale={props.scale}
+            readOnly={props.readOnly}
+          />
+        </div>
       </div>
-      <div className="question-tile-spacer" />
-      {content.locked ? (
-        <ReadOnlyTileTitle />
-      ) : (
-        <BasicEditableTileTitle />
-      )}
-      <div className="question-tile-rows focusable">
-        <RowListComponent
-          rowListModel={content}
-          documentContent={props.documentContent}
-          context={props.context}
-          documentId={props.documentId}
-          docId={props.docId}
-          scale={props.scale}
-          readOnly={props.readOnly}
-        />
-      </div>
-    </div>
+    </LockedContainerContext.Provider>
   );
 });

--- a/src/components/tiles/text/text-tile.tsx
+++ b/src/components/tiles/text/text-tile.tsx
@@ -234,7 +234,7 @@ export default class TextToolComponent extends BaseComponent<ITileProps, IState>
   private handleMouseDownInWrapper = (e: React.MouseEvent<HTMLDivElement>) => {
     const { ui } = this.stores;
     const { model, readOnly } = this.props;
-    if (model.isFixedPosition) return;
+    // if (model.isFixedPosition) return; TODO check read-only
 
     const isExtendingSelection = hasSelectionModifier(e);
     const isWrapperClick = e.target === this.textTileDiv;

--- a/src/components/tiles/tile-component.tsx
+++ b/src/components/tiles/tile-component.tsx
@@ -337,11 +337,6 @@ export class TileComponent extends BaseComponent<IProps, IState> {
       return;
     }
 
-    // If the tile is fixed, don't allow selection
-    // if (model.isFixedPosition) {
-    //   return;
-    // }
-
     // Select the tile if the tool doesn't handle the selection itself
     if (!getTileComponentInfo(model.content.type)?.tileHandlesOwnSelection) {
       ui.setSelectedTile(model, {append: hasSelectionModifier(e)});

--- a/src/components/tiles/tile-component.tsx
+++ b/src/components/tiles/tile-component.tsx
@@ -339,9 +339,9 @@ export class TileComponent extends BaseComponent<IProps, IState> {
     }
 
     // If the tile is fixed, don't allow selection
-    if (model.isFixedPosition) {
-      return;
-    }
+    // if (model.isFixedPosition) {
+    //   return;
+    // }
 
     // Select the tile if the tool doesn't handle the selection itself
     if (!getTileComponentInfo(model.content.type)?.tileHandlesOwnSelection) {

--- a/src/components/tiles/tile-component.tsx
+++ b/src/components/tiles/tile-component.tsx
@@ -259,8 +259,7 @@ export class TileComponent extends BaseComponent<IProps, IState> {
                 key={`tile-component-${tileId}`}
                 tileElt={this.domElement}
                 {...this.props}
-                readOnly={this.props.readOnly ||
-                  (this.props.model.isFixedPosition && this.props.model.isInsideLockedTile)}
+                readOnly={this.props.readOnly}
                 onRegisterTileApi={this.handleRegisterTileApi}
                 onUnregisterTileApi={this.handleUnregisterTileApi} />
             : null;

--- a/src/components/toolbar.tsx
+++ b/src/components/toolbar.tsx
@@ -304,12 +304,14 @@ export class ToolbarComponent extends BaseComponent<IProps, IState> {
     const { document } = this.props;
     const { ui } = this.stores;
     const selectedTileIds = ui.selectedTileIds;
+    if (!document?.content) return;
 
     // Sort the selected tile ids in top->bottom, left->right order so they duplicate in the correct formation
-    const tilePositions = document?.content?.getTilePositions(Array.from(selectedTileIds)) || [];
-    const dragTileItems = document?.content?.getDragTileItems(tilePositions.map(info => info.tileId)) || [];
+    const tilePositions = document.content.getTilePositions(Array.from(selectedTileIds)) || [];
+    const selectedDragTileItems = document.content.getDragTileItems(tilePositions.map(info => info.tileId)) || [];
+    const dragTileItems = document.content.addEmbeddedTilesToDragTiles(selectedDragTileItems);
 
-    document?.content?.duplicateTiles(dragTileItems);
+    document.content.duplicateTiles(dragTileItems);
     ui.clearSelectedTiles();
     this.removeDropRowHighlight();
   }

--- a/src/models/document/base-document-content.ts
+++ b/src/models/document/base-document-content.ts
@@ -666,25 +666,36 @@ export const BaseDocumentContentModel = RowList.named("BaseDocumentContent")
     copyTilesIntoExistingRow(tiles: IDropTileItem[], rowInfo: IDropRowInfo) {
       const results: NewRowTileArray = [];
       if (tiles.length > 0) {
-        tiles.forEach(tile => {
+        // If inserting to the left, reverse the order of the tiles so that
+        // the first tile is the one that ends up at the beginning of the row.
+        const orderedTiles = rowInfo.rowDropLocation === "left" ? tiles.reverse() : tiles;
+        orderedTiles.forEach(tile => {
           let result: INewRowTile | undefined;
           const parsedContent = safeJsonParse<ITileModelSnapshotIn>(tile.tileContent);
           const title = parsedContent?.title;
           const uniqueTitle = title && self.getUniqueTitle(title);
-          if (parsedContent?.content) {
-            const rowOptions: INewTileOptions = {
-              rowIndex: rowInfo.rowInsertIndex,
-              locationInRow: rowInfo.rowDropLocation
-            };
-            if (tile.rowHeight) {
-              rowOptions.rowHeight = tile.rowHeight;
+          const content = parsedContent?.content;
+          if (content) {
+            if (tile.embedded) {
+              // already is part of another tile, so we don't need to add it to any rows, just the tileMap.
+              self.tileMap.put({id: tile.newTileId, content, title: uniqueTitle});
+              result = { rowId: "", tileId: tile.newTileId };
+            } else {
+              const rowOptions: INewTileOptions = {
+                rowId: rowInfo.rowDropId,
+                locationInRow: rowInfo.rowDropLocation
+              };
+              console.log("adding tile", tile.tileId, "at", rowInfo.rowDropId, rowInfo.rowDropLocation);
+              if (tile.rowHeight) {
+                rowOptions.rowHeight = tile.rowHeight;
+              }
+              const adjustedSnapshot = {
+                  ...parsedContent,
+                  id: tile.newTileId,
+                  title: uniqueTitle
+                };
+              result = self.addTileSnapshotInExistingRow(adjustedSnapshot, rowOptions);
             }
-            const adjustedSnapshot = {
-              ...parsedContent,
-              id: tile.newTileId,
-              title: uniqueTitle
-            };
-            result = self.addTileSnapshotInExistingRow(adjustedSnapshot, rowOptions);
           }
           results.push(result);
         });
@@ -704,31 +715,39 @@ export const BaseDocumentContentModel = RowList.named("BaseDocumentContent")
           const uniqueTitle = title && self.getUniqueTitle(title);
           const content = parsedContent?.content;
           if (content) {
-            if (tile.rowIndex !== lastRowIndex) {
-              rowDelta++;
-            }
-            const tileOptions: INewTileOptions = {
-              rowList: (rowInfo.rowDropId && self.getRowListForRow(rowInfo.rowDropId)) || self,
-              rowId: lastRowId,
-              rowIndex: rowInfo.rowInsertIndex + rowDelta,
-              tileId: tile.newTileId,
-              title: uniqueTitle
-            };
-            if (tile.rowHeight) {
-              tileOptions.rowHeight = tile.rowHeight;
-            }
-            if (tile.rowIndex !== lastRowIndex) {
-              result = self.addTileContentInNewRow(content, tileOptions);
-              lastRowIndex = tile.rowIndex;
-              lastRowId = result.rowId;
-            }
-            else {
-              // This code path happens when there are two or more tiles which
-              // were in the same row in the source document. `tile.rowIndex` is
-              // the rowIndex of the tile in the source document. `lastRowIndex`
-              // is the source row index of the last tile.
-              const tileSnapshot: ITileModelSnapshotIn = { id: tile.newTileId, title: parsedContent.title, content };
-              result = self.addTileSnapshotInExistingRow(tileSnapshot, tileOptions);
+            if (tile.embedded) {
+              // already is part of another tile, so we don't need to add it to any rows, just the tileMap.
+              console.log("embedded tile", tile.tileId);
+              self.tileMap.put({id: tile.newTileId, content, title: uniqueTitle});
+              result = { rowId: "", tileId: tile.newTileId };
+            } else {
+              console.log("non-embedded tile", tile.tileId);
+              if (tile.rowIndex !== lastRowIndex) {
+                rowDelta++;
+              }
+              const tileOptions: INewTileOptions = {
+                rowList: (rowInfo.rowDropId && self.getRowListForRow(rowInfo.rowDropId)) || self,
+                rowId: lastRowId,
+                rowIndex: rowInfo.rowInsertIndex + rowDelta,
+                tileId: tile.newTileId,
+                title: uniqueTitle
+              };
+              if (tile.rowHeight) {
+                tileOptions.rowHeight = tile.rowHeight;
+              }
+              if (tile.rowIndex !== lastRowIndex) {
+                result = self.addTileContentInNewRow(content, tileOptions);
+                lastRowIndex = tile.rowIndex;
+                lastRowId = result.rowId;
+              }
+              else {
+                // This code path happens when there are two or more tiles which
+                // were in the same row in the source document. `tile.rowIndex` is
+                // the rowIndex of the tile in the source document. `lastRowIndex`
+                // is the source row index of the last tile.
+                const tileSnapshot: ITileModelSnapshotIn = { id: tile.newTileId, title: parsedContent.title, content };
+                result = self.addTileSnapshotInExistingRow(tileSnapshot, tileOptions);
+              }
             }
           }
           results.push(result);

--- a/src/models/document/document-content-tests/dc-question-tile-move-copy.test.ts
+++ b/src/models/document/document-content-tests/dc-question-tile-move-copy.test.ts
@@ -30,10 +30,43 @@ describe("Question tile operations", () => {
         // NOTE: The layout below is the starting layout of the document before each subsequent test.
         .toEqual("testid-6: [Text: text-1]\n" +
                  "testid-7: [Table: table-1] [Expression: expression-1]\n" +
-                 "testid-8: [Question: question-1]" +
-                 "\nContents of embedded row list:\n" +
+                 "testid-8: [Question: question-1]\n" +
+                 "Contents of embedded row list:\n" +
                  "  testid-9: [Text: text-2]\n" +
                  "  testid-10: [Table: table-2] [Drawing: sketch-1]");
+    });
+
+    it("can move a question tile to new row", () => {
+      const dragTiles = getDocumentDragTileItems(["question-1"]);
+      const dropRowInfo: IDropRowInfo = {
+        rowInsertIndex: 0,
+        rowDropId: "testid-6",
+        rowDropLocation: "bottom"
+      };
+      documentContent.moveTiles(dragTiles, dropRowInfo);
+      expect(documentContent.debugDescribeThis(documentContent.tileMap, ""))
+        .toEqual("testid-6: [Text: text-1]\n" +
+                 "testid-8: [Question: question-1]\n" +
+                 "Contents of embedded row list:\n" +
+                 "  testid-9: [Text: text-2]\n" +
+                 "  testid-10: [Table: table-2] [Drawing: sketch-1]\n" +
+                 "testid-7: [Table: table-1] [Expression: expression-1]");
+    });
+
+    it("can move a question tile to existing row", () => {
+      const dragTiles = getDocumentDragTileItems(["question-1"]);
+      const dropRowInfo: IDropRowInfo = {
+        rowInsertIndex: 0,
+        rowDropId: "testid-6",
+        rowDropLocation: "left"
+      };
+      documentContent.moveTiles(dragTiles, dropRowInfo);
+      expect(documentContent.debugDescribeThis(documentContent.tileMap, ""))
+        .toEqual("testid-6: [Question: question-1] [Text: text-1]\n" +
+                 "Contents of embedded row list:\n" +
+                 "  testid-9: [Text: text-2]\n" +
+                 "  testid-10: [Table: table-2] [Drawing: sketch-1]\n" +
+                 "testid-7: [Table: table-1] [Expression: expression-1]");
     });
 
     it("can move a tile into a question tile", () => {
@@ -47,8 +80,8 @@ describe("Question tile operations", () => {
       documentContent.moveTiles(dragTiles, dropRowInfo);
       expect(documentContent.debugDescribeThis(documentContent.tileMap, ""))
         .toEqual("testid-7: [Table: table-1] [Expression: expression-1]\n" +
-                 "testid-8: [Question: question-1]" +
-                 "\nContents of embedded row list:\n" +
+                 "testid-8: [Question: question-1]\n" +
+                 "Contents of embedded row list:\n" +
                  "  testid-9: [Text: text-1] [Text: text-2]\n" +
                  "  testid-10: [Table: table-2] [Drawing: sketch-1]");
     });
@@ -82,11 +115,11 @@ describe("Question tile operations", () => {
       documentContent.moveTiles(dragTiles, dropRowInfo);
       expect(documentContent.debugDescribeThis(documentContent.tileMap, ""))
         .toEqual("testid-7: [Table: table-1] [Expression: expression-1]\n" +
-          "testid-8: [Question: question-1]" +
-          "\nContents of embedded row list:\n" +
-          "  testid-9: [Text: text-2]\n" +
-          "  testid-6: [Text: text-1]\n" +
-          "  testid-10: [Table: table-2] [Drawing: sketch-1]");
+                 "testid-8: [Question: question-1]\n" +
+                 "Contents of embedded row list:\n" +
+                 "  testid-9: [Text: text-2]\n" +
+                 "  testid-6: [Text: text-1]\n" +
+                 "  testid-10: [Table: table-2] [Drawing: sketch-1]");
       });
 
     it("can move a tile out of a question tile", () => {
@@ -100,8 +133,8 @@ describe("Question tile operations", () => {
       expect(documentContent.debugDescribeThis(documentContent.tileMap, ""))
       .toEqual("testid-6: [Text: text-1] [Drawing: sketch-1]\n" +
         "testid-7: [Table: table-1] [Expression: expression-1]\n" +
-        "testid-8: [Question: question-1]" +
-        "\nContents of embedded row list:\n" +
+        "testid-8: [Question: question-1]\n" +
+        "Contents of embedded row list:\n" +
         "  testid-9: [Text: text-2]\n" +
         "  testid-10: [Table: table-2]");
     });
@@ -117,8 +150,8 @@ describe("Question tile operations", () => {
       expect(documentContent.debugDescribeThis(documentContent.tileMap, ""))
       .toEqual("testid-6: [Text: text-1]\n" +
         "testid-7: [Table: table-1] [Expression: expression-1]\n" +
-        "testid-8: [Question: question-1]" +
-        "\nContents of embedded row list:\n" +
+        "testid-8: [Question: question-1]\n" +
+        "Contents of embedded row list:\n" +
         "  testid-9: [Text: text-2]\n" +
         "  testid-10: [Table: table-2]\n" +
         "testid-16: [Drawing: sketch-1]");
@@ -137,8 +170,8 @@ describe("Question tile operations", () => {
       expect(documentContent.debugDescribeThis(documentContent.tileMap, ""))
       .toEqual("testid-6: [Text: text-1] [Text: text-2] [Drawing: sketch-1]\n" +
         "testid-7: [Table: table-1] [Expression: expression-1]\n" +
-        "testid-8: [Question: question-1]" +
-        "\nContents of embedded row list:\n" +
+        "testid-8: [Question: question-1]\n" +
+        "Contents of embedded row list:\n" +
         "  testid-10: [Table: table-2]");
     });
 
@@ -153,8 +186,8 @@ describe("Question tile operations", () => {
       expect(documentContent.debugDescribeThis(documentContent.tileMap, ""))
         .toEqual("testid-6: [Text: text-1]\n" +
                  "testid-7: [Table: table-1] [Expression: expression-1]\n" +
-                 "testid-8: [Question: question-1]" +
-                 "\nContents of embedded row list:\n" +
+                 "testid-8: [Question: question-1]\n" +
+                 "Contents of embedded row list:\n" +
                  "  testid-10: [Table: table-2] [Drawing: sketch-1]\n" +
                  "  testid-9: [Text: text-2]");
     });
@@ -170,8 +203,8 @@ describe("Question tile operations", () => {
       expect(documentContent.debugDescribeThis(documentContent.tileMap, ""))
         .toEqual("testid-6: [Text: text-1]\n" +
                  "testid-7: [Table: table-1] [Expression: expression-1]\n" +
-                 "testid-8: [Question: question-1]" +
-                 "\nContents of embedded row list:\n" +
+                 "testid-8: [Question: question-1]\n" +
+                 "Contents of embedded row list:\n" +
                  "  testid-9: [Text: text-2]\n" +
                  "  testid-10: [Drawing: sketch-1] [Table: table-2]");
     });
@@ -187,8 +220,8 @@ describe("Question tile operations", () => {
       expect(documentContent.debugDescribeThis(documentContent.tileMap, ""))
         .toEqual("testid-6: [Text: text-1]\n" +
                  "testid-7: [Table: table-1] [Expression: expression-1]\n" +
-                 "testid-8: [Question: question-1]" +
-                 "\nContents of embedded row list:\n" +
+                 "testid-8: [Question: question-1]\n" +
+                 "Contents of embedded row list:\n" +
                  "  testid-9: [Text: text-2]\n" +
                  "  testid-10: [Drawing: sketch-1] [Table: table-2]");
     });

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -11,7 +11,7 @@ import {
 import { sharedModelFactory, UnknownSharedModel } from "../shared/shared-model-manager";
 import { SharedModelType } from "../shared/shared-model";
 import { getTileContentInfo, IDocumentExportOptions } from "../tiles/tile-content-info";
-import { IDragTileItem, IDropTileItem, ITileModel,
+import { IDragTileItem, IDropTileItem, isContainerTile, ITileModel,
          ITileModelSnapshotIn,
          ITileModelSnapshotOut } from "../tiles/tile-model";
 import { uniqueId } from "../../utilities/js-utils";
@@ -25,7 +25,6 @@ import {
 } from "../shared/shared-data-set";
 import { IClueObjectSnapshot } from "../annotations/clue-object";
 import { isRowListSnapshotIn, isRowListSnapshotOut } from "./row-list";
-import { kQuestionTileType } from "../tiles/question/question-content";
 
 
 export interface ITileCopyPosition {
@@ -305,8 +304,8 @@ export const DocumentContentModel = DocumentContentModelWithTileDragging.named("
     // We have to process container tiles last, so that we can update them with the
     // references to their new embedded tiles.
     const reorderedTiles: IDragTileItem[] = [
-      ...tiles.filter(tile => tile.tileType !== kQuestionTileType),
-      ...tiles.filter(tile => tile.tileType === kQuestionTileType)
+      ...tiles.filter(tile => !isContainerTile(tile)),
+      ...tiles.filter(tile => isContainerTile(tile))
     ];
     reorderedTiles.forEach(tile => {
       const oldTile: ITileModelSnapshotIn = JSON.parse(tile.tileContent);
@@ -564,8 +563,6 @@ export const DocumentContentModel = DocumentContentModelWithTileDragging.named("
     };
   },
   applyCopySpec(copySpec: ICopySpec, isCrossingDocuments: boolean) {
-        // FIXME needs to include any embedded tiles
-
     return self.copyTiles(
       copySpec.tiles, copySpec.sharedModelEntries, copySpec.annotations, isCrossingDocuments, undefined, copySpec
     );

--- a/src/models/document/drag-tiles.ts
+++ b/src/models/document/drag-tiles.ts
@@ -137,7 +137,6 @@ export const DocumentContentModelWithTileDragging = DocumentContentModelWithAnno
       annotations: Object.values(self.getAnnotationsUsedByTiles(tileIds))
     };
 
-    console.log("dragTiles", dragTiles.tiles.map(t => `${t.tileId} ${t.tileType}`));
     return dragTiles;
   }
 }));

--- a/src/models/document/drag-tiles.ts
+++ b/src/models/document/drag-tiles.ts
@@ -85,6 +85,13 @@ export const DocumentContentModelWithTileDragging = DocumentContentModelWithAnno
 
     return dragTileItems;
   },
+  /**
+   * If any of the tiles being dragged are RowListContainer tiles,
+   * this adds drag items for all of the tiles contained within them.
+   * Used for copying where we need to copy all the contents as well as the containers.
+   * @param tiles list of drag items
+   * @returns the same list with any embedded tiles added to the end
+   */
   addEmbeddedTilesToDragTiles(tiles: IDragTileItem[]) {
     const allTiles = [...tiles];
     tiles.forEach(dragTile => {
@@ -95,6 +102,21 @@ export const DocumentContentModelWithTileDragging = DocumentContentModelWithAnno
       }
     });
     return allTiles;
+  },
+  /**
+   * If the list of drag items contains both containers and tiles embedded within them,
+   * this removes the embedded tiles so that only the containers are included.
+   * This is used for moving tiles, where the embedded tiles will automatically get moved
+   * as part of their containers without our having to do anything to them.
+   * @param tiles list of drag items
+   * @returns the same list with the embedded tiles removed
+   */
+  removeEmbeddedTilesFromDragTiles(tiles: IDragTileItem[]) {
+    const tilesToRemove = tiles.flatMap(tile => {
+      const tileContent = self.getTile(tile.tileId)?.content;
+      return tileContent && isRowListContainer(tileContent) ? tileContent.tileIds : [];
+    });
+    return tiles.filter(tile => !tilesToRemove.includes(tile.tileId));
   }
 }))
 .views(self => ({

--- a/src/models/document/row-list.ts
+++ b/src/models/document/row-list.ts
@@ -1,4 +1,4 @@
-import { Instance, types, detach } from "mobx-state-tree";
+import { Instance, types, detach, SnapshotIn, SnapshotOut } from "mobx-state-tree";
 import { StringBuilder, comma } from "../../utilities/string-builder";
 import { getTileContentInfo, IDocumentExportOptions } from "../tiles/tile-content-info";
 import { ITileModel } from "../tiles/tile-model";
@@ -21,7 +21,7 @@ export const RowList = types
       return self.rowMap.get(rowId);
     },
     getRowByIndex(index: number): TileRowModelType | undefined {
-      return self.rowMap.get(self.rowOrder[index]);
+      return self.rowOrder.length > index ? self.rowMap.get(self.rowOrder[index]) : undefined;
     },
     getRowIndex(rowId: string) {
       return self.rowOrder.findIndex(_rowId => _rowId === rowId);
@@ -171,10 +171,24 @@ export const RowList = types
   }));
 
 export type RowListType = Instance<typeof RowList>;
+export type RowListSnapshotIn = SnapshotIn<typeof RowList>
+export type RowListSnapshotOut = SnapshotOut<typeof RowList>
 
 export function isRowListContainer(model: any): model is RowListType {
   if (!model) return false;
   // Check if the model has the required RowList properties
+  return typeof model.rowMap !== 'undefined' &&
+         typeof model.rowOrder !== 'undefined' &&
+         Array.isArray(model.rowOrder);
+}
+
+export function isRowListSnapshotIn(model: any): model is RowListSnapshotIn {
+  return typeof model.rowMap !== 'undefined' &&
+         typeof model.rowOrder !== 'undefined' &&
+         Array.isArray(model.rowOrder);
+}
+
+export function isRowListSnapshotOut(model: any): model is RowListSnapshotOut {
   return typeof model.rowMap !== 'undefined' &&
          typeof model.rowOrder !== 'undefined' &&
          Array.isArray(model.rowOrder);

--- a/src/models/tiles/question/question-registration.ts
+++ b/src/models/tiles/question/question-registration.ts
@@ -3,7 +3,7 @@ import { registerTileContentInfo } from "../tile-content-info";
 import { TileMetadataModel } from "../tile-metadata";
 import { kQuestionTileType, QuestionContentModel, defaultQuestionContent } from "./question-content";
 import { QuestionTileComponent } from "../../../components/tiles/question/question-tile";
-import { updateQuestionContentForNewDocument } from "./question-utils";
+import { updateQuestionContentForCopy } from "./question-utils";
 
 import Icon from "../../../clue/assets/icons/question-tool.svg";
 import HeaderIcon from "../../../assets/icons/sort-by-tools/question-tile-id.svg";
@@ -14,7 +14,7 @@ registerTileContentInfo({
   modelClass: QuestionContentModel,
   metadataClass: TileMetadataModel,
   defaultContent: defaultQuestionContent,
-  updateContentForNewDocument: updateQuestionContentForNewDocument
+  updateContentForCopy: updateQuestionContentForCopy
 });
 
 registerTileComponentInfo({

--- a/src/models/tiles/question/question-utils.test.ts
+++ b/src/models/tiles/question/question-utils.test.ts
@@ -1,19 +1,33 @@
-import { updateQuestionContentForNewDocument } from "./question-utils";
+import { updateQuestionContentForCopy } from "./question-utils";
 import { kQuestionTileType } from "./question-content";
 
 describe("question-utils", () => {
-  describe("updateQuestionContentForNewDocument", () => {
-    it("locks question tile content when copied to a new document", () => {
+  describe("updateQuestionContentForCopy", () => {
+    it("locks question tile content when copied across documents", () => {
       const content = {
         type: kQuestionTileType,
         version: 1,
         locked: false
       };
-      const updatedContent = updateQuestionContentForNewDocument(content);
+      const updatedContent = updateQuestionContentForCopy(content, true);
       expect(updatedContent).toEqual({
         type: kQuestionTileType,
         version: 1,
         locked: true
+      });
+    });
+
+    it("unlocks question tile content when copied within same document", () => {
+      const content = {
+        type: kQuestionTileType,
+        version: 1,
+        locked: true
+      };
+      const updatedContent = updateQuestionContentForCopy(content, false);
+      expect(updatedContent).toEqual({
+        type: kQuestionTileType,
+        version: 1,
+        locked: false
       });
     });
 
@@ -23,7 +37,7 @@ describe("question-utils", () => {
         version: 1,
         text: "Hello"
       };
-      const updatedContent = updateQuestionContentForNewDocument(content);
+      const updatedContent = updateQuestionContentForCopy(content, false);
       expect(updatedContent).toBe(content);
     });
   });

--- a/src/models/tiles/question/question-utils.ts
+++ b/src/models/tiles/question/question-utils.ts
@@ -1,13 +1,14 @@
 import { kQuestionTileType } from "./question-content";
 
 /**
- * Updates question tile content when it's being copied to a new document.
- * For example, ensures the question is locked when copied.
+ * Updates question tile content when it's being copied.
+ * The question should be locked when copied to a new document,
+ * while a copy within the same document should not be locked.
  * Returns the updated content.
  */
-export function updateQuestionContentForNewDocument(content: any) {
+export function updateQuestionContentForCopy(content: any, acrossDocuments: boolean) {
   if (content.type === kQuestionTileType) {
-    return { ...content, locked: true };
+    return { ...content, locked: acrossDocuments };
   }
   return content;
 }

--- a/src/models/tiles/tile-content-info.ts
+++ b/src/models/tiles/tile-content-info.ts
@@ -73,12 +73,12 @@ export interface ITileContentInfo {
   updateContentWithNewSharedModelIds?: TileContentNewSharedModelIdUpdater;
   updateObjectReferenceWithNewSharedModelIds?: ClueObjectNewSharedModelIdUpdater;
   /**
-   * Called when a tile is being copied to a new document.
-   * This allows tiles to handle any special logic needed when their content is moved to a new document.
-   * For example, the Question tile uses this to ensure it's locked when copied.
+   * If supplied, this function is called when a tile is being copied.
+   * This allows tiles to handle any special logic needed beyond the standard updates of IDs.
+   * For example, the Question tile uses this to ensure it's locked when copied across documents.
    * Returns the updated content.
    */
-  updateContentForNewDocument?: (content: any) => any;
+  updateContentForCopy?: (content: any, acrossDocuments: boolean) => any;
 }
 
 const gTileContentInfoMap: Record<string, ITileContentInfo> = {};

--- a/src/models/tiles/tile-model.ts
+++ b/src/models/tiles/tile-model.ts
@@ -10,7 +10,7 @@ import { StringBuilder } from "../../utilities/string-builder";
 import { logTileDocumentEvent } from "./log/log-tile-document-event";
 import { LogEventName } from "../../lib/logger-types";
 import { RowListType } from "../document/row-list";
-import { QuestionContentModel } from "./question/question-content";
+import { kQuestionTileType, QuestionContentModel } from "./question/question-content";
 
 // generally negotiated with app, e.g. single column width for table
 export const kDefaultMinWidth = 60;
@@ -25,10 +25,20 @@ export interface IDragTileItem extends ITilePosition {
   rowHeight?: number;
   tileContent: string;  // modified tile contents
   tileType: string;
+  embedded?: boolean;   // if tile is included in another tile being dragged
 }
 
 export interface IDropTileItem extends IDragTileItem {
   newTileId: string;
+}
+
+/**
+ * Determine if a drag item is a container tile that may include other tiles.
+ * This provides an efficient way to check without having to unpack the JSON content and
+ * see if the model is a RowList.
+ */
+export function isContainerTile(item: IDragTileItem) {
+  return item.tileType === kQuestionTileType;
 }
 
 export function cloneTileSnapshotWithoutId(tile: ITileModel) {


### PR DESCRIPTION
CLUE-80.  Make copying work properly for tiles including Question tile and the tiles within it.

Make sure that when copying, all tiles embedded within a Question tile are copied properly as well.

Get the order right when multiple tiles are copied (there were some pre-existing bugs here).

Question tiles are locked when copying across documents, but unlocked copies are made for within-document copies.

Set proper read-only, unselectable behavior for prompts when in locked tiles.