### PR TITLE
chore: improve text chips are sparrow targets (CLUE-238)

### DIFF
--- a/cypress/e2e/functional/document_tests/skip_links_student_spec.js
+++ b/cypress/e2e/functional/document_tests/skip_links_student_spec.js
@@ -13,7 +13,7 @@
  * browser session below the renderer-crash memory threshold in CI.
  */
 
-const queryParamsStudent = `${Cypress.config("qaUnitStudent5")}`;
+const queryParamsStudent = Cypress.config("qaUnitStudent5");
 
 function beforeTest(params) {
   cy.visit(params);

--- a/cypress/e2e/functional/document_tests/skip_links_student_spec.js
+++ b/cypress/e2e/functional/document_tests/skip_links_student_spec.js
@@ -1,17 +1,19 @@
 /**
- * Skip Links Accessibility Tests
+ * Skip Links Accessibility Tests — Student View
  *
  * Tests the skip links navigation feature that allows keyboard users
  * to bypass repetitive navigation and jump directly to main content areas.
  *
- * Skip links tested:
+ * Skip links tested in this file (student persona):
  * - "Skip to Lessons and Documents" → #resources-panel
  * - "Skip to Workspace" → #workspace-panel
- * - "Skip to Dashboard" → #main-dashboard (teacher only)
+ *
+ * Teacher-specific cases (including the dashboard skip link) live in
+ * skip_links_teacher_spec.js. The two files were split to keep each spec's
+ * browser session below the renderer-crash memory threshold in CI.
  */
 
 const queryParamsStudent = `${Cypress.config("qaUnitStudent5")}`;
-const queryParamsTeacher = `${Cypress.config("qaUnitTeacher6")}`;
 
 function beforeTest(params) {
   cy.visit(params);
@@ -116,98 +118,6 @@ context('Skip Links Navigation', function () {
     });
   });
 
-  describe('Teacher View', function () {
-
-    beforeEach(function () {
-      beforeTest(queryParamsTeacher);
-    });
-
-    it('shows resources and workspace skip links in workspace view', function () {
-      cy.log('Verify in workspace view by default');
-      cy.get('.workspace').should('be.visible');
-
-      cy.log('Verify resources skip link exists');
-      cy.get('nav.skip-links a.skip-link')
-        .contains('Skip to Lessons and Documents')
-        .should('exist');
-
-      cy.log('Verify workspace skip link exists');
-      cy.get('nav.skip-links a.skip-link')
-        .contains('Skip to Workspace')
-        .should('exist');
-
-      cy.log('Verify dashboard skip link does NOT exist when in workspace view');
-      cy.get('nav.skip-links').should('not.contain', 'Skip to Dashboard');
-    });
-
-    it('shows dashboard skip link when in dashboard view', function () {
-      cy.log('Switch to dashboard view');
-      cy.get('.toggle-button').contains('Dashboard').click();
-
-      cy.log('Verify in dashboard');
-      // Note: #main-dashboard has 0 height because .tabbed-area uses position:fixed,
-      // so we check the visible child element instead
-      cy.get('#main-dashboard .tabbed-area').should('be.visible');
-
-      cy.log('Verify dashboard skip link exists');
-      cy.get('nav.skip-links a.skip-link')
-        .contains('Skip to Dashboard')
-        .should('exist')
-        .and('have.attr', 'href', '#main-dashboard');
-
-      cy.log('Verify workspace/resources skip links do NOT exist in dashboard view');
-      cy.get('nav.skip-links').should('not.contain', 'Skip to Lessons and Documents');
-      cy.get('nav.skip-links').should('not.contain', 'Skip to Workspace');
-    });
-
-    it('navigates to dashboard when skip link is activated', function () {
-      cy.log('Switch to dashboard view');
-      cy.get('.toggle-button').contains('Dashboard').click();
-      cy.get('#main-dashboard .tabbed-area').should('be.visible');
-
-      cy.log('Click the dashboard skip link');
-      cy.get('body').realPress('Tab');
-      cy.get('nav.skip-links a.skip-link')
-        .contains('Skip to Dashboard')
-        .click();
-
-      cy.log('Verify dashboard receives focus');
-      cy.focused().should('have.id', 'main-dashboard');
-      cy.url().should('include', '#main-dashboard');
-    });
-
-    it('skip links update when switching between workspace and dashboard', function () {
-      cy.log('Initially in workspace view, verify workspace skip links');
-      cy.get('nav.skip-links a.skip-link')
-        .contains('Skip to Workspace')
-        .should('exist');
-
-      cy.log('Switch to dashboard');
-      cy.get('.toggle-button').contains('Dashboard').click();
-      cy.get('#main-dashboard .tabbed-area').should('be.visible');
-
-      cy.log('Verify dashboard skip link appears');
-      cy.get('nav.skip-links a.skip-link')
-        .contains('Skip to Dashboard')
-        .should('exist');
-
-      cy.log('Verify workspace skip links are gone');
-      cy.get('nav.skip-links').should('not.contain', 'Skip to Workspace');
-
-      cy.log('Switch back to workspace');
-      cy.get('.toggle-button').contains('Workspace').click();
-      cy.get('.workspace').should('be.visible');
-
-      cy.log('Verify workspace skip links return');
-      cy.get('nav.skip-links a.skip-link')
-        .contains('Skip to Workspace')
-        .should('exist');
-
-      cy.log('Verify dashboard skip link is gone');
-      cy.get('nav.skip-links').should('not.contain', 'Skip to Dashboard');
-    });
-  });
-
   describe('Panel Target Elements', function () {
 
     beforeEach(function () {
@@ -228,23 +138,6 @@ context('Skip Links Navigation', function () {
 
       cy.log('Workspace panel should be focusable');
       cy.get('#workspace-panel').should('have.attr', 'tabindex', '-1');
-    });
-  });
-
-  describe('Teacher Dashboard Target Element', function () {
-
-    beforeEach(function () {
-      beforeTest(queryParamsTeacher);
-      cy.get('.toggle-button').contains('Dashboard').click();
-      cy.get('#main-dashboard .tabbed-area').should('be.visible');
-    });
-
-    it('dashboard element has correct id attribute', function () {
-      cy.get('#main-dashboard').should('exist');
-    });
-
-    it('dashboard element is focusable', function () {
-      cy.get('#main-dashboard').should('have.attr', 'tabindex', '-1');
     });
   });
 

--- a/cypress/e2e/functional/document_tests/skip_links_teacher_spec.js
+++ b/cypress/e2e/functional/document_tests/skip_links_teacher_spec.js
@@ -1,0 +1,137 @@
+/**
+ * Skip Links Accessibility Tests — Teacher View
+ *
+ * Tests the skip links navigation feature that allows keyboard users
+ * to bypass repetitive navigation and jump directly to main content areas.
+ *
+ * Skip links tested in this file (teacher persona):
+ * - "Skip to Lessons and Documents" → #resources-panel
+ * - "Skip to Workspace" → #workspace-panel
+ * - "Skip to Dashboard" → #main-dashboard (teacher only)
+ *
+ * Student-specific cases live in skip_links_student_spec.js. The two files
+ * were split to keep each spec's browser session below the renderer-crash
+ * memory threshold in CI.
+ */
+
+const queryParamsTeacher = `${Cypress.config("qaUnitTeacher6")}`;
+
+function beforeTest(params) {
+  cy.visit(params);
+  cy.waitForLoad();
+}
+
+context('Skip Links Navigation', function () {
+
+  describe('Teacher View', function () {
+
+    beforeEach(function () {
+      beforeTest(queryParamsTeacher);
+    });
+
+    it('shows resources and workspace skip links in workspace view', function () {
+      cy.log('Verify in workspace view by default');
+      cy.get('.workspace').should('be.visible');
+
+      cy.log('Verify resources skip link exists');
+      cy.get('nav.skip-links a.skip-link')
+        .contains('Skip to Lessons and Documents')
+        .should('exist');
+
+      cy.log('Verify workspace skip link exists');
+      cy.get('nav.skip-links a.skip-link')
+        .contains('Skip to Workspace')
+        .should('exist');
+
+      cy.log('Verify dashboard skip link does NOT exist when in workspace view');
+      cy.get('nav.skip-links').should('not.contain', 'Skip to Dashboard');
+    });
+
+    it('shows dashboard skip link when in dashboard view', function () {
+      cy.log('Switch to dashboard view');
+      cy.get('.toggle-button').contains('Dashboard').click();
+
+      cy.log('Verify in dashboard');
+      // Note: #main-dashboard has 0 height because .tabbed-area uses position:fixed,
+      // so we check the visible child element instead
+      cy.get('#main-dashboard .tabbed-area').should('be.visible');
+
+      cy.log('Verify dashboard skip link exists');
+      cy.get('nav.skip-links a.skip-link')
+        .contains('Skip to Dashboard')
+        .should('exist')
+        .and('have.attr', 'href', '#main-dashboard');
+
+      cy.log('Verify workspace/resources skip links do NOT exist in dashboard view');
+      cy.get('nav.skip-links').should('not.contain', 'Skip to Lessons and Documents');
+      cy.get('nav.skip-links').should('not.contain', 'Skip to Workspace');
+    });
+
+    it('navigates to dashboard when skip link is activated', function () {
+      cy.log('Switch to dashboard view');
+      cy.get('.toggle-button').contains('Dashboard').click();
+      cy.get('#main-dashboard .tabbed-area').should('be.visible');
+
+      cy.log('Focus and activate the dashboard skip link');
+      // Focus directly rather than Tab-walking — after clicking the Dashboard
+      // toggle button, focus is on that button, so Tab would move forward from
+      // there rather than landing on the skip link at the top of tab order.
+      cy.get('nav.skip-links a.skip-link')
+        .contains('Skip to Dashboard')
+        .focus()
+        .realPress('Enter');
+
+      cy.log('Verify dashboard receives focus');
+      cy.focused().should('have.id', 'main-dashboard');
+      cy.url().should('include', '#main-dashboard');
+    });
+
+    it('skip links update when switching between workspace and dashboard', function () {
+      cy.log('Initially in workspace view, verify workspace skip links');
+      cy.get('nav.skip-links a.skip-link')
+        .contains('Skip to Workspace')
+        .should('exist');
+
+      cy.log('Switch to dashboard');
+      cy.get('.toggle-button').contains('Dashboard').click();
+      cy.get('#main-dashboard .tabbed-area').should('be.visible');
+
+      cy.log('Verify dashboard skip link appears');
+      cy.get('nav.skip-links a.skip-link')
+        .contains('Skip to Dashboard')
+        .should('exist');
+
+      cy.log('Verify workspace skip links are gone');
+      cy.get('nav.skip-links').should('not.contain', 'Skip to Workspace');
+
+      cy.log('Switch back to workspace');
+      cy.get('.toggle-button').contains('Workspace').click();
+      cy.get('.workspace').should('be.visible');
+
+      cy.log('Verify workspace skip links return');
+      cy.get('nav.skip-links a.skip-link')
+        .contains('Skip to Workspace')
+        .should('exist');
+
+      cy.log('Verify dashboard skip link is gone');
+      cy.get('nav.skip-links').should('not.contain', 'Skip to Dashboard');
+    });
+  });
+
+  describe('Teacher Dashboard Target Element', function () {
+
+    beforeEach(function () {
+      beforeTest(queryParamsTeacher);
+      cy.get('.toggle-button').contains('Dashboard').click();
+      cy.get('#main-dashboard .tabbed-area').should('be.visible');
+    });
+
+    it('dashboard element has correct id attribute', function () {
+      cy.get('#main-dashboard').should('exist');
+    });
+
+    it('dashboard element is focusable', function () {
+      cy.get('#main-dashboard').should('have.attr', 'tabindex', '-1');
+    });
+  });
+});

--- a/cypress/e2e/functional/document_tests/skip_links_teacher_spec.js
+++ b/cypress/e2e/functional/document_tests/skip_links_teacher_spec.js
@@ -14,7 +14,7 @@
  * memory threshold in CI.
  */
 
-const queryParamsTeacher = `${Cypress.config("qaUnitTeacher6")}`;
+const queryParamsTeacher = Cypress.config("qaUnitTeacher6");
 
 function beforeTest(params) {
   cy.visit(params);
@@ -124,10 +124,6 @@ context('Skip Links Navigation', function () {
       beforeTest(queryParamsTeacher);
       cy.get('.toggle-button').contains('Dashboard').click();
       cy.get('#main-dashboard .tabbed-area').should('be.visible');
-    });
-
-    it('dashboard element has correct id attribute', function () {
-      cy.get('#main-dashboard').should('exist');
     });
 
     it('dashboard element is focusable', function () {

--- a/cypress/e2e/functional/tile_tests/arrow_annotation_spec.js
+++ b/cypress/e2e/functional/tile_tests/arrow_annotation_spec.js
@@ -827,13 +827,6 @@ context('Arrow Annotations (Sparrows)', function () {
       assertHandleNearChip({ handleIndex: 0, chipIndex: 0, workspaceClass: navPanel, tolerance: 100 });
       assertHandleNearChip({ handleIndex: 1, chipIndex: 1, workspaceClass: navPanel, tolerance: 100 });
     });
-
-    // Pending stubs — these views need Cypress scaffolding the repo doesn't yet have:
-    // a helper to open the same doc in `.reference-workspace` (two-up same-doc), and
-    // helpers to locate and inspect a thumbnail's annotation SVG.
-    it("renders sparrow on chip correctly in the right-side (read-only local) view when the same doc is open on both sides");
-    it("renders sparrow on chip correctly in a My Work thumbnail");
-    it("renders sparrow on chip correctly after opening the doc from a My Work thumbnail (no drift)");
   });
 
   it("Can add annotations to tiles nested within a question tile", () => {

--- a/cypress/e2e/functional/tile_tests/arrow_annotation_spec.js
+++ b/cypress/e2e/functional/tile_tests/arrow_annotation_spec.js
@@ -7,6 +7,7 @@ import GeometryToolTile from '../../../support/elements/tile/GeometryToolTile';
 import NumberlineToolTile from '../../../support/elements/tile/NumberlineToolTile';
 import SimulatorTile from '../../../support/elements/tile/SimulatorTile';
 import TableToolTile from '../../../support/elements/tile/TableToolTile';
+import TextToolTile from '../../../support/elements/tile/TextToolTile';
 import XYPlotToolTile from '../../../support/elements/tile/XYPlotToolTile';
 
 const aa = new ArrowAnnotation;
@@ -18,10 +19,12 @@ const geometryToolTile = new GeometryToolTile;
 const numberlineToolTile = new NumberlineToolTile;
 const simulatorTile = new SimulatorTile;
 const tableToolTile = new TableToolTile;
+const textToolTile = new TextToolTile;
 const xyTile = new XYPlotToolTile;
 
 const queryParams = `${Cypress.config("qaConfigSubtabsUnitStudent5")}`;
 const queryParamsQa = `${Cypress.config("qaUnitStudent7Investigation3")}`;
+const queryParamsGroup = `${Cypress.config("qaUnitGroup")}&fakeUser=student:15`;
 
 // Note copied from drawing tile test
 // NOTE: For some reason cypress+chrome thinks that the SVG elements are in a
@@ -622,6 +625,215 @@ context('Arrow Annotations (Sparrows)', function () {
     dataflowTile.getClearDataWarningClear().click();
     dataflowTile.getSamplingRateLabel().should("have.text", "Sampling Rate");
     aa.getAnnotationArrows().should("have.length", 2);
+  });
+
+  context('Sparrows on text chips', function () {
+
+    // Adds two text tiles, each with a highlight chip on its full text, and connects them
+    // with a sparrow. `before` runs after the chips are created but before sparrow mode is
+    // entered — used by callers that need to switch to straight-arrow mode first.
+    function setupTwoChipsAndSparrow({ before } = {}) {
+      const text1 = 'Alpha chip.';
+      const text2 = 'Beta chip.';
+
+      clueCanvas.addTile('text');
+      textToolTile.verifyTextTileIsEditable();
+      textToolTile.enterText(text1);
+      textToolTile.getTextEditor().last().type('{selectall}');
+      textToolTile.verifyHighlightToolbarButtonEnabled();
+      textToolTile.getHighlightButton().click();
+      textToolTile.getTextEditor().last().find('.highlight-chip').should('exist');
+
+      clueCanvas.addTile('text');
+      textToolTile.getTextEditor().last().click();
+      textToolTile.verifyTextTileIsEditable();
+      textToolTile.enterText(text2);
+      textToolTile.getTextEditor().last().type('{selectall}');
+      textToolTile.verifyHighlightToolbarButtonEnabled();
+      textToolTile.getHighlightButton().click();
+      textToolTile.getTextEditor().last().find('.highlight-chip').should('exist');
+
+      if (before) before();
+
+      aa.getAnnotationModeButton().click();
+      aa.getAnnotationButtons().should('have.length', 2);
+      aa.getAnnotationArrows().should('not.exist');
+      aa.getAnnotationButtons().eq(0).click();
+      aa.getAnnotationButtons().eq(1).click();
+      aa.getAnnotationArrows().should('have.length', 1);
+      aa.getAnnotationModeButton().click();
+    }
+
+    // Asserts the `handleIndex`-th sparrow drag handle's center is within `tolerance` of
+    // the `chipIndex`-th chip matching `chipSelector` (default `.highlight-chip`; pass
+    // `.variable-chip` for variable chips). The tolerance is loose because the default
+    // offsets in getObjectDefaultOffsets pull endpoints toward the chip's edge.
+    function assertHandleNearChip({ handleIndex, chipIndex, workspaceClass = '.primary-workspace',
+                                    chipSelector = '.highlight-chip', tolerance = 60 } = {}) {
+      cy.get(`${workspaceClass} ${chipSelector}`).eq(chipIndex).then($chip => {
+        const chipRect = $chip[0].getBoundingClientRect();
+        aa.getAnnotationArrowDragHandles(workspaceClass).eq(handleIndex).then($handle => {
+          const handleRect = $handle[0].getBoundingClientRect();
+          const hx = handleRect.left + handleRect.width / 2;
+          const hy = handleRect.top + handleRect.height / 2;
+          expect(hx, `handle[${handleIndex}].x near chip[${chipIndex}].x`)
+            .to.be.within(chipRect.left - tolerance, chipRect.right + tolerance);
+          expect(hy, `handle[${handleIndex}].y near chip[${chipIndex}].y`)
+            .to.be.within(chipRect.top - tolerance, chipRect.bottom + tolerance);
+        });
+      });
+    }
+
+    it("renders sparrow on chip correctly in the main (editable) view", () => {
+      beforeTest(queryParams);
+      setupTwoChipsAndSparrow();
+      aa.getAnnotationArrowDragHandles().should('have.length', 2);
+      assertHandleNearChip({ handleIndex: 0, chipIndex: 0 });
+      assertHandleNearChip({ handleIndex: 1, chipIndex: 1 });
+    });
+
+    it("supports straight-line sparrows with a text-chip endpoint", () => {
+      beforeTest(queryParams);
+      setupTwoChipsAndSparrow({
+        before: () => {
+          aa.getAnnotationModeButton().click();
+          aa.getAnnotationMenuExpander().click();
+          aa.getStraightArrowToolbarButton().click();
+          aa.getAnnotationModeButton().should('have.attr', 'title', 'Sparrow: straight');
+          aa.getAnnotationModeButton().click();
+        }
+      });
+      aa.getAnnotationArrowDragHandles().should('have.length', 2);
+      assertHandleNearChip({ handleIndex: 0, chipIndex: 0 });
+      assertHandleNearChip({ handleIndex: 1, chipIndex: 1 });
+    });
+
+    it("removes sparrows when the chip is unhighlighted", () => {
+      beforeTest(queryParams);
+      setupTwoChipsAndSparrow();
+      // Click the first chip to select it, then click the highlight button to unhighlight.
+      textToolTile.getTextEditor().first().find('.highlight-chip').click();
+      textToolTile.getHighlightButton().click();
+      aa.getAnnotationArrows().should('have.length', 0);
+    });
+
+    it("removes sparrows when the text containing the chip is deleted", () => {
+      beforeTest(queryParams);
+      setupTwoChipsAndSparrow();
+      // Remove the chip by mutating editor.children directly + firing onChange.
+      // Cypress can't drive this via keyboard: focusing a Slate editor whose only
+      // content is a void chip trips a Slate + Chrome DOMException that throws
+      // inside Cypress's command execution and can't be suppressed.
+      cy.window().then((win) => {
+        const stores = win.stores;
+        const docKey = stores.persistentUI.problemWorkspace.primaryDocumentKey;
+        const doc = stores.documents.getDocument(docKey);
+        let firstTextContent = null;
+        doc.content.tileMap.forEach((tile) => {
+          if (tile.content.type === 'Text' && !firstTextContent) {
+            firstTextContent = tile.content;
+          }
+        });
+        const editor = firstTextContent.editor;
+        editor.children = [{ type: 'paragraph', children: [{ text: 'cleared' }] }];
+        editor.onChange();
+      });
+      textToolTile.getTextEditor().first().find('.highlight-chip').should('not.exist');
+      aa.getAnnotationArrows().should('have.length', 0);
+    });
+
+    it("renders sparrow on chip correctly in 4-up view", () => {
+      cy.visit(queryParamsGroup);
+      cy.waitForLoad();
+      clueCanvas.shareCanvas();
+      cy.wait(3000);
+      setupTwoChipsAndSparrow();
+      // Sanity check in primary view before switching to 4-up.
+      aa.getAnnotationArrows().should('have.length', 1);
+      clueCanvas.openFourUpView();
+      clueCanvas.getFourUpView().should('be.visible');
+      // The student's own work renders in the NW quadrant.
+      const nw = '.primary-workspace .north-west';
+      cy.get(`${nw} .highlight-chip`, { timeout: 10000 }).should('have.length', 2);
+      aa.getAnnotationArrows(nw).should('have.length', 1);
+      aa.getAnnotationArrowDragHandles(nw).should('have.length', 2);
+      assertHandleNearChip({ handleIndex: 0, chipIndex: 0, workspaceClass: nw, tolerance: 100 });
+      assertHandleNearChip({ handleIndex: 1, chipIndex: 1, workspaceClass: nw, tolerance: 100 });
+    });
+
+    it("renders sparrow on variable chip correctly in the main (editable) view", () => {
+      // qa-variables is the only QA unit with `new-variable` in the text toolbar plus
+      // `annotations: all`. The diagram tile initializes the shared-variables model.
+      cy.visit(`${Cypress.config("qaVariablesUnitStudent5")}`);
+      cy.waitForLoad();
+      cy.showOnlyDocumentWorkspace();
+
+      clueCanvas.addTile('text');
+      clueCanvas.addTile('diagram');
+
+      const createVariableChip = (name, value) => {
+        clueCanvas.clickToolbarButton('text', 'new-variable');
+        cy.get('.custom-modal').should('exist');
+        cy.get('#evd-name').type(name);
+        cy.get('#evd-value').type(value);
+        cy.get('.modal-button').last().click();
+      };
+
+      textToolTile.getTextEditor().first().click();
+      createVariableChip('alpha', '1');
+      cy.get('.primary-workspace .variable-chip').should('have.length', 1);
+
+      clueCanvas.addTile('text');
+      textToolTile.getTextEditor().last().click();
+      createVariableChip('beta', '2');
+      cy.get('.primary-workspace .variable-chip').should('have.length', 2);
+
+      aa.getAnnotationModeButton().click();
+      aa.getAnnotationButtons().should('have.length', 2);
+      aa.getAnnotationArrows().should('not.exist');
+      aa.getAnnotationButtons().eq(0).click();
+      aa.getAnnotationButtons().eq(1).click();
+      aa.getAnnotationArrows().should('have.length', 1);
+      aa.getAnnotationModeButton().click();
+      aa.getAnnotationArrowDragHandles().should('have.length', 2);
+
+      // Assert handle endpoints land within tolerance of the variable chips' bounding boxes.
+      assertHandleNearChip({ handleIndex: 0, chipIndex: 0, chipSelector: '.variable-chip' });
+      assertHandleNearChip({ handleIndex: 1, chipIndex: 1, chipSelector: '.variable-chip' });
+    });
+
+    it("renders sparrow on chip correctly in the Lessons & Documents panel (read-only)", () => {
+      // Opens the same document in the editable Workspace panel and the read-only
+      // Lessons & Documents nav panel — two React trees rendering the same MST doc.
+      // Uses qaUnitStudent5 because it has `highlight` in the text toolbar,
+      // `annotations: all`, and a known workspace title for the thumbnail click.
+      cy.visit(`${Cypress.config("qaUnitStudent5")}`);
+      cy.waitForLoad();
+      const studentWorkspace = 'QA 1.1 Solving a Mystery with Proportional Reasoning';
+
+      setupTwoChipsAndSparrow();
+      aa.getAnnotationArrows().should('have.length', 1);
+
+      // Open the workspace doc as a read-only thumbnail view in the nav panel.
+      cy.openTopTab('my-work');
+      cy.openSection('my-work', 'workspaces');
+      cy.openDocumentThumbnail('my-work', 'workspaces', studentWorkspace);
+
+      const navPanel = '.nav-tab-panel';
+      cy.get(`${navPanel} .highlight-chip`, { timeout: 10000 }).should('have.length', 2);
+      aa.getAnnotationArrows(navPanel).should('have.length', 1);
+      aa.getAnnotationArrowDragHandles(navPanel).should('have.length', 2);
+      // Wider tolerance for the scaled layout.
+      assertHandleNearChip({ handleIndex: 0, chipIndex: 0, workspaceClass: navPanel, tolerance: 100 });
+      assertHandleNearChip({ handleIndex: 1, chipIndex: 1, workspaceClass: navPanel, tolerance: 100 });
+    });
+
+    // Pending stubs — these views need Cypress scaffolding the repo doesn't yet have:
+    // a helper to open the same doc in `.reference-workspace` (two-up same-doc), and
+    // helpers to locate and inspect a thumbnail's annotation SVG.
+    it("renders sparrow on chip correctly in the right-side (read-only local) view when the same doc is open on both sides");
+    it("renders sparrow on chip correctly in a My Work thumbnail");
+    it("renders sparrow on chip correctly after opening the doc from a My Work thumbnail (no drift)");
   });
 
   it("Can add annotations to tiles nested within a question tile", () => {

--- a/src/components/tiles/text/spec-text-tile.tsx
+++ b/src/components/tiles/text/spec-text-tile.tsx
@@ -13,6 +13,7 @@ import { ITileApi, TileModelContext } from "../tile-api";
 
 export interface ISpecTextTileOptions {
   tileModel?: ITileModel,
+  readOnly?: boolean,
   onRegisterTileApi?: (tileApi: ITileApi, facet?: string) => void
 }
 
@@ -53,7 +54,7 @@ export function specTextTile(options: ISpecTextTileOptions) {
     docId: "",
     documentContent,
     isUserResizable: true,
-    readOnly: false,
+    readOnly: options.readOnly ?? false,
     onResizeRow: (e) => {
       throw new Error("Function not implemented.");
     },

--- a/src/components/tiles/text/spec-text-tile.tsx
+++ b/src/components/tiles/text/spec-text-tile.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Provider } from "mobx-react";
 import { ModalProvider } from "@concord-consortium/react-modal-hook";
-import { render, screen } from "@testing-library/react";
+import { render } from "@testing-library/react";
 
 import { defaultTextContent } from "../../../models/tiles/text/text-content";
 import { ITileModel, TileModel } from "../../../models/tiles/tile-model";
@@ -9,10 +9,11 @@ import { specStores } from "../../../models/stores/spec-stores";
 import { specAppConfig } from "../../../models/stores/spec-app-config";
 import TextToolComponent from "./text-tile";
 import { ITileProps } from "../tile-component";
-import { TileModelContext } from "../tile-api";
+import { ITileApi, TileModelContext } from "../tile-api";
 
 export interface ISpecTextTileOptions {
-  tileModel?: ITileModel
+  tileModel?: ITileModel,
+  onRegisterTileApi?: (tileApi: ITileApi, facet?: string) => void
 }
 
 export function specTextTile(options: ISpecTextTileOptions) {
@@ -41,8 +42,9 @@ export function specTextTile(options: ISpecTextTileOptions) {
       }
       })
     });
-  render(<div className="document-content" data-testid="document-content"/>);
-  const documentContent = screen.getByTestId("document-content");
+  // Tests don't read from this element. `null` (allowed by the prop type) avoids
+  // collisions when multiple specTextTile() calls share the same test root.
+  const documentContent = null;
 
   const defaultProps: ITileProps = {
     model,
@@ -62,7 +64,7 @@ export function specTextTile(options: ISpecTextTileOptions) {
       throw new Error("Function not implemented.");
     },
     onRegisterTileApi: (tileApi, facet) => {
-      // throw new Error("Function not implemented.");
+      options.onRegisterTileApi?.(tileApi, facet);
     },
     onUnregisterTileApi: (facet) => {
       // throw new Error("Function not implemented.");

--- a/src/components/tiles/text/text-tile.test.tsx
+++ b/src/components/tiles/text/text-tile.test.tsx
@@ -39,7 +39,7 @@ describe("TextToolComponent", () => {
 
 describe("TextToolComponent highlight bbox cache", () => {
 
-  it("reports bbox only for highlights that have been registered", () => {
+  it("reports the registered bbox for a known highlight id", () => {
     let tileApi: ITileApi | undefined;
     const { textTile } = specTextTile({
       onRegisterTileApi: (api) => { tileApi = api; }
@@ -57,16 +57,18 @@ describe("TextToolComponent highlight bbox cache", () => {
     expect(tileApi?.getObjectBoundingBox?.("unknown-id", kHighlightFormat)).toBeUndefined();
   });
 
-  it("two TextToolComponent instances backed by the same model have independent caches", () => {
+  it("editable and read-only views of the same tile have independent bbox caches", () => {
+    // Models a problem doc open on both sides of the app rendering two Text tile instances, one editable, one
+    // read-only. A bbox written by the editable view must not appear in the read-only view's cache.
     const tileModel = TileModel.create({ content: defaultTextContent() });
-    let apiA: ITileApi | undefined;
-    let apiB: ITileApi | undefined;
-    const a = specTextTile({ tileModel, onRegisterTileApi: (api) => { apiA = api; } });
-    specTextTile({ tileModel, onRegisterTileApi: (api) => { apiB = api; } });
+    let editableApi: ITileApi | undefined;
+    let readOnlyApi: ITileApi | undefined;
+    const editable = specTextTile({ tileModel, onRegisterTileApi: (api) => { editableApi = api; } });
+    specTextTile({ tileModel, readOnly: true, onRegisterTileApi: (api) => { readOnlyApi = api; } });
     const box = { left: 1, top: 2, width: 3, height: 4 };
-    (a.textTile as any).handleUpdateHighlightBoxCache("shared-id", box);
-    expect(apiA?.getObjectBoundingBox?.("shared-id", kHighlightFormat)).toEqual(box);
-    expect(apiB?.getObjectBoundingBox?.("shared-id", kHighlightFormat)).toBeUndefined();
+    (editable.textTile as any).handleUpdateHighlightBoxCache("shared-id", box);
+    expect(editableApi?.getObjectBoundingBox?.("shared-id", kHighlightFormat)).toEqual(box);
+    expect(readOnlyApi?.getObjectBoundingBox?.("shared-id", kHighlightFormat)).toBeUndefined();
   });
 
   it("bumps the observable tick when a bbox is written", () => {

--- a/src/components/tiles/text/text-tile.test.tsx
+++ b/src/components/tiles/text/text-tile.test.tsx
@@ -1,7 +1,10 @@
 import {screen} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { reaction } from "mobx";
 import { defaultTextContent } from "../../../models/tiles/text/text-content";
 import { TileModel } from "../../../models/tiles/tile-model";
+import { kHighlightFormat } from "../../../plugins/text/highlights-plugin";
+import { ITileApi } from "../tile-api";
 import { specTextTile } from "./spec-text-tile";
 
 // The text tile needs to be registered so the TileModel.create
@@ -30,6 +33,59 @@ describe("TextToolComponent", () => {
     const buttons = screen.getAllByRole("button");
     const headingButton = buttons.find(b => b.getAttribute("aria-label") === "Heading");
     expect(headingButton).toBeDefined();
+  });
+
+});
+
+describe("TextToolComponent highlight bbox cache", () => {
+
+  it("reports bbox only for highlights that have been registered", () => {
+    let tileApi: ITileApi | undefined;
+    const { textTile } = specTextTile({
+      onRegisterTileApi: (api) => { tileApi = api; }
+    });
+    const box = { left: 1, top: 2, width: 10, height: 20 };
+    (textTile as any).handleUpdateHighlightBoxCache("abc", box);
+    expect(tileApi?.getObjectBoundingBox?.("abc", kHighlightFormat)).toEqual(box);
+  });
+
+  it("returns no bbox for unknown highlight ids", () => {
+    let tileApi: ITileApi | undefined;
+    specTextTile({
+      onRegisterTileApi: (api) => { tileApi = api; }
+    });
+    expect(tileApi?.getObjectBoundingBox?.("unknown-id", kHighlightFormat)).toBeUndefined();
+  });
+
+  it("two TextToolComponent instances backed by the same model have independent caches", () => {
+    const tileModel = TileModel.create({ content: defaultTextContent() });
+    let apiA: ITileApi | undefined;
+    let apiB: ITileApi | undefined;
+    const a = specTextTile({ tileModel, onRegisterTileApi: (api) => { apiA = api; } });
+    specTextTile({ tileModel, onRegisterTileApi: (api) => { apiB = api; } });
+    const box = { left: 1, top: 2, width: 3, height: 4 };
+    (a.textTile as any).handleUpdateHighlightBoxCache("shared-id", box);
+    expect(apiA?.getObjectBoundingBox?.("shared-id", kHighlightFormat)).toEqual(box);
+    expect(apiB?.getObjectBoundingBox?.("shared-id", kHighlightFormat)).toBeUndefined();
+  });
+
+  it("bumps the observable tick when a bbox is written", () => {
+    let tileApi: ITileApi | undefined;
+    const { textTile } = specTextTile({
+      onRegisterTileApi: (api) => { tileApi = api; }
+    });
+    const observed: Array<unknown> = [];
+    const dispose = reaction(
+      () => tileApi?.getObjectBoundingBox?.("tick-id", kHighlightFormat),
+      (value) => { observed.push(value); }
+    );
+    try {
+      const box = { left: 1, top: 2, width: 3, height: 4 };
+      (textTile as any).handleUpdateHighlightBoxCache("tick-id", box);
+      expect(observed).toEqual([box]);
+    } finally {
+      dispose();
+    }
   });
 
 });

--- a/src/components/tiles/text/text-tile.test.tsx
+++ b/src/components/tiles/text/text-tile.test.tsx
@@ -54,6 +54,7 @@ describe("TextToolComponent highlight bbox cache", () => {
     specTextTile({
       onRegisterTileApi: (api) => { tileApi = api; }
     });
+    expect(tileApi).toBeDefined();
     expect(tileApi?.getObjectBoundingBox?.("unknown-id", kHighlightFormat)).toBeUndefined();
   });
 

--- a/src/components/tiles/text/text-tile.tsx
+++ b/src/components/tiles/text/text-tile.tsx
@@ -140,7 +140,7 @@ export default class TextToolComponent extends BaseComponent<ITileProps, IState>
   private isHandlingUserChange = false;
   private highlightBoxesCache: Map<string, IHighlightBox> = new Map();
   private variableBoxesCache: Map<string, IHighlightBox> = new Map();
-  private highlightBoxesCacheTick = observable({ count: 0 });
+  private chipBoxesCacheTick = observable({ count: 0 });
   private previousVariableIds: Set<string> = new Set();
 
   static contextType = ContainerContext;
@@ -226,7 +226,7 @@ export default class TextToolComponent extends BaseComponent<ITileProps, IState>
       getObjectBoundingBox: (objectId: string, objectType?: string) => {
         // Track the tick so MobX observers re-run when the cache is written.
         // eslint-disable-next-line unused-imports/no-unused-vars
-        const _tick = this.highlightBoxesCacheTick.count;
+        const _tick = this.chipBoxesCacheTick.count;
         if (objectType === kHighlightFormat) {
           const box = this.highlightBoxesCache.get(objectId);
           if (box) return box;
@@ -241,7 +241,7 @@ export default class TextToolComponent extends BaseComponent<ITileProps, IState>
         // and then offset should be the center of the edge closes to the target
         // Track the tick so MobX observers re-run when the cache is written.
         // eslint-disable-next-line unused-imports/no-unused-vars
-        const _tick = this.highlightBoxesCacheTick.count;
+        const _tick = this.chipBoxesCacheTick.count;
         const offsets = OffsetModel.create({});
         const box = objectType === kHighlightFormat ? this.highlightBoxesCache.get(objectId)
                   : objectType === kVariableFormat ? this.variableBoxesCache.get(objectId)
@@ -489,7 +489,7 @@ export default class TextToolComponent extends BaseComponent<ITileProps, IState>
       if (!existing) return;
       cache.delete(id);
     }
-    runInAction(() => { this.highlightBoxesCacheTick.count++; });
+    runInAction(() => { this.chipBoxesCacheTick.count++; });
   }
 
   private handleUpdateHighlightBoxCache = (id: string, box: IHighlightBox) => {

--- a/src/components/tiles/text/text-tile.tsx
+++ b/src/components/tiles/text/text-tile.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import classNames from "classnames";
-import { IReactionDisposer, reaction } from "mobx";
+import { IReactionDisposer, observable, reaction, runInAction } from "mobx";
 import { observer, inject } from "mobx-react";
 import {
   createEditor, defaultHotkeyMap, Editor, EditorValue, normalizeSelection, ReactEditor, Slate, SlateEditor
@@ -13,7 +13,10 @@ import { logTileChangeEvent } from "../../../models/tiles/log/log-tile-change-ev
 import { TextContentModelType } from "../../../models/tiles/text/text-content";
 import { HighlightRegistryContext, HighlightRevisionContext, IHighlightBox }
     from "../../../plugins/text/highlight-registry-context";
+import { removeAnnotationsForChip } from "../../../plugins/text/chip-annotation-cleanup";
 import { kHighlightFormat } from "../../../plugins/text/highlights-plugin";
+import { kVariableFormat, VariableRegistryContext }
+    from "../../../plugins/shared-variables/slate/variables-plugin";
 import { hasSelectionModifier } from "../../../utilities/event-utils";
 import { ITileApi, TileResizeEntry } from "../tile-api";
 import { ITileProps } from "../tile-component";
@@ -28,6 +31,36 @@ import { VoiceTypingOverlay } from "../../../utilities/voice-typing-overlay";
 
 import "./toolbar/text-toolbar-registration";
 import "./text-tile.scss";
+
+// Returns the ids of all highlight chip elements in a Slate value.
+function collectHighlightIds(value: EditorValue): Set<string> {
+  const ids = new Set<string>();
+  const walk = (nodes: readonly any[]) => {
+    for (const node of nodes) {
+      if (node?.type === kHighlightFormat && typeof node.highlightId === "string") {
+        ids.add(node.highlightId);
+      }
+      if (Array.isArray(node?.children)) walk(node.children);
+    }
+  };
+  walk(value as any);
+  return ids;
+}
+
+// Returns the references of all variable chip elements in a Slate value.
+function collectVariableReferences(value: EditorValue): Set<string> {
+  const refs = new Set<string>();
+  const walk = (nodes: readonly any[]) => {
+    for (const node of nodes) {
+      if (node?.type === kVariableFormat && typeof node.reference === "string") {
+        refs.add(node.reference);
+      }
+      if (Array.isArray(node?.children)) walk(node.children);
+    }
+  };
+  walk(value as any);
+  return refs;
+}
 
 /*
   The Slate internal data model uses, among other things, "marks" and "blocks"
@@ -102,10 +135,13 @@ export default class TextToolComponent extends BaseComponent<ITileProps, IState>
   private disposers: IReactionDisposer[];
   private textTileDiv: HTMLElement | null;
   private editor: Editor | undefined;
-  private tileContentRect: DOMRectReadOnly;
   private toolbarTileApi: ITileApi | undefined;
   private textOnFocus: string | string [] | undefined;
   private isHandlingUserChange = false;
+  private highlightBoxesCache: Map<string, IHighlightBox> = new Map();
+  private variableBoxesCache: Map<string, IHighlightBox> = new Map();
+  private highlightBoxesCacheTick = observable({ count: 0 });
+  private previousVariableIds: Set<string> = new Set();
 
   static contextType = ContainerContext;
   declare context: React.ContextType<typeof ContainerContext>;
@@ -142,7 +178,9 @@ export default class TextToolComponent extends BaseComponent<ITileProps, IState>
     options.history = false;
     this.editor = createEditor(options);
     this.getContent().setEditor(this.editor);
-    this.setState({ initialValue: this.getContent().asSlate() });
+    const initialValue = this.getContent().asSlate();
+    this.setState({ initialValue });
+    this.previousVariableIds = collectVariableReferences(initialValue);
 
     this.disposers = [];
     // Synchronize slate with model changes. e.g. changes to any text in another tile is refelected here.
@@ -183,27 +221,35 @@ export default class TextToolComponent extends BaseComponent<ITileProps, IState>
         this.toolbarTileApi?.handleDocumentScroll?.(x, y);
       },
       handleTileResize: (entry: TileResizeEntry) => {
-        const { x, y, width, height, top, left, bottom, right } = entry.contentRect;
-        this.tileContentRect = { x, y, width, height, top, left, bottom, right, toJSON: () => "" };
         this.toolbarTileApi?.handleTileResize?.(entry);
       },
       getObjectBoundingBox: (objectId: string, objectType?: string) => {
+        // Track the tick so MobX observers re-run when the cache is written.
+        // eslint-disable-next-line unused-imports/no-unused-vars
+        const _tick = this.highlightBoxesCacheTick.count;
         if (objectType === kHighlightFormat) {
-          const box = this.getContent().highlightBoxesCache.get(objectId);
+          const box = this.highlightBoxesCache.get(objectId);
+          if (box) return box;
+        }
+        if (objectType === kVariableFormat) {
+          const box = this.variableBoxesCache.get(objectId);
           if (box) return box;
         }
       },
       getObjectDefaultOffsets: (objectId: string, objectType?: string) => {
         // offset the annotation arrows to the right top corner of the bounding box until connected to a target,
         // and then offset should be the center of the edge closes to the target
+        // Track the tick so MobX observers re-run when the cache is written.
+        // eslint-disable-next-line unused-imports/no-unused-vars
+        const _tick = this.highlightBoxesCacheTick.count;
         const offsets = OffsetModel.create({});
-        if (objectType === kHighlightFormat) {
-          const box = this.getContent().highlightBoxesCache.get(objectId);
-          if (box) {
-            const { width, height } = box;
-            offsets.setDx(width / 2);
-            offsets.setDy(- height / 2);
-          }
+        const box = objectType === kHighlightFormat ? this.highlightBoxesCache.get(objectId)
+                  : objectType === kVariableFormat ? this.variableBoxesCache.get(objectId)
+                  : undefined;
+        if (box) {
+          const { width, height } = box;
+          offsets.setDx(width / 2);
+          offsets.setDy(- height / 2);
         }
         return offsets;
       },
@@ -268,32 +314,34 @@ export default class TextToolComponent extends BaseComponent<ITileProps, IState>
           <TextPluginsContext.Provider value={this.plugins} >
             <HighlightRevisionContext.Provider value={this.state.revision}>
               <HighlightRegistryContext.Provider value={this.handleUpdateHighlightBoxCache}>
-                <div
-                  className={containerClasses}
-                  data-testid="text-tool-wrapper"
-                  ref={elt => this.textTileDiv = elt}
-                  onMouseDown={this.handleMouseDownInWrapper}
-                >
-                  <Slate
-                    editor={this.editor as ReactEditor}
-                    initialValue={this.state.initialValue}
-                    onChange={this.handleChange}
+                <VariableRegistryContext.Provider value={this.handleUpdateVariableBoxCache}>
+                  <div
+                    className={containerClasses}
+                    data-testid="text-tool-wrapper"
+                    ref={elt => this.textTileDiv = elt}
+                    onMouseDown={this.handleMouseDownInWrapper}
                   >
-                    <SlateEditor
-                      placeholder={placeholderText}
-                      hotkeyMap={defaultHotkeyMap}
-                      readOnly={readOnly}
-                      onFocus={this.handleFocus}
-                      onBlur={this.handleBlur}
-                      className={`ccrte-editor slate-editor ${slateClasses || ""}`}
+                    <Slate
+                      editor={this.editor as ReactEditor}
+                      initialValue={this.state.initialValue}
+                      onChange={this.handleChange}
+                    >
+                      <SlateEditor
+                        placeholder={placeholderText}
+                        hotkeyMap={defaultHotkeyMap}
+                        readOnly={readOnly}
+                        onFocus={this.handleFocus}
+                        onBlur={this.handleBlur}
+                        className={`ccrte-editor slate-editor ${slateClasses || ""}`}
+                      />
+                      <TileToolbar tileType="text" tileElement={this.props.tileElt} readOnly={!!readOnly} />
+                    </Slate>
+                    <VoiceTypingOverlay
+                      text={this.state.interimText || ""}
+                      tileElement={this.textTileDiv}
                     />
-                    <TileToolbar tileType="text" tileElement={this.props.tileElt} readOnly={!!readOnly} />
-                  </Slate>
-                  <VoiceTypingOverlay
-                    text={this.state.interimText || ""}
-                    tileElement={this.textTileDiv}
-                  />
-                </div>
+                  </div>
+                </VariableRegistryContext.Provider>
               </HighlightRegistryContext.Provider>
             </HighlightRevisionContext.Provider>
           </TextPluginsContext.Provider>
@@ -314,8 +362,39 @@ export default class TextToolComponent extends BaseComponent<ITileProps, IState>
 
     if (!readOnly) {
       this.isHandlingUserChange = true;
+      // Cascade-clean any chip the user edited out: remove sparrows attached to it and
+      // clear its bbox cache. For highlights, also prune the highlightedText MST entry.
+      // The two chip kinds track previous state differently: highlights are mirrored in
+      // content.highlightedText, while variables live only in the Slate tree, so we keep
+      // a parallel previousVariableIds snapshot on the component instance.
+      const previousHighlightIds = content.highlightedText.map(h => h.id);
+      const currentHighlightIds = collectHighlightIds(value);
+      const removedHighlightIds = previousHighlightIds.filter(id => !currentHighlightIds.has(id));
+
+      const currentVariableIds = collectVariableReferences(value);
+      const removedVariableIds = [...this.previousVariableIds].filter(id => !currentVariableIds.has(id));
+      const variableChipsChanged = removedVariableIds.length > 0
+        || currentVariableIds.size !== this.previousVariableIds.size;
+      this.previousVariableIds = currentVariableIds;
+
       // Update content model when user changes slate
       content.setSlate(value);
+
+      for (const id of removedHighlightIds) {
+        removeAnnotationsForChip(this.stores, model.id, id, kHighlightFormat);
+        content.removeHighlight(id);
+        this.updateBoxCache(this.highlightBoxesCache, id, undefined);
+      }
+      for (const id of removedVariableIds) {
+        removeAnnotationsForChip(this.stores, model.id, id, kVariableFormat);
+        this.updateBoxCache(this.variableBoxesCache, id, undefined);
+      }
+      // Notify annotatableObjects observers (e.g. AnnotationLayer) that the set of
+      // variable chips has changed, since Slate's editor state isn't observable.
+      if (variableChipsChanged) {
+        content.bumpVariableChipsRevision();
+      }
+
       this.setState({ revision: this.state.revision + 1 });
       this.isHandlingUserChange = false;
     }
@@ -398,7 +477,26 @@ export default class TextToolComponent extends BaseComponent<ITileProps, IState>
     this.setState({ revision: this.state.revision + 1 }); // Force a rerender
   };
 
+  // Skips the tick bump if the value hasn't actually changed, so a no-op ResizeObserver
+  // fire doesn't wake up downstream observers (e.g. AnnotationLayer's render).
+  private updateBoxCache(cache: Map<string, IHighlightBox>, id: string, box: IHighlightBox | undefined) {
+    const existing = cache.get(id);
+    if (box) {
+      if (existing && existing.left === box.left && existing.top === box.top
+          && existing.width === box.width && existing.height === box.height) return;
+      cache.set(id, box);
+    } else {
+      if (!existing) return;
+      cache.delete(id);
+    }
+    runInAction(() => { this.highlightBoxesCacheTick.count++; });
+  }
+
   private handleUpdateHighlightBoxCache = (id: string, box: IHighlightBox) => {
-    this.getContent().setHighlightBoxesCache(id, box);
+    this.updateBoxCache(this.highlightBoxesCache, id, box);
+  };
+
+  private handleUpdateVariableBoxCache = (id: string, box: IHighlightBox) => {
+    this.updateBoxCache(this.variableBoxesCache, id, box);
   };
 }

--- a/src/components/tiles/text/text-tile.tsx
+++ b/src/components/tiles/text/text-tile.tsx
@@ -15,8 +15,6 @@ import { HighlightRegistryContext, HighlightRevisionContext, IHighlightBox }
     from "../../../plugins/text/highlight-registry-context";
 import { removeAnnotationsForChip } from "../../../plugins/text/chip-annotation-cleanup";
 import { kHighlightFormat } from "../../../plugins/text/highlights-plugin";
-import { kVariableFormat, VariableRegistryContext }
-    from "../../../plugins/shared-variables/slate/variables-plugin";
 import { hasSelectionModifier } from "../../../utilities/event-utils";
 import { ITileApi, TileResizeEntry } from "../tile-api";
 import { ITileProps } from "../tile-component";
@@ -45,21 +43,6 @@ function collectHighlightIds(value: EditorValue): Set<string> {
   };
   walk(value as any);
   return ids;
-}
-
-// Returns the references of all variable chip elements in a Slate value.
-function collectVariableReferences(value: EditorValue): Set<string> {
-  const refs = new Set<string>();
-  const walk = (nodes: readonly any[]) => {
-    for (const node of nodes) {
-      if (node?.type === kVariableFormat && typeof node.reference === "string") {
-        refs.add(node.reference);
-      }
-      if (Array.isArray(node?.children)) walk(node.children);
-    }
-  };
-  walk(value as any);
-  return refs;
 }
 
 /*
@@ -139,9 +122,7 @@ export default class TextToolComponent extends BaseComponent<ITileProps, IState>
   private textOnFocus: string | string [] | undefined;
   private isHandlingUserChange = false;
   private highlightBoxesCache: Map<string, IHighlightBox> = new Map();
-  private variableBoxesCache: Map<string, IHighlightBox> = new Map();
   private chipBoxesCacheTick = observable({ count: 0 });
-  private previousVariableIds: Set<string> = new Set();
 
   static contextType = ContainerContext;
   declare context: React.ContextType<typeof ContainerContext>;
@@ -180,7 +161,12 @@ export default class TextToolComponent extends BaseComponent<ITileProps, IState>
     this.getContent().setEditor(this.editor);
     const initialValue = this.getContent().asSlate();
     this.setState({ initialValue });
-    this.previousVariableIds = collectVariableReferences(initialValue);
+    // Give plugins access to stores + tileId (for cleanup hooks) and let them seed any
+    // initial-value state (e.g., the variables plugin's `previousVariableIds` baseline).
+    for (const plugin of Object.values(this.plugins)) {
+      plugin?.setTileContext?.(this.stores, this.props.model.id);
+      plugin?.initializeFromValue?.(initialValue);
+    }
 
     this.disposers = [];
     // Synchronize slate with model changes. e.g. changes to any text in another tile is refelected here.
@@ -228,13 +214,14 @@ export default class TextToolComponent extends BaseComponent<ITileProps, IState>
         // eslint-disable-next-line unused-imports/no-unused-vars
         const _tick = this.chipBoxesCacheTick.count;
         if (objectType === kHighlightFormat) {
-          const box = this.highlightBoxesCache.get(objectId);
+          return this.highlightBoxesCache.get(objectId);
+        }
+        // Other chip kinds (e.g., variable chips) live in their plugin's bbox cache.
+        for (const plugin of Object.values(this.plugins)) {
+          const box = plugin?.getObjectBoundingBox?.(objectId, objectType);
           if (box) return box;
         }
-        if (objectType === kVariableFormat) {
-          const box = this.variableBoxesCache.get(objectId);
-          if (box) return box;
-        }
+        return undefined;
       },
       getObjectDefaultOffsets: (objectId: string, objectType?: string) => {
         // offset the annotation arrows to the right top corner of the bounding box until connected to a target,
@@ -242,16 +229,20 @@ export default class TextToolComponent extends BaseComponent<ITileProps, IState>
         // Track the tick so MobX observers re-run when the cache is written.
         // eslint-disable-next-line unused-imports/no-unused-vars
         const _tick = this.chipBoxesCacheTick.count;
-        const offsets = OffsetModel.create({});
-        const box = objectType === kHighlightFormat ? this.highlightBoxesCache.get(objectId)
-                  : objectType === kVariableFormat ? this.variableBoxesCache.get(objectId)
-                  : undefined;
-        if (box) {
-          const { width, height } = box;
-          offsets.setDx(width / 2);
-          offsets.setDy(- height / 2);
+        if (objectType === kHighlightFormat) {
+          const offsets = OffsetModel.create({});
+          const box = this.highlightBoxesCache.get(objectId);
+          if (box) {
+            offsets.setDx(box.width / 2);
+            offsets.setDy(-box.height / 2);
+          }
+          return offsets;
         }
-        return offsets;
+        for (const plugin of Object.values(this.plugins)) {
+          const offsets = plugin?.getObjectDefaultOffsets?.(objectId, objectType);
+          if (offsets) return offsets;
+        }
+        return OffsetModel.create({});
       },
       // Return focusable elements for focus trap navigation
       getFocusableElements: () => {
@@ -314,34 +305,32 @@ export default class TextToolComponent extends BaseComponent<ITileProps, IState>
           <TextPluginsContext.Provider value={this.plugins} >
             <HighlightRevisionContext.Provider value={this.state.revision}>
               <HighlightRegistryContext.Provider value={this.handleUpdateHighlightBoxCache}>
-                <VariableRegistryContext.Provider value={this.handleUpdateVariableBoxCache}>
-                  <div
-                    className={containerClasses}
-                    data-testid="text-tool-wrapper"
-                    ref={elt => this.textTileDiv = elt}
-                    onMouseDown={this.handleMouseDownInWrapper}
+                <div
+                  className={containerClasses}
+                  data-testid="text-tool-wrapper"
+                  ref={elt => this.textTileDiv = elt}
+                  onMouseDown={this.handleMouseDownInWrapper}
+                >
+                  <Slate
+                    editor={this.editor as ReactEditor}
+                    initialValue={this.state.initialValue}
+                    onChange={this.handleChange}
                   >
-                    <Slate
-                      editor={this.editor as ReactEditor}
-                      initialValue={this.state.initialValue}
-                      onChange={this.handleChange}
-                    >
-                      <SlateEditor
-                        placeholder={placeholderText}
-                        hotkeyMap={defaultHotkeyMap}
-                        readOnly={readOnly}
-                        onFocus={this.handleFocus}
-                        onBlur={this.handleBlur}
-                        className={`ccrte-editor slate-editor ${slateClasses || ""}`}
-                      />
-                      <TileToolbar tileType="text" tileElement={this.props.tileElt} readOnly={!!readOnly} />
-                    </Slate>
-                    <VoiceTypingOverlay
-                      text={this.state.interimText || ""}
-                      tileElement={this.textTileDiv}
+                    <SlateEditor
+                      placeholder={placeholderText}
+                      hotkeyMap={defaultHotkeyMap}
+                      readOnly={readOnly}
+                      onFocus={this.handleFocus}
+                      onBlur={this.handleBlur}
+                      className={`ccrte-editor slate-editor ${slateClasses || ""}`}
                     />
-                  </div>
-                </VariableRegistryContext.Provider>
+                    <TileToolbar tileType="text" tileElement={this.props.tileElt} readOnly={!!readOnly} />
+                  </Slate>
+                  <VoiceTypingOverlay
+                    text={this.state.interimText || ""}
+                    tileElement={this.textTileDiv}
+                  />
+                </div>
               </HighlightRegistryContext.Provider>
             </HighlightRevisionContext.Provider>
           </TextPluginsContext.Provider>
@@ -362,20 +351,11 @@ export default class TextToolComponent extends BaseComponent<ITileProps, IState>
 
     if (!readOnly) {
       this.isHandlingUserChange = true;
-      // Cascade-clean any chip the user edited out: remove sparrows attached to it and
-      // clear its bbox cache. For highlights, also prune the highlightedText MST entry.
-      // The two chip kinds track previous state differently: highlights are mirrored in
-      // content.highlightedText, while variables live only in the Slate tree, so we keep
-      // a parallel previousVariableIds snapshot on the component instance.
+      // Cascade-clean any highlight chip the user edited out: remove sparrows attached
+      // to it, prune the highlightedText MST entry, and clear its bbox cache.
       const previousHighlightIds = content.highlightedText.map(h => h.id);
       const currentHighlightIds = collectHighlightIds(value);
       const removedHighlightIds = previousHighlightIds.filter(id => !currentHighlightIds.has(id));
-
-      const currentVariableIds = collectVariableReferences(value);
-      const removedVariableIds = [...this.previousVariableIds].filter(id => !currentVariableIds.has(id));
-      const variableChipsChanged = removedVariableIds.length > 0
-        || currentVariableIds.size !== this.previousVariableIds.size;
-      this.previousVariableIds = currentVariableIds;
 
       // Update content model when user changes slate
       content.setSlate(value);
@@ -385,14 +365,10 @@ export default class TextToolComponent extends BaseComponent<ITileProps, IState>
         content.removeHighlight(id);
         this.updateBoxCache(this.highlightBoxesCache, id, undefined);
       }
-      for (const id of removedVariableIds) {
-        removeAnnotationsForChip(this.stores, model.id, id, kVariableFormat);
-        this.updateBoxCache(this.variableBoxesCache, id, undefined);
-      }
-      // Notify annotatableObjects observers (e.g. AnnotationLayer) that the set of
-      // variable chips has changed, since Slate's editor state isn't observable.
-      if (variableChipsChanged) {
-        content.bumpVariableChipsRevision();
+      // Other chip kinds (e.g., variable chips) handle their own diff/cleanup inside
+      // their plugin's handleSlateValueChange hook.
+      for (const plugin of Object.values(this.plugins)) {
+        plugin?.handleSlateValueChange?.(value);
       }
 
       this.setState({ revision: this.state.revision + 1 });
@@ -494,9 +470,5 @@ export default class TextToolComponent extends BaseComponent<ITileProps, IState>
 
   private handleUpdateHighlightBoxCache = (id: string, box: IHighlightBox) => {
     this.updateBoxCache(this.highlightBoxesCache, id, box);
-  };
-
-  private handleUpdateVariableBoxCache = (id: string, box: IHighlightBox) => {
-    this.updateBoxCache(this.variableBoxesCache, id, box);
   };
 }

--- a/src/components/tiles/text/toolbar/highlight-button.tsx
+++ b/src/components/tiles/text/toolbar/highlight-button.tsx
@@ -4,6 +4,7 @@ import { Path, Text } from "slate";
 import { ReactEditor, Editor, Range, Transforms, useSlate } from "@concord-consortium/slate-editor";
 import { HighlightsPlugin, kHighlightTextPluginName, kHighlightFormat, HighlightElement }
   from "../../../../plugins/text/highlights-plugin";
+import { removeAnnotationsForChip } from "../../../../plugins/text/chip-annotation-cleanup";
 import { useStores } from "../../../../hooks/use-stores";
 import { TileToolbarButton } from "../../../toolbar/tile-toolbar-button";
 import { IToolbarButtonComponentProps } from "../../../toolbar/toolbar-button-manager";
@@ -89,29 +90,6 @@ export const HighlightButton = ({name}: IToolbarButtonComponentProps) => {
       if (!selectedChips || selectedChips.length === 0) return;
       const chipReferences = selectedChips.map(([chipNode]) => chipNode.highlightId);
 
-      const removeAnnotationsForHighlight = (highlightId: string) => {
-        if (!stores?.documents || !model?.id) return;
-        const document = stores.documents.findDocumentOfTile(model.id);
-        if (!document?.content) return;
-        const annotationsToRemove: string[] = [];
-        document.content.annotations.forEach((annotation) => {
-          // Check if the annotation's source or target object references this highlight
-          if (annotation.sourceObject?.objectId === highlightId &&
-                annotation.sourceObject?.objectType === kHighlightFormat) {
-            annotationsToRemove.push(annotation.id);
-          }
-          if (annotation.targetObject?.objectId === highlightId &&
-                annotation.targetObject?.objectType === kHighlightFormat) {
-            annotationsToRemove.push(annotation.id);
-          }
-        });
-        annotationsToRemove.forEach(annotationId => {
-          if (document.content) {
-            document.content.deleteAnnotation(annotationId);
-          }
-        });
-      };
-
       chipReferences.forEach(ref => {
         const [chipEntry] = Array.from(Editor.nodes(editor, {
           match: n => (n as any).type === kHighlightFormat && (n as any).highlightId === ref,
@@ -121,7 +99,7 @@ export const HighlightButton = ({name}: IToolbarButtonComponentProps) => {
           const chipReference = chipEntry[0].highlightId;
           highlightsPlugin?.removeHighlight(ref);
           unHighlightChip(chipEntry);
-          removeAnnotationsForHighlight(chipReference);
+          removeAnnotationsForChip(stores, model?.id, chipReference, kHighlightFormat);
         }
       });
       Transforms.deselect(editor);

--- a/src/models/tiles/text/text-content.ts
+++ b/src/models/tiles/text/text-content.ts
@@ -10,7 +10,6 @@ import { escapeBackslashes, escapeDoubleQuotes, removeNewlines, removeTabs } fro
 import { tileContentAPIViews } from "../tile-model-hooks";
 import { IClueTileObject } from "../../../models/annotations/clue-object";
 import { kHighlightFormat } from "../../../plugins/text/highlights-plugin";
-import { kVariableFormat } from "../../../plugins/shared-variables/slate/variables-plugin";
 
 export const kTextTileType = "Text";
 
@@ -29,10 +28,6 @@ export const TextContentModel = TileContentModel
   })
   .volatile(self => ({
     editor:  undefined as CustomEditor | undefined,
-    // Bumped when variable chips are added to or removed from the Slate editor. Read by
-    // `annotatableObjects` so the view participates in MobX reactivity for variable
-    // chips — Slate's editor state isn't otherwise observable.
-    variableChipsRevision: 0
   }))
   .views(self => ({
     // guarantees string (not readonly string) types
@@ -149,9 +144,6 @@ export const TextContentModel = TileContentModel
       if (index >= 0) {
         self.highlightedText.splice(index, 1);
       }
-    },
-    bumpVariableChipsRevision() {
-      self.variableChipsRevision++;
     }
   }))
   .actions(self => ({
@@ -167,20 +159,14 @@ export const TextContentModel = TileContentModel
       self.highlightedText.forEach(highlight => {
         objects.push({objectId: highlight.id, objectType: kHighlightFormat});
       });
-      // Variable chips live only in the Slate tree (no MST mirror), so enumerate them
-      // by walking the editor. Read variableChipsRevision so MobX re-evaluates this
-      // view when text-tile's handleChange detects a variable chip add or remove.
-      // eslint-disable-next-line unused-imports/no-unused-vars
-      const _revision = self.variableChipsRevision;
-      const editor = self.editor;
-      if (editor) {
-        for (const [node] of Editor.nodes(editor, { at: [], mode: "all" })) {
-          const anyNode = node as any;
-          if (anyNode?.type === kVariableFormat && typeof anyNode.reference === "string") {
-            objects.push({ objectId: anyNode.reference, objectType: kVariableFormat });
-          }
+      // Each text plugin contributes its own annotatable objects (e.g. variable chips
+      // from the shared-variables plugin) and is responsible for its own MobX
+      // reactivity — Slate's editor state isn't otherwise observable.
+      getAllTextPluginInfos().forEach(info => {
+        if (info?.getAnnotatableObjects) {
+          objects.push(...info.getAnnotatableObjects(self));
         }
-      }
+      });
       return objects;
     },
   }));

--- a/src/models/tiles/text/text-content.ts
+++ b/src/models/tiles/text/text-content.ts
@@ -1,4 +1,3 @@
-import { ObservableMap } from "mobx";
 import { types, Instance, SnapshotIn, cast } from "mobx-state-tree";
 import {
   convertDocument, CustomEditor, Editor, EditorValue, htmlToSlate, serializeValue, slateToHtml, textToSlate, slateToText
@@ -11,7 +10,7 @@ import { escapeBackslashes, escapeDoubleQuotes, removeNewlines, removeTabs } fro
 import { tileContentAPIViews } from "../tile-model-hooks";
 import { IClueTileObject } from "../../../models/annotations/clue-object";
 import { kHighlightFormat } from "../../../plugins/text/highlights-plugin";
-import { IHighlightBox } from "../../../plugins/text/highlight-registry-context";
+import { kVariableFormat } from "../../../plugins/shared-variables/slate/variables-plugin";
 
 export const kTextTileType = "Text";
 
@@ -30,7 +29,10 @@ export const TextContentModel = TileContentModel
   })
   .volatile(self => ({
     editor:  undefined as CustomEditor | undefined,
-    highlightBoxesCache: new ObservableMap<string, IHighlightBox>(),
+    // Bumped when variable chips are added to or removed from the Slate editor. Read by
+    // `annotatableObjects` so the view participates in MobX reactivity for variable
+    // chips — Slate's editor state isn't otherwise observable.
+    variableChipsRevision: 0
   }))
   .views(self => ({
     // guarantees string (not readonly string) types
@@ -148,12 +150,8 @@ export const TextContentModel = TileContentModel
         self.highlightedText.splice(index, 1);
       }
     },
-    setHighlightBoxesCache(id: string, box: IHighlightBox) {
-      if (box) {
-        self.highlightBoxesCache.set(id, box);
-      } else {
-        self.highlightBoxesCache.delete(id);
-      }
+    bumpVariableChipsRevision() {
+      self.variableChipsRevision++;
     }
   }))
   .actions(self => ({
@@ -166,10 +164,23 @@ export const TextContentModel = TileContentModel
   .views(self => tileContentAPIViews({
     get annotatableObjects(): IClueTileObject[] {
       const objects: IClueTileObject[] = [];
-      const objectType = kHighlightFormat;
       self.highlightedText.forEach(highlight => {
-        objects.push({objectId: highlight.id, objectType});
+        objects.push({objectId: highlight.id, objectType: kHighlightFormat});
       });
+      // Variable chips live only in the Slate tree (no MST mirror), so enumerate them
+      // by walking the editor. Read variableChipsRevision so MobX re-evaluates this
+      // view when text-tile's handleChange detects a variable chip add or remove.
+      // eslint-disable-next-line unused-imports/no-unused-vars
+      const _revision = self.variableChipsRevision;
+      const editor = self.editor;
+      if (editor) {
+        for (const [node] of Editor.nodes(editor, { at: [], mode: "all" })) {
+          const anyNode = node as any;
+          if (anyNode?.type === kVariableFormat && typeof anyNode.reference === "string") {
+            objects.push({ objectId: anyNode.reference, objectType: kVariableFormat });
+          }
+        }
+      }
       return objects;
     },
   }));

--- a/src/models/tiles/text/text-plugin-info.ts
+++ b/src/models/tiles/text/text-plugin-info.ts
@@ -1,10 +1,20 @@
-import { Editor} from "@concord-consortium/slate-editor";
+import { Editor, EditorValue } from "@concord-consortium/slate-editor";
+import { IClueTileObject, IOffsetModel, ObjectBoundingBox } from "../../annotations/clue-object";
 import { SharedModelType } from "../../shared/shared-model";
+import { IStores } from "../../stores/stores";
 import { TextContentModelType } from "./text-content";
 
 export interface ITextPlugin {
   onInitEditor?: (editor: Editor) => Editor;
   dispose?: () => void;
+  getObjectBoundingBox?: (id: string, type?: string) => ObjectBoundingBox | undefined;
+  getObjectDefaultOffsets?: (id: string, type?: string) => IOffsetModel | undefined;
+  handleSlateValueChange?: (value: EditorValue) => void;
+  initializeFromValue?: (value: EditorValue) => void;
+  // Optional post-construction setter for plugins that need access to application
+  // stores and the owning tile id (e.g., to clean up annotations attached to chips
+  // the user edited out). createSlatePlugin(textContent) doesn't expose either.
+  setTileContext?: (stores: IStores, tileId: string) => void;
 }
 
 export interface IButtonDefProps {
@@ -19,6 +29,7 @@ export interface ITextPluginInfo {
     (textContent: TextContentModelType) => ITextPlugin;
   updateTextContentAfterSharedModelChanges?:
     (textContent: TextContentModelType, sharedModel?: SharedModelType) => void;
+  getAnnotatableObjects?: (textContent: TextContentModelType) => IClueTileObject[];
 }
 
 const gTextPluginInfoMap: Record<string, ITextPluginInfo | undefined> = {};

--- a/src/plugins/shared-variables/shared-variables-registration.ts
+++ b/src/plugins/shared-variables/shared-variables-registration.ts
@@ -1,6 +1,9 @@
+import { Editor } from "@concord-consortium/slate-editor";
 import { registerTileToolbarButtons } from "../../components/toolbar/toolbar-button-manager";
+import { IClueTileObject } from "../../models/annotations/clue-object";
 import { ISharedModelManager } from "../../models/shared/shared-model-manager";
 import { registerSharedModelInfo } from "../../models/shared/shared-model-registry";
+import { TextContentModelType } from "../../models/tiles/text/text-content";
 import { registerTextPluginInfo } from "../../models/tiles/text/text-plugin-info";
 import { registerDrawingObjectInfo } from "../drawing/components/drawing-object-manager";
 import { IGraphModel, registerGraphSharedModelUpdateFunction } from "../graph/models/graph-model";
@@ -15,7 +18,7 @@ import {
 import { kSharedVariablesID, SharedVariables } from "./shared-variables";
 import { NewVariableTextButton, InsertVariableTextButton, EditVariableTextButton,
   kNewVariableButtonName, kInsertVariableButtonName, kEditVariableButtonName} from "./slate/text-tile-buttons";
-import { kVariableTextPluginName, VariablesPlugin } from "./slate/variables-plugin";
+import { kVariableFormat, kVariableTextPluginName, VariablesPlugin } from "./slate/variables-plugin";
 
 
 registerSharedModelInfo({
@@ -24,12 +27,38 @@ registerSharedModelInfo({
   hasName: false
 });
 
+// Look up the per-textContent plugin instance from the info-level `getAnnotatableObjects`
+// hook, which has only `textContent` to work with. WeakMap keeps GC behavior intact —
+// when the textContent is collected, its plugin entry goes with it.
+const gPluginByContent = new WeakMap<TextContentModelType, VariablesPlugin>();
+
 registerTextPluginInfo({
   pluginName: kVariableTextPluginName,
   createSlatePlugin(textContent) {
     const plugin = new VariablesPlugin(textContent);
     plugin.addTileSharedModelWhenReady();
+    gPluginByContent.set(textContent, plugin);
     return plugin;
+  },
+  getAnnotatableObjects(textContent): IClueTileObject[] {
+    // Read textContent.editor BEFORE the WeakMap lookup so MobX tracks it even when
+    // the plugin isn't yet registered. The text tile sets the editor (via setEditor)
+    // immediately after createSlatePlugin populates the WeakMap, so once that observable
+    // changes, the next re-evaluation will find both editor and plugin.
+    const editor = textContent.editor;
+    const plugin = gPluginByContent.get(textContent);
+    if (!plugin || !editor) return [];
+    // Track the revision so MobX re-evaluates when variable chips are added or removed.
+    // eslint-disable-next-line unused-imports/no-unused-vars
+    const _pluginRevision = plugin.variableChipsRevision;
+    const objects: IClueTileObject[] = [];
+    for (const [node] of Editor.nodes(editor, { at: [], mode: "all" })) {
+      const anyNode = node as any;
+      if (anyNode?.type === kVariableFormat && typeof anyNode.reference === "string") {
+        objects.push({ objectId: anyNode.reference, objectType: kVariableFormat });
+      }
+    }
+    return objects;
   },
 });
 

--- a/src/plugins/shared-variables/slate/variables-plugin.tsx
+++ b/src/plugins/shared-variables/slate/variables-plugin.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useCallback, useContext, useRef } from "react";
 import classNames from "classnames/dedupe";
 
 import {
@@ -12,13 +12,22 @@ import { VariableChip, VariableType } from "@concord-consortium/diagram-view";
 import { TextContentModelType } from "../../../models/tiles/text/text-content";
 import { ITextPlugin } from "../../../models/tiles/text/text-plugin-info";
 import { TextPluginsContext } from "../../../components/tiles/text/text-plugins-context";
+import { IHighlightBox } from "../../text/highlight-registry-context";
+import { getChipBoxInWrapperCoords, useChipMeasurement } from "../../text/use-chip-measurement";
 
 import { DEBUG_SHARED_MODELS } from "../../../lib/debug";
 import { SharedVariables, SharedVariablesType } from "../shared-variables";
 
 const kVariableClass = "slate-variable-chip";
+const kVariableChipOffset = 2;
 export const kVariableFormat = "m2s-variable";
 export const kVariableTextPluginName = "variables";
+
+// The owning TextToolComponent provides this callback; each chip invokes it post-mount
+// and on layout changes to publish its bounding box (in `.text-tool-wrapper` coords) so
+// the annotation layer can attach sparrows to the chip.
+export type VariableRegistryFn = (id: string, box: IHighlightBox) => void;
+export const VariableRegistryContext = React.createContext<VariableRegistryFn | null>(null);
 
 export class VariablesPlugin implements ITextPlugin {
   public textContent;
@@ -142,21 +151,37 @@ export const VariableComponent = observer(function({ attributes, children, eleme
   const variablesPlugin = plugins[kVariableTextPluginName] as VariablesPlugin|undefined;
   const isHighlighted = useSelected();
   const isSerializing = useSerializing();
+  const registryFn = useContext(VariableRegistryContext);
+  const chipRef = useRef<HTMLSpanElement>(null);
+
+  const reference = isVariableElement(element) ? element.reference : undefined;
+
+  // Publish the chip's bbox in `.text-tool-wrapper` coordinates. Skips zero-sized
+  // measurements so the registry only sees real layout. useChipMeasurement handles
+  // the retry/observer scaffolding.
+  const measure = useCallback(() => {
+    const el = chipRef.current;
+    if (!el || !registryFn || !reference) return;
+    const box = getChipBoxInWrapperCoords(el, kVariableChipOffset);
+    if (box) registryFn(reference, box);
+  }, [reference, registryFn]);
+
+  useChipMeasurement(chipRef, measure);
 
   if (!isVariableElement(element)) return null;
 
-  const {reference} = element;
-
   const classes = classNames(kSlateVoidClass, kVariableClass);
   const selectedClass = isHighlighted && !isSerializing ? "slate-selected" : undefined;
-  const variable = variablesPlugin?.variables.find(v => v.id === reference);
+  const variable = variablesPlugin?.variables.find(v => v.id === element.reference);
   // FIXME: HTML serialization/deserialization. This will serialize the VariableChip too.
   return (
     <span className={classes} {...attributes} contentEditable={false}>
       {children}
       { variable ?
-        <VariableChip variable={variable} className={selectedClass} /> :
-        `invalid reference: ${reference}`
+        <span ref={chipRef} className="variable-chip-measure-wrapper">
+          <VariableChip variable={variable} className={selectedClass} />
+        </span> :
+        `invalid reference: ${element.reference}`
       }
     </span>
   );

--- a/src/plugins/shared-variables/slate/variables-plugin.tsx
+++ b/src/plugins/shared-variables/slate/variables-plugin.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useRef } from "react";
+import React, { useCallback, useContext, useState } from "react";
 import classNames from "classnames/dedupe";
 
 import {
@@ -152,7 +152,10 @@ export const VariableComponent = observer(function({ attributes, children, eleme
   const isHighlighted = useSelected();
   const isSerializing = useSerializing();
   const registryFn = useContext(VariableRegistryContext);
-  const chipRef = useRef<HTMLSpanElement>(null);
+  // useState + callback ref so the effect in useChipMeasurement re-runs when the chip
+  // element appears — the chip is conditionally rendered (only when the variable
+  // resolves), and a useRef wouldn't trigger a re-run when `.current` changes.
+  const [chipEl, setChipEl] = useState<HTMLSpanElement | null>(null);
 
   const reference = isVariableElement(element) ? element.reference : undefined;
 
@@ -160,13 +163,12 @@ export const VariableComponent = observer(function({ attributes, children, eleme
   // measurements so the registry only sees real layout. useChipMeasurement handles
   // the retry/observer scaffolding.
   const measure = useCallback(() => {
-    const el = chipRef.current;
-    if (!el || !registryFn || !reference) return;
-    const box = getChipBoxInWrapperCoords(el, kVariableChipOffset);
+    if (!chipEl || !registryFn || !reference) return;
+    const box = getChipBoxInWrapperCoords(chipEl, kVariableChipOffset);
     if (box) registryFn(reference, box);
-  }, [reference, registryFn]);
+  }, [chipEl, reference, registryFn]);
 
-  useChipMeasurement(chipRef, measure);
+  useChipMeasurement(chipEl, measure);
 
   if (!isVariableElement(element)) return null;
 
@@ -178,7 +180,7 @@ export const VariableComponent = observer(function({ attributes, children, eleme
     <span className={classes} {...attributes} contentEditable={false}>
       {children}
       { variable ?
-        <span ref={chipRef} className="variable-chip-measure-wrapper">
+        <span ref={setChipEl} className="variable-chip-measure-wrapper">
           <VariableChip variable={variable} className={selectedClass} />
         </span> :
         `invalid reference: ${element.reference}`

--- a/src/plugins/shared-variables/slate/variables-plugin.tsx
+++ b/src/plugins/shared-variables/slate/variables-plugin.tsx
@@ -2,45 +2,149 @@ import React, { useCallback, useContext, useState } from "react";
 import classNames from "classnames/dedupe";
 
 import {
-  BaseElement, CustomEditor, CustomElement, Editor, isCustomElement, kSlateVoidClass, registerElementComponent,
-  RenderElementProps, useSelected, useSerializing
+  BaseElement, CustomEditor, CustomElement, Editor, EditorValue, isCustomElement, kSlateVoidClass,
+  registerElementComponent, RenderElementProps, useSelected, useSerializing
 } from "@concord-consortium/slate-editor";
-import { action, autorun, computed, IReactionDisposer, makeObservable, observable } from "mobx";
+import { action, autorun, computed, IReactionDisposer, makeObservable, observable, runInAction } from "mobx";
 import { getType } from "mobx-state-tree";
 import { observer } from "mobx-react";
 import { VariableChip, VariableType } from "@concord-consortium/diagram-view";
 import { TextContentModelType } from "../../../models/tiles/text/text-content";
 import { ITextPlugin } from "../../../models/tiles/text/text-plugin-info";
 import { TextPluginsContext } from "../../../components/tiles/text/text-plugins-context";
-import { IHighlightBox } from "../../text/highlight-registry-context";
+import { IOffsetModel, ObjectBoundingBox, OffsetModel } from "../../../models/annotations/clue-object";
+import { IStores } from "../../../models/stores/stores";
+import { removeAnnotationsForChip } from "../../text/chip-annotation-cleanup";
 import { getChipBoxInWrapperCoords, useChipMeasurement } from "../../text/use-chip-measurement";
 
 import { DEBUG_SHARED_MODELS } from "../../../lib/debug";
 import { SharedVariables, SharedVariablesType } from "../shared-variables";
+
+// Returns the references of all variable chip elements in a Slate value.
+function collectVariableReferences(value: EditorValue): Set<string> {
+  const refs = new Set<string>();
+  const walk = (nodes: readonly any[]) => {
+    for (const node of nodes) {
+      if (node?.type === kVariableFormat && typeof node.reference === "string") {
+        refs.add(node.reference);
+      }
+      if (Array.isArray(node?.children)) walk(node.children);
+    }
+  };
+  walk(value as any);
+  return refs;
+}
 
 const kVariableClass = "slate-variable-chip";
 const kVariableChipOffset = 2;
 export const kVariableFormat = "m2s-variable";
 export const kVariableTextPluginName = "variables";
 
-// The owning TextToolComponent provides this callback; each chip invokes it post-mount
-// and on layout changes to publish its bounding box (in `.text-tool-wrapper` coords) so
-// the annotation layer can attach sparrows to the chip.
-export type VariableRegistryFn = (id: string, box: IHighlightBox) => void;
-export const VariableRegistryContext = React.createContext<VariableRegistryFn | null>(null);
-
 export class VariablesPlugin implements ITextPlugin {
   public textContent;
   private disposeSharedModelManagerAutorun: IReactionDisposer|undefined;
+  private variableBoxesCache: Map<string, ObjectBoundingBox> = new Map();
+  private previousVariableIds: Set<string> = new Set();
+  private chipBoxesCacheTick = observable({ count: 0 });
+  private stores: IStores | undefined;
+  private tileId: string | undefined;
+  // Bumped when variable chips are added to or removed from the Slate editor. Read by
+  // the variables plugin's `getAnnotatableObjects` so `annotatableObjects` re-evaluates
+  // when the chip set changes — Slate's editor state isn't otherwise observable.
+  variableChipsRevision = 0;
 
   constructor(textContent: TextContentModelType) {
     makeObservable(this, {
       textContent: observable,
       sharedModel: computed,
       variables: computed,
-      onInitEditor: action
+      onInitEditor: action,
+      variableChipsRevision: observable,
+      bumpRevision: action
     });
     this.textContent = textContent;
+  }
+
+  /**
+   * Publish a chip's bounding box (in `.text-tool-wrapper` coords) to the per-plugin cache.
+   * Skips the tick bump if the box hasn't changed, so a no-op ResizeObserver fire doesn't
+   * wake up downstream observers (e.g. AnnotationLayer's render).
+   */
+  publishChipBox(reference: string, box: ObjectBoundingBox) {
+    const existing = this.variableBoxesCache.get(reference);
+    if (existing && existing.left === box.left && existing.top === box.top
+        && existing.width === box.width && existing.height === box.height) return;
+    this.variableBoxesCache.set(reference, box);
+    runInAction(() => { this.chipBoxesCacheTick.count++; });
+  }
+
+  private clearChipBox(reference: string) {
+    if (!this.variableBoxesCache.has(reference)) return;
+    this.variableBoxesCache.delete(reference);
+    runInAction(() => { this.chipBoxesCacheTick.count++; });
+  }
+
+  getObjectBoundingBox(id: string, type?: string): ObjectBoundingBox | undefined {
+    if (type !== kVariableFormat) return undefined;
+    // Track the tick so MobX observers re-run when the cache is written.
+    // eslint-disable-next-line unused-imports/no-unused-vars
+    const _tick = this.chipBoxesCacheTick.count;
+    return this.variableBoxesCache.get(id);
+  }
+
+  getObjectDefaultOffsets(id: string, type?: string): IOffsetModel | undefined {
+    if (type !== kVariableFormat) return undefined;
+    // Track the tick so MobX observers re-run when the cache is written.
+    // eslint-disable-next-line unused-imports/no-unused-vars
+    const _tick = this.chipBoxesCacheTick.count;
+    const offsets = OffsetModel.create({});
+    const box = this.variableBoxesCache.get(id);
+    if (box) {
+      offsets.setDx(box.width / 2);
+      offsets.setDy(-box.height / 2);
+    }
+    return offsets;
+  }
+
+  /**
+   * Provide the plugin with the application stores and the owning tile id.
+   * Required so `handleSlateValueChange` can clean up annotations attached to chips
+   * the user edited out. Called by the text tile after the plugin is constructed —
+   * `createSlatePlugin(textContent)` doesn't expose either of these.
+   */
+  setTileContext(stores: IStores, tileId: string) {
+    this.stores = stores;
+    this.tileId = tileId;
+  }
+
+  /**
+   * Seed `previousVariableIds` from the initial Slate value before the first user edit,
+   * so the first `handleSlateValueChange` diff has the correct baseline.
+   */
+  initializeFromValue(value: EditorValue) {
+    this.previousVariableIds = collectVariableReferences(value);
+  }
+
+  /**
+   * Diff the variable-chip set on each Slate change. For every removed chip, prune any
+   * annotation attached to it and clear its bbox cache entry. Bumps the revision counter
+   * when the chip set changes, so observers of `annotatableObjects` re-run.
+   */
+  handleSlateValueChange(value: EditorValue) {
+    const currentIds = collectVariableReferences(value);
+    const removed = [...this.previousVariableIds].filter(id => !currentIds.has(id));
+    const changed = removed.length > 0 || currentIds.size !== this.previousVariableIds.size;
+    this.previousVariableIds = currentIds;
+
+    for (const id of removed) {
+      removeAnnotationsForChip(this.stores, this.tileId, id, kVariableFormat);
+      this.clearChipBox(id);
+    }
+    if (changed) this.bumpRevision();
+  }
+
+  bumpRevision() {
+    this.variableChipsRevision++;
   }
 
   get sharedModel() {
@@ -151,7 +255,6 @@ export const VariableComponent = observer(function({ attributes, children, eleme
   const variablesPlugin = plugins[kVariableTextPluginName] as VariablesPlugin|undefined;
   const isHighlighted = useSelected();
   const isSerializing = useSerializing();
-  const registryFn = useContext(VariableRegistryContext);
   // useState + callback ref so the effect in useChipMeasurement re-runs when the chip
   // element appears — the chip is conditionally rendered (only when the variable
   // resolves), and a useRef wouldn't trigger a re-run when `.current` changes.
@@ -163,10 +266,10 @@ export const VariableComponent = observer(function({ attributes, children, eleme
   // measurements so the registry only sees real layout. useChipMeasurement handles
   // the retry/observer scaffolding.
   const measure = useCallback(() => {
-    if (!chipEl || !registryFn || !reference) return;
+    if (!chipEl || !variablesPlugin || !reference) return;
     const box = getChipBoxInWrapperCoords(chipEl, kVariableChipOffset);
-    if (box) registryFn(reference, box);
-  }, [chipEl, reference, registryFn]);
+    if (box) variablesPlugin.publishChipBox(reference, box);
+  }, [chipEl, reference, variablesPlugin]);
 
   useChipMeasurement(chipEl, measure);
 

--- a/src/plugins/text/chip-annotation-cleanup.ts
+++ b/src/plugins/text/chip-annotation-cleanup.ts
@@ -1,0 +1,30 @@
+import { IStores } from "../../models/stores/stores";
+
+// Removes any arrow annotations whose source or target endpoint references the given
+// chip. Called whenever a chip is removed (via the unhighlight toolbar button or by
+// editing the text out from under it). Supports both highlight chips and variable chips
+// — caller passes the appropriate `chipType` (kHighlightFormat or kVariableFormat).
+export function removeAnnotationsForChip(
+  stores: IStores | null | undefined,
+  tileId: string | undefined,
+  chipId: string,
+  chipType: string
+) {
+  if (!stores?.documents || !tileId) return;
+  const document = stores.documents.findDocumentOfTile(tileId);
+  if (!document?.content) return;
+  const annotationsToRemove: string[] = [];
+  document.content.annotations.forEach(annotation => {
+    if (annotation.sourceObject?.objectId === chipId
+        && annotation.sourceObject?.objectType === chipType) {
+      annotationsToRemove.push(annotation.id);
+    }
+    if (annotation.targetObject?.objectId === chipId
+        && annotation.targetObject?.objectType === chipType) {
+      annotationsToRemove.push(annotation.id);
+    }
+  });
+  annotationsToRemove.forEach(annotationId => {
+    document.content?.deleteAnnotation(annotationId);
+  });
+}

--- a/src/plugins/text/chip-annotation-cleanup.ts
+++ b/src/plugins/text/chip-annotation-cleanup.ts
@@ -1,9 +1,17 @@
 import { IStores } from "../../models/stores/stores";
 
-// Removes any arrow annotations whose source or target endpoint references the given
-// chip. Called whenever a chip is removed (via the unhighlight toolbar button or by
-// editing the text out from under it). Supports both highlight chips and variable chips
-// — caller passes the appropriate `chipType` (kHighlightFormat or kVariableFormat).
+/**
+ * Removes any arrow annotations whose source or target endpoint references the given
+ * chip. Called whenever a chip is removed — via the unhighlight toolbar button, or by
+ * editing the text out from under it. Supports both highlight chips and variable chips;
+ * the caller passes the appropriate `chipType` constant.
+ *
+ * @param stores - Application stores, used to look up the document containing the tile.
+ * @param tileId - The id of the text tile whose chip is being removed.
+ * @param chipId - For highlights, the chip's `highlightId`; for variables, the chip's
+ *                 `reference`.
+ * @param chipType - `kHighlightFormat` or `kVariableFormat`.
+ */
 export function removeAnnotationsForChip(
   stores: IStores | null | undefined,
   tileId: string | undefined,
@@ -13,15 +21,15 @@ export function removeAnnotationsForChip(
   if (!stores?.documents || !tileId) return;
   const document = stores.documents.findDocumentOfTile(tileId);
   if (!document?.content) return;
-  const annotationsToRemove: string[] = [];
+  const annotationsToRemove = new Set<string>();
   document.content.annotations.forEach(annotation => {
     if (annotation.sourceObject?.objectId === chipId
         && annotation.sourceObject?.objectType === chipType) {
-      annotationsToRemove.push(annotation.id);
+      annotationsToRemove.add(annotation.id);
     }
     if (annotation.targetObject?.objectId === chipId
         && annotation.targetObject?.objectType === chipType) {
-      annotationsToRemove.push(annotation.id);
+      annotationsToRemove.add(annotation.id);
     }
   });
   annotationsToRemove.forEach(annotationId => {

--- a/src/plugins/text/highlights-plugin.tsx
+++ b/src/plugins/text/highlights-plugin.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect, useRef } from "react";
+import React, { useCallback, useContext, useRef } from "react";
 import classNames from "classnames/dedupe";
 import { BaseElement, CustomEditor, CustomElement, Editor, kSlateVoidClass, registerElementComponent,
   RenderElementProps, useSelected } from "@concord-consortium/slate-editor";
@@ -7,6 +7,7 @@ import { TextContentModelType } from "../../models/tiles/text/text-content";
 import { ITextPlugin } from "../../models/tiles/text/text-plugin-info";
 import { TextPluginsContext } from "../../components/tiles/text/text-plugins-context";
 import { HighlightRegistryContext, HighlightRevisionContext } from "./highlight-registry-context";
+import { getChipBoxInWrapperCoords, useChipMeasurement } from "./use-chip-measurement";
 
 export const kHighlightFormat = "highlight";
 export const kHighlightTextPluginName = "highlights";
@@ -67,23 +68,12 @@ export const HighlightComponent = ({ attributes, children, element }: RenderElem
   // Memoize getHighlightChipBoundingBox so it can be used in the dependency array
   const getHighlightChipBoundingBox = useCallback(() => {
     const el = chipRef.current;
-    if (!el) return;
-    const highlightRect = el.getBoundingClientRect();
-    const textBoxRect = el.closest('.primary-workspace .text-tool-wrapper')?.getBoundingClientRect();
-    if (highlightRect && textBoxRect && highlightRect.width > 0 && highlightRect.height > 0
-          && highlightRegistryContextFn) {
-      highlightRegistryContextFn(highlightId, {
-        left: highlightRect.left - textBoxRect.left,
-        top: highlightRect.top - textBoxRect.top,
-        width: highlightRect.width - kHighlightOffset,
-        height: highlightRect.height - kHighlightOffset
-      });
-    }
+    if (!el || !highlightRegistryContextFn) return;
+    const box = getChipBoxInWrapperCoords(el, kHighlightOffset);
+    if (box) highlightRegistryContextFn(highlightId, box);
   }, [highlightId, highlightRegistryContextFn]);
 
-  useEffect(() => {
-    getHighlightChipBoundingBox();
-  }, [editorRevisionContext, getHighlightChipBoundingBox]);
+  useChipMeasurement(chipRef, getHighlightChipBoundingBox, editorRevisionContext);
 
   if (!isHighlightElement(element)) return null;
 

--- a/src/plugins/text/highlights-plugin.tsx
+++ b/src/plugins/text/highlights-plugin.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useRef } from "react";
+import React, { useCallback, useContext, useState } from "react";
 import classNames from "classnames/dedupe";
 import { BaseElement, CustomEditor, CustomElement, Editor, kSlateVoidClass, registerElementComponent,
   RenderElementProps, useSelected } from "@concord-consortium/slate-editor";
@@ -58,7 +58,9 @@ export const HighlightComponent = ({ attributes, children, element }: RenderElem
   const highlightPlugin = plugins[kHighlightTextPluginName] as HighlightsPlugin|undefined;
   const isSelected = useSelected();
   const highlightRegistryContextFn = useContext(HighlightRegistryContext);
-  const chipRef = useRef<HTMLSpanElement>(null);
+  // useState + callback ref so the effect in useChipMeasurement re-runs when the chip
+  // element actually appears (a useRef wouldn't, since the ref object is stable).
+  const [chipEl, setChipEl] = useState<HTMLSpanElement | null>(null);
   const editorRevisionContext = useContext(HighlightRevisionContext);
 
   const { highlightId } = element as HighlightElement;
@@ -67,13 +69,12 @@ export const HighlightComponent = ({ attributes, children, element }: RenderElem
 
   // Memoize getHighlightChipBoundingBox so it can be used in the dependency array
   const getHighlightChipBoundingBox = useCallback(() => {
-    const el = chipRef.current;
-    if (!el || !highlightRegistryContextFn) return;
-    const box = getChipBoxInWrapperCoords(el, kHighlightOffset);
+    if (!chipEl || !highlightRegistryContextFn) return;
+    const box = getChipBoxInWrapperCoords(chipEl, kHighlightOffset);
     if (box) highlightRegistryContextFn(highlightId, box);
-  }, [highlightId, highlightRegistryContextFn]);
+  }, [chipEl, highlightId, highlightRegistryContextFn]);
 
-  useChipMeasurement(chipRef, getHighlightChipBoundingBox, editorRevisionContext);
+  useChipMeasurement(chipEl, getHighlightChipBoundingBox, editorRevisionContext);
 
   if (!isHighlightElement(element)) return null;
 
@@ -81,7 +82,7 @@ export const HighlightComponent = ({ attributes, children, element }: RenderElem
 
   return (
     <span className={classes} {...attributes} contentEditable={false}>
-      <span ref={chipRef} className={classNames("highlight-chip", {"slate-selected": highlightEntry && isSelected})} >
+      <span ref={setChipEl} className={classNames("highlight-chip", {"slate-selected": highlightEntry && isSelected})} >
         {children}
         {textToHighlight}
       </span>

--- a/src/plugins/text/use-chip-measurement.ts
+++ b/src/plugins/text/use-chip-measurement.ts
@@ -1,0 +1,73 @@
+import { RefObject, useEffect } from "react";
+import { IHighlightBox } from "./highlight-registry-context";
+
+const kMaxRafAttempts = 120; // ~2 seconds at 60fps
+
+// Returns the chip's bbox in coordinates relative to its `.text-tool-wrapper`, in
+// layout (pre-transform) pixels — the coordinate system the annotation layer combines
+// with tile offsets. getBoundingClientRect returns viewport pixels, so we divide the
+// wrapper-relative delta by the wrapper's effective CSS scale to get layout coords.
+// Returns undefined if the chip or wrapper hasn't been laid out.
+export function getChipBoxInWrapperCoords(
+  chipEl: HTMLElement,
+  shrinkBy: number
+): IHighlightBox | undefined {
+  const wrapperEl = chipEl.closest(".text-tool-wrapper") as HTMLElement | null;
+  if (!wrapperEl || !wrapperEl.offsetWidth) return undefined;
+  const chipRect = chipEl.getBoundingClientRect();
+  if (chipRect.width <= 0 || chipRect.height <= 0) return undefined;
+  const wrapperRect = wrapperEl.getBoundingClientRect();
+  const scale = wrapperRect.width / wrapperEl.offsetWidth;
+  return {
+    left: (chipRect.left - wrapperRect.left) / scale,
+    top: (chipRect.top - wrapperRect.top) / scale,
+    width: (chipRect.width - shrinkBy) / scale,
+    height: (chipRect.height - shrinkBy) / scale
+  };
+}
+
+// Wires up chip-measurement: initial measure, rAF retry until the chip has non-zero
+// dimensions (covers remounts into containers whose layout settles after first paint,
+// like 4-up cells and scaled thumbnails), and a ResizeObserver on the chip and its
+// `.text-tool-wrapper` ancestor (the wrapper catches container-driven reflows that
+// don't resize the chip's own inline box).
+//
+// `measure` is the caller's bbox-publishing callback; it's responsible for its own
+// zero-size guard. `trigger` is an optional extra dependency that forces a re-run when
+// its value changes (used by highlights to re-measure on Slate revision changes).
+export function useChipMeasurement(
+  chipRef: RefObject<HTMLElement | null>,
+  measure: () => void,
+  trigger?: unknown
+) {
+  useEffect(() => {
+    const el = chipRef.current;
+    if (!el) return;
+    const wrapperEl = el.closest('.text-tool-wrapper');
+
+    measure();
+
+    let rafId = 0;
+    let attempts = 0;
+    const retryIfZero = () => {
+      const rect = el.getBoundingClientRect();
+      if (rect.width > 0 && rect.height > 0) return;
+      attempts++;
+      if (attempts >= kMaxRafAttempts) return;
+      rafId = requestAnimationFrame(() => {
+        measure();
+        retryIfZero();
+      });
+    };
+    retryIfZero();
+
+    const resizeObs = new ResizeObserver(measure);
+    resizeObs.observe(el);
+    if (wrapperEl) resizeObs.observe(wrapperEl);
+
+    return () => {
+      if (rafId) cancelAnimationFrame(rafId);
+      resizeObs.disconnect();
+    };
+  }, [chipRef, measure, trigger]);
+}

--- a/src/plugins/text/use-chip-measurement.ts
+++ b/src/plugins/text/use-chip-measurement.ts
@@ -1,13 +1,19 @@
-import { RefObject, useEffect } from "react";
+import { useEffect } from "react";
 import { IHighlightBox } from "./highlight-registry-context";
 
 const kMaxRafAttempts = 120; // ~2 seconds at 60fps
 
-// Returns the chip's bbox in coordinates relative to its `.text-tool-wrapper`, in
-// layout (pre-transform) pixels — the coordinate system the annotation layer combines
-// with tile offsets. getBoundingClientRect returns viewport pixels, so we divide the
-// wrapper-relative delta by the wrapper's effective CSS scale to get layout coords.
-// Returns undefined if the chip or wrapper hasn't been laid out.
+/**
+ * Returns the chip's bbox in coordinates relative to its `.text-tool-wrapper`, in
+ * layout (pre-transform) pixels — the coordinate system the annotation layer combines
+ * with tile offsets. `getBoundingClientRect` returns viewport pixels, so we divide the
+ * wrapper-relative delta by the wrapper's effective CSS scale to get layout coords.
+ *
+ * @param chipEl - The chip's DOM element.
+ * @param shrinkBy - Pixels to subtract from width/height (a small visual inset so the
+ *                   sparrow doesn't touch the chip's edge directly).
+ * @returns The bbox, or `undefined` if the chip or wrapper hasn't been laid out.
+ */
 export function getChipBoxInWrapperCoords(
   chipEl: HTMLElement,
   shrinkBy: number
@@ -18,39 +24,48 @@ export function getChipBoxInWrapperCoords(
   if (chipRect.width <= 0 || chipRect.height <= 0) return undefined;
   const wrapperRect = wrapperEl.getBoundingClientRect();
   const scale = wrapperRect.width / wrapperEl.offsetWidth;
+  if (!Number.isFinite(scale) || scale <= 0) return undefined;
   return {
     left: (chipRect.left - wrapperRect.left) / scale,
     top: (chipRect.top - wrapperRect.top) / scale,
-    width: (chipRect.width - shrinkBy) / scale,
-    height: (chipRect.height - shrinkBy) / scale
+    width: Math.max(0, chipRect.width - shrinkBy) / scale,
+    height: Math.max(0, chipRect.height - shrinkBy) / scale
   };
 }
 
-// Wires up chip-measurement: initial measure, rAF retry until the chip has non-zero
-// dimensions (covers remounts into containers whose layout settles after first paint,
-// like 4-up cells and scaled thumbnails), and a ResizeObserver on the chip and its
-// `.text-tool-wrapper` ancestor (the wrapper catches container-driven reflows that
-// don't resize the chip's own inline box).
-//
-// `measure` is the caller's bbox-publishing callback; it's responsible for its own
-// zero-size guard. `trigger` is an optional extra dependency that forces a re-run when
-// its value changes (used by highlights to re-measure on Slate revision changes).
+/**
+ * Wires up chip-measurement: initial measure, rAF retry until the chip has non-zero
+ * dimensions (covers remounts into containers whose layout settles after first paint,
+ * like 4-up cells and scaled thumbnails), and a `ResizeObserver` on the chip and its
+ * `.text-tool-wrapper` ancestor (the wrapper catches container-driven reflows that
+ * don't resize the chip's own inline box).
+ *
+ * Takes the chip element directly rather than a ref so the effect re-runs when the
+ * element appears or changes — refs are stable across renders even when `.current`
+ * updates, so a conditionally-rendered chip wouldn't otherwise be measured. Callers
+ * drive this with a `useState` + callback ref pattern.
+ *
+ * @param chipEl - The chip's DOM element, or `null` while it isn't mounted.
+ * @param measure - Caller's bbox-publishing callback; responsible for its own zero-
+ *                  size guard.
+ * @param trigger - Optional extra dependency that forces a re-run when its value
+ *                  changes (used by highlights to re-measure on Slate revision changes).
+ */
 export function useChipMeasurement(
-  chipRef: RefObject<HTMLElement | null>,
+  chipEl: HTMLElement | null,
   measure: () => void,
   trigger?: unknown
 ) {
   useEffect(() => {
-    const el = chipRef.current;
-    if (!el) return;
-    const wrapperEl = el.closest('.text-tool-wrapper');
+    if (!chipEl) return;
+    const wrapperEl = chipEl.closest('.text-tool-wrapper');
 
     measure();
 
     let rafId = 0;
     let attempts = 0;
     const retryIfZero = () => {
-      const rect = el.getBoundingClientRect();
+      const rect = chipEl.getBoundingClientRect();
       if (rect.width > 0 && rect.height > 0) return;
       attempts++;
       if (attempts >= kMaxRafAttempts) return;
@@ -62,12 +77,12 @@ export function useChipMeasurement(
     retryIfZero();
 
     const resizeObs = new ResizeObserver(measure);
-    resizeObs.observe(el);
+    resizeObs.observe(chipEl);
     if (wrapperEl) resizeObs.observe(wrapperEl);
 
     return () => {
       if (rafId) cancelAnimationFrame(rafId);
       resizeObs.disconnect();
     };
-  }, [chipRef, measure, trigger]);
+  }, [chipEl, measure, trigger]);
 }

--- a/src/public/demo/units/qa-variables/content.json
+++ b/src/public/demo/units/qa-variables/content.json
@@ -17,6 +17,7 @@
       }
     ],
     "placeholderText": "Enter notes here",
+    "annotations": "all",
     "defaultDocumentType": "personal",
     "defaultDocumentTitle": "Untitled",
     "documentLabels": {


### PR DESCRIPTION
[CLUE-238](https://concord-consortium.atlassian.net/browse/CLUE-238)

Replaces the CLUE-187 "bandaid" fix with a per-view bounding-box cache so sparrows attached to text-highlight chips render correctly in every view (primary, 2-up, 4-up cells, Resources/Lessons panel, `/editor/` read-only panels).

**Root cause:** the previous code stored the chip bbox cache on the shared MST model, with a `.primary-workspace`-hardcoded `closest()` selector that prevented chips in any other view from measuring themselves. Every non-primary view ended up reading whichever coordinates the main workspace had last written.

**Architecture:** per @scytacki's recommendation, the chip bbox cache now lives on per-view instances (the `TextToolComponent` for highlights; the per-view `VariablesPlugin` instance for variable chips), not on the MST model. MobX reactivity is preserved via Boris's geometry-tile bump-counter pattern. Each rendered view of a document constructs its own cache and populates it by measuring its own DOM.

All variable-chip-specific state and slate-change handling lives in the variables plugin (`src/plugins/shared-variables/`) rather than the text tile. `text-tile.tsx` delegates chip-type-specific logic to plugins through new optional hooks on `ITextPlugin` (`getObjectBoundingBox`, `getObjectDefaultOffsets`, `handleSlateValueChange`, `initializeFromValue`, `setTileContext`) and a new `getAnnotatableObjects` hook on `ITextPluginInfo`. The highlight cache and highlight cleanup stay in the text tile — highlights are a built-in companion plugin and were already coupled to the tile on `master`.

**Additional changes that surfaced during the work:**

- **Scale compensation** in chip measurement: chip bboxes are now reported in layout (pre-transform) coords so they compose correctly with the tile offsets the annotation layer reads from `offsetLeft`/`offsetTop`. Without this, scaled views (4-up cells, thumbnails, the read-only-local panel at 0.5×) rendered intra-tile arrows compressed.
- **Annotation cleanup reconciliation:** new shared `removeAnnotationsForChip` utility used by both the unhighlight toolbar button and a new `handleChange`-driven detection that cascades sparrow cleanup when a chip is edited out (selectall + delete, etc.). Replaces the inline cleanup that previously lived only in the unhighlight path. For variable chips, the cleanup runs inside `VariablesPlugin.handleSlateValueChange`.
- **Variable chips as sparrow targets:** variable chips now work as sparrow targets in all views, not just the primary editable one. The variables plugin owns the per-view bbox cache; chips publish their bboxes directly to the plugin instance via `TextPluginsContext`.
- **Layout-settling robustness:** `useChipMeasurement` hook with rAF retry + `ResizeObserver` on chip and `.text-tool-wrapper` for container-driven reflows that Slate's revision context doesn't catch (notably 4-up cell mounts whose grid is sized via a debounced `ResizeObserver`).
- **Reactivity for variable-chip enumeration:** `annotatableObjects` walks the Slate tree for variable chips, which isn't observable. The variables plugin bumps an observable `variableChipsRevision` counter from its `handleSlateValueChange` hook, and contributes its chip enumeration via the new `getAnnotatableObjects` plugin-info hook so the view re-evaluates when chips are added or removed.
- **Skip link Cypress test split** Unrelated to this branch's work, but `skip_links_spec.js` kept crashing CI with the error "Chrome Renderer process just crashed". Split it into two smaller specs so each runs in its own browser process and memory resets before hitting the renderer's limit.


[CLUE-238]: https://concord-consortium.atlassian.net/browse/CLUE-238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ