### PR TITLE
feat: Add nav tab authoring [CLUE-269]

### DIFF
--- a/src/authoring/components/editors/raw-settings-control.scss
+++ b/src/authoring/components/editors/raw-settings-control.scss
@@ -6,4 +6,6 @@
   resize: none;
   box-sizing: border-box;
   border: 0;
+  outline: none;
+  background: inherit;
 }

--- a/src/authoring/components/left-nav.tsx
+++ b/src/authoring/components/left-nav.tsx
@@ -45,19 +45,8 @@ const LeftNav: React.FC<IProps> = ({ unitConfig, branch, unit, files, showMediaL
             label: "Curriculum Tabs",
           },
           {
-            id: "unitSettings",
-            label: "Unit Settings",
-            tbd: true
-          },
-          {
-            id: "teacherGuideTabs",
-            label: "Teacher Guide Tabs",
-            tbd: true
-          },
-          {
-            id: "investigations",
-            label: "Investigations",
-            tbd: true
+            id: "navTabs",
+            label: "Navigation Tabs",
           },
           {
             id: "raw",

--- a/src/authoring/components/workspace.scss
+++ b/src/authoring/components/workspace.scss
@@ -19,7 +19,6 @@
   .config {
     font-size: 0.9rem;
     height: 100%;
-    overflow: auto;
     overflow: hidden;
 
     &>* {

--- a/src/authoring/components/workspace.scss
+++ b/src/authoring/components/workspace.scss
@@ -20,8 +20,37 @@
     font-size: 0.9rem;
     height: 100%;
     overflow: auto;
+    overflow: hidden;
 
-    padding: 10px;
+    &>* {
+      padding: 10px;
+    }
+
+    table {
+      border-collapse: collapse;
+      width: 100%;
+
+      th {
+        text-align: left;
+        white-space: nowrap;
+        padding-right: 10px;
+      }
+      td {
+        padding-right: 10px;
+        text-align: center;
+        white-space: nowrap;
+
+        &:last-child {
+          padding-right: 0;
+        }
+      }
+      td.left {
+        text-align: left;
+      }
+      td.wide {
+        width: 100%;
+      }
+    }
 
     label, .sectionLabel {
       display: block;
@@ -32,7 +61,7 @@
       margin-top: 20px;
     }
 
-    input {
+    input[type="text"] {
       width: 100%;
       box-sizing: border-box;
       margin-top: 4px;

--- a/src/authoring/components/workspace.tsx
+++ b/src/authoring/components/workspace.tsx
@@ -1,14 +1,15 @@
 
 import React, { useEffect, useRef } from "react";
+import { Updater, useImmer } from "use-immer";
 
 import { IUnit } from "../types";
-import { Updater, useImmer } from "use-immer";
 
 import { IframeControl } from "./editors/iframe-control";
 import RawSettingsControl from "./editors/raw-settings-control";
 import { AuthoringApi } from "../hooks/use-authoring-api";
 import CurriculumTabs from "./workspace/curriculum-tabs";
 import { SaveState } from "../hooks/use-curriculum";
+import NavTabs from "./workspace/nav-tabs";
 
 import "./workspace.scss";
 
@@ -94,8 +95,12 @@ const Workspace: React.FC<IProps> = ({ branch, unit, unitConfig, setUnitConfig, 
 
   const renderConfig = () => {
     switch (path) {
+      case "config/raw":
+        return <RawSettingsControl initialValue={unitConfig} />;
       case "config/curriculumTabs":
         return <CurriculumTabs unitConfig={unitConfig} setUnitConfig={setUnitConfig} saveState={saveState} />;
+      case "config/navTabs":
+        return <NavTabs unitConfig={unitConfig} setUnitConfig={setUnitConfig} saveState={saveState} />;
       default:
         return <div className="centered muted">Not yet implemented.</div>;
     }

--- a/src/authoring/components/workspace/curriculum-tabs.tsx
+++ b/src/authoring/components/workspace/curriculum-tabs.tsx
@@ -34,6 +34,7 @@ const CurriculumTabs: React.FC<IWorkspaceConfigComponentProps> = ({ unitConfig, 
       <div>
         <label htmlFor="tabLabel">Curriculum Tab Label</label>
         <input
+          type="text"
           id="tabLabel"
           defaultValue={problemTab?.label}
           {...register("tabLabel", { required: "Tab label is required" })}
@@ -44,6 +45,7 @@ const CurriculumTabs: React.FC<IWorkspaceConfigComponentProps> = ({ unitConfig, 
       {(problemTab?.sections ?? []).map((section, index) => (
         <div key={index}>
           <input
+            type="text"
             {...register(`sections.${index}.title`, { required: "Section title is required" })}
             defaultValue={section.title}
           />
@@ -51,7 +53,7 @@ const CurriculumTabs: React.FC<IWorkspaceConfigComponentProps> = ({ unitConfig, 
         </div>
       ))}
       <div className="bottomButtons">
-        <button type="submit" disabled={saveState === "saving"}>Update</button>
+        <button type="submit" disabled={saveState === "saving"}>Save</button>
       </div>
     </form>
   );

--- a/src/authoring/components/workspace/nav-tabs.tsx
+++ b/src/authoring/components/workspace/nav-tabs.tsx
@@ -1,0 +1,146 @@
+import React, { useMemo } from "react";
+import { useForm, SubmitHandler } from "react-hook-form";
+
+import { IWorkspaceConfigComponentProps } from "./common";
+import { AuthorableNavTab, INavTabSpec } from "../../types";
+import { EAuthorableNavTab } from "../../../models/view/nav-tabs";
+
+interface FormTab {
+  tab: AuthorableNavTab;
+  defaultLabel: string;
+  customLabel: string;
+  teacherOnly: boolean;
+  show: boolean;
+}
+
+interface INavTabsInputs {
+  tabs: FormTab[];
+}
+
+export const allNavTabs: AuthorableNavTab[] = Object.values(EAuthorableNavTab);
+const defaultTabLabels: Record<AuthorableNavTab, string> = {
+  problems: "Problems",
+  "teacher-guide": "Teacher Guide",
+  "student-work": "Student Work",
+  "my-work": "My Work",
+  "class-work": "Class Work",
+  "sort-work": "Sort Work",
+};
+
+const NavTabs: React.FC<IWorkspaceConfigComponentProps> = ({ unitConfig, setUnitConfig, saveState }) => {
+  const usedTabs = useMemo(() => {
+    return unitConfig.config.navTabs.tabSpecs.map(t => t.tab);
+  }, [unitConfig]);
+
+  // returns allNavTabs sorted so that tabs used in the current configuration appear first,
+  // in the order they appear in the configuration followed by any unused tabs in their default order
+  const sortedAllNavTabs = useMemo(() => {
+    return [...allNavTabs].sort((a, b) => {
+      const indexA = usedTabs.indexOf(a);
+      const indexB = usedTabs.indexOf(b);
+      if (indexA === -1 && indexB === -1) return 0;
+      if (indexA === -1) return 1;
+      if (indexB === -1) return -1;
+      return indexA - indexB;
+    });
+  }, [usedTabs]);
+
+  // build the data for the form, in the order determined above
+  const formTabs: FormTab[] = useMemo(() => {
+    return sortedAllNavTabs.map(tab => {
+      const found = unitConfig.config.navTabs.tabSpecs.find(t => t.tab === tab);
+      const defaultLabel = defaultTabLabels[tab];
+      return {
+        tab,
+        defaultLabel,
+        customLabel: found && found.label !== defaultLabel ? found.label : "",
+        teacherOnly: found ? !!found.teacherOnly : false,
+        show: found ? !found.hidden : false,
+      };
+    });
+  }, [sortedAllNavTabs, unitConfig]);
+
+  const { handleSubmit, register, formState: { errors } } = useForm<INavTabsInputs>();
+
+  const onSubmit: SubmitHandler<INavTabsInputs> = (data) => {
+    setUnitConfig(draft => {
+      if (draft) {
+        formTabs.forEach((tab, index) => {
+          const formTab = data.tabs[index];
+          const customLabel = formTab.customLabel.trim();
+          const existingIndex = draft.config.navTabs.tabSpecs.findIndex(t => t.tab === tab.tab);
+          const newTabSpec: INavTabSpec = {
+            tab: tab.tab,
+            label: customLabel !== "" ? customLabel : tab.defaultLabel,
+            teacherOnly: formTab.teacherOnly,
+            hidden: !formTab.show
+          };
+          if (existingIndex !== -1) {
+            const tabSpec = draft.config.navTabs.tabSpecs[existingIndex];
+            tabSpec.tab = newTabSpec.tab;
+            tabSpec.label = newTabSpec.label;
+            tabSpec.teacherOnly = newTabSpec.teacherOnly;
+            tabSpec.hidden = newTabSpec.hidden;
+          } else {
+            draft.config.navTabs.tabSpecs.push(newTabSpec);
+          }
+        });
+      }
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <table>
+        <thead>
+          <tr>
+            <th>Teacher Only</th>
+            <th>Show</th>
+            <th>Default Label</th>
+            <th>Custom Label</th>
+          </tr>
+        </thead>
+        <tbody>
+          {formTabs.map((formTab, index) => (
+            <React.Fragment key={formTab.tab}>
+              <tr key={index}>
+                <td>
+                  <input
+                    type="checkbox"
+                    {...register(`tabs.${index}.teacherOnly`)}
+                    defaultChecked={formTab.teacherOnly}
+                  />
+                </td>
+                <td>
+                  <input
+                    type="checkbox"
+                    {...register(`tabs.${index}.show`)}
+                    defaultChecked={formTab.show}
+                  />
+                </td>
+                <td className="left">
+                  {formTab.defaultLabel}
+                </td>
+                <td className="wide">
+                  <input
+                    type="text"
+                    {...register(`tabs.${index}.customLabel`)}
+                    defaultValue={formTab.customLabel}
+                  />
+                </td>
+              </tr>
+              {errors.tabs?.[index]?.customLabel && (
+                <tr><td colSpan={3}>{errors.tabs?.[index]?.customLabel?.message}</td></tr>
+              )}
+            </React.Fragment>
+          ))}
+        </tbody>
+      </table>
+      <div className="bottomButtons">
+        <button type="submit" disabled={saveState === "saving"}>Save</button>
+      </div>
+    </form>
+  );
+};
+
+export default NavTabs;

--- a/src/authoring/components/workspace/nav-tabs.tsx
+++ b/src/authoring/components/workspace/nav-tabs.tsx
@@ -130,7 +130,7 @@ const NavTabs: React.FC<IWorkspaceConfigComponentProps> = ({ unitConfig, setUnit
                 </td>
               </tr>
               {errors.tabs?.[index]?.customLabel && (
-                <tr><td colSpan={3}>{errors.tabs?.[index]?.customLabel?.message}</td></tr>
+                <tr><td colSpan={3}></td><td>{errors.tabs?.[index]?.customLabel?.message}</td></tr>
               )}
             </React.Fragment>
           ))}

--- a/src/authoring/types.ts
+++ b/src/authoring/types.ts
@@ -1,3 +1,5 @@
+import { EAuthorableNavTab } from "../models/view/nav-tabs";
+
 export type IUnitFiles = Record<string, IUnitFile>;
 export interface IUnitFile {
   sha: string;
@@ -44,11 +46,14 @@ export interface INavTabs {
   tabSpecs: INavTabSpec[];
 }
 
+export type AuthorableNavTab = `${EAuthorableNavTab}`;
+
 export interface INavTabSpec {
-  tab: string;
+  tab: AuthorableNavTab;
   label: string;
   teacherOnly?: boolean;
   sections?: INavTabSection[];
+  hidden?: boolean;
 }
 
 export interface INavTabSection {

--- a/src/models/stores/nav-tabs.ts
+++ b/src/models/stores/nav-tabs.ts
@@ -11,10 +11,10 @@ export const NavTabsConfigModel = types
   })
   .views(self => ({
     getNavTabSpec(tabId: ENavTab) {
-      return self.tabSpecs.find(tab => tabId === tab.tab);
+      return self.tabSpecs.find(tab => tabId === tab.tab && !tab.hidden);
     },
     hasSortWorkTab() {
-      return self.tabSpecs.some(tab => tab.tab === ENavTab.kSortWork);
+      return self.tabSpecs.some(tab => tab.tab === ENavTab.kSortWork && !tab.hidden);
     }
   }))
   .actions(self => ({

--- a/src/models/stores/stores.ts
+++ b/src/models/stores/stores.ts
@@ -207,9 +207,12 @@ class Stores implements IStores{
 
     const removeNonCurriculumTabs = standalone && standaloneAuth;
 
-    const tabs = (isTeacherOrResearcher)
+    let tabs = (isTeacherOrResearcher)
       ? navTabSpecs.tabSpecs.filter(t => (t.tab !== "teacher-guide") || teacherGuide)
       : navTabSpecs.tabSpecs.filter(t => !t.teacherOnly);
+
+    // remove any hidden tabs - authors can hide tabs in the authoring UI
+    tabs = tabs.filter(t => !t.hidden);
 
     return removeNonCurriculumTabs
       ? tabs.filter(t => t.tab === "problems" || t.tab === "teacher-guide")

--- a/src/models/view/nav-tabs.ts
+++ b/src/models/view/nav-tabs.ts
@@ -13,6 +13,16 @@ export enum ENavTab {
   kSupports = "supports"
 }
 
+// these are the tabs used in the current unit configurations
+export enum EAuthorableNavTab {
+  kProblems = "problems",
+  kTeacherGuide = "teacher-guide",
+  kStudentWork = "student-work",
+  kMyWork = "my-work",
+  kClassWork = "class-work",
+  kSortWork = "sort-work",
+}
+
 export const kBookmarksTabTitle = "Bookmarks";
 
 // generic type which maps tab id to values of another type
@@ -82,7 +92,8 @@ export const NavTabModel =
     tab: types.enumeration<ENavTab>("ENavTab", Object.values(ENavTab)),
     label: types.string,
     teacherOnly: false,
-    sections: types.array(NavTabSectionModel)
+    sections: types.array(NavTabSectionModel),
+    hidden: types.optional(types.boolean, false)
   })
   .views(self => ({
     // combine sections with matching titles into a single tab with sub-sections


### PR DESCRIPTION
This commit allows authors to customize the navigation tabs in the workspace.

Authors can now set which tabs are visible, their labels, and whether they are teacher-only.

The implementation includes a new component for managing nav tabs, updates to the unit configuration, and necessary styling adjustments.

Since the nav tabs are defined using an array in the unit configuration, a new `hidden` property has been added to each tab specification to manage visibility. This approach maintains the order of tabs as defined by the author and keeps any customizations intact.