### PR TITLE
fix: Wrong param name for class word passed to portal [CLUE-135]

### DIFF
--- a/src/utilities/auth-utils.test.ts
+++ b/src/utilities/auth-utils.test.ts
@@ -71,16 +71,16 @@ describe("auth-utils", () => {
       expect(actualURL).toBe(expectedURL);
     });
 
-    it("adds the class param to the redirect URL if present", () => {
-      setLocation("https://collaborative-learning.concord.org/standalone/?class=m2studio");
-      const expectedURL = "https://learn.concord.org/users/sign_in_or_register?app_name=CLUE&login_url=https%3A%2F%2Fcollaborative-learning.concord.org%2Fstandalone%2F%3Fclass%3Dm2studio%26authDomain%3Dhttps%253A%252F%252Flearn.concord.org&class_word=m2studio";
+    it("adds the classWord param to the redirect URL if present", () => {
+      setLocation("https://collaborative-learning.concord.org/standalone/?classWord=m2studio");
+      const expectedURL = "https://learn.concord.org/users/sign_in_or_register?app_name=CLUE&login_url=https%3A%2F%2Fcollaborative-learning.concord.org%2Fstandalone%2F%3FclassWord%3Dm2studio%26authDomain%3Dhttps%253A%252F%252Flearn.concord.org&class_word=m2studio";
       const actualURL = getPortalStandaloneSignInOrRegisterUrl();
       expect(actualURL).toBe(expectedURL);
     });
 
-    it("adds the classWord param to the auth URL if class is present", () => {
-      setLocation("https://collaborative-learning.concord.org/standalone/?class=m2studio");
-      const expectedURL = "https://learn.concord.org/users/sign_in_or_register?app_name=CLUE&login_url=https%3A%2F%2Fcollaborative-learning.concord.org%2Fstandalone%2F%3Fclass%3Dm2studio%26authDomain%3Dhttps%253A%252F%252Flearn.concord.org&class_word=m2studio";
+    it("adds the classWord param to the auth URL if classWord is present", () => {
+      setLocation("https://collaborative-learning.concord.org/standalone/?classWord=m2studio");
+      const expectedURL = "https://learn.concord.org/users/sign_in_or_register?app_name=CLUE&login_url=https%3A%2F%2Fcollaborative-learning.concord.org%2Fstandalone%2F%3FclassWord%3Dm2studio%26authDomain%3Dhttps%253A%252F%252Flearn.concord.org&class_word=m2studio";
       const actualURL = getPortalStandaloneSignInOrRegisterUrl();
       expect(actualURL).toBe(expectedURL);
     });

--- a/src/utilities/auth-utils.ts
+++ b/src/utilities/auth-utils.ts
@@ -186,10 +186,10 @@ export const getPortalStandaloneSignInOrRegisterUrl = () => {
   const authUrl = new URL(`${basePortalUrl}${PORTAL_SIGNIN_OR_REGISTER_PATH}`);
   authUrl.searchParams.set("app_name", "CLUE");
   authUrl.searchParams.set("login_url", loginUrl.toString());
-  if (urlParams.class) {
-    // if a class word is passed in (as class), add it to the params so
+  if (urlParams.classWord) {
+    // if a class word is passed in, add it to the params so
     // that it can be pre-filled in the student registration
-    authUrl.searchParams.set("class_word", urlParams.class);
+    authUrl.searchParams.set("class_word", urlParams.classWord);
   }
 
   return authUrl.toString();


### PR DESCRIPTION
Early in the standalone development I used "class" for the class word as that what was used in the tech design document but that conflicted with an existing class param so it was changed to classWord but I failed to change this instance.