### PR TITLE
fix: white bar on bar graph disappears (CLUE-110)

### DIFF
--- a/src/plugins/bar-graph/bar-graph.scss
+++ b/src/plugins/bar-graph/bar-graph.scss
@@ -14,7 +14,7 @@ $color-button-active: rgba(20, 244, 158, .5); // 50% #14f49e
 
   svg.bar-graph-svg {
 
-    .visx-bar-group .visx-bar {
+    .visx-bar {
       stroke: black;
       stroke-width: 1px;
     }


### PR DESCRIPTION
[CLUE-110](https://concord-consortium.atlassian.net/browse/CLUE-110)

Previously, bars only had an outline when there was a secondary sort. That worked fine before we allowed users to change the bar colors from the default blue when there is no sort. Now that the user can change the color to white, though, bars can become essentially invisible. This change would ensure bars always have an outline to prevent that. (I checked with @mtirenin who confirmed bars should always have an outline.)

[CLUE-110]: https://concord-consortium.atlassian.net/browse/CLUE-110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ