### PR TITLE
CLUE-102: Vertically center history slider thumb on track

### DIFF
--- a/src/components/playback/playback-control.scss
+++ b/src/components/playback/playback-control.scss
@@ -326,7 +326,7 @@ $border-radius-base: 6px;
   .rc-slider {
     position: relative;
     width: 100%;
-    height: 14px;
+    height: 100%;
     padding: 12px 0;
     margin: 0 10px 0 10px;
     border-radius: $border-radius-base;
@@ -335,6 +335,9 @@ $border-radius-base: 6px;
 
     &-rail {
       position: absolute;
+      top: 0;
+      bottom: 0;
+      margin-block: auto;
       width: 100%;
       height: 2px;
       background-color: #949494;
@@ -342,17 +345,21 @@ $border-radius-base: 6px;
     }
 
     &-track {
-      position: relative;
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      margin-block: auto;
       width: 100%;
       height: 4px;
-      top: -1px;
       background-color: #545454;
       border-radius: $border-radius-base;
     }
 
     &-handle {
       position: absolute;
-      top: 2px;
+      top: 0;
+      bottom: 0;
+      margin-block: auto;
       width: 22px;
       height: 22px;
       border: solid 2px;

--- a/src/components/playback/playback-control.scss
+++ b/src/components/playback/playback-control.scss
@@ -352,7 +352,7 @@ $border-radius-base: 6px;
 
     &-handle {
       position: absolute;
-      top: 1.5px;
+      top: 2px;
       width: 22px;
       height: 22px;
       border: solid 2px;


### PR DESCRIPTION
## Summary
- Fix CSS alignment of the history playback slider thumb so it is vertically centered on the track

## Test plan
- [x] Open history playback (teacher role) and verify the slider thumb sits centered on the track rail

🤖 Generated with [Claude Code](https://claude.com/claude-code)