### PR TITLE
Fix grouping of Text objects

### DIFF
--- a/src/plugins/drawing/components/drawing-scale-context.tsx
+++ b/src/plugins/drawing/components/drawing-scale-context.tsx
@@ -1,0 +1,38 @@
+import React, { createContext, useContext } from "react";
+
+/**
+ * Represents the current SVG scaling in effect in X and Y directions due to groups.
+ */
+export interface DrawingScale {
+  scaleX: number;
+  scaleY: number;
+}
+
+/**
+ * React context for the current drawing scale. Default is no scale (1, 1).
+ */
+export const DrawingScaleContext = createContext<DrawingScale>({ scaleX: 1, scaleY: 1 });
+
+/**
+ * Hook to access the current drawing scale from context.
+ */
+export const useDrawingScale = () => useContext(DrawingScaleContext);
+
+/**
+ * Provider that multiplies the parent scale with the local scale and provides it to children.
+ * @param scale - The local scale to apply (will be multiplied with parent scale)
+ * @param children - The children to render
+ */
+export const DrawingScaleProvider:
+    React.FC<{ scale: DrawingScale; children: React.ReactNode }> = ({ scale, children }) => {
+  const parentScale = useDrawingScale();
+  const combinedScale = {
+    scaleX: parentScale.scaleX * scale.scaleX,
+    scaleY: parentScale.scaleY * scale.scaleY,
+  };
+  return (
+    <DrawingScaleContext.Provider value={combinedScale}>
+      {children}
+    </DrawingScaleContext.Provider>
+  );
+};

--- a/src/plugins/drawing/objects/group.test.tsx
+++ b/src/plugins/drawing/objects/group.test.tsx
@@ -1,0 +1,131 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { GroupComponent, GroupObject } from "./group";
+import { RectangleObject } from "./rectangle";
+import { useDrawingScale } from "../components/drawing-scale-context";
+import { TextObject } from "./text";
+
+import "../drawing-registration";
+
+// Patch RectangleComponent to render the scale context for the test
+jest.mock("./rectangle", () => {
+  const actual = jest.requireActual("./rectangle");
+  return {
+    ...actual,
+    RectangleComponent: ({ model }: any) => {
+      const { scaleX, scaleY } = useDrawingScale();
+      return (<text data-testid="scale">{`scaleX:${scaleX},scaleY:${scaleY}`}</text>);
+    }
+  };
+});
+
+// Minimal mock for useReadOnlyContext
+jest.mock("../../../components/document/read-only-context", () => ({
+  useReadOnlyContext: () => false
+}));
+
+// Minimal mock for Transformable
+jest.mock("../components/transformable", () => ({
+  Transformable: ({ children }: { children: React.ReactNode }) => children
+}));
+
+// Suppress React/JSDOM warnings about unrecognized SVG tags
+let originalConsoleError: typeof console.error;
+beforeAll(() => {
+  originalConsoleError = console.error;
+  console.error = (...args: any[]) => {
+    if (typeof args[0] === "string" && args[0].includes("is unrecognized in this browser")) {
+      return;
+    }
+    originalConsoleError(...args);
+  };
+});
+afterAll(() => {
+  console.error = originalConsoleError;
+});
+
+describe("GroupComponent scale context with MST models", () => {
+  it("provides the correct scale to children via context", () => {
+    // Create a rectangle MST object as the child
+    const rect = RectangleObject.create({
+      type: "rectangle",
+      x: 0,
+      y: 0,
+      width: 1,
+      height: 1,
+      fill: "#fff",
+      stroke: "#000",
+      strokeDashArray: "",
+      strokeWidth: 1
+    });
+    // Create a group MST object with known width/height
+    const group = GroupObject.create({
+      type: "group",
+      x: 0,
+      y: 0,
+      width: 5,
+      height: 7,
+      objects: [rect]
+    });
+    render(<GroupComponent model={group} />);
+    expect(screen.getByTestId("scale")).toHaveTextContent("scaleX:5,scaleY:7");
+  });
+
+  it("provides the correct scale to children in nested groups", () => {
+    // Create a rectangle MST object as the child
+    const rect = RectangleObject.create({
+      type: "rectangle",
+      x: 0,
+      y: 0,
+      width: 1,
+      height: 1,
+      fill: "#fff",
+      stroke: "#000",
+      strokeDashArray: "",
+      strokeWidth: 1
+    });
+    // Create an inner group MST object with width 0.5 and height 0.2
+    const innerGroup = GroupObject.create({
+      type: "group",
+      x: 0,
+      y: 0,
+      width: 0.5,
+      height: 0.2,
+      objects: [rect]
+    });
+    // Create an outer group MST object
+    const outerGroup = GroupObject.create({
+      type: "group",
+      x: 0,
+      y: 0,
+      width: 5,
+      height: 3,
+      objects: [innerGroup]
+    });
+    render(<GroupComponent model={outerGroup} />);
+    expect(screen.getByTestId("scale")).toHaveTextContent("scaleX:2.5,scaleY:0.6");
+  });
+
+  it("renders a Text object inside a group with a <g> transform that is the reciprocal of the scaling", () => {
+    const text = TextObject.create({
+      type: "text",
+      x: 0,
+      y: 0,
+      width: 1,
+      height: 1,
+      stroke: "#000",
+      text: "Hello"
+    });
+    const group = GroupObject.create({
+      type: "group",
+      x: 0,
+      y: 0,
+      width: 2,
+      height: 4,
+      objects: [text]
+    });
+    const { container } = render(<GroupComponent model={group} />);
+    const g = container.querySelector("g.text");
+    expect(g).toHaveAttribute("transform", "scale(0.5, 0.25)");
+  });
+});

--- a/src/plugins/drawing/objects/group.tsx
+++ b/src/plugins/drawing/objects/group.tsx
@@ -13,6 +13,7 @@ import { isVectorObject } from "./vector";
 import { useReadOnlyContext } from "../../../components/document/read-only-context";
 import { Transformable } from "../components/transformable";
 import { SizedObject } from "./sized-object";
+import { DrawingScaleProvider } from "../components/drawing-scale-context";
 
 import GroupObjectsIcon from "../assets/group-objects-icon.svg";
 
@@ -153,28 +154,28 @@ export const GroupComponent = observer(function GroupComponent(
 
   return (
     <Transformable type="group" key={id} transform={group.transform} setAnimating={group.setAnimating}>
-      <g className="group"
-         transform={`scale(${currentDims.width}, ${currentDims.height})`}>
-        {renderChildDrawingObjects(group, readOnly)}
-        {/* A rectangle that is invisible, but reacts to mouse events for the group*/}
-        <rect
-          key={id}
-          className="group-rect"
-          x={0}
-          y={0}
-          width={1}
-          height={1}
-          stroke="none" strokeWidth={0}
-          fill="none"
-          onMouseEnter={(e) => handleHover ? handleHover(e, model, true) : null}
-          onMouseLeave={(e) => handleHover ? handleHover(e, model, false) : null}
-          onPointerDown={(e) => handleDrag?.(e, model)}
-          pointerEvents={"visible"}
-        />
-      </g>
+      <DrawingScaleProvider scale={{ scaleX: currentDims.width, scaleY: currentDims.height }}>
+        <g className="group"
+           transform={`scale(${currentDims.width}, ${currentDims.height})`}>
+          {renderChildDrawingObjects(group, readOnly)}
+          {/* A rectangle that is invisible, but reacts to mouse events for the group*/}
+          <rect
+            key={id}
+            className="group-rect"
+            x={0}
+            y={0}
+            width={1}
+            height={1}
+            stroke="none" strokeWidth={0}
+            fill="none"
+            onMouseEnter={(e) => handleHover ? handleHover(e, model, true) : null}
+            onMouseLeave={(e) => handleHover ? handleHover(e, model, false) : null}
+            onPointerDown={(e) => handleDrag?.(e, model)}
+            pointerEvents={"visible"}
+          />
+        </g>
+      </DrawingScaleProvider>
     </Transformable>
   );
-
-
 });
 


### PR DESCRIPTION
Fixes CLUE-160. The 'giant ellipse' was actually the frame drawn around text elements with an absurdly scaled stroke width and corner radius, since these were rendered as absolute pixel values but now groups created a scaled SVG context.

The solution is to pass the current scale factors down in a Context, and apply the inverse scale inside the Text element so that font sizes and border dimensions make sense again.

Adds tests for the context and inverse scaling, and removes one unused method from TextObject.