### PR TITLE
fix: Update metadata watcher to watch all unit code variants [CLUE-205]

### DIFF
--- a/src/models/stores/curriculum-config.test.ts
+++ b/src/models/stores/curriculum-config.test.ts
@@ -34,6 +34,14 @@ describe("CurriculumConfig", () => {
     expect(config.getUnitBasePath(exampleUnitUrl)).toBe(exampleUnitUrl);
   });
 
+  it("can return unit code variants", () => {
+    const config = getConfig({
+      unitCodeMap: { foo: "bar", bam: "bar", baz: "qux" }
+    });
+    expect(config.getUnitCodeVariants("bar")).toEqual(["bar", "foo", "bam"]);
+    expect(config.getUnitCodeVariants("qux")).toEqual(["qux", "baz"]);
+    expect(config.getUnitCodeVariants("unknown")).toEqual(["unknown"]);
+  });
 });
 
 describe("PortalOfferingParser", () => {

--- a/src/models/stores/curriculum-config.ts
+++ b/src/models/stores/curriculum-config.ts
@@ -75,8 +75,24 @@ export const CurriculumConfig = types
                               ? self.unitCodeMap.get(unitCode)
                               : undefined;
       return mappedUnitCode || unitCode;
+    },
+
+    /**
+     * Returns the unit code, plus all the unit code variants for renamed unit codes.
+     * So "sas" will return ["sas", "s s", "s+s", "stretching-and-shrinking"]
+     */
+    getUnitCodeVariants(unitId: string) {
+      const variantsSet = new Set<string>([unitId]);
+      self.unitCodeMap.forEach((value, key) => {
+        if (value === unitId) {
+          variantsSet.add(key);
+        }
+      });
+      return Array.from(variantsSet);
     }
   }));
+
+export type CurriculumConfigType = typeof CurriculumConfig.Type;
 
 export interface ICurriculumConfig extends Instance<typeof CurriculumConfig> {}
 export interface ICurriculumConfigSnapshot extends SnapshotIn<typeof CurriculumConfig> {}
@@ -95,4 +111,3 @@ export function getProblemOrdinal(url: string) {
     ? queryParams.query.problem as string
     : undefined;
 }
-

--- a/src/models/stores/sorted-documents.ts
+++ b/src/models/stores/sorted-documents.ts
@@ -25,6 +25,7 @@ import { DocumentGroup } from "./document-group";
 import { getTileContentInfo } from "../tiles/tile-content-info";
 import { PrimarySortType } from "./ui-types";
 import { IArrowAnnotation } from "../annotations/arrow-annotation";
+import { CurriculumConfigType } from "./curriculum-config";
 
 export type SortedDocumentsMap = Record<string, DocumentGroup[]>;
 
@@ -42,6 +43,7 @@ export interface ISortedDocumentsStores {
   appConfig: AppConfigModelType;
   bookmarks: Bookmarks;
   user: UserModelType;
+  curriculumConfig: CurriculumConfigType;
 }
 
 /**
@@ -117,6 +119,9 @@ export class SortedDocuments {
   }
   get user() {
     return this.stores.user;
+  }
+  get curriculumConfig() {
+    return this.stores.curriculumConfig;
   }
 
   setDocumentHistoryViewRequest(docKey: string, historyId: string) {
@@ -272,7 +277,9 @@ export class SortedDocuments {
     let filteredQuery = baseQuery;
 
     if (filter !== "All") {
-      filteredQuery = filteredQuery.where("unit" , "==", unit);
+      // an "in" query is used here so that we can find any documents that use unit and
+      // any the older renamed unit codes.
+      filteredQuery = filteredQuery.where("unit" , "in", this.curriculumConfig.getUnitCodeVariants(unit));
     }
     if (filter === "Investigation" || filter === "Problem") {
       filteredQuery = filteredQuery.where("investigation", "==", String(investigation));


### PR DESCRIPTION
This updates the sorted-documents.ts#watchFirestoreMetaDataDocs function to use a new CurriculumConfig#getUnitCodeVariants function that is passed the unit and returns an array that includes that unit plus and old unit names that have been renamed to the passed unit.  This ensures that metadata documents that use older unit names are found.