### PR TITLE
fix: Straight arrows scale with tiles [CLUE-247]

### DIFF
--- a/src/components/annotations/annotation-utilities.ts
+++ b/src/components/annotations/annotation-utilities.ts
@@ -11,6 +11,11 @@ export type IParent = {
   tileId: string,
 }
 
+export interface ITileSize {
+  width: number;
+  height: number;
+}
+
 /**
  * Find the point on the line from source to target that is closest to the input point.
  * @param source - The start point of the line.
@@ -324,6 +329,17 @@ export const getTileOffsets = (canvasElement: HTMLDivElement, tileId: string) =>
   };
 
   return offsets;
+};
+
+export const getTileClientSize = (canvasElement: HTMLDivElement, tileId: string): ITileSize | undefined => {
+  const tileSelector = `[data-tool-id='${tileId}']`;
+  const tileElements = canvasElement.querySelectorAll<HTMLElement>(tileSelector);
+  const tileElement = tileElements && tileElements.length === 1 ? tileElements[0] : undefined;
+  if (!tileElement) return;
+
+  const {width, height} = tileElement.getBoundingClientRect();
+
+  return { width, height };
 };
 
 export const getParentOffsets = (canvasElement: HTMLDivElement, parentRowId: string, parentTileId: string) => {

--- a/src/models/document/row-list.ts
+++ b/src/models/document/row-list.ts
@@ -49,6 +49,15 @@ export const RowList = types
     get tileIds() {
       return self.rowOrder.flatMap(rowId => this.getRow(rowId)?.tileIds ?? []);
     },
+    /**
+     * Returns the tile ids in each row as map of row ids to an array of tile ids.
+     */
+    get orderedTileIds() {
+      return self.rowOrder.reduce<Record<string, string[]>>((acc, rowId) => {
+        acc[rowId] = this.getRow(rowId)?.tileIds ?? [];
+        return acc;
+      }, {});
+    },
     rowHeightToExport(row: TileRowModelType, tileId: string, tileMap: Map<string|number, ITileModel>) {
       if (!row?.height) return;
       // we only export heights for specific tiles configured to do so

--- a/src/models/document/row-list.ts
+++ b/src/models/document/row-list.ts
@@ -50,13 +50,19 @@ export const RowList = types
       return self.rowOrder.flatMap(rowId => this.getRow(rowId)?.tileIds ?? []);
     },
     /**
-     * Returns the tile ids in each row as map of row ids to an array of tile ids.
+     * Returns a string "signature" used to identify when the content has changed,
+     * either row ordering, tile ordering in rows or heights of rows
      */
-    get orderedTileIds() {
-      return self.rowOrder.reduce<Record<string, string[]>>((acc, rowId) => {
-        acc[rowId] = this.getRow(rowId)?.tileIds ?? [];
+    get layoutSignature(): string {
+      const rowLayouts = self.rowOrder.reduce<Record<string, {height: number, tileIds: string[]}>>((acc, rowId) => {
+        const row = this.getRow(rowId);
+        acc[rowId] = {
+          height: row?.height ?? 0,
+          tileIds: row?.tileIds ?? []
+        };
         return acc;
       }, {});
+      return JSON.stringify(rowLayouts);
     },
     rowHeightToExport(row: TileRowModelType, tileId: string, tileMap: Map<string|number, ITileModel>) {
       if (!row?.height) return;


### PR DESCRIPTION
Straight arrows now maintain their relative position on source tiles when those tiles are resized.

This is achieved by storing a normalized offset based on the source tile's dimensions.

NOTE: as part of this change the trigger for re-rendering the annotation layer was modified from when the row order changed to when the tile order changed across all rows.  This is to ensure that the annotation layer is re-rendered when tiles are moved between rows.