### PR TITLE
sync history changes from CODAP

### DIFF
--- a/src/hooks/use-document-sync-to-firebase.ts
+++ b/src/hooks/use-document-sync-to-firebase.ts
@@ -67,7 +67,7 @@ export function useDocumentSyncToFirebase(
     if (!readOnly && contentStatus === ContentStatus.Valid) {
       // enable history tracking on this document
       if (document.treeMonitor) {
-        document.treeMonitor.enabled = true;
+        document.treeMonitor.enableMonitoring();
       }
       // Set up listener for online status
       if (commonSyncEnabled) {
@@ -77,7 +77,7 @@ export function useDocumentSyncToFirebase(
       return () => {
         // disable history tracking on this document
         if (document.treeMonitor) {
-          document.treeMonitor.enabled = false;
+          document.treeMonitor.disableMonitoring();
         }
         // Remove the online status listener
         if (!readOnly && commonSyncEnabled) {

--- a/src/models/document/document.test.ts
+++ b/src/models/document/document.test.ts
@@ -198,7 +198,7 @@ describe("document model", () => {
   });
 
   it("allows undo and redo", async () => {
-    document.treeMonitor!.enabled = true;
+    document.treeMonitor!.enableMonitoring();
     const manager = document.treeManagerAPI as Instance<typeof TreeManager>;
 
     document.addTile("text");

--- a/src/models/document/shared-model-document-manager.test.ts
+++ b/src/models/document/shared-model-document-manager.test.ts
@@ -173,7 +173,7 @@ describe("SharedModelDocumentManager", () => {
     });
 
     // Enable the tree monitor so changes to the shared model trigger the update.
-    docModel.treeMonitor!.enabled = true;
+    docModel.treeMonitor!.enableMonitoring();
 
     return {doc, docModel};
   }

--- a/src/models/history/create-action-tracking-middleware-3.test.ts
+++ b/src/models/history/create-action-tracking-middleware-3.test.ts
@@ -188,7 +188,7 @@ test("#1250", async () => {
     filter(call) {
       calls.push(
         `${call.actionCall.name} (${call.actionCall.id}) <- (${
-          call.parentCall && call.parentCall.actionCall.id
+          call.parentCall?.actionCall.id
         }) - filter`
       );
       return true;
@@ -196,14 +196,14 @@ test("#1250", async () => {
     onStart(call) {
       calls.push(
         `${call.actionCall.name} (${call.actionCall.id}) <- (${
-          call.parentCall && call.parentCall.actionCall.id
+          call.parentCall?.actionCall.id
         }) - onStart`
       );
     },
     onFinish(call, error) {
       calls.push(
         `${call.actionCall.name} (${call.actionCall.id}) <- (${
-          call.parentCall && call.parentCall.actionCall.id
+          call.parentCall?.actionCall.id
         }) - onFinish (error: ${!!error})`
       );
     }
@@ -268,7 +268,7 @@ test("MobX action calling MST actions, causes separate calls for each MST action
     filter(call) {
       calls.push(
         `${call.actionCall.name} (${call.actionCall.id}) <- (${
-          call.parentCall && call.parentCall.actionCall.id
+          call.parentCall?.actionCall.id
         }) - filter`
       );
       return true;
@@ -276,14 +276,14 @@ test("MobX action calling MST actions, causes separate calls for each MST action
     onStart(call) {
       calls.push(
         `${call.actionCall.name} (${call.actionCall.id}) <- (${
-          call.parentCall && call.parentCall.actionCall.id
+          call.parentCall?.actionCall.id
         }) - onStart`
       );
     },
     onFinish(call, error) {
       calls.push(
         `${call.actionCall.name} (${call.actionCall.id}) <- (${
-          call.parentCall && call.parentCall.actionCall.id
+          call.parentCall?.actionCall.id
         }) - onFinish (error: ${!!error})`
       );
     }

--- a/src/models/history/create-action-tracking-middleware-3.ts
+++ b/src/models/history/create-action-tracking-middleware-3.ts
@@ -2,10 +2,10 @@ import { IActionContext, IMiddlewareEvent, IMiddlewareHandler } from "mobx-state
 
 
 /**
- * This is based on MST's own createActionTrackingMiddleware2. The change is that 
+ * This is based on MST's own createActionTrackingMiddleware2. The change is that
  * the actual actionContext is provided to the filter, onStart, and onFinish hooks.
  * This makes it possible to match this up with the getRunningActionContext.
- * 
+ *
  * Because we are customizing this, it might be best to just combine this with the
  * tree monitor code and remove the extra abstraction.
  */
@@ -98,8 +98,8 @@ export function createActionTrackingMiddleware3<TEnv = any>(
       const newCall: IActionTrackingMiddleware3Call<TEnv> = {
         actionCall: call,
         // make a shallow copy of the parent action env
-        env: parentRunningAction && parentRunningAction.call.env,
-        parentCall: parentRunningAction && parentRunningAction.call
+        env: parentRunningAction?.call.env,
+        parentCall: parentRunningAction?.call
       };
 
       const passesFilter = !middlewareHooks.filter || middlewareHooks.filter(newCall);

--- a/src/models/history/history.ts
+++ b/src/models/history/history.ts
@@ -19,11 +19,20 @@ export const TreePatchRecord = types.model("TreePatchRecord", {
 }));
 export interface TreePatchRecordSnapshot extends SnapshotIn<typeof TreePatchRecord> {}
 
+export interface ICreateHistoryEntry {
+  id: string;
+  exchangeId: string;
+  tree: string;
+  model: string;
+  action: string;
+  undoable: boolean;
+}
 
 export const HistoryEntry = types.model("HistoryEntry", {
   id: types.identifier,
   tree: types.maybe(types.string),
-  action: types.maybe(types.string),
+  model: types.maybe(types.string),   // name of model
+  action: types.maybe(types.string),  // name of action
   // This doesn't need to be recorded in the state, but putting it here is
   // the easiest place for now.
   undoable: types.maybe(types.boolean),
@@ -34,10 +43,18 @@ export const HistoryEntry = types.model("HistoryEntry", {
 })
 .volatile(self => ({
   // The value of the map should be the name of the exchange. This is useful
-  // for debugging an activeExchange that hasn't been ended. 
-  // The {name: "activeExchanges"} is a feature of MobX that can also 
+  // for debugging an activeExchange that hasn't been ended.
+  // The {name: "activeExchanges"} is a feature of MobX that can also
   // help with debugging.
   activeExchanges: observable.map<string, string>({}, {name: "activeExchanges"})
+}))
+.views(self => ({
+  get modelActionKey() {
+    const modelName = self.model ?? "UnknownModel";
+    const pathParts = self.action?.split("/") ?? [];
+    const actionName = pathParts.length ? pathParts[pathParts.length - 1] : "unknownAction";
+    return `${modelName}.${actionName}`;
+  }
 }));
 export interface HistoryEntrySnapshot extends SnapshotIn<typeof HistoryEntry> {}
 export interface HistoryEntryType extends Instance<typeof HistoryEntry> {}

--- a/src/models/history/tree-manager-api.ts
+++ b/src/models/history/tree-manager-api.ts
@@ -1,9 +1,9 @@
-import { TreePatchRecordSnapshot } from "./history";
+import { ICreateHistoryEntry, TreePatchRecordSnapshot } from "./history";
 import { IUndoManager } from "./undo-store";
 
 export interface TreeManagerAPI {
     /**
-     * Propagate shared model state to other trees. 
+     * Propagate shared model state to other trees.
      *
      * The shared model is identified by an id inside of the snapshot. The
      * sourceTreeId indicates which tree is sending this update. The new shared
@@ -24,7 +24,7 @@ export interface TreeManagerAPI {
      * applying it means the tree of the shared model has sent its changes to
      * all of the trees that are using it. So when the shared model tree gets
      * the applyPatchesFromManager call it then calls this updateSharedModel and
-     * waits for it to resolve before resolving its own promise. 
+     * waits for it to resolve before resolving its own promise.
      *
      * The returned promise will also be used when a user event is sent, we need
      * to make sure the manager has received this update message before the
@@ -36,9 +36,9 @@ export interface TreeManagerAPI {
      * That blocking could be the responsibility of the manager after this call
      * is done.
      */
-    updateSharedModel: (historyEntryId: string, exchangeId: string, 
+    updateSharedModel: (historyEntryId: string, exchangeId: string,
         sourceTreeId: string, snapshot: any) => Promise<void>;
-    
+
     /**
      * Trees should call this to start a new history entry. These history
      * entries are used for 2 things:
@@ -63,7 +63,7 @@ export interface TreeManagerAPI {
      * trees might respond to a sharedModel update with further changes to other
      * sharedModels this might trigger another change back in the original tree.
      * In order to differentiate between the initiating call and the second call
-     * the exchangeId parameter is used. 
+     * the exchangeId parameter is used.
      *
      * One reason why we don't just use addTreePatchRecord to start the history
      * entry is because some actions don't have any patches in their own tree
@@ -71,24 +71,26 @@ export interface TreeManagerAPI {
      * want to record the initiating tree action so there is more info for the
      * researcher.
      *
-     * @param historyEntryId should be a unique id created by the tree. 
+     * @param entryInfo.id should be a unique id created by the tree.
      *
-     * @param exchangeId should be another unique id created by the tree. The
+     * @param entryInfo.exchangeId should be another unique id created by the tree. The
      * manager uses this to differentiate between multiple flows of messages
      * being sent to the manager. For every addHistoryEntry message there
      * should be a addTreePatchRecord message with the same exchangeId.
      *
-     * @param treeId id of the tree that is adding this history entry.
+     * @param entryInfo.treeId id of the tree that is adding this history entry.
      *
-     * @param actionName name of the action that caused this history entry to be
+     * @param entryInfo.modelName name of the model that caused this history entry to be
      * added.
      *
-     * @param undoable true if this action should be saved to the undo stack.
+     * @param entryInfo.actionName name of the action that caused this history entry to be
+     * added.
+     *
+     * @param entryInfo.undoable true if this action should be saved to the undo stack.
      * Changes that result from `applyPatchesFromManager` should not be undo-able.
-     */    
-    addHistoryEntry: (historyEntryId: string, exchangeId: string, treeId: string, 
-        actionName: string, undoable: boolean) => Promise<void>;
-    
+     */
+    addHistoryEntry: (entryInfo: ICreateHistoryEntry) => Promise<void>;
+
     /**
      * Trees should call this to record the actual patches of a history event.
      * They should always call this even if there are no patches. This message
@@ -105,7 +107,7 @@ export interface TreeManagerAPI {
      * @param exchangeId the exchangeId that started this flow of events. If
      * this tree initiated this history entry with `addHistoryEntry`, this id
      * should be the exchangeId sent in that call.  If the patches being sent were
-     * triggered by the manager this id should be the `exchangeId` that was 
+     * triggered by the manager this id should be the `exchangeId` that was
      * passed in with the message from the manager. TODO: list the tree
      * methods the manager can call that might result in changes.
      *
@@ -119,9 +121,9 @@ export interface TreeManagerAPI {
      * used by the manager to know when the history entry is complete. If there
      * are any open exchanges, then the history entry is still recording.
      * `addHistoryEntry` automatically starts an exchange, so it isn't necessary
-     * to call `startExchange` before `addHistoryEntry`.  
+     * to call `startExchange` before `addHistoryEntry`.
      * When the manager calls the tree with `applyPatchesFromManager`, the
-     * manager starts an exchange. 
+     * manager starts an exchange.
      *
      * startExchange should be called when the tree wants to start some async
      * code outside of one of these existing exchanges. It should call
@@ -137,7 +139,7 @@ export interface TreeManagerAPI {
      *
      * @param historyEntryId the history entry id that this exchange is being
      * added to. This could be the one that was created with addHistoryEntry or
-     * it could be one that was initialized by the manager. 
+     * it could be one that was initialized by the manager.
      *
      * @param exchangeId a unique id created by the tree to identify this
      * exchange. This same exchangeId needs to be passed to addTreePatchRecord

--- a/src/models/history/tree-manager-history.test.ts
+++ b/src/models/history/tree-manager-history.test.ts
@@ -57,7 +57,7 @@ function setupDocument(initialContent? : DocumentContentSnapshotType) {
     content: docContent as any
   });
 
-  docModel.treeMonitor!.enabled = true;
+  docModel.treeMonitor!.enableMonitoring();
 
   const tileContent = docContent.tileMap.get("t1")?.content as TestTileType;
   const manager = docModel.treeManagerAPI as Instance<typeof TreeManager>;

--- a/src/models/history/tree-monitor.ts
+++ b/src/models/history/tree-monitor.ts
@@ -1,20 +1,22 @@
 import {
-  addDisposer, addMiddleware, getSnapshot, IJsonPatch, Instance, IPatchRecorder,
+  addDisposer, addMiddleware, getSnapshot, IJsonPatch, Instance,
   isActionContextThisOrChildOf, isAlive, recordPatches, tryResolve
 } from "mobx-state-tree";
 import { nanoid } from "nanoid";
+import { DocumentContentModelType } from "../document/document-content";
 import { TreeManagerAPI } from "./tree-manager-api";
 import { TreePatchRecordSnapshot } from "./history";
 import { Tree } from "./tree";
-import { CallEnv, getActionPath, isActionFromManager, runningCalls, SharedModelModifications } from "./tree-types";
+import {
+  CallEnv, getActionModelName, getActionPath, isActionFromManager, isValidCallEnv, runningCalls,
+  SharedModelModifications
+} from "./tree-types";
 import { createActionTrackingMiddleware3, IActionTrackingMiddleware3Call } from "./create-action-tracking-middleware-3";
-import { DocumentContentModelType } from "../document/document-content";
-import { SharedModelMapSnapshotOutType } from "../document/shared-model-entry";
 
 export class TreeMonitor {
   tree: Instance<typeof Tree>;
   manager: TreeManagerAPI;
-  enabled = false;
+  private enabled = false;
 
   constructor(tree: Instance<typeof Tree>,  manager: TreeManagerAPI, includeHooks: boolean) {
     // We don't care how `this` is handled by createActionTrackingMiddleware
@@ -112,7 +114,7 @@ export class TreeMonitor {
             // When a shared model is linked or unlinked to a tile the path will be:
             //   /content/sharedModelMap/${sharedModelId}/tiles/[index]
             const pathMatch = _patch.path.match(/(.*\/content\/sharedModelMap\/[^/]+)/);
-            if(pathMatch) {
+            if (pathMatch) {
               const sharedModelPath = pathMatch[1];
 
               if (!sharedModelModifications[sharedModelPath]) {
@@ -144,22 +146,21 @@ export class TreeMonitor {
         };
       },
       onFinish(call, error) {
-        const { recorder, initialSharedModelMap, sharedModelModifications,
-          historyEntryId, exchangeId, undoable } = call.env || {};
-        if (!recorder || !initialSharedModelMap || !sharedModelModifications || !historyEntryId ||
-          !exchangeId || undoable === undefined) {
-          throw new Error(`The call.env is corrupted: ${ JSON.stringify(call.env)}`);
+        const env = call.env;
+        if (!isValidCallEnv(env)) {
+          throw new Error(`The call.env is corrupted: ${JSON.stringify(env)}`);
         }
         // DEBUG:
         // console.log("onFinish", getActionPath(call));
 
         call.env = undefined;
+
+        const { recorder } = env;
         recorder.stop();
 
         if (error === undefined) {
           // recordAction is async
-          self.recordAction(call, historyEntryId, exchangeId, recorder,
-            initialSharedModelMap, sharedModelModifications, undoable);
+          self.recordAction(call, env);
         } else {
           // TODO: This is a new feature that is being added to the tree:
           // any errors that happen during an action will cause the tree to revert back to
@@ -186,6 +187,14 @@ export class TreeMonitor {
     addDisposer(tree, middlewareDisposer);
   }
 
+  enableMonitoring() {
+    this.enabled = true;
+  }
+
+  disableMonitoring() {
+    this.enabled = false;
+  }
+
   // recordAction is async because it needs to wait for the manager to
   // respond, to the addHistoryEntry, startExchange, and
   // handleSharedModelChanges calls before it can call addTreePatchRecord. The
@@ -199,11 +208,9 @@ export class TreeMonitor {
   // shared model state sending is just to synchronize other views of the
   // shared model in other trees. The actual changes to the shared model are
   // stored in the recorder.
-  async recordAction(call: IActionTrackingMiddleware3Call<CallEnv>,
-    historyEntryId: string, exchangeId: string,
-    recorder: IPatchRecorder,
-    initialSharedModelMap: SharedModelMapSnapshotOutType, sharedModelModifications: SharedModelModifications,
-    undoable: boolean) {
+  async recordAction(call: IActionTrackingMiddleware3Call<CallEnv>, env: CallEnv) {
+    const { recorder, initialSharedModelMap, sharedModelModifications, historyEntryId,
+      exchangeId, undoable } = env;
     if (!isActionFromManager(call)) {
       // We record the start of the action even if it doesn't have any
       // patches. This is useful when an action only modifies the shared
@@ -212,8 +219,14 @@ export class TreeMonitor {
       // If the manager triggered the action then the manager already
       // added the history entry.
       //
-      await this.manager.addHistoryEntry(historyEntryId, exchangeId, this.tree.treeId,
-          getActionPath(call), undoable);
+      await this.manager.addHistoryEntry({
+        id: historyEntryId,
+        exchangeId,
+        tree: this.tree.treeId,
+        model: getActionModelName(call),
+        action: getActionPath(call),
+        undoable
+      });
     }
 
     // Call the shared model notification function if there are changes.

--- a/src/models/history/tree-types.ts
+++ b/src/models/history/tree-types.ts
@@ -1,4 +1,4 @@
-import { getPath, IActionContext, IPatchRecorder } from "mobx-state-tree";
+import { getPath, getType, IActionContext, IPatchRecorder } from "mobx-state-tree";
 import { SharedModelMapSnapshotOutType } from "../document/shared-model-entry";
 import { IActionTrackingMiddleware3Call } from "./create-action-tracking-middleware-3";
 
@@ -13,9 +13,18 @@ export interface CallEnv {
   undoable: boolean;
 }
 
+export function isValidCallEnv(env?: CallEnv): env is CallEnv {
+  return !!env && !!env.recorder && !!env.initialSharedModelMap &&
+    !!env.sharedModelModifications && !!env.historyEntryId && !!env.exchangeId && env.undoable != null;
+}
+
 export type SharedModelModifications = Record<string, number>;
 
 export const runningCalls = new WeakMap<IActionContext, IActionTrackingMiddleware3Call<CallEnv>>();
+
+export function getActionModelName(call: IActionTrackingMiddleware3Call<CallEnv>) {
+  return getType(call.actionCall.context).name;
+}
 
 export function getActionPath(call: IActionTrackingMiddleware3Call<CallEnv>) {
   return `${getPath(call.actionCall.context)}/${call.actionCall.name}`;

--- a/src/models/history/tree.ts
+++ b/src/models/history/tree.ts
@@ -21,7 +21,8 @@ export const Tree = types.model("Tree", {
 }))
 .actions(self => ({
   updateTreeAfterSharedModelChanges(options?: {sharedModel: SharedModelType,
-      initialSharedModelMap: SharedModelMapSnapshotOutType}) {
+      initialSharedModelMap: SharedModelMapSnapshotOutType})
+  {
     // If there is no sharedModel param, run the update function on all tiles which
     // have shared model references.
     // If there is a sharedModel param, only run the update function on tiles which
@@ -78,7 +79,7 @@ export const Tree = types.model("Tree", {
     }
 
     // Run update function on the tiles
-    for(const tile of tiles) {
+    for (const tile of tiles) {
       if (isAlive(tile)) {
         tile.content.updateAfterSharedModelChanges(sharedModel);
       }
@@ -86,40 +87,34 @@ export const Tree = types.model("Tree", {
   }
 }))
 .actions(self => {
-    const updateTreeAfterSharedModelChangesInternal = (sharedModel: SharedModelType,
-        initialSharedModelMap: SharedModelMapSnapshotOutType) => {
-      // If we are applying manager patches, then we ignore any sync actions
-      // otherwise the user might make a change such as changing the name of a
-      // node while the patches are applied. When they do this the patch for
-      // the shared model might have been applied first, and which if sync is
-      // enabled could create a new node in the diagram. Then the patch for the
-      // diagram is applied which also creates a new node in the diagram.
-      // Even if we just disable the sync when the shared model update is done
-      // from the patch, if the user makes a change, this would be a separate
-      // action would would trigger the sync. So if the user made this change
-      // at just the right time it would could result in duplicate nodes in the
-      // diagram.
-      if (self.applyingManagerPatches) {
-          return;
-      }
+  const updateTreeAfterSharedModelChangesInternal = (sharedModel: SharedModelType,
+      initialSharedModelMap: SharedModelMapSnapshotOutType) => {
+    // If we are applying manager patches, then we ignore any sync actions
+    // otherwise the user might make a change such as changing the name of a
+    // node while the patches are applied. When they do this the patch for
+    // the shared model might have been applied first, and which if sync is
+    // enabled could create a new node in the diagram. Then the patch for the
+    // diagram is applied which also creates a new node in the diagram.
+    // Even if we just disable the sync when the shared model update is done
+    // from the patch, if the user makes a change, this would be a separate
+    // action would would trigger the sync. So if the user made this change
+    // at just the right time it would could result in duplicate nodes in the
+    // diagram.
+    if (self.applyingManagerPatches) {
+      return;
+    }
 
-      // FIXME: if a shared model is unlinked from a tile we need to notify that
-      // tile. However when this happens we no longer have this tile in the list
-      // of tiles. So I think we need to update things so we pass this removed
-      // tile through. Either by constructing a list of tiles or just passing
-      // this one specific tile.
+    // The TreeMonitor middleware should pickup the historyEntryId and
+    // exchangeId parameters automatically. And then when it sends any
+    // changes captured during the update, it should include these ids
+    if (isAlive(self)) {
+      self.updateTreeAfterSharedModelChanges({sharedModel, initialSharedModelMap});
+    }
+  };
 
-      // The TreeMonitor middleware should pickup the historyEntryId and
-      // exchangeId parameters automatically. And then when it sends any
-      // changes captured during the update, it should include these ids
-      if (isAlive(self)) {
-        self.updateTreeAfterSharedModelChanges({sharedModel, initialSharedModelMap});
-      }
-    };
-
-    return {
-        updateTreeAfterSharedModelChangesInternal
-    };
+  return {
+    updateTreeAfterSharedModelChangesInternal
+  };
 })
 .actions(self => {
   return {

--- a/src/models/history/undo-store-test-utils.ts
+++ b/src/models/history/undo-store-test-utils.ts
@@ -5,7 +5,7 @@ import { TreeManager, CDocument } from "./tree-manager";
 // TODO: it would nicer to use a custom Jest matcher here so we can
 // provide a better error message when it fails
 export async function expectEntryToBeComplete(manager: Instance<typeof TreeManager>, length: number) {
-  const changeDocument = manager.document as Instance<typeof CDocument>;
+  const changeDocument: Instance<typeof CDocument> = manager.document;
   let timedOut = false;
   try {
     await when(

--- a/src/models/history/undo-store.ts
+++ b/src/models/history/undo-store.ts
@@ -17,8 +17,8 @@ export interface IUndoManager {
 
 // Information that is returned by undo and redo calls
 export interface IUndoInformation {
-  id: string|undefined,
-  action: string|undefined
+  id?: string;
+  action?: string;
 }
 
 export const UndoStore = types

--- a/src/models/history/without-undo.ts
+++ b/src/models/history/without-undo.ts
@@ -2,22 +2,22 @@ import { getRoot, getRunningActionContext } from "mobx-state-tree";
 import { DEBUG_UNDO } from "../../lib/debug";
 import { runningCalls } from "./tree-types";
 
-  /**
-   * When added to the body of a MST action, this will prevent any changes
-   * made by the action from being recorded in the CLUE undo stack. The changes
-   * will still be recorded in the CLUE document history.
-   *
-   * If this action was called from another MST action it is considered a child
-   * action. Child action changes are always recorded, so by default a warning
-   * is printed when withoutUndo is called from a child action.
-   *
-   * There is is an option so you can record the child action changes, but not
-   * record the changes when the action is the initial action:
-   *
-   *   `withoutUndo({ unlessChildAction: true })`
-   *
-   */
-  export function withoutUndo(options?: { unlessChildAction?: boolean }) {
+/**
+ * When added to the body of a MST action, this will prevent any changes
+ * made by the action from being recorded in the CLUE undo stack. The changes
+ * will still be recorded in the CLUE document history.
+ *
+ * If this action was called from another MST action it is considered a child
+ * action. Child action changes are always recorded, so by default a warning
+ * is printed when withoutUndo is called from a child action.
+ *
+ * There is is an option so you can record the child action changes, but not
+ * record the changes when the action is the initial action:
+ *
+ *   `withoutUndo({ unlessChildAction: true })`
+ *
+ */
+export function withoutUndo(options?: { unlessChildAction?: boolean }) {
   const actionCall = getRunningActionContext();
   if (!actionCall) {
     throw new Error("withoutUndo called outside of an MST action");


### PR DESCRIPTION
-  add enableMonitoring disableMonitoring actions
- fix some syntax and indenting differences
- use an object to pass arguments when there are a lot of arguments
- add a model name to HistoryEntries to make debugging easier
- add a document revisionId which CODAP uses for integration with the CFM
- add isValidCallEnv to simply and clarify code
- remove a FIXME that has already been addressed
- update tests to match the new runtime code
- reuse test helper function expectEntryToBeComplete

CLUE-226