### PR TITLE
Prevent creating nested question tiles

### DIFF
--- a/docs/tile-creation.md
+++ b/docs/tile-creation.md
@@ -1,66 +1,79 @@
 # Tile creation
 
-How do tiles get into the document? There are several ways.
+How do tiles get into the document? Let me count the ways.
 
 ```mermaid
 flowchart TD
 %%{init: {"flowchart": {"defaultRenderer": "elk"}} }%%
 
 toolbarClick{{"Toolbar button clicked"}}
-TBhandleAddTile("handleAddTile\n(toolbar.tsx)")
-DaddTile("addTile\n(document.ts)\nsets unique title")
-BDCuserAddTile[["userAddTile\n(base-document-content.ts)\nLogs CREATE_TILE event"]]
-BDCaddTile("addTile\n(base-document-content.ts)")
+TBhandleAddTile("handleAddTile<br/>(toolbar.tsx)")
+DaddTile("addTile<br/>(document.ts)<br/>sets unique title")
+BDCuserAddTile[["userAddTile<br/>(base-document-content.ts)<br/>Calls createTileContent<br/>Logs CREATE_TILE event"]]
+BDCaddTile("addTile<br/>(base-document-content.ts)")
 
-toolbarClick --> TBhandleAddTile --> DaddTile --> BDCuserAddTile --> BDCaddTile --> BDCaddTileContentInNewRow
+toolbarClick --> TBhandleAddTile --> DaddTile --> BDCuserAddTile
+
+BDCuserAddTile --> BDCaddTile --> BDCaddTileContentInNewRow
 
 toolbarDrag{{"Toolbar button drag & drop"}}
-ThandleDragNewTile("handleDragNewTile\n(toolbar.tsx)\nsets unique title")
-DChandleDrop("handleDrop\n(document-content.tsx)")
-DChandleInsertNewTile("handleInsertNewTile\n(document-content.tsx)")
+ThandleDragNewTile("handleDragNewTile<br/>(toolbar.tsx)<br/>sets unique title")
+DChandleDrop("handleDrop<br/>(document-content.tsx)")
+DChandleInsertNewTile("handleInsertNewTile<br/>(document-content.tsx)")
 
 toolbarDrag -- (drag) --> ThandleDragNewTile
-toolbarDrag -- (drop) --> DChandleDrop -- (new) --> DChandleInsertNewTile --> BDCuserAddTile
+toolbarDrag -- (drop) --> DChandleDrop -- (create new) --> DChandleInsertNewTile --> BDCuserAddTile
 
 toolbarDuplicate{{Toolbar duplicate button}}
-ThandleDuplicate("handleDuplicate\n(toolbar.tsx)")
-DCduplicateTiles("duplicateTiles\n(document-content.ts)")
-DCcopyTiles("copyTiles\n(document-content.ts)\nCopies shared models\nUpdates titles for uniqueness")
-BDCcopyTilesIntoNewRows("copyTilesIntoNewRows\n(base-document-content.ts)")
+ThandleDuplicate("handleDuplicate<br/>(toolbar.tsx)")
+DCduplicateTiles("duplicateTiles<br/>(document-content.ts)")
+DCcopyTiles("copyTiles<br/>(document-content.ts)<br/>Copies shared models<br/>Updates titles for uniqueness")
+BDCcopyTilesIntoNewRows("copyTilesIntoNewRows<br/>(base-document-content.ts)")
 
 toolbarDuplicate --> ThandleDuplicate --> DCduplicateTiles --> DCcopyTiles
-BDCcopyTilesIntoNewRows --> BDCaddTileContentInNewRow
+BDCcopyTilesIntoNewRows --> |first tile|BDCaddTileContentInNewRow
+BDCcopyTilesIntoNewRows --> |subsequent tiles| BDCaddTileSnapshotInExistingRow
+BDCcopyTilesIntoNewRows --> |embedded| BDCaddToTileMap
 
-tableIt{{"Table It! and other\nview-as buttons"}}
+tableIt{{"Table It! and other<br/>view-as buttons"}}
 useConsumerTileLinking("useConsumerTileLinking")
-DCaddTileAfter("addTileAfter\n(document-content.ts)\nSets title if needed")
+DCaddTileAfter("addTileAfter<br/>(document-content.ts)<br/>Sets title if needed")
 
 tableIt --> useConsumerTileLinking --> DCaddTileAfter --> BDCuserAddTile
 
-placeholder{{"Create placeholder tile"}}
-BDCaddPlaceholderTile("addPlaceholderTile\n(base-document-content.ts)")
-placeholder --> BDCaddPlaceholderTile --> BDCaddTileContentInNewRow
+placeholder{{"Create placeholder tile"}} -->
+BDCaddPlaceholderRowIfAppropriate("addPlaceholderRowIfAppropriate<br/>(base-document-content.ts)")
+BDCaddPlaceholderRowIfAppropriate --> insert
 
 dragImage{{"Drag & Drop image"}}
-DWhandleImageDrop("handleImageDrop\n(document-workspace.tsx)\nSets unique title")
+DWhandleImageDrop("handleImageDrop<br/>(document-workspace.tsx)<br/>Sets unique title")
 dragImage --> DWhandleImageDrop --> BDCuserAddTile
 
 dragTile{{"Drag & Drop copy tile"}}
-DChandleDrop("handleDrop\n(document-content.tsx)")
-DChandleCopyTilesDrop("handleCopyTilesDrop\n(document-content.tsx)")
-DChandleDragCopyTiles("handleDragCopyTiles\n(document-content.ts)")
-BDCuserCopyTiles[["userCopyTiles\n(base-document-content.ts)\nLogs COPY_TILE event"]]
-BDCcopyTilesIntoExistingRow("copyTilesIntoExistingRow\n(base-document-content.ts)")
+DChandleDrop("handleDrop<br/>(document-content.tsx)")
+DChandleCopyTilesDrop("handleCopyTilesDrop<br/>(document-content.tsx)")
+DChandleDragCopyTiles("handleDragCopyTiles<br/>(document-content.ts)")
+BDCuserCopyTiles[["userCopyTiles<br/>(base-document-content.ts)<br/>Logs COPY_TILE event"]]
+BDCcopyTilesIntoExistingRow("copyTilesIntoExistingRow<br/>(base-document-content.ts)")
+BDCcopyTilesIntoExistingRow --> |embedded| BDCaddToTileMap
+BDCcopyTilesIntoExistingRow --> |top-level| BDCaddTileSnapshotInExistingRow
 
-dragTile --> DChandleDrop -- (existing) --> DChandleCopyTilesDrop --> DChandleDragCopyTiles --> DCcopyTiles --> BDCuserCopyTiles --> BDCcopyTilesIntoNewRows & BDCcopyTilesIntoExistingRow --> BDCaddTileSnapshotInExistingRow
+dragTile --> DChandleDrop -- (copy existing) --> DChandleCopyTilesDrop --> DChandleDragCopyTiles --> DCcopyTiles --> BDCuserCopyTiles --> BDCcopyTilesIntoNewRows & BDCcopyTilesIntoExistingRow
 
-BDCaddTileContentInNewRow("addTileContentInNewRow\n(base-document-content.ts)")
-BDCaddTileSnapshotInExistingRow("addTileSnapshotInExistingRow\n(base-document-content.ts)")
-insert([add to tileMap and row])
 
-BDCaddTileContentInNewRow & BDCaddTileSnapshotInExistingRow --> insert
+BDCaddTileContentInNewRow("addTileContentInNewRow<br/>(base-document-content.ts)")
+BDCaddTileSnapshotInExistingRow("addTileSnapshotInExistingRow<br/>(base-document-content.ts)")
+
+BDCaddToTileMap["addToTileMap<br/>(base-document-content.ts)"] --> insert
+
+BDCaddTileContentInNewRow & BDCaddTileSnapshotInExistingRow --> BDCaddToTileMap
+BDCaddTileContentInNewRow & BDCaddTileSnapshotInExistingRow & BDCaddPlaceholderRowIfAppropriate --> rowinsert
+
+insert([insert into tileMap])
+rowinsert([insert into rows structure])
 
 style insert fill:#8A8
+style rowinsert fill:#8A8
 
 style toolbarClick fill:#88F
 style toolbarDrag fill:#88F
@@ -72,7 +85,7 @@ style placeholder fill:#88F
 
 ```
 
-This should display version of mermaid:
+<!-- This should display version of mermaid:
 ```mermaid
 info
-```
+``` -->

--- a/src/models/document/document-content-tests/dc-question-tile-move-copy.test.ts
+++ b/src/models/document/document-content-tests/dc-question-tile-move-copy.test.ts
@@ -5,6 +5,14 @@ import { mockUniqueId, resetMockUniqueId } from "./dc-test-utils";
 import { DocumentContentModel, DocumentContentModelType, DocumentContentSnapshotType } from "../document-content";
 import { IDropRowInfo } from "../tile-row";
 import { registerTileTypes } from "../../../register-tile-types";
+import { IDragTilesData } from "../document-content-types";
+
+// mock Logger calls
+const mockLogTileCopyEvent = jest.fn();
+jest.mock("../../tiles/log/log-tile-copy-event", () => ({
+  logTileCopyEvent: (...args: any[]) => mockLogTileCopyEvent(...args)
+}));
+
 
 registerTileTypes(["Question", "Text", "Expression", "Table", "Drawing"]);
 
@@ -228,5 +236,59 @@ describe("Question tile operations", () => {
 
   });
 
+  describe("Question tile copying", () => {
+    it("can copy a question tile", () => {
+      const dragTiles: IDragTilesData = {
+        sourceDocId: documentContent.contentId,
+        tiles: getDocumentDragTileItems(["question-1", "sketch-1", "text-2", "table-2"]),
+        sharedModels: [], // No shared models in this test
+        annotations: []  // No annotations in this test
+      };
+      const dropRowInfo: IDropRowInfo = {
+        rowInsertIndex: 1,
+        rowDropId: "testid-6",
+        rowDropLocation: "bottom"
+      };
+      documentContent.handleDragCopyTiles(dragTiles, dropRowInfo);
+      expect(documentContent.debugDescribeThis(documentContent.tileMap, "")).
+toMatchInlineSnapshot(`
+"testid-6: [Text: text-1]
+testid-28: [Question: testid-25]
+Contents of embedded row list:
+  testid-26: [Text: testid-22]
+  testid-27: [Table: testid-23] [Drawing: testid-24]
+testid-7: [Table: table-1] [Expression: expression-1]
+testid-8: [Question: question-1]
+Contents of embedded row list:
+  testid-9: [Text: text-2]
+  testid-10: [Table: table-2] [Drawing: sketch-1]"
+`);
+    });
+
+    it("will not copy a question tile into itself", () => {
+      const dragTiles: IDragTilesData = {
+        sourceDocId: documentContent.contentId,
+        tiles: getDocumentDragTileItems(["question-1", "sketch-1", "text-2", "table-2"]),
+        sharedModels: [], // No shared models in this test
+        annotations: []  // No annotations in this test
+      };
+      const dropRowInfo: IDropRowInfo = {
+        rowInsertIndex: 1,
+        rowDropId: "testid-9",
+        rowDropLocation: "bottom"
+      };
+      documentContent.handleDragCopyTiles(dragTiles, dropRowInfo);
+      expect(documentContent.debugDescribeThis(documentContent.tileMap, "")).
+toMatchInlineSnapshot(`
+"testid-6: [Text: text-1]
+testid-7: [Table: table-1] [Expression: expression-1]
+testid-8: [Question: question-1]
+Contents of embedded row list:
+  testid-9: [Text: text-2]
+  testid-10: [Table: table-2] [Drawing: sketch-1]"
+`);
+    });
+
+  });
 
 });

--- a/src/models/tiles/question/question-registration.ts
+++ b/src/models/tiles/question/question-registration.ts
@@ -13,6 +13,7 @@ registerTileContentInfo({
   displayName: "Question",
   modelClass: QuestionContentModel,
   metadataClass: TileMetadataModel,
+  isContainer: true,
   defaultContent: defaultQuestionContent,
   updateContentForCopy: updateQuestionContentForCopy
 });

--- a/src/models/tiles/tile-content-info.ts
+++ b/src/models/tiles/tile-content-info.ts
@@ -64,6 +64,10 @@ export interface ITileContentInfo {
   metadataClass?: typeof TileMetadataModel;
   defaultHeight?: number;
   exportNonDefaultHeight?: boolean;
+  /**
+   * If true, the tile can contain other tiles.
+   */
+  isContainer?: boolean;
   isDataConsumer?: boolean;
   isDataProvider?: boolean;
   isVariableProvider?: boolean;

--- a/src/models/tiles/tile-model.ts
+++ b/src/models/tiles/tile-model.ts
@@ -10,7 +10,7 @@ import { StringBuilder } from "../../utilities/string-builder";
 import { logTileDocumentEvent } from "./log/log-tile-document-event";
 import { LogEventName } from "../../lib/logger-types";
 import { RowListType } from "../document/row-list";
-import { kQuestionTileType, QuestionContentModel } from "./question/question-content";
+import { QuestionContentModel } from "./question/question-content";
 
 // generally negotiated with app, e.g. single column width for table
 export const kDefaultMinWidth = 60;
@@ -38,7 +38,7 @@ export interface IDropTileItem extends IDragTileItem {
  * see if the model is a RowList.
  */
 export function isContainerTile(item: IDragTileItem) {
-  return item.tileType === kQuestionTileType;
+  return !!getTileContentInfo(item.tileType)?.isContainer;
 }
 
 export function cloneTileSnapshotWithoutId(tile: ITileModel) {


### PR DESCRIPTION
Fixes an omission in the previous PR for CLUE-80.

Question tiles now cannot be created inside other Question tiles, either by use of toolbar buttons, or by copying.

Upated documentation diagram of how CLUE tiles can be created in order to make sure all pathways were addressed.

Improve robustness of `isContainer` by making a new tile metadata field.
