### PR TITLE
chore: dataflow focus trap and keyboard nav (CLUE-455)

### DIFF
--- a/cypress/e2e/functional/tile_tests/dataflow_tile_keyboard_spec.js
+++ b/cypress/e2e/functional/tile_tests/dataflow_tile_keyboard_spec.js
@@ -1,0 +1,335 @@
+import ClueCanvas from '../../../support/elements/common/cCanvas';
+import DataflowToolTile from '../../../support/elements/tile/DataflowToolTile';
+
+const clueCanvas = new ClueCanvas;
+const dataflowToolTile = new DataflowToolTile;
+
+context('Dataflow keyboard accessibility (CLUE-455)', function () {
+  beforeEach(function () {
+    cy.visit('/?appMode=qa&fakeClass=5&fakeUser=student:5&qaGroup=5&unit=qa&noStorage');
+    cy.waitForLoad();
+    clueCanvas.addTile('dataflow');
+  });
+
+  function selectDataflowTile() {
+    dataflowToolTile.getDataflowTile().click();
+    cy.realPress('Enter');
+    cy.focused().should('have.class', 'editable-tile-title-text');
+  }
+
+  const focusOrder = [
+    ['data-testid', 'serial-icon'],
+    ['data-testid', 'rate-select'],
+    ['data-testid', 'record-data-button'],
+    ['data-testid', 'zoom-in-button'],
+    ['data-testid', 'zoom-out-button'],
+    ['data-testid', 'add-sensor-button'],
+    ['class', 'data-set-view'],
+    ['class', 'tool-tile-resize-handle-wrapper'],
+  ];
+
+  function assertFocused([attr, value]) {
+    if (attr === 'class') cy.focused().should('have.class', value);
+    else cy.focused().should('have.attr', attr, value);
+  }
+
+  it('Tab cycles through every focus slot of an empty Dataflow tile in expected order', function () {
+    selectDataflowTile();
+
+    focusOrder.forEach((entry) => {
+      cy.realPress('Tab');
+      assertFocused(entry);
+    });
+
+    // One more Tab wraps to the title.
+    cy.realPress('Tab');
+    cy.focused().should('have.class', 'editable-tile-title-text');
+  });
+
+  it('Shift+Tab cycles in reverse through every focus slot of an empty Dataflow tile', function () {
+    selectDataflowTile();
+
+    [...focusOrder].reverse().forEach((entry) => {
+      cy.realPress(['Shift', 'Tab']);
+      assertFocused(entry);
+    });
+
+    // One more Shift+Tab wraps back to the title.
+    cy.realPress(['Shift', 'Tab']);
+    cy.focused().should('have.class', 'editable-tile-title-text');
+  });
+
+  it('User can build and connect a 3-node program with the keyboard alone', function () {
+    selectDataflowTile();
+    dataflowToolTile.getCreateNodeButton('number').focus();
+
+    cy.realPress('Enter'); // Add first block (Number)
+    cy.realPress('ArrowDown');
+    cy.realPress('ArrowDown');
+    cy.realPress('ArrowDown');
+    cy.realPress('Enter'); // Add second (Math)
+    cy.realPress('ArrowDown');
+    cy.realPress('ArrowDown');
+    cy.realPress('ArrowDown');
+    cy.realPress('ArrowDown');
+    cy.realPress('Enter'); // Add third (Demo Output)
+
+    dataflowToolTile.getDataflowTile().find('.editor-graph-container .node')
+      .should('have.length', 3);
+
+    // Connect Number → Math
+    dataflowToolTile.getDataflowTile()
+      .find('.editor-graph-container .node.number .output').focus();
+    cy.focused().should('have.attr', 'data-socket-side', 'output');
+
+    cy.realPress('Enter'); // begin connecting mode
+    cy.focused().should('have.attr', 'data-socket-side', 'input');
+
+    cy.realPress('Enter'); // commit on first candidate (Math.num1 by reading order)
+    dataflowToolTile.getDataflowTile().find('.dataflow-connection')
+      .should('have.length', 1);
+
+    // Connect Math → Demo Output
+    dataflowToolTile.getDataflowTile()
+      .find('.editor-graph-container .node.math .output').focus();
+    cy.focused().should('have.attr', 'data-socket-side', 'output');
+
+    cy.realPress('Enter');
+    cy.focused().should('have.attr', 'data-socket-side', 'input');
+
+    cy.realPress('Enter'); // commit (Demo Output.nodeValue is the only candidate)
+    dataflowToolTile.getDataflowTile().find('.dataflow-connection')
+      .should('have.length', 2);
+  });
+
+  it('Escape during connecting mode cancels and restores focus to the source socket', function () {
+    selectDataflowTile();
+    dataflowToolTile.getCreateNodeButton('number').click();
+    dataflowToolTile.getCreateNodeButton('demo-output').click();
+
+    dataflowToolTile.getDataflowTile()
+      .find('.editor-graph-container .node.number .output').focus();
+    cy.realPress('Enter'); // begin connecting mode
+    cy.focused().should('have.attr', 'data-socket-side', 'input');
+
+    cy.realPress('Escape');
+    cy.focused().should('have.attr', 'data-socket-side', 'output');
+    cy.focused().should('have.attr', 'data-node-id');
+
+    // No connection was committed.
+    dataflowToolTile.getDataflowTile().find('.dataflow-connection').should('not.exist');
+  });
+
+  it('Tab moves focus from one block to the next, skipping internal controls', function () {
+    selectDataflowTile();
+    dataflowToolTile.getCreateNodeButton('number').click();
+    dataflowToolTile.getCreateNodeButton('math').click();
+    dataflowToolTile.getCreateNodeButton('demo-output').click();
+
+    // Land focus on the first block container.
+    dataflowToolTile.getDataflowTile()
+      .find('.editor-graph-container .node.number').focus();
+    cy.focused().invoke('attr', 'aria-label').should('match', /^Number block:/);
+
+    cy.realPress('Tab');
+    cy.focused().invoke('attr', 'aria-label').should('match', /^Math block:/);
+
+    cy.realPress('Tab');
+    cy.focused().invoke('attr', 'aria-label').should('match', /^Demo Output block:/);
+
+    cy.realPress(['Shift', 'Tab']);
+    cy.focused().invoke('attr', 'aria-label').should('match', /^Math block:/);
+  });
+
+  it('Arrow keys cycle through a block\'s interactive elements within the focused block', function () {
+    selectDataflowTile();
+    dataflowToolTile.getCreateNodeButton('number').click();
+
+    // The Number block's interactive descendants in DOM order are:
+    //   close-node-button, node-name-input, output socket (value),
+    //   number-input (value control), graph-button (plot toggle).
+    dataflowToolTile.getDataflowTile()
+      .find('.editor-graph-container .node.number').focus();
+
+    // ArrowDown on the block container enters the cycle on the first interactive.
+    cy.realPress('ArrowDown');
+    cy.focused().should('have.class', 'close-node-button');
+
+    cy.realPress('ArrowDown');
+    cy.focused().should('have.class', 'node-name-input');
+
+    // Skip the rove-out-of-text-input behavior on this stop with ArrowDown
+    // (ArrowLeft/Right would move the caret instead).
+    cy.realPress('ArrowDown');
+    cy.focused().should('have.attr', 'data-socket-side', 'output');
+
+    cy.realPress('ArrowDown');
+    cy.focused().should('have.class', 'number-input');
+
+    cy.realPress('ArrowDown');
+    cy.focused().should('have.class', 'graph-button');
+
+    // Wraps back to the first interactive — focus stays inside this Number block.
+    cy.realPress('ArrowDown');
+    cy.focused().should('have.class', 'close-node-button');
+
+    // ArrowUp at the first interactive wraps to the last interactive (still inside the same block).
+    cy.realPress('ArrowUp');
+    cy.focused().should('have.class', 'graph-button');
+  });
+
+  it('Arrow keys inside a text input move the caret instead of cycling out', function () {
+    selectDataflowTile();
+    dataflowToolTile.getCreateNodeButton('number').click();
+
+    dataflowToolTile.getDataflowTile()
+      .find('.editor-graph-container .node.number .node-name-input')
+      .focus()
+      .invoke('val', 'Hello')
+      .then($input => $input.get(0).setSelectionRange(5, 5));
+
+    // ArrowLeft inside a text input is left to native handling so the caret moves.
+    cy.realPress('ArrowLeft');
+    cy.focused().should('have.class', 'node-name-input');
+    cy.focused().then($input => {
+      expect($input.get(0).selectionStart).to.equal(4);
+    });
+  });
+
+  it('Enter on a focused node toggles its selected state', function () {
+    dataflowToolTile.getCreateNodeButton('number').click();
+
+    dataflowToolTile.getDataflowTile()
+      .find('.editor-graph-container .node.number')
+      .focus()
+      .should('not.have.class', 'selected');
+
+    cy.realPress('Enter');
+    dataflowToolTile.getDataflowTile()
+      .find('.editor-graph-container .node.number')
+      .should('have.class', 'selected');
+  });
+
+  it('Arrow keys cycle through candidate inputs during connecting mode', function () {
+    selectDataflowTile();
+    dataflowToolTile.getCreateNodeButton('number').click();
+    dataflowToolTile.getCreateNodeButton('math').click();
+    dataflowToolTile.getCreateNodeButton('demo-output').click();
+
+    dataflowToolTile.getDataflowTile()
+      .find('.editor-graph-container .node.number .output').focus();
+    cy.realPress('Enter'); // begin connecting mode
+
+    // Candidates are sorted by reading order, then by input declaration order
+    // within a node: Math.num1, Math.num2, DemoOutput.nodeValue.
+    cy.focused().should('have.attr', 'data-socket-key', 'num1');
+
+    cy.realPress('ArrowDown');
+    cy.focused().should('have.attr', 'data-socket-key', 'num2');
+
+    cy.realPress('ArrowDown');
+    cy.focused().should('have.attr', 'data-socket-key', 'nodeValue');
+
+    cy.realPress('ArrowDown'); // wraps back to first candidate
+    cy.focused().should('have.attr', 'data-socket-key', 'num1');
+
+    cy.realPress('ArrowUp'); // wraps backward
+    cy.focused().should('have.attr', 'data-socket-key', 'nodeValue');
+  });
+
+  it('Delete button on a node removes the node when activated by keyboard', function () {
+    dataflowToolTile.getCreateNodeButton('number').click();
+    dataflowToolTile.getDataflowTile()
+      .find('.editor-graph-container .node').should('have.length', 1);
+
+    dataflowToolTile.getDataflowTile()
+      .find('.editor-graph-container .node.number .close-node-button').focus();
+    cy.realPress('Enter');
+
+    dataflowToolTile.getDataflowTile()
+      .find('.editor-graph-container .node').should('not.exist');
+  });
+
+  it('Block name is editable from the keyboard', function () {
+    dataflowToolTile.getCreateNodeButton('number').click();
+
+    dataflowToolTile.getDataflowTile()
+      .find('.editor-graph-container .node.number .node-name-input')
+      .focus()
+      .clear()
+      .type('My Custom Number');
+    cy.realPress('Enter'); // blurs the input, persisting the new name
+
+    dataflowToolTile.getDataflowTile()
+      .find('.editor-graph-container .node.number .node-name-input')
+      .should('have.value', 'My Custom Number');
+  });
+
+  context('Live-region announcements', function () {
+    beforeEach(function () {
+      selectDataflowTile();
+    });
+
+    function announcer() {
+      return dataflowToolTile.getDataflowTile()
+        .find('[data-testid="dataflow-announcer"]');
+    }
+
+    it('announces "Selected …" when Enter selects a focused block', function () {
+      dataflowToolTile.getCreateNodeButton('number').click();
+      dataflowToolTile.getDataflowTile()
+        .find('.editor-graph-container .node.number').focus();
+      cy.realPress('Enter');
+
+      announcer().should('contain.text', 'Selected Number block Number 1');
+    });
+
+    it('announces "Connecting from …" when Enter starts a connection', function () {
+      dataflowToolTile.getCreateNodeButton('number').click();
+      dataflowToolTile.getCreateNodeButton('demo-output').click();
+
+      dataflowToolTile.getDataflowTile()
+        .find('.editor-graph-container .node.number .output').focus();
+      cy.realPress('Enter');
+
+      announcer()
+        .should('contain.text', 'Connecting from')
+        .and('contain.text', 'Use arrow keys');
+    });
+
+    it('announces "No compatible target sockets" when nothing accepts the source', function () {
+      // Only a Number block exists, so no input sockets are reachable.
+      dataflowToolTile.getCreateNodeButton('number').click();
+
+      dataflowToolTile.getDataflowTile()
+        .find('.editor-graph-container .node.number .output').focus();
+      cy.realPress('Enter');
+
+      announcer().should('contain.text', 'No compatible target sockets');
+    });
+
+    it('announces "Connected …" when a connection is committed', function () {
+      dataflowToolTile.getCreateNodeButton('number').click();
+      dataflowToolTile.getCreateNodeButton('demo-output').click();
+
+      dataflowToolTile.getDataflowTile()
+        .find('.editor-graph-container .node.number .output').focus();
+      cy.realPress('Enter'); // begin connecting mode
+      cy.realPress('Enter'); // commit on first candidate
+
+      announcer().should('contain.text', 'Connected Number to Demo Output');
+    });
+
+    it('announces "Cancelled connection" when Escape exits connecting mode', function () {
+      dataflowToolTile.getCreateNodeButton('number').click();
+      dataflowToolTile.getCreateNodeButton('demo-output').click();
+
+      dataflowToolTile.getDataflowTile()
+        .find('.editor-graph-container .node.number .output').focus();
+      cy.realPress('Enter'); // begin connecting mode
+      cy.realPress('Escape');
+
+      announcer().should('contain.text', 'Cancelled connection');
+    });
+  });
+});

--- a/cypress/e2e/functional/tile_tests/dataflow_tool_spec.js
+++ b/cypress/e2e/functional/tile_tests/dataflow_tool_spec.js
@@ -579,7 +579,7 @@ context('Dataflow Tool Tile', function () {
     dataflowToolTile.getNodeTitle().invoke("val").should("include", "Timer (on/off) 1");
     dataflowToolTile.getCreateNodeButton(nodes[1]).click();
     dataflowToolTile.getNode(nodes[1]).should("exist");
-    dataflowToolTile.getNode("demo-output").click(50, 10)
+    dataflowToolTile.getNode("timer").click(50, 10)
       .trigger("pointerdown", 50, 10)
       .trigger("pointermove", dragXDestination, dragYDestination, { force: true })
       .trigger("pointerup", dragXDestination, dragYDestination, { force: true });

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@chakra-ui/react": "^1.8.9",
         "@codemirror/lang-json": "^6.0.2",
-        "@concord-consortium/accessibility-tools": "git+https://github.com/concord-consortium/accessibility-tools#main",
+        "@concord-consortium/accessibility-tools": "0.0.1-pre.1",
         "@concord-consortium/codap-formulas-react17": "^1.1.0",
         "@concord-consortium/compute-engine": "^0.12.3-cc.2",
         "@concord-consortium/diagram-view": "1.0.2",
@@ -2909,8 +2909,9 @@
       }
     },
     "node_modules/@concord-consortium/accessibility-tools": {
-      "version": "0.0.1-pre.0",
-      "resolved": "git+ssh://git@github.com/concord-consortium/accessibility-tools.git#7d8569944baba5ee085978fd8de88cc413c28464",
+      "version": "0.0.1-pre.1",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/accessibility-tools/-/accessibility-tools-0.0.1-pre.1.tgz",
+      "integrity": "sha512-EcINxZBnpzbzBzE+eCJFJN7tbu9e+Qqavq/x5IZ/9JSjsMXTFFLyR7zoanLO3n+OMTsZ7S/OXVEVATYI1RdrEg==",
       "license": "MIT",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
@@ -30864,8 +30865,9 @@
       }
     },
     "@concord-consortium/accessibility-tools": {
-      "version": "git+ssh://git@github.com/concord-consortium/accessibility-tools.git#7d8569944baba5ee085978fd8de88cc413c28464",
-      "from": "@concord-consortium/accessibility-tools@git+https://github.com/concord-consortium/accessibility-tools#main",
+      "version": "0.0.1-pre.1",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/accessibility-tools/-/accessibility-tools-0.0.1-pre.1.tgz",
+      "integrity": "sha512-EcINxZBnpzbzBzE+eCJFJN7tbu9e+Qqavq/x5IZ/9JSjsMXTFFLyR7zoanLO3n+OMTsZ7S/OXVEVATYI1RdrEg==",
       "requires": {
         "@heroicons/react": "^2.2.0",
         "dom-accessibility-api": "^0.7.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@chakra-ui/react": "^1.8.9",
         "@codemirror/lang-json": "^6.0.2",
-        "@concord-consortium/accessibility-tools": "0.0.1-pre.0",
+        "@concord-consortium/accessibility-tools": "git+https://github.com/concord-consortium/accessibility-tools#main",
         "@concord-consortium/codap-formulas-react17": "^1.1.0",
         "@concord-consortium/compute-engine": "^0.12.3-cc.2",
         "@concord-consortium/diagram-view": "1.0.2",
@@ -2910,8 +2910,7 @@
     },
     "node_modules/@concord-consortium/accessibility-tools": {
       "version": "0.0.1-pre.0",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/accessibility-tools/-/accessibility-tools-0.0.1-pre.0.tgz",
-      "integrity": "sha512-Ly3ubyjr3cTIGRUdPwLNtJvFN6B2LBj6G0Sk3WJyThyI98fTJn5VPJCQH2JnKrWFtKOd0DR24KR0ev9zFi0IXg==",
+      "resolved": "git+ssh://git@github.com/concord-consortium/accessibility-tools.git#7d8569944baba5ee085978fd8de88cc413c28464",
       "license": "MIT",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
@@ -30865,9 +30864,8 @@
       }
     },
     "@concord-consortium/accessibility-tools": {
-      "version": "0.0.1-pre.0",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/accessibility-tools/-/accessibility-tools-0.0.1-pre.0.tgz",
-      "integrity": "sha512-Ly3ubyjr3cTIGRUdPwLNtJvFN6B2LBj6G0Sk3WJyThyI98fTJn5VPJCQH2JnKrWFtKOd0DR24KR0ev9zFi0IXg==",
+      "version": "git+ssh://git@github.com/concord-consortium/accessibility-tools.git#7d8569944baba5ee085978fd8de88cc413c28464",
+      "from": "@concord-consortium/accessibility-tools@git+https://github.com/concord-consortium/accessibility-tools#main",
       "requires": {
         "@heroicons/react": "^2.2.0",
         "dom-accessibility-api": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -251,7 +251,7 @@
   "dependencies": {
     "@chakra-ui/react": "^1.8.9",
     "@codemirror/lang-json": "^6.0.2",
-    "@concord-consortium/accessibility-tools": "git+https://github.com/concord-consortium/accessibility-tools#main",
+    "@concord-consortium/accessibility-tools": "0.0.1-pre.1",
     "@concord-consortium/codap-formulas-react17": "^1.1.0",
     "@concord-consortium/compute-engine": "^0.12.3-cc.2",
     "@concord-consortium/diagram-view": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -251,7 +251,7 @@
   "dependencies": {
     "@chakra-ui/react": "^1.8.9",
     "@codemirror/lang-json": "^6.0.2",
-    "@concord-consortium/accessibility-tools": "0.0.1-pre.0",
+    "@concord-consortium/accessibility-tools": "git+https://github.com/concord-consortium/accessibility-tools#main",
     "@concord-consortium/codap-formulas-react17": "^1.1.0",
     "@concord-consortium/compute-engine": "^0.12.3-cc.2",
     "@concord-consortium/diagram-view": "1.0.2",

--- a/src/components/tiles/tile-api.tsx
+++ b/src/components/tiles/tile-api.tsx
@@ -21,6 +21,14 @@ export interface ITileFocusableElements {
   contentElement?: HTMLElement;  // main content area (editor, grid, canvas, etc.)
   titleElement?: HTMLElement;    // tile title input if visible
   focusContent?: () => boolean;  // custom focus method for content (e.g., Slate's ReactEditor.focus)
+  // Optional secondary controls bar above the main content (e.g. dataflow's
+  // Sampling Rate / Record area). Visited as its own slot between title and
+  // content. Walked focusable-by-focusable like content (in tabWithinSlots).
+  topbarElement?: HTMLElement;
+  // Optional inline secondary toolbar (e.g. dataflow's Add-Block palette). Visited
+  // as its own slot in the trap cycle, between content and the standard floating
+  // toolbar, so its internal roving-tabindex is a single tab stop with arrow nav.
+  paletteElement?: HTMLElement;
 }
 
 export interface ITileApi {

--- a/src/components/tiles/tile-component.test.tsx
+++ b/src/components/tiles/tile-component.test.tsx
@@ -330,13 +330,14 @@ describe("TileComponent focus trap", () => {
       expect(document.activeElement).toBe(titleElement);
     });
 
-    it("Shift+Tab on selected tile enters focus trap backward", () => {
+    it("Shift+Tab on selected tile enters focus trap on the toolbar's active item", () => {
       const { stores, tileModel, tileElement, toolbarButtons } = renderFocusTrapTile();
       act(() => { stores.ui.setSelectedTileId(tileModel.id); });
       act(() => { tileElement.focus(); });
       fireEvent.keyDown(tileElement, { key: "Tab", shiftKey: true });
-      // Reverse entry: resize (absent) → toolbar (last button)
-      expect(document.activeElement).toBe(toolbarButtons[toolbarButtons.length - 1]);
+      // Reverse entry: resize (absent) → toolbar; lands on the roving-active
+      // button (the one with tabindex="0"), which is the first button by default.
+      expect(document.activeElement).toBe(toolbarButtons[0]);
     });
 
     it("Tab on selected tile without title/content enters focus trap and reaches toolbar", () => {
@@ -400,13 +401,14 @@ describe("TileComponent focus trap", () => {
       expect(document.activeElement).toBe(titleElement);
     });
 
-    it("Shift+Tab from title wraps to last toolbar button", () => {
+    it("Shift+Tab from title wraps backward to the toolbar's active item", () => {
       const { stores, tileModel, titleElement, toolbarButtons } = renderFocusTrapTile();
       act(() => { stores.ui.setSelectedTileId(tileModel.id); });
       act(() => { titleElement!.focus(); });
       fireEvent.keyDown(titleElement!, { key: "Tab", shiftKey: true });
-      // Reverse: title → resize (absent) → toolbar (last button)
-      expect(document.activeElement).toBe(toolbarButtons[toolbarButtons.length - 1]);
+      // Reverse: title → resize (absent) → toolbar; lands on the roving-active
+      // button (the one with tabindex="0"), which is the first button by default.
+      expect(document.activeElement).toBe(toolbarButtons[0]);
     });
 
     it("Shift+Tab from content with no title/toolbar calls preventDefault", () => {

--- a/src/components/tiles/tile-component.tsx
+++ b/src/components/tiles/tile-component.tsx
@@ -529,6 +529,8 @@ class InternalTileComponent extends BaseComponent<IProps, IState> {
       getContentElement: () => this.getFocusTrapElements().contentElement ?? undefined,
       getTitleElement: () => this.getFocusTrapElements().titleElement ?? undefined,
       getToolbarElement: () => this.toolbarElement ?? undefined,
+      getTopbarElement: () => this.getFocusTrapElements().topbarElement ?? undefined,
+      getPaletteElement: () => this.getFocusTrapElements().paletteElement ?? undefined,
       getResizeElement: () => this.resizeElement ?? undefined,
       focusContent: () => this.getFocusTrapElements().focusContent?.() ?? false,
       onTabWhenInactive: (e, reverse) => this.navigateToSiblingTile(e, reverse),
@@ -583,6 +585,8 @@ class InternalTileComponent extends BaseComponent<IProps, IState> {
       activeToolbarButton,
       contentElement: focusable?.contentElement || null,
       focusContent: focusable?.focusContent || null,
+      topbarElement: focusable?.topbarElement || null,
+      paletteElement: focusable?.paletteElement || null,
       resizeHandle: this.resizeElement,
     };
   }

--- a/src/components/toolbar.tsx
+++ b/src/components/toolbar.tsx
@@ -46,7 +46,7 @@ export const ToolbarComponent = observer(function ToolbarComponent(props: IProps
   const stores = useStores();
   const ariaLabels = useAriaLabels();
   const toolbarRef = useRef<HTMLDivElement>(null);
-  const { handleKeyDown: handleToolbarKeyDown } = useRovingTabindex(toolbarRef);
+  const { handleKeyDown: handleToolbarKeyDown } = useRovingTabindex(toolbarRef, "vertical");
 
   const [defaultTool, setDefaultTool] = useState<IToolbarButtonModel | undefined>();
   const [activeTool, setActiveTool] = useState<IToolbarButtonModel | undefined>();

--- a/src/components/toolbar/tile-toolbar.tsx
+++ b/src/components/toolbar/tile-toolbar.tsx
@@ -62,7 +62,7 @@ export const TileToolbar = observer(
     // Roving tabindex for keyboard navigation within toolbar
     const toolbarContainerRef = useRef<HTMLDivElement | null>(null);
     const [toolbarContainer, setToolbarContainer] = useState<HTMLDivElement | null>(null);
-    const { handleKeyDown: handleRovingKeyDown } = useRovingTabindex(toolbarContainerRef);
+    const { handleKeyDown: handleRovingKeyDown } = useRovingTabindex(toolbarContainerRef, "horizontal");
 
     // Combine floating ref with our container ref
     const setToolbarRef = useCallback((el: HTMLDivElement | null) => {
@@ -111,6 +111,7 @@ export const TileToolbar = observer(
           const contentElement = focusable?.contentElement;
           const titleElement = focusable?.titleElement;
           const focusContentFn = focusable?.focusContent;
+          const paletteElement = focusable?.paletteElement;
           const resizeHandle = tileElement.querySelector(
             ".tool-tile-resize-handle-wrapper"
           ) as HTMLElement | null;
@@ -133,24 +134,39 @@ export const TileToolbar = observer(
             return false;
           };
 
-          // Cycle: title → content → toolbar → resize → (wrap)
+          // Focuses the palette slot's active item (preferred), otherwise its
+          // first focusable. Returns true if focus moved into the palette.
+          const tryFocusPalette = () => {
+            if (!paletteElement) return false;
+            const focusables = getVisibleFocusables(paletteElement);
+            if (focusables.length === 0) return false;
+            const rovingTarget = focusables.find(el => el.getAttribute("tabindex") === "0");
+            const target = rovingTarget ?? focusables[0];
+            target.focus();
+            return document.activeElement === target;
+          };
+
+          // Cycle (matches the focus-trap controller's cycleOrder):
+          //   title → topbar → content → palette → toolbar → resize → (wrap)
           // Try candidates in order, skipping any that can't actually receive focus.
           if (e.shiftKey) {
-            // Shift+Tab: toolbar → last content child → title → resize → tile
-            const focusedLastChild = (() => {
-              if (!contentElement) return false;
-              const focusables = getVisibleFocusables(contentElement);
-              if (focusables.length > 0) {
-                focusables[focusables.length - 1].focus();
-                return document.activeElement === focusables[focusables.length - 1];
-              }
-              return false;
-            })();
-            if (!focusedLastChild) {
-              if (!tryFocusContent()) {
-                if (titleElement) { titleElement.focus(); }
-                if (document.activeElement !== titleElement) {
-                  if (!tryFocusResize()) { tileElement.focus(); }
+            // Shift+Tab: toolbar → palette → last content child → title → resize → tile
+            if (!tryFocusPalette()) {
+              const focusedLastChild = (() => {
+                if (!contentElement) return false;
+                const focusables = getVisibleFocusables(contentElement);
+                if (focusables.length > 0) {
+                  focusables[focusables.length - 1].focus();
+                  return document.activeElement === focusables[focusables.length - 1];
+                }
+                return false;
+              })();
+              if (!focusedLastChild) {
+                if (!tryFocusContent()) {
+                  if (titleElement) { titleElement.focus(); }
+                  if (document.activeElement !== titleElement) {
+                    if (!tryFocusResize()) { tileElement.focus(); }
+                  }
                 }
               }
             }

--- a/src/components/utilities/icon-button.tsx
+++ b/src/components/utilities/icon-button.tsx
@@ -24,6 +24,7 @@ export const IconButton = (props: IconButtonProps) => {
       className={`icon-button ${props.className}`}
       onClick={props.onClickButton}
       data-test={props.dataTestName || `${props.icon}-icon`}
+      data-testid={props.dataTestName || `${props.icon}-icon`}
       disabled={props.disabled}
     >
       <div

--- a/src/hooks/create-clue-tile-strategy.ts
+++ b/src/hooks/create-clue-tile-strategy.ts
@@ -16,6 +16,10 @@ export function createClueTileStrategy(config: ClueFocusTrapConfig): FocusTrapSt
     ?? (() => config.titleRef?.current ?? undefined);
   const getToolbar = config.getToolbarElement
     ?? (() => config.toolbarRef?.current ?? undefined);
+  const getTopbar = config.getTopbarElement
+    ?? (() => config.topbarRef?.current ?? undefined);
+  const getPalette = config.getPaletteElement
+    ?? (() => config.paletteRef?.current ?? undefined);
   const getResize = config.getResizeElement
     ?? (() => config.resizeRef?.current ?? undefined);
 
@@ -26,11 +30,18 @@ export function createClueTileStrategy(config: ClueFocusTrapConfig): FocusTrapSt
       content: getContent(),
       title: getTitle(),
       toolbar: getToolbar(),
+      topbar: getTopbar(),
+      palette: getPalette(),
       resize: getResize(),
     }),
     focusContent: config.focusContent,
-    cycleOrder: ["title", "content", "toolbar", "resize"],
-    tabWithinSlots: ["content"],
+    // topbar sits between title and content — for tiles that have a secondary
+    // controls strip above the editor (e.g. dataflow). palette sits between
+    // content and toolbar so an inline secondary toolbar is a single tab stop
+    // with internal arrow nav. findNextSlot skips slots whose elements are
+    // undefined, so tiles that don't provide topbar/palette are unaffected.
+    cycleOrder: ["title", "topbar", "content", "palette", "toolbar", "resize"],
+    tabWithinSlots: ["topbar", "content"],
     announceEnter: ariaLabels.announce.editingTile(config.tileType),
     announceExit: ariaLabels.announce.exitedTile(config.tileType),
     getExternalElements: () => {

--- a/src/hooks/use-clue-accessibility.test.tsx
+++ b/src/hooks/use-clue-accessibility.test.tsx
@@ -47,14 +47,19 @@ describe("createClueTileStrategy", () => {
     expect(elements.toolbar).toBeUndefined();
   });
 
-  it("sets cycle order to title/content/toolbar/resize", () => {
+  it("sets cycle order to title/topbar/content/palette/toolbar/resize", () => {
     const strategy = createClueTileStrategy({
       onRegisterTileApi: jest.fn(),
       onUnregisterTileApi: jest.fn(),
       tileType: "text",
     });
 
-    expect(strategy.cycleOrder).toEqual(["title", "content", "toolbar", "resize"]);
+    // `topbar` (e.g. dataflow's Sampling Rate / Record bar) sits between title and
+    // content; `palette` (e.g. dataflow's Add-Block palette) sits between content
+    // and toolbar so it can be a single tab stop. Tiles that don't provide topbar
+    // or palette elements have those slots skipped by the trap's findNextSlot.
+    expect(strategy.cycleOrder).toEqual(
+      ["title", "topbar", "content", "palette", "toolbar", "resize"]);
   });
 
   it("sets announcement text from tile type", () => {

--- a/src/hooks/use-clue-accessibility.ts
+++ b/src/hooks/use-clue-accessibility.ts
@@ -38,6 +38,17 @@ export interface ClueFocusTrapConfig {
   toolbarRef?: RefObject<HTMLElement | null>;
   getToolbarElement?: () => HTMLElement | undefined;
 
+  // Optional secondary controls bar element (e.g. dataflow's Sampling Rate / Record bar).
+  // Visited as its own slot between `title` and `content`; walked focusable-by-focusable.
+  topbarRef?: RefObject<HTMLElement | null>;
+  getTopbarElement?: () => HTMLElement | undefined;
+
+  // Optional inline secondary toolbar element (e.g. dataflow's Add-Block palette).
+  // Visited as its own slot between `content` and `toolbar` (single tab stop with
+  // arrow-key roving inside).
+  paletteRef?: RefObject<HTMLElement | null>;
+  getPaletteElement?: () => HTMLElement | undefined;
+
   // Resize handle element
   resizeRef?: RefObject<HTMLElement | null>;
   getResizeElement?: () => HTMLElement | undefined;
@@ -133,6 +144,8 @@ export function useClueAccessibility(options: ClueAccessibilityOptions): Accessi
           contentElement: elements.content,
           titleElement: elements.title,
           focusContent: strategy.focusContent,
+          topbarElement: elements.topbar,
+          paletteElement: elements.palette,
         };
       },
     };

--- a/src/hooks/use-clue-accessibility.ts
+++ b/src/hooks/use-clue-accessibility.ts
@@ -152,7 +152,6 @@ export function useClueAccessibility(options: ClueAccessibilityOptions): Accessi
 
     config.onRegisterTileApi(tileApi);
     return () => config.onUnregisterTileApi();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // mount/unmount lifecycle matches componentDidMount/componentWillUnmount
 
   // Delegate to generic useAccessibility with focus trap wired.

--- a/src/hooks/use-roving-tabindex.test.tsx
+++ b/src/hooks/use-roving-tabindex.test.tsx
@@ -3,9 +3,15 @@ import React, { useRef } from "react";
 import { useRovingTabindex } from "./use-roving-tabindex";
 
 // Toolbar with one group of buttons
-function TestToolbar({ buttonLabels }: { buttonLabels: string[] }) {
+function TestToolbar({
+  buttonLabels,
+  orientation = "vertical",
+}: {
+  buttonLabels: string[];
+  orientation?: "horizontal" | "vertical";
+}) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const { handleKeyDown } = useRovingTabindex(containerRef);
+  const { handleKeyDown } = useRovingTabindex(containerRef, orientation);
 
   return (
     <div ref={containerRef} data-testid="toolbar" role="toolbar" onKeyDown={handleKeyDown}>
@@ -19,7 +25,7 @@ function TestToolbar({ buttonLabels }: { buttonLabels: string[] }) {
 // Toolbar with multiple groups of buttons (mimics upper/lower toolbar sections)
 function GroupedTestToolbar() {
   const containerRef = useRef<HTMLDivElement>(null);
-  const { handleKeyDown } = useRovingTabindex(containerRef);
+  const { handleKeyDown } = useRovingTabindex(containerRef, "vertical");
 
   return (
     <div ref={containerRef} data-testid="toolbar" role="toolbar" onKeyDown={handleKeyDown}>
@@ -63,14 +69,6 @@ describe("useRovingTabindex", () => {
     expect(btnB).toHaveAttribute("tabindex", "-1");
     expect(btnC).toHaveAttribute("tabindex", "-1");
 
-    // ArrowRight also moves forward
-    fireEvent.keyDown(toolbar, { key: "ArrowRight" });
-    expect(document.activeElement).toBe(btnB);
-
-    // ArrowLeft also moves backward
-    fireEvent.keyDown(toolbar, { key: "ArrowLeft" });
-    expect(document.activeElement).toBe(btnA);
-
     // Does not wrap at the beginning
     fireEvent.keyDown(toolbar, { key: "ArrowUp" });
     expect(document.activeElement).toBe(btnA);
@@ -91,6 +89,61 @@ describe("useRovingTabindex", () => {
     fireEvent.keyDown(toolbar, { key: "Home" });
     expect(document.activeElement).toBe(btnA);
     expect(btnA).toHaveAttribute("tabindex", "0");
+  });
+
+  it("ignores off-axis arrow keys for vertical orientation", () => {
+    render(<TestToolbar buttonLabels={["A", "B", "C"]} orientation="vertical" />);
+    const toolbar = screen.getByTestId("toolbar");
+    const btnA = screen.getByTestId("btn-A");
+
+    btnA.focus();
+
+    // ArrowRight/ArrowLeft must not move focus on a vertical toolbar
+    fireEvent.keyDown(toolbar, { key: "ArrowRight" });
+    expect(document.activeElement).toBe(btnA);
+
+    fireEvent.keyDown(toolbar, { key: "ArrowLeft" });
+    expect(document.activeElement).toBe(btnA);
+  });
+
+  it("navigates with ArrowLeft/ArrowRight for horizontal orientation", () => {
+    render(<TestToolbar buttonLabels={["A", "B", "C"]} orientation="horizontal" />);
+    const toolbar = screen.getByTestId("toolbar");
+    const btnA = screen.getByTestId("btn-A");
+    const btnB = screen.getByTestId("btn-B");
+    const btnC = screen.getByTestId("btn-C");
+
+    btnA.focus();
+
+    // ArrowRight moves forward
+    fireEvent.keyDown(toolbar, { key: "ArrowRight" });
+    expect(document.activeElement).toBe(btnB);
+
+    // ArrowLeft moves backward
+    fireEvent.keyDown(toolbar, { key: "ArrowLeft" });
+    expect(document.activeElement).toBe(btnA);
+
+    // Home/End still work regardless of orientation
+    fireEvent.keyDown(toolbar, { key: "End" });
+    expect(document.activeElement).toBe(btnC);
+
+    fireEvent.keyDown(toolbar, { key: "Home" });
+    expect(document.activeElement).toBe(btnA);
+  });
+
+  it("ignores off-axis arrow keys for horizontal orientation", () => {
+    render(<TestToolbar buttonLabels={["A", "B", "C"]} orientation="horizontal" />);
+    const toolbar = screen.getByTestId("toolbar");
+    const btnA = screen.getByTestId("btn-A");
+
+    btnA.focus();
+
+    // ArrowDown/ArrowUp must not move focus on a horizontal toolbar
+    fireEvent.keyDown(toolbar, { key: "ArrowDown" });
+    expect(document.activeElement).toBe(btnA);
+
+    fireEvent.keyDown(toolbar, { key: "ArrowUp" });
+    expect(document.activeElement).toBe(btnA);
   });
 
   it("does not preventDefault for keys the hook does not handle", () => {

--- a/src/hooks/use-roving-tabindex.ts
+++ b/src/hooks/use-roving-tabindex.ts
@@ -10,7 +10,10 @@ import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
  *   horizontal to Left/Right).
  * - Home/End move to first/last button (regardless of orientation).
  * - Does not wrap around
- * - Disabled buttons are focusable (not skipped)
+ * - The cycle includes every <button> descendant without filtering on disabled
+ *   state, so SR users can still discover and announce a "disabled-looking"
+ *   button. For that to actually deliver focus, those buttons must use
+ *   `aria-disabled` rather than the HTML `disabled` attribute.
  *
  * The hook queries buttons from the DOM at navigation time so it stays correct
  * when buttons dynamically change or when the toolbar configuration varies.

--- a/src/hooks/use-roving-tabindex.ts
+++ b/src/hooks/use-roving-tabindex.ts
@@ -4,15 +4,21 @@ import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
  * Manages roving tabindex for toolbar keyboard navigation.
  * - Only one button has tabIndex=0 at a time (the roving target)
  * - All other buttons have tabIndex=-1
- * - All four arrow keys move focus between buttons
- * - Home/End move to first/last button
+ * - Arrow keys on the toolbar's primary axis move focus between buttons; the
+ *   off-axis arrows are intentionally ignored so they don't conflict with the
+ *   declared `aria-orientation` (vertical toolbars only respond to Up/Down,
+ *   horizontal to Left/Right).
+ * - Home/End move to first/last button (regardless of orientation).
  * - Does not wrap around
  * - Disabled buttons are focusable (not skipped)
  *
  * The hook queries buttons from the DOM at navigation time so it stays correct
  * when buttons dynamically change or when the toolbar configuration varies.
  */
-export function useRovingTabindex(containerRef: React.RefObject<HTMLElement | null>) {
+export function useRovingTabindex(
+  containerRef: React.RefObject<HTMLElement | null>,
+  orientation: "horizontal" | "vertical"
+) {
   const currentIndexRef = useRef(0);
 
   const getButtons = useCallback((): HTMLElement[] => {
@@ -61,16 +67,16 @@ export function useRovingTabindex(containerRef: React.RefObject<HTMLElement | nu
     const buttons = getButtons();
     if (buttons.length === 0) return;
 
+    const forwardKey = orientation === "vertical" ? "ArrowDown" : "ArrowRight";
+    const backwardKey = orientation === "vertical" ? "ArrowUp" : "ArrowLeft";
     const currentIndex = currentIndexRef.current;
     let newIndex: number;
 
     switch (e.key) {
-      case "ArrowDown":
-      case "ArrowRight":
+      case forwardKey:
         newIndex = Math.min(currentIndex + 1, buttons.length - 1);
         break;
-      case "ArrowUp":
-      case "ArrowLeft":
+      case backwardKey:
         newIndex = Math.max(currentIndex - 1, 0);
         break;
       case "Home":
@@ -80,10 +86,17 @@ export function useRovingTabindex(containerRef: React.RefObject<HTMLElement | nu
         newIndex = buttons.length - 1;
         break;
       default:
-        return; // Don't preventDefault for other keys (Enter, Space, Tab, etc.)
+        return; // Don't preventDefault for other keys (Enter, Space, Tab, off-axis arrows, etc.)
     }
 
     e.preventDefault();
+    // Also stop propagation so the event doesn't bubble to ancestors that handle
+    // the same keys for unrelated reasons. Specifically, tile-component.tsx has an
+    // ArrowUp "soft-exit" handler that pops focus back to the tile container; without
+    // stopPropagation here, ArrowUp on a roving toolbar inside the tile would exit
+    // the toolbar instead of moving the active item. Safe for floating toolbars
+    // (rendered in a portal) because portal events don't bubble to .tool-tile.
+    e.stopPropagation();
 
     if (newIndex !== currentIndex) {
       buttons[currentIndex].setAttribute("tabindex", "-1");
@@ -91,7 +104,7 @@ export function useRovingTabindex(containerRef: React.RefObject<HTMLElement | nu
       buttons[newIndex].focus();
       currentIndexRef.current = newIndex;
     }
-  }, [getButtons]);
+  }, [getButtons, orientation]);
 
   return { handleKeyDown };
 }

--- a/src/plugins/dataflow/components/dataflow-program.scss
+++ b/src/plugins/dataflow/components/dataflow-program.scss
@@ -21,7 +21,11 @@ $dataflow-toolbar-height: 364px;
   min-height: 300px;
   height: 100%;
 
-  .toolbar-editor-container {
+  // CLUE-455: palette is a sibling of content (not a descendant) so the focus
+  // trap can treat it as its own slot. The body is a flex row containing
+  // (content, palette); palette uses order:-1 to render visually on the left
+  // while staying after content in DOM (so SR linear order matches tab order).
+  .dataflow-program-body {
     display: flex;
     flex-direction: row;
     width: 100%;
@@ -30,6 +34,13 @@ $dataflow-toolbar-height: 364px;
     &.complete {
       height: 100%;
     }
+  }
+
+  .dataflow-program-content {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-width: 0;
   }
 
   .editor-graph-container {

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -72,6 +72,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
   private lastIntervalTime: number;
   private reteManager: ReteManager | undefined;
   private playbackReteManager: ReteManager | undefined;
+  private programContainerEl: HTMLElement | null = null;
   private updateObservable = observable({updateCount: 0});
 
   constructor(props: IProps) {
@@ -110,7 +111,10 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
     return (
       <div
         className="dataflow-program-container"
-        ref={el => this.props.onProgramContainerRef?.(el)}
+        ref={el => {
+          this.programContainerEl = el;
+          this.props.onProgramContainerRef?.(el);
+        }}
       >
         <DataflowProgramTopbar
           onSerialRefreshDevices={this.serialDeviceRefresh}
@@ -197,6 +201,19 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
   private handleConnectingKeyDown = (e: KeyboardEvent) => {
     const reteManager = this.reteManager;
     if (!reteManager?.isConnecting) return;
+
+    // Only intercept when the keydown originates inside this tile's program
+    // container. Otherwise — e.g. the user mouse-clicked outside the tile while
+    // connecting mode was still active — the document-level capture would
+    // hijack Arrow/Escape from elsewhere on the page. Cancel the in-flight
+    // connection and bail so subsequent keys aren't trapped either.
+    const container = this.programContainerEl;
+    const target = e.target as Node | null;
+    if (!container || !target || !container.contains(target)) {
+      reteManager.cancelConnecting();
+      return;
+    }
+
     switch (e.key) {
       case "ArrowRight":
       case "ArrowDown":

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -15,9 +15,9 @@ import { DataflowProgramZoom } from "./ui/dataflow-program-zoom";
 import { ProgramDataRates } from "../model/utilities/node";
 import { DocumentContextReact } from "../../../components/document/document-context";
 import { ITileProps } from "../../../components/tiles/tile-component";
-import { ITileExportOptions } from "../../../models/tiles/tile-content-info";
 import { ProgramMode } from "./types/dataflow-tile-types";
 import { IDataSet } from "../../../models/data/data-set";
+import { ObjectBoundingBox } from "../../../models/annotations/clue-object";
 
 import { recordCase } from "../model/utilities/recording-utilities";
 import { DataflowDropZone } from "./ui/dataflow-drop-zone";
@@ -33,6 +33,10 @@ export interface IStartProgramParams {
   title: string;
 }
 
+export interface IDataflowProgramApi {
+  getObjectBoundingBox: (objectId: string, objectType?: string) => ObjectBoundingBox | undefined;
+}
+
 interface IProps extends SizeMeProps {
   documentProperties?: { [key: string]: string };
   tileId?: string;
@@ -44,6 +48,8 @@ interface IProps extends SizeMeProps {
   tileElt: HTMLElement | null;
   onRegisterTileApi: ITileProps["onRegisterTileApi"];
   onReteManagerCreated?: (reteManager: ReteManager | undefined) => void;
+  onProgramContainerRef?: (el: HTMLElement | null) => void;
+  onProgramApiRef?: (api: IDataflowProgramApi | null) => void;
 }
 
 interface IState {
@@ -92,15 +98,20 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
 
     const editorClassForDisplayState = "full";
     const editorClass = `editor ${editorClassForDisplayState}`;
-    const toolbarEditorContainerClass = `toolbar-editor-container`;
     const isTesting = ["qa", "test"].indexOf(this.stores.appMode) >= 0;
     const showRateUI = ["qa", "test", "dev"].indexOf(this.stores.appMode) >= 0;
     const showZoomControl = !documentProperties?.dfHasData;
     const disableToolBarModes = programMode === ProgramMode.Recording || programMode === ProgramMode.Done;
     const showProgramToolbar = showZoomControl && !disableToolBarModes;
 
+    // The palette must be a sibling of content (not a descendant) so the focus
+    // trap can treat it as its own single-tab-stop slot without nested-slot
+    // patches; `.dataflow-program-body` holds them as flex siblings.
     return (
-      <div className="dataflow-program-container">
+      <div
+        className="dataflow-program-container"
+        ref={el => this.props.onProgramContainerRef?.(el)}
+      >
         <DataflowProgramTopbar
           onSerialRefreshDevices={this.serialDeviceRefresh}
           programDataRates={ProgramDataRates}
@@ -117,7 +128,51 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
           tileContent={tileContent}
           handleChangeOfProgramMode={this.handleChangeOfProgramMode}
         />
-        <div className={toolbarEditorContainerClass}>
+        <div className="dataflow-program-body">
+          <div className="dataflow-program-content">
+            <DataflowDropZone
+              addNode={this.addNode}
+              className="editor-graph-container"
+              reteManager={this.reteManager}
+              readOnly={readOnly}
+              style={this.getEditorStyle}
+              tileId={this.tileId}
+            >
+              <div
+                className={editorClass}
+              >
+                {
+                  // the main flow-tool div is just hidden so its reteManager doesn't have
+                  // to be disposed and recreated each time the recording finishes
+                }
+                <div
+                  className={`flow-tool ${programMode === ProgramMode.Done ? "hidden" : ""}`}
+                  ref={elt => this.toolDiv = elt}
+                />
+                { programMode === ProgramMode.Done &&
+                  <div
+                    className="flow-tool"
+                    ref={elt => this.playbackToolDiv = elt}
+                  />
+                }
+                { this.shouldShowProgramCover() &&
+                  <DataflowProgramCover editorClass={editorClassForDisplayState} /> }
+                {showZoomControl && this.reteManager &&
+                  <DataflowProgramZoom
+                    onZoomInClick={this.handleZoomIn}
+                    onZoomOutClick={this.handleZoomOut}
+                    disabled={false}
+                  /> }
+              </div>
+            </DataflowDropZone>
+            <div
+              aria-live="polite"
+              className="visually-hidden"
+              data-testid="dataflow-announcer"
+            >
+              {this.reteManager?.announcement.value ?? ""}
+            </div>
+          </div>
           { showProgramToolbar && <DataflowProgramToolbar
             disabled={!!readOnly}
             isTesting={isTesting}
@@ -125,45 +180,47 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
             onNodeCreateClick={this.addNode}
             tileId={this.tileId}
           /> }
-          <DataflowDropZone
-            addNode={this.addNode}
-            className="editor-graph-container"
-            reteManager={this.reteManager}
-            readOnly={readOnly}
-            style={this.getEditorStyle}
-            tileId={this.tileId}
-          >
-            <div
-              className={editorClass}
-            >
-              {
-                // the main flow-tool div is just hidden so its reteManager doesn't have
-                // to be disposed and recreated each time the recording finishes
-              }
-              <div
-                className={`flow-tool ${programMode === ProgramMode.Done ? "hidden" : ""}`}
-                ref={elt => this.toolDiv = elt}
-              />
-              { programMode === ProgramMode.Done &&
-                <div
-                  className="flow-tool"
-                  ref={elt => this.playbackToolDiv = elt}
-                />
-              }
-              { this.shouldShowProgramCover() &&
-                <DataflowProgramCover editorClass={editorClassForDisplayState} /> }
-              {showZoomControl && this.reteManager &&
-                <DataflowProgramZoom
-                  onZoomInClick={this.handleZoomIn}
-                  onZoomOutClick={this.handleZoomOut}
-                  disabled={false}
-                /> }
-            </div>
-          </DataflowDropZone>
         </div>
       </div>
     );
   }
+
+  // Routes ArrowKey / Escape / Tab to the rete manager's connection-mode state machine.
+  // Registered as a document capture-phase listener (rather than a React onKeyDown
+  // on the program container) because the focus trap's own document capture-phase
+  // listener calls `stopPropagation` for Escape — that swallows the event before it
+  // reaches React's bubble-phase handlers and exits the trap instead of cancelling
+  // the in-flight connection. Children mount before parents, so this listener is
+  // registered before the trap's (which lives on the parent TileComponent) and
+  // fires first in capture order. We `stopPropagation` so the trap never sees these
+  // keys while a connection is in flight.
+  private handleConnectingKeyDown = (e: KeyboardEvent) => {
+    const reteManager = this.reteManager;
+    if (!reteManager?.isConnecting) return;
+    switch (e.key) {
+      case "ArrowRight":
+      case "ArrowDown":
+        e.preventDefault();
+        e.stopPropagation();
+        reteManager.moveConnectingCandidate(1);
+        break;
+      case "ArrowLeft":
+      case "ArrowUp":
+        e.preventDefault();
+        e.stopPropagation();
+        reteManager.moveConnectingCandidate(-1);
+        break;
+      case "Escape":
+        e.preventDefault();
+        e.stopPropagation();
+        reteManager.cancelConnecting();
+        break;
+      case "Tab":
+        // Cancel and let Tab proceed so the trap controller can move focus on.
+        reteManager.cancelConnecting();
+        break;
+    }
+  };
 
   private handleZoomIn = () => {
     const zoomManager = this.playbackReteManager || this.reteManager;
@@ -183,71 +240,67 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
       this.reteManager.setupComplete.then(() => this.reteManager?.fitContent());
     }
 
-    this.props.onRegisterTileApi({
-      exportContentAsTileJson: (options?: ITileExportOptions) => {
-        return this.props.tileContent.exportJson(options);
-      },
-      // Note: when the component mounts it is likely that the tileElt will be undefined.
-      // So we use an arrow function so we can access `this` and look up the tileElt from
-      // props when it is needed.
-      getObjectBoundingBox: (objectId, objectType) => {
-        // The annotation layer adds the tile border when computing the position of the
-        // tile in the document. So basically it is figuring out the "inside" top left
-        // corner of the tile. This makes sense, since internally in the tile its elements
-        // are positioned inside of this border.
-        // However tileElt.getBoundClientRect gives the position include the width of the
-        // border. So this is the position of the "outside" of the tile element. Thus when
-        // we provide our bounding boxes we also need to subtract off the tile border width
-        // so they will line up when the annotation layer re-adds this border width.
-        const tileBorder = 2;
-        const padding = 5;
+    this.props.onProgramApiRef?.({ getObjectBoundingBox: this.getObjectBoundingBox });
 
-        const nodeModel = this.props.program?.nodes.get(objectId);
-
-        const reteManager = this.playbackReteManager || this.reteManager;
-        const nodeView = reteManager?.area.nodeViews.get(objectId);
-        const { tileElt } = this.props;
-        if (!nodeModel || !nodeView || !tileElt) return undefined;
-
-
-        // Observe the updateCount so every time the component is updated
-        // we recompute the bounding boxes. This is mainly important so changes
-        // to the recording state are taken into account.
-        // eslint-disable-next-line unused-imports/no-unused-vars -- need to observe
-        const {updateCount} = this.updateObservable;
-
-        // Observe node position changes. We use liveX and liveY so we update during
-        // the drag.
-        // eslint-disable-next-line unused-imports/no-unused-vars
-        const {liveX, liveY} = nodeModel;
-
-        // Observe program canvas changes like translation and zooming.
-        // eslint-disable-next-line unused-imports/no-unused-vars
-        const {dx, dy, scale: programScale} = this.props.tileContent.liveProgramZoom;
-
-        const tileRect = tileElt.getBoundingClientRect();
-        const scale = tileElt.offsetWidth / tileRect.width;
-        const nodeRect = nodeView.element.getBoundingClientRect();
-
-        return {
-          left: (nodeRect.left-tileRect.left) * scale - tileBorder - padding,
-          top:  (nodeRect.top-tileRect.top) * scale - tileBorder - padding,
-          width: nodeRect.width * scale + padding*2,
-          height: nodeRect.height * scale + padding*2
-        };
-      }
-    });
-
+    document.addEventListener("keydown", this.handleConnectingKeyDown, true);
   }
 
   public componentWillUnmount() {
+    document.removeEventListener("keydown", this.handleConnectingKeyDown, true);
     clearInterval(this.intervalHandle);
     this.reteManager?.dispose();
     this.reteManager = undefined;
     this.playbackReteManager?.dispose();
     this.playbackReteManager = undefined;
     this.props.onReteManagerCreated?.(undefined);
+    this.props.onProgramApiRef?.(null);
   }
+
+  public getObjectBoundingBox = (objectId: string, _objectType?: string): ObjectBoundingBox | undefined => {
+    // The annotation layer adds the tile border when computing the position of the
+    // tile in the document. So basically it is figuring out the "inside" top left
+    // corner of the tile. This makes sense, since internally in the tile its elements
+    // are positioned inside of this border.
+    // However tileElt.getBoundClientRect gives the position include the width of the
+    // border. So this is the position of the "outside" of the tile element. Thus when
+    // we provide our bounding boxes we also need to subtract off the tile border width
+    // so they will line up when the annotation layer re-adds this border width.
+    const tileBorder = 2;
+    const padding = 5;
+
+    const nodeModel = this.props.program?.nodes.get(objectId);
+
+    const reteManager = this.playbackReteManager || this.reteManager;
+    const nodeView = reteManager?.area.nodeViews.get(objectId);
+    const { tileElt } = this.props;
+    if (!nodeModel || !nodeView || !tileElt) return undefined;
+
+    // Observe the updateCount so every time the component is updated
+    // we recompute the bounding boxes. This is mainly important so changes
+    // to the recording state are taken into account.
+    // eslint-disable-next-line unused-imports/no-unused-vars -- need to observe
+    const {updateCount} = this.updateObservable;
+
+    // Observe node position changes. We use liveX and liveY so we update during
+    // the drag.
+    // eslint-disable-next-line unused-imports/no-unused-vars
+    const {liveX, liveY} = nodeModel;
+
+    // Observe program canvas changes like translation and zooming.
+    // eslint-disable-next-line unused-imports/no-unused-vars
+    const {dx, dy, scale: programScale} = this.props.tileContent.liveProgramZoom;
+
+    const tileRect = tileElt.getBoundingClientRect();
+    const scale = tileElt.offsetWidth / tileRect.width;
+    const nodeRect = nodeView.element.getBoundingClientRect();
+
+    return {
+      left: (nodeRect.left-tileRect.left) * scale - tileBorder - padding,
+      top:  (nodeRect.top-tileRect.top) * scale - tileBorder - padding,
+      width: nodeRect.width * scale + padding*2,
+      height: nodeRect.height * scale + padding*2
+    };
+  };
 
   public componentDidUpdate(prevProps: IProps) {
     this.initReteManagersIfNeeded();

--- a/src/plugins/dataflow/components/dataflow-tile.scss
+++ b/src/plugins/dataflow/components/dataflow-tile.scss
@@ -19,4 +19,20 @@
     display: flex;
     height: 100%;
   }
+
+  // The shared `.tool-tile:focus-visible` rule renders the focus ring as an
+  // inset box-shadow on the tile container. Dataflow fills the tile with
+  // opaque content (`.flow-tool` has `background: white`), which paints over
+  // the shadow. Re-render the same ring on a top-layer pseudo-element so it
+  // stays visible while focus is on the tile container itself.
+  &:focus-visible:not(.selected)::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    box-shadow:
+      inset 0 0 0 3px white,
+      inset 0 0 0 5px rgb(9, 87, 208);
+    z-index: 10;
+  }
 }

--- a/src/plugins/dataflow/components/dataflow-tile.tsx
+++ b/src/plugins/dataflow/components/dataflow-tile.tsx
@@ -3,7 +3,7 @@ import { SizeMe, SizeMeProps } from "react-sizeme";
 import { observer, inject } from "mobx-react";
 import classNames from "classnames";
 
-import { DataflowProgram } from "./dataflow-program";
+import { DataflowProgram, IDataflowProgramApi } from "./dataflow-program";
 import { BaseComponent } from "../../../components/base";
 import { ITileModel } from "../../../models/tiles/tile-model";
 import { ITileProps } from "../../../components/tiles/tile-component";
@@ -15,6 +15,10 @@ import { TileTitleArea } from "../../../components/tiles/tile-title-area";
 import { TileToolbar } from "../../../components/toolbar/tile-toolbar";
 import { ReteManager } from "../nodes/rete-manager";
 import { DataflowReteManagerContext } from "./dataflow-rete-manager-context";
+import { ClueTileAccessibilityBridge } from "../../../hooks/use-clue-accessibility";
+import { getEditableTitleElement } from "../../../utilities/dom-utils";
+import { ITileExportOptions } from "../../../models/tiles/tile-content-info";
+import { ITileApi } from "../../../components/tiles/tile-api";
 
 import "../dataflow-toolbar-registration";
 import "./dataflow-tile.scss";
@@ -39,6 +43,9 @@ interface IDataflowTileState {
 export default class DataflowToolComponent extends BaseComponent<IProps, IDataflowTileState> {
   public static tileHandlesSelection = true;
 
+  private programContainerEl: HTMLElement | null = null;
+  private programApi: IDataflowProgramApi | null = null;
+
   constructor(props: IProps) {
     super(props);
     this.state = {
@@ -51,9 +58,35 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IDatafl
     };
   }
 
+  // Read-only tiles don't render <ClueTileAccessibilityBridge> (which only sets
+  // up the editable focus trap), so they need to register the additional tile
+  // API (exportContentAsTileJson, getObjectBoundingBox) directly. componentDidMount
+  // runs after children's componentDidMount, so the program API ref is already set.
+  public componentDidMount() {
+    if (this.props.readOnly) {
+      this.props.onRegisterTileApi(this.getAdditionalApi());
+    }
+  }
+
+  public componentWillUnmount() {
+    if (this.props.readOnly) {
+      this.props.onUnregisterTileApi();
+    }
+  }
+
   private handleReteManagerCreated = (reteManager: ReteManager | undefined) => {
     this.setState({ reteManager });
   };
+
+  private getAdditionalApi = (): ITileApi => ({
+    exportContentAsTileJson: (options?: ITileExportOptions) => {
+      return this.getContent().exportJson(options);
+    },
+    getObjectBoundingBox: (objectId, objectType) => {
+      return this.programApi?.getObjectBoundingBox(objectId, objectType);
+    },
+  });
+
   public render() {
     const { readOnly, height, model, onRegisterTileApi, tileElt } = this.props;
     const editableClass = readOnly ? "read-only" : "editable";
@@ -86,12 +119,31 @@ export default class DataflowToolComponent extends BaseComponent<IProps, IDatafl
                   tileElt={tileElt}
                   onRegisterTileApi={onRegisterTileApi}
                   onReteManagerCreated={this.handleReteManagerCreated}
+                  onProgramContainerRef={el => this.programContainerEl = el}
+                  onProgramApiRef={api => this.programApi = api}
                 />
               );
             }}
           </SizeMe>
           <TileToolbar tileType="dataflow" readOnly={!!readOnly} tileElement={this.props.tileElt} />
         </div>
+        {!readOnly && (
+          <ClueTileAccessibilityBridge
+            tileType="dataflow"
+            onRegisterTileApi={this.props.onRegisterTileApi}
+            onUnregisterTileApi={this.props.onUnregisterTileApi}
+            getTitleElement={() => getEditableTitleElement(this.props.tileElt ?? undefined)}
+            getContentElement={() =>
+              this.programContainerEl?.querySelector<HTMLElement>(".dataflow-program-content")
+              ?? undefined}
+            getTopbarElement={() =>
+              this.programContainerEl?.querySelector<HTMLElement>(".program-editor-topbar")
+              ?? undefined}
+            getPaletteElement={() =>
+              this.programContainerEl?.querySelector<HTMLElement>(".program-toolbar") ?? undefined}
+            additionalApi={this.getAdditionalApi()}
+          />
+        )}
         </>
       </DataflowReteManagerContext.Provider>
     );

--- a/src/plugins/dataflow/components/ui/dataflow-program-toolbar.scss
+++ b/src/plugins/dataflow/components/ui/dataflow-program-toolbar.scss
@@ -1,4 +1,5 @@
 @import "../../../../components/vars";
+@import "../../../../components/mixins";
 @import "../dataflow-vars";
 
 $toolbar-width: 83px;
@@ -30,6 +31,10 @@ $button-label-text: $gray-text;
   border: solid 2px white;
   border-radius: 0 $half-border-radius 0 0;
   background-color: $gray-light;
+  // Render visually first inside .dataflow-program-body even though the DOM
+  // puts the palette after content (CLUE-455 requires SR linear order to match
+  // tab order: content before palette). The trap's cycleOrder enforces tab order.
+  order: -1;
 
   button {
     text-align: center;
@@ -38,8 +43,11 @@ $button-label-text: $gray-text;
     height: 40px;
     background-color: $toolbar-background;
     border: 0;
-    outline: 0;
     cursor: pointer;
+    // Bar-graph pattern: suppress non-keyboard focus outline, then layer the
+    // canonical focus ring on keyboard focus only.
+    &:focus { outline: none; }
+    @include focus-ring(-2px);
     &:hover:not([disabled]) {
       background-color: $button-hover;
     }

--- a/src/plugins/dataflow/components/ui/dataflow-program-toolbar.test.tsx
+++ b/src/plugins/dataflow/components/ui/dataflow-program-toolbar.test.tsx
@@ -1,0 +1,142 @@
+import React from "react";
+import { fireEvent, render } from "@testing-library/react";
+import { Provider } from "mobx-react";
+import { specStores } from "../../../../models/stores/spec-stores";
+import { DataflowProgramToolbar } from "./dataflow-program-toolbar";
+import { NodeTypes } from "../../model/utilities/node";
+
+// Required so the dataflow tile is registered before any rendering pulls in
+// dataflow-types side effects.
+import "../../dataflow-registration";
+
+interface IRenderOptions {
+  disabled?: boolean;
+  isTesting?: boolean;
+}
+
+interface IRenderResult {
+  container: HTMLElement;
+  onNodeCreateClick: jest.Mock<void, [string]>;
+  onClearClick: jest.Mock<void, []>;
+  toolbar: HTMLElement;
+  buttons: HTMLButtonElement[];
+}
+
+function renderToolbar(opts: IRenderOptions = {}): IRenderResult {
+  const stores = specStores();
+  const onNodeCreateClick = jest.fn();
+  const onClearClick = jest.fn();
+  const utils = render(
+    <Provider stores={stores}>
+      <DataflowProgramToolbar
+        disabled={opts.disabled ?? false}
+        isTesting={opts.isTesting ?? false}
+        onClearClick={onClearClick}
+        onNodeCreateClick={onNodeCreateClick}
+        tileId="test-tile"
+      />
+    </Provider>
+  );
+  const toolbar = utils.container.querySelector('[role="toolbar"]') as HTMLElement;
+  // Filter to the Add-Block buttons only (excludes the test-only Clear button).
+  const buttons = Array.from(
+    utils.container.querySelectorAll<HTMLButtonElement>('button[aria-label^="Add "]')
+  );
+  return { container: utils.container, onNodeCreateClick, onClearClick, toolbar, buttons };
+}
+
+describe("DataflowProgramToolbar accessibility (CLUE-455)", () => {
+  it("renders as a toolbar with aria-orientation=vertical and an aria-label", () => {
+    const { toolbar } = renderToolbar();
+    expect(toolbar).not.toBeNull();
+    expect(toolbar.getAttribute("aria-orientation")).toBe("vertical");
+    expect(toolbar.getAttribute("aria-label")).toBe("Add block");
+  });
+
+  it("renders one Add-Block button per NodeType with an aria-label", () => {
+    const { buttons } = renderToolbar();
+    expect(buttons).toHaveLength(NodeTypes.length);
+    NodeTypes.forEach((nt, i) => {
+      const expected = `Add ${nt.displayName ?? nt.name} block`;
+      expect(buttons[i].getAttribute("aria-label")).toBe(expected);
+    });
+  });
+
+  it("makes only the first button a tab stop (roving tabindex)", () => {
+    const { buttons } = renderToolbar();
+    expect(buttons[0].getAttribute("tabindex")).toBe("0");
+    buttons.slice(1).forEach(b => {
+      expect(b.getAttribute("tabindex")).toBe("-1");
+    });
+  });
+});
+
+describe("DataflowProgramToolbar keyboard navigation (CLUE-455)", () => {
+  it("ArrowDown advances the roving tabindex to the next button", () => {
+    const { toolbar, buttons } = renderToolbar();
+    buttons[0].focus();
+    fireEvent.keyDown(toolbar, { key: "ArrowDown" });
+    expect(buttons[1].getAttribute("tabindex")).toBe("0");
+    expect(buttons[0].getAttribute("tabindex")).toBe("-1");
+    expect(document.activeElement).toBe(buttons[1]);
+  });
+
+  it("ArrowUp from the first button stays on the first (no-wrap behavior)", () => {
+    const { toolbar, buttons } = renderToolbar();
+    buttons[0].focus();
+    fireEvent.keyDown(toolbar, { key: "ArrowUp" });
+    expect(buttons[0].getAttribute("tabindex")).toBe("0");
+    expect(document.activeElement).toBe(buttons[0]);
+  });
+
+  it("ArrowDown from the last button stays on the last (no-wrap behavior)", () => {
+    const { toolbar, buttons } = renderToolbar();
+    const last = buttons.length - 1;
+    fireEvent.keyDown(toolbar, { key: "End" });
+    fireEvent.keyDown(toolbar, { key: "ArrowDown" });
+    expect(buttons[last].getAttribute("tabindex")).toBe("0");
+    expect(document.activeElement).toBe(buttons[last]);
+  });
+
+  it("Home jumps to the first button", () => {
+    const { toolbar, buttons } = renderToolbar();
+    fireEvent.keyDown(toolbar, { key: "End" });
+    fireEvent.keyDown(toolbar, { key: "Home" });
+    expect(buttons[0].getAttribute("tabindex")).toBe("0");
+    expect(document.activeElement).toBe(buttons[0]);
+  });
+
+  it("End jumps to the last button", () => {
+    const { toolbar, buttons } = renderToolbar();
+    fireEvent.keyDown(toolbar, { key: "End" });
+    expect(buttons[buttons.length - 1].getAttribute("tabindex")).toBe("0");
+    expect(document.activeElement).toBe(buttons[buttons.length - 1]);
+  });
+});
+
+describe("DataflowProgramToolbar activation (CLUE-455)", () => {
+  it("clicking a button calls onNodeCreateClick with that node type", () => {
+    const { buttons, onNodeCreateClick } = renderToolbar();
+    fireEvent.click(buttons[0]);
+    expect(onNodeCreateClick).toHaveBeenCalledWith(NodeTypes[0].name);
+  });
+
+  it("does not call onNodeCreateClick when the toolbar is disabled", () => {
+    const { buttons, onNodeCreateClick } = renderToolbar({ disabled: true });
+    fireEvent.click(buttons[0]);
+    expect(onNodeCreateClick).not.toHaveBeenCalled();
+  });
+
+  it("announces 'Added X block' via the aria-live region on activation", () => {
+    const { container, buttons } = renderToolbar();
+    const live = container.querySelector<HTMLDivElement>('[aria-live="polite"]');
+    expect(live).not.toBeNull();
+    fireEvent.click(buttons[0]);
+    // Wait for the 150ms setTimeout in announce() (clear-then-set timing for SR pollers).
+    return new Promise<void>(resolve => setTimeout(() => {
+      const expected = `Added ${NodeTypes[0].displayName ?? NodeTypes[0].name} block`;
+      expect(live!.textContent).toBe(expected);
+      resolve();
+    }, 200));
+  });
+});

--- a/src/plugins/dataflow/components/ui/dataflow-program-toolbar.tsx
+++ b/src/plugins/dataflow/components/ui/dataflow-program-toolbar.tsx
@@ -1,8 +1,9 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { DragOverlay, useDraggable } from "@dnd-kit/core";
 import { getNodeType, isNodeDraggableId, nodeDraggableId } from "../dataflow-types";
 import { NodeType, NodeTypes } from "../../model/utilities/node";
 import { useUIStore } from "../../../../hooks/use-stores";
+import { useRovingTabindex } from "../../../../hooks/use-roving-tabindex";
 import { getNodeLetter } from "../../nodes/utilities/view-utilities";
 
 import "./dataflow-program-toolbar.scss";
@@ -61,19 +62,32 @@ interface IAddNodeButtonProps {
   nodeDisplayName?: string;
   onNodeCreateClick: (type: string) => void;
   tileId: string;
+  onActivate: () => void;
 }
-const AddNodeButton = ({ disabled, i, nodeType, nodeDisplayName, onNodeCreateClick, tileId }: IAddNodeButtonProps) => {
+const AddNodeButton = ({
+  disabled, i, nodeType, nodeDisplayName, onNodeCreateClick, tileId, onActivate,
+}: IAddNodeButtonProps) => {
   const draggableId = nodeDraggableId(nodeType, tileId);
   const { attributes, listeners, setNodeRef } = useDraggable({ id: draggableId });
 
-  const handleAddNodeButtonClick = () => { onNodeCreateClick(nodeType); };
+  const handleAddNodeButtonClick = () => {
+    onNodeCreateClick(nodeType);
+    onActivate();
+  };
+
+  // dnd-kit's useDraggable adds attributes (incl. role="button" and tabIndex) to the wrapper.
+  // The actual focus target is the inner <button>, so we strip dnd-kit's role/tabindex from
+  // the wrapper to avoid two focus stops per palette item and to keep the roving tabindex
+  // hook (which queries `<button>` descendants) authoritative.
+  const { tabIndex: _ignoredTabIndex, role: _ignoredRole, ...wrapperAttrs } = attributes;
 
   return (
-    <div ref={setNodeRef} {...attributes} {...listeners} >
+    <div ref={setNodeRef} {...wrapperAttrs} {...listeners}>
       <button
         disabled={disabled}
         key={i}
-        title={`Add ${nodeDisplayName} Block`}
+        aria-label={`Add ${nodeDisplayName ?? nodeType} block`}
+        title={`Add ${nodeDisplayName ?? nodeType} Block`}
         onClick={handleAddNodeButtonClick}
         data-testid={`add-${nodeType.toLowerCase().replace(" ", "-")}-button`}
       >
@@ -92,6 +106,32 @@ interface IProps {
 }
 export const DataflowProgramToolbar = ({ disabled, isTesting, onClearClick, onNodeCreateClick, tileId }: IProps) => {
   const ui = useUIStore();
+  const containerRef = useRef<HTMLElement>(null);
+  const { handleKeyDown } = useRovingTabindex(containerRef, "vertical");
+
+  // Live region for "Added X block" announcements. Lives inside the toolbar nav
+  // because the assistive tech is interacting with this region. Clear-then-set
+  // with a 150ms gap (long enough for SR pollers ~100-150ms to observe the
+  // empty state) so identical back-to-back messages are still re-announced.
+  const announcerRef = useRef<HTMLDivElement>(null);
+  const announceTimeoutRef = useRef<number | null>(null);
+  const announce = (text: string) => {
+    if (!announcerRef.current) return;
+    if (announceTimeoutRef.current !== null) {
+      window.clearTimeout(announceTimeoutRef.current);
+    }
+    announcerRef.current.textContent = "";
+    announceTimeoutRef.current = window.setTimeout(() => {
+      announceTimeoutRef.current = null;
+      if (announcerRef.current) announcerRef.current.textContent = text;
+    }, 150);
+  };
+  useEffect(() => () => {
+    if (announceTimeoutRef.current !== null) {
+      window.clearTimeout(announceTimeoutRef.current);
+    }
+  }, []);
+
   let dragOverlay = null;
   if (ui.dragId && isNodeDraggableId(ui.dragId)) {
     dragOverlay = (
@@ -102,7 +142,15 @@ export const DataflowProgramToolbar = ({ disabled, isTesting, onClearClick, onNo
   }
 
   return (
-    <div className="program-toolbar" data-test="program-toolbar">
+    <nav
+      ref={containerRef}
+      className="program-toolbar"
+      role="toolbar"
+      aria-orientation="vertical"
+      aria-label="Add block"
+      data-test="program-toolbar"
+      onKeyDown={handleKeyDown}
+    >
       { NodeTypes.map((nt: NodeType, i: number) => (
         <AddNodeButton
           disabled={disabled}
@@ -112,10 +160,14 @@ export const DataflowProgramToolbar = ({ disabled, isTesting, onClearClick, onNo
           nodeDisplayName={nt.displayName}
           onNodeCreateClick={onNodeCreateClick}
           tileId={tileId}
+          onActivate={() => announce(`Added ${nt.displayName ?? nt.name} block`)}
         />
       ))}
       {<DragOverlay dropAnimation={null}>{ dragOverlay }</DragOverlay> }
-      { isTesting && <button className="qa" onClick={ onClearClick }>Clear</button> }
-    </div>
+      { isTesting && (
+        <button className="qa" onClick={onClearClick} aria-label="Clear program">Clear</button>
+      ) }
+      <div ref={announcerRef} aria-live="polite" className="visually-hidden" />
+    </nav>
   );
 };

--- a/src/plugins/dataflow/components/ui/dataflow-program-topbar.tsx
+++ b/src/plugins/dataflow/components/ui/dataflow-program-topbar.tsx
@@ -132,6 +132,8 @@ const RecordStopOrClearButton = (props: IRecordStopOrClearProps) => {
         className="record-data-btn"
         onClick={onClickHandler}
         disabled={disabled}
+        aria-label={Mode[programMode]}
+        data-testid="record-data-button"
       >
         <div className="record-data-icon">
           {iconArr[programMode]}
@@ -160,6 +162,7 @@ const PlaybackButton = (props: IPlaybackProps) => {
         className="playback-data-btn"
         disabled={programMode === ProgramMode.Recording}
         onClick={handleChangeIsPlaying}
+        aria-label={isPlaying ? "Pause" : "Play"} // Added aria-label for screen readers
       >
         <div className="playback-data-icon">
           {isPlaying ? <PauseIcon/> : <PlayIcon/>}

--- a/src/plugins/dataflow/components/ui/dataflow-program-zoom.scss
+++ b/src/plugins/dataflow/components/ui/dataflow-program-zoom.scss
@@ -1,4 +1,6 @@
 @import "../../../../components/vars";
+@import "../../../../components/mixins";
+@import "../dataflow-vars";
 
 .program-editor-zoom {
   position: absolute;
@@ -12,41 +14,48 @@
   button {
     width: 26px;
     height: 26px;
-    line-height: 17px;
     padding: 0;
-    font-size: 30px;
-    color: #969696;
-    background-color: #FEFEFE;
-    border: 2px solid #bcbcbc;
+    font-size: 22px;
+    color: $gray-mid-click;
+    background-color: $gray-light-2;
+    border: 2px solid $gray-mid;
     border-radius: 3px 3px 0 0;
     cursor: pointer;
+    align-items: center;
+    display: flex;
+    justify-content: center;
+    position: relative;
 
     &:nth-child(1) {
       border-radius: 3px 3px 0 0;
-      border-bottom-width: 1px;
+      border-bottom-width: 0;
     }
 
     &:nth-child(2) {
       border-radius: 0 0 3px 3px;
       border-top-width: 1px;
-    }
 
-    &::before { /** hack for vertical text alignment */
-      content: "";
-      vertical-align: middle;
-      line-height: 20px;
+      span {
+        transform: translateY(-1px) scaleX(0.85);
+      }
     }
 
     &:hover {
-      border-color: #a8a8a8;
-      color: #838383;
+      border-color: $gray-mid-hover;
+      color: $gray-mid-select;
     }
     &:active {
-      border-color: #838383;
-      color: #838383;
+      border-color: $gray-mid-select;
+      color: $gray-mid-select;
     }
-    &:focus {
-      outline: none;
+    // Bar-graph pattern: suppress non-keyboard focus outline, then layer the
+    // canonical focus ring on keyboard focus only.
+    &:focus { outline: none; }
+    @include focus-ring(2px);
+    &:focus-visible { z-index: 1; }
+
+    span {
+      display: inline-block;
     }
   }
 }

--- a/src/plugins/dataflow/components/ui/dataflow-program-zoom.tsx
+++ b/src/plugins/dataflow/components/ui/dataflow-program-zoom.tsx
@@ -12,18 +12,22 @@ export const DataflowProgramZoom = (props: ZoomProps) => {
   return (
     <div className="program-editor-zoom">
       <button
-        title={"Zoom In"}
+        title="Zoom In"
+        aria-label="Zoom In"
         onClick={props.onZoomInClick}
         disabled={props.disabled}
+        data-testid="zoom-in-button"
       >
-        +
+        <span>+</span>
       </button>
       <button
-        title={"Zoom Out"}
+        title="Zoom Out"
+        aria-label="Zoom Out"
         onClick={props.onZoomOutClick}
         disabled={props.disabled}
+        data-testid="zoom-out-button"
       >
-        -
+        <span>–</span>
       </button>
     </div>
   );

--- a/src/plugins/dataflow/components/ui/dataflow-rateselector-playback.scss
+++ b/src/plugins/dataflow/components/ui/dataflow-rateselector-playback.scss
@@ -1,4 +1,5 @@
 @import "../../../../components/vars";
+@import "../../../../components/mixins";
 @import "../dataflow-vars";
 
 $duration-label-back: $gray-mid;
@@ -68,10 +69,7 @@ $duration-label-back: $gray-mid;
         touch-action: pan-x;
         z-index: 2;
 
-        &:focus {
-          outline: none;
-          box-shadow: none;
-        }
+        @include focus-ring(2px);
 
         &:active {
           cursor: grabbing;
@@ -143,7 +141,10 @@ $duration-label-back: $gray-mid;
     border-radius: 12px;
     background-color: #ffffff;
     font-size: 11px;
-    outline: 0;
+    // Suppress the browser's default focus outline (it overlaps the rounded chrome
+    // awkwardly), then layer the canonical focus ring on keyboard focus only.
+    &:focus { outline: none; }
+    @include focus-ring(2px);
     &:disabled {
       cursor: default;
     }

--- a/src/plugins/dataflow/components/ui/dataflow-rateselector-playback.tsx
+++ b/src/plugins/dataflow/components/ui/dataflow-rateselector-playback.tsx
@@ -44,6 +44,10 @@ export const RateSelectorOrPlayBack = observer(function RateSelectorOrPlayBack(p
     onRateSelectClick(Number(event.target.value));
   };
 
+  const sliderAriaLabel = isRecording ? "Recording duration" : "Playback position";
+  const sliderValueTextFormatter = (value: number) =>
+    `${formatTime(value)} of ${formatTime(sliderMaxValue)}`;
+
   return (
     <>
       <div className="topbar-sampleratetext-or-timeslider">
@@ -56,6 +60,8 @@ export const RateSelectorOrPlayBack = observer(function RateSelectorOrPlayBack(p
               step={1}
               value={sliderSec}
               ref={railRef}
+              ariaLabelForHandle={sliderAriaLabel}
+              ariaValueTextFormatterForHandle={sliderValueTextFormatter}
             />
           </div>
           :
@@ -71,6 +77,7 @@ export const RateSelectorOrPlayBack = observer(function RateSelectorOrPlayBack(p
               disabled={readOnly}
               value={dataRate.toString()}
               id="rate-select" // TODO: The id needs to be unique to the particular DF tile
+              data-testid="rate-select"
             >
               {
                 rateOptions.map((rate: ProgramDataRate) => (

--- a/src/plugins/dataflow/nodes/connection-mode.test.ts
+++ b/src/plugins/dataflow/nodes/connection-mode.test.ts
@@ -1,0 +1,292 @@
+import { ReteManager } from "./rete-manager";
+
+interface IFakeNode {
+  id: string;
+  label: string;
+  inputs: Record<string, { socket: unknown }>;
+  outputs: Record<string, { socket: unknown }>;
+}
+
+interface IBuildNode {
+  id: string;
+  label?: string;
+  x?: number;
+  y?: number;
+  inputs?: string[];
+  outputs?: string[];
+}
+
+interface IFakeEnv {
+  manager: ReteManager;
+  addConnectionCalls: Array<{ id?: string; source: string; sourceOutput: string;
+                              target: string; targetInput: string }>;
+  removeInputConnectionCalls: Array<{ nodeId: string; inputKey: string }>;
+  socketEl: (nodeId: string, side: "input" | "output", key: string) => HTMLElement;
+}
+
+function buildEnv(specs: IBuildNode[], opts: { readOnly?: boolean } = {}): IFakeEnv {
+  // Each node renders into a real DOM element so querySelector works just like
+  // the production code path. Each socket wrapper carries the data-* attributes
+  // production sets in dataflow-node.tsx.
+  const elements = new Map<string, HTMLDivElement>();
+  const fakeNodes: IFakeNode[] = specs.map(spec => {
+    const el = document.createElement("div");
+    el.className = "node";
+    el.setAttribute("data-test-node-id", spec.id);
+    for (const inputKey of spec.inputs ?? []) {
+      const socket = document.createElement("div");
+      socket.setAttribute("data-socket-side", "input");
+      socket.setAttribute("data-socket-key", inputKey);
+      socket.setAttribute("data-node-id", spec.id);
+      socket.tabIndex = 0;
+      el.appendChild(socket);
+    }
+    for (const outputKey of spec.outputs ?? []) {
+      const socket = document.createElement("div");
+      socket.setAttribute("data-socket-side", "output");
+      socket.setAttribute("data-socket-key", outputKey);
+      socket.setAttribute("data-node-id", spec.id);
+      socket.tabIndex = 0;
+      el.appendChild(socket);
+    }
+    document.body.appendChild(el);
+    elements.set(spec.id, el);
+
+    const inputs = Object.fromEntries(
+      (spec.inputs ?? []).map(k => [k, { socket: {} }])
+    );
+    const outputs = Object.fromEntries(
+      (spec.outputs ?? []).map(k => [k, { socket: {} }])
+    );
+    return { id: spec.id, label: spec.label ?? spec.id, inputs, outputs };
+  });
+
+  const fakeViews = new Map<string, { position: {x:number;y:number}; element: HTMLDivElement }>(
+    specs.map(spec => [
+      spec.id,
+      { position: { x: spec.x ?? 0, y: spec.y ?? 0 }, element: elements.get(spec.id)! }
+    ])
+  );
+
+  const addConnectionCalls: IFakeEnv["addConnectionCalls"] = [];
+  const removeInputConnectionCalls: IFakeEnv["removeInputConnectionCalls"] = [];
+
+  const stub = Object.create(ReteManager.prototype);
+  stub.editor = {
+    getNodes: () => fakeNodes,
+    getNode: (id: string) => fakeNodes.find(n => n.id === id),
+    addConnection: (data: any) => {
+      addConnectionCalls.push(data);
+      return Promise.resolve(true);
+    },
+  };
+  stub.area = { nodeViews: fakeViews };
+  stub.readOnly = !!opts.readOnly;
+  stub.removeInputConnection = (nodeId: string, inputKey: string) => {
+    removeInputConnectionCalls.push({ nodeId, inputKey });
+  };
+  // Stub `announce` so we don't hit requestAnimationFrame in tests; capture into an array.
+  stub.announceCalls = [] as string[];
+  stub.announce = (msg: string) => { stub.announceCalls.push(msg); };
+
+  return {
+    manager: stub,
+    addConnectionCalls,
+    removeInputConnectionCalls,
+    socketEl: (nodeId, side, key) =>
+      elements.get(nodeId)!.querySelector(
+        `[data-socket-side="${side}"][data-socket-key="${key}"]`
+      ) as HTMLElement,
+  };
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("ReteManager connection-mode state machine (CLUE-455)", () => {
+  it("Enter on output socket transitions from idle to connecting", () => {
+    const env = buildEnv([
+      { id: "src", x: 0,   y: 0, outputs: ["value"] },
+      { id: "dst", x: 200, y: 0, inputs: ["num1"] },
+    ]);
+    expect(env.manager.isConnecting).toBe(false);
+    env.manager.beginConnectingFrom("src", "value");
+    expect(env.manager.isConnecting).toBe(true);
+  });
+
+  it("announces 'No compatible target sockets' when none exist and stays idle", () => {
+    const env = buildEnv([
+      { id: "src", outputs: ["value"] },
+    ]);
+    env.manager.beginConnectingFrom("src", "value");
+    expect(env.manager.isConnecting).toBe(false);
+    expect((env.manager as any).announceCalls).toContain("No compatible target sockets");
+  });
+
+  it("highlights all candidate sockets and focuses the first one", () => {
+    const env = buildEnv([
+      { id: "src", x: 0,   y: 0, outputs: ["value"] },
+      { id: "a",   x: 100, y: 0, inputs: ["num1"] },
+      { id: "b",   x: 200, y: 0, inputs: ["num1"] },
+    ]);
+    env.manager.beginConnectingFrom("src", "value");
+    expect(env.socketEl("a", "input", "num1").classList.contains("connection-candidate")).toBe(true);
+    expect(env.socketEl("b", "input", "num1").classList.contains("connection-candidate")).toBe(true);
+    expect(document.activeElement).toBe(env.socketEl("a", "input", "num1"));
+  });
+
+  it("excludes the source node's own inputs from candidates", () => {
+    const env = buildEnv([
+      { id: "src", x: 0,   y: 0, inputs: ["num1"], outputs: ["value"] },
+      { id: "dst", x: 100, y: 0, inputs: ["num1"] },
+    ]);
+    env.manager.beginConnectingFrom("src", "value");
+    const candidates = env.manager.getCompatibleTargets("src", "value");
+    expect(candidates.map(c => c.nodeId)).toEqual(["dst"]);
+  });
+
+  it("orders candidates in node reading order", () => {
+    // Three input nodes: positions chosen so reading order is "left", "middle", "right".
+    const env = buildEnv([
+      { id: "src",    x: 0,   y: 0,   outputs: ["value"] },
+      { id: "right",  x: 400, y: 100, inputs: ["num1"] },
+      { id: "left",   x: 100, y: 100, inputs: ["num1"] },
+      { id: "middle", x: 250, y: 100, inputs: ["num1"] },
+    ]);
+    const candidates = env.manager.getCompatibleTargets("src", "value");
+    expect(candidates.map(c => c.nodeId)).toEqual(["left", "middle", "right"]);
+  });
+
+  it("moveConnectingCandidate(1) wraps from last to first", () => {
+    const env = buildEnv([
+      { id: "src", x: 0,   y: 0, outputs: ["value"] },
+      { id: "a",   x: 100, y: 0, inputs: ["num1"] },
+      { id: "b",   x: 200, y: 0, inputs: ["num1"] },
+    ]);
+    env.manager.beginConnectingFrom("src", "value");
+    env.manager.moveConnectingCandidate(1); // -> b
+    env.manager.moveConnectingCandidate(1); // wraps -> a
+    expect(document.activeElement).toBe(env.socketEl("a", "input", "num1"));
+  });
+
+  it("moveConnectingCandidate(-1) wraps from first to last", () => {
+    const env = buildEnv([
+      { id: "src", x: 0,   y: 0, outputs: ["value"] },
+      { id: "a",   x: 100, y: 0, inputs: ["num1"] },
+      { id: "b",   x: 200, y: 0, inputs: ["num1"] },
+    ]);
+    env.manager.beginConnectingFrom("src", "value");
+    env.manager.moveConnectingCandidate(-1); // wraps -> b
+    expect(document.activeElement).toBe(env.socketEl("b", "input", "num1"));
+  });
+
+  it("commitConnectingTo with a candidate input creates the connection and resets to idle", async () => {
+    const env = buildEnv([
+      { id: "src", x: 0,   y: 0, outputs: ["value"] },
+      { id: "dst", x: 100, y: 0, inputs: ["num1"] },
+    ]);
+    env.manager.beginConnectingFrom("src", "value");
+    await env.manager.commitConnectingTo("dst", "num1");
+    expect(env.addConnectionCalls).toHaveLength(1);
+    expect(env.addConnectionCalls[0]).toMatchObject({
+      source: "src", sourceOutput: "value", target: "dst", targetInput: "num1",
+    });
+    expect(env.manager.isConnecting).toBe(false);
+  });
+
+  it("removes any existing connection on the target input before adding the new one", async () => {
+    const env = buildEnv([
+      { id: "src", x: 0,   y: 0, outputs: ["value"] },
+      { id: "dst", x: 100, y: 0, inputs: ["num1"] },
+    ]);
+    env.manager.beginConnectingFrom("src", "value");
+    await env.manager.commitConnectingTo("dst", "num1");
+    expect(env.removeInputConnectionCalls).toEqual([{ nodeId: "dst", inputKey: "num1" }]);
+  });
+
+  it("clears connection-candidate classes from all candidate sockets after commit", async () => {
+    const env = buildEnv([
+      { id: "src", x: 0,   y: 0, outputs: ["value"] },
+      { id: "a",   x: 100, y: 0, inputs: ["num1"] },
+      { id: "b",   x: 200, y: 0, inputs: ["num1"] },
+    ]);
+    env.manager.beginConnectingFrom("src", "value");
+    await env.manager.commitConnectingTo("a", "num1");
+    expect(env.socketEl("a", "input", "num1").classList.contains("connection-candidate")).toBe(false);
+    expect(env.socketEl("b", "input", "num1").classList.contains("connection-candidate")).toBe(false);
+  });
+
+  it("marks the source output socket with the connection-source class while connecting", () => {
+    const env = buildEnv([
+      { id: "src", x: 0,   y: 0, outputs: ["value"] },
+      { id: "dst", x: 100, y: 0, inputs: ["num1"] },
+    ]);
+    env.manager.beginConnectingFrom("src", "value");
+    expect(env.socketEl("src", "output", "value").classList.contains("connection-source")).toBe(true);
+  });
+
+  it("clears the connection-source class on commit", async () => {
+    const env = buildEnv([
+      { id: "src", x: 0,   y: 0, outputs: ["value"] },
+      { id: "dst", x: 100, y: 0, inputs: ["num1"] },
+    ]);
+    env.manager.beginConnectingFrom("src", "value");
+    await env.manager.commitConnectingTo("dst", "num1");
+    expect(env.socketEl("src", "output", "value").classList.contains("connection-source")).toBe(false);
+  });
+
+  it("clears the connection-source class on cancel", () => {
+    const env = buildEnv([
+      { id: "src", x: 0,   y: 0, outputs: ["value"] },
+      { id: "dst", x: 100, y: 0, inputs: ["num1"] },
+    ]);
+    env.manager.beginConnectingFrom("src", "value");
+    env.manager.cancelConnecting();
+    expect(env.socketEl("src", "output", "value").classList.contains("connection-source")).toBe(false);
+  });
+
+  it("commitConnectingTo with a non-candidate input is a no-op", async () => {
+    const env = buildEnv([
+      { id: "src",      x: 0,   y: 0, outputs: ["value"] },
+      { id: "dst",      x: 100, y: 0, inputs: ["num1"] },
+      { id: "unrelated", x: 200, y: 0, inputs: ["num1"] },
+    ]);
+    env.manager.beginConnectingFrom("src", "value");
+    // Lie about the target id so it doesn't match any candidate.
+    await env.manager.commitConnectingTo("not-a-real-id", "num1");
+    expect(env.addConnectionCalls).toHaveLength(0);
+    expect(env.manager.isConnecting).toBe(true);
+  });
+
+  it("cancelConnecting resets to idle and announces 'Cancelled connection'", () => {
+    const env = buildEnv([
+      { id: "src", x: 0,   y: 0, outputs: ["value"] },
+      { id: "dst", x: 100, y: 0, inputs: ["num1"] },
+    ]);
+    env.manager.beginConnectingFrom("src", "value");
+    env.manager.cancelConnecting();
+    expect(env.manager.isConnecting).toBe(false);
+    expect((env.manager as any).announceCalls).toContain("Cancelled connection");
+  });
+
+  it("cancelConnecting refocuses the source output socket", () => {
+    const env = buildEnv([
+      { id: "src", x: 0,   y: 0, outputs: ["value"] },
+      { id: "dst", x: 100, y: 0, inputs: ["num1"] },
+    ]);
+    env.manager.beginConnectingFrom("src", "value");
+    env.manager.cancelConnecting();
+    expect(document.activeElement).toBe(env.socketEl("src", "output", "value"));
+  });
+
+  it("beginConnectingFrom is a no-op in read-only mode", () => {
+    const env = buildEnv([
+      { id: "src", x: 0,   y: 0, outputs: ["value"] },
+      { id: "dst", x: 100, y: 0, inputs: ["num1"] },
+    ], { readOnly: true });
+    env.manager.beginConnectingFrom("src", "value");
+    expect(env.manager.isConnecting).toBe(false);
+    expect((env.manager as any).announceCalls).toEqual([]);
+  });
+});

--- a/src/plugins/dataflow/nodes/controls/dropdown-list-control.scss
+++ b/src/plugins/dataflow/nodes/controls/dropdown-list-control.scss
@@ -31,12 +31,23 @@
     box-sizing: border-box;
     background-color: white;
     padding: 0 0 0 4px;
+    // Reset native button chrome on the trigger element so it visually matches
+    // the option rows (which remain divs) and the prior <div> trigger.
+    border: 0;
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+    width: 100%;
+    color: inherit;
     &.top {
       padding: 0 6px 0 6px;
       border-radius: 3px;
       &.missing {
         background-color: pink;
       }
+    }
+    &.highlighted {
+      background-color: rgba(0, 0, 0, 0.08);
     }
     &.selectable {
       &.missing {

--- a/src/plugins/dataflow/nodes/controls/dropdown-list-control.test.tsx
+++ b/src/plugins/dataflow/nodes/controls/dropdown-list-control.test.tsx
@@ -1,0 +1,255 @@
+import { fireEvent, render } from "@testing-library/react";
+import React from "react";
+import {
+  DropdownList,
+  IDropdownListControl,
+  ListOption,
+} from "./dropdown-list-control";
+
+interface IFakeControlOptions {
+  id?: string;
+  options: ListOption[];
+  initialValue?: string;
+  modelKey?: string;
+  modelType?: string;
+  disabledFunction?: (opt: ListOption) => boolean;
+  readOnly?: boolean;
+}
+
+interface IFakeControl extends IDropdownListControl {
+  setValueCalls: string[];
+  logEventCalls: string[];
+  selectNodeCalls: number;
+}
+
+function makeFakeControl(opts: IFakeControlOptions): IFakeControl {
+  let value = opts.initialValue ?? "";
+  const setValueCalls: string[] = [];
+  const logEventCalls: string[] = [];
+  const fake: IFakeControl = {
+    id: opts.id ?? "ctl-1",
+    node: { readOnly: !!opts.readOnly } as any,
+    model: { type: opts.modelType ?? "Number" } as any,
+    modelKey: opts.modelKey ?? "value",
+    options: opts.options,
+    setOptions: () => undefined,
+    tooltip: "Pick option",
+    placeholder: "Select an option",
+    getValue: () => value,
+    setValue: (v: string) => {
+      value = v;
+      setValueCalls.push(v);
+    },
+    disabledFunction: opts.disabledFunction,
+    setActiveOption: () => undefined,
+    logEvent: (op: string) => { logEventCalls.push(op); },
+    selectNode: () => { fake.selectNodeCalls++; },
+    getSelectionId: () => undefined,
+    setValueCalls,
+    logEventCalls,
+    selectNodeCalls: 0,
+  };
+  return fake;
+}
+
+const threeOptions: ListOption[] = [
+  { name: "alpha", displayName: "Alpha" },
+  { name: "beta", displayName: "Beta" },
+  { name: "gamma", displayName: "Gamma" },
+];
+
+function renderDropdown(control: IDropdownListControl) {
+  return render(<DropdownList control={control} listClass="value" />);
+}
+
+function getTrigger(container: HTMLElement) {
+  return container.querySelector('button[aria-haspopup="listbox"]') as HTMLButtonElement;
+}
+
+function getListbox(container: HTMLElement) {
+  return container.querySelector('[role="listbox"]') as HTMLDivElement | null;
+}
+
+describe("DropdownList trigger element (CLUE-455)", () => {
+  it("renders the trigger as a button with aria-haspopup=listbox", () => {
+    const control = makeFakeControl({ options: threeOptions });
+    const { container } = renderDropdown(control);
+    const trigger = getTrigger(container);
+    expect(trigger).not.toBeNull();
+    expect(trigger.getAttribute("aria-haspopup")).toBe("listbox");
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    expect(trigger.getAttribute("aria-controls")).toBe("dropdown-listbox-ctl-1");
+  });
+
+  it("includes the current option in the trigger's aria-label", () => {
+    const control = makeFakeControl({ options: threeOptions, initialValue: "beta" });
+    const { container } = renderDropdown(control);
+    expect(getTrigger(container).getAttribute("aria-label")).toBe("Pick option: Beta");
+  });
+
+  it("falls back to the placeholder in the aria-label when no value is set", () => {
+    const control = makeFakeControl({ options: threeOptions });
+    const { container } = renderDropdown(control);
+    expect(getTrigger(container).getAttribute("aria-label")).toBe("Pick option: Select an option");
+  });
+});
+
+describe("DropdownList opening behavior (CLUE-455)", () => {
+  it("opens the listbox on Enter and reports aria-expanded=true", () => {
+    const control = makeFakeControl({ options: threeOptions });
+    const { container } = renderDropdown(control);
+    const trigger = getTrigger(container);
+    fireEvent.keyDown(trigger, { key: "Enter" });
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+    expect(getListbox(container)).not.toBeNull();
+  });
+
+  it("opens the listbox on Space", () => {
+    const control = makeFakeControl({ options: threeOptions });
+    const { container } = renderDropdown(control);
+    fireEvent.keyDown(getTrigger(container), { key: " " });
+    expect(getListbox(container)).not.toBeNull();
+  });
+
+  it("does not open the listbox on ArrowDown — the in-block roving cycle owns arrow keys", () => {
+    // Block-level arrow keys move between interactive descendants of the focused
+    // block (CLUE-455 composite-widget pattern). Enter and Space are the canonical
+    // gestures for opening the dropdown.
+    const control = makeFakeControl({ options: threeOptions });
+    const { container } = renderDropdown(control);
+    fireEvent.keyDown(getTrigger(container), { key: "ArrowDown" });
+    expect(getListbox(container)).toBeNull();
+  });
+
+  it("highlights the currently-selected option when opened", () => {
+    const control = makeFakeControl({ options: threeOptions, initialValue: "beta" });
+    const { container } = renderDropdown(control);
+    fireEvent.keyDown(getTrigger(container), { key: "Enter" });
+    expect(getListbox(container)?.getAttribute("aria-activedescendant"))
+      .toBe("dropdown-listbox-ctl-1-opt-1");
+  });
+});
+
+describe("DropdownList listbox keyboard navigation (CLUE-455)", () => {
+  function openWithListbox() {
+    const control = makeFakeControl({ options: threeOptions });
+    const utils = renderDropdown(control);
+    fireEvent.keyDown(getTrigger(utils.container), { key: "Enter" });
+    return { control, ...utils };
+  }
+
+  it("ArrowDown advances aria-activedescendant to the next option", () => {
+    const { container } = openWithListbox();
+    const listbox = getListbox(container)!;
+    fireEvent.keyDown(listbox, { key: "ArrowDown" });
+    expect(listbox.getAttribute("aria-activedescendant"))
+      .toBe("dropdown-listbox-ctl-1-opt-1");
+  });
+
+  it("ArrowUp from the first option wraps to the last", () => {
+    const { container } = openWithListbox();
+    const listbox = getListbox(container)!;
+    fireEvent.keyDown(listbox, { key: "ArrowUp" });
+    expect(listbox.getAttribute("aria-activedescendant"))
+      .toBe("dropdown-listbox-ctl-1-opt-2");
+  });
+
+  it("Home jumps to the first option", () => {
+    const { container } = openWithListbox();
+    const listbox = getListbox(container)!;
+    fireEvent.keyDown(listbox, { key: "ArrowDown" });
+    fireEvent.keyDown(listbox, { key: "ArrowDown" });
+    fireEvent.keyDown(listbox, { key: "Home" });
+    expect(listbox.getAttribute("aria-activedescendant"))
+      .toBe("dropdown-listbox-ctl-1-opt-0");
+  });
+
+  it("End jumps to the last option", () => {
+    const { container } = openWithListbox();
+    const listbox = getListbox(container)!;
+    fireEvent.keyDown(listbox, { key: "End" });
+    expect(listbox.getAttribute("aria-activedescendant"))
+      .toBe("dropdown-listbox-ctl-1-opt-2");
+  });
+
+  it("ArrowDown skips disabled options", () => {
+    const control = makeFakeControl({
+      options: [
+        { name: "alpha" },
+        { name: "beta", active: false },
+        { name: "gamma" },
+      ],
+    });
+    const { container } = renderDropdown(control);
+    fireEvent.keyDown(getTrigger(container), { key: "Enter" });
+    const listbox = getListbox(container)!;
+    fireEvent.keyDown(listbox, { key: "ArrowDown" });
+    expect(listbox.getAttribute("aria-activedescendant"))
+      .toBe("dropdown-listbox-ctl-1-opt-2");
+  });
+});
+
+describe("DropdownList commit and dismiss (CLUE-455)", () => {
+  it("Enter on a highlighted option commits the value and closes the listbox", () => {
+    const control = makeFakeControl({ options: threeOptions });
+    const { container } = renderDropdown(control);
+    fireEvent.keyDown(getTrigger(container), { key: "Enter" });
+    fireEvent.keyDown(getListbox(container)!, { key: "ArrowDown" });
+    fireEvent.keyDown(getListbox(container)!, { key: "Enter" });
+    expect(control.setValueCalls).toEqual(["beta"]);
+    expect(getListbox(container)).toBeNull();
+  });
+
+  it("Space on a highlighted option commits the value and closes the listbox", () => {
+    const control = makeFakeControl({ options: threeOptions });
+    const { container } = renderDropdown(control);
+    fireEvent.keyDown(getTrigger(container), { key: "Enter" });
+    fireEvent.keyDown(getListbox(container)!, { key: "ArrowDown" });
+    fireEvent.keyDown(getListbox(container)!, { key: " " });
+    expect(control.setValueCalls).toEqual(["beta"]);
+    expect(getListbox(container)).toBeNull();
+  });
+
+  it("Escape closes the listbox without committing and returns focus to the trigger", () => {
+    const control = makeFakeControl({ options: threeOptions, initialValue: "alpha" });
+    const { container } = renderDropdown(control);
+    const trigger = getTrigger(container);
+    fireEvent.keyDown(trigger, { key: "Enter" });
+    fireEvent.keyDown(getListbox(container)!, { key: "ArrowDown" });
+    fireEvent.keyDown(getListbox(container)!, { key: "Escape" });
+    expect(control.setValueCalls).toEqual([]);
+    expect(getListbox(container)).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("Tab closes the listbox without committing", () => {
+    const control = makeFakeControl({ options: threeOptions });
+    const { container } = renderDropdown(control);
+    fireEvent.keyDown(getTrigger(container), { key: "Enter" });
+    fireEvent.keyDown(getListbox(container)!, { key: "Tab" });
+    expect(control.setValueCalls).toEqual([]);
+    expect(getListbox(container)).toBeNull();
+  });
+
+  it("clicking outside closes the listbox", () => {
+    const control = makeFakeControl({ options: threeOptions });
+    const { container } = renderDropdown(control);
+    fireEvent.keyDown(getTrigger(container), { key: "Enter" });
+    fireEvent.pointerDown(document.body);
+    expect(getListbox(container)).toBeNull();
+  });
+});
+
+describe("DropdownList read-only behavior (CLUE-455)", () => {
+  it("disables the trigger button when the node is read-only", () => {
+    const control = makeFakeControl({ options: threeOptions, readOnly: true });
+    const { container } = renderDropdown(control);
+    expect(getTrigger(container).disabled).toBe(true);
+  });
+
+  it("does not disable the trigger button when the node is editable", () => {
+    const control = makeFakeControl({ options: threeOptions, readOnly: false });
+    const { container } = renderDropdown(control);
+    expect(getTrigger(container).disabled).toBe(false);
+  });
+});

--- a/src/plugins/dataflow/nodes/controls/dropdown-list-control.test.tsx
+++ b/src/plugins/dataflow/nodes/controls/dropdown-list-control.test.tsx
@@ -241,15 +241,22 @@ describe("DropdownList commit and dismiss (CLUE-455)", () => {
 });
 
 describe("DropdownList read-only behavior (CLUE-455)", () => {
-  it("disables the trigger button when the node is read-only", () => {
+  it("marks the trigger button aria-disabled when the node is read-only", () => {
     const control = makeFakeControl({ options: threeOptions, readOnly: true });
     const { container } = renderDropdown(control);
-    expect(getTrigger(container).disabled).toBe(true);
+    expect(getTrigger(container).getAttribute("aria-disabled")).toBe("true");
   });
 
-  it("does not disable the trigger button when the node is editable", () => {
+  it("does not mark the trigger button aria-disabled when the node is editable", () => {
     const control = makeFakeControl({ options: threeOptions, readOnly: false });
     const { container } = renderDropdown(control);
-    expect(getTrigger(container).disabled).toBe(false);
+    expect(getTrigger(container).getAttribute("aria-disabled")).toBe("false");
+  });
+
+  it("does not open the listbox on Enter when the node is read-only", () => {
+    const control = makeFakeControl({ options: threeOptions, readOnly: true });
+    const { container } = renderDropdown(control);
+    fireEvent.keyDown(getTrigger(container), { key: "Enter" });
+    expect(container.querySelector('[role="listbox"]')).toBeNull();
   });
 });

--- a/src/plugins/dataflow/nodes/controls/dropdown-list-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/dropdown-list-control.tsx
@@ -294,6 +294,7 @@ export const DropdownList: React.FC<{
   };
 
   const handleTriggerClick = () => {
+    if (control.node.readOnly) return;
     if (showList) {
       close();
     } else {
@@ -304,7 +305,7 @@ export const DropdownList: React.FC<{
   const handleTriggerKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
     if (e.key === "Enter" || e.key === " ") {
       e.preventDefault();
-      open();
+      if (!control.node.readOnly) open();
       return;
     }
     // ArrowDown used to open the listbox, but the in-block roving cycle now owns
@@ -333,7 +334,7 @@ export const DropdownList: React.FC<{
         type="button"
         className={labelClasses}
         tabIndex={-1}
-        disabled={control.node.readOnly}
+        aria-disabled={control.node.readOnly}
         aria-haspopup="listbox"
         aria-expanded={showList}
         aria-controls={listboxId}

--- a/src/plugins/dataflow/nodes/controls/dropdown-list-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/dropdown-list-control.tsx
@@ -1,10 +1,11 @@
-import React, { FunctionComponent, SVGProps, useCallback, useRef, useState } from "react";
+import React, { FunctionComponent, SVGProps, useEffect, useRef, useState } from "react";
 import { action, computed, makeObservable, observable } from "mobx";
 import { observer } from "mobx-react";
 import { ClassicPreset } from "rete";
 import classNames from "classnames";
 import { useStopEventPropagation, useCloseDropdownOnOutsideEvent } from "./custom-hooks";
 import { IBaseNode, IBaseNodeModel } from "../base-node";
+import { handleBlockChildKeyDown } from "../dataflow-node";
 
 import DropdownCaretIcon from "../../../../assets/dropdown-caret.svg";
 
@@ -182,6 +183,7 @@ export class DropdownListControl<
 
 export interface IDropdownListControl {
   id: string;
+  node: IBaseNode;
   model: IBaseNodeModel;
   modelKey: string;
   options: ListOption[];
@@ -218,44 +220,127 @@ export const DropdownList: React.FC<{
   const title = control.tooltip;
   const { options, placeholder } = control;
   const divRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
   useStopEventPropagation(divRef, "pointerdown");
   useStopEventPropagation(divRef, "wheel");
-  const listRef = useRef<HTMLDivElement>(null);
 
   const [showList, setShowList] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
 
-  // This will reset the listeners on every render because internally it has a useEffect depending
-  // on the two callbacks
   useCloseDropdownOnOutsideEvent(listRef, () => showList, () => {
     setShowList(false);
   });
 
+  // Focus the listbox when it opens so subsequent key events route to handleListKeyDown.
+  // (React's autoFocus prop is only valid on form elements, not on <div>.)
+  useEffect(() => {
+    if (showList) listRef.current?.focus();
+  }, [showList]);
+
   const val = control.getValue();
   const option = options.find((opt) => optionValue(opt) === val);
+  const currentIndex = options.findIndex(opt => optionValue(opt) === val);
   const activeHub = option?.active !== false;
   const liveNode = control.model.type.substring(0,4) === "Live";
   const disableSelected = control.modelKey === "hubSelect" && liveNode && !activeHub;
   const labelClasses = classNames("item top", { disabled: disableSelected, missing: option?.missing });
+  const listboxId = `dropdown-listbox-${control.id}`;
 
-  const onItemClick = useCallback((v: any) => {
+  const isOptionDisabled = (opt: ListOption) =>
+    opt.active === false || control.disabledFunction?.(opt) === true;
+
+  const moveHighlight = (delta: 1 | -1) => {
+    let i = highlightedIndex;
+    for (let step = 0; step < options.length; step++) {
+      i = (i + delta + options.length) % options.length;
+      if (!isOptionDisabled(options[i])) {
+        setHighlightedIndex(i);
+        return;
+      }
+    }
+  };
+
+  const findFirstEnabledIndex = (start: number, dir: 1 | -1): number => {
+    let i = start;
+    for (let step = 0; step < options.length; step++) {
+      if (!isOptionDisabled(options[i])) return i;
+      i = (i + dir + options.length) % options.length;
+    }
+    return start;
+  };
+
+  const open = () => {
     control.selectNode();
-    setShowList(value => !value);
-
+    setShowList(true);
+    const startIndex = currentIndex >= 0 && !isOptionDisabled(options[currentIndex])
+      ? currentIndex
+      : findFirstEnabledIndex(0, 1);
+    setHighlightedIndex(startIndex);
     control.logEvent("nodedropdownclick");
-  }, [control]);
+  };
 
-  // Generate a handler for each list item
-  const onListClick = useCallback((v: string) => () => {
+  const close = () => {
+    setShowList(false);
+  };
+
+  const commit = (i: number) => {
+    if (isOptionDisabled(options[i])) return;
     control.selectNode();
-    setShowList(value => !value);
-    control.setValue(v);
-
+    control.setValue(optionValue(options[i]));
+    setShowList(false);
     control.logEvent("nodedropdownselection");
-  }, [control]);
+    triggerRef.current?.focus();
+  };
+
+  const handleTriggerClick = () => {
+    if (showList) {
+      close();
+    } else {
+      open();
+    }
+  };
+
+  const handleTriggerKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      open();
+      return;
+    }
+    // ArrowDown used to open the listbox, but the in-block roving cycle now owns
+    // the arrow keys; Enter/Space is the canonical "open" gesture.
+    handleBlockChildKeyDown(e);
+  };
+
+  const handleListKeyDown = (e: React.KeyboardEvent) => {
+    switch (e.key) {
+      case "ArrowDown": e.preventDefault(); moveHighlight(1); break;
+      case "ArrowUp":   e.preventDefault(); moveHighlight(-1); break;
+      case "Home":      e.preventDefault(); setHighlightedIndex(findFirstEnabledIndex(0, 1)); break;
+      case "End":       e.preventDefault();
+                        setHighlightedIndex(findFirstEnabledIndex(options.length - 1, -1)); break;
+      case "Enter":
+      case " ":         e.preventDefault(); commit(highlightedIndex); break;
+      case "Escape":    e.preventDefault(); close(); triggerRef.current?.focus(); break;
+      case "Tab":       close(); break; // let Tab proceed
+    }
+  };
 
   return (
     <div className={`node-select ${listClass}`} ref={divRef} title={title}>
-      <div className={labelClasses} onMouseDown={onItemClick}>
+      <button
+        ref={triggerRef}
+        type="button"
+        className={labelClasses}
+        tabIndex={-1}
+        disabled={control.node.readOnly}
+        aria-haspopup="listbox"
+        aria-expanded={showList}
+        aria-controls={listboxId}
+        aria-label={`${title}: ${option?.displayName ?? option?.name ?? placeholder}`}
+        onMouseDown={handleTriggerClick}
+        onKeyDown={handleTriggerKeyDown}
+      >
         { option
           ? <ListOptionComponent option={option}/>
           : <div className="label unselected">{placeholder}</div>
@@ -263,30 +348,42 @@ export const DropdownList: React.FC<{
         <svg className="icon dropdown-caret">
           <DropdownCaretIcon />
         </svg>
-      </div>
-      {showList ?
-      <div className={`option-list ${listClass}`} ref={listRef}>
-        {options.map((ops, i) => {
-          const disabled = ops.active === false || control.disabledFunction?.(ops);
-          const missing = ops.missing;
-          const className = classNames("item", listClass, {
-            disabled,
-            selectable: !disabled,
-            selected: optionValue(ops) === val,
-            missing
-          });
-          return (
-            <div
-              className={className}
-              key={i}
-              onMouseDown={!disabled ? onListClick(optionValue(ops)) : undefined}
-            >
-              <ListOptionComponent option={ops} />
-            </div>
-          );
-        })}
-      </div>
-      : null }
+      </button>
+      {showList && (
+        <div
+          id={listboxId}
+          ref={listRef}
+          className={`option-list ${listClass}`}
+          role="listbox"
+          tabIndex={-1}
+          aria-activedescendant={`${listboxId}-opt-${highlightedIndex}`}
+          onKeyDown={handleListKeyDown}
+        >
+          {options.map((ops, i) => {
+            const disabled = isOptionDisabled(ops);
+            const className = classNames("item", listClass, {
+              disabled,
+              selectable: !disabled,
+              selected: optionValue(ops) === val,
+              highlighted: i === highlightedIndex,
+              missing: ops.missing
+            });
+            return (
+              <div
+                id={`${listboxId}-opt-${i}`}
+                role="option"
+                aria-selected={optionValue(ops) === val}
+                aria-disabled={disabled}
+                className={className}
+                key={i}
+                onMouseDown={!disabled ? () => commit(i) : undefined}
+              >
+                <ListOptionComponent option={ops} />
+              </div>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 });

--- a/src/plugins/dataflow/nodes/controls/num-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/num-control.tsx
@@ -3,6 +3,7 @@ import { ClassicPreset } from "rete";
 import { observer } from "mobx-react";
 import { useStopEventPropagation } from "./custom-hooks";
 import { IBaseNode } from "../base-node";
+import { handleBlockChildKeyDown } from "../dataflow-node";
 
 // This generics design isn't very user friendly if a caller
 // tries to construct the NumberControl with a key that doesn't
@@ -97,10 +98,12 @@ export const NumberControlComponent: React.FC<{ data: INumberControl }> = observ
     }
   }, [control]);
 
-  const handleKeyPress = useCallback((e: any) => {
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
       e.currentTarget.blur();
+      return;
     }
+    handleBlockChildKeyDown(e);
   }, []);
 
   // FIXME: in readOnly mode there is a lot of stuff in this component that is
@@ -121,9 +124,11 @@ export const NumberControlComponent: React.FC<{ data: INumberControl }> = observ
       }
       <input className={`number-input`}
         ref={inputRef}
+        tabIndex={-1}
         type={"text"}
         value={possiblyReadOnlyInputValue}
-        onKeyPress={handleKeyPress}
+        disabled={control.node.readOnly}
+        onKeyDown={handleKeyDown}
         onChange={handleChange}
         onBlur={handleBlur}
       />

--- a/src/plugins/dataflow/nodes/controls/num-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/num-control.tsx
@@ -86,6 +86,7 @@ export const NumberControlComponent: React.FC<{ data: INumberControl }> = observ
   }, []);
 
   const handleBlur = useCallback((e: any) => {
+    if (control.node.readOnly) return;
     const v = e.target.value;
     if (isFinite(v)) {
       const newValue = Number(v);
@@ -127,7 +128,7 @@ export const NumberControlComponent: React.FC<{ data: INumberControl }> = observ
         tabIndex={-1}
         type={"text"}
         value={possiblyReadOnlyInputValue}
-        disabled={control.node.readOnly}
+        readOnly={control.node.readOnly}
         onKeyDown={handleKeyDown}
         onChange={handleChange}
         onBlur={handleBlur}

--- a/src/plugins/dataflow/nodes/controls/num-units-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/num-units-control.tsx
@@ -133,6 +133,7 @@ export const NumberUnitsControlComponent: React.FC<{ data: INumberUnitsControl; 
   }, []);
 
   const handleBlur = useCallback((e: any) => {
+    if (control.node.readOnly) return;
     const v = e.target.value;
     // Note that "" and " " are considered finite. This is because they are converted to 0.
     if (isFinite(v)) {
@@ -157,6 +158,7 @@ export const NumberUnitsControlComponent: React.FC<{ data: INumberUnitsControl; 
   }, []);
 
   const handleSelectChange = useCallback((event: React.ChangeEvent<HTMLSelectElement>) => {
+    if (control.node.readOnly) return;
     const oldValue = control.getValueForUser();
 
     control.setCurrentUnits(event.target.value);
@@ -195,7 +197,7 @@ export const NumberUnitsControlComponent: React.FC<{ data: INumberUnitsControl; 
         tabIndex={-1}
         type={"text"}
         value={possiblyReadOnlyInputValue}
-        disabled={control.node.readOnly}
+        readOnly={control.node.readOnly}
         onKeyDown={handleKeyDown}
         onChange={handleChange}
         onBlur={handleBlur}
@@ -208,7 +210,7 @@ export const NumberUnitsControlComponent: React.FC<{ data: INumberUnitsControl; 
             <div className="type-options">
               <select onChange={handleSelectChange}
                 value={control.getCurrentUnits()}
-                disabled={control.node.readOnly}
+                aria-disabled={control.node.readOnly}
                 tabIndex={-1}
               >
                 { control.units.map((unit, index) => (

--- a/src/plugins/dataflow/nodes/controls/num-units-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/num-units-control.tsx
@@ -5,6 +5,7 @@ import { NodePeriodUnits } from "../../model/utilities/node";
 import { IBaseNode } from "../base-node";
 import { observer } from "mobx-react";
 import classNames from "classnames";
+import { handleBlockChildKeyDown } from "../dataflow-node";
 
 export class NumberUnitsControl <
   ModelType extends
@@ -147,10 +148,12 @@ export const NumberUnitsControlComponent: React.FC<{ data: INumberUnitsControl; 
     }
   }, [control]);
 
-  const handleKeyPress = useCallback((e: any) => {
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
       e.currentTarget.blur();
+      return;
     }
+    handleBlockChildKeyDown(e);
   }, []);
 
   const handleSelectChange = useCallback((event: React.ChangeEvent<HTMLSelectElement>) => {
@@ -189,9 +192,11 @@ export const NumberUnitsControlComponent: React.FC<{ data: INumberUnitsControl; 
       }
       <input className={`number-input units ${unitsCountClass}`}
         ref={inputRef}
+        tabIndex={-1}
         type={"text"}
         value={possiblyReadOnlyInputValue}
-        onKeyPress={handleKeyPress}
+        disabled={control.node.readOnly}
+        onKeyDown={handleKeyDown}
         onChange={handleChange}
         onBlur={handleBlur}
       />
@@ -203,6 +208,8 @@ export const NumberUnitsControlComponent: React.FC<{ data: INumberUnitsControl; 
             <div className="type-options">
               <select onChange={handleSelectChange}
                 value={control.getCurrentUnits()}
+                disabled={control.node.readOnly}
+                tabIndex={-1}
               >
                 { control.units.map((unit, index) => (
                     <option key={index} value={unit}>{unit}</option>

--- a/src/plugins/dataflow/nodes/controls/plot-button-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/plot-button-control.tsx
@@ -4,6 +4,7 @@ import PreviewPlotIcon from "../../assets/icons/preview-plot.svg";
 import { observer } from "mobx-react";
 import { useStopEventPropagation } from "./custom-hooks";
 import { IBaseNode } from "../base-node";
+import { handleBlockChildKeyDown } from "../dataflow-node";
 
 interface PlottableModel {
   plot: boolean;
@@ -23,6 +24,7 @@ export class PlotButtonControl extends ClassicPreset.Control
   }
 
   togglePlot = () => {
+    if (this.node.readOnly) return;
     this.model.setPlot(!this.model.plot);
 
     const toggleStr = this.model.plot ? "on" : "off";
@@ -46,7 +48,19 @@ export const PlotButtonControlComponent = observer(
       <div
         ref={divRef}
         className={`graph-button main-color ${showGraph ? "active" : ""}`}
-        onClick={control.togglePlot}>
+        role="button"
+        tabIndex={-1}
+        aria-label={showGraph ? "Hide block value graph" : "Show block value graph"}
+        aria-pressed={showGraph}
+        onClick={control.togglePlot}
+        onKeyDown={e => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            control.togglePlot();
+            return;
+          }
+          handleBlockChildKeyDown(e);
+        }}>
         <svg className="icon">
           <PreviewPlotIcon />
         </svg>

--- a/src/plugins/dataflow/nodes/dataflow-node.scss
+++ b/src/plugins/dataflow/nodes/dataflow-node.scss
@@ -1,4 +1,5 @@
 @import "../../../components/vars";
+@import "../../../components/mixins";
 @import "../components/dataflow-vars";
 
 $node-width: 176px;
@@ -26,6 +27,8 @@ $top-space: 18px;
     box-shadow: 0 0 0 3px $charcoal-light-1;
   }
 
+  @include focus-ring(2px);
+
   .top-bar {
     display: flex;
     width: $node-inner-width;
@@ -38,11 +41,17 @@ $top-space: 18px;
       top: 1px;
       width: $top-space;
       height: $top-space;
+      // Reset native button chrome so it visually matches the prior <div>.
+      background: transparent;
+      border: 0;
+      padding: 0;
+      cursor: pointer;
       svg {
         width: 8px;
         height: 8px;
         z-index: 1;
       }
+      @include focus-ring(-2px);
     }
   }
   .node-type-letter {
@@ -71,10 +80,38 @@ $top-space: 18px;
       border-radius:4px;
       transform: translateX(9px);
       width: 123px;
+      @include focus-ring(-2px);
     }
   }
   .input {
     height: 2px;
+    // The wrapper is the focus target (so screen readers hit it on Tab) but
+    // it's often only 2px tall and is positioned away from the visible socket
+    // dot (esp. on demo-output / live-output nodes). Forward focus and
+    // connection-mode indicators onto the inner .input-socket so each ring
+    // surrounds the dot the user actually sees.
+    //
+    // Only one outline can be drawn per element, so the rules below are
+    // ordered by specificity: the most specific (focused candidate) wins.
+    &:focus { outline: none; }
+    // Plain keyboard focus (no connection mode in progress).
+    &:focus-visible .input-socket,
+    &.keyboard-focused .input-socket {
+      outline: 2px solid $focus-ring-color;
+      outline-offset: 2px;
+    }
+    // Candidate, not currently focused: dashed ring marks "you can land here".
+    &.connection-candidate .input-socket {
+      outline: 2px dashed $focus-ring-color;
+      outline-offset: 4px;
+    }
+    // Currently-focused candidate: solid ring (replaces the dashed one).
+    // Higher specificity than both rules above so this wins.
+    &.connection-candidate:focus-visible .input-socket,
+    &.connection-candidate.keyboard-focused .input-socket {
+      outline: 2px solid $focus-ring-color;
+      outline-offset: 4px;
+    }
     .input-socket {
       position: absolute;
       left: -20px;
@@ -87,6 +124,18 @@ $top-space: 18px;
   .output {
     position: absolute;
     right: -21px;
+    // Same reasoning as .input — visual indicators go on the dot, not the wrapper.
+    // Order matters for cascade resolution: source ring wins over focus ring.
+    &:focus { outline: none; }
+    &:focus-visible .output-socket,
+    &.keyboard-focused .output-socket {
+      outline: 2px solid $focus-ring-color;
+      outline-offset: 2px;
+    }
+    &.connection-source .output-socket {
+      outline: 2px solid $focus-ring-color;
+      outline-offset: 4px;
+    }
     .output-title {
       display: none;
     }
@@ -98,6 +147,7 @@ $top-space: 18px;
     .node-select .item {
       height: $std-height;
       font-size: 13px;
+      @include focus-ring(-2px);
     }
   }
   .node-graph-toggle-button {
@@ -118,6 +168,7 @@ $top-space: 18px;
       border-radius: 1px;
       border: 2px solid white;
       background-color: white;
+      @include focus-ring(-2px);
       svg {
         width: 14px;
         height: 14px;
@@ -153,6 +204,7 @@ $top-space: 18px;
         border-radius: 1px;
         margin-left: 1px;
         border:0px;
+        @include focus-ring(-2px);
 
         &.plus {
           font-size: 14px;
@@ -248,7 +300,16 @@ $top-space: 18px;
       flex:1;
       border-radius:3px;
       height: $std-height;
+      @include focus-ring(-2px);
     }
+  }
+}
+
+.node {
+  // Catch-all focus rings for inner buttons that may sit outside the more specific
+  // selectors above (e.g. <button> children of demo-output-value-container).
+  .demo-output-value-container button {
+    @include focus-ring(-2px);
   }
 }
 
@@ -569,4 +630,3 @@ $top-space: 18px;
     top: 125px;
   }
 }
-

--- a/src/plugins/dataflow/nodes/dataflow-node.tsx
+++ b/src/plugins/dataflow/nodes/dataflow-node.tsx
@@ -37,6 +37,111 @@ function inputClass(s?: string) {
   return s ? "input " + s.toLowerCase().replace(/ /g, "-") : "input";
 }
 
+// Keyboard-actionable descendants of a block, returned in DOM order. Hand-curated
+// rather than reusing `getVisibleFocusables` because every entry here has
+// `tabindex="-1"` (composite-widget pattern) — the standard focusable selector
+// excludes those by design.
+const BLOCK_INTERACTIVE_SELECTOR = [
+  '.close-node-button',
+  '.node-name-input',
+  '[data-socket-side]',
+  '.number-input',
+  '.number-container select',
+  '.node-select > button',
+  '.graph-button',
+].join(',');
+
+export function getBlockInteractives(blockEl: HTMLElement): HTMLElement[] {
+  return Array.from(blockEl.querySelectorAll<HTMLElement>(BLOCK_INTERACTIVE_SELECTOR));
+}
+
+function isTextEditingTarget(el: EventTarget | null): el is HTMLInputElement {
+  if (!(el instanceof HTMLInputElement)) return false;
+  return el.type === "text" || el.type === "number" || el.type === "search";
+}
+
+/**
+ * Roving in-block focus handler. Attach to every keyboard-actionable descendant
+ * of a block (the elements matched by `BLOCK_INTERACTIVE_SELECTOR`). Cycles focus
+ * within the closest `.node` ancestor on Arrow/Home/End. Tab/Shift+Tab are left
+ * to native handling so they leave the block entirely.
+ *
+ * Text inputs keep ArrowLeft/ArrowRight for cursor movement; ArrowUp/Down/Home/End
+ * still rove out of the input.
+ */
+export function handleBlockChildKeyDown(e: React.KeyboardEvent<HTMLElement>) {
+  if (!["ArrowRight", "ArrowDown", "ArrowLeft", "ArrowUp", "Home", "End"].includes(e.key)) return;
+  if (isTextEditingTarget(e.target) && (e.key === "ArrowLeft" || e.key === "ArrowRight")) return;
+
+  const blockEl = e.currentTarget.closest<HTMLElement>('.node');
+  if (!blockEl) return;
+  const interactives = getBlockInteractives(blockEl);
+  if (interactives.length === 0) return;
+  const i = interactives.indexOf(e.currentTarget);
+  if (i < 0) return;
+
+  e.preventDefault();
+  e.stopPropagation();
+  let next: number;
+  switch (e.key) {
+    case "Home":      next = 0; break;
+    case "End":       next = interactives.length - 1; break;
+    case "ArrowLeft":
+    case "ArrowUp":   next = (i - 1 + interactives.length) % interactives.length; break;
+    default:          next = (i + 1) % interactives.length; break; // ArrowRight, ArrowDown
+  }
+  interactives[next].focus();
+}
+
+function handleNodeKeyDown(
+  e: React.KeyboardEvent<HTMLDivElement>,
+  node: IBaseNode,
+  reteManager: ReteManager
+) {
+  // Don't intercept keys that originate from interactive descendants — those have
+  // their own roving handler. The block container only handles keys when it is
+  // itself the focus target.
+  if (e.target !== e.currentTarget) return;
+
+  if (e.key === "Enter" || e.key === " ") {
+    e.preventDefault();
+    reteManager.selectNode(node.id);
+    reteManager.announce(`Selected ${node.model.type} block ${node.model.orderedDisplayName}`);
+    return;
+  }
+
+  // Arrow keys on the block container itself enter the in-block cycle: ArrowRight/
+  // ArrowDown/Home land on the first interactive descendant; ArrowLeft/ArrowUp/End
+  // land on the last. Block-to-block navigation is via Tab.
+  if (["ArrowRight", "ArrowDown", "ArrowLeft", "ArrowUp", "Home", "End"].includes(e.key)) {
+    const interactives = getBlockInteractives(e.currentTarget);
+    if (interactives.length === 0) return;
+    e.preventDefault();
+    e.stopPropagation();
+    const goLast = e.key === "ArrowLeft" || e.key === "ArrowUp" || e.key === "End";
+    interactives[goLast ? interactives.length - 1 : 0].focus();
+  }
+}
+
+function handleSocketKeyDown(
+  e: React.KeyboardEvent<HTMLDivElement>,
+  nodeId: string,
+  socketKey: string,
+  side: "input" | "output",
+  reteManager: ReteManager
+) {
+  if (e.target !== e.currentTarget) return;
+  if (e.key !== "Enter" && e.key !== " ") return;
+  e.preventDefault();
+  e.stopPropagation();
+  if (side === "output") {
+    reteManager.beginConnectingFrom(nodeId, socketKey);
+  } else {
+    // Input-side Enter only commits when in connecting mode; otherwise it's a no-op.
+    reteManager.commitConnectingTo(nodeId, socketKey);
+  }
+}
+
 type Props<S extends ClassicScheme> = {
     data: S['Node'] & NodeExtraData
     styles?: () => any
@@ -48,7 +153,8 @@ type Props<S extends ClassicScheme> = {
 export type DataflowNodeComponent<Scheme extends ClassicScheme> = (props: Props<Scheme>) => JSX.Element
 
 export const CustomDataflowNode = observer(
-  function CustomDataflowNode<Scheme extends ClassicScheme>({data, styles, emit, editor, reteManager}: Props<Scheme>)
+  function CustomDataflowNode<Scheme extends ClassicScheme>(
+    {data, styles, emit, reteManager}: Props<Scheme>)
 {
   const inputs = Object.entries(data.inputs);
   const outputs = Object.entries(data.outputs);
@@ -81,9 +187,14 @@ export const CustomDataflowNode = observer(
     <div
       className={`node ${model.type.toLowerCase().replace(/ /g, "-")} ${dynamicClasses}`}
       data-testid="node"
+      tabIndex={0}
+      role="group"
+      aria-roledescription="block"
+      aria-label={`${model.type} block: ${model.orderedDisplayName}`}
+      onKeyDown={e => handleNodeKeyDown(e, node, reteManager)}
     >
       <div className="top-bar" onClick={() => console.log("top-bar click")}>
-        <Delete reteManager={reteManager} nodeId={id}/>
+        {!node.readOnly && <Delete reteManager={reteManager} nodeId={id}/>}
       </div>
 
       <div className="node-type-letter">{nodeLetter}</div>
@@ -93,7 +204,21 @@ export const CustomDataflowNode = observer(
       {/* Outputs */}
       {outputs.map(([key, output]) => (
         output &&
-          <div className="output" key={key} data-testid={`output-${key}`}>
+          <div
+            className="output"
+            key={key}
+            data-testid={`output-${key}`}
+            tabIndex={-1}
+            role="button"
+            aria-label={`Output socket: ${output?.label ?? key}`}
+            data-socket-side="output"
+            data-node-id={id}
+            data-socket-key={key}
+            onKeyDown={e => {
+              handleSocketKeyDown(e, id, key, "output", reteManager);
+              if (!e.defaultPrevented) handleBlockChildKeyDown(e);
+            }}
+          >
             <div className="output-title" data-testid="output-title">{output?.label}</div>
             <RefSocket
               name="output-socket"
@@ -119,7 +244,21 @@ export const CustomDataflowNode = observer(
       {/* Inputs */}
       {inputs.map(([key, input]) => (
         input &&
-          <div className={inputClass(input.label)} key={key} data-testid={`input-${key}`}>
+          <div
+            className={inputClass(input.label)}
+            key={key}
+            data-testid={`input-${key}`}
+            tabIndex={-1}
+            role="button"
+            aria-label={`Input socket: ${input?.label ?? key}`}
+            data-socket-side="input"
+            data-node-id={id}
+            data-socket-key={key}
+            onKeyDown={e => {
+              handleSocketKeyDown(e, id, key, "input", reteManager);
+              if (!e.defaultPrevented) handleBlockChildKeyDown(e);
+            }}
+          >
             <RefSocket
               name="input-socket"
               side="input"

--- a/src/plugins/dataflow/nodes/dataflow-node.tsx
+++ b/src/plugins/dataflow/nodes/dataflow-node.tsx
@@ -193,7 +193,7 @@ export const CustomDataflowNode = observer(
       aria-label={`${model.type} block: ${model.orderedDisplayName}`}
       onKeyDown={e => handleNodeKeyDown(e, node, reteManager)}
     >
-      <div className="top-bar" onClick={() => console.log("top-bar click")}>
+      <div className="top-bar">
         {!node.readOnly && <Delete reteManager={reteManager} nodeId={id}/>}
       </div>
 

--- a/src/plugins/dataflow/nodes/delete.tsx
+++ b/src/plugins/dataflow/nodes/delete.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useRef } from "react";
 import DeleteNodeIcon from "../assets/icons/delete-node.svg";
 import { useStopEventPropagation } from "./controls/custom-hooks";
 import { ReteManager } from "./rete-manager";
+import { handleBlockChildKeyDown } from "./dataflow-node";
 
 
 interface IProps {
@@ -15,15 +16,22 @@ export const Delete = ({reteManager, nodeId}: IProps) => {
     reteManager.removeNodeAndConnections(nodeId);
   }, [reteManager, nodeId]);
 
-  const divRef = useRef<HTMLDivElement>(null);
-  useStopEventPropagation(divRef, "pointerdown");
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  useStopEventPropagation(buttonRef, "pointerdown");
   return (
-    <div className="close-node-button control-color control-color-hoverable"
-      ref={divRef}
-      onClick={handleClick} title={"Delete Block"}>
+    <button
+      type="button"
+      className="close-node-button control-color control-color-hoverable"
+      ref={buttonRef}
+      tabIndex={-1}
+      onClick={handleClick}
+      onKeyDown={handleBlockChildKeyDown}
+      aria-label="Delete Block"
+      title="Delete Block"
+    >
       <svg className="icon">
         <DeleteNodeIcon />
       </svg>
-    </div>
+    </button>
   );
 };

--- a/src/plugins/dataflow/nodes/editable-node-name.tsx
+++ b/src/plugins/dataflow/nodes/editable-node-name.tsx
@@ -37,7 +37,7 @@ export const EditableNodeName: React.FC<EditableNodeNameProps> = observer(
     }
 
     function saveNodeName() {
-      if (discardingRef.current) return;
+      if (discardingRef.current || node.readOnly) return;
       nodeName && node.model.setOrderedDisplayName(nodeName);
     }
 
@@ -52,7 +52,7 @@ export const EditableNodeName: React.FC<EditableNodeNameProps> = observer(
           value={valueString}
           onChange={handleInputChange}
           onBlur={saveNodeName}
-          disabled={node.readOnly}
+          readOnly={node.readOnly}
           onKeyDown={handleKeyDown}
         />
       </div>

--- a/src/plugins/dataflow/nodes/editable-node-name.tsx
+++ b/src/plugins/dataflow/nodes/editable-node-name.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { IBaseNode } from './base-node';
 import { observer } from 'mobx-react';
+import { handleBlockChildKeyDown } from './dataflow-node';
 
 interface EditableNodeNameProps {
   node: IBaseNode;
@@ -9,6 +10,11 @@ interface EditableNodeNameProps {
 export const EditableNodeName: React.FC<EditableNodeNameProps> = observer(
   function EditableNodeName({ node }) {
     const [nodeName, setNodeName] = useState(node.model.orderedDisplayName);
+    // Tracks whether the upcoming blur is a discard (Escape) so `saveNodeName`
+    // can skip writing. We can't rely on resetting `nodeName` state before the
+    // blur — the state update is batched and the blur handler reads the stale
+    // (still-edited) closure value.
+    const discardingRef = useRef(false);
 
     function handleInputChange(e: React.ChangeEvent<HTMLInputElement>) {
       setNodeName(e.target.value);
@@ -17,10 +23,21 @@ export const EditableNodeName: React.FC<EditableNodeNameProps> = observer(
     function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
       if (e.key === 'Enter') {
         e.currentTarget.blur();
+        return;
       }
+      if (e.key === 'Escape') {
+        discardingRef.current = true;
+        setNodeName(node.model.orderedDisplayName);
+        e.currentTarget.blur();
+        discardingRef.current = false;
+        return;
+      }
+      // ArrowLeft/ArrowRight stay native (caret movement); ArrowUp/Down/Home/End rove.
+      handleBlockChildKeyDown(e);
     }
 
     function saveNodeName() {
+      if (discardingRef.current) return;
       nodeName && node.model.setOrderedDisplayName(nodeName);
     }
 
@@ -30,6 +47,8 @@ export const EditableNodeName: React.FC<EditableNodeNameProps> = observer(
       <div className="node-name">
         <input
           className="node-name-input"
+          aria-label="Block name"
+          tabIndex={-1}
           value={valueString}
           onChange={handleInputChange}
           onBlur={saveNodeName}

--- a/src/plugins/dataflow/nodes/rete-manager.test.ts
+++ b/src/plugins/dataflow/nodes/rete-manager.test.ts
@@ -1,0 +1,148 @@
+import { ReteManager } from "./rete-manager";
+
+interface IFakeNode { id: string; }
+interface IFakeNodeView {
+  position: { x: number; y: number };
+  element?: { getBoundingClientRect: () => { height: number; width: number } };
+}
+
+/**
+ * Builds a stub object with just enough surface area for the reading-order helpers.
+ * `getNodeIdsInReadingOrder` reads `this.editor.getNodes()`, the position from
+ * `this.area.nodeViews.get(id)?.position`, and the rendered height from
+ * `view.element?.getBoundingClientRect()`. Pass `h` per node to simulate
+ * variable-height nodes (e.g. plot-open); omit to fall back to the default 90.
+ */
+function makeManagerStub(
+  nodes: Array<{ id: string; x: number; y: number; h?: number }>
+): ReteManager {
+  const fakeNodes: IFakeNode[] = nodes.map(({ id }) => ({ id }));
+  const fakeViews = new Map<string, IFakeNodeView>(
+    nodes.map(({ id, x, y, h }) => [id, {
+      position: { x, y },
+      element: h !== undefined
+        ? { getBoundingClientRect: () => ({ height: h, width: 176 }) }
+        : undefined,
+    }])
+  );
+  const stub = Object.create(ReteManager.prototype);
+  stub.editor = { getNodes: () => fakeNodes };
+  stub.area = { nodeViews: fakeViews };
+  return stub;
+}
+
+describe("ReteManager.getNodeIdsInReadingOrder (CLUE-455)", () => {
+  it("orders three nodes left-to-right when they share the same row band", () => {
+    const manager = makeManagerStub([
+      { id: "c", x: 300, y: 10 },
+      { id: "a", x: 100, y: 10 },
+      { id: "b", x: 200, y: 10 },
+    ]);
+    expect(manager.getNodeIdsInReadingOrder()).toEqual(["a", "b", "c"]);
+  });
+
+  it("orders nodes top-to-bottom across row bands", () => {
+    const manager = makeManagerStub([
+      { id: "bottom", x: 100, y: 400 },
+      { id: "top", x: 100, y: 10 },
+      { id: "middle", x: 100, y: 200 },
+    ]);
+    expect(manager.getNodeIdsInReadingOrder()).toEqual(["top", "middle", "bottom"]);
+  });
+
+  it("breaks exact-position ties by node id", () => {
+    const manager = makeManagerStub([
+      { id: "node-z", x: 100, y: 100 },
+      { id: "node-a", x: 100, y: 100 },
+    ]);
+    expect(manager.getNodeIdsInReadingOrder()).toEqual(["node-a", "node-z"]);
+  });
+
+  it("sorts by x within a row before advancing to the next row", () => {
+    const manager = makeManagerStub([
+      { id: "row1-right", x: 200, y: 10 },
+      { id: "row1-left", x: 100, y: 10 },
+      { id: "row2-only", x: 50, y: 200 },
+    ]);
+    expect(manager.getNodeIdsInReadingOrder()).toEqual(["row1-left", "row1-right", "row2-only"]);
+  });
+
+  it("treats a node with no view as positioned at (0, 0)", () => {
+    const manager = makeManagerStub([{ id: "positioned", x: 500, y: 500 }]);
+    // Add an extra node whose view lookup will return undefined.
+    (manager as any).editor = { getNodes: () => [{ id: "no-view" }, { id: "positioned" }] };
+    expect(manager.getNodeIdsInReadingOrder()).toEqual(["no-view", "positioned"]);
+  });
+
+  it("groups a tall node and a node within its vertical extent into the same row", () => {
+    // Plot-open node: top=0, height=300, so it extends to y=300.
+    // Sibling at y=150 visually sits inside the tall node's footprint.
+    const manager = makeManagerStub([
+      { id: "tall-left", x: 0, y: 0, h: 300 },
+      { id: "short-right", x: 200, y: 150, h: 90 },
+    ]);
+    expect(manager.getNodeIdsInReadingOrder()).toEqual(["tall-left", "short-right"]);
+  });
+
+  it("starts a new row when a node sits below the previous row's bottom", () => {
+    // Top row's bottom is at y=90. The next node at y=200 is clearly below it.
+    const manager = makeManagerStub([
+      { id: "top-left", x: 0, y: 0, h: 90 },
+      { id: "top-right", x: 200, y: 0, h: 90 },
+      { id: "below-row", x: 100, y: 200, h: 90 },
+    ]);
+    expect(manager.getNodeIdsInReadingOrder()).toEqual(["top-left", "top-right", "below-row"]);
+  });
+
+  it("extends the current row when a later node's measured height pushes the row's bottom down", () => {
+    // First node short, second node taller and slightly offset down: its bottom
+    // becomes the row's bottom and absorbs a third node that would otherwise land below.
+    const manager = makeManagerStub([
+      { id: "a", x: 0,   y: 0,  h: 50 },
+      { id: "b", x: 100, y: 30, h: 250 },
+      { id: "c", x: 200, y: 200, h: 50 },
+    ]);
+    expect(manager.getNodeIdsInReadingOrder()).toEqual(["a", "b", "c"]);
+  });
+});
+
+describe("ReteManager.nextNodeIdInReadingOrder", () => {
+  const threeNodes = () => makeManagerStub([
+    { id: "a", x: 100, y: 10 },
+    { id: "b", x: 200, y: 10 },
+    { id: "c", x: 300, y: 10 },
+  ]);
+
+  it("wraps from last node to first on ArrowRight", () => {
+    expect(threeNodes().nextNodeIdInReadingOrder("c", "ArrowRight")).toBe("a");
+  });
+
+  it("wraps from first node to last on ArrowLeft", () => {
+    expect(threeNodes().nextNodeIdInReadingOrder("a", "ArrowLeft")).toBe("c");
+  });
+
+  it("advances to the next node on ArrowDown", () => {
+    expect(threeNodes().nextNodeIdInReadingOrder("a", "ArrowDown")).toBe("b");
+  });
+
+  it("returns the first node id on Home", () => {
+    expect(threeNodes().nextNodeIdInReadingOrder("c", "Home")).toBe("a");
+  });
+
+  it("returns the last node id on End", () => {
+    expect(threeNodes().nextNodeIdInReadingOrder("a", "End")).toBe("c");
+  });
+
+  it("returns the first node id when current id is unknown", () => {
+    expect(threeNodes().nextNodeIdInReadingOrder("missing", "ArrowRight")).toBe("a");
+  });
+
+  it("returns undefined when there are no nodes", () => {
+    const empty = makeManagerStub([]);
+    expect(empty.nextNodeIdInReadingOrder("anything", "ArrowRight")).toBeUndefined();
+  });
+
+  it("returns undefined for an unrecognized key", () => {
+    expect(threeNodes().nextNodeIdInReadingOrder("a", "Backspace")).toBeUndefined();
+  });
+});

--- a/src/plugins/dataflow/nodes/rete-manager.test.ts
+++ b/src/plugins/dataflow/nodes/rete-manager.test.ts
@@ -1,29 +1,21 @@
 import { ReteManager } from "./rete-manager";
 
 interface IFakeNode { id: string; }
-interface IFakeNodeView {
-  position: { x: number; y: number };
-  element?: { getBoundingClientRect: () => { height: number; width: number } };
-}
+interface IFakeNodeView { position: { x: number; y: number }; }
 
 /**
  * Builds a stub object with just enough surface area for the reading-order helpers.
- * `getNodeIdsInReadingOrder` reads `this.editor.getNodes()`, the position from
- * `this.area.nodeViews.get(id)?.position`, and the rendered height from
- * `view.element?.getBoundingClientRect()`. Pass `h` per node to simulate
- * variable-height nodes (e.g. plot-open); omit to fall back to the default 90.
+ * `getNodeIdsInReadingOrder` reads `this.editor.getNodes()` and the position
+ * from `this.mstProgram?.nodes?.get(id)` (with `this.area.nodeViews.get(id)?.position`
+ * as a fallback for tests that don't supply an MST model). Rows are banded
+ * with a fixed y-tolerance — measured node heights are intentionally not used.
  */
 function makeManagerStub(
-  nodes: Array<{ id: string; x: number; y: number; h?: number }>
+  nodes: Array<{ id: string; x: number; y: number }>
 ): ReteManager {
   const fakeNodes: IFakeNode[] = nodes.map(({ id }) => ({ id }));
   const fakeViews = new Map<string, IFakeNodeView>(
-    nodes.map(({ id, x, y, h }) => [id, {
-      position: { x, y },
-      element: h !== undefined
-        ? { getBoundingClientRect: () => ({ height: h, width: 176 }) }
-        : undefined,
-    }])
+    nodes.map(({ id, x, y }) => [id, { position: { x, y } }])
   );
   const stub = Object.create(ReteManager.prototype);
   stub.editor = { getNodes: () => fakeNodes };
@@ -74,35 +66,15 @@ describe("ReteManager.getNodeIdsInReadingOrder (CLUE-455)", () => {
     expect(manager.getNodeIdsInReadingOrder()).toEqual(["no-view", "positioned"]);
   });
 
-  it("groups a tall node and a node within its vertical extent into the same row", () => {
-    // Plot-open node: top=0, height=300, so it extends to y=300.
-    // Sibling at y=150 visually sits inside the tall node's footprint.
+  it("bands nodes into the same row when their y-coordinates are within tolerance", () => {
+    // 45px tolerance against the first node's y. y=0 and y=30 are within
+    // tolerance and band together; y=200 is well outside and starts a new row.
     const manager = makeManagerStub([
-      { id: "tall-left", x: 0, y: 0, h: 300 },
-      { id: "short-right", x: 200, y: 150, h: 90 },
+      { id: "left",  x: 0,   y: 0   },
+      { id: "right", x: 100, y: 30  },
+      { id: "below", x: 50,  y: 200 },
     ]);
-    expect(manager.getNodeIdsInReadingOrder()).toEqual(["tall-left", "short-right"]);
-  });
-
-  it("starts a new row when a node sits below the previous row's bottom", () => {
-    // Top row's bottom is at y=90. The next node at y=200 is clearly below it.
-    const manager = makeManagerStub([
-      { id: "top-left", x: 0, y: 0, h: 90 },
-      { id: "top-right", x: 200, y: 0, h: 90 },
-      { id: "below-row", x: 100, y: 200, h: 90 },
-    ]);
-    expect(manager.getNodeIdsInReadingOrder()).toEqual(["top-left", "top-right", "below-row"]);
-  });
-
-  it("extends the current row when a later node's measured height pushes the row's bottom down", () => {
-    // First node short, second node taller and slightly offset down: its bottom
-    // becomes the row's bottom and absorbs a third node that would otherwise land below.
-    const manager = makeManagerStub([
-      { id: "a", x: 0,   y: 0,  h: 50 },
-      { id: "b", x: 100, y: 30, h: 250 },
-      { id: "c", x: 200, y: 200, h: 50 },
-    ]);
-    expect(manager.getNodeIdsInReadingOrder()).toEqual(["a", "b", "c"]);
+    expect(manager.getNodeIdsInReadingOrder()).toEqual(["left", "right", "below"]);
   });
 });
 

--- a/src/plugins/dataflow/nodes/rete-manager.tsx
+++ b/src/plugins/dataflow/nodes/rete-manager.tsx
@@ -520,7 +520,6 @@ export class ReteManager implements INodeServices {
     candidateIndex: number;
   } | null = null;
 
-  // eslint-disable-next-line eqeqeq -- loose equality treats undefined as idle for prototype-only test stubs
   public get isConnecting() { return this.connecting != null; }
 
   /**

--- a/src/plugins/dataflow/nodes/rete-manager.tsx
+++ b/src/plugins/dataflow/nodes/rete-manager.tsx
@@ -148,6 +148,9 @@ export class ReteManager implements INodeServices {
         if (event === "nodedragged") {
           // We are done dragging the node, so save the position for real
           nodeModel.setPosition(nodeView.position);
+          // Drag changes the reading order; re-sync DOM so tab order matches.
+          // Deferred so Rete finishes its own DOM updates first.
+          queueMicrotask(() => this.syncNodeDomOrder());
         } else {
           // We are currently translating the node, only save it in volatile
           nodeModel.setLivePosition(nodeView.position);
@@ -290,6 +293,30 @@ export class ReteManager implements INodeServices {
     // Need to do an initial process after all of the nodes are create so their inputs are correct
     this.processAfterProgramChange();
     this.updateSharedProgramData();
+
+    // After the initial node DOM is mounted, sort children to match reading order
+    // so tab cycle / SR linear nav follow the visual layout. Subsequent changes are
+    // handled by the editor and area pipes below.
+    queueMicrotask(() => this.syncNodeDomOrder());
+
+    // Keep DOM order in sync with reading order on add/remove. Runs in both editable
+    // and read-only modes — the read-only tile still presents tabbable nodes for SR users.
+    editor.addPipe(context => {
+      if (context.type === "nodecreated" || context.type === "noderemoved") {
+        queueMicrotask(() => this.syncNodeDomOrder());
+      }
+      return context;
+    });
+
+    // If a node is removed while the user is in keyboard connection mode, recompute
+    // candidates so the cached socket-element references don't point at detached DOM.
+    // queueMicrotask defers until React has flushed the unmount.
+    editor.addPipe(context => {
+      if (context.type === "noderemoved" && this.isConnecting) {
+        queueMicrotask(() => this.refreshConnectingCandidates({ refocus: true }));
+      }
+      return context;
+    });
 
     if (!this.readOnly) {
       editor.addPipe(context => {
@@ -457,6 +484,331 @@ export class ReteManager implements INodeServices {
   public selectNode = (nodeId: string) => {
     this.area.emit({ type: "nodepicked", data: { id: nodeId } });
   };
+
+  /**
+   * Focus the node's keyboard-focusable `.node` div.
+   *
+   * `area.nodeViews.get(id).element` is Rete's positioning wrapper (no tabindex),
+   * with the React-rendered `.node` div nested inside. Calling `.focus()` on the
+   * wrapper does nothing, so callers that move focus by node id must reach down
+   * to the inner `.node` element instead.
+   */
+  public focusNode(nodeId: string) {
+    const view = this.area.nodeViews.get(nodeId);
+    view?.element?.querySelector<HTMLElement>('.node')?.focus();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Keyboard-driven connection mode
+  //
+  // Public surface:
+  //   beginConnectingFrom(sourceNodeId, sourceKey)  Enter on output socket
+  //   moveConnectingCandidate(direction)            Arrow keys cycle candidates
+  //   commitConnectingTo(targetNodeId, targetKey)   Enter on candidate input
+  //   cancelConnecting()                            Escape (and Tab via program)
+  //   isConnecting                                  read-only flag for handlers
+  //
+  // The state is a plain field — render code does not read it; the visual cue
+  // comes from a `connection-candidate` DOM class on each candidate socket and
+  // from focus moves between candidates.
+  // ---------------------------------------------------------------------------
+
+  private connecting: {
+    sourceNodeId: string;
+    sourceKey: string;
+    candidates: Array<{ nodeId: string; inputKey: string; socketEl: HTMLElement }>;
+    candidateIndex: number;
+  } | null = null;
+
+  // eslint-disable-next-line eqeqeq -- loose equality treats undefined as idle for prototype-only test stubs
+  public get isConnecting() { return this.connecting != null; }
+
+  /**
+   * Walks every node other than the source, every input socket on each, and
+   * collects the rendered socket-wrapper elements (those carrying
+   * `data-socket-side="input"` and `data-socket-key`). Sorted by node reading
+   * order so arrow-cycling matches what a sighted user expects.
+   */
+  public getCompatibleTargets(sourceNodeId: string, sourceOutputKey: string): Array<{
+    nodeId: string;
+    inputKey: string;
+    socketEl: HTMLElement;
+  }> {
+    const sourceNode = this.editor.getNode(sourceNodeId);
+    if (!sourceNode || !sourceNode.outputs?.[sourceOutputKey]) return [];
+    const candidates: Array<{ nodeId: string; inputKey: string; socketEl: HTMLElement }> = [];
+    for (const node of this.editor.getNodes()) {
+      if (node.id === sourceNodeId) continue;
+      const view = this.area.nodeViews.get(node.id);
+      if (!view?.element) continue;
+      for (const inputKey of Object.keys(node.inputs)) {
+        if (!node.inputs[inputKey]) continue;
+        const socketEl = view.element.querySelector<HTMLElement>(
+          `[data-socket-side="input"][data-socket-key="${inputKey}"]`
+        );
+        if (socketEl) candidates.push({ nodeId: node.id, inputKey, socketEl });
+      }
+    }
+    const order = this.getNodeIdsInReadingOrder();
+    const orderIndex = new Map(order.map((id, i) => [id, i]));
+    candidates.sort((a, b) => (orderIndex.get(a.nodeId) ?? 0) - (orderIndex.get(b.nodeId) ?? 0));
+    return candidates;
+  }
+
+  /**
+   * Programmatically create a connection. The connection plugin's drag flow
+   * routes through the same `editor.addConnection` underneath, so the MST
+   * model, processing, and event listeners all fire identically. Replaces any
+   * existing connection on the target input first to mirror the drag UX.
+   */
+  public async connect(
+    sourceNodeId: string, sourceOutputKey: string,
+    targetNodeId: string, targetInputKey: string
+  ) {
+    this.removeInputConnection(targetNodeId, targetInputKey);
+    await this.editor.addConnection({
+      id: uniqueId(),
+      source: sourceNodeId,
+      sourceOutput: sourceOutputKey,
+      target: targetNodeId,
+      targetInput: targetInputKey,
+    } as any);
+  }
+
+  public beginConnectingFrom(sourceNodeId: string, sourceKey: string) {
+    if (this.readOnly) return;
+    const candidates = this.getCompatibleTargets(sourceNodeId, sourceKey);
+    if (candidates.length === 0) {
+      this.announce("No compatible target sockets");
+      return;
+    }
+    this.connecting = { sourceNodeId, sourceKey, candidates, candidateIndex: 0 };
+    candidates.forEach(c => c.socketEl.classList.add("connection-candidate"));
+    // Mark the source so users can still see where the in-flight connection starts.
+    this.getOutputSocketEl(sourceNodeId, sourceKey)?.classList.add("connection-source");
+    candidates[0].socketEl.focus();
+    const sourceNode = this.editor.getNode(sourceNodeId);
+    this.announce(
+      `Connecting from ${sourceNode?.label} ${sourceKey}. ` +
+      `Use arrow keys to choose target. Enter to connect, Escape to cancel.`
+    );
+  }
+
+  public moveConnectingCandidate(direction: 1 | -1) {
+    if (!this.connecting) return;
+    // If the cached candidate's DOM element is detached (e.g. its node was
+    // removed mid-connection), recompute against the live editor before moving.
+    const current = this.connecting.candidates[this.connecting.candidateIndex];
+    if (!current?.socketEl.isConnected && !this.refreshConnectingCandidates({ refocus: false })) {
+      return;
+    }
+    const n = this.connecting.candidates.length;
+    this.connecting.candidateIndex = (this.connecting.candidateIndex + direction + n) % n;
+    this.connecting.candidates[this.connecting.candidateIndex].socketEl.focus();
+  }
+
+  public async commitConnectingTo(targetNodeId: string, targetInputKey: string) {
+    if (!this.connecting) return;
+    const { sourceNodeId, sourceKey, candidates } = this.connecting;
+    const matched = candidates.some(c => c.nodeId === targetNodeId && c.inputKey === targetInputKey);
+    if (!matched) return;
+    await this.connect(sourceNodeId, sourceKey, targetNodeId, targetInputKey);
+    this.cleanupConnectingHighlights();
+    const sourceNode = this.editor.getNode(sourceNodeId);
+    const targetNode = this.editor.getNode(targetNodeId);
+    this.connecting = null;
+    this.announce(`Connected ${sourceNode?.label} to ${targetNode?.label}`);
+    this.focusNode(targetNodeId);
+  }
+
+  public cancelConnecting() {
+    if (!this.connecting) return;
+    const { sourceNodeId, sourceKey } = this.connecting;
+    this.cleanupConnectingHighlights();
+    this.connecting = null;
+    this.announce("Cancelled connection");
+    // Don't try to focus a detached socket — its node may have been removed.
+    const sourceEl = this.getOutputSocketEl(sourceNodeId, sourceKey);
+    if (sourceEl?.isConnected) sourceEl.focus();
+  }
+
+  /**
+   * Recompute the connecting candidate list from the live editor and DOM,
+   * preserving the active candidate's focus when possible. Used when a node
+   * removal mid-connection invalidates cached `socketEl` references.
+   *
+   * Returns `true` if connecting mode can continue; `false` if the source
+   * node is gone or no candidates remain, in which case state is reset and
+   * a "Cancelled connection" announcement fires.
+   */
+  private refreshConnectingCandidates({ refocus }: { refocus: boolean }): boolean {
+    if (!this.connecting) return false;
+    const { sourceNodeId, sourceKey, candidates, candidateIndex } = this.connecting;
+
+    const sourceNode = this.editor.getNode(sourceNodeId);
+    if (!sourceNode) {
+      // Source node was removed — nothing to connect from.
+      candidates.forEach(c => c.socketEl.classList.remove("connection-candidate"));
+      this.connecting = null;
+      this.announce("Cancelled connection");
+      return false;
+    }
+
+    const fresh = this.getCompatibleTargets(sourceNodeId, sourceKey);
+    if (fresh.length === 0) {
+      this.cleanupConnectingHighlights();
+      this.connecting = null;
+      this.announce("Cancelled connection");
+      return false;
+    }
+
+    // Try to keep the previously-active candidate; otherwise clamp to a valid index.
+    const prev = candidates[candidateIndex];
+    let nextIndex = prev
+      ? fresh.findIndex(c => c.nodeId === prev.nodeId && c.inputKey === prev.inputKey)
+      : -1;
+    if (nextIndex === -1) nextIndex = Math.min(candidateIndex, fresh.length - 1);
+
+    // Clear stale highlights, apply to the new set.
+    candidates.forEach(c => c.socketEl.classList.remove("connection-candidate"));
+    fresh.forEach(c => c.socketEl.classList.add("connection-candidate"));
+
+    this.connecting = { sourceNodeId, sourceKey, candidates: fresh, candidateIndex: nextIndex };
+    if (refocus) fresh[nextIndex].socketEl.focus();
+    return true;
+  }
+
+  private cleanupConnectingHighlights() {
+    if (!this.connecting) return;
+    this.connecting.candidates.forEach(c => c.socketEl.classList.remove("connection-candidate"));
+    this.getOutputSocketEl(
+      this.connecting.sourceNodeId, this.connecting.sourceKey
+    )?.classList.remove("connection-source");
+  }
+
+  private getOutputSocketEl(nodeId: string, socketKey: string): HTMLElement | undefined {
+    const view = this.area.nodeViews.get(nodeId);
+    return view?.element?.querySelector<HTMLElement>(
+      `[data-socket-side="output"][data-socket-key="${socketKey}"]`
+    ) ?? undefined;
+  }
+
+  public announcement = observable({ value: "" });
+  private announceTimeoutId: number | null = null;
+
+  /**
+   * Pushes a string into the live region for screen reader announcements.
+   * Clears the region, then sets the message after a delay long enough for
+   * SR pollers (~100-150ms) to observe the cleared state — so identical
+   * back-to-back messages are still re-announced. rAF (~16ms) is too short.
+   */
+  public announce(message: string) {
+    if (this.announceTimeoutId !== null) {
+      window.clearTimeout(this.announceTimeoutId);
+    }
+    runInAction(() => {
+      this.announcement.value = "";
+    });
+    this.announceTimeoutId = window.setTimeout(() => {
+      this.announceTimeoutId = null;
+      runInAction(() => {
+        this.announcement.value = message;
+      });
+    }, 150);
+  }
+
+  /**
+   * Returns node ids in left-to-right, top-to-bottom reading order.
+   *
+   * Groups nodes into rows by Y position with a tolerance of half the placement
+   * grid's row height (`kRowHeight` in `getNewNodePosition`). A node joins the
+   * current row when its Y is within that tolerance of the row's first entry;
+   * otherwise it starts a new row. Within a row, sorts by X. Breaks exact-position
+   * ties by id (creation-order-stable).
+   *
+   * Using a fixed tolerance instead of measured-height overlap avoids merging
+   * vertically-stacked nodes whose rendered heights exceed the 90px grid spacing
+   * (e.g. plot-open or Live Output nodes), which would otherwise put every
+   * node in column 0 into the same "row" and let the id tiebreaker decide order.
+   */
+  public getNodeIdsInReadingOrder(): string[] {
+    const ROW_TOLERANCE = 45;
+    interface Entry { id: string; x: number; y: number; }
+    const entries: Entry[] = this.editor.getNodes().map(n => {
+      // Prefer the MST model's persisted position over the area-plugin's
+      // view.position. `area.translate(...)` is async (it awaits guards before
+      // assigning to view.position), so a node created and translated in the
+      // same task still has view.position = {0, 0} at this point — that would
+      // collapse every just-created node into the same y-band and let the id
+      // tiebreaker decide order. The MST model gets x/y from `addNodeSnapshot`
+      // synchronously, so reading from there avoids the race. Fall back to the
+      // view position when the MST model isn't available (e.g., unit-test stubs).
+      const model = this.mstProgram?.nodes?.get(n.id);
+      if (model && Number.isFinite(model.x) && Number.isFinite(model.y)) {
+        return { id: n.id, x: model.x, y: model.y };
+      }
+      const view = this.area.nodeViews.get(n.id);
+      const pos = view?.position ?? { x: 0, y: 0 };
+      return { id: n.id, x: pos.x, y: pos.y };
+    });
+    entries.sort((a, b) => a.y - b.y);
+
+    const rows: Entry[][] = [];
+    for (const e of entries) {
+      const lastRow = rows[rows.length - 1];
+      if (lastRow && Math.abs(e.y - lastRow[0].y) < ROW_TOLERANCE) {
+        lastRow.push(e);
+      } else {
+        rows.push([e]);
+      }
+    }
+    for (const row of rows) {
+      row.sort((a, b) => a.x !== b.x ? a.x - b.x : a.id.localeCompare(b.id));
+    }
+    return rows.flatMap(row => row.map(e => e.id));
+  }
+
+  /**
+   * Re-sorts the Rete area container's node DOM children to match
+   * `getNodeIdsInReadingOrder()`. Rete positions nodes via CSS `transform`
+   * (independent of DOM order), so moving children around is visually a no-op,
+   * but it makes Tab order, screen-reader linear navigation, and the DevTools
+   * Elements panel all match the visual reading order. Without this, tab-cycle
+   * follows Rete's creation order which can leave a left-side node visited
+   * after a right-side node.
+   *
+   * Safe to call any time. No-op when there are fewer than 2 nodes or when no
+   * node has been attached to a parent yet.
+   */
+  public syncNodeDomOrder = () => {
+    const order = this.getNodeIdsInReadingOrder();
+    if (order.length < 2) return;
+    const firstView = this.area.nodeViews.get(order[0]);
+    const container = firstView?.element?.parentElement;
+    if (!container) return;
+    // appendChild moves an already-attached node to the end of children, so
+    // walking in reading order leaves the children in that exact order.
+    for (const id of order) {
+      const view = this.area.nodeViews.get(id);
+      if (view?.element) container.appendChild(view.element);
+    }
+  };
+
+  public nextNodeIdInReadingOrder(currentId: string, key: string): string | undefined {
+    const order = this.getNodeIdsInReadingOrder();
+    if (order.length === 0) return undefined;
+    const i = order.indexOf(currentId);
+    if (i < 0) return order[0];
+    switch (key) {
+      case "ArrowRight":
+      case "ArrowDown": return order[(i + 1) % order.length];
+      case "ArrowLeft":
+      case "ArrowUp":   return order[(i - 1 + order.length) % order.length];
+      case "Home":      return order[0];
+      case "End":       return order[order.length - 1];
+      default:          return undefined;
+    }
+  }
 
   private syncSelection() {
     // The selector stores entities with compound keys like "node_<id>".
@@ -724,6 +1076,10 @@ export class ReteManager implements INodeServices {
     if (this.fitTimeout) {
       clearTimeout(this.fitTimeout);
       this.fitTimeout = undefined;
+    }
+    if (this.announceTimeoutId !== null) {
+      window.clearTimeout(this.announceTimeoutId);
+      this.announceTimeoutId = null;
     }
 
     const {area, editor} = this;


### PR DESCRIPTION
[CLUE-455](https://concord-consortium.atlassian.net/browse/CLUE-455)

Brings the Dataflow tile to keyboard-accessibility parity with Sketch (CLUE-393) and Bar Graph (CLUE-454): a single Tab lands on the tile, Enter enters a focus trap, and arrow / Tab / Enter / Escape drive a complete keyboard interaction model over the program editor, including connection creation which previously had no keyboard path.

**What's in the Trap**

Focus cycle: title → topbar → program nodes (when present) → zoom in/out buttons → add-block palette → tile toolbar → resize handle → wrap.

- **Program nodes** (`.node`) - single Tab stop per block; arrow keys move between blocks in left-to-right / top-to-bottom visual order (banded by row, tie-broken by id for stability across renders, since Rete's DOM order is creation-order, not visual). Each block exposes `role="group"` + `aria-roledescription="block"`.
- **Add-Block palette** (`DataflowProgramToolbar`) - Now a real `role="toolbar"` with vertical roving tabindex, `aria-label="Add block"`, and an `aria-live` region announcing "Added X block".
- **Connection creation by keyboard** - Enter on an output socket enters "connecting" mode; arrow keys cycle the compatible-target candidate list; Enter commits via `editor.addConnection`, Escape cancels. Mode lives on the rete manager; live region announces begin / cancel / commit. Recovers gracefully from mid-connection node deletion.
- **Read-only Dataflow tiles** get the lighter `type: "region"` wiring - no trap, but ARIA labels, focus rings, and live-region announcements for the elements that remain interactive.

**Notable Infrastructure Changes**

- New optional `topbar` and `palette` slots on `ClueFocusTrapConfig`; palette is a single Tab stop with internal arrow roving (not in `tabWithinSlots`). DOM restructured so palette is a sibling of content rather than nested inside it.
- New shared `useRovingTabindex(containerRef, orientation)` hook, used by the program palette (vertical), tile toolbar (horizontal), and main app toolbar. Honors `aria-orientation` — vertical toolbars only respond to ArrowUp/Down, horizontal only to ArrowLeft/Right.
- `DataflowToolComponent` participates via `<ClueTileAccessibilityBridge>` rather than being refactored to a function component (preserves existing class-component lifecycle around `reteManager`).
- Dropdown control reworked into a real listbox with arrow / Enter / Escape semantics, focus management, and unit tests.
- Live regions use clear-then-set with a 150ms gap (long enough for SR pollers ~100-150ms to observe the cleared state) so identical back-to-back messages re-announce.
- Playback slider gets `ariaLabelForHandle`, `ariaValueTextFormatterForHandle` ("M:SS of M:SS"), and a real `:focus-visible` ring.

**NOTE:** The `@concord-consortium/accessibility-tools` version needs to be updated to a new pre-release before this is merged.

[CLUE-455]: https://concord-consortium.atlassian.net/browse/CLUE-455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ