### PR TITLE
Copying Question tile from other users

### DIFF
--- a/cypress/e2e/functional/document_tests/copy_doc_test_spec.js
+++ b/cypress/e2e/functional/document_tests/copy_doc_test_spec.js
@@ -12,6 +12,7 @@ import DiagramToolTile from '../../../support/elements/tile/DiagramToolTile';
 import DataflowToolTile from '../../../support/elements/tile/DataflowToolTile';
 import SimulatorTile from '../../../support/elements/tile/SimulatorTile';
 import XYPlotToolTile from '../../../support/elements/tile/XYPlotToolTile';
+import QuestionToolTile from '../../../support/elements/tile/QuestionToolTile';
 
 let tableTile = new TableToolTile;
 let textTile = new TextToolTile;
@@ -25,6 +26,7 @@ let diagramTile = new DiagramToolTile;
 let dataflowTile = new DataflowToolTile;
 let simulatorTile = new SimulatorTile;
 let xyTile = new XYPlotToolTile;
+let questionTile = new QuestionToolTile;
 
 let clueCanvas = new ClueCanvas;
 let canvas = new Canvas;
@@ -129,14 +131,19 @@ context('Copy Document', () => {
     xyTile.linkProgram("Program 1");
     xyTile.getGraphDot().should('have.length.greaterThan', 3);
 
+    cy.log("Add default question tile");
+    clueCanvas.addTile("question");
+    questionTile.getQuestionTile().should("exist");
+    questionTile.getQuestionTileEmbeddedTiles().should("have.length", 2); // prompt and placeholder
+
     cy.log("Copy Document");
     const copyTitle = 'Personal Workspace Copy';
     canvas.copyDocument(copyTitle);
     canvas.getPersonalDocTitle().should('contain', copyTitle);
 
     cy.log("Check all tiles are restored in copied document");
-    textTile.getTextTile().scrollIntoView().should('be.visible');
-    textTile.getTextEditor().last().should('contain', 'Hello World');
+    textTile.getTextTile().first().scrollIntoView().should('be.visible');
+    textTile.getTextEditor().first().should('contain', 'Hello World');
 
     tableTile.getTableTile().scrollIntoView().should('be.visible');
     tableTile.getTableCell().eq(1).should('contain', '3');
@@ -174,6 +181,9 @@ context('Copy Document', () => {
 
     xyTile.getTile().scrollIntoView().should('be.visible');
     xyTile.getGraphDot().should('have.length.greaterThan', 3);
+
+    questionTile.getQuestionTile().scrollIntoView().should('be.visible');
+    questionTile.getQuestionTileEmbeddedTiles().should("have.length", 2);
   });
 });
 

--- a/cypress/support/elements/tile/QuestionToolTile.js
+++ b/cypress/support/elements/tile/QuestionToolTile.js
@@ -16,6 +16,10 @@ class QuestionToolTile {
         cy.get('.tool.delete').click();
         cy.get('.ReactModalPortal .modal-footer .modal-button.default').click();
     }
+
+    getQuestionTileEmbeddedTiles(workspaceClass) {
+      return this.getQuestionTile().find('.tool-tile');
+    }
 }
 
 export default QuestionToolTile;

--- a/src/models/document/base-document-content.ts
+++ b/src/models/document/base-document-content.ts
@@ -585,7 +585,7 @@ export const BaseDocumentContentModel = RowList.named("BaseDocumentContent")
       });
       // fix any "collapsed" sections
       self.allRowLists.forEach(rowList => {
-        for (let i = 1; i < rowList.rowCount; ++i) {
+        for (let i = 1; i <= rowList.rowCount; ++i) {
           self.addPlaceholderRowIfAppropriate(rowList, i);
         }
       });

--- a/src/models/document/base-document-content.ts
+++ b/src/models/document/base-document-content.ts
@@ -558,6 +558,12 @@ export const BaseDocumentContentModel = RowList.named("BaseDocumentContent")
         rowList.deleteRow(beforeRow.id);
       }
     },
+    /**
+     * Inserts a row with a placeholder tile if needed at the given index in the rowList.
+     * The index can be 0 (top of the rowList) up to the full rowCount (the position after the last existing row).
+     * @param rowList
+     * @param rowIndex
+     */
     addPlaceholderRowIfAppropriate(rowList: RowListType, rowIndex: number) {
       const beforeRow = (rowIndex > 0) && rowList.getRowByIndex(rowIndex - 1);
       const afterRow = (rowIndex < rowList.rowCount) && rowList.getRowByIndex(rowIndex);

--- a/src/models/document/drag-tiles.ts
+++ b/src/models/document/drag-tiles.ts
@@ -130,11 +130,14 @@ export const DocumentContentModelWithTileDragging = DocumentContentModelWithAnno
     // will change on each load of the document
     const sourceDocId = self.contentId;
 
+    const allTiles = self.addEmbeddedTilesToDragTiles(self.getDragTileItems(tileIds));
+    const allTileIds = allTiles.map(tile => tile.tileId);
+
     const dragTiles: IDragTilesData = {
       sourceDocId,
-      tiles: self.addEmbeddedTilesToDragTiles(self.getDragTileItems(tileIds)),
-      sharedModels: sharedManager?.getSharedModelDragDataForTiles(tileIds) ?? [],
-      annotations: Object.values(self.getAnnotationsUsedByTiles(tileIds))
+      tiles: allTiles,
+      sharedModels: sharedManager?.getSharedModelDragDataForTiles(allTileIds) ?? [],
+      annotations: Object.values(self.getAnnotationsUsedByTiles(allTileIds))
     };
 
     return dragTiles;

--- a/src/models/tiles/tile-model.ts
+++ b/src/models/tiles/tile-model.ts
@@ -141,6 +141,9 @@ export const TileModel = types
       if (self.display) {
         builder.pushLine(`"display": "${self.display}",`, 2);
       }
+      if (self.fixedPosition) {
+        builder.pushLine(`"fixedPosition": true,`, 2);
+      }
       builder.pushBlock(`"content": ${contentJson}`, 2);
       options?.rowHeight && builder.pushLine(`"layout": { "height": ${options.rowHeight} }`, 2);
       const comma = options?.appendComma ? ',' : '';


### PR DESCRIPTION
CLUE-99

This fixes three bugs that were found in the Question tile implementation:
- the method to copy an entire document, used in the "Make a Copy" menu item, did not recursively update nested rows.
- exporting JSON (as used in authoring) did not include the "fixedPosition" annotation that prompts need.
- placeholder tiles were not properly created at the end of question tiles in all cases.