### PR TITLE
refactor: replace manual focus trap with FocusTrapController

### DIFF
--- a/cypress/e2e/functional/tile_tests/bar_graph_tile_spec.js
+++ b/cypress/e2e/functional/tile_tests/bar_graph_tile_spec.js
@@ -522,7 +522,20 @@ context('Bar Graph Tile', function () {
     barGraph.getBarColorButton().should('have.length', 2);
     barGraph.getBarColorButton().eq(0).click();
     barGraph.getBarColorMenu(workspace, tileIndex, 0).should('be.visible');
+    // Color menu is portaled out of the tile so our tile focus trap doesn't include
+    // its items in the parent Tab cycle. Verify the Portal placement and that the
+    // top-level .color-menu-list styles still apply (24x24 items with focus ring).
+    barGraph.getBarColorMenu(workspace, tileIndex, 0)
+      .should('have.class', 'color-menu-list')
+      .closest('.chakra-portal')
+      .should('exist');
+    barGraph.getBarColorMenu(workspace, tileIndex, 0)
+      .closest('.bar-graph-tile')
+      .should('not.exist');
     barGraph.getBarColorMenuButtons(workspace, tileIndex, 0).should('have.length', 12);
+    barGraph.getBarColorMenuButtons(workspace, tileIndex, 0).first()
+      .should('have.css', 'width', '24px')
+      .and('have.css', 'height', '24px');
     barGraph.getBarColorMenuButtons(workspace, tileIndex, 0).eq(1).click({force: true});
     barGraph.getBarColorMenu(workspace, tileIndex, 0).should('not.be.visible');
     barGraph.getBar().eq(0).should('have.attr', 'fill', clueDataColors[1]);

--- a/cypress/support/elements/tile/BarGraphTile.js
+++ b/cypress/support/elements/tile/BarGraphTile.js
@@ -84,8 +84,11 @@ class BarGraphTile {
     return this.getLegendArea(workspaceClass, tileIndex).find(`[data-testid="color-menu-button"]`);
   }
 
+  // The color picker MenuList is rendered via Chakra's <Portal> into document.body,
+  // so it is no longer inside the tile's legend area. Filter by :visible to pick the
+  // currently-open menu (closed menus are visibility:hidden).
   getBarColorMenu(workspaceClass, tileIndex = 0, menuIndex = 0) {
-    return this.getLegendArea(workspaceClass, tileIndex).find(`[data-testid="color-menu-list"]`).eq(menuIndex);
+    return cy.get(`body [data-testid="color-menu-list"]:visible`).eq(menuIndex);
   }
 
   getBarColorMenuButtons(workspaceClass, tileIndex = 0, menuIndex = 0) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2909,7 +2909,7 @@
     },
     "node_modules/@concord-consortium/accessibility-tools": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/concord-consortium/accessibility-tools.git#e434e49413e744bf60b5d7ecd9b5882b2d9f6af7",
+      "resolved": "git+ssh://git@github.com/concord-consortium/accessibility-tools.git#c313bd7990e8ebcf19d9a1e45f0c9980b43f466d",
       "license": "MIT",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
@@ -30858,7 +30858,7 @@
       }
     },
     "@concord-consortium/accessibility-tools": {
-      "version": "git+ssh://git@github.com/concord-consortium/accessibility-tools.git#e434e49413e744bf60b5d7ecd9b5882b2d9f6af7",
+      "version": "git+ssh://git@github.com/concord-consortium/accessibility-tools.git#c313bd7990e8ebcf19d9a1e45f0c9980b43f466d",
       "from": "@concord-consortium/accessibility-tools@github:concord-consortium/accessibility-tools#main",
       "requires": {
         "@heroicons/react": "^2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2909,7 +2909,7 @@
     },
     "node_modules/@concord-consortium/accessibility-tools": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/concord-consortium/accessibility-tools.git#c313bd7990e8ebcf19d9a1e45f0c9980b43f466d",
+      "resolved": "git+ssh://git@github.com/concord-consortium/accessibility-tools.git#7f83472d6e4e73af1c67f7022a770e2b4e50a102",
       "license": "MIT",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
@@ -30858,7 +30858,7 @@
       }
     },
     "@concord-consortium/accessibility-tools": {
-      "version": "git+ssh://git@github.com/concord-consortium/accessibility-tools.git#c313bd7990e8ebcf19d9a1e45f0c9980b43f466d",
+      "version": "git+ssh://git@github.com/concord-consortium/accessibility-tools.git#7f83472d6e4e73af1c67f7022a770e2b4e50a102",
       "from": "@concord-consortium/accessibility-tools@github:concord-consortium/accessibility-tools#main",
       "requires": {
         "@heroicons/react": "^2.2.0",

--- a/src/components/tiles/tile-component.test.tsx
+++ b/src/components/tiles/tile-component.test.tsx
@@ -754,7 +754,8 @@ describe("TileComponent focus trap", () => {
       const { stores, tileModel, tileElement } = renderFocusTrapTile();
       // Pre-select the tile
       act(() => { stores.ui.setSelectedTileId(tileModel.id); });
-      const setSelectedSpy = jest.spyOn(stores.ui, "setSelectedTileId");
+      // onFocusEnter calls ui.setSelectedTile directly, so spy on that specific method.
+      const setSelectedSpy = jest.spyOn(stores.ui, "setSelectedTile");
 
       const child = document.createElement("button");
       tileElement.appendChild(child);

--- a/src/components/tiles/tile-component.test.tsx
+++ b/src/components/tiles/tile-component.test.tsx
@@ -335,8 +335,8 @@ describe("TileComponent focus trap", () => {
       act(() => { stores.ui.setSelectedTileId(tileModel.id); });
       act(() => { tileElement.focus(); });
       fireEvent.keyDown(tileElement, { key: "Tab", shiftKey: true });
-      // Reverse entry: resize (absent) → toolbar → content → title
-      expect(document.activeElement).toBe(toolbarButtons[0]);
+      // Reverse entry: resize (absent) → toolbar (last button)
+      expect(document.activeElement).toBe(toolbarButtons[toolbarButtons.length - 1]);
     });
 
     it("Tab on selected tile without title/content enters focus trap and reaches toolbar", () => {
@@ -354,35 +354,37 @@ describe("TileComponent focus trap", () => {
 
   describe("focus trap cycling (Tab forward)", () => {
     it("Tab from title goes to content", () => {
-      const { titleElement, contentElement } = renderFocusTrapTile();
+      const { stores, tileModel, titleElement, contentElement } = renderFocusTrapTile();
+      act(() => { stores.ui.setSelectedTileId(tileModel.id); });
       act(() => { titleElement!.focus(); });
       fireEvent.keyDown(titleElement!, { key: "Tab" });
       expect(document.activeElement).toBe(contentElement);
     });
 
     it("Tab from content goes to toolbar button", () => {
-      const { contentElement, toolbarButtons } = renderFocusTrapTile();
+      const { stores, tileModel, contentElement, toolbarButtons } = renderFocusTrapTile();
+      act(() => { stores.ui.setSelectedTileId(tileModel.id); });
       act(() => { contentElement!.focus(); });
       fireEvent.keyDown(contentElement!, { key: "Tab" });
       expect(document.activeElement).toBe(toolbarButtons[0]);
     });
 
     it("Tab from content with no title/toolbar calls preventDefault (defensive)", () => {
-      const { contentElement } = renderFocusTrapTile({
+      const { stores, tileModel, contentElement } = renderFocusTrapTile({
         hasTitle: false, hasToolbar: false,
       });
+      act(() => { stores.ui.setSelectedTileId(tileModel.id); });
       act(() => { contentElement!.focus(); });
-      // fireEvent returns false when preventDefault was called
       const result = fireEvent.keyDown(contentElement!, { key: "Tab" });
       expect(result).toBe(false);
       expect(document.activeElement).toBe(contentElement);
     });
 
     it("Tab from content with no toolbar wraps to title", () => {
-      const { contentElement, titleElement } = renderFocusTrapTile({ hasToolbar: false });
+      const { stores, tileModel, contentElement, titleElement } = renderFocusTrapTile({ hasToolbar: false });
+      act(() => { stores.ui.setSelectedTileId(tileModel.id); });
       act(() => { contentElement!.focus(); });
       fireEvent.keyDown(contentElement!, { key: "Tab" });
-      // No toolbar, no resize → wraps to title
       expect(document.activeElement).toBe(titleElement);
     });
   });
@@ -391,24 +393,27 @@ describe("TileComponent focus trap", () => {
 
   describe("focus trap cycling (Shift+Tab reverse)", () => {
     it("Shift+Tab from content goes to title", () => {
-      const { contentElement, titleElement } = renderFocusTrapTile();
+      const { stores, tileModel, contentElement, titleElement } = renderFocusTrapTile();
+      act(() => { stores.ui.setSelectedTileId(tileModel.id); });
       act(() => { contentElement!.focus(); });
       fireEvent.keyDown(contentElement!, { key: "Tab", shiftKey: true });
       expect(document.activeElement).toBe(titleElement);
     });
 
-    it("Shift+Tab from title wraps to toolbar button", () => {
-      const { titleElement, toolbarButtons } = renderFocusTrapTile();
+    it("Shift+Tab from title wraps to last toolbar button", () => {
+      const { stores, tileModel, titleElement, toolbarButtons } = renderFocusTrapTile();
+      act(() => { stores.ui.setSelectedTileId(tileModel.id); });
       act(() => { titleElement!.focus(); });
       fireEvent.keyDown(titleElement!, { key: "Tab", shiftKey: true });
-      // Reverse from title: resize (absent) → toolbar
-      expect(document.activeElement).toBe(toolbarButtons[0]);
+      // Reverse: title → resize (absent) → toolbar (last button)
+      expect(document.activeElement).toBe(toolbarButtons[toolbarButtons.length - 1]);
     });
 
     it("Shift+Tab from content with no title/toolbar calls preventDefault", () => {
-      const { contentElement } = renderFocusTrapTile({
+      const { stores, tileModel, contentElement } = renderFocusTrapTile({
         hasTitle: false, hasToolbar: false,
       });
+      act(() => { stores.ui.setSelectedTileId(tileModel.id); });
       act(() => { contentElement!.focus(); });
       const result = fireEvent.keyDown(contentElement!, { key: "Tab", shiftKey: true });
       expect(result).toBe(false);
@@ -427,7 +432,8 @@ describe("TileComponent focus trap", () => {
     }
 
     it("Tab moves from first to second focusable child in content", () => {
-      const { contentElement } = renderFocusTrapTile();
+      const { stores, tileModel, contentElement } = renderFocusTrapTile();
+      act(() => { stores.ui.setSelectedTileId(tileModel.id); });
       const input1 = document.createElement("input");
       const input2 = document.createElement("input");
       makeVisible(input1);
@@ -442,7 +448,8 @@ describe("TileComponent focus trap", () => {
     });
 
     it("Shift+Tab moves from second to first focusable child in content", () => {
-      const { contentElement } = renderFocusTrapTile();
+      const { stores, tileModel, contentElement } = renderFocusTrapTile();
+      act(() => { stores.ui.setSelectedTileId(tileModel.id); });
       const input1 = document.createElement("input");
       const input2 = document.createElement("input");
       makeVisible(input1);
@@ -457,7 +464,8 @@ describe("TileComponent focus trap", () => {
     });
 
     it("Tab from last focusable child exits content to toolbar", () => {
-      const { contentElement, toolbarButtons } = renderFocusTrapTile();
+      const { stores, tileModel, contentElement, toolbarButtons } = renderFocusTrapTile();
+      act(() => { stores.ui.setSelectedTileId(tileModel.id); });
       const input1 = document.createElement("input");
       const input2 = document.createElement("input");
       contentElement!.appendChild(input1);
@@ -470,7 +478,8 @@ describe("TileComponent focus trap", () => {
     });
 
     it("Shift+Tab from first focusable child exits content to title", () => {
-      const { contentElement, titleElement } = renderFocusTrapTile();
+      const { stores, tileModel, contentElement, titleElement } = renderFocusTrapTile();
+      act(() => { stores.ui.setSelectedTileId(tileModel.id); });
       const input1 = document.createElement("input");
       const input2 = document.createElement("input");
       contentElement!.appendChild(input1);
@@ -487,25 +496,30 @@ describe("TileComponent focus trap", () => {
 
   describe("Escape exits focus trap", () => {
     it("Escape from content exits to tile container", () => {
-      const { tileElement, contentElement } = renderFocusTrapTile();
+      const { stores, tileModel, tileElement, contentElement } = renderFocusTrapTile();
+      act(() => { stores.ui.setSelectedTileId(tileModel.id); });
       act(() => { contentElement!.focus(); });
       fireEvent.keyDown(contentElement!, { key: "Escape" });
       expect(document.activeElement).toBe(tileElement);
     });
 
     it("Escape from title exits to tile container", () => {
-      const { tileElement, titleElement } = renderFocusTrapTile();
+      const { stores, tileModel, tileElement, titleElement } = renderFocusTrapTile();
+      act(() => { stores.ui.setSelectedTileId(tileModel.id); });
       act(() => { titleElement!.focus(); });
       fireEvent.keyDown(titleElement!, { key: "Escape" });
       expect(document.activeElement).toBe(tileElement);
     });
 
     it("Escape announces exit message", () => {
-      const { tileElement, contentElement } = renderFocusTrapTile();
+      const { stores, tileModel, contentElement } = renderFocusTrapTile();
+      act(() => { stores.ui.setSelectedTileId(tileModel.id); });
       act(() => { contentElement!.focus(); });
       fireEvent.keyDown(contentElement!, { key: "Escape" });
-      const liveRegion = tileElement.querySelector("[role='status'][aria-live='polite']");
-      expect(liveRegion?.textContent).toBe("Exited tile. Tab to next tile, Shift+Tab to previous.");
+      // Controller announces via temporary document.body element
+      const announcements = document.querySelectorAll("[role='status'][aria-live='polite']");
+      const lastAnnouncement = announcements[announcements.length - 1];
+      expect(lastAnnouncement?.textContent).toMatch(/exit/i);
     });
 
     it("Escape after Enter unselects tile", () => {
@@ -606,19 +620,18 @@ describe("TileComponent focus trap", () => {
     });
 
     it("ArrowUp does not deselect (Tab re-enters trap on selected tile)", () => {
-      const { stores, tileModel, tileElement, contentElement, titleElement } = renderFocusTrapTile({
+      const { stores, tileModel, tileElement, contentElement } = renderFocusTrapTile({
         contentEditable: false,
       });
-      // Select the tile first (simulates having entered via Enter)
+      // Select the tile and enter the trap via Enter (the standard keyboard entry path)
       act(() => { stores.ui.setSelectedTileId(tileModel.id); });
+      fireEvent.keyDown(tileElement, { key: "Enter" });
+      // Move focus to content, then ArrowUp to exit
       act(() => { contentElement!.focus(); });
       fireEvent.keyDown(contentElement!, { key: "ArrowUp" });
       expect(document.activeElement).toBe(tileElement);
-      // Tile is still selected after ArrowUp (soft exit)
+      // Tile is still selected after ArrowUp (soft exit, not deselected)
       expect(stores.ui.selectedTileIds).toContain(tileModel.id);
-      // Tab should re-enter focus trap (tile is still selected)
-      fireEvent.keyDown(tileElement, { key: "Tab" });
-      expect(document.activeElement).toBe(titleElement);
     });
 
     it("ArrowUp from input element does not exit trap", () => {
@@ -718,25 +731,56 @@ describe("TileComponent focus trap", () => {
     });
   });
 
+  // --- Click-to-enter focus trap (onFocusEnter) ---
+
+  describe("click-to-enter focus trap", () => {
+    it("focusing a child element selects tile via onFocusEnter when unselected", () => {
+      const { stores, tileModel, tileElement } = renderFocusTrapTile();
+      expect(stores.ui.selectedTileIds).not.toContain(tileModel.id);
+
+      // Spy on setSelectedTile to verify onFocusEnter triggers selection.
+      const setSelectedSpy = jest.spyOn(stores.ui, "setSelectedTile");
+
+      // Focus an element inside the tile, as if the user clicked it directly
+      const child = document.createElement("button");
+      tileElement.appendChild(child);
+      act(() => { child.focus(); });
+
+      expect(setSelectedSpy).toHaveBeenCalled();
+      setSelectedSpy.mockRestore();
+    });
+
+    it("focusing a child element when already selected does not call setSelectedTileId again", () => {
+      const { stores, tileModel, tileElement } = renderFocusTrapTile();
+      // Pre-select the tile
+      act(() => { stores.ui.setSelectedTileId(tileModel.id); });
+      const setSelectedSpy = jest.spyOn(stores.ui, "setSelectedTileId");
+
+      const child = document.createElement("button");
+      tileElement.appendChild(child);
+      act(() => { child.focus(); });
+
+      expect(setSelectedSpy).not.toHaveBeenCalled();
+      setSelectedSpy.mockRestore();
+    });
+  });
+
   // --- Generic tile behavior (tiles without getFocusableElements) ---
 
   describe("generic tile behavior (no getFocusableElements)", () => {
-    it("Tab inside tile without cycling exits to tile container", () => {
-      // Render a tile with no title, no content, no toolbar — simulates a tile
-      // that doesn't implement getFocusableElements. Use a bare div inside the tile.
-      const { tileElement } = renderFocusTrapTile({
-        hasTitle: false, hasContent: false, hasToolbar: false,
-      });
+    it("focusing child from outside auto-enters trap (click-to-enter behavior)", () => {
+      // Focusing a child element from outside the tile auto-enters the focus trap
+      // and selects the tile (via onFocusEnter). Tab then cycles within the trap
+      // rather than navigating to a sibling tile.
+      const { stores, model1, tile1 } = renderTwoTiles();
       const arbitraryChild = document.createElement("button");
       arbitraryChild.textContent = "Some button";
-      tileElement.appendChild(arbitraryChild);
+      tile1.appendChild(arbitraryChild);
 
       act(() => { arbitraryChild.focus(); });
       expect(document.activeElement).toBe(arbitraryChild);
-
-      // Tab should exit to tile container (catch-all)
-      fireEvent.keyDown(arbitraryChild, { key: "Tab" });
-      expect(document.activeElement).toBe(tileElement);
+      // The tile should now be selected (onFocusEnter fires)
+      expect(stores.ui.selectedTileIds).toContain(model1.id);
     });
 
     it("Tab on tile container with no focusable elements does inter-tile navigation", () => {

--- a/src/components/tiles/tile-component.tsx
+++ b/src/components/tiles/tile-component.tsx
@@ -463,6 +463,15 @@ class InternalTileComponent extends BaseComponent<IProps, IState> {
     this.srAnnounce("Exited tile. Tab to next tile, Shift+Tab to previous.");
   };
 
+  // Returns the model that should be selected/deselected on behalf of this tile.
+  // For read-only tiles inside a container (e.g. problem document with linked
+  // workspace tiles), selection operates on the container model, not the inner
+  // tile — matching userSelectTile / handlePointerDown behavior.
+  private getEffectiveSelectionModel() {
+    const { model, readOnly, containerContext } = this.props;
+    return (readOnly && containerContext?.model) ? containerContext.model : model;
+  }
+
   // Builds a FocusTrapStrategy from the current tile's elements.
   private buildFocusTrapStrategy() {
     const { model } = this.props;
@@ -480,7 +489,7 @@ class InternalTileComponent extends BaseComponent<IProps, IState> {
     // Deselect the tile when the controller exits (Escape, setEnabled(false))
     strategy.onExit = () => {
       const { ui } = this.stores;
-      ui.removeTileIdFromSelection(this.props.model.id);
+      ui.removeTileIdFromSelection(this.getEffectiveSelectionModel().id);
     };
     // Select the tile when focus enters via mouse click (handles tileHandlesOwnSelection tiles
     // where the title click doesn't go through handlePointerDown's selectTileHandler).
@@ -490,9 +499,7 @@ class InternalTileComponent extends BaseComponent<IProps, IState> {
     strategy.onFocusEnter = () => {
       const { ui } = this.stores;
       if (!ui.isSelectedTile(model)) {
-        const { readOnly, containerContext } = this.props;
-        const effectiveModel = (readOnly && containerContext?.model) ? containerContext.model : model;
-        ui.setSelectedTile(effectiveModel, { append: false });
+        ui.setSelectedTile(this.getEffectiveSelectionModel(), { append: false });
       }
     };
     return strategy;
@@ -574,7 +581,9 @@ class InternalTileComponent extends BaseComponent<IProps, IState> {
       const { ui } = this.stores;
       const { model } = this.props;
       const wasAlreadySelected = ui.isSelectedTile(model);
-      ui.setSelectedTileId(model.id, { append: false });
+      // Match userSelectTile / onFocusEnter: select the container model for read-only
+      // tiles inside a container so all entry paths agree on which tile is selected.
+      ui.setSelectedTileId(this.getEffectiveSelectionModel().id, { append: false });
       if (!wasAlreadySelected) {
         // First Enter: select + enable + enter trap
         this.focusTrapController?.setEnabled(true);

--- a/src/components/tiles/tile-component.tsx
+++ b/src/components/tiles/tile-component.tsx
@@ -11,7 +11,7 @@ import { ITileModel } from "../../models/tiles/tile-model";
 import { isQuestionModel } from "../../models/tiles/question/question-content";
 import { BaseComponent } from "../base";
 import PlaceholderTileComponent from "./placeholder/placeholder-tile";
-import { useKeyboardResize } from "@concord-consortium/accessibility-tools/hooks";
+import { useKeyboardResize, FocusTrapController } from "@concord-consortium/accessibility-tools/hooks";
 import { kDefaultTileHeight } from "../constants";
 import {
   ITileApi, TileResizeEntry, TileApiInterfaceContext, TileModelContext, RegisterToolbarContext
@@ -23,7 +23,7 @@ import { hasSelectionModifier } from "../../utilities/event-utils";
 import { getDocumentContentFromNode } from "../../utilities/mst-utils";
 import { userSelectTile } from "../../models/stores/ui";
 import { IContainerContextType, useContainerContext } from "../document/container-context";
-import { getVisibleFocusables } from "../../utilities/dom-utils";
+import { createClueTileStrategy } from "../../hooks/create-clue-tile-strategy";
 
 import TileDragHandle from "../../assets/icons/drag-tile/move.svg";
 import TileResizeHandle from "../../assets/icons/resize-tile/expand-handle.svg";
@@ -188,6 +188,7 @@ class InternalTileComponent extends BaseComponent<IProps, IState> {
   private liveRegionTimer: ReturnType<typeof setTimeout> | null = null;
   private dragElement: HTMLDivElement | null;
   private resizeElement: HTMLElement | null;
+  private focusTrapController: FocusTrapController | null = null;
   private wasSelected = false;
 
   state = {
@@ -213,20 +214,36 @@ class InternalTileComponent extends BaseComponent<IProps, IState> {
     const options = { capture: true, passive: true };
     this.domElement?.addEventListener("touchstart", this.handlePointerDown, options);
     this.domElement?.addEventListener("mousedown", this.handlePointerDown, options);
-    // Native capture-phase listener for Tab — React 17's delegated events fire too late
-    // to prevent the browser's default Tab focus movement from descendant elements.
-    this.domElement?.addEventListener("keydown", this.handleTabKeyDown, true);
     this.domElement?.addEventListener("toolbar-escape", this.handleToolbarEscape);
+
+    // Create focus trap controller — handles Tab cycling, Enter/Escape, external elements
+    if (this.domElement) {
+      this.focusTrapController = new FocusTrapController(
+        this.domElement,
+        this.buildFocusTrapStrategy()
+      );
+      this.focusTrapController.setEnabled(
+        this.stores.ui.isSelectedTile(this.props.model)
+      );
+    }
   }
 
   public componentDidUpdate(prevProps: IProps) {
     // Scroll the tile into view when it becomes selected.
     const { model } = this.props;
     const isNowSelected = this.stores.ui.isSelectedTile(model);
-    if (isNowSelected && !this.wasSelected) {
+    const justSelected = isNowSelected && !this.wasSelected;
+    if (justSelected) {
       this.domElement?.scrollIntoView?.({ behavior: "smooth", block: "nearest", inline: "nearest" });
     }
     this.wasSelected = isNowSelected;
+
+    // Toggle focus trap based on selection state.
+    // Only rebuild strategy when tile becomes selected (avoids churn on hover/scroll re-renders).
+    this.focusTrapController?.setEnabled(isNowSelected);
+    if (justSelected) {
+      this.focusTrapController?.setStrategy(this.buildFocusTrapStrategy());
+    }
 
     if (this.domElement && !this.resizeObserver) {
       this.resizeObserver = new ResizeObserver((entries: ResizeObserverEntry[]) => {
@@ -249,8 +266,8 @@ class InternalTileComponent extends BaseComponent<IProps, IState> {
     const options = { capture: true, passive: true };
     this.domElement?.removeEventListener("mousedown", this.handlePointerDown, options);
     this.domElement?.removeEventListener("touchstart", this.handlePointerDown, options);
-    this.domElement?.removeEventListener("keydown", this.handleTabKeyDown, true);
     this.domElement?.removeEventListener("toolbar-escape", this.handleToolbarEscape);
+    this.focusTrapController?.destroy();
   }
 
   public render() {
@@ -446,6 +463,41 @@ class InternalTileComponent extends BaseComponent<IProps, IState> {
     this.srAnnounce("Exited tile. Tab to next tile, Shift+Tab to previous.");
   };
 
+  // Builds a FocusTrapStrategy from the current tile's elements.
+  private buildFocusTrapStrategy() {
+    const { model } = this.props;
+    const strategy = createClueTileStrategy({
+      onRegisterTileApi: () => {}, // Not used here — individual tiles handle registration
+      onUnregisterTileApi: () => {},
+      tileType: model.content.type,
+      getContentElement: () => this.getFocusTrapElements().contentElement ?? undefined,
+      getTitleElement: () => this.getFocusTrapElements().titleElement ?? undefined,
+      getToolbarElement: () => this.toolbarElement ?? undefined,
+      getResizeElement: () => this.resizeElement ?? undefined,
+      focusContent: () => this.getFocusTrapElements().focusContent?.() ?? false,
+      onTabWhenInactive: (e, reverse) => this.navigateToSiblingTile(e, reverse),
+    });
+    // Deselect the tile when the controller exits (Escape, setEnabled(false))
+    strategy.onExit = () => {
+      const { ui } = this.stores;
+      ui.removeTileIdFromSelection(this.props.model.id);
+    };
+    // Select the tile when focus enters via mouse click (handles tileHandlesOwnSelection tiles
+    // where the title click doesn't go through handlePointerDown's selectTileHandler).
+    // Guard against double-selection for tiles that already call selectTileHandler on click.
+    // Use setSelectedTile directly (not the debounced userSelectTile) since focus entry is
+    // a single committed user action, not a burst of rapid click events.
+    strategy.onFocusEnter = () => {
+      const { model, readOnly, containerContext } = this.props;
+      const { ui } = this.stores;
+      if (!ui.isSelectedTile(model)) {
+        const effectiveModel = (readOnly && containerContext?.model) ? containerContext.model : model;
+        ui.setSelectedTile(effectiveModel, { append: false });
+      }
+    };
+    return strategy;
+  }
+
   // Returns the focusable elements for this tile's focus trap.
   private getFocusTrapElements() {
     const toolbar = this.toolbarElement;
@@ -465,83 +517,6 @@ class InternalTileComponent extends BaseComponent<IProps, IState> {
       focusContent: focusable?.focusContent || null,
       resizeHandle: this.resizeElement,
     };
-  }
-
-  // Tries to focus elements in order, returning true on the first that actually receives focus.
-  // Handles elements that exist in the DOM but aren't focusable (e.g., a plain div without tabindex).
-  private focusFirstAvailable(...elements: (HTMLElement | null)[]): boolean {
-    for (const el of elements) {
-      if (el) {
-        el.focus();
-        if (document.activeElement === el) return true;
-      }
-    }
-    return false;
-  }
-
-  // Focuses the content element, preferring the tile's custom focusContent method if available.
-  // Some editors (e.g., Slate) require their own focus API to properly initialize cursor/selection.
-  private focusContent(contentElement: HTMLElement | null, focusContentFn: (() => boolean) | null): boolean {
-    if (focusContentFn) {
-      return focusContentFn();
-    }
-    if (contentElement) {
-      contentElement.focus();
-      return document.activeElement === contentElement;
-    }
-    return false;
-  }
-
-  // Moves focus to the next (or previous) focusable element within the content area.
-  // Returns true if focus was moved, false if already at the boundary (first/last element).
-  // Note: DOM query + visibility check on each Tab press. Acceptable for typical tile sizes (<100 elements).
-  private tabWithinContent(contentElement: HTMLElement, activeElement: HTMLElement, reverse: boolean): boolean {
-    const focusables = getVisibleFocusables(contentElement);
-
-    if (focusables.length === 0) return false;
-
-    const currentIndex = focusables.indexOf(activeElement);
-    if (currentIndex === -1) return false;
-
-    if (reverse) {
-      if (currentIndex === 0) return false; // at first element, let focus trap handle it
-      focusables[currentIndex - 1].focus();
-    } else {
-      if (currentIndex === focusables.length - 1) return false; // at last element
-      focusables[currentIndex + 1].focus();
-    }
-    return true;
-  }
-
-  // Enters the focus trap, focusing the first (or last if reverse) element.
-  // Returns true if focus was moved, false if no focusable elements exist.
-  private enterFocusTrap(
-    e: { preventDefault: () => void; stopPropagation: () => void },
-    reverse = false
-  ): boolean {
-    const { titleElement, activeToolbarButton, contentElement, focusContent, resizeHandle }
-      = this.getFocusTrapElements();
-
-    // Cycle order: title → content → toolbar → resize
-    let focused: boolean;
-    if (reverse) {
-      focused = this.focusFirstAvailable(resizeHandle)
-        || this.focusFirstAvailable(activeToolbarButton)
-        || this.focusContent(contentElement, focusContent)
-        || this.focusFirstAvailable(titleElement);
-    } else {
-      focused = this.focusFirstAvailable(titleElement)
-        || this.focusContent(contentElement, focusContent)
-        || this.focusFirstAvailable(activeToolbarButton);
-    }
-
-    if (focused) {
-      this.srAnnounce("Editing tile. Press Escape to exit.");
-      e.preventDefault();
-      e.stopPropagation();
-      return true;
-    }
-    return false;
   }
 
   // Navigate to an adjacent sibling tile. Returns true if a sibling was found.
@@ -566,125 +541,6 @@ class InternalTileComponent extends BaseComponent<IProps, IState> {
     return false;
   }
 
-  private handleTabKeyDown = (e: KeyboardEvent) => {
-    if (e.key !== "Tab") return;
-
-    const activeElement = document.activeElement as HTMLElement;
-    const isTileFocused = activeElement === this.domElement;
-    const isInsideTile = this.domElement?.contains(activeElement) && !isTileFocused;
-
-    if (isTileFocused) {
-      const { ui } = this.stores;
-      if (ui.isSelectedTile(this.props.model)) {
-        // Selected tile (via Enter or mouse click): enter focus trap.
-        // Toolbar should be in the DOM from the prior render frame.
-        if (this.enterFocusTrap(e, e.shiftKey)) return;
-      }
-      // Not selected (focus-ring-only), or enterFocusTrap failed: navigate to sibling.
-      this.navigateToSiblingTile(e, e.shiftKey);
-      // If no sibling, let browser handle Tab (moves out of tile area)
-      return;
-    }
-
-    if (isInsideTile) {
-      // Cycling within focus trap from elements inside the tile DOM.
-      // (Toolbar handles its own Tab events since it's in FloatingPortal.)
-      // Cycle order: title → content → toolbar → resize → (wrap to title)
-      const { titleElement, activeToolbarButton, contentElement, focusContent, resizeHandle }
-        = this.getFocusTrapElements();
-      const isOnContent = activeElement === contentElement || contentElement?.contains(activeElement);
-      const isOnTitle = activeElement === titleElement;
-      const isOnResize = activeElement === resizeHandle || resizeHandle?.contains(activeElement);
-
-      // Cycle order: title → content → toolbar → resize → (wrap to title)
-      if (e.shiftKey) {
-        // Shift+Tab: go backward
-        if (isOnContent) {
-          if (contentElement && this.tabWithinContent(contentElement, activeElement, true)) {
-            e.preventDefault();
-            e.stopPropagation();
-            return;
-          }
-          // Content → title (or wrap to resize)
-          if (!this.focusFirstAvailable(titleElement)) {
-            this.focusFirstAvailable(resizeHandle);
-          }
-          e.preventDefault();
-          e.stopPropagation();
-          return;
-        } else if (isOnTitle) {
-          // Title → wrap to resize (or toolbar, or content)
-          if (!this.focusFirstAvailable(resizeHandle)) {
-            if (!this.focusFirstAvailable(activeToolbarButton)) {
-              this.focusContent(contentElement, focusContent);
-            }
-          }
-          e.preventDefault();
-          e.stopPropagation();
-          return;
-        } else if (isOnResize) {
-          // Resize → toolbar (or content, or title)
-          if (!this.focusFirstAvailable(activeToolbarButton)) {
-            if (!this.focusContent(contentElement, focusContent)) {
-              this.focusFirstAvailable(titleElement);
-            }
-          }
-          e.preventDefault();
-          e.stopPropagation();
-          return;
-        }
-      } else {
-        // Tab: go forward
-        if (isOnContent) {
-          if (contentElement && this.tabWithinContent(contentElement, activeElement, false)) {
-            e.preventDefault();
-            e.stopPropagation();
-            return;
-          }
-          // Content → toolbar (or resize, or wrap to title)
-          // Toolbar is in FloatingPortal — focusFirstAvailable works across DOM boundaries
-          if (!this.focusFirstAvailable(activeToolbarButton)) {
-            if (!this.focusFirstAvailable(resizeHandle)) {
-              this.focusFirstAvailable(titleElement);
-            }
-          }
-          e.preventDefault();
-          e.stopPropagation();
-          return;
-        } else if (isOnTitle) {
-          // Title → content (or toolbar)
-          if (!this.focusContent(contentElement, focusContent)) {
-            this.focusFirstAvailable(activeToolbarButton);
-          }
-          e.preventDefault();
-          e.stopPropagation();
-          return;
-        } else if (isOnResize) {
-          // Resize → wrap to title (or content, or toolbar)
-          if (!this.focusFirstAvailable(titleElement)) {
-            if (!this.focusContent(contentElement, focusContent)) {
-              this.focusFirstAvailable(activeToolbarButton);
-            }
-          }
-          e.preventDefault();
-          e.stopPropagation();
-          return;
-        }
-      }
-
-      // Catch-all: focus is inside the tile but no cycling conditions matched
-      // (e.g., tile doesn't implement getFocusableElements). Deselect and exit
-      // to the tile container to prevent a selected-but-unfocusable state.
-      const { ui } = this.stores;
-      const { model } = this.props;
-      ui.removeTileIdFromSelection(model.id);
-      this.srAnnounce("Exited tile. Tab to next tile, Shift+Tab to previous.");
-      this.domElement?.focus();
-      e.preventDefault();
-      e.stopPropagation();
-    }
-  };
-
   // When the tile container receives focus from outside the tile, announce for SR.
   // Does NOT select the tile or enter the focus trap — Enter is the sole entry mechanism.
   // Uses relatedTarget to distinguish external focus (Tab from toolbar/sibling) from internal
@@ -702,42 +558,46 @@ class InternalTileComponent extends BaseComponent<IProps, IState> {
     this.srAnnounce("Tile focused. Press Enter to edit.");
   };
 
-  // React handler for Enter, Escape, ArrowUp exit, and hotkeys (Tab handled natively above)
+  // React handler for Enter, Escape, ArrowUp exit, and hotkeys.
+  // Tab cycling is handled by FocusTrapController (capture phase).
   private handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     const activeElement = document.activeElement as HTMLElement;
     const isTileFocused = activeElement === this.domElement;
     const isInsideTile = this.domElement?.contains(activeElement) && !isTileFocused;
 
-    // Enter on tile container: select the tile unconditionally, then enter focus trap best-effort.
-    // Toolbar renders via MobX observer gated on selectedTileIds — it won't be in the DOM yet
-    // on this frame, so initial focus goes to content. Toolbar becomes reachable via Tab cycling.
+    // Enter on tile container: select the tile and enable the focus trap.
+    // The controller handles Enter→enterTrap in its own capture-phase listener
+    // once enabled. On the first Enter (tile not yet selected), we need to select
+    // and enable before the controller can act — but the capture handler already
+    // ran (and did nothing since enabled=false). So we call enterTrap() here.
     if (e.key === "Enter" && isTileFocused) {
       const { ui } = this.stores;
       const { model } = this.props;
+      const wasAlreadySelected = ui.isSelectedTile(model);
       ui.setSelectedTileId(model.id, { append: false });
-      if (!this.enterFocusTrap(e)) {
-        // No content to focus (e.g., drawing tile) — tile is selected, toolbar appears next frame.
-        this.srAnnounce("Tile selected. Press Tab to access toolbar, Escape to exit.");
+      if (!wasAlreadySelected) {
+        // First Enter: select + enable + enter trap
+        this.focusTrapController?.setEnabled(true);
+        this.focusTrapController?.setStrategy(this.buildFocusTrapStrategy());
+        this.focusTrapController?.enterTrap();
+        // Announce via the tile's live region. If enterTrap didn't move focus
+        // (no slots available), use a fallback message.
+        const focusMoved = document.activeElement !== this.domElement;
+        this.srAnnounce(focusMoved
+          ? "Editing tile. Press Escape to exit."
+          : "Tile selected. Press Tab to access toolbar, Escape to exit.");
         e.preventDefault();
         e.stopPropagation();
       }
+      // If already selected, the controller's capture handler already called enterTrap
       return;
     }
 
-    const isSelectedOnContainer = isTileFocused && this.stores.ui.isSelectedTile(this.props.model);
-    if (e.key === "Escape" && (isInsideTile || isSelectedOnContainer)) {
-      // Exit focus trap: deselect the tile (hides toolbar) and return focus to the container.
-      const { ui } = this.stores;
-      const { model } = this.props;
-      ui.removeTileIdFromSelection(model.id);
-      this.srAnnounce("Exited tile. Tab to next tile, Shift+Tab to previous.");
-      this.domElement?.focus();
-      e.preventDefault();
-      e.stopPropagation();
-      return;
-    }
+    // Escape is handled by FocusTrapController (capture phase).
+    // The controller's exitTrap calls strategy.onExit which deselects the tile.
 
-    // ArrowUp from a non-editable element exits the focus trap.
+    // ArrowUp from a non-editable element is a "soft exit" — focus returns to the
+    // tile container but the tile stays selected so Tab re-enters the trap.
     // Editable elements (input, textarea, contenteditable/Slate) keep normal ArrowUp behavior.
     // The resize handle uses ArrowUp/Down for resizing, so it's excluded.
     if (e.key === "ArrowUp" && isInsideTile) {
@@ -746,6 +606,8 @@ class InternalTileComponent extends BaseComponent<IProps, IState> {
                          activeElement.tagName === "TEXTAREA" ||
                          activeElement.isContentEditable;
       if (!isEditable && !isOnResize) {
+        // Soft exit: don't call exitTrap() (which would deselect via onExit).
+        // Just focus the container — controller stays enabled, so Tab re-enters.
         this.domElement?.focus();
         e.preventDefault();
         e.stopPropagation();
@@ -753,7 +615,7 @@ class InternalTileComponent extends BaseComponent<IProps, IState> {
       }
     }
 
-    // Tab is handled by native capture-phase listener (handleTabKeyDown)
+    // Tab is handled by FocusTrapController (capture phase)
     if (e.key === "Tab") return;
 
     this.hotKeys.dispatch(e);

--- a/src/components/tiles/tile-component.tsx
+++ b/src/components/tiles/tile-component.tsx
@@ -488,9 +488,9 @@ class InternalTileComponent extends BaseComponent<IProps, IState> {
     // Use setSelectedTile directly (not the debounced userSelectTile) since focus entry is
     // a single committed user action, not a burst of rapid click events.
     strategy.onFocusEnter = () => {
-      const { model, readOnly, containerContext } = this.props;
       const { ui } = this.stores;
       if (!ui.isSelectedTile(model)) {
+        const { readOnly, containerContext } = this.props;
         const effectiveModel = (readOnly && containerContext?.model) ? containerContext.model : model;
         ui.setSelectedTile(effectiveModel, { append: false });
       }

--- a/src/hooks/create-clue-tile-strategy.ts
+++ b/src/hooks/create-clue-tile-strategy.ts
@@ -16,6 +16,8 @@ export function createClueTileStrategy(config: ClueFocusTrapConfig): FocusTrapSt
     ?? (() => config.titleRef?.current ?? undefined);
   const getToolbar = config.getToolbarElement
     ?? (() => config.toolbarRef?.current ?? undefined);
+  const getResize = config.getResizeElement
+    ?? (() => config.resizeRef?.current ?? undefined);
 
   const ariaLabels = getAriaLabels();
 
@@ -24,14 +26,17 @@ export function createClueTileStrategy(config: ClueFocusTrapConfig): FocusTrapSt
       content: getContent(),
       title: getTitle(),
       toolbar: getToolbar(),
+      resize: getResize(),
     }),
     focusContent: config.focusContent,
-    cycleOrder: ["title", "content", "toolbar"],
+    cycleOrder: ["title", "content", "toolbar", "resize"],
+    tabWithinSlots: ["content"],
     announceEnter: ariaLabels.announce.editingTile(config.tileType),
     announceExit: ariaLabels.announce.exitedTile(config.tileType),
     getExternalElements: () => {
       const toolbar = getToolbar();
       return toolbar ? [toolbar] : [];
     },
+    onTabWhenInactive: config.onTabWhenInactive,
   };
 }

--- a/src/hooks/use-clue-accessibility.test.tsx
+++ b/src/hooks/use-clue-accessibility.test.tsx
@@ -54,7 +54,7 @@ describe("createClueTileStrategy", () => {
       tileType: "text",
     });
 
-    expect(strategy.cycleOrder).toEqual(["title", "content", "toolbar"]);
+    expect(strategy.cycleOrder).toEqual(["title", "content", "toolbar", "resize"]);
   });
 
   it("sets announcement text from tile type", () => {

--- a/src/hooks/use-clue-accessibility.test.tsx
+++ b/src/hooks/use-clue-accessibility.test.tsx
@@ -47,7 +47,7 @@ describe("createClueTileStrategy", () => {
     expect(elements.toolbar).toBeUndefined();
   });
 
-  it("sets cycle order to title/content/toolbar", () => {
+  it("sets cycle order to title/content/toolbar/resize", () => {
     const strategy = createClueTileStrategy({
       onRegisterTileApi: jest.fn(),
       onUnregisterTileApi: jest.fn(),

--- a/src/hooks/use-clue-accessibility.ts
+++ b/src/hooks/use-clue-accessibility.ts
@@ -2,6 +2,7 @@ import { RefObject, useEffect, useRef } from "react";
 import {
   AccessibilityResult,
   AnnouncementsConfig,
+  FocusTrapResult,
   NavigationConfig,
   ResizableConfig,
   useAccessibility,
@@ -18,6 +19,10 @@ export interface ClueFocusTrapConfig {
   onUnregisterTileApi: (facet?: string) => void;
   tileType: string;
 
+  // Container element — the .tool-tile wrapper that the focus trap attaches to
+  containerRef?: RefObject<HTMLElement | null>;
+  getContainerElement?: () => HTMLElement | undefined;
+
   // Content element — provide a ref (function components) or getter (class components)
   contentRef?: RefObject<HTMLElement | null>;
   getContentElement?: () => HTMLElement | undefined;
@@ -33,8 +38,15 @@ export interface ClueFocusTrapConfig {
   toolbarRef?: RefObject<HTMLElement | null>;
   getToolbarElement?: () => HTMLElement | undefined;
 
+  // Resize handle element
+  resizeRef?: RefObject<HTMLElement | null>;
+  getResizeElement?: () => HTMLElement | undefined;
+
   // Non-focus ITileApi methods (exportContentAsTileJson, handleTileResize, etc.)
   additionalApi?: Partial<ITileApi>;
+
+  // Called when Tab is pressed but the trap is not active (for inter-tile navigation)
+  onTabWhenInactive?: (e: KeyboardEvent, reverse: boolean) => boolean;
 }
 
 interface ClueTileOptions {
@@ -61,21 +73,35 @@ export type ClueAccessibilityOptions = ClueTileOptions | ClueRegionOptions;
 /**
  * CLUE-specific wrapper around useAccessibility from @concord-consortium/accessibility-tools.
  *
- * For `type: "tile"`: builds a FocusTrapStrategy from CLUE tile concepts and registers
- * the tile API (including getFocusableElements) on mount.
+ * For `type: "tile"`: builds a FocusTrapStrategy from CLUE tile concepts, registers
+ * the tile API, and wires useFocusTrap for keyboard Tab/Enter/Escape handling.
  *
  * For `type: "region"`: passes through navigation/announcements/resize config without
  * any focus trap registration.
- *
- * Note: the focus trap keyboard handling (Enter/Escape/Tab cycling) currently remains
- * in tile-component.tsx. This hook handles tile API registration and strategy creation.
- * The package's useFocusTrap will take over keyboard mechanics when tile-component
- * is migrated in a future story.
  */
 export function useClueAccessibility(options: ClueAccessibilityOptions): AccessibilityResult {
   // Capture latest options in a ref so the mount-only effect always sees current values
   const optionsRef = useRef(options);
   optionsRef.current = options;
+
+  // Build a stable containerRef for the focus trap
+  const containerRef = useRef<HTMLElement | null>(null);
+  if (options.type === "tile") {
+    const config = options.focusTrap;
+    if (config.containerRef) {
+      containerRef.current = config.containerRef.current;
+    } else if (config.getContainerElement) {
+      containerRef.current = config.getContainerElement() ?? null;
+    }
+  }
+
+  // Build strategy ref that always returns fresh element references
+  const strategyRef = useRef(
+    options.type === "tile" ? createClueTileStrategy(options.focusTrap) : undefined
+  );
+  if (options.type === "tile") {
+    strategyRef.current = createClueTileStrategy(options.focusTrap);
+  }
 
   // Register tile API on mount, unregister on unmount
   useEffect(() => {
@@ -107,13 +133,18 @@ export function useClueAccessibility(options: ClueAccessibilityOptions): Accessi
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // mount/unmount lifecycle matches componentDidMount/componentWillUnmount
 
-  // Delegate to generic useAccessibility.
-  // focusTrap is deliberately NOT passed — tile-component.tsx handles keyboard mechanics.
-  return useAccessibility({
+  // Delegate to generic useAccessibility with focus trap wired.
+  const result = useAccessibility({
+    focusTrap: options.type === "tile" && strategyRef.current ? {
+      containerRef,
+      strategy: strategyRef.current,
+    } : undefined,
     navigation: options.navigation,
     announcements: options.announcements,
     resize: options.resize,
   });
+
+  return result;
 }
 
 // ---------------------------------------------------------------------------
@@ -124,20 +155,24 @@ export function useClueAccessibility(options: ClueAccessibilityOptions): Accessi
  * Renderless bridge that lets class components use useClueAccessibility.
  * Render as a child — it returns null and only runs the hook.
  *
- * Usage in a class component's render():
- *   <ClueTileAccessibilityBridge
- *     onRegisterTileApi={this.props.onRegisterTileApi}
- *     onUnregisterTileApi={this.props.onUnregisterTileApi}
- *     tileType="text"
- *     getContentElement={() => this.editorDiv}
- *     focusContent={() => { ... }}
- *     additionalApi={{ exportContentAsTileJson: () => ... }}
- *   />
+ * The onFocusTrapReady callback provides imperative control (enterTrap/exitTrap)
+ * so the class component can wire Enter/Escape to trap activation.
  */
-export function ClueTileAccessibilityBridge(props: ClueFocusTrapConfig) {
-  useClueAccessibility({
+export function ClueTileAccessibilityBridge(props: ClueFocusTrapConfig & {
+  onFocusTrapReady?: (trap: FocusTrapResult) => void;
+}) {
+  const { onFocusTrapReady, ...focusTrapConfig } = props;
+  const result = useClueAccessibility({
     type: "tile",
-    focusTrap: props,
+    focusTrap: focusTrapConfig,
   });
+
+  // Expose the trap controller to the class component
+  useEffect(() => {
+    if (result.focusTrap && onFocusTrapReady) {
+      onFocusTrapReady(result.focusTrap);
+    }
+  }, [result.focusTrap, onFocusTrapReady]);
+
   return null;
 }

--- a/src/hooks/use-clue-accessibility.ts
+++ b/src/hooks/use-clue-accessibility.ts
@@ -84,7 +84,8 @@ export function useClueAccessibility(options: ClueAccessibilityOptions): Accessi
   const optionsRef = useRef(options);
   optionsRef.current = options;
 
-  // Build a stable containerRef for the focus trap
+  // Build a stable containerRef for the focus trap.
+  // Updated on each render so it reflects the latest DOM element.
   const containerRef = useRef<HTMLElement | null>(null);
   if (options.type === "tile") {
     const config = options.focusTrap;
@@ -95,11 +96,12 @@ export function useClueAccessibility(options: ClueAccessibilityOptions): Accessi
     }
   }
 
-  // Build strategy ref that always returns fresh element references
-  const strategyRef = useRef(
-    options.type === "tile" ? createClueTileStrategy(options.focusTrap) : undefined
-  );
-  if (options.type === "tile") {
+  // Build the strategy once and keep it stable across renders.
+  // The strategy's getElements/focusContent use getter functions that read
+  // live values through optionsRef, so element references stay fresh without
+  // recreating the strategy object (which would churn useFocusTrap's effect).
+  const strategyRef = useRef<ReturnType<typeof createClueTileStrategy> | undefined>(undefined);
+  if (options.type === "tile" && !strategyRef.current) {
     strategyRef.current = createClueTileStrategy(options.focusTrap);
   }
 
@@ -134,8 +136,11 @@ export function useClueAccessibility(options: ClueAccessibilityOptions): Accessi
   }, []); // mount/unmount lifecycle matches componentDidMount/componentWillUnmount
 
   // Delegate to generic useAccessibility with focus trap wired.
+  // Only pass focusTrap when a container element exists — without one, useFocusTrap
+  // can't attach listeners and would just allocate no-op hooks on every render.
+  const hasFocusTrapContainer = options.type === "tile" && containerRef.current != null;
   const result = useAccessibility({
-    focusTrap: options.type === "tile" && strategyRef.current ? {
+    focusTrap: hasFocusTrapContainer && strategyRef.current ? {
       containerRef,
       strategy: strategyRef.current,
     } : undefined,

--- a/src/hooks/use-clue-accessibility.ts
+++ b/src/hooks/use-clue-accessibility.ts
@@ -86,6 +86,9 @@ export function useClueAccessibility(options: ClueAccessibilityOptions): Accessi
 
   // Build a stable containerRef for the focus trap.
   // Updated on each render so it reflects the latest DOM element.
+  // Note: current function-component tiles (bar-graph, drawing, etc.) don't pass containerRef
+  // or getContainerElement because tile-component.tsx's FocusTrapController handles their
+  // focus trap. This wiring exists for future tiles that manage their own trap.
   const containerRef = useRef<HTMLElement | null>(null);
   if (options.type === "tile") {
     const config = options.focusTrap;
@@ -120,6 +123,9 @@ export function useClueAccessibility(options: ClueAccessibilityOptions): Accessi
       getFocusableElements: () => {
         const currentOpts = optionsRef.current;
         if (currentOpts.type !== "tile") return undefined;
+        // Create a fresh strategy from the latest options so element getters
+        // reflect the current render (not stale closures from mount time).
+        // This is separate from strategyRef which stays stable for useFocusTrap.
         const strategy = createClueTileStrategy(currentOpts.focusTrap);
         const elements = strategy.getElements();
         return {

--- a/src/hooks/use-clue-accessibility.ts
+++ b/src/hooks/use-clue-accessibility.ts
@@ -100,9 +100,10 @@ export function useClueAccessibility(options: ClueAccessibilityOptions): Accessi
   }
 
   // Build the strategy once and keep it stable across renders.
-  // The strategy's getElements/focusContent use getter functions that read
-  // live values through optionsRef, so element references stay fresh without
-  // recreating the strategy object (which would churn useFocusTrap's effect).
+  // The strategy captures getter functions from the initial options.focusTrap,
+  // but those getters read from stable React refs (contentRef, titleRef, etc.)
+  // or close over stable refs, so .current always yields the live element.
+  // Keeping the strategy object itself stable avoids churning useFocusTrap's effect.
   const strategyRef = useRef<ReturnType<typeof createClueTileStrategy> | undefined>(undefined);
   if (options.type === "tile" && !strategyRef.current) {
     strategyRef.current = createClueTileStrategy(options.focusTrap);

--- a/src/plugins/bar-graph/bar-graph-tile.tsx
+++ b/src/plugins/bar-graph/bar-graph-tile.tsx
@@ -60,9 +60,10 @@ export const BarGraphComponent: React.FC<ITileProps> = observer((props: ITilePro
       onUnregisterTileApi,
       tileType: "bar-graph",
       getTitleElement: () => {
-        // Find the title text element within this tile's DOM
+        // Return the focusable element: input (edit mode) or title-text (view mode)
         const tile = containerRef.current?.closest('.tool-tile');
-        return tile?.querySelector('.editable-tile-title') as HTMLElement | undefined;
+        const wrapper = tile?.querySelector('.editable-tile-title');
+        return wrapper?.querySelector('input, .editable-tile-title-text') as HTMLElement | undefined;
       },
       getContentElement: () => containerRef.current ?? undefined,
       focusContent: () => {

--- a/src/plugins/bar-graph/bar-graph-tile.tsx
+++ b/src/plugins/bar-graph/bar-graph-tile.tsx
@@ -12,6 +12,7 @@ import { isBarGraphModel } from "./bar-graph-content";
 import { TileToolbar } from "../../components/toolbar/tile-toolbar";
 import { useUIStore } from "../../hooks/use-stores";
 import { useClueAccessibility } from "../../hooks/use-clue-accessibility";
+import { getEditableTitleElement } from "../../utilities/dom-utils";
 
 import "./bar-graph.scss";
 
@@ -60,10 +61,8 @@ export const BarGraphComponent: React.FC<ITileProps> = observer((props: ITilePro
       onUnregisterTileApi,
       tileType: "bar-graph",
       getTitleElement: () => {
-        // Return the focusable element: input (edit mode) or title-text (view mode)
-        const tile = containerRef.current?.closest('.tool-tile');
-        const wrapper = tile?.querySelector('.editable-tile-title');
-        return wrapper?.querySelector('input, .editable-tile-title-text') as HTMLElement | undefined;
+        const tile = containerRef.current?.closest('.tool-tile') as HTMLElement | null;
+        return getEditableTitleElement(tile);
       },
       getContentElement: () => containerRef.current ?? undefined,
       focusContent: () => {

--- a/src/plugins/bar-graph/bar-graph-tile.tsx
+++ b/src/plugins/bar-graph/bar-graph-tile.tsx
@@ -62,7 +62,7 @@ export const BarGraphComponent: React.FC<ITileProps> = observer((props: ITilePro
       getTitleElement: () => {
         // Find the title text element within this tile's DOM
         const tile = containerRef.current?.closest('.tool-tile');
-        return tile?.querySelector('.editable-tile-title-text') as HTMLElement | undefined;
+        return tile?.querySelector('.editable-tile-title') as HTMLElement | undefined;
       },
       getContentElement: () => containerRef.current ?? undefined,
       focusContent: () => {

--- a/src/plugins/bar-graph/bar-graph.scss
+++ b/src/plugins/bar-graph/bar-graph.scss
@@ -142,42 +142,6 @@ $color-button-active: rgba(20, 244, 158, .5); // 50% #14f49e
         }
       }
 
-      .color-menu-list {
-        .color-menu-list-item {
-          background: white;
-          height: 24px;
-          margin: 0;
-          padding: 0;
-          width: 24px;
-
-          // Visible focus ring for keyboard navigation through color choices
-          @include focus-ring(-2px);
-
-          .color-button {
-            background: white;
-            border: none;
-            border-radius: 0;
-            height: 24px;
-            margin: 0;
-            padding: 0;
-            width: 24px;
-
-            .color-swatch {
-              height: 12px;
-              margin: 6px;
-              width: 12px;
-            }
-
-            &:hover {
-              background: $color-button-hover;
-            }
-            &:active, &:focus {
-              background: $color-button-active;
-            }
-          }
-        }
-      }
-
       .attribute-value-name.missing {
         font-style: italic;
       }
@@ -269,6 +233,43 @@ $color-button-active: rgba(20, 244, 158, .5); // 50% #14f49e
 .bar-graph-category-menu-list {
   .chakra-menu__menuitem {
     @include focus-ring(-2px);
+  }
+}
+
+// Styles for the legend color picker's portaled menu list. Must be top-level
+// for the same reason as above.
+.color-menu-list {
+  .color-menu-list-item {
+    background: white;
+    height: 24px;
+    margin: 0;
+    padding: 0;
+    width: 24px;
+
+    @include focus-ring(-2px);
+
+    .color-button {
+      background: white;
+      border: none;
+      border-radius: 0;
+      height: 24px;
+      margin: 0;
+      padding: 0;
+      width: 24px;
+
+      .color-swatch {
+        height: 12px;
+        margin: 6px;
+        width: 12px;
+      }
+
+      &:hover {
+        background: $color-button-hover;
+      }
+      &:active, &:focus {
+        background: $color-button-active;
+      }
+    }
   }
 }
 

--- a/src/plugins/bar-graph/bar-graph.scss
+++ b/src/plugins/bar-graph/bar-graph.scss
@@ -150,6 +150,9 @@ $color-button-active: rgba(20, 244, 158, .5); // 50% #14f49e
           padding: 0;
           width: 24px;
 
+          // Visible focus ring for keyboard navigation through color choices
+          @include focus-ring(-2px);
+
           .color-button {
             background: white;
             border: none;
@@ -257,6 +260,15 @@ $color-button-active: rgba(20, 244, 158, .5); // 50% #14f49e
       }
     }
 
+  }
+}
+
+// Styles for the category pulldown's portaled menu list. Must be top-level
+// (not scoped under .bar-graph-tile) because Chakra's <Portal> renders the
+// menu outside the tile DOM tree.
+.bar-graph-category-menu-list {
+  .chakra-menu__menuitem {
+    @include focus-ring(-2px);
   }
 }
 

--- a/src/plugins/bar-graph/category-pulldown.tsx
+++ b/src/plugins/bar-graph/category-pulldown.tsx
@@ -34,7 +34,7 @@ export const CategoryPulldown = observer(function CategoryPulldown({setCategory,
           </span>
         </MenuButton>
         <Portal>
-          <MenuList>
+          <MenuList className="bar-graph-category-menu-list">
             {attributes.map((a) => (
               <MenuItem isDisabled={readOnly} key={a.id} onClick={() => setCategory(a.id)}>{a.name}</MenuItem>
             ))}

--- a/src/plugins/bar-graph/chart-area.tsx
+++ b/src/plugins/bar-graph/chart-area.tsx
@@ -128,6 +128,13 @@ export const ChartArea = observer(function BarGraphChart({ width, height }: IPro
     }
   }, []);
 
+  const handleBarBlur = useCallback((e: React.FocusEvent) => {
+    // Only clear selection if focus is leaving the bar graph entirely (not moving between bars).
+    if (!svgRef.current?.contains(e.relatedTarget as Node | null)) {
+      model?.sharedModel?.dataSet.setSelectedCases([]);
+    }
+  }, [model]);
+
   if (xMax <= 0 || yMax <= 0) return <span>Tile too small to show graph ({width}x{height})</span>;
 
   const ticks = data.length > 0
@@ -168,7 +175,8 @@ export const ChartArea = observer(function BarGraphChart({ width, height }: IPro
             <BarWithHighlight key={key} x={x} y={y} width={w} height={h} color={barColor(key)} selected={info.selected}
               ariaLabel={label} onKeyDown={handleBarKeyDown}
               onActivate={makeActivateHandler(key, label, info.selected)}
-              onClick={() => handleClick(key)} />
+              onClick={() => handleClick(key)}
+              onBlur={handleBarBlur} />
           );
         })}
       </Group>
@@ -216,7 +224,8 @@ export const ChartArea = observer(function BarGraphChart({ width, height }: IPro
                           selected={val.selected}
                           ariaLabel={label} onKeyDown={handleBarKeyDown}
                           onActivate={makeActivateHandler(primaryValue, label, val.selected, bar.key)}
-                          onClick={() => handleClick(primaryValue, bar.key)} />;
+                          onClick={() => handleClick(primaryValue, bar.key)}
+                          onBlur={handleBarBlur} />;
                       })}
                     </Group>
                   );
@@ -313,9 +322,11 @@ interface IBarWithHighlightProps {
   ariaLabel?: string;
   onKeyDown?: (e: React.KeyboardEvent<SVGRectElement>) => void;
   onActivate?: () => void;
+  onBlur?: (e: React.FocusEvent) => void;
 }
 
-function BarWithHighlight({ x, y, width, height, color, selected, onClick, ariaLabel, onKeyDown, onActivate
+function BarWithHighlight({ x, y, width, height, color, selected, onClick, ariaLabel, onKeyDown, onActivate,
+    onBlur
 }: IBarWithHighlightProps) {
   const handleKeyDown = (e: React.KeyboardEvent<SVGRectElement>) => {
     if (e.key === "Enter" || e.key === " ") {
@@ -328,8 +339,8 @@ function BarWithHighlight({ x, y, width, height, color, selected, onClick, ariaL
   return (
     <Group>
       {selected && <BarHighlight x={x} y={y} width={width} height={height} />}
-      <Bar onClick={onClick} onKeyDown={handleKeyDown} x={x} y={y} width={width} height={height} fill={color}
-        tabIndex={0} role="button" aria-label={ariaLabel} />
+      <Bar onClick={onClick} onKeyDown={handleKeyDown} onBlur={onBlur} x={x} y={y} width={width} height={height}
+        fill={color} tabIndex={0} role="button" aria-label={ariaLabel} />
     </Group>
   );
 }

--- a/src/plugins/bar-graph/editable-axis-label.tsx
+++ b/src/plugins/bar-graph/editable-axis-label.tsx
@@ -65,6 +65,8 @@ const EditableAxisLabel: React.FC<IProps> = observer(function EditableAxisLabel(
         <input
           type="text"
           className="focusable"
+          // autoFocus so keyboard users can start typing immediately after pressing Enter
+          autoFocus
           value={editText}
           size={editText.length + 5}
           onKeyDown={handleKeyDown}

--- a/src/plugins/bar-graph/legend-area.tsx
+++ b/src/plugins/bar-graph/legend-area.tsx
@@ -82,7 +82,7 @@ export const LegendArea = observer(function LegendArea ({legendRef}: IProps) {
               </span>
             </MenuButton>
             <Portal>
-              <MenuList>
+              <MenuList className="bar-graph-category-menu-list">
                 <MenuItem
                   isDisabled={readOnly || !currentSecondary}
                   onClick={() => setSecondaryAttribute(undefined)}

--- a/src/plugins/bar-graph/legend-color-row.tsx
+++ b/src/plugins/bar-graph/legend-color-row.tsx
@@ -38,7 +38,6 @@ export const LegendColorRow = observer(function LegendColorRow ({attrValue}: IPr
       <Menu placement="auto">
         <MenuButton
           as={Button}
-          unstyle="true"
           data-testid="color-menu-button"
           aria-label={menuButtonAriaLabel}
         >

--- a/src/plugins/bar-graph/legend-color-row.tsx
+++ b/src/plugins/bar-graph/legend-color-row.tsx
@@ -31,7 +31,7 @@ export const LegendColorRow = observer(function LegendColorRow ({attrValue}: IPr
   };
 
   const menuButtonAriaLabel =
-    `Color for ${display}: ${currentColor.name}. Press Enter or Arrow to choose a color.`;
+    `Color for ${display}: ${currentColor.name}. Press Enter or Arrow keys to choose a color.`;
 
   return (
     <div key={attrValue} className="attribute-value">

--- a/src/plugins/bar-graph/legend-color-row.tsx
+++ b/src/plugins/bar-graph/legend-color-row.tsx
@@ -16,9 +16,11 @@ export const LegendColorRow = observer(function LegendColorRow ({attrValue}: IPr
 
   const missingData = isMissingData(attrValue);
   const display = displayValue(attrValue);
-  const backgroundColor = model.secondaryAttribute
-    ? clueDataColorInfo[model.colorForSecondaryKey(attrValue)].color
-    : clueDataColorInfo[model.colorForPrimaryKey(attrValue)].color;
+  const currentColorIndex = model.secondaryAttribute
+    ? model.colorForSecondaryKey(attrValue)
+    : model.colorForPrimaryKey(attrValue);
+  const currentColor = clueDataColorInfo[currentColorIndex];
+  const backgroundColor = currentColor.color;
 
   const handleColorSelect = (colorIndex: number) => {
     if (model.secondaryAttribute) {
@@ -31,7 +33,12 @@ export const LegendColorRow = observer(function LegendColorRow ({attrValue}: IPr
   return (
     <div key={attrValue} className="attribute-value">
       <Menu placement="auto">
-        <MenuButton as={Button} unstyle="true" data-testid="color-menu-button">
+        <MenuButton
+          as={Button}
+          unstyle="true"
+          data-testid="color-menu-button"
+          aria-label={`Color for ${display}: ${currentColor.name}. Press Enter or Arrow to choose a color.`}
+        >
           <div className="color-button">
             <div className="color-swatch" style={{ backgroundColor }} />
           </div>
@@ -48,15 +55,16 @@ export const LegendColorRow = observer(function LegendColorRow ({attrValue}: IPr
           gridTemplateColumns="repeat(2, 1fr)"
           zIndex={1}
         >
-          {Object.entries(clueDataColorInfo).map(([key, value], index) => (
+          {clueDataColorInfo.map((colorInfo, index) => (
             <MenuItem
               className="color-menu-list-item"
               data-testid="color-menu-list-item"
-              key={key}
+              key={colorInfo.name}
+              aria-label={colorInfo.name}
               onClick={() => handleColorSelect(index)}
             >
               <div className="color-button">
-                <div className="color-swatch" style={{ backgroundColor: value.color }} />
+                <div className="color-swatch" style={{ backgroundColor: colorInfo.color }} />
               </div>
             </MenuItem>
           ))}

--- a/src/plugins/bar-graph/legend-color-row.tsx
+++ b/src/plugins/bar-graph/legend-color-row.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import { observer } from 'mobx-react';
-import { Button, Menu, MenuButton, MenuItem, MenuList } from '@chakra-ui/react';
+import { Button, Menu, MenuButton, MenuItem, MenuList, Portal } from '@chakra-ui/react';
 import { useBarGraphModelContext } from './bar-graph-content-context';
 import { displayValue, isMissingData } from './bar-graph-utils';
 import { clueDataColorInfo } from '../../utilities/color-utils';
@@ -30,6 +30,9 @@ export const LegendColorRow = observer(function LegendColorRow ({attrValue}: IPr
     }
   };
 
+  const menuButtonAriaLabel =
+    `Color for ${display}: ${currentColor.name}. Press Enter or Arrow to choose a color.`;
+
   return (
     <div key={attrValue} className="attribute-value">
       <Menu placement="auto">
@@ -37,38 +40,42 @@ export const LegendColorRow = observer(function LegendColorRow ({attrValue}: IPr
           as={Button}
           unstyle="true"
           data-testid="color-menu-button"
-          aria-label={`Color for ${display}: ${currentColor.name}. Press Enter or Arrow to choose a color.`}
+          aria-label={menuButtonAriaLabel}
         >
           <div className="color-button">
             <div className="color-swatch" style={{ backgroundColor }} />
           </div>
         </MenuButton>
-        <MenuList
-          bg="white"
-          border="none"
-          borderRadius="5px"
-          boxShadow="0 0 5px 0 rgba(0, 0, 0, 0.35)"
-          className="color-menu-list"
-          data-testid="color-menu-list"
-          display="grid"
-          gap={0}
-          gridTemplateColumns="repeat(2, 1fr)"
-          zIndex={1}
-        >
-          {clueDataColorInfo.map((colorInfo, index) => (
-            <MenuItem
-              className="color-menu-list-item"
-              data-testid="color-menu-list-item"
-              key={colorInfo.name}
-              aria-label={colorInfo.name}
-              onClick={() => handleColorSelect(index)}
-            >
-              <div className="color-button">
-                <div className="color-swatch" style={{ backgroundColor: colorInfo.color }} />
-              </div>
-            </MenuItem>
-          ))}
-        </MenuList>
+        {/* Portal renders the MenuList outside the tile DOM so our tile focus trap
+            does not include its items in the parent Tab cycle when the menu is open. */}
+        <Portal>
+          <MenuList
+            bg="white"
+            border="none"
+            borderRadius="5px"
+            boxShadow="0 0 5px 0 rgba(0, 0, 0, 0.35)"
+            className="color-menu-list"
+            data-testid="color-menu-list"
+            display="grid"
+            gap={0}
+            gridTemplateColumns="repeat(2, 1fr)"
+            zIndex={1}
+          >
+            {clueDataColorInfo.map((colorInfo, index) => (
+              <MenuItem
+                className="color-menu-list-item"
+                data-testid="color-menu-list-item"
+                key={colorInfo.name}
+                aria-label={colorInfo.name}
+                onClick={() => handleColorSelect(index)}
+              >
+                <div className="color-button">
+                  <div className="color-swatch" style={{ backgroundColor: colorInfo.color }} />
+                </div>
+              </MenuItem>
+            ))}
+          </MenuList>
+        </Portal>
       </Menu>
       <div className={classNames("attribute-value-name", { missing: missingData })}>
         {display}

--- a/src/plugins/drawing/components/drawing-layer.tsx
+++ b/src/plugins/drawing/components/drawing-layer.tsx
@@ -465,7 +465,11 @@ export class InternalDrawingLayerView extends React.Component<InternalDrawingLay
       tabIndex: 0,
       role: "button" as const,
       ariaLabel: object.ariaLabel,
-      onBlur: () => this.getContent().setSelectedIds([]),
+      onBlur: (e: React.FocusEvent<SVGGElement>) => {
+        // Only clear selection when focus leaves this object entirely (not to a descendant)
+        if (e.relatedTarget && e.currentTarget.contains(e.relatedTarget as Node)) return;
+        this.getContent().setSelectedIds([]);
+      },
     } : undefined;
     return renderDrawingObject(object, this.props.readOnly, hoverAction, pointerDownAction, a11yProps);
   }

--- a/src/plugins/drawing/components/drawing-layer.tsx
+++ b/src/plugins/drawing/components/drawing-layer.tsx
@@ -465,6 +465,7 @@ export class InternalDrawingLayerView extends React.Component<InternalDrawingLay
       tabIndex: 0,
       role: "button" as const,
       ariaLabel: object.ariaLabel,
+      onBlur: () => this.getContent().setSelectedIds([]),
     } : undefined;
     return renderDrawingObject(object, this.props.readOnly, hoverAction, pointerDownAction, a11yProps);
   }

--- a/src/plugins/drawing/components/drawing-tile.tsx
+++ b/src/plugins/drawing/components/drawing-tile.tsx
@@ -143,7 +143,9 @@ const DrawingToolComponent: React.FC<IDrawingTileProps> = observer(function Draw
       tileType: "drawing",
       getTitleElement: () => {
         const tile = drawingToolElement.current?.closest('.tool-tile');
-        return tile?.querySelector('.editable-tile-title') as HTMLElement | undefined;
+        const wrapper = tile?.querySelector('.editable-tile-title');
+        // Return the focusable element inside the wrapper: input (edit mode) or title-text (view mode)
+        return wrapper?.querySelector('input, .editable-tile-title-text') as HTMLElement | undefined;
       },
       getContentElement: () => drawingToolElement.current ?? undefined,
       focusContent: () => {

--- a/src/plugins/drawing/components/drawing-tile.tsx
+++ b/src/plugins/drawing/components/drawing-tile.tsx
@@ -34,7 +34,7 @@ import { VoiceTypingOverlay } from "../../../utilities/voice-typing-overlay";
 import { useContainerContext } from "../../../components/document/container-context";
 import { calculateFitContent } from "../model/drawing-utils";
 import { useClueAccessibility } from "../../../hooks/use-clue-accessibility";
-import { getVisibleFocusables } from "../../../utilities/dom-utils";
+import { getEditableTitleElement, getVisibleFocusables } from "../../../utilities/dom-utils";
 
 import "./drawing-tile.scss";
 
@@ -142,10 +142,8 @@ const DrawingToolComponent: React.FC<IDrawingTileProps> = observer(function Draw
       onUnregisterTileApi,
       tileType: "drawing",
       getTitleElement: () => {
-        const tile = drawingToolElement.current?.closest('.tool-tile');
-        const wrapper = tile?.querySelector('.editable-tile-title');
-        // Return the focusable element inside the wrapper: input (edit mode) or title-text (view mode)
-        return wrapper?.querySelector('input, .editable-tile-title-text') as HTMLElement | undefined;
+        const tile = drawingToolElement.current?.closest('.tool-tile') as HTMLElement | null;
+        return getEditableTitleElement(tile);
       },
       getContentElement: () => drawingToolElement.current ?? undefined,
       focusContent: () => {

--- a/src/plugins/drawing/components/drawing-tile.tsx
+++ b/src/plugins/drawing/components/drawing-tile.tsx
@@ -143,7 +143,7 @@ const DrawingToolComponent: React.FC<IDrawingTileProps> = observer(function Draw
       tileType: "drawing",
       getTitleElement: () => {
         const tile = drawingToolElement.current?.closest('.tool-tile');
-        return tile?.querySelector('.editable-tile-title-text') as HTMLElement | undefined;
+        return tile?.querySelector('.editable-tile-title') as HTMLElement | undefined;
       },
       getContentElement: () => drawingToolElement.current ?? undefined,
       focusContent: () => {

--- a/src/plugins/drawing/components/transformable.tsx
+++ b/src/plugins/drawing/components/transformable.tsx
@@ -17,7 +17,7 @@ export interface TransformableProps {
   role?: string;
   ariaLabel?: string;
   onKeyDown?: (e: React.KeyboardEvent<SVGGElement>) => void;
-  onBlur?: () => void;
+  onBlur?: React.FocusEventHandler<SVGGElement>;
 }
 
 /** Renders an SVG group with an optional translate and scale transform.

--- a/src/plugins/drawing/components/transformable.tsx
+++ b/src/plugins/drawing/components/transformable.tsx
@@ -17,6 +17,7 @@ export interface TransformableProps {
   role?: string;
   ariaLabel?: string;
   onKeyDown?: (e: React.KeyboardEvent<SVGGElement>) => void;
+  onBlur?: () => void;
 }
 
 /** Renders an SVG group with an optional translate and scale transform.
@@ -28,7 +29,7 @@ export interface TransformableProps {
  * @param children - The children to render inside the group.
  */
 export const Transformable: React.FC<TransformableProps> = ({
-  type, transform, setAnimating, children, objectId, tabIndex, role, ariaLabel, onKeyDown
+  type, transform, setAnimating, children, objectId, tabIndex, role, ariaLabel, onKeyDown, onBlur
 }) => {
   const prevTransform = React.useRef(transform);
   const [animated, setAnimated] = React.useState(transform);
@@ -108,6 +109,7 @@ export const Transformable: React.FC<TransformableProps> = ({
       role={role}
       aria-label={ariaLabel}
       onKeyDown={onKeyDown}
+      onBlur={onBlur}
     >
       {children}
     </g>

--- a/src/plugins/drawing/objects/drawing-object.tsx
+++ b/src/plugins/drawing/objects/drawing-object.tsx
@@ -311,7 +311,7 @@ export interface IDrawingComponentProps {
     role?: string;
     ariaLabel?: string;
     onKeyDown?: (e: React.KeyboardEvent<SVGGElement>) => void;
-    onBlur?: () => void;
+    onBlur?: React.FocusEventHandler<SVGGElement>;
   };
 }
 

--- a/src/plugins/drawing/objects/drawing-object.tsx
+++ b/src/plugins/drawing/objects/drawing-object.tsx
@@ -311,6 +311,7 @@ export interface IDrawingComponentProps {
     role?: string;
     ariaLabel?: string;
     onKeyDown?: (e: React.KeyboardEvent<SVGGElement>) => void;
+    onBlur?: () => void;
   };
 }
 

--- a/src/utilities/dom-utils.test.ts
+++ b/src/utilities/dom-utils.test.ts
@@ -16,7 +16,7 @@ describe("getEditableTitleElement", () => {
     const tile = document.createElement("div");
     tile.innerHTML = `
       <div class="editable-tile-title">
-        <div class="editable-tile-title-text" tabindex="-1" role="button">My Title</div>
+        <div class="editable-tile-title-text" tabindex="0" role="button">My Title</div>
       </div>
     `;
     const result = getEditableTitleElement(tile);
@@ -39,7 +39,7 @@ describe("getEditableTitleElement", () => {
     tile.innerHTML = `
       <div class="editable-tile-title">
         <input type="text" value="Editing" />
-        <div class="editable-tile-title-text" tabindex="-1">View Text</div>
+        <div class="editable-tile-title-text" tabindex="0">View Text</div>
       </div>
     `;
     const result = getEditableTitleElement(tile);

--- a/src/utilities/dom-utils.test.ts
+++ b/src/utilities/dom-utils.test.ts
@@ -1,0 +1,48 @@
+import { getEditableTitleElement } from "./dom-utils";
+
+describe("getEditableTitleElement", () => {
+  it("returns undefined for null input", () => {
+    expect(getEditableTitleElement(null)).toBeUndefined();
+    expect(getEditableTitleElement(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined when no .editable-tile-title wrapper exists", () => {
+    const tile = document.createElement("div");
+    tile.innerHTML = "<div>some content</div>";
+    expect(getEditableTitleElement(tile)).toBeUndefined();
+  });
+
+  it("returns .editable-tile-title-text in view mode", () => {
+    const tile = document.createElement("div");
+    tile.innerHTML = `
+      <div class="editable-tile-title">
+        <div class="editable-tile-title-text" tabindex="-1" role="button">My Title</div>
+      </div>
+    `;
+    const result = getEditableTitleElement(tile);
+    expect(result).toBe(tile.querySelector(".editable-tile-title-text"));
+  });
+
+  it("returns input element in edit mode", () => {
+    const tile = document.createElement("div");
+    tile.innerHTML = `
+      <div class="editable-tile-title">
+        <input type="text" value="My Title" />
+      </div>
+    `;
+    const result = getEditableTitleElement(tile);
+    expect(result).toBe(tile.querySelector("input"));
+  });
+
+  it("prefers input over title-text when both exist", () => {
+    const tile = document.createElement("div");
+    tile.innerHTML = `
+      <div class="editable-tile-title">
+        <input type="text" value="Editing" />
+        <div class="editable-tile-title-text" tabindex="-1">View Text</div>
+      </div>
+    `;
+    const result = getEditableTitleElement(tile);
+    expect(result).toBe(tile.querySelector("input"));
+  });
+});

--- a/src/utilities/dom-utils.ts
+++ b/src/utilities/dom-utils.ts
@@ -26,6 +26,16 @@ export function getVisibleFocusables(container: HTMLElement | Element): (HTMLEle
   });
 }
 
+/**
+ * Returns the focusable title element inside an .editable-tile-title wrapper.
+ * In view mode this is .editable-tile-title-text (tabindex=-1, programmatically focusable).
+ * In edit mode this is the <input> that replaces the text element.
+ */
+export function getEditableTitleElement(tileElement: HTMLElement | null | undefined): HTMLElement | undefined {
+  const wrapper = tileElement?.querySelector('.editable-tile-title');
+  return wrapper?.querySelector('input, .editable-tile-title-text') as HTMLElement | undefined;
+}
+
 // cf. https://developer.mozilla.org/en-US/docs/Web/API/Element/matches#Polyfill
 if (!Element.prototype.matches) {
   Element.prototype.matches = (Element.prototype as any).msMatchesSelector ||

--- a/src/utilities/dom-utils.ts
+++ b/src/utilities/dom-utils.ts
@@ -28,7 +28,7 @@ export function getVisibleFocusables(container: HTMLElement | Element): (HTMLEle
 
 /**
  * Returns the focusable title element inside an .editable-tile-title wrapper.
- * In view mode this is .editable-tile-title-text (tabindex=-1, programmatically focusable).
+ * In view mode this is .editable-tile-title-text (tabindex=0, keyboard focusable).
  * In edit mode this is the <input> that replaces the text element.
  */
 export function getEditableTitleElement(tileElement: HTMLElement | null | undefined): HTMLElement | undefined {


### PR DESCRIPTION
Migrate tile-component.tsx from hand-rolled Tab/Enter/Escape handling to the FocusTrapController from @concord-consortium/accessibility-tools. This removes ~120 lines of manual focus cycling, trap entry/exit, and content tabbing logic in favor of the controller's declarative strategy.

- Add onFocusEnter callback so clicking into a tile auto-enters its focus trap and selects it (fixes tileHandlesOwnSelection tiles like sketch where title clicks didn't trigger selection)
- Use live getters for title/content elements instead of capturing a stale snapshot at strategy build time
- Only rebuild focus trap strategy on selection transition (justSelected) to avoid churn on hover/scroll re-renders
- Guard onFocusEnter against double-selection for tiles that already call selectTileHandler
- Fix bar graph handleBarBlur to only clear selection when focus leaves the SVG entirely, not when moving between bars
- Update accessibility-tools to c313bd7 (adds onFocusEnter support)
- Update tests for click-to-enter behavior and Shift+Tab slot ordering