### PR TITLE
Define 8 colors for geometry tile

### DIFF
--- a/src/components/tiles/geometry/color-palette.scss
+++ b/src/components/tiles/geometry/color-palette.scss
@@ -94,9 +94,9 @@
           background-color: rgb($data-indigo, .2);
         }
 
-        &.gray {
-          border: 2px solid $data-gray;
-          background-color: rgb($data-gray, .2);
+        &.black {
+          border: 2px solid $data-black;
+          background-color: rgb($data-black, .2);
         }
 
       }

--- a/src/components/tiles/geometry/color-palette.scss
+++ b/src/components/tiles/geometry/color-palette.scss
@@ -94,9 +94,9 @@
           background-color: rgb($data-indigo, .2);
         }
 
-        &.black {
-          border: 2px solid $data-black;
-          background-color: rgb($data-black, .2);
+        &.gray {
+          border: 2px solid $data-gray;
+          background-color: rgb($data-gray, .2);
         }
 
       }

--- a/src/components/tiles/geometry/color-palette.tsx
+++ b/src/components/tiles/geometry/color-palette.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { ColorSwatch } from "./color-swatch";
-import { ClueColor, clueDataColorInfo } from "../../../utilities/color-utils";
+import { ClueColor, clueBasicDataColorInfo } from "../../../utilities/color-utils";
 
 import "./color-palette.scss";
 
@@ -13,7 +13,7 @@ export const ColorPalette: React.FC<IProps> = ({ selectedColor, onSelectColor })
   return (
     <div className="toolbar-palette color-palette">
       <div className="palette-buttons">
-        {clueDataColorInfo.map((colorInfo: ClueColor, index) =>
+        {clueBasicDataColorInfo.map((colorInfo: ClueColor, index) =>
           <ColorSwatch
             key={colorInfo.name}
             name={colorInfo.name}

--- a/src/components/tiles/geometry/geometry-toolbar-registration.tsx
+++ b/src/components/tiles/geometry/geometry-toolbar-registration.tsx
@@ -9,7 +9,7 @@ import { useReadOnlyContext } from "../../document/read-only-context";
 import { useTileModelContext } from "../hooks/use-tile-model-context";
 import { GeometryTileMode } from "./geometry-types";
 import { ColorPalette } from "./color-palette";
-import { clueDataColorInfo } from "../../../utilities/color-utils";
+import { clueBasicDataColorInfo } from "../../../utilities/color-utils";
 import { GeometryContentModelType } from "src/models/tiles/geometry/geometry-content";
 import { NavigatorButton } from "../../toolbar/navigator-button";
 import { logGeometryEvent } from "../../../models/tiles/geometry/geometry-utils";
@@ -33,7 +33,7 @@ import FitAllSvg from "../../../clue/assets/icons/fit-view-icon.svg";
 import "./geometry-toolbar.scss";
 
 function getColorClass (content: GeometryContentModelType | undefined) {
-  return content?.selectedColor ? clueDataColorInfo[content.selectedColor].name : undefined;
+  return content?.selectedColor ? clueBasicDataColorInfo[content.selectedColor].name : undefined;
 }
 
 function ModeButton({name, title, targetMode, Icon, colorClass}:
@@ -111,7 +111,7 @@ const ColorChangeButton = observer(function ColorChangeButton({name}: IToolbarBu
 
 const CircleButton = observer(function CircleButton({name}: IToolbarButtonComponentProps) {
   const { content } = useGeometryTileContext();
-  const colorClass = clueDataColorInfo[content?.selectedColor || 0].name;
+  const colorClass = clueBasicDataColorInfo[content?.selectedColor || 0].name;
   return(<ModeButton name={name} title="Circle" targetMode="circle" Icon={CircleSvg} colorClass={colorClass}/>);
 });
 

--- a/src/models/tiles/geometry/geometry-model.ts
+++ b/src/models/tiles/geometry/geometry-model.ts
@@ -6,7 +6,7 @@ import { typeField } from "../../../utilities/mst-utils";
 import { ELabelOption, JXGPositionProperty } from "./jxg-changes";
 import { kGeometryDefaultPixelsPerUnit } from "./jxg-types";
 import { findLeastUsedNumber } from "../../../utilities/math-utils";
-import { clueDataColorInfo } from "../../../utilities/color-utils";
+import { clueBasicDataColorInfo } from "../../../utilities/color-utils";
 import { NavigatableTileModel } from "../navigatable-tile-model";
 
 export interface IDependsUponResult {
@@ -486,7 +486,7 @@ export const GeometryBaseContentModel = NavigatableTileModel
       if (self.linkedAttributeColors.get(id)) {
         return self.linkedAttributeColors.get(id);
       }
-      const color = findLeastUsedNumber(clueDataColorInfo.length, self.linkedAttributeColors.values());
+      const color = findLeastUsedNumber(clueBasicDataColorInfo.length, self.linkedAttributeColors.values());
       self.linkedAttributeColors.set(id, color);
       return color;
     },

--- a/src/models/tiles/geometry/geometry-utils.ts
+++ b/src/models/tiles/geometry/geometry-utils.ts
@@ -9,7 +9,7 @@ import { LogEventName } from "../../../lib/logger-types";
 import { GeometryBaseContentModel } from "./geometry-model";
 import { getTileIdFromContent } from "../tile-model";
 import { isFiniteNumber } from "../../../utilities/math-utils";
-import { clueDataColorInfo } from "../../../utilities/color-utils";
+import { clueBasicDataColorInfo } from "../../../utilities/color-utils";
 import { GeometryContentModel } from "./geometry-content";
 import { SharedModelEntrySnapshotType } from "../../document/shared-model-entry";
 import { replaceJsonStringsWithUpdatedIds, UpdatedSharedDataSetIds } from "../../shared/shared-data-set";
@@ -237,7 +237,7 @@ export function logGeometryEvent(model: Instance<typeof GeometryBaseContentModel
 }
 
 export function fillPropsForColorScheme(colorScheme: number) {
-  const spec = clueDataColorInfo[colorScheme % clueDataColorInfo.length];
+  const spec = clueBasicDataColorInfo[colorScheme % clueBasicDataColorInfo.length];
   return {
     fillColor: spec.color,
     highlightFillColor: spec.color
@@ -245,7 +245,7 @@ export function fillPropsForColorScheme(colorScheme: number) {
 }
 
 export function strokePropsForColorScheme(colorScheme: number) {
-  const spec = clueDataColorInfo[(colorScheme||0) % clueDataColorInfo.length];
+  const spec = clueBasicDataColorInfo[(colorScheme||0) % clueBasicDataColorInfo.length];
   return {
     strokeColor: spec.color,
     highlightStrokeColor: spec.color

--- a/src/utilities/color-utils.ts
+++ b/src/utilities/color-utils.ts
@@ -56,7 +56,7 @@ export const clueBasicDataColorInfo: ClueColor[] = [
   { color: clueDataColors.dataYellow, name: "yellow" },
   { color: clueDataColors.dataPurple, name: "purple" },
   { color: clueDataColors.dataIndigo, name: "indigo" },
-  { color: clueDataColors.dataGray, name: "gray" }
+  { color: clueDataColors.dataBlack, name: "black" }
 ];
 
 /*

--- a/src/utilities/color-utils.ts
+++ b/src/utilities/color-utils.ts
@@ -31,6 +31,7 @@ export interface ClueColor {
   name: string;
 }
 
+// Full set of 12 data colors from clueDataColors.scss; this is used by the Graph and BarGraph tiles
 export const clueDataColorInfo: ClueColor[] = [
   { color: clueDataColors.dataBlue, name: "blue" },
   { color: clueDataColors.dataOrange, name: "orange" },
@@ -44,6 +45,18 @@ export const clueDataColorInfo: ClueColor[] = [
   { color: clueDataColors.dataGray, name: "gray" },
   { color: clueDataColors.dataBrown, name: "brown" },
   { color: clueDataColors.dataBlack, name: "black" }
+];
+
+// Smaller set of 8 data colors used by the Geometry tile
+export const clueBasicDataColorInfo: ClueColor[] = [
+  { color: clueDataColors.dataBlue, name: "blue" },
+  { color: clueDataColors.dataOrange, name: "orange" },
+  { color: clueDataColors.dataGreen, name: "green" },
+  { color: clueDataColors.dataRed, name: "red" },
+  { color: clueDataColors.dataYellow, name: "yellow" },
+  { color: clueDataColors.dataPurple, name: "purple" },
+  { color: clueDataColors.dataIndigo, name: "indigo" },
+  { color: clueDataColors.dataGray, name: "gray" }
 ];
 
 /*


### PR DESCRIPTION
Previously the Coordinate Grid, Graph, and Bar Graph were programmed to use the same set of colors; at some point 4 new colors were added to the set to make the bar graph more flexible, but they were neither properly added nor excluded from Coordinate Grid, making the color menu display oddly.  This PR restricts it to the subset of 8 colors.