### PR TITLE
fix: custom ai prompt not stored on disconnect (CLUE-214)

### DIFF
--- a/src/lib/firebase.test.ts
+++ b/src/lib/firebase.test.ts
@@ -112,7 +112,7 @@ describe("Firebase class", () => {
       jest.spyOn(firebaseWithCustom, 'ref').mockReturnValue(mockRef as any);
 
       await firebaseWithCustom.setLastEditedNow(mockUser as any, mockDocumentKey, mockUserId);
-      expect(mockRef.set).toHaveBeenCalledTimes(2); // lastEditedAt and timestamp
+      expect(mockRef.set).toHaveBeenCalledTimes(1); // lastEditedAt only
     });
 
     it("should handle non-custom evaluation", () => {

--- a/src/lib/firebase.test.ts
+++ b/src/lib/firebase.test.ts
@@ -94,7 +94,7 @@ describe("Firebase class", () => {
 
       return firebaseWithCustom.setLastEditedNow(mockUser as any, mockDocumentKey, mockUserId)
         .then(() => {
-          expect(mockRef.set).toHaveBeenCalledTimes(2); // lastEditedAt + evaluation
+          expect(mockRef.set).toHaveBeenCalledTimes(2); // lastEditedAt and timestamp + aiPrompt
           expect(mockRef.set).toHaveBeenCalledWith({
             aiPrompt: "test prompt",
             timestamp: "server-timestamp"
@@ -112,7 +112,7 @@ describe("Firebase class", () => {
       jest.spyOn(firebaseWithCustom, 'ref').mockReturnValue(mockRef as any);
 
       await firebaseWithCustom.setLastEditedNow(mockUser as any, mockDocumentKey, mockUserId);
-      expect(mockRef.set).toHaveBeenCalledTimes(1); // only lastEditedAt
+      expect(mockRef.set).toHaveBeenCalledTimes(2); // lastEditedAt and timestamp
     });
 
     it("should handle non-custom evaluation", () => {
@@ -126,7 +126,7 @@ describe("Firebase class", () => {
 
       return firebaseWithNonCustom.setLastEditedNow(mockUser as any, mockDocumentKey, mockUserId)
         .then(() => {
-          expect(mockRef.set).toHaveBeenCalledTimes(2); // lastEditedAt + evaluation
+          expect(mockRef.set).toHaveBeenCalledTimes(2); // lastEditedAt and timestamp
           expect(mockRef.set).toHaveBeenCalledWith({
             timestamp: "server-timestamp"
           });

--- a/src/lib/firebase.test.ts
+++ b/src/lib/firebase.test.ts
@@ -94,7 +94,7 @@ describe("Firebase class", () => {
 
       return firebaseWithCustom.setLastEditedNow(mockUser as any, mockDocumentKey, mockUserId)
         .then(() => {
-          expect(mockRef.set).toHaveBeenCalledTimes(2); // lastEditedAt and timestamp + aiPrompt
+          expect(mockRef.set).toHaveBeenCalledTimes(2); // lastEditedAt + evaluation
           expect(mockRef.set).toHaveBeenCalledWith({
             aiPrompt: "test prompt",
             timestamp: "server-timestamp"
@@ -112,7 +112,7 @@ describe("Firebase class", () => {
       jest.spyOn(firebaseWithCustom, 'ref').mockReturnValue(mockRef as any);
 
       await firebaseWithCustom.setLastEditedNow(mockUser as any, mockDocumentKey, mockUserId);
-      expect(mockRef.set).toHaveBeenCalledTimes(1); // lastEditedAt only
+      expect(mockRef.set).toHaveBeenCalledTimes(1); // only lastEditedAt
     });
 
     it("should handle non-custom evaluation", () => {
@@ -126,7 +126,7 @@ describe("Firebase class", () => {
 
       return firebaseWithNonCustom.setLastEditedNow(mockUser as any, mockDocumentKey, mockUserId)
         .then(() => {
-          expect(mockRef.set).toHaveBeenCalledTimes(2); // lastEditedAt and timestamp
+          expect(mockRef.set).toHaveBeenCalledTimes(2); // lastEditedAt + evaluation
           expect(mockRef.set).toHaveBeenCalledWith({
             timestamp: "server-timestamp"
           });

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -477,6 +477,7 @@ export class Firebase {
 private updateEvaluation = (targetRef: firebase.database.Reference | firebase.database.OnDisconnect) => {
   const { aiEvaluation, aiPrompt } = this.db.stores.appConfig;
 
+  // If this unit uses "custom" evaluation, read and store the prompt strings if they're defined.
   if (aiEvaluation === "custom") {
     return aiPrompt
       ? targetRef.set({ aiPrompt, timestamp: firebase.database.ServerValue.TIMESTAMP })


### PR DESCRIPTION
[CLUE-214](https://concord-consortium.atlassian.net/browse/CLUE-214)

Copilot-generated summary:

This PR fixes an issue where custom AI prompt values were not being stored in analysis queue documents when users disconnect. The fix introduces a shared method to handle timestamp and AI prompt storage consistently across both immediate edits and disconnect scenarios.

- Extracted duplicated logic for storing timestamps and AI prompts into a reusable private method
- Updated disconnect handling to use the same logic as immediate edits for consistent data storage
- Updated test comments to reflect the corrected behavior

[CLUE-214]: https://concord-consortium.atlassian.net/browse/CLUE-214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ