### PR TITLE
CLUE-516 Address review feedback and document classnames convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,8 @@ See [tiles.md](tiles.md) for detailed tile documentation.
 - `doc-editor.tsx` - Standalone document editor (`/editor/`)
 - `authoring/` - CMS authoring system
 
+**className construction**: When a JSX element has any conditional or computed class, use the `classnames` helper (`import classNames from "classnames"`) rather than template literals or string concatenation. Pass static classes as bare strings, conditional classes via the object form, and any precomputed class variable as another argument. Example: `classNames("history-entry-item", sourceClass, { expanded, "not-undoable": !undoable })`. A plain string literal is fine only when there are no conditions or interpolations at all.
+
 ### URL Parameters for Testing
 
 | Parameter | Values | Purpose |

--- a/src/components/document/history-entry-item.tsx
+++ b/src/components/document/history-entry-item.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { observer } from "mobx-react";
 import { Instance } from "mobx-state-tree";
+import classNames from "classnames";
 import { HistoryEntryType } from "../../models/history/history";
 import { UndoStore } from "../../models/history/undo-store";
 import { useStores } from "../../hooks/use-stores";
@@ -50,6 +51,7 @@ export const HistoryEntryItem: React.FC<IHistoryEntryItemProps> = observer(({
 
   const patchCount = entry.records.reduce((total, record) => total + record.patches.length, 0);
 
+  const unknownUser = { initials: "?", fullName: undefined };
   const author = (() => {
     if (entry.uid) {
       const classUser = classStore.getUserById(entry.uid);
@@ -58,23 +60,17 @@ export const HistoryEntryItem: React.FC<IHistoryEntryItemProps> = observer(({
         fullName: classUser?.displayName,
       };
     }
-    // No uid on the entry.
-    if (section === "remote") return { initials: "?", fullName: undefined };
-    // Local section. Source distinguishes how the entry got here.
-    if (entry.source === "remote") {
-      // remote-applied but legacy entry without uid
-      return { initials: "?", fullName: undefined };
-    }
-    // "local" or "revert" — created on this client
+    // No uid on the entry. In the remote section, or in the local section when the
+    // entry was applied from a remote source, this is a legacy pre-feature entry.
+    if (section === "remote" || entry.source === "remote") return unknownUser;
+    // Local section, source is "local" or "revert" — created on this client.
     return { initials: user.initials, fullName: user.name };
   })();
   const authorDetail = author.fullName
     ? `${author.fullName} (${author.initials})`
     : author.initials;
 
-  // Color the entry by its arrival source, but only in the local section —
-  // the remote section is uniformly "remote" by construction, so a per-entry
-  // accent there would just be noise.
+  // Color the entry by its arrival source, but only in the local section.
   const sourceClass = section === "local" ? `source-${entry.source}` : "";
 
   // Undo-stack decoration. undoStore is passed only in the local section.
@@ -87,7 +83,8 @@ export const HistoryEntryItem: React.FC<IHistoryEntryItemProps> = observer(({
     : onUndoStack
       ? "on-undo-stack"
       : "";
-  const undoableTitle = !entry.undoable
+  const undoable = entry.undoable;
+  const undoableTitle = !undoable
     ? "Not undoable"
     : isUndoPointer
       ? "Undoable — next undo target"
@@ -96,7 +93,7 @@ export const HistoryEntryItem: React.FC<IHistoryEntryItemProps> = observer(({
         : "Undoable";
 
   return (
-    <div className={`history-entry-item ${sourceClass} ${expanded ? "expanded" : ""}`}>
+    <div className={classNames("history-entry-item", sourceClass, { expanded })}>
       <button className="history-entry-summary" onClick={toggleExpanded}>
         <span className="history-entry-expand">
           {expanded ? "▼" : "▶"}
@@ -109,12 +106,10 @@ export const HistoryEntryItem: React.FC<IHistoryEntryItemProps> = observer(({
           {patchCount}p
         </span>
         <span
-          className={
-            `history-entry-undoable ${entry.undoable ? "undoable" : "not-undoable"} ${undoStackClass}`
-          }
+          className={classNames("history-entry-undoable", undoStackClass, { undoable, "not-undoable": !undoable })}
           title={undoableTitle}
         >
-          <span className="glyph">{entry.undoable ? "↩" : "✕"}</span>
+          <span className="glyph">{undoable ? "↩" : "✕"}</span>
         </span>
         <span className="history-entry-author" title={author.fullName ?? "Author"}>{author.initials}</span>
         <span className="history-entry-time">{formatTimestamp(entry.created)}</span>

--- a/src/components/document/history-manager-controls.tsx
+++ b/src/components/document/history-manager-controls.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { observer } from "mobx-react";
+import classNames from "classnames";
+import { FirestoreHistoryManagerConcurrent } from "../../models/history/firestore-history-manager-concurrent";
+
+interface IHistoryManagerControlsProps {
+  manager: FirestoreHistoryManagerConcurrent;
+}
+
+export const HistoryManagerControls: React.FC<IHistoryManagerControlsProps> = observer(({ manager }) => {
+  return (
+    <div className="history-manager-controls">
+      {manager.resumeCountdownSeconds !== null ? (
+        <>
+          <button disabled>Pause Uploads</button>
+          <span className="history-manager-status">
+            Resuming in {manager.resumeCountdownSeconds}s…
+          </span>
+        </>
+      ) : manager.paused ? (
+        <button onClick={() => manager.resumeUploadsAfterDelay(5000)}>
+          Resume After 5s
+        </button>
+      ) : (
+        <button onClick={() => manager.pauseUploads()}>
+          Pause Uploads
+        </button>
+      )}
+      <button
+        className={classNames({ paused: manager.pausedDownloads })}
+        onClick={() => manager.pausedDownloads
+          ? manager.resumeDownloads()
+          : manager.pauseDownloads()}
+      >
+        {manager.pausedDownloads ? "Resume Downloads" : "Pause Downloads"}
+      </button>
+    </div>
+  );
+});

--- a/src/components/document/history-view-panel.tsx
+++ b/src/components/document/history-view-panel.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { observer } from "mobx-react";
 import { HistoryEntryItem } from "./history-entry-item";
+import { HistoryManagerControls } from "./history-manager-controls";
 import { useStores } from "../../hooks/use-stores";
 import { DocumentModelType } from "../../models/document/document";
 import { TreeManagerType } from "../../models/history/tree-manager";
@@ -143,34 +144,7 @@ export const HistoryViewPanel: React.FC<IHistoryViewPanelProps> = observer(funct
           <div className="history-view-section-header">
             <h4>Remote History (Firestore)</h4>
             <span className="history-view-count">{remoteHistoryEntries.length} entries</span>
-            {concurrentManager && (
-              <div className="history-manager-controls">
-                {concurrentManager.resumeCountdownSeconds !== null ? (
-                  <>
-                    <button disabled>Pause Uploads</button>
-                    <span className="history-manager-status">
-                      Resuming in {concurrentManager.resumeCountdownSeconds}s…
-                    </span>
-                  </>
-                ) : concurrentManager.paused ? (
-                  <button onClick={() => concurrentManager.resumeUploadsAfterDelay(5000)}>
-                    Resume After 5s
-                  </button>
-                ) : (
-                  <button onClick={() => concurrentManager.pauseUploads()}>
-                    Pause Uploads
-                  </button>
-                )}
-                <button
-                  className={concurrentManager.pausedDownloads ? "paused" : ""}
-                  onClick={() => concurrentManager.pausedDownloads
-                    ? concurrentManager.resumeDownloads()
-                    : concurrentManager.pauseDownloads()}
-                >
-                  {concurrentManager.pausedDownloads ? "Resume Downloads" : "Pause Downloads"}
-                </button>
-              </div>
-            )}
+            {concurrentManager && <HistoryManagerControls manager={concurrentManager} />}
           </div>
           <div className="history-view-list">
             {remoteHistoryError ? (

--- a/src/hooks/use-document-sync-to-firebase.ts
+++ b/src/hooks/use-document-sync-to-firebase.ts
@@ -58,11 +58,7 @@ export function useDocumentSyncToFirebase(
   // The current hacky approach is to use a window level property to disable the firebase syncing
   const disableFirebaseSync = (window as any).DISABLE_FIREBASE_SYNC;
 
-  // The warning's concern is writing to another user's user-namespaced path.
-  // Group documents are exempt: they have a synthetic uid (`group_<offering>_<group>`),
-  // not a user id, so any real user satisfies `user.id !== uid`. Wrong-group anomalies
-  // are caught separately by the workspace's group-change reaction, which closes such
-  // docs rather than just logging.
+  // The warning's concern is writing to another user's user-namespaced path, so we allow group documents.
   !disableFirebaseSync && !readOnly && !document.isGroup && (user.id !== uid) &&
     console.warn("useDocumentSyncToFirebase monitoring another user's document?!?");
 

--- a/src/models/document/document-utils.ts
+++ b/src/models/document/document-utils.ts
@@ -92,9 +92,6 @@ export function getDocumentIdentifier(document?: DocumentContentModelType) {
 
 /**
  * True when `doc` is a group document and `user` is currently in that group.
- * Group documents use a synthetic uid (`group_<offering>_<group>`) rather than
- * any real user's id, so `doc.uid === user.id` never holds for them; group
- * membership is the right authorization check.
  */
 export function isOwnGroupDocument(
   doc: Pick<IDocumentMetadataBase, "type" | "groupId">,


### PR DESCRIPTION
## Summary

Follow-up to #2843 — applies Teale's review comments. I accidentally merged the PR without pushing these changes first.  It also codifies the related convention in `CLAUDE.md`.

- **CLAUDE.md** — adds a *className construction* note under Key Patterns: any JSX with a conditional or computed class should use the `classnames` helper (object form for conditionals) rather than template-literal string concatenation.
- **history-entry-item** — collapses the two unknown-author branches behind a shared `unknownUser`, switches the wrapper and the undoable badge to `classNames(...)`, and shortens the source-color comment.
- **history-view-panel** — extracts the `FirestoreHistoryManagerConcurrent` controls into a new `HistoryManagerControls` component now that the upload pause/resume/countdown logic has grown a third state.
- **use-document-sync-to-firebase** — collapses the multi-line group-document rationale to a single line.
- **document-utils** — collapses the `isOwnGroupDocument` JSDoc to its summary.

Teale's original review: https://github.com/concord-consortium/collaborative-learning/pull/2843#pullrequestreview-4207546521

## Test plan

- [x] `npm run lint:build` clean
- [x] `npm test` clean (verified locally: 1962 passing on touched test set)
- [x] Open the document history view and confirm the undoable badge, source coloring, and remote-history pause/resume/countdown controls still render and behave the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)