### PR TITLE
upgrade MST

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
       "dependencies": {
         "@chakra-ui/react": "^1.8.9",
         "@concord-consortium/compute-engine": "^0.12.3-cc.2",
-        "@concord-consortium/diagram-view": "1.0.1",
-        "@concord-consortium/mobx-state-tree": "^5.1.8-cc.2",
+        "@concord-consortium/diagram-view": "1.0.2",
+        "@concord-consortium/mobx-state-tree": "^6.0.0-cc.1",
         "@concord-consortium/react-components": "^1.0.0",
         "@concord-consortium/react-modal-hook": "^3.0.0-cc.1",
         "@concord-consortium/slate-editor": "^0.10.1",
@@ -2718,9 +2718,9 @@
       }
     },
     "node_modules/@concord-consortium/diagram-view": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-1.0.1.tgz",
-      "integrity": "sha512-duVqOeyZFcOEMpz9PAZNKJePGFLkQad3hGYcn9d7mFGJ9LaQdQf2D2XMsfoijcKueTWZpyiPr/yUG0ecCOWFnA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-1.0.2.tgz",
+      "integrity": "sha512-RlaTEc8U3v2sXpBicHi4Ka8jafWv9z5vZqGkYGOMiFA+O3yvJtFY7KnFKeIOdVcIVHvGwdvUEDg4Cot0NjBknA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -2734,7 +2734,7 @@
         "reactflow": "^11.7.2"
       },
       "peerDependencies": {
-        "@concord-consortium/mobx-state-tree": "^5.1.8-cc.1",
+        "@concord-consortium/mobx-state-tree": "^5.1.8-cc.1 || ^6.0.0-cc.1",
         "mobx": "^6.4.2",
         "mobx-react-lite": "^3.3.0",
         "nanoid": "^3.3.1",
@@ -2745,13 +2745,10 @@
       }
     },
     "node_modules/@concord-consortium/mobx-state-tree": {
-      "version": "5.1.8-cc.2",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/mobx-state-tree/-/mobx-state-tree-5.1.8-cc.2.tgz",
-      "integrity": "sha512-IdPE58mKY2jRPZFYIX4JSLaqdJk7dhUD+1rf6aUoWRtwJy3/Y5eDc5mRwyl+o1Ap5VrgiFmJtqptO1jNASQTNA==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mobx"
-      },
+      "version": "6.0.0-cc.1",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/mobx-state-tree/-/mobx-state-tree-6.0.0-cc.1.tgz",
+      "integrity": "sha512-dfzSe4ba2dNreouI3YXsUv1tmNlyx2Lj3oa5QoEi2WQazMgCqQY/mCMM87z1HfflYlCnLFoDu8KP2XTp3ljTvg==",
+      "license": "MIT",
       "peerDependencies": {
         "mobx": "^6.3.0"
       }
@@ -25191,9 +25188,9 @@
       }
     },
     "@concord-consortium/diagram-view": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-1.0.1.tgz",
-      "integrity": "sha512-duVqOeyZFcOEMpz9PAZNKJePGFLkQad3hGYcn9d7mFGJ9LaQdQf2D2XMsfoijcKueTWZpyiPr/yUG0ecCOWFnA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-1.0.2.tgz",
+      "integrity": "sha512-RlaTEc8U3v2sXpBicHi4Ka8jafWv9z5vZqGkYGOMiFA+O3yvJtFY7KnFKeIOdVcIVHvGwdvUEDg4Cot0NjBknA==",
       "requires": {
         "classnames": "^2.3.2",
         "iframe-phone": "^1.3.1",
@@ -25206,9 +25203,9 @@
       }
     },
     "@concord-consortium/mobx-state-tree": {
-      "version": "5.1.8-cc.2",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/mobx-state-tree/-/mobx-state-tree-5.1.8-cc.2.tgz",
-      "integrity": "sha512-IdPE58mKY2jRPZFYIX4JSLaqdJk7dhUD+1rf6aUoWRtwJy3/Y5eDc5mRwyl+o1Ap5VrgiFmJtqptO1jNASQTNA==",
+      "version": "6.0.0-cc.1",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/mobx-state-tree/-/mobx-state-tree-6.0.0-cc.1.tgz",
+      "integrity": "sha512-dfzSe4ba2dNreouI3YXsUv1tmNlyx2Lj3oa5QoEi2WQazMgCqQY/mCMM87z1HfflYlCnLFoDu8KP2XTp3ljTvg==",
       "requires": {}
     },
     "@concord-consortium/react-components": {

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
   },
   "homepage": "https://github.com/concord-consortium/collaborative-learning#readme",
   "overrides": {
-    "mobx-state-tree": "npm:@concord-consortium/mobx-state-tree@5.1.8-cc.1",
+    "mobx-state-tree": "npm:@concord-consortium/mobx-state-tree@6.0.0-cc.1",
     "@cortex-js/compute-engine": "npm:@concord-consortium/compute-engine@0.12.3-cc.1"
   },
   "devDependencies": {
@@ -223,8 +223,8 @@
   "dependencies": {
     "@chakra-ui/react": "^1.8.9",
     "@concord-consortium/compute-engine": "^0.12.3-cc.2",
-    "@concord-consortium/diagram-view": "1.0.1",
-    "@concord-consortium/mobx-state-tree": "^5.1.8-cc.2",
+    "@concord-consortium/diagram-view": "1.0.2",
+    "@concord-consortium/mobx-state-tree": "^6.0.0-cc.1",
     "@concord-consortium/react-components": "^1.0.0",
     "@concord-consortium/react-modal-hook": "^3.0.0-cc.1",
     "@concord-consortium/slate-editor": "^0.10.1",

--- a/src/components/tiles/geometry/geometry-content.tsx
+++ b/src/components/tiles/geometry/geometry-content.tsx
@@ -1472,7 +1472,7 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
     const content = this.getContent();
     this.setDragging(true);
     if (board && !hasSelectionModifier(evt || {})) {
-      content.metadata.selection.forEach((isSelected: boolean, id: string) => {
+      content.metadata.selection.forEach((isSelected, id) => {
         const obj = board.objects[id];
         const pt = isPoint(obj) ? obj : undefined;
         if (pt && isSelected && !pt.getAttribute("fixed")) {

--- a/src/components/tiles/table/use-editable-expressions.ts
+++ b/src/components/tiles/table/use-editable-expressions.ts
@@ -9,7 +9,8 @@ export const useEditableExpressions = (metadata: TableMetadataModelType, xName: 
   useLayoutEffect(() => {
     const rawExpressions = metadataRef.current.rawExpressions;
     const canonicalExpressions = metadataRef.current.expressions;
-    canonicalExpressions.forEach((canonical, attrId) => {
+    canonicalExpressions.forEach((canonical, _attrId) => {
+      const attrId = String(_attrId);
       const editExpr = getEditableExpression(rawExpressions.get(attrId), canonical, xName);
       editExpr && editExpressions.current?.set(attrId, editExpr);
     });

--- a/src/models/data/data-set.ts
+++ b/src/models/data/data-set.ts
@@ -1,7 +1,8 @@
 import { cloneDeep, findIndex } from "lodash";
 import { observable } from "mobx";
 import { applyAction, getEnv, Instance, ISerializedActionCall,
-          onAction, types, getSnapshot, SnapshotOut } from "mobx-state-tree";
+          onAction, types, getSnapshot, SnapshotOut,
+          hasEnv } from "mobx-state-tree";
 import { Attribute, IAttribute, IAttributeSnapshot } from "./attribute";
 import { uniqueId, uniqueSortableId } from "../../utilities/js-utils";
 import { CaseGroup } from "./data-set-types";
@@ -35,8 +36,8 @@ export interface IDerivationSpec {
 }
 
 interface IEnvContext {
-  srcDataSet: IDataSet;
-  derivationSpec: IDerivationSpec;
+  srcDataSet?: IDataSet;
+  derivationSpec?: IDerivationSpec;
 }
 
 export const DataSet = types.model("DataSet", {
@@ -522,7 +523,7 @@ export const DataSet = types.model("DataSet", {
     },
     actions: {
       afterCreate() {
-        const context: IEnvContext = getEnv(self),
+        const context: IEnvContext = hasEnv(self) ? getEnv(self) : {},
               { srcDataSet, derivationSpec = {} } = context,
               { attributeIDs, filter, synchronize } = derivationSpec;
 
@@ -977,5 +978,3 @@ export function getDataSetBounds(dataSet: IDataSet) {
   });
   return result;
 }
-
-

--- a/src/models/document/row-list.ts
+++ b/src/models/document/row-list.ts
@@ -49,7 +49,7 @@ export const RowList = types
     get tileIds() {
       return self.rowOrder.flatMap(rowId => this.getRow(rowId)?.tileIds ?? []);
     },
-    rowHeightToExport(row: TileRowModelType, tileId: string, tileMap: Map<string, ITileModel>) {
+    rowHeightToExport(row: TileRowModelType, tileId: string, tileMap: Map<string|number, ITileModel>) {
       if (!row?.height) return;
       // we only export heights for specific tiles configured to do so
       const tileType = tileMap.get(tileId)?.content.type;
@@ -59,7 +59,7 @@ export const RowList = types
       const defaultHeight = tileContentInfo.defaultHeight;
       return defaultHeight && (row.height !== defaultHeight) ? row.height : undefined;
     },
-    exportTileAsJson(tileInfo: TileLayoutModelType, tileMap: Map<string, ITileModel>,
+    exportTileAsJson(tileInfo: TileLayoutModelType, tileMap: Map<string|number, ITileModel>,
         options?: IDocumentExportOptions) {
       const { includeTileIds, ...otherOptions } = options || {};
       const tileOptions = { includeId: includeTileIds, ...otherOptions};
@@ -69,14 +69,14 @@ export const RowList = types
         return json;
       }
     },
-    exportableRows(tileMap: Map<string, ITileModel>) {
+    exportableRows(tileMap: Map<string|number, ITileModel>) {
       // identify rows with exportable tiles
       return self.rowOrder.map(rowId => {
         const row = this.getRow(rowId);
         return row && !row.isSectionHeader && !row.isEmpty && !row.isPlaceholderRow(tileMap) ? row : undefined;
       }).filter(row => !!row);
     },
-    exportRowsAsJson(rows: (TileRowModelType | undefined)[], tileMap: Map<string, ITileModel>,
+    exportRowsAsJson(rows: (TileRowModelType | undefined)[], tileMap: Map<string|number, ITileModel>,
         options?: IDocumentExportOptions) {
       const builder = new StringBuilder();
       builder.pushLine(`"tiles": [`);
@@ -112,7 +112,7 @@ export const RowList = types
     },
     // Returns a string that describes the row list and its contents.
     // For testing/debugging purposes only, but may be useful to keep.
-    debugDescribeThis(tileMap: Map<string, ITileModel>, indent: string): string {
+    debugDescribeThis(tileMap: Map<string|number, ITileModel>, indent: string): string {
       return self.rowOrder.map(rowId => {
         const row = self.rowMap.get(rowId);
         const embedded: RowListType[] = [];

--- a/src/models/document/tile-row.ts
+++ b/src/models/document/tile-row.ts
@@ -53,7 +53,7 @@ export const TileRowModel = types
     get tileIds() {
       return self.tiles.map(tile => tile.tileId);
     },
-    acceptTileDrop(rowInfo: IDropRowInfo, tileMap: Map<string, ITileModel>) {
+    acceptTileDrop(rowInfo: IDropRowInfo, tileMap: Map<string|number, ITileModel>) {
       const rowDropLocation = rowInfo.rowDropLocation;
       return !self.isSectionHeader
         && !this.isFixedPositionRow(tileMap)
@@ -66,7 +66,7 @@ export const TileRowModel = types
     hasTile(tileId: string) {
       return self.tiles.findIndex(tileRef => tileRef.tileId === tileId) >= 0;
     },
-    isPlaceholderRow(tileMap: Map<string, ITileModel>) {
+    isPlaceholderRow(tileMap: Map<string|number, ITileModel>) {
       return (this.tileCount > 0) &&
         self.tiles.every((entry) => {
           const tile = entry.tileId ? tileMap.get(entry.tileId) : undefined;
@@ -77,7 +77,7 @@ export const TileRowModel = types
     isEmbeddedRow(): boolean {
       return getParentWithTypeName(self, "TileModel") !== undefined;
     },
-    isFixedPositionRow(tileMap: Map<string, ITileModel>) {
+    isFixedPositionRow(tileMap: Map<string|number, ITileModel>) {
       return self.tiles.every(tileRef => tileMap.get(tileRef.tileId)?.isFixedPosition ?? false);
     },
     indexOfTile(tileId: string) {

--- a/src/models/mst.test.ts
+++ b/src/models/mst.test.ts
@@ -321,7 +321,7 @@ describe("mst", () => {
 
     // We create the object with no environment
     // Previously MST would return {} in this case, now it throws an exception
-    // but hasEnv is be used to check if the environment is defined
+    // but hasEnv can be used to check if the environment is defined
     const todo = Todo.create({name: "hello"});
     expect(autorunCount).toBe(1);
     expect(doSomething).toBeCalledTimes(0);

--- a/src/models/mst.test.ts
+++ b/src/models/mst.test.ts
@@ -2,7 +2,9 @@ import { action, autorun, makeObservable, observable } from "mobx";
 import { addDisposer, applySnapshot, getType, isAlive, types, getRoot,
   isStateTreeNode, SnapshotOut, Instance, getParent, destroy, hasParent,
   getSnapshot, addMiddleware, getEnv,
-  createActionTrackingMiddleware2, resolvePath, flow, onSnapshot} from "mobx-state-tree";
+  createActionTrackingMiddleware2, resolvePath, flow, onSnapshot,
+  hasEnv
+} from "mobx-state-tree";
 
 describe("mst", () => {
   it("snapshotProcessor unexpectedly modifies the base type", () => {
@@ -292,7 +294,7 @@ describe("mst", () => {
     });
   });
 
-  test("getEnv is not observable by itself", () => {
+  test("hasEnv and getEnv are not observable", () => {
     let autorunCount = 0;
     const doSomething = jest.fn();
 
@@ -303,7 +305,7 @@ describe("mst", () => {
       afterCreate() {
         addDisposer(self, autorun(() => {
           autorunCount++;
-          doSomething(getEnv(self).someValue);
+          hasEnv(self) && doSomething(getEnv(self).someValue);
         }));
       }
     }));
@@ -317,18 +319,20 @@ describe("mst", () => {
       }
     }));
 
-    // We are not passing an environment here so MST creates an
-    // empty object as the environment.
+    // We create the object with no environment
+    // Previously MST would return {} in this case, now it throws an exception
+    // but hasEnv is be used to check if the environment is defined
     const todo = Todo.create({name: "hello"});
     expect(autorunCount).toBe(1);
-    expect(doSomething).toBeCalledTimes(1);
-    expect(getEnv(todo)).toEqual({});
+    expect(doSomething).toBeCalledTimes(0);
+    expect(hasEnv(todo)).toEqual(false);
 
     // Now we pass an environment with someValue
     const todoList = TodoList.create({}, {someValue: 1});
     todoList.addTodo(todo);
 
     // The environment of the todo has now changed
+    expect(hasEnv(todo)).toBe(true);
     expect(getEnv(todo)).toEqual({someValue: 1});
 
     return new Promise(resolve => {
@@ -338,7 +342,7 @@ describe("mst", () => {
       // even though the environment has changed the autorun is not triggered
       // a second time
       expect(autorunCount).toBe(1);
-      expect(doSomething).toBeCalledTimes(1);
+      expect(doSomething).toBeCalledTimes(0);
     });
   });
 

--- a/src/models/stores/curriculum-config.ts
+++ b/src/models/stores/curriculum-config.ts
@@ -1,4 +1,4 @@
-import { Instance, SnapshotIn, getEnv, types } from "mobx-state-tree";
+import { Instance, SnapshotIn, getEnv, types, hasEnv } from "mobx-state-tree";
 import { getUrlFromRelativeOrFullString } from "../../utilities/url-utils";
 import { stripPTNumberFromBranch } from "../../utilities/branch-utils";
 import { parseUrl } from "query-string";
@@ -18,7 +18,7 @@ export const CurriculumConfig = types
   })
   .views(self => ({
     get env() {
-      return getEnv(self) as ICurriculumConfigEnv | undefined;
+      return hasEnv(self) ? getEnv(self) as ICurriculumConfigEnv : undefined;
     }
   }))
   .views(self => ({
@@ -83,7 +83,8 @@ export const CurriculumConfig = types
      */
     getUnitCodeVariants(unitId: string) {
       const variantsSet = new Set<string>([unitId]);
-      self.unitCodeMap.forEach((value, key) => {
+      self.unitCodeMap.forEach((value, _key) => {
+        const key = String(_key);
         if (value === unitId) {
           variantsSet.add(key);
         }

--- a/src/models/stores/groups.ts
+++ b/src/models/stores/groups.ts
@@ -1,4 +1,4 @@
-import { types, getEnv, SnapshotIn, applySnapshot } from "mobx-state-tree";
+import { types, getEnv, SnapshotIn, applySnapshot, hasEnv } from "mobx-state-tree";
 import { DBOfferingGroup, DBOfferingGroupMap } from "../../lib/db-types";
 import { ClassModelType } from "./class";
 import { GroupVirtualDocument } from "../document/group-virtual-document";
@@ -26,12 +26,12 @@ export const GroupUserModel = types
   })
   .views(self => ({
     get environment() {
-      return getEnv(self) as IGroupsEnvironment;
+      return hasEnv(self) ? getEnv(self) as IGroupsEnvironment : undefined;
     }
   }))
   .views(self => ({
     get classUser() {
-      return self.environment.class?.getUserById(self.id);
+      return self.environment?.class?.getUserById(self.id);
     },
   }))
   .views(self => ({
@@ -51,7 +51,7 @@ export const GroupUserModel = types
       // to be Removed.
       // Also in the future we might support setting up the groups before the class is
       // initialized. For the time being we list users as New in that case.
-      const clazz = self.environment.class;
+      const clazz = self.environment?.class;
       if (!clazz || (self.connectedTimestamp + 1000) > clazz.timestamp) {
         return GroupUserState.New;
       }
@@ -83,10 +83,10 @@ export const GroupUserModel = types
       return !disconnectedTimestamp || (connectedTimestamp > disconnectedTimestamp);
     },
     get problemDocument() {
-      return self.environment.documents?.getProblemDocument(self.id);
+      return self.environment?.documents?.getProblemDocument(self.id);
     },
     get lastPublishedProblemDocument() {
-      const publishedProblemDocs = self.environment.documents?.byTypeForUser(ProblemPublication, self.id);
+      const publishedProblemDocs = self.environment?.documents?.byTypeForUser(ProblemPublication, self.id);
       if ( publishedProblemDocs?.length === 0) {
         return undefined;
       }
@@ -101,7 +101,7 @@ export const GroupModel = types
   })
   .views(self => ({
     get environment() {
-      return getEnv(self) as IGroupsEnvironment;
+      return hasEnv(self) ? getEnv(self) as IGroupsEnvironment : undefined;
     },
     get activeUsers() {
       return self.users.filter(user => user.state !== GroupUserState.Removed);
@@ -118,7 +118,7 @@ export const GroupModel = types
     // This will put the current user first if they are in this group
     get sortedUsers() {
       const sortedUsers = [...self.activeUsers];
-      const userId = self.environment.user?.id;
+      const userId = self.environment?.user?.id;
       return sortedUsers.sort((a, b) => {
         if (a.id === userId) return -1;
         if (b.id === userId) return 1;
@@ -220,4 +220,3 @@ export const GroupsModel = types
 export type GroupUserModelType = typeof GroupUserModel.Type;
 export type GroupModelType = typeof GroupModel.Type;
 export type GroupsModelType = typeof GroupsModel.Type;
-

--- a/src/models/stores/selection.ts
+++ b/src/models/stores/selection.ts
@@ -32,7 +32,8 @@ export const DataSetSelectionModel = types
   }))
   .actions(self => ({
     setSelected(ids: string[]) {
-      self.selection.forEach((isSelected, id) => {
+      self.selection.forEach((isSelected, _id) => {
+        const id = String(_id);
         if (isSelected && (ids.indexOf(id) < 0)) {
           self.select(id, false);
         }

--- a/src/models/tiles/geometry/geometry-content.ts
+++ b/src/models/tiles/geometry/geometry-content.ts
@@ -457,7 +457,7 @@ export const GeometryContentModel = GeometryBaseContentModel
     },
     deselectAll(board: JXG.Board) {
       self.metadata.selection.forEach((value, id) => {
-        self.deselectElement(board, id);
+        self.deselectElement(board, String(id));
       });
     },
     setShowColorPalette(showOrHide: boolean) {

--- a/src/models/tiles/table/table-content.ts
+++ b/src/models/tiles/table/table-content.ts
@@ -96,7 +96,8 @@ export const TableMetadataModel = TileMetadataModel
       self.expressions.delete(colId);
     },
     clearRawExpressions(varName: string) {
-      self.expressions.forEach((expression, colId) => {
+      self.expressions.forEach((expression, _colId) => {
+        const colId = String(_colId);
         if (expression) {
           const parsedExpression = self.parseExpression(expression);
           if (parsedExpression && (parsedExpression.variables().indexOf(varName) >= 0)) {

--- a/src/models/tiles/text/text-content.ts
+++ b/src/models/tiles/text/text-content.ts
@@ -1,4 +1,4 @@
-import { types, Instance, SnapshotIn } from "mobx-state-tree";
+import { types, Instance, SnapshotIn, cast } from "mobx-state-tree";
 import {
   convertDocument, CustomEditor, Editor, EditorValue, htmlToSlate, serializeValue, slateToHtml, textToSlate, slateToText
 } from "@concord-consortium/slate-editor";
@@ -119,11 +119,11 @@ export const TextContentModel = TileContentModel
     },
     setHtml(text: string | string[]) {
       self.format = "html";
-      self.text = text;
+      self.text = cast(text);
     },
     setMarkdown(text: string | string[]) {
       self.format = "markdown";
-      self.text = text;
+      self.text = cast(text);
     },
     setSlate(value: EditorValue) {
       self.format = "slate";

--- a/src/models/tiles/tile-content.ts
+++ b/src/models/tiles/tile-content.ts
@@ -1,4 +1,4 @@
-import { getEnv, getSnapshot, Instance, types } from "mobx-state-tree";
+import { getEnv, getSnapshot, hasEnv, Instance, types } from "mobx-state-tree";
 import { SharedModelType } from "../shared/shared-model";
 import { ISharedModelManager } from "../shared/shared-model-manager";
 import { tileContentAPIActions, tileContentAPIViews } from "./tile-model-hooks";
@@ -38,7 +38,7 @@ export const TileContentModel = types.model("TileContentModel", {
   })
   .views(self => ({
     get tileEnv() {
-      return getEnv(self) as ITileEnvironment | undefined;
+      return hasEnv(self) ? getEnv(self) as ITileEnvironment : undefined;
     },
     // Override in specific tile content model when external data (like from SharedModels) is needed when copying
     get tileSnapshotForCopy() {

--- a/src/models/tiles/tile-environment.ts
+++ b/src/models/tiles/tile-environment.ts
@@ -1,4 +1,4 @@
-import { getEnv, IAnyStateTreeNode } from "mobx-state-tree";
+import { getEnv, hasEnv, IAnyStateTreeNode } from "mobx-state-tree";
 import { ISharedModelManager } from "../shared/shared-model-manager";
 import { AppConfigModelType } from "../stores/app-config-model";
 
@@ -8,7 +8,7 @@ export interface ITileEnvironment {
 }
 
 export function getTileEnvironment(node?: IAnyStateTreeNode) {
-  return node ? getEnv<ITileEnvironment | undefined>(node) : undefined;
+  return node && hasEnv(node) ? getEnv<ITileEnvironment | undefined>(node) : undefined;
 }
 
 export function getAppConfig(node?: IAnyStateTreeNode) {

--- a/src/models/tiles/tile-model.ts
+++ b/src/models/tiles/tile-model.ts
@@ -109,7 +109,7 @@ export const TileModel = types
     get isFixedPosition() {
       return self.fixedPosition;
     },
-    exportJson(options?: ITileExportOptions, tileMap?: Map<string, ITileModel>): string | undefined {
+    exportJson(options?: ITileExportOptions, tileMap?: Map<string|number, ITileModel>): string | undefined {
       const { includeId, excludeTitle, ...otherOptions } = options || {};
       let contentJson = (self.content as any).exportJson?.(otherOptions, tileMap);
       if (!contentJson) return;

--- a/src/models/tiles/toolbar-button.ts
+++ b/src/models/tiles/toolbar-button.ts
@@ -1,4 +1,4 @@
-import { getEnv, Instance, SnapshotOut, types } from "mobx-state-tree";
+import { getEnv, hasEnv, Instance, SnapshotOut, types } from "mobx-state-tree";
 import { getTileComponentInfo } from "./tile-component-info";
 import { getTileContentInfo } from "./tile-content-info";
 
@@ -23,7 +23,7 @@ const BaseToolbarButtonModel = types.model("BaseToolbarButton", {
 }))
 .views(self => ({
   get env() {
-    return getEnv(self);
+    return hasEnv(self) ? getEnv(self) : undefined;
   }
 }));
 
@@ -39,7 +39,7 @@ const AppToolbarButtonModel = BaseToolbarButtonModel.named("AppToolbarButtonMode
         // Get the appConfig from the environment
         // Unfortunately the environment cannot be typed very well
         //   https://github.com/mobxjs/mobx-state-tree/issues/431
-        const appIcons = self.env.appIcons;
+        const appIcons = self.env?.appIcons;
         self.setIcon(appIcons?.[self.iconId]);
       }
     }

--- a/src/plugins/dataflow/model/dataflow-program-model.ts
+++ b/src/plugins/dataflow/model/dataflow-program-model.ts
@@ -67,7 +67,7 @@ export const DataflowNodeModel = types.
       SensorNodeModel,
       TimerNodeModel,
       TransformNodeModel,
-    ) as typeof BaseNodeModel
+    ) as unknown as typeof BaseNodeModel
   })
   .volatile(self => ({
     // These are stored so annotations can update as the node moves around

--- a/src/plugins/graph/adornments/movable-line/movable-line-model.ts
+++ b/src/plugins/graph/adornments/movable-line/movable-line-model.ts
@@ -146,7 +146,8 @@ export const MovableLineModel = AdornmentModel
     }
   },
   deleteSelected() {
-    self.lines.forEach((line, key) => {
+    self.lines.forEach((line, _key) => {
+      const key = String(_key);
       if (line.isSelected) {
         self.lines.delete(key);
       }

--- a/src/plugins/graph/adornments/movable-line/movable-line.tsx
+++ b/src/plugins/graph/adornments/movable-line/movable-line.tsx
@@ -451,7 +451,8 @@ export const MovableLine = observer(function MovableLine(props: IProps) {
       selection.html(null);
       select(`#${containerId}`).selectAll("div").remove();
 
-      model.lines.forEach((line, key) => {
+      model.lines.forEach((line, _key) => {
+        const key = String(_key);
         const newLineObject: ILineObject = { key };
         if (graphModel.getColorForId(key) === "#000000") {
           graphModel.setColorForId(key);


### PR DESCRIPTION
- keys of forEach of MST maps have changed to be `string|number` type so this required changing parts of the code. This is probably a bug in MST, but its easier to change our code rather than fix it.
- `getEnv` now throws an error if the MST node has no environment, so now we use `hasEnv` to check for the environment first, this is mostly needed when the models are being tested without environments
- the typing of MST arrays now prevents  assignment of a simple array, but by using MST's cast function it fixes the problem
- A types.union of MST model types can't be simply coerced to a super type so now it is coerced to unknown first