### PR TITLE
Clue 96 table sort controls

### DIFF
--- a/src/assets/sort-column-icon.svg
+++ b/src/assets/sort-column-icon.svg
@@ -1,7 +1,5 @@
-<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-    <g fill="none" fill-rule="evenodd">
-        <circle class="border" cx="12" cy="12" r="12"/>
-        <path class="inner-circle" d="M12 2c5.52 0 10 4.48 10 10s-4.48 10-10 10S2 17.52 2 12 6.48 2 12 2zm0 2c-4.41 0-8 3.59-8 8s3.59 8 8 8 8-3.59 8-8-3.59-8-8-8z" fill="#0481A0"/>
-        <path class="sort-arrow" fill="#0481A0" d="m11.95 7-5.025 5.05 1.425 1.425 2.6-2.6V17h2v-6.125l2.575 2.575L16.95 12z"/>
-    </g>
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" stroke="none" fill="none">
+  <circle class="background sort" cx="12" cy="12" r="12"/>
+  <path class="foreground sort circle" d="M12 2c5.52 0 10 4.48 10 10s-4.48 10-10 10S2 17.52 2 12 6.48 2 12 2zm0 2c-4.41 0-8 3.59-8 8s3.59 8 8 8 8-3.59 8-8-3.59-8-8-8z" fill="none"/>
+  <path class="foreground sort arrow" fill="none" d="m11.95 7-5.025 5.05 1.425 1.425 2.6-2.6V17h2v-6.125l2.575 2.575L16.95 12z"/>
 </svg>

--- a/src/assets/sort-column-icon.svg
+++ b/src/assets/sort-column-icon.svg
@@ -1,0 +1,7 @@
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <g fill="none" fill-rule="evenodd">
+        <circle class="border" cx="12" cy="12" r="12"/>
+        <path class="inner-circle" d="M12 2c5.52 0 10 4.48 10 10s-4.48 10-10 10S2 17.52 2 12 6.48 2 12 2zm0 2c-4.41 0-8 3.59-8 8s3.59 8 8 8 8-3.59 8-8-3.59-8-8-8z" fill="#0481A0"/>
+        <path class="sort-arrow" fill="#0481A0" d="m11.95 7-5.025 5.05 1.425 1.425 2.6-2.6V17h2v-6.125l2.575 2.575L16.95 12z"/>
+    </g>
+</svg>

--- a/src/components/tiles/table/column-header-cell.scss
+++ b/src/components/tiles/table/column-header-cell.scss
@@ -105,7 +105,7 @@
     }
   }
 
-  &:hover {
+  &:not(.selected-column):hover {
     background-color: $highlight-blue-20;
     .column-button {
       display: flex !important;
@@ -191,6 +191,7 @@
 // }
 
 .selected-column {
+  background-color: $highlight-blue-40;
   .column-header-cell {
     .column-button {
       display: flex !important;
@@ -230,6 +231,17 @@
             }
 
           }
+        }
+      }
+
+      &:hover {
+        svg {
+          .background {
+            fill: $workspace-teal-light-3;
+            // stroke: var(--header-background-color);
+            opacity: 1;
+          }
+
         }
       }
     }

--- a/src/components/tiles/table/column-header-cell.scss
+++ b/src/components/tiles/table/column-header-cell.scss
@@ -89,6 +89,16 @@
       justify-content: center;
       align-items: center;
 
+      svg {
+        .background {
+          fill: var(--header-background-color);
+        }
+        .sort.circle {
+          fill: var(--header-background-color);
+        }
+
+      }
+
       &.ascending {
         svg {
           .background {
@@ -159,6 +169,14 @@
             opacity: 0.35;
           }
         }
+        &.ascending, &.descending {
+          svg {
+            .foreground.arrow {
+              fill: $workspace-teal-dark-1;
+              opacity: 1;
+            }
+          }
+        }
       }
     }
   }
@@ -217,17 +235,37 @@
             .foreground {
               fill: var(--header-background-color);
               opacity: 1;
-              &.sort.circle {
+              &.sort {
                 fill: var(--header-background-color);
                 opacity: 1;
+              }
+            }
+          }
+          &.ascending {
+            transform: rotate(180deg);
+            svg {
+              .foreground.arrow {
+                fill: var(--header-background-color);
+                opacity: 1;
+              }
+            }
+          }
+          &.descending {
+            transform: rotate(0deg);
+            svg {
+              .foreground.arrow {
+                fill: var(--header-background-color);
+                opacity: 0.35;
               }
             }
           }
         }
       }
       &.ascending, .descending {
-        .foreground.arrow {
-          fill: $workspace-teal-dark-1;
+        svg {
+          .foreground.arrow {
+            fill: $workspace-teal-dark-1;
+          }
         }
       }
 
@@ -236,6 +274,14 @@
           .background {
             fill: $workspace-teal-light-3;
             opacity: 1;
+          }
+        }
+        &.ascending, .descending {
+          svg {
+            .foreground.arrow {
+              fill: $workspace-teal-dark-1;
+              opacity: 1;
+            }
           }
         }
       }

--- a/src/components/tiles/table/column-header-cell.scss
+++ b/src/components/tiles/table/column-header-cell.scss
@@ -4,14 +4,8 @@
   position: relative;
   width: 100%;
   height: 100%;
-
-  &.show-expression {
-    .flex-container {
-      .editable-header-cell {
-        height: calc(var(--header-row-height) / 2);
-      }
-    }
-  }
+  display: flex;
+  flex-direction: column;
 
   .header-cell-container {
     display: flex;
@@ -19,75 +13,56 @@
     align-items: center;
     justify-content: center ;
 
-    .flex-container {
+    &.show-expression {
+      height: calc(var(--header-row-height) / 2);
+    }
+
+    .editable-header-cell {
+      width: 100%;
       display: flex;
-      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      white-space: normal;
+      word-break: break-word;
+      text-align: center;
+      line-height: 18px;
 
-      .editable-header-cell {
-        width: 100%;
-        height: var(--header-row-height);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        white-space: normal;
-        word-break: break-word;
-        text-align: center;
-        line-height: 18px;
-
-        .header-name {
-          margin: 0 16px;
-        }
-
-        &.table-title-editing {
-          padding: 0 !important;
-
-          .rdg-text-editor:focus {
-            border-color: $highlight-blue;
-            outline: 0
-          }
-
-          input {
-            text-align: center;
-          }
-        }
+      .header-name {
+        margin: 0 16px;
       }
 
-      .expression-cell {
-        width: 100%;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        font-style: italic;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        line-height: 18px;
-        &.has-expression {
-          border-top: 1px solid white;
+      &.table-title-editing {
+        padding: 0 !important;
+
+        .rdg-text-editor:focus {
+          border-color: $highlight-blue;
+          outline: 0
+        }
+
+        input {
+          text-align: center;
         }
       }
     }
 
-    .remove-column-button {
+    .column-button {
       position: absolute;
-      left: -4px;
-      top: 0;
       width: 36px;
       height: 34px;
-      display: none;  // overridden when tile is selected
       justify-content: center;
       align-items: center;
+    }
+
+    .remove-column-button {
+      left: -4px;
+      display: none;  // overridden when tile is selected
+      margin-right: 5px;
     }
 
     .sort-column-button {
       display: flex;
-      position: absolute;
       right: -4px;
-      top: 0;
-      width: 36px;
-      height: 34px;
-      justify-content: center;
-      align-items: center;
+      margin-left: 5px;
 
       svg {
         .background {
@@ -178,6 +153,21 @@
           }
         }
       }
+    }
+  }
+
+  .expression-cell {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-style: italic;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    line-height: 18px;
+    &.has-expression {
+      border-top: 1px solid white;
     }
   }
 }

--- a/src/components/tiles/table/column-header-cell.scss
+++ b/src/components/tiles/table/column-header-cell.scss
@@ -77,22 +77,6 @@
       display: none;  // overridden when tile is selected
       justify-content: center;
       align-items: center;
-      svg {
-        fill: var(--header-background-color);
-        stroke: $highlight-blue;
-      }
-      &:hover {
-        svg {
-          fill: $highlight-blue-25;
-          stroke: $highlight-blue;
-        }
-      }
-      &:active {
-        svg {
-          fill: $highlight-blue;
-          stroke: var(--header-background-color);
-        }
-      }
     }
 
     .sort-column-button {
@@ -105,23 +89,17 @@
       justify-content: center;
       align-items: center;
 
-      &.ascending, .descending {
-        display: flex !important;
-      }
-
       &.ascending {
-        svg {
-          .border, .inner-circle {
-            display: none !important;
-          }
+        .foreground.arrow {
+          display: flex !important;
+          fill: $workspace-teal-dark-1;
         }
       }
       &.descending {
         transform: rotate(180deg);
-        svg {
-          .border, .inner-circle {
-            display: none !important;
-          }
+        .foreground.arrow {
+          display: flex !important;
+          fill: $workspace-teal-dark-1;
         }
       }
     }
@@ -129,38 +107,130 @@
 
   &:hover {
     background-color: $highlight-blue-20;
-    // .remove-column-button,
-    .sort-column-button {
+    .column-button {
       display: flex !important;
-      svg {
-        fill: var(--header-background-color);
-        stroke: $highlight-blue;
-        opacity: 0.35;
-      }
-    }
-  }
-  &.selected-column {
-    .remove-column-button,
-    .sort-column-button {
-      display: flex !important;
-      svg {
-        fill: var(--header-background-color);
-        // stroke: $highlight-blue;
-        .border {
-          stroke: $highlight-blue;
+      &.remove-column-button {
+        display: flex !important;
+        svg {
+          .background {
+            fill: var(--header-background-color);
+            // stroke: var(--header-background-color);
+            opacity: 0.35;
+          }
+          .foreground {
+            // fill: $workspace-teal-dark-1;
+            stroke: $workspace-teal-dark-1;
+            opacity: 0.35;
+          }
         }
-        // opacity: 0.35;
+      }
+      &.sort-column-button {
+        display: flex !important;
+        svg {
+          .background {
+            fill: var(--header-background-color);
+            // stroke: var(--header-background-color);
+            opacity: 0.35;
+          }
+          .foreground {
+            fill: $workspace-teal-dark-1;
+            // stroke: $workspace-teal-dark-1;
+            opacity: 0.35;
+          }
+        }
       }
     }
   }
+
+  // &.selected-column {
+  //   background-color: $highlight-blue-20;
+
+  //   .remove-column-button {
+  //     display: flex !important;
+  //     svg {
+  //       .background {
+  //         fill: var(--header-background-color);
+  //         // stroke: var(--header-background-color);
+  //         opacity: 1;
+  //       }
+  //       .foreground {
+  //         // fill: $workspace-teal-dark-1;
+  //         stroke: $workspace-teal-dark-1;
+  //         opacity: 1;
+  //       }
+  //     }
+  //   }
+  //   .sort-column-button {
+  //     display: flex !important;
+  //     svg {
+  //       .background {
+  //         fill: var(--header-background-color);
+  //         // stroke: var(--header-background-color);
+  //         opacity: 1;
+  //       }
+  //       .foreground {
+  //         fill: $workspace-teal-dark-1;
+  //         // stroke: $workspace-teal-dark-1;
+  //         opacity: 0.35;
+  //       }
+  //     }
+  //   }
+  // }
 }
 
-.tool-tile.selected {
-  .table-tool {
-    .selected-column {
-      .remove-column-button, .sort-column-button {
-        // show buttons only when tile and column are selected
-        display: flex !important;
+// .tool-tile.selected {
+//   .table-tool {
+//     .selected-column {
+//       .remove-column-button,
+//       .sort-column-button {
+//         // show buttons only when tile and column are selected
+//         display: flex !important;
+//       }
+//     }
+//   }
+// }
+
+.selected-column {
+  .column-header-cell {
+    .column-button {
+      display: flex !important;
+
+      &.remove-column-button {
+        // display: flex !important;
+        svg {
+          .background {
+            fill: var(--header-background-color);
+            // stroke: var(--header-background-color);
+            opacity: 1;
+          }
+          .foreground {
+            // fill: $workspace-teal-dark-1;
+            stroke: $workspace-teal-dark-1;
+            opacity: 1;
+          }
+        }
+      }
+      &.sort-column-button {
+        // display: flex !important;
+        svg {
+          .background {
+            fill: var(--header-background-color);
+            // stroke: var(--header-background-color);
+            opacity: 1;
+          }
+          .foreground {
+            fill: $workspace-teal-dark-1;
+            // stroke: $workspace-teal-dark-1;
+            opacity: 0.35;
+
+            &.sort.circle {
+              fill: $workspace-teal-dark-1;
+              // stroke: $workspace-teal-dark-1;
+              opacity: 1;
+            }
+
+          }
+        }
       }
     }
   }

--- a/src/components/tiles/table/column-header-cell.scss
+++ b/src/components/tiles/table/column-header-cell.scss
@@ -85,21 +85,45 @@
       top: 0;
       width: 36px;
       height: 34px;
-      display: none;  // overridden when tile is selected
       justify-content: center;
       align-items: center;
 
       &.ascending {
-        .foreground.arrow {
-          display: flex !important;
-          fill: $workspace-teal-dark-1;
+        svg {
+          .background {
+            fill: var(--header-background-color);
+          }
+          .sort.circle {
+            fill: var(--header-background-color);
+          }
+          .sort.arrow {
+            display: flex !important;
+            fill: $workspace-teal-dark-1;
+            opacity: 1;
+          }
         }
       }
       &.descending {
         transform: rotate(180deg);
-        .foreground.arrow {
-          display: flex !important;
-          fill: $workspace-teal-dark-1;
+        svg {
+          .background {
+            fill: var(--header-background-color);
+          }
+          .sort.circle {
+            fill: var(--header-background-color);
+          }
+          .sort.arrow {
+            display: flex !important;
+            fill: $workspace-teal-dark-1;
+            opacity: 1;
+          }
+        }
+      }
+      &:not(.selected-column):hover {
+        svg {
+          .sort.arrow {
+            opacity: 0.35; // Semi-transparent on hover
+          }
         }
       }
     }
@@ -205,6 +229,11 @@
               }
             }
           }
+        }
+      }
+      &.ascending, .descending {
+        .foreground.arrow {
+          fill: $workspace-teal-dark-1;
         }
       }
 

--- a/src/components/tiles/table/column-header-cell.scss
+++ b/src/components/tiles/table/column-header-cell.scss
@@ -13,78 +13,143 @@
     }
   }
 
-  .flex-container {
+  .header-cell-container {
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center ;
 
-    .editable-header-cell {
-      width: 100%;
-      height: var(--header-row-height);
+    .flex-container {
       display: flex;
-      align-items: center;
-      justify-content: center;
-      white-space: normal;
-      word-break: break-word;
-      text-align: center;
-      line-height: 18px;
+      flex-direction: column;
 
-      .header-name {
-        margin: 0 16px;
-      }
+      .editable-header-cell {
+        width: 100%;
+        height: var(--header-row-height);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        white-space: normal;
+        word-break: break-word;
+        text-align: center;
+        line-height: 18px;
 
-      &.table-title-editing {
-        padding: 0 !important;
-
-        .rdg-text-editor:focus {
-          border-color: $highlight-blue;
-          outline: 0
+        .header-name {
+          margin: 0 16px;
         }
 
-        input {
-          text-align: center;
+        &.table-title-editing {
+          padding: 0 !important;
+
+          .rdg-text-editor:focus {
+            border-color: $highlight-blue;
+            outline: 0
+          }
+
+          input {
+            text-align: center;
+          }
+        }
+      }
+
+      .expression-cell {
+        width: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-style: italic;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        line-height: 18px;
+        &.has-expression {
+          border-top: 1px solid white;
         }
       }
     }
 
-    .expression-cell {
-      width: 100%;
-      display: flex;
-      align-items: center;
+    .remove-column-button {
+      position: absolute;
+      left: -4px;
+      top: 0;
+      width: 36px;
+      height: 34px;
+      display: none;  // overridden when tile is selected
       justify-content: center;
-      font-style: italic;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      line-height: 18px;
-      &.has-expression {
-        border-top: 1px solid white;
+      align-items: center;
+      svg {
+        fill: var(--header-background-color);
+        stroke: $highlight-blue;
+      }
+      &:hover {
+        svg {
+          fill: $highlight-blue-25;
+          stroke: $highlight-blue;
+        }
+      }
+      &:active {
+        svg {
+          fill: $highlight-blue;
+          stroke: var(--header-background-color);
+        }
+      }
+    }
+
+    .sort-column-button {
+      position: absolute;
+      right: -4px;
+      top: 0;
+      width: 36px;
+      height: 34px;
+      display: none;  // overridden when tile is selected
+      justify-content: center;
+      align-items: center;
+
+      &.ascending, .descending {
+        display: flex !important;
+      }
+
+      &.ascending {
+        svg {
+          .border, .inner-circle {
+            display: none !important;
+          }
+        }
+      }
+      &.descending {
+        transform: rotate(180deg);
+        svg {
+          .border, .inner-circle {
+            display: none !important;
+          }
+        }
       }
     }
   }
 
-  .remove-column-button {
-    position: absolute;
-    left: -4px;
-    top: 0;
-    width: 36px;
-    height: 34px;
-    display: none;  // overridden when tile is selected
-    justify-content: center;
-    align-items: center;
-    svg {
-      fill: var(--header-background-color);
-      stroke: $highlight-blue;
-    }
-    &:hover {
+  &:hover {
+    background-color: $highlight-blue-20;
+    // .remove-column-button,
+    .sort-column-button {
+      display: flex !important;
       svg {
-        fill: $highlight-blue-25;
+        fill: var(--header-background-color);
         stroke: $highlight-blue;
+        opacity: 0.35;
       }
     }
-    &:active {
+  }
+  &.selected-column {
+    .remove-column-button,
+    .sort-column-button {
+      display: flex !important;
       svg {
-        fill: $highlight-blue;
-        stroke: var(--header-background-color);
+        fill: var(--header-background-color);
+        // stroke: $highlight-blue;
+        .border {
+          stroke: $highlight-blue;
+        }
+        // opacity: 0.35;
       }
     }
   }
@@ -93,7 +158,7 @@
 .tool-tile.selected {
   .table-tool {
     .selected-column {
-      .remove-column-button {
+      .remove-column-button, .sort-column-button {
         // show buttons only when tile and column are selected
         display: flex !important;
       }

--- a/src/components/tiles/table/column-header-cell.scss
+++ b/src/components/tiles/table/column-header-cell.scss
@@ -80,6 +80,7 @@
     }
 
     .sort-column-button {
+      display: flex;
       position: absolute;
       right: -4px;
       top: 0;
@@ -97,7 +98,6 @@
             fill: var(--header-background-color);
           }
           .sort.arrow {
-            display: flex !important;
             fill: $workspace-teal-dark-1;
             opacity: 1;
           }
@@ -113,7 +113,6 @@
             fill: var(--header-background-color);
           }
           .sort.arrow {
-            display: flex !important;
             fill: $workspace-teal-dark-1;
             opacity: 1;
           }
@@ -122,7 +121,7 @@
       &:not(.selected-column):hover {
         svg {
           .sort.arrow {
-            opacity: 0.35; // Semi-transparent on hover
+            opacity: 0.35;
           }
         }
       }
@@ -140,11 +139,9 @@
         svg {
           .background {
             fill: var(--header-background-color);
-            // stroke: var(--header-background-color);
             opacity: 0.35;
           }
           .foreground {
-            // fill: $workspace-teal-dark-1;
             stroke: $workspace-teal-dark-1;
             opacity: 0.35;
           }
@@ -152,16 +149,13 @@
       }
 
       &.sort-column-button {
-        display: flex !important;
         svg {
           .background {
             fill: var(--header-background-color);
-            // stroke: var(--header-background-color);
             opacity: 0.35;
           }
           .foreground {
             fill: $workspace-teal-dark-1;
-            // stroke: $workspace-teal-dark-1;
             opacity: 0.35;
           }
         }
@@ -241,7 +235,6 @@
         svg {
           .background {
             fill: $workspace-teal-light-3;
-            // stroke: var(--header-background-color);
             opacity: 1;
           }
         }

--- a/src/components/tiles/table/column-header-cell.scss
+++ b/src/components/tiles/table/column-header-cell.scss
@@ -107,8 +107,10 @@
 
   &:not(.selected-column):hover {
     background-color: $highlight-blue-20;
+
     .column-button {
       display: flex !important;
+
       &.remove-column-button {
         display: flex !important;
         svg {
@@ -124,6 +126,7 @@
           }
         }
       }
+
       &.sort-column-button {
         display: flex !important;
         svg {
@@ -141,95 +144,66 @@
       }
     }
   }
-
-  // &.selected-column {
-  //   background-color: $highlight-blue-20;
-
-  //   .remove-column-button {
-  //     display: flex !important;
-  //     svg {
-  //       .background {
-  //         fill: var(--header-background-color);
-  //         // stroke: var(--header-background-color);
-  //         opacity: 1;
-  //       }
-  //       .foreground {
-  //         // fill: $workspace-teal-dark-1;
-  //         stroke: $workspace-teal-dark-1;
-  //         opacity: 1;
-  //       }
-  //     }
-  //   }
-  //   .sort-column-button {
-  //     display: flex !important;
-  //     svg {
-  //       .background {
-  //         fill: var(--header-background-color);
-  //         // stroke: var(--header-background-color);
-  //         opacity: 1;
-  //       }
-  //       .foreground {
-  //         fill: $workspace-teal-dark-1;
-  //         // stroke: $workspace-teal-dark-1;
-  //         opacity: 0.35;
-  //       }
-  //     }
-  //   }
-  // }
 }
-
-// .tool-tile.selected {
-//   .table-tool {
-//     .selected-column {
-//       .remove-column-button,
-//       .sort-column-button {
-//         // show buttons only when tile and column are selected
-//         display: flex !important;
-//       }
-//     }
-//   }
-// }
 
 .selected-column {
   background-color: $highlight-blue-40;
+
   .column-header-cell {
     .column-button {
       display: flex !important;
 
       &.remove-column-button {
-        // display: flex !important;
         svg {
           .background {
             fill: var(--header-background-color);
-            // stroke: var(--header-background-color);
             opacity: 1;
           }
           .foreground {
-            // fill: $workspace-teal-dark-1;
             stroke: $workspace-teal-dark-1;
             opacity: 1;
           }
         }
+        &:active {
+          svg {
+            .background {
+              fill: $workspace-teal-dark-1;
+            }
+            .foreground {
+              stroke: var(--header-background-color);
+            }
+          }
+        }
       }
       &.sort-column-button {
-        // display: flex !important;
         svg {
           .background {
             fill: var(--header-background-color);
-            // stroke: var(--header-background-color);
             opacity: 1;
           }
           .foreground {
             fill: $workspace-teal-dark-1;
-            // stroke: $workspace-teal-dark-1;
             opacity: 0.35;
 
             &.sort.circle {
               fill: $workspace-teal-dark-1;
-              // stroke: $workspace-teal-dark-1;
               opacity: 1;
             }
-
+          }
+        }
+        &:active {
+          svg {
+            .background {
+              fill: $workspace-teal-dark-1;
+            }
+            .foreground {
+              fill: var(--header-background-color);
+              opacity: 1;
+              &.sort.circle {
+                fill: var(--header-background-color);
+                opacity: 1;
+              }
+            }
           }
         }
       }
@@ -241,9 +215,9 @@
             // stroke: var(--header-background-color);
             opacity: 1;
           }
-
         }
       }
     }
   }
 }
+

--- a/src/components/tiles/table/column-header-cell.tsx
+++ b/src/components/tiles/table/column-header-cell.tsx
@@ -51,15 +51,18 @@ export const useColumnHeaderCell = (height: number) => {
       };
 
       const handleSort = (e: React.MouseEvent) => {
-        e.stopPropagation();
-        if (sortDirection === "ascending") {
-          setSortDirection("descending");
-        } else if (sortDirection === "descending") {
-          setSortDirection(undefined);
-        } else {
-          setSortDirection("ascending");
+        if (!gridContext?.isColumnSelected(column.key)) {
+          e.stopPropagation();
+          if (sortDirection === "ascending") {
+            setSortDirection("descending");
+          } else if (sortDirection === "descending") {
+            setSortDirection(undefined);
+          } else {
+            setSortDirection("ascending");
+          }
         }
       };
+      
       return (
         <div className={classes} onMouseOver={handleColumnHeaderCellMouseOver}
               onMouseLeave={handleColumnHeaderCellMouseLeave} onClick={handleHeaderClick}>

--- a/src/components/tiles/table/column-header-cell.tsx
+++ b/src/components/tiles/table/column-header-cell.tsx
@@ -55,8 +55,6 @@ export const useColumnHeaderCell = (height: number) => {
           }
         }
       };
-      console.log("sortDirection", sortDirection);
-      console.log("gridContext.isColumnSelected", gridContext?.isColumnSelected(column.key));
 
       return (
         <div className={classes} onMouseOver={handleColumnHeaderCellMouseOver}
@@ -68,7 +66,6 @@ export const useColumnHeaderCell = (height: number) => {
                   isColumnSelected={gridContext?.isColumnSelected(column.key) ?? false}/>
               }
               <EditableHeaderCell height={height} {...props} />
-              {/* {showExpressions && <ExpressionCell readOnly={readOnly} column={column} />} */}
               {hasData &&
                 <div className={clsx("column-button sort-column-button", { "ascending": sortDirection === "ascending",
                                       "descending": sortDirection === "descending" })} onClick={handleSort}>

--- a/src/components/tiles/table/column-header-cell.tsx
+++ b/src/components/tiles/table/column-header-cell.tsx
@@ -17,12 +17,18 @@ export const useColumnHeaderCell = (height: number) => {
       const column = props.column as unknown as TColumn;
       const { gridContext, readOnly, isEditing, isRemovable, showExpressions, onRemoveColumn } = column.appData || {};
       const [ columnHeaderHover, setColumnHeaderHover ] = React.useState(false);
-      const classes = classNames("column-header-cell", { "show-expression": showExpressions });
+      const classes = classNames("column-header-cell",
+                        { "show-expression": showExpressions,
+                          "selected-column": gridContext?.isColumnSelected(column.key),}
+                      );
 
       // FIXME: temporary local state
       const [sortDirection, setSortDirection] = React.useState<"ascending" | "descending" | undefined>(undefined);
 
       const handleColumnHeaderCellMouseOver = (e: React.MouseEvent) => {
+        console.log("in handleColumnHeaderCellMouseOver gridContext.isColumnSelected",
+            gridContext?.isColumnSelected(column.key));
+
         if (!gridContext?.isColumnSelected(column.key)) {
           setColumnHeaderHover(true);
           document.querySelectorAll(`.column-${column.key}`).forEach(cell => {
@@ -40,6 +46,7 @@ export const useColumnHeaderCell = (height: number) => {
         if (!gridContext?.isColumnSelected(column.key)) {
           e.stopPropagation();
           gridContext?.onSelectColumn(column.key);
+          setColumnHeaderHover(false);
         }
       };
 
@@ -53,7 +60,6 @@ export const useColumnHeaderCell = (height: number) => {
           setSortDirection("ascending");
         }
       };
-      console.log("gridContext.isColumnSelected", gridContext?.isColumnSelected(column.key));
       return (
         <div className={classes} onMouseOver={handleColumnHeaderCellMouseOver}
               onMouseLeave={handleColumnHeaderCellMouseLeave} onClick={handleHeaderClick}>

--- a/src/components/tiles/table/column-header-cell.tsx
+++ b/src/components/tiles/table/column-header-cell.tsx
@@ -51,7 +51,7 @@ export const useColumnHeaderCell = (height: number) => {
       };
 
       const handleSort = (e: React.MouseEvent) => {
-        if (!gridContext?.isColumnSelected(column.key)) {
+        if (gridContext?.isColumnSelected(column.key)) {
           e.stopPropagation();
           if (sortDirection === "ascending") {
             setSortDirection("descending");
@@ -62,7 +62,9 @@ export const useColumnHeaderCell = (height: number) => {
           }
         }
       };
-      
+      console.log("sortDirection", sortDirection);
+      console.log("gridContext.isColumnSelected", gridContext?.isColumnSelected(column.key));
+
       return (
         <div className={classes} onMouseOver={handleColumnHeaderCellMouseOver}
               onMouseLeave={handleColumnHeaderCellMouseLeave} onClick={handleHeaderClick}>
@@ -76,10 +78,8 @@ export const useColumnHeaderCell = (height: number) => {
               {showExpressions && <ExpressionCell readOnly={readOnly} column={column} />}
             </div>
             <div className={clsx("column-button sort-column-button", { "ascending": sortDirection === "ascending",
-                                      "descending": sortDirection === "descending"})}
-                  onClick={handleSort}>
-              <SortIcon className={clsx("column-icon sort-column-icon")}
-              />
+                                  "descending": sortDirection === "descending" })} onClick={handleSort}>
+              <SortIcon className={clsx("column-icon sort-column-icon")} />
             </div>
           </div>
         </div>

--- a/src/components/tiles/table/column-header-cell.tsx
+++ b/src/components/tiles/table/column-header-cell.tsx
@@ -61,22 +61,24 @@ export const useColumnHeaderCell = (height: number) => {
       return (
         <div className={classes} onMouseOver={handleColumnHeaderCellMouseOver}
               onMouseLeave={handleColumnHeaderCellMouseLeave} onClick={handleHeaderClick}>
-          <div className="header-cell-container">
-            {!isEditing && isRemovable &&
-              <RemoveColumnButton colId={column.key} colName={column.name as string} onRemoveColumn={onRemoveColumn}
-                isColumnSelected={gridContext?.isColumnSelected(column.key) ?? false}/>
-            }
-            <div className="flex-container">
+          <div className="flex-container">
+            <div className={clsx("header-cell-container", {"show-expression": showExpressions})}>
+              {!isEditing && isRemovable &&
+                <RemoveColumnButton colId={column.key} colName={column.name as string} onRemoveColumn={onRemoveColumn}
+                  isColumnSelected={gridContext?.isColumnSelected(column.key) ?? false}/>
+              }
               <EditableHeaderCell height={height} {...props} />
-              {showExpressions && <ExpressionCell readOnly={readOnly} column={column} />}
+              {/* {showExpressions && <ExpressionCell readOnly={readOnly} column={column} />} */}
+              {hasData &&
+                <div className={clsx("column-button sort-column-button", { "ascending": sortDirection === "ascending",
+                                      "descending": sortDirection === "descending" })} onClick={handleSort}>
+                  <SortIcon className={clsx("column-icon sort-column-icon")} />
+                </div>
+              }
             </div>
-            {hasData &&
-              <div className={clsx("column-button sort-column-button", { "ascending": sortDirection === "ascending",
-                                    "descending": sortDirection === "descending" })} onClick={handleSort}>
-                <SortIcon className={clsx("column-icon sort-column-icon")} />
-              </div>
-            }
+            {showExpressions && <ExpressionCell readOnly={readOnly} column={column} />}
           </div>
+
         </div>
       );
     };

--- a/src/components/tiles/table/column-header-cell.tsx
+++ b/src/components/tiles/table/column-header-cell.tsx
@@ -27,7 +27,6 @@ export const useColumnHeaderCell = ({height, getSortDirection, onSort}: IProps) 
                         { "show-expression": showExpressions,
                           "selected-column": gridContext?.isColumnSelected(column.key),}
                       );
-      // FIXME: temporary local state
 
       const handleColumnHeaderCellMouseOver = (e: React.MouseEvent) => {
         if (!gridContext?.isColumnSelected(column.key)) {

--- a/src/components/tiles/table/column-header-cell.tsx
+++ b/src/components/tiles/table/column-header-cell.tsx
@@ -36,6 +36,12 @@ export const useColumnHeaderCell = (height: number) => {
           cell.classList.remove("hovered-column");
         });
       };
+      const handleHeaderClick = (e: React.MouseEvent) => {
+        if (!gridContext?.isColumnSelected(column.key)) {
+          e.stopPropagation();
+          gridContext?.onSelectColumn(column.key);
+        }
+      };
 
       const handleSort = (e: React.MouseEvent) => {
         e.stopPropagation();
@@ -50,18 +56,20 @@ export const useColumnHeaderCell = (height: number) => {
       console.log("gridContext.isColumnSelected", gridContext?.isColumnSelected(column.key));
       return (
         <div className={classes} onMouseOver={handleColumnHeaderCellMouseOver}
-              onMouseLeave={handleColumnHeaderCellMouseLeave}>
+              onMouseLeave={handleColumnHeaderCellMouseLeave} onClick={handleHeaderClick}>
           <div className="header-cell-container">
             {!isEditing && isRemovable &&
-              <RemoveColumnButton colId={column.key} colName={column.name as string} onRemoveColumn={onRemoveColumn}/>}
+              <RemoveColumnButton colId={column.key} colName={column.name as string} onRemoveColumn={onRemoveColumn}
+                isColumnSelected={gridContext?.isColumnSelected(column.key) ?? false}/>
+            }
             <div className="flex-container">
               <EditableHeaderCell height={height} {...props} />
               {showExpressions && <ExpressionCell readOnly={readOnly} column={column} />}
             </div>
-            <div className={clsx("sort-column-button", { "ascending": sortDirection === "ascending",
+            <div className={clsx("column-button sort-column-button", { "ascending": sortDirection === "ascending",
                                       "descending": sortDirection === "descending"})}
                   onClick={handleSort}>
-              <SortIcon className={clsx("sort-icon")}
+              <SortIcon className={clsx("column-icon sort-column-icon")}
               />
             </div>
           </div>
@@ -75,9 +83,11 @@ export const useColumnHeaderCell = (height: number) => {
 interface IRemoveColumnButtonProps {
   colId: string;
   colName: string;
+  isColumnSelected: boolean;
   onRemoveColumn?: (colId: string) => void;
 }
-const RemoveColumnButton: React.FC<IRemoveColumnButtonProps> = ({ colId, colName, onRemoveColumn }) => {
+const RemoveColumnButton: React.FC<IRemoveColumnButtonProps> =
+        ({ colId, colName, isColumnSelected, onRemoveColumn }) => {
   const AlertContent = () => {
     return <p>Remove column <b>{colName}</b> and its contents from the table?</p>;
   };
@@ -87,9 +97,15 @@ const RemoveColumnButton: React.FC<IRemoveColumnButtonProps> = ({ colId, colName
     confirmLabel: "Remove Column",
     onConfirm: () => onRemoveColumn?.(colId)
   });
+
+  const handleClick = () => {
+    if (isColumnSelected) {
+      showAlert();
+    }
+  };
   return (
-    <div className="remove-column-button" onClick={showAlert}>
-      <RemoveColumnSvg className="remove-column-icon"/>
+    <div className="column-button remove-column-button" onClick={handleClick}>
+      <RemoveColumnSvg className="column-icon remove-column-icon"/>
     </div>
   );
 };

--- a/src/components/tiles/table/column-header-cell.tsx
+++ b/src/components/tiles/table/column-header-cell.tsx
@@ -15,29 +15,23 @@ export const useColumnHeaderCell = (height: number) => {
   return useMemo(() => {
     const ColumnHeaderCell: React.FC<IProps> = (props: IProps) => {
       const column = props.column as unknown as TColumn;
-      const { gridContext, readOnly, isEditing, isRemovable, showExpressions, onRemoveColumn } = column.appData || {};
-      const [ columnHeaderHover, setColumnHeaderHover ] = React.useState(false);
+      const { gridContext, readOnly, isEditing, isRemovable, showExpressions, hasData,
+              onRemoveColumn } = column.appData || {};
       const classes = classNames("column-header-cell",
                         { "show-expression": showExpressions,
                           "selected-column": gridContext?.isColumnSelected(column.key),}
                       );
-
       // FIXME: temporary local state
       const [sortDirection, setSortDirection] = React.useState<"ascending" | "descending" | undefined>(undefined);
 
       const handleColumnHeaderCellMouseOver = (e: React.MouseEvent) => {
-        console.log("in handleColumnHeaderCellMouseOver gridContext.isColumnSelected",
-            gridContext?.isColumnSelected(column.key));
-
         if (!gridContext?.isColumnSelected(column.key)) {
-          setColumnHeaderHover(true);
           document.querySelectorAll(`.column-${column.key}`).forEach(cell => {
             cell.classList.add("hovered-column");
           });
         }
       };
       const handleColumnHeaderCellMouseLeave = (e: React.MouseEvent) => {
-        setColumnHeaderHover(false);
         document.querySelectorAll(`.column-${column.key}`).forEach(cell => {
           cell.classList.remove("hovered-column");
         });
@@ -46,7 +40,6 @@ export const useColumnHeaderCell = (height: number) => {
         if (!gridContext?.isColumnSelected(column.key)) {
           e.stopPropagation();
           gridContext?.onSelectColumn(column.key);
-          setColumnHeaderHover(false);
         }
       };
 
@@ -77,10 +70,12 @@ export const useColumnHeaderCell = (height: number) => {
               <EditableHeaderCell height={height} {...props} />
               {showExpressions && <ExpressionCell readOnly={readOnly} column={column} />}
             </div>
-            <div className={clsx("column-button sort-column-button", { "ascending": sortDirection === "ascending",
-                                  "descending": sortDirection === "descending" })} onClick={handleSort}>
-              <SortIcon className={clsx("column-icon sort-column-icon")} />
-            </div>
+            {hasData &&
+              <div className={clsx("column-button sort-column-button", { "ascending": sortDirection === "ascending",
+                                    "descending": sortDirection === "descending" })} onClick={handleSort}>
+                <SortIcon className={clsx("column-icon sort-column-icon")} />
+              </div>
+            }
           </div>
         </div>
       );

--- a/src/components/tiles/table/table-tile.scss
+++ b/src/components/tiles/table/table-tile.scss
@@ -141,6 +141,12 @@ $controls-hover-background: #c0dfe7;
       }
       .rdg-cell {
         border-top: $border-style;
+        &.highlighted-column {
+          background-color: $highlight-blue-20;
+          &.linked {
+            background-color: $highlight-linked-header;
+          }
+        }
         &.selected-column {
           background-color: $highlight-unlinked-header;
 
@@ -299,6 +305,19 @@ $controls-hover-background: #c0dfe7;
 
       &.has-expression {
         background-color: $charcoal-light-5;
+      }
+      &.hovered-column {
+        background-color: $highlight-blue-20;
+
+        &.linked {
+          background-color: $highlight-linked-cell;
+        }
+      }
+      &.controls-column {
+        background-color: white;
+        border: none;
+        box-shadow: none;
+        padding: 0;
       }
       &.selected-column {
         background-color: $highlight-unlinked-cell;

--- a/src/components/tiles/table/table-tile.tsx
+++ b/src/components/tiles/table/table-tile.tsx
@@ -2,7 +2,8 @@ import { observer } from "mobx-react";
 import { onSnapshot } from "mobx-state-tree";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import ReactDataGrid from "react-data-grid";
-// If SortColumn is not exported, define it here based on react-data-grid's documentation:
+import { compareValues } from "../../../models/data/data-set-utils";
+
 export interface SortColumn {
   columnKey: string;
   direction: 'ASC' | 'DESC';
@@ -144,13 +145,15 @@ const TableToolComponent: React.FC<ITileProps> = observer(function TableToolComp
     const sorted =  [...rowsToSort].sort((a, b) => {
       for (const sort of sortColumns) {
         const { columnKey, direction } = sort;
-        const aValue = a[columnKey];
-        const bValue = b[columnKey];
+        const result = compareValues(
+          a[columnKey],
+          b[columnKey],
+          (aStr, bStr) => aStr.localeCompare(bStr, undefined, { sensitivity: 'base' })
+        );
 
-        if (aValue === bValue) continue;
-
-        const sortOrder = direction === 'ASC' ? 1 : -1;
-        return aValue > bValue ? sortOrder : -sortOrder;
+        if (result !== 0) {
+          return direction === "ASC" ? result : -result;
+        }
       }
       return 0;
     });

--- a/src/components/tiles/table/table-tile.tsx
+++ b/src/components/tiles/table/table-tile.tsx
@@ -174,7 +174,7 @@ const TableToolComponent: React.FC<ITileProps> = observer(function TableToolComp
 
   // Expands the columns with additional data and callbacks
   useColumnExtensions({
-    gridContext, metadata, readOnly, columns, columnEditingName, changeHandlers,
+    gridContext, metadata, readOnly, columns, rows, columnEditingName, changeHandlers,
     setColumnEditingName: handleSetColumnEditingName, onShowExpressionsDialog: handleShowExpressionsDialog
   });
 

--- a/src/components/tiles/table/table-tile.tsx
+++ b/src/components/tiles/table/table-tile.tsx
@@ -130,11 +130,11 @@ const TableToolComponent: React.FC<ITileProps> = observer(function TableToolComp
     ...rowLabelProps, measureColumnWidth, lookupImage,
     sortColumns,
     onSort: (columnKey: string, direction: "ASC" | "DESC" | "NONE") => {
-      setSortColumns(prev => {
-        const filtered = prev.filter(c => c.columnKey !== columnKey);
-        if (direction === "NONE") return filtered;
-        return [...filtered, { columnKey, direction }];
-      });
+      if (direction === "NONE") {
+        setSortColumns([]);
+      } else {
+        setSortColumns([{ columnKey, direction }]);
+      }
   }});
 
   const sortedRows = useMemo(() => {

--- a/src/components/tiles/table/table-types.ts
+++ b/src/components/tiles/table/table-types.ts
@@ -39,6 +39,8 @@ export interface TColumnAppData {
   isRemovable: boolean;
   showExpressions: boolean;
   expression?: string;
+  hasData?: boolean;
+  // sortDirection: "ascending" | "descending" | undefined;
   onBeginHeaderCellEdit: () => boolean | undefined;
   onHeaderCellEditKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => void;
   onEndHeaderCellEdit: (value?: string) => void;

--- a/src/components/tiles/table/use-column-extensions.ts
+++ b/src/components/tiles/table/use-column-extensions.ts
@@ -1,6 +1,6 @@
 import { getEditableExpression } from "../../../models/data/expression-utils";
 import { TableMetadataModelType } from "../../../models/tiles/table/table-content";
-import { IGridContext, isDataColumn, TColumn } from "./table-types";
+import { IGridContext, isDataColumn, TColumn, TRow } from "./table-types";
 import { IContentChangeHandlers } from "./use-content-change-handlers";
 
 interface IProps {
@@ -9,12 +9,13 @@ interface IProps {
   readOnly?: boolean;
   columns: TColumn[];
   columnEditingName?: string;
+  rows: TRow[];
   setColumnEditingName: (column?: TColumn) => void;
   onShowExpressionsDialog?: (attrId?: string) => void;
   changeHandlers: IContentChangeHandlers;
 }
 export const useColumnExtensions = ({
-  gridContext, metadata, readOnly, columns, columnEditingName,
+  gridContext, metadata, readOnly, columns, columnEditingName, rows,
   setColumnEditingName, onShowExpressionsDialog, changeHandlers
 }: IProps) => {
   const { onSetColumnName, onRemoveColumn } = changeHandlers;
@@ -56,7 +57,13 @@ export const useColumnExtensions = ({
         setColumnEditingName();
       },
       onRemoveColumn,
-      onShowExpressionsDialog
+      onShowExpressionsDialog,
+      hasData: (() => {
+        return rows.some((c: any) => {
+          const value = c[column.key];
+          return value !== undefined && value !== null && value !== "";
+        });
+      })()
     };
   });
 };

--- a/src/components/tiles/table/use-columns-from-data-set.ts
+++ b/src/components/tiles/table/use-columns-from-data-set.ts
@@ -67,14 +67,14 @@ export const useColumnsFromDataSet = ({
     };
   }, [readOnly]);
 
-const ColumnHeaderCell = (props: any) => useColumnHeaderCell({
-  column: props.column,
-  height: headerHeight(),
-  getSortDirection: (columnKey: string) => sortColumns?.find(col => col.columnKey === columnKey)?.direction ?? "NONE",
-  onSort: onSort ?? (() => {}),
-  allRowsSelected: false,
-  onAllRowsSelectionChange: () => {}
-})(props);
+  const ColumnHeaderCell = (props: any) => useColumnHeaderCell({
+    column: props.column,
+    height: headerHeight(),
+    getSortDirection: (columnKey: string) => sortColumns?.find(col => col.columnKey === columnKey)?.direction ?? "NONE",
+    onSort: onSort ?? (() => {}),
+    allRowsSelected: false,
+    onAllRowsSelectionChange: () => {}
+  })(props);
 
   const columns = useMemo(() => {
     const cols: TColumn[] = attributes.map(attr => {

--- a/src/components/tiles/table/use-columns-from-data-set.ts
+++ b/src/components/tiles/table/use-columns-from-data-set.ts
@@ -42,7 +42,8 @@ export const useColumnsFromDataSet = ({
     };
     dataSet.selectedAttributeIds; // eslint-disable-line no-unused-expressions
     return {
-      cellClass: classNames({ "has-expression": metadata?.hasExpression(attrId), ...selectedColumnClass }),
+      cellClass: classNames(`column-${attrId}`,
+                            { "has-expression": metadata?.hasExpression(attrId), ...selectedColumnClass }),
       headerCellClass: classNames({ "rdg-cell-editing": columnEditingName === attrId, ...selectedColumnClass })
     };
   }, [columnEditingName, dataSet.selectedAttributeIds, gridContext, isLinked, metadata]);

--- a/src/components/vars.sass
+++ b/src/components/vars.sass
@@ -327,6 +327,7 @@ $id-green: #91e7a2
 $new-comment-notice: #5fff32
 
 $highlight-blue: #0081ff
+$highlight-blue-20: #0081ff33 // $highlight-blue @ 20% opacity
 $highlight-blue-50: #80c0ff     // $highlight-blue @ 50% opacity
 $highlight-blue-25: #c0e0ff     // $highlight-blue @ 25% opacity
 $highlight-blue-50-35: #c3efff  // $highlight-blue-50 @ 35% opacity

--- a/src/components/vars.sass
+++ b/src/components/vars.sass
@@ -328,6 +328,7 @@ $new-comment-notice: #5fff32
 
 $highlight-blue: #0081ff
 $highlight-blue-20: #0081ff33 // $highlight-blue @ 20% opacity
+$highlight-blue-40: #0081ff66 // $highlight-blue @ 20% opacity
 $highlight-blue-50: #80c0ff     // $highlight-blue @ 50% opacity
 $highlight-blue-25: #c0e0ff     // $highlight-blue @ 25% opacity
 $highlight-blue-50-35: #c3efff  // $highlight-blue-50 @ 35% opacity

--- a/src/models/data/attribute.ts
+++ b/src/models/data/attribute.ts
@@ -239,6 +239,14 @@ export const Attribute = types.model("Attribute", {
     if ((index != null) && (index < self.values.length) && (count > 0)) {
       self.values.splice(index, count);
     }
+  },
+  // order the values of the attribute according to the provided indices
+  orderValues(indices: number[]) {
+    const _values = self.values.slice();
+    // const _numValues = self.numValues.slice()
+    for (let i = 0; i < _values.length; ++i) {
+      self.values[i] = _values[indices[i]];
+    }
   }
 }));
 export interface IAttribute extends Instance<typeof Attribute> {}

--- a/src/models/data/data-set-utils.ts
+++ b/src/models/data/data-set-utils.ts
@@ -18,3 +18,85 @@ export function mergeTwoDataSets(source: IDataSetSnapshot, target: IDataSet) {
     });
     addCasesToDataSet(target, sourceCases);
 }
+
+interface ICompareProps {
+  a: number
+  b: number
+  order: "asc" | "desc"
+}
+
+export const numericSortComparator = function ({a, b, order}: ICompareProps): number {
+  const aIsNaN = isNaN(a);
+  const bIsNaN = isNaN(b);
+
+  if (aIsNaN && bIsNaN) return 0;
+  if (bIsNaN) return order === "asc" ? 1 : -1;
+  if (aIsNaN) return order === "asc" ? -1 : 1;
+  return order === "asc" ? a - b : b - a;
+};
+
+export const
+  kTypeError = 1,
+  kTypeNaN = 2,
+  kTypeNull = 3,
+  kTypeNumber = 4,
+  kTypeString = 5,
+  kTypeBoolean = 6,
+  // kTypeDate = 7,
+  // kTypeSimpleMap = 8, // e.g. boundaries
+  kTypeUnknown = 9;
+
+export function typeCode(value: any) {
+  if (value == null) return kTypeNull;
+  if (value instanceof Error) return kTypeError;
+  // if (isDate(value) || isDateString(value)) return kTypeDate
+  // if (value instanceof DG.SimpleMap) return kTypeSimpleMap;
+  switch (typeof value) {
+    case 'number': return isNaN(value) ? kTypeNaN : kTypeNumber;
+    case 'boolean': return kTypeBoolean;
+    case 'string': return kTypeString;
+    /* istanbul ignore next */
+    default: return kTypeUnknown;
+  }
+}
+
+export function sortableValue(value: any) {
+  const type = typeCode(value);
+  let num = type === kTypeNumber ? value : NaN;
+  // strings convertible to numbers are treated numerically
+  if (type === kTypeString && value.length) {
+    num = Number(value);
+    if (!isNaN(num)) return { type: kTypeNumber, value: num };
+  }
+  // booleans are treated as strings
+  else if (type === kTypeBoolean) {
+    return { type: kTypeString, value };
+  }
+
+  // TODO: May be useful later when we want to sort dates. Code from CODAP data-utils.
+  // dates are treated numerically
+  // else if (type === kTypeDate) {
+  //   const date = isDate(value) ? value : parseDate(value);
+  //   if (!date) return { type: kTypeNull, value: null };
+  //   return { type: kTypeNumber, value: date.getTime() / 1000 };
+  // }
+  // other values are treated according to their type
+  return { type, value };
+}
+
+// Ascending comparator; negate the result for descending
+export function compareValues(value1: any, value2: any, strCompare: (a: string, b: string) => number) {
+  const v1 = sortableValue(value1);
+  const v2 = sortableValue(value2);
+
+  // if types differ, then sort by type
+  if (v1.type !== v2.type) return v1.type - v2.type;
+
+  // if types are the same, then sort by value
+  switch (v1.type) {
+    case kTypeNumber: return v1.value - v2.value;
+    case kTypeString:
+    case kTypeError: return strCompare(String(v1.value), String(v2.value));
+    default: return 0; // other types are not ordered within type
+  }
+}

--- a/src/models/data/data-set-utils.ts
+++ b/src/models/data/data-set-utils.ts
@@ -47,7 +47,7 @@ export const
   kTypeUnknown = 9;
 
 export function typeCode(value: any) {
-  if (value == null) return kTypeNull;
+  if (value == null || value === "") return kTypeNull;
   if (value instanceof Error) return kTypeError;
   // if (isDate(value) || isDateString(value)) return kTypeDate
   // if (value instanceof DG.SimpleMap) return kTypeSimpleMap;

--- a/src/models/data/data-set-utils.ts
+++ b/src/models/data/data-set-utils.ts
@@ -36,12 +36,12 @@ export const numericSortComparator = function ({a, b, order}: ICompareProps): nu
 };
 
 export const
-  kTypeError = 1,
-  kTypeNaN = 2,
-  kTypeNull = 3,
-  kTypeNumber = 4,
-  kTypeString = 5,
-  kTypeBoolean = 6,
+  kTypeNumber = 1,
+  kTypeString = 2,
+  kTypeBoolean = 3,
+  kTypeError = 4,
+  kTypeNaN = 5,
+  kTypeNull = 6,
   // kTypeDate = 7,
   // kTypeSimpleMap = 8, // e.g. boundaries
   kTypeUnknown = 9;


### PR DESCRIPTION
Adds sort controls to the header cells of each column.
Cases can be sorted ascending or descending by numbers, alphanumeric, booleans, blanks.
Only one column can be used to sort cases by.

Bugs:
1. There is a slight state mismatch in that the sort indicator may show the unsorted state, once a column has been sorted it cannot revert back to its unsorted state.
2. If a user adds or changes a value to the sorted column, the sort indicator does not change to unsorted.