### PR TITLE
fix: CLUE registration crash due to sign_up_path to long on the portal [CLUE-135]

### DIFF
--- a/src/initialize-app.tsx
+++ b/src/initialize-app.tsx
@@ -14,7 +14,7 @@ import { AppConfigModel } from "./models/stores/app-config-model";
 import { IStores } from "./models/stores/stores";
 import { IStandaloneAuth, UserModel } from "./models/stores/user";
 import { urlParams } from "./utilities/url-params";
-import { getBearerToken } from "./utilities/auth-utils";
+import { getBearerToken, getStandaloneBasePortalUrl, STANDALONE_AUTH_DOMAIN_SENTINEL } from "./utilities/auth-utils";
 import { getAppMode } from "./lib/auth";
 import { DEBUG_STORES } from "./lib/debug";
 import { gImageMap } from "./models/image-map";
@@ -65,6 +65,11 @@ export const initializeApp = ({authoring, standalone, authDomain}: IInitializeAp
       // so fall back to that if the authDomain is not set in the hash parameters
       // checked in auth-utils.ts#initializeAuthorization and passed to this function
       authDomain = authDomain ?? urlParams.domain;
+      if (authDomain === STANDALONE_AUTH_DOMAIN_SENTINEL) {
+        // to save space in the saved registration redirect URL, we don't send the full authDomain
+        // parameter to the portal when the user is registering and instead send a sentinel value.
+        authDomain = getStandaloneBasePortalUrl();
+      }
 
       if (bearerToken && authDomain) {
         standaloneAuth = {state: "haveBearerToken", bearerToken, authDomain};

--- a/src/models/stores/portal.ts
+++ b/src/models/stores/portal.ts
@@ -100,7 +100,6 @@ export class Portal {
       return this.ensureTrailingSlash(urlParams.domain);
     }
     else if (urlParams.authDomain) {
-      // TODO: check if this change is still needed (added during development)
       return this.ensureTrailingSlash(urlParams.authDomain);
     }
     else {

--- a/src/utilities/auth-utils.test.ts
+++ b/src/utilities/auth-utils.test.ts
@@ -38,49 +38,49 @@ describe("auth-utils", () => {
 
     it("uses the portalDomain param if present", () => {
       setLocation("https://collaborative-learning.concord.org/standalone/?portalDomain=https://example.com");
-      const expectedURL = "https://example.com/users/sign_in_or_register?app_name=CLUE&login_url=https%3A%2F%2Fcollaborative-learning.concord.org%2Fstandalone%2F%3FportalDomain%3Dhttps%253A%252F%252Fexample.com%26authDomain%3Dhttps%253A%252F%252Fexample.com";
+      const expectedURL = "https://example.com/users/sign_in_or_register?app_name=CLUE&login_url=https%3A%2F%2Fcollaborative-learning.concord.org%2Fstandalone%2F%3FportalDomain%3Dhttps%253A%252F%252Fexample.com%26authDomain%3Dstandalone";
       const actualURL = getPortalStandaloneSignInOrRegisterUrl();
       expect(actualURL).toBe(expectedURL);
     });
 
     it("returns the learn production URL for production", () => {
       setLocation("https://collaborative-learning.concord.org/standalone/");
-      const expectedURL = "https://learn.concord.org/users/sign_in_or_register?app_name=CLUE&login_url=https%3A%2F%2Fcollaborative-learning.concord.org%2Fstandalone%2F%3FauthDomain%3Dhttps%253A%252F%252Flearn.concord.org";
+      const expectedURL = "https://learn.concord.org/users/sign_in_or_register?app_name=CLUE&login_url=https%3A%2F%2Fcollaborative-learning.concord.org%2Fstandalone%2F%3FauthDomain%3Dstandalone";
       const actualURL = getPortalStandaloneSignInOrRegisterUrl();
       expect(actualURL).toBe(expectedURL);
     });
 
     it("returns the learn staging URL for branches", () => {
       setLocation("https://collaborative-learning.concord.org/branch/master/standalone/");
-      const expectedURL = "https://learn.portal.staging.concord.org/users/sign_in_or_register?app_name=CLUE&login_url=https%3A%2F%2Fcollaborative-learning.concord.org%2Fbranch%2Fmaster%2Fstandalone%2F%3FauthDomain%3Dhttps%253A%252F%252Flearn.portal.staging.concord.org";
+      const expectedURL = "https://learn.portal.staging.concord.org/users/sign_in_or_register?app_name=CLUE&login_url=https%3A%2F%2Fcollaborative-learning.concord.org%2Fbranch%2Fmaster%2Fstandalone%2F%3FauthDomain%3Dstandalone";
       const actualURL = getPortalStandaloneSignInOrRegisterUrl();
       expect(actualURL).toBe(expectedURL);
     });
 
     it("returns the learn staging URL for localhost", () => {
       setLocation("http://localhost:8080/standalone/");
-      const expectedURL = "https://learn.portal.staging.concord.org/users/sign_in_or_register?app_name=CLUE&login_url=http%3A%2F%2Flocalhost%3A8080%2Fstandalone%2F%3FauthDomain%3Dhttps%253A%252F%252Flearn.portal.staging.concord.org";
+      const expectedURL = "https://learn.portal.staging.concord.org/users/sign_in_or_register?app_name=CLUE&login_url=http%3A%2F%2Flocalhost%3A8080%2Fstandalone%2F%3FauthDomain%3Dstandalone";
       const actualURL = getPortalStandaloneSignInOrRegisterUrl();
       expect(actualURL).toBe(expectedURL);
     });
 
     it("returns the learn staging URL for anything but production", () => {
       setLocation("https://example.com/standalone/");
-      const expectedURL = "https://learn.portal.staging.concord.org/users/sign_in_or_register?app_name=CLUE&login_url=https%3A%2F%2Fexample.com%2Fstandalone%2F%3FauthDomain%3Dhttps%253A%252F%252Flearn.portal.staging.concord.org";
+      const expectedURL = "https://learn.portal.staging.concord.org/users/sign_in_or_register?app_name=CLUE&login_url=https%3A%2F%2Fexample.com%2Fstandalone%2F%3FauthDomain%3Dstandalone";
       const actualURL = getPortalStandaloneSignInOrRegisterUrl();
       expect(actualURL).toBe(expectedURL);
     });
 
     it("adds the classWord param to the redirect URL if present", () => {
       setLocation("https://collaborative-learning.concord.org/standalone/?classWord=m2studio");
-      const expectedURL = "https://learn.concord.org/users/sign_in_or_register?app_name=CLUE&login_url=https%3A%2F%2Fcollaborative-learning.concord.org%2Fstandalone%2F%3FclassWord%3Dm2studio%26authDomain%3Dhttps%253A%252F%252Flearn.concord.org&class_word=m2studio";
+      const expectedURL = "https://learn.concord.org/users/sign_in_or_register?app_name=CLUE&login_url=https%3A%2F%2Fcollaborative-learning.concord.org%2Fstandalone%2F%3FclassWord%3Dm2studio%26authDomain%3Dstandalone&class_word=m2studio";
       const actualURL = getPortalStandaloneSignInOrRegisterUrl();
       expect(actualURL).toBe(expectedURL);
     });
 
     it("adds the classWord param to the auth URL if classWord is present", () => {
       setLocation("https://collaborative-learning.concord.org/standalone/?classWord=m2studio");
-      const expectedURL = "https://learn.concord.org/users/sign_in_or_register?app_name=CLUE&login_url=https%3A%2F%2Fcollaborative-learning.concord.org%2Fstandalone%2F%3FclassWord%3Dm2studio%26authDomain%3Dhttps%253A%252F%252Flearn.concord.org&class_word=m2studio";
+      const expectedURL = "https://learn.concord.org/users/sign_in_or_register?app_name=CLUE&login_url=https%3A%2F%2Fcollaborative-learning.concord.org%2Fstandalone%2F%3FclassWord%3Dm2studio%26authDomain%3Dstandalone&class_word=m2studio";
       const actualURL = getPortalStandaloneSignInOrRegisterUrl();
       expect(actualURL).toBe(expectedURL);
     });

--- a/src/utilities/auth-utils.ts
+++ b/src/utilities/auth-utils.ts
@@ -14,6 +14,8 @@ const OAUTH_CLIENT_NAME = "clue";
 const PORTAL_AUTH_PATH = "/auth/oauth_authorize";
 const PORTAL_SIGNIN_OR_REGISTER_PATH = "/users/sign_in_or_register";
 
+export const STANDALONE_AUTH_DOMAIN_SENTINEL = "standalone";
+
 let accessToken: string | undefined;
 
 // Only return string or undefined
@@ -108,6 +110,11 @@ export const initializeAuthorization = ({standAlone}: {standAlone?: boolean} = {
   }
   else {
     authDomain = queryValue("authDomain");
+    if (standAlone && authDomain === STANDALONE_AUTH_DOMAIN_SENTINEL) {
+      // to save space in the saved registration redirect URL, we don't send the full authDomain
+      // parameter to the portal when the user is registering and instead send a sentinel value.
+      authDomain = getStandaloneBasePortalUrl();
+    }
 
     if (authDomain) {
       const key = Math.random().toString(36).substring(2,15);
@@ -154,7 +161,7 @@ export const convertURLToOAuth2 = (urlString: string, basePortalUrl: string, off
   }
 };
 
-export const getPortalStandaloneSignInOrRegisterUrl = () => {
+export const getStandaloneBasePortalUrl = () => {
   // the default portal URL is the staging portal
   let basePortalUrl = "https://learn.portal.staging.concord.org";
 
@@ -171,11 +178,18 @@ export const getPortalStandaloneSignInOrRegisterUrl = () => {
     }
   }
 
+  return basePortalUrl;
+};
+
+export const getPortalStandaloneSignInOrRegisterUrl = () => {
+  const basePortalUrl = getStandaloneBasePortalUrl();
+
   // pass all the current parameters to the login URL, minus any current auth params
   const loginUrl = new URL(removeAuthParams(window.location.href));
 
-  // update the authDomain to be the portal URL
-  loginUrl.searchParams.set("authDomain", basePortalUrl);
+  // update the authDomain to be a sentinel value as the full URL can be long and exceed
+  // the saved redirect URL length stored in the database in the portal during registration
+  loginUrl.searchParams.set("authDomain", STANDALONE_AUTH_DOMAIN_SENTINEL);
 
   if (urlParams.portalDomain) {
     // the portalDomain is passed so that is kept in the return url during development


### PR DESCRIPTION
This fix shortens the url sent to the portal during login/registration.  This is url saved in the database and is used to redirect after registration is successful on the portal.  The database has a current limit of 255 characters for the url and the url used by CLUE just exceeded that.

The url we were sending had a long authDomain url, it has been replaced by a much shorter sentinel value.

A more future proof solution would be to extend the size of the sign_up_path column in the portal from a varchar(255) to varchar(512) but that would require a migration over the nearly 2 million existing user accounts.