### PR TITLE
chore: patch for checking CLUE standalone

### DIFF
--- a/.github/workflows/regression-daily.yml
+++ b/.github/workflows/regression-daily.yml
@@ -66,6 +66,8 @@ jobs:
           CYPRESS_coverage: true
           # Increase memory allocation
           NODE_OPTIONS: "--max_old_space_size=4096"
+          CYPRESS_PORTAL_USERNAME: ${{ secrets.PORTAL_USERNAME }}
+          CYPRESS_PORTAL_PASSWORD: ${{ secrets.PORTAL_PASSWORD }}
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
         with:


### PR DESCRIPTION
This is a patch for the CLUE standalone Cypress check. Apparently the github actions were configured in the CI Regression and Regression label, but not in the Daily Regression label.