### PR TITLE
CLUE-485: prevent document corruption (GD-6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,8 @@ npm run test:cypress           # Run Cypress E2E tests headless
 npm run test:cypress:open      # Open Cypress interactive UI
 
 # Code Quality
-npm run lint                   # ESLint check
+npm run lint                   # ESLint check (use during development)
+npm run lint:build             # Stricter check that also flags unnecessarily disabled rules — run before committing
 npm run lint:fix               # ESLint with auto-fix
 npm run check:types            # TypeScript type checking
 

--- a/src/components/document/history-view-panel.tsx
+++ b/src/components/document/history-view-panel.tsx
@@ -152,6 +152,14 @@ export const HistoryViewPanel: React.FC<IHistoryViewPanelProps> = observer(funct
                 >
                   Resume After 5s
                 </button>
+                <button
+                  className={concurrentManager.pausedDownloads ? "paused" : ""}
+                  onClick={() => concurrentManager.pausedDownloads
+                    ? concurrentManager.resumeDownloads()
+                    : concurrentManager.pauseDownloads()}
+                >
+                  {concurrentManager.pausedDownloads ? "Resume Downloads" : "Pause Downloads"}
+                </button>
               </div>
             )}
           </div>

--- a/src/hooks/use-document-sync-to-firebase.ts
+++ b/src/hooks/use-document-sync-to-firebase.ts
@@ -16,6 +16,7 @@ import { useMutation, UseMutationOptions } from "react-query";
 import { ITileMapEntry } from "../../shared/shared";
 import { DocumentContentSnapshotType } from "src/models/document/document-content";
 import { IArrowAnnotation } from "src/models/annotations/arrow-annotation";
+import { TreeManagerType } from "../models/history/tree-manager";
 
 function debugLog(...args: any[]) {
   // eslint-disable-next-line no-console
@@ -217,8 +218,22 @@ export function useDocumentSyncToFirebase(
       console.warn(`ERROR: Failed to update document content for ${type} document ${key}:`, document.changeCount);
     }
   };
-  const transform = (snapshot: DocumentContentSnapshotType) =>
-    ({ changeCount: document.incChangeCount(), content: JSON.stringify(snapshot) });
+  const transform = (snapshot: DocumentContentSnapshotType) => {
+    // Record the id of the last history entry that had been applied when
+    // this content snapshot was captured. The drift check on document load
+    // compares this to the Firestore history — if the id isn't present in
+    // the history, the content reflects edits that never made it to the
+    // history chain.
+    const treeManager = document.treeManagerAPI as TreeManagerType | undefined;
+    const lastHistoryEntryId = treeManager?.latestDocumentHistoryEntry?.id;
+    const base = {
+      changeCount: document.incChangeCount(),
+      content: JSON.stringify(snapshot)
+    };
+    return lastHistoryEntryId
+      ? { ...base, lastHistoryEntryId }
+      : base;
+  };
 
   const mutation = useMutation((snapshot: DocumentContentSnapshotType) => {
     if (!disconnectHandlers.current && commonSyncEnabled) {

--- a/src/lib/db-types.ts
+++ b/src/lib/db-types.ts
@@ -119,6 +119,12 @@ export interface DBDocument {
   };
   content?: string;
   changeCount?: number;
+  // Id of the last history entry that had been applied when this content
+  // snapshot was saved. Used to detect drift between RTDB content and the
+  // Firestore history chain on load. Duplicates a value that also lives in
+  // Firestore (metadata.lastHistoryEntry) because we need it co-located with
+  // the content in RTDB — we can't transact across RTDB and Firestore.
+  lastHistoryEntryId?: string;
   type: DBDocumentType;
 }
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -865,7 +865,7 @@ export class DB {
 
           const content = this.parseDocumentContent(document);
           try {
-            return createDocumentModel({
+            const docModel = createDocumentModel({
               type,
               title,
               properties: { ...properties, ...metadata.properties },
@@ -882,6 +882,13 @@ export class DB {
               investigation,
               unit
             });
+            // Stash the envelope's lastHistoryEntryId for the drift check that
+            // runs once the Firestore history loads. Skipped (undefined) for
+            // pre-feature saves and fresh docs with no prior history.
+            if (typeof document.lastHistoryEntryId === "string") {
+              docModel.setSavedLastHistoryEntryId(document.lastHistoryEntryId);
+            }
+            return docModel;
           } catch (e) {
             const msg = "Could not open " +
                         `document '${documentKey}' of type '${type}' for user '${userId}'.` +

--- a/src/models/document/document.ts
+++ b/src/models/document/document.ts
@@ -82,6 +82,12 @@ export const DocumentModel = Tree.named("Document")
     contentErrorMessage: undefined as string | undefined,
     showPlaybackControls: false,
     commentsManager: undefined as DocumentCommentsManager | undefined,
+    // Value of envelope.lastHistoryEntryId loaded from RTDB — the id of the
+    // last history entry that had been applied when this content snapshot
+    // was saved. Used once at history-load time to detect drift between the
+    // loaded content and the Firestore history chain. Undefined for pre-
+    // feature saves or fresh docs with no prior history.
+    savedLastHistoryEntryId: undefined as string | undefined,
   }))
   .views(self => ({
     // This is needed for the tree monitor and manager
@@ -286,6 +292,10 @@ export const DocumentModel = Tree.named("Document")
       self.contentStatus = ContentStatus.Error;
       self.invalidContent = content;
       self.contentErrorMessage = message;
+    },
+
+    setSavedLastHistoryEntryId(id: string | undefined) {
+      self.savedLastHistoryEntryId = id;
     }
   }))
   .actions(self => ({

--- a/src/models/history/firestore-history-manager-concurrent.test.ts
+++ b/src/models/history/firestore-history-manager-concurrent.test.ts
@@ -244,13 +244,10 @@ describe("FirestoreHistoryManagerConcurrent", () => {
       // Simulate local user A: made a local edit L1 that set
       // items[1].color = "red". The patch has already been applied
       // locally, and L1 is in local history and in the upload queue.
-      const l1Snapshot = makeEntrySnapshot(
-        "L1",
-        "main",
-        [{ op: "replace", path: "/items/1/color", value: "red" }],
-        [{ op: "replace", path: "/items/1/color", value: "white" }],
-      );
-      applyPatch(tree, l1Snapshot.records![0]!.patches as IJsonPatch[]);
+      const l1Patches: IJsonPatch[] = [{ op: "replace", path: "/items/1/color", value: "red" }];
+      const l1InversePatches: IJsonPatch[] = [{ op: "replace", path: "/items/1/color", value: "white" }];
+      const l1Snapshot = makeEntrySnapshot("L1", "main", l1Patches, l1InversePatches);
+      applyPatch(tree, l1Patches);
       const l1Entry = HistoryEntry.create(l1Snapshot);
       manager.addHistoryEntryAfterApplying(l1Entry);
       historyManager.completedHistoryEntryQueue.push(l1Entry);

--- a/src/models/history/firestore-history-manager-concurrent.test.ts
+++ b/src/models/history/firestore-history-manager-concurrent.test.ts
@@ -182,4 +182,65 @@ describe("FirestoreHistoryManagerConcurrent", () => {
       expect(historyManager.expectedRemoteHead).toBe("R1");
     });
   });
+
+  describe("applyHistoryEntries — receive-side fork", () => {
+    it("rolls back local uncommitted entries when a remote entry arrives with a mismatched previousEntryId", async () => {
+      // Mock so the manager's initial-last-history-entry load
+      // seeds expectedRemoteHead to "r0".
+      getLastHistoryEntry.mockResolvedValue({ id: "r0", index: 0 });
+      const { manager, tree, historyManager } = await setupManager();
+      expect(historyManager.expectedRemoteHead).toBe("r0");
+
+      // Baseline: 3 items. A prior remote entry r0 is the last known
+      // remote-chain tail.
+      tree.setItems([
+        Item.create({ id: "a" }),
+        Item.create({ id: "b" }),
+        Item.create({ id: "c" }),
+      ]);
+
+      // Simulate local user A: made a local edit L1 that set
+      // items[1].color = "red". The patch has already been applied
+      // locally, and L1 is in local history and in the upload queue.
+      const l1Snapshot = makeEntrySnapshot(
+        "L1",
+        "main",
+        [{ op: "replace", path: "/items/1/color", value: "red" }],
+        [{ op: "replace", path: "/items/1/color", value: "white" }],
+      );
+      applyPatch(tree, l1Snapshot.records![0]!.patches as IJsonPatch[]);
+      const l1Entry = HistoryEntry.create(l1Snapshot);
+      manager.addHistoryEntryAfterApplying(l1Entry);
+      historyManager.completedHistoryEntryQueue.push(l1Entry);
+
+      // Sanity: local state currently reflects A's edit.
+      expect(tree.items[1].color).toBe("red");
+
+      // Incoming remote entry R1 from user B: remove items[0].
+      // previousEntryId = "r0", which matches expectedRemoteHead but
+      // NOT our local head (which is L1) — that's the fork.
+      const r1Snapshot = makeEntrySnapshot(
+        "R1",
+        "main",
+        [{ op: "remove", path: "/items/0" }],
+        [{ op: "add", path: "/items/0", value: { id: "a", color: "white" } }],
+      );
+      const r1wrap = makeWrapperDoc(1, "r0", r1Snapshot);
+
+      await historyManager.applyHistoryEntries([r1wrap]);
+
+      // Post-fix expectations:
+      // 1. L1 is rolled back (items[1].color back to white).
+      // 2. R1 applied (items[0] "a" removed).
+      // 3. L1 removed from local history; R1 added.
+      // 4. L1 removed from upload queue.
+      // 5. expectedRemoteHead advances to R1.
+      expect(tree.items.map(i => i.id)).toEqual(["b", "c"]);
+      expect(tree.items[0].color).toBe("white");
+      expect(tree.items[1].color).toBe("white");
+      expect(manager.document.history.map(e => e.id)).toEqual(["R1"]);
+      expect(historyManager.completedHistoryEntryQueue.map(e => e.id)).toEqual([]);
+      expect(historyManager.expectedRemoteHead).toBe("R1");
+    });
+  });
 });

--- a/src/models/history/firestore-history-manager-concurrent.test.ts
+++ b/src/models/history/firestore-history-manager-concurrent.test.ts
@@ -226,7 +226,7 @@ describe("FirestoreHistoryManagerConcurrent", () => {
   });
 
   describe("applyHistoryEntries — receive-side fork", () => {
-    it("rolls back local uncommitted entries when a remote entry arrives with a mismatched previousEntryId", async () => {
+    it("rolls back local uncommitted entries on mismatched previousEntryId", async () => {
       // Mock so the manager's initial-last-history-entry load
       // seeds expectedRemoteHead to "r0".
       getLastHistoryEntry.mockResolvedValue({ id: "r0", index: 0 });

--- a/src/models/history/firestore-history-manager-concurrent.test.ts
+++ b/src/models/history/firestore-history-manager-concurrent.test.ts
@@ -328,4 +328,92 @@ describe("FirestoreHistoryManagerConcurrent", () => {
       expect(historyManager.expectedRemoteHead).toBe("r0");
     });
   });
+
+  describe("applyHistoryEntries — serialization", () => {
+    it("waits for a prior applyHistoryEntries call to finish before starting the next", async () => {
+      const { tree, historyManager } = await setupManager();
+      tree.setItems([Item.create({ id: "a" })]);
+
+      // Intercept tree.applyPatchesFromManager so we can block the
+      // first invocation and observe when the second one would start.
+      const patchCalls: number[] = [];
+      let releaseFirstApply!: () => void;
+      const firstApplyGate = new Promise<void>(resolve => {
+        releaseFirstApply = resolve;
+      });
+      const originalApply = tree.applyPatchesFromManager;
+      tree.applyPatchesFromManager = jest.fn(async (h, e, patches) => {
+        const callIndex = patchCalls.length;
+        patchCalls.push(callIndex);
+        if (callIndex === 0) {
+          await firstApplyGate;
+        }
+        return originalApply.call(tree, h, e, patches);
+      }) as any;
+
+      const e1 = makeEntrySnapshot(
+        "E1", "main",
+        [{ op: "replace", path: "/items/0/color", value: "red" }],
+        [{ op: "replace", path: "/items/0/color", value: "white" }],
+      );
+      const e2 = makeEntrySnapshot(
+        "E2", "main",
+        [{ op: "replace", path: "/items/0/color", value: "blue" }],
+        [{ op: "replace", path: "/items/0/color", value: "red" }],
+      );
+
+      // Kick off two applies concurrently.
+      const p1 = historyManager.applyHistoryEntries([makeWrapperDoc(0, undefined, e1)]);
+      const p2 = historyManager.applyHistoryEntries([makeWrapperDoc(1, "E1", e2)]);
+
+      // Flush a few microtasks so p1 has a chance to reach applyPatchesFromManager.
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+
+      // Only the first apply should have reached the tree.
+      expect(patchCalls).toEqual([0]);
+
+      // Release p1 — p2 should then start.
+      releaseFirstApply();
+      await p1;
+      await p2;
+
+      expect(patchCalls).toEqual([0, 1]);
+      expect(tree.items[0].color).toBe("blue");
+    });
+
+    it("does not stall subsequent apply calls when a prior one rejects", async () => {
+      const { tree, historyManager } = await setupManager();
+      tree.setItems([Item.create({ id: "a" })]);
+
+      let shouldFail = true;
+      const originalApply = tree.applyPatchesFromManager;
+      tree.applyPatchesFromManager = jest.fn(async (h, e, patches) => {
+        if (shouldFail) {
+          shouldFail = false;
+          throw new Error("boom");
+        }
+        return originalApply.call(tree, h, e, patches);
+      }) as any;
+
+      const e1 = makeEntrySnapshot(
+        "E1", "main",
+        [{ op: "replace", path: "/items/0/color", value: "red" }],
+        [{ op: "replace", path: "/items/0/color", value: "white" }],
+      );
+      const e2 = makeEntrySnapshot(
+        "E2", "main",
+        [{ op: "replace", path: "/items/0/color", value: "green" }],
+        [{ op: "replace", path: "/items/0/color", value: "white" }],
+      );
+
+      // First call rejects.
+      await expect(
+        historyManager.applyHistoryEntries([makeWrapperDoc(0, undefined, e1)])
+      ).rejects.toThrow("boom");
+
+      // Second call should still run and succeed.
+      await historyManager.applyHistoryEntries([makeWrapperDoc(1, undefined, e2)]);
+      expect(tree.items[0].color).toBe("green");
+    });
+  });
 });

--- a/src/models/history/firestore-history-manager-concurrent.test.ts
+++ b/src/models/history/firestore-history-manager-concurrent.test.ts
@@ -63,13 +63,34 @@ const ArrayTestTree = types.model("ArrayTestTree", {
   },
 }));
 
-function makeFirestoreMock(): Firestore {
-  const docRef = () => {
-    const ref: any = { path: "mock/path" };
+interface FirestoreMockOptions {
+  // Value returned for metadata.lastHistoryEntry inside the transaction.
+  txMetadataLastHistoryEntry?: { id: string; index: number } | null;
+}
+
+interface FirestoreMockCapture {
+  transactionSetCalls: Array<{ ref: any; data: any }>;
+  transactionUpdateCalls: Array<{ ref: any; data: any }>;
+}
+
+function makeFirestoreMock(opts: FirestoreMockOptions = {}): {
+  firestore: Firestore;
+  capture: FirestoreMockCapture;
+} {
+  const capture: FirestoreMockCapture = {
+    transactionSetCalls: [],
+    transactionUpdateCalls: [],
+  };
+  const makeDocRef = (...parts: string[]): any => {
+    const ref: any = { path: parts.join("/") };
+    // The manager chains .withConverter(...) off documentRef before
+    // passing to transaction.get; return the same ref so subsequent
+    // calls keep the identity and the mock transaction.get can read
+    // from it.
     ref.withConverter = () => ref;
     return ref;
   };
-  return {
+  const firestore = {
     doc: jest.fn(() => ({
       get: jest.fn(async () => ({ exists: true })),
       onSnapshot: jest.fn((callback: (doc: { exists: boolean }) => void) => {
@@ -78,8 +99,27 @@ function makeFirestoreMock(): Firestore {
       }),
     })),
     getFullPath: jest.fn((path: string) => path),
-    documentRef: jest.fn(() => docRef()),
+    documentRef: jest.fn((...parts: string[]) => makeDocRef(...parts)),
+    timestamp: jest.fn(() => new Date()),
+    runTransaction: jest.fn(async (fn: (tx: any) => Promise<void>) => {
+      const tx = {
+        get: jest.fn(async () => ({
+          exists: true,
+          data: () => ({
+            lastHistoryEntry: opts.txMetadataLastHistoryEntry ?? null,
+          }),
+        })),
+        set: jest.fn((ref: any, data: any) => {
+          capture.transactionSetCalls.push({ ref, data });
+        }),
+        update: jest.fn((ref: any, data: any) => {
+          capture.transactionUpdateCalls.push({ ref, data });
+        }),
+      };
+      await fn(tx);
+    }),
   } as unknown as Firestore;
+  return { firestore, capture };
 }
 
 function makeUserContextProviderMock(): UserContextProvider {
@@ -92,7 +132,7 @@ function makeUserContextProviderMock(): UserContextProvider {
 // waitUntilEnvironmentAndMetadataDocReady and an initial
 // last-history-entry load (which writes to expectedRemoteHead). We
 // await both here so each test starts in a deterministic state.
-async function setupManager() {
+async function setupManager(firestoreOpts: FirestoreMockOptions = {}) {
   const treeId = "main";
   const manager = TreeManager.create({ document: {}, undoStore: {} });
   const tree = ArrayTestTree.create({ key: treeId, uid: "test-user" });
@@ -100,18 +140,20 @@ async function setupManager() {
   // not need a separate putTree call.
   manager.setMainDocument(tree as any);
 
+  const { firestore, capture } = makeFirestoreMock(firestoreOpts);
+
   const historyManager = new FirestoreHistoryManagerConcurrent({
-    firestore: makeFirestoreMock(),
+    firestore,
     userContextProvider: makeUserContextProviderMock(),
     treeManager: manager,
-    uploadLocalHistory: false,
+    uploadLocalHistory: true,
     syncRemoteHistory: false,
   });
 
   await historyManager.environmentAndMetadataDocReadyPromise;
   await historyManager.getInitialLastHistoryEntry();
 
-  return { manager, tree, historyManager, treeId };
+  return { manager, tree, historyManager, treeId, firestoreCapture: capture };
 }
 
 // Build a HistoryEntrySnapshot with a single record on the given tree.
@@ -241,6 +283,49 @@ describe("FirestoreHistoryManagerConcurrent", () => {
       expect(manager.document.history.map(e => e.id)).toEqual(["R1"]);
       expect(historyManager.completedHistoryEntryQueue.map(e => e.id)).toEqual([]);
       expect(historyManager.expectedRemoteHead).toBe("R1");
+    });
+  });
+
+  describe("uploadQueuedHistoryEntries — send-side fork", () => {
+    it("aborts the upload transaction when metadata.lastHistoryEntry.id doesn't match expectedRemoteHead", async () => {
+      // Simulate: our client believes the remote head is "r0", but
+      // between queueing L1 and running the transaction, client B has
+      // already uploaded R1 (so the metadata now reports R1 as head).
+      getLastHistoryEntry.mockResolvedValue({ id: "r0", index: 0 });
+      const { manager, historyManager, firestoreCapture } = await setupManager({
+        txMetadataLastHistoryEntry: { id: "R1", index: 1 },
+      });
+      expect(historyManager.expectedRemoteHead).toBe("r0");
+
+      // Queue a local entry L1.
+      const l1Snapshot = makeEntrySnapshot(
+        "L1",
+        "main",
+        [{ op: "replace", path: "/items/1/color", value: "red" }],
+        [{ op: "replace", path: "/items/1/color", value: "white" }],
+      );
+      const l1Entry = HistoryEntry.create(l1Snapshot);
+      manager.addHistoryEntryAfterApplying(l1Entry);
+      historyManager.completedHistoryEntryQueue.push(l1Entry);
+
+      // Make environmentAndMetadataDocReadyPromise resolve immediately
+      // so the transaction body actually runs.
+      historyManager.environmentAndMetadataDocReadyPromise = Promise.resolve();
+
+      // Invoke upload. Should detect the mismatch and NOT write the entry.
+      await historyManager.uploadQueuedHistoryEntries();
+
+      // Transaction.set should NOT have been called for L1 — the
+      // upload is aborted because remote head differs from expected.
+      expect(firestoreCapture.transactionSetCalls).toEqual([]);
+
+      // L1 stays in the queue (receive-side rollback will remove it
+      // when the listener eventually delivers R1).
+      expect(historyManager.completedHistoryEntryQueue.map(e => e.id)).toEqual(["L1"]);
+
+      // expectedRemoteHead is unchanged — only a successful upload
+      // advances it on the send side.
+      expect(historyManager.expectedRemoteHead).toBe("r0");
     });
   });
 });

--- a/src/models/history/firestore-history-manager-concurrent.test.ts
+++ b/src/models/history/firestore-history-manager-concurrent.test.ts
@@ -1,0 +1,185 @@
+import { applyPatch, IJsonPatch, Instance, types } from "mobx-state-tree";
+import { Firestore } from "../../lib/firestore";
+import { UserContextProvider } from "../stores/user-context-provider";
+import { TreeManager } from "./tree-manager";
+import { HistoryEntry, HistoryEntrySnapshot } from "./history";
+import { IFirestoreHistoryEntryDoc, getLastHistoryEntry as _getLastHistoryEntry } from "./history-firestore";
+import { FirestoreHistoryManagerConcurrent } from "./firestore-history-manager-concurrent";
+
+jest.mock("./history-firestore");
+const getLastHistoryEntry = jest.mocked(_getLastHistoryEntry);
+
+// Minimal tree with an array of items, modeling a drawing-like tile.
+// Patches to this tree use numeric array indices, which is the
+// source of the corruption GD-6 is preventing: when a remote entry
+// removes items[0], the local patch targeting items[1] silently
+// lands on a different object.
+//
+// `key` and `uid` are here so an instance can be registered as the
+// TreeManager's mainDocument. waitUntilEnvironmentAndMetadataDocReady
+// checks for a mainDocument with a key before allowing history work,
+// and setMainDocument uses `key` to also register the document as the
+// tree for that id.
+const Item = types.model("Item", {
+  id: types.identifier,
+  color: types.optional(types.string, "white"),
+});
+interface ItemType extends Instance<typeof Item> {}
+
+const ArrayTestTree = types.model("ArrayTestTree", {
+  key: types.string,
+  uid: types.string,
+  items: types.array(Item),
+})
+.volatile(self => ({
+  applyingManagerPatches: false,
+  // Stub metadata to satisfy the IMainDocument shape; nothing reads it
+  // in these tests.
+  metadata: {} as any,
+}))
+.views(self => ({
+  get treeId(): string { return self.key; },
+}))
+.actions(self => ({
+  setItems(newItems: ItemType[]) {
+    self.items.replace(newItems);
+  },
+
+  // --- TreeAPI surface ---
+  startApplyingPatchesFromManager(_h: string, _e: string) {
+    self.applyingManagerPatches = true;
+    return Promise.resolve();
+  },
+  applyPatchesFromManager(_h: string, _e: string, patchesToApply: readonly IJsonPatch[]) {
+    applyPatch(self, patchesToApply as IJsonPatch[]);
+    return Promise.resolve();
+  },
+  finishApplyingPatchesFromManager(_h: string, _e: string) {
+    self.applyingManagerPatches = false;
+    return Promise.resolve();
+  },
+  applySharedModelSnapshotFromManager(_h: string, _e: string, _s: any) {
+    return Promise.resolve();
+  },
+}));
+
+function makeFirestoreMock(): Firestore {
+  const docRef = () => {
+    const ref: any = { path: "mock/path" };
+    ref.withConverter = () => ref;
+    return ref;
+  };
+  return {
+    doc: jest.fn(() => ({
+      get: jest.fn(async () => ({ exists: true })),
+      onSnapshot: jest.fn((callback: (doc: { exists: boolean }) => void) => {
+        callback({ exists: true });
+        return jest.fn();
+      }),
+    })),
+    getFullPath: jest.fn((path: string) => path),
+    documentRef: jest.fn(() => docRef()),
+  } as unknown as Firestore;
+}
+
+function makeUserContextProviderMock(): UserContextProvider {
+  return {
+    userContext: { uid: "test-user" },
+  } as unknown as UserContextProvider;
+}
+
+// Async because the manager's constructor schedules an async
+// waitUntilEnvironmentAndMetadataDocReady and an initial
+// last-history-entry load (which writes to expectedRemoteHead). We
+// await both here so each test starts in a deterministic state.
+async function setupManager() {
+  const treeId = "main";
+  const manager = TreeManager.create({ document: {}, undoStore: {} });
+  const tree = ArrayTestTree.create({ key: treeId, uid: "test-user" });
+  // setMainDocument also registers the tree under its key, so we do
+  // not need a separate putTree call.
+  manager.setMainDocument(tree as any);
+
+  const historyManager = new FirestoreHistoryManagerConcurrent({
+    firestore: makeFirestoreMock(),
+    userContextProvider: makeUserContextProviderMock(),
+    treeManager: manager,
+    uploadLocalHistory: false,
+    syncRemoteHistory: false,
+  });
+
+  await historyManager.environmentAndMetadataDocReadyPromise;
+  await historyManager.getInitialLastHistoryEntry();
+
+  return { manager, tree, historyManager, treeId };
+}
+
+// Build a HistoryEntrySnapshot with a single record on the given tree.
+function makeEntrySnapshot(
+  id: string,
+  treeId: string,
+  patches: IJsonPatch[],
+  inversePatches: IJsonPatch[],
+): HistoryEntrySnapshot {
+  return {
+    id,
+    tree: treeId,
+    model: "ArrayTestTree",
+    action: "/test",
+    undoable: true,
+    state: "complete",
+    records: [{
+      tree: treeId,
+      action: "/test",
+      patches,
+      inversePatches,
+    }],
+  };
+}
+
+// Build an IFirestoreHistoryEntryDoc wrapping a snapshot.
+function makeWrapperDoc(
+  index: number,
+  previousEntryId: string | undefined,
+  entry: HistoryEntrySnapshot,
+): IFirestoreHistoryEntryDoc {
+  return { index, previousEntryId, entry };
+}
+
+describe("FirestoreHistoryManagerConcurrent", () => {
+  beforeEach(() => {
+    getLastHistoryEntry.mockReset();
+    getLastHistoryEntry.mockResolvedValue(undefined);
+  });
+
+  describe("applyHistoryEntries — non-forked path", () => {
+    it("applies a remote entry that continues from the local head", async () => {
+      // Mock returns undefined (no prior remote history), so after
+      // setupManager awaits the init, expectedRemoteHead is null.
+      const { tree, historyManager } = await setupManager();
+
+      // Initial state: 3 items.
+      tree.setItems([
+        Item.create({ id: "a" }),
+        Item.create({ id: "b" }),
+        Item.create({ id: "c" }),
+      ]);
+
+      // Remote entry R1: set items[1].color = "red".
+      // previousEntryId = undefined (matches our null expectedRemoteHead).
+      const r1 = makeEntrySnapshot(
+        "R1",
+        "main",
+        [{ op: "replace", path: "/items/1/color", value: "red" }],
+        [{ op: "replace", path: "/items/1/color", value: "white" }],
+      );
+      const r1wrap = makeWrapperDoc(0, undefined, r1);
+
+      await historyManager.applyHistoryEntries([r1wrap]);
+
+      expect(tree.items.map(i => i.id)).toEqual(["a", "b", "c"]);
+      expect(tree.items[1].color).toBe("red");
+      expect(historyManager.expectedRemoteHead).toBe("R1");
+    });
+  });
+});

--- a/src/models/history/firestore-history-manager-concurrent.test.ts
+++ b/src/models/history/firestore-history-manager-concurrent.test.ts
@@ -324,6 +324,63 @@ describe("FirestoreHistoryManagerConcurrent", () => {
       // advances it on the send side.
       expect(historyManager.expectedRemoteHead).toBe("r0");
     });
+
+    it("waits for getInitialLastHistoryEntry to seed expectedRemoteHead before the fork check", async () => {
+      // Regression: if an upload is triggered before
+      // getInitialLastHistoryEntry resolves, expectedRemoteHead is
+      // still null, and any document with existing remote history
+      // would spuriously throw RemoteHeadChangedError inside the
+      // transaction.
+      let resolveInit!: (v: any) => void;
+      getLastHistoryEntry.mockImplementation(
+        () => new Promise<any>(resolve => { resolveInit = resolve; })
+      );
+
+      // Inline setup — setupManager awaits init, which we specifically
+      // want to leave pending here.
+      const treeId = "main";
+      const manager = TreeManager.create({ document: {}, undoStore: {} });
+      const tree = ArrayTestTree.create({ key: treeId, uid: "test-user" });
+      manager.setMainDocument(tree as any);
+      const { firestore, capture } = makeFirestoreMock({
+        txMetadataLastHistoryEntry: { id: "r0", index: 0 },
+      });
+      const historyManager = new FirestoreHistoryManagerConcurrent({
+        firestore,
+        userContextProvider: makeUserContextProviderMock(),
+        treeManager: manager,
+        uploadLocalHistory: true,
+        syncRemoteHistory: false,
+      });
+      await historyManager.environmentAndMetadataDocReadyPromise;
+      expect(historyManager.expectedRemoteHead).toBeNull();
+
+      // Queue L1 and kick off the upload while init is still pending.
+      const l1Snapshot = makeEntrySnapshot(
+        "L1", "main",
+        [{ op: "replace", path: "/items/0/color", value: "red" }],
+        [{ op: "replace", path: "/items/0/color", value: "white" }],
+      );
+      const l1Entry = HistoryEntry.create(l1Snapshot);
+      manager.addHistoryEntryAfterApplying(l1Entry);
+      historyManager.completedHistoryEntryQueue.push(l1Entry);
+
+      const uploadPromise = historyManager.uploadQueuedHistoryEntries();
+
+      // Flush microtasks: the transaction must NOT have run yet.
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      expect(capture.transactionSetCalls).toEqual([]);
+      expect(historyManager.expectedRemoteHead).toBeNull();
+
+      // Resolve init — expectedRemoteHead seeds to "r0", matching the
+      // mocked metadata head, so the transaction proceeds.
+      resolveInit({ id: "r0", index: 0 });
+      await uploadPromise;
+
+      expect(capture.transactionSetCalls.length).toBe(1);
+      expect(historyManager.completedHistoryEntryQueue.map(e => e.id)).toEqual([]);
+      expect(historyManager.expectedRemoteHead).toBe("L1");
+    });
   });
 
   describe("applyHistoryEntries — serialization", () => {

--- a/src/models/history/firestore-history-manager-concurrent.ts
+++ b/src/models/history/firestore-history-manager-concurrent.ts
@@ -46,6 +46,18 @@ export class FirestoreHistoryManagerConcurrent extends FirestoreHistoryManager {
   paused = false;
 
   /**
+   * Stop processing remote history entries delivered by the Firestore
+   * listener. Only used manually from the history-view panel to set up
+   * fork scenarios deterministically — specifically, to drive the
+   * send-side RemoteHeadChangedError path, which otherwise races the
+   * listener. loadHistory delivers the full remote state on each
+   * snapshot, so we simply buffer the latest delivery and replay it on
+   * resume.
+   */
+  pausedDownloads = false;
+  pendingDownloadBuffer: IFirestoreHistoryEntryDoc[] | undefined;
+
+  /**
    * Serialization chain for applyHistoryEntries. Each call awaits the
    * previous promise before doing work so that concurrent listener
    * firings don't cause interleaved mutations of document.history and
@@ -84,9 +96,12 @@ export class FirestoreHistoryManagerConcurrent extends FirestoreHistoryManager {
     // an action so MobX batches its mutation.
     makeObservable<this, "setExpectedRemoteHead">(this, {
       paused: observable,
+      pausedDownloads: observable,
       expectedRemoteHead: observable,
       pauseUploads: action,
       resumeUploadsAfterDelay: action,
+      pauseDownloads: action,
+      resumeDownloads: action,
       setExpectedRemoteHead: action,
     });
   }
@@ -122,6 +137,19 @@ export class FirestoreHistoryManagerConcurrent extends FirestoreHistoryManager {
     }, delayMs);
   }
 
+  pauseDownloads() {
+    this.pausedDownloads = true;
+  }
+
+  resumeDownloads() {
+    this.pausedDownloads = false;
+    const buffered = this.pendingDownloadBuffer;
+    this.pendingDownloadBuffer = undefined;
+    if (buffered) {
+      this.applyHistoryEntries(buffered);
+    }
+  }
+
   private setExpectedRemoteHead(id: string | null) {
     this.expectedRemoteHead = id;
   }
@@ -138,6 +166,14 @@ export class FirestoreHistoryManagerConcurrent extends FirestoreHistoryManager {
       throw new Error("syncRemoteFirestoreHistory: no change document exists yet");
       // If we need to create the change document here, we can use this code:
       // treeManager.setChangeDocument(CDocument.create({history: []}));
+    }
+
+    if (this.pausedDownloads) {
+      // Buffer the latest delivery; loadHistory sends the full remote
+      // state on every snapshot, so later deliveries supersede earlier
+      // ones. resumeDownloads replays the latest buffered state.
+      this.pendingDownloadBuffer = historyEntryDocs;
+      return;
     }
 
     // Pass the wrapper docs through so applyHistoryEntries retains

--- a/src/models/history/firestore-history-manager-concurrent.ts
+++ b/src/models/history/firestore-history-manager-concurrent.ts
@@ -262,6 +262,83 @@ export class FirestoreHistoryManagerConcurrent extends FirestoreHistoryManager {
     }
   }
 
+  /**
+   * Roll back the last `count` entries of the local history by applying
+   * their inverse patches (in reverse order). Also drops the
+   * corresponding entries from the upload queue by id.
+   *
+   * Used after fork detection on the receive side. The caller has
+   * verified these trailing entries are local-uncommitted (they live
+   * in document.history after expectedRemoteHead) before invoking.
+   */
+  async rollbackLocalEntries(count: number): Promise<void> {
+    if (count <= 0) return;
+    const { treeManager } = this;
+    const history = treeManager.document.history;
+    const entriesToRollback = history.slice(history.length - count).reverse();
+    const rolledBackIds = new Set(entriesToRollback.map(e => e.id));
+
+    const trees = Object.values(treeManager.trees);
+    await Promise.all(trees.map(tree =>
+      tree.startApplyingPatchesFromManager(FAKE_HISTORY_ENTRY_ID, FAKE_EXCHANGE_ID)));
+
+    // Each entry's inverse patches, grouped by tree, applied newest-first.
+    const treePatches: Record<string, IJsonPatch[]> = {};
+    Object.keys(treeManager.trees).forEach(treeId => { treePatches[treeId] = []; });
+    for (const entry of entriesToRollback) {
+      const records = [...entry.records].reverse();
+      for (const record of records) {
+        const patches = treePatches[record.tree];
+        if (patches) patches.push(...record.getPatches(HistoryOperation.Undo));
+      }
+    }
+
+    await Promise.all(Object.entries(treePatches).map(([treeId, patches]) => {
+      if (patches.length === 0) return undefined;
+      const tree = treeManager.trees[treeId];
+      return tree?.applyPatchesFromManager(FAKE_HISTORY_ENTRY_ID, FAKE_EXCHANGE_ID, patches);
+    }));
+
+    await Promise.all(trees.map(tree =>
+      tree.finishApplyingPatchesFromManager(FAKE_HISTORY_ENTRY_ID, FAKE_EXCHANGE_ID)));
+
+    // Remove the rolled-back entries from local history and upload queue.
+    treeManager.removeTailHistoryEntries(count);
+    this.completedHistoryEntryQueue =
+      this.completedHistoryEntryQueue.filter(e => !rolledBackIds.has(e.id));
+  }
+
+  /**
+   * Check whether the incoming remote entries continue from our local
+   * head. If not, we've forked: roll back local uncommitted entries
+   * (those living after expectedRemoteHead in document.history) and
+   * then fall through to normal application.
+   *
+   * This is the single place fork resolution happens on the receive
+   * side. GD-9/GD-10 will extend this to merge non-conflicting
+   * changes instead of rolling them all back.
+   */
+  async detectAndResolveFork(newWrapperDocs: IFirestoreHistoryEntryDoc[]): Promise<void> {
+    if (newWrapperDocs.length === 0) return;
+
+    const history = this.treeManager.document.history;
+    const localHeadId = history.length > 0 ? history[history.length - 1].id : null;
+    const firstIncomingPrev = newWrapperDocs[0].previousEntryId ?? null;
+
+    if (firstIncomingPrev === localHeadId) {
+      // Not forked — the incoming stream continues from our head.
+      return;
+    }
+
+    // Forked. Everything after expectedRemoteHead in our local history
+    // is local-uncommitted and must be rolled back.
+    const headIndex = this.expectedRemoteHead
+      ? history.findIndex(e => e.id === this.expectedRemoteHead)
+      : -1;
+    const localUncommittedCount = history.length - (headIndex + 1);
+    await this.rollbackLocalEntries(localUncommittedCount);
+  }
+
   // The second half of this method is very similar to gotoHistoryEntry in TreeManager
   async applyHistoryEntries(wrapperDocs: IFirestoreHistoryEntryDoc[]) {
     const { treeManager } = this;
@@ -299,11 +376,22 @@ export class FirestoreHistoryManagerConcurrent extends FirestoreHistoryManager {
     // above.
     const existingIds = new Set(existingHistory.map(e => e.id));
     const entrySnapshots: HistoryEntrySnapshot[] = [];
-    for (const entry of unappliedHistory) {
+    const newWrapperDocs: IFirestoreHistoryEntryDoc[] = [];
+    for (let i = 0; i < unappliedHistory.length; i++) {
+      const entry = unappliedHistory[i];
       if (!existingIds.has(entry.id)) {
         entrySnapshots.push(entry);
+        // wrapperDocs and unappliedHistory may be offset if some
+        // initial entries were filtered by getInitialLastHistoryEntry.
+        // Find the wrapper for this entry by id.
+        const wrap = wrapperDocs.find(w => w.entry.id === entry.id);
+        if (wrap) newWrapperDocs.push(wrap);
       }
     }
+
+    // Fork detection: if the first new entry doesn't continue from our
+    // local head, roll back local uncommitted entries first.
+    await this.detectAndResolveFork(newWrapperDocs);
 
     const trees = Object.values(treeManager.trees);
 

--- a/src/models/history/firestore-history-manager-concurrent.ts
+++ b/src/models/history/firestore-history-manager-concurrent.ts
@@ -388,7 +388,7 @@ export class FirestoreHistoryManagerConcurrent extends FirestoreHistoryManager {
       tree.finishApplyingPatchesFromManager(FAKE_HISTORY_ENTRY_ID, FAKE_EXCHANGE_ID)));
 
     // Remove the rolled-back entries from local history and upload queue.
-    treeManager.removeTailHistoryEntries(count);
+    treeManager.removeLastHistoryEntries(count);
     this.completedHistoryEntryQueue =
       this.completedHistoryEntryQueue.filter(e => !rolledBackIds.has(e.id));
   }

--- a/src/models/history/firestore-history-manager-concurrent.ts
+++ b/src/models/history/firestore-history-manager-concurrent.ts
@@ -45,6 +45,15 @@ export class FirestoreHistoryManagerConcurrent extends FirestoreHistoryManager {
    */
   paused = false;
 
+  /**
+   * Serialization chain for applyHistoryEntries. Each call awaits the
+   * previous promise before doing work so that concurrent listener
+   * firings don't cause interleaved mutations of document.history and
+   * the upload queue. Rejection-safe: the chain continues even after
+   * a prior call throws.
+   */
+  applyInProgress: Promise<void> = Promise.resolve();
+
   initialLastHistoryPromise: Promise<LastHistoryEntry> | undefined;
 
   constructor(args: IFirestoreHistoryManagerArgs) {
@@ -379,8 +388,25 @@ export class FirestoreHistoryManagerConcurrent extends FirestoreHistoryManager {
     await this.rollbackLocalEntries(localUncommittedCount);
   }
 
+  /**
+   * Public entry point. Serializes concurrent callers by chaining
+   * through applyInProgress. Each call waits for the previous to
+   * finish (even if the previous rejected) before doing work.
+   */
+  async applyHistoryEntries(wrapperDocs: IFirestoreHistoryEntryDoc[]): Promise<void> {
+    const previous = this.applyInProgress;
+    const run = (async () => {
+      try { await previous; } catch { /* prior call failed — still run */ }
+      return this.doApplyHistoryEntries(wrapperDocs);
+    })();
+    // Record a rejection-safe handle so future callers don't inherit
+    // a rejected promise (which would then re-throw on every await).
+    this.applyInProgress = run.then(() => undefined, () => undefined);
+    return run;
+  }
+
   // The second half of this method is very similar to gotoHistoryEntry in TreeManager
-  async applyHistoryEntries(wrapperDocs: IFirestoreHistoryEntryDoc[]) {
+  private async doApplyHistoryEntries(wrapperDocs: IFirestoreHistoryEntryDoc[]) {
     const { treeManager } = this;
 
     // Carry the wrapper shape through the method so previousEntryId stays

--- a/src/models/history/firestore-history-manager-concurrent.ts
+++ b/src/models/history/firestore-history-manager-concurrent.ts
@@ -176,9 +176,10 @@ export class FirestoreHistoryManagerConcurrent extends FirestoreHistoryManager {
       return;
     }
 
-    // Pass the wrapper docs through so applyHistoryEntries retains
-    // previousEntryId for fork detection. The snapshots themselves are
-    // unwrapped inside applyHistoryEntries when they're actually applied.
+    // Pass the wrapper docs through so fork detection can see
+    // previousEntryId on each entry. Entries are unwrapped to
+    // HistoryEntrySnapshot inside doApplyHistoryEntries where they're
+    // actually applied to the tree.
     //
     // We do not use applySnapshot here because it would replace the entire history with
     // the remote history. Sometimes there will be local history entries that have not
@@ -477,16 +478,17 @@ export class FirestoreHistoryManagerConcurrent extends FirestoreHistoryManager {
     // TODO: this could be more efficient by combining it with the incomingHistory.findIndex()
     // above.
     const existingIds = new Set(existingHistory.map(e => e.id));
+    // Index wrappers by entry id for O(1) lookup below. unappliedHistory
+    // is a subset of incomingHistory (= wrapperDocs.map(doc => doc.entry)),
+    // so every entry we keep has a corresponding wrapper here by
+    // construction.
+    const wrapperById = new Map(wrapperDocs.map(w => [w.entry.id, w]));
     const entrySnapshots: HistoryEntrySnapshot[] = [];
     const newWrapperDocs: IFirestoreHistoryEntryDoc[] = [];
-    for (let i = 0; i < unappliedHistory.length; i++) {
-      const entry = unappliedHistory[i];
+    for (const entry of unappliedHistory) {
       if (!existingIds.has(entry.id)) {
         entrySnapshots.push(entry);
-        // wrapperDocs and unappliedHistory may be offset if some
-        // initial entries were filtered by getInitialLastHistoryEntry.
-        // Find the wrapper for this entry by id.
-        const wrap = wrapperDocs.find(w => w.entry.id === entry.id);
+        const wrap = wrapperById.get(entry.id);
         if (wrap) newWrapperDocs.push(wrap);
       }
     }

--- a/src/models/history/firestore-history-manager-concurrent.ts
+++ b/src/models/history/firestore-history-manager-concurrent.ts
@@ -54,9 +54,10 @@ export class FirestoreHistoryManagerConcurrent extends FirestoreHistoryManager {
     this.getInitialLastHistoryEntry();
 
     // Make paused observable so UI can react to changes.
-    // Cast to `any` is required because TypeScript's AnnotationsMap only
-    // exposes public members; `setExpectedRemoteHead` is private but must
-    // still be wrapped as an action so MobX batches its mutation.
+    // The <this, "setExpectedRemoteHead"> type parameter widens
+    // AnnotationsMap to include the private setter, which otherwise
+    // wouldn't be assignable. The method still needs to be wrapped as
+    // an action so MobX batches its mutation.
     makeObservable<this, "setExpectedRemoteHead">(this, {
       paused: observable,
       expectedRemoteHead: observable,

--- a/src/models/history/firestore-history-manager-concurrent.ts
+++ b/src/models/history/firestore-history-manager-concurrent.ts
@@ -24,6 +24,7 @@ export class FirestoreHistoryManagerConcurrent extends FirestoreHistoryManager {
    * upload.
    */
   expectedRemoteHead: string | null = null;
+
   /**
    * Stop uploading history entries from Firestore temporarily.
    */
@@ -52,8 +53,11 @@ export class FirestoreHistoryManagerConcurrent extends FirestoreHistoryManager {
     // history entries that are not in this list.
     this.getInitialLastHistoryEntry();
 
-    // Make paused observable so UI can react to changes
-    makeObservable(this, {
+    // Make paused observable so UI can react to changes.
+    // Cast to `any` is required because TypeScript's AnnotationsMap only
+    // exposes public members; `setExpectedRemoteHead` is private but must
+    // still be wrapped as an action so MobX batches its mutation.
+    makeObservable<this, "setExpectedRemoteHead">(this, {
       paused: observable,
       expectedRemoteHead: observable,
       pauseUploads: action,
@@ -69,9 +73,10 @@ export class FirestoreHistoryManagerConcurrent extends FirestoreHistoryManager {
       this.initialLastHistoryPromise = getLastHistoryEntry(firestore, documentPath).then(entry => {
         // Seed expectedRemoteHead from the initial load exactly once.
         // Later updates come from applyHistoryEntries / uploadQueuedHistoryEntries.
-        // setExpectedRemoteHead is registered as a MobX action via
-        // makeObservable, so this assignment is wrapped in an action
-        // context automatically.
+        // Calling setExpectedRemoteHead here is safe: the method is
+        // registered as a MobX action via makeObservable, so it creates
+        // its own action batch for the mutation even though the .then
+        // callback itself is not an action context.
         this.setExpectedRemoteHead(entry?.id ?? null);
         return entry;
       });
@@ -92,7 +97,7 @@ export class FirestoreHistoryManagerConcurrent extends FirestoreHistoryManager {
     }, delayMs);
   }
 
-  setExpectedRemoteHead(id: string | null) {
+  private setExpectedRemoteHead(id: string | null) {
     this.expectedRemoteHead = id;
   }
 
@@ -348,13 +353,13 @@ export class FirestoreHistoryManagerConcurrent extends FirestoreHistoryManager {
     });
     await Promise.all(finishPromises);
 
-    // Advance expectedRemoteHead to the last wrapper we just applied.
-    // Use the wrapper docs (not entries) so we're tracking the
-    // remote-chain id, not a local-uncommitted id. If nothing was
-    // applied (e.g. all were filtered by dedup), leave it alone.
-    const lastApplied = wrapperDocs[wrapperDocs.length - 1];
-    if (lastApplied) {
-      this.setExpectedRemoteHead(lastApplied.entry.id);
+    // Advance expectedRemoteHead to the id of the last wrapper we
+    // received. These came from the remote listener, so they're on the
+    // remote chain even if local history already contains some of them.
+    // If no wrappers were delivered, leave the head alone.
+    const lastWrapper = wrapperDocs[wrapperDocs.length - 1];
+    if (lastWrapper) {
+      this.setExpectedRemoteHead(lastWrapper.entry.id);
     }
   }
 }

--- a/src/models/history/firestore-history-manager-concurrent.ts
+++ b/src/models/history/firestore-history-manager-concurrent.ts
@@ -12,6 +12,19 @@ export class FirestoreHistoryManagerConcurrent extends FirestoreHistoryManager {
   completedHistoryEntryQueue: Array<HistoryEntryType> = [];
   uploadInProgress = false;
   /**
+   * The id of the entry we believe is currently the last entry on the
+   * remote chain. `null` means "no remote entries yet." Used for
+   * fork detection:
+   *   - Receive side: if an incoming remote entry's previousEntryId
+   *     differs from the local head (after dedup), we've forked.
+   *   - Send side: if metadata.lastHistoryEntry.id differs from this
+   *     during the upload transaction, someone else committed entries
+   *     we don't know about; we abort the upload.
+   * Updated after successful remote application and after successful
+   * upload.
+   */
+  expectedRemoteHead: string | null = null;
+  /**
    * Stop uploading history entries from Firestore temporarily.
    */
   paused = false;
@@ -42,8 +55,10 @@ export class FirestoreHistoryManagerConcurrent extends FirestoreHistoryManager {
     // Make paused observable so UI can react to changes
     makeObservable(this, {
       paused: observable,
+      expectedRemoteHead: observable,
       pauseUploads: action,
       resumeUploadsAfterDelay: action,
+      setExpectedRemoteHead: action,
     });
   }
 
@@ -51,7 +66,15 @@ export class FirestoreHistoryManagerConcurrent extends FirestoreHistoryManager {
     if (!this.initialLastHistoryPromise) {
       await this.environmentAndMetadataDocReadyPromise;
       const { firestore, documentPath } = this;
-      this.initialLastHistoryPromise = getLastHistoryEntry(firestore, documentPath);
+      this.initialLastHistoryPromise = getLastHistoryEntry(firestore, documentPath).then(entry => {
+        // Seed expectedRemoteHead from the initial load exactly once.
+        // Later updates come from applyHistoryEntries / uploadQueuedHistoryEntries.
+        // setExpectedRemoteHead is registered as a MobX action via
+        // makeObservable, so this assignment is wrapped in an action
+        // context automatically.
+        this.setExpectedRemoteHead(entry?.id ?? null);
+        return entry;
+      });
     }
     return this.initialLastHistoryPromise;
   }
@@ -67,6 +90,10 @@ export class FirestoreHistoryManagerConcurrent extends FirestoreHistoryManager {
       });
       this.uploadQueuedHistoryEntries();
     }, delayMs);
+  }
+
+  setExpectedRemoteHead(id: string | null) {
+    this.expectedRemoteHead = id;
   }
 
   syncRemoteFirestoreHistory(historyEntryDocs: IFirestoreHistoryEntryDoc[]): void {
@@ -212,6 +239,13 @@ export class FirestoreHistoryManagerConcurrent extends FirestoreHistoryManager {
       // If we made it here then the transaction succeeded so we can remove the entriesToUpload
       // from the queue.
       this.completedHistoryEntryQueue.splice(0, entriesToUpload.length);
+
+      // Advance expectedRemoteHead: our uploaded entries are now on the
+      // remote chain, so our last-uploaded id is the new head.
+      const lastUploaded = entriesToUpload[entriesToUpload.length - 1];
+      if (lastUploaded) {
+        this.setExpectedRemoteHead(lastUploaded.id);
+      }
     } finally {
       this.uploadInProgress = false;
     }
@@ -313,5 +347,14 @@ export class FirestoreHistoryManagerConcurrent extends FirestoreHistoryManager {
       return tree.finishApplyingPatchesFromManager(FAKE_HISTORY_ENTRY_ID, FAKE_EXCHANGE_ID);
     });
     await Promise.all(finishPromises);
+
+    // Advance expectedRemoteHead to the last wrapper we just applied.
+    // Use the wrapper docs (not entries) so we're tracking the
+    // remote-chain id, not a local-uncommitted id. If nothing was
+    // applied (e.g. all were filtered by dedup), leave it alone.
+    const lastApplied = wrapperDocs[wrapperDocs.length - 1];
+    if (lastApplied) {
+      this.setExpectedRemoteHead(lastApplied.entry.id);
+    }
   }
 }

--- a/src/models/history/firestore-history-manager-concurrent.ts
+++ b/src/models/history/firestore-history-manager-concurrent.ts
@@ -83,10 +83,10 @@ export class FirestoreHistoryManagerConcurrent extends FirestoreHistoryManager {
       // treeManager.setChangeDocument(CDocument.create({history: []}));
     }
 
-    // Not the most efficient but lets get the history entries from the historyEntryDocs
-    // If we unify on loadFirestoreHistory we can have it do this parsing for us
-    const incomingHistory: HistoryEntrySnapshot[] = historyEntryDocs.map(doc => doc.entry);
-
+    // Pass the wrapper docs through so applyHistoryEntries retains
+    // previousEntryId for fork detection. The snapshots themselves are
+    // unwrapped inside applyHistoryEntries when they're actually applied.
+    //
     // We do not use applySnapshot here because it would replace the entire history with
     // the remote history. Sometimes there will be local history entries that have not
     // yet been uploaded, so we can't just overwrite those.
@@ -95,7 +95,7 @@ export class FirestoreHistoryManagerConcurrent extends FirestoreHistoryManager {
     // than on other clients. That's because those other clients wouldn't have our local
     // entries yet.
     // This problem is being punted for now.
-    this.applyHistoryEntries(incomingHistory);
+    this.applyHistoryEntries(historyEntryDocs);
   }
 
   async onHistoryEntryCompleted(
@@ -223,8 +223,13 @@ export class FirestoreHistoryManagerConcurrent extends FirestoreHistoryManager {
   }
 
   // The second half of this method is very similar to gotoHistoryEntry in TreeManager
-  async applyHistoryEntries(incomingHistory: HistoryEntrySnapshot[]) {
+  async applyHistoryEntries(wrapperDocs: IFirestoreHistoryEntryDoc[]) {
     const { treeManager } = this;
+
+    // Carry the wrapper shape through the method so previousEntryId stays
+    // available for fork-detection in later steps. The snapshots themselves
+    // are what get applied to the tree.
+    const incomingHistory: HistoryEntrySnapshot[] = wrapperDocs.map(doc => doc.entry);
 
     // This should be the last entry that was applied to the document when it was first loaded.
     const lastEntry = await this.getInitialLastHistoryEntry();

--- a/src/models/history/firestore-history-manager-concurrent.ts
+++ b/src/models/history/firestore-history-manager-concurrent.ts
@@ -181,14 +181,21 @@ export class FirestoreHistoryManagerConcurrent extends FirestoreHistoryManager {
     // HistoryEntrySnapshot inside doApplyHistoryEntries where they're
     // actually applied to the tree.
     //
-    // We do not use applySnapshot here because it would replace the entire history with
-    // the remote history. Sometimes there will be local history entries that have not
-    // yet been uploaded, so we can't just overwrite those.
-    // Instead we just add the new history entries that aren't in our local history yet.
-    // This means that the history entries on this client will be in a different order
-    // than on other clients. That's because those other clients wouldn't have our local
-    // entries yet.
-    // This problem is being punted for now.
+    // We do not use applySnapshot here because it would replace the entire
+    // history with the remote history, discarding any local entries that
+    // haven't been uploaded yet. Instead doApplyHistoryEntries skips entries
+    // already in local history, and — via detectAndResolveFork →
+    // rollbackLocalEntries — rolls back local-uncommitted entries first when
+    // the incoming stream has forked away from expectedRemoteHead. After
+    // that, local history order matches remote order.
+    //
+    // FIXME: applyHistoryEntries is fire-and-forget here. It can reject
+    // (e.g., patch application or rollback failures) and those rejections
+    // surface as unhandled promise errors — see the similar pattern note in
+    // firestore-history-manager.ts around the metadata-doc timeout. We
+    // should route failures into setHistoryError / logging so they're
+    // handled deterministically. The same applies to the call in
+    // resumeDownloads below.
     this.applyHistoryEntries(historyEntryDocs);
   }
 
@@ -226,6 +233,16 @@ export class FirestoreHistoryManagerConcurrent extends FirestoreHistoryManager {
       // 1. Track when this has failed and stop retrying
       // 2. Show the user that sync is broken
       await this.environmentAndMetadataDocReadyPromise;
+
+      // Also wait for the initial last-history-entry fetch to seed
+      // expectedRemoteHead. Without this, a local edit queued before the
+      // seed resolves would hit the send-side fork check below with
+      // expectedRemoteHead still at its default null, spuriously throwing
+      // RemoteHeadChangedError for any document that already has remote
+      // history. After the first seed completes, subsequent uploads take
+      // the cached promise, so the extra await is effectively free.
+      await this.getInitialLastHistoryEntry();
+
       const { firestore } = this;
 
       // add a new document for this history entry

--- a/src/models/history/firestore-history-manager-concurrent.ts
+++ b/src/models/history/firestore-history-manager-concurrent.ts
@@ -7,6 +7,21 @@ import { CDocumentType, FAKE_EXCHANGE_ID, FAKE_HISTORY_ENTRY_ID } from "./tree-m
 import { HistoryEntry, HistoryEntrySnapshot, HistoryEntryType, HistoryOperation } from "./history";
 import { FirestoreHistoryManager, IFirestoreHistoryManagerArgs } from "./firestore-history-manager";
 
+/**
+ * Thrown inside the upload transaction when the remote chain's head
+ * has advanced past what we expected — meaning another client has
+ * committed entries we don't yet know about. Aborts the transaction
+ * so the pending uploads don't chain off a stale head. The receive
+ * side will pick up the unknown remote entries via the Firestore
+ * listener and trigger the shared rollback path.
+ */
+export class RemoteHeadChangedError extends Error {
+  constructor(public expected: string | null, public actual: string | null) {
+    super(`Remote head changed: expected ${expected}, actual ${actual}`);
+    this.name = "RemoteHeadChangedError";
+  }
+}
+
 export class FirestoreHistoryManagerConcurrent extends FirestoreHistoryManager {
 
   completedHistoryEntryQueue: Array<HistoryEntryType> = [];
@@ -155,6 +170,7 @@ export class FirestoreHistoryManagerConcurrent extends FirestoreHistoryManager {
       return;
     }
     this.uploadInProgress = true;
+    let uploadAborted = false;
 
     try {
       // The parent Firestore metadata document might not be ready yet so we need to wait for that.
@@ -192,72 +208,96 @@ export class FirestoreHistoryManagerConcurrent extends FirestoreHistoryManager {
         // Nothing to do
         return;
       }
-      await firestore.runTransaction(async (transaction) => {
+      try {
+        await firestore.runTransaction(async (transaction) => {
 
-        const converter = typeConverter<IDocumentMetadata>();
-        const metadataDoc = await transaction.get(firestore.documentRef(metadataPath).withConverter(converter));
+          const converter = typeConverter<IDocumentMetadata>();
+          const metadataDoc = await transaction.get(firestore.documentRef(metadataPath).withConverter(converter));
 
-        if (!metadataDoc.exists) {
-          // The metadata document must exist because we waited for it above
-          throw new Error("Could not get metadata document in history transaction");
-        }
-
-        const metadata = metadataDoc.data();
-        if (!metadata) {
-          throw new Error("Could not get metadata document data in history transaction");
-        }
-
-        const lastEntry = metadata.lastHistoryEntry;
-        let lastEntryIndex = lastEntry?.index ?? -1;
-        let lastEntryId = lastEntry?.id ?? null;
-
-        // TODO: if we want to migrate existing documents to this approach then if there is no lastHistoryEntry
-        // we need to look through the existing history entries. We can't do that in a transaction
-        // though. So we would need to do that before starting the transaction.
-        // This migration would not be safe if there are multiple clients writing history at the same time.
-        // The plan is to just use this for new group documents, so if there is some lost history
-        // for existing group documents that is OK.
-
-        entriesToUpload.forEach(entry => {
-          const newEntryIndex = lastEntryIndex + 1;
-
-          const docRef = firestore.documentRef(historyEntriesPath, entry.id);
-          const snapshot = getSnapshot(entry);
-
-          transaction.set(docRef, {
-            index: newEntryIndex,
-            created: firestore.timestamp(),
-            previousEntryId: lastEntryId,
-            entry: JSON.stringify(snapshot)
-          });
-          lastEntryIndex = newEntryIndex;
-          lastEntryId = entry.id;
-        });
-
-        transaction.update(firestore.documentRef(metadataPath), {
-          lastHistoryEntry: {
-            index: lastEntryIndex,
-            id: lastEntryId
+          if (!metadataDoc.exists) {
+            // The metadata document must exist because we waited for it above
+            throw new Error("Could not get metadata document in history transaction");
           }
+
+          const metadata = metadataDoc.data();
+          if (!metadata) {
+            throw new Error("Could not get metadata document data in history transaction");
+          }
+
+          const lastEntry = metadata.lastHistoryEntry;
+          let lastEntryIndex = lastEntry?.index ?? -1;
+          let lastEntryId = lastEntry?.id ?? null;
+
+          // Send-side fork check: if metadata's last-entry id differs
+          // from what we expect, another client has advanced the remote
+          // chain. Abort the transaction so we don't chain our local
+          // entries onto a stale head. The receive side will handle
+          // the rollback when the listener delivers the unknown entries.
+          if (lastEntryId !== this.expectedRemoteHead) {
+            throw new RemoteHeadChangedError(this.expectedRemoteHead, lastEntryId);
+          }
+
+          // TODO: if we want to migrate existing documents to this approach then if there is no lastHistoryEntry
+          // we need to look through the existing history entries. We can't do that in a transaction
+          // though. So we would need to do that before starting the transaction.
+          // This migration would not be safe if there are multiple clients writing history at the same time.
+          // The plan is to just use this for new group documents, so if there is some lost history
+          // for existing group documents that is OK.
+
+          entriesToUpload.forEach(entry => {
+            const newEntryIndex = lastEntryIndex + 1;
+
+            const docRef = firestore.documentRef(historyEntriesPath, entry.id);
+            const snapshot = getSnapshot(entry);
+
+            transaction.set(docRef, {
+              index: newEntryIndex,
+              created: firestore.timestamp(),
+              previousEntryId: lastEntryId,
+              entry: JSON.stringify(snapshot)
+            });
+            lastEntryIndex = newEntryIndex;
+            lastEntryId = entry.id;
+          });
+
+          transaction.update(firestore.documentRef(metadataPath), {
+            lastHistoryEntry: {
+              index: lastEntryIndex,
+              id: lastEntryId
+            }
+          });
         });
-      });
+      } catch (error) {
+        if (error instanceof RemoteHeadChangedError) {
+          // Expected: another client wrote between our read and this
+          // transaction. Leave the queue intact; the receive side
+          // will drain it after resolving the fork.
+          uploadAborted = true;
+        } else {
+          throw error;
+        }
+      }
 
-      // If we made it here then the transaction succeeded so we can remove the entriesToUpload
-      // from the queue.
-      this.completedHistoryEntryQueue.splice(0, entriesToUpload.length);
+      if (!uploadAborted) {
+        // Transaction succeeded: remove uploaded entries from the queue.
+        this.completedHistoryEntryQueue.splice(0, entriesToUpload.length);
 
-      // Advance expectedRemoteHead: our uploaded entries are now on the
-      // remote chain, so our last-uploaded id is the new head.
-      const lastUploaded = entriesToUpload[entriesToUpload.length - 1];
-      if (lastUploaded) {
-        this.setExpectedRemoteHead(lastUploaded.id);
+        // Advance expectedRemoteHead: our uploaded entries are now on the
+        // remote chain, so our last-uploaded id is the new head.
+        const lastUploaded = entriesToUpload[entriesToUpload.length - 1];
+        if (lastUploaded) {
+          this.setExpectedRemoteHead(lastUploaded.id);
+        }
       }
     } finally {
       this.uploadInProgress = false;
     }
 
-    // If there are more entries to upload, do that now
-    if (this.completedHistoryEntryQueue.length > 0) {
+    // If there are more entries to upload, do that now.
+    // But don't retry if we aborted due to a remote-head mismatch —
+    // the receive-side listener will re-trigger uploads after the fork
+    // is resolved.
+    if (!uploadAborted && this.completedHistoryEntryQueue.length > 0) {
       this.uploadQueuedHistoryEntries();
     }
   }

--- a/src/models/history/firestore-history-manager.ts
+++ b/src/models/history/firestore-history-manager.ts
@@ -28,6 +28,11 @@ export interface IFirestoreHistoryManagerArgs {
   treeManager: TreeManagerType;
   uploadLocalHistory: boolean;
   syncRemoteHistory: boolean;
+  // Id recorded alongside the document content at save time (from the RTDB
+  // envelope). When the Firestore history first loads, we verify this id is
+  // present in the history. If not, the content reflects entries that never
+  // made it to the history chain — drift. Undefined skips the check.
+  savedLastHistoryEntryId?: string;
 }
 
 /**
@@ -45,18 +50,22 @@ export class FirestoreHistoryManager {
   historyError = undefined as firebase.firestore.FirestoreError | undefined;
   environmentAndMetadataDocReadyPromise: Promise<void> | undefined;
   firestoreHistoryInfoPromise: Promise<IFirestoreHistoryInfo> | undefined;
+  savedLastHistoryEntryId: string | undefined;
+  driftChecked = false;
 
   constructor({
     firestore,
     userContextProvider,
     treeManager,
     uploadLocalHistory,
-    syncRemoteHistory
+    syncRemoteHistory,
+    savedLastHistoryEntryId
   }: IFirestoreHistoryManagerArgs) {
     this.firestore = firestore;
     this.userContextProvider = userContextProvider;
     this.treeManager = treeManager;
     this.uploadLocalHistory = uploadLocalHistory;
+    this.savedLastHistoryEntryId = savedLastHistoryEntryId;
 
     if (syncRemoteHistory) {
       this.subscribeToFirestoreHistory();
@@ -282,6 +291,48 @@ export class FirestoreHistoryManager {
   }
 
   /**
+   * Compare the envelope's saved lastHistoryEntryId against the loaded
+   * Firestore history. If the saved id isn't found in the history, the
+   * loaded content reflects edits that never made it to the history chain —
+   * drift. On mismatch, surface via DocumentModel.setContentError so the
+   * user sees the DocumentError UI instead of potentially-corrupted content.
+   *
+   * Skipped when no saved id is available (pre-feature envelopes, fresh
+   * documents with no prior history).
+   *
+   * This only runs when subscribeToFirestoreHistory is actually invoked,
+   * which today is gated by syncRemoteHistory=true in the manager args.
+   * In practice that means group documents (see documents.ts) and the
+   * playback path (see canvas.tsx). Playback doesn't pass
+   * savedLastHistoryEntryId so the check is a no-op there. Other document
+   * types never subscribe, so the drift check does not run for them.
+   */
+  checkContentDriftAgainstHistory(history: IFirestoreHistoryEntryDoc[]) {
+    const savedId = this.savedLastHistoryEntryId;
+    if (!savedId) return;
+    const found = history.some(doc => doc.entry?.id === savedId);
+    if (found) return;
+
+    const tailId = history.length > 0 ? history[history.length - 1].entry?.id : undefined;
+    const message =
+      `History drift detected: content was saved with lastHistoryEntryId="${savedId}" ` +
+      `but that id is not present in the Firestore history ` +
+      `(history length=${history.length}, tail id=${tailId ?? "none"}). ` +
+      `The content may reflect edits that never made it to the history chain.`;
+    // eslint-disable-next-line no-console
+    console.error("CLUE history drift:", message);
+
+    // Surface via the DocumentError UI. mainDocument on the TreeManager is
+    // set to the DocumentModel in the normal load flow (see documents.ts).
+    const mainDocument = this.treeManager.mainDocument as
+      { setContentError?: (content: object, message: string) => void } | undefined;
+    if (mainDocument?.setContentError) {
+      const content = (this.treeManager.mainDocument as any).content;
+      mainDocument.setContentError(content ? getSnapshot(content) : {}, message);
+    }
+  }
+
+  /**
    * This is called each time the remote history changes in Firestore
    */
   syncRemoteFirestoreHistory(historyDocs: IFirestoreHistoryEntryDoc[]) {
@@ -326,6 +377,13 @@ export class FirestoreHistoryManager {
         if (error) {
           this.setHistoryError(error);
         } else {
+          // Run the drift check once, on the first successful load. Subsequent
+          // snapshots are delta updates and don't represent the "as loaded"
+          // state the content was saved against.
+          if (!this.driftChecked) {
+            this.driftChecked = true;
+            this.checkContentDriftAgainstHistory(history);
+          }
           // FIXME: this is being called twice for a single change in the document.
           // I've confirmed there are not multiple listeners being created.
           // TODO: confirm this comment

--- a/src/models/history/firestore-history-manager.ts
+++ b/src/models/history/firestore-history-manager.ts
@@ -33,6 +33,11 @@ export interface IFirestoreHistoryManagerArgs {
   // present in the history. If not, the content reflects entries that never
   // made it to the history chain — drift. Undefined skips the check.
   savedLastHistoryEntryId?: string;
+  // Invoked once if the loaded Firestore history doesn't contain
+  // savedLastHistoryEntryId. The owner decides how to react — typically by
+  // setting the document content into an error state. Keeping this as a
+  // callback avoids the history layer having to import DocumentModel.
+  onContentDrift?: (message: string) => void;
 }
 
 /**
@@ -51,6 +56,7 @@ export class FirestoreHistoryManager {
   environmentAndMetadataDocReadyPromise: Promise<void> | undefined;
   firestoreHistoryInfoPromise: Promise<IFirestoreHistoryInfo> | undefined;
   savedLastHistoryEntryId: string | undefined;
+  onContentDrift: ((message: string) => void) | undefined;
   driftChecked = false;
 
   constructor({
@@ -59,13 +65,15 @@ export class FirestoreHistoryManager {
     treeManager,
     uploadLocalHistory,
     syncRemoteHistory,
-    savedLastHistoryEntryId
+    savedLastHistoryEntryId,
+    onContentDrift
   }: IFirestoreHistoryManagerArgs) {
     this.firestore = firestore;
     this.userContextProvider = userContextProvider;
     this.treeManager = treeManager;
     this.uploadLocalHistory = uploadLocalHistory;
     this.savedLastHistoryEntryId = savedLastHistoryEntryId;
+    this.onContentDrift = onContentDrift;
 
     if (syncRemoteHistory) {
       this.subscribeToFirestoreHistory();
@@ -294,8 +302,9 @@ export class FirestoreHistoryManager {
    * Compare the envelope's saved lastHistoryEntryId against the loaded
    * Firestore history. If the saved id isn't found in the history, the
    * loaded content reflects edits that never made it to the history chain —
-   * drift. On mismatch, surface via DocumentModel.setContentError so the
-   * user sees the DocumentError UI instead of potentially-corrupted content.
+   * drift. On mismatch, invoke onContentDrift so the owner can surface
+   * the DocumentError UI instead of leaving potentially-corrupted content
+   * visible to the user.
    *
    * Skipped when no saved id is available (pre-feature envelopes, fresh
    * documents with no prior history).
@@ -319,17 +328,9 @@ export class FirestoreHistoryManager {
       `but that id is not present in the Firestore history ` +
       `(history length=${history.length}, tail id=${tailId ?? "none"}). ` +
       `The content may reflect edits that never made it to the history chain.`;
-    // eslint-disable-next-line no-console
     console.error("CLUE history drift:", message);
 
-    // Surface via the DocumentError UI. mainDocument on the TreeManager is
-    // set to the DocumentModel in the normal load flow (see documents.ts).
-    const mainDocument = this.treeManager.mainDocument as
-      { setContentError?: (content: object, message: string) => void } | undefined;
-    if (mainDocument?.setContentError) {
-      const content = (this.treeManager.mainDocument as any).content;
-      mainDocument.setContentError(content ? getSnapshot(content) : {}, message);
-    }
+    this.onContentDrift?.(message);
   }
 
   /**

--- a/src/models/history/tree-manager.ts
+++ b/src/models/history/tree-manager.ts
@@ -231,6 +231,17 @@ export const TreeManager = types
     self.document.history.push(entry);
   },
 
+  /**
+   * Remove the last `count` entries from the local history. Used by
+   * FirestoreHistoryManagerConcurrent when it rolls back uncommitted
+   * local entries after detecting a fork with the remote chain.
+   */
+  removeTailHistoryEntries(count: number) {
+    if (count <= 0) return;
+    const start = Math.max(0, self.document.history.length - count);
+    self.document.history.splice(start, self.document.history.length - start);
+  },
+
   setChangeDocument(cDoc: CDocumentType) {
     self.document = cDoc;
   },

--- a/src/models/history/tree-manager.ts
+++ b/src/models/history/tree-manager.ts
@@ -235,10 +235,27 @@ export const TreeManager = types
    * Remove the last `count` entries from the local history. Used by
    * FirestoreHistoryManagerConcurrent when it rolls back uncommitted
    * local entries after detecting a fork with the remote chain.
+   *
+   * Also removes the corresponding entries from undoStore.history. The
+   * undo store holds MST references to HistoryEntry instances in
+   * document.history; if we spliced document.history first, those
+   * references would dangle and the next undoStore access would throw
+   * "Failed to resolve reference" — which was the root cause of the
+   * fork-rollback + local-edit crash that prevented change uploads.
    */
   removeTailHistoryEntries(count: number) {
     if (count <= 0) return;
     const start = Math.max(0, self.document.history.length - count);
+
+    // Collect ids while references in undoStore still resolve.
+    const removedIds = new Set<string>();
+    for (let i = start; i < self.document.history.length; i++) {
+      removedIds.add(self.document.history[i].id);
+    }
+
+    // Clean undoStore BEFORE removing entries from document.history.
+    self.undoStore.removeHistoryEntries(removedIds);
+
     self.document.history.splice(start, self.document.history.length - start);
   },
 

--- a/src/models/history/tree-manager.ts
+++ b/src/models/history/tree-manager.ts
@@ -243,7 +243,7 @@ export const TreeManager = types
    * "Failed to resolve reference" — which was the root cause of the
    * fork-rollback + local-edit crash that prevented change uploads.
    */
-  removeTailHistoryEntries(count: number) {
+  removeLastHistoryEntries(count: number) {
     if (count <= 0) return;
     const start = Math.max(0, self.document.history.length - count);
 

--- a/src/models/history/undo-store.test.ts
+++ b/src/models/history/undo-store.test.ts
@@ -940,7 +940,7 @@ async function expectUpdateToBeCalledTimes(testTile: TestTileType, times: number
   return expect(updateCalledTimes).resolves.toBeUndefined();
 }
 
-describe("removeTailHistoryEntries cleans up undoStore", () => {
+describe("removeLastHistoryEntries cleans up undoStore", () => {
   it("removes the corresponding undoStore references", async () => {
     const {tileContent, manager, undoStore} = setupDocument();
 
@@ -953,7 +953,7 @@ describe("removeTailHistoryEntries cleans up undoStore", () => {
     expect(undoStore.history.length).toBe(2);
     expect(undoStore.undoIdx).toBe(2);
 
-    manager.removeTailHistoryEntries(1);
+    manager.removeLastHistoryEntries(1);
 
     expect(manager.document.history.length).toBe(1);
     expect(undoStore.history.length).toBe(1);
@@ -962,11 +962,11 @@ describe("removeTailHistoryEntries cleans up undoStore", () => {
 
   it("allows a new undoable action after a rollback without MST reference errors", async () => {
     // This reproduces the exact crash that motivated the fix: after
-    // removeTailHistoryEntries, the next undoStore.addHistoryEntry call
+    // removeLastHistoryEntries, the next undoStore.addHistoryEntry call
     // used to throw "Failed to resolve reference" because the entry it
     // pointed at had been destroyed in document.history.
     //
-    // Note: removeTailHistoryEntries drops history entries but does NOT
+    // Note: removeLastHistoryEntries drops history entries but does NOT
     // revert the tree state — the fork-rollback path in
     // FirestoreHistoryManagerConcurrent applies inverse patches
     // separately. So flag is still true after the removal, and we flip
@@ -976,7 +976,7 @@ describe("removeTailHistoryEntries cleans up undoStore", () => {
     tileContent.setFlag(true);
     await expectEntryToBeComplete(manager, 1);
 
-    manager.removeTailHistoryEntries(1);
+    manager.removeLastHistoryEntries(1);
     expect(undoStore.history.length).toBe(0);
 
     // If the fix is working this completes without throwing.
@@ -999,7 +999,7 @@ describe("removeTailHistoryEntries cleans up undoStore", () => {
     expect(undoStore.history.length).toBe(2);
     expect(undoStore.undoIdx).toBe(2);
 
-    manager.removeTailHistoryEntries(2);
+    manager.removeLastHistoryEntries(2);
 
     expect(undoStore.history.length).toBe(0);
     // Both removals were at index < undoIdx, so undoIdx should have

--- a/src/models/history/undo-store.test.ts
+++ b/src/models/history/undo-store.test.ts
@@ -939,3 +939,96 @@ async function expectUpdateToBeCalledTimes(testTile: TestTileType, times: number
   const updateCalledTimes = when(() => testTile.updateCount === times, {timeout: 100});
   return expect(updateCalledTimes).resolves.toBeUndefined();
 }
+
+describe("removeTailHistoryEntries cleans up undoStore", () => {
+  it("removes the corresponding undoStore references", async () => {
+    const {tileContent, manager, undoStore} = setupDocument();
+
+    tileContent.setFlag(true);
+    await expectEntryToBeComplete(manager, 1);
+    tileContent.setFlag(false);
+    await expectEntryToBeComplete(manager, 2);
+
+    expect(manager.document.history.length).toBe(2);
+    expect(undoStore.history.length).toBe(2);
+    expect(undoStore.undoIdx).toBe(2);
+
+    manager.removeTailHistoryEntries(1);
+
+    expect(manager.document.history.length).toBe(1);
+    expect(undoStore.history.length).toBe(1);
+    expect(undoStore.undoIdx).toBe(1);
+  });
+
+  it("allows a new undoable action after a rollback without MST reference errors", async () => {
+    // This reproduces the exact crash that motivated the fix: after
+    // removeTailHistoryEntries, the next undoStore.addHistoryEntry call
+    // used to throw "Failed to resolve reference" because the entry it
+    // pointed at had been destroyed in document.history.
+    //
+    // Note: removeTailHistoryEntries drops history entries but does NOT
+    // revert the tree state — the fork-rollback path in
+    // FirestoreHistoryManagerConcurrent applies inverse patches
+    // separately. So flag is still true after the removal, and we flip
+    // it to false to trigger a new patch.
+    const {tileContent, manager, undoStore} = setupDocument();
+
+    tileContent.setFlag(true);
+    await expectEntryToBeComplete(manager, 1);
+
+    manager.removeTailHistoryEntries(1);
+    expect(undoStore.history.length).toBe(0);
+
+    // If the fix is working this completes without throwing.
+    tileContent.setFlag(false);
+    await expectEntryToBeComplete(manager, 1);
+
+    expect(undoStore.history.length).toBe(1);
+    expect(undoStore.canUndo).toBe(true);
+  });
+
+  it("decrements undoIdx when removing entries that were still 'done'", async () => {
+    const {tileContent, manager, undoStore} = setupDocument();
+
+    tileContent.setFlag(true);
+    await expectEntryToBeComplete(manager, 1);
+    tileContent.setFlag(false);
+    await expectEntryToBeComplete(manager, 2);
+
+    // Two undoable entries; cursor at the end.
+    expect(undoStore.history.length).toBe(2);
+    expect(undoStore.undoIdx).toBe(2);
+
+    manager.removeTailHistoryEntries(2);
+
+    expect(undoStore.history.length).toBe(0);
+    // Both removals were at index < undoIdx, so undoIdx should have
+    // decremented twice, landing at 0.
+    expect(undoStore.undoIdx).toBe(0);
+    expect(undoStore.canUndo).toBe(false);
+  });
+});
+
+describe("UndoStore.removeHistoryEntries", () => {
+  it("no-ops when given an empty id set", async () => {
+    const {tileContent, manager, undoStore} = setupDocument();
+    tileContent.setFlag(true);
+    await expectEntryToBeComplete(manager, 1);
+
+    undoStore.removeHistoryEntries(new Set());
+
+    expect(undoStore.history.length).toBe(1);
+    expect(undoStore.undoIdx).toBe(1);
+  });
+
+  it("ignores ids not present in the undo history", async () => {
+    const {tileContent, manager, undoStore} = setupDocument();
+    tileContent.setFlag(true);
+    await expectEntryToBeComplete(manager, 1);
+
+    undoStore.removeHistoryEntries(new Set(["does-not-exist"]));
+
+    expect(undoStore.history.length).toBe(1);
+    expect(undoStore.undoIdx).toBe(1);
+  });
+});

--- a/src/models/history/undo-store.ts
+++ b/src/models/history/undo-store.ts
@@ -169,7 +169,7 @@ export const UndoStore = types
 
     /**
      * Remove any entries whose id is in `ids` from the undo stack. Used by
-     * TreeManager.removeTailHistoryEntries when a fork rollback removes
+     * TreeManager.removeLastHistoryEntries when a fork rollback removes
      * entries from document.history: those entries are the resolution
      * targets of references held here, so they must be dropped from this
      * array before the referenced entries are destroyed — otherwise MST

--- a/src/models/history/undo-store.ts
+++ b/src/models/history/undo-store.ts
@@ -167,6 +167,29 @@ export const UndoStore = types
       self.undoIdx = self.history.length;
     },
 
+    /**
+     * Remove any entries whose id is in `ids` from the undo stack. Used by
+     * TreeManager.removeTailHistoryEntries when a fork rollback removes
+     * entries from document.history: those entries are the resolution
+     * targets of references held here, so they must be dropped from this
+     * array before the referenced entries are destroyed — otherwise MST
+     * throws "Failed to resolve reference" on the next access.
+     *
+     * Iterates in reverse so indices stay stable for subsequent splices.
+     * Decrements undoIdx for each removal at index < undoIdx so the
+     * done/redoable boundary tracks the same logical position.
+     */
+    removeHistoryEntries(ids: Set<string>) {
+      for (let i = self.history.length - 1; i >= 0; i--) {
+        if (ids.has(self.history[i].id)) {
+          self.history.splice(i, 1);
+          if (i < self.undoIdx) {
+            self.undoIdx--;
+          }
+        }
+      }
+    },
+
     // TODO: The MST undo manager that this code is based on, used atomic
     // operations for this. That way if the was an error applying the patch, then
     // the whole set of changes would be aborted. We do not currently take this

--- a/src/models/stores/documents.ts
+++ b/src/models/stores/documents.ts
@@ -262,7 +262,8 @@ export const DocumentsModel = types
           userContextProvider,
           treeManager,
           uploadLocalHistory: true,
-          syncRemoteHistory: false
+          syncRemoteHistory: false,
+          savedLastHistoryEntryId: document.savedLastHistoryEntryId
         };
         if (document.type === GroupDocument) {
           historyManagerArgs.syncRemoteHistory = true;

--- a/src/models/stores/documents.ts
+++ b/src/models/stores/documents.ts
@@ -1,5 +1,5 @@
 import { forEach } from "lodash";
-import { types } from "mobx-state-tree";
+import { getSnapshot, types } from "mobx-state-tree";
 import { observable } from "mobx";
 import { AppConfigModelType } from "./app-config-model";
 import { DocumentModelType } from "../document/document";
@@ -263,7 +263,12 @@ export const DocumentsModel = types
           treeManager,
           uploadLocalHistory: true,
           syncRemoteHistory: false,
-          savedLastHistoryEntryId: document.savedLastHistoryEntryId
+          savedLastHistoryEntryId: document.savedLastHistoryEntryId,
+          onContentDrift: (message) => {
+            const content = document.content;
+            const snapshot = content && getSnapshot(content);
+            document.setContentError(snapshot ?? {}, message);
+          }
         };
         if (document.type === GroupDocument) {
           historyManagerArgs.syncRemoteHistory = true;


### PR DESCRIPTION
Jira: CLUE-485
Updated design and status docs: https://github.com/concord-consortium/collaborative-learning/pull/2836

## Summary

Implements GD-6 from the group-docs plan: detect and resolve forks in the group-document history chain so concurrent edits can't produce corrupted state.

- **Receive-side fork detection** in `FirestoreHistoryManagerConcurrent`: when an incoming remote entry's `previousEntryId` disagrees with the local head, roll back local uncommitted entries via their inverse patches, drop them from the upload queue, then apply the remote entries. `detectAndResolveFork` is the extension point for GD-9/GD-10 merging exceptions.
- **Send-side abort**: inside the upload transaction, compare `metadata.lastHistoryEntry.id` to the locally-tracked `expectedRemoteHead`. On mismatch, throw `RemoteHeadChangedError` to abort and leave the queue intact; the listener will deliver the unknown entries and trigger the shared receive-side rollback.
- **Serialization**: chain concurrent `applyHistoryEntries` calls through an `applyInProgress` promise so listener double-firings can't interleave rollbacks against a mutating `document.history`.

## Additional fixes / improvements uncovered during manual testing

- **Pause-downloads** toggle in the history view panel — deterministic manual setup for the send-side abort scenario (parallels the existing pause-uploads).
- **Content/history drift detection**: persist the id of the last applied history entry in the RTDB envelope (`DBDocument.lastHistoryEntryId`) at save time; compare against the Firestore history chain on load. On mismatch, surface via the existing DocumentError UI instead of rendering potentially-corrupted content.
- **UndoStore cleanup on rollback**: root-cause fix for an MST "Failed to resolve reference" crash. `TreeManager.removeLastHistoryEntries` now cleans `UndoStore.history` references before splicing `document.history`.

## Out of scope (deferred)

- GD-9 / GD-10 per-tile / per-shared-model merging exceptions (plug into `detectAndResolveFork`)
- Faster send-side resolution (inline fetch + apply instead of abort + wait)
- Pre-existing race in initial history load (`FIXME` in `getInitialLastHistoryEntry`)
- Repair tool for already-drifted documents
- Drift check for non-group document types (the envelope field is already saved for all types; check only runs where `subscribeToFirestoreHistory` runs, i.e., group docs today)
- Cypress E2E for group documents
- Collaborative undo/redo soundness: remote entries are not added to the local undo stack, and pressing undo after a remote edit has touched the same area may apply stale inverse patches. Pre-existing behavior, not addressed here.

## Test plan

- [x] Full Jest suite passes locally (2341 tests, 224 suites) — ✅ verified on this branch
- [ ] Manually verify receive-side fork: user A pauses uploads → user B makes a change → user A resumes → A's edit reverts, B's change appears
- [ ] Manually verify send-side abort: user B pauses downloads → user A uploads a change → user B makes a change → B's upload aborts, change stays visible locally → B resumes downloads → B's change reverts, A's change appears
- [ ] Manually verify drift surfacing: user A pauses uploads → user A makes a change to the group document (saves envelope with a `lastHistoryEntryId` that hasn't been uploaded to Firestore yet) → user B reloads their page → B's view shows the DocumentError UI with the drift message instead of stale content
- [ ] Confirm pressing undo/redo after a fork-rollback does not throw (the crash fixed in `TreeManager.removeLastHistoryEntries` / `UndoStore.removeHistoryEntries`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)