### PR TITLE
docs: add GD-12/GD-13 dev tooling, undo/redo note, duplicate docs bug

### DIFF
--- a/docs/group-docs/group-docs-current-state.md
+++ b/docs/group-docs/group-docs-current-state.md
@@ -142,6 +142,12 @@ If a new column is added then User B sees the new attribute name.
 
 I don't know the exact steps yet, but I found that when a graph is connected to a table only one of the documents actually shows the points on the graph.
 
+## Duplicate Group Documents
+
+Two users in the same group ended up working on completely separate group documents rather than a shared one. The suspicion is that two group documents got created — possibly due to a race during document provisioning — and each user opened a different one.
+
+Not yet investigated. Unknowns: steps to reproduce, the provisioning code path involved, whether this happens reliably, and whether it's recoverable once it has occurred.
+
 # Implementation TODOs
 
 These are unfinished items identified in the code:

--- a/docs/group-docs/group-docs-current-state.md
+++ b/docs/group-docs/group-docs-current-state.md
@@ -2,6 +2,8 @@
 
 CLUE has some work in progress support for group documents that can be edited by multiple users at the same time. While this works in some cases when changes do not overlap, there are several cases that can break it. Below is a list of a few.
 
+GD-6 (PR #2835 / CLUE-485) introduces fork detection and rollback that should prevent the Model Inconsistency scenarios below. Those scenarios need to be retested once GD-6 lands. Confirmed fixes will be moved to a separate "fixed issues" document; anything still broken stays here.
+
 ## How It Works
 
 Group documents use `FirestoreHistoryManagerConcurrent` (in `src/models/history/firestore-history-manager-concurrent.ts`) which extends `FirestoreHistoryManager`. The key differences are:
@@ -88,26 +90,6 @@ If I remember right graph annotations have types which determine their shape. Pe
 
 The result seems to be same as if the tile is deleted by a single user after they made the sparrow connection. The sparrow shows up as a loop pointing to the same object.
 
-
-# Global Fix
-
-So far all the issues that have been explored above, could be addressed by a global change. When a change in the remote history is downloaded by a client, it can check if it has a local fork from this history. That would be a history entry that has the same previousEntryId as a different remote history entry. In this case the client should reverse its history until this fork point and then apply the remote history.
-
-Some of the infrastructure for this is already in place. `FirestoreHistoryManagerConcurrent.uploadQueuedHistoryEntries()` uses Firestore transactions to atomically write history entries and update a `lastHistoryEntry` field (index and id) on the metadata document. Each uploaded entry includes a `previousEntryId` linking it to the prior entry. This means conflicting writes are serialized on the server side — two clients can't both claim the same `previousEntryId`. However, the client does not yet detect when its local history has forked from the remote history, and does not roll back local changes when that happens. Currently, remote entries are just appended to local history regardless of whether they conflict (see `syncRemoteFirestoreHistory()`), which can result in the inconsistencies described above.
-
-What remains to be implemented is fork detection + rollback in two places, both routing through a single rollback codepath:
-
-1. **Receive side.** When a remote entry arrives via the Firestore listener (`syncRemoteFirestoreHistory()`) whose `previousEntryId` doesn't match the local head, reverse the local uncommitted entries (via their undo patches) back to the fork point, drop them from the upload queue, and apply the remote entries.
-
-2. **Send side.** Inside the upload transaction in `uploadQueuedHistoryEntries()`, compare the `metadata.lastHistoryEntry.id` read from Firestore to the locally-tracked expected remote head. If they differ, another client has committed entries this one doesn't know about yet. Abort the transaction. Without this, the current code blindly chains the queued local entries off whatever head it finds, even though those local entries were derived from a different base — the resulting remote records then claim a chain position they were not actually derived from. Once aborted, the Firestore listener will deliver the unknown entries and the receive-side handler drains the queue.
-
-Both paths share a single rollback method. GD-9 and GD-10 extend that method with per-tile / per-shared-model merging exceptions; routing both sides through it ensures those exceptions apply symmetrically.
-
-This approach will mean any conflicting changes will be lost by one of the users. If the users do not edit the same tile at the same time these conflicting changes should be minimal.
-
-This approach should guarantee that the document state and history state are valid, and that all users' documents show the same thing.
-
-In the future we can add special handling for certain cases so we can accept some changes even when there is a local fork. These would be changes that we know will not conflict with each other.
 
 # UI Issues
 

--- a/docs/group-docs/group-docs-current-state.md
+++ b/docs/group-docs/group-docs-current-state.md
@@ -2,7 +2,7 @@
 
 CLUE has some work in progress support for group documents that can be edited by multiple users at the same time. While this works in some cases when changes do not overlap, there are several cases that can break it. Below is a list of a few.
 
-GD-6 (PR #2835 / CLUE-485) introduces fork detection and rollback that should prevent the Model Inconsistency scenarios below. Those scenarios need to be retested once GD-6 lands. Confirmed fixes will be moved to a separate "fixed issues" document; anything still broken stays here.
+GD-6 (PR #2835 / CLUE-485, merged) introduces fork detection and rollback that should prevent the Model Inconsistency scenarios below. Those scenarios need to be retested. Confirmed fixes will be moved to a separate "fixed issues" document; anything still broken stays here.
 
 ## How It Works
 

--- a/docs/group-docs/group-docs-future-dev-tooling.md
+++ b/docs/group-docs/group-docs-future-dev-tooling.md
@@ -1,0 +1,40 @@
+# Future Dev Tooling Notes
+
+Early notes about larger investments in developer tooling that came up during GD-6 testing. At this point these feel necessary to complete robust group document support — without them it will be too hard to track progress and to create reproducible cases for the issues we're finding. More progress on the plan may prove that wrong. The same tooling is also useful for CLUE work beyond group documents.
+
+The items below are not scoped. They're meant as reference material when discussing this with other developers, and as a bookmark if this work is paused and picked up later.
+
+## Fork the standalone editor into dev and end-user builds
+
+People have started demoing with the current standalone editor. For demos, the default with both side views visible is unnecessary, and the editor is picking up dev-only features that will make a clean end-user editor harder to maintain over time.
+
+The proposal is to split the `doc-editor` build target into two:
+- **Dev editor** — optimized for development and debugging. Includes the features listed in the next section.
+- **End-user editor** — stripped down, suitable for demos and whatever end-user authoring use cases emerge.
+
+**Concern**: another webpack entry point slows the build. Before committing, profile the build with and without the split to confirm the cost is acceptable.
+
+## Dev editor feature set
+
+The dev editor should support at least:
+- History view
+- History replay
+- Auto-revert mode (GD-13)
+- Side-by-side history debugging (the mode already in use for debugging group docs)
+- Rearrangeable panel layout, like VSCode — so a developer can arrange the workspace to match the task
+
+Rearrangeable layout is ambitious, but becomes more valuable as more dev views are added.
+
+## Deterministic Cypress/Playwright tests for collaborative editing
+
+Without automated tests for the collaborative scenarios we're fixing, regressions are almost certain. We need a deterministic pattern for driving two (or more) simulated clients through the scenarios described in `group-docs-potential-ui-issues.md` and `group-docs-current-state.md`.
+
+Ideally the test system also tracks progress through the work:
+- The **default/automated build** runs only tests for scenarios we've actually implemented fixes for, so it stays green.
+- A **separate status build** runs all tests — including ones for scenarios not yet addressed — to show progress toward full coverage.
+
+Tests would be labeled so results can be sliced by dimension. Labels are not yet decided but possibilities include:
+- Category: "component state sync", "unhandled conflict", etc.
+- Tile affected: table, text, drawing, etc.
+
+This infrastructure is needed beyond group-docs work — collaborative editing is one of the harder things to test by hand, and the same multi-client determinism helps elsewhere in CLUE.

--- a/docs/group-docs/group-docs-plan.md
+++ b/docs/group-docs/group-docs-plan.md
@@ -14,6 +14,8 @@ Note: The original GD-5 (from `group-docs-brainstorm.md`) included both the tran
 | **GD-9** | Document-Level Merging | Merge non-conflicting changes at the document/tile level instead of rolling back |
 | **GD-10** | Shared Model Merging | Merge non-conflicting changes within shared models |
 | **GD-11** | Tile Hardening | Per-tile fixes to preserve transient UI state across remote updates |
+| **GD-12** | Debug Re-render Controls | Hotkeys to force-recreate components for a tile or the whole document to isolate render bugs from model bugs |
+| **GD-13** | Auto-Revert Stress Mode | Dev mode that automatically reverts the last change (sync, fixed delay, or random delay) to surface race conditions without needing a second user |
 
 ## Immediate: UI Disruption Testing
 
@@ -64,6 +66,8 @@ After GD-6, any conflict rolls back all local changes. Smarter merging would red
 - **Document level**: Changes to different tiles (that don't share a model) can be merged instead of rolling back. For example, adding a new tile shouldn't affect someone editing an existing tile.
 - **Tile + shared model level**: If two tiles are being changed and they don't share a model, merge the changes.
 
+Note: the merging/conflict-detection code introduced here is expected to be reused for undo/redo once that is picked up again. See "Deferred: Undo/Redo" below.
+
 ### GD-10: Shared Model Merging
 
 Support concurrent changes to shared models when they don't actually conflict. For example:
@@ -72,6 +76,8 @@ Support concurrent changes to shared models when they don't actually conflict. F
 - One user rescaling a graph while another edits data in the linked table
 
 True conflicts (e.g., one user deleting an object another user is referencing) still need to be detected and one side rolled back.
+
+Note: the merging/conflict-detection code introduced here is expected to be reused for undo/redo once that is picked up again. See "Deferred: Undo/Redo" below.
 
 ### GD-11: Tile Hardening (as needed)
 
@@ -178,3 +184,36 @@ Hardening the existing infrastructure to prevent silent failures and data loss i
 ### DataFlow Simulation
 
 DataFlow generates history entries on every simulation tick. Two users with DataFlow running will produce constant conflicting entries. This needs a fundamentally different approach — likely excluding simulation tick state from history, or batching/throttling it. This is a blocker for using group documents with DataFlow tiles.
+
+## Supporting Dev Tooling
+
+Small, targeted dev tools that make debugging and testing the group-doc work easier. Can be done in parallel with either plan.
+
+### GD-12: Debug Re-render Controls
+
+Add hotkeys (or toolbar buttons) to re-render a single tile and to re-render the whole document. "Re-render" here means recreating all React components for that scope so they drop any component state.
+
+**Why**: when something looks broken, it's hard to tell whether the problem is in the document/model state or in how the component is rendering it. If a forced re-render makes the problem go away, the model state is fine and the bug is in the component. Volatile state in the model and global state are deliberately left alone — keeping them intact helps isolate the component layer from the data layer.
+
+### GD-13: Auto-Revert Stress Mode
+
+A dev mode that, whenever a change is committed locally, automatically reverts the most recent change. This simulates the race conditions that come up when two users' edits land on top of each other, without requiring a second human to test with.
+
+**Why**: while testing GD-6, the text tile showed problems when edits were rapidly reverted. The symptoms suggest race conditions in either the model-level rollback or the way the tile keeps its internal state sync'd with the model state. Reproducing these today requires two people, which slows iteration. Many tiles likely have similar problems.
+
+Reversion timing should be configurable:
+- Synchronous (as close as possible)
+- Fixed ms delay
+- Random ms delay
+
+Each timing mode exposes different race windows.
+
+## Deferred: Undo/Redo
+
+Undo/redo in group documents was deliberately punted when this work was proposed, and for now that's still the right call. But it should be kept in mind as we design GD-9 and GD-10; more progress may change the call later.
+
+Today, undo/redo assumes each patch is being applied to the document state it was recorded against. In a collaborative world that assumption breaks: the document can be changed by someone else between when an entry is recorded and when the local user undoes or redoes it, and those remote changes aren't in the local undo/redo stack.
+
+Making undo/redo correct in this world requires the same judgment GD-9 and GD-10 need for rollback: given an entry's patches and action, can we safely apply them against the current document state, or do they conflict with changes from other users? When we eventually pick up undo/redo, we should be able to reuse the merging and conflict-detection code introduced by GD-9 and GD-10 rather than build a second implementation.
+
+**Design implication**: keep the GD-9 and GD-10 merge exceptions factored so they can be reused by a future undo/redo implementation — the decision of whether a given patch set can be safely applied should not be entangled with the rollback-specific code path.

--- a/docs/group-docs/group-docs-plan.md
+++ b/docs/group-docs/group-docs-plan.md
@@ -8,7 +8,7 @@ Note: The original GD-5 (from `group-docs-brainstorm.md`) included both the tran
 
 | Label | Name | Description |
 |---|---|---|
-| **GD-6** | Corruption Prevention | Client-side fork detection and rollback to prevent document corruption. **Status: code complete, in review (PR #2835 / CLUE-485).** |
+| **GD-6** | Corruption Prevention | Client-side fork detection and rollback to prevent document corruption. **Status: merged (PR #2835 / CLUE-485).** |
 | **GD-7** | Undo Bugs | Fix cases where patch-applied model changes don't update the tile UI |
 | **GD-8** | Tile Locking | Lock tiles so only one user can edit at a time (Plan B only) |
 | **GD-9** | Document-Level Merging | Merge non-conflicting changes at the document/tile level instead of rolling back |
@@ -47,7 +47,7 @@ Fix cases where model changes via patch application don't update the tile UI. Th
 
 ### GD-6: Corruption Prevention
 
-**Status: code complete, in review (PR #2835 / CLUE-485).** The section below describes the design; the implementation follows it. The shared rollback method, `detectAndResolveFork`, is the extension point GD-9 and GD-10 will plug into.
+**Status: merged (PR #2835 / CLUE-485).** The section below describes the design; the implementation follows it. The shared rollback method, `detectAndResolveFork`, is the extension point GD-9 and GD-10 will plug into.
 
 The transaction infrastructure is in place (`lastHistoryEntry` metadata, `previousEntryId` chaining, Firestore transactions in `uploadQueuedHistoryEntries()`). What GD-6 adds is client-side fork detection and rollback in two places that share a single codepath:
 

--- a/docs/group-docs/group-docs-plan.md
+++ b/docs/group-docs/group-docs-plan.md
@@ -8,7 +8,7 @@ Note: The original GD-5 (from `group-docs-brainstorm.md`) included both the tran
 
 | Label | Name | Description |
 |---|---|---|
-| **GD-6** | Corruption Prevention | Client-side fork detection and rollback to prevent document corruption |
+| **GD-6** | Corruption Prevention | Client-side fork detection and rollback to prevent document corruption. **Status: code complete, in review (PR #2835 / CLUE-485).** |
 | **GD-7** | Undo Bugs | Fix cases where patch-applied model changes don't update the tile UI |
 | **GD-8** | Tile Locking | Lock tiles so only one user can edit at a time (Plan B only) |
 | **GD-9** | Document-Level Merging | Merge non-conflicting changes at the document/tile level instead of rolling back |
@@ -47,7 +47,9 @@ Fix cases where model changes via patch application don't update the tile UI. Th
 
 ### GD-6: Corruption Prevention
 
-The transaction infrastructure is in place (`lastHistoryEntry` metadata, `previousEntryId` chaining, Firestore transactions in `uploadQueuedHistoryEntries()`). What remains is client-side fork detection and rollback, which is needed in two places that share a single codepath:
+**Status: code complete, in review (PR #2835 / CLUE-485).** The section below describes the design; the implementation follows it. The shared rollback method, `detectAndResolveFork`, is the extension point GD-9 and GD-10 will plug into.
+
+The transaction infrastructure is in place (`lastHistoryEntry` metadata, `previousEntryId` chaining, Firestore transactions in `uploadQueuedHistoryEntries()`). What GD-6 adds is client-side fork detection and rollback in two places that share a single codepath:
 
 **Receive-side fork detection.** When a remote entry arrives whose `previousEntryId` doesn't match the local head, the client should reverse its local uncommitted entries (using their undo patches) back to the fork point, drop them from the upload queue, and apply the remote entries.
 
@@ -176,10 +178,11 @@ These areas can be worked on alongside either plan:
 
 Hardening the existing infrastructure to prevent silent failures and data loss in edge cases. These are documented as Implementation TODOs in `group-docs-current-state.md`:
 
-- Race condition in initial history load
+- Race condition in initial history load (explicitly deferred by GD-6)
 - Error handling when metadata promise rejects (silent infinite failure loop)
-- Document drift detection (no checkpointing between full document content and history)
 - Unhandled promise in recursive upload
+
+Document drift detection between full document content and history was addressed by GD-6 via the RTDB envelope's `lastHistoryEntryId` field.
 
 ### DataFlow Simulation
 


### PR DESCRIPTION
While working on and testing GD-6/ PR #2835 / CLUE-485, I updated the design and status documents here. I made this a PR in case you have already read these documents. This way you can see the changes in them.

## Summary

- Adds **GD-12 (Debug Re-render Controls)** and **GD-13 (Auto-Revert Stress Mode)** as new work areas in a new "Supporting Dev Tooling" section of the plan. These came out of GD-6 testing — small, targeted tools to isolate render-vs-model bugs and surface race conditions without a second tester.
- Adds a **"Deferred: Undo/Redo"** section flagging that GD-9/GD-10's merge/conflict-detection code is expected to be reused when undo/redo is eventually picked up again, with cross-references from GD-9 and GD-10 so the design stays factored accordingly.
- Adds a **"Duplicate Group Documents"** entry under "Other issues" in the current-state doc — two users in the same group ended up editing separate documents, suspected to be a document-provisioning race. Not yet investigated.
- Adds **`group-docs-future-dev-tooling.md`** with broader notes that feel necessary for robust group-doc support: forking the standalone editor into dev and end-user builds, a dev editor feature set (history view/replay, side-by-side debugging, rearrangeable layout), and a deterministic Cypress/Playwright pattern for collaborative-editing tests with progress tracking.
- Reflects **GD-6 in-review status** (PR #2835 / CLUE-485):
  - Plan: status markers on the Work Areas table row and the GD-6 section, pointer to `detectAndResolveFork` as the GD-9/GD-10 extension point, drift-detection bullet removed from Parallel Tracks (addressed by GD-6), initial-history-load race marked as explicitly deferred.
  - Current-state: concise Summary note that the Model Inconsistency scenarios need retesting once GD-6 lands, with confirmed fixes moving to a separate "fixed issues" doc. GD-6 implementation details are intentionally not duplicated here — they live in PR #2835.

## Test plan
- [ ] Review `group-docs-plan.md` — new rows in the Work Areas table, new "Supporting Dev Tooling" section, new "Deferred: Undo/Redo" section, cross-references in Plan A's GD-9 and GD-10, GD-6 status markers, and Parallel Tracks updates.
- [ ] Review `group-docs-current-state.md` — Summary retest callout, new "Duplicate Group Documents" subsection under "Other issues".
- [ ] Review new file `group-docs-future-dev-tooling.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)