### PR TITLE
New "mock" value for aiEvaluation for testing

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -2,5 +2,12 @@
   "projects": {
     "production": "collaborative-learning-ec215",
     "staging": "collaborative-learning-staging"
-  }
+  },
+  "targets": {},
+  "etags": {
+    "collaborative-learning-staging": {
+      "extensionInstances": {}
+    }
+  },
+  "dataconnectEmulatorConfig": {}
 }

--- a/cypress/e2e/functional/document_tests/ai_evaluation_test_spec.js
+++ b/cypress/e2e/functional/document_tests/ai_evaluation_test_spec.js
@@ -1,24 +1,14 @@
-import SortedWork from "../../../support/elements/common/SortedWork";
-import ClueCanvas from '../../../support/elements/common/cCanvas';
 import Canvas from '../../../support/elements/common/Canvas';
-import DrawToolTile from '../../../support/elements/tile/DrawToolTile';
-import TextToolTile from "../../../support/elements/tile/TextToolTile";
 import ResourcesPanel from "../../../support/elements/common/ResourcesPanel";
 import ChatPanel from "../../../support/elements/common/ChatPanel";
 
-let sortWork = new SortedWork,
-  clueCanvas = new ClueCanvas,
-  canvas = new Canvas,
-  drawToolTile = new DrawToolTile,
-  textToolTile = new TextToolTile,
+let canvas = new Canvas,
   resourcesPanel = new ResourcesPanel,
   chatPanel = new ChatPanel;
 
 // qa unit has mock AI analysis
+/// TODO: remove firebaseEnv=staging once we have the rules deployed to production
 const queryParams = `${Cypress.config("qaUnitStudent5")}&firebaseEnv=staging`;
-
-// qaMothPlot unit has no AI analysis configured
-const queryParams2 = `${Cypress.config("qaMothPlotUnitStudent5")}`;
 
 const studentDocumentName = "QA 1.1 Solving a Mystery with Proportional Reasoning";
 const aiEvaluationPendingMessage = "Ada is evaluating...";
@@ -49,8 +39,8 @@ context('AI Evaluation', function () {
       .and("contain.text", aiEvaluationPendingMessage);
 
     // And eventually should show the AI analysis result
-    chatPanel.getCommentCardContent().should("be.visible");
-    chatPanel.getCommentCardContent().should("contain.text", "Mock reply from AI analysis", {timeout: 60000});
+    cy.get('[data-testid=comment-card-content]', { timeout: 60000 })
+      .should("contain.text", "Mock reply from AI analysis");
   });
 
 });

--- a/cypress/e2e/functional/document_tests/ai_evaluation_test_spec.js
+++ b/cypress/e2e/functional/document_tests/ai_evaluation_test_spec.js
@@ -1,0 +1,56 @@
+import SortedWork from "../../../support/elements/common/SortedWork";
+import ClueCanvas from '../../../support/elements/common/cCanvas';
+import Canvas from '../../../support/elements/common/Canvas';
+import DrawToolTile from '../../../support/elements/tile/DrawToolTile';
+import TextToolTile from "../../../support/elements/tile/TextToolTile";
+import ResourcesPanel from "../../../support/elements/common/ResourcesPanel";
+import ChatPanel from "../../../support/elements/common/ChatPanel";
+
+let sortWork = new SortedWork,
+  clueCanvas = new ClueCanvas,
+  canvas = new Canvas,
+  drawToolTile = new DrawToolTile,
+  textToolTile = new TextToolTile,
+  resourcesPanel = new ResourcesPanel,
+  chatPanel = new ChatPanel;
+
+// qa unit has mock AI analysis
+const queryParams = `${Cypress.config("qaUnitStudent5")}&firebaseEnv=staging`;
+
+// qaMothPlot unit has no AI analysis configured
+const queryParams2 = `${Cypress.config("qaMothPlotUnitStudent5")}`;
+
+const studentDocumentName = "QA 1.1 Solving a Mystery with Proportional Reasoning";
+const aiEvaluationPendingMessage = "Ada is evaluating...";
+
+function beforeTest(params) {
+  cy.visit(params);
+  cy.waitForLoad();
+}
+
+context('AI Evaluation', function () {
+  it('Clicking Ideas button triggers AI analysis', function () {
+    beforeTest(queryParams);
+
+    canvas.getIdeasButton().should("be.visible").click();
+
+    // The left side should be changed to show the user's document and the comments pane
+    resourcesPanel.getPrimaryWorkspaceTab("my-work").should("have.class", "selected");
+    resourcesPanel.getFocusDocument().should("be.visible");
+    resourcesPanel.getFocusDocumentTitle().should("contain.text", studentDocumentName);
+
+    // Should open the chat and select the whole document comments section
+    chatPanel.getChatPanel().should('be.visible').should('contain.text', 'Comments');
+    chatPanel.getChatThread().eq(0).should("have.class", "chat-thread-focused");
+    chatPanel.getUsernameFromCommentHeader().should("be.visible").and("contain.text", "Ada Insight");
+
+    // Should show the pending message
+    chatPanel.getCommentCardContent().should("be.visible")
+      .and("contain.text", aiEvaluationPendingMessage);
+
+    // And eventually should show the AI analysis result
+    chatPanel.getCommentCardContent().should("be.visible");
+    chatPanel.getCommentCardContent().should("contain.text", "Mock reply from AI analysis", {timeout: 60000});
+  });
+
+});

--- a/functions-v2/src/on-analysis-document-pending.ts
+++ b/functions-v2/src/on-analysis-document-pending.ts
@@ -1,5 +1,5 @@
 import {FirestoreEvent, onDocumentCreated, QueryDocumentSnapshot} from "firebase-functions/v2/firestore";
-import {getAnalysisQueueFirestorePath} from "./utils";
+import {getAnalysisQueueFirestorePath, isKnownEvaluator} from "./utils";
 import {getDatabase} from "firebase-admin/database";
 import * as admin from "firebase-admin";
 import * as logger from "firebase-functions/logger";
@@ -62,7 +62,7 @@ export const onAnalysisDocumentPending =
     const firestore = admin.firestore();
     const queueDoc = event.data?.data();
 
-    if (queueDoc?.evaluator !== "categorize-design") {
+    if (!isKnownEvaluator(queueDoc?.evaluator)) {
       await error(`Unexpected value for evaluator: ${queueDoc?.evaluator}`, event);
       return;
     }

--- a/functions-v2/src/utils.ts
+++ b/functions-v2/src/utils.ts
@@ -2,6 +2,10 @@ export function isArrayEqual(array1: string[] | undefined, array2: string[]) {
   return array1?.length === array2.length && array1.every((value, index) => value === array2[index]);
 }
 
+export function isKnownEvaluator(evaluator: string) {
+  return evaluator === "categorize-design" || evaluator === "mock";
+}
+
 type analysisQueueStatus = "pending" | "imaged" | "done" | "failedImaging" | "failedAnalyzing";
 
 export function getAnalysisQueueFirestorePath(status: analysisQueueStatus, docId?: string) {

--- a/src/public/demo/units/qa/content.json
+++ b/src/public/demo/units/qa/content.json
@@ -13,6 +13,7 @@
       {"url": "curriculum/moving-straight-ahead/stamps/rparen.png", "width": 25, "height": 25}
     ],
     "annotations": "all",
+    "aiEvaluation": "mock",
     "settings": {
       "table": { "numFormat": ".2~f" },
       "datacard": {


### PR DESCRIPTION
Add a "mock" option to the configuration of AI analysis, for testing purposes.  When a unit specifies `aiEvaluation: "mock"`, an AI comment will be created, but without calling any LLM.