### PR TITLE
chore: hide show/sort when sketch tile unselected (CLUE-206)

### DIFF
--- a/cypress/e2e/functional/tile_tests/drawing_tool_spec.js
+++ b/cypress/e2e/functional/tile_tests/drawing_tool_spec.js
@@ -147,13 +147,15 @@ context('Draw Tool Tile', function () {
     cy.log("has a navigator panel to pan drawing");
     drawToolTile.getDrawTileNavigatorPanel().should("exist");
 
-    cy.log("navigator is not shown when tile is not selected");
+    cy.log("navigator and show/sort panel are not shown when tile is not selected");
     const textTile = new TextToolTile;
     clueCanvas.addTile("text");
     textTile.getTextTile().click();
     drawToolTile.getDrawTileNavigatorPanel().should("not.exist");
+    drawToolTile.getDrawTileShowSortPanel().should("not.exist");
     drawToolTile.getDrawTile().click();
     drawToolTile.getDrawTileNavigatorPanel().should("exist");
+    drawToolTile.getDrawTileShowSortPanel().should("exist");
 
     cy.log("can delete objects and close panel");
     // Reset zoom to 100%

--- a/src/plugins/drawing/components/drawing-tile.scss
+++ b/src/plugins/drawing/components/drawing-tile.scss
@@ -1,6 +1,10 @@
 @import "../../../components/vars";
 @import "../../../utilities/voice-typing-overlay";
 
+$object-list-border-width: 1.5px;
+$closed-object-list-inner-width: 26px;
+$closed-object-list-total-width: $closed-object-list-inner-width + 2 * $object-list-border-width;
+
 .drawing-tool-tile {
   .transformable[tabindex="0"] {
     &:focus-visible,
@@ -30,8 +34,12 @@
     display: flex;
     justify-content: flex-start;
 
+    .object-list-spacer {
+      flex: 0 0 $closed-object-list-total-width;
+    }
+
     .object-list {
-      border: solid 1.5px $charcoal-light-1;
+      border: solid $object-list-border-width $charcoal-light-1;
       border-radius: 0px 3px 3px 0px;
       display: flex;
       flex-direction: column;
@@ -44,8 +52,7 @@
       }
 
       &.closed {
-        // kClosedObjectListPanelWidth is this plus 3px border width
-        flex: 0 0 26px;
+        flex: 0 0 $closed-object-list-inner-width;
 
         button {
           width: 100%;
@@ -229,4 +236,3 @@
     }
   }
 }
-

--- a/src/plugins/drawing/components/drawing-tile.test.tsx
+++ b/src/plugins/drawing/components/drawing-tile.test.tsx
@@ -40,6 +40,7 @@ import { Provider } from "mobx-react";
 import { specStores } from "../../../models/stores/spec-stores";
 import { ModalProvider } from "react-modal-hook";
 import { createDrawingContent } from "../model/drawing-content";
+import { kClosedObjectListPanelWidth } from "../model/drawing-types";
 import DrawingToolComponent from "./drawing-tile";
 import { RectangleObjectSnapshotForAdd } from "../objects/rectangle";
 
@@ -87,6 +88,10 @@ describe("DrawingToolComponent", () => {
   model.setTitle('A Title for Testing');
   render(<div className="document-content" data-testid="document-content"/>);
   const documentContent = screen.getByTestId("document-content");
+
+  beforeEach(() => {
+    stores.ui.setSelectedTile(model);
+  });
 
   const defaultProps = {
     tileElt: null,
@@ -346,6 +351,77 @@ describe("DrawingToolComponent", () => {
       // Left will include the object list panel width, so we just verify it's transformed.
       expect(bbox!.left).toBeGreaterThan(expectedLeft);
       expect(bbox!.top).toBeCloseTo(expectedTop, 1);
+    });
+  });
+
+  describe("when tile is not selected", () => {
+    const unselectedContent = createDrawingContent();
+    const unselectedModel = TileModel.create({content: unselectedContent});
+
+    it("does not show object list panel", () => {
+      render(
+        <ModalProvider>
+          <Provider stores={stores}>
+            <DrawingToolComponent {...defaultProps} model={unselectedModel} />
+          </Provider>
+        </ModalProvider>
+      );
+      expect(screen.queryByTestId("object-list-view")).not.toBeInTheDocument();
+    });
+
+    it("renders an object-list-spacer in place of the panel", () => {
+      render(
+        <ModalProvider>
+          <Provider stores={stores}>
+            <DrawingToolComponent {...defaultProps} model={unselectedModel} />
+          </Provider>
+        </ModalProvider>
+      );
+      // The spacer reserves the closed-panel width so the drawing layer
+      // stays in place when the tile is deselected (CLUE-206).
+      expect(screen.queryByTestId("object-list-spacer")).toBeInTheDocument();
+    });
+
+    it("getObjectBoundingBox stays offset by closed panel width", () => {
+      // Sparrows must remain anchored to the drawing when the tile is unselected.
+      // The panel is replaced by a same-width spacer, so getObjectBoundingBox
+      // must still report that left offset.
+      let capturedApi: ITileApi | undefined;
+      const onRegisterTileApi = (tileApi: ITileApi) => {
+        capturedApi = tileApi;
+      };
+
+      const testContent = createDrawingContent();
+      const testRect: RectangleObjectSnapshotForAdd = {
+        type: "rectangle",
+        x: 100,
+        y: 50,
+        width: 40,
+        height: 30,
+        ...mockSettings,
+      };
+      testContent.addObject(testRect);
+      const testModel = TileModel.create({content: testContent});
+
+      render(
+        <ModalProvider>
+          <Provider stores={stores}>
+            <DrawingToolComponent
+              {...defaultProps}
+              model={testModel}
+              readOnly={false}
+              onRegisterTileApi={onRegisterTileApi}
+            />
+          </Provider>
+        </ModalProvider>
+      );
+
+      const objectId = testContent.objects[0]?.id;
+      const bbox = capturedApi?.getObjectBoundingBox?.(objectId!);
+      expect(bbox).toBeDefined();
+      const bbPadding = 5;
+      const expectedLeft = (testRect.x - bbPadding) + kClosedObjectListPanelWidth;
+      expect(bbox!.left).toBeCloseTo(expectedLeft, 1);
     });
   });
 });

--- a/src/plugins/drawing/components/drawing-tile.test.tsx
+++ b/src/plugins/drawing/components/drawing-tile.test.tsx
@@ -89,10 +89,6 @@ describe("DrawingToolComponent", () => {
   render(<div className="document-content" data-testid="document-content"/>);
   const documentContent = screen.getByTestId("document-content");
 
-  beforeEach(() => {
-    stores.ui.setSelectedTile(model);
-  });
-
   const defaultProps = {
     tileElt: null,
     context: "",
@@ -122,83 +118,160 @@ describe("DrawingToolComponent", () => {
     createElementSpy.mockRestore();
   });
 
-  it("renders successfully", () => {
-    render(
-      <ModalProvider>
-        <Provider stores={stores}>
-          <TileModelContext.Provider value={model}>
+  describe("when tile is selected", () => {
+    beforeAll(() => {
+      stores.ui.setSelectedTile(model);
+    });
+
+    it("renders successfully", () => {
+      render(
+        <ModalProvider>
+          <Provider stores={stores}>
+            <TileModelContext.Provider value={model}>
+              <DrawingToolComponent {...defaultProps} {...{model}} />
+            </TileModelContext.Provider>
+          </Provider>
+        </ModalProvider>
+      );
+      expect(screen.getByTestId("drawing-tool")).toBeInTheDocument();
+      expect(screen.getByTestId("drawing-toolbar")).toBeInTheDocument();
+      expect(screen.getByLabelText("Open show/sort panel")).toBeInTheDocument();
+      expect(screen.getByText("A Title for Testing")).toBeInTheDocument();
+    });
+
+    it("can open and close show/sort panel", () => {
+      render(
+        <ModalProvider>
+          <Provider stores={stores}>
             <DrawingToolComponent {...defaultProps} {...{model}} />
-          </TileModelContext.Provider>
-        </Provider>
-      </ModalProvider>
-    );
-    expect(screen.getByTestId("drawing-tool")).toBeInTheDocument();
-    expect(screen.getByTestId("drawing-toolbar")).toBeInTheDocument();
-    expect(screen.getByLabelText("Open show/sort panel")).toBeInTheDocument();
-    expect(screen.getByText("A Title for Testing")).toBeInTheDocument();
+          </Provider>
+        </ModalProvider>
+      );
+      expect(screen.getByTestId("drawing-tool")).toContainHTML("Open show/sort panel");
+      expect(screen.getByTestId("drawing-tool")).not.toContainHTML("Close show/sort panel");
+
+      screen.getByLabelText("Open show/sort panel").click();
+      expect(screen.getByTestId("drawing-tool")).toContainHTML("Close show/sort panel");
+      expect(screen.getByTestId("drawing-tool")).not.toContainHTML("Open show/sort panel");
+
+      screen.getByLabelText("Close show/sort panel").click();
+      expect(screen.getByTestId("drawing-tool")).toContainHTML("Open show/sort panel");
+      expect(screen.getByTestId("drawing-tool")).not.toContainHTML("Close show/sort panel");
+    });
+
+    it("shows objects in show/sort panel", () => {
+      render(
+        <ModalProvider>
+          <Provider stores={stores}>
+            <DrawingToolComponent {...defaultProps} {...{model}} />
+          </Provider>
+        </ModalProvider>
+      );
+
+      expect(screen.getByTestId("object-list-view")).not.toContainHTML("Square");
+      content.addAndSelectObject(squareSnapshot);
+      screen.getByLabelText("Open show/sort panel").click();
+      expect(screen.getByTestId("object-list-view")).toContainHTML("Square");
+    });
+
+    it("shows correct order of objects in show/sort panel", () => {
+      render(
+        <ModalProvider>
+          <Provider stores={stores}>
+            <DrawingToolComponent {...defaultProps} {...{model}} />
+          </Provider>
+        </ModalProvider>
+      );
+
+      // Content already has a square in it from previous test.
+      content.addAndSelectObject(rectangleSnapshot);
+      let items = within(screen.getByTestId("object-list-view")).getAllByRole("listitem");
+      expect(items).toHaveLength(2);
+      expect(items[0]).toContainHTML("Rectangle");
+      expect(items[1]).toContainHTML("Square");
+
+      // Move square to top.
+      if (content.objects.length >= 2) {
+        content.changeZOrder(content.objects[1].id, content.objects[0].id);
+      }
+      items = within(screen.getByTestId("object-list-view")).getAllByRole("listitem");
+      expect(items).toHaveLength(2);
+
+      expect(items[0]).toContainHTML("Square");
+      expect(items[1]).toContainHTML("Rectangle");
+
+    });
   });
 
-  it("can open and close show/sort panel", () => {
-    render(
-      <ModalProvider>
-        <Provider stores={stores}>
-          <DrawingToolComponent {...defaultProps} {...{model}} />
-        </Provider>
-      </ModalProvider>
-    );
-    expect(screen.getByTestId("drawing-tool")).toContainHTML("Open show/sort panel");
-    expect(screen.getByTestId("drawing-tool")).not.toContainHTML("Close show/sort panel");
+  describe("when tile is not selected", () => {
+    const unselectedContent = createDrawingContent();
+    const unselectedModel = TileModel.create({content: unselectedContent});
 
-    screen.getByLabelText("Open show/sort panel").click();
-    expect(screen.getByTestId("drawing-tool")).toContainHTML("Close show/sort panel");
-    expect(screen.getByTestId("drawing-tool")).not.toContainHTML("Open show/sort panel");
+    it("does not show object list panel", () => {
+      render(
+        <ModalProvider>
+          <Provider stores={stores}>
+            <DrawingToolComponent {...defaultProps} model={unselectedModel} />
+          </Provider>
+        </ModalProvider>
+      );
+      expect(screen.queryByTestId("object-list-view")).not.toBeInTheDocument();
+    });
 
-    screen.getByLabelText("Close show/sort panel").click();
-    expect(screen.getByTestId("drawing-tool")).toContainHTML("Open show/sort panel");
-    expect(screen.getByTestId("drawing-tool")).not.toContainHTML("Close show/sort panel");
-  });
+    it("renders an object-list-spacer in place of the panel", () => {
+      render(
+        <ModalProvider>
+          <Provider stores={stores}>
+            <DrawingToolComponent {...defaultProps} model={unselectedModel} />
+          </Provider>
+        </ModalProvider>
+      );
+      // The spacer reserves the closed-panel width so the drawing layer
+      // stays in place when the tile is deselected (CLUE-206).
+      expect(screen.queryByTestId("object-list-spacer")).toBeInTheDocument();
+    });
 
-  it("shows objects in show/sort panel", () => {
-    render(
-      <ModalProvider>
-        <Provider stores={stores}>
-          <DrawingToolComponent {...defaultProps} {...{model}} />
-        </Provider>
-      </ModalProvider>
-    );
+    it("getObjectBoundingBox stays offset by closed panel width", () => {
+      // Sparrows must remain anchored to the drawing when the tile is unselected.
+      // The panel is replaced by a same-width spacer, so getObjectBoundingBox
+      // must still report that left offset.
+      let capturedApi: ITileApi | undefined;
+      const onRegisterTileApi = (tileApi: ITileApi) => {
+        capturedApi = tileApi;
+      };
 
-    expect(screen.getByTestId("object-list-view")).not.toContainHTML("Square");
-    content.addAndSelectObject(squareSnapshot);
-    screen.getByLabelText("Open show/sort panel").click();
-    expect(screen.getByTestId("object-list-view")).toContainHTML("Square");
-  });
+      const testContent = createDrawingContent();
+      const testRect: RectangleObjectSnapshotForAdd = {
+        type: "rectangle",
+        x: 100,
+        y: 50,
+        width: 40,
+        height: 30,
+        ...mockSettings,
+      };
+      testContent.addObject(testRect);
+      const testModel = TileModel.create({content: testContent});
 
-  it("shows correct order of objects in show/sort panel", () => {
-    render(
-      <ModalProvider>
-        <Provider stores={stores}>
-          <DrawingToolComponent {...defaultProps} {...{model}} />
-        </Provider>
-      </ModalProvider>
-    );
+      render(
+        <ModalProvider>
+          <Provider stores={stores}>
+            <DrawingToolComponent
+              {...defaultProps}
+              model={testModel}
+              readOnly={false}
+              onRegisterTileApi={onRegisterTileApi}
+            />
+          </Provider>
+        </ModalProvider>
+      );
 
-    // Content already has a square in it from previous test.
-    content.addAndSelectObject(rectangleSnapshot);
-    let items = within(screen.getByTestId("object-list-view")).getAllByRole("listitem");
-    expect(items).toHaveLength(2);
-    expect(items[0]).toContainHTML("Rectangle");
-    expect(items[1]).toContainHTML("Square");
-
-    // Move square to top.
-    if (content.objects.length >= 2) {
-      content.changeZOrder(content.objects[1].id, content.objects[0].id);
-    }
-    items = within(screen.getByTestId("object-list-view")).getAllByRole("listitem");
-    expect(items).toHaveLength(2);
-
-    expect(items[0]).toContainHTML("Square");
-    expect(items[1]).toContainHTML("Rectangle");
-
+      const objectId = testContent.objects[0]?.id;
+      const bbox = capturedApi?.getObjectBoundingBox?.(objectId!);
+      expect(bbox).toBeDefined();
+      const bbPadding = 5;
+      const expectedLeft = (testRect.x - bbPadding) + kClosedObjectListPanelWidth;
+      expect(bbox!.left).toBeCloseTo(expectedLeft, 1);
+    });
   });
 
   describe("read-only mode", () => {
@@ -351,77 +424,6 @@ describe("DrawingToolComponent", () => {
       // Left will include the object list panel width, so we just verify it's transformed.
       expect(bbox!.left).toBeGreaterThan(expectedLeft);
       expect(bbox!.top).toBeCloseTo(expectedTop, 1);
-    });
-  });
-
-  describe("when tile is not selected", () => {
-    const unselectedContent = createDrawingContent();
-    const unselectedModel = TileModel.create({content: unselectedContent});
-
-    it("does not show object list panel", () => {
-      render(
-        <ModalProvider>
-          <Provider stores={stores}>
-            <DrawingToolComponent {...defaultProps} model={unselectedModel} />
-          </Provider>
-        </ModalProvider>
-      );
-      expect(screen.queryByTestId("object-list-view")).not.toBeInTheDocument();
-    });
-
-    it("renders an object-list-spacer in place of the panel", () => {
-      render(
-        <ModalProvider>
-          <Provider stores={stores}>
-            <DrawingToolComponent {...defaultProps} model={unselectedModel} />
-          </Provider>
-        </ModalProvider>
-      );
-      // The spacer reserves the closed-panel width so the drawing layer
-      // stays in place when the tile is deselected (CLUE-206).
-      expect(screen.queryByTestId("object-list-spacer")).toBeInTheDocument();
-    });
-
-    it("getObjectBoundingBox stays offset by closed panel width", () => {
-      // Sparrows must remain anchored to the drawing when the tile is unselected.
-      // The panel is replaced by a same-width spacer, so getObjectBoundingBox
-      // must still report that left offset.
-      let capturedApi: ITileApi | undefined;
-      const onRegisterTileApi = (tileApi: ITileApi) => {
-        capturedApi = tileApi;
-      };
-
-      const testContent = createDrawingContent();
-      const testRect: RectangleObjectSnapshotForAdd = {
-        type: "rectangle",
-        x: 100,
-        y: 50,
-        width: 40,
-        height: 30,
-        ...mockSettings,
-      };
-      testContent.addObject(testRect);
-      const testModel = TileModel.create({content: testContent});
-
-      render(
-        <ModalProvider>
-          <Provider stores={stores}>
-            <DrawingToolComponent
-              {...defaultProps}
-              model={testModel}
-              readOnly={false}
-              onRegisterTileApi={onRegisterTileApi}
-            />
-          </Provider>
-        </ModalProvider>
-      );
-
-      const objectId = testContent.objects[0]?.id;
-      const bbox = capturedApi?.getObjectBoundingBox?.(objectId!);
-      expect(bbox).toBeDefined();
-      const bbPadding = 5;
-      const expectedLeft = (testRect.x - bbPadding) + kClosedObjectListPanelWidth;
-      expect(bbox!.left).toBeCloseTo(expectedLeft, 1);
     });
   });
 });

--- a/src/plugins/drawing/components/drawing-tile.tsx
+++ b/src/plugins/drawing/components/drawing-tile.tsx
@@ -55,7 +55,6 @@ const DrawingToolComponent: React.FC<IDrawingTileProps> = observer(function Draw
   const [objectListHoveredObject, setObjectListHoveredObject] = useState(null as string|null);
   const stores = useStores();
   const { clipboard, ui } = stores;
-  const showObjectListView = !readOnly && ui.isSelectedTile(model);
   const showNavigator = ui.isSelectedTile(model) &&
                         navigatorAllowed &&
                         contentRef.current.isNavigatorVisible;
@@ -290,9 +289,11 @@ const DrawingToolComponent: React.FC<IDrawingTileProps> = observer(function Draw
 
   const getObjectListPanelWidth = () => {
     if (readOnly) return 0;
+
     // When unselected, the panel is replaced by a same-width spacer so the drawing
     // layer's left edge doesn't shift. Report that width so sparrows stay anchored.
-    if (!showObjectListView) return kClosedObjectListPanelWidth;
+    if (!ui.isSelectedTile(model)) return kClosedObjectListPanelWidth;
+
     return contentRef.current.listViewOpen ? kOpenObjectListPanelWidth : kClosedObjectListPanelWidth;
   };
 
@@ -304,6 +305,14 @@ const DrawingToolComponent: React.FC<IDrawingTileProps> = observer(function Draw
       x: drawingToolElement.current.clientWidth-getObjectListPanelWidth(),
       y: drawingToolElement.current.clientHeight
     };
+  };
+
+  const renderObjectListView = () => {
+    if (readOnly) return null;
+    if (ui.isSelectedTile(model)) {
+      return <ObjectListView model={model} setHoverObject={setObjectListHoveredObject} />;
+    }
+    return <div className="object-list-spacer" aria-hidden="true" data-testid="object-list-spacer" />;
   };
 
   const handleNavigatorPan = (direction: NavigatorDirection) => {
@@ -385,10 +394,7 @@ const DrawingToolComponent: React.FC<IDrawingTileProps> = observer(function Draw
             <TileToolbar tileType="drawing" readOnly={!!readOnly} tileElement={tileElt} />
           </div>
           <div className="drawing-container">
-            {showObjectListView
-              ? <ObjectListView model={model} setHoverObject={setObjectListHoveredObject} />
-              : !readOnly && <div className="object-list-spacer" aria-hidden="true" data-testid="object-list-spacer" />
-            }
+            {renderObjectListView()}
             <TileNavigatorContext.Provider value={{ reportVisibleBoundingBox: updateTileVisibleBoundingBox }}>
               <DrawingLayerView
                 {...props}

--- a/src/plugins/drawing/components/drawing-tile.tsx
+++ b/src/plugins/drawing/components/drawing-tile.tsx
@@ -55,6 +55,7 @@ const DrawingToolComponent: React.FC<IDrawingTileProps> = observer(function Draw
   const [objectListHoveredObject, setObjectListHoveredObject] = useState(null as string|null);
   const stores = useStores();
   const { clipboard, ui } = stores;
+  const showObjectListView = !readOnly && ui.isSelectedTile(model);
   const showNavigator = ui.isSelectedTile(model) &&
                         navigatorAllowed &&
                         contentRef.current.isNavigatorVisible;
@@ -82,7 +83,6 @@ const DrawingToolComponent: React.FC<IDrawingTileProps> = observer(function Draw
       setTileVisibleBoundingBox(bb);
     }
   };
-
 
   const tileAdditionalApi = useMemo(() => ({
     exportContentAsTileJson: (options?: ITileExportOptions) => {
@@ -290,6 +290,9 @@ const DrawingToolComponent: React.FC<IDrawingTileProps> = observer(function Draw
 
   const getObjectListPanelWidth = () => {
     if (readOnly) return 0;
+    // When unselected, the panel is replaced by a same-width spacer so the drawing
+    // layer's left edge doesn't shift. Report that width so sparrows stay anchored.
+    if (!showObjectListView) return kClosedObjectListPanelWidth;
     return contentRef.current.listViewOpen ? kOpenObjectListPanelWidth : kClosedObjectListPanelWidth;
   };
 
@@ -382,7 +385,10 @@ const DrawingToolComponent: React.FC<IDrawingTileProps> = observer(function Draw
             <TileToolbar tileType="drawing" readOnly={!!readOnly} tileElement={tileElt} />
           </div>
           <div className="drawing-container">
-            {!readOnly && <ObjectListView model={model} setHoverObject={setObjectListHoveredObject} />}
+            {showObjectListView
+              ? <ObjectListView model={model} setHoverObject={setObjectListHoveredObject} />
+              : !readOnly && <div className="object-list-spacer" aria-hidden="true" data-testid="object-list-spacer" />
+            }
             <TileNavigatorContext.Provider value={{ reportVisibleBoundingBox: updateTileVisibleBoundingBox }}>
               <DrawingLayerView
                 {...props}

--- a/src/plugins/drawing/components/drawing-tile.tsx
+++ b/src/plugins/drawing/components/drawing-tile.tsx
@@ -290,8 +290,9 @@ const DrawingToolComponent: React.FC<IDrawingTileProps> = observer(function Draw
   const getObjectListPanelWidth = () => {
     if (readOnly) return 0;
 
-    // When unselected, the panel is replaced by a same-width spacer so the drawing
-    // layer's left edge doesn't shift. Report that width so sparrows stay anchored.
+    // When the tile is not selected, the panel is not shown and a same-width spacer
+    // is rendered in its place so the drawing layer's left edge doesn't shift.
+    // Report that width so sparrows stay anchored.
     if (!ui.isSelectedTile(model)) return kClosedObjectListPanelWidth;
 
     return contentRef.current.listViewOpen ? kOpenObjectListPanelWidth : kClosedObjectListPanelWidth;


### PR DESCRIPTION
[CLUE-206](https://concord-consortium.atlassian.net/browse/CLUE-206)

Updates the Drawing tile so its Show/Sort sidebar is only rendered when the tile is selected, while preserving the drawing layer’s horizontal positioning via a same-width spacer when the sidebar is hidden.

**Changes**

- Render the Show/Sort (`ObjectListView`) panel only for currently-selected drawing tile, otherwise render a spacer.
- Update bounding-box offset logic to account for the spacer when the tile is not selected.

[CLUE-206]: https://concord-consortium.atlassian.net/browse/CLUE-206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ