### PR TITLE
feat: Add auth to authoring [CLUE-292]

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -18,6 +18,9 @@
     },
     "functions": {
       "port": 5001
+    },
+    "auth": {
+      "port": 9099
     }
   },
   "functions": [

--- a/src/authoring/components/app.scss
+++ b/src/authoring/components/app.scss
@@ -1,8 +1,9 @@
+@import "../../components/vars.scss";
 
 html, body, #app {
   margin: 0;
   padding: 0;
-      font-family: "Lato", "Noto Sans Symbols 2", "Noto Sans Math", sans-serif;
+  font-family: "Lato", "Noto Sans Symbols 2", "Noto Sans Math", sans-serif;
 }
 
 .app {
@@ -12,9 +13,9 @@ html, body, #app {
 	overflow: hidden;
 
   .header {
-    background-color: #cdebf2;
+    background-color: $workspace-teal-light-5;
     border-bottom: 1px solid #ccc;
-    color: #3f3f3f;
+    color: $charcoal-dark-2;
     padding: 5px 10px;
     display: flex;
     align-items: center;
@@ -28,10 +29,13 @@ html, body, #app {
     }
 
     .info {
-      a {
+      a, span {
         font-weight: 600;
         color: inherit;
+        text-decoration: underline;
+        cursor: pointer;
       }
+      text-align: right;
     }
   }
 
@@ -53,6 +57,42 @@ html, body, #app {
 
       select {
         padding: 5px;
+      }
+    }
+
+    .sign-in-form {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      align-items: flex-start;
+
+      label {
+        font-weight: 600;
+        margin-right: 10px;
+        display: block;
+      }
+
+      input {
+        padding: 5px;
+        font-size: 1em;
+        border: 1px solid #ccc;
+        border-radius: 3px;
+        min-width: 300px;
+      }
+    }
+
+    button {
+      padding: 5px 15px;
+      font-size: 1em;
+      background-color: $color7;
+      color: white;
+      border: none;
+      border-radius: 3px;
+      cursor: pointer;
+
+      &:disabled {
+        background-color: #9e9e9e;
+        cursor: not-allowed;
       }
     }
   }

--- a/src/authoring/components/app.tsx
+++ b/src/authoring/components/app.tsx
@@ -4,12 +4,14 @@ import React, { useEffect } from "react";
 import { units, useCurriculum } from "../hooks/use-curriculum";
 import LeftNav from "./left-nav";
 import Workspace from "./workspace";
+import useAuth from "../hooks/use-auth";
 
 import "./app.scss";
 
 const App: React.FC = () => {
   const { branch, listBranches, setBranch, unit, setUnit, unitConfig, error, path, loadFile } = useCurriculum();
   const [branches, setBranches] = React.useState<string[]>([]);
+  const auth = useAuth();
 
   useEffect(() => {
     if (!branch) {
@@ -19,23 +21,79 @@ const App: React.FC = () => {
     }
   }, [branch, listBranches]);
 
+  const maybeSignOut = () => {
+    if (confirm("Are you sure you want to sign out?")) {
+      auth.signOut();
+    }
+  };
+
   const renderHeader = () => {
     const title = `CLUE Authoring${unitConfig ? `: ${unitConfig.title}` : ""}`;
 
     return (
       <header className="header">
         <div className="title">{title}</div>
-        {branch && unit && unitConfig && (
-          <div className="info">
-            Branch: <a href="#/">{branch}</a> / Unit: <a href={`#/${branch}`}>{unit}</a>
-          </div>
-        )}
+        <div className="info">
+          {auth.user && (
+            <div>{auth.user.email} | <span onClick={() => maybeSignOut()}>Logout</span></div>
+          )}
+          {(branch || unit) && (
+            <>
+              Branch: <a href="#/">{branch}</a> {unit && "| Unit:"} {unit && <a href={`#/${branch}`}>{unit}</a>}
+            </>
+          )}
+        </div>
       </header>
     );
   };
 
   const renderMainContent = () => {
-    // skip authState check for now
+    if (auth.loading) {
+      return <div className="centered">Checking authentication...</div>;
+    }
+    if (auth.error) {
+      return (
+        <div className="centered">
+          <div className="error">Authentication error: {auth.error}</div>
+          <div>
+            <button onClick={auth.reset}>Try Again</button>
+          </div>
+        </div>
+      );
+    }
+    if (!auth.user) {
+      return (
+        <div className="centered">
+          <div>
+            <h2>Please Sign In</h2>
+            <form
+              className="sign-in-form"
+              onSubmit={async (e) => {
+                e.preventDefault();
+                const form = e.target as HTMLFormElement;
+                const email = (form.elements.namedItem("email") as HTMLInputElement).value;
+                const password = (form.elements.namedItem("password") as HTMLInputElement).value;
+                await auth.signIn(email, password);
+              }}
+            >
+              <div>
+                <label htmlFor="email">Email:</label>
+                <input id="email" type="email" name="email" required autoFocus disabled={auth.loading} />
+              </div>
+              <div>
+                <label htmlFor="password">Password:</label>
+                <input id="password" type="password" name="password" required disabled={auth.loading} />
+              </div>
+              <div>
+                <button type="submit" disabled={auth.loading}>
+                  {auth.loading ? "Signing in..." : "Sign In"}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      );
+    }
 
     if (!branch) {
       if (branches.length === 0) {

--- a/src/authoring/hooks/use-auth.ts
+++ b/src/authoring/hooks/use-auth.ts
@@ -1,0 +1,65 @@
+import { useState, useEffect } from "react";
+import firebase from "firebase/app";
+import "firebase/auth";
+
+import { initializeApp } from "../../lib/firebase-config";
+
+function useAuth() {
+  const [user, setUser] = useState<firebase.User | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [resetCount, setResetCount] = useState(0);
+
+  useEffect(() => {
+    initializeApp();
+
+    const unsubscribe = firebase.auth().onAuthStateChanged((authUser) => {
+      // do not allow anonymous users (which happens when running the main CLUE app directly before signing in here)
+      if (authUser?.isAnonymous) {
+        firebase.auth().signOut();
+        setUser(null);
+      } else {
+        setUser(authUser);
+      }
+      setLoading(false);
+    });
+
+    return () => unsubscribe();
+  }, [resetCount]);
+
+  const signIn = async (email: string, password: string) => {
+    reset();
+    try {
+      await firebase.auth().signInWithEmailAndPassword(email, password);
+    } catch (err: any) {
+      setError(err.message ?? "An error occurred during sign-in.");
+      console.error("Sign-in error:", err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const signOut = async () => {
+    reset();
+
+    try {
+      await firebase.auth().signOut();
+    } catch (err: any) {
+      setError(err.message ?? "An error occurred during sign-out.");
+      console.error("Sign-out error:", err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const reset = () => {
+    setUser(null);
+    setLoading(true);
+    setError(null);
+    setResetCount((count) => count + 1);
+  };
+
+  return { user, loading, error, signIn, signOut,reset };
+}
+
+export default useAuth;

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -36,8 +36,7 @@ import { getFirebaseFunction } from "../hooks/use-firebase-function";
 import { IStores } from "../models/stores/stores";
 import { TeacherSupportModelType, SectionTarget, AudienceModelType } from "../models/stores/supports";
 import { safeJsonParse } from "../utilities/js-utils";
-import { urlParams } from "../utilities/url-params";
-import { firebaseConfig } from "./firebase-config";
+import { initializeApp } from "./firebase-config";
 import { UserModelType } from "../models/stores/user";
 import { logExemplarDocumentEvent } from "../models/document/log-exemplar-document-event";
 import { AppMode } from "../models/stores/store-types";
@@ -126,37 +125,7 @@ export class DB {
         reject("Already connected to database!");
       }
 
-      // check for already being initialized for tests
-      if (firebase.apps.length === 0) {
-        firebase.initializeApp(firebaseConfig());
-      }
-
-      if (urlParams.firebase) {
-        // pass `firebase=emulator` to test against firebase emulator instance
-        const url = new URL(urlParams.firebase === "emulator"
-                              ? "http://localhost:9000" : urlParams.firebase);
-        if (url.hostname && url.port) {
-          firebase.database().useEmulator(url.hostname, parseInt(url.port, 10));
-        }
-      }
-
-      if (urlParams.firestore) {
-        // pass `firestore=emulator` to test against firestore emulator instance
-        const url = new URL(urlParams.firestore === "emulator"
-                              ? "http://localhost:8088" : urlParams.firestore);
-        if (url.hostname && url.port) {
-          firebase.firestore().useEmulator(url.hostname, parseInt(url.port, 10));
-        }
-      }
-
-      if (urlParams.functions) {
-        // pass `functions=emulator` to test against functions running in the emulator
-        const url = new URL(urlParams.functions === "emulator"
-                              ? "http://localhost:5001" : urlParams.functions);
-        if (url.hostname && url.port) {
-          firebase.functions().useEmulator(url.hostname, parseInt(url.port, 10));
-        }
-      }
+      initializeApp();
 
       this.stores = options.stores;
 

--- a/src/lib/firebase-config.ts
+++ b/src/lib/firebase-config.ts
@@ -1,4 +1,9 @@
 import firebase from "firebase/app";
+import "firebase/auth";
+import "firebase/database";
+import "firebase/firestore";
+import "firebase/functions";
+import "firebase/storage";
 
 import { urlParams } from "../utilities/url-params";
 

--- a/src/lib/firebase-config.ts
+++ b/src/lib/firebase-config.ts
@@ -1,3 +1,5 @@
+import firebase from "firebase/app";
+
 import { urlParams } from "../utilities/url-params";
 
 const validProjects = ["staging", "production"] as const;
@@ -42,4 +44,48 @@ export function firebaseConfig() {
   }
 
   return configs[firebaseEnv];
+}
+
+export function initializeApp() {
+  // check for already being initialized for tests
+  if (firebase.apps.length === 0) {
+    firebase.initializeApp(firebaseConfig());
+  }
+
+  if (urlParams.firebase) {
+    // pass `firebase=emulator` to test against firebase emulator instance
+    const url = new URL(urlParams.firebase === "emulator"
+                          ? "http://localhost:9000" : urlParams.firebase);
+    if (url.hostname && url.port) {
+      firebase.database().useEmulator(url.hostname, parseInt(url.port, 10));
+    }
+  }
+
+  if (urlParams.firestore) {
+    // pass `firestore=emulator` to test against firestore emulator instance
+    const url = new URL(urlParams.firestore === "emulator"
+                          ? "http://localhost:8088" : urlParams.firestore);
+    if (url.hostname && url.port) {
+      firebase.firestore().useEmulator(url.hostname, parseInt(url.port, 10));
+    }
+  }
+
+  if (urlParams.functions) {
+    // pass `functions=emulator` to test against functions running in the emulator
+    const url = new URL(urlParams.functions === "emulator"
+                          ? "http://localhost:5001" : urlParams.functions);
+    if (url.hostname && url.port) {
+      firebase.functions().useEmulator(url.hostname, parseInt(url.port, 10));
+    }
+  }
+
+  if (urlParams.auth) {
+    // pass `auth=emulator` to test against auth running in the emulator
+    const url = new URL(urlParams.auth === "emulator"
+                          ? "http://localhost:9099" : urlParams.auth);
+    if (url.hostname && url.port) {
+      // note: unlike the other useEmulator() methods this takes a full url
+      firebase.auth().useEmulator(url.toString());
+    }
+  }
 }

--- a/src/utilities/url-params.ts
+++ b/src/utilities/url-params.ts
@@ -96,6 +96,8 @@ export interface QueryParams {
   firestore?: string; // "emulator" or host:port url
   // direct firebase function calls to the emulator
   functions?: string; // "emulator" or host:port url
+  // direct firebase auth to the emulator
+  auth?: string; // "emulator" or host:port url
   // do not use persistentUI in some cy tests that rely on demo
   noPersistentUI?: boolean;
   // mouse sensor can be enabled for cypress drag and drop tests for dnd-kit


### PR DESCRIPTION
This adds Firebase email/password authentication to the authoring tool.

It includes sign-in, sign-out, and user state management.  A custom hook is used as the FirebaseUI package is not compatible with Firebase 8.

This may be extended in the future to support Gmail OAuth to allow CC Google Workspace users to sign in with their Google accounts and automatically be granted access.

To enable local testing, the Firebase Auth emulator is now supported via the `?auth=emulator` URL parameter.

NOTE: this also centralizes Firebase initialization to avoid duplicating code in the main app.