### PR TITLE
CLUE-516 Clean up history system to make bugs easier to identify and reproduce

### DIFF
--- a/src/components/document/document-workspace.tsx
+++ b/src/components/document/document-workspace.tsx
@@ -1,3 +1,4 @@
+import { comparer, reaction, IReactionDisposer } from "mobx";
 import { inject, observer } from "mobx-react";
 import React from "react";
 import { BaseComponent, IBaseProps } from "../../components/base";
@@ -28,6 +29,7 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps> {
   private imageDragDrop: ImageDragDrop;
   private primaryDocument?: DocumentModelType;
   private primaryDocumentLoaded = false;
+  private groupChangeDisposer?: IReactionDisposer;
 
   constructor(props: IProps) {
     super(props);
@@ -40,6 +42,35 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps> {
 
   public componentDidMount() {
     this.guaranteeInitialDocuments();
+
+    // Watch the primary doc's group id alongside the user's current group
+    // id. When the user is in a group AND the primary is a group doc for a
+    // different group, fall back to the default doc. Skipping when
+    // currentGroupId is undefined avoids closing during bootstrap before
+    // the groups listener has set the user's group. Tracking both values
+    // also handles the stale-doc case where the persisted primary group
+    // doc loads before or after currentGroupId resolves on next session.
+    this.groupChangeDisposer = reaction(
+      () => {
+        const { persistentUI: { problemWorkspace }, user } = this.stores;
+        const primary = this.getPrimaryDocument(problemWorkspace.primaryDocumentKey);
+        return {
+          primaryDocGroupId: primary?.isGroup ? primary.groupId : undefined,
+          currentGroupId: user.currentGroupId,
+        };
+      },
+      ({ primaryDocGroupId, currentGroupId }) => {
+        if (!currentGroupId) return;
+        if (!primaryDocGroupId) return;
+        if (primaryDocGroupId === currentGroupId) return;
+        this.loadDefaultPrimaryDocument();
+      },
+      { equals: comparer.shallow }
+    );
+  }
+
+  public componentWillUnmount() {
+    this.groupChangeDisposer?.();
   }
 
   public componentDidUpdate(): void {
@@ -145,19 +176,24 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps> {
     return defaultContent;
   }
 
+  private async loadDefaultPrimaryDocument() {
+    const { db, persistentUI: { problemWorkspace }, sectionsLoadedPromise } = this.stores;
+    const { type, content } = this.getDefaultDocumentContentSpec();
+    await sectionsLoadedPromise;
+    const documentContent = this.getDefaultSectionedDocumentContent(type, content);
+    const defaultDocument = await db.guaranteeOpenDefaultDocument(type, documentContent);
+    if (defaultDocument) {
+      problemWorkspace.setPrimaryDocument(defaultDocument);
+    }
+  }
+
   private async guaranteeInitialDocuments() {
     const { appConfig: { defaultLearningLogDocument, defaultLearningLogTitle, initialLearningLogTitle,
               groupDocumentsEnabled },
-            db, persistentUI: { problemWorkspace }, sectionsLoadedPromise,
+            db, persistentUI: { problemWorkspace },
             unit: { planningDocument }, user: { type: role } } = this.stores;
     if (!problemWorkspace.primaryDocumentKey) {
-      const { type, content } = this.getDefaultDocumentContentSpec();
-      await sectionsLoadedPromise;
-      const documentContent = this.getDefaultSectionedDocumentContent(type, content);
-      const defaultDocument = await db.guaranteeOpenDefaultDocument(type, documentContent);
-      if (defaultDocument) {
-        problemWorkspace.setPrimaryDocument(defaultDocument);
-      }
+      await this.loadDefaultPrimaryDocument();
     } else if (groupDocumentsEnabled) {
       // If the primary document is a group document, make sure it is opened properly.
       // This is because group documents are not loaded automatically like other documents.
@@ -351,7 +387,8 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps> {
     .then((confirmDelete: boolean) => {
       if (confirmDelete) {
         document.setProperty("isDeleted", "true");
-        this.handleDeleteOpenPrimaryDocument();
+        // Replace the now-tombstoned primary with the default doc.
+        this.loadDefaultPrimaryDocument();
       }
     });
   };
@@ -369,15 +406,6 @@ export class DocumentWorkspaceComponent extends BaseComponent<IProps> {
         window.location.reload();
       }
     });
-  };
-
-  private handleDeleteOpenPrimaryDocument = async () => {
-    const { db, persistentUI: { problemWorkspace } } = this.stores;
-    const { type, content } = this.getDefaultDocumentContentSpec();
-    const defaultDocument = await db.guaranteeOpenDefaultDocument(type, content);
-    if (defaultDocument) {
-      problemWorkspace.setPrimaryDocument(defaultDocument);
-    }
   };
 
   private getPrimaryDocument(documentKey?: string) {

--- a/src/components/document/document.tsx
+++ b/src/components/document/document.tsx
@@ -319,8 +319,8 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
   }
 
   private renderGroupDocumentTitleBar(hideButtons?: boolean) {
-    const { user: { currentGroupId } } = this.stores;
-    const title = `Group ${currentGroupId} Document`;
+    const { document } = this.props;
+    const title = `Group ${document.groupId} Document`;
     return this.renderGenericTitleBar({
       title,
       hideButtons,

--- a/src/components/document/history-entry-item.scss
+++ b/src/components/document/history-entry-item.scss
@@ -22,6 +22,7 @@
     border-left-color: #d55e00; // vermillion
   }
 
+
   .history-entry-summary {
     display: flex;
     align-items: center;
@@ -73,13 +74,32 @@
     .history-entry-undoable {
       font-size: 12px;
       flex-shrink: 0;
+      padding: 0 4px;
+      border-radius: 3px;
 
       &.undoable {
         color: #4a9;
+
+        // The ↩ glyph sits high above its baseline; nudge the inner span
+        // down so it visually centers without moving the outer box.
+        .glyph {
+          display: inline-block;
+          transform: translateY(1px);
+        }
       }
 
       &.not-undoable {
         color: #bbb;
+      }
+
+      // Undo-stack decoration. on-undo-stack shades the icon when the entry
+      // is currently on the undo stack; is-undo-pointer is a more prominent
+      // highlight on the entry that the next undo would target.
+      &.on-undo-stack {
+        background: #e0e0e0;
+      }
+      &.is-undo-pointer {
+        background: #b8dcff;
       }
     }
 

--- a/src/components/document/history-entry-item.scss
+++ b/src/components/document/history-entry-item.scss
@@ -1,11 +1,25 @@
 .history-entry-item {
   border: 1px solid #e0e0e0;
+  border-left-width: 4px;
   border-radius: 4px;
   margin-bottom: 4px;
   background: white;
 
   &.expanded {
     border-color: #bbb;
+  }
+
+  // Source accent (Okabe-Ito colorblind-safe palette). Applied only in the
+  // local history section; in the remote section every entry is remote and
+  // a per-row accent would be noise.
+  &.source-local {
+    border-left-color: #009e73; // bluish green
+  }
+  &.source-remote {
+    border-left-color: #0072b2; // blue
+  }
+  &.source-revert {
+    border-left-color: #d55e00; // vermillion
   }
 
   .history-entry-summary {
@@ -57,9 +71,26 @@
     }
 
     .history-entry-undoable {
-      color: #4a9;
       font-size: 12px;
       flex-shrink: 0;
+
+      &.undoable {
+        color: #4a9;
+      }
+
+      &.not-undoable {
+        color: #bbb;
+      }
+    }
+
+    .history-entry-author {
+      color: #555;
+      font-size: 11px;
+      flex-shrink: 0;
+      max-width: 120px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
 
     .history-entry-time {
@@ -78,6 +109,19 @@
 
     > div {
       margin-bottom: 4px;
+    }
+
+    .history-entry-source-swatch {
+      display: inline-block;
+      width: 10px;
+      height: 10px;
+      margin-right: 4px;
+      border: 1px solid rgba(0, 0, 0, 0.15);
+      vertical-align: middle;
+
+      &.source-local { background: #009e73; }
+      &.source-remote { background: #0072b2; }
+      &.source-revert { background: #d55e00; }
     }
 
     .history-entry-record {

--- a/src/components/document/history-entry-item.tsx
+++ b/src/components/document/history-entry-item.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { observer } from "mobx-react";
 import { HistoryEntryType } from "../../models/history/history";
+import { useStores } from "../../hooks/use-stores";
 
 import "./history-entry-item.scss";
 
@@ -8,13 +9,23 @@ interface IHistoryEntryItemProps {
   entry: HistoryEntryType;
   index: number;
   previousEntryId?: string;
+  /**
+   * Which section of the history view this entry is being rendered in.
+   * Drives attribution: in the local section, an entry without a uid is
+   * by definition this user's (entries from other clients arrive via the
+   * remote listener, which stamps them with their uploader's uid). In the
+   * remote section, a missing uid indicates a legacy pre-feature entry.
+   */
+  section?: "local" | "remote";
 }
 
 export const HistoryEntryItem: React.FC<IHistoryEntryItemProps> = observer(({
   entry,
   index,
   previousEntryId,
+  section = "local",
 }) => {
+  const { class: classStore, user } = useStores();
   const [expanded, setExpanded] = useState(false);
 
   const toggleExpanded = () => setExpanded(!expanded);
@@ -30,8 +41,35 @@ export const HistoryEntryItem: React.FC<IHistoryEntryItemProps> = observer(({
 
   const patchCount = entry.records.reduce((total, record) => total + record.patches.length, 0);
 
+  const author = (() => {
+    if (entry.uid) {
+      const classUser = classStore.getUserById(entry.uid);
+      return {
+        initials: classUser?.initials ?? entry.uid,
+        fullName: classUser?.displayName,
+      };
+    }
+    // No uid on the entry.
+    if (section === "remote") return { initials: "?", fullName: undefined };
+    // Local section. Source distinguishes how the entry got here.
+    if (entry.source === "remote") {
+      // remote-applied but legacy entry without uid
+      return { initials: "?", fullName: undefined };
+    }
+    // "local" or "revert" — created on this client
+    return { initials: user.initials, fullName: user.name };
+  })();
+  const authorDetail = author.fullName
+    ? `${author.fullName} (${author.initials})`
+    : author.initials;
+
+  // Color the entry by its arrival source, but only in the local section —
+  // the remote section is uniformly "remote" by construction, so a per-entry
+  // accent there would just be noise.
+  const sourceClass = section === "local" ? `source-${entry.source}` : "";
+
   return (
-    <div className={`history-entry-item ${expanded ? "expanded" : ""}`}>
+    <div className={`history-entry-item ${sourceClass} ${expanded ? "expanded" : ""}`}>
       <button className="history-entry-summary" onClick={toggleExpanded}>
         <span className="history-entry-expand">
           {expanded ? "▼" : "▶"}
@@ -43,9 +81,13 @@ export const HistoryEntryItem: React.FC<IHistoryEntryItemProps> = observer(({
         <span className="history-entry-patches" title="Number of patches">
           {patchCount}p
         </span>
-        {entry.undoable && (
-          <span className="history-entry-undoable" title="Undoable">↩</span>
-        )}
+        <span
+          className={`history-entry-undoable ${entry.undoable ? "undoable" : "not-undoable"}`}
+          title={entry.undoable ? "Undoable" : "Not undoable"}
+        >
+          {entry.undoable ? "↩" : "✕"}
+        </span>
+        <span className="history-entry-author" title={author.fullName ?? "Author"}>{author.initials}</span>
         <span className="history-entry-time">{formatTimestamp(entry.created)}</span>
       </button>
       {expanded && (
@@ -53,6 +95,14 @@ export const HistoryEntryItem: React.FC<IHistoryEntryItemProps> = observer(({
           <div><strong>ID:</strong> {entry.id}</div>
           <div><strong>Model:</strong> {entry.model}</div>
           <div><strong>Action:</strong> {entry.action}</div>
+          <div><strong>Author:</strong> {authorDetail}{entry.uid ? ` — ${entry.uid}` : ""}</div>
+          {section === "local" && (
+            <div>
+              <strong>Source:</strong>{" "}
+              <span className={`history-entry-source-swatch source-${entry.source}`} />
+              {entry.source}
+            </div>
+          )}
           <div><strong>Previous Entry ID:</strong> {previousEntryId}</div>
           {entry.isRevert && (
             <>

--- a/src/components/document/history-entry-item.tsx
+++ b/src/components/document/history-entry-item.tsx
@@ -95,7 +95,10 @@ export const HistoryEntryItem: React.FC<IHistoryEntryItemProps> = observer(({
           <div><strong>ID:</strong> {entry.id}</div>
           <div><strong>Model:</strong> {entry.model}</div>
           <div><strong>Action:</strong> {entry.action}</div>
-          <div><strong>Author:</strong> {authorDetail}{entry.uid ? ` — ${entry.uid}` : ""}</div>
+          <div>
+            <strong>Author:</strong> {authorDetail}
+            {entry.uid && authorDetail !== entry.uid ? ` — ${entry.uid}` : ""}
+          </div>
           {section === "local" && (
             <div>
               <strong>Source:</strong>{" "}

--- a/src/components/document/history-entry-item.tsx
+++ b/src/components/document/history-entry-item.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from "react";
 import { observer } from "mobx-react";
+import { Instance } from "mobx-state-tree";
 import { HistoryEntryType } from "../../models/history/history";
+import { UndoStore } from "../../models/history/undo-store";
 import { useStores } from "../../hooks/use-stores";
 
 import "./history-entry-item.scss";
@@ -17,6 +19,12 @@ interface IHistoryEntryItemProps {
    * remote section, a missing uid indicates a legacy pre-feature entry.
    */
   section?: "local" | "remote";
+  /**
+   * UndoStore for the document, passed only in the local section. Used to
+   * decorate entries that are currently on the undo stack and to highlight
+   * the entry that the undo pointer is at.
+   */
+  undoStore?: Instance<typeof UndoStore>;
 }
 
 export const HistoryEntryItem: React.FC<IHistoryEntryItemProps> = observer(({
@@ -24,6 +32,7 @@ export const HistoryEntryItem: React.FC<IHistoryEntryItemProps> = observer(({
   index,
   previousEntryId,
   section = "local",
+  undoStore,
 }) => {
   const { class: classStore, user } = useStores();
   const [expanded, setExpanded] = useState(false);
@@ -68,6 +77,24 @@ export const HistoryEntryItem: React.FC<IHistoryEntryItemProps> = observer(({
   // accent there would just be noise.
   const sourceClass = section === "local" ? `source-${entry.source}` : "";
 
+  // Undo-stack decoration. undoStore is passed only in the local section.
+  // Entries currently on the stack get a shaded background; the entry the
+  // undo pointer would undo next gets a more prominent highlight.
+  const onUndoStack = undoStore?.findHistoryEntry(entry.id) !== undefined;
+  const isUndoPointer = undoStore?.undoEntry?.id === entry.id;
+  const undoStackClass = isUndoPointer
+    ? "is-undo-pointer"
+    : onUndoStack
+      ? "on-undo-stack"
+      : "";
+  const undoableTitle = !entry.undoable
+    ? "Not undoable"
+    : isUndoPointer
+      ? "Undoable — next undo target"
+      : onUndoStack
+        ? "Undoable — on undo stack"
+        : "Undoable";
+
   return (
     <div className={`history-entry-item ${sourceClass} ${expanded ? "expanded" : ""}`}>
       <button className="history-entry-summary" onClick={toggleExpanded}>
@@ -82,10 +109,12 @@ export const HistoryEntryItem: React.FC<IHistoryEntryItemProps> = observer(({
           {patchCount}p
         </span>
         <span
-          className={`history-entry-undoable ${entry.undoable ? "undoable" : "not-undoable"}`}
-          title={entry.undoable ? "Undoable" : "Not undoable"}
+          className={
+            `history-entry-undoable ${entry.undoable ? "undoable" : "not-undoable"} ${undoStackClass}`
+          }
+          title={undoableTitle}
         >
-          {entry.undoable ? "↩" : "✕"}
+          <span className="glyph">{entry.undoable ? "↩" : "✕"}</span>
         </span>
         <span className="history-entry-author" title={author.fullName ?? "Author"}>{author.initials}</span>
         <span className="history-entry-time">{formatTimestamp(entry.created)}</span>

--- a/src/components/document/history-view-panel.scss
+++ b/src/components/document/history-view-panel.scss
@@ -93,6 +93,12 @@
             border-color: #ffc107;
           }
         }
+
+        .history-manager-status {
+          font-size: 11px;
+          color: #555;
+          align-self: center;
+        }
       }
     }
 

--- a/src/components/document/history-view-panel.tsx
+++ b/src/components/document/history-view-panel.tsx
@@ -139,19 +139,22 @@ export const HistoryViewPanel: React.FC<IHistoryViewPanelProps> = observer(funct
             <span className="history-view-count">{remoteHistoryEntries.length} entries</span>
             {concurrentManager && (
               <div className="history-manager-controls">
-                <button
-                  className={concurrentManager.paused ? "paused" : ""}
-                  onClick={() => concurrentManager.pauseUploads()}
-                  disabled={concurrentManager.paused}
-                >
-                  {concurrentManager.paused ? "Paused" : "Pause Uploads"}
-                </button>
-                <button
-                  onClick={() => concurrentManager.resumeUploadsAfterDelay(5000)}
-                  disabled={!concurrentManager.paused}
-                >
-                  Resume After 5s
-                </button>
+                {concurrentManager.resumeCountdownSeconds !== null ? (
+                  <>
+                    <button disabled>Pause Uploads</button>
+                    <span className="history-manager-status">
+                      Resuming in {concurrentManager.resumeCountdownSeconds}s…
+                    </span>
+                  </>
+                ) : concurrentManager.paused ? (
+                  <button onClick={() => concurrentManager.resumeUploadsAfterDelay(5000)}>
+                    Resume After 5s
+                  </button>
+                ) : (
+                  <button onClick={() => concurrentManager.pauseUploads()}>
+                    Pause Uploads
+                  </button>
+                )}
                 <button
                   className={concurrentManager.pausedDownloads ? "paused" : ""}
                   onClick={() => concurrentManager.pausedDownloads

--- a/src/components/document/history-view-panel.tsx
+++ b/src/components/document/history-view-panel.tsx
@@ -113,7 +113,7 @@ export const HistoryViewPanel: React.FC<IHistoryViewPanelProps> = observer(funct
             <div className="history-view-empty">No local history entries</div>
           ) : (
             localHistoryEntries.map((entry, index) => (
-              <HistoryEntryItem key={entry.id} entry={entry} index={index} />
+              <HistoryEntryItem key={entry.id} entry={entry} index={index} section="local" />
             ))
           )}
         </div>
@@ -178,6 +178,7 @@ export const HistoryViewPanel: React.FC<IHistoryViewPanelProps> = observer(funct
                   entry={entryWithMeta.entry}
                   index={entryWithMeta.index}
                   previousEntryId={entryWithMeta.previousEntryId}
+                  section="remote"
                 />
               ))
             )}

--- a/src/components/document/history-view-panel.tsx
+++ b/src/components/document/history-view-panel.tsx
@@ -113,7 +113,13 @@ export const HistoryViewPanel: React.FC<IHistoryViewPanelProps> = observer(funct
             <div className="history-view-empty">No local history entries</div>
           ) : (
             localHistoryEntries.map((entry, index) => (
-              <HistoryEntryItem key={entry.id} entry={entry} index={index} section="local" />
+              <HistoryEntryItem
+                key={entry.id}
+                entry={entry}
+                index={index}
+                section="local"
+                undoStore={treeManager?.undoStore}
+              />
             ))
           )}
         </div>

--- a/src/hooks/use-document-sync-to-firebase.ts
+++ b/src/hooks/use-document-sync-to-firebase.ts
@@ -17,6 +17,7 @@ import { ITileMapEntry } from "../../shared/shared";
 import { DocumentContentSnapshotType } from "src/models/document/document-content";
 import { IArrowAnnotation } from "src/models/annotations/arrow-annotation";
 import { TreeManagerType } from "../models/history/tree-manager";
+import { isOwnGroupDocument } from "../models/document/document-utils";
 
 function debugLog(...args: any[]) {
   // eslint-disable-next-line no-console
@@ -58,7 +59,11 @@ export function useDocumentSyncToFirebase(
   // The current hacky approach is to use a window level property to disable the firebase syncing
   const disableFirebaseSync = (window as any).DISABLE_FIREBASE_SYNC;
 
-  !disableFirebaseSync && !readOnly && (user.id !== uid) &&
+  // Group documents have a synthetic uid (`group_<offering>_<group>`) rather
+  // than any real user's id, so `user.id !== uid` is always true for them.
+  // Suppress the warning when the user belongs to the group; if not, fall
+  // through so the warning still fires for the genuine anomaly.
+  !disableFirebaseSync && !readOnly && !isOwnGroupDocument(document, user) && (user.id !== uid) &&
     console.warn("useDocumentSyncToFirebase monitoring another user's document?!?");
 
   const commonSyncEnabled = !disableFirebaseSync && contentStatus === ContentStatus.Valid;

--- a/src/hooks/use-document-sync-to-firebase.ts
+++ b/src/hooks/use-document-sync-to-firebase.ts
@@ -17,7 +17,6 @@ import { ITileMapEntry } from "../../shared/shared";
 import { DocumentContentSnapshotType } from "src/models/document/document-content";
 import { IArrowAnnotation } from "src/models/annotations/arrow-annotation";
 import { TreeManagerType } from "../models/history/tree-manager";
-import { isOwnGroupDocument } from "../models/document/document-utils";
 
 function debugLog(...args: any[]) {
   // eslint-disable-next-line no-console
@@ -59,11 +58,12 @@ export function useDocumentSyncToFirebase(
   // The current hacky approach is to use a window level property to disable the firebase syncing
   const disableFirebaseSync = (window as any).DISABLE_FIREBASE_SYNC;
 
-  // Group documents have a synthetic uid (`group_<offering>_<group>`) rather
-  // than any real user's id, so `user.id !== uid` is always true for them.
-  // Suppress the warning when the user belongs to the group; if not, fall
-  // through so the warning still fires for the genuine anomaly.
-  !disableFirebaseSync && !readOnly && !isOwnGroupDocument(document, user) && (user.id !== uid) &&
+  // The warning's concern is writing to another user's user-namespaced path.
+  // Group documents are exempt: they have a synthetic uid (`group_<offering>_<group>`),
+  // not a user id, so any real user satisfies `user.id !== uid`. Wrong-group anomalies
+  // are caught separately by the workspace's group-change reaction, which closes such
+  // docs rather than just logging.
+  !disableFirebaseSync && !readOnly && !document.isGroup && (user.id !== uid) &&
     console.warn("useDocumentSyncToFirebase monitoring another user's document?!?");
 
   const commonSyncEnabled = !disableFirebaseSync && contentStatus === ContentStatus.Valid;

--- a/src/models/document/document-utils.ts
+++ b/src/models/document/document-utils.ts
@@ -90,15 +90,27 @@ export function getDocumentIdentifier(document?: DocumentContentModelType) {
   }
 }
 
-// TODO: handle the visibility of group documents. The request in upcoming work is for group documents
-// to be visible to everyone in the class by default. So either we just say anything that is a group
-// document is visible to everyone in the class. Or we set the visibility property on group documents
-// to "public" when they are created.
-export const isDocumentAccessibleToUser = (
+/**
+ * True when `doc` is a group document and `user` is currently in that group.
+ * Group documents use a synthetic uid (`group_<offering>_<group>`) rather than
+ * any real user's id, so `doc.uid === user.id` never holds for them; group
+ * membership is the right authorization check.
+ */
+export function isOwnGroupDocument(
+  doc: Pick<IDocumentMetadataBase, "type" | "groupId">,
+  user: UserModelType
+): boolean {
+  return doc.type === GroupDocument && !!doc.groupId && user.currentGroupId === doc.groupId;
+}
+
+// TODO: handle the visibility of group documents — see CLUE-380 ("Group documents autoshared").
+// Group docs should be visible to everyone in the class by default. Either treat any group document
+// as class-visible here, or set visibility to "public" when group docs are created.
+export function isDocumentAccessibleToUser(
   doc: IDocumentMetadataBase, user: UserModelType, documentStore: IExemplarVisibilityProvider
-) => {
+): boolean {
   const ownDocument = doc.uid === user.id;
-  const ownGroupDocument = doc.type === GroupDocument && doc.groupId && user.currentGroupId === doc.groupId;
+  const ownGroupDocument = isOwnGroupDocument(doc, user);
   const isShared = doc.visibility === "public";
   const isPublished = isPublishedType(doc.type);
   if (user.isTeacherOrResearcher) return true;
@@ -107,4 +119,4 @@ export const isDocumentAccessibleToUser = (
            || (isExemplarType(doc.type) && documentStore.isExemplarVisible(doc.key));
   }
   return false;
-};
+}

--- a/src/models/history/firestore-history-manager-concurrent.test.ts
+++ b/src/models/history/firestore-history-manager-concurrent.test.ts
@@ -952,4 +952,82 @@ describe("FirestoreHistoryManagerConcurrent", () => {
       expect(tree.items[0].color).toBe("green");
     });
   });
+
+  describe("uploadQueuedHistoryEntries — uid stamping", () => {
+    it("stamps the uploading user's uid into each entry's serialized snapshot", async () => {
+      const { manager, historyManager, firestoreCapture } = await setupManager();
+
+      const entrySnapshot = makeEntrySnapshot(
+        "L1",
+        "main",
+        [{ op: "replace", path: "/items/0/color", value: "red" }],
+        [{ op: "replace", path: "/items/0/color", value: "white" }],
+      );
+      const entry = HistoryEntry.create(entrySnapshot);
+      manager.addHistoryEntryAfterApplying(entry);
+      historyManager.completedHistoryEntryQueue.push(entry);
+      historyManager.environmentAndMetadataDocReadyPromise = Promise.resolve();
+
+      await historyManager.uploadQueuedHistoryEntries();
+
+      expect(firestoreCapture.transactionSetCalls).toHaveLength(1);
+      const writtenEntry = JSON.parse(firestoreCapture.transactionSetCalls[0].data.entry);
+      expect(writtenEntry.uid).toBe("test-user");
+      expect(writtenEntry.id).toBe("L1");
+    });
+  });
+
+  describe("resumeUploadsAfterDelay — countdown", () => {
+    beforeEach(() => jest.useFakeTimers());
+    afterEach(() => jest.useRealTimers());
+
+    it("ticks the countdown once per second and resumes when it reaches zero", async () => {
+      const { historyManager } = await setupManager();
+      // Clear the orphan 5s metadata-doc fallback timer scheduled in
+      // FirestoreHistoryManager.waitForMetadataDocument; the synchronous
+      // onSnapshot mock resolves the wait but doesn't clear the timer.
+      jest.clearAllTimers();
+
+      historyManager.pauseUploads();
+      expect(historyManager.paused).toBe(true);
+      expect(historyManager.resumeCountdownSeconds).toBe(null);
+
+      historyManager.resumeUploadsAfterDelay(5000);
+      expect(historyManager.resumeCountdownSeconds).toBe(5);
+      expect(historyManager.paused).toBe(true);
+
+      jest.advanceTimersByTime(1000);
+      expect(historyManager.resumeCountdownSeconds).toBe(4);
+      expect(historyManager.paused).toBe(true);
+
+      jest.advanceTimersByTime(2000);
+      expect(historyManager.resumeCountdownSeconds).toBe(2);
+      expect(historyManager.paused).toBe(true);
+
+      jest.advanceTimersByTime(2000);
+      expect(historyManager.resumeCountdownSeconds).toBe(null);
+      expect(historyManager.paused).toBe(false);
+
+      // No further ticks scheduled — countdown is one-shot.
+      const sentinelBefore = historyManager.resumeCountdownSeconds;
+      jest.advanceTimersByTime(5000);
+      expect(historyManager.resumeCountdownSeconds).toBe(sentinelBefore);
+    });
+
+    it("ignores re-entrant calls while a countdown is in progress", async () => {
+      const { historyManager } = await setupManager();
+      jest.clearAllTimers();
+
+      historyManager.pauseUploads();
+      historyManager.resumeUploadsAfterDelay(5000);
+      expect(historyManager.resumeCountdownSeconds).toBe(5);
+
+      jest.advanceTimersByTime(1000);
+      expect(historyManager.resumeCountdownSeconds).toBe(4);
+
+      // Re-call mid-countdown — should be a no-op, not restart the timer.
+      historyManager.resumeUploadsAfterDelay(10000);
+      expect(historyManager.resumeCountdownSeconds).toBe(4);
+    });
+  });
 });

--- a/src/models/history/firestore-history-manager-concurrent.ts
+++ b/src/models/history/firestore-history-manager-concurrent.ts
@@ -332,11 +332,17 @@ export class FirestoreHistoryManagerConcurrent extends FirestoreHistoryManager {
           // The plan is to just use this for new group documents, so if there is some lost history
           // for existing group documents that is OK.
 
+          // Stamp the uploading client's uid into each entry so other
+          // clients can attribute remote entries to their author. We don't
+          // mutate the in-memory entry — the local copy stays uid-less,
+          // which the history view treats as "this client's entry."
+          const uploaderUid = this.userContextProvider?.userContext?.uid;
+
           entriesToUpload.forEach(entry => {
             const newEntryIndex = lastEntryIndex + 1;
 
             const docRef = firestore.documentRef(historyEntriesPath, entry.id);
-            const snapshot = getSnapshot(entry);
+            const snapshot = { ...getSnapshot(entry), uid: uploaderUid };
 
             transaction.set(docRef, {
               index: newEntryIndex,
@@ -445,6 +451,7 @@ export class FirestoreHistoryManagerConcurrent extends FirestoreHistoryManager {
     for (const original of originalsNewestFirst) {
       const revertSnapshot = buildRevertEntrySnapshot(getSnapshot(original), triggeringBatchIds);
       const revertEntry = HistoryEntry.create(revertSnapshot);
+      revertEntry.setSource("revert");
       treeManager.addHistoryEntryAfterApplying(revertEntry);
     }
 
@@ -556,7 +563,11 @@ export class FirestoreHistoryManagerConcurrent extends FirestoreHistoryManager {
     const treePatches: Record<string, IJsonPatch[] | undefined> = {};
     Object.keys(treeManager.trees).forEach(treeId => treePatches[treeId] = []);
 
-    const entries: HistoryEntryType[] = entrySnapshots.map(snapshot => HistoryEntry.create(snapshot));
+    const entries: HistoryEntryType[] = entrySnapshots.map(snapshot => {
+      const entry = HistoryEntry.create(snapshot);
+      entry.setSource("remote");
+      return entry;
+    });
 
     for (const historyEntry of entries) {
       const records = historyEntry ? [ ...historyEntry.records] : [];

--- a/src/models/history/firestore-history-manager-concurrent.ts
+++ b/src/models/history/firestore-history-manager-concurrent.ts
@@ -48,6 +48,13 @@ export class FirestoreHistoryManagerConcurrent extends FirestoreHistoryManager {
   paused = false;
 
   /**
+   * Seconds remaining on the active resume-after-delay countdown, or
+   * null when no resume is pending. Drives the history-view button's
+   * "Resuming in Ns…" feedback while paused waits for the timer to fire.
+   */
+  resumeCountdownSeconds: number | null = null;
+
+  /**
    * Stop processing remote history entries delivered by the Firestore
    * listener. Only used manually from the history-view panel to set up
    * fork scenarios deterministically — specifically, to drive the
@@ -99,6 +106,7 @@ export class FirestoreHistoryManagerConcurrent extends FirestoreHistoryManager {
     makeObservable<this, "setExpectedRemoteHead">(this, {
       paused: observable,
       pausedDownloads: observable,
+      resumeCountdownSeconds: observable,
       expectedRemoteHead: observable,
       pauseUploads: action,
       resumeUploadsAfterDelay: action,
@@ -131,12 +139,25 @@ export class FirestoreHistoryManagerConcurrent extends FirestoreHistoryManager {
   }
 
   resumeUploadsAfterDelay(delayMs: number) {
-    setTimeout(() => {
+    // Ignore re-entry while a countdown is already running.
+    if (this.resumeCountdownSeconds !== null) return;
+
+    this.resumeCountdownSeconds = Math.max(1, Math.ceil(delayMs / 1000));
+
+    const tick = () => {
       runInAction(() => {
-        this.paused = false;
+        const remaining = (this.resumeCountdownSeconds ?? 0) - 1;
+        if (remaining > 0) {
+          this.resumeCountdownSeconds = remaining;
+          setTimeout(tick, 1000);
+        } else {
+          this.resumeCountdownSeconds = null;
+          this.paused = false;
+          this.uploadQueuedHistoryEntries();
+        }
       });
-      this.uploadQueuedHistoryEntries();
-    }, delayMs);
+    };
+    setTimeout(tick, 1000);
   }
 
   pauseDownloads() {

--- a/src/models/history/history.ts
+++ b/src/models/history/history.ts
@@ -28,6 +28,8 @@ export interface ICreateHistoryEntry {
   undoable: boolean;
 }
 
+export type HistoryEntrySource = "local" | "remote" | "revert";
+
 export const HistoryEntry = types.model("HistoryEntry", {
   id: types.identifier,
   tree: types.maybe(types.string),
@@ -46,14 +48,37 @@ export const HistoryEntry = types.model("HistoryEntry", {
   // entries, populated with the incoming batch's entry ids on reverts.
   isRevert: types.maybe(types.boolean),
   revertsEntryId: types.maybe(types.string),
-  triggeringBatchIds: types.array(types.string)
+  triggeringBatchIds: types.array(types.string),
+  /**
+   * Id of the user who originally generated this entry. Stamped into the
+   * Firestore snapshot at upload time, so locally-created entries lack uid
+   * until they round-trip via the remote listener (which we skip for our
+   * own entries — see existingIds filter in applyHistoryEntries). In
+   * practice: present on entries received from other clients, absent on
+   * entries created by this client and on legacy pre-feature entries.
+   */
+  uid: types.maybe(types.string),
 })
 .volatile(self => ({
   // The value of the map should be the name of the exchange. This is useful
   // for debugging an activeExchange that hasn't been ended.
   // The {name: "activeExchanges"} is a feature of MobX that can also
   // help with debugging.
-  activeExchanges: observable.map<string, string>({}, {name: "activeExchanges"})
+  activeExchanges: observable.map<string, string>({}, {name: "activeExchanges"}),
+  /**
+   * How this entry got into this process's local document.history. Default
+   * "local" covers entries created via the action middleware. Overridden to
+   * "remote" for entries applied from the Firestore listener and to
+   * "revert" for system-generated revert entries from rollbackLocalEntries.
+   * Volatile because it describes the local arrival path, not the entry
+   * itself, so it must not round-trip through Firestore.
+   */
+  source: "local" as HistoryEntrySource,
+}))
+.actions(self => ({
+  setSource(source: HistoryEntrySource) {
+    self.source = source;
+  }
 }))
 .views(self => ({
   get modelActionKey() {


### PR DESCRIPTION
CLUE-516

## Summary

Catch-all cleanup pass on the history system, geared toward making bugs easier to identify and reproduce.

- **Resume After 5s feedback** — replaces the always-visible Pause/Resume button pair with a single state-driven button plus an adjacent text-only countdown. Click on the resume button now produces visible feedback while the timer runs.
- **Group-doc warning suppression** — the `useDocumentSyncToFirebase monitoring another user's document?!?` warning no longer fires for group docs. Group docs use a synthetic uid (`group_<offering>_<group>`), not a user id, so the warning's premise (writing to another user's user-namespaced path) doesn't apply. The genuine wrong-group anomaly is handled separately by the workspace reaction below. Also extracts `isOwnGroupDocument` as a shared helper between this site and `isDocumentAccessibleToUser`.
- **Group-change handling** — title bar of a group doc now reads the doc's own `groupId` instead of `user.currentGroupId`, so a stale doc no longer relabels itself when the user switches groups. Adds a workspace reaction that watches both the primary doc's groupId and `user.currentGroupId`; when the user is in a group AND the primary is a group doc for a different group, falls back to the default doc. Covers live group changes and the stale-on-reopen case where a saved primary key for a foreign group's doc gets restored across sessions. Refactors to share the load-default-doc logic across the new reaction, the initial bootstrap path, and the post-delete swap.
- **Author attribution on history entries** — adds an optional `uid` field to `HistoryEntry`, stamped into the Firestore snapshot at upload time, and a volatile `source` field (`"local" | "remote" | "revert"`) set when an entry enters this process's local `document.history`. The history view shows author initials (full name in tooltip and details), and local-section entries get a left-border accent and detail swatch colored from the Okabe-Ito colorblind-safe palette.
- **Undo-stack indicator on the undoable icon** — the ↩/✕ icon now also reflects the entry's current undo-stack state: a gray rounded background when the entry is on the undo stack, a sky-blue background when it's the next-undo target. Hover tooltip names the state ("Undoable — on undo stack" / "Undoable — next undo target"). Glyph alignment is fixed so ↩ and ✕ visually center within the same box.
- **Non-undoable indicator** — flips the undoable icon to render an explicit `✕` for non-undoable entries instead of nothing, so the absence of `↩` is no longer ambiguous.

## Test plan
- [ ] Open the history view in a group document and confirm the Resume After 5s button shows a "Resuming in Ns…" countdown after click.
- [ ] Verify the `monitoring another user's document?!?` warning no longer fires when opening a group document or switching groups.
- [ ] Open a group doc, switch to a different group, confirm the workspace falls back to the problem doc and the title doesn't relabel mid-stream.
- [ ] In a group with multiple students, confirm history entries show the originating user's initials in the local section. Reverts get the vermillion accent; remote-applied entries the blue accent; local entries the green accent.
- [ ] Confirm the undoable icon is shaded gray for entries on the undo stack, sky-blue for the next-undo target. Hover tooltip names the state.
- [ ] Test plan items also covered by existing Jest suites: 16 concurrent-history-manager tests (3 new), 14 sync-firebase tests, 9 document-utils tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)