### PR TITLE
Make sure teacher styling is shown in the CMS

### DIFF
--- a/docs/cms.md
+++ b/docs/cms.md
@@ -74,6 +74,8 @@ With this approach you'll be editing the content in the `clue-curriculum` reposi
 
 If you want to have more local access to the curriculum you are editing, and you don't want to be updating the `clue-curriculum` repository, you can use the `localCMSBackend` parameter. See above for details on how to use this. Note the proxy needs to be on its own port. If it can't start on 8081 (because the cms is running there) then you'll need to configure it. See the "Configure the Decap CMS proxy server port number" section of [this Decap documentation page](https://decapcms.org/docs/working-with-a-local-git-repository).
 
+When the CMS loads the unit it will look for it at: `https://models-resources.concord.org/clue-curriculum/branch/[curriculumBranch]/msa/content.json`. This unit file is just used to figure out the tools that should be enabled in the document editors the CMS shows. Importantly, it is not loading it directly from Git. This means that your curriculumBranch needs to be pushed and deployed before the CMS will work. This is required even when working with a local git repository. Passing a full url for the unit does not work; it seems to cause other problems.
+
 ### Remote build
 
 In the CI (github actions), the toplevel `npm run build` is used. This will build both CLUE and the CMS. And then it will copy the files from `/cms/dist` to `/dist/cms`. Additionally, it copies the file `/cms/dist/admin.html` to `/dist/admin.html`. This admin.html file refers to its resources in the cms folder like `cms/admin.js` and `cms/admin.css`. This file is called `admin.html` because that was its original name, and now various authors have direct links to it. So we don't want to change that name.

--- a/src/components/document/tile-row.tsx
+++ b/src/components/document/tile-row.tsx
@@ -185,7 +185,6 @@ const TileRowComponent = forwardRef<TileRowHandle, IProps>((props, ref) => {
             indexInRow={index}
             model={tileModel}
             widthPct={tileWidthPct}
-            typeClass={typeClass}
             height={tileHeight}
             isUserResizable={!readOnly && model.isUserResizable}
             onResizeRow={handleStartResizeRow}
@@ -200,7 +199,7 @@ const TileRowComponent = forwardRef<TileRowHandle, IProps>((props, ref) => {
         />
         : null;
     });
-  }, [props, getTile, getTileWidth, typeClass, readOnly, model.isUserResizable,
+  }, [props, getTile, getTileWidth, readOnly, model.isUserResizable,
     handleStartResizeRow, handleSetCanAcceptDrop, handleRequestRowHeight]);
 
   const renderDragDropHandles = useCallback(() => {

--- a/src/components/tiles/tile-component.scss
+++ b/src/components/tiles/tile-component.scss
@@ -13,45 +13,6 @@
     border: 1px solid white;
   }
 
-  &.problem-panel {
-    &.readonly {
-      border: 1px solid white;
-
-      .tile-content {
-        border: 1px solid white;
-      }
-
-      &.hovered {
-        border: 1px solid rgba(191, 191, 191, 0.5);
-        .tile-content.hovered {
-          border: 1px solid rgba(191, 191, 191, 0.5);
-        }
-      }
-
-      &.selected {
-        border: 1px solid $charcoal-light-2;
-        .tile-content.selected {
-          border: 1px solid $charcoal-light-2;
-        }
-      }
-    }
-
-    &.teacher, &.teacher.readonly {
-      background-color: $learninglog-green-light-8;
-      margin: 5px 0 10px 20px;
-      padding: 10px;
-      border-left: $half-border-width solid $learninglog-green;
-      border-right: 0;
-      border-top: 0;
-      border-bottom: 0;
-
-      .tile-content {
-        border: 0;
-        background-color: $learninglog-green-light-8;
-      }
-    }
-  }
-
   &.readonly, &.readonly.hovered {
     border: 1px solid $tool-tile-readonly-border-color;
     .tile-content {
@@ -143,6 +104,49 @@
 
     &:focus {
       outline: none;
+    }
+  }
+}
+
+// Only show the teacher styling when the tile is inside of the
+// problem panel or when it is inside of the CMS (iframe-control)
+.problem-panel, .iframe-control {
+  .tool-tile {
+    &.readonly {
+      border: 1px solid white;
+
+      .tile-content {
+        border: 1px solid white;
+      }
+
+      &.hovered {
+        border: 1px solid rgba(191, 191, 191, 0.5);
+        .tile-content.hovered {
+          border: 1px solid rgba(191, 191, 191, 0.5);
+        }
+      }
+
+      &.selected {
+        border: 1px solid $charcoal-light-2;
+        .tile-content.selected {
+          border: 1px solid $charcoal-light-2;
+        }
+      }
+    }
+
+    &.teacher {
+      background-color: $learninglog-green-light-8;
+      margin: 5px 0 10px 20px;
+      padding: 10px;
+      border-left: $half-border-width solid $learninglog-green;
+      border-right: 0;
+      border-top: 0;
+      border-bottom: 0;
+
+      .tile-content {
+        border: 0;
+        background-color: $learninglog-green-light-8;
+      }
     }
   }
 }

--- a/src/components/tiles/tile-component.tsx
+++ b/src/components/tiles/tile-component.tsx
@@ -69,7 +69,6 @@ interface ITileBaseProps {
   indexInRow?: number;
   model: ITileModel;
   readOnly?: boolean;
-  typeClass?: string;
   onResizeRow: (e: React.DragEvent<HTMLDivElement>) => void;
   onSetCanAcceptDrop: (tileId?: string) => void;
   onRequestRowHeight: (tileId: string, height?: number, deltaHeight?: number) => void;
@@ -202,14 +201,14 @@ export class TileComponent extends BaseComponent<IProps, IState> {
   }
 
   public render() {
-    const { model, readOnly, isUserResizable, widthPct, typeClass } = this.props;
+    const { model, readOnly, isUserResizable, widthPct } = this.props;
     const { hoverTile } = this.state;
     const { appConfig, ui, persistentUI } = this.stores;
     const { Component, tileEltClass } = getTileComponentInfo(model.content.type) || {};
     const isPlaceholderTile = Component === PlaceholderTileComponent;
     const isTileSelected = ui.isSelectedTile(model);
     const tileSelectedForComment = isTileSelected && persistentUI.showChatPanel;
-    const classes = classNames("tool-tile", model.display, tileEltClass, typeClass, {
+    const classes = classNames("tool-tile", model.display, tileEltClass, {
       placeholder: isPlaceholderTile,
       readonly: readOnly,
       fixed: model.isFixedPosition,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -57,6 +57,11 @@ module.exports = (env, argv) => {
     context: __dirname, // to automatically find tsconfig.json
     // https://survivejs.com/webpack/building/source-maps/
     devtool: devMode ? 'eval-cheap-module-source-map' : 'source-map',
+    devServer: {
+      headers: {
+        'Access-Control-Allow-Origin': '*'
+      },
+    },
     // Performance: disabling these other entry points had no effect
     // on the devServer start up time
     entry: {


### PR DESCRIPTION
Make sure teacher styling is shown in the CMS.

This removes the passing of the typeClass into the TileComponent. Instead the styling is based on the parent div of the tile component.

Additionally:
- add some more documentation about running the CMS.
- make the webpack server work over CORS which can help when units
are being loaded from a different domain.