### PR TITLE
Copy Questions tiles correctly via toolbar button

### DIFF
--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -317,7 +317,7 @@ export const DocumentContentModel = DocumentContentModelWithTileDragging.named("
     // of their embedded tiles and update their references to them.
     // However, the sorting has the effect of actually putting the Question tiles
     // after other tiles that are getting copied, which is a bug.
-    // TOOD: This loop should be split up so that the actual order of tiles is preserved,
+    // TODO: This loop should be split up so that the actual order of tiles is preserved,
     // while still allowing the references to embedded tiles to be updated.
     const reorderedTiles: IDragTileItem[] = [
       ...tiles.filter(tile => !isContainerTile(tile)),

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -190,10 +190,10 @@ export const DocumentContentModel = DocumentContentModelWithTileDragging.named("
     const targetRowMap = new Map<string, TileRowModelType>();
 
     updatedTiles.forEach(tile => {
-      const {rowId, sectionId} = copySpec.tilePositions[tile.tileId];
+      const { rowId, sectionId } = copySpec.tilePositions[tile.tileId];
       let targetRow = targetRowMap.get(rowId);
       let insertedRowIndex = self.defaultInsertRowIndex;
-      const insertingRow = !targetRow;
+      const insertingRow = !targetRow && !tile.embedded;
 
       if (sectionId) {
         const sectionRows = self.getRowsInSection(sectionId);
@@ -213,13 +213,11 @@ export const DocumentContentModel = DocumentContentModelWithTileDragging.named("
         targetRowMap.set(rowId, targetRow);
       }
 
-      if (targetRow) {
-        self.copyTilesIntoExistingRow([tile], {
-          rowInsertIndex: 0, // this is ignored
-          rowDropId: targetRow.id,
-          rowDropLocation: "right"
-        }, false);
-      }
+      self.copyTilesIntoExistingRow([tile], {
+        rowInsertIndex: 0, // this is ignored
+        rowDropId: targetRow?.id,
+        rowDropLocation: "right"
+      }, false);
     });
   },
 }))
@@ -558,8 +556,10 @@ export const DocumentContentModel = DocumentContentModelWithTileDragging.named("
       entry.tiles.push(newTileId);
     });
   },
-  getCopySpec(tileIds: string[], sectionId?: string): ICopySpec {
-    const tiles = self.getDragTileItems(tileIds);
+  getCopySpec(selectedTileIds: string[], sectionId?: string): ICopySpec {
+    const selectedTiles = self.getDragTileItems(selectedTileIds);
+    const tiles = self.addEmbeddedTilesToDragTiles(selectedTiles);
+    const tileIds = tiles.map(tile => tile.tileId);
     const tilePositions = tileIds.reduce<Record<string, ITileCopyPosition>>((acc, tileId) => {
       const rowId = self.findRowIdContainingTile(tileId)!;
       acc[tileId] = { rowId, sectionId: sectionId ?? self.getSectionIdForTile(tileId) };

--- a/src/models/document/document-content.ts
+++ b/src/models/document/document-content.ts
@@ -312,8 +312,13 @@ export const DocumentContentModel = DocumentContentModelWithTileDragging.named("
     // Clone the tile content and update it with the new shared model ids
     const tileIdMap: Record<string, string> = {};
     const updatedTiles: IDropTileItem[] = [];
-    // We have to process container tiles last, so that we can update them with the
-    // references to their new embedded tiles.
+    // This sorts the tiles to put containers last.
+    // The container (eg Question) tiles can then simply read the updated IDs
+    // of their embedded tiles and update their references to them.
+    // However, the sorting has the effect of actually putting the Question tiles
+    // after other tiles that are getting copied, which is a bug.
+    // TOOD: This loop should be split up so that the actual order of tiles is preserved,
+    // while still allowing the references to embedded tiles to be updated.
     const reorderedTiles: IDragTileItem[] = [
       ...tiles.filter(tile => !isContainerTile(tile)),
       ...tiles.filter(tile => isContainerTile(tile))


### PR DESCRIPTION
CLUE-191

When copying Question tiles via the `copyTilesWithSpec` [pathway](https://github.com/concord-consortium/collaborative-learning/blob/master/docs/tile-creation.md), make sure that tiles embedded within those Question tiles are also brought along. 

Tweak the logic so that extra rows are not inadvertently created for them.

Add a TODO comment about the tile ordering issue.