### PR TITLE
CLUE-496: provisional CategorySets to eliminate stray history entries

### DIFF
--- a/docs/specs/2026-04-11-category-set-provisional-design.md
+++ b/docs/specs/2026-04-11-category-set-provisional-design.md
@@ -76,15 +76,28 @@ The invariant: **a provisional CategorySet exists iff an attribute is currently 
 
 When `ensurePersistentCategorySet` promotes a provisional, it removes the provisional from `provisionalCategories` and calls `destroy(provisional)`. MST marks the node as dead — any subsequent read or write throws the "object no longer part of a state tree" error. This makes the "don't cache a CategorySet across a mutation" invariant runtime-enforced rather than documented.
 
-For provisional cleanup on attribute destruction, CLUE uses `addDisposer(attribute, ...)` registered at creation time rather than the `onAttributeInvalidated` callback. `addDisposer` fires on all destruction paths (removeAttribute, moveAttribute, DataSet destruction, applySnapshot/applyPatch during history playback) and fires synchronously inside the destruction call stack, ensuring cleanup runs inside the outer action — one history entry, not two.
-
 (Persistent CategorySets don't need explicit `destroy` — `types.map` destroys removed children automatically.)
 
-#### Deviation 4: volatile pointer instead of MST environment
+#### Deviation 4: unified per-attribute `addDisposer` for cleanup
+
+CODAP cleans up CategorySets via the `onAttributeInvalidated` callback on `types.reference(Attribute)`. A volatile `handleAttributeInvalidated` holds a handler, and `getCategorySet` wires that handler each time it creates a provisional. The handler then removes the entry from whichever map it lives in. This has two problems:
+
+1. The handler is only wired at provisional-creation time. A persistent CategorySet that arrives by snapshot rehydration or `applyPatch` never passes through `getCategorySet`, so its volatile handler stays undefined and removing its attribute leaves an orphan entry behind.
+2. The call path is twisted: `types.reference.onInvalidated` → volatile `handleAttributeInvalidated` → `onAttributeInvalidated` action → parent handler → map mutation. It takes four hops to route a destruction event into a cleanup.
+
+CLUE replaces this with a **single `addDisposer(attribute, ...)` per attribute**, installed by `SharedCaseMetadata` via a reaction over `self.data.attributes`. The disposer body (`_cleanupAttribute(attrId)`) removes any CategorySet keyed by that attribute — provisional OR persistent — when the attribute is destroyed. Keying cleanup off the Attribute lifecycle rather than the CategorySet lifecycle means the mechanism is oblivious to *how* the CategorySet came into existence: fresh inserts, snapshot rehydration, and patch-added entries are all handled uniformly. MST fires `addDisposer` callbacks synchronously inside the destruction call stack, so cleanup stays inside the enclosing action — one history entry, not two.
+
+A MobX reaction is NOT an option for this cleanup: reactions fire after the enclosing action completes, which would produce a second top-level action and a second history entry — the exact problem CLUE-496 exists to eliminate. `addDisposer` is the only mechanism that fires synchronously during destruction.
+
+Because the disposer is installed on the Attribute but closes over `SharedCaseMetadata`, it can outlive `self` if `SharedCaseMetadata` is destroyed before the DataSet. The callback guards with `isAlive(self)` to no-op in that case. (MST's public API provides no way to unregister a disposer once added, so proactive cleanup isn't possible.)
+
+With this change, CLUE's `CategorySet` no longer needs the `onInvalidated` callback on its `types.reference`, the volatile `handleAttributeInvalidated`, or the `onAttributeInvalidated` action — all three are removed.
+
+#### Deviation 5: volatile pointer instead of MST environment
 
 CODAP uses a custom MST environment so that `types.reference(Attribute)` on a detached provisional can resolve via the dataset. CLUE uses a simpler approach: a volatile `_provisionalAttribute` pointer on `CategorySet` that holds a direct reference to the `IAttribute` instance. An `attr` view returns `self._provisionalAttribute ?? self.attribute`, and an `isProvisional` view checks whether the pointer is set. This avoids the `getEnv`/`hasEnv` machinery and makes provisional detection a simple property check.
 
-#### Deviation 5: no `afterCreate`/`afterAttach` split for subscriptions
+#### Deviation 6: no `afterCreate`/`afterAttach` split for subscriptions
 
 CODAP splits the attribute-action subscription across `afterCreate` (for provisionals) and `afterAttach` (for persistents). CLUE only installs the subscription in `afterAttach`, meaning only persistent instances get it. Provisional instances don't need it because they are never mutated and their derived data is rebuilt on demand.
 
@@ -100,9 +113,14 @@ CODAP splits the attribute-action subscription across `afterCreate` (for provisi
 #### `SharedCaseMetadata`
 
 - `provisionalCategories`: volatile `observable.map<string, ICategorySet>`.
-- `getCategorySet(attrId)`: pure view, returns persistent entry if it exists, otherwise provisional, otherwise `undefined`. The free-function wrapper `getCategorySet(metadata, attrId)` is kept for backward compatibility.
-- `ensureProvisionalCategorySet(attrId)`: idempotent action. Returns any existing instance (persistent or provisional). If none exists, creates a provisional via `createProvisionalCategorySet`, stores it in `provisionalCategories`, and registers `addDisposer(attribute, ...)` for cleanup. **Called only from the ensure reaction on `DataConfigurationModel`.**
-- `ensurePersistentCategorySet(attrId)`: idempotent action. Returns existing persistent if present. Otherwise creates a fresh persistent entry (no snapshot copy needed since provisionals can never be mutated), destroys any existing provisional, and registers the `onAttributeInvalidated` handler for persistent cleanup.
+- `_attrsWithCleanupDisposer`: volatile `Set<string>` tracking which attribute ids already have a cleanup disposer, so the reaction below doesn't re-register on repeat firings.
+- `getCategorySet(attrId)`: pure view, returns persistent entry if it exists, otherwise provisional, otherwise `undefined`.
+- `ensureProvisionalCategorySet(attrId)`: idempotent action. Returns any existing instance (persistent or provisional). If none exists, creates a provisional via `createProvisionalCategorySet` and stores it in `provisionalCategories`. **Called only from the ensure reaction on `DataConfigurationModel`.** Cleanup on attribute destruction is handled uniformly by the per-attribute disposer — this action does not register its own `addDisposer`.
+- `ensurePersistentCategorySet(attrId)`: idempotent action. Returns existing persistent if present. Otherwise creates a fresh persistent entry (no snapshot copy needed since provisionals can never be mutated) and destroys any existing provisional. Cleanup on attribute destruction is again handled by the per-attribute disposer.
+- `removeCategorySet(attrId)`: action that deletes from the `categories` MST map. Called from `_cleanupAttribute` so MST's action-protection model permits the map mutation even when invoked from inside a DataSet action (e.g., `removeAttribute`).
+- `_cleanupAttribute(attrId)`: action invoked from the per-attribute disposer. Removes any persistent entry (via `removeCategorySet`), destroys any provisional, and clears the entry from `_attrsWithCleanupDisposer`. Additional attribute-keyed state (e.g., `columnWidths`, `hidden`) can be cleaned up here too.
+- `_ensureAttributeCleanupDisposer(attribute)`: action that calls `addDisposer(attribute, ...)` at most once per attrId, tracked via `_attrsWithCleanupDisposer`. The disposer callback guards with `isAlive(self)` and delegates to `_cleanupAttribute`.
+- `afterAttach`: installs an `mstReaction` over `self.data?.attributes.map(a => a.id)` that calls `_ensureAttributeCleanupDisposer` for each attribute. `fireImmediately: true` + `comparer.structural` means existing attributes get their disposer at rehydration time, and new attributes get one as they're added.
 - The old `addCategorySet` action is removed.
 
 #### `CategorySet`
@@ -111,6 +129,7 @@ CODAP splits the attribute-action subscription across `afterCreate` (for provisi
 - `attr` view that reads the volatile pointer for provisionals and the MST reference for persistents — all internal attribute reads go through this.
 - Mutation guard on `move`, `setColorForCategory`, `storeCurrentColorForCategory`, and `storeAllCurrentColors`: throws if `isProvisional` is true.
 - Attribute-action subscription installed only in `afterAttach` (persistent instances only).
+- **No cleanup plumbing of its own.** The `types.reference(Attribute)` is a plain reference (no `onInvalidated` callback). There is no volatile `handleAttributeInvalidated` and no `onAttributeInvalidated` action. Cleanup is entirely owned by `SharedCaseMetadata`'s per-attribute disposer, installed via the reaction above.
 
 #### Ensure reaction on `DataConfigurationModel`
 
@@ -162,8 +181,8 @@ This fix applies to every user action that previously caused on-demand category 
 
 | File | Change |
 |---|---|
-| `src/models/data/category-set.ts` | Add `_provisionalAttribute` volatile pointer, `setProvisionalAttribute` action, `attr` and `isProvisional` views. Add `createProvisionalCategorySet` constructor. Add `isProvisional` guard on all mutation actions. |
-| `src/models/shared/shared-case-metadata.ts` | Add `provisionalCategories` volatile map. Make `getCategorySet` a pure view. Add `ensureProvisionalCategorySet` and `ensurePersistentCategorySet` actions. Remove `addCategorySet`. |
+| `src/models/data/category-set.ts` | Add `_provisionalAttribute` volatile pointer, `setProvisionalAttribute` action, `attr` and `isProvisional` views. Add `createProvisionalCategorySet` constructor. Add `isProvisional` guard on all mutation actions. Remove the `onInvalidated` callback on `types.reference(Attribute)`, the volatile `handleAttributeInvalidated`, and the `onAttributeInvalidated` action — replaced by the unified per-attribute disposer on `SharedCaseMetadata`. |
+| `src/models/shared/shared-case-metadata.ts` | Add `provisionalCategories` volatile map. Make `getCategorySet` a pure view. Add `ensureProvisionalCategorySet` and `ensurePersistentCategorySet` actions. Remove `addCategorySet`. Add `_cleanupAttribute` / `_ensureAttributeCleanupDisposer` / `removeCategorySet` actions and an `afterAttach` reaction over `data.attributes` that installs one cleanup disposer per attribute. |
 | `src/plugins/graph/models/data-configuration-model.ts` | Add `ensurePersistentCategorySetForRole` action. Update `storeAllCurrentColorsForAttrRole` and `swapCategoriesForAttrRole` to use it. Add the ensure reaction in `afterAttach`. |
 | `src/plugins/graph/imports/components/axis/hooks/use-sub-axis.ts` | Route drag-reorder through `ensurePersistentCategorySetForRole`. |
 | `src/models/shared/shared-case-metadata.test.ts` | Tests for pure `getCategorySet`, provisional/persistent lifecycle, stale-reference safety, attribute-removal cleanup. |
@@ -178,7 +197,7 @@ This fix applies to every user action that previously caused on-demand category 
 
 ## Testing
 
-- Unit tests for `SharedCaseMetadata`: `getCategorySet` purity, `ensureProvisionalCategorySet` idempotency and snapshot exclusion, `ensurePersistentCategorySet` promotion and provisional destruction, stale-reference errors after promotion and after attribute removal.
+- Unit tests for `SharedCaseMetadata`: `getCategorySet` purity, `ensureProvisionalCategorySet` idempotency and snapshot exclusion, `ensurePersistentCategorySet` promotion and provisional destruction, stale-reference errors after promotion and after attribute removal. Rehydration test: a persistent entry restored from a snapshot is still cleaned up when its attribute is later removed. Patch test: a persistent entry inserted via `applyPatch` is cleaned up when its attribute is later removed.
 - Unit tests for `CategorySet` guards: mutation actions throw on provisional instances.
 - Unit test for the ensure reaction on `DataConfigurationModel`: categorical attributes get provisionals, numeric ones don't, type flips behave correctly, re-firing after promotion is idempotent.
 - Regression test: `createEditableLayer` produces exactly one history entry.

--- a/docs/specs/2026-04-11-category-set-provisional-design.md
+++ b/docs/specs/2026-04-11-category-set-provisional-design.md
@@ -1,0 +1,185 @@
+# Spec: Provisional CategorySets for SharedCaseMetadata
+
+**CLUE Repository**: https://github.com/concord-consortium/collaborative-learning
+
+## Status
+
+Implemented (CLUE-496).
+
+## Problem
+
+`SharedCaseMetadata.addCategorySet` was an MST action called from MST **view** functions (via the `getCategorySet` helper in `shared-case-metadata.ts`). Because the view-level callers (`categoryArrayForAttrRole`, `categorySetForAttrRole`, `getLegendColorForCategory`, `categorySetForPlace` on `DataConfigurationModel`) are evaluated inside MobX reactions, `addCategorySet` fired whenever one of those reactions ran — producing its own history entry even when the view read was triggered by an unrelated user action.
+
+### Concrete example
+
+`graph-model.createEditableLayer` is a synchronous MST action. A single user click of "Add manual points" produced **three** history entries:
+
+1. `addCategorySet` on `SharedCaseMetadata` (for the x attribute)
+2. `addCategorySet` on `SharedCaseMetadata` (for the y attribute)
+3. `createEditableLayer` on the graph model
+
+The two `addCategorySet` entries appeared because MobX reactions fire at the end of the outermost MST action. The reaction chain: `setAttributeForRole` → `handleAttributeAssignment` → `setAxis` → `use-axis.ts` `mstAutorun` → `computeDesiredExtent` → `categoryArrayForAttrRole` → `getCategorySet` → `addCategorySet`. This happened once per axis regardless of whether it was categorical.
+
+### Impact
+
+- User actions fragment into multiple history entries.
+- Undo/redo grouping is wrong: undoing "create editable layer" doesn't undo the category-set creations that were logically part of it.
+- History replay of older documents may encounter these stray entries in ways that aren't robust.
+
+The underlying design tension is that `CategorySet` does two different jobs inside a single MST model.
+
+## Design
+
+### Observation: `CategorySet` has two jobs
+
+**Job 1 — Derived category data (ephemeral):** The `values` list, `_indexMap`, `_isValid` cache, computed from `self.attribute.strValues`. The `afterAttach` subscription to attribute actions that invalidates the cache. Nothing here needs to persist.
+
+**Job 2 — User customizations (persistent):** `colors` map (user-assigned colors per category value) and `moves` array (user-reordered category positions). These only have meaning after the user has actually recolored or reordered something.
+
+The reason `getCategorySet` created on demand was that Job 1 needs an MST instance (it holds `volatile` state, subscribes to attribute actions, and holds a `types.reference(Attribute)`). Lazily creating them avoided instantiating Job-1-only sets for every attribute in every dataset — but the lazy creation from a view was the source of the problem.
+
+### CODAP's approach
+
+CODAP v3 solved the same problem by splitting CategorySet instances into two tiers using the same model type:
+
+- **Provisional** CategorySets live in a `volatile observable.map` on the metadata model. Creating one does not produce MST actions or history entries, because `volatile` state is not part of the MST snapshot.
+- **Persistent** CategorySets live in the normal `types.map` slot on the metadata model. They are only created when the user actually does something that needs to be saved.
+
+CODAP uses a custom MST environment (`{ provisionalDataSet: data }`) so that the `types.reference(Attribute)` on a detached provisional can resolve via the dataset. CODAP promotes a provisional to a persistent instance via a `when(...)` reaction that watches `moves.length > 0 || colors.size > 0` and, on the first change, copies the provisional's state into the persistent slot.
+
+### Deviations from CODAP
+
+CLUE adopts CODAP's provisional/persistent split but deviates in several ways, each motivated by a specific problem with CODAP's approach.
+
+#### Deviation 1: synchronous promotion instead of `when`
+
+CODAP's `when(...)`-based promotion has two drawbacks:
+
+1. The promotion fires as a **separate top-level MST action**, not grouped with the user's action in history.
+2. The user's mutation (`move`, `setColorForCategory`, …) happens on the **detached provisional instance**. Document-level `onAnyAction` middleware never sees those mutations — it only sees the post-facto promotion. History records "a category set appeared with these moves", not "the user moved category X".
+
+CLUE promotes **synchronously, before the mutation is applied**, via `ensurePersistentCategorySet(attrId)` on `SharedCaseMetadata`. Call sites use a two-step pattern: ensure persistent, then mutate the returned instance. All mutations flow through the attached persistent instance, so they appear in history as the actual user action.
+
+#### Deviation 2: pure `getCategorySet` view, eager ensure reaction
+
+CODAP's `getCategorySet` is a view that mutates `provisionalCategories` when a provisional doesn't exist yet. Mutating an `observable.map` from inside a MobX computed has fragilities:
+
+- MobX strict-mode (`enforceActions: "always"`) would flag it.
+- The view reads and writes the same key, creating a self-invalidation edge in the dependency graph.
+- Composing the view inside other reactions produces ordering-sensitive re-runs.
+
+CLUE makes `getCategorySet` a **pure view** with no side effects. Provisionals are created eagerly via an `mstReaction` installed in `DataConfigurationModel.afterAttach`. The reaction watches the set of attribute IDs currently assigned to a graph role as categorical, and calls `ensureProvisionalCategorySet(attrId)` for each one. This is a real MST action on `SharedCaseMetadata` — no strict-mode issue, no self-invalidation.
+
+The invariant: **a provisional CategorySet exists iff an attribute is currently assigned to a graph role as categorical.** Numeric attributes never get a provisional. The old behavior where `computeDesiredExtent` triggered on-demand creation of category sets for every axis regardless of type becomes a non-issue: `getCategorySet` returns `undefined` for numeric attributes and callers fall back to `['__main__']`.
+
+#### Deviation 3: disposal-based invariant enforcement
+
+When `ensurePersistentCategorySet` promotes a provisional, it removes the provisional from `provisionalCategories` and calls `destroy(provisional)`. MST marks the node as dead — any subsequent read or write throws the "object no longer part of a state tree" error. This makes the "don't cache a CategorySet across a mutation" invariant runtime-enforced rather than documented.
+
+For provisional cleanup on attribute destruction, CLUE uses `addDisposer(attribute, ...)` registered at creation time rather than the `onAttributeInvalidated` callback. `addDisposer` fires on all destruction paths (removeAttribute, moveAttribute, DataSet destruction, applySnapshot/applyPatch during history playback) and fires synchronously inside the destruction call stack, ensuring cleanup runs inside the outer action — one history entry, not two.
+
+(Persistent CategorySets don't need explicit `destroy` — `types.map` destroys removed children automatically.)
+
+#### Deviation 4: volatile pointer instead of MST environment
+
+CODAP uses a custom MST environment so that `types.reference(Attribute)` on a detached provisional can resolve via the dataset. CLUE uses a simpler approach: a volatile `_provisionalAttribute` pointer on `CategorySet` that holds a direct reference to the `IAttribute` instance. An `attr` view returns `self._provisionalAttribute ?? self.attribute`, and an `isProvisional` view checks whether the pointer is set. This avoids the `getEnv`/`hasEnv` machinery and makes provisional detection a simple property check.
+
+#### Deviation 5: no `afterCreate`/`afterAttach` split for subscriptions
+
+CODAP splits the attribute-action subscription across `afterCreate` (for provisionals) and `afterAttach` (for persistents). CLUE only installs the subscription in `afterAttach`, meaning only persistent instances get it. Provisional instances don't need it because they are never mutated and their derived data is rebuilt on demand.
+
+#### What stays identical to CODAP
+
+- The provisional/persistent split as two tiers using the same model type.
+- Provisional instances live in a `volatile observable.map` on metadata.
+- `createProvisionalCategorySet(data, attrId)` as the constructor helper.
+- The overall shape of persistent storage (`categories: types.map(CategorySet)` slot on `SharedCaseMetadata`).
+
+### Key model behaviors
+
+#### `SharedCaseMetadata`
+
+- `provisionalCategories`: volatile `observable.map<string, ICategorySet>`.
+- `getCategorySet(attrId)`: pure view, returns persistent entry if it exists, otherwise provisional, otherwise `undefined`. The free-function wrapper `getCategorySet(metadata, attrId)` is kept for backward compatibility.
+- `ensureProvisionalCategorySet(attrId)`: idempotent action. Returns any existing instance (persistent or provisional). If none exists, creates a provisional via `createProvisionalCategorySet`, stores it in `provisionalCategories`, and registers `addDisposer(attribute, ...)` for cleanup. **Called only from the ensure reaction on `DataConfigurationModel`.**
+- `ensurePersistentCategorySet(attrId)`: idempotent action. Returns existing persistent if present. Otherwise creates a fresh persistent entry (no snapshot copy needed since provisionals can never be mutated), destroys any existing provisional, and registers the `onAttributeInvalidated` handler for persistent cleanup.
+- The old `addCategorySet` action is removed.
+
+#### `CategorySet`
+
+- Volatile `_provisionalAttribute` pointer and `isProvisional` view for distinguishing provisional from persistent instances.
+- `attr` view that reads the volatile pointer for provisionals and the MST reference for persistents — all internal attribute reads go through this.
+- Mutation guard on `move`, `setColorForCategory`, `storeCurrentColorForCategory`, and `storeAllCurrentColors`: throws if `isProvisional` is true.
+- Attribute-action subscription installed only in `afterAttach` (persistent instances only).
+
+#### Ensure reaction on `DataConfigurationModel`
+
+An `mstReaction` in `afterAttach` maintains the invariant that provisionals exist for all categorical graph-role attributes:
+
+- `fireImmediately: true` ensures the initial state is covered (snapshot load, history replay, initial attachment).
+- `comparer.structural` prevents spurious re-runs.
+- `attributeType(role)` establishes dependencies on both the override type and the inferred type.
+- Idempotent: fires safely with the same inputs without creating duplicates.
+- Categorical → numeric flips leave the provisional in place (volatile and cheap). A flip back re-uses it.
+- Install order: `afterAttach` runs before React components mount, so provisionals are in place before consumer reactions read them.
+
+#### Why the ensure approach is safe for promotion
+
+After `ensurePersistentCategorySet` promotes an attribute:
+
+1. The persistent entry exists in `self.categories`.
+2. The provisional is removed and destroyed.
+3. If the ensure reaction re-fires, `ensureProvisionalCategorySet` finds the persistent entry first and returns it unchanged — no duplicate provisional is created.
+4. `getCategorySet` checks `self.categories` first, so the pure view always returns the persistent entry after promotion.
+
+#### Reads after promotion
+
+`getCategorySet` reads `self.categories.get(attrId)` first, then falls back to `self.provisionalCategories.get(attrId)`. MobX tracks dependencies on both. When `ensurePersistentCategorySet` runs, both map mutations happen inside the same action, so dependents see both changes atomically. Stale references explode via MST's dead-node check.
+
+### Call site changes
+
+All three production mutation call sites use `ensurePersistentCategorySetForRole(role)` on `DataConfigurationModel`, which wraps the `metadata.ensurePersistentCategorySet(attrId)` lookup:
+
+1. **use-sub-axis.ts** (category drag-reorder): calls `dI.dataConfiguration.ensurePersistentCategorySetForRole(dI.attrRole)` then `persistent?.move(...)`.
+2. **`storeAllCurrentColorsForAttrRole`**: calls `ensurePersistentCategorySetForRole(role)` then `persistent?.storeAllCurrentColors()`.
+3. **`swapCategoriesForAttrRole`**: uses `categorySetForAttrRole` (the read-side view) for reading `categoryArray`, then `ensurePersistentCategorySetForRole(role)` for the mutation.
+
+This keeps the two-step pattern in `DataConfigurationModel` rather than in UI code.
+
+## Interaction with history replay
+
+- **Recording.** Provisional CategorySets live in volatile state, never appear in snapshots, and never generate history entries. The ensure reaction's `ensureProvisionalCategorySet` is an MST action but only mutates volatile state, so it produces no snapshot patches. Persistent CategorySets are created by normal MST actions and appear in history normally.
+- **Replay.** Volatile state is rebuilt from scratch. The ensure reaction fires with `fireImmediately: true` and re-populates provisionals. Persistent categories are restored from snapshot. Recorded `ensurePersistentCategorySet` actions replay normally.
+- **Historic documents.** Existing documents may contain persistent `CategorySet` entries for attributes the user never customized. These are valid: `ensurePersistentCategorySet` returns them unchanged, and the ensure reaction's idempotency check short-circuits. The extra entries are harmless.
+
+## Behavior change: `createEditableLayer` no longer produces stray history entries
+
+After the change, `createEditableLayer` produces a single history entry. The x and y attributes are numeric, so the ensure reaction creates no provisionals. The view-level reads are pure: `getCategorySet` returns `undefined`, `categoryArrayForAttrRole` falls back to `['__main__']`, no MST action fires.
+
+This fix applies to every user action that previously caused on-demand category set creation during a reaction. Only user actions that actually mutate a persistent CategorySet produce history entries, and each produces exactly one logical history group.
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `src/models/data/category-set.ts` | Add `_provisionalAttribute` volatile pointer, `setProvisionalAttribute` action, `attr` and `isProvisional` views. Add `createProvisionalCategorySet` constructor. Add `isProvisional` guard on all mutation actions. |
+| `src/models/shared/shared-case-metadata.ts` | Add `provisionalCategories` volatile map. Make `getCategorySet` a pure view. Add `ensureProvisionalCategorySet` and `ensurePersistentCategorySet` actions. Remove `addCategorySet`. |
+| `src/plugins/graph/models/data-configuration-model.ts` | Add `ensurePersistentCategorySetForRole` action. Update `storeAllCurrentColorsForAttrRole` and `swapCategoriesForAttrRole` to use it. Add the ensure reaction in `afterAttach`. |
+| `src/plugins/graph/imports/components/axis/hooks/use-sub-axis.ts` | Route drag-reorder through `ensurePersistentCategorySetForRole`. |
+| `src/models/shared/shared-case-metadata.test.ts` | Tests for pure `getCategorySet`, provisional/persistent lifecycle, stale-reference safety, attribute-removal cleanup. |
+| `src/models/data/category-set.test.ts` | Tests for provisional creation, `isProvisional` view, mutation guard. |
+
+## Out of scope
+
+- Collapsing the derived-category-data logic into a non-MST structure. The derived data still lives inside `CategorySet` as in CODAP.
+- Changing the `categories: types.map(CategorySet)` slot shape on `SharedCaseMetadata`.
+- Upstreaming the synchronous-promotion deviation back to CODAP.
+- Optimizing `computeDesiredExtent` to skip `categoryArrayForAttrRole` for numeric axes. Under this design the read is harmless (pure view, returns `undefined`, caller falls back to `['__main__']`).
+
+## Testing
+
+- Unit tests for `SharedCaseMetadata`: `getCategorySet` purity, `ensureProvisionalCategorySet` idempotency and snapshot exclusion, `ensurePersistentCategorySet` promotion and provisional destruction, stale-reference errors after promotion and after attribute removal.
+- Unit tests for `CategorySet` guards: mutation actions throw on provisional instances.
+- Unit test for the ensure reaction on `DataConfigurationModel`: categorical attributes get provisionals, numeric ones don't, type flips behave correctly, re-firing after promotion is idempotent.
+- Regression test: `createEditableLayer` produces exactly one history entry.
+- Manual verification: category drag-reorder produces a clean, single, undoable history entry. History playback of documents with graph interactions works end to end.

--- a/src/models/data/category-set.test.ts
+++ b/src/models/data/category-set.test.ts
@@ -1,7 +1,8 @@
 import { types } from "mobx-state-tree";
 import { kellyColors } from "../../utilities/color-utils";
 import { Attribute, IAttribute } from "./attribute";
-import { CategorySet } from "./category-set";
+import { CategorySet, createProvisionalCategorySet } from "./category-set";
+import { DataSet } from "./data-set";
 
 describe("CategorySet", () => {
   const Tree = types.model("Tree", {
@@ -118,5 +119,20 @@ describe("CategorySet", () => {
     cTree.setAttribute(Attribute.create({ name: "d" }));
     expect(handleAttributeInvalidated).toHaveBeenCalledTimes(1);
     expect(handleAttributeInvalidated).toHaveBeenCalledWith(cId);
+  });
+
+  it("createProvisionalCategorySet builds a detached instance backed by a volatile attribute pointer", () => {
+    const data = DataSet.create();
+    data.addAttributeWithID({ id: "aId", name: "a" });
+    data.addCasesWithIDs([
+      { __id__: "c1", a: "x" },
+      { __id__: "c2", a: "y" },
+      { __id__: "c3", a: "x" }
+    ]);
+
+    const cs = createProvisionalCategorySet(data, "aId");
+    expect(cs.isProvisional).toBe(true);
+    expect(cs.attr.id).toBe("aId");
+    expect(cs.values).toEqual(["x", "y"]);
   });
 });

--- a/src/models/data/category-set.test.ts
+++ b/src/models/data/category-set.test.ts
@@ -135,4 +135,23 @@ describe("CategorySet", () => {
     expect(cs.attr.id).toBe("aId");
     expect(cs.values).toEqual(["x", "y"]);
   });
+
+  it("throws when mutation actions are called on a provisional instance", () => {
+    const data = DataSet.create();
+    data.addAttributeWithID({ id: "aId", name: "a" });
+    data.addCasesWithIDs([
+      { __id__: "c1", a: "x" },
+      { __id__: "c2", a: "y" }
+    ]);
+    const cs = createProvisionalCategorySet(data, "aId");
+
+    // Reads work fine.
+    expect(cs.values).toEqual(["x", "y"]);
+
+    // Mutations throw.
+    expect(() => cs.move("y", "x")).toThrow(/provisional/);
+    expect(() => cs.setColorForCategory("x", "#ff0000")).toThrow(/provisional/);
+    expect(() => cs.storeCurrentColorForCategory("x")).toThrow(/provisional/);
+    expect(() => cs.storeAllCurrentColors()).toThrow(/provisional/);
+  });
 });

--- a/src/models/data/category-set.test.ts
+++ b/src/models/data/category-set.test.ts
@@ -102,25 +102,6 @@ describe("CategorySet", () => {
     expect(categories.lastMove?.fromIndex).toBe(originalFromIndex);
   });
 
-  it("supports callback on invalidation of attribute", () => {
-    const handleAttributeInvalidated = jest.fn();
-
-    // can destroy attribute without having set an invalidation handler
-    const a = Attribute.create({ name: "a" });
-    const aTree = Tree.create({ attribute: a, categories: { attribute: a.id } });
-    aTree.setAttribute(Attribute.create({ name: "b" }));
-    expect(handleAttributeInvalidated).not.toHaveBeenCalled();
-
-    // handler is called on attribute destruction if one has been specified
-    const c = Attribute.create({ name: "c" });
-    const cId = c.id;
-    const cTree = Tree.create({ attribute: c, categories: { attribute: cId } });
-    cTree.categories.onAttributeInvalidated((attrId: string) => handleAttributeInvalidated(attrId));
-    cTree.setAttribute(Attribute.create({ name: "d" }));
-    expect(handleAttributeInvalidated).toHaveBeenCalledTimes(1);
-    expect(handleAttributeInvalidated).toHaveBeenCalledWith(cId);
-  });
-
   it("createProvisionalCategorySet builds a detached instance backed by a volatile attribute pointer", () => {
     const data = DataSet.create();
     data.addAttributeWithID({ id: "aId", name: "a" });

--- a/src/models/data/category-set.ts
+++ b/src/models/data/category-set.ts
@@ -2,7 +2,8 @@ import { observable, runInAction } from "mobx";
 import { addDisposer, Instance, isValidReference, types } from "mobx-state-tree";
 import { kellyColors } from "../../utilities/color-utils";
 import { onAnyAction } from "../../utilities/mst-utils";
-import { Attribute } from "./attribute";
+import { Attribute, IAttribute } from "./attribute";
+import { IDataSet } from "./data-set";
 
 interface ICategoryMove {
   value: string     // category value
@@ -25,11 +26,35 @@ export const CategorySet = types.model("CategorySet", {
   moves: types.array(types.frozen<ICategoryMove>())
 })
 .volatile(self => ({
-  handleAttributeInvalidated: undefined as ((attrId: string) => void) | undefined
+  handleAttributeInvalidated: undefined as ((attrId: string) => void) | undefined,
+  // Set on provisional instances only. When set, `self.attr` reads this pointer
+  // instead of the MST `attribute` reference (which does not resolve on a
+  // detached instance). See createProvisionalCategorySet below and the
+  // persistent/provisional design discussion in
+  // docs/superpowers/specs/2026-04-11-category-set-provisional-design.md.
+  _provisionalAttribute: undefined as IAttribute | undefined
 }))
 .actions(self => ({
   onAttributeInvalidated(handler: (attrId: string) => void) {
     self.handleAttributeInvalidated = handler;
+  },
+  setProvisionalAttribute(attribute: IAttribute) {
+    self._provisionalAttribute = attribute;
+  }
+}))
+.views(self => ({
+  /**
+   * Returns the attribute this CategorySet describes. For persistent
+   * instances this reads the MST reference. For provisional instances
+   * (created via createProvisionalCategorySet) this reads a volatile
+   * pointer because the instance is not attached to a state tree and
+   * the MST reference cannot be resolved.
+   */
+  get attr(): IAttribute {
+    return self._provisionalAttribute ?? self.attribute;
+  },
+  get isProvisional(): boolean {
+    return self._provisionalAttribute != null;
   }
 }))
 .extend(self => {
@@ -66,7 +91,7 @@ export const CategorySet = types.model("CategorySet", {
 
       // build default category set order (order of occurrence)
       // could default to alphameric sort order if desired instead
-      self.attribute.strValues.forEach(value => {
+      self.attr.strValues.forEach(value => {
         if (value !== '' && _indexMap.get(value) == null) {
           _indexMap.set(value, _values.length);
           _values.push(value);
@@ -211,4 +236,24 @@ export const CategorySet = types.model("CategorySet", {
     });
   }
 }));
+/**
+ * Create a detached (not attached to any state tree) CategorySet that reads
+ * its attribute via a volatile pointer. The caller is responsible for wiring
+ * cleanup via `addDisposer(attribute, ...)` — see
+ * SharedCaseMetadata.ensureProvisionalCategorySet for the canonical wiring.
+ *
+ * The MST `attribute` reference is still set for snapshot/serialization shape
+ * consistency, but on a detached instance it will not resolve. All reads must
+ * go through `self.attr`, never `self.attribute` directly.
+ */
+export function createProvisionalCategorySet(data: IDataSet, attrId: string): ICategorySet {
+  const attribute = data.attrFromID(attrId);
+  if (!attribute) {
+    throw new Error(`createProvisionalCategorySet: attribute '${attrId}' not found in dataset`);
+  }
+  const cs = CategorySet.create({ attribute: attrId });
+  cs.setProvisionalAttribute(attribute);
+  return cs;
+}
+
 export interface ICategorySet extends Instance<typeof CategorySet> {}

--- a/src/models/data/category-set.ts
+++ b/src/models/data/category-set.ts
@@ -15,18 +15,13 @@ interface ICategoryMove {
 }
 
 export const CategorySet = types.model("CategorySet", {
-  attribute: types.reference(Attribute, {
-    onInvalidated: ({ parent: self, invalidId }) => {
-      self.handleAttributeInvalidated?.(invalidId);
-    }
-  }),
+  attribute: types.reference(Attribute),
   // user color assignments
   colors: types.map(types.string),
   // user category re-orderings
   moves: types.array(types.frozen<ICategoryMove>())
 })
 .volatile(self => ({
-  handleAttributeInvalidated: undefined as ((attrId: string) => void) | undefined,
   // Set on provisional instances only. When set, `self.attr` reads this pointer
   // instead of the MST `attribute` reference (which does not resolve on a
   // detached instance). See createProvisionalCategorySet below and the
@@ -35,9 +30,6 @@ export const CategorySet = types.model("CategorySet", {
   _provisionalAttribute: undefined as IAttribute | undefined
 }))
 .actions(self => ({
-  onAttributeInvalidated(handler: (attrId: string) => void) {
-    self.handleAttributeInvalidated = handler;
-  },
   setProvisionalAttribute(attribute: IAttribute) {
     self._provisionalAttribute = attribute;
   }

--- a/src/models/data/category-set.ts
+++ b/src/models/data/category-set.ts
@@ -194,6 +194,10 @@ export const CategorySet = types.model("CategorySet", {
     }
   },
   move(value: string, beforeValue?: string) {
+    if (self.isProvisional) {
+      throw new Error("CategorySet.move called on a provisional instance. " +
+        "Call metadata.ensurePersistentCategorySet(attrId) first.");
+    }
     const fromIndex = self.index(value);
     if (fromIndex == null) return;
     const toIndex = (beforeValue != null) ? self.index(beforeValue) ?? self.values.length - 1 : self.values.length - 1;
@@ -218,17 +222,29 @@ export const CategorySet = types.model("CategorySet", {
     self.invalidate();
   },
   setColorForCategory(value: string, color: string) {
+    if (self.isProvisional) {
+      throw new Error("CategorySet.setColorForCategory called on a provisional instance. " +
+        "Call metadata.ensurePersistentCategorySet(attrId) first.");
+    }
     if (self.index(value)) {
       self.colors.set(value, color);
     }
   },
   storeCurrentColorForCategory(value: string) {
+    if (self.isProvisional) {
+      throw new Error("CategorySet.storeCurrentColorForCategory called on a provisional instance. " +
+        "Call metadata.ensurePersistentCategorySet(attrId) first.");
+    }
     const color = self.colorForCategory(value);
     if (color) {
       self.colors.set(value, color);
     }
   },
   storeAllCurrentColors() {
+    if (self.isProvisional) {
+      throw new Error("CategorySet.storeAllCurrentColors called on a provisional instance. " +
+        "Call metadata.ensurePersistentCategorySet(attrId) first.");
+    }
     self.values.forEach(value => {
       if (!self.colors.get(value)) {
         this.storeCurrentColorForCategory(value);

--- a/src/models/data/category-set.ts
+++ b/src/models/data/category-set.ts
@@ -226,7 +226,7 @@ export const CategorySet = types.model("CategorySet", {
       throw new Error("CategorySet.setColorForCategory called on a provisional instance. " +
         "Call metadata.ensurePersistentCategorySet(attrId) first.");
     }
-    if (self.index(value)) {
+    if (self.index(value) != null) {
       self.colors.set(value, color);
     }
   },

--- a/src/models/shared/shared-case-metadata.test.ts
+++ b/src/models/shared/shared-case-metadata.test.ts
@@ -1,6 +1,6 @@
-import { getSnapshot, Instance, onAction, types } from "mobx-state-tree";
+import { applyPatch, getSnapshot, Instance, onAction, types } from "mobx-state-tree";
 import { DataSet } from "../data/data-set";
-import { getCategorySet, isSharedCaseMetadata, SharedCaseMetadata } from "./shared-case-metadata";
+import { isSharedCaseMetadata, SharedCaseMetadata } from "./shared-case-metadata";
 import { SharedModel } from "./shared-model";
 
 // eslint-disable-next-line no-var
@@ -80,7 +80,7 @@ describe("SharedCaseMetadata", () => {
     tree.metadata.setIsCollapsed("foo", true);
     expect(tree.metadata.isCollapsed("foo")).toBe(false);
     // ignores category set calls before DataSet is associated
-    const categories = getCategorySet(tree.metadata, "foo");
+    const categories = tree.metadata.getCategorySet("foo");
     expect(categories).toBeUndefined();
   });
 
@@ -207,6 +207,42 @@ describe("SharedCaseMetadata", () => {
 
       expect(topLevelActions).toEqual(["removeAttribute"]);
       expect(tree.metadata.provisionalCategories.size).toBe(0);
+    });
+
+    it("removes a rehydrated persistent entry when its attribute is removed after reload", () => {
+      // Create a persistent category set, then rehydrate from snapshots as
+      // happens on document reopen. The per-attribute cleanup disposer must
+      // be installed for rehydrated entries so attribute removal still
+      // cleans them up.
+      tree.metadata.ensurePersistentCategorySet("aId");
+      expect(tree.metadata.categories.size).toBe(1);
+
+      const dataSnap = getSnapshot(tree.data);
+      const metaSnap = getSnapshot(tree.metadata);
+      const rehydrated = TreeModel.create({ data: dataSnap, metadata: metaSnap });
+      rehydrated.metadata.setData(rehydrated.data);
+      expect(rehydrated.metadata.categories.size).toBe(1);
+
+      rehydrated.data.removeAttribute("aId");
+      expect(rehydrated.metadata.categories.size).toBe(0);
+    });
+
+    it("removes a patch-added persistent entry when its attribute is removed", () => {
+      // A patch that inserts a persistent CategorySet directly into the map
+      // (e.g. history replay / applyPatch) must still be cleaned up when
+      // the underlying attribute is removed. Since the unified disposer
+      // keys off the Attribute lifecycle, this works regardless of how the
+      // CategorySet came into existence.
+      expect(tree.metadata.categories.size).toBe(0);
+      applyPatch(tree.metadata, {
+        op: "add",
+        path: "/categories/aId",
+        value: { attribute: "aId", colors: {}, moves: [] }
+      });
+      expect(tree.metadata.categories.size).toBe(1);
+
+      tree.data.removeAttribute("aId");
+      expect(tree.metadata.categories.size).toBe(0);
     });
   });
 });

--- a/src/models/shared/shared-case-metadata.test.ts
+++ b/src/models/shared/shared-case-metadata.test.ts
@@ -1,4 +1,4 @@
-import { getSnapshot, Instance, types } from "mobx-state-tree";
+import { getSnapshot, Instance, onAction, types } from "mobx-state-tree";
 import { DataSet } from "../data/data-set";
 import { getCategorySet, isSharedCaseMetadata, SharedCaseMetadata } from "./shared-case-metadata";
 import { SharedModel } from "./shared-model";
@@ -104,22 +104,109 @@ describe("SharedCaseMetadata", () => {
   //   expect(tree.metadata.collections.get(collection.id)?.collapsed.size).toBe(0);
   // });
 
-  it("supports CategorySets", () => {
+  it("getCategorySet is a pure view that does not create entries", () => {
     expect(tree.metadata.categories.size).toBe(0);
-    expect(tree.metadata.categories.get("aId")).toBeUndefined();
-    const set1 = getCategorySet(tree.metadata, "aId");
-    expect(tree.metadata.categories.size).toBe(1);
-    expect(tree.metadata.categories.get("aId")).toBe(set1);
-    const set2 = getCategorySet(tree.metadata, "aId");
-    expect(tree.metadata.categories.size).toBe(1);
-    expect(tree.metadata.categories.get("aId")).toBe(set1);
-    expect(set1).toBe(set2);
-    const noSet = getCategorySet(tree.metadata, "zId");
-    expect(noSet).toBeUndefined();
-    expect(tree.metadata.categories.size).toBe(1);
-    expect(tree.metadata.categories.get("zId")).toBeUndefined();
-    // removes set from map when its attribute is invalidated
-    tree.data.removeAttribute("aId");
+    // Reading via the view should not create anything.
+    const result = tree.metadata.getCategorySet("aId");
+    expect(result).toBeUndefined();
     expect(tree.metadata.categories.size).toBe(0);
+  });
+
+  describe("CategorySet lifecycle", () => {
+    it("ensureProvisionalCategorySet creates a provisional and is idempotent", () => {
+      expect(tree.metadata.categories.size).toBe(0);
+      expect(tree.metadata.provisionalCategories.size).toBe(0);
+
+      const cs1 = tree.metadata.ensureProvisionalCategorySet("aId");
+      expect(cs1).toBeDefined();
+      expect(tree.metadata.provisionalCategories.size).toBe(1);
+      expect(tree.metadata.provisionalCategories.get("aId")).toBe(cs1);
+      expect(tree.metadata.categories.size).toBe(0);
+
+      const cs2 = tree.metadata.ensureProvisionalCategorySet("aId");
+      expect(cs2).toBe(cs1);
+      expect(tree.metadata.provisionalCategories.size).toBe(1);
+    });
+
+    it("ensureProvisionalCategorySet returns undefined for unknown attributes", () => {
+      const cs = tree.metadata.ensureProvisionalCategorySet("zId");
+      expect(cs).toBeUndefined();
+      expect(tree.metadata.provisionalCategories.size).toBe(0);
+    });
+
+    it("ensurePersistentCategorySet creates a persistent and destroys the previous provisional", () => {
+      const provisional = tree.metadata.ensureProvisionalCategorySet("aId");
+      expect(provisional).toBeDefined();
+
+      const persistent = tree.metadata.ensurePersistentCategorySet("aId");
+      expect(persistent).toBeDefined();
+      expect(tree.metadata.categories.size).toBe(1);
+      expect(tree.metadata.categories.get("aId")).toBe(persistent);
+      expect(tree.metadata.provisionalCategories.size).toBe(0);
+
+      // The stale provisional reference is dead — any read throws.
+      expect(() => (provisional as any).values).toThrow();
+    });
+
+    it("ensurePersistentCategorySet is idempotent", () => {
+      const p1 = tree.metadata.ensurePersistentCategorySet("aId");
+      const p2 = tree.metadata.ensurePersistentCategorySet("aId");
+      expect(p1).toBe(p2);
+      expect(tree.metadata.categories.size).toBe(1);
+    });
+
+    it("destroys the provisional when the underlying attribute is removed", () => {
+      const provisional = tree.metadata.ensureProvisionalCategorySet("aId");
+      expect(provisional).toBeDefined();
+      expect(tree.metadata.provisionalCategories.size).toBe(1);
+
+      tree.data.removeAttribute("aId");
+
+      expect(tree.metadata.provisionalCategories.size).toBe(0);
+      expect(() => (provisional as any).values).toThrow();
+    });
+
+    it("removes the persistent entry when the underlying attribute is removed", () => {
+      tree.metadata.ensurePersistentCategorySet("aId");
+      expect(tree.metadata.categories.size).toBe(1);
+      tree.data.removeAttribute("aId");
+      expect(tree.metadata.categories.size).toBe(0);
+    });
+
+    it("removeAttribute destroys a persistent entry without a separate top-level action", () => {
+      tree.metadata.ensurePersistentCategorySet("aId");
+      expect(tree.metadata.categories.size).toBe(1);
+
+      const topLevelActions: string[] = [];
+      const dispose = onAction(tree, (call) => {
+        topLevelActions.push(call.name);
+      });
+      try {
+        tree.data.removeAttribute("aId");
+      } finally {
+        dispose();
+      }
+
+      expect(topLevelActions).toEqual(["removeAttribute"]);
+      expect(tree.metadata.categories.size).toBe(0);
+    });
+
+    it("removeAttribute destroys a provisional entry without a separate top-level action", () => {
+      tree.metadata.ensureProvisionalCategorySet("aId");
+      expect(tree.metadata.provisionalCategories.size).toBe(1);
+
+      const topLevelActions: string[] = [];
+      const dispose = onAction(tree, (call) => {
+        topLevelActions.push(call.name);
+      });
+      try {
+        tree.data.removeAttribute("aId");
+      } finally {
+        dispose();
+      }
+
+      expect(topLevelActions).toEqual(["removeAttribute"]);
+      expect(tree.metadata.provisionalCategories.size).toBe(0);
+    });
   });
 });

--- a/src/models/shared/shared-case-metadata.ts
+++ b/src/models/shared/shared-case-metadata.ts
@@ -1,5 +1,6 @@
-import { getType, Instance, ISerializedActionCall, types } from "mobx-state-tree";
-import { CategorySet, ICategorySet } from "../data/category-set";
+import { observable } from "mobx";
+import { addDisposer, destroy, getType, Instance, ISerializedActionCall, types } from "mobx-state-tree";
+import { CategorySet, createProvisionalCategorySet, ICategorySet } from "../data/category-set";
 import { DataSet, IDataSet } from "../data/data-set";
 import { SharedModelType, SharedModel } from "./shared-model";
 
@@ -9,11 +10,6 @@ export const CollectionTableMetadata = types.model("CollectionTable", {
   // key is valueJson; value is true (false values are deleted)
   collapsed: types.map(types.boolean)
 });
-
-// utility function for retrieving a category set, creating it if it doesn't already exist
-export function getCategorySet(metadata: ISharedCaseMetadata, attrId: string): ICategorySet | undefined {
-  return metadata.categories.get(attrId) ?? metadata.addCategorySet(attrId);
-}
 
 export const SharedCaseMetadata = SharedModel
   .named(kSharedCaseMetadataType)
@@ -29,6 +25,15 @@ export const SharedCaseMetadata = SharedModel
     // key is attribute id; value is true (false values are deleted)
     hidden: types.map(types.boolean)
   })
+  .volatile(() => ({
+    // CategorySets are generated on demand whenever something needs to treat
+    // an attribute categorically. CategorySets only need to be saved when they
+    // contain user modifications (re-orderings or color assignments). CategorySets
+    // created automatically before any user modification live here as
+    // "provisional" sets and are promoted to the persistent `categories` map when
+    // the user first modifies one. This keeps them from cluttering up history.
+    provisionalCategories: observable.map<string, ICategorySet>()
+  }))
   .views(self => ({
     columnWidth(attrId: string) {
       return self.columnWidths.get(attrId);
@@ -41,6 +46,11 @@ export const SharedCaseMetadata = SharedModel
     // true if passed the id of a hidden attribute, false otherwise
     isHidden(attrId: string) {
       return self.hidden.get(attrId) ?? false;
+    },
+    getCategorySet(attrId: string): ICategorySet | undefined {
+      // Persistent has priority. Reads inside other MobX computations establish
+      // dependencies on both maps so either mutation triggers re-evaluation.
+      return self.categories.get(attrId) ?? self.provisionalCategories.get(attrId);
     }
   }))
   .actions(self => ({
@@ -89,18 +99,80 @@ export const SharedCaseMetadata = SharedModel
     }
   }))
   .actions(self => ({
-    addCategorySet(attrId: string): ICategorySet | undefined {
-      let categorySet = self.categories.get(attrId);
-      if (!categorySet && self.data?.attrFromID(attrId)) {
-        // add category set to map
-        self.categories.set(attrId, { attribute: attrId });
-        categorySet = self.categories.get(attrId);
-        // remove category sets from map when attribute references are invalidated
-        categorySet?.onAttributeInvalidated(function(invalidAttrId: string) {
-          self.removeCategorySet(invalidAttrId);
-        });
-      }
+    ensureProvisionalCategorySet(attrId: string): ICategorySet | undefined {
+      // Idempotent: return any existing instance unchanged.
+      const existing = self.categories.get(attrId) ?? self.provisionalCategories.get(attrId);
+      if (existing) return existing;
+
+      const attribute = self.data?.attrFromID(attrId);
+      if (!self.data || !attribute) return undefined;
+
+      const categorySet = createProvisionalCategorySet(self.data, attrId);
+      self.provisionalCategories.set(attrId, categorySet);
+
+      // Clean up the provisional when the underlying Attribute node is
+      // destroyed. We use `addDisposer(attribute, ...)` rather than watching
+      // the DataSet's `removeAttribute` action by name because:
+      //
+      //   1. Attributes can be destroyed by many paths — removeAttribute,
+      //      moveAttribute (which splices the instance out and recreates it),
+      //      DataSet destruction, applySnapshot/applyPatch during history
+      //      playback. `addDisposer(attribute, ...)` fires on all of them.
+      //   2. MST fires disposers synchronously, inside the destruction call
+      //      stack. That means this cleanup runs INSIDE the outer action that
+      //      triggered the destruction (e.g. removeAttribute), and the tree
+      //      monitor's action-tracking middleware groups it under that single
+      //      top-level action — producing one history entry, not two.
+      //
+      // This is the provisional counterpart to the persistent path's
+      // `onInvalidated` callback on the `types.reference(Attribute, ...)`
+      // below in ensurePersistentCategorySet. Both mechanisms are synchronous
+      // and same-action by MST's guarantees; both exist so that cleanup never
+      // produces a stray history entry. Do not convert either to a MobX
+      // reaction — reactions fire after the action completes, which would
+      // create a second top-level action and a second history entry.
+      addDisposer(attribute, () => {
+        const stale = self.provisionalCategories.get(attrId);
+        if (stale) {
+          self.provisionalCategories.delete(attrId);
+          destroy(stale);
+        }
+      });
+
       return categorySet;
+    },
+    ensurePersistentCategorySet(attrId: string): ICategorySet | undefined {
+      const existing = self.categories.get(attrId);
+      if (existing) return existing;
+
+      if (!self.data?.attrFromID(attrId)) return undefined;
+
+      // Create a fresh persistent entry. Because provisional instances can
+      // never be mutated (see the guard in category-set.ts), there is no
+      // mutable state on the provisional that needs to be carried over to
+      // the new persistent instance.
+      self.categories.set(attrId, { attribute: attrId });
+      const persistent = self.categories.get(attrId);
+
+      // Dispose any existing provisional so stale references explode.
+      const provisional = self.provisionalCategories.get(attrId);
+      if (provisional) {
+        self.provisionalCategories.delete(attrId);
+        destroy(provisional);
+      }
+
+      // Persistent instances rely on MST's native `onInvalidated` callback on
+      // the `types.reference(Attribute, ...)` prop in CategorySet. MST fires
+      // that callback synchronously from inside the reference-resolution
+      // pipeline when the referenced Attribute node is destroyed. We route it
+      // through `removeCategorySet` here, same as the old `addCategorySet`
+      // action used to. This is the persistent counterpart to the
+      // `addDisposer(attribute, ...)` hook above in ensureProvisionalCategorySet
+      // — see that comment for the full rationale about synchronous cleanup.
+      persistent?.onAttributeInvalidated((invalidAttrId: string) => {
+        self.removeCategorySet(invalidAttrId);
+      });
+      return persistent;
     }
   }));
 export interface ISharedCaseMetadata extends Instance<typeof SharedCaseMetadata> {}
@@ -116,4 +188,10 @@ export interface SetIsCollapsedAction extends ISerializedActionCall {
 
 export function isSetIsCollapsedAction(action: ISerializedActionCall): action is SetIsCollapsedAction {
   return action.name === "setIsCollapsed";
+}
+
+// Thin wrapper for backward compatibility. Use metadata.getCategorySet directly
+// in new code.
+export function getCategorySet(metadata: ISharedCaseMetadata, attrId: string): ICategorySet | undefined {
+  return metadata.getCategorySet(attrId);
 }

--- a/src/models/shared/shared-case-metadata.ts
+++ b/src/models/shared/shared-case-metadata.ts
@@ -1,8 +1,10 @@
-import { observable } from "mobx";
-import { addDisposer, destroy, getType, Instance, ISerializedActionCall, types } from "mobx-state-tree";
+import { comparer, observable } from "mobx";
+import { addDisposer, destroy, getType, Instance, isAlive, ISerializedActionCall, types } from "mobx-state-tree";
+import { IAttribute } from "../data/attribute";
 import { CategorySet, createProvisionalCategorySet, ICategorySet } from "../data/category-set";
 import { DataSet, IDataSet } from "../data/data-set";
 import { SharedModelType, SharedModel } from "./shared-model";
+import { mstReaction } from "../../utilities/mst-reaction";
 
 export const kSharedCaseMetadataType = "SharedCaseMetadata";
 
@@ -32,7 +34,10 @@ export const SharedCaseMetadata = SharedModel
     // created automatically before any user modification live here as
     // "provisional" sets and are promoted to the persistent `categories` map when
     // the user first modifies one. This keeps them from cluttering up history.
-    provisionalCategories: observable.map<string, ICategorySet>()
+    provisionalCategories: observable.map<string, ICategorySet>(),
+    // Tracks attrIds that already have a cleanup disposer installed on their
+    // Attribute, so the attribute-watching reaction doesn't re-register.
+    _attrsWithCleanupDisposer: new Set<string>()
   }))
   .views(self => ({
     columnWidth(attrId: string) {
@@ -102,9 +107,64 @@ export const SharedCaseMetadata = SharedModel
     }
   }))
   .actions(self => ({
+    _cleanupAttribute(attrId: string) {
+      // Remove any attribute-keyed state left behind when an Attribute is
+      // destroyed. Add more here (e.g. columnWidths, hidden) as needed —
+      // anything keyed by attrId should be cleaned up in one place.
+      //
+      // Persistent: delegate to the action so MST's action protection permits
+      // the map mutation even when this runs inside a DataSet action context.
+      if (self.categories.has(attrId)) self.removeCategorySet(attrId);
+      // Provisional: volatile map, not protected.
+      const provisional = self.provisionalCategories.get(attrId);
+      if (provisional) {
+        self.provisionalCategories.delete(attrId);
+        destroy(provisional);
+      }
+      self._attrsWithCleanupDisposer.delete(attrId);
+    }
+  }))
+  .actions(self => ({
+    _ensureAttributeCleanupDisposer(attribute: IAttribute) {
+      if (self._attrsWithCleanupDisposer.has(attribute.id)) return;
+      self._attrsWithCleanupDisposer.add(attribute.id);
+      // Single disposer per Attribute. When the Attribute is destroyed —
+      // via removeAttribute, moveAttribute, DataSet destruction, or patch
+      // playback — this disposer removes any CategorySet (provisional OR
+      // persistent) keyed by that attribute's id. Keying cleanup off the
+      // Attribute lifecycle (not the CategorySet's) means cleanup works
+      // regardless of when or how the CategorySet came into existence:
+      // fresh inserts, snapshot rehydration, and patch-added entries are
+      // all handled uniformly.
+      addDisposer(attribute, () => {
+        // Guard against SharedCaseMetadata having been destroyed before the
+        // Attribute. MST's addDisposer has no way to unregister a disposer
+        // from a foreign node when `self` dies first, so the disposer can
+        // outlive us. Calling an action on a dead tree would throw.
+        if (!isAlive(self)) return;
+        self._cleanupAttribute(attribute.id);
+      });
+    }
+  }))
+  .actions(self => ({
+    afterAttach() {
+      // Install a cleanup disposer for every attribute in the associated
+      // DataSet, reactively as attributes are added. Runs immediately for
+      // attributes already present at rehydration time. The reaction is
+      // tied to this model's lifecycle by mstReaction.
+      mstReaction(
+        () => self.data?.attributes.map(a => a.id) ?? [],
+        () => self.data?.attributes.forEach(a => self._ensureAttributeCleanupDisposer(a)),
+        { name: "SharedCaseMetadata.ensureAttributeCleanupDisposers",
+          fireImmediately: true, equals: comparer.structural },
+        self
+      );
+    }
+  }))
+  .actions(self => ({
     ensureProvisionalCategorySet(attrId: string): ICategorySet | undefined {
       // Idempotent: return any existing instance unchanged.
-      const existing = self.categories.get(attrId) ?? self.provisionalCategories.get(attrId);
+      const existing = self.getCategorySet(attrId);
       if (existing) return existing;
 
       const attribute = self.data?.attrFromID(attrId);
@@ -113,35 +173,11 @@ export const SharedCaseMetadata = SharedModel
       const categorySet = createProvisionalCategorySet(self.data, attrId);
       self.provisionalCategories.set(attrId, categorySet);
 
-      // Clean up the provisional when the underlying Attribute node is
-      // destroyed. We use `addDisposer(attribute, ...)` rather than watching
-      // the DataSet's `removeAttribute` action by name because:
-      //
-      //   1. Attributes can be destroyed by many paths — removeAttribute,
-      //      moveAttribute (which splices the instance out and recreates it),
-      //      DataSet destruction, applySnapshot/applyPatch during history
-      //      playback. `addDisposer(attribute, ...)` fires on all of them.
-      //   2. MST fires disposers synchronously, inside the destruction call
-      //      stack. That means this cleanup runs INSIDE the outer action that
-      //      triggered the destruction (e.g. removeAttribute), and the tree
-      //      monitor's action-tracking middleware groups it under that single
-      //      top-level action — producing one history entry, not two.
-      //
-      // This is the provisional counterpart to the persistent path's
-      // `onInvalidated` callback on the `types.reference(Attribute, ...)`
-      // below in ensurePersistentCategorySet. Both mechanisms are synchronous
-      // and same-action by MST's guarantees; both exist so that cleanup never
-      // produces a stray history entry. Do not convert either to a MobX
-      // reaction — reactions fire after the action completes, which would
-      // create a second top-level action and a second history entry.
-      addDisposer(attribute, () => {
-        const stale = self.provisionalCategories.get(attrId);
-        if (stale) {
-          self.provisionalCategories.delete(attrId);
-          destroy(stale);
-        }
-      });
-
+      // Cleanup on attribute destruction is handled by the per-attribute
+      // disposer installed by `_ensureAttributeCleanupDisposer` from the
+      // afterAttach reaction above. That disposer removes any CategorySet
+      // (provisional or persistent) keyed by this attribute's id, keying
+      // cleanup off the Attribute lifecycle rather than per ensure-call.
       return categorySet;
     },
     ensurePersistentCategorySet(attrId: string): ICategorySet | undefined {
@@ -164,17 +200,10 @@ export const SharedCaseMetadata = SharedModel
         destroy(provisional);
       }
 
-      // Persistent instances rely on MST's native `onInvalidated` callback on
-      // the `types.reference(Attribute, ...)` prop in CategorySet. MST fires
-      // that callback synchronously from inside the reference-resolution
-      // pipeline when the referenced Attribute node is destroyed. We route it
-      // through `removeCategorySet` here, same as the old `addCategorySet`
-      // action used to. This is the persistent counterpart to the
-      // `addDisposer(attribute, ...)` hook above in ensureProvisionalCategorySet
-      // — see that comment for the full rationale about synchronous cleanup.
-      persistent?.onAttributeInvalidated((invalidAttrId: string) => {
-        self.removeCategorySet(invalidAttrId);
-      });
+      // Cleanup on Attribute destruction is handled by a disposer installed
+      // from CategorySet.afterAttach, which fires for every attach path
+      // (fresh insert, snapshot rehydration, patch-materialized entries).
+      // The disposer calls removeCategorySet on this model.
       return persistent;
     }
   }));
@@ -191,10 +220,4 @@ export interface SetIsCollapsedAction extends ISerializedActionCall {
 
 export function isSetIsCollapsedAction(action: ISerializedActionCall): action is SetIsCollapsedAction {
   return action.name === "setIsCollapsed";
-}
-
-// Thin wrapper for backward compatibility. Use metadata.getCategorySet directly
-// in new code.
-export function getCategorySet(metadata: ISharedCaseMetadata, attrId: string): ICategorySet | undefined {
-  return metadata.getCategorySet(attrId);
 }

--- a/src/models/shared/shared-case-metadata.ts
+++ b/src/models/shared/shared-case-metadata.ts
@@ -48,9 +48,12 @@ export const SharedCaseMetadata = SharedModel
       return self.hidden.get(attrId) ?? false;
     },
     getCategorySet(attrId: string): ICategorySet | undefined {
-      // Persistent has priority. Reads inside other MobX computations establish
-      // dependencies on both maps so either mutation triggers re-evaluation.
-      return self.categories.get(attrId) ?? self.provisionalCategories.get(attrId);
+      // Persistent has priority. Read both maps unconditionally so MobX tracks
+      // dependencies on both — otherwise `??` would short-circuit and skip
+      // tracking provisionalCategories whenever a persistent entry exists.
+      const persistent = self.categories.get(attrId);
+      const provisional = self.provisionalCategories.get(attrId);
+      return persistent ?? provisional;
     }
   }))
   .actions(self => ({

--- a/src/plugins/graph/imports/components/axis/axis-utils.ts
+++ b/src/plugins/graph/imports/components/axis/axis-utils.ts
@@ -2,8 +2,9 @@ import {ScaleLinear} from "d3";
 import {MutableRefObject} from "react";
 import {AxisPlace} from "./axis-types";
 import {measureText, measureTextExtent} from "../../../../../components/tiles/hooks/use-measure-text";
-import {kAxisGap, kAxisTickLength, kAxisTickPadding, kGraphFont} from "../../../graph-types";
+import {GraphAttrRole, kAxisGap, kAxisTickLength, kAxisTickPadding, kGraphFont} from "../../../graph-types";
 import {ICategorySet} from "../../../../../models/data/category-set";
+import {IDataConfigurationModel} from "../../../models/data-configuration-model";
 
 export const getStringBounds = (s = 'Wy', font = kGraphFont) => {
   return measureTextExtent(s, font);
@@ -102,6 +103,11 @@ export interface DragInfo {
   currentOffset: number
   currentDragPosition: number
   categorySet?: ICategorySet
+  /** DataConfigurationModel for the layer the dragged axis belongs to.
+   *  Used to promote the provisional CategorySet to persistent at drag time. */
+  dataConfiguration?: IDataConfigurationModel
+  /** Graph role for the dragged axis (e.g. "x", "y", "topSplit"). */
+  attrRole?: GraphAttrRole
   categories: string[]
   bandwidth: number
   axisOrientation: 'horizontal' | 'vertical'

--- a/src/plugins/graph/imports/components/axis/hooks/use-sub-axis.ts
+++ b/src/plugins/graph/imports/components/axis/hooks/use-sub-axis.ts
@@ -7,6 +7,7 @@ import {useAxisLayoutContext} from "../models/axis-layout-context";
 import {IAxisModel, isCategoricalAxisModel, isNumericAxisModel} from "../models/axis-model";
 import {isVertical} from "../../axis-graph-shared";
 import {
+  axisPlaceToAttrRole,
   kAxisStrokeWidth, kAxisTickLength, kAxisTickPadding, kTickAndGridColor, kTickFontColor, transitionDuration
 } from "../../../../graph-types";
 import {DragInfo, collisionExists, computeBestNumberOfTicks,
@@ -217,6 +218,8 @@ export const useSubAxis = ({subAxisIndex, axisModel, subAxisElt, showScatterPlot
       // Fill out dragInfo for use in drag callbacks
       const dI = dragInfo.current;
       dI.categorySet = categorySet;
+      dI.dataConfiguration = graphModel.config;
+      dI.attrRole = axisPlaceToAttrRole[place];
       dI.categories = categories;
       dI.bandwidth = bandWidth;
       dI.axisOrientation = axisIsVertical ? 'vertical' : 'horizontal';
@@ -299,7 +302,7 @@ export const useSubAxis = ({subAxisIndex, axisModel, subAxisElt, showScatterPlot
         break;
     }
   }, [subAxisElt, layout, showScatterPlotGridLines, enableAnimation, centerCategoryLabels,
-      axisModel, subAxisIndex, graphModel.isLinkedToDataSet]);
+      axisModel, subAxisIndex, graphModel.isLinkedToDataSet, graphModel.config]);
 
   const onDragStart = useCallback((event: any) => {
     const dI = dragInfo.current;
@@ -338,7 +341,10 @@ export const useSubAxis = ({subAxisIndex, axisModel, subAxisElt, showScatterPlot
             ? (newCatIndex === numCategories - 1 ? '' : dI.categories[newCatIndex + 1])
             : dI.categories[newCatIndex];
         dI.indexOfCategory = newCatIndex;
-        dI.categorySet?.move(dI.catName, catToMoveBefore);
+        const persistent = dI.dataConfiguration && dI.attrRole
+          ? dI.dataConfiguration.ensurePersistentCategorySetForRole(dI.attrRole)
+          : undefined;
+        persistent?.move(dI.catName, catToMoveBefore);
       } else {
         renderSubAxis();
       }

--- a/src/plugins/graph/models/data-configuration-model.test.ts
+++ b/src/plugins/graph/models/data-configuration-model.test.ts
@@ -259,8 +259,11 @@ describe("DataConfigurationModel", () => {
     expect(config.valuesForAttrRole("x")).toEqual(["1", "1", "6", "6"]);
     expect(config.valuesForAttrRole("y")).toEqual(["1", "1", "1", "6"]);
     expect(config.valuesForAttrRole("caption")).toEqual(["n1", "n1", "n1"]);
-    expect(config.categoryArrayForAttrRole("x")).toEqual(["1", "6"]);
-    expect(config.categoryArrayForAttrRole("y")).toEqual(["1", "6"]);
+    // x and y are numeric, so no CategorySet is created for them; their
+    // categoryArray falls back to the empty default.
+    expect(config.categoryArrayForAttrRole("x")).toEqual(["__main__"]);
+    expect(config.categoryArrayForAttrRole("y")).toEqual(["__main__"]);
+    // caption (nId) is categorical, so it has a CategorySet.
     expect(config.categoryArrayForAttrRole("caption")).toEqual(["n1"]);
     expect(config.numericValuesForAttrRole("x")).toEqual([1, 1, 6, 6]);
     expect(config.numericValuesForAttrRole("caption")).toEqual([]);
@@ -294,6 +297,72 @@ describe("DataConfigurationModel", () => {
       {"__id__": "c2", "xId": 2},
       {"__id__": "c3", "nId": "n3", "yId": 3}
     ]);
+  });
+
+  describe("ensure-provisional-category-sets reaction", () => {
+    // Note: after setDataset, the "caption" role defaults to the first attribute
+    // (nId) with type categorical, so the reaction eagerly creates a provisional
+    // CategorySet for "nId". Tests here account for that baseline.
+
+    it("creates a provisional when a categorical attribute is assigned", () => {
+      const config = tree.config;
+      config.setDataset(tree.data, tree.metadata);
+
+      // The default caption role picks up nId (categorical) automatically.
+      expect(tree.metadata.provisionalCategories.size).toBe(1);
+      expect(tree.metadata.provisionalCategories.get("nId")).toBeDefined();
+
+      config.setAttributeForRole("x", { attributeID: "nId", type: "categorical" });
+      // Still only nId (same attribute used for both roles).
+      expect(tree.metadata.provisionalCategories.size).toBe(1);
+      expect(tree.metadata.provisionalCategories.get("nId")).toBeDefined();
+      expect(tree.metadata.categories.size).toBe(0);
+    });
+
+    it("does not create a provisional for a numeric attribute", () => {
+      const config = tree.config;
+      config.setDataset(tree.data, tree.metadata);
+
+      // Baseline: one provisional for the default caption (nId).
+      expect(tree.metadata.provisionalCategories.size).toBe(1);
+
+      config.setAttributeForRole("x", { attributeID: "xId", type: "numeric" });
+      // Numeric assignment should not add a new provisional for xId.
+      expect(tree.metadata.provisionalCategories.size).toBe(1);
+      expect(tree.metadata.provisionalCategories.get("xId")).toBeUndefined();
+      expect(tree.metadata.categories.size).toBe(0);
+    });
+
+    it("creates a provisional when an already-assigned attribute is flipped to categorical", () => {
+      const config = tree.config;
+      config.setDataset(tree.data, tree.metadata);
+
+      config.setAttributeForRole("x", { attributeID: "xId", type: "numeric" });
+      expect(tree.metadata.provisionalCategories.get("xId")).toBeUndefined();
+
+      config.setAttributeType("x", "categorical");
+      expect(tree.metadata.provisionalCategories.get("xId")).toBeDefined();
+    });
+
+    it("does not overwrite an existing persistent entry on re-fire", () => {
+      const config = tree.config;
+      config.setDataset(tree.data, tree.metadata);
+
+      config.setAttributeForRole("x", { attributeID: "nId", type: "categorical" });
+      const provisional = tree.metadata.provisionalCategories.get("nId");
+      expect(provisional).toBeDefined();
+
+      const persistent = config.ensurePersistentCategorySetForRole("x");
+      expect(tree.metadata.categories.size).toBe(1);
+      expect(tree.metadata.provisionalCategories.get("nId")).toBeUndefined();
+
+      config.setAttributeForRole("y", { attributeID: "yId", type: "numeric" });
+
+      // The persistent entry for nId should survive the re-fire, and no
+      // new provisional should be created for nId (since it's still persistent).
+      expect(tree.metadata.categories.get("nId")).toBe(persistent);
+      expect(tree.metadata.provisionalCategories.get("nId")).toBeUndefined();
+    });
   });
 
 });

--- a/src/plugins/graph/models/data-configuration-model.test.ts
+++ b/src/plugins/graph/models/data-configuration-model.test.ts
@@ -270,6 +270,22 @@ describe("DataConfigurationModel", () => {
     expect(config.categoryArrayForAttrRole("y")).toEqual(["__main__"]);
   });
 
+  it("ensurePersistentCategorySetForRole returns the persistent category set", () => {
+    const config = tree.config;
+    config.setDataset(tree.data, tree.metadata);
+    config.setAttributeForRole("x", { attributeID: "nId", type: "categorical" });
+
+    expect(tree.metadata.categories.size).toBe(0);
+    const cs = config.ensurePersistentCategorySetForRole("x");
+    expect(cs).toBeDefined();
+    expect(tree.metadata.categories.size).toBe(1);
+    expect(tree.metadata.categories.get("nId")).toBe(cs);
+
+    // Second call is idempotent.
+    const cs2 = config.ensurePersistentCategorySetForRole("x");
+    expect(cs2).toBe(cs);
+  });
+
   it("returns an array of cases in a plot", () => {
     const config = tree.config;
     config.setDataset(tree.data, tree.metadata);

--- a/src/plugins/graph/models/data-configuration-model.ts
+++ b/src/plugins/graph/models/data-configuration-model.ts
@@ -602,9 +602,11 @@ export const DataConfigurationModel = types
         () => {
           if (!self.metadata) return [];
           const ids: string[] = [];
+          const seen = new Set<string>();
           GraphAttrRoles.forEach(role => {
             const attrId = self.attributeID(role);
-            if (attrId && self.attributeType(role) === "categorical") {
+            if (attrId && !seen.has(attrId) && self.attributeType(role) === "categorical") {
+              seen.add(attrId);
               ids.push(attrId);
             }
           });

--- a/src/plugins/graph/models/data-configuration-model.ts
+++ b/src/plugins/graph/models/data-configuration-model.ts
@@ -612,24 +612,25 @@ export const DataConfigurationModel = types
      * @param role
      */
     storeAllCurrentColorsForAttrRole(role: GraphAttrRole) {
-      const categorySet = self.categorySetForAttrRole(role);
-      if (categorySet) {
-        categorySet.storeAllCurrentColors();
-      }
+      const persistent = this.ensurePersistentCategorySetForRole(role);
+      persistent?.storeAllCurrentColors();
     },
     swapCategoriesForAttrRole(role: GraphAttrRole, catIndex1: number, catIndex2: number) {
       const categoryArray = self.categoryArrayForAttrRole(role),
-        numCategories = categoryArray.length,
-        categorySet = self.categorySetForAttrRole(role);
+        numCategories = categoryArray.length;
       if (catIndex2 < catIndex1) {
         const temp = catIndex1;
         catIndex1 = catIndex2;
         catIndex2 = temp;
       }
-      if (categorySet && numCategories > catIndex1 && numCategories > catIndex2) {
+      if (numCategories > catIndex1 && numCategories > catIndex2) {
         const cat1 = categoryArray[catIndex1],
           beforeCat = catIndex2 < numCategories - 1 ? categoryArray[catIndex2 + 1] : undefined;
-        categorySet.move(cat1, beforeCat);
+        // Read-side categoryArray uses whatever getCategorySet returns
+        // (provisional or persistent). The mutation must go through a
+        // guaranteed-persistent instance.
+        const persistent = this.ensurePersistentCategorySetForRole(role);
+        persistent?.move(cat1, beforeCat);
       }
     },
     handleAction(actionCall: ISerializedActionCall) {

--- a/src/plugins/graph/models/data-configuration-model.ts
+++ b/src/plugins/graph/models/data-configuration-model.ts
@@ -1,4 +1,4 @@
-import { observable, reaction } from "mobx";
+import { comparer, observable, reaction } from "mobx";
 import {scaleQuantile, ScaleQuantile, schemeBlues} from "d3";
 import { addDisposer, getSnapshot, Instance, ISerializedActionCall, SnapshotIn, types} from "mobx-state-tree";
 import {AttributeType, attributeTypes} from "../../../models/data/attribute";
@@ -11,8 +11,9 @@ import {FilteredCases, IFilteredChangedCases} from "../../../models/data/filtere
 import {typedId, uniqueId} from "../../../utilities/js-utils";
 import {missingColor} from "../../../utilities/color-utils";
 import {onAnyAction} from "../../../utilities/mst-utils";
+import {mstReaction} from "../../../utilities/mst-reaction";
 import {CaseData} from "../d3-types";
-import {GraphAttrRole, graphPlaceToAttrRole, PrimaryAttrRoles, TipAttrRoles} from "../graph-types";
+import {GraphAttrRole, GraphAttrRoles, graphPlaceToAttrRole, PrimaryAttrRoles, TipAttrRoles} from "../graph-types";
 import {AxisPlace} from "../imports/components/axis/axis-types";
 import {GraphPlace} from "../imports/components/axis-graph-shared";
 
@@ -592,6 +593,34 @@ export const DataConfigurationModel = types
       }
     }))
   .actions(self => ({
+    afterAttach() {
+      // Maintain the invariant: a provisional CategorySet exists for every
+      // attribute currently assigned to a graph role as categorical. This
+      // reaction replaces the old on-demand creation inside getCategorySet,
+      // so that no MST action fires from inside a view/reaction code path.
+      mstReaction(
+        () => {
+          if (!self.metadata) return [];
+          const ids: string[] = [];
+          GraphAttrRoles.forEach(role => {
+            const attrId = self.attributeID(role);
+            if (attrId && self.attributeType(role) === "categorical") {
+              ids.push(attrId);
+            }
+          });
+          return ids;
+        },
+        (categoricalAttrIds) => {
+          categoricalAttrIds.forEach(id => self.metadata?.ensureProvisionalCategorySet(id));
+        },
+        {
+          name: "DataConfigurationModel.ensureProvisionalCategorySets",
+          fireImmediately: true,
+          equals: comparer.structural
+        },
+        self
+      );
+    },
     beforeDestroy() {
       self.actionHandlerDisposer?.();
     },

--- a/src/plugins/graph/models/data-configuration-model.ts
+++ b/src/plugins/graph/models/data-configuration-model.ts
@@ -5,6 +5,7 @@ import {AttributeType, attributeTypes} from "../../../models/data/attribute";
 import { ICase } from "../../../models/data/data-set-types";
 import { DataSet, IDataSet } from "../../../models/data/data-set";
 import {getCategorySet, ISharedCaseMetadata, SharedCaseMetadata} from "../../../models/shared/shared-case-metadata";
+import { ICategorySet } from "../../../models/data/category-set";
 import {isRemoveAttributeAction, isSetCaseValuesAction} from "../../../models/data/data-set-actions";
 import {FilteredCases, IFilteredChangedCases} from "../../../models/data/filtered-cases";
 import {typedId, uniqueId} from "../../../utilities/js-utils";
@@ -593,6 +594,17 @@ export const DataConfigurationModel = types
   .actions(self => ({
     beforeDestroy() {
       self.actionHandlerDisposer?.();
+    },
+    /**
+     * Obtain a persistent CategorySet for the given role, promoting any
+     * existing provisional entry in the process. Use this at every call site
+     * that is about to mutate a CategorySet.
+     */
+    ensurePersistentCategorySetForRole(role: GraphAttrRole): ICategorySet | undefined {
+      if (!self.metadata) return undefined;
+      const attrId = self.attributeID(role);
+      if (!attrId) return undefined;
+      return self.metadata.ensurePersistentCategorySet(attrId);
     },
     /**
      * This is called when the user swaps categories in the legend, but not when the user swaps categories

--- a/src/plugins/graph/models/data-configuration-model.ts
+++ b/src/plugins/graph/models/data-configuration-model.ts
@@ -4,7 +4,7 @@ import { addDisposer, getSnapshot, Instance, ISerializedActionCall, SnapshotIn, 
 import {AttributeType, attributeTypes} from "../../../models/data/attribute";
 import { ICase } from "../../../models/data/data-set-types";
 import { DataSet, IDataSet } from "../../../models/data/data-set";
-import {getCategorySet, ISharedCaseMetadata, SharedCaseMetadata} from "../../../models/shared/shared-case-metadata";
+import {ISharedCaseMetadata, SharedCaseMetadata} from "../../../models/shared/shared-case-metadata";
 import { ICategorySet } from "../../../models/data/category-set";
 import {isRemoveAttributeAction, isSetCaseValuesAction} from "../../../models/data/data-set-actions";
 import {FilteredCases, IFilteredChangedCases} from "../../../models/data/filtered-cases";
@@ -380,7 +380,7 @@ export const DataConfigurationModel = types
       categorySetForAttrRole(role: GraphAttrRole) {
         if (self.metadata) {
           const attributeID = self.attributeID(role) || '';
-          return getCategorySet(self.metadata, attributeID);
+          return self.metadata.getCategorySet(attributeID);
         }
       },
       /**
@@ -393,7 +393,7 @@ export const DataConfigurationModel = types
         let categoryArray: string[] = [];
         if (self.metadata) {
           const attributeID = self.attributeID(role) || '',
-            categorySet = getCategorySet(self.metadata, attributeID),
+            categorySet = self.metadata.getCategorySet(attributeID),
             validValues: Set<string> = new Set(this.valuesForAttrRole(role));
           categoryArray = (categorySet?.values || emptyCategoryArray)
                             .filter((aValue: string) => validValues.has(aValue));
@@ -558,7 +558,7 @@ export const DataConfigurationModel = types
       categorySetForPlace(place: AxisPlace) {
         if (self.metadata) {
           const role = graphPlaceToAttrRole[place];
-          return getCategorySet(self.metadata, self.attributeID(role) ?? '');
+          return self.metadata.getCategorySet(self.attributeID(role) ?? '');
         }
       },
       /**

--- a/src/plugins/graph/models/graph-model.test.ts
+++ b/src/plugins/graph/models/graph-model.test.ts
@@ -267,6 +267,61 @@ describe('GraphModel', () => {
     });
   });
 
+  describe('history entries for createEditableLayer (CLUE-496 regression)', () => {
+    it('records exactly one history entry for one createEditableLayer call', async () => {
+      const document = createDocumentModel({
+        type: "problem", uid: "user-1", key: "document-ce", content: {}
+      });
+      document.treeMonitor!.enableMonitoring();
+
+      const { tileId } = document.content?.addTileContentInNewRow(
+        getSnapshot(GraphModel.create())) || {};
+      const graphModel = document.content?.getTile(tileId!)?.content as IGraphModel;
+      if (!graphModel) fail('No graph model');
+
+      const manager = document.treeManagerAPI as any;
+
+      // Wait for any setup-related history entries (e.g. addTileContentInNewRow)
+      // to settle before capturing the baseline.
+      async function waitForQuiescence() {
+        let lastLength = -1;
+        for (let i = 0; i < 50; i++) {
+          await new Promise(r => setTimeout(r, 20));
+          const entries = manager.document.history;
+          const lastEntry = entries[entries.length - 1];
+          if (entries.length === lastLength &&
+              (!lastEntry || lastEntry.state === "complete")) {
+            return;
+          }
+          lastLength = entries.length;
+        }
+      }
+
+      await waitForQuiescence();
+      const baselineHistory = manager.document.history.length;
+
+      graphModel.createEditableLayer();
+
+      // Wait for the action (and any pending reactions) to finish recording.
+      const deadline = Date.now() + 2000;
+      while (Date.now() < deadline) {
+        const entries = manager.document.history;
+        if (entries.length > baselineHistory &&
+            entries[entries.length - 1].state === "complete") {
+          break;
+        }
+        await new Promise(r => setTimeout(r, 10));
+      }
+      // Give any follow-up reactions a chance to record additional entries.
+      await new Promise(r => setTimeout(r, 100));
+
+      const newEntries = manager.document.history.length - baselineHistory;
+      expect(newEntries).toBe(1);
+      const entry = manager.document.history[manager.document.history.length - 1];
+      expect(entry.action).toContain("createEditableLayer");
+    });
+  });
+
   afterAll(() => {
     createElementSpy.mockRestore();
   });

--- a/src/plugins/graph/models/graph-model.test.ts
+++ b/src/plugins/graph/models/graph-model.test.ts
@@ -295,10 +295,14 @@ describe('GraphModel', () => {
           }
           lastLength = entries.length;
         }
+        throw new Error("waitForQuiescence: history did not settle within timeout");
       }
 
       await waitForQuiescence();
-      const baselineHistory = manager.document.history.length;
+      const entriesAtBaseline = manager.document.history;
+      const lastBaselineEntry = entriesAtBaseline[entriesAtBaseline.length - 1];
+      expect(!lastBaselineEntry || lastBaselineEntry.state === "complete").toBe(true);
+      const baselineHistory = entriesAtBaseline.length;
 
       graphModel.createEditableLayer();
 


### PR DESCRIPTION
## Summary

Adopts CODAP's provisional/persistent split for `CategorySet` to fix stray history entries, then diverges from CODAP where CODAP's approach would itself produce extra history entries or leak state.

### What we borrowed from CODAP
- **Provisional/persistent concept**: CategorySets that haven't been user-modified live as "provisional" (volatile, invisible to history). Only when the user mutates one (reorders categories, sets colors) is it promoted to "persistent" (in the snapshot, tracked by history).

### How CLUE diverges from CODAP
1. **Synchronous promotion** — CODAP uses a `when(...)` reaction to promote provisionals asynchronously. CLUE promotes synchronously at mutation call sites: `metadata.ensurePersistentCategorySet(attrId).move(...)`. This avoids a second top-level action.
2. **Pure-view `getCategorySet`** — CODAP's equivalent lazily creates on read. CLUE's `getCategorySet` is a pure view with no side effects. Provisionals are created eagerly by a reaction on `DataConfigurationModel` that watches categorical attribute assignments.
3. **`destroy()` on removal** — CODAP leaves removed provisionals as orphans. CLUE calls `destroy(stale)` so any stale reference throws MST's dead-node error instead of silently returning stale data.
4. **Volatile `_provisionalAttribute` pointer** — CODAP uses a `{ provisionalDataSet }` MST env with a custom `types.reference` resolver. CLUE adds a volatile pointer that `self.attr` reads first, keeping the reference itself plain and avoiding the `getEnv`/`hasEnv` machinery.
5. **Unified per-attribute cleanup disposer** — CODAP's cleanup runs through a four-hop path: `types.reference.onInvalidated` → volatile `handleAttributeInvalidated` → `onAttributeInvalidated` action → parent handler → map mutation. And because CODAP only wires the handler when `getCategorySet` creates a provisional, persistent entries arriving by **snapshot rehydration** or **`applyPatch`** never get a handler at all — removing their attribute later leaves orphans. CLUE replaces this with a single `addDisposer(attribute, ...)` per attribute, installed by `SharedCaseMetadata` via a reaction over `data.attributes`. One disposer body handles both provisional and persistent cleanup, keyed off the Attribute lifecycle, so fresh inserts / rehydration / patch-added entries are all handled uniformly. `addDisposer` fires synchronously in the destruction call stack — a MobX reaction is NOT usable here because it would fire after the action and produce a stray history entry, which is the bug this PR exists to fix.

### Scope of CategorySet use in CLUE

CategorySets in CODAP drive both **color legends** and **axis category ordering**. CLUE only uses the second:

- **No color legend UI.** CLUE's bar graph tracks its own colors independently of `CategorySet`. As far as we can tell, the graph (points and lines) has no UI for coloring points by a categorical legend, so the color-related fields on `CategorySet` are currently unused in CLUE.
- **Axis drag-reorder exists but is visually broken.** You can drag-reorder a categorical axis, which is why this PR still routes that path through `ensurePersistentCategorySetForRole`. However the current UI behavior is buggy: labels change as you drag, points don't stay lined up with the category being dragged, and points aren't grouped above unique category labels. **Fixing the axis drag-reorder UI is out of scope for this PR** — this PR only ensures the underlying mutation produces correct history entries.

### Changes

- **`CategorySet`**: Added volatile `_provisionalAttribute`, `attr`/`isProvisional` views, mutation guards that throw on provisional instances, `createProvisionalCategorySet` factory. Removed the `onInvalidated` callback on `types.reference(Attribute)`, the volatile `handleAttributeInvalidated`, and the `onAttributeInvalidated` action — cleanup is now entirely owned by `SharedCaseMetadata`.
- **`SharedCaseMetadata`**: Added `provisionalCategories` volatile map, pure-view `getCategorySet`, `ensureProvisionalCategorySet`, `ensurePersistentCategorySet`. Removed `addCategorySet`. Added a unified per-attribute cleanup pipeline: an `afterAttach` reaction over `data.attributes` installs one `addDisposer(attribute, ...)` per attribute; the disposer body (`_cleanupAttribute`) removes whichever CategorySet is keyed by that attribute. Removed the free-function `getCategorySet(metadata, attrId)` wrapper in favor of `metadata.getCategorySet(attrId)` (review feedback).
- **`DataConfigurationModel`**: Added `ensurePersistentCategorySetForRole(role)` action, `afterAttach` reaction to eagerly create provisionals for categorical roles, routed `storeAllCurrentColorsForAttrRole` and `swapCategoriesForAttrRole` through the new helper. Updated three call sites to use `metadata.getCategorySet(...)` directly.
- **`use-sub-axis.ts`**: Axis category drag-reorder now promotes via `ensurePersistentCategorySetForRole` instead of calling `dI.categorySet?.move(...)` directly.
- **Regression tests**: `createEditableLayer` produces exactly one history entry. Rehydrated persistent entries are cleaned up when the attribute is later removed. `applyPatch`-inserted persistent entries are cleaned up too.

### Critical invariant
Cleanup on attribute destruction fires synchronously inside the same top-level action that destroyed the attribute. This is verified by middleware tests that assert `topLevelActions === ["removeAttribute"]` for both provisional and persistent entries. The cleanup disposer must not be converted to a MobX reaction — reactions fire after the enclosing action, producing the stray history entry this PR exists to fix.

## Test plan
- [x] All affected Jest suites pass (41 tests in the four impacted suites; no regressions in the broader repo)
- [x] `npm run check:types` clean (project files)
- [x] `npm run lint` clean
- [x] Middleware test verifies cleanup fires inside `removeAttribute` (no stray top-level action) for both provisional and persistent paths
- [x] Regression test locks in single history entry for `createEditableLayer`
- [x] Regression test: rehydrated persistent entry cleaned up when its attribute is later removed
- [x] Regression test: patch-inserted persistent entry cleaned up when its attribute is later removed
- [ ] Manual: add graph tile, click "Add manual points", verify one history entry
- [ ] Manual: assign categorical attribute to axis, drag-reorder labels, verify one entry per drag, undo works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>