### PR TITLE
fix: Daily regression test breaks

### DIFF
--- a/cypress/e2e/functional/standalone_tests/standalone_load_spec.js
+++ b/cypress/e2e/functional/standalone_tests/standalone_load_spec.js
@@ -1,4 +1,4 @@
-const url = "/standalone/";
+const url = "/standalone/?unit=msa";
 
 function beforeTest() {
   cy.visit(url);

--- a/cypress/e2e/functional/standalone_tests/standalone_load_spec.js
+++ b/cypress/e2e/functional/standalone_tests/standalone_load_spec.js
@@ -1,12 +1,20 @@
-const url = "/standalone/?unit=msa";
+const urlWithUnit = "/standalone/?unit=msa";
+const urlWithNoUnit = "/standalone/";
 
-function beforeTest() {
+function beforeTest(url) {
   cy.visit(url);
 }
 
 context('Standalone', () => {
+  it('verify standalone page shows error with no unit in parameters', function () {
+    beforeTest(urlWithNoUnit);
+
+    cy.log("verify no unit error message is visible");
+    cy.get("[data-testid=error-alert-content]").should("contain", "Using CLUE in Standalone Mode requires a unit");
+  });
+
   it('verify standalone page loads', function () {
-    beforeTest();
+    beforeTest(urlWithUnit);
 
     cy.log("verify welcome message is visible");
     cy.get("[data-testid=standalone-welcome]").should("exist");

--- a/src/components/utilities/dialog.sass
+++ b/src/components/utilities/dialog.sass
@@ -72,6 +72,7 @@
 
       .dialog-input
         margin: $margin 0
+        height: auto
 
         input, textarea, select
           width: 100%

--- a/src/components/utilities/use-error-alert.tsx
+++ b/src/components/utilities/use-error-alert.tsx
@@ -35,7 +35,8 @@ export const useErrorAlert = ({
     buttons: onClick ? [
       { label: buttonLabel || "OK", isDefault: true, onClick }
     ] : [],
-    onClose
+    onClose,
+    dataTestId: "error-alert"
   });
 
   return [showAlert, hideAlert];

--- a/src/hooks/use-custom-modal.tsx
+++ b/src/hooks/use-custom-modal.tsx
@@ -33,10 +33,11 @@ interface IProps<IContentProps> {
   // defined left-to-right, e.g. Extra Button, Cancel, OK
   buttons: IModalButton[];
   onClose?: () => void;
+  dataTestId?: string;
 }
 export const useCustomModal = <IContentProps,>({
   className, Icon, title, Content, contentProps, focusElement, canCancel, buttons,
-  onClose
+  onClose, dataTestId
 }: IProps<IContentProps>, dependencies?: any[]) => {
 
   const [contentElt, setContentElt] = useState<HTMLDivElement>();
@@ -82,13 +83,16 @@ export const useCustomModal = <IContentProps,>({
   handleCloseRef.current = handleClose;
 
   const [showModal, hideModal] = useModal(() => {
+    // NOTE: the data-testid attribute is not passed to the modal element
+    // because it is not a valid attribute for ReactModal and instead
+    // is passed to the modal header and content elements to allow for testing
     return (
       <Modal className={`custom-modal ${className || ""}`} isOpen
               shouldCloseOnEsc={canCancel}
               shouldCloseOnOverlayClick={false}
               onAfterOpen={handleAfterOpen as any}
               onRequestClose={handleClose} onAfterClose={onClose}>
-        <div className="modal-header">
+        <div className="modal-header" data-testid={dataTestId && `${dataTestId}-header`}>
           <div className="modal-icon">
             {Icon && <Icon/>}
           </div>
@@ -98,7 +102,7 @@ export const useCustomModal = <IContentProps,>({
               <CloseIconSvg />
             </button>}
         </div>
-        <div className="modal-content">
+        <div className="modal-content" data-testid={dataTestId && `${dataTestId}-content`}>
           { /* TODO Fix type cast */ }
           <Content as any {...(contentProps)}/>
         </div>


### PR DESCRIPTION
- Added height: auto to standard dialog input container so that inner input/select padding addition worked when container had a set height
- Fixed missing unit parameter in standalone test