### PR TITLE
chore: keyboard nav for curriculum tiles, menu items (CLUE-426)

### DIFF
--- a/cypress/e2e/functional/document_tests/my_work_keyboard_nav_spec.js
+++ b/cypress/e2e/functional/document_tests/my_work_keyboard_nav_spec.js
@@ -1,0 +1,119 @@
+/**
+ * Keyboard navigation tests for the My Work tab.
+ *
+ * - Tabbing reaches a document thumbnail (.list-item) and lands on its
+ *   bookmark button on the next tab.
+ * - Enter on a focused list item opens the document.
+ * - Enter on a focused bookmark toggles the starred state.
+ * - Tabbing never enters the embedded canvas (which is marked inert).
+ * - Clicking the inert canvas region still opens the document, since the
+ *   click bubbles to the parent .list-item.
+ */
+
+const queryParamsStudent = Cypress.config("qaUnitStudent5");
+
+function visitMyWork() {
+  cy.visit(queryParamsStudent);
+  cy.waitForLoad();
+  cy.openTopTab("my-work");
+  cy.openSection("my-work", "workspaces");
+  cy.get(".documents-list.workspaces .list-item").should("have.length.greaterThan", 0);
+}
+
+// Press Tab repeatedly until cy.focused() matches `selector`, up to maxTabs times.
+// Don't enumerate tab stops in tests — they're brittle to UI churn.
+function tabUntil(selector, maxTabs = 60) {
+  function step(remaining) {
+    if (remaining === 0) {
+      throw new Error(`tabUntil: did not reach ${selector} within ${maxTabs} tabs`);
+    }
+    cy.realPress("Tab");
+    cy.focused().then(($el) => {
+      if (!$el.is(selector)) {
+        step(remaining - 1);
+      }
+    });
+  }
+  step(maxTabs);
+}
+
+context("My Work tab — keyboard navigation", function () {
+  beforeEach(function () {
+    visitMyWork();
+  });
+
+  it("places focus on a list item after tabbing in from the My Work tab", function () {
+    cy.get(".top-tab.tab-my-work").focus();
+    tabUntil(".list-item");
+    cy.focused().should("have.attr", "role", "button");
+    cy.focused().invoke("attr", "aria-label").should("not.be.empty");
+  });
+
+  it("places focus on the bookmark button on the next tab after a list item", function () {
+    cy.get(".documents-list.workspaces .list-item").first().as("firstItem");
+    cy.get("@firstItem").focus();
+    cy.realPress("Tab");
+    cy.focused().should("have.attr", "data-testid", "bookmark-button");
+    // The bookmark button is a sibling of the .list-item (both wrapped by
+    // .list-item-container), so correlate them via that shared parent.
+    cy.focused().then(($focused) => {
+      cy.get("@firstItem").then(($firstItem) => {
+        expect($focused.closest(".list-item-container")[0])
+          .to.equal($firstItem.closest(".list-item-container")[0]);
+      });
+    });
+  });
+
+  it("opens the document when Enter is pressed on a focused list item", function () {
+    cy.get(".documents-list.workspaces .list-item").first().focus();
+    cy.realPress("Enter");
+    cy.get(".primary-workspace .editable-document-content").should("be.visible");
+  });
+
+  it("toggles bookmark state when Enter is pressed on a focused bookmark button", function () {
+    // The bookmark button is a sibling of .list-item, both inside
+    // .list-item-container. Scope queries to the first container so the test
+    // is unambiguous about which item's bookmark we're toggling.
+    cy.get(".documents-list.workspaces .list-item-container").first().as("container");
+    cy.get("@container").find('[data-testid="bookmark-button"]').as("bookmark");
+
+    cy.get("@bookmark").then(($btn) => {
+      const wasStarred = $btn.find(".icon-star").hasClass("starred");
+      cy.get("@bookmark").focus();
+      cy.realPress("Enter");
+      cy.get("@container").find(".icon-star")
+        .should(wasStarred ? "not.have.class" : "have.class", "starred");
+    });
+  });
+
+  it("does not move focus into the embedded canvas during keyboard navigation", function () {
+    // Start with focus on the first list item, then tab forward. At every
+    // stop, assert focus is not inside the inert canvas region. Stop when
+    // focus leaves the documents list — that means we've traversed all items
+    // and their bookmark buttons. A safety limit guards against UI bugs that
+    // could trap focus inside the list forever.
+    cy.get(".documents-list.workspaces .list-item").first().focus();
+    const safetyLimit = 200;
+    function step(remaining) {
+      if (remaining === 0) throw new Error("tab loop did not exit the documents-list");
+      cy.focused().then(($el) => {
+        expect(
+          $el.closest(".scaled-list-item-container").length,
+          "focus should not enter the inert canvas region"
+        ).to.eq(0);
+        if ($el.closest(".documents-list.workspaces").length > 0) {
+          cy.realPress("Tab");
+          step(remaining - 1);
+        }
+      });
+    }
+    step(safetyLimit);
+  });
+
+  it("opens the document when the inert canvas region is clicked (event bubbles to .list-item)", function () {
+    cy.get(".documents-list.workspaces .list-item").first()
+      .find(".scaled-list-item-container")
+      .click({ force: true });
+    cy.get(".primary-workspace .editable-document-content").should("be.visible");
+  });
+});

--- a/cypress/e2e/functional/document_tests/student_chat_spec.js
+++ b/cypress/e2e/functional/document_tests/student_chat_spec.js
@@ -22,7 +22,7 @@ context("Chat Panel", () => {
     cy.wait(1000);
 
     // click on a document
-    cy.get(".scaled-list-item-container").first().click();
+    cy.get(".documents-list .list-item").first().click();
 
     ChatTestHelpers.verifyChatPanelBasics();
     // This check will fail because commenting on curriculum is not currently supported,

--- a/cypress/support/elements/common/ResourcesPanel.js
+++ b/cypress/support/elements/common/ResourcesPanel.js
@@ -36,11 +36,11 @@ class ResourcesPanel{
     }
 
     starCanvasItem(tab, section,title){
-        cy.get('.documents-list.'+section+' .list-item[data-test='+section+'-list-items]').contains('.footer', title).siblings('.icon-holder').find('.icon-star').click();
+        cy.get('.documents-list.'+section+' .list-item[data-test='+section+'-list-items]').contains('.footer', title).closest('.list-item-container').children('.icon-holder').find('.icon-star').click();
     }
 
     getCanvasStarIcon(tab,section,title){
-        return this.getCanvasItemTitle(tab, section).contains(title).parent().parent().siblings('.icon-holder').find('.icon-star');
+        return this.getCanvasItemTitle(tab, section).contains(title).closest('.list-item-container').children('.icon-holder').find('.icon-star');
     }
 
     getDocumentCloseButton() {

--- a/src/components/document/document-file-menu.scss
+++ b/src/components/document/document-file-menu.scss
@@ -20,6 +20,7 @@
 
       &:active, &.show-list {
         background-color: $workspace-teal-dark-1;
+        color: white;
 
         svg path {
           fill: white;

--- a/src/components/document/document-group.scss
+++ b/src/components/document/document-group.scss
@@ -1,4 +1,5 @@
 @import "../vars";
+@import "../mixins";
 
 .doc-group {
   align-items: center;
@@ -62,6 +63,7 @@
   margin: 0;
   padding: 0;
   width: 16px;
+  @include focus-ring(2px);
 
   &.scroll-left {
     margin-right: 10px;

--- a/src/components/document/document.scss
+++ b/src/components/document/document.scss
@@ -1,4 +1,5 @@
 @import "../vars";
+@import "../mixins";
 
 .document {
   position: absolute;
@@ -242,6 +243,11 @@
           &:active {
             background-color: $workspace-teal-light-2;
           }
+        }
+        &.icon-publish,
+        &.icon-up1,
+        &.icon-up4 {
+          @include focus-ring(-2px);
         }
       }
       .icon-new {

--- a/src/components/document/sorted-section.scss
+++ b/src/components/document/sorted-section.scss
@@ -1,4 +1,5 @@
 @import "../vars";
+@import "../mixins";
 $title-margin: 2px;
 
 .sorted-sections {
@@ -64,6 +65,17 @@ $title-margin: 2px;
       .section-header-right {
         display: flex;
         align-items: center;
+
+        .section-header-arrow-button {
+          align-items: center;
+          appearance: none;
+          background: none;
+          border: none;
+          cursor: pointer;
+          display: inline-flex;
+          padding: 0;
+          @include focus-ring(2px);
+        }
 
         .section-header-arrow {
           cursor: pointer;

--- a/src/components/document/sorted-section.test.tsx
+++ b/src/components/document/sorted-section.test.tsx
@@ -1,0 +1,105 @@
+import { render, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Provider } from "mobx-react";
+import React from "react";
+
+import { SortedSection } from "./sorted-section";
+import { specStores } from "../../models/stores/spec-stores";
+import { DocumentGroup } from "../../models/stores/document-group";
+
+jest.mock("../../assets/icons/arrow/arrow.svg", () => function ArrowIconMock(props: object) {
+  return <svg data-testid="arrow-icon" {...props} />;
+});
+
+jest.mock("../thumbnail/decorated-document-thumbnail-item", () => ({
+  DecoratedDocumentThumbnailItem: () => <div data-testid="mock-thumb" />,
+}));
+
+jest.mock("./document-group", () => ({
+  DocumentGroupComponent: () => <div data-testid="mock-group" />,
+}));
+
+jest.mock("../../lib/logger", () => ({
+  Logger: { log: jest.fn() },
+}));
+
+function renderSection({ expanded = false }: { expanded?: boolean } = {}) {
+  const stores = specStores();
+  if (expanded) {
+    stores.ui.setExpandedSortWorkSections("Group A", true);
+  }
+  const documentGroup = new DocumentGroup({
+    label: "Group A",
+    sortType: "Group",
+    documents: [],
+    stores: {
+      groups: stores.groups,
+      class: stores.class,
+      appConfig: stores.appConfig,
+      bookmarks: stores.bookmarks,
+    },
+  });
+  const result = render(
+    <Provider stores={stores}>
+      <SortedSection
+        docFilter="Problem"
+        documentGroup={documentGroup}
+        idx={0}
+        secondarySort="None"
+        primarySortBy="Problem"
+        secondarySortBy="None"
+      />
+    </Provider>
+  );
+  const toggleButton = within(result.container).getByRole("button", { name: /toggle/i });
+  return { ...result, stores, toggleButton, documentGroup };
+}
+
+describe("SortedSection header toggle", () => {
+  it("sets aria-expanded='false' when the section is collapsed", () => {
+    const { toggleButton } = renderSection({ expanded: false });
+    expect(toggleButton).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("sets aria-expanded='true' when the section is expanded", () => {
+    const { toggleButton } = renderSection({ expanded: true });
+    expect(toggleButton).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("sets aria-controls to the id of the documents-list element", () => {
+    const { container, toggleButton } = renderSection();
+    const documentsList = container.querySelector('[data-testid="section-document-list"]');
+    expect(documentsList).not.toBeNull();
+    expect(documentsList!.id).toBeTruthy();
+    expect(toggleButton.getAttribute("aria-controls")).toBe(documentsList!.id);
+  });
+
+  it("marks the arrow icon with aria-hidden so screen readers announce only the button label", () => {
+    const { toggleButton } = renderSection();
+    const arrow = within(toggleButton).getByTestId("arrow-icon");
+    expect(arrow).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("uses an aria-label that is identical when expanded vs collapsed", () => {
+    const collapsedLabel = renderSection({ expanded: false }).toggleButton.getAttribute("aria-label");
+    const expandedLabel = renderSection({ expanded: true }).toggleButton.getAttribute("aria-label");
+    expect(collapsedLabel).toBeTruthy();
+    expect(collapsedLabel).toBe(expandedLabel);
+  });
+
+  it("expands the section when Enter is pressed on the toggle button", async () => {
+    const user = userEvent.setup();
+    const { toggleButton, stores } = renderSection({ expanded: false });
+    toggleButton.focus();
+    await user.keyboard("{Enter}");
+    expect(stores.ui.expandedSortWorkSections.includes("Group A")).toBe(true);
+  });
+
+  it("collapses the section when Enter is pressed while expanded", async () => {
+    const user = userEvent.setup();
+    const { toggleButton, stores } = renderSection({ expanded: true });
+    toggleButton.focus();
+    await user.keyboard("{Enter}");
+    expect(stores.ui.expandedSortWorkSections.includes("Group A")).toBe(false);
+  });
+});

--- a/src/components/document/sorted-section.tsx
+++ b/src/components/document/sorted-section.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { observer } from "mobx-react";
 import classNames from "classnames";
+import { kebabCase } from "lodash";
 
 import { useStores } from "../../hooks/use-stores";
 import { Logger } from "../../lib/logger";
@@ -120,6 +121,8 @@ export const SortedSection: React.FC<IProps> = observer(function SortedSection(p
   };
 
   const sectionClasses = classNames("sorted-sections", {"show-documents": showDocuments});
+  const documentsListId = `documents-list-${kebabCase(documentGroup.label)}-${idx}`;
+  const toggleLabel = `Toggle ${documentGroup.label} documents`;
 
   return (
     <div className={sectionClasses} key={`documentGroup-${idx}`}>
@@ -130,10 +133,19 @@ export const SortedSection: React.FC<IProps> = observer(function SortedSection(p
         </div>
         <div className="section-header-right">
           <div>Total {translate("workspaces")}: {documentCount}</div>
-          <ArrowIcon
-            className={classNames("section-header-arrow", {up: showDocuments})}
+          <button
+            aria-controls={documentsListId}
+            aria-expanded={showDocuments}
+            aria-label={toggleLabel}
+            className="section-header-arrow-button"
+            type="button"
             onClick={handleToggleShowDocuments}
-          />
+          >
+            <ArrowIcon
+              className={classNames("section-header-arrow", {up: showDocuments})}
+              aria-hidden="true"
+            />
+          </button>
         </div>
         </div>
       </div>
@@ -142,7 +154,7 @@ export const SortedSection: React.FC<IProps> = observer(function SortedSection(p
           {secondarySort}
         </div>
       }
-      <div className="documents-list" data-testid="section-document-list">
+      <div id={documentsListId} className="documents-list" data-testid="section-document-list">
         {showDocuments && renderList()}
       </div>
     </div>

--- a/src/components/thumbnail/document-type-collection.scss
+++ b/src/components/thumbnail/document-type-collection.scss
@@ -1,4 +1,5 @@
 @import "../vars";
+@import "../mixins";
 
 $list-item-height: 660px;
 $list-item-width: 880px;
@@ -75,6 +76,62 @@ $section-padding: 6px;
     overflow-y: hidden;
   }
 
+  .list-item-container {
+    position: relative;
+    flex-grow: 0;
+    flex-shrink: 0;
+
+    > .icon-holder {
+      appearance: none;
+      background: none;
+      border: none;
+      cursor: pointer;
+      padding: 0;
+      position: absolute;
+      right: 78px;
+      top: 4px;
+      @include focus-ring(2px);
+
+      &[aria-disabled="true"] {
+        cursor: default;
+      }
+
+      .icon-star {
+        height: 24px;
+        width: 24px;
+        fill: $charcoal;
+        opacity: .25;
+        display: block;
+
+        &.starred {
+          opacity: .75;
+          fill: $problem-orange;
+        }
+      }
+
+      &:hover .icon-star {
+        fill: $problem-orange;
+        opacity: 0.35;
+      }
+      &:active .icon-star {
+        opacity: .75;
+        fill: $problem-orange;
+      }
+      &:active .icon-star.starred {
+        opacity: .75;
+        fill: $problem-orange;
+      }
+
+      .bookmark-label {
+        position: absolute;
+        top: -2px;
+        right: -4px;
+        margin: 0;
+        font-size: 5pt;
+      }
+    }
+  }
+
   .list-item {
     position: relative;
     min-height: 120px;
@@ -83,11 +140,10 @@ $section-padding: 6px;
     padding: $padding 0;
     display: flex;
     flex-direction: column;
-    flex-grow: 0;
-    flex-shrink: 0;
     align-items: center;
     overflow: hidden;
     cursor: pointer;
+    @include focus-ring(-2px);
 
     &.selected {
       background-color: $classwork-purple-light-6;
@@ -147,49 +203,6 @@ $section-padding: 6px;
             margin-top: 8px;
           }
         }
-      }
-    }
-
-    .icon-holder {
-      position: absolute;
-      top: 5px;
-      right: 12px;
-      cursor: pointer;
-
-      .icon-star {
-        height: 24px;
-        width: 24px;
-        fill: $charcoal;
-        opacity: .25;
-        position: relative;
-        right: 66px;
-        top: -1px;
-
-        &.starred {
-          opacity: .75;
-          fill: $problem-orange;
-        }
-      }
-
-      &:hover .icon-star {
-        fill: $problem-orange;
-        opacity: 0.35;
-      }
-      &:active .icon-star {
-        opacity: .75;
-        fill: $problem-orange;
-      }
-      &:active .icon-star.starred {
-        opacity: .75;
-        fill: $problem-orange;
-      }
-
-      .bookmark-label {
-        position: absolute;
-        top: -2px;
-        right: -4px;
-        margin: 0;
-        font-size: 5pt;
       }
     }
 

--- a/src/components/thumbnail/simple-document-item.scss
+++ b/src/components/thumbnail/simple-document-item.scss
@@ -1,4 +1,5 @@
 @import "../vars";
+@import "../mixins";
 
 .simple-document-item {
   background: $classwork-purple-light-7;
@@ -10,7 +11,9 @@
   flex-shrink: 0;
   height: 16px;
   margin: 0;
+  padding: 0;
   width: 16px;
+  @include focus-ring(-2px);
 
   &:hover {
     background: $classwork-purple-light-4;
@@ -19,16 +22,13 @@
     background: $classwork-purple-light-2;
   }
 
-  &.private {
+  &[aria-disabled="true"] {
     background: $charcoal-light-7;
     border: dotted 1px $charcoal;
     cursor: not-allowed;
 
     &:hover {
       background: $charcoal-light-4;
-    }
-    &:active {
-      background: $color3;
     }
   }
 }

--- a/src/components/thumbnail/simple-document-item.test.tsx
+++ b/src/components/thumbnail/simple-document-item.test.tsx
@@ -1,0 +1,79 @@
+import { fireEvent, render } from "@testing-library/react";
+import { Provider } from "mobx-react";
+import React from "react";
+
+import { SimpleDocumentItem } from "./simple-document-item";
+import { DocumentMetadataModel, IDocumentMetadataModel } from "../../models/document/document-metadata-model";
+import { ProblemDocument } from "../../models/document/document-types";
+import { specStores } from "../../models/stores/spec-stores";
+import { UserModel } from "../../models/stores/user";
+
+interface IRenderOptions {
+  isPrivate?: boolean;
+  selected?: boolean;
+  onSelectDocument?: (document: IDocumentMetadataModel) => void;
+}
+
+function renderItem(options: IRenderOptions = {}) {
+  const { isPrivate = false, selected = false, onSelectDocument = jest.fn() } = options;
+  const ownerId = isPrivate ? "other-user" : "test-student";
+  const user = UserModel.create({ id: "test-student", type: "student", name: "Test Student" });
+  const stores = specStores({ user });
+  const document = DocumentMetadataModel.create({
+    type: ProblemDocument,
+    title: "Test Document",
+    uid: ownerId,
+    key: "doc-key-1",
+    visibility: "private",
+  });
+  if (selected) {
+    stores.ui.setHighlightedSortWorkDocument(document.key);
+  }
+  const result = render(
+    <Provider stores={stores}>
+      <SimpleDocumentItem document={document} onSelectDocument={onSelectDocument} />
+    </Provider>
+  );
+  const item = result.container.querySelector(".simple-document-item") as HTMLElement;
+  return { ...result, item, document, onSelectDocument };
+}
+
+describe("SimpleDocumentItem", () => {
+  it("calls onSelectDocument when clicked", () => {
+    const { item, onSelectDocument, document } = renderItem();
+    fireEvent.click(item);
+    expect(onSelectDocument).toHaveBeenCalledWith(document);
+  });
+
+  it("uses the same string for aria-label as for title (so screen readers match the tooltip)", () => {
+    const { item } = renderItem();
+    expect(item.getAttribute("aria-label")).toBe(item.getAttribute("title"));
+  });
+
+  it("sets aria-current='true' when the document is selected", () => {
+    const { item } = renderItem({ selected: true });
+    expect(item).toHaveAttribute("aria-current", "true");
+  });
+
+  it("omits aria-current when the document is not selected", () => {
+    const { item } = renderItem({ selected: false });
+    expect(item).not.toHaveAttribute("aria-current");
+  });
+
+  it("marks the item with aria-disabled='true' when the document is private", () => {
+    const { item } = renderItem({ isPrivate: true });
+    expect(item).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("keeps the item in the tab order when private (so AT users can discover it)", () => {
+    const { item } = renderItem({ isPrivate: true });
+    expect(item).not.toHaveAttribute("tabindex", "-1");
+    expect(item).not.toBeDisabled();
+  });
+
+  it("does not call onSelectDocument when clicked while private", () => {
+    const { item, onSelectDocument } = renderItem({ isPrivate: true });
+    fireEvent.click(item);
+    expect(onSelectDocument).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/thumbnail/simple-document-item.tsx
+++ b/src/components/thumbnail/simple-document-item.tsx
@@ -24,16 +24,19 @@ export const SimpleDocumentItem = observer(function SimpleDocumentItem(
   const selected = ui.highlightedSortWorkDocument === document.key;
 
   const handleClick = () => {
-    onSelectDocument(document);
+    if (!isPrivate) onSelectDocument(document);
   };
 
   return (
-    <div
+    <button
+      aria-current={selected ? "true" : undefined}
+      aria-disabled={isPrivate || undefined}
+      aria-label={titleWithUser}
       className={classNames("simple-document-item", { selected, private: isPrivate })}
       data-test="simple-document-item"
       title={titleWithUser}
-      onClick={!isPrivate ? handleClick : undefined}
-    >
-    </div>
+      type="button"
+      onClick={handleClick}
+    />
   );
 });

--- a/src/components/thumbnail/thumbnail-document-item.test.tsx
+++ b/src/components/thumbnail/thumbnail-document-item.test.tsx
@@ -1,0 +1,219 @@
+import { fireEvent, render } from "@testing-library/react";
+import { Provider } from "mobx-react";
+import React from "react";
+import { ThumbnailDocumentItem } from "./thumbnail-document-item";
+import { createDocumentModel, DocumentModelType } from "../../models/document/document";
+import { ProblemDocument } from "../../models/document/document-types";
+import { specStores } from "../../models/stores/spec-stores";
+import { UserModel } from "../../models/stores/user";
+import { Bookmark } from "../../models/stores/bookmarks";
+
+jest.mock("../document/canvas", () => ({
+  CanvasComponent: () => <div data-testid="mock-canvas" />,
+}));
+
+const captionText = "My Document Caption";
+
+interface IRenderOptions {
+  isPrivate?: boolean;
+  isSelected?: boolean;
+  isStarred?: boolean;
+  userType?: "student" | "teacher" | "researcher";
+  onDocumentClick?: (document: DocumentModelType) => void;
+  onDocumentDragStart?: (e: React.DragEvent<HTMLDivElement>, document: DocumentModelType) => void;
+  onDocumentStarClick?: (document: DocumentModelType) => void;
+}
+
+function renderItem(options: IRenderOptions = {}) {
+  const {
+    isPrivate = false,
+    isSelected = false,
+    isStarred = false,
+    userType = "student",
+    onDocumentClick = jest.fn(),
+    onDocumentDragStart,
+    onDocumentStarClick,
+  } = options;
+  const ownerId = isPrivate ? "other-user" : "test-student";
+  const user = UserModel.create({ id: "test-student", type: userType, name: "Test Student" });
+  const stores = specStores({ user });
+  const document = createDocumentModel({
+    type: ProblemDocument,
+    title: "Test Document",
+    uid: ownerId,
+    key: "doc-key-1",
+    createdAt: 1,
+    visibility: "private"
+  });
+  if (isStarred) {
+    // Bypass `toggleUserBookmark`, which would hit the DB; seed the bookmark directly.
+    stores.bookmarks.updateDocumentBookmark(document.key, new Bookmark(user.id, "bookmark-1", true));
+  }
+  const result = render(
+    <Provider stores={stores}>
+      <ThumbnailDocumentItem
+        canvasContext="test"
+        captionText={captionText}
+        dataTestName="my-work-list-items"
+        document={document}
+        isSelected={isSelected}
+        onDocumentClick={onDocumentClick}
+        onDocumentDragStart={onDocumentDragStart}
+        onDocumentStarClick={onDocumentStarClick}
+        scale={0.1}
+      />
+    </Provider>
+  );
+  const listItem = result.container.querySelector(".list-item") as HTMLElement;
+  return { ...result, listItem, document, onDocumentClick, onDocumentStarClick };
+}
+
+describe("ThumbnailDocumentItem", () => {
+  describe("when the document is accessible", () => {
+    it("renders the list item with role='button'", () => {
+      const { listItem } = renderItem();
+      expect(listItem).toHaveAttribute("role", "button");
+    });
+
+    it("renders the list item with tabIndex 0", () => {
+      const { listItem } = renderItem();
+      expect(listItem).toHaveAttribute("tabindex", "0");
+    });
+
+    it("uses captionText as the list item's aria-label", () => {
+      const { listItem } = renderItem();
+      expect(listItem).toHaveAttribute("aria-label", captionText);
+    });
+
+    it("calls onDocumentClick when Enter is pressed on the list item", () => {
+      const { listItem, onDocumentClick, document } = renderItem();
+      fireEvent.keyDown(listItem, { key: "Enter" });
+      expect(onDocumentClick).toHaveBeenCalledWith(document);
+    });
+
+    it("calls onDocumentClick when Space is pressed on the list item", () => {
+      const { listItem, onDocumentClick, document } = renderItem();
+      fireEvent.keyDown(listItem, { key: " " });
+      expect(onDocumentClick).toHaveBeenCalledWith(document);
+    });
+
+    it("marks the canvas container with aria-hidden='true'", () => {
+      const { container } = renderItem();
+      const canvasContainer = container.querySelector(".scaled-list-item-container");
+      expect(canvasContainer).toHaveAttribute("aria-hidden", "true");
+    });
+
+    it("marks the canvas container with the inert attribute", () => {
+      const { container } = renderItem();
+      const canvasContainer = container.querySelector(".scaled-list-item-container");
+      expect(canvasContainer).toHaveAttribute("inert");
+    });
+
+    it("sets aria-current='true' when the document is selected", () => {
+      const { listItem } = renderItem({ isSelected: true });
+      expect(listItem).toHaveAttribute("aria-current", "true");
+    });
+
+    it("omits aria-current when the document is not selected", () => {
+      const { listItem } = renderItem({ isSelected: false });
+      expect(listItem).not.toHaveAttribute("aria-current");
+    });
+  });
+
+  describe("when the document is private", () => {
+    it("keeps the list item in the tab order (so AT users can discover it)", () => {
+      const { listItem } = renderItem({ isPrivate: true });
+      expect(listItem).toHaveAttribute("tabindex", "0");
+    });
+
+    it("renders the list item with aria-disabled='true'", () => {
+      const { listItem } = renderItem({ isPrivate: true });
+      expect(listItem).toHaveAttribute("aria-disabled", "true");
+    });
+
+    it("does not call onDocumentClick when Enter is pressed", () => {
+      const { listItem, onDocumentClick } = renderItem({ isPrivate: true });
+      fireEvent.keyDown(listItem, { key: "Enter" });
+      expect(onDocumentClick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("DocumentBookmark", () => {
+    it("sets aria-pressed='true' when the document is bookmarked", () => {
+      const { container } = renderItem({ isStarred: true, onDocumentStarClick: jest.fn() });
+      const bookmark = container.querySelector(".icon-holder");
+      expect(bookmark).toHaveAttribute("aria-pressed", "true");
+    });
+
+    it("sets aria-pressed='false' when the document is not bookmarked", () => {
+      const { container } = renderItem({ isStarred: false, onDocumentStarClick: jest.fn() });
+      const bookmark = container.querySelector(".icon-holder");
+      expect(bookmark).toHaveAttribute("aria-pressed", "false");
+    });
+
+    it("uses 'Bookmark document' as aria-label when not bookmarked", () => {
+      const { container } = renderItem({ isStarred: false, onDocumentStarClick: jest.fn() });
+      const bookmark = container.querySelector(".icon-holder");
+      expect(bookmark).toHaveAttribute("aria-label", "Bookmark document");
+    });
+
+    it("uses 'Remove bookmark' as aria-label when bookmarked", () => {
+      const { container } = renderItem({ isStarred: true, onDocumentStarClick: jest.fn() });
+      const bookmark = container.querySelector(".icon-holder");
+      expect(bookmark).toHaveAttribute("aria-label", "Remove bookmark");
+    });
+
+    it("calls onDocumentStarClick when the bookmark button is clicked", () => {
+      const onDocumentStarClick = jest.fn();
+      const { container, document } = renderItem({ onDocumentStarClick });
+      const bookmark = container.querySelector(".icon-holder") as HTMLElement;
+      fireEvent.click(bookmark);
+      expect(onDocumentStarClick).toHaveBeenCalledWith(document);
+    });
+
+    it("does not activate the parent list item when Enter is pressed on the bookmark", () => {
+      const onDocumentClick = jest.fn();
+      const onDocumentStarClick = jest.fn();
+      const { container } = renderItem({ onDocumentClick, onDocumentStarClick });
+      const bookmark = container.querySelector(".icon-holder") as HTMLElement;
+      fireEvent.keyDown(bookmark, { key: "Enter" });
+      expect(onDocumentClick).not.toHaveBeenCalled();
+    });
+
+    it("marks the bookmark button with aria-disabled='true' for researchers", () => {
+      const { container } = renderItem({ userType: "researcher", onDocumentStarClick: jest.fn() });
+      const bookmark = container.querySelector(".icon-holder");
+      expect(bookmark).toHaveAttribute("aria-disabled", "true");
+    });
+
+    it("keeps the bookmark button in the tab order for researchers (so AT users can hear its state)", () => {
+      const { container } = renderItem({ userType: "researcher", onDocumentStarClick: jest.fn() });
+      const bookmark = container.querySelector(".icon-holder");
+      expect(bookmark).not.toBeDisabled();
+      expect(bookmark).not.toHaveAttribute("tabindex", "-1");
+    });
+
+    it("does not call onDocumentStarClick when researchers click the bookmark", () => {
+      const onDocumentStarClick = jest.fn();
+      const { container } = renderItem({ userType: "researcher", onDocumentStarClick });
+      const bookmark = container.querySelector(".icon-holder") as HTMLElement;
+      fireEvent.click(bookmark);
+      expect(onDocumentStarClick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("drag handlers", () => {
+    it("places draggable='true' on the list item when onDocumentDragStart is provided", () => {
+      const onDocumentDragStart = jest.fn();
+      const { listItem } = renderItem({ onDocumentDragStart });
+      expect(listItem).toHaveAttribute("draggable", "true");
+    });
+
+    it("does not set draggable on the inner .scaled-list-item-container", () => {
+      const onDocumentDragStart = jest.fn();
+      const { container } = renderItem({ onDocumentDragStart });
+      const canvasContainer = container.querySelector(".scaled-list-item-container");
+      expect(canvasContainer).not.toHaveAttribute("draggable");
+    });
+  });
+});

--- a/src/components/thumbnail/thumbnail-document-item.tsx
+++ b/src/components/thumbnail/thumbnail-document-item.tsx
@@ -39,13 +39,17 @@ export const ThumbnailDocumentItem: React.FC<IProps> = observer((props: IProps) 
     onDocumentClick?.(document);
     e.stopPropagation();
   };
+  const handleDocumentKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onDocumentClick?.(document);
+    }
+  };
   const handleDocumentDragStart = (e: React.DragEvent<HTMLDivElement>) => {
     onDocumentDragStart?.(e, document);
   };
-  const handleDocumentStarClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    if (!user.isResearcher) {
-      onDocumentStarClick?.(document);
-    }
+  const handleDocumentStarClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    onDocumentStarClick?.(document);
     e.stopPropagation();
   };
   const handleDocumentDeleteClick = (e: React.MouseEvent<HTMLDivElement>) => {
@@ -74,42 +78,59 @@ export const ThumbnailDocumentItem: React.FC<IProps> = observer((props: IProps) 
     private: isPrivate, selected: isSelected, secondary: isSecondarySelected
   });
   return (
-    <div className={className}
-      data-test={dataTestName} key={document.key} data-document-key={document.key}
-      title={documentTitle} onClick={isPrivate ? undefined : handleDocumentClick}
-    >
-      <div
-        className={classNames("scaled-list-item-container", { group })}
-        onDragStart={handleDocumentDragStart}
+    <div className="list-item-container" key={document.key}>
+      <div className={className}
+        data-test={dataTestName} data-document-key={document.key}
+        title={documentTitle}
+        role="button"
+        tabIndex={0}
+        aria-label={captionText}
+        aria-current={isSelected ? "true" : undefined}
+        aria-disabled={isPrivate || undefined}
+        onClick={isPrivate ? undefined : handleDocumentClick}
+        onKeyDown={isPrivate ? undefined : handleDocumentKeyDown}
+        onDragStart={!isPrivate && onDocumentDragStart ? handleDocumentDragStart : undefined}
         draggable={!!onDocumentDragStart && !isPrivate}
       >
-        { isPrivate
-          ? <ThumbnailPrivateIcon />
-          : document.content
-            ? <div className="scaled-list-item">
-                <CanvasComponent
-                  context={canvasContext}
-                  document={document}
-                  readOnly={true}
-                  scale={scale}
-                />
-              </div>
-            : <ThumbnailPlaceHolderIcon />
-        }
-        {group && (
-          <div className="group-doc-badge">
-            <GroupIcon color="#fff" aria-hidden={true} focusable={false} />
-          </div>
-        )}
+        <div
+          className={classNames("scaled-list-item-container", { group })}
+          aria-hidden={true}
+          // Spread bypasses React 17's type definitions, which lack `inert`.
+          {...{ inert: "" }}
+        >
+          { isPrivate
+            ? <ThumbnailPrivateIcon />
+            : document.content
+              ? <div className="scaled-list-item">
+                  <CanvasComponent
+                    context={canvasContext}
+                    document={document}
+                    readOnly={true}
+                    scale={scale}
+                  />
+                </div>
+              : <ThumbnailPlaceHolderIcon />
+          }
+          {group && (
+            <div className="group-doc-badge">
+              <GroupIcon color="#fff" aria-hidden={true} focusable={false} />
+            </div>
+          )}
+        </div>
+        <DocumentCaption
+          captionText={captionText}
+          onDeleteClick={onDocumentDeleteClick ? handleDocumentDeleteClick : undefined}
+        />
       </div>
       {
         onDocumentStarClick &&
-        <DocumentBookmark isStarred={isStarred} onStarClick={handleDocumentStarClick} label={label}/>
+        <DocumentBookmark
+          isStarred={isStarred}
+          onStarClick={handleDocumentStarClick}
+          label={label}
+          disabled={user.isResearcher}
+        />
       }
-      <DocumentCaption
-        captionText={captionText}
-        onDeleteClick={onDocumentDeleteClick ? handleDocumentDeleteClick : undefined}
-      />
     </div>
   );
 });
@@ -120,19 +141,29 @@ ThumbnailDocumentItem.displayName = "ThumbnailDocumentItem";
  */
 interface IDocumentStarProps {
   isStarred: boolean;
-  onStarClick: (e: React.MouseEvent<HTMLDivElement>) => void;
+  onStarClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
   label: string;
+  disabled?: boolean;
 }
 
 const DocumentBookmark = (props: IDocumentStarProps) => {
-  const { isStarred, onStarClick, label } = props;
+  const { isStarred, onStarClick, label, disabled } = props;
+  const ariaLabel = isStarred ? "Remove bookmark" : "Bookmark document";
 
   return (
-    <div className="icon-holder" onClick={onStarClick}>
-      <svg className={"icon-star " + (isStarred ? "starred" : "")} >
+    <button
+      aria-disabled={disabled || undefined}
+      aria-pressed={isStarred}
+      aria-label={ariaLabel}
+      className="icon-holder"
+      data-testid="bookmark-button"
+      type="button"
+      onClick={disabled ? undefined : onStarClick}
+    >
+      <svg className={"icon-star " + (isStarred ? "starred" : "")} aria-hidden="true">
         <ThumbnailBookmark />
       </svg>
-      {label && <pre className={"bookmark-label"}>{label}</pre> }
-    </div>
+      {label && <span className="bookmark-label">{label}</span>}
+    </button>
     );
 };

--- a/src/components/utilities/toggle-control.scss
+++ b/src/components/utilities/toggle-control.scss
@@ -1,12 +1,20 @@
 @import "../vars";
+@import "../mixins";
 
 .toggle-control {
+  background: none;
+  border: none;
+  appearance: none;
+  padding: 0;
+  font: inherit;
   box-sizing: content-box;
   width: 34px;
   height: 14px;
   cursor: pointer;
+  @include focus-ring(2px);
 
   .track {
+    display: block;
     width: 34px;
     height: 14px;
     border-radius: 7px;
@@ -18,6 +26,7 @@
   }
 
   .ball {
+    display: block;
     position: relative;
     top: -17px;
     width: 17px;

--- a/src/components/utilities/toggle-control.test.tsx
+++ b/src/components/utilities/toggle-control.test.tsx
@@ -1,0 +1,56 @@
+import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import ToggleControl from "./toggle-control";
+
+const defaultTitle = "Shared: click to unshare from group";
+
+function renderToggle(value: boolean, onChange: (next: boolean) => void = jest.fn(), title = defaultTitle) {
+  const result = render(<ToggleControl value={value} onChange={onChange} title={title} />);
+  const control = result.container.querySelector(".toggle-control") as HTMLElement;
+  return { ...result, control };
+}
+
+describe("ToggleControl", () => {
+  it("calls onChange with the negated value when clicked", async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    const { control } = renderToggle(false, onChange);
+    await user.click(control);
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it("calls onChange with false when clicked while on", async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    const { control } = renderToggle(true, onChange);
+    await user.click(control);
+    expect(onChange).toHaveBeenCalledWith(false);
+  });
+
+  it("has role='switch'", () => {
+    const { control } = renderToggle(false);
+    expect(control).toHaveAttribute("role", "switch");
+  });
+
+  it("sets aria-checked='true' when value is true", () => {
+    const { control } = renderToggle(true);
+    expect(control).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("sets aria-checked='false' when value is false", () => {
+    const { control } = renderToggle(false);
+    expect(control).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("forwards the title prop to the title attribute (mouse hover)", () => {
+    const { control } = renderToggle(false, jest.fn(), "custom hover text");
+    expect(control).toHaveAttribute("title", "custom hover text");
+  });
+
+  it("uses the title prop as aria-label so screen readers match the tooltip", () => {
+    const { control } = renderToggle(false, jest.fn(), "custom hover text");
+    expect(control).toHaveAttribute("aria-label", "custom hover text");
+  });
+});

--- a/src/components/utilities/toggle-control.tsx
+++ b/src/components/utilities/toggle-control.tsx
@@ -7,7 +7,7 @@ interface IProps {
   dataTest?: string;
   value: boolean;
   onChange: (value: boolean) => void;
-  title?: string;
+  title: string;
 }
 
 const ToggleControl: React.FC<IProps> = ({ className, dataTest, value, onChange, title }) => {
@@ -19,10 +19,19 @@ const ToggleControl: React.FC<IProps> = ({ className, dataTest, value, onChange,
   const onClass = value ? "toggle-on" : "";
 
   return (
-    <div className={`toggle-control ${className}`} data-test={dataTest} title={title} onClick={handleClick}>
-      <div className={`track ${onClass}`}/>
-      <div className={`ball ${onClass}`}/>
-    </div>
+    <button
+      aria-checked={value}
+      aria-label={title}
+      className={`toggle-control ${className ?? ""}`}
+      data-test={dataTest}
+      role="switch"
+      title={title}
+      type="button"
+      onClick={handleClick}
+    >
+      <span className={`track ${onClass}`} aria-hidden="true" />
+      <span className={`ball ${onClass}`} aria-hidden="true" />
+    </button>
   );
 };
 


### PR DESCRIPTION
[CLUE-426](https://concord-consortium.atlassian.net/browse/CLUE-426)

Makes the document lists (My Work / Class Work / Sort Work), Join Group View button, and Share toggle reachable and operable by keyboard, with visible focus indicators throughout. Verifies previously-reported keyboard issues with the File menu, Problem menu, header Group control, and Log Out option (already accessible via the recently added `CustomSelect` / `useDropdown` plumbing).

## Changes

**Made keyboard-accessible:**
- `ThumbnailDocumentItem` — `role="button"`, `tabIndex`, `aria-label`, `aria-current`/`aria-disabled`, Enter/Space activation. Inner canvas marked `inert` + `aria-hidden` so descendants don't capture focus. `data-document-key` preserved on the wrapper.
- `DocumentBookmark` — converted from `<div>` to `<button>` with `aria-pressed` toggle-button semantics and a descriptive `aria-label`.
- `SortedSection` arrow — wrapped in a real `<button>` with `aria-expanded`, `aria-controls`, and a static `aria-label`.
- `SimpleDocumentItem` (Sort Work small squares) — converted to `<button>` with `aria-disabled` for private docs (still tab-reachable per APG guidance).
- `ToggleControl` (Share switch) — converted to `<button role="switch">` with `aria-checked`. `title` prop now required so it always has an accessible name.

**Visible focus indicators added** via the existing `focus-ring` mixin on: list items, bookmark buttons, sort-section toggles, simple document squares, scroll buttons, the up1/up4 Join Group View buttons, the Publish button (closing an existing WCAG 2.4.7 gap), and the Share toggle.

**Tests:**
- New unit tests for `ThumbnailDocumentItem`, `DocumentBookmark`, `SimpleDocumentItem`, `SortedSection`, and `ToggleControl`.
- New Cypress spec exercising keyboard navigation through My Work (`my_work_keyboard_nav_spec.js`).

[CLUE-426]: https://concord-consortium.atlassian.net/browse/CLUE-426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ