### PR TITLE
CLUE-494: Fail fast on history playback failures

### DIFF
--- a/cypress/e2e/functional/document_tests/history_view_panel_spec.js
+++ b/cypress/e2e/functional/document_tests/history_view_panel_spec.js
@@ -69,6 +69,21 @@ context('History View Panel', () => {
     cy.get('.playback-failure-marker').click();
     cy.get('[data-testid="playback-failure-detail"]').should('be.visible');
     cy.get('.playback-failure-detail-body').should('contain', 'NONEXISTENT_TILE');
+
+    // The slider opens at the end-of-history position. The backward
+    // scrub above fails immediately on the last history entry (the
+    // injected failing one), so no backward progress is made and
+    // numHistoryEventsApplied stays at history.length. The slider
+    // handle should stay at the end position — not snap back to the
+    // user-clicked target near the start. Regression coverage for
+    // Copilot review comment #4 on CLUE-494.
+    cy.log('verify slider stays at end when failure blocks all backward progress');
+    cy.get('[data-testid="playback-slider"] .rc-slider-handle')
+      .should($handle => {
+        const now = Number($handle.attr('aria-valuenow'));
+        const max = Number($handle.attr('aria-valuemax'));
+        expect(now).to.equal(max);
+      });
   });
 
   it('opens panel and shows local and remote history', function () {

--- a/cypress/e2e/functional/document_tests/history_view_panel_spec.js
+++ b/cypress/e2e/functional/document_tests/history_view_panel_spec.js
@@ -17,6 +17,49 @@ function beforeTest(params) {
 }
 
 context('History View Panel', () => {
+  it('playback stops at injected failing history entry', function () {
+    const teacherParams = `${Cypress.config("qaUnitTeacher6")}`;
+    cy.visit(teacherParams, {
+      onBeforeLoad(win) {
+        win.localStorage.setItem("debug", "historyView");
+      }
+    });
+    cy.waitForLoad();
+
+    cy.log('create some history by adding a text tile');
+    clueCanvas.addTile('text');
+    textToolTile.enterText('Some content');
+
+    cy.log('open history view and inject a failing entry');
+    cy.get('.primary-workspace .toolbar .tool.historyview').click();
+    cy.get('.history-view-panel').should('be.visible');
+    cy.get('.inject-failing-entry').click();
+    cy.get('.history-view-close').click();
+
+    cy.log('open my-work tab and open the document to get playback controls');
+    cy.wait(4000); // wait for firestore to record history
+    clueCanvas.getInvestigationCanvasTitle().text().then((investigationTitle) => {
+      cy.openTopTab('my-work');
+      cy.openDocumentThumbnail('my-work', 'workspaces', investigationTitle);
+    });
+
+    cy.log('open playback controls');
+    cy.get('.toolbar .tool.toggleplayback').click();
+    cy.get('[data-testid="playback-slider"]').should('be.visible');
+
+    cy.log('scrub to beginning — should be blocked by failing entry');
+    cy.get('.rc-slider-horizontal').then($slider => {
+      const width = $slider.width();
+      cy.wrap($slider).click(width * 0.05, 0);
+    });
+
+    cy.log('verify failure marker appears and is clickable');
+    cy.get('.playback-failure-marker').should('exist');
+    cy.get('.playback-failure-marker').click();
+    cy.get('[data-testid="playback-failure-detail"]').should('be.visible');
+    cy.get('.playback-failure-detail-body').should('contain', 'NONEXISTENT_TILE');
+  });
+
   it('opens panel and shows local and remote history', function () {
     beforeTest(queryParams);
 

--- a/cypress/e2e/functional/document_tests/history_view_panel_spec.js
+++ b/cypress/e2e/functional/document_tests/history_view_panel_spec.js
@@ -34,10 +34,21 @@ context('History View Panel', () => {
     cy.get('.primary-workspace .toolbar .tool.historyview').click();
     cy.get('.history-view-panel').should('be.visible');
     cy.get('.inject-failing-entry').click();
+
+    cy.log('wait for the injected entry to appear in remote (Firestore) history');
+    // Turn on remote history and wait for the injectFailingHistoryEntry
+    // action to show up there. This is deterministic — it confirms the
+    // injected entry has been persisted to Firestore before the teacher
+    // opens the document from My Work (which loads history from Firestore).
+    cy.get('.history-view-toggle input[type="checkbox"]').click();
+    cy.get('.history-view-section').last().within(() => {
+      cy.get('.history-entry-item', { timeout: 4000 })
+        .contains('injectFailingHistoryEntry')
+        .should('exist');
+    });
     cy.get('.history-view-close').click();
 
     cy.log('open my-work tab and open the document to get playback controls');
-    cy.wait(4000); // wait for firestore to record history
     clueCanvas.getInvestigationCanvasTitle().text().then((investigationTitle) => {
       cy.openTopTab('my-work');
       cy.openDocumentThumbnail('my-work', 'workspaces', investigationTitle);
@@ -48,7 +59,7 @@ context('History View Panel', () => {
     cy.get('[data-testid="playback-slider"]').should('be.visible');
 
     cy.log('scrub to beginning — should be blocked by failing entry');
-    cy.get('.rc-slider-horizontal').then($slider => {
+    cy.get('[data-testid="playback-slider"] .rc-slider-horizontal').then($slider => {
       const width = $slider.width();
       cy.wrap($slider).click(width * 0.05, 0);
     });

--- a/src/components/document/history-view-panel.tsx
+++ b/src/components/document/history-view-panel.tsx
@@ -99,6 +99,14 @@ export const HistoryViewPanel: React.FC<IHistoryViewPanelProps> = observer(funct
         <div className="history-view-section-header">
           <h4>Local History (Current Session)</h4>
           <span className="history-view-count">{localHistoryEntries.length} entries</span>
+          {treeManager && (
+            <button
+              className="inject-failing-entry"
+              onClick={() => treeManager.injectFailingHistoryEntry()}
+            >
+              Inject Failing Entry
+            </button>
+          )}
         </div>
         <div className="history-view-list">
           {localHistoryEntries.length === 0 ? (

--- a/src/components/playback/playback-control.scss
+++ b/src/components/playback/playback-control.scss
@@ -480,6 +480,102 @@ $border-radius-base: 6px;
   }
 }
 
+.playback-failure-markers-container {
+  position: absolute;
+  top: 0;
+  left: 10px;
+  right: 10px;
+  height: 100%;
+}
+
+.playback-failure-marker {
+  position: absolute;
+  top: 0;
+
+  .playback-failure-marker-line {
+    position: absolute;
+    left: 50%;
+    top: 20px;
+    width: 2px;
+    height: 28px;
+    background-color: #dc3545;
+    transform: translateX(-50%);
+  }
+
+  .playback-failure-marker-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background-color: #dc3545;
+    color: white;
+    font-size: 12px;
+    font-weight: bold;
+    cursor: default;
+  }
+}
+
+.playback-failure-detail {
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: #fff;
+  border: 1px solid #dc3545;
+  border-radius: 4px;
+  padding: 8px 12px;
+  font-size: 12px;
+  z-index: 10;
+  min-width: 250px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+
+  .playback-failure-detail-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-weight: bold;
+    color: #dc3545;
+    margin-bottom: 6px;
+  }
+
+  .playback-failure-detail-close {
+    background: none;
+    border: none;
+    font-size: 16px;
+    cursor: pointer;
+    padding: 0 4px;
+    color: #666;
+
+    &:hover {
+      color: #000;
+    }
+  }
+
+  .playback-failure-detail-body {
+    color: #333;
+    line-height: 1.6;
+    word-break: break-word;
+    user-select: text;
+  }
+}
+
+.playback-failure-warning {
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: #f8d7da;
+  color: #721c24;
+  border: 1px solid #f5c6cb;
+  border-radius: 4px;
+  padding: 4px 12px;
+  font-size: 12px;
+  white-space: nowrap;
+  z-index: 10;
+}
+
 .time-info {
   width: 85px;
   text-align: center;

--- a/src/components/playback/playback-control.scss
+++ b/src/components/playback/playback-control.scss
@@ -491,6 +491,10 @@ $border-radius-base: 6px;
 .playback-failure-marker {
   position: absolute;
   top: 0;
+  padding: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
 
   .playback-failure-marker-line {
     position: absolute;
@@ -513,7 +517,6 @@ $border-radius-base: 6px;
     color: white;
     font-size: 12px;
     font-weight: bold;
-    cursor: default;
   }
 }
 

--- a/src/components/playback/playback-control.tsx
+++ b/src/components/playback/playback-control.tsx
@@ -368,22 +368,33 @@ export const PlaybackControlComponent: React.FC<IProps> = observer((props: IProp
           const location = Math.max(0, Math.min(100, 100 * (sliderIndex / sliderEntries.length)));
           const isSelected = selectedFailure?.historyIndex === failure.historyIndex;
           return (
-            <div
+            <button
               key={`corrupt-${failure.historyIndex}`}
+              type="button"
               className="playback-failure-marker"
               style={{ left: `calc(${location}% - 5px)` }}
+              aria-label={`History playback failure at entry ${failure.historyIndex}`}
+              aria-expanded={isSelected}
               onClick={() => setSelectedFailure(isSelected ? null : failure)}
             >
               <div className="playback-failure-marker-line" />
               <div className="playback-failure-marker-icon">!</div>
-            </div>
+            </button>
           );
         })}
         {selectedFailure && (
-          <div className="playback-failure-detail" data-testid="playback-failure-detail">
+          <div className="playback-failure-detail" data-testid="playback-failure-detail" role="dialog"
+              aria-label="History playback failure details">
             <div className="playback-failure-detail-header">
               <span>History Playback Failure</span>
-              <button className="playback-failure-detail-close" onClick={() => setSelectedFailure(null)}>×</button>
+              <button
+                type="button"
+                className="playback-failure-detail-close"
+                aria-label="Close failure details"
+                onClick={() => setSelectedFailure(null)}
+              >
+                ×
+              </button>
             </div>
             <div className="playback-failure-detail-body">
               <div><strong>Entry:</strong> {selectedFailure.historyIndex}</div>

--- a/src/components/playback/playback-control.tsx
+++ b/src/components/playback/playback-control.tsx
@@ -121,7 +121,7 @@ export const PlaybackControlComponent: React.FC<IProps> = observer((props: IProp
   // After goToHistoryEntry runs, numHistoryEventsApplied may differ from
   // what we requested if a failed entry blocked the move. We detect this
   // and show a warning.
-  const [playbackFailureWarning, setCorruptWarning] = useState<string | null>(null);
+  const [playbackFailureWarning, setPlaybackFailureWarning] = useState<string | null>(null);
 
   const goToSliderValue = useCallback(async (value: number) => {
     // the slider max is sliderEntries.length, which is one more than the last index
@@ -162,11 +162,10 @@ export const PlaybackControlComponent: React.FC<IProps> = observer((props: IProp
         e => e.kind === "history" && e.index === actual
       );
       setSliderValue(actualSliderIndex >= 0 ? actualSliderIndex : value);
-      setCorruptWarning("History playback could not apply some changes and was stopped.");
-      console.log("Slider Entries", sliderEntries);
+      setPlaybackFailureWarning("History playback could not apply some changes and was stopped.");
     } else {
       setSliderValue(value);
-      setCorruptWarning(null);
+      setPlaybackFailureWarning(null);
     }
   }, [treeManager, history, sliderEntries, setPlaybackTime]);
 

--- a/src/components/playback/playback-control.tsx
+++ b/src/components/playback/playback-control.tsx
@@ -157,10 +157,15 @@ export const PlaybackControlComponent: React.FC<IProps> = observer((props: IProp
     // slider to the last fully applied position and show a warning.
     const actual = treeManager.numHistoryEventsApplied;
     if (actual !== undefined && actual !== newHistoryEntryIndex) {
-      // Find the slider entry that corresponds to the actual history position
-      const actualSliderIndex = sliderEntries.findIndex(
-        e => e.kind === "history" && e.index === actual
-      );
+      // Find the slider entry that corresponds to the actual history
+      // position. The end-of-history position is represented by
+      // sliderEntries.length (one past the last index), not by any
+      // entry inside sliderEntries, so findIndex can't locate it.
+      const actualSliderIndex = actual === history.length
+        ? sliderEntries.length
+        : sliderEntries.findIndex(
+          e => e.kind === "history" && e.index === actual
+        );
       setSliderValue(actualSliderIndex >= 0 ? actualSliderIndex : value);
       setPlaybackFailureWarning("History playback could not apply some changes and was stopped.");
     } else {

--- a/src/components/playback/playback-control.tsx
+++ b/src/components/playback/playback-control.tsx
@@ -5,7 +5,7 @@ import { Instance } from "mobx-state-tree";
 import { observer } from "mobx-react";
 import { usePersistentUIStore, useStores } from "../../hooks/use-stores";
 import { logCurrentHistoryEvent } from "../../models/history/log-history-event";
-import { TreeManager } from "../../models/history/tree-manager";
+import { HistoryPlaybackFailure, TreeManager } from "../../models/history/tree-manager";
 import Marker from "../../clue/assets/icons/playback/marker.svg";
 import PlayButton from "../../clue/assets/icons/playback/play-button.svg";
 import PauseButton from "../../clue/assets/icons/playback/pause-button.svg";
@@ -72,12 +72,34 @@ export const PlaybackControlComponent: React.FC<IProps> = observer((props: IProp
   // numHistoryEventsApplied can be 0 or undefined, the event is undefined in both cases
 
   const sliderEntries = useMemo(() => {
-    let entries: ISliderEntry[] = history
-      .map((entry, index) => ({kind: "history", entry, created: entry.created, index}));
-    entries = entries.concat(allComments.map((comment) => (
-      {kind: "comment", entry: comment, created: comment.createdAt}))
+    // History entries must stay in index order (their position in the array),
+    // not sorted by created time. Created times can be out of order when
+    // sub-actions complete before their parent action.
+    const historyEntries: ISliderEntry[] = history
+      .map((entry, index) => ({kind: "history" as const, entry, created: entry.created, index}));
+
+    // Insert comments at the correct position among history entries based
+    // on the comment's created time. Each comment goes after the last
+    // history entry whose created time is <= the comment's created time.
+    const sortedComments = [...allComments].sort(
+      (a, b) => a.createdAt.getTime() - b.createdAt.getTime()
     );
-    entries.sort((a, b) => a.created.getTime() - b.created.getTime());
+    const entries: ISliderEntry[] = [];
+    let commentIdx = 0;
+    for (const historyEntry of historyEntries) {
+      while (commentIdx < sortedComments.length &&
+             sortedComments[commentIdx].createdAt.getTime() < historyEntry.created.getTime()) {
+        const comment = sortedComments[commentIdx];
+        entries.push({kind: "comment", entry: comment, created: comment.createdAt});
+        commentIdx++;
+      }
+      entries.push(historyEntry);
+    }
+    while (commentIdx < sortedComments.length) {
+      const comment = sortedComments[commentIdx];
+      entries.push({kind: "comment", entry: comment, created: comment.createdAt});
+      commentIdx++;
+    }
     return entries;
   }, [history, allComments]);
 
@@ -96,7 +118,12 @@ export const PlaybackControlComponent: React.FC<IProps> = observer((props: IProp
     setSliderPlaying(playStatus);
   }, [sliderPlaying, treeManager]);
 
-  const goToSliderValue = useCallback((value: number) => {
+  // After goToHistoryEntry runs, numHistoryEventsApplied may differ from
+  // what we requested if a failed entry blocked the move. We detect this
+  // and show a warning.
+  const [playbackFailureWarning, setCorruptWarning] = useState<string | null>(null);
+
+  const goToSliderValue = useCallback(async (value: number) => {
     // the slider max is sliderEntries.length, which is one more than the last index
     // in sliderEntries. This value indicates going to the end of the history.
     const sliderEntry = sliderEntries[value];
@@ -124,9 +151,23 @@ export const PlaybackControlComponent: React.FC<IProps> = observer((props: IProp
       // go to the final history entry when at the end of the slider
       newHistoryEntryIndex = history.length;
     }
-    treeManager.goToHistoryEntry(newHistoryEntryIndex);
+    await treeManager.goToHistoryEntry(newHistoryEntryIndex);
 
-    setSliderValue(value);
+    // Check if the move was blocked by a failed entry. If so, snap the
+    // slider to the last fully applied position and show a warning.
+    const actual = treeManager.numHistoryEventsApplied;
+    if (actual !== undefined && actual !== newHistoryEntryIndex) {
+      // Find the slider entry that corresponds to the actual history position
+      const actualSliderIndex = sliderEntries.findIndex(
+        e => e.kind === "history" && e.index === actual
+      );
+      setSliderValue(actualSliderIndex >= 0 ? actualSliderIndex : value);
+      setCorruptWarning("History playback could not apply some changes and was stopped.");
+      console.log("Slider Entries", sliderEntries);
+    } else {
+      setSliderValue(value);
+      setCorruptWarning(null);
+    }
   }, [treeManager, history, sliderEntries, setPlaybackTime]);
 
   const goToComment = useCallback((comment: WithId<CommentDocument>) => {
@@ -138,6 +179,11 @@ export const PlaybackControlComponent: React.FC<IProps> = observer((props: IProp
 
   useEffect(() => {
     if (sliderPlaying) {
+      // Stop auto-play if we hit a playback failure
+      if (playbackFailureWarning) {
+        handlePlayPauseToggle(false);
+        return;
+      }
       const slider = setTimeout(()=>{
         if (sliderValue < sliderEntries.length) {
           goToSliderValue(sliderValue + 1);
@@ -147,7 +193,8 @@ export const PlaybackControlComponent: React.FC<IProps> = observer((props: IProp
       }, 500);
       return () => clearTimeout(slider);
     }
-  }, [handlePlayPauseToggle, sliderEntries.length, sliderPlaying, sliderValue, goToSliderValue]);
+  }, [handlePlayPauseToggle, sliderEntries.length, sliderPlaying, sliderValue,
+      goToSliderValue, playbackFailureWarning]);
 
   //TODO: need to add a modal that warns users about max number of markers. Currently, a generic alert is shown
   //TODO: Currently, if add marker is on and user moves the time handle, a marker is added where the user
@@ -199,10 +246,13 @@ export const PlaybackControlComponent: React.FC<IProps> = observer((props: IProp
     const minutesStr = minutes < 10 ? "0" + minutes : minutes;
     const strTime = date ? hours + ":" + minutesStr + " " + ampm : "";
 
+    const entry = sliderEntries[sliderValue];
+    const historyIndex = entry?.kind === "history" ? entry.index : undefined;
+
     return (
       <div className={"time-info"} data-testid="playback-time-info">
         <div className={"date-info"}>{monthStr} {dateDay}, {year}</div>
-        <div className={"time-info"}>{strTime}</div>
+        <div className={"time-info"}>{strTime} {historyIndex !== undefined && `(${historyIndex})`}</div>
       </div>
     );
   };
@@ -294,6 +344,60 @@ export const PlaybackControlComponent: React.FC<IProps> = observer((props: IProp
     );
   };
 
+  const [selectedFailure, setSelectedFailure] = useState<HistoryPlaybackFailure | null>(null);
+
+  const renderPlaybackFailureMarkers = () => {
+    const failures = treeManager.historyPlaybackFailures;
+    if (failures.length === 0 || sliderEntries.length === 0) return null;
+
+    // Deduplicate by history index for marker placement
+    const seenIndices = new Set<number>();
+    const uniqueFailures = failures.filter(f => {
+      if (seenIndices.has(f.historyIndex)) return false;
+      seenIndices.add(f.historyIndex);
+      return true;
+    });
+
+    return (
+      <div className="playback-failure-markers-container" data-testid="playback-failure-markers">
+        {uniqueFailures.map(failure => {
+          const sliderIndex = sliderEntries.findIndex(
+            e => e.kind === "history" && e.index === failure.historyIndex
+          );
+          if (sliderIndex < 0) return null;
+          const location = Math.max(0, Math.min(100, 100 * (sliderIndex / sliderEntries.length)));
+          const isSelected = selectedFailure?.historyIndex === failure.historyIndex;
+          return (
+            <div
+              key={`corrupt-${failure.historyIndex}`}
+              className="playback-failure-marker"
+              style={{ left: `calc(${location}% - 5px)` }}
+              onClick={() => setSelectedFailure(isSelected ? null : failure)}
+            >
+              <div className="playback-failure-marker-line" />
+              <div className="playback-failure-marker-icon">!</div>
+            </div>
+          );
+        })}
+        {selectedFailure && (
+          <div className="playback-failure-detail" data-testid="playback-failure-detail">
+            <div className="playback-failure-detail-header">
+              <span>History Playback Failure</span>
+              <button className="playback-failure-detail-close" onClick={() => setSelectedFailure(null)}>×</button>
+            </div>
+            <div className="playback-failure-detail-body">
+              <div><strong>Entry:</strong> {selectedFailure.historyIndex}</div>
+              <div><strong>Direction:</strong> {selectedFailure.direction}</div>
+              <div><strong>Model:</strong> {selectedFailure.historyEntry.model ?? "unknown"}</div>
+              <div><strong>Action:</strong> {selectedFailure.historyEntry.action ?? "unknown"}</div>
+              <div><strong>Error:</strong> {selectedFailure.errorMessage}</div>
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  };
+
   const playbackControlsClass = classNames("playback-controls", activeNavTab, {"disabled" : false});
   const sliderComponentClass = classNames(`slider-component ${activeNavTab}`);
 
@@ -305,9 +409,15 @@ export const PlaybackControlComponent: React.FC<IProps> = observer((props: IProp
       <div className={sliderComponentClass}>
         {renderMarkerComponent()}
         {renderCommentMarkers()}
+        {renderPlaybackFailureMarkers()}
         {renderSliderContainer()}
       </div>
       {renderTimeInfo()}
+      {playbackFailureWarning && !selectedFailure &&
+        <div className="playback-failure-warning" data-testid="playback-failure-warning">
+          {playbackFailureWarning}
+        </div>
+      }
     </div>
   );
 });

--- a/src/models/history/tree-manager-multi-tree.test.ts
+++ b/src/models/history/tree-manager-multi-tree.test.ts
@@ -48,6 +48,10 @@ const TestTree = types.model("TestTree", {
   applyingManagerPatches: false,
   startCount: 0,
   finishCount: 0,
+  // When set, the next applyPatchesFromManager call throws this error
+  // instead of applying patches. Used to exercise the unexpected-error
+  // code path in goToHistoryEntry.
+  unexpectedErrorOnNextApply: undefined as unknown,
 }))
 .views(self => ({
   get treeId(): string { return self.myId; }
@@ -55,6 +59,9 @@ const TestTree = types.model("TestTree", {
 .actions(self => ({
   setValue(v: string | undefined) { self.value = v; },
   setCounter(c: number) { self.counter = c; },
+  setUnexpectedErrorOnNextApply(error: unknown) {
+    self.unexpectedErrorOnNextApply = error;
+  },
 
   // --- TreeAPI ---
 
@@ -67,6 +74,11 @@ const TestTree = types.model("TestTree", {
   applyPatchesFromManager(
     _historyEntryId: string, _exchangeId: string, patchesToApply: readonly IJsonPatch[]
   ) {
+    if (self.unexpectedErrorOnNextApply !== undefined) {
+      const err = self.unexpectedErrorOnNextApply;
+      self.unexpectedErrorOnNextApply = undefined;
+      throw err;
+    }
     for (const patch of patchesToApply) {
       if (!patch.path) {
         throw new Error("History patches must have a non-empty path.");
@@ -501,6 +513,99 @@ describe("TreeManager multi-tree support", () => {
       manager.historyPlaybackFailures.forEach(f => {
         expect(f.direction).toBe("undo");
       });
+    });
+  });
+
+  describe("unexpected errors during apply", () => {
+    // Any error other than PatchApplicationError is, by construction,
+    // a bug — applyPatchesFromManager wraps patch-apply failures in
+    // PatchApplicationError, and there is no IO or network path that
+    // could produce a transient failure. Even so, we don't want these
+    // bugs to escape as unhandled promise rejections (which are
+    // invisible to users and easy for developers to miss). They should
+    // flow through the same playback-failure machinery as recoverable
+    // errors: record a failure, log the original stack with
+    // console.error, let finish run so shared-model syncing is
+    // re-enabled, and do not advance the history position.
+
+    it("does not throw when a tree's apply throws a non-PatchApplicationError", async () => {
+      const { manager, treeA } = setupManager();
+      treeA.setUnexpectedErrorOnNextApply(new Error("unexpected boom"));
+      const history = [
+        makeEntry([setValueRecord("treeA", undefined, "A1")]),
+      ];
+      manager.setChangeDocument({ history } as any);
+      manager.setNumHistoryEntriesApplied(0);
+
+      // The await should resolve, not reject.
+      await jestSpyConsole("error", async () => {
+        await manager.goToHistoryEntry(1);
+      });
+    });
+
+    it("records a playback failure and leaves the position unchanged", async () => {
+      const { manager, treeA } = setupManager();
+      treeA.setUnexpectedErrorOnNextApply(new Error("unexpected boom"));
+      const history = [
+        makeEntry([setValueRecord("treeA", undefined, "A1")]),
+        makeEntry([setValueRecord("treeA", "A1", "A2")]),
+      ];
+      manager.setChangeDocument({ history } as any);
+      manager.setNumHistoryEntriesApplied(0);
+
+      await jestSpyConsole("error", async () => {
+        await manager.goToHistoryEntry(2);
+      });
+
+      // Position stays where it started — we don't know how far the
+      // failing tree got, so the safest thing is no advance.
+      expect(manager.numHistoryEventsApplied).toBe(0);
+      expect(manager.historyPlaybackFailures.length).toBe(1);
+      expect(manager.historyPlaybackFailures[0].direction).toBe("redo");
+      expect(manager.historyPlaybackFailures[0].errorMessage).toContain("unexpected boom");
+    });
+
+    it("runs the finish phase after an unexpected error (shared-model syncing re-enabled)", async () => {
+      const { manager, treeA, treeB } = setupManager();
+      treeA.setUnexpectedErrorOnNextApply(new Error("unexpected boom"));
+      const history = [
+        makeEntry([setValueRecord("treeA", undefined, "A1")]),
+      ];
+      manager.setChangeDocument({ history } as any);
+      manager.setNumHistoryEntriesApplied(0);
+
+      await jestSpyConsole("error", async () => {
+        await manager.goToHistoryEntry(1);
+      });
+
+      // Both trees should be un-stuck.
+      expect(treeA.applyingManagerPatches).toBe(false);
+      expect(treeB.applyingManagerPatches).toBe(false);
+      expect(treeA.finishCount).toBe(1);
+      expect(treeB.finishCount).toBe(1);
+    });
+
+    it("rolls back other trees that successfully applied patches", async () => {
+      const { manager, treeA, treeB } = setupManager();
+      // treeB will fail unexpectedly; treeA's apply should be rolled
+      // back to the initial (start) position even though treeA itself
+      // succeeded.
+      treeB.setUnexpectedErrorOnNextApply(new Error("unexpected boom"));
+      const history = [
+        makeEntry([setValueRecord("treeA", undefined, "A1")]),
+        makeEntry([setValueRecord("treeB", undefined, "B1")]),
+      ];
+      manager.setChangeDocument({ history } as any);
+      manager.setNumHistoryEntriesApplied(0);
+
+      await jestSpyConsole("error", async () => {
+        await manager.goToHistoryEntry(2);
+      });
+
+      // treeA's successful apply of entry 0 must be rolled back so the
+      // session state matches the unchanged position.
+      expect(manager.numHistoryEventsApplied).toBe(0);
+      expect(treeA.value).toBeUndefined();
     });
   });
 

--- a/src/models/history/tree-manager-multi-tree.test.ts
+++ b/src/models/history/tree-manager-multi-tree.test.ts
@@ -1,0 +1,429 @@
+import { nanoid } from "nanoid";
+import {
+  applyPatch, getSnapshot, IJsonPatch, Instance, onPatch, types
+} from "mobx-state-tree";
+import { TreeManager } from "./tree-manager";
+import { HistoryEntrySnapshot } from "./history";
+import { PatchApplicationError } from "./tree";
+
+// These tests exercise the multi-tree code paths in TreeManager
+// (replayHistoryToTrees, goToHistoryEntry, addTreePatchRecord) without
+// dragging in DocumentContentModel/tiles. A minimal TestTree implements
+// the TreeAPI surface directly so we can register multiple trees with a
+// single TreeManager and drive them with hand-crafted history entries.
+//
+// Multi-tree support exists in the framework but is not currently used
+// by CLUE, so these tests serve as both regression coverage and a
+// characterization of current behavior — including at least one known
+// gap (cross-tree rollback on partial failure) flagged with an
+// explanatory comment.
+
+const mockCreateFirestoreMetadataDocument_v2 = jest.fn();
+const mockPostDocumentComment_v2 = jest.fn();
+const mockHttpsCallable = jest.fn((fn: string) => {
+  switch (fn) {
+    case "createFirestoreMetadataDocument_v2":
+      return mockCreateFirestoreMetadataDocument_v2;
+    case "postDocumentComment_v2":
+      return mockPostDocumentComment_v2;
+  }
+});
+jest.mock("firebase/app", () => ({
+  functions: () => ({
+    httpsCallable: (fn: string) => mockHttpsCallable(fn)
+  })
+}));
+
+// A minimal Tree implementation that satisfies the TreeAPI shape the
+// TreeManager calls. It mirrors the batched-applyPatch + onPatch
+// counting pattern from the real Tree model so that PatchApplicationError
+// is thrown with an accurate numApplied count — which is what the
+// goToHistoryEntry rollback logic depends on.
+const TestTree = types.model("TestTree", {
+  myId: types.string,
+  value: types.maybe(types.string),
+  counter: types.optional(types.number, 0),
+})
+.volatile(self => ({
+  applyingManagerPatches: false,
+  startCount: 0,
+  finishCount: 0,
+}))
+.views(self => ({
+  get treeId(): string { return self.myId; }
+}))
+.actions(self => ({
+  setValue(v: string | undefined) { self.value = v; },
+  setCounter(c: number) { self.counter = c; },
+
+  // --- TreeAPI ---
+
+  startApplyingPatchesFromManager(_historyEntryId: string, _exchangeId: string) {
+    self.applyingManagerPatches = true;
+    self.startCount++;
+    return Promise.resolve();
+  },
+
+  applyPatchesFromManager(
+    _historyEntryId: string, _exchangeId: string, patchesToApply: readonly IJsonPatch[]
+  ) {
+    for (const patch of patchesToApply) {
+      if (!patch.path) {
+        throw new Error("History patches must have a non-empty path.");
+      }
+    }
+    let numApplied = 0;
+    const disposer = onPatch(self, () => { numApplied++; });
+    try {
+      applyPatch(self, patchesToApply);
+    } catch (e) {
+      throw new PatchApplicationError(numApplied, e);
+    } finally {
+      disposer();
+    }
+    return Promise.resolve();
+  },
+
+  finishApplyingPatchesFromManager(_historyEntryId: string, _exchangeId: string) {
+    self.applyingManagerPatches = false;
+    self.finishCount++;
+    return Promise.resolve();
+  },
+
+  applySharedModelSnapshotFromManager(
+    _historyEntryId: string, _exchangeId: string, _snapshot: any
+  ) {
+    return Promise.resolve();
+  },
+}));
+interface TestTreeType extends Instance<typeof TestTree> {}
+
+function setupManager() {
+  const manager = TreeManager.create({ document: {}, undoStore: {} });
+  const treeA = TestTree.create({ myId: "treeA" });
+  const treeB = TestTree.create({ myId: "treeB" });
+  manager.putTree("treeA", treeA);
+  manager.putTree("treeB", treeB);
+  return { manager, treeA, treeB };
+}
+
+interface RecordSpec {
+  tree: string;
+  patches: IJsonPatch[];
+  inversePatches: IJsonPatch[];
+  action?: string;
+}
+
+function makeEntry(records: RecordSpec[], opts?: { action?: string }): HistoryEntrySnapshot {
+  const action = opts?.action ?? "/test";
+  return {
+    id: nanoid(),
+    created: Date.now(),
+    model: "TestTree",
+    action,
+    tree: records[0]?.tree,
+    undoable: true,
+    state: "complete",
+    records: records.map(r => ({
+      tree: r.tree,
+      action: r.action ?? action,
+      patches: r.patches,
+      inversePatches: r.inversePatches,
+    })),
+  };
+}
+
+// Simple single-tree setValue record.
+function setValueRecord(tree: string, from: string | undefined, to: string): RecordSpec {
+  return {
+    tree,
+    patches: [{ op: "replace", path: "/value", value: to }],
+    inversePatches: [{ op: "replace", path: "/value", value: from }],
+  };
+}
+
+// A record whose patches reference a non-existent path. applyPatch will
+// throw in either direction.
+function failingRecord(tree: string): RecordSpec {
+  return {
+    tree,
+    patches: [{ op: "replace", path: "/nothing/here", value: 1 }],
+    inversePatches: [{ op: "replace", path: "/nothing/here", value: 0 }],
+  };
+}
+
+describe("TreeManager multi-tree support", () => {
+  describe("replayHistoryToTrees", () => {
+    it("routes patches to the correct tree when each entry targets one tree", async () => {
+      const { manager, treeA, treeB } = setupManager();
+      const history = [
+        makeEntry([setValueRecord("treeA", undefined, "A1")]),
+        makeEntry([setValueRecord("treeB", undefined, "B1")]),
+        makeEntry([setValueRecord("treeA", "A1", "A2")]),
+      ];
+      manager.setChangeDocument({ history } as any);
+
+      await manager.replayHistoryToTrees();
+
+      expect(treeA.value).toBe("A2");
+      expect(treeB.value).toBe("B1");
+      // Every registered tree should have been started/finished exactly once,
+      // even trees that received no patches in a given replay.
+      expect(treeA.startCount).toBe(1);
+      expect(treeA.finishCount).toBe(1);
+      expect(treeB.startCount).toBe(1);
+      expect(treeB.finishCount).toBe(1);
+      expect(treeA.applyingManagerPatches).toBe(false);
+      expect(treeB.applyingManagerPatches).toBe(false);
+    });
+
+    it("applies records from a single history entry to multiple trees", async () => {
+      const { manager, treeA, treeB } = setupManager();
+      const history = [
+        makeEntry([
+          setValueRecord("treeA", undefined, "A1"),
+          setValueRecord("treeB", undefined, "B1"),
+        ]),
+      ];
+      manager.setChangeDocument({ history } as any);
+
+      await manager.replayHistoryToTrees();
+
+      expect(treeA.value).toBe("A1");
+      expect(treeB.value).toBe("B1");
+    });
+
+    it("leaves registered trees in their initial state when no history targets them", async () => {
+      const { manager, treeA, treeB } = setupManager();
+      const history = [
+        makeEntry([setValueRecord("treeA", undefined, "A1")]),
+      ];
+      manager.setChangeDocument({ history } as any);
+
+      await manager.replayHistoryToTrees();
+
+      expect(treeA.value).toBe("A1");
+      expect(treeB.value).toBeUndefined();
+      // treeB still gets the start/finish lifecycle calls.
+      expect(treeB.startCount).toBe(1);
+      expect(treeB.finishCount).toBe(1);
+    });
+
+    it("silently ignores patches whose tree id isn't registered", async () => {
+      const { manager, treeA, treeB } = setupManager();
+      const history = [
+        makeEntry([setValueRecord("treeA", undefined, "A1")]),
+        makeEntry([setValueRecord("ghostTree", undefined, "X")]),
+      ];
+      manager.setChangeDocument({ history } as any);
+
+      // Should not throw.
+      await manager.replayHistoryToTrees();
+
+      expect(treeA.value).toBe("A1");
+      expect(treeB.value).toBeUndefined();
+    });
+  });
+
+  describe("goToHistoryEntry", () => {
+    it("scrubs forward across multiple trees", async () => {
+      const { manager, treeA, treeB } = setupManager();
+      const history = [
+        makeEntry([setValueRecord("treeA", undefined, "A1")]),
+        makeEntry([setValueRecord("treeB", undefined, "B1")]),
+        makeEntry([setValueRecord("treeA", "A1", "A2")]),
+      ];
+      manager.setChangeDocument({ history } as any);
+      manager.setNumHistoryEntriesApplied(0);
+
+      await manager.goToHistoryEntry(3);
+
+      expect(treeA.value).toBe("A2");
+      expect(treeB.value).toBe("B1");
+      expect(manager.numHistoryEventsApplied).toBe(3);
+    });
+
+    it("scrubs backward across multiple trees", async () => {
+      const { manager, treeA, treeB } = setupManager();
+      const history = [
+        makeEntry([setValueRecord("treeA", undefined, "A1")]),
+        makeEntry([setValueRecord("treeB", undefined, "B1")]),
+        makeEntry([setValueRecord("treeA", "A1", "A2")]),
+      ];
+      // Seed state at "all applied".
+      treeA.setValue("A2");
+      treeB.setValue("B1");
+      manager.setChangeDocument({ history } as any);
+      manager.setNumHistoryEntriesApplied(3);
+
+      await manager.goToHistoryEntry(0);
+
+      expect(treeA.value).toBeUndefined();
+      expect(treeB.value).toBeUndefined();
+      expect(manager.numHistoryEventsApplied).toBe(0);
+    });
+
+    it("scrubs to an intermediate position, updating only affected trees", async () => {
+      const { manager, treeA, treeB } = setupManager();
+      const history = [
+        makeEntry([setValueRecord("treeA", undefined, "A1")]),
+        makeEntry([setValueRecord("treeB", undefined, "B1")]),
+        makeEntry([setValueRecord("treeA", "A1", "A2")]),
+      ];
+      manager.setChangeDocument({ history } as any);
+      manager.setNumHistoryEntriesApplied(0);
+
+      await manager.goToHistoryEntry(1);
+      expect(treeA.value).toBe("A1");
+      expect(treeB.value).toBeUndefined();
+
+      await manager.goToHistoryEntry(2);
+      expect(treeA.value).toBe("A1");
+      expect(treeB.value).toBe("B1");
+
+      await manager.goToHistoryEntry(3);
+      expect(treeA.value).toBe("A2");
+      expect(treeB.value).toBe("B1");
+
+      await manager.goToHistoryEntry(0);
+      expect(treeA.value).toBeUndefined();
+      expect(treeB.value).toBeUndefined();
+    });
+
+    it("applies combined records from a single entry atomically across trees", async () => {
+      const { manager, treeA, treeB } = setupManager();
+      const history = [
+        makeEntry([
+          setValueRecord("treeA", undefined, "A1"),
+          setValueRecord("treeB", undefined, "B1"),
+        ]),
+      ];
+      manager.setChangeDocument({ history } as any);
+      manager.setNumHistoryEntriesApplied(0);
+
+      await manager.goToHistoryEntry(1);
+      expect(treeA.value).toBe("A1");
+      expect(treeB.value).toBe("B1");
+
+      await manager.goToHistoryEntry(0);
+      expect(treeA.value).toBeUndefined();
+      expect(treeB.value).toBeUndefined();
+    });
+
+    it("records a failure when one tree's patches fail during a multi-tree scrub", async () => {
+      const { manager, treeA } = setupManager();
+      const history = [
+        makeEntry([setValueRecord("treeA", undefined, "A1")]),
+        makeEntry([failingRecord("treeB")]),
+      ];
+      manager.setChangeDocument({ history } as any);
+      manager.setNumHistoryEntriesApplied(0);
+
+      await jestSpyConsole("warn", async () => {
+        await manager.goToHistoryEntry(2);
+      });
+
+      // The failing entry is entry 1, so numHistoryEventsApplied stops at 1.
+      expect(manager.numHistoryEventsApplied).toBe(1);
+      expect(manager.historyPlaybackFailures.length).toBe(1);
+      expect(manager.historyPlaybackFailures[0].historyIndex).toBe(1);
+      expect(manager.historyPlaybackFailures[0].direction).toBe("redo");
+      // treeA should reflect entry 0 having been applied.
+      expect(treeA.value).toBe("A1");
+    });
+
+    // This test characterizes a *known gap* in the multi-tree rollback
+    // logic that tree-manager.ts:573-579 calls out with a TODO. When a
+    // scrub spans an entry that has records for multiple trees, the
+    // trees apply their batches in parallel. If one tree's record fails,
+    // only that tree's partial application is rolled back — the other
+    // trees' fully-applied records in the same entry are NOT rolled
+    // back, even though numHistoryEventsApplied is rewound to before
+    // that entry. This leaves the other trees' state inconsistent with
+    // what numHistoryEventsApplied claims.
+    //
+    // If/when this is fixed, this test should be updated to assert the
+    // corrected (consistent) behavior.
+    it("KNOWN GAP: does not roll back other trees when one tree fails mid-entry", async () => {
+      const { manager, treeA, treeB } = setupManager();
+      const history = [
+        makeEntry([
+          setValueRecord("treeA", undefined, "A1"),
+          failingRecord("treeB"),
+        ]),
+      ];
+      manager.setChangeDocument({ history } as any);
+      manager.setNumHistoryEntriesApplied(0);
+
+      await jestSpyConsole("warn", async () => {
+        await manager.goToHistoryEntry(1);
+      });
+
+      // The manager thinks entry 0 has NOT been applied (it rewound to
+      // before the failing entry).
+      expect(manager.numHistoryEventsApplied).toBe(0);
+      expect(manager.historyPlaybackFailures.length).toBe(1);
+      expect(manager.historyPlaybackFailures[0].historyIndex).toBe(0);
+
+      // But treeA has in fact been mutated, exposing the inconsistency:
+      // manager position says "nothing applied", treeA says "A1".
+      expect(treeA.value).toBe("A1");
+      // treeB's partial application (of zero good patches) was rolled
+      // back, so it is still in the initial state.
+      expect(treeB.value).toBeUndefined();
+    });
+  });
+
+  describe("addTreePatchRecord with multiple trees", () => {
+    it("aggregates records from different trees into a single history entry", async () => {
+      const { manager } = setupManager();
+
+      const historyEntryId = nanoid();
+      const entry = manager.createHistoryEntry({
+        id: historyEntryId,
+        exchangeId: "create",
+        tree: "treeA",
+        model: "TestTree",
+        action: "/combined",
+        undoable: true,
+      });
+
+      const exchangeA = nanoid();
+      const exchangeB = nanoid();
+      await manager.startExchange(historyEntryId, exchangeA, "treeA patches");
+      await manager.startExchange(historyEntryId, exchangeB, "treeB patches");
+
+      manager.addTreePatchRecord(historyEntryId, exchangeA, {
+        tree: "treeA",
+        action: "/combined",
+        patches: [{ op: "replace", path: "/value", value: "A" }],
+        inversePatches: [{ op: "replace", path: "/value", value: undefined }],
+      });
+      manager.addTreePatchRecord(historyEntryId, exchangeB, {
+        tree: "treeB",
+        action: "/combined",
+        patches: [{ op: "replace", path: "/value", value: "B" }],
+        inversePatches: [{ op: "replace", path: "/value", value: undefined }],
+      });
+
+      // The create exchange is the last one still open; closing it
+      // completes the entry.
+      manager.addTreePatchRecord(historyEntryId, "create", {
+        tree: "treeA",
+        action: "/combined",
+        patches: [],
+        inversePatches: [],
+      });
+
+      expect(entry.state).toBe("complete");
+      const historySnap = getSnapshot(manager.document.history);
+      expect(historySnap.length).toBe(1);
+      const storedRecords = historySnap[0].records as ReadonlyArray<{ tree: string }>;
+      expect(storedRecords.map(r => r.tree).sort()).toEqual(["treeA", "treeB"]);
+    });
+  });
+});
+
+// Keeps TS happy about the interface export even though we don't use it
+// directly elsewhere in the file.
+export type { TestTreeType };

--- a/src/models/history/tree-manager-multi-tree.test.ts
+++ b/src/models/history/tree-manager-multi-tree.test.ts
@@ -332,19 +332,11 @@ describe("TreeManager multi-tree support", () => {
       expect(treeA.value).toBe("A1");
     });
 
-    // This test characterizes a *known gap* in the multi-tree rollback
-    // logic that tree-manager.ts:573-579 calls out with a TODO. When a
-    // scrub spans an entry that has records for multiple trees, the
-    // trees apply their batches in parallel. If one tree's record fails,
-    // only that tree's partial application is rolled back — the other
-    // trees' fully-applied records in the same entry are NOT rolled
-    // back, even though numHistoryEventsApplied is rewound to before
-    // that entry. This leaves the other trees' state inconsistent with
-    // what numHistoryEventsApplied claims.
-    //
-    // If/when this is fixed, this test should be updated to assert the
-    // corrected (consistent) behavior.
-    it("KNOWN GAP: does not roll back other trees when one tree fails mid-entry", async () => {
+    // When a single history entry has records for multiple trees and
+    // one tree's record fails, all trees must roll back to a consistent
+    // position. In the single-entry case, that means every tree that
+    // applied anything for the entry has it rolled back.
+    it("rolls back other trees when one tree fails mid-entry", async () => {
       const { manager, treeA, treeB } = setupManager();
       const history = [
         makeEntry([
@@ -359,18 +351,156 @@ describe("TreeManager multi-tree support", () => {
         await manager.goToHistoryEntry(1);
       });
 
-      // The manager thinks entry 0 has NOT been applied (it rewound to
-      // before the failing entry).
+      // Position stops at the failing entry.
       expect(manager.numHistoryEventsApplied).toBe(0);
       expect(manager.historyPlaybackFailures.length).toBe(1);
       expect(manager.historyPlaybackFailures[0].historyIndex).toBe(0);
 
-      // But treeA has in fact been mutated, exposing the inconsistency:
-      // manager position says "nothing applied", treeA says "A1".
-      expect(treeA.value).toBe("A1");
-      // treeB's partial application (of zero good patches) was rolled
-      // back, so it is still in the initial state.
+      // Both trees are consistent with position 0.
+      expect(treeA.value).toBeUndefined();
       expect(treeB.value).toBeUndefined();
+    });
+
+    // Tree A succeeds through all entries, including entries past the
+    // one where tree B fails. Tree A's state past the failing entry
+    // must be rolled back so both trees are consistent with the
+    // stop position.
+    it("rolls back other trees that succeeded past the failing entry (forward)", async () => {
+      const { manager, treeA, treeB } = setupManager();
+      const history = [
+        makeEntry([setValueRecord("treeA", undefined, "A1")]),    // 0
+        makeEntry([setValueRecord("treeA", "A1", "A2")]),         // 1
+        makeEntry([setValueRecord("treeB", undefined, "B1")]),    // 2
+        makeEntry([failingRecord("treeB")]),                       // 3
+        makeEntry([setValueRecord("treeA", "A2", "A3")]),         // 4
+      ];
+      manager.setChangeDocument({ history } as any);
+      manager.setNumHistoryEntriesApplied(0);
+
+      await jestSpyConsole("warn", async () => {
+        await manager.goToHistoryEntry(5);
+      });
+
+      // Scrub stops at the earliest failing entry (index 3).
+      expect(manager.numHistoryEventsApplied).toBe(3);
+      // treeA would have applied entry 4 past the failure point —
+      // that must be rolled back so treeA reflects state at position 3
+      // (entries 0 and 1 applied, entry 4 not).
+      expect(treeA.value).toBe("A2");
+      expect(treeB.value).toBe("B1");
+      expect(manager.historyPlaybackFailures.length).toBe(1);
+      expect(manager.historyPlaybackFailures[0].historyIndex).toBe(3);
+      expect(manager.historyPlaybackFailures[0].direction).toBe("redo");
+    });
+
+    // Backward equivalent. Tree B successfully undoes an entry whose
+    // index is before the earliest (= max, for backward) failing
+    // entry — that undo must be re-applied forward so tree B reflects
+    // the stop position.
+    it("re-applies other trees that succeeded past the failing entry (backward)", async () => {
+      const { manager, treeA, treeB } = setupManager();
+      const history = [
+        makeEntry([setValueRecord("treeB", undefined, "B1")]),    // 0
+        makeEntry([setValueRecord("treeA", undefined, "A1")]),    // 1
+        makeEntry([setValueRecord("treeA", "A1", "A2")]),         // 2
+        makeEntry([failingRecord("treeA")]),                       // 3
+        makeEntry([setValueRecord("treeA", "A2", "A3")]),         // 4
+      ];
+      // Seed state matching "all 5 entries applied".
+      treeA.setValue("A3");
+      treeB.setValue("B1");
+      manager.setChangeDocument({ history } as any);
+      manager.setNumHistoryEntriesApplied(5);
+
+      await jestSpyConsole("warn", async () => {
+        await manager.goToHistoryEntry(0);
+      });
+
+      // Scrub stops at position just-after the failing entry going
+      // backward (failedEntryIndex + 1 = 4).
+      expect(manager.numHistoryEventsApplied).toBe(4);
+      // State at position 4: entries 0..3 applied, entry 4 not.
+      // treeA = A2 (entry 1 → A1, entry 2 → A2, entry 3 is broken and
+      // doesn't affect /value, entry 4 not applied).
+      expect(treeA.value).toBe("A2");
+      // treeB successfully undid entry 0 during the backward batch;
+      // that must be re-applied since entry 0 is < stop position 4.
+      expect(treeB.value).toBe("B1");
+      expect(manager.historyPlaybackFailures.length).toBe(1);
+      expect(manager.historyPlaybackFailures[0].historyIndex).toBe(3);
+      expect(manager.historyPlaybackFailures[0].direction).toBe("undo");
+    });
+
+    // When multiple trees fail, use the earliest (min) index forward.
+    it("uses the earliest failing index when multiple trees fail (forward)", async () => {
+      const { manager, treeA, treeB } = setupManager();
+      const history = [
+        makeEntry([setValueRecord("treeA", undefined, "A1")]),    // 0
+        makeEntry([setValueRecord("treeB", undefined, "B1")]),    // 1
+        makeEntry([failingRecord("treeA")]),                       // 2
+        makeEntry([setValueRecord("treeB", "B1", "B2")]),         // 3
+        makeEntry([failingRecord("treeB")]),                       // 4
+        makeEntry([setValueRecord("treeA", "A1", "A2")]),         // 5
+      ];
+      manager.setChangeDocument({ history } as any);
+      manager.setNumHistoryEntriesApplied(0);
+
+      await jestSpyConsole("warn", async () => {
+        await manager.goToHistoryEntry(6);
+      });
+
+      // Earliest (min) failing index forward is treeA's at 2.
+      expect(manager.numHistoryEventsApplied).toBe(2);
+      // Position 2: entries 0 and 1 applied.
+      expect(treeA.value).toBe("A1");
+      // treeB applied entry 3 past the stop position and must have it
+      // rolled back to B1.
+      expect(treeB.value).toBe("B1");
+      // Both failures should be recorded.
+      expect(manager.historyPlaybackFailures.length).toBe(2);
+      const indices = manager.historyPlaybackFailures.map(f => f.historyIndex).sort();
+      expect(indices).toEqual([2, 4]);
+      manager.historyPlaybackFailures.forEach(f => {
+        expect(f.direction).toBe("redo");
+      });
+    });
+
+    // When multiple trees fail backward, use the latest (max) index.
+    it("uses the latest failing index when multiple trees fail (backward)", async () => {
+      const { manager, treeA, treeB } = setupManager();
+      const history = [
+        makeEntry([setValueRecord("treeA", undefined, "A1")]),    // 0
+        makeEntry([setValueRecord("treeB", undefined, "B1")]),    // 1
+        makeEntry([failingRecord("treeA")]),                       // 2
+        makeEntry([setValueRecord("treeB", "B1", "B2")]),         // 3
+        makeEntry([failingRecord("treeB")]),                       // 4
+        makeEntry([setValueRecord("treeA", "A1", "A2")]),         // 5
+      ];
+      // Seed at position 6 (all applied). Entries 2 and 4 are broken
+      // and don't modify any value; treeA ends at A2, treeB ends at B2.
+      treeA.setValue("A2");
+      treeB.setValue("B2");
+      manager.setChangeDocument({ history } as any);
+      manager.setNumHistoryEntriesApplied(6);
+
+      await jestSpyConsole("warn", async () => {
+        await manager.goToHistoryEntry(0);
+      });
+
+      // Latest (max) failing index backward is treeB's at 4;
+      // numHistoryEventsApplied = 4 + 1 = 5.
+      expect(manager.numHistoryEventsApplied).toBe(5);
+      // Position 5: entries 0..4 applied, entry 5 not.
+      // treeA = A1 (entry 0 → A1; entry 5 not applied).
+      expect(treeA.value).toBe("A1");
+      // treeB = B2 (entries 1 → B1 and 3 → B2).
+      expect(treeB.value).toBe("B2");
+      expect(manager.historyPlaybackFailures.length).toBe(2);
+      const indices = manager.historyPlaybackFailures.map(f => f.historyIndex).sort();
+      expect(indices).toEqual([2, 4]);
+      manager.historyPlaybackFailures.forEach(f => {
+        expect(f.direction).toBe("undo");
+      });
     });
   });
 

--- a/src/models/history/tree-manager.test.ts
+++ b/src/models/history/tree-manager.test.ts
@@ -580,6 +580,49 @@ describe("history playback failure handling", () => {
     expect(manager.numHistoryEventsApplied).toBe(1);
     expect(manager.historyPlaybackFailures.length).toBe(1);
   });
+
+  // A history entry containing a patch with an empty `path` (which MST
+  // interprets as a whole-tree snapshot replacement). Tree rejects
+  // pathless patches up front; we want that rejection to flow through
+  // the recoverable playback-failure path just like any other patch
+  // application failure.
+  const pathlessPatchEntry = {
+    model: "TestTile",
+    action: "/pathlessEntry",
+    created: expect.any(Number),
+    id: expect.any(String),
+    records: [
+      { action: "/pathlessEntry",
+        inversePatches: [
+          { op: "replace", path: "", value: {} }
+        ],
+        patches: [
+          { op: "replace", path: "", value: {} }
+        ],
+        tree: "test"
+      },
+    ],
+    state: "complete",
+    tree: "test",
+    undoable: true
+  };
+
+  it("handles a pathless patch as a recoverable playback failure", async () => {
+    const { manager } = setupDocument();
+    seedHistory(manager, [makeRealHistoryEntry(pathlessPatchEntry)], 0);
+
+    await jestSpyConsole("warn", async () => {
+      await manager.goToHistoryEntry(1);
+    });
+
+    // Pathless patches must not escape as an unhandled error — they
+    // should be recorded as a playback failure and leave the position
+    // just before the bad entry.
+    expect(manager.numHistoryEventsApplied).toBe(0);
+    expect(manager.historyPlaybackFailures.length).toBe(1);
+    expect(manager.historyPlaybackFailures[0].historyIndex).toBe(0);
+    expect(manager.historyPlaybackFailures[0].direction).toBe("redo");
+  });
 });
 
 it("records tile model changes in response to shared model changes", async () => {

--- a/src/models/history/tree-manager.test.ts
+++ b/src/models/history/tree-manager.test.ts
@@ -349,6 +349,239 @@ it("can replay the history entries", async () => {
   expect(getSnapshot(manager.document.history)).toEqual(history);
 });
 
+// A history entry containing a patch that references a non-existent tile.
+// Both the forward patch and the inverse patch target the missing path,
+// so replaying this entry fails in either direction.
+const failingEntry = {
+  model: "TestTile",
+  action: "/injectedFailingEntry",
+  created: expect.any(Number),
+  id: expect.any(String),
+  records: [
+    { action: "/injectedFailingEntry",
+      inversePatches: [
+        { op: "replace", path: "/content/tileMap/NONEXISTENT/content/flag", value: false}
+      ],
+      patches: [
+        { op: "replace", path: "/content/tileMap/NONEXISTENT/content/flag", value: true}
+      ],
+      tree: "test"
+    },
+  ],
+  state: "complete",
+  tree: "test",
+  undoable: true
+};
+
+// An entry with three records for the same tree. The bad record is
+// sandwiched between two good records so that in either direction, at
+// least one good record's patches are applied before the bad record
+// fails — exercising the rollback logic in both directions.
+const mixedEntry = {
+  model: "TestTile",
+  action: "/mixedEntry",
+  created: expect.any(Number),
+  id: expect.any(String),
+  records: [
+    { action: "/mixedEntry",
+      inversePatches: [
+        { op: "replace", path: "/content/tileMap/t1/content/actionText", value: "initial"}
+      ],
+      patches: [
+        { op: "replace", path: "/content/tileMap/t1/content/actionText", value: "good first"}
+      ],
+      tree: "test"
+    },
+    { action: "/mixedEntry",
+      inversePatches: [
+        { op: "replace", path: "/content/tileMap/NONEXISTENT/content/flag", value: false}
+      ],
+      patches: [
+        { op: "replace", path: "/content/tileMap/NONEXISTENT/content/flag", value: true}
+      ],
+      tree: "test"
+    },
+    { action: "/mixedEntry",
+      inversePatches: [
+        { op: "replace", path: "/content/tileMap/t1/content/flag", value: undefined}
+      ],
+      patches: [
+        { op: "replace", path: "/content/tileMap/t1/content/flag", value: true}
+      ],
+      tree: "test"
+    }
+  ],
+  state: "complete",
+  tree: "test",
+  undoable: true
+};
+
+// An entry with a single record containing three patches: a good patch,
+// a bad patch (non-existent tile), and another good patch. Sandwiching
+// the bad patch ensures that in either direction at least one good
+// patch is applied before the bad patch fails.
+const mixedPatchesEntry = {
+  model: "TestTile",
+  action: "/mixedPatchesEntry",
+  created: expect.any(Number),
+  id: expect.any(String),
+  records: [
+    { action: "/mixedPatchesEntry",
+      inversePatches: [
+        { op: "replace", path: "/content/tileMap/t1/content/actionText", value: "initial"},
+        { op: "replace", path: "/content/tileMap/NONEXISTENT/content/flag", value: false},
+        { op: "replace", path: "/content/tileMap/t1/content/flag", value: undefined}
+      ],
+      patches: [
+        { op: "replace", path: "/content/tileMap/t1/content/actionText", value: "good patch first"},
+        { op: "replace", path: "/content/tileMap/NONEXISTENT/content/flag", value: true},
+        { op: "replace", path: "/content/tileMap/t1/content/flag", value: true}
+      ],
+      tree: "test"
+    }
+  ],
+  state: "complete",
+  tree: "test",
+  undoable: true
+};
+
+/**
+ * Seed the manager with a given history and corresponding tree state,
+ * positioned at a given numHistoryEventsApplied. The `setState` callback
+ * can make any tile state changes needed to match the "already applied"
+ * position. The callback's actions will be recorded by the middleware
+ * temporarily, but we reset the change document afterwards to clear
+ * that recording.
+ */
+function seedHistory(
+  manager: Instance<typeof TreeManager>,
+  history: HistoryEntrySnapshot[],
+  numApplied: number,
+  setState?: () => void
+) {
+  setState?.();
+  manager.setChangeDocument(CDocument.create({history}));
+  manager.setNumHistoryEntriesApplied(numApplied);
+}
+
+describe("history playback failure handling", () => {
+  // History: [action1, failingEntry, action2]. Scrubbing forward across
+  // failingEntry from position 1 should stop at position 1 and record
+  // a redo failure. Scrubbing backward across failingEntry from position
+  // 3 should stop at position 2 and record an undo failure.
+  const historyWithFailingEntry = [
+    makeRealHistoryEntry(action1),
+    makeRealHistoryEntry(failingEntry),
+    makeRealHistoryEntry(action2),
+  ];
+
+  it("records a failure and stops replay when scrubbing forward past a failing entry", async () => {
+    const {tileContent, manager} = setupDocument();
+    seedHistory(manager, historyWithFailingEntry, 1, () => tileContent.setActionText("action 1"));
+
+    // Scrub forward past the failing entry
+    await manager.goToHistoryEntry(3);
+
+    // Should have stopped at the failing entry without applying action2
+    expect(manager.numHistoryEventsApplied).toBe(1);
+    expect(tileContent.actionText).toBe("action 1");
+    expect(manager.historyPlaybackFailures.length).toBe(1);
+    expect(manager.historyPlaybackFailures[0].historyIndex).toBe(1);
+    expect(manager.historyPlaybackFailures[0].direction).toBe("redo");
+  });
+
+  it("records a failure and stops replay when scrubbing backward past a failing entry", async () => {
+    const {tileContent, manager} = setupDocument();
+    // Seed at position 3 (all entries applied) with actionText = "action 2"
+    // so the tree state matches what it would be if the history had been
+    // played forward successfully.
+    seedHistory(manager, historyWithFailingEntry, 3, () => tileContent.setActionText("action 2"));
+
+    // Scrub backward past the failing entry
+    await manager.goToHistoryEntry(0);
+
+    // Entry 2 (action2) should have been undone successfully, then entry 1
+    // (failingEntry) failed to undo. Rollback position is failedEntryIndex + 1 = 2,
+    // so entries 0 and 1 are still "applied". tileContent should reflect
+    // action1's value because action2's undo ran before the failure.
+    expect(manager.numHistoryEventsApplied).toBe(2);
+    expect(tileContent.actionText).toBe("action 1");
+    expect(manager.historyPlaybackFailures.length).toBe(1);
+    expect(manager.historyPlaybackFailures[0].historyIndex).toBe(1);
+    expect(manager.historyPlaybackFailures[0].direction).toBe("undo");
+  });
+
+  it("rolls back good records from the failing entry when scrubbing forward", async () => {
+    const {tileContent, manager} = setupDocument();
+    // mixedEntry records in forward order: good-1 (actionText), bad, good-3 (flag).
+    // Applying forward: good-1 succeeds → bad fails. Rollback should undo good-1.
+    seedHistory(manager, [makeRealHistoryEntry(mixedEntry)], 0,
+      () => tileContent.setActionText("initial"));
+
+    await manager.goToHistoryEntry(1);
+
+    expect(tileContent.actionText).toBe("initial");
+    expect(tileContent.flag).toBeUndefined();
+    expect(manager.numHistoryEventsApplied).toBe(0);
+    expect(manager.historyPlaybackFailures.length).toBe(1);
+  });
+
+  it("rolls back good records from the failing entry when scrubbing backward", async () => {
+    const {tileContent, manager} = setupDocument();
+    // Seed at position 1 as if mixedEntry had been played forward. State:
+    // actionText = "good first", flag = true.
+    // Scrubbing backward processes records in reverse: good-3's undo (flag → undefined)
+    // succeeds, then the bad record's undo fails. Rollback should re-apply the flag patch.
+    seedHistory(manager, [makeRealHistoryEntry(mixedEntry)], 1, () => {
+      tileContent.setActionText("good first");
+      tileContent.setFlag(true);
+    });
+
+    await manager.goToHistoryEntry(0);
+
+    expect(tileContent.flag).toBe(true);
+    expect(tileContent.actionText).toBe("good first");
+    expect(manager.numHistoryEventsApplied).toBe(1);
+    expect(manager.historyPlaybackFailures.length).toBe(1);
+  });
+
+  it("rolls back good patches from the failing record when scrubbing forward", async () => {
+    const {tileContent, manager} = setupDocument();
+    // mixedPatchesEntry's record has patches in order: good (actionText),
+    // bad, good (flag). Forward: good-1 succeeds → bad fails. Rollback
+    // should undo good-1.
+    seedHistory(manager, [makeRealHistoryEntry(mixedPatchesEntry)], 0,
+      () => tileContent.setActionText("initial"));
+
+    await manager.goToHistoryEntry(1);
+
+    expect(tileContent.actionText).toBe("initial");
+    expect(tileContent.flag).toBeUndefined();
+    expect(manager.numHistoryEventsApplied).toBe(0);
+    expect(manager.historyPlaybackFailures.length).toBe(1);
+  });
+
+  it("rolls back good patches from the failing record when scrubbing backward", async () => {
+    const {tileContent, manager} = setupDocument();
+    // Seed at position 1 as if mixedPatchesEntry had been played forward.
+    // State: actionText = "good patch first", flag = true.
+    // Scrubbing backward applies inversePatches in reverse: good-3 inverse
+    // (flag → undefined) succeeds, then bad inverse fails. Rollback should
+    // re-apply the flag patch.
+    seedHistory(manager, [makeRealHistoryEntry(mixedPatchesEntry)], 1, () => {
+      tileContent.setActionText("good patch first");
+      tileContent.setFlag(true);
+    });
+
+    await manager.goToHistoryEntry(0);
+
+    expect(tileContent.flag).toBe(true);
+    expect(tileContent.actionText).toBe("good patch first");
+    expect(manager.numHistoryEventsApplied).toBe(1);
+    expect(manager.historyPlaybackFailures.length).toBe(1);
+  });
+});
+
 it("records tile model changes in response to shared model changes", async () => {
   const {tileContent, manager, sharedModel} = setupDocument();
   sharedModel.setValue("shared value");

--- a/src/models/history/tree-manager.ts
+++ b/src/models/history/tree-manager.ts
@@ -1,5 +1,5 @@
 import {
-  applyPatch, types, Instance, flow, IJsonPatch, detach, destroy, toGenerator
+  types, Instance, flow, IJsonPatch, detach, destroy, toGenerator
 } from "mobx-state-tree";
 import { nanoid } from "nanoid";
 import { TreeAPI } from "./tree-api";
@@ -529,16 +529,23 @@ export const TreeManager = types
       if (direction === -1) {
         records = records.reverse();
       }
+      // A history entry may contain multiple records for the same tree
+      // (e.g. tile update + shared-model update). Track the per-tree
+      // patch count for this history entry so we can push a single
+      // segment per tree that covers the whole entry — that way rollback
+      // on failure covers all records in the entry, not just one.
+      const entryPatchCountByTree: Record<string, number> = {};
       for (const entryRecord of records) {
         const patches = treePatches[entryRecord.tree];
         const entryPatches = entryRecord.getPatches(opType);
         if (patches && entryPatches.length > 0) {
           patches.push(...entryPatches);
-          treePatchSegments[entryRecord.tree].push({
-            historyIndex: i,
-            patchCount: entryPatches.length
-          });
+          entryPatchCountByTree[entryRecord.tree] =
+            (entryPatchCountByTree[entryRecord.tree] ?? 0) + entryPatches.length;
         }
+      }
+      for (const [treeId, patchCount] of Object.entries(entryPatchCountByTree)) {
+        treePatchSegments[treeId].push({ historyIndex: i, patchCount });
       }
     }
 
@@ -558,21 +565,28 @@ export const TreeManager = types
     const applyPromises = Object.entries(treePatches).map(async ([treeId, patches]) => {
       if (!patches || patches.length === 0) return;
       const tree = self.trees[treeId];
+      if (!tree) return;
       try {
-        await tree?.applyPatchesFromManager(FAKE_HISTORY_ENTRY_ID, FAKE_EXCHANGE_ID, patches);
+        await tree.applyPatchesFromManager(FAKE_HISTORY_ENTRY_ID, FAKE_EXCHANGE_ID, patches);
       } catch (e) {
         if (e instanceof PatchApplicationError) {
           const segments = treePatchSegments[treeId];
           const { historyIndex, appliedInEntry } = findFailedSegment(e.numApplied, segments);
 
           // Roll back the partially applied patches from the failed entry
+          // by sending their reversed inverse patches back through
+          // applyPatchesFromManager. That action is in the list of actions
+          // the TreeMonitor middleware treats as coming from the manager,
+          // so the rollback patches won't be recorded as a new user
+          // history entry. Using the TreeAPI also keeps the abstraction
+          // intact for trees that might run in iframes/workers.
           if (e.inversePatches.length > 0) {
             // The inverse patches for the failed entry start at the end of the
             // successfully applied patches from prior entries.
             const priorApplied = e.numApplied - appliedInEntry;
             const partialInverse = e.inversePatches.slice(priorApplied).reverse();
             if (partialInverse.length > 0) {
-              applyPatch(tree as any, partialInverse);
+              await tree.applyPatchesFromManager(FAKE_HISTORY_ENTRY_ID, FAKE_EXCHANGE_ID, partialInverse);
             }
           }
 

--- a/src/models/history/tree-manager.ts
+++ b/src/models/history/tree-manager.ts
@@ -32,6 +32,30 @@ interface PatchSegment {
 }
 
 /**
+ * Build the list of patches for a single history entry that a tree
+ * would receive in a given direction, in the same order and record
+ * ordering that goToHistoryEntry uses when batching. Used to
+ * reconstruct patches without needing the onPatch-collected inverses.
+ */
+function getEntryPatchesForTree(
+  historyEntry: Instance<typeof HistoryEntry>,
+  treeId: string,
+  opType: HistoryOperation
+): IJsonPatch[] {
+  let records = [...historyEntry.records];
+  if (opType === HistoryOperation.Undo) {
+    records = records.reverse();
+  }
+  const result: IJsonPatch[] = [];
+  for (const entryRecord of records) {
+    if (entryRecord.tree === treeId) {
+      result.push(...entryRecord.getPatches(opType));
+    }
+  }
+  return result;
+}
+
+/**
  * Given the number of patches that were successfully applied and the
  * segment mapping, returns the history entry index that contains the
  * patch that failed, and the number of patches from that entry that
@@ -523,29 +547,22 @@ export const TreeManager = types
     const opType = direction === 1 ? HistoryOperation.Redo : HistoryOperation.Undo;
     const startingIndex = direction === 1 ? self.numHistoryEventsApplied : self.numHistoryEventsApplied - 1;
     const endingIndex = direction === 1 ? newHistoryPosition : newHistoryPosition - 1;
+    // A history entry may contain multiple records for the same tree
+    // (e.g. tile update + shared-model update). getEntryPatchesForTree
+    // aggregates them into one ordered list per tree so we can push a
+    // single segment per tree per history entry — that way rollback on
+    // failure covers all records in the entry, not just one.
+    // Using the same helper for both the initial batching and the
+    // rollback ensures the two paths produce matching orderings.
     for (let i=startingIndex; i !== endingIndex; i=i+direction) {
       const historyEntry = self.document.history.at(i);
-      let records = historyEntry ? [ ...historyEntry.records] : [];
-      if (direction === -1) {
-        records = records.reverse();
-      }
-      // A history entry may contain multiple records for the same tree
-      // (e.g. tile update + shared-model update). Track the per-tree
-      // patch count for this history entry so we can push a single
-      // segment per tree that covers the whole entry — that way rollback
-      // on failure covers all records in the entry, not just one.
-      const entryPatchCountByTree: Record<string, number> = {};
-      for (const entryRecord of records) {
-        const patches = treePatches[entryRecord.tree];
-        const entryPatches = entryRecord.getPatches(opType);
-        if (patches && entryPatches.length > 0) {
-          patches.push(...entryPatches);
-          entryPatchCountByTree[entryRecord.tree] =
-            (entryPatchCountByTree[entryRecord.tree] ?? 0) + entryPatches.length;
+      if (!historyEntry) continue;
+      for (const treeId of Object.keys(self.trees)) {
+        const entryPatches = getEntryPatchesForTree(historyEntry, treeId, opType);
+        if (entryPatches.length > 0) {
+          treePatches[treeId]!.push(...entryPatches);
+          treePatchSegments[treeId].push({ historyIndex: i, patchCount: entryPatches.length });
         }
-      }
-      for (const [treeId, patchCount] of Object.entries(entryPatchCountByTree)) {
-        treePatchSegments[treeId].push({ historyIndex: i, patchCount });
       }
     }
 
@@ -574,19 +591,32 @@ export const TreeManager = types
           const { historyIndex, appliedInEntry } = findFailedSegment(e.numApplied, segments);
 
           // Roll back the partially applied patches from the failed entry
-          // by sending their reversed inverse patches back through
-          // applyPatchesFromManager. That action is in the list of actions
-          // the TreeMonitor middleware treats as coming from the manager,
-          // so the rollback patches won't be recorded as a new user
-          // history entry. Using the TreeAPI also keeps the abstraction
-          // intact for trees that might run in iframes/workers.
-          if (e.inversePatches.length > 0) {
-            // The inverse patches for the failed entry start at the end of the
-            // successfully applied patches from prior entries.
-            const priorApplied = e.numApplied - appliedInEntry;
-            const partialInverse = e.inversePatches.slice(priorApplied).reverse();
-            if (partialInverse.length > 0) {
-              await tree.applyPatchesFromManager(FAKE_HISTORY_ENTRY_ID, FAKE_EXCHANGE_ID, partialInverse);
+          // by sending the opposite-direction patches for that entry back
+          // through applyPatchesFromManager. That action is in the list of
+          // actions the TreeMonitor middleware treats as coming from the
+          // manager, so the rollback patches won't be recorded as a new
+          // user history entry. Using the TreeAPI also keeps the
+          // abstraction intact for trees that might run in iframes/workers.
+          //
+          // Derivation of the slice: in the opposite direction, an entry's
+          // batched patches list is the reverse of the forward direction's
+          // list. The first `appliedInEntry` patches of the forward list
+          // correspond to the last `appliedInEntry` patches of the opposite
+          // list — so .slice(length - appliedInEntry) gives us the patches
+          // we need (already in the correct order to undo the partial
+          // application).
+          if (appliedInEntry > 0) {
+            const failedEntry = self.document.history.at(historyIndex);
+            if (failedEntry) {
+              const oppositeOp = opType === HistoryOperation.Redo
+                ? HistoryOperation.Undo
+                : HistoryOperation.Redo;
+              const oppositePatches = getEntryPatchesForTree(failedEntry, treeId, oppositeOp);
+              const rollbackPatches = oppositePatches.slice(oppositePatches.length - appliedInEntry);
+              if (rollbackPatches.length > 0) {
+                await tree.applyPatchesFromManager(
+                  FAKE_HISTORY_ENTRY_ID, FAKE_EXCHANGE_ID, rollbackPatches);
+              }
             }
           }
 

--- a/src/models/history/tree-manager.ts
+++ b/src/models/history/tree-manager.ts
@@ -566,89 +566,165 @@ export const TreeManager = types
       }
     }
 
-    // Apply the batched patches to each tree. If any tree fails, roll back
-    // the partially applied patches, mark the offending history entry as
-    // failed, and set the position to the last fully applied entry.
-    //
-    // TODO: Because trees are applied in parallel, if one tree fails at
-    // history entry N, other trees may have already applied patches past N.
-    // This leaves the trees out of sync. Currently CLUE only has one tree
-    // so this isn't a practical issue, but if multiple trees are used in
-    // the future we'll need to roll back the other trees to the same
-    // position (e.g., by tracking per-tree segments and reversing patches
-    // past the failed entry on all trees).
-    let failedEntryIndex: number | undefined;
+    // Apply the batched patches to each tree in parallel. If any tree
+    // fails, we pick an "earliest" failing history index across all
+    // trees and roll every tree back so their state is consistent with
+    // that stop position:
+    //   - Forward (Redo): stopPosition = min(failedIndices)
+    //   - Backward (Undo): stopPosition = max(failedIndices) + 1
+    // Trees that succeeded past the stop position have those entries
+    // rolled back; trees that failed have their own partial rollback
+    // plus any entries they applied past the stop position.
+    interface TreeApplyFailure {
+      error: PatchApplicationError;
+      historyIndex: number;
+      appliedInEntry: number;
+      failingSegIdx: number;
+    }
+    interface TreeApplyResult {
+      treeId: string;
+      tree: TreeAPI;
+      segments: PatchSegment[];
+      failure?: TreeApplyFailure;
+    }
+    const results: TreeApplyResult[] = [];
 
     const applyPromises = Object.entries(treePatches).map(async ([treeId, patches]) => {
       if (!patches || patches.length === 0) return;
       const tree = self.trees[treeId];
       if (!tree) return;
+      const segments = treePatchSegments[treeId];
       try {
         await tree.applyPatchesFromManager(FAKE_HISTORY_ENTRY_ID, FAKE_EXCHANGE_ID, patches);
+        results.push({ treeId, tree, segments });
       } catch (e) {
         if (e instanceof PatchApplicationError) {
-          const segments = treePatchSegments[treeId];
           const { historyIndex, appliedInEntry } = findFailedSegment(e.numApplied, segments);
-
-          // Roll back the partially applied patches from the failed entry
-          // by sending the opposite-direction patches for that entry back
-          // through applyPatchesFromManager. That action is in the list of
-          // actions the TreeMonitor middleware treats as coming from the
-          // manager, so the rollback patches won't be recorded as a new
-          // user history entry. Using the TreeAPI also keeps the
-          // abstraction intact for trees that might run in iframes/workers.
-          //
-          // Derivation of the slice: in the opposite direction, an entry's
-          // batched patches list is the reverse of the forward direction's
-          // list. The first `appliedInEntry` patches of the forward list
-          // correspond to the last `appliedInEntry` patches of the opposite
-          // list — so .slice(length - appliedInEntry) gives us the patches
-          // we need (already in the correct order to undo the partial
-          // application).
-          if (appliedInEntry > 0) {
-            const failedEntry = self.document.history.at(historyIndex);
-            if (failedEntry) {
-              const oppositeOp = opType === HistoryOperation.Redo
-                ? HistoryOperation.Undo
-                : HistoryOperation.Redo;
-              const oppositePatches = getEntryPatchesForTree(failedEntry, treeId, oppositeOp);
-              const rollbackPatches = oppositePatches.slice(oppositePatches.length - appliedInEntry);
-              if (rollbackPatches.length > 0) {
-                await tree.applyPatchesFromManager(
-                  FAKE_HISTORY_ENTRY_ID, FAKE_EXCHANGE_ID, rollbackPatches);
-              }
-            }
-          }
-
-          failedEntryIndex = historyIndex;
-          const directionStr = opType === HistoryOperation.Redo ? "redo" : "undo";
-          const historyEntry = self.document.history.at(historyIndex);
-          if (historyEntry) {
-            // Skip if we already recorded a failure for this entry and
-            // direction (user may scrub past the same entry repeatedly).
-            const alreadyRecorded = self.historyPlaybackFailures.some(
-              f => f.historyIndex === historyIndex && f.direction === directionStr
-            );
-            if (!alreadyRecorded) {
-              self.historyPlaybackFailures.push({
-                historyEntry,
-                historyIndex,
-                direction: directionStr,
-                errorMessage: e.message
-              });
-            }
-          }
-
-          // eslint-disable-next-line no-console
-          console.warn(
-            `History entry ${historyIndex} failed to ${directionStr}: ${e.message}`
-          );
+          // Each segment has a unique historyIndex because
+          // getEntryPatchesForTree aggregates per-entry.
+          const failingSegIdx = segments.findIndex(s => s.historyIndex === historyIndex);
+          results.push({
+            treeId, tree, segments,
+            failure: { error: e, historyIndex, appliedInEntry, failingSegIdx }
+          });
         } else {
           throw e;
         }
       }
     });
     yield Promise.all(applyPromises);
+
+    const failedResults = results.filter(r => r.failure);
+    let stopPosition: number | undefined;
+    if (failedResults.length > 0) {
+      const failedIndices = failedResults.map(r => r.failure!.historyIndex);
+      const earliestFailedIndex = direction === 1
+        ? Math.min(...failedIndices)
+        : Math.max(...failedIndices);
+      stopPosition = direction === 1
+        ? earliestFailedIndex
+        : earliestFailedIndex + 1;
+
+      // For forward, entries with historyIndex >= stopPosition must
+      // not be "applied" at the stop position. For backward, entries
+      // with historyIndex < stopPosition must be "applied".
+      const needsRollback = (historyIndex: number): boolean => {
+        return direction === 1
+          ? historyIndex >= stopPosition!
+          : historyIndex < stopPosition!;
+      };
+
+      const oppositeOp = opType === HistoryOperation.Redo
+        ? HistoryOperation.Undo
+        : HistoryOperation.Redo;
+
+      // Build and apply per-tree rollback batches.
+      //
+      // Rollback ordering: patches need to be applied in reverse of the
+      // order they were applied in the forward batch. The failing
+      // entry's partial was applied last, so it rolls back first; then
+      // fully-applied segments roll back in reverse segment order.
+      //
+      // Partial slice derivation: in the opposite direction, an
+      // entry's batched patches list is the reverse of the forward
+      // direction's list. The first `appliedInEntry` patches of the
+      // forward list correspond to the last `appliedInEntry` patches
+      // of the opposite list — so .slice(length - appliedInEntry)
+      // gives us the patches we need (already in the correct order
+      // to undo the partial application).
+      const rollbackPromises = results.map(async (r) => {
+        const rollbackPatches: IJsonPatch[] = [];
+
+        if (r.failure) {
+          const { historyIndex, appliedInEntry } = r.failure;
+          if (appliedInEntry > 0) {
+            const failedEntry = self.document.history.at(historyIndex);
+            if (failedEntry) {
+              const oppositePatches = getEntryPatchesForTree(failedEntry, r.treeId, oppositeOp);
+              rollbackPatches.push(
+                ...oppositePatches.slice(oppositePatches.length - appliedInEntry)
+              );
+            }
+          }
+        }
+
+        // Fully-applied segments (those before the failing segment, or
+        // all segments if this tree didn't fail), in reverse application
+        // order. Only those "past" the stop position need rollback.
+        const failingSegIdx = r.failure ? r.failure.failingSegIdx : r.segments.length;
+        for (let i = failingSegIdx - 1; i >= 0; i--) {
+          const seg = r.segments[i];
+          if (needsRollback(seg.historyIndex)) {
+            const entry = self.document.history.at(seg.historyIndex);
+            if (entry) {
+              const oppositePatches = getEntryPatchesForTree(entry, r.treeId, oppositeOp);
+              rollbackPatches.push(...oppositePatches);
+            }
+          }
+        }
+
+        if (rollbackPatches.length > 0) {
+          try {
+            await r.tree.applyPatchesFromManager(
+              FAKE_HISTORY_ENTRY_ID, FAKE_EXCHANGE_ID, rollbackPatches);
+          } catch (rollbackError) {
+            // Rollback itself failed — trees are now out of sync and
+            // we can't recover automatically. Log and continue.
+            // TODO: consider surfacing this as a distinct catastrophic
+            // failure signal for the UI.
+            // eslint-disable-next-line no-console
+            console.warn(
+              `Rollback of tree '${r.treeId}' failed: ${(rollbackError as Error).message}. ` +
+              `Trees may be in an inconsistent state.`
+            );
+          }
+        }
+      });
+      yield Promise.all(rollbackPromises);
+
+      // Record one failure per (historyIndex, direction) pair, deduped.
+      const directionStr = direction === 1 ? "redo" : "undo";
+      for (const r of failedResults) {
+        const { historyIndex, error } = r.failure!;
+        const historyEntry = self.document.history.at(historyIndex);
+        if (!historyEntry) continue;
+        const alreadyRecorded = self.historyPlaybackFailures.some(
+          f => f.historyIndex === historyIndex && f.direction === directionStr
+        );
+        if (!alreadyRecorded) {
+          self.historyPlaybackFailures.push({
+            historyEntry,
+            historyIndex,
+            direction: directionStr,
+            errorMessage: error.message
+          });
+        }
+        // eslint-disable-next-line no-console
+        console.warn(
+          `History entry ${historyIndex} failed to ${directionStr}: ${error.message}`
+        );
+      }
+    }
 
     // finish the patch application
     // Need to tell all of the tiles to re-enable the sync and run the sync
@@ -668,14 +744,8 @@ export const TreeManager = types
     // and print a warning to the console.
     // One way might be using unique history_entry_ids that we mark as closed
     // after the finish call.
-    if (failedEntryIndex !== undefined) {
-      // Set position to just before the failed entry (when going forward)
-      // or just after it (when going backward).
-      if (direction === 1) {
-        self.numHistoryEventsApplied = failedEntryIndex;
-      } else {
-        self.numHistoryEventsApplied = failedEntryIndex + 1;
-      }
+    if (stopPosition !== undefined) {
+      self.numHistoryEventsApplied = stopPosition;
     } else {
       self.numHistoryEventsApplied = newHistoryPosition;
     }

--- a/src/models/history/tree-manager.ts
+++ b/src/models/history/tree-manager.ts
@@ -1,5 +1,5 @@
 import {
-  types, Instance, flow, IJsonPatch, detach, destroy, toGenerator
+  applyPatch, types, Instance, flow, IJsonPatch, detach, destroy, toGenerator
 } from "mobx-state-tree";
 import { nanoid } from "nanoid";
 import { TreeAPI } from "./tree-api";
@@ -8,10 +8,48 @@ import { TreePatchRecord, HistoryEntry, TreePatchRecordSnapshot,
   HistoryOperation,
   ICreateHistoryEntry} from "./history";
 import { DEBUG_HISTORY } from "../../lib/debug";
+import { PatchApplicationError } from "./tree";
 import { IDocumentMetadata } from "../../../shared/shared";
 import { Firestore } from "../../lib/firestore";
 import { UserContextProvider } from "../stores/user-context-provider";
 import { getLastHistoryEntry } from "./history-firestore";
+
+export interface HistoryPlaybackFailure {
+  historyEntry: Instance<typeof HistoryEntry>;
+  historyIndex: number;
+  direction: "undo" | "redo";
+  errorMessage: string;
+}
+
+/**
+ * Tracks how patches in a batched array map back to their history entries.
+ * Each segment records a history entry index and the number of patches
+ * from that entry that were added to the batch.
+ */
+interface PatchSegment {
+  historyIndex: number;
+  patchCount: number;
+}
+
+/**
+ * Given the number of patches that were successfully applied and the
+ * segment mapping, returns the history entry index that contains the
+ * patch that failed, and the number of patches from that entry that
+ * were successfully applied before the failure.
+ */
+function findFailedSegment(numApplied: number, segments: PatchSegment[]) {
+  let remaining = numApplied;
+  for (const segment of segments) {
+    if (remaining < segment.patchCount) {
+      return { historyIndex: segment.historyIndex, appliedInEntry: remaining };
+    }
+    remaining -= segment.patchCount;
+  }
+  // This shouldn't happen — numApplied should be less than total patches
+  // if we're in an error path. Return the last segment as a fallback.
+  const last = segments[segments.length - 1];
+  return { historyIndex: last.historyIndex, appliedInEntry: last.patchCount };
+}
 
 /**
  * Helper method to print objects in template strings
@@ -85,7 +123,12 @@ export const TreeManager = types
    * History manager to be notified when new history entries are completed.
    * Consumers can check for specific types (e.g., FirestoreHistoryManagerConcurrent).
    */
-  historyManager: undefined as IHistoryManager | undefined
+  historyManager: undefined as IHistoryManager | undefined,
+  /**
+   * History entries whose patches could not be applied. A patch may fail
+   * in one direction but not the other, so entries include the direction.
+   */
+  historyPlaybackFailures: [] as HistoryPlaybackFailure[]
 }))
 .views((self) => ({
   get undoManager() : IUndoManager {
@@ -178,6 +221,48 @@ export const TreeManager = types
 
   setNumHistoryEntriesApplied(value: number) {
     self.numHistoryEventsApplied = value;
+  },
+
+  /**
+   * Inject a synthetic history entry with a patch that will always fail
+   * when replayed (references a non-existent tile). Useful for testing
+   * playback failure handling.
+   */
+  injectFailingHistoryEntry() {
+    if (!self.mainDocument) {
+      console.warn("Cannot inject failing entry: no main document");
+      return;
+    }
+    const entryId = nanoid();
+    const treeId = self.mainDocument.key;
+    const entry = HistoryEntry.create({
+      id: entryId,
+      tree: treeId,
+      model: "TestFailure",
+      action: "/injectFailingHistoryEntry",
+      undoable: true,
+      state: "complete",
+      records: [{
+        tree: treeId,
+        action: "/injectFailingHistoryEntry",
+        patches: [{
+          op: "replace",
+          path: "/content/tileMap/NONEXISTENT_TILE/content/value",
+          value: "this patch will fail"
+        }],
+        inversePatches: [{
+          op: "replace",
+          path: "/content/tileMap/NONEXISTENT_TILE/content/value",
+          value: "original"
+        }]
+      }]
+    });
+    const newLocalIndex = self.document.history.length;
+    self.document.history.push(entry);
+    self.numHistoryEventsApplied = self.document.history.length;
+    self.revisionId = entryId;
+    self.undoStore.addHistoryEntry(entry);
+    self.historyManager?.onHistoryEntryCompleted(self.document, entry, newLocalIndex);
   },
 
   putTree(treeId: string, tree: TreeAPI) {
@@ -423,13 +508,19 @@ export const TreeManager = types
     yield Promise.all(startPromises);
 
     const treePatches: Record<string, IJsonPatch[] | undefined> = {};
-    Object.keys(self.trees).forEach(treeId => treePatches[treeId] = []);
+    // Track which history entry each patch came from, per tree.
+    const treePatchSegments: Record<string, PatchSegment[]> = {};
+    Object.keys(self.trees).forEach(treeId => {
+      treePatches[treeId] = [];
+      treePatchSegments[treeId] = [];
+    });
 
     // direction tells us which direction to go
     // startingIndex and endingIndex are so we don't add the currentHistoryEvent into patches
     // because we are going to assume that it has already been played, and we don't want to play it
     // again if we are going forward.
     const direction = newHistoryPosition > self.numHistoryEventsApplied ? 1 : -1;
+    const opType = direction === 1 ? HistoryOperation.Redo : HistoryOperation.Undo;
     const startingIndex = direction === 1 ? self.numHistoryEventsApplied : self.numHistoryEventsApplied - 1;
     const endingIndex = direction === 1 ? newHistoryPosition : newHistoryPosition - 1;
     for (let i=startingIndex; i !== endingIndex; i=i+direction) {
@@ -440,18 +531,70 @@ export const TreeManager = types
       }
       for (const entryRecord of records) {
         const patches = treePatches[entryRecord.tree];
-        if (newHistoryPosition > self.numHistoryEventsApplied) {
-          patches?.push(...entryRecord.getPatches(HistoryOperation.Redo));
-        } else {
-          patches?.push(...entryRecord.getPatches(HistoryOperation.Undo));
+        const entryPatches = entryRecord.getPatches(opType);
+        if (patches && entryPatches.length > 0) {
+          patches.push(...entryPatches);
+          treePatchSegments[entryRecord.tree].push({
+            historyIndex: i,
+            patchCount: entryPatches.length
+          });
         }
       }
     }
 
-    const applyPromises = Object.entries(treePatches).map(([treeId, patches]) => {
-      if (patches && patches.length > 0) {
-        const tree = self.trees[treeId];
-        return tree?.applyPatchesFromManager(FAKE_HISTORY_ENTRY_ID, FAKE_EXCHANGE_ID, patches);
+    // Apply the batched patches to each tree. If any tree fails, roll back
+    // the partially applied patches, mark the offending history entry as
+    // failed, and set the position to the last fully applied entry.
+    //
+    // TODO: Because trees are applied in parallel, if one tree fails at
+    // history entry N, other trees may have already applied patches past N.
+    // This leaves the trees out of sync. Currently CLUE only has one tree
+    // so this isn't a practical issue, but if multiple trees are used in
+    // the future we'll need to roll back the other trees to the same
+    // position (e.g., by tracking per-tree segments and reversing patches
+    // past the failed entry on all trees).
+    let failedEntryIndex: number | undefined;
+
+    const applyPromises = Object.entries(treePatches).map(async ([treeId, patches]) => {
+      if (!patches || patches.length === 0) return;
+      const tree = self.trees[treeId];
+      try {
+        await tree?.applyPatchesFromManager(FAKE_HISTORY_ENTRY_ID, FAKE_EXCHANGE_ID, patches);
+      } catch (e) {
+        if (e instanceof PatchApplicationError) {
+          const segments = treePatchSegments[treeId];
+          const { historyIndex, appliedInEntry } = findFailedSegment(e.numApplied, segments);
+
+          // Roll back the partially applied patches from the failed entry
+          if (e.inversePatches.length > 0) {
+            // The inverse patches for the failed entry start at the end of the
+            // successfully applied patches from prior entries.
+            const priorApplied = e.numApplied - appliedInEntry;
+            const partialInverse = e.inversePatches.slice(priorApplied).reverse();
+            if (partialInverse.length > 0) {
+              applyPatch(tree as any, partialInverse);
+            }
+          }
+
+          failedEntryIndex = historyIndex;
+          const directionStr = opType === HistoryOperation.Redo ? "redo" : "undo";
+          const historyEntry = self.document.history.at(historyIndex);
+          if (historyEntry) {
+            self.historyPlaybackFailures.push({
+              historyEntry,
+              historyIndex,
+              direction: directionStr,
+              errorMessage: e.message
+            });
+          }
+
+          // eslint-disable-next-line no-console
+          console.warn(
+            `History entry ${historyIndex} failed to ${directionStr}: ${e.message}`
+          );
+        } else {
+          throw e;
+        }
       }
     });
     yield Promise.all(applyPromises);
@@ -474,7 +617,17 @@ export const TreeManager = types
     // and print a warning to the console.
     // One way might be using unique history_entry_ids that we mark as closed
     // after the finish call.
-    self.numHistoryEventsApplied = newHistoryPosition;
+    if (failedEntryIndex !== undefined) {
+      // Set position to just before the failed entry (when going forward)
+      // or just after it (when going backward).
+      if (direction === 1) {
+        self.numHistoryEventsApplied = failedEntryIndex;
+      } else {
+        self.numHistoryEventsApplied = failedEntryIndex + 1;
+      }
+    } else {
+      self.numHistoryEventsApplied = newHistoryPosition;
+    }
   }),
 }))
 .views(self => ({

--- a/src/models/history/tree-manager.ts
+++ b/src/models/history/tree-manager.ts
@@ -594,12 +594,19 @@ export const TreeManager = types
           const directionStr = opType === HistoryOperation.Redo ? "redo" : "undo";
           const historyEntry = self.document.history.at(historyIndex);
           if (historyEntry) {
-            self.historyPlaybackFailures.push({
-              historyEntry,
-              historyIndex,
-              direction: directionStr,
-              errorMessage: e.message
-            });
+            // Skip if we already recorded a failure for this entry and
+            // direction (user may scrub past the same entry repeatedly).
+            const alreadyRecorded = self.historyPlaybackFailures.some(
+              f => f.historyIndex === historyIndex && f.direction === directionStr
+            );
+            if (!alreadyRecorded) {
+              self.historyPlaybackFailures.push({
+                historyEntry,
+                historyIndex,
+                direction: directionStr,
+                errorMessage: e.message
+              });
+            }
           }
 
           // eslint-disable-next-line no-console

--- a/src/models/history/tree-manager.ts
+++ b/src/models/history/tree-manager.ts
@@ -561,9 +561,13 @@ export const TreeManager = types
       const historyEntry = self.document.history.at(i);
       if (!historyEntry) continue;
       for (const treeId of Object.keys(self.trees)) {
+        const patches = treePatches[treeId];
+        if (!patches) {
+          throw new Error(`treePatches missing entry for known tree '${treeId}'`);
+        }
         const entryPatches = getEntryPatchesForTree(historyEntry, treeId, opType);
         if (entryPatches.length > 0) {
-          treePatches[treeId]!.push(...entryPatches);
+          patches.push(...entryPatches);
           treePatchSegments[treeId].push({ historyIndex: i, patchCount: entryPatches.length });
         }
       }
@@ -608,7 +612,12 @@ export const TreeManager = types
       failure?: TreeApplyFailure;
       unexpected?: TreeApplyUnexpected;
     }
+    type FailedResult = TreeApplyResult & { failure: TreeApplyFailure };
+    type UnexpectedResult = TreeApplyResult & { unexpected: TreeApplyUnexpected };
+
     const results: TreeApplyResult[] = [];
+    const failedResults: FailedResult[] = [];
+    const unexpectedResults: UnexpectedResult[] = [];
 
     const applyPromises = Object.entries(treePatches).map(async ([treeId, patches]) => {
       if (!patches || patches.length === 0) return;
@@ -624,23 +633,30 @@ export const TreeManager = types
           // Each segment has a unique historyIndex because
           // getEntryPatchesForTree aggregates per-entry.
           const failingSegIdx = segments.findIndex(s => s.historyIndex === historyIndex);
-          results.push({
+          const failedResult: FailedResult = {
             treeId, tree, segments,
             failure: { error: e, historyIndex, appliedInEntry, failingSegIdx }
-          });
+          };
+          results.push(failedResult);
+          failedResults.push(failedResult);
         } else {
           // Do NOT rethrow: route this through the playback-failure
           // handling below so the user and developer both see it.
-          results.push({ treeId, tree, segments, unexpected: { error: e } });
+          const unexpectedResult: UnexpectedResult = {
+            treeId, tree, segments, unexpected: { error: e }
+          };
+          results.push(unexpectedResult);
+          unexpectedResults.push(unexpectedResult);
         }
       }
     });
     yield Promise.all(applyPromises);
 
-    const failedResults = results.filter(r => r.failure);
-    const unexpectedResults = results.filter(r => r.unexpected);
     const hasAnyFailure = failedResults.length > 0 || unexpectedResults.length > 0;
-    let stopPosition: number | undefined;
+    // Default to the requested target; the failure branch below may change
+    // it to a previous position depending on the direction we are moving in
+    // if some patches couldn't be applied.
+    let stopPosition: number = newHistoryPosition;
 
     if (hasAnyFailure) {
       if (unexpectedResults.length > 0) {
@@ -649,13 +665,17 @@ export const TreeManager = types
         // started and don't touch the failing tree at all.
         stopPosition = initialPosition;
       } else {
-        const failedIndices = failedResults.map(r => r.failure!.historyIndex);
-        const earliestFailedIndex = direction === 1
-          ? Math.min(...failedIndices)
-          : Math.max(...failedIndices);
+        const failedIndices = failedResults.map(r => r.failure.historyIndex);
+        // stopPosition is the new numHistoryEventsApplied.
+        // When going forward the entry at index numHistoryEventsApplied hasn't
+        // been applied yet. So we can apply events until
+        // numHistoryEventsApplied equals the first failing entry.
+        // When going backward the entry at index numHistoryEventsApplied has
+        // had its "undo" patches applied. So we have to stop just before
+        // numHistoryEventsApplied equals this failing entry.
         stopPosition = direction === 1
-          ? earliestFailedIndex
-          : earliestFailedIndex + 1;
+          ? Math.min(...failedIndices)
+          : Math.max(...failedIndices) + 1;
       }
 
       // For forward, entries with historyIndex >= stopPosition must
@@ -663,8 +683,8 @@ export const TreeManager = types
       // with historyIndex < stopPosition must be "applied".
       const needsRollback = (historyIndex: number): boolean => {
         return direction === 1
-          ? historyIndex >= stopPosition!
-          : historyIndex < stopPosition!;
+          ? historyIndex >= stopPosition
+          : historyIndex < stopPosition;
       };
 
       const oppositeOp = opType === HistoryOperation.Redo
@@ -732,7 +752,6 @@ export const TreeManager = types
             // we can't recover automatically. Log and continue.
             // TODO: consider surfacing this as a distinct catastrophic
             // failure signal for the UI.
-            // eslint-disable-next-line no-console
             console.warn(
               `Rollback of tree '${r.treeId}' failed: ${(rollbackError as Error).message}. ` +
               `Trees may be in an inconsistent state.`
@@ -742,15 +761,23 @@ export const TreeManager = types
       });
       yield Promise.all(rollbackPromises);
 
+      // Track which (historyIndex, direction) pairs have been recorded so
+      // we can dedupe in O(1) instead of scanning historyPlaybackFailures
+      // on every push. directionStr is constant for this call, so keying
+      // on historyIndex alone is sufficient.
+      const recordedIndices = new Set<number>(
+        self.historyPlaybackFailures
+          .filter(f => f.direction === directionStr)
+          .map(f => f.historyIndex)
+      );
+
       // Record one failure per (historyIndex, direction) pair, deduped.
       for (const r of failedResults) {
-        const { historyIndex, error } = r.failure!;
+        const { historyIndex, error } = r.failure;
         const historyEntry = self.document.history.at(historyIndex);
         if (!historyEntry) continue;
-        const alreadyRecorded = self.historyPlaybackFailures.some(
-          f => f.historyIndex === historyIndex && f.direction === directionStr
-        );
-        if (!alreadyRecorded) {
+        if (!recordedIndices.has(historyIndex)) {
+          recordedIndices.add(historyIndex);
           self.historyPlaybackFailures.push({
             historyEntry,
             historyIndex,
@@ -758,7 +785,6 @@ export const TreeManager = types
             errorMessage: error.message
           });
         }
-        // eslint-disable-next-line no-console
         console.warn(
           `History entry ${historyIndex} failed to ${directionStr}: ${error.message}`
         );
@@ -777,22 +803,17 @@ export const TreeManager = types
           ? self.document.history.at(unexpectedIndex)
           : undefined;
       for (const r of unexpectedResults) {
-        const err = r.unexpected!.error;
+        const err = r.unexpected.error;
         const errMessage = err instanceof Error ? err.message : String(err);
-        if (unexpectedEntry) {
-          const alreadyRecorded = self.historyPlaybackFailures.some(
-            f => f.historyIndex === unexpectedIndex && f.direction === directionStr
-          );
-          if (!alreadyRecorded) {
-            self.historyPlaybackFailures.push({
-              historyEntry: unexpectedEntry,
-              historyIndex: unexpectedIndex,
-              direction: directionStr,
-              errorMessage: `Unexpected error during playback: ${errMessage}`
-            });
-          }
+        if (unexpectedEntry && !recordedIndices.has(unexpectedIndex)) {
+          recordedIndices.add(unexpectedIndex);
+          self.historyPlaybackFailures.push({
+            historyEntry: unexpectedEntry,
+            historyIndex: unexpectedIndex,
+            direction: directionStr,
+            errorMessage: `Unexpected error during playback: ${errMessage}`
+          });
         }
-        // eslint-disable-next-line no-console
         console.error(
           `Unexpected error playing back tree '${r.treeId}' ` +
           `at history position ${unexpectedIndex}:`,
@@ -819,11 +840,7 @@ export const TreeManager = types
     // and print a warning to the console.
     // One way might be using unique history_entry_ids that we mark as closed
     // after the finish call.
-    if (stopPosition !== undefined) {
-      self.numHistoryEventsApplied = stopPosition;
-    } else {
-      self.numHistoryEventsApplied = newHistoryPosition;
-    }
+    self.numHistoryEventsApplied = stopPosition;
   }),
 }))
 .views(self => ({

--- a/src/models/history/tree-manager.ts
+++ b/src/models/history/tree-manager.ts
@@ -521,6 +521,9 @@ export const TreeManager = types
 
     if (newHistoryPosition === self.numHistoryEventsApplied) return;
     if (self.numHistoryEventsApplied === undefined) return;
+    // Capture the starting position so unexpected-error handling can
+    // anchor its failure recording and rollback to a known-safe point.
+    const initialPosition = self.numHistoryEventsApplied;
     // Disable shared model syncing on all of the trees. This is
     // different than when the undo store applies patches because in
     // this case we are going to apply lots of history entries all at
@@ -566,26 +569,44 @@ export const TreeManager = types
       }
     }
 
-    // Apply the batched patches to each tree in parallel. If any tree
-    // fails, we pick an "earliest" failing history index across all
-    // trees and roll every tree back so their state is consistent with
-    // that stop position:
-    //   - Forward (Redo): stopPosition = min(failedIndices)
-    //   - Backward (Undo): stopPosition = max(failedIndices) + 1
-    // Trees that succeeded past the stop position have those entries
-    // rolled back; trees that failed have their own partial rollback
-    // plus any entries they applied past the stop position.
+    // Apply the batched patches to each tree in parallel. Two kinds of
+    // failure can happen during the apply phase:
+    //
+    // 1. PatchApplicationError — a recoverable patch-apply failure.
+    //    We pick an earliest failing history index across all trees
+    //    that had one:
+    //      - Forward (Redo): stopPosition = min(failedIndices)
+    //      - Backward (Undo): stopPosition = max(failedIndices) + 1
+    //    Trees that succeeded past the stop position have those
+    //    entries rolled back; trees that failed have their own partial
+    //    rollback plus any entries they applied past the stop position.
+    //
+    // 2. Any other error — a bug, by construction: applyPatchesFromManager
+    //    wraps patch-apply failures as PatchApplicationError, and there
+    //    is no IO/network path that could produce a transient failure.
+    //    We refuse to advance at all (stopPosition = initialPosition),
+    //    roll back any tree that succeeded in the batch, leave the
+    //    failing tree alone (we don't know how far it got), record a
+    //    playback-failure marker so the user sees the existing UI
+    //    banner, and console.error the original stack so a developer
+    //    can find the bug. This replaces the old behavior of letting
+    //    the error escape as an unhandled promise rejection (which was
+    //    invisible in the UI and easy to miss in logs).
     interface TreeApplyFailure {
       error: PatchApplicationError;
       historyIndex: number;
       appliedInEntry: number;
       failingSegIdx: number;
     }
+    interface TreeApplyUnexpected {
+      error: unknown;
+    }
     interface TreeApplyResult {
       treeId: string;
       tree: TreeAPI;
       segments: PatchSegment[];
       failure?: TreeApplyFailure;
+      unexpected?: TreeApplyUnexpected;
     }
     const results: TreeApplyResult[] = [];
 
@@ -608,22 +629,34 @@ export const TreeManager = types
             failure: { error: e, historyIndex, appliedInEntry, failingSegIdx }
           });
         } else {
-          throw e;
+          // Do NOT rethrow: route this through the playback-failure
+          // handling below so the user and developer both see it.
+          results.push({ treeId, tree, segments, unexpected: { error: e } });
         }
       }
     });
     yield Promise.all(applyPromises);
 
     const failedResults = results.filter(r => r.failure);
+    const unexpectedResults = results.filter(r => r.unexpected);
+    const hasAnyFailure = failedResults.length > 0 || unexpectedResults.length > 0;
     let stopPosition: number | undefined;
-    if (failedResults.length > 0) {
-      const failedIndices = failedResults.map(r => r.failure!.historyIndex);
-      const earliestFailedIndex = direction === 1
-        ? Math.min(...failedIndices)
-        : Math.max(...failedIndices);
-      stopPosition = direction === 1
-        ? earliestFailedIndex
-        : earliestFailedIndex + 1;
+
+    if (hasAnyFailure) {
+      if (unexpectedResults.length > 0) {
+        // Conservative: refuse to advance. We don't know how far the
+        // failing tree got, so we re-anchor all trees to where we
+        // started and don't touch the failing tree at all.
+        stopPosition = initialPosition;
+      } else {
+        const failedIndices = failedResults.map(r => r.failure!.historyIndex);
+        const earliestFailedIndex = direction === 1
+          ? Math.min(...failedIndices)
+          : Math.max(...failedIndices);
+        stopPosition = direction === 1
+          ? earliestFailedIndex
+          : earliestFailedIndex + 1;
+      }
 
       // For forward, entries with historyIndex >= stopPosition must
       // not be "applied" at the stop position. For backward, entries
@@ -637,6 +670,7 @@ export const TreeManager = types
       const oppositeOp = opType === HistoryOperation.Redo
         ? HistoryOperation.Undo
         : HistoryOperation.Redo;
+      const directionStr = direction === 1 ? "redo" : "undo";
 
       // Build and apply per-tree rollback batches.
       //
@@ -652,7 +686,13 @@ export const TreeManager = types
       // of the opposite list — so .slice(length - appliedInEntry)
       // gives us the patches we need (already in the correct order
       // to undo the partial application).
+      //
+      // Trees that failed unexpectedly are skipped entirely: we don't
+      // have a trustworthy numApplied count and can't safely roll back
+      // their state. We leave them as-is and rely on the recorded
+      // playback-failure + console.error to surface the bug.
       const rollbackPromises = results.map(async (r) => {
+        if (r.unexpected) return;
         const rollbackPatches: IJsonPatch[] = [];
 
         if (r.failure) {
@@ -703,7 +743,6 @@ export const TreeManager = types
       yield Promise.all(rollbackPromises);
 
       // Record one failure per (historyIndex, direction) pair, deduped.
-      const directionStr = direction === 1 ? "redo" : "undo";
       for (const r of failedResults) {
         const { historyIndex, error } = r.failure!;
         const historyEntry = self.document.history.at(historyIndex);
@@ -722,6 +761,42 @@ export const TreeManager = types
         // eslint-disable-next-line no-console
         console.warn(
           `History entry ${historyIndex} failed to ${directionStr}: ${error.message}`
+        );
+      }
+
+      // Record unexpected-error failures. We anchor the failure marker
+      // to the first entry the batch was about to touch, since we don't
+      // know where within the batch the error originated:
+      //   - Forward: initialPosition (next entry to apply)
+      //   - Backward: initialPosition - 1 (first entry to undo)
+      // If that index isn't a valid history position, skip the marker
+      // but still console.error so the bug is visible to developers.
+      const unexpectedIndex = direction === 1 ? initialPosition : initialPosition - 1;
+      const unexpectedEntry =
+        unexpectedIndex >= 0 && unexpectedIndex < self.document.history.length
+          ? self.document.history.at(unexpectedIndex)
+          : undefined;
+      for (const r of unexpectedResults) {
+        const err = r.unexpected!.error;
+        const errMessage = err instanceof Error ? err.message : String(err);
+        if (unexpectedEntry) {
+          const alreadyRecorded = self.historyPlaybackFailures.some(
+            f => f.historyIndex === unexpectedIndex && f.direction === directionStr
+          );
+          if (!alreadyRecorded) {
+            self.historyPlaybackFailures.push({
+              historyEntry: unexpectedEntry,
+              historyIndex: unexpectedIndex,
+              direction: directionStr,
+              errorMessage: `Unexpected error during playback: ${errMessage}`
+            });
+          }
+        }
+        // eslint-disable-next-line no-console
+        console.error(
+          `Unexpected error playing back tree '${r.treeId}' ` +
+          `at history position ${unexpectedIndex}:`,
+          err
         );
       }
     }

--- a/src/models/history/tree-monitor.ts
+++ b/src/models/history/tree-monitor.ts
@@ -8,10 +8,11 @@ import { TreeManagerAPI } from "./tree-manager-api";
 import { TreePatchRecordSnapshot } from "./history";
 import { Tree } from "./tree";
 import {
-  CallEnv, getActionModelName, getActionPath, isActionFromManager, isActionHandlingOwnErrors,
+  CallEnv, getActionModelName, getActionPath, isActionFromManager,
   isValidCallEnv, runningCalls,
   SharedModelModifications
 } from "./tree-types";
+import { FAKE_HISTORY_ENTRY_ID } from "./tree-manager";
 import { createActionTrackingMiddleware3, IActionTrackingMiddleware3Call } from "./create-action-tracking-middleware-3";
 
 export class TreeMonitor {
@@ -162,11 +163,14 @@ export class TreeMonitor {
         if (error === undefined) {
           // recordAction is async
           self.recordAction(call, env);
-        } else if (isActionHandlingOwnErrors(call)) {
-          // This action takes responsibility for its own partial-failure
-          // recovery. Don't revert its patches automatically — the caller
-          // (e.g. TreeManager.goToHistoryEntry) needs the already-applied
-          // patches to remain so it can decide what to roll back.
+        } else if (env.historyEntryId === FAKE_HISTORY_ENTRY_ID) {
+          // History playback (goToHistoryEntry / replayHistoryToTrees)
+          // uses FAKE_HISTORY_ENTRY_ID to mark its own apply calls. It
+          // handles partial-failure recovery itself and needs the
+          // already-applied patches to remain, so skip the auto-revert.
+          // All other callers of applyPatchesFromManager (e.g.
+          // UndoStore.applyPatchesToTrees) use real ids and get the
+          // normal middleware auto-rollback below.
         } else {
           // TODO: This is a new feature that is being added to the tree:
           // any errors that happen during an action will cause the tree to revert back to

--- a/src/models/history/tree-monitor.ts
+++ b/src/models/history/tree-monitor.ts
@@ -8,7 +8,8 @@ import { TreeManagerAPI } from "./tree-manager-api";
 import { TreePatchRecordSnapshot } from "./history";
 import { Tree } from "./tree";
 import {
-  CallEnv, getActionModelName, getActionPath, isActionFromManager, isValidCallEnv, runningCalls,
+  CallEnv, getActionModelName, getActionPath, isActionFromManager, isActionHandlingOwnErrors,
+  isValidCallEnv, runningCalls,
   SharedModelModifications
 } from "./tree-types";
 import { createActionTrackingMiddleware3, IActionTrackingMiddleware3Call } from "./create-action-tracking-middleware-3";
@@ -161,6 +162,11 @@ export class TreeMonitor {
         if (error === undefined) {
           // recordAction is async
           self.recordAction(call, env);
+        } else if (isActionHandlingOwnErrors(call)) {
+          // This action takes responsibility for its own partial-failure
+          // recovery. Don't revert its patches automatically — the caller
+          // (e.g. TreeManager.goToHistoryEntry) needs the already-applied
+          // patches to remain so it can decide what to roll back.
         } else {
           // TODO: This is a new feature that is being added to the tree:
           // any errors that happen during an action will cause the tree to revert back to

--- a/src/models/history/tree-types.ts
+++ b/src/models/history/tree-types.ts
@@ -49,17 +49,3 @@ export function isActionFromManager(call: IActionTrackingMiddleware3Call<CallEnv
   const actionName = call.actionCall.name;
   return actionsFromManager.includes(actionName);
 }
-
-// Actions that manage their own partial-failure recovery and should NOT
-// have the TreeMonitor middleware auto-revert their patches when they
-// throw. By default the middleware calls recorder.undo() in its onFinish
-// error path, which would undo patches that we want to keep (e.g. patches
-// from earlier history entries in a batched goToHistoryEntry replay).
-export const actionsHandlingOwnErrors = [
-  "applyPatchesFromManager"
-];
-
-export function isActionHandlingOwnErrors(call: IActionTrackingMiddleware3Call<CallEnv>) {
-  const actionName = call.actionCall.name;
-  return actionsHandlingOwnErrors.includes(actionName);
-}

--- a/src/models/history/tree-types.ts
+++ b/src/models/history/tree-types.ts
@@ -49,3 +49,17 @@ export function isActionFromManager(call: IActionTrackingMiddleware3Call<CallEnv
   const actionName = call.actionCall.name;
   return actionsFromManager.includes(actionName);
 }
+
+// Actions that manage their own partial-failure recovery and should NOT
+// have the TreeMonitor middleware auto-revert their patches when they
+// throw. By default the middleware calls recorder.undo() in its onFinish
+// error path, which would undo patches that we want to keep (e.g. patches
+// from earlier history entries in a batched goToHistoryEntry replay).
+export const actionsHandlingOwnErrors = [
+  "applyPatchesFromManager"
+];
+
+export function isActionHandlingOwnErrors(call: IActionTrackingMiddleware3Call<CallEnv>) {
+  const actionName = call.actionCall.name;
+  return actionsHandlingOwnErrors.includes(actionName);
+}

--- a/src/models/history/tree.ts
+++ b/src/models/history/tree.ts
@@ -10,20 +10,19 @@ import { TreeManagerAPI } from "./tree-manager-api";
 
 /**
  * Error thrown when applyPatch fails partway through a batch.
- * Includes the number of patches that were successfully applied and their
- * inverse patches (captured via onPatch), so callers can undo partial
- * application and identify which input patch caused the failure.
+ * Includes the number of patches that were successfully applied so callers
+ * can identify which input patch caused the failure. The caller is
+ * responsible for rolling back the partial application using the inverse
+ * patches it already has access to (e.g. from history entry records).
  */
 export class PatchApplicationError extends Error {
   numApplied: number;
-  inversePatches: IJsonPatch[];
 
-  constructor(numApplied: number, inversePatches: IJsonPatch[], originalError: unknown) {
+  constructor(numApplied: number, originalError: unknown) {
     const message = originalError instanceof Error ? originalError.message : String(originalError);
     super(`Patch application failed after ${numApplied} patches: ${message}`);
     this.name = "PatchApplicationError";
     this.numApplied = numApplied;
-    this.inversePatches = inversePatches;
   }
 }
 
@@ -168,10 +167,12 @@ export const Tree = types.model("Tree", {
     //
     // However, batch applyPatch doesn't tell us which patch failed if an
     // error occurs partway through. To work around this, we register an
-    // onPatch listener that counts successfully applied patches and collects
-    // their inverse patches. On failure, we throw a PatchApplicationError
-    // containing the count and inverse patches so callers can roll back the
-    // partial application and identify which input patch caused the failure.
+    // onPatch listener that counts successfully applied patches. On
+    // failure, we throw a PatchApplicationError containing the count so
+    // the caller can identify which input patch caused the failure. The
+    // caller is responsible for rolling back the partial application
+    // using the inverse patches it already has (e.g. from the history
+    // entry records that produced the batch).
     //
     // MST treats a patch with an empty or missing path as a whole-tree
     // snapshot replacement. Applying such a patch produces multiple onPatch
@@ -190,15 +191,13 @@ export const Tree = types.model("Tree", {
       }
 
       let numApplied = 0;
-      const inversePatches: IJsonPatch[] = [];
-      const disposer = onPatch(self, (_patch, reversePatch) => {
+      const disposer = onPatch(self, () => {
         numApplied++;
-        inversePatches.push(reversePatch);
       });
       try {
         applyPatch(self, patchesToApply);
       } catch (e) {
-        throw new PatchApplicationError(numApplied, inversePatches, e);
+        throw new PatchApplicationError(numApplied, e);
       } finally {
         disposer();
       }

--- a/src/models/history/tree.ts
+++ b/src/models/history/tree.ts
@@ -173,13 +173,19 @@ export const Tree = types.model("Tree", {
     // containing the count and inverse patches so callers can roll back the
     // partial application and identify which input patch caused the failure.
     //
-    // Patches without a path are treated as snapshots, which would produce
-    // multiple onPatch calls and break our counting. We reject them upfront
-    // since history patches should always have paths.
+    // MST treats a patch with an empty or missing path as a whole-tree
+    // snapshot replacement. Applying such a patch produces multiple onPatch
+    // calls (one per field in the resulting snapshot) which would break our
+    // 1:1 mapping between input patches and onPatch events. We reject both
+    // the undefined/missing case AND the empty-string case upfront because
+    // neither form should appear in recorded history patches, and either
+    // would silently corrupt the numApplied counter.
     applyPatchesFromManager(historyEntryId: string, exchangeId: string, patchesToApply: readonly IJsonPatch[]) {
       for (const patch of patchesToApply) {
         if (!patch.path) {
-          throw new Error("History patches must have a path. Pathless (snapshot) patches are not supported.");
+          throw new Error(
+            "History patches must have a non-empty path. Pathless or root-snapshot patches are not supported."
+          );
         }
       }
 

--- a/src/models/history/tree.ts
+++ b/src/models/history/tree.ts
@@ -160,9 +160,18 @@ export const Tree = types.model("Tree", {
     // Actually apply the patches.
     // It might be called multiple times after startApplyingPatchesFromManager.
     //
-    // Uses onPatch to count how many patches were successfully applied. If an
-    // error occurs, throws a PatchApplicationError containing the count and
-    // inverse patches so callers can roll back the partial application.
+    // Patches are applied as a single batch for performance. MST's applyPatch
+    // wraps the array in one action, which means middlewares (like the
+    // TreeMonitor) fire once for the whole batch instead of once per patch.
+    // With hundreds or thousands of patches during history playback, applying
+    // them one at a time would be significantly slower.
+    //
+    // However, batch applyPatch doesn't tell us which patch failed if an
+    // error occurs partway through. To work around this, we register an
+    // onPatch listener that counts successfully applied patches and collects
+    // their inverse patches. On failure, we throw a PatchApplicationError
+    // containing the count and inverse patches so callers can roll back the
+    // partial application and identify which input patch caused the failure.
     //
     // Patches without a path are treated as snapshots, which would produce
     // multiple onPatch calls and break our counting. We reject them upfront

--- a/src/models/history/tree.ts
+++ b/src/models/history/tree.ts
@@ -1,5 +1,5 @@
 import {
-  applyPatch, flow, getSnapshot, IJsonPatch, isAlive, resolvePath, resolveIdentifier, types
+  applyPatch, flow, getSnapshot, IJsonPatch, isAlive, onPatch, resolvePath, resolveIdentifier, types
 } from "mobx-state-tree";
 import { DEBUG_HISTORY } from "../../lib/debug";
 import { DocumentContentModelType } from "../document/document-content";
@@ -7,6 +7,25 @@ import { SharedModelMapSnapshotOutType } from "../document/shared-model-entry";
 import { SharedModelType } from "../shared/shared-model";
 import { ITileModel, TileModel } from "../tiles/tile-model";
 import { TreeManagerAPI } from "./tree-manager-api";
+
+/**
+ * Error thrown when applyPatch fails partway through a batch.
+ * Includes the number of patches that were successfully applied and their
+ * inverse patches (captured via onPatch), so callers can undo partial
+ * application and identify which input patch caused the failure.
+ */
+export class PatchApplicationError extends Error {
+  numApplied: number;
+  inversePatches: IJsonPatch[];
+
+  constructor(numApplied: number, inversePatches: IJsonPatch[], originalError: unknown) {
+    const message = originalError instanceof Error ? originalError.message : String(originalError);
+    super(`Patch application failed after ${numApplied} patches: ${message}`);
+    this.name = "PatchApplicationError";
+    this.numApplied = numApplied;
+    this.inversePatches = inversePatches;
+  }
+}
 
 export const Tree = types.model("Tree", {
 })
@@ -139,9 +158,36 @@ export const Tree = types.model("Tree", {
     },
 
     // Actually apply the patches.
-    // It might be called multiple times after startApplyingPatchesFromManager
+    // It might be called multiple times after startApplyingPatchesFromManager.
+    //
+    // Uses onPatch to count how many patches were successfully applied. If an
+    // error occurs, throws a PatchApplicationError containing the count and
+    // inverse patches so callers can roll back the partial application.
+    //
+    // Patches without a path are treated as snapshots, which would produce
+    // multiple onPatch calls and break our counting. We reject them upfront
+    // since history patches should always have paths.
     applyPatchesFromManager(historyEntryId: string, exchangeId: string, patchesToApply: readonly IJsonPatch[]) {
-      applyPatch(self, patchesToApply);
+      for (const patch of patchesToApply) {
+        if (!patch.path) {
+          throw new Error("History patches must have a path. Pathless (snapshot) patches are not supported.");
+        }
+      }
+
+      let numApplied = 0;
+      const inversePatches: IJsonPatch[] = [];
+      const disposer = onPatch(self, (_patch, reversePatch) => {
+        numApplied++;
+        inversePatches.push(reversePatch);
+      });
+      try {
+        applyPatch(self, patchesToApply);
+      } catch (e) {
+        throw new PatchApplicationError(numApplied, inversePatches, e);
+      } finally {
+        disposer();
+      }
+
       // We return a promise because the API is async
       // The action itself doesn't do anything asynchronous though
       // so it isn't necessary to use a flow

--- a/src/models/history/tree.ts
+++ b/src/models/history/tree.ts
@@ -184,8 +184,17 @@ export const Tree = types.model("Tree", {
     applyPatchesFromManager(historyEntryId: string, exchangeId: string, patchesToApply: readonly IJsonPatch[]) {
       for (const patch of patchesToApply) {
         if (!patch.path) {
-          throw new Error(
-            "History patches must have a non-empty path. Pathless or root-snapshot patches are not supported."
+          // Throw PatchApplicationError (with numApplied=0) so this
+          // case flows through the playback-failure handling path in
+          // TreeManager.goToHistoryEntry, rather than escaping as an
+          // unhandled error that bypasses rollback and failure
+          // recording.
+          throw new PatchApplicationError(
+            0,
+            new Error(
+              "History patches must have a non-empty path. " +
+              "Pathless or root-snapshot patches are not supported."
+            )
           );
         }
       }


### PR DESCRIPTION
## Summary
- Detect and handle patch application failures during history playback instead of silently corrupting state
- Show clickable failure markers on the slider with detail popups (entry index, direction, model, action, error)
- Fix slider entry ordering to use history index order (created timestamps can be out of order for sub-actions)
- Add `injectFailingHistoryEntry` action and history viewer button for testing
- **Partial rollback within a failing entry**: if some patches of a failing entry succeeded before the failure, they are rolled back so the tree state is consistent with the stop position
- **Multi-tree consistent rollback**: when scrubbing across multiple registered trees, a failure in any tree causes all trees to roll back to the same stop position (\`min(failedIndices)\` forward, \`max(failedIndices) + 1\` backward). Trees that successfully applied patches past the stop position have those entries rolled back, and every affected tree's failure is recorded
- Add multi-tree history test coverage in \`tree-manager-multi-tree.test.ts\` using a minimal \`TestTree\` that implements \`TreeAPI\` directly (no \`DocumentContentModel\` needed)
- autoplay should also stop at the failure point, however since autoplay goes forward and we always start the history view at the end, it isn't easy to verify this.

## Test plan
- [x] Make a new doc in full CLUE, Open history viewer (debug=historyView), Make basic change, click \"Inject Failing Entry\", make another basic change, open the document on the left with the history slider, then scrub the history slider backward
- [x] Verify the slider stops at the failure point and a red marker appears
- [x] Click the marker to see failure details including the error message
- [x] Run \`cypress/e2e/functional/document_tests/history_view_panel_spec.js\`

CLUE-494

🤖 Generated with [Claude Code](https://claude.com/claude-code)