### PR TITLE
feat: Add shareable link to teacher dropdown [CLUE-91]

### DIFF
--- a/src/clue/components/clue-app-header.sass
+++ b/src/clue/components/clue-app-header.sass
@@ -69,6 +69,7 @@ $member-size: 18px
     display: flex
     align-items: center
     justify-content: flex-end
+    gap: 10px
 
     .network-status-and-version
       display: flex
@@ -78,6 +79,9 @@ $member-size: 18px
 
       .version
         font-size: 12px
+
+    .version
+      font-size: 12px
 
     .group
       height: 40px

--- a/src/clue/components/clue-app-header.tsx
+++ b/src/clue/components/clue-app-header.tsx
@@ -162,7 +162,7 @@ export const ClueAppHeaderComponent: React.FC<IProps> = observer(function ClueAp
           {renderPanelButtons()}
         </div>
         <div className="right">
-          <div className="version">Version {appVersion}</div>
+          <div className="version">CLUE v{appVersion}</div>
           <div className="user teacher" title={getUserTitle()}>
             <div className="class" data-test="user-class">
               <ClassMenuContainer />

--- a/src/clue/components/custom-select.sass
+++ b/src/clue/components/custom-select.sass
@@ -100,6 +100,9 @@
         width: fit-content
         margin-right: 10px
 
+        &.italicize
+          font-style: italic
+
       &:hover
         background-color: $workspace-teal-light-3
 
@@ -119,6 +122,10 @@
         background-position: center
         &.selected
           background-image: url("../../assets/icons/check/check-selected.svg")
+
+      &:active .hidden-item-check, .hidden-item-check, .hidden-item-check.selected
+        background-image: none
+
 
     .list-item:last-child
       border-radius: 0 0 5px 5px

--- a/src/clue/components/custom-select.tsx
+++ b/src/clue/components/custom-select.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode } from "react";
 import { VisuallyHidden } from "@chakra-ui/react";
 import { IDropdownItem } from "@concord-consortium/react-components";
+import classNames from "classnames";
 import ArrowIcon from "../../assets/icons/arrow/arrow.svg";
 
 import "./custom-select.sass";
@@ -8,6 +9,8 @@ import "./custom-select.sass";
 export interface ICustomDropdownItem extends IDropdownItem {
   id?: string;
   itemIcon?: ReactNode;
+  hideItemCheck?: boolean;
+  italicize?: boolean;
 }
 
 function getItemId(item: ICustomDropdownItem) {
@@ -122,9 +125,12 @@ export class CustomSelect extends React.PureComponent<IProps, IState> {
               onClick={this.handleListClick(item)}
               data-test={`list-item-${itemId}`}
             >
-              {(showItemChecks !== false) && <div className={`check ${selectedClass}`} />}
+              {(showItemChecks !== false) &&
+                <div className={classNames("check", selectedClass, {
+                  "hidden-item-check": item.hideItemCheck})}
+                />}
               {this.renderItemIcon(item)}
-              <div className="item">{item.text}</div>
+              <div className={classNames("item", {italicize: item.italicize })}>{item.text}</div>
             </div>
           );
         }) }

--- a/src/components/class-menu-container.tsx
+++ b/src/components/class-menu-container.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { uniq } from "lodash";
 import { inject, observer } from "mobx-react";
 import { BaseComponent, IBaseProps } from "./base";
-import { CustomSelect } from "../clue/components/custom-select";
+import { CustomSelect, ICustomDropdownItem } from "../clue/components/custom-select";
 import { Logger } from "../lib/logger";
 import { LogEventMethod, LogEventName } from "../lib/logger-types";
 import { IUserPortalOffering } from "../models/stores/user";
@@ -14,8 +14,28 @@ interface IProps extends IBaseProps {}
 @observer
 export class ClassMenuContainer extends BaseComponent <IProps> {
   public render() {
-    const links = this.getPortalClasses();
-    const { user } = this.stores;
+    const links = this.getPortalClasses() as ICustomDropdownItem[];
+    const { user, ui } = this.stores;
+
+    // if the user authenticated in standalone mode, we add a link to copy the shareable link
+    // of the current URL as it contains all the information needed to join the class
+    if (user.standaloneAuthUser) {
+      links.unshift({
+        text: "Copy Shareable Link",
+        selected: false,
+        hideItemCheck: true,
+        italicize: true,
+        onClick: () => {
+          // in standalone mode the shareable link is the current URL
+          navigator.clipboard.writeText(window.location.href).then(() => {
+            ui.alert("The shareable link has been copied to the clipboard.", "Copy Shareable Link");
+          }).catch(err => {
+            ui.alert(`Failed to copy sharable link: ${err.toString()}.`, "Copy Shareable Link");
+          });
+        }
+      });
+    }
+
     return(
       <CustomSelect
         titlePrefix={user.name}


### PR DESCRIPTION
This adds the functionality to share a link to the current standalone app instance in the teacher dropdown.

This does not update the dropdown styling to match the new spec.  That will be done in a follow on PR as there are a couple of styling issues that need to be resolved first and the current header styling is a bit of a mess.

This commit also updates the version output in the teacher app header to match the student app header and adds a gap between the version and teacher dropdown.