### PR TITLE
CLUE-249 use a global BulkWriter

### DIFF
--- a/scripts/consolidate-metadata-docs.ts
+++ b/scripts/consolidate-metadata-docs.ts
@@ -70,7 +70,7 @@ async function getAllDocuments(ref: FirebaseFirestore.CollectionReference) {
   console.log("Ok Getting all documents from", ref.path);
   const documents: FirebaseFirestore.QueryDocumentSnapshot[] = [];
   let lastDoc: FirebaseFirestore.QueryDocumentSnapshot | null = null;
-  const batchSize = 100;
+  const batchSize = 1000;
 
   // This fetches 100 matching documents at a time to avoid query limits or memory issues.
   // eslint-disable-next-line no-constant-condition
@@ -454,6 +454,10 @@ async function reorganizeDocuments() {
         console.log("  would delete documents:", documentsToDelete);
       } else {
         for (const doc of documentsToDelete) {
+          if (doc === "" || doc == null) {
+            console.log("  skipping empty document deletion:", doc);
+            continue;
+          }
           console.log("  deleting document:", doc);
           await firestore.recursiveDelete(firestore.doc(documentsRoot + "/" + doc), writerState.bulkWriter);
         }

--- a/scripts/consolidate-metadata-docs.ts
+++ b/scripts/consolidate-metadata-docs.ts
@@ -8,8 +8,12 @@
 // $ npx tsx consolidate-comments.ts
 
 import admin from "firebase-admin";
+import { GrpcStatus } from "firebase-admin/firestore";
 import _ from "lodash";
-import { getFirestoreBasePath, getScriptRootFilePath, moveFirestoreDoc } from "./lib/script-utils.js";
+import {
+  copyFirestoreDoc, getFirestoreBasePath, getScriptRootFilePath, logErrorList,
+  logList, WriterState
+} from "./lib/script-utils.js";
 
 const databaseURL = "https://collaborative-learning-ec215.firebaseio.com";
 
@@ -98,16 +102,15 @@ async function getAllDocuments(ref: FirebaseFirestore.CollectionReference) {
   return documents;
 }
 
-function displayList(title: string, list: any[]) {
-  console.log(`Err ${title} (${list.length}):`);
-  for (const item of list) {
-    console.log("Err  ", item);
-  }
-}
+interface DocumentUpdates { [key: string]: any }
 
 // Checks and combines two documents.
 // Key fields must match; a few can differ and we combine them smartly.
-async function checkAndMerge(name: string, key: string) {
+async function checkAndMerge(
+  name: string,
+  baseData: admin.firestore.DocumentData,
+  updates: DocumentUpdates
+): Promise<string[]> {
   // Make sure that the contents of the new document match the existing one.
   const mustMatch = ["key", "uid", "context_id", "type", "title", ];
   const otherFields = ["tools", "tileTypes", "strategies", "teachers", "originDoc", "contextId", "createdAt",
@@ -117,111 +120,98 @@ async function checkAndMerge(name: string, key: string) {
 
   const newDoc = await firestore.doc(documentsRoot + "/" + name).get();
   const newData = newDoc.data();
-  const oldDoc = await firestore.doc(documentsRoot + "/" + key).get();
-  const oldData = oldDoc.data();
-  if (dryRun && oldData === undefined) {
-    // Since we're in dry run mode, this documents may not have been written.
-    return true;
-  }
+
+  const errors: string[] = [];
 
   for (const field of mustMatch) {
-    if (!_.isEqual(newData[field], oldData[field]) && (newData[field] || oldData[field])) {
-      console.error("Err Sanity check failed, mismatch in", field);
-      console.error("Err New data:", newData);
-      console.error("Err Old data:", oldData);
-      return false;
+    if (!_.isEqual(newData[field], baseData[field]) && (newData[field] || baseData[field])) {
+      errors.push(`mismatch in ${field} new data: ${newData[field]} base data: ${baseData[field]}`);
     }
   }
   // Check that there are no fields beyond the ones in our mustMatch and otherFields lists.
   const newFields = Object.keys(newData);
-  const oldFields = Object.keys(oldData);
+  const baseFields = Object.keys(baseData);
   for (const field of newFields) {
     if (!mustMatch.includes(field) && !otherFields.includes(field)) {
-      console.error("Err Sanity check failed, unexpected field:", field);
-      return false;
+      errors.push(`unexpected field in newDoc: ${field}`);
     }
   }
-  for (const field of oldFields) {
+  for (const field of baseFields) {
     if (!mustMatch.includes(field) && !otherFields.includes(field)) {
-      console.error("Err Sanity check failed, unexpected field:", field);
-      return false;
+      errors.push(`unexpected field in baseDoc: ${field}`);
     }
   }
 
   // See if there are any updates needed
-  const updates: { [key: string]: any } = {};
 
   // createdAt -- choose the earlier one.
-  if (newData.createdAt && (!oldData.createdAt || newData.createdAt < oldData.createdAt)) {
+  if (newData.createdAt && (!baseData.createdAt || newData.createdAt < baseData.createdAt)) {
     updates.createdAt = newData.createdAt;
   }
   // unit, investigation, problem, visibility, offeringId -- if one has a value, use that.
-  if (newData.unit && !oldData.unit) {
+  if (newData.unit && !baseData.unit) {
     updates.unit = newData.unit;
   }
-  if (newData.unit && oldData.unit && newData.unit !== oldData.unit) {
-    console.log("Err mismatch in unit:", newData.unit, oldData.unit);
-    return false;
+  if (newData.unit && baseData.unit && newData.unit !== baseData.unit) {
+    errors.push(`mismatch in unit, new: ${newData.unit} base: ${baseData.unit}`);
   }
-  if (newData.investigation && !oldData.investigation) {
+  if (newData.investigation && !baseData.investigation) {
     updates.investigation = newData.investigation;
   }
-  if (newData.investigation && oldData.investigation && newData.investigation !== oldData.investigation) {
-    console.log("Err mismatch in investigation:", newData.investigation, oldData.investigation);
-    return false;
+  if (newData.investigation && baseData.investigation && newData.investigation !== baseData.investigation) {
+    errors.push(`mismatch in investigation, new: ${newData.investigation} base: ${baseData.investigation}`);
   }
-  if (newData.problem && !oldData.problem) {
+  if (newData.problem && !baseData.problem) {
     updates.problem = newData.problem;
   }
-  if (newData.problem && oldData.problem && newData.problem !== oldData.problem) {
-    console.log("Err mismatch in problem:", newData.problem, oldData.problem);
-    return false;
+  if (newData.problem && baseData.problem && newData.problem !== baseData.problem) {
+    errors.push(`mismatch in problem, new: ${newData.problem} base: ${baseData.problem}`);
   }
-  if (newData.visibility && !oldData.visibility) {
+  if (newData.visibility && !baseData.visibility) {
     updates.visibility = newData.visibility;
   }
-  if (newData.visibility && oldData.visibility && newData.visibility !== oldData.visibility) {
-    console.log("Err mismatch in visibility:", newData.visibility, oldData.visibility);
-    return false;
+  if (newData.visibility && baseData.visibility && newData.visibility !== baseData.visibility) {
+    errors.push(`mismatch in visibility, new: ${newData.visibility} base: ${baseData.visibility}`);
   }
-  if (newData.offeringId && !oldData.offeringId) {
+  if (newData.offeringId && !baseData.offeringId) {
     updates.offeringId = newData.offeringId;
   }
-  if (newData.offeringId && oldData.offeringId && newData.offeringId !== oldData.offeringId) {
-    console.log("Err mismatch in offeringId:", newData.offeringId, oldData.offeringId);
-    return false;
+  if (newData.offeringId && baseData.offeringId && newData.offeringId !== baseData.offeringId) {
+    errors.push(`mismatch in offeringId, new: ${newData.offeringId} base: ${baseData.offeringId}`);
   }
   // tileTypes, tools, strategies -- choose the one with more values.
-  if (newData.tileTypes && (!oldData.tileTypes || newData.tileTypes.length > oldData.tileTypes.length)) {
+  if (newData.tileTypes && (!baseData.tileTypes || newData.tileTypes.length > baseData.tileTypes.length)) {
     updates.tileTypes = newData.tileTypes;
   }
-  if (newData.tools && (!oldData.tools || newData.tools.length > oldData.tools.length)) {
+  if (newData.tools && (!baseData.tools || newData.tools.length > baseData.tools.length)) {
     updates.tools = newData.tools;
   }
-  if (newData.strategies && (!oldData.strategies || newData.strategies.length > oldData.strategies.length)) {
+  if (newData.strategies && (!baseData.strategies || newData.strategies.length > baseData.strategies.length)) {
     updates.strategies = newData.strategies;
   }
   // originDoc -- if one has a value, use that.
-  if (newData.originDoc !== undefined && oldData.originDoc === undefined) {
+  if (newData.originDoc !== undefined && baseData.originDoc === undefined) {
     updates.originDoc = newData.originDoc;
   }
-  if (!_.isEmpty(newData.properties) && _.isEmpty(oldData.properties)) {
+  if (!_.isEmpty(newData.properties) && _.isEmpty(baseData.properties)) {
     updates.properties = newData.properties;
   }
-  if (!_.isEmpty(newData.properties) && !_.isEmpty(oldData.properties)
-    && !_.isEqual(newData.properties, oldData.properties)) {
+  if (!_.isEmpty(newData.properties) && !_.isEmpty(baseData.properties)
+    && !_.isEqual(newData.properties, baseData.properties)) {
     // Warn if the properties contains any fields other than pubCount or isDeleted
     if (Object.keys(newData.properties).some(k => !propertiesFields.includes(k))
-      || Object.keys(oldData.properties).some(k => !propertiesFields.includes(k))) {
-        console.log("Err unknown field in properties:", newData.properties, oldData.properties);
-        return false;
+      || Object.keys(baseData.properties).some(k => !propertiesFields.includes(k))) {
+        errors.push(`unknown field in properties, ` +
+          `new: ${newData.properties.toJSON()} ` +
+          `base: ${baseData.properties.toJSON()}`
+        );
     }
-    updates.properties = oldData.properties;
+    updates.properties = baseData.properties;
     if (newData.properties.pubCount !== undefined) {
       // For pubCount, keep the larger one.
-      updates.properties.pubCount = Math.max(newData.properties.pubCount, oldData.properties.pubCount || 0);
+      updates.properties.pubCount = Math.max(newData.properties.pubCount, baseData.properties.pubCount || 0);
     }
-    if (newData.properties.isDeleted !== undefined && oldData.properties.isDeleted === undefined) {
+    if (newData.properties.isDeleted !== undefined && baseData.properties.isDeleted === undefined) {
       // For isDeleted, keep whichever has a value.
       updates.properties.isDeleted = newData.properties.isDeleted;
     }
@@ -229,41 +219,17 @@ async function checkAndMerge(name: string, key: string) {
 
   // teachers, contextId, network -- not used any more, just ignore.
 
-  // Write out the updates
-  if (Object.keys(updates).length > 0) {
-    console.log("Ok Updates needed:", updates);
-    if (!dryRun) {
-      await oldDoc.ref.update(updates);
-    }
-  }
-
-  return true;
-}
-
-// Moves a document and all its subcollections.
-async function moveDocument(name: string, newName: string) {
-  console.log("Ok  move", name, "->", newName);
-  if (!dryRun) {
-    await moveFirestoreDoc(firestore, documentsRoot, name, documentsRoot, newName, "all");
-  }
-}
-
-// Copies comments, history, or whatever subcollections in finds under the parent,
-// but just deletes the parent document.
-async function moveSubcollections(name: string, newName: string) {
-  console.log("Ok  move subcollections only", name, "->", newName);
-  if (!dryRun) {
-    await moveFirestoreDoc(firestore, documentsRoot, name, documentsRoot, newName, "subcollections");
-  }
+  return errors;
 }
 
 async function reorganizeDocuments() {
   const documentsRef = firestore.collection(documentsRoot);
   const documents = await getAllDocuments(documentsRef);
-  const numDocs = documents.length;
+  let docsToProcess = 0;
   let docsProcessed = 0;
   const docInfo: { [key: string]: DocumentInfo } = {};
   const errorDocs = [];
+  const curriculumDocs = [];
   for (const docSnapshot of documents) {
     const type = typeOfDocument(docSnapshot);
     if (type === "error") {
@@ -271,47 +237,226 @@ async function reorganizeDocuments() {
       continue;
     }
     if (type === "curriculum") {
+      curriculumDocs.push(docSnapshot.id);
       continue;
     }
     const unprefixed = docSnapshot.data().key;
 
     if (!(unprefixed in docInfo)) {
+      docsToProcess++;
       docInfo[unprefixed] = { key: unprefixed, commentableDocs: [] };
     }
     docInfo[unprefixed].commentableDocs.push({ name: docSnapshot.id, type });
   }
 
   if (errorDocs.length > 0) {
-    displayList("Unexpected documents found, ignoring:", errorDocs);
+    logList("Err Unexpected documents found, ignoring:", errorDocs);
   }
+  if (curriculumDocs.length > 0) {
+    logList("Curriculum documents found, ignoring:", curriculumDocs);
+  }
+
+  const writerState: WriterState = {
+    firestore,
+    bulkWriter: firestore.bulkWriter(),
+    operationsCount: 0,
+    writeErrors: [],
+    dryRun
+  };
+
+  const allowedExistingPaths = new Set<string>();
+  let resourceExhaustedErrors = 0;
+
+  writerState.bulkWriter.onWriteError((err) => {
+    // Because this script has been run before and then stopped in the middle there are some
+    // documents that have been partially processed. This means they have history and comment
+    // entries already copied into the unprefixed document. These history and comment entries
+    // have unique ids, so if they already exist we can just ignore this error.
+    if (err.code === GrpcStatus.ALREADY_EXISTS) {
+      for (const allowedExistingPath of allowedExistingPaths) {
+        if (err.documentRef.path.startsWith(allowedExistingPath)) {
+          console.log("  skipping existing document", err.documentRef.path);
+          // We reject the promise here, but don't record it as a writeError
+          return false;
+        }
+      }
+
+    }
+
+    const retriable = (
+      err.code === GrpcStatus.ABORTED ||
+      err.code === GrpcStatus.UNAVAILABLE ||
+      err.code === GrpcStatus.RESOURCE_EXHAUSTED
+    ) && err.failedAttempts < 10;
+    if (err.code === GrpcStatus.RESOURCE_EXHAUSTED) {
+      resourceExhaustedErrors++;
+      if (resourceExhaustedErrors > 10) {
+        console.error("Err Too many resource exhausted errors, exiting");
+        logErrorList("Err Errors during writes:", writerState.writeErrors);
+        // If we are getting resource exhausted errors then we should stop
+        // trying to write more documents.
+        process.exit(1);
+      }
+    }
+    if (!retriable) {
+      writerState.writeErrors.push({
+        path: err.documentRef.path,
+        code: err.code,
+        attempts: err.failedAttempts,
+        message: err.message,
+      });
+    }
+    return retriable; // true = retry, false = stop and reject that write's Promise
+  });
 
   for (const key in docInfo) {
     const documentInfo = docInfo[key];
-    let hasBaseDoc = documentInfo.commentableDocs.some(doc => doc.type === "unprefixed");
+    const hasUnprefixedDoc = documentInfo.commentableDocs.some(doc => doc.type === "unprefixed");
     docsProcessed++;
-    console.log("Ok", docsProcessed, "of", numDocs, "documents", key, ":");
-    if (hasBaseDoc && documentInfo.commentableDocs.length === 1) {
+    console.log("Processing", key, `(${docsProcessed}/${docsToProcess}) :`);
+    if (hasUnprefixedDoc && documentInfo.commentableDocs.length === 1) {
+      console.log("  only found an unprefixed doc, nothing to do");
       continue;
     }
+
+    // We want a single write to the unprefixed/base document
+    // So we maintain a local copy of the base document data. If this document
+    // already exists in Firestore then we track any updates needed to it.
+    // If the document doesn't exist then we start the content with the first
+    // prefixed document and then merge any additional prefixed documents into this
+    // one.
+    // At the end we either apply the updates to the existing document or we create
+    // a new document.
+    // Finally if there are no errors then we delete the old documents
+    const baseDocRef = firestore.doc(documentsRoot + "/" + key);
+    let baseDocData: admin.firestore.DocumentData | undefined;
+    let updates: DocumentUpdates | undefined;
+
+    if (hasUnprefixedDoc) {
+      const baseDoc = await baseDocRef.get();
+      baseDocData = baseDoc.data();
+      updates = {};
+    }
+
+    const documentsToDelete: string[] = [];
+
+    // Ignore errors for existing documents under this baseDocument
+    const subDocumentsPath = baseDocRef.path + "/";
+    allowedExistingPaths.add(subDocumentsPath);
+    let skipBecauseOfMergeErrors = false;
+
     for (const doc of documentInfo.commentableDocs) {
       if (doc.type === "unprefixed") {
-        console.log("Ok  unprefixed doc, leave as is", doc.name);
+        console.log("  unprefixed doc, leave as is", doc.name);
       } else if (doc.type === "prefixed") {
-        if (hasBaseDoc) {
-          if (await checkAndMerge(doc.name, key)) {
-            await moveSubcollections(doc.name, key);
-          } else {
-            // We exit the entire script if the sanity check fails -- it means there is an unexpected
-            // data inconsistency that should be investigated, or something the script doesn't yet handle.
-            console.error("Err Sanity check failed");
-            process.exit(1);
+        if (baseDocData) {
+          console.log("  merging prefixed doc into base", doc.name);
+          const mergeErrors = await checkAndMerge(doc.name, baseDocData, updates);
+          if (mergeErrors.length > 0) {
+            // We don't exit the entire script if the sanity check fails
+            // We just log the errors and don't make any changes to the database for this
+            // document.
+            logErrorList(`Err Sanity check failed for prefixed doc: ${doc.name}`, mergeErrors);
+            skipBecauseOfMergeErrors = true;
           }
         } else {
-          await moveDocument(doc.name, key);
-          hasBaseDoc = true; // this becomes the base doc after the move
+          console.log("  using first prefixed doc as base", doc.name);
+          // There is no baseDoc yet so the first prefixed document we find
+          // becomes the initial content of the baseDoc
+          const newBaseDoc = await firestore.doc(documentsRoot + "/" + doc.name).get();
+          baseDocData = newBaseDoc.data();
+
+          // We set the updates to this baseDocData. This way any changes
+          // merged from additional prefixed documents will directly update the
+          // baseDocData that we are going to write out at the end.
+          updates = baseDocData;
         }
+
+        if (skipBecauseOfMergeErrors) {
+          continue;
+        }
+
+        // Copy comments, history, or whatever subcollections it finds under the parent,
+        console.log("  copying subcollections from", doc.name, "to", key);
+        const startingOperationsCount = writerState.operationsCount;
+        // If writerState.dryRun is true, we won't actually update the database
+        const copied = await copyFirestoreDoc(
+          writerState,
+          documentsRoot, doc.name,
+          documentsRoot, key,
+          "subcollections"
+        );
+
+        const docsCopied = writerState.operationsCount - startingOperationsCount;
+        if (dryRun) {
+          console.log("  would have copied", docsCopied, "documents");
+        } else {
+          console.log("  copied", docsCopied, "documents");
+        }
+
+        if (!copied) {
+          console.error("Err Failed to copy document", doc.name, "to", key);
+          process.exit(1);
+        }
+
+        documentsToDelete.push(doc.name);
       } else {
         throw new Error("Unexpected document type: " + doc.type);
+      }
+    }
+
+    allowedExistingPaths.delete(subDocumentsPath);
+
+    if (skipBecauseOfMergeErrors) {
+      console.log("  skipping document due to merge errors");
+      continue;
+    }
+
+    if (hasUnprefixedDoc) {
+      // We had a unprefixed document already
+      // If there are changes from prefixed documents we need to update this doc
+      if (Object.keys(updates).length > 0) {
+        if (dryRun) {
+          console.log("  would update base document:", updates);
+        } else {
+          console.log("  updating base document:", updates);
+          // We wait for the update to complete incase there is an error.
+          // The BulkWriter will send the error to the onWriteError handler
+          // it might throw it here too, that isn't clear
+          await writerState.bulkWriter.update(baseDocRef, updates);
+        }
+      } else {
+        console.log("  no updates to base document");
+      }
+    } else {
+      // We didn't have a base (unprefixed) document, so we need to create one
+      if (!baseDocData) {
+        throw new Error("No baseDocData for key " + key);
+      }
+      if (dryRun) {
+        console.log("  would create base document:", baseDocData);
+      } else {
+        console.log("  creating base document:", baseDocData);
+        // We wait for the create to complete incase there is an error.
+        // The BulkWriter will send the error to the onWriteError handler
+        // it might throw it here too, that isn't clear
+        await writerState.bulkWriter.create(baseDocRef, baseDocData);
+      }
+    }
+
+    if (writerState.writeErrors.length > 0) {
+      logErrorList("Err Errors during writes:", writerState.writeErrors);
+      process.exit(1);
+    }
+
+    if (documentsToDelete.length > 0) {
+      if (dryRun) {
+        console.log("  would delete documents:", documentsToDelete);
+      } else {
+        for (const doc of documentsToDelete) {
+          console.log("  deleting document:", doc);
+          await firestore.recursiveDelete(firestore.doc(documentsRoot + "/" + doc), writerState.bulkWriter);
+        }
       }
     }
   }

--- a/scripts/consolidate-metadata-docs.ts
+++ b/scripts/consolidate-metadata-docs.ts
@@ -369,7 +369,7 @@ async function reorganizeDocuments() {
             // We don't exit the entire script if the sanity check fails
             // We just log the errors and don't make any changes to the database for this
             // document.
-            logErrorList(`Err Sanity check failed for prefixed doc: ${doc.name}`, mergeErrors);
+            logErrorList(`Err Sanity check failed for prefixed doc: ${doc.name}`, mergeResult.errors);
             skipBecauseOfMergeErrors = true;
           }
           prefixedCreatedTime = mergeResult.newData.createdAt;

--- a/scripts/lib/script-utils.ts
+++ b/scripts/lib/script-utils.ts
@@ -327,7 +327,6 @@ export const internalCopyFirestoreDoc = async (
     // Note there are other places where the bulkWriter is used to create or update
     // documents, currently those other places are not counted towards the 1000 limit.
     if (state.operationsCount % 1000 === 0) {
-      console.log("  flushing writes", state.operationsCount);
       // As far as I can tell the flush here will wait for all of the write operations
       // to complete and honor the exponential backoff before continuing.
       await bulkWriter.flush();
@@ -343,6 +342,8 @@ export const internalCopyFirestoreDoc = async (
   for (const subcollectionRef of subcollections) {
     const subcollectionPath = `${collectionFrom}/${docId}/${subcollectionRef.id}`;
     const subcollectionPathTo = `${collectionTo}/${docIdTo}/${subcollectionRef.id}`;
+
+    process.stdout.write(`  copying ${subcollectionRef.id} `);
 
     // get all the documents in the collection
     try {
@@ -373,7 +374,11 @@ export const internalCopyFirestoreDoc = async (
           numCopiedDocs++;
           lastDoc = doc;
         }
+        process.stdout.write(".");
       } while (snapshot.docs.length === 1000);
+
+      // Close out the status line
+      process.stdout.write("\n");
 
       const logMessage = `${numCopiedDocs} documents from ${subcollectionRef.id}`;
       if (dryRun) {

--- a/scripts/lib/script-utils.ts
+++ b/scripts/lib/script-utils.ts
@@ -420,7 +420,7 @@ export const moveFirestoreDoc = async (
   scope: "document" | "subcollections" | "all" = "all",
 ): Promise<boolean> => {
   const { firestore, bulkWriter } = state;
-  const copied = await copyFirestoreDoc(state, collectionFrom, docId, collectionTo, docIdTo, scope);
+  const copied = await copyFirestoreDoc(state, collectionFrom, docId, collectionTo, docIdTo, scope, undefined);
   // If copy was successful, delete the original
   // We use a passed in bulkWriter, so the exponential backoff will be shared
   // between the copy and delete operations.


### PR DESCRIPTION
- improve logging and error logging
- reduce number of writes needed when there are multiple prefixed documents
- don't delete top level document or its collections until all of its data has been merged into the unprefixed document
- allow subcollection documents to already exist at the unprefixed location
- retry if a resource exhausted error is reported by firestore, the bulk writer should wait 1 minute before retrying.
- if we get more than 10 resource exhausted errors then just exit the script.
- don't completely bail if there are merge errors, report all of them and then skip the document
- fix count of documents so the status matches up
- record curriculum metadata docs
- during a dryRun actually process the subcollections
- log how many documents are in each subcollection
- don't look for subcollections of subcollections, this slowed down the process a lot since some subcollections had 40,000 documents in them