### PR TITLE
fix: Added missing isMe prop to playback control ChatAvatar [CLUE-276]

### DIFF
--- a/src/components/playback/comment-marker.tsx
+++ b/src/components/playback/comment-marker.tsx
@@ -9,12 +9,13 @@ import "./comment-marker.scss";
 
 interface IProps {
   comment: WithId<CommentDocument>;
+  isMe: boolean;
   commentLocation?: number;
   activeNavTab?: string;
   onClick: (commentEntry: WithId<CommentDocument>) => void;
 }
 
-export const CommentMarker: React.FC<IProps> = ({comment, commentLocation, activeNavTab, onClick}) => {
+export const CommentMarker: React.FC<IProps> = ({comment, isMe, commentLocation, activeNavTab, onClick}) => {
   // 10px is half the width of the marker, it is subtracted to center it
   const style = {left: `calc(${commentLocation}% - 10px)`};
 
@@ -24,7 +25,7 @@ export const CommentMarker: React.FC<IProps> = ({comment, commentLocation, activ
   return (
     <div key={`comment-${comment.id}`} className="comment-marker" style={style} onClick={handleOnClick} title={title}>
       <div className={classNames("vertical-line", activeNavTab)} />
-      <ChatAvatar uid={comment.uid} />
+      <ChatAvatar uid={comment.uid} isMe={isMe} />
     </div>
   );
 };

--- a/src/components/playback/playback-control.tsx
+++ b/src/components/playback/playback-control.tsx
@@ -3,7 +3,7 @@ import Slider from "rc-slider";
 import classNames from "classnames";
 import { Instance } from "mobx-state-tree";
 import { observer } from "mobx-react";
-import { usePersistentUIStore } from "../../hooks/use-stores";
+import { usePersistentUIStore, useStores } from "../../hooks/use-stores";
 import { logCurrentHistoryEvent } from "../../models/history/log-history-event";
 import { TreeManager } from "../../models/history/tree-manager";
 import Marker from "../../clue/assets/icons/playback/marker.svg";
@@ -43,6 +43,7 @@ interface IProps {
 export const PlaybackControlComponent: React.FC<IProps> = observer((props: IProps) => {
   const { treeManager } = props;
   const { activeNavTab, focusDocument } = usePersistentUIStore();
+  const { user } = useStores();
   const [sliderPlaying, setSliderPlaying] = useState(false);
   const sliderContainerRef = useRef<HTMLDivElement>(null);
   const railRef = useRef<HTMLDivElement>(null);
@@ -264,6 +265,7 @@ export const PlaybackControlComponent: React.FC<IProps> = observer((props: IProp
           allComments.map(comment => {
             return <CommentMarker
               key={comment.id}
+              isMe={comment.uid === user?.id}
               comment={comment}
               commentLocation={getCommentLocation(comment)}
               activeNavTab={activeNavTab}


### PR DESCRIPTION
This was causing the avatar's background color not to be set correctly.