### PR TITLE
feat: Restyle Online Indicator & Version Number [CLUE-101]

### DIFF
--- a/src/clue/components/app-mode-indicator.scss
+++ b/src/clue/components/app-mode-indicator.scss
@@ -10,8 +10,7 @@
   color: white;
 
   svg {
-    height: 1.5em;
-    margin-right: 5px;
+    width: 28px;
     fill: white;
   }
 }

--- a/src/clue/components/app-mode-indicator.tsx
+++ b/src/clue/components/app-mode-indicator.tsx
@@ -35,7 +35,7 @@ const AppModeIndicator: React.FC<AppModeIndicatorProps> = ({ appMode }) => {
   return (
     <Tooltip {...tipOptions} interactive={true} html={kPreviewTooltipHtml}>
       <div className="mode">
-       <WarningIcon />
+        <WarningIcon />
         Preview Mode
       </div>
     </Tooltip>

--- a/src/clue/components/app-mode-indicator.tsx
+++ b/src/clue/components/app-mode-indicator.tsx
@@ -35,7 +35,7 @@ const AppModeIndicator: React.FC<AppModeIndicatorProps> = ({ appMode }) => {
   return (
     <Tooltip {...tipOptions} interactive={true} html={kPreviewTooltipHtml}>
       <div className="mode">
-        <WarningIcon/>
+       <WarningIcon />
         Preview Mode
       </div>
     </Tooltip>

--- a/src/clue/components/clue-app-header.sass
+++ b/src/clue/components/clue-app-header.sass
@@ -70,9 +70,14 @@ $member-size: 18px
     align-items: center
     justify-content: flex-end
 
-    .version
-      padding-right: $padding
-      font-size: 0.9em
+    .network-status-and-version
+      display: flex
+      flex-direction: column
+      justify-content: space-between
+      gap: 5px
+
+      .version
+        font-size: 12px
 
     .group
       height: 40px

--- a/src/clue/components/clue-app-header.tsx
+++ b/src/clue/components/clue-app-header.tsx
@@ -220,8 +220,10 @@ export const ClueAppHeaderComponent: React.FC<IProps> = observer(function ClueAp
         </div>
         <div className="right">
           {showAppMode && <AppModeIndicator appMode={appMode}/>}
-          <NetworkStatus user={user}/>
-          <div className="version">Version {appVersion}</div>
+          <div className="network-status-and-version">
+            <NetworkStatus user={user}/>
+            <div className="version">CLUE v{appVersion}</div>
+          </div>
           {showGroupInfo && myGroup ? renderGroup(myGroup) : null}
           {showUserInfo &&
           <div className="user" title={getUserTitle()}>

--- a/src/components/network-status.scss
+++ b/src/components/network-status.scss
@@ -1,13 +1,14 @@
+@import './vars';
+
 .network-status {
   height: 100%;
-  margin-right: 15px;
   display: flex;
   justify-content: space-around;
   align-items: center;
 
   .status {
     width: 70px;
-    height: 40px;
+    height: 20px;
     border-radius: 5px;
     display: flex;
     justify-content: center;
@@ -15,10 +16,11 @@
     background-color: #D50103;
     color: white;
     font-weight: bold;
+    font-size: 13px;
 
     &.connected {
       background-color: #00d700;
-      color: black;
+      color: $charcoal-dark-2;
       font-weight: normal;
     }
   }


### PR DESCRIPTION
This commit introduces a new design for the online indicator and version number display in the header.

The changes include:

- Stacked the online indicator and version number to save horizontal space.
- Updated the online indicator to use the spec'ed font color and size.
- Adjusted the version number be "CLUE v{version}" to match the design spec

Also fixed the icon spacing of the preview warning icon in the app header - it was being clipped.

Before update:

![image](https://github.com/user-attachments/assets/d0a492a9-cd18-464b-b2b3-457c1cd3d859)

After update:

![image](https://github.com/user-attachments/assets/bd0f4669-b498-4163-a759-6eb09ed9f111)
