### PR TITLE
Don't make names unique when copying across documents

### DIFF
--- a/docs/tile-creation.md
+++ b/docs/tile-creation.md
@@ -27,8 +27,8 @@ toolbarDrag -- (drop) --> DChandleDrop -- (create new) --> DChandleInsertNewTile
 toolbarDuplicate{{Toolbar duplicate button}}
 ThandleDuplicate("handleDuplicate<br/>(toolbar.tsx)")
 DCduplicateTiles("duplicateTiles<br/>(document-content.ts)")
-DCcopyTiles("copyTiles<br/>(document-content.ts)<br/>Copies shared models<br/>Updates titles for uniqueness")
-BDCcopyTilesIntoNewRows("copyTilesIntoNewRows<br/>(base-document-content.ts)")
+DCcopyTiles("copyTiles<br/>(document-content.ts)<br/>Copies shared models")
+BDCcopyTilesIntoNewRows("copyTilesIntoNewRows<br/>(base-document-content.ts)<br/>Updates titles for uniqueness")
 
 toolbarDuplicate --> ThandleDuplicate --> DCduplicateTiles --> DCcopyTiles
 BDCcopyTilesIntoNewRows --> |first tile|BDCaddTileContentInNewRow
@@ -54,12 +54,17 @@ DChandleDrop("handleDrop<br/>(document-content.tsx)")
 DChandleCopyTilesDrop("handleCopyTilesDrop<br/>(document-content.tsx)")
 DChandleDragCopyTiles("handleDragCopyTiles<br/>(document-content.ts)")
 BDCuserCopyTiles[["userCopyTiles<br/>(base-document-content.ts)<br/>Logs COPY_TILE event"]]
-BDCcopyTilesIntoExistingRow("copyTilesIntoExistingRow<br/>(base-document-content.ts)")
+BDCcopyTilesIntoExistingRow("copyTilesIntoExistingRow<br/>(base-document-content.ts)<br/>Updates titles for uniqueness")
 BDCcopyTilesIntoExistingRow --> |embedded| BDCaddToTileMap
 BDCcopyTilesIntoExistingRow --> |top-level| BDCaddTileSnapshotInExistingRow
 
-dragTile --> DChandleDrop -- (copy existing) --> DChandleCopyTilesDrop --> DChandleDragCopyTiles --> DCcopyTiles --> BDCuserCopyTiles --> BDCcopyTilesIntoNewRows & BDCcopyTilesIntoExistingRow
+dragTile --> DChandleDrop -- (copy existing) --> DChandleCopyTilesDrop --> DChandleDragCopyTiles --> DCcopyTiles -- (no spec) --> BDCuserCopyTiles --> BDCcopyTilesIntoNewRows & BDCcopyTilesIntoExistingRow
 
+toolbarCopy{{Toolbar copy buttons}} --> handleCopyTo
+handleCopyTo[["handleCopyToWorkspace<br/>handleCopyToDocument<br/>(toolbar.tsx)<br/>Logs TOOLBAR_COPY... event"]] --> DCapplyCopySpec
+DCapplyCopySpec["applyCopySpec<br/>(document-content.ts)"] --> DCcopyTiles
+DCcopyTiles -- (spec) --> DCcopyTilesWithSpec
+DCcopyTilesWithSpec["copyTilesWithSpec<br/>(document-content.ts)"] --> BDCcopyTilesIntoExistingRow
 
 BDCaddTileContentInNewRow("addTileContentInNewRow<br/>(base-document-content.ts)")
 BDCaddTileSnapshotInExistingRow("addTileSnapshotInExistingRow<br/>(base-document-content.ts)")
@@ -81,6 +86,7 @@ style toolbarDuplicate fill:#88F
 style dragImage fill:#88F
 style dragTile fill:#88F
 style tableIt fill:#88F
+style toolbarCopy fill:#88F
 style placeholder fill:#88F
 
 ```

--- a/src/lib/logger.test.ts
+++ b/src/lib/logger.test.ts
@@ -364,7 +364,7 @@ describe("authed logger", () => {
         tileType: tileToCopy.content.type
       };
 
-      destinationDocument.content!.userCopyTiles([copyTileInfo], { rowInsertIndex: 0 });
+      destinationDocument.content!.userCopyTiles([copyTileInfo], { rowInsertIndex: 0 }, true);
     });
 
   });

--- a/src/models/document/document-content-tests/multiple-tiles-example.json
+++ b/src/models/document/document-content-tests/multiple-tiles-example.json
@@ -82,6 +82,7 @@
       },
       "textTool1": {
         "id": "textTool1",
+        "title": "Text 1",
         "content": {"type": "Text", "text": "Some text"}
       },
       "tableTool": {

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -218,7 +218,7 @@ export const DocumentContentModel = DocumentContentModelWithTileDragging.named("
           rowInsertIndex: 0, // this is ignored
           rowDropId: targetRow.id,
           rowDropLocation: "right"
-        });
+        }, false);
       }
     });
   },
@@ -274,6 +274,9 @@ export const DocumentContentModel = DocumentContentModelWithTileDragging.named("
     rowInfo?: IDropRowInfo,
     copySpec?: ICopySpec
   ) {
+    // Titles should be made unique unless we are copying from another document.
+    const makeTitlesUnique = !copySpec && !isCrossingDocuments;
+
     // Update shared models with new names and ids
     const updatedSharedModelMap: Record<string, UpdatedSharedDataSetIds> = {};
     const newSharedModelEntries: SharedModelEntrySnapshotType[] = [];
@@ -389,7 +392,7 @@ export const DocumentContentModel = DocumentContentModelWithTileDragging.named("
     if (copySpec) {
       self.copyTilesWithSpec(updatedTiles, copySpec);
     } else if (rowInfo) {
-      self.userCopyTiles(updatedTiles, rowInfo);
+      self.userCopyTiles(updatedTiles, rowInfo, makeTitlesUnique);
     }
 
     // Update tile ids for shared models and add those references to document.
@@ -407,9 +410,9 @@ export const DocumentContentModel = DocumentContentModelWithTileDragging.named("
         // Make dataset name unique.
         // We can't do this earlier since getUniqueDataSetName only considers datasets that are linked to tiles.
         const name = updatedSharedModel.sharedModel.dataSet?.name;
-        const uniqueName = name && self.getUniqueSharedModelName(name);
-        if (updatedSharedModel.sharedModel.dataSet?.name && uniqueName) {
-          updatedSharedModel.sharedModel.dataSet.name = uniqueName;
+        const newName = makeTitlesUnique ? self.getUniqueSharedModelName(name) : name;
+        if (updatedSharedModel.sharedModel.dataSet?.name && newName) {
+          updatedSharedModel.sharedModel.dataSet.name = newName;
         }
 
         const id = sharedModelEntry.sharedModel.id;


### PR DESCRIPTION
CLUE-83

Skips making tile titles & dataset names unique when copying a tile from one document to another.

Updates `tile-creation` documentation with the document toolbar -> "copy with spec" alternate pathway.
