### PR TITLE
Fix default placeholder content

### DIFF
--- a/src/components/tiles/placeholder/placeholder-tile.tsx
+++ b/src/components/tiles/placeholder/placeholder-tile.tsx
@@ -18,7 +18,8 @@ const PlaceholderTileComponent: React.FC<ITileProps> = (props) => {
 
   const renderPlaceholderText = () => {
     const content = props.model.content as PlaceholderContentModelType;
-    const { sectionId, containerType } = content;
+    const { sectionId } = content;
+    const containerType = content.containerType || "DocumentContent";
     let placeholderText = undefined;
     // First see if there is a section-specific placeholder
     if (containerType === "DocumentContent") {

--- a/src/models/document/sectioned-content.ts
+++ b/src/models/document/sectioned-content.ts
@@ -16,7 +16,7 @@ export function createDefaultSectionedContent({ sections, content }: ISectionedC
       tiles.push(...(content[section.type].tiles || []));
     }
     else {
-      tiles.push({ content: { type: "Placeholder", sectionId: section.type }});
+      tiles.push({ content: { type: "Placeholder", sectionId: section.type, containerType: "DocumentContent" }});
     }
   });
   // cast required because we're using the import format


### PR DESCRIPTION
CLUE-120

In some pre-existing content no "containerType" was getting initialized for placeholders, leading to a "No placeholder content is configured" message. This PR makes sure to always use the configured default placeholder content even in that case.
