### PR TITLE
Sketch tool align buttons

### DIFF
--- a/cypress/e2e/functional/tile_tests/drawing_tool_spec.js
+++ b/cypress/e2e/functional/tile_tests/drawing_tool_spec.js
@@ -231,6 +231,7 @@ context('Draw Tool Tile', function () {
     drawToolTile.getTileTitle().should("contain", newName);
     drawToolTile.getRectangleDrawing().should("exist").and("have.length", 1);
   });
+
   it("Vector", { scrollBehavior: false }, () => {
     beforeTest();
     clueCanvas.addTile("drawing");
@@ -706,7 +707,26 @@ context('Draw Tool Tile', function () {
     drawToolTile.dragSelectionRectangle(50, 20, 250, 100);
     drawToolTile.getSelectionBox().should("have.length", 3);
     clueCanvas.toolbarButtonIsEnabled('drawing', 'align');
-    // By default button will align the left edges of the objects
+    // Aligns left by default
+    clueCanvas.getToolbarButtonToolTipText('drawing', 'align').should("eq", "Align left");
+    drawToolTile.getDrawToolAlignOptions().should("not.exist");
+    clueCanvas.longClickToolbarButton('drawing', 'align'); // Open palette via long click
+    drawToolTile.getDrawToolAlignOptions().should("exist").and("be.visible").and("have.length", 6);
+    drawToolTile.getDrawToolAlignOptions().eq(2).click();
+    drawToolTile.getDrawToolAlignOptions().should("not.exist");
+    clueCanvas.getToolbarButtonToolTipText('drawing', 'align').should("eq", "Align right");
+    drawToolTile.getDrawToolAlignExpand().click(); // Open palette via triangle button
+    drawToolTile.getDrawToolAlignOptions().should("exist").and("be.visible").and("have.length", 6);
+    drawToolTile.getDrawToolAlignOptions().eq(0).click();
+    drawToolTile.getDrawToolAlignOptions().should("not.exist");
+    clueCanvas.getToolbarButtonToolTipText('drawing', 'align').should("eq", "Align left");
+    // Palette can also be toggled open and closed without changing the alignment type
+    drawToolTile.getDrawToolAlignExpand().click(); // Open palette via triangle button
+    drawToolTile.getDrawToolAlignOptions().should("exist").and("be.visible").and("have.length", 6);
+    drawToolTile.getDrawToolAlignExpand().click(); // Close palette via triangle button
+    drawToolTile.getDrawToolAlignOptions().should("not.exist");
+    clueCanvas.getToolbarButtonToolTipText('drawing', 'align').should("eq", "Align left");
+
     clueCanvas.clickToolbarButton('drawing', 'align');
     // All should now have been moved to the location of the rectangle
     drawToolTile.getRectangleDrawing().eq(0).invoke('attr', 'transform')

--- a/cypress/e2e/functional/tile_tests/drawing_tool_spec.js
+++ b/cypress/e2e/functional/tile_tests/drawing_tool_spec.js
@@ -712,22 +712,9 @@ context('Draw Tool Tile', function () {
     drawToolTile.getDrawToolAlignOptions().should("not.exist");
     clueCanvas.longClickToolbarButton('drawing', 'align'); // Open palette via long click
     drawToolTile.getDrawToolAlignOptions().should("exist").and("be.visible").and("have.length", 6);
-    drawToolTile.getDrawToolAlignOptions().eq(2).click();
-    drawToolTile.getDrawToolAlignOptions().should("not.exist");
-    clueCanvas.getToolbarButtonToolTipText('drawing', 'align').should("eq", "Align right");
-    drawToolTile.getDrawToolAlignExpand().click(); // Open palette via triangle button
-    drawToolTile.getDrawToolAlignOptions().should("exist").and("be.visible").and("have.length", 6);
-    drawToolTile.getDrawToolAlignOptions().eq(0).click();
+    drawToolTile.getDrawToolAlignOptions().eq(0).click(); // Aligns shapes left and closes palette
     drawToolTile.getDrawToolAlignOptions().should("not.exist");
     clueCanvas.getToolbarButtonToolTipText('drawing', 'align').should("eq", "Align left");
-    // Palette can also be toggled open and closed without changing the alignment type
-    drawToolTile.getDrawToolAlignExpand().click(); // Open palette via triangle button
-    drawToolTile.getDrawToolAlignOptions().should("exist").and("be.visible").and("have.length", 6);
-    drawToolTile.getDrawToolAlignExpand().click(); // Close palette via triangle button
-    drawToolTile.getDrawToolAlignOptions().should("not.exist");
-    clueCanvas.getToolbarButtonToolTipText('drawing', 'align').should("eq", "Align left");
-
-    clueCanvas.clickToolbarButton('drawing', 'align');
     // All should now have been moved to the location of the rectangle
     drawToolTile.getRectangleDrawing().eq(0).invoke('attr', 'transform')
       .then(transform =>
@@ -738,6 +725,13 @@ context('Draw Tool Tile', function () {
     drawToolTile.getEllipseDrawing().eq(0).invoke('attr', 'transform')
       .then(transform =>
         expect(parseTransform(transform, 'translate')[0]).to.be.within(rectX+ellipseOffset-fudgeFactor, rectX+ellipseOffset+fudgeFactor));
+
+    // Palette can also be toggled open and closed without changing the alignment type
+    drawToolTile.getDrawToolAlignExpand().click(); // Open palette via triangle button
+    drawToolTile.getDrawToolAlignOptions().should("exist").and("be.visible").and("have.length", 6);
+    drawToolTile.getDrawToolAlignExpand().click(); // Close palette via triangle button
+    drawToolTile.getDrawToolAlignOptions().should("not.exist");
+    clueCanvas.getToolbarButtonToolTipText('drawing', 'align').should("eq", "Align left");
 
     // Undo the alignment
     clueCanvas.getUndoTool().click();
@@ -750,6 +744,12 @@ context('Draw Tool Tile', function () {
     drawToolTile.getEllipseDrawing().eq(0).invoke('attr', 'transform')
       .then(transform =>
         expect(parseTransform(transform, 'translate')[0]).to.be.within(ellipseX+ellipseOffset-fudgeFactor, ellipseX+ellipseOffset+fudgeFactor));
+
+    // Change alignment type
+    drawToolTile.getDrawToolAlignExpand().click(); // Open palette via triangle button
+    drawToolTile.getDrawToolAlignOptions().eq(2).click(); // Aligns shapes right and closes palette
+    drawToolTile.getDrawToolAlignOptions().should("not.exist");
+    clueCanvas.getToolbarButtonToolTipText('drawing', 'align').should("eq", "Align right");
   });
 
   it("Image", { scrollBehavior: false }, () => {

--- a/cypress/e2e/functional/tile_tests/drawing_tool_spec.js
+++ b/cypress/e2e/functional/tile_tests/drawing_tool_spec.js
@@ -670,6 +670,68 @@ context('Draw Tool Tile', function () {
     drawToolTile.getSelectionBox().should("have.length", 4);
   });
 
+  it("Align objects", { scrollBehavior: false }, () => {
+    const
+      rectX = 50, // left edge of rectangle in screen coordinates
+      rectOffset = 10, // offsets compensate for difference between screen and object coordinates
+      freehandX = 110,
+      freehandOffset = 0,
+      ellipseX = 165,
+      ellipseOffset = 60,
+      fudgeFactor = 10;
+
+    beforeTest();
+    clueCanvas.addTile("drawing");
+    clueCanvas.toolbarButtonIsDisabled('drawing', 'align');
+    drawToolTile.drawRectangle(rectX, 50, 50, 50);
+    drawToolTile.getRectangleDrawing().first()
+      .invoke('attr', 'transform')
+      .then(transform =>
+        expect(parseTransform(transform, 'translate')[0]).to.be.within(rectX+rectOffset-fudgeFactor, rectX+rectOffset+fudgeFactor));
+    drawToolTile.drawFreehand([ {x: freehandX, y: 60}, {x: freehandX+30, y: 50} ]);
+    drawToolTile.getFreehandDrawing().first()
+      .invoke('attr', 'transform')
+      .then(transform =>
+        expect(parseTransform(transform, 'translate')[0]).to.be.within(freehandX+freehandOffset-fudgeFactor, freehandX+freehandOffset+fudgeFactor));
+    drawToolTile.drawEllipse(ellipseX+35, 70, 50, 30); // drawing of ellipse starts at its center, not its left edge
+    drawToolTile.getEllipseDrawing().first()
+      .invoke('attr', 'transform')
+      .then(transform =>
+        expect(parseTransform(transform, 'translate')[0]).to.be.within(ellipseX+ellipseOffset-fudgeFactor, ellipseX+ellipseOffset+fudgeFactor));
+    clueCanvas.toolbarButtonIsDisabled('drawing', 'align');
+    drawToolTile.getRectangleDrawing().eq(0).click();
+    drawToolTile.getSelectionBox().should("have.length", 1);
+    // Toolbar button remains disabled with one object selected
+    clueCanvas.toolbarButtonIsDisabled('drawing', 'align');
+    drawToolTile.dragSelectionRectangle(50, 20, 250, 100);
+    drawToolTile.getSelectionBox().should("have.length", 3);
+    clueCanvas.toolbarButtonIsEnabled('drawing', 'align');
+    // By default button will align the left edges of the objects
+    clueCanvas.clickToolbarButton('drawing', 'align');
+    // All should now have been moved to the location of the rectangle
+    drawToolTile.getRectangleDrawing().eq(0).invoke('attr', 'transform')
+      .then(transform =>
+        expect(parseTransform(transform, 'translate')[0]).to.be.within(rectX+rectOffset-fudgeFactor, rectX+rectOffset+fudgeFactor));
+    drawToolTile.getFreehandDrawing().eq(0).invoke('attr', 'transform')
+      .then(transform =>
+        expect(parseTransform(transform, 'translate')[0]).to.be.within(rectX+freehandOffset-fudgeFactor, rectX+freehandOffset+fudgeFactor));
+    drawToolTile.getEllipseDrawing().eq(0).invoke('attr', 'transform')
+      .then(transform =>
+        expect(parseTransform(transform, 'translate')[0]).to.be.within(rectX+ellipseOffset-fudgeFactor, rectX+ellipseOffset+fudgeFactor));
+
+    // Undo the alignment
+    clueCanvas.getUndoTool().click();
+    drawToolTile.getRectangleDrawing().eq(0).invoke('attr', 'transform')
+      .then(transform =>
+        expect(parseTransform(transform, 'translate')[0]).to.be.within(rectX+rectOffset-fudgeFactor, rectX+rectOffset+fudgeFactor));
+    drawToolTile.getFreehandDrawing().eq(0).invoke('attr', 'transform')
+      .then(transform =>
+        expect(parseTransform(transform, 'translate')[0]).to.be.within(freehandX+freehandOffset-fudgeFactor, freehandX+freehandOffset+fudgeFactor));
+    drawToolTile.getEllipseDrawing().eq(0).invoke('attr', 'transform')
+      .then(transform =>
+        expect(parseTransform(transform, 'translate')[0]).to.be.within(ellipseX+ellipseOffset-fudgeFactor, ellipseX+ellipseOffset+fudgeFactor));
+  });
+
   it("Image", { scrollBehavior: false }, () => {
     beforeTest();
     clueCanvas.addTile("drawing");

--- a/cypress/support/elements/common/cCanvas.js
+++ b/cypress/support/elements/common/cCanvas.js
@@ -471,6 +471,18 @@ class ClueCanvas {
       });
     }
 
+    longClickToolbarButton(tileType, buttonName, options = {}) {
+      cy.document().within(() => {
+        cy.get(`[data-test=canvas] .tile-toolbar.${tileType}-toolbar .toolbar-button.${buttonName}`)
+          .should('have.length', 1)
+          .should('not.be.disabled')
+          .trigger('mousedown', options);
+        cy.wait(600);
+        cy.get(`[data-test=canvas] .tile-toolbar.${tileType}-toolbar .toolbar-button.${buttonName}`)
+          .trigger('mouseup', options);
+      });
+    }
+
     /**
      * Locate a requested toolbar button's tooltip element.
      * @param {*} tileType string name of the tile

--- a/cypress/support/elements/tile/DrawToolTile.js
+++ b/cypress/support/elements/tile/DrawToolTile.js
@@ -69,6 +69,15 @@ class DrawToolTile{
     getDrawToolUploadImage(){
       return cy.get('.primary-workspace .drawing-toolbar .upload-button-input');
     }
+    getDrawToolAlign(){
+      return cy.get('.primary-workspace .drawing-toolbar .toolbar-button.align');
+    }
+    getDrawToolAlignExpand(){
+      return cy.get('.primary-workspace .drawing-toolbar .toolbar-button.align .expand-collapse');
+    }
+    getDrawToolAlignOptions(){
+      return cy.get('.primary-workspace .drawing-toolbar .toolbar-palette.aligns button');
+    }
     getDrawToolGroup(){
       return cy.get('.primary-workspace .drawing-toolbar .toolbar-button.group');
     }

--- a/src/clue/app-config.json
+++ b/src/clue/app-config.json
@@ -337,6 +337,7 @@
           "rotate-right",
           "flip-horizontal",
           "flip-vertical",
+          "align",
           "group",
           "ungroup",
           "|",

--- a/src/plugins/drawing/assets/align-bottom-icon.svg
+++ b/src/plugins/drawing/assets/align-bottom-icon.svg
@@ -1,0 +1,10 @@
+<svg width="36" height="34" viewBox="0 0 36 34" xmlns="http://www.w3.org/2000/svg">
+    <g fill="none">
+        <path d="M0 0h36v34H0z"/>
+        <g fill-rule="nonzero" fill="#545454">
+            <path d="M19.5 15.75H27v9.5h-7.5v-9.5zM9 7.75h7.5v17.5H9V7.75z" opacity=".2"/>
+            <path d="M27 15.75v9.5h-7.5v-9.5H27zm-1.5 1.5H21v6.5h4.5v-6.5zm-9-9.5v17.5H9V7.75h7.5zM15 9.25h-4.5v14.5H15V9.25z"/>
+            <path opacity=".65" d="M29.5 26.75v2h-23v-2z"/>
+        </g>
+    </g>
+</svg>

--- a/src/plugins/drawing/assets/align-center-icon.svg
+++ b/src/plugins/drawing/assets/align-center-icon.svg
@@ -1,0 +1,10 @@
+<svg width="36" height="34" viewBox="0 0 36 34" xmlns="http://www.w3.org/2000/svg">
+    <g fill="none">
+        <path d="M0 0h36v34H0z"/>
+        <g fill-rule="nonzero" fill="#545454">
+            <path d="M13.25 18h9.5v7.5h-9.5V18zm-4-10.5h17.5V15H9.25V7.5z" opacity=".2"/>
+            <path d="M22.75 18v7.5h-9.5V18h9.5zm4-10.5V15H9.25V7.5h17.5zm-5.5 12h-6.5V24h6.5v-4.5zm4-10.5h-14.5v4.5h14.5V9z"/>
+            <path d="M19 25.5V28h-2v-2.5h2zM19 15v3h-2v-3h2zm0-10v2.5h-2V5h2z" opacity=".65"/>
+        </g>
+    </g>
+</svg>

--- a/src/plugins/drawing/assets/align-left-icon.svg
+++ b/src/plugins/drawing/assets/align-left-icon.svg
@@ -1,0 +1,10 @@
+<svg width="36" height="34" viewBox="0 0 36 34" xmlns="http://www.w3.org/2000/svg">
+    <g fill="none">
+        <path d="M0 0h36v34H0z"/>
+        <g fill-rule="nonzero" fill="#545454">
+            <path d="M9.25 18h9.5v7.5h-9.5V18zm0-10.5h17.5V15H9.25V7.5z" opacity=".2"/>
+            <path d="M18.75 18v7.5h-9.5V18h9.5zm-1.5 1.5h-6.5V24h6.5v-4.5zm9.5-12V15H9.25V7.5h17.5zM25.25 9h-14.5v4.5h14.5V9z"/>
+            <path opacity=".65" d="M5.75 5v23h2V5z"/>
+        </g>
+    </g>
+</svg>

--- a/src/plugins/drawing/assets/align-middle-icon.svg
+++ b/src/plugins/drawing/assets/align-middle-icon.svg
@@ -1,0 +1,10 @@
+<svg width="36" height="34" viewBox="0 0 36 34" xmlns="http://www.w3.org/2000/svg">
+    <g fill="none">
+        <path d="M0 0h36v34H0z"/>
+        <g fill-rule="nonzero" fill="#545454">
+            <path d="M19.5 11.75H27v9.5h-7.5v-9.5zM9 7.75h7.5v17.5H9V7.75z" opacity=".2"/>
+            <path d="M16.5 7.75v17.5H9V7.75h7.5zm3 4H27v9.5h-7.5v-9.5zM15 9.25h-4.5v14.5H15V9.25zm10.5 4H21v6.5h4.5v-6.5z"/>
+            <path d="M27 15.5h2.5v2H27v-2zm-10.5 0h3v2h-3v-2zm-7.5 2H6.5v-2H9v2z" opacity=".65"/>
+        </g>
+    </g>
+</svg>

--- a/src/plugins/drawing/assets/align-right-icon.svg
+++ b/src/plugins/drawing/assets/align-right-icon.svg
@@ -1,0 +1,10 @@
+<svg width="36" height="34" viewBox="0 0 36 34" xmlns="http://www.w3.org/2000/svg">
+    <g fill="none">
+        <path d="M0 0h36v34H0z"/>
+        <g fill-rule="nonzero" fill="#545454">
+            <path d="M17.25 18h9.5v7.5h-9.5V18zm-8-10.5h17.5V15H9.25V7.5z" opacity=".2"/>
+            <path d="M26.75 18v7.5h-9.5V18h9.5zm-1.5 1.5h-6.5V24h6.5v-4.5zm1.5-12V15H9.25V7.5h17.5zM25.25 9h-14.5v4.5h14.5V9z"/>
+            <path opacity=".65" d="M28.25 5v23h2V5z"/>
+        </g>
+    </g>
+</svg>

--- a/src/plugins/drawing/assets/align-top-icon.svg
+++ b/src/plugins/drawing/assets/align-top-icon.svg
@@ -1,0 +1,10 @@
+<svg width="36" height="34" viewBox="0 0 36 34" xmlns="http://www.w3.org/2000/svg">
+    <g fill="none">
+        <path d="M0 0h36v34H0z"/>
+        <g fill-rule="nonzero" fill="#545454">
+            <path d="M19.5 7.75H27v9.5h-7.5v-9.5zM9 7.75h7.5v17.5H9V7.75z" opacity=".2"/>
+            <path d="M27 7.75v9.5h-7.5v-9.5H27zm-1.5 1.5H21v6.5h4.5v-6.5zm-9-1.5v17.5H9V7.75h7.5zM15 9.25h-4.5v14.5H15V9.25z"/>
+            <path opacity=".65" d="M29.5 4.25v2h-23v-2z"/>
+        </g>
+    </g>
+</svg>

--- a/src/plugins/drawing/components/align-palette.tsx
+++ b/src/plugins/drawing/components/align-palette.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { AlignTypeButton } from "./align-type-button";
+import { ToolbarSettings, AlignType } from "../model/drawing-basic-types";
+
+interface IProps {
+  selectedAlignType?: AlignType;
+  onSelectAlignType: (alignType: AlignType) => void;
+  settings: ToolbarSettings;
+}
+
+export function AlignTypePalette({ selectedAlignType, onSelectAlignType, settings }: IProps) {
+  return (
+    <div className="toolbar-palette aligns">
+      <div className="palette-buttons">
+        {Object.values(AlignType).map(type =>
+          <AlignTypeButton
+            key={type}
+            alignType={type}
+            isSelected={type === selectedAlignType}
+            onSelectAlignType={onSelectAlignType}
+            settings={settings}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/plugins/drawing/components/align-type-button.tsx
+++ b/src/plugins/drawing/components/align-type-button.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { observer } from "mobx-react";
+import { ToolbarSettings, AlignType, getAlignTypeIcon, getAlignTypeTooltip } from "../model/drawing-basic-types";
+import { TileToolbarButton } from "../../../components/toolbar/tile-toolbar-button";
+import { ToolbarButtonSvg } from "../toolbar-buttons/toolbar-button-svg";
+
+interface IProps {
+  alignType: AlignType;
+  isSelected: boolean;
+  onSelectAlignType: (alignType: AlignType) => void;
+  settings: ToolbarSettings;
+}
+
+export const AlignTypeButton = observer(
+  function AlignTypeButton({ alignType, isSelected, onSelectAlignType, settings }: IProps) {
+
+  const icon = getAlignTypeIcon(alignType);
+  const tooltip = getAlignTypeTooltip(alignType);
+
+  return (
+    <TileToolbarButton
+      name={"align-" + alignType}
+      title={tooltip}
+      selected={isSelected}
+      onClick={() => onSelectAlignType(alignType)}
+    >
+      <ToolbarButtonSvg SvgIcon={icon}/>
+    </TileToolbarButton>
+  );
+});

--- a/src/plugins/drawing/components/vector-type-button.tsx
+++ b/src/plugins/drawing/components/vector-type-button.tsx
@@ -22,7 +22,8 @@ export const VectorTypeButton = observer(
     stroke: settings.stroke,
     strokeDashArray: settings.strokeDashArray,
     strokeWidth: settings.strokeWidth,
-    vectorType: settings.vectorType
+    vectorType: settings.vectorType,
+    alignType: settings.alignType
   };
 
   return (
@@ -36,5 +37,3 @@ export const VectorTypeButton = observer(
     </TileToolbarButton>
   );
 });
-
-

--- a/src/plugins/drawing/components/vector-type-button.tsx
+++ b/src/plugins/drawing/components/vector-type-button.tsx
@@ -22,8 +22,7 @@ export const VectorTypeButton = observer(
     stroke: settings.stroke,
     strokeDashArray: settings.strokeDashArray,
     strokeWidth: settings.strokeWidth,
-    vectorType: settings.vectorType,
-    alignType: settings.alignType
+    vectorType: settings.vectorType
   };
 
   return (

--- a/src/plugins/drawing/drawing-registration.ts
+++ b/src/plugins/drawing/drawing-registration.ts
@@ -18,6 +18,7 @@ import { DeleteButton, DuplicateButton, FlipHorizontalButton, FlipVerticalButton
 import { ImageUploadButton } from "./toolbar-buttons/image-upload-button";
 import { ZoomInButton, ZoomOutButton, FitAllButton } from "./toolbar-buttons/zoom-buttons";
 import { NavigatorButton } from "../../components/toolbar/navigator-button";
+import { AlignButton } from "./toolbar-buttons/align-button";
 
 import Icon from "./assets/draw-tool.svg";
 import HeaderIcon from "./assets/sketch-tile-id.svg";
@@ -75,6 +76,7 @@ registerTileToolbarButtons("drawing", [
   { name: "fill-color", component: FillColorButton },
   { name: "text", component: TextButton },
   { name: "upload", component: ImageUploadButton },
+  { name: "align", component: AlignButton },
   { name: "group", component: GroupButton },
   { name: "ungroup", component: UngroupButton },
   { name: "duplicate", component: DuplicateButton },

--- a/src/plugins/drawing/drawing-toolbar.scss
+++ b/src/plugins/drawing/drawing-toolbar.scss
@@ -33,6 +33,10 @@
       width: 190px;
     }
 
+    &.aligns {
+      width: 112px;
+    }
+
     &.stroke-color {
       width: 129px;
     }

--- a/src/plugins/drawing/model/drawing-basic-types.ts
+++ b/src/plugins/drawing/model/drawing-basic-types.ts
@@ -1,7 +1,14 @@
+import { FunctionComponent, SVGProps } from "react";
+
 import LineToolIcon from "../assets/line-icon.svg";
 import SingleArrowIcon from "../assets/line-single-arrow-icon.svg";
 import DoubleArrowIcon from "../assets/line-double-arrow-icon.svg";
-import { FunctionComponent, SVGProps } from "react";
+import AlignLeftIcon from "../assets/align-left-icon.svg";
+import AlignCenterIcon from "../assets/align-center-icon.svg";
+import AlignRightIcon from "../assets/align-right-icon.svg";
+import AlignTopIcon from "../assets/align-top-icon.svg";
+import AlignMiddleIcon from "../assets/align-middle-icon.svg";
+import AlignBottomIcon from "../assets/align-bottom-icon.svg";
 
 export interface Point { x: number; y: number; }
 
@@ -13,9 +20,9 @@ export interface BoundingBox {
 }
 
 export interface BoundingBoxSides {
-  top: number, 
-  right: number, 
-  bottom: number, 
+  top: number,
+  right: number,
+  bottom: number,
   left: number
 }
 
@@ -73,6 +80,44 @@ export function vectorTypeForEndShapes(headShape?: VectorEndShape, tailShape?: V
   }
 }
 
+export enum AlignType {
+  h_left = "h_left",
+  h_center = "h_center",
+  h_right = "h_right",
+  v_top = "v_top",
+  v_center = "v_center",
+  v_bottom = "v_bottom",
+}
+
+const alignTypeIcons: Map<AlignType, FunctionComponent<SVGProps<SVGSVGElement>>> = new Map();
+alignTypeIcons.set(AlignType.h_left, AlignLeftIcon);
+alignTypeIcons.set(AlignType.h_center, AlignCenterIcon);
+alignTypeIcons.set(AlignType.h_right, AlignRightIcon);
+alignTypeIcons.set(AlignType.v_top, AlignTopIcon);
+alignTypeIcons.set(AlignType.v_center, AlignMiddleIcon);
+alignTypeIcons.set(AlignType.v_bottom, AlignBottomIcon);
+
+const alignTypeTooltips: Map<AlignType, string> = new Map();
+alignTypeTooltips.set(AlignType.h_left, "Align left");
+alignTypeTooltips.set(AlignType.h_center, "Align center");
+alignTypeTooltips.set(AlignType.h_right, "Align right");
+alignTypeTooltips.set(AlignType.v_top, "Align top");
+alignTypeTooltips.set(AlignType.v_center, "Align middle");
+alignTypeTooltips.set(AlignType.v_bottom, "Align bottom");
+
+export function isHorizontalAlignType(alignType: AlignType) {
+  return alignType === AlignType.h_left
+    || alignType === AlignType.h_center
+    || alignType === AlignType.h_right;
+}
+
+export function getAlignTypeIcon(alignType?: AlignType) {
+  return (alignType && alignTypeIcons.get(alignType)) || AlignCenterIcon;
+}
+
+export function getAlignTypeTooltip(alignType?: AlignType) {
+  return (alignType && alignTypeTooltips.get(alignType)) || "Unknown";
+}
 
 export interface ToolbarSettings {
   stroke: string;
@@ -80,6 +125,7 @@ export interface ToolbarSettings {
   strokeDashArray: string;
   strokeWidth: number;
   vectorType?: VectorType;
+  alignType: AlignType;
 }
 
 export const DefaultToolbarSettings: ToolbarSettings = {
@@ -87,5 +133,6 @@ export const DefaultToolbarSettings: ToolbarSettings = {
   fill: "none",
   strokeDashArray: "",
   strokeWidth: 2,
-  vectorType: VectorType.line
+  vectorType: VectorType.line,
+  alignType: AlignType.h_left,
 };

--- a/src/plugins/drawing/model/drawing-basic-types.ts
+++ b/src/plugins/drawing/model/drawing-basic-types.ts
@@ -125,7 +125,6 @@ export interface ToolbarSettings {
   strokeDashArray: string;
   strokeWidth: number;
   vectorType?: VectorType;
-  alignType: AlignType;
 }
 
 export const DefaultToolbarSettings: ToolbarSettings = {
@@ -133,6 +132,5 @@ export const DefaultToolbarSettings: ToolbarSettings = {
   fill: "none",
   strokeDashArray: "",
   strokeWidth: 2,
-  vectorType: VectorType.line,
-  alignType: AlignType.h_left,
+  vectorType: VectorType.line
 };

--- a/src/plugins/drawing/model/drawing-content.test.ts
+++ b/src/plugins/drawing/model/drawing-content.test.ts
@@ -4,7 +4,7 @@ import {
   DrawingContentModelSnapshot, DrawingToolMetadataModel
 } from "./drawing-content";
 import { kDrawingTileType } from "./drawing-types";
-import { DefaultToolbarSettings, VectorEndShape } from "./drawing-basic-types";
+import { AlignType, DefaultToolbarSettings, VectorEndShape } from "./drawing-basic-types";
 import { AppConfigModel } from "../../../models/stores/app-config-model";
 import { ImageObject, ImageObjectSnapshotForAdd } from "../objects/image";
 import { RectangleObject, RectangleObjectSnapshot, RectangleObjectSnapshotForAdd,
@@ -122,7 +122,9 @@ describe("DrawingContentModel", () => {
       stroke: DefaultToolbarSettings.stroke,
       fill: DefaultToolbarSettings.fill,
       strokeDashArray: DefaultToolbarSettings.strokeDashArray,
-      strokeWidth: DefaultToolbarSettings.strokeWidth
+      strokeWidth: DefaultToolbarSettings.strokeWidth,
+      vectorType: undefined,
+      alignType: DefaultToolbarSettings.alignType
     };
     expect(model.toolbarSettings).toEqual(defaultSettings);
     model.setStroke(stroke, model.selection);
@@ -328,6 +330,122 @@ describe("DrawingContentModel", () => {
     expect(model.objects[1].y).toBe(0);
     expect(model.selection.length).toBe(1); // new object is selected
     expect(model.selection[0]).toBe(model.objects[1].id);
+  });
+
+  it("can align objects left", () => {
+    const model = createDrawingContentWithMetadata();
+    const rectSnapshot1: RectangleObjectSnapshotForAdd = {...baseRectangleSnapshot,
+      id:"a", x:1, y:1, width: 5, height: 5};
+    const rect1 = model.addObject(rectSnapshot1);
+    const rectSnapshot2: RectangleObjectSnapshotForAdd = {...baseRectangleSnapshot,
+      id:"b", x:10, y:10, width: 6, height: 6};
+    const rect2 = model.addObject(rectSnapshot2);
+    model.alignObjects(["a", "b"], AlignType.h_left);
+    expect(rect1.x).toBe(1);
+    expect(rect2.x).toBe(1);
+    expect(rect1.y).toBe(1);
+    expect(rect2.y).toBe(10);
+  });
+
+  it("can align objects center", () => {
+    const model = createDrawingContentWithMetadata();
+    const rectSnapshot1: RectangleObjectSnapshotForAdd = {...baseRectangleSnapshot,
+      id:"a", x:1, y:1, width: 5, height: 5};
+    const rect1 = model.addObject(rectSnapshot1);
+    const rectSnapshot2: RectangleObjectSnapshotForAdd = {...baseRectangleSnapshot,
+      id:"b", x:10, y:10, width: 6, height: 6};
+    const rect2 = model.addObject(rectSnapshot2);
+    model.alignObjects(["a", "b"], AlignType.h_center);
+    expect(rect1.x).toBe(8.5-2.5);
+    expect(rect2.x).toBe(8.5-3);
+    expect(rect1.y).toBe(1);
+    expect(rect2.y).toBe(10);
+  });
+
+  it("can align objects right", () => {
+    const model = createDrawingContentWithMetadata();
+    const rectSnapshot1: RectangleObjectSnapshotForAdd = {...baseRectangleSnapshot,
+      id:"a", x:1, y:1, width: 5, height: 5};
+    const rect1 = model.addObject(rectSnapshot1);
+    const rectSnapshot2: RectangleObjectSnapshotForAdd = {...baseRectangleSnapshot,
+      id:"b", x:10, y:10, width: 6, height: 6};
+    const rect2 = model.addObject(rectSnapshot2);
+    model.alignObjects(["a", "b"], AlignType.h_right);
+    expect(rect1.x).toBe(16-5);
+    expect(rect2.x).toBe(16-6);
+    expect(rect1.y).toBe(1);
+    expect(rect2.y).toBe(10);
+  });
+
+  it("can align objects top", () => {
+    const model = createDrawingContentWithMetadata();
+    const rectSnapshot1: RectangleObjectSnapshotForAdd = {...baseRectangleSnapshot,
+      id:"a", x:1, y:1, width: 5, height: 5};
+    const rect1 = model.addObject(rectSnapshot1);
+    const rectSnapshot2: RectangleObjectSnapshotForAdd = {...baseRectangleSnapshot,
+      id:"b", x:10, y:10, width: 6, height: 6};
+    const rect2 = model.addObject(rectSnapshot2);
+    model.alignObjects(["a", "b"], AlignType.v_top);
+    expect(rect1.x).toBe(1);
+    expect(rect2.x).toBe(10);
+    expect(rect1.y).toBe(1);
+    expect(rect2.y).toBe(1);
+  });
+
+  it("can align objects middle", () => {
+    const model = createDrawingContentWithMetadata();
+    const rectSnapshot1: RectangleObjectSnapshotForAdd = {...baseRectangleSnapshot,
+      id:"a", x:1, y:1, width: 5, height: 5};
+    const rect1 = model.addObject(rectSnapshot1);
+    const rectSnapshot2: RectangleObjectSnapshotForAdd = {...baseRectangleSnapshot,
+      id:"b", x:10, y:10, width: 6, height: 6};
+    const rect2 = model.addObject(rectSnapshot2);
+    model.alignObjects(["a", "b"], AlignType.v_center);
+    expect(rect1.x).toBe(1);
+    expect(rect2.x).toBe(10);
+    expect(rect1.y).toBe(8.5-2.5);
+    expect(rect2.y).toBe(8.5-3);
+  });
+
+  it("can align objects bottom", () => {
+    const model = createDrawingContentWithMetadata();
+    const rectSnapshot1: RectangleObjectSnapshotForAdd = {...baseRectangleSnapshot,
+      id:"a", x:1, y:1, width: 5, height: 5};
+    const rect1 = model.addObject(rectSnapshot1);
+    const rectSnapshot2: RectangleObjectSnapshotForAdd = {...baseRectangleSnapshot,
+      id:"b", x:10, y:10, width: 6, height: 6};
+    const rect2 = model.addObject(rectSnapshot2);
+    model.alignObjects(["a", "b"], AlignType.v_bottom);
+    expect(rect1.x).toBe(1);
+    expect(rect2.x).toBe(10);
+    expect(rect1.y).toBe(16-5);
+    expect(rect2.y).toBe(16-6);
+  });
+
+  it("can align all types of objects", () => {
+    // Left edge of sized objects is just their x
+    const rect = RectangleObject.create({ ...baseRectangleSnapshot, x: 1, y: 1, id: "rect" });
+    const text = TextObject.create({ id: "text", x: 2, y: 2, width: 10, height: 10,
+      text: "Hello, world!", ...mockSettings });
+    const image = ImageObject.create({ id: "image", x: 3, y: 3, width: 10, height: 10,
+      url: "my/image/url", ...mockSettings });
+    // Left edge of line is the leftmost point, in this case x-11 = 4.
+    const line = LineObject.create({ id: "line", x: 15, y: 15,
+      deltaPoints: [{dx: -5, dy: -5}, {dx: -6, dy: 0}], ...mockSettings });
+    // Left edge of ellipse is x - rx (= 10-5 = 5)
+    const ellipse = EllipseObject.create({ id: "ellipse", x: 10, y: 10, rx: 5, ry: 1, ...mockSettings });
+    // Left edge of vector is the leftmost point, in this case 16-10 = 6
+    const vector = VectorObject.create({ id: "vector", x: 16, y: 16, dx: -10, dy: 10, ...mockSettings });
+
+    const model = createDrawingContentWithMetadata({ objects: [rect, ellipse, text, image, line, vector] });
+    model.alignObjects(["rect", "ellipse", "text", "image", "line", "vector"], AlignType.h_left);
+
+    expect(rect.x).toBe(1);
+    expect(text.x).toBe(1);
+    expect(image.x).toBe(1);
+    expect(line.x).toBe(12); // x-11 = 1
+    expect(ellipse.x).toBe(6); // x-dx = 1
+    expect(vector.x).toBe(11); // x-dx = 1
   });
 
   it("can resize rectangle", () => {
@@ -966,4 +1084,3 @@ describe("DrawingContentModel", () => {
   });
 
 });
-

--- a/src/plugins/drawing/model/drawing-content.test.ts
+++ b/src/plugins/drawing/model/drawing-content.test.ts
@@ -123,8 +123,7 @@ describe("DrawingContentModel", () => {
       fill: DefaultToolbarSettings.fill,
       strokeDashArray: DefaultToolbarSettings.strokeDashArray,
       strokeWidth: DefaultToolbarSettings.strokeWidth,
-      vectorType: undefined,
-      alignType: DefaultToolbarSettings.alignType
+      vectorType: undefined
     };
     expect(model.toolbarSettings).toEqual(defaultSettings);
     model.setStroke(stroke, model.selection);

--- a/src/plugins/drawing/model/drawing-content.ts
+++ b/src/plugins/drawing/model/drawing-content.ts
@@ -102,8 +102,8 @@ export const DrawingContentModel = NavigatableTileModel
               : null;
     },
     get toolbarSettings(): ToolbarSettings {
-      const { stroke, fill, strokeDashArray, strokeWidth, vectorType, alignType } = self;
-      return { stroke, fill, strokeDashArray, strokeWidth, vectorType, alignType };
+      const { stroke, fill, strokeDashArray, strokeWidth, vectorType } = self;
+      return { stroke, fill, strokeDashArray, strokeWidth, vectorType };
     },
     // Return the first object found that has its origin at the given point; or undefined if none.
     objectAtLocation(pos: Point) {

--- a/src/plugins/drawing/objects/group.tsx
+++ b/src/plugins/drawing/objects/group.tsx
@@ -14,7 +14,7 @@ import { useReadOnlyContext } from "../../../components/document/read-only-conte
 import { Transformable } from "../components/transformable";
 import { SizedObject } from "./sized-object";
 import { DrawingScaleProvider } from "../components/drawing-scale-context";
-import { boundingBoxSidesForPoints, rotatePoint } from "../model/drawing-utils";
+import { boundingBoxSidesForPoints, rotatePoint, computeObjectsBoundingBox } from "../model/drawing-utils";
 
 import GroupObjectsIcon from "../assets/group-objects-icon.svg";
 
@@ -104,16 +104,7 @@ export const GroupObject = SizedObject.named("GroupObject")
      */
     assimilateObjects() {
       // Compute the overall bounding box of the group's members.
-      const bb = self.objects.reduce((cur, obj) => {
-        if (obj) {
-          const objBB = obj.boundingBox;
-          if (objBB.nw.x < cur.nw.x) cur.nw.x = objBB.nw.x;
-          if (objBB.nw.y < cur.nw.y) cur.nw.y = objBB.nw.y;
-          if (objBB.se.x > cur.se.x) cur.se.x = objBB.se.x;
-          if (objBB.se.y > cur.se.y) cur.se.y = objBB.se.y;
-        }
-        return cur;
-      }, { nw: { x: Number.MAX_VALUE, y: Number.MAX_VALUE }, se: { x: -Number.MAX_VALUE, y: -Number.MAX_VALUE } });
+      const bb = computeObjectsBoundingBox(self.objects);
 
       self.x = bb.nw.x;
       self.y = bb.nw.y;
@@ -223,4 +214,3 @@ export const GroupComponent = observer(function GroupComponent(
     </Transformable>
   );
 });
-

--- a/src/plugins/drawing/toolbar-buttons/align-button.tsx
+++ b/src/plugins/drawing/toolbar-buttons/align-button.tsx
@@ -1,0 +1,74 @@
+import React, { useContext } from "react";
+import { observer } from "mobx-react";
+import { TileToolbarButton } from "../../../components/toolbar/tile-toolbar-button";
+import { IToolbarButtonComponentProps } from "../../../components/toolbar/toolbar-button-manager";
+import { DrawingContentModelContext } from "../components/drawing-content-context";
+import { OpenPaletteValues } from "../model/drawing-content";
+import { ToolbarButtonSvg } from "./toolbar-button-svg";
+import { useTouchHold } from "../../../hooks/use-touch-hold";
+import SmallCornerTriangle from "../../../../src/assets/icons/small-corner-triangle.svg";
+
+// Import align icon - using center align as default
+import { AlignTypePalette } from "../components/align-palette";
+import { AlignType, getAlignTypeIcon } from "../model/drawing-basic-types";
+
+export const AlignButton = observer(({ name }: IToolbarButtonComponentProps) => {
+  const drawingModel = useContext(DrawingContentModelContext);
+  const isSelected = drawingModel?.selectedButton === "align";
+  const isOpen = drawingModel?.openPallette === OpenPaletteValues.Align;
+  const enabled = drawingModel.selection.length > 1;
+
+  const { onClick } = useTouchHold(toggleOpen, alignItems);
+
+  function alignItems() {
+    drawingModel.setOpenPalette(OpenPaletteValues.None);
+    console.log("Aligning items");
+
+    drawingModel.alignObjects(drawingModel.selection, drawingModel.alignType);
+  }
+
+  function handleTriangleClick(e: React.MouseEvent) {
+    e.stopPropagation();
+    toggleOpen();
+  }
+
+  function toggleOpen() {
+    if (isOpen) {
+      drawingModel.setOpenPalette(OpenPaletteValues.None);
+    } else {
+      drawingModel.setOpenPalette(OpenPaletteValues.Align);
+    }
+  }
+
+  function handleAlignTypeChange(alignType: AlignType) {
+    drawingModel.setOpenPalette(OpenPaletteValues.None);
+    drawingModel.setSelectedAlignType(alignType);
+  }
+
+  const icon = getAlignTypeIcon(drawingModel.toolbarSettings.alignType);
+  const typesPalette = isOpen ?
+    <AlignTypePalette
+      selectedAlignType={drawingModel.toolbarSettings.alignType}
+      onSelectAlignType={handleAlignTypeChange}
+      settings={drawingModel}
+    />
+    : undefined;
+
+  return (
+    <TileToolbarButton
+      name={name}
+      title={"Align"}
+      selected={isSelected}
+      onClick={onClick}
+      onTouchHold={toggleOpen}
+      disabled={!enabled}
+      extraContent={typesPalette}
+    >
+      <ToolbarButtonSvg SvgIcon={icon} />
+      <SmallCornerTriangle
+        onClick={handleTriangleClick}
+        className="corner-triangle expand-collapse"
+      />
+    </TileToolbarButton>
+  );
+});

--- a/src/plugins/drawing/toolbar-buttons/align-button.tsx
+++ b/src/plugins/drawing/toolbar-buttons/align-button.tsx
@@ -7,10 +7,8 @@ import { OpenPaletteValues } from "../model/drawing-content";
 import { ToolbarButtonSvg } from "./toolbar-button-svg";
 import { useTouchHold } from "../../../hooks/use-touch-hold";
 import SmallCornerTriangle from "../../../../src/assets/icons/small-corner-triangle.svg";
-
-// Import align icon - using center align as default
 import { AlignTypePalette } from "../components/align-palette";
-import { AlignType, getAlignTypeIcon } from "../model/drawing-basic-types";
+import { AlignType, getAlignTypeIcon, getAlignTypeTooltip } from "../model/drawing-basic-types";
 
 export const AlignButton = observer(({ name }: IToolbarButtonComponentProps) => {
   const drawingModel = useContext(DrawingContentModelContext);
@@ -19,13 +17,6 @@ export const AlignButton = observer(({ name }: IToolbarButtonComponentProps) => 
   const enabled = drawingModel.selection.length > 1;
 
   const { onClick } = useTouchHold(toggleOpen, alignItems);
-
-  function alignItems() {
-    drawingModel.setOpenPalette(OpenPaletteValues.None);
-    console.log("Aligning items");
-
-    drawingModel.alignObjects(drawingModel.selection, drawingModel.alignType);
-  }
 
   function handleTriangleClick(e: React.MouseEvent) {
     e.stopPropagation();
@@ -40,15 +31,22 @@ export const AlignButton = observer(({ name }: IToolbarButtonComponentProps) => 
     }
   }
 
+  function alignItems() {
+    drawingModel.setOpenPalette(OpenPaletteValues.None);
+    drawingModel.alignObjects(drawingModel.selection, drawingModel.alignType);
+  }
+
   function handleAlignTypeChange(alignType: AlignType) {
     drawingModel.setOpenPalette(OpenPaletteValues.None);
     drawingModel.setSelectedAlignType(alignType);
   }
 
-  const icon = getAlignTypeIcon(drawingModel.toolbarSettings.alignType);
+  const icon = getAlignTypeIcon(drawingModel.alignType);
+  const tooltip = getAlignTypeTooltip(drawingModel.alignType);
+
   const typesPalette = isOpen ?
     <AlignTypePalette
-      selectedAlignType={drawingModel.toolbarSettings.alignType}
+      selectedAlignType={drawingModel.alignType}
       onSelectAlignType={handleAlignTypeChange}
       settings={drawingModel}
     />
@@ -57,7 +55,7 @@ export const AlignButton = observer(({ name }: IToolbarButtonComponentProps) => 
   return (
     <TileToolbarButton
       name={name}
-      title={"Align"}
+      title={tooltip}
       selected={isSelected}
       onClick={onClick}
       onTouchHold={toggleOpen}

--- a/src/plugins/drawing/toolbar-buttons/align-button.tsx
+++ b/src/plugins/drawing/toolbar-buttons/align-button.tsx
@@ -12,7 +12,6 @@ import { AlignType, getAlignTypeIcon, getAlignTypeTooltip } from "../model/drawi
 
 export const AlignButton = observer(({ name }: IToolbarButtonComponentProps) => {
   const drawingModel = useContext(DrawingContentModelContext);
-  const isSelected = drawingModel?.selectedButton === "align";
   const isOpen = drawingModel?.openPallette === OpenPaletteValues.Align;
   const enabled = drawingModel.selection.length > 1;
 
@@ -56,7 +55,6 @@ export const AlignButton = observer(({ name }: IToolbarButtonComponentProps) => 
     <TileToolbarButton
       name={name}
       title={tooltip}
-      selected={isSelected}
       onClick={onClick}
       onTouchHold={toggleOpen}
       disabled={!enabled}

--- a/src/plugins/drawing/toolbar-buttons/align-button.tsx
+++ b/src/plugins/drawing/toolbar-buttons/align-button.tsx
@@ -36,8 +36,8 @@ export const AlignButton = observer(({ name }: IToolbarButtonComponentProps) => 
   }
 
   function handleAlignTypeChange(alignType: AlignType) {
-    drawingModel.setOpenPalette(OpenPaletteValues.None);
     drawingModel.setSelectedAlignType(alignType);
+    alignItems();
   }
 
   const icon = getAlignTypeIcon(drawingModel.alignType);

--- a/src/plugins/drawing/toolbar-buttons/vector-button.tsx
+++ b/src/plugins/drawing/toolbar-buttons/vector-button.tsx
@@ -47,8 +47,7 @@ export const VectorButton = observer(({ name }: IToolbarButtonComponentProps) =>
     stroke: drawingModel.stroke,
     strokeDashArray: drawingModel.strokeDashArray,
     strokeWidth: drawingModel.strokeWidth,
-    vectorType: drawingModel.vectorType,
-    alignType: drawingModel.alignType
+    vectorType: drawingModel.vectorType
   };
 
   const vectorIcon = getVectorTypeIcon(drawingModel.toolbarSettings.vectorType);

--- a/src/plugins/drawing/toolbar-buttons/vector-button.tsx
+++ b/src/plugins/drawing/toolbar-buttons/vector-button.tsx
@@ -47,10 +47,19 @@ export const VectorButton = observer(({ name }: IToolbarButtonComponentProps) =>
     stroke: drawingModel.stroke,
     strokeDashArray: drawingModel.strokeDashArray,
     strokeWidth: drawingModel.strokeWidth,
-    vectorType: drawingModel.vectorType
+    vectorType: drawingModel.vectorType,
+    alignType: drawingModel.alignType
   };
 
   const vectorIcon = getVectorTypeIcon(drawingModel.toolbarSettings.vectorType);
+
+  const typesPalette = isOpen ?
+    <VectorTypePalette
+      selectedVectorType={drawingModel.toolbarSettings.vectorType}
+      onSelectVectorType={handleVectorTypeChange}
+      settings={settings}
+    />
+    : undefined;
 
   return (
     <TileToolbarButton
@@ -59,15 +68,9 @@ export const VectorButton = observer(({ name }: IToolbarButtonComponentProps) =>
       selected={isSelected}
       onClick={onClick}
       onTouchHold={toggleOpen}
+      extraContent={typesPalette}
     >
-      <ToolbarButtonSvg SvgIcon={vectorIcon} settings={settings}/>
-      { isOpen &&
-        <VectorTypePalette
-          selectedVectorType={drawingModel.toolbarSettings.vectorType}
-          onSelectVectorType={handleVectorTypeChange}
-          settings={settings}
-        />
-      }
+      <ToolbarButtonSvg SvgIcon={vectorIcon} settings={settings} />
       <SmallCornerTriangle
         onClick={handleTriangleClick}
         className="corner-triangle expand-collapse"


### PR DESCRIPTION
Adds an "align" button with a tool palette to the Sketch tile toolbar.

* Requested alignment type is persisted in the model
* Implements align behavior
* Fixes console error with other palette buttons due to nesting of <button> within <button>
* Adds Jest and Cypress tests