### PR TITLE
feat: Add authoring mode preview [CLUE-298]

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ There are a number of URL parameters that can aid in testing:
 |`showAiSummary` |`true`                   |When set to true the "ai summary" button in the document editor and Student Work view|
 |`includeModelInAiSummary`|`true`          |When set to true the JSON.stringified raw model is included in the AI summary|
 |`fakeAuthoringAuth`|`true`                |When set to true the authoring system fakes the GitHub login|
+|`authoringBranch`  |string                |When set to a value the runtime knows it should use the authoring api to get content using the specified branch|
 
 The `unit` parameter can be in 3 forms:
 

--- a/authoring-api/src/helpers/github.ts
+++ b/authoring-api/src/helpers/github.ts
@@ -1,11 +1,5 @@
-import {Octokit} from "@octokit/rest";
-
 export const owner = "concord-consortium";
 export const repo = "clue-curriculum";
-
-export const newOctoKit = (auth: string) => {
-  return new Octokit({auth});
-};
 
 export const baseCurriculumPath = "curriculum";
 export const getBaseUnitPath = (unit: string) => `${baseCurriculumPath}/${unit}/`;

--- a/authoring-api/src/helpers/github.ts
+++ b/authoring-api/src/helpers/github.ts
@@ -10,6 +10,10 @@ export const newOctoKit = (auth: string) => {
 export const baseCurriculumPath = "curriculum";
 export const getBaseUnitPath = (unit: string) => `${baseCurriculumPath}/${unit}/`;
 
+export const getRawCurriculumUrl = (branch: string) => {
+  return `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/${baseCurriculumPath}/`;
+};
+
 export const getRawUrl = (branch: string, unit: string, path: string) => {
   return `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/${getBaseUnitPath(unit)}${path}`;
 };

--- a/authoring-api/src/index.ts
+++ b/authoring-api/src/index.ts
@@ -3,6 +3,7 @@ import admin from "firebase-admin";
 import express, {Request, Response, NextFunction} from "express";
 import cors from "cors";
 import {DecodedIdToken} from "firebase-admin/auth";
+import {Octokit} from "@octokit/rest";
 
 import pullUnit from "./routes/pull-unit";
 import getContent from "./routes/get-content";
@@ -16,7 +17,7 @@ import putImage from "./routes/put-image";
 import getRawContent from "./routes/get-raw-content";
 
 import {AuthorizedRequest} from "./helpers/express";
-import {newOctoKit, owner, repo} from "./helpers/github";
+import {owner, repo} from "./helpers/github";
 
 const adminOnlyPaths = ["/pullUnit"];
 
@@ -76,7 +77,7 @@ const isUserAuthorized = async (path: string, decodedToken: DecodedIdToken, gitH
   // check if the user is a collaborator in the CLUE curriculum repository
   let isCollaborator = false;
   try {
-    const octokit = newOctoKit(gitHubToken);
+    const octokit = new Octokit({auth: gitHubToken});
 
     // get the username associated with the token
     const {data} = await octokit.request("GET /user");

--- a/authoring-api/src/index.ts
+++ b/authoring-api/src/index.ts
@@ -13,6 +13,7 @@ import getPulledUnits from "./routes/get-pulled-units";
 import getPulledFiles from "./routes/get-pulled-files";
 import putContent from "./routes/put-content";
 import putImage from "./routes/put-image";
+import getRawContent from "./routes/get-raw-content";
 
 import {AuthorizedRequest} from "./helpers/express";
 import {newOctoKit, owner, repo} from "./helpers/github";
@@ -105,6 +106,11 @@ const isUserAuthorized = async (path: string, decodedToken: DecodedIdToken, gitH
 };
 
 export const authenticateAndAuthorize = async (req: Request, res: Response, next: NextFunction) => {
+  // don't require auth for rawContent endpoint
+  if (req.path.startsWith("/rawContent/")) {
+    return next();
+  }
+
   const authHeader = req.headers.authorization;
   if (!authHeader) {
     return res.status(401).send("Unauthorized: No authorization header provided.");
@@ -183,5 +189,8 @@ app.get("/getRemoteUnits", getRemoteUnits);
 app.get("/getPulledBranches", getPulledBranches);
 app.get("/getPulledUnits", getPulledUnits);
 app.get("/getPulledFiles", getPulledFiles);
+
+// NOTE: app.use() is used here to allow for paths with slashes (i.e. /rawContent/:branch/:unit/*)
+app.use("/rawContent", getRawContent);
 
 export const api = https.onRequest(app);

--- a/authoring-api/src/routes/get-raw-content.ts
+++ b/authoring-api/src/routes/get-raw-content.ts
@@ -1,0 +1,41 @@
+import {Request, Response} from "express";
+import {getRawUrl} from "../helpers/github";
+import {escapeFirebaseKey, getDb, getUnitContentPath} from "../helpers/db";
+
+const getRawContent = async (req: Request, res: Response) => {
+  const matches = req.path.match(/^\/?([^/]+)\/([^/]+)\/(.+)$/);
+  if (!matches) {
+    // don't use the sendErrorResponse helper here since it adds extra json formatting
+    res.status(400).send("Bad Request: Invalid path format. Expected /rawContent/:branch/:unit/:path");
+    return;
+  }
+
+  const branch = matches[1];
+  const unit = matches[2];
+  const path = matches[3];
+
+  // look first for updates
+  const db = getDb();
+  const escapedPath = escapeFirebaseKey(path);
+  const contentPath = getUnitContentPath(branch, unit, escapedPath);
+  const snapshot = await db.ref(contentPath).once("value");
+  const content = snapshot.val();
+  if (content) {
+    return res.send(content);
+  }
+
+  // otherwise get from github
+  const rawUrl = getRawUrl(branch, unit, path);
+  try {
+    const response = await fetch(rawUrl);
+    if (!response.ok) {
+      return res.status(response.status).send(`Error fetching content from GitHub: ${response.statusText}`);
+    }
+    const rawContent = await response.text();
+    return res.send(rawContent);
+  } catch (error) {
+    return res.status(500).send(`Error fetching content from GitHub: ${error}`);
+  }
+};
+
+export default getRawContent;

--- a/authoring-api/src/routes/get-remote-branches.ts
+++ b/authoring-api/src/routes/get-remote-branches.ts
@@ -1,10 +1,11 @@
 import {Request, Response} from "express";
-import {newOctoKit, owner, repo} from "../helpers/github";
+import {Octokit} from "@octokit/rest";
+import {owner, repo} from "../helpers/github";
 import {AuthorizedRequest, sendErrorResponse, sendSuccessResponse} from "../helpers/express";
 
 const getRemoteBranches = async (req: Request, res: Response) => {
   const authorizedRequest = req as AuthorizedRequest;
-  const octokit = newOctoKit(authorizedRequest.gitHubToken);
+  const octokit = new Octokit({auth: authorizedRequest.gitHubToken});
 
   let page = 1;
   const perPage = 100;

--- a/authoring-api/src/routes/get-remote-units.ts
+++ b/authoring-api/src/routes/get-remote-units.ts
@@ -1,5 +1,7 @@
 import {Request, Response} from "express";
-import {baseCurriculumPath, newOctoKit, owner, repo} from "../helpers/github";
+import {Octokit} from "@octokit/rest";
+import {baseCurriculumPath, owner, repo} from "../helpers/github";
+
 import {AuthorizedRequest, sendErrorResponse, sendSuccessResponse} from "../helpers/express";
 
 const getRemoteUnits = async (req: Request, res: Response) => {
@@ -10,7 +12,7 @@ const getRemoteUnits = async (req: Request, res: Response) => {
 
   try {
     const authorizedRequest = req as AuthorizedRequest;
-    const octokit = newOctoKit(authorizedRequest.gitHubToken);
+    const octokit = new Octokit({auth: authorizedRequest.gitHubToken});
 
     const {data} = await octokit.rest.repos.getContent({
       owner,

--- a/authoring-api/src/routes/pull-unit.ts
+++ b/authoring-api/src/routes/pull-unit.ts
@@ -1,6 +1,8 @@
 import {Request, Response} from "express";
 import admin from "firebase-admin";
-import {getBaseUnitPath, newOctoKit, owner, getRawUrl, repo} from "../helpers/github";
+import {Octokit} from "@octokit/rest";
+import {getBaseUnitPath, owner, getRawUrl, repo} from "../helpers/github";
+
 import {
   BranchesMetadata, BranchMetadata, escapeFirebaseKey, getBranchesMetadataPath, getDb,
   getUnitFilesPath, getUnitUpdatesPath,
@@ -25,7 +27,7 @@ const pullUnit = async (req: Request, res: Response) => {
 
   try {
     const authorizedRequest = req as AuthorizedRequest;
-    const octokit = newOctoKit(authorizedRequest.gitHubToken);
+    const octokit = new Octokit({auth: authorizedRequest.gitHubToken});
 
     const {data: {commit: {sha: branchSha}}} = await octokit.rest.repos.getBranch({
       owner,

--- a/authoring-api/src/routes/put-image.ts
+++ b/authoring-api/src/routes/put-image.ts
@@ -1,6 +1,7 @@
 import {Request, Response} from "express";
+import {Octokit} from "@octokit/rest";
 import {AuthorizedRequest, sendErrorResponse, sendSuccessResponse} from "../helpers/express";
-import {newOctoKit, owner, repo} from "../helpers/github";
+import {owner, repo} from "../helpers/github";
 import {escapeFirebaseKey, getDb, getUnitFilesPath, UnitFile} from "../helpers/db";
 
 const putImage = async (req: Request, res: Response) => {
@@ -24,7 +25,7 @@ const putImage = async (req: Request, res: Response) => {
 
   try {
     const authorizedRequest = req as AuthorizedRequest;
-    const octokit = newOctoKit(authorizedRequest.gitHubToken);
+    const octokit = new Octokit({auth: authorizedRequest.gitHubToken});
 
     const path = `curriculum/${unit}/images/${fileName}`;
     const filesPath = getUnitFilesPath(branch, unit);

--- a/src/authoring/components/app.scss
+++ b/src/authoring/components/app.scss
@@ -12,6 +12,21 @@ html, body, #app {
 	flex-direction: column;
 	overflow: hidden;
 
+  button {
+    padding: 5px 15px;
+    font-size: 1em;
+    background-color: $color7;
+    color: white;
+    border: none;
+    border-radius: 3px;
+    cursor: pointer;
+
+    &:disabled {
+      background-color: #9e9e9e;
+      cursor: not-allowed;
+    }
+  }
+
   .header {
     background-color: $workspace-teal-light-5;
     border-bottom: 1px solid #ccc;
@@ -40,6 +55,11 @@ html, body, #app {
         padding: 2px 6px;
         border-radius: 3px;
         text-transform: capitalize;
+      }
+
+      .preview-button {
+        font-size: 0.9em;
+        padding: 3px 10px;
       }
     }
 
@@ -93,21 +113,6 @@ html, body, #app {
         border: 1px solid #ccc;
         border-radius: 3px;
         min-width: 300px;
-      }
-    }
-
-    button {
-      padding: 5px 15px;
-      font-size: 1em;
-      background-color: $color7;
-      color: white;
-      border: none;
-      border-radius: 3px;
-      cursor: pointer;
-
-      &:disabled {
-        background-color: #9e9e9e;
-        cursor: not-allowed;
       }
     }
   }

--- a/src/authoring/components/app.tsx
+++ b/src/authoring/components/app.tsx
@@ -1,5 +1,5 @@
 
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 
 import { units, useCurriculum } from "../hooks/use-curriculum";
 import LeftNav from "./left-nav";
@@ -7,19 +7,21 @@ import Workspace from "./workspace";
 import MediaLibrary from "./media-library";
 import useAuth from "../hooks/use-auth";
 import useAuthoringApi from "../hooks/use-authoring-api";
+import { useAuthoringPreview } from "../hooks/use-authoring-preview";
 
 import "./app.scss";
 
 const App: React.FC = () => {
   const auth = useAuth();
   const api = useAuthoringApi(auth);
+  const authoringPreview = useAuthoringPreview();
   const {
     branch, listBranches, setBranch, unit, setUnit,
     unitConfig, setUnitConfig, error, path, files, reset,
     saveState
-  } = useCurriculum(auth, api);
-  const [branches, setBranches] = React.useState<string[]>([]);
-  const [showMediaLibrary, setShowMediaLibrary] = React.useState(false);
+  } = useCurriculum(auth, api, authoringPreview);
+  const [branches, setBranches] = useState<string[]>([]);
+  const [showMediaLibrary, setShowMediaLibrary] = useState(false);
 
   const toggleMediaLibrary = () => setShowMediaLibrary(value => !value);
 
@@ -71,6 +73,12 @@ const App: React.FC = () => {
     }
   };
 
+  const handlePreviewClick = () => {
+    if (branch && unit) {
+      authoringPreview.openPreview(branch, unit);
+    }
+  };
+
   const renderHeader = () => {
     const title = `CLUE Authoring${unitConfig ? `: ${unitConfig.title}` : ""}`;
 
@@ -79,6 +87,11 @@ const App: React.FC = () => {
         <div className="left-header">
           <div className="title">{title}</div>
           {saveState && <div className="save-state">{saveState}</div>}
+          { branch && unit && (
+            <button className="preview-button" onClick={handlePreviewClick}>
+              Preview
+            </button>
+          )}
         </div>
         <div className="info">
           {auth.user && (
@@ -189,6 +202,7 @@ const App: React.FC = () => {
           path={path}
           api={api}
           saveState={saveState}
+          authoringPreview={authoringPreview}
         />
         {showMediaLibrary && (
           <MediaLibrary
@@ -197,6 +211,7 @@ const App: React.FC = () => {
             branch={branch}
             unit={unit}
             api={api}
+            authoringPreview={authoringPreview}
           />
         )}
       </>

--- a/src/authoring/components/editors/iframe-control.tsx
+++ b/src/authoring/components/editors/iframe-control.tsx
@@ -8,17 +8,20 @@ import "./iframe-control.scss";
 (window as any).DISABLE_FIREBASE_SYNC = true;
 
 const urlParams = new URLSearchParams(window.location.search);
-const iframeBase = urlParams.get("iframeBase") ?? ".";
+// note: .. is used below as iframe.html is in root and authoring is in authoring/
+const iframeBase = urlParams.get("iframeBase") ?? "..";
 const iframeBaseURL = new URL(iframeBase, window.location.href);
 const validOrigin = iframeBaseURL.origin;
 
 interface IProps {
   initialValue: string;
+  branch: string;
+  unit: string;
   onChange?: (value: string) => void;
 }
 
 export const IframeControl: React.FC<IProps> = (props) => {
-  const { initialValue, onChange} = props;
+  const { initialValue, branch, unit, onChange} = props;
 
   useEffect(() => {
     if (DEBUG_IFRAME) {
@@ -59,17 +62,23 @@ export const IframeControl: React.FC<IProps> = (props) => {
     };
   }, [receiveUpdateFromEditor]);
 
-  const curriculumBranch = urlParams.get("curriculumBranch") ?? "author";
-  const iframeBaseUrl = `${iframeBase}/iframe.html?fullHeight=true&noBorder=true&curriculumBranch=${curriculumBranch}`;
-  const iframeUrl = urlParams.get("unit")
-    ? `${iframeBaseUrl}&unit=${urlParams.get("unit")}`
-    : iframeBaseUrl;
+
+  // use the same params to enable overrides of the emulator, functions, etc
+  const iframeParams = new URLSearchParams(window.location.search);
+  iframeParams.set("fullHeight", "true");
+  iframeParams.set("noBorder", "true");
+  iframeParams.set("authoringBranch", branch);
+  iframeParams.set("unit", unit);
+  iframeParams.delete("fakeAuthoringAuth");
+
+  const iframeUrl = new URL(`${iframeBaseURL.toString()}iframe.html`);
+  iframeUrl.search = iframeParams.toString();
 
   return (
     <div className="iframe-control custom-widget">
       <iframe
         id="editor"
-        src={iframeUrl}
+        src={iframeUrl.toString()}
         allow="clipboard-read; clipboard-write; serial"
         onLoad={sendInitialValueToEditor}
       />

--- a/src/authoring/components/media-library.tsx
+++ b/src/authoring/components/media-library.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { IUnitFiles } from "../types";
 import { AuthoringApi } from "../hooks/use-authoring-api";
+import { AuthoringPreview } from "../hooks/use-authoring-preview";
 
 import "./media-library.scss";
 
@@ -10,9 +11,10 @@ interface IProps {
   branch: string;
   unit: string;
   api: AuthoringApi;
+  authoringPreview: AuthoringPreview;
 }
 
-const MediaLibrary: React.FC<IProps> = ({ onClose, files, branch, unit, api }) => {
+const MediaLibrary: React.FC<IProps> = ({ onClose, files, branch, unit, api, authoringPreview }) => {
   const [filter, setFilter] = useState("");
   const filterInputRef = useRef<HTMLInputElement | null>(null);
   const [activeTab, setActiveTab] = useState<"images" | "upload">("images");
@@ -95,6 +97,7 @@ const MediaLibrary: React.FC<IProps> = ({ onClose, files, branch, unit, api }) =
           fileName: file.name
         });
         setUploadProgress("completed");
+        authoringPreview.reloadAllPreviews();
         console.log('Upload successful:', response);
       } catch (error) {
         console.error('Upload failed:', error);

--- a/src/authoring/components/workspace/curriculum-tabs.tsx
+++ b/src/authoring/components/workspace/curriculum-tabs.tsx
@@ -23,8 +23,19 @@ const CurriculumTabs: React.FC<IWorkspaceConfigComponentProps> = ({ unitConfig, 
   const onSubmit: SubmitHandler<ICurriculumTabFormInputs> = (data) => {
     setUnitConfig(draft => {
       if (draft && problemTabIndex >= 0) {
-        draft.config.navTabs.tabSpecs[problemTabIndex].label = data.tabLabel;
-        draft.config.navTabs.tabSpecs[problemTabIndex].sections = data.sections;
+        const tabSpec = draft.config.navTabs.tabSpecs[problemTabIndex];
+        tabSpec.label = data.tabLabel;
+        data.sections.forEach(({title}, index) => {
+          if (tabSpec.sections && index < tabSpec.sections.length) {
+            tabSpec.sections[index].title = title;
+            const initials = tabSpec.sections[index].initials;
+
+            const section = Object.values(draft.sections).find(sec => sec.initials === initials);
+            if (section) {
+              section.title = title;
+            }
+          }
+        });
       }
     });
   };

--- a/src/authoring/components/workspace/curriculum-tabs.tsx
+++ b/src/authoring/components/workspace/curriculum-tabs.tsx
@@ -3,7 +3,7 @@ import React, { useMemo } from "react";
 import { useForm, SubmitHandler } from "react-hook-form";
 
 import { IWorkspaceConfigComponentProps } from "./common";
-import { INavTabSection } from "../../types";
+import { INavTabSection, ISection } from "../../types";
 
 interface ICurriculumTabFormInputs {
   tabLabel: string;
@@ -25,14 +25,20 @@ const CurriculumTabs: React.FC<IWorkspaceConfigComponentProps> = ({ unitConfig, 
       if (draft && problemTabIndex >= 0) {
         const tabSpec = draft.config.navTabs.tabSpecs[problemTabIndex];
         tabSpec.label = data.tabLabel;
+
+        // avoid an O(n²) lookup in the forEach below
+        const sectionMap: Record<string, ISection> = {};
+        Object.values(draft.sections).forEach(section => {
+          sectionMap[section.initials] = section;
+        });
+
         data.sections.forEach(({title}, index) => {
           if (tabSpec.sections && index < tabSpec.sections.length) {
             tabSpec.sections[index].title = title;
-            const initials = tabSpec.sections[index].initials;
 
-            const section = Object.values(draft.sections).find(sec => sec.initials === initials);
-            if (section) {
-              section.title = title;
+            const initials = tabSpec.sections[index].initials;
+            if (initials && sectionMap[initials]) {
+              sectionMap[initials].title = title;
             }
           }
         });

--- a/src/authoring/hooks/use-authoring-api.ts
+++ b/src/authoring/hooks/use-authoring-api.ts
@@ -1,7 +1,6 @@
 import { useCallback } from "react";
-import { localFunctionsHost } from "../../lib/firebase-config";
-import { urlParams } from "../../utilities/url-params";
 import { Auth } from "./use-auth";
+import { getAuthoringApiUrl } from "../utils/authoring-api";
 
 export type GetEndPoint =
   "/whoami" |
@@ -43,20 +42,6 @@ export interface AuthoringApi {
 
 function useAuthoringApi(auth: Auth): AuthoringApi {
 
-  const getBaseUrl = () => {
-    if (urlParams.functions) {
-      const hostname = urlParams.functions === "emulator" ? localFunctionsHost : urlParams.functions;
-      // NOTE: this relies on running `firebase use staging` before running the emulator as
-      // the emulator uses the project ID to determine the local functions url
-      return `${hostname}/collaborative-learning-staging/us-central1/api`;
-    }
-
-    if (urlParams.firebaseEnv === "staging") {
-      return "https://us-central1-collaborative-learning-staging.cloudfunctions.net/api";
-    }
-
-    return "https://us-central1-collaborative-learning-ec215.cloudfunctions.net/api";
-  };
 
   // eslint-disable-next-line max-len
   const apiFetch = useCallback(async (method: "GET" | "POST", endpoint: EndPoint, queryParams: ApiParams = {}, options: RequestInit = {}): Promise<ApiResponse> => {
@@ -70,7 +55,7 @@ function useAuthoringApi(auth: Auth): AuthoringApi {
     }
     queryParams = { ...queryParams, gitHubToken };
 
-    const url = new URL(`${getBaseUrl()}${endpoint}`);
+    const url = new URL(getAuthoringApiUrl(endpoint));
     url.search = new URLSearchParams(queryParams).toString();
 
     const response = await fetch(url.toString(), {

--- a/src/authoring/hooks/use-authoring-preview.ts
+++ b/src/authoring/hooks/use-authoring-preview.ts
@@ -1,0 +1,84 @@
+import { useEffect, useRef } from "react";
+import { urlParams } from "../../utilities/url-params";
+
+export interface AuthoringPreview {
+  openPreview: (branch: string, unit: string) => void;
+  reloadAllPreviews: () => void;
+}
+
+const isAuthoring = window.location.pathname.startsWith("/authoring");
+
+export const useAuthoringPreview = (): AuthoringPreview => {
+  const windowsRef = useRef<Window[]>([]);
+  const lastAliveRef = useRef<number>(Date.now());
+
+  useEffect(() => {
+    if (isAuthoring) {
+      const sendHeartbeat = () => {
+        windowsRef.current = windowsRef.current.filter(win => {
+          if (win && !win.closed) {
+            win.postMessage("authoring:alive!", "*");
+            return true;
+          }
+          return false;
+        });
+      };
+
+      const heartbeatInterval = setInterval(sendHeartbeat, 1000);
+      return () => clearInterval(heartbeatInterval);
+
+    } else if (urlParams.authoringBranch) {
+      // In runtime authoring preview, show an alert if the authoring window closes
+      const handleMessage = (event: MessageEvent) => {
+        if (event.data === "authoring:alive!") {
+          lastAliveRef.current = Date.now();
+        }
+      };
+      window.addEventListener("message", handleMessage);
+
+      const interval = setInterval(() => {
+        if (Date.now() - lastAliveRef.current > 5000) {
+          alert([
+            "The authoring window has closed or been reloaded and this window will no longer automatically reload.",
+            "Please close this window and reopen the preview from the authoring tool."
+          ].join("\n\n"));
+          clearInterval(interval);
+        }
+      }, 5000);
+
+      return () => {
+        window.removeEventListener("message", handleMessage);
+        clearInterval(interval);
+      };
+    }
+  }, []);
+
+  const openPreview = (branch: string, unit: string) => {
+    if (!branch || !unit) {
+      return;
+    }
+    const runtimeUrl = new URL("..", window.location.href);
+    const params = new URLSearchParams(window.location.search);
+    params.set("unit", unit);
+    params.set("authoringBranch", branch);
+    params.delete("fakeAuthoringAuth");
+    runtimeUrl.search = params.toString();
+
+    const win = window.open(runtimeUrl.toString(), "_blank");
+    if (win) {
+      windowsRef.current.push(win);
+    }
+  };
+
+  const reloadAllPreviews = () => {
+    windowsRef.current = windowsRef.current.filter(win => {
+      if (win && !win.closed) {
+        win.location.reload();
+        return true;
+      }
+      return false;
+    });
+  };
+
+  return { openPreview, reloadAllPreviews };
+};

--- a/src/authoring/hooks/use-authoring-preview.ts
+++ b/src/authoring/hooks/use-authoring-preview.ts
@@ -7,6 +7,8 @@ export interface AuthoringPreview {
 }
 
 const isAuthoring = window.location.pathname.startsWith("/authoring");
+const sendHeartbeatIntervalMs = 1000;
+const checkHeartbeatIntervalMs = 5000;
 
 export const useAuthoringPreview = (): AuthoringPreview => {
   const windowsRef = useRef<Window[]>([]);
@@ -24,7 +26,7 @@ export const useAuthoringPreview = (): AuthoringPreview => {
         });
       };
 
-      const heartbeatInterval = setInterval(sendHeartbeat, 1000);
+      const heartbeatInterval = setInterval(sendHeartbeat, sendHeartbeatIntervalMs);
       return () => clearInterval(heartbeatInterval);
 
     } else if (urlParams.authoringBranch) {
@@ -37,14 +39,14 @@ export const useAuthoringPreview = (): AuthoringPreview => {
       window.addEventListener("message", handleMessage);
 
       const interval = setInterval(() => {
-        if (Date.now() - lastAliveRef.current > 5000) {
+        if (Date.now() - lastAliveRef.current > checkHeartbeatIntervalMs) {
           alert([
             "The authoring window has closed or been reloaded and this window will no longer automatically reload.",
             "Please close this window and reopen the preview from the authoring tool."
           ].join("\n\n"));
           clearInterval(interval);
         }
-      }, 5000);
+      }, checkHeartbeatIntervalMs);
 
       return () => {
         window.removeEventListener("message", handleMessage);

--- a/src/authoring/hooks/use-curriculum.ts
+++ b/src/authoring/hooks/use-curriculum.ts
@@ -7,11 +7,12 @@ export type SaveState = "saving" | "saved" | "error" | undefined;
 import { IUnit, IUnitFiles } from "../types";
 import { AuthoringApi } from "./use-authoring-api";
 import { Auth } from "./use-auth";
+import { AuthoringPreview } from "./use-authoring-preview";
 
 export const units = ["cas", "mods", "brain", "m2s"];
 export const branches = ["authoring-testing"];
 
-export const useCurriculum = (auth: Auth, api: AuthoringApi) => {
+export const useCurriculum = (auth: Auth, api: AuthoringApi, authoringPreview: AuthoringPreview) => {
   const [branch, _setBranch] = useImmer<string | undefined>(undefined);
   const [unit, _setUnit] = useImmer<string | undefined>(undefined);
   const [path, setPath] = useImmer<string | undefined>(undefined);
@@ -140,6 +141,7 @@ export const useCurriculum = (auth: Auth, api: AuthoringApi) => {
           saveStateClearTimeoutRef.current = window.setTimeout(() => {
             setSaveState(undefined);
           }, 1000);
+          authoringPreview.reloadAllPreviews();
         } else {
           setSaveState("error");
           setError(response.error);
@@ -148,7 +150,7 @@ export const useCurriculum = (auth: Auth, api: AuthoringApi) => {
         setError(err.message);
       });
     }
-  }, [api, branch, unit, unitConfig, setError, setSaveState]);
+  }, [api, branch, unit, unitConfig, setError, setSaveState, authoringPreview]);
 
   const listBranches = async () => {
     return branches;

--- a/src/authoring/utils/authoring-api.ts
+++ b/src/authoring/utils/authoring-api.ts
@@ -1,0 +1,19 @@
+import { localFunctionsHost } from "../../lib/firebase-config";
+import { urlParams } from "../../utilities/url-params";
+
+export const getAuthoringApiUrl = (endPoint?: string) => {
+  const suffix = endPoint?.startsWith("/") ? endPoint : (endPoint ? `/${endPoint}` : "");
+
+  if (urlParams.functions) {
+    const hostname = urlParams.functions === "emulator" ? localFunctionsHost : urlParams.functions;
+    // NOTE: this relies on running `firebase use staging` before running the emulator as
+    // the emulator uses the project ID to determine the local functions url
+    return `${hostname}/collaborative-learning-staging/us-central1/api${suffix}`;
+  }
+
+  if (urlParams.firebaseEnv === "staging") {
+    return `https://us-central1-collaborative-learning-staging.cloudfunctions.net/api${suffix}`;
+  }
+
+  return `https://us-central1-collaborative-learning-ec215.cloudfunctions.net/api${suffix}`;
+};

--- a/src/components/app-content.tsx
+++ b/src/components/app-content.tsx
@@ -1,8 +1,13 @@
 import React from "react";
 import { AppContentComponent, IBaseProps } from "../app-config";
+import { useAuthoringPreview } from "../authoring/hooks/use-authoring-preview";
 
 interface IProps extends IBaseProps {}
 export const AppContentContainerComponent: React.FC<IProps> = (props) => {
+
+  // sets up heartbeat to keep authoring preview windows in sync
+  useAuthoringPreview();
+
   return (
     <div className="app-content">
       <AppContentComponent {...props} />

--- a/src/components/app-content.tsx
+++ b/src/components/app-content.tsx
@@ -1,13 +1,8 @@
 import React from "react";
 import { AppContentComponent, IBaseProps } from "../app-config";
-import { useAuthoringPreview } from "../authoring/hooks/use-authoring-preview";
 
 interface IProps extends IBaseProps {}
 export const AppContentContainerComponent: React.FC<IProps> = (props) => {
-
-  // sets up heartbeat to keep authoring preview windows in sync
-  useAuthoringPreview();
-
   return (
     <div className="app-content">
       <AppContentComponent {...props} />

--- a/src/models/curriculum/problem.ts
+++ b/src/models/curriculum/problem.ts
@@ -6,6 +6,7 @@ import { SupportModel } from "./support";
 import { ProblemConfiguration } from "../stores/problem-configuration";
 import { ITileEnvironment } from "../tiles/tile-content";
 import { SharedModelDocumentManager } from "../document/shared-model-document-manager";
+import { getContent } from "../../utilities/get-content";
 
 const LegacyProblemModel = types
   .model("Problem", {
@@ -96,7 +97,7 @@ const ModernProblemModel = types
 
   function getExternalProblemSectionData(dataUrl: string){
     try {
-      return fetch(dataUrl).then(res => res.json());
+      return getContent(dataUrl).then(res => res.json());
     } catch (error) {
       throw new Error(`Failed to load problem-section ${dataUrl} cause:\n ${error}`);
     }

--- a/src/models/curriculum/unit-utils.ts
+++ b/src/models/curriculum/unit-utils.ts
@@ -1,3 +1,4 @@
+import { getContent } from "../../utilities/get-content";
 import { ICurriculumConfig } from "../stores/curriculum-config";
 
 export function getUnitJson(unitId: string | undefined, curriculumConfig: ICurriculumConfig) {
@@ -13,7 +14,7 @@ export function getGuideJson(unitId: string | undefined, curriculumConfig: ICurr
 }
 
 function fetchJson(url: string) {
-  return fetch(url)
+  return getContent(url)
     .then((response) => {
       if (response.ok) {
         return response.json();

--- a/src/models/stores/create-exemplar-docs.ts
+++ b/src/models/stores/create-exemplar-docs.ts
@@ -8,6 +8,7 @@ import { AppConfigModelType } from "./app-config-model";
 import { UnitModelType } from "../curriculum/unit";
 import { InvestigationModelType } from "../curriculum/investigation";
 import { kExemplarUserParams } from "../../../shared/shared";
+import { getContent } from "../../utilities/get-content";
 
 interface ICreateExemplarDocsParams {
   unit: UnitModelType;
@@ -48,7 +49,7 @@ export async function getExemplarsData(unitUrl: string, exemplarUrls: string[]){
   return Promise.all(
     exemplarUrls.map(async (url: string) => {
       const fetchUrl = new URL(url, unitUrl).href;
-      const response = await fetch(fetchUrl);
+      const response = await getContent(fetchUrl);
       const data = await response.json();
       // TODO: validate shape of `data`?
       const result: IExemplarData = {

--- a/src/utilities/get-content.ts
+++ b/src/utilities/get-content.ts
@@ -1,0 +1,21 @@
+import { getAuthoringApiUrl } from "../authoring/utils/authoring-api";
+import { urlParams } from "./url-params";
+
+export const getContent = async (input: RequestInfo, init?: RequestInit): Promise<Response> => {
+  // If there is an `authoringBranch` param, rewrite the URL to fetch from the authoring API's
+  // `rawContent` endpoint overriding the branch to use the `authoringBranch` value.
+  if (urlParams.authoringBranch) {
+    const url = typeof input === "string" ? input : input.url;
+    const matches = url.match(/\/clue-curriculum\/branch\/([^/]+)\/(.+)$/);
+    if (matches) {
+      const authoringUrl = getAuthoringApiUrl(`/rawContent/${urlParams.authoringBranch}/${matches[2]}`);
+      if (typeof input === "string") {
+        input = authoringUrl;
+      } else {
+        input = {...input, url: authoringUrl};
+      }
+    }
+  }
+
+  return fetch(input, init);
+};

--- a/src/utilities/url-params.ts
+++ b/src/utilities/url-params.ts
@@ -128,6 +128,17 @@ export interface QueryParams {
   portalDomain?: string;
   // the class word for the class that the user is in
   classWord?: string;
+
+  //
+  // Authoring options
+  //
+
+  // When set to true the authoring system fakes the GitHub login.
+  // This is not used in the runtime, only in authoring.
+  fakeAuthoringAuth?: boolean;
+  // When set to a value the runtime knows it should use the authoring api to get content
+  // using the specified branch
+  authoringBranch?: string;
 }
 
 // Make a union of all of the boolean params from the QueryParams


### PR DESCRIPTION
This commit introduces a new authoring mode preview feature that allows users to see real-time updates of their content changes.

A new url param, `authoringBranch`, has been added to enable this feature. When present, the runtime will fetch raw content from the authoring branch instead of the published branch, allowing authors to preview their edits. This also sets the base curriculum url to use the authoring branch so that images are also loaded from the raw authoring branch url.

This same param is also passed to the content iframe in the authoring workspace so that the iframe can also load content from the authoring branch.

A new hook, `useAuthoringPreview`, has been added to encapsulate the logic for determining if the preview mode is active.  It is used both in authoring to launch preview windows and in the runtime to check if the authoring window is still open.  The authoring system uses this hook to reload all previews when content is changed.

Finally, the curriculum tab authoring compoent has been updated to fix a bug where the title was not being updated correctly.

---

**Working branch link**: https://collaborative-learning.concord.org/branch/add-content-provider/authoring/index.html?firebaseEnv=staging#/authoring-testing/cas/config/curriculumTabs