### PR TITLE
Clue 498 seismic cleanup

### DIFF
--- a/src/models/stores/seismic-query-service.ts
+++ b/src/models/stores/seismic-query-service.ts
@@ -90,6 +90,14 @@ export class SeismicQueryService {
     this.loadData(callerId, params, level);
   }
 
+  /**
+   * Returns the metadata for the station at the specified time.
+   */
+  async getMetadata({ network, station, channel }: StationData, timeSec: number): Promise<ChannelMetadata | undefined> {
+    const allMetadata = await this.getAllMetadata(network, station);
+    return this.getMetadataForChannel(allMetadata, channel, timeSec);
+  }
+
   // --- Private helpers (general) ---
 
   private addNull(time: number, timestamps: NullableNumberArray, v1: NullableNumberArray, v2?: NullableNumberArray) {
@@ -179,7 +187,7 @@ export class SeismicQueryService {
 
     if (toFetch.length === 0) return;
 
-    const metadata = raw ? await this.getMetadata(stationData.network, stationData.station) : [];
+    const metadata = raw ? await this.getAllMetadata(stationData.network, stationData.station) : [];
 
     // Fetch missing tiles
     for (const index of toFetch) {
@@ -359,7 +367,7 @@ export class SeismicQueryService {
     return { level: "raw", data: [timestamps, values], amplitudeRange: autoRange, isLoading };
   }
 
-  private async getMetadata(network: string, station: string): Promise<ChannelMetadata[]> {
+  private async getAllMetadata(network: string, station: string): Promise<ChannelMetadata[]> {
     const metaKey = `${network}_${station}`;
     let metadata = this.metadataCache.get(metaKey);
     if (!metadata) {
@@ -369,16 +377,15 @@ export class SeismicQueryService {
     return metadata;
   }
 
-  private findSensitivity(metadata: ChannelMetadata[], channel: string, timeSec: number): number {
+  private getMetadataForChannel(
+    metadata: ChannelMetadata[], channel: string, timeSec: number
+  ): ChannelMetadata | undefined {
     const matching = metadata.filter(m => m.channel === channel);
-    if (matching.length === 0) return 1;
     for (const m of matching) {
       const start = new Date(m.startTime).getTime() / 1000;
       const end = m.endTime === "" ? Infinity : new Date(m.endTime).getTime() / 1000;
-      if (timeSec >= start && timeSec < end) return m.scale;
+      if (timeSec >= start && timeSec < end) return m;
     }
-    // No time match — use the latest entry
-    return matching[matching.length - 1].scale;
   }
 
   private async fetchAndParseRaw(
@@ -397,7 +404,7 @@ export class SeismicQueryService {
     if (seismogram && seismogram.segments) {
       for (const seg of seismogram.segments) {
         const segStartTime = seg.startTime.toSeconds();
-        const sensitivity = this.findSensitivity(metadata, channel, segStartTime);
+        const sensitivity = this.getMetadataForChannel(metadata, channel, segStartTime)?.scale ?? 1;
         const sampleRate = seg.sampleRate;
         const y = seg.y;
         const samples = new Float64Array(y.length);

--- a/src/models/stores/seismic-query-service.ts
+++ b/src/models/stores/seismic-query-service.ts
@@ -386,6 +386,7 @@ export class SeismicQueryService {
       const end = m.endTime === "" ? Infinity : new Date(m.endTime).getTime() / 1000;
       if (timeSec >= start && timeSec < end) return m;
     }
+    return matching[matching.length - 1];
   }
 
   private async fetchAndParseRaw(

--- a/src/models/stores/seismic-query-service.ts
+++ b/src/models/stores/seismic-query-service.ts
@@ -386,6 +386,7 @@ export class SeismicQueryService {
       const end = m.endTime === "" ? Infinity : new Date(m.endTime).getTime() / 1000;
       if (timeSec >= start && timeSec < end) return m;
     }
+    // When no time matches, return the last metadata (or undefined if there aren't any)
     return matching[matching.length - 1];
   }
 

--- a/src/plugins/shared-seismogram/station-model.test.ts
+++ b/src/plugins/shared-seismogram/station-model.test.ts
@@ -32,6 +32,45 @@ describe("StationModel", () => {
     });
     expect(station.id).toBe("AK_DDM_01_HNZ");
   });
+
+  describe("equals", () => {
+    const base = { network: "AK", station: "K204", location: "", channel: "HNZ", label: "Anchorage Airport" };
+
+    it("returns true for an identical config", () => {
+      const station = StationModel.create(base);
+      expect(station.equals(base)).toBe(true);
+    });
+
+    it("returns true when config omits optional fields that default to empty", () => {
+      const station = StationModel.create({ network: "AK", station: "K204", channel: "HNZ" });
+      expect(station.equals({ network: "AK", station: "K204", channel: "HNZ" })).toBe(true);
+    });
+
+    it("returns false when network differs", () => {
+      const station = StationModel.create(base);
+      expect(station.equals({ ...base, network: "US" })).toBe(false);
+    });
+
+    it("returns false when station differs", () => {
+      const station = StationModel.create(base);
+      expect(station.equals({ ...base, station: "DDM" })).toBe(false);
+    });
+
+    it("returns false when location differs", () => {
+      const station = StationModel.create(base);
+      expect(station.equals({ ...base, location: "01" })).toBe(false);
+    });
+
+    it("returns false when channel differs", () => {
+      const station = StationModel.create(base);
+      expect(station.equals({ ...base, channel: "BHZ" })).toBe(false);
+    });
+
+    it("returns false when label differs", () => {
+      const station = StationModel.create(base);
+      expect(station.equals({ ...base, label: "Different Label" })).toBe(false);
+    });
+  });
 });
 
 describe("stationId", () => {

--- a/src/plugins/shared-seismogram/station-model.ts
+++ b/src/plugins/shared-seismogram/station-model.ts
@@ -28,8 +28,8 @@ export const StationModel = types
     },
     equals(station: StationConfig) {
       return self.network === station.network && self.station === station.station
-        && self.location === station.location && self.channel === station.network
-        && self.label === station.label;
+        && self.location === (station.location ?? "") && self.channel === station.channel
+        && self.label === (station.label ?? "");
     }
   }));
 

--- a/src/plugins/shared-seismogram/station-model.ts
+++ b/src/plugins/shared-seismogram/station-model.ts
@@ -26,6 +26,11 @@ export const StationModel = types
     get id() {
       return stationId(self);
     },
+    equals(station: StationConfig) {
+      return self.network === station.network && self.station === station.station
+        && self.location === station.location && self.channel === station.network
+        && self.label === station.label;
+    }
   }));
 
 export interface StationModelType extends Instance<typeof StationModel> {}

--- a/src/plugins/timeline/components/timeline.scss
+++ b/src/plugins/timeline/components/timeline.scss
@@ -5,6 +5,13 @@
   .waveform-wrapper {
     margin-top: 24px;
     position: relative;
+
+    .scale-unit {
+      left: -24px;
+      position: absolute;
+      top: 50%;
+      transform: rotate(270deg) translateX(50%);
+    }
   }
 
   .waveform {

--- a/src/plugins/timeline/components/timeline.tsx
+++ b/src/plugins/timeline/components/timeline.tsx
@@ -44,8 +44,7 @@ export const Timeline = observer(function Timeline() {
   useEffect(() => {
     if (!stationData) return;
 
-    const { network, station, channel } = stationData;
-    seismicQueryService.getMetadata({ network, station, channel }, viewStartSeconds).then(metadata => {
+    seismicQueryService.getMetadata(stationData, viewStartSeconds).then(metadata => {
       setScaleUnits(metadata?.scaleUnits ?? "");
     });
   }, [seismicQueryService, stationData, viewStartSeconds]);

--- a/src/plugins/timeline/components/timeline.tsx
+++ b/src/plugins/timeline/components/timeline.tsx
@@ -17,7 +17,7 @@ export const Timeline = observer(function Timeline() {
 
   const { sharedSeismogram, dataStartTime, dataEndTime, viewStartTime, viewEndTime } = content;
   const stationData = sharedSeismogram?.station;
-  const viewStartSeconds = (viewStartTime?.toMillis() ?? 0) * 1000;
+  const viewStartSeconds = (viewStartTime?.toSeconds() ?? 0);
 
   // Initialize view range when data becomes available,
   // and clamp view to stay within bounds if data range changes.

--- a/src/plugins/timeline/components/timeline.tsx
+++ b/src/plugins/timeline/components/timeline.tsx
@@ -1,6 +1,7 @@
 import { DateTime } from "luxon";
 import { observer } from "mobx-react-lite";
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
+import { useStores } from "../../../hooks/use-stores";
 import { isValidDateTime } from "../../../utilities/luxon-utils";
 import { WaveformPanel } from "../../shared-seismogram/components/waveform-panel";
 import { useTimelineContent } from "../hooks/use-timeline-content";
@@ -10,9 +11,13 @@ import { TimelineScrollbar } from "./timeline-scrollbar";
 import "./timeline.scss";
 
 export const Timeline = observer(function Timeline() {
+  const { seismicQueryService } = useStores();
   const content = useTimelineContent();
+  const [scaleUnits, setScaleUnits] = useState("");
 
   const { sharedSeismogram, dataStartTime, dataEndTime, viewStartTime, viewEndTime } = content;
+  const stationData = sharedSeismogram?.station;
+  const viewStartSeconds = (viewStartTime?.toMillis() ?? 0) * 1000;
 
   // Initialize view range when data becomes available,
   // and clamp view to stay within bounds if data range changes.
@@ -35,11 +40,22 @@ export const Timeline = observer(function Timeline() {
     }
   }, [content, dataStartTime, dataEndTime]);
 
+  // Find scale units from station metadata
+  useEffect(() => {
+    if (!stationData) return;
+
+    const { network, station, channel } = stationData;
+    seismicQueryService.getMetadata({ network, station, channel }, viewStartSeconds).then(metadata => {
+      setScaleUnits(metadata?.scaleUnits ?? "");
+    });
+  }, [seismicQueryService, stationData, viewStartSeconds]);
+
   return (
     <div className="timeline-area">
       {sharedSeismogram && isValidDateTime(viewStartTime) && isValidDateTime(viewEndTime) ? (
         <>
           <div className="waveform-wrapper">
+            <div className="scale-unit">{scaleUnits}</div>
             <WaveformPanel
               mode="timeline"
               sharedSeismogram={sharedSeismogram}

--- a/src/plugins/timeline/components/timeline.tsx
+++ b/src/plugins/timeline/components/timeline.tsx
@@ -53,7 +53,7 @@ export const Timeline = observer(function Timeline() {
               <div>{viewStartTime.toUTC().toLocaleString()}</div>
               <div>{viewStartTime.toUTC().toLocaleString(DateTime.TIME_WITH_SECONDS)}</div>
             </div>
-            <div className="range-duration">{content.viewRangeSeconds} seconds</div>
+            <div className="range-duration">{content.viewRangeDurationText ?? ""}</div>
             <div className="range-date range-end">
               <div>{viewEndTime.toUTC().toLocaleString()}</div>
               <div>{viewEndTime.toUTC().toLocaleString(DateTime.TIME_WITH_SECONDS)}</div>

--- a/src/plugins/timeline/models/timeline-content.ts
+++ b/src/plugins/timeline/models/timeline-content.ts
@@ -1,5 +1,5 @@
 import { types, Instance } from "mobx-state-tree";
-import { DateTime } from "luxon";
+import { DateTime, Duration } from "luxon";
 import { ITileContentModel, TileContentModel } from "../../../models/tiles/tile-content";
 import { getSharedModelManager } from "../../../models/tiles/tile-environment";
 import { isValidDateTime } from "../../../utilities/luxon-utils";
@@ -114,6 +114,13 @@ export const TimelineContentModel = TileContentModel
     get dataRangeSeconds() {
       if (!self.dataStartTime || !self.dataEndTime) return undefined;
       return self.dataEndTime.diff(self.dataStartTime, "seconds").seconds;
+    },
+    get viewRangeDurationText() {
+      const totalSeconds = self.viewRangeSeconds;
+      if (totalSeconds == null) return undefined;
+      return Duration.fromObject({ seconds: totalSeconds })
+        .shiftTo("weeks", "days", "hours", "minutes", "seconds")
+        .toHuman({ showZeros: false });
     },
     get canZoomIn() {
       const range = self.viewRangeSeconds;

--- a/src/plugins/wave-runner/components/status-and-output.tsx
+++ b/src/plugins/wave-runner/components/status-and-output.tsx
@@ -43,7 +43,7 @@ export const StatusAndOutput: React.FC = observer(function StatusAndOutput() {
         </div>
         <div className="status-count">
           <label className="status-count-label">Event Categories</label>
-          <div className="status-count-box"/>
+          <div className="status-count-box">-</div>
         </div>
       </div>
     </div>

--- a/src/plugins/wave-runner/components/status-and-output.tsx
+++ b/src/plugins/wave-runner/components/status-and-output.tsx
@@ -38,7 +38,7 @@ export const StatusAndOutput: React.FC = observer(function StatusAndOutput() {
         <div className="status-count">
           <label className="status-count-label">Events Identified</label>
           <div className="status-count-box">
-            {isRunning || eventsDataSet ? model.eventsFound ?? "" : "-"}
+            {model.eventsFound ?? "-"}
           </div>
         </div>
         <div className="status-count">

--- a/src/plugins/wave-runner/components/status-and-output.tsx
+++ b/src/plugins/wave-runner/components/status-and-output.tsx
@@ -6,7 +6,9 @@ import "./status-and-output.scss";
 
 export const StatusAndOutput: React.FC = observer(function StatusAndOutput() {
   const model = useWaveRunnerContent();
-  const { hasStationData, sharedSeismogram, startDateISO, endDateISO } = model;
+  const {
+    hasStationData, sharedSeismogram, startDateISO, endDateISO, isRunning, eventsDataSet, runError
+  } = model;
 
   return (
     <div className="section status-and-output">
@@ -22,24 +24,26 @@ export const StatusAndOutput: React.FC = observer(function StatusAndOutput() {
         )}
       </div>
       <div className="download-status-container">
-        {model.isRunning && <div>Running model...</div>}
-        {model.runError && <div className="waveform-error">{model.runError}</div>}
+        {isRunning && <div>Running model...</div>}
+        {runError && <div className="waveform-error">{runError}</div>}
       </div>
       <div className="estimated-time">
-        {model.isRunning
+        {isRunning
           ? `Processing day ${model.chunksProcessed + 1} of ${model.chunksTotal || "?"}...`
-          : model.eventsFound
+          : eventsDataSet
             ? "Run complete."
             : "Estimated time to complete run:"}
       </div>
       <div className="status-counts-row">
         <div className="status-count">
           <label className="status-count-label">Events Identified</label>
-          <div className="status-count-box">{model.eventsFound ?? ""}</div>
+          <div className="status-count-box">
+            {isRunning || eventsDataSet ? model.eventsFound ?? "" : "-"}
+          </div>
         </div>
         <div className="status-count">
           <label className="status-count-label">Event Categories</label>
-          <div className="status-count-box" />
+          <div className="status-count-box"/>
         </div>
       </div>
     </div>

--- a/src/plugins/wave-runner/models/wave-runner-content.test.ts
+++ b/src/plugins/wave-runner/models/wave-runner-content.test.ts
@@ -1,4 +1,18 @@
-import { WaveRunnerContentModel, DEFAULT_MODELS } from "./wave-runner-content";
+import { DocumentContentModel } from "../../../models/document/document-content";
+import { createDocumentModel } from "../../../models/document/document";
+import { ProblemDocument } from "../../../models/document/document-types";
+import "../../../models/shared/shared-data-set-registration";
+import "../../shared-seismogram/shared-seismogram-registration";
+import { registerTileContentInfo } from "../../../models/tiles/tile-content-info";
+import { kWaveRunnerTileType } from "../wave-runner-types";
+import { WaveRunnerContentModel, DEFAULT_MODELS, defaultWaveRunnerContent } from "./wave-runner-content";
+
+registerTileContentInfo({
+  type: kWaveRunnerTileType,
+  displayName: "Wave Runner",
+  modelClass: WaveRunnerContentModel,
+  defaultContent: defaultWaveRunnerContent,
+});
 
 const mockCompactMetadata = {
   $schema: "https://collaborative-learning.concord.org/schemas/seismic-model/v1.json",
@@ -16,6 +30,23 @@ describe("WaveRunnerContent", () => {
     jest.restoreAllMocks();
   });
 
+  function setupTileInDocument() {
+    const docContent = DocumentContentModel.create({
+      tileMap: {
+        "tile1": {
+          id: "tile1",
+          content: { type: kWaveRunnerTileType },
+        }
+      }
+    });
+    const docModel = createDocumentModel({
+      uid: "1", type: ProblemDocument, key: "test", content: docContent as any
+    });
+    docModel.treeMonitor!.enableMonitoring();
+
+    return docContent.tileMap.get("tile1")!.content as any;
+  }
+
   it("is always user resizable", () => {
     const content = WaveRunnerContentModel.create();
     expect(content.isUserResizable).toBe(true);
@@ -28,11 +59,14 @@ describe("WaveRunnerContent", () => {
   });
 
   it("allows setting start and end dates", () => {
-    const content = WaveRunnerContentModel.create();
+    const content = setupTileInDocument();
+    content.getOrCreateEventsDataSet();
+    expect(content.eventsDataSet).toBeTruthy();
     content.setStartDate("2026-02-01");
     content.setEndDate("2026-02-03");
     expect(content.startDate).toBe("2026-02-01");
     expect(content.endDate).toBe("2026-02-03");
+    expect(content.eventsDataSet).toBeFalsy();
   });
 
   it("starts with no station", () => {
@@ -52,15 +86,18 @@ describe("WaveRunnerContent", () => {
   });
 
   it("replaces station when setStation is called again", () => {
-    const content = WaveRunnerContentModel.create();
+    const content = setupTileInDocument();
     content.setStation({
       network: "AK", station: "K204", location: "", channel: "HNZ", label: "Anchorage Airport"
     });
+    content.getOrCreateEventsDataSet();
+    expect(content.eventsDataSet).toBeTruthy();
     content.setStation({
       network: "AK", station: "DDM", location: "01", channel: "HNZ", label: "Dexter Display Mine"
     });
     expect(content.station?.station).toBe("DDM");
     expect(content.station?.location).toBe("01");
+    expect(content.eventsDataSet).toBeFalsy();
   });
 
   it("has no model selected initially", () => {

--- a/src/plugins/wave-runner/models/wave-runner-content.ts
+++ b/src/plugins/wave-runner/models/wave-runner-content.ts
@@ -61,7 +61,6 @@ export const WaveRunnerContentModel = TileContentModel
     isRunning: false,
     chunksProcessed: 0,
     chunksTotal: 0,
-    eventsFound: 0,
     runError: null as string | null,
     detectedEvents: [] as SeismicEvent[],
     selectedModelMetadata: null as ModelMetadata | null,
@@ -92,6 +91,9 @@ export const WaveRunnerContentModel = TileContentModel
     get hasStationData() {
       return !!self.sharedSeismogram?.station;
     },
+    get eventsFound() {
+      return self.isRunning ? self.detectedEvents.length : self.eventsDataSet?.dataSet.cases.length;
+    }
   }))
   .actions(self => ({
     async loadData() {
@@ -118,9 +120,6 @@ export const WaveRunnerContentModel = TileContentModel
 
       const smm = getSharedModelManager(self);
       if (smm?.isReady) smm.removeTileSharedModel(self, self.eventsDataSet);
-
-      self.eventsFound = 0;
-      self.detectedEvents = [];
     }
   }))
   .actions(self => ({
@@ -149,9 +148,8 @@ export const WaveRunnerContentModel = TileContentModel
       self.chunksProcessed = done;
       self.chunksTotal = total;
     },
-    addEvents(events: SeismicEvent[]) {
+    addDetectedEvents(events: SeismicEvent[]) {
       self.detectedEvents = [...self.detectedEvents, ...events];
-      self.eventsFound = self.detectedEvents.length;
     },
     getOrCreateEventsDataSet(): SharedDataSetType | undefined {
       if (self.eventsDataSet) return self.eventsDataSet;
@@ -159,21 +157,12 @@ export const WaveRunnerContentModel = TileContentModel
       const smm = getSharedModelManager(self);
       if (!smm?.isReady) return undefined;
 
-      const modelLabel = DEFAULT_MODELS.find(m => m.metadataUrl === self.selectedModelUrl)?.label ?? "";
-
       const dataSet = DataSet.create();
       addAttributeToDataSet(dataSet, { name: "eventType" });
       addAttributeToDataSet(dataSet, { name: "windowStart" });
       addAttributeToDataSet(dataSet, { name: "windowEnd" });
       addAttributeToDataSet(dataSet, { name: "confidence" });
       addAttributeToDataSet(dataSet, { name: "modelLabel" });
-      addCasesToDataSet(dataSet, self.detectedEvents.map(evt => ({
-        windowStart: new Date(evt.windowStart).toISOString(),
-        windowEnd: new Date(evt.windowEnd).toISOString(),
-        eventType: evt.eventType,
-        confidence: evt.confidence,
-        modelLabel,
-      })));
 
       const sharedDataSet = SharedDataSet.create({ dataSet });
       smm.addTileSharedModel(self, sharedDataSet);
@@ -294,7 +283,7 @@ export const WaveRunnerContentModel = TileContentModel
             {
               onProgress: () => {},
               onEvents: (events: SeismicEvent[]) => {
-                self.addEvents(events);
+                self.addDetectedEvents(events);
               },
             },
             detectionThreshold,
@@ -302,7 +291,19 @@ export const WaveRunnerContentModel = TileContentModel
           self.updateChunkProgress(day + 1, totalDays);
         }
 
-        self.getOrCreateEventsDataSet();
+        const dataSet = self.getOrCreateEventsDataSet()?.dataSet;
+        if (dataSet) {
+          const modelLabel = DEFAULT_MODELS.find(m => m.metadataUrl === self.selectedModelUrl)?.label ?? "";
+          addCasesToDataSet(dataSet, self.detectedEvents.map(evt => ({
+            windowStart: new Date(evt.windowStart).toISOString(),
+            windowEnd: new Date(evt.windowEnd).toISOString(),
+            eventType: evt.eventType,
+            confidence: evt.confidence,
+            modelLabel,
+          })));
+        }
+
+        self.detectedEvents = [];
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : String(err);
         self.runError = `Error running model: ${message}`;

--- a/src/plugins/wave-runner/models/wave-runner-content.ts
+++ b/src/plugins/wave-runner/models/wave-runner-content.ts
@@ -139,7 +139,7 @@ export const WaveRunnerContentModel = TileContentModel
       self.clearEventsDataSet();
     },
     setStation(station: StationSnapshot) {
-      if (!self.station?.equals(station)) return;
+      if (self.station?.equals(station)) return;
 
       self.station = cast(station);
       self.loadData();

--- a/src/plugins/wave-runner/models/wave-runner-content.ts
+++ b/src/plugins/wave-runner/models/wave-runner-content.ts
@@ -64,7 +64,6 @@ export const WaveRunnerContentModel = TileContentModel
     eventsFound: 0,
     runError: null as string | null,
     detectedEvents: [] as SeismicEvent[],
-    cachedEventsDataSet: undefined as SharedDataSetType | undefined,
     selectedModelMetadata: null as ModelMetadata | null,
     modelLoadError: null as string | null,
   }))
@@ -82,6 +81,11 @@ export const WaveRunnerContentModel = TileContentModel
     },
     get endDateISO() {
       return DateTime.fromISO(`${self.endDate}T00:00:00Z`, { zone: "utc" });
+    },
+    get eventsDataSet(): SharedDataSetType | undefined {
+      const smm = getSharedModelManager(self);
+      if (!smm?.isReady) return;
+      return smm.getTileSharedModelsByType(self, SharedDataSet)[0] as SharedDataSetType | undefined;
     }
   }))
   .views(self => ({
@@ -108,20 +112,38 @@ export const WaveRunnerContentModel = TileContentModel
         `${self.startDate}T00:00:00Z`,
         `${self.endDate}T00:00:00Z`
       );
+    },
+    clearEventsDataSet() {
+      if (!self.eventsDataSet) return;
+
+      const smm = getSharedModelManager(self);
+      if (smm?.isReady) smm.removeTileSharedModel(self, self.eventsDataSet);
+
+      self.eventsFound = 0;
+      self.detectedEvents = [];
     }
   }))
   .actions(self => ({
     setStartDate(date: string) {
+      if (self.startDate === date) return;
+
       self.startDate = date;
       self.loadData();
+      self.clearEventsDataSet();
     },
     setEndDate(date: string) {
+      if (self.endDate === date) return;
+
       self.endDate = date;
       self.loadData();
+      self.clearEventsDataSet();
     },
     setStation(station: StationSnapshot) {
+      if (!self.station?.equals(station)) return;
+
       self.station = cast(station);
       self.loadData();
+      self.clearEventsDataSet();
     },
     updateChunkProgress(done: number, total: number) {
       self.chunksProcessed = done;
@@ -131,12 +153,8 @@ export const WaveRunnerContentModel = TileContentModel
       self.detectedEvents = [...self.detectedEvents, ...events];
       self.eventsFound = self.detectedEvents.length;
     },
-    clearCachedEventsDataSet() {
-      self.cachedEventsDataSet = undefined;
-    },
     getOrCreateEventsDataSet(): SharedDataSetType | undefined {
-      if (self.detectedEvents.length === 0) return undefined;
-      if (self.cachedEventsDataSet) return self.cachedEventsDataSet;
+      if (self.eventsDataSet) return self.eventsDataSet;
 
       const smm = getSharedModelManager(self);
       if (!smm?.isReady) return undefined;
@@ -159,7 +177,6 @@ export const WaveRunnerContentModel = TileContentModel
 
       const sharedDataSet = SharedDataSet.create({ dataSet });
       smm.addTileSharedModel(self, sharedDataSet);
-      self.cachedEventsDataSet = sharedDataSet;
       return sharedDataSet;
     },
     ensureModelMetadata: flow(function* (metadataUrl: string) {
@@ -169,6 +186,7 @@ export const WaveRunnerContentModel = TileContentModel
       self.selectedModelUrl = metadataUrl;
       self.selectedModelMetadata = null;
       self.modelLoadError = null;
+      self.clearEventsDataSet();
 
       // Placeholder model — use hardcoded metadata, no fetch needed
       if (metadataUrl === PLACEHOLDER_MODEL_URL) {
@@ -217,11 +235,9 @@ export const WaveRunnerContentModel = TileContentModel
         return;
       }
 
-      self.isRunning = true;
+      self.clearEventsDataSet();
       self.runError = null;
-      self.eventsFound = 0;
-      self.detectedEvents = [];
-      self.cachedEventsDataSet = undefined;
+      self.isRunning = true;
 
       const metadata = self.selectedModelMetadata;
       const { network, station, location, channel } = self.station;

--- a/src/plugins/wave-runner/wave-runner-toolbar.tsx
+++ b/src/plugins/wave-runner/wave-runner-toolbar.tsx
@@ -62,7 +62,7 @@ const TimelineButton = observer(function TimelineButton({ name }: IToolbarButton
 
   function handleClick() {
     if (!tileModel || !addTilesContext) return;
-    const sharedDataSet = content.getOrCreateEventsDataSet();
+    const sharedDataSet = content.eventsDataSet;
     const sharedSeismogram = content.sharedSeismogram;
     if (!sharedSeismogram?.station) return;
     // Create a copy so the Timeline keeps its data when Wave Runner reloads.

--- a/src/plugins/wave-runner/wave-runner-toolbar.tsx
+++ b/src/plugins/wave-runner/wave-runner-toolbar.tsx
@@ -30,7 +30,7 @@ const LoadDataButton = observer(function LoadDataButton({ name }: IToolbarButton
 
 const PlayButton = observer(function PlayButton({ name }: IToolbarButtonComponentProps) {
   const content = useWaveRunnerContent();
-  const disabled = content.isRunning || !content.selectedModelUrl;
+  const disabled = content.isRunning || !content.selectedModelUrl || !!content.eventsDataSet;
   return (
     <TileToolbarButton name={name} title="Run Model" onClick={() => content.runModel()} disabled={disabled}>
       <RunIcon/>


### PR DESCRIPTION
Jira story: https://concord-consortium.atlassian.net/browse/CLUE-498

This PR makes three changes:
- The wave runner tile now clears its events dataset whenever any parameters change.
  - The model now uses its shared dataset much more for managing events and some redundant volatile state has been removed.
  - The run button is disabled after the model has run until a parameter changes.
  - When the model clears its dataset, it now just severs the tile from the shared dataset. Any other tiles using that dataset will be unaffected.
- Adds a unit label to the y axis of the timeline tile.
  - The unit is fetched from station metadata via a new seismic query service. The unit at the start of the view is used, in case there are multiple units at different points in time.
- The view duration is now written in a much more human friendly way, not just a count of seconds.