### PR TITLE
fix: Default adornments on categorical a-axis causes null intercepts [CLUE-268]

### DIFF
--- a/src/plugins/graph/adornments/movable-line/movable-line-model.test.ts
+++ b/src/plugins/graph/adornments/movable-line/movable-line-model.test.ts
@@ -131,6 +131,13 @@ describe("MovableLineInstance", () => {
     const line = roundTripLine({intercept: 1, slope: null as unknown as number});
     expect(line.slope).toBe(NaN);
   });
+  it("fixes invalid intercept and slope properties", () => {
+    const lineParams = MovableLineInstance.create({intercept: null, slope: Infinity} as any);
+    expect(lineParams.intercept).toEqual(0);
+    expect(lineParams.slope).toEqual(Infinity);
+    expect(lineParams.currentIntercept).toEqual(0);
+    expect(lineParams.currentSlope).toEqual(Infinity);
+  });
 });
 
 describe("MovableLineModel", () => {

--- a/src/plugins/graph/adornments/movable-line/movable-line-model.ts
+++ b/src/plugins/graph/adornments/movable-line/movable-line-model.ts
@@ -31,6 +31,14 @@ export const MovableLineInstance = types.model("MovableLineInstance", {
   dragIntercept: undefined as number|undefined,
   dragSlope: undefined as number|undefined
 }))
+.preProcessSnapshot(snap => {
+  // ensure valid intercept
+  const validIntercept = snap.intercept == null || !isFinite(snap.intercept) ? 0 : snap.intercept;
+  return {
+    ...snap,
+    intercept: validIntercept,
+  };
+})
 .views(self => ({
   get currentEquationCoords() {
     if (self.dragEquationCoords) return self.dragEquationCoords;

--- a/src/plugins/graph/utilities/graph-utils.ts
+++ b/src/plugins/graph/utilities/graph-utils.ts
@@ -643,7 +643,7 @@ export function computeSlopeAndIntercept(xAxis?: IAxisModel, yAxis?: IAxisModel)
   // it fits a typical set of points
   const adjustedXUpper = xLower + (xUpper - xLower) / 2,
     slope = (yUpper - yLower) / (adjustedXUpper - xLower),
-    intercept = yLower - slope * xLower;
+    intercept = isFinite(slope) ? yLower - slope * xLower : adjustedXUpper;
 
   return {slope, intercept};
 }


### PR DESCRIPTION
This fix ensures that the movable line model and graph utilities handle cases where the slope is infinite or the intercept is null,
which is caused when the x axis is categorical and not numeric.

CLUE-268

(cherry picked from commit f6338e7aaae5db094a2976a1d05f8b5925ebe47e)