### PR TITLE
build: Update deployment link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,25 +37,7 @@ The production release is available at `https://collaborative-learning.concord.o
 
 Production releases are done using a manual GitHub Actions workflow. You specify which tag you want to release to production and the workflow copies that tag's `index-top.html` to `https://collaborative-learning.concord.org/index.html`.
 
-See [docs/deploy.md](docs/deploy.md) for more details.
-
-To deploy a production release:
-
-1. Update the version number in `package.json` and `package-lock.json`
-    - `npm version --no-git-tag-version [patch|minor|major]`
-1. Update the `CHANGELOG.md` with a description of the new version
-1. Verify that everything builds correctly
-    - `npm run lint && npm run build && npm run test`
-1. Copy asset size markdown table from previous release and change sizes to match new sizes in `dist`
-    - `cd dist`
-    - `ls -lhS *.js | awk '{print "|", $9, "|", $5, "|"}'`
-    - `ls -lhS *.css | awk '{print "|", $9, "|", $5, "|"}'`
-1. Create `release-<version>` branch and commit changes, push to GitHub, create PR and merge
-1. Test the master build at: <https://collaborative-learning.concord.org/index-master.html>
-1. Push a version tag to GitHub and/or use <https://github.com/concord-consortium/collaborative-learning/releases> to create a new GitHub release
-1. Stage the release by running the [Release Staging Workflow](https://github.com/concord-consortium/collaborative-learning/actions/workflows/release-staging.yml) and entering the version tag you just pushed.
-1. Test the staged release at <https://collaborative-learning.concord.org/index-staging.html>
-1. Update production by running the [Release Workflow](https://github.com/concord-consortium/collaborative-learning/actions/workflows/release.yml) and entering the release version tag.
+See [CLUE-release-steps.md](https://github.com/concord-consortium/dev-templates/blob/main/CLUE-release-steps.md) for the steps for a production release.
 
 ## Developing/deploying cloud functions
 


### PR DESCRIPTION
Updated the README to replace the existing deployment steps with a link to a markdown doc in the dev-templates repo that lists all the CLUE release steps.