### PR TITLE
Update rollbar config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
         run: npm run lint:build
       - name: Clean
         run: npm run clean
+      - name: Write Version
+        run: npm run build:version
       - name: Build Main App
         run: npm run build:webpack
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,20 +64,11 @@ jobs:
           log-url: ${{ inputs.url }}
           state: 'failure'
           deployment-id: ${{ steps.deployment.outputs.deployment_id }}
-      - name: Format version number
-        uses: actions/github-script@v7
-        id: format-version
-        with:
-          result-encoding: string
-          script: |
-            const version = '${{ inputs.version }}';
-            const bareVersion = version.replace(/^v/, '');
-            return bareVersion;
       - name: Notify Rollbar
         if: success()
         uses: rollbar/github-deploy-action@2.1.2
         with:
           environment: ${{ inputs.environment }}
-          version: ${{ steps.format-version.outputs.result }}
+          version: ${{ github.sha }}
         env:
           ROLLBAR_ACCESS_TOKEN: ${{ secrets.ROLLBAR_ACCESS_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,11 +64,20 @@ jobs:
           log-url: ${{ inputs.url }}
           state: 'failure'
           deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+      - name: Format version number
+        uses: actions/github-script@v7
+        id: format-version
+        with:
+          result-encoding: string
+          script: |
+            const version = '${{ inputs.version }}';
+            const bareVersion = version.replace(/^v/, '');
+            return bareVersion;
       - name: Notify Rollbar
         if: success()
         uses: rollbar/github-deploy-action@2.1.2
         with:
           environment: ${{ inputs.environment }}
-          version: ${{ inputs.version }}
+          version: ${{ steps.format-version.outputs.result }}
         env:
           ROLLBAR_ACCESS_TOKEN: ${{ secrets.ROLLBAR_ACCESS_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,3 +64,12 @@ jobs:
           log-url: ${{ inputs.url }}
           state: 'failure'
           deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+      - name: Notify Rollbar
+        if: success()
+        uses: rollbar/github-deploy-action@2.1.2
+        id: rollbar_deploy
+        with:
+          environment: ${{ inputs.environment }}
+          version: ${{ inputs.version }}
+        env:
+          ROLLBAR_ACCESS_TOKEN: ${{ secrets.ROLLBAR_ACCESS_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,6 @@ jobs:
       - name: Notify Rollbar
         if: success()
         uses: rollbar/github-deploy-action@2.1.2
-        id: rollbar_deploy
         with:
           environment: ${{ inputs.environment }}
           version: ${{ inputs.version }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -147,6 +147,7 @@
         "eslint-plugin-unused-imports": "^3.0.0",
         "eslint-webpack-plugin": "^3.2.0",
         "firebase-admin": "^11.0.1",
+        "git-repo-info": "^2.1.1",
         "googleapis": "^110.0.0",
         "html-webpack-plugin": "^5.5.0",
         "is-hotkey": "^0.2.0",
@@ -13160,6 +13161,15 @@
       "dev": true,
       "dependencies": {
         "assert-plus": "^1.0.0"
+      }
+    },
+    "node_modules/git-repo-info": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/git-repo-info/-/git-repo-info-2.1.1.tgz",
+      "integrity": "sha512-8aCohiDo4jwjOwma4FmYFd3i97urZulL8XL24nIPxuE+GZnfsAyy/g2Shqx6OjUiFKUXZM+Yy+KHnOmmA3FVcg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0"
       }
     },
     "node_modules/glob": {
@@ -32287,6 +32297,12 @@
       "requires": {
         "assert-plus": "^1.0.0"
       }
+    },
+    "git-repo-info": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/git-repo-info/-/git-repo-info-2.1.1.tgz",
+      "integrity": "sha512-8aCohiDo4jwjOwma4FmYFd3i97urZulL8XL24nIPxuE+GZnfsAyy/g2Shqx6OjUiFKUXZM+Yy+KHnOmmA3FVcg==",
+      "dev": true
     },
     "glob": {
       "version": "7.1.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "rete-engine": "^2.0.1",
         "rete-react-plugin": "^2.0.5",
         "rete-structures": "^2.0.1",
-        "rollbar": "^2.25.1",
+        "rollbar": "^2.26.4",
         "rtree": "^1.4.2",
         "superagent": "^8.0.0",
         "ts-polyfill": "^3.8.2",
@@ -14206,10 +14206,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/is_js": {
-      "version": "0.9.0",
-      "license": "MIT"
-    },
     "node_modules/is-arguments": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
@@ -20173,11 +20169,9 @@
       }
     },
     "node_modules/request-ip": {
-      "version": "2.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "is_js": "^0.9.0"
-      }
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/request-ip/-/request-ip-3.3.0.tgz",
+      "integrity": "sha512-cA6Xh6e0fDBBBwH77SLJaJPBmD3nWVAcF9/XAcsrIHdjhFzFiB5aNQFytdjCGPezU3ROwrR11IddKAM08vohxA=="
     },
     "node_modules/request-progress": {
       "version": "3.0.0",
@@ -20418,15 +20412,16 @@
       "license": "Unlicense"
     },
     "node_modules/rollbar": {
-      "version": "2.25.1",
-      "license": "MIT",
+      "version": "2.26.4",
+      "resolved": "https://registry.npmjs.org/rollbar/-/rollbar-2.26.4.tgz",
+      "integrity": "sha512-JKmrj6riYm9ZPJisgxljgH4uCsvjMHDHXrinDF7aAFaP+eoF51HomVPtLcDTYLsrJ568aKVNLUhedFajONBwSg==",
       "dependencies": {
         "async": "~3.2.3",
         "console-polyfill": "0.3.0",
         "error-stack-parser": "^2.0.4",
         "json-stringify-safe": "~5.0.0",
         "lru-cache": "~2.2.1",
-        "request-ip": "~2.0.1",
+        "request-ip": "~3.3.0",
         "source-map": "^0.5.7"
       },
       "optionalDependencies": {
@@ -32965,9 +32960,6 @@
       "version": "1.9.1",
       "dev": true
     },
-    "is_js": {
-      "version": "0.9.0"
-    },
     "is-arguments": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
@@ -36804,10 +36796,9 @@
       }
     },
     "request-ip": {
-      "version": "2.0.2",
-      "requires": {
-        "is_js": "^0.9.0"
-      }
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/request-ip/-/request-ip-3.3.0.tgz",
+      "integrity": "sha512-cA6Xh6e0fDBBBwH77SLJaJPBmD3nWVAcF9/XAcsrIHdjhFzFiB5aNQFytdjCGPezU3ROwrR11IddKAM08vohxA=="
     },
     "request-progress": {
       "version": "3.0.0",
@@ -36959,7 +36950,9 @@
       "version": "3.0.1"
     },
     "rollbar": {
-      "version": "2.25.1",
+      "version": "2.26.4",
+      "resolved": "https://registry.npmjs.org/rollbar/-/rollbar-2.26.4.tgz",
+      "integrity": "sha512-JKmrj6riYm9ZPJisgxljgH4uCsvjMHDHXrinDF7aAFaP+eoF51HomVPtLcDTYLsrJ568aKVNLUhedFajONBwSg==",
       "requires": {
         "async": "~3.2.3",
         "console-polyfill": "0.3.0",
@@ -36967,7 +36960,7 @@
         "error-stack-parser": "^2.0.4",
         "json-stringify-safe": "~5.0.0",
         "lru-cache": "~2.2.1",
-        "request-ip": "~2.0.1",
+        "request-ip": "~3.3.0",
         "source-map": "^0.5.7"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "report-dir": "coverage-cypress"
   },
   "scripts": {
-    "build": "npm-run-all lint:build clean build:webpack build:cms",
+    "build": "npm-run-all lint:build clean build:version build:webpack build:cms",
     "build-and-serve": "npm-run-all build serve",
     "build:debug": "npm-run-all lint clean build:webpack",
     "build:webpack": "cross-env NODE_OPTIONS=--max-old-space-size=4096 webpack --mode production",
@@ -112,7 +112,8 @@
     "top-test:build:copy-index": "cp top-test/specific/release/index-top.html top-test/index.html",
     "top-test:build:copy-editor": "mkdir -p top-test/editor && cp top-test/specific/release/editor/index-top.html top-test/editor/index.html",
     "top-test:build": "npm-run-all top-test:build:*",
-    "top-test:serve": "npx http-server top-test"
+    "top-test:serve": "npx http-server top-test",
+    "build:version": "node ./scripts/write-version.js"
   },
   "repository": {
     "type": "git",
@@ -188,6 +189,7 @@
     "eslint-plugin-unused-imports": "^3.0.0",
     "eslint-webpack-plugin": "^3.2.0",
     "firebase-admin": "^11.0.1",
+    "git-repo-info": "^2.1.1",
     "googleapis": "^110.0.0",
     "html-webpack-plugin": "^5.5.0",
     "is-hotkey": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -285,7 +285,7 @@
     "rete-engine": "^2.0.1",
     "rete-react-plugin": "^2.0.5",
     "rete-structures": "^2.0.1",
-    "rollbar": "^2.25.1",
+    "rollbar": "^2.26.4",
     "rtree": "^1.4.2",
     "superagent": "^8.0.0",
     "ts-polyfill": "^3.8.2",

--- a/scripts/write-version.js
+++ b/scripts/write-version.js
@@ -17,4 +17,4 @@ const version = {
 
 const outPath = path.join(path.dirname(new URL(import.meta.url).pathname), '../version.json');
 fs.writeFileSync(outPath, JSON.stringify(version, null, 2));
-console.log('Wrote version.json:', version);
+console.log('Wrote version information to', outPath);

--- a/scripts/write-version.js
+++ b/scripts/write-version.js
@@ -1,0 +1,20 @@
+import fs from 'fs';
+import path from 'path';
+import gitRepoInfo from 'git-repo-info';
+
+// Writes information about the git repository to version.json
+// This is used to identify the version of the app and to track errors
+// in the rollbar dashboard.
+
+const info = gitRepoInfo();
+
+const version = {
+  gitSha: info.sha || null,
+  branch: info.branch || null,
+  tag: info.tag || null,
+  date: info.committerDate || null,
+};
+
+const outPath = path.join(path.dirname(new URL(import.meta.url).pathname), '../version.json');
+fs.writeFileSync(outPath, JSON.stringify(version, null, 2));
+console.log('Wrote version.json:', version);

--- a/src/index.html
+++ b/src/index.html
@@ -20,7 +20,7 @@
           accessToken: "<%= rollbarAccessToken %>",
           captureUncaught: true,
           captureUnhandledRejections: true,
-          enabled: isProduction,
+          enabled: isProduction || isMasterBranch,
           payload: {
             environment: isProduction ? "production" : "staging"
           }

--- a/src/initialize-app.tsx
+++ b/src/initialize-app.tsx
@@ -19,6 +19,7 @@ import { getAppMode } from "./lib/auth";
 import { DEBUG_STORES } from "./lib/debug";
 import { gImageMap } from "./models/image-map";
 import PackageJson from "./../package.json";
+import gitInfo from "../version.json";
 
 import "./index.scss";
 
@@ -97,7 +98,7 @@ export const initializeApp = ({authoring, standalone, authDomain}: IInitializeAp
 
   const appConfig = AppConfigModel.create(appConfigSnapshot);
   const stores = createStores(
-    { appMode, appVersion, appConfig, user, showDemoCreator, demoName,
+    { appMode, appVersion, gitInfo, appConfig, user, showDemoCreator, demoName,
       documentToDisplay: urlParams.studentDocument, documentHistoryId: urlParams.studentDocumentHistoryId });
 
   if (standalone) {

--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -16,7 +16,7 @@ function setPageTitle(stores: IStores) {
 }
 
 function initRollbar(stores: IStores, problemId: string) {
-  const {user, unit, appVersion} = stores;
+  const {user, unit, gitInfo} = stores;
   const portal = user.portal ?? "unauthenticated";
   if (typeof (window as any).Rollbar !== "undefined") {
     const _Rollbar = (window as any).Rollbar;
@@ -35,7 +35,8 @@ function initRollbar(stores: IStores, problemId: string) {
           problem: stores.problem.title,
           role: user.type,
           unit: unit.title,
-          version: appVersion
+          code_version: gitInfo?.gitSha,
+          version_tag: gitInfo?.tag
         }
       };
       _Rollbar.configure(config);

--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -40,7 +40,6 @@ function initRollbar(stores: IStores, problemId: string) {
         }
       };
       _Rollbar.configure(config);
-      console.log("Rollbar configured with:", config);
     }
   }
 }

--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -17,6 +17,7 @@ function setPageTitle(stores: IStores) {
 
 function initRollbar(stores: IStores, problemId: string) {
   const {user, unit, appVersion} = stores;
+  const portal = user.portal ?? "unauthenticated";
   if (typeof (window as any).Rollbar !== "undefined") {
     const _Rollbar = (window as any).Rollbar;
     if (_Rollbar.configure) {
@@ -25,8 +26,11 @@ function initRollbar(stores: IStores, problemId: string) {
         stackTraceLimit: 50,
         payload: {
           class: user.classHash,
+          context: `${unit.code} ${problemId}`,
           offering: user.offeringId,
-          person: { id: user.id },
+          person: {
+            id: `${user.id}@${portal}`
+          },
           problemId: problemId || "",
           problem: stores.problem.title,
           role: user.type,

--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -20,16 +20,20 @@ function initRollbar(stores: IStores, problemId: string) {
   if (typeof (window as any).Rollbar !== "undefined") {
     const _Rollbar = (window as any).Rollbar;
     if (_Rollbar.configure) {
-      const config = { payload: {
-              class: user.classHash,
-              offering: user.offeringId,
-              person: { id: user.id },
-              problemId: problemId || "",
-              problem: stores.problem.title,
-              role: user.type,
-              unit: unit.title,
-              version: appVersion
-            }};
+      const config = {
+        maxItems: 100,
+        stackTraceLimit: 50,
+        payload: {
+          class: user.classHash,
+          offering: user.offeringId,
+          person: { id: user.id },
+          problemId: problemId || "",
+          problem: stores.problem.title,
+          role: user.type,
+          unit: unit.title,
+          version: appVersion
+        }
+      };
       _Rollbar.configure(config);
     }
   }
@@ -41,4 +45,9 @@ export function problemLoaded(stores: IStores, problemId: string) {
 
   // The logger will only be enabled if the appMode is "authed", or DEBUG_LOGGER is true
   Logger.initializeLogger(stores, { investigation: stores.investigation.title, problem: stores.problem.title });
+
+  // Send event logs to rollbar as well
+  Logger.Instance?.registerLogListener((logMessage) => {
+    (window as any).Rollbar?.captureEvent(logMessage, 'info');
+  });
 }

--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -40,6 +40,7 @@ function initRollbar(stores: IStores, problemId: string) {
         }
       };
       _Rollbar.configure(config);
+      console.log("Rollbar configured with:", config);
     }
   }
 }

--- a/src/models/stores/base-stores-types.ts
+++ b/src/models/stores/base-stores-types.ts
@@ -18,10 +18,17 @@ import { SerialDevice } from "./serial";
 import { Bookmarks } from "./bookmarks";
 import { ICurriculumConfig } from "./curriculum-config";
 
+export interface IGitInfo {
+  gitSha?: string|null;
+  branch?: string|null;
+  tag?: string|null;
+  date?: string|null;
+}
 
 export interface IBaseStores {
   appMode: AppMode;
   appVersion: string;
+  gitInfo: IGitInfo;
   appConfig: AppConfigModelType;
   curriculumConfig: ICurriculumConfig;
   unit: UnitModelType;

--- a/src/models/stores/stores.ts
+++ b/src/models/stores/stores.ts
@@ -22,7 +22,7 @@ import { ClipboardModel, ClipboardModelType } from "./clipboard";
 import { SelectionStoreModel, SelectionStoreModelType } from "./selection";
 import { AppMode } from "./store-types";
 import { SerialDevice } from "./serial";
-import { IBaseStores } from "./base-stores-types";
+import { IBaseStores, IGitInfo } from "./base-stores-types";
 import { NavTabModelType } from "../view/nav-tabs";
 import { Bookmarks } from "./bookmarks";
 import { SortedDocuments } from "./sorted-documents";
@@ -57,6 +57,7 @@ export interface IStores extends IBaseStores {
   startedLoadingUnitAndProblem: boolean;
   exemplarController: ExemplarControllerModelType;
   portal: Portal;
+  gitInfo: IGitInfo;
 }
 
 export interface ICreateStores extends Partial<IStores> {
@@ -73,6 +74,7 @@ export function createStores(params?: ICreateStores): IStores {
 class Stores implements IStores{
   appMode: AppMode;
   appVersion: string;
+  gitInfo: IGitInfo;
   appConfig: AppConfigModelType;
   curriculumConfig: ICurriculumConfig;
   unit: UnitModelType;
@@ -113,6 +115,7 @@ class Stores implements IStores{
     makeAutoObservable(this);
     this.appMode = params?.appMode || "dev";
     this.appVersion = params?.appVersion || "unknown";
+    this.gitInfo = params?.gitInfo || {};
     this.curriculumConfig = params?.curriculumConfig || CurriculumConfig.create(curriculumConfigJson, {urlParams});
     this.appConfig = params?.appConfig || AppConfigModel.create();
 

--- a/version.json
+++ b/version.json
@@ -1,0 +1,7 @@
+{
+  "comment": "These are placeholder values; for production use they are overwritten by the build process",
+  "gitSha": "dev",
+  "branch": "dev",
+  "tag": "dev",
+  "date": ""
+}


### PR DESCRIPTION
CLUE-184

Rollbar package updated
Increase stacktrace depth
Limit to 100 error reports per page view
Add event log items to Rollbar "telemetry"
Notify Rollbar of releases in Github Actions

The "version"/"code_version" field was changed to use Github SHA since that seems to be what's recommended.
The sementic version is sent as an extra "version_tag" payload property.
