### PR TITLE
fix: Update copy shareable link styling [CLUE-91]

### DIFF
--- a/src/clue/components/custom-select.sass
+++ b/src/clue/components/custom-select.sass
@@ -96,12 +96,12 @@
       overflow: hidden
       text-overflow: ellipsis
 
+      &.underline
+        border-bottom: 1px dashed $workspace-teal-light-5
+
       .item
         width: fit-content
         margin-right: 10px
-
-        &.italicize
-          font-style: italic
 
       &:hover
         background-color: $workspace-teal-light-3

--- a/src/clue/components/custom-select.sass
+++ b/src/clue/components/custom-select.sass
@@ -96,7 +96,7 @@
       overflow: hidden
       text-overflow: ellipsis
 
-      &.underline
+      &.bottomBorder
         border-bottom: 1px dashed $workspace-teal-light-5
 
       .item

--- a/src/clue/components/custom-select.tsx
+++ b/src/clue/components/custom-select.tsx
@@ -10,7 +10,7 @@ export interface ICustomDropdownItem extends IDropdownItem {
   id?: string;
   itemIcon?: ReactNode;
   hideItemCheck?: boolean;
-  underline?: boolean;
+  bottomBorder?: boolean;
 }
 
 function getItemId(item: ICustomDropdownItem) {
@@ -132,7 +132,7 @@ export class CustomSelect extends React.PureComponent<IProps, IState> {
           return (
             <div
               key={`item-${i}-${itemId}`}
-              className={classNames(`list-item ${disabledClass} ${selectedClass}`, {underline: item.underline })}
+              className={classNames(`list-item ${disabledClass} ${selectedClass}`, {bottomBorder: item.bottomBorder })}
               onClick={this.handleListClick(item)}
               data-test={`list-item-${itemId}`}
             >

--- a/src/clue/components/custom-select.tsx
+++ b/src/clue/components/custom-select.tsx
@@ -10,7 +10,7 @@ export interface ICustomDropdownItem extends IDropdownItem {
   id?: string;
   itemIcon?: ReactNode;
   hideItemCheck?: boolean;
-  italicize?: boolean;
+  underline?: boolean;
 }
 
 function getItemId(item: ICustomDropdownItem) {
@@ -132,7 +132,7 @@ export class CustomSelect extends React.PureComponent<IProps, IState> {
           return (
             <div
               key={`item-${i}-${itemId}`}
-              className={`list-item ${disabledClass} ${selectedClass}`}
+              className={classNames(`list-item ${disabledClass} ${selectedClass}`, {underline: item.underline })}
               onClick={this.handleListClick(item)}
               data-test={`list-item-${itemId}`}
             >
@@ -141,7 +141,7 @@ export class CustomSelect extends React.PureComponent<IProps, IState> {
                   "hidden-item-check": item.hideItemCheck})}
                 />}
               {this.renderItemIcon(item)}
-              <div className={classNames("item", {italicize: item.italicize })}>{item.text}</div>
+              <div className="item">{item.text}</div>
             </div>
           );
         }) }

--- a/src/components/class-menu-container.tsx
+++ b/src/components/class-menu-container.tsx
@@ -24,7 +24,7 @@ export class ClassMenuContainer extends BaseComponent <IProps> {
         text: "Copy Shareable Link",
         selected: false,
         hideItemCheck: true,
-        underline: true,
+        bottomBorder: true,
         onClick: () => {
           // in standalone mode the shareable link is the current URL
           navigator.clipboard.writeText(window.location.href).then(() => {

--- a/src/components/class-menu-container.tsx
+++ b/src/components/class-menu-container.tsx
@@ -24,7 +24,7 @@ export class ClassMenuContainer extends BaseComponent <IProps> {
         text: "Copy Shareable Link",
         selected: false,
         hideItemCheck: true,
-        italicize: true,
+        underline: true,
         onClick: () => {
           // in standalone mode the shareable link is the current URL
           navigator.clipboard.writeText(window.location.href).then(() => {


### PR DESCRIPTION
This removes the italicized text and replaces it with a dashed underline.

Before change:
![image](https://github.com/user-attachments/assets/89443e35-55f4-4fc7-b88b-4c0e444772fc)

After change:
![image](https://github.com/user-attachments/assets/26cde197-c23c-4cc0-b9a5-e60d4494e3c9)
