### PR TITLE
fix: Double border on dialog input [CLUE-81]

### DIFF
--- a/src/components/utilities/dialog.sass
+++ b/src/components/utilities/dialog.sass
@@ -73,6 +73,8 @@
       .dialog-input
         margin: $margin 0
         height: auto
+        padding: 0
+        border: 0
 
         input, textarea, select
           width: 100%


### PR DESCRIPTION
Adding the inner padding on the input elements conflicted with the outer padding in the standard prompt dialog causing two borders.