### PR TITLE
Allow students access to document comments

### DIFF
--- a/cypress/e2e/functional/document_tests/student_chat_spec.js
+++ b/cypress/e2e/functional/document_tests/student_chat_spec.js
@@ -1,0 +1,47 @@
+import ChatPanel from "../../../support/elements/common/ChatPanel";
+
+let chatPanel = new ChatPanel;
+
+function beforeTest(configName) {
+  const queryParams = `${Cypress.config(configName)}`;
+  cy.visit(queryParams);
+  cy.waitForLoad();
+  cy.openTopTab("problems");
+}
+
+context("Chat Panel", () => {
+  it("should be disabled for students in default config", () => {
+    beforeTest("qaConfigSubtabsUnitStudent5");
+    chatPanel.getChatPanelToggle().should('not.exist');
+  });
+
+  it("should be enabled for students in QA config", () => {
+    beforeTest("qaUnitStudent5");
+
+    cy.log('verify chat panel opens and closes');
+    chatPanel.getChatPanelToggle().should('exist');
+    chatPanel.getChatPanelToggle().click();
+    chatPanel.getChatPanelToggle().should('not.exist');
+    chatPanel.getChatPanel().should('exist').should('contain.text', 'Comments');
+    chatPanel.getChatCloseButton().should('exist').click();
+    chatPanel.getChatPanel().should('not.exist');
+    chatPanel.getChatCloseButton().should('not.exist');
+    chatPanel.getChatPanelToggle().should('exist');
+
+    cy.log('verify new comment card exits, card icon exists and Post button is disabled');
+    chatPanel.getChatPanelToggle().click();
+    chatPanel.getCommentCard().should('exist');
+
+    cy.log('verify the comment card and the document are highlighted');
+    chatPanel.verifyProblemCommentClass();
+    chatPanel.getProblemDocumentContent().should('be.visible');
+
+    cy.log('verify the comment card and tile are highlighted and have tile icon');
+    cy.clickProblemResourceTile('introduction');
+    chatPanel.getSelectedCommentThreadHeader().should('exist');
+    chatPanel.getCommentTileTypeIcon().should('exist');
+
+  });
+
+
+});

--- a/docs/unit-configuration.md
+++ b/docs/unit-configuration.md
@@ -31,71 +31,67 @@ If any of these properties are encountered at the top-level of the unit configur
 
 These properties are configurable at the application (built into the code) or the unit level of the curriculum JSON.
 
-```typescript
-  // used in application loading message, log messages, etc.
-  appName: string;
-  // displayed in browser tab/window title
-  pageTitle: string;
-  // used for demo creator links
-  demoProblemTitle: string;
-  // default problem to load if none specified
-  defaultProblemOrdinal: string;
-  // disable grouping of students (e.g. Dataflow)
-  autoAssignStudentsToIndividualGroups: boolean;
-  // type of user document to create/show by default
-  defaultDocumentType: "problem" | "personal";
-  // default title of personal documents (problem documents don't have user-assigned titles)
-  defaultDocumentTitle: string;
-  // following two properties used for displaying titles for documents
-  docTimeStampPropertyName: string;
-  docDisplayIdPropertyName: string;
-  // default title of learning log documents
-  defaultLearningLogTitle: string;
-  // overrides `defaultLearningLogTitle`; not clear why both are required
-  initialLearningLogTitle: string;
-  // whether to create an initial/default learning log document for each user
-  defaultLearningLogDocument: boolean;
-  // whether to automatically divide problem documents into sections
-  autoSectionProblemDocuments: boolean;
-  // array of property names to use when constructing document labels
-  documentLabelProperties: string[];
-  // terminology for referencing documents
-  documentLabels: Record<string, SnapshotIn<typeof DocumentLabelModel>>;
-  // disables publishing documents of particular types or with particular properties
-  disablePublish: Array<SnapshotIn<typeof DocumentSpecModel>> | boolean;
-  // enable/disable showing the history-scrubbing controls for users in different roles
-  enableHistoryRoles: Array<"student" | "teacher" | "researcher">;
-  // configures naming of copied documents
-  copyPreferOriginTitle: boolean;
-  // enable/disable dragging of tiles
-  disableTileDrags: boolean;
-  // show the class switcher menu for teachers
-  showClassSwitcher: boolean;
-  // whether to show one-up/two-up view icons in document title bar
-  supportStackedTwoUpView: boolean;
-  // whether to show published (non-editable) documents in the editing workspace
-  showPublishedDocsInPrimaryWorkspace: boolean;
-  // comparison view placeholder content
-  comparisonPlaceholderContent: string | string[];
-  // Whether exemplars are hidden from students by default, becoming visible based on conditions
-  initiallyHideExemplars: boolean;
-  // configuration of navigation tabs (document navigation UI)
-  navTabs: SnapshotIn<typeof NavTabsConfigModel>;
+`appName`: (string) used in application loading message, log messages, etc.
 
-  // must be true for any of the comment-tag functionality to be enabled
-  showCommentTag?: boolean;
-  // prompt shown in the tagging pulldown menu when a comment is being made
-  tagPrompt?: string;
-  // list of possible values for tagging in comments
-  commentTags?: Record<string, string>;
-  // If set, enable the specified AI evaluation to run after document updates
-  // At the moment, there is only one evaluation pipeline defined.
-  aiEvaluation?: "categorize-design";
+`pageTitle`: (string) displayed in browser tab/window title
 
-  // List of the types of annotations supported (eg "curved-sparrow") or "all" or "none"
-  // Currently any value other than "none" will be treated as "all".
-  annotations?: "all" | "none" | string[];
-```
+`demoProblemTitle`: (string) used for demo creator links
+
+`defaultProblemOrdinal`: (string) default problem to load if none specified
+
+`autoAssignStudentsToIndividualGroups`: (boolean) disable grouping of students (e.g. Dataflow)
+
+`defaultDocumentType`: ("problem" | "personal") type of user document to create/show by default
+
+`defaultDocumentTitle`: (string) default title of personal documents (problem documents don't have user-assigned titles)
+
+`docTimeStampPropertyName`: (string) used for displaying titles for documents
+
+`docDisplayIdPropertyName`: (string) used for displaying titles for documents
+
+`defaultLearningLogTitle`: (string) default title of learning log documents
+
+`initialLearningLogTitle`: (string) overrides `defaultLearningLogTitle`; not clear why both are required
+
+`defaultLearningLogDocument`: (boolean) whether to create an initial/default learning log document for each user
+
+`autoSectionProblemDocuments`: (boolean) whether to automatically divide problem documents into sections
+
+`documentLabelProperties`: (string[]) array of property names to use when constructing document labels
+
+`documentLabels`: (object) terminology for referencing documents
+
+`disablePublish`: (boolean or array) disables publishing documents of particular types or with particular properties
+
+`enableHistoryRoles`: (array of "student" | "teacher" | "researcher") enable/disable showing the history-scrubbing controls for users in different roles
+
+`copyPreferOriginTitle`: (boolean) configures naming of copied documents
+
+`disableTileDrags`: (boolean) enable/disable dragging of tiles
+
+`showClassSwitcher`: (boolean) show the class switcher menu for teachers
+
+`supportStackedTwoUpView`: (boolean) whether to show one-up/two-up view icons in document title bar
+
+`showPublishedDocsInPrimaryWorkspace`: (boolean) whether to show published (non-editable) documents in the editing workspace
+
+`comparisonPlaceholderContent`: (string | string[]) comparison view placeholder content
+
+`initiallyHideExemplars`: (boolean) Whether exemplars are hidden from students by default, becoming visible based on conditions
+
+`navTabs`: (object) configuration of navigation tabs (document navigation UI)
+
+`enableCommentRoles`: (array of "student" | "teacher" | "researcher") list of roles that can use the comments panel
+
+`showCommentTag`: (boolean) must be true for any of the comment-tag functionality to be enabled
+
+`tagPrompt`: (string) prompt shown in the tagging pulldown menu when a comment is being made
+
+`commentTags`: (object) list of possible values for tagging in comments
+
+`aiEvaluation`: ("categorize-design") If set, enable the specified AI evaluation to run after document updates. At the moment, there is only one evaluation pipeline defined.
+
+`annotations`: ("all" | "none" | string[]) List of the types of annotations supported (eg "curved-sparrow") or "all" or "none". Currently any value other than "none" will be treated as "all".
 
 ## Unit- or Problem-level `config` properties
 

--- a/firebase-test/src/setup-rules-tests.ts
+++ b/firebase-test/src/setup-rules-tests.ts
@@ -10,6 +10,7 @@ export const otherClass = "other-class";
 export const lastClass = "last-class";
 export const studentIdNumeric = 1;
 export const studentId = `${studentIdNumeric}`;
+export const studentName = "Sam Student";
 export const studentAuth = { uid: studentId, platform_user_id: studentIdNumeric, user_type: "student", class_hash: thisClass };
 export const student2IdNumeric = 2;
 export const student2Id = `${student2IdNumeric}`;

--- a/firestore.rules
+++ b/firestore.rules
@@ -419,15 +419,17 @@ service cloud.firestore {
         function userOwnsDocument() {
           return getDocumentOwner() == string(request.auth.token.platform_user_id);
         }
+
+        function hasDocumentAccess() {
+          return teacherCanAccessDocument() || researcherCanAccessDocument() || userCanAccessDocument();
+        }
+
         match /comments/{commentId} {
-          // portal-authenticated teachers with access to the document can create valid comments
-          allow create: if (teacherCanAccessDocument() || researcherCanAccessDocument()) && isValidCommentCreateRequest();
-          // teachers can only update their own comments and only if they're valid
-          allow update: if (teacherCanAccessDocument() || researcherCanAccessDocument()) && isValidCommentUpdateRequest();
-          // teachers can only delete their own comments
-          allow delete: if (teacherCanAccessDocument() || researcherCanAccessDocument()) && userIsResourceUser();
-          // only teachers that "own" the document can read the comments (for now)
-          allow read: if teacherCanAccessDocument() || researcherCanAccessDocument();
+          // Any user with access to the document can read or create comments and make valid update/delete requests
+          allow create: if hasDocumentAccess() && isValidCommentCreateRequest();
+          allow update: if hasDocumentAccess() && isValidCommentUpdateRequest();
+          allow delete: if hasDocumentAccess() && userIsResourceUser();
+          allow read: if hasDocumentAccess();
         }
 
         // For writing individual history entries

--- a/src/clue/app-config.json
+++ b/src/clue/app-config.json
@@ -35,6 +35,7 @@
       }
     },
     "disablePublish": [],
+    "enableCommentRoles": ["teacher", "researcher"],
     "enableHistoryRoles": ["student", "teacher"],
     "copyPreferOriginTitle": false,
     "disableTileDrags": false,

--- a/src/components/document/document-content.tsx
+++ b/src/components/document/document-content.tsx
@@ -149,8 +149,8 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
 
   public render() {
     const { viaTeacherDashboard } = this.props;
-    const { ui, persistentUI, user } = this.stores;
-    const isChatEnabled = user.isTeacherOrResearcher;
+    const { ui, persistentUI, user, appConfig } = this.stores;
+    const isChatEnabled = appConfig.showCommentPanelFor(user.type);
     const documentSelectedForComment = isChatEnabled && persistentUI.showChatPanel && ui.selectedTileIds.length === 0
                                           && persistentUI.focusDocument;
     const documentClass = classNames(

--- a/src/components/document/editable-document-content.tsx
+++ b/src/components/document/editable-document-content.tsx
@@ -79,13 +79,13 @@ export function EditableDocumentContent({
   className, contained, mode, isPrimary, document, toolbar, readOnly, showPlayback, fullHeight, sectionClass
 }: IProps) {
   const documentContext = useDocumentContext(document);
-  const { db: { firebase, firestore }, ui, persistentUI, user } = useStores();
+  const { db: { firebase, firestore }, ui, persistentUI, user, appConfig } = useStores();
   // set by the canvas and used by the toolbar
   const editableTileApiInterfaceRef: EditableTileApiInterfaceRef = useRef(null);
   const isReadOnly = !isPrimary || readOnly || document.isPublished;
   const isShowingToolbar = toolbar?.length;
   const showToolbarClass = isShowingToolbar ? "show-toolbar" : "hide-toolbar";
-  const isChatEnabled = user.isTeacherOrResearcher;
+  const isChatEnabled = appConfig.showCommentPanelFor(user.type);
   const documentSelectedForComment = isChatEnabled && persistentUI.showChatPanel
                                      && ui.selectedTileIds.length === 0 && !isPrimary;
   const editableDocContentClass = classNames("editable-document-content", showToolbarClass, sectionClass,

--- a/src/components/navigation/nav-tab-panel.tsx
+++ b/src/components/navigation/nav-tab-panel.tsx
@@ -33,10 +33,10 @@ export class NavTabPanel extends BaseComponent<IProps> {
 
   public render() {
     const { persistentUI: { activeNavTab, focusDocument, showChatPanel }, ui: { selectedTileIds },
-            user } = this.stores;
+            user, appConfig } = this.stores;
     const tabs = this.stores.tabsToDisplay;
     const selectedTabIndex = tabs?.findIndex(t => t.tab === activeNavTab);
-    const isChatEnabled = user.isTeacherOrResearcher; //only enable chat for teachers or researchers
+    const isChatEnabled = appConfig.showCommentPanelFor(user.type);
     const openChatPanel = isChatEnabled && showChatPanel;
     const focusTileId = selectedTileIds?.length === 1 ? selectedTileIds[0] : undefined;
 

--- a/src/models/stores/app-config-model.ts
+++ b/src/models/stores/app-config-model.ts
@@ -164,7 +164,6 @@ export const AppConfigModel = types
       return self.placeholder?.[key];
     },
     showCommentPanelFor(userType: "student" | "teacher" | "researcher" | undefined) {
-      console.log("showCommentPanelFor", userType, self.enableCommentRoles);
       return userType && self.enableCommentRoles.includes(userType);
     }
 

--- a/src/models/stores/app-config-model.ts
+++ b/src/models/stores/app-config-model.ts
@@ -76,6 +76,7 @@ export const AppConfigModel = types
     get documentLabels() { return self.configMgr.documentLabels; },
     get disablePublish() { return self.configMgr.disablePublish; },
     get enableHistoryRoles() { return self.configMgr.enableHistoryRoles; },
+    get enableCommentRoles() { return self.configMgr.enableCommentRoles; },
     get copyPreferOriginTitle() { return self.configMgr.copyPreferOriginTitle; },
     get disableTileDrags() { return self.configMgr.disableTileDrags; },
     get showClassSwitcher() { return self.configMgr.showClassSwitcher; },
@@ -161,6 +162,10 @@ export const AppConfigModel = types
     getPlaceholder(containerType: string) {
       const key = (containerType === undefined || containerType === "DocumentContent") ? "default" : containerType;
       return self.placeholder?.[key];
+    },
+    showCommentPanelFor(userType: "student" | "teacher" | "researcher" | undefined) {
+      console.log("showCommentPanelFor", userType, self.enableCommentRoles);
+      return userType && self.enableCommentRoles.includes(userType);
     }
 
   }));

--- a/src/models/stores/app-config-model.ts
+++ b/src/models/stores/app-config-model.ts
@@ -6,6 +6,7 @@ import { NavTabsConfigModel } from "./nav-tabs";
 import { ToolbarModel } from "./problem-configuration";
 import { SettingsGroupMstType } from "./settings";
 import { DocumentLabelModel, UnitConfiguration } from "./unit-configuration";
+import { UserType } from "./user-types";
 
 interface IMyResourcesToolbarOptions {
   showEdit?: boolean;
@@ -163,7 +164,7 @@ export const AppConfigModel = types
       const key = (containerType === undefined || containerType === "DocumentContent") ? "default" : containerType;
       return self.placeholder?.[key];
     },
-    showCommentPanelFor(userType: "student" | "teacher" | "researcher" | undefined) {
+    showCommentPanelFor(userType: UserType | undefined) {
       return userType && self.enableCommentRoles.includes(userType);
     }
 

--- a/src/models/stores/configuration-manager.ts
+++ b/src/models/stores/configuration-manager.ts
@@ -107,6 +107,10 @@ export class ConfigurationManager implements UnitConfiguration {
     return this.getProp<UC["enableHistoryRoles"]>("enableHistoryRoles");
   }
 
+  get enableCommentRoles() {
+    return this.getProp<UC["enableCommentRoles"]>("enableCommentRoles");
+  }
+
   get copyPreferOriginTitle() {
     return this.getProp<UC["copyPreferOriginTitle"]>("copyPreferOriginTitle");
   }

--- a/src/models/stores/unit-configuration.ts
+++ b/src/models/stores/unit-configuration.ts
@@ -65,6 +65,8 @@ export interface UnitConfiguration extends ProblemConfiguration {
   disablePublish: Array<SnapshotIn<typeof DocumentSpecModel>> | boolean;
   // enable/disable showing the history-scrubbing controls for users in different roles
   enableHistoryRoles: Array<"student" | "teacher" | "researcher">;
+  // list of roles that can use the comments panel
+  enableCommentRoles: Array<"student" | "teacher" | "researcher">;
   // configures naming of copied documents
   copyPreferOriginTitle: boolean;
   // enable/disable dragging of tiles

--- a/src/public/demo/units/qa/content.json
+++ b/src/public/demo/units/qa/content.json
@@ -89,6 +89,7 @@
       {"id": "delete", "title": "Delete", "iconId": "icon-delete-tool", "isTileTool": false}
     ],
     "tools": ["Simulator"],
+    "enableCommentRoles": ["student", "teacher", "researcher"],
     "showCommentTag": true,
     "commentTags": {
       "diverging": "Diverging Designs",


### PR DESCRIPTION
CLUE-163

Adds an app-config setting to enable the comment panel based on the user's role.

Add database rules to allow students access to comments (enables read/write access, which goes beyond this story to enable the later stories in this epic).

Add tests at the database-rules level and Cypress tests.

Update the documentation (including some reformatting)

