### PR TITLE
fix: Add special admin email exception

### DIFF
--- a/authoring-api/src/index.ts
+++ b/authoring-api/src/index.ts
@@ -44,8 +44,10 @@ const isUserAuthorized = async (path: string, decodedToken: DecodedIdToken, gitH
     return false;
   }
 
-  // allow CC folks (with a concord.org email) access to everything
-  const isCCEmail = email.endsWith("@concord.org");
+  // allow CC folks (with a concord.org email) access to everything and add a special exception
+  // for Doug's old zoopdoop.com email that Firebase auth is setting as the GitHub provider email
+  // in the generated auth token even though it is not used on GitHub anymore
+  const isCCEmail = email.endsWith("@concord.org") || email === "doug@zoopdoop.com";
   if (isCCEmail) {
     return true;
   }

--- a/src/authoring/components/app.tsx
+++ b/src/authoring/components/app.tsx
@@ -23,6 +23,10 @@ const App: React.FC = () => {
 
   const toggleMediaLibrary = () => setShowMediaLibrary(value => !value);
 
+  // uncomment when using the manual admin actions below - remove when
+  // we have a proper admin UI
+  // const pulledRef = React.useRef(false);
+
   // until we have an admin UI, use direct api calls to set things up
   useEffect(() => {
     /*
@@ -36,14 +40,21 @@ const App: React.FC = () => {
     */
 
     /*
-    console.log("Pulling unit");
-    api.post("/pullUnit", { branch: "authoring-testing", unit: "cas" }).then(() => {
-      console.log("Pulled unit");
-    }).catch((err) => {
-      console.error("Error pulling unit:", err);
-    });
+    if (auth.firebaseToken && auth.gitHubToken && pulledRef.current !== true) {
+      pulledRef.current = true;
+
+      const branchToPull = "authoring-testing";
+      const unitToPull = "m2s";
+
+      console.log(`Pulling unit: ${branchToPull}/${unitToPull}`);
+      api.post("/pullUnit", { branch: branchToPull, unit: unitToPull }).then(() => {
+        console.log(`Pulled unit: ${branchToPull}/${unitToPull}`);
+      }).catch((err) => {
+        console.error(`Error pulling unit: ${branchToPull}/${unitToPull}`, err);
+      });
+    }
     */
-  }, [api]);
+  }, [api, auth.firebaseToken, auth.gitHubToken]);
 
   useEffect(() => {
     if (!branch) {


### PR DESCRIPTION
This commit introduces a special case for Doug's old zoopdoop.com email address that seems to be stuck in Firebase's auth database even though it is no longer used on GitHub.

This also updates the temp admin api calls in the app component to wait for the auth state to be fully initialized before making calls.