### PR TITLE
fix: Remove heights from custom modals [CLUE-113]

### DIFF
--- a/src/components/chat/comment-card.scss
+++ b/src/components/chat/comment-card.scss
@@ -154,7 +154,6 @@
   }
 }
 .custom-modal.error-alert.confirm-delete-alert {
-  height: 149px;
   width: 200px;
   border-color: $charcoal;
   display: flex;

--- a/src/components/document/publish-dialog.scss
+++ b/src/components/document/publish-dialog.scss
@@ -2,6 +2,5 @@
 
 .custom-modal.publish-dialog {
   width: 400px;
-  height: 160px;
   outline: none;
 }

--- a/src/components/network-status.scss
+++ b/src/components/network-status.scss
@@ -25,7 +25,3 @@
     }
   }
 }
-
-.custom-modal.error-alert.network-error {
-  height: 190px;
-}

--- a/src/components/tiles/table/expressions-dialog.scss
+++ b/src/components/tiles/table/expressions-dialog.scss
@@ -2,15 +2,12 @@
 
 .custom-modal.set-expression {
   width: 512px;
-  height: 237px;
   outline: none;
 
   .modal-content {
     justify-content: flex-start;
 
     .prompt {
-      margin-top: 15px;
-
       select {
         margin: 0 3px;
         padding: 0 3px;

--- a/src/components/utilities/single-string-dialog.scss
+++ b/src/components/utilities/single-string-dialog.scss
@@ -2,7 +2,6 @@
 
 .custom-modal.single-string {
   width: 400px;
-  height: 183px;
 
   .modal-icon svg {
     width: 36px * 0.65;

--- a/src/hooks/link-tile-dialog.scss
+++ b/src/hooks/link-tile-dialog.scss
@@ -3,19 +3,15 @@
 .custom-modal.link-tile,
 .custom-modal.merge-tile {
   width: 420px;
-  height: 200px;
   outline: none;
 
   .modal-content {
     justify-content: flex-start;
-
-    .prompt {
-      margin-top: 15px;
-    }
   }
 
   select {
-    margin: 15px 20px;
+    padding: 5px 10px;
+    margin: 10px 0;
     font-style: italic;
   }
 

--- a/src/plugins/drawing/components/variable-dialog.scss
+++ b/src/plugins/drawing/components/variable-dialog.scss
@@ -1,6 +1,5 @@
 .custom-modal.variable-dialog {
   width: 512px;
-  height: 242px;
   .content {
     margin: 10px;
     .input-entry {

--- a/src/plugins/shared-variables/dialog/variable-dialog.scss
+++ b/src/plugins/shared-variables/dialog/variable-dialog.scss
@@ -6,8 +6,12 @@
   margin-top: 15px;
 }
 
+.variable-type-icon {
+  top: 0;
+}
+
 .dialog-content {
-  padding-top: 15px;
+  padding-top: 10px;
 }
 
 .diagram-dialog-content {


### PR DESCRIPTION
This removes all the explicit heights from the custom modals as they are not needed anymore as the custom modal was updated in CLUE-90 to add default padding to the modal content which accomplishes the same effect as the height setting but without having to determine and set the height.

This also updates the select styling in the link tile dialog to match the spec'ed padding.