### PR TITLE
chore: remove AccessibilityDebugSidebar and debugA11y query param

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -11,7 +11,6 @@ import { GroupManagementModal } from "./group/group-management-modal";
 import { IStores } from "../models/stores/stores";
 import ErrorAlert from "./utilities/error-alert";
 import { getCurrentLoadingMessage, removeLoadingMessage, showLoadingMessage } from "../utilities/loading-utils";
-import { AccessibilityDebugSidebar } from "@concord-consortium/accessibility-tools/debug";
 import { PickedUpTileGhost } from "./picked-up-tile-ghost";
 import { LogMonitor } from "@concord-consortium/log-monitor";
 
@@ -251,7 +250,6 @@ export class AppComponent extends BaseComponent<IProps> {
           {children}
           <PickedUpTileGhost />
         </div>
-        {urlParams.debugA11y && <AccessibilityDebugSidebar />}
         {urlParams.logMonitor && <LogMonitor logFilePrefix="clue-log-events" />}
       </>
     );

--- a/src/utilities/url-params.ts
+++ b/src/utilities/url-params.ts
@@ -146,9 +146,6 @@ export interface QueryParams {
 
   // Show the log monitor sidebar
   logMonitor?: boolean;
-
-  // Show the accessibility debugger sidebar
-  debugA11y?: boolean;
 }
 
 // Make a union of all of the boolean params from the QueryParams
@@ -159,7 +156,7 @@ type BooleanParamNames = Exclude<
 undefined>;
 
 const booleanParams: BooleanParamNames[] =
-  [ "debugA11y", "demo", "logMonitor", "mouseSensor", "noPersistentUI", "readOnly", "noStorage", "unwrapped" ];
+  [ "demo", "logMonitor", "mouseSensor", "noPersistentUI", "readOnly", "noStorage", "unwrapped" ];
 
 const processBooleanValue = (value: string | (string | null)[] | null | undefined) => {
   if (value === undefined || value === "false") {


### PR DESCRIPTION
The debug sidebar from @concord-consortium/accessibility-tools/debug is no longer needed in CLUE. Drops the import and conditional render in app.tsx, and removes the debugA11y entry from the QueryParams interface and the booleanParams list.