### PR TITLE
Clue 138 table sort marker

### DIFF
--- a/src/components/tiles/table/column-header-cell.scss
+++ b/src/components/tiles/table/column-header-cell.scss
@@ -84,7 +84,7 @@
           }
           .sort.arrow {
             fill: $workspace-teal-dark-1;
-            opacity: 0;
+            opacity: 1;
           }
         }
       }
@@ -99,12 +99,9 @@
           }
           .sort.arrow {
             fill: $workspace-teal-dark-1;
-            opacity: 0;
+            opacity: 1;
           }
         }
-      }
-      &:not(.selected-column) {
-        display: none;
       }
       &:not(.selected-column):hover {
         display: flex;
@@ -152,6 +149,7 @@
           svg {
             .foreground.arrow {
               fill: $workspace-teal-dark-1;
+              opacity: 1;
             }
           }
         }
@@ -215,10 +213,6 @@
             opacity: 0.35;
 
             &.sort.circle {
-              fill: $workspace-teal-dark-1;
-              opacity: 1;
-            }
-            &.arrow {
               fill: $workspace-teal-dark-1;
               opacity: 1;
             }

--- a/src/components/tiles/table/table-tile.tsx
+++ b/src/components/tiles/table/table-tile.tsx
@@ -36,11 +36,6 @@ import { TRow } from "./table-types";
 import "./table-tile.scss";
 import "./table-toolbar-registration";
 
-export interface SortColumn {
-  columnKey: string;
-  direction: 'ASC' | 'DESC';
-}
-
 // observes row selection from shared selection store
 const TableToolComponent: React.FC<ITileProps> = observer(function TableToolComponent({
   documentContent, tileElt, model, readOnly, height, hovered, scale,
@@ -58,7 +53,6 @@ const TableToolComponent: React.FC<ITileProps> = observer(function TableToolComp
   const linkedTiles = content.tileEnv?.sharedModelManager?.getSharedModelTiles(content.sharedModel);
   const isLinked = linkedTiles && linkedTiles.length > 1;
   const tableContextValue: ITableContext = { linked: !!isLinked };
-  const [sortColumns, setSortColumns] = useState<SortColumn[]>([]);
   const [gridElement, setGridElement] = useState<HTMLDivElement | null>(null);
 
   // Basic operations based on the model
@@ -132,20 +126,15 @@ const TableToolComponent: React.FC<ITileProps> = observer(function TableToolComp
     rowChanges, context: gridContext, selectedCaseIds });
 
   const onSort = useCallback((columnKey: string, direction: "ASC" | "DESC" | "NONE") => {
-    if (direction === "NONE") {
-      setSortColumns([]);
-    } else {
-      setSortColumns([{ columnKey, direction }]);
-      dataSet.sortByAttribute(columnKey, direction);
+    if (dataSet) {
+      dataSet.sortCases(columnKey, direction);
     }
   }, [dataSet]);
 
   // columns are required by ReactDataGrid and are used by other hooks as well
   const { columns, controlsColumn, columnEditingName, handleSetColumnEditingName } = useColumnsFromDataSet({
     gridContext, dataSet, isLinked, metadata, readOnly: !!readOnly, columnChanges, headerHeight, rowHeight,
-    ...rowLabelProps, showRowLabels, measureColumnWidth, lookupImage,
-    sortColumns,
-    onSort,
+    ...rowLabelProps, showRowLabels, measureColumnWidth, lookupImage, onSort,
   });
 
   // The size of the title bar

--- a/src/components/tiles/table/use-columns-from-data-set.ts
+++ b/src/components/tiles/table/use-columns-from-data-set.ts
@@ -25,12 +25,11 @@ interface IUseColumnsFromDataSet {
   RowLabelFormatter: React.FC<any>;
   measureColumnWidth: (attr: IAttribute) => number;
   lookupImage: (value: string) => string|undefined;
-  sortColumns?: { columnKey: string, direction: "ASC" | "DESC" }[];
   onSort?: (columnKey: string, direction: "ASC" | "DESC" | "NONE") => void;
 }
 export const useColumnsFromDataSet = ({
   gridContext, dataSet, isLinked, metadata, readOnly, showRowLabels, columnChanges, headerHeight, rowHeight,
-  RowLabelHeader, RowLabelFormatter, measureColumnWidth, lookupImage, sortColumns, onSort
+  RowLabelHeader, RowLabelFormatter, measureColumnWidth, lookupImage, onSort
 }: IUseColumnsFromDataSet) => {
   const { attributes } = dataSet;
 
@@ -70,8 +69,12 @@ export const useColumnsFromDataSet = ({
   }, [readOnly]);
 
   const getSortDirection = useCallback((columnKey: string) => {
-    return sortColumns?.find(col => col.columnKey === columnKey)?.direction ?? "NONE";
-  }, [sortColumns]);
+    // Only return the sort direction if this column is the one being sorted
+    if (dataSet?.sortByAttribute === columnKey) {
+      return dataSet.sortDirection ?? "NONE";
+    }
+    return "NONE";
+  }, [dataSet?.sortByAttribute, dataSet?.sortDirection]);
 
   const ColumnHeaderCell = useColumnHeaderCell({
     height: headerHeight(),

--- a/src/models/data/data-set.test.ts
+++ b/src/models/data/data-set.test.ts
@@ -640,14 +640,14 @@ test("DataSet client synchronization", (done) => {
   src.removeAttribute(src.attributes[0].id);
 });
 
-test("DataSet sortByAttribute handles empty dataset", () => {
+test("DataSet sortCases handles empty dataset", () => {
   const dataset = DataSet.create({ name: "Empty", attributes: [], cases: [] });
   // Should not throw or change anything
-  expect(() => dataset.sortByAttribute("nonexistent")).not.toThrow();
+  expect(() => dataset.sortCases("nonexistent")).not.toThrow();
   expect(dataset.cases.length).toBe(0);
 });
 
-test("DataSet sortByAttribute with missing attribute values", () => {
+test("DataSet sortCases with missing attribute values", () => {
   const dataset = DataSet.create({ name: "Missing", attributes: [], cases: [] });
   const attrA = addAttributeToDataSet(dataset, { id: "a", name: "A", values: [] });
   addCasesToDataSet(dataset, [
@@ -655,12 +655,12 @@ test("DataSet sortByAttribute with missing attribute values", () => {
     { __id__: "2" }, // missing value for A
     { __id__: "3", A: "y" }
   ]);
-  dataset.sortByAttribute(attrA.id, "ASC");
+  dataset.sortCases(attrA.id, "ASC");
   // Case "2" (missing value) should sort before "1" and "3"
   expect(dataset.cases.map(c => c.__id__)).toEqual(["1", "3", "2"]);
 });
 
-test("DataSet sortByAttribute is stable for equal values", () => {
+test("DataSet sortCases is stable for equal values", () => {
   const dataset = DataSet.create({ name: "Stable", attributes: [], cases: [] });
   const attrA = addAttributeToDataSet(dataset, { id: "a", name: "A", values: [] });
   addCasesToDataSet(dataset, [
@@ -668,12 +668,12 @@ test("DataSet sortByAttribute is stable for equal values", () => {
     { __id__: "2", A: "same" },
     { __id__: "3", A: "same" }
   ]);
-  dataset.sortByAttribute(attrA.id, "ASC");
+  dataset.sortCases(attrA.id, "ASC");
   // Order should be preserved
   expect(dataset.cases.map(c => c.__id__)).toEqual(["1", "2", "3"]);
 });
 
-test("DataSet sortByAttribute returns correct index mapping", () => {
+test("DataSet sortCases returns correct index mapping", () => {
   const dataset = DataSet.create({ name: "Mapping", attributes: [], cases: [] });
   const attrA = addAttributeToDataSet(dataset, { id: "a", name: "A", values: [] });
   addCasesToDataSet(dataset, [
@@ -681,7 +681,7 @@ test("DataSet sortByAttribute returns correct index mapping", () => {
     { __id__: "2", A: "a" },
     { __id__: "3", A: "b" }
   ]);
-  const mapping = dataset.sortByAttribute(attrA.id, "ASC");
+  const mapping = dataset.sortCases(attrA.id, "ASC");
   expect(mapping).toEqual({
     "2": { beforeIndex: 1, afterIndex: 0 },
     "3": { beforeIndex: 2, afterIndex: 1 },
@@ -689,7 +689,7 @@ test("DataSet sortByAttribute returns correct index mapping", () => {
   });
 });
 
-test("DataSet sortByAttribute does not mutate attribute values if already sorted", () => {
+test("DataSet sortCases does not mutate attribute values if already sorted", () => {
   const dataset = DataSet.create({ name: "NoMutation", attributes: [], cases: [] });
   const attrA = addAttributeToDataSet(dataset, { id: "a", name: "A", values: [] });
   addCasesToDataSet(dataset, [
@@ -697,6 +697,64 @@ test("DataSet sortByAttribute does not mutate attribute values if already sorted
     { __id__: "2", A: "b" }
   ]);
   const origValues = dataset.attributes[0].values.slice();
-  dataset.sortByAttribute(attrA.id, "ASC");
+  dataset.sortCases(attrA.id, "ASC");
   expect(dataset.attributes[0].values).toEqual(origValues);
+});
+
+test("DataSet sortCases with NONE direction restores original order", () => {
+  const dataset = DataSet.create({ name: "OriginalOrder", attributes: [], cases: [] });
+  const attrA = addAttributeToDataSet(dataset, { id: "a", name: "A", values: [] });
+
+  // Add cases in original order: 1, 2, 3
+  addCasesToDataSet(dataset, [
+    { __id__: "1", A: "c" },
+    { __id__: "2", A: "a" },
+    { __id__: "3", A: "b" }
+  ]);
+
+  const originalOrder = dataset.cases.map(c => c.__id__);
+  expect(originalOrder).toEqual(["1", "2", "3"]);
+
+  // Sort in ascending order: 2, 3, 1
+  dataset.sortCases(attrA.id, "ASC");
+  expect(dataset.cases.map(c => c.__id__)).toEqual(["2", "3", "1"]);
+
+  // Sort with NONE direction should restore original order: 1, 2, 3
+  dataset.sortCases(attrA.id, "NONE");
+  expect(dataset.cases.map(c => c.__id__)).toEqual(["1", "2", "3"]);
+
+  // Sort in descending order: 1, 3, 2
+  dataset.sortCases(attrA.id, "DESC");
+  expect(dataset.cases.map(c => c.__id__)).toEqual(["1", "3", "2"]);
+
+  // Sort with NONE direction should restore original order again: 1, 2, 3
+  dataset.sortCases(attrA.id, "NONE");
+  expect(dataset.cases.map(c => c.__id__)).toEqual(["1", "2", "3"]);
+});
+
+test("DataSet sortCases only affects the specified attribute", () => {
+  const dataset = DataSet.create({ name: "MultipleAttributes", attributes: [], cases: [] });
+  const attrA = addAttributeToDataSet(dataset, { id: "a", name: "A", values: [] });
+  const attrB = addAttributeToDataSet(dataset, { id: "b", name: "B", values: [] });
+
+  // Add cases
+  addCasesToDataSet(dataset, [
+    { __id__: "1", A: "c", B: "x" },
+    { __id__: "2", A: "a", B: "y" },
+    { __id__: "3", A: "b", B: "z" }
+  ]);
+
+  // Sort by attribute A
+  dataset.sortCases(attrA.id, "ASC");
+  expect(dataset.sortByAttribute).toBe(attrA.id);
+  expect(dataset.sortDirection).toBe("ASC");
+
+  // Sort by attribute B - this should change the sortByAttribute to B
+  dataset.sortCases(attrB.id, "DESC");
+  expect(dataset.sortByAttribute).toBe(attrB.id);
+  expect(dataset.sortDirection).toBe("DESC");
+
+  // The cases should now be sorted by attribute B in descending order
+  // B values: x, y, z -> descending order: z, y, x -> case IDs: 3, 2, 1
+  expect(dataset.cases.map(c => c.__id__)).toEqual(["3", "2", "1"]);
 });

--- a/src/models/data/data-set.ts
+++ b/src/models/data/data-set.ts
@@ -45,6 +45,8 @@ export const DataSet = types.model("DataSet", {
   name: types.maybe(types.string),
   attributes: types.array(Attribute),
   cases: types.array(CaseID),
+  sortByAttribute: types.maybe(types.string),
+  sortDirection: types.optional(types.union(types.literal("ASC"), types.literal("DESC"), types.literal("NONE")), "ASC")
 })
 .volatile(self => ({
   // MobX-observable set of selected attribute IDs
@@ -55,7 +57,9 @@ export const DataSet = types.model("DataSet", {
   cellSelection: observable.set<string>(),
   // map from pseudo-case ID to the CaseGroup it represents
   pseudoCaseMap: {} as Record<string, CaseGroup>,
-  transactionCount: 0
+  transactionCount: 0,
+  // Store the original case order to restore when sort direction is "NONE"
+  originalCaseOrder: [] as string[]
 }))
 .views(self => ({
   get isEmpty() {
@@ -688,6 +692,10 @@ export const DataSet = types.model("DataSet", {
           });
           insertCaseIDAtIndex(aCase.__id__, beforeIndex);
         });
+        // Store original case order if not already stored
+        if (self.originalCaseOrder.length === 0) {
+          self.originalCaseOrder = self.cases.map(c => c.__id__);
+        }
       },
 
       addCanonicalCasesWithIDs(cases: ICase[], beforeID?: string | string[]) {
@@ -700,6 +708,11 @@ export const DataSet = types.model("DataSet", {
           });
           newCases.push(insertCaseIDAtIndex(aCase.__id__, beforeIndex));
         });
+
+        // Store original case order if not already stored
+        if (self.originalCaseOrder.length === 0) {
+          self.originalCaseOrder = self.cases.map(c => c.__id__);
+        }
       },
 
       setCaseValues(cases: ICase[], affectedAttributes?: string[]) {
@@ -724,6 +737,13 @@ export const DataSet = types.model("DataSet", {
             });
           }
         });
+
+        // Update original case order to remove deleted cases
+        if (self.originalCaseOrder.length > 0) {
+          self.originalCaseOrder = self.originalCaseOrder.filter(caseId =>
+            !caseIDs.includes(caseId)
+          );
+        }
       },
       moveCase(caseID: string, beforeIndex: number) {
         const srcIndex = self.caseIDMap[caseID];
@@ -750,7 +770,51 @@ export const DataSet = types.model("DataSet", {
           self.cases.replace(finalCaseIds.map(__id__ => ({__id__})));
         }
       },
-      sortByAttribute(attributeId: string, direction: "ASC" |"DESC" = "ASC") {
+      sortCases(attributeId: string, direction: "ASC" |"DESC"|"NONE" = "ASC") {
+        self.sortByAttribute = attributeId;
+        self.sortDirection = direction;
+
+                // If direction is "NONE", restore the original order
+        if (direction === "NONE") {
+          // If we don't have an original order stored, use current order as original
+          if (self.originalCaseOrder.length === 0) {
+            self.originalCaseOrder = self.cases.map(c => c.__id__);
+            return;
+          }
+
+          // Restore original order
+          const restoredCaseIds = [...self.originalCaseOrder];
+          const restoreCaseIdToIndexMap: Record<string, { beforeIndex: number, afterIndex: number }> = {};
+          const currentCaseIds = self.cases.map(c => c.__id__);
+
+          // Create mapping from current positions to original positions
+          currentCaseIds.forEach((caseId, beforeIndex) => {
+            const afterIndex = restoredCaseIds.indexOf(caseId);
+            if (afterIndex !== -1) {
+              restoreCaseIdToIndexMap[caseId] = { beforeIndex, afterIndex };
+            }
+          });
+
+          // Check if we need to reorder
+          if (restoredCaseIds.every((caseId, index) => caseId === self.cases[index].__id__)) {
+            return;
+          }
+
+          // Apply the index mapping to each attribute's value arrays
+          const restoreOrigIndices = restoredCaseIds.map(caseId => restoreCaseIdToIndexMap[caseId]?.beforeIndex ?? 0);
+          self.attributes.forEach(attr => attr.orderValues(restoreOrigIndices));
+
+          // Update the cases array
+          self.cases.replace(restoredCaseIds.map(__id__ => ({__id__})));
+
+          return restoreCaseIdToIndexMap;
+        }
+
+        // For ASC/DESC sorting, store original order if not already stored
+        if (self.originalCaseOrder.length === 0) {
+          self.originalCaseOrder = self.cases.map(c => c.__id__);
+        }
+
         const compareFn = (aItemId: string, bItemId: string) => {
           const aValue = self.getValue(aItemId, attributeId);
           const bValue = self.getValue(bItemId, attributeId);
@@ -977,5 +1041,3 @@ export function getDataSetBounds(dataSet: IDataSet) {
   });
   return result;
 }
-
-

--- a/src/models/data/data-set.ts
+++ b/src/models/data/data-set.ts
@@ -325,6 +325,11 @@ export const DataSet = types.model("DataSet", {
     self.caseSelection.replace(ids);
   }
 
+  function resetSortState() {
+    self.sortDirection = "NONE";
+    self.sortByAttribute = undefined;
+  }
+
   return {
     views: {
       attrFromID(id: string) {
@@ -692,10 +697,8 @@ export const DataSet = types.model("DataSet", {
           });
           insertCaseIDAtIndex(aCase.__id__, beforeIndex);
         });
-        // Store original case order if not already stored
-        if (self.originalCaseOrder.length === 0) {
-          self.originalCaseOrder = self.cases.map(c => c.__id__);
-        }
+        self.originalCaseOrder = self.cases.map(c => c.__id__);
+        resetSortState();
       },
 
       addCanonicalCasesWithIDs(cases: ICase[], beforeID?: string | string[]) {
@@ -708,23 +711,25 @@ export const DataSet = types.model("DataSet", {
           });
           newCases.push(insertCaseIDAtIndex(aCase.__id__, beforeIndex));
         });
+        self.originalCaseOrder = self.cases.map(c => c.__id__);
+        resetSortState();
 
-        // Store original case order if not already stored
-        if (self.originalCaseOrder.length === 0) {
-          self.originalCaseOrder = self.cases.map(c => c.__id__);
-        }
       },
 
       setCaseValues(cases: ICase[], affectedAttributes?: string[]) {
         cases.forEach((caseValues) => {
           setCaseValues(caseValues);
         });
+        self.originalCaseOrder = self.cases.map(c => c.__id__);
+        resetSortState();
       },
 
       setCanonicalCaseValues(cases: ICase[]) {
         cases.forEach((caseValues) => {
           setCanonicalCaseValues(caseValues);
         });
+        self.originalCaseOrder = self.cases.map(c => c.__id__);
+        resetSortState();
       },
 
       removeCases(caseIDs: string[]) {
@@ -744,6 +749,8 @@ export const DataSet = types.model("DataSet", {
             !caseIDs.includes(caseId)
           );
         }
+        self.originalCaseOrder = self.cases.map(c => c.__id__);
+        resetSortState();
       },
       moveCase(caseID: string, beforeIndex: number) {
         const srcIndex = self.caseIDMap[caseID];
@@ -769,6 +776,7 @@ export const DataSet = types.model("DataSet", {
           // update the cases array
           self.cases.replace(finalCaseIds.map(__id__ => ({__id__})));
         }
+        resetSortState();
       },
       sortCases(attributeId: string, direction: "ASC" |"DESC"|"NONE" = "ASC") {
         self.sortByAttribute = attributeId;


### PR DESCRIPTION
Moves the state of the sort marker into the data-set model.
Implements showing the sort direction arrow if a column is sorted. Implements the not sorted state. If a user cycles from ASC->DESC->NONE, then the original case order on load is restored. But if a user edits or adds a new case, the order of the cases at that point is the new "original" order.
If a user adds or edits a case, the sort arrow is removed and is now considered unsorted.
Sort state is restored on reload.
Some undo/redo behavior.