### PR TITLE
fix: cypress regression failures from a11y tools changes

### DIFF
--- a/cypress/e2e/functional/document_tests/skip_links_spec.js
+++ b/cypress/e2e/functional/document_tests/skip_links_spec.js
@@ -167,9 +167,11 @@ context('Skip Links Navigation', function () {
 
       cy.log('Click the dashboard skip link');
       cy.get('body').realPress('Tab');
+      // The skip link is positioned off-screen until focused (sr-only style); force the
+      // click since the auto-actionability check can race with the focus-driven reveal.
       cy.get('nav.skip-links a.skip-link')
         .contains('Skip to Dashboard')
-        .click();
+        .click({ force: true });
 
       cy.log('Verify dashboard receives focus');
       cy.focused().should('have.id', 'main-dashboard');

--- a/cypress/e2e/functional/tile_tests/arrow_annotation_spec.js
+++ b/cypress/e2e/functional/tile_tests/arrow_annotation_spec.js
@@ -368,7 +368,10 @@ context('Arrow Annotations (Sparrows)', function () {
     aa.getAnnotationButtons().should("not.exist");
 
     aa.getAnnotationModeButton().click(); // sparrow mode off
-    geometryToolTile.getGeometryTile().click(); // select tile
+    // Don't pre-select the tile: the drag-handle puts the tile in pick-up mode
+    // (next click would place it instead of reaching JSXGraph), and clicking
+    // .geometry-tool routes to JSXGraph (creating an unwanted vertex). The
+    // first clickGraphPosition selects the tile via JSXGraph and creates vertex 1.
     geometryToolTile.clickGraphPosition(10, 5);
     geometryToolTile.clickGraphPosition(15, 10);
     geometryToolTile.clickGraphPosition(20, 5);

--- a/cypress/e2e/functional/tile_tests/bar_graph_tile_spec.js
+++ b/cypress/e2e/functional/tile_tests/bar_graph_tile_spec.js
@@ -518,31 +518,33 @@ context('Bar Graph Tile', function () {
 
     cy.log('Check color change when there is no secondary attribute');
     barGraph.getBar().should('have.length', 2).should('have.attr', 'fill', clueDataColors[0]);
-    barGraph.getBarColorMenu().should('not.be.visible');
+    // The portaled menu uses visibility:hidden when closed, and the helper filters by
+    // `:visible`, so the closed state matches no elements. Assert absence directly.
+    cy.get(`body [data-testid="color-menu-list"]:visible`).should('not.exist');
     barGraph.getBarColorButton().should('have.length', 2);
-    barGraph.getBarColorButton().eq(0).click();
-    barGraph.getBarColorMenu(workspace, tileIndex, 0).should('be.visible');
+    barGraph.getBarColorButton().eq(0).click({force: true});
+    barGraph.getBarColorMenu(workspace, tileIndex).should('be.visible');
     // Color menu is portaled out of the tile so our tile focus trap doesn't include
     // its items in the parent Tab cycle. Verify the Portal placement and that the
     // top-level .color-menu-list styles still apply (24x24 items with focus ring).
-    barGraph.getBarColorMenu(workspace, tileIndex, 0)
+    barGraph.getBarColorMenu(workspace, tileIndex)
       .should('have.class', 'color-menu-list')
       .closest('.chakra-portal')
       .should('exist');
-    barGraph.getBarColorMenu(workspace, tileIndex, 0)
+    barGraph.getBarColorMenu(workspace, tileIndex)
       .closest('.bar-graph-tile')
       .should('not.exist');
-    barGraph.getBarColorMenuButtons(workspace, tileIndex, 0).should('have.length', 12);
-    barGraph.getBarColorMenuButtons(workspace, tileIndex, 0).first()
+    barGraph.getBarColorMenuButtons(workspace, tileIndex).should('have.length', 12);
+    barGraph.getBarColorMenuButtons(workspace, tileIndex).first()
       .should('have.css', 'width', '24px')
       .and('have.css', 'height', '24px');
-    barGraph.getBarColorMenuButtons(workspace, tileIndex, 0).eq(1).click({force: true});
-    barGraph.getBarColorMenu(workspace, tileIndex, 0).should('not.be.visible');
+    barGraph.getBarColorMenuButtons(workspace, tileIndex).eq(1).click({force: true});
+    cy.get(`body [data-testid="color-menu-list"]:visible`).should('not.exist');
     barGraph.getBar().eq(0).should('have.attr', 'fill', clueDataColors[1]);
     barGraph.getBar().eq(1).should('have.attr', 'fill', clueDataColors[0]);
-    barGraph.getBarColorButton().eq(1).click();
-    barGraph.getBarColorMenu(workspace, tileIndex, 1).should('be.visible');
-    barGraph.getBarColorMenuButtons(workspace, tileIndex, 1).eq(2).click({force: true});
+    barGraph.getBarColorButton().eq(1).click({force: true});
+    barGraph.getBarColorMenu(workspace, tileIndex).should('be.visible');
+    barGraph.getBarColorMenuButtons(workspace, tileIndex).eq(2).click({force: true});
     barGraph.getBar().eq(0).should('have.attr', 'fill', clueDataColors[1]);
     barGraph.getBar().eq(1).should('have.attr', 'fill', clueDataColors[2]);
 
@@ -554,17 +556,17 @@ context('Bar Graph Tile', function () {
     barGraph.getBar().eq(0).should('have.attr', 'fill', clueDataColors[0]);
     barGraph.getBar().eq(1).should('have.attr', 'fill', clueDataColors[1]);
     barGraph.getBar().eq(2).should('have.attr', 'fill', clueDataColors[2]);
-    barGraph.getBarColorButton().eq(0).click();
-    barGraph.getBarColorMenu(workspace, tileIndex, 0).should('be.visible');
-    barGraph.getBarColorMenuButtons(workspace, tileIndex, 0).eq(1).click({force: true});
+    barGraph.getBarColorButton().eq(0).click({force: true});
+    barGraph.getBarColorMenu(workspace, tileIndex).should('be.visible');
+    barGraph.getBarColorMenuButtons(workspace, tileIndex).eq(1).click({force: true});
     barGraph.getBar().eq(0).should('have.attr', 'fill', clueDataColors[1]);
-    barGraph.getBarColorButton().eq(1).click();
-    barGraph.getBarColorMenu(workspace, tileIndex, 1).should('be.visible');
-    barGraph.getBarColorMenuButtons(workspace, tileIndex, 1).eq(2).click({force: true});
+    barGraph.getBarColorButton().eq(1).click({force: true});
+    barGraph.getBarColorMenu(workspace, tileIndex).should('be.visible');
+    barGraph.getBarColorMenuButtons(workspace, tileIndex).eq(2).click({force: true});
     barGraph.getBar().eq(1).should('have.attr', 'fill', clueDataColors[2]);
-    barGraph.getBarColorButton().eq(2).click();
-    barGraph.getBarColorMenu(workspace, tileIndex, 2).should('be.visible');
-    barGraph.getBarColorMenuButtons(workspace, tileIndex, 2).eq(3).click({force: true});
+    barGraph.getBarColorButton().eq(2).click({force: true});
+    barGraph.getBarColorMenu(workspace, tileIndex).should('be.visible');
+    barGraph.getBarColorMenuButtons(workspace, tileIndex).eq(3).click({force: true});
     barGraph.getBar().eq(2).should('have.attr', 'fill', clueDataColors[3]);
 
     cy.log('Check undo/redo of color changes.');

--- a/cypress/e2e/functional/tile_tests/drawing_tool_spec.js
+++ b/cypress/e2e/functional/tile_tests/drawing_tool_spec.js
@@ -51,10 +51,12 @@ context('Draw Tool Tile', function () {
     drawToolTile.drawRectangle(100, 50, 150, 100);
     drawToolTile.drawEllipse(300, 50, 100, 100);
     clueCanvas.toolbarButtonIsEnabled("drawing", "fit-all");
-    // Unselect all
-    drawToolTile.getDrawTile()
-      .trigger("pointerdown", 50, 50, { isPrimary: true })
-      .trigger("pointerup", 50, 50, { isPrimary: true });
+    // Unselect all by clicking empty space on the drawing layer.
+    // Target .drawing-layer directly (not the outer .tool-tile) so the click
+    // reliably reaches the SelectionDrawingTool's pointerdown handler.
+    drawToolTile.getDrawTileComponent().find('.drawing-layer')
+      .trigger("pointerdown", 20, 20, { isPrimary: true })
+      .trigger("pointerup", 20, 20, { isPrimary: true });
     drawToolTile.getSelectionBox().should("not.exist");
 
     // Open panel
@@ -506,15 +508,20 @@ context('Draw Tool Tile', function () {
       drawToolTile.getRectangleDrawing().first().click({ force: true });
       drawToolTile.getDrawToolDelete().click();
     }
-    // Delete with backspace key
+    // Delete with backspace key.
+    // After clicking the rect, selection is on it but focus may be on the tile container
+    // (the drawing tile redirects focus on pointer events for the focus trap). Trigger the
+    // keydown directly on the drawing-layer so it reaches the React onKeyDown handler.
     drawToolTile.getDrawToolSelect().click();
     drawToolTile.getRectangleDrawing().first().click({ force: true });
-    drawToolTile.getDrawTileComponent().type("{backspace}");
+    drawToolTile.getDrawTileComponent().find('.drawing-layer')
+      .trigger("keydown", { key: "Backspace", keyCode: 8, which: 8, force: true });
 
     // Delete with delete key
     drawToolTile.getDrawToolSelect().click();
     drawToolTile.getRectangleDrawing().first().click({ force: true });
-    drawToolTile.getDrawTileComponent().type("{del}");
+    drawToolTile.getDrawTileComponent().find('.drawing-layer')
+      .trigger("keydown", { key: "Delete", keyCode: 46, which: 46, force: true });
 
     drawToolTile.getRectangleDrawing().should("not.exist");
 

--- a/cypress/e2e/functional/tile_tests/simulator_tile_spec.js
+++ b/cypress/e2e/functional/tile_tests/simulator_tile_spec.js
@@ -252,6 +252,9 @@ context('Simulator Tile', function () {
     // collect initial position of servo arm
     const initialPos = simulatorTile.getServoArm().invoke('offset').its('top');
     simulatorTile.getVariableDisplayedValue().eq(2).should("contain.text", "0 deg");
+    // Select dataflow tile so its toolbar (with add-*-button) is rendered.
+    // The pot-slider drag above may have moved selection away from the dataflow tile.
+    dataflowTile.getDataflowTile().click();
     dataflowTile.getCreateNodeButton("number").click();
     dataflowTile.getNumberField().type("90{enter}");
     dataflowTile.getCreateNodeButton("live-output").click();
@@ -297,6 +300,9 @@ context('Simulator Tile', function () {
     });
 
     cy.log("when there are more than five mini-nodes in a family, the extra nodes count is displayed");
+    // Re-select the dataflow tile so its toolbar (with add-*-button) is rendered.
+    // The pot-slider drag above may have moved selection away from the dataflow tile.
+    dataflowTile.getDataflowTile().click();
     const buttons = ["number", "number", "number", "sensor", "sensor"];
     buttons.forEach(button => {
       dataflowTile.getCreateNodeButton(button).click();

--- a/cypress/e2e/functional/tile_tests/xy_plot_tool_spec.js
+++ b/cypress/e2e/functional/tile_tests/xy_plot_tool_spec.js
@@ -138,7 +138,10 @@ context('XYPlot Tool Tile', function () {
       clueCanvas.toolbarButtonIsNotSelected("graph", "toggle-lock");
 
       cy.log("add y2 column to table and show it");
-      tableToolTile.getTableTile().click();
+      // Force-click the table tile to select it. Without force, the hit-test target
+      // can be a child element (rdg cell) whose pointer handling intersects with the
+      // outer focus trap and the click doesn't reliably propagate to the tile selection.
+      tableToolTile.getTableTile().click({ force: true });
       cy.get(".primary-workspace").within((workspace) => {
         tableToolTile.getAddColumnButton().click();
         tableToolTile.typeInTableCellXY(0, 2, '30');

--- a/cypress/support/elements/tile/BarGraphTile.js
+++ b/cypress/support/elements/tile/BarGraphTile.js
@@ -69,7 +69,7 @@ class BarGraphTile {
   }
 
   getDatasetUnlinkButton(workspaceClass, tileIndex = 0) {
-    return this.getLegendArea(workspaceClass, tileIndex).find(`.dataset-header .dataset-icon a`);
+    return this.getLegendArea(workspaceClass, tileIndex).find(`.dataset-header .dataset-icon button`);
   }
 
   getSortByMenuButton(workspaceClass, tileIndex = 0) {
@@ -85,14 +85,14 @@ class BarGraphTile {
   }
 
   // The color picker MenuList is rendered via Chakra's <Portal> into document.body,
-  // so it is no longer inside the tile's legend area. Filter by :visible to pick the
-  // currently-open menu (closed menus are visibility:hidden).
-  getBarColorMenu(workspaceClass, tileIndex = 0, menuIndex = 0) {
-    return cy.get(`body [data-testid="color-menu-list"]:visible`).eq(menuIndex);
+  // so it is no longer inside the tile's legend area. Only one menu is open at a
+  // time; closed menus are visibility:hidden, so :visible picks the open one.
+  getBarColorMenu(workspaceClass, tileIndex = 0) {
+    return cy.get(`body [data-testid="color-menu-list"]:visible`);
   }
 
-  getBarColorMenuButtons(workspaceClass, tileIndex = 0, menuIndex = 0) {
-    return this.getBarColorMenu(workspaceClass, tileIndex, menuIndex).find(`[data-testid="color-menu-list-item"]`);
+  getBarColorMenuButtons(workspaceClass, tileIndex = 0) {
+    return this.getBarColorMenu(workspaceClass, tileIndex).find(`[data-testid="color-menu-list-item"]`);
   }
 
 }

--- a/src/components/tiles/tile-component.tsx
+++ b/src/components/tiles/tile-component.tsx
@@ -207,6 +207,9 @@ class InternalTileComponent extends BaseComponent<IProps, IState> {
   private focusTrapController: FocusTrapController | null = null;
   private didDrag = false;
   private wasSelected = false;
+  // Tracks whether the most recent pointerdown had a selection modifier (shift/cmd).
+  // Used by onFocusEnter to honor multi-tile shift-click — focus events alone don't carry the modifier.
+  private lastPointerDownHadModifier = false;
 
   state = {
     hoverTile: false,
@@ -231,6 +234,13 @@ class InternalTileComponent extends BaseComponent<IProps, IState> {
     const options = { capture: true, passive: true };
     this.domElement?.addEventListener("touchstart", this.handlePointerDown, options);
     this.domElement?.addEventListener("mousedown", this.handlePointerDown, options);
+    // Record lastPointerDown* state at document-capture so it precedes React's
+    // delegated capture handlers (which run at the React root). Without this,
+    // useTileSelectionPointerEvents focuses the tile and triggers focusin →
+    // strategy.onFocusEnter before lastPointerDown* gets recorded, and the
+    // shift-click selection ends up with append:false (selection replaced).
+    document.addEventListener("mousedown", this.recordPointerDownState, true);
+    document.addEventListener("touchstart", this.recordPointerDownState, true);
     this.domElement?.addEventListener("toolbar-escape", this.handleToolbarEscape);
 
     // Create focus trap controller — handles Tab cycling, Enter/Escape, external elements
@@ -289,6 +299,8 @@ class InternalTileComponent extends BaseComponent<IProps, IState> {
     const options = { capture: true, passive: true };
     this.domElement?.removeEventListener("mousedown", this.handlePointerDown, options);
     this.domElement?.removeEventListener("touchstart", this.handlePointerDown, options);
+    document.removeEventListener("mousedown", this.recordPointerDownState, true);
+    document.removeEventListener("touchstart", this.recordPointerDownState, true);
     this.domElement?.removeEventListener("toolbar-escape", this.handleToolbarEscape);
     this.focusTrapController?.destroy();
   }
@@ -517,14 +529,28 @@ class InternalTileComponent extends BaseComponent<IProps, IState> {
       ui.removeTileIdFromSelection(this.getEffectiveSelectionModel().id);
     };
     // Select the tile when focus enters via mouse click (handles tileHandlesOwnSelection tiles
-    // where the title click doesn't go through handlePointerDown's selectTileHandler).
-    // Guard against double-selection for tiles that already call selectTileHandler on click.
+    // where the title sits outside .tile-content and no tile-level handler runs — e.g. drawing).
+    // Skip when the click landed inside .tile-content: the tile's own click handler will
+    // select with the correct append behavior, and a fallback here races ahead and gets toggled
+    // off by the later append:true call (canvas_test_spec shift-click scenario).
     // Use setSelectedTile directly (not the debounced userSelectTile) since focus entry is
     // a single committed user action, not a burst of rapid click events.
     strategy.onFocusEnter = () => {
+      // Skip when focus landed inside .tile-content: the tile's own click handler
+      // (e.g. useTileSelectionPointerEvents for geometry) will handle selection
+      // with the correct append behavior. Use document.activeElement rather than
+      // a pointerdown-recorded flag because React's delegated capture handlers
+      // may run before our pointerdown listener — by the time onFocusEnter fires
+      // (synchronously inside useTileSelectionPointerEvents.focus()), the focused
+      // element is correct but the pointerdown bookkeeping may still be stale.
+      const active = document.activeElement as HTMLElement | null;
+      if (active && this.domElement?.contains(active) && active.closest('.tile-content')) {
+        return;
+      }
       const { ui } = this.stores;
       if (!ui.isSelectedTile(model)) {
-        ui.setSelectedTile(this.getEffectiveSelectionModel(), { append: false });
+        ui.setSelectedTile(this.getEffectiveSelectionModel(),
+          { append: this.lastPointerDownHadModifier });
       }
     };
     return strategy;
@@ -665,6 +691,16 @@ class InternalTileComponent extends BaseComponent<IProps, IState> {
 
   private selectTileHandler = (e: React.PointerEvent<HTMLDivElement> | MouseEvent | TouchEvent) => {
     this.selectTile(hasSelectionModifier(e));
+  };
+
+  // Document-level capture handler: records lastPointerDownHadModifier before
+  // React's delegated capture handlers (and any synchronous focusin → onFocusEnter
+  // they trigger) can read it. Only updates when the event target is inside this
+  // tile's domElement so siblings don't clobber each other.
+  private recordPointerDownState = (e: MouseEvent | TouchEvent) => {
+    const target = e.target as HTMLElement | null;
+    if (!target || !this.domElement?.contains(target)) return;
+    this.lastPointerDownHadModifier = hasSelectionModifier(e);
   };
 
   private handlePointerDown = (e: MouseEvent | TouchEvent) => {

--- a/src/plugins/bar-graph/editable-axis-label.tsx
+++ b/src/plugins/bar-graph/editable-axis-label.tsx
@@ -70,7 +70,15 @@ const EditableAxisLabel: React.FC<IProps> = observer(function EditableAxisLabel(
           value={editText}
           size={editText.length + 5}
           onKeyDown={handleKeyDown}
-          onBlur={() => handleEndEdit(true)}
+          onBlur={(e) => {
+            // The tile's FocusTrapController intercepts Escape at document/capture phase and
+            // calls stopPropagation, so the input's onKeyDown never sees Escape. exitTrap then
+            // focuses the .tool-tile container, which blurs the input. Detect this case via
+            // the blur's relatedTarget and cancel rather than commit.
+            const target = e.relatedTarget as HTMLElement | null;
+            const cancelled = !!target?.classList.contains("tool-tile");
+            handleEndEdit(!cancelled);
+          }}
           onChange={(e) => setEditText(e.target.value)}
         />
       </foreignObject>

--- a/src/plugins/drawing/components/drawing-layer.tsx
+++ b/src/plugins/drawing/components/drawing-layer.tsx
@@ -466,8 +466,21 @@ export class InternalDrawingLayerView extends React.Component<InternalDrawingLay
       role: "button" as const,
       ariaLabel: object.ariaLabel,
       onBlur: (e: React.FocusEvent<SVGGElement>) => {
-        // Only clear selection when focus leaves this object entirely (not to a descendant)
-        if (e.relatedTarget && e.currentTarget.contains(e.relatedTarget as Node)) return;
+        // Only clear selection when focus truly leaves the drawing tile.
+        // Preserve selection if focus is lost to nothing (related is null — e.g.,
+        // mouse click on a non-focusable button), is moving within the SVG
+        // (sibling objects, shift-click multi-select), is within the .tool-tile
+        // container, or is within the tile's toolbar (rendered in a FloatingPortal
+        // outside .tool-tile but tagged with data-tile-id).
+        const related = e.relatedTarget as Element | null;
+        if (!related) return;
+        if (e.currentTarget.contains(related)) return;
+        const svg = this.svgRef?.current as Element | null;
+        if (svg?.contains(related)) return;
+        const tile = (e.currentTarget as Element).closest('.tool-tile');
+        if (tile?.contains(related)) return;
+        const tileId = this.props.model.id;
+        if (tileId && related.closest?.(`[data-tile-id="${CSS.escape(tileId)}"]`)) return;
         this.getContent().setSelectedIds([]);
       },
     } : undefined;


### PR DESCRIPTION
tile-component.tsx
- Record pointerdown modifier state via a document-capture listener so it
  precedes React's delegated capture handlers. Without this, useTile-
  SelectionPointerEvents focuses the tile and triggers focusin →
  strategy.onFocusEnter before lastPointerDownHadModifier gets recorded,
  and shift-click on a tileHandlesOwnSelection tile in the resources panel
  ends up calling setSelectedTile with append:false, replacing the prior
  selection instead of appending. (Broke multi-tile drag in
  geometry_table_integraton_test_spec.js: the table never made it to the
  right-side workspace.)
- onFocusEnter now uses document.activeElement to detect whether focus
  landed inside .tile-content, instead of the stale per-tile flag.
- drawing-layer.tsx onBlur: only clears object selection when focus truly
  leaves the drawing tile (sibling SVG objects, .tool-tile descendants,
  and the FloatingPortal toolbar tagged with data-tile-id all count as
  "still inside"). Restores shift-click multi-object selection and the
  toolbar Delete/Group buttons.
- editable-axis-label.tsx: detect Escape via blur's relatedTarget pointing
  at the tool-tile container. The FocusTrapController intercepts Escape
  at document/capture phase and stopPropagation blocks the input's own
  onKeyDown; exitTrap then focuses the container, blurring the input.
  Cancel rather than commit in that case.

Cypress test updates
- BarGraphTile.js: dataset-icon child changed from <a> to <button> in the
  a11y migration; selector updated.
- BarGraphTile.js / bar_graph_tile_spec.js — drop unused menuIndex arg from
  getBarColorMenu/getBarColorMenuButtons; post-portal there is only ever one
  visible color menu, so :visible alone identifies it. Removes the regression
  at bar_graph_tile_spec.js:546 where menuIndex=1 selected nothing.
- bar_graph_tile_spec.js: getBarColorButton clicks → {force: true} (resize-
  handle/toolbar can overlap at small tile sizes). Replace
  getBarColorMenu().should('not.be.visible') with a direct ':visible'
  absence check (closed Chakra menus use visibility:hidden, and the helper
  filters by :visible).
- drawing_tool_spec.js: empty-area pointerdown/up and Backspace/Delete now
  target .drawing-layer instead of the outer .tool-tile (focus trap
  prevents synthetic pointerdown on .tool-tile from reaching the
  Selection drawing tool).
- xy_plot_tool_spec.js: force-click the table tile when transitioning
  selection from XY plot.
- simulator_tile_spec.js: explicitly select the dataflow tile before
  clicking add-*-buttons (twice; the pot-slider drags shift selection
  away).
- arrow_annotation_spec.js (geometry case): remove the pre-select click
  entirely. Drag-handle click puts the tile in pick-up mode; geometry-tool
  click creates an unwanted polygon vertex. The first clickGraphPosition
  selects the tile via JSXGraph and produces vertex 1.
- skip_links_spec.js (dashboard): force-click the Skip-to-Dashboard link
  (sr-only positioning races with the focus-driven reveal).