### PR TITLE
fix: Header menus rendering under selected nav tabs

### DIFF
--- a/src/clue/components/clue-app-header.sass
+++ b/src/clue/components/clue-app-header.sass
@@ -4,7 +4,7 @@ $member-size: 18px
 
 .app-header
   position: relative
-  z-index: 2
+  z-index: 20
   height: $header-height
   background-color: $workspace-teal-light-5
   color: $charcoal-dark-2


### PR DESCRIPTION
The header creates a stacking context the the dropdown uses and that stacking context needs to be above the nav tabs z-index.  Before this change it was below it so the selected nav tab rendered above the header menus when they were opened.