### PR TITLE
build: Update default CMS port to 8082 and add README

### DIFF
--- a/cms/README.md
+++ b/cms/README.md
@@ -30,13 +30,13 @@ npm install
 ```bash
 npm start
 ```
-This runs the CMS on a local development server (default port: 8081).
+This runs the CMS on a local development server (default port: 8082).
 
 ### Typical local development workflow
 1. Start CLUE (`npm start` in the top-level folder)
 2. (Optional) Start the local git proxy in the `clue-curriculum` repo: `npx netlify-cms-proxy-server`
 3. Start the CMS (`npm start` in this folder)
-4. Open the CMS in your browser with appropriate URL parameters (see docs)
+4. Open the CMS in your browser with appropriate URL parameters (see [`docs/cms.md`](../docs/cms.md))
 
 ## Build & Deployment
 - Production builds: `npm run build`

--- a/cms/README.md
+++ b/cms/README.md
@@ -1,0 +1,62 @@
+# CLUE CMS
+
+[See the full documentation in `docs/cms.md`](../docs/cms.md)
+
+## Overview
+This folder contains the source code and build configuration for the CLUE CMS, a content management system for authoring curriculum content in the Collaborative Learning User Environment (CLUE). The CMS is based on [Decap CMS](https://decapcms.org/) and is customized to support CLUE's curriculum structure and workflow.
+
+## Features
+- Edit curriculum content in the `clue-curriculum` repository via a web interface
+- Custom widgets for CLUE document editing and previewing
+- Support for GitHub and local git proxy backends
+- Flexible configuration via URL parameters
+
+## Documentation
+For detailed usage, configuration, and troubleshooting, see [`docs/cms.md`](../docs/cms.md).
+
+## Getting Started
+
+### Prerequisites
+- Node.js and npm
+- Access to the `clue-curriculum` repository
+- (Optional) Local git proxy for development
+
+### Install dependencies
+```bash
+npm install
+```
+
+### Start the CMS for local development
+```bash
+npm start
+```
+This runs the CMS on a local development server (default port: 8081).
+
+### Typical local development workflow
+1. Start CLUE (`npm start` in the top-level folder)
+2. (Optional) Start the local git proxy in the `clue-curriculum` repo: `npx netlify-cms-proxy-server`
+3. Start the CMS (`npm start` in this folder)
+4. Open the CMS in your browser with appropriate URL parameters (see docs)
+
+## Build & Deployment
+- Production builds: `npm run build`
+- Output is placed in `dist/` and copied to the main CLUE `dist/cms` folder during CI
+- The main entry point for authors is `admin.html`
+
+## Architecture
+- The CMS is configured in `src/init-cms.ts` and uses custom widgets in `src/`
+- The document editor is embedded via iframe (`cms-editor.html`)
+- Webpack is used for building and bundling assets (`webpack.config.js`)
+- TypeScript configuration is in `tsconfig.json`
+
+## Scripts
+- `npm start` — Start development server on port 8082
+- `npm run build` — Build for production
+- `npm run lint` — Lint source files
+- `npm test` — Run tests (if present)
+
+## Contributing
+See the [full documentation](../docs/cms.md) for advanced configuration, known issues, and development notes.
+
+## License
+MIT — see LICENSE in the root of the repository.

--- a/cms/webpack.config.js
+++ b/cms/webpack.config.js
@@ -23,6 +23,9 @@ module.exports = (env, argv) => {
     context: __dirname, // to automatically find tsconfig.json
     // https://survivejs.com/webpack/building/source-maps/
     devtool: devMode ? 'eval-cheap-module-source-map' : 'source-map',
+    devServer: {
+      port: 8082
+    },
     entry: {
       admin: './src/admin.tsx',
     },
@@ -134,7 +137,7 @@ module.exports = (env, argv) => {
       extensions: [ '.ts', '.tsx', '.js', '.jsx' ]
     },
     ignoreWarnings: [/export .* was not found in/],
-    plugins: [
+  plugins: [
       new ESLintPlugin(),
       new MiniCssExtractPlugin({
         filename: devMode ? '[name].css' : '[name].[chunkhash:8].css',

--- a/docs/cms.md
+++ b/docs/cms.md
@@ -65,14 +65,14 @@ To work on the CMS locally you'll need to start both CLUE and the CMS:
 - open the CMS with `http://localhost:[cms_port]/?iframeBase=http://localhost:[clue_port]&unit=[clue_unit_code]&curriculumBranch=[your own branch]`
     (add `&localCMSBackend` if using it). Make sure there are no extra "#" or "/" characters in the URL.
 
-Typically CLUE will be running on portal 8080 and the CMS will be running on 8081, or CLUE on 8080, Git proxy on 8081, and CMS on 8082. In this case the url above would be:
+Typically CLUE will be running on portal 8080 and the CMS will be running on 8082, or CLUE on 8080, Git proxy on 8081, and CMS on 8082. In this case the url above would be:
 
-- No proxy: `http://localhost:8081/?iframeBase=http://localhost:8080&unit=[clue_unit_code]&curriculumBranch=[your own branch]`
+- No proxy: `http://localhost:8082/?iframeBase=http://localhost:8080&unit=[clue_unit_code]&curriculumBranch=[your own branch]`
 - With proxy: `http://localhost:8082/?iframeBase=http://localhost:8080&localCMSBackend&unit=[clue_unit_code]`
 
 With this approach you'll be editing the content in the `clue-curriculum` repository directly. By default this will use the `author` branch in the `clue-curriculum` repository. So you aren't making changes to the same branch as other people, you should make your own branch in that repository and pass it to the `curriculumBranch` parameter. You have to make this branch using your own git tools, the CMS cannot create branches itself.
 
-If you want to have more local access to the curriculum you are editing, and you don't want to be updating the `clue-curriculum` repository, you can use the `localCMSBackend` parameter. See above for details on how to use this. Note the proxy needs to be on its own port. If it can't start on 8081 (because the cms is running there) then you'll need to configure it. See the "Configure the Decap CMS proxy server port number" section of [this Decap documentation page](https://decapcms.org/docs/working-with-a-local-git-repository).
+If you want to have more local access to the curriculum you are editing, and you don't want to be updating the `clue-curriculum` repository, you can use the `localCMSBackend` parameter. See above for details on how to use this. Note the proxy needs to be on its own port. If it can't start on 8081 (because something else is running there) then you'll need to configure it. See the "Configure the Decap CMS proxy server port number" section of [this Decap documentation page](https://decapcms.org/docs/working-with-a-local-git-repository).
 
 When the CMS loads the unit it will look for it at: `https://models-resources.concord.org/clue-curriculum/branch/[curriculumBranch]/msa/content.json`. This unit file is just used to figure out the tools that should be enabled in the document editors the CMS shows. Importantly, it is not loading it directly from Git. This means that your curriculumBranch needs to be pushed and deployed before the CMS will work. This is required even when working with a local git repository. Passing a full url for the unit does not work; it seems to cause other problems.
 

--- a/docs/cms.md
+++ b/docs/cms.md
@@ -65,7 +65,7 @@ To work on the CMS locally you'll need to start both CLUE and the CMS:
 - open the CMS with `http://localhost:[cms_port]/?iframeBase=http://localhost:[clue_port]&unit=[clue_unit_code]&curriculumBranch=[your own branch]`
     (add `&localCMSBackend` if using it). Make sure there are no extra "#" or "/" characters in the URL.
 
-Typically CLUE will be running on portal 8080 and the CMS will be running on 8082, or CLUE on 8080, Git proxy on 8081, and CMS on 8082. In this case the url above would be:
+Typically CLUE will be running on port 8080 and the CMS will be running on 8082, or CLUE on 8080, Git proxy on 8081, and CMS on 8082. In this case the url above would be:
 
 - No proxy: `http://localhost:8082/?iframeBase=http://localhost:8080&unit=[clue_unit_code]&curriculumBranch=[your own branch]`
 - With proxy: `http://localhost:8082/?iframeBase=http://localhost:8080&localCMSBackend&unit=[clue_unit_code]`


### PR DESCRIPTION
This adds a README.md to the cms folder that points to the existing cms.md folder and also includes other info.

This also sets the default port of the cms to 8082 to reduce the complexity of the order of startup of the app, the git proxy and the cms.