### PR TITLE
Make table tests less flaky

### DIFF
--- a/cypress/e2e/functional/tile_tests/xy_plot_tool_spec.js
+++ b/cypress/e2e/functional/tile_tests/xy_plot_tool_spec.js
@@ -44,9 +44,7 @@ function beforeTest(params) {
 
 context('XYPlot Tool Tile', function () {
   describe("XYPlot Tool", () => {
-    // TODO: Re-enable this test once the underlying issue is resolved
-    // Skipped due to failing Cypress tests as discussed in Slack
-    it.skip("XYPlot tool tile", () => {
+    it("XYPlot tool tile", () => {
       beforeTest(queryParamsMultiDataset);
       cy.log("Add XY Plot Tile");
       cy.collapseResourceTabs();
@@ -358,7 +356,7 @@ context('XYPlot Tool Tile', function () {
       xyTile.getTile().should('not.exist');
     });
 
-    it.skip("Test adding 2 Y Series", () => {
+    it("Test adding 2 Y Series", () => {
       // Skipped as discussed on Slack - test is failing for reasons we don't understand
       beforeTest(queryParamsMultiDataset);
       cy.log("Add XY Plot Tile");
@@ -415,7 +413,7 @@ context('XYPlot Tool Tile', function () {
       xyTile.getPortalButton().contains("Remove").should("not.exist");
     });
 
-    it.skip("Test linking two datasets", () => {
+    it("Test linking two datasets", () => {
       beforeTest(queryParamsMultiDataset);
       cy.log("Add XY Plot Tile");
       cy.collapseResourceTabs();

--- a/cypress/support/elements/tile/TableToolTile.js
+++ b/cypress/support/elements/tile/TableToolTile.js
@@ -69,22 +69,30 @@ class TableToolTile{
         return cy.get('.rdg-text-editor');
     }
     typeInTableCellXY(row, col, text) {
-      this.getTableCellXY(row, col).click({ scrollBehavior: false });
-      this.getTableCellXY(row, col).should('have.attr', 'aria-selected', 'true');
-      cy.wait(100);
-      this.getTableCellXY(row, col).click({ scrollBehavior: false });
-      return cy.document().within(() => {
-        this.getTableCellEdit().type(`${text}{enter}`, { scrollBehavior: false });
+      this.getTableCellXY(row, col).then($cell => {
+        if ($cell.attr('aria-selected') !== 'true') {
+          this.getTableCellXY(row, col).click({ scrollBehavior: false });
+          this.getTableCellXY(row, col).should('have.attr', 'aria-selected', 'true');
+          cy.wait(100);
+        }
+        this.getTableCellXY(row, col).click({ scrollBehavior: false });
+        cy.document().within(() => {
+          this.getTableCellEdit().type(`${text}{enter}`, { scrollBehavior: false });
+        });
       });
     }
     typeInTableCell(i, text, confirm=true) {
       const confirmation = confirm ? '{enter}' : '';
-      this.getTableCell().eq(i).click({ scrollBehavior: false });
-      this.getTableCell().eq(i).should('have.attr', 'aria-selected', 'true');
-      cy.wait(100);
-      this.getTableCell().eq(i).click({ scrollBehavior: false });
-      return cy.document().within(() => {
-        this.getTableCellEdit().type(`${text}${confirmation}`, { scrollBehavior: false });
+      this.getTableCell().eq(i).then($cell => {
+        if ($cell.attr('aria-selected') !== 'true') {
+          this.getTableCell().eq(i).click({ scrollBehavior: false });
+          this.getTableCell().eq(i).should('have.attr', 'aria-selected', 'true');
+          cy.wait(100);
+        }
+        this.getTableCell().eq(i).click({ scrollBehavior: false });
+        return cy.document().within(() => {
+          this.getTableCellEdit().type(`${text}${confirmation}`, { scrollBehavior: false });
+        });
       });
     }
     getTableCellWithColIndex(colIndex, colValue){

--- a/cypress/support/elements/tile/TableToolTile.js
+++ b/cypress/support/elements/tile/TableToolTile.js
@@ -69,17 +69,18 @@ class TableToolTile{
         return cy.get('.rdg-text-editor');
     }
     typeInTableCellXY(row, col, text) {
-      this.getTableCellXY(row, col).click({ scrollBehavior: false }).should('have.attr', 'aria-selected', 'true');
+      this.getTableCellXY(row, col).click({ scrollBehavior: false });
+      this.getTableCellXY(row, col).should('have.attr', 'aria-selected', 'true');
       cy.wait(100);
       this.getTableCellXY(row, col).click({ scrollBehavior: false });
-      cy.wait(100);
       return cy.document().within(() => {
         this.getTableCellEdit().type(`${text}{enter}`, { scrollBehavior: false });
       });
     }
     typeInTableCell(i, text, confirm=true) {
       const confirmation = confirm ? '{enter}' : '';
-      this.getTableCell().eq(i).click({ scrollBehavior: false }).should('have.attr', 'aria-selected', 'true');
+      this.getTableCell().eq(i).click({ scrollBehavior: false });
+      this.getTableCell().eq(i).should('have.attr', 'aria-selected', 'true');
       cy.wait(100);
       this.getTableCell().eq(i).click({ scrollBehavior: false });
       return cy.document().within(() => {

--- a/cypress/support/elements/tile/TableToolTile.js
+++ b/cypress/support/elements/tile/TableToolTile.js
@@ -68,30 +68,22 @@ class TableToolTile{
     getTableCellEdit(){
         return cy.get('.rdg-text-editor');
     }
-    // Opening a table cell for editing takes two click: one to select, another to edit.
-    // Calling `.dblclick()` can fail since some time is needed between the clicks.
-    openEditor(cell) {
-      cell.as('cellref').then($cell => {
-        // If the cell is not selected, click to select it.
-        if (!$cell.attr('aria-selected') || $cell.attr('aria-selected') === 'false') {
-          cy.wrap($cell).click({ scrollBehavior: 'none' });
-          cy.get('@cellref').should('have.attr', 'aria-selected', 'true');
-        }
-        cy.get('@cellref').click({ scrollBehavior: 'none' });
-        cy.get('@cellref').should('have.class', 'rdg-cell-editing');
-      });
-    }
     typeInTableCellXY(row, col, text) {
-      this.openEditor(this.getTableCellXY(row, col));
+      this.getTableCellXY(row, col).click({ scrollBehavior: false }).should('have.attr', 'aria-selected', 'true');
+      cy.wait(100);
+      this.getTableCellXY(row, col).click({ scrollBehavior: false });
+      cy.wait(100);
       return cy.document().within(() => {
-        this.getTableCellEdit().type(`${text}{enter}`);
+        this.getTableCellEdit().type(`${text}{enter}`, { scrollBehavior: false });
       });
     }
     typeInTableCell(i, text, confirm=true) {
       const confirmation = confirm ? '{enter}' : '';
-      this.openEditor(this.getTableCell().eq(i));
+      this.getTableCell().eq(i).click({ scrollBehavior: false }).should('have.attr', 'aria-selected', 'true');
+      cy.wait(100);
+      this.getTableCell().eq(i).click({ scrollBehavior: false });
       return cy.document().within(() => {
-        this.getTableCellEdit().type(`${text}${confirmation}`);
+        this.getTableCellEdit().type(`${text}${confirmation}`, { scrollBehavior: false });
       });
     }
     getTableCellWithColIndex(colIndex, colValue){


### PR DESCRIPTION
Makes some test changes that should improve the reliability of several cypress tests:
- Add `scrollBehavior: false` to the click events to minimize the chance of the table cell editor rendering in the wrong place. If it renders outside the table cell the edit cannot be completed.
- Do not depend on chaining or caching of DOM elements while doing table edits, since the table tile can get re-rendered and cause those DOM elements to be detached.

Optimistically removes the `skip` from the most problematic tests.