### PR TITLE
fix: Only show students the problem switcher in standalone mode [CLUE-143]

### DIFF
--- a/src/clue/components/clue-app-header.tsx
+++ b/src/clue/components/clue-app-header.tsx
@@ -9,6 +9,7 @@ import { ToggleGroup } from "@concord-consortium/react-components";
 import { GroupModelType, GroupUserModelType } from "../../models/stores/groups";
 import { useStores } from "../../hooks/use-stores";
 import AppModeIndicator from "./app-mode-indicator";
+import { CustomSelect } from "./custom-select";
 
 // cf. https://mattferderer.com/use-sass-variables-in-typescript-and-javascript
 import styles from "./toggle-buttons.scss";
@@ -24,7 +25,7 @@ interface IProps extends IBaseProps {
 
 export const ClueAppHeaderComponent: React.FC<IProps> = observer(function ClueAppHeaderComponent(props) {
   const { showGroup } = props;
-  const { appConfig, appMode, appVersion, db, user, groups, investigation, ui, unit } = useStores();
+  const { appConfig, appMode, appVersion, db, user, groups, investigation, ui, unit, problem } = useStores();
   const myGroup = showGroup ? groups.getGroupById(user.currentGroupId) : undefined;
   const getUserTitle = () => {
     switch(appMode){
@@ -175,6 +176,29 @@ export const ClueAppHeaderComponent: React.FC<IProps> = observer(function ClueAp
     );
   };
 
+  const renderProblemInfo = () => {
+    // Only show the problem menu if the user is in standalone mode as we currently
+    // only support switching in standalone for students.  Teachers should already
+    // see the class switcher via the renderNonStudentHeader function unless the
+    // showClassSwitcher flag is set to false in which case they will get here
+    // as the default case (in which case we still don't show the problem menu since
+    // the flag is still false).
+    if ((ui.standalone || user.standaloneAuthUser) && appConfig.showClassSwitcher) {
+      return (
+        <div className="problem-dropdown" data-test="user-problem">
+          <ProblemMenuContainer />
+        </div>
+      );
+    }
+
+    return (
+      <CustomSelect
+        items={[{text: `${problem.title}${problem.subtitle ? `: ${problem.subtitle}`: ""}`}]}
+        isDisabled={true}
+      />
+    );
+  };
+
   if (user.isResearcher) {
     return renderNonStudentHeader({showProblemMenu: false});
   }
@@ -204,9 +228,7 @@ export const ClueAppHeaderComponent: React.FC<IProps> = observer(function ClueAp
             <div className="separator"/>
           </>
           }
-          <div className="problem-dropdown" data-test="user-problem">
-            <ProblemMenuContainer />
-          </div>
+          {renderProblemInfo()}
         </div>
         <div className="middle student">
           {renderPanelButtons()}


### PR DESCRIPTION
This updates the app header to only show the problem switcher to students in standalone mode.

Before standalone mode was added the students had no access to the switcher.  While standalone mode was being developed it was changed to show for all students, however we only added support to switching classes for students while they were in standalone mode so now the original non-dropdown is shown unless the student is in standalone mode.