### PR TITLE
feat: Add unit navigation for students [CLUE-76]

### DIFF
--- a/src/clue/components/clue-app-header.tsx
+++ b/src/clue/components/clue-app-header.tsx
@@ -180,7 +180,10 @@ export const ClueAppHeaderComponent: React.FC<IProps> = observer(function ClueAp
     return renderNonStudentHeader({showProblemMenu: false});
   }
 
-  if (user.isTeacher && appConfig.showClassSwitcher) {
+  // in standalone mode students can navigate between problems because all the
+  // information is in the URL and it doesn't need to be launched from the portal.
+  const isAuthedStandaloneStudent = user.isStudent && user.standaloneAuthUser;
+  if ((user.isTeacher || isAuthedStandaloneStudent) && appConfig.showClassSwitcher) {
     return renderNonStudentHeader({showProblemMenu: true});
   }
 

--- a/src/components/problem-menu-container.tsx
+++ b/src/components/problem-menu-container.tsx
@@ -13,10 +13,10 @@ export const ProblemMenuContainer: React.FC<IProps> = observer(function ProblemM
   const { problem, ui, unit, user } = useStores();
 
   const showUnassignedLinkAlert = (problemName: string) => {
-    ui.alert(
-      `You must first assign ${problemName} from the portal.`,
-      "Problem not currently assigned"
-    );
+    const message = user.isStudent
+      ? `Please contact your teacher to assign ${problemName}.`
+      : `You must first assign ${problemName} from the portal.`;
+    ui.alert(message, "Problem not currently assigned");
   };
 
   const handleMenuItemClick = (item: IDropdownItem, problemName: string) => {
@@ -50,6 +50,17 @@ export const ProblemMenuContainer: React.FC<IProps> = observer(function ProblemM
             offering.unitCode === unitCode
           );
         });
+        if (portalOffering && portalOffering.location.includes("/standalone")) {
+          // Add autoLogin hash param to any standalone links.  This isn't done in the portal API
+          // function to keep the links "pure" for other uses.  The autoLogin hash param signals
+          // to the standalone app to log in the user automatically so they don't have to
+          // click the login button after they select a different problem.
+          const offeringLocation = new URL(portalOffering.location);
+          const hashParams = new URLSearchParams(offeringLocation.hash.substring(1));
+          hashParams.set("autoLogin", "true");
+          offeringLocation.hash = hashParams.toString();
+          portalOffering.location = offeringLocation.toString();
+        }
         const fullTitle = invProb.subtitle ? `${invProb.title}: ${invProb.subtitle}` : invProb.title;
         const link: IDropdownItem = {
           selected: problem.title === invProb.title,

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -85,7 +85,7 @@ const FIREBASE_JWT_PATH = `/${FIREBASE_JWT_URL_SUFFIX}`;
 const OFFERING_INFO_PATH = "/api/v1/offerings/1033";
 const CLASS_INFO_PATH = "/api/v1/classes/66";
 const CLASSES_MINE_PATH = "/api/v1/classes/mine";
-// const OFFERINGS_PATH = "/api/v1/offerings";
+const OFFERINGS_PATH = "/api/v1/offerings/";
 
 const CLASS_INFO_URL = BASE_PORTAL_HOST + CLASS_INFO_PATH;
 const OFFERING_INFO_URL = BASE_PORTAL_HOST + OFFERING_INFO_PATH;
@@ -325,6 +325,14 @@ describe("student authentication", () => {
     .reply(200, {
       token: RAW_STUDENT_FIREBASE_JWT,
     });
+
+    nock(BASE_PORTAL_HOST, {
+      reqheaders: {
+        authorization: `Bearer/JWT ${RAW_STUDENT_PORTAL_JWT}`
+      }
+    })
+    .get(OFFERINGS_PATH)
+    .reply(200, []);
 
     const urlParams = {token: GOOD_STUDENT_TOKEN, domain: BASE_PORTAL_URL};
     const portal = new Portal(urlParams);

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -175,7 +175,6 @@ export const authenticate = async (
   const unitCode = urlParams.unit || "";
   // when launched as a report, the params will not contain the problemOrdinal
   const problemOrdinal = urlParams.problem || appConfig.defaultProblemOrdinal;
-  const offeringId = urlParams.resourceLinkId || undefined;
 
   let {fakeClass, fakeUser} = urlParams;
   // handle preview launch from portal
@@ -255,7 +254,7 @@ export const authenticate = async (
   const tokenType = user?.standaloneAuthUser ? "Bearer/JWT" : "Bearer";
   const rawToken = user?.standaloneAuthUser?.rawJWT ?? bearerToken;
   const firebaseJWTPromise = getFirebaseJWTWithBearerToken(basePortalUrl, tokenType, rawToken, classHash);
-  const portalOfferingsPromise = getPortalOfferings(user_type, uid, domain, rawPortalJWT, offeringId);
+  const portalOfferingsPromise = getPortalOfferings(user_type, uid, domain, rawPortalJWT);
   const problemIdPromise = getProblemIdForAuthenticatedUser(rawPortalJWT, curriculumConfig, urlParams);
 
   const [firebaseJWTResult, portalOfferingsResult, problemIdResult] =

--- a/src/lib/portal-api.test.ts
+++ b/src/lib/portal-api.test.ts
@@ -1,7 +1,7 @@
 import nock from "nock";
 import { getPortalClassOfferings, getPortalOfferings } from "./portal-api";
 import { IPortalOffering } from "./portal-types";
-import { TeacherMineClasses, TeacherOfferings } from "../test-fixtures/sample-portal-offerings";
+import { StudentOfferings, TeacherMineClasses, TeacherOfferings } from "../test-fixtures/sample-portal-offerings";
 import { AppConfigModelType } from "../models/stores/app-config-model";
 import { CurriculumConfig } from "../models/stores/curriculum-config";
 
@@ -15,6 +15,9 @@ describe("Portal Offerings", () => {
     nock(/superfake/)
       .get(/\/api\/v1\/offerings\/\?user_id=22/)
       .reply(200, TeacherOfferings);
+    nock(/superfake/)
+      .get(/\/api\/v1\/offerings\//)
+      .reply(200, StudentOfferings);
     nock(/superfake/)
       .get(/\/api\/v1\/offerings\/1190/)
       .reply(200, TeacherOfferings[0]);
@@ -42,13 +45,12 @@ describe("Portal Offerings", () => {
   });
 
   describe("getPortalOfferings for learner or other", () => {
-    it("should return a single offering for learner", async () => {
-      const offerings = await getPortalOfferings("learner", userID, domain, fakeJWT, "1190");
+    it("should return all the offerings for the learner", async () => {
+      const offerings = await getPortalOfferings("learner", userID, domain, fakeJWT);
       expect(offerings.length).toEqual(1);
       expect(offerings[0].id).toEqual(1190);
       expect(offerings[0].activity_url).toEqual("https://collaborative-learning.concord.org/branch/master/?unit=sas&problem=1.2");
     });
-
 
     it("should not return anything for researcher", async () => {
       expect(await getPortalOfferings("researcher", userID, domain, fakeJWT)).toEqual([]);

--- a/src/test-fixtures/sample-portal-offerings.ts
+++ b/src/test-fixtures/sample-portal-offerings.ts
@@ -550,3 +550,59 @@ export const TeacherOfferings = [
     students: []
   }
 ];
+
+
+export const StudentOfferings = [
+  {
+    id: 1190,
+    teacher: "Dave Love",
+    clazz: "ClueClass1",
+    clazz_id: 242,
+    clazz_info_url: "https://learn.staging.concord.org/api/v1/classes/242",
+    activity: "CLUE 1.2: Stretching a Figure - Comparing Similar Figures",
+    activity_url: "https://collaborative-learning.concord.org/branch/master/?unit=sas&problem=1.2",
+    material_type: "Activity",
+    report_url: null,
+    rubric_url: "",
+    preview_url: "https://learn.staging.concord.org/eresources/1129.run_resource_html?logging=true",
+    external_report: {
+      id: 14,
+      name: "CLUE Dashboard",
+      url: "https://learn.staging.concord.org/portal/offerings/1190/external_report/14",
+      launch_text: "CLUE Dashboard"
+    },
+    external_reports: [
+      {
+        id: 14,
+        name: "CLUE Dashboard",
+        url: "https://learn.staging.concord.org/portal/offerings/1190/external_report/14",
+        launch_text: "CLUE Dashboard"
+      }
+    ],
+    reportable: false,
+    reportable_activities: null,
+    students: [
+      {
+        name: "first1 last1",
+        first_name: "first1",
+        last_name: "last1",
+        username: "flast1",
+        user_id: 4866,
+        started_activity: true,
+        endpoint_url: "https://learn.staging.concord.org/dataservice/external_activity_data/c23e58c4-6bb3-456a-af47-05a48597e129",
+        learner_report_url: null,
+        last_run: null,
+        total_progress: 0,
+        detailed_progress: [
+          {
+            activity_id: 1237,
+            activity_name: "CLUE: Stretching a Figure - Comparing Similar Figures",
+            progress: 0,
+            learner_activity_report_url: null,
+            feedback: null
+          }
+        ]
+      },
+    ]
+  },
+];


### PR DESCRIPTION
This allows students to navigate between units in the app.  Before only teachers could navigate between units.  This change requires the portal API to be updated to allow students to request their own offerings.

This also updates unrelated code in the standalone auth component to change a variable name and update a comment based on an earlier PR comment.
