### PR TITLE
feat: Sync comments with history [CLUE-276]

### DIFF
--- a/src/assets/icons/deleted-tile-icon.svg
+++ b/src/assets/icons/deleted-tile-icon.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="22px" height="22px" viewBox="0 0 22 22" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>499A3601-7021-49C4-96FE-0971A047958B</title>
+    <g id="Deleted-Tile-ICON" stroke="none" fill="none">
+        <rect id="Rectangle" x="0" y="0" width="22" height="22"></rect>
+        <polygon id="Path" fill="#FF0000" fill-rule="nonzero" points="2.16066017 0.0393398282 21.9606602 19.8393398 19.8393398 21.9606602 0.0393398282 2.16066017"></polygon>
+    </g>
+</svg>

--- a/src/components/chat/chat-comment-thread.test.ts
+++ b/src/components/chat/chat-comment-thread.test.ts
@@ -31,7 +31,8 @@ describe("Chat comment thread", () => {
             title: null,
             tileId: null,
             tileType: null,
-            comments: [fakeComment]
+            comments: [fakeComment],
+            isDeletedTile: false,
         };
         expect(threads.length).toEqual(1);
         expect(threads[0]).toEqual(fakeChatThread);
@@ -85,5 +86,27 @@ describe("Chat comment thread", () => {
         expect(threads[1].comments).toEqual(tileComments);
         expect(threads[1].tileId).toEqual("tile1");
         expect(threads[1].tileType).toBeDefined();
+    });
+
+    it("Test comments on deleted tiles", () => {
+        const content = DocumentContentModel.create(createSingleTileContent({
+            type: "Text",
+            title: "test title",
+          }));
+        const c1 = makeFakeComment("c1", "tile1");
+        const c2 = makeFakeComment("c2", "tile2"); // tile2 does not exist in content, this fakes a deleted tile
+        const comments = [c1, c2];
+        const threads = makeChatThreads(comments, content);
+        expect(threads.length).toEqual(2);
+
+        expect(threads[0].comments).toEqual([c1]);
+        expect(threads[0].tileId).toEqual("tile1");
+        expect(threads[0].tileType).toBeDefined();
+        expect(threads[0].isDeletedTile).toEqual(false);
+
+        expect(threads[1].comments).toEqual([c2]);
+        expect(threads[1].tileId).toEqual("tile2");
+        expect(threads[1].tileType).toBeDefined();
+        expect(threads[1].isDeletedTile).toEqual(true);
     });
 });

--- a/src/components/chat/chat-comment-thread.ts
+++ b/src/components/chat/chat-comment-thread.ts
@@ -7,6 +7,7 @@ export interface ChatCommentThread {
   tileId: string | null;
   tileType: string | null;
   comments: WithId<CommentDocument>[];
+  isDeletedTile: boolean;
 }
 
 // Expects a list of comments in Document order with document level comments (with no (null) tileId) first.
@@ -29,11 +30,13 @@ export function makeChatThreads (
         isTileComment = true;
         tile = content?.getTile(comment.tileId);
       }
+      const isDeletedTile = isTileComment && !tile;
       chatThreads.push({
-        title: (isTileComment ? tile?.computedTitle : docTitle) ?? null,
+        title: (isTileComment ? (isDeletedTile ? "Deleted Tile" : tile?.computedTitle) : docTitle) ?? null,
         tileType: isTileComment && tile ? tile.content?.type : null,
         tileId: isTileComment ? tileId : null,
-        comments: [comment]
+        comments: [comment],
+        isDeletedTile,
       });
     }
   });

--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -19,6 +19,7 @@ import { getDocumentDisplayTitle } from "../../models/document/document-utils";
 import { AppConfigModelType } from "../../models/stores/app-config-model";
 import { UnitModelType } from "../../models/curriculum/unit";
 import { DocumentModelType } from "../../models/document/document";
+import { useNavTabPanelInfo } from "../../hooks/use-nav-tab-panel-info";
 
 import "./chat-panel.scss";
 
@@ -61,7 +62,9 @@ export const ChatPanel: React.FC<IProps> = ({ user, activeNavTab, focusDocument,
   const ordering = content?.getTilesInDocumentOrder();
   const { data: comments } = useDocumentComments(focusDocument);
   const { data: simplePathComments } = useDocumentCommentsAtSimplifiedPath(focusDocument);
+  const { playbackTime } = useNavTabPanelInfo();
   const allComments = [...comments||[], ...simplePathComments||[]]
+    .filter((comment) => playbackTime ? comment.createdAt <= playbackTime : true)
     .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
   const { data: unreadComments } = useUnreadDocumentComments(focusDocument);
   const documentComments = allComments?.filter(comment => comment.tileId == null);

--- a/src/components/chat/chat-thread.scss
+++ b/src/components/chat/chat-thread.scss
@@ -91,6 +91,15 @@
         margin-right: 5px;
         text-align: center;
         overflow: hidden;
+        position: relative; // to allow absolute positioning of deleted icon
+
+        .deleted-tile-indicator {
+          position: absolute;
+          top: 0;
+          left: 0;
+          width: 22px;
+          height: 22px;
+        }
 
         svg {
           width: 100%;

--- a/src/components/chat/chat-thread.scss
+++ b/src/components/chat/chat-thread.scss
@@ -95,7 +95,7 @@
 
         .deleted-tile-indicator {
           position: absolute;
-          top: 0;
+          top: 2px;
           left: 0;
           width: 22px;
           height: 22px;

--- a/src/components/chat/chat-thread.test.tsx
+++ b/src/components/chat/chat-thread.test.tsx
@@ -50,7 +50,8 @@ const makeFakeCommentThread = (title: string, tileId: string, uid: string) => {
     comments: [
       { uid, id: "asdf", name: "Teacher 1", createdAt: new Date(), content: title + " Comment 1" },
       { uid, id: "zyxw", name: "Teacher 2", createdAt: new Date(), content: title + " Comment 2" },
-    ]
+    ],
+    isDeletedTile: false,
   };
 };
 describe("CommentThread", () => {

--- a/src/components/chat/chat-thread.tsx
+++ b/src/components/chat/chat-thread.tsx
@@ -10,6 +10,8 @@ import { TileIconComponent } from "./tile-icon-component";
 import { ChatThreadToggle } from "./chat-thread-toggle";
 import type { PostCommentFn, DeleteCommentFn } from "./chat-panel";
 
+import DeletedTileIcon from "../../assets/icons/deleted-tile-icon.svg";
+
 import "./chat-thread.scss";
 
 interface IProps {
@@ -57,6 +59,7 @@ const ChatThreadItem: React.FC<ChatThreadItemProps> = observer(({
   const numComments = commentThread?.comments.length || 0;
   const comments = commentThread?.comments || [];
   const tileId = commentThread?.tileId || focusTileId;
+  const isDeletedTile = commentThread?.isDeletedTile || false;
 
   return (
     <div key={threadId}
@@ -73,6 +76,7 @@ const ChatThreadItem: React.FC<ChatThreadItemProps> = observer(({
         <div className="chat-thread-tile-info">
           <div className="chat-thread-tile-type" data-testid="chat-thread-tile-type">
             <TileIconComponent documentKey={focusDocument} tileId={tileId}/>
+            {isDeletedTile && <DeletedTileIcon className="deleted-tile-indicator" />}
           </div>
           <div className="chat-thread-title"> {title} </div>
         </div>

--- a/src/components/chat/comment-card.scss
+++ b/src/components/chat/comment-card.scss
@@ -1,25 +1,5 @@
 @import "../vars";
 
-$user-icon-student-color:            #828282;
-$user-icon-student-background:       #CDEBF2;
-$user-icon-student-border:           white;
-
-$user-icon-student-me-color:         #0592AF;
-$user-icon-student-me-background:    white;
-$user-icon-student-me-border:        #949494;
-
-$user-icon-student-ivan-color:       #FDFFAB;
-$user-icon-student-ivan-background:  #0592AF;
-$user-icon-student-ivan-border:      white;
-
-$user-icon-teacher-color:            #FF8415;
-$user-icon-teacher-background:       white;
-$user-icon-teacher-border:           #949494;
-
-// $user-icon-teacher-ada-color:  none; icon is multicolored
-$user-icon-teacher-ada-background:   white;
-$user-icon-teacher-ada-border:       #949494;
-
 @keyframes pulse {
   0%, 100% {
     opacity: 0;

--- a/src/components/navigation/nav-tab-panel.tsx
+++ b/src/components/navigation/nav-tab-panel.tsx
@@ -12,6 +12,7 @@ import { SectionDocumentOrBrowser } from "./section-document-or-browser";
 import { ChatPanel } from "../chat/chat-panel";
 import ChatIcon from "../../assets/chat-icon.svg";
 import { SortWorkView } from "../document/sort-work-view";
+import { NavTabPanelInfoProvider } from "../../hooks/use-nav-tab-panel-info";
 
 import "react-tabs/style/react-tabs.css";
 import "./nav-tab-panel.scss";
@@ -42,60 +43,62 @@ export class NavTabPanel extends BaseComponent<IProps> {
     const focusTileId = selectedTileIds?.length === 1 ? selectedTileIds[0] : undefined;
 
     return (
-      <div className="resource-and-chat-panel">
-        <div className="nav-tab-panel"
-            ref={elt => this.navTabPanelElt = elt}>
-          <Tabs
-            className={["react-tabs", "top-level-tabs"]}
-            selectedIndex={selectedTabIndex}
-            onSelect={this.handleSelectTab}
-            forceRenderTabPanel={true}
-          >
-            <div className="top-row">
-              <TabList className="top-tab-list">
-                { tabs?.map((tabSpec, index) => {
-                    const tabClass = `top-tab tab-${tabSpec.tab}
-                                      ${selectedTabIndex === index ? "selected" : ""}`;
-                    let dataTestId = undefined;
-                    if (tabSpec.tab === 'teacher-guide') dataTestId = 'nav-tab-teacher-guide';
-                    if (tabSpec.tab === 'student-work') dataTestId = 'nav-tab-student-work';
-                    if (tabSpec.tab === 'class-work') dataTestId = 'nav-tab-class-work';
-                    return (
-                      <React.Fragment key={tabSpec.tab}>
-                        <Tab className={tabClass} data-testid={dataTestId}>{tabSpec.label}</Tab>
-                      </React.Fragment>
-                    );
-                  })
+      <NavTabPanelInfoProvider>
+        <div className="resource-and-chat-panel">
+          <div className="nav-tab-panel"
+              ref={elt => this.navTabPanelElt = elt}>
+            <Tabs
+              className={["react-tabs", "top-level-tabs"]}
+              selectedIndex={selectedTabIndex}
+              onSelect={this.handleSelectTab}
+              forceRenderTabPanel={true}
+            >
+              <div className="top-row">
+                <TabList className="top-tab-list">
+                  { tabs?.map((tabSpec, index) => {
+                      const tabClass = `top-tab tab-${tabSpec.tab}
+                                        ${selectedTabIndex === index ? "selected" : ""}`;
+                      let dataTestId = undefined;
+                      if (tabSpec.tab === 'teacher-guide') dataTestId = 'nav-tab-teacher-guide';
+                      if (tabSpec.tab === 'student-work') dataTestId = 'nav-tab-student-work';
+                      if (tabSpec.tab === 'class-work') dataTestId = 'nav-tab-class-work';
+                      return (
+                        <React.Fragment key={tabSpec.tab}>
+                          <Tab className={tabClass} data-testid={dataTestId}>{tabSpec.label}</Tab>
+                        </React.Fragment>
+                      );
+                    })
+                  }
+                </TabList>
+                { isChatEnabled
+                    ? !openChatPanel &&
+                      <div className={`chat-panel-toggle themed ${activeNavTab}`}>
+                        {/* The next line of code is commented out, but deliberately not removed,
+                            per: https://www.pivotaltracker.com/story/show/179754830 */}
+                        {/* <NewCommentsBadge documentKey={focusDocument} /> */}
+                        <ChatIcon
+                          className={`chat-button ${activeNavTab}`}
+                          onClick={this.handleShowChatColumn}
+                        />
+                      </div>
+                    : <button className="close-button" onClick={this.handleCloseResources}/>
                 }
-              </TabList>
-              { isChatEnabled
-                  ? !openChatPanel &&
-                    <div className={`chat-panel-toggle themed ${activeNavTab}`}>
-                      {/* The next line of code is commented out, but deliberately not removed,
-                          per: https://www.pivotaltracker.com/story/show/179754830 */}
-                      {/* <NewCommentsBadge documentKey={focusDocument} /> */}
-                      <ChatIcon
-                        className={`chat-button ${activeNavTab}`}
-                        onClick={this.handleShowChatColumn}
-                      />
-                    </div>
-                  : <button className="close-button" onClick={this.handleCloseResources}/>
+              </div>
+              { tabs?.map((tabSpec) => {
+                  return (
+                    <TabPanel key={tabSpec.tab} className={["react-tabs__tab-panel", "top-level-tab-panel"]}>
+                      {this.renderTabContent(tabSpec)}
+                    </TabPanel>
+                  );
+                })
               }
-            </div>
-            { tabs?.map((tabSpec) => {
-                return (
-                  <TabPanel key={tabSpec.tab} className={["react-tabs__tab-panel", "top-level-tab-panel"]}>
-                    {this.renderTabContent(tabSpec)}
-                  </TabPanel>
-                );
-              })
-            }
-          </Tabs>
-          {showChatPanel && activeNavTab &&
-            <ChatPanel user={user} activeNavTab={activeNavTab} focusDocument={focusDocument} focusTileId={focusTileId}
-                        onCloseChatPanel={this.handleShowChatColumn} />}
+            </Tabs>
+            {showChatPanel && activeNavTab &&
+              <ChatPanel user={user} activeNavTab={activeNavTab} focusDocument={focusDocument} focusTileId={focusTileId}
+                          onCloseChatPanel={this.handleShowChatColumn} />}
+          </div>
         </div>
-      </div>
+      </NavTabPanelInfoProvider>
     );
   }
 

--- a/src/components/playback/comment-marker.scss
+++ b/src/components/playback/comment-marker.scss
@@ -1,0 +1,107 @@
+@import "../vars";
+
+$user-icon-student-color:            #828282;
+$user-icon-student-background:       #CDEBF2;
+$user-icon-student-border:           white;
+
+$user-icon-student-me-color:         #0592AF;
+$user-icon-student-me-background:    white;
+$user-icon-student-me-border:        #949494;
+
+$user-icon-student-ivan-color:       #FDFFAB;
+$user-icon-student-ivan-background:  #0592AF;
+$user-icon-student-ivan-border:      white;
+
+$user-icon-teacher-color:            #FF8415;
+$user-icon-teacher-background:       white;
+$user-icon-teacher-border:           #949494;
+
+// $user-icon-teacher-ada-color:  none; icon is multicolored
+$user-icon-teacher-ada-background:   white;
+$user-icon-teacher-ada-border:       #949494;
+
+.comment-marker {
+  position: absolute;
+  top: 0px;
+
+  .vertical-line {
+    position: absolute;
+    left: 50%;
+    top: 20px;
+    width: 2px;
+    height: 28px;
+    background-color: red;
+    transform: translateX(-50%);
+
+    &.my-work {
+      background-color: $workspace-teal;
+    }
+    &.class-work, &.sort-work {
+      background-color: $classwork-purple
+    }
+    &.student-work {
+      background-color: $charcoal;
+    }
+    &.learning-log {
+      background-color: $learninglog-green;
+    }
+    &.problems {
+      background-color: $problem-orange;
+    }
+  }
+
+  .user-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 4px;
+    border: solid 1.5px;
+    border-color: $user-icon-student-border;
+    background-color: $user-icon-student-background;
+    width: 20px;
+    height: 20px;
+
+    &.round {
+      border-radius: 50%;
+    }
+
+    svg {
+      width: 20px;
+      height: 20px;
+      fill: $user-icon-student-color;
+      margin-left: -1px;
+    }
+
+    &.me {
+      background-color: $user-icon-student-me-background;
+      border-color: $user-icon-student-me-border;
+
+      svg {
+        fill: $user-icon-student-me-color;
+      }
+    }
+
+    &.ivan {
+      background-color: $user-icon-student-ivan-background;
+      border-color: $user-icon-student-ivan-border;
+
+      svg {
+        fill: $user-icon-student-ivan-color;
+      }
+    }
+
+    &.teacher {
+      background-color: $user-icon-teacher-background;
+      border-color: $user-icon-teacher-border;
+
+      svg {
+        fill: $user-icon-teacher-color;
+      }
+    }
+
+    &.ada {
+      background-color: $user-icon-teacher-ada-background;
+      border-color: $user-icon-teacher-ada-border;
+    }
+  }
+}

--- a/src/components/playback/comment-marker.scss
+++ b/src/components/playback/comment-marker.scss
@@ -1,25 +1,5 @@
 @import "../vars";
 
-$user-icon-student-color:            #828282;
-$user-icon-student-background:       #CDEBF2;
-$user-icon-student-border:           white;
-
-$user-icon-student-me-color:         #0592AF;
-$user-icon-student-me-background:    white;
-$user-icon-student-me-border:        #949494;
-
-$user-icon-student-ivan-color:       #FDFFAB;
-$user-icon-student-ivan-background:  #0592AF;
-$user-icon-student-ivan-border:      white;
-
-$user-icon-teacher-color:            #FF8415;
-$user-icon-teacher-background:       white;
-$user-icon-teacher-border:           #949494;
-
-// $user-icon-teacher-ada-color:  none; icon is multicolored
-$user-icon-teacher-ada-background:   white;
-$user-icon-teacher-ada-border:       #949494;
-
 .comment-marker {
   position: absolute;
   top: 0px;

--- a/src/components/playback/comment-marker.tsx
+++ b/src/components/playback/comment-marker.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import classNames from "classnames";
+import { WithId } from "../../hooks/firestore-hooks";
+import { CommentDocument } from "../../lib/firestore-schema";
+import ChatAvatar from "../chat/chat-avatar";
+import { getDisplayTimeDate } from "../../utilities/time";
+
+import "./comment-marker.scss";
+
+interface IProps {
+  comment: WithId<CommentDocument>;
+  commentLocation?: number;
+  activeNavTab?: string;
+  onClick: (commentEntry: WithId<CommentDocument>) => void;
+}
+
+export const CommentMarker: React.FC<IProps> = ({comment, commentLocation, activeNavTab, onClick}) => {
+  // 10px is half the width of the marker, it is subtracted to center it
+  const style = {left: `calc(${commentLocation}% - 10px)`};
+
+  const handleOnClick = () => onClick(comment);
+  const title = `${comment.name}\n${getDisplayTimeDate(comment.createdAt.getTime())}`;
+
+  return (
+    <div key={`comment-${comment.id}`} className="comment-marker" style={style} onClick={handleOnClick} title={title}>
+      <div className={classNames("vertical-line", activeNavTab)} />
+      <ChatAvatar uid={comment.uid} />
+    </div>
+  );
+};

--- a/src/components/playback/playback-control.scss
+++ b/src/components/playback/playback-control.scss
@@ -315,6 +315,14 @@ $border-radius-base: 6px;
     }
   }
 
+  .comment-markers-container {
+    position: absolute;
+    top: 0;
+    left: 10px;
+    right: 10px;
+    height: 100%;
+  }
+
   .rc-slider {
     position: relative;
     width: 100%;

--- a/src/components/playback/playback-control.tsx
+++ b/src/components/playback/playback-control.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Slider from "rc-slider";
 import classNames from "classnames";
 import { Instance } from "mobx-state-tree";
@@ -9,6 +9,12 @@ import { TreeManager } from "../../models/history/tree-manager";
 import Marker from "../../clue/assets/icons/playback/marker.svg";
 import PlayButton from "../../clue/assets/icons/playback/play-button.svg";
 import PauseButton from "../../clue/assets/icons/playback/pause-button.svg";
+import { useDocumentComments, useDocumentCommentsAtSimplifiedPath } from "../../hooks/document-comment-hooks";
+import { WithId } from "../../hooks/firestore-hooks";
+import { CommentDocument } from "../../lib/firestore-schema";
+import { useNavTabPanelInfo } from "../../hooks/use-nav-tab-panel-info";
+import { HistoryEntryType } from "../../models/history/history";
+import { CommentMarker } from "./comment-marker";
 
 import "./playback-control.scss";
 
@@ -17,21 +23,41 @@ export interface IMarkerProps {
   location: number;
 }
 
+interface IHistorySliderEntry {
+  kind: "history";
+  entry: HistoryEntryType;
+  index: number;
+  created: Date;
+}
+export interface ICommentSliderEntry {
+  kind: "comment";
+  entry: WithId<CommentDocument>;
+  created: Date;
+}
+type ISliderEntry = IHistorySliderEntry | ICommentSliderEntry;
+
 interface IProps {
   treeManager: Instance<typeof TreeManager>;
 }
 
 export const PlaybackControlComponent: React.FC<IProps> = observer((props: IProps) => {
   const { treeManager } = props;
-  const { activeNavTab } = usePersistentUIStore();
+  const { activeNavTab, focusDocument } = usePersistentUIStore();
   const [sliderPlaying, setSliderPlaying] = useState(false);
   const sliderContainerRef = useRef<HTMLDivElement>(null);
   const railRef = useRef<HTMLDivElement>(null);
   const [markerSelected, setMarkerSelected] = useState(false);
   const [addMarkerButtonSelected, /* setAddMarkerButtonSelected */] = useState(false);
   const [markers, setMarkers] = useState<IMarkerProps[]>([]);
+  const { data: comments } = useDocumentComments(focusDocument);
+  const { data: simplePathComments } = useDocumentCommentsAtSimplifiedPath(focusDocument);
+  const allComments = [...comments||[], ...simplePathComments||[]]
+    .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+  const { setPlaybackTime } = useNavTabPanelInfo();
+
   // const [selectedMarkers, ] = useState<IMarkerProps[]>([]);
   const history = treeManager.document.history;
+
   // The numHistoryEntriesApplied should be set to the position of the history entry
   // that last "modified" the current document.
   //
@@ -41,11 +67,27 @@ export const PlaybackControlComponent: React.FC<IProps> = observer((props: IProp
   // by the history stuff, but it is being used to trigger document saves to Firebase
   // I think.  In some sense this is like a hash of the document content.
 
-  const {numHistoryEventsApplied, currentHistoryEntry} = treeManager;
+  const {numHistoryEventsApplied} = treeManager;
   // numHistoryEventsApplied can be 0 or undefined, the event is undefined in both cases
-  const sliderValue = numHistoryEventsApplied ?? 0;
-  const eventCreatedTime = currentHistoryEntry?.created;
-  const playbackDisabled = numHistoryEventsApplied === undefined || sliderValue === history.length;
+
+  const sliderEntries = useMemo(() => {
+    let entries: ISliderEntry[] = history
+      .map((entry, index) => ({kind: "history", entry, created: entry.created, index}));
+    entries = entries.concat(allComments.map((comment) => (
+      {kind: "comment", entry: comment, created: comment.createdAt}))
+    );
+    entries.sort((a, b) => a.created.getTime() - b.created.getTime());
+    return entries;
+  }, [history, allComments]);
+
+  const [sliderValue, setSliderValue] = useState(() => sliderEntries.length);
+
+  const eventCreatedTime = useMemo(() => {
+    const entry = sliderEntries[sliderValue] ?? sliderEntries[sliderEntries.length - 1];
+    return entry?.created;
+  }, [sliderValue, sliderEntries]);
+
+  const playbackDisabled = numHistoryEventsApplied === undefined || sliderValue === sliderEntries.length;
 
   const handlePlayPauseToggle = useCallback((playing?: boolean) => {
     const playStatus = playing !== undefined ? playing : !sliderPlaying;
@@ -53,19 +95,41 @@ export const PlaybackControlComponent: React.FC<IProps> = observer((props: IProp
     setSliderPlaying(playStatus);
   }, [sliderPlaying, treeManager]);
 
+  const goToSliderValue = useCallback((value: number) => {
+    // the slider max is sliderEntries.length, which is one more than the last index
+    // in sliderEntries. This value indicates going to the end of the history.
+    const sliderEntry = sliderEntries[value];
+    if (sliderEntry) {
+      setPlaybackTime(sliderEntry.created);
+      if (sliderEntry.kind === "history") {
+        treeManager.goToHistoryEntry(sliderEntry.index);
+      }
+    } else {
+      // go to the final history entry when at the end of the slider
+      treeManager.goToHistoryEntry(history.length);
+    }
+    setSliderValue(value);
+  }, [treeManager, history, sliderEntries, setPlaybackTime]);
+
+  const goToComment = useCallback((comment: WithId<CommentDocument>) => {
+    const index = sliderEntries.findIndex(e => e.kind === "comment" && e.entry.id === comment.id);
+    if (index !== -1) {
+      goToSliderValue(index);
+    }
+  }, [sliderEntries, goToSliderValue]);
+
   useEffect(() => {
     if (sliderPlaying) {
       const slider = setTimeout(()=>{
-        if (sliderValue < history.length) {
-          treeManager.goToHistoryEntry(sliderValue + 1);
+        if (sliderValue < sliderEntries.length) {
+          goToSliderValue(sliderValue + 1);
         } else {
           handlePlayPauseToggle(false);
         }
       }, 500);
       return () => clearTimeout(slider);
     }
-  }, [handlePlayPauseToggle, history.length, sliderPlaying, sliderValue, treeManager]);
-
+  }, [handlePlayPauseToggle, sliderEntries.length, sliderPlaying, sliderValue, goToSliderValue]);
 
   //TODO: need to add a modal that warns users about max number of markers. Currently, a generic alert is shown
   //TODO: Currently, if add marker is on and user moves the time handle, a marker is added where the user
@@ -90,7 +154,7 @@ export const PlaybackControlComponent: React.FC<IProps> = observer((props: IProp
   // };
 
   const handleSliderValueChange = (value: any) => {
-    treeManager.goToHistoryEntry(value);
+    goToSliderValue(value);
   };
 
   const handleSliderAfterChange = (value: any) => {
@@ -143,24 +207,33 @@ export const PlaybackControlComponent: React.FC<IProps> = observer((props: IProp
     }
   };
 
+  const getCommentLocation = (comment: WithId<CommentDocument>) => {
+    if (sliderEntries.length === 0) {
+      return 0;
+    }
+
+    const index = sliderEntries.findIndex(entry => entry.kind === "comment" && entry.entry.id === comment.id);
+    return Math.max(0, Math.min(100, 100 * (index / sliderEntries.length)));
+  };
+
+  const getMarkerLocation = (location: number) => {
+    const sliderComponentWidth = sliderContainerRef.current?.offsetWidth;
+    if (sliderComponentWidth) {
+      const markerOffset = ((location * (sliderComponentWidth - 20))/sliderComponentWidth);
+      return (markerOffset);
+    }
+  };
+
   const renderSliderContainer = () => {
     const markerContainerClass = classNames("marker-container", activeNavTab, {"selected": markerSelected});
     const markerClass = classNames("marker", activeNavTab);
-
-    const getMarkerLocation = (location: number) => {
-      const sliderComponentWidth = sliderContainerRef.current?.offsetWidth;
-      if (sliderComponentWidth) {
-        const markerOffset = ((location * (sliderComponentWidth - 20))/sliderComponentWidth);
-        return (markerOffset);
-      }
-    };
 
     return (
       <>
         <div className="slider-container" ref={sliderContainerRef} data-testid="playback-slider">
           <Slider
             min={0}
-            max={history.length}
+            max={sliderEntries.length}
             step={1}
             value={sliderValue}
             ref={railRef}
@@ -179,9 +252,26 @@ export const PlaybackControlComponent: React.FC<IProps> = observer((props: IProp
               <Marker className={markerClass}/>
             </div>
           );
-        })
-      }
+        })}
       </>
+    );
+  };
+
+  const renderCommentMarkers = () => {
+    return (
+      <div className="comment-markers-container" data-testid="comment-markers">
+        {
+          allComments.map(comment => {
+            return <CommentMarker
+              key={comment.id}
+              comment={comment}
+              commentLocation={getCommentLocation(comment)}
+              activeNavTab={activeNavTab}
+              onClick={goToComment}
+            />;
+          })
+        }
+      </div>
     );
   };
 
@@ -195,6 +285,7 @@ export const PlaybackControlComponent: React.FC<IProps> = observer((props: IProp
           addMarkerSelected={addMarkerButtonSelected} onAddMarkerSelected={handleAddMarkerButtonSelected}/> */}
       <div className={sliderComponentClass}>
         {renderMarkerComponent()}
+        {renderCommentMarkers()}
         {renderSliderContainer()}
       </div>
       {renderTimeInfo()}

--- a/src/components/vars.scss
+++ b/src/components/vars.scss
@@ -440,3 +440,24 @@ $six-pack-height: calc(100vh - (#{$header-height} + 20px));
   toolbarButtonMargin: $toolbar-button-margin;
   toolbarDividerWidth: $toolbar-divider-width;
 }
+
+// user icons (use in comments and in history playlist)
+$user-icon-student-color:            #828282;
+$user-icon-student-background:       #CDEBF2;
+$user-icon-student-border:           white;
+
+$user-icon-student-me-color:         #0592AF;
+$user-icon-student-me-background:    white;
+$user-icon-student-me-border:        #949494;
+
+$user-icon-student-ivan-color:       #FDFFAB;
+$user-icon-student-ivan-background:  #0592AF;
+$user-icon-student-ivan-border:      white;
+
+$user-icon-teacher-color:            #FF8415;
+$user-icon-teacher-background:       white;
+$user-icon-teacher-border:           #949494;
+
+// $user-icon-teacher-ada-color:  none; icon is multicolored
+$user-icon-teacher-ada-background:   white;
+$user-icon-teacher-ada-border:       #949494;

--- a/src/hooks/use-nav-tab-panel-info.tsx
+++ b/src/hooks/use-nav-tab-panel-info.tsx
@@ -1,0 +1,33 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+
+// This exists because the canvas component that renders the playback control keeps the history document
+// copy local and that history document's tree manager tracks the playback time. We need to
+// know the playback time in the chat panel which is a distant sibling of the canvas and can't react
+// to the local history document copy, so we must put this in a context of the nearest ancestor component
+// which is the nav tab panel.  The naming of this context is generic in case it is needed for other
+// uses in the nav tab panel in the future.
+
+type NavTabPanelInfoContextType = {
+  playbackTime: Date | undefined;
+  setPlaybackTime: (time: Date | undefined) => void;
+};
+
+const NavTabPanelInfoContext = createContext<NavTabPanelInfoContextType | undefined>(undefined);
+
+export const NavTabPanelInfoProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [playbackTime, setPlaybackTime] = useState<Date | undefined>(undefined);
+
+  return (
+    <NavTabPanelInfoContext.Provider value={{ playbackTime, setPlaybackTime }}>
+      {children}
+    </NavTabPanelInfoContext.Provider>
+  );
+};
+
+export const useNavTabPanelInfo = (): NavTabPanelInfoContextType => {
+  const context = useContext(NavTabPanelInfoContext);
+  if (!context) {
+    throw new Error('useNavTabPanelInfo must be used within a NavTabPanelInfoProvider');
+  }
+  return context;
+};


### PR DESCRIPTION
This changes the playback control to show markers for comments along the playback slider. The slider positions are now a combination of history entries and comments.  As the playback position changes, the comment thread updates to show comments relevant to the current position.

A few notes:

1. The playback will still show there is no history when there are only comments. We may want to change this in the future.
2. The comment thread header for deleted tiles has been updated to show a deleted icon along with the title "Deleted Tile".  Before the title was empty.  Since the tile name is not available after deletion, this is the best we can do.