### PR TITLE
[CLUE-56]: Scroller list header shows document group labels

### DIFF
--- a/cypress/e2e/functional/teacher_tests/teacher_sort_work_view_7_spec.js
+++ b/cypress/e2e/functional/teacher_tests/teacher_sort_work_view_7_spec.js
@@ -19,8 +19,6 @@ function beforeTest(params) {
 // separate files for each test due to Cypress running out of memory when running all tests.
 
 describe('SortWorkView Tests', () => {
-  const headerTexts = () => cy.get('.document-scroller-header .header-text');
-
   it("shows the current sort selections in the document-scroller header", () => {
     beforeTest(queryParams1);
 
@@ -37,13 +35,13 @@ describe('SortWorkView Tests', () => {
         /* header exists and shows the expected strings */
         cy.get('.document-scroller-header').should('exist');
 
-        headerTexts().eq(0)
+        sortWork.getHeaderTexts().eq(0)
           .should('contain', 'Sorted by')
           .find('span').should('contain', 'Group')
           .parent().should('not.contain', 'None') // don't show "None" in the header
           .should('contain', primaryLabel);      // dynamic bit
 
-          headerTexts().eq(1)
+          sortWork.getHeaderTexts().eq(1)
             .should('contain', 'Shown for')
             .find('span').should('contain', 'Problem');
       }
@@ -75,14 +73,14 @@ describe('SortWorkView Tests', () => {
             /* header exists and shows the expected strings */
             cy.get('.document-scroller-header').should('exist');
 
-            headerTexts().eq(0)
+            sortWork.getHeaderTexts().eq(0)
               .should('contain', 'Sorted by')
               .find('span').eq(0).should('contain', 'Strategy')
               .parent().should('contain', primaryLabel)
               .find('span').eq(1).should('contain', 'Name')
               .parent().should('contain', secondaryLabel);
 
-              headerTexts().eq(1)
+              sortWork.getHeaderTexts().eq(1)
                 .should('contain', 'Shown for')
                 .find('span').should('contain', 'Investigation');
           }

--- a/cypress/e2e/functional/teacher_tests/teacher_sort_work_view_7_spec.js
+++ b/cypress/e2e/functional/teacher_tests/teacher_sort_work_view_7_spec.js
@@ -19,19 +19,38 @@ function beforeTest(params) {
 // separate files for each test due to Cypress running out of memory when running all tests.
 
 describe('SortWorkView Tests', () => {
-  it("should show the selected sort options when viewing a document within the Sort Work tab and the document scroller is visible", () => {
+  const headerTexts = () => cy.get('.document-scroller-header .header-text');
+
+  it("shows the current sort selections in the document-scroller header", () => {
     beforeTest(queryParams1);
 
-    cy.log("open a document and verify that the selected sort options are displayed in the header");
-    cy.get('.section-header-arrow').eq(0).click();
-    sortWork.getSortWorkItem().first().click();
-    cy.get('.document-scroller-header').should("exist");
-    cy.get('.document-scroller-header').find('.header-text').eq(0).should("contain", "Sorted by");
-    cy.get('.document-scroller-header').find('.header-text').eq(0).find("span").should("contain", "Group / None");
-    cy.get('.document-scroller-header').find('.header-text').eq(1).should("contain", "Shown for");
-    cy.get('.document-scroller-header').find('.header-text').eq(1).find("span").should("contain", "Problem");
+    cy.log("open a document and verify the initial header");
 
-    cy.log("change the selected sort options and verify that the header text is updated");
+    cy.get('.section-header-arrow').first().click();
+    sortWork.getPrimarySortLabelForItem(0)
+      .invoke('text')
+      .then((primaryLabel) => {
+
+        // open the first document under that sort category
+        sortWork.getSortWorkItem().first().click();
+
+        /* header exists and shows the expected strings */
+        cy.get('.document-scroller-header').should('exist');
+
+        headerTexts().eq(0)
+          .should('contain', 'Sorted by')
+          .find('span').should('contain', 'Group')
+          .parent().should('not.contain', 'None') // don't show "None" in the header
+          .should('contain', primaryLabel);      // dynamic bit
+
+          headerTexts().eq(1)
+            .should('contain', 'Shown for')
+            .find('span').should('contain', 'Problem');
+      }
+    );
+
+    cy.log("change sort selections and verify header update");
+
     cy.get('.close-doc-button').click();
     sortWork.getPrimarySortByMenu().click();
     sortWork.getPrimarySortByTagOption().click();
@@ -39,19 +58,43 @@ describe('SortWorkView Tests', () => {
     sortWork.getSecondarySortByNameOption().click();
     sortWork.getShowForMenu().click();
     sortWork.getShowForInvestigationOption().click();
-    cy.get('.section-header-arrow').click({multiple: true});
-    cy.get(".sort-work-view .sorted-sections .simple-document-item").first().click();
-    cy.get('.document-scroller-header').find('.header-text').eq(0).find("span").should("contain", "Strategy / Name");
-    cy.get('.document-scroller-header').find('.header-text').eq(1).find("span").should("contain", "Investigation");
 
-    cy.log("toggle the document scroller and verify that the selected sort options are not displayed");
-    cy.get('[data-testid="toggle-document-scroller"]').click();
-    cy.get('.document-scroller-header').should("not.exist");
+    cy.get('.section-header-arrow').click({ multiple: true });
+    // capture the text of the first “Primary Sort By” pill
+    sortWork.getPrimarySortLabelForItem(0, true)
+      .invoke('text')
+      .then((primaryLabel) => {
 
-    cy.log("toggle the document scroller back on and verify that the selected sort options are displayed again");
+        sortWork.getSecondarySortLabelForItem(0)
+          .invoke('text')
+          .then((secondaryLabel) => {
+
+            // open the first document under that sort category
+            sortWork.getSimpleDocumentItem().first().click();
+
+            /* header exists and shows the expected strings */
+            cy.get('.document-scroller-header').should('exist');
+
+            headerTexts().eq(0)
+              .should('contain', 'Sorted by')
+              .find('span').eq(0).should('contain', 'Strategy')
+              .parent().should('contain', primaryLabel)
+              .find('span').eq(1).should('contain', 'Name')
+              .parent().should('contain', secondaryLabel);
+
+              headerTexts().eq(1)
+                .should('contain', 'Shown for')
+                .find('span').should('contain', 'Investigation');
+          }
+        );
+      }
+    );
+
+    cy.log("toggle document scroller visibility");
+
     cy.get('[data-testid="toggle-document-scroller"]').click();
-    cy.get('.document-scroller-header').should("exist");
-    cy.get('.document-scroller-header').find('.header-text').eq(0).find("span").should("contain", "Strategy / Name");
-    cy.get('.document-scroller-header').find('.header-text').eq(1).find("span").should("contain", "Investigation");
+    cy.get('.document-scroller-header').should('not.exist');
+    cy.get('[data-testid="toggle-document-scroller"]').click();
+    cy.get('.document-scroller-header').should('exist');
   });
 });

--- a/cypress/support/elements/common/SortedWork.js
+++ b/cypress/support/elements/common/SortedWork.js
@@ -146,6 +146,10 @@ class SortedWork {
               .siblings('[data-testid="doc-group-label"]')
               .eq(0);
   }
+
+  getHeaderTexts() {
+    return cy.get('.document-scroller-header .header-text');
+  }
 }
 
 export default SortedWork;

--- a/cypress/support/elements/common/SortedWork.js
+++ b/cypress/support/elements/common/SortedWork.js
@@ -122,6 +122,30 @@ class SortedWork {
     return this.getFocusDocument().find('.document-title');
   }
 
+  getSimpleDocumentItem() {
+    return cy.get('.sort-work-view .sorted-sections .simple-document-item');
+  }
+
+  getPrimarySortLabelForItem(sortWorkItemIdx, isSimpleDocument = false) {
+    const selector = isSimpleDocument ?
+      '.sort-work-view .sorted-sections .simple-document-item' :
+      '.sort-work-view .sorted-sections .list-item';
+    return cy.get(selector)
+              .eq(sortWorkItemIdx)
+              .parents('.documents-list')
+              .eq(0)
+              .siblings('.section-header')
+              .eq(0)
+              .find('.section-header-left');
+  }
+
+  getSecondarySortLabelForItem(sortWorkItemIdx) {
+    return cy.get('.sort-work-view .sorted-sections .simple-document-item')
+              .eq(sortWorkItemIdx)
+              .parent()
+              .siblings('[data-testid="doc-group-label"]')
+              .eq(0);
+  }
 }
 
 export default SortedWork;

--- a/src/components/document/document-scroller.tsx
+++ b/src/components/document/document-scroller.tsx
@@ -96,16 +96,35 @@ export const DocumentScroller: React.FC<IProps> = observer(function DocumentThum
     return () => obs?.disconnect();
   }, []);
 
-  return (
-    <>
+  const renderHeader = () => {
+    if (!openDocumentKey) return;
+    const { primarySortBy, secondarySortBy } = persistentUI;
+    const hasSecondarySort = secondarySortBy !== "None";
+
+    // The document group passed down to this component will be the secondary sort group if it exists.
+    // Otherwise, it will be the primary sort group.
+    const primaryLabel = hasSecondarySort
+      ? sortedDocuments.getDocSortLabel(openDocumentKey, primarySortBy)
+      : documentGroup?.label;
+    const secondaryLabel = hasSecondarySort ? documentGroup?.label : "";
+
+    return (
       <div className="document-scroller-header">
         <div className="header-text">
-          Sorted by <span>{persistentUI.primarySortBy} / {persistentUI.secondarySortBy}</span>
+          Sorted by
+          <span> {primarySortBy}: </span>{primaryLabel}{" "}
+          { secondaryLabel && <><span> {secondarySortBy}: </span>{secondaryLabel}</> }
         </div>
         <div className="header-text">
           Shown for <span>{persistentUI.docFilter}</span>
         </div>
       </div>
+    );
+  };
+
+  return (
+    <>
+      {renderHeader()}
       <div ref={documentScrollerRef} className="document-thumbnail-scroller" data-testid="document-thumbnail-scroller">
         {scrollToLocation > 0 &&
           <button className="scroll-arrow left" data-testid="scroll-arrow-left" onClick={handleScrollTo("left")}>

--- a/src/models/stores/sorted-documents.ts
+++ b/src/models/stores/sorted-documents.ts
@@ -226,6 +226,15 @@ export class SortedDocuments {
                               }));
   }
 
+  getDocSortLabel(docKey: string, sortBy: string): string|undefined {
+    const sortKey = `by${sortBy}` as keyof SortedDocuments;
+    const sortedDocs = this[sortKey] as DocumentGroup[];
+    const docGroup = sortedDocs?.find(group => group.documents.some(doc => doc.key === docKey));
+    if (docGroup) {
+      return docGroup.label;
+    }
+  }
+
   getMSTSnapshotFromFBSnapshot(snapshot: firebase.firestore.QuerySnapshot<IDocumentMetadata>) {
     const mstSnapshot: SnapshotIn<typeof MetadataDocMapModel> = {};
     snapshot.docs.forEach(doc => {


### PR DESCRIPTION
[CLUE-56](https://concord-consortium.atlassian.net/browse/CLUE-56?atlOrigin=eyJpIjoiOTRlMDhiNTFiOGI5NDI2ZWIzNDJkYzU5MDYzNzc5YjgiLCJwIjoiaiJ9)

Updates the scroll view header so that it contains the primary / secondary sort labels relevant to the document group.

[CLUE-56]: https://concord-consortium.atlassian.net/browse/CLUE-56?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ