### PR TITLE
chore: try s3-deploy-action v1.7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
         with:
           name: build
           path: dist
-      - uses: concord-consortium/s3-deploy-action@v1
+      - uses: concord-consortium/s3-deploy-action@v1.7.0
         id: s3-deploy
         with:
           build: echo no build


### PR DESCRIPTION
This is just for testing that deploying still works correctly when using s3-deploy-action v1.7.0.