### PR TITLE
fixed: Reset logic in comment text box [CLUE-223]

### DIFF
--- a/src/components/chat/comment-textbox.tsx
+++ b/src/components/chat/comment-textbox.tsx
@@ -75,10 +75,16 @@ export const CommentTextBox: React.FC<IProps> = (props) => {
     }
   };
 
-  const handleCancelPost = () => {
+  const resetInputs = () => {
     setCommentTextAreaHeight(minTextAreaHeight);
     setCommentAdded(false);
     setCommentText("");
+    setAllTags((oldArray) => [""]); //select will go back to top choice (tagPrompt)
+    setAgreeWithAi(undefined);
+  };
+
+  const handleCancelPost = () => {
+    resetInputs();
   };
 
   const handlePostComment = () => {
@@ -87,11 +93,7 @@ export const CommentTextBox: React.FC<IProps> = (props) => {
     if (!isEmpty || (showCommentTag && allTags[0] !== "" )){
       //do not post to Firestore if select tag is tagPrompt
       onPostComment?.({comment: trimmedText, tags: allTags, agreeWithAi});
-      setCommentTextAreaHeight(minTextAreaHeight);
-      setCommentAdded(false);
-      setCommentText("");
-      setAllTags((oldArray) => [""]); //select will go back to top choice (tagPrompt)
-      setAgreeWithAi(undefined);
+      resetInputs();
     }
   };
 
@@ -99,9 +101,7 @@ export const CommentTextBox: React.FC<IProps> = (props) => {
     const [trimmedText, isEmpty] = trimContent(commentText);
     switch(event.key) {
       case "Escape":
-        setCommentTextAreaHeight(minTextAreaHeight);
-        setCommentAdded(false);
-        setCommentText("");
+        resetInputs();
         break;
       case "Enter":
         if(event.shiftKey) {


### PR DESCRIPTION
This refactors the reset logic in the comment text box to be more concise and maintainable.

The initial reason for the bugfix was to ensure that the `agreeWithAi` state is reset correctly when the user cancels a comment post.

The code now includes a dedicated `resetInputs` function that handles all necessary state resets which is now called in the following places:

- In the `handleCancelPost` function to ensure all inputs are reset when the user cancels a comment.
- After posting a comment in the `handlePostComment` function to ensure the inputs are cleared after a successful post.
- In `handleCommentTextboxKeyDown` when the Escape key is pressed.