### PR TITLE
CLUE-501 Save WaveRunner and Timeline tiles from the authoring system

### DIFF
--- a/src/plugins/starter/starter-content.test.ts
+++ b/src/plugins/starter/starter-content.test.ts
@@ -16,4 +16,15 @@ describe("StarterContent", () => {
     const content = StarterContentModel.create();
     expect(content.isUserResizable).toBe(true);
   });
+
+  it("exports a JSON string including the persisted fields", () => {
+    const content = StarterContentModel.create({ text: "Greeting" });
+    const json = content.exportJson();
+    expect(typeof json).toBe("string");
+    expect(json.length).toBeGreaterThan(0);
+    expect(JSON.parse(json)).toEqual({
+      type: "Starter",
+      text: "Greeting"
+    });
+  });
 });

--- a/src/plugins/starter/starter-content.ts
+++ b/src/plugins/starter/starter-content.ts
@@ -1,5 +1,7 @@
-import { types, Instance } from "mobx-state-tree";
+import { getSnapshot, types, Instance } from "mobx-state-tree";
+import stringify from "json-stringify-pretty-compact";
 import { TileContentModel } from "../../models/tiles/tile-content";
+import { ITileExportOptions } from "../../models/tiles/tile-content-info";
 import { kStarterTileType } from "./starter-types";
 
 export function defaultStarterContent(): StarterContentModelType {
@@ -16,6 +18,9 @@ export const StarterContentModel = TileContentModel
   .views(self => ({
     get isUserResizable() {
       return true;
+    },
+    exportJson(options?: ITileExportOptions) {
+      return stringify(getSnapshot(self), {maxLength: 200});
     }
   }))
   .actions(self => ({

--- a/src/plugins/timeline/models/timeline-content.test.ts
+++ b/src/plugins/timeline/models/timeline-content.test.ts
@@ -28,6 +28,23 @@ describe("TimelineContent", () => {
     const content = TimelineContentModel.create();
     expect(content.isUserResizable).toBe(true);
   });
+
+  it("exports a JSON string including persisted fields", () => {
+    const content = TimelineContentModel.create({
+      viewStartTimeISO: "2026-02-01T00:00:00.000Z",
+      viewEndTimeISO: "2026-02-02T00:00:00.000Z",
+      selectedEventIndex: 3
+    });
+    const json = content.exportJson();
+    expect(typeof json).toBe("string");
+    expect(json.length).toBeGreaterThan(0);
+    expect(JSON.parse(json)).toEqual({
+      type: "Timeline",
+      viewStartTimeISO: "2026-02-01T00:00:00.000Z",
+      viewEndTimeISO: "2026-02-02T00:00:00.000Z",
+      selectedEventIndex: 3
+    });
+  });
 });
 
 describe("zoom functionality", () => {

--- a/src/plugins/timeline/models/timeline-content.ts
+++ b/src/plugins/timeline/models/timeline-content.ts
@@ -1,6 +1,8 @@
-import { types, Instance } from "mobx-state-tree";
+import { getSnapshot, types, Instance } from "mobx-state-tree";
 import { DateTime } from "luxon";
+import stringify from "json-stringify-pretty-compact";
 import { ITileContentModel, TileContentModel } from "../../../models/tiles/tile-content";
+import { ITileExportOptions } from "../../../models/tiles/tile-content-info";
 import { getSharedModelManager } from "../../../models/tiles/tile-environment";
 import { isValidDateTime } from "../../../utilities/luxon-utils";
 import { SharedDataSet, SharedDataSetType } from "../../../models/shared/shared-data-set";
@@ -24,6 +26,9 @@ export const TimelineContentModel = TileContentModel
   .views(self => ({
     get isUserResizable() {
       return true;
+    },
+    exportJson(options?: ITileExportOptions) {
+      return stringify(getSnapshot(self), {maxLength: 200});
     },
     get sharedSeismogram() {
       const smm = getSharedModelManager(self);

--- a/src/plugins/wave-runner/models/wave-runner-content.test.ts
+++ b/src/plugins/wave-runner/models/wave-runner-content.test.ts
@@ -69,6 +69,24 @@ describe("WaveRunnerContent", () => {
     expect(content.selectedModelMetadata).toBeNull();
   });
 
+  it("exports a JSON string including persisted fields", () => {
+    const content = WaveRunnerContentModel.create({
+      startDate: "2026-02-01",
+      endDate: "2026-02-03",
+      station: { network: "AK", station: "K204", location: "", channel: "HNZ", label: "Anchorage Airport" },
+      selectedModelUrl: "https://example.com/model/metadata.json"
+    });
+    const json = content.exportJson();
+    expect(typeof json).toBe("string");
+    expect(json.length).toBeGreaterThan(0);
+    const parsed = JSON.parse(json);
+    expect(parsed.type).toBe("WaveRunner");
+    expect(parsed.startDate).toBe("2026-02-01");
+    expect(parsed.endDate).toBe("2026-02-03");
+    expect(parsed.station).toMatchObject({ network: "AK", station: "K204", channel: "HNZ" });
+    expect(parsed.selectedModelUrl).toBe("https://example.com/model/metadata.json");
+  });
+
   it("DEFAULT_MODELS contains at least the compact model", () => {
     expect(DEFAULT_MODELS.length).toBeGreaterThanOrEqual(1);
     expect(DEFAULT_MODELS[0].label).toBe("Compact Model");

--- a/src/plugins/wave-runner/models/wave-runner-content.ts
+++ b/src/plugins/wave-runner/models/wave-runner-content.ts
@@ -1,5 +1,6 @@
 import { DateTime } from "luxon";
-import { cast, flow, types, Instance } from "mobx-state-tree";
+import stringify from "json-stringify-pretty-compact";
+import { cast, flow, getSnapshot, types, Instance } from "mobx-state-tree";
 import { miniseed } from "seisplotjs";
 import { fetchRawSeismicData } from "../../../../shared/seismic/earthscope-client";
 import { SeismicModelRunner } from "../../../../shared/seismic/seismic-model-runner";
@@ -7,6 +8,7 @@ import { ModelMetadata, SeismicEvent } from "../../../../shared/seismic/seismic-
 import { addAttributeToDataSet, addCasesToDataSet, DataSet } from "../../../models/data/data-set";
 import { SharedDataSet, SharedDataSetType } from "../../../models/shared/shared-data-set";
 import { ITileContentModel, TileContentModel } from "../../../models/tiles/tile-content";
+import { ITileExportOptions } from "../../../models/tiles/tile-content-info";
 import { getSharedModelManager } from "../../../models/tiles/tile-environment";
 import { SharedSeismogram, SharedSeismogramType } from "../../shared-seismogram/shared-seismogram";
 import { StationModel, StationSnapshot } from "../../shared-seismogram/station-model";
@@ -71,6 +73,9 @@ export const WaveRunnerContentModel = TileContentModel
   .views(self => ({
     get isUserResizable() {
       return true;
+    },
+    exportJson(options?: ITileExportOptions) {
+      return stringify(getSnapshot(self), {maxLength: 200});
     },
     get sharedSeismogram(): SharedSeismogramType | undefined {
       const smm = getSharedModelManager(self);


### PR DESCRIPTION
CLUE-501

## Summary
- Adds `exportJson` to the WaveRunner and Timeline content models so the authoring system persists them. Without `exportJson` on the content model, `TileModel.exportJson` returns `undefined` and the tile is silently dropped from the exported document — which is what flows through the authoring iframe's `onSnapshot` → `exportAsJson` → `postMessage` pipeline.
- Adds the same `exportJson` view to the Starter tile so new tiles copied from the starter template save correctly by default.
- Matches the pattern used by BarGraph / Expression: serialize `getSnapshot(self)` with `json-stringify-pretty-compact`. None of these content models have cross-tile id references, so no `tileMap` remapping is needed.

Jira: [CLUE-501](https://concord-consortium.atlassian.net/browse/CLUE-501)

## Test plan
- [x] In the authoring system, open a unit whose toolbar includes WaveRunner and Timeline (e.g. the `seismic` unit on the `seismicAuth` branch of `clue-curriculum`), using `https://collaborative-learning.concord.org/branch/waverunner-timeline-export-json/authoring/` so the iframe loads this branch's build.
- [x] Add a WaveRunner tile and a Timeline tile to the document.
- [x] Switch to the "Raw JSON (Admin Only)" tab — both tiles should now appear in the saved JSON. You need to move to another section in the authoring system and back again to get the RawJSON tab to refresh.
- [x] Reload the authoring page — both tiles should come back with their persisted state (WaveRunner: dates, station, selected model URL; Timeline: view range, selected event index).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CLUE-501]: https://concord-consortium.atlassian.net/browse/CLUE-501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ