### PR TITLE
fix: Lost first keystroke in table cells (CLUE-40)

### DIFF
--- a/src/components/tiles/table/cell-text-editor.tsx
+++ b/src/components/tiles/table/cell-text-editor.tsx
@@ -77,15 +77,13 @@ export default function CellTextEditor<TRow, TSummaryRow = unknown>({
         style={{top, left, width: column.width}}
         autoFocus={true}
         onChange={event => {
+          // Ignore newline inserted when editor first opens via Enter/Return key
+          if (event.target.value === "\n") return;
+
           updateValue(event.target.value);
         }}
         onFocus={event => {
-          // Select all text when focused, but not until after the current event
-          // has been processed. Otherwise, starting to edit a cell with a
-          // keystroke will select the text and then overwrite it all immediately.
-          setTimeout(() => {
-            event.target.select();
-          }, 1);
+          event.target.select();
         }}
         onBlur={event => {
           finishAndSave(true);


### PR DESCRIPTION
[CLUE-40](https://concord-consortium.atlassian.net/browse/CLUE-40)

[CLUE-40]: https://concord-consortium.atlassian.net/browse/CLUE-40?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ