### PR TITLE
Add read-only offset & click handler.

### DIFF
--- a/src/plugins/drawing/components/drawing-layer.tsx
+++ b/src/plugins/drawing/components/drawing-layer.tsx
@@ -17,6 +17,8 @@ import { ImageObject } from "../objects/image";
 import { debounce } from "lodash";
 import { combineBoundingBoxes } from "../../../models/tiles/geometry/geometry-utils";
 import { useTileNavigatorContext } from "../../../components/tiles/hooks/use-tile-navigator-context";
+import { hasSelectionModifier } from "../../../utilities/event-utils";
+import { kReadOnlyOffset } from "../model/drawing-types";
 
 const SELECTION_COLOR = "#777";
 const HOVER_COLOR = "#bbdd00";
@@ -185,7 +187,9 @@ export class InternalDrawingLayerView extends React.Component<InternalDrawingLay
       this.props.reportVisibleBoundingBox?.(actualBoundingBox);
     } else {
       // In regular tile display, offset and zoom are the values stored in the model.
-      this.offsetX = this.props.offsetX;
+      // However, we tweak the displayed offset if there is no "show/sort" sidebar so that the
+      // read-only and read-write versions of the tile center content the same way.
+      this.offsetX = this.props.offsetX + (this.props.readOnly ? kReadOnlyOffset : 0);
       this.offsetY = this.props.offsetY;
       this.zoom = this.props.zoom;
 
@@ -256,6 +260,8 @@ export class InternalDrawingLayerView extends React.Component<InternalDrawingLay
   public handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
     if (!this.props.readOnly) {
       this.getCurrentTool()?.handlePointerDown(e);
+    } else {
+      this.selectTile(hasSelectionModifier(e));
     }
   };
 

--- a/src/plugins/drawing/components/drawing-tile.scss
+++ b/src/plugins/drawing/components/drawing-tile.scss
@@ -26,6 +26,7 @@
       }
 
       &.closed {
+        // See kReadOnlyOffset
         flex: 0 0 26px;
 
         button {

--- a/src/plugins/drawing/model/drawing-types.ts
+++ b/src/plugins/drawing/model/drawing-types.ts
@@ -9,6 +9,7 @@ export const kDrawingStateVersion = "1.1.0";
 export const kDrawingDefaultHeight = 180;
 export const kDuplicateOffset = 10; // Pixels between original and duplicated object
 export const kFlipOffset = 10; // Pixels between original and flipped object
+export const kReadOnlyOffset = 29; // Pixels to shift read-only tile content (width+border of Show/Sort sidebar)
 
 // These types are used by legacy import code in drawing-change-playback.ts
 export type DrawingToolMove = Array<{id: string, destination: Point}>;


### PR DESCRIPTION
CLUE-67.

- Add offset to read-only view so that content that is centered under the title when edited is still centered in read-only view.
- Clicking read-only tile should select it.
