### PR TITLE
chore: use published accessibility-tools package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@chakra-ui/react": "^1.8.9",
         "@codemirror/lang-json": "^6.0.2",
-        "@concord-consortium/accessibility-tools": "github:concord-consortium/accessibility-tools#main",
+        "@concord-consortium/accessibility-tools": "0.0.1-pre.0",
         "@concord-consortium/codap-formulas-react17": "^1.1.0",
         "@concord-consortium/compute-engine": "^0.12.3-cc.2",
         "@concord-consortium/diagram-view": "1.0.2",
@@ -2909,8 +2909,9 @@
       }
     },
     "node_modules/@concord-consortium/accessibility-tools": {
-      "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/concord-consortium/accessibility-tools.git#7f83472d6e4e73af1c67f7022a770e2b4e50a102",
+      "version": "0.0.1-pre.0",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/accessibility-tools/-/accessibility-tools-0.0.1-pre.0.tgz",
+      "integrity": "sha512-Ly3ubyjr3cTIGRUdPwLNtJvFN6B2LBj6G0Sk3WJyThyI98fTJn5VPJCQH2JnKrWFtKOd0DR24KR0ev9zFi0IXg==",
       "license": "MIT",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
@@ -30864,8 +30865,9 @@
       }
     },
     "@concord-consortium/accessibility-tools": {
-      "version": "git+ssh://git@github.com/concord-consortium/accessibility-tools.git#7f83472d6e4e73af1c67f7022a770e2b4e50a102",
-      "from": "@concord-consortium/accessibility-tools@github:concord-consortium/accessibility-tools#main",
+      "version": "0.0.1-pre.0",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/accessibility-tools/-/accessibility-tools-0.0.1-pre.0.tgz",
+      "integrity": "sha512-Ly3ubyjr3cTIGRUdPwLNtJvFN6B2LBj6G0Sk3WJyThyI98fTJn5VPJCQH2JnKrWFtKOd0DR24KR0ev9zFi0IXg==",
       "requires": {
         "@heroicons/react": "^2.2.0",
         "dom-accessibility-api": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -251,7 +251,7 @@
   "dependencies": {
     "@chakra-ui/react": "^1.8.9",
     "@codemirror/lang-json": "^6.0.2",
-    "@concord-consortium/accessibility-tools": "github:concord-consortium/accessibility-tools#main",
+    "@concord-consortium/accessibility-tools": "0.0.1-pre.0",
     "@concord-consortium/codap-formulas-react17": "^1.1.0",
     "@concord-consortium/compute-engine": "^0.12.3-cc.2",
     "@concord-consortium/diagram-view": "1.0.2",


### PR DESCRIPTION
Switch from github:concord-consortium/accessibility-tools#main to the published npm version 0.0.1-pre.0.