### PR TITLE
CLUE-154 added test for log out and return to welcome screen

### DIFF
--- a/cypress/e2e/functional/standalone_tests/standalone_load_spec.js
+++ b/cypress/e2e/functional/standalone_tests/standalone_load_spec.js
@@ -130,5 +130,18 @@ context('Standalone', () => {
       cy.wait(500); // Wait for any animations/resize operations to complete
       clueCanvas.deleteTile('text');
     });
+
+    it("should allow user to log out and return to welcome screen", () => {
+      // Visit the standalone page
+      standaloneHelper.visitStandalone("/standalone/?unit=msa");
+      standaloneHelper.startStandaloneSession();
+      standaloneHelper.selectOrCreateGroup(1);
+
+      // Verify we're logged in by checking for the user menu
+      cy.get("[data-test=user-header]").should("exist");
+
+      // Log out
+      standaloneHelper.logout();
+    });
   });
 });

--- a/cypress/support/elements/common/standalone-helper.js
+++ b/cypress/support/elements/common/standalone-helper.js
@@ -10,32 +10,58 @@ class StandaloneHelper {
   }
 
   selectOrCreateGroup(groupNumber) {
-    // Wait for the group selection dialog and select Group 1
-    cy.get("[data-testid=group-select]", { timeout: 30000 }).should("exist");
+    // Only select a group if the group selection dialog is present
+    cy.get('body').then($body => {
+      if ($body.find('[data-testid=group-select]').length) {
+        cy.get('[data-testid=group-select]', { timeout: 30000 }).should('exist');
 
-    // Wait for the groups to be fully loaded
-    cy.get("[data-testid=existing-groups]", { timeout: 30000 }).should("exist").then($groups => {
-      // Store the group element if it exists
-      const group = $groups.find(`[data-testid=existing-group-${groupNumber}]`);
+        // Wait for the groups to be fully loaded
+        cy.get('[data-testid=existing-groups]', { timeout: 30000 }).should('exist').then($groups => {
+          const group = $groups.find(`[data-testid=existing-group-${groupNumber}]`);
 
-      if (group.length > 0) {
-        // If Group exists, click it using force option to handle any overlay issues
-        cy.get(`[data-testid=existing-group-${groupNumber}]`).should("exist").click({ force: true });
+          if (group.length > 0) {
+            cy.get(`[data-testid=existing-group-${groupNumber}]`).should('exist').click({ force: true });
+          } else {
+            cy.get('[data-testid=new-group-select]').should('exist').select(groupNumber.toString());
+            cy.get('[data-testid=create-group-button]').should('exist').click();
+          }
+        });
+
+        // Wait for the navigation dropdown to appear with a longer timeout
+        cy.get('[data-testid=problem-navigation-dropdown]', { timeout: 60000 }).should('exist');
       } else {
-        // If Group doesn't exist, create it
-        cy.get("[data-testid=new-group-select]").should("exist").select(groupNumber.toString());
-        cy.get("[data-testid=create-group-button]").should("exist").click();
+        cy.log('Group select dialog not present, continuing...');
       }
     });
-
-    // Wait for the navigation dropdown to appear with a longer timeout
-    cy.get("[data-testid=problem-navigation-dropdown]", { timeout: 60000 }).should("exist");
   }
 
   startStandaloneSession() {
     // Click "Get Started" to begin authentication
     cy.get("[data-testid=standalone-welcome]", { timeout: 30000 }).should("exist");
     cy.get("[data-testid=standalone-get-started-button]").click();
+  }
+
+  logout() {
+    // Click the user menu button
+    cy.get("[data-test=user-header]").should("exist").click();
+
+    // Click the logout button in the menu
+    cy.get("[data-test=user-list]").should("exist");
+    cy.get("[data-test=list-item-log-out]").should("exist").click();
+
+    // Handle the portal confirmation dialog
+    cy.origin('https://learn.portal.staging.concord.org', () => {
+      // Wait for the page to load
+      cy.get('body').should('exist');
+      // Click the Yes button using the exact selector
+      cy.get('input[name="confirm"]').click();
+    });
+
+    // Wait for redirect back to standalone page
+    cy.url().should('include', '/standalone/');
+
+    // Confirm the presence of the Get Started button
+    cy.get("[data-testid=standalone-get-started-button]").should("exist");
   }
 
   // Navigation helpers can be added here when CLUE-143 is completed

--- a/cypress/support/elements/common/standalone-helper.js
+++ b/cypress/support/elements/common/standalone-helper.js
@@ -37,17 +37,17 @@ class StandaloneHelper {
 
   startStandaloneSession() {
     // Click "Get Started" to begin authentication
-    cy.get("[data-testid=standalone-welcome]", { timeout: 30000 }).should("exist");
-    cy.get("[data-testid=standalone-get-started-button]").click();
+    cy.get('[data-testid=standalone-welcome]', { timeout: 30000 }).should("exist");
+    cy.get('[data-testid=standalone-get-started-button]').click();
   }
 
   logout() {
     // Click the user menu button
-    cy.get("[data-test=user-header]").should("exist").click();
+    cy.get('[data-test=user-header]').should('exist').click();
 
     // Click the logout button in the menu
-    cy.get("[data-test=user-list]").should("exist");
-    cy.get("[data-test=list-item-log-out]").should("exist").click();
+    cy.get('[data-test=user-list]').should('exist');
+    cy.get('[data-test=list-item-log-out]').should('exist').click();
 
     // Handle the portal confirmation dialog
     cy.origin('https://learn.portal.staging.concord.org', () => {
@@ -61,7 +61,7 @@ class StandaloneHelper {
     cy.url().should('include', '/standalone/');
 
     // Confirm the presence of the Get Started button
-    cy.get("[data-testid=standalone-get-started-button]").should("exist");
+    cy.get('[data-testid=standalone-get-started-button]').should('exist');
   }
 
   // Navigation helpers can be added here when CLUE-143 is completed


### PR DESCRIPTION
[CLUE-154](https://concord-consortium.atlassian.net/browse/CLUE-154)

This PR improves the Cypress test coverage for the standalone CLUE application by:
- Adding a logout test that verifies a user can log out and is returned to the welcome screen.
- Improving the StandaloneHelper and test logic to handle conditional UI states so that the dialog text is less brittle

[CLUE-154]: https://concord-consortium.atlassian.net/browse/CLUE-154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ