### PR TITLE
feat(ada): rename 'Key Indicators' to 'Your work shows' in AI respons…

### DIFF
--- a/functions-v2/src/categorize-docs.ts
+++ b/functions-v2/src/categorize-docs.ts
@@ -37,7 +37,7 @@ fs.readdir(sourceDirectory, async (_error, files) => {
     console.error(_error);
     return;
   }
-  console.log("File,Category,Key Indicators,Discussion,Prompt Tokens,Completion Tokens");
+  console.log("File,Category,Your Work Shows,Discussion,Prompt Tokens,Completion Tokens");
   for (const file of files) {
     const fullFile = `${sourceDirectory}/${file}`;
     const response = await categorizeDocument(fullFile, apiKey);

--- a/functions-v2/src/on-analysis-document-imaged.ts
+++ b/functions-v2/src/on-analysis-document-imaged.ts
@@ -76,7 +76,7 @@ export const onAnalysisDocumentImaged =
         }
         tags = reply.parsed.category && reply.parsed.category !== "unknown" ? [reply.parsed.category] : [];
         const indicators = reply.parsed.keyIndicators && reply.parsed.keyIndicators.length ?
-          ` Key Indicators: ${reply.parsed.keyIndicators.join(", ")}` : "";
+          ` Your work shows: ${reply.parsed.keyIndicators.join(", ")}` : "";
         message = (reply.parsed.discussion || "") + indicators;
         fullResponse = JSON.stringify(completion);
       } else {

--- a/functions-v2/test/on-analysis-document-imaged.test.ts
+++ b/functions-v2/test/on-analysis-document-imaged.test.ts
@@ -309,7 +309,7 @@ describe("functions", () => {
         expect(snapshot.size).toBe(1);
         const comment = snapshot.docs[0].data();
         expect(comment).toEqual({
-          content: "Discussion. Key Indicators: key1, key2",
+          content: "Discussion. Your work shows: key1, key2",
           tags: ["category"],
           createdAt: expect.any(Object),
           name: "Ada Insight",
@@ -382,7 +382,7 @@ describe("functions", () => {
         expect(snapshot.size).toBe(1);
         const comment = snapshot.docs[0].data();
         expect(comment).toEqual({
-          content: "Discussion. Key Indicators: key1, key2",
+          content: "Discussion. Your work shows: key1, key2",
           tags: ["category"],
           createdAt: expect.any(Object),
           name: "Ada Insight",

--- a/src/authoring/components/workspace/ai-settings.tsx
+++ b/src/authoring/components/workspace/ai-settings.tsx
@@ -355,7 +355,7 @@ const AISettings: React.FC = () => {
           <tr>
             <td className="left">
               <div className="stacked">
-                <label htmlFor="keyIndicatorsPrompt">Key Indicators Prompt</label>
+                <label htmlFor="keyIndicatorsPrompt">Your Work Shows Prompt</label>
                 <textarea
                   id="keyIndicatorsPrompt"
                   defaultValue={settings.aiPrompt.keyIndicatorsPrompt}


### PR DESCRIPTION
CLUE-497

Student-facing: the AI response prefix changes from 'Key Indicators:' to 'Your work shows:' to use simpler language.

Authoring: the label in the AI Settings form changes from 'Key Indicators Prompt' to 'Your Work Shows Prompt'.

The underlying field name (keyIndicatorsPrompt) is unchanged to avoid a data migration.