### PR TITLE
feat: Add AI settings authoring [CLUE-290]

### DIFF
--- a/src/authoring/components/left-nav.tsx
+++ b/src/authoring/components/left-nav.tsx
@@ -49,6 +49,10 @@ const LeftNav: React.FC<IProps> = ({ unitConfig, branch, unit, files, showMediaL
             label: "Navigation Tabs",
           },
           {
+            id: "aiSettings",
+            label: "AI Settings",
+          },
+          {
             id: "raw",
             label: "Raw Settings (Dev Only)"
           },

--- a/src/authoring/components/workspace.scss
+++ b/src/authoring/components/workspace.scss
@@ -2,6 +2,34 @@
   width: 100%;
   overflow: hidden;
 
+  &.overflowing {
+    overflow: auto;
+  }
+
+  .horizontalGroup {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 20px;
+  }
+
+  .vertical {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .left {
+    text-align: left;
+  }
+  .wide {
+    width: 100%;
+  }
+  .narrow {
+    white-space: nowrap;
+    width: 1%;
+  }
+
   .centered {
     display: flex;
     flex-direction: row;
@@ -19,10 +47,14 @@
   .config {
     font-size: 0.9rem;
     height: 100%;
-    overflow: hidden;
 
     &>* {
       padding: 10px;
+      overflow: auto;
+    }
+
+    &>form>* {
+      margin-bottom: 10px;
     }
 
     table {
@@ -39,15 +71,13 @@
         text-align: center;
         white-space: nowrap;
 
+        &.left {
+          text-align: left;
+        }
+
         &:last-child {
           padding-right: 0;
         }
-      }
-      td.left {
-        text-align: left;
-      }
-      td.wide {
-        width: 100%;
       }
     }
 
@@ -60,12 +90,16 @@
       margin-top: 20px;
     }
 
-    input[type="text"] {
+    input[type="text"], select, textarea {
       width: 100%;
       box-sizing: border-box;
       margin-top: 4px;
       padding: 6px;
       font-size: 1em;
+    }
+
+    textarea {
+      height: 80px;
     }
 
     .bottomButtons {

--- a/src/authoring/components/workspace.tsx
+++ b/src/authoring/components/workspace.tsx
@@ -1,6 +1,7 @@
 
 import React, { useEffect, useRef } from "react";
 import { Updater, useImmer } from "use-immer";
+import classNames from "classnames";
 
 import { IUnit } from "../types";
 
@@ -10,6 +11,7 @@ import { AuthoringApi } from "../hooks/use-authoring-api";
 import CurriculumTabs from "./workspace/curriculum-tabs";
 import { SaveState } from "../hooks/use-curriculum";
 import NavTabs from "./workspace/nav-tabs";
+import AISettings from "./workspace/ai-settings";
 
 import "./workspace.scss";
 
@@ -101,6 +103,8 @@ const Workspace: React.FC<IProps> = ({ branch, unit, unitConfig, setUnitConfig, 
         return <CurriculumTabs unitConfig={unitConfig} setUnitConfig={setUnitConfig} saveState={saveState} />;
       case "config/navTabs":
         return <NavTabs unitConfig={unitConfig} setUnitConfig={setUnitConfig} saveState={saveState} />;
+      case "config/aiSettings":
+        return <AISettings unitConfig={unitConfig} setUnitConfig={setUnitConfig} saveState={saveState} />;
       default:
         return <div className="centered muted">Not yet implemented.</div>;
     }
@@ -133,8 +137,12 @@ const Workspace: React.FC<IProps> = ({ branch, unit, unitConfig, setUnitConfig, 
     return <div className="centered muted">No content available.</div>;
   };
 
+  const className = classNames("workspace", {
+    "overflowing": isConfigPath,
+  });
+
   return (
-    <div className="workspace">
+    <div className={className}>
       {renderContent()}
     </div>
   );

--- a/src/authoring/components/workspace/ai-settings.tsx
+++ b/src/authoring/components/workspace/ai-settings.tsx
@@ -1,0 +1,260 @@
+
+import React, { useMemo } from "react";
+import { useForm, SubmitHandler, useFieldArray } from "react-hook-form";
+
+import { IWorkspaceConfigComponentProps } from "./common";
+import { AIEvaluation, Summarizer } from "src/authoring/types";
+
+interface CommentTag {
+  label: string;
+  display: string;
+}
+
+interface AISettingsFormInputs {
+  tagPrompt: string;
+  commentTags: CommentTag[];
+  aiEvaluation: AIEvaluation;
+  aiPrompt: {
+    systemPrompt: string;
+    mainPrompt: string;
+    categorizationDescription: string;
+    keyIndicatorsPrompt: string;
+    discussionPrompt: string;
+    summarizer: Summarizer;
+  },
+  aiTileAvailable: boolean;
+  showIdeasButton: boolean;
+}
+
+const AISettings: React.FC<IWorkspaceConfigComponentProps> = ({ unitConfig, setUnitConfig, saveState }) => {
+  const settings: AISettingsFormInputs = useMemo(() => {
+    const { tagPrompt, aiEvaluation, commentTags: rawCommentTags, aiPrompt } = unitConfig?.config || {};
+
+    const commentTags: CommentTag[] = !rawCommentTags
+      ? []
+      : Object.entries(rawCommentTags).map(([label, display]) => ({ label, display }));
+
+    // TODO: figure out how to determine these
+    const aiTileAvailable = false;
+    const showIdeasButton = false;
+
+    return {
+      tagPrompt: tagPrompt ?? "",
+      commentTags: commentTags ?? [],
+      aiEvaluation: aiEvaluation as AIEvaluation ?? "categorize-design",
+      aiPrompt: {
+        systemPrompt: aiPrompt?.systemPrompt ?? "",
+        mainPrompt: aiPrompt?.mainPrompt ?? "",
+        categorizationDescription: aiPrompt?.categorizationDescription ?? "",
+        keyIndicatorsPrompt: aiPrompt?.keyIndicatorsPrompt ?? "",
+        discussionPrompt: aiPrompt?.discussionPrompt ?? "",
+        summarizer: (aiPrompt?.summarizer ?? "image") as Summarizer,
+      },
+      aiTileAvailable,
+      showIdeasButton
+    };
+  }, [unitConfig]);
+
+  const { handleSubmit, register, control, formState: { errors } } = useForm<AISettingsFormInputs>({
+    defaultValues: settings
+  });
+  const commentTagsFieldArray = useFieldArray({ control, name: "commentTags" });
+
+  const onSubmit: SubmitHandler<AISettingsFormInputs> = (data) => {
+    setUnitConfig(draft => {
+      const config = draft?.config;
+      if (config) {
+        config.tagPrompt = data.tagPrompt;
+        config.aiEvaluation = data.aiEvaluation;
+        config.commentTags = data.commentTags.reduce((obj, tag) => {
+          if (tag.label && tag.display) {
+            obj[tag.label] = tag.display;
+          }
+          return obj;
+        }, {} as Record<string, string>);
+
+        const aiPrompt = config.aiPrompt || {};
+        aiPrompt.systemPrompt = data.aiPrompt.systemPrompt;
+        aiPrompt.mainPrompt = data.aiPrompt.mainPrompt;
+        aiPrompt.categorizationDescription = data.aiPrompt.categorizationDescription;
+        aiPrompt.keyIndicatorsPrompt = data.aiPrompt.keyIndicatorsPrompt;
+        aiPrompt.discussionPrompt = data.aiPrompt.discussionPrompt;
+        aiPrompt.summarizer = data.aiPrompt.summarizer;
+      }
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <div>
+        <label htmlFor="tabLabel">Tag Prompt</label>
+        <input
+          type="text"
+          id="tabLabel"
+          defaultValue={settings.tagPrompt}
+          {...register("tagPrompt", { required: "Tab prompt is required" })}
+        />
+        {errors.tagPrompt && <span>{errors.tagPrompt.message}</span>}
+      </div>
+      <table>
+        <thead>
+          <tr>
+            <th>Tag Label</th>
+            <th>Tag Display</th>
+          </tr>
+        </thead>
+        <tbody>
+          {commentTagsFieldArray.fields.map((tag, index) => (
+            <tr key={index}>
+              <td>
+                <div className="vertical left">
+                  <input
+                    type="text"
+                    {...register(`commentTags.${index}.label`, { required: "Required" })}
+                    defaultValue={tag.label}
+                  />
+                  {errors.commentTags?.[index]?.label && <span>{errors.commentTags?.[index]?.label?.message}</span>}
+                </div>
+              </td>
+              <td>
+                <div className="vertical left">
+                  <input
+                    type="text"
+                    {...register(`commentTags.${index}.display`, { required: "Required" })}
+                    defaultValue={tag.display}
+                  />
+                  {errors.commentTags?.[index]?.display && <span>{errors.commentTags?.[index]?.display?.message}</span>}
+                </div>
+              </td>
+              <td className="narrow">
+                <button type="button" onClick={() => {
+                  if (confirm("Are you sure you want to delete this tag?")) {
+                    commentTagsFieldArray.remove(index);
+                  }
+                }}>
+                  Delete
+                </button>
+              </td>
+            </tr>
+          ))}
+          <tr>
+            <td className="left" style={{paddingTop: 10}}>
+              <button type="button" onClick={() => commentTagsFieldArray.append({ label: "", display: "" })}>
+                Add Tag
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <div className="horizontalGroup">
+        <div>
+          <label htmlFor="showIdeasButton">Show Ideas Button</label>
+          <input
+            type="checkbox"
+            {...register("showIdeasButton")}
+            disabled={true}
+          /> <span style={{textDecoration: "line-through"}}>Add to titlebar</span> (TBD in future PR)
+
+        </div>
+        <div>
+          <label htmlFor="aiTileAvailable">AI Tile</label>
+          <input
+            type="checkbox"
+            {...register("aiTileAvailable")}
+            disabled={true}
+          /> <span style={{textDecoration: "line-through"}}>Add to toolbar</span> (TBD in future PR)
+        </div>
+      </div>
+      <div>
+        <label htmlFor="aiEvaluation">AI Evaluation Style</label>
+        <select
+          id="aiEvaluation"
+          defaultValue={settings.aiEvaluation}
+          {...register("aiEvaluation", { required: "AI Evaluation is required" })}
+        >
+          <option value="custom">Custom</option>
+          <option value="categorize-design">Categorize Design</option>
+        </select>
+        {errors.aiEvaluation && <span>{errors.aiEvaluation.message}</span>}
+      </div>
+      <div>
+        <label>Content Summarizer</label>
+        <select
+          id="summarizer"
+          defaultValue={settings.aiPrompt.summarizer}
+          {...register("aiPrompt.summarizer", { required: "Summarizer is required" })}
+        >
+          <option value="image">Image of Content</option>
+          <option value="text">Text Summary of Content</option>
+        </select>
+        {errors.aiPrompt?.summarizer && <span>{errors.aiPrompt?.summarizer?.message}</span>}
+      </div>
+      <div>
+        <label htmlFor="systemPrompt">System Prompt</label>
+        <textarea
+          id="systemPrompt"
+          defaultValue={settings.aiPrompt.systemPrompt}
+          {...register("aiPrompt.systemPrompt", { required: "System prompt is required" })}
+        />
+        {errors.aiPrompt?.systemPrompt && <span>{errors.aiPrompt?.systemPrompt?.message}</span>}
+      </div>
+      <table>
+        <tbody>
+          <tr>
+            <td className="left">
+              <label htmlFor="mainPrompt">Main Prompt</label>
+              <textarea
+                id="mainPrompt"
+                defaultValue={settings.aiPrompt.mainPrompt}
+                {...register("aiPrompt.mainPrompt", { required: "Main prompt is required" })}
+              />
+              {errors.aiPrompt?.mainPrompt && <span>{errors.aiPrompt?.mainPrompt?.message}</span>}
+            </td>
+            <td className="left">
+              <label htmlFor="categorizationDescription">Categorization Description</label>
+              <textarea
+                id="categorizationDescription"
+                defaultValue={settings.aiPrompt.categorizationDescription}
+                {...register("aiPrompt.categorizationDescription", {
+                  required: "Categorization description is required"
+                })}
+              />
+              {errors.aiPrompt?.categorizationDescription && (
+                <span>
+                  {errors.aiPrompt?.categorizationDescription?.message}
+                </span>
+              )}
+            </td>
+          </tr>
+          <tr>
+            <td className="left">
+              <label htmlFor="keyIndicatorsPrompt">Key Indicators Prompt</label>
+              <textarea
+                id="keyIndicatorsPrompt"
+                defaultValue={settings.aiPrompt.keyIndicatorsPrompt}
+                {...register("aiPrompt.keyIndicatorsPrompt", {
+                  required: "Key indicators prompt is required"
+                })}
+              />
+              {errors.aiPrompt?.keyIndicatorsPrompt && <span>{errors.aiPrompt?.keyIndicatorsPrompt?.message}</span>}
+            </td>
+            <td className="left">
+              <label htmlFor="discussionPrompt">Discussion Prompt</label>
+              <textarea
+                id="discussionPrompt"
+                defaultValue={settings.aiPrompt.discussionPrompt}
+                {...register("aiPrompt.discussionPrompt", { required: "Discussion prompt is required" })}
+              />
+              {errors.aiPrompt?.discussionPrompt && <span>{errors.aiPrompt?.discussionPrompt?.message}</span>}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <div className="bottomButtons">
+        <button type="submit" disabled={saveState === "saving"}>Save</button>
+      </div>
+    </form>
+  );
+};
+
+export default AISettings;

--- a/src/authoring/types.ts
+++ b/src/authoring/types.ts
@@ -1,5 +1,12 @@
 import { EAuthorableNavTab } from "../models/view/nav-tabs";
 
+
+export const aiEvaluations = ["categorize-design", "custom"] as const;
+export type AIEvaluation = typeof aiEvaluations[number];
+
+export const summarizers = ["text", "image"] as const;
+export type Summarizer = typeof summarizers[number];
+
 export type IUnitFiles = Record<string, IUnitFile>;
 export interface IUnitFile {
   sha: string;
@@ -28,7 +35,7 @@ export interface IUnitConfig {
   commentTags: Record<string, string>;
   tagPrompt: string;
   enableCommentRoles: string[];
-  aiEvaluation: string;
+  aiEvaluation: AIEvaluation;
   aiPrompt: IAiPrompt;
 }
 
@@ -97,6 +104,7 @@ export interface IAiPrompt {
   categories: string[];
   keyIndicatorsPrompt: string;
   discussionPrompt: string;
+  summarizer?: Summarizer;
 }
 
 export interface ISection {


### PR DESCRIPTION
This commit introduces a new AI Settings section, allowing authors to customize AI-related features such as evaluation criteria, content summarization methods, and comment tagging options.

The changes include updates to the left navigation component, workspace styles, and the addition of a new AI settings component.

Within the AI setting form there are two checkboxes that is disabled for now as they would require additional runtime support.  They will be enabled in a future update.