### PR TITLE
CLUE-489 Bump @testing-library/user-event to v14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -115,7 +115,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^12.1.5",
         "@testing-library/react-hooks": "^8.0.1",
-        "@testing-library/user-event": "^13.5.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/chart.js": "^2.9.37",
         "@types/color-string": "^1.5.2",
         "@types/common-tags": "^1.8.1",
@@ -7806,14 +7806,13 @@
       }
     },
     "node_modules/@testing-library/user-event": {
-      "version": "13.5.0",
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
       "engines": {
-        "node": ">=10",
+        "node": ">=12",
         "npm": ">=6"
       },
       "peerDependencies": {
@@ -34147,11 +34146,11 @@
       }
     },
     "@testing-library/user-event": {
-      "version": "13.5.0",
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
       "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.12.5"
-      }
+      "requires": {}
     },
     "@tootallnate/once": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^12.1.5",
     "@testing-library/react-hooks": "^8.0.1",
-    "@testing-library/user-event": "^13.5.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/chart.js": "^2.9.37",
     "@types/color-string": "^1.5.2",
     "@types/common-tags": "^1.8.1",

--- a/src/authoring/components/workspace/term-overrides-settings.test.tsx
+++ b/src/authoring/components/workspace/term-overrides-settings.test.tsx
@@ -58,19 +58,21 @@ describe("TermOverridesSettings", () => {
   });
 
   it("allows entering custom override values", async () => {
+    const user = userEvent.setup();
     render(<TermOverridesSettings />);
 
     const groupInput = screen.getByLabelText("group") as HTMLInputElement;
-    await userEvent.type(groupInput, "Team");
+    await user.type(groupInput, "Team");
 
     expect(groupInput.value).toBe("Team");
   });
 
   it("calls setUnitConfig with custom terms on save", async () => {
+    const user = userEvent.setup();
     render(<TermOverridesSettings />);
 
     const groupInput = screen.getByLabelText("group") as HTMLInputElement;
-    await userEvent.type(groupInput, "Team");
+    await user.type(groupInput, "Team");
 
     const saveButton = screen.getByRole("button", { name: /Save/i });
     fireEvent.click(saveButton);
@@ -94,10 +96,11 @@ describe("TermOverridesSettings", () => {
   });
 
   it("does not save terms that match the default value", async () => {
+    const user = userEvent.setup();
     render(<TermOverridesSettings />);
 
     const groupInput = screen.getByLabelText("group") as HTMLInputElement;
-    userEvent.type(groupInput, "group");
+    await user.type(groupInput, "group");
 
     const saveButton = screen.getByRole("button", { name: /Save/i });
     fireEvent.click(saveButton);

--- a/src/components/chat/chat-panel.test.tsx
+++ b/src/components/chat/chat-panel.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 import { ModalProvider } from "react-modal-hook";
@@ -131,7 +131,8 @@ jest.mock("../../hooks/use-stores", () => ({
 
 describe("ChatPanel", () => {
 
-  it("should render successfully", () => {
+  it("should render successfully", async () => {
+    const user = userEvent.setup();
     const mockCloseChatPanel = jest.fn();
     render((
       <ModalProvider>
@@ -141,9 +142,7 @@ describe("ChatPanel", () => {
     expect(screen.getByTestId("chat-panel")).toBeInTheDocument();
     expect(screen.getByTestId("chat-panel-header")).toBeInTheDocument();
 
-    act(() => {
-      userEvent.click(screen.getByTestId("chat-close-button"));
-    });
+    await user.click(screen.getByTestId("chat-close-button"));
     expect(mockCloseChatPanel).toHaveBeenCalled();
   });
   it("should show select document message if document has not been selected", () => {

--- a/src/components/chat/comment-textbox.test.tsx
+++ b/src/components/chat/comment-textbox.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
-import { act } from "react-dom/test-utils";
 import { CommentTextBox } from "./comment-textbox";
 
 jest.mock("../../hooks/use-stores", () => ({
@@ -23,7 +22,8 @@ describe("Comment Textbox", () => {
     expect(screen.getByTestId("comment-post-button")).toHaveClass(activeNavTab);
   });
 
-  it("should allow user to type text in the textarea and enable Post button", () => {
+  it("should allow user to type text in the textarea and enable Post button", async () => {
+    const user = userEvent.setup();
     const { rerender } = render((
       <CommentTextBox numPostedComments={5}/>
     ));
@@ -31,21 +31,18 @@ describe("Comment Textbox", () => {
     const textarea = screen.getByTestId("comment-textarea") as HTMLTextAreaElement;
     const text = "X"; //testing library issue when typing in more than one character
     expect(postButton).toHaveClass("disabled");
-    act(() =>{
-      userEvent.type(textarea, text);
-    });
+    await user.type(textarea, text);
     rerender(
       <CommentTextBox numPostedComments={5} />
     );
     expect(textarea.value).toBe(text);
     expect(postButton).not.toHaveClass("disabled");
-    act(() => {
-      userEvent.click(screen.getByTestId("comment-cancel-button"));
-    });
+    await user.click(screen.getByTestId("comment-cancel-button"));
     expect(textarea.value).toBe("");
     expect(postButton).toHaveClass("disabled");
   });
-  it("should allow user to type text in the textarea and enable Post button", () => {
+  it("should call onPostComment when Post button is clicked", async () => {
+    const user = userEvent.setup();
     const onPostComment = jest.fn();
     window.alert = jest.fn();
     const { rerender } = render((
@@ -55,17 +52,13 @@ describe("Comment Textbox", () => {
     const textarea = screen.getByTestId("comment-textarea") as HTMLTextAreaElement;
     const text = "X"; //testing library issue when typing in more than one character
     expect(postButton).toHaveClass("disabled");
-    act(() =>{
-      userEvent.type(textarea, text);
-    });
+    await user.type(textarea, text);
     rerender(
       <CommentTextBox numPostedComments={5} onPostComment={onPostComment} />
     );
     expect(textarea.value).toBe(text);
     expect(postButton).not.toHaveClass("disabled");
-    act(() => {
-      userEvent.click(postButton);
-    });
+    await user.click(postButton);
     expect(textarea.value).toBe("");
     expect(postButton).toHaveClass("disabled");
     expect(onPostComment).toHaveBeenCalled();

--- a/src/components/delete-button.test.tsx
+++ b/src/components/delete-button.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "mobx-react";
 import React from "react";
@@ -36,7 +36,8 @@ describe("DeleteButton", () => {
         };
   const toolButton = ToolbarButtonModel.create(buttonConfig);
 
-  it("renders when disabled", () => {
+  it("renders when disabled", async () => {
+    const user = userEvent.setup();
     render(
       <Provider stores={stores}>
         <div className="app"/>
@@ -58,16 +59,15 @@ describe("DeleteButton", () => {
     expect(button).toHaveAttribute("aria-label", "Delete");
     expect(button).toHaveAttribute("aria-disabled", "true");
 
-    act(() => {
-      Modal.setAppElement(".app");
-      userEvent.click(button);
-    });
+    Modal.setAppElement(".app");
+    await user.click(button);
     expect(onSetToolActive).not.toHaveBeenCalled();
     expect(onClick).not.toHaveBeenCalled();
     expect(onSetShowDeleteTilesConfirmationAlert).toHaveBeenCalledTimes(1);
   });
 
-  it("renders when enabled", () => {
+  it("renders when enabled", async () => {
+    const user = userEvent.setup();
     render(
       <Provider stores={stores}>
         <div className="app"/>
@@ -87,16 +87,15 @@ describe("DeleteButton", () => {
     expect(button).toBeInTheDocument();
     expect(button).not.toHaveAttribute("aria-disabled");
 
-    act(() => {
-      Modal.setAppElement(".app");
-      userEvent.click(button);
-    });
+    Modal.setAppElement(".app");
+    await user.click(button);
     expect(onSetToolActive).toHaveBeenCalledTimes(1);
     expect(onClick).toHaveBeenCalledTimes(1);
     expect(onSetShowDeleteTilesConfirmationAlert).toHaveBeenCalledTimes(1);
   });
 
-  it("deletes picked-up tile on click", () => {
+  it("deletes picked-up tile on click", async () => {
+    const user = userEvent.setup();
     const testStores = specStores();
     testStores.ui.pickUpTile("tile-1", "doc-1", "Text");
 
@@ -116,21 +115,18 @@ describe("DeleteButton", () => {
       </Provider>
     );
 
-    act(() => {
-      Modal.setAppElement(".app");
-      userEvent.click(screen.getByTestId("delete-button"));
-    });
+    Modal.setAppElement(".app");
+    await user.click(screen.getByTestId("delete-button"));
     // Pick-up should be cleared
     expect(testStores.ui.pickedUpTileId).toBeUndefined();
     // Confirmation modal should appear
-    act(() => {
-      userEvent.click(screen.getByText("Delete Tile", { selector: "button" }));
-    });
+    await user.click(screen.getByText("Delete Tile", { selector: "button" }));
     expect(onDeleteTile).toHaveBeenCalledWith("tile-1");
     expect(onClick).not.toHaveBeenCalled();
   });
 
-  it("deletes tile on drag-and-drop", () => {
+  it("deletes tile on drag-and-drop", async () => {
+    const user = userEvent.setup();
     render(
       <Provider stores={stores}>
         <div className="app"/>
@@ -159,18 +155,15 @@ describe("DeleteButton", () => {
       preventDefault: jest.fn(),
     };
 
-    act(() => {
-      Modal.setAppElement(".app");
-      fireEvent.drop(button, { dataTransfer });
-    });
+    Modal.setAppElement(".app");
+    fireEvent.drop(button, { dataTransfer });
     // Confirmation modal should appear
-    act(() => {
-      userEvent.click(screen.getByText("Delete Tile", { selector: "button" }));
-    });
+    await user.click(screen.getByText("Delete Tile", { selector: "button" }));
     expect(onDeleteTile).toHaveBeenCalledWith("tile-2");
   });
 
-  it("shows confirmation alert when requested", () => {
+  it("shows confirmation alert when requested", async () => {
+    const user = userEvent.setup();
     let showAlert: () => void;
 
     function setShowAlert(show: () => void) {
@@ -198,13 +191,9 @@ describe("DeleteButton", () => {
     );
     expect(screen.getByTestId("delete-button")).toBeInTheDocument();
 
-    act(() => {
-      Modal.setAppElement(".app");
-      userEvent.click(screen.getByTestId("delete-button"));
-    });
-    act(() => {
-      userEvent.click(screen.getByText("Delete Tiles", { selector: "button" }));
-    });
+    Modal.setAppElement(".app");
+    await user.click(screen.getByTestId("delete-button"));
+    await user.click(screen.getByText("Delete Tiles", { selector: "button" }));
     expect(onDeleteSelectedTiles).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/demo/demo-creator.test.tsx
+++ b/src/components/demo/demo-creator.test.tsx
@@ -1,4 +1,4 @@
-import { act, configure, render, screen } from "@testing-library/react";
+import { configure, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 import { DemoCreatorComponent, passThroughQueryItemsFromUrl } from "./demo-creator";
@@ -99,22 +99,19 @@ describe("DemoCreator Component", () => {
     expect(screen.getAllByRole("heading")[0]).toHaveTextContent("Demo Creator");
   });
 
-  it("can change classes and problems", () => {
+  it("can change classes and problems", async () => {
+    const user = userEvent.setup();
     render(<DemoCreatorComponent stores={stores} />);
 
     // test changing classes
     expect(screen.getAllByRole("link")[0])
       .toHaveAttribute("href", "?appMode=demo&fakeClass=1&fakeUser=student:1&problem=1.1");
-    act(() => {
-      userEvent.selectOptions(screen.getByTestId("class-select"), "2");
-    });
+    await user.selectOptions(screen.getByTestId("class-select"), "2");
     expect(screen.getAllByRole("link")[0])
       .toHaveAttribute("href", "?appMode=demo&fakeClass=2&fakeUser=student:1&problem=1.1");
 
     // test changing problems
-    act(() => {
-      userEvent.selectOptions(screen.getByTestId("problem-select"), "1.2");
-    });
+    await user.selectOptions(screen.getByTestId("problem-select"), "1.2");
     expect(screen.getAllByRole("link")[0])
       .toHaveAttribute("href", "?appMode=demo&fakeClass=2&fakeUser=student:1&problem=1.2");
   });

--- a/src/components/document/document-file-menu.test.tsx
+++ b/src/components/document/document-file-menu.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 import { Provider } from "mobx-react";
@@ -76,12 +76,11 @@ describe("DocumentFileMenu", () => {
       expect(screen.getByText("File")).toBeInTheDocument();
     });
 
-    it("shows menu items when clicked", () => {
+    it("shows menu items when clicked", async () => {
+      const user = userEvent.setup();
       renderFileMenu();
 
-      act(() => {
-        userEvent.click(screen.getByTestId("document-file-menu-header"));
-      });
+      await user.click(screen.getByTestId("document-file-menu-header"));
 
       expect(screen.getByTestId("document-file-menu-list")).toBeInTheDocument();
       expect(screen.getByTestId("list-item-icon-new-workspace")).toBeInTheDocument();
@@ -90,82 +89,64 @@ describe("DocumentFileMenu", () => {
       expect(screen.getByTestId("list-item-icon-delete-workspace")).toBeInTheDocument();
     });
 
-    it("calls onNewDocument when New menu item is clicked", () => {
+    it("calls onNewDocument when New menu item is clicked", async () => {
+      const user = userEvent.setup();
       renderFileMenu();
 
-      act(() => {
-        userEvent.click(screen.getByTestId("document-file-menu-header"));
-      });
-
-      act(() => {
-        userEvent.click(screen.getByTestId("list-item-icon-new-workspace"));
-      });
+      await user.click(screen.getByTestId("document-file-menu-header"));
+      await user.click(screen.getByTestId("list-item-icon-new-workspace"));
 
       expect(onNewDocument).toHaveBeenCalledTimes(1);
     });
 
-    it("calls onOpenDocument when Open menu item is clicked", () => {
+    it("calls onOpenDocument when Open menu item is clicked", async () => {
+      const user = userEvent.setup();
       renderFileMenu();
 
-      act(() => {
-        userEvent.click(screen.getByTestId("document-file-menu-header"));
-      });
-
-      act(() => {
-        userEvent.click(screen.getByTestId("list-item-icon-open-workspace"));
-      });
+      await user.click(screen.getByTestId("document-file-menu-header"));
+      await user.click(screen.getByTestId("list-item-icon-open-workspace"));
 
       expect(onOpenDocument).toHaveBeenCalledTimes(1);
       expect(onOpenDocument).toHaveBeenCalledWith(document);
     });
 
-    it("calls onCopyDocument when Make a copy menu item is clicked", () => {
+    it("calls onCopyDocument when Make a copy menu item is clicked", async () => {
+      const user = userEvent.setup();
       renderFileMenu();
 
-      act(() => {
-        userEvent.click(screen.getByTestId("document-file-menu-header"));
-      });
-
-      act(() => {
-        userEvent.click(screen.getByTestId("list-item-icon-copy-workspace"));
-      });
+      await user.click(screen.getByTestId("document-file-menu-header"));
+      await user.click(screen.getByTestId("list-item-icon-copy-workspace"));
 
       expect(onCopyDocument).toHaveBeenCalledTimes(1);
       expect(onCopyDocument).toHaveBeenCalledWith(document);
     });
 
-    it("calls onDeleteDocument when Delete menu item is clicked", () => {
+    it("calls onDeleteDocument when Delete menu item is clicked", async () => {
+      const user = userEvent.setup();
       renderFileMenu();
 
-      act(() => {
-        userEvent.click(screen.getByTestId("document-file-menu-header"));
-      });
-
-      act(() => {
-        userEvent.click(screen.getByTestId("list-item-icon-delete-workspace"));
-      });
+      await user.click(screen.getByTestId("document-file-menu-header"));
+      await user.click(screen.getByTestId("list-item-icon-delete-workspace"));
 
       expect(onDeleteDocument).toHaveBeenCalledTimes(1);
       expect(onDeleteDocument).toHaveBeenCalledWith(document);
     });
 
-    it("disables New menu item when onNewDocument is not provided", () => {
+    it("disables New menu item when onNewDocument is not provided", async () => {
+      const user = userEvent.setup();
       renderFileMenu({ onNewDocument: undefined });
 
-      act(() => {
-        userEvent.click(screen.getByTestId("document-file-menu-header"));
-      });
+      await user.click(screen.getByTestId("document-file-menu-header"));
 
       const newItem = screen.getByTestId("list-item-icon-new-workspace");
       expect(newItem).toHaveClass("disabled");
     });
 
-    it("disables Delete menu item when isDeleteDisabled is true", () => {
+    it("disables Delete menu item when isDeleteDisabled is true", async () => {
+      const user = userEvent.setup();
       renderFileMenu({ isDeleteDisabled: true });
 
-      act(() => {
-        userEvent.click(screen.getByTestId("document-file-menu-header"));
-      });
+      await user.click(screen.getByTestId("document-file-menu-header"));
 
       const deleteItem = screen.getByTestId("list-item-icon-delete-workspace");
       expect(deleteItem).toHaveClass("disabled");
@@ -221,71 +202,75 @@ describe("DocumentFileMenu", () => {
       return { stores, document };
     };
 
-    const openMenu = async () => {
-      await act(async () => {
-        userEvent.click(screen.getByTestId("document-file-menu-header"));
-      });
+    const openMenu = async (user: ReturnType<typeof userEvent.setup>) => {
+      await user.click(screen.getByTestId("document-file-menu-header"));
     };
 
     it("does not show Group Doc when groupDocumentsEnabled is false", async () => {
+      const user = userEvent.setup();
       renderDocumentFileMenu({
         autoAssignStudentsToIndividualGroups: false,
         groupDocumentsEnabled: false,
         currentGroupId: "group-1"
       });
 
-      await openMenu();
+      await openMenu(user);
 
       expect(screen.queryByTestId("list-item-icon-open-group-doc")).not.toBeInTheDocument();
     });
 
     it("does not show Group Doc when groupDocumentsEnabled is undefined", async () => {
+      const user = userEvent.setup();
       renderDocumentFileMenu({
         autoAssignStudentsToIndividualGroups: false,
         currentGroupId: "group-1"
       });
 
-      await openMenu();
+      await openMenu(user);
 
       expect(screen.queryByTestId("list-item-icon-open-group-doc")).not.toBeInTheDocument();
     });
 
     it("does not show Group Doc when groups are not permitted", async () => {
+      const user = userEvent.setup();
       renderDocumentFileMenu({
         autoAssignStudentsToIndividualGroups: true,
         currentGroupId: "group-1",
         groupDocumentsEnabled: true
       });
 
-      await openMenu();
+      await openMenu(user);
 
       expect(screen.queryByTestId("list-item-icon-open-group-doc")).not.toBeInTheDocument();
     });
 
     it("does not show Group Doc when user is not in a group", async () => {
+      const user = userEvent.setup();
       renderDocumentFileMenu({
         autoAssignStudentsToIndividualGroups: false,
         groupDocumentsEnabled: true
       });
 
-      await openMenu();
+      await openMenu(user);
 
       expect(screen.queryByTestId("list-item-icon-open-group-doc")).not.toBeInTheDocument();
     });
 
     it("shows Group Doc when all conditions are met", async () => {
+      const user = userEvent.setup();
       renderDocumentFileMenu({
         autoAssignStudentsToIndividualGroups: false,
         currentGroupId: "group-1",
         groupDocumentsEnabled: true
       });
 
-      await openMenu();
+      await openMenu(user);
 
       expect(screen.getByTestId("list-item-icon-open-group-doc")).toBeInTheDocument();
     });
 
     it("calls onOpenGroupDocument when Group Doc is clicked", async () => {
+      const user = userEvent.setup();
       const onOpenGroupDocument = jest.fn();
       const { document } = renderDocumentFileMenu({
         autoAssignStudentsToIndividualGroups: false,
@@ -294,11 +279,9 @@ describe("DocumentFileMenu", () => {
         onOpenGroupDocument
       });
 
-      await openMenu();
+      await openMenu(user);
 
-      await act(async () => {
-        userEvent.click(screen.getByTestId("list-item-icon-open-group-doc"));
-      });
+      await user.click(screen.getByTestId("list-item-icon-open-group-doc"));
 
       expect(onOpenGroupDocument).toHaveBeenCalledWith(document);
     });

--- a/src/components/four-up.test.tsx
+++ b/src/components/four-up.test.tsx
@@ -82,7 +82,8 @@ describe("Four Up Component", () => {
     expect(container.querySelectorAll(".member")).toHaveLength(1);
   });
 
-  it("renders group members", () => {
+  it("renders group members", async () => {
+    const ue = userEvent.setup();
     const user = UserModel.create({
       id: "3",
       name: "User 3"
@@ -174,8 +175,8 @@ describe("Four Up Component", () => {
     expect(memberList[2].textContent).toBe("**");
 
     // TODO: figure out how to add coverage for window mouse events setup by the splitter handlers
-    userEvent.click(screen.getByTestId("4up-horizontal-splitter"));
-    userEvent.click(screen.getByTestId("4up-vertical-splitter"));
-    userEvent.click(screen.getByTestId("4up-center"));
+    await ue.click(screen.getByTestId("4up-horizontal-splitter"));
+    await ue.click(screen.getByTestId("4up-vertical-splitter"));
+    await ue.click(screen.getByTestId("4up-center"));
   });
 });

--- a/src/components/student-menu-container.test.tsx
+++ b/src/components/student-menu-container.test.tsx
@@ -35,7 +35,7 @@ describe("StudentMenuContainer", () => {
     expect(screen.getByTestId("user-list")).toBeInTheDocument();
     expect(screen.getByTestId("list-item-log-out")).toBeInTheDocument();
 
-    // In Jest 30/jsdom 25, window.location is non-configurable so we cannot
+    // In Jest 30/jsdom, window.location is non-configurable so we cannot
     // mock location.assign directly. The call to location.assign triggers a
     // jsdom "not implemented" error which we suppress here.
     await jestSpyConsole("error", async () => {

--- a/src/components/student-menu-container.test.tsx
+++ b/src/components/student-menu-container.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 import { Provider } from "mobx-react";
@@ -17,6 +17,7 @@ jest.mock("../utilities/auth-utils", () => ({
 describe("StudentMenuContainer", () => {
 
   it("renders custom select with logout link", async () => {
+    const ue = userEvent.setup();
     const user = UserModel.create({
       id: "1",
       name: "Test User"
@@ -30,19 +31,15 @@ describe("StudentMenuContainer", () => {
     );
     expect(screen.getByTestId("user-header")).toBeInTheDocument();
 
-    act(() => {
-      userEvent.click(screen.getByTestId("user-header"));
-    });
+    await ue.click(screen.getByTestId("user-header"));
     expect(screen.getByTestId("user-list")).toBeInTheDocument();
     expect(screen.getByTestId("list-item-log-out")).toBeInTheDocument();
 
     // In Jest 30/jsdom 25, window.location is non-configurable so we cannot
     // mock location.assign directly. The call to location.assign triggers a
     // jsdom "not implemented" error which we suppress here.
-    await jestSpyConsole("error", () => {
-      act(() => {
-        userEvent.click(screen.getByTestId("list-item-log-out"));
-      });
+    await jestSpyConsole("error", async () => {
+      await ue.click(screen.getByTestId("list-item-log-out"));
     });
     // Verify getConfirmLogoutUrl was called with undefined (no return URL)
     // since user.standaloneAuthUser is not set

--- a/src/components/tiles/text/text-tile.test.tsx
+++ b/src/components/tiles/text/text-tile.test.tsx
@@ -27,9 +27,10 @@ describe("TextToolComponent", () => {
     expect(content.editor).toBeDefined();
   });
 
-  it("renders its toolbar with heading button", () => {
+  it("renders its toolbar with heading button", async () => {
+    const user = userEvent.setup();
     specTextTile({});
-    userEvent.click(screen.getByTestId("ccrte-editor"));
+    await user.click(screen.getByTestId("ccrte-editor"));
     const buttons = screen.getAllByRole("button");
     const headingButton = buttons.find(b => b.getAttribute("aria-label") === "Heading");
     expect(headingButton).toBeDefined();

--- a/src/components/toolbar-button.test.tsx
+++ b/src/components/toolbar-button.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 import { ToolbarButtonModel } from "../models/tiles/toolbar-button";
@@ -52,7 +52,8 @@ describe("ToolButtonComponent", () => {
     expect(onSetToolActive).not.toHaveBeenCalled();
   });
 
-  it("does not call click handler on disabled tool", () => {
+  it("does not call click handler on disabled tool", async () => {
+    const user = userEvent.setup();
     const toolButton = ToolbarButtonModel.create({
       id: "delete",
       title: "Delete",
@@ -73,13 +74,12 @@ describe("ToolButtonComponent", () => {
         />
     );
     expect(screen.getByTestId("tool-delete")).toBeInTheDocument();
-    act(() => {
-      userEvent.click(screen.getByTestId("tool-delete"));
-    });
+    await user.click(screen.getByTestId("tool-delete"));
     expect(onClick).toHaveBeenCalledTimes(0);
   });
 
-  it("renders enabled text tool", () => {
+  it("renders enabled text tool", async () => {
+    const user = userEvent.setup();
     const toolButton = ToolbarButtonModel.create({
       id: "Text",
       isDefault: false,
@@ -105,15 +105,11 @@ describe("ToolButtonComponent", () => {
     expect(element).toHaveAttribute("title", "Text");
     expect(element).toHaveAttribute("aria-label", "Text");
     expect(element).not.toHaveAttribute("aria-disabled");
-    act(() => {
-      userEvent.click(screen.getByTestId("tool-text"));
-    });
+    await user.click(screen.getByTestId("tool-text"));
     expect(onSetToolActive).toHaveBeenCalledTimes(2);
     expect(onClick).toHaveBeenCalledTimes(1);
-    act(() => {
-      fireEvent.dragStart(screen.getByTestId("tool-text"));
-      fireEvent.dragEnd(screen.getByTestId("tool-text"));
-    });
+    fireEvent.dragStart(screen.getByTestId("tool-text"));
+    fireEvent.dragEnd(screen.getByTestId("tool-text"));
     expect(onDragStart).toHaveBeenCalledTimes(1);
   });
 

--- a/src/components/toolbar.test.tsx
+++ b/src/components/toolbar.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "mobx-react";
 import React from "react";
@@ -47,7 +47,8 @@ describe("ToolbarComponent", () => {
     }
   ];
 
-  it("renders successfully", () => {
+  it("renders successfully", async () => {
+    const user = userEvent.setup();
     render(
       <ModalProvider>
         <Provider stores={stores}>
@@ -57,11 +58,9 @@ describe("ToolbarComponent", () => {
     );
     expect(screen.getByTestId("toolbar")).toBeInTheDocument();
 
-    act(() => {
-      userEvent.click(screen.getByTestId("tool-select"));
-      userEvent.click(screen.getByTestId("tool-text"));
-      userEvent.click(screen.getByTestId("delete-button"));
-    });
+    await user.click(screen.getByTestId("tool-select"));
+    await user.click(screen.getByTestId("tool-text"));
+    await user.click(screen.getByTestId("delete-button"));
 
     // act(() => {
     //   fireEvent.dragStart(screen.getByTestId("tool-text"), new DragEvent('dragstart'));

--- a/src/plugins/graph/components/graph-component.test.tsx
+++ b/src/plugins/graph/components/graph-component.test.tsx
@@ -39,7 +39,7 @@ describe.skip("Graph", () => {
   });
 
   it.skip("can switch to dot plot", async () => {
-    const user = userEvent;
+    const user = userEvent.setup();
     const data = DataSet.create();
     data.addAttributeWithID({ name: "xVariable" });
     data.addAttributeWithID({ name: "yVariable" });

--- a/src/plugins/starter/starter-tile.test.tsx
+++ b/src/plugins/starter/starter-tile.test.tsx
@@ -59,13 +59,15 @@ describe("StarterToolComponent", () => {
     expect(await findByText("New Text")).toBeInTheDocument();
   });
 
-  it("updates the model when the user types", () => {
+  it("updates the model when the user types", async () => {
+    const user = userEvent.setup();
     const {getByRole, getByText} =
       render(<StarterToolComponent  {...defaultProps} {...{model}}></StarterToolComponent>);
     expect(getByText("New Text")).toBeInTheDocument();
 
     const textBox = getByRole("textbox");
-    userEvent.type(textBox, "{selectall}{del}Typed Text");
+    await user.clear(textBox);
+    await user.type(textBox, "Typed Text");
 
     expect(textBox).toHaveValue("Typed Text");
     expect(content.text).toBe("Typed Text");


### PR DESCRIPTION
## Summary

Migrates CLUE off `@testing-library/user-event@13` to v14. This is shipped as a separate, independently reviewable piece of the broader React 18 upgrade work tracked in [CLUE-489](https://concord-consortium.atlassian.net/browse/CLUE-489) — `user-event` v14 doesn't depend on React 18, so we can land it now to shrink the eventual React 18 PR.

The v14 changes touch every test that uses `userEvent`:
- All interactions are now async — added `await`.
- Switched to the `userEvent.setup()` factory pattern.
- Tests that called `userEvent` are now `async`.
- Dropped the `act(() => { userEvent.X(...) })` wrappers that v13's sync events required (v14's awaited interactions wrap in `act` themselves).

13 test files migrated. One v14-specific syntax change in `starter-tile.test.tsx`: replaced the v13 `"{selectall}{del}"` prefix with a `user.clear()` call — the `{selectall}` key syntax was removed in v14.

## Test plan

- [x] `npm test` against the 13 migrated suites passes with the same counts as the v13 baseline (61 passed, 4 skipped, 1 suite `describe.skip`'d).
- [x] CI green.

## Notes

- This PR targets `CLUE-489-remove-netlify-cms` (#2854) so the diff is scoped to just the user-event work. GitHub will auto-retarget to `master` once #2854 lands.
- The branch is part of a stacked chain: `master` ← `CLUE-489-remove-netlify-cms` ← **`CLUE-489-user-event-v14`** ← `CLUE-489-react-upgrade` (next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CLUE-489]: https://concord-consortium.atlassian.net/browse/CLUE-489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ