### PR TITLE
[CLUE-86] Return to Sort View retains state

### DIFF
--- a/cypress/e2e/functional/document_tests/student_test_spec.js
+++ b/cypress/e2e/functional/document_tests/student_test_spec.js
@@ -95,11 +95,9 @@ context("check public/private document access", function() {
     sortWork.checkGroupDocumentVisibility("Group 1", false, true);
 
     cy.log("verify other user's shared documents are not marked as private and are accessible");
-    openAllGroupSections();
     sortWork.checkGroupDocumentVisibility("Group 2", false, true);
 
     cy.log("verify private documents are marked as private and are not accessible");
-    openAllGroupSections();
     sortWork.checkGroupDocumentVisibility("Group 3", true, true);
 
     // Check the same conditions in a view that contains compact document items
@@ -112,11 +110,9 @@ context("check public/private document access", function() {
     sortWork.checkGroupDocumentVisibility("Group 1", false);
 
     cy.log("verify other user's shared documents are not marked as private and are accessible in the compact view");
-    openAllGroupSections();
     sortWork.checkGroupDocumentVisibility("Group 2", false);
 
     cy.log("verify private documents are marked as private and are not accessible in the compact view");
-    openAllGroupSections();
     sortWork.checkGroupDocumentVisibility("Group 3", true);
   });
 });

--- a/cypress/e2e/functional/teacher_tests/teacher_sort_work_view_spec.js
+++ b/cypress/e2e/functional/teacher_tests/teacher_sort_work_view_spec.js
@@ -396,4 +396,49 @@ describe('SortWorkView Tests', () => {
     sortWork.getPrimarySortByNameOption().should("have.class", "selected");
     sortWork.getSecondarySortByGroupOption().should("have.class", "selected");
   });
+
+  it("should retain selection state when going between sort options and viewing a sorted document", () => {
+    beforeTest(queryParams1);
+
+    cy.log("expand a section and verify that the section remains expanded after selecting a new secondary sort option");
+    cy.get('.section-header-arrow').eq(1).click();
+    cy.get('.section-header-arrow').eq(1).should("have.class", "up");
+    sortWork.getSecondarySortByMenu().click();
+    sortWork.getSecondarySortByNameOption().click();
+    sortWork.getSecondarySortByNameOption().should("have.class", "selected");
+    cy.get('.section-header-arrow').eq(1).should("have.class", "up");
+
+    cy.log("open a document and verify that the section remains expanded and the document is highlighted");
+    sortWork.getSecondarySortByMenu().click();
+    sortWork.getSecondarySortByNoneOption().click();
+    sortWork.getSecondarySortByNoneOption().should("have.class", "selected");
+    cy.get('.section-header-arrow').eq(1).should("have.class", "up");
+    let prevFocusDocTitle = "";
+    sortWork.getSortWorkItem().first().find('div').invoke('text').then((docText) => {
+      prevFocusDocTitle = docText.trim();
+    });
+    sortWork.getSortWorkItem().first().click();
+    cy.get('.close-doc-button').click();
+    cy.get('.section-header-arrow').eq(1).should("have.class", "up");
+    cy.get(".sort-work-view .sorted-sections .list-item").first().should("have.class", "selected");
+
+    cy.log("change the secondary sort and verify that the section remains expanded and the document is highlighted");
+    sortWork.getSecondarySortByMenu().click();
+    sortWork.getSecondarySortByNameOption().click();
+    cy.get(".sort-work-view .sorted-sections .simple-document-item.selected")
+      .should("exist")
+      .invoke("attr", "title")
+      .then((docTitle2) => {
+        expect(docTitle2).to.equal(prevFocusDocTitle);
+      });
+
+    cy.log("when primary sort is switched, there should be no expanded sections, and no highlighted documents");
+    sortWork.getPrimarySortByMenu().click();
+    sortWork.getPrimarySortByTagOption().click();
+    cy.get('.section-header-arrow').should("not.have.class", "up");
+    sortWork.getSecondarySortByMenu().click();
+    sortWork.getSecondarySortByNoneOption().click();
+    cy.get('.section-header-arrow').click({multiple: true});
+    cy.get(".sort-work-view .sorted-sections .list-item").should("not.have.class", "selected");
+  });
 });

--- a/cypress/e2e/functional/teacher_tests/teacher_sort_work_view_spec.js
+++ b/cypress/e2e/functional/teacher_tests/teacher_sort_work_view_spec.js
@@ -89,7 +89,6 @@ describe('SortWorkView Tests', () => {
     resourcesPanel.getDocumentSwitchBtnNext().should('exist').and('not.have.class', 'disabled');
 
     resourcesPanel.getDocumentCloseButton().click();
-    cy.get('.section-header-arrow').click({multiple: true}); // Open the sections
     sortWork.getSortWorkItem().should('be.visible'); // Verify the document is closed
   });
 
@@ -243,13 +242,11 @@ describe('SortWorkView Tests', () => {
     resourcesPanel.getDocumentCloseButton().should("exist").click();
 
     cy.log("open personal doc and make sure Edit button doesn't show and Close button shows");
-    cy.get('.section-header-arrow').click({multiple: true}); // Open the sections
     sortWork.getSortWorkItem().contains(studentPersonalDocs[0]).click();
     resourcesPanel.getDocumentEditButton().should("not.exist");
     resourcesPanel.getDocumentCloseButton().should("exist").click();
 
     cy.log("open exemplar doc and make sure Edit button doesn't show and Close button shows");
-    cy.get('.section-header-arrow').click({multiple: true}); // Open the sections
     sortWork.getSortWorkItem().contains(exemplarDocs[0]).click();
     resourcesPanel.getDocumentEditButton().should("not.exist");
     resourcesPanel.getDocumentCloseButton().should("exist");
@@ -261,7 +258,6 @@ describe('SortWorkView Tests', () => {
     resourcesPanel.getDocumentCloseButton().click();
 
     cy.log("check all problem and personal docs show in the correct group");
-    cy.get('.section-header-arrow').click({multiple: true}); // Open the sections
     studentProblemDocs.forEach(doc => {
       sortWork.checkDocumentInGroup("Group 5", doc);
     });
@@ -323,7 +319,6 @@ describe('SortWorkView Tests', () => {
     chatPanel.getChatCloseButton().click();
     cy.openTopTab('sort-work');
 
-    cy.get('.section-header-arrow').click({multiple: true}); // Open the sections
     sortWork.checkDocumentInGroup("Diverging Designs", exemplarDocs[0]);
 
     cy.log("remove the teacher added tag and reload");

--- a/src/components/document/sort-work-view.tsx
+++ b/src/components/document/sort-work-view.tsx
@@ -19,7 +19,7 @@ import "./sort-work-view.scss";
  * Various options for sorting the display are available - by user, by group, by tools used, etc.
  */
 export const SortWorkView: React.FC = observer(function SortWorkView() {
-  const { appConfig, investigation, persistentUI, problem, sortedDocuments, unit } = useStores();
+  const { appConfig, investigation, persistentUI, problem, sortedDocuments, ui, unit } = useStores();
   const { tagPrompt } = appConfig;
   const { docFilter: persistentUIDocFilter, primarySortBy, secondarySortBy } = persistentUI;
   const sortTagPrompt = tagPrompt || ""; //first dropdown choice for comment tags
@@ -40,6 +40,8 @@ export const SortWorkView: React.FC = observer(function SortWorkView() {
     if (sort === secondarySortBy) {
       persistentUI.setSecondarySortBy("None");
     }
+    ui.clearHighlightedSortWorkDocument();
+    ui.clearExpandedSortWorkSections();
   };
 
   const primarySortByOptions: ICustomDropdownItem[] = sortOptions.map((option) => ({

--- a/src/components/document/sorted-section.tsx
+++ b/src/components/document/sorted-section.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { observer } from "mobx-react";
 import classNames from "classnames";
 
@@ -33,7 +33,8 @@ export interface IOpenDocumentsGroupMetadata {
 export const SortedSection: React.FC<IProps> = observer(function SortedSection(props: IProps) {
   const { docFilter, documentGroup, idx, secondarySort } = props;
   const { persistentUI, sortedDocuments } = useStores();
-  const [showDocuments, setShowDocuments] = useState(false);
+  const { isDocumentGroupOpen, addOpenDocumentGroup, removeOpenDocumentGroup } = persistentUI;
+  const showDocuments = isDocumentGroupOpen(documentGroup.label);
   const documentCount = documentGroup.documents?.length || 0;
 
   const getDocument = (docKey: string) => {
@@ -67,13 +68,18 @@ export const SortedSection: React.FC<IProps> = observer(function SortedSection(p
   };
 
   const handleToggleShowDocuments = () => {
-    setShowDocuments(!showDocuments);
+    if (showDocuments) {
+      removeOpenDocumentGroup(documentGroup.label);
+    } else {
+      addOpenDocumentGroup(documentGroup.label);
+    }
   };
 
   const renderUngroupedDocument = (doc: IDocumentMetadataModel) => {
     const fullDocument = getDocument(doc.key);
     if (!fullDocument) return <div key={doc.key} className="loading-spinner"/>;
-
+    const maybeTabState = persistentUI.tabs.get(ENavTab.kSortWork);
+    const openDocumentKey = maybeTabState?.currentDocumentGroup?.primaryDocumentKey;
     return <DecoratedDocumentThumbnailItem
              key={doc.key}
              scale={0.1}
@@ -81,6 +87,7 @@ export const SortedSection: React.FC<IProps> = observer(function SortedSection(p
              tab={ENavTab.kSortWork}
              shouldHandleStarClick
              allowDelete={false}
+             selectedDocument={openDocumentKey}
              onSelectDocument={handleSelectDocument(documentGroup)}
            />;
   };

--- a/src/components/document/sorted-section.tsx
+++ b/src/components/document/sorted-section.tsx
@@ -32,9 +32,9 @@ export interface IOpenDocumentsGroupMetadata {
 
 export const SortedSection: React.FC<IProps> = observer(function SortedSection(props: IProps) {
   const { docFilter, documentGroup, idx, secondarySort } = props;
-  const { persistentUI, sortedDocuments } = useStores();
-  const { isDocumentGroupOpen, addOpenDocumentGroup, removeOpenDocumentGroup } = persistentUI;
-  const showDocuments = isDocumentGroupOpen(documentGroup.label);
+  const { persistentUI, sortedDocuments, ui } = useStores();
+  const { expandedSortWorkSections, setExpandedSortWorkSections, setHighlightedSortWorkDocument } = ui;
+  const showDocuments = expandedSortWorkSections.includes(documentGroup.label);
   const documentCount = documentGroup.documents?.length || 0;
 
   const getDocument = (docKey: string) => {
@@ -62,17 +62,13 @@ export const SortedSection: React.FC<IProps> = observer(function SortedSection(p
       const documentGroupId = JSON.stringify(openDocGroupMetadata);
       const tabState = persistentUI.getOrCreateTabState(ENavTab.kSortWork);
       tabState.openDocumentGroupPrimaryDocument(documentGroupId, document.key);
-      persistentUI.setSelectedDocumentKey(document.key);
+      setHighlightedSortWorkDocument(document.key);
       logDocumentViewEvent(document);
     };
   };
 
   const handleToggleShowDocuments = () => {
-    if (showDocuments) {
-      removeOpenDocumentGroup(documentGroup.label);
-    } else {
-      addOpenDocumentGroup(documentGroup.label);
-    }
+    setExpandedSortWorkSections(documentGroup.label, !showDocuments);
   };
 
   const renderUngroupedDocument = (doc: IDocumentMetadataModel) => {
@@ -85,8 +81,8 @@ export const SortedSection: React.FC<IProps> = observer(function SortedSection(p
              tab={ENavTab.kSortWork}
              shouldHandleStarClick
              allowDelete={false}
+             selectedDocument={ui.highlightedSortWorkDocument}
              onSelectDocument={handleSelectDocument(documentGroup)}
-             usePersistentUI={true}
            />;
   };
 

--- a/src/components/document/sorted-section.tsx
+++ b/src/components/document/sorted-section.tsx
@@ -62,7 +62,7 @@ export const SortedSection: React.FC<IProps> = observer(function SortedSection(p
       const documentGroupId = JSON.stringify(openDocGroupMetadata);
       const tabState = persistentUI.getOrCreateTabState(ENavTab.kSortWork);
       tabState.openDocumentGroupPrimaryDocument(documentGroupId, document.key);
-
+      persistentUI.setSelectedDocumentKey(document.key);
       logDocumentViewEvent(document);
     };
   };
@@ -78,8 +78,6 @@ export const SortedSection: React.FC<IProps> = observer(function SortedSection(p
   const renderUngroupedDocument = (doc: IDocumentMetadataModel) => {
     const fullDocument = getDocument(doc.key);
     if (!fullDocument) return <div key={doc.key} className="loading-spinner"/>;
-    const maybeTabState = persistentUI.tabs.get(ENavTab.kSortWork);
-    const openDocumentKey = maybeTabState?.currentDocumentGroup?.primaryDocumentKey;
     return <DecoratedDocumentThumbnailItem
              key={doc.key}
              scale={0.1}
@@ -87,8 +85,8 @@ export const SortedSection: React.FC<IProps> = observer(function SortedSection(p
              tab={ENavTab.kSortWork}
              shouldHandleStarClick
              allowDelete={false}
-             selectedDocument={openDocumentKey}
              onSelectDocument={handleSelectDocument(documentGroup)}
+             usePersistentUI={true}
            />;
   };
 

--- a/src/components/thumbnail/decorated-document-thumbnail-item.tsx
+++ b/src/components/thumbnail/decorated-document-thumbnail-item.tsx
@@ -19,7 +19,6 @@ interface IProps {
   document: DocumentModelType;
   selectedDocument?: string;
   selectedSecondaryDocument?: string;
-  usePersistentUI?: boolean;
   allowDelete: boolean;
   tab: string;
 }
@@ -27,13 +26,11 @@ interface IProps {
 // observes teacher names via useDocumentCaption()
 export const DecoratedDocumentThumbnailItem: React.FC<IProps> = observer(({
   document, tab, scale, selectedDocument, selectedSecondaryDocument, allowDelete,
-  onSelectDocument, shouldHandleStarClick, usePersistentUI,
+  onSelectDocument, shouldHandleStarClick,
 }: IProps) => {
-    const { user, db: dbStore, bookmarks, ui, persistentUI } = useStores();
+    const { user, db: dbStore, bookmarks, ui } = useStores();
     const tabName = tab.toLowerCase().replace(' ', '-');
     const caption = useDocumentCaption(document);
-    const selectedDocumentKey = usePersistentUI ?
-      persistentUI.selectedDocumentKey : selectedDocument;
 
     // sync delete a publication to firebase
     useDocumentSyncToFirebase(user, dbStore.firebase, dbStore.firestore, document, true);
@@ -78,7 +75,7 @@ export const DecoratedDocumentThumbnailItem: React.FC<IProps> = observer(({
         canvasContext={tab}
         document={document}
         scale={scale}
-        isSelected={document.key === selectedDocumentKey}
+        isSelected={document.key === selectedDocument}
         isSecondarySelected={document.key === selectedSecondaryDocument}
         captionText={caption}
         onDocumentClick={handleDocumentClick}

--- a/src/components/thumbnail/decorated-document-thumbnail-item.tsx
+++ b/src/components/thumbnail/decorated-document-thumbnail-item.tsx
@@ -5,7 +5,7 @@ import { ThumbnailDocumentItem } from "./thumbnail-document-item";
 import { useDocumentCaption } from "../../hooks/use-document-caption";
 import { useDocumentSyncToFirebase } from "../../hooks/use-document-sync-to-firebase";
 import { DocumentModelType } from "../../models/document/document";
-import { useDBStore, useStores, useUIStore, useUserStore } from "../../hooks/use-stores";
+import { useStores } from "../../hooks/use-stores";
 import { DocumentDragKey, SupportPublication } from "../../models/document/document-types";
 import { logDocumentEvent } from "../../models/document/log-document-event";
 import { LogEventName } from "../../lib/logger-types";
@@ -19,6 +19,7 @@ interface IProps {
   document: DocumentModelType;
   selectedDocument?: string;
   selectedSecondaryDocument?: string;
+  usePersistentUI?: boolean;
   allowDelete: boolean;
   tab: string;
 }
@@ -26,14 +27,13 @@ interface IProps {
 // observes teacher names via useDocumentCaption()
 export const DecoratedDocumentThumbnailItem: React.FC<IProps> = observer(({
   document, tab, scale, selectedDocument, selectedSecondaryDocument, allowDelete,
-  onSelectDocument, shouldHandleStarClick
+  onSelectDocument, shouldHandleStarClick, usePersistentUI,
 }: IProps) => {
-    const user = useUserStore();
-    const dbStore = useDBStore();
+    const { user, db: dbStore, bookmarks, ui, persistentUI } = useStores();
     const tabName = tab.toLowerCase().replace(' ', '-');
     const caption = useDocumentCaption(document);
-    const ui = useUIStore();
-    const { bookmarks } = useStores();
+    const selectedDocumentKey = usePersistentUI ?
+      persistentUI.selectedDocumentKey : selectedDocument;
 
     // sync delete a publication to firebase
     useDocumentSyncToFirebase(user, dbStore.firebase, dbStore.firestore, document, true);
@@ -78,7 +78,7 @@ export const DecoratedDocumentThumbnailItem: React.FC<IProps> = observer(({
         canvasContext={tab}
         document={document}
         scale={scale}
-        isSelected={document.key === selectedDocument}
+        isSelected={document.key === selectedDocumentKey}
         isSecondarySelected={document.key === selectedSecondaryDocument}
         captionText={caption}
         onDocumentClick={handleDocumentClick}

--- a/src/components/thumbnail/document-type-collection.scss
+++ b/src/components/thumbnail/document-type-collection.scss
@@ -86,6 +86,10 @@ $section-padding: 6px;
     overflow: hidden;
     cursor: pointer;
 
+    &.selected {
+      background-color: $classwork-purple-light-6;
+    }
+
     .scaled-list-item-container {
       border-radius: 5px;
       border: solid 1.5px $charcoal-light-1;

--- a/src/components/thumbnail/simple-document-item.scss
+++ b/src/components/thumbnail/simple-document-item.scss
@@ -15,7 +15,7 @@
   &:hover {
     background: $classwork-purple-light-4;
   }
-  &:active {
+  &:active, &.selected {
     background: $classwork-purple-light-2;
   }
 

--- a/src/components/thumbnail/simple-document-item.tsx
+++ b/src/components/thumbnail/simple-document-item.tsx
@@ -1,5 +1,6 @@
 import { observer } from "mobx-react";
 import React from "react";
+import classNames from "classnames";
 import { IDocumentMetadataModel } from "../../models/stores/sorted-documents";
 import { useStores } from "../../hooks/use-stores";
 import { getDocumentDisplayTitle, isDocumentAccessibleToUser } from "../../models/document/document-utils";
@@ -14,12 +15,13 @@ interface IProps {
 export const SimpleDocumentItem = observer(function SimpleDocumentItem(
   { document, onSelectDocument }: IProps
 ) {
-  const { appConfig, documents, class: classStore, unit, user } = useStores();
+  const { appConfig, documents, class: classStore, unit, user, persistentUI } = useStores();
   const { uid } = document;
   const userName = classStore.getUserById(uid)?.displayName;
   const title = getDocumentDisplayTitle(unit, document, appConfig);
   const titleWithUser = `${userName}: ${title}`;
   const isPrivate = !isDocumentAccessibleToUser(document, user, documents);
+  const isSelected = persistentUI.selectedDocumentKey === document.key;
 
   const handleClick = () => {
     onSelectDocument(document);
@@ -27,7 +29,7 @@ export const SimpleDocumentItem = observer(function SimpleDocumentItem(
 
   return (
     <div
-      className={isPrivate ? "simple-document-item private" : "simple-document-item"}
+      className={classNames("simple-document-item", { selected: isSelected, private: isPrivate })}
       data-test="simple-document-item"
       title={titleWithUser}
       onClick={!isPrivate ? handleClick : undefined}

--- a/src/components/thumbnail/simple-document-item.tsx
+++ b/src/components/thumbnail/simple-document-item.tsx
@@ -15,13 +15,13 @@ interface IProps {
 export const SimpleDocumentItem = observer(function SimpleDocumentItem(
   { document, onSelectDocument }: IProps
 ) {
-  const { appConfig, documents, class: classStore, unit, user, persistentUI } = useStores();
+  const { appConfig, documents, class: classStore, unit, user, ui } = useStores();
   const { uid } = document;
   const userName = classStore.getUserById(uid)?.displayName;
   const title = getDocumentDisplayTitle(unit, document, appConfig);
   const titleWithUser = `${userName}: ${title}`;
   const isPrivate = !isDocumentAccessibleToUser(document, user, documents);
-  const isSelected = persistentUI.selectedDocumentKey === document.key;
+  const isSelected = ui.highlightedSortWorkDocument === document.key;
 
   const handleClick = () => {
     onSelectDocument(document);

--- a/src/models/stores/persistent-ui/persistent-ui.ts
+++ b/src/models/stores/persistent-ui/persistent-ui.ts
@@ -122,7 +122,10 @@ export const PersistentUIModelV2 = types
     },
     removeOpenDocumentGroup(docGroupLabel: string) {
       remove(self.openDocumentGroups, (docGroup) => docGroup === docGroupLabel);
-    }
+    },
+    setSelectedDocumentKey(key: string) {
+      self.selectedDocumentKey = key;
+    },
   }))
   .actions((self) => ({
     /**
@@ -191,13 +194,12 @@ export const PersistentUIModelV2 = types
     openDocumentGroupPrimaryDocument(tab: string, docGroupId: string, documentKey: string) {
       const tabState = self.getOrCreateTabState(tab);
       self.activeNavTab = tab;
-      self.selectedDocumentKey = documentKey;
+      self.setSelectedDocumentKey(documentKey);
       tabState.openDocumentGroupPrimaryDocument(docGroupId, documentKey);
     },
     openDocumentGroupSecondaryDocument(tab: string, docGroupId: string, documentKey: string) {
       const tabState = self.getOrCreateTabState(tab);
       self.activeNavTab = tab;
-      self.selectedDocumentKey = documentKey;
       tabState.setDocumentGroupSecondaryDocument(docGroupId, documentKey);
       tabState.currentDocumentGroupId = docGroupId;
     },

--- a/src/models/stores/persistent-ui/persistent-ui.ts
+++ b/src/models/stores/persistent-ui/persistent-ui.ts
@@ -35,7 +35,6 @@ export const PersistentUIModelV2 = types
     docFilter: types.optional(DocFilterTypeEnum, "Problem"),
     primarySortBy: types.optional(types.string, "Group"),
     secondarySortBy: types.optional(types.string, "None"),
-    selectedSecondaryDocumentKey: types.maybe(types.string),
     showAnnotations: true,
     showTeacherContent: true,
     showChatPanel: false,

--- a/src/models/stores/persistent-ui/persistent-ui.ts
+++ b/src/models/stores/persistent-ui/persistent-ui.ts
@@ -2,7 +2,7 @@ import {
   getSnapshot, applySnapshot, types, onSnapshot,
   SnapshotIn, Instance
 } from "mobx-state-tree";
-import { cloneDeep, remove } from "lodash";
+import { cloneDeep } from "lodash";
 import { AppConfigModelType } from "../app-config-model";
 import {
   DocFilterType, DocFilterTypeEnum, kDividerHalf, kDividerMax,
@@ -33,10 +33,8 @@ export const PersistentUIModelV2 = types
     dividerPosition: kDividerHalf,
     activeNavTab: types.maybe(types.string),
     docFilter: types.optional(DocFilterTypeEnum, "Problem"),
-    openDocumentGroups: types.optional(types.array(types.string), []),
     primarySortBy: types.optional(types.string, "Group"),
     secondarySortBy: types.optional(types.string, "None"),
-    selectedDocumentKey: types.maybe(types.string),
     selectedSecondaryDocumentKey: types.maybe(types.string),
     showAnnotations: true,
     showTeacherContent: true,
@@ -64,9 +62,6 @@ export const PersistentUIModelV2 = types
     get activeTabModel () {
       if (!self.activeNavTab) return undefined;
       return self.tabs.get(self.activeNavTab);
-    },
-    isDocumentGroupOpen(docGroupLabel: string) {
-      return self.openDocumentGroups.includes(docGroupLabel);
     }
   }))
   .views((self) => ({
@@ -114,18 +109,7 @@ export const PersistentUIModelV2 = types
         self.tabs.put(tabState);
       }
       return tabState;
-    },
-    addOpenDocumentGroup(docGroupLabel: string) {
-      if (!self.openDocumentGroups.includes(docGroupLabel)) {
-        self.openDocumentGroups.push(docGroupLabel);
-      }
-    },
-    removeOpenDocumentGroup(docGroupLabel: string) {
-      remove(self.openDocumentGroups, (docGroup) => docGroup === docGroupLabel);
-    },
-    setSelectedDocumentKey(key: string) {
-      self.selectedDocumentKey = key;
-    },
+    }
   }))
   .actions((self) => ({
     /**
@@ -194,7 +178,6 @@ export const PersistentUIModelV2 = types
     openDocumentGroupPrimaryDocument(tab: string, docGroupId: string, documentKey: string) {
       const tabState = self.getOrCreateTabState(tab);
       self.activeNavTab = tab;
-      self.setSelectedDocumentKey(documentKey);
       tabState.openDocumentGroupPrimaryDocument(docGroupId, documentKey);
     },
     openDocumentGroupSecondaryDocument(tab: string, docGroupId: string, documentKey: string) {

--- a/src/models/stores/ui.ts
+++ b/src/models/stores/ui.ts
@@ -47,6 +47,8 @@ export const UIModel = types
   .model("UI", {
     annotationMode: types.maybe(types.string),
     error: types.maybeNull(types.string),
+    expandedSortWorkSections: types.optional(types.array(types.string), []),
+    highlightedSortWorkDocument: types.maybe(types.string),
     selectedTileIds: types.array(types.string),
     selectedCommentId: types.maybe(types.string),
     scrollTo: types.maybe(ScrollToModel),
@@ -63,7 +65,7 @@ export const UIModel = types
   .views((self) => ({
     isSelectedTile(tile: ITileModel) {
       return self.selectedTileIds.indexOf(tile.id) !== -1;
-    },
+    }
   }))
   .actions((self) => {
     const alert = (textOrOpts: string | UIDialogModelSnapshotWithoutType, title?: string) => {
@@ -215,7 +217,25 @@ export const UIModel = types
       self.selectedTileIds.forEach(tileId => self.removeTileIdFromSelection(tileId));
     },
 
+    setExpandedSortWorkSections(docGroupLabel: string, expand: boolean) {
+      if (expand) {
+        self.expandedSortWorkSections.push(docGroupLabel);
+      } else {
+        self.expandedSortWorkSections.remove(docGroupLabel);
+      }
+    },
 
+    setHighlightedSortWorkDocument(docId: string) {
+      self.highlightedSortWorkDocument = docId;
+    },
+
+    clearHighlightedSortWorkDocument() {
+      self.highlightedSortWorkDocument = undefined;
+    },
+
+    clearExpandedSortWorkSections() {
+      self.expandedSortWorkSections.clear();
+    }
 }));
 export type UIModelType = typeof UIModel.Type;
 export type UIDialogModelType = typeof UIDialogModel.Type;


### PR DESCRIPTION
[CLUE-86](https://concord-consortium.atlassian.net/browse/CLUE-86?atlOrigin=eyJpIjoiYTA2NTM3ZjA4ZmIxNDc0NmFhMTc5NjUxNTk2ZDA4ODQiLCJwIjoiaiJ9)

When a user expands a section in the Sort Work overview, clicks on a thumbnail within a section to view a document, and then exits that view to return to the Sort Work overview, any previously expanded sections remain open, and the previously opened document remains visibly highlighted. 

When a user switches the 'Secondary Sort' option or the 'Filter', if a section is expanded, the section remains expanded, and if a document is highlighted, it remains highlighted. 

When a user switches the 'Primary Sort' option, everything resets -- expanded sections are no longer remembered, and neither is the previously highlighted document.

[CLUE-86]: https://concord-consortium.atlassian.net/browse/CLUE-86?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ