### PR TITLE
Sparrows in groups

### DIFF
--- a/cypress/e2e/functional/tile_tests/arrow_annotation_spec.js
+++ b/cypress/e2e/functional/tile_tests/arrow_annotation_spec.js
@@ -143,6 +143,24 @@ context('Arrow Annotations (Sparrows)', function () {
     aa.getPreviewArrow().should("not.exist");
     aa.getAnnotationDeleteButtons().eq(2).click();
 
+    cy.log("Can annotate grouped objects");
+    aa.getAnnotationArrows().should("have.length", 2);
+    aa.getAnnotationButtons().should("have.length", 3);
+    // Group the two rectangles
+    aa.getAnnotationModeButton().click(); // sparrow mode off
+    drawToolTile.getRectangleDrawing().eq(0).click();
+    drawToolTile.getRectangleDrawing().eq(1).click({ shiftKey: true });
+    clueCanvas.clickToolbarButton('drawing', 'group');
+    aa.getAnnotationModeButton().click(); // sparrow mode on
+    aa.getAnnotationArrows().should("have.length", 2); // doesn't change number of arrows
+    aa.getAnnotationButtons().should("have.length", 3); // doesn't change number of buttons
+    // Ungroup the two rectangles
+    aa.getAnnotationModeButton().click(); // sparrow mode off
+    drawToolTile.getDrawTile().click();
+    drawToolTile.getGroupDrawing().eq(0).find("rect.group-rect").eq(0).click();
+    clueCanvas.clickToolbarButton('drawing', 'ungroup');
+    aa.getAnnotationModeButton().click(); // sparrow mode on
+
     // Long click or drag, however, does not create a new sparrow.
     aa.getAnnotationArrowDragHandles().eq(3).trigger('mousedown', { force: true });
     cy.wait(500);
@@ -240,7 +258,7 @@ context('Arrow Annotations (Sparrows)', function () {
     aa.getAnnotationMenuExpander().click();
     aa.getStraightArrowToolbarButton().click();
     aa.getAnnotationButtons().eq(0).click(); // First end is anchored to an object
-    aa.getAnnotationSvg().click(200, 150);
+    aa.getAnnotationSvg().click(200, 190);
     aa.getAnnotationArrows().should("have.length", 1);
 
     aa.getAnnotationSvg().click(500, 100);
@@ -254,8 +272,8 @@ context('Arrow Annotations (Sparrows)', function () {
     aa.getAnnotationArrows().should("have.length", 0);
 
     // Attempting to connect both ends to objects results in second end being free
-    aa.getAnnotationButtons().eq(0).click();
-    aa.getAnnotationButtons().eq(1).click(); // Just the click location is used.
+    aa.getAnnotationButtons().eq(1).click();
+    aa.getAnnotationButtons().eq(0).click(); // Just the click location is used.
     aa.getAnnotationModeButton().click(); // exit sparrow mode
     aa.getAnnotationArrows().should("have.length", 1);
     drawToolTile.getEllipseDrawing().find("ellipse").click({ force: true, scrollBehavior: false });

--- a/src/plugins/drawing/components/drawing-layer.tsx
+++ b/src/plugins/drawing/components/drawing-layer.tsx
@@ -18,7 +18,7 @@ import { debounce } from "lodash";
 import { combineBoundingBoxes } from "../../../models/tiles/geometry/geometry-utils";
 import { useTileNavigatorContext } from "../../../components/tiles/hooks/use-tile-navigator-context";
 import { hasSelectionModifier } from "../../../utilities/event-utils";
-import { kReadOnlyOffset } from "../model/drawing-types";
+import { kClosedObjectListPanelWidth } from "../model/drawing-types";
 
 const SELECTION_COLOR = "#777";
 const HOVER_COLOR = "#bbdd00";
@@ -189,7 +189,7 @@ export class InternalDrawingLayerView extends React.Component<InternalDrawingLay
       // In regular tile display, offset and zoom are the values stored in the model.
       // However, we tweak the displayed offset if there is no "show/sort" sidebar so that the
       // read-only and read-write versions of the tile center content the same way.
-      this.offsetX = this.props.offsetX + (this.props.readOnly ? kReadOnlyOffset : 0);
+      this.offsetX = this.props.offsetX + (this.props.readOnly ? kClosedObjectListPanelWidth : 0);
       this.offsetY = this.props.offsetY;
       this.zoom = this.props.zoom;
 

--- a/src/plugins/drawing/components/drawing-tile.scss
+++ b/src/plugins/drawing/components/drawing-tile.scss
@@ -21,12 +21,13 @@
       z-index: 1;
 
       &.open {
+        // This should match kOpenObjectListPanelWidth
         flex: 0 0 170px;
         background-color: $workspace-teal-light-9;
       }
 
       &.closed {
-        // See kReadOnlyOffset
+        // kClosedObjectListPanelWidth is this plus 3px border width
         flex: 0 0 26px;
 
         button {

--- a/src/plugins/drawing/components/drawing-tile.test.tsx
+++ b/src/plugins/drawing/components/drawing-tile.test.tsx
@@ -179,7 +179,6 @@ describe("DrawingToolComponent", () => {
 
     // Content already has a square in it from previous test.
     content.addAndSelectObject(rectangleSnapshot);
-    screen.getByLabelText("Open show/sort panel").click();
     let items = within(screen.getByTestId("object-list-view")).getAllByRole("listitem");
     expect(items).toHaveLength(2);
     expect(items[0]).toContainHTML("Rectangle");

--- a/src/plugins/drawing/components/drawing-tile.tsx
+++ b/src/plugins/drawing/components/drawing-tile.tsx
@@ -25,6 +25,7 @@ import { NavigatorDirection } from "../../../models/tiles/navigatable-tile-model
 import { BoundingBox } from "../model/drawing-basic-types";
 import { TileNavigatorContext } from "../../../components/tiles/hooks/use-tile-navigator-context";
 import { ObjectBoundingBox } from "../../../models/annotations/clue-object";
+import { kClosedObjectListPanelWidth, kOpenObjectListPanelWidth } from "../model/drawing-types";
 
 import "./drawing-tile.scss";
 
@@ -178,12 +179,7 @@ const DrawingToolComponent: React.FC<IDrawingTileProps> = observer(function Draw
   };
 
   const getObjectListPanelWidth = () => {
-    if (drawingToolElement.current) {
-      const objectListElement = drawingToolElement.current.querySelector<HTMLDivElement>('div.object-list');
-      return objectListElement ? objectListElement.offsetWidth : 0;
-    } else {
-      return 0;
-    }
+    return contentRef.current.listViewOpen ? kOpenObjectListPanelWidth : kClosedObjectListPanelWidth;
   };
 
   const getVisibleCanvasSize = () => {

--- a/src/plugins/drawing/components/drawing-tile.tsx
+++ b/src/plugins/drawing/components/drawing-tile.tsx
@@ -24,8 +24,10 @@ import { TileNavigator } from "../../../components/tiles/tile-navigator";
 import { NavigatorDirection } from "../../../models/tiles/navigatable-tile-model";
 import { BoundingBox } from "../model/drawing-basic-types";
 import { TileNavigatorContext } from "../../../components/tiles/hooks/use-tile-navigator-context";
+import { ObjectBoundingBox } from "../../../models/annotations/clue-object";
 
 import "./drawing-tile.scss";
+
 export interface IDrawingTileProps extends ITileProps {
   overflowVisible?: boolean;
 }
@@ -58,12 +60,11 @@ const DrawingToolComponent: React.FC<IDrawingTileProps> = observer(function Draw
       exportContentAsTileJson: (options?: ITileExportOptions) => {
         return contentRef.current.exportJson(options);
       },
-      getObjectBoundingBox(objectId, objectType) {
+      getObjectBoundingBox(objectId, objectType): ObjectBoundingBox | undefined {
         const bbPadding = 5;
-        const object = contentRef.current.objectMap[objectId];
+        const bb = contentRef.current.getObjectBoundingBox(objectId);
         const zoom = contentRef.current.zoom;
-        if (object) {
-          const bb = object.boundingBox;
+        if (bb) {
           const height = (bb.se.y - bb.nw.y + bbPadding * 2) * zoom;
           const width = (bb.se.x - bb.nw.x + bbPadding * 2) * zoom;
           const left = (bb.nw.x - bbPadding) * zoom + getObjectListPanelWidth();

--- a/src/plugins/drawing/components/object-list-view.tsx
+++ b/src/plugins/drawing/components/object-list-view.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { observer } from "mobx-react";
 import classNames from "classnames";
 import { DndContext, DragEndEvent, KeyboardSensor, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
@@ -28,7 +28,6 @@ interface IObjectListViewProps {
 
 export const ObjectListView = observer(function ObjectListView({model, setHoverObject}: IObjectListViewProps) {
 
-  const [open, setOpen] = useState(false);
   const sensors = useSensors(
     useSensor(PointerSensor),
     useSensor(KeyboardSensor, {
@@ -41,11 +40,11 @@ export const ObjectListView = observer(function ObjectListView({model, setHoverO
   }
 
   function handleOpen() {
-    setOpen(true);
+    getContent().setListViewOpen(true);
   }
 
   function handleClose() {
-    setOpen(false);
+    getContent().setListViewOpen(false);
   }
 
   function handleDragEnd(event: DragEndEvent) {
@@ -56,7 +55,7 @@ export const ObjectListView = observer(function ObjectListView({model, setHoverO
     }
   }
 
-  if (open) {
+  if (getContent().listViewOpen) {
     const content = getContent();
     const selection = content.selection;
     const objectIdList = content.objects.map((obj)=>obj.id).reverse();

--- a/src/plugins/drawing/model/drawing-content.ts
+++ b/src/plugins/drawing/model/drawing-content.ts
@@ -58,6 +58,7 @@ export const DrawingContentModel = NavigatableTileModel
     selectedButton: "select",
     selection: [] as string[],
     openPallette: OpenPaletteValues.None as OpenPaletteValues,
+    listViewOpen: false,
   }))
   .views(self => ({
     get objectMap(): ObjectMap {
@@ -213,6 +214,10 @@ export const DrawingContentModel = NavigatableTileModel
 
     setOpenPalette(pallette: OpenPaletteValues) {
       self.openPallette = pallette;
+    },
+
+    setListViewOpen(open: boolean) {
+      self.listViewOpen = open;
     },
 
     addObject(object: DrawingObjectSnapshotForAdd, addAtBack=false) {

--- a/src/plugins/drawing/model/drawing-types.ts
+++ b/src/plugins/drawing/model/drawing-types.ts
@@ -9,7 +9,9 @@ export const kDrawingStateVersion = "1.1.0";
 export const kDrawingDefaultHeight = 180;
 export const kDuplicateOffset = 10; // Pixels between original and duplicated object
 export const kFlipOffset = 10; // Pixels between original and flipped object
-export const kReadOnlyOffset = 29; // Pixels to shift read-only tile content (width+border of Show/Sort sidebar)
+
+export const kClosedObjectListPanelWidth = 29; // Size of the Show/Sort sidebar when closed
+export const kOpenObjectListPanelWidth = 170; // Size of the Show/Sort sidebar when open
 
 // These types are used by legacy import code in drawing-change-playback.ts
 export type DrawingToolMove = Array<{id: string, destination: Point}>;

--- a/src/plugins/drawing/model/drawing-utils.ts
+++ b/src/plugins/drawing/model/drawing-utils.ts
@@ -41,7 +41,7 @@ export function rotatePoint(point: {x: number, y: number}, center: {x: number, y
   };
 }
 
-export function boundingBoxForPoints(points: {x: number, y: number}[]): BoundingBoxSides {
+export function boundingBoxSidesForPoints(points: {x: number, y: number}[]): BoundingBoxSides {
   const minX = Math.min(...points.map(p => p.x));
   const maxX = Math.max(...points.map(p => p.x));
   const minY = Math.min(...points.map(p => p.y));
@@ -89,7 +89,7 @@ export function rotateBoundingBox(boundingBox: BoundingBox, rotation: number): B
   const rotatedSE = se; //rotatePoint(se, se, rotation);
   const rotatedSW = rotatePoint(sw, se, rotation);
   // Find min/max x and y
-  const boundingSides = boundingBoxForPoints([rotatedNW, rotatedNE, rotatedSE, rotatedSW]);
+  const boundingSides = boundingBoxSidesForPoints([rotatedNW, rotatedNE, rotatedSE, rotatedSW]);
   return {
     nw: { x: boundingSides.left, y: boundingSides.top },
     se: { x: boundingSides.right, y: boundingSides.bottom }

--- a/src/plugins/drawing/objects/drawing-object.tsx
+++ b/src/plugins/drawing/objects/drawing-object.tsx
@@ -5,7 +5,7 @@ import { SelectionBox } from "../components/selection-box";
 import { BoundingBox, BoundingBoxSides, Point, ToolbarSettings }
    from "../model/drawing-basic-types";
 import { StampModelType } from "../model/stamp";
-import { boundingBoxForPoints, normalizeRotation, rotateBoundingBox,
+import { boundingBoxSidesForPoints, normalizeRotation, rotateBoundingBox,
   rotatePoint, rotationPoint } from "../model/drawing-utils";
 
 import ErrorIcon from "../../../assets/icons/error.svg";
@@ -196,7 +196,7 @@ export const DrawingObject = types.model("DrawingObject", {
     const rotatedNE = rotatePoint(ne, center, -self.rotation);
     const rotatedSE = rotatePoint(se, center, -self.rotation);
     const rotatedSW = rotatePoint(sw, center, -self.rotation);
-    const trueBoundingBox = boundingBoxForPoints([rotatedNW, rotatedNE, rotatedSE, rotatedSW]);
+    const trueBoundingBox = boundingBoxSidesForPoints([rotatedNW, rotatedNE, rotatedSE, rotatedSW]);
     self.setUnrotatedDragBounds(trueBoundingBox);
   },
 }))

--- a/src/plugins/drawing/objects/group.tsx
+++ b/src/plugins/drawing/objects/group.tsx
@@ -41,7 +41,6 @@ export const GroupObject = SizedObject.named("GroupObject")
      */
     adjustInternalBoundingBox(internalBB: BoundingBox): BoundingBox {
       const groupBB = self.unrotatedBoundingBox;
-      console.log("adjustInternalBoundingBox -- group", self.id, groupBB);
       const groupWidth = groupBB.se.x - groupBB.nw.x;
       const groupHeight = groupBB.se.y - groupBB.nw.y;
       const groupRotation = self.rotation;


### PR DESCRIPTION
CLUE-172

Updates the `getObjectBoundingBox` method of the drawing tile to find correct bounding boxes for objects that are in groups. One method was moved from the `actions` section to the `views` section of the model since the incorrect placement was preventing mobx reactivity from working. 

Updates the `annotatableObjects` method to list objects inside groups, but not the groups themselves (matches requested UX where groups are not themselves considered annotatable).

Also fixes Sparrow endpoints when the "Show/Sort" panel is opened. To enable this reaction, the state variable representing whether the panel is open was moved to a volatile property of the drawing content. The width of the open panel was also previously determined dynamically but is now stored as a constant, which parallels how the width of the closed panel was represented by a constant. Without this change, at the point that the volatile property was updated, the DOM had not yet been changed so the full width could not be determined.
