### PR TITLE
ffeat: Replace authoring username/password with GitHub Auth [CLUE-297]

### DIFF
--- a/authoring-api/src/helpers/express.ts
+++ b/authoring-api/src/helpers/express.ts
@@ -1,4 +1,10 @@
-import {Response} from "express";
+import {Request, Response} from "express";
+import {DecodedIdToken} from "firebase-admin/auth";
+
+export interface AuthorizedRequest extends Request{
+  decodedToken: DecodedIdToken;
+  gitHubToken: string;
+}
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const sendSuccessResponse = (res: Response, data: any) => {

--- a/authoring-api/src/helpers/github.ts
+++ b/authoring-api/src/helpers/github.ts
@@ -3,8 +3,9 @@ import {Octokit} from "@octokit/rest";
 export const owner = "concord-consortium";
 export const repo = "clue-curriculum";
 
-// TODO: change auth to required to avoid rate limiting
-export const newOctoKit = (auth?: string) => new Octokit({auth});
+export const newOctoKit = (auth: string) => {
+  return new Octokit({auth});
+};
 
 export const baseCurriculumPath = "curriculum";
 export const getBaseUnitPath = (unit: string) => `${baseCurriculumPath}/${unit}/`;

--- a/authoring-api/src/index.ts
+++ b/authoring-api/src/index.ts
@@ -134,7 +134,8 @@ export const authenticateAndAuthorize = async (req: Request, res: Response, next
     }
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   } catch (error) {
-    return res.status(401).send(`Unauthorized: Invalid or expired token: ${error}`);
+    console.error("Authentication error:", error);
+    return res.status(401).send("Unauthorized: Invalid or expired token.");
   }
 };
 

--- a/authoring-api/src/index.ts
+++ b/authoring-api/src/index.ts
@@ -13,25 +13,92 @@ import getPulledUnits from "./routes/get-pulled-units";
 import getPulledFiles from "./routes/get-pulled-files";
 import putContent from "./routes/put-content";
 
-export interface AuthorizedRequest extends Request{
-  decodedToken: DecodedIdToken;
-}
+import {AuthorizedRequest} from "./helpers/express";
+import {newOctoKit, owner, repo} from "./helpers/github";
 
-const adminEmails = ["dmartin@concord.org", "lbondaryk@concord.org"];
 const adminOnlyPaths = ["/pullUnit"];
+
+const fakeEmulatorDecodedToken = {
+  email: "test@concord.org",
+  firebase: {
+    sign_in_provider: "github.com",
+  },
+} as DecodedIdToken;
+
+const tokenCache = new Map<string, {isCollaborator: boolean, expires: Date}>();
+
+const getCacheExpirationDate = () => {
+  const now = new Date();
+  const tokenCacheExpirationMs = 15 * 60 * 1000; // 15 minutes
+  return new Date(now.getTime() + tokenCacheExpirationMs);
+};
 
 admin.initializeApp();
 
-const isUserAuthorized = (path: string, decodedToken: DecodedIdToken): boolean => {
-  const {email, email_verified: emailVerified} = decodedToken;
+const isUserAuthorized = async (path: string, decodedToken: DecodedIdToken, gitHubToken: string): Promise<boolean> => {
+  const {email, firebase} = decodedToken;
 
-  // only allow admins to pull units (the email check should be changed to a role check later)
-  if (adminOnlyPaths.includes(path) && !adminEmails.includes(email ?? "")) {
+  // make sure the user signed in using GitHub and has an email associated with their account
+  if (firebase?.sign_in_provider !== "github.com" || !email) {
     return false;
   }
 
-  // for now just allow anyone with a verified concord.org email have access
-  return !!(emailVerified && /concord\.org$/.test(email ?? ""));
+  // allow CC folks (with a concord.org email) access to everything
+  const isCCEmail = email.endsWith("@concord.org");
+  if (isCCEmail) {
+    return true;
+  }
+
+  // only allow CC folks to do admin-only operations
+  if (!isCCEmail && adminOnlyPaths.includes(path)) {
+    return false;
+  }
+
+  // clear out any expired cache entries to avoid unbounded growth
+  const now = new Date();
+  for (const [token, entry] of tokenCache) {
+    if (entry.expires <= now) {
+      tokenCache.delete(token);
+    }
+  }
+
+  // if we have a cached token and it is still valid (since it wasn't cleared above),
+  // use that to determine authorization based on whether the user is a collaborator
+  const entry = tokenCache.get(gitHubToken);
+  if (entry) {
+    return entry.isCollaborator;
+  }
+
+  // check if the user is a collaborator in the CLUE curriculum repository
+  let isCollaborator = false;
+  try {
+    const octokit = newOctoKit(gitHubToken);
+
+    // get the username associated with the token
+    const {data} = await octokit.request("GET /user");
+    const username = data?.login;
+    if (!username) {
+      console.log("Could not get GitHub username associated with the token.");
+      return false;
+    }
+
+    // This API call checks if the user is a collaborator
+    // If the response status is 204 No Content, the user is a collaborator.
+    // The Octokit client handles this by returning the response object
+    // without throwing an error.
+    const response = await octokit.rest.repos.checkCollaborator({owner, repo, username});
+    isCollaborator = (response.status === 204);
+  } catch (error) {
+    console.log(`Error checking if user is a collaborator on GitHub: ${error}`);
+    isCollaborator = false;
+  }
+
+  tokenCache.set(gitHubToken, {
+    isCollaborator,
+    expires: getCacheExpirationDate(),
+  });
+
+  return isCollaborator;
 };
 
 export const authenticateAndAuthorize = async (req: Request, res: Response, next: NextFunction) => {
@@ -45,8 +112,21 @@ export const authenticateAndAuthorize = async (req: Request, res: Response, next
 
   const idToken = authHeader.split("Bearer ")[1];
   try {
-    const decodedToken = await admin.auth().verifyIdToken(idToken);
-    if (isUserAuthorized(req.path, decodedToken)) {
+    // in order to allow using the emulator with real github tokens
+    // (since the emulator can't emulate the GitHub auth flow), allow skipping auth validation
+    // by setting DANGEROUSLY_SKIP_AUTH_TOKEN_VALIDATION=true in the .env.local file
+    // DO NOT USE THIS IN PRODUCTION
+    const decodedToken = process.env.DANGEROUSLY_SKIP_AUTH_TOKEN_VALIDATION === "true" ?
+      fakeEmulatorDecodedToken :
+      await admin.auth().verifyIdToken(idToken);
+
+    const gitHubToken = req.query.gitHubToken?.toString();
+    if (!gitHubToken) {
+      return res.status(401).send("Unauthorized: No GitHub token provided.");
+    }
+    (req as AuthorizedRequest).gitHubToken = gitHubToken;
+
+    if (await isUserAuthorized(req.path, decodedToken, gitHubToken)) {
       (req as AuthorizedRequest).decodedToken = decodedToken;
       return next();
     } else {
@@ -54,7 +134,7 @@ export const authenticateAndAuthorize = async (req: Request, res: Response, next
     }
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   } catch (error) {
-    return res.status(401).send("Unauthorized: Invalid or expired token.");
+    return res.status(401).send(`Unauthorized: Invalid or expired token: ${error}`);
   }
 };
 

--- a/authoring-api/src/routes/get-remote-branches.ts
+++ b/authoring-api/src/routes/get-remote-branches.ts
@@ -1,9 +1,10 @@
 import {Request, Response} from "express";
 import {newOctoKit, owner, repo} from "../helpers/github";
-import {sendErrorResponse, sendSuccessResponse} from "../helpers/express";
+import {AuthorizedRequest, sendErrorResponse, sendSuccessResponse} from "../helpers/express";
 
 const getRemoteBranches = async (req: Request, res: Response) => {
-  const octokit = newOctoKit();
+  const authorizedRequest = req as AuthorizedRequest;
+  const octokit = newOctoKit(authorizedRequest.gitHubToken);
 
   let page = 1;
   const perPage = 100;

--- a/authoring-api/src/routes/get-remote-units.ts
+++ b/authoring-api/src/routes/get-remote-units.ts
@@ -1,6 +1,6 @@
 import {Request, Response} from "express";
 import {baseCurriculumPath, newOctoKit, owner, repo} from "../helpers/github";
-import {sendErrorResponse, sendSuccessResponse} from "../helpers/express";
+import {AuthorizedRequest, sendErrorResponse, sendSuccessResponse} from "../helpers/express";
 
 const getRemoteUnits = async (req: Request, res: Response) => {
   const branch = req.query.branch?.toString();
@@ -9,7 +9,8 @@ const getRemoteUnits = async (req: Request, res: Response) => {
   }
 
   try {
-    const octokit = newOctoKit();
+    const authorizedRequest = req as AuthorizedRequest;
+    const octokit = newOctoKit(authorizedRequest.gitHubToken);
 
     const {data} = await octokit.rest.repos.getContent({
       owner,

--- a/authoring-api/src/routes/pull-unit.ts
+++ b/authoring-api/src/routes/pull-unit.ts
@@ -7,7 +7,7 @@ import {
   unescapeFirebaseKey,
   UnitFiles,
 } from "../helpers/db";
-import {sendErrorResponse, sendSuccessResponse} from "../helpers/express";
+import {AuthorizedRequest, sendErrorResponse, sendSuccessResponse} from "../helpers/express";
 
 const pullUnit = async (req: Request, res: Response) => {
   const unit = req.query.unit?.toString();
@@ -24,7 +24,8 @@ const pullUnit = async (req: Request, res: Response) => {
   }
 
   try {
-    const octokit = newOctoKit();
+    const authorizedRequest = req as AuthorizedRequest;
+    const octokit = newOctoKit(authorizedRequest.gitHubToken);
 
     const {data: {commit: {sha: branchSha}}} = await octokit.rest.repos.getBranch({
       owner,

--- a/src/authoring/components/app.tsx
+++ b/src/authoring/components/app.tsx
@@ -12,7 +12,7 @@ import "./app.scss";
 const App: React.FC = () => {
   const auth = useAuth();
   const api = useAuthoringApi(auth);
-  const { branch, listBranches, setBranch, unit, setUnit, unitConfig, error, path, files } = useCurriculum(auth, api);
+  const { branch, listBranches, setBranch, unit, setUnit, unitConfig, error, path, files, reset } = useCurriculum(auth, api);
   const [branches, setBranches] = React.useState<string[]>([]);
 
   // until we have an admin UI, use direct api calls to set things up
@@ -45,9 +45,10 @@ const App: React.FC = () => {
     }
   }, [branch, listBranches]);
 
-  const maybeSignOut = () => {
-    if (confirm("Are you sure you want to sign out?")) {
+  const maybeSignOut = (force?: boolean) => {
+    if (force || confirm("Are you sure you want to sign out?")) {
       auth.signOut();
+      reset();
     }
   };
 
@@ -80,7 +81,7 @@ const App: React.FC = () => {
         <div className="centered">
           <div className="error">Authentication error: {auth.error}</div>
           <div>
-            <button onClick={auth.reset}>Try Again</button>
+            <button onClick={() => maybeSignOut(true)}>Try Again</button>
           </div>
         </div>
       );
@@ -89,28 +90,16 @@ const App: React.FC = () => {
       return (
         <div className="centered">
           <div>
-            <h2>Please Sign In</h2>
             <form
               className="sign-in-form"
               onSubmit={async (e) => {
                 e.preventDefault();
-                const form = e.target as HTMLFormElement;
-                const email = (form.elements.namedItem("email") as HTMLInputElement).value;
-                const password = (form.elements.namedItem("password") as HTMLInputElement).value;
-                await auth.signIn(email, password);
+                await auth.signIn();
               }}
             >
               <div>
-                <label htmlFor="email">Email:</label>
-                <input id="email" type="email" name="email" required autoFocus disabled={auth.loading} />
-              </div>
-              <div>
-                <label htmlFor="password">Password:</label>
-                <input id="password" type="password" name="password" required disabled={auth.loading} />
-              </div>
-              <div>
                 <button type="submit" disabled={auth.loading}>
-                  {auth.loading ? "Signing in..." : "Sign In"}
+                  {auth.loading ? "Signing in with your GitHub account..." : "Please sign in to GitHub"}
                 </button>
               </div>
             </form>

--- a/src/authoring/hooks/use-auth.ts
+++ b/src/authoring/hooks/use-auth.ts
@@ -36,7 +36,7 @@ function useAuth(): Auth {
       if (authUser?.isAnonymous) {
         firebase.auth().signOut();
         setUser(null);
-      } else {
+    } else {
         setUser(authUser);
       }
       setLoading(false);
@@ -46,7 +46,7 @@ function useAuth(): Auth {
   }, [resetCount]);
 
   useEffect(() => {
-    window.clearTimeout(reAuthTimeoutRef.current!);
+    window.clearTimeout(reAuthTimeoutRef.current ?? undefined);
 
     if (user) {
       // re-authenticate every 7.5 hours (GitHub OAuth tokens last for 8 hours)
@@ -102,11 +102,10 @@ function useAuth(): Auth {
     setGitHubToken(null);
     setError(null);
     setLoading(true);
-    setError(null);
     setResetCount((count) => count + 1);
   };
 
-  return { user, firebaseToken, gitHubToken, loading, error, signIn, signOut,reset };
+  return { user, firebaseToken, gitHubToken, loading, error, signIn, signOut, reset };
 }
 
 export default useAuth;

--- a/src/authoring/hooks/use-auth.ts
+++ b/src/authoring/hooks/use-auth.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import firebase from "firebase/app";
 import "firebase/auth";
 
@@ -8,7 +8,9 @@ export interface Auth {
   user: firebase.User | null;
   loading: boolean;
   error: string | null;
-  signIn: (email: string, password: string) => Promise<void>;
+  firebaseToken: string | null;
+  gitHubToken: string | null;
+  signIn: () => Promise<void>;
   signOut: () => Promise<void>;
   reset: () => void;
 }
@@ -18,9 +20,16 @@ function useAuth(): Auth {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [resetCount, setResetCount] = useState(0);
+  const [firebaseToken, setFirebaseToken] = useState<string | null>(null);
+  const [gitHubToken, setGitHubToken] = useState<string | null>(null);
+  const reAuthTimeoutRef = useRef<number | null>(null);
 
   useEffect(() => {
     initializeApp();
+
+    // do not persist auth state between sessions as we need to get the GitHub token
+    // and that is only available after the sign-in completes
+    firebase.auth().setPersistence(firebase.auth.Auth.Persistence.NONE);
 
     const unsubscribe = firebase.auth().onAuthStateChanged((authUser) => {
       // do not allow anonymous users (which happens when running the main CLUE app directly before signing in here)
@@ -36,10 +45,36 @@ function useAuth(): Auth {
     return () => unsubscribe();
   }, [resetCount]);
 
-  const signIn = async (email: string, password: string) => {
+  useEffect(() => {
+    window.clearTimeout(reAuthTimeoutRef.current!);
+
+    if (user) {
+      // re-authenticate every 7.5 hours (GitHub OAuth tokens last for 8 hours)
+      // and we need a valid GitHub token to make API calls
+      const reAuthTimeoutMs = 7.5 * 60 * 60 * 1000;
+      reAuthTimeoutRef.current = window.setTimeout(() => {
+        alert("For security reasons, please sign in again to continue using the authoring tool.");
+
+        // to ensure everything is reset properly, just do a full reload
+        window.location.reload();
+      }, reAuthTimeoutMs);
+    }
+  }, [user]);
+
+  const signIn = async () => {
     reset();
     try {
-      await firebase.auth().signInWithEmailAndPassword(email, password);
+      const provider = new firebase.auth.GithubAuthProvider();
+      provider.addScope("public_repo");
+      const result = await firebase.auth().signInWithPopup(provider);
+      if (result.credential) {
+        const credential = result.credential as firebase.auth.OAuthCredential;
+        setGitHubToken(credential.accessToken ?? null);
+      }
+      if (result.user) {
+        const token = await result.user.getIdToken();
+        setFirebaseToken(token);
+      }
     } catch (err: any) {
       setError(err.message ?? "An error occurred during sign-in.");
       console.error("Sign-in error:", err);
@@ -63,12 +98,15 @@ function useAuth(): Auth {
 
   const reset = () => {
     setUser(null);
+    setFirebaseToken(null);
+    setGitHubToken(null);
+    setError(null);
     setLoading(true);
     setError(null);
     setResetCount((count) => count + 1);
   };
 
-  return { user, loading, error, signIn, signOut,reset };
+  return { user, firebaseToken, gitHubToken, loading, error, signIn, signOut,reset };
 }
 
 export default useAuth;

--- a/src/authoring/hooks/use-curriculum.ts
+++ b/src/authoring/hooks/use-curriculum.ts
@@ -92,10 +92,10 @@ export const useCurriculum = (auth: Auth, api: AuthoringApi) => {
 
   useEffect(() => {
     // wait until auth is ready
-    if (auth.user) {
+    if (auth.firebaseToken && auth.gitHubToken) {
       processHash();
     }
-  }, [auth, processHash]);
+  }, [auth.firebaseToken, auth.gitHubToken, processHash]);
 
   const listBranches = async () => {
     return branches;
@@ -119,6 +119,7 @@ export const useCurriculum = (auth: Auth, api: AuthoringApi) => {
     error,
     setError,
     path,
-    files
+    files,
+    reset
   };
 };


### PR DESCRIPTION
This commit updates the authoring API and frontend to use Firebase GitHub authentication instead of the Firebase username/password system.

Users can now authenticate using their GitHub accounts, and the system checks if they are collaborators on the CLUE curriculum repository.  Each call to the authoring API must include a valid GitHub token in the query parameters.

Further checks are in place to ensure that only users with email addresses from the concord.org domain can perform admin-only operations, such as pulling units.